### PR TITLE
docs: add missing READMEs and audit SYNC blocks

### DIFF
--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -4,9 +4,11 @@
  * @output Exports XDSDropdownMenu component
  * @position Core implementation; consumed by index.ts
  *
- * SYNC: When modified, update:
+ * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/DropdownMenu/README.md
+ * - /packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
  * - /packages/core/src/DropdownMenu/index.ts
+ * - /apps/storybook/stories/DropdownMenu.stories.tsx
  */
 
 import React, {

--- a/packages/core/src/DropdownMenu/XDSDropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenuItem.tsx
@@ -3,9 +3,11 @@
  * @output Exports XDSDropdownMenuItem component for custom item rendering
  * @position Sub-component; used by XDSDropdownMenu and consumers for custom items
  *
- * SYNC: When modified, update:
+ * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/DropdownMenu/README.md
+ * - /packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
  * - /packages/core/src/DropdownMenu/index.ts
+ * - /apps/storybook/stories/DropdownMenu.stories.tsx
  */
 
 import type {ReactNode} from 'react';

--- a/packages/core/src/RadioList/README.md
+++ b/packages/core/src/RadioList/README.md
@@ -1,0 +1,135 @@
+# /packages/core/src/RadioList
+
+A radio group component for single-value selection from a list of options.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Accessible**: Uses native `<input type="radio">` with proper `role="radiogroup"` and ARIA attributes
+- **Orientation**: Supports `vertical` and `horizontal` layouts
+- **Sizes**: `sm` (18px radio, 20px wrapper) and `md` (22px radio, 24px wrapper)
+- **Descriptions**: Optional description text per item
+- **Custom content**: `startContent` and `endContent` slots on each item
+- **Disabled state**: Supports disabling the entire group or individual items
+- **Field integration**: Uses `XDSField` for label, description, required/optional, and status messaging
+
+## Usage
+
+```tsx
+import { XDSRadioList, XDSRadioListItem } from '@xds/core/RadioList';
+
+// Basic usage
+<XDSRadioList
+  label="Notification preference"
+  value={selected}
+  onChange={setSelected}
+>
+  <XDSRadioListItem label="Email" value="email" />
+  <XDSRadioListItem label="SMS" value="sms" />
+  <XDSRadioListItem label="Push" value="push" />
+</XDSRadioList>
+
+// With descriptions
+<XDSRadioList
+  label="Plan"
+  value={plan}
+  onChange={setPlan}
+>
+  <XDSRadioListItem
+    label="Free"
+    value="free"
+    description="Basic features, limited usage"
+  />
+  <XDSRadioListItem
+    label="Pro"
+    value="pro"
+    description="All features, unlimited usage"
+  />
+</XDSRadioList>
+
+// Horizontal layout
+<XDSRadioList
+  label="Size"
+  value={size}
+  onChange={setSize}
+  orientation="horizontal"
+>
+  <XDSRadioListItem label="Small" value="sm" />
+  <XDSRadioListItem label="Medium" value="md" />
+  <XDSRadioListItem label="Large" value="lg" />
+</XDSRadioList>
+
+// With status
+<XDSRadioList
+  label="Required choice"
+  value={choice}
+  onChange={setChoice}
+  isRequired
+  status={{ type: 'error', message: 'Please select an option' }}
+>
+  <XDSRadioListItem label="Option A" value="a" />
+  <XDSRadioListItem label="Option B" value="b" />
+</XDSRadioList>
+
+// Disabled group
+<XDSRadioList
+  label="Locked selection"
+  value="locked"
+  onChange={() => {}}
+  isDisabled
+>
+  <XDSRadioListItem label="Locked" value="locked" />
+  <XDSRadioListItem label="Unavailable" value="unavailable" />
+</XDSRadioList>
+```
+
+## XDSRadioList Props
+
+| Prop            | Type                              | Default      | Description                                                         |
+| --------------- | --------------------------------- | ------------ | ------------------------------------------------------------------- |
+| `label`         | `string`                          | —            | Label text for the radio group (always rendered for accessibility)   |
+| `isLabelHidden` | `boolean`                         | `false`      | Whether to visually hide the label                                  |
+| `description`   | `string`                          | —            | Description text displayed below the label                          |
+| `value`         | `string`                          | —            | The currently selected value                                        |
+| `onChange`      | `(value: string) => void`         | —            | Callback fired when the selected value changes                      |
+| `orientation`   | `'vertical' \| 'horizontal'`     | `'vertical'` | Layout direction of the radio items                                 |
+| `isDisabled`    | `boolean`                         | `false`      | Whether all radio items are disabled                                |
+| `isRequired`    | `boolean`                         | `false`      | Whether the radio group is required                                 |
+| `isOptional`    | `boolean`                         | `false`      | Whether the field is optional (mutually exclusive with `isRequired`) |
+| `status`        | `XDSInputStatus`                  | —            | Status indicator (`{ type, message }`)                              |
+| `size`          | `'sm' \| 'md'`                   | `'md'`       | Size of the radio controls                                          |
+| `labelTooltip`  | `string`                          | —            | Tooltip text for an info icon next to the label                     |
+| `xstyle`        | `StyleXStyles`                    | —            | Additional styles for the outer container                           |
+| `data-testid`   | `string`                          | —            | Test ID for the outer container                                     |
+| `children`      | `ReactNode`                       | —            | `XDSRadioListItem` elements                                        |
+
+## XDSRadioListItem Props
+
+| Prop           | Type        | Default | Description                                    |
+| -------------- | ----------- | ------- | ---------------------------------------------- |
+| `label`        | `string`    | —       | Label text for the radio item                  |
+| `value`        | `string`    | —       | Value of this radio item                       |
+| `description`  | `string`    | —       | Description text displayed below the label     |
+| `isDisabled`   | `boolean`   | `false` | Whether this individual radio item is disabled |
+| `startContent` | `ReactNode` | —       | Content to render before the radio circle      |
+| `endContent`   | `ReactNode` | —       | Content to render after the label              |
+| `data-testid`  | `string`    | —       | Test ID for the radio item container           |
+
+## Files
+
+| File                      | Role  | Purpose                                            |
+| ------------------------- | ----- | -------------------------------------------------- |
+| `index.ts`                | Entry | Exports components and types                       |
+| `XDSRadioList.tsx`        | Core  | Radio group container with context provider        |
+| `XDSRadioListItem.tsx`    | Core  | Individual radio item consuming `RadioListContext` |
+| `XDSRadioList.test.tsx`   | Test  | Unit tests                                         |
+
+## Implementation Notes
+
+- `XDSRadioList` creates a `RadioListContext` that provides `name`, `value`, `onChange`, `isDisabled`, `isRequired`, `size`, and `status` to child items
+- `XDSRadioListItem` must be used within an `XDSRadioList` — throws if context is missing
+- Uses a hidden native `<input type="radio">` with a custom visual overlay for consistent styling
+- Focus outline uses the standard XDS focus outline token with `2px` offset
+- Hover states use `color-mix()` for consistent overlay tinting
+- Size variants match `CheckboxInput` dimensions for visual consistency

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -5,9 +5,10 @@
  * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
- * - /packages/core/src/RadioList/XDSRadioList.test.tsx (tests for new/changed behavior)
- * - /packages/core/src/RadioList/index.ts (exports if types change)
- * - /apps/storybook/stories/RadioList.stories.tsx (storybook stories)
+ * - /packages/core/src/RadioList/README.md
+ * - /packages/core/src/RadioList/XDSRadioList.test.tsx
+ * - /packages/core/src/RadioList/index.ts
+ * - /apps/storybook/stories/RadioList.stories.tsx
  */
 
 import {createContext, useId, type ReactNode} from 'react';

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -5,9 +5,10 @@
  * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
- * - /packages/core/src/RadioList/XDSRadioList.test.tsx (tests for new/changed behavior)
- * - /packages/core/src/RadioList/index.ts (exports if types change)
- * - /apps/storybook/stories/RadioList.stories.tsx (storybook stories)
+ * - /packages/core/src/RadioList/README.md
+ * - /packages/core/src/RadioList/XDSRadioList.test.tsx
+ * - /packages/core/src/RadioList/index.ts
+ * - /apps/storybook/stories/RadioList.stories.tsx
  */
 
 import {useContext, useId, type ReactNode} from 'react';

--- a/packages/core/src/Slider/README.md
+++ b/packages/core/src/Slider/README.md
@@ -1,0 +1,157 @@
+# /packages/core/src/Slider
+
+A slider component for selecting numeric values or ranges with full keyboard and pointer support.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Single & range modes**: Pass a `number` for single thumb, `[number, number]` for range
+- **Orientation**: Supports `horizontal` and `vertical` layouts
+- **Value display**: Tooltip (default), inline text, or none
+- **Tick marks**: Optional marks at specified positions with labels
+- **Keyboard navigation**: Arrow keys, Page Up/Down, Home/End
+- **Drag interaction**: Pointer capture for smooth dragging
+- **Custom formatting**: `formatValue` function for display and `aria-valuetext`
+- **Field integration**: Uses `XDSField` for label, description, required/optional, and status messaging
+- **Accessible**: Uses `role="slider"` with full ARIA attributes
+
+## Usage
+
+```tsx
+import { XDSSlider } from '@xds/core/Slider';
+
+// Basic single value
+<XDSSlider label="Volume" value={50} onChange={setValue} />
+
+// Range slider
+<XDSSlider
+  label="Price range"
+  value={[20, 80]}
+  onChange={setRange}
+/>
+
+// With custom formatting
+<XDSSlider
+  label="Temperature"
+  value={72}
+  onChange={setTemp}
+  min={32}
+  max={212}
+  formatValue={(v) => `${v}°F`}
+/>
+
+// With step and marks
+<XDSSlider
+  label="Rating"
+  value={3}
+  onChange={setRating}
+  min={1}
+  max={5}
+  step={1}
+  marks={[
+    { value: 1, label: 'Poor' },
+    { value: 3, label: 'Average' },
+    { value: 5, label: 'Excellent' },
+  ]}
+/>
+
+// Text value display
+<XDSSlider
+  label="Opacity"
+  value={75}
+  onChange={setOpacity}
+  formatValue={(v) => `${v}%`}
+  valueDisplay="text"
+/>
+
+// Range with minimum gap
+<XDSSlider
+  label="Date range"
+  value={[10, 90]}
+  onChange={setDateRange}
+  minStepsBetweenThumbs={5}
+/>
+
+// With onChangeEnd for committing value
+<XDSSlider
+  label="Brightness"
+  value={brightness}
+  onChange={setBrightness}
+  onChangeEnd={commitBrightness}
+/>
+
+// Vertical orientation
+<XDSSlider
+  label="Level"
+  value={60}
+  onChange={setLevel}
+  orientation="vertical"
+/>
+
+// Disabled
+<XDSSlider
+  label="Locked"
+  value={50}
+  onChange={() => {}}
+  isDisabled
+/>
+```
+
+## XDSSlider Props (Base)
+
+| Prop            | Type                                            | Default        | Description                                                     |
+| --------------- | ----------------------------------------------- | -------------- | --------------------------------------------------------------- |
+| `label`         | `string`                                        | —              | Label text (always rendered for accessibility)                  |
+| `isLabelHidden` | `boolean`                                       | `false`        | Whether to visually hide the label                              |
+| `description`   | `string`                                        | —              | Description text below the label                                |
+| `isDisabled`    | `boolean`                                       | `false`        | Whether the slider is disabled                                  |
+| `isOptional`    | `boolean`                                       | `false`        | Whether the field is optional                                   |
+| `isRequired`    | `boolean`                                       | `false`        | Whether the field is required                                   |
+| `status`        | `XDSInputStatus`                                | —              | Status indicator (`{ type, message }`)                          |
+| `labelTooltip`  | `string`                                        | —              | Tooltip text for an info icon next to the label                 |
+| `min`           | `number`                                        | `0`            | Minimum value                                                   |
+| `max`           | `number`                                        | `100`          | Maximum value                                                   |
+| `step`          | `number`                                        | `1`            | Step increment                                                  |
+| `orientation`   | `'horizontal' \| 'vertical'`                   | `'horizontal'` | Orientation of the slider                                       |
+| `formatValue`   | `(value: number) => string`                     | —              | Custom value formatting for display and `aria-valuetext`        |
+| `valueDisplay`  | `'tooltip' \| 'text' \| 'none'`                | `'tooltip'`    | How the current value is displayed                              |
+| `marks`         | `Array<{ value: number; label?: string }>`      | —              | Tick marks at specified positions with optional labels           |
+| `xstyle`        | `StyleXStyles`                                  | —              | Additional styles                                               |
+| `data-testid`   | `string`                                        | —              | Test ID for the root element                                    |
+
+### Single Value Mode
+
+| Prop          | Type                         | Description                                    |
+| ------------- | ---------------------------- | ---------------------------------------------- |
+| `value`       | `number`                     | Current value                                  |
+| `onChange`    | `(value: number) => void`    | Callback fired on value change during drag     |
+| `onChangeEnd` | `(value: number) => void`   | Callback fired when drag ends                  |
+
+### Range Mode
+
+| Prop                     | Type                                   | Default | Description                              |
+| ------------------------ | -------------------------------------- | ------- | ---------------------------------------- |
+| `value`                  | `[number, number]`                     | —       | Current range `[min, max]`               |
+| `onChange`               | `(value: [number, number]) => void`    | —       | Callback fired on value change           |
+| `onChangeEnd`            | `(value: [number, number]) => void`    | —       | Callback fired when drag ends            |
+| `minStepsBetweenThumbs`  | `number`                               | `0`     | Minimum number of steps between thumbs   |
+
+## Files
+
+| File                  | Role  | Purpose                                              |
+| --------------------- | ----- | ---------------------------------------------------- |
+| `index.ts`            | Entry | Exports XDSSlider component and all type variants    |
+| `XDSSlider.tsx`       | Core  | Slider component with single and range mode support  |
+| `XDSSlider.test.tsx`  | Test  | Unit tests                                           |
+
+## Implementation Notes
+
+- The component uses `forwardRef` — the ref is merged with an internal `trackRef` for pointer position calculations
+- Pointer capture is used during drag for smooth interaction even when the cursor leaves the track
+- `snapToStep` rounds to the nearest valid step value; `clamp` enforces min/max bounds
+- In range mode, the closest thumb is selected on track click based on distance to each thumb
+- `minStepsBetweenThumbs` prevents range thumbs from overlapping by enforcing a minimum gap
+- Keyboard navigation: Arrow keys ±1 step, Page Up/Down ±10 steps, Home/End jump to min/max
+- Tooltip display wraps each thumb in `XDSTooltip` with `delay={0}` and `focusTrigger="always"`
+- Vertical orientation inverts the Y axis (bottom = min, top = max)

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -5,9 +5,10 @@
  * @position Core implementation; consumed by index.ts, tested by XDSSlider.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
- * - /packages/core/src/Slider/XDSSlider.test.tsx (tests for new/changed behavior)
- * - /packages/core/src/Slider/index.ts (exports if types change)
- * - /apps/storybook/stories/Slider.stories.tsx (storybook stories)
+ * - /packages/core/src/Slider/README.md
+ * - /packages/core/src/Slider/XDSSlider.test.tsx
+ * - /packages/core/src/Slider/index.ts
+ * - /apps/storybook/stories/Slider.stories.tsx
  */
 
 import {


### PR DESCRIPTION
## Summary

Adds missing documentation and normalizes SYNC blocks across recently added components.

### New READMEs

- **RadioList** — Documents `XDSRadioList` and `XDSRadioListItem` with props tables, usage examples, and implementation notes
- **Slider** — Documents `XDSSlider` covering single value and range modes, keyboard navigation, marks, and value display options

### SYNC Block Audit

| Component | File | Status |
|-----------|------|--------|
| RadioList | `XDSRadioList.tsx` | Added `README.md` entry, normalized format |
| RadioList | `XDSRadioListItem.tsx` | Added `README.md` entry, normalized format |
| Slider | `XDSSlider.tsx` | Added `README.md` entry, normalized format |
| DropdownMenu | `XDSDropdownMenu.tsx` | Expanded: added test + storybook entries |
| DropdownMenu | `XDSDropdownMenuItem.tsx` | Expanded: added test + storybook entries |
| TopNav | All 4 files | ✅ Already correct, no changes needed |

### README Format

Both READMEs follow the established pattern (see `Button/README.md`, `CheckboxInput/README.md`):
- Component heading with path
- SYNC comment
- Features list
- Usage examples
- Props tables (one per exported component)
- Files table
- Implementation notes

---
*Crafted with care by Navi*