### PR TITLE
Add XDSFieldStatus + status prop to XDSCheckboxInput/XDSSwitch

### DIFF
--- a/apps/storybook/stories/CheckboxInput.stories.tsx
+++ b/apps/storybook/stories/CheckboxInput.stories.tsx
@@ -361,3 +361,107 @@ export const StartIconVariations: Story = {
     );
   },
 };
+
+export const WithErrorStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState<boolean | 'indeterminate'>(
+      args.value ?? false,
+    );
+    const {value: _, onChange: __, ...restArgs} = args;
+    return (
+      <XDSCheckboxInput
+        {...restArgs}
+        value={value}
+        onChange={checked => setValue(checked)}
+      />
+    );
+  },
+  args: {
+    label: 'Accept terms and conditions',
+    status: {type: 'error', message: 'You must accept the terms to continue'},
+  },
+};
+
+export const WithWarningStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState<boolean | 'indeterminate'>(
+      args.value ?? true,
+    );
+    const {value: _, onChange: __, ...restArgs} = args;
+    return (
+      <XDSCheckboxInput
+        {...restArgs}
+        value={value}
+        onChange={checked => setValue(checked)}
+      />
+    );
+  },
+  args: {
+    label: 'Share usage data',
+    description: 'Help us improve by sharing anonymous usage statistics',
+    status: {type: 'warning', message: 'This data may be shared with partners'},
+  },
+};
+
+export const WithSuccessStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState<boolean | 'indeterminate'>(
+      args.value ?? true,
+    );
+    const {value: _, onChange: __, ...restArgs} = args;
+    return (
+      <XDSCheckboxInput
+        {...restArgs}
+        value={value}
+        onChange={checked => setValue(checked)}
+      />
+    );
+  },
+  args: {
+    label: 'Email verified',
+    status: {type: 'success', message: 'Your email has been verified'},
+  },
+};
+
+export const StatusVariations: Story = {
+  render: () => {
+    const [value1, setValue1] = useState<boolean | 'indeterminate'>(false);
+    const [value2, setValue2] = useState<boolean | 'indeterminate'>(true);
+    const [value3, setValue3] = useState<boolean | 'indeterminate'>(true);
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '24px',
+          maxWidth: '400px',
+        }}>
+        <XDSCheckboxInput
+          label="Accept terms and conditions"
+          value={value1}
+          onChange={setValue1}
+          status={{
+            type: 'error',
+            message: 'You must accept the terms to continue',
+          }}
+        />
+        <XDSCheckboxInput
+          label="Share usage data"
+          description="Help us improve by sharing anonymous usage statistics"
+          value={value2}
+          onChange={setValue2}
+          status={{
+            type: 'warning',
+            message: 'This data may be shared with partners',
+          }}
+        />
+        <XDSCheckboxInput
+          label="Email verified"
+          value={value3}
+          onChange={setValue3}
+          status={{type: 'success', message: 'Your email has been verified'}}
+        />
+      </div>
+    );
+  },
+};

--- a/apps/storybook/stories/Switch.stories.tsx
+++ b/apps/storybook/stories/Switch.stories.tsx
@@ -435,3 +435,105 @@ export const SpreadSpacingExample: Story = {
     );
   },
 };
