### PR TITLE
Add XDSBanner component

### DIFF
--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -1,0 +1,136 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSBanner} from '@xds/core/Banner';
+import {XDSButton} from '@xds/core/Button';
+import {StarIcon} from '@heroicons/react/24/solid';
+
+const meta: Meta<typeof XDSBanner> = {
+  title: 'Core/XDSBanner',
+  component: XDSBanner,
+  tags: ['autodocs'],
+  argTypes: {
+    status: {
+      control: 'select',
+      options: ['info', 'warning', 'error', 'success'],
+      description: 'Status type',
+    },
+    variant: {
+      control: 'select',
+      options: ['card', 'section'],
+      description: 'Visual variant',
+    },
+    isDismissable: {
+      control: 'boolean',
+      description: 'Whether the banner can be dismissed',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSBanner>;
+
+export const Default: Story = {
+  args: {
+    status: 'info',
+    title: 'This is an informational banner',
+    description: 'Here is some additional context about this message.',
+  },
+};
+
+export const Statuses: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
+      <XDSBanner
+        status="info"
+        title="Information"
+        description="This is an informational message."
+      />
+      <XDSBanner
+        status="success"
+        title="Success"
+        description="The operation completed successfully."
+      />
+      <XDSBanner
+        status="warning"
+        title="Warning"
+        description="Please review before proceeding."
+      />
+      <XDSBanner
+        status="error"
+        title="Error"
+        description="Something went wrong. Please try again."
+      />
+    </div>
+  ),
+};
+
+export const Dismissable: Story = {
+  args: {
+    status: 'warning',
+    title: 'Dismissable banner',
+    description: 'Click the close button to dismiss this banner.',
+    isDismissable: true,
+  },
+};
+
+export const WithEndButton: Story = {
+  args: {
+    status: 'info',
+    title: 'New version available',
+    description: 'Version 2.0 is ready to install.',
+    endButton: <XDSButton variant="secondary" size="sm" label="Update" />,
+  },
+};
+
+export const CustomIcon: Story = {
+  args: {
+    status: 'info',
+    title: 'Featured content',
+    description: 'This banner uses a custom icon.',
+    icon: <StarIcon width={20} height={20} />,
+  },
+};
+
+export const SectionVariant: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
+      <XDSBanner
+        status="info"
+        title="Section banner"
+        description="Full-width with no border radius."
+        variant="section"
+      />
+      <XDSBanner
+        status="error"
+        title="Section error"
+        description="Full-width error banner."
+        variant="section"
+      />
+    </div>
+  ),
+};
+
+export const WithChildren: Story = {
+  args: {
+    status: 'warning',
+    title: 'Action required',
+    description: 'Please complete the following steps:',
+    children: (
+      <ul style={{margin: 0, paddingLeft: '20px'}}>
+        <li>Verify your email address</li>
+        <li>Complete your profile</li>
+        <li>Set up two-factor authentication</li>
+      </ul>
+    ),
+  },
+};
+
+export const TitleOnly: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
+      <XDSBanner status="info" title="Simple info banner" />
+      <XDSBanner status="success" title="Operation complete" />
+      <XDSBanner status="warning" title="Check your settings" />
+      <XDSBanner status="error" title="Connection lost" />
+    </div>
+  ),
+};

