### PR TITLE
XDSCheckboxInput startIcon

### DIFF
--- a/apps/storybook/stories/CheckboxInput.stories.tsx
+++ b/apps/storybook/stories/CheckboxInput.stories.tsx
@@ -1,6 +1,11 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+import {
+  BellIcon,
+  EnvelopeIcon,
+  ShieldCheckIcon,
+} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSCheckboxInput> = {
   title: 'Core/XDSCheckboxInput',
@@ -234,6 +239,60 @@ export const SizeComparison: Story = {
           value={value4}
           onChange={setValue4}
           size="sm"
+        />
+      </div>
+    );
+  },
+};
+
+export const WithStartIcon: Story = {
+  render: args => {
+    const [value, setValue] = useState<boolean | 'indeterminate'>(
+      args.value ?? false
+    );
+    return <XDSCheckboxInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Enable notifications',
+    description: 'Receive alerts when important events occur',
+    startIcon: BellIcon,
+  },
+};
+
+export const StartIconVariations: Story = {
+  render: () => {
+    const [value1, setValue1] = useState<boolean | 'indeterminate'>(false);
+    const [value2, setValue2] = useState<boolean | 'indeterminate'>(true);
+    const [value3, setValue3] = useState<boolean | 'indeterminate'>(false);
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '400px',
+        }}>
+        <XDSCheckboxInput
+          label="Email notifications"
+          description="Receive updates via email"
+          value={value1}
+          onChange={setValue1}
+          startIcon={EnvelopeIcon}
+        />
+        <XDSCheckboxInput
+          label="Push notifications"
+          description="Get instant alerts on your device"
+          value={value2}
+          onChange={setValue2}
+          startIcon={BellIcon}
+        />
+        <XDSCheckboxInput
+          label="Two-factor authentication"
+          description="Add an extra layer of security"
+          value={value3}
+          onChange={setValue3}
+          startIcon={ShieldCheckIcon}
+          isDisabled
         />
       </div>
     );

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSCheckboxInput.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, XDSFieldLabel, useHoverState
+ * @input Uses React forwardRef, useId, ChangeEvent, XDSFieldLabel, useHoverState, XDSIconType
  * @output Exports XDSCheckboxInput component, XDSCheckboxInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSCheckboxInput.test.tsx
  *
@@ -22,6 +22,7 @@ import {
 } from '../theme/tokens.stylex';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
 import {useHoverState} from '../hooks/useHoverState';
+import type {XDSIconType} from '../Icon';
 
 const styles = stylex.create({
   container: {
@@ -210,6 +211,10 @@ export interface XDSCheckboxInputProps {
    * Callback fired when the checkbox loses focus.
    */
   onBlur?: (e: FocusEvent<HTMLInputElement>) => void;
+  /**
+   * Icon to display before the label text.
+   */
+  startIcon?: XDSIconType;
 }
 
 /**
@@ -246,6 +251,7 @@ export const XDSCheckboxInput = forwardRef<
       size = 'md',
       onFocus,
       onBlur,
+      startIcon,
     },
     ref
   ) => {
@@ -331,6 +337,7 @@ export const XDSCheckboxInput = forwardRef<
             inputID={id}
             isLabelHidden={isLabelHidden}
             isDisabled={isDisabled}
+            startIcon={startIcon}
           />
           {description && (
             <span id={descriptionID} {...stylex.props(styles.description)}>

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSField.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode, XDSFieldLabel
+ * @input Uses React forwardRef, HTMLAttributes, ReactNode, XDSFieldLabel, XDSIconType
  * @output Exports XDSField component, XDSFieldProps
  * @position Core implementation; consumed by index.ts, tested by XDSField.test.tsx
  *
@@ -15,6 +15,7 @@ import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSFieldLabel} from './XDSFieldLabel';
 import {colorVars, spacingVars, typographyVars} from '../theme/tokens.stylex';
+import type {XDSIconType} from '../Icon';
 
 const styles = stylex.create({
   container: {
@@ -61,10 +62,8 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSFieldProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'children'
-> {
+export interface XDSFieldProps
+  extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
   /**
    * Label text for the field (always rendered for accessibility).
    */
@@ -97,6 +96,10 @@ export interface XDSFieldProps extends Omit<
    */
   isRequired?: boolean;
   /**
+   * Icon to display before the label text.
+   */
+  labelStartIcon?: XDSIconType;
+  /**
    * The input or control to render inside the field.
    */
   children: ReactNode;
@@ -124,10 +127,11 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
       descriptionID,
       isOptional = false,
       isRequired = false,
+      labelStartIcon,
       children,
       ...props
     },
-    ref,
+    ref
   ) => {
     return (
       <div ref={ref} {...stylex.props(styles.container)} {...props}>
@@ -137,6 +141,7 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
           isLabelHidden={isLabelHidden}
           isOptional={isOptional}
           isRequired={isRequired}
+          startIcon={labelStartIcon}
         />
         {description && (
           <span id={descriptionID} {...stylex.props(styles.description)}>
@@ -146,7 +151,7 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
         {children}
       </div>
     );
-  },
+  }
 );
 
 XDSField.displayName = 'XDSField';

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSFieldLabel.tsx
- * @input Uses React forwardRef
+ * @input Uses React forwardRef, XDSIcon, XDSIconType
  * @output Exports XDSFieldLabel component, XDSFieldLabelProps
  * @position Core label implementation; used by XDSField, XDSCheckboxInput
  *
@@ -11,10 +11,14 @@
 
 import {forwardRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, typographyVars} from '../theme/tokens.stylex';
+import {colorVars, spacingVars, typographyVars} from '../theme/tokens.stylex';
+import {XDSIcon, type XDSIconType} from '../Icon';
 
 const styles = stylex.create({
   label: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-body'],
     fontSize: '0.875rem',
     fontWeight: 500,
@@ -78,6 +82,10 @@ export interface XDSFieldLabelProps {
    * @default false
    */
   isRequired?: boolean;
+  /**
+   * Icon to display before the label text.
+   */
+  startIcon?: XDSIconType;
 }
 
 /**
@@ -98,8 +106,9 @@ export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
       isDisabled = false,
       isOptional = false,
       isRequired = false,
+      startIcon,
     },
-    ref,
+    ref
   ) => {
     const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
 
@@ -111,8 +120,15 @@ export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
           styles.label,
           !isDisabled && styles.labelClickable,
           isDisabled && styles.labelDisabled,
-          isLabelHidden && styles.labelHidden,
+          isLabelHidden && styles.labelHidden
         )}>
+        {startIcon && (
+          <XDSIcon
+            icon={startIcon}
+            size="sm"
+            color={isDisabled ? 'disabled' : 'primary'}
+          />
+        )}
         {label}
         {statusText && (
           <span {...stylex.props(styles.optionalRequired)}>
@@ -122,7 +138,7 @@ export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
         )}
       </label>
     );
-  },
+  }
 );
 
 XDSFieldLabel.displayName = 'XDSFieldLabel';


### PR DESCRIPTION
Add startIcon prop to XDSCheckboxInput. I added it to XDSFieldLabel so we could use it in other components as well.

<img width="444" height="271" alt="image" src="https://github.com/user-attachments/assets/cbc2635d-a150-4fdb-a836-a6ebeeabfed2" />
