### PR TITLE
Add XDSCard and XDSSection components with nested layout support

### DIFF
--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -1,0 +1,299 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSCard, XDSSection, XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSLayout, XDSLayoutHeader, XDSLayoutContent, XDSLayoutFooter} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {colorVars, spacingVars, typographyVars} from '@xds/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  pageWrapper: {
+    backgroundColor: colorVars['--color-wash'],
+    padding: spacingVars['--spacing-6'],
+  },
+  text: {
+    fontFamily: typographyVars['--font-body'],
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+  textSecondary: {
+    color: colorVars['--color-text-secondary'],
+    fontSize: 14,
+  },
+  storyWrapper: {
+    display: 'flex',
+    gap: spacingVars['--spacing-6'],
+    flexWrap: 'wrap',
+  },
+  heading: {
+    margin: `0 0 ${spacingVars['--spacing-2']} 0`,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: 14,
+    color: colorVars['--color-text-secondary'],
+  },
+});
+
+const meta: Meta<typeof XDSCard> = {
+  title: 'Layout/XDSCard',
+  component: XDSCard,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    width: {
+      control: {type: 'range', min: 100, max: 800, step: 10},
+      description: 'Width in pixels',
+    },
+    height: {
+      control: {type: 'range', min: 100, max: 600, step: 10},
+      description: 'Height in pixels',
+    },
+    maxWidth: {
+      control: {type: 'range', min: 100, max: 800, step: 10},
+      description: 'Maximum width in pixels',
+    },
+    minHeight: {
+      control: {type: 'range', min: 100, max: 600, step: 10},
+      description: 'Minimum height in pixels',
+    },
+    isFullBleed: {
+      control: 'boolean',
+      description: 'Removes internal padding',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCard>;
+
+export const Default: Story = {
+  args: {
+    width: 300,
+  },
+  render: (args) => (
+    <XDSCard {...args}>
+      <p {...stylex.props(styles.text)}>
+        Simple content inside a card. The card provides default padding via
+        the --container-padding CSS variable.
+      </p>
+    </XDSCard>
+  ),
+};
+
+export const WithSimpleContent: Story = {
+  render: () => (
+    <XDSCard width={320}>
+      <XDSVStack gap="space2">
+        <h3 {...stylex.props(styles.text)}>Card Title</h3>
+        <p {...stylex.props(styles.text, styles.textSecondary)}>
+          This card contains simple content without XDSLayout.
+          The container padding is applied automatically.
+        </p>
+      </XDSVStack>
+    </XDSCard>
+  ),
+};
+
+export const WithInnerLayout: Story = {
+  render: () => (
+    <XDSCard width={350}>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider>
+            <h3 {...stylex.props(styles.text)}>Card with Layout</h3>
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <p {...stylex.props(styles.text, styles.textSecondary)}>
+              When using XDSLayout, the layout uses negative margin to escape
+              the container padding, then manages its own padding.
+            </p>
+          </XDSLayoutContent>
+        }
+        footer={
+          <XDSLayoutFooter hasDivider>
+            <XDSHStack gap="space2" hAlign="end">
+              <XDSButton variant="secondary">Cancel</XDSButton>
+              <XDSButton variant="primary">Save</XDSButton>
+            </XDSHStack>
+          </XDSLayoutFooter>
+        }
+      />
+    </XDSCard>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>Small (200px)</h4>
+        <XDSCard width={200}>
+          <p {...stylex.props(styles.text)}>Small card</p>
+        </XDSCard>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>Medium (300px)</h4>
+        <XDSCard width={300}>
+          <p {...stylex.props(styles.text)}>Medium card</p>
+        </XDSCard>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>Large (400px)</h4>
+        <XDSCard width={400}>
+          <p {...stylex.props(styles.text)}>Large card</p>
+        </XDSCard>
+      </div>
+    </div>
+  ),
+};
+
+export const FixedHeight: Story = {
+  render: () => (
+    <XDSCard width={300} height={200}>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider>
+            <h3 {...stylex.props(styles.text)}>Fixed Height Card</h3>
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <p {...stylex.props(styles.text, styles.textSecondary)}>
+              This card has a fixed height. Content area will scroll if needed.
+            </p>
+          </XDSLayoutContent>
+        }
+      />
+    </XDSCard>
+  ),
+};
+
+export const NestedCards: Story = {
+  render: () => (
+    <XDSCard width={400}>
+      <XDSVStack gap="space3">
+        <h3 {...stylex.props(styles.text)}>Parent Card</h3>
+        <XDSCard width="100%">
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            Nested card resets --container-padding and gets its own padding.
+          </p>
+        </XDSCard>
+        <XDSCard width="100%">
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            Another nested card with independent padding.
+          </p>
+        </XDSCard>
+      </XDSVStack>
+    </XDSCard>
+  ),
+};
+
+export const NestedSections: Story = {
+  render: () => (
+    <XDSCard width={400}>
+      <XDSSection variant="transparent" dividers={['bottom']}>
+        <XDSVStack gap="space2">
+          <h3 {...stylex.props(styles.text)}>First Section</h3>
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            This section escapes the card padding on top and sides because
+            it's the first child.
+          </p>
+        </XDSVStack>
+      </XDSSection>
+      <XDSSection variant="transparent" dividers={['bottom']}>
+        <XDSVStack gap="space2">
+          <h3 {...stylex.props(styles.text)}>Middle Section</h3>
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            Middle sections only escape horizontal padding, maintaining
+            visual separation from adjacent sections.
+          </p>
+        </XDSVStack>
+      </XDSSection>
+      <XDSSection variant="transparent">
+        <XDSVStack gap="space2">
+          <h3 {...stylex.props(styles.text)}>Last Section</h3>
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            This section escapes the card padding on bottom and sides
+            because it's the last child.
+          </p>
+        </XDSVStack>
+      </XDSSection>
+    </XDSCard>
+  ),
+};
+
+export const SingleSection: Story = {
+  render: () => (
+    <XDSCard width={350}>
+      <XDSSection variant="wash">
+        <XDSVStack gap="space2">
+          <h3 {...stylex.props(styles.text)}>Only Section (Full Bleed All Sides)</h3>
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            When a section is both first and last child, it gets full bleed
+            on all four sides, completely filling the card.
+          </p>
+        </XDSVStack>
+      </XDSSection>
+    </XDSCard>
+  ),
+};
+
+export const MixedContent: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>Simple Content</h4>
+        <XDSCard width={250}>
+          <XDSVStack gap="space2">
+            <h3 {...stylex.props(styles.text)}>Card Title</h3>
+            <p {...stylex.props(styles.text, styles.textSecondary)}>
+              Regular content uses the card's container padding.
+            </p>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>With Section</h4>
+        <XDSCard width={250}>
+          <XDSSection variant="wash">
+            <XDSVStack gap="space2">
+              <h3 {...stylex.props(styles.text)}>Card Title</h3>
+              <p {...stylex.props(styles.text, styles.textSecondary)}>
+                Section content bleeds to the card edges.
+              </p>
+            </XDSVStack>
+          </XDSSection>
+        </XDSCard>
+      </div>
+    </div>
+  ),
+};
+
+export const FullBleed: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>Default (with padding)</h4>
+        <XDSCard width={250}>
+          <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
+            <p {...stylex.props(styles.text)}>Content with card padding</p>
+          </div>
+        </XDSCard>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>Full Bleed (no padding)</h4>
+        <XDSCard width={250} isFullBleed>
+          <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
+            <p {...stylex.props(styles.text)}>Content touches card edges</p>
+          </div>
+        </XDSCard>
+      </div>
+    </div>
+  ),
+};

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -344,7 +344,8 @@ export const Playground = {
             args.showHeader ? (
               <XDSLayoutHeader
                 hasDivider={args.headerHasDivider}
-                isFullBleed={args.headerIsFullBleed}>
+                isFullBleed={args.headerIsFullBleed}
+              >
                 <h3 {...stylex.props(styles.heading)}>Layout Header</h3>
               </XDSLayoutHeader>
             ) : undefined
@@ -355,7 +356,8 @@ export const Playground = {
                 width={args.startPanelWidth}
                 hasDivider={args.startPanelHasDivider}
                 isScrollable={args.startPanelIsScrollable}
-                role="navigation">
+                role="navigation"
+              >
                 <NavItem active>Dashboard</NavItem>
                 <NavItem>Settings</NavItem>
                 <NavItem>Profile</NavItem>
@@ -366,7 +368,8 @@ export const Playground = {
           content={
             <XDSLayoutContent
               isFullBleed={args.contentIsFullBleed}
-              isScrollable={args.contentIsScrollable}>
+              isScrollable={args.contentIsScrollable}
+            >
               <h4 {...stylex.props(styles.subheading)}>Main Content Area</h4>
               <br />
               <p {...stylex.props(styles.bodyText)}>
@@ -391,7 +394,8 @@ export const Playground = {
                 width={args.endPanelWidth}
                 hasDivider={args.endPanelHasDivider}
                 isScrollable={args.endPanelIsScrollable}
-                role="complementary">
+                role="complementary"
+              >
                 <p {...stylex.props(styles.sectionLabel)}>Details</p>
                 <p {...stylex.props(styles.bodyText)}>
                   Additional information or actions can go in the end panel.
@@ -403,7 +407,8 @@ export const Playground = {
             args.showFooter ? (
               <XDSLayoutFooter
                 hasDivider={args.footerHasDivider}
-                isFullBleed={args.footerIsFullBleed}>
+                isFullBleed={args.footerIsFullBleed}
+              >
                 <XDSHStack gap="space2" hAlign="end">
                   <XDSButton variant="secondary">Cancel</XDSButton>
                   <XDSButton variant="primary">Save</XDSButton>
@@ -699,7 +704,7 @@ export const ThemedLayout: Story = {
           Default Theme (16px padding)
         </p>
         <Theme theme={defaultTheme}>
-          <XDSCard width={400} height={350}>
+          <XDSCard width={400}>
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
@@ -732,7 +737,7 @@ export const ThemedLayout: Story = {
           Neutral Theme (12px padding)
         </p>
         <Theme theme={neutralTheme}>
-          <XDSCard width={400} height={350}>
+          <XDSCard width={400}>
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
@@ -775,16 +780,17 @@ export const OuterPaddingDemo: Story = {
       </p>
       <XDSHStack gap="space4" wrap="wrap">
         <XDSVStack gap="space2">
-          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space0</p>
+          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing0</p>
           <div
             {...stylex.props(
               ...container({
-                paddingOuterX: 'space0',
-                paddingOuterY: 'space0',
+                paddingOuterX: 'spacing0',
+                paddingOuterY: 'spacing0',
               }),
               styles.demoContainer,
               styles.demoSize,
-            )}>
+            )}
+          >
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
@@ -808,16 +814,17 @@ export const OuterPaddingDemo: Story = {
         </XDSVStack>
 
         <XDSVStack gap="space2">
-          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space4</p>
+          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing4</p>
           <div
             {...stylex.props(
               ...container({
-                paddingOuterX: 'space4',
-                paddingOuterY: 'space4',
+                paddingOuterX: 'spacing4',
+                paddingOuterY: 'spacing4',
               }),
               styles.demoContainer,
               styles.demoSize,
-            )}>
+            )}
+          >
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
@@ -841,16 +848,17 @@ export const OuterPaddingDemo: Story = {
         </XDSVStack>
 
         <XDSVStack gap="space2">
-          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = space7</p>
+          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing7</p>
           <div
             {...stylex.props(
               ...container({
-                paddingOuterX: 'space7',
-                paddingOuterY: 'space7',
+                paddingOuterX: 'spacing7',
+                paddingOuterY: 'spacing7',
               }),
               styles.demoContainer,
               styles.demoSize,
-            )}>
+            )}
+          >
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -1,0 +1,209 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSSection, XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSLayout, XDSLayoutHeader, XDSLayoutContent, XDSLayoutFooter, XDSLayoutPanel} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {colorVars, spacingVars, typographyVars} from '@xds/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  pageWrapper: {
+    backgroundColor: colorVars['--color-wash'],
+    padding: spacingVars['--spacing-6'],
+  },
+  text: {
+    fontFamily: typographyVars['--font-body'],
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+  textSecondary: {
+    color: colorVars['--color-text-secondary'],
+    fontSize: 14,
+  },
+  storyWrapper: {
+    display: 'flex',
+    gap: spacingVars['--spacing-6'],
+    flexWrap: 'wrap',
+  },
+  heading: {
+    margin: `0 0 ${spacingVars['--spacing-2']} 0`,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: 14,
+    color: colorVars['--color-text-secondary'],
+  },
+});
+
+const meta: Meta<typeof XDSSection> = {
+  title: 'Layout/XDSSection',
+  component: XDSSection,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['section', 'transparent', 'wash'],
+      description: 'Visual variant of the section',
+    },
+    width: {
+      control: {type: 'range', min: 100, max: 800, step: 10},
+      description: 'Width in pixels',
+    },
+    height: {
+      control: {type: 'range', min: 100, max: 600, step: 10},
+      description: 'Height in pixels',
+    },
+    isFullBleed: {
+      control: 'boolean',
+      description: 'Removes internal padding',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSSection>;
+
+export const Default: Story = {
+  args: {
+    variant: 'section',
+    width: 300,
+  },
+  render: (args) => (
+    <XDSSection {...args}>
+      <p {...stylex.props(styles.text)}>
+        A section with default padding. Sections are used to define
+        distinct areas within a page.
+      </p>
+    </XDSSection>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>section (default)</h4>
+        <XDSSection variant="section" width={200}>
+          <p {...stylex.props(styles.text)}>Surface background</p>
+        </XDSSection>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>wash</h4>
+        <XDSSection variant="wash" width={200}>
+          <p {...stylex.props(styles.text)}>Wash background</p>
+        </XDSSection>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>transparent</h4>
+        <XDSSection variant="transparent" width={200}>
+          <p {...stylex.props(styles.text)}>Transparent background</p>
+        </XDSSection>
+      </div>
+    </div>
+  ),
+};
+
+export const WithSimpleContent: Story = {
+  render: () => (
+    <XDSSection variant="wash" width={320}>
+      <XDSVStack gap="space2">
+        <h3 {...stylex.props(styles.text)}>Section Title</h3>
+        <p {...stylex.props(styles.text, styles.textSecondary)}>
+          This section contains simple content without XDSLayout.
+          The container padding is applied automatically.
+        </p>
+      </XDSVStack>
+    </XDSSection>
+  ),
+};
+
+export const WithInnerLayout: Story = {
+  render: () => (
+    <XDSSection variant="wash" width={350} height={250}>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider>
+            <h3 {...stylex.props(styles.text)}>Section with Layout</h3>
+          </XDSLayoutHeader>
+        }
+        content={
+          <XDSLayoutContent>
+            <p {...stylex.props(styles.text, styles.textSecondary)}>
+              When using XDSLayout, the layout manages its own padding
+              independently from the container padding.
+            </p>
+          </XDSLayoutContent>
+        }
+        footer={
+          <XDSLayoutFooter hasDivider>
+            <XDSHStack gap="space2" hAlign="end">
+              <XDSButton variant="primary">Action</XDSButton>
+            </XDSHStack>
+          </XDSLayoutFooter>
+        }
+      />
+    </XDSSection>
+  ),
+};
+
+export const PageLayout: Story = {
+  render: () => (
+    <XDSSection variant="section" width={600} height={300}>
+      <XDSLayout
+        header={
+          <XDSLayoutHeader hasDivider>
+            <XDSVStack gap="space2">
+              <h2 {...stylex.props(styles.text)}>Page Header</h2>
+              <p {...stylex.props(styles.text, styles.textSecondary)}>
+                Welcome to the application
+              </p>
+            </XDSVStack>
+          </XDSLayoutHeader>
+        }
+        start={
+          <XDSLayoutPanel hasDivider width={150}>
+            <h3 {...stylex.props(styles.text)}>Sidebar</h3>
+          </XDSLayoutPanel>
+        }
+        content={
+          <XDSLayoutContent>
+            <XDSVStack gap="space2">
+              <h3 {...stylex.props(styles.text)}>Main Content</h3>
+              <p {...stylex.props(styles.text, styles.textSecondary)}>
+                This demonstrates how XDSLayout can be used to create
+                page layouts with header, sidebar, and content areas.
+              </p>
+            </XDSVStack>
+          </XDSLayoutContent>
+        }
+      />
+    </XDSSection>
+  ),
+};
+
+export const FullBleed: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>Default (with padding)</h4>
+        <XDSSection variant="wash" width={250}>
+          <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
+            <p {...stylex.props(styles.text)}>Content with section padding</p>
+          </div>
+        </XDSSection>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>Full Bleed (no padding)</h4>
+        <XDSSection variant="wash" width={250} isFullBleed>
+          <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
+            <p {...stylex.props(styles.text)}>Content touches section edges</p>
+          </div>
+        </XDSSection>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/src/Layout/Container/XDSCard.tsx
+++ b/packages/core/src/Layout/Container/XDSCard.tsx
@@ -7,7 +7,11 @@
 
 import {forwardRef, useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, radiusVars, elevationVars} from '../../theme/tokens.stylex';
+import {
+  colorVars,
+  radiusVars,
+  elevationVars,
+} from '../../theme/tokens.stylex';
 import {ThemeContext} from '../../theme/ThemeContext';
 import type {StyleXStyles as ThemeStyleXStyles} from '../../theme/types';
 import {container} from './container.stylex';
@@ -19,17 +23,43 @@ import {container} from './container.stylex';
 declare module '../../theme/types' {
   interface ComponentStyles {
     card?: {
-      /** Base style overrides */
-      base?: ThemeStyleXStyles;
+      /** Outer container styles (background, border, shadow, border-radius) */
+      container?: ThemeStyleXStyles;
+      /** Inner content styles (padding) */
+      content?: ThemeStyleXStyles;
     };
   }
 }
 
 const styles = stylex.create({
-  card: {
+  // Outer wrapper: visual styling with clip for border-radius
+  cardOuter: {
     backgroundColor: colorVars['--color-card'],
     borderRadius: radiusVars['--radius-container'],
     boxShadow: elevationVars['--elevation-base'],
+    // Clip content to border-radius so nested containers don't peek out corners
+    overflow: 'clip',
+    // Use inherited --card-border-color if set by ancestor, otherwise transparent
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: 'var(--card-border-color, transparent)',
+  },
+  // Inner wrapper: container padding and overflow handling
+  cardInner: {
+    height: '100%',
+    // Cards have surface background, so nested cards need visible borders
+    '--card-border-color': colorVars['--color-divider'],
+  },
+  // Only enable scrolling when card has fixed height
+  scrollable: {
+    overflow: 'auto',
+  },
+  // Full bleed: removes all internal padding
+  fullBleed: {
+    paddingInlineStart: 0,
+    paddingInlineEnd: 0,
+    paddingBlockStart: 0,
+    paddingBlockEnd: 0,
   },
 });
 
@@ -83,6 +113,12 @@ export interface XDSCardProps {
    * Should typically be XDSLayout child components.
    */
   children?: ReactNode;
+
+  /**
+   * Removes internal padding, allowing content to touch the edges.
+   * @default false
+   */
+  isFullBleed?: boolean;
 }
 
 /**
@@ -104,25 +140,23 @@ export interface XDSCardProps {
  */
 export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
   function XDSCard(
-    {width, height, maxWidth, minHeight, children, ...props},
+    {width, height, maxWidth, minHeight, children, isFullBleed = false, ...props},
     ref,
   ) {
     // Get theme context for component-level overrides
     const themeContext = useContext(ThemeContext);
-    const themeOverride = themeContext?.theme.components?.card?.base;
+    const containerOverride = themeContext?.theme.components?.card?.container;
+    const contentOverride = themeContext?.theme.components?.card?.content;
+
+    // Only enable scrolling when card has a fixed height (not null/undefined and not "auto")
+    const hasFixedHeight = height != null && height !== 'auto';
 
     return (
       <div
         ref={ref}
         {...stylex.props(
-          ...container({
-            paddingInnerX: 'spacing4',
-            paddingInnerY: 'spacing4',
-            paddingOuterX: 'spacing4',
-            paddingOuterY: 'spacing4',
-          }),
-          styles.card,
-          themeOverride,
+          styles.cardOuter,
+          containerOverride,
           dynamicStyles.sizing(
             width ?? null,
             height ?? null,
@@ -131,7 +165,21 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
           ),
         )}
         {...props}>
-        {children}
+        <div
+          {...stylex.props(
+            styles.cardInner,
+            hasFixedHeight && styles.scrollable,
+            ...container({
+              paddingInnerX: 'spacing4',
+              paddingInnerY: 'spacing4',
+              paddingOuterX: 'spacing4',
+              paddingOuterY: 'spacing4',
+            }),
+            isFullBleed && styles.fullBleed,
+            contentOverride,
+          )}>
+          {children}
+        </div>
       </div>
     );
   },

--- a/packages/core/src/Layout/Container/XDSSection.tsx
+++ b/packages/core/src/Layout/Container/XDSSection.tsx
@@ -25,7 +25,11 @@ export type XDSSectionVariant = 'section' | 'transparent' | 'wash';
 declare module '../../theme/types' {
   interface ComponentStyles {
     section?: {
-      /** Style overrides for each variant */
+      /** Outer container styles (positioning, margins) */
+      container?: ThemeStyleXStyles;
+      /** Inner content styles (padding) */
+      content?: ThemeStyleXStyles;
+      /** Style overrides for each variant (background, visual styling) */
       variants?: Partial<Record<XDSSectionVariant, ThemeStyleXStyles>>;
     };
   }
@@ -34,12 +38,72 @@ declare module '../../theme/types' {
 const variantStyles = stylex.create({
   section: {
     backgroundColor: colorVars['--color-surface'],
+    // Surface background: nested cards need visible borders
+    '--card-border-color': colorVars['--color-divider'],
   },
   transparent: {
     backgroundColor: 'transparent',
+    // Transparent inherits --card-border-color from parent
   },
   wash: {
     backgroundColor: colorVars['--color-wash'],
+    // Wash background: nested cards don't need borders
+    '--card-border-color': 'transparent',
+  },
+});
+
+// Styles for escaping parent container padding when nested
+const nestedStyles = stylex.create({
+  // Outer wrapper escapes parent's container padding
+  outer: {
+    // Always escape horizontal padding
+    marginInline: 'calc(-1 * var(--container-padding, 0px))',
+    // Escape top padding only if first child
+    marginTop: {
+      default: null,
+      ':first-child': 'calc(-1 * var(--container-padding, 0px))',
+    },
+    // Escape bottom padding only if last child
+    marginBottom: {
+      default: null,
+      ':last-child': 'calc(-1 * var(--container-padding, 0px))',
+    },
+  },
+  // Inner wrapper resets container padding for descendants
+  inner: {
+    '--container-padding': '0px',
+    height: '100%',
+  },
+  // Full bleed: removes all internal padding
+  fullBleed: {
+    paddingInlineStart: 0,
+    paddingInlineEnd: 0,
+    paddingBlockStart: 0,
+    paddingBlockEnd: 0,
+  },
+});
+
+// Divider styles for each side
+const dividerStyles = stylex.create({
+  top: {
+    borderTopWidth: 1,
+    borderTopStyle: 'solid',
+    borderTopColor: colorVars['--color-divider'],
+  },
+  bottom: {
+    borderBottomWidth: 1,
+    borderBottomStyle: 'solid',
+    borderBottomColor: colorVars['--color-divider'],
+  },
+  start: {
+    borderInlineStartWidth: 1,
+    borderInlineStartStyle: 'solid',
+    borderInlineStartColor: colorVars['--color-divider'],
+  },
+  end: {
+    borderInlineEndWidth: 1,
+    borderInlineEndStyle: 'solid',
+    borderInlineEndColor: colorVars['--color-divider'],
   },
 });
 
@@ -97,6 +161,19 @@ export interface XDSSectionProps {
    * Should typically be XDSLayout child components.
    */
   children?: ReactNode;
+
+  /**
+   * Which sides should have divider borders.
+   * Use 'start'/'end' for horizontal (respects RTL).
+   * @example dividers={['top', 'bottom']}
+   */
+  dividers?: Array<'top' | 'bottom' | 'start' | 'end'>;
+
+  /**
+   * Removes internal padding, allowing content to touch the edges.
+   * @default false
+   */
+  isFullBleed?: boolean;
 }
 
 /**
@@ -123,36 +200,53 @@ export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
       maxWidth,
       minHeight,
       children,
+      dividers,
+      isFullBleed = false,
       ...props
     },
     ref,
   ) {
     // Get theme context for component-level overrides
     const themeContext = useContext(ThemeContext);
-    const themeVariantOverride =
+    const containerOverride = themeContext?.theme.components?.section?.container;
+    const contentOverride = themeContext?.theme.components?.section?.content;
+    const variantOverride =
       themeContext?.theme.components?.section?.variants?.[variant];
 
     return (
       <div
         ref={ref}
         {...stylex.props(
-          ...container({
-            paddingInnerX: 'spacing4',
-            paddingInnerY: 'spacing4',
-            paddingOuterX: 'spacing4',
-            paddingOuterY: 'spacing4',
-          }),
-          variantStyles[variant],
-          themeVariantOverride,
+          nestedStyles.outer,
           dynamicStyles.sizing(
             width ?? null,
             height ?? null,
             maxWidth ?? null,
             minHeight ?? null,
           ),
+          containerOverride,
         )}
         {...props}>
-        {children}
+        <div
+          {...stylex.props(
+            nestedStyles.inner,
+            ...container({
+              paddingInnerX: 'spacing4',
+              paddingInnerY: 'spacing4',
+              paddingOuterX: 'spacing4',
+              paddingOuterY: 'spacing4',
+            }),
+            variantStyles[variant],
+            variantOverride,
+            isFullBleed && nestedStyles.fullBleed,
+            dividers?.includes('top') && dividerStyles.top,
+            dividers?.includes('bottom') && dividerStyles.bottom,
+            dividers?.includes('start') && dividerStyles.start,
+            dividers?.includes('end') && dividerStyles.end,
+            contentOverride,
+          )}>
+          {children}
+        </div>
       </div>
     );
   },

--- a/packages/core/src/Layout/Container/container.stylex.ts
+++ b/packages/core/src/Layout/Container/container.stylex.ts
@@ -27,10 +27,25 @@ export type SpacingToken =
 const baseStyles = stylex.create({
   container: {
     boxSizing: 'border-box',
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
+    padding: 'var(--container-padding)',
   },
+});
+
+/**
+ * Container padding styles.
+ * Sets --container-padding CSS variable for simple content padding.
+ * XDSLayout will override this to 0 and handle its own padding.
+ */
+const containerPaddingStyles = stylex.create({
+  spacing0: {'--container-padding': spacingVars['--spacing-0']},
+  spacing0_5: {'--container-padding': spacingVars['--spacing-0-5']},
+  spacing1: {'--container-padding': spacingVars['--spacing-1']},
+  spacing2: {'--container-padding': spacingVars['--spacing-2']},
+  spacing3: {'--container-padding': spacingVars['--spacing-3']},
+  spacing4: {'--container-padding': spacingVars['--spacing-4']},
+  spacing5: {'--container-padding': spacingVars['--spacing-5']},
+  spacing6: {'--container-padding': spacingVars['--spacing-6']},
+  spacing7: {'--container-padding': spacingVars['--spacing-7']},
 });
 
 const paddingOuterXStyles = stylex.create({
@@ -83,6 +98,14 @@ const paddingInnerYStyles = stylex.create({
 
 export interface ContainerOptions {
   /**
+   * Default container padding for simple content.
+   * Sets --container-padding CSS variable.
+   * XDSLayout overrides this to 0 and manages its own padding.
+   * @default 'spacing4'
+   */
+  padding?: SpacingToken;
+
+  /**
    * Outer horizontal padding (left/right).
    * Sets --layout-padding-outer-x CSS variable.
    * @default 'spacing4'
@@ -115,6 +138,7 @@ export interface ContainerOptions {
  * StyleX utility to add layout container styles to any element.
  *
  * Sets CSS variables for padding that child layout components read:
+ * - `--container-padding` — Default padding for simple content
  * - `--layout-padding-outer-x`, `--layout-padding-outer-y`
  * - `--layout-padding-inner-x`, `--layout-padding-inner-y`
  *
@@ -130,7 +154,7 @@ export interface ContainerOptions {
  *
  * // Custom padding values
  * <div {...stylex.props(
- *   ...container({ paddingInnerX: 'space3', paddingOuterY: 'space2' }),
+ *   ...container({ padding: 'spacing3', paddingOuterY: 'spacing2', paddingInnerX: 'spacing3' }),
  *   customStyles.card
  * )}>
  *   <XDSLayout ... />
@@ -138,6 +162,7 @@ export interface ContainerOptions {
  * ```
  */
 export function container({
+  padding = 'spacing4',
   paddingOuterX = 'spacing4',
   paddingOuterY = 'spacing4',
   paddingInnerX = 'spacing4',
@@ -145,6 +170,7 @@ export function container({
 }: ContainerOptions) {
   return [
     baseStyles.container,
+    containerPaddingStyles[padding],
     paddingOuterXStyles[paddingOuterX],
     paddingOuterYStyles[paddingOuterY],
     paddingInnerXStyles[paddingInnerX],

--- a/packages/core/src/Layout/XDSLayout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayout.tsx
@@ -25,8 +25,17 @@ import {stackItem} from '../Stack/stackItem.stylex';
 export type XDSLayoutHeight = 'fill' | 'auto';
 
 const styles = stylex.create({
+  // Outer wrapper uses negative margin to escape container padding
+  layoutOuter: {
+    margin: 'calc(-1 * var(--container-padding, 0px))',
+  },
+  // Inner wrapper resets --container-padding for descendants
+  layoutInner: {
+    '--container-padding': '0px',
+  },
   fill: {
-    height: '100%',
+    // Add 2x container padding to compensate for negative margins on top/bottom
+    height: 'calc(100% + 2 * var(--container-padding, 0px))',
   },
   auto: {
     minHeight: '100%',
@@ -155,20 +164,30 @@ export function XDSLayout({
     <XDSLayoutSlotsContext.Provider value={slotsValue}>
       <div
         {...stylex.props(
-          ...stack({direction: 'vertical'}),
+          styles.layoutOuter,
           isFill ? styles.fill : styles.auto,
-          isFullBleed && styles.fullBleed,
         )}>
-        <AreaProvider area="header">{header}</AreaProvider>
         <div
-          {...stylex.props(...stack({direction: 'horizontal'}), styles.middle)}>
-          <AreaProvider area="start">{start}</AreaProvider>
-          <div {...stylex.props(...stackItem({size: 'fill'}))}>
-            <AreaProvider area="content">{content}</AreaProvider>
+          {...stylex.props(
+            styles.layoutInner,
+            ...stack({direction: 'vertical'}),
+            isFill ? styles.fill : styles.auto,
+            isFullBleed && styles.fullBleed,
+          )}>
+          <AreaProvider area="header">{header}</AreaProvider>
+          <div
+            {...stylex.props(
+              ...stack({direction: 'horizontal'}),
+              styles.middle,
+            )}>
+            <AreaProvider area="start">{start}</AreaProvider>
+            <div {...stylex.props(...stackItem({size: 'fill'}))}>
+              <AreaProvider area="content">{content}</AreaProvider>
+            </div>
+            <AreaProvider area="end">{end}</AreaProvider>
           </div>
-          <AreaProvider area="end">{end}</AreaProvider>
+          <AreaProvider area="footer">{footer}</AreaProvider>
         </div>
-        <AreaProvider area="footer">{footer}</AreaProvider>
       </div>
     </XDSLayoutSlotsContext.Provider>
   );

--- a/packages/core/src/theme/neutralTheme.stylex.ts
+++ b/packages/core/src/theme/neutralTheme.stylex.ts
@@ -300,7 +300,7 @@ const buttonVariants = stylex.create({
 
 const cardStyles = stylex.create({
   // Override card default padding to 12px for tighter layout
-  base: {
+  content: {
     '--layout-padding-inner-x': spacingVars['--spacing-3'],
     '--layout-padding-inner-y': spacingVars['--spacing-3'],
     '--layout-padding-outer-x': spacingVars['--spacing-3'],
@@ -308,21 +308,9 @@ const cardStyles = stylex.create({
   },
 });
 
-const sectionVariants = stylex.create({
-  // Override section padding to 12px for tighter layout
-  section: {
-    '--layout-padding-inner-x': spacingVars['--spacing-3'],
-    '--layout-padding-inner-y': spacingVars['--spacing-3'],
-    '--layout-padding-outer-x': spacingVars['--spacing-3'],
-    '--layout-padding-outer-y': spacingVars['--spacing-3'],
-  },
-  transparent: {
-    '--layout-padding-inner-x': spacingVars['--spacing-3'],
-    '--layout-padding-inner-y': spacingVars['--spacing-3'],
-    '--layout-padding-outer-x': spacingVars['--spacing-3'],
-    '--layout-padding-outer-y': spacingVars['--spacing-3'],
-  },
-  wash: {
+const sectionStyles = stylex.create({
+  // Override section default padding to 12px for tighter layout
+  content: {
     '--layout-padding-inner-x': spacingVars['--spacing-3'],
     '--layout-padding-inner-y': spacingVars['--spacing-3'],
     '--layout-padding-outer-x': spacingVars['--spacing-3'],
@@ -357,10 +345,10 @@ export const neutralTheme: Theme = {
       variants: buttonVariants,
     },
     card: {
-      base: cardStyles.base,
+      content: cardStyles.content,
     },
     section: {
-      variants: sectionVariants,
+      content: sectionStyles.content,
     },
   },
 };


### PR DESCRIPTION
- Add XDSCard with outer/inner wrapper structure for proper border-radius clipping
- Add XDSSection with nested styles for escaping parent container padding
- Add dividers prop to XDSSection for border control
- Add isFullBleed prop to both components
- Update XDSLayout with outer/inner wrapper to escape container padding
- Add container padding CSS variable support to container.stylex.ts
- Update neutralTheme with card.content and section.content overrides
- Add storybook stories for Card and Section components