### PR TITLE
Add startIcon to XDSTextInput

### DIFF
--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -1,6 +1,11 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSTextInput} from '@xds/core/TextInput';
+import {
+  MagnifyingGlassIcon,
+  EnvelopeIcon,
+  UserIcon,
+} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextInput> = {
   title: 'Core/XDSTextInput',
@@ -212,5 +217,69 @@ export const Disabled: Story = {
     label: 'Locked Field',
     isDisabled: true,
     value: 'Cannot edit this',
+  },
+};
+
+export const WithStartIcon: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Search',
+    placeholder: 'Search...',
+    startIcon: MagnifyingGlassIcon,
+  },
+};
+
+export const WithStartIconAndSmallSize: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Search',
+    placeholder: 'Search...',
+    startIcon: MagnifyingGlassIcon,
+    size: 'sm',
+  },
+};
+
+export const StartIconVariations: Story = {
+  render: () => {
+    const [search, setSearch] = useState('');
+    const [email, setEmail] = useState('');
+    const [username, setUsername] = useState('');
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '300px',
+        }}>
+        <XDSTextInput
+          label="Search"
+          value={search}
+          onChange={setSearch}
+          placeholder="Search..."
+          startIcon={MagnifyingGlassIcon}
+        />
+        <XDSTextInput
+          label="Email"
+          value={email}
+          onChange={setEmail}
+          placeholder="Enter your email"
+          startIcon={EnvelopeIcon}
+        />
+        <XDSTextInput
+          label="Username"
+          value={username}
+          onChange={setUsername}
+          placeholder="Enter your username"
+          startIcon={UserIcon}
+        />
+      </div>
+    );
   },
 };

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -1,7 +1,7 @@
 /**
  * @file XDSIcon.tsx
  * @input Uses React forwardRef, SVGProps, and @heroicons/react icon components
- * @output Exports XDSIcon component, XDSIconProps, XDSIconColor, XDSIconSize types
+ * @output Exports XDSIcon component, XDSIconProps, XDSIconColor, XDSIconSize, XDSIconType types
  * @position Core implementation; consumed by index.ts, tested by XDSIcon.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -82,6 +82,12 @@ export type XDSIconColor = keyof typeof colorStyles;
 export type XDSIconSize = keyof typeof sizeStyles;
 
 /**
+ * Type for icon components that can be passed to XDSIcon.
+ * Use this type when accepting an icon prop in other components.
+ */
+export type XDSIconType = ComponentType<SVGProps<SVGSVGElement>>;
+
+/**
  * Props for XDSIcon component.
  * Extends SVGProps to allow passing additional SVG attributes.
  */
@@ -91,7 +97,7 @@ export interface XDSIconProps
    * The Hero Icon component to render.
    * Import from @heroicons/react/24/outline or @heroicons/react/24/solid.
    */
-  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  icon: XDSIconType;
   /**
    * The color variant of the icon.
    * @default 'primary'

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -1,11 +1,16 @@
 /**
  * @file index.ts
  * @input Imports XDSIcon component and types from XDSIcon.tsx
- * @output Exports XDSIcon, XDSIconProps, XDSIconColor, XDSIconSize
+ * @output Exports XDSIcon, XDSIconProps, XDSIconColor, XDSIconSize, XDSIconType
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Icon/README.md
  */
 
 export {XDSIcon} from './XDSIcon';
-export type {XDSIconProps, XDSIconColor, XDSIconSize} from './XDSIcon';
+export type {
+  XDSIconProps,
+  XDSIconColor,
+  XDSIconSize,
+  XDSIconType,
+} from './XDSIcon';

