### PR TITLE
feat: add example-vite app for source distribution consumers

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -4,9 +4,10 @@ Application packages for development, documentation, and visual testing.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
-| Directory | Role | Purpose |
-|-----------|------|---------|
-| `docs/` | Documentation | Documentation website for the design system |
-| `sandbox/` | Development | Local development and testing environment |
-| `storybook/` | Visual Testing | Storybook for component development and visual documentation |
-
+| Directory         | Role           | Purpose                                                                        |
+| ----------------- | -------------- | ------------------------------------------------------------------------------ |
+| `docs/`           | Documentation  | Documentation website for the design system                                    |
+| `example-nextjs/` | Example        | Reference Next.js app for source distribution consumers (Babel + PostCSS path) |
+| `example-vite/`   | Example        | Reference Vite + React app for source distribution consumers (unplugin path)   |
+| `sandbox/`        | Development    | Local development and testing environment                                      |
+| `storybook/`      | Visual Testing | Storybook for component development and visual documentation                   |

--- a/apps/example-vite/.gitignore
+++ b/apps/example-vite/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+dist-ssr
+*.local

--- a/apps/example-vite/README.md
+++ b/apps/example-vite/README.md
@@ -1,0 +1,123 @@
+# XDS Example — Vite
+
+Reference application for consuming **@xds/core** as a source distribution in a Vite + React project.
+
+XDS ships as raw TypeScript + StyleX source. Consumers compile it at the application level — there's no pre-built CSS or JS bundle. This example shows the complete setup using `@stylexjs/unplugin`, which handles both StyleX compilation and CSS extraction in a single Vite plugin.
+
+## How it differs from Next.js
+
+| Concern             | Next.js                                                     | Vite                                 |
+| ------------------- | ----------------------------------------------------------- | ------------------------------------ |
+| StyleX integration  | Babel plugin + PostCSS plugin                               | `@stylexjs/unplugin` (single plugin) |
+| CSS extraction      | PostCSS replaces `@stylex;` at-rule                         | Handled automatically by unplugin    |
+| Config files needed | `babel.config.js` + `postcss.config.js` + `next.config.mjs` | `vite.config.ts` only                |
+| Theme provider      | Needs `'use client'` boundary                               | No client/server boundary needed     |
+
+## Setup Steps
+
+### 1. Install dependencies
+
+```bash
+npm install @stylexjs/stylex @xds/core @xds/theme react react-dom
+npm install --save-dev @stylexjs/unplugin @vitejs/plugin-react typescript \
+  @types/react @types/react-dom vite
+```
+
+### 2. Vite config
+
+`vite.config.ts` — configure the StyleX unplugin, React plugin, and resolve aliases:
+
+```ts
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+import stylex from '@stylexjs/unplugin';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [
+    stylex.vite({
+      dev: process.env.NODE_ENV === 'development',
+      runtimeInjection: false,
+      treeshakeCompensation: true,
+      unstable_moduleResolution: {
+        type: 'commonJS',
+        rootDir: __dirname,
+      },
+    }),
+    react(),
+  ],
+  resolve: {
+    alias: {
+      '@xds/core/theme/tokens.stylex': path.resolve(
+        __dirname,
+        'node_modules/@xds/core/src/theme/tokens.stylex.ts',
+      ),
+      '@xds/core': path.resolve(__dirname, 'node_modules/@xds/core/src'),
+    },
+  },
+});
+```
+
+> **Important:** The `resolve.alias` config points `@xds/core` to the source directory so Vite compiles XDS components from TypeScript source. The `unstable_moduleResolution` config helps StyleX resolve token definitions correctly. Plugin order matters — `stylex.vite()` must come before `react()`.
+
+### 3. CSS entry point
+
+`src/index.css` — a minimal CSS file so Vite emits a CSS asset for StyleX to append to:
+
+```css
+:root {
+  --stylex-injection: 0;
+}
+```
+
+Import it in `src/main.tsx`:
+
+```tsx
+import './index.css';
+```
+
+### 4. Theme provider
+
+Wrap your app with `XDSTheme` and the default theme:
+
+```tsx
+import {XDSTheme} from '@xds/core/theme';
+import {defaultTheme} from '@xds/theme/default';
+
+export default function App() {
+  return <XDSTheme theme={defaultTheme}>{/* your app */}</XDSTheme>;
+}
+```
+
+No `'use client'` needed — Vite doesn't have server/client boundaries.
+
+## Commands
+
+```bash
+# Start dev server with HMR
+npm run dev
+
+# Production build
+npm run build
+
+# Preview the production build
+npm run preview
+```
+
+## Gotchas
+
+| Issue                   | Symptom                                 | Fix                                                                       |
+| ----------------------- | --------------------------------------- | ------------------------------------------------------------------------- |
+| Missing resolve aliases | Module not found errors for `@xds/core` | Add `resolve.alias` pointing to source directory                          |
+| Missing CSS entry point | StyleX has no CSS asset to append to    | Create a minimal `index.css` and import it in `main.tsx`                  |
+| Plugin order            | Styles not extracted or HMR broken      | `stylex.vite()` must come before `react()` in the plugins array           |
+| Duplicate React types   | JSX component type errors in monorepo   | Known monorepo issue with `@types/react` hoisting; doesn't affect runtime |
+
+## Related
+
+- [Issue #145 — Example apps for source distribution consumers](https://github.com/facebookexperimental/xds/issues/145)
+- [StyleX Vite React example](https://github.com/facebook/stylex/tree/main/examples/example-vite-react)
+- [XDS Example — Next.js](../example-nextjs/)

--- a/apps/example-vite/index.html
+++ b/apps/example-vite/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>XDS Example — Vite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/example-vite/package.json
+++ b/apps/example-vite/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@xds/example-vite",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@stylexjs/stylex": "^0.17.4",
+    "@xds/core": "*",
+    "@xds/theme": "*",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0"
+  },
+  "devDependencies": {
+    "@stylexjs/unplugin": "^0.17.4",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.0",
+    "typescript": "^5.7.0",
+    "vite": "^5.4.0"
+  }
+}

