### PR TITLE
fix(theme): include sizeVars in theme system

### DIFF
--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -98,6 +98,7 @@ export function XDSTheme({
     colorSchemeStyle,
     theme.styles.colors,
     theme.styles.spacing,
+    theme.styles.size,
     theme.styles.radius,
     theme.styles.elevation,
     theme.styles.transition,

--- a/packages/core/src/theme/defaultTheme.stylex.ts
+++ b/packages/core/src/theme/defaultTheme.stylex.ts
@@ -16,6 +16,7 @@ import type {Theme} from './types';
 import {
   colorVars,
   spacingVars,
+  sizeVars,
   radiusVars,
   elevationVars,
   transitionVars,
@@ -27,6 +28,7 @@ import {
 import type {
   ColorVarName,
   SpacingVarName,
+  SizeVarName,
   RadiusVarName,
   ElevationVarName,
   TransitionVarName,
@@ -36,6 +38,7 @@ import type {
   FontWeightVarName,
   BaseColorRaw,
   BaseSpacingRaw,
+  BaseSizeRaw,
   BaseRadiusRaw,
   BaseElevationRaw,
   BaseTransitionRaw,
@@ -181,6 +184,12 @@ const spacingRaw = {
   '--spacing-7': '32px',
 } as const satisfies Record<SpacingVarName, string>;
 
+const sizeRaw = {
+  '--size-sm': '28px',
+  '--size-md': '32px',
+  '--size-lg': '36px',
+} as const satisfies Record<SizeVarName, string>;
+
 const radiusRaw = {
   '--radius-rounded': '9999px',
   '--radius-container': '12px',
@@ -255,6 +264,11 @@ const colorTheme = stylex.createTheme(
 const spacingTheme = stylex.createTheme(
   spacingVars,
   spacingRaw as unknown as BaseSpacingRaw,
+);
+
+const sizeTheme = stylex.createTheme(
+  sizeVars,
+  sizeRaw as unknown as BaseSizeRaw,
 );
 
 const radiusTheme = stylex.createTheme(
@@ -577,6 +591,7 @@ export const defaultTheme: Theme = {
   styles: {
     colors: colorTheme,
     spacing: spacingTheme,
+    size: sizeTheme,
     radius: radiusTheme,
     elevation: elevationTheme,
     transition: transitionTheme,
@@ -588,6 +603,7 @@ export const defaultTheme: Theme = {
   raw: {
     colors: colorRaw,
     spacing: spacingRaw,
+    size: sizeRaw,
     radius: radiusRaw,
     elevation: elevationRaw,
     transition: transitionRaw,

--- a/packages/core/src/theme/neutralTheme.stylex.ts
+++ b/packages/core/src/theme/neutralTheme.stylex.ts
@@ -18,6 +18,7 @@ import type {Theme} from './types';
 import {
   colorVars,
   spacingVars,
+  sizeVars,
   radiusVars,
   elevationVars,
   transitionVars,
@@ -29,6 +30,7 @@ import {
 import type {
   ColorVarName,
   SpacingVarName,
+  SizeVarName,
   RadiusVarName,
   ElevationVarName,
   TransitionVarName,
@@ -38,6 +40,7 @@ import type {
   FontWeightVarName,
   BaseColorRaw,
   BaseSpacingRaw,
+  BaseSizeRaw,
   BaseRadiusRaw,
   BaseElevationRaw,
   BaseTransitionRaw,
@@ -223,6 +226,12 @@ const spacingRaw = {
   '--spacing-7': '32px',
 } as const satisfies Record<SpacingVarName, string>;
 
+const sizeRaw = {
+  '--size-sm': '28px',
+  '--size-md': '32px',
+  '--size-lg': '36px',
+} as const satisfies Record<SizeVarName, string>;
+
 const radiusRaw = {
   '--radius-rounded': '9999px',
   '--radius-container': '0.75rem',
@@ -298,6 +307,11 @@ const colorTheme = stylex.createTheme(
 const spacingTheme = stylex.createTheme(
   spacingVars,
   spacingRaw as unknown as BaseSpacingRaw,
+);
+
+const sizeTheme = stylex.createTheme(
+  sizeVars,
+  sizeRaw as unknown as BaseSizeRaw,
 );
 
 const radiusTheme = stylex.createTheme(
@@ -544,6 +558,7 @@ export const neutralTheme: Theme = {
   styles: {
     colors: colorTheme,
     spacing: spacingTheme,
+    size: sizeTheme,
     radius: radiusTheme,
     elevation: elevationTheme,
     transition: transitionTheme,
@@ -555,6 +570,7 @@ export const neutralTheme: Theme = {
   raw: {
     colors: colorRaw,
     spacing: spacingRaw,
+    size: sizeRaw,
     radius: radiusRaw,
     elevation: elevationRaw,
     transition: transitionRaw,

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -172,6 +172,8 @@ export interface ThemeRaw {
   colors: Record<string, string>;
   /** Raw spacing values (e.g., '8px') */
   spacing: Record<string, string>;
+  /** Raw size values (e.g., '32px') */
+  size: Record<string, string>;
   /** Raw radius values (e.g., '12px') */
   radius: Record<string, string>;
   /** Raw elevation values (e.g., '0px 2px 4px rgba(0,0,0,0.1)') */
@@ -196,6 +198,8 @@ export interface ThemeStyles {
   colors: StyleXStyles;
   /** Spacing CSS variables */
   spacing: StyleXStyles;
+  /** Size CSS variables (component heights: sm, md, lg) */
+  size: StyleXStyles;
   /** Radius CSS variables */
   radius: StyleXStyles;
   /** Elevation CSS variables */


### PR DESCRIPTION
## Summary

`sizeVars` (`--size-sm`, `--size-md`, `--size-lg`) were defined in `tokens.stylex.ts` but weren't included in the `ThemeStyles`/`ThemeRaw` interfaces or applied by the `XDSTheme` provider. This meant they couldn't be overridden per-theme — a theme couldn't customize component heights.

## Changes

- **`types.ts`** — Added `size` to `ThemeStyles` and `ThemeRaw` interfaces
- **`XDSTheme.tsx`** — Apply `theme.styles.size` in the provider
- **`defaultTheme.stylex.ts`** — Added `sizeRaw` + `sizeTheme` (same defaults as tokens)
- **`neutralTheme.stylex.ts`** — Added `sizeRaw` + `sizeTheme` (same defaults as tokens)

Both themes currently use the same size values as the base tokens. This just makes the plumbing work so themes *can* override them.

---
*Crafted with care by Navi*