### PR TITLE
Refactor: replace inline spinners with XDSSpinner

### DIFF
--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -31,6 +31,7 @@ import {
 } from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
 import {XDSTooltip} from '../Layer/XDSTooltip';
+import {XDSSpinner} from '../Spinner';
 
 /**
  * Base button styles
@@ -241,34 +242,6 @@ const loadingStyles = stylex.create({
     position: 'relative',
     color: 'transparent',
   },
-  spinner: {
-    position: 'absolute',
-    width: '1em',
-    height: '1em',
-    borderWidth: '2px',
-    borderStyle: 'solid',
-    borderColor: 'currentColor',
-    borderRightColor: 'transparent',
-    borderRadius: '50%',
-    animationName: stylex.keyframes({
-      to: {transform: 'rotate(360deg)'},
-    }),
-    animationDuration: '0.6s',
-    animationTimingFunction: 'linear',
-    animationIterationCount: 'infinite',
-  },
-  spinnerLight: {
-    borderTopColor: colorVars['--color-icon-on-media'],
-    borderLeftColor: colorVars['--color-icon-on-media'],
-    borderBottomColor: colorVars['--color-icon-on-media'],
-    borderRightColor: 'transparent',
-  },
-  spinnerDark: {
-    borderTopColor: colorVars['--color-text-primary'],
-    borderLeftColor: colorVars['--color-text-primary'],
-    borderBottomColor: colorVars['--color-text-primary'],
-    borderRightColor: 'transparent',
-  },
 });
 
 /**
@@ -327,13 +300,17 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
         {...props}>
         {isLoading && (
           <span
-            {...stylex.props(
-              loadingStyles.spinner,
-              useLightSpinner
-                ? loadingStyles.spinnerLight
-                : loadingStyles.spinnerDark,
-            )}
-          />
+            style={{
+              position: 'absolute',
+              top: '50%',
+              left: '50%',
+              transform: 'translate(-50%, -50%)',
+            }}>
+            <XDSSpinner
+              size="sm"
+              shade={useLightSpinner ? 'onMedia' : 'default'}
+            />
+          </span>
         )}
         {icon}
         {children ?? (isIconOnly ? null : label)}

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -302,9 +302,13 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
           <span
             style={{
               position: 'absolute',
-              top: '50%',
-              left: '50%',
-              transform: 'translate(-50%, -50%)',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}>
             <XDSSpinner
               size="sm"


### PR DESCRIPTION
Replaces the Button's inline CSS border spinner with the new XDSSpinner component.

## Changes
- Remove `loadingStyles.spinner`, `spinnerLight`, `spinnerDark` from Button
- Use `<XDSSpinner size="sm" shade={...} />` instead
- `shade="onMedia"` for primary/destructive variants, `"default"` for secondary/ghost

## Why
XDSSpinner was just merged to main with a proper canvas-based spinner implementation. The Button had its own inline CSS border spinner that duplicated this functionality. This refactor consolidates to a single spinner component for consistency and maintainability.

## Testing
- All 10 existing Button tests pass
- Loading stories in Storybook continue to work

## Follow-up
The react-transitions PR (#93) adds spinners to 7 more components (CheckboxInput, Switch, TextInput, TextArea, DateInput, TimeInput, Selector). Those should also adopt XDSSpinner when #93 merges.

---
*Crafted with care by Navi*