### PR TITLE
Add useXDSCollapsible hook

### DIFF
--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -15,3 +15,9 @@ export type {UseGridFocusOptions, UseGridFocusReturn} from './useGridFocus';
 
 export {useListFocus} from './useListFocus';
 export type {UseListFocusOptions, UseListFocusReturn} from './useListFocus';
+
+export {useXDSCollapsible} from './useXDSCollapsible';
+export type {
+  XDSCollapsibleConfig,
+  UseXDSCollapsibleOptions,
+} from './useXDSCollapsible';

--- a/packages/core/src/hooks/useXDSCollapsible.test.ts
+++ b/packages/core/src/hooks/useXDSCollapsible.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @file useXDSCollapsible.test.ts
+ * @input Uses vitest, @testing-library/react, useXDSCollapsible
+ * @output Unit tests for useXDSCollapsible hook
+ * @position Testing; validates useXDSCollapsible.ts implementation
+ *
+ * SYNC: When useXDSCollapsible.ts changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {useXDSCollapsible} from './useXDSCollapsible';
+import type {XDSCollapsibleConfig} from './useXDSCollapsible';
+
+describe('useXDSCollapsible', () => {
+  it('returns isOpen: false by default', () => {
+    const {result} = renderHook(() => useXDSCollapsible());
+    expect(result.current.isOpen).toBe(false);
+    expect(result.current.onOpenChange).toBeInstanceOf(Function);
+  });
+
+  it('returns isOpen: false when called with empty options', () => {
+    const {result} = renderHook(() => useXDSCollapsible({}));
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('initialIsOpen sets initial state', () => {
+    const {result} = renderHook(() => useXDSCollapsible({initialIsOpen: true}));
+    expect(result.current.isOpen).toBe(true);
+  });
+
+  it('initialIsOpen: false starts closed', () => {
+    const {result} = renderHook(() =>
+      useXDSCollapsible({initialIsOpen: false}),
+    );
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('toggles state in uncontrolled mode', () => {
+    const {result} = renderHook(() => useXDSCollapsible());
+
+    act(() => {
+      result.current.onOpenChange?.(true);
+    });
+    expect(result.current.isOpen).toBe(true);
+
+    act(() => {
+      result.current.onOpenChange?.(false);
+    });
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('onOpenChange fires when toggled in uncontrolled mode', () => {
+    const onOpenChange = vi.fn();
+    const {result} = renderHook(() => useXDSCollapsible({onOpenChange}));
+
+    act(() => {
+      result.current.onOpenChange?.(true);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    expect(onOpenChange).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.onOpenChange?.(false);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onOpenChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('controlled mode uses isOpen prop', () => {
+    const {result, rerender} = renderHook(
+      ({isOpen}: {isOpen: boolean}) => useXDSCollapsible({isOpen}),
+      {initialProps: {isOpen: false}},
+    );
+
+    expect(result.current.isOpen).toBe(false);
+
+    rerender({isOpen: true});
+    expect(result.current.isOpen).toBe(true);
+
+    rerender({isOpen: false});
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('controlled mode does not update internal state', () => {
+    const onOpenChange = vi.fn();
+    const {result} = renderHook(() =>
+      useXDSCollapsible({isOpen: false, onOpenChange}),
+    );
+
+    // Calling onOpenChange should fire the callback but not change isOpen
+    // (since it's controlled externally)
+    act(() => {
+      result.current.onOpenChange?.(true);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+    // isOpen should still be false because the controlled prop hasn't changed
+    expect(result.current.isOpen).toBe(false);
+  });
+
+  it('controlled mode fires onOpenChange callback', () => {
+    const onOpenChange = vi.fn();
+    const {result} = renderHook(() =>
+      useXDSCollapsible({isOpen: true, onOpenChange}),
+    );
+
+    act(() => {
+      result.current.onOpenChange?.(false);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('config object is constructable manually (just a plain object)', () => {
+    const config: XDSCollapsibleConfig = {
+      isOpen: true,
+      onOpenChange: vi.fn(),
+    };
+
+    expect(config.isOpen).toBe(true);
+    config.onOpenChange?.(false);
+    expect(config.onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('config object works with trigger', () => {
+    const config: XDSCollapsibleConfig = {
+      isOpen: false,
+      trigger: 'Click me',
+    };
+
+    expect(config.isOpen).toBe(false);
+    expect(config.trigger).toBe('Click me');
+  });
+
+  it('config object works with minimal fields', () => {
+    const config: XDSCollapsibleConfig = {
+      isOpen: false,
+    };
+
+    expect(config.isOpen).toBe(false);
+    expect(config.onOpenChange).toBeUndefined();
+    expect(config.trigger).toBeUndefined();
+  });
+});

--- a/packages/core/src/hooks/useXDSCollapsible.ts
+++ b/packages/core/src/hooks/useXDSCollapsible.ts
@@ -1,0 +1,125 @@
+/**
+ * @file useXDSCollapsible.ts
+ * @input Uses React useState, useCallback
+ * @output Exports useXDSCollapsible hook and XDSCollapsibleConfig type
+ * @position Core hook; provides collapsible state for Card, ListItem, etc.
+ *
+ * Returns a config object that components accept via a `collapsible` prop.
+ * Supports both controlled (isOpen) and uncontrolled (initialIsOpen) modes.
+ *
+ * Components receiving the config should wrap children in an animated container
+ * using CSS grid-template-rows transition for smooth height animation:
+ *
+ * ```tsx
+ * const collapsibleContentStyles = stylex.create({
+ *   wrapper: {
+ *     display: 'grid',
+ *     transitionProperty: 'grid-template-rows',
+ *     transitionDuration: '0.2s',
+ *     transitionTimingFunction: 'ease',
+ *   },
+ *   open: { gridTemplateRows: '1fr' },
+ *   closed: { gridTemplateRows: '0fr' },
+ *   inner: { overflow: 'hidden' },
+ * });
+ * ```
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts
+ */
+
+import {type ReactNode, useCallback, useState} from 'react';
+
+/**
+ * Configuration object for collapsible behavior.
+ * Passed to components via their `collapsible` prop.
+ *
+ * Can be constructed manually (it's just a plain object) or
+ * obtained from the useXDSCollapsible hook.
+ *
+ * @example
+ * ```tsx
+ * // Via hook
+ * const collapsible = useXDSCollapsible({ initialIsOpen: true });
+ * <XDSCard collapsible={collapsible}>...</XDSCard>
+ *
+ * // Manual construction
+ * const collapsible: XDSCollapsibleConfig = {
+ *   isOpen: true,
+ *   onOpenChange: (open) => console.log(open),
+ * };
+ * ```
+ */
+export interface XDSCollapsibleConfig {
+  /** Whether the collapsible content is currently open/expanded. */
+  isOpen: boolean;
+  /** Callback fired when the open state should change. */
+  onOpenChange?: (isOpen: boolean) => void;
+  /** Optional trigger element rendered by the component. */
+  trigger?: ReactNode;
+}
+
+/**
+ * Options for the useXDSCollapsible hook.
+ */
+export interface UseXDSCollapsibleOptions {
+  /** Initial open state for uncontrolled mode. Defaults to false. */
+  initialIsOpen?: boolean;
+  /** Controlled open state. When provided, the hook operates in controlled mode. */
+  isOpen?: boolean;
+  /** Callback fired when the open state changes. */
+  onOpenChange?: (isOpen: boolean) => void;
+}
+
+/**
+ * Hook that returns a collapsible config object for use with
+ * components that accept a `collapsible` prop.
+ *
+ * Supports controlled and uncontrolled modes:
+ * - **Uncontrolled:** Pass `initialIsOpen` to set the starting state.
+ *   The hook manages state internally.
+ * - **Controlled:** Pass `isOpen` to control the state externally.
+ *   You must also handle `onOpenChange` to update your state.
+ *
+ * @example
+ * ```tsx
+ * // Uncontrolled
+ * const collapsible = useXDSCollapsible({ initialIsOpen: false });
+ *
+ * // Controlled
+ * const [open, setOpen] = useState(false);
+ * const collapsible = useXDSCollapsible({ isOpen: open, onOpenChange: setOpen });
+ *
+ * return <XDSCard collapsible={collapsible}>...</XDSCard>;
+ * ```
+ */
+export function useXDSCollapsible(
+  options?: UseXDSCollapsibleOptions,
+): XDSCollapsibleConfig {
+  const {
+    initialIsOpen = false,
+    isOpen: controlledIsOpen,
+    onOpenChange: controlledOnOpenChange,
+  } = options ?? {};
+
+  const isControlled = controlledIsOpen !== undefined;
+
+  const [internalIsOpen, setInternalIsOpen] = useState(initialIsOpen);
+
+  const currentIsOpen = isControlled ? controlledIsOpen : internalIsOpen;
+
+  const onOpenChange = useCallback(
+    (newIsOpen: boolean) => {
+      if (!isControlled) {
+        setInternalIsOpen(newIsOpen);
+      }
+      controlledOnOpenChange?.(newIsOpen);
+    },
+    [isControlled, controlledOnOpenChange],
+  );
+
+  return {
+    isOpen: currentIsOpen,
+    onOpenChange,
+  };
+}


### PR DESCRIPTION
## Summary

Adds `useXDSCollapsible` — a hook that returns a collapsible config object, designed to be accepted by components via a `collapsible` prop.

Closes #187

## API

```tsx
interface XDSCollapsibleConfig {
  isOpen: boolean;
  onOpenChange?: (isOpen: boolean) => void;
  trigger?: ReactNode;
}

function useXDSCollapsible(options?: {
  initialIsOpen?: boolean;
  isOpen?: boolean;
  onOpenChange?: (isOpen: boolean) => void;
}): XDSCollapsibleConfig;
```

## What's included

- **`useXDSCollapsible` hook** — supports controlled (`isOpen`) and uncontrolled (`initialIsOpen`) modes
- **`XDSCollapsibleConfig` type** — exported for manual construction (it's just a plain object)
- **`UseXDSCollapsibleOptions` type** — exported for extensibility
- **CSS animation pattern** — documented in JSDoc using `grid-template-rows: 0fr → 1fr` transition
- **12 unit tests** covering default state, initial state, controlled mode, uncontrolled toggling, callback firing, and manual config construction

## Files changed

- `packages/core/src/hooks/useXDSCollapsible.ts` — the hook
- `packages/core/src/hooks/useXDSCollapsible.test.ts` — tests
- `packages/core/src/hooks/index.ts` — re-exports

---
*Crafted with care by Navi*