### PR TITLE
docs(layout): add padding/scroll hints to slot components

### DIFF
--- a/packages/core/src/Layout/XDSLayout/README.md
+++ b/packages/core/src/Layout/XDSLayout/README.md
@@ -244,6 +244,32 @@ Use `isFullBleed` on XDSLayoutContent to remove internal padding, allowing conte
 
 When `hasDivider` is false, spacing collapse is applied automatically for seamless visual flow.
 
+## Padding and Scroll
+
+Layout slot components (`XDSLayoutContent`, `XDSLayoutPanel`, `XDSLayoutHeader`, `XDSLayoutFooter`) provide their own padding and scroll containment. Don't add padding or overflow styles to their children — it will double up.
+
+```tsx
+// ✅ Correct — let the layout slot handle padding
+<XDSLayoutPanel hasDivider width={320}>
+  <Navigation />
+</XDSLayoutPanel>
+
+// ❌ Wrong — padding doubles up with the panel's built-in padding
+<XDSLayoutPanel hasDivider width={320}>
+  <div style={{ padding: 16, overflow: 'auto' }}>
+    <Navigation />
+  </div>
+</XDSLayoutPanel>
+```
+
+If you need to remove the built-in padding (e.g., for edge-to-edge tables or content that manages its own padding), use `isFullBleed`:
+
+```tsx
+<XDSLayoutContent isFullBleed>
+  <Table />
+</XDSLayoutContent>
+```
+
 ## RTL Support
 
 Uses CSS logical properties (`padding-inline`, `border-inline-start`, etc.) for automatic RTL support. The `start`/`end` naming ensures panels appear on the correct side in both LTR and RTL contexts.

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutContent.tsx
@@ -97,6 +97,9 @@ export interface XDSLayoutContentProps extends Omit<
  * Scrollable main content area for XDSLayout. Wraps the primary body content
  * with automatic scroll containment and context-aware padding.
  *
+ * Already provides its own padding and scroll — don't add padding or
+ * overflow to children. Use `isFullBleed` if you need edge-to-edge content.
+ *
  * @example
  * ```tsx
  * <XDSLayoutContainer variant="card">

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutFooter.tsx
@@ -94,6 +94,9 @@ export interface XDSLayoutFooterProps extends Omit<
  * Bottom bar / footer for XDSLayout. Use for action bars, pagination, or status bars.
  * Renders in the footer slot with optional divider and padding control.
  *
+ * Already provides its own padding — don't add padding to children.
+ * Use `isFullBleed` if your content manages its own padding.
+ *
  * @example
  * ```tsx
  * <XDSLayoutContainer variant="card">

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutHeader.tsx
@@ -94,6 +94,9 @@ export interface XDSLayoutHeaderProps extends Omit<
  * Top bar / header for XDSLayout. Use for page titles, app bars, or toolbars.
  * Renders in the header slot with optional divider and padding control.
  *
+ * Already provides its own padding — don't add padding to children.
+ * Use `isFullBleed` if your content manages its own padding (e.g. XDSTopNav).
+ *
  * @example
  * ```tsx
  * <XDSLayoutContainer variant="card">

--- a/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayout/XDSLayoutPanel.tsx
@@ -140,6 +140,9 @@ export interface XDSLayoutPanelProps extends Omit<
  * Renders with optional divider and context-aware padding.
  * Divider position is auto-detected based on which slot the panel is in.
  *
+ * Already provides its own padding and scroll — don't add padding or
+ * overflow to children. Use `isFullBleed` if you need edge-to-edge content.
+ *
  * @example
  * ```tsx
  * <XDSLayoutContainer variant="card">


### PR DESCRIPTION
## What

Adds explicit hints to layout slot component JSDoc that they provide their own padding and scroll — don't add your own.

## Why

From theme builder v2 exercise — the LLM added `paddingInline`, `paddingBlock`, and `overflowY: 'auto'` to components inside `XDSLayoutPanel` and `XDSLayoutContent`, causing double padding and nested scrollbars. The existing docs describe the padding *system* but don't say "you don't need to add padding to children."

## Changes

**JSDoc on each slot component:**
- XDSLayoutContent: "Already provides its own padding and scroll — don't add padding or overflow to children"
- XDSLayoutPanel: same
- XDSLayoutHeader: "Already provides its own padding — don't add padding to children"
- XDSLayoutFooter: same

**README:** New "Padding and Scroll" section with ✅/❌ code examples.

---
*Crafted with care by Navi*