### PR TITLE
Use StyleX recommended pseudo-class syntax in Button

### DIFF
--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -73,12 +73,12 @@ const variants = stylex.create({
     backgroundColor: colorTokens.accent,
     color: 'white',
     backgroundImage: {
-      default: 'none',
+      default: null,
       ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
       ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },
     outline: {
-      default: 'none',
+      default: null,
       ':focus-visible': `2px solid ${colorTokens.focusOutline}`,
     },
     outlineOffset: {
@@ -90,12 +90,12 @@ const variants = stylex.create({
     backgroundColor: colorTokens.deemphasized,
     color: colorTokens.textPrimary,
     backgroundImage: {
-      default: 'none',
+      default: null,
       ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
       ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },
     outline: {
-      default: 'none',
+      default: null,
       ':focus-visible': `2px solid ${colorTokens.focusOutline}`,
     },
     outlineOffset: {
@@ -107,12 +107,12 @@ const variants = stylex.create({
     backgroundColor: 'transparent',
     color: colorTokens.textPrimary,
     backgroundImage: {
-      default: 'none',
+      default: null,
       ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
       ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },
     outline: {
-      default: 'none',
+      default: null,
       ':focus-visible': `2px solid ${colorTokens.focusOutline}`,
     },
     outlineOffset: {
@@ -124,12 +124,12 @@ const variants = stylex.create({
     backgroundColor: colorTokens.negative,
     color: 'white',
     backgroundImage: {
-      default: 'none',
+      default: null,
       ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
       ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },
     outline: {
-      default: 'none',
+      default: null,
       ':focus-visible': `2px solid ${colorTokens.negative}`,
     },
     outlineOffset: {

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -25,6 +25,8 @@ import type { StyleXStyles } from '../theme/types';
 
 /**
  * Base button styles
+ * Pseudo-classes are nested within properties per StyleX recommendation:
+ * https://stylexjs.com/docs/learn/styling-ui/defining-styles#pseudo-classes
  */
 const styles = stylex.create({
   base: {
@@ -45,21 +47,24 @@ const styles = stylex.create({
     cursor: 'pointer',
     transitionProperty: 'background-image, transform',
     transitionDuration: transitionTokens.fast,
-    ':active': {
-      transform: 'scale(0.98)',
+    transform: {
+      default: 'scale(1)',
+      ':active': 'scale(0.98)',
     },
   },
   disabled: {
     cursor: 'not-allowed',
     opacity: 0.5,
-    ':active': {
-      transform: 'none',
+    transform: {
+      default: 'none',
+      ':active': 'none',
     },
   },
 });
 
 /**
  * Variant styles using backgroundImage for layered colors
+ * Pseudo-classes are nested within properties per StyleX recommendation
  * Overlay is stacked on top of base color using multiple linear-gradients
  * Focus outline color matches variant (destructive uses negative color)
  */
@@ -67,57 +72,69 @@ const variants = stylex.create({
   primary: {
     backgroundColor: colorTokens.accent,
     color: 'white',
-    ':hover': {
-      backgroundImage: `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
+    backgroundImage: {
+      default: 'none',
+      ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
+      ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },
-    ':active': {
-      backgroundImage: `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
+    outline: {
+      default: 'none',
+      ':focus-visible': `2px solid ${colorTokens.focusOutline}`,
     },
-    ':focus-visible': {
-      outline: `2px solid ${colorTokens.focusOutline}`,
-      outlineOffset: '3px',
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '3px',
     },
   },
   secondary: {
     backgroundColor: colorTokens.deemphasized,
     color: colorTokens.textPrimary,
-    ':hover': {
-      backgroundImage: `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
+    backgroundImage: {
+      default: 'none',
+      ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
+      ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },
-    ':active': {
-      backgroundImage: `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
+    outline: {
+      default: 'none',
+      ':focus-visible': `2px solid ${colorTokens.focusOutline}`,
     },
-    ':focus-visible': {
-      outline: `2px solid ${colorTokens.focusOutline}`,
-      outlineOffset: '3px',
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '3px',
     },
   },
   ghost: {
     backgroundColor: 'transparent',
     color: colorTokens.textPrimary,
-    ':hover': {
-      backgroundImage: `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
+    backgroundImage: {
+      default: 'none',
+      ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
+      ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },
-    ':active': {
-      backgroundImage: `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
+    outline: {
+      default: 'none',
+      ':focus-visible': `2px solid ${colorTokens.focusOutline}`,
     },
-    ':focus-visible': {
-      outline: `2px solid ${colorTokens.focusOutline}`,
-      outlineOffset: '3px',
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '3px',
     },
   },
   destructive: {
     backgroundColor: colorTokens.negative,
     color: 'white',
-    ':hover': {
-      backgroundImage: `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
+    backgroundImage: {
+      default: 'none',
+      ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
+      ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },
-    ':active': {
-      backgroundImage: `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
+    outline: {
+      default: 'none',
+      ':focus-visible': `2px solid ${colorTokens.negative}`,
     },
-    ':focus-visible': {
-      outline: `2px solid ${colorTokens.negative}`,
-      outlineOffset: '3px',
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '3px',
     },
   },
 });

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -124,7 +124,7 @@ const variants = stylex.create({
     backgroundColor: colorTokens.negative,
     color: 'white',
     backgroundImage: {
-      default: 'none',
+      default: null,
       ':hover': `linear-gradient(${colorTokens.hoverOverlay}, ${colorTokens.hoverOverlay})`,
       ':active': `linear-gradient(${colorTokens.pressedOverlay}, ${colorTokens.pressedOverlay})`,
     },


### PR DESCRIPTION
Updates Button.tsx to follow StyleX's recommended pattern for pseudo-classes, where states are nested within properties rather than as top-level keys.

  Reference: https://stylexjs.com/docs/learn/styling-ui/defining-styles#pseudo-classes

  ## Changes

  - Refactored `transform`, `backgroundImage`, `outline`, and `outlineOffset` to use nested pseudo-class syntax
  - Added documentation comment linking to StyleX docs

  ## Test plan

  - [x] Unit tests pass (7/7)
  - [x] Build succeeds
