### PR TITLE
feat(Breadcrumbs): add XDSBreadcrumbs component

### DIFF
--- a/apps/storybook/stories/Breadcrumbs.stories.tsx
+++ b/apps/storybook/stories/Breadcrumbs.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
+import {HomeIcon, Cog6ToothIcon, FolderIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSBreadcrumbs> = {
   title: 'Navigation/XDSBreadcrumbs',
@@ -13,6 +14,11 @@ const meta: Meta<typeof XDSBreadcrumbs> = {
     label: {
       control: 'text',
       description: 'Accessible label for the nav landmark',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'supporting'],
+      description: 'Visual variant controlling text size and color',
     },
   },
 };
@@ -52,7 +58,7 @@ export const AutoDetectCurrent: Story = {
 
 export const CustomSeparator: Story = {
   render: () => (
-    <XDSBreadcrumbs separator={'\u203a'}>
+    <XDSBreadcrumbs separator={'›'}>
       <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
       <XDSBreadcrumbItem href="/docs">Docs</XDSBreadcrumbItem>
       <XDSBreadcrumbItem isCurrent>API Reference</XDSBreadcrumbItem>
@@ -65,12 +71,12 @@ export const WithIcons: Story = {
     <XDSBreadcrumbs>
       <XDSBreadcrumbItem
         href="/"
-        startIcon={<span aria-hidden="true">{'\ud83c\udfe0'}</span>}>
+        startIcon={<HomeIcon width={16} height={16} aria-hidden="true" />}>
         Home
       </XDSBreadcrumbItem>
       <XDSBreadcrumbItem
         href="/settings"
-        startIcon={<span aria-hidden="true">{'\u2699\ufe0f'}</span>}>
+        startIcon={<Cog6ToothIcon width={16} height={16} aria-hidden="true" />}>
         Settings
       </XDSBreadcrumbItem>
       <XDSBreadcrumbItem isCurrent>Profile</XDSBreadcrumbItem>
@@ -114,6 +120,36 @@ export const DeepHierarchy: Story = {
         Phones
       </XDSBreadcrumbItem>
       <XDSBreadcrumbItem isCurrent>iPhone 15 Pro</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};
+
+export const SupportingVariant: Story = {
+  name: 'Supporting Variant',
+  render: () => (
+    <XDSBreadcrumbs variant="supporting">
+      <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};
+
+export const SupportingWithIcons: Story = {
+  name: 'Supporting Variant with Icons',
+  render: () => (
+    <XDSBreadcrumbs variant="supporting">
+      <XDSBreadcrumbItem
+        href="/"
+        startIcon={<HomeIcon width={14} height={14} aria-hidden="true" />}>
+        Home
+      </XDSBreadcrumbItem>
+      <XDSBreadcrumbItem
+        href="/projects"
+        startIcon={<FolderIcon width={14} height={14} aria-hidden="true" />}>
+        Projects
+      </XDSBreadcrumbItem>
+      <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
     </XDSBreadcrumbs>
   ),
 };

--- a/apps/storybook/stories/Breadcrumbs.stories.tsx
+++ b/apps/storybook/stories/Breadcrumbs.stories.tsx
@@ -1,0 +1,119 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
+
+const meta: Meta<typeof XDSBreadcrumbs> = {
+  title: 'Navigation/XDSBreadcrumbs',
+  component: XDSBreadcrumbs,
+  tags: ['autodocs'],
+  argTypes: {
+    separator: {
+      control: 'text',
+      description: 'Separator between items',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label for the nav landmark',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSBreadcrumbs>;
+
+export const Default: Story = {
+  render: () => (
+    <XDSBreadcrumbs>
+      <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};
+
+export const TwoLevels: Story = {
+  render: () => (
+    <XDSBreadcrumbs>
+      <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem isCurrent>Settings</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};
+
+export const AutoDetectCurrent: Story = {
+  name: 'Auto-detect Current',
+  render: () => (
+    <XDSBreadcrumbs>
+      <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem>Auto Current</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};
+
+export const CustomSeparator: Story = {
+  render: () => (
+    <XDSBreadcrumbs separator={'\u203a'}>
+      <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem href="/docs">Docs</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem isCurrent>API Reference</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};
+
+export const WithIcons: Story = {
+  render: () => (
+    <XDSBreadcrumbs>
+      <XDSBreadcrumbItem
+        href="/"
+        startIcon={<span aria-hidden="true">{'\ud83c\udfe0'}</span>}>
+        Home
+      </XDSBreadcrumbItem>
+      <XDSBreadcrumbItem
+        href="/settings"
+        startIcon={<span aria-hidden="true">{'\u2699\ufe0f'}</span>}>
+        Settings
+      </XDSBreadcrumbItem>
+      <XDSBreadcrumbItem isCurrent>Profile</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};
+
+export const WithOnClick: Story = {
+  render: () => (
+    <XDSBreadcrumbs>
+      <XDSBreadcrumbItem
+        href="/"
+        onClick={e => {
+          e.preventDefault();
+          console.log('Navigate to Home');
+        }}>
+        Home
+      </XDSBreadcrumbItem>
+      <XDSBreadcrumbItem
+        href="/projects"
+        onClick={e => {
+          e.preventDefault();
+          console.log('Navigate to Projects');
+        }}>
+        Projects
+      </XDSBreadcrumbItem>
+      <XDSBreadcrumbItem isCurrent>Detail</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};
+
+export const DeepHierarchy: Story = {
+  render: () => (
+    <XDSBreadcrumbs>
+      <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem href="/products">Products</XDSBreadcrumbItem>
+      <XDSBreadcrumbItem href="/products/electronics">
+        Electronics
+      </XDSBreadcrumbItem>
+      <XDSBreadcrumbItem href="/products/electronics/phones">
+        Phones
+      </XDSBreadcrumbItem>
+      <XDSBreadcrumbItem isCurrent>iPhone 15 Pro</XDSBreadcrumbItem>
+    </XDSBreadcrumbs>
+  ),
+};

--- a/packages/core/src/Breadcrumbs/README.md
+++ b/packages/core/src/Breadcrumbs/README.md
@@ -1,80 +1,79 @@
 # Breadcrumbs
 
-A navigation breadcrumb trail showing the user's location within a hierarchy.
+A navigation breadcrumb trail with semantic HTML.
 
 ## Exports
 
-| Export                   | Type      | Description                 |
-| ------------------------ | --------- | --------------------------- |
-| `XDSBreadcrumbs`         | Component | Container nav + ol wrapper  |
-| `XDSBreadcrumbItem`      | Component | Individual breadcrumb item  |
-| `XDSBreadcrumbsProps`    | Type      | Props for XDSBreadcrumbs    |
-| `XDSBreadcrumbItemProps` | Type      | Props for XDSBreadcrumbItem |
+| Export                   | Type      | Description                |
+| ------------------------ | --------- | -------------------------- |
+| `XDSBreadcrumbs`         | Component | Container with nav + ol    |
+| `XDSBreadcrumbsProps`    | Type      | Container props interface  |
+| `XDSBreadcrumbsVariant`  | Type      | Variant union type         |
+| `XDSBreadcrumbItem`      | Component | Individual breadcrumb item |
+| `XDSBreadcrumbItemProps` | Type      | Item props interface       |
 
-## XDSBreadcrumbs Props
+## Props — XDSBreadcrumbs
 
-| Prop          | Type           | Default        | Description                          |
-| ------------- | -------------- | -------------- | ------------------------------------ |
-| `children`    | `ReactNode`    | —              | XDSBreadcrumbItem elements           |
-| `separator`   | `ReactNode`    | `'/'`          | Separator between items (decorative) |
-| `xstyle`      | `StyleXStyles` | —              | StyleX styles for the nav container  |
-| `label`       | `string`       | `'Breadcrumb'` | aria-label for the nav landmark      |
-| `data-testid` | `string`       | —              | Test ID for the nav element          |
+| Prop          | Type                        | Default        | Description                       |
+| ------------- | --------------------------- | -------------- | --------------------------------- |
+| `children`    | `ReactNode`                 | —              | XDSBreadcrumbItem elements        |
+| `separator`   | `ReactNode`                 | `'/'`          | Separator between items           |
+| `variant`     | `'default' \| 'supporting'` | `'default'`    | Visual variant                    |
+| `xstyle`      | `StyleXStyles`              | —              | StyleX overrides                  |
+| `label`       | `string`                    | `'Breadcrumb'` | Accessible label for nav landmark |
+| `data-testid` | `string`                    | —              | Test ID                           |
 
-## XDSBreadcrumbItem Props
+## Props — XDSBreadcrumbItem
 
-| Prop          | Type                      | Default | Description                                 |
-| ------------- | ------------------------- | ------- | ------------------------------------------- |
-| `children`    | `ReactNode`               | —       | Label content                               |
-| `href`        | `string`                  | —       | URL for the breadcrumb link                 |
-| `onClick`     | `(e: MouseEvent) => void` | —       | Click handler                               |
-| `isCurrent`   | `boolean`                 | `false` | Marks as current page (aria-current="page") |
-| `startIcon`   | `ReactNode`               | —       | Icon rendered before the label              |
-| `data-testid` | `string`                  | —       | Test ID for the list item                   |
+| Prop          | Type                      | Default | Description                          |
+| ------------- | ------------------------- | ------- | ------------------------------------ |
+| `children`    | `ReactNode`               | —       | Item label content                   |
+| `href`        | `string`                  | —       | URL for the breadcrumb link          |
+| `onClick`     | `(e: MouseEvent) => void` | —       | Click handler                        |
+| `isCurrent`   | `boolean`                 | `false` | Marks as current page (aria-current) |
+| `startIcon`   | `ReactNode`               | —       | Icon before the label                |
+| `data-testid` | `string`                  | —       | Test ID                              |
 
 ## Usage
 
 ```tsx
 import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
 
-// Basic usage
+// Basic breadcrumbs
 <XDSBreadcrumbs>
   <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
   <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
   <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
 </XDSBreadcrumbs>
 
-// Auto-detect current (last item becomes current automatically)
-<XDSBreadcrumbs>
-  <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
-  <XDSBreadcrumbItem>Settings</XDSBreadcrumbItem>
-</XDSBreadcrumbs>
-
-// Custom separator
-<XDSBreadcrumbs separator="›">
+// Supporting variant (smaller, secondary text)
+<XDSBreadcrumbs variant="supporting">
   <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
   <XDSBreadcrumbItem isCurrent>Page</XDSBreadcrumbItem>
 </XDSBreadcrumbs>
 
 // With icons
 <XDSBreadcrumbs>
-  <XDSBreadcrumbItem href="/" startIcon={<HomeIcon />}>Home</XDSBreadcrumbItem>
+  <XDSBreadcrumbItem href="/" startIcon={<XDSIcon icon={HomeIcon} size="sm" />}>
+    Home
+  </XDSBreadcrumbItem>
   <XDSBreadcrumbItem isCurrent>Settings</XDSBreadcrumbItem>
 </XDSBreadcrumbs>
 ```
 
 ## Accessibility
 
-- Outer `<nav>` landmark with `aria-label`
-- Items rendered in an `<ol>` ordered list
-- Current item has `aria-current="page"` and renders as `<span>` (not a link)
-- Separators are `aria-hidden="true"` with `role="presentation"`
-- Auto-detects last child as current if no `isCurrent` is explicitly set
+- Container is `<nav aria-label>` landmark
+- Items in `<ol>` with `<li>` elements
+- Current item has `aria-current="page"`
+- Separators are `aria-hidden="true"`
+- Auto-detects last child as current when no `isCurrent` is set
 
 ## Files
 
-| File                      | Purpose                  |
-| ------------------------- | ------------------------ |
-| `XDSBreadcrumbs.tsx`      | Component implementation |
-| `XDSBreadcrumbs.test.tsx` | Unit tests               |
-| `index.ts`                | Barrel exports           |
+| File                      | Purpose                   |
+| ------------------------- | ------------------------- |
+| `XDSBreadcrumbs.tsx`      | Container component       |
+| `XDSBreadcrumbItem.tsx`   | Individual item component |
+| `XDSBreadcrumbs.test.tsx` | Unit tests                |
+| `index.ts`                | Barrel exports            |

--- a/packages/core/src/Breadcrumbs/README.md
+++ b/packages/core/src/Breadcrumbs/README.md
@@ -1,0 +1,80 @@
+# Breadcrumbs
+
+A navigation breadcrumb trail showing the user's location within a hierarchy.
+
+## Exports
+
+| Export                   | Type      | Description                 |
+| ------------------------ | --------- | --------------------------- |
+| `XDSBreadcrumbs`         | Component | Container nav + ol wrapper  |
+| `XDSBreadcrumbItem`      | Component | Individual breadcrumb item  |
+| `XDSBreadcrumbsProps`    | Type      | Props for XDSBreadcrumbs    |
+| `XDSBreadcrumbItemProps` | Type      | Props for XDSBreadcrumbItem |
+
+## XDSBreadcrumbs Props
+
+| Prop          | Type           | Default        | Description                          |
+| ------------- | -------------- | -------------- | ------------------------------------ |
+| `children`    | `ReactNode`    | —              | XDSBreadcrumbItem elements           |
+| `separator`   | `ReactNode`    | `'/'`          | Separator between items (decorative) |
+| `xstyle`      | `StyleXStyles` | —              | StyleX styles for the nav container  |
+| `label`       | `string`       | `'Breadcrumb'` | aria-label for the nav landmark      |
+| `data-testid` | `string`       | —              | Test ID for the nav element          |
+
+## XDSBreadcrumbItem Props
+
+| Prop          | Type                      | Default | Description                                 |
+| ------------- | ------------------------- | ------- | ------------------------------------------- |
+| `children`    | `ReactNode`               | —       | Label content                               |
+| `href`        | `string`                  | —       | URL for the breadcrumb link                 |
+| `onClick`     | `(e: MouseEvent) => void` | —       | Click handler                               |
+| `isCurrent`   | `boolean`                 | `false` | Marks as current page (aria-current="page") |
+| `startIcon`   | `ReactNode`               | —       | Icon rendered before the label              |
+| `data-testid` | `string`                  | —       | Test ID for the list item                   |
+
+## Usage
+
+```tsx
+import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
+
+// Basic usage
+<XDSBreadcrumbs>
+  <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+  <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+  <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
+</XDSBreadcrumbs>
+
+// Auto-detect current (last item becomes current automatically)
+<XDSBreadcrumbs>
+  <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+  <XDSBreadcrumbItem>Settings</XDSBreadcrumbItem>
+</XDSBreadcrumbs>
+
+// Custom separator
+<XDSBreadcrumbs separator="›">
+  <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+  <XDSBreadcrumbItem isCurrent>Page</XDSBreadcrumbItem>
+</XDSBreadcrumbs>
+
+// With icons
+<XDSBreadcrumbs>
+  <XDSBreadcrumbItem href="/" startIcon={<HomeIcon />}>Home</XDSBreadcrumbItem>
+  <XDSBreadcrumbItem isCurrent>Settings</XDSBreadcrumbItem>
+</XDSBreadcrumbs>
+```
+
+## Accessibility
+
+- Outer `<nav>` landmark with `aria-label`
+- Items rendered in an `<ol>` ordered list
+- Current item has `aria-current="page"` and renders as `<span>` (not a link)
+- Separators are `aria-hidden="true"` with `role="presentation"`
+- Auto-detects last child as current if no `isCurrent` is explicitly set
+
+## Files
+
+| File                      | Purpose                  |
+| ------------------------- | ------------------------ |
+| `XDSBreadcrumbs.tsx`      | Component implementation |
+| `XDSBreadcrumbs.test.tsx` | Unit tests               |
+| `index.ts`                | Barrel exports           |

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -1,0 +1,178 @@
+/**
+ * @file XDSBreadcrumbItem.tsx
+ * @input Uses React useContext, stylex, theme tokens, BreadcrumbContext
+ * @output Exports XDSBreadcrumbItem component and XDSBreadcrumbItemProps
+ * @position Individual breadcrumb item; used inside XDSBreadcrumbs
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Breadcrumbs/README.md
+ * - /packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
+ * - /packages/core/src/Breadcrumbs/index.ts
+ * - /apps/storybook/stories/Breadcrumbs.stories.tsx
+ */
+
+import {useContext, type ReactNode, type MouseEvent} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+import {BreadcrumbCtx} from './XDSBreadcrumbs';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+export interface XDSBreadcrumbItemProps {
+  /**
+   * Label content of the breadcrumb item.
+   */
+  children: ReactNode;
+  /**
+   * URL for the breadcrumb link. Omit for the current page.
+   */
+  href?: string;
+  /**
+   * Click handler. Works with or without href.
+   */
+  onClick?: (e: MouseEvent<HTMLElement>) => void;
+  /**
+   * Marks this item as the current page. Renders as a span with aria-current="page".
+   * If not set on any item, the last item is auto-detected as current.
+   * @default false
+   */
+  isCurrent?: boolean;
+  /**
+   * Optional icon rendered before the label.
+   */
+  startIcon?: ReactNode;
+  /**
+   * Test ID for the list item.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const itemStyles = stylex.create({
+  root: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    lineHeight: lineHeightVars['--leading-snug'],
+  },
+  defaultSize: {
+    fontSize: textSizeVars['--text-sm'],
+  },
+  supportingSize: {
+    fontSize: textSizeVars['--text-xsm'],
+  },
+  link: {
+    textDecoration: {
+      default: 'none',
+      ':hover': 'underline',
+    },
+    cursor: 'pointer',
+  },
+  defaultLink: {
+    color: colorVars['--color-text-link'],
+  },
+  supportingLink: {
+    color: colorVars['--color-text-secondary'],
+  },
+  current: {
+    fontWeight: 'inherit',
+  },
+  defaultCurrent: {
+    color: colorVars['--color-text-primary'],
+  },
+  supportingCurrent: {
+    color: colorVars['--color-text-secondary'],
+  },
+  icon: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    flexShrink: 0,
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * An individual breadcrumb item. Renders as a link (`<a>`) or a span
+ * depending on whether it represents the current page.
+ *
+ * @example
+ * ```tsx
+ * <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+ * <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
+ * ```
+ */
+export function XDSBreadcrumbItem({
+  children,
+  href,
+  onClick,
+  isCurrent: isCurrentProp,
+  startIcon,
+  'data-testid': testId,
+}: XDSBreadcrumbItemProps) {
+  const ctx = useContext(BreadcrumbCtx);
+  const isCurrent = isCurrentProp ?? ctx.isAutoLast;
+  const isSupporting = ctx.variant === 'supporting';
+
+  const content = (
+    <>
+      {startIcon && <span {...stylex.props(itemStyles.icon)}>{startIcon}</span>}
+      {children}
+    </>
+  );
+
+  if (isCurrent) {
+    return (
+      <li
+        {...stylex.props(
+          itemStyles.root,
+          isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
+        )}
+        data-testid={testId}>
+        <span
+          {...stylex.props(
+            itemStyles.current,
+            isSupporting
+              ? itemStyles.supportingCurrent
+              : itemStyles.defaultCurrent,
+          )}
+          aria-current="page">
+          {content}
+        </span>
+      </li>
+    );
+  }
+
+  return (
+    <li
+      {...stylex.props(
+        itemStyles.root,
+        isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
+      )}
+      data-testid={testId}>
+      <a
+        href={href}
+        onClick={onClick}
+        {...stylex.props(
+          itemStyles.link,
+          isSupporting ? itemStyles.supportingLink : itemStyles.defaultLink,
+        )}>
+        {content}
+      </a>
+    </li>
+  );
+}
+
+XDSBreadcrumbItem.displayName = 'XDSBreadcrumbItem';

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -71,7 +71,15 @@ const itemStyles = stylex.create({
   supportingSize: {
     fontSize: textSizeVars['--text-xsm'],
   },
+  contentWrapper: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+  },
   link: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
     textDecoration: {
       default: 'none',
       ':hover': 'underline',
@@ -143,6 +151,7 @@ export function XDSBreadcrumbItem({
         data-testid={testId}>
         <span
           {...stylex.props(
+            itemStyles.contentWrapper,
             itemStyles.current,
             isSupporting
               ? itemStyles.supportingCurrent

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
@@ -1,0 +1,201 @@
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSBreadcrumbs, XDSBreadcrumbItem} from './XDSBreadcrumbs';
+
+describe('XDSBreadcrumbs', () => {
+  it('renders a nav landmark with aria-label', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const nav = screen.getByRole('navigation');
+    expect(nav).toHaveAttribute('aria-label', 'Breadcrumb');
+  });
+
+  it('supports custom aria-label', () => {
+    render(
+      <XDSBreadcrumbs label="Custom nav">
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    expect(screen.getByRole('navigation')).toHaveAttribute(
+      'aria-label',
+      'Custom nav',
+    );
+  });
+
+  it('renders items in an ordered list', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const list = screen.getByRole('list');
+    expect(list.tagName).toBe('OL');
+  });
+
+  it('renders separators between items', () => {
+    const {container} = render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Detail</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const separators = container.querySelectorAll('li[aria-hidden="true"]');
+    expect(separators).toHaveLength(2);
+    expect(separators[0].textContent).toBe('/');
+  });
+
+  it('supports custom separator', () => {
+    const {container} = render(
+      <XDSBreadcrumbs separator={<span>{'\u203a'}</span>}>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Page</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const separators = container.querySelectorAll('li[aria-hidden="true"]');
+    expect(separators[0].textContent).toBe('\u203a');
+  });
+
+  it('separators have role="presentation"', () => {
+    const {container} = render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Page</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const separators = container.querySelectorAll('li[aria-hidden="true"]');
+    expect(separators[0]).toHaveAttribute('role', 'presentation');
+  });
+
+  it('forwards ref to the nav element', () => {
+    const ref = {current: null as HTMLElement | null};
+    render(
+      <XDSBreadcrumbs ref={ref}>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLElement);
+    expect(ref.current?.tagName).toBe('NAV');
+  });
+
+  it('supports data-testid', () => {
+    render(
+      <XDSBreadcrumbs data-testid="my-breadcrumbs">
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    expect(screen.getByTestId('my-breadcrumbs')).toBeInTheDocument();
+  });
+});
+
+describe('XDSBreadcrumbItem', () => {
+  it('renders a link when href is provided', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/home">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Current</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const link = screen.getByRole('link', {name: 'Home'});
+    expect(link).toHaveAttribute('href', '/home');
+  });
+
+  it('renders current item as span with aria-current="page"', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Current Page</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const current = screen.getByText('Current Page');
+    expect(current.tagName).toBe('SPAN');
+    expect(current).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('auto-detects last child as current when no isCurrent is set', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem>Last Item</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const lastItem = screen.getByText('Last Item');
+    expect(lastItem).toHaveAttribute('aria-current', 'page');
+    expect(lastItem.tagName).toBe('SPAN');
+  });
+
+  it('does not auto-detect when isCurrent is explicitly set', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem isCurrent>First</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem href="/second">Second</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem href="/third">Third</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    expect(screen.getByText('First')).toHaveAttribute('aria-current', 'page');
+    const third = screen.getByText('Third');
+    expect(third).not.toHaveAttribute('aria-current');
+    expect(third.tagName).toBe('A');
+  });
+
+  it('handles onClick', async () => {
+    const handleClick = vi.fn();
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/" onClick={handleClick}>
+          Home
+        </XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Current</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const link = screen.getByRole('link', {name: 'Home'});
+    await userEvent.click(link);
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders startIcon', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem
+          href="/"
+          startIcon={<span data-testid="home-icon">icon</span>}>
+          Home
+        </XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Current</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    expect(screen.getByTestId('home-icon')).toBeInTheDocument();
+  });
+
+  it('supports data-testid on items', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/" data-testid="crumb-home">
+          Home
+        </XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent data-testid="crumb-current">
+          Current
+        </XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    expect(screen.getByTestId('crumb-home')).toBeInTheDocument();
+    expect(screen.getByTestId('crumb-current')).toBeInTheDocument();
+  });
+
+  it('renders single item as current by auto-detection', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem>Only Item</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const item = screen.getByText('Only Item');
+    expect(item).toHaveAttribute('aria-current', 'page');
+    expect(item.tagName).toBe('SPAN');
+  });
+});

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
@@ -1,7 +1,8 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {XDSBreadcrumbs, XDSBreadcrumbItem} from './XDSBreadcrumbs';
+import {XDSBreadcrumbs} from './XDSBreadcrumbs';
+import {XDSBreadcrumbItem} from './XDSBreadcrumbItem';
 
 describe('XDSBreadcrumbs', () => {
   it('renders a nav landmark with aria-label', () => {
@@ -52,13 +53,13 @@ describe('XDSBreadcrumbs', () => {
 
   it('supports custom separator', () => {
     const {container} = render(
-      <XDSBreadcrumbs separator={<span>{'\u203a'}</span>}>
+      <XDSBreadcrumbs separator={<span>›</span>}>
         <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
         <XDSBreadcrumbItem isCurrent>Page</XDSBreadcrumbItem>
       </XDSBreadcrumbs>,
     );
     const separators = container.querySelectorAll('li[aria-hidden="true"]');
-    expect(separators[0].textContent).toBe('\u203a');
+    expect(separators[0].textContent).toBe('›');
   });
 
   it('separators have role="presentation"', () => {
@@ -90,6 +91,41 @@ describe('XDSBreadcrumbs', () => {
       </XDSBreadcrumbs>,
     );
     expect(screen.getByTestId('my-breadcrumbs')).toBeInTheDocument();
+  });
+
+  it('defaults to variant="default"', () => {
+    render(
+      <XDSBreadcrumbs>
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Current</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+
+  it('accepts variant="supporting"', () => {
+    render(
+      <XDSBreadcrumbs variant="supporting">
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Current</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByText('Home')).toBeInTheDocument();
+    expect(screen.getByText('Current')).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('supporting variant renders links and current items', () => {
+    render(
+      <XDSBreadcrumbs variant="supporting">
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem isCurrent>Detail</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const link = screen.getByRole('link', {name: 'Home'});
+    expect(link).toHaveAttribute('href', '/');
+    expect(screen.getByText('Detail')).toHaveAttribute('aria-current', 'page');
   });
 });
 
@@ -197,5 +233,17 @@ describe('XDSBreadcrumbItem', () => {
     const item = screen.getByText('Only Item');
     expect(item).toHaveAttribute('aria-current', 'page');
     expect(item.tagName).toBe('SPAN');
+  });
+
+  it('auto-detects last child as current with supporting variant', () => {
+    render(
+      <XDSBreadcrumbs variant="supporting">
+        <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+        <XDSBreadcrumbItem>Last</XDSBreadcrumbItem>
+      </XDSBreadcrumbs>,
+    );
+    const last = screen.getByText('Last');
+    expect(last).toHaveAttribute('aria-current', 'page');
+    expect(last.tagName).toBe('SPAN');
   });
 });

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -1,0 +1,287 @@
+/**
+ * @file XDSBreadcrumbs.tsx
+ * @input Uses React forwardRef, Children, cloneElement, stylex, theme tokens
+ * @output Exports XDSBreadcrumbs, XDSBreadcrumbItem components and their prop types
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Breadcrumbs/README.md (props table, features, implementation notes)
+ * - /packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/Breadcrumbs/index.ts (exports if types change)
+ * - /apps/storybook/stories/Breadcrumbs.stories.tsx (storybook stories)
+ */
+
+import {
+  forwardRef,
+  Children,
+  isValidElement,
+  cloneElement,
+  type ReactNode,
+  type MouseEvent,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+export interface XDSBreadcrumbsProps {
+  /**
+   * XDSBreadcrumbItem elements to render as breadcrumb trail.
+   */
+  children: ReactNode;
+  /**
+   * Separator rendered between items. Decorative only (aria-hidden).
+   * @default '/'
+   */
+  separator?: ReactNode;
+  /**
+   * StyleX styles to apply to the nav container.
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * Accessible label for the nav landmark.
+   * @default 'Breadcrumb'
+   */
+  label?: string;
+  /**
+   * Test ID for the nav element.
+   */
+  'data-testid'?: string;
+}
+
+export interface XDSBreadcrumbItemProps {
+  /**
+   * Label content of the breadcrumb item.
+   */
+  children: ReactNode;
+  /**
+   * URL for the breadcrumb link. Omit for the current page.
+   */
+  href?: string;
+  /**
+   * Click handler. Works with or without href.
+   */
+  onClick?: (e: MouseEvent<HTMLElement>) => void;
+  /**
+   * Marks this item as the current page. Renders as a span with aria-current="page".
+   * If not set on any item, the last item is auto-detected as current.
+   * @default false
+   */
+  isCurrent?: boolean;
+  /**
+   * Optional icon rendered before the label.
+   */
+  startIcon?: ReactNode;
+  /**
+   * Test ID for the list item.
+   */
+  'data-testid'?: string;
+  /**
+   * @internal Used by XDSBreadcrumbs to auto-detect the last item.
+   */
+  _isLast?: boolean;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const navStyles = stylex.create({
+  root: {
+    display: 'block',
+  },
+});
+
+const listStyles = stylex.create({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    gap: spacingVars['--spacing-1'],
+  },
+});
+
+const separatorStyles = stylex.create({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    color: colorVars['--color-text-secondary'],
+    fontSize: textSizeVars['--text-sm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    userSelect: 'none',
+  },
+});
+
+const itemStyles = stylex.create({
+  root: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    fontSize: textSizeVars['--text-sm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+  },
+  link: {
+    color: colorVars['--color-text-link'],
+    textDecoration: {
+      default: 'none',
+      ':hover': 'underline',
+    },
+    cursor: 'pointer',
+  },
+  current: {
+    color: colorVars['--color-text-primary'],
+    fontWeight: 'inherit',
+  },
+  icon: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    flexShrink: 0,
+  },
+});
+
+// =============================================================================
+// XDSBreadcrumbItem
+// =============================================================================
+
+/**
+ * An individual breadcrumb item. Renders as a link (`<a>`) or a span
+ * depending on whether it represents the current page.
+ *
+ * @example
+ * ```tsx
+ * <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+ * <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
+ * ```
+ */
+export function XDSBreadcrumbItem({
+  children,
+  href,
+  onClick,
+  isCurrent: isCurrentProp,
+  startIcon,
+  'data-testid': testId,
+  _isLast,
+}: XDSBreadcrumbItemProps) {
+  // If isCurrent is explicitly set, use it. Otherwise, auto-detect from _isLast.
+  const isCurrent = isCurrentProp ?? _isLast === true;
+
+  const content = (
+    <>
+      {startIcon && <span {...stylex.props(itemStyles.icon)}>{startIcon}</span>}
+      {children}
+    </>
+  );
+
+  if (isCurrent) {
+    return (
+      <li {...stylex.props(itemStyles.root)} data-testid={testId}>
+        <span {...stylex.props(itemStyles.current)} aria-current="page">
+          {content}
+        </span>
+      </li>
+    );
+  }
+
+  return (
+    <li {...stylex.props(itemStyles.root)} data-testid={testId}>
+      <a href={href} onClick={onClick} {...stylex.props(itemStyles.link)}>
+        {content}
+      </a>
+    </li>
+  );
+}
+
+XDSBreadcrumbItem.displayName = 'XDSBreadcrumbItem';
+
+// =============================================================================
+// XDSBreadcrumbs
+// =============================================================================
+
+/**
+ * A navigation breadcrumb trail. Wraps XDSBreadcrumbItem children in
+ * semantic `<nav>` + `<ol>` markup with separators between items.
+ *
+ * Auto-detects the last child as the current page if no item has
+ * `isCurrent` explicitly set.
+ *
+ * @example
+ * ```tsx
+ * <XDSBreadcrumbs>
+ *   <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+ *   <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
+ *   <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
+ * </XDSBreadcrumbs>
+ * ```
+ */
+export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
+  function XDSBreadcrumbs(
+    {
+      children,
+      separator = '/',
+      xstyle,
+      label = 'Breadcrumb',
+      'data-testid': testId,
+    },
+    ref,
+  ) {
+    const items = Children.toArray(children);
+
+    // Check if any child has isCurrent explicitly set
+    const hasExplicitCurrent = items.some(
+      child =>
+        isValidElement<XDSBreadcrumbItemProps>(child) &&
+        child.props.isCurrent === true,
+    );
+
+    const rendered: ReactNode[] = [];
+
+    items.forEach((child, index) => {
+      // Clone the last child with _isLast if no explicit isCurrent exists
+      if (
+        !hasExplicitCurrent &&
+        index === items.length - 1 &&
+        isValidElement<XDSBreadcrumbItemProps>(child)
+      ) {
+        rendered.push(cloneElement(child, {_isLast: true, key: child.key}));
+      } else {
+        rendered.push(child);
+      }
+
+      // Add separator between items (not after the last one)
+      if (index < items.length - 1) {
+        rendered.push(
+          <li
+            key={`sep-${index}`}
+            role="presentation"
+            aria-hidden="true"
+            {...stylex.props(separatorStyles.root)}>
+            {separator}
+          </li>,
+        );
+      }
+    });
+
+    return (
+      <nav
+        ref={ref}
+        aria-label={label}
+        data-testid={testId}
+        {...stylex.props(navStyles.root, xstyle)}>
+        <ol {...stylex.props(listStyles.root)}>{rendered}</ol>
+      </nav>
+    );
+  },
+);
+
+XDSBreadcrumbs.displayName = 'XDSBreadcrumbs';

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -1,14 +1,14 @@
 /**
  * @file XDSBreadcrumbs.tsx
- * @input Uses React forwardRef, Children, createContext, useContext, stylex, theme tokens
- * @output Exports XDSBreadcrumbs, XDSBreadcrumbItem components and their prop types
- * @position Core implementation; consumed by index.ts
+ * @input Uses React forwardRef, Children, createContext, stylex, theme tokens
+ * @output Exports XDSBreadcrumbs component, XDSBreadcrumbsProps, BreadcrumbCtx
+ * @position Core container component; consumed by index.ts
  *
  * SYNC: When modified, update these files to stay in sync:
- * - /packages/core/src/Breadcrumbs/README.md (props table, features, implementation notes)
- * - /packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx (tests for new/changed behavior)
- * - /packages/core/src/Breadcrumbs/index.ts (exports if types change)
- * - /apps/storybook/stories/Breadcrumbs.stories.tsx (storybook stories)
+ * - /packages/core/src/Breadcrumbs/README.md
+ * - /packages/core/src/Breadcrumbs/XDSBreadcrumbs.test.tsx
+ * - /packages/core/src/Breadcrumbs/index.ts
+ * - /apps/storybook/stories/Breadcrumbs.stories.tsx
  */
 
 import {
@@ -16,9 +16,7 @@ import {
   Children,
   isValidElement,
   createContext,
-  useContext,
   type ReactNode,
-  type MouseEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -28,18 +26,32 @@ import {
   textSizeVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
+import type {XDSBreadcrumbItemProps} from './XDSBreadcrumbItem';
 
 // =============================================================================
-// Context for auto-detecting last item
+// Variant type
 // =============================================================================
 
-interface BreadcrumbItemContext {
-  /** Whether this item is the last in the list and no explicit isCurrent exists. */
+/**
+ * Visual variant for the breadcrumb trail.
+ * - `'default'`: Standard text styling
+ * - `'supporting'`: Smaller, secondary text for supporting context
+ */
+export type XDSBreadcrumbsVariant = 'default' | 'supporting';
+
+// =============================================================================
+// Context shared with XDSBreadcrumbItem
+// =============================================================================
+
+/** @internal Context for passing state from XDSBreadcrumbs to XDSBreadcrumbItem. */
+export interface BreadcrumbContextValue {
   isAutoLast: boolean;
+  variant: XDSBreadcrumbsVariant;
 }
 
-const BreadcrumbItemCtx = createContext<BreadcrumbItemContext>({
+export const BreadcrumbCtx = createContext<BreadcrumbContextValue>({
   isAutoLast: false,
+  variant: 'default',
 });
 
 // =============================================================================
@@ -57,6 +69,13 @@ export interface XDSBreadcrumbsProps {
    */
   separator?: ReactNode;
   /**
+   * Visual variant for the breadcrumb trail.
+   * - `'default'`: Standard text styling
+   * - `'supporting'`: Smaller, secondary text for supporting context
+   * @default 'default'
+   */
+  variant?: XDSBreadcrumbsVariant;
+  /**
    * StyleX styles to apply to the nav container.
    */
   xstyle?: StyleXStyles;
@@ -67,35 +86,6 @@ export interface XDSBreadcrumbsProps {
   label?: string;
   /**
    * Test ID for the nav element.
-   */
-  'data-testid'?: string;
-}
-
-export interface XDSBreadcrumbItemProps {
-  /**
-   * Label content of the breadcrumb item.
-   */
-  children: ReactNode;
-  /**
-   * URL for the breadcrumb link. Omit for the current page.
-   */
-  href?: string;
-  /**
-   * Click handler. Works with or without href.
-   */
-  onClick?: (e: MouseEvent<HTMLElement>) => void;
-  /**
-   * Marks this item as the current page. Renders as a span with aria-current="page".
-   * If not set on any item, the last item is auto-detected as current.
-   * @default false
-   */
-  isCurrent?: boolean;
-  /**
-   * Optional icon rendered before the label.
-   */
-  startIcon?: ReactNode;
-  /**
-   * Test ID for the list item.
    */
   'data-testid'?: string;
 }
@@ -127,102 +117,19 @@ const separatorStyles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     color: colorVars['--color-text-secondary'],
-    fontSize: textSizeVars['--text-sm'],
     lineHeight: lineHeightVars['--leading-snug'],
     userSelect: 'none',
   },
-});
-
-const itemStyles = stylex.create({
-  root: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
+  defaultSize: {
     fontSize: textSizeVars['--text-sm'],
-    lineHeight: lineHeightVars['--leading-snug'],
   },
-  link: {
-    color: colorVars['--color-text-link'],
-    textDecoration: {
-      default: 'none',
-      ':hover': 'underline',
-    },
-    cursor: 'pointer',
-  },
-  current: {
-    color: colorVars['--color-text-primary'],
-    fontWeight: 'inherit',
-  },
-  icon: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    flexShrink: 0,
+  supportingSize: {
+    fontSize: textSizeVars['--text-xsm'],
   },
 });
 
 // =============================================================================
-// XDSBreadcrumbItem
-// =============================================================================
-
-/**
- * An individual breadcrumb item. Renders as a link (`<a>`) or a span
- * depending on whether it represents the current page.
- *
- * @example
- * ```tsx
- * <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
- * <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
- * ```
- */
-export function XDSBreadcrumbItem({
-  children,
-  href,
-  onClick,
-  isCurrent: isCurrentProp,
-  startIcon,
-  'data-testid': testId,
-}: XDSBreadcrumbItemProps) {
-  const ctx = useContext(BreadcrumbItemCtx);
-  // If isCurrent is explicitly set, use it. Otherwise, auto-detect from context.
-  const isCurrent = isCurrentProp ?? ctx.isAutoLast;
-
-  const content = (
-    <>
-      {startIcon && <span {...stylex.props(itemStyles.icon)}>{startIcon}</span>}
-      {children}
-    </>
-  );
-
-  if (isCurrent) {
-    return (
-      <li {...stylex.props(itemStyles.root)} data-testid={testId}>
-        <span {...stylex.props(itemStyles.current)} aria-current="page">
-          {content}
-        </span>
-      </li>
-    );
-  }
-
-  return (
-    <li {...stylex.props(itemStyles.root)} data-testid={testId}>
-      <a href={href} onClick={onClick} {...stylex.props(itemStyles.link)}>
-        {content}
-      </a>
-    </li>
-  );
-}
-
-XDSBreadcrumbItem.displayName = 'XDSBreadcrumbItem';
-
-// =============================================================================
-// Context values (stable references)
-// =============================================================================
-
-const AUTO_LAST_CTX: BreadcrumbItemContext = {isAutoLast: true};
-const DEFAULT_CTX: BreadcrumbItemContext = {isAutoLast: false};
-
-// =============================================================================
-// XDSBreadcrumbs
+// Component
 // =============================================================================
 
 /**
@@ -246,6 +153,7 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
     {
       children,
       separator = '/',
+      variant = 'default',
       xstyle,
       label = 'Breadcrumb',
       'data-testid': testId,
@@ -253,6 +161,7 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
     ref,
   ) {
     const items = Children.toArray(children);
+    const isSupporting = variant === 'supporting';
 
     // Check if any child has isCurrent explicitly set
     const hasExplicitCurrent = items.some(
@@ -266,22 +175,16 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
     items.forEach((child, index) => {
       const isLast = index === items.length - 1;
 
-      // Wrap the last item in context to auto-detect as current
-      if (!hasExplicitCurrent && isLast) {
-        rendered.push(
-          <BreadcrumbItemCtx.Provider
-            key={`item-${index}`}
-            value={AUTO_LAST_CTX}>
-            {child}
-          </BreadcrumbItemCtx.Provider>,
-        );
-      } else {
-        rendered.push(
-          <BreadcrumbItemCtx.Provider key={`item-${index}`} value={DEFAULT_CTX}>
-            {child}
-          </BreadcrumbItemCtx.Provider>,
-        );
-      }
+      const ctxValue: BreadcrumbContextValue = {
+        isAutoLast: !hasExplicitCurrent && isLast,
+        variant,
+      };
+
+      rendered.push(
+        <BreadcrumbCtx.Provider key={`item-${index}`} value={ctxValue}>
+          {child}
+        </BreadcrumbCtx.Provider>,
+      );
 
       // Add separator between items (not after the last one)
       if (!isLast) {
@@ -290,7 +193,12 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
             key={`sep-${index}`}
             role="presentation"
             aria-hidden="true"
-            {...stylex.props(separatorStyles.root)}>
+            {...stylex.props(
+              separatorStyles.root,
+              isSupporting
+                ? separatorStyles.supportingSize
+                : separatorStyles.defaultSize,
+            )}>
             {separator}
           </li>,
         );

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSBreadcrumbs.tsx
- * @input Uses React forwardRef, Children, cloneElement, stylex, theme tokens
+ * @input Uses React forwardRef, Children, createContext, useContext, stylex, theme tokens
  * @output Exports XDSBreadcrumbs, XDSBreadcrumbItem components and their prop types
  * @position Core implementation; consumed by index.ts
  *
@@ -15,7 +15,8 @@ import {
   forwardRef,
   Children,
   isValidElement,
-  cloneElement,
+  createContext,
+  useContext,
   type ReactNode,
   type MouseEvent,
 } from 'react';
@@ -27,6 +28,19 @@ import {
   textSizeVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
+
+// =============================================================================
+// Context for auto-detecting last item
+// =============================================================================
+
+interface BreadcrumbItemContext {
+  /** Whether this item is the last in the list and no explicit isCurrent exists. */
+  isAutoLast: boolean;
+}
+
+const BreadcrumbItemCtx = createContext<BreadcrumbItemContext>({
+  isAutoLast: false,
+});
 
 // =============================================================================
 // Props
@@ -84,10 +98,6 @@ export interface XDSBreadcrumbItemProps {
    * Test ID for the list item.
    */
   'data-testid'?: string;
-  /**
-   * @internal Used by XDSBreadcrumbs to auto-detect the last item.
-   */
-  _isLast?: boolean;
 }
 
 // =============================================================================
@@ -171,10 +181,10 @@ export function XDSBreadcrumbItem({
   isCurrent: isCurrentProp,
   startIcon,
   'data-testid': testId,
-  _isLast,
 }: XDSBreadcrumbItemProps) {
-  // If isCurrent is explicitly set, use it. Otherwise, auto-detect from _isLast.
-  const isCurrent = isCurrentProp ?? _isLast === true;
+  const ctx = useContext(BreadcrumbItemCtx);
+  // If isCurrent is explicitly set, use it. Otherwise, auto-detect from context.
+  const isCurrent = isCurrentProp ?? ctx.isAutoLast;
 
   const content = (
     <>
@@ -203,6 +213,13 @@ export function XDSBreadcrumbItem({
 }
 
 XDSBreadcrumbItem.displayName = 'XDSBreadcrumbItem';
+
+// =============================================================================
+// Context values (stable references)
+// =============================================================================
+
+const AUTO_LAST_CTX: BreadcrumbItemContext = {isAutoLast: true};
+const DEFAULT_CTX: BreadcrumbItemContext = {isAutoLast: false};
 
 // =============================================================================
 // XDSBreadcrumbs
@@ -247,19 +264,27 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
     const rendered: ReactNode[] = [];
 
     items.forEach((child, index) => {
-      // Clone the last child with _isLast if no explicit isCurrent exists
-      if (
-        !hasExplicitCurrent &&
-        index === items.length - 1 &&
-        isValidElement<XDSBreadcrumbItemProps>(child)
-      ) {
-        rendered.push(cloneElement(child, {_isLast: true, key: child.key}));
+      const isLast = index === items.length - 1;
+
+      // Wrap the last item in context to auto-detect as current
+      if (!hasExplicitCurrent && isLast) {
+        rendered.push(
+          <BreadcrumbItemCtx.Provider
+            key={`item-${index}`}
+            value={AUTO_LAST_CTX}>
+            {child}
+          </BreadcrumbItemCtx.Provider>,
+        );
       } else {
-        rendered.push(child);
+        rendered.push(
+          <BreadcrumbItemCtx.Provider key={`item-${index}`} value={DEFAULT_CTX}>
+            {child}
+          </BreadcrumbItemCtx.Provider>,
+        );
       }
 
       // Add separator between items (not after the last one)
-      if (index < items.length - 1) {
+      if (!isLast) {
         rendered.push(
           <li
             key={`sep-${index}`}

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -2,8 +2,10 @@
  * @file Breadcrumbs component barrel export
  */
 
-export {XDSBreadcrumbs, XDSBreadcrumbItem} from './XDSBreadcrumbs';
+export {XDSBreadcrumbs} from './XDSBreadcrumbs';
 export type {
   XDSBreadcrumbsProps,
-  XDSBreadcrumbItemProps,
+  XDSBreadcrumbsVariant,
 } from './XDSBreadcrumbs';
+export {XDSBreadcrumbItem} from './XDSBreadcrumbItem';
+export type {XDSBreadcrumbItemProps} from './XDSBreadcrumbItem';

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @file Breadcrumbs component barrel export
+ */
+
+export {XDSBreadcrumbs, XDSBreadcrumbItem} from './XDSBreadcrumbs';
+export type {
+  XDSBreadcrumbsProps,
+  XDSBreadcrumbItemProps,
+} from './XDSBreadcrumbs';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@
 export * from './AspectRatio';
 export * from './Avatar';
 export * from './Badge';
+export * from './Breadcrumbs';
 export * from './Button';
 export * from './Calendar';
 export * from './Center';


### PR DESCRIPTION
## Summary

Implements XDSBreadcrumbs — a navigation breadcrumb trail with semantic HTML.

## Features
- `XDSBreadcrumbs` container with `<nav>` + `<ol>` semantics
- `XDSBreadcrumbItem` with `href`, `onClick`, `isCurrent` support
- Custom `separator` via prop (default `/`)
- `startIcon` support on items
- Auto-detect current (last) item
- `aria-current="page"` on current item
- `forwardRef`, `xstyle` override, `data-testid`

## Usage
```tsx
<XDSBreadcrumbs>
  <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
  <XDSBreadcrumbItem href="/projects">Projects</XDSBreadcrumbItem>
  <XDSBreadcrumbItem isCurrent>My Project</XDSBreadcrumbItem>
</XDSBreadcrumbs>
```

Closes #177

---
*Crafted with care by Navi*