### PR TITLE
Add size tokens and consistent sizing across form controls

### DIFF
--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -16,6 +16,11 @@ const meta: Meta<typeof XDSButton> = {
       options: ['primary', 'secondary', 'ghost', 'destructive'],
       description: 'Visual style variant',
     },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size variant',
+    },
     loading: {
       control: 'boolean',
       description: 'Loading state',
@@ -72,6 +77,16 @@ export const Disabled: Story = {
     variant: 'primary',
     disabled: true,
   },
+};
+
+export const SizeVariants: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <XDSButton label="Small" variant="primary" size="sm" />
+      <XDSButton label="Medium" variant="primary" size="md" />
+      <XDSButton label="Large" variant="primary" size="lg" />
+    </div>
+  ),
 };
 
 export const IconOnly: Story = {

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof XDSDateInput> = {
     },
     size: {
       control: 'radio',
-      options: ['sm', 'md'],
+      options: ['sm', 'md', 'lg'],
       description: 'Size of the input',
     },
     numberOfMonths: {

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -45,7 +45,7 @@ const meta: Meta<typeof XDSSelector> = {
     },
     size: {
       control: 'radio',
-      options: ['sm', 'md'],
+      options: ['sm', 'md', 'lg'],
       description: 'Size variant of the selector',
     },
     isDisabled: {
@@ -253,6 +253,7 @@ export const SizeVariants: Story = {
   render: () => {
     const [value1, setValue1] = useState<string | undefined>();
     const [value2, setValue2] = useState<string | undefined>();
+    const [value3, setValue3] = useState<string | undefined>();
     return (
       <div
         style={{display: 'flex', flexDirection: 'column', gap: 16, width: 250}}>
@@ -262,7 +263,7 @@ export const SizeVariants: Story = {
           items={['Apple', 'Banana', 'Orange']}
           value={value1}
           onChange={setValue1}
-          placeholder="Small size"
+          placeholder="Small size (28px)"
         />
         <XDSSelector
           label="Medium"
@@ -270,7 +271,15 @@ export const SizeVariants: Story = {
           items={['Apple', 'Banana', 'Orange']}
           value={value2}
           onChange={setValue2}
-          placeholder="Medium size (default)"
+          placeholder="Medium size (32px)"
+        />
+        <XDSSelector
+          label="Large"
+          size="lg"
+          items={['Apple', 'Banana', 'Orange']}
+          value={value3}
+          onChange={setValue3}
+          placeholder="Large size (36px)"
         />
       </div>
     );

--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -33,6 +33,11 @@ const meta: Meta<typeof XDSTextInput> = {
       control: 'text',
       description: 'Current input value (required)',
     },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size variant',
+    },
     isOptional: {
       control: 'boolean',
       description:
@@ -252,6 +257,45 @@ export const WithStartIconAndSmallSize: Story = {
     placeholder: 'Search...',
     startIcon: MagnifyingGlassIcon,
     size: 'sm',
+  },
+};
+
+export const SizeVariants: Story = {
+  render: () => {
+    const [sm, setSm] = useState('');
+    const [md, setMd] = useState('');
+    const [lg, setLg] = useState('');
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '300px',
+        }}>
+        <XDSTextInput
+          label="Small (28px)"
+          value={sm}
+          onChange={setSm}
+          placeholder="Small size"
+          size="sm"
+        />
+        <XDSTextInput
+          label="Medium (32px)"
+          value={md}
+          onChange={setMd}
+          placeholder="Medium size (default)"
+          size="md"
+        />
+        <XDSTextInput
+          label="Large (36px)"
+          value={lg}
+          onChange={setLg}
+          placeholder="Large size"
+          size="lg"
+        />
+      </div>
+    );
   },
 };
 

--- a/apps/storybook/stories/TimeInput.stories.tsx
+++ b/apps/storybook/stories/TimeInput.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof XDSTimeInput> = {
     },
     size: {
       control: 'radio',
-      options: ['sm', 'md'],
+      options: ['sm', 'md', 'lg'],
       description: 'Size of the input',
     },
     hourFormat: {

--- a/packages/agent-tools/docs/tokens.md
+++ b/packages/agent-tools/docs/tokens.md
@@ -18,6 +18,16 @@ All design tokens are defined in `packages/core/src/theme/tokens.stylex.ts`.
 
 Component gap props use `space0`-`space7` which map to these tokens.
 
+## Size Tokens
+
+Control heights for consistent sizing across buttons, inputs, and selectors.
+
+| Token     | Value | Usage                           |
+| --------- | ----- | ------------------------------- |
+| --size-sm | 28px  | Compact controls                |
+| --size-md | 32px  | Default control size            |
+| --size-lg | 36px  | Larger, more prominent controls |
+
 ## Color Tokens
 
 ### Semantic Colors
@@ -103,13 +113,16 @@ Component gap props use `space0`-`space7` which map to these tokens.
 
 ```tsx
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, spacingVars, radiusVars} from '@xds/core';
+import {colorVars, spacingVars, sizeVars, radiusVars} from '@xds/core';
 
 const styles = stylex.create({
   card: {
     padding: spacingVars['--spacing-4'],
     backgroundColor: colorVars['--color-surface'],
     borderRadius: radiusVars['--radius-container'],
+  },
+  button: {
+    height: sizeVars['--size-md'],
   },
 });
 ```

--- a/packages/core/src/Button/README.md
+++ b/packages/core/src/Button/README.md
@@ -1,12 +1,13 @@
 # /packages/core/src/Button
 
-XDSButton component with multiple variants and loading state support.
+XDSButton component with multiple variants, sizes, and loading state support.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
 ## Features
 
 - **Variants**: `primary`, `secondary`, `ghost`, `destructive`
+- **Sizes**: `sm` (28px), `md` (32px), `lg` (36px)
 - **Loading state**: Shows spinner, disables interaction
 - **Focus visible**: Accessible focus outline with variant-specific colors
 - **Hover/active states**: Uses overlay colors via `backgroundImage` for consistent layering
@@ -17,23 +18,29 @@ XDSButton component with multiple variants and loading state support.
 import { XDSButton } from '@xds/core/Button';
 
 // Basic usage
-<XDSButton variant="primary">Click me</XDSButton>
+<XDSButton label="Click me" variant="primary" />
+
+// With size
+<XDSButton label="Large button" variant="primary" size="lg" />
 
 // With loading state
-<XDSButton variant="primary" loading>Saving...</XDSButton>
+<XDSButton label="Saving..." variant="primary" loading />
 
 // Destructive action
-<XDSButton variant="destructive">Delete</XDSButton>
+<XDSButton label="Delete" variant="destructive" />
 ```
 
 ## Props
 
-| Prop       | Type                                                   | Default     | Description           |
-| ---------- | ------------------------------------------------------ | ----------- | --------------------- |
-| `variant`  | `'primary' \| 'secondary' \| 'ghost' \| 'destructive'` | `'primary'` | Visual style variant  |
-| `loading`  | `boolean`                                              | `false`     | Shows loading spinner |
-| `disabled` | `boolean`                                              | `false`     | Disables the button   |
-| `children` | `ReactNode`                                            | —           | Button content        |
+| Prop       | Type                                                   | Default       | Description                 |
+| ---------- | ------------------------------------------------------ | ------------- | --------------------------- |
+| `label`    | `string`                                               | —             | Accessible label (required) |
+| `variant`  | `'primary' \| 'secondary' \| 'ghost' \| 'destructive'` | `'secondary'` | Visual style variant        |
+| `size`     | `'sm' \| 'md' \| 'lg'`                                 | `'md'`        | Size variant                |
+| `loading`  | `boolean`                                              | `false`       | Shows loading spinner       |
+| `disabled` | `boolean`                                              | `false`       | Disables the button         |
+| `icon`     | `ReactNode`                                            | —             | Icon element                |
+| `children` | `ReactNode`                                            | —             | Button content              |
 
 ## Files
 

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -20,6 +20,7 @@ import {
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
+  sizeVars,
   spacingVars,
   radiusVars,
   transitionVars,
@@ -69,6 +70,18 @@ const styles = stylex.create({
   iconOnly: {
     aspectRatio: '1 / 1',
     paddingInline: spacingVars['--spacing-2'],
+  },
+});
+
+const sizeStyles = stylex.create({
+  sm: {
+    height: sizeVars['--size-sm'],
+  },
+  md: {
+    height: sizeVars['--size-md'],
+  },
+  lg: {
+    height: sizeVars['--size-lg'],
   },
 });
 
@@ -154,6 +167,11 @@ const variants = stylex.create({
  */
 export type XDSButtonVariant = keyof typeof variants;
 
+/**
+ * Button size type derived from the sizeStyles StyleX object
+ */
+export type XDSButtonSize = keyof typeof sizeStyles;
+
 // =============================================================================
 // Module Augmentation - Register Button's variant type with ComponentStyles
 // =============================================================================
@@ -182,6 +200,11 @@ export interface XDSButtonProps extends Omit<
    * @default 'secondary'
    */
   variant?: XDSButtonVariant;
+  /**
+   * The size of the button.
+   * @default 'md'
+   */
+  size?: XDSButtonSize;
   /**
    * Whether the button is in a loading state.
    * @default false
@@ -257,6 +280,7 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
     {
       label,
       variant = 'secondary',
+      size = 'md',
       loading = false,
       icon,
       disabled,
@@ -281,6 +305,7 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
         aria-label={isIconOnly ? label : undefined}
         {...stylex.props(
           styles.base,
+          sizeStyles[size],
           variants[variant],
           themeVariantOverride,
           isIconOnly && styles.iconOnly,

--- a/packages/core/src/Button/index.ts
+++ b/packages/core/src/Button/index.ts
@@ -8,4 +8,8 @@
  */
 
 export {XDSButton} from './XDSButton';
-export type {XDSButtonProps, XDSButtonVariant} from './XDSButton';
+export type {
+  XDSButtonProps,
+  XDSButtonVariant,
+  XDSButtonSize,
+} from './XDSButton';

--- a/packages/core/src/DateInput/README.md
+++ b/packages/core/src/DateInput/README.md
@@ -78,7 +78,7 @@ import { XDSDateInput } from '@xds/core/DateInput';
 | max             | `ISODateString`                               | —                 | Maximum selectable date                  |
 | dateConstraints | `Array<(date: Date) => boolean>`              | —                 | Custom constraint functions              |
 | placeholder     | `string`                                      | `"Select a date"` | Input placeholder text                   |
-| size            | `'sm' \| 'md'`                                | `'md'`            | Input size                               |
+| size            | `'sm' \| 'md' \| 'lg'`                        | `'md'`            | Input size                               |
 | status          | `XDSInputStatus`                              | —                 | Status indicator (error/warning/success) |
 | numberOfMonths  | `1 \| 2`                                      | `1`               | Months shown in calendar popover         |
 

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -21,6 +21,7 @@ import {
 } from '@heroicons/react/24/solid';
 import {
   colorVars,
+  sizeVars,
   spacingVars,
   radiusVars,
   transitionVars,
@@ -123,10 +124,13 @@ const styles = stylex.create({
 
 const sizeStyles = stylex.create({
   sm: {
-    height: 18,
+    height: sizeVars['--size-sm'],
   },
   md: {
-    height: 26,
+    height: sizeVars['--size-md'],
+  },
+  lg: {
+    height: sizeVars['--size-lg'],
   },
 });
 
@@ -446,6 +450,7 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
           ref={popover.triggerRef}
           {...stylex.props(
             styles.wrapper,
+            sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
           )}>
@@ -477,7 +482,6 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
             {...stylex.props(
               styles.input,
-              sizeStyles[size],
               isDisabled && styles.inputDisabled,
               !isInputValid && styles.inputInvalid,
             )}

--- a/packages/core/src/Selector/README.md
+++ b/packages/core/src/Selector/README.md
@@ -70,7 +70,7 @@ import {XDSSelector, XDSSelectorItem} from '@xds/core/Selector';
 | `value`                     | `string`                                                  | Selected value                                                      |
 | `onChange`                  | `(value: string) => void`                                 | Selection callback                                                  |
 | `placeholder`               | `string`                                                  | Placeholder text (default: `'Select...'`)                           |
-| `size`                      | `'sm' \| 'md'`                                            | Size variant (default: `'md'`)                                      |
+| `size`                      | `'sm' \| 'md' \| 'lg'`                                    | Size variant (default: `'md'`)                                      |
 | `isDisabled`                | `boolean`                                                 | Disable selector                                                    |
 | `isLabelHidden`             | `boolean`                                                 | Visually hide label                                                 |
 | `description`               | `string`                                                  | Helper text below label                                             |

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -30,6 +30,7 @@ import {XDSField} from '../Field';
 import {XDSDivider} from '../Divider';
 import {
   colorVars,
+  sizeVars,
   spacingVars,
   radiusVars,
   transitionVars,
@@ -192,10 +193,13 @@ const styles = stylex.create({
 
 const sizeStyles = stylex.create({
   sm: {
-    paddingBlock: spacingVars['--spacing-1'],
+    height: sizeVars['--size-sm'],
   },
   md: {
-    paddingBlock: spacingVars['--spacing-2'],
+    height: sizeVars['--size-md'],
+  },
+  lg: {
+    height: sizeVars['--size-lg'],
   },
 });
 
@@ -226,7 +230,7 @@ const STATUS_ICON_COLOR_MAP: Record<
   success: 'positive',
 };
 
-export type XDSSelectorSize = 'sm' | 'md';
+export type XDSSelectorSize = 'sm' | 'md' | 'lg';
 
 export type XDSSelectorStatusType = 'warning' | 'error' | 'success';
 

--- a/packages/core/src/TextInput/README.md
+++ b/packages/core/src/TextInput/README.md
@@ -47,6 +47,7 @@ import { XDSTextInput } from '@xds/core/TextInput';
 | `label`         | `string`                                                    | Yes      | Label text for the input (always rendered for accessibility)       |
 | `value`         | `string`                                                    | Yes      | Current value of the input                                         |
 | `onChange`      | `(value: string, e: ChangeEvent<HTMLInputElement>) => void` | Yes      | Callback fired when input value changes                            |
+| `size`          | `'sm' \| 'md' \| 'lg'`                                      | No       | Size variant (default: `'md'`)                                     |
 | `isLabelHidden` | `boolean`                                                   | No       | Visually hide the label (still accessible to screen readers)       |
 | `description`   | `string`                                                    | No       | Description text displayed between the label and input             |
 | `isOptional`    | `boolean`                                                   | No       | Whether the field is optional (mutually exclusive with isRequired) |

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -20,6 +20,7 @@ import {
 } from '@heroicons/react/24/solid';
 import {
   colorVars,
+  sizeVars,
   spacingVars,
   radiusVars,
   transitionVars,
@@ -86,10 +87,13 @@ const styles = stylex.create({
 
 const sizeStyles = stylex.create({
   sm: {
-    height: 18,
+    height: sizeVars['--size-sm'],
   },
   md: {
-    height: 26,
+    height: sizeVars['--size-md'],
+  },
+  lg: {
+    height: sizeVars['--size-lg'],
   },
 });
 
@@ -267,6 +271,7 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
         <div
           {...stylex.props(
             styles.wrapper,
+            sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
           )}>
@@ -284,11 +289,7 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
             aria-describedby={ariaDescribedBy}
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
-            {...stylex.props(
-              styles.input,
-              sizeStyles[size],
-              isDisabled && styles.inputDisabled,
-            )}
+            {...stylex.props(styles.input, isDisabled && styles.inputDisabled)}
           />
           {status && (
             <XDSIcon

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -30,6 +30,7 @@ import {
 } from '@heroicons/react/24/solid';
 import {
   colorVars,
+  sizeVars,
   spacingVars,
   radiusVars,
   transitionVars,
@@ -131,10 +132,13 @@ const styles = stylex.create({
 
 const sizeStyles = stylex.create({
   sm: {
-    height: 18,
+    height: sizeVars['--size-sm'],
   },
   md: {
-    height: 26,
+    height: sizeVars['--size-md'],
+  },
+  lg: {
+    height: sizeVars['--size-lg'],
   },
 });
 
@@ -490,6 +494,7 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
         <div
           {...stylex.props(
             styles.wrapper,
+            sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
           )}>
@@ -512,7 +517,6 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
             {...stylex.props(
               styles.input,
-              sizeStyles[size],
               isDisabled && styles.inputDisabled,
               !isInputValid && styles.inputInvalid,
             )}

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -152,6 +152,18 @@ export const spacingRaw = {
 export const spacingVars = stylex.defineVars(spacingRaw);
 
 // =============================================================================
+// Size Tokens
+// =============================================================================
+
+export const sizeRaw = {
+  '--size-sm': '28px',
+  '--size-md': '32px',
+  '--size-lg': '36px',
+} as const;
+
+export const sizeVars = stylex.defineVars(sizeRaw);
+
+// =============================================================================
 // Radius Tokens
 // =============================================================================
 
@@ -260,6 +272,7 @@ export const fontWeightVars = stylex.defineVars(fontWeightRaw);
 
 export type ColorVarName = keyof typeof colorRaw;
 export type SpacingVarName = keyof typeof spacingRaw;
+export type SizeVarName = keyof typeof sizeRaw;
 export type RadiusVarName = keyof typeof radiusRaw;
 export type ElevationVarName = keyof typeof elevationRaw;
 export type TransitionVarName = keyof typeof transitionRaw;
@@ -274,6 +287,7 @@ export type FontWeightVarName = keyof typeof fontWeightRaw;
 // Type safety is maintained via `as const satisfies Record<*VarName, string>`.
 export type BaseColorRaw = typeof colorRaw;
 export type BaseSpacingRaw = typeof spacingRaw;
+export type BaseSizeRaw = typeof sizeRaw;
 export type BaseRadiusRaw = typeof radiusRaw;
 export type BaseElevationRaw = typeof elevationRaw;
 export type BaseTransitionRaw = typeof transitionRaw;


### PR DESCRIPTION
- Add sizeVars tokens: --size-sm (28px), --size-md (32px), --size-lg (36px)
- Update Button, Selector, TextInput, DateInput, TimeInput to use size tokens
- Add size prop to Button component
- Add lg size variant to all form controls
- Update stories with size argTypes and SizeVariants examples
- Update READMEs and token documentation