### PR TITLE
adding XDSTextArea additional props

### DIFF
--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -1,6 +1,11 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSTextArea} from '@xds/core/TextArea';
+import {XDSTextArea, type XDSTextAreaStatus} from '@xds/core/TextArea';
+import {
+  DocumentTextIcon,
+  ChatBubbleLeftIcon,
+  PencilSquareIcon,
+} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextArea> = {
   title: 'Core/XDSTextArea',
@@ -45,6 +50,25 @@ const meta: Meta<typeof XDSTextArea> = {
     isDisabled: {
       control: 'boolean',
       description: 'Whether the textarea is disabled',
+    },
+    status: {
+      control: 'object',
+      description:
+        'Status indicator with type (warning/error/success) and optional message',
+    },
+    labelTooltip: {
+      control: 'text',
+      description:
+        'Tooltip text to display in an info icon at the end of the label',
+    },
+    hasSpellCheck: {
+      control: 'boolean',
+      description: 'Whether to enable browser spell checking (default: true)',
+    },
+    maxLength: {
+      control: 'number',
+      description:
+        'Maximum number of characters allowed. Displays a counter when set.',
     },
   },
 };
@@ -91,7 +115,7 @@ export const WithValue: Story = {
   render: args => {
     const [value, setValue] = useState(
       args.value ??
-        'This is a pre-filled textarea with some content that demonstrates how the component handles existing text.',
+        'This is a pre-filled textarea with some content that demonstrates how the component handles existing text.'
     );
     return <XDSTextArea {...args} value={value} onChange={setValue} />;
   },
@@ -234,7 +258,7 @@ export const DescriptionWithOptional: Story = {
 export const Disabled: Story = {
   render: args => {
     const [value, setValue] = useState(
-      args.value ?? 'This textarea is disabled and cannot be edited.',
+      args.value ?? 'This textarea is disabled and cannot be edited.'
     );
     return <XDSTextArea {...args} value={value} onChange={setValue} />;
   },
@@ -242,5 +266,280 @@ export const Disabled: Story = {
     label: 'Disabled Field',
     isDisabled: true,
     value: 'This textarea is disabled and cannot be edited.',
+  },
+};
+
+export const WithStartIcon: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Notes',
+    placeholder: 'Enter your notes...',
+    startIcon: DocumentTextIcon,
+  },
+};
+
+export const StartIconVariations: Story = {
+  render: () => {
+    const [notes, setNotes] = useState('');
+    const [message, setMessage] = useState('');
+    const [draft, setDraft] = useState('');
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '400px',
+        }}>
+        <XDSTextArea
+          label="Notes"
+          value={notes}
+          onChange={setNotes}
+          placeholder="Enter your notes..."
+          startIcon={DocumentTextIcon}
+        />
+        <XDSTextArea
+          label="Message"
+          value={message}
+          onChange={setMessage}
+          placeholder="Type your message..."
+          startIcon={ChatBubbleLeftIcon}
+        />
+        <XDSTextArea
+          label="Draft"
+          value={draft}
+          onChange={setDraft}
+          placeholder="Write your draft..."
+          startIcon={PencilSquareIcon}
+        />
+      </div>
+    );
+  },
+};
+
+export const ErrorStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? 'Too short');
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Description',
+    placeholder: 'Enter a description...',
+    status: {
+      type: 'error',
+      message: 'Description must be at least 50 characters',
+    },
+  },
+};
+
+export const WarningStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState(
+      args.value ?? 'This content may contain issues'
+    );
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Content',
+    placeholder: 'Enter content...',
+    status: {
+      type: 'warning',
+      message: 'Content may need review before publishing',
+    },
+  },
+};
+
+export const SuccessStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState(
+      args.value ?? 'This is a valid description that meets all requirements.'
+    );
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Description',
+    placeholder: 'Enter a description...',
+    status: {type: 'success', message: 'Description looks good!'},
+  },
+};
+
+export const StatusWithoutMessage: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? 'Invalid content');
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Field',
+    placeholder: 'Enter value',
+    status: {type: 'error'},
+  },
+};
+
+export const StatusVariations: Story = {
+  render: () => {
+    const [error, setError] = useState('Too short');
+    const [warning, setWarning] = useState('This may need review');
+    const [success, setSuccess] = useState(
+      'This description meets all the requirements perfectly.'
+    );
+    const [errorNoMsg, setErrorNoMsg] = useState('Invalid');
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '400px',
+        }}>
+        <XDSTextArea
+          label="Error with message"
+          value={error}
+          onChange={setError}
+          status={{type: 'error', message: 'Must be at least 50 characters'}}
+        />
+        <XDSTextArea
+          label="Warning with message"
+          value={warning}
+          onChange={setWarning}
+          status={{type: 'warning', message: 'Content may need review'}}
+        />
+        <XDSTextArea
+          label="Success with message"
+          value={success}
+          onChange={setSuccess}
+          status={{type: 'success', message: 'Description is valid'}}
+        />
+        <XDSTextArea
+          label="Error without message"
+          value={errorNoMsg}
+          onChange={setErrorNoMsg}
+          status={{type: 'error'}}
+        />
+      </div>
+    );
+  },
+};
+
+export const WithTooltip: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'API Documentation',
+    placeholder: 'Describe your API endpoint...',
+    labelTooltip:
+      'Provide a detailed description of what this API endpoint does, including expected inputs and outputs.',
+  },
+};
+
+export const TooltipWithOptional: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Additional Notes',
+    placeholder: 'Any additional information...',
+    labelTooltip:
+      'Include any extra details that might be helpful for reviewers.',
+    isOptional: true,
+  },
+};
+
+export const CombinedFeatures: Story = {
+  render: () => {
+    const [value, setValue] = useState('');
+    return (
+      <div style={{maxWidth: '400px'}}>
+        <XDSTextArea
+          label="Detailed Description"
+          description="Provide a comprehensive description of your project"
+          value={value}
+          onChange={setValue}
+          placeholder="Enter description..."
+          startIcon={DocumentTextIcon}
+          labelTooltip="This description will be visible to all team members"
+          isRequired
+          status={
+            value.length > 0 && value.length < 20
+              ? {type: 'warning', message: 'Consider adding more detail'}
+              : value.length >= 20
+              ? {type: 'success', message: 'Description looks good!'}
+              : undefined
+          }
+        />
+      </div>
+    );
+  },
+};
+
+export const WithMaxLength: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Bio',
+    placeholder: 'Tell us about yourself...',
+    maxLength: 150,
+  },
+};
+
+export const MaxLengthWithValue: Story = {
+  render: args => {
+    const [value, setValue] = useState(
+      args.value ??
+        'This is a pre-filled bio that demonstrates the character counter.'
+    );
+    return <XDSTextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Bio',
+    maxLength: 100,
+  },
+};
+
+export const MaxLengthVariations: Story = {
+  render: () => {
+    const [short, setShort] = useState('');
+    const [medium, setMedium] = useState('Some text here');
+    const [long, setLong] = useState(
+      'This is a longer text that approaches the maximum length limit.'
+    );
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '400px',
+        }}>
+        <XDSTextArea
+          label="Short limit"
+          value={short}
+          onChange={setShort}
+          placeholder="Max 50 characters"
+          maxLength={50}
+        />
+        <XDSTextArea
+          label="Medium limit"
+          value={medium}
+          onChange={setMedium}
+          placeholder="Max 100 characters"
+          maxLength={100}
+        />
+        <XDSTextArea
+          label="Long limit"
+          value={long}
+          onChange={setLong}
+          placeholder="Max 200 characters"
+          maxLength={200}
+        />
+      </div>
+    );
   },
 };