+
+export const WithErrorStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? false);
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSSwitch
+        {...restArgs}
+        value={value}
+        onChange={checked => setValue(checked)}
+      />
+    );
+  },
+  args: {
+    label: 'Accept terms and conditions',
+    isRequired: true,
+    status: {type: 'error', message: 'You must accept the terms to continue'},
+  },
+};
+
+export const WithWarningStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? true);
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSSwitch
+        {...restArgs}
+        value={value}
+        onChange={checked => setValue(checked)}
+      />
+    );
+  },
+  args: {
+    label: 'Share usage data',
+    description: 'Help us improve by sharing anonymous usage statistics',
+    status: {type: 'warning', message: 'This data may be shared with partners'},
+  },
+};
+
+export const WithSuccessStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? true);
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSSwitch
+        {...restArgs}
+        value={value}
+        onChange={checked => setValue(checked)}
+      />
+    );
+  },
+  args: {
+    label: 'Two-factor authentication',
+    labelIcon: ShieldCheckIcon,
+    status: {type: 'success', message: 'Your account is now more secure'},
+  },
+};
+
+export const StatusVariations: Story = {
+  render: () => {
+    const [value1, setValue1] = useState(false);
+    const [value2, setValue2] = useState(true);
+    const [value3, setValue3] = useState(true);
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '24px',
+          maxWidth: '400px',
+        }}>
+        <XDSSwitch
+          label="Accept terms and conditions"
+          value={value1}
+          onChange={setValue1}
+          isRequired
+          status={{
+            type: 'error',
+            message: 'You must accept the terms to continue',
+          }}
+        />
+        <XDSSwitch
+          label="Share usage data"
+          description="Help us improve by sharing anonymous usage statistics"
+          value={value2}
+          onChange={setValue2}
+          status={{
+            type: 'warning',
+            message: 'This data may be shared with partners',
+          }}
+        />
+        <XDSSwitch
+          label="Two-factor authentication"
+          value={value3}
+          onChange={setValue3}
+          labelIcon={ShieldCheckIcon}
+          status={{type: 'success', message: 'Your account is now more secure'}}
+        />
+      </div>
+    );
+  },
+};

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSCheckboxInput.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, XDSFieldLabel, XDSIconType
+ * @input Uses React forwardRef, useId, ChangeEvent, XDSFieldLabel, XDSFieldStatus, XDSIconType, XDSInputStatus
  * @output Exports XDSCheckboxInput component, XDSCheckboxInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSCheckboxInput.test.tsx
  *
@@ -17,12 +17,14 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
+  textSizeVars,
   transitionVars,
   typographyVars,
-  textSizeVars,
 } from '../theme/tokens.stylex';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
+import {XDSFieldStatus} from '../Field/XDSFieldStatus';
 import type {XDSIconType} from '../Icon';
