### PR TITLE
Organize storybook categories to match CLI component groups

### DIFF
--- a/apps/storybook/stories/CheckboxInput.stories.tsx
+++ b/apps/storybook/stories/CheckboxInput.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSCheckboxInput> = {
-  title: 'Core/XDSCheckboxInput',
+  title: 'Form/XDSCheckboxInput',
   component: XDSCheckboxInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -4,7 +4,7 @@ import {XDSDateInput} from '@xds/core/DateInput';
 import type {ISODateString} from '@xds/core/Calendar';
 
 const meta: Meta<typeof XDSDateInput> = {
-  title: 'Core/XDSDateInput',
+  title: 'Form/XDSDateInput',
   component: XDSDateInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Field.stories.tsx
+++ b/apps/storybook/stories/Field.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSField} from '@xds/core/Field';
 
 const meta: Meta<typeof XDSField> = {
-  title: 'Core/XDSField',
+  title: 'Form/XDSField',
   component: XDSField,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/NumberInput.stories.tsx
+++ b/apps/storybook/stories/NumberInput.stories.tsx
@@ -4,7 +4,7 @@ import {XDSNumberInput} from '@xds/core/NumberInput';
 import {HashtagIcon, CurrencyDollarIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSNumberInput> = {
-  title: 'Core/XDSNumberInput',
+  title: 'Form/XDSNumberInput',
   component: XDSNumberInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/RadioList.stories.tsx
+++ b/apps/storybook/stories/RadioList.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 
 const meta: Meta<typeof XDSRadioList> = {
-  title: 'Core/XDSRadioList',
+  title: 'Form/XDSRadioList',
   component: XDSRadioList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -4,7 +4,7 @@ import {XDSSelector, XDSSelectorItem} from '@xds/core/Selector';
 import {UserIcon, CogIcon, BellIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSelector> = {
-  title: 'Core/XDSSelector',
+  title: 'Form/XDSSelector',
   component: XDSSelector,
   tags: ['autodocs'],
   parameters: {

--- a/apps/storybook/stories/Slider.stories.tsx
+++ b/apps/storybook/stories/Slider.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSSlider} from '@xds/core/Slider';
 
 const meta: Meta<typeof XDSSlider> = {
-  title: 'Core/XDSSlider',
+  title: 'Form/XDSSlider',
   component: XDSSlider,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/Switch.stories.tsx
+++ b/apps/storybook/stories/Switch.stories.tsx
@@ -9,7 +9,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSSwitch> = {
-  title: 'Core/XDSSwitch',
+  title: 'Form/XDSSwitch',
   component: XDSSwitch,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSTabList, XDSTab, XDSTabMenu} from '@xds/core/TabList';
 
 const meta: Meta<typeof XDSTabList> = {
-  title: 'Core/XDSTabList',
+  title: 'Navigation/XDSTabList',
   component: XDSTabList,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextArea> = {
-  title: 'Core/XDSTextArea',
+  title: 'Form/XDSTextArea',
   component: XDSTextArea,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTextInput> = {
-  title: 'Core/XDSTextInput',
+  title: 'Form/XDSTextInput',
   component: XDSTextInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TimeInput.stories.tsx
+++ b/apps/storybook/stories/TimeInput.stories.tsx
@@ -4,7 +4,7 @@ import {XDSTimeInput} from '@xds/core/TimeInput';
 import type {ISOTimeString} from '@xds/core';
 
 const meta: Meta<typeof XDSTimeInput> = {
-  title: 'Core/XDSTimeInput',
+  title: 'Form/XDSTimeInput',
   component: XDSTimeInput,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/stories/TopNav.stories.tsx
+++ b/apps/storybook/stories/TopNav.stories.tsx
@@ -18,7 +18,7 @@ import {
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSTopNav> = {
-  title: 'Core/XDSTopNav',
+  title: 'Navigation/XDSTopNav',
   component: XDSTopNav,
   tags: ['autodocs'],
   parameters: {

--- a/packages/cli/src/commands/component.mjs
+++ b/packages/cli/src/commands/component.mjs
@@ -16,30 +16,46 @@ import {findCoreDir} from '../utils/paths.mjs';
  * Adding a new component file to an existing directory requires NO changes here.
  */
 const DIR_TO_CATEGORY = {
+  // Layout
   AspectRatio: 'Layout',
   Center: 'Layout',
   Grid: 'Layout',
   Layout: 'Layout',
+  // Display
   Avatar: 'Display',
   Badge: 'Display',
   Divider: 'Display',
   Icon: 'Display',
   Skeleton: 'Display',
+  Table: 'Display',
   Text: 'Display',
+  // Form
   CheckboxInput: 'Form',
   DateInput: 'Form',
   Field: 'Form',
+  NumberInput: 'Form',
+  RadioList: 'Form',
   Selector: 'Form',
+  Slider: 'Form',
   Switch: 'Form',
   TextArea: 'Form',
   TextInput: 'Form',
   TimeInput: 'Form',
+  // Action
   Button: 'Action',
+  CloseButton: 'Action',
+  DropdownMenu: 'Action',
+  Link: 'Action',
+  // Navigation
+  TabList: 'Navigation',
+  TopNav: 'Navigation',
+  // Overlay
   Calendar: 'Overlay',
+  Dialog: 'Overlay',
   Layer: 'Overlay',
 };
 
-const CATEGORY_ORDER = ['Layout', 'Display', 'Form', 'Action', 'Overlay'];
+const CATEGORY_ORDER = ['Layout', 'Display', 'Form', 'Action', 'Navigation', 'Overlay'];
 const SKIP_DIRS = new Set(['theme', 'hooks', 'utils', '__tests__', 'node_modules']);
 
 /**


### PR DESCRIPTION
## Summary

Aligns storybook story categories with the CLI `DIR_TO_CATEGORY` mapping, and adds newly created components to the CLI category map.

### CLI changes (`packages/cli/src/commands/component.mjs`)

Added 10 missing components to `DIR_TO_CATEGORY`:

| Component | Category |
|-----------|----------|
| RadioList | Form |
| NumberInput | Form |
| Slider | Form |
| CloseButton | Action |
| Link | Action |
| DropdownMenu | Action |
| Dialog | Overlay |
| Table | Display |
| TabList | Navigation (new) |
| TopNav | Navigation (new) |

Added `Navigation` to `CATEGORY_ORDER`.

### Storybook changes

Moved 11 form components from `Core/` → `Form/`:
- CheckboxInput, DateInput, Field, NumberInput, RadioList, Selector, Slider, Switch, TextArea, TextInput, TimeInput

Moved 2 navigation components from `Core/` → `Navigation/`:
- TabList, TopNav

Existing categories (`Layout/`, `Typography/`, `Core/`) are unchanged.

### Testing

All 16 existing CLI tests pass.

---
*Crafted with care by Navi*