### PR TITLE
feat: rework base theming architecture

### DIFF
--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -1,47 +1,55 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
-import { XDSAvatar } from '@xds/core/Avatar';
-import { color, spacing, typography } from '@xds/core/theme/tokens.stylex';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {
+  colorVars,
+  spacingVars,
+  typographyVars,
+} from '@xds/core/theme/tokens.stylex';
 
 const styles = stylex.create({
   storyWrapper: {
     display: 'flex',
     flexDirection: 'column',
-    gap: spacing.space6,
+    gap: spacingVars['--spacing-6'],
   },
   row: {
     display: 'flex',
     alignItems: 'center',
-    gap: spacing.space4,
+    gap: spacingVars['--spacing-4'],
   },
   heading: {
-    margin: `0 0 ${spacing.space2} 0`,
-    fontFamily: typography.fontFamilyBody,
+    margin: `0 0 ${spacingVars['--spacing-2']} 0`,
+    fontFamily: typographyVars['--font-body'],
   },
   statusDot: {
     width: 10,
     height: 10,
     borderRadius: '50%',
-    backgroundColor: color.positive,
+    backgroundColor: colorVars['--color-positive'],
     borderWidth: 2,
     borderStyle: 'solid',
-    borderColor: color.surface,
+    borderColor: colorVars['--color-surface'],
   },
   statusDotOffline: {
-    backgroundColor: color.textSecondary,
+    backgroundColor: colorVars['--color-text-secondary'],
   },
   statusDotBusy: {
-    backgroundColor: color.negative,
+    backgroundColor: colorVars['--color-negative'],
   },
 });
 
 // Simple status indicator component for demos
