### PR TITLE
Add XDSSlider component

### DIFF
--- a/apps/storybook/stories/Slider.stories.tsx
+++ b/apps/storybook/stories/Slider.stories.tsx
@@ -1,0 +1,236 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSSlider} from '@xds/core/Slider';
+
+const meta: Meta<typeof XDSSlider> = {
+  title: 'Core/XDSSlider',
+  component: XDSSlider,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Label text (required)',
+    },
+    isLabelHidden: {
+      control: 'boolean',
+      description:
+        'Visually hide the label (still accessible to screen readers)',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Whether the slider is disabled',
+    },
+    min: {
+      control: 'number',
+      description: 'Minimum value',
+    },
+    max: {
+      control: 'number',
+      description: 'Maximum value',
+    },
+    step: {
+      control: 'number',
+      description: 'Step increment',
+    },
+    orientation: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'Slider orientation',
+    },
+    valueDisplay: {
+      control: 'select',
+      options: ['tooltip', 'text', 'none'],
+      description: 'How the value is displayed',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSSlider>;
+
+export const Default: Story = {
+  render: args => {
+    const [value, setValue] = useState(50);
+    return <XDSSlider {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Volume',
+  },
+};
+
+export const Range: Story = {
+  render: args => {
+    const [value, setValue] = useState<[number, number]>([20, 80]);
+    return <XDSSlider {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Price range',
+  },
+};
+
+export const WithMarks: Story = {
+  render: args => {
+    const [value, setValue] = useState(50);
+    return <XDSSlider {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Volume',
+    marks: [
+      {value: 0, label: '0'},
+      {value: 25, label: '25'},
+      {value: 50, label: '50'},
+      {value: 75, label: '75'},
+      {value: 100, label: '100'},
+    ],
+  },
+};
+
+export const CustomStep: Story = {
+  render: args => {
+    const [value, setValue] = useState(50);
+    return (
+      <XDSSlider
+        {...args}
+        value={value}
+        onChange={setValue}
+        valueDisplay="text"
+      />
+    );
+  },
+  args: {
+    label: 'Quantity',
+    min: 0,
+    max: 100,
+    step: 10,
+  },
+};
+
+export const WithFormatValue: Story = {
+  render: args => {
+    const [value, setValue] = useState(72);
+    return (
+      <XDSSlider
+        {...args}
+        value={value}
+        onChange={setValue}
+        valueDisplay="text"
+      />
+    );
+  },
+  args: {
+    label: 'Temperature',
+    min: 60,
+    max: 90,
+    step: 1,
+    formatValue: (v: number) => `${v}°F`,
+  },
+};
+
+export const Disabled: Story = {
+  render: args => {
+    return <XDSSlider {...args} />;
+  },
+  args: {
+    label: 'Volume',
+    value: 50,
+    isDisabled: true,
+  },
+};
+
+export const VerticalOrientation: Story = {
+  render: args => {
+    const [value, setValue] = useState(50);
+    return (
+      <div style={{height: 200}}>
+        <XDSSlider {...args} value={value} onChange={setValue} />
+      </div>
+    );
+  },
+  args: {
+    label: 'Volume',
+    orientation: 'vertical',
+  },
+};
+
+export const WithStatus: Story = {
+  render: () => {
+    const [value1, setValue1] = useState(95);
+    const [value2, setValue2] = useState(50);
+    const [value3, setValue3] = useState(75);
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '24px',
+          maxWidth: '400px',
+        }}>
+        <XDSSlider
+          label="CPU Usage"
+          value={value1}
+          onChange={setValue1}
+          status={{type: 'error', message: 'CPU usage is critically high'}}
+        />
+        <XDSSlider
+          label="Memory"
+          value={value2}
+          onChange={setValue2}
+          status={{type: 'warning', message: 'Memory usage is moderate'}}
+        />
+        <XDSSlider
+          label="Disk"
+          value={value3}
+          onChange={setValue3}
+          status={{type: 'success', message: 'Disk usage is healthy'}}
+        />
+      </div>
+    );
+  },
+};
+
+export const AllVariations: Story = {
+  render: () => {
+    const [v1, setV1] = useState(50);
+    const [v2, setV2] = useState<[number, number]>([20, 80]);
+    const [v3, setV3] = useState(30);
+    const [v4, setV4] = useState(72);
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '32px',
+          maxWidth: '400px',
+        }}>
+        <XDSSlider label="Default slider" value={v1} onChange={setV1} />
+        <XDSSlider label="Range slider" value={v2} onChange={setV2} />
+        <XDSSlider
+          label="With marks"
+          value={v3}
+          onChange={setV3}
+          marks={[
+            {value: 0, label: '0%'},
+            {value: 50, label: '50%'},
+            {value: 100, label: '100%'},
+          ]}
+        />
+        <XDSSlider
+          label="With text display"
+          value={v4}
+          onChange={setV4}
+          formatValue={v => `${v}°F`}
+          valueDisplay="text"
+          min={60}
+          max={90}
+        />
+        <XDSSlider label="Disabled" value={50} isDisabled />
+        <XDSSlider
+          label="No value display"
+          value={v1}
+          onChange={setV1}
+          valueDisplay="none"
+        />
+      </div>
+    );
+  },
+};

