### PR TITLE
More layouts: XDSAspectRatio, XDSCenter, XDSGrid, XDSDivider

### DIFF
--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -1,0 +1,299 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSText} from '@xds/core/Text';
+import {XDSSkeleton} from '@xds/core/Skeleton';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+} from '@xds/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  container: {
+    padding: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-surface'],
+    maxWidth: 600,
+  },
+  wideContainer: {
+    padding: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-surface'],
+    maxWidth: 1000,
+  },
+  storyWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-6'],
+  },
+  sectionLabel: {
+    marginBlockEnd: spacingVars['--spacing-2'],
+  },
+  image: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    borderRadius: radiusVars['--radius-element'],
+  },
+  placeholder: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: colorVars['--color-wash'],
+    borderRadius: radiusVars['--radius-element'],
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  gradientPlaceholder: {
+    width: '100%',
+    height: '100%',
+    background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+    borderRadius: radiusVars['--radius-element'],
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: 'white',
+  },
+  gridItem: {
+    overflow: 'hidden',
+  },
+  smallContainer: {
+    maxWidth: 300,
+    padding: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-surface'],
+  },
+});
+
+const meta: Meta<typeof XDSAspectRatio> = {
+  title: 'Layout/XDSAspectRatio',
+  component: XDSAspectRatio,
+  tags: ['autodocs'],
+  argTypes: {
+    ratio: {
+      control: 'number',
+      description: 'The aspect ratio as width/height (e.g., 16/9 = 1.777...)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSAspectRatio>;
+
+// Placeholder image URLs
+const PLACEHOLDER_IMAGE = 'https://picsum.photos/800/600';
+const PLACEHOLDER_SQUARE = 'https://picsum.photos/400/400';
+
+export const Default: Story = {
+  args: {
+    ratio: 16 / 9,
+  },
+  render: args => (
+    <div {...stylex.props(styles.container)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        16:9 Aspect Ratio (Default)
+      </XDSText>
+      <XDSAspectRatio {...args}>
+        <img
+          {...stylex.props(styles.image)}
+          src={PLACEHOLDER_IMAGE}
+          alt="16:9 placeholder"
+        />
+      </XDSAspectRatio>
+    </div>
+  ),
+};
+
+export const Widescreen16x9: Story = {
+  render: () => (
+    <div {...stylex.props(styles.container)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        16:9 - Standard widescreen (YouTube, TV)
+      </XDSText>
+      <XDSAspectRatio ratio={16 / 9}>
+        <img
+          {...stylex.props(styles.image)}
+          src={PLACEHOLDER_IMAGE}
+          alt="16:9 widescreen"
+        />
+      </XDSAspectRatio>
+    </div>
+  ),
+};
+
+export const Classic4x3: Story = {
+  render: () => (
+    <div {...stylex.props(styles.container)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        4:3 - Classic TV and photography
+      </XDSText>
+      <XDSAspectRatio ratio={4 / 3}>
+        <img
+          {...stylex.props(styles.image)}
+          src={PLACEHOLDER_IMAGE}
+          alt="4:3 classic"
+        />
+      </XDSAspectRatio>
+    </div>
+  ),
+};
+
+export const Square1x1: Story = {
+  render: () => (
+    <div {...stylex.props(styles.smallContainer)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        1:1 - Square (Instagram, avatars)
+      </XDSText>
+      <XDSAspectRatio ratio={1}>
+        <img
+          {...stylex.props(styles.image)}
+          src={PLACEHOLDER_SQUARE}
+          alt="1:1 square"
+        />
+      </XDSAspectRatio>
+    </div>
+  ),
+};
+
+export const Ultrawide21x9: Story = {
+  render: () => (
+    <div {...stylex.props(styles.wideContainer)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        21:9 - Ultrawide cinematic
+      </XDSText>
+      <XDSAspectRatio ratio={21 / 9}>
+        <div {...stylex.props(styles.gradientPlaceholder)}>
+          <XDSText type="label">Ultrawide 21:9</XDSText>
+        </div>
+      </XDSAspectRatio>
+    </div>
+  ),
+};
+
+export const WithPlaceholderSkeleton: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div {...stylex.props(styles.container)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          16:9 with loading skeleton
+        </XDSText>
+        <XDSAspectRatio ratio={16 / 9}>
+          <XDSSkeleton width="100%" height="100%" />
+        </XDSAspectRatio>
+      </div>
+      <div {...stylex.props(styles.smallContainer)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          1:1 with loading skeleton
+        </XDSText>
+        <XDSAspectRatio ratio={1}>
+          <XDSSkeleton width="100%" height="100%" />
+        </XDSAspectRatio>
+      </div>
+    </div>
+  ),
+};
+
+export const ResponsiveGrid: Story = {
+  render: () => (
+    <div {...stylex.props(styles.wideContainer)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Responsive grid of aspect ratio boxes
+      </XDSText>
+      <XDSGrid minChildWidth={200} gap="space4">
+        {[
+          {ratio: 16 / 9, label: '16:9'},
+          {ratio: 4 / 3, label: '4:3'},
+          {ratio: 1, label: '1:1'},
+          {ratio: 3 / 2, label: '3:2'},
+          {ratio: 21 / 9, label: '21:9'},
+          {ratio: 2 / 3, label: '2:3 Portrait'},
+        ].map(({ratio, label}) => (
+          <div key={label} {...stylex.props(styles.gridItem)}>
+            <XDSAspectRatio ratio={ratio}>
+              <div {...stylex.props(styles.placeholder)}>
+                <XDSText type="label">{label}</XDSText>
+              </div>
+            </XDSAspectRatio>
+          </div>
+        ))}
+      </XDSGrid>
+    </div>
+  ),
+};
+
+export const AllRatiosComparison: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div {...stylex.props(styles.container)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          16:9 (1.778) - Widescreen HD
+        </XDSText>
+        <XDSAspectRatio ratio={16 / 9}>
+          <div {...stylex.props(styles.placeholder)}>
+            <XDSText type="body">16:9</XDSText>
+          </div>
+        </XDSAspectRatio>
+      </div>
+      <div {...stylex.props(styles.container)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          4:3 (1.333) - Classic TV
+        </XDSText>
+        <XDSAspectRatio ratio={4 / 3}>
+          <div {...stylex.props(styles.placeholder)}>
+            <XDSText type="body">4:3</XDSText>
+          </div>
+        </XDSAspectRatio>
+      </div>
+      <div {...stylex.props(styles.smallContainer)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          1:1 (1.0) - Square
+        </XDSText>
+        <XDSAspectRatio ratio={1}>
+          <div {...stylex.props(styles.placeholder)}>
+            <XDSText type="body">1:1</XDSText>
+          </div>
+        </XDSAspectRatio>
+      </div>
+      <div {...stylex.props(styles.container)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          3:2 (1.5) - Classic 35mm Film
+        </XDSText>
+        <XDSAspectRatio ratio={3 / 2}>
+          <div {...stylex.props(styles.placeholder)}>
+            <XDSText type="body">3:2</XDSText>
+          </div>
+        </XDSAspectRatio>
+      </div>
+      <div {...stylex.props(styles.wideContainer)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          21:9 (2.333) - Ultrawide Cinematic
+        </XDSText>
+        <XDSAspectRatio ratio={21 / 9}>
+          <div {...stylex.props(styles.placeholder)}>
+            <XDSText type="body">21:9</XDSText>
+          </div>
+        </XDSAspectRatio>
+      </div>
+    </div>
+  ),
+};
+
+export const ImageGallery: Story = {
+  render: () => (
+    <div {...stylex.props(styles.wideContainer)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Image gallery with consistent aspect ratios
+      </XDSText>
+      <XDSGrid columns={3} gap="space4">
+        {Array.from({length: 6}, (_, i) => (
+          <XDSAspectRatio key={i} ratio={4 / 3}>
+            <img
+              {...stylex.props(styles.image)}
+              src={`https://picsum.photos/seed/${i + 1}/400/300`}
+              alt={`Gallery image ${i + 1}`}
+            />
+          </XDSAspectRatio>
+        ))}
+      </XDSGrid>
+    </div>
+  ),
+};

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -1,0 +1,224 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSCard, XDSSection} from '@xds/core/Layout';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSText} from '@xds/core/Text';
+import {CheckCircleIcon} from '@heroicons/react/24/outline';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+} from '@xds/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  box: {
+    backgroundColor: colorVars['--color-blue-background'],
+    color: colorVars['--color-blue-text'],
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-blue-border'],
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-6'],
+    borderRadius: radiusVars['--radius-element'],
+    fontWeight: 500,
+  },
+  storyWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-6'],
+  },
+  iconWrapper: {
+    backgroundColor: colorVars['--color-blue-background'],
+    color: colorVars['--color-blue-text'],
+    padding: spacingVars['--spacing-2'],
+    borderRadius: radiusVars['--radius-element'],
+  },
+});
+
+// Demo box component for visibility
+const Box = ({children}: {children: React.ReactNode}) => (
+  <div {...stylex.props(styles.box)}>{children}</div>
+);
+
+const meta: Meta<typeof XDSCenter> = {
+  title: 'Layout/XDSCenter',
+  component: XDSCenter,
+  tags: ['autodocs'],
+  argTypes: {
+    axis: {
+      control: 'select',
+      options: ['both', 'horizontal', 'vertical'],
+      description: 'Which direction(s) to center',
+    },
+    width: {
+      control: 'text',
+      description:
+        'Width of the container (number for px, string for any unit)',
+    },
+    height: {
+      control: 'text',
+      description:
+        'Height of the container (number for px, string for any unit)',
+    },
+    inline: {
+      control: 'boolean',
+      description: 'Whether to render as inline-flex',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCenter>;
+
+export const Default: Story = {
+  args: {
+    axis: 'both',
+    width: 300,
+    height: 200,
+    children: null,
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCenter {...args}>
+        <Box>Centered Content</Box>
+      </XDSCenter>
+    </XDSSection>
+  ),
+};
+
+export const HorizontalOnly: Story = {
+  args: {
+    axis: 'horizontal',
+    width: 300,
+    children: null,
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCenter {...args}>
+        <Box>Horizontal Center</Box>
+      </XDSCenter>
+    </XDSSection>
+  ),
+};
+
+export const VerticalOnly: Story = {
+  args: {
+    axis: 'vertical',
+    height: 150,
+    children: null,
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCenter {...args}>
+        <Box>Vertical Center</Box>
+      </XDSCenter>
+    </XDSSection>
+  ),
+};
+
+export const FullSize: Story = {
+  args: {
+    axis: 'both',
+    width: '100%',
+    height: 300,
+    children: null,
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCenter {...args}>
+        <Box>Full Width, Fixed Height</Box>
+      </XDSCenter>
+    </XDSSection>
+  ),
+};
+
+export const Inline: Story = {
+  args: {
+    inline: true,
+    children: null,
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCard>
+        <XDSText type="body">
+          Text with inline centered icon:{' '}
+          <XDSCenter {...args} xstyle={styles.iconWrapper}>
+            <XDSIcon icon={CheckCircleIcon} size="sm" />
+          </XDSCenter>{' '}
+          and more text after.
+        </XDSText>
+      </XDSCard>
+    </XDSSection>
+  ),
+};
+
+export const WithIcon: Story = {
+  args: {
+    axis: 'both',
+    width: 300,
+    height: 200,
+    children: null,
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCenter {...args}>
+        <div {...stylex.props(styles.iconWrapper)}>
+          <XDSIcon icon={CheckCircleIcon} size="lg" />
+        </div>
+      </XDSCenter>
+    </XDSSection>
+  ),
+};
+
+export const InsideACard: Story = {
+  args: {
+    height: 150,
+    children: null,
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCard>
+        <XDSCenter {...args}>
+          <Box>Centered in Card</Box>
+        </XDSCenter>
+      </XDSCard>
+    </XDSSection>
+  ),
+};
+
+export const AllAxisModes: Story = {
+  args: {
+    children: null,
+  },
+  render: () => (
+    <XDSSection variant="wash">
+      <div {...stylex.props(styles.storyWrapper)}>
+        <XDSCard>
+          <XDSText type="supporting" display="block">
+            axis: both (default)
+          </XDSText>
+          <XDSCenter axis="both" width={300} height={150}>
+            <Box>Both Axes</Box>
+          </XDSCenter>
+        </XDSCard>
+        <XDSCard>
+          <XDSText type="supporting" display="block">
+            axis: horizontal
+          </XDSText>
+          <XDSCenter axis="horizontal" width={300}>
+            <Box>Horizontal Only</Box>
+          </XDSCenter>
+        </XDSCard>
+        <XDSCard>
+          <XDSText type="supporting" display="block">
+            axis: vertical
+          </XDSText>
+          <XDSCenter axis="vertical" height={150}>
+            <Box>Vertical Only</Box>
+          </XDSCenter>
+        </XDSCard>
+      </div>
+    </XDSSection>
+  ),
+};

--- a/apps/storybook/stories/Divider.stories.tsx
+++ b/apps/storybook/stories/Divider.stories.tsx
@@ -1,0 +1,181 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSVStack, XDSHStack, XDSCard, XDSSection} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {spacingVars} from '@xds/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  storyWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-6'],
+  },
+});
+
+const meta: Meta<typeof XDSDivider> = {
+  title: 'Layout/XDSDivider',
+  component: XDSDivider,
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'Orientation of the divider',
+    },
+    variant: {
+      control: 'select',
+      options: ['subtle', 'strong'],
+      description: 'Visual weight of the divider line',
+    },
+    isFullBleed: {
+      control: 'boolean',
+      description: 'Escape parent container padding',
+    },
+    label: {
+      control: 'text',
+      description: 'Optional label text (rendered small and secondary)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSDivider>;
+
+export const Default: Story = {
+  args: {},
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCard>
+        <XDSVStack gap="space3">
+          <XDSText type="body">Content above</XDSText>
+          <XDSDivider {...args} />
+          <XDSText type="body">Content below</XDSText>
+        </XDSVStack>
+      </XDSCard>
+    </XDSSection>
+  ),
+};
+
+export const WithLabel: Story = {
+  args: {
+    label: 'or',
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCard>
+        <XDSVStack gap="space3">
+          <XDSText type="body">Content above</XDSText>
+          <XDSDivider {...args} />
+          <XDSText type="body">Content below</XDSText>
+        </XDSVStack>
+      </XDSCard>
+    </XDSSection>
+  ),
+};
+
+export const Variants: Story = {
+  render: () => (
+    <XDSSection variant="wash">
+      <div {...stylex.props(styles.storyWrapper)}>
+        <XDSCard>
+          <XDSVStack gap="space3">
+            <XDSText type="supporting">Subtle (default)</XDSText>
+            <XDSDivider variant="subtle" />
+          </XDSVStack>
+        </XDSCard>
+        <XDSCard>
+          <XDSVStack gap="space3">
+            <XDSText type="supporting">Strong</XDSText>
+            <XDSDivider variant="strong" />
+          </XDSVStack>
+        </XDSCard>
+      </div>
+    </XDSSection>
+  ),
+};
+
+export const FullBleed: Story = {
+  render: () => (
+    <XDSSection variant="wash">
+      <div {...stylex.props(styles.storyWrapper)}>
+        <XDSCard>
+          <XDSVStack gap="space3">
+            <XDSText type="label">Normal divider</XDSText>
+            <XDSText type="body">
+              The divider respects container padding.
+            </XDSText>
+            <XDSDivider />
+            <XDSText type="body">Content below the divider.</XDSText>
+          </XDSVStack>
+        </XDSCard>
+        <XDSCard>
+          <XDSVStack gap="space3">
+            <XDSText type="label">Full bleed divider</XDSText>
+            <XDSText type="body">
+              The divider extends to container edges.
+            </XDSText>
+            <XDSDivider isFullBleed />
+            <XDSText type="body">Content below the divider.</XDSText>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+    </XDSSection>
+  ),
+};
+
+export const Vertical: Story = {
+  args: {
+    orientation: 'vertical',
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCard height={200}>
+        <XDSHStack gap="space4" xstyle={{height: '100%'}}>
+          <XDSText type="body">Left content</XDSText>
+          <XDSDivider {...args} />
+          <XDSText type="body">Right content</XDSText>
+        </XDSHStack>
+      </XDSCard>
+    </XDSSection>
+  ),
+};
+
+export const VerticalWithLabel: Story = {
+  args: {
+    orientation: 'vertical',
+    label: 'OR',
+  },
+  render: args => (
+    <XDSSection variant="wash">
+      <XDSCard height={200}>
+        <XDSHStack gap="space4" xstyle={{height: '100%'}}>
+          <XDSText type="body">Option A</XDSText>
+          <XDSDivider {...args} />
+          <XDSText type="body">Option B</XDSText>
+        </XDSHStack>
+      </XDSCard>
+    </XDSSection>
+  ),
+};
+
+export const InCard: Story = {
+  render: () => (
+    <XDSSection variant="wash">
+      <XDSCard>
+        <XDSVStack gap="space3">
+          <XDSText type="label">Card Title</XDSText>
+          <XDSDivider />
+          <XDSText type="body">
+            This demonstrates how a divider can be used to separate content
+            sections within a card or panel.
+          </XDSText>
+          <XDSDivider label="More Info" />
+          <XDSText type="supporting">
+            Additional details can appear below a labeled divider.
+          </XDSText>
+        </XDSVStack>
+      </XDSCard>
+    </XDSSection>
+  ),
+};

--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -1,0 +1,385 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSGrid, XDSGridSpan} from '@xds/core/Grid';
+import {XDSCard, XDSSection} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+} from '@xds/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  container: {
+    padding: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-surface'],
+  },
+  item: {
+    padding: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-wash'],
+    borderRadius: radiusVars['--radius-element'],
+    textAlign: 'center',
+  },
+  featuredItem: {
+    padding: spacingVars['--spacing-6'],
+    backgroundColor: colorVars['--color-accent-deemphasized'],
+    borderRadius: radiusVars['--radius-element'],
+    textAlign: 'center',
+    height: '100%',
+    boxSizing: 'border-box',
+  },
+  cardImage: {
+    height: 120,
+    backgroundColor: colorVars['--color-wash'],
+    borderRadius: radiusVars['--radius-element'],
+    marginBlockEnd: spacingVars['--spacing-3'],
+  },
+  storyWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-6'],
+  },
+  sectionLabel: {
+    marginBlockEnd: spacingVars['--spacing-2'],
+  },
+});
+
+const meta: Meta<typeof XDSGrid> = {
+  title: 'Layout/XDSGrid',
+  component: XDSGrid,
+  tags: ['autodocs'],
+  argTypes: {
+    columns: {
+      control: 'number',
+      description: 'Maximum number of columns',
+    },
+    minChildWidth: {
+      control: 'number',
+      description:
+        'Minimum width of each grid item in pixels (enables auto-fit)',
+    },
+    gap: {
+      control: 'select',
+      options: [
+        'space0',
+        'space0.5',
+        'space1',
+        'space2',
+        'space3',
+        'space4',
+        'space5',
+        'space6',
+        'space7',
+      ],
+      description: 'Spacing between all grid items',
+    },
+    rowGap: {
+      control: 'select',
+      options: [
+        'space0',
+        'space0.5',
+        'space1',
+        'space2',
+        'space3',
+        'space4',
+        'space5',
+        'space6',
+        'space7',
+      ],
+      description: 'Spacing between rows (overrides gap)',
+    },
+    columnGap: {
+      control: 'select',
+      options: [
+        'space0',
+        'space0.5',
+        'space1',
+        'space2',
+        'space3',
+        'space4',
+        'space5',
+        'space6',
+        'space7',
+      ],
+      description: 'Spacing between columns (overrides gap)',
+    },
+    align: {
+      control: 'select',
+      options: ['start', 'center', 'end', 'stretch'],
+      description: 'Vertical alignment of grid items',
+    },
+    justify: {
+      control: 'select',
+      options: ['start', 'center', 'end', 'stretch'],
+      description: 'Horizontal alignment of grid items',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSGrid>;
+
+const GridItem = ({children}: {children: React.ReactNode}) => (
+  <div {...stylex.props(styles.item)}>
+    <XDSText type="body">{children}</XDSText>
+  </div>
+);
+
+const FeaturedItem = ({children}: {children: React.ReactNode}) => (
+  <div {...stylex.props(styles.featuredItem)}>
+    <XDSText type="body">{children}</XDSText>
+  </div>
+);
+
+export const Default: Story = {
+  args: {
+    columns: 3,
+    gap: 'space4',
+  },
+  render: args => (
+    <div {...stylex.props(styles.container)}>
+      <XDSGrid {...args}>
+        <GridItem>Item 1</GridItem>
+        <GridItem>Item 2</GridItem>
+        <GridItem>Item 3</GridItem>
+        <GridItem>Item 4</GridItem>
+        <GridItem>Item 5</GridItem>
+        <GridItem>Item 6</GridItem>
+      </XDSGrid>
+    </div>
+  ),
+};
+
+export const FixedColumns: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div {...stylex.props(styles.container)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          2 Columns
+        </XDSText>
+        <XDSGrid columns={2} gap="space4">
+          <GridItem>Item 1</GridItem>
+          <GridItem>Item 2</GridItem>
+          <GridItem>Item 3</GridItem>
+          <GridItem>Item 4</GridItem>
+        </XDSGrid>
+      </div>
+      <div {...stylex.props(styles.container)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          4 Columns
+        </XDSText>
+        <XDSGrid columns={4} gap="space4">
+          <GridItem>Item 1</GridItem>
+          <GridItem>Item 2</GridItem>
+          <GridItem>Item 3</GridItem>
+          <GridItem>Item 4</GridItem>
+          <GridItem>Item 5</GridItem>
+          <GridItem>Item 6</GridItem>
+          <GridItem>Item 7</GridItem>
+          <GridItem>Item 8</GridItem>
+        </XDSGrid>
+      </div>
+    </div>
+  ),
+};
+
+export const ResponsiveAutoFit: Story = {
+  render: () => (
+    <div {...stylex.props(styles.container)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Resize the viewport - columns adjust automatically (min 200px per item)
+      </XDSText>
+      <XDSGrid minChildWidth={200} gap="space4">
+        <GridItem>Item 1</GridItem>
+        <GridItem>Item 2</GridItem>
+        <GridItem>Item 3</GridItem>
+        <GridItem>Item 4</GridItem>
+        <GridItem>Item 5</GridItem>
+        <GridItem>Item 6</GridItem>
+      </XDSGrid>
+    </div>
+  ),
+};
+
+export const CappedResponsive: Story = {
+  render: () => (
+    <div {...stylex.props(styles.container)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Auto-fit with max 3 columns (min 250px per item, capped via max-width)
+      </XDSText>
+      <XDSGrid columns={3} minChildWidth={250} gap="space4">
+        <GridItem>Item 1</GridItem>
+        <GridItem>Item 2</GridItem>
+        <GridItem>Item 3</GridItem>
+        <GridItem>Item 4</GridItem>
+        <GridItem>Item 5</GridItem>
+        <GridItem>Item 6</GridItem>
+      </XDSGrid>
+    </div>
+  ),
+};
+
+export const WithGridSpan: Story = {
+  render: () => (
+    <div {...stylex.props(styles.container)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Using XDSGridSpan to span multiple columns/rows
+      </XDSText>
+      <XDSGrid columns={4} gap="space4">
+        <XDSGridSpan columns={2}>
+          <FeaturedItem>Spans 2 columns</FeaturedItem>
+        </XDSGridSpan>
+        <GridItem>Normal</GridItem>
+        <GridItem>Normal</GridItem>
+        <GridItem>Normal</GridItem>
+        <XDSGridSpan columns={3}>
+          <FeaturedItem>Spans 3 columns</FeaturedItem>
+        </XDSGridSpan>
+        <XDSGridSpan columns="full">
+          <FeaturedItem>Full width (spans all columns)</FeaturedItem>
+        </XDSGridSpan>
+      </XDSGrid>
+    </div>
+  ),
+};
+
+export const GridSpanWithRows: Story = {
+  render: () => (
+    <div {...stylex.props(styles.container)}>
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Grid items spanning both columns and rows
+      </XDSText>
+      <XDSGrid columns={4} gap="space4">
+        <XDSGridSpan columns={2} rows={2}>
+          <FeaturedItem>2x2 Featured</FeaturedItem>
+        </XDSGridSpan>
+        <GridItem>Item 1</GridItem>
+        <GridItem>Item 2</GridItem>
+        <GridItem>Item 3</GridItem>
+        <GridItem>Item 4</GridItem>
+        <GridItem>Item 5</GridItem>
+        <GridItem>Item 6</GridItem>
+      </XDSGrid>
+    </div>
+  ),
+};
+
+export const GalleryExample: Story = {
+  render: () => (
+    <XDSSection variant="wash">
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Gallery/Card Grid - Responsive with min 280px cards
+      </XDSText>
+      <XDSGrid minChildWidth={280} gap="space5">
+        {Array.from({length: 8}, (_, i) => (
+          <XDSCard key={i}>
+            <div {...stylex.props(styles.cardImage)} />
+            <XDSText type="label" display="block">
+              Card Title {i + 1}
+            </XDSText>
+            <XDSText type="supporting" display="block">
+              A brief description of the card content goes here.
+            </XDSText>
+          </XDSCard>
+        ))}
+      </XDSGrid>
+    </XDSSection>
+  ),
+};
+
+export const DifferentGaps: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div {...stylex.props(styles.container)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          Same gap for rows and columns (space4)
+        </XDSText>
+        <XDSGrid columns={3} gap="space4">
+          <GridItem>Item 1</GridItem>
+          <GridItem>Item 2</GridItem>
+          <GridItem>Item 3</GridItem>
+          <GridItem>Item 4</GridItem>
+          <GridItem>Item 5</GridItem>
+          <GridItem>Item 6</GridItem>
+        </XDSGrid>
+      </div>
+      <div {...stylex.props(styles.container)}>
+        <XDSText type="supporting" xstyle={styles.sectionLabel}>
+          Different gaps: rowGap=space2, columnGap=space6
+        </XDSText>
+        <XDSGrid columns={3} rowGap="space2" columnGap="space6">
+          <GridItem>Item 1</GridItem>
+          <GridItem>Item 2</GridItem>
+          <GridItem>Item 3</GridItem>
+          <GridItem>Item 4</GridItem>
+          <GridItem>Item 5</GridItem>
+          <GridItem>Item 6</GridItem>
+        </XDSGrid>
+      </div>
+    </div>
+  ),
+};
+
+export const DashboardLayout: Story = {
+  render: () => (
+    <XDSSection variant="wash">
+      <XDSText type="supporting" xstyle={styles.sectionLabel}>
+        Dashboard-style layout with different sized widgets
+      </XDSText>
+      <XDSGrid columns={4} gap="space4">
+        <XDSGridSpan columns={2} rows={2}>
+          <XDSCard>
+            <XDSText type="label" display="block">
+              Main Chart
+            </XDSText>
+            <XDSText type="supporting" display="block">
+              Large visualization widget
+            </XDSText>
+          </XDSCard>
+        </XDSGridSpan>
+        <XDSCard>
+          <XDSText type="label" display="block">
+            Metric 1
+          </XDSText>
+          <XDSText type="supporting" display="block">
+            Quick stat
+          </XDSText>
+        </XDSCard>
+        <XDSCard>
+          <XDSText type="label" display="block">
+            Metric 2
+          </XDSText>
+          <XDSText type="supporting" display="block">
+            Quick stat
+          </XDSText>
+        </XDSCard>
+        <XDSCard>
+          <XDSText type="label" display="block">
+            Metric 3
+          </XDSText>
+          <XDSText type="supporting" display="block">
+            Quick stat
+          </XDSText>
+        </XDSCard>
+        <XDSCard>
+          <XDSText type="label" display="block">
+            Metric 4
+          </XDSText>
+          <XDSText type="supporting" display="block">
+            Quick stat
+          </XDSText>
+        </XDSCard>
+        <XDSGridSpan columns="full">
+          <XDSCard>
+            <XDSText type="label" display="block">
+              Full-width Section
+            </XDSText>
+            <XDSText type="supporting" display="block">
+              This section spans the entire width of the grid
+            </XDSText>
+          </XDSCard>
+        </XDSGridSpan>
+      </XDSGrid>
+    </XDSSection>
+  ),
+};

--- a/packages/core/src/AspectRatio/XDSAspectRatio.test.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * @file XDSAspectRatio.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSAspectRatio component
+ * @output Unit tests for XDSAspectRatio component behavior
+ * @position Testing; validates XDSAspectRatio.tsx implementation
+ *
+ * SYNC: When XDSAspectRatio.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSAspectRatio} from './XDSAspectRatio';
+
+describe('XDSAspectRatio', () => {
+  it('renders with correct aspect ratio', () => {
+    render(
+      <XDSAspectRatio ratio={16 / 9} data-testid="aspect-ratio">
+        <div>Content</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element).toBeInTheDocument();
+    expect(element.style.aspectRatio).toBe(String(16 / 9));
+  });
+
+  it('children fill the container', () => {
+    render(
+      <XDSAspectRatio ratio={1} data-testid="aspect-ratio">
+        <div data-testid="child">Content</div>
+      </XDSAspectRatio>,
+    );
+    const container = screen.getByTestId('aspect-ratio');
+    const child = screen.getByTestId('child');
+    expect(container).toContainElement(child);
+    // Child is wrapped in an absolute positioned div
+    const childWrapper = child.parentElement;
+    expect(childWrapper).not.toBeNull();
+  });
+
+  it('renders with 16:9 ratio', () => {
+    const ratio = 16 / 9;
+    render(
+      <XDSAspectRatio ratio={ratio} data-testid="aspect-ratio">
+        <div>16:9</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element.style.aspectRatio).toBe(String(ratio));
+  });
+
+  it('renders with 4:3 ratio', () => {
+    const ratio = 4 / 3;
+    render(
+      <XDSAspectRatio ratio={ratio} data-testid="aspect-ratio">
+        <div>4:3</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element.style.aspectRatio).toBe(String(ratio));
+  });
+
+  it('renders with 1:1 square ratio', () => {
+    render(
+      <XDSAspectRatio ratio={1} data-testid="aspect-ratio">
+        <div>Square</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element.style.aspectRatio).toBe('1');
+  });
+
+  it('renders with 21:9 ultrawide ratio', () => {
+    const ratio = 21 / 9;
+    render(
+      <XDSAspectRatio ratio={ratio} data-testid="aspect-ratio">
+        <div>Ultrawide</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element.style.aspectRatio).toBe(String(ratio));
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(
+      <XDSAspectRatio ratio={1} ref={ref}>
+        <div>Content</div>
+      </XDSAspectRatio>,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it('passes through additional props', () => {
+    render(
+      <XDSAspectRatio
+        ratio={1}
+        data-testid="aspect-ratio"
+        aria-label="Image container">
+        <div>Content</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element).toHaveAttribute('aria-label', 'Image container');
+  });
+
+  it('renders with ReactNode children', () => {
+    render(
+      <XDSAspectRatio ratio={16 / 9} data-testid="aspect-ratio">
+        <img
+          src="test.jpg"
+          alt="Test"
+          data-testid="image"
+          style={{width: '100%', height: '100%', objectFit: 'cover'}}
+        />
+      </XDSAspectRatio>,
+    );
+    const image = screen.getByTestId('image');
+    expect(image).toBeInTheDocument();
+  });
+
+  it('renders with xstyle prop', () => {
+    // Verify that xstyle is accepted and component renders without error
+    render(
+      <XDSAspectRatio ratio={1} data-testid="aspect-ratio" xstyle={{}}>
+        <div>Content</div>
+      </XDSAspectRatio>,
+    );
+    const element = screen.getByTestId('aspect-ratio');
+    expect(element).toBeInTheDocument();
+  });
+
+  it('renders different content types', () => {
+    render(
+      <XDSAspectRatio ratio={16 / 9} data-testid="aspect-ratio">
+        <video data-testid="video" src="test.mp4" />
+      </XDSAspectRatio>,
+    );
+    const video = screen.getByTestId('video');
+    expect(video).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -1,0 +1,80 @@
+/**
+ * @file XDSAspectRatio.tsx
+ * @input Uses React forwardRef, stylex
+ * @output Exports XDSAspectRatio component and XDSAspectRatioProps
+ * @position AspectRatio component; maintains a specific aspect ratio for its children
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/AspectRatio/README.md
+ * - /packages/core/src/AspectRatio/XDSAspectRatio.test.tsx
+ * - /apps/storybook/stories/AspectRatio.stories.tsx
+ */
+
+import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+
+export interface XDSAspectRatioProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'style' | 'className'
+> {
+  /**
+   * The aspect ratio as width/height (e.g., 16/9 = 1.777..., 4/3 = 1.333..., 1 for square).
+   */
+  ratio: number;
+
+  /**
+   * Content to render inside the aspect ratio container.
+   * The child element will be positioned absolutely to fill the container.
+   */
+  children: ReactNode;
+
+  /**
+   * StyleX styles to apply to the aspect ratio container.
+   */
+  xstyle?: StyleXStyles;
+}
+
+const styles = stylex.create({
+  container: {
+    position: 'relative',
+    width: '100%',
+  },
+  child: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+  },
+});
+
+/**
+ * AspectRatio component for maintaining a specific aspect ratio for its children.
+ *
+ * Uses the CSS aspect-ratio property to maintain the ratio. The child element
+ * is positioned absolutely to fill the container, which is useful for images,
+ * videos, embeds, and placeholders.
+ *
+ * @example
+ * ```tsx
+ * <XDSAspectRatio ratio={16 / 9}>
+ *   <img src="image.jpg" alt="Widescreen image" style={{objectFit: 'cover'}} />
+ * </XDSAspectRatio>
+ * ```
+ */
+export const XDSAspectRatio = forwardRef<HTMLElement, XDSAspectRatioProps>(
+  function XDSAspectRatio({ratio, children, xstyle, ...props}, ref) {
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        {...stylex.props(styles.container, xstyle)}
+        style={{aspectRatio: ratio}}
+        {...props}>
+        <div {...stylex.props(styles.child)}>{children}</div>
+      </div>
+    );
+  },
+);
+
+XDSAspectRatio.displayName = 'XDSAspectRatio';

--- a/packages/core/src/AspectRatio/index.ts
+++ b/packages/core/src/AspectRatio/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input Imports from XDSAspectRatio.tsx
+ * @output Exports XDSAspectRatio component and props type
+ * @position Package entry point for AspectRatio
+ *
+ * SYNC: When modified, update /packages/core/src/AspectRatio/README.md
+ */
+
+export {XDSAspectRatio} from './XDSAspectRatio';
+export type {XDSAspectRatioProps} from './XDSAspectRatio';

--- a/packages/core/src/Center/XDSCenter.test.tsx
+++ b/packages/core/src/Center/XDSCenter.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @file XDSCenter.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSCenter component
+ * @output Unit tests for XDSCenter component behavior
+ * @position Testing; validates XDSCenter.tsx implementation
+ *
+ * SYNC: When XDSCenter.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSCenter} from './XDSCenter';
+
+describe('XDSCenter', () => {
+  it('renders and centers children (both axes by default)', () => {
+    render(
+      <XDSCenter data-testid="center">
+        <div>Centered Content</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    expect(screen.getByText('Centered Content')).toBeInTheDocument();
+    expect(element).toBeInTheDocument();
+    // Check that it has flex display
+    expect(element).toHaveStyle({display: 'flex'});
+  });
+
+  it('centers horizontally only', () => {
+    render(
+      <XDSCenter axis="horizontal" data-testid="center">
+        <div>Horizontal Center</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    expect(screen.getByText('Horizontal Center')).toBeInTheDocument();
+    expect(element).toHaveStyle({display: 'flex'});
+  });
+
+  it('centers vertically only', () => {
+    render(
+      <XDSCenter axis="vertical" data-testid="center">
+        <div>Vertical Center</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    expect(screen.getByText('Vertical Center')).toBeInTheDocument();
+    expect(element).toHaveStyle({display: 'flex'});
+  });
+
+  it('applies height prop', () => {
+    render(
+      <XDSCenter height="100%" data-testid="center">
+        <div>Full Height</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    // Height is applied via StyleX dynamic styles
+    expect(element).toBeInTheDocument();
+  });
+
+  it('applies width prop', () => {
+    render(
+      <XDSCenter width={300} data-testid="center">
+        <div>Fixed Width</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    // Width is applied via StyleX dynamic styles
+    expect(element).toBeInTheDocument();
+  });
+
+  it('applies both width and height props', () => {
+    render(
+      <XDSCenter width="50%" height={200} data-testid="center">
+        <div>Sized Content</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    // Width and height are applied via StyleX dynamic styles
+    expect(element).toBeInTheDocument();
+  });
+
+  it('renders as inline-flex when inline is true', () => {
+    render(
+      <XDSCenter inline data-testid="center">
+        <div>Inline Content</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    expect(element).toHaveStyle({display: 'inline-flex'});
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(
+      <XDSCenter ref={ref}>
+        <div>Test</div>
+      </XDSCenter>,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+  });
+
+  it('applies xstyle prop', () => {
+    // Note: StyleX styles are transformed at build time, so we test that
+    // the component renders without error when xstyle is provided
+    render(
+      <XDSCenter data-testid="center" xstyle={undefined}>
+        <div>Styled Content</div>
+      </XDSCenter>,
+    );
+    expect(screen.getByTestId('center')).toBeInTheDocument();
+  });
+
+  it('passes through additional props', () => {
+    render(
+      <XDSCenter data-testid="center" aria-label="centered container">
+        <div>Content</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    expect(element).toHaveAttribute('aria-label', 'centered container');
+  });
+
+  it('renders as div element', () => {
+    render(
+      <XDSCenter data-testid="center">
+        <div>Content</div>
+      </XDSCenter>,
+    );
+    const element = screen.getByTestId('center');
+    expect(element.tagName).toBe('DIV');
+  });
+});

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -1,0 +1,119 @@
+/**
+ * @file XDSCenter.tsx
+ * @input Uses React forwardRef, StyleX for centering styles
+ * @output Exports XDSCenter component and XDSCenterProps
+ * @position Center component for centering children horizontally/vertically
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Center/README.md
+ * - /packages/core/src/Center/XDSCenter.test.tsx
+ * - /apps/storybook/stories/Center.stories.tsx
+ */
+
+import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import type {SizeValue} from '../Layout';
+
+const styles = stylex.create({
+  base: {
+    display: 'flex',
+  },
+  inline: {
+    display: 'inline-flex',
+  },
+  alignItemsCenter: {
+    alignItems: 'center',
+  },
+  justifyContentCenter: {
+    justifyContent: 'center',
+  },
+});
+
+// Dynamic styles for sizing props
+const dynamicStyles = stylex.create({
+  sizing: (width: SizeValue | null, height: SizeValue | null) => ({
+    width,
+    height,
+  }),
+});
+
+export type CenterAxis = 'both' | 'horizontal' | 'vertical';
+
+export interface XDSCenterProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'style' | 'className'
+> {
+  /**
+   * Center axis - which direction(s) to center.
+   * - `both`: Center both horizontally and vertically (default)
+   * - `horizontal`: Center horizontally only (justifyContent: center)
+   * - `vertical`: Center vertically only (alignItems: center)
+   * @default 'both'
+   */
+  axis?: CenterAxis;
+
+  /**
+   * Width of the container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  width?: SizeValue;
+
+  /**
+   * Height of the container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  height?: SizeValue;
+
+  /**
+   * Whether to make the container inline-flex (useful for text/icons).
+   * @default false
+   */
+  inline?: boolean;
+
+  /**
+   * Content to render inside the center container.
+   */
+  children: ReactNode;
+
+  /**
+   * StyleX styles to apply to the container.
+   */
+  xstyle?: StyleXStyles;
+}
+
+/**
+ * Center component for centering children horizontally and/or vertically.
+ *
+ * Uses flexbox for centering. By default, centers on both axes.
+ * Use the `axis` prop to center on only one axis.
+ *
+ * @example
+ * ```tsx
+ * <XDSCenter width={300} height={200}>
+ *   <Content />
+ * </XDSCenter>
+ * ```
+ */
+export const XDSCenter = forwardRef<HTMLDivElement, XDSCenterProps>(
+  function XDSCenter(
+    {axis = 'both', width, height, inline = false, children, xstyle, ...props},
+    ref,
+  ) {
+    const stylexProps = stylex.props(
+      inline ? styles.inline : styles.base,
+      (axis === 'both' || axis === 'vertical') && styles.alignItemsCenter,
+      (axis === 'both' || axis === 'horizontal') && styles.justifyContentCenter,
+      dynamicStyles.sizing(width ?? null, height ?? null),
+      xstyle,
+    );
+
+    return (
+      <div ref={ref} {...stylexProps} {...props}>
+        {children}
+      </div>
+    );
+  },
+);
+
+XDSCenter.displayName = 'XDSCenter';

--- a/packages/core/src/Center/index.ts
+++ b/packages/core/src/Center/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input Imports XDSCenter component
+ * @output Exports XDSCenter and types for @xds/core/Center
+ * @position Entry point for Center component
+ *
+ * SYNC: When modified, update /packages/core/src/Center/README.md
+ */
+
+export {XDSCenter} from './XDSCenter';
+export type {XDSCenterProps, CenterAxis} from './XDSCenter';

--- a/packages/core/src/Divider/XDSDivider.test.tsx
+++ b/packages/core/src/Divider/XDSDivider.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * @file XDSDivider.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSDivider component
+ * @output Unit tests for XDSDivider component behavior
+ * @position Testing; validates XDSDivider.tsx implementation
+ *
+ * SYNC: When XDSDivider.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSDivider} from './XDSDivider';
+
+describe('XDSDivider', () => {
+  it('renders horizontal by default', () => {
+    render(<XDSDivider data-testid="divider" />);
+    const element = screen.getByTestId('divider');
+    expect(element).toBeInTheDocument();
+    expect(element).toHaveAttribute('role', 'separator');
+    expect(element).toHaveAttribute('aria-orientation', 'horizontal');
+    // Without label, should have 1 child (single line)
+    const children = Array.from(element.children);
+    expect(children.length).toBe(1);
+  });
+
+  it('renders vertical when specified', () => {
+    render(<XDSDivider orientation="vertical" data-testid="divider" />);
+    const element = screen.getByTestId('divider');
+    expect(element).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  it('renders with label', () => {
+    render(<XDSDivider label="Section" />);
+    expect(screen.getByText('Section')).toBeInTheDocument();
+  });
+
+  it('renders label centered with lines on both sides', () => {
+    render(<XDSDivider label="Center" data-testid="divider" />);
+    const divider = screen.getByTestId('divider');
+    expect(divider).toBeInTheDocument();
+    expect(screen.getByText('Center')).toBeInTheDocument();
+    // Should have 3 children: line, label, line
+    const children = Array.from(divider.children);
+    expect(children.length).toBe(3);
+  });
+
+  it('applies isFullBleed styles', () => {
+    render(<XDSDivider isFullBleed data-testid="divider" />);
+    const element = screen.getByTestId('divider');
+    expect(element).toBeInTheDocument();
+    // isFullBleed is applied via stylex, we verify component renders without error
+  });
+
+  it('applies subtle variant by default', () => {
+    render(<XDSDivider data-testid="divider" />);
+    const element = screen.getByTestId('divider');
+    expect(element).toBeInTheDocument();
+  });
+
+  it('applies strong variant when specified', () => {
+    render(<XDSDivider variant="strong" data-testid="divider" />);
+    const element = screen.getByTestId('divider');
+    expect(element).toBeInTheDocument();
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(<XDSDivider ref={ref} />);
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it('passes through additional props', () => {
+    render(<XDSDivider data-testid="divider" aria-label="Content separator" />);
+    const element = screen.getByTestId('divider');
+    expect(element).toHaveAttribute('aria-label', 'Content separator');
+  });
+
+  it('renders with ReactNode as label', () => {
+    render(
+      <XDSDivider
+        label={<span data-testid="custom-label">Custom</span>}
+        data-testid="divider"
+      />,
+    );
+    expect(screen.getByTestId('custom-label')).toBeInTheDocument();
+  });
+
+  it('renders vertical divider with label', () => {
+    render(
+      <XDSDivider
+        orientation="vertical"
+        label="Vertical"
+        data-testid="divider"
+      />,
+    );
+    const divider = screen.getByTestId('divider');
+    expect(divider).toHaveAttribute('aria-orientation', 'vertical');
+    expect(screen.getByText('Vertical')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -1,0 +1,187 @@
+/**
+ * @file XDSDivider.tsx
+ * @input Uses React forwardRef, stylex, spacing and color tokens
+ * @output Exports XDSDivider component and XDSDividerProps
+ * @position Divider component; provides visual separation with optional label
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Divider/README.md
+ * - /packages/core/src/Divider/XDSDivider.test.tsx
+ * - /apps/storybook/stories/Divider.stories.tsx
+ */
+
+import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+
+export interface XDSDividerProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'style' | 'className' | 'children'
+> {
+  /**
+   * Orientation of the divider.
+   * @default 'horizontal'
+   */
+  orientation?: 'horizontal' | 'vertical';
+
+  /**
+   * Optional label to display centered on the divider.
+   * Rendered with small, secondary text styling.
+   */
+  label?: ReactNode;
+
+  /**
+   * Visual weight of the divider line.
+   * - 'subtle': Uses --color-divider (default)
+   * - 'strong': Uses --color-divider-emphasized
+   * @default 'subtle'
+   */
+  variant?: 'subtle' | 'strong';
+
+  /**
+   * Makes the divider escape its parent's container padding.
+   * Uses negative margins to extend to the container edges.
+   * @default false
+   */
+  isFullBleed?: boolean;
+
+  /**
+   * StyleX styles to apply to the divider container.
+   */
+  xstyle?: StyleXStyles;
+}
+
+const baseStyles = stylex.create({
+  horizontal: {
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+  },
+  vertical: {
+    display: 'inline-flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    height: '100%',
+  },
+});
+
+const lineStyles = stylex.create({
+  horizontalLine: {
+    height: '1px',
+    flexGrow: 1,
+    flexShrink: 1,
+  },
+  verticalLine: {
+    width: '1px',
+    flexGrow: 1,
+    flexShrink: 1,
+  },
+  subtle: {
+    backgroundColor: colorVars['--color-divider'],
+  },
+  strong: {
+    backgroundColor: colorVars['--color-divider-emphasized'],
+  },
+});
+
+const labelStyles = stylex.create({
+  label: {
+    flexShrink: 0,
+    paddingInline: spacingVars['--spacing-3'],
+    backgroundColor: colorVars['--color-surface'],
+    // Small secondary text styling
+    fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-normal'],
+    color: colorVars['--color-text-secondary'],
+  },
+  verticalLabel: {
+    paddingInline: 0,
+    paddingBlock: spacingVars['--spacing-3'],
+  },
+});
+
+const fullBleedStyles = stylex.create({
+  horizontal: {
+    marginInline: 'calc(-1 * var(--container-padding, 0px))',
+  },
+  vertical: {
+    marginBlock: 'calc(-1 * var(--container-padding, 0px))',
+  },
+});
+
+/**
+ * Divider component for visual separation of content.
+ *
+ * Provides horizontal and vertical dividers with optional labels.
+ * Uses XDS design tokens for colors and spacing.
+ *
+ * @example
+ * ```tsx
+ * <XDSDivider label="or" />
+ * ```
+ */
+export const XDSDivider = forwardRef<HTMLElement, XDSDividerProps>(
+  function XDSDivider(
+    {
+      orientation = 'horizontal',
+      label,
+      variant = 'subtle',
+      isFullBleed = false,
+      xstyle,
+      ...props
+    },
+    ref,
+  ) {
+    const isHorizontal = orientation === 'horizontal';
+
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        role="separator"
+        aria-orientation={orientation}
+        {...stylex.props(
+          isHorizontal ? baseStyles.horizontal : baseStyles.vertical,
+          isFullBleed &&
+            (isHorizontal
+              ? fullBleedStyles.horizontal
+              : fullBleedStyles.vertical),
+          xstyle,
+        )}
+        {...props}>
+        <div
+          {...stylex.props(
+            isHorizontal ? lineStyles.horizontalLine : lineStyles.verticalLine,
+            lineStyles[variant],
+          )}
+        />
+        {label && (
+          <div
+            {...stylex.props(
+              labelStyles.label,
+              !isHorizontal && labelStyles.verticalLabel,
+            )}>
+            {label}
+          </div>
+        )}
+        {label && (
+          <div
+            {...stylex.props(
+              isHorizontal
+                ? lineStyles.horizontalLine
+                : lineStyles.verticalLine,
+              lineStyles[variant],
+            )}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+XDSDivider.displayName = 'XDSDivider';

--- a/packages/core/src/Divider/index.ts
+++ b/packages/core/src/Divider/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input Imports from XDSDivider.tsx
+ * @output Exports XDSDivider component and props type
+ * @position Package entry point for Divider
+ *
+ * SYNC: When modified, update /packages/core/src/Divider/README.md
+ */
+
+export {XDSDivider} from './XDSDivider';
+export type {XDSDividerProps} from './XDSDivider';

--- a/packages/core/src/Grid/XDSGrid.test.tsx
+++ b/packages/core/src/Grid/XDSGrid.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * @file XDSGrid.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSGrid and XDSGridSpan components
+ * @output Unit tests for XDSGrid and XDSGridSpan component behavior
+ * @position Testing; validates XDSGrid.tsx and XDSGridSpan.tsx implementation
+ *
+ * SYNC: When XDSGrid.tsx or XDSGridSpan.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSGrid} from './XDSGrid';
+import {XDSGridSpan} from './XDSGridSpan';
+
+describe('XDSGrid', () => {
+  it('renders with fixed columns', () => {
+    render(
+      <XDSGrid columns={3} data-testid="grid">
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid).toBeInTheDocument();
+    expect(grid.style.gridTemplateColumns).toBe('repeat(3, 1fr)');
+  });
+
+  it('renders with minChildWidth (auto-fit)', () => {
+    render(
+      <XDSGrid minChildWidth={250} data-testid="grid">
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid.style.gridTemplateColumns).toBe(
+      'repeat(auto-fit, minmax(250px, 1fr))',
+    );
+  });
+
+  it('renders with both columns and minChildWidth (capped)', () => {
+    render(
+      <XDSGrid columns={3} minChildWidth={250} gap="space4" data-testid="grid">
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid.style.gridTemplateColumns).toBe(
+      'repeat(auto-fit, minmax(250px, 1fr))',
+    );
+    // maxWidth = 3 * 250 + 2 * 16 = 750 + 32 = 782px
+    expect(grid.style.maxWidth).toBe('782px');
+  });
+
+  it('renders with columns and minChildWidth using columnGap', () => {
+    render(
+      <XDSGrid
+        columns={4}
+        minChildWidth={200}
+        columnGap="space6"
+        data-testid="grid">
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    // maxWidth = 4 * 200 + 3 * 24 = 800 + 72 = 872px
+    expect(grid.style.maxWidth).toBe('872px');
+  });
+
+  it('applies gap correctly', () => {
+    render(
+      <XDSGrid columns={2} gap="space4" data-testid="grid">
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid).toBeInTheDocument();
+    // Gap is applied via stylex class, just verify component renders
+  });
+
+  it('applies rowGap and columnGap separately', () => {
+    render(
+      <XDSGrid
+        columns={2}
+        rowGap="space2"
+        columnGap="space6"
+        data-testid="grid">
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid).toBeInTheDocument();
+    // Gaps are applied via stylex classes
+  });
+
+  it('applies alignment props', () => {
+    render(
+      <XDSGrid columns={2} align="center" justify="start" data-testid="grid">
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid).toBeInTheDocument();
+    // Alignment is applied via stylex classes
+  });
+
+  it('defaults to 1 column when nothing specified', () => {
+    render(
+      <XDSGrid data-testid="grid">
+        <div>Item 1</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid.style.gridTemplateColumns).toBe('1fr');
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(
+      <XDSGrid columns={2} ref={ref}>
+        <div>Item</div>
+      </XDSGrid>,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it('passes through additional props', () => {
+    render(
+      <XDSGrid columns={2} data-testid="grid" aria-label="Product grid">
+        <div>Item</div>
+      </XDSGrid>,
+    );
+    const grid = screen.getByTestId('grid');
+    expect(grid).toHaveAttribute('aria-label', 'Product grid');
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <XDSGrid columns={3} data-testid="grid">
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+      </XDSGrid>,
+    );
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+    expect(screen.getByText('Item 3')).toBeInTheDocument();
+  });
+});
+
+describe('XDSGridSpan', () => {
+  it('spans correct number of columns', () => {
+    render(
+      <XDSGrid columns={4}>
+        <XDSGridSpan columns={2} data-testid="span">
+          Wide item
+        </XDSGridSpan>
+      </XDSGrid>,
+    );
+    const span = screen.getByTestId('span');
+    expect(span.style.gridColumn).toBe('span 2');
+  });
+
+  it('spans full width with columns="full"', () => {
+    render(
+      <XDSGrid columns={4}>
+        <XDSGridSpan columns="full" data-testid="span">
+          Full width
+        </XDSGridSpan>
+      </XDSGrid>,
+    );
+    const span = screen.getByTestId('span');
+    expect(span.style.gridColumn).toBe('1 / -1');
+  });
+
+  it('spans correct number of rows', () => {
+    render(
+      <XDSGrid columns={3}>
+        <XDSGridSpan rows={2} data-testid="span">
+          Tall item
+        </XDSGridSpan>
+      </XDSGrid>,
+    );
+    const span = screen.getByTestId('span');
+    expect(span.style.gridRow).toBe('span 2');
+  });
+
+  it('spans both columns and rows', () => {
+    render(
+      <XDSGrid columns={4}>
+        <XDSGridSpan columns={2} rows={2} data-testid="span">
+          2x2 item
+        </XDSGridSpan>
+      </XDSGrid>,
+    );
+    const span = screen.getByTestId('span');
+    expect(span.style.gridColumn).toBe('span 2');
+    expect(span.style.gridRow).toBe('span 2');
+  });
+
+  it('renders without span props', () => {
+    render(
+      <XDSGrid columns={3}>
+        <XDSGridSpan data-testid="span">Normal item</XDSGridSpan>
+      </XDSGrid>,
+    );
+    const span = screen.getByTestId('span');
+    expect(span).toBeInTheDocument();
+    expect(span.style.gridColumn).toBe('');
+    expect(span.style.gridRow).toBe('');
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(
+      <XDSGrid columns={2}>
+        <XDSGridSpan ref={ref}>Item</XDSGridSpan>
+      </XDSGrid>,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it('passes through additional props', () => {
+    render(
+      <XDSGrid columns={2}>
+        <XDSGridSpan columns={2} data-testid="span" aria-label="Featured item">
+          Content
+        </XDSGridSpan>
+      </XDSGrid>,
+    );
+    const span = screen.getByTestId('span');
+    expect(span).toHaveAttribute('aria-label', 'Featured item');
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <XDSGrid columns={3}>
+        <XDSGridSpan columns="full">
+          <span data-testid="child">Child content</span>
+        </XDSGridSpan>
+      </XDSGrid>,
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -1,0 +1,346 @@
+/**
+ * @file XDSGrid.tsx
+ * @input Uses React forwardRef, stylex, spacing tokens
+ * @output Exports XDSGrid component and XDSGridProps
+ * @position Grid component; provides CSS Grid-based layout
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Grid/README.md
+ * - /packages/core/src/Grid/XDSGrid.test.tsx
+ * - /apps/storybook/stories/Grid.stories.tsx
+ */
+
+import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {spacingVars} from '../theme/tokens.stylex';
+import type {SpacingScale, SizeValue} from '../Layout';
+
+/**
+ * Grid alignment options for align-items and justify-items.
+ */
+export type GridAlignment = 'start' | 'center' | 'end' | 'stretch';
+
+export interface XDSGridProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'style' | 'className'
+> {
+  /**
+   * Maximum number of columns.
+   * - When only columns is set: creates fixed equal-width columns
+   * - When both columns and minChildWidth are set: caps the max columns
+   * - When neither is set with minChildWidth: unlimited columns
+   */
+  columns?: number;
+
+  /**
+   * Minimum width of each grid item in pixels.
+   * Enables auto-fit responsive behavior where columns automatically
+   * adjust based on available width.
+   * @default 0 (disabled - uses fixed columns)
+   */
+  minChildWidth?: number;
+
+  /**
+   * Width of the grid container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  width?: SizeValue;
+
+  /**
+   * Height of the grid container.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '100%').
+   */
+  height?: SizeValue;
+
+  /**
+   * Spacing between all grid items (both row and column).
+   * Uses XDS spacing tokens.
+   */
+  gap?: SpacingScale;
+
+  /**
+   * Spacing between rows. Overrides gap for rows.
+   * Uses XDS spacing tokens.
+   */
+  rowGap?: SpacingScale;
+
+  /**
+   * Spacing between columns. Overrides gap for columns.
+   * Uses XDS spacing tokens.
+   */
+  columnGap?: SpacingScale;
+
+  /**
+   * Vertical alignment of grid items (align-items).
+   * @default 'stretch'
+   */
+  align?: GridAlignment;
+
+  /**
+   * Horizontal alignment of grid items (justify-items).
+   * @default 'stretch'
+   */
+  justify?: GridAlignment;
+
+  /**
+   * StyleX styles to apply to the grid container.
+   */
+  xstyle?: StyleXStyles;
+
+  /**
+   * Content to render inside the grid.
+   */
+  children?: ReactNode;
+}
+
+const baseStyles = stylex.create({
+  grid: {
+    display: 'grid',
+  },
+});
+
+const alignStyles = stylex.create({
+  start: {
+    alignItems: 'start',
+  },
+  center: {
+    alignItems: 'center',
+  },
+  end: {
+    alignItems: 'end',
+  },
+  stretch: {
+    alignItems: 'stretch',
+  },
+});
+
+const justifyStyles = stylex.create({
+  start: {
+    justifyItems: 'start',
+  },
+  center: {
+    justifyItems: 'center',
+  },
+  end: {
+    justifyItems: 'end',
+  },
+  stretch: {
+    justifyItems: 'stretch',
+  },
+});
+
+const gapStyles = stylex.create({
+  space0: {
+    gap: spacingVars['--spacing-0'],
+  },
+  'space0.5': {
+    gap: spacingVars['--spacing-0-5'],
+  },
+  space1: {
+    gap: spacingVars['--spacing-1'],
+  },
+  space2: {
+    gap: spacingVars['--spacing-2'],
+  },
+  space3: {
+    gap: spacingVars['--spacing-3'],
+  },
+  space4: {
+    gap: spacingVars['--spacing-4'],
+  },
+  space5: {
+    gap: spacingVars['--spacing-5'],
+  },
+  space6: {
+    gap: spacingVars['--spacing-6'],
+  },
+  space7: {
+    gap: spacingVars['--spacing-7'],
+  },
+});
+
+const rowGapStyles = stylex.create({
+  space0: {
+    rowGap: spacingVars['--spacing-0'],
+  },
+  'space0.5': {
+    rowGap: spacingVars['--spacing-0-5'],
+  },
+  space1: {
+    rowGap: spacingVars['--spacing-1'],
+  },
+  space2: {
+    rowGap: spacingVars['--spacing-2'],
+  },
+  space3: {
+    rowGap: spacingVars['--spacing-3'],
+  },
+  space4: {
+    rowGap: spacingVars['--spacing-4'],
+  },
+  space5: {
+    rowGap: spacingVars['--spacing-5'],
+  },
+  space6: {
+    rowGap: spacingVars['--spacing-6'],
+  },
+  space7: {
+    rowGap: spacingVars['--spacing-7'],
+  },
+});
+
+const columnGapStyles = stylex.create({
+  space0: {
+    columnGap: spacingVars['--spacing-0'],
+  },
+  'space0.5': {
+    columnGap: spacingVars['--spacing-0-5'],
+  },
+  space1: {
+    columnGap: spacingVars['--spacing-1'],
+  },
+  space2: {
+    columnGap: spacingVars['--spacing-2'],
+  },
+  space3: {
+    columnGap: spacingVars['--spacing-3'],
+  },
+  space4: {
+    columnGap: spacingVars['--spacing-4'],
+  },
+  space5: {
+    columnGap: spacingVars['--spacing-5'],
+  },
+  space6: {
+    columnGap: spacingVars['--spacing-6'],
+  },
+  space7: {
+    columnGap: spacingVars['--spacing-7'],
+  },
+});
+
+// Spacing token values in pixels for max-width calculation
+const spacingPixels: Record<SpacingScale, number> = {
+  space0: 0,
+  'space0.5': 2,
+  space1: 4,
+  space2: 8,
+  space3: 12,
+  space4: 16,
+  space5: 20,
+  space6: 24,
+  space7: 32,
+};
+
+/**
+ * Calculate max-width when capping columns with minChildWidth.
+ * maxWidth = columns * minChildWidth + (columns - 1) * gapPx
+ */
+function calculateMaxWidth(
+  columns: number,
+  minChildWidth: number,
+  gap: SpacingScale | undefined,
+  columnGap: SpacingScale | undefined,
+): number {
+  const gapPx =
+    columnGap != null
+      ? spacingPixels[columnGap]
+      : gap != null
+        ? spacingPixels[gap]
+        : 0;
+  return columns * minChildWidth + (columns - 1) * gapPx;
+}
+
+/**
+ * Grid component for CSS Grid-based layouts.
+ *
+ * Supports both fixed-column and responsive auto-fit layouts.
+ * The `columns` and `minChildWidth` props work together:
+ * - columns only: Fixed equal-width columns
+ * - minChildWidth only: Auto-fit responsive, unlimited columns
+ * - Both: Auto-fit responsive, capped at max columns
+ *
+ * @example
+ * ```tsx
+ * <XDSGrid columns={3} gap="space4">
+ *   <Item />
+ *   <Item />
+ *   <Item />
+ * </XDSGrid>
+ * ```
+ */
+export const XDSGrid = forwardRef<HTMLElement, XDSGridProps>(function XDSGrid(
+  {
+    columns,
+    minChildWidth = 0,
+    width,
+    height,
+    gap,
+    rowGap,
+    columnGap,
+    align,
+    justify,
+    xstyle,
+    children,
+    ...props
+  },
+  ref,
+) {
+  // Determine grid-template-columns value
+  let gridTemplateColumns: string;
+  let calculatedMaxWidth: number | undefined;
+
+  if (minChildWidth > 0) {
+    // Auto-fit mode: responsive columns
+    gridTemplateColumns = `repeat(auto-fit, minmax(${minChildWidth}px, 1fr))`;
+
+    // If columns is also set, cap the max columns via max-width
+    if (columns != null && columns > 0) {
+      calculatedMaxWidth = calculateMaxWidth(
+        columns,
+        minChildWidth,
+        gap,
+        columnGap,
+      );
+    }
+  } else if (columns != null && columns > 0) {
+    // Fixed columns mode
+    gridTemplateColumns = `repeat(${columns}, 1fr)`;
+  } else {
+    // Default to 1 column if nothing specified
+    gridTemplateColumns = '1fr';
+  }
+
+  // Build inline style for dynamic values
+  const inlineStyle: React.CSSProperties = {
+    gridTemplateColumns,
+    ...(calculatedMaxWidth != null && {maxWidth: `${calculatedMaxWidth}px`}),
+    ...(width != null && {
+      width: typeof width === 'number' ? `${width}px` : width,
+    }),
+    ...(height != null && {
+      height: typeof height === 'number' ? `${height}px` : height,
+    }),
+  };
+
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      {...stylex.props(
+        baseStyles.grid,
+        gap != null && gapStyles[gap],
+        rowGap != null && rowGapStyles[rowGap],
+        columnGap != null && columnGapStyles[columnGap],
+        align != null && alignStyles[align],
+        justify != null && justifyStyles[justify],
+        xstyle,
+      )}
+      style={inlineStyle}
+      {...props}>
+      {children}
+    </div>
+  );
+});
+
+XDSGrid.displayName = 'XDSGrid';

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -1,0 +1,93 @@
+/**
+ * @file XDSGridSpan.tsx
+ * @input Uses React forwardRef, stylex
+ * @output Exports XDSGridSpan component and XDSGridSpanProps
+ * @position Grid span component; controls grid item span
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Grid/README.md
+ * - /packages/core/src/Grid/XDSGrid.test.tsx
+ * - /apps/storybook/stories/Grid.stories.tsx
+ */
+
+import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+
+export interface XDSGridSpanProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'style' | 'className'
+> {
+  /**
+   * Number of columns to span, or 'full' to span all columns.
+   * - Number: `grid-column: span N`
+   * - 'full': `grid-column: 1 / -1` (spans entire row)
+   */
+  columns?: number | 'full';
+
+  /**
+   * Number of rows to span.
+   * Sets `grid-row: span N`.
+   */
+  rows?: number;
+
+  /**
+   * StyleX styles to apply to the grid span element.
+   */
+  xstyle?: StyleXStyles;
+
+  /**
+   * Content to render inside the grid span.
+   */
+  children?: ReactNode;
+}
+
+const baseStyles = stylex.create({
+  span: {
+    // Base styles for grid item
+    minWidth: 0, // Prevent overflow in grid
+    // Make span fill grid cell and stretch children
+    display: 'grid',
+    height: '100%',
+  },
+});
+
+/**
+ * Grid span component for controlling how many columns/rows a grid item spans.
+ *
+ * Use as a direct child of XDSGrid to make an item span multiple columns
+ * or rows.
+ *
+ * @example
+ * ```tsx
+ * <XDSGrid columns={3} gap="space4">
+ *   <XDSGridSpan columns={2}>Wide item</XDSGridSpan>
+ *   <div>Normal</div>
+ * </XDSGrid>
+ * ```
+ */
+export const XDSGridSpan = forwardRef<HTMLElement, XDSGridSpanProps>(
+  function XDSGridSpan({columns, rows, xstyle, children, ...props}, ref) {
+    // Build inline style for grid spanning
+    const inlineStyle: React.CSSProperties = {
+      ...(columns != null && {
+        gridColumn: columns === 'full' ? '1 / -1' : `span ${columns}`,
+      }),
+      ...(rows != null && {
+        gridRow: `span ${rows}`,
+      }),
+    };
+
+    return (
+      <div
+        ref={ref as React.Ref<HTMLDivElement>}
+        {...stylex.props(baseStyles.span, xstyle)}
+        style={inlineStyle}
+        {...props}>
+        {children}
+      </div>
+    );
+  },
+);
+
+XDSGridSpan.displayName = 'XDSGridSpan';

--- a/packages/core/src/Grid/index.ts
+++ b/packages/core/src/Grid/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @file index.ts
+ * @input Imports from XDSGrid.tsx and XDSGridSpan.tsx
+ * @output Exports Grid components and types
+ * @position Package entry point for Grid
+ *
+ * SYNC: When modified, update /packages/core/src/Grid/README.md
+ */
+
+export {XDSGrid} from './XDSGrid';
+export type {XDSGridProps, GridAlignment} from './XDSGrid';
+
+export {XDSGridSpan} from './XDSGridSpan';
+export type {XDSGridSpanProps} from './XDSGridSpan';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,12 +8,16 @@
  */
 
 // Components
+export * from './AspectRatio';
 export * from './Avatar';
 export * from './Button';
 export * from './Calendar';
+export * from './Center';
 export * from './CheckboxInput';
 export * from './DatePicker';
+export * from './Divider';
 export * from './Field';
+export * from './Grid';
 export * from './Icon';
 export * from './Text';
 export * from './TextInput';


### PR DESCRIPTION
These came up from the vibe tests as recommendations to handle more layouts. Some of them are similar to components like XDSMedia. I do think these will be generally useful since we've needed a good grid and center layout for some time. Divider is just a given. I think with these updates the layout offerings are complete.

<img width="1085" height="566" alt="Screenshot 2026-02-02 at 5 52 53 PM" src="https://github.com/user-attachments/assets/59e91d32-22ab-4bff-835b-7780c502de7d" />
<img width="1087" height="751" alt="Screenshot 2026-02-02 at 5 53 09 PM" src="https://github.com/user-attachments/assets/6fbdfdc9-ece4-49d3-a20f-6b500ca75650" />
<img width="946" height="903" alt="Screenshot 2026-02-02 at 5 53 20 PM" src="https://github.com/user-attachments/assets/09466341-3894-4e82-9cbe-7197c19bffbe" />
<img width="1088" height="702" alt="Screenshot 2026-02-02 at 5 53 28 PM" src="https://github.com/user-attachments/assets/3daf39ea-9a92-4225-a90c-ad38a934c60c" />
<img width="1072" height="468" alt="Screenshot 2026-02-02 at 5 54 03 PM" src="https://github.com/user-attachments/assets/3b0b8ada-0acb-4ce5-bd2b-6b79fe8e337d" />
<img width="1085" height="895" alt="Screenshot 2026-02-02 at 5 54 10 PM" src="https://github.com/user-attachments/assets/b6a482bd-4f7a-40c3-9c4f-b340c8961fca" />
<img width="1054" height="645" alt="Screenshot 2026-02-02 at 5 54 30 PM" src="https://github.com/user-attachments/assets/604137c6-6529-4d55-b769-fd25b815af42" />
<img width="1098" height="761" alt="Screenshot 2026-02-02 at 5 54 37 PM" src="https://github.com/user-attachments/assets/b473de60-d9fb-4d28-99f6-8461102d6072" />
<img width="1084" height="784" alt="Screenshot 2026-02-02 at 5 54 47 PM" src="https://github.com/user-attachments/assets/14d14a2a-6651-456d-9e5e-6f1b8b0b1a65" />
<img width="1060" height="875" alt="Screenshot 2026-02-02 at 5 54 53 PM" src="https://github.com/user-attachments/assets/f32d0cdb-eaa0-40ab-8ef6-2f730c8a8342" />
<img width="1086" height="430" alt="Screenshot 2026-02-02 at 5 55 00 PM" src="https://github.com/user-attachments/assets/96c9089f-5279-4700-bab8-49022e0d8816" />
