### PR TITLE
feat(Illustration): add theme-compatible illustration components

### DIFF
--- a/apps/storybook/stories/Illustration.stories.tsx
+++ b/apps/storybook/stories/Illustration.stories.tsx
@@ -1,0 +1,127 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  XDSIllustrationNoResults,
+  XDSIllustrationEmptyInbox,
+  XDSIllustrationEmptyFolder,
+  XDSIllustrationError,
+  XDSIllustrationSuccess,
+} from '@xds/core/Illustration';
+
+const meta: Meta<typeof XDSIllustrationNoResults> = {
+  title: 'Core/XDSIllustration',
+  component: XDSIllustrationNoResults,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Illustration size',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSIllustrationNoResults>;
+
+export const NoResults: Story = {
+  render: args => <XDSIllustrationNoResults {...args} />,
+  args: {
+    size: 'md',
+  },
+};
+
+export const EmptyInbox: Story = {
+  render: args => <XDSIllustrationEmptyInbox {...args} />,
+  args: {
+    size: 'md',
+  },
+};
+
+export const EmptyFolder: Story = {
+  render: args => <XDSIllustrationEmptyFolder {...args} />,
+  args: {
+    size: 'md',
+  },
+};
+
+export const Error: Story = {
+  render: args => <XDSIllustrationError {...args} />,
+  args: {
+    size: 'md',
+  },
+};
+
+export const Success: Story = {
+  render: args => <XDSIllustrationSuccess {...args} />,
+  args: {
+    size: 'md',
+  },
+};
+
+export const AllIllustrations: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '32px',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}>
+      <div style={{textAlign: 'center'}}>
+        <XDSIllustrationNoResults size="md" />
+        <div style={{marginTop: '8px', fontSize: '12px', color: '#666'}}>
+          No Results
+        </div>
+      </div>
+      <div style={{textAlign: 'center'}}>
+        <XDSIllustrationEmptyInbox size="md" />
+        <div style={{marginTop: '8px', fontSize: '12px', color: '#666'}}>
+          Empty Inbox
+        </div>
+      </div>
+      <div style={{textAlign: 'center'}}>
+        <XDSIllustrationEmptyFolder size="md" />
+        <div style={{marginTop: '8px', fontSize: '12px', color: '#666'}}>
+          Empty Folder
+        </div>
+      </div>
+      <div style={{textAlign: 'center'}}>
+        <XDSIllustrationError size="md" />
+        <div style={{marginTop: '8px', fontSize: '12px', color: '#666'}}>
+          Error
+        </div>
+      </div>
+      <div style={{textAlign: 'center'}}>
+        <XDSIllustrationSuccess size="md" />
+        <div style={{marginTop: '8px', fontSize: '12px', color: '#666'}}>
+          Success
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '32px', alignItems: 'end'}}>
+      <div style={{textAlign: 'center'}}>
+        <XDSIllustrationNoResults size="sm" />
+        <div style={{marginTop: '8px', fontSize: '12px', color: '#666'}}>
+          sm (48px)
+        </div>
+      </div>
+      <div style={{textAlign: 'center'}}>
+        <XDSIllustrationNoResults size="md" />
+        <div style={{marginTop: '8px', fontSize: '12px', color: '#666'}}>
+          md (80px)
+        </div>
+      </div>
+      <div style={{textAlign: 'center'}}>
+        <XDSIllustrationNoResults size="lg" />
+        <div style={{marginTop: '8px', fontSize: '12px', color: '#666'}}>
+          lg (120px)
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/src/Illustration/README.md
+++ b/packages/core/src/Illustration/README.md
@@ -1,0 +1,70 @@
+# Illustration
+
+Theme-compatible SVG illustration components designed to pair with `XDSEmptyState` (and usable anywhere).
+
+## Components
+
+| Component                    | Use case                        | Visual concept                      |
+| ---------------------------- | ------------------------------- | ----------------------------------- |
+| `XDSIllustrationNoResults`   | Search with no matches          | Magnifying glass with question mark |
+| `XDSIllustrationEmptyInbox`  | Empty message/notification list | Open envelope                       |
+| `XDSIllustrationEmptyFolder` | No files/projects/items         | Open folder                         |
+| `XDSIllustrationError`       | Something went wrong            | Warning triangle with exclamation   |
+| `XDSIllustrationSuccess`     | All done / completed state      | Checkmark in circle with sparkles   |
+
+## Props
+
+| Prop          | Type                   | Default | Description                            |
+| ------------- | ---------------------- | ------- | -------------------------------------- |
+| `size`        | `'sm' \| 'md' \| 'lg'` | `'md'`  | Size: sm (48px), md (80px), lg (120px) |
+| `xstyle`      | `StyleXStyles`         | —       | StyleX overrides                       |
+| `data-testid` | `string`               | —       | Test ID                                |
+
+## Usage
+
+```tsx
+import {XDSIllustrationNoResults} from '@xds/core/Illustration';
+
+// Standalone
+<XDSIllustrationNoResults size="lg" />
+
+// With XDSEmptyState
+<XDSEmptyState
+  icon={<XDSIllustrationNoResults />}
+  title="No results found"
+  description="Try adjusting your search or filters."
+/>
+```
+
+## Design
+
+- **SVG-based** — inline SVGs, not image files
+- **Theme-compatible** — uses XDS color tokens (`--color-text-secondary`, `--color-accent`, etc.)
+- **Light/dark adaptive** — colors automatically adapt via `light-dark()` tokens
+- **Simple line-art style** — clean strokes, minimal fills, works at small sizes
+- **Decorative** — all illustrations are `aria-hidden="true"`; the parent provides semantic meaning
+- **`forwardRef`** — refs forward to the `<svg>` element
+
+## Color Usage
+
+| Token                    | Purpose                       |
+| ------------------------ | ----------------------------- |
+| `--color-text-secondary` | Primary strokes (outlines)    |
+| `--color-deemphasized`   | Subtle background fills       |
+| `--color-accent`         | Accent elements (brand color) |
+| `--color-positive`       | Success illustration elements |
+| `--color-negative`       | Error illustration elements   |
+
+## File Manifest
+
+| File                             | Purpose                                                       |
+| -------------------------------- | ------------------------------------------------------------- |
+| `types.ts`                       | Shared `XDSIllustrationProps` and `XDSIllustrationSize` types |
+| `XDSIllustrationNoResults.tsx`   | Magnifying glass + question mark                              |
+| `XDSIllustrationEmptyInbox.tsx`  | Open envelope                                                 |
+| `XDSIllustrationEmptyFolder.tsx` | Open folder                                                   |
+| `XDSIllustrationError.tsx`       | Warning triangle                                              |
+| `XDSIllustrationSuccess.tsx`     | Checkmark circle with sparkles                                |
+| `XDSIllustration.test.tsx`       | Tests for all illustration components                         |
+| `index.ts`                       | Barrel export                                                 |
+| `README.md`                      | This file                                                     |

