### PR TITLE
feat(ProgressBar): add XDSProgressBar component

### DIFF
--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -1,0 +1,155 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSProgressBar} from '@xds/core/ProgressBar';
+
+const meta: Meta<typeof XDSProgressBar> = {
+  title: 'Core/XDSProgressBar',
+  component: XDSProgressBar,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: {type: 'range', min: 0, max: 100, step: 1},
+      description: 'Current value',
+    },
+    max: {
+      control: 'number',
+      description: 'Maximum value',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label',
+    },
+    variant: {
+      control: 'select',
+      options: ['accent', 'positive', 'warning', 'negative'],
+      description: 'Semantic color variant',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Track height',
+    },
+    isLabelHidden: {
+      control: 'boolean',
+      description: 'Visually hide the label',
+    },
+    hasValueLabel: {
+      control: 'boolean',
+      description: 'Show formatted value',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSProgressBar>;
+
+export const Default: Story = {
+  args: {
+    value: 60,
+    label: 'Progress',
+  },
+};
+
+export const WithValueLabel: Story = {
+  args: {
+    value: 75,
+    label: 'Storage used',
+    hasValueLabel: true,
+  },
+};
+
+export const CustomFormat: Story = {
+  args: {
+    value: 3.2,
+    max: 5,
+    label: 'Disk usage',
+    hasValueLabel: true,
+    formatValueLabel: (value: number, max: number) => `${value} GB / ${max} GB`,
+  },
+};
+
+export const Variants: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        width: '300px',
+      }}>
+      <XDSProgressBar
+        value={60}
+        label="Accent"
+        variant="accent"
+        hasValueLabel
+      />
+      <XDSProgressBar
+        value={80}
+        label="Positive"
+        variant="positive"
+        hasValueLabel
+      />
+      <XDSProgressBar
+        value={50}
+        label="Warning"
+        variant="warning"
+        hasValueLabel
+      />
+      <XDSProgressBar
+        value={92}
+        label="Negative"
+        variant="negative"
+        hasValueLabel
+      />
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        width: '300px',
+      }}>
+      <XDSProgressBar value={60} label="Small" size="sm" hasValueLabel />
+      <XDSProgressBar value={60} label="Medium" size="md" hasValueLabel />
+      <XDSProgressBar value={60} label="Large" size="lg" hasValueLabel />
+    </div>
+  ),
+};
+
+export const HiddenLabel: Story = {
+  args: {
+    value: 50,
+    label: 'Loading progress',
+    isLabelHidden: true,
+  },
+};
+
+export const HiddenLabelWithValue: Story = {
+  args: {
+    value: 75,
+    label: 'Upload',
+    isLabelHidden: true,
+    hasValueLabel: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: 0,
+    label: 'Not started',
+    hasValueLabel: true,
+  },
+};
+
+export const Full: Story = {
+  args: {
+    value: 100,
+    label: 'Complete',
+    hasValueLabel: true,
+    variant: 'positive',
+  },
+};

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -153,3 +153,51 @@ export const Full: Story = {
     variant: 'positive',
   },
 };
+
+export const Indeterminate: Story = {
+  args: {
+    isIndeterminate: true,
+    label: 'Loading...',
+  },
+};
+
+export const IndeterminateHiddenLabel: Story = {
+  args: {
+    isIndeterminate: true,
+    label: 'Loading',
+    isLabelHidden: true,
+  },
+};
+
+export const IndeterminateVariants: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        width: '300px',
+      }}>
+      <XDSProgressBar isIndeterminate label="Accent" variant="accent" />
+      <XDSProgressBar isIndeterminate label="Positive" variant="positive" />
+      <XDSProgressBar isIndeterminate label="Warning" variant="warning" />
+      <XDSProgressBar isIndeterminate label="Negative" variant="negative" />
+    </div>
+  ),
+};
+
+export const IndeterminateSizes: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        width: '300px',
+      }}>
+      <XDSProgressBar isIndeterminate label="Small" size="sm" />
+      <XDSProgressBar isIndeterminate label="Medium" size="md" />
+      <XDSProgressBar isIndeterminate label="Large" size="lg" />
+    </div>
+  ),
+};

