### PR TITLE
feat(StatusDot): add XDSStatusDot component

### DIFF
--- a/apps/storybook/stories/StatusDot.stories.tsx
+++ b/apps/storybook/stories/StatusDot.stories.tsx
@@ -1,0 +1,92 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSStatusDot} from '@xds/core/StatusDot';
+
+const meta: Meta<typeof XDSStatusDot> = {
+  title: 'Core/XDSStatusDot',
+  component: XDSStatusDot,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['positive', 'warning', 'negative', 'info', 'neutral'],
+      description: 'Semantic color variant',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Dot size',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label',
+    },
+    isPulsing: {
+      control: 'boolean',
+      description: 'Pulse animation',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSStatusDot>;
+
+export const Default: Story = {
+  args: {
+    variant: 'positive',
+    label: 'Online',
+  },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+      <XDSStatusDot variant="positive" label="Positive" />
+      <XDSStatusDot variant="warning" label="Warning" />
+      <XDSStatusDot variant="negative" label="Negative" />
+      <XDSStatusDot variant="info" label="Info" />
+      <XDSStatusDot variant="neutral" label="Neutral" />
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+      <XDSStatusDot variant="positive" label="Small" size="sm" />
+      <XDSStatusDot variant="positive" label="Medium" size="md" />
+    </div>
+  ),
+};
+
+export const Pulsing: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+      <XDSStatusDot variant="positive" label="Live" isPulsing />
+      <XDSStatusDot variant="warning" label="Processing" isPulsing />
+      <XDSStatusDot variant="negative" label="Error" isPulsing />
+    </div>
+  ),
+};
+
+export const StatusIndicators: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
+      <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+        <XDSStatusDot variant="positive" label="Online" />
+        <span>Online</span>
+      </div>
+      <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+        <XDSStatusDot variant="warning" label="Away" />
+        <span>Away</span>
+      </div>
+      <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+        <XDSStatusDot variant="negative" label="Offline" />
+        <span>Offline</span>
+      </div>
+      <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+        <XDSStatusDot variant="neutral" label="Unknown" />
+        <span>Unknown</span>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/src/StatusDot/README.md
+++ b/packages/core/src/StatusDot/README.md
@@ -1,0 +1,54 @@
+# StatusDot
+
+A small colored dot indicator for status display (online/offline, severity, etc).
+
+## Exports
+
+| Export                | Type      | Description              |
+| --------------------- | --------- | ------------------------ |
+| `XDSStatusDot`        | Component | Main status dot component |
+| `XDSStatusDotProps`   | Type      | Props interface          |
+| `XDSStatusDotVariant` | Type      | Variant union type       |
+| `XDSStatusDotSize`    | Type      | Size union type          |
+
+## Props
+
+| Prop          | Type                                                              | Default  | Description                                      |
+| ------------- | ----------------------------------------------------------------- | -------- | ------------------------------------------------ |
+| `variant`     | `'positive' \| 'warning' \| 'negative' \| 'info' \| 'neutral'`   | -        | Semantic color variant (required)                |
+| `size`        | `'sm' \| 'md'`                                                    | `'md'`   | Dot size: sm=8px, md=10px                        |
+| `label`       | `string`                                                          | -        | Accessible label (required)                      |
+| `isPulsing`   | `boolean`                                                         | `false`  | Pulse animation, respects prefers-reduced-motion |
+| `xstyle`      | `StyleXStyles`                                                    | -        | Optional StyleX style override                   |
+| `data-testid` | `string`                                                          | -        | Optional test ID                                 |
+
+## Usage
+
+```tsx
+import {XDSStatusDot} from '@xds/core/StatusDot';
+
+// Basic status indicators
+<XDSStatusDot variant="positive" label="Online" />
+<XDSStatusDot variant="negative" label="Offline" />
+<XDSStatusDot variant="warning" label="Away" />
+
+// Small size
+<XDSStatusDot variant="positive" label="Active" size="sm" />
+
+// Pulsing animation
+<XDSStatusDot variant="positive" label="Live" isPulsing />
+```
+
+## Accessibility
+
+- Renders as `<span role="img" aria-label={label}>` for screen reader support
+- Not focusable (decorative indicator)
+- `isPulsing` animation respects `prefers-reduced-motion: reduce`
+
+## Files
+
+| File                    | Purpose                  |
+| ----------------------- | ------------------------ |
+| `XDSStatusDot.tsx`      | Component implementation |
+| `XDSStatusDot.test.tsx` | Unit tests               |
+| `index.ts`              | Barrel exports           |