--- a/packages/core/src/Illustration/XDSIllustration.test.tsx
+++ b/packages/core/src/Illustration/XDSIllustration.test.tsx
@@ -1,0 +1,75 @@
+import {describe, it, expect} from 'vitest';
+import {render} from '@testing-library/react';
+import {XDSIllustrationNoResults} from './XDSIllustrationNoResults';
+import {XDSIllustrationEmptyInbox} from './XDSIllustrationEmptyInbox';
+import {XDSIllustrationEmptyFolder} from './XDSIllustrationEmptyFolder';
+import {XDSIllustrationError} from './XDSIllustrationError';
+import {XDSIllustrationSuccess} from './XDSIllustrationSuccess';
+import type {XDSIllustrationSize} from './types';
+
+const illustrations = [
+  {name: 'XDSIllustrationNoResults', Component: XDSIllustrationNoResults},
+  {name: 'XDSIllustrationEmptyInbox', Component: XDSIllustrationEmptyInbox},
+  {name: 'XDSIllustrationEmptyFolder', Component: XDSIllustrationEmptyFolder},
+  {name: 'XDSIllustrationError', Component: XDSIllustrationError},
+  {name: 'XDSIllustrationSuccess', Component: XDSIllustrationSuccess},
+] as const;
+
+const sizeMap: Record<XDSIllustrationSize, number> = {
+  sm: 48,
+  md: 80,
+  lg: 120,
+};
+
+describe.each(illustrations)('$name', ({name, Component}) => {
+  it('renders without crashing', () => {
+    const {container} = render(<Component />);
+    expect(container.firstChild).toBeTruthy();
+  });
+
+  it('has aria-hidden="true"', () => {
+    const {container} = render(<Component />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('renders an SVG element', () => {
+    const {container} = render(<Component />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+    expect(svg?.tagName).toBe('svg');
+  });
+
+  it('defaults to md size (80px)', () => {
+    const {container} = render(<Component />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '80');
+    expect(svg).toHaveAttribute('height', '80');
+  });
+
+  it.each(['sm', 'md', 'lg'] as const)('renders at %s size', size => {
+    const {container} = render(<Component size={size} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', String(sizeMap[size]));
+    expect(svg).toHaveAttribute('height', String(sizeMap[size]));
+  });
+
+  it('forwards ref', () => {
+    const ref = {current: null as SVGSVGElement | null};
+    render(<Component ref={ref} />);
+    expect(ref.current).toBeInstanceOf(SVGSVGElement);
+  });
+
+  it('accepts data-testid', () => {
+    const testId = `test-${name}`;
+    const {container} = render(<Component data-testid={testId} />);
+    const svg = container.querySelector(`[data-testid="${testId}"]`);
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('has a viewBox attribute', () => {
+    const {container} = render(<Component />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('viewBox', '0 0 120 120');
+  });
+});

--- a/packages/core/src/Illustration/XDSIllustrationEmptyFolder.tsx
+++ b/packages/core/src/Illustration/XDSIllustrationEmptyFolder.tsx
@@ -1,0 +1,104 @@
+/**
+ * @file XDSIllustrationEmptyFolder.tsx
+ * @input Uses React forwardRef, StyleX, XDS color tokens
+ * @output Exports XDSIllustrationEmptyFolder component
+ * @position Component implementation; consumed by index.ts
+ *
+ * Open folder illustration — for no files, projects, or items.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Illustration/README.md
+ * - /packages/core/src/Illustration/XDSIllustration.test.tsx
+ * - /packages/core/src/Illustration/index.ts
+ * - /apps/storybook/stories/Illustration.stories.tsx
+ */
+
+import {forwardRef} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+import type {XDSIllustrationProps} from './types';
+
+const sizes = {
+  sm: 48,
+  md: 80,
+  lg: 120,
+} as const;
+
+const styles = stylex.create({
+  svg: {
+    display: 'block',
+    flexShrink: 0,
+  },
+  stroke: {
+    color: colorVars['--color-text-secondary'],
+  },
+  accent: {
+    color: colorVars['--color-accent'],
+  },
+  deemphasized: {
+    color: colorVars['--color-deemphasized'],
+  },
+});
+
+/**
+ * Open folder illustration.
+ * Use for empty folder, no files, or no projects states.
+ *
+ * @example
+ * ```tsx
+ * <XDSIllustrationEmptyFolder size="md" />
+ * ```
+ */
+export const XDSIllustrationEmptyFolder = forwardRef<
+  SVGSVGElement,
+  XDSIllustrationProps
+>(({size = 'md', xstyle, 'data-testid': testId}, ref) => {
+  const px = sizes[size];
+
+  return (
+    <svg
+      ref={ref}
+      width={px}
+      height={px}
+      viewBox="0 0 120 120"
+      fill="none"
+      aria-hidden="true"
+      data-testid={testId}
+      {...stylex.props(styles.svg, xstyle)}>
+      {/* Folder back */}
+      <path
+        d="M16 36C16 33.791 17.791 32 20 32H46L54 42H100C102.209 42 104 43.791 104 46V88C104 90.209 102.209 92 100 92H20C17.791 92 16 90.209 16 88V36Z"
+        {...stylex.props(styles.deemphasized)}
+        fill="currentColor"
+      />
+      {/* Folder back stroke */}
+      <path
+        d="M16 36C16 33.791 17.791 32 20 32H46L54 42H100C102.209 42 104 43.791 104 46V88C104 90.209 102.209 92 100 92H20C17.791 92 16 90.209 16 88V36Z"
+        {...stylex.props(styles.stroke)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Folder front flap */}
+      <path
+        d="M16 54H104V88C104 90.209 102.209 92 100 92H20C17.791 92 16 90.209 16 88V54Z"
+        {...stylex.props(styles.stroke)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Tab accent */}
+      <path
+        d="M46 32L54 42"
+        {...stylex.props(styles.accent)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+});
+
+XDSIllustrationEmptyFolder.displayName = 'XDSIllustrationEmptyFolder';

--- a/packages/core/src/Illustration/XDSIllustrationEmptyInbox.tsx
+++ b/packages/core/src/Illustration/XDSIllustrationEmptyInbox.tsx
@@ -1,0 +1,113 @@
+/**
+ * @file XDSIllustrationEmptyInbox.tsx
+ * @input Uses React forwardRef, StyleX, XDS color tokens
+ * @output Exports XDSIllustrationEmptyInbox component
+ * @position Component implementation; consumed by index.ts
+ *
+ * Open envelope illustration — for empty message/notification lists.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Illustration/README.md
+ * - /packages/core/src/Illustration/XDSIllustration.test.tsx
+ * - /packages/core/src/Illustration/index.ts
+ * - /apps/storybook/stories/Illustration.stories.tsx
+ */
+
+import {forwardRef} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+import type {XDSIllustrationProps} from './types';
+
+const sizes = {
+  sm: 48,
+  md: 80,
+  lg: 120,
+} as const;
+
+const styles = stylex.create({
+  svg: {
+    display: 'block',
+    flexShrink: 0,
+  },
+  stroke: {
+    color: colorVars['--color-text-secondary'],
+  },
+  accent: {
+    color: colorVars['--color-accent'],
+  },
+  deemphasized: {
+    color: colorVars['--color-deemphasized'],
+  },
+});
+
+/**
+ * Open envelope illustration.
+ * Use for empty inbox, no messages, or empty notification states.
+ *
+ * @example
+ * ```tsx
+ * <XDSIllustrationEmptyInbox size="md" />
+ * ```
+ */
+export const XDSIllustrationEmptyInbox = forwardRef<
+  SVGSVGElement,
+  XDSIllustrationProps
+>(({size = 'md', xstyle, 'data-testid': testId}, ref) => {
+  const px = sizes[size];
+
+  return (
+    <svg
+      ref={ref}
+      width={px}
+      height={px}
+      viewBox="0 0 120 120"
+      fill="none"
+      aria-hidden="true"
+      data-testid={testId}
+      {...stylex.props(styles.svg, xstyle)}>
+      {/* Envelope body background */}
+      <rect
+        x="20"
+        y="40"
+        width="80"
+        height="56"
+        rx="4"
+        {...stylex.props(styles.deemphasized)}
+        fill="currentColor"
+      />
+      {/* Envelope body stroke */}
+      <rect
+        x="20"
+        y="40"
+        width="80"
+        height="56"
+        rx="4"
+        {...stylex.props(styles.stroke)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Open flap */}
+      <path
+        d="M20 44L60 24L100 44"
+        {...stylex.props(styles.stroke)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Inner V fold */}
+      <path
+        d="M20 44L60 72L100 44"
+        {...stylex.props(styles.accent)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+});
+
+XDSIllustrationEmptyInbox.displayName = 'XDSIllustrationEmptyInbox';

--- a/packages/core/src/Illustration/XDSIllustrationError.tsx
+++ b/packages/core/src/Illustration/XDSIllustrationError.tsx
@@ -1,0 +1,106 @@
+/**
+ * @file XDSIllustrationError.tsx
+ * @input Uses React forwardRef, StyleX, XDS color tokens
+ * @output Exports XDSIllustrationError component
+ * @position Component implementation; consumed by index.ts
+ *
+ * Warning triangle illustration — for error or "something went wrong" states.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Illustration/README.md
+ * - /packages/core/src/Illustration/XDSIllustration.test.tsx
+ * - /packages/core/src/Illustration/index.ts
+ * - /apps/storybook/stories/Illustration.stories.tsx
+ */
+
+import {forwardRef} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+import type {XDSIllustrationProps} from './types';
+
+const sizes = {
+  sm: 48,
+  md: 80,
+  lg: 120,
+} as const;
+
+const styles = stylex.create({
+  svg: {
+    display: 'block',
+    flexShrink: 0,
+  },
+  stroke: {
+    color: colorVars['--color-text-secondary'],
+  },
+  negative: {
+    color: colorVars['--color-negative'],
+  },
+  deemphasized: {
+    color: colorVars['--color-deemphasized'],
+  },
+});
+
+/**
+ * Warning triangle illustration.
+ * Use for error states or "something went wrong" scenarios.
+ *
+ * @example
+ * ```tsx
+ * <XDSIllustrationError size="md" />
+ * ```
+ */
+export const XDSIllustrationError = forwardRef<
+  SVGSVGElement,
+  XDSIllustrationProps
+>(({size = 'md', xstyle, 'data-testid': testId}, ref) => {
+  const px = sizes[size];
+
+  return (
+    <svg
+      ref={ref}
+      width={px}
+      height={px}
+      viewBox="0 0 120 120"
+      fill="none"
+      aria-hidden="true"
+      data-testid={testId}
+      {...stylex.props(styles.svg, xstyle)}>
+      {/* Triangle background */}
+      <path
+        d="M60 20L104 96H16L60 20Z"
+        {...stylex.props(styles.deemphasized)}
+        fill="currentColor"
+      />
+      {/* Triangle stroke */}
+      <path
+        d="M60 20L104 96H16L60 20Z"
+        {...stylex.props(styles.stroke)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Exclamation line */}
+      <line
+        x1="60"
+        y1="48"
+        x2="60"
+        y2="72"
+        {...stylex.props(styles.negative)}
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      {/* Exclamation dot */}
+      <circle
+        cx="60"
+        cy="82"
+        r="2.5"
+        {...stylex.props(styles.negative)}
+        fill="currentColor"
+      />
+    </svg>
+  );
+});
+
+XDSIllustrationError.displayName = 'XDSIllustrationError';

--- a/packages/core/src/Illustration/XDSIllustrationNoResults.tsx
+++ b/packages/core/src/Illustration/XDSIllustrationNoResults.tsx
@@ -1,0 +1,119 @@
+/**
+ * @file XDSIllustrationNoResults.tsx
+ * @input Uses React forwardRef, StyleX, XDS color tokens
+ * @output Exports XDSIllustrationNoResults component
+ * @position Component implementation; consumed by index.ts
+ *
+ * Magnifying glass with a question mark — for search with no matches.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Illustration/README.md
+ * - /packages/core/src/Illustration/XDSIllustration.test.tsx
+ * - /packages/core/src/Illustration/index.ts
+ * - /apps/storybook/stories/Illustration.stories.tsx
+ */
+
+import {forwardRef} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+import type {XDSIllustrationProps} from './types';
+
+const sizes = {
+  sm: 48,
+  md: 80,
+  lg: 120,
+} as const;
+
+const styles = stylex.create({
+  svg: {
+    display: 'block',
+    flexShrink: 0,
+  },
+  stroke: {
+    color: colorVars['--color-text-secondary'],
+  },
+  accent: {
+    color: colorVars['--color-accent'],
+  },
+  deemphasized: {
+    color: colorVars['--color-deemphasized'],
+  },
+});
+
+/**
+ * Magnifying glass with question mark illustration.
+ * Use for search with no results or empty search states.
+ *
+ * @example
+ * ```tsx
+ * <XDSIllustrationNoResults size="md" />
+ * ```
+ */
+export const XDSIllustrationNoResults = forwardRef<
+  SVGSVGElement,
+  XDSIllustrationProps
+>(({size = 'md', xstyle, 'data-testid': testId}, ref) => {
+  const px = sizes[size];
+
+  return (
+    <svg
+      ref={ref}
+      width={px}
+      height={px}
+      viewBox="0 0 120 120"
+      fill="none"
+      aria-hidden="true"
+      data-testid={testId}
+      {...stylex.props(styles.svg, xstyle)}>
+      {/* Lens circle background */}
+      <circle
+        cx="52"
+        cy="52"
+        r="32"
+        {...stylex.props(styles.deemphasized)}
+        fill="currentColor"
+      />
+      {/* Lens circle stroke */}
+      <circle
+        cx="52"
+        cy="52"
+        r="32"
+        {...stylex.props(styles.stroke)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Handle */}
+      <line
+        x1="76"
+        y1="76"
+        x2="100"
+        y2="100"
+        {...stylex.props(styles.stroke)}
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+      />
+      {/* Question mark */}
+      <path
+        d="M44 42C44 36.477 48.477 32 54 32C59.523 32 64 36.477 64 42C64 46 61.5 48.5 58 50C55.5 51 54 53 54 56"
+        {...stylex.props(styles.accent)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Question mark dot */}
+      <circle
+        cx="54"
+        cy="64"
+        r="2"
+        {...stylex.props(styles.accent)}
+        fill="currentColor"
+      />
+    </svg>
+  );
+});
+
+XDSIllustrationNoResults.displayName = 'XDSIllustrationNoResults';

--- a/packages/core/src/Illustration/XDSIllustrationSuccess.tsx
+++ b/packages/core/src/Illustration/XDSIllustrationSuccess.tsx
@@ -1,0 +1,112 @@
+/**
+ * @file XDSIllustrationSuccess.tsx
+ * @input Uses React forwardRef, StyleX, XDS color tokens
+ * @output Exports XDSIllustrationSuccess component
+ * @position Component implementation; consumed by index.ts
+ *
+ * Checkmark in circle illustration — for success or completed states.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Illustration/README.md
+ * - /packages/core/src/Illustration/XDSIllustration.test.tsx
+ * - /packages/core/src/Illustration/index.ts
+ * - /apps/storybook/stories/Illustration.stories.tsx
+ */
+
+import {forwardRef} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+import type {XDSIllustrationProps} from './types';
+
+const sizes = {
+  sm: 48,
+  md: 80,
+  lg: 120,
+} as const;
+
+const styles = stylex.create({
+  svg: {
+    display: 'block',
+    flexShrink: 0,
+  },
+  stroke: {
+    color: colorVars['--color-text-secondary'],
+  },
+  positive: {
+    color: colorVars['--color-positive'],
+  },
+  deemphasized: {
+    color: colorVars['--color-deemphasized'],
+  },
+});
+
+/**
+ * Checkmark in circle illustration.
+ * Use for success, completed, or "all done" states.
+ *
+ * @example
+ * ```tsx
+ * <XDSIllustrationSuccess size="md" />
+ * ```
+ */
+export const XDSIllustrationSuccess = forwardRef<
+  SVGSVGElement,
+  XDSIllustrationProps
+>(({size = 'md', xstyle, 'data-testid': testId}, ref) => {
+  const px = sizes[size];
+
+  return (
+    <svg
+      ref={ref}
+      width={px}
+      height={px}
+      viewBox="0 0 120 120"
+      fill="none"
+      aria-hidden="true"
+      data-testid={testId}
+      {...stylex.props(styles.svg, xstyle)}>
+      {/* Circle background */}
+      <circle
+        cx="60"
+        cy="60"
+        r="40"
+        {...stylex.props(styles.deemphasized)}
+        fill="currentColor"
+      />
+      {/* Circle stroke */}
+      <circle
+        cx="60"
+        cy="60"
+        r="40"
+        {...stylex.props(styles.stroke)}
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Checkmark */}
+      <path
+        d="M40 62L54 76L82 48"
+        {...stylex.props(styles.positive)}
+        stroke="currentColor"
+        strokeWidth="3.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Celebratory sparkle top-right */}
+      <path
+        d="M96 24L98 18L100 24L106 26L100 28L98 34L96 28L90 26L96 24Z"
+        {...stylex.props(styles.positive)}
+        fill="currentColor"
+      />
+      {/* Small sparkle */}
+      <path
+        d="M108 40L109 37L110 40L113 41L110 42L109 45L108 42L105 41L108 40Z"
+        {...stylex.props(styles.positive)}
+        fill="currentColor"
+      />
+    </svg>
+  );
+});
+
+XDSIllustrationSuccess.displayName = 'XDSIllustrationSuccess';

--- a/packages/core/src/Illustration/index.ts
+++ b/packages/core/src/Illustration/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @file Illustration component barrel export
+ */
+
+export {XDSIllustrationNoResults} from './XDSIllustrationNoResults';
+export {XDSIllustrationEmptyInbox} from './XDSIllustrationEmptyInbox';
+export {XDSIllustrationEmptyFolder} from './XDSIllustrationEmptyFolder';
+export {XDSIllustrationError} from './XDSIllustrationError';
+export {XDSIllustrationSuccess} from './XDSIllustrationSuccess';
+export type {XDSIllustrationProps, XDSIllustrationSize} from './types';

--- a/packages/core/src/Illustration/types.ts
+++ b/packages/core/src/Illustration/types.ts
@@ -1,0 +1,33 @@
+/**
+ * @file types.ts
+ * @input None
+ * @output Exports shared types for XDSIllustration components
+ * @position Type definitions; consumed by all illustration components
+ */
+
+import type {StyleXStyles} from '@stylexjs/stylex';
+
+/**
+ * Available illustration sizes.
+ * - sm: 48px — compact empty states
+ * - md: 80px — standard empty states
+ * - lg: 120px — prominent empty states
+ */
+export type XDSIllustrationSize = 'sm' | 'md' | 'lg';
+
+export interface XDSIllustrationProps {
+  /**
+   * Size of the illustration.
+   * - sm: 48px — compact empty states
+   * - md: 80px — standard empty states
+   * - lg: 120px — prominent empty states
+   * @default 'md'
+   */
+  size?: XDSIllustrationSize;
+
+  /** StyleX overrides */
+  xstyle?: StyleXStyles;
+
+  /** Test ID */
+  'data-testid'?: string;
+}


### PR DESCRIPTION
## Summary

Adds a starter set of SVG illustration components designed to pair with XDSEmptyState. All illustrations use XDS theme tokens so they automatically adapt to light/dark mode and custom themes.

## Components

| Component | Use case |
|-----------|----------|
| `XDSIllustrationNoResults` | Search with no matches |
| `XDSIllustrationEmptyInbox` | Empty message/notification list |
| `XDSIllustrationEmptyFolder` | No files/projects/items |
| `XDSIllustrationError` | Something went wrong |
| `XDSIllustrationSuccess` | All done / completed |

## Features
- **Theme-compatible**: Uses XDS color tokens (`--color-text-secondary`, `--color-accent`, etc.)
- **Three sizes**: `sm` (48px), `md` (80px), `lg` (120px)
- **SVG React components** with `forwardRef`
- **Decorative** (`aria-hidden="true"`) — parent provides semantic meaning

## Usage with XDSEmptyState
```tsx
<XDSEmptyState
  icon={<XDSIllustrationNoResults />}
  title="No results found"
  description="Try adjusting your search or filters."
/>

<XDSEmptyState
  icon={<XDSIllustrationEmptyInbox size="lg" />}
  title="No messages"
  description="You're all caught up!"
  actions={<XDSButton label="Compose" variant="primary" onClick={handleCompose} />}
/>
```

Relates to #166

---
*Crafted with care by Navi*