### PR TITLE
Add XDSTextInput component

### DIFF
--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { XDSTextInput } from '@xds/core/TextInput';
+
+const meta: Meta<typeof XDSTextInput> = {
+  title: 'Core/XDSTextInput',
+  component: XDSTextInput,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Label text (required)',
+    },
+    isLabelHidden: {
+      control: 'boolean',
+      description: 'Visually hide the label (still accessible to screen readers)',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'Placeholder text',
+    },
+    value: {
+      control: 'text',
+      description: 'Current input value (required)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSTextInput>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Name',
+    placeholder: 'Enter your name',
+  },
+};
+
+export const WithHiddenLabel: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Search',
+    isLabelHidden: true,
+    placeholder: 'Search...',
+  },
+};
+
+export const WithValue: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value ?? 'Hello, world!');
+    return <XDSTextInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Greeting',
+    value: 'Hello, world!',
+  },
+};
+
+export const AllVariations: Story = {
+  render: () => {
+    const [value1, setValue1] = useState('');
+    const [value2, setValue2] = useState('');
+    const [value3, setValue3] = useState('Pre-filled value');
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: '16px', maxWidth: '300px' }}>
+        <XDSTextInput label="Visible label" value={value1} onChange={setValue1} placeholder="Enter text..." />
+        <XDSTextInput label="Hidden label" isLabelHidden value={value2} onChange={setValue2} placeholder="Hidden label input" />
+        <XDSTextInput label="With value" value={value3} onChange={setValue3} />
+      </div>
+    );
+  },
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,11 @@
       "types": "./dist/Layout/index.d.ts",
       "import": "./dist/Layout/index.mjs",
       "require": "./dist/Layout/index.js"