--- a/packages/core/src/TextInput/XDSTextInput.test.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.test.tsx
@@ -10,6 +10,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 import {XDSTextInput} from './XDSTextInput';
 
 describe('XDSTextInput', () => {
@@ -25,7 +26,7 @@ describe('XDSTextInput', () => {
         value=""
         onChange={() => {}}
         placeholder="Enter text"
-      />,
+      />
     );
     expect(screen.getByPlaceholderText('Enter text')).toBeInTheDocument();
   });
@@ -53,11 +54,7 @@ describe('XDSTextInput', () => {
 
   it('displays controlled value', () => {
     render(
-      <XDSTextInput
-        label="Name"
-        value="Controlled value"
-        onChange={() => {}}
-      />,
+      <XDSTextInput label="Name" value="Controlled value" onChange={() => {}} />
     );
     expect(screen.getByRole('textbox')).toHaveValue('Controlled value');
   });
@@ -65,19 +62,14 @@ describe('XDSTextInput', () => {
   it('forwards ref correctly', () => {
     const ref = vi.fn();
     render(
-      <XDSTextInput ref={ref} label="Name" value="" onChange={() => {}} />,
+      <XDSTextInput ref={ref} label="Name" value="" onChange={() => {}} />
     );
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));
   });
 
   it('visually hides label when isLabelHidden is true', () => {
     render(
-      <XDSTextInput
-        label="Search"
-        isLabelHidden
-        value=""
-        onChange={() => {}}
-      />,
+      <XDSTextInput label="Search" isLabelHidden value="" onChange={() => {}} />
     );
     const label = screen.getByText('Search');
     expect(label).toBeInTheDocument();
@@ -93,11 +85,11 @@ describe('XDSTextInput', () => {
 
   it('sets aria-required when isRequired is true', () => {
     render(
-      <XDSTextInput label="Username" isRequired value="" onChange={() => {}} />,
+      <XDSTextInput label="Username" isRequired value="" onChange={() => {}} />
     );
     expect(screen.getByRole('textbox')).toHaveAttribute(
       'aria-required',
-      'true',
+      'true'
     );
   });
 
@@ -108,7 +100,7 @@ describe('XDSTextInput', () => {
 
   it('sets disabled attribute when isDisabled is true', () => {
     render(
-      <XDSTextInput label="Name" isDisabled value="" onChange={() => {}} />,
+      <XDSTextInput label="Name" isDisabled value="" onChange={() => {}} />
     );
     expect(screen.getByRole('textbox')).toBeDisabled();
   });
@@ -117,7 +109,7 @@ describe('XDSTextInput', () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
     render(
-      <XDSTextInput label="Name" isDisabled value="" onChange={handleChange} />,
+      <XDSTextInput label="Name" isDisabled value="" onChange={handleChange} />
     );
 
     const input = screen.getByRole('textbox');
@@ -128,5 +120,28 @@ describe('XDSTextInput', () => {
   it('is not disabled by default', () => {
     render(<XDSTextInput label="Name" value="" onChange={() => {}} />);
     expect(screen.getByRole('textbox')).not.toBeDisabled();
+  });
+
+  it('renders with startIcon', () => {
+    render(
+      <XDSTextInput
+        label="Search"
+        value=""
+        onChange={() => {}}
+        startIcon={MagnifyingGlassIcon}
+      />
+    );
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    // Icon should be rendered (as an SVG element)
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('renders without icon wrapper when startIcon is not provided', () => {
+    const {container} = render(
+      <XDSTextInput label="Name" value="" onChange={() => {}} />
+    );
+    // No SVG should be present
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
   });
 });

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSTextInput.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, XDSField
+ * @input Uses React forwardRef, useId, ChangeEvent, XDSField, XDSIcon
  * @output Exports XDSTextInput component, XDSTextInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSTextInput.test.tsx
  *
@@ -21,13 +21,15 @@ import {
   typographyVars,
 } from '../theme/tokens.stylex';
 import {XDSField} from '../Field';
+import {XDSIcon, type XDSIconType} from '../Icon';
 
 const styles = stylex.create({
-  input: {
-    display: 'block',
-    width: '100%',
-    paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
+  wrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
     borderWidth: '1px',
     borderStyle: 'solid',
     borderColor: {
@@ -35,31 +37,54 @@ const styles = stylex.create({
       ':hover': colorVars['--color-divider-high-contrast'],
     },
     borderRadius: radiusVars['--radius-element'],
-    fontFamily: typographyVars['--font-body'],
-    fontSize: '0.875rem',
-    lineHeight: 1.429,
-    color: colorVars['--color-text-primary'],
     backgroundColor: colorVars['--color-surface'],
     transitionProperty: 'border-color, outline',
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
-      ':focus': '1px',
-    },
-    '::placeholder': {
-      color: colorVars['--color-text-placeholder'],
+      ':focus-within': '1px',
     },
   },
-  disabled: {
+  wrapperDisabled: {
     cursor: 'not-allowed',
     opacity: 0.5,
     borderColor: colorVars['--color-divider-emphasized'],
   },
+  input: {
+    display: 'block',
+    flex: 1,
+    minWidth: 0,
+    border: 0,
+    padding: 0,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: '0.875rem',
+    lineHeight: 1.429,
+    color: colorVars['--color-text-primary'],
+    backgroundColor: 'transparent',
+    outline: 0,
+    '::placeholder': {
+      color: colorVars['--color-text-placeholder'],
+    },
+  },
+  inputDisabled: {
+    cursor: 'not-allowed',
+  },
 });
+
+const sizeStyles = stylex.create({
+  sm: {
+    height: 18,
+  },
+  md: {
+    height: 26,
+  },
+});
+
+export type XDSTextInputSize = keyof typeof sizeStyles;
 
 export interface XDSTextInputProps {
   /**
@@ -90,6 +115,18 @@ export interface XDSTextInputProps {
    * @default false
    */
   isDisabled?: boolean;
+  /**
+   * Icon to display at the start of the input.
+   * Import from @heroicons/react/24/outline or @heroicons/react/24/solid.
+   */
+  startIcon?: XDSIconType;
+  /**
+   * The size of the input.
+   * - 'sm': Compact size (18px height)
+   * - 'md': Default size (26px height)
+   * @default 'md'
+   */
+  size?: XDSTextInputSize;
   /**
    * Callback fired when the input value changes.
    */
@@ -122,11 +159,13 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
       isOptional = false,
       isRequired = false,
       isDisabled = false,
+      startIcon,
+      size = 'md',
       onChange,
       value,
       placeholder,
     },
-    ref,
+    ref
   ) => {
     const id = useId();
     const descriptionID = useId();
@@ -140,21 +179,32 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
         descriptionID={description ? descriptionID : undefined}
         isOptional={isOptional}
         isRequired={isRequired}>
-        <input
-          ref={ref}
-          id={id}
-          type="text"
-          value={value}
-          onChange={e => onChange(e.target.value, e)}
-          placeholder={placeholder}
-          disabled={isDisabled}
-          aria-describedby={description ? descriptionID : undefined}
-          aria-required={isRequired === true ? 'true' : undefined}
-          {...stylex.props(styles.input, isDisabled && styles.disabled)}
-        />
+        <div
+          {...stylex.props(
+            styles.wrapper,
+            isDisabled && styles.wrapperDisabled
+          )}>
+          {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
+          <input
+            ref={ref}
+            id={id}
+            type="text"
+            value={value}
+            onChange={e => onChange(e.target.value, e)}
+            placeholder={placeholder}
+            disabled={isDisabled}
+            aria-describedby={description ? descriptionID : undefined}
+            aria-required={isRequired === true ? 'true' : undefined}
+            {...stylex.props(
+              styles.input,
+              sizeStyles[size],
+              isDisabled && styles.inputDisabled
+            )}
+          />
+        </div>
       </XDSField>
     );
-  },
+  }
 );
 
 XDSTextInput.displayName = 'XDSTextInput';

--- a/packages/core/src/TextInput/index.ts
+++ b/packages/core/src/TextInput/index.ts
@@ -1,11 +1,11 @@
 /**
  * @file index.ts
  * @input Imports XDSTextInput component and types from TextInput.tsx
- * @output Exports XDSTextInput, XDSTextInputProps, XDSTextInputVariant
+ * @output Exports XDSTextInput, XDSTextInputProps, XDSTextInputSize
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/TextInput/README.md
  */
 
 export {XDSTextInput} from './XDSTextInput';
-export type {XDSTextInputProps} from './XDSTextInput';
+export type {XDSTextInputProps, XDSTextInputSize} from './XDSTextInput';


### PR DESCRIPTION
0. Add XDSIconType export to XDSIcon, this will be useful if we want to support non-SVG icons later.
1. Add startIcon prop using the new XDSIcon
2. Also add size prop (md = 36px, sm = 28px) which correspond to our current "default" and "compact" sizes. Could add other sizes later if we want.

<img width="1061" height="658" alt="image" src="https://github.com/user-attachments/assets/4295b65d-7cae-49c0-ac33-cf425660179e" />