--- a/packages/core/src/ProgressBar/README.md
+++ b/packages/core/src/ProgressBar/README.md
@@ -1,0 +1,68 @@
+# ProgressBar
+
+A determinate progress bar for displaying known values within a range.
+
+## Exports
+
+| Export                  | Type      | Description                 |
+| ----------------------- | --------- | --------------------------- |
+| `XDSProgressBar`        | Component | Main progress bar component |
+| `XDSProgressBarProps`   | Type      | Props interface             |
+| `XDSProgressBarVariant` | Type      | Variant union type          |
+| `XDSProgressBarSize`    | Type      | Size union type             |
+
+## Props
+
+| Prop               | Type                                                | Default    | Description                                  |
+| ------------------ | --------------------------------------------------- | ---------- | -------------------------------------------- |
+| `value`            | `number`                                            | —          | Current value of the progress bar            |
+| `max`              | `number`                                            | `100`      | Maximum value                                |
+| `label`            | `string`                                            | —          | Accessible label (required)                  |
+| `isLabelHidden`    | `boolean`                                           | `false`    | Visually hide the label (remains accessible) |
+| `hasValueLabel`    | `boolean`                                           | `false`    | Show formatted value text next to the label  |
+| `formatValueLabel` | `(value: number, max: number) => string`            | percentage | Custom value label formatter                 |
+| `variant`          | `'accent' \| 'positive' \| 'warning' \| 'negative'` | `'accent'` | Semantic color variant                       |
+| `size`             | `'sm' \| 'md' \| 'lg'`                              | `'md'`     | Track height: sm=4px, md=8px, lg=12px        |
+| `xstyle`           | `StyleXStyles`                                      | —          | StyleX overrides for outer container         |
+| `data-testid`      | `string`                                            | —          | Test ID                                      |
+
+## Usage
+
+```tsx
+import {XDSProgressBar} from '@xds/core/ProgressBar';
+
+// Basic progress bar
+<XDSProgressBar value={75} label="Upload progress" />
+
+// With visible value label
+<XDSProgressBar value={75} label="Storage used" hasValueLabel />
+
+// Custom format
+<XDSProgressBar
+  value={3.2}
+  max={5}
+  label="Disk usage"
+  hasValueLabel
+  formatValueLabel={(value, max) => `${value} GB / ${max} GB`}
+/>
+
+// Variant and size
+<XDSProgressBar value={92} label="Disk" variant="negative" size="sm" />
+
+// Hidden label (accessible but not visible)
+<XDSProgressBar value={50} label="Loading" isLabelHidden />
+```
+
+## Accessibility
+
+- Uses `role="meter"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
+- Label is always connected via `aria-labelledby`
+- `aria-valuetext` provides human-readable value description
+
+## Files
+
+| File                      | Purpose                  |
+| ------------------------- | ------------------------ |
+| `XDSProgressBar.tsx`      | Component implementation |
+| `XDSProgressBar.test.tsx` | Unit tests               |
+| `index.ts`                | Barrel exports           |

--- a/packages/core/src/ProgressBar/README.md
+++ b/packages/core/src/ProgressBar/README.md
@@ -1,6 +1,6 @@
 # ProgressBar
 
-A determinate progress bar for displaying known values within a range.
+A progress bar for displaying determinate or indeterminate progress.
 
 ## Exports
 
@@ -13,25 +13,26 @@ A determinate progress bar for displaying known values within a range.
 
 ## Props
 
-| Prop               | Type                                                | Default    | Description                                  |
-| ------------------ | --------------------------------------------------- | ---------- | -------------------------------------------- |
-| `value`            | `number`                                            | —          | Current value of the progress bar            |
-| `max`              | `number`                                            | `100`      | Maximum value                                |
-| `label`            | `string`                                            | —          | Accessible label (required)                  |
-| `isLabelHidden`    | `boolean`                                           | `false`    | Visually hide the label (remains accessible) |
-| `hasValueLabel`    | `boolean`                                           | `false`    | Show formatted value text next to the label  |
-| `formatValueLabel` | `(value: number, max: number) => string`            | percentage | Custom value label formatter                 |
-| `variant`          | `'accent' \| 'positive' \| 'warning' \| 'negative'` | `'accent'` | Semantic color variant                       |
-| `size`             | `'sm' \| 'md' \| 'lg'`                              | `'md'`     | Track height: sm=4px, md=8px, lg=12px        |
-| `xstyle`           | `StyleXStyles`                                      | —          | StyleX overrides for outer container         |
-| `data-testid`      | `string`                                            | —          | Test ID                                      |
+| Prop               | Type                                                | Default    | Description                                            |
+| ------------------ | --------------------------------------------------- | ---------- | ------------------------------------------------------ |
+| `value`            | `number`                                            | `0`        | Current value (ignored when indeterminate)             |
+| `max`              | `number`                                            | `100`      | Maximum value                                          |
+| `label`            | `string`                                            | —          | Accessible label (required)                            |
+| `isLabelHidden`    | `boolean`                                           | `false`    | Visually hide the label (remains accessible)           |
+| `hasValueLabel`    | `boolean`                                           | `false`    | Show formatted value text (ignored when indeterminate) |
+| `formatValueLabel` | `(value: number, max: number) => string`            | percentage | Custom value label formatter                           |
+| `variant`          | `'accent' \| 'positive' \| 'warning' \| 'negative'` | `'accent'` | Semantic color variant                                 |
+| `size`             | `'sm' \| 'md' \| 'lg'`                              | `'md'`     | Track height: sm=4px, md=8px, lg=12px                  |
+| `isIndeterminate`  | `boolean`                                           | `false`    | Animated loading indicator for unknown progress        |
+| `xstyle`           | `StyleXStyles`                                      | —          | StyleX overrides for outer container                   |
+| `data-testid`      | `string`                                            | —          | Test ID                                                |
 
 ## Usage
 
 ```tsx
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 
-// Basic progress bar
+// Determinate progress bar
 <XDSProgressBar value={75} label="Upload progress" />
 
 // With visible value label