--- a/packages/core/src/Banner/README.md
+++ b/packages/core/src/Banner/README.md
@@ -1,0 +1,74 @@
+# Banner
+
+A banner component for displaying contextual messages with status indicators. Supports info, warning, error, and success statuses with appropriate colors, default icons, and optional dismiss functionality.
+
+## Exports
+
+| Export             | Type      | Description                          |
+| ------------------ | --------- | ------------------------------------ |
+| `XDSBanner`        | Component | Main banner component                |
+| `XDSBannerProps`   | Type      | Props interface                      |
+| `XDSBannerStatus`  | Type      | Status union: info, warning, error, success |
+| `XDSBannerVariant` | Type      | Variant union: card, section         |
+
+## Props
+
+| Prop            | Type                                           | Default  | Description                                      |
+| --------------- | ---------------------------------------------- | -------- | ------------------------------------------------ |
+| `status`        | `'info' \| 'warning' \| 'error' \| 'success'` | —        | Status type controlling color and default icon   |
+| `title`         | `ReactNode`                                    | —        | Title text of the banner                         |
+| `description`   | `ReactNode`                                    | —        | Optional description below the title             |
+| `icon`          | `ReactNode`                                    | —        | Custom icon (overrides default status icon)      |
+| `isDismissable` | `boolean`                                      | `false`  | Whether the banner can be dismissed              |
+| `onDismiss`     | `() => void`                                   | —        | Callback fired on dismiss                        |
+| `endButton`     | `ReactNode`                                    | —        | Action button at the end of the banner           |
+| `variant`       | `'card' \| 'section'`                          | `'card'` | Visual variant                                   |
+| `children`      | `ReactNode`                                    | —        | Additional content below title and description   |
+| `xstyle`        | `StyleXStyles`                                 | —        | Additional StyleX styles                         |
+| `data-testid`   | `string`                                       | —        | Test ID for testing frameworks                   |
+
+## Usage
+
+```tsx
+import {XDSBanner} from '@xds/core/Banner';
+
+// Basic info banner
+<XDSBanner status="info" title="Update available" />
+
+// With description
+<XDSBanner
+  status="error"
+  title="Upload failed"
+  description="Please try again later."
+/>
+
+// Dismissable
+<XDSBanner
+  status="warning"
+  title="Low disk space"
+  isDismissable
+  onDismiss={() => console.log('dismissed')}
+/>
+
+// Section variant (full-width, no border radius)
+<XDSBanner status="success" title="Saved!" variant="section" />
+```
+
+## Variants
+
+- **card** (default): Rounded corners with a colored left border accent
+- **section**: Full-width with no border radius, suitable for page-level banners
+
+## Accessibility
+
+- Uses `role="alert"` for `error` and `warning` statuses
+- Uses `role="status"` for `info` and `success` statuses
+- Dismiss button uses `XDSCloseButton` with accessible label
+
+## Files
+
+| File                 | Purpose                  |
+| -------------------- | ------------------------ |
+| `XDSBanner.tsx`      | Component implementation |
+| `XDSBanner.test.tsx` | Unit tests               |
+| `index.ts`           | Barrel exports           |