--- a/packages/core/src/StatusDot/XDSStatusDot.test.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.test.tsx
@@ -1,0 +1,82 @@
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSStatusDot} from './XDSStatusDot';
+
+describe('XDSStatusDot', () => {
+  it('renders with role="img" and aria-label', () => {
+    render(<XDSStatusDot variant="positive" label="Online" />);
+    const dot = screen.getByRole('img', {name: 'Online'});
+    expect(dot).toBeInTheDocument();
+  });
+
+  it('renders as a span element', () => {
+    render(<XDSStatusDot variant="positive" label="Online" />);
+    const dot = screen.getByRole('img', {name: 'Online'});
+    expect(dot.tagName).toBe('SPAN');
+  });
+
+  it('renders with all variant types', () => {
+    const variants = [
+      'positive',
+      'warning',
+      'negative',
+      'info',
+      'neutral',
+    ] as const;
+
+    for (const variant of variants) {
+      const {unmount} = render(
+        <XDSStatusDot variant={variant} label={variant} />,
+      );
+      expect(screen.getByRole('img', {name: variant})).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('defaults to md size', () => {
+    render(<XDSStatusDot variant="positive" label="Online" />);
+    const dot = screen.getByRole('img', {name: 'Online'});
+    expect(dot).toBeInTheDocument();
+  });
+
+  it('accepts sm size', () => {
+    render(<XDSStatusDot variant="positive" label="Online" size="sm" />);
+    const dot = screen.getByRole('img', {name: 'Online'});
+    expect(dot).toBeInTheDocument();
+  });
+
+  it('forwards ref', () => {
+    const ref = {current: null as HTMLSpanElement | null};
+    render(<XDSStatusDot ref={ref} variant="positive" label="Online" />);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+
+  it('supports data-testid', () => {
+    render(
+      <XDSStatusDot
+        variant="positive"
+        label="Online"
+        data-testid="status-dot"
+      />,
+    );
+    expect(screen.getByTestId('status-dot')).toBeInTheDocument();
+  });
+
+  it('is not focusable', () => {
+    render(<XDSStatusDot variant="positive" label="Online" />);
+    const dot = screen.getByRole('img', {name: 'Online'});
+    expect(dot.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('renders with isPulsing', () => {
+    render(<XDSStatusDot variant="positive" label="Live" isPulsing />);
+    const dot = screen.getByRole('img', {name: 'Live'});
+    expect(dot).toBeInTheDocument();
+  });
+
+  it('renders without isPulsing by default', () => {
+    render(<XDSStatusDot variant="positive" label="Online" />);
+    const dot = screen.getByRole('img', {name: 'Online'});
+    expect(dot).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -1,0 +1,162 @@
+/**
+ * @file XDSStatusDot.tsx
+ * @input Uses React forwardRef
+ * @output Exports XDSStatusDot component, XDSStatusDotProps, XDSStatusDotVariant, XDSStatusDotSize types
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/StatusDot/README.md (props table, features, implementation notes)
+ * - /packages/core/src/StatusDot/XDSStatusDot.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/StatusDot/index.ts (exports if types change)
+ * - /apps/storybook/stories/StatusDot.stories.tsx (storybook stories)
+ */
+
+import {forwardRef} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+
+/**
+ * Pulse animation keyframes
+ */
+const pulseKeyframes = stylex.keyframes({
+  '0%': {opacity: 1},
+  '50%': {opacity: 0.5},
+  '100%': {opacity: 1},
+});
+
+/**
+ * Base styles
+ */
+const styles = stylex.create({
+  base: {
+    display: 'inline-block',
+    borderRadius: '50%',
+    flexShrink: 0,
+  },
+  pulsing: {
+    animationName: pulseKeyframes,
+    animationDuration: '2s',
+    animationTimingFunction: 'ease-in-out',
+    animationIterationCount: 'infinite',
+  },
+  reducedMotion: {
+    '@media (prefers-reduced-motion: reduce)': {
+      animationName: 'none',
+    },
+  },
+});
+
+/**
+ * Size styles
+ */
+const sizes = stylex.create({
+  sm: {
+    width: '8px',
+    height: '8px',
+  },
+  md: {
+    width: '10px',
+    height: '10px',
+  },
+});
+
+/**
+ * Variant styles mapping to theme color tokens
+ */
+const variants = stylex.create({
+  positive: {
+    backgroundColor: colorVars['--color-positive'],
+  },
+  warning: {
+    backgroundColor: colorVars['--color-warning'],
+  },
+  negative: {
+    backgroundColor: colorVars['--color-negative'],
+  },
+  info: {
+    backgroundColor: colorVars['--color-accent'],
+  },
+  neutral: {
+    backgroundColor: colorVars['--color-deemphasized'],
+  },
+});
+
+/**
+ * Status dot variant type
+ */
+export type XDSStatusDotVariant = keyof typeof variants;
+
+/**
+ * Status dot size type
+ */
+export type XDSStatusDotSize = 'sm' | 'md';
+
+export interface XDSStatusDotProps {
+  /**
+   * The semantic color variant.
+   */
+  variant: XDSStatusDotVariant;
+  /**
+   * The size of the dot.
+   * @default 'md'
+   */
+  size?: XDSStatusDotSize;
+  /**
+   * Accessible label describing the status. Required for a11y.
+   */
+  label: string;
+  /**
+   * Whether the dot should pulse to indicate activity.
+   * Respects `prefers-reduced-motion`.
+   * @default false
+   */
+  isPulsing?: boolean;
+  /**
+   * Optional StyleX styles override.
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * Optional test ID for testing.
+   */
+  'data-testid'?: string;
+}
+
+/**
+ * A small colored dot indicator for status display (online/offline, severity, etc).
+ *
+ * Renders as a non-focusable `<span>` with `role="img"` and `aria-label` for accessibility.
+ * Styles use XDS theme tokens via StyleX. Wrap your app in `<Theme>` to apply a theme.
+ *
+ * @example
+ * ```tsx
+ * <XDSStatusDot variant="positive" label="Online" />
+ * <XDSStatusDot variant="negative" label="Offline" size="sm" />
+ * <XDSStatusDot variant="positive" label="Live" isPulsing />
+ * ```
+ */
+export const XDSStatusDot = forwardRef<HTMLSpanElement, XDSStatusDotProps>(
+  (
+    {variant, size = 'md', label, isPulsing = false, xstyle, ...props},
+    ref,
+  ) => {
+    return (
+      <span
+        ref={ref}
+        role="img"
+        aria-label={label}
+        {...stylex.props(
+          styles.base,
+          sizes[size],
+          variants[variant],
+          isPulsing && styles.pulsing,
+          isPulsing && styles.reducedMotion,
+          xstyle,
+        )}
+        {...props}
+      />
+    );
+  },
+);
+
+XDSStatusDot.displayName = 'XDSStatusDot';

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @file StatusDot component barrel export
+ */
+
+export {XDSStatusDot} from './XDSStatusDot';
+export type {
+  XDSStatusDotProps,
+  XDSStatusDotVariant,
+  XDSStatusDotSize,
+} from './XDSStatusDot';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,9 @@ export * from './Layer';
 // Skeleton loading placeholder
 export * from './Skeleton';
 
+// Status dot indicator
+export * from './StatusDot';
+
 // Spinner loading indicator
 export * from './Spinner';
 


### PR DESCRIPTION
## Summary

Implements XDSStatusDot — a small colored dot indicator for status display (online/offline, severity, etc).

## Features
- Five semantic variants: `positive`, `warning`, `negative`, `info`, `neutral`
- Two sizes: `sm` (8px), `md` (10px)
- Required `label` for accessibility (`role="img"` + `aria-label`)
- `isPulsing` animation with `prefers-reduced-motion` support
- `forwardRef` to span element
- `xstyle` override support

## Usage
```tsx
<XDSStatusDot variant="positive" label="Online" />
<XDSStatusDot variant="negative" label="Offline" size="sm" />
<XDSStatusDot variant="positive" label="Live" isPulsing />
```

Closes #173

---
*Crafted with care by Navi*