### PR TITLE
Add XDSRadioList and XDSRadioListItem components

### DIFF
--- a/apps/storybook/stories/RadioList.stories.tsx
+++ b/apps/storybook/stories/RadioList.stories.tsx
@@ -1,0 +1,332 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
+
+const meta: Meta<typeof XDSRadioList> = {
+  title: 'Core/XDSRadioList',
+  component: XDSRadioList,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Label text (required)',
+    },
+    isLabelHidden: {
+      control: 'boolean',
+      description:
+        'Visually hide the label (still accessible to screen readers)',
+    },
+    description: {
+      control: 'text',
+      description: 'Description text displayed below the label',
+    },
+    value: {
+      control: 'text',
+      description: 'The currently selected value',
+    },
+    orientation: {
+      control: 'select',
+      options: ['vertical', 'horizontal'],
+      description: 'Layout direction of the radio items',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Whether all radio items are disabled',
+    },
+    isRequired: {
+      control: 'boolean',
+      description: 'Whether the radio group is required',
+    },
+    isOptional: {
+      control: 'boolean',
+      description: 'Whether the field is optional',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSRadioList>;
+
+export const Default: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem label="Email" value="email" />
+        <XDSRadioListItem label="SMS" value="sms" />
+        <XDSRadioListItem label="Push notification" value="push" />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Notification preference',
+  },
+};
+
+export const WithDescription: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem
+          label="Email"
+          value="email"
+          description="Receive notifications via email"
+        />
+        <XDSRadioListItem
+          label="SMS"
+          value="sms"
+          description="Standard messaging rates apply"
+        />
+        <XDSRadioListItem
+          label="Push notification"
+          value="push"
+          description="Instant alerts on your device"
+        />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Notification preference',
+    description: 'Choose how you would like to be notified',
+  },
+};
+
+export const Horizontal: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem label="Small" value="sm" />
+        <XDSRadioListItem label="Medium" value="md" />
+        <XDSRadioListItem label="Large" value="lg" />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Size',
+    orientation: 'horizontal',
+  },
+};
+
+export const Disabled: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? 'email');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem label="Email" value="email" />
+        <XDSRadioListItem label="SMS" value="sms" />
+        <XDSRadioListItem label="Push notification" value="push" />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Notification preference',
+    isDisabled: true,
+  },
+};
+
+export const DisabledItem: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem label="Email" value="email" />
+        <XDSRadioListItem label="SMS" value="sms" isDisabled />
+        <XDSRadioListItem label="Push notification" value="push" />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Notification preference',
+  },
+};
+
+export const Required: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem label="Email" value="email" />
+        <XDSRadioListItem label="SMS" value="sms" />
+        <XDSRadioListItem label="Push notification" value="push" />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Notification preference',
+    isRequired: true,
+  },
+};
+
+export const Optional: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem label="Email" value="email" />
+        <XDSRadioListItem label="SMS" value="sms" />
+        <XDSRadioListItem label="Push notification" value="push" />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Notification preference',
+    isOptional: true,
+  },
+};
+
+export const WithErrorStatus: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem label="Email" value="email" />
+        <XDSRadioListItem label="SMS" value="sms" />
+        <XDSRadioListItem label="Push notification" value="push" />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Notification preference',
+    isRequired: true,
+    status: {type: 'error', message: 'Please select a notification method'},
+  },
+};
+
+export const WithStartContent: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem
+          label="Email"
+          value="email"
+          startContent={<span>📧</span>}
+        />
+        <XDSRadioListItem
+          label="SMS"
+          value="sms"
+          startContent={<span>💬</span>}
+        />
+        <XDSRadioListItem
+          label="Push notification"
+          value="push"
+          startContent={<span>🔔</span>}
+        />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Notification preference',
+  },
+};
+
+export const WithEndContent: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return (
+      <XDSRadioList {...restArgs} value={value} onChange={setValue}>
+        <XDSRadioListItem
+          label="Free"
+          value="free"
+          endContent={<span style={{color: '#0D8626'}}>$0/mo</span>}
+        />
+        <XDSRadioListItem
+          label="Pro"
+          value="pro"
+          endContent={<span style={{color: '#0064E0'}}>$9/mo</span>}
+        />
+        <XDSRadioListItem
+          label="Enterprise"
+          value="enterprise"
+          endContent={<span style={{color: '#5B08D8'}}>Custom</span>}
+        />
+      </XDSRadioList>
+    );
+  },
+  args: {
+    label: 'Plan',
+  },
+};
+
+export const AllVariations: Story = {
+  render: () => {
+    const [value1, setValue1] = useState('');
+    const [value2, setValue2] = useState('email');
+    const [value3, setValue3] = useState('');
+    const [value4, setValue4] = useState('sm');
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '24px',
+          maxWidth: '400px',
+        }}>
+        <XDSRadioList label="Unselected" value={value1} onChange={setValue1}>
+          <XDSRadioListItem label="Option A" value="a" />
+          <XDSRadioListItem label="Option B" value="b" />
+        </XDSRadioList>
+        <XDSRadioList label="Pre-selected" value={value2} onChange={setValue2}>
+          <XDSRadioListItem label="Email" value="email" />
+          <XDSRadioListItem label="SMS" value="sms" />
+        </XDSRadioList>
+        <XDSRadioList
+          label="Disabled group"
+          value=""
+          onChange={() => {}}
+          isDisabled>
+          <XDSRadioListItem label="Option A" value="a" />
+          <XDSRadioListItem label="Option B" value="b" />
+        </XDSRadioList>
+        <XDSRadioList
+          label="With descriptions"
+          value={value3}
+          onChange={setValue3}>
+          <XDSRadioListItem
+            label="Email"
+            value="email"
+            description="Delivered to your inbox"
+          />
+          <XDSRadioListItem
+            label="SMS"
+            value="sms"
+            description="Standard rates apply"
+          />
+        </XDSRadioList>
+        <XDSRadioList
+          label="Horizontal"
+          value={value4}
+          onChange={setValue4}
+          orientation="horizontal">
+          <XDSRadioListItem label="S" value="sm" />
+          <XDSRadioListItem label="M" value="md" />
+          <XDSRadioListItem label="L" value="lg" />
+        </XDSRadioList>
+        <XDSRadioList
+          label="With error"
+          value=""
+          onChange={() => {}}
+          isRequired
+          status={{
+            type: 'error',
+            message: 'Please select an option',
+          }}>
+          <XDSRadioListItem label="Option A" value="a" />
+          <XDSRadioListItem label="Option B" value="b" />
+        </XDSRadioList>
+      </div>
+    );
+  },
+};

