### PR TITLE
Disable StyleX runtime injection in core build config

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
             '@stylexjs/babel-plugin',
             {
               dev: false,
-              runtimeInjection: true,
+              runtimeInjection: false,
               genConditionalClasses: true,
               treeshakeCompensation: true,
               unstable_moduleResolution: {


### PR DESCRIPTION
Runtime injection is unnecessary for the bundled output since styles are extracted at build time.