### PR TITLE
Add XDSCloseButton + use it in XDSDialog

### DIFF
--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof XDSButton> = {
       control: 'boolean',
       description: 'Loading state',
     },
-    disabled: {
+    isDisabled: {
       control: 'boolean',
       description: 'Disabled state',
     },
@@ -75,7 +75,7 @@ export const Disabled: Story = {
   args: {
     label: 'Disabled',
     variant: 'primary',
-    disabled: true,
+    isDisabled: true,
   },
 };
 
@@ -147,10 +147,10 @@ export const AllVariants: Story = {
         <XDSButton label="Loading..." variant="destructive" loading />
       </div>
       <div style={{display: 'flex', gap: '12px'}}>
-        <XDSButton label="Disabled" variant="primary" disabled />
-        <XDSButton label="Disabled" variant="secondary" disabled />
-        <XDSButton label="Disabled" variant="ghost" disabled />
-        <XDSButton label="Disabled" variant="destructive" disabled />
+        <XDSButton label="Disabled" variant="primary" isDisabled />
+        <XDSButton label="Disabled" variant="secondary" isDisabled />
+        <XDSButton label="Disabled" variant="ghost" isDisabled />
+        <XDSButton label="Disabled" variant="destructive" isDisabled />
       </div>
       <div style={{display: 'flex', gap: '12px'}}>
         <XDSButton

--- a/apps/storybook/stories/CloseButton.stories.tsx
+++ b/apps/storybook/stories/CloseButton.stories.tsx
@@ -1,0 +1,74 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSCloseButton} from '@xds/core/CloseButton';
+import {XDSHStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
+
+const meta: Meta<typeof XDSCloseButton> = {
+  title: 'Core/XDSCloseButton',
+  component: XDSCloseButton,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size of the close button',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the button is disabled',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCloseButton>;
+
+/**
+ * Default close button
+ */
+export const Default: Story = {
+  args: {
+    onClick: () => alert('Close clicked'),
+  },
+};
+
+/**
+ * All sizes
+ */
+export const Sizes: Story = {
+  render: () => (
+    <XDSHStack gap="space4" vAlign="center">
+      <XDSHStack gap="space2" vAlign="center">
+        <XDSCloseButton size="sm" />
+        <XDSText type="supporting">sm</XDSText>
+      </XDSHStack>
+      <XDSHStack gap="space2" vAlign="center">
+        <XDSCloseButton size="md" />
+        <XDSText type="supporting">md</XDSText>
+      </XDSHStack>
+      <XDSHStack gap="space2" vAlign="center">
+        <XDSCloseButton size="lg" />
+        <XDSText type="supporting">lg</XDSText>
+      </XDSHStack>
+    </XDSHStack>
+  ),
+};
+
+/**
+ * Disabled state
+ */
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+  },
+};
+
+/**
+ * With custom aria-label
+ */
+export const CustomAriaLabel: Story = {
+  args: {
+    'aria-label': 'Dismiss notification',
+    onClick: () => alert('Dismissed'),
+  },
+};

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -9,6 +9,7 @@ import {
   XDSHStack,
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
+import {XDSCloseButton} from '@xds/core/CloseButton';
 import {XDSHeading, XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSDialog> = {
@@ -61,7 +62,10 @@ function BasicModalExample() {
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Modal Title</XDSHeading>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={2}>Modal Title</XDSHeading>
+                <XDSCloseButton onClick={() => setIsShown(false)} />
+              </XDSHStack>
             </XDSLayoutHeader>
           }
           content={
@@ -116,7 +120,10 @@ function WideModalExample() {
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Wide Modal</XDSHeading>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={2}>Wide Modal</XDSHeading>
+                <XDSCloseButton onClick={() => setIsShown(false)} />
+              </XDSHStack>
             </XDSLayoutHeader>
           }
           content={
@@ -167,7 +174,10 @@ function FullscreenModalExample() {
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Fullscreen Modal</XDSHeading>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={2}>Fullscreen Modal</XDSHeading>
+                <XDSCloseButton onClick={() => setIsShown(false)} />
+              </XDSHStack>
             </XDSLayoutHeader>
           }
           content={
@@ -283,7 +293,10 @@ function FormModalExample() {
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Edit Profile</XDSHeading>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={2}>Edit Profile</XDSHeading>
+                <XDSCloseButton onClick={() => setIsShown(false)} />
+              </XDSHStack>
             </XDSLayoutHeader>
           }
           content={
@@ -341,7 +354,10 @@ function InfoModalExample() {
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Information</XDSHeading>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={2}>Information</XDSHeading>
+                <XDSCloseButton onClick={() => setIsShown(false)} />
+              </XDSHStack>
             </XDSLayoutHeader>
           }
           content={
@@ -395,7 +411,10 @@ function PositionedModalExample() {
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Positioned Modal</XDSHeading>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={2}>Positioned Modal</XDSHeading>
+                <XDSCloseButton onClick={() => setIsShown(false)} />
+              </XDSHStack>
             </XDSLayoutHeader>
           }
           content={
@@ -447,7 +466,10 @@ function ScrollingModalExample() {
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Terms and Conditions</XDSHeading>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={2}>Terms and Conditions</XDSHeading>
+                <XDSCloseButton onClick={() => setIsShown(false)} />
+              </XDSHStack>
             </XDSLayoutHeader>
           }
           content={
@@ -523,7 +545,10 @@ function ConfirmationModalExample() {
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Confirm Delete</XDSHeading>
+              <XDSHStack hAlign="between" vAlign="center">
+                <XDSHeading level={2}>Confirm Delete</XDSHeading>
+                <XDSCloseButton onClick={() => setIsShown(false)} />
+              </XDSHStack>
             </XDSLayoutHeader>
           }
           content={

--- a/internal/test-utils/src/setup.ts
+++ b/internal/test-utils/src/setup.ts
@@ -9,3 +9,13 @@
 
 /// <reference types="@testing-library/jest-dom" />
 import '@testing-library/jest-dom/vitest';
+
+// Polyfill for Popover API (not supported in jsdom)
+// This prevents errors when testing components that use XDSTooltip
+if (typeof HTMLElement.prototype.showPopover === 'undefined') {
+  HTMLElement.prototype.showPopover = function () {};
+  HTMLElement.prototype.hidePopover = function () {};
+  HTMLElement.prototype.togglePopover = function () {
+    return false;
+  };
+}

--- a/packages/core/src/Button/README.md
+++ b/packages/core/src/Button/README.md
@@ -32,15 +32,16 @@ import { XDSButton } from '@xds/core/Button';
 
 ## Props
 
-| Prop       | Type                                                   | Default       | Description                 |
-| ---------- | ------------------------------------------------------ | ------------- | --------------------------- |
-| `label`    | `string`                                               | —             | Accessible label (required) |
-| `variant`  | `'primary' \| 'secondary' \| 'ghost' \| 'destructive'` | `'secondary'` | Visual style variant        |
-| `size`     | `'sm' \| 'md' \| 'lg'`                                 | `'md'`        | Size variant                |
-| `loading`  | `boolean`                                              | `false`       | Shows loading spinner       |
-| `disabled` | `boolean`                                              | `false`       | Disables the button         |
-| `icon`     | `ReactNode`                                            | —             | Icon element                |
-| `children` | `ReactNode`                                            | —             | Button content              |
+| Prop         | Type                                                   | Default       | Description                 |
+| ------------ | ------------------------------------------------------ | ------------- | --------------------------- |
+| `label`      | `string`                                               | —             | Accessible label (required) |
+| `variant`    | `'primary' \| 'secondary' \| 'ghost' \| 'destructive'` | `'secondary'` | Visual style variant        |
+| `size`       | `'sm' \| 'md' \| 'lg'`                                 | `'md'`        | Size variant                |
+| `loading`    | `boolean`                                              | `false`       | Shows loading spinner       |
+| `isDisabled` | `boolean`                                              | `false`       | Disables the button         |
+| `icon`       | `ReactNode`                                            | —             | Icon element                |
+| `children`   | `ReactNode`                                            | —             | Button content              |
+| `tooltip`    | `string`                                               | —             | Tooltip text shown on hover |
 
 ## Files
 

--- a/packages/core/src/Button/XDSButton.test.tsx
+++ b/packages/core/src/Button/XDSButton.test.tsx
@@ -78,7 +78,7 @@ describe('XDSButton', () => {
   it('does not fire click when disabled', async () => {
     const user = userEvent.setup();
     const handleClick = vi.fn();
-    render(<XDSButton label="Click me" disabled onClick={handleClick} />);
+    render(<XDSButton label="Click me" isDisabled onClick={handleClick} />);
 
     await user.click(screen.getByRole('button'));
     expect(handleClick).not.toHaveBeenCalled();

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -15,6 +15,7 @@ import {
   forwardRef,
   useContext,
   type ButtonHTMLAttributes,
+  type ReactElement,
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
@@ -29,6 +30,7 @@ import {
   lineHeightVars,
 } from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
+import {XDSTooltip} from '../Layer/XDSTooltip';
 
 /**
  * Base button styles
@@ -188,7 +190,7 @@ declare module '../theme/types' {
 
 export interface XDSButtonProps extends Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
-  'children'
+  'children' | 'disabled'
 > {
   /**
    * Accessible label for the button (required for accessibility).
@@ -206,6 +208,11 @@ export interface XDSButtonProps extends Omit<
    */
   size?: XDSButtonSize;
   /**
+   * Whether the button is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
    * Whether the button is in a loading state.
    * @default false
    */
@@ -220,6 +227,10 @@ export interface XDSButtonProps extends Omit<
    * button becomes icon-only with label used as aria-label.
    */
   children?: ReactNode;
+  /**
+   * Tooltip text shown on hover.
+   */
+  tooltip?: string;
 }
 
 /**
@@ -281,15 +292,16 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
       label,
       variant = 'secondary',
       size = 'md',
+      isDisabled = false,
       loading = false,
       icon,
-      disabled,
       children,
+      tooltip,
       ...props
     },
     ref,
-  ) => {
-    const isDisabled = disabled || loading;
+  ): ReactElement => {
+    const buttonDisabled = isDisabled || loading;
     const useLightSpinner = variant === 'primary' || variant === 'destructive';
     const isIconOnly = icon != null && children == null;
 
@@ -298,10 +310,10 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
     const themeVariantOverride =
       themeContext?.theme.components?.button?.variants?.[variant];
 
-    return (
+    const button = (
       <button
         ref={ref}
-        disabled={isDisabled}
+        disabled={buttonDisabled}
         aria-label={isIconOnly ? label : undefined}
         {...stylex.props(
           styles.base,
@@ -309,7 +321,7 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
           variants[variant],
           themeVariantOverride,
           isIconOnly && styles.iconOnly,
-          isDisabled && styles.disabled,
+          buttonDisabled && styles.disabled,
           loading && loadingStyles.loading,
         )}
         {...props}>
@@ -327,6 +339,16 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
         {children ?? (isIconOnly ? null : label)}
       </button>
     );
+
+    if (tooltip) {
+      return (
+        <XDSTooltip content={tooltip} placement="above">
+          {button}
+        </XDSTooltip>
+      );
+    }
+
+    return button;
   },
 );
 

--- a/packages/core/src/CloseButton/README.md
+++ b/packages/core/src/CloseButton/README.md
@@ -1,0 +1,66 @@
+# /packages/core/src/CloseButton
+
+XDSCloseButton component for dismissing dialogs, panels, and other closeable UI elements.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Theme-configurable icon**: Default Heroicons XMarkIcon, customizable via theme
+- **Sizes**: `sm`, `md`, `lg` matching standard size tokens
+- **Accessible**: Includes `aria-label="Close"` by default
+- **Ghost styling**: Transparent background with hover/active states
+
+## Usage
+
+```tsx
+import {XDSCloseButton} from '@xds/core/CloseButton';
+
+<XDSCloseButton onClick={handleClose} />
+
+// With custom label (used for aria-label and tooltip)
+<XDSCloseButton onClick={handleClose} label="Dismiss notification" />
+
+// Different sizes
+<XDSCloseButton size="sm" onClick={handleClose} />
+<XDSCloseButton size="lg" onClick={handleClose} />
+```
+
+## Props
+
+| Prop         | Type                   | Default   | Description                                    |
+| ------------ | ---------------------- | --------- | ---------------------------------------------- |
+| `size`       | `'sm' \| 'md' \| 'lg'` | `'md'`    | Size of the button                             |
+| `label`      | `string`               | `'Close'` | Accessible label (aria-label) and tooltip text |
+| `isDisabled` | `boolean`              | `false`   | Whether the button is disabled                 |
+
+## Customizing the Icon
+
+The icon can be customized via the theme's `components.closeButton.icon` setting:
+
+```tsx
+import {XCircleIcon} from '@heroicons/react/24/solid';
+
+const customTheme = {
+  ...baseTheme,
+  components: {
+    closeButton: {
+      icon: XCircleIcon,
+    },
+  },
+};
+```
+
+## Files
+
+| File                      | Role  | Purpose                                    |
+| ------------------------- | ----- | ------------------------------------------ |
+| `index.ts`                | Entry | Exports XDSCloseButton component and types |
+| `XDSCloseButton.tsx`      | Core  | XDSCloseButton component implementation    |
+| `XDSCloseButton.test.tsx` | Test  | Unit tests for XDSCloseButton component    |
+
+## Implementation Notes
+
+- Uses ghost-style button with hover/active overlays
+- Icon size scales with button size (sm: 16px, md: 20px, lg: 24px)
+- Theme augmentation allows icon customization without component imports

--- a/packages/core/src/CloseButton/XDSCloseButton.test.tsx
+++ b/packages/core/src/CloseButton/XDSCloseButton.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * @file XDSCloseButton.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSCloseButton component
+ * @output Unit tests for XDSCloseButton component behavior
+ * @position Testing; validates XDSCloseButton.tsx implementation
+ *
+ * SYNC: When XDSCloseButton.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSCloseButton} from './XDSCloseButton';
+
+describe('XDSCloseButton', () => {
+  it('renders a button element', () => {
+    render(<XDSCloseButton />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('has aria-label="Close" by default', () => {
+    render(<XDSCloseButton />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Close');
+  });
+
+  it('allows custom label for aria-label', () => {
+    render(<XDSCloseButton label="Dismiss" />);
+    expect(screen.getByRole('button')).toHaveAttribute('aria-label', 'Dismiss');
+  });
+
+  it('uses label as tooltip content via aria-describedby', () => {
+    render(<XDSCloseButton label="Dismiss notification" />);
+    const button = screen.getByRole('button');
+    // XDSTooltip sets aria-describedby on the button
+    expect(button).toHaveAttribute('aria-describedby');
+  });
+
+  it('has tooltip with default "Close" label', () => {
+    render(<XDSCloseButton />);
+    const button = screen.getByRole('button');
+    // XDSTooltip sets aria-describedby on the button
+    expect(button).toHaveAttribute('aria-describedby');
+  });
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<XDSCloseButton onClick={handleClick} />);
+
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onClick when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<XDSCloseButton onClick={handleClick} isDisabled />);
+
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('renders with type="button"', () => {
+    render(<XDSCloseButton />);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  it('can be disabled', () => {
+    render(<XDSCloseButton isDisabled />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('renders an SVG icon', () => {
+    render(<XDSCloseButton />);
+    const button = screen.getByRole('button');
+    const svg = button.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  describe('sizes', () => {
+    it('renders with default md size', () => {
+      render(<XDSCloseButton />);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('renders with sm size', () => {
+      render(<XDSCloseButton size="sm" />);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('renders with lg size', () => {
+      render(<XDSCloseButton size="lg" />);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/core/src/CloseButton/XDSCloseButton.tsx
+++ b/packages/core/src/CloseButton/XDSCloseButton.tsx
@@ -1,0 +1,109 @@
+/**
+ * @file XDSCloseButton.tsx
+ * @input Uses React forwardRef, XDSButton, XDSIcon
+ * @output Exports XDSCloseButton component, XDSCloseButtonProps, XDSCloseButtonSize types
+ * @position Core implementation; consumed by index.ts, tested by XDSCloseButton.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CloseButton/README.md (props table, features, implementation notes)
+ * - /packages/core/src/CloseButton/XDSCloseButton.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/CloseButton/index.ts (exports if types change)
+ * - /apps/storybook/stories/CloseButton.stories.tsx (storybook stories)
+ */
+
+import {forwardRef, useContext, type ButtonHTMLAttributes} from 'react';
+import {XMarkIcon} from '@heroicons/react/24/outline';
+import {XDSButton, type XDSButtonSize} from '../Button';
+import {XDSIcon, type XDSIconType, type XDSIconSize} from '../Icon';
+import {ThemeContext} from '../theme/ThemeContext';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type XDSCloseButtonSize = XDSButtonSize;
+
+// Map button sizes to icon sizes
+const buttonSizeToIconSize: Record<XDSCloseButtonSize, XDSIconSize> = {
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+};
+
+// =============================================================================
+// Module Augmentation - Register CloseButton config with ComponentStyles
+// =============================================================================
+
+declare module '../theme/types' {
+  interface ComponentStyles {
+    closeButton?: {
+      /** Custom icon component to use instead of the default XMarkIcon */
+      icon?: XDSIconType;
+    };
+  }
+}
+
+export interface XDSCloseButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'disabled'
+> {
+  /**
+   * The size of the close button.
+   * @default 'md'
+   */
+  size?: XDSCloseButtonSize;
+  /**
+   * Accessible label for the button, also used as tooltip.
+   * @default 'Close'
+   */
+  label?: string;
+  /**
+   * Whether the button is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * A close button component with a configurable icon.
+ *
+ * The icon can be customized via the theme's `components.closeButton.icon` setting.
+ * Defaults to the Heroicons XMarkIcon (outline).
+ *
+ * @example
+ * ```tsx
+ * <XDSCloseButton onClick={handleClose} />
+ * <XDSCloseButton onClick={handleClose} label="Dismiss notification" />
+ * ```
+ */
+export const XDSCloseButton = forwardRef<
+  HTMLButtonElement,
+  XDSCloseButtonProps
+>(({size = 'md', label = 'Close', isDisabled, ...props}, ref) => {
+  // Get theme context for custom icon
+  const themeContext = useContext(ThemeContext);
+  const IconComponent =
+    themeContext?.theme.components?.closeButton?.icon ?? XMarkIcon;
+
+  const iconSize = buttonSizeToIconSize[size];
+
+  return (
+    <XDSButton
+      ref={ref}
+      type="button"
+      variant="ghost"
+      size={size}
+      label={label}
+      tooltip={label}
+      isDisabled={isDisabled}
+      icon={<XDSIcon icon={IconComponent} size={iconSize} color="inherit" />}
+      {...props}
+    />
+  );
+});
+
+XDSCloseButton.displayName = 'XDSCloseButton';

--- a/packages/core/src/CloseButton/index.ts
+++ b/packages/core/src/CloseButton/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input Imports XDSCloseButton component and types from XDSCloseButton.tsx
+ * @output Exports XDSCloseButton, XDSCloseButtonProps, XDSCloseButtonSize
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/CloseButton/README.md
+ */
+
+export {XDSCloseButton} from './XDSCloseButton';
+export type {XDSCloseButtonProps, XDSCloseButtonSize} from './XDSCloseButton';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './Button';
 export * from './Calendar';
 export * from './Center';
 export * from './CheckboxInput';
+export * from './CloseButton';
 export * from './Divider';
 export * from './Link';
 export * from './Switch';


### PR DESCRIPTION
1. Made some adjustments to XDSButton props (isDisabled, tooltip)
2. Create new XDSCloseButton component
3. Use it in XDSDialog examples

Since we don't have a "standard" layout for XDSDialog it has to be manually hooked up which is sort of a downside. 