--- a/packages/core/src/Banner/XDSBanner.test.tsx
+++ b/packages/core/src/Banner/XDSBanner.test.tsx
@@ -1,0 +1,138 @@
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSBanner} from './XDSBanner';
+
+describe('XDSBanner', () => {
+  it('renders with title', () => {
+    render(<XDSBanner status="info" title="Test Title" />);
+    expect(screen.getByText('Test Title')).toBeInTheDocument();
+  });
+
+  it('renders with description', () => {
+    render(
+      <XDSBanner
+        status="info"
+        title="Title"
+        description="Test description"
+      />,
+    );
+    expect(screen.getByText('Test description')).toBeInTheDocument();
+  });
+
+  it('renders info status with role="status"', () => {
+    render(<XDSBanner status="info" title="Info" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders success status with role="status"', () => {
+    render(<XDSBanner status="success" title="Success" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders warning status with role="alert"', () => {
+    render(<XDSBanner status="warning" title="Warning" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('renders error status with role="alert"', () => {
+    render(<XDSBanner status="error" title="Error" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('renders with custom icon', () => {
+    render(
+      <XDSBanner
+        status="info"
+        title="Custom Icon"
+        icon={<span data-testid="custom-icon">★</span>}
+      />,
+    );
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+
+  it('renders default icon when no custom icon provided', () => {
+    const {container} = render(<XDSBanner status="info" title="Default Icon" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('renders as dismissable and handles dismiss', async () => {
+    const user = userEvent.setup();
+    const onDismiss = vi.fn();
+    render(
+      <XDSBanner
+        status="info"
+        title="Dismissable"
+        isDismissable
+        onDismiss={onDismiss}
+      />,
+    );
+
+    expect(screen.getByText('Dismissable')).toBeInTheDocument();
+    const dismissButton = screen.getByRole('button', {name: 'Dismiss'});
+    expect(dismissButton).toBeInTheDocument();
+
+    await user.click(dismissButton);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Dismissable')).not.toBeInTheDocument();
+  });
+
+  it('renders endButton', () => {
+    render(
+      <XDSBanner
+        status="info"
+        title="With Action"
+        endButton={<button data-testid="action-btn">Action</button>}
+      />,
+    );
+    expect(screen.getByTestId('action-btn')).toBeInTheDocument();
+  });
+
+  it('renders card variant by default', () => {
+    const {container} = render(<XDSBanner status="info" title="Card" />);
+    const banner = container.firstElementChild;
+    expect(banner).toBeInTheDocument();
+  });
+
+  it('renders section variant', () => {
+    const {container} = render(
+      <XDSBanner status="info" title="Section" variant="section" />,
+    );
+    const banner = container.firstElementChild;
+    expect(banner).toBeInTheDocument();
+  });
+
+  it('renders children', () => {
+    render(
+      <XDSBanner status="info" title="With Children">
+        <span data-testid="child-content">Extra content</span>
+      </XDSBanner>,
+    );
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
+  });
+
+  it('supports data-testid', () => {
+    render(
+      <XDSBanner status="info" title="Test" data-testid="my-banner" />,
+    );
+    expect(screen.getByTestId('my-banner')).toBeInTheDocument();
+  });
+
+  it('forwards ref', () => {
+    const ref = {current: null as HTMLDivElement | null};
+    render(<XDSBanner ref={ref} status="info" title="Ref Test" />);
+    expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  it('renders all four status types', () => {
+    const statuses = ['info', 'success', 'warning', 'error'] as const;
+    for (const status of statuses) {
+      const {unmount} = render(
+        <XDSBanner status={status} title={`${status} banner`} />,
+      );
+      expect(screen.getByText(`${status} banner`)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -1,0 +1,299 @@
+/**
+ * @file XDSBanner.tsx
+ * @input Uses React forwardRef, HTMLAttributes, ReactNode, StyleXStyles
+ * @output Exports XDSBanner component, XDSBannerProps, XDSBannerStatus types
+ * @position Core implementation; consumed by index.ts, tested by XDSBanner.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Banner/README.md
+ * - /packages/core/src/Banner/XDSBanner.test.tsx
+ * - /packages/core/src/Banner/index.ts
+ * - /apps/storybook/stories/Banner.stories.tsx
+ */
+
+import {forwardRef, useState, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  InformationCircleIcon,
+  ExclamationTriangleIcon,
+  XCircleIcon,
+  CheckCircleIcon,
+} from '@heroicons/react/24/solid';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+import {XDSCloseButton} from '../CloseButton';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Banner status type controlling color scheme and default icon.
+ */
+export type XDSBannerStatus = 'info' | 'warning' | 'error' | 'success';
+
+/**
+ * Banner variant type controlling layout shape.
+ */
+export type XDSBannerVariant = 'card' | 'section';
+
+export interface XDSBannerProps {
+  /**
+   * The status type of the banner, controlling color and default icon.
+   */
+  status: XDSBannerStatus;
+  /**
+   * The title text of the banner.
+   */
+  title: ReactNode;
+  /**
+   * Optional description text displayed below the title.
+   */
+  description?: ReactNode;
+  /**
+   * Custom icon to display. Overrides the default status icon.
+   */
+  icon?: ReactNode;
+  /**
+   * Whether the banner can be dismissed.
+   * @default false
+   */
+  isDismissable?: boolean;
+  /**
+   * Callback fired when the banner is dismissed.
+   */
+  onDismiss?: () => void;
+  /**
+   * Optional action button rendered at the end of the banner.
+   */
+  endButton?: ReactNode;
+  /**
+   * The visual variant of the banner.
+   * - `card`: rounded corners with a colored left border
+   * - `section`: full-width with no border radius
+   * @default 'card'
+   */
+  variant?: XDSBannerVariant;
+  /**
+   * Additional content rendered below the title and description.
+   */
+  children?: ReactNode;
+  /**
+   * Additional StyleX styles to apply to the root element.
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * Test ID for testing frameworks.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  base: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    gap: spacingVars['--spacing-3'],
+    padding: spacingVars['--spacing-4'],
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+  },
+  card: {
+    borderRadius: radiusVars['--radius-container'],
+    borderLeftWidth: '4px',
+    borderLeftStyle: 'solid',
+  },
+  section: {
+    borderRadius: '0',
+    borderLeftWidth: '0',
+    width: '100%',
+  },
+  icon: {
+    flexShrink: 0,
+    width: '20px',
+    height: '20px',
+    marginTop: '2px',
+  },
+  content: {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+  },
+  title: {
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-primary'],
+  },
+  description: {
+    fontSize: textSizeVars['--text-sm'],
+    lineHeight: lineHeightVars['--leading-normal'],
+    color: colorVars['--color-text-secondary'],
+  },
+  actions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    flexShrink: 0,
+    marginTop: '2px',
+  },
+});
+
+const statusStyles = stylex.create({
+  info: {
+    backgroundColor: colorVars['--color-accent-deemphasized'],
+    borderLeftColor: colorVars['--color-accent'],
+  },
+  warning: {
+    backgroundColor: colorVars['--color-warning-deemphasized'],
+    borderLeftColor: colorVars['--color-warning'],
+  },
+  error: {
+    backgroundColor: colorVars['--color-negative-deemphasized'],
+    borderLeftColor: colorVars['--color-negative'],
+  },
+  success: {
+    backgroundColor: colorVars['--color-positive-deemphasized'],
+    borderLeftColor: colorVars['--color-positive'],
+  },
+});
+
+const iconColorStyles = stylex.create({
+  info: {
+    color: colorVars['--color-accent'],
+  },
+  warning: {
+    color: colorVars['--color-warning'],
+  },
+  error: {
+    color: colorVars['--color-negative'],
+  },
+  success: {
+    color: colorVars['--color-positive'],
+  },
+});
+
+// =============================================================================
+// Default Icons
+// =============================================================================
+
+const defaultIcons: Record<XDSBannerStatus, React.ComponentType<React.SVGProps<SVGSVGElement>>> = {
+  info: InformationCircleIcon,
+  warning: ExclamationTriangleIcon,
+  error: XCircleIcon,
+  success: CheckCircleIcon,
+};
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * A banner component for displaying contextual messages with status indicators.
+ *
+ * Supports info, warning, error, and success statuses with appropriate colors
+ * and default icons. Can be dismissable and supports custom actions.
+ *
+ * @example
+ * ```tsx
+ * <XDSBanner status="info" title="Update available">
+ *   A new version is ready to install.
+ * </XDSBanner>
+ *
+ * <XDSBanner
+ *   status="error"
+ *   title="Upload failed"
+ *   description="Please try again later."
+ *   isDismissable
+ * />
+ * ```
+ */
+export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
+  (
+    {
+      status,
+      title,
+      description,
+      icon,
+      isDismissable = false,
+      onDismiss,
+      endButton,
+      variant = 'card',
+      children,
+      xstyle,
+      'data-testid': testId,
+    },
+    ref,
+  ) => {
+    const [isDismissed, setIsDismissed] = useState(false);
+
+    if (isDismissed) {
+      return null;
+    }
+
+    const handleDismiss = () => {
+      setIsDismissed(true);
+      onDismiss?.();
+    };
+
+    const role = status === 'error' || status === 'warning' ? 'alert' : 'status';
+
+    const DefaultIcon = defaultIcons[status];
+    const renderedIcon = icon ?? (
+      <DefaultIcon aria-hidden="true" />
+    );
+
+    return (
+      <div
+        ref={ref}
+        role={role}
+        data-testid={testId}
+        {...stylex.props(
+          styles.base,
+          variant === 'card' && styles.card,
+          variant === 'section' && styles.section,
+          statusStyles[status],
+          xstyle,
+        )}>
+        <div {...stylex.props(styles.icon, iconColorStyles[status])}>
+          {renderedIcon}
+        </div>
+        <div {...stylex.props(styles.content)}>
+          <div {...stylex.props(styles.title)}>{title}</div>
+          {description != null && (
+            <div {...stylex.props(styles.description)}>{description}</div>
+          )}
+          {children}
+        </div>
+        {(endButton != null || isDismissable) && (
+          <div {...stylex.props(styles.actions)}>
+            {endButton}
+            {isDismissable && (
+              <XDSCloseButton
+                size="sm"
+                label="Dismiss"
+                onClick={handleDismiss}
+              />
+            )}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+XDSBanner.displayName = 'XDSBanner';

--- a/packages/core/src/Banner/index.ts
+++ b/packages/core/src/Banner/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @file Banner component barrel export
+ */
+
+export {XDSBanner} from './XDSBanner';
+export type {
+  XDSBannerProps,
+  XDSBannerStatus,
+  XDSBannerVariant,
+} from './XDSBanner';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@
 export * from './AspectRatio';
 export * from './Avatar';
 export * from './Badge';
+export * from './Banner';
 export * from './Breadcrumbs';
 export * from './Button';
 export * from './Calendar';


### PR DESCRIPTION
## Summary

Adds the `XDSBanner` component for displaying contextual messages with status indicators.

Closes #163

## Features

- **Status types**: `info`, `warning`, `error`, `success` — each with appropriate color scheme and default icon
- **Variants**: `card` (rounded corners, colored left border) and `section` (full-width, no border radius)
- **Dismissable**: Internal dismissed state with `XDSCloseButton`, `onDismiss` callback
- **Composition**: `icon`, `endButton`, `children` slots for flexible content
- **Accessibility**: `role="alert"` for error/warning, `role="status"` for info/success
- **API conventions**: `forwardRef`, `displayName`, `xstyle`, `data-testid`

## Files

| File | Purpose |
|------|---------|
| `packages/core/src/Banner/XDSBanner.tsx` | Component implementation |
| `packages/core/src/Banner/XDSBanner.test.tsx` | 16 unit tests |
| `packages/core/src/Banner/index.ts` | Barrel exports |
| `packages/core/src/Banner/README.md` | Component documentation |
| `apps/storybook/stories/Banner.stories.tsx` | Storybook stories |
| `packages/core/src/index.ts` | Added `export * from './Banner'` |

## Test Results

All 16 tests passing:
- Renders with title, description, children
- All four status types with correct ARIA roles
- Custom icon override
- Dismiss behavior (click → hidden, callback fired)
- endButton rendering
- Card and section variants
- data-testid passthrough
- Ref forwarding

---
*Crafted with care by Navi*