### PR TITLE
feat(cli): add fuzzy search and props-only mode to component docs

### DIFF
--- a/packages/cli/src/commands/component.mjs
+++ b/packages/cli/src/commands/component.mjs
@@ -359,6 +359,89 @@ export function findComponentSource(coreDir, name) {
   return searchDir(srcDir);
 }
 
+/**
+ * Compute the Levenshtein (edit) distance between two strings.
+ * Used for fuzzy-matching component names. Dependency-free.
+ */
+export function levenshteinDistance(a, b) {
+  const m = a.length, n = b.length;
+  const dp = Array.from({length: m + 1}, () => Array(n + 1).fill(0));
+  for (let i = 0; i <= m; i++) dp[i][0] = i;
+  for (let j = 0; j <= n; j++) dp[0][j] = j;
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      dp[i][j] = a[i-1] === b[j-1]
+        ? dp[i-1][j-1]
+        : 1 + Math.min(dp[i-1][j], dp[i][j-1], dp[i-1][j-1]);
+    }
+  }
+  return dp[m][n];
+}
+
+/**
+ * Find the closest component names to a given (possibly misspelled) name.
+ * Returns matches sorted by distance, filtered to maxDistance.
+ */
+export function findClosestComponents(name, components, maxDistance = 3) {
+  const allNames = Object.values(components).flat();
+  const needle = name.toLowerCase();
+
+  const matches = allNames
+    .map(comp => ({
+      name: comp,
+      distance: levenshteinDistance(needle, comp.toLowerCase()),
+    }))
+    .filter(m => m.distance <= maxDistance)
+    .sort((a, b) => a.distance - b.distance);
+
+  return matches;
+}
+
+/**
+ * Extract only the Props section(s) from a README.
+ * Useful for quick reference and LLM context.
+ */
+export function extractProps(content, componentName) {
+  const lines = content.split('\n');
+  const output = [];
+  let inPropsSection = false;
+  let sectionDepth = 0;
+
+  for (const line of lines) {
+    // Detect Props section (## Props or ### XDSFoo Props)
+    if (/^#{2,3}\s+.*Props/.test(line)) {
+      inPropsSection = true;
+      sectionDepth = line.match(/^(#+)/)[1].length;
+      output.push(line);
+      continue;
+    }
+
+    // Exit props section when hitting another section at same or higher level
+    if (inPropsSection && /^#{2,3}\s+/.test(line) && !line.includes('Props')) {
+      const depth = line.match(/^(#+)/)[1].length;
+      if (depth <= sectionDepth) {
+        inPropsSection = false;
+        continue;
+      }
+    }
+
+    if (inPropsSection) {
+      output.push(line);
+    }
+  }
+
+  if (output.length === 0) {
+    return `No props documentation found for ${componentName}.\n`;
+  }
+
+  // Trim trailing blank lines
+  while (output.length > 0 && output[output.length - 1].trim() === '') {
+    output.pop();
+  }
+
+  return output.join('\n') + '\n';
+}
+
 export function registerComponent(program) {
   program
     .command('component [name]')
@@ -366,6 +449,7 @@ export function registerComponent(program) {
     .option('--list', 'List all components grouped by category')
     .option('--category <category>', 'List components in a specific category')
     .option('--compact', 'Token-optimized output for LLMs')
+    .option('--props', 'Print only the props table')
     .option('--source', 'Print component source code')
     .action((name, options) => {
       const coreDir = findCoreDir(process.cwd());
@@ -428,20 +512,44 @@ export function registerComponent(program) {
         return;
       }
 
-      const readmePath = findComponentReadme(coreDir, dirName);
+      let readmePath = findComponentReadme(coreDir, dirName);
+      let resolvedName = dirName;
 
       if (!readmePath) {
-        console.error(`Error: Component "${name}" not found.`);
-        console.error('Run `npx xds component --list` to see available components.');
-        process.exit(1);
+        // Try fuzzy matching
+        const components = discoverComponents(coreDir);
+        const closest = findClosestComponents(dirName, components);
+
+        if (closest.length === 1) {
+          resolvedName = closest[0].name;
+          readmePath = findComponentReadme(coreDir, resolvedName);
+          if (readmePath) {
+            console.log(`Did you mean ${resolvedName}?\n`);
+          }
+        } else if (closest.length > 1) {
+          console.error(`Component "${name}" not found. Did you mean one of these?\n`);
+          for (const match of closest) {
+            console.error(`  ${match.name}`);
+          }
+          console.error('');
+          process.exit(1);
+        }
+
+        if (!readmePath) {
+          console.error(`Error: Component "${name}" not found.`);
+          console.error('Run `npx xds component --list` to see available components.');
+          process.exit(1);
+        }
       }
 
       const content = fs.readFileSync(readmePath, 'utf-8');
 
-      if (options.compact) {
-        console.log(extractCompact(content, dirName));
+      if (options.props) {
+        console.log(extractProps(content, resolvedName));
+      } else if (options.compact) {
+        console.log(extractCompact(content, resolvedName));
       } else {
-        console.log(cleanReadme(content, dirName));
+        console.log(cleanReadme(content, resolvedName));
       }
     });
 }

--- a/packages/cli/src/commands/component.test.mjs
+++ b/packages/cli/src/commands/component.test.mjs
@@ -6,8 +6,11 @@ import {
   discoverComponents,
   cleanReadme,
   extractCompact,
+  extractProps,
   findComponentReadme,
   findComponentSource,
+  levenshteinDistance,
+  findClosestComponents,
 } from './component.mjs';
 
 let tmpDir;
@@ -239,5 +242,152 @@ describe('findComponentSource', () => {
     const srcDir = path.join(tmpDir, 'src');
     fs.mkdirSync(srcDir, {recursive: true});
     expect(findComponentSource(tmpDir, 'NonExistent')).toBeNull();
+  });
+});
+
+describe('levenshteinDistance', () => {
+  it('returns 0 for identical strings', () => {
+    expect(levenshteinDistance('button', 'button')).toBe(0);
+  });
+
+  it('returns correct distance for single edit', () => {
+    expect(levenshteinDistance('button', 'buton')).toBe(1);
+  });
+
+  it('returns correct distance for multiple edits', () => {
+    expect(levenshteinDistance('button', 'butan')).toBe(2);
+  });
+
+  it('handles empty strings', () => {
+    expect(levenshteinDistance('', 'abc')).toBe(3);
+    expect(levenshteinDistance('abc', '')).toBe(3);
+    expect(levenshteinDistance('', '')).toBe(0);
+  });
+
+  it('handles completely different strings', () => {
+    expect(levenshteinDistance('abc', 'xyz')).toBe(3);
+  });
+});
+
+describe('findClosestComponents', () => {
+  const components = {
+    Action: ['Button', 'CloseButton', 'Link'],
+    Form: ['TextInput', 'CheckboxInput', 'Switch'],
+    Display: ['Avatar', 'Badge', 'Text'],
+  };
+
+  it('finds exact match (distance 0)', () => {
+    const matches = findClosestComponents('Button', components);
+    expect(matches[0]).toEqual({name: 'Button', distance: 0});
+  });
+
+  it('finds close match for misspelling', () => {
+    const matches = findClosestComponents('buton', components);
+    expect(matches.length).toBeGreaterThan(0);
+    expect(matches[0].name).toBe('Button');
+    expect(matches[0].distance).toBe(1);
+  });
+
+  it('is case-insensitive', () => {
+    const matches = findClosestComponents('BUTTON', components);
+    expect(matches[0]).toEqual({name: 'Button', distance: 0});
+  });
+
+  it('returns empty array for no close matches', () => {
+    const matches = findClosestComponents('zzzzzzzzz', components);
+    expect(matches).toEqual([]);
+  });
+
+  it('returns multiple matches when ambiguous', () => {
+    // "Buttn" is close to both "Button" (distance 1) and could be near others
+    const matches = findClosestComponents('Butten', components);
+    // Should match at least Button
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    expect(matches[0].name).toBe('Button');
+    // With maxDistance=3, "Badge" (distance 5) won't match,
+    // but let's verify multiple matches with a wider net
+    const wideMatches = findClosestComponents('Butten', components, 5);
+    expect(wideMatches.length).toBeGreaterThan(1);
+  });
+
+  it('respects maxDistance parameter', () => {
+    const matches = findClosestComponents('buton', components, 0);
+    expect(matches).toEqual([]);
+  });
+});
+
+describe('extractProps', () => {
+  it('extracts a Props section from README content', () => {
+    const input = [
+      '# Button',
+      '',
+      '## Description',
+      'A button component.',
+      '',
+      '## Props',
+      '',
+      '| Prop | Type | Default |',
+      '|------|------|---------|',
+      '| size | string | "md" |',
+      '| variant | string | "primary" |',
+      '',
+      '## Examples',
+      'Some examples here.',
+    ].join('\n');
+
+    const result = extractProps(input, 'Button');
+    expect(result).toContain('## Props');
+    expect(result).toContain('| size | string | "md" |');
+    expect(result).toContain('| variant | string | "primary" |');
+    expect(result).not.toContain('## Description');
+    expect(result).not.toContain('## Examples');
+  });
+
+  it('extracts multiple Props sections', () => {
+    const input = [
+      '# Layout',
+      '',
+      '## XDSLayout Props',
+      '| Prop | Type |',
+      '|------|------|',
+      '| gap | number |',
+      '',
+      '## XDSLayoutItem Props',
+      '| Prop | Type |',
+      '|------|------|',
+      '| flex | number |',
+      '',
+      '## Examples',
+      'Some examples.',
+    ].join('\n');
+
+    const result = extractProps(input, 'Layout');
+    expect(result).toContain('## XDSLayout Props');
+    expect(result).toContain('| gap | number |');
+    expect(result).toContain('## XDSLayoutItem Props');
+    expect(result).toContain('| flex | number |');
+    expect(result).not.toContain('## Examples');
+  });
+
+  it('returns fallback message when no Props section found', () => {
+    const input = '# Button\n\n## Description\nA button.\n';
+    const result = extractProps(input, 'Button');
+    expect(result).toBe('No props documentation found for Button.\n');
+  });
+
+  it('trims trailing blank lines', () => {
+    const input = [
+      '## Props',
+      '| Prop | Type |',
+      '|------|------|',
+      '| size | string |',
+      '',
+      '',
+      '',
+    ].join('\n');
+
+    const result = extractProps(input, 'Button');
+    expect(result).not.toMatch(/\n\n$/);
+    expect(result).toMatch(/\n$/);
   });
 });


### PR DESCRIPTION
## Summary

Two improvements to `npx xds component`:

### Fuzzy search
Partial or misspelled component names now find the closest match:
```bash
npx xds component buton     # → Did you mean Button?
npx xds component textinp   # → Did you mean TextInput?
```

Uses Levenshtein distance (dependency-free). Shows docs directly for close matches, lists options for ambiguous ones.

### Props-only mode
New `--props` flag prints just the props table — no description, no examples:
```bash
npx xds component Button --props
```

Useful for quick reference and LLM context.

## Changes

- `packages/cli/src/commands/component.mjs` — added `levenshteinDistance`, `findClosestComponents`, `extractProps`, updated command handler
- `packages/cli/src/commands/component.test.mjs` — tests for new functions

Closes #133

---
*Crafted with care by Navi*