@@ -46,6 +47,9 @@ import {XDSProgressBar} from '@xds/core/ProgressBar';
   formatValueLabel={(value, max) => `${value} GB / ${max} GB`}
 />
 
+// Indeterminate loading
+<XDSProgressBar isIndeterminate label="Loading..." />
+
 // Variant and size
 <XDSProgressBar value={92} label="Disk" variant="negative" size="sm" />
 
@@ -55,9 +59,11 @@ import {XDSProgressBar} from '@xds/core/ProgressBar';
 
 ## Accessibility
 
-- Uses `role="meter"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
+- Determinate: uses `role="meter"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
+- Indeterminate: uses `role="progressbar"` without value attributes
 - Label is always connected via `aria-labelledby`
-- `aria-valuetext` provides human-readable value description
+- `aria-valuetext` provides human-readable value description (determinate only)
+- Indeterminate animation respects `prefers-reduced-motion`
 
 ## Files
 

--- a/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
@@ -1,0 +1,125 @@
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSProgressBar} from './XDSProgressBar';
+
+describe('XDSProgressBar', () => {
+  it('renders with default props', () => {
+    render(<XDSProgressBar value={50} label="Progress" />);
+    const meter = screen.getByRole('meter');
+    expect(meter).toBeInTheDocument();
+    expect(meter).toHaveAttribute('aria-valuenow', '50');
+    expect(meter).toHaveAttribute('aria-valuemin', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('renders visible label by default', () => {
+    render(<XDSProgressBar value={50} label="Storage used" />);
+    expect(screen.getByText('Storage used')).toBeInTheDocument();
+  });
+
+  it('hides label visually when isLabelHidden is true', () => {
+    render(<XDSProgressBar value={50} label="Hidden label" isLabelHidden />);
+    // Label should still be in the DOM for a11y
+    const label = screen.getByText('Hidden label');
+    expect(label).toBeInTheDocument();
+    // The meter should still be labelled
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-labelledby');
+  });
+
+  it('shows value label when hasValueLabel is true', () => {
+    render(<XDSProgressBar value={75} label="Upload" hasValueLabel />);
+    expect(screen.getByText('75%')).toBeInTheDocument();
+  });
+
+  it('uses custom formatValueLabel', () => {
+    render(
+      <XDSProgressBar
+        value={3}
+        max={5}
+        label="Disk"
+        hasValueLabel
+        formatValueLabel={(v, m) => `${v} GB / ${m} GB`}
+      />,
+    );
+    expect(screen.getByText('3 GB / 5 GB')).toBeInTheDocument();
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuetext', '3 GB / 5 GB');
+  });
+
+  it('sets aria-valuetext from formatValueLabel', () => {
+    render(<XDSProgressBar value={50} label="Progress" />);
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuetext', '50%');
+  });
+
+  it('respects custom max', () => {
+    render(<XDSProgressBar value={3} max={10} label="Steps" />);
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '3');
+    expect(meter).toHaveAttribute('aria-valuemax', '10');
+  });
+
+  it('clamps value to [0, max]', () => {
+    const {rerender} = render(
+      <XDSProgressBar value={150} max={100} label="Over" />,
+    );
+    let meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '100');
+
+    rerender(<XDSProgressBar value={-10} max={100} label="Under" />);
+    meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('forwards ref to outer container', () => {
+    const ref = {current: null as HTMLDivElement | null};
+    render(<XDSProgressBar ref={ref} value={50} label="Test" />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('passes data-testid', () => {
+    render(
+      <XDSProgressBar value={50} label="Test" data-testid="my-progress" />,
+    );
+    expect(screen.getByTestId('my-progress')).toBeInTheDocument();
+  });
+
+  it('renders with all variant options', () => {
+    const variants = ['accent', 'positive', 'warning', 'negative'] as const;
+    for (const variant of variants) {
+      const {unmount} = render(
+        <XDSProgressBar value={50} label={variant} variant={variant} />,
+      );
+      expect(screen.getByRole('meter')).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('renders with all size options', () => {
+    const sizes = ['sm', 'md', 'lg'] as const;
+    for (const size of sizes) {
+      const {unmount} = render(
+        <XDSProgressBar value={50} label={size} size={size} />,
+      );
+      expect(screen.getByRole('meter')).toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('shows value label with hidden label', () => {
+    render(
+      <XDSProgressBar value={60} label="Hidden" isLabelHidden hasValueLabel />,
+    );
+    expect(screen.getByText('60%')).toBeInTheDocument();
+    // Label is still in DOM for a11y
+    expect(screen.getByText('Hidden')).toBeInTheDocument();
+  });
+
+  it('handles zero max gracefully', () => {
+    render(<XDSProgressBar value={0} max={0} label="Empty" />);
+    const meter = screen.getByRole('meter');
+    expect(meter).toHaveAttribute('aria-valuenow', '0');
+    expect(meter).toHaveAttribute('aria-valuemax', '0');
+  });
+});

--- a/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
@@ -122,4 +122,56 @@ describe('XDSProgressBar', () => {
     expect(meter).toHaveAttribute('aria-valuenow', '0');
     expect(meter).toHaveAttribute('aria-valuemax', '0');
   });
+
+  // Indeterminate mode tests
+  describe('indeterminate mode', () => {
+    it('renders with role="progressbar" when isIndeterminate', () => {
+      render(<XDSProgressBar isIndeterminate label="Loading" />);
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar).toBeInTheDocument();
+    });
+
+    it('does not set aria-valuenow/min/max when indeterminate', () => {
+      render(<XDSProgressBar isIndeterminate label="Loading" />);
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar).not.toHaveAttribute('aria-valuenow');
+      expect(progressbar).not.toHaveAttribute('aria-valuemin');
+      expect(progressbar).not.toHaveAttribute('aria-valuemax');
+      expect(progressbar).not.toHaveAttribute('aria-valuetext');
+    });
+
+    it('still renders label when indeterminate', () => {
+      render(<XDSProgressBar isIndeterminate label="Processing" />);
+      expect(screen.getByText('Processing')).toBeInTheDocument();
+    });
+
+    it('hides value label when indeterminate even if hasValueLabel is true', () => {
+      render(
+        <XDSProgressBar
+          isIndeterminate
+          label="Loading"
+          value={50}
+          hasValueLabel
+        />,
+      );
+      expect(screen.queryByText('50%')).not.toBeInTheDocument();
+    });
+
+    it('is labelled via aria-labelledby when indeterminate', () => {
+      render(<XDSProgressBar isIndeterminate label="Loading data" />);
+      const progressbar = screen.getByRole('progressbar');
+      expect(progressbar).toHaveAttribute('aria-labelledby');
+    });
+
+    it('renders with all variants in indeterminate mode', () => {
+      const variants = ['accent', 'positive', 'warning', 'negative'] as const;
+      for (const variant of variants) {
+        const {unmount} = render(
+          <XDSProgressBar isIndeterminate label={variant} variant={variant} />,
+        );
+        expect(screen.getByRole('progressbar')).toBeInTheDocument();
+        unmount();
+      }
+    });
+  });
 });

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -1,0 +1,256 @@
+/**
+ * @file XDSProgressBar.tsx
+ * @input Uses React forwardRef, useId, stylex, color/spacing/radius/transition tokens
+ * @output Exports XDSProgressBar component, XDSProgressBarProps, XDSProgressBarVariant, XDSProgressBarSize types
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/ProgressBar/README.md (props table, features, implementation notes)
+ * - /packages/core/src/ProgressBar/XDSProgressBar.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/ProgressBar/index.ts (exports if types change)
+ * - /apps/storybook/stories/ProgressBar.stories.tsx (storybook stories)
+ */
+
+import {forwardRef, useId} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+  transitionVars,
+} from '../theme/tokens.stylex';
+
+/**
+ * Progress bar variant type — maps to semantic color tokens.
+ */
+export type XDSProgressBarVariant =
+  | 'accent'
+  | 'positive'
+  | 'warning'
+  | 'negative';
+
+/**
+ * Progress bar size type — controls track height.
+ */
+export type XDSProgressBarSize = 'sm' | 'md' | 'lg';
+
+export interface XDSProgressBarProps {
+  /**
+   * Current value of the progress bar.
+   */
+  value: number;
+  /**
+   * Maximum value of the progress bar.
+   * @default 100
+   */
+  max?: number;
+  /**
+   * Accessible label for the progress bar. Required for a11y.
+   * Shown visually above the bar unless `isLabelHidden` is true.
+   */
+  label: string;
+  /**
+   * When true, the label is visually hidden but remains accessible to screen readers.
+   * @default false
+   */
+  isLabelHidden?: boolean;
+  /**
+   * When true, displays the formatted value (e.g. "75%") next to the label.
+   * @default false
+   */
+  hasValueLabel?: boolean;
+  /**
+   * Custom formatter for the value label.
+   * @default (value, max) => `${Math.round((value / max) * 100)}%`
+   */
+  formatValueLabel?: (value: number, max: number) => string;
+  /**
+   * Visual style variant mapped to semantic color tokens.
+   * @default 'accent'
+   */
+  variant?: XDSProgressBarVariant;
+  /**
+   * Size of the progress bar track.
+   * - sm: 4px
+   * - md: 8px
+   * - lg: 12px
+   * @default 'md'
+   */
+  size?: XDSProgressBarSize;
+  /**
+   * StyleX styles to apply to the outer container.
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * Test ID for testing utilities.
+   */
+  'data-testid'?: string;
+}
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+    width: '100%',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'baseline',
+  },
+  label: {
+    fontSize: textSizeVars['--text-sm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-primary'],
+  },
+  valueLabel: {
+    fontSize: textSizeVars['--text-sm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    color: colorVars['--color-text-secondary'],
+  },
+  visuallyHidden: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderWidth: 0,
+  },
+  track: {
+    width: '100%',
+    backgroundColor: colorVars['--color-deemphasized'],
+    borderRadius: radiusVars['--radius-rounded'],
+    overflow: 'hidden',
+  },
+  fill: {
+    height: '100%',
+    borderRadius: radiusVars['--radius-rounded'],
+    transitionProperty: 'width',
+    transitionDuration: transitionVars['--transition-normal'],
+  },
+});
+
+const sizeStyles = stylex.create({
+  sm: {
+    height: '4px',
+  },
+  md: {
+    height: '8px',
+  },
+  lg: {
+    height: '12px',
+  },
+});
+
+const variantStyles = stylex.create({
+  accent: {
+    backgroundColor: colorVars['--color-accent'],
+  },
+  positive: {
+    backgroundColor: colorVars['--color-positive'],
+  },
+  warning: {
+    backgroundColor: colorVars['--color-warning'],
+  },
+  negative: {
+    backgroundColor: colorVars['--color-negative'],
+  },
+});
+
+function defaultFormatValueLabel(value: number, max: number): string {
+  return `${Math.round((value / max) * 100)}%`;
+}
+
+/**
+ * A determinate progress bar for displaying known values within a range.
+ *
+ * Displays progress such as upload completion, disk usage, or battery level.
+ * Uses `role="meter"` with full ARIA attributes.
+ *
+ * Styles use XDS theme tokens via StyleX.
+ * Wrap your app in <Theme> to apply a theme.
+ *
+ * @example
+ * ```tsx
+ * <XDSProgressBar value={75} label="Upload progress" />
+ * <XDSProgressBar value={3.2} max={5} label="Disk usage" hasValueLabel
+ *   formatValueLabel={(v, m) => `${v} GB / ${m} GB`} />
+ * ```
+ */
+export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
+  function XDSProgressBar(
+    {
+      value,
+      max = 100,
+      label,
+      isLabelHidden = false,
+      hasValueLabel = false,
+      formatValueLabel = defaultFormatValueLabel,
+      variant = 'accent',
+      size = 'md',
+      xstyle,
+      'data-testid': dataTestId,
+    },
+    ref,
+  ) {
+    const labelId = useId();
+    const clampedValue = Math.min(Math.max(0, value), max);
+    const percentage = max > 0 ? (clampedValue / max) * 100 : 0;
+    const valueText = formatValueLabel(clampedValue, max);
+
+    return (
+      <div
+        ref={ref}
+        {...stylex.props(styles.container, xstyle)}
+        data-testid={dataTestId}>
+        {/* Label row */}
+        {!isLabelHidden || hasValueLabel ? (
+          <div {...stylex.props(styles.header)}>
+            <span
+              id={labelId}
+              {...stylex.props(
+                styles.label,
+                isLabelHidden && styles.visuallyHidden,
+              )}>
+              {label}
+            </span>
+            {hasValueLabel && (
+              <span {...stylex.props(styles.valueLabel)}>{valueText}</span>
+            )}
+          </div>
+        ) : (
+          <span id={labelId} {...stylex.props(styles.visuallyHidden)}>
+            {label}
+          </span>
+        )}
+
+        {/* Progress track */}
+        <div
+          role="meter"
+          aria-valuenow={clampedValue}
+          aria-valuemin={0}
+          aria-valuemax={max}
+          aria-labelledby={labelId}
+          aria-valuetext={valueText}
+          {...stylex.props(styles.track, sizeStyles[size])}>
+          <div
+            {...stylex.props(styles.fill, variantStyles[variant])}
+            style={{width: `${percentage}%`}}
+          />
+        </div>
+      </div>
+    );
+  },
+);
+
+XDSProgressBar.displayName = 'XDSProgressBar';

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -41,8 +41,9 @@ export type XDSProgressBarSize = 'sm' | 'md' | 'lg';
 export interface XDSProgressBarProps {
   /**
    * Current value of the progress bar.
+   * Ignored when `isIndeterminate` is true.
    */
-  value: number;
+  value?: number;
   /**
    * Maximum value of the progress bar.
    * @default 100
@@ -60,6 +61,7 @@ export interface XDSProgressBarProps {
   isLabelHidden?: boolean;
   /**
    * When true, displays the formatted value (e.g. "75%") next to the label.
+   * Ignored when `isIndeterminate` is true.
    * @default false
    */
   hasValueLabel?: boolean;
@@ -82,6 +84,14 @@ export interface XDSProgressBarProps {
    */
   size?: XDSProgressBarSize;
   /**
+   * When true, renders an animated indeterminate progress indicator.
+   * Use when the progress amount is unknown (e.g. loading, processing).
+   * The `value` and `hasValueLabel` props are ignored in this mode.
+   * Respects `prefers-reduced-motion` by slowing the animation.
+   * @default false
+   */
+  isIndeterminate?: boolean;
+  /**
    * StyleX styles to apply to the outer container.
    */
   xstyle?: StyleXStyles;
@@ -90,6 +100,23 @@ export interface XDSProgressBarProps {
    */
   'data-testid'?: string;
 }
+
+// =============================================================================
+// Indeterminate animation
+// =============================================================================
+
+const indeterminateSlide = stylex.keyframes({
+  '0%': {
+    transform: 'translateX(-100%)',
+  },
+  '100%': {
+    transform: 'translateX(250%)',
+  },
+});
+
+// =============================================================================
+// Styles
+// =============================================================================
 
 const styles = stylex.create({
   container: {
@@ -138,6 +165,18 @@ const styles = stylex.create({
     transitionProperty: 'width',
     transitionDuration: transitionVars['--transition-normal'],
   },
+  indeterminateFill: {
+    height: '100%',
+    width: '40%',
+    borderRadius: radiusVars['--radius-rounded'],
+    animationName: indeterminateSlide,
+    animationDuration: {
+      default: '1.5s',
+      '@media (prefers-reduced-motion: reduce)': '3s',
+    },
+    animationTimingFunction: 'ease-in-out',
+    animationIterationCount: 'infinite',
+  },
 });
 
 const sizeStyles = stylex.create({
@@ -172,17 +211,24 @@ function defaultFormatValueLabel(value: number, max: number): string {
 }
 
 /**
- * A determinate progress bar for displaying known values within a range.
+ * A progress bar for displaying determinate or indeterminate progress.
  *
- * Displays progress such as upload completion, disk usage, or battery level.
- * Uses `role="meter"` with full ARIA attributes.
+ * In determinate mode, displays a known value within a range (upload progress,
+ * disk usage, etc). In indeterminate mode, shows an animated loading indicator
+ * for unknown progress.
  *
  * Styles use XDS theme tokens via StyleX.
  * Wrap your app in <Theme> to apply a theme.
  *
  * @example
  * ```tsx
+ * // Determinate
  * <XDSProgressBar value={75} label="Upload progress" />
+ *
+ * // Indeterminate
+ * <XDSProgressBar isIndeterminate label="Loading..." />
+ *
+ * // Custom format
  * <XDSProgressBar value={3.2} max={5} label="Disk usage" hasValueLabel
  *   formatValueLabel={(v, m) => `${v} GB / ${m} GB`} />
  * ```
@@ -190,7 +236,7 @@ function defaultFormatValueLabel(value: number, max: number): string {
 export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
   function XDSProgressBar(
     {
-      value,
+      value = 0,
       max = 100,
       label,
       isLabelHidden = false,
@@ -198,6 +244,7 @@ export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
       formatValueLabel = defaultFormatValueLabel,
       variant = 'accent',
       size = 'md',
+      isIndeterminate = false,
       xstyle,
       'data-testid': dataTestId,
     },
@@ -208,13 +255,16 @@ export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
     const percentage = max > 0 ? (clampedValue / max) * 100 : 0;
     const valueText = formatValueLabel(clampedValue, max);
 
+    // In indeterminate mode, don't show value label
+    const showValueLabel = hasValueLabel && !isIndeterminate;
+
     return (
       <div
         ref={ref}
         {...stylex.props(styles.container, xstyle)}
         data-testid={dataTestId}>
         {/* Label row */}
-        {!isLabelHidden || hasValueLabel ? (
+        {!isLabelHidden || showValueLabel ? (
           <div {...stylex.props(styles.header)}>
             <span
               id={labelId}
@@ -224,7 +274,7 @@ export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
               )}>
               {label}
             </span>
-            {hasValueLabel && (
+            {showValueLabel && (
               <span {...stylex.props(styles.valueLabel)}>{valueText}</span>
             )}
           </div>
@@ -236,17 +286,26 @@ export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
 
         {/* Progress track */}
         <div
-          role="meter"
-          aria-valuenow={clampedValue}
-          aria-valuemin={0}
-          aria-valuemax={max}
+          role={isIndeterminate ? 'progressbar' : 'meter'}
+          aria-valuenow={isIndeterminate ? undefined : clampedValue}
+          aria-valuemin={isIndeterminate ? undefined : 0}
+          aria-valuemax={isIndeterminate ? undefined : max}
           aria-labelledby={labelId}
-          aria-valuetext={valueText}
+          aria-valuetext={isIndeterminate ? undefined : valueText}
           {...stylex.props(styles.track, sizeStyles[size])}>
-          <div
-            {...stylex.props(styles.fill, variantStyles[variant])}
-            style={{width: `${percentage}%`}}
-          />
+          {isIndeterminate ? (
+            <div
+              {...stylex.props(
+                styles.indeterminateFill,
+                variantStyles[variant],
+              )}
+            />
+          ) : (
+            <div
+              {...stylex.props(styles.fill, variantStyles[variant])}
+              style={{width: `${percentage}%`}}
+            />
+          )}
         </div>
       </div>
     );

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @file ProgressBar component barrel export
+ */
+
+export {XDSProgressBar} from './XDSProgressBar';
+export type {
+  XDSProgressBarProps,
+  XDSProgressBarVariant,
+  XDSProgressBarSize,
+} from './XDSProgressBar';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,6 +36,7 @@ export * from './Table';
 export * from './Dialog';
 export * from './DropdownMenu';
 export * from './TopNav';
+export * from './ProgressBar';
 
 // Layout utilities and components (includes XDSHStack, XDSVStack)
 export * from './Layout';


### PR DESCRIPTION
## Summary

Implements XDSProgressBar — a determinate progress bar for displaying known values like upload completion, disk usage, or battery level.

> Renamed from `XDSMeter` to `XDSProgressBar` for discoverability — developers search for "progress bar", not "meter". See [issue comment](https://github.com/facebookexperimental/xds/issues/176#issuecomment-3929509125). Supersedes #189.

## Features
- Four semantic variants: `accent`, `positive`, `warning`, `negative`
- Three sizes: `sm` (4px), `md` (8px), `lg` (12px)
- Required `label` for accessibility (`role="meter"` with full ARIA attributes)
- Optional visible label (`isLabelHidden`) and value label (`hasValueLabel`)
- Custom `formatValueLabel` function for display formatting
- Smooth fill animation via CSS transition
- `forwardRef`, `xstyle` override, `data-testid`

## Usage
```tsx
<XDSProgressBar value={75} label="Upload progress" />

<XDSProgressBar value={75} label="Storage used" hasValueLabel />

<XDSProgressBar
  value={3.2}
  max={5}
  label="Disk usage"
  hasValueLabel
  formatValueLabel={(value, max) => `${value} GB / ${max} GB`}
/>

<XDSProgressBar value={92} label="Disk" variant="negative" size="sm" />
```

Closes #176

---
*Crafted with care by Navi*