### PR TITLE
Fix docsRead tracking in vibe test aggregator

### DIFF
--- a/internal/vibe-tests/src/aggregate.ts
+++ b/internal/vibe-tests/src/aggregate.ts
@@ -867,6 +867,7 @@ function loadResults(resultsDir: string): (TestResult & {target?: string})[] {
       }
 
       // Load docs read metadata if available
+      // First try .meta.json, then fall back to corresponding .json result file
       let docsRead: string[] | undefined;
       if (fs.existsSync(metaPath)) {
         try {
@@ -874,6 +875,23 @@ function loadResults(resultsDir: string): (TestResult & {target?: string})[] {
           docsRead = meta.docsRead;
         } catch {
           console.warn(`Warning: Could not parse ${metaPath}`);
+        }
+      }
+      // Fall back to loading from .json result file if .meta.json doesn't exist or didn't have docsRead
+      if (!docsRead) {
+        const jsonResultPath = path.join(
+          individualResultsDir,
+          `${promptId}.json`,
+        );
+        if (fs.existsSync(jsonResultPath)) {
+          try {
+            const jsonResult = JSON.parse(
+              fs.readFileSync(jsonResultPath, 'utf-8'),
+            );
+            docsRead = jsonResult.docsRead;
+          } catch {
+            // Ignore parse errors, docsRead will remain undefined
+          }
         }
       }
 

--- a/internal/vibe-tests/src/aggregate.ts
+++ b/internal/vibe-tests/src/aggregate.ts
@@ -848,7 +848,6 @@ function loadResults(resultsDir: string): (TestResult & {target?: string})[] {
       const promptId = file.replace('.tsx', '');
       const resultPath = path.join(individualResultsDir, file);
       const taskPath = path.join(tasksDir, `${promptId}.json`);
-      const metaPath = path.join(individualResultsDir, `${promptId}.meta.json`);
 
       // Read the generated code
       const code = fs.readFileSync(resultPath, 'utf-8');
@@ -866,32 +865,20 @@ function loadResults(resultsDir: string): (TestResult & {target?: string})[] {
         task = JSON.parse(fs.readFileSync(taskPath, 'utf-8'));
       }
 
-      // Load docs read metadata if available
-      // First try .meta.json, then fall back to corresponding .json result file
+      // Load docs read from corresponding .json result file
       let docsRead: string[] | undefined;
-      if (fs.existsSync(metaPath)) {
+      const jsonResultPath = path.join(
+        individualResultsDir,
+        `${promptId}.json`,
+      );
+      if (fs.existsSync(jsonResultPath)) {
         try {
-          const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'));
-          docsRead = meta.docsRead;
+          const jsonResult = JSON.parse(
+            fs.readFileSync(jsonResultPath, 'utf-8'),
+          );
+          docsRead = jsonResult.docsRead;
         } catch {
-          console.warn(`Warning: Could not parse ${metaPath}`);
-        }
-      }
-      // Fall back to loading from .json result file if .meta.json doesn't exist or didn't have docsRead
-      if (!docsRead) {
-        const jsonResultPath = path.join(
-          individualResultsDir,
-          `${promptId}.json`,
-        );
-        if (fs.existsSync(jsonResultPath)) {
-          try {
-            const jsonResult = JSON.parse(
-              fs.readFileSync(jsonResultPath, 'utf-8'),
-            );
-            docsRead = jsonResult.docsRead;
-          } catch {
-            // Ignore parse errors, docsRead will remain undefined
-          }
+          // Ignore parse errors, docsRead will remain undefined
         }
       }
 

--- a/internal/vibe-tests/src/interactive.ts
+++ b/internal/vibe-tests/src/interactive.ts
@@ -902,7 +902,6 @@ function generateSubagentPrompt(
   resultsDir: string,
 ): string {
   const codePath = `${resultsDir}/results/${prompt.id}.tsx`;
-  const metaPath = `${resultsDir}/results/${prompt.id}.meta.json`;
 
   // Target-specific AGENTS.md file
   const agentsMdFile =
@@ -924,15 +923,13 @@ function generateSubagentPrompt(
 
   const framing = personaFraming[config.target]?.[config.persona] || '';
 
-  // Natural prompt with AGENTS.md instruction and metadata tracking
+  // Natural prompt with AGENTS.md instruction
+  // Note: docsRead tracking is handled via the structured JSON result (see subagent instructions)
   return `First read ${agentsMdFile} in this directory for component library guidance.
 
 ${framing}${prompt.prompt}
 
-Write the code to: ${codePath}
-
-After writing the code, create ${metaPath} listing any doc files you read:
-{"docsRead": ["filename1.md", "filename2.md"]}`;
+Write the code to: ${codePath}`;
 }
 
 /**


### PR DESCRIPTION
## Summary                                                       
  - Fix docsRead tracking when both .tsx and .json result files exist                                                                           
  - Remove deprecated .meta.json workflow from subagent prompts                                                                                 
  - Simplify aggregator to read docsRead directly from .json result files                                                                       
                                                                                                                                                
  ## Test plan                                                                                                                                  
  - Ran vibe test iteration d74c3c87 with 3 tests                                                                                               
  - Verified token breakdown shows correct values for design docs and component docs                                                            
  - All tests passed with 100% Gold tier