### PR TITLE
feat(sandbox): set up sandbox for designer exploration

### DIFF
--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -21,6 +21,7 @@ const screenshotUrlsFile = getArg('screenshot-urls') || 'screenshot-urls.json';
 const runUrl = getArg('run-url') || '';
 const prNumber = getArg('pr-number') || '';
 const storybookUrl = getArg('storybook-url') || '';
+const sandboxUrl = getArg('sandbox-url') || '';
 
 // Read analysis results
 let analysis = { newComponents: [], modifiedComponents: [], componentStats: {}, totalBundle: {} };
@@ -196,16 +197,27 @@ if (storybookUrl) {
 `;
 }
 
+// Build sandbox link section
+let sandboxSection = '';
+if (sandboxUrl) {
+  sandboxSection = `### 🎨 Sandbox Preview
+
+**[Open Sandbox](${sandboxUrl})**
+
+`;
+}
+
 // Build footer with links
 let footerLinks = [];
 if (storybookUrl) footerLinks.push(`[Storybook](${storybookUrl})`);
+if (sandboxUrl) footerLinks.push(`[Sandbox](${sandboxUrl})`);
 if (runUrl) footerLinks.push(`[View full report](${runUrl})`);
 const footerLinksStr = footerLinks.length > 0 ? ` | ${footerLinks.join(' | ')}` : '';
 
 // Build the full comment
 const body = `## PR Analysis Report
 
-${storybookSection}${componentSection || '_No new or modified components detected._\n\n'}
+${storybookSection}${sandboxSection}${componentSection || '_No new or modified components detected._\n\n'}
 ${bundleSection}
 ${a11ySection}
 ${screenshotSection}

--- a/.github/workflows/sandbox.yml
+++ b/.github/workflows/sandbox.yml
@@ -1,0 +1,129 @@
+# Deploy Sandbox to GitHub Pages
+name: Deploy Sandbox
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'apps/sandbox/**'
+      - 'packages/core/**'
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+  pull-requests: write
+
+concurrency:
+  group: "sandbox-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - run: yarn install --frozen-lockfile
+
+      - name: Build core package
+        run: yarn build
+
+      - name: Compute deploy hash
+        id: hash
+        run: |
+          COMMIT_HASH="${{ github.event.pull_request.head.sha || github.sha }}"
+          echo "short_hash=${COMMIT_HASH:0:7}" >> $GITHUB_OUTPUT
+
+      - name: Build Sandbox
+        run: yarn workspace @xds/sandbox build
+        env:
+          SANDBOX_BASE_PATH: /${{ github.event.repository.name }}/${{ steps.hash.outputs.short_hash }}/sandbox
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        run: |
+          SHORT_HASH="${{ steps.hash.outputs.short_hash }}"
+          REPO_NAME="${{ github.event.repository.name }}"
+          REPO_OWNER="${{ github.repository_owner }}"
+          SANDBOX_URL="https://${REPO_OWNER}.github.io/${REPO_NAME}/${SHORT_HASH}/sandbox/"
+
+          echo "sandbox_url=${SANDBOX_URL}" >> $GITHUB_OUTPUT
+          echo "short_hash=${SHORT_HASH}" >> $GITHUB_OUTPUT
+
+          mkdir -p deploy/${SHORT_HASH}/sandbox
+          cp -r apps/sandbox/out/* deploy/${SHORT_HASH}/sandbox/
+          touch deploy/.nojekyll
+
+      - name: Publish to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./deploy
+          keep_files: true
+          destination_dir: .
+
+      - name: Comment sandbox link on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          SANDBOX_URL: ${{ steps.deploy.outputs.sandbox_url }}
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const prNumber = ${{ github.event.pull_request.number }};
+            const sandboxUrl = process.env.SANDBOX_URL;
+
+            // Detect changed sandbox pages
+            const changedFiles = execSync(
+              `git diff --name-only origin/${{ github.base_ref }}...HEAD -- apps/sandbox/src/app/pages/`
+            ).toString().trim().split('\n').filter(Boolean);
+
+            let body = `### 🧪 Sandbox Preview\n\n**[Open Sandbox](${sandboxUrl})**\n\n`;
+
+            if (changedFiles.length > 0) {
+              body += 'Changed pages:\n';
+              for (const file of changedFiles) {
+                const pageName = file
+                  .replace('apps/sandbox/src/app/pages/', '')
+                  .replace('/page.tsx', '');
+                body += `- [${pageName}](${sandboxUrl}pages/${pageName})\n`;
+              }
+            }
+
+            // Find and update existing sandbox comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('Sandbox Preview')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body
+              });
+            }

--- a/apps/sandbox/.gitignore
+++ b/apps/sandbox/.gitignore
@@ -1,4 +1,6 @@
 node_modules
 AGENTS.md
 xds.config.mjs
-pages
+out
+# Ignore Next.js Pages Router directory (we use App Router instead)
+/pages

--- a/apps/sandbox/README.md
+++ b/apps/sandbox/README.md
@@ -1,10 +1,78 @@
 # /apps/sandbox
 
-Local development and testing environment for XDS components.
+Local development and exploration environment for XDS components. Designers and developers can compose XDS components into real-world layouts and test them interactively.
 
 <!-- SYNC: When files in this directory change, update this document. -->
+
+## Getting Started
+
+```bash
+# From the repo root
+yarn dev --filter @xds/sandbox
+
+# Or from this directory
+cd apps/sandbox
+yarn dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) to see the sandbox.
+
+## Adding a New Page
+
+1. Create a directory under `src/app/pages/<name>/`
+2. Add a `page.tsx` file:
+
+```tsx
+import {XDSVStack, XDSHeading, XDSText} from '@xds/core';
+
+export default function MyPage() {
+  return (
+    <XDSVStack gap="space4">
+      <XDSHeading level={1}>My Page</XDSHeading>
+      <XDSText type="body">Content here</XDSText>
+    </XDSVStack>
+  );
+}
+```
+
+3. Add an entry to the `pages` array in `src/app/Sidebar.tsx`:
+
+```tsx
+const pages = [
+  {name: 'Buttons', href: '/pages/buttons'},
+  {name: 'Form', href: '/pages/form'},
+  {name: 'My Page', href: '/pages/my-page'},  // ← add here
+];
+```
+
+The page will be accessible at `/pages/<name>` and appear in the sidebar navigation.
+
+## Directory Structure
 
 | File | Role | Purpose |
 |------|------|---------|
 | `package.json` | Config | Package dependencies and scripts |
+| `next.config.mjs` | Config | Next.js config with static export and StyleX |
+| `src/app/layout.tsx` | Layout | Root layout with theme provider and sidebar |
+| `src/app/Sidebar.tsx` | Component | Navigation sidebar listing all pages |
+| `src/app/page.tsx` | Page | Home / welcome page |
+| `src/app/pages/` | Directory | All sandbox exploration pages |
+| `src/app/pages/buttons/page.tsx` | Page | Button variants, sizes, and states |
+| `src/app/pages/form/page.tsx` | Page | Text inputs, checkboxes, and switches |
 
+## Deployment
+
+The sandbox is built as a static export (`output: 'export'`) and deployed alongside Storybook on GitHub Pages via the CI workflow. Each PR gets a unique sandbox URL at:
+
+```
+https://<owner>.github.io/<repo>/<commit-hash>/sandbox/
+```
+
+PR enrichment automatically detects new/modified sandbox pages and adds links to the PR comment.
+
+## Notes
+
+- Uses Next.js App Router with file-based routing
+- Static export means no server components that require runtime — use `'use client'` for interactive pages
+- `basePath` is set via `SANDBOX_BASE_PATH` env var for GitHub Pages subdirectory deployment
+- All pages should use XDS components from `@xds/core`

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -2,7 +2,11 @@ import stylexPlugin from '@stylexjs/nextjs-plugin';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
   transpilePackages: ['@xds/core'],
+  // Base path for GitHub Pages deployment (set via env var in CI)
+  basePath: process.env.SANDBOX_BASE_PATH || '',
+  images: {unoptimized: true},
 };
 
 export default stylexPlugin({

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -1,4 +1,8 @@
 import stylexPlugin from '@stylexjs/nextjs-plugin';
+import {fileURLToPath} from 'url';
+import {dirname} from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/apps/sandbox/src/app/Sidebar.tsx
+++ b/apps/sandbox/src/app/Sidebar.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSText} from '@xds/core';
+import {XDSVStack} from '@xds/core';
+import Link from 'next/link';
+import {usePathname} from 'next/navigation';
+
+/**
+ * Sidebar page entries.
+ *
+ * To add a new page to the sidebar, create a page at
+ * `src/app/pages/<name>/page.tsx` and add an entry here.
+ */
+const pages = [
+  {name: 'Buttons', href: '/pages/buttons'},
+  {name: 'Form', href: '/pages/form'},
+];
+
+const styles = stylex.create({
+  sidebar: {
+    width: 240,
+    borderRightWidth: 1,
+    borderRightStyle: 'solid',
+    borderRightColor: '#e0e0e0',
+    backgroundColor: '#fafafa',
+    padding: 16,
+    flexShrink: 0,
+  },
+  title: {
+    paddingBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomStyle: 'solid',
+    borderBottomColor: '#e0e0e0',
+    marginBottom: 8,
+  },
+  link: {
+    display: 'block',
+    padding: 8,
+    paddingLeft: 12,
+    borderRadius: 6,
+    textDecoration: 'none',
+    color: '#333',
+    fontSize: 14,
+    transition: 'background-color 0.15s',
+  },
+  linkActive: {
+    backgroundColor: '#e8e8e8',
+    fontWeight: 600,
+  },
+  linkHover: {
+    backgroundColor: {
+      ':hover': '#f0f0f0',
+    },
+  },
+  homeLink: {
+    display: 'block',
+    padding: 8,
+    paddingLeft: 12,
+    borderRadius: 6,
+    textDecoration: 'none',
+    color: '#666',
+    fontSize: 13,
+    transition: 'background-color 0.15s',
+  },
+});
+
+export function Sidebar() {
+  const pathname = usePathname();
+
+  return (
+    <nav {...stylex.props(styles.sidebar)}>
+      <XDSVStack gap="space1">
+        <div {...stylex.props(styles.title)}>
+          <XDSText type="large" weight="bold">
+            XDS Sandbox
+          </XDSText>
+        </div>
+
+        <Link href="/" {...stylex.props(styles.homeLink)}>
+          ← Home
+        </Link>
+
+        <XDSText type="supporting" weight="bold">
+          Pages
+        </XDSText>
+
+        {pages.map(page => (
+          <Link
+            key={page.href}
+            href={page.href}
+            {...stylex.props(
+              styles.link,
+              styles.linkHover,
+              pathname === page.href && styles.linkActive,
+            )}>
+            {page.name}
+          </Link>
+        ))}
+      </XDSVStack>
+    </nav>
+  );
+}

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -1,16 +1,28 @@
 import type {Metadata} from 'next';
 import {XDSTheme, defaultTheme} from '@xds/core/theme';
+import {Sidebar} from './Sidebar';
 
 export const metadata: Metadata = {
   title: 'XDS Sandbox',
-  description: 'XDS component testing sandbox',
+  description: 'XDS component exploration and testing sandbox',
 };
 
 export default function RootLayout({children}: {children: React.ReactNode}) {
   return (
     <html lang="en">
-      <body>
-        <XDSTheme theme={defaultTheme}>{children}</XDSTheme>
+      <body style={{margin: 0}}>
+        <XDSTheme theme={defaultTheme}>
+          <div
+            style={{
+              display: 'flex',
+              minHeight: '100vh',
+            }}>
+            <Sidebar />
+            <main style={{flex: 1, padding: 24, overflow: 'auto'}}>
+              {children}
+            </main>
+          </div>
+        </XDSTheme>
       </body>
     </html>
   );

--- a/apps/sandbox/src/app/page.tsx
+++ b/apps/sandbox/src/app/page.tsx
@@ -1,30 +1,45 @@
-import * as stylex from '@stylexjs/stylex';
 import {XDSText} from '@xds/core';
-import {XDSButton} from '@xds/core';
+import {XDSHeading} from '@xds/core';
 import {XDSVStack} from '@xds/core';
-
-const styles = stylex.create({
-  main: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: '100vh',
-    padding: 'var(--spacing-6)',
-  },
-});
+import {XDSLink} from '@xds/core';
 
 export default function Home() {
   return (
-    <main {...stylex.props(styles.main)}>
-      <XDSVStack gap="space4" align="center">
-        <XDSText type="large" weight="bold">
-          XDS Sandbox
+    <XDSVStack gap="space4">
+      <XDSHeading level={1}>Welcome to the XDS Sandbox</XDSHeading>
+      <XDSText type="large">
+        A testing ground for exploring and composing XDS components in
+        real-world layouts.
+      </XDSText>
+
+      <XDSVStack gap="space2">
+        <XDSHeading level={2}>Example Pages</XDSHeading>
+        <XDSText type="body">
+          Browse the sidebar to explore example pages, or jump to one directly:
         </XDSText>
-        <XDSText color="secondary">
-          A testing ground for XDS components.
-        </XDSText>
-        <XDSButton variant="primary">Get Started</XDSButton>
+        <XDSVStack gap="space1">
+          <XDSLink label="Buttons page" href="/pages/buttons">
+            Buttons — variants, sizes, and states
+          </XDSLink>
+          <XDSLink label="Form page" href="/pages/form">
+            Form — text inputs, checkboxes, and switches
+          </XDSLink>
+        </XDSVStack>
       </XDSVStack>
-    </main>
+
+      <XDSVStack gap="space2">
+        <XDSHeading level={2}>Adding a New Page</XDSHeading>
+        <XDSText type="body">
+          Create a file at{' '}
+          <XDSText type="code">
+            src/app/pages/&lt;name&gt;/page.tsx
+          </XDSText>{' '}
+          and add an entry to the sidebar in{' '}
+          <XDSText type="code">src/app/Sidebar.tsx</XDSText>. The page will be
+          accessible at{' '}
+          <XDSText type="code">/pages/&lt;name&gt;</XDSText>.
+        </XDSText>
+      </XDSVStack>
+    </XDSVStack>
   );
 }

--- a/apps/sandbox/src/app/pages/buttons/page.tsx
+++ b/apps/sandbox/src/app/pages/buttons/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import {XDSButton} from '@xds/core';
+import {XDSVStack} from '@xds/core';
+import {XDSHStack} from '@xds/core';
+import {XDSText} from '@xds/core';
+import {XDSHeading} from '@xds/core';
+import {XDSDivider} from '@xds/core';
+
+export default function ButtonsPage() {
+  return (
+    <XDSVStack gap="space4">
+      <XDSHeading level={1}>Buttons</XDSHeading>
+      <XDSText type="body" color="secondary">
+        Button variants, sizes, and states.
+      </XDSText>
+
+      <XDSDivider />
+
+      <XDSVStack gap="space2">
+        <XDSHeading level={3}>Variants</XDSHeading>
+        <XDSHStack gap="space2">
+          <XDSButton variant="primary" label="Primary" />
+          <XDSButton variant="secondary" label="Secondary" />
+          <XDSButton variant="ghost" label="Ghost" />
+          <XDSButton variant="destructive" label="Destructive" />
+        </XDSHStack>
+      </XDSVStack>
+
+      <XDSDivider />
+
+      <XDSVStack gap="space2">
+        <XDSHeading level={3}>Sizes</XDSHeading>
+        <XDSHStack gap="space2" align="center">
+          <XDSButton variant="primary" size="sm" label="Small" />
+          <XDSButton variant="primary" size="md" label="Medium" />
+          <XDSButton variant="primary" size="lg" label="Large" />
+        </XDSHStack>
+      </XDSVStack>
+
+      <XDSDivider />
+
+      <XDSVStack gap="space2">
+        <XDSHeading level={3}>States</XDSHeading>
+        <XDSHStack gap="space2">
+          <XDSButton variant="primary" label="Disabled" isDisabled />
+          <XDSButton variant="primary" label="Loading" isLoading />
+        </XDSHStack>
+      </XDSVStack>
+    </XDSVStack>
+  );
+}

--- a/apps/sandbox/src/app/pages/form/page.tsx
+++ b/apps/sandbox/src/app/pages/form/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import {XDSVStack} from '@xds/core';
+import {XDSHStack} from '@xds/core';
+import {XDSText} from '@xds/core';
+import {XDSHeading} from '@xds/core';
+import {XDSTextInput} from '@xds/core';
+import {XDSCheckboxInput} from '@xds/core';
+import {XDSSwitch} from '@xds/core';
+import {XDSButton} from '@xds/core';
+import {XDSDivider} from '@xds/core';
+
+export default function FormPage() {
+  return (
+    <XDSVStack gap="space4">
+      <XDSHeading level={1}>Form Elements</XDSHeading>
+      <XDSText type="body" color="secondary">
+        Text inputs, checkboxes, switches, and form composition.
+      </XDSText>
+
+      <XDSDivider />
+
+      <XDSVStack gap="space3">
+        <XDSHeading level={3}>Text Inputs</XDSHeading>
+        <XDSTextInput label="Full name" placeholder="Enter your name" />
+        <XDSTextInput
+          label="Email"
+          placeholder="you@example.com"
+          description="We'll never share your email."
+        />
+        <XDSTextInput
+          label="Password"
+          placeholder="Enter password"
+          isRequired
+        />
+        <XDSTextInput
+          label="Disabled input"
+          placeholder="Cannot edit"
+          isDisabled
+        />
+      </XDSVStack>
+
+      <XDSDivider />
+
+      <XDSVStack gap="space3">
+        <XDSHeading level={3}>Checkboxes</XDSHeading>
+        <XDSCheckboxInput label="Accept terms and conditions" />
+        <XDSCheckboxInput
+          label="Subscribe to newsletter"
+          description="Get weekly updates about XDS."
+        />
+        <XDSCheckboxInput label="Disabled checkbox" isDisabled />
+      </XDSVStack>
+
+      <XDSDivider />
+
+      <XDSVStack gap="space3">
+        <XDSHeading level={3}>Switches</XDSHeading>
+        <XDSSwitch label="Enable dark mode" />
+        <XDSSwitch
+          label="Email notifications"
+          description="Receive email alerts for important updates."
+        />
+        <XDSSwitch label="Disabled switch" isDisabled />
+      </XDSVStack>
+
+      <XDSDivider />
+
+      <XDSVStack gap="space3">
+        <XDSHeading level={3}>Example Form</XDSHeading>
+        <XDSTextInput label="Username" placeholder="Choose a username" isRequired />
+        <XDSTextInput label="Bio" placeholder="Tell us about yourself" isOptional />
+        <XDSCheckboxInput label="I agree to the terms of service" />
+        <XDSHStack gap="space2">
+          <XDSButton variant="primary" label="Submit" />
+          <XDSButton variant="ghost" label="Cancel" />
+        </XDSHStack>
+      </XDSVStack>
+    </XDSVStack>
+  );
+}

--- a/apps/sandbox/src/app/pages/layout.tsx
+++ b/apps/sandbox/src/app/pages/layout.tsx
@@ -1,0 +1,3 @@
+export default function PagesLayout({children}: {children: React.ReactNode}) {
+  return <>{children}</>;
+}


### PR DESCRIPTION
Sets up the sandbox app for designer vibe exploration per #126.

## Changes

- **Sidebar navigation**: New `Sidebar.tsx` component with page links, integrated into the root layout
- **Example pages**: Buttons page (variants, sizes, states) and Form page (text inputs, checkboxes, switches)
- **Static export**: Configured `next.config.mjs` with `output: 'export'`, `basePath` env var, and `images: {unoptimized: true}` for GitHub Pages
- **PR enrichment**: Updated `generate-pr-comment.js` to accept `--sandbox-url` and render a sandbox preview section
- **README**: Full guide on adding pages, directory structure, deployment info
- **.gitignore**: Fixed `pages` rule to only ignore root `/pages` (Pages Router), not `src/app/pages/` (App Router)

## CI Workflow Changes (needs manual apply)

The workflow file (`.github/workflows/storybook.yml`) couldn't be pushed due to OAuth token scope limitations. The changes need to be applied manually or with a token that has `workflow` scope. The diff adds:

- **Build Sandbox** step after Storybook build (with `SANDBOX_BASE_PATH` env var)
- Sandbox output copied to `deploy/${SHORT_HASH}/sandbox/`
- `sandbox_url` output passed to PR enrichment
- New **Add sandbox link to PR comment** step that detects changed sandbox pages and prepends links

<details>
<summary>Workflow diff</summary>

Key additions to the `deploy` job:
```yaml
- name: Build Sandbox
  run: yarn workspace @xds/sandbox build
  env:
    SANDBOX_BASE_PATH: /${{ steps.urls.outputs.repo_name }}/${{ steps.urls.outputs.short_hash }}/sandbox
```

And in deployment:
```yaml
mkdir -p deploy/${SHORT_HASH}/sandbox
cp -r apps/sandbox/out/* deploy/${SHORT_HASH}/sandbox/
```

PR enrichment detects changed sandbox pages:
```yaml
- name: Add sandbox link to PR comment
  run: |
    SANDBOX_CHANGES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- apps/sandbox/src/app/pages/ | head -20)
    if [ -n "$SANDBOX_CHANGES" ]; then
      # Prepends sandbox preview section with links to changed pages
    fi
```

</details>

## How to add a new page

1. Create `apps/sandbox/src/app/pages/<name>/page.tsx`:
```tsx
import {XDSVStack, XDSHeading, XDSText} from '@xds/core';

export default function MyPage() {
  return (
    <XDSVStack gap="space4">
      <XDSHeading level={1}>My Page</XDSHeading>
      <XDSText type="body">Content here</XDSText>
    </XDSVStack>
  );
}
```

2. Add an entry to the `pages` array in `src/app/Sidebar.tsx`

The page appears in the sidebar and gets a unique URL in the PR deployment.

Closes #126

---
*Crafted with care by Navi*