--- a/packages/core/src/RadioList/XDSRadioList.test.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.test.tsx
@@ -1,0 +1,338 @@
+/**
+ * @file XDSRadioList.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSRadioList, XDSRadioListItem
+ * @output Unit tests for XDSRadioList and XDSRadioListItem behavior
+ * @position Testing; validates XDSRadioList.tsx and XDSRadioListItem.tsx implementation
+ *
+ * SYNC: When XDSRadioList.tsx or XDSRadioListItem.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSRadioList} from './XDSRadioList';
+import {XDSRadioListItem} from './XDSRadioListItem';
+
+describe('XDSRadioList', () => {
+  it('renders with label', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}}>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByText('Preference')).toBeInTheDocument();
+  });
+
+  it('renders radio items', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}}>
+        <XDSRadioListItem label="Option A" value="a" />
+        <XDSRadioListItem label="Option B" value="b" />
+        <XDSRadioListItem label="Option C" value="c" />
+      </XDSRadioList>,
+    );
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('renders radiogroup role', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}}>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+  });
+
+  it('selects the correct radio based on value prop', () => {
+    render(
+      <XDSRadioList label="Preference" value="b" onChange={() => {}}>
+        <XDSRadioListItem label="Option A" value="a" />
+        <XDSRadioListItem label="Option B" value="b" />
+        <XDSRadioListItem label="Option C" value="c" />
+      </XDSRadioList>,
+    );
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).not.toBeChecked();
+    expect(radios[1]).toBeChecked();
+    expect(radios[2]).not.toBeChecked();
+  });
+
+  it('calls onChange with value string when clicking a radio', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSRadioList label="Preference" value="a" onChange={handleChange}>
+        <XDSRadioListItem label="Option A" value="a" />
+        <XDSRadioListItem label="Option B" value="b" />
+      </XDSRadioList>,
+    );
+
+    await user.click(screen.getByLabelText('Option B'));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith('b');
+  });
+
+  it('calls onChange when clicking on a label', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSRadioList label="Preference" value="a" onChange={handleChange}>
+        <XDSRadioListItem label="Option A" value="a" />
+        <XDSRadioListItem label="Option B" value="b" />
+      </XDSRadioList>,
+    );
+
+    await user.click(screen.getByText('Option B'));
+    expect(handleChange).toHaveBeenCalledWith('b');
+  });
+
+  it('disables all radios when group isDisabled is true', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}} isDisabled>
+        <XDSRadioListItem label="Option A" value="a" />
+        <XDSRadioListItem label="Option B" value="b" />
+      </XDSRadioList>,
+    );
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).toBeDisabled();
+    expect(radios[1]).toBeDisabled();
+  });
+
+  it('does not call onChange when group is disabled', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSRadioList
+        label="Preference"
+        value=""
+        onChange={handleChange}
+        isDisabled>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+
+    await user.click(screen.getByLabelText('Option A'));
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('disables individual item when item isDisabled is true', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}}>
+        <XDSRadioListItem label="Option A" value="a" />
+        <XDSRadioListItem label="Option B" value="b" isDisabled />
+      </XDSRadioList>,
+    );
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).not.toBeDisabled();
+    expect(radios[1]).toBeDisabled();
+  });
+
+  it('does not call onChange when individual item is disabled', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSRadioList label="Preference" value="" onChange={handleChange}>
+        <XDSRadioListItem label="Option A" value="a" isDisabled />
+      </XDSRadioList>,
+    );
+
+    await user.click(screen.getByLabelText('Option A'));
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('shows Required indicator when isRequired is true', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}} isRequired>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByText(/Required/)).toBeInTheDocument();
+  });
+
+  it('shows Optional indicator when isOptional is true', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}} isOptional>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByText(/Optional/)).toBeInTheDocument();
+  });
+
+  it('renders error status message', () => {
+    render(
+      <XDSRadioList
+        label="Preference"
+        value=""
+        onChange={() => {}}
+        status={{type: 'error', message: 'Please select an option'}}>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByText('Please select an option')).toBeInTheDocument();
+  });
+
+  it('renders warning status message', () => {
+    render(
+      <XDSRadioList
+        label="Preference"
+        value="a"
+        onChange={() => {}}
+        status={{type: 'warning', message: 'This may change later'}}>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByText('This may change later')).toBeInTheDocument();
+  });
+
+  it('renders success status message', () => {
+    render(
+      <XDSRadioList
+        label="Preference"
+        value="a"
+        onChange={() => {}}
+        status={{type: 'success', message: 'Great choice!'}}>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByText('Great choice!')).toBeInTheDocument();
+  });
+
+  it('sets aria-invalid on radiogroup when status is error', () => {
+    render(
+      <XDSRadioList
+        label="Preference"
+        value=""
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByRole('radiogroup')).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('renders startContent', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}}>
+        <XDSRadioListItem
+          label="Option A"
+          value="a"
+          startContent={<span data-testid="start">★</span>}
+        />
+      </XDSRadioList>,
+    );
+    expect(screen.getByTestId('start')).toBeInTheDocument();
+  });
+
+  it('renders endContent', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}}>
+        <XDSRadioListItem
+          label="Option A"
+          value="a"
+          endContent={<span data-testid="end">Badge</span>}
+        />
+      </XDSRadioList>,
+    );
+    expect(screen.getByTestId('end')).toBeInTheDocument();
+  });
+
+  it('supports data-testid on RadioList', () => {
+    render(
+      <XDSRadioList
+        label="Preference"
+        value=""
+        onChange={() => {}}
+        data-testid="my-radio-list">
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByTestId('my-radio-list')).toBeInTheDocument();
+  });
+
+  it('supports data-testid on RadioListItem', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}}>
+        <XDSRadioListItem
+          label="Option A"
+          value="a"
+          data-testid="my-radio-item"
+        />
+      </XDSRadioList>,
+    );
+    expect(screen.getByTestId('my-radio-item')).toBeInTheDocument();
+  });
+
+  it('visually hides label when isLabelHidden is true', () => {
+    render(
+      <XDSRadioList
+        label="Hidden label"
+        isLabelHidden
+        value=""
+        onChange={() => {}}>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    const label = screen.getByText('Hidden label');
+    expect(label).toBeInTheDocument();
+    // The radiogroup should still be labeled
+    expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-labelledby');
+  });
+
+  it('renders description on items', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}}>
+        <XDSRadioListItem
+          label="Option A"
+          value="a"
+          description="This is option A"
+        />
+      </XDSRadioList>,
+    );
+    expect(screen.getByText('This is option A')).toBeInTheDocument();
+  });
+
+  it('renders description on the radio list group', () => {
+    render(
+      <XDSRadioList
+        label="Preference"
+        description="Choose your preference"
+        value=""
+        onChange={() => {}}>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByText('Choose your preference')).toBeInTheDocument();
+  });
+
+  it('applies horizontal orientation', () => {
+    render(
+      <XDSRadioList
+        label="Preference"
+        value=""
+        onChange={() => {}}
+        orientation="horizontal">
+        <XDSRadioListItem label="Option A" value="a" />
+        <XDSRadioListItem label="Option B" value="b" />
+      </XDSRadioList>,
+    );
+    // The radiogroup should exist and contain items
+    const radiogroup = screen.getByRole('radiogroup');
+    expect(radiogroup).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(2);
+  });
+
+  it('sets aria-required on radiogroup when isRequired is true', () => {
+    render(
+      <XDSRadioList label="Preference" value="" onChange={() => {}} isRequired>
+        <XDSRadioListItem label="Option A" value="a" />
+      </XDSRadioList>,
+    );
+    expect(screen.getByRole('radiogroup')).toHaveAttribute(
+      'aria-required',
+      'true',
+    );
+  });
+});

--- a/packages/core/src/RadioList/XDSRadioList.test.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.test.tsx
@@ -278,7 +278,10 @@ describe('XDSRadioList', () => {
     const label = screen.getByText('Hidden label');
     expect(label).toBeInTheDocument();
     // The radiogroup should still be labeled
-    expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-labelledby');
+    expect(screen.getByRole('radiogroup')).toHaveAttribute(
+      'aria-label',
+      'Hidden label',
+    );
   });
 
   it('renders description on items', () => {

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -1,0 +1,262 @@
+/**
+ * @file XDSRadioList.tsx
+ * @input Uses React useId, createContext, ReactNode, XDSFieldLabel, XDSFieldStatus, XDSInputStatus
+ * @output Exports XDSRadioList component, XDSRadioListProps, RadioListContext
+ * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/RadioList/XDSRadioList.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/RadioList/index.ts (exports if types change)
+ * - /apps/storybook/stories/RadioList.stories.tsx (storybook stories)
+ */
+
+import {createContext, useId, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  typographyVars,
+  fontWeightVars,
+} from '../theme/tokens.stylex';
+import {XDSFieldStatus} from '../Field/XDSFieldStatus';
+import type {XDSInputStatus} from '../Field/types';
+
+export interface RadioListContextValue {
+  name: string;
+  value: string;
+  onChange: (value: string) => void;
+  isDisabled: boolean;
+  isRequired: boolean;
+  status?: XDSInputStatus;
+}
+
+export const RadioListContext = createContext<RadioListContextValue | null>(
+  null,
+);
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+  },
+  label: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-primary'],
+  },
+  labelDisabled: {
+    color: colorVars['--color-text-disabled'],
+  },
+  labelHidden: {
+    borderStyle: 'none',
+    clip: 'rect(0, 0, 0, 0)',
+    height: 1,
+    left: 0,
+    margin: -1,
+    overflow: 'hidden',
+    padding: 0,
+    pointerEvents: 'none',
+    position: 'absolute',
+    top: 0,
+    userSelect: 'none',
+    whiteSpace: 'nowrap',
+    width: 1,
+  },
+  optionalRequired: {
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+  },
+  description: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+  },
+  radiogroup: {
+    display: 'flex',
+    gap: spacingVars['--spacing-2'],
+  },
+  vertical: {
+    flexDirection: 'column',
+  },
+  horizontal: {
+    flexDirection: 'row',
+  },
+});
+
+export interface XDSRadioListProps {
+  /**
+   * Label text for the radio group (always rendered for accessibility).
+   */
+  label: string;
+  /**
+   * Whether to visually hide the label (still accessible to screen readers).
+   * @default false
+   */
+  isLabelHidden?: boolean;
+  /**
+   * Description text displayed below the label.
+   */
+  description?: string;
+  /**
+   * The currently selected value.
+   */
+  value: string;
+  /**
+   * Callback fired when the selected value changes.
+   */
+  onChange: (value: string) => void;
+  /**
+   * Layout direction of the radio items.
+   * @default "vertical"
+   */
+  orientation?: 'vertical' | 'horizontal';
+  /**
+   * Whether all radio items are disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Whether the radio group is required.
+   * @default false
+   */
+  isRequired?: boolean;
+  /**
+   * Whether the field is optional. Mutually exclusive with isRequired.
+   * @default false
+   */
+  isOptional?: boolean;
+  /**
+   * Status indicator for the radio group.
+   * When set with a message, displays a colored message box below the group.
+   */
+  status?: XDSInputStatus;
+  /**
+   * Tooltip text to display in an info icon at the end of the label.
+   */
+  labelTooltip?: string;
+  /**
+   * Additional styles for the outer container.
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * Test ID for the outer container.
+   */
+  'data-testid'?: string;
+  /**
+   * Radio list items to render.
+   */
+  children: ReactNode;
+}
+
+/**
+ * A radio group component for single-value selection.
+ *
+ * @example
+ * ```tsx
+ * <XDSRadioList
+ *   label="Notification preference"
+ *   value={selected}
+ *   onChange={setSelected}
+ * >
+ *   <XDSRadioListItem label="Email" value="email" />
+ *   <XDSRadioListItem label="SMS" value="sms" />
+ *   <XDSRadioListItem label="Push" value="push" />
+ * </XDSRadioList>
+ * ```
+ */
+export function XDSRadioList({
+  label,
+  isLabelHidden = false,
+  description,
+  value,
+  onChange,
+  orientation = 'vertical',
+  isDisabled = false,
+  isRequired = false,
+  isOptional = false,
+  status,
+  labelTooltip: _labelTooltip,
+  xstyle,
+  'data-testid': dataTestId,
+  children,
+}: XDSRadioListProps) {
+  const name = useId();
+  const labelID = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
+
+  const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
+
+  const contextValue: RadioListContextValue = {
+    name,
+    value,
+    onChange,
+    isDisabled,
+    isRequired,
+    status,
+  };
+
+  return (
+    <div data-testid={dataTestId} {...stylex.props(styles.container, xstyle)}>
+      <span
+        id={labelID}
+        {...stylex.props(
+          styles.label,
+          isDisabled && styles.labelDisabled,
+          isLabelHidden && styles.labelHidden,
+        )}>
+        {label}
+        {statusText && (
+          <span {...stylex.props(styles.optionalRequired)}>
+            {' '}
+            ∙ {statusText}
+          </span>
+        )}
+      </span>
+      {description && (
+        <span id={descriptionID} {...stylex.props(styles.description)}>
+          {description}
+        </span>
+      )}
+      <div
+        role="radiogroup"
+        aria-labelledby={labelID}
+        aria-describedby={
+          [
+            description ? descriptionID : null,
+            status?.message ? statusMessageID : null,
+          ]
+            .filter(Boolean)
+            .join(' ') || undefined
+        }
+        aria-invalid={status?.type === 'error' ? true : undefined}
+        aria-required={isRequired || undefined}
+        {...stylex.props(
+          styles.radiogroup,
+          orientation === 'vertical' ? styles.vertical : styles.horizontal,
+        )}>
+        <RadioListContext.Provider value={contextValue}>
+          {children}
+        </RadioListContext.Provider>
+      </div>
+      {status?.message && (
+        <XDSFieldStatus
+          type={status.type}
+          message={status.message}
+          id={statusMessageID}
+          variant="detached"
+        />
+      )}
+    </div>
+  );
+}
+
+XDSRadioList.displayName = 'XDSRadioList';

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -23,12 +23,18 @@ import {
 import {XDSFieldStatus} from '../Field/XDSFieldStatus';
 import type {XDSInputStatus} from '../Field/types';
 
+/**
+ * Size of the radio controls, matching CheckboxInput sizes.
+ */
+export type XDSRadioListSize = 'sm' | 'md';
+
 export interface RadioListContextValue {
   name: string;
   value: string;
   onChange: (value: string) => void;
   isDisabled: boolean;
   isRequired: boolean;
+  size: XDSRadioListSize;
   status?: XDSInputStatus;
 }
 
@@ -139,6 +145,13 @@ export interface XDSRadioListProps {
    */
   status?: XDSInputStatus;
   /**
+   * The size of the radio controls.
+   * - 'sm': Compact size (18px radio, 20px wrapper)
+   * - 'md': Default size (22px radio, 24px wrapper)
+   * @default 'md'
+   */
+  size?: XDSRadioListSize;
+  /**
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
@@ -182,6 +195,7 @@ export function XDSRadioList({
   isDisabled = false,
   isRequired = false,
   isOptional = false,
+  size = 'md',
   status,
   labelTooltip: _labelTooltip,
   xstyle,
@@ -201,6 +215,7 @@ export function XDSRadioList({
     onChange,
     isDisabled,
     isRequired,
+    size,
     status,
   };
 

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSRadioList.tsx
- * @input Uses React useId, createContext, ReactNode, XDSFieldLabel, XDSFieldStatus, XDSInputStatus
+ * @input Uses React useId, createContext, ReactNode, XDSField, XDSInputStatus
  * @output Exports XDSRadioList component, XDSRadioListProps, RadioListContext
  * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
  *
@@ -13,14 +13,8 @@
 import {createContext, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {
-  colorVars,
-  spacingVars,
-  textSizeVars,
-  typographyVars,
-  fontWeightVars,
-} from '../theme/tokens.stylex';
-import {XDSFieldStatus} from '../Field/XDSFieldStatus';
+import {spacingVars} from '../theme/tokens.stylex';
+import {XDSField} from '../Field/XDSField';
 import type {XDSInputStatus} from '../Field/types';
 
 /**
@@ -43,48 +37,6 @@ export const RadioListContext = createContext<RadioListContextValue | null>(
 );
 
 const styles = stylex.create({
-  container: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-1'],
-  },
-  label: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
-    fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    color: colorVars['--color-text-primary'],
-  },
-  labelDisabled: {
-    color: colorVars['--color-text-disabled'],
-  },
-  labelHidden: {
-    borderStyle: 'none',
-    clip: 'rect(0, 0, 0, 0)',
-    height: 1,
-    left: 0,
-    margin: -1,
-    overflow: 'hidden',
-    padding: 0,
-    pointerEvents: 'none',
-    position: 'absolute',
-    top: 0,
-    userSelect: 'none',
-    whiteSpace: 'nowrap',
-    width: 1,
-  },
-  optionalRequired: {
-    fontWeight: fontWeightVars['--font-weight-normal'],
-    fontSize: textSizeVars['--text-xsm'],
-    color: colorVars['--color-text-secondary'],
-  },
-  description: {
-    fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
-    color: colorVars['--color-text-secondary'],
-  },
   radiogroup: {
     display: 'flex',
     gap: spacingVars['--spacing-2'],
@@ -197,17 +149,15 @@ export function XDSRadioList({
   isOptional = false,
   size = 'md',
   status,
-  labelTooltip: _labelTooltip,
+  labelTooltip,
   xstyle,
   'data-testid': dataTestId,
   children,
 }: XDSRadioListProps) {
   const name = useId();
-  const labelID = useId();
+  const inputID = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
-
-  const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
 
   const contextValue: RadioListContextValue = {
     name,
@@ -220,30 +170,29 @@ export function XDSRadioList({
   };
 
   return (
-    <div data-testid={dataTestId} {...stylex.props(styles.container, xstyle)}>
-      <span
-        id={labelID}
-        {...stylex.props(
-          styles.label,
-          isDisabled && styles.labelDisabled,
-          isLabelHidden && styles.labelHidden,
-        )}>
-        {label}
-        {statusText && (
-          <span {...stylex.props(styles.optionalRequired)}>
-            {' '}
-            ∙ {statusText}
-          </span>
-        )}
-      </span>
-      {description && (
-        <span id={descriptionID} {...stylex.props(styles.description)}>
-          {description}
-        </span>
-      )}
+    <XDSField
+      data-testid={dataTestId}
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={inputID}
+      descriptionID={description ? descriptionID : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageID : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}
+      {...stylex.props(xstyle)}>
       <div
         role="radiogroup"
-        aria-labelledby={labelID}
+        aria-label={label}
         aria-describedby={
           [
             description ? descriptionID : null,
@@ -262,15 +211,7 @@ export function XDSRadioList({
           {children}
         </RadioListContext.Provider>
       </div>
-      {status?.message && (
-        <XDSFieldStatus
-          type={status.type}
-          message={status.message}
-          id={statusMessageID}
-          variant="detached"
-        />
-      )}
-    </div>
+    </XDSField>
   );
 }
 

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -81,9 +81,16 @@ const styles = stylex.create({
         `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-hover-tint']} 15%)`,
     },
   },
-  radioFocused: {
-    outline: `2px solid ${colorVars['--color-focus-outline']}`,
-    outlineOffset: 2,
+  radioWrapperFocus: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-within': '2px',
+    },
+    borderRadius: '50%',
   },
   radioDisabled: {
     opacity: 0.5,
@@ -249,7 +256,12 @@ export function XDSRadioListItem({
       {startContent && (
         <div {...stylex.props(styles.startContent)}>{startContent}</div>
       )}
-      <div {...stylex.props(styles.radioWrapper, wrapperSizeStyles[size])}>
+      <div
+        {...stylex.props(
+          styles.radioWrapper,
+          wrapperSizeStyles[size],
+          !isDisabled && styles.radioWrapperFocus,
+        )}>
         <input
           id={id}
           type="radio"

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -34,8 +34,6 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
-    width: 20,
-    height: 20,
   },
   input: {
     position: 'absolute',
@@ -44,8 +42,6 @@ const styles = stylex.create({
     opacity: 0,
     cursor: 'pointer',
     zIndex: 1,
-    width: 20,
-    height: 20,
   },
   inputDisabled: {
     cursor: 'not-allowed',
@@ -54,8 +50,6 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    width: 18,
-    height: 18,
     borderWidth: 1,
     borderStyle: 'solid',
     borderRadius: '50%',
@@ -99,8 +93,6 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-deemphasized'],
   },
   innerDot: {
-    width: 8,
-    height: 8,
     borderRadius: '50%',
     backgroundColor: colorVars['--color-icon-on-media'],
   },
@@ -136,6 +128,49 @@ const styles = stylex.create({
     alignItems: 'center',
     flexShrink: 0,
     marginInlineStart: 'auto',
+  },
+});
+
+// Size styles matching CheckboxInput dimensions
+const wrapperSizeStyles = stylex.create({
+  sm: {
+    width: 20,
+    height: 20,
+  },
+  md: {
+    width: 24,
+    height: 24,
+  },
+});
+
+const radioSizeStyles = stylex.create({
+  sm: {
+    width: 18,
+    height: 18,
+  },
+  md: {
+    width: 22,
+    height: 22,
+  },
+});
+
+const dotSizeStyles = stylex.create({
+  sm: {
+    width: 8,
+    height: 8,
+  },
+  md: {
+    width: 10,
+    height: 10,
+  },
+});
+
+const labelWrapperSizeStyles = stylex.create({
+  sm: {
+    marginTop: 1,
+  },
+  md: {
+    marginTop: 3,
   },
 });
 
@@ -202,6 +237,7 @@ export function XDSRadioListItem({
   const descriptionID = useId();
   const isDisabled = context.isDisabled || isItemDisabled;
   const isChecked = context.value === value;
+  const size = context.size;
 
   return (
     <div
@@ -213,7 +249,7 @@ export function XDSRadioListItem({
       {startContent && (
         <div {...stylex.props(styles.startContent)}>{startContent}</div>
       )}
-      <div {...stylex.props(styles.radioWrapper)}>
+      <div {...stylex.props(styles.radioWrapper, wrapperSizeStyles[size])}>
         <input
           id={id}
           type="radio"
@@ -224,20 +260,27 @@ export function XDSRadioListItem({
           required={context.isRequired}
           onChange={() => context.onChange(value)}
           aria-describedby={description ? descriptionID : undefined}
-          {...stylex.props(styles.input, isDisabled && styles.inputDisabled)}
+          {...stylex.props(
+            styles.input,
+            wrapperSizeStyles[size],
+            isDisabled && styles.inputDisabled,
+          )}
         />
         <div
           aria-hidden="true"
           {...stylex.props(
             styles.radio,
+            radioSizeStyles[size],
             isChecked ? styles.radioChecked : styles.radioUnchecked,
             isDisabled && styles.radioDisabled,
             isDisabled && !isChecked && styles.radioDisabledUnchecked,
           )}>
-          {isChecked && <div {...stylex.props(styles.innerDot)} />}
+          {isChecked && (
+            <div {...stylex.props(styles.innerDot, dotSizeStyles[size])} />
+          )}
         </div>
       </div>
-      <div {...stylex.props(styles.labelWrapper)}>
+      <div {...stylex.props(styles.labelWrapper, labelWrapperSizeStyles[size])}>
         <label
           htmlFor={id}
           {...stylex.props(styles.label, isDisabled && styles.labelDisabled)}>

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -1,0 +1,259 @@
+/**
+ * @file XDSRadioListItem.tsx
+ * @input Uses React useContext, useId, RadioListContext
+ * @output Exports XDSRadioListItem component, XDSRadioListItemProps
+ * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/RadioList/XDSRadioList.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/RadioList/index.ts (exports if types change)
+ * - /apps/storybook/stories/RadioList.stories.tsx (storybook stories)
+ */
+
+import {useContext, useId, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  transitionVars,
+  typographyVars,
+  fontWeightVars,
+} from '../theme/tokens.stylex';
+import {RadioListContext} from './XDSRadioList';
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: spacingVars['--spacing-2'],
+  },
+  radioWrapper: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    width: 20,
+    height: 20,
+  },
+  input: {
+    position: 'absolute',
+    margin: 0,
+    padding: 0,
+    opacity: 0,
+    cursor: 'pointer',
+    zIndex: 1,
+    width: 20,
+    height: 20,
+  },
+  inputDisabled: {
+    cursor: 'not-allowed',
+  },
+  radio: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 18,
+    height: 18,
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderRadius: '50%',
+    transitionProperty: 'background-color, border-color',
+    transitionDuration: transitionVars['--transition-fast'],
+    boxSizing: 'border-box',
+  },
+  radioUnchecked: {
+    borderColor: {
+      default: colorVars['--color-divider-emphasized'],
+      [stylex.when.ancestor(':hover')]:
+        `color-mix(in srgb, ${colorVars['--color-divider-emphasized']}, ${colorVars['--color-hover-tint']} 20%)`,
+    },
+    backgroundColor: {
+      default: colorVars['--color-surface'],
+      [stylex.when.ancestor(':hover')]:
+        `color-mix(in srgb, ${colorVars['--color-surface']}, ${colorVars['--color-hover-tint']} 5%)`,
+    },
+  },
+  radioChecked: {
+    borderColor: {
+      default: colorVars['--color-accent'],
+      [stylex.when.ancestor(':hover')]:
+        `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-hover-tint']} 15%)`,
+    },
+    backgroundColor: {
+      default: colorVars['--color-accent'],
+      [stylex.when.ancestor(':hover')]:
+        `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-hover-tint']} 15%)`,
+    },
+  },
+  radioFocused: {
+    outline: `2px solid ${colorVars['--color-focus-outline']}`,
+    outlineOffset: 2,
+  },
+  radioDisabled: {
+    opacity: 0.5,
+    borderColor: colorVars['--color-divider'],
+  },
+  radioDisabledUnchecked: {
+    backgroundColor: colorVars['--color-deemphasized'],
+  },
+  innerDot: {
+    width: 8,
+    height: 8,
+    borderRadius: '50%',
+    backgroundColor: colorVars['--color-icon-on-media'],
+  },
+  labelWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
+    marginTop: 1,
+  },
+  label: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-primary'],
+    cursor: 'pointer',
+  },
+  labelDisabled: {
+    color: colorVars['--color-text-disabled'],
+    cursor: 'not-allowed',
+  },
+  description: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+  },
+  startContent: {
+    display: 'flex',
+    alignItems: 'center',
+    flexShrink: 0,
+  },
+  endContent: {
+    display: 'flex',
+    alignItems: 'center',
+    flexShrink: 0,
+    marginInlineStart: 'auto',
+  },
+});
+
+export interface XDSRadioListItemProps {
+  /**
+   * Label text for the radio item.
+   */
+  label: string;
+  /**
+   * Value of this radio item.
+   */
+  value: string;
+  /**
+   * Description text displayed below the label.
+   */
+  description?: string;
+  /**
+   * Whether this individual radio item is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Content to render before the radio circle.
+   */
+  startContent?: ReactNode;
+  /**
+   * Content to render after the label.
+   */
+  endContent?: ReactNode;
+  /**
+   * Test ID for the radio item container.
+   */
+  'data-testid'?: string;
+}
+
+/**
+ * An individual radio item within an XDSRadioList.
+ *
+ * @example
+ * ```tsx
+ * <XDSRadioListItem label="Email" value="email" />
+ * <XDSRadioListItem
+ *   label="SMS"
+ *   value="sms"
+ *   description="Standard messaging rates apply"
+ * />
+ * ```
+ */
+export function XDSRadioListItem({
+  label,
+  value,
+  description,
+  isDisabled: isItemDisabled = false,
+  startContent,
+  endContent,
+  'data-testid': dataTestId,
+}: XDSRadioListItemProps) {
+  const context = useContext(RadioListContext);
+  if (!context) {
+    throw new Error('XDSRadioListItem must be used within an XDSRadioList');
+  }
+
+  const id = useId();
+  const descriptionID = useId();
+  const isDisabled = context.isDisabled || isItemDisabled;
+  const isChecked = context.value === value;
+
+  return (
+    <div
+      data-testid={dataTestId}
+      {...stylex.props(
+        styles.container,
+        !isDisabled && stylex.defaultMarker(),
+      )}>
+      {startContent && (
+        <div {...stylex.props(styles.startContent)}>{startContent}</div>
+      )}
+      <div {...stylex.props(styles.radioWrapper)}>
+        <input
+          id={id}
+          type="radio"
+          name={context.name}
+          value={value}
+          checked={isChecked}
+          disabled={isDisabled}
+          required={context.isRequired}
+          onChange={() => context.onChange(value)}
+          aria-describedby={description ? descriptionID : undefined}
+          {...stylex.props(styles.input, isDisabled && styles.inputDisabled)}
+        />
+        <div
+          aria-hidden="true"
+          {...stylex.props(
+            styles.radio,
+            isChecked ? styles.radioChecked : styles.radioUnchecked,
+            isDisabled && styles.radioDisabled,
+            isDisabled && !isChecked && styles.radioDisabledUnchecked,
+          )}>
+          {isChecked && <div {...stylex.props(styles.innerDot)} />}
+        </div>
+      </div>
+      <div {...stylex.props(styles.labelWrapper)}>
+        <label
+          htmlFor={id}
+          {...stylex.props(styles.label, isDisabled && styles.labelDisabled)}>
+          {label}
+        </label>
+        {description && (
+          <span id={descriptionID} {...stylex.props(styles.description)}>
+            {description}
+          </span>
+        )}
+      </div>
+      {endContent && (
+        <div {...stylex.props(styles.endContent)}>{endContent}</div>
+      )}
+    </div>
+  );
+}
+
+XDSRadioListItem.displayName = 'XDSRadioListItem';