-const StatusDot = ({ status = 'online' }: { status?: 'online' | 'offline' | 'busy' }) => (
+const StatusDot = ({
+  status = 'online',
+}: {
+  status?: 'online' | 'offline' | 'busy';
+}) => (
   <div
     {...stylex.props(
       styles.statusDot,
       status === 'offline' && styles.statusDotOffline,
-      status === 'busy' && styles.statusDotBusy
+      status === 'busy' && styles.statusDotBusy,
     )}
   />
 );
@@ -53,7 +61,27 @@ const meta: Meta<typeof XDSAvatar> = {
   argTypes: {
     size: {
       control: 'select',
-      options: ['tiny', 'xsmall', 'small', 'medium', 'large', 16, 20, 24, 32, 36, 40, 48, 60, 64, 72, 96, 128, 144, 180],
+      options: [
+        'tiny',
+        'xsmall',
+        'small',
+        'medium',
+        'large',
+        16,
+        20,
+        24,
+        32,
+        36,
+        40,
+        48,
+        60,
+        64,
+        72,
+        96,
+        128,
+        144,
+        180,
+      ],
       description: 'Size of the avatar',
     },
     src: {
@@ -121,11 +149,31 @@ export const WithImages: Story = {
     <div {...stylex.props(styles.storyWrapper)}>
       <h4 {...stylex.props(styles.heading)}>With Images (Different Sizes)</h4>
       <div {...stylex.props(styles.row)}>
-        <XDSAvatar src="https://i.pravatar.cc/150?img=1" name="User 1" size="tiny" />
-        <XDSAvatar src="https://i.pravatar.cc/150?img=2" name="User 2" size="xsmall" />
-        <XDSAvatar src="https://i.pravatar.cc/150?img=3" name="User 3" size="small" />
-        <XDSAvatar src="https://i.pravatar.cc/150?img=4" name="User 4" size="medium" />
-        <XDSAvatar src="https://i.pravatar.cc/150?img=5" name="User 5" size="large" />
+        <XDSAvatar
+          src="https://i.pravatar.cc/150?img=1"
+          name="User 1"
+          size="tiny"
+        />
+        <XDSAvatar
+          src="https://i.pravatar.cc/150?img=2"
+          name="User 2"
+          size="xsmall"
+        />
+        <XDSAvatar
+          src="https://i.pravatar.cc/150?img=3"
+          name="User 3"
+          size="small"
+        />
+        <XDSAvatar
+          src="https://i.pravatar.cc/150?img=4"
+          name="User 4"
+          size="medium"
+        />
+        <XDSAvatar
+          src="https://i.pravatar.cc/150?img=5"
+          name="User 5"
+          size="large"
+        />
       </div>
     </div>
   ),
@@ -167,10 +215,16 @@ export const FallbackChain: Story = {
       <div {...stylex.props(styles.row)}>
         <div>
           <p {...stylex.props(styles.heading)}>Valid src</p>
-          <XDSAvatar src="https://i.pravatar.cc/150?img=10" name="Test User" size="large" />
+          <XDSAvatar
+            src="https://i.pravatar.cc/150?img=10"
+            name="Test User"
+            size="large"
+          />
         </div>
         <div>
-          <p {...stylex.props(styles.heading)}>Invalid src, valid fallbackSrc</p>
+          <p {...stylex.props(styles.heading)}>
+            Invalid src, valid fallbackSrc
+          </p>
           <XDSAvatar
             src="https://invalid-url.example/broken.jpg"
             fallbackSrc="https://i.pravatar.cc/150?img=11"

--- a/apps/storybook/stories/HStack.stories.tsx
+++ b/apps/storybook/stories/HStack.stories.tsx
@@ -1,27 +1,32 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
-import { XDSHStack } from '@xds/core/Layout';
-import { color, spacing, radius, typography } from '@xds/core/theme/tokens.stylex';
+import {XDSHStack} from '@xds/core/Layout';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  typographyVars,
+} from '@xds/core/theme/tokens.stylex';
 
 const styles = stylex.create({
   box: {
-    backgroundColor: color.blueBackground,
-    color: color.blueText,
+    backgroundColor: colorVars['--color-blue-background'],
+    color: colorVars['--color-blue-text'],
     borderWidth: 1,
     borderStyle: 'solid',
-    borderColor: color.blueBorder,
-    paddingBlock: spacing.space4,
-    paddingInline: spacing.space6,
-    borderRadius: radius.element,
+    borderColor: colorVars['--color-blue-border'],
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-6'],
+    borderRadius: radiusVars['--radius-element'],
     fontWeight: 500,
   },
   boxAlt: {
-    backgroundColor: color.grayBackground,
-    color: color.grayText,
-    borderColor: color.grayBorder,
+    backgroundColor: colorVars['--color-gray-background'],
+    color: colorVars['--color-gray-text'],
+    borderColor: colorVars['--color-gray-border'],
   },
   container: {
-    backgroundColor: color.wash,
+    backgroundColor: colorVars['--color-wash'],
   },
   containerHeight: {
     height: 120,
@@ -33,23 +38,27 @@ const styles = stylex.create({
     width: 300,
   },
   containerPadding: {
-    padding: spacing.space2,
+    padding: spacingVars['--spacing-2'],
   },
   storyWrapper: {
     display: 'flex',
     flexDirection: 'column',
-    gap: spacing.space6,
+    gap: spacingVars['--spacing-6'],
   },
   heading: {
-    margin: `0 0 ${spacing.space2} 0`,
-    fontFamily: typography.fontFamilyBody,
+    margin: `0 0 ${spacingVars['--spacing-2']} 0`,
+    fontFamily: typographyVars['--font-body'],
   },
 });
 
 // Demo box component for visibility
-const Box = ({ children, alt = false }: { children: React.ReactNode; alt?: boolean }) => (
-  <div {...stylex.props(styles.box, alt && styles.boxAlt)}>{children}</div>
-);
+const Box = ({
+  children,
+  alt = false,
+}: {
+  children: React.ReactNode;
+  alt?: boolean;
+}) => <div {...stylex.props(styles.box, alt && styles.boxAlt)}>{children}</div>;
 
 const meta: Meta<typeof XDSHStack> = {
   title: 'Layout/XDSHStack',
@@ -58,7 +67,17 @@ const meta: Meta<typeof XDSHStack> = {
   argTypes: {
     gap: {
       control: 'select',
-      options: ['space0', 'space0.5', 'space1', 'space2', 'space3', 'space4', 'space5', 'space6', 'space7'],
+      options: [
+        'space0',
+        'space0.5',
+        'space1',
+        'space2',
+        'space3',
+        'space4',
+        'space5',
+        'space6',
+        'space7',
+      ],
       description: 'Spacing token for gap between items',
     },
     vAlign: {
@@ -82,7 +101,7 @@ export const Default: Story = {
     gap: 'space2',
     children: null,
   },
-  render: (args) => (
+  render: args => (
     <XDSHStack {...args}>
       <Box>Item 1</Box>
       <Box>Item 2</Box>
@@ -95,7 +114,7 @@ export const WithGap: Story = {
   args: {
     gap: 'space4',
   },
-  render: (args) => (
+  render: args => (
     <XDSHStack {...args}>
       <Box>Item 1</Box>
       <Box>Item 2</Box>
@@ -109,7 +128,7 @@ export const VerticalAlignCenter: Story = {
     gap: 'space4',
     vAlign: 'center',
   },
-  render: (args) => (
+  render: args => (
     <XDSHStack {...args} xstyle={[styles.container, styles.containerHeight]}>
       <Box>Short</Box>
       <Box>
@@ -127,7 +146,7 @@ export const VerticalAlignStart: Story = {
     gap: 'space4',
     vAlign: 'start',
   },
-  render: (args) => (
+  render: args => (
     <XDSHStack {...args} xstyle={[styles.container, styles.containerHeight]}>
       <Box>Short</Box>
       <Box>
@@ -145,7 +164,7 @@ export const VerticalAlignEnd: Story = {
     gap: 'space4',
     vAlign: 'end',
   },
-  render: (args) => (
+  render: args => (
     <XDSHStack {...args} xstyle={[styles.container, styles.containerHeight]}>
       <Box>Short</Box>
       <Box>
@@ -163,8 +182,14 @@ export const Wrapping: Story = {
     gap: 'space2',
     wrap: 'wrap',
   },
-  render: (args) => (
-    <XDSHStack {...args} xstyle={[styles.container, styles.containerWidth, styles.containerPadding]}>
+  render: args => (
+    <XDSHStack
+      {...args}
+      xstyle={[
+        styles.container,
+        styles.containerWidth,
+        styles.containerPadding,
+      ]}>
       <Box>Item 1</Box>
       <Box>Item 2</Box>
       <Box>Item 3</Box>
@@ -179,7 +204,10 @@ export const AllAlignments: Story = {
     <div {...stylex.props(styles.storyWrapper)}>
       <div>
         <h4 {...stylex.props(styles.heading)}>vAlign: start</h4>
-        <XDSHStack gap="space2" vAlign="start" xstyle={[styles.container, styles.containerHeightSmall]}>
+        <XDSHStack
+          gap="space2"
+          vAlign="start"
+          xstyle={[styles.container, styles.containerHeightSmall]}>
           <Box>A</Box>
           <Box>
             B<br />B
@@ -189,7 +217,10 @@ export const AllAlignments: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>vAlign: center</h4>
-        <XDSHStack gap="space2" vAlign="center" xstyle={[styles.container, styles.containerHeightSmall]}>
+        <XDSHStack
+          gap="space2"
+          vAlign="center"
+          xstyle={[styles.container, styles.containerHeightSmall]}>
           <Box>A</Box>
           <Box>
             B<br />B
@@ -199,7 +230,10 @@ export const AllAlignments: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>vAlign: end</h4>
-        <XDSHStack gap="space2" vAlign="end" xstyle={[styles.container, styles.containerHeightSmall]}>
+        <XDSHStack
+          gap="space2"
+          vAlign="end"
+          xstyle={[styles.container, styles.containerHeightSmall]}>
           <Box>A</Box>
           <Box>
             B<br />B
@@ -209,7 +243,10 @@ export const AllAlignments: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>vAlign: stretch (default)</h4>
-        <XDSHStack gap="space2" vAlign="stretch" xstyle={[styles.container, styles.containerHeightSmall]}>
+        <XDSHStack
+          gap="space2"
+          vAlign="stretch"
+          xstyle={[styles.container, styles.containerHeightSmall]}>
           <Box>A</Box>
           <Box>
             B<br />B

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
 import {
   XDSLayout,
@@ -12,95 +12,101 @@ import {
   XDSHStack,
   XDSVStack,
 } from '@xds/core/Layout';
-import { XDSButton } from '@xds/core/Button';
-import { color, spacing, typography, radius, elevation } from '@xds/core/theme/tokens.stylex';
-import { Theme, neutralTheme, defaultTheme } from '@xds/core';
+import {XDSButton} from '@xds/core/Button';
+import {
+  colorVars,
+  spacingVars,
+  typographyVars,
+  radiusVars,
+  elevationVars,
+} from '@xds/core/theme/tokens.stylex';
+import {Theme, neutralTheme, defaultTheme} from '@xds/core';
 
 const styles = stylex.create({
   // Story wrapper styles
   pageWrapper: {
     height: 500,
-    backgroundColor: color.wash,
-    padding: spacing.space4,
+    backgroundColor: colorVars['--color-wash'],
+    padding: spacingVars['--spacing-4'],
   },
   pageWrapperTall: {
     height: 600,
   },
   storySection: {
-    padding: spacing.space4,
-    backgroundColor: color.wash,
+    padding: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-wash'],
   },
   // Typography
   heading: {
     margin: 0,
-    fontFamily: typography.fontFamilyBody,
+    fontFamily: typographyVars['--font-body'],
     fontSize: 18,
     fontWeight: 600,
-    color: color.textPrimary,
+    color: colorVars['--color-text-primary'],
   },
   subheading: {
     margin: 0,
-    fontFamily: typography.fontFamilyBody,
+    fontFamily: typographyVars['--font-body'],
     fontSize: 14,
     fontWeight: 500,
-    color: color.textSecondary,
+    color: colorVars['--color-text-secondary'],
   },
   bodyText: {
     margin: 0,
-    fontFamily: typography.fontFamilyBody,
+    fontFamily: typographyVars['--font-body'],
     fontSize: 14,
     lineHeight: 1.5,
-    color: color.textSecondary,
+    color: colorVars['--color-text-secondary'],
   },
   // Panel content
   navItem: {
-    padding: `${spacing.space2} ${spacing.space3}`,
+    padding: `${spacingVars['--spacing-2']} ${spacingVars['--spacing-3']}`,
     borderRadius: 6,
     cursor: 'pointer',
-    color: color.textPrimary,
-    fontFamily: typography.fontFamilyBody,
+    color: colorVars['--color-text-primary'],
+    fontFamily: typographyVars['--font-body'],
     fontSize: 14,
     backgroundColor: {
       default: 'transparent',
-      ':hover': color.hoverOverlay,
+      ':hover': colorVars['--color-hover-overlay'],
     },
   },
   navItemActive: {
-    backgroundColor: color.accentDeemphasized,
-    color: color.accentText,
+    backgroundColor: colorVars['--color-accent-deemphasized'],
+    color: colorVars['--color-accent-text'],
   },
   // Content placeholder
   placeholder: {
-    backgroundColor: color.grayBackground,
+    backgroundColor: colorVars['--color-gray-background'],
     borderRadius: 8,
-    padding: spacing.space4,
-    color: color.textSecondary,
-    fontFamily: typography.fontFamilyBody,
+    padding: spacingVars['--spacing-4'],
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-body'],
     fontSize: 14,
   },
   // Full bleed placeholder (no radius, no padding)
   placeholderFullBleed: {
-    backgroundColor: color.grayBackground,
-    padding: spacing.space4,
-    color: color.textSecondary,
-    fontFamily: typography.fontFamilyBody,
+    backgroundColor: colorVars['--color-gray-background'],
+    padding: spacingVars['--spacing-4'],
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-body'],
     fontSize: 14,
     minHeight: 100,
   },
   sectionLabel: {
-    margin: `0 0 ${spacing.space2} 0`,
-    fontFamily: typography.fontFamilyBody,
+    margin: `0 0 ${spacingVars['--spacing-2']} 0`,
+    fontFamily: typographyVars['--font-body'],
     fontSize: 12,
     fontWeight: 600,
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
-    color: color.textSecondary,
+    color: colorVars['--color-text-secondary'],
   },
   // Demo container styling to visualize bounds
   demoContainer: {
-    backgroundColor: color.card,
-    borderRadius: radius.container,
-    boxShadow: elevation.base,
+    backgroundColor: colorVars['--color-card'],
+    borderRadius: radiusVars['--radius-container'],
+    boxShadow: elevationVars['--elevation-base'],
   },
   // Demo sizing for outer padding story
   demoSize: {
@@ -110,8 +116,16 @@ const styles = stylex.create({
 });
 
 // Helper components for demo content
-const NavItem = ({ active, children }: { active?: boolean; children: React.ReactNode }) => (
-  <div {...stylex.props(styles.navItem, active && styles.navItemActive)}>{children}</div>
+const NavItem = ({
+  active,
+  children,
+}: {
+  active?: boolean;
+  children: React.ReactNode;
+}) => (
+  <div {...stylex.props(styles.navItem, active && styles.navItemActive)}>
+    {children}
+  </div>
 );
 
 const meta: Meta<typeof XDSLayout> = {
@@ -141,13 +155,13 @@ The XDS Layout System provides a structured way to build page and component layo
   },
   // Hide auto-generated controls from XDSLayout component
   argTypes: {
-    content: { table: { disable: true } },
-    end: { table: { disable: true } },
-    footer: { table: { disable: true } },
-    header: { table: { disable: true } },
-    height: { table: { disable: true } },
-    isFullBleed: { table: { disable: true } },
-    start: { table: { disable: true } },
+    content: {table: {disable: true}},
+    end: {table: {disable: true}},
+    footer: {table: {disable: true}},
+    header: {table: {disable: true}},
+    height: {table: {disable: true}},
+    isFullBleed: {table: {disable: true}},
+    start: {table: {disable: true}},
   },
 };
 
@@ -220,105 +234,105 @@ export const Playground = {
   argTypes: {
     // Card controls
     cardWidth: {
-      control: { type: 'range', min: 300, max: 1000, step: 50 },
+      control: {type: 'range', min: 300, max: 1000, step: 50},
       description: 'Width of the card container',
-      table: { category: 'Card' },
+      table: {category: 'Card'},
     },
     cardHeight: {
-      control: { type: 'range', min: 200, max: 600, step: 50 },
+      control: {type: 'range', min: 200, max: 600, step: 50},
       description: 'Height of the card container',
-      table: { category: 'Card' },
+      table: {category: 'Card'},
     },
     // Layout controls
     layoutIsFullBleed: {
       control: 'boolean',
       description: 'Remove padding at layout outer edges (affects all slots)',
-      table: { category: 'Layout' },
+      table: {category: 'Layout'},
     },
     // Header controls
     showHeader: {
       control: 'boolean',
       description: 'Show or hide the header',
-      table: { category: 'Header' },
+      table: {category: 'Header'},
     },
     headerHasDivider: {
       control: 'boolean',
       description: 'Add a border below the header',
-      table: { category: 'Header' },
+      table: {category: 'Header'},
     },
     headerIsFullBleed: {
       control: 'boolean',
       description: 'Remove header padding',
-      table: { category: 'Header' },
+      table: {category: 'Header'},
     },
     // Content controls
     contentIsFullBleed: {
       control: 'boolean',
       description: 'Remove content padding for edge-to-edge content',
-      table: { category: 'Content' },
+      table: {category: 'Content'},
     },
     contentIsScrollable: {
       control: 'boolean',
       description: 'Enable scrollable overflow',
-      table: { category: 'Content' },
+      table: {category: 'Content'},
     },
     // Footer controls
     showFooter: {
       control: 'boolean',
       description: 'Show or hide the footer',
-      table: { category: 'Footer' },
+      table: {category: 'Footer'},
     },
     footerHasDivider: {
       control: 'boolean',
       description: 'Add a border above the footer',
-      table: { category: 'Footer' },
+      table: {category: 'Footer'},
     },
     footerIsFullBleed: {
       control: 'boolean',
       description: 'Remove footer padding',
-      table: { category: 'Footer' },
+      table: {category: 'Footer'},
     },
     // Start panel controls
     showStartPanel: {
       control: 'boolean',
       description: 'Show or hide the start (left) panel',
-      table: { category: 'Start Panel' },
+      table: {category: 'Start Panel'},
     },
     startPanelWidth: {
-      control: { type: 'range', min: 100, max: 300, step: 20 },
+      control: {type: 'range', min: 100, max: 300, step: 20},
       description: 'Width of the start panel',
-      table: { category: 'Start Panel' },
+      table: {category: 'Start Panel'},
     },
     startPanelHasDivider: {
       control: 'boolean',
       description: 'Add a border to the start panel',
-      table: { category: 'Start Panel' },
+      table: {category: 'Start Panel'},
     },
     startPanelIsScrollable: {
       control: 'boolean',
       description: 'Enable scrollable overflow for start panel',
-      table: { category: 'Start Panel' },
+      table: {category: 'Start Panel'},
     },
     // End panel controls
     showEndPanel: {
       control: 'boolean',
       description: 'Show or hide the end (right) panel',
-      table: { category: 'End Panel' },
+      table: {category: 'End Panel'},
     },
     endPanelWidth: {
-      control: { type: 'range', min: 100, max: 300, step: 20 },
+      control: {type: 'range', min: 100, max: 300, step: 20},
       description: 'Width of the end panel',
-      table: { category: 'End Panel' },
+      table: {category: 'End Panel'},
     },
     endPanelHasDivider: {
       control: 'boolean',
       description: 'Add a border to the end panel',
-      table: { category: 'End Panel' },
+      table: {category: 'End Panel'},
     },
     endPanelIsScrollable: {
       control: 'boolean',
       description: 'Enable scrollable overflow for end panel',
-      table: { category: 'End Panel' },
+      table: {category: 'End Panel'},
     },
   },
   render: (args: PlaygroundArgs) => (
@@ -330,8 +344,7 @@ export const Playground = {
             args.showHeader ? (
               <XDSLayoutHeader
                 hasDivider={args.headerHasDivider}
-                isFullBleed={args.headerIsFullBleed}
-              >
+                isFullBleed={args.headerIsFullBleed}>
                 <h3 {...stylex.props(styles.heading)}>Layout Header</h3>
               </XDSLayoutHeader>
             ) : undefined
@@ -342,8 +355,7 @@ export const Playground = {
                 width={args.startPanelWidth}
                 hasDivider={args.startPanelHasDivider}
                 isScrollable={args.startPanelIsScrollable}
-                role="navigation"
-              >
+                role="navigation">
                 <NavItem active>Dashboard</NavItem>
                 <NavItem>Settings</NavItem>
                 <NavItem>Profile</NavItem>
@@ -354,8 +366,7 @@ export const Playground = {
           content={
             <XDSLayoutContent
               isFullBleed={args.contentIsFullBleed}
-              isScrollable={args.contentIsScrollable}
-            >
+              isScrollable={args.contentIsScrollable}>
               <h4 {...stylex.props(styles.subheading)}>Main Content Area</h4>
               <br />
               <p {...stylex.props(styles.bodyText)}>
@@ -364,8 +375,9 @@ export const Playground = {
               </p>
               <br />
               <p {...stylex.props(styles.bodyText)}>
-                Try enabling &quot;isFullBleed&quot; to see how content can extend
-                to the edges, or toggle &quot;isScrollable&quot; to change overflow behavior.
+                Try enabling &quot;isFullBleed&quot; to see how content can
+                extend to the edges, or toggle &quot;isScrollable&quot; to
+                change overflow behavior.
               </p>
               <br />
               <div {...stylex.props(styles.placeholder)}>
@@ -379,8 +391,7 @@ export const Playground = {
                 width={args.endPanelWidth}
                 hasDivider={args.endPanelHasDivider}
                 isScrollable={args.endPanelIsScrollable}
-                role="complementary"
-              >
+                role="complementary">
                 <p {...stylex.props(styles.sectionLabel)}>Details</p>
                 <p {...stylex.props(styles.bodyText)}>
                   Additional information or actions can go in the end panel.
@@ -392,8 +403,7 @@ export const Playground = {
             args.showFooter ? (
               <XDSLayoutFooter
                 hasDivider={args.footerHasDivider}
-                isFullBleed={args.footerIsFullBleed}
-              >
+                isFullBleed={args.footerIsFullBleed}>
                 <XDSHStack gap="space2" hAlign="end">
                   <XDSButton variant="secondary">Cancel</XDSButton>
                   <XDSButton variant="primary">Save</XDSButton>
@@ -425,8 +435,9 @@ export const BasicCard: Story = {
           content={
             <XDSLayoutContent>
               <p {...stylex.props(styles.bodyText)}>
-                This is a basic card layout with a header, scrollable content area, and footer.
-                The layout automatically handles padding and spacing between sections.
+                This is a basic card layout with a header, scrollable content
+                area, and footer. The layout automatically handles padding and
+                spacing between sections.
               </p>
               <br />
               <p {...stylex.props(styles.bodyText)}>
@@ -579,9 +590,9 @@ export const FullBleedContent: Story = {
           content={
             <XDSLayoutContent isFullBleed>
               <div {...stylex.props(styles.placeholderFullBleed)}>
-                This content uses isFullBleed to remove padding,
-                allowing it to touch the edges. Useful for tables,
-                images, or other edge-to-edge content.
+                This content uses isFullBleed to remove padding, allowing it to
+                touch the edges. Useful for tables, images, or other
+                edge-to-edge content.
               </div>
             </XDSLayoutContent>
           }
@@ -606,22 +617,50 @@ export const SectionVariants: Story = {
       <XDSHStack gap="space4" wrap="wrap">
         <XDSSection variant="section" width={300} height={250}>
           <XDSLayout
-            header={<XDSLayoutHeader hasDivider><p {...stylex.props(styles.subheading)}>Section</p></XDSLayoutHeader>}
-            content={<XDSLayoutContent><p {...stylex.props(styles.bodyText)}>Surface background color</p></XDSLayoutContent>}
+            header={
+              <XDSLayoutHeader hasDivider>
+                <p {...stylex.props(styles.subheading)}>Section</p>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <p {...stylex.props(styles.bodyText)}>
+                  Surface background color
+                </p>
+              </XDSLayoutContent>
+            }
           />
         </XDSSection>
 
         <XDSSection variant="wash" width={300} height={250}>
           <XDSLayout
-            header={<XDSLayoutHeader hasDivider><p {...stylex.props(styles.subheading)}>Wash</p></XDSLayoutHeader>}
-            content={<XDSLayoutContent><p {...stylex.props(styles.bodyText)}>Wash background color</p></XDSLayoutContent>}
+            header={
+              <XDSLayoutHeader hasDivider>
+                <p {...stylex.props(styles.subheading)}>Wash</p>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <p {...stylex.props(styles.bodyText)}>Wash background color</p>
+              </XDSLayoutContent>
+            }
           />
         </XDSSection>
 
         <XDSSection variant="transparent" width={300} height={250}>
           <XDSLayout
-            header={<XDSLayoutHeader hasDivider><p {...stylex.props(styles.subheading)}>Transparent</p></XDSLayoutHeader>}
-            content={<XDSLayoutContent><p {...stylex.props(styles.bodyText)}>No background, shows parent</p></XDSLayoutContent>}
+            header={
+              <XDSLayoutHeader hasDivider>
+                <p {...stylex.props(styles.subheading)}>Transparent</p>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <p {...stylex.props(styles.bodyText)}>
+                  No background, shows parent
+                </p>
+              </XDSLayoutContent>
+            }
           />
         </XDSSection>
       </XDSHStack>
@@ -640,8 +679,8 @@ export const ContentOnly: Story = {
               <h3 {...stylex.props(styles.heading)}>Simple Content</h3>
               <br />
               <p {...stylex.props(styles.bodyText)}>
-                A layout can have just content without header or footer.
-                This is useful for simple cards or content blocks.
+                A layout can have just content without header or footer. This is
+                useful for simple cards or content blocks.
               </p>
             </XDSLayoutContent>
           }
@@ -656,7 +695,9 @@ export const ThemedLayout: Story = {
   render: () => (
     <XDSHStack gap="space6" xstyle={styles.storySection}>
       <XDSVStack gap="space3">
-        <p {...stylex.props(styles.sectionLabel)}>Default Theme (16px padding)</p>
+        <p {...stylex.props(styles.sectionLabel)}>
+          Default Theme (16px padding)
+        </p>
         <Theme theme={defaultTheme}>
           <XDSCard width={400} height={350}>
             <XDSLayout
@@ -668,7 +709,8 @@ export const ThemedLayout: Story = {
               content={
                 <XDSLayoutContent>
                   <p {...stylex.props(styles.bodyText)}>
-                    This card uses the default theme with 16px padding around the layout areas.
+                    This card uses the default theme with 16px padding around
+                    the layout areas.
                   </p>
                 </XDSLayoutContent>
               }
@@ -686,7 +728,9 @@ export const ThemedLayout: Story = {
       </XDSVStack>
 
       <XDSVStack gap="space3">
-        <p {...stylex.props(styles.sectionLabel)}>Neutral Theme (12px padding)</p>
+        <p {...stylex.props(styles.sectionLabel)}>
+          Neutral Theme (12px padding)
+        </p>
         <Theme theme={neutralTheme}>
           <XDSCard width={400} height={350}>
             <XDSLayout
@@ -698,7 +742,8 @@ export const ThemedLayout: Story = {
               content={
                 <XDSLayoutContent>
                   <p {...stylex.props(styles.bodyText)}>
-                    This card uses the neutral theme with 12px padding around the layout areas.
+                    This card uses the neutral theme with 12px padding around
+                    the layout areas.
                   </p>
                 </XDSLayoutContent>
               }
@@ -724,8 +769,9 @@ export const OuterPaddingDemo: Story = {
     <XDSVStack gap="space6" xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>Outer Padding</p>
       <p {...stylex.props(styles.bodyText)}>
-        Outer padding creates space between the container edge and the layout content.
-        Notice how the dividers are inset from the container edges as outer padding increases.
+        Outer padding creates space between the container edge and the layout
+        content. Notice how the dividers are inset from the container edges as
+        outer padding increases.
       </p>
       <XDSHStack gap="space4" wrap="wrap">
         <XDSVStack gap="space2">
@@ -737,9 +783,8 @@ export const OuterPaddingDemo: Story = {
                 paddingOuterY: 'space0',
               }),
               styles.demoContainer,
-              styles.demoSize
-            )}
-          >
+              styles.demoSize,
+            )}>
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
@@ -771,9 +816,8 @@ export const OuterPaddingDemo: Story = {
                 paddingOuterY: 'space4',
               }),
               styles.demoContainer,
-              styles.demoSize
-            )}
-          >
+              styles.demoSize,
+            )}>
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
@@ -805,9 +849,8 @@ export const OuterPaddingDemo: Story = {
                 paddingOuterY: 'space7',
               }),
               styles.demoContainer,
-              styles.demoSize
-            )}
-          >
+              styles.demoSize,
+            )}>
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>

--- a/apps/storybook/stories/StackItem.stories.tsx
+++ b/apps/storybook/stories/StackItem.stories.tsx
@@ -1,44 +1,49 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
-import { XDSHStack, XDSVStack, XDSStackItem } from '@xds/core/Layout';
-import { color, spacing, radius, typography } from '@xds/core/theme/tokens.stylex';
+import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Layout';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  typographyVars,
+} from '@xds/core/theme/tokens.stylex';
 
 const styles = stylex.create({
   box: {
-    backgroundColor: color.blueBackground,
-    color: color.blueText,
+    backgroundColor: colorVars['--color-blue-background'],
+    color: colorVars['--color-blue-text'],
     borderWidth: 1,
     borderStyle: 'solid',
-    borderColor: color.blueBorder,
-    paddingBlock: spacing.space4,
-    paddingInline: spacing.space6,
-    borderRadius: radius.element,
+    borderColor: colorVars['--color-blue-border'],
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-6'],
+    borderRadius: radiusVars['--radius-element'],
     fontWeight: 500,
     height: '100%',
     boxSizing: 'border-box',
   },
   boxAlt: {
-    backgroundColor: color.grayBackground,
-    color: color.grayText,
-    borderColor: color.grayBorder,
+    backgroundColor: colorVars['--color-gray-background'],
+    color: colorVars['--color-gray-text'],
+    borderColor: colorVars['--color-gray-border'],
   },
   boxGreen: {
-    backgroundColor: color.greenBackground,
-    color: color.greenText,
-    borderColor: color.greenBorder,
+    backgroundColor: colorVars['--color-green-background'],
+    color: colorVars['--color-green-text'],
+    borderColor: colorVars['--color-green-border'],
   },
   boxPurple: {
-    backgroundColor: color.purpleBackground,
-    color: color.purpleText,
-    borderColor: color.purpleBorder,
+    backgroundColor: colorVars['--color-purple-background'],
+    color: colorVars['--color-purple-text'],
+    borderColor: colorVars['--color-purple-border'],
   },
   boxOrange: {
-    backgroundColor: color.orangeBackground,
-    color: color.orangeText,
-    borderColor: color.orangeBorder,
+    backgroundColor: colorVars['--color-orange-background'],
+    color: colorVars['--color-orange-text'],
+    borderColor: colorVars['--color-orange-border'],
   },
   container: {
-    backgroundColor: color.wash,
+    backgroundColor: colorVars['--color-wash'],
   },
   containerWidth: {
     width: 500,
@@ -53,7 +58,7 @@ const styles = stylex.create({
     height: 200,
   },
   containerPadding: {
-    padding: spacing.space2,
+    padding: spacingVars['--spacing-2'],
   },
   sidebarWidth: {
     width: 150,
@@ -61,23 +66,36 @@ const styles = stylex.create({
   storyWrapper: {
     display: 'flex',
     flexDirection: 'column',
-    gap: spacing.space6,
+    gap: spacingVars['--spacing-6'],
   },
   heading: {
-    margin: `0 0 ${spacing.space2} 0`,
-    fontFamily: typography.fontFamilyBody,
+    margin: `0 0 ${spacingVars['--spacing-2']} 0`,
+    fontFamily: typographyVars['--font-body'],
   },
 });
 
 // Demo box component for visibility
-const Box = ({ children, alt = false, green = false, purple = false, orange = false }: {
+const Box = ({
+  children,
+  alt = false,
+  green = false,
+  purple = false,
+  orange = false,
+}: {
   children: React.ReactNode;
   alt?: boolean;
   green?: boolean;
   purple?: boolean;
   orange?: boolean;
 }) => (
-  <div {...stylex.props(styles.box, alt && styles.boxAlt, green && styles.boxGreen, purple && styles.boxPurple, orange && styles.boxOrange)}>
+  <div
+    {...stylex.props(
+      styles.box,
+      alt && styles.boxAlt,
+      green && styles.boxGreen,
+      purple && styles.boxPurple,
+      orange && styles.boxOrange,
+    )}>
     {children}
   </div>
 );
@@ -113,8 +131,14 @@ export const Default: Story = {
     size: 'static',
     children: null,
   },
-  render: (args) => (
-    <XDSHStack gap="space2" xstyle={[styles.container, styles.containerWidth, styles.containerPadding]}>
+  render: args => (
+    <XDSHStack
+      gap="space2"
+      xstyle={[
+        styles.container,
+        styles.containerWidth,
+        styles.containerPadding,
+      ]}>
       <XDSStackItem {...args}>
         <Box>Stack Item</Box>
       </XDSStackItem>
@@ -125,7 +149,13 @@ export const Default: Story = {
 
 export const FillSize: Story = {
   render: () => (
-    <XDSHStack gap="space2" xstyle={[styles.container, styles.containerWidth, styles.containerPadding]}>
+    <XDSHStack
+      gap="space2"
+      xstyle={[
+        styles.container,
+        styles.containerWidth,
+        styles.containerPadding,
+      ]}>
       <XDSStackItem size="static">
         <Box alt>Static</Box>
       </XDSStackItem>
@@ -143,7 +173,13 @@ export const EqualFill: Story = {
   render: () => (
     <div>
       <h4 {...stylex.props(styles.heading)}>Equal Fill (1:1:1)</h4>
-      <XDSHStack gap="space2" xstyle={[styles.container, styles.containerWidth, styles.containerPadding]}>
+      <XDSHStack
+        gap="space2"
+        xstyle={[
+          styles.container,
+          styles.containerWidth,
+          styles.containerPadding,
+        ]}>
         <XDSStackItem size="fill">
           <Box>fill</Box>
         </XDSStackItem>
@@ -160,7 +196,13 @@ export const EqualFill: Story = {
 
 export const CrossAlignSelf: Story = {
   render: () => (
-    <XDSHStack gap="space2" xstyle={[styles.container, styles.containerHeight, styles.containerPadding]}>
+    <XDSHStack
+      gap="space2"
+      xstyle={[
+        styles.container,
+        styles.containerHeight,
+        styles.containerPadding,
+      ]}>
       <XDSStackItem crossAlignSelf="start">
         <Box>start</Box>
       </XDSStackItem>
@@ -179,7 +221,13 @@ export const CrossAlignSelf: Story = {
 
 export const PolymorphicElement: Story = {
   render: () => (
-    <XDSHStack gap="space2" xstyle={[styles.container, styles.containerWidth, styles.containerPadding]}>
+    <XDSHStack
+      gap="space2"
+      xstyle={[
+        styles.container,
+        styles.containerWidth,
+        styles.containerPadding,
+      ]}>
       <XDSStackItem element="section" size="fill">
         <Box>section element</Box>
       </XDSStackItem>
@@ -198,7 +246,13 @@ export const CommonLayoutPattern: Story = {
     <XDSVStack gap="space4">
       <div>
         <h4 {...stylex.props(styles.heading)}>Header Layout</h4>
-        <XDSHStack gap="space2" xstyle={[styles.container, styles.containerWidthLarge, styles.containerPadding]}>
+        <XDSHStack
+          gap="space2"
+          xstyle={[
+            styles.container,
+            styles.containerWidthLarge,
+            styles.containerPadding,
+          ]}>
           <XDSStackItem size="static">
             <Box alt>Logo</Box>
           </XDSStackItem>
@@ -212,7 +266,14 @@ export const CommonLayoutPattern: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>Sidebar Layout</h4>
-        <XDSHStack gap="space2" xstyle={[styles.container, styles.containerWidthLarge, styles.containerHeightLarge, styles.containerPadding]}>
+        <XDSHStack
+          gap="space2"
+          xstyle={[
+            styles.container,
+            styles.containerWidthLarge,
+            styles.containerHeightLarge,
+            styles.containerPadding,
+          ]}>
           <XDSStackItem size="static" xstyle={styles.sidebarWidth}>
             <Box alt>Sidebar</Box>
           </XDSStackItem>

--- a/apps/storybook/stories/VStack.stories.tsx
+++ b/apps/storybook/stories/VStack.stories.tsx
@@ -1,27 +1,32 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
-import { XDSVStack } from '@xds/core/Layout';
-import { color, spacing, radius, typography } from '@xds/core/theme/tokens.stylex';
+import {XDSVStack} from '@xds/core/Layout';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  typographyVars,
+} from '@xds/core/theme/tokens.stylex';
 
 const styles = stylex.create({
   box: {
-    backgroundColor: color.blueBackground,
-    color: color.blueText,
+    backgroundColor: colorVars['--color-blue-background'],
+    color: colorVars['--color-blue-text'],
     borderWidth: 1,
     borderStyle: 'solid',
-    borderColor: color.blueBorder,
-    paddingBlock: spacing.space4,
-    paddingInline: spacing.space6,
-    borderRadius: radius.element,
+    borderColor: colorVars['--color-blue-border'],
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-6'],
+    borderRadius: radiusVars['--radius-element'],
     fontWeight: 500,
   },
   boxAlt: {
-    backgroundColor: color.grayBackground,
-    color: color.grayText,
-    borderColor: color.grayBorder,
+    backgroundColor: colorVars['--color-gray-background'],
+    color: colorVars['--color-gray-text'],
+    borderColor: colorVars['--color-gray-border'],
   },
   container: {
-    backgroundColor: color.wash,
+    backgroundColor: colorVars['--color-wash'],
   },
   containerWidth: {
     width: 300,
@@ -33,22 +38,26 @@ const styles = stylex.create({
     height: 150,
   },
   containerPadding: {
-    padding: spacing.space2,
+    padding: spacingVars['--spacing-2'],
   },
   storyWrapper: {
     display: 'flex',
-    gap: spacing.space6,
+    gap: spacingVars['--spacing-6'],
   },
   heading: {
-    margin: `0 0 ${spacing.space2} 0`,
-    fontFamily: typography.fontFamilyBody,
+    margin: `0 0 ${spacingVars['--spacing-2']} 0`,
+    fontFamily: typographyVars['--font-body'],
   },
 });
 
 // Demo box component for visibility
-const Box = ({ children, alt = false }: { children: React.ReactNode; alt?: boolean }) => (
-  <div {...stylex.props(styles.box, alt && styles.boxAlt)}>{children}</div>
-);
+const Box = ({
+  children,
+  alt = false,
+}: {
+  children: React.ReactNode;
+  alt?: boolean;
+}) => <div {...stylex.props(styles.box, alt && styles.boxAlt)}>{children}</div>;
 
 const meta: Meta<typeof XDSVStack> = {
   title: 'Layout/XDSVStack',
@@ -57,7 +66,17 @@ const meta: Meta<typeof XDSVStack> = {
   argTypes: {
     gap: {
       control: 'select',
-      options: ['space0', 'space0.5', 'space1', 'space2', 'space3', 'space4', 'space5', 'space6', 'space7'],
+      options: [
+        'space0',
+        'space0.5',
+        'space1',
+        'space2',
+        'space3',
+        'space4',
+        'space5',
+        'space6',
+        'space7',
+      ],
       description: 'Spacing token for gap between items',
     },
     hAlign: {
@@ -81,7 +100,7 @@ export const Default: Story = {
     gap: 'space2',
     children: null,
   },
-  render: (args) => (
+  render: args => (
     <XDSVStack {...args}>
       <Box>Item 1</Box>
       <Box>Item 2</Box>
@@ -94,7 +113,7 @@ export const WithGap: Story = {
   args: {
     gap: 'space4',
   },
-  render: (args) => (
+  render: args => (
     <XDSVStack {...args}>
       <Box>Item 1</Box>
       <Box>Item 2</Box>
@@ -108,7 +127,7 @@ export const HorizontalAlignCenter: Story = {
     gap: 'space4',
     hAlign: 'center',
   },
-  render: (args) => (
+  render: args => (
     <XDSVStack {...args} xstyle={[styles.container, styles.containerWidth]}>
       <Box>Short</Box>
       <Box>Medium Item</Box>
@@ -122,7 +141,7 @@ export const HorizontalAlignStart: Story = {
     gap: 'space4',
     hAlign: 'start',
   },
-  render: (args) => (
+  render: args => (
     <XDSVStack {...args} xstyle={[styles.container, styles.containerWidth]}>
       <Box>Short</Box>
       <Box>Medium Item</Box>
@@ -136,7 +155,7 @@ export const HorizontalAlignEnd: Story = {
     gap: 'space4',
     hAlign: 'end',
   },
-  render: (args) => (
+  render: args => (
     <XDSVStack {...args} xstyle={[styles.container, styles.containerWidth]}>
       <Box>Short</Box>
       <Box>Medium Item</Box>
@@ -150,8 +169,14 @@ export const Wrapping: Story = {
     gap: 'space2',
     wrap: 'wrap',
   },
-  render: (args) => (
-    <XDSVStack {...args} xstyle={[styles.container, styles.containerHeight, styles.containerPadding]}>
+  render: args => (
+    <XDSVStack
+      {...args}
+      xstyle={[
+        styles.container,
+        styles.containerHeight,
+        styles.containerPadding,
+      ]}>
       <Box>Item 1</Box>
       <Box>Item 2</Box>
       <Box>Item 3</Box>
@@ -166,7 +191,14 @@ export const AllAlignments: Story = {
     <div {...stylex.props(styles.storyWrapper)}>
       <div>
         <h4 {...stylex.props(styles.heading)}>hAlign: start</h4>
-        <XDSVStack gap="space2" hAlign="start" xstyle={[styles.container, styles.containerWidthSmall, styles.containerPadding]}>
+        <XDSVStack
+          gap="space2"
+          hAlign="start"
+          xstyle={[
+            styles.container,
+            styles.containerWidthSmall,
+            styles.containerPadding,
+          ]}>
           <Box>A</Box>
           <Box>BB</Box>
           <Box>CCC</Box>
@@ -174,7 +206,14 @@ export const AllAlignments: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>hAlign: center</h4>
-        <XDSVStack gap="space2" hAlign="center" xstyle={[styles.container, styles.containerWidthSmall, styles.containerPadding]}>
+        <XDSVStack
+          gap="space2"
+          hAlign="center"
+          xstyle={[
+            styles.container,
+            styles.containerWidthSmall,
+            styles.containerPadding,
+          ]}>
           <Box>A</Box>
           <Box>BB</Box>
           <Box>CCC</Box>
@@ -182,7 +221,14 @@ export const AllAlignments: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>hAlign: end</h4>
-        <XDSVStack gap="space2" hAlign="end" xstyle={[styles.container, styles.containerWidthSmall, styles.containerPadding]}>
+        <XDSVStack
+          gap="space2"
+          hAlign="end"
+          xstyle={[
+            styles.container,
+            styles.containerWidthSmall,
+            styles.containerPadding,
+          ]}>
           <Box>A</Box>
           <Box>BB</Box>
           <Box>CCC</Box>
@@ -190,7 +236,14 @@ export const AllAlignments: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>hAlign: stretch</h4>
-        <XDSVStack gap="space2" hAlign="stretch" xstyle={[styles.container, styles.containerWidthSmall, styles.containerPadding]}>
+        <XDSVStack
+          gap="space2"
+          hAlign="stretch"
+          xstyle={[
+            styles.container,
+            styles.containerWidthSmall,
+            styles.containerPadding,
+          ]}>
           <Box>A</Box>
           <Box>BB</Box>
           <Box>CCC</Box>

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -13,7 +13,7 @@
 
 import {forwardRef, useState, type HTMLAttributes, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {color, spacing, radius, typography} from '../theme/tokens.stylex';
+import {colorVars, typographyVars} from '../theme/tokens.stylex';
 
 /**
  * The offset ratio for positioning elements on a circle's edge at 45°.
@@ -119,9 +119,9 @@ const styles = stylex.create({
     justifyContent: 'center',
     width: '100%',
     height: '100%',
-    backgroundColor: color.deemphasized,
-    color: color.textSecondary,
-    fontFamily: typography.fontFamilyBody,
+    backgroundColor: colorVars['--color-deemphasized'],
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-body'],
     fontWeight: 500,
     textTransform: 'uppercase',
   },

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -19,11 +19,10 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
-  color,
-  spacing,
-  radius,
-  transition,
-  typography,
+  colorVars,
+  spacingVars,
+  radiusVars,
+  transitionVars,
 } from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
 
@@ -38,19 +37,19 @@ const styles = stylex.create({
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: spacing.space2,
-    paddingBlock: spacing.space2,
-    paddingInline: spacing.space3,
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
     borderWidth: 0,
     borderStyle: 'none',
-    borderRadius: radius.element,
-    fontFamily: typography.fontFamilyBody,
+    borderRadius: radiusVars['--radius-element'],
+    fontFamily: 'inherit',
     fontSize: '0.875rem',
     lineHeight: 1.429,
     fontWeight: 500,
     cursor: 'pointer',
     transitionProperty: 'background-image, transform',
-    transitionDuration: transition.fast,
+    transitionDuration: transitionVars['--transition-fast'],
     transform: {
       default: 'scale(1)',
       ':active': 'scale(0.98)',
@@ -74,70 +73,70 @@ const styles = stylex.create({
  */
 const variants = stylex.create({
   primary: {
-    backgroundColor: color.accent,
+    backgroundColor: colorVars['--color-accent'],
     color: 'white',
     backgroundImage: {
       default: null,
-      ':hover': `linear-gradient(${color.hoverOverlay}, ${color.hoverOverlay})`,
-      ':active': `linear-gradient(${color.pressedOverlay}, ${color.pressedOverlay})`,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${color.focusOutline}`,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
-      default: null,
+      default: '0',
       ':focus-visible': '3px',
     },
   },
   secondary: {
-    backgroundColor: color.deemphasized,
-    color: color.textPrimary,
+    backgroundColor: colorVars['--color-deemphasized'],
+    color: colorVars['--color-text-primary'],
     backgroundImage: {
       default: null,
-      ':hover': `linear-gradient(${color.hoverOverlay}, ${color.hoverOverlay})`,
-      ':active': `linear-gradient(${color.pressedOverlay}, ${color.pressedOverlay})`,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${color.focusOutline}`,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
-      default: null,
+      default: '0',
       ':focus-visible': '3px',
     },
   },
   ghost: {
     backgroundColor: 'transparent',
-    color: color.textPrimary,
+    color: colorVars['--color-text-primary'],
     backgroundImage: {
       default: null,
-      ':hover': `linear-gradient(${color.hoverOverlay}, ${color.hoverOverlay})`,
-      ':active': `linear-gradient(${color.pressedOverlay}, ${color.pressedOverlay})`,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${color.focusOutline}`,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
-      default: null,
+      default: '0',
       ':focus-visible': '3px',
     },
   },
   destructive: {
-    backgroundColor: color.negative,
+    backgroundColor: colorVars['--color-negative'],
     color: 'white',
     backgroundImage: {
       default: null,
-      ':hover': `linear-gradient(${color.hoverOverlay}, ${color.hoverOverlay})`,
-      ':active': `linear-gradient(${color.pressedOverlay}, ${color.pressedOverlay})`,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${color.negative}`,
+      ':focus-visible': `2px solid ${colorVars['--color-negative']}`,
     },
     outlineOffset: {
-      default: null,
+      default: '0',
       ':focus-visible': '3px',
     },
   },
@@ -210,9 +209,9 @@ const loadingStyles = stylex.create({
     borderRightColor: 'transparent',
   },
   spinnerDark: {
-    borderTopColor: color.textPrimary,
-    borderLeftColor: color.textPrimary,
-    borderBottomColor: color.textPrimary,
+    borderTopColor: colorVars['--color-text-primary'],
+    borderLeftColor: colorVars['--color-text-primary'],
+    borderBottomColor: colorVars['--color-text-primary'],
     borderRightColor: 'transparent',
   },
 });

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -13,13 +13,13 @@
 
 import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {color, spacing, typography} from '../theme/tokens.stylex';
+import {colorVars, spacingVars, typographyVars} from '../theme/tokens.stylex';
 
 const styles = stylex.create({
   container: {
     display: 'flex',
     flexDirection: 'column',
-    gap: spacing.space1,
+    gap: spacingVars['--spacing-1'],
   },
   labelRow: {
     display: 'flex',
@@ -27,10 +27,10 @@ const styles = stylex.create({
     alignItems: 'baseline',
   },
   label: {
-    fontFamily: typography.fontFamilyBody,
+    fontFamily: typographyVars['--font-body'],
     fontSize: '0.875rem',
     fontWeight: 500,
-    color: color.textPrimary,
+    color: colorVars['--color-text-primary'],
   },
   labelHidden: {
     borderStyle: 'none',
@@ -48,15 +48,15 @@ const styles = stylex.create({
     width: 1,
   },
   description: {
-    fontFamily: typography.fontFamilyBody,
+    fontFamily: typographyVars['--font-body'],
     fontSize: '0.75rem',
-    color: color.textSecondary,
+    color: colorVars['--color-text-secondary'],
   },
   optionalRequired: {
-    fontFamily: typography.fontFamilyBody,
+    fontFamily: typographyVars['--font-body'],
     fontSize: '0.75rem',
-    color: color.textSecondary,
-    marginInlineStart: spacing.space1,
+    color: colorVars['--color-text-secondary'],
+    marginInlineStart: spacingVars['--spacing-1'],
   },
 });
 

--- a/packages/core/src/Layer/XDSHoverCard.tsx
+++ b/packages/core/src/Layer/XDSHoverCard.tsx
@@ -22,7 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 import {ThemeContext} from '../theme/ThemeContext';
 import {useXDSHoverCard, type HoverCardFocusTrigger} from './useXDSHoverCard';
 import type {LayerAlignment, LayerPlacement} from './useXDSLayer';
-import {color} from '../theme/tokens.stylex';
+import {colorVars} from '../theme/tokens.stylex';
 
 export type {HoverCardFocusTrigger} from './useXDSHoverCard';
 
@@ -36,7 +36,7 @@ const styles = stylex.create({
   hoverIndication: {
     textDecorationLine: 'underline',
     textDecorationStyle: 'dashed',
-    textDecorationColor: color.dividerEmphasized,
+    textDecorationColor: colorVars['--color-divider-emphasized'],
     textUnderlineOffset: '2px',
   },
 });

--- a/packages/core/src/Layer/XDSTooltip.tsx
+++ b/packages/core/src/Layer/XDSTooltip.tsx
@@ -22,7 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 import {ThemeContext} from '../theme/ThemeContext';
 import {useXDSTooltip, type TooltipFocusTrigger} from './useXDSTooltip';
 import type {LayerAlignment, LayerPlacement} from './useXDSLayer';
-import {color} from '../theme/tokens.stylex';
+import {colorVars} from '../theme/tokens.stylex';
 
 export type {TooltipFocusTrigger} from './useXDSTooltip';
 
@@ -36,7 +36,7 @@ const styles = stylex.create({
   hoverIndication: {
     textDecorationLine: 'underline',
     textDecorationStyle: 'dashed',
-    textDecorationColor: color.dividerEmphasized,
+    textDecorationColor: colorVars['--color-divider-emphasized'],
     textUnderlineOffset: '2px',
   },
 });

--- a/packages/core/src/Layer/useXDSHoverCard.tsx
+++ b/packages/core/src/Layer/useXDSHoverCard.tsx
@@ -26,14 +26,19 @@ import {
   type LayerAlignment,
   type LayerPlacement,
 } from './useXDSLayer';
-import {color, elevation, radius, spacing} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  elevationVars,
+  radiusVars,
+  spacingVars,
+} from '../theme/tokens.stylex';
 
 const styles = stylex.create({
   // Base container styles passed to useXDSLayer (includes animations)
   container: {
-    backgroundColor: color.surface,
-    borderRadius: radius.container,
-    boxShadow: elevation.hover,
+    backgroundColor: colorVars['--color-surface'],
+    borderRadius: radiusVars['--radius-container'],
+    boxShadow: elevationVars['--elevation-hover'],
     // Animation: closed state (default) and open state
     opacity: {
       default: 0,
@@ -56,23 +61,23 @@ const styles = stylex.create({
   },
   // Position-based margin styles
   marginBlock: {
-    marginBlockStart: spacing.space1,
-    marginBlockEnd: spacing.space1,
+    marginBlockStart: spacingVars['--spacing-1'],
+    marginBlockEnd: spacingVars['--spacing-1'],
     marginInlineStart: 0,
     marginInlineEnd: 0,
   },
   marginInline: {
     marginBlockStart: 0,
     marginBlockEnd: 0,
-    marginInlineStart: spacing.space1,
-    marginInlineEnd: spacing.space1,
+    marginInlineStart: spacingVars['--spacing-1'],
+    marginInlineEnd: spacingVars['--spacing-1'],
   },
   // Content wrapper for padding and mouse events
   content: {
-    paddingBlockStart: spacing.space3,
-    paddingBlockEnd: spacing.space3,
-    paddingInlineStart: spacing.space3,
-    paddingInlineEnd: spacing.space3,
+    paddingBlockStart: spacingVars['--spacing-3'],
+    paddingBlockEnd: spacingVars['--spacing-3'],
+    paddingInlineStart: spacingVars['--spacing-3'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
   },
 });
 

--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -19,7 +19,6 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {spacing} from '../theme/tokens.stylex';
 
 // Extend React's HTMLAttributes to include popover API attributes
 declare module 'react' {

--- a/packages/core/src/Layer/useXDSTooltip.tsx
+++ b/packages/core/src/Layer/useXDSTooltip.tsx
@@ -26,17 +26,22 @@ import {
   type LayerAlignment,
   type LayerPlacement,
 } from './useXDSLayer';
-import {color, radius, spacing, typography} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  radiusVars,
+  spacingVars,
+  typographyVars,
+} from '../theme/tokens.stylex';
 
 const styles = stylex.create({
   // Base container styles - inverted colors for high contrast
   container: {
     // Inverted color palette: dark background, light text
-    backgroundColor: color.textPrimary,
-    color: color.surface,
-    borderRadius: radius.element,
+    backgroundColor: colorVars['--color-text-primary'],
+    color: colorVars['--color-surface'],
+    borderRadius: radiusVars['--radius-element'],
     // Typography
-    fontFamily: typography.fontFamilyBody,
+    fontFamily: typographyVars['--font-body'],
     fontSize: 14,
     lineHeight: 1.4285714285714,
     // Animation: closed state (default) and open state
@@ -61,23 +66,23 @@ const styles = stylex.create({
   },
   // Position-based margin styles
   marginBlock: {
-    marginBlockStart: spacing.space1,
-    marginBlockEnd: spacing.space1,
+    marginBlockStart: spacingVars['--spacing-1'],
+    marginBlockEnd: spacingVars['--spacing-1'],
     marginInlineStart: 0,
     marginInlineEnd: 0,
   },
   marginInline: {
     marginBlockStart: 0,
     marginBlockEnd: 0,
-    marginInlineStart: spacing.space1,
-    marginInlineEnd: spacing.space1,
+    marginInlineStart: spacingVars['--spacing-1'],
+    marginInlineEnd: spacingVars['--spacing-1'],
   },
   // Content wrapper for padding
   content: {
-    paddingBlockStart: spacing.space1,
-    paddingBlockEnd: spacing.space1,
-    paddingInlineStart: spacing.space2,
-    paddingInlineEnd: spacing.space2,
+    paddingBlockStart: spacingVars['--spacing-1'],
+    paddingBlockEnd: spacingVars['--spacing-1'],
+    paddingInlineStart: spacingVars['--spacing-2'],
+    paddingInlineEnd: spacingVars['--spacing-2'],
   },
 });
 

--- a/packages/core/src/Layout/Container/XDSCard.tsx
+++ b/packages/core/src/Layout/Container/XDSCard.tsx
@@ -7,7 +7,7 @@
 
 import {forwardRef, useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {color, radius, elevation} from '../../theme/tokens.stylex';
+import {colorVars, radiusVars, elevationVars} from '../../theme/tokens.stylex';
 import {ThemeContext} from '../../theme/ThemeContext';
 import type {StyleXStyles as ThemeStyleXStyles} from '../../theme/types';
 import {container} from './container.stylex';
@@ -27,9 +27,9 @@ declare module '../../theme/types' {
 
 const styles = stylex.create({
   card: {
-    backgroundColor: color.card,
-    borderRadius: radius.container,
-    boxShadow: elevation.base,
+    backgroundColor: colorVars['--color-card'],
+    borderRadius: radiusVars['--radius-container'],
+    boxShadow: elevationVars['--elevation-base'],
   },
 });
 
@@ -116,10 +116,10 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
         ref={ref}
         {...stylex.props(
           ...container({
-            paddingInnerX: 'space4',
-            paddingInnerY: 'space4',
-            paddingOuterX: 'space4',
-            paddingOuterY: 'space4',
+            paddingInnerX: 'spacing4',
+            paddingInnerY: 'spacing4',
+            paddingOuterX: 'spacing4',
+            paddingOuterY: 'spacing4',
           }),
           styles.card,
           themeOverride,

--- a/packages/core/src/Layout/Container/XDSSection.tsx
+++ b/packages/core/src/Layout/Container/XDSSection.tsx
@@ -7,7 +7,7 @@
 
 import {forwardRef, useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {color} from '../../theme/tokens.stylex';
+import {colorVars} from '../../theme/tokens.stylex';
 import {ThemeContext} from '../../theme/ThemeContext';
 import type {StyleXStyles as ThemeStyleXStyles} from '../../theme/types';
 import {container} from './container.stylex';
@@ -33,13 +33,13 @@ declare module '../../theme/types' {
 
 const variantStyles = stylex.create({
   section: {
-    backgroundColor: color.surface,
+    backgroundColor: colorVars['--color-surface'],
   },
   transparent: {
     backgroundColor: 'transparent',
   },
   wash: {
-    backgroundColor: color.wash,
+    backgroundColor: colorVars['--color-wash'],
   },
 });
 
@@ -137,10 +137,10 @@ export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
         ref={ref}
         {...stylex.props(
           ...container({
-            paddingInnerX: 'space4',
-            paddingInnerY: 'space4',
-            paddingOuterX: 'space4',
-            paddingOuterY: 'space4',
+            paddingInnerX: 'spacing4',
+            paddingInnerY: 'spacing4',
+            paddingOuterX: 'spacing4',
+            paddingOuterY: 'spacing4',
           }),
           variantStyles[variant],
           themeVariantOverride,

--- a/packages/core/src/Layout/Container/container.stylex.ts
+++ b/packages/core/src/Layout/Container/container.stylex.ts
@@ -8,21 +8,21 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
-import {spacing} from '../../theme/tokens.stylex';
+import {spacingVars} from '../../theme/tokens.stylex';
 
 /**
  * Spacing token keys for padding props.
  */
 export type SpacingToken =
-  | 'space0'
-  | 'space0_5'
-  | 'space1'
-  | 'space2'
-  | 'space3'
-  | 'space4'
-  | 'space5'
-  | 'space6'
-  | 'space7';
+  | 'spacing0'
+  | 'spacing0_5'
+  | 'spacing1'
+  | 'spacing2'
+  | 'spacing3'
+  | 'spacing4'
+  | 'spacing5'
+  | 'spacing6'
+  | 'spacing7';
 
 const baseStyles = stylex.create({
   container: {
@@ -34,79 +34,79 @@ const baseStyles = stylex.create({
 });
 
 const paddingOuterXStyles = stylex.create({
-  space0: {'--layout-padding-outer-x': spacing.space0},
-  space0_5: {'--layout-padding-outer-x': spacing.space0_5},
-  space1: {'--layout-padding-outer-x': spacing.space1},
-  space2: {'--layout-padding-outer-x': spacing.space2},
-  space3: {'--layout-padding-outer-x': spacing.space3},
-  space4: {'--layout-padding-outer-x': spacing.space4},
-  space5: {'--layout-padding-outer-x': spacing.space5},
-  space6: {'--layout-padding-outer-x': spacing.space6},
-  space7: {'--layout-padding-outer-x': spacing.space7},
+  spacing0: {'--layout-padding-outer-x': spacingVars['--spacing-0']},
+  spacing0_5: {'--layout-padding-outer-x': spacingVars['--spacing-0-5']},
+  spacing1: {'--layout-padding-outer-x': spacingVars['--spacing-1']},
+  spacing2: {'--layout-padding-outer-x': spacingVars['--spacing-2']},
+  spacing3: {'--layout-padding-outer-x': spacingVars['--spacing-3']},
+  spacing4: {'--layout-padding-outer-x': spacingVars['--spacing-4']},
+  spacing5: {'--layout-padding-outer-x': spacingVars['--spacing-5']},
+  spacing6: {'--layout-padding-outer-x': spacingVars['--spacing-6']},
+  spacing7: {'--layout-padding-outer-x': spacingVars['--spacing-7']},
 });
 
 const paddingOuterYStyles = stylex.create({
-  space0: {'--layout-padding-outer-y': spacing.space0},
-  space0_5: {'--layout-padding-outer-y': spacing.space0_5},
-  space1: {'--layout-padding-outer-y': spacing.space1},
-  space2: {'--layout-padding-outer-y': spacing.space2},
-  space3: {'--layout-padding-outer-y': spacing.space3},
-  space4: {'--layout-padding-outer-y': spacing.space4},
-  space5: {'--layout-padding-outer-y': spacing.space5},
-  space6: {'--layout-padding-outer-y': spacing.space6},
-  space7: {'--layout-padding-outer-y': spacing.space7},
+  spacing0: {'--layout-padding-outer-y': spacingVars['--spacing-0']},
+  spacing0_5: {'--layout-padding-outer-y': spacingVars['--spacing-0-5']},
+  spacing1: {'--layout-padding-outer-y': spacingVars['--spacing-1']},
+  spacing2: {'--layout-padding-outer-y': spacingVars['--spacing-2']},
+  spacing3: {'--layout-padding-outer-y': spacingVars['--spacing-3']},
+  spacing4: {'--layout-padding-outer-y': spacingVars['--spacing-4']},
+  spacing5: {'--layout-padding-outer-y': spacingVars['--spacing-5']},
+  spacing6: {'--layout-padding-outer-y': spacingVars['--spacing-6']},
+  spacing7: {'--layout-padding-outer-y': spacingVars['--spacing-7']},
 });
 
 const paddingInnerXStyles = stylex.create({
-  space0: {'--layout-padding-inner-x': spacing.space0},
-  space0_5: {'--layout-padding-inner-x': spacing.space0_5},
-  space1: {'--layout-padding-inner-x': spacing.space1},
-  space2: {'--layout-padding-inner-x': spacing.space2},
-  space3: {'--layout-padding-inner-x': spacing.space3},
-  space4: {'--layout-padding-inner-x': spacing.space4},
-  space5: {'--layout-padding-inner-x': spacing.space5},
-  space6: {'--layout-padding-inner-x': spacing.space6},
-  space7: {'--layout-padding-inner-x': spacing.space7},
+  spacing0: {'--layout-padding-inner-x': spacingVars['--spacing-0']},
+  spacing0_5: {'--layout-padding-inner-x': spacingVars['--spacing-0-5']},
+  spacing1: {'--layout-padding-inner-x': spacingVars['--spacing-1']},
+  spacing2: {'--layout-padding-inner-x': spacingVars['--spacing-2']},
+  spacing3: {'--layout-padding-inner-x': spacingVars['--spacing-3']},
+  spacing4: {'--layout-padding-inner-x': spacingVars['--spacing-4']},
+  spacing5: {'--layout-padding-inner-x': spacingVars['--spacing-5']},
+  spacing6: {'--layout-padding-inner-x': spacingVars['--spacing-6']},
+  spacing7: {'--layout-padding-inner-x': spacingVars['--spacing-7']},
 });
 
 const paddingInnerYStyles = stylex.create({
-  space0: {'--layout-padding-inner-y': spacing.space0},
-  space0_5: {'--layout-padding-inner-y': spacing.space0_5},
-  space1: {'--layout-padding-inner-y': spacing.space1},
-  space2: {'--layout-padding-inner-y': spacing.space2},
-  space3: {'--layout-padding-inner-y': spacing.space3},
-  space4: {'--layout-padding-inner-y': spacing.space4},
-  space5: {'--layout-padding-inner-y': spacing.space5},
-  space6: {'--layout-padding-inner-y': spacing.space6},
-  space7: {'--layout-padding-inner-y': spacing.space7},
+  spacing0: {'--layout-padding-inner-y': spacingVars['--spacing-0']},
+  spacing0_5: {'--layout-padding-inner-y': spacingVars['--spacing-0-5']},
+  spacing1: {'--layout-padding-inner-y': spacingVars['--spacing-1']},
+  spacing2: {'--layout-padding-inner-y': spacingVars['--spacing-2']},
+  spacing3: {'--layout-padding-inner-y': spacingVars['--spacing-3']},
+  spacing4: {'--layout-padding-inner-y': spacingVars['--spacing-4']},
+  spacing5: {'--layout-padding-inner-y': spacingVars['--spacing-5']},
+  spacing6: {'--layout-padding-inner-y': spacingVars['--spacing-6']},
+  spacing7: {'--layout-padding-inner-y': spacingVars['--spacing-7']},
 });
 
 export interface ContainerOptions {
   /**
    * Outer horizontal padding (left/right).
    * Sets --layout-padding-outer-x CSS variable.
-   * @default 'space4'
+   * @default 'spacing4'
    */
   paddingOuterX?: SpacingToken;
 
   /**
    * Outer vertical padding (top/bottom).
    * Sets --layout-padding-outer-y CSS variable.
-   * @default 'space4'
+   * @default 'spacing4'
    */
   paddingOuterY?: SpacingToken;
 
   /**
    * Inner horizontal padding for content areas.
    * Sets --layout-padding-inner-x CSS variable.
-   * @default 'space4'
+   * @default 'spacing4'
    */
   paddingInnerX?: SpacingToken;
 
   /**
    * Inner vertical padding for content areas.
    * Sets --layout-padding-inner-y CSS variable.
-   * @default 'space4'
+   * @default 'spacing4'
    */
   paddingInnerY?: SpacingToken;
 }
@@ -138,10 +138,10 @@ export interface ContainerOptions {
  * ```
  */
 export function container({
-  paddingOuterX = 'space4',
-  paddingOuterY = 'space4',
-  paddingInnerX = 'space4',
-  paddingInnerY = 'space4',
+  paddingOuterX = 'spacing4',
+  paddingOuterY = 'spacing4',
+  paddingInnerX = 'spacing4',
+  paddingInnerY = 'spacing4',
 }: ContainerOptions) {
   return [
     baseStyles.container,

--- a/packages/core/src/Layout/Stack/stack.stylex.ts
+++ b/packages/core/src/Layout/Stack/stack.stylex.ts
@@ -8,7 +8,7 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
-import {spacing} from '../../theme/tokens.stylex';
+import {spacingVars} from '../../theme/tokens.stylex';
 
 const alignItemsStyles = stylex.create({
   center: {
@@ -108,40 +108,40 @@ const baseStyles = stylex.create({
  */
 const gapStyles = stylex.create({
   space0: {
-    columnGap: spacing.space0,
-    rowGap: spacing.space0,
+    columnGap: spacingVars['--spacing-0'],
+    rowGap: spacingVars['--spacing-0'],
   },
   'space0.5': {
-    columnGap: spacing.space0_5,
-    rowGap: spacing.space0_5,
+    columnGap: spacingVars['--spacing-0-5'],
+    rowGap: spacingVars['--spacing-0-5'],
   },
   space1: {
-    columnGap: spacing.space1,
-    rowGap: spacing.space1,
+    columnGap: spacingVars['--spacing-1'],
+    rowGap: spacingVars['--spacing-1'],
   },
   space2: {
-    columnGap: spacing.space2,
-    rowGap: spacing.space2,
+    columnGap: spacingVars['--spacing-2'],
+    rowGap: spacingVars['--spacing-2'],
   },
   space3: {
-    columnGap: spacing.space3,
-    rowGap: spacing.space3,
+    columnGap: spacingVars['--spacing-3'],
+    rowGap: spacingVars['--spacing-3'],
   },
   space4: {
-    columnGap: spacing.space4,
-    rowGap: spacing.space4,
+    columnGap: spacingVars['--spacing-4'],
+    rowGap: spacingVars['--spacing-4'],
   },
   space5: {
-    columnGap: spacing.space5,
-    rowGap: spacing.space5,
+    columnGap: spacingVars['--spacing-5'],
+    rowGap: spacingVars['--spacing-5'],
   },
   space6: {
-    columnGap: spacing.space6,
-    rowGap: spacing.space6,
+    columnGap: spacingVars['--spacing-6'],
+    rowGap: spacingVars['--spacing-6'],
   },
   space7: {
-    columnGap: spacing.space7,
-    rowGap: spacing.space7,
+    columnGap: spacingVars['--spacing-7'],
+    rowGap: spacingVars['--spacing-7'],
   },
 });
 

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
@@ -12,7 +12,7 @@
 import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
 import {forwardRef, useContext} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {spacing} from '../../theme/tokens.stylex';
+import {spacingVars} from '../../theme/tokens.stylex';
 import {XDSLayoutSlotsContext} from './XDSLayoutSlotsContext';
 
 const styles = stylex.create({
@@ -23,26 +23,26 @@ const styles = stylex.create({
     minHeight: 0,
     overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
-    paddingInlineStart: `var(--layout-padding-inner-x, ${spacing.space4})`,
-    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacing.space4})`,
-    paddingBlockStart: `var(--layout-padding-inner-y, ${spacing.space4})`,
-    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacing.space4})`,
+    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
+    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
   },
   // When no start panel: outer-x on left edge
   noStart: {
-    paddingInlineStart: `var(--layout-padding-outer-x, ${spacing.space4})`,
+    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
   },
   // When no end panel: outer-x on right edge
   noEnd: {
-    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacing.space4})`,
+    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
   },
   // When no header: outer-y on top
   noHeader: {
-    paddingBlockStart: `var(--layout-padding-outer-y, ${spacing.space4})`,
+    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
   // When no footer: outer-y on bottom
   noFooter: {
-    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacing.space4})`,
+    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
   scrollable: {
     overflow: 'auto',

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
@@ -12,17 +12,17 @@
 import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
 import {forwardRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {color, spacing} from '../../theme/tokens.stylex';
+import {colorVars, spacingVars} from '../../theme/tokens.stylex';
 
 const styles = stylex.create({
   footer: {
     boxSizing: 'border-box',
     flexShrink: 0,
     // Default: outer padding on edges that touch container, inner on interior edges
-    paddingInlineStart: `var(--layout-padding-outer-x, ${spacing.space4})`,
-    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacing.space4})`,
-    paddingBlockStart: `var(--layout-padding-inner-y, ${spacing.space4})`,
-    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacing.space4})`,
+    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
   fullBleed: {
     paddingInlineStart: 0,
@@ -33,11 +33,11 @@ const styles = stylex.create({
   divider: {
     borderBlockStartWidth: 1,
     borderBlockStartStyle: 'solid',
-    borderBlockStartColor: color.divider,
+    borderBlockStartColor: colorVars['--color-divider'],
   },
   // When no divider, collapse spacing to avoid double-padding with content
   collapseTop: {
-    marginBlockStart: `calc(-1 * var(--layout-padding-inner-y, ${spacing.space4}))`,
+    marginBlockStart: `calc(-1 * var(--layout-padding-inner-y, ${spacingVars['--spacing-4']}))`,
   },
 });
 

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
@@ -12,17 +12,17 @@
 import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
 import {forwardRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {color, spacing} from '../../theme/tokens.stylex';
+import {colorVars, spacingVars} from '../../theme/tokens.stylex';
 
 const styles = stylex.create({
   header: {
     boxSizing: 'border-box',
     flexShrink: 0,
     // Default: outer padding on edges that touch container, inner on interior edges
-    paddingInlineStart: `var(--layout-padding-outer-x, ${spacing.space4})`,
-    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacing.space4})`,
-    paddingBlockStart: `var(--layout-padding-outer-y, ${spacing.space4})`,
-    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacing.space4})`,
+    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
   },
   fullBleed: {
     paddingInlineStart: 0,
@@ -33,11 +33,11 @@ const styles = stylex.create({
   divider: {
     borderBlockEndWidth: 1,
     borderBlockEndStyle: 'solid',
-    borderBlockEndColor: color.divider,
+    borderBlockEndColor: colorVars['--color-divider'],
   },
   // When no divider, collapse spacing to avoid double-padding with content
   collapseBottom: {
-    marginBlockEnd: `calc(-1 * var(--layout-padding-inner-y, ${spacing.space4}))`,
+    marginBlockEnd: `calc(-1 * var(--layout-padding-inner-y, ${spacingVars['--spacing-4']}))`,
   },
 });
 

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
@@ -12,7 +12,7 @@
 import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
 import {forwardRef, useContext} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {color, spacing} from '../../theme/tokens.stylex';
+import {colorVars, spacingVars} from '../../theme/tokens.stylex';
 import {XDSLayoutAreaContext} from './XDSLayoutAreaContext';
 import {XDSLayoutSlotsContext} from './XDSLayoutSlotsContext';
 
@@ -22,26 +22,26 @@ const styles = stylex.create({
     flexShrink: 0,
     overflow: 'clip',
     // Default: inner padding on all sides (will be overridden by position-specific styles)
-    paddingInlineStart: `var(--layout-padding-inner-x, ${spacing.space4})`,
-    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacing.space4})`,
-    paddingBlockStart: `var(--layout-padding-inner-y, ${spacing.space4})`,
-    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacing.space4})`,
+    paddingInlineStart: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
+    paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
+    paddingBlockStart: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
   },
   // Start panel: outer-x on left edge
   startPanel: {
-    paddingInlineStart: `var(--layout-padding-outer-x, ${spacing.space4})`,
+    paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
   },
   // End panel: outer-x on right edge
   endPanel: {
-    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacing.space4})`,
+    paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
   },
   // When no header: outer-y on top
   noHeader: {
-    paddingBlockStart: `var(--layout-padding-outer-y, ${spacing.space4})`,
+    paddingBlockStart: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
   // When no footer: outer-y on bottom
   noFooter: {
-    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacing.space4})`,
+    paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
   fullBleed: {
     paddingInlineStart: 0,
@@ -56,22 +56,22 @@ const styles = stylex.create({
   dividerEnd: {
     borderInlineEndWidth: 1,
     borderInlineEndStyle: 'solid',
-    borderInlineEndColor: color.divider,
+    borderInlineEndColor: colorVars['--color-divider'],
   },
   // For end panel: divider on start edge
   dividerStart: {
     borderInlineStartWidth: 1,
     borderInlineStartStyle: 'solid',
-    borderInlineStartColor: color.divider,
+    borderInlineStartColor: colorVars['--color-divider'],
   },
   // When no divider, collapse spacing on the side facing content
   // Start panel: collapse end (right in LTR) to merge with content
   // End panel: collapse start (left in LTR) to merge with content
   collapseStart: {
-    marginInlineStart: `calc(-1 * var(--layout-padding-inner-x, ${spacing.space4}))`,
+    marginInlineStart: `calc(-1 * var(--layout-padding-inner-x, ${spacingVars['--spacing-4']}))`,
   },
   collapseEnd: {
-    marginInlineEnd: `calc(-1 * var(--layout-padding-inner-x, ${spacing.space4}))`,
+    marginInlineEnd: `calc(-1 * var(--layout-padding-inner-x, ${spacingVars['--spacing-4']}))`,
   },
 });
 

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -12,7 +12,7 @@
 
 import {forwardRef, type HTMLAttributes} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {color, radius} from '../theme/tokens.stylex';
+import {colorVars, radiusVars} from '../theme/tokens.stylex';
 
 // =============================================================================
 // Animation Timing Constants
@@ -52,8 +52,9 @@ const skeletonFade = stylex.keyframes({
 const styles = stylex.create({
   root: {
     backgroundColor: {
-      default: color.glimmer,
-      '@media (prefers-contrast: more)': color.glimmerHighContrast,
+      default: colorVars['--color-glimmer'],
+      '@media (prefers-contrast: more)':
+        colorVars['--color-glimmer-high-contrast'],
     },
     opacity: 0.25,
   },
@@ -71,19 +72,19 @@ const radiusStyles = stylex.create({
     borderRadius: 0,
   },
   rounded: {
-    borderRadius: radius.rounded,
+    borderRadius: radiusVars['--radius-rounded'],
   },
   container: {
-    borderRadius: radius.container,
+    borderRadius: radiusVars['--radius-container'],
   },
   element: {
-    borderRadius: radius.element,
+    borderRadius: radiusVars['--radius-element'],
   },
   content: {
-    borderRadius: radius.content,
+    borderRadius: radiusVars['--radius-content'],
   },
   inner: {
-    borderRadius: radius.inner,
+    borderRadius: radiusVars['--radius-inner'],
   },
 });
 

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -14,11 +14,11 @@
 import {forwardRef, useId, type ChangeEvent} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
-  color,
-  spacing,
-  radius,
-  transition,
-  typography,
+  colorVars,
+  spacingVars,
+  radiusVars,
+  transitionVars,
+  typographyVars,
 } from '../theme/tokens.stylex';
 import {XDSField} from '../Field';
 
@@ -26,32 +26,32 @@ const styles = stylex.create({
   input: {
     display: 'block',
     width: '100%',
-    paddingBlock: spacing.space2,
-    paddingInline: spacing.space3,
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
     borderWidth: '1px',
     borderStyle: 'solid',
     borderColor: {
-      default: color.dividerEmphasized,
-      ':hover': color.dividerHighContrast,
+      default: colorVars['--color-divider-emphasized'],
+      ':hover': colorVars['--color-divider-high-contrast'],
     },
-    borderRadius: radius.content,
-    fontFamily: typography.fontFamilyBody,
+    borderRadius: radiusVars['--radius-content'],
+    fontFamily: typographyVars['--font-body'],
     fontSize: '0.875rem',
     lineHeight: 1.429,
-    color: color.textPrimary,
-    backgroundColor: color.surface,
+    color: colorVars['--color-text-primary'],
+    backgroundColor: colorVars['--color-surface'],
     transitionProperty: 'border-color, outline',
-    transitionDuration: transition.fast,
+    transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus': `2px solid ${color.focusOutline}`,
+      ':focus': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
       ':focus': '1px',
     },
     '::placeholder': {
-      color: color.textPlaceholder,
+      color: colorVars['--color-text-placeholder'],
     },
   },
 });

--- a/packages/core/src/theme/Theme.tsx
+++ b/packages/core/src/theme/Theme.tsx
@@ -20,7 +20,7 @@ import React, {useContext, useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {Theme as ThemeType, ThemeMode} from './types';
 import {ThemeContext, type ThemeContextValue} from './ThemeContext';
-import {color} from './tokens.stylex';
+import {colorVars, typographyVars} from './tokens.stylex';
 
 // Re-export for backwards compatibility
 export {ThemeContext} from './ThemeContext';
@@ -54,7 +54,8 @@ interface ThemeProps {
 const wrapperStyles = stylex.create({
   base: {
     display: 'contents',
-    color: color.textPrimary,
+    color: colorVars['--color-text-primary'],
+    fontFamily: typographyVars['--font-body'],
   },
   light: {
     colorScheme: 'light',

--- a/packages/core/src/theme/defaultTheme.stylex.ts
+++ b/packages/core/src/theme/defaultTheme.stylex.ts
@@ -13,6 +13,14 @@
 
 import * as stylex from '@stylexjs/stylex';
 import type {Theme} from './types';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  elevationVars,
+  transitionVars,
+  typographyVars,
+} from './tokens.stylex';
 import type {
   ColorVarName,
   SpacingVarName,
@@ -20,12 +28,18 @@ import type {
   ElevationVarName,
   TransitionVarName,
   TypographyVarName,
+  BaseColorRaw,
+  BaseSpacingRaw,
+  BaseRadiusRaw,
+  BaseElevationRaw,
+  BaseTransitionRaw,
+  BaseTypographyRaw,
 } from './tokens.stylex';
 
 // =============================================================================
 // Raw Theme Values
 // =============================================================================
-// Define raw values as plain objects first, then use in stylex.create
+// Define raw values as plain objects first, then use in createTheme
 // This allows programmatic access to values (e.g., parsing light-dark())
 
 const colorRaw = {
@@ -188,18 +202,42 @@ const typographyRaw = {
 } as const satisfies Record<TypographyVarName, string>;
 
 // =============================================================================
-// Theme Styles
+// Theme Overrides using createTheme
 // =============================================================================
-// Create StyleX styles from raw values for applying to elements
 
-const themeStyles = stylex.create({
-  colors: colorRaw,
-  spacing: spacingRaw,
-  radius: radiusRaw,
-  elevation: elevationRaw,
-  transition: transitionRaw,
-  typography: typographyRaw,
-});
+const colorTheme = stylex.createTheme(
+  colorVars,
+  colorRaw as unknown as BaseColorRaw,
+);
+
+const spacingTheme = stylex.createTheme(
+  spacingVars,
+  spacingRaw as unknown as BaseSpacingRaw,
+);
+
+const radiusTheme = stylex.createTheme(
+  radiusVars,
+  radiusRaw as unknown as BaseRadiusRaw,
+);
+
+const elevationTheme = stylex.createTheme(
+  elevationVars,
+  elevationRaw as unknown as BaseElevationRaw,
+);
+
+const transitionTheme = stylex.createTheme(
+  transitionVars,
+  transitionRaw as unknown as BaseTransitionRaw,
+);
+
+const typographyTheme = stylex.createTheme(
+  typographyVars,
+  typographyRaw as unknown as BaseTypographyRaw,
+);
+
+// =============================================================================
+// Component Style Overrides
+// =============================================================================
 
 const buttonVariants = stylex.create({
   secondary: {
@@ -215,12 +253,12 @@ const buttonVariants = stylex.create({
 export const defaultTheme: Theme = {
   name: 'default',
   styles: {
-    colors: themeStyles.colors,
-    spacing: themeStyles.spacing,
-    radius: themeStyles.radius,
-    elevation: themeStyles.elevation,
-    transition: themeStyles.transition,
-    typography: themeStyles.typography,
+    colors: colorTheme,
+    spacing: spacingTheme,
+    radius: radiusTheme,
+    elevation: elevationTheme,
+    transition: transitionTheme,
+    typography: typographyTheme,
   },
   raw: {
     colors: colorRaw,

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -15,22 +15,34 @@ export {neutralTheme} from './neutralTheme.stylex';
 
 // Export tokens for use in custom components
 export {
-  color,
-  spacing,
-  radius,
-  elevation,
-  transition,
-  typography,
+  colorRaw,
+  spacingRaw,
+  radiusRaw,
+  elevationRaw,
+  transitionRaw,
+  typographyRaw,
+  colorVars,
+  spacingVars,
+  radiusVars,
+  elevationVars,
+  transitionVars,
+  typographyVars,
 } from './tokens.stylex';
 
 // Export token key types for theme authoring
 export type {
-  ColorTokenKey,
-  SpacingTokenKey,
-  RadiusTokenKey,
-  ElevationTokenKey,
-  TransitionTokenKey,
-  TypographyTokenKey,
+  ColorVarName,
+  SpacingVarName,
+  RadiusVarName,
+  ElevationVarName,
+  TransitionVarName,
+  TypographyVarName,
+  BaseColorRaw,
+  BaseSpacingRaw,
+  BaseRadiusRaw,
+  BaseElevationRaw,
+  BaseTransitionRaw,
+  BaseTypographyRaw,
 } from './tokens.stylex';
 
 export type {

--- a/packages/core/src/theme/neutralTheme.stylex.ts
+++ b/packages/core/src/theme/neutralTheme.stylex.ts
@@ -15,6 +15,14 @@
 
 import * as stylex from '@stylexjs/stylex';
 import type {Theme} from './types';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  elevationVars,
+  transitionVars,
+  typographyVars,
+} from './tokens.stylex';
 import type {
   ColorVarName,
   SpacingVarName,
@@ -22,13 +30,18 @@ import type {
   ElevationVarName,
   TransitionVarName,
   TypographyVarName,
+  BaseColorRaw,
+  BaseSpacingRaw,
+  BaseRadiusRaw,
+  BaseElevationRaw,
+  BaseTransitionRaw,
+  BaseTypographyRaw,
 } from './tokens.stylex';
-import {color, spacing} from './tokens.stylex';
 
 // =============================================================================
 // Raw Theme Values
 // =============================================================================
-// Define raw values as plain objects first, then use in stylex.create
+// Define raw values as plain objects first, then use in createTheme
 // This allows programmatic access to values (e.g., parsing light-dark())
 
 const colorRaw = {
@@ -232,18 +245,38 @@ const typographyRaw = {
 } as const satisfies Record<TypographyVarName, string>;
 
 // =============================================================================
-// Theme Styles
+// Theme Overrides using createTheme
 // =============================================================================
-// Create StyleX styles from raw values for applying to elements
 
-const themeStyles = stylex.create({
-  colors: colorRaw,
-  spacing: spacingRaw,
-  radius: radiusRaw,
-  elevation: elevationRaw,
-  transition: transitionRaw,
-  typography: typographyRaw,
-});
+const colorTheme = stylex.createTheme(
+  colorVars,
+  colorRaw as unknown as BaseColorRaw,
+);
+
+const spacingTheme = stylex.createTheme(
+  spacingVars,
+  spacingRaw as unknown as BaseSpacingRaw,
+);
+
+const radiusTheme = stylex.createTheme(
+  radiusVars,
+  radiusRaw as unknown as BaseRadiusRaw,
+);
+
+const elevationTheme = stylex.createTheme(
+  elevationVars,
+  elevationRaw as unknown as BaseElevationRaw,
+);
+
+const transitionTheme = stylex.createTheme(
+  transitionVars,
+  transitionRaw as unknown as BaseTransitionRaw,
+);
+
+const typographyTheme = stylex.createTheme(
+  typographyVars,
+  typographyRaw as unknown as BaseTypographyRaw,
+);
 
 // =============================================================================
 // Component Style Overrides
@@ -261,39 +294,39 @@ const buttonVariants = stylex.create({
   secondary: {
     borderWidth: '1px',
     borderStyle: 'solid',
-    borderColor: color.divider,
+    borderColor: colorVars['--color-divider'],
   },
 });
 
 const cardStyles = stylex.create({
   // Override card default padding to 12px for tighter layout
   base: {
-    '--layout-padding-inner-x': spacing.space3,
-    '--layout-padding-inner-y': spacing.space3,
-    '--layout-padding-outer-x': spacing.space3,
-    '--layout-padding-outer-y': spacing.space3,
+    '--layout-padding-inner-x': spacingVars['--spacing-3'],
+    '--layout-padding-inner-y': spacingVars['--spacing-3'],
+    '--layout-padding-outer-x': spacingVars['--spacing-3'],
+    '--layout-padding-outer-y': spacingVars['--spacing-3'],
   },
 });
 
 const sectionVariants = stylex.create({
   // Override section padding to 12px for tighter layout
   section: {
-    '--layout-padding-inner-x': spacing.space3,
-    '--layout-padding-inner-y': spacing.space3,
-    '--layout-padding-outer-x': spacing.space3,
-    '--layout-padding-outer-y': spacing.space3,
+    '--layout-padding-inner-x': spacingVars['--spacing-3'],
+    '--layout-padding-inner-y': spacingVars['--spacing-3'],
+    '--layout-padding-outer-x': spacingVars['--spacing-3'],
+    '--layout-padding-outer-y': spacingVars['--spacing-3'],
   },
   transparent: {
-    '--layout-padding-inner-x': spacing.space3,
-    '--layout-padding-inner-y': spacing.space3,
-    '--layout-padding-outer-x': spacing.space3,
-    '--layout-padding-outer-y': spacing.space3,
+    '--layout-padding-inner-x': spacingVars['--spacing-3'],
+    '--layout-padding-inner-y': spacingVars['--spacing-3'],
+    '--layout-padding-outer-x': spacingVars['--spacing-3'],
+    '--layout-padding-outer-y': spacingVars['--spacing-3'],
   },
   wash: {
-    '--layout-padding-inner-x': spacing.space3,
-    '--layout-padding-inner-y': spacing.space3,
-    '--layout-padding-outer-x': spacing.space3,
-    '--layout-padding-outer-y': spacing.space3,
+    '--layout-padding-inner-x': spacingVars['--spacing-3'],
+    '--layout-padding-inner-y': spacingVars['--spacing-3'],
+    '--layout-padding-outer-x': spacingVars['--spacing-3'],
+    '--layout-padding-outer-y': spacingVars['--spacing-3'],
   },
 });
 
@@ -304,12 +337,12 @@ const sectionVariants = stylex.create({
 export const neutralTheme: Theme = {
   name: 'neutral',
   styles: {
-    colors: themeStyles.colors,
-    spacing: themeStyles.spacing,
-    radius: themeStyles.radius,
-    elevation: themeStyles.elevation,
-    transition: themeStyles.transition,
-    typography: themeStyles.typography,
+    colors: colorTheme,
+    spacing: spacingTheme,
+    radius: radiusTheme,
+    elevation: elevationTheme,
+    transition: transitionTheme,
+    typography: typographyTheme,
   },
   raw: {
     colors: colorRaw,

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -1,8 +1,9 @@
 /**
  * XDS Design Tokens
  *
- * Defines all design tokens using StyleX defineConsts.
- * These reference CSS variables that are set by theme files.
+ * Defines all design tokens using StyleX defineVars.
+ * - *Raw: Plain objects with default values (can be reused by themes)
+ * - *Vars: CSS custom properties that themes can override via createTheme
  */
 
 import * as stylex from '@stylexjs/stylex';
@@ -11,302 +12,213 @@ import * as stylex from '@stylexjs/stylex';
 // Color Tokens
 // =============================================================================
 
-export const color = stylex.defineConsts({
+export const colorRaw = {
   // Core semantic
-  accent: 'var(--color-accent)',
-  accentDeemphasized: 'var(--color-accent-deemphasized)',
-  accentText: 'var(--color-accent-text)',
-  surface: 'var(--color-surface)',
-  wash: 'var(--color-wash)',
-  overlay: 'var(--color-overlay)',
-  hoverOverlay: 'var(--color-hover-overlay)',
-  pressedOverlay: 'var(--color-pressed-overlay)',
-  focusOutline: 'var(--color-focus-outline)',
-  deemphasized: 'var(--color-deemphasized)',
+  '--color-accent': '#0064E0',
+  '--color-accent-deemphasized': '#0082FB33',
+  '--color-accent-text': '#0143B5',
+  '--color-surface': '#FFFFFF',
+  '--color-wash': '#F1F4F7',
+  '--color-overlay': '#01122866',
+  '--color-hover-overlay': '#0536590C',
+  '--color-pressed-overlay': '#05365919',
+  '--color-focus-outline': '#042F97',
+  '--color-deemphasized': '#0536590C',
 
   // Text
-  textPrimary: 'var(--color-text-primary)',
-  textSecondary: 'var(--color-text-secondary)',
-  textDisabled: 'var(--color-text-disabled)',
-  textLink: 'var(--color-text-link)',
-  textPlaceholder: 'var(--color-text-placeholder)',
+  '--color-text-primary': '#0A1317',
+  '--color-text-secondary': '#4E606F',
+  '--color-text-disabled': '#A4B0BC',
+  '--color-text-link': '#0064E0',
+  '--color-text-placeholder': '#4E606F',
 
   // Icon
-  iconPrimary: 'var(--color-icon-primary)',
-  iconSecondary: 'var(--color-icon-secondary)',
-  iconTertiary: 'var(--color-icon-tertiary)',
-  iconDisabled: 'var(--color-icon-disabled)',
+  '--color-icon-primary': '#0A1317',
+  '--color-icon-secondary': '#4E606F',
+  '--color-icon-tertiary': '#748695',
+  '--color-icon-disabled': '#A4B0BC',
 
   // Surface variants
-  card: 'var(--color-card)',
-  popover: 'var(--color-popover)',
-  navbar: 'var(--color-navbar)',
+  '--color-card': '#FFFFFF',
+  '--color-popover': '#FFFFFF',
+  '--color-navbar': '#FFFFFF',
 
   // Status/Sentiment
-  positive: 'var(--color-positive)',
-  positiveDeemphasized: 'var(--color-positive-deemphasized)',
-  negative: 'var(--color-negative)',
-  negativeDeemphasized: 'var(--color-negative-deemphasized)',
-  warning: 'var(--color-warning)',
-  warningDeemphasized: 'var(--color-warning-deemphasized)',
-  educational: 'var(--color-educational)',
-  educationalDeemphasized: 'var(--color-educational-deemphasized)',
+  '--color-positive': '#0D8626',
+  '--color-positive-deemphasized': '#0B991F33',
+  '--color-negative': '#E3193B',
+  '--color-negative-deemphasized': '#E3193B33',
+  '--color-warning': '#E9AF08',
+  '--color-warning-deemphasized': '#E2A40033',
+  '--color-educational': '#5B08D8',
+  '--color-educational-deemphasized': '#7952FF33',
 
   // Divider
-  divider: 'var(--color-divider)',
-  dividerHighContrast: 'var(--color-divider-high-contrast)',
-  dividerEmphasized: 'var(--color-divider-emphasized)',
+  '--color-divider': '#05365919',
+  '--color-divider-high-contrast': '#647685',
+  '--color-divider-emphasized': '#CCD3DB',
 
   // Disabled/Effects
-  disabledOverlay: 'var(--color-disabled-overlay)',
-  glimmer: 'var(--color-glimmer)',
-  glimmerHighContrast: 'var(--color-glimmer-high-contrast)',
-  shadowElevation: 'var(--color-shadow-elevation)',
+  '--color-disabled-overlay': '#FFFFFF7F',
+  '--color-glimmer': '#CCD3DB',
+  '--color-glimmer-high-contrast': '#A4B0BC',
+  '--color-shadow-elevation': 'rgba(5, 54, 89, 0.1)',
 
-  // Literal color sets - Blue
-  blueBackground: 'var(--color-blue-background)',
-  blueBorder: 'var(--color-blue-border)',
-  blueIcon: 'var(--color-blue-icon)',
-  blueText: 'var(--color-blue-text)',
+  // Blue
+  '--color-blue-background': '#0171E333',
+  '--color-blue-border': '#0171E3',
+  '--color-blue-icon': '#0064E0',
+  '--color-blue-text': '#042F97',
 
   // Cyan
-  cyanBackground: 'var(--color-cyan-background)',
-  cyanBorder: 'var(--color-cyan-border)',
-  cyanIcon: 'var(--color-cyan-icon)',
-  cyanText: 'var(--color-cyan-text)',
+  '--color-cyan-background': '#00BCD433',
+  '--color-cyan-border': '#00BCD4',
+  '--color-cyan-icon': '#00ACC1',
+  '--color-cyan-text': '#006064',
 
   // Gray
-  grayBackground: 'var(--color-gray-background)',
-  grayBorder: 'var(--color-gray-border)',
-  grayIcon: 'var(--color-gray-icon)',
-  grayText: 'var(--color-gray-text)',
+  '--color-gray-background': '#0A131733',
+  '--color-gray-border': '#647685',
+  '--color-gray-icon': '#4E606F',
+  '--color-gray-text': '#0A1317',
 
   // Green
-  greenBackground: 'var(--color-green-background)',
-  greenBorder: 'var(--color-green-border)',
-  greenIcon: 'var(--color-green-icon)',
-  greenText: 'var(--color-green-text)',
+  '--color-green-background': '#24BB5E33',
+  '--color-green-border': '#24BB5E',
+  '--color-green-icon': '#0D8626',
+  '--color-green-text': '#09441F',
 
   // Orange
-  orangeBackground: 'var(--color-orange-background)',
-  orangeBorder: 'var(--color-orange-border)',
-  orangeIcon: 'var(--color-orange-icon)',
-  orangeText: 'var(--color-orange-text)',
+  '--color-orange-background': '#F2790233',
+  '--color-orange-border': '#F27902',
+  '--color-orange-icon': '#E9690B',
+  '--color-orange-text': '#6B2203',
 
   // Pink
-  pinkBackground: 'var(--color-pink-background)',
-  pinkBorder: 'var(--color-pink-border)',
-  pinkIcon: 'var(--color-pink-icon)',
-  pinkText: 'var(--color-pink-text)',
+  '--color-pink-background': '#E91E6333',
+  '--color-pink-border': '#E91E63',
+  '--color-pink-icon': '#C2185B',
+  '--color-pink-text': '#880E4F',
 
   // Purple
-  purpleBackground: 'var(--color-purple-background)',
-  purpleBorder: 'var(--color-purple-border)',
-  purpleIcon: 'var(--color-purple-icon)',
-  purpleText: 'var(--color-purple-text)',
+  '--color-purple-background': '#7952FF33',
+  '--color-purple-border': '#7952FF',
+  '--color-purple-icon': '#5B08D8',
+  '--color-purple-text': '#3E0697',
 
   // Red
-  redBackground: 'var(--color-red-background)',
-  redBorder: 'var(--color-red-border)',
-  redIcon: 'var(--color-red-icon)',
-  redText: 'var(--color-red-text)',
+  '--color-red-background': '#E3193B33',
+  '--color-red-border': '#E3193B',
+  '--color-red-icon': '#D31130',
+  '--color-red-text': '#7B0210',
 
   // Teal
-  tealBackground: 'var(--color-teal-background)',
-  tealBorder: 'var(--color-teal-border)',
-  tealIcon: 'var(--color-teal-icon)',
-  tealText: 'var(--color-teal-text)',
+  '--color-teal-background': '#0DB7AF33',
+  '--color-teal-border': '#0DB7AF',
+  '--color-teal-icon': '#009688',
+  '--color-teal-text': '#083943',
 
   // Yellow
-  yellowBackground: 'var(--color-yellow-background)',
-  yellowBorder: 'var(--color-yellow-border)',
-  yellowIcon: 'var(--color-yellow-icon)',
-  yellowText: 'var(--color-yellow-text)',
-});
+  '--color-yellow-background': '#FFEB3B33',
+  '--color-yellow-border': '#FFEB3B',
+  '--color-yellow-icon': '#FBC02D',
+  '--color-yellow-text': '#F57F17',
+} as const;
+
+export const colorVars = stylex.defineVars(colorRaw);
 
 // =============================================================================
 // Spacing Tokens
 // =============================================================================
 
-export const spacing = stylex.defineConsts({
-  space0: 'var(--spacing-0)',
-  space0_5: 'var(--spacing-0-5)',
-  space1: 'var(--spacing-1)',
-  space2: 'var(--spacing-2)',
-  space3: 'var(--spacing-3)',
-  space4: 'var(--spacing-4)',
-  space5: 'var(--spacing-5)',
-  space6: 'var(--spacing-6)',
-  space7: 'var(--spacing-7)',
-});
+export const spacingRaw = {
+  '--spacing-0': '0px',
+  '--spacing-0-5': '2px',
+  '--spacing-1': '4px',
+  '--spacing-2': '8px',
+  '--spacing-3': '12px',
+  '--spacing-4': '16px',
+  '--spacing-5': '20px',
+  '--spacing-6': '24px',
+  '--spacing-7': '32px',
+} as const;
+
+export const spacingVars = stylex.defineVars(spacingRaw);
 
 // =============================================================================
 // Radius Tokens
 // =============================================================================
 
-export const radius = stylex.defineConsts({
-  rounded: 'var(--radius-rounded)',
-  container: 'var(--radius-container)',
-  element: 'var(--radius-element)',
-  content: 'var(--radius-content)',
-  inner: 'var(--radius-inner)',
-});
+export const radiusRaw = {
+  '--radius-rounded': '9999px',
+  '--radius-container': '12px',
+  '--radius-element': '8px',
+  '--radius-content': '4px',
+  '--radius-inner': '0px',
+} as const;
+
+export const radiusVars = stylex.defineVars(radiusRaw);
 
 // =============================================================================
 // Elevation Tokens
 // =============================================================================
 
-export const elevation = stylex.defineConsts({
-  base: 'var(--elevation-base)',
-  thumb: 'var(--elevation-thumb)',
-  dialog: 'var(--elevation-dialog)',
-  hover: 'var(--elevation-hover)',
-  menu: 'var(--elevation-menu)',
-});
+export const elevationRaw = {
+  '--elevation-base': '0px 0px 1px rgba(0, 0, 0, 0.1)',
+  '--elevation-thumb': '0 1px 3px rgba(0, 0, 0, 0.2)',
+  '--elevation-dialog':
+    '0px 2px 2px rgba(0, 0, 0, 0.1), 0px 8px 24px rgba(0, 0, 0, 0.1)',
+  '--elevation-hover':
+    '0px 1px 2px rgba(0, 0, 0, 0.1), 0px 2px 12px rgba(0, 0, 0, 0.1)',
+  '--elevation-menu':
+    '0px 1px 1px rgba(0, 0, 0, 0.1), 0px 2px 8px rgba(0, 0, 0, 0.1)',
+} as const;
+
+export const elevationVars = stylex.defineVars(elevationRaw);
 
 // =============================================================================
 // Transition Tokens
 // =============================================================================
 
-export const transition = stylex.defineConsts({
-  fast: 'var(--transition-fast)',
-  normal: 'var(--transition-normal)',
-});
+export const transitionRaw = {
+  '--transition-fast': '0.15s ease',
+  '--transition-normal': '0.2s ease',
+} as const;
+
+export const transitionVars = stylex.defineVars(transitionRaw);
 
 // =============================================================================
 // Typography Tokens
 // =============================================================================
 
-export const typography = stylex.defineConsts({
-  fontFamilyBody: 'var(--font-body)',
-  fontFamilyCode: 'var(--font-code)',
-  fontFamilyHeading: 'var(--font-heading)',
-});
+export const typographyRaw = {
+  '--font-body':
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+  '--font-code': '"SF Mono", Monaco, Consolas, monospace',
+  '--font-heading':
+    '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+} as const;
+
+export const typographyVars = stylex.defineVars(typographyRaw);
 
 // =============================================================================
-// Token Key Types - For theme authoring
+// Token Types
 // =============================================================================
 
-export type ColorTokenKey = keyof typeof color;
-export type SpacingTokenKey = keyof typeof spacing;
-export type RadiusTokenKey = keyof typeof radius;
-export type ElevationTokenKey = keyof typeof elevation;
-export type TransitionTokenKey = keyof typeof transition;
-export type TypographyTokenKey = keyof typeof typography;
+export type ColorVarName = keyof typeof colorRaw;
+export type SpacingVarName = keyof typeof spacingRaw;
+export type RadiusVarName = keyof typeof radiusRaw;
+export type ElevationVarName = keyof typeof elevationRaw;
+export type TransitionVarName = keyof typeof transitionRaw;
+export type TypographyVarName = keyof typeof typographyRaw;
 
-// =============================================================================
-// CSS Variable Name Types - For strict theme validation
-// =============================================================================
-// These types ensure theme files define exactly the required CSS variables.
-// If you add/remove a token above, update the corresponding VarName type.
-
-export type ColorVarName =
-  | '--color-accent'
-  | '--color-accent-deemphasized'
-  | '--color-accent-text'
-  | '--color-surface'
-  | '--color-wash'
-  | '--color-overlay'
-  | '--color-hover-overlay'
-  | '--color-pressed-overlay'
-  | '--color-focus-outline'
-  | '--color-deemphasized'
-  | '--color-text-primary'
-  | '--color-text-secondary'
-  | '--color-text-disabled'
-  | '--color-text-link'
-  | '--color-text-placeholder'
-  | '--color-icon-primary'
-  | '--color-icon-secondary'
-  | '--color-icon-tertiary'
-  | '--color-icon-disabled'
-  | '--color-card'
-  | '--color-popover'
-  | '--color-navbar'
-  | '--color-positive'
-  | '--color-positive-deemphasized'
-  | '--color-negative'
-  | '--color-negative-deemphasized'
-  | '--color-warning'
-  | '--color-warning-deemphasized'
-  | '--color-educational'
-  | '--color-educational-deemphasized'
-  | '--color-divider'
-  | '--color-divider-high-contrast'
-  | '--color-divider-emphasized'
-  | '--color-disabled-overlay'
-  | '--color-glimmer'
-  | '--color-glimmer-high-contrast'
-  | '--color-shadow-elevation'
-  | '--color-blue-background'
-  | '--color-blue-border'
-  | '--color-blue-icon'
-  | '--color-blue-text'
-  | '--color-cyan-background'
-  | '--color-cyan-border'
-  | '--color-cyan-icon'
-  | '--color-cyan-text'
-  | '--color-gray-background'
-  | '--color-gray-border'
-  | '--color-gray-icon'
-  | '--color-gray-text'
-  | '--color-green-background'
-  | '--color-green-border'
-  | '--color-green-icon'
-  | '--color-green-text'
-  | '--color-orange-background'
-  | '--color-orange-border'
-  | '--color-orange-icon'
-  | '--color-orange-text'
-  | '--color-pink-background'
-  | '--color-pink-border'
-  | '--color-pink-icon'
-  | '--color-pink-text'
-  | '--color-purple-background'
-  | '--color-purple-border'
-  | '--color-purple-icon'
-  | '--color-purple-text'
-  | '--color-red-background'
-  | '--color-red-border'
-  | '--color-red-icon'
-  | '--color-red-text'
-  | '--color-teal-background'
-  | '--color-teal-border'
-  | '--color-teal-icon'
-  | '--color-teal-text'
-  | '--color-yellow-background'
-  | '--color-yellow-border'
-  | '--color-yellow-icon'
-  | '--color-yellow-text';
-
-export type SpacingVarName =
-  | '--spacing-0'
-  | '--spacing-0-5'
-  | '--spacing-1'
-  | '--spacing-2'
-  | '--spacing-3'
-  | '--spacing-4'
-  | '--spacing-5'
-  | '--spacing-6'
-  | '--spacing-7';
-
-export type RadiusVarName =
-  | '--radius-rounded'
-  | '--radius-container'
-  | '--radius-element'
-  | '--radius-content'
-  | '--radius-inner';
-
-export type ElevationVarName =
-  | '--elevation-base'
-  | '--elevation-thumb'
-  | '--elevation-dialog'
-  | '--elevation-hover'
-  | '--elevation-menu';
-
-export type TransitionVarName = '--transition-fast' | '--transition-normal';
-
-export type TypographyVarName =
-  | '--font-body'
-  | '--font-code'
-  | '--font-heading';
+// Base raw types for createTheme casting
+// StyleX's createTheme requires exact literal types from defineVars.
+// Theme overrides have different values, so we cast through these types.
+// Type safety is maintained via `as const satisfies Record<*VarName, string>`.
+export type BaseColorRaw = typeof colorRaw;
+export type BaseSpacingRaw = typeof spacingRaw;
+export type BaseRadiusRaw = typeof radiusRaw;
+export type BaseElevationRaw = typeof elevationRaw;
+export type BaseTransitionRaw = typeof transitionRaw;
+export type BaseTypographyRaw = typeof typographyRaw;


### PR DESCRIPTION
## Context
Reworking the general theming infrastructure from https://github.com/facebookexperimental/xds/pull/16 

The theming flow looks something like this:
- All raw hex/rgb/static values for colors, spacing, etc are stored in `defineConsts` calls.  `defineConsts` transpiles to a plain JS object that is inlined at build time, generates no CSS, and its values can be imported and used within `stylex.create` or `stylex.defineVars` files as needed.
    - Alternatively, we can still use raw JS objects if we never need to use these in `create` calls and we don't care about repeating across files. But it'll get messy
- `defineVars` uses the `defineConsts` values and `--` keys, which expose the variable name and allow users to modify them as CSS variables anywhere.

```
export const colorRaw = stylex.defineConsts({
    '--xdsAccent': colorTokens.accent,
    '--xdsSurface': colorTokens.surface,
    // ... map all tokens
  },
});

export const colorTokens = stylex.defineVars({
   '--xds-accent': colorRaw['--xdsAccent']
   '--xds-surface': colorRaw['--xdsSurface']
});

export const neutralColors = stylex.createTheme(colorTokens, {overrides})

// Not settled on the shape of the export here or the keys we want to expose, but we can iterate
export themeTokens = {
   colors: colorRaw,
   ...
}

```

There are two primary issues to using create/props instead of defineVars/createTheme in https://github.com/facebookexperimental/xds/pull/16 

1, Losing the VarGroup guarantee that each theme sets all variables (and unset keys are reset)
2. It creates a single class to set all variables and not one class per variable. (performance critical)

## Blockers/Todos
- [ ] Replace camelCase keys with -- in defineConsts?
- [ ] Reuse base token values across tokens + defaultTheme + neutralTheme
- [ ] Refactor, clean types, update docs

One option is to also use `--` keys in defineConsts as well instead of the camelCased key for ease of use. Currently we disallow such keys in `defineConsts` for relatively arbitrary (safety/obfuscation) reasons but opening https://github.com/facebook/stylex/pull/1460 as an option to fix this

We could have a system that maps cleanly from defineVars -> defineCosts (one camel cased, another --)

## Testing
Storybook theming works

https://github.com/user-attachments/assets/f2b7d432-22d1-44c8-81e2-4cb0f80d707a


