### PR TITLE
XDSTextInput tooltip prop

### DIFF
--- a/apps/storybook/stories/Field.stories.tsx
+++ b/apps/storybook/stories/Field.stories.tsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
-import type { Meta, StoryObj } from '@storybook/react';
-import { XDSField } from '@xds/core/Field';
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSField} from '@xds/core/Field';
 
 const meta: Meta<typeof XDSField> = {
   title: 'Core/XDSField',
@@ -13,7 +13,8 @@ const meta: Meta<typeof XDSField> = {
     },
     isLabelHidden: {
       control: 'boolean',
-      description: 'Visually hide the label (still accessible to screen readers)',
+      description:
+        'Visually hide the label (still accessible to screen readers)',
     },
     description: {
       control: 'text',
@@ -21,7 +22,8 @@ const meta: Meta<typeof XDSField> = {
     },
     inputID: {
       control: 'text',
-      description: 'ID for the input element (used for label htmlFor attribute)',
+      description:
+        'ID for the input element (used for label htmlFor attribute)',
     },
     descriptionID: {
       control: 'text',
@@ -29,11 +31,18 @@ const meta: Meta<typeof XDSField> = {
     },
     isOptional: {
       control: 'boolean',
-      description: 'Whether the field is optional (mutually exclusive with isRequired)',
+      description:
+        'Whether the field is optional (mutually exclusive with isRequired)',
     },
     isRequired: {
       control: 'boolean',
-      description: 'Whether the field is required (mutually exclusive with isOptional)',
+      description:
+        'Whether the field is required (mutually exclusive with isOptional)',
+    },
+    labelTooltip: {
+      control: 'text',
+      description:
+        'Tooltip text to display in an info icon at the end of the label',
     },
   },
 };
@@ -42,15 +51,20 @@ export default meta;
 type Story = StoryObj<typeof XDSField>;
 
 export const Default: Story = {
-  render: (args) => {
+  render: args => {
     const [value, setValue] = useState('');
     return (
       <XDSField {...args} inputID="email-input">
         <input
           id="email-input"
           value={value}
-          onChange={(e) => setValue(e.target.value)}
-          style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+          onChange={e => setValue(e.target.value)}
+          style={{
+            padding: '8px',
+            fontSize: '14px',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
         />
       </XDSField>
     );
@@ -61,7 +75,7 @@ export const Default: Story = {
 };
 
 export const WithDescription: Story = {
-  render: (args) => {
+  render: args => {
     const [value, setValue] = useState('');
     return (
       <XDSField {...args} inputID="email-input" descriptionID="email-desc">
@@ -69,8 +83,13 @@ export const WithDescription: Story = {
           id="email-input"
           aria-describedby="email-desc"
           value={value}
-          onChange={(e) => setValue(e.target.value)}
-          style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+          onChange={e => setValue(e.target.value)}
+          style={{
+            padding: '8px',
+            fontSize: '14px',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
         />
       </XDSField>
     );
@@ -82,16 +101,21 @@ export const WithDescription: Story = {
 };
 
 export const WithHiddenLabel: Story = {
-  render: (args) => {
+  render: args => {
     const [value, setValue] = useState('');
     return (
       <XDSField {...args} inputID="search-input">
         <input
           id="search-input"
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={e => setValue(e.target.value)}
           placeholder="Search..."
-          style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+          style={{
+            padding: '8px',
+            fontSize: '14px',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
         />
       </XDSField>
     );
@@ -110,47 +134,87 @@ export const AllVariations: Story = {
     const [value4, setValue4] = useState('');
     const [value5, setValue5] = useState('');
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: '24px', maxWidth: '300px' }}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '24px',
+          maxWidth: '300px',
+        }}>
         <XDSField label="Default field" inputID="default-input">
           <input
             id="default-input"
             value={value1}
-            onChange={(e) => setValue1(e.target.value)}
-            style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+            onChange={e => setValue1(e.target.value)}
+            style={{
+              padding: '8px',
+              fontSize: '14px',
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
           />
         </XDSField>
-        <XDSField label="With description" description="This is helpful information" inputID="desc-input" descriptionID="desc-text">
+        <XDSField
+          label="With description"
+          description="This is helpful information"
+          inputID="desc-input"
+          descriptionID="desc-text">
           <input
             id="desc-input"
             aria-describedby="desc-text"
             value={value2}
-            onChange={(e) => setValue2(e.target.value)}
-            style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+            onChange={e => setValue2(e.target.value)}
+            style={{
+              padding: '8px',
+              fontSize: '14px',
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
           />
         </XDSField>
         <XDSField label="Optional field" isOptional inputID="optional-input">
           <input
             id="optional-input"
             value={value3}
-            onChange={(e) => setValue3(e.target.value)}
-            style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+            onChange={e => setValue3(e.target.value)}
+            style={{
+              padding: '8px',
+              fontSize: '14px',
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
           />
         </XDSField>
         <XDSField label="Required field" isRequired inputID="required-input">
           <input
             id="required-input"
             value={value4}
-            onChange={(e) => setValue4(e.target.value)}
-            style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+            onChange={e => setValue4(e.target.value)}
+            style={{
+              padding: '8px',
+              fontSize: '14px',
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
           />
         </XDSField>
-        <XDSField label="With description and optional" description="Enter your nickname" isOptional inputID="desc-optional-input" descriptionID="desc-optional-text">
+        <XDSField
+          label="With description and optional"
+          description="Enter your nickname"
+          isOptional
+          inputID="desc-optional-input"
+          descriptionID="desc-optional-text">
           <input
             id="desc-optional-input"
             aria-describedby="desc-optional-text"
             value={value5}
-            onChange={(e) => setValue5(e.target.value)}
-            style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+            onChange={e => setValue5(e.target.value)}
+            style={{
+              padding: '8px',
+              fontSize: '14px',
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
           />
         </XDSField>
       </div>
@@ -159,16 +223,21 @@ export const AllVariations: Story = {
 };
 
 export const OptionalField: Story = {
-  render: (args) => {
+  render: args => {
     const [value, setValue] = useState('');
     return (
       <XDSField {...args} inputID="nickname-input">
         <input
           id="nickname-input"
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={e => setValue(e.target.value)}
           placeholder="Enter your nickname"
-          style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+          style={{
+            padding: '8px',
+            fontSize: '14px',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
         />
       </XDSField>
     );
@@ -180,16 +249,21 @@ export const OptionalField: Story = {
 };
 
 export const RequiredField: Story = {
-  render: (args) => {
+  render: args => {
     const [value, setValue] = useState('');
     return (
       <XDSField {...args} inputID="username-input">
         <input
           id="username-input"
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={e => setValue(e.target.value)}
           placeholder="Enter your username"
-          style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+          style={{
+            padding: '8px',
+            fontSize: '14px',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
         />
       </XDSField>
     );
@@ -201,7 +275,7 @@ export const RequiredField: Story = {
 };
 
 export const DescriptionWithOptional: Story = {
-  render: (args) => {
+  render: args => {
     const [value, setValue] = useState('');
     return (
       <XDSField {...args} inputID="bio-input" descriptionID="bio-desc">
@@ -209,9 +283,14 @@ export const DescriptionWithOptional: Story = {
           id="bio-input"
           aria-describedby="bio-desc"
           value={value}
-          onChange={(e) => setValue(e.target.value)}
+          onChange={e => setValue(e.target.value)}
           placeholder="Tell us about yourself"
-          style={{ padding: '8px', fontSize: '14px', width: '100%', boxSizing: 'border-box' }}
+          style={{
+            padding: '8px',
+            fontSize: '14px',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
         />
       </XDSField>
     );
@@ -219,6 +298,59 @@ export const DescriptionWithOptional: Story = {
   args: {
     label: 'Bio',
     description: 'A short description about yourself',
+    isOptional: true,
+  },
+};
+
+export const WithTooltip: Story = {
+  render: args => {
+    const [value, setValue] = useState('');
+    return (
+      <XDSField {...args} inputID="tooltip-input">
+        <input
+          id="tooltip-input"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          placeholder="Enter value"
+          style={{
+            padding: '8px',
+            fontSize: '14px',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
+        />
+      </XDSField>
+    );
+  },
+  args: {
+    label: 'API Key',
+    labelTooltip: 'Your unique API key for authentication. Keep this secret!',
+  },
+};
+
+export const TooltipWithOptional: Story = {
+  render: args => {
+    const [value, setValue] = useState('');
+    return (
+      <XDSField {...args} inputID="tooltip-optional-input">
+        <input
+          id="tooltip-optional-input"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          placeholder="Enter value"
+          style={{
+            padding: '8px',
+            fontSize: '14px',
+            width: '100%',
+            boxSizing: 'border-box',
+          }}
+        />
+      </XDSField>
+    );
+  },
+  args: {
+    label: 'Webhook URL',
+    labelTooltip: 'The URL where we will send event notifications.',
     isOptional: true,
   },
 };

--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -52,6 +52,11 @@ const meta: Meta<typeof XDSTextInput> = {
       description:
         'Status indicator with type (warning/error/success) and optional message',
     },
+    labelTooltip: {
+      control: 'text',
+      description:
+        'Tooltip text to display in an info icon at the end of the label',
+    },
   },
 };
 
@@ -377,5 +382,30 @@ export const StatusVariations: Story = {
         />
       </div>
     );
+  },
+};
+
+export const WithTooltip: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'API Key',
+    placeholder: 'Enter your API key',
+    labelTooltip: 'Your unique API key for authentication. Keep this secret!',
+  },
+};
+
+export const TooltipWithOptional: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Webhook URL',
+    placeholder: 'https://example.com/webhook',
+    labelTooltip: 'The URL where we will send event notifications.',
+    isOptional: true,
   },
 };

--- a/packages/core/src/Field/README.md
+++ b/packages/core/src/Field/README.md
@@ -9,6 +9,7 @@ A form field wrapper component that provides label and description.
 - **Label Support**: Required label for accessibility (can be visually hidden)
 - **Description**: Optional description text displayed between the label and input
 - **Optional/Required Indicators**: Display "Optional" or "Required" text with bullet separator
+- **Label Tooltip**: Optional info icon with tooltip at end of label
 - **Accessible**: Label properly associated with input via htmlFor/id
 - **Styled with StyleX**: Uses XDS design tokens for consistent styling
 
@@ -68,16 +69,18 @@ const bioDescId = useId();
 
 ## Props
 
-| Prop            | Type        | Required | Description                                                            |
-| --------------- | ----------- | -------- | ---------------------------------------------------------------------- |
-| `label`         | `string`    | Yes      | Label text for the field (always rendered for accessibility)           |
-| `isLabelHidden` | `boolean`   | No       | Visually hide the label (still accessible to screen readers)           |
-| `description`   | `string`    | No       | Description text displayed between the label and input                 |
-| `inputID`       | `string`    | Yes      | ID for the input element (used for label's htmlFor attribute)          |
-| `descriptionID` | `string`    | No       | ID for the description element (use for aria-describedby on the input) |
-| `isOptional`    | `boolean`   | No       | Whether the field is optional (mutually exclusive with isRequired)     |
-| `isRequired`    | `boolean`   | No       | Whether the field is required (mutually exclusive with isOptional)     |
-| `children`      | `ReactNode` | Yes      | The input or control to render                                         |
+| Prop             | Type          | Required | Description                                                            |
+| ---------------- | ------------- | -------- | ---------------------------------------------------------------------- |
+| `label`          | `string`      | Yes      | Label text for the field (always rendered for accessibility)           |
+| `isLabelHidden`  | `boolean`     | No       | Visually hide the label (still accessible to screen readers)           |
+| `description`    | `string`      | No       | Description text displayed between the label and input                 |
+| `inputID`        | `string`      | Yes      | ID for the input element (used for label's htmlFor attribute)          |
+| `descriptionID`  | `string`      | No       | ID for the description element (use for aria-describedby on the input) |
+| `isOptional`     | `boolean`     | No       | Whether the field is optional (mutually exclusive with isRequired)     |
+| `isRequired`     | `boolean`     | No       | Whether the field is required (mutually exclusive with isOptional)     |
+| `labelStartIcon` | `XDSIconType` | No       | Icon to display before the label text                                  |
+| `labelTooltip`   | `string`      | No       | Tooltip text to display in an info icon at the end of the label        |
+| `children`       | `ReactNode`   | Yes      | The input or control to render                                         |
 
 ## Files
 

--- a/packages/core/src/Field/XDSField.test.tsx
+++ b/packages/core/src/Field/XDSField.test.tsx
@@ -16,7 +16,7 @@ describe('XDSField', () => {
     render(
       <XDSField label="Email" inputID="email-input">
         <input id="email-input" />
-      </XDSField>,
+      </XDSField>
     );
     expect(screen.getByLabelText('Email')).toBeInTheDocument();
   });
@@ -29,10 +29,10 @@ describe('XDSField', () => {
         description="We'll never share your email"
         descriptionID="email-desc">
         <input id="email-input" aria-describedby="email-desc" />
-      </XDSField>,
+      </XDSField>
     );
     expect(
-      screen.getByText("We'll never share your email"),
+      screen.getByText("We'll never share your email")
     ).toBeInTheDocument();
   });
 
@@ -44,7 +44,7 @@ describe('XDSField', () => {
         description="Description text"
         descriptionID="email-desc">
         <input id="email-input" aria-describedby="email-desc" />
-      </XDSField>,
+      </XDSField>
     );
     const description = screen.getByText('Description text');
     expect(description).toHaveAttribute('id', 'email-desc');
@@ -54,7 +54,7 @@ describe('XDSField', () => {
     render(
       <XDSField label="Search" isLabelHidden inputID="search-input">
         <input id="search-input" />
-      </XDSField>,
+      </XDSField>
     );
     const label = screen.getByText('Search');
     expect(label).toBeInTheDocument();
@@ -66,7 +66,7 @@ describe('XDSField', () => {
     render(
       <XDSField label="Email" inputID="email-input">
         <input id="email-input" />
-      </XDSField>,
+      </XDSField>
     );
     const label = screen.getByText('Email');
     expect(label).toBeVisible();
@@ -77,7 +77,7 @@ describe('XDSField', () => {
     render(
       <XDSField ref={ref} label="Name" inputID="name-input">
         <input id="name-input" />
-      </XDSField>,
+      </XDSField>
     );
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
   });
@@ -89,7 +89,7 @@ describe('XDSField', () => {
         inputID="email-input"
         description="Description text">
         <input id="email-input" />
-      </XDSField>,
+      </XDSField>
     );
     const description = screen.getByText('Description text');
     expect(description).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('XDSField', () => {
     render(
       <XDSField label="Name" inputID="name-input" isOptional>
         <input id="name-input" />
-      </XDSField>,
+      </XDSField>
     );
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText(/Optional/)).toBeInTheDocument();
@@ -110,7 +110,7 @@ describe('XDSField', () => {
     render(
       <XDSField label="Name" inputID="name-input" isRequired>
         <input id="name-input" />
-      </XDSField>,
+      </XDSField>
     );
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText(/Required/)).toBeInTheDocument();
@@ -125,7 +125,7 @@ describe('XDSField', () => {
         descriptionID="name-desc"
         isOptional>
         <input id="name-input" aria-describedby="name-desc" />
-      </XDSField>,
+      </XDSField>
     );
     expect(screen.getByText('Enter your name')).toBeInTheDocument();
     expect(screen.getByText(/Optional/)).toBeInTheDocument();
@@ -140,7 +140,7 @@ describe('XDSField', () => {
         descriptionID="name-desc"
         isRequired>
         <input id="name-input" aria-describedby="name-desc" />
-      </XDSField>,
+      </XDSField>
     );
     expect(screen.getByText('This field is mandatory')).toBeInTheDocument();
     expect(screen.getByText(/Required/)).toBeInTheDocument();
@@ -150,9 +150,28 @@ describe('XDSField', () => {
     render(
       <XDSField label="Name" inputID="name-input" isOptional>
         <input id="name-input" />
-      </XDSField>,
+      </XDSField>
     );
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText(/∙.*Optional/)).toBeInTheDocument();
+  });
+
+  it('renders tooltip info icon when labelTooltip is provided', () => {
+    render(
+      <XDSField label="Help" inputID="help-input" labelTooltip="Helpful info">
+        <input id="help-input" />
+      </XDSField>
+    );
+    // Info icon should be present
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('does not render tooltip icon when labelTooltip is not provided', () => {
+    render(
+      <XDSField label="Name" inputID="name-input">
+        <input id="name-input" />
+      </XDSField>
+    );
+    expect(document.querySelector('svg')).not.toBeInTheDocument();
   });
 });

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -158,6 +158,10 @@ export interface XDSFieldProps
    */
   status?: XDSFieldStatus;
   /**
+   * Tooltip text to display in an info icon at the end of the label.
+   */
+  labelTooltip?: string;
+  /**
    * The input or control to render inside the field.
    */
   children: ReactNode;
@@ -187,6 +191,7 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
       isRequired = false,
       labelStartIcon,
       status,
+      labelTooltip,
       children,
       ...props
     },
@@ -201,6 +206,7 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
           isOptional={isOptional}
           isRequired={isRequired}
           startIcon={labelStartIcon}
+          tooltip={labelTooltip}
         />
         {description && (
           <span id={descriptionID} {...stylex.props(styles.description)}>

--- a/packages/core/src/Field/XDSFieldLabel.test.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * @file XDSFieldLabel.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSFieldLabel component
+ * @output Unit tests for XDSFieldLabel component behavior
+ * @position Testing; validates XDSFieldLabel.tsx implementation
+ *
+ * SYNC: When XDSFieldLabel.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {StarIcon} from '@heroicons/react/24/outline';
+import {XDSFieldLabel} from './XDSFieldLabel';
+
+describe('XDSFieldLabel', () => {
+  it('renders label text', () => {
+    render(<XDSFieldLabel label="Email" inputID="email-input" />);
+    expect(screen.getByText('Email')).toBeInTheDocument();
+  });
+
+  it('associates label with input via htmlFor', () => {
+    render(<XDSFieldLabel label="Email" inputID="email-input" />);
+    const label = screen.getByText('Email').closest('label');
+    expect(label).toHaveAttribute('for', 'email-input');
+  });
+
+  it('renders Optional text when isOptional is true', () => {
+    render(<XDSFieldLabel label="Name" inputID="name-input" isOptional />);
+    expect(screen.getByText(/Optional/)).toBeInTheDocument();
+  });
+
+  it('renders Required text when isRequired is true', () => {
+    render(<XDSFieldLabel label="Name" inputID="name-input" isRequired />);
+    expect(screen.getByText(/Required/)).toBeInTheDocument();
+  });
+
+  it('shows Optional when both isOptional and isRequired are true', () => {
+    render(
+      <XDSFieldLabel label="Name" inputID="name-input" isOptional isRequired />
+    );
+    expect(screen.getByText(/Optional/)).toBeInTheDocument();
+    expect(screen.queryByText(/Required/)).not.toBeInTheDocument();
+  });
+
+  it('renders startIcon when provided', () => {
+    render(
+      <XDSFieldLabel
+        label="Starred"
+        inputID="starred-input"
+        startIcon={StarIcon}
+      />
+    );
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(<XDSFieldLabel ref={ref} label="Name" inputID="name-input" />);
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLLabelElement));
+  });
+
+  it('renders tooltip info icon when tooltip prop is provided', () => {
+    render(
+      <XDSFieldLabel
+        label="Help"
+        inputID="help-input"
+        tooltip="This is helpful information"
+      />
+    );
+    // Two SVGs: the info icon is wrapped in tooltip
+    const svgs = document.querySelectorAll('svg');
+    expect(svgs.length).toBeGreaterThan(0);
+  });
+
+  it('does not render extra icon when tooltip is not provided', () => {
+    render(<XDSFieldLabel label="Name" inputID="name-input" />);
+    // No SVGs should be present when no icons are provided
+    expect(document.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  it('renders tooltip with Optional indicator together', () => {
+    render(
+      <XDSFieldLabel
+        label="Field"
+        inputID="field-input"
+        isOptional
+        tooltip="Help text"
+      />
+    );
+    expect(screen.getByText(/Optional/)).toBeInTheDocument();
+    // Info icon should be present
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -11,8 +11,10 @@
 
 import {forwardRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import {InformationCircleIcon} from '@heroicons/react/24/outline';
 import {colorVars, spacingVars, typographyVars} from '../theme/tokens.stylex';
 import {XDSIcon, type XDSIconType} from '../Icon';
+import {XDSTooltip} from '../Layer';
 
 const styles = stylex.create({
   label: {
@@ -86,6 +88,10 @@ export interface XDSFieldLabelProps {
    * Icon to display before the label text.
    */
   startIcon?: XDSIconType;
+  /**
+   * Tooltip text to display in an info icon at the end of the label.
+   */
+  tooltip?: string;
 }
 
 /**
@@ -107,6 +113,7 @@ export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
       isOptional = false,
       isRequired = false,
       startIcon,
+      tooltip,
     },
     ref
   ) => {
@@ -135,6 +142,15 @@ export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
             {' '}
             ∙ {statusText}
           </span>
+        )}
+        {tooltip && (
+          <XDSTooltip content={tooltip} placement="above">
+            <XDSIcon
+              icon={InformationCircleIcon}
+              size="sm"
+              color={isDisabled ? 'disabled' : 'secondary'}
+            />
+          </XDSTooltip>
         )}
       </label>
     );

--- a/packages/core/src/TextInput/README.md
+++ b/packages/core/src/TextInput/README.md
@@ -9,6 +9,7 @@ A text input component for collecting user text input.
 - **Label Support**: Required label for accessibility (can be visually hidden)
 - **Description**: Optional description text displayed between the label and input
 - **Optional/Required Indicators**: Display "Optional" or "Required" text with bullet separator
+- **Label Tooltip**: Optional info icon with tooltip at end of label
 - **Accessible**: Label properly associated with input via htmlFor/id
 - **Styled with StyleX**: Uses XDS design tokens for consistent styling
 
@@ -51,6 +52,7 @@ import { XDSTextInput } from '@xds/core/TextInput';
 | `isOptional`    | `boolean`                                                   | No       | Whether the field is optional (mutually exclusive with isRequired) |
 | `isRequired`    | `boolean`                                                   | No       | Whether the field is required (mutually exclusive with isOptional) |
 | `placeholder`   | `string`                                                    | No       | Placeholder text                                                   |
+| `labelTooltip`  | `string`                                                    | No       | Tooltip text to display in an info icon at the end of the label    |
 
 ## Files
 

--- a/packages/core/src/TextInput/XDSTextInput.test.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.test.tsx
@@ -263,4 +263,22 @@ describe('XDSTextInput', () => {
       expect(describedBy).toContain(messageElement.id);
     });
   });
+
+  it('renders tooltip info icon when labelTooltip is provided', () => {
+    render(
+      <XDSTextInput
+        label="Help"
+        value=""
+        onChange={() => {}}
+        labelTooltip="Helpful info"
+      />
+    );
+    // Info icon should be present
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('does not render tooltip icon when labelTooltip is not provided', () => {
+    render(<XDSTextInput label="Name" value="" onChange={() => {}} />);
+    expect(document.querySelector('svg')).not.toBeInTheDocument();
+  });
 });

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -177,6 +177,10 @@ export interface XDSTextInputProps {
    * Placeholder text shown when the input is empty.
    */
   placeholder?: string;
+  /**
+   * Tooltip text to display in an info icon at the end of the label.
+   */
+  labelTooltip?: string;
 }
 
 /**
@@ -203,6 +207,7 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
       onChange,
       value,
       placeholder,
+      labelTooltip,
     },
     ref
   ) => {
@@ -250,7 +255,8 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
                 messageID: status.message ? statusMessageID : undefined,
               }
             : undefined
-        }>
+        }
+        labelTooltip={labelTooltip}>
         <div
           {...stylex.props(
             styles.wrapper,


### PR DESCRIPTION
Adding tooltip prop to XDSField / XDSFieldLabel / XDSTextInput.

<img width="442" height="165" alt="image" src="https://github.com/user-attachments/assets/6700c207-c0db-4f05-a094-c381ae9a4fce" />

I called it `tooltip` rather than `helpMessage` since that seems more standard, but we can change it if we want.
