### PR TITLE
Audit: fix API guideline violations across components

### DIFF
--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -155,7 +155,7 @@ export const WithDisabledItems: Story = {
       items={[
         {label: 'Edit', onClick: () => console.log('Edit')},
         {label: 'Duplicate', onClick: () => console.log('Duplicate')},
-        {label: 'Delete (disabled)', disabled: true},
+        {label: 'Delete (disabled)', isDisabled: true},
       ]}
     />
   ),

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -78,7 +78,10 @@ const variants = stylex.create({
  */
 export type XDSBadgeVariant = keyof typeof variants;
 
-export interface XDSBadgeProps extends HTMLAttributes<HTMLSpanElement> {
+export interface XDSBadgeProps extends Omit<
+  HTMLAttributes<HTMLSpanElement>,
+  'className' | 'style'
+> {
   /**
    * The visual style variant of the badge.
    * @default 'neutral'

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
@@ -190,7 +190,7 @@ describe('XDSDropdownMenu items', () => {
     render(
       <XDSDropdownMenu
         button={{label: 'Actions'}}
-        items={[{label: 'Edit', onClick: handleClick, disabled: true}]}
+        items={[{label: 'Edit', onClick: handleClick, isDisabled: true}]}
       />,
     );
 
@@ -204,7 +204,7 @@ describe('XDSDropdownMenu items', () => {
     render(
       <XDSDropdownMenu
         button={{label: 'Actions'}}
-        items={[{label: 'Edit', disabled: true}]}
+        items={[{label: 'Edit', isDisabled: true}]}
       />,
     );
     expect(

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -122,8 +122,9 @@ export interface XDSDropdownMenuItemData {
 
   /**
    * Whether the item is disabled.
+   * @default false
    */
-  disabled?: boolean;
+  isDisabled?: boolean;
 
   /**
    * Icon to display before the label.
@@ -226,6 +227,8 @@ export interface XDSDropdownMenuProps {
 
   /**
    * Whether the menu is open (controlled mode).
+   * When omitted, the component manages its own open state.
+   * @default undefined
    */
   isMenuOpen?: boolean;
 
@@ -372,7 +375,7 @@ export function XDSDropdownMenu({
   // Handle item click
   const handleItemClick = useCallback(
     (item: XDSDropdownMenuItemData) => {
-      if (item.disabled) return;
+      if (item.isDisabled) return;
       item.onClick?.();
       closeMenu();
     },
@@ -382,7 +385,7 @@ export function XDSDropdownMenu({
   // Handle item mouse enter
   const handleItemMouseEnter = useCallback(
     (item: XDSDropdownMenuItemData, index: number) => {
-      if (item.disabled) return;
+      if (item.isDisabled) return;
       setHighlightedIndex(index);
     },
     [],
@@ -408,7 +411,7 @@ export function XDSDropdownMenu({
             // Skip disabled items
             while (
               next < selectableItems.length &&
-              selectableItems[next].disabled
+              selectableItems[next].isDisabled
             ) {
               next++;
             }
@@ -420,7 +423,7 @@ export function XDSDropdownMenu({
           setHighlightedIndex(prev => {
             let next = prev - 1;
             // Skip disabled items
-            while (next >= 0 && selectableItems[next].disabled) {
+            while (next >= 0 && selectableItems[next].isDisabled) {
               next--;
             }
             return next >= 0 ? next : prev;
@@ -432,7 +435,7 @@ export function XDSDropdownMenu({
             let index = 0;
             while (
               index < selectableItems.length &&
-              selectableItems[index].disabled
+              selectableItems[index].isDisabled
             ) {
               index++;
             }
@@ -443,7 +446,7 @@ export function XDSDropdownMenu({
           e.preventDefault();
           {
             let index = selectableItems.length - 1;
-            while (index >= 0 && selectableItems[index].disabled) {
+            while (index >= 0 && selectableItems[index].isDisabled) {
               index--;
             }
             setHighlightedIndex(index >= 0 ? index : -1);
@@ -479,13 +482,13 @@ export function XDSDropdownMenu({
           id={getItemId(flatIndex)}
           role="menuitem"
           tabIndex={-1}
-          aria-disabled={item.disabled}
+          aria-disabled={item.isDisabled}
           onClick={() => handleItemClick(item)}
           onMouseEnter={() => handleItemMouseEnter(item, flatIndex)}
           {...stylex.props(
             styles.item,
             isHighlighted && styles.itemHighlighted,
-            item.disabled && styles.itemDisabled,
+            item.isDisabled && styles.itemDisabled,
           )}>
           {children ? children(item) : <DefaultItem item={item} />}
         </div>

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -108,7 +108,10 @@ export type XDSSkeletonRadius = keyof typeof radiusStyles;
 // Component
 // =============================================================================
 
-export interface XDSSkeletonProps extends HTMLAttributes<HTMLDivElement> {
+export interface XDSSkeletonProps extends Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'className' | 'style'
+> {
   /**
    * Width of the skeleton.
    * Accepts a number (pixels) or string (any CSS value).

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -626,17 +626,17 @@ describe('XDSTableRow', () => {
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLTableRowElement));
   });
 
-  it('passes through HTML attributes', () => {
+  it('passes through HTML attributes (excluding className/style)', () => {
     render(
       <table>
         <tbody>
-          <XDSTableRow className="custom" data-testid="row">
+          <XDSTableRow data-testid="row" aria-label="test row">
             <td>Cell</td>
           </XDSTableRow>
         </tbody>
       </table>,
     );
-    expect(screen.getByTestId('row')).toHaveClass('custom');
+    expect(screen.getByTestId('row')).toHaveAttribute('aria-label', 'test row');
   });
 });
 

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -21,7 +21,10 @@ import type {StyleXStyles} from '../theme/types';
 import {XDSTableContext} from './XDSTableContext';
 
 /** Props for XDSTableCell — thin `<td>` wrapper */
-export interface XDSTableCellProps extends TdHTMLAttributes<HTMLTableCellElement> {
+export interface XDSTableCellProps extends Omit<
+  TdHTMLAttributes<HTMLTableCellElement>,
+  'className' | 'style'
+> {
   children?: ReactNode;
 }
 

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -21,7 +21,10 @@ import type {StyleXStyles} from '../theme/types';
 import {XDSTableContext} from './XDSTableContext';
 
 /** Props for XDSTableRow — thin `<tr>` wrapper */
-export interface XDSTableRowProps extends HTMLAttributes<HTMLTableRowElement> {
+export interface XDSTableRowProps extends Omit<
+  HTMLAttributes<HTMLTableRowElement>,
+  'className' | 'style'
+> {
   children: ReactNode;
 }
 


### PR DESCRIPTION
## Summary

Audited all XDS components against the API guidelines in `.context/decisions/api-guidance.md`. Found and fixed the following violations:

### Boolean prop naming (must use `is`/`has` prefix)

- **DropdownMenu**: Renamed `disabled` → `isDisabled` on `XDSDropdownMenuItemData` interface
  - Updated all internal usages (keyboard navigation, click handlers, aria attributes, styling)
  - Updated tests and storybook stories

### No `className` or `style` props

Four components extended `HTMLAttributes` without omitting `className` and `style`, allowing these props to leak through:

- **Badge** (`XDSBadgeProps`): Added `Omit<..., 'className' | 'style'>`
- **Skeleton** (`XDSSkeletonProps`): Added `Omit<..., 'className' | 'style'>`
- **TableCell** (`XDSTableCellProps`): Added `Omit<..., 'className' | 'style'>`
- **TableRow** (`XDSTableRowProps`): Added `Omit<..., 'className' | 'style'>`

### JSDoc `@default` annotations

- Added `@default false` to `XDSDropdownMenuItemData.isDisabled`
- Added `@default undefined` to `XDSDropdownMenuProps.isMenuOpen`

### What passed audit (no violations found)

- ✅ All components use `forwardRef` with `displayName` set
- ✅ All exported props interfaces have JSDoc comments
- ✅ Callbacks follow `on{Verb}{Scope}` pattern
- ✅ `data-testid` used (not `testId` or `data-test-id`)
- ✅ All other boolean props already use `is`/`has` prefix
- ✅ `value` props on CheckboxInput/Switch are controlled component values (not boolean flags)

### Testing

All 725 tests pass. Updated the `XDSTableRow` test that was asserting `className` passthrough to instead test `aria-label` passthrough.

---
*Crafted with care by Navi*