--- a/apps/example-vite/src/App.tsx
+++ b/apps/example-vite/src/App.tsx
@@ -1,0 +1,106 @@
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSTheme} from '@xds/core/theme';
+import {defaultTheme} from '@xds/theme/default';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSDivider} from '@xds/core';
+
+const styles = stylex.create({
+  main: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: '100vh',
+    padding: '2rem',
+  },
+  container: {
+    maxWidth: 640,
+    width: '100%',
+  },
+});
+
+export default function App() {
+  const [email, setEmail] = useState('');
+
+  return (
+    <XDSTheme theme={defaultTheme}>
+      <main {...stylex.props(styles.main)}>
+        <div {...stylex.props(styles.container)}>
+          <XDSVStack gap="space6">
+            <XDSVStack gap="space2">
+              <XDSHeading level={1}>XDS Example — Vite</XDSHeading>
+              <XDSText type="body" color="secondary">
+                This is a reference example for consuming{' '}
+                <XDSText type="body" weight="bold">
+                  @xds/core
+                </XDSText>{' '}
+                as a source distribution in a Vite + React application. StyleX
+                compilation and CSS extraction are handled by{' '}
+                <XDSText type="body" weight="bold">
+                  @stylexjs/unplugin
+                </XDSText>{' '}
+                — no PostCSS or Babel config needed.
+              </XDSText>
+            </XDSVStack>
+
+            <XDSDivider />
+
+            {/* Buttons */}
+            <XDSVStack gap="space3">
+              <XDSHeading level={2}>Buttons</XDSHeading>
+              <XDSHStack gap="space3" vAlign="center">
+                <XDSButton label="Primary" variant="primary" />
+                <XDSButton label="Secondary" variant="secondary" />
+                <XDSButton label="Ghost" variant="ghost" />
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSDivider />
+
+            {/* Badges */}
+            <XDSVStack gap="space3">
+              <XDSHeading level={2}>Badges</XDSHeading>
+              <XDSHStack gap="space3" vAlign="center">
+                <XDSBadge variant="info">Info</XDSBadge>
+                <XDSBadge variant="success">Success</XDSBadge>
+                <XDSBadge variant="warning">Warning</XDSBadge>
+                <XDSBadge variant="error">Error</XDSBadge>
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSDivider />
+
+            {/* Text Input */}
+            <XDSVStack gap="space3">
+              <XDSHeading level={2}>Text Input</XDSHeading>
+              <XDSTextInput
+                label="Email address"
+                placeholder="you@example.com"
+                value={email}
+                onChange={setEmail}
+              />
+            </XDSVStack>
+
+            <XDSDivider />
+
+            {/* Typography */}
+            <XDSVStack gap="space3">
+              <XDSHeading level={2}>Typography</XDSHeading>
+              <XDSText type="large" weight="bold">
+                Large bold text
+              </XDSText>
+              <XDSText type="body">Default body text</XDSText>
+              <XDSText type="supporting" color="secondary">
+                Supporting text in secondary color
+              </XDSText>
+            </XDSVStack>
+          </XDSVStack>
+        </div>
+      </main>
+    </XDSTheme>
+  );
+}