--- a/packages/core/src/TextArea/XDSTextArea.test.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.test.tsx
@@ -8,8 +8,9 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
 import {XDSTextArea} from './XDSTextArea';
 
 describe('XDSTextArea', () => {
@@ -25,10 +26,10 @@ describe('XDSTextArea', () => {
         value=""
         onChange={() => {}}
         placeholder="Enter description"
-      />,
+      />
     );
     expect(
-      screen.getByPlaceholderText('Enter description'),
+      screen.getByPlaceholderText('Enter description')
     ).toBeInTheDocument();
   });
 
@@ -36,7 +37,7 @@ describe('XDSTextArea', () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
     render(
-      <XDSTextArea label="Description" value="" onChange={handleChange} />,
+      <XDSTextArea label="Description" value="" onChange={handleChange} />
     );
 
     const textarea = screen.getByRole('textbox');
@@ -61,7 +62,7 @@ describe('XDSTextArea', () => {
         label="Description"
         value="Controlled value"
         onChange={() => {}}
-      />,
+      />
     );
     expect(screen.getByRole('textbox')).toHaveValue('Controlled value');
   });
@@ -69,12 +70,7 @@ describe('XDSTextArea', () => {
   it('forwards ref correctly', () => {
     const ref = vi.fn();
     render(
-      <XDSTextArea
-        ref={ref}
-        label="Description"
-        value=""
-        onChange={() => {}}
-      />,
+      <XDSTextArea ref={ref} label="Description" value="" onChange={() => {}} />
     );
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLTextAreaElement));
   });
@@ -86,7 +82,7 @@ describe('XDSTextArea', () => {
         isLabelHidden
         value=""
         onChange={() => {}}
-      />,
+      />
     );
     const label = screen.getByText('Comments');
     expect(label).toBeInTheDocument();
@@ -102,11 +98,11 @@ describe('XDSTextArea', () => {
 
   it('sets aria-required when isRequired is true', () => {
     render(
-      <XDSTextArea label="Feedback" isRequired value="" onChange={() => {}} />,
+      <XDSTextArea label="Feedback" isRequired value="" onChange={() => {}} />
     );
     expect(screen.getByRole('textbox')).toHaveAttribute(
       'aria-required',
-      'true',
+      'true'
     );
   });
 
@@ -117,7 +113,7 @@ describe('XDSTextArea', () => {
 
   it('renders with custom rows', () => {
     render(
-      <XDSTextArea label="Description" value="" onChange={() => {}} rows={5} />,
+      <XDSTextArea label="Description" value="" onChange={() => {}} rows={5} />
     );
     expect(screen.getByRole('textbox')).toHaveAttribute('rows', '5');
   });
@@ -134,7 +130,7 @@ describe('XDSTextArea', () => {
         isDisabled
         value=""
         onChange={() => {}}
-      />,
+      />
     );
     expect(screen.getByRole('textbox')).toBeDisabled();
   });
@@ -153,11 +149,337 @@ describe('XDSTextArea', () => {
         isDisabled
         value=""
         onChange={handleChange}
-      />,
+      />
     );
 
     const textarea = screen.getByRole('textbox');
     await user.type(textarea, 'Hi');
     expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('renders with startIcon', () => {
+    render(
+      <XDSTextArea
+        label="Description"
+        value=""
+        onChange={() => {}}
+        startIcon={MagnifyingGlassIcon}
+      />
+    );
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    // Icon should be rendered (as an SVG element)
+    const svg = document.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('renders without icon wrapper when startIcon is not provided', () => {
+    const {container} = render(
+      <XDSTextArea label="Description" value="" onChange={() => {}} />
+    );
+    // No SVG should be present
+    expect(container.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  describe('status prop', () => {
+    it('renders with error status icon', () => {
+      const {container} = render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'error'}}
+        />
+      );
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('renders with warning status icon', () => {
+      const {container} = render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'warning'}}
+        />
+      );
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('renders with success status icon', () => {
+      const {container} = render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'success'}}
+        />
+      );
+      expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('renders status message when provided', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'error', message: 'Description is required'}}
+        />
+      );
+      expect(screen.getByText('Description is required')).toBeInTheDocument();
+    });
+
+    it('does not render status message when not provided', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'error'}}
+        />
+      );
+      expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
+    });
+
+    it('sets aria-invalid when status type is error', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'error'}}
+        />
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      );
+    });
+
+    it('does not set aria-invalid for warning status', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'warning'}}
+        />
+      );
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('does not set aria-invalid for success status', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'success'}}
+        />
+      );
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('includes status message in aria-describedby', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          status={{type: 'error', message: 'Too short'}}
+        />
+      );
+      const textarea = screen.getByRole('textbox');
+      const describedBy = textarea.getAttribute('aria-describedby');
+      expect(describedBy).toBeTruthy();
+      // The status message should be reachable via the described-by ID
+      const messageElement = screen.getByText('Too short');
+      expect(messageElement).toHaveAttribute('id');
+      expect(describedBy).toContain(messageElement.id);
+    });
+  });
+
+  it('renders tooltip info icon when labelTooltip is provided', () => {
+    render(
+      <XDSTextArea
+        label="Description"
+        value=""
+        onChange={() => {}}
+        labelTooltip="Enter a detailed description"
+      />
+    );
+    // Info icon should be present
+    expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('does not render tooltip icon when labelTooltip is not provided', () => {
+    render(<XDSTextArea label="Description" value="" onChange={() => {}} />);
+    expect(document.querySelector('svg')).not.toBeInTheDocument();
+  });
+
+  describe('hasSpellCheck prop', () => {
+    it('enables spellcheck by default', () => {
+      render(<XDSTextArea label="Description" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).toHaveAttribute('spellcheck', 'true');
+    });
+
+    it('enables spellcheck when hasSpellCheck is true', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          hasSpellCheck={true}
+        />
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute('spellcheck', 'true');
+    });
+
+    it('disables spellcheck when hasSpellCheck is false', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          hasSpellCheck={false}
+        />
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'spellcheck',
+        'false'
+      );
+    });
+  });
+
+  describe('onPaste prop', () => {
+    it('calls onPaste when content is pasted', () => {
+      const handlePaste = vi.fn();
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          onPaste={handlePaste}
+        />
+      );
+
+      const textarea = screen.getByRole('textbox');
+      fireEvent.paste(textarea, {
+        clipboardData: {getData: () => 'pasted text'},
+      });
+      expect(handlePaste).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not throw when onPaste is not provided', () => {
+      render(<XDSTextArea label="Description" value="" onChange={() => {}} />);
+
+      const textarea = screen.getByRole('textbox');
+      expect(() => {
+        fireEvent.paste(textarea, {
+          clipboardData: {getData: () => 'pasted text'},
+        });
+      }).not.toThrow();
+    });
+  });
+
+  describe('maxLength prop', () => {
+    it('displays character counter when maxLength is provided', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value="Hello"
+          onChange={() => {}}
+          maxLength={20}
+        />
+      );
+      expect(screen.getByText('5/20')).toBeInTheDocument();
+    });
+
+    it('does not display counter when maxLength is not provided', () => {
+      render(
+        <XDSTextArea label="Description" value="Hello" onChange={() => {}} />
+      );
+      expect(screen.queryByText(/\/\d+/)).not.toBeInTheDocument();
+    });
+
+    it('updates counter as value changes', () => {
+      const {rerender} = render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          maxLength={100}
+        />
+      );
+      expect(screen.getByText('0/100')).toBeInTheDocument();
+
+      rerender(
+        <XDSTextArea
+          label="Description"
+          value="Hello World"
+          onChange={() => {}}
+          maxLength={100}
+        />
+      );
+      expect(screen.getByText('11/100')).toBeInTheDocument();
+    });
+
+    it('sets maxLength attribute on textarea', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          maxLength={50}
+        />
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute('maxlength', '50');
+    });
+
+    it('does not set maxLength attribute when not provided', () => {
+      render(<XDSTextArea label="Description" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('maxlength');
+    });
+  });
+
+  describe('hasAutoFocus prop', () => {
+    it('sets autofocus attribute when hasAutoFocus is true', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          hasAutoFocus
+        />
+      );
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('does not set autofocus when hasAutoFocus is false', () => {
+      render(<XDSTextArea label="Description" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
+  });
+
+  describe('htmlName prop', () => {
+    it('sets name attribute when htmlName is provided', () => {
+      render(
+        <XDSTextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          htmlName="description"
+        />
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute(
+        'name',
+        'description'
+      );
+    });
+
+    it('does not set name attribute when htmlName is not provided', () => {
+      render(<XDSTextArea label="Description" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('name');
+    });
   });
 });

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -1,7 +1,7 @@
 /**
  * @file XDSTextArea.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, XDSField
- * @output Exports XDSTextArea component, XDSTextAreaProps
+ * @input Uses React forwardRef, useId, ChangeEvent, ClipboardEvent, XDSField, XDSIcon
+ * @output Exports XDSTextArea component, XDSTextAreaProps, XDSTextAreaStatus, XDSTextAreaStatusType
  * @position Core implementation; consumed by index.ts, tested by XDSTextArea.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -11,23 +11,33 @@
  * - /apps/storybook/stories/TextArea.stories.tsx (storybook stories)
  */
 
-import {forwardRef, useId, type ChangeEvent} from 'react';
+import {forwardRef, useId, type ChangeEvent, type ClipboardEvent} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import {
+  CheckCircleIcon,
+  ExclamationTriangleIcon,
+  XCircleIcon,
+} from '@heroicons/react/24/solid';
 import {
   colorVars,
   spacingVars,
   radiusVars,
   transitionVars,
   typographyVars,
+  textSizeVars,
 } from '../theme/tokens.stylex';
 import {XDSField} from '../Field';
+import {XDSIcon, type XDSIconType} from '../Icon';
 
 const styles = stylex.create({
-  textarea: {
-    display: 'block',
-    width: '100%',
+  wrapper: {
+    position: 'relative',
+    zIndex: 1,
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
     borderWidth: '1px',
     borderStyle: 'solid',
     borderColor: {
@@ -35,36 +45,81 @@ const styles = stylex.create({
       ':hover': colorVars['--color-divider-high-contrast'],
     },
     borderRadius: radiusVars['--radius-element'],
-    fontFamily: typographyVars['--font-body'],
-    fontSize: '0.875rem',
-    lineHeight: 1.429,
-    color: colorVars['--color-text-primary'],
     backgroundColor: colorVars['--color-surface'],
     transitionProperty: 'border-color, outline',
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
-      ':focus': '1px',
+      ':focus-within': '1px',
     },
+  },
+  wrapperDisabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+    borderColor: colorVars['--color-divider-emphasized'],
+  },
+  textarea: {
+    display: 'block',
+    flex: 1,
+    minWidth: 0,
+    border: 0,
+    padding: 0,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: 1.429,
+    color: colorVars['--color-text-primary'],
+    backgroundColor: 'transparent',
+    outline: 0,
     '::placeholder': {
       color: colorVars['--color-text-placeholder'],
     },
     resize: 'vertical',
     minHeight: '80px',
   },
-  disabled: {
+  textareaDisabled: {
     cursor: 'not-allowed',
-    opacity: 0.5,
-    borderColor: {
-      default: colorVars['--color-divider-emphasized'],
-      ':hover': colorVars['--color-divider-emphasized'],
-    },
+  },
+  counter: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    marginTop: spacingVars['--spacing-1'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+  },
+  counterError: {
+    color: colorVars['--color-negative'],
   },
 });
+
+const statusBorderStyles = stylex.create({
+  warning: {
+    borderColor: colorVars['--color-warning'],
+  },
+  error: {
+    borderColor: colorVars['--color-negative'],
+  },
+  success: {
+    borderColor: colorVars['--color-positive'],
+  },
+});
+
+export type XDSTextAreaStatusType = 'warning' | 'error' | 'success';
+
+export interface XDSTextAreaStatus {
+  /**
+   * The type of status to display.
+   */
+  type: XDSTextAreaStatusType;
+  /**
+   * Optional message to display below the textarea.
+   */
+  message?: string;
+}
 
 export interface XDSTextAreaProps {
   /**
@@ -112,6 +167,45 @@ export interface XDSTextAreaProps {
    * @default false
    */
   isDisabled?: boolean;
+  /**
+   * Status indicator for the textarea.
+   * When set, displays a colored border and status icon.
+   * If message is provided, displays a floating message box below the textarea.
+   */
+  status?: XDSTextAreaStatus;
+  /**
+   * Tooltip text to display in an info icon at the end of the label.
+   */
+  labelTooltip?: string;
+  /**
+   * Icon to display at the start of the textarea.
+   * Import from @heroicons/react/24/outline or @heroicons/react/24/solid.
+   */
+  startIcon?: XDSIconType;
+  /**
+   * Whether to enable browser spell checking.
+   * @default true
+   */
+  hasSpellCheck?: boolean;
+  /**
+   * Callback fired when content is pasted into the textarea.
+   */
+  onPaste?: (e: ClipboardEvent<HTMLTextAreaElement>) => void;
+  /**
+   * Maximum number of characters allowed.
+   * When set, displays a character counter below the textarea.
+   */
+  maxLength?: number;
+  /**
+   * Whether to automatically focus the textarea on mount.
+   * @default false
+   */
+  hasAutoFocus?: boolean;
+  /**
+   * The HTML name attribute for the textarea.
+   * Useful for form submissions.
+   */
+  htmlName?: string;
 }
 
 /**
@@ -136,11 +230,43 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
       placeholder,
       rows = 3,
       isDisabled = false,
+      status,
+      labelTooltip,
+      startIcon,
+      hasSpellCheck = true,
+      onPaste,
+      maxLength,
+      hasAutoFocus = false,
+      htmlName,
     },
-    ref,
+    ref
   ) => {
     const id = useId();
     const descriptionID = useId();
+    const statusMessageID = useId();
+
+    const statusIconMap: Record<XDSTextAreaStatusType, XDSIconType> = {
+      warning: ExclamationTriangleIcon,
+      error: XCircleIcon,
+      success: CheckCircleIcon,
+    };
+
+    const statusIconColorMap: Record<
+      XDSTextAreaStatusType,
+      'warning' | 'negative' | 'positive'
+    > = {
+      warning: 'warning',
+      error: 'negative',
+      success: 'positive',
+    };
+
+    const ariaDescribedBy =
+      [
+        description ? descriptionID : null,
+        status?.message ? statusMessageID : null,
+      ]
+        .filter(Boolean)
+        .join(' ') || undefined;
 
     return (
       <XDSField
@@ -150,22 +276,65 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
         inputID={id}
         descriptionID={description ? descriptionID : undefined}
         isOptional={isOptional}
-        isRequired={isRequired}>
-        <textarea
-          ref={ref}
-          id={id}
-          value={value}
-          onChange={e => onChange(e.target.value, e)}
-          placeholder={placeholder}
-          rows={rows}
-          disabled={isDisabled}
-          aria-describedby={description ? descriptionID : undefined}
-          aria-required={isRequired === true ? 'true' : undefined}
-          {...stylex.props(styles.textarea, isDisabled && styles.disabled)}
-        />
+        isRequired={isRequired}
+        status={
+          status
+            ? {
+                type: status.type,
+                message: status.message,
+                messageID: status.message ? statusMessageID : undefined,
+              }
+            : undefined
+        }
+        labelTooltip={labelTooltip}>
+        <div
+          {...stylex.props(
+            styles.wrapper,
+            isDisabled && styles.wrapperDisabled,
+            status && statusBorderStyles[status.type]
+          )}>
+          {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
+          <textarea
+            ref={ref}
+            id={id}
+            name={htmlName}
+            value={value}
+            onChange={e => onChange(e.target.value, e)}
+            onPaste={onPaste}
+            placeholder={placeholder}
+            rows={rows}
+            disabled={isDisabled}
+            spellCheck={hasSpellCheck}
+            maxLength={maxLength}
+            autoFocus={hasAutoFocus}
+            aria-describedby={ariaDescribedBy}
+            aria-required={isRequired === true ? 'true' : undefined}
+            aria-invalid={status?.type === 'error' ? 'true' : undefined}
+            {...stylex.props(
+              styles.textarea,
+              isDisabled && styles.textareaDisabled
+            )}
+          />
+          {status && (
+            <XDSIcon
+              icon={statusIconMap[status.type]}
+              size="md"
+              color={statusIconColorMap[status.type]}
+            />
+          )}
+        </div>
+        {maxLength != null && (
+          <div
+            {...stylex.props(
+              styles.counter,
+              value.length > maxLength && styles.counterError
+            )}>
+            {value.length}/{maxLength}
+          </div>
+        )}
       </XDSField>
     );
-  },
+  }
 );
 
 XDSTextArea.displayName = 'XDSTextArea';

--- a/packages/core/src/TextArea/index.ts
+++ b/packages/core/src/TextArea/index.ts
@@ -1,11 +1,15 @@
 /**
  * @file index.ts
  * @input Imports XDSTextArea component and types from XDSTextArea.tsx
- * @output Exports XDSTextArea, XDSTextAreaProps
+ * @output Exports XDSTextArea, XDSTextAreaProps, XDSTextAreaStatus, XDSTextAreaStatusType
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/TextArea/README.md
  */
 
 export {XDSTextArea} from './XDSTextArea';
-export type {XDSTextAreaProps} from './XDSTextArea';
+export type {
+  XDSTextAreaProps,
+  XDSTextAreaStatus,
+  XDSTextAreaStatusType,
+} from './XDSTextArea';

--- a/packages/core/src/TextInput/XDSTextInput.test.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.test.tsx
@@ -281,4 +281,37 @@ describe('XDSTextInput', () => {
     render(<XDSTextInput label="Name" value="" onChange={() => {}} />);
     expect(document.querySelector('svg')).not.toBeInTheDocument();
   });
+
+  describe('hasAutoFocus prop', () => {
+    it('focuses the input when hasAutoFocus is true', () => {
+      render(
+        <XDSTextInput label="Name" value="" onChange={() => {}} hasAutoFocus />
+      );
+      expect(screen.getByRole('textbox')).toHaveFocus();
+    });
+
+    it('does not focus when hasAutoFocus is false', () => {
+      render(<XDSTextInput label="Name" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveFocus();
+    });
+  });
+
+  describe('htmlName prop', () => {
+    it('sets name attribute when htmlName is provided', () => {
+      render(
+        <XDSTextInput
+          label="Name"
+          value=""
+          onChange={() => {}}
+          htmlName="username"
+        />
+      );
+      expect(screen.getByRole('textbox')).toHaveAttribute('name', 'username');
+    });
+
+    it('does not set name attribute when htmlName is not provided', () => {
+      render(<XDSTextInput label="Name" value="" onChange={() => {}} />);
+      expect(screen.getByRole('textbox')).not.toHaveAttribute('name');
+    });
+  });
 });

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -181,6 +181,16 @@ export interface XDSTextInputProps {
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
+  /**
+   * Whether to automatically focus the input on mount.
+   * @default false
+   */
+  hasAutoFocus?: boolean;
+  /**
+   * The HTML name attribute for the input.
+   * Useful for form submissions.
+   */
+  htmlName?: string;
 }
 
 /**
@@ -208,6 +218,8 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
       value,
       placeholder,
       labelTooltip,
+      hasAutoFocus = false,
+      htmlName,
     },
     ref
   ) => {
@@ -267,11 +279,13 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
           <input
             ref={ref}
             id={id}
+            name={htmlName}
             type="text"
             value={value}
             onChange={e => onChange(e.target.value, e)}
             placeholder={placeholder}
             disabled={isDisabled}
+            autoFocus={hasAutoFocus}
             aria-describedby={ariaDescribedBy}
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={status?.type === 'error' ? 'true' : undefined}


### PR DESCRIPTION
Added a bunch of additional props to XDSTextArea. In particular status, startIcon, and maxLength. This completes all the core props for #32

<img width="1077" height="790" alt="image" src="https://github.com/user-attachments/assets/34c2157e-ebff-4f59-ad1b-6d09d7aead41" />

<img width="1062" height="239" alt="image" src="https://github.com/user-attachments/assets/50bc7cb8-9947-4621-9957-f08d02319cff" />

<img width="1041" height="237" alt="image" src="https://github.com/user-attachments/assets/13858b2d-832b-42f7-a5b0-189dd3b9917a" />