--- a/packages/core/src/RadioList/index.ts
+++ b/packages/core/src/RadioList/index.ts
@@ -1,0 +1,13 @@
+/**
+ * @file index.ts
+ * @input Imports XDSRadioList, XDSRadioListItem components and types
+ * @output Exports XDSRadioList, XDSRadioListProps, XDSRadioListItem, XDSRadioListItemProps
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header
+ */
+
+export {XDSRadioList} from './XDSRadioList';
+export type {XDSRadioListProps} from './XDSRadioList';
+export {XDSRadioListItem} from './XDSRadioListItem';
+export type {XDSRadioListItemProps} from './XDSRadioListItem';

--- a/packages/core/src/RadioList/index.ts
+++ b/packages/core/src/RadioList/index.ts
@@ -8,6 +8,6 @@
  */
 
 export {XDSRadioList} from './XDSRadioList';
-export type {XDSRadioListProps} from './XDSRadioList';
+export type {XDSRadioListProps, XDSRadioListSize} from './XDSRadioList';
 export {XDSRadioListItem} from './XDSRadioListItem';
 export type {XDSRadioListItemProps} from './XDSRadioListItem';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './Button';
 export * from './Calendar';
 export * from './Center';
 export * from './CheckboxInput';
+export * from './RadioList';
 export * from './CloseButton';
 export * from './Divider';
 export * from './Link';


### PR DESCRIPTION
Implements the radio list component per the spec in #39.

## Components
- **XDSRadioList** — Group container with label, description, status, orientation
- **XDSRadioListItem** — Individual radio option with startContent/endContent slots

## Design decisions
- `orientation` (not `direction`) — corpus standard across Radix, Ark, React Aria
- `string` value type — simpler than generic, matches most external systems
- Unified `status` object — matches TextInput, Selector, Switch, CheckboxInput
- `startContent`/`endContent` on items — flexible slots for badges, icons, custom content
- Composition pattern — children-based, consistent with internal API

## Follows
- Input props convention: `.context/decisions/input-props-convention.md`
- Sibling patterns: CheckboxInput, Switch, TextInput

Closes #39