### PR TITLE
Add statusVariant prop to XDSField

### DIFF
--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -139,6 +139,13 @@ export interface XDSFieldProps extends Omit<
    */
   labelTooltip?: string;
   /**
+   * How the status message is rendered relative to the input.
+   * - 'attached': Status sits directly below the input (default, for bordered inputs)
+   * - 'detached': Status is a separate element below the field (for checkboxes, switches, sliders)
+   * @default 'attached'
+   */
+  statusVariant?: 'attached' | 'detached';
+  /**
    * The input or control to render inside the field.
    */
   children: ReactNode;
@@ -169,6 +176,7 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
       labelStartIcon,
       status,
       labelTooltip,
+      statusVariant = 'attached',
       children,
       ...props
     },
@@ -190,17 +198,31 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
             {description}
           </span>
         )}
-        <div {...stylex.props(styles.inputStatusWrapper)}>
-          {children}
-          {status?.message && (
-            <XDSFieldStatus
-              type={status.type}
-              message={status.message}
-              id={status.messageID}
-              variant="attached"
-            />
-          )}
-        </div>
+        {statusVariant === 'attached' ? (
+          <div {...stylex.props(styles.inputStatusWrapper)}>
+            {children}
+            {status?.message && (
+              <XDSFieldStatus
+                type={status.type}
+                message={status.message}
+                id={status.messageID}
+                variant="attached"
+              />
+            )}
+          </div>
+        ) : (
+          <>
+            {children}
+            {status?.message && (
+              <XDSFieldStatus
+                type={status.type}
+                message={status.message}
+                id={status.messageID}
+                variant="detached"
+              />
+            )}
+          </>
+        )}
       </div>
     );
   },

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -189,6 +189,7 @@ export function XDSRadioList({
           : undefined
       }
       labelTooltip={labelTooltip}
+      statusVariant="detached"
       {...stylex.props(xstyle)}>
       <div
         role="radiogroup"


### PR DESCRIPTION
Adds `statusVariant` prop to `XDSField` so components can choose between attached and detached status message rendering without manually composing `XDSFieldLabel` + `XDSFieldStatus`.

## Changes

- **XDSField**: New `statusVariant` prop (`'attached'` | `'detached'`, default `'attached'`)
  - `attached`: status message in a wrapper directly below the input (TextInput, Selector)
  - `detached`: status message as a separate element below the field (RadioList, Slider, CheckboxInput, Switch)
- **RadioList**: Updated to use `statusVariant="detached"`

## Why

Components like Slider and RadioList need detached status messages but were either manually composing field parts or using the wrong variant. This prop lets them use `XDSField` consistently while controlling the status rendering.

CheckboxInput and Switch keep their manual layout since their label is inline next to the control — `XDSField`'s stacked layout doesn't fit their pattern.

## Usage

```tsx
// Attached (default) — for bordered inputs like TextInput
<XDSField label="Email" inputID={id}>
  <input id={id} />
</XDSField>

// Detached — for controls like RadioList, Slider
<XDSField label="Priority" inputID={id} statusVariant="detached" status={...}>
  <div role="radiogroup">...</div>
</XDSField>
```