### PR TITLE
fix(inputs): add border-box sizing to input wrappers

### DIFF
--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -45,6 +45,7 @@ const styles = stylex.create({
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
+    boxSizing: 'border-box',
     gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -46,6 +46,7 @@ const styles = stylex.create({
     zIndex: 1,
     display: 'flex',
     alignItems: 'center',
+    boxSizing: 'border-box',
     gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -36,6 +36,7 @@ const styles = stylex.create({
     zIndex: 1,
     display: 'flex',
     alignItems: 'flex-start',
+    boxSizing: 'border-box',
     gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -37,6 +37,7 @@ const styles = stylex.create({
     zIndex: 1,
     display: 'flex',
     alignItems: 'center',
+    boxSizing: 'border-box',
     gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -55,6 +55,7 @@ const styles = stylex.create({
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
+    boxSizing: 'border-box',
     gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],


### PR DESCRIPTION
## Summary

Adds `boxSizing: 'border-box'` to the outer wrapper styles of all five input components. Without this, padding and borders cause the elements to overflow their expected size.

### Changes

- **TextInput** — added `boxSizing: 'border-box'` to wrapper
- **TextArea** — added `boxSizing: 'border-box'` to wrapper
- **NumberInput** — added `boxSizing: 'border-box'` to wrapper
- **DateInput** — added `boxSizing: 'border-box'` to wrapper
- **TimeInput** — added `boxSizing: 'border-box'` to wrapper

### Notes

Inner `<input>` and `<textarea>` elements already had proper border/outline resets (`border: 0`, `outline: 0`, `backgroundColor: 'transparent'`). Audited other components with padding (Layout, Card, Section, Dialog) — they already handle box-sizing correctly via the container mixin or explicit declarations.

Fixes #150

---
*Crafted with care by Navi*