+import type {XDSInputStatus} from '../Field/types';
 
 const styles = stylex.create({
   container: {
@@ -227,6 +229,11 @@ export interface XDSCheckboxInputProps {
    * Icon to display before the label text.
    */
   startIcon?: XDSIconType;
+  /**
+   * Status indicator for the checkbox.
+   * When set with a message, displays a colored message box below the checkbox.
+   */
+  status?: XDSInputStatus;
 }
 
 /**
@@ -264,93 +271,117 @@ export const XDSCheckboxInput = forwardRef<
       onFocus,
       onBlur,
       startIcon,
+      status,
     },
     ref,
   ) => {
     const id = useId();
     const descriptionID = useId();
+    const statusMessageID = useId();
 
     const isIndeterminate = value === 'indeterminate';
     const isChecked = value === true;
     const isCheckedOrIndeterminate = isChecked || isIndeterminate;
 
+    // Build aria-describedby from description and status message
+    const describedByParts: string[] = [];
+    if (description) describedByParts.push(descriptionID);
+    if (status?.message) describedByParts.push(statusMessageID);
+    const ariaDescribedBy =
+      describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
+
     return (
-      <div
-        {...stylex.props(
-          styles.container,
-          !isDisabled && stylex.defaultMarker(),
-        )}>
-        <div {...stylex.props(styles.checkboxWrapper, wrapperSizeStyles[size])}>
-          <input
-            ref={ref}
-            id={id}
-            type="checkbox"
-            checked={isChecked}
-            disabled={isDisabled}
-            required={isRequired}
-            onChange={e => onChange(e.target.checked, e)}
-            onFocus={onFocus}
-            onBlur={onBlur}
-            aria-describedby={description ? descriptionID : undefined}
-            {...stylex.props(
-              styles.input,
-              wrapperSizeStyles[size],
-              isDisabled && styles.inputDisabled,
-            )}
-          />
+      <div>
+        <div
+          {...stylex.props(
+            styles.container,
+            !isDisabled && stylex.defaultMarker(),
+          )}>
           <div
-            aria-hidden="true"
-            {...stylex.props(
-              styles.checkbox,
-              checkboxSizeStyles[size],
-              isCheckedOrIndeterminate
-                ? styles.checkboxChecked
-                : styles.checkboxUnchecked,
-              isDisabled && styles.checkboxDisabled,
-              isDisabled &&
-                !isCheckedOrIndeterminate &&
-                styles.checkboxDisabledUnchecked,
-            )}>
-            <svg
-              viewBox="0 0 10 10"
+            {...stylex.props(styles.checkboxWrapper, wrapperSizeStyles[size])}>
+            <input
+              ref={ref}
+              id={id}
+              type="checkbox"
+              checked={isChecked}
+              disabled={isDisabled}
+              required={isRequired}
+              onChange={e => onChange(e.target.checked, e)}
+              onFocus={onFocus}
+              onBlur={onBlur}
+              aria-describedby={ariaDescribedBy}
+              aria-invalid={status?.type === 'error' ? true : undefined}
               {...stylex.props(
-                styles.checkmark,
-                checkmarkSizeStyles[size],
-                isChecked && styles.checkmarkVisible,
-              )}>
-              <path
-                d="M8.5 2.5L4 7.5L1.5 5"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                fill="none"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              />
-            </svg>
-            <div
-              {...stylex.props(
-                styles.indeterminateMark,
-                indeterminateSizeStyles[size],
-                isIndeterminate && styles.indeterminateMarkVisible,
+                styles.input,
+                wrapperSizeStyles[size],
+                isDisabled && styles.inputDisabled,
               )}
             />
+            <div
+              aria-hidden="true"
+              {...stylex.props(
+                styles.checkbox,
+                checkboxSizeStyles[size],
+                isCheckedOrIndeterminate
+                  ? styles.checkboxChecked
+                  : styles.checkboxUnchecked,
+                isDisabled && styles.checkboxDisabled,
+                isDisabled &&
+                  !isCheckedOrIndeterminate &&
+                  styles.checkboxDisabledUnchecked,
+              )}>
+              <svg
+                viewBox="0 0 10 10"
+                {...stylex.props(
+                  styles.checkmark,
+                  checkmarkSizeStyles[size],
+                  isChecked && styles.checkmarkVisible,
+                )}>
+                <path
+                  d="M8.5 2.5L4 7.5L1.5 5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+              <div
+                {...stylex.props(
+                  styles.indeterminateMark,
+                  indeterminateSizeStyles[size],
+                  isIndeterminate && styles.indeterminateMarkVisible,
+                )}
+              />
+            </div>
+          </div>
+          <div
+            {...stylex.props(
+              styles.labelWrapper,
+              labelWrapperSizeStyles[size],
+            )}>
+            <XDSFieldLabel
+              label={label}
+              inputID={id}
+              isLabelHidden={isLabelHidden}
+              isDisabled={isDisabled}
+              startIcon={startIcon}
+            />
+            {description && (
+              <span id={descriptionID} {...stylex.props(styles.description)}>
+                {description}
+              </span>
+            )}
           </div>
         </div>
-        <div
-          {...stylex.props(styles.labelWrapper, labelWrapperSizeStyles[size])}>
-          <XDSFieldLabel
-            label={label}
-            inputID={id}
-            isLabelHidden={isLabelHidden}
-            isDisabled={isDisabled}
-            startIcon={startIcon}
+        {status?.message && (
+          <XDSFieldStatus
+            type={status.type}
+            message={status.message}
+            id={statusMessageID}
+            variant="detached"
           />
-          {description && (
-            <span id={descriptionID} {...stylex.props(styles.description)}>
-              {description}
-            </span>
-          )}
-        </div>
+        )}
       </div>
     );
   },

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -14,14 +14,13 @@
 import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSFieldLabel} from './XDSFieldLabel';
+import {XDSFieldStatus} from './XDSFieldStatus';
 import {
   colorVars,
-  radiusVars,
+  fontWeightVars,
   spacingVars,
   textSizeVars,
   typographyVars,
-  fontWeightVars,
-  lineHeightVars,
 } from '../theme/tokens.stylex';
 import type {XDSIconType} from '../Icon';
 
@@ -71,32 +70,6 @@ const styles = stylex.create({
   inputStatusWrapper: {
     display: 'flex',
     flexDirection: 'column',
-  },
-  statusMessage: {
-    marginTop: -6,
-    paddingBlockStart: 14,
-    paddingBlockEnd: 8,
-    paddingInline: spacingVars['--spacing-2'],
-    borderBottomLeftRadius: radiusVars['--radius-element'],
-    borderBottomRightRadius: radiusVars['--radius-element'],
-    fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
-    lineHeight: lineHeightVars['--leading-base'],
-  },
-});
-
-const statusMessageColorStyles = stylex.create({
-  warning: {
-    backgroundColor: colorVars['--color-warning-deemphasized'],
-    color: colorVars['--color-yellow-text'],
-  },
-  error: {
-    backgroundColor: colorVars['--color-negative-deemphasized'],
-    color: colorVars['--color-red-text'],
-  },
-  success: {
-    backgroundColor: colorVars['--color-positive-deemphasized'],
-    color: colorVars['--color-green-text'],
   },
 });
 
@@ -220,14 +193,12 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
         <div {...stylex.props(styles.inputStatusWrapper)}>
           {children}
           {status?.message && (
-            <div
+            <XDSFieldStatus
+              type={status.type}
+              message={status.message}
               id={status.messageID}
-              {...stylex.props(
-                styles.statusMessage,
-                statusMessageColorStyles[status.type],
-              )}>
-              {status.message}
-            </div>
+              variant="attached"
+            />
           )}
         </div>
       </div>

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -14,10 +14,10 @@ import * as stylex from '@stylexjs/stylex';
 import {InformationCircleIcon} from '@heroicons/react/24/outline';
 import {
   colorVars,
-  spacingVars,
-  typographyVars,
-  textSizeVars,
   fontWeightVars,
+  spacingVars,
+  textSizeVars,
+  typographyVars,
 } from '../theme/tokens.stylex';
 import {XDSIcon, type XDSIconType} from '../Icon';
 import {XDSTooltip} from '../Layer';

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -1,0 +1,119 @@
+/**
+ * @file XDSFieldStatus.tsx
+ * @input Uses React, stylex, theme tokens
+ * @output Exports XDSFieldStatus component, XDSFieldStatusProps
+ * @position Core implementation; consumed by index.ts, XDSField.tsx, XDSSwitch.tsx, XDSCheckboxInput.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Field/README.md (props table, features, implementation notes)
+ * - /packages/core/src/Field/index.ts (exports if types change)
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  lineHeightVars,
+  radiusVars,
+  spacingVars,
+  textSizeVars,
+  typographyVars,
+} from '../theme/tokens.stylex';
+import type {XDSInputStatusType} from './types';
+
+const styles = stylex.create({
+  base: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+  },
+  attached: {
+    marginTop: -6,
+    paddingBlockStart: 14,
+    paddingBlockEnd: 8,
+    paddingInline: spacingVars['--spacing-2'],
+    borderBottomLeftRadius: radiusVars['--radius-element'],
+    borderBottomRightRadius: radiusVars['--radius-element'],
+  },
+  detached: {
+    marginTop: spacingVars['--spacing-1'],
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-2'],
+    borderRadius: radiusVars['--radius-element'],
+  },
+});
+
+const colorStyles = stylex.create({
+  warning: {
+    backgroundColor: colorVars['--color-warning-deemphasized'],
+    color: colorVars['--color-yellow-text'],
+  },
+  error: {
+    backgroundColor: colorVars['--color-negative-deemphasized'],
+    color: colorVars['--color-red-text'],
+  },
+  success: {
+    backgroundColor: colorVars['--color-positive-deemphasized'],
+    color: colorVars['--color-green-text'],
+  },
+});
+
+export type XDSFieldStatusVariant = 'attached' | 'detached';
+
+export interface XDSFieldStatusProps {
+  /**
+   * The type of status to display.
+   */
+  type: XDSInputStatusType;
+  /**
+   * The status message to display.
+   */
+  message: string;
+  /**
+   * ID for the status message element (use for aria-describedby on the input).
+   */
+  id?: string;
+  /**
+   * Visual variant of the status message.
+   * - 'attached': Overlaps with input above (used in XDSField)
+   * - 'detached': Floats below with spacing (used in XDSSwitch, XDSCheckboxInput)
+   * @default 'attached'
+   */
+  variant?: XDSFieldStatusVariant;
+}
+
+/**
+ * A status message component for form fields.
+ *
+ * @example
+ * ```tsx
+ * <XDSFieldStatus
+ *   type="error"
+ *   message="This field is required"
+ * />
+ * <XDSFieldStatus
+ *   type="warning"
+ *   message="This will be visible to others"
+ *   variant="detached"
+ * />
+ * ```
+ */
+export function XDSFieldStatus({
+  type,
+  message,
+  id,
+  variant = 'attached',
+}: XDSFieldStatusProps) {
+  return (
+    <div
+      id={id}
+      {...stylex.props(
+        styles.base,
+        variant === 'attached' ? styles.attached : styles.detached,
+        colorStyles[type],
+      )}>
+      {message}
+    </div>
+  );
+}
+
+XDSFieldStatus.displayName = 'XDSFieldStatus';

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -1,7 +1,7 @@
 /**
  * @file index.ts
- * @input Imports XDSField component and types from XDSField.tsx, XDSFieldLabel from XDSFieldLabel.tsx
- * @output Exports XDSField, XDSFieldProps, XDSFieldStatus, XDSFieldStatusType, XDSFieldLabel, XDSFieldLabelProps
+ * @input Imports XDSField component and types from XDSField.tsx, XDSFieldLabel from XDSFieldLabel.tsx, XDSFieldStatus from XDSFieldStatus.tsx
+ * @output Exports XDSField, XDSFieldProps, XDSFieldStatus, XDSFieldStatusType, XDSFieldLabel, XDSFieldLabelProps, XDSFieldStatus component
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Field/README.md
@@ -15,6 +15,11 @@ export type {
 } from './XDSField';
 export {XDSFieldLabel} from './XDSFieldLabel';
 export type {XDSFieldLabelProps} from './XDSFieldLabel';
+export {XDSFieldStatus as XDSFieldStatusComponent} from './XDSFieldStatus';
+export type {
+  XDSFieldStatusProps,
+  XDSFieldStatusVariant,
+} from './XDSFieldStatus';
 
 // Shared input types
 export type {XDSInputStatus, XDSInputStatusType, XDSInputSize} from './types';

--- a/packages/core/src/Switch/XDSSwitch.test.tsx
+++ b/packages/core/src/Switch/XDSSwitch.test.tsx
@@ -201,7 +201,9 @@ describe('XDSSwitch', () => {
         labelPosition="start"
       />,
     );
-    const containerDiv = container.firstChild as HTMLElement;
+    // The outer div wraps the container div which has the label and switch
+    const outerDiv = container.firstChild as HTMLElement;
+    const containerDiv = outerDiv.firstChild as HTMLElement;
     const children = Array.from(containerDiv.children);
     // First child should be label wrapper, second should be switch wrapper
     expect(children.length).toBe(2);
@@ -216,7 +218,9 @@ describe('XDSSwitch', () => {
         labelPosition="end"
       />,
     );
-    const containerDiv = container.firstChild as HTMLElement;
+    // The outer div wraps the container div which has the switch and label
+    const outerDiv = container.firstChild as HTMLElement;
+    const containerDiv = outerDiv.firstChild as HTMLElement;
     const children = Array.from(containerDiv.children);
     // First child should be switch wrapper, second should be label wrapper
     expect(children.length).toBe(2);

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSwitch.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, XDSFieldLabel, XDSIconType
+ * @input Uses React forwardRef, useId, ChangeEvent, XDSFieldLabel, XDSFieldStatus, XDSIconType, XDSInputStatus
  * @output Exports XDSSwitch component, XDSSwitchProps, XDSSwitchLabelPosition, XDSSwitchLabelSpacing
  * @position Core implementation; consumed by index.ts, tested by XDSSwitch.test.tsx
  *
@@ -23,7 +23,9 @@ import {
   textSizeVars,
 } from '../theme/tokens.stylex';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
+import {XDSFieldStatus} from '../Field/XDSFieldStatus';
 import type {XDSIconType} from '../Icon';
+import type {XDSInputStatus} from '../Field/types';
 
 // Fixed dimensions: 40px width, 24px height, 16px thumb (off), 20px thumb (on)
 const SWITCH_WIDTH = 40;
@@ -216,6 +218,11 @@ export interface XDSSwitchProps {
    * @default 'default'
    */
   labelSpacing?: XDSSwitchLabelSpacing;
+  /**
+   * Status indicator for the switch.
+   * When set with a message, displays a colored message box below the switch.
+   */
+  status?: XDSInputStatus;
 }
 
 /**
@@ -253,13 +260,22 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
       labelTooltip,
       labelPosition = 'end',
       labelSpacing = 'default',
+      status,
     },
     ref,
   ) => {
     const id = useId();
     const descriptionID = useId();
+    const statusMessageID = useId();
 
     const isOn = value === true;
+
+    // Build aria-describedby from description and status message
+    const describedByParts: string[] = [];
+    if (description) describedByParts.push(descriptionID);
+    if (status?.message) describedByParts.push(statusMessageID);
+    const ariaDescribedBy =
+      describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
 
     const switchElement = (
       <div {...stylex.props(styles.switchWrapper)}>
@@ -274,7 +290,8 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
           onChange={e => onChange(e.target.checked, e)}
           onFocus={onFocus}
           onBlur={onBlur}
-          aria-describedby={description ? descriptionID : undefined}
+          aria-describedby={ariaDescribedBy}
+          aria-invalid={status?.type === 'error' ? true : undefined}
           {...stylex.props(styles.input, isDisabled && styles.inputDisabled)}
         />
         <div
@@ -316,22 +333,32 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
     );
 
     return (
-      <div
-        {...stylex.props(
-          styles.container,
-          labelSpacing === 'spread' && styles.containerSpread,
-          !isDisabled && stylex.defaultMarker(),
-        )}>
-        {labelPosition === 'start' ? (
-          <>
-            {labelElement}
-            {switchElement}
-          </>
-        ) : (
-          <>
-            {switchElement}
-            {labelElement}
-          </>
+      <div>
+        <div
+          {...stylex.props(
+            styles.container,
+            labelSpacing === 'spread' && styles.containerSpread,
+            !isDisabled && stylex.defaultMarker(),
+          )}>
+          {labelPosition === 'start' ? (
+            <>
+              {labelElement}
+              {switchElement}
+            </>
+          ) : (
+            <>
+              {switchElement}
+              {labelElement}
+            </>
+          )}
+        </div>
+        {status?.message && (
+          <XDSFieldStatus
+            type={status.type}
+            message={status.message}
+            id={statusMessageID}
+            variant="detached"
+          />
         )}
       </div>
     );


### PR DESCRIPTION
1. Extract the status rendering into XDSFieldStatus
2. Use it for XDSCheckboxInput + XDSSwitch

<img width="480" height="359" alt="image" src="https://github.com/user-attachments/assets/f4618818-0475-40cf-8738-a188320d0990" />

<img width="480" height="345" alt="image" src="https://github.com/user-attachments/assets/ae218444-b519-4192-a3c9-e7885156a76b" />