--- a/apps/example-vite/src/index.css
+++ b/apps/example-vite/src/index.css
@@ -1,0 +1,4 @@
+/* Placeholder to ensure Vite emits a CSS asset for StyleX aggregation. */
+:root {
+  --stylex-injection: 0;
+}

--- a/apps/example-vite/src/main.tsx
+++ b/apps/example-vite/src/main.tsx
@@ -1,0 +1,10 @@
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import './index.css';
+import App from './App';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/example-vite/src/main.tsx
+++ b/apps/example-vite/src/main.tsx
@@ -1,5 +1,7 @@
 import {StrictMode} from 'react';
 import {createRoot} from 'react-dom/client';
+import '@xds/core/reset.css';
+import '@xds/core/typography.css';
 import './index.css';
 import App from './App';
 

--- a/apps/example-vite/tsconfig.app.json
+++ b/apps/example-vite/tsconfig.app.json
@@ -1,0 +1,32 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    /* Monorepo: resolve @xds packages to source */
+    "paths": {
+      "@xds/core/*": ["../../packages/core/src/*"],
+      "@xds/core": ["../../packages/core/src"],
+      "@xds/theme/*": ["../../packages/theme/src/*"]
+    }
+  },
+  "include": ["src"]
+}

--- a/apps/example-vite/tsconfig.json
+++ b/apps/example-vite/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/apps/example-vite/tsconfig.node.json
+++ b/apps/example-vite/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "types": ["node"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/example-vite/vite.config.ts
+++ b/apps/example-vite/vite.config.ts
@@ -1,0 +1,34 @@
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+import stylex from '@stylexjs/unplugin';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [
+    stylex.vite({
+      dev: process.env.NODE_ENV === 'development',
+      runtimeInjection: false,
+      treeshakeCompensation: true,
+      unstable_moduleResolution: {
+        type: 'commonJS',
+        rootDir: __dirname,
+      },
+    }),
+    react(),
+  ],
+  resolve: {
+    alias: {
+      // Alias @xds/core subpaths to source files so Vite compiles them
+      // from TypeScript source rather than requiring a pre-built dist/.
+      '@xds/core/theme/tokens.stylex': path.resolve(
+        __dirname,
+        '../../packages/core/src/theme/tokens.stylex.ts',
+      ),
+      '@xds/core': path.resolve(__dirname, '../../packages/core/src'),
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5110,7 +5110,7 @@ vite-node@2.1.9:
     pathe "^1.1.2"
     vite "^5.0.0"
 
-vite@^5.0.0:
+vite@^5.0.0, vite@^5.4.0:
   version "5.4.21"
   resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
   integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==


### PR DESCRIPTION
## Summary

Reference Vite + React application showing how to consume `@xds/core` as a source distribution using the **unplugin** integration path.

Related to #145

## What's included

| File | Purpose |
|------|---------|
| `vite.config.ts` | StyleX unplugin + resolve aliases for source compilation |
| `src/App.tsx` | Demo page with buttons, badges, text input, typography, dividers |
| `src/main.tsx` | Entry point with React root |
| `src/index.css` | Placeholder CSS for StyleX aggregation |
| `tsconfig.*.json` | TypeScript config with monorepo path aliases |
| `README.md` | Setup guide with Next.js comparison and documented gotchas |

## How it differs from example-nextjs

| Concern | Next.js | Vite |
|---------|---------|------|
| StyleX integration | Babel plugin + PostCSS plugin | `@stylexjs/unplugin` (single plugin) |
| CSS extraction | PostCSS replaces `@stylex;` at-rule | Handled automatically by unplugin |
| Config files needed | `babel.config.js` + `postcss.config.js` + `next.config.mjs` | `vite.config.ts` only |
| Theme provider | Needs `'use client'` boundary | No client/server boundary needed |

## Key setup details

- **Unplugin**: `stylex.vite()` must come before `react()` in the plugins array
- **Resolve aliases**: `@xds/core` is aliased to the source directory so Vite compiles from TypeScript source
- **CSS placeholder**: A minimal `index.css` ensures Vite emits a CSS asset for StyleX to append to
- **No PostCSS**: The unplugin handles both compilation and CSS extraction — no `@stylex;` directive needed

## Build verification

```
✓ 1135 modules transformed.
dist/index.html                   0.40 kB │ gzip:  0.28 kB
dist/assets/index-OkiDtojn.css   54.81 kB │ gzip:  9.55 kB
dist/assets/index-MPrrzn7o.js   182.28 kB │ gzip: 58.43 kB
✓ built in 2.27s
```

---
*Crafted with care by Navi*