--- a/packages/core/src/Slider/XDSSlider.test.tsx
+++ b/packages/core/src/Slider/XDSSlider.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * @file XDSSlider.test.tsx
+ * @input Uses vitest, @testing-library/react, userEvent, XDSSlider component
+ * @output Unit tests for XDSSlider component behavior
+ * @position Testing; validates XDSSlider.tsx implementation
+ *
+ * SYNC: When XDSSlider.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, act} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSSlider} from './XDSSlider';
+
+describe('XDSSlider', () => {
+  it('renders with label', () => {
+    render(<XDSSlider label="Volume" value={50} />);
+    expect(screen.getByText('Volume')).toBeInTheDocument();
+  });
+
+  it('single value mode renders one slider thumb', () => {
+    render(<XDSSlider label="Volume" value={50} />);
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders).toHaveLength(1);
+  });
+
+  it('range mode renders two slider thumbs', () => {
+    render(
+      <XDSSlider label="Price range" value={[20, 80] as [number, number]} />,
+    );
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders).toHaveLength(2);
+  });
+
+  it('sets aria-valuemin, aria-valuemax, aria-valuenow', () => {
+    render(<XDSSlider label="Volume" value={50} min={0} max={100} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuemin', '0');
+    expect(slider).toHaveAttribute('aria-valuemax', '100');
+    expect(slider).toHaveAttribute('aria-valuenow', '50');
+  });
+
+  it('sets aria-valuetext with formatValue', () => {
+    render(
+      <XDSSlider label="Temperature" value={72} formatValue={v => `${v}°F`} />,
+    );
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuetext', '72°F');
+  });
+
+  it('does not set aria-valuetext without formatValue', () => {
+    render(<XDSSlider label="Volume" value={50} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).not.toHaveAttribute('aria-valuetext');
+  });
+
+  it('disables thumbs when isDisabled is true', () => {
+    render(<XDSSlider label="Volume" value={50} isDisabled />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-disabled', 'true');
+    expect(slider).toHaveAttribute('tabIndex', '-1');
+  });
+
+  it('arrow right increases value by step', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSSlider label="Volume" value={50} step={5} onChange={handleChange} />,
+    );
+    const slider = screen.getByRole('slider');
+    act(() => {
+      slider.focus();
+    });
+    await user.keyboard('{ArrowRight}');
+    expect(handleChange).toHaveBeenCalledWith(55);
+  });
+
+  it('arrow left decreases value by step', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSSlider label="Volume" value={50} step={5} onChange={handleChange} />,
+    );
+    const slider = screen.getByRole('slider');
+    act(() => {
+      slider.focus();
+    });
+    await user.keyboard('{ArrowLeft}');
+    expect(handleChange).toHaveBeenCalledWith(45);
+  });
+
+  it('Home key sets value to min', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSSlider
+        label="Volume"
+        value={50}
+        min={10}
+        max={100}
+        onChange={handleChange}
+      />,
+    );
+    const slider = screen.getByRole('slider');
+    act(() => {
+      slider.focus();
+    });
+    await user.keyboard('{Home}');
+    expect(handleChange).toHaveBeenCalledWith(10);
+  });
+
+  it('End key sets value to max', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSSlider
+        label="Volume"
+        value={50}
+        min={0}
+        max={90}
+        onChange={handleChange}
+      />,
+    );
+    const slider = screen.getByRole('slider');
+    act(() => {
+      slider.focus();
+    });
+    await user.keyboard('{End}');
+    expect(handleChange).toHaveBeenCalledWith(90);
+  });
+
+  it('does not change value on keyboard when disabled', () => {
+    const handleChange = vi.fn();
+    render(
+      <XDSSlider
+        label="Volume"
+        value={50}
+        onChange={handleChange}
+        isDisabled
+      />,
+    );
+    const slider = screen.getByRole('slider');
+    // Disabled slider has tabIndex=-1, so it won't receive keyboard events
+    // via normal tabbing. We verify the aria-disabled attribute instead.
+    expect(slider).toHaveAttribute('aria-disabled', 'true');
+    expect(slider).toHaveAttribute('tabIndex', '-1');
+  });
+
+  it('renders marks', () => {
+    render(
+      <XDSSlider
+        label="Volume"
+        value={50}
+        marks={[{value: 0}, {value: 50}, {value: 100}]}
+      />,
+    );
+    const marks = screen.getAllByTestId('slider-mark');
+    expect(marks).toHaveLength(3);
+  });
+
+  it('renders mark labels', () => {
+    render(
+      <XDSSlider
+        label="Volume"
+        value={50}
+        marks={[
+          {value: 0, label: 'Low'},
+          {value: 100, label: 'High'},
+        ]}
+      />,
+    );
+    expect(screen.getByText('Low')).toBeInTheDocument();
+    expect(screen.getByText('High')).toBeInTheDocument();
+  });
+
+  it('renders status messages', () => {
+    render(
+      <XDSSlider
+        label="Volume"
+        value={50}
+        status={{type: 'error', message: 'Value too high'}}
+      />,
+    );
+    expect(screen.getByText('Value too high')).toBeInTheDocument();
+  });
+
+  it('sets aria-invalid when status type is error', () => {
+    render(
+      <XDSSlider
+        label="Volume"
+        value={50}
+        status={{type: 'error', message: 'Value too high'}}
+      />,
+    );
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('applies data-testid', () => {
+    render(<XDSSlider label="Volume" value={50} data-testid="volume-slider" />);
+    expect(screen.getByTestId('volume-slider')).toBeInTheDocument();
+  });
+
+  it('sets aria-orientation for vertical', () => {
+    render(<XDSSlider label="Volume" value={50} orientation="vertical" />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-orientation', 'vertical');
+  });
+
+  it('sets aria-orientation for horizontal', () => {
+    render(<XDSSlider label="Volume" value={50} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-orientation', 'horizontal');
+  });
+
+  it('range thumbs have correct aria-labels', () => {
+    render(
+      <XDSSlider label="Price range" value={[20, 80] as [number, number]} />,
+    );
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders[0]).toHaveAttribute('aria-label', 'Minimum value');
+    expect(sliders[1]).toHaveAttribute('aria-label', 'Maximum value');
+  });
+
+  it('single thumb uses label as aria-label', () => {
+    render(<XDSSlider label="Volume" value={50} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-label', 'Volume');
+  });
+
+  it('uses custom min and max', () => {
+    render(<XDSSlider label="Temperature" value={72} min={60} max={90} />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAttribute('aria-valuemin', '60');
+    expect(slider).toHaveAttribute('aria-valuemax', '90');
+    expect(slider).toHaveAttribute('aria-valuenow', '72');
+  });
+
+  it('range mode sets correct aria values on both thumbs', () => {
+    render(
+      <XDSSlider
+        label="Range"
+        value={[25, 75] as [number, number]}
+        min={0}
+        max={100}
+      />,
+    );
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders[0]).toHaveAttribute('aria-valuenow', '25');
+    expect(sliders[1]).toHaveAttribute('aria-valuenow', '75');
+  });
+});

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -529,7 +529,7 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
         : label;
 
       const useTooltip = valueDisplay === 'tooltip';
-      const tooltipPlacement = isHorizontal ? 'above' : 'before';
+      const tooltipPlacement = isHorizontal ? 'above' : 'start';
 
       const thumbElement = (
         <div

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSlider.tsx
- * @input Uses React forwardRef, useId, useRef, useCallback, useState, XDSFieldLabel, XDSFieldStatus, XDSInputStatus
+ * @input Uses React forwardRef, useId, useRef, useCallback, XDSField, XDSTooltip
  * @output Exports XDSSlider component, XDSSliderProps, XDSSliderSingleProps, XDSSliderRangeProps, XDSSliderBaseProps
  * @position Core implementation; consumed by index.ts, tested by XDSSlider.test.tsx
  *
@@ -29,8 +29,7 @@ import {
   elevationVars,
   textSizeVars,
 } from '../theme/tokens.stylex';
-import {XDSFieldLabel} from '../Field/XDSFieldLabel';
-import {XDSFieldStatus} from '../Field/XDSFieldStatus';
+import {XDSField} from '../Field/XDSField';
 import {XDSTooltip} from '../Layer/XDSTooltip';
 import type {XDSInputStatus} from '../Field/types';
 
@@ -109,21 +108,6 @@ const THUMB_SIZE = 20;
 // =============================================================================
 
 const styles = stylex.create({
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-1'],
-  },
-  labelWrapper: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-0-5'],
-  },
-  description: {
-    fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
-    color: colorVars['--color-text-secondary'],
-  },
   sliderRow: {
     display: 'flex',
     alignItems: 'center',
@@ -138,12 +122,12 @@ const styles = stylex.create({
     userSelect: 'none',
   },
   trackContainerHorizontal: {
-    height: THUMB_SIZE + 8,
+    height: THUMB_SIZE,
     width: '100%',
     cursor: 'pointer',
   },
   trackContainerVertical: {
-    width: THUMB_SIZE + 8,
+    width: THUMB_SIZE,
     height: 160,
     flexDirection: 'column',
     justifyContent: 'center',
@@ -192,7 +176,7 @@ const styles = stylex.create({
     width: THUMB_SIZE,
     height: THUMB_SIZE,
     borderRadius: radiusVars['--radius-rounded'],
-    backgroundColor: colorVars['--color-surface'],
+    backgroundColor: colorVars['--color-popover'],
     boxShadow: elevationVars['--elevation-thumb'],
     transform: 'translate(-50%, -50%)',
     transitionProperty: 'box-shadow',
@@ -267,11 +251,11 @@ const styles = stylex.create({
   },
   markLabelHorizontal: {
     transform: 'translateX(-50%)',
-    top: THUMB_SIZE / 2 + 8,
+    top: THUMB_SIZE / 2 + 4,
   },
   markLabelVertical: {
     transform: 'translateY(50%)',
-    left: THUMB_SIZE / 2 + 8,
+    left: THUMB_SIZE / 2 + 4,
   },
 });
 
@@ -617,24 +601,26 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
       ) : null;
 
     return (
-      <div data-testid={testId} {...stylex.props(styles.root, xstyle)}>
-        <div {...stylex.props(styles.labelWrapper)}>
-          <XDSFieldLabel
-            label={label}
-            inputID={id}
-            isLabelHidden={isLabelHidden}
-            isDisabled={isDisabled}
-            isOptional={isOptional}
-            isRequired={isRequired}
-            tooltip={labelTooltip}
-          />
-          {description && (
-            <span id={descriptionID} {...stylex.props(styles.description)}>
-              {description}
-            </span>
-          )}
-        </div>
-
+      <XDSField
+        data-testid={testId}
+        label={label}
+        isLabelHidden={isLabelHidden}
+        description={description}
+        inputID={id}
+        descriptionID={description ? descriptionID : undefined}
+        isOptional={isOptional}
+        isRequired={isRequired}
+        status={
+          status
+            ? {
+                type: status.type,
+                message: status.message,
+                messageID: status.message ? statusMessageID : undefined,
+              }
+            : undefined
+        }
+        labelTooltip={labelTooltip}
+        {...stylex.props(xstyle)}>
         <div {...stylex.props(styles.sliderRow)}>
           <div
             ref={node => {
@@ -729,16 +715,7 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
 
           {textDisplay}
         </div>
-
-        {status?.message && (
-          <XDSFieldStatus
-            type={status.type}
-            message={status.message}
-            id={statusMessageID}
-            variant="detached"
-          />
-        )}
-      </div>
+      </XDSField>
     );
   },
 );

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSlider.tsx
- * @input Uses React forwardRef, useId, useRef, useCallback, XDSFieldLabel, XDSFieldStatus, XDSTooltip
+ * @input Uses React forwardRef, useId, useRef, useCallback, XDSField, XDSTooltip
  * @output Exports XDSSlider component, XDSSliderProps, XDSSliderSingleProps, XDSSliderRangeProps, XDSSliderBaseProps
  * @position Core implementation; consumed by index.ts, tested by XDSSlider.test.tsx
  *
@@ -28,8 +28,7 @@ import {
   typographyVars,
   textSizeVars,
 } from '../theme/tokens.stylex';
-import {XDSFieldLabel} from '../Field/XDSFieldLabel';
-import {XDSFieldStatus} from '../Field/XDSFieldStatus';
+import {XDSField} from '../Field/XDSField';
 import {XDSTooltip} from '../Layer/XDSTooltip';
 import type {XDSInputStatus} from '../Field/types';
 
@@ -108,21 +107,6 @@ const THUMB_SIZE = 20;
 // =============================================================================
 
 const styles = stylex.create({
-  root: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-1'],
-  },
-  labelWrapper: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-0-5'],
-  },
-  description: {
-    fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
-    color: colorVars['--color-text-secondary'],
-  },
   sliderRow: {
     display: 'flex',
     alignItems: 'center',
@@ -621,24 +605,27 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
       ) : null;
 
     return (
-      <div data-testid={testId} {...stylex.props(styles.root, xstyle)}>
-        <div {...stylex.props(styles.labelWrapper)}>
-          <XDSFieldLabel
-            label={label}
-            inputID={id}
-            isLabelHidden={isLabelHidden}
-            isDisabled={isDisabled}
-            isOptional={isOptional}
-            isRequired={isRequired}
-            tooltip={labelTooltip}
-          />
-          {description && (
-            <span id={descriptionID} {...stylex.props(styles.description)}>
-              {description}
-            </span>
-          )}
-        </div>
-
+      <XDSField
+        data-testid={testId}
+        label={label}
+        isLabelHidden={isLabelHidden}
+        description={description}
+        inputID={id}
+        descriptionID={description ? descriptionID : undefined}
+        isOptional={isOptional}
+        isRequired={isRequired}
+        status={
+          status
+            ? {
+                type: status.type,
+                message: status.message,
+                messageID: status.message ? statusMessageID : undefined,
+              }
+            : undefined
+        }
+        labelTooltip={labelTooltip}
+        statusVariant="detached"
+        {...stylex.props(xstyle)}>
         <div {...stylex.props(styles.sliderRow)}>
           <div
             ref={node => {
@@ -733,16 +720,7 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
 
           {textDisplay}
         </div>
-
-        {status?.message && (
-          <XDSFieldStatus
-            type={status.type}
-            message={status.message}
-            id={statusMessageID}
-            variant="detached"
-          />
-        )}
-      </div>
+      </XDSField>
     );
   },
 );

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -15,7 +15,6 @@ import {
   useId,
   useRef,
   useCallback,
-  useState,
   type KeyboardEvent,
   type PointerEvent,
 } from 'react';
@@ -32,6 +31,7 @@ import {
 } from '../theme/tokens.stylex';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
 import {XDSFieldStatus} from '../Field/XDSFieldStatus';
+import {XDSTooltip} from '../Layer/XDSTooltip';
 import type {XDSInputStatus} from '../Field/types';
 
 // =============================================================================
@@ -223,32 +223,6 @@ const styles = stylex.create({
   thumbActive: {
     cursor: 'grabbing',
   },
-  tooltip: {
-    position: 'absolute',
-    left: '50%',
-    transform: 'translateX(-50%)',
-    bottom: '100%',
-    marginBottom: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-0-5'],
-    paddingInline: spacingVars['--spacing-2'],
-    backgroundColor: colorVars['--color-text-primary'],
-    color: colorVars['--color-text-on-media'],
-    fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
-    borderRadius: radiusVars['--radius-content'],
-    whiteSpace: 'nowrap',
-    pointerEvents: 'none',
-    zIndex: 2,
-  },
-  tooltipVertical: {
-    left: 'auto',
-    top: '50%',
-    transform: 'translateY(-50%)',
-    bottom: 'auto',
-    right: '100%',
-    marginBottom: 0,
-    marginRight: spacingVars['--spacing-2'],
-  },
   textValue: {
     fontFamily: typographyVars['--font-body'],
     fontSize: textSizeVars['--text-base'],
@@ -375,29 +349,6 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
     const trackRef = useRef<HTMLDivElement>(null);
     const draggingThumbRef = useRef<number | null>(null);
 
-    // Track hover/focus/active per thumb for tooltip visibility
-    const [thumbStates, setThumbStates] = useState<
-      Array<{hover: boolean; focus: boolean; active: boolean}>
-    >(
-      isRange
-        ? [
-            {hover: false, focus: false, active: false},
-            {hover: false, focus: false, active: false},
-          ]
-        : [{hover: false, focus: false, active: false}],
-    );
-
-    const updateThumbState = useCallback(
-      (index: number, key: 'hover' | 'focus' | 'active', val: boolean) => {
-        setThumbStates(prev => {
-          const next = [...prev];
-          next[index] = {...next[index], [key]: val};
-          return next;
-        });
-      },
-      [],
-    );
-
     // Build aria-describedby
     const describedByParts: string[] = [];
     if (description) describedByParts.push(descriptionID);
@@ -505,7 +456,6 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
         const thumbIndex = getClosestThumb(newVal);
         draggingThumbRef.current = thumbIndex;
         updateValue(thumbIndex, newVal);
-        updateThumbState(thumbIndex, 'active', true);
         if (
           typeof (e.currentTarget as HTMLElement).setPointerCapture ===
           'function'
@@ -513,13 +463,7 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
           (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
         }
       },
-      [
-        isDisabled,
-        getValueFromPosition,
-        getClosestThumb,
-        updateValue,
-        updateThumbState,
-      ],
+      [isDisabled, getValueFromPosition, getClosestThumb, updateValue],
     );
 
     const handlePointerMove = useCallback(
@@ -534,12 +478,11 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
     const handlePointerUp = useCallback(
       (_e: PointerEvent<HTMLDivElement>) => {
         if (draggingThumbRef.current !== null) {
-          updateThumbState(draggingThumbRef.current, 'active', false);
           draggingThumbRef.current = null;
           fireChangeEnd();
         }
       },
-      [updateThumbState, fireChangeEnd],
+      [fireChangeEnd],
     );
 
     // Keyboard handler
@@ -590,14 +533,6 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
     const renderThumb = (thumbIndex: number) => {
       const val = values[thumbIndex];
       const percent = getPercent(val, min, max);
-      const state = thumbStates[thumbIndex] ?? {
-        hover: false,
-        focus: false,
-        active: false,
-      };
-      const showTooltip =
-        valueDisplay === 'tooltip' &&
-        (state.hover || state.focus || state.active);
 
       const positionStyle = isHorizontal
         ? {left: `${percent}%`}
@@ -609,7 +544,10 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
           : 'Maximum value'
         : label;
 
-      return (
+      const useTooltip = valueDisplay === 'tooltip';
+      const tooltipPlacement = isHorizontal ? 'above' : 'before';
+
+      const thumbElement = (
         <div
           key={thumbIndex}
           role="slider"
@@ -625,29 +563,29 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
           aria-describedby={ariaDescribedBy}
           style={positionStyle}
           onKeyDown={e => handleKeyDown(thumbIndex, e)}
-          onFocus={() => updateThumbState(thumbIndex, 'focus', true)}
-          onBlur={() => updateThumbState(thumbIndex, 'focus', false)}
-          onPointerEnter={() => updateThumbState(thumbIndex, 'hover', true)}
-          onPointerLeave={() => updateThumbState(thumbIndex, 'hover', false)}
           {...stylex.props(
             styles.thumb,
             isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
             !isDisabled && styles.thumbHover,
-            state.focus && styles.thumbFocus,
             isDisabled && styles.thumbDisabled,
-            state.active && styles.thumbActive,
-          )}>
-          {showTooltip && (
-            <div
-              {...stylex.props(
-                styles.tooltip,
-                !isHorizontal && styles.tooltipVertical,
-              )}>
-              {displayValue(val)}
-            </div>
           )}
-        </div>
+        />
       );
+
+      if (useTooltip) {
+        return (
+          <XDSTooltip
+            key={thumbIndex}
+            content={displayValue(val)}
+            placement={tooltipPlacement}
+            delay={0}
+            focusTrigger="always">
+            {thumbElement}
+          </XDSTooltip>
+        );
+      }
+
+      return thumbElement;
     };
 
     // Filled track position

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -26,7 +26,6 @@ import {
   radiusVars,
   transitionVars,
   typographyVars,
-  elevationVars,
   textSizeVars,
 } from '../theme/tokens.stylex';
 import {XDSField} from '../Field/XDSField';
@@ -176,14 +175,22 @@ const styles = stylex.create({
     width: THUMB_SIZE,
     height: THUMB_SIZE,
     borderRadius: radiusVars['--radius-rounded'],
-    backgroundColor: colorVars['--color-popover'],
-    boxShadow: elevationVars['--elevation-thumb'],
+    backgroundColor: colorVars['--color-accent'],
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     transform: 'translate(-50%, -50%)',
-    transitionProperty: 'box-shadow',
+    transitionProperty: 'background-color, box-shadow',
     transitionDuration: transitionVars['--transition-fast'],
     outline: 'none',
     cursor: 'grab',
     zIndex: 1,
+  },
+  thumbInnerDot: {
+    width: THUMB_SIZE - 8,
+    height: THUMB_SIZE - 8,
+    borderRadius: radiusVars['--radius-rounded'],
+    backgroundColor: colorVars['--color-surface'],
   },
   thumbHorizontal: {
     top: '50%',
@@ -192,20 +199,24 @@ const styles = stylex.create({
     left: '50%',
   },
   thumbHover: {
-    boxShadow: {
-      default: elevationVars['--elevation-thumb'],
-      ':hover': elevationVars['--elevation-hover'],
+    backgroundColor: {
+      default: colorVars['--color-accent'],
+      ':hover': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-hover-tint']} 15%)`,
     },
   },
-  thumbFocus: {
-    outline: `2px solid ${colorVars['--color-focus-outline']}`,
-    outlineOffset: 2,
+  thumbFocusWithin: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-within': '2px',
+    },
   },
   thumbDisabled: {
+    backgroundColor: colorVars['--color-deemphasized'],
     cursor: 'not-allowed',
-  },
-  thumbActive: {
-    cursor: 'grabbing',
   },
   textValue: {
     fontFamily: typographyVars['--font-body'],
@@ -551,9 +562,11 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
             styles.thumb,
             isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
             !isDisabled && styles.thumbHover,
+            !isDisabled && styles.thumbFocusWithin,
             isDisabled && styles.thumbDisabled,
-          )}
-        />
+          )}>
+          <div {...stylex.props(styles.thumbInnerDot)} />
+        </div>
       );
 
       if (useTooltip) {

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -192,9 +192,6 @@ const styles = stylex.create({
     height: THUMB_SIZE,
     borderRadius: radiusVars['--radius-rounded'],
     backgroundColor: colorVars['--color-accent'],
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
     transform: 'translate(-50%, -50%)',
     transitionProperty: 'background-color, box-shadow',
     transitionDuration: transitionVars['--transition-fast'],
@@ -202,17 +199,12 @@ const styles = stylex.create({
     cursor: 'grab',
     zIndex: 1,
   },
-  thumbInnerDot: {
-    width: THUMB_SIZE - 8,
-    height: THUMB_SIZE - 8,
-    borderRadius: radiusVars['--radius-rounded'],
-    backgroundColor: colorVars['--color-surface'],
-  },
   thumbHorizontal: {
     top: '50%',
   },
   thumbVertical: {
     left: '50%',
+    transform: 'translate(-50%, 50%)',
   },
   thumbHover: {
     backgroundColor: {
@@ -580,9 +572,8 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
             !isDisabled && styles.thumbHover,
             !isDisabled && styles.thumbFocusWithin,
             isDisabled && styles.thumbDisabled,
-          )}>
-          <div {...stylex.props(styles.thumbInnerDot)} />
-        </div>
+          )}
+        />
       );
 
       if (useTooltip) {

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -1,0 +1,805 @@
+/**
+ * @file XDSSlider.tsx
+ * @input Uses React forwardRef, useId, useRef, useCallback, useState, XDSFieldLabel, XDSFieldStatus, XDSInputStatus
+ * @output Exports XDSSlider component, XDSSliderProps, XDSSliderSingleProps, XDSSliderRangeProps, XDSSliderBaseProps
+ * @position Core implementation; consumed by index.ts, tested by XDSSlider.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Slider/XDSSlider.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/Slider/index.ts (exports if types change)
+ * - /apps/storybook/stories/Slider.stories.tsx (storybook stories)
+ */
+
+import {
+  forwardRef,
+  useId,
+  useRef,
+  useCallback,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  transitionVars,
+  typographyVars,
+  elevationVars,
+  textSizeVars,
+} from '../theme/tokens.stylex';
+import {XDSFieldLabel} from '../Field/XDSFieldLabel';
+import {XDSFieldStatus} from '../Field/XDSFieldStatus';
+import type {XDSInputStatus} from '../Field/types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface XDSSliderBaseProps {
+  /** Label text for the slider (always rendered for accessibility). */
+  label: string;
+  /** Whether to visually hide the label (still accessible to screen readers). @default false */
+  isLabelHidden?: boolean;
+  /** Description text displayed below the label. */
+  description?: string;
+  /** Whether the slider is disabled. @default false */
+  isDisabled?: boolean;
+  /** Whether the field is optional. @default false */
+  isOptional?: boolean;
+  /** Whether the field is required. @default false */
+  isRequired?: boolean;
+  /** Status indicator for the slider. */
+  status?: XDSInputStatus;
+  /** Tooltip text to display in an info icon at the end of the label. */
+  labelTooltip?: string;
+  /** Minimum value. @default 0 */
+  min?: number;
+  /** Maximum value. @default 100 */
+  max?: number;
+  /** Step increment. @default 1 */
+  step?: number;
+  /** Orientation of the slider. @default "horizontal" */
+  orientation?: 'horizontal' | 'vertical';
+  /** Custom value formatting function for display and aria-valuetext. */
+  formatValue?: (value: number) => string;
+  /** How the current value is displayed. @default "tooltip" */
+  valueDisplay?: 'tooltip' | 'text' | 'none';
+  /** Tick marks at specified positions with optional labels. */
+  marks?: Array<{value: number; label?: string}>;
+  /** Additional styles. */
+  xstyle?: StyleXStyles;
+  /** Test ID for the root element. */
+  'data-testid'?: string;
+}
+
+export interface XDSSliderSingleProps extends XDSSliderBaseProps {
+  /** Current value (single thumb mode). */
+  value: number;
+  /** Callback fired on value change during drag. */
+  onChange?: (value: number) => void;
+  /** Callback fired when drag ends (on pointer up or keyboard). */
+  onChangeEnd?: (value: number) => void;
+}
+
+export interface XDSSliderRangeProps extends XDSSliderBaseProps {
+  /** Current value (range mode: [min, max]). */
+  value: [number, number];
+  /** Callback fired on value change during drag. */
+  onChange?: (value: [number, number]) => void;
+  /** Callback fired when drag ends (on pointer up or keyboard). */
+  onChangeEnd?: (value: [number, number]) => void;
+  /** Minimum number of steps between thumbs. */
+  minStepsBetweenThumbs?: number;
+}
+
+export type XDSSliderProps = XDSSliderSingleProps | XDSSliderRangeProps;
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const TRACK_SIZE = 4;
+const THUMB_SIZE = 20;
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+  },
+  labelWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
+  },
+  description: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+  },
+  sliderRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+  },
+  trackContainer: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    flexGrow: 1,
+    touchAction: 'none',
+    userSelect: 'none',
+  },
+  trackContainerHorizontal: {
+    height: THUMB_SIZE + 8,
+    width: '100%',
+    cursor: 'pointer',
+  },
+  trackContainerVertical: {
+    width: THUMB_SIZE + 8,
+    height: 160,
+    flexDirection: 'column',
+    justifyContent: 'center',
+    cursor: 'pointer',
+  },
+  trackContainerDisabled: {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  },
+  track: {
+    position: 'absolute',
+    backgroundColor: colorVars['--color-deemphasized'],
+    borderRadius: radiusVars['--radius-rounded'],
+  },
+  trackHorizontal: {
+    left: 0,
+    right: 0,
+    height: TRACK_SIZE,
+    top: '50%',
+    transform: 'translateY(-50%)',
+  },
+  trackVertical: {
+    top: 0,
+    bottom: 0,
+    width: TRACK_SIZE,
+    left: '50%',
+    transform: 'translateX(-50%)',
+  },
+  filledTrack: {
+    position: 'absolute',
+    backgroundColor: colorVars['--color-accent'],
+    borderRadius: radiusVars['--radius-rounded'],
+  },
+  filledTrackHorizontal: {
+    height: TRACK_SIZE,
+    top: '50%',
+    transform: 'translateY(-50%)',
+  },
+  filledTrackVertical: {
+    width: TRACK_SIZE,
+    left: '50%',
+    transform: 'translateX(-50%)',
+  },
+  thumb: {
+    position: 'absolute',
+    width: THUMB_SIZE,
+    height: THUMB_SIZE,
+    borderRadius: radiusVars['--radius-rounded'],
+    backgroundColor: colorVars['--color-surface'],
+    boxShadow: elevationVars['--elevation-thumb'],
+    transform: 'translate(-50%, -50%)',
+    transitionProperty: 'box-shadow',
+    transitionDuration: transitionVars['--transition-fast'],
+    outline: 'none',
+    cursor: 'grab',
+    zIndex: 1,
+  },
+  thumbHorizontal: {
+    top: '50%',
+  },
+  thumbVertical: {
+    left: '50%',
+  },
+  thumbHover: {
+    boxShadow: {
+      default: elevationVars['--elevation-thumb'],
+      ':hover': elevationVars['--elevation-hover'],
+    },
+  },
+  thumbFocus: {
+    outline: `2px solid ${colorVars['--color-focus-outline']}`,
+    outlineOffset: 2,
+  },
+  thumbDisabled: {
+    cursor: 'not-allowed',
+  },
+  thumbActive: {
+    cursor: 'grabbing',
+  },
+  tooltip: {
+    position: 'absolute',
+    transform: 'translateX(-50%)',
+    bottom: '100%',
+    marginBottom: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-0-5'],
+    paddingInline: spacingVars['--spacing-2'],
+    backgroundColor: colorVars['--color-text-primary'],
+    color: colorVars['--color-text-on-media'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    borderRadius: radiusVars['--radius-content'],
+    whiteSpace: 'nowrap',
+    pointerEvents: 'none',
+    zIndex: 2,
+  },
+  tooltipVertical: {
+    transform: 'translateY(50%)',
+    bottom: 'auto',
+    right: '100%',
+    marginBottom: 0,
+    marginRight: spacingVars['--spacing-2'],
+  },
+  textValue: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    color: colorVars['--color-text-primary'],
+    whiteSpace: 'nowrap',
+    flexShrink: 0,
+  },
+  marksContainer: {
+    position: 'absolute',
+  },
+  marksContainerHorizontal: {
+    left: 0,
+    right: 0,
+    top: '50%',
+  },
+  marksContainerVertical: {
+    top: 0,
+    bottom: 0,
+    left: '50%',
+  },
+  mark: {
+    position: 'absolute',
+    backgroundColor: colorVars['--color-divider-emphasized'],
+    borderRadius: radiusVars['--radius-rounded'],
+  },
+  markHorizontal: {
+    width: 2,
+    height: 8,
+    transform: 'translate(-50%, -50%)',
+  },
+  markVertical: {
+    height: 2,
+    width: 8,
+    transform: 'translate(-50%, 50%)',
+  },
+  markLabel: {
+    position: 'absolute',
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+    whiteSpace: 'nowrap',
+  },
+  markLabelHorizontal: {
+    transform: 'translateX(-50%)',
+    top: THUMB_SIZE / 2 + 8,
+  },
+  markLabelVertical: {
+    transform: 'translateY(50%)',
+    left: THUMB_SIZE / 2 + 8,
+  },
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function clamp(val: number, min: number, max: number): number {
+  return Math.min(Math.max(val, min), max);
+}
+
+function snapToStep(val: number, min: number, step: number): number {
+  const steps = Math.round((val - min) / step);
+  return min + steps * step;
+}
+
+function getPercent(val: number, min: number, max: number): number {
+  if (max === min) return 0;
+  return ((val - min) / (max - min)) * 100;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * A slider component for selecting numeric values or ranges.
+ *
+ * @example
+ * ```tsx
+ * // Single value
+ * <XDSSlider label="Volume" value={50} onChange={setValue} />
+ *
+ * // Range
+ * <XDSSlider label="Price range" value={[20, 80]} onChange={setRange} />
+ * ```
+ */
+export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
+  (props, ref) => {
+    const {
+      label,
+      isLabelHidden = false,
+      description,
+      isDisabled = false,
+      isOptional = false,
+      isRequired = false,
+      status,
+      labelTooltip,
+      min = 0,
+      max = 100,
+      step = 1,
+      orientation = 'horizontal',
+      formatValue,
+      valueDisplay = 'tooltip',
+      marks,
+      xstyle,
+      'data-testid': testId,
+      value,
+      onChange,
+      onChangeEnd,
+    } = props;
+
+    const isRange = Array.isArray(value);
+    const minStepsBetweenThumbs =
+      isRange && 'minStepsBetweenThumbs' in props
+        ? ((props as XDSSliderRangeProps).minStepsBetweenThumbs ?? 0)
+        : 0;
+
+    const isHorizontal = orientation === 'horizontal';
+
+    const id = useId();
+    const descriptionID = useId();
+    const statusMessageID = useId();
+
+    const trackRef = useRef<HTMLDivElement>(null);
+    const draggingThumbRef = useRef<number | null>(null);
+
+    // Track hover/focus/active per thumb for tooltip visibility
+    const [thumbStates, setThumbStates] = useState<
+      Array<{hover: boolean; focus: boolean; active: boolean}>
+    >(
+      isRange
+        ? [
+            {hover: false, focus: false, active: false},
+            {hover: false, focus: false, active: false},
+          ]
+        : [{hover: false, focus: false, active: false}],
+    );
+
+    const updateThumbState = useCallback(
+      (index: number, key: 'hover' | 'focus' | 'active', val: boolean) => {
+        setThumbStates(prev => {
+          const next = [...prev];
+          next[index] = {...next[index], [key]: val};
+          return next;
+        });
+      },
+      [],
+    );
+
+    // Build aria-describedby
+    const describedByParts: string[] = [];
+    if (description) describedByParts.push(descriptionID);
+    if (status?.message) describedByParts.push(statusMessageID);
+    const ariaDescribedBy =
+      describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
+
+    // Value helpers
+    const values: number[] = isRange
+      ? (value as [number, number])
+      : [value as number];
+
+    const getValueFromPosition = useCallback(
+      (clientX: number, clientY: number): number => {
+        const track = trackRef.current;
+        if (!track) return min;
+        const rect = track.getBoundingClientRect();
+
+        let percent: number;
+        if (isHorizontal) {
+          percent = (clientX - rect.left) / rect.width;
+        } else {
+          // Vertical: bottom = min, top = max
+          percent = 1 - (clientY - rect.top) / rect.height;
+        }
+        percent = clamp(percent, 0, 1);
+        const raw = min + percent * (max - min);
+        return clamp(snapToStep(raw, min, step), min, max);
+      },
+      [min, max, step, isHorizontal],
+    );
+
+    const getClosestThumb = useCallback(
+      (newValue: number): number => {
+        if (!isRange) return 0;
+        const [v0, v1] = values;
+        const d0 = Math.abs(newValue - v0);
+        const d1 = Math.abs(newValue - v1);
+        // Prefer the lower thumb if equidistant
+        return d0 <= d1 ? 0 : 1;
+      },
+      [isRange, values],
+    );
+
+    const updateValue = useCallback(
+      (thumbIndex: number, newVal: number) => {
+        if (isDisabled) return;
+        const clamped = clamp(snapToStep(newVal, min, step), min, max);
+
+        if (isRange) {
+          const currentValues = [...values] as [number, number];
+          currentValues[thumbIndex] = clamped;
+
+          // Enforce minStepsBetweenThumbs
+          const minGap = minStepsBetweenThumbs * step;
+          if (thumbIndex === 0) {
+            currentValues[0] = Math.min(
+              currentValues[0],
+              currentValues[1] - minGap,
+            );
+          } else {
+            currentValues[1] = Math.max(
+              currentValues[1],
+              currentValues[0] + minGap,
+            );
+          }
+
+          // Keep within bounds
+          currentValues[0] = clamp(currentValues[0], min, max);
+          currentValues[1] = clamp(currentValues[1], min, max);
+
+          (onChange as XDSSliderRangeProps['onChange'])?.(currentValues);
+        } else {
+          (onChange as XDSSliderSingleProps['onChange'])?.(clamped);
+        }
+      },
+      [
+        isDisabled,
+        isRange,
+        values,
+        min,
+        max,
+        step,
+        minStepsBetweenThumbs,
+        onChange,
+      ],
+    );
+
+    const fireChangeEnd = useCallback(() => {
+      if (isRange) {
+        (onChangeEnd as XDSSliderRangeProps['onChangeEnd'])?.(
+          values as unknown as [number, number],
+        );
+      } else {
+        (onChangeEnd as XDSSliderSingleProps['onChangeEnd'])?.(values[0]);
+      }
+    }, [isRange, values, onChangeEnd]);
+
+    // Pointer handlers
+    const handlePointerDown = useCallback(
+      (e: PointerEvent<HTMLDivElement>) => {
+        if (isDisabled) return;
+        e.preventDefault();
+        const newVal = getValueFromPosition(e.clientX, e.clientY);
+        const thumbIndex = getClosestThumb(newVal);
+        draggingThumbRef.current = thumbIndex;
+        updateValue(thumbIndex, newVal);
+        updateThumbState(thumbIndex, 'active', true);
+        if (
+          typeof (e.currentTarget as HTMLElement).setPointerCapture ===
+          'function'
+        ) {
+          (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+        }
+      },
+      [
+        isDisabled,
+        getValueFromPosition,
+        getClosestThumb,
+        updateValue,
+        updateThumbState,
+      ],
+    );
+
+    const handlePointerMove = useCallback(
+      (e: PointerEvent<HTMLDivElement>) => {
+        if (draggingThumbRef.current === null || isDisabled) return;
+        const newVal = getValueFromPosition(e.clientX, e.clientY);
+        updateValue(draggingThumbRef.current, newVal);
+      },
+      [isDisabled, getValueFromPosition, updateValue],
+    );
+
+    const handlePointerUp = useCallback(
+      (_e: PointerEvent<HTMLDivElement>) => {
+        if (draggingThumbRef.current !== null) {
+          updateThumbState(draggingThumbRef.current, 'active', false);
+          draggingThumbRef.current = null;
+          fireChangeEnd();
+        }
+      },
+      [updateThumbState, fireChangeEnd],
+    );
+
+    // Keyboard handler
+    const handleKeyDown = useCallback(
+      (thumbIndex: number, e: KeyboardEvent<HTMLDivElement>) => {
+        if (isDisabled) return;
+        const currentVal = values[thumbIndex];
+        let newVal = currentVal;
+
+        switch (e.key) {
+          case 'ArrowRight':
+          case 'ArrowUp':
+            newVal = currentVal + step;
+            break;
+          case 'ArrowLeft':
+          case 'ArrowDown':
+            newVal = currentVal - step;
+            break;
+          case 'PageUp':
+            newVal = currentVal + step * 10;
+            break;
+          case 'PageDown':
+            newVal = currentVal - step * 10;
+            break;
+          case 'Home':
+            newVal = min;
+            break;
+          case 'End':
+            newVal = max;
+            break;
+          default:
+            return;
+        }
+
+        e.preventDefault();
+        updateValue(thumbIndex, newVal);
+      },
+      [isDisabled, values, step, min, max, updateValue],
+    );
+
+    // Format display value
+    const displayValue = (val: number): string => {
+      if (formatValue) return formatValue(val);
+      return String(val);
+    };
+
+    // Render a thumb
+    const renderThumb = (thumbIndex: number) => {
+      const val = values[thumbIndex];
+      const percent = getPercent(val, min, max);
+      const state = thumbStates[thumbIndex] ?? {
+        hover: false,
+        focus: false,
+        active: false,
+      };
+      const showTooltip =
+        valueDisplay === 'tooltip' &&
+        (state.hover || state.focus || state.active);
+
+      const positionStyle = isHorizontal
+        ? {left: `${percent}%`}
+        : {bottom: `${percent}%`, left: '50%'};
+
+      const thumbLabel = isRange
+        ? thumbIndex === 0
+          ? 'Minimum value'
+          : 'Maximum value'
+        : label;
+
+      return (
+        <div
+          key={thumbIndex}
+          role="slider"
+          tabIndex={isDisabled ? -1 : 0}
+          aria-valuemin={min}
+          aria-valuemax={max}
+          aria-valuenow={val}
+          aria-valuetext={formatValue ? formatValue(val) : undefined}
+          aria-orientation={orientation}
+          aria-disabled={isDisabled || undefined}
+          aria-invalid={status?.type === 'error' ? true : undefined}
+          aria-label={thumbLabel}
+          aria-describedby={ariaDescribedBy}
+          style={positionStyle}
+          onKeyDown={e => handleKeyDown(thumbIndex, e)}
+          onFocus={() => updateThumbState(thumbIndex, 'focus', true)}
+          onBlur={() => updateThumbState(thumbIndex, 'focus', false)}
+          onPointerEnter={() => updateThumbState(thumbIndex, 'hover', true)}
+          onPointerLeave={() => updateThumbState(thumbIndex, 'hover', false)}
+          {...stylex.props(
+            styles.thumb,
+            isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
+            !isDisabled && styles.thumbHover,
+            state.focus && styles.thumbFocus,
+            isDisabled && styles.thumbDisabled,
+            state.active && styles.thumbActive,
+          )}>
+          {showTooltip && (
+            <div
+              {...stylex.props(
+                styles.tooltip,
+                !isHorizontal && styles.tooltipVertical,
+              )}>
+              {displayValue(val)}
+            </div>
+          )}
+        </div>
+      );
+    };
+
+    // Filled track position
+    const filledStyle = (() => {
+      if (isRange) {
+        const [v0, v1] = values;
+        const p0 = getPercent(v0, min, max);
+        const p1 = getPercent(v1, min, max);
+        if (isHorizontal) {
+          return {left: `${p0}%`, width: `${p1 - p0}%`};
+        }
+        return {bottom: `${p0}%`, height: `${p1 - p0}%`};
+      }
+      const p = getPercent(values[0], min, max);
+      if (isHorizontal) {
+        return {left: '0%', width: `${p}%`};
+      }
+      return {bottom: '0%', height: `${p}%`};
+    })();
+
+    // Text value display
+    const textDisplay =
+      valueDisplay === 'text' ? (
+        <span {...stylex.props(styles.textValue)}>
+          {isRange
+            ? `${displayValue(values[0])} – ${displayValue(values[1])}`
+            : displayValue(values[0])}
+        </span>
+      ) : null;
+
+    return (
+      <div data-testid={testId} {...stylex.props(styles.root, xstyle)}>
+        <div {...stylex.props(styles.labelWrapper)}>
+          <XDSFieldLabel
+            label={label}
+            inputID={id}
+            isLabelHidden={isLabelHidden}
+            isDisabled={isDisabled}
+            isOptional={isOptional}
+            isRequired={isRequired}
+            tooltip={labelTooltip}
+          />
+          {description && (
+            <span id={descriptionID} {...stylex.props(styles.description)}>
+              {description}
+            </span>
+          )}
+        </div>
+
+        <div {...stylex.props(styles.sliderRow)}>
+          <div
+            ref={node => {
+              // Merge refs
+              (
+                trackRef as React.MutableRefObject<HTMLDivElement | null>
+              ).current = node;
+              if (typeof ref === 'function') {
+                ref(node);
+              } else if (ref) {
+                (ref as React.MutableRefObject<HTMLDivElement | null>).current =
+                  node;
+              }
+            }}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={handlePointerUp}
+            {...stylex.props(
+              styles.trackContainer,
+              isHorizontal
+                ? styles.trackContainerHorizontal
+                : styles.trackContainerVertical,
+              isDisabled && styles.trackContainerDisabled,
+            )}>
+            {/* Background track */}
+            <div
+              {...stylex.props(
+                styles.track,
+                isHorizontal ? styles.trackHorizontal : styles.trackVertical,
+              )}
+            />
+
+            {/* Filled track */}
+            <div
+              style={filledStyle}
+              {...stylex.props(
+                styles.filledTrack,
+                isHorizontal
+                  ? styles.filledTrackHorizontal
+                  : styles.filledTrackVertical,
+              )}
+            />
+
+            {/* Marks */}
+            {marks && (
+              <div
+                {...stylex.props(
+                  styles.marksContainer,
+                  isHorizontal
+                    ? styles.marksContainerHorizontal
+                    : styles.marksContainerVertical,
+                )}>
+                {marks.map(mark => {
+                  const percent = getPercent(mark.value, min, max);
+                  const markPos = isHorizontal
+                    ? {left: `${percent}%`}
+                    : {bottom: `${percent}%`};
+                  return (
+                    <div key={mark.value}>
+                      <div
+                        data-testid="slider-mark"
+                        style={markPos}
+                        {...stylex.props(
+                          styles.mark,
+                          isHorizontal
+                            ? styles.markHorizontal
+                            : styles.markVertical,
+                        )}
+                      />
+                      {mark.label && (
+                        <span
+                          data-testid="slider-mark-label"
+                          style={markPos}
+                          {...stylex.props(
+                            styles.markLabel,
+                            isHorizontal
+                              ? styles.markLabelHorizontal
+                              : styles.markLabelVertical,
+                          )}>
+                          {mark.label}
+                        </span>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+
+            {/* Thumbs */}
+            {values.map((_, i) => renderThumb(i))}
+          </div>
+
+          {textDisplay}
+        </div>
+
+        {status?.message && (
+          <XDSFieldStatus
+            type={status.type}
+            message={status.message}
+            id={statusMessageID}
+            variant="detached"
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+XDSSlider.displayName = 'XDSSlider';

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSlider.tsx
- * @input Uses React forwardRef, useId, useRef, useCallback, XDSField, XDSTooltip
+ * @input Uses React forwardRef, useId, useRef, useCallback, XDSFieldLabel, XDSFieldStatus, XDSTooltip
  * @output Exports XDSSlider component, XDSSliderProps, XDSSliderSingleProps, XDSSliderRangeProps, XDSSliderBaseProps
  * @position Core implementation; consumed by index.ts, tested by XDSSlider.test.tsx
  *
@@ -28,7 +28,8 @@ import {
   typographyVars,
   textSizeVars,
 } from '../theme/tokens.stylex';
-import {XDSField} from '../Field/XDSField';
+import {XDSFieldLabel} from '../Field/XDSFieldLabel';
+import {XDSFieldStatus} from '../Field/XDSFieldStatus';
 import {XDSTooltip} from '../Layer/XDSTooltip';
 import type {XDSInputStatus} from '../Field/types';
 
@@ -107,6 +108,21 @@ const THUMB_SIZE = 20;
 // =============================================================================
 
 const styles = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+  },
+  labelWrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
+  },
+  description: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+  },
   sliderRow: {
     display: 'flex',
     alignItems: 'center',
@@ -614,26 +630,24 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
       ) : null;
 
     return (
-      <XDSField
-        data-testid={testId}
-        label={label}
-        isLabelHidden={isLabelHidden}
-        description={description}
-        inputID={id}
-        descriptionID={description ? descriptionID : undefined}
-        isOptional={isOptional}
-        isRequired={isRequired}
-        status={
-          status
-            ? {
-                type: status.type,
-                message: status.message,
-                messageID: status.message ? statusMessageID : undefined,
-              }
-            : undefined
-        }
-        labelTooltip={labelTooltip}
-        {...stylex.props(xstyle)}>
+      <div data-testid={testId} {...stylex.props(styles.root, xstyle)}>
+        <div {...stylex.props(styles.labelWrapper)}>
+          <XDSFieldLabel
+            label={label}
+            inputID={id}
+            isLabelHidden={isLabelHidden}
+            isDisabled={isDisabled}
+            isOptional={isOptional}
+            isRequired={isRequired}
+            tooltip={labelTooltip}
+          />
+          {description && (
+            <span id={descriptionID} {...stylex.props(styles.description)}>
+              {description}
+            </span>
+          )}
+        </div>
+
         <div {...stylex.props(styles.sliderRow)}>
           <div
             ref={node => {
@@ -728,7 +742,16 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
 
           {textDisplay}
         </div>
-      </XDSField>
+
+        {status?.message && (
+          <XDSFieldStatus
+            type={status.type}
+            message={status.message}
+            id={statusMessageID}
+            variant="detached"
+          />
+        )}
+      </div>
     );
   },
 );

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -225,6 +225,7 @@ const styles = stylex.create({
   },
   tooltip: {
     position: 'absolute',
+    left: '50%',
     transform: 'translateX(-50%)',
     bottom: '100%',
     marginBottom: spacingVars['--spacing-2'],
@@ -240,7 +241,9 @@ const styles = stylex.create({
     zIndex: 2,
   },
   tooltipVertical: {
-    transform: 'translateY(50%)',
+    left: 'auto',
+    top: '50%',
+    transform: 'translateY(-50%)',
     bottom: 'auto',
     right: '100%',
     marginBottom: 0,

--- a/packages/core/src/Slider/index.ts
+++ b/packages/core/src/Slider/index.ts
@@ -1,0 +1,7 @@
+export {XDSSlider} from './XDSSlider';
+export type {
+  XDSSliderProps,
+  XDSSliderBaseProps,
+  XDSSliderSingleProps,
+  XDSSliderRangeProps,
+} from './XDSSlider';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export * from './RadioList';
 export * from './CloseButton';
 export * from './Divider';
 export * from './Link';
+export * from './Slider';
 export * from './Switch';
 export * from './DateInput';
 export * from './Field';


### PR DESCRIPTION
Implements the slider component per the spec in #37.

## Features
- **Single thumb**: `value: number` for simple value selection
- **Range**: `value: [number, number]` for min/max range selection
- **Marks**: Tick marks with optional labels
- **Value display**: Tooltip (on hover/drag), text (inline), or none
- **Keyboard**: Arrow keys, Page Up/Down, Home/End
- **formatValue**: Custom value formatting function

## Design decisions
- Discriminated union for single vs range — dominant pattern (Radix, MUI, Ant). Less API surface for LLMs.
- `onChangeEnd` (not `onChangeSettled`) — most common name (React Aria, Mantine)
- `min`/`max` (not `minValue`/`maxValue`) — corpus standard
- `isLabelHidden` defaults to `false` — accessibility-first (internal defaulted to `true` for backward compat)
- Unified `status` object — matches input family

## Follows
- Input props convention: `.context/decisions/input-props-convention.md`
- Sibling patterns: TextInput, Switch, CheckboxInput

Closes #37