### PR TITLE
Fix API guideline violations

### DIFF
--- a/apps/storybook/stories/Heading.stories.tsx
+++ b/apps/storybook/stories/Heading.stories.tsx
@@ -301,7 +301,7 @@ export const MultiLineTruncation: Story = {
 export const TruncationWithoutTooltip: Story = {
   render: () => (
     <div style={{width: '300px', border: '1px solid #ccc', padding: '12px'}}>
-      <XDSHeading level={2} maxLines={1} truncateTooltip={false}>
+      <XDSHeading level={2} maxLines={1} hasTruncateTooltip={false}>
         Truncated Heading Without Tooltip On Hover
       </XDSHeading>
     </div>

--- a/apps/storybook/stories/Text.stories.tsx
+++ b/apps/storybook/stories/Text.stories.tsx
@@ -242,7 +242,7 @@ export const MultiLineTruncation: Story = {
 export const TruncationWithoutTooltip: Story = {
   render: () => (
     <div style={{width: '300px', border: '1px solid #ccc', padding: '12px'}}>
-      <XDSText type="body" maxLines={1} truncateTooltip={false}>
+      <XDSText type="body" maxLines={1} hasTruncateTooltip={false}>
         This text is truncated but has no tooltip on hover. Sometimes you don't
         want a tooltip.
       </XDSText>

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -316,3 +316,6 @@ export const XDSBaseTable = forwardRef(XDSBaseTableInner) as <
 >(
   props: XDSBaseTableProps<T> & {ref?: Ref<HTMLTableElement>},
 ) => ReactElement;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(XDSBaseTable as any).displayName = 'XDSBaseTable';

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -235,3 +235,6 @@ export const XDSTable = forwardRef(XDSTableInner) as <
 >(
   props: XDSTableProps<T> & {ref?: Ref<HTMLTableElement>},
 ) => ReactElement;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(XDSTable as any).displayName = 'XDSTable';

--- a/packages/core/src/Text/XDSFontWrapper.tsx
+++ b/packages/core/src/Text/XDSFontWrapper.tsx
@@ -97,6 +97,8 @@ export function XDSFontWrapper({
   );
 }
 
+XDSFontWrapper.displayName = 'XDSFontWrapper';
+
 /**
  * Hook to access font wrapper styles from the current theme.
  * Use this for applying styles to native HTML elements programmatically.

--- a/packages/core/src/Text/XDSHeading.test.tsx
+++ b/packages/core/src/Text/XDSHeading.test.tsx
@@ -174,10 +174,10 @@ describe('XDSHeading', () => {
       expect(screen.getByText('Heading with word break')).toBeInTheDocument();
     });
 
-    it('accepts truncateTooltip=false to disable tooltip', () => {
+    it('accepts hasTruncateTooltip=false to disable tooltip', () => {
       render(
         <XDSTheme theme={defaultTheme}>
-          <XDSHeading level={1} maxLines={1} truncateTooltip={false}>
+          <XDSHeading level={1} maxLines={1} hasTruncateTooltip={false}>
             No tooltip
           </XDSHeading>
         </XDSTheme>,

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -100,7 +100,7 @@ export interface XDSHeadingProps {
    * - Position value: show tooltip at specific position
    * @default true
    */
-  truncateTooltip?: boolean | LayerPlacement;
+  hasTruncateTooltip?: boolean | LayerPlacement;
 
   /**
    * Word break behavior for truncated text.
@@ -188,7 +188,7 @@ export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
       color = 'primary',
       display = 'block',
       maxLines = 0,
-      truncateTooltip = true,
+      hasTruncateTooltip = true,
       wordBreak,
       textWrap,
       hasCapsize = false,
@@ -228,9 +228,9 @@ export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
 
     // Tooltip for truncated text
     const tooltipPlacement: LayerPlacement =
-      typeof truncateTooltip === 'string' ? truncateTooltip : 'above';
+      typeof hasTruncateTooltip === 'string' ? hasTruncateTooltip : 'above';
     const tooltipEnabled =
-      maxLines > 0 && truncateTooltip !== false && truncation.isTruncated;
+      maxLines > 0 && hasTruncateTooltip !== false && truncation.isTruncated;
 
     const tooltip = useXDSTooltip({
       placement: tooltipPlacement,
@@ -297,3 +297,5 @@ export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
     );
   },
 );
+
+XDSHeading.displayName = 'XDSHeading';

--- a/packages/core/src/Text/XDSText.test.tsx
+++ b/packages/core/src/Text/XDSText.test.tsx
@@ -213,10 +213,10 @@ describe('XDSText', () => {
       expect(screen.getByText('Text with word break')).toBeInTheDocument();
     });
 
-    it('accepts truncateTooltip=false to disable tooltip', () => {
+    it('accepts hasTruncateTooltip=false to disable tooltip', () => {
       render(
         <XDSTheme theme={defaultTheme}>
-          <XDSText type="body" maxLines={1} truncateTooltip={false}>
+          <XDSText type="body" maxLines={1} hasTruncateTooltip={false}>
             No tooltip
           </XDSText>
         </XDSTheme>,

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -90,7 +90,7 @@ export interface XDSTextProps {
    * - Position value: show tooltip at specific position
    * @default true
    */
-  truncateTooltip?: boolean | LayerPlacement;
+  hasTruncateTooltip?: boolean | LayerPlacement;
 
   /**
    * Word break behavior for truncated text.
@@ -182,7 +182,7 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
     weight,
     display = 'inline',
     maxLines = 0,
-    truncateTooltip = true,
+    hasTruncateTooltip = true,
     wordBreak,
     textWrap,
     hasCapsize = false,
@@ -214,9 +214,9 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
 
   // Tooltip for truncated text
   const tooltipPlacement: LayerPlacement =
-    typeof truncateTooltip === 'string' ? truncateTooltip : 'above';
+    typeof hasTruncateTooltip === 'string' ? hasTruncateTooltip : 'above';
   const tooltipEnabled =
-    maxLines > 0 && truncateTooltip !== false && truncation.isTruncated;
+    maxLines > 0 && hasTruncateTooltip !== false && truncation.isTruncated;
 
   const tooltip = useXDSTooltip({
     placement: tooltipPlacement,
@@ -283,3 +283,5 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
     </>
   );
 });
+
+XDSText.displayName = 'XDSText';

--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -117,5 +117,7 @@ export function XDSTheme({
   );
 }
 
+XDSTheme.displayName = 'XDSTheme';
+
 /** @deprecated Use XDSTheme instead */
 export const Theme = XDSTheme;


### PR DESCRIPTION
## Summary

Fix API guideline violations across the XDS component library.

### Changes

#### 1. Boolean prop naming: `truncateTooltip` → `hasTruncateTooltip`

Per the `is/has` boolean naming convention, renamed the `truncateTooltip` prop to `hasTruncateTooltip` in:

- `XDSHeading` — interface, default value, and internal usage
- `XDSText` — interface, default value, and internal usage
- `XDSHeading.test.tsx` — updated test references
- `XDSText.test.tsx` — updated test references
- `Heading.stories.tsx` — updated story usage
- `Text.stories.tsx` — updated story usage

#### 2. Missing `displayName`

Added explicit `displayName` to components that were missing it:

- `XDSBaseTable.displayName = 'XDSBaseTable'`
- `XDSTable.displayName = 'XDSTable'`
- `XDSFontWrapper.displayName = 'XDSFontWrapper'`
- `XDSHeading.displayName = 'XDSHeading'`
- `XDSText.displayName = 'XDSText'`
- `XDSTheme.displayName = 'XDSTheme'`

Note: `XDSBaseTable` and `XDSTable` use generic `forwardRef` with `as` casts that erase the `displayName` type, so these use `(Component as any).displayName` to work around the TypeScript limitation.

#### 3. DropdownMenu `disabled` — no change (intentional)

`XDSDropdownMenuItemData.disabled` is a **data interface field**, not a component prop. It's used as `items={[{label: 'foo', disabled: true}]}` — data objects don't follow the `is/has` convention. Left as-is.

### Testing

All 725 tests pass. Lint and prettier pass via lint-staged.

---
*Crafted with care by Navi*