### PR TITLE
Add typography hallucination test prompts and evaluation criteria

### DIFF
--- a/internal/vibe-tests/src/aggregate.ts
+++ b/internal/vibe-tests/src/aggregate.ts
@@ -339,6 +339,7 @@ const ANTI_PATTERN_HATCHES: EscapeHatchType[] = [
   'hardcoded_spacing',
   'inline_style', // Should use StyleX instead
   'a11y_click_handler', // Accessibility issue: use button instead
+  'hardcoded_typography', // Should use XDSText/XDSHeading type system
 ];
 
 interface TierCounts {
@@ -766,6 +767,88 @@ function detectEscapeHatches(
         }
       }
     }
+  }
+
+  // Check for hardcoded typography values (fontSize, fontWeight, lineHeight, fontFamily)
+  // These should use XDSText/XDSHeading type system or design tokens
+  if (target === 'xds') {
+    // Hardcoded fontSize (raw px/rem/em values, not via var(--text-*))
+    const hardcodedFontSizeRegex =
+      /fontSize\s*:\s*['"]?\d+(?:\.\d+)?(?:px|rem|em)['"]?/gi;
+    while ((match = hardcodedFontSizeRegex.exec(code)) !== null) {
+      if (!match[0].includes('var(')) {
+        hatches.push({
+          type: 'hardcoded_typography',
+          severity: 'acceptable',
+          detail:
+            'Hardcoded fontSize instead of using XDSText/XDSHeading type system or --text-* tokens',
+          codeSnippet: match[0],
+        });
+      }
+    }
+
+    // Hardcoded fontWeight (raw numeric values, not via var(--font-weight-*))
+    const hardcodedFontWeightRegex =
+      /fontWeight\s*:\s*['"]?(?:100|200|300|400|500|600|700|800|900)['"]?/gi;
+    while ((match = hardcodedFontWeightRegex.exec(code)) !== null) {
+      if (!match[0].includes('var(')) {
+        hatches.push({
+          type: 'hardcoded_typography',
+          severity: 'acceptable',
+          detail:
+            'Hardcoded fontWeight instead of using XDSText weight prop or --font-weight-* tokens',
+          codeSnippet: match[0],
+        });
+      }
+    }
+
+    // Hardcoded lineHeight (raw numeric/px/rem values, not via var(--leading-*))
+    const hardcodedLineHeightRegex =
+      /lineHeight\s*:\s*['"]?\d+(?:\.\d+)?(?:px|rem|em)?['"]?/gi;
+    while ((match = hardcodedLineHeightRegex.exec(code)) !== null) {
+      if (!match[0].includes('var(')) {
+        hatches.push({
+          type: 'hardcoded_typography',
+          severity: 'acceptable',
+          detail:
+            'Hardcoded lineHeight instead of using XDSText/XDSHeading type system or --leading-* tokens',
+          codeSnippet: match[0],
+        });
+      }
+    }
+
+    // Hardcoded fontFamily (raw font stack instead of var(--font-*))
+    const hardcodedFontFamilyRegex =
+      /fontFamily\s*:\s*['"][^'"]*(?:sans-serif|serif|monospace|Arial|Helvetica|Roboto|Geist)[^'"]*['"]/gi;
+    while ((match = hardcodedFontFamilyRegex.exec(code)) !== null) {
+      if (!match[0].includes('var(')) {
+        hatches.push({
+          type: 'hardcoded_typography',
+          severity: 'acceptable',
+          detail:
+            'Hardcoded fontFamily instead of using --font-body, --font-heading, or --font-code tokens',
+          codeSnippet: match[0],
+        });
+      }
+    }
+
+    // Hallucinated typography CSS variables
+    const hallucinatedTypographyTokenRegex =
+      /var\(\s*--(?:font-size-\w+|font-family-\w+|xds-font-\w+|xds-text-\w+|xds-heading-\w+|text-size-\w+|line-height-\w+)\s*\)/gi;
+    while ((match = hallucinatedTypographyTokenRegex.exec(code)) !== null) {
+      hatches.push({
+        type: 'hallucinated_typography_token',
+        severity: 'critical',
+        detail:
+          'Hallucinated typography CSS variable. Valid tokens: --text-*, --font-body, --font-code, --font-heading, --font-weight-*, --leading-*',
+        codeSnippet: match[0],
+      });
+    }
+
+    // Note: Raw HTML heading/paragraph elements (<h1>-<h6>, <p>) are acceptable
+    // in XDS because global typography styles handle them correctly.
+    // We still prefer XDSHeading/XDSText for structured UI (props like weight,
+    // maxLines, variant) but don't flag raw HTML as an escape hatch.
   }
 
   return hatches;

--- a/internal/vibe-tests/src/quality-agent.ts
+++ b/internal/vibe-tests/src/quality-agent.ts
@@ -191,7 +191,16 @@ The code should use:
 - StyleX for styling with CSS variable tokens (var(--spacing-*), var(--color-*))
 - XDSTextInput should use \`status\` prop for validation errors (not manual border styling)
 - Interactive elements should use Button components, not clickable divs/spans
-- Layout should use XDSVStack, XDSHStack, XDSStackItem when appropriate`
+- Layout should use XDSVStack, XDSHStack, XDSStackItem when appropriate
+
+### Typography Requirements
+- **XDSHeading** for all heading text (h1-h6), with \`level\` prop for semantic level and \`variant="editorial"\` for display-scale headings
+- **XDSText** for all non-heading text, with \`type\` prop: \`body\`, \`large\`, \`label\`, \`supporting\`, or \`code\`
+- **XDSFontWrapper** is a global provider that styles native HTML elements with proper typography — raw HTML is acceptable for prose/markdown content rendered within it
+- For structured UI (cards, forms, dashboards), prefer XDSHeading/XDSText over raw HTML for access to props like \`weight\`, \`maxLines\`, \`variant\`, \`hasTabularNumbers\`
+- Never hardcode fontSize, fontWeight, lineHeight, or fontFamily — use the component type system or design tokens
+- Valid typography tokens: \`--text-*\` (sizes), \`--font-weight-*\` (weights), \`--leading-*\` (line heights), \`--font-body\`, \`--font-code\`, \`--font-heading\` (font families)
+- Common hallucinated tokens to flag: \`--font-size-*\`, \`--font-family-*\`, \`--xds-font-*\` (these don't exist)`
       : `
 ## Design System Context (shadcn/Tailwind)
 
@@ -237,7 +246,7 @@ Review this code and provide a quality assessment. Return your findings as a JSO
     "issues": [
       {
         "severity": "critical|moderate|minor",
-        "category": "component-usage|token-usage|pattern-violation",
+        "category": "component-usage|token-usage|pattern-violation|typography-violation",
         "issue": "<description of the issue>",
         "recommendation": "<how to fix it>",
         "codeSnippet": "<optional relevant code>"

--- a/internal/vibe-tests/src/types.ts
+++ b/internal/vibe-tests/src/types.ts
@@ -22,7 +22,9 @@ export type EscapeHatchType =
   | 'hardcoded_size' // Acceptable: explicit sizes are often needed
   | 'custom_animation' // Gap: missing animation support
   | 'layout_workaround' // Gap: missing layout primitive
-  | 'a11y_click_handler'; // Anti-pattern: onClick on non-interactive element
+  | 'a11y_click_handler' // Anti-pattern: onClick on non-interactive element
+  | 'hardcoded_typography' // Anti-pattern: raw fontSize/fontWeight/lineHeight/fontFamily instead of tokens
+  | 'hallucinated_typography_token'; // Hallucination: invalid CSS variable like --font-size-*, --font-family-*
 
 export type EscapeHatchSeverity = 'critical' | 'acceptable';
 
@@ -215,7 +217,11 @@ export interface AccessibilityIssue {
 
 export interface DesignSystemIssue {
   severity: 'critical' | 'moderate' | 'minor';
-  category: 'component-usage' | 'token-usage' | 'pattern-violation';
+  category:
+    | 'component-usage'
+    | 'token-usage'
+    | 'pattern-violation'
+    | 'typography-violation';
   issue: string;
   recommendation: string;
   codeSnippet?: string;

--- a/internal/vibe-tests/test-sets/default.json
+++ b/internal/vibe-tests/test-sets/default.json
@@ -275,6 +275,116 @@
         "Add breadcrumbs below the header",
         "Add a footer with version info and links"
       ]
+    },
+    {
+      "id": "ty-1",
+      "category": "typography",
+      "prompt": "Show a page title with a short description underneath",
+      "expectedComponents": ["XDSHeading", "XDSText"],
+      "complexity": "simple",
+      "followUps": [
+        "Make the title use the larger editorial scale",
+        "Add a label above the title that says 'Getting Started'"
+      ]
+    },
+    {
+      "id": "ty-2",
+      "category": "typography",
+      "prompt": "Create a blog post header with a big editorial headline, a publication date in small text, and an author name",
+      "expectedComponents": ["XDSHeading", "XDSText"],
+      "complexity": "moderate",
+      "followUps": [
+        "Add a reading time estimate next to the date in the same small style",
+        "Make the author name semibold"
+      ]
+    },
+    {
+      "id": "ty-3",
+      "category": "typography",
+      "prompt": "Build a metrics dashboard card that shows a label like 'Total Revenue', a large numeric value like '$12,340.56', and a small supporting line that says '+12% from last month'",
+      "expectedComponents": ["XDSCard", "XDSText"],
+      "complexity": "moderate",
+      "followUps": [
+        "Make the numeric value use tabular numbers so digits align across cards",
+        "Add a second metric card next to it and ensure the numbers line up vertically"
+      ]
+    },
+    {
+      "id": "ty-4",
+      "category": "typography",
+      "prompt": "Create a settings page with 3 sections. Each section needs a heading, a brief description, and some form controls. Use different heading levels for the page title vs section titles.",
+      "expectedComponents": ["XDSHeading", "XDSText", "XDSTextInput"],
+      "complexity": "moderate",
+      "followUps": [
+        "Add helper text below each input using the appropriate supporting text style",
+        "Make the section headings visually smaller than the page title"
+      ]
+    },
+    {
+      "id": "ty-5",
+      "category": "typography",
+      "prompt": "Build a landing page hero with a large display heading that says 'Build faster with XDS', a subheading paragraph, and a CTA button",
+      "expectedComponents": ["XDSHeading", "XDSText", "XDSButton"],
+      "complexity": "simple",
+      "followUps": [
+        "The heading should use the editorial display scale for maximum visual impact",
+        "Add a secondary tagline below the heading in a lighter color"
+      ]
+    },
+    {
+      "id": "ty-6",
+      "category": "typography",
+      "prompt": "Display a code example with a label that says 'Installation' above it, the code snippet 'yarn add @xds/core', and a note below in small text",
+      "expectedComponents": ["XDSText"],
+      "complexity": "simple",
+      "followUps": [
+        "Add a copy button next to the code",
+        "Add a second code example for npm below the yarn one"
+      ]
+    },
+    {
+      "id": "ty-7",
+      "category": "typography",
+      "prompt": "Render a markdown-formatted changelog that includes headings, paragraphs, bullet lists, and inline code. The content should use proper typography styling.",
+      "expectedComponents": ["XDSHeading", "XDSText"],
+      "complexity": "complex",
+      "followUps": [
+        "Make the changelog use the editorial heading scale",
+        "Add a table of contents at the top with links to each section"
+      ]
+    },
+    {
+      "id": "ty-8",
+      "category": "typography",
+      "prompt": "Create a profile card with the user's name as a heading, their role as a label, their bio as body text, and their join date in small supporting text",
+      "expectedComponents": ["XDSCard", "XDSHeading", "XDSText"],
+      "complexity": "simple",
+      "followUps": [
+        "Add an email address that truncates with an ellipsis if it's too long",
+        "Make the role text medium weight"
+      ]
+    },
+    {
+      "id": "ty-9",
+      "category": "typography",
+      "prompt": "Build a comparison table header where each column has a plan name heading and a price. The 'Enterprise' plan should have visually larger display-style typography compared to the other plans.",
+      "expectedComponents": ["XDSHeading", "XDSText"],
+      "complexity": "complex",
+      "followUps": [
+        "Add a 'Most Popular' label badge on the Pro plan using label-style text",
+        "Make all prices use tabular numbers so they align across columns"
+      ]
+    },
+    {
+      "id": "ty-10",
+      "category": "typography",
+      "prompt": "Create an article page with a full editorial-style header (large title, subtitle, author info) and a body section that renders rich text content with proper heading hierarchy, paragraphs, code blocks, and lists",
+      "expectedComponents": ["XDSHeading", "XDSText"],
+      "complexity": "complex",
+      "followUps": [
+        "Add a 'Table of Contents' sidebar that lists all the section headings",
+        "Make the body text use the large text type for better readability"
+      ]
     }
   ],
   "holdout": [
@@ -353,6 +463,28 @@
       "followUps": [
         "Add recent searches that show before typing",
         "Add result categories with headers (Users, Posts, etc.)"
+      ]
+    },
+    {
+      "id": "ho-ty-1",
+      "category": "typography",
+      "prompt": "Create a documentation page header with a breadcrumb trail in small text, a large editorial heading, and a description paragraph",
+      "expectedComponents": ["XDSHeading", "XDSText"],
+      "complexity": "moderate",
+      "followUps": [
+        "Add a 'Last updated' timestamp in supporting text style",
+        "Optically align the heading text with the content below it"
+      ]
+    },
+    {
+      "id": "ho-ty-2",
+      "category": "typography",
+      "prompt": "Build a notification detail view with a bold title, a timestamp in supporting text, and a body that may contain formatted markdown content",
+      "expectedComponents": ["XDSHeading", "XDSText"],
+      "complexity": "moderate",
+      "followUps": [
+        "Truncate the title to a single line with a tooltip showing the full text",
+        "Add a secondary text line showing who triggered the notification"
       ]
     }
   ],


### PR DESCRIPTION
Add 12 typography-focused prompts (10 main + 2 holdout) to the vibe test battery to assess how well LLMs use XDS typography components (XDSHeading, XDSText, XDSFontWrapper) vs falling back to raw CSS or hallucinated tokens.

Detection for hardcoded typography values (fontSize, fontWeight, lineHeight, fontFamily) and hallucinated CSS variables (--font-size-*, --font-family-*, --xds-font-*) added to the escape hatch static analysis. Quality agent updated with typography-specific evaluation context.

<img width="905" height="391" alt="Screenshot 2026-02-13 at 4 57 05 PM" src="https://github.com/user-attachments/assets/28b5c2f5-ff5d-48d0-8d6c-4e8e6217f1b0" />
<img width="925" height="380" alt="Screenshot 2026-02-13 at 5 03 43 PM" src="https://github.com/user-attachments/assets/40d19cde-cdf6-4c6c-b762-060317524768" />
