### PR TITLE
Add XDSTabList, XDSTab, and XDSTabMenu components

### DIFF
--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -1,0 +1,141 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSTabList, XDSTab, XDSTabMenu} from '@xds/core/TabList';
+
+const meta: Meta<typeof XDSTabList> = {
+  title: 'Core/XDSTabList',
+  component: XDSTabList,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size variant for tabs',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSTabList>;
+
+export const Default: Story = {
+  render: () => {
+    const [value, setValue] = useState('home');
+    return (
+      <XDSTabList value={value} onChange={setValue}>
+        <XDSTab value="home" label="Home" />
+        <XDSTab value="projects" label="Projects" />
+        <XDSTab value="settings" label="Settings" />
+      </XDSTabList>
+    );
+  },
+};
+
+export const WithMenu: Story = {
+  render: () => {
+    const [value, setValue] = useState('home');
+    return (
+      <XDSTabList value={value} onChange={setValue}>
+        <XDSTab value="home" label="Home" />
+        <XDSTab value="projects" label="Projects" />
+        <XDSTabMenu
+          label="More"
+          options={[
+            {value: 'analytics', label: 'Analytics'},
+            {value: 'reports', label: 'Reports'},
+            {value: 'billing', label: 'Billing'},
+          ]}
+        />
+      </XDSTabList>
+    );
+  },
+};
+
+export const MenuWithSelectedChild: Story = {
+  render: () => {
+    const [value, setValue] = useState('analytics');
+    return (
+      <XDSTabList value={value} onChange={setValue}>
+        <XDSTab value="home" label="Home" />
+        <XDSTab value="projects" label="Projects" />
+        <XDSTabMenu
+          label="More"
+          options={[
+            {value: 'analytics', label: 'Analytics'},
+            {value: 'reports', label: 'Reports'},
+          ]}
+        />
+      </XDSTabList>
+    );
+  },
+};
+
+export const SizeVariants: Story = {
+  render: () => {
+    const [value, setValue] = useState('home');
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: '24px'}}>
+        <div>
+          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
+            Small
+          </div>
+          <XDSTabList value={value} onChange={setValue} size="sm">
+            <XDSTab value="home" label="Home" />
+            <XDSTab value="projects" label="Projects" />
+            <XDSTab value="settings" label="Settings" />
+          </XDSTabList>
+        </div>
+        <div>
+          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
+            Medium (default)
+          </div>
+          <XDSTabList value={value} onChange={setValue} size="md">
+            <XDSTab value="home" label="Home" />
+            <XDSTab value="projects" label="Projects" />
+            <XDSTab value="settings" label="Settings" />
+          </XDSTabList>
+        </div>
+        <div>
+          <div style={{marginBottom: '8px', fontSize: '12px', color: '#666'}}>
+            Large
+          </div>
+          <XDSTabList value={value} onChange={setValue} size="lg">
+            <XDSTab value="home" label="Home" />
+            <XDSTab value="projects" label="Projects" />
+            <XDSTab value="settings" label="Settings" />
+          </XDSTabList>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const WithIcons: Story = {
+  render: () => {
+    const [value, setValue] = useState('home');
+
+    // Inline SVG icons for the story
+    const HomeIcon = (
+      <svg viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%">
+        <path d="M8.543 2.232a.75.75 0 0 0-1.085 0l-5.25 5.5A.75.75 0 0 0 2.75 9H4v4a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-2h1v2a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1V9h1.25a.75.75 0 0 0 .543-1.268l-5.25-5.5Z" />
+      </svg>
+    );
+
+    const CogIcon = (
+      <svg viewBox="0 0 16 16" fill="currentColor" width="100%" height="100%">
+        <path
+          fillRule="evenodd"
+          d="M6.955 1.45A.5.5 0 0 1 7.452 1h1.096a.5.5 0 0 1 .497.45l.17 1.699c.484.12.94.312 1.356.562l1.321-.816a.5.5 0 0 1 .67.087l.774.774a.5.5 0 0 1 .087.67l-.816 1.321c.25.416.442.872.562 1.356l1.699.17a.5.5 0 0 1 .45.497v1.096a.5.5 0 0 1-.45.497l-1.699.17c-.12.484-.312.94-.562 1.356l.816 1.321a.5.5 0 0 1-.087.67l-.774.774a.5.5 0 0 1-.67.087l-1.321-.816c-.416.25-.872.442-1.356.562l-.17 1.699a.5.5 0 0 1-.497.45H7.452a.5.5 0 0 1-.497-.45l-.17-1.699a4.973 4.973 0 0 1-1.356-.562l-1.321.816a.5.5 0 0 1-.67-.087l-.774-.774a.5.5 0 0 1-.087-.67l.816-1.321a4.972 4.972 0 0 1-.562-1.356l-1.699-.17A.5.5 0 0 1 1 8.548V7.452a.5.5 0 0 1 .45-.497l1.699-.17c.12-.484.312-.94.562-1.356l-.816-1.321a.5.5 0 0 1 .087-.67l.774-.774a.5.5 0 0 1 .67-.087l1.321.816c.416-.25.872-.442 1.356-.562l.17-1.699ZM8 10.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z"
+          clipRule="evenodd"
+        />
+      </svg>
+    );
+
+    return (
+      <XDSTabList value={value} onChange={setValue}>
+        <XDSTab value="home" label="Home" icon={HomeIcon} />
+        <XDSTab value="settings" label="Settings" icon={CogIcon} />
+      </XDSTabList>
+    );
+  },
+};

--- a/packages/core/src/TabList/README.md
+++ b/packages/core/src/TabList/README.md
@@ -1,0 +1,135 @@
+# /packages/core/src/TabList
+
+XDSTabList component for tab navigation with overflow menu support.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Context-based communication**: `XDSTabListContext` passes value/onChange/size from XDSTabList to children
+- **Single-responsibility XDSTab**: Renders as `<button>` or `<a>` (when `href` is provided) in the nav
+- **Overflow menu**: `XDSTabMenu` accepts an `options` prop and renders menu items internally
+- **Dynamic trigger label**: Menu trigger shows the selected option's label when one is active
+- **Menu heading**: Dropdown includes an `XDSDivider` with the menu's `label` as a separator heading
+- **Selection indicator**: Selected menu items show a checkmark icon (matching XDSSelector pattern)
+- **Keyboard navigation**: Tab between items, ArrowUp/Down in menu, Home/End, Escape closes menu (via `useListFocus`)
+- **Hover state**: Unselected tabs show a gray underline on hover; no background hover overlay
+- **Accessibility**: `nav` landmark, `aria-current="page"` on selected tabs, `role="menu"` + `aria-label` on dropdown, `aria-controls` connecting trigger to menu, `role="menuitem"` for items, `role="separator"` for heading divider
+
+## Usage
+
+```tsx
+import { XDSTabList, XDSTab, XDSTabMenu } from '@xds/core/TabList';
+
+// Basic usage
+<XDSTabList value={activeTab} onChange={setActiveTab}>
+  <XDSTab value="home" label="Home" />
+  <XDSTab value="settings" label="Settings" />
+</XDSTabList>
+
+// With links
+<XDSTabList value={activeTab} onChange={setActiveTab}>
+  <XDSTab value="home" label="Home" href="/home" />
+  <XDSTab value="settings" label="Settings" href="/settings" />
+</XDSTabList>
+
+// With icons
+<XDSTabList value={activeTab} onChange={setActiveTab}>
+  <XDSTab value="home" label="Home" icon={<HomeIcon />} selectedIcon={<HomeFilledIcon />} />
+  <XDSTab value="settings" label="Settings" icon={<CogIcon />} />
+</XDSTabList>
+
+// With bottom divider
+<XDSTabList value={activeTab} onChange={setActiveTab} hasDivider>
+  <XDSTab value="home" label="Home" />
+  <XDSTab value="settings" label="Settings" />
+</XDSTabList>
+
+// With overflow menu (including icons on menu items)
+<XDSTabList value={activeTab} onChange={setActiveTab}>
+  <XDSTab value="home" label="Home" />
+  <XDSTab value="settings" label="Settings" />
+  <XDSTabMenu
+    label="More"
+    options={[
+      {value: 'analytics', label: 'Analytics', icon: ChartBarIcon},
+      {value: 'reports', label: 'Reports', icon: DocumentTextIcon},
+    ]}
+  />
+</XDSTabList>
+```
+
+## Props
+
+### XDSTabList
+
+| Prop         | Type                   | Default | Description                        |
+| ------------ | ---------------------- | ------- | ---------------------------------- |
+| `value`      | `string`               | —       | Active tab value                   |
+| `onChange`   | `(v: string) => void`  | —       | Tab change callback                |
+| `size`       | `'sm' \| 'md' \| 'lg'` | `'md'`  | Size variant for tabs              |
+| `hasDivider` | `boolean`              | `false` | Show bottom divider under tab list |
+| `children`   | `ReactNode`            | —       | XDSTab/XDSTabMenu items            |
+
+### XDSTab
+
+| Prop           | Type        | Default     | Description                               |
+| -------------- | ----------- | ----------- | ----------------------------------------- |
+| `value`        | `string`    | —           | Unique tab value                          |
+| `label`        | `string`    | —           | Visible label text                        |
+| `href`         | `string`    | `undefined` | URL; renders as `<a>` when provided       |
+| `icon`         | `ReactNode` | `undefined` | Icon when not selected                    |
+| `selectedIcon` | `ReactNode` | `undefined` | Icon when selected (falls back to `icon`) |
+
+### XDSTabMenu
+
+| Prop      | Type                 | Default | Description                                               |
+| --------- | -------------------- | ------- | --------------------------------------------------------- |
+| `label`   | `string`             | —       | Trigger label (shown when no option selected) and heading |
+| `options` | `XDSTabMenuOption[]` | —       | Menu options rendered in dropdown                         |
+
+### XDSTabMenuOption
+
+| Field   | Type          | Description                    |
+| ------- | ------------- | ------------------------------ |
+| `value` | `string`      | Option value                   |
+| `label` | `string`      | Option display label           |
+| `icon`  | `XDSIconType` | Optional icon before the label |
+
+## Files
+
+| File                   | Role    | Purpose                                    |
+| ---------------------- | ------- | ------------------------------------------ |
+| `index.ts`             | Entry   | Exports all components and types           |
+| `XDSTabListContext.ts` | Context | XDSTabListContext definition               |
+| `XDSTabList.tsx`       | Core    | Nav wrapper providing XDSTabListContext    |
+| `XDSTab.tsx`           | Core    | Tab button/link with `aria-current="page"` |
+| `XDSTabMenu.tsx`       | Core    | Menu trigger with `role="menu"` dropdown   |
+| `XDSTabList.test.tsx`  | Test    | Unit tests                                 |
+
+## Accessibility
+
+### XDSTab
+
+- Renders as `<button>` or `<a>` (no `role="tab"` — uses navigation pattern instead)
+- Selected tab has `aria-current="page"`
+- Hover shows gray underline; selected shows accent underline
+
+### XDSTabMenu
+
+- Trigger: `aria-haspopup="menu"` + `aria-expanded` + `aria-controls` pointing to menu
+- Dropdown: `role="menu"` + `id` (matching `aria-controls`) + `aria-label`
+- Heading: `XDSDivider` with `role="separator"`
+- Items: `role="menuitem"` + `aria-current="true"` for selected
+- Keyboard: ArrowUp/Down (wrapping), Home/End, Escape to close (via `useListFocus` hook)
+
+## Implementation Notes
+
+- `XDSTab` renders as `<button>` by default, `<a>` when `href` is provided
+- `XDSTabMenu` renders menu items internally from `options` prop — no child composition
+- Trigger label derives from `options.find(o => o.value === ctx.value)?.label ?? label`
+- Menu trigger underline scopes to the label text only (not the chevron icon)
+- Icons on menu items render via `XDSIcon` with `size="sm"` and `color="secondary"`
+- Selected menu items show a `CheckIcon` checkmark (matching XDSSelector pattern)
+- `hasDivider` on XDSTabList controls the bottom border (default: off)
+- Size uses hardcoded 28/32/36px heights (`sizeVars` not yet available on this branch)

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -94,7 +94,7 @@ const styles = stylex.create({
       right: spacingVars['--spacing-3'],
       height: '2px',
       backgroundColor: colorVars['--color-accent'],
-      borderRadius: '1px',
+      borderRadius: radiusVars['--radius-rounded'],
     },
   },
   underlineHover: {
@@ -109,7 +109,7 @@ const styles = stylex.create({
         default: 'transparent',
         ':hover': colorVars['--color-divider'],
       },
-      borderRadius: '1px',
+      borderRadius: radiusVars['--radius-rounded'],
       transitionProperty: 'background-color',
       transitionDuration: transitionVars['--transition-fast'],
     },

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -66,7 +66,7 @@ const styles = stylex.create({
     fontFamily: 'inherit',
     fontSize: textSizeVars['--text-base'],
     lineHeight: lineHeightVars['--leading-base'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
     textDecoration: 'none',
@@ -97,28 +97,41 @@ const styles = stylex.create({
       borderRadius: radiusVars['--radius-rounded'],
     },
   },
-  underlineHover: {
-    '::after': {
-      content: '""',
-      position: 'absolute',
-      bottom: 0,
-      left: spacingVars['--spacing-3'],
-      right: spacingVars['--spacing-3'],
-      height: '2px',
-      backgroundColor: {
-        default: 'transparent',
-        ':hover': colorVars['--color-divider'],
-      },
-      borderRadius: radiusVars['--radius-rounded'],
-      transitionProperty: 'background-color',
-      transitionDuration: transitionVars['--transition-fast'],
+  hoverUnderline: {
+    position: 'absolute',
+    bottom: 0,
+    left: spacingVars['--spacing-3'],
+    right: spacingVars['--spacing-3'],
+    height: '2px',
+    backgroundColor: colorVars['--color-divider'],
+    borderRadius: radiusVars['--radius-rounded'],
+    opacity: {
+      default: 0,
+      [stylex.when.ancestor(':hover')]: 1,
     },
+    transitionProperty: 'opacity',
+    transitionDuration: transitionVars['--transition-fast'],
+    pointerEvents: 'none',
   },
   icon: {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
+  },
+  labelContainer: {
+    display: 'inline-grid',
+  },
+  labelText: {
+    gridRowStart: 1,
+    gridColumnStart: 1,
+  },
+  labelSizer: {
+    gridRowStart: 1,
+    gridColumnStart: 1,
+    visibility: 'hidden',
+    pointerEvents: 'none',
+    fontWeight: fontWeightVars['--font-weight-semibold'],
   },
 });
 
@@ -161,15 +174,30 @@ export function XDSTab({value, label, href, icon, selectedIcon}: XDSTabProps) {
       styles.base,
       sizeStyles[size],
       isSelected && styles.selected,
-      isSelected ? styles.underlineSelected : styles.underlineHover,
+      isSelected && styles.underlineSelected,
+      !isSelected && stylex.defaultMarker(),
     ),
   };
+
+  const hoverUnderlineElement = !isSelected ? (
+    <span {...stylex.props(styles.hoverUnderline)} />
+  ) : null;
+
+  const labelElement = (
+    <span {...stylex.props(styles.labelContainer)}>
+      <span {...stylex.props(styles.labelText)}>{label}</span>
+      <span aria-hidden="true" {...stylex.props(styles.labelSizer)}>
+        {label}
+      </span>
+    </span>
+  );
 
   if (href != null) {
     return (
       <a href={href} onClick={handleSelect} {...sharedProps}>
         {iconElement}
-        {label}
+        {labelElement}
+        {hoverUnderlineElement}
       </a>
     );
   }
@@ -177,7 +205,8 @@ export function XDSTab({value, label, href, icon, selectedIcon}: XDSTabProps) {
   return (
     <button type="button" onClick={handleSelect} {...sharedProps}>
       {iconElement}
-      {label}
+      {labelElement}
+      {hoverUnderlineElement}
     </button>
   );
 }

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -1,0 +1,185 @@
+/**
+ * @file XDSTab.tsx
+ * @input Uses React, StyleX, XDSTabListContext
+ * @output Exports XDSTab component and XDSTabProps type
+ * @position Core tab item; renders as button or anchor in navigation
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/TabList/README.md
+ * - /packages/core/src/TabList/index.ts
+ * - /packages/core/src/TabList/XDSTabList.test.tsx
+ */
+
+import {useCallback, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  transitionVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+import {useXDSTabListContext} from './XDSTabListContext';
+import type {XDSTabListSize} from './XDSTabListContext';
+
+export interface XDSTabProps {
+  /**
+   * Unique value for this tab. Matched against XDSTabListContext.value.
+   */
+  value: string;
+  /**
+   * Visible label text for this tab.
+   */
+  label: string;
+  /**
+   * URL to navigate to. When provided, renders as an anchor element.
+   */
+  href?: string;
+  /**
+   * Icon element shown when tab is not selected.
+   */
+  icon?: ReactNode;
+  /**
+   * Icon element shown when tab is selected. Falls back to `icon` if not provided.
+   */
+  selectedIcon?: ReactNode;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  base: {
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-3'],
+    backgroundColor: 'transparent',
+    borderWidth: 0,
+    borderStyle: 'none',
+    borderRadius: radiusVars['--radius-element'],
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-secondary'],
+    cursor: 'pointer',
+    textDecoration: 'none',
+    transitionProperty: 'color',
+    transitionDuration: transitionVars['--transition-fast'],
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
+  },
+  selected: {
+    color: colorVars['--color-accent-text'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+  },
+  underlineSelected: {
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      bottom: 0,
+      left: spacingVars['--spacing-3'],
+      right: spacingVars['--spacing-3'],
+      height: '2px',
+      backgroundColor: colorVars['--color-accent'],
+      borderRadius: '1px',
+    },
+  },
+  underlineHover: {
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      bottom: 0,
+      left: spacingVars['--spacing-3'],
+      right: spacingVars['--spacing-3'],
+      height: '2px',
+      backgroundColor: {
+        default: 'transparent',
+        ':hover': colorVars['--color-divider'],
+      },
+      borderRadius: '1px',
+      transitionProperty: 'background-color',
+      transitionDuration: transitionVars['--transition-fast'],
+    },
+  },
+  icon: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+});
+
+const sizeStyles = stylex.create({
+  sm: {height: '28px'},
+  md: {height: '32px'},
+  lg: {height: '36px'},
+});
+
+const iconSizeStyles = stylex.create({
+  sm: {width: '14px', height: '14px'},
+  md: {width: '16px', height: '16px'},
+  lg: {width: '18px', height: '18px'},
+});
+
+/**
+ * Tab item component. Renders as an anchor when `href` is provided,
+ * otherwise as a button.
+ */
+export function XDSTab({value, label, href, icon, selectedIcon}: XDSTabProps) {
+  const tabListCtx = useXDSTabListContext();
+
+  const isSelected = tabListCtx.value === value;
+  const size: XDSTabListSize = tabListCtx.size;
+  const displayIcon = isSelected && selectedIcon ? selectedIcon : icon;
+
+  const handleSelect = useCallback(() => {
+    tabListCtx.onChange(value);
+  }, [tabListCtx, value]);
+
+  const iconElement = displayIcon ? (
+    <span {...stylex.props(styles.icon, iconSizeStyles[size])}>
+      {displayIcon}
+    </span>
+  ) : null;
+
+  const sharedProps = {
+    'aria-current': isSelected ? ('page' as const) : undefined,
+    ...stylex.props(
+      styles.base,
+      sizeStyles[size],
+      isSelected && styles.selected,
+      isSelected ? styles.underlineSelected : styles.underlineHover,
+    ),
+  };
+
+  if (href != null) {
+    return (
+      <a href={href} onClick={handleSelect} {...sharedProps}>
+        {iconElement}
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <button type="button" onClick={handleSelect} {...sharedProps}>
+      {iconElement}
+      {label}
+    </button>
+  );
+}
+
+XDSTab.displayName = 'XDSTab';

--- a/packages/core/src/TabList/XDSTabList.test.tsx
+++ b/packages/core/src/TabList/XDSTabList.test.tsx
@@ -1,0 +1,317 @@
+/**
+ * @file XDSTabList.test.tsx
+ * @input Uses vitest, @testing-library/react, TabList components
+ * @output Unit tests for XDSTabList, XDSTab, XDSTabMenu behavior
+ * @position Testing; validates TabList component implementation
+ *
+ * SYNC: When TabList components change, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSTabList} from './XDSTabList';
+import {XDSTab} from './XDSTab';
+import {XDSTabMenu} from './XDSTabMenu';
+
+// Store original matches to restore later
+const originalMatches = HTMLElement.prototype.matches;
+
+// Track popover open state per element
+const popoverOpenState = new WeakMap<HTMLElement, boolean>();
+
+// Mock Popover API for jsdom
+beforeAll(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, true);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, false);
+  });
+
+  // Only intercept :popover-open, delegate everything else to original
+  HTMLElement.prototype.matches = function (selector: string) {
+    if (selector === ':popover-open') {
+      return popoverOpenState.get(this) ?? false;
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterAll(() => {
+  HTMLElement.prototype.matches = originalMatches;
+});
+
+describe('XDSTabList', () => {
+  it('renders a nav element with tab buttons', () => {
+    render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTab value="settings" label="Settings" />
+      </XDSTabList>,
+    );
+
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Home'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Settings'})).toBeInTheDocument();
+  });
+
+  it('marks selected tab with aria-current', () => {
+    render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTab value="settings" label="Settings" />
+      </XDSTabList>,
+    );
+
+    expect(screen.getByRole('button', {name: 'Home'})).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+    expect(screen.getByRole('button', {name: 'Settings'})).not.toHaveAttribute(
+      'aria-current',
+    );
+  });
+
+  it('calls onChange when a tab is clicked', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(
+      <XDSTabList value="home" onChange={handleChange}>
+        <XDSTab value="home" label="Home" />
+        <XDSTab value="settings" label="Settings" />
+      </XDSTabList>,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Settings'}));
+    expect(handleChange).toHaveBeenCalledWith('settings');
+  });
+
+  it('updates aria-current when value changes', () => {
+    const {rerender} = render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTab value="settings" label="Settings" />
+      </XDSTabList>,
+    );
+
+    expect(screen.getByRole('button', {name: 'Home'})).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+
+    rerender(
+      <XDSTabList value="settings" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTab value="settings" label="Settings" />
+      </XDSTabList>,
+    );
+
+    expect(screen.getByRole('button', {name: 'Home'})).not.toHaveAttribute(
+      'aria-current',
+    );
+    expect(screen.getByRole('button', {name: 'Settings'})).toHaveAttribute(
+      'aria-current',
+      'page',
+    );
+  });
+
+  it('renders with different sizes', () => {
+    const {rerender} = render(
+      <XDSTabList value="home" onChange={() => {}} size="sm">
+        <XDSTab value="home" label="Home" />
+      </XDSTabList>,
+    );
+    expect(screen.getByRole('button', {name: 'Home'})).toBeInTheDocument();
+
+    rerender(
+      <XDSTabList value="home" onChange={() => {}} size="lg">
+        <XDSTab value="home" label="Home" />
+      </XDSTabList>,
+    );
+    expect(screen.getByRole('button', {name: 'Home'})).toBeInTheDocument();
+  });
+
+  it('renders tab with icon', () => {
+    render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab
+          value="home"
+          label="Home"
+          icon={<span data-testid="icon">🏠</span>}
+        />
+      </XDSTabList>,
+    );
+
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('renders selectedIcon when tab is selected', () => {
+    render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab
+          value="home"
+          label="Home"
+          icon={<span data-testid="icon">○</span>}
+          selectedIcon={<span data-testid="selected-icon">●</span>}
+        />
+      </XDSTabList>,
+    );
+
+    expect(screen.getByTestId('selected-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('icon')).not.toBeInTheDocument();
+  });
+
+  it('renders regular icon when tab is not selected', () => {
+    render(
+      <XDSTabList value="other" onChange={() => {}}>
+        <XDSTab
+          value="home"
+          label="Home"
+          icon={<span data-testid="icon">○</span>}
+          selectedIcon={<span data-testid="selected-icon">●</span>}
+        />
+      </XDSTabList>,
+    );
+
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('selected-icon')).not.toBeInTheDocument();
+  });
+});
+
+describe('XDSTabMenu', () => {
+  const menuOptions = [
+    {value: 'analytics', label: 'Analytics'},
+    {value: 'reports', label: 'Reports'},
+  ];
+
+  it('renders a trigger button with aria-haspopup and aria-controls', () => {
+    render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTabMenu label="More" options={menuOptions} />
+      </XDSTabList>,
+    );
+
+    const trigger = screen.getByRole('button', {name: /More/});
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    // aria-controls points to the menu element
+    const menuId = trigger.getAttribute('aria-controls');
+    expect(menuId).toBeTruthy();
+    const menu = document.getElementById(menuId!);
+    expect(menu).toBeInTheDocument();
+    expect(menu).toHaveAttribute('role', 'menu');
+  });
+
+  it('shows label prop as trigger text when no option is selected', () => {
+    render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTabMenu label="More" options={menuOptions} />
+      </XDSTabList>,
+    );
+
+    expect(screen.getByRole('button', {name: /More/})).toBeInTheDocument();
+  });
+
+  it('shows selected option label as trigger text when an option is active', () => {
+    render(
+      <XDSTabList value="analytics" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTabMenu label="More" options={menuOptions} />
+      </XDSTabList>,
+    );
+
+    const trigger = screen.getByRole('button', {name: /Analytics/});
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it('opens dropdown on click and shows menu items', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTabMenu label="More" options={menuOptions} />
+      </XDSTabList>,
+    );
+
+    await user.click(screen.getByRole('button', {name: /More/}));
+
+    // showPopover should have been called
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+
+    // Menu items are rendered in DOM (popover controls visibility, hidden from a11y tree)
+    expect(
+      screen.getByRole('menuitem', {name: 'Analytics', hidden: true}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', {name: 'Reports', hidden: true}),
+    ).toBeInTheDocument();
+  });
+
+  it('renders heading divider with menu label in dropdown', () => {
+    render(
+      <XDSTabList value="home" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTabMenu label="More" options={menuOptions} />
+      </XDSTabList>,
+    );
+
+    // The dropdown has role="menu" with aria-label
+    const menu = screen.getByRole('menu', {name: 'More', hidden: true});
+    expect(menu).toBeInTheDocument();
+
+    // The heading is an XDSDivider with role="separator"
+    const separator = screen.getByRole('separator', {hidden: true});
+    expect(separator).toBeInTheDocument();
+  });
+
+  it('selects a menu item and calls onChange', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+
+    render(
+      <XDSTabList value="home" onChange={handleChange}>
+        <XDSTab value="home" label="Home" />
+        <XDSTabMenu label="More" options={menuOptions} />
+      </XDSTabList>,
+    );
+
+    // Click the menu trigger
+    await user.click(screen.getByRole('button', {name: /More/}));
+
+    // Click the menu item (popover content, hidden from a11y tree in jsdom)
+    const menuItem = screen.getByRole('menuitem', {
+      name: 'Analytics',
+      hidden: true,
+    });
+    await user.click(menuItem);
+    expect(handleChange).toHaveBeenCalledWith('analytics');
+  });
+
+  it('marks menu item as selected with aria-current', () => {
+    render(
+      <XDSTabList value="analytics" onChange={() => {}}>
+        <XDSTab value="home" label="Home" />
+        <XDSTabMenu label="More" options={menuOptions} />
+      </XDSTabList>,
+    );
+
+    // Menu items are in DOM (popover content, hidden from a11y tree in jsdom)
+    const analyticsItem = screen.getByRole('menuitem', {
+      name: 'Analytics',
+      hidden: true,
+    });
+    expect(analyticsItem).toHaveAttribute('aria-current', 'true');
+
+    const reportsItem = screen.getByRole('menuitem', {
+      name: 'Reports',
+      hidden: true,
+    });
+    expect(reportsItem).not.toHaveAttribute('aria-current');
+  });
+});

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -1,0 +1,96 @@
+/**
+ * @file XDSTabList.tsx
+ * @input Uses React, StyleX, XDSTabListContext
+ * @output Exports XDSTabList component and XDSTabListProps type
+ * @position Nav wrapper; provides XDSTabListContext to XDSTab and XDSTabMenu children
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/TabList/README.md
+ * - /packages/core/src/TabList/index.ts
+ * - /packages/core/src/TabList/XDSTabList.test.tsx
+ */
+
+import {useMemo, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {XDSTabListContext} from './XDSTabListContext';
+import type {XDSTabListSize} from './XDSTabListContext';
+
+export interface XDSTabListProps {
+  /**
+   * The currently selected tab value.
+   */
+  value: string;
+  /**
+   * Callback fired when a tab is selected.
+   */
+  onChange: (value: string) => void;
+  /**
+   * Size variant for all tabs.
+   * @default 'md'
+   */
+  size?: XDSTabListSize;
+  /**
+   * Whether to show a bottom divider under the tab list.
+   * @default false
+   */
+  hasDivider?: boolean;
+  /**
+   * XDSTab and XDSTabMenu children.
+   */
+  children: ReactNode;
+}
+
+const styles = stylex.create({
+  nav: {
+    display: 'flex',
+    alignItems: 'stretch',
+    gap: spacingVars['--spacing-0-5'],
+  },
+  divider: {
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: colorVars['--color-divider'],
+  },
+});
+
+/**
+ * Tab navigation wrapper. Provides context for value/onChange/size
+ * to XDSTab and XDSTabMenu children.
+ *
+ * @example
+ * ```tsx
+ * <XDSTabList value={activeTab} onChange={setActiveTab}>
+ *   <XDSTab value="home" label="Home" />
+ *   <XDSTab value="settings" label="Settings" />
+ *   <XDSTabMenu label="More">
+ *     <XDSTab value="analytics" label="Analytics" />
+ *     <XDSTab value="reports" label="Reports" />
+ *   </XDSTabMenu>
+ * </XDSTabList>
+ * ```
+ */
+export function XDSTabList({
+  value,
+  onChange,
+  size = 'md',
+  hasDivider = false,
+  children,
+}: XDSTabListProps) {
+  const contextValue = useMemo(
+    () => ({value, onChange, size}),
+    [value, onChange, size],
+  );
+
+  return (
+    <XDSTabListContext.Provider value={contextValue}>
+      <nav
+        aria-label="Tabs"
+        {...stylex.props(styles.nav, hasDivider && styles.divider)}>
+        {children}
+      </nav>
+    </XDSTabListContext.Provider>
+  );
+}
+
+XDSTabList.displayName = 'XDSTabList';

--- a/packages/core/src/TabList/XDSTabListContext.ts
+++ b/packages/core/src/TabList/XDSTabListContext.ts
@@ -1,0 +1,43 @@
+/**
+ * @file XDSTabListContext.ts
+ * @input React createContext, useContext
+ * @output Exports XDSTabListContext, useXDSTabListContext
+ * @position Context provider; consumed by XDSTab.tsx, XDSTabMenu.tsx
+ *
+ * SYNC: When modified, update /packages/core/src/TabList/README.md
+ */
+
+import {createContext, useContext} from 'react';
+
+/**
+ * Size variants for tab list items.
+ * Uses hardcoded px values (sizeVars not available on this branch).
+ */
+export type XDSTabListSize = 'sm' | 'md' | 'lg';
+
+/**
+ * Context for communicating value/onChange/size from XDSTabList to children.
+ */
+export interface XDSTabListContextValue {
+  value: string;
+  onChange: (value: string) => void;
+  size: XDSTabListSize;
+}
+
+export const XDSTabListContext = createContext<XDSTabListContextValue | null>(
+  null,
+);
+
+/**
+ * Returns XDSTabListContext value or throws if used outside XDSTabList.
+ */
+export function useXDSTabListContext(): XDSTabListContextValue {
+  const ctx = useContext(XDSTabListContext);
+  if (ctx == null) {
+    throw new Error(
+      'useXDSTabListContext must be used within XDSTabList. ' +
+        'Wrap your XDSTab/XDSTabMenu in <XDSTabList>.',
+    );
+  }
+  return ctx;
+}

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -1,0 +1,295 @@
+/**
+ * @file XDSTabMenu.tsx
+ * @input Uses React, StyleX, useXDSLayer, XDSTabListContext
+ * @output Exports XDSTabMenu component, XDSTabMenuProps type, XDSTabMenuOption type
+ * @position Menu trigger button; opens dropdown of overflow menu items
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/TabList/README.md
+ * - /packages/core/src/TabList/index.ts
+ * - /packages/core/src/TabList/XDSTabList.test.tsx
+ */
+
+import React, {useCallback, useId} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {CheckIcon, ChevronDownIcon} from '@heroicons/react/16/solid';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  transitionVars,
+  elevationVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+import {useXDSLayer} from '../Layer/useXDSLayer';
+import {useListFocus} from '../hooks/useListFocus';
+import {XDSIcon} from '../Icon';
+import type {XDSIconType} from '../Icon';
+import {XDSDivider} from '../Divider';
+import {useXDSTabListContext} from './XDSTabListContext';
+import type {XDSTabListSize} from './XDSTabListContext';
+
+export interface XDSTabMenuOption {
+  value: string;
+  label: string;
+  /**
+   * Icon to display before the label.
+   */
+  icon?: XDSIconType;
+}
+
+export interface XDSTabMenuProps {
+  /**
+   * Label for the trigger button and dropdown heading.
+   * Displayed as trigger text when no option is selected.
+   */
+  label: string;
+  /**
+   * Menu options rendered in the dropdown.
+   */
+  options: XDSTabMenuOption[];
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  trigger: {
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-3'],
+    backgroundColor: 'transparent',
+    borderWidth: 0,
+    borderStyle: 'none',
+    borderRadius: radiusVars['--radius-element'],
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    color: colorVars['--color-text-secondary'],
+    cursor: 'pointer',
+    transitionProperty: 'color, background-image',
+    transitionDuration: transitionVars['--transition-fast'],
+    backgroundImage: {
+      default: null,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+    },
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
+  },
+  triggerSelected: {
+    color: colorVars['--color-accent-text'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+  },
+  triggerLabel: {
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    alignSelf: 'stretch',
+  },
+  underline: {
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      height: '2px',
+      backgroundColor: colorVars['--color-accent'],
+      borderRadius: '1px',
+    },
+  },
+  chevron: {
+    width: '16px',
+    height: '16px',
+    flexShrink: 0,
+    transitionProperty: 'transform',
+    transitionDuration: transitionVars['--transition-fast'],
+  },
+  chevronOpen: {
+    transform: 'rotate(180deg)',
+  },
+  dropdown: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-1'],
+    backgroundColor: colorVars['--color-surface'],
+    borderRadius: radiusVars['--radius-element'],
+    boxShadow: elevationVars['--elevation-menu'],
+    minWidth: '160px',
+  },
+  menuItem: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    borderRadius: radiusVars['--radius-content'],
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    color: colorVars['--color-text-primary'],
+    cursor: 'pointer',
+    transitionProperty: 'background-color',
+    transitionDuration: transitionVars['--transition-fast'],
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': colorVars['--color-hover-overlay'],
+    },
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+  },
+  menuItemSelected: {
+    fontWeight: fontWeightVars['--font-weight-medium'],
+  },
+  menuItemContent: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+  },
+  itemCheckmark: {
+    flexShrink: 0,
+    width: 16,
+    height: 16,
+    color: colorVars['--color-icon-primary'],
+  },
+});
+
+const sizeStyles = stylex.create({
+  sm: {height: '28px'},
+  md: {height: '32px'},
+  lg: {height: '36px'},
+});
+
+/**
+ * Tab menu trigger that opens a dropdown of additional tab options.
+ * Shows the selected option's label as trigger text when an option is active.
+ * Dropdown includes a heading showing the menu's label prop.
+ */
+export function XDSTabMenu({label, options}: XDSTabMenuProps) {
+  const tabListCtx = useXDSTabListContext();
+  const menuId = useId();
+
+  const layer = useXDSLayer({
+    mode: 'context',
+    lightDismiss: true,
+  });
+
+  const {listRef, handleKeyDown: handleListKeyDown} = useListFocus({
+    onEscape: () => layer.hide(),
+  });
+
+  const handleToggle = useCallback(() => {
+    if (layer.isOpen) {
+      layer.hide();
+    } else {
+      layer.show();
+    }
+  }, [layer]);
+
+  const selectedOption = options.find(o => o.value === tabListCtx.value);
+  const triggerLabel = selectedOption?.label ?? label;
+  const hasSelectedOption = selectedOption != null;
+
+  const size: XDSTabListSize = tabListCtx.size;
+
+  const handleSelect = useCallback(
+    (value: string) => {
+      tabListCtx.onChange(value);
+      layer.hide();
+    },
+    [tabListCtx, layer],
+  );
+
+  return (
+    <>
+      <button
+        ref={layer.ref}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={layer.isOpen}
+        aria-controls={menuId}
+        onClick={handleToggle}
+        {...stylex.props(
+          styles.trigger,
+          sizeStyles[size],
+          hasSelectedOption && styles.triggerSelected,
+        )}>
+        <span
+          {...stylex.props(
+            styles.triggerLabel,
+            hasSelectedOption && styles.underline,
+          )}>
+          {triggerLabel}
+        </span>
+        <ChevronDownIcon
+          aria-hidden="true"
+          {...stylex.props(styles.chevron, layer.isOpen && styles.chevronOpen)}
+        />
+      </button>
+      {layer.render(
+        <div
+          ref={listRef as React.RefObject<HTMLDivElement>}
+          id={menuId}
+          role="menu"
+          aria-label={label}
+          onKeyDown={handleListKeyDown}
+          {...stylex.props(styles.dropdown)}>
+          <XDSDivider label={label} />
+          {options.map(option => {
+            const isSelected = tabListCtx.value === option.value;
+            return (
+              <div
+                key={option.value}
+                role="menuitem"
+                tabIndex={0}
+                aria-current={isSelected ? 'true' : undefined}
+                onClick={() => handleSelect(option.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleSelect(option.value);
+                  }
+                }}
+                {...stylex.props(
+                  styles.menuItem,
+                  isSelected && styles.menuItemSelected,
+                )}>
+                <span {...stylex.props(styles.menuItemContent)}>
+                  {option.icon && (
+                    <XDSIcon icon={option.icon} size="sm" color="secondary" />
+                  )}
+                  {option.label}
+                </span>
+                {isSelected && (
+                  <CheckIcon {...stylex.props(styles.itemCheckmark)} />
+                )}
+              </div>
+            );
+          })}
+        </div>,
+        {placement: 'below', alignment: 'start'},
+      )}
+    </>
+  );
+}
+
+XDSTabMenu.displayName = 'XDSTabMenu';

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -108,7 +108,7 @@ const styles = stylex.create({
       right: 0,
       height: '2px',
       backgroundColor: colorVars['--color-accent'],
-      borderRadius: '1px',
+      borderRadius: radiusVars['--radius-rounded'],
     },
   },
   chevron: {

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -74,12 +74,9 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
-    transitionProperty: 'color, background-image',
+    textDecoration: 'none',
+    transitionProperty: 'color',
     transitionDuration: transitionVars['--transition-fast'],
-    backgroundImage: {
-      default: null,
-      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
-    },
     outline: {
       default: null,
       ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
@@ -95,9 +92,20 @@ const styles = stylex.create({
   },
   triggerLabel: {
     position: 'relative',
-    display: 'inline-flex',
+    display: 'inline-grid',
     alignItems: 'center',
     alignSelf: 'stretch',
+  },
+  triggerLabelText: {
+    gridRowStart: 1,
+    gridColumnStart: 1,
+  },
+  triggerLabelSizer: {
+    gridRowStart: 1,
+    gridColumnStart: 1,
+    visibility: 'hidden',
+    pointerEvents: 'none',
+    fontWeight: fontWeightVars['--font-weight-semibold'],
   },
   underline: {
     '::after': {
@@ -110,6 +118,22 @@ const styles = stylex.create({
       backgroundColor: colorVars['--color-accent'],
       borderRadius: radiusVars['--radius-rounded'],
     },
+  },
+  hoverUnderline: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: '2px',
+    backgroundColor: colorVars['--color-divider'],
+    borderRadius: radiusVars['--radius-rounded'],
+    opacity: {
+      default: 0,
+      [stylex.when.ancestor(':hover')]: 1,
+    },
+    transitionProperty: 'opacity',
+    transitionDuration: transitionVars['--transition-fast'],
+    pointerEvents: 'none',
   },
   chevron: {
     width: '16px',
@@ -232,13 +256,20 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
           styles.trigger,
           sizeStyles[size],
           hasSelectedOption && styles.triggerSelected,
+          !hasSelectedOption && stylex.defaultMarker(),
         )}>
         <span
           {...stylex.props(
             styles.triggerLabel,
             hasSelectedOption && styles.underline,
           )}>
-          {triggerLabel}
+          <span {...stylex.props(styles.triggerLabelText)}>{triggerLabel}</span>
+          <span aria-hidden="true" {...stylex.props(styles.triggerLabelSizer)}>
+            {triggerLabel}
+          </span>
+          {!hasSelectedOption && (
+            <span {...stylex.props(styles.hoverUnderline)} />
+          )}
         </span>
         <ChevronDownIcon
           aria-hidden="true"

--- a/packages/core/src/TabList/index.ts
+++ b/packages/core/src/TabList/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @file index.ts
+ * @input Imports from TabList component files
+ * @output Exports XDSTabList, XDSTab, XDSTabMenu and their types
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/TabList/README.md
+ */
+
+export {XDSTabList} from './XDSTabList';
+export type {XDSTabListProps} from './XDSTabList';
+
+export {XDSTab} from './XDSTab';
+export type {XDSTabProps} from './XDSTab';
+
+export {XDSTabMenu} from './XDSTabMenu';
+export type {XDSTabMenuProps, XDSTabMenuOption} from './XDSTabMenu';
+
+export type {XDSTabListSize} from './XDSTabListContext';

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -12,3 +12,6 @@ export type {UseFocusTrapOptions, UseFocusTrapReturn} from './useFocusTrap';
 
 export {useGridFocus} from './useGridFocus';
 export type {UseGridFocusOptions, UseGridFocusReturn} from './useGridFocus';
+
+export {useListFocus} from './useListFocus';
+export type {UseListFocusOptions, UseListFocusReturn} from './useListFocus';

--- a/packages/core/src/hooks/useListFocus.ts
+++ b/packages/core/src/hooks/useListFocus.ts
@@ -1,0 +1,200 @@
+/**
+ * @file useListFocus.ts
+ * @input Uses React useCallback, useRef
+ * @output Exports useListFocus hook for linear list keyboard navigation
+ * @position Core hook; used by XDSTabMenu for dropdown menu navigation
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts
+ */
+
+import {useCallback, useRef} from 'react';
+
+/**
+ * Configuration for list focus behavior
+ */
+export interface UseListFocusOptions {
+  /**
+   * Selector for focusable items within the list.
+   * @default '[role="menuitem"]'
+   */
+  itemSelector?: string;
+
+  /**
+   * Whether arrow navigation wraps around at the ends.
+   * @default true
+   */
+  wrap?: boolean;
+
+  /**
+   * Callback when Escape key is pressed.
+   */
+  onEscape?: () => void;
+}
+
+/**
+ * Return type for useListFocus hook
+ */
+export interface UseListFocusReturn {
+  /**
+   * Ref to attach to the list container element.
+   */
+  listRef: React.RefObject<HTMLElement>;
+
+  /**
+   * Key down handler to attach to the list container.
+   */
+  handleKeyDown: (e: React.KeyboardEvent) => void;
+
+  /**
+   * Focus a specific item by index.
+   */
+  focusItem: (index: number) => void;
+
+  /**
+   * Focus the first focusable item.
+   */
+  focusFirst: () => void;
+
+  /**
+   * Focus the last focusable item.
+   */
+  focusLast: () => void;
+}
+
+/**
+ * Hook for managing keyboard navigation within a linear list.
+ *
+ * Implements WAI-ARIA menu/listbox pattern:
+ * - ArrowDown: Move to next item (wraps to first)
+ * - ArrowUp: Move to previous item (wraps to last)
+ * - Home: Move to first item
+ * - End: Move to last item
+ * - Escape: Custom callback (e.g., close menu)
+ *
+ * @example
+ * ```tsx
+ * const {listRef, handleKeyDown} = useListFocus({
+ *   onEscape: () => layer.hide(),
+ * });
+ *
+ * <div ref={listRef} role="menu" onKeyDown={handleKeyDown}>
+ *   {items.map(item => <div role="menuitem" tabIndex={0}>{item}</div>)}
+ * </div>
+ * ```
+ */
+export function useListFocus(
+  options: UseListFocusOptions = {},
+): UseListFocusReturn {
+  const {itemSelector = '[role="menuitem"]', wrap = true, onEscape} = options;
+
+  const listRef = useRef<HTMLElement>(null);
+
+  /**
+   * Get all focusable items in the list.
+   */
+  const getItems = useCallback((): HTMLElement[] => {
+    if (!listRef.current) return [];
+    return Array.from(
+      listRef.current.querySelectorAll<HTMLElement>(itemSelector),
+    );
+  }, [itemSelector]);
+
+  /**
+   * Get the currently focused item index.
+   */
+  const getCurrentIndex = useCallback((): number => {
+    const items = getItems();
+    const active = document.activeElement;
+    return items.findIndex(
+      item => item === active || item.contains(active as Node),
+    );
+  }, [getItems]);
+
+  /**
+   * Focus an item by index, clamping to valid range.
+   */
+  const focusItem = useCallback(
+    (index: number) => {
+      const items = getItems();
+      if (items.length === 0) return;
+      const clampedIndex = Math.max(0, Math.min(index, items.length - 1));
+      items[clampedIndex]?.focus();
+    },
+    [getItems],
+  );
+
+  /**
+   * Focus the first item.
+   */
+  const focusFirst = useCallback(() => {
+    const items = getItems();
+    items[0]?.focus();
+  }, [getItems]);
+
+  /**
+   * Focus the last item.
+   */
+  const focusLast = useCallback(() => {
+    const items = getItems();
+    items[items.length - 1]?.focus();
+  }, [getItems]);
+
+  /**
+   * Handle keyboard navigation.
+   */
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      const currentIndex = getCurrentIndex();
+      const items = getItems();
+      let handled = true;
+
+      switch (e.key) {
+        case 'ArrowDown': {
+          if (currentIndex === -1) {
+            items[0]?.focus();
+          } else if (currentIndex < items.length - 1) {
+            items[currentIndex + 1]?.focus();
+          } else if (wrap) {
+            items[0]?.focus();
+          }
+          break;
+        }
+        case 'ArrowUp': {
+          if (currentIndex === -1) {
+            items[items.length - 1]?.focus();
+          } else if (currentIndex > 0) {
+            items[currentIndex - 1]?.focus();
+          } else if (wrap) {
+            items[items.length - 1]?.focus();
+          }
+          break;
+        }
+        case 'Home':
+          focusFirst();
+          break;
+        case 'End':
+          focusLast();
+          break;
+        case 'Escape':
+          onEscape?.();
+          break;
+        default:
+          handled = false;
+      }
+
+      if (handled) {
+        e.preventDefault();
+      }
+    },
+    [getCurrentIndex, getItems, wrap, focusFirst, focusLast, onEscape],
+  );
+
+  return {
+    listRef,
+    handleKeyDown,
+    focusItem,
+    focusFirst,
+    focusLast,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export * from './Selector';
 export * from './Icon';
 export * from './Text';
 export * from './TextInput';
+export * from './TabList';
 export * from './TextArea';
 export * from './TimeInput';
 


### PR DESCRIPTION
Notes that this doesn't implement the `tablist` and `tab` APG spec (https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). Instead this is a `<nav>` landmark which contains buttons or inputs with `aria-current` marking the current page. This is because our tab lists can include menus for grouping tabs. Unfortunately, the `tablist` role can only support `tab` children so we need to bail out to a more generic navigation format for accessibility.

Implement tab navigation with an overflow menu pattern:
- XDSTabList provides context (value/onChange/size) with optional hasDivider
- XDSTab renders as <button> or <a> (via href prop) with aria-current="page", gray hover underline, and icon/selectedIcon support
- XDSTabMenu uses a data-driven options prop with icon support, renders a role="menu" dropdown with aria-controls, XDSDivider heading, CheckIcon selection indicator, and useListFocus keyboard navigation
- Add useListFocus hook for linear list keyboard navigation (ArrowUp/Down, Home/End, Escape) following the useGridFocus pattern