### PR TITLE
Layout -- implement the system

### DIFF
--- a/.context/proposals/layout-system.md
+++ b/.context/proposals/layout-system.md
@@ -396,9 +396,168 @@ This repetition builds strong pattern recognition.
 
 ## Open Questions
 
-1. **Nested layouts** — How do contexts compose when layouts are nested?
-2. **SplitPane/Grid** — Detailed API design
-3. **Animation** — Transition support for panels (collapse/expand)?
+### 1. Should XDSLayoutContainer have variants?
+
+**Current approach:** XDSLayoutContainer has variants (`card`, `modal`, `popover`, etc.) that set appearance and padding.
+
+**Alternative approach:** Remove variants from XDSLayoutContainer. Instead:
+- Higher-order components (XDSCard, XDSModal, XDSPopover) handle their own appearance
+- Each component is individually themable without XDSLayoutContainer growing arbitrarily
+- New containers with unique constraints (e.g., page content with max-width) don't need to be added as variants
+
+**Arguments for removing variants:**
+1. Higher-order components will exist anyway as the primary API
+2. Each container type may have unique requirements (e.g., page content needs max-width constraints for forms)
+3. Prevents XDSLayoutContainer from growing arbitrarily as new use cases emerge
+4. Theming becomes per-component rather than per-variant, giving more control
+5. Components can have domain-specific props (e.g., XDSPageContent with `maxWidth` prop)
+
+**Arguments for keeping variants:**
+1. Unified low-level API for custom use cases not covered by higher-order components
+2. Guarantees consistent styling across similar containers
+3. Enables layout reuse across contexts (same layout, different containers)
+
+**Recommendation:** Treat XDSLayoutContainer as a **primitive**:
+- Accepts `xstyle` for customization
+- No variants — visual styling moves to higher-order components
+- Only handles CSS variable propagation and flex container setup
+
+Higher-order components (XDSCard, XDSModal, etc.) configure the primitive:
+
+```jsx
+// XDSCard internally uses XDSLayoutContainer as a primitive
+function XDSCard({ children, xstyle, ...props }) {
+  return (
+    <XDSLayoutContainer
+      xstyle={[cardStyles.base, xstyle]}
+      {...props}
+    >
+      {children}
+    </XDSLayoutContainer>
+  );
+}
+
+// Usage - XDSCard handles appearance
+<XDSCard>
+  <XDSLayout
+    header={<XDSLayoutHeader>...</XDSLayoutHeader>}
+    content={<XDSLayoutContent>...</XDSLayoutContent>}
+  />
+</XDSCard>
+```
+
+**XDSLayoutContainer as primitive:**
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `xstyle` | `StyleXStyles` | Custom styles (background, shadow, radius, etc.) |
+| `paddingOuterX` | `SpacingToken` | Outer horizontal padding (left/right) |
+| `paddingOuterY` | `SpacingToken` | Outer vertical padding (top/bottom) |
+| `paddingInnerX` | `SpacingToken` | Inner horizontal padding for content areas |
+| `paddingInnerY` | `SpacingToken` | Inner vertical padding for content areas |
+| `children` | `ReactNode` | Must be an `XDSLayout` component |
+
+**What it provides:**
+- Sets CSS variables based on padding props:
+  - `--layout-padding-outer-x`, `--layout-padding-outer-y`
+  - `--layout-padding-inner-x`, `--layout-padding-inner-y`
+- Flex container setup for XDSLayout
+- `height: 100%` default (overridable via xstyle)
+
+**What it does NOT provide:**
+- No backgroundColor, boxShadow, borderRadius — these come from higher-order components via `xstyle`
+- No variants — each higher-order component is individually themable
+
+### 2. Page Content Layout
+
+A specific use case: page content that constrains central space to a max-width (for forms, articles, etc.).
+
+**Requirements:**
+- Content width constrained to a value like 800px
+- On smaller screens, content fills available width with minimum padding
+- Side panels (if present) remain at container edges
+
+**Challenge:** With panels, you can't simply use `max-width` on the container since panels need to be at the edges.
+
+**Solution:** Calculate padding dynamically to center content within the constraint:
+
+```css
+/* Centers content at 800px max, with minimum 16px padding */
+padding-inline: max(16px, calc((100% - 800px) / 2));
+```
+
+This approach:
+- Wide screens → padding grows to center the constrained content
+- Narrow screens → minimum padding prevents content touching edges
+- Panels stay at container edges, unaffected by content centering
+
+**Architecture: Internal StyleX utility**
+
+Content width constraints apply to a limited set of containers (page content, form modals). Rather than adding complexity to XDSLayoutContainer, create an **internal StyleX utility** that these specific components use:
+
+```tsx
+// Internal utility - not exported
+const contentWidthStyles = stylex.create({
+  form: {
+    '--layout-padding-inner-x': `max(${spacingTokens.space4}, calc((100% - 800px) / 2))`,
+  },
+  capped: {
+    '--layout-padding-inner-x': `max(${spacingTokens.space4}, calc((100% - 1200px) / 2))`,
+  },
+  full: {
+    // No override - uses standard padding
+  },
+});
+```
+
+**Components that use content width:**
+
+1. **XDSPageContent** - Exposes `contentWidth` prop for page layouts
+2. **XDSModal** - May have `variant="form"` that applies the form constraint
+
+```tsx
+// XDSPageContent exposes contentWidth prop
+<XDSPageContent contentWidth="form">
+  <XDSLayout ... />
+</XDSPageContent>
+
+// XDSModal might have a variant for form modals
+<XDSModal variant="form">
+  <XDSLayout ... />
+</XDSModal>
+```
+
+**Why this approach:**
+
+1. **XDSLayoutContainer stays simple:** Pure primitive with token-based padding.
+
+2. **Limited scope:** Only components that need content width get the prop.
+
+3. **Internal utility:** The calc-based styles are implementation details, not public API.
+
+4. **Explicit semantics:** `XDSPageContent contentWidth="form"` clearly communicates intent.
+
+**Content width variants:**
+
+| Variant | Use Case | Width |
+|---------|----------|-------|
+| `form` | Forms, focused content | 800px |
+| `capped` | Articles, content-heavy pages | 1200px |
+| `full` | Dashboards, data tables, no constraint (default) | 100% |
+
+**LLM-friendliness:** Use-case-based naming (`form`) is more discoverable than descriptive naming (`narrow`). An LLM building a form knows immediately to use `contentWidth="form"` without having to decide if content is "narrow enough."
+
+### 3. Nested layouts
+
+How do contexts compose when layouts are nested?
+
+### 4. SplitPane/Grid
+
+Detailed API design.
+
+### 5. Animation
+
+Transition support for panels (collapse/expand)?
 
 ---
 

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -125,6 +125,9 @@ const meta: Meta<typeof XDSLayout> = {
   component: XDSLayout,
   tags: ['autodocs'],
   parameters: {
+    controls: {
+      expanded: false,
+    },
     docs: {
       description: {
         component: `
@@ -142,10 +145,277 @@ The XDS Layout System provides a structured way to build page and component layo
       },
     },
   },
+  // Hide auto-generated controls from XDSLayout component
+  argTypes: {
+    content: { table: { disable: true } },
+    end: { table: { disable: true } },
+    footer: { table: { disable: true } },
+    header: { table: { disable: true } },
+    height: { table: { disable: true } },
+    isFullBleed: { table: { disable: true } },
+    start: { table: { disable: true } },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof XDSLayout>;
+
+// =============================================================================
+// Interactive Playground
+// =============================================================================
+
+interface PlaygroundArgs {
+  // Card props
+  cardWidth: number;
+  cardHeight: number;
+  // Layout props
+  layoutIsFullBleed: boolean;
+  // Header props
+  showHeader: boolean;
+  headerHasDivider: boolean;
+  headerIsFullBleed: boolean;
+  // Content props
+  contentIsFullBleed: boolean;
+  contentIsScrollable: boolean;
+  // Footer props
+  showFooter: boolean;
+  footerHasDivider: boolean;
+  footerIsFullBleed: boolean;
+  // Start panel props
+  showStartPanel: boolean;
+  startPanelWidth: number;
+  startPanelHasDivider: boolean;
+  startPanelIsScrollable: boolean;
+  // End panel props
+  showEndPanel: boolean;
+  endPanelWidth: number;
+  endPanelHasDivider: boolean;
+  endPanelIsScrollable: boolean;
+}
+
+export const Playground = {
+  name: 'Playground',
+  args: {
+    // Card defaults
+    cardWidth: 700,
+    cardHeight: 400,
+    // Layout defaults
+    layoutIsFullBleed: false,
+    // Header defaults
+    showHeader: true,
+    headerHasDivider: true,
+    headerIsFullBleed: false,
+    // Content defaults
+    contentIsFullBleed: false,
+    contentIsScrollable: true,
+    // Footer defaults
+    showFooter: true,
+    footerHasDivider: true,
+    footerIsFullBleed: false,
+    // Start panel defaults
+    showStartPanel: true,
+    startPanelWidth: 160,
+    startPanelHasDivider: true,
+    startPanelIsScrollable: true,
+    // End panel defaults
+    showEndPanel: false,
+    endPanelWidth: 200,
+    endPanelHasDivider: true,
+    endPanelIsScrollable: true,
+  },
+  argTypes: {
+    // Card controls
+    cardWidth: {
+      control: { type: 'range', min: 300, max: 1000, step: 50 },
+      description: 'Width of the card container',
+      table: { category: 'Card' },
+    },
+    cardHeight: {
+      control: { type: 'range', min: 200, max: 600, step: 50 },
+      description: 'Height of the card container',
+      table: { category: 'Card' },
+    },
+    // Layout controls
+    layoutIsFullBleed: {
+      control: 'boolean',
+      description: 'Remove padding at layout outer edges (affects all slots)',
+      table: { category: 'Layout' },
+    },
+    // Header controls
+    showHeader: {
+      control: 'boolean',
+      description: 'Show or hide the header',
+      table: { category: 'Header' },
+    },
+    headerHasDivider: {
+      control: 'boolean',
+      description: 'Add a border below the header',
+      table: { category: 'Header' },
+    },
+    headerIsFullBleed: {
+      control: 'boolean',
+      description: 'Remove header padding',
+      table: { category: 'Header' },
+    },
+    // Content controls
+    contentIsFullBleed: {
+      control: 'boolean',
+      description: 'Remove content padding for edge-to-edge content',
+      table: { category: 'Content' },
+    },
+    contentIsScrollable: {
+      control: 'boolean',
+      description: 'Enable scrollable overflow',
+      table: { category: 'Content' },
+    },
+    // Footer controls
+    showFooter: {
+      control: 'boolean',
+      description: 'Show or hide the footer',
+      table: { category: 'Footer' },
+    },
+    footerHasDivider: {
+      control: 'boolean',
+      description: 'Add a border above the footer',
+      table: { category: 'Footer' },
+    },
+    footerIsFullBleed: {
+      control: 'boolean',
+      description: 'Remove footer padding',
+      table: { category: 'Footer' },
+    },
+    // Start panel controls
+    showStartPanel: {
+      control: 'boolean',
+      description: 'Show or hide the start (left) panel',
+      table: { category: 'Start Panel' },
+    },
+    startPanelWidth: {
+      control: { type: 'range', min: 100, max: 300, step: 20 },
+      description: 'Width of the start panel',
+      table: { category: 'Start Panel' },
+    },
+    startPanelHasDivider: {
+      control: 'boolean',
+      description: 'Add a border to the start panel',
+      table: { category: 'Start Panel' },
+    },
+    startPanelIsScrollable: {
+      control: 'boolean',
+      description: 'Enable scrollable overflow for start panel',
+      table: { category: 'Start Panel' },
+    },
+    // End panel controls
+    showEndPanel: {
+      control: 'boolean',
+      description: 'Show or hide the end (right) panel',
+      table: { category: 'End Panel' },
+    },
+    endPanelWidth: {
+      control: { type: 'range', min: 100, max: 300, step: 20 },
+      description: 'Width of the end panel',
+      table: { category: 'End Panel' },
+    },
+    endPanelHasDivider: {
+      control: 'boolean',
+      description: 'Add a border to the end panel',
+      table: { category: 'End Panel' },
+    },
+    endPanelIsScrollable: {
+      control: 'boolean',
+      description: 'Enable scrollable overflow for end panel',
+      table: { category: 'End Panel' },
+    },
+  },
+  render: (args: PlaygroundArgs) => (
+    <div {...stylex.props(styles.pageWrapper)}>
+      <XDSCard width={args.cardWidth} height={args.cardHeight}>
+        <XDSLayout
+          isFullBleed={args.layoutIsFullBleed}
+          header={
+            args.showHeader ? (
+              <XDSLayoutHeader
+                hasDivider={args.headerHasDivider}
+                isFullBleed={args.headerIsFullBleed}
+              >
+                <h3 {...stylex.props(styles.heading)}>Layout Header</h3>
+              </XDSLayoutHeader>
+            ) : undefined
+          }
+          start={
+            args.showStartPanel ? (
+              <XDSLayoutPanel
+                width={args.startPanelWidth}
+                hasDivider={args.startPanelHasDivider}
+                isScrollable={args.startPanelIsScrollable}
+                role="navigation"
+              >
+                <NavItem active>Dashboard</NavItem>
+                <NavItem>Settings</NavItem>
+                <NavItem>Profile</NavItem>
+                <NavItem>Help</NavItem>
+              </XDSLayoutPanel>
+            ) : undefined
+          }
+          content={
+            <XDSLayoutContent
+              isFullBleed={args.contentIsFullBleed}
+              isScrollable={args.contentIsScrollable}
+            >
+              <h4 {...stylex.props(styles.subheading)}>Main Content Area</h4>
+              <br />
+              <p {...stylex.props(styles.bodyText)}>
+                This is the main content area. Use the controls panel to toggle
+                headers, footers, side panels, and adjust their properties.
+              </p>
+              <br />
+              <p {...stylex.props(styles.bodyText)}>
+                Try enabling &quot;isFullBleed&quot; to see how content can extend
+                to the edges, or toggle &quot;isScrollable&quot; to change overflow behavior.
+              </p>
+              <br />
+              <div {...stylex.props(styles.placeholder)}>
+                Placeholder content block
+              </div>
+            </XDSLayoutContent>
+          }
+          end={
+            args.showEndPanel ? (
+              <XDSLayoutPanel
+                width={args.endPanelWidth}
+                hasDivider={args.endPanelHasDivider}
+                isScrollable={args.endPanelIsScrollable}
+                role="complementary"
+              >
+                <p {...stylex.props(styles.sectionLabel)}>Details</p>
+                <p {...stylex.props(styles.bodyText)}>
+                  Additional information or actions can go in the end panel.
+                </p>
+              </XDSLayoutPanel>
+            ) : undefined
+          }
+          footer={
+            args.showFooter ? (
+              <XDSLayoutFooter
+                hasDivider={args.footerHasDivider}
+                isFullBleed={args.footerIsFullBleed}
+              >
+                <XDSHStack gap="space2" hAlign="end">
+                  <XDSButton variant="secondary">Cancel</XDSButton>
+                  <XDSButton variant="primary">Save</XDSButton>
+                </XDSHStack>
+              </XDSLayoutFooter>
+            ) : undefined
+          }
+        />
+      </XDSCard>
+    </div>
+  ),
+};
+
+// =============================================================================
+// Example Stories
+// =============================================================================
 
 export const BasicCard: Story = {
   name: 'Basic Card Layout',

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -1,0 +1,441 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutFooter,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+  XDSCard,
+  XDSSection,
+  XDSHStack,
+  XDSVStack,
+} from '@xds/core/Layout';
+import { XDSButton } from '@xds/core/Button';
+import {
+  colorTokens,
+  spacingTokens,
+  typographyTokens,
+} from '@xds/core/theme/tokens.stylex';
+import { Theme, neutralTheme, defaultTheme } from '@xds/core';
+
+const styles = stylex.create({
+  // Story wrapper styles
+  pageWrapper: {
+    height: 500,
+    backgroundColor: colorTokens.wash,
+    padding: spacingTokens.space4,
+  },
+  pageWrapperTall: {
+    height: 600,
+  },
+  storySection: {
+    padding: spacingTokens.space4,
+    backgroundColor: colorTokens.wash,
+  },
+  // Typography
+  heading: {
+    margin: 0,
+    fontFamily: typographyTokens.fontFamilyBody,
+    fontSize: 18,
+    fontWeight: 600,
+    color: colorTokens.textPrimary,
+  },
+  subheading: {
+    margin: 0,
+    fontFamily: typographyTokens.fontFamilyBody,
+    fontSize: 14,
+    fontWeight: 500,
+    color: colorTokens.textSecondary,
+  },
+  bodyText: {
+    margin: 0,
+    fontFamily: typographyTokens.fontFamilyBody,
+    fontSize: 14,
+    lineHeight: 1.5,
+    color: colorTokens.textSecondary,
+  },
+  // Panel content
+  navItem: {
+    padding: `${spacingTokens.space2} ${spacingTokens.space3}`,
+    borderRadius: 6,
+    cursor: 'pointer',
+    color: colorTokens.textPrimary,
+    fontFamily: typographyTokens.fontFamilyBody,
+    fontSize: 14,
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': colorTokens.hoverOverlay,
+    },
+  },
+  navItemActive: {
+    backgroundColor: colorTokens.accentDeemphasized,
+    color: colorTokens.accentText,
+  },
+  // Content placeholder
+  placeholder: {
+    backgroundColor: colorTokens.grayBackground,
+    borderRadius: 8,
+    padding: spacingTokens.space4,
+    color: colorTokens.textSecondary,
+    fontFamily: typographyTokens.fontFamilyBody,
+    fontSize: 14,
+  },
+  // Full bleed placeholder (no radius, no padding)
+  placeholderFullBleed: {
+    backgroundColor: colorTokens.grayBackground,
+    padding: spacingTokens.space4,
+    color: colorTokens.textSecondary,
+    fontFamily: typographyTokens.fontFamilyBody,
+    fontSize: 14,
+    minHeight: 100,
+  },
+  sectionLabel: {
+    margin: `0 0 ${spacingTokens.space2} 0`,
+    fontFamily: typographyTokens.fontFamilyBody,
+    fontSize: 12,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    color: colorTokens.textSecondary,
+  },
+});
+
+// Helper components for demo content
+const NavItem = ({ active, children }: { active?: boolean; children: React.ReactNode }) => (
+  <div {...stylex.props(styles.navItem, active && styles.navItemActive)}>{children}</div>
+);
+
+const meta: Meta<typeof XDSLayout> = {
+  title: 'Layout/XDSLayout',
+  component: XDSLayout,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: `
+The XDS Layout System provides a structured way to build page and component layouts.
+
+**Components:**
+- \`XDSCard\` - Card container with elevation
+- \`XDSSection\` - Section container with background variants
+- \`XDSLayout\` - Arranges content into header, content, footer, and panel slots
+- \`XDSLayoutHeader\` - Header slot with optional divider
+- \`XDSLayoutContent\` - Scrollable main content area
+- \`XDSLayoutFooter\` - Footer slot with optional divider
+- \`XDSLayoutPanel\` - Side panel slots (start/end) with optional divider
+        `,
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSLayout>;
+
+export const BasicCard: Story = {
+  name: 'Basic Card Layout',
+  render: () => (
+    <div {...stylex.props(styles.pageWrapper)}>
+      <XDSCard width={400} height={350}>
+        <XDSLayout
+          header={
+            <XDSLayoutHeader hasDivider>
+              <h3 {...stylex.props(styles.heading)}>Card Title</h3>
+            </XDSLayoutHeader>
+          }
+          content={
+            <XDSLayoutContent>
+              <p {...stylex.props(styles.bodyText)}>
+                This is a basic card layout with a header, scrollable content area, and footer.
+                The layout automatically handles padding and spacing between sections.
+              </p>
+              <br />
+              <p {...stylex.props(styles.bodyText)}>
+                Try scrolling this content area when it overflows.
+              </p>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter hasDivider>
+              <XDSHStack gap="space2" hAlign="end">
+                <XDSButton variant="secondary">Cancel</XDSButton>
+                <XDSButton variant="primary">Save</XDSButton>
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </XDSCard>
+    </div>
+  ),
+};
+
+export const WithSidebar: Story = {
+  name: 'Layout with Sidebar',
+  render: () => (
+    <div {...stylex.props(styles.pageWrapper)}>
+      <XDSCard width={700} height={400}>
+        <XDSLayout
+          header={
+            <XDSLayoutHeader hasDivider>
+              <h3 {...stylex.props(styles.heading)}>Settings</h3>
+            </XDSLayoutHeader>
+          }
+          start={
+            <XDSLayoutPanel hasDivider role="navigation">
+              <NavItem active>General</NavItem>
+              <NavItem>Account</NavItem>
+              <NavItem>Privacy</NavItem>
+              <NavItem>Notifications</NavItem>
+              <NavItem>Security</NavItem>
+            </XDSLayoutPanel>
+          }
+          content={
+            <XDSLayoutContent>
+              <h4 {...stylex.props(styles.subheading)}>General Settings</h4>
+              <br />
+              <p {...stylex.props(styles.bodyText)}>
+                Configure your general preferences here. The sidebar navigation
+                allows you to switch between different settings sections.
+              </p>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter hasDivider>
+              <XDSHStack gap="space2" hAlign="end">
+                <XDSButton variant="secondary">Reset</XDSButton>
+                <XDSButton variant="primary">Save Changes</XDSButton>
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </XDSCard>
+    </div>
+  ),
+};
+
+export const DualPanels: Story = {
+  name: 'Dual Panel Layout',
+  render: () => (
+    <div {...stylex.props(styles.pageWrapper, styles.pageWrapperTall)}>
+      <XDSCard width="100%" maxWidth={800} height={400}>
+        <XDSLayout
+          header={
+            <XDSLayoutHeader hasDivider>
+              <h3 {...stylex.props(styles.heading)}>File Browser</h3>
+            </XDSLayoutHeader>
+          }
+          start={
+            <XDSLayoutPanel hasDivider>
+              <p {...stylex.props(styles.sectionLabel)}>Folders</p>
+              <NavItem>Documents</NavItem>
+              <NavItem active>Projects</NavItem>
+              <NavItem>Downloads</NavItem>
+            </XDSLayoutPanel>
+          }
+          content={
+            <XDSLayoutContent>
+              <p {...stylex.props(styles.sectionLabel)}>Files</p>
+              <div {...stylex.props(styles.placeholder)}>
+                Select a folder to view its contents
+              </div>
+            </XDSLayoutContent>
+          }
+          end={
+            <XDSLayoutPanel hasDivider>
+              <p {...stylex.props(styles.sectionLabel)}>Details</p>
+              <p {...stylex.props(styles.bodyText)}>
+                Select a file to view details
+              </p>
+            </XDSLayoutPanel>
+          }
+        />
+      </XDSCard>
+    </div>
+  ),
+};
+
+export const NoDividers: Story = {
+  name: 'Without Dividers',
+  render: () => (
+    <div {...stylex.props(styles.pageWrapper)}>
+      <XDSCard width={400} height={350}>
+        <XDSLayout
+          header={
+            <XDSLayoutHeader>
+              <h3 {...stylex.props(styles.heading)}>Seamless Layout</h3>
+            </XDSLayoutHeader>
+          }
+          content={
+            <XDSLayoutContent>
+              <p {...stylex.props(styles.bodyText)}>
+                When dividers are not used, the layout automatically collapses
+                spacing between sections for a seamless visual flow.
+              </p>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter>
+              <XDSHStack gap="space2" hAlign="end">
+                <XDSButton variant="primary">Continue</XDSButton>
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </XDSCard>
+    </div>
+  ),
+};
+
+export const FullBleedContent: Story = {
+  name: 'Full Bleed Content',
+  render: () => (
+    <div {...stylex.props(styles.pageWrapper)}>
+      <XDSCard width={400} height={350}>
+        <XDSLayout
+          header={
+            <XDSLayoutHeader hasDivider>
+              <h3 {...stylex.props(styles.heading)}>Full Bleed Example</h3>
+            </XDSLayoutHeader>
+          }
+          content={
+            <XDSLayoutContent isFullBleed>
+              <div {...stylex.props(styles.placeholderFullBleed)}>
+                This content uses isFullBleed to remove padding,
+                allowing it to touch the edges. Useful for tables,
+                images, or other edge-to-edge content.
+              </div>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter hasDivider>
+              <XDSHStack gap="space2" hAlign="end">
+                <XDSButton variant="secondary">Close</XDSButton>
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </XDSCard>
+    </div>
+  ),
+};
+
+export const SectionVariants: Story = {
+  name: 'Section Variants',
+  render: () => (
+    <XDSVStack gap="space6" xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>XDSSection Variants</p>
+      <XDSHStack gap="space4" wrap="wrap">
+        <XDSSection variant="section" width={300} height={250}>
+          <XDSLayout
+            header={<XDSLayoutHeader hasDivider><p {...stylex.props(styles.subheading)}>Section</p></XDSLayoutHeader>}
+            content={<XDSLayoutContent><p {...stylex.props(styles.bodyText)}>Surface background color</p></XDSLayoutContent>}
+          />
+        </XDSSection>
+
+        <XDSSection variant="wash" width={300} height={250}>
+          <XDSLayout
+            header={<XDSLayoutHeader hasDivider><p {...stylex.props(styles.subheading)}>Wash</p></XDSLayoutHeader>}
+            content={<XDSLayoutContent><p {...stylex.props(styles.bodyText)}>Wash background color</p></XDSLayoutContent>}
+          />
+        </XDSSection>
+
+        <XDSSection variant="transparent" width={300} height={250}>
+          <XDSLayout
+            header={<XDSLayoutHeader hasDivider><p {...stylex.props(styles.subheading)}>Transparent</p></XDSLayoutHeader>}
+            content={<XDSLayoutContent><p {...stylex.props(styles.bodyText)}>No background, shows parent</p></XDSLayoutContent>}
+          />
+        </XDSSection>
+      </XDSHStack>
+    </XDSVStack>
+  ),
+};
+
+export const ContentOnly: Story = {
+  name: 'Content Only',
+  render: () => (
+    <div {...stylex.props(styles.pageWrapper)}>
+      <XDSCard width={400} height={350}>
+        <XDSLayout
+          content={
+            <XDSLayoutContent>
+              <h3 {...stylex.props(styles.heading)}>Simple Content</h3>
+              <br />
+              <p {...stylex.props(styles.bodyText)}>
+                A layout can have just content without header or footer.
+                This is useful for simple cards or content blocks.
+              </p>
+            </XDSLayoutContent>
+          }
+        />
+      </XDSCard>
+    </div>
+  ),
+};
+
+export const ThemedLayout: Story = {
+  name: 'Themed Layout (Neutral vs Default)',
+  render: () => (
+    <XDSHStack gap="space6" xstyle={styles.storySection}>
+      <XDSVStack gap="space3">
+        <p {...stylex.props(styles.sectionLabel)}>Default Theme (16px padding)</p>
+        <Theme theme={defaultTheme}>
+          <XDSCard width={400} height={350}>
+            <XDSLayout
+              header={
+                <XDSLayoutHeader hasDivider>
+                  <h3 {...stylex.props(styles.heading)}>Default Theme</h3>
+                </XDSLayoutHeader>
+              }
+              content={
+                <XDSLayoutContent>
+                  <p {...stylex.props(styles.bodyText)}>
+                    This card uses the default theme with 16px padding around the layout areas.
+                  </p>
+                </XDSLayoutContent>
+              }
+              footer={
+                <XDSLayoutFooter hasDivider>
+                  <XDSHStack gap="space2" hAlign="end">
+                    <XDSButton variant="secondary">Cancel</XDSButton>
+                    <XDSButton variant="primary">Save</XDSButton>
+                  </XDSHStack>
+                </XDSLayoutFooter>
+              }
+            />
+          </XDSCard>
+        </Theme>
+      </XDSVStack>
+
+      <XDSVStack gap="space3">
+        <p {...stylex.props(styles.sectionLabel)}>Neutral Theme (12px padding)</p>
+        <Theme theme={neutralTheme}>
+          <XDSCard width={400} height={350}>
+            <XDSLayout
+              header={
+                <XDSLayoutHeader hasDivider>
+                  <h3 {...stylex.props(styles.heading)}>Neutral Theme</h3>
+                </XDSLayoutHeader>
+              }
+              content={
+                <XDSLayoutContent>
+                  <p {...stylex.props(styles.bodyText)}>
+                    This card uses the neutral theme with 12px padding around the layout areas.
+                  </p>
+                </XDSLayoutContent>
+              }
+              footer={
+                <XDSLayoutFooter hasDivider>
+                  <XDSHStack gap="space2" hAlign="end">
+                    <XDSButton variant="secondary">Cancel</XDSButton>
+                    <XDSButton variant="primary">Save</XDSButton>
+                  </XDSHStack>
+                </XDSLayoutFooter>
+              }
+            />
+          </XDSCard>
+        </Theme>
+      </XDSVStack>
+    </XDSHStack>
+  ),
+};

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -6,7 +6,7 @@ import {
   XDSLayoutFooter,
   XDSLayoutContent,
   XDSLayoutPanel,
-  XDSLayoutContainer,
+  container,
   XDSCard,
   XDSSection,
   XDSHStack,
@@ -107,6 +107,11 @@ const styles = stylex.create({
     backgroundColor: colorTokens.card,
     borderRadius: radiusTokens.container,
     boxShadow: elevationTokens.base,
+  },
+  // Demo sizing for outer padding story
+  demoSize: {
+    width: 300,
+    height: 220,
   },
 });
 
@@ -461,11 +466,15 @@ export const OuterPaddingDemo: Story = {
       <XDSHStack gap="space4" wrap="wrap">
         <XDSVStack gap="space2">
           <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space0</p>
-          <XDSLayoutContainer
-            xstyle={styles.demoContainer}
-            style={{ width: 300, height: 220 }}
-            paddingOuterX="space0"
-            paddingOuterY="space0"
+          <div
+            {...stylex.props(
+              ...container({
+                paddingOuterX: 'space0',
+                paddingOuterY: 'space0',
+              }),
+              styles.demoContainer,
+              styles.demoSize
+            )}
           >
             <XDSLayout
               header={
@@ -486,16 +495,20 @@ export const OuterPaddingDemo: Story = {
                 </XDSLayoutFooter>
               }
             />
-          </XDSLayoutContainer>
+          </div>
         </XDSVStack>
 
         <XDSVStack gap="space2">
           <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space4</p>
-          <XDSLayoutContainer
-            xstyle={styles.demoContainer}
-            style={{ width: 300, height: 220 }}
-            paddingOuterX="space4"
-            paddingOuterY="space4"
+          <div
+            {...stylex.props(
+              ...container({
+                paddingOuterX: 'space4',
+                paddingOuterY: 'space4',
+              }),
+              styles.demoContainer,
+              styles.demoSize
+            )}
           >
             <XDSLayout
               header={
@@ -516,16 +529,20 @@ export const OuterPaddingDemo: Story = {
                 </XDSLayoutFooter>
               }
             />
-          </XDSLayoutContainer>
+          </div>
         </XDSVStack>
 
         <XDSVStack gap="space2">
           <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space7</p>
-          <XDSLayoutContainer
-            xstyle={styles.demoContainer}
-            style={{ width: 300, height: 220 }}
-            paddingOuterX="space7"
-            paddingOuterY="space7"
+          <div
+            {...stylex.props(
+              ...container({
+                paddingOuterX: 'space7',
+                paddingOuterY: 'space7',
+              }),
+              styles.demoContainer,
+              styles.demoSize
+            )}
           >
             <XDSLayout
               header={
@@ -546,7 +563,7 @@ export const OuterPaddingDemo: Story = {
                 </XDSLayoutFooter>
               }
             />
-          </XDSLayoutContainer>
+          </div>
         </XDSVStack>
       </XDSHStack>
     </XDSVStack>

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -6,6 +6,7 @@ import {
   XDSLayoutFooter,
   XDSLayoutContent,
   XDSLayoutPanel,
+  XDSLayoutContainer,
   XDSCard,
   XDSSection,
   XDSHStack,
@@ -16,6 +17,8 @@ import {
   colorTokens,
   spacingTokens,
   typographyTokens,
+  radiusTokens,
+  elevationTokens,
 } from '@xds/core/theme/tokens.stylex';
 import { Theme, neutralTheme, defaultTheme } from '@xds/core';
 
@@ -98,6 +101,12 @@ const styles = stylex.create({
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
     color: colorTokens.textSecondary,
+  },
+  // Demo container styling to visualize bounds
+  demoContainer: {
+    backgroundColor: colorTokens.card,
+    borderRadius: radiusTokens.container,
+    boxShadow: elevationTokens.base,
   },
 });
 
@@ -437,5 +446,109 @@ export const ThemedLayout: Story = {
         </Theme>
       </XDSVStack>
     </XDSHStack>
+  ),
+};
+
+export const OuterPaddingDemo: Story = {
+  name: 'Outer Padding Demonstration',
+  render: () => (
+    <XDSVStack gap="space6" xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>Outer Padding</p>
+      <p {...stylex.props(styles.bodyText)}>
+        Outer padding creates space between the container edge and the layout content.
+        Notice how the dividers are inset from the container edges as outer padding increases.
+      </p>
+      <XDSHStack gap="space4" wrap="wrap">
+        <XDSVStack gap="space2">
+          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space0</p>
+          <XDSLayoutContainer
+            xstyle={styles.demoContainer}
+            style={{ width: 300, height: 220 }}
+            paddingOuterX="space0"
+            paddingOuterY="space0"
+          >
+            <XDSLayout
+              header={
+                <XDSLayoutHeader hasDivider>
+                  <p {...stylex.props(styles.subheading)}>Header</p>
+                </XDSLayoutHeader>
+              }
+              content={
+                <XDSLayoutContent>
+                  <p {...stylex.props(styles.bodyText)}>
+                    Dividers touch container edges.
+                  </p>
+                </XDSLayoutContent>
+              }
+              footer={
+                <XDSLayoutFooter hasDivider>
+                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                </XDSLayoutFooter>
+              }
+            />
+          </XDSLayoutContainer>
+        </XDSVStack>
+
+        <XDSVStack gap="space2">
+          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space4</p>
+          <XDSLayoutContainer
+            xstyle={styles.demoContainer}
+            style={{ width: 300, height: 220 }}
+            paddingOuterX="space4"
+            paddingOuterY="space4"
+          >
+            <XDSLayout
+              header={
+                <XDSLayoutHeader hasDivider>
+                  <p {...stylex.props(styles.subheading)}>Header</p>
+                </XDSLayoutHeader>
+              }
+              content={
+                <XDSLayoutContent>
+                  <p {...stylex.props(styles.bodyText)}>
+                    16px inset from edges.
+                  </p>
+                </XDSLayoutContent>
+              }
+              footer={
+                <XDSLayoutFooter hasDivider>
+                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                </XDSLayoutFooter>
+              }
+            />
+          </XDSLayoutContainer>
+        </XDSVStack>
+
+        <XDSVStack gap="space2">
+          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space7</p>
+          <XDSLayoutContainer
+            xstyle={styles.demoContainer}
+            style={{ width: 300, height: 220 }}
+            paddingOuterX="space7"
+            paddingOuterY="space7"
+          >
+            <XDSLayout
+              header={
+                <XDSLayoutHeader hasDivider>
+                  <p {...stylex.props(styles.subheading)}>Header</p>
+                </XDSLayoutHeader>
+              }
+              content={
+                <XDSLayoutContent>
+                  <p {...stylex.props(styles.bodyText)}>
+                    48px inset from edges.
+                  </p>
+                </XDSLayoutContent>
+              }
+              footer={
+                <XDSLayoutFooter hasDivider>
+                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                </XDSLayoutFooter>
+              }
+            />
+          </XDSLayoutContainer>
+        </XDSVStack>
+      </XDSHStack>
+    </XDSVStack>
   ),
 };

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -3,8 +3,11 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@xds/core": ["../../packages/core/src"],
-      "@xds/core/*": ["../../packages/core/src/*"]
+      "@xds/core": ["../../packages/core/src/index.ts"],
+      "@xds/core/*": [
+        "../../packages/core/src/*/index.ts",
+        "../../packages/core/src/*"
+      ]
     }
   },
   "include": [".storybook/**/*", "stories/**/*"]

--- a/packages/core/src/Layout/Container/README.md
+++ b/packages/core/src/Layout/Container/README.md
@@ -1,0 +1,171 @@
+# /packages/core/src/Layout/Container
+
+Layout container components: a primitive and higher-order containers for cards and sections.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Overview
+
+This folder contains:
+- **XDSLayoutContainer** — A primitive that sets CSS variables for padding
+- **XDSCard** — Higher-order component with card styling (elevation, radius)
+- **XDSSection** — Higher-order component with background variants
+
+## Import
+
+```tsx
+import {
+  XDSLayoutContainer,
+  XDSCard,
+  XDSSection,
+} from '@xds/core/Layout';
+```
+
+## Components
+
+### Types
+
+```tsx
+// Size value type - accepts numbers (pixels) or strings (CSS values)
+type SizeValue = number | string;
+
+// Examples:
+// width={400}        → "400px"
+// width="100%"       → "100%"
+// width="50vh"       → "50vh"
+```
+
+### XDSCard
+
+A card container with elevation and themed styling. Use for elevated content containers.
+
+```tsx
+<XDSCard width={400} height={300}>
+  <XDSLayout
+    header={<XDSLayoutHeader hasDivider>Title</XDSLayoutHeader>}
+    content={<XDSLayoutContent>Content</XDSLayoutContent>}
+    footer={<XDSLayoutFooter hasDivider>Actions</XDSLayoutFooter>}
+  />
+</XDSCard>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `width` | `SizeValue` | — | Width (number = pixels, string = as-is) |
+| `height` | `SizeValue` | — | Height (number = pixels, string = as-is) |
+| `maxWidth` | `SizeValue` | — | Maximum width |
+| `minHeight` | `SizeValue` | — | Minimum height |
+| `children` | `ReactNode` | — | Content (typically XDSLayout) |
+
+### XDSSection
+
+A section container with background variants. Use for content sections within a page.
+
+```tsx
+<XDSSection variant="wash" width={300} height={250}>
+  <XDSLayout
+    content={<XDSLayoutContent>Content in wash section</XDSLayoutContent>}
+  />
+</XDSSection>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `'section' \| 'transparent' \| 'wash'` | `'section'` | Background variant |
+| `width` | `SizeValue` | — | Width (number = pixels, string = as-is) |
+| `height` | `SizeValue` | — | Height (number = pixels, string = as-is) |
+| `maxWidth` | `SizeValue` | — | Maximum width |
+| `minHeight` | `SizeValue` | — | Minimum height |
+| `children` | `ReactNode` | — | Content |
+
+**Variants:**
+
+| Variant | Background |
+|---------|------------|
+| `section` | Surface color |
+| `transparent` | Transparent |
+| `wash` | Wash color |
+
+### XDSLayoutContainer (Primitive)
+
+A low-level primitive that sets CSS variables for layout padding. Prefer XDSCard or XDSSection for most use cases.
+
+```tsx
+// Direct usage is rare - prefer higher-order components
+<XDSLayoutContainer
+  xstyle={customStyles}
+  paddingInnerX="space3"
+  paddingInnerY="space3"
+>
+  <XDSLayout ... />
+</XDSLayoutContainer>
+```
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `xstyle` | `StyleXStyles` | — | Custom styles (background, shadow, radius, sizing) |
+| `paddingOuterX` | `SpacingToken` | `'space4'` | Outer horizontal padding |
+| `paddingOuterY` | `SpacingToken` | `'space4'` | Outer vertical padding |
+| `paddingInnerX` | `SpacingToken` | `'space4'` | Inner horizontal padding for content areas |
+| `paddingInnerY` | `SpacingToken` | `'space4'` | Inner vertical padding for content areas |
+| `children` | `ReactNode` | — | Content |
+
+**CSS Variables Set:**
+- `--layout-padding-outer-x`, `--layout-padding-outer-y` — Used by XDSLayout for fullBleed calculations
+- `--layout-padding-inner-x`, `--layout-padding-inner-y` — Used by content areas (Header, Footer, Content, Panel)
+
+## Files
+
+| File | Role | Purpose |
+|------|------|---------|
+| `index.ts` | Entry | Exports all components and types |
+| `XDSLayoutContainer.tsx` | Primitive | Base container, sets CSS variables |
+| `XDSCard.tsx` | Component | Card with elevation |
+| `XDSSection.tsx` | Component | Section with background variants |
+| `README.md` | Docs | This documentation |
+
+## Theming
+
+Higher-order components support theme-level overrides:
+
+```tsx
+// XDSCard theming
+declare module '@xds/core' {
+  interface ComponentStyles {
+    card?: { base?: StyleXStyles };
+  }
+}
+
+// XDSSection theming
+declare module '@xds/core' {
+  interface ComponentStyles {
+    section?: { variants?: Partial<Record<XDSSectionVariant, StyleXStyles>> };
+  }
+}
+```
+
+Themes can override padding by setting the CSS variables in their style overrides:
+
+```tsx
+const cardStyles = stylex.create({
+  base: {
+    '--layout-padding-inner-x': spacingTokens.space3,
+    '--layout-padding-inner-y': spacingTokens.space3,
+  },
+});
+```
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Higher-Order Components                                 │
+│  XDSCard, XDSSection (and future: XDSModal, XDSPopover) │
+├─────────────────────────────────────────────────────────┤
+│  Primitive                                               │
+│  XDSLayoutContainer                                      │
+│  (Sets CSS variables, flex container)                    │
+└─────────────────────────────────────────────────────────┘
+```
+
+XDSCard and XDSSection wrap XDSLayoutContainer, adding their own styling. They expose explicit sizing props (width, height, maxWidth, minHeight) rather than xstyle for better introspectability. Padding values are fixed internally (not exposed as props).

--- a/packages/core/src/Layout/Container/XDSCard.tsx
+++ b/packages/core/src/Layout/Container/XDSCard.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSCard.tsx
- * @input Uses XDSLayoutContainer, StyleX, ThemeContext
+ * @input Uses container utility, StyleX, ThemeContext
  * @output Exports XDSCard component and XDSCardProps
  * @position Higher-order container component for card layouts
  */
@@ -14,7 +14,7 @@ import {
 } from '../../theme/tokens.stylex';
 import { ThemeContext } from '../../theme/ThemeContext';
 import type { StyleXStyles as ThemeStyleXStyles } from '../../theme/types';
-import { XDSLayoutContainer } from './XDSLayoutContainer';
+import { container } from './container.stylex';
 
 // =============================================================================
 // Module Augmentation - Register XDSCard's themeable properties
@@ -92,8 +92,8 @@ export interface XDSCardProps {
 /**
  * A card container with elevation and themed styling.
  *
- * Uses XDSLayoutContainer internally and applies card-specific
- * appearance (background, shadow, border-radius).
+ * Applies card-specific appearance (background, shadow, border-radius)
+ * and sets CSS variables for child layout components.
  *
  * @example
  * ```tsx
@@ -113,9 +113,15 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
     const themeOverride = themeContext?.theme.components?.card?.base;
 
     return (
-      <XDSLayoutContainer
+      <div
         ref={ref}
-        xstyle={[
+        {...stylex.props(
+          ...container({
+            paddingInnerX: 'space4',
+            paddingInnerY: 'space4',
+            paddingOuterX: 'space4',
+            paddingOuterY: 'space4',
+          }),
           styles.card,
           themeOverride,
           dynamicStyles.sizing(
@@ -123,16 +129,12 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
             height ?? null,
             maxWidth ?? null,
             minHeight ?? null
-          ),
-        ]}
-        paddingInnerX="space4"
-        paddingInnerY="space4"
-        paddingOuterX="space4"
-        paddingOuterY="space4"
+          )
+        )}
         {...props}
       >
         {children}
-      </XDSLayoutContainer>
+      </div>
     );
   }
 );

--- a/packages/core/src/Layout/Container/XDSCard.tsx
+++ b/packages/core/src/Layout/Container/XDSCard.tsx
@@ -1,0 +1,132 @@
+/**
+ * @file XDSCard.tsx
+ * @input Uses XDSLayoutContainer, StyleX, ThemeContext
+ * @output Exports XDSCard component and XDSCardProps
+ * @position Higher-order container component for card layouts
+ */
+
+import { forwardRef, useContext, type ReactNode, type CSSProperties } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorTokens,
+  radiusTokens,
+  elevationTokens,
+} from '../../theme/tokens.stylex';
+import { ThemeContext } from '../../theme/ThemeContext';
+import type { StyleXStyles as ThemeStyleXStyles } from '../../theme/types';
+import { XDSLayoutContainer } from './XDSLayoutContainer';
+
+// =============================================================================
+// Module Augmentation - Register XDSCard's themeable properties
+// =============================================================================
+
+declare module '../../theme/types' {
+  interface ComponentStyles {
+    card?: {
+      /** Base style overrides */
+      base?: ThemeStyleXStyles;
+    };
+  }
+}
+
+const styles = stylex.create({
+  card: {
+    backgroundColor: colorTokens.card,
+    borderRadius: radiusTokens.container,
+    boxShadow: elevationTokens.base,
+  },
+});
+
+/**
+ * Size value type - accepts numbers (treated as pixels) or strings (e.g., '100%', '50vh')
+ */
+export type SizeValue = number | string;
+
+export interface XDSCardProps {
+  /**
+   * Width of the card.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  width?: SizeValue;
+
+  /**
+   * Height of the card.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  height?: SizeValue;
+
+  /**
+   * Maximum width of the card.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  maxWidth?: SizeValue;
+
+  /**
+   * Minimum height of the card.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  minHeight?: SizeValue;
+
+  /**
+   * Content to render inside the card.
+   * Should typically be XDSLayout child components.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Converts a size value to a CSS-compatible string.
+ */
+function formatSize(value: SizeValue | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === 'number' ? `${value}px` : value;
+}
+
+/**
+ * A card container with elevation and themed styling.
+ *
+ * Uses XDSLayoutContainer internally and applies card-specific
+ * appearance (background, shadow, border-radius).
+ *
+ * @example
+ * ```tsx
+ * <XDSCard width={400} height={300}>
+ *   <XDSLayout
+ *     header={<XDSLayoutHeader hasDivider>Title</XDSLayoutHeader>}
+ *     content={<XDSLayoutContent>Content</XDSLayoutContent>}
+ *     footer={<XDSLayoutFooter hasDivider>Actions</XDSLayoutFooter>}
+ *   />
+ * </XDSCard>
+ * ```
+ */
+export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
+  function XDSCard({ width, height, maxWidth, minHeight, children, ...props }, ref) {
+    // Get theme context for component-level overrides
+    const themeContext = useContext(ThemeContext);
+    const themeOverride = themeContext?.theme.components?.card?.base;
+
+    // Build inline style for sizing props
+    const sizeStyle: CSSProperties = {};
+    if (width !== undefined) sizeStyle.width = formatSize(width);
+    if (height !== undefined) sizeStyle.height = formatSize(height);
+    if (maxWidth !== undefined) sizeStyle.maxWidth = formatSize(maxWidth);
+    if (minHeight !== undefined) sizeStyle.minHeight = formatSize(minHeight);
+
+    return (
+      <XDSLayoutContainer
+        ref={ref}
+        xstyle={[styles.card, themeOverride]}
+        style={sizeStyle}
+        paddingInnerX="space4"
+        paddingInnerY="space4"
+        paddingOuterX="space4"
+        paddingOuterY="space4"
+        {...props}
+      >
+        {children}
+      </XDSLayoutContainer>
+    );
+  }
+);
+
+XDSCard.displayName = 'XDSCard';

--- a/packages/core/src/Layout/Container/XDSCard.tsx
+++ b/packages/core/src/Layout/Container/XDSCard.tsx
@@ -40,10 +40,10 @@ const styles = stylex.create({
 // Dynamic styles for sizing props
 const dynamicStyles = stylex.create({
   sizing: (
-    width: string | null,
-    height: string | null,
-    maxWidth: string | null,
-    minHeight: string | null
+    width: SizeValue | null,
+    height: SizeValue | null,
+    maxWidth: SizeValue | null,
+    minHeight: SizeValue | null
   ) => ({
     width,
     height,
@@ -90,14 +90,6 @@ export interface XDSCardProps {
 }
 
 /**
- * Converts a size value to a CSS-compatible string or null.
- */
-function formatSize(value: SizeValue | undefined): string | null {
-  if (value === undefined) return null;
-  return typeof value === 'number' ? `${value}px` : value;
-}
-
-/**
  * A card container with elevation and themed styling.
  *
  * Uses XDSLayoutContainer internally and applies card-specific
@@ -127,10 +119,10 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
           styles.card,
           themeOverride,
           dynamicStyles.sizing(
-            formatSize(width),
-            formatSize(height),
-            formatSize(maxWidth),
-            formatSize(minHeight)
+            width ?? null,
+            height ?? null,
+            maxWidth ?? null,
+            minHeight ?? null
           ),
         ]}
         paddingInnerX="space4"

--- a/packages/core/src/Layout/Container/XDSCard.tsx
+++ b/packages/core/src/Layout/Container/XDSCard.tsx
@@ -5,7 +5,7 @@
  * @position Higher-order container component for card layouts
  */
 
-import { forwardRef, useContext, type ReactNode, type CSSProperties } from 'react';
+import { forwardRef, useContext, type ReactNode } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorTokens,
@@ -35,6 +35,21 @@ const styles = stylex.create({
     borderRadius: radiusTokens.container,
     boxShadow: elevationTokens.base,
   },
+});
+
+// Dynamic styles for sizing props
+const dynamicStyles = stylex.create({
+  sizing: (
+    width: string | null,
+    height: string | null,
+    maxWidth: string | null,
+    minHeight: string | null
+  ) => ({
+    width,
+    height,
+    maxWidth,
+    minHeight,
+  }),
 });
 
 /**
@@ -75,10 +90,10 @@ export interface XDSCardProps {
 }
 
 /**
- * Converts a size value to a CSS-compatible string.
+ * Converts a size value to a CSS-compatible string or null.
  */
-function formatSize(value: SizeValue | undefined): string | undefined {
-  if (value === undefined) return undefined;
+function formatSize(value: SizeValue | undefined): string | null {
+  if (value === undefined) return null;
   return typeof value === 'number' ? `${value}px` : value;
 }
 
@@ -105,18 +120,19 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
     const themeContext = useContext(ThemeContext);
     const themeOverride = themeContext?.theme.components?.card?.base;
 
-    // Build inline style for sizing props
-    const sizeStyle: CSSProperties = {};
-    if (width !== undefined) sizeStyle.width = formatSize(width);
-    if (height !== undefined) sizeStyle.height = formatSize(height);
-    if (maxWidth !== undefined) sizeStyle.maxWidth = formatSize(maxWidth);
-    if (minHeight !== undefined) sizeStyle.minHeight = formatSize(minHeight);
-
     return (
       <XDSLayoutContainer
         ref={ref}
-        xstyle={[styles.card, themeOverride]}
-        style={sizeStyle}
+        xstyle={[
+          styles.card,
+          themeOverride,
+          dynamicStyles.sizing(
+            formatSize(width),
+            formatSize(height),
+            formatSize(maxWidth),
+            formatSize(minHeight)
+          ),
+        ]}
         paddingInnerX="space4"
         paddingInnerY="space4"
         paddingOuterX="space4"

--- a/packages/core/src/Layout/Container/XDSLayoutContainer.tsx
+++ b/packages/core/src/Layout/Container/XDSLayoutContainer.tsx
@@ -1,0 +1,201 @@
+/**
+ * @file XDSLayoutContainer.tsx
+ * @input Uses React forwardRef, ReactNode, StyleX
+ * @output Exports XDSLayoutContainer component and XDSLayoutContainerProps
+ * @position Layout/Container primitive component
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layout/Container/README.md
+ * - /packages/core/src/Layout/Container/index.ts
+ */
+
+import {
+  forwardRef,
+  type CSSProperties,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type { StyleXStyles } from '@stylexjs/stylex';
+import { spacingTokens } from '../../theme/tokens.stylex';
+
+/**
+ * Spacing token keys for padding props.
+ */
+export type SpacingToken =
+  | 'space0'
+  | 'space0_5'
+  | 'space1'
+  | 'space2'
+  | 'space3'
+  | 'space4'
+  | 'space5'
+  | 'space6'
+  | 'space7';
+
+const styles = stylex.create({
+  container: {
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+  },
+});
+
+const paddingOuterXStyles = stylex.create({
+  space0: { '--layout-padding-outer-x': spacingTokens.space0 },
+  space0_5: { '--layout-padding-outer-x': spacingTokens.space0_5 },
+  space1: { '--layout-padding-outer-x': spacingTokens.space1 },
+  space2: { '--layout-padding-outer-x': spacingTokens.space2 },
+  space3: { '--layout-padding-outer-x': spacingTokens.space3 },
+  space4: { '--layout-padding-outer-x': spacingTokens.space4 },
+  space5: { '--layout-padding-outer-x': spacingTokens.space5 },
+  space6: { '--layout-padding-outer-x': spacingTokens.space6 },
+  space7: { '--layout-padding-outer-x': spacingTokens.space7 },
+});
+
+const paddingOuterYStyles = stylex.create({
+  space0: { '--layout-padding-outer-y': spacingTokens.space0 },
+  space0_5: { '--layout-padding-outer-y': spacingTokens.space0_5 },
+  space1: { '--layout-padding-outer-y': spacingTokens.space1 },
+  space2: { '--layout-padding-outer-y': spacingTokens.space2 },
+  space3: { '--layout-padding-outer-y': spacingTokens.space3 },
+  space4: { '--layout-padding-outer-y': spacingTokens.space4 },
+  space5: { '--layout-padding-outer-y': spacingTokens.space5 },
+  space6: { '--layout-padding-outer-y': spacingTokens.space6 },
+  space7: { '--layout-padding-outer-y': spacingTokens.space7 },
+});
+
+const paddingInnerXStyles = stylex.create({
+  space0: { '--layout-padding-inner-x': spacingTokens.space0 },
+  space0_5: { '--layout-padding-inner-x': spacingTokens.space0_5 },
+  space1: { '--layout-padding-inner-x': spacingTokens.space1 },
+  space2: { '--layout-padding-inner-x': spacingTokens.space2 },
+  space3: { '--layout-padding-inner-x': spacingTokens.space3 },
+  space4: { '--layout-padding-inner-x': spacingTokens.space4 },
+  space5: { '--layout-padding-inner-x': spacingTokens.space5 },
+  space6: { '--layout-padding-inner-x': spacingTokens.space6 },
+  space7: { '--layout-padding-inner-x': spacingTokens.space7 },
+});
+
+const paddingInnerYStyles = stylex.create({
+  space0: { '--layout-padding-inner-y': spacingTokens.space0 },
+  space0_5: { '--layout-padding-inner-y': spacingTokens.space0_5 },
+  space1: { '--layout-padding-inner-y': spacingTokens.space1 },
+  space2: { '--layout-padding-inner-y': spacingTokens.space2 },
+  space3: { '--layout-padding-inner-y': spacingTokens.space3 },
+  space4: { '--layout-padding-inner-y': spacingTokens.space4 },
+  space5: { '--layout-padding-inner-y': spacingTokens.space5 },
+  space6: { '--layout-padding-inner-y': spacingTokens.space6 },
+  space7: { '--layout-padding-inner-y': spacingTokens.space7 },
+});
+
+export interface XDSLayoutContainerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'style' | 'className'> {
+  /**
+   * Custom styles for the container.
+   * Use for background, shadow, radius, etc.
+   */
+  xstyle?: StyleXStyles;
+
+  /**
+   * Inline styles for sizing (width, height, etc.).
+   * Used internally by higher-order components like XDSCard.
+   */
+  style?: CSSProperties;
+
+  /**
+   * Outer horizontal padding (left/right).
+   * Sets --layout-padding-outer-x CSS variable.
+   * @default 'space4'
+   */
+  paddingOuterX?: SpacingToken;
+
+  /**
+   * Outer vertical padding (top/bottom).
+   * Sets --layout-padding-outer-y CSS variable.
+   * @default 'space4'
+   */
+  paddingOuterY?: SpacingToken;
+
+  /**
+   * Inner horizontal padding for content areas.
+   * Sets --layout-padding-inner-x CSS variable.
+   * @default 'space4'
+   */
+  paddingInnerX?: SpacingToken;
+
+  /**
+   * Inner vertical padding for content areas.
+   * Sets --layout-padding-inner-y CSS variable.
+   * @default 'space4'
+   */
+  paddingInnerY?: SpacingToken;
+
+  /**
+   * Content to render inside the container.
+   * Should typically be XDSLayout child components.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * A primitive container component for layout composition.
+ *
+ * Sets CSS variables for padding that child layout components read:
+ * - `--layout-padding-outer-x`, `--layout-padding-outer-y`
+ * - `--layout-padding-inner-x`, `--layout-padding-inner-y`
+ *
+ * This is a low-level primitive. For styled containers, use:
+ * - XDSCard - Card with elevation
+ * - XDSSection - Section with background variants
+ * - XDSModal, XDSPopover, etc.
+ *
+ * @example
+ * ```tsx
+ * // Direct usage (rare - prefer higher-order components)
+ * <XDSLayoutContainer
+ *   xstyle={customStyles}
+ *   paddingInnerX="space3"
+ *   paddingInnerY="space3"
+ * >
+ *   <XDSLayout ... />
+ * </XDSLayoutContainer>
+ * ```
+ */
+export const XDSLayoutContainer = forwardRef<HTMLDivElement, XDSLayoutContainerProps>(
+  function XDSLayoutContainer(
+    {
+      xstyle,
+      style,
+      paddingOuterX = 'space4',
+      paddingOuterY = 'space4',
+      paddingInnerX = 'space4',
+      paddingInnerY = 'space4',
+      children,
+      ...props
+    },
+    ref
+  ) {
+    const stylexResult = stylex.props(
+      styles.container,
+      paddingOuterXStyles[paddingOuterX],
+      paddingOuterYStyles[paddingOuterY],
+      paddingInnerXStyles[paddingInnerX],
+      paddingInnerYStyles[paddingInnerY],
+      xstyle
+    );
+
+    return (
+      <div
+        ref={ref}
+        className={stylexResult.className}
+        style={{ ...stylexResult.style, ...style }}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+XDSLayoutContainer.displayName = 'XDSLayoutContainer';

--- a/packages/core/src/Layout/Container/XDSLayoutContainer.tsx
+++ b/packages/core/src/Layout/Container/XDSLayoutContainer.tsx
@@ -11,7 +11,6 @@
 
 import {
   forwardRef,
-  type CSSProperties,
   type HTMLAttributes,
   type ReactNode,
 } from 'react';
@@ -93,15 +92,9 @@ const paddingInnerYStyles = stylex.create({
 export interface XDSLayoutContainerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'style' | 'className'> {
   /**
    * Custom styles for the container.
-   * Use for background, shadow, radius, etc.
+   * Use for background, shadow, radius, sizing, etc.
    */
   xstyle?: StyleXStyles;
-
-  /**
-   * Inline styles for sizing (width, height, etc.).
-   * Used internally by higher-order components like XDSCard.
-   */
-  style?: CSSProperties;
 
   /**
    * Outer horizontal padding (left/right).
@@ -166,7 +159,6 @@ export const XDSLayoutContainer = forwardRef<HTMLDivElement, XDSLayoutContainerP
   function XDSLayoutContainer(
     {
       xstyle,
-      style,
       paddingOuterX = 'space4',
       paddingOuterY = 'space4',
       paddingInnerX = 'space4',
@@ -176,20 +168,17 @@ export const XDSLayoutContainer = forwardRef<HTMLDivElement, XDSLayoutContainerP
     },
     ref
   ) {
-    const stylexResult = stylex.props(
-      styles.container,
-      paddingOuterXStyles[paddingOuterX],
-      paddingOuterYStyles[paddingOuterY],
-      paddingInnerXStyles[paddingInnerX],
-      paddingInnerYStyles[paddingInnerY],
-      xstyle
-    );
-
     return (
       <div
         ref={ref}
-        className={stylexResult.className}
-        style={{ ...stylexResult.style, ...style }}
+        {...stylex.props(
+          styles.container,
+          paddingOuterXStyles[paddingOuterX],
+          paddingOuterYStyles[paddingOuterY],
+          paddingInnerXStyles[paddingInnerX],
+          paddingInnerYStyles[paddingInnerY],
+          xstyle
+        )}
         {...props}
       >
         {children}

--- a/packages/core/src/Layout/Container/XDSSection.tsx
+++ b/packages/core/src/Layout/Container/XDSSection.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSection.tsx
- * @input Uses XDSLayoutContainer, StyleX, ThemeContext
+ * @input Uses container utility, StyleX, ThemeContext
  * @output Exports XDSSection component and XDSSectionProps
  * @position Higher-order container component for section layouts
  */
@@ -10,7 +10,7 @@ import * as stylex from '@stylexjs/stylex';
 import { colorTokens } from '../../theme/tokens.stylex';
 import { ThemeContext } from '../../theme/ThemeContext';
 import type { StyleXStyles as ThemeStyleXStyles } from '../../theme/types';
-import { XDSLayoutContainer } from './XDSLayoutContainer';
+import { container } from './container.stylex';
 import type { SizeValue } from './XDSCard';
 
 /**
@@ -102,8 +102,8 @@ export interface XDSSectionProps {
 /**
  * A section container with background variants.
  *
- * Uses XDSLayoutContainer internally and applies section-specific
- * appearance based on the variant prop.
+ * Applies section-specific appearance based on the variant prop
+ * and sets CSS variables for child layout components.
  *
  * @example
  * ```tsx
@@ -124,9 +124,15 @@ export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
     const themeVariantOverride = themeContext?.theme.components?.section?.variants?.[variant];
 
     return (
-      <XDSLayoutContainer
+      <div
         ref={ref}
-        xstyle={[
+        {...stylex.props(
+          ...container({
+            paddingInnerX: 'space4',
+            paddingInnerY: 'space4',
+            paddingOuterX: 'space4',
+            paddingOuterY: 'space4',
+          }),
           variantStyles[variant],
           themeVariantOverride,
           dynamicStyles.sizing(
@@ -134,16 +140,12 @@ export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
             height ?? null,
             maxWidth ?? null,
             minHeight ?? null
-          ),
-        ]}
-        paddingInnerX="space4"
-        paddingInnerY="space4"
-        paddingOuterX="space4"
-        paddingOuterY="space4"
+          )
+        )}
         {...props}
       >
         {children}
-      </XDSLayoutContainer>
+      </div>
     );
   }
 );

--- a/packages/core/src/Layout/Container/XDSSection.tsx
+++ b/packages/core/src/Layout/Container/XDSSection.tsx
@@ -5,7 +5,7 @@
  * @position Higher-order container component for section layouts
  */
 
-import { forwardRef, useContext, type ReactNode, type CSSProperties } from 'react';
+import { forwardRef, useContext, type ReactNode } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { colorTokens } from '../../theme/tokens.stylex';
 import { ThemeContext } from '../../theme/ThemeContext';
@@ -41,6 +41,21 @@ const variantStyles = stylex.create({
   wash: {
     backgroundColor: colorTokens.wash,
   },
+});
+
+// Dynamic styles for sizing props
+const dynamicStyles = stylex.create({
+  sizing: (
+    width: string | null,
+    height: string | null,
+    maxWidth: string | null,
+    minHeight: string | null
+  ) => ({
+    width,
+    height,
+    maxWidth,
+    minHeight,
+  }),
 });
 
 export interface XDSSectionProps {
@@ -85,10 +100,10 @@ export interface XDSSectionProps {
 }
 
 /**
- * Converts a size value to a CSS-compatible string.
+ * Converts a size value to a CSS-compatible string or null.
  */
-function formatSize(value: SizeValue | undefined): string | undefined {
-  if (value === undefined) return undefined;
+function formatSize(value: SizeValue | undefined): string | null {
+  if (value === undefined) return null;
   return typeof value === 'number' ? `${value}px` : value;
 }
 
@@ -116,18 +131,19 @@ export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
     const themeContext = useContext(ThemeContext);
     const themeVariantOverride = themeContext?.theme.components?.section?.variants?.[variant];
 
-    // Build inline style for sizing props
-    const sizeStyle: CSSProperties = {};
-    if (width !== undefined) sizeStyle.width = formatSize(width);
-    if (height !== undefined) sizeStyle.height = formatSize(height);
-    if (maxWidth !== undefined) sizeStyle.maxWidth = formatSize(maxWidth);
-    if (minHeight !== undefined) sizeStyle.minHeight = formatSize(minHeight);
-
     return (
       <XDSLayoutContainer
         ref={ref}
-        xstyle={[variantStyles[variant], themeVariantOverride]}
-        style={sizeStyle}
+        xstyle={[
+          variantStyles[variant],
+          themeVariantOverride,
+          dynamicStyles.sizing(
+            formatSize(width),
+            formatSize(height),
+            formatSize(maxWidth),
+            formatSize(minHeight)
+          ),
+        ]}
         paddingInnerX="space4"
         paddingInnerY="space4"
         paddingOuterX="space4"

--- a/packages/core/src/Layout/Container/XDSSection.tsx
+++ b/packages/core/src/Layout/Container/XDSSection.tsx
@@ -46,10 +46,10 @@ const variantStyles = stylex.create({
 // Dynamic styles for sizing props
 const dynamicStyles = stylex.create({
   sizing: (
-    width: string | null,
-    height: string | null,
-    maxWidth: string | null,
-    minHeight: string | null
+    width: SizeValue | null,
+    height: SizeValue | null,
+    maxWidth: SizeValue | null,
+    minHeight: SizeValue | null
   ) => ({
     width,
     height,
@@ -100,14 +100,6 @@ export interface XDSSectionProps {
 }
 
 /**
- * Converts a size value to a CSS-compatible string or null.
- */
-function formatSize(value: SizeValue | undefined): string | null {
-  if (value === undefined) return null;
-  return typeof value === 'number' ? `${value}px` : value;
-}
-
-/**
  * A section container with background variants.
  *
  * Uses XDSLayoutContainer internally and applies section-specific
@@ -138,10 +130,10 @@ export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
           variantStyles[variant],
           themeVariantOverride,
           dynamicStyles.sizing(
-            formatSize(width),
-            formatSize(height),
-            formatSize(maxWidth),
-            formatSize(minHeight)
+            width ?? null,
+            height ?? null,
+            maxWidth ?? null,
+            minHeight ?? null
           ),
         ]}
         paddingInnerX="space4"

--- a/packages/core/src/Layout/Container/XDSSection.tsx
+++ b/packages/core/src/Layout/Container/XDSSection.tsx
@@ -1,0 +1,143 @@
+/**
+ * @file XDSSection.tsx
+ * @input Uses XDSLayoutContainer, StyleX, ThemeContext
+ * @output Exports XDSSection component and XDSSectionProps
+ * @position Higher-order container component for section layouts
+ */
+
+import { forwardRef, useContext, type ReactNode, type CSSProperties } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { colorTokens } from '../../theme/tokens.stylex';
+import { ThemeContext } from '../../theme/ThemeContext';
+import type { StyleXStyles as ThemeStyleXStyles } from '../../theme/types';
+import { XDSLayoutContainer } from './XDSLayoutContainer';
+import type { SizeValue } from './XDSCard';
+
+/**
+ * Visual variant for the section.
+ */
+export type XDSSectionVariant = 'section' | 'transparent' | 'wash';
+
+// =============================================================================
+// Module Augmentation - Register XDSSection's themeable properties
+// =============================================================================
+
+declare module '../../theme/types' {
+  interface ComponentStyles {
+    section?: {
+      /** Style overrides for each variant */
+      variants?: Partial<Record<XDSSectionVariant, ThemeStyleXStyles>>;
+    };
+  }
+}
+
+const variantStyles = stylex.create({
+  section: {
+    backgroundColor: colorTokens.surface,
+  },
+  transparent: {
+    backgroundColor: 'transparent',
+  },
+  wash: {
+    backgroundColor: colorTokens.wash,
+  },
+});
+
+export interface XDSSectionProps {
+  /**
+   * Visual variant of the section.
+   * - 'section': Surface background color
+   * - 'transparent': Fully transparent background
+   * - 'wash': Wash background color
+   * @default 'section'
+   */
+  variant?: XDSSectionVariant;
+
+  /**
+   * Width of the section.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  width?: SizeValue;
+
+  /**
+   * Height of the section.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  height?: SizeValue;
+
+  /**
+   * Maximum width of the section.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  maxWidth?: SizeValue;
+
+  /**
+   * Minimum height of the section.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  minHeight?: SizeValue;
+
+  /**
+   * Content to render inside the section.
+   * Should typically be XDSLayout child components.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Converts a size value to a CSS-compatible string.
+ */
+function formatSize(value: SizeValue | undefined): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === 'number' ? `${value}px` : value;
+}
+
+/**
+ * A section container with background variants.
+ *
+ * Uses XDSLayoutContainer internally and applies section-specific
+ * appearance based on the variant prop.
+ *
+ * @example
+ * ```tsx
+ * <XDSSection variant="wash" width={300} height={250}>
+ *   <XDSLayout
+ *     content={<XDSLayoutContent>Content in wash section</XDSLayoutContent>}
+ *   />
+ * </XDSSection>
+ * ```
+ */
+export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
+  function XDSSection(
+    { variant = 'section', width, height, maxWidth, minHeight, children, ...props },
+    ref
+  ) {
+    // Get theme context for component-level overrides
+    const themeContext = useContext(ThemeContext);
+    const themeVariantOverride = themeContext?.theme.components?.section?.variants?.[variant];
+
+    // Build inline style for sizing props
+    const sizeStyle: CSSProperties = {};
+    if (width !== undefined) sizeStyle.width = formatSize(width);
+    if (height !== undefined) sizeStyle.height = formatSize(height);
+    if (maxWidth !== undefined) sizeStyle.maxWidth = formatSize(maxWidth);
+    if (minHeight !== undefined) sizeStyle.minHeight = formatSize(minHeight);
+
+    return (
+      <XDSLayoutContainer
+        ref={ref}
+        xstyle={[variantStyles[variant], themeVariantOverride]}
+        style={sizeStyle}
+        paddingInnerX="space4"
+        paddingInnerY="space4"
+        paddingOuterX="space4"
+        paddingOuterY="space4"
+        {...props}
+      >
+        {children}
+      </XDSLayoutContainer>
+    );
+  }
+);
+
+XDSSection.displayName = 'XDSSection';

--- a/packages/core/src/Layout/Container/container.stylex.ts
+++ b/packages/core/src/Layout/Container/container.stylex.ts
@@ -1,21 +1,13 @@
 /**
- * @file XDSLayoutContainer.tsx
- * @input Uses React forwardRef, ReactNode, StyleX
- * @output Exports XDSLayoutContainer component and XDSLayoutContainerProps
- * @position Layout/Container primitive component
+ * @file container.stylex.ts
+ * @input Uses @stylexjs/stylex, spacingTokens from theme
+ * @output StyleX utility for layout container styling
+ * @position Layout utility; used by XDSCard, XDSSection components
  *
- * SYNC: When modified, update these files to stay in sync:
- * - /packages/core/src/Layout/Container/README.md
- * - /packages/core/src/Layout/Container/index.ts
+ * SYNC: When modified, update /packages/core/src/Layout/README.md
  */
 
-import {
-  forwardRef,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type { StyleXStyles } from '@stylexjs/stylex';
 import { spacingTokens } from '../../theme/tokens.stylex';
 
 /**
@@ -32,7 +24,7 @@ export type SpacingToken =
   | 'space6'
   | 'space7';
 
-const styles = stylex.create({
+const baseStyles = stylex.create({
   container: {
     boxSizing: 'border-box',
     display: 'flex',
@@ -89,13 +81,7 @@ const paddingInnerYStyles = stylex.create({
   space7: { '--layout-padding-inner-y': spacingTokens.space7 },
 });
 
-export interface XDSLayoutContainerProps extends Omit<HTMLAttributes<HTMLDivElement>, 'style' | 'className'> {
-  /**
-   * Custom styles for the container.
-   * Use for background, shadow, radius, sizing, etc.
-   */
-  xstyle?: StyleXStyles;
-
+export interface ContainerOptions {
   /**
    * Outer horizontal padding (left/right).
    * Sets --layout-padding-outer-x CSS variable.
@@ -123,68 +109,45 @@ export interface XDSLayoutContainerProps extends Omit<HTMLAttributes<HTMLDivElem
    * @default 'space4'
    */
   paddingInnerY?: SpacingToken;
-
-  /**
-   * Content to render inside the container.
-   * Should typically be XDSLayout child components.
-   */
-  children?: ReactNode;
 }
 
 /**
- * A primitive container component for layout composition.
+ * StyleX utility to add layout container styles to any element.
  *
  * Sets CSS variables for padding that child layout components read:
  * - `--layout-padding-outer-x`, `--layout-padding-outer-y`
  * - `--layout-padding-inner-x`, `--layout-padding-inner-y`
  *
- * This is a low-level primitive. For styled containers, use:
- * - XDSCard - Card with elevation
- * - XDSSection - Section with background variants
- * - XDSModal, XDSPopover, etc.
- *
  * @example
  * ```tsx
- * // Direct usage (rare - prefer higher-order components)
- * <XDSLayoutContainer
- *   xstyle={customStyles}
- *   paddingInnerX="space3"
- *   paddingInnerY="space3"
- * >
+ * import { container } from '@xds/core/Layout';
+ * import * as stylex from '@stylexjs/stylex';
+ *
+ * // Basic container with default padding
+ * <div {...stylex.props(...container({}))}>
  *   <XDSLayout ... />
- * </XDSLayoutContainer>
+ * </div>
+ *
+ * // Custom padding values
+ * <div {...stylex.props(
+ *   ...container({ paddingInnerX: 'space3', paddingOuterY: 'space2' }),
+ *   customStyles.card
+ * )}>
+ *   <XDSLayout ... />
+ * </div>
  * ```
  */
-export const XDSLayoutContainer = forwardRef<HTMLDivElement, XDSLayoutContainerProps>(
-  function XDSLayoutContainer(
-    {
-      xstyle,
-      paddingOuterX = 'space4',
-      paddingOuterY = 'space4',
-      paddingInnerX = 'space4',
-      paddingInnerY = 'space4',
-      children,
-      ...props
-    },
-    ref
-  ) {
-    return (
-      <div
-        ref={ref}
-        {...stylex.props(
-          styles.container,
-          paddingOuterXStyles[paddingOuterX],
-          paddingOuterYStyles[paddingOuterY],
-          paddingInnerXStyles[paddingInnerX],
-          paddingInnerYStyles[paddingInnerY],
-          xstyle
-        )}
-        {...props}
-      >
-        {children}
-      </div>
-    );
-  }
-);
-
-XDSLayoutContainer.displayName = 'XDSLayoutContainer';
+export function container({
+  paddingOuterX = 'space4',
+  paddingOuterY = 'space4',
+  paddingInnerX = 'space4',
+  paddingInnerY = 'space4',
+}: ContainerOptions) {
+  return [
+    baseStyles.container,
+    paddingOuterXStyles[paddingOuterX],
+    paddingOuterYStyles[paddingOuterY],
+    paddingInnerXStyles[paddingInnerX],
+    paddingInnerYStyles[paddingInnerY],
+  ] as const;
+}

--- a/packages/core/src/Layout/Container/index.ts
+++ b/packages/core/src/Layout/Container/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @file index.ts
+ * @input Imports Container components
+ * @output Exports XDSLayoutContainer, XDSCard, XDSSection and types
+ * @position Entry point for Layout/Container module
+ *
+ * SYNC: When modified, update /packages/core/src/Layout/Container/README.md
+ */
+
+export { XDSLayoutContainer } from './XDSLayoutContainer';
+export type {
+  XDSLayoutContainerProps,
+  SpacingToken,
+} from './XDSLayoutContainer';
+
+export { XDSCard } from './XDSCard';
+export type { XDSCardProps, SizeValue } from './XDSCard';
+
+export { XDSSection } from './XDSSection';
+export type { XDSSectionProps, XDSSectionVariant } from './XDSSection';

--- a/packages/core/src/Layout/Container/index.ts
+++ b/packages/core/src/Layout/Container/index.ts
@@ -1,17 +1,11 @@
 /**
  * @file index.ts
  * @input Imports Container components
- * @output Exports XDSLayoutContainer, XDSCard, XDSSection and types
+ * @output Exports XDSCard, XDSSection components and types
  * @position Entry point for Layout/Container module
  *
  * SYNC: When modified, update /packages/core/src/Layout/Container/README.md
  */
-
-export { XDSLayoutContainer } from './XDSLayoutContainer';
-export type {
-  XDSLayoutContainerProps,
-  SpacingToken,
-} from './XDSLayoutContainer';
 
 export { XDSCard } from './XDSCard';
 export type { XDSCardProps, SizeValue } from './XDSCard';

--- a/packages/core/src/Layout/README.md
+++ b/packages/core/src/Layout/README.md
@@ -7,10 +7,10 @@ XDS Layout System - composable utilities and components for building structured 
 ## Overview
 
 The layout system provides a container/content separation pattern with:
-- Zero styling customization (no xstyle props)
-- Context-aware defaults
-- Automatic RTL support via logical properties
-- Polymorphic rendering support
+- **Primitive + higher-order architecture** — XDSLayoutContainer is a primitive; XDSCard, XDSSection are higher-order
+- **Directional padding via CSS variables** — Inner/outer, horizontal/vertical padding control
+- **Context-aware defaults** — Components detect their slot and self-adjust
+- **Automatic RTL support** — Uses CSS logical properties
 
 ## Import
 
@@ -18,11 +18,22 @@ All layout utilities and components are exported from `@xds/core/Layout`:
 
 ```tsx
 import {
+  // Container components
+  XDSLayoutContainer,
+  XDSCard,
+  XDSSection,
+  // Layout structure
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutFooter,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+  // Stack utilities
   XDSHStack,
   XDSVStack,
   XDSStackItem,
   stack,
-  stackItem
+  stackItem,
 } from '@xds/core/Layout';
 ```
 
@@ -30,28 +41,95 @@ import {
 
 ```
 Layout/
-├── index.ts           # Entry point, re-exports everything
-├── Stack/             # Stack utilities and components
+├── index.ts              # Entry point, re-exports everything
+├── README.md             # This documentation
+├── Container/            # Container primitive and higher-order components
 │   ├── index.ts
-│   ├── README.md      # Stack documentation
-│   ├── stack.stylex.ts
-│   ├── stackItem.stylex.ts
-│   ├── XDSHStack.tsx
-│   ├── XDSHStack.test.tsx
-│   ├── XDSVStack.tsx
-│   ├── XDSVStack.test.tsx
-│   ├── XDSStackItem.tsx
-│   └── XDSStackItem.test.tsx
-└── README.md
+│   ├── README.md
+│   ├── XDSLayoutContainer.tsx  # Primitive
+│   ├── XDSCard.tsx             # Card with elevation
+│   └── XDSSection.tsx          # Section with background variants
+├── XDSLayout/            # Layout structure components
+│   ├── index.ts
+│   ├── README.md
+│   ├── XDSLayout.tsx
+│   ├── XDSLayoutHeader.tsx
+│   ├── XDSLayoutFooter.tsx
+│   ├── XDSLayoutContent.tsx
+│   ├── XDSLayoutPanel.tsx
+│   └── XDSLayoutAreaContext.ts
+└── Stack/                # Stack utilities and components
+    ├── index.ts
+    ├── README.md
+    ├── stack.stylex.ts
+    ├── stackItem.stylex.ts
+    ├── XDSHStack.tsx
+    ├── XDSVStack.tsx
+    └── XDSStackItem.tsx
 ```
 
-## Available Components
+## Quick Start
+
+### Card Layout
+
+```tsx
+<XDSCard>
+  <XDSLayout
+    header={<XDSLayoutHeader hasDivider>Title</XDSLayoutHeader>}
+    content={<XDSLayoutContent>Body content</XDSLayoutContent>}
+    footer={
+      <XDSLayoutFooter hasDivider>
+        <XDSHStack gap="space2" hAlign="end">
+          <XDSButton variant="secondary">Cancel</XDSButton>
+          <XDSButton variant="primary">Save</XDSButton>
+        </XDSHStack>
+      </XDSLayoutFooter>
+    }
+  />
+</XDSCard>
+```
+
+### Layout with Sidebar
+
+```tsx
+<XDSCard>
+  <XDSLayout
+    header={<XDSLayoutHeader hasDivider>Settings</XDSLayoutHeader>}
+    start={
+      <XDSLayoutPanel hasDivider role="navigation">
+        <Navigation />
+      </XDSLayoutPanel>
+    }
+    content={<XDSLayoutContent>Main content</XDSLayoutContent>}
+  />
+</XDSCard>
+```
+
+## Components
+
+### Container Components
+
+| Component | Description |
+|-----------|-------------|
+| `XDSLayoutContainer` | Primitive that sets CSS variables for padding |
+| `XDSCard` | Card with elevation and themed styling |
+| `XDSSection` | Section with background variants (section, transparent, wash) |
+
+See [Container/README.md](./Container/README.md) for full documentation.
+
+### Layout Structure
+
+| Component | Description |
+|-----------|-------------|
+| `XDSLayout` | Arranges content into header, footer, content, start, end slots |
+| `XDSLayoutHeader` | Header content area with optional divider |
+| `XDSLayoutFooter` | Footer content area with optional divider |
+| `XDSLayoutContent` | Scrollable main content area |
+| `XDSLayoutPanel` | Side panel for start/end slots |
+
+See [XDSLayout/README.md](./XDSLayout/README.md) for full documentation.
 
 ### Stack Components
-
-Stack layout primitives for arranging items in horizontal or vertical sequences.
-
-See [Stack/README.md](./Stack/README.md) for full documentation.
 
 | Component | Description |
 |-----------|-------------|
@@ -59,26 +137,36 @@ See [Stack/README.md](./Stack/README.md) for full documentation.
 | `XDSVStack` | Vertical stack (top-to-bottom) |
 | `XDSStackItem` | Stack item with fill/alignment control |
 
-Quick example:
+See [Stack/README.md](./Stack/README.md) for full documentation.
 
-```tsx
-<XDSHStack gap="space2">
-  <XDSStackItem size="static">Logo</XDSStackItem>
-  <XDSStackItem size="fill">Content</XDSStackItem>
-  <XDSStackItem size="static">Actions</XDSStackItem>
-</XDSHStack>
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Higher-Order Components                                 │
+│  XDSCard, XDSSection (future: XDSModal, XDSPopover)     │
+├─────────────────────────────────────────────────────────┤
+│  Layout Structure                                        │
+│  XDSLayout + XDSLayoutHeader/Footer/Content/Panel       │
+├─────────────────────────────────────────────────────────┤
+│  Primitive                                               │
+│  XDSLayoutContainer (sets CSS variables)                │
+├─────────────────────────────────────────────────────────┤
+│  Layout Utilities                                        │
+│  XDSHStack, XDSVStack, stack(), stackItem()             │
+└─────────────────────────────────────────────────────────┘
 ```
 
-## Components (Planned)
+## CSS Variables
 
-| Component | Status | Description |
-|-----------|--------|-------------|
-| `XDSLayoutContainer` | Planned | Outer container with variant-based styling |
-| `XDSLayout` | Planned | Section arrangement with named slots |
-| `XDSLayoutHeader` | Planned | Header content area |
-| `XDSLayoutFooter` | Planned | Footer content area |
-| `XDSLayoutContent` | Planned | Main content area |
-| `XDSLayoutPanel` | Planned | Side panel content area |
+XDSLayoutContainer sets these CSS variables that child components read:
+
+| Variable | Used By | Purpose |
+|----------|---------|---------|
+| `--layout-padding-outer-x` | XDSLayout | Outer horizontal padding |
+| `--layout-padding-outer-y` | XDSLayout | Outer vertical padding |
+| `--layout-padding-inner-x` | Header, Footer, Content, Panel | Inner horizontal padding |
+| `--layout-padding-inner-y` | Header, Footer, Content, Panel | Inner vertical padding |
 
 ## Related
 

--- a/packages/core/src/Layout/Stack/XDSHStack.tsx
+++ b/packages/core/src/Layout/Stack/XDSHStack.tsx
@@ -20,9 +20,20 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type { StyleXStyles } from '@stylexjs/stylex';
-import { stack, type StackCrossAlignment, type StackWrap, type SpacingScale } from './stack.stylex';
+import { stack, type StackCrossAlignment, type StackMainAlignment, type StackWrap, type SpacingScale } from './stack.stylex';
 
 export interface XDSHStackProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
+  /**
+   * Horizontal alignment of items (main-axis for horizontal stack).
+   * - `start`: Align to start (left in LTR)
+   * - `center`: Center items
+   * - `end`: Align to end (right in LTR)
+   * - `between`: Space between items
+   * - `around`: Space around items
+   * - `evenly`: Even space distribution
+   */
+  hAlign?: StackMainAlignment;
+
   /**
    * Vertical alignment of items (cross-axis for horizontal stack).
    * @default 'stretch'
@@ -82,13 +93,14 @@ export interface XDSHStackProps extends Omit<HTMLAttributes<HTMLElement>, 'style
  */
 export const XDSHStack = forwardRef<HTMLElement, XDSHStackProps>(
   function XDSHStack(
-    { vAlign, gap, wrap, element = 'div', xstyle, children, ...props },
+    { hAlign, vAlign, gap, wrap, element = 'div', xstyle, children, ...props },
     ref
   ) {
     const stylexProps = stylex.props(
       ...stack({
         direction: 'horizontal',
         crossAlign: vAlign,
+        mainAlign: hAlign,
         gap,
         wrap,
       }),

--- a/packages/core/src/Layout/Stack/XDSVStack.tsx
+++ b/packages/core/src/Layout/Stack/XDSVStack.tsx
@@ -20,7 +20,7 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type { StyleXStyles } from '@stylexjs/stylex';
-import { stack, type StackCrossAlignment, type StackWrap, type SpacingScale } from './stack.stylex';
+import { stack, type StackCrossAlignment, type StackMainAlignment, type StackWrap, type SpacingScale } from './stack.stylex';
 
 export interface XDSVStackProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
   /**
@@ -28,6 +28,17 @@ export interface XDSVStackProps extends Omit<HTMLAttributes<HTMLElement>, 'style
    * @default 'stretch'
    */
   hAlign?: StackCrossAlignment;
+
+  /**
+   * Vertical alignment of items (main-axis for vertical stack).
+   * - `start`: Align to top
+   * - `center`: Center items
+   * - `end`: Align to bottom
+   * - `between`: Space between items
+   * - `around`: Space around items
+   * - `evenly`: Even space distribution
+   */
+  vAlign?: StackMainAlignment;
 
   /**
    * Spacing between items using theme spacing tokens.
@@ -82,13 +93,14 @@ export interface XDSVStackProps extends Omit<HTMLAttributes<HTMLElement>, 'style
  */
 export const XDSVStack = forwardRef<HTMLElement, XDSVStackProps>(
   function XDSVStack(
-    { hAlign, gap, wrap, element = 'div', xstyle, children, ...props },
+    { hAlign, vAlign, gap, wrap, element = 'div', xstyle, children, ...props },
     ref
   ) {
     const stylexProps = stylex.props(
       ...stack({
         direction: 'vertical',
         crossAlign: hAlign,
+        mainAlign: vAlign,
         gap,
         wrap,
       }),

--- a/packages/core/src/Layout/Stack/index.ts
+++ b/packages/core/src/Layout/Stack/index.ts
@@ -13,6 +13,7 @@ export type {
   StackOptions,
   StackDirection,
   StackCrossAlignment,
+  StackMainAlignment,
   StackWrap,
   SpacingScale,
 } from './stack.stylex';

--- a/packages/core/src/Layout/Stack/index.ts
+++ b/packages/core/src/Layout/Stack/index.ts
@@ -1,29 +1,11 @@
 /**
  * @file index.ts
- * @input Imports stack utilities and components
- * @output Exports stack utilities and XDSHStack/XDSVStack/XDSStackItem components
+ * @input Imports stack components
+ * @output Exports XDSHStack, XDSVStack, XDSStackItem components
  * @position Entry point for Layout/Stack
  *
  * SYNC: When modified, update /packages/core/src/Layout/README.md
  */
-
-// Utilities
-export { stack } from './stack.stylex';
-export type {
-  StackOptions,
-  StackDirection,
-  StackCrossAlignment,
-  StackMainAlignment,
-  StackWrap,
-  SpacingScale,
-} from './stack.stylex';
-
-export { stackItem } from './stackItem.stylex';
-export type {
-  StackItemOptions,
-  StackItemCrossAlignSelf,
-  StackItemSize,
-} from './stackItem.stylex';
 
 // Components
 export { XDSHStack } from './XDSHStack';

--- a/packages/core/src/Layout/Stack/stack.stylex.ts
+++ b/packages/core/src/Layout/Stack/stack.stylex.ts
@@ -32,6 +32,34 @@ const alignItemsStyles = stylex.create({
  */
 export type StackCrossAlignment = keyof typeof alignItemsStyles;
 
+const justifyContentStyles = stylex.create({
+  start: {
+    justifyContent: 'flex-start',
+  },
+  center: {
+    justifyContent: 'center',
+  },
+  end: {
+    justifyContent: 'flex-end',
+  },
+  between: {
+    justifyContent: 'space-between',
+  },
+  around: {
+    justifyContent: 'space-around',
+  },
+  evenly: {
+    justifyContent: 'space-evenly',
+  },
+});
+
+/**
+ * Main-axis alignment options for stack items.
+ * - For HStack: horizontal alignment
+ * - For VStack: vertical alignment
+ */
+export type StackMainAlignment = keyof typeof justifyContentStyles;
+
 const directionStyles = stylex.create({
   horizontal: {
     flexDirection: 'row',
@@ -143,6 +171,13 @@ export interface StackOptions {
   gap?: SpacingScale;
 
   /**
+   * Position of items along the main-axis.
+   * - For HStack: horizontal alignment
+   * - For VStack: vertical alignment
+   */
+  mainAlign?: StackMainAlignment;
+
+  /**
    * Whether items should wrap to the next line.
    * - `nowrap`: Items stay on one line (default)
    * - `wrap`: Items wrap to next line
@@ -184,6 +219,7 @@ export function stack({
   crossAlign,
   direction,
   gap,
+  mainAlign,
   wrap,
 }: StackOptions) {
   return [
@@ -191,6 +227,7 @@ export function stack({
     directionStyles[direction],
     gap != null && gapStyles[gap],
     crossAlign != null && alignItemsStyles[crossAlign],
+    mainAlign != null && justifyContentStyles[mainAlign],
     wrap != null && wrapStyles[wrap],
   ] as const;
 }

--- a/packages/core/src/Layout/XDSLayout/README.md
+++ b/packages/core/src/Layout/XDSLayout/README.md
@@ -1,0 +1,188 @@
+# /packages/core/src/Layout/XDSLayout
+
+XDS Layout structure components for arranging sections using named slots.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Overview
+
+The XDSLayout system provides a 5-slot layout structure for building consistent page and component layouts. It follows a **zero styling** principle — no `xstyle` customization props.
+
+```
+┌─────────────────────────────────────────┐
+│                 header                  │
+├──────┬─────────────────────────┬────────┤
+│      │                         │        │
+│start │        content          │  end   │
+│      │                         │        │
+├──────┴─────────────────────────┴────────┤
+│                 footer                  │
+└─────────────────────────────────────────┘
+```
+
+## Import
+
+```tsx
+import {
+  XDSCard,
+  XDSSection,
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutFooter,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+} from '@xds/core/Layout';
+```
+
+## Usage
+
+XDSLayout must be wrapped in a container component (XDSCard, XDSSection, or XDSLayoutContainer), which provides visual appearance and padding context.
+
+### Basic Layout
+
+```tsx
+<XDSCard>
+  <XDSLayout
+    header={<XDSLayoutHeader hasDivider>Page Title</XDSLayoutHeader>}
+    content={<XDSLayoutContent>Main content here</XDSLayoutContent>}
+    footer={<XDSLayoutFooter>Actions</XDSLayoutFooter>}
+  />
+</XDSCard>
+```
+
+### With Sidebars
+
+```tsx
+<XDSCard>
+  <XDSLayout
+    header={<XDSLayoutHeader hasDivider>Dashboard</XDSLayoutHeader>}
+    start={
+      <XDSLayoutPanel hasDivider role="navigation">
+        <Navigation />
+      </XDSLayoutPanel>
+    }
+    content={<XDSLayoutContent>Main content</XDSLayoutContent>}
+    end={
+      <XDSLayoutPanel hasDivider role="complementary">
+        <Sidebar />
+      </XDSLayoutPanel>
+    }
+  />
+</XDSCard>
+```
+
+### Full Bleed Content
+
+Use `isFullBleed` on XDSLayoutContent to remove internal padding, allowing content to touch the edges. Useful for tables, images, or other edge-to-edge content.
+
+```tsx
+<XDSCard>
+  <XDSLayout
+    header={<XDSLayoutHeader hasDivider>Users</XDSLayoutHeader>}
+    content={
+      <XDSLayoutContent isFullBleed>
+        <Table />
+      </XDSLayoutContent>
+    }
+    footer={<XDSLayoutFooter hasDivider>Actions</XDSLayoutFooter>}
+  />
+</XDSCard>
+```
+
+### Section Variants
+
+```tsx
+<XDSSection variant="wash">
+  <XDSLayout
+    content={<XDSLayoutContent>Content in wash section</XDSLayoutContent>}
+  />
+</XDSSection>
+```
+
+## Components
+
+| Component | Description | Renders |
+|-----------|-------------|---------|
+| `XDSLayout` | Main layout component with named slots | `<div>` |
+| `XDSLayoutHeader` | Header content area | `<div>` (use `role` for landmark) |
+| `XDSLayoutFooter` | Footer content area | `<div>` (use `role` for landmark) |
+| `XDSLayoutContent` | Main content area | `<div>` (use `role` for landmark) |
+| `XDSLayoutPanel` | Side panel for start/end slots | `<div>` (use `role` for landmark) |
+
+## Props
+
+### XDSLayout
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `header` | `ReactNode` | — | Header slot content |
+| `footer` | `ReactNode` | — | Footer slot content |
+| `content` | `ReactNode` | — | Main content slot |
+| `start` | `ReactNode` | — | Start panel (left in LTR) |
+| `end` | `ReactNode` | — | End panel (right in LTR) |
+| `height` | `'fill' \| 'auto'` | `'fill'` | `fill`: layout fills container, content scrolls. `auto`: layout grows with content |
+| `isFullBleed` | `boolean` | `false` | Removes padding at layout's outer edges |
+
+### XDSLayoutHeader / XDSLayoutFooter
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | Area content |
+| `hasDivider` | `boolean` | `false` | Adds themed border (bottom for header, top for footer) |
+| `isFullBleed` | `boolean` | `false` | Removes internal padding |
+| `label` | `string` | — | Accessible label for the landmark (required when multiple landmarks of same type) |
+| `role` | `AriaRole` | — | ARIA landmark role (e.g., `'banner'`, `'contentinfo'`) |
+
+### XDSLayoutContent
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | Area content |
+| `isFullBleed` | `boolean` | `false` | Removes internal padding |
+| `isScrollable` | `boolean` | `true` | Enables scrollable overflow. Set to `false` for auto-height layouts with sticky elements |
+| `label` | `string` | — | Accessible label for the landmark |
+| `role` | `AriaRole` | — | ARIA landmark role (e.g., `'main'`) |
+
+### XDSLayoutPanel
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `children` | `ReactNode` | — | Area content |
+| `hasDivider` | `boolean` | `false` | Adds themed border (auto-positioned based on slot) |
+| `isFullBleed` | `boolean` | `false` | Removes internal padding |
+| `label` | `string` | — | Accessible label for the landmark (required when multiple landmarks of same type) |
+| `role` | `AriaRole` | — | ARIA landmark role (e.g., `'navigation'`, `'complementary'`) |
+
+## Files
+
+| File | Role | Purpose |
+|------|------|---------|
+| `index.ts` | Entry | Exports all components and types |
+| `XDSLayout.tsx` | Core | Main layout component |
+| `XDSLayoutHeader.tsx` | Component | Header content area |
+| `XDSLayoutFooter.tsx` | Component | Footer content area |
+| `XDSLayoutContent.tsx` | Component | Main content area |
+| `XDSLayoutPanel.tsx` | Component | Side panel component |
+| `XDSLayoutAreaContext.ts` | Context | Slot detection context |
+
+## Dividers
+
+`hasDivider` on content areas auto-places the divider on the correct edge:
+
+| Component | Divider Position |
+|-----------|------------------|
+| Header | Bottom edge |
+| Footer | Top edge |
+| Panel (start) | End edge |
+| Panel (end) | Start edge |
+
+When `hasDivider` is false, spacing collapse is applied automatically for seamless visual flow.
+
+## RTL Support
+
+Uses CSS logical properties (`padding-inline`, `border-inline-start`, etc.) for automatic RTL support. The `start`/`end` naming ensures panels appear on the correct side in both LTR and RTL contexts.
+
+## Related
+
+- See `.context/proposals/layout-system.md` for full design proposal
+- See `../Stack/README.md` for stack primitives used internally

--- a/packages/core/src/Layout/XDSLayout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayout.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayout.tsx
- * @input Uses React, XDSHStack, XDSVStack, XDSLayoutAreaContext, XDSLayoutSlotsContext
+ * @input Uses React, stack/stackItem utilities, XDSLayoutAreaContext, XDSLayoutSlotsContext
  * @output Exports XDSLayout component and XDSLayoutProps, XDSLayoutHeight types
  * @position Core layout component with named slots
  *
@@ -14,9 +14,8 @@ import { type ReactNode, useMemo } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { XDSLayoutAreaContext, type LayoutArea } from './XDSLayoutAreaContext';
 import { XDSLayoutSlotsContext, type LayoutSlots } from './XDSLayoutSlotsContext';
-import { XDSHStack } from '../Stack/XDSHStack';
-import { XDSVStack } from '../Stack/XDSVStack';
-import { XDSStackItem } from '../Stack/XDSStackItem';
+import { stack } from '../Stack/stack.stylex';
+import { stackItem } from '../Stack/stackItem.stylex';
 
 /**
  * Height behavior for the layout.
@@ -35,6 +34,11 @@ const styles = stylex.create({
   middle: {
     flex: 1,
     minHeight: 0,
+  },
+  // When full bleed, set outer padding variables to 0 so child components touch container edges
+  fullBleed: {
+    '--layout-padding-outer-x': '0px',
+    '--layout-padding-outer-y': '0px',
   },
 });
 
@@ -143,24 +147,29 @@ export function XDSLayout({
       hasFooter: footer != null,
       hasStart: start != null,
       hasEnd: end != null,
-      isFullBleed,
     }),
-    [header != null, footer != null, start != null, end != null, isFullBleed]
+    [header != null, footer != null, start != null, end != null]
   );
 
   return (
     <XDSLayoutSlotsContext.Provider value={slotsValue}>
-      <XDSVStack xstyle={isFill ? styles.fill : styles.auto}>
+      <div
+        {...stylex.props(
+          ...stack({ direction: 'vertical' }),
+          isFill ? styles.fill : styles.auto,
+          isFullBleed && styles.fullBleed
+        )}
+      >
         <AreaProvider area="header">{header}</AreaProvider>
-        <XDSHStack xstyle={styles.middle}>
+        <div {...stylex.props(...stack({ direction: 'horizontal' }), styles.middle)}>
           <AreaProvider area="start">{start}</AreaProvider>
-          <XDSStackItem size="fill">
+          <div {...stylex.props(...stackItem({ size: 'fill' }))}>
             <AreaProvider area="content">{content}</AreaProvider>
-          </XDSStackItem>
+          </div>
           <AreaProvider area="end">{end}</AreaProvider>
-        </XDSHStack>
+        </div>
         <AreaProvider area="footer">{footer}</AreaProvider>
-      </XDSVStack>
+      </div>
     </XDSLayoutSlotsContext.Provider>
   );
 }

--- a/packages/core/src/Layout/XDSLayout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayout.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayout.tsx
- * @input Uses React, XDSHStack, XDSVStack, XDSLayoutAreaContext
+ * @input Uses React, XDSHStack, XDSVStack, XDSLayoutAreaContext, XDSLayoutSlotsContext
  * @output Exports XDSLayout component and XDSLayoutProps, XDSLayoutHeight types
  * @position Core layout component with named slots
  *
@@ -10,9 +10,10 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-import { type ReactNode } from 'react';
+import { type ReactNode, useMemo } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { XDSLayoutAreaContext, type LayoutArea } from './XDSLayoutAreaContext';
+import { XDSLayoutSlotsContext, type LayoutSlots } from './XDSLayoutSlotsContext';
 import { XDSHStack } from '../Stack/XDSHStack';
 import { XDSVStack } from '../Stack/XDSVStack';
 import { XDSStackItem } from '../Stack/XDSStackItem';
@@ -34,11 +35,6 @@ const styles = stylex.create({
   middle: {
     flex: 1,
     minHeight: 0,
-  },
-  fullBleed: {
-    // Removes outer padding from layout edges
-    marginInline: 'calc(-1 * var(--layout-padding-outer-x, 0px))',
-    marginBlock: 'calc(-1 * var(--layout-padding-outer-y, 0px))',
   },
 });
 
@@ -140,23 +136,32 @@ export function XDSLayout({
 }: XDSLayoutProps) {
   const isFill = height === 'fill';
 
+  // Memoize slots info to avoid unnecessary re-renders
+  const slotsValue = useMemo<LayoutSlots>(
+    () => ({
+      hasHeader: header != null,
+      hasFooter: footer != null,
+      hasStart: start != null,
+      hasEnd: end != null,
+      isFullBleed,
+    }),
+    [header != null, footer != null, start != null, end != null, isFullBleed]
+  );
+
   return (
-    <XDSVStack
-      xstyle={[
-        isFill ? styles.fill : styles.auto,
-        isFullBleed && styles.fullBleed,
-      ]}
-    >
-      <AreaProvider area="header">{header}</AreaProvider>
-      <XDSHStack xstyle={styles.middle}>
-        <AreaProvider area="start">{start}</AreaProvider>
-        <XDSStackItem size="fill">
-          <AreaProvider area="content">{content}</AreaProvider>
-        </XDSStackItem>
-        <AreaProvider area="end">{end}</AreaProvider>
-      </XDSHStack>
-      <AreaProvider area="footer">{footer}</AreaProvider>
-    </XDSVStack>
+    <XDSLayoutSlotsContext.Provider value={slotsValue}>
+      <XDSVStack xstyle={isFill ? styles.fill : styles.auto}>
+        <AreaProvider area="header">{header}</AreaProvider>
+        <XDSHStack xstyle={styles.middle}>
+          <AreaProvider area="start">{start}</AreaProvider>
+          <XDSStackItem size="fill">
+            <AreaProvider area="content">{content}</AreaProvider>
+          </XDSStackItem>
+          <AreaProvider area="end">{end}</AreaProvider>
+        </XDSHStack>
+        <AreaProvider area="footer">{footer}</AreaProvider>
+      </XDSVStack>
+    </XDSLayoutSlotsContext.Provider>
   );
 }
 

--- a/packages/core/src/Layout/XDSLayout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayout.tsx
@@ -1,0 +1,163 @@
+/**
+ * @file XDSLayout.tsx
+ * @input Uses React, XDSHStack, XDSVStack, XDSLayoutAreaContext
+ * @output Exports XDSLayout component and XDSLayoutProps, XDSLayoutHeight types
+ * @position Core layout component with named slots
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layout/XDSLayout/README.md
+ * - /packages/core/src/Layout/XDSLayout/index.ts
+ * - /apps/storybook/stories/Layout.stories.tsx
+ */
+
+import { type ReactNode } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { XDSLayoutAreaContext, type LayoutArea } from './XDSLayoutAreaContext';
+import { XDSHStack } from '../Stack/XDSHStack';
+import { XDSVStack } from '../Stack/XDSVStack';
+import { XDSStackItem } from '../Stack/XDSStackItem';
+
+/**
+ * Height behavior for the layout.
+ * - `fill`: Layout fills container height, content scrolls internally (default)
+ * - `auto`: Layout grows with content, container/page scrolls
+ */
+export type XDSLayoutHeight = 'fill' | 'auto';
+
+const styles = stylex.create({
+  fill: {
+    height: '100%',
+  },
+  auto: {
+    minHeight: '100%',
+  },
+  middle: {
+    flex: 1,
+    minHeight: 0,
+  },
+  fullBleed: {
+    // Removes outer padding from layout edges
+    marginInline: 'calc(-1 * var(--layout-padding-outer-x, 0px))',
+    marginBlock: 'calc(-1 * var(--layout-padding-outer-y, 0px))',
+  },
+});
+
+export interface XDSLayoutProps {
+  /**
+   * Main content area (center).
+   */
+  content?: ReactNode;
+
+  /**
+   * End panel slot (right in LTR, left in RTL).
+   */
+  end?: ReactNode;
+
+  /**
+   * Footer slot.
+   */
+  footer?: ReactNode;
+
+  /**
+   * Header slot.
+   */
+  header?: ReactNode;
+
+  /**
+   * Controls the height behavior:
+   * - `fill`: Layout fills container height, content scrolls internally (default)
+   * - `auto`: Layout grows with content, container/page scrolls
+   * @default 'fill'
+   */
+  height?: XDSLayoutHeight;
+
+  /**
+   * Removes padding at layout's outer edges, making layout touch container edges.
+   * @default false
+   */
+  isFullBleed?: boolean;
+
+  /**
+   * Start panel slot (left in LTR, right in RTL).
+   */
+  start?: ReactNode;
+}
+
+/**
+ * Helper component to wrap content in layout area context.
+ */
+function AreaProvider({
+  area,
+  children,
+}: {
+  area: LayoutArea;
+  children: ReactNode;
+}) {
+  if (children == null) {
+    return null;
+  }
+  return (
+    <XDSLayoutAreaContext.Provider value={area}>
+      {children}
+    </XDSLayoutAreaContext.Provider>
+  );
+}
+
+/**
+ * Arranges sections using named slots. Must be wrapped in XDSLayoutContainer.
+ *
+ * Structure:
+ * ```
+ * ┌─────────────────────────────────────────┐
+ * │                 header                  │
+ * ├──────┬─────────────────────────┬────────┤
+ * │      │                         │        │
+ * │start │        content          │  end   │
+ * │      │                         │        │
+ * ├──────┴─────────────────────────┴────────┤
+ * │                 footer                  │
+ * └─────────────────────────────────────────┘
+ * ```
+ *
+ * @example
+ * ```tsx
+ * <XDSLayoutContainer variant="card">
+ *   <XDSLayout
+ *     header={<XDSLayoutHeader>Title</XDSLayoutHeader>}
+ *     content={<XDSLayoutContent>Body</XDSLayoutContent>}
+ *   />
+ * </XDSLayoutContainer>
+ * ```
+ */
+export function XDSLayout({
+  content,
+  end,
+  footer,
+  header,
+  height = 'fill',
+  isFullBleed = false,
+  start,
+}: XDSLayoutProps) {
+  const isFill = height === 'fill';
+
+  return (
+    <XDSVStack
+      xstyle={[
+        isFill ? styles.fill : styles.auto,
+        isFullBleed && styles.fullBleed,
+      ]}
+    >
+      <AreaProvider area="header">{header}</AreaProvider>
+      <XDSHStack xstyle={styles.middle}>
+        <AreaProvider area="start">{start}</AreaProvider>
+        <XDSStackItem size="fill">
+          <AreaProvider area="content">{content}</AreaProvider>
+        </XDSStackItem>
+        <AreaProvider area="end">{end}</AreaProvider>
+      </XDSHStack>
+      <AreaProvider area="footer">{footer}</AreaProvider>
+    </XDSVStack>
+  );
+}
+
+XDSLayout.displayName = 'XDSLayout';

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutAreaContext.ts
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutAreaContext.ts
@@ -1,0 +1,26 @@
+/**
+ * @file XDSLayoutAreaContext.ts
+ * @input Uses React createContext
+ * @output Exports XDSLayoutAreaContext and LayoutArea type
+ * @position Context for layout slot detection
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layout/XDSLayout/README.md
+ */
+
+import { createContext } from 'react';
+
+/**
+ * Layout area type representing which slot a component is rendered in.
+ * Used by content area components to detect their position and adjust styling.
+ */
+export type LayoutArea = 'header' | 'footer' | 'content' | 'start' | 'end' | null;
+
+/**
+ * Context for detecting which layout area a component is rendered in.
+ * Content area components use this to:
+ * - Auto-position dividers correctly
+ * - Apply correct semantic elements
+ * - Adjust internal spacing
+ */
+export const XDSLayoutAreaContext = createContext<LayoutArea>(null);

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
@@ -126,6 +126,9 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
   ) {
     const { hasHeader, hasFooter, hasStart, hasEnd, isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
 
+    // Don't apply any padding styles when content is full bleed
+    const applyOuterPadding = !isFullBleed && !isLayoutFullBleed;
+
     return (
       <div
         ref={ref as React.Ref<HTMLDivElement>}
@@ -133,11 +136,11 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
         aria-label={label}
         {...stylex.props(
           styles.content,
-          // Outer padding on container edges (unless layout is full bleed)
-          !hasStart && !isLayoutFullBleed && styles.noStart,
-          !hasEnd && !isLayoutFullBleed && styles.noEnd,
-          !hasHeader && !isLayoutFullBleed && styles.noHeader,
-          !hasFooter && !isLayoutFullBleed && styles.noFooter,
+          // Outer padding on container edges (unless content or layout is full bleed)
+          !hasStart && applyOuterPadding && styles.noStart,
+          !hasEnd && applyOuterPadding && styles.noEnd,
+          !hasHeader && applyOuterPadding && styles.noHeader,
+          !hasFooter && applyOuterPadding && styles.noFooter,
           isScrollable && styles.scrollable,
           isFullBleed && styles.fullBleed
         )}

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutContent.tsx
- * @input Uses React forwardRef, StyleX
+ * @input Uses React forwardRef, StyleX, XDSLayoutSlotsContext
  * @output Exports XDSLayoutContent component and XDSLayoutContentProps
  * @position Layout content area component
  *
@@ -10,17 +10,35 @@
  */
 
 import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { spacingTokens } from '../../theme/tokens.stylex';
+import { XDSLayoutSlotsContext } from './XDSLayoutSlotsContext';
 
 const styles = stylex.create({
   content: {
     boxSizing: 'border-box',
     flex: 1,
     minHeight: 0,
+    // Default: inner padding on all sides (will be overridden by position-specific styles)
     paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
     paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+  },
+  // When no start panel: outer-x on left edge
+  noStart: {
+    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+  },
+  // When no end panel: outer-x on right edge
+  noEnd: {
+    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+  },
+  // When no header: outer-y on top
+  noHeader: {
+    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
+  },
+  // When no footer: outer-y on bottom
+  noFooter: {
+    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
   },
   scrollable: {
     overflow: 'auto',
@@ -106,6 +124,8 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
     { children, isFullBleed = false, isScrollable = true, label, role, ...props },
     ref
   ) {
+    const { hasHeader, hasFooter, hasStart, hasEnd, isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
+
     return (
       <div
         ref={ref as React.Ref<HTMLDivElement>}
@@ -113,6 +133,11 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
         aria-label={label}
         {...stylex.props(
           styles.content,
+          // Outer padding on container edges (unless layout is full bleed)
+          !hasStart && !isLayoutFullBleed && styles.noStart,
+          !hasEnd && !isLayoutFullBleed && styles.noEnd,
+          !hasHeader && !isLayoutFullBleed && styles.noHeader,
+          !hasFooter && !isLayoutFullBleed && styles.noFooter,
           isScrollable && styles.scrollable,
           isFullBleed && styles.fullBleed
         )}

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
@@ -1,0 +1,127 @@
+/**
+ * @file XDSLayoutContent.tsx
+ * @input Uses React forwardRef, StyleX
+ * @output Exports XDSLayoutContent component and XDSLayoutContentProps
+ * @position Layout content area component
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layout/XDSLayout/README.md
+ * - /apps/storybook/stories/Layout.stories.tsx
+ */
+
+import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { spacingTokens } from '../../theme/tokens.stylex';
+
+const styles = stylex.create({
+  content: {
+    boxSizing: 'border-box',
+    flex: 1,
+    minHeight: 0,
+    paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+  },
+  scrollable: {
+    overflow: 'auto',
+  },
+  fullBleed: {
+    paddingInline: 0,
+    paddingBlock: 0,
+  },
+});
+
+export interface XDSLayoutContentProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
+  /**
+   * Content to render inside the content area.
+   */
+  children?: ReactNode;
+
+  /**
+   * Removes internal padding, allowing content to touch the edges.
+   * Useful for edge-to-edge content like tables.
+   * @default false
+   */
+  isFullBleed?: boolean;
+
+  /**
+   * Enables scrollable overflow for the content area.
+   * Set to false for auto-height layouts where sticky positioning
+   * needs to work with parent containers.
+   * @default true
+   */
+  isScrollable?: boolean;
+
+  /**
+   * Accessible label for the landmark.
+   * Required when role is set and multiple landmarks of the same type exist.
+   */
+  label?: string;
+
+  /**
+   * ARIA landmark role for accessibility.
+   * Use 'main' only for the primary content area of the page (not in nested layouts).
+   */
+  role?: AriaRole;
+}
+
+/**
+ * Main content area for XDSLayout.
+ * Renders in the content slot with optional scrollable overflow and padding control.
+ *
+ * @example
+ * ```tsx
+ * <XDSLayoutContainer variant="card">
+ *   <XDSLayout
+ *     header={<XDSLayoutHeader>Title</XDSLayoutHeader>}
+ *     content={<XDSLayoutContent>Main body content</XDSLayoutContent>}
+ *   />
+ * </XDSLayoutContainer>
+ *
+ * // Full bleed for edge-to-edge content
+ * <XDSLayoutContainer variant="card">
+ *   <XDSLayout
+ *     content={
+ *       <XDSLayoutContent isFullBleed>
+ *         <Table />
+ *       </XDSLayoutContent>
+ *     }
+ *   />
+ * </XDSLayoutContainer>
+ *
+ * // Non-scrollable for auto-height layouts with sticky elements
+ * <XDSLayoutContainer variant="card">
+ *   <XDSLayout
+ *     content={
+ *       <XDSLayoutContent isScrollable={false}>
+ *         <StickyElement />
+ *       </XDSLayoutContent>
+ *     }
+ *   />
+ * </XDSLayoutContainer>
+ * ```
+ */
+export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
+  function XDSLayoutContent(
+    { children, isFullBleed = false, isScrollable = true, label, role, ...props },
+    ref
+  ) {
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        role={role}
+        aria-label={label}
+        {...stylex.props(
+          styles.content,
+          isScrollable && styles.scrollable,
+          isFullBleed && styles.fullBleed
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+XDSLayoutContent.displayName = 'XDSLayoutContent';

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
@@ -20,9 +20,12 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     flex: 1,
     minHeight: 0,
+    overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
-    paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-    paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   // When no start panel: outer-x on left edge
   noStart: {
@@ -44,8 +47,10 @@ const styles = stylex.create({
     overflow: 'auto',
   },
   fullBleed: {
-    paddingInline: 0,
-    paddingBlock: 0,
+    paddingInlineStart: 0,
+    paddingInlineEnd: 0,
+    paddingBlockStart: 0,
+    paddingBlockEnd: 0,
   },
 });
 

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
@@ -18,6 +18,7 @@ import { XDSLayoutSlotsContext } from './XDSLayoutSlotsContext';
 const styles = stylex.create({
   content: {
     boxSizing: 'border-box',
+    height: '100%',
     flex: 1,
     minHeight: 0,
     overflow: 'clip',
@@ -129,10 +130,7 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
     { children, isFullBleed = false, isScrollable = true, label, role, ...props },
     ref
   ) {
-    const { hasHeader, hasFooter, hasStart, hasEnd, isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
-
-    // Don't apply any padding styles when content is full bleed
-    const applyOuterPadding = !isFullBleed && !isLayoutFullBleed;
+    const { hasHeader, hasFooter, hasStart, hasEnd } = useContext(XDSLayoutSlotsContext);
 
     return (
       <div
@@ -141,11 +139,11 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
         aria-label={label}
         {...stylex.props(
           styles.content,
-          // Outer padding on container edges (unless content or layout is full bleed)
-          !hasStart && applyOuterPadding && styles.noStart,
-          !hasEnd && applyOuterPadding && styles.noEnd,
-          !hasHeader && applyOuterPadding && styles.noHeader,
-          !hasFooter && applyOuterPadding && styles.noFooter,
+          // Outer padding on container edges (unless content is full bleed)
+          !hasStart && !isFullBleed && styles.noStart,
+          !hasEnd && !isFullBleed && styles.noEnd,
+          !hasHeader && !isFullBleed && styles.noHeader,
+          !hasFooter && !isFullBleed && styles.noFooter,
           isScrollable && styles.scrollable,
           isFullBleed && styles.fullBleed
         )}

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutFooter.tsx
- * @input Uses React forwardRef, StyleX, XDSLayoutSlotsContext
+ * @input Uses React forwardRef, StyleX
  * @output Exports XDSLayoutFooter component and XDSLayoutFooterProps
  * @position Layout content area component
  *
@@ -10,10 +10,9 @@
  */
 
 import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
-import { forwardRef, useContext } from 'react';
+import { forwardRef } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { colorTokens, spacingTokens } from '../../theme/tokens.stylex';
-import { XDSLayoutSlotsContext } from './XDSLayoutSlotsContext';
 
 const styles = stylex.create({
   footer: {
@@ -24,12 +23,6 @@ const styles = stylex.create({
     paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
     paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
     paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
-  },
-  // When layout is full bleed, use inner padding instead of outer
-  layoutFullBleed: {
-    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   fullBleed: {
     paddingInlineStart: 0,
@@ -112,13 +105,8 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
     { children, hasDivider = false, height, isFullBleed = false, label, role, ...props },
     ref
   ) {
-    const { isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
-
     // When no divider, collapse spacing for seamless visual flow
     const shouldCollapseSpacing = !hasDivider && !isFullBleed;
-
-    // Don't apply layout full bleed styles when component is full bleed
-    const applyLayoutFullBleed = isLayoutFullBleed && !isFullBleed;
 
     return (
       <div
@@ -128,7 +116,6 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
         {...stylex.props(
           styles.footer,
           dynamicStyles.sizing(height ?? null),
-          applyLayoutFullBleed && styles.layoutFullBleed,
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,
           shouldCollapseSpacing && styles.collapseTop

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
@@ -1,0 +1,112 @@
+/**
+ * @file XDSLayoutFooter.tsx
+ * @input Uses React forwardRef, StyleX
+ * @output Exports XDSLayoutFooter component and XDSLayoutFooterProps
+ * @position Layout content area component
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layout/XDSLayout/README.md
+ * - /apps/storybook/stories/Layout.stories.tsx
+ */
+
+import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { colorTokens, spacingTokens } from '../../theme/tokens.stylex';
+
+const styles = stylex.create({
+  footer: {
+    boxSizing: 'border-box',
+    flexShrink: 0,
+    paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+  },
+  fullBleed: {
+    paddingInline: 0,
+    paddingBlock: 0,
+  },
+  divider: {
+    borderBlockStartWidth: 1,
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorTokens.divider,
+  },
+  // When no divider, collapse spacing to avoid double-padding with content
+  collapseTop: {
+    marginBlockStart: `calc(-1 * var(--layout-padding-inner-y, ${spacingTokens.space4}))`,
+  },
+});
+
+export interface XDSLayoutFooterProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
+  /**
+   * Content to render inside the footer.
+   */
+  children?: ReactNode;
+
+  /**
+   * Adds a themed border at the top edge.
+   * When false, spacing collapse is applied automatically for seamless visual flow.
+   * @default false
+   */
+  hasDivider?: boolean;
+
+  /**
+   * Removes internal padding, allowing content to touch the edges.
+   * @default false
+   */
+  isFullBleed?: boolean;
+
+  /**
+   * Accessible label for the landmark.
+   * Required when role is set and multiple landmarks of the same type exist.
+   */
+  label?: string;
+
+  /**
+   * ARIA landmark role for accessibility.
+   * Use 'contentinfo' only for site-wide footers (not in nested layouts).
+   */
+  role?: AriaRole;
+}
+
+/**
+ * Footer content area for XDSLayout.
+ * Renders in the footer slot with optional divider and padding control.
+ *
+ * @example
+ * ```tsx
+ * <XDSLayoutContainer variant="card">
+ *   <XDSLayout
+ *     content={<XDSLayoutContent>...</XDSLayoutContent>}
+ *     footer={<XDSLayoutFooter hasDivider>Actions</XDSLayoutFooter>}
+ *   />
+ * </XDSLayoutContainer>
+ * ```
+ */
+export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
+  function XDSLayoutFooter(
+    { children, hasDivider = false, isFullBleed = false, label, role, ...props },
+    ref
+  ) {
+    // When no divider, collapse spacing for seamless visual flow
+    const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        role={role}
+        aria-label={label}
+        {...stylex.props(
+          styles.footer,
+          isFullBleed && styles.fullBleed,
+          hasDivider && styles.divider,
+          shouldCollapseSpacing && styles.collapseTop
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+XDSLayoutFooter.displayName = 'XDSLayoutFooter';

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
@@ -100,6 +100,9 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
     // When no divider, collapse spacing for seamless visual flow
     const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
+    // Don't apply layout full bleed styles when component is full bleed
+    const applyLayoutFullBleed = isLayoutFullBleed && !isFullBleed;
+
     return (
       <div
         ref={ref as React.Ref<HTMLDivElement>}
@@ -107,7 +110,7 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
         aria-label={label}
         {...stylex.props(
           styles.footer,
-          isLayoutFullBleed && styles.layoutFullBleed,
+          applyLayoutFullBleed && styles.layoutFullBleed,
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,
           shouldCollapseSpacing && styles.collapseTop

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutFooter.tsx
- * @input Uses React forwardRef, StyleX
+ * @input Uses React forwardRef, StyleX, XDSLayoutSlotsContext
  * @output Exports XDSLayoutFooter component and XDSLayoutFooterProps
  * @position Layout content area component
  *
@@ -10,16 +10,24 @@
  */
 
 import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { colorTokens, spacingTokens } from '../../theme/tokens.stylex';
+import { XDSLayoutSlotsContext } from './XDSLayoutSlotsContext';
 
 const styles = stylex.create({
   footer: {
     boxSizing: 'border-box',
     flexShrink: 0,
+    // Default: outer padding on edges that touch container, inner on interior edges
+    paddingInline: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
+  },
+  // When layout is full bleed, use inner padding instead of outer
+  layoutFullBleed: {
     paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-    paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   fullBleed: {
     paddingInline: 0,
@@ -87,6 +95,8 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
     { children, hasDivider = false, isFullBleed = false, label, role, ...props },
     ref
   ) {
+    const { isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
+
     // When no divider, collapse spacing for seamless visual flow
     const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
@@ -97,6 +107,7 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
         aria-label={label}
         {...stylex.props(
           styles.footer,
+          isLayoutFullBleed && styles.layoutFullBleed,
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,
           shouldCollapseSpacing && styles.collapseTop

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
@@ -20,18 +20,22 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     flexShrink: 0,
     // Default: outer padding on edges that touch container, inner on interior edges
-    paddingInline: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
     paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
     paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
   },
   // When layout is full bleed, use inner padding instead of outer
   layoutFullBleed: {
-    paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
     paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   fullBleed: {
-    paddingInline: 0,
-    paddingBlock: 0,
+    paddingInlineStart: 0,
+    paddingInlineEnd: 0,
+    paddingBlockStart: 0,
+    paddingBlockEnd: 0,
   },
   divider: {
     borderBlockStartWidth: 1,
@@ -42,6 +46,13 @@ const styles = stylex.create({
   collapseTop: {
     marginBlockStart: `calc(-1 * var(--layout-padding-inner-y, ${spacingTokens.space4}))`,
   },
+});
+
+// Dynamic styles for sizing props
+const dynamicStyles = stylex.create({
+  sizing: (height: number | string | null) => ({
+    height,
+  }),
 });
 
 export interface XDSLayoutFooterProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
@@ -56,6 +67,12 @@ export interface XDSLayoutFooterProps extends Omit<HTMLAttributes<HTMLElement>, 
    * @default false
    */
   hasDivider?: boolean;
+
+  /**
+   * Height of the footer.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  height?: number | string;
 
   /**
    * Removes internal padding, allowing content to touch the edges.
@@ -92,7 +109,7 @@ export interface XDSLayoutFooterProps extends Omit<HTMLAttributes<HTMLElement>, 
  */
 export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
   function XDSLayoutFooter(
-    { children, hasDivider = false, isFullBleed = false, label, role, ...props },
+    { children, hasDivider = false, height, isFullBleed = false, label, role, ...props },
     ref
   ) {
     const { isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
@@ -110,6 +127,7 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
         aria-label={label}
         {...stylex.props(
           styles.footer,
+          dynamicStyles.sizing(height ?? null),
           applyLayoutFullBleed && styles.layoutFullBleed,
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutHeader.tsx
- * @input Uses React forwardRef, StyleX, XDSLayoutSlotsContext
+ * @input Uses React forwardRef, StyleX
  * @output Exports XDSLayoutHeader component and XDSLayoutHeaderProps
  * @position Layout content area component
  *
@@ -10,10 +10,9 @@
  */
 
 import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
-import { forwardRef, useContext } from 'react';
+import { forwardRef } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { colorTokens, spacingTokens } from '../../theme/tokens.stylex';
-import { XDSLayoutSlotsContext } from './XDSLayoutSlotsContext';
 
 const styles = stylex.create({
   header: {
@@ -24,12 +23,6 @@ const styles = stylex.create({
     paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
     paddingBlockStart: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
     paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
-  },
-  // When layout is full bleed, use inner padding instead of outer
-  layoutFullBleed: {
-    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   fullBleed: {
     paddingInlineStart: 0,
@@ -112,13 +105,8 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
     { children, hasDivider = false, height, isFullBleed = false, label, role, ...props },
     ref
   ) {
-    const { isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
-
     // When no divider, collapse spacing for seamless visual flow
     const shouldCollapseSpacing = !hasDivider && !isFullBleed;
-
-    // Don't apply layout full bleed styles when component is full bleed
-    const applyLayoutFullBleed = isLayoutFullBleed && !isFullBleed;
 
     return (
       <div
@@ -128,7 +116,6 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
         {...stylex.props(
           styles.header,
           dynamicStyles.sizing(height ?? null),
-          applyLayoutFullBleed && styles.layoutFullBleed,
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,
           shouldCollapseSpacing && styles.collapseBottom

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutHeader.tsx
- * @input Uses React forwardRef, StyleX, XDSLayoutAreaContext
+ * @input Uses React forwardRef, StyleX, XDSLayoutSlotsContext
  * @output Exports XDSLayoutHeader component and XDSLayoutHeaderProps
  * @position Layout content area component
  *
@@ -10,16 +10,24 @@
  */
 
 import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useContext } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { colorTokens, spacingTokens } from '../../theme/tokens.stylex';
+import { XDSLayoutSlotsContext } from './XDSLayoutSlotsContext';
 
 const styles = stylex.create({
   header: {
     boxSizing: 'border-box',
     flexShrink: 0,
+    // Default: outer padding on edges that touch container, inner on interior edges
+    paddingInline: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
+    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+  },
+  // When layout is full bleed, use inner padding instead of outer
+  layoutFullBleed: {
     paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-    paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   fullBleed: {
     paddingInline: 0,
@@ -87,6 +95,8 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
     { children, hasDivider = false, isFullBleed = false, label, role, ...props },
     ref
   ) {
+    const { isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
+
     // When no divider, collapse spacing for seamless visual flow
     const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
@@ -97,6 +107,7 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
         aria-label={label}
         {...stylex.props(
           styles.header,
+          isLayoutFullBleed && styles.layoutFullBleed,
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,
           shouldCollapseSpacing && styles.collapseBottom

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
@@ -100,6 +100,9 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
     // When no divider, collapse spacing for seamless visual flow
     const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
+    // Don't apply layout full bleed styles when component is full bleed
+    const applyLayoutFullBleed = isLayoutFullBleed && !isFullBleed;
+
     return (
       <div
         ref={ref as React.Ref<HTMLDivElement>}
@@ -107,7 +110,7 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
         aria-label={label}
         {...stylex.props(
           styles.header,
-          isLayoutFullBleed && styles.layoutFullBleed,
+          applyLayoutFullBleed && styles.layoutFullBleed,
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,
           shouldCollapseSpacing && styles.collapseBottom

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
@@ -1,0 +1,112 @@
+/**
+ * @file XDSLayoutHeader.tsx
+ * @input Uses React forwardRef, StyleX, XDSLayoutAreaContext
+ * @output Exports XDSLayoutHeader component and XDSLayoutHeaderProps
+ * @position Layout content area component
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layout/XDSLayout/README.md
+ * - /apps/storybook/stories/Layout.stories.tsx
+ */
+
+import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
+import { forwardRef } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { colorTokens, spacingTokens } from '../../theme/tokens.stylex';
+
+const styles = stylex.create({
+  header: {
+    boxSizing: 'border-box',
+    flexShrink: 0,
+    paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+  },
+  fullBleed: {
+    paddingInline: 0,
+    paddingBlock: 0,
+  },
+  divider: {
+    borderBlockEndWidth: 1,
+    borderBlockEndStyle: 'solid',
+    borderBlockEndColor: colorTokens.divider,
+  },
+  // When no divider, collapse spacing to avoid double-padding with content
+  collapseBottom: {
+    marginBlockEnd: `calc(-1 * var(--layout-padding-inner-y, ${spacingTokens.space4}))`,
+  },
+});
+
+export interface XDSLayoutHeaderProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
+  /**
+   * Content to render inside the header.
+   */
+  children?: ReactNode;
+
+  /**
+   * Adds a themed border at the bottom edge.
+   * When false, spacing collapse is applied automatically for seamless visual flow.
+   * @default false
+   */
+  hasDivider?: boolean;
+
+  /**
+   * Removes internal padding, allowing content to touch the edges.
+   * @default false
+   */
+  isFullBleed?: boolean;
+
+  /**
+   * Accessible label for the landmark.
+   * Required when role is set and multiple landmarks of the same type exist.
+   */
+  label?: string;
+
+  /**
+   * ARIA landmark role for accessibility.
+   * Use 'banner' only for site-wide headers (not in nested layouts).
+   */
+  role?: AriaRole;
+}
+
+/**
+ * Header content area for XDSLayout.
+ * Renders in the header slot with optional divider and padding control.
+ *
+ * @example
+ * ```tsx
+ * <XDSLayoutContainer variant="card">
+ *   <XDSLayout
+ *     header={<XDSLayoutHeader hasDivider>Page Title</XDSLayoutHeader>}
+ *     content={<XDSLayoutContent>...</XDSLayoutContent>}
+ *   />
+ * </XDSLayoutContainer>
+ * ```
+ */
+export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
+  function XDSLayoutHeader(
+    { children, hasDivider = false, isFullBleed = false, label, role, ...props },
+    ref
+  ) {
+    // When no divider, collapse spacing for seamless visual flow
+    const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        role={role}
+        aria-label={label}
+        {...stylex.props(
+          styles.header,
+          isFullBleed && styles.fullBleed,
+          hasDivider && styles.divider,
+          shouldCollapseSpacing && styles.collapseBottom
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+XDSLayoutHeader.displayName = 'XDSLayoutHeader';

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
@@ -20,18 +20,22 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     flexShrink: 0,
     // Default: outer padding on edges that touch container, inner on interior edges
-    paddingInline: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
     paddingBlockStart: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
     paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   // When layout is full bleed, use inner padding instead of outer
   layoutFullBleed: {
-    paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
     paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   fullBleed: {
-    paddingInline: 0,
-    paddingBlock: 0,
+    paddingInlineStart: 0,
+    paddingInlineEnd: 0,
+    paddingBlockStart: 0,
+    paddingBlockEnd: 0,
   },
   divider: {
     borderBlockEndWidth: 1,
@@ -42,6 +46,13 @@ const styles = stylex.create({
   collapseBottom: {
     marginBlockEnd: `calc(-1 * var(--layout-padding-inner-y, ${spacingTokens.space4}))`,
   },
+});
+
+// Dynamic styles for sizing props
+const dynamicStyles = stylex.create({
+  sizing: (height: number | string | null) => ({
+    height,
+  }),
 });
 
 export interface XDSLayoutHeaderProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
@@ -56,6 +67,12 @@ export interface XDSLayoutHeaderProps extends Omit<HTMLAttributes<HTMLElement>, 
    * @default false
    */
   hasDivider?: boolean;
+
+  /**
+   * Height of the header.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  height?: number | string;
 
   /**
    * Removes internal padding, allowing content to touch the edges.
@@ -92,7 +109,7 @@ export interface XDSLayoutHeaderProps extends Omit<HTMLAttributes<HTMLElement>, 
  */
 export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
   function XDSLayoutHeader(
-    { children, hasDivider = false, isFullBleed = false, label, role, ...props },
+    { children, hasDivider = false, height, isFullBleed = false, label, role, ...props },
     ref
   ) {
     const { isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
@@ -110,6 +127,7 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
         aria-label={label}
         {...stylex.props(
           styles.header,
+          dynamicStyles.sizing(height ?? null),
           applyLayoutFullBleed && styles.layoutFullBleed,
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
@@ -152,6 +152,9 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
     // When no divider, collapse spacing for seamless visual flow
     const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
+    // Don't apply any outer padding styles when component is full bleed
+    const applyOuterPadding = !isFullBleed && !isLayoutFullBleed;
+
     // Select divider style based on position
     const dividerStyle = isStartPanel ? styles.dividerEnd
       : isEndPanel ? styles.dividerStart
@@ -169,11 +172,11 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
         aria-label={label}
         {...stylex.props(
           styles.panel,
-          // Outer padding on container edges (unless layout is full bleed)
-          isStartPanel && !isLayoutFullBleed && styles.startPanel,
-          isEndPanel && !isLayoutFullBleed && styles.endPanel,
-          !hasHeader && !isLayoutFullBleed && styles.noHeader,
-          !hasFooter && !isLayoutFullBleed && styles.noFooter,
+          // Outer padding on container edges (unless component or layout is full bleed)
+          isStartPanel && applyOuterPadding && styles.startPanel,
+          isEndPanel && applyOuterPadding && styles.endPanel,
+          !hasHeader && applyOuterPadding && styles.noHeader,
+          !hasFooter && applyOuterPadding && styles.noFooter,
           // Full bleed overrides
           isFullBleed && styles.fullBleed,
           hasDivider && dividerStyle,

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
@@ -43,19 +43,6 @@ const styles = stylex.create({
   noFooter: {
     paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
   },
-  // When layout is full bleed, use inner padding on outer edges
-  layoutFullBleedStart: {
-    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-  },
-  layoutFullBleedEnd: {
-    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-  },
-  layoutFullBleedTop: {
-    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
-  },
-  layoutFullBleedBottom: {
-    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
-  },
   fullBleed: {
     paddingInlineStart: 0,
     paddingInlineEnd: 0,
@@ -77,7 +64,9 @@ const styles = stylex.create({
     borderInlineStartStyle: 'solid',
     borderInlineStartColor: colorTokens.divider,
   },
-  // When no divider, collapse spacing to avoid double-padding
+  // When no divider, collapse spacing on the side facing content
+  // Start panel: collapse end (right in LTR) to merge with content
+  // End panel: collapse start (left in LTR) to merge with content
   collapseStart: {
     marginInlineStart: `calc(-1 * var(--layout-padding-inner-x, ${spacingTokens.space4}))`,
   },
@@ -171,7 +160,7 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
     ref
   ) {
     const area = useContext(XDSLayoutAreaContext);
-    const { hasHeader, hasFooter, isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
+    const { hasHeader, hasFooter } = useContext(XDSLayoutSlotsContext);
 
     // Determine panel position
     const isStartPanel = area === 'start';
@@ -180,17 +169,14 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
     // When no divider, collapse spacing for seamless visual flow
     const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
-    // Don't apply any outer padding styles when component is full bleed
-    const applyOuterPadding = !isFullBleed && !isLayoutFullBleed;
-
     // Select divider style based on position
     const dividerStyle = isStartPanel ? styles.dividerEnd
       : isEndPanel ? styles.dividerStart
       : null;
 
-    // Select collapse style based on position
-    const collapseStyle = isStartPanel ? styles.collapseStart
-      : isEndPanel ? styles.collapseEnd
+    // Select collapse style based on position (collapse the side where divider would be)
+    const collapseStyle = isStartPanel ? styles.collapseEnd
+      : isEndPanel ? styles.collapseStart
       : null;
 
     return (
@@ -201,13 +187,12 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
         {...stylex.props(
           styles.panel,
           dynamicStyles.sizing(width ?? null),
-          // Outer padding on container edges (unless component or layout is full bleed)
-          isStartPanel && applyOuterPadding && styles.startPanel,
-          isEndPanel && applyOuterPadding && styles.endPanel,
-          !hasHeader && applyOuterPadding && styles.noHeader,
-          !hasFooter && applyOuterPadding && styles.noFooter,
+          // Outer padding on container edges (unless component is full bleed)
+          isStartPanel && !isFullBleed && styles.startPanel,
+          isEndPanel && !isFullBleed && styles.endPanel,
+          !hasHeader && !isFullBleed && styles.noHeader,
+          !hasFooter && !isFullBleed && styles.noFooter,
           isScrollable && styles.scrollable,
-          // Full bleed overrides
           isFullBleed && styles.fullBleed,
           hasDivider && dividerStyle,
           shouldCollapseSpacing && collapseStyle

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
@@ -20,10 +20,12 @@ const styles = stylex.create({
   panel: {
     boxSizing: 'border-box',
     flexShrink: 0,
-    overflow: 'auto',
+    overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
-    paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
-    paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   // Start panel: outer-x on left edge
   startPanel: {
@@ -55,8 +57,13 @@ const styles = stylex.create({
     paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   fullBleed: {
-    paddingInline: 0,
-    paddingBlock: 0,
+    paddingInlineStart: 0,
+    paddingInlineEnd: 0,
+    paddingBlockStart: 0,
+    paddingBlockEnd: 0,
+  },
+  scrollable: {
+    overflow: 'auto',
   },
   // For start panel: divider on end edge
   dividerEnd: {
@@ -77,6 +84,13 @@ const styles = stylex.create({
   collapseEnd: {
     marginInlineEnd: `calc(-1 * var(--layout-padding-inner-x, ${spacingTokens.space4}))`,
   },
+});
+
+// Dynamic styles for sizing props
+const dynamicStyles = stylex.create({
+  sizing: (width: number | string | null) => ({
+    width,
+  }),
 });
 
 export interface XDSLayoutPanelProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
@@ -101,6 +115,14 @@ export interface XDSLayoutPanelProps extends Omit<HTMLAttributes<HTMLElement>, '
   isFullBleed?: boolean;
 
   /**
+   * Enables scrollable overflow for the panel.
+   * Set to false for auto-height layouts where sticky positioning
+   * needs to work with parent containers.
+   * @default true
+   */
+  isScrollable?: boolean;
+
+  /**
    * Accessible label for the landmark.
    * Required when role is set and multiple landmarks of the same type exist.
    */
@@ -111,6 +133,12 @@ export interface XDSLayoutPanelProps extends Omit<HTMLAttributes<HTMLElement>, '
    * Use 'navigation' or 'complementary' only for top-level layouts (not nested).
    */
   role?: AriaRole;
+
+  /**
+   * Width of the panel.
+   * Numbers are treated as pixels, strings are used as-is.
+   */
+  width?: number | string;
 }
 
 /**
@@ -139,7 +167,7 @@ export interface XDSLayoutPanelProps extends Omit<HTMLAttributes<HTMLElement>, '
  */
 export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
   function XDSLayoutPanel(
-    { children, hasDivider = false, isFullBleed = false, label, role, ...props },
+    { children, hasDivider = false, isFullBleed = false, isScrollable = true, label, role, width, ...props },
     ref
   ) {
     const area = useContext(XDSLayoutAreaContext);
@@ -172,11 +200,13 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
         aria-label={label}
         {...stylex.props(
           styles.panel,
+          dynamicStyles.sizing(width ?? null),
           // Outer padding on container edges (unless component or layout is full bleed)
           isStartPanel && applyOuterPadding && styles.startPanel,
           isEndPanel && applyOuterPadding && styles.endPanel,
           !hasHeader && applyOuterPadding && styles.noHeader,
           !hasFooter && applyOuterPadding && styles.noFooter,
+          isScrollable && styles.scrollable,
           // Full bleed overrides
           isFullBleed && styles.fullBleed,
           hasDivider && dividerStyle,

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
@@ -1,0 +1,152 @@
+/**
+ * @file XDSLayoutPanel.tsx
+ * @input Uses React forwardRef, StyleX, XDSLayoutAreaContext
+ * @output Exports XDSLayoutPanel component and XDSLayoutPanelProps
+ * @position Layout content area component
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layout/XDSLayout/README.md
+ * - /apps/storybook/stories/Layout.stories.tsx
+ */
+
+import type { AriaRole, HTMLAttributes, ReactNode } from 'react';
+import { forwardRef, useContext } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import { colorTokens, spacingTokens } from '../../theme/tokens.stylex';
+import { XDSLayoutAreaContext } from './XDSLayoutAreaContext';
+
+const styles = stylex.create({
+  panel: {
+    boxSizing: 'border-box',
+    flexShrink: 0,
+    overflow: 'auto',
+    paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+    paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+  },
+  fullBleed: {
+    paddingInline: 0,
+    paddingBlock: 0,
+  },
+  // For start panel: divider on end edge
+  dividerEnd: {
+    borderInlineEndWidth: 1,
+    borderInlineEndStyle: 'solid',
+    borderInlineEndColor: colorTokens.divider,
+  },
+  // For end panel: divider on start edge
+  dividerStart: {
+    borderInlineStartWidth: 1,
+    borderInlineStartStyle: 'solid',
+    borderInlineStartColor: colorTokens.divider,
+  },
+  // When no divider, collapse spacing to avoid double-padding
+  collapseStart: {
+    marginInlineStart: `calc(-1 * var(--layout-padding-inner-x, ${spacingTokens.space4}))`,
+  },
+  collapseEnd: {
+    marginInlineEnd: `calc(-1 * var(--layout-padding-inner-x, ${spacingTokens.space4}))`,
+  },
+});
+
+export interface XDSLayoutPanelProps extends Omit<HTMLAttributes<HTMLElement>, 'style' | 'className'> {
+  /**
+   * Content to render inside the panel.
+   */
+  children?: ReactNode;
+
+  /**
+   * Adds a themed border on the appropriate edge.
+   * - Start panel: border on end edge (right in LTR)
+   * - End panel: border on start edge (left in LTR)
+   * When false, spacing collapse is applied automatically for seamless visual flow.
+   * @default false
+   */
+  hasDivider?: boolean;
+
+  /**
+   * Removes internal padding, allowing content to touch the edges.
+   * @default false
+   */
+  isFullBleed?: boolean;
+
+  /**
+   * Accessible label for the landmark.
+   * Required when role is set and multiple landmarks of the same type exist.
+   */
+  label?: string;
+
+  /**
+   * ARIA landmark role for accessibility.
+   * Use 'navigation' or 'complementary' only for top-level layouts (not nested).
+   */
+  role?: AriaRole;
+}
+
+/**
+ * Side panel content area for XDSLayout.
+ * Renders in the start or end slot with optional divider and padding control.
+ * Divider position is auto-detected based on which slot the panel is in.
+ *
+ * @example
+ * ```tsx
+ * <XDSLayoutContainer variant="card">
+ *   <XDSLayout
+ *     start={
+ *       <XDSLayoutPanel hasDivider role="navigation">
+ *         <Navigation />
+ *       </XDSLayoutPanel>
+ *     }
+ *     content={<XDSLayoutContent>Main content</XDSLayoutContent>}
+ *     end={
+ *       <XDSLayoutPanel hasDivider role="complementary">
+ *         <Sidebar />
+ *       </XDSLayoutPanel>
+ *     }
+ *   />
+ * </XDSLayoutContainer>
+ * ```
+ */
+export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
+  function XDSLayoutPanel(
+    { children, hasDivider = false, isFullBleed = false, label, role, ...props },
+    ref
+  ) {
+    const area = useContext(XDSLayoutAreaContext);
+
+    // Determine panel position
+    const isStartPanel = area === 'start';
+    const isEndPanel = area === 'end';
+
+    // When no divider, collapse spacing for seamless visual flow
+    const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+
+    // Select divider style based on position
+    const dividerStyle = isStartPanel ? styles.dividerEnd
+      : isEndPanel ? styles.dividerStart
+      : null;
+
+    // Select collapse style based on position
+    const collapseStyle = isStartPanel ? styles.collapseStart
+      : isEndPanel ? styles.collapseEnd
+      : null;
+
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        role={role}
+        aria-label={label}
+        {...stylex.props(
+          styles.panel,
+          isFullBleed && styles.fullBleed,
+          hasDivider && dividerStyle,
+          shouldCollapseSpacing && collapseStyle
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+XDSLayoutPanel.displayName = 'XDSLayoutPanel';

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutPanel.tsx
- * @input Uses React forwardRef, StyleX, XDSLayoutAreaContext
+ * @input Uses React forwardRef, StyleX, XDSLayoutAreaContext, XDSLayoutSlotsContext
  * @output Exports XDSLayoutPanel component and XDSLayoutPanelProps
  * @position Layout content area component
  *
@@ -14,14 +14,45 @@ import { forwardRef, useContext } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import { colorTokens, spacingTokens } from '../../theme/tokens.stylex';
 import { XDSLayoutAreaContext } from './XDSLayoutAreaContext';
+import { XDSLayoutSlotsContext } from './XDSLayoutSlotsContext';
 
 const styles = stylex.create({
   panel: {
     boxSizing: 'border-box',
     flexShrink: 0,
     overflow: 'auto',
+    // Default: inner padding on all sides (will be overridden by position-specific styles)
     paddingInline: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
     paddingBlock: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+  },
+  // Start panel: outer-x on left edge
+  startPanel: {
+    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+  },
+  // End panel: outer-x on right edge
+  endPanel: {
+    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingTokens.space4})`,
+  },
+  // When no header: outer-y on top
+  noHeader: {
+    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
+  },
+  // When no footer: outer-y on bottom
+  noFooter: {
+    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingTokens.space4})`,
+  },
+  // When layout is full bleed, use inner padding on outer edges
+  layoutFullBleedStart: {
+    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+  },
+  layoutFullBleedEnd: {
+    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingTokens.space4})`,
+  },
+  layoutFullBleedTop: {
+    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
+  },
+  layoutFullBleedBottom: {
+    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingTokens.space4})`,
   },
   fullBleed: {
     paddingInline: 0,
@@ -112,6 +143,7 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
     ref
   ) {
     const area = useContext(XDSLayoutAreaContext);
+    const { hasHeader, hasFooter, isFullBleed: isLayoutFullBleed } = useContext(XDSLayoutSlotsContext);
 
     // Determine panel position
     const isStartPanel = area === 'start';
@@ -137,6 +169,12 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
         aria-label={label}
         {...stylex.props(
           styles.panel,
+          // Outer padding on container edges (unless layout is full bleed)
+          isStartPanel && !isLayoutFullBleed && styles.startPanel,
+          isEndPanel && !isLayoutFullBleed && styles.endPanel,
+          !hasHeader && !isLayoutFullBleed && styles.noHeader,
+          !hasFooter && !isLayoutFullBleed && styles.noFooter,
+          // Full bleed overrides
           isFullBleed && styles.fullBleed,
           hasDivider && dividerStyle,
           shouldCollapseSpacing && collapseStyle

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutSlotsContext.ts
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutSlotsContext.ts
@@ -1,0 +1,49 @@
+/**
+ * @file XDSLayoutSlotsContext.ts
+ * @input Uses React createContext
+ * @output Exports XDSLayoutSlotsContext and LayoutSlots type
+ * @position Context for layout slot information
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layout/XDSLayout/README.md
+ * - /packages/core/src/Layout/XDSLayout/index.ts
+ */
+
+import { createContext } from 'react';
+
+/**
+ * Information about which layout slots are filled.
+ * Used by content area components to determine their edge positions
+ * and apply appropriate outer padding.
+ */
+export interface LayoutSlots {
+  /** Whether a header is rendered */
+  hasHeader: boolean;
+  /** Whether a footer is rendered */
+  hasFooter: boolean;
+  /** Whether a start panel is rendered */
+  hasStart: boolean;
+  /** Whether an end panel is rendered */
+  hasEnd: boolean;
+  /** Whether outer padding should be removed (full bleed mode) */
+  isFullBleed: boolean;
+}
+
+/**
+ * Default slot state - no slots filled, not full bleed.
+ */
+const defaultSlots: LayoutSlots = {
+  hasHeader: false,
+  hasFooter: false,
+  hasStart: false,
+  hasEnd: false,
+  isFullBleed: false,
+};
+
+/**
+ * Context for layout slot information.
+ * Content area components use this to:
+ * - Determine if they are at an edge (for outer padding)
+ * - Check if full bleed mode is enabled
+ */
+export const XDSLayoutSlotsContext = createContext<LayoutSlots>(defaultSlots);

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutSlotsContext.ts
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutSlotsContext.ts
@@ -25,25 +25,21 @@ export interface LayoutSlots {
   hasStart: boolean;
   /** Whether an end panel is rendered */
   hasEnd: boolean;
-  /** Whether outer padding should be removed (full bleed mode) */
-  isFullBleed: boolean;
 }
 
 /**
- * Default slot state - no slots filled, not full bleed.
+ * Default slot state - no slots filled.
  */
 const defaultSlots: LayoutSlots = {
   hasHeader: false,
   hasFooter: false,
   hasStart: false,
   hasEnd: false,
-  isFullBleed: false,
 };
 
 /**
  * Context for layout slot information.
- * Content area components use this to:
- * - Determine if they are at an edge (for outer padding)
- * - Check if full bleed mode is enabled
+ * Content area components use this to determine if they are at an edge
+ * (for applying outer padding).
  */
 export const XDSLayoutSlotsContext = createContext<LayoutSlots>(defaultSlots);

--- a/packages/core/src/Layout/XDSLayout/index.ts
+++ b/packages/core/src/Layout/XDSLayout/index.ts
@@ -1,0 +1,26 @@
+/**
+ * @file index.ts
+ * @input Imports layout components
+ * @output Exports XDSLayout system components and types
+ * @position Entry point for XDSLayout components
+ *
+ * SYNC: When modified, update /packages/core/src/Layout/XDSLayout/README.md
+ */
+
+export { XDSLayout } from './XDSLayout';
+export type { XDSLayoutProps, XDSLayoutHeight } from './XDSLayout';
+
+export { XDSLayoutHeader } from './XDSLayoutHeader';
+export type { XDSLayoutHeaderProps } from './XDSLayoutHeader';
+
+export { XDSLayoutFooter } from './XDSLayoutFooter';
+export type { XDSLayoutFooterProps } from './XDSLayoutFooter';
+
+export { XDSLayoutContent } from './XDSLayoutContent';
+export type { XDSLayoutContentProps } from './XDSLayoutContent';
+
+export { XDSLayoutPanel } from './XDSLayoutPanel';
+export type { XDSLayoutPanelProps } from './XDSLayoutPanel';
+
+export { XDSLayoutAreaContext } from './XDSLayoutAreaContext';
+export type { LayoutArea } from './XDSLayoutAreaContext';

--- a/packages/core/src/Layout/XDSLayout/index.ts
+++ b/packages/core/src/Layout/XDSLayout/index.ts
@@ -24,3 +24,6 @@ export type { XDSLayoutPanelProps } from './XDSLayoutPanel';
 
 export { XDSLayoutAreaContext } from './XDSLayoutAreaContext';
 export type { LayoutArea } from './XDSLayoutAreaContext';
+
+export { XDSLayoutSlotsContext } from './XDSLayoutSlotsContext';
+export type { LayoutSlots } from './XDSLayoutSlotsContext';

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -28,3 +28,36 @@ export type {
   XDSVStackProps,
   XDSStackItemProps,
 } from './Stack';
+
+// Container components
+export {
+  XDSLayoutContainer,
+  XDSCard,
+  XDSSection,
+} from './Container';
+export type {
+  XDSLayoutContainerProps,
+  SpacingToken,
+  XDSCardProps,
+  XDSSectionProps,
+  XDSSectionVariant,
+} from './Container';
+
+// Layout structure components
+export {
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutFooter,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+  XDSLayoutAreaContext,
+} from './XDSLayout';
+export type {
+  XDSLayoutProps,
+  XDSLayoutHeight,
+  XDSLayoutHeaderProps,
+  XDSLayoutFooterProps,
+  XDSLayoutContentProps,
+  XDSLayoutPanelProps,
+  LayoutArea,
+} from './XDSLayout';

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -7,23 +7,34 @@
  * SYNC: When modified, update /packages/core/src/Layout/README.md
  */
 
-// Stack utilities and components
+// Utilities
+export { container } from './Container/container.stylex';
+export type { ContainerOptions, SpacingToken } from './Container/container.stylex';
+
+export { stack } from './Stack/stack.stylex';
+export type {
+  StackOptions,
+  StackDirection,
+  StackCrossAlignment,
+  StackMainAlignment,
+  StackWrap,
+  SpacingScale,
+} from './Stack/stack.stylex';
+
+export { stackItem } from './Stack/stackItem.stylex';
+export type {
+  StackItemOptions,
+  StackItemCrossAlignSelf,
+  StackItemSize,
+} from './Stack/stackItem.stylex';
+
+// Stack components
 export {
-  stack,
-  stackItem,
   XDSHStack,
   XDSVStack,
   XDSStackItem,
 } from './Stack';
 export type {
-  StackOptions,
-  StackDirection,
-  StackCrossAlignment,
-  StackWrap,
-  SpacingScale,
-  StackItemOptions,
-  StackItemCrossAlignSelf,
-  StackItemSize,
   XDSHStackProps,
   XDSVStackProps,
   XDSStackItemProps,
@@ -31,14 +42,12 @@ export type {
 
 // Container components
 export {
-  XDSLayoutContainer,
   XDSCard,
   XDSSection,
 } from './Container';
 export type {
-  XDSLayoutContainerProps,
-  SpacingToken,
   XDSCardProps,
+  SizeValue,
   XDSSectionProps,
   XDSSectionVariant,
 } from './Container';

--- a/packages/core/src/theme/defaultTheme.stylex.ts
+++ b/packages/core/src/theme/defaultTheme.stylex.ts
@@ -146,13 +146,13 @@ const colorTheme = stylex.createTheme(colorTokens, {
 // =============================================================================
 
 const elevationTheme = stylex.createTheme(elevationTokens, {
-  base: 'light-dark(0px 0px 1px rgba(0, 0, 0, 0.1), 0px 0px 1px #111112)',
-  thumb: 'light-dark(0 1px 3px rgba(0, 0, 0, 0.2), 0 1px 3px rgba(0, 0, 0, 0.4))',
+  base: '0 0 1px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4))',
+  thumb: '0 1px 3px light-dark(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.4))',
   dialog:
-    'light-dark(0px 2px 2px rgba(0, 0, 0, 0.1) 0px 8px 24px rgba(0, 0, 0, 0.1), 0px 2px 2px rgba(0, 0, 0, 0.2) 0px 8px 24px rgba(0, 0, 0, 0.3))',
+    '0 2px 2px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0 8px 24px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.3))',
   hover:
-    'light-dark(0px 1px 2px rgba(0, 0, 0, 0.1) 0px 2px 12px rgba(0, 0, 0, 0.1), 0px 1px 2px rgba(0, 0, 0, 0.2) 0px 2px 12px rgba(0, 0, 0, 0.2))',
-  menu: 'light-dark(0px 1px 1px rgba(0, 0, 0, 0.1) 0px 2px 8px rgba(0, 0, 0, 0.1), 0px 1px 1px rgba(0, 0, 0, 0.2) 0px 2px 8px rgba(0, 0, 0, 0.2))',
+    '0 1px 2px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0 2px 12px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2))',
+  menu: '0 1px 1px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0 2px 8px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2))',
 });
 
 // =============================================================================

--- a/packages/core/src/theme/neutralTheme.stylex.ts
+++ b/packages/core/src/theme/neutralTheme.stylex.ts
@@ -166,14 +166,13 @@ const colorTheme = stylex.createTheme(colorTokens, {
 // =============================================================================
 
 const elevationTheme = stylex.createTheme(elevationTokens, {
-  base: 'light-dark(0 1px 2px oklch(0 0 0 / 5%), 0 1px 2px oklch(0 0 0 / 20%))',
-  thumb:
-    'light-dark(0 1px 3px oklch(0 0 0 / 10%), 0 1px 3px oklch(0 0 0 / 30%))',
+  base: '0 1px 2px light-dark(oklch(0 0 0 / 5%), oklch(0 0 0 / 20%))',
+  thumb: '0 1px 3px light-dark(oklch(0 0 0 / 10%), oklch(0 0 0 / 30%))',
   dialog:
-    'light-dark(0 4px 6px oklch(0 0 0 / 10%) 0 12px 24px oklch(0 0 0 / 15%), 0 4px 6px oklch(0 0 0 / 25%) 0 12px 24px oklch(0 0 0 / 35%))',
+    '0 4px 6px light-dark(oklch(0 0 0 / 10%), oklch(0 0 0 / 25%)), 0 12px 24px light-dark(oklch(0 0 0 / 15%), oklch(0 0 0 / 35%))',
   hover:
-    'light-dark(0 2px 4px oklch(0 0 0 / 5%) 0 4px 12px oklch(0 0 0 / 10%), 0 2px 4px oklch(0 0 0 / 15%) 0 4px 12px oklch(0 0 0 / 20%))',
-  menu: 'light-dark(0 2px 4px oklch(0 0 0 / 5%) 0 4px 8px oklch(0 0 0 / 10%), 0 2px 4px oklch(0 0 0 / 15%) 0 4px 8px oklch(0 0 0 / 20%))',
+    '0 2px 4px light-dark(oklch(0 0 0 / 5%), oklch(0 0 0 / 15%)), 0 4px 12px light-dark(oklch(0 0 0 / 10%), oklch(0 0 0 / 20%))',
+  menu: '0 2px 4px light-dark(oklch(0 0 0 / 5%), oklch(0 0 0 / 15%)), 0 4px 8px light-dark(oklch(0 0 0 / 10%), oklch(0 0 0 / 20%))',
 });
 
 // =============================================================================
@@ -242,6 +241,38 @@ const buttonVariants = stylex.create({
   },
 });
 
+const cardStyles = stylex.create({
+  // Override card default padding to 12px for tighter layout
+  base: {
+    '--layout-padding-inner-x': spacingTokens.space3,
+    '--layout-padding-inner-y': spacingTokens.space3,
+    '--layout-padding-outer-x': spacingTokens.space3,
+    '--layout-padding-outer-y': spacingTokens.space3,
+  },
+});
+
+const sectionVariants = stylex.create({
+  // Override section padding to 12px for tighter layout
+  section: {
+    '--layout-padding-inner-x': spacingTokens.space3,
+    '--layout-padding-inner-y': spacingTokens.space3,
+    '--layout-padding-outer-x': spacingTokens.space3,
+    '--layout-padding-outer-y': spacingTokens.space3,
+  },
+  transparent: {
+    '--layout-padding-inner-x': spacingTokens.space3,
+    '--layout-padding-inner-y': spacingTokens.space3,
+    '--layout-padding-outer-x': spacingTokens.space3,
+    '--layout-padding-outer-y': spacingTokens.space3,
+  },
+  wash: {
+    '--layout-padding-inner-x': spacingTokens.space3,
+    '--layout-padding-inner-y': spacingTokens.space3,
+    '--layout-padding-outer-x': spacingTokens.space3,
+    '--layout-padding-outer-y': spacingTokens.space3,
+  },
+});
+
 // =============================================================================
 // Theme Export
 // =============================================================================
@@ -257,6 +288,12 @@ export const neutralTheme: Theme = {
   components: {
     button: {
       variants: buttonVariants,
+    },
+    card: {
+      base: cardStyles.base,
+    },
+    section: {
+      variants: sectionVariants,
     },
   },
 };


### PR DESCRIPTION
Implements the layout system. Included are a few new containers to demonstrate.

I tried to eliminate xstyle so the only xstyle-able component here is the XDSLayoutContainer. I think arguably these xstyle components might not need to exist and we can just repeat some of this code for building basically flexboxes so I'm curious if people have thoughts on this.

I noticed that a lot of containers visually adjust the height to be slightly smaller so we separate x and y padding considerations on the outer padding.


<img width="1031" height="955" alt="Screenshot 2026-01-14 at 6 47 49 PM" src="https://github.com/user-attachments/assets/bff0b0d0-ad3e-4b31-bccb-3ca12cc5144e" />
<img width="1049" height="639" alt="Screenshot 2026-01-14 at 6 47 54 PM" src="https://github.com/user-attachments/assets/299b3ced-7f09-48ec-a66f-7957532a121c" />
<img width="1052" height="641" alt="Screenshot 2026-01-14 at 6 47 57 PM" src="https://github.com/user-attachments/assets/68a10ba4-e8f4-4e5e-86d8-0ed70b2a78b7" />
<img width="1046" height="755" alt="Screenshot 2026-01-14 at 6 48 02 PM" src="https://github.com/user-attachments/assets/83304513-76e7-483f-98bc-1a97c7824251" />
<img width="1048" height="640" alt="Screenshot 2026-01-14 at 6 48 06 PM" src="https://github.com/user-attachments/assets/4c8c4bc9-860a-4452-8893-9181c9e8909b" />
<img width="1063" height="656" alt="Screenshot 2026-01-14 at 6 48 09 PM" src="https://github.com/user-attachments/assets/c0d6624b-919d-4c8d-b721-78c924f14d91" />
<img width="1067" height="454" alt="Screenshot 2026-01-14 at 6 48 13 PM" src="https://github.com/user-attachments/assets/1c8ef8d0-4f20-473c-9847-731f985d13f9" />
<img width="1060" height="653" alt="Screenshot 2026-01-14 at 6 48 17 PM" src="https://github.com/user-attachments/assets/c7b5491e-5ef5-4790-b33c-cd8158851623" />
<img width="1063" height="545" alt="Screenshot 2026-01-14 at 6 48 23 PM" src="https://github.com/user-attachments/assets/fd53d591-8d77-44ef-b31a-01199cadc5b8" />
<img width="1076" height="531" alt="Screenshot 2026-01-14 at 7 43 01 PM" src="https://github.com/user-attachments/assets/304834e4-7bfe-44d3-8368-824b3b34c9c9" />
