### PR TITLE
fix(packaging): auto-discover component exports in source tarball

### DIFF
--- a/scripts/package-source.js
+++ b/scripts/package-source.js
@@ -57,6 +57,9 @@ function copyDir(src, dest) {
 /**
  * Transform dist exports to source exports
  * e.g., "./dist/Button/index.mjs" -> "./Button/index.ts"
+ *
+ * Also auto-discovers component directories that have an index.ts
+ * but are missing from the core package.json exports.
  */
 function deriveSourceExports() {
   const sourceExports = {};
@@ -86,6 +89,19 @@ function deriveSourceExports() {
         .replace(/\.js$/, '.ts');
 
       sourceExports[key] = sourcePath;
+    }
+  }
+
+  // Auto-discover component directories with index.ts that aren't in exports
+  const srcEntries = fs.readdirSync(SRC_DIR, { withFileTypes: true });
+  for (const entry of srcEntries) {
+    if (!entry.isDirectory()) continue;
+    const exportKey = './' + entry.name;
+    if (sourceExports[exportKey]) continue;
+
+    const indexPath = path.join(SRC_DIR, entry.name, 'index.ts');
+    if (fs.existsSync(indexPath)) {
+      sourceExports[exportKey] = './' + entry.name + '/index.ts';
     }
   }
 


### PR DESCRIPTION
## What

The `package-source.js` script only included exports that were already in `packages/core/package.json`. 20 component directories (TopNav, TabList, Slider, Switch, NumberInput, RadioList, Table, StatusDot, etc.) were missing from the tarball's exports map.

## Why

Consumers using subpath imports like `@xds/core/TopNav` got `Module not found` errors even though the source files were in the tarball. This was hit during the theme builder v2 exercise on `cixzhang/xds_sandbox`.

## Fix

Auto-discovers all component directories with an `index.ts` in `packages/core/src/` and adds them to the exports map if not already present. This is a fallback — the core `package.json` should still be the source of truth, but consumers won't hit silent failures when new components are added.

Before: 22 exports. After: 43 exports (all component directories covered).

---
*Crafted with care by Navi*