### PR TITLE
feat(EmptyState): add XDSEmptyState component

### DIFF
--- a/apps/storybook/stories/EmptyState.stories.tsx
+++ b/apps/storybook/stories/EmptyState.stories.tsx
@@ -1,0 +1,106 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSEmptyState} from '@xds/core/EmptyState';
+
+const meta: Meta<typeof XDSEmptyState> = {
+  title: 'Core/XDSEmptyState',
+  component: XDSEmptyState,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+      description: 'Primary message',
+    },
+    description: {
+      control: 'text',
+      description: 'Optional secondary text',
+    },
+    isCompact: {
+      control: 'boolean',
+      description: 'Compact variant with reduced spacing',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSEmptyState>;
+
+export const Default: Story = {
+  args: {
+    title: 'No results found',
+    description: 'Try adjusting your search or filters to find what you need.',
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    title: 'Nothing here yet',
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    icon: <span style={{fontSize: '48px'}}>📭</span>,
+    title: 'No messages',
+    description: "You're all caught up!",
+  },
+};
+
+export const WithActions: Story = {
+  args: {
+    icon: <span style={{fontSize: '48px'}}>🔍</span>,
+    title: 'No results found',
+    description: 'Try adjusting your search or filters.',
+    actions: (
+      <>
+        <button>Clear filters</button>
+        <button>Go back</button>
+      </>
+    ),
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    icon: <span style={{fontSize: '32px'}}>📋</span>,
+    title: 'No items',
+    description: 'Nothing to show here.',
+    isCompact: true,
+  },
+};
+
+export const CompactWithActions: Story = {
+  args: {
+    title: 'No data',
+    description: 'Add some data to get started.',
+    actions: (
+      <>
+        <button>Add item</button>
+        <button>Import</button>
+      </>
+    ),
+    isCompact: true,
+  },
+};
+
+export const FullExample: Story = {
+  render: () => (
+    <div
+      style={{
+        border: '1px dashed #ccc',
+        borderRadius: '12px',
+        maxWidth: '480px',
+      }}>
+      <XDSEmptyState
+        icon={<span style={{fontSize: '48px'}}>📬</span>}
+        title="No notifications"
+        description="When you receive notifications, they will appear here. Check back later!"
+        actions={
+          <>
+            <button>Refresh</button>
+            <button>Settings</button>
+          </>
+        }
+      />
+    </div>
+  ),
+};

--- a/packages/core/src/EmptyState/README.md
+++ b/packages/core/src/EmptyState/README.md
@@ -1,0 +1,66 @@
+# EmptyState
+
+An empty state placeholder for content areas with no data. Displays an icon or illustration, title, optional description, and action buttons.
+
+## Exports
+
+| Export               | Type      | Description                |
+| -------------------- | --------- | -------------------------- |
+| `XDSEmptyState`      | Component | Main empty state component |
+| `XDSEmptyStateProps` | Type      | Props interface            |
+
+## Props
+
+| Prop          | Type           | Default | Description                                                   |
+| ------------- | -------------- | ------- | ------------------------------------------------------------- |
+| `title`       | `string`       | —       | Primary message (required)                                    |
+| `description` | `string`       | —       | Optional secondary text                                       |
+| `icon`        | `ReactNode`    | —       | Optional icon/illustration (rendered decorative, aria-hidden) |
+| `actions`     | `ReactNode`    | —       | Optional action buttons (horizontal, stacked when compact)    |
+| `isCompact`   | `boolean`      | `false` | Compact variant with reduced spacing                          |
+| `xstyle`      | `StyleXStyles` | —       | StyleX override styles for the container                      |
+| `data-testid` | `string`       | —       | Test ID for the container element                             |
+
+## Usage
+
+```tsx
+import {XDSEmptyState} from '@xds/core/EmptyState';
+
+// Minimal
+<XDSEmptyState title="No results found" />
+
+// With description
+<XDSEmptyState
+  title="No results found"
+  description="Try adjusting your search or filters."
+/>
+
+// Full example
+<XDSEmptyState
+  icon={<XDSIcon icon={InboxIcon} size="lg" />}
+  title="No messages"
+  description="You're all caught up!"
+  actions={<XDSButton label="Compose" variant="primary" />}
+/>
+
+// Compact variant
+<XDSEmptyState
+  title="No items"
+  description="Nothing to show here."
+  isCompact
+/>
+```
+
+## Accessibility
+
+- Container uses `role="status"` to announce content to screen readers
+- Icon wrapper has `aria-hidden="true"` (decorative)
+- Title renders as an `<h3>` heading element
+
+## Files
+
+| File                     | Purpose                  |
+| ------------------------ | ------------------------ |
+| `XDSEmptyState.tsx`      | Component implementation |
+| `XDSEmptyState.test.tsx` | Unit tests               |
+| `index.ts`               | Barrel exports           |

--- a/packages/core/src/EmptyState/XDSEmptyState.test.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.test.tsx
@@ -1,0 +1,121 @@
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSEmptyState} from './XDSEmptyState';
+
+describe('XDSEmptyState', () => {
+  it('renders with title', () => {
+    render(<XDSEmptyState title="No results found" />);
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+  });
+
+  it('renders title as a heading element', () => {
+    render(<XDSEmptyState title="No data" />);
+    expect(screen.getByRole('heading', {name: 'No data'})).toBeInTheDocument();
+  });
+
+  it('renders with description', () => {
+    render(
+      <XDSEmptyState
+        title="No results"
+        description="Try adjusting your search."
+      />,
+    );
+    expect(screen.getByText('Try adjusting your search.')).toBeInTheDocument();
+  });
+
+  it('does not render description when not provided', () => {
+    const {container} = render(<XDSEmptyState title="No results" />);
+    expect(container.querySelector('p')).not.toBeInTheDocument();
+  });
+
+  it('renders with icon', () => {
+    render(
+      <XDSEmptyState
+        title="No results"
+        icon={<span data-testid="empty-icon">📭</span>}
+      />,
+    );
+    expect(screen.getByTestId('empty-icon')).toBeInTheDocument();
+  });
+
+  it('marks icon as decorative with aria-hidden', () => {
+    render(
+      <XDSEmptyState
+        title="No results"
+        icon={<span data-testid="empty-icon">📭</span>}
+      />,
+    );
+    const iconWrapper = screen.getByTestId('empty-icon').parentElement;
+    expect(iconWrapper).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('does not render icon wrapper when icon is not provided', () => {
+    const {container} = render(<XDSEmptyState title="No results" />);
+    expect(
+      container.querySelector('[aria-hidden="true"]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders with actions', () => {
+    render(
+      <XDSEmptyState
+        title="No results"
+        actions={<button data-testid="action-btn">Retry</button>}
+      />,
+    );
+    expect(screen.getByTestId('action-btn')).toBeInTheDocument();
+  });
+
+  it('does not render actions wrapper when actions is not provided', () => {
+    const {container} = render(<XDSEmptyState title="No results" />);
+    // Only the container div and the heading should be present
+    const divs = container.querySelectorAll('div');
+    expect(divs).toHaveLength(1); // just the container
+  });
+
+  it('has role="status" on the container', () => {
+    render(<XDSEmptyState title="No results" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders compact variant', () => {
+    render(<XDSEmptyState title="No results" isCompact />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(screen.getByText('No results')).toBeInTheDocument();
+  });
+
+  it('forwards ref', () => {
+    const ref = {current: null as HTMLDivElement | null};
+    render(<XDSEmptyState ref={ref} title="No results" />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('spreads data-testid', () => {
+    render(<XDSEmptyState title="No results" data-testid="empty-state" />);
+    expect(screen.getByTestId('empty-state')).toBeInTheDocument();
+  });
+
+  it('renders all slots together', () => {
+    render(
+      <XDSEmptyState
+        icon={<span data-testid="icon">🔍</span>}
+        title="No results found"
+        description="Try a different search term."
+        actions={
+          <>
+            <button>Clear filters</button>
+            <button>Go back</button>
+          </>
+        }
+        data-testid="full-empty-state"
+      />,
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(
+      screen.getByText('Try a different search term.'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Clear filters')).toBeInTheDocument();
+    expect(screen.getByText('Go back')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -1,0 +1,174 @@
+/**
+ * @file XDSEmptyState.tsx
+ * @input Uses React forwardRef, HTMLAttributes
+ * @output Exports XDSEmptyState component, XDSEmptyStateProps type
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/EmptyState/README.md (props table, features, implementation notes)
+ * - /packages/core/src/EmptyState/XDSEmptyState.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/EmptyState/index.ts (exports if types change)
+ * - /apps/storybook/stories/EmptyState.stories.tsx (storybook stories)
+ */
+
+import {forwardRef, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    textAlign: 'center',
+    gap: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-8'],
+    paddingInline: spacingVars['--spacing-6'],
+  },
+  containerCompact: {
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-4'],
+  },
+  title: {
+    margin: 0,
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-lg'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    color: colorVars['--color-text-primary'],
+  },
+  titleCompact: {
+    fontSize: textSizeVars['--text-base'],
+  },
+  description: {
+    margin: 0,
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-secondary'],
+    maxWidth: '360px',
+  },
+  descriptionCompact: {
+    fontSize: textSizeVars['--text-sm'],
+  },
+  actions: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    marginTop: spacingVars['--spacing-1'],
+  },
+  actionsCompact: {
+    flexDirection: 'column',
+  },
+});
+
+export interface XDSEmptyStateProps {
+  /**
+   * The primary message displayed in the empty state.
+   */
+  title: string;
+  /**
+   * Optional secondary text providing additional context.
+   */
+  description?: string;
+  /**
+   * Optional icon or illustration displayed above the title.
+   * Rendered as decorative (aria-hidden="true").
+   */
+  icon?: ReactNode;
+  /**
+   * Optional action buttons displayed below the description.
+   * Laid out horizontally by default, stacked vertically when `isCompact`.
+   */
+  actions?: ReactNode;
+  /**
+   * Use compact variant for constrained spaces with reduced spacing.
+   * @default false
+   */
+  isCompact?: boolean;
+  /**
+   * StyleX override styles applied to the container.
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * Test ID for the container element.
+   */
+  'data-testid'?: string;
+}
+
+/**
+ * An empty state placeholder for content areas with no data.
+ * Displays an icon or illustration, title, optional description, and action buttons.
+ *
+ * Uses `role="status"` to announce content to screen readers.
+ * Styles use XDS theme tokens via StyleX. Wrap your app in <Theme> to apply a theme.
+ *
+ * @example
+ * ```tsx
+ * <XDSEmptyState
+ *   title="No results found"
+ *   description="Try adjusting your search or filters."
+ * />
+ *
+ * <XDSEmptyState
+ *   icon={<XDSIcon icon={InboxIcon} size="lg" />}
+ *   title="No messages"
+ *   description="You're all caught up!"
+ *   actions={<XDSButton label="Compose" variant="primary" />}
+ * />
+ * ```
+ */
+export const XDSEmptyState = forwardRef<HTMLDivElement, XDSEmptyStateProps>(
+  (
+    {title, description, icon, actions, isCompact = false, xstyle, ...props},
+    ref,
+  ) => {
+    return (
+      <div
+        ref={ref}
+        role="status"
+        {...stylex.props(
+          styles.container,
+          isCompact && styles.containerCompact,
+          xstyle,
+        )}
+        {...props}>
+        {icon != null && <div aria-hidden="true">{icon}</div>}
+        <h3 {...stylex.props(styles.title, isCompact && styles.titleCompact)}>
+          {title}
+        </h3>
+        {description != null && (
+          <p
+            {...stylex.props(
+              styles.description,
+              isCompact && styles.descriptionCompact,
+            )}>
+            {description}
+          </p>
+        )}
+        {actions != null && (
+          <div
+            {...stylex.props(
+              styles.actions,
+              isCompact && styles.actionsCompact,
+            )}>
+            {actions}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+XDSEmptyState.displayName = 'XDSEmptyState';

--- a/packages/core/src/EmptyState/index.ts
+++ b/packages/core/src/EmptyState/index.ts
@@ -1,0 +1,6 @@
+/**
+ * @file EmptyState component barrel export
+ */
+
+export {XDSEmptyState} from './XDSEmptyState';
+export type {XDSEmptyStateProps} from './XDSEmptyState';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from './CheckboxInput';
 export * from './RadioList';
 export * from './CloseButton';
 export * from './Divider';
+export * from './EmptyState';
 export * from './Link';
 export * from './Slider';
 export * from './Switch';


### PR DESCRIPTION
## Summary

Implements XDSEmptyState — an empty state placeholder for content areas with no data.

## Features
- `title` (required) and optional `description`
- `icon` slot for custom icons/illustrations (decorative, `aria-hidden`)
- `actions` slot for CTA buttons (horizontal layout, stacked when `isCompact`)
- `isCompact` variant for constrained spaces
- `role="status"` for screen reader announcements
- `forwardRef`, `xstyle` override, `data-testid`

## Usage
```tsx
<XDSEmptyState
  title="No results found"
  description="Try adjusting your search or filters."
/>

<XDSEmptyState
  icon={<XDSIcon icon={InboxIcon} size="lg" />}
  title="No messages"
  description="You're all caught up!"
  actions={<XDSButton label="Compose" variant="primary" onClick={handleCompose} />}
/>
```

Closes #166

---
*Crafted with care by Navi*