### PR TITLE
Add XDSIcon component

### DIFF
--- a/apps/storybook/stories/Icon.stories.tsx
+++ b/apps/storybook/stories/Icon.stories.tsx
@@ -1,0 +1,248 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSIcon} from '@xds/core/Icon';
+import {
+  HomeIcon,
+  HeartIcon,
+  StarIcon,
+  BellIcon,
+  UserIcon,
+  CogIcon,
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/outline';
+import {
+  HeartIcon as HeartIconSolid,
+  StarIcon as StarIconSolid,
+} from '@heroicons/react/24/solid';
+
+const meta: Meta<typeof XDSIcon> = {
+  title: 'Core/XDSIcon',
+  component: XDSIcon,
+  tags: ['autodocs'],
+  argTypes: {
+    icon: {
+      control: false,
+      description: 'Hero Icon component to render',
+    },
+    color: {
+      control: 'select',
+      options: [
+        'primary',
+        'secondary',
+        'tertiary',
+        'disabled',
+        'accent',
+        'positive',
+        'negative',
+        'warning',
+        'inherit',
+      ],
+      description: 'Color variant',
+    },
+    size: {
+      control: 'select',
+      options: ['xsm', 'sm', 'md', 'lg'],
+      description: 'Icon size',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSIcon>;
+
+export const Default: Story = {
+  args: {
+    icon: HomeIcon,
+    color: 'primary',
+    size: 'md',
+  },
+};
+
+export const Primary: Story = {
+  args: {
+    icon: HomeIcon,
+    color: 'primary',
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    icon: HomeIcon,
+    color: 'secondary',
+  },
+};
+
+export const Accent: Story = {
+  args: {
+    icon: HeartIcon,
+    color: 'accent',
+  },
+};
+
+export const Positive: Story = {
+  args: {
+    icon: CheckCircleIcon,
+    color: 'positive',
+  },
+};
+
+export const Negative: Story = {
+  args: {
+    icon: XCircleIcon,
+    color: 'negative',
+  },
+};
+
+export const Warning: Story = {
+  args: {
+    icon: ExclamationTriangleIcon,
+    color: 'warning',
+  },
+};
+
+export const ExtraSmall: Story = {
+  args: {
+    icon: StarIcon,
+    size: 'xsm',
+  },
+};
+
+export const Small: Story = {
+  args: {
+    icon: StarIcon,
+    size: 'sm',
+  },
+};
+
+export const Medium: Story = {
+  args: {
+    icon: StarIcon,
+    size: 'md',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    icon: StarIcon,
+    size: 'lg',
+  },
+};
+
+export const SolidIcon: Story = {
+  args: {
+    icon: HeartIconSolid,
+    color: 'negative',
+    size: 'lg',
+  },
+};
+
+export const AllColors: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
+      <XDSIcon icon={HomeIcon} color="primary" />
+      <XDSIcon icon={UserIcon} color="secondary" />
+      <XDSIcon icon={CogIcon} color="tertiary" />
+      <XDSIcon icon={BellIcon} color="disabled" />
+      <XDSIcon icon={HeartIcon} color="accent" />
+      <XDSIcon icon={CheckCircleIcon} color="positive" />
+      <XDSIcon icon={XCircleIcon} color="negative" />
+      <XDSIcon icon={ExclamationTriangleIcon} color="warning" />
+    </div>
+  ),
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
+      <XDSIcon icon={StarIcon} size="xsm" />
+      <XDSIcon icon={StarIcon} size="sm" />
+      <XDSIcon icon={StarIcon} size="md" />
+      <XDSIcon icon={StarIcon} size="lg" />
+    </div>
+  ),
+};
+
+export const OutlineVsSolid: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '8px',
+        }}>
+        <XDSIcon icon={HeartIcon} size="lg" color="negative" />
+        <span style={{fontSize: '12px', color: '#666'}}>Outline</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '8px',
+        }}>
+        <XDSIcon icon={HeartIconSolid} size="lg" color="negative" />
+        <span style={{fontSize: '12px', color: '#666'}}>Solid</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '8px',
+        }}>
+        <XDSIcon icon={StarIcon} size="lg" color="warning" />
+        <span style={{fontSize: '12px', color: '#666'}}>Outline</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '8px',
+        }}>
+        <XDSIcon icon={StarIconSolid} size="lg" color="warning" />
+        <span style={{fontSize: '12px', color: '#666'}}>Solid</span>
+      </div>
+    </div>
+  ),
+};
+
+export const InheritColor: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
+      <span
+        style={{
+          color: 'blue',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={HomeIcon} color="inherit" size="sm" />
+        Blue text
+      </span>
+      <span
+        style={{
+          color: 'green',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={CheckCircleIcon} color="inherit" size="sm" />
+        Green text
+      </span>
+      <span
+        style={{
+          color: 'red',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={XCircleIcon} color="inherit" size="sm" />
+        Red text
+      </span>
+    </div>
+  ),
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -37,6 +37,11 @@
       "import": "./dist/Field/index.mjs",
       "require": "./dist/Field/index.js"
     },
+    "./Icon": {
+      "types": "./dist/Icon/index.d.ts",
+      "import": "./dist/Icon/index.mjs",
+      "require": "./dist/Icon/index.js"
+    },
     "./Layout": {
       "types": "./dist/Layout/index.d.ts",
       "import": "./dist/Layout/index.mjs",
@@ -75,6 +80,7 @@
     "esbuild-plugin-babel": "^0.2.3"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "@stylexjs/stylex": "^0.17.4"
   }
 }

--- a/packages/core/src/Icon/README.md
+++ b/packages/core/src/Icon/README.md
@@ -1,0 +1,98 @@
+# /packages/core/src/Icon
+
+A wrapper component for rendering Hero Icons with XDS design system colors and sizes.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Hero Icons Integration**: Renders any Hero Icon (outline or solid) as a component
+- **Theme Colors**: Color variants mapped to XDS icon color tokens
+- **Consistent Sizing**: Four size options aligned with common UI patterns
+- **Tree-shakeable**: Icons are imported individually, keeping bundle size minimal
+- **Accessible**: Icons are hidden from screen readers by default (aria-hidden)
+
+## Usage
+
+```tsx
+import { XDSIcon } from '@xds/core/Icon';
+import { HomeIcon } from '@heroicons/react/24/outline';
+import { HeartIcon } from '@heroicons/react/24/solid';
+
+// Basic usage
+<XDSIcon icon={HomeIcon} />
+
+// With color variant
+<XDSIcon icon={HomeIcon} color="accent" />
+
+// With size
+<XDSIcon icon={HomeIcon} size="lg" />
+
+// Solid icon with color
+<XDSIcon icon={HeartIcon} color="negative" />
+
+// Accessible icon with label
+<XDSIcon icon={HomeIcon} aria-hidden={false} aria-label="Home" role="img" />
+```
+
+## Props
+
+| Prop    | Type                                                                                                                     | Default     | Description                   |
+| ------- | ------------------------------------------------------------------------------------------------------------------------ | ----------- | ----------------------------- |
+| `icon`  | `ComponentType<SVGProps>`                                                                                                | (required)  | Hero Icon component to render |
+| `color` | `'primary' \| 'secondary' \| 'tertiary' \| 'disabled' \| 'accent' \| 'positive' \| 'negative' \| 'warning' \| 'inherit'` | `'primary'` | Color variant                 |
+| `size`  | `'xsm' \| 'sm' \| 'md' \| 'lg'`                                                                                          | `'md'`      | Icon size                     |
+
+Additional SVG props (like `aria-label`, `role`, `className`) are passed through to the underlying SVG element.
+
+## Color Variants
+
+| Value       | Token                    | Use Case                        |
+| ----------- | ------------------------ | ------------------------------- |
+| `primary`   | `--color-icon-primary`   | Default icon color              |
+| `secondary` | `--color-icon-secondary` | De-emphasized icons             |
+| `tertiary`  | `--color-icon-tertiary`  | Subtle, background icons        |
+| `disabled`  | `--color-icon-disabled`  | Disabled state                  |
+| `accent`    | `--color-accent`         | Interactive, actionable icons   |
+| `positive`  | `--color-positive`       | Success, confirmation           |
+| `negative`  | `--color-negative`       | Error, destructive actions      |
+| `warning`   | `--color-warning`        | Caution, attention              |
+| `inherit`   | `currentColor`           | Inherits from parent text color |
+
+## Size Variants
+
+| Value | Dimensions | Use Case                     |
+| ----- | ---------- | ---------------------------- |
+| `xsm` | 12x12px    | Dense UI, badges, indicators |
+| `sm`  | 16x16px    | Inline with text, compact UI |
+| `md`  | 20x20px    | Default, buttons, inputs     |
+| `lg`  | 24x24px    | Emphasis, standalone icons   |
+
+## Icon Sources
+
+Import icons from Hero Icons:
+
+```tsx
+// Outline style (24x24, 1.5px stroke)
+import {HomeIcon} from '@heroicons/react/24/outline';
+
+// Solid style (24x24, filled)
+import {HomeIcon} from '@heroicons/react/24/solid';
+```
+
+Browse available icons at [heroicons.com](https://heroicons.com).
+
+## Files
+
+| File               | Role  | Purpose                     |
+| ------------------ | ----- | --------------------------- |
+| `index.ts`         | Entry | Exports component and types |
+| `XDSIcon.tsx`      | Core  | Component implementation    |
+| `XDSIcon.test.tsx` | Test  | Unit tests                  |
+
+## Implementation Notes
+
+- Uses `aria-hidden="true"` by default since icons are typically decorative
+- For meaningful icons, set `aria-hidden={false}`, `role="img"`, and `aria-label`
+- `flexShrink: 0` prevents icons from shrinking in flex containers
+- Colors are applied via the CSS `color` property, which Hero Icons inherit for stroke/fill

--- a/packages/core/src/Icon/XDSIcon.test.tsx
+++ b/packages/core/src/Icon/XDSIcon.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @file XDSIcon.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSIcon component
+ * @output Unit tests for XDSIcon component behavior
+ * @position Testing; validates XDSIcon.tsx implementation
+ *
+ * SYNC: When XDSIcon.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {HomeIcon} from '@heroicons/react/24/outline';
+import {XDSIcon} from './XDSIcon';
+
+describe('XDSIcon', () => {
+  it('renders the icon component', () => {
+    render(<XDSIcon icon={HomeIcon} data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('renders as an SVG element', () => {
+    render(<XDSIcon icon={HomeIcon} data-testid="icon" />);
+    const icon = screen.getByTestId('icon');
+    expect(icon.tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('applies aria-hidden by default', () => {
+    render(<XDSIcon icon={HomeIcon} data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders with different color variants', () => {
+    const {rerender} = render(
+      <XDSIcon icon={HomeIcon} color="primary" data-testid="icon" />
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} color="secondary" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} color="accent" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} color="positive" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} color="negative" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} color="warning" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} color="inherit" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('renders with different size variants', () => {
+    const {rerender} = render(
+      <XDSIcon icon={HomeIcon} size="xsm" data-testid="icon" />
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} size="sm" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} size="md" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    rerender(<XDSIcon icon={HomeIcon} size="lg" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(<XDSIcon icon={HomeIcon} ref={ref} />);
+    expect(ref).toHaveBeenCalledWith(expect.any(SVGSVGElement));
+  });
+
+  it('passes additional SVG props', () => {
+    render(
+      <XDSIcon
+        icon={HomeIcon}
+        data-testid="icon"
+        role="img"
+        aria-label="Home"
+      />
+    );
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('role', 'img');
+    expect(icon).toHaveAttribute('aria-label', 'Home');
+  });
+
+  it('uses default color and size when not specified', () => {
+    render(<XDSIcon icon={HomeIcon} data-testid="icon" />);
+    // The component should render without errors with defaults
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -1,0 +1,128 @@
+/**
+ * @file XDSIcon.tsx
+ * @input Uses React forwardRef, SVGProps, and @heroicons/react icon components
+ * @output Exports XDSIcon component, XDSIconProps, XDSIconColor, XDSIconSize types
+ * @position Core implementation; consumed by index.ts, tested by XDSIcon.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Icon/README.md (props table, features, implementation notes)
+ * - /packages/core/src/Icon/XDSIcon.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/Icon/index.ts (exports if types change)
+ * - /apps/storybook/stories/Icon.stories.tsx (storybook stories)
+ */
+
+import {forwardRef, type ComponentType, type SVGProps} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    flexShrink: 0,
+  },
+});
+
+const colorStyles = stylex.create({
+  primary: {
+    color: colorVars['--color-icon-primary'],
+  },
+  secondary: {
+    color: colorVars['--color-icon-secondary'],
+  },
+  tertiary: {
+    color: colorVars['--color-icon-tertiary'],
+  },
+  disabled: {
+    color: colorVars['--color-icon-disabled'],
+  },
+  accent: {
+    color: colorVars['--color-accent'],
+  },
+  positive: {
+    color: colorVars['--color-positive'],
+  },
+  negative: {
+    color: colorVars['--color-negative'],
+  },
+  warning: {
+    color: colorVars['--color-warning'],
+  },
+  inherit: {
+    color: 'inherit',
+  },
+});
+
+const sizeStyles = stylex.create({
+  xsm: {
+    width: 12,
+    height: 12,
+  },
+  sm: {
+    width: 16,
+    height: 16,
+  },
+  md: {
+    width: 20,
+    height: 20,
+  },
+  lg: {
+    width: 24,
+    height: 24,
+  },
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type XDSIconColor = keyof typeof colorStyles;
+export type XDSIconSize = keyof typeof sizeStyles;
+
+/**
+ * Props for XDSIcon component.
+ * Extends SVGProps to allow passing additional SVG attributes.
+ */
+export interface XDSIconProps
+  extends Omit<SVGProps<SVGSVGElement>, 'ref' | 'color'> {
+  /**
+   * The Hero Icon component to render.
+   * Import from @heroicons/react/24/outline or @heroicons/react/24/solid.
+   */
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  /**
+   * The color variant of the icon.
+   * @default 'primary'
+   */
+  color?: XDSIconColor;
+  /**
+   * The size of the icon.
+   * - 'xsm': 12px
+   * - 'sm': 16px
+   * - 'md': 20px
+   * - 'lg': 24px
+   * @default 'md'
+   */
+  size?: XDSIconSize;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export const XDSIcon = forwardRef<SVGSVGElement, XDSIconProps>(
+  ({icon: IconComponent, color = 'primary', size = 'md', ...props}, ref) => {
+    return (
+      <IconComponent
+        ref={ref}
+        aria-hidden="true"
+        {...stylex.props(styles.root, colorStyles[color], sizeStyles[size])}
+        {...props}
+      />
+    );
+  }
+);
+
+XDSIcon.displayName = 'XDSIcon';

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input Imports XDSIcon component and types from XDSIcon.tsx
+ * @output Exports XDSIcon, XDSIconProps, XDSIconColor, XDSIconSize
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/Icon/README.md
+ */
+
+export {XDSIcon} from './XDSIcon';
+export type {XDSIconProps, XDSIconColor, XDSIconSize} from './XDSIcon';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './Avatar';
 export * from './Button';
 export * from './CheckboxInput';
 export * from './Field';
+export * from './Icon';
 export * from './TextInput';
 export * from './TextArea';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,6 +1170,11 @@
   resolved "https://registry.yarnpkg.com/@exodus/bytes/-/bytes-1.8.0.tgz#8382835f71db8377cf634a4ef5a71806e86ba9c7"
   integrity sha512-8JPn18Bcp8Uo1T82gR8lh2guEOa5KKU/IEKvvdp0sgmi7coPBWf1Doi1EXsGZb2ehc8ym/StJCjffYV+ne7sXQ==
 
+"@heroicons/react@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-2.2.0.tgz#0c05124af50434a800773abec8d3af6a297d904b"
+  integrity sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==
+
 "@humanfs/core@^0.19.1":
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/@humanfs/core/-/core-0.19.1.tgz#17c55ca7d426733fe3c561906b8173c336b40a77"


### PR DESCRIPTION
1. Add heroicons package (SVG icons)
2. Add XDSIcon as a wrapper around it providing standard colors/sizes

I opted to use the "tree shaking friendly" icons where you have to actually import the icon component and then pass it into XDSIcon. Rather than just passing a string to label the icon. LMK your thoughts on this.

I also have it using semantic sizes (small/medium/large) instead of numeric (16/20/24). Not sure if that's better, LMK if I should change it!

Sizes:
<img width="1044" height="401" alt="image" src="https://github.com/user-attachments/assets/bde278ed-86c8-40ab-82b3-f36f0f7296a4" />

Colors:
<img width="1081" height="966" alt="image" src="https://github.com/user-attachments/assets/f5836e16-529b-4aa2-95f4-aa2a70799c3d" />