+    },
+    "./TextInput": {
+      "types": "./dist/TextInput/index.d.ts",
+      "import": "./dist/TextInput/index.mjs",
+      "require": "./dist/TextInput/index.js"
     }
   },
   "scripts": {

--- a/packages/core/src/TextInput/README.md
+++ b/packages/core/src/TextInput/README.md
@@ -1,0 +1,50 @@
+# /packages/core/src/TextInput
+
+A text input component for collecting user text input.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Label Support**: Required label for accessibility (can be visually hidden)
+- **Accessible**: Label properly associated with input via htmlFor/id
+- **Styled with StyleX**: Uses XDS design tokens for consistent styling
+
+## Usage
+
+```tsx
+import { XDSTextInput } from '@xds/core/TextInput';
+
+// Basic input with label
+<XDSTextInput label="Name" value={name} onChange={setName} />
+
+// With placeholder
+<XDSTextInput label="Email" value={email} onChange={setEmail} placeholder="email@example.com" />
+
+// Hidden label (for screen readers only)
+<XDSTextInput label="Search" isLabelHidden value={query} onChange={setQuery} placeholder="Search..." />
+```
+
+## Props
+
+| Prop | Type | Required | Description |
+|------|------|----------|-------------|
+| `label` | `string` | Yes | Label text for the input (always rendered for accessibility) |
+| `value` | `string` | Yes | Current value of the input |
+| `onChange` | `(value: string, e: ChangeEvent<HTMLInputElement>) => void` | Yes | Callback fired when input value changes |
+| `isLabelHidden` | `boolean` | No | Visually hide the label (still accessible to screen readers) |
+| `placeholder` | `string` | No | Placeholder text |
+
+## Files
+
+| File | Role | Purpose |
+|------|------|---------|
+| `index.ts` | Entry | Exports component and types |
+| `XDSTextInput.tsx` | Core | Component implementation |
+| `XDSTextInput.test.tsx` | Test | Unit tests |
+
+## Implementation Notes
+
+- Uses `useId` hook for accessible label-input association
+- Label is always rendered for accessibility; use `isLabelHidden` to hide visually
+- Hidden label uses CSS technique that remains accessible to screen readers

--- a/packages/core/src/TextInput/XDSTextInput.test.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * @file XDSTextInput.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSTextInput component
+ * @output Unit tests for XDSTextInput component behavior
+ * @position Testing; validates XDSTextInput.tsx implementation
+ *
+ * SYNC: When XDSTextInput.tsx changes, update tests to match new behavior
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { XDSTextInput } from './XDSTextInput';
+
+describe('XDSTextInput', () => {
+  it('renders with label', () => {
+    render(<XDSTextInput label="Name" value="" onChange={() => {}} />);
+    expect(screen.getByLabelText('Name')).toBeInTheDocument();
+  });
+
+  it('renders with placeholder', () => {
+    render(<XDSTextInput label="Name" value="" onChange={() => {}} placeholder="Enter text" />);
+    expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument();
+  });
+
+  it('calls onChange with value and event when typing', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<XDSTextInput label="Name" value="" onChange={handleChange} />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'Hi');
+    expect(handleChange).toHaveBeenCalledTimes(2);
+    expect(handleChange).toHaveBeenLastCalledWith('i', expect.any(Object));
+  });
+
+  it('works with state setter function directly', async () => {
+    const user = userEvent.setup();
+    const setValue = vi.fn();
+    render(<XDSTextInput label="Name" value="" onChange={setValue} />);
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'A');
+    expect(setValue).toHaveBeenCalledWith('A', expect.any(Object));
+  });
+
+  it('displays controlled value', () => {
+    render(<XDSTextInput label="Name" value="Controlled value" onChange={() => {}} />);
+    expect(screen.getByRole('textbox')).toHaveValue('Controlled value');
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(<XDSTextInput ref={ref} label="Name" value="" onChange={() => {}} />);
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));
+  });
+
+  it('visually hides label when isLabelHidden is true', () => {
+    render(<XDSTextInput label="Search" isLabelHidden value="" onChange={() => {}} />);
+    const label = screen.getByText('Search');
+    expect(label).toBeInTheDocument();
+    // Label should still be accessible
+    expect(screen.getByLabelText('Search')).toBeInTheDocument();
+  });
+
+  it('shows label visually by default', () => {
+    render(<XDSTextInput label="Email" value="" onChange={() => {}} />);
+    const label = screen.getByText('Email');
+    expect(label).toBeVisible();
+  });
+});

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -1,0 +1,143 @@
+/**
+ * @file XDSTextInput.tsx
+ * @input Uses React forwardRef, ChangeEvent
+ * @output Exports XDSTextInput component, XDSTextInputProps
+ * @position Core implementation; consumed by index.ts, tested by XDSTextInput.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/TextInput/README.md (props table, features, implementation notes)
+ * - /packages/core/src/TextInput/XDSTextInput.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/TextInput/index.ts (exports if types change)
+ * - /apps/storybook/stories/TextInput.stories.tsx (storybook stories)
+ */
+
+import { forwardRef, useId, type ChangeEvent } from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  color,
+  spacing,
+  radius,
+  transition,
+  typography,
+} from '../theme/tokens.stylex';
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacing.space1,
+  },
+  label: {
+    fontFamily: typography.fontFamilyBody,
+    fontSize: '0.875rem',
+    fontWeight: 500,
+    color: color.textPrimary,
+  },
+  labelHidden: {
+    borderStyle: 'none',
+    clip: 'rect(0, 0, 0, 0)',
+    height: 1,
+    left: 0,
+    margin: -1,
+    overflow: 'hidden',
+    padding: 0,
+    pointerEvents: 'none',
+    position: 'absolute',
+    top: 0,
+    userSelect: 'none',
+    whiteSpace: 'nowrap',
+    width: 1,
+  },
+  input: {
+    display: 'block',
+    width: '100%',
+    paddingBlock: spacing.space2,
+    paddingInline: spacing.space3,
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: {
+      default: color.dividerEmphasized,
+      ':hover': color.dividerHighContrast,
+    },
+    borderRadius: radius.content,
+    fontFamily: typography.fontFamilyBody,
+    fontSize: '0.875rem',
+    lineHeight: 1.429,
+    color: color.textPrimary,
+    backgroundColor: color.surface,
+    transitionProperty: 'border-color, outline',
+    transitionDuration: transition.fast,
+    outline: {
+      default: 'none',
+      ':focus': `2px solid ${color.focusOutline}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus': '1px',
+    },
+    '::placeholder': {
+      color: color.textPlaceholder,
+    },
+  },
+});
+
+export interface XDSTextInputProps {
+  /**
+   * Label text for the input (always rendered for accessibility).
+   */
+  label: string;
+  /**
+   * Whether to visually hide the label (still accessible to screen readers).
+   * @default false
+   */
+  isLabelHidden?: boolean;
+  /**
+   * Callback fired when the input value changes.
+   */
+  onChange: (value: string, e: ChangeEvent<HTMLInputElement>) => void;
+  /**
+   * The current value of the input.
+   */
+  value: string;
+  /**
+   * Placeholder text shown when the input is empty.
+   */
+  placeholder?: string;
+}
+
+/**
+ * A text input component for collecting user input.
+ *
+ * @example
+ * ```tsx
+ * <XDSTextInput label="Name" value={name} onChange={setName} />
+ * <XDSTextInput label="Search" isLabelHidden value={query} onChange={setQuery} />
+ * ```
+ */
+export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
+  ({ label, isLabelHidden = false, onChange, value, placeholder }, ref) => {
+    const id = useId();
+
+    return (
+      <div {...stylex.props(styles.container)}>
+        <label
+          htmlFor={id}
+          {...stylex.props(styles.label, isLabelHidden && styles.labelHidden)}
+        >
+          {label}
+        </label>
+        <input
+          ref={ref}
+          id={id}
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value, e)}
+          placeholder={placeholder}
+          {...stylex.props(styles.input)}
+        />
+      </div>
+    );
+  }
+);
+
+XDSTextInput.displayName = 'XDSTextInput';

--- a/packages/core/src/TextInput/index.ts
+++ b/packages/core/src/TextInput/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input Imports XDSTextInput component and types from TextInput.tsx
+ * @output Exports XDSTextInput, XDSTextInputProps, XDSTextInputVariant
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/TextInput/README.md
+ */
+
+export { XDSTextInput } from './XDSTextInput';
+export type { XDSTextInputProps } from './XDSTextInput';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@
 
 // Components
 export * from './Button';
+export * from './TextInput';
 
 // Layout utilities and components (includes XDSHStack, XDSVStack)
 export * from './Layout';

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -11,7 +11,7 @@ import { defineConfig } from 'tsup';
 import babel from 'esbuild-plugin-babel';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/Button/index.ts', 'src/Layout/index.ts'],
+  entry: ['src/index.ts', 'src/Button/index.ts', 'src/Layout/index.ts', 'src/TextInput/index.ts'],
   format: ['cjs', 'esm'],
   dts: true,
   splitting: true,


### PR DESCRIPTION
Added basic text input component. Modeled after the existing XDSTextInput, but this is just a simple version for now.

Currently only has the following props:
- label (required): Label text, always rendered for accessibility
- value (required): Current input value
- onChange (required): Callback with (value, event) signature for easy state setter usage
- isLabelHidden: Visually hide label while keeping it accessible to screen readers
- placeholder: Placeholder text

<img width="1046" height="895" alt="image" src="https://github.com/user-attachments/assets/4acf8741-08e3-45b7-a79e-bf99d17677b4" />
