### PR TITLE
Fix unused import/variable lint warnings in Table components

### DIFF
--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -1,13 +1,12 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {
   XDSTable,
-  XDSBaseTable,
   XDSTableRow,
   XDSTableCell,
   proportional,
   pixel,
 } from '@xds/core/Table';
-import type {XDSTableColumn, TablePlugin} from '@xds/core/Table';
+import type {XDSTableColumn} from '@xds/core/Table';
 import {colorRaw, spacingRaw, radiusRaw, textSizeRaw} from '@xds/core/theme';
 
 // =============================================================================

--- a/packages/core/src/Table/XDSTable.perf.test.tsx
+++ b/packages/core/src/Table/XDSTable.perf.test.tsx
@@ -10,9 +10,9 @@
  * 3. Non-memoized columns/data don't cause excessive re-renders
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi} from 'vitest';
 import {render, screen, act} from '@testing-library/react';
-import {useState, useCallback, useRef, useEffect, useMemo} from 'react';
+import {useState} from 'react';
 import {XDSTable} from './XDSTable';
 import type {XDSTableColumn} from './types';
 

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen, within} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import {XDSBaseTable} from './XDSBaseTable';
 import {XDSTable} from './XDSTable';
 import {XDSTableRow} from './XDSTableRow';

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -135,7 +135,7 @@ function buildXDSStylePlugin<T extends Record<string, unknown>>(
 
     transformHeaderCell(
       props: HeaderCellRenderProps,
-      column,
+      _column,
     ): HeaderCellRenderProps {
       const cellStyles = [
         ...props.styles,


### PR DESCRIPTION
- Remove unused imports: XDSBaseTable, TablePlugin, within, beforeEach, useCallback, useRef, useEffect, useMemo
- Prefix unused column parameter with underscore in transformHeaderCell