### PR TITLE
Add XDSDialogHeader component

### DIFF
--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -1,16 +1,14 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSDialog} from '@xds/core/Dialog';
+import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
 import {
   XDSLayout,
-  XDSLayoutHeader,
   XDSLayoutContent,
   XDSLayoutFooter,
   XDSHStack,
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
-import {XDSCloseButton} from '@xds/core/CloseButton';
-import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSText} from '@xds/core/Text';
 
 const meta: Meta<typeof XDSDialog> = {
   title: 'Core/XDSDialog',
@@ -46,7 +44,7 @@ export default meta;
 type Story = StoryObj<typeof XDSDialog>;
 
 /**
- * Basic modal example with XDSLayout
+ * Basic modal example with XDSDialogHeader
  */
 function BasicModalExample() {
   const [isShown, setIsShown] = useState(false);
@@ -61,12 +59,10 @@ function BasicModalExample() {
       <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
         <XDSLayout
           header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHStack hAlign="between" vAlign="center">
-                <XDSHeading level={2}>Modal Title</XDSHeading>
-                <XDSCloseButton onClick={() => setIsShown(false)} />
-              </XDSHStack>
-            </XDSLayoutHeader>
+            <XDSDialogHeader
+              title="Modal Title"
+              onHide={() => setIsShown(false)}
+            />
           }
           content={
             <XDSLayoutContent>
@@ -104,6 +100,62 @@ export const Default: Story = {
 };
 
 /**
+ * Dialog with subtitle example
+ */
+function SubtitleModalExample() {
+  const [isShown, setIsShown] = useState(false);
+
+  return (
+    <>
+      <XDSButton
+        label="Open Modal with Subtitle"
+        variant="secondary"
+        onClick={() => setIsShown(true)}
+      />
+      <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
+        <XDSLayout
+          header={
+            <XDSDialogHeader
+              title="Edit User Profile"
+              subtitle="Make changes to your account settings"
+              onHide={() => setIsShown(false)}
+            />
+          }
+          content={
+            <XDSLayoutContent>
+              <XDSText type="body">
+                The subtitle appears below the title in smaller, secondary text.
+                It provides additional context about the dialog&apos;s purpose.
+              </XDSText>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter hasDivider>
+              <XDSHStack gap="space2" hAlign="end">
+                <XDSButton
+                  label="Cancel"
+                  variant="secondary"
+                  onClick={() => setIsShown(false)}
+                />
+                <XDSButton
+                  label="Save Changes"
+                  variant="primary"
+                  onClick={() => setIsShown(false)}
+                />
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </XDSDialog>
+    </>
+  );
+}
+
+export const WithSubtitle: Story = {
+  render: () => <SubtitleModalExample />,
+};
+
+/**
  * Custom width example
  */
 function WideModalExample() {
@@ -119,12 +171,10 @@ function WideModalExample() {
       <XDSDialog isShown={isShown} onHide={() => setIsShown(false)} width={600}>
         <XDSLayout
           header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHStack hAlign="between" vAlign="center">
-                <XDSHeading level={2}>Wide Modal</XDSHeading>
-                <XDSCloseButton onClick={() => setIsShown(false)} />
-              </XDSHStack>
-            </XDSLayoutHeader>
+            <XDSDialogHeader
+              title="Wide Modal"
+              onHide={() => setIsShown(false)}
+            />
           }
           content={
             <XDSLayoutContent>
@@ -173,12 +223,10 @@ function FullscreenModalExample() {
         variant="fullscreen">
         <XDSLayout
           header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHStack hAlign="between" vAlign="center">
-                <XDSHeading level={2}>Fullscreen Modal</XDSHeading>
-                <XDSCloseButton onClick={() => setIsShown(false)} />
-              </XDSHStack>
-            </XDSLayoutHeader>
+            <XDSDialogHeader
+              title="Fullscreen Modal"
+              onHide={() => setIsShown(false)}
+            />
           }
           content={
             <XDSLayoutContent>
@@ -238,11 +286,7 @@ function RequiredModalExample() {
         onHide={() => setIsShown(false)}
         purpose="required">
         <XDSLayout
-          header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHeading level={2}>Accept Terms</XDSHeading>
-            </XDSLayoutHeader>
-          }
+          header={<XDSDialogHeader title="Accept Terms" />}
           content={
             <XDSLayoutContent>
               <XDSText type="body">
@@ -292,12 +336,10 @@ function FormModalExample() {
         width={500}>
         <XDSLayout
           header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHStack hAlign="between" vAlign="center">
-                <XDSHeading level={2}>Edit Profile</XDSHeading>
-                <XDSCloseButton onClick={() => setIsShown(false)} />
-              </XDSHStack>
-            </XDSLayoutHeader>
+            <XDSDialogHeader
+              title="Edit Profile"
+              onHide={() => setIsShown(false)}
+            />
           }
           content={
             <XDSLayoutContent>
@@ -353,12 +395,10 @@ function InfoModalExample() {
         purpose="info">
         <XDSLayout
           header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHStack hAlign="between" vAlign="center">
-                <XDSHeading level={2}>Information</XDSHeading>
-                <XDSCloseButton onClick={() => setIsShown(false)} />
-              </XDSHStack>
-            </XDSLayoutHeader>
+            <XDSDialogHeader
+              title="Information"
+              onHide={() => setIsShown(false)}
+            />
           }
           content={
             <XDSLayoutContent>
@@ -410,12 +450,10 @@ function PositionedModalExample() {
         width={350}>
         <XDSLayout
           header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHStack hAlign="between" vAlign="center">
-                <XDSHeading level={2}>Positioned Modal</XDSHeading>
-                <XDSCloseButton onClick={() => setIsShown(false)} />
-              </XDSHStack>
-            </XDSLayoutHeader>
+            <XDSDialogHeader
+              title="Positioned Modal"
+              onHide={() => setIsShown(false)}
+            />
           }
           content={
             <XDSLayoutContent>
@@ -465,12 +503,10 @@ function ScrollingModalExample() {
         maxHeight="50vh">
         <XDSLayout
           header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHStack hAlign="between" vAlign="center">
-                <XDSHeading level={2}>Terms and Conditions</XDSHeading>
-                <XDSCloseButton onClick={() => setIsShown(false)} />
-              </XDSHStack>
-            </XDSLayoutHeader>
+            <XDSDialogHeader
+              title="Terms and Conditions"
+              onHide={() => setIsShown(false)}
+            />
           }
           content={
             <XDSLayoutContent>
@@ -544,12 +580,10 @@ function ConfirmationModalExample() {
         purpose="form">
         <XDSLayout
           header={
-            <XDSLayoutHeader hasDivider>
-              <XDSHStack hAlign="between" vAlign="center">
-                <XDSHeading level={2}>Confirm Delete</XDSHeading>
-                <XDSCloseButton onClick={() => setIsShown(false)} />
-              </XDSHStack>
-            </XDSLayoutHeader>
+            <XDSDialogHeader
+              title="Confirm Delete"
+              onHide={() => setIsShown(false)}
+            />
           }
           content={
             <XDSLayoutContent>

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -211,7 +211,7 @@ export interface XDSDialogProps extends Omit<
  *
  * <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
  *   <XDSLayout
- *     header={<XDSLayoutHeader hasDivider>Title</XDSLayoutHeader>}
+ *     header={<XDSDialogHeader title="Title" onHide={() => setIsShown(false)} />}
  *     content={<XDSLayoutContent>Content</XDSLayoutContent>}
  *     footer={<XDSLayoutFooter hasDivider>Actions</XDSLayoutFooter>}
  *   />

--- a/packages/core/src/Dialog/XDSDialogHeader.test.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.test.tsx
@@ -1,0 +1,125 @@
+/**
+ * @file XDSDialogHeader.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSDialogHeader component
+ * @output Unit tests for XDSDialogHeader component behavior
+ * @position Testing; validates XDSDialogHeader.tsx implementation
+ *
+ * SYNC: When XDSDialogHeader.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSDialogHeader} from './XDSDialogHeader';
+
+describe('XDSDialogHeader', () => {
+  it('renders the title', () => {
+    render(<XDSDialogHeader title="My Dialog Title" />);
+    expect(
+      screen.getByRole('heading', {level: 2, name: 'My Dialog Title'}),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the title as an h2 element', () => {
+    render(<XDSDialogHeader title="Title" />);
+    const heading = screen.getByRole('heading', {level: 2});
+    expect(heading.tagName).toBe('H2');
+  });
+
+  it('title has tabIndex=-1 for programmatic focus', () => {
+    render(<XDSDialogHeader title="Title" />);
+    const heading = screen.getByRole('heading', {level: 2});
+    expect(heading).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('auto-focuses the title when mounted', () => {
+    render(<XDSDialogHeader title="Title" />);
+    const heading = screen.getByRole('heading', {level: 2});
+    expect(document.activeElement).toBe(heading);
+  });
+
+  it('renders subtitle when provided', () => {
+    render(<XDSDialogHeader title="Title" subtitle="This is a subtitle" />);
+    expect(screen.getByText('This is a subtitle')).toBeInTheDocument();
+  });
+
+  it('does not render subtitle when not provided', () => {
+    render(<XDSDialogHeader title="Title" />);
+    expect(screen.queryByText('This is a subtitle')).not.toBeInTheDocument();
+  });
+
+  it('renders close button when onHide is provided', () => {
+    render(<XDSDialogHeader title="Title" onHide={() => {}} />);
+    expect(screen.getByRole('button', {name: /close/i})).toBeInTheDocument();
+  });
+
+  it('does not render close button when onHide is not provided', () => {
+    render(<XDSDialogHeader title="Title" />);
+    expect(
+      screen.queryByRole('button', {name: /close/i}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onHide when close button is clicked', async () => {
+    const user = userEvent.setup();
+    const handleHide = vi.fn();
+    render(<XDSDialogHeader title="Title" onHide={handleHide} />);
+
+    await user.click(screen.getByRole('button', {name: /close/i}));
+    expect(handleHide).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders with divider by default', () => {
+    const {container} = render(<XDSDialogHeader title="Title" />);
+    // Check that the header div has divider styles (border-bottom)
+    const header = container.firstChild as HTMLElement;
+    expect(header).toBeInTheDocument();
+  });
+
+  it('renders additional endContent', () => {
+    render(
+      <XDSDialogHeader
+        title="Title"
+        endContent={<button>Custom Action</button>}
+      />,
+    );
+    expect(
+      screen.getByRole('button', {name: 'Custom Action'}),
+    ).toBeInTheDocument();
+  });
+
+  it('renders endContent alongside close button', () => {
+    render(
+      <XDSDialogHeader
+        title="Title"
+        onHide={() => {}}
+        endContent={<button>Custom Action</button>}
+      />,
+    );
+    expect(
+      screen.getByRole('button', {name: 'Custom Action'}),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /close/i})).toBeInTheDocument();
+  });
+
+  it('renders startContent before the title', () => {
+    render(
+      <XDSDialogHeader title="Title" startContent={<button>Back</button>} />,
+    );
+    expect(screen.getByRole('button', {name: 'Back'})).toBeInTheDocument();
+  });
+
+  it('renders startContent and endContent together', () => {
+    render(
+      <XDSDialogHeader
+        title="Title"
+        startContent={<button>Back</button>}
+        endContent={<button>Save</button>}
+        onHide={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button', {name: 'Back'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: /close/i})).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -1,0 +1,143 @@
+/**
+ * @file XDSDialogHeader.tsx
+ * @input Uses React forwardRef, useEffect, useRef, XDSLayoutHeader, XDSHeading, XDSText
+ * @output Exports XDSDialogHeader component and XDSDialogHeaderProps
+ * @position Dialog header component; used with XDSDialog and XDSLayout
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Dialog/README.md
+ * - /packages/core/src/Dialog/XDSDialogHeader.test.tsx
+ * - /packages/core/src/Dialog/index.ts
+ * - /apps/storybook/stories/Dialog.stories.tsx
+ */
+
+import {forwardRef, useEffect, useRef, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {spacingVars} from '../theme/tokens.stylex';
+import {XDSLayoutHeader} from '../Layout/XDSLayout/XDSLayoutHeader';
+import {XDSCloseButton} from '../CloseButton';
+import {XDSHeading} from '../Text/XDSHeading';
+import {XDSText} from '../Text/XDSText';
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'space-between',
+    gap: spacingVars['--spacing-3'],
+  },
+  titleWrapper: {
+    flex: 1,
+    minWidth: 0,
+  },
+  titleFocusable: {
+    outline: 'none',
+  },
+  actions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    flexShrink: 0,
+  },
+});
+
+export interface XDSDialogHeaderProps {
+  /**
+   * The title of the dialog.
+   * This title receives focus when the dialog opens for screen reader accessibility.
+   */
+  title: string;
+
+  /**
+   * Optional subtitle displayed below the title in smaller, secondary text.
+   */
+  subtitle?: string;
+
+  /**
+   * Callback fired when the close button is clicked.
+   * If not provided, no close button will be rendered.
+   */
+  onHide?: () => unknown;
+
+  /**
+   * Content to render before the title (e.g., a back button).
+   */
+  startContent?: ReactNode;
+
+  /**
+   * Content to render after the title, before the close button (e.g., action buttons).
+   */
+  endContent?: ReactNode;
+
+  /**
+   * Adds a themed border at the bottom edge.
+   * When false, spacing collapse is applied automatically for seamless visual flow.
+   * @default true
+   */
+  hasDivider?: boolean;
+}
+
+/**
+ * Header component designed specifically for XDSDialog.
+ *
+ * Renders a title that receives focus when the dialog opens (for screen reader accessibility)
+ * and an optional close button. The title is an h2 element with tabIndex={-1} so it can be
+ * programmatically focused but doesn't appear in the tab order.
+ *
+ * Uses XDSLayoutHeader internally for consistent styling with other layout headers.
+ *
+ * @example
+ * ```tsx
+ * <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
+ *   <XDSLayout
+ *     header={<XDSDialogHeader title="Modal Title" onHide={() => setIsShown(false)} />}
+ *     content={<XDSLayoutContent>Content</XDSLayoutContent>}
+ *     footer={<XDSLayoutFooter hasDivider>Actions</XDSLayoutFooter>}
+ *   />
+ * </XDSDialog>
+ * ```
+ */
+export const XDSDialogHeader = forwardRef<HTMLElement, XDSDialogHeaderProps>(
+  function XDSDialogHeader(
+    {title, subtitle, onHide, startContent, endContent, hasDivider = true},
+    ref,
+  ) {
+    const titleRef = useRef<HTMLHeadingElement>(null);
+
+    // Auto-focus the title when mounted for screen reader accessibility
+    useEffect(() => {
+      if (titleRef.current) {
+        titleRef.current.tabIndex = -1;
+        titleRef.current.focus();
+      }
+    }, []);
+
+    return (
+      <XDSLayoutHeader ref={ref} hasDivider={hasDivider}>
+        <div {...stylex.props(styles.container)}>
+          {startContent && (
+            <div {...stylex.props(styles.actions)}>{startContent}</div>
+          )}
+          <div {...stylex.props(styles.titleWrapper)}>
+            <XDSHeading ref={titleRef} level={2} xstyle={styles.titleFocusable}>
+              {title}
+            </XDSHeading>
+            {subtitle && (
+              <XDSText type="body" size="sm" color="secondary">
+                {subtitle}
+              </XDSText>
+            )}
+          </div>
+          {(endContent || onHide) && (
+            <div {...stylex.props(styles.actions)}>
+              {endContent}
+              {onHide && <XDSCloseButton onClick={onHide} />}
+            </div>
+          )}
+        </div>
+      </XDSLayoutHeader>
+    );
+  },
+);
+
+XDSDialogHeader.displayName = 'XDSDialogHeader';

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -1,7 +1,7 @@
 /**
  * @file index.ts
  * @input Imports XDSDialog component and types from XDSDialog.tsx
- * @output Exports XDSDialog, XDSDialogProps, XDSDialogVariant, XDSDialogPurpose, XDSDialogPosition, XDSDialogRef
+ * @output Exports XDSDialog, XDSDialogHeader, and related types
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Dialog/README.md
@@ -14,3 +14,6 @@ export type {
   XDSDialogPurpose,
   XDSDialogPosition,
 } from './XDSDialog';
+
+export {XDSDialogHeader} from './XDSDialogHeader';
+export type {XDSDialogHeaderProps} from './XDSDialogHeader';


### PR DESCRIPTION
Expanded version of XDSLayoutHeader that supports focusing on title and has more structured slots. Also supports subtitle.

<img width="417" height="253" alt="image" src="https://github.com/user-attachments/assets/04269958-1711-4b57-a573-153242559e26" />
