### PR TITLE
feat(cli): rewrite theme command as interactive scaffold + add theme vibe tests

### DIFF
--- a/internal/vibe-tests/test-sets/default.json
+++ b/internal/vibe-tests/test-sets/default.json
@@ -5,7 +5,10 @@
       "id": "fwc-1",
       "category": "feature-with-constraint",
       "prompt": "I need a banner that warns users their trial expires in X days and lets them upgrade",
-      "expectedComponents": ["XDSCard", "XDSButton"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add a dismiss button that hides the banner and remembers the choice",
@@ -16,7 +19,9 @@
       "id": "fwc-2",
       "category": "feature-with-constraint",
       "prompt": "Build a notification that shows unread count, but hides when count is zero",
-      "expectedComponents": ["XDSCard"],
+      "expectedComponents": [
+        "XDSCard"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add a dropdown that shows the list of notifications when clicked",
@@ -27,7 +32,10 @@
       "id": "fwc-3",
       "category": "feature-with-constraint",
       "prompt": "Create a password input that shows strength indicator and has a show/hide toggle",
-      "expectedComponents": ["XDSTextInput", "XDSButton"],
+      "expectedComponents": [
+        "XDSTextInput",
+        "XDSButton"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add specific requirements that check off as you type (8+ chars, uppercase, number, symbol)",
@@ -37,8 +45,12 @@
     {
       "id": "wd-1",
       "category": "workflow-description",
-      "prompt": "Build a checkout flow: cart summary → shipping → payment → confirmation",
-      "expectedComponents": ["XDSCard", "XDSButton", "XDSTextInput"],
+      "prompt": "Build a checkout flow: cart summary \u2192 shipping \u2192 payment \u2192 confirmation",
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton",
+        "XDSTextInput"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add form validation with inline error messages for required fields",
@@ -49,7 +61,11 @@
       "id": "wd-2",
       "category": "workflow-description",
       "prompt": "Create a multi-step form wizard with back/next buttons and a progress indicator",
-      "expectedComponents": ["XDSCard", "XDSButton", "XDSVStack"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton",
+        "XDSVStack"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add validation that prevents going to the next step if required fields are empty",
@@ -59,8 +75,12 @@
     {
       "id": "wd-3",
       "category": "workflow-description",
-      "prompt": "Build an onboarding flow: welcome screen → profile setup → preferences → done",
-      "expectedComponents": ["XDSCard", "XDSButton", "XDSTextInput"],
+      "prompt": "Build an onboarding flow: welcome screen \u2192 profile setup \u2192 preferences \u2192 done",
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton",
+        "XDSTextInput"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add a skip button that allows skipping optional steps",
@@ -71,7 +91,10 @@
       "id": "cwm-1",
       "category": "clone-with-modification",
       "prompt": "Something like Stripe's pricing table but with monthly/annual toggle",
-      "expectedComponents": ["XDSCard", "XDSButton"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Highlight the most popular plan with a badge",
@@ -82,7 +105,11 @@
       "id": "cwm-2",
       "category": "clone-with-modification",
       "prompt": "A GitHub-style issue label picker with color dots and search",
-      "expectedComponents": ["XDSTextInput", "XDSButton", "XDSCard"],
+      "expectedComponents": [
+        "XDSTextInput",
+        "XDSButton",
+        "XDSCard"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add the ability to create a new label inline with a color picker",
@@ -93,7 +120,10 @@
       "id": "cwm-3",
       "category": "clone-with-modification",
       "prompt": "Like Notion's page header with icon picker and cover image",
-      "expectedComponents": ["XDSCard", "XDSButton"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add the ability to reposition the cover image by dragging",
@@ -103,8 +133,11 @@
     {
       "id": "sd-1",
       "category": "state-driven",
-      "prompt": "Show a dashboard widget with loading → error → data states",
-      "expectedComponents": ["XDSCard", "XDSSkeleton"],
+      "prompt": "Show a dashboard widget with loading \u2192 error \u2192 data states",
+      "expectedComponents": [
+        "XDSCard",
+        "XDSSkeleton"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add a refresh button that reloads the data",
@@ -115,7 +148,9 @@
       "id": "sd-2",
       "category": "state-driven",
       "prompt": "A button that shows loading spinner while submitting, then success checkmark",
-      "expectedComponents": ["XDSButton"],
+      "expectedComponents": [
+        "XDSButton"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add an error state with a red X icon and error message tooltip",
@@ -126,7 +161,10 @@
       "id": "sd-3",
       "category": "state-driven",
       "prompt": "Form that disables submit until all required fields are valid",
-      "expectedComponents": ["XDSTextInput", "XDSButton"],
+      "expectedComponents": [
+        "XDSTextInput",
+        "XDSButton"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Show validation errors inline below each field after blur",
@@ -137,7 +175,9 @@
       "id": "dd-1",
       "category": "data-display",
       "prompt": "A table of users with sortable columns and search",
-      "expectedComponents": ["XDSTextInput"],
+      "expectedComponents": [
+        "XDSTextInput"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add pagination with page size selector (10, 25, 50)",
@@ -148,7 +188,10 @@
       "id": "dd-2",
       "category": "data-display",
       "prompt": "Display a list of transactions with amount, date, and status indicator",
-      "expectedComponents": ["XDSCard", "XDSVStack"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSVStack"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add filtering by date range and status",
@@ -159,7 +202,10 @@
       "id": "dd-3",
       "category": "data-display",
       "prompt": "Show a grid of product cards with image, title, price, and add to cart button",
-      "expectedComponents": ["XDSCard", "XDSButton"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add a quantity selector to each card",
@@ -170,7 +216,10 @@
       "id": "rc-1",
       "category": "responsive-context",
       "prompt": "Navigation that collapses to hamburger on mobile",
-      "expectedComponents": ["XDSButton", "XDSHStack"],
+      "expectedComponents": [
+        "XDSButton",
+        "XDSHStack"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add a dropdown for nav items with children",
@@ -181,7 +230,10 @@
       "id": "rc-2",
       "category": "responsive-context",
       "prompt": "A sidebar that becomes a bottom sheet on mobile",
-      "expectedComponents": ["XDSCard", "XDSLayoutPanel"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSLayoutPanel"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add a drag handle to resize the bottom sheet",
@@ -192,7 +244,9 @@
       "id": "rc-3",
       "category": "responsive-context",
       "prompt": "Cards that stack vertically on mobile but show in a grid on desktop",
-      "expectedComponents": ["XDSCard"],
+      "expectedComponents": [
+        "XDSCard"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add a toggle to switch between grid and list view",
@@ -203,7 +257,10 @@
       "id": "io-1",
       "category": "integration-oriented",
       "prompt": "A form that validates email and posts to /api/subscribe",
-      "expectedComponents": ["XDSTextInput", "XDSButton"],
+      "expectedComponents": [
+        "XDSTextInput",
+        "XDSButton"
+      ],
       "complexity": "simple",
       "followUps": [
         "Show a success message with the user's email after subscribing",
@@ -214,7 +271,10 @@
       "id": "io-2",
       "category": "integration-oriented",
       "prompt": "An autocomplete input that fetches suggestions from an API as you type",
-      "expectedComponents": ["XDSTextInput", "XDSCard"],
+      "expectedComponents": [
+        "XDSTextInput",
+        "XDSCard"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add keyboard navigation (up/down arrows, enter to select)",
@@ -225,7 +285,9 @@
       "id": "io-3",
       "category": "integration-oriented",
       "prompt": "A file upload button that shows progress and calls an upload endpoint",
-      "expectedComponents": ["XDSButton"],
+      "expectedComponents": [
+        "XDSButton"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add drag-and-drop support with a drop zone",
@@ -236,7 +298,11 @@
       "id": "wd-4",
       "category": "workflow-description",
       "prompt": "Create a new internal tool called TodoTracker. UI Requirements: Display todos in a paginated table (default 25 per page). Columns: Title, Status, Created, Updated. Sortable by: Updated date (default desc), Created date, Title. Add a filter bar that filters by title (substring match) and status. Inline editing for todo title (with save/cancel). Status toggle button (Open <-> Closed). 'Create Todo' button that opens a modal with title input. Delete button with confirmation dialog. UI should update optimistically after any modification. Optimistic updates should be marked as 'pending' until the modification is complete.",
-      "expectedComponents": ["XDSTable", "XDSButton", "XDSTextInput"],
+      "expectedComponents": [
+        "XDSTable",
+        "XDSButton",
+        "XDSTextInput"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add keyboard shortcuts: Ctrl+N for new todo, Delete key to delete selected",
@@ -247,7 +313,13 @@
       "id": "ps-1",
       "category": "page-setup",
       "prompt": "Create a new page for a settings dashboard. It should have a header with the app title, a sidebar for navigation, and a main content area. Use the XDS theme system.",
-      "expectedComponents": ["Theme", "XDSLayout", "XDSLayoutHeader", "XDSLayoutContent", "XDSLayoutPanel"],
+      "expectedComponents": [
+        "Theme",
+        "XDSLayout",
+        "XDSLayoutHeader",
+        "XDSLayoutContent",
+        "XDSLayoutPanel"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add a user avatar with dropdown menu in the header",
@@ -258,7 +330,13 @@
       "id": "ps-2",
       "category": "page-setup",
       "prompt": "Set up the root layout for a new internal tool. Include proper body styling, theme provider with defaultTheme, and a layout with header and main content area.",
-      "expectedComponents": ["Theme", "defaultTheme", "XDSLayout", "XDSLayoutHeader", "XDSLayoutContent"],
+      "expectedComponents": [
+        "Theme",
+        "defaultTheme",
+        "XDSLayout",
+        "XDSLayoutHeader",
+        "XDSLayoutContent"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add a theme toggle button (light/dark mode)",
@@ -269,7 +347,13 @@
       "id": "ps-3",
       "category": "page-setup",
       "prompt": "Create an admin panel page layout with a fixed header, collapsible left sidebar, main content area, and a right panel for details. Wrap everything in the XDS theme.",
-      "expectedComponents": ["Theme", "XDSLayout", "XDSLayoutHeader", "XDSLayoutContent", "XDSLayoutPanel"],
+      "expectedComponents": [
+        "Theme",
+        "XDSLayout",
+        "XDSLayoutHeader",
+        "XDSLayoutContent",
+        "XDSLayoutPanel"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add breadcrumbs below the header",
@@ -280,7 +364,10 @@
       "id": "ty-1",
       "category": "typography",
       "prompt": "Show a page title with a short description underneath",
-      "expectedComponents": ["XDSHeading", "XDSText"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText"
+      ],
       "complexity": "simple",
       "followUps": [
         "Make the title use the larger editorial scale",
@@ -291,7 +378,10 @@
       "id": "ty-2",
       "category": "typography",
       "prompt": "Create a blog post header with a big editorial headline, a publication date in small text, and an author name",
-      "expectedComponents": ["XDSHeading", "XDSText"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add a reading time estimate next to the date in the same small style",
@@ -302,7 +392,10 @@
       "id": "ty-3",
       "category": "typography",
       "prompt": "Build a metrics dashboard card that shows a label like 'Total Revenue', a large numeric value like '$12,340.56', and a small supporting line that says '+12% from last month'",
-      "expectedComponents": ["XDSCard", "XDSText"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSText"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Make the numeric value use tabular numbers so digits align across cards",
@@ -313,7 +406,11 @@
       "id": "ty-4",
       "category": "typography",
       "prompt": "Create a settings page with 3 sections. Each section needs a heading, a brief description, and some form controls. Use different heading levels for the page title vs section titles.",
-      "expectedComponents": ["XDSHeading", "XDSText", "XDSTextInput"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText",
+        "XDSTextInput"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add helper text below each input using the appropriate supporting text style",
@@ -324,7 +421,11 @@
       "id": "ty-5",
       "category": "typography",
       "prompt": "Build a landing page hero with a large display heading that says 'Build faster with XDS', a subheading paragraph, and a CTA button",
-      "expectedComponents": ["XDSHeading", "XDSText", "XDSButton"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText",
+        "XDSButton"
+      ],
       "complexity": "simple",
       "followUps": [
         "The heading should use the editorial display scale for maximum visual impact",
@@ -335,7 +436,9 @@
       "id": "ty-6",
       "category": "typography",
       "prompt": "Display a code example with a label that says 'Installation' above it, the code snippet 'yarn add @xds/core', and a note below in small text",
-      "expectedComponents": ["XDSText"],
+      "expectedComponents": [
+        "XDSText"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add a copy button next to the code",
@@ -346,7 +449,10 @@
       "id": "ty-7",
       "category": "typography",
       "prompt": "Render a markdown-formatted changelog that includes headings, paragraphs, bullet lists, and inline code. The content should use proper typography styling.",
-      "expectedComponents": ["XDSHeading", "XDSText"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText"
+      ],
       "complexity": "complex",
       "followUps": [
         "Make the changelog use the editorial heading scale",
@@ -357,7 +463,11 @@
       "id": "ty-8",
       "category": "typography",
       "prompt": "Create a profile card with the user's name as a heading, their role as a label, their bio as body text, and their join date in small supporting text",
-      "expectedComponents": ["XDSCard", "XDSHeading", "XDSText"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSHeading",
+        "XDSText"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add an email address that truncates with an ellipsis if it's too long",
@@ -368,7 +478,10 @@
       "id": "ty-9",
       "category": "typography",
       "prompt": "Build a comparison table header where each column has a plan name heading and a price. The 'Enterprise' plan should have visually larger display-style typography compared to the other plans.",
-      "expectedComponents": ["XDSHeading", "XDSText"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add a 'Most Popular' label badge on the Pro plan using label-style text",
@@ -379,11 +492,129 @@
       "id": "ty-10",
       "category": "typography",
       "prompt": "Create an article page with a full editorial-style header (large title, subtitle, author info) and a body section that renders rich text content with proper heading hierarchy, paragraphs, code blocks, and lists",
-      "expectedComponents": ["XDSHeading", "XDSText"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add a 'Table of Contents' sidebar that lists all the section headings",
         "Make the body text use the large text type for better readability"
+      ]
+    },
+    {
+      "id": "tc-1",
+      "category": "theme-customization",
+      "prompt": "Set up a dark mode toggle for my app. I want a button that switches between light and dark themes using the XDS theme system.",
+      "expectedComponents": [
+        "XDSTheme",
+        "XDSButton"
+      ],
+      "complexity": "simple",
+      "followUps": [
+        "Persist the user's theme preference to localStorage",
+        "Add a 'system' option that follows the OS preference"
+      ]
+    },
+    {
+      "id": "tc-2",
+      "category": "theme-customization",
+      "prompt": "I want to create a custom brand theme for my app. The primary accent color should be purple (#7B61FF), with a dark surface (#1A1A2E) and light text. Set up a proper XDS theme with these colors.",
+      "expectedComponents": [
+        "XDSTheme"
+      ],
+      "complexity": "moderate",
+      "followUps": [
+        "Add a matching light mode version of the theme",
+        "Override the button styles in this theme to have rounded-full corners"
+      ]
+    },
+    {
+      "id": "tc-3",
+      "category": "theme-customization",
+      "prompt": "I need my page background to use the wash color from the theme. Right now wrapping my app in XDSTheme doesn't change the page background \u2014 it stays white.",
+      "expectedComponents": [
+        "XDSTheme",
+        "XDSLayout"
+      ],
+      "complexity": "simple",
+      "followUps": [
+        "Also set the body background color to match",
+        "Make the content area use the surface color instead"
+      ]
+    },
+    {
+      "id": "tc-4",
+      "category": "theme-customization",
+      "prompt": "Create a theme switcher that lets users pick between three themes: Default, Midnight (dark purple), and Earth (warm brown tones). Show a preview card for each theme.",
+      "expectedComponents": [
+        "XDSTheme",
+        "XDSCard",
+        "XDSButton"
+      ],
+      "complexity": "complex",
+      "followUps": [
+        "Show a live preview of each theme using actual XDS components inside the preview cards",
+        "Save the selected theme to localStorage and restore it on page load"
+      ]
+    },
+    {
+      "id": "tc-5",
+      "category": "theme-customization",
+      "prompt": "I want to customize the card component's appearance in my theme \u2014 add a gradient border and increase the border radius. How do I do component-level style overrides in the XDS theme?",
+      "expectedComponents": [
+        "XDSTheme",
+        "XDSCard"
+      ],
+      "complexity": "moderate",
+      "followUps": [
+        "Also override the button variants to have a shadow on hover",
+        "Make the heading component use a custom font family in this theme"
+      ]
+    },
+    {
+      "id": "tc-6",
+      "category": "theme-customization",
+      "prompt": "Build a settings page where users can customize the app's appearance. Include controls for accent color, border radius, and spacing scale. Changes should apply via the XDS theme system, not inline styles.",
+      "expectedComponents": [
+        "XDSTheme",
+        "XDSTextInput",
+        "XDSCard",
+        "XDSButton"
+      ],
+      "complexity": "complex",
+      "followUps": [
+        "Add a preview section that shows how buttons, cards, and inputs look with the current settings",
+        "Add a reset button that restores the default theme"
+      ]
+    },
+    {
+      "id": "tc-7",
+      "category": "theme-customization",
+      "prompt": "I have a section of my app that needs a different theme than the rest \u2014 like a dark sidebar next to a light content area. How do I nest themes in XDS?",
+      "expectedComponents": [
+        "XDSTheme",
+        "XDSLayout",
+        "XDSLayoutPanel",
+        "XDSLayoutContent"
+      ],
+      "complexity": "moderate",
+      "followUps": [
+        "Make sure the sidebar text and icons use the dark theme's colors",
+        "Add a smooth transition when the sidebar theme changes"
+      ]
+    },
+    {
+      "id": "tc-8",
+      "category": "theme-customization",
+      "prompt": "Create a brutalist theme for XDS \u2014 zero border radius, high contrast black and white, bold borders, and a hot pink accent color. Wire it up with XDSTheme.",
+      "expectedComponents": [
+        "XDSTheme"
+      ],
+      "complexity": "moderate",
+      "followUps": [
+        "Override card styles to have a thick 2px black border",
+        "Make buttons use uppercase text in this theme"
       ]
     }
   ],
@@ -392,7 +623,10 @@
       "id": "ho-fwc-1",
       "category": "feature-with-constraint",
       "prompt": "A cookie consent banner that remembers user choice and has accept/decline buttons",
-      "expectedComponents": ["XDSCard", "XDSButton"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add a 'Manage preferences' link that opens a modal with cookie categories",
@@ -402,8 +636,12 @@
     {
       "id": "ho-wd-1",
       "category": "workflow-description",
-      "prompt": "Build a return request flow: select items → reason → shipping method → confirmation",
-      "expectedComponents": ["XDSCard", "XDSButton", "XDSTextInput"],
+      "prompt": "Build a return request flow: select items \u2192 reason \u2192 shipping method \u2192 confirmation",
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton",
+        "XDSTextInput"
+      ],
       "complexity": "complex",
       "followUps": [
         "Add a photo upload step for damaged items",
@@ -414,7 +652,10 @@
       "id": "ho-cwm-1",
       "category": "clone-with-modification",
       "prompt": "Like Slack's emoji reaction picker but for status icons",
-      "expectedComponents": ["XDSButton", "XDSHoverCard"],
+      "expectedComponents": [
+        "XDSButton",
+        "XDSHoverCard"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add a search filter for icons",
@@ -425,7 +666,9 @@
       "id": "ho-sd-1",
       "category": "state-driven",
       "prompt": "A save button that shows 'Saving...' then 'Saved!' then returns to 'Save'",
-      "expectedComponents": ["XDSButton"],
+      "expectedComponents": [
+        "XDSButton"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add an 'Unsaved changes' indicator next to the button",
@@ -436,7 +679,10 @@
       "id": "ho-dd-1",
       "category": "data-display",
       "prompt": "Show a timeline of events with timestamps and icons",
-      "expectedComponents": ["XDSCard", "XDSVStack"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSVStack"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add expandable details for each event",
@@ -447,7 +693,10 @@
       "id": "ho-rc-1",
       "category": "responsive-context",
       "prompt": "A pricing comparison that scrolls horizontally on mobile",
-      "expectedComponents": ["XDSCard", "XDSHStack"],
+      "expectedComponents": [
+        "XDSCard",
+        "XDSHStack"
+      ],
       "complexity": "simple",
       "followUps": [
         "Add sticky column headers that stay visible while scrolling",
@@ -458,7 +707,10 @@
       "id": "ho-io-1",
       "category": "integration-oriented",
       "prompt": "A search box that debounces input and shows live results from /api/search",
-      "expectedComponents": ["XDSTextInput", "XDSCard"],
+      "expectedComponents": [
+        "XDSTextInput",
+        "XDSCard"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add recent searches that show before typing",
@@ -469,7 +721,10 @@
       "id": "ho-ty-1",
       "category": "typography",
       "prompt": "Create a documentation page header with a breadcrumb trail in small text, a large editorial heading, and a description paragraph",
-      "expectedComponents": ["XDSHeading", "XDSText"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Add a 'Last updated' timestamp in supporting text style",
@@ -480,11 +735,43 @@
       "id": "ho-ty-2",
       "category": "typography",
       "prompt": "Build a notification detail view with a bold title, a timestamp in supporting text, and a body that may contain formatted markdown content",
-      "expectedComponents": ["XDSHeading", "XDSText"],
+      "expectedComponents": [
+        "XDSHeading",
+        "XDSText"
+      ],
       "complexity": "moderate",
       "followUps": [
         "Truncate the title to a single line with a tooltip showing the full text",
         "Add a secondary text line showing who triggered the notification"
+      ]
+    },
+    {
+      "id": "ho-tc-1",
+      "category": "theme-customization",
+      "prompt": "I want to use XDS's default theme but just change the accent color to green. What's the minimal way to do that?",
+      "expectedComponents": [
+        "XDSTheme"
+      ],
+      "complexity": "simple",
+      "followUps": [
+        "Also adjust the positive/negative status colors to match the new palette",
+        "Create a second variant with a blue accent for comparison"
+      ]
+    },
+    {
+      "id": "ho-tc-2",
+      "category": "theme-customization",
+      "prompt": "Build a theme editor that shows all the color tokens from the XDS theme and lets you edit them with color pickers. Group them by category (text, surface, status, etc).",
+      "expectedComponents": [
+        "XDSTheme",
+        "XDSCard",
+        "XDSTextInput",
+        "XDSVStack"
+      ],
+      "complexity": "complex",
+      "followUps": [
+        "Add an export button that generates a valid XDS theme file from the current values",
+        "Add a 'derive from palette' mode where picking 3-5 key colors generates the full token set"
       ]
     }
   ],

--- a/packages/cli/docs/theme.md
+++ b/packages/cli/docs/theme.md
@@ -1,0 +1,247 @@
+# XDS Theme System
+
+## Quick Start
+
+```tsx
+import {XDSTheme} from '@xds/core';
+import {defaultTheme} from '@xds/theme/default';
+
+function App() {
+  return (
+    <XDSTheme theme={defaultTheme}>
+      <YourApp />
+    </XDSTheme>
+  );
+}
+```
+
+## Available Themes
+
+| Theme   | Import                                            | Description                           |
+| ------- | ------------------------------------------------- | ------------------------------------- |
+| Default | `import {defaultTheme} from '@xds/theme/default'` | Blue accent, system fonts, light/dark |
+| Neutral | `import {neutralTheme} from '@xds/theme/neutral'` | Grayscale, shadcn-inspired            |
+
+Run `npx xds theme --list` to see themes in your project.
+
+## XDSTheme Props
+
+| Prop       | Type                            | Default    | Description                                   |
+| ---------- | ------------------------------- | ---------- | --------------------------------------------- |
+| `theme`    | `Theme`                         | —          | Theme object (required)                       |
+| `mode`     | `'system' \| 'light' \| 'dark'` | `'system'` | Color mode. `'system'` follows OS preference. |
+| `children` | `ReactNode`                     | —          | App content                                   |
+
+## Creating a Custom Theme
+
+### Scaffold with CLI (recommended)
+
+```bash
+npx xds theme
+```
+
+Interactive wizard that generates a complete `.stylex.ts` theme file with your brand colors.
+
+### Manual creation
+
+A theme is an object with `name`, `styles`, and `raw`:
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+import type {ThemeType as Theme} from '@xds/core/theme';
+import {
+  colorVars,
+  spacingVars,
+  sizeVars,
+  radiusVars,
+  elevationVars,
+  transitionVars,
+  typographyVars,
+  textSizeVars,
+  lineHeightVars,
+  fontWeightVars,
+} from '@xds/core/theme/tokens.stylex';
+
+// 1. Define raw values
+const colorRaw = {
+  '--color-accent': 'light-dark(#7B61FF, #9B85FF)',
+  '--color-surface': 'light-dark(#FFFFFF, #1A1A2E)',
+  // ... all ~60 color tokens (see npx xds docs tokens)
+};
+
+// 2. Create StyleX theme overrides
+const colorTheme = stylex.createTheme(
+  colorVars,
+  colorRaw as unknown as BaseColorRaw,
+);
+
+// 3. Export the theme
+export const myTheme: Theme = {
+  name: 'my-theme',
+  styles: {colors: colorTheme, spacing: spacingTheme /* ... all 10 */},
+  raw: {colors: colorRaw, spacing: spacingRaw /* ... all 10 */},
+};
+```
+
+The `styles` field uses `stylex.createTheme()` for each token group. The `raw` field has the same values as plain objects for programmatic access.
+
+**Token groups** (all required in both `styles` and `raw`):
+colors, spacing, size, radius, elevation, transition, typography, textSize, lineHeight, fontWeight
+
+## Light/Dark Mode
+
+### Automatic (recommended)
+
+Use `light-dark()` in token values:
+
+```tsx
+'--color-accent': 'light-dark(#0064E0, #2694FE)',
+//                            ^light     ^dark
+```
+
+Then use `mode="system"` (default) on XDSTheme — it follows OS preference.
+
+### Toggle with a button
+
+```tsx
+const [mode, setMode] = useState<'light' | 'dark'>('light');
+
+<XDSTheme theme={myTheme} mode={mode}>
+  <XDSButton
+    label={mode === 'light' ? 'Switch to Dark' : 'Switch to Light'}
+    onClick={() => setMode(m => (m === 'light' ? 'dark' : 'light'))}
+  />
+</XDSTheme>;
+```
+
+### Dark-only or light-only theme
+
+Set `mode` explicitly and use single values (not `light-dark()`):
+
+```tsx
+<XDSTheme theme={darkTheme} mode="dark">
+```
+
+## Nesting Themes
+
+Wrap different sections in separate `<XDSTheme>` providers:
+
+```tsx
+<XDSTheme theme={lightTheme} mode="light">
+  <XDSLayout
+    header={<XDSLayoutHeader>...</XDSLayoutHeader>}
+    start={
+      <XDSTheme theme={darkTheme} mode="dark">
+        <XDSLayoutPanel>{/* Dark sidebar */}</XDSLayoutPanel>
+      </XDSTheme>
+    }
+    content={<XDSLayoutContent>{/* Light content */}</XDSLayoutContent>}
+  />
+</XDSTheme>
+```
+
+## Page Background
+
+**Important:** `XDSTheme` uses `display: contents` — it doesn't create a visual box.
+To apply the theme's background color, add it to a wrapper element via StyleX:
+
+```tsx
+const styles = stylex.create({
+  page: {
+    backgroundColor: 'var(--color-wash)',
+    minHeight: '100vh',
+  },
+});
+
+<XDSTheme theme={myTheme}>
+  <div {...stylex.props(styles.page)}>
+    <XDSLayout>...</XDSLayout>
+  </div>
+</XDSTheme>;
+```
+
+## Component Style Overrides
+
+Themes can override individual component styles via the `components` field.
+
+### How it works
+
+1. Components register their themeable properties via module augmentation:
+
+```tsx
+// Inside XDSCard.tsx
+declare module '../theme/types' {
+  interface ComponentStyles {
+    card?: {
+      container?: ThemeStyleXStyles;
+      content?: ThemeStyleXStyles;
+    };
+  }
+}
+```
+
+2. Your theme provides StyleX overrides:
+
+```tsx
+const cardOverrides = stylex.create({
+  container: {
+    borderRadius: '20px',
+    background:
+      'linear-gradient(135deg, var(--color-accent), var(--color-positive))',
+    padding: '2px', // gradient border width
+  },
+  content: {
+    backgroundColor: 'var(--color-card)',
+    borderRadius: '18px', // inner radius = outer - padding
+  },
+});
+
+export const myTheme: Theme = {
+  name: 'my-theme',
+  styles: {
+    /* ... */
+  },
+  raw: {
+    /* ... */
+  },
+  components: {
+    card: {
+      container: cardOverrides.container,
+      content: cardOverrides.content,
+    },
+  } as Theme['components'],
+};
+```
+
+### Available component overrides
+
+| Component | Key       | Slots                                                                      | What to customize                      |
+| --------- | --------- | -------------------------------------------------------------------------- | -------------------------------------- |
+| Button    | `button`  | `variants` (by variant name)                                               | Background, border, shadow per variant |
+| Card      | `card`    | `container`, `content`                                                     | Border, radius, shadow, background     |
+| Heading   | `heading` | `styles` (h1-h6), `editorialStyles` (h1-h6)                                | Font, size, weight, color per level    |
+| Text      | `text`    | `styles` (body, large, label, supporting, code)                            | Font, size, weight, color per type     |
+| Prose     | `prose`   | `base`, `styles` (p, ul, ol, li, blockquote, code, pre, hr, strong, em, a) | Prose element styling                  |
+
+Run `npx xds component <Name> --compact` to see a component's themeable slots.
+
+### The `as Theme['components']` cast
+
+The `components` field requires a type assertion because `ComponentStyles` is augmented by individual components via `declare module`. The theme package doesn't import those components, so the augmentations aren't visible at compile time. The cast is safe — types are enforced at the consumer site.
+
+## useXDSTheme Hook
+
+Access the current theme in any component:
+
+```tsx
+import {useXDSTheme} from '@xds/core';
+
+function MyComponent() {
+  const ctx = useXDSTheme();
+  // ctx.theme — the Theme object
+  // ctx.mode — 'system' | 'light' | 'dark'
+  return null;
+}
+```
+
+**Note:** This is read-only. To change the theme/mode, manage state at the app level and pass it to `<XDSTheme>`.

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -27,7 +27,8 @@ export function generateCompressedIndex(version) {
 |npx xds docs principles              Design rules, anti-patterns, StyleX patterns
 |npx xds docs tokens                  Token reference (spacing, color, radius, type)
 |npx xds swizzle <Name>               Copy component source for customization
-|npx xds theme <preset>               Apply theme (default, neutral)
+|npx xds theme                         Scaffold a custom theme (interactive)
+|npx xds theme --list                  List existing themes in the project
 |npx xds template <name> [path]       Scaffold page (blank, table, login)
 |npx xds swizzle <Name> --gap "<reason>"  Swizzle + file gap report
 |npx xds gap-report --component <Name> --category <cat> --reason "<why>"  File gap without swizzle

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -26,6 +26,7 @@ export function generateCompressedIndex(version) {
 |npx xds component --list             All components by category
 |npx xds docs principles              Design rules, anti-patterns, StyleX patterns
 |npx xds docs tokens                  Token reference (spacing, color, radius, type)
+|npx xds docs theme                   Theme system: XDSTheme, custom themes, overrides, nesting
 |npx xds swizzle <Name>               Copy component source for customization
 |npx xds theme                         Scaffold a custom theme (interactive)
 |npx xds theme --list                  List existing themes in the project

--- a/packages/cli/src/commands/docs.mjs
+++ b/packages/cli/src/commands/docs.mjs
@@ -14,6 +14,7 @@ const DOCS_DIR = path.join(CLI_ROOT, 'docs');
 const TOPICS = {
   principles: 'XDS design principles, rules, and anti-patterns',
   tokens: 'Full design token reference (spacing, colors, radius, typography)',
+  theme: 'Theme system: XDSTheme, custom themes, overrides, light/dark mode',
 };
 
 export function registerDocs(program) {

--- a/packages/cli/src/commands/theme.mjs
+++ b/packages/cli/src/commands/theme.mjs
@@ -1,36 +1,546 @@
 /**
- * @file theme command — Discover and apply XDS themes
+ * @file theme command — Scaffold and apply XDS themes
  *
- * Scans packages/core/src/theme/*Theme.stylex.ts for available themes.
- * Writes xds.config.mjs with the selected theme.
+ * Interactive wizard that generates a complete theme file with:
+ * - Preset selection (default, neutral, or custom brand)
+ * - Brand color configuration for custom themes
+ * - Component style override scaffolding
+ * - Setup instructions for XDSTheme provider
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as p from '@clack/prompts';
 import {findCoreDir} from '../utils/paths.mjs';
 
-/**
- * Discover available themes by scanning theme directory.
- * Returns array of {name, exportName} objects.
- */
-export function discoverThemes(coreDir) {
-  const themeDir = path.join(coreDir, 'src', 'theme');
-  if (!fs.existsSync(themeDir)) return [];
+function isCancel(value) {
+  if (p.isCancel(value)) {
+    p.cancel('Theme setup cancelled.');
+    process.exit(0);
+  }
+  return value;
+}
 
-  const files = fs.readdirSync(themeDir);
-  return files
-    .filter(f => f.endsWith('Theme.stylex.ts'))
-    .map(f => {
-      const exportName = f.replace('.stylex.ts', '');
-      const name = exportName.replace('Theme', '');
-      return {name, exportName};
+// =============================================================================
+// Color utilities
+// =============================================================================
+
+/**
+ * Parse a hex color to RGB components
+ */
+function hexToRgb(hex) {
+  const clean = hex.replace('#', '');
+  const r = parseInt(clean.slice(0, 2), 16);
+  const g = parseInt(clean.slice(2, 4), 16);
+  const b = parseInt(clean.slice(4, 6), 16);
+  return {r, g, b};
+}
+
+/**
+ * Convert RGB to hex
+ */
+function rgbToHex(r, g, b) {
+  const clamp = (v) => Math.max(0, Math.min(255, Math.round(v)));
+  return '#' + [r, g, b].map(v => clamp(v).toString(16).padStart(2, '0')).join('').toUpperCase();
+}
+
+/**
+ * Mix two hex colors
+ */
+function mixColors(hex1, hex2, weight = 0.5) {
+  const c1 = hexToRgb(hex1);
+  const c2 = hexToRgb(hex2);
+  return rgbToHex(
+    c1.r * (1 - weight) + c2.r * weight,
+    c1.g * (1 - weight) + c2.g * weight,
+    c1.b * (1 - weight) + c2.b * weight,
+  );
+}
+
+/**
+ * Add alpha to a hex color
+ */
+function withAlpha(hex, alpha) {
+  const alphaHex = Math.round(alpha * 255).toString(16).padStart(2, '0').toUpperCase();
+  return hex + alphaHex;
+}
+
+/**
+ * Derive a full color palette from a few key colors.
+ *
+ * @param {object} opts
+ * @param {string} opts.accent - Primary accent color (hex)
+ * @param {string} opts.positive - Success color (hex, optional)
+ * @param {string} opts.negative - Error color (hex, optional)
+ * @param {string} opts.warning - Warning color (hex, optional)
+ * @param {'light'|'dark'|'both'} opts.mode - Color mode
+ */
+function deriveColorPalette({accent, positive, negative, warning, mode}) {
+  positive = positive || '#0D8626';
+  negative = negative || '#E3193B';
+  warning = warning || '#E9AF08';
+
+  const accentRgb = hexToRgb(accent);
+  // Create a lighter version for dark mode accent
+  const accentLight = rgbToHex(
+    Math.min(255, accentRgb.r + 60),
+    Math.min(255, accentRgb.g + 60),
+    Math.min(255, accentRgb.b + 60),
+  );
+  const accentDark = accent;
+
+  // Derive accent text (darker in light, lighter in dark)
+  const accentTextLight = mixColors(accent, '#000000', 0.3);
+  const accentTextDark = mixColors(accent, '#FFFFFF', 0.4);
+
+  const ld = (light, dark) => {
+    if (mode === 'light') return light;
+    if (mode === 'dark') return dark;
+    return `light-dark(${light}, ${dark})`;
+  };
+
+  return {
+    // Core semantic
+    '--color-accent': ld(accentDark, accentLight),
+    '--color-accent-deemphasized': ld(withAlpha(accent, 0.2), withAlpha(accent, 0.25)),
+    '--color-accent-text': ld(accentTextLight, accentTextDark),
+    '--color-surface': ld('#FFFFFF', '#1F1F22'),
+    '--color-wash': ld('#F1F4F7', '#111112'),
+    '--color-overlay': ld('#01122866', '#11111299'),
+    '--color-hover-overlay': ld('#0536590C', '#FFFFFF0C'),
+    '--color-pressed-overlay': ld('#05365919', '#FFFFFF19'),
+    '--color-focus-outline': ld(accentTextLight, accentTextDark),
+    '--color-deemphasized': ld('#0536590C', '#1111127F'),
+
+    // Text
+    '--color-text-primary': ld('#0A1317', '#DFE2E5'),
+    '--color-text-secondary': ld('#4E606F', '#AAAFB5'),
+    '--color-text-disabled': ld('#A4B0BC', '#6F747C'),
+    '--color-text-link': ld(accentDark, accentLight),
+    '--color-text-placeholder': ld('#4E606F', '#AAAFB5'),
+    '--color-text-on-media': ld('#FFFFFF', '#FFFFFF'),
+
+    // Icon
+    '--color-icon-primary': ld('#0A1317', '#DFE2E5'),
+    '--color-icon-secondary': ld('#4E606F', '#AAAFB5'),
+    '--color-icon-tertiary': ld('#748695', '#8C939B'),
+    '--color-icon-disabled': ld('#A4B0BC', '#6F747C'),
+    '--color-icon-on-media': ld('#FFFFFF', '#FFFFFF'),
+
+    // Surface variants
+    '--color-card': ld('#FFFFFF', '#1F1F22'),
+    '--color-popover': ld('#FFFFFF', '#28292C'),
+    '--color-navbar': ld('#FFFFFF', '#1F1F22'),
+
+    // Status
+    '--color-positive': ld(positive, positive),
+    '--color-positive-deemphasized': ld(withAlpha(positive, 0.2), withAlpha(positive, 0.25)),
+    '--color-negative': ld(negative, mixColors(negative, '#FF6666', 0.3)),
+    '--color-negative-deemphasized': ld(withAlpha(negative, 0.2), withAlpha(negative, 0.25)),
+    '--color-warning': ld(warning, mixColors(warning, '#FFCC00', 0.3)),
+    '--color-warning-deemphasized': ld(withAlpha(warning, 0.2), withAlpha(warning, 0.25)),
+    '--color-educational': ld('#5B08D8', '#6B1EFD'),
+    '--color-educational-deemphasized': ld('#7952FF33', '#5B08D83F'),
+
+    // Divider
+    '--color-divider': ld('#05365919', '#F2F4F619'),
+    '--color-divider-high-contrast': ld('#647685', '#6F747C'),
+    '--color-divider-emphasized': ld('#CCD3DB', '#494D53'),
+
+    // Disabled/Effects
+    '--color-disabled-overlay': ld('#FFFFFF7F', '#1F1F227F'),
+    '--color-glimmer': ld('#CCD3DB', '#5A5E66'),
+    '--color-glimmer-high-contrast': ld('#A4B0BC', '#8C939B'),
+    '--color-shadow-elevation': ld('rgba(5, 54, 89, 0.1)', 'rgba(0, 0, 0, 0.3)'),
+    '--color-hover-tint': ld('black', 'white'),
+
+    // Literal color sets
+    '--color-blue-background': ld('#0171E333', '#0171E333'),
+    '--color-blue-border': ld('#0171E3', '#4BA9FE'),
+    '--color-blue-icon': ld('#0064E0', '#2694FE'),
+    '--color-blue-text': ld('#042F97', '#AFD7FF'),
+    '--color-cyan-background': ld('#00BCD433', '#00BCD433'),
+    '--color-cyan-border': ld('#00BCD4', '#4DD0E1'),
+    '--color-cyan-icon': ld('#00ACC1', '#26C6DA'),
+    '--color-cyan-text': ld('#006064', '#B2EBF2'),
+    '--color-gray-background': ld('#0A131733', '#666A724C'),
+    '--color-gray-border': ld('#647685', '#8C939B'),
+    '--color-gray-icon': ld('#4E606F', '#AAAFB5'),
+    '--color-gray-text': ld('#0A1317', '#E7EAED'),
+    '--color-green-background': ld('#24BB5E33', '#24BB5E33'),
+    '--color-green-border': ld('#24BB5E', '#4CD964'),
+    '--color-green-icon': ld('#0D8626', '#26A756'),
+    '--color-green-text': ld('#09441F', '#A5F690'),
+    '--color-orange-background': ld('#F2790233', '#F2790233'),
+    '--color-orange-border': ld('#F27902', '#FFA040'),
+    '--color-orange-icon': ld('#E9690B', '#FB8C00'),
+    '--color-orange-text': ld('#6B2203', '#FDB876'),
+    '--color-pink-background': ld('#E91E6333', '#E91E6333'),
+    '--color-pink-border': ld('#E91E63', '#F48FB1'),
+    '--color-pink-icon': ld('#C2185B', '#EC407A'),
+    '--color-pink-text': ld('#880E4F', '#F8BBD0'),
+    '--color-purple-background': ld('#7952FF33', '#7952FF33'),
+    '--color-purple-border': ld('#7952FF', '#9575CD'),
+    '--color-purple-icon': ld('#5B08D8', '#7952FF'),
+    '--color-purple-text': ld('#3E0697', '#B3B0FE'),
+    '--color-red-background': ld('#E3193B33', '#E3193B33'),
+    '--color-red-border': ld('#E3193B', '#F5394F'),
+    '--color-red-icon': ld('#D31130', '#E3193B'),
+    '--color-red-text': ld('#7B0210', '#FFB2B8'),
+    '--color-teal-background': ld('#0DB7AF33', '#0DB7AF33'),
+    '--color-teal-border': ld('#0DB7AF', '#4DB6AC'),
+    '--color-teal-icon': ld('#009688', '#26A69A'),
+    '--color-teal-text': ld('#083943', '#40DCCD'),
+    '--color-yellow-background': ld('#FFEB3B33', '#FFEB3B33'),
+    '--color-yellow-border': ld('#FFEB3B', '#FFF176'),
+    '--color-yellow-icon': ld('#FBC02D', '#FFEE58'),
+    '--color-yellow-text': ld('#753F07', '#FBCE03'),
+  };
+}
+
+// =============================================================================
+// Theme file generation
+// =============================================================================
+
+/**
+ * Generate the theme file content
+ */
+function generateThemeFile({name, exportName, colors, includeComponentOverrides, mode}) {
+  const modeComment = mode === 'both'
+    ? 'Uses CSS light-dark() for automatic light/dark mode switching.'
+    : mode === 'dark'
+      ? 'Designed for dark mode. Use with <XDSTheme mode="dark">.'
+      : 'Designed for light mode. Use with <XDSTheme mode="light">.';
+
+  const componentOverrideSection = includeComponentOverrides
+    ? `
+// =============================================================================
+// Component Style Overrides (optional)
+// =============================================================================
+// Uncomment and customize any section below.
+// Each component reads its overrides from theme.components.<name>.
+//
+// To discover what's themeable for a component, run:
+//   npx xds component <Name> --compact
+// and look for the "Theme Overrides" section.
+
+// --- Button ---
+// const buttonVariants = stylex.create({
+//   secondary: {
+//     backgroundColor: 'light-dark(rgba(0, 0, 0, 0.06), rgba(255, 255, 255, 0.1))',
+//   },
+// });
+
+// --- Card ---
+// const cardOverrides = stylex.create({
+//   container: {
+//     borderRadius: radiusVars['--radius-container'],
+//     // gradient border: set a gradient background + padding, inner content covers it
+//     // background: 'linear-gradient(135deg, ...)',
+//   },
+//   content: {
+//     backgroundColor: colorVars['--color-card'],
+//   },
+// });
+
+// --- Heading ---
+// const headingStyles = stylex.create({
+//   h1: {
+//     fontFamily: typographyVars['--font-heading'],
+//     fontSize: textSizeVars['--text-2xl'],
+//     fontWeight: fontWeightVars['--font-weight-semibold'],
+//     lineHeight: 1.2,
+//     color: colorVars['--color-text-primary'],
+//     margin: 0,
+//   },
+//   // h2, h3, h4, h5, h6...
+// });
+
+// --- Text ---
+// const textStyles = stylex.create({
+//   body: {
+//     fontFamily: typographyVars['--font-body'],
+//     fontSize: textSizeVars['--text-base'],
+//     fontWeight: fontWeightVars['--font-weight-normal'],
+//     lineHeight: lineHeightVars['--leading-base'],
+//     color: colorVars['--color-text-primary'],
+//     margin: 0,
+//   },
+//   // large, label, supporting, code...
+// });
+`
+    : '';
+
+  const componentsField = includeComponentOverrides
+    ? `  // Uncomment to apply component overrides:
+  // components: {
+  //   button: { variants: buttonVariants },
+  //   card: { container: cardOverrides.container, content: cardOverrides.content },
+  //   heading: { styles: headingStyles },
+  //   text: { styles: textStyles },
+  // } as Theme['components'],`
+    : '';
+
+  // Format colors as source code
+  const colorEntries = Object.entries(colors)
+    .map(([key, value]) => `  '${key}': '${value}',`)
+    .join('\n');
+
+  return `/**
+ * ${name} Theme
+ *
+ * ${modeComment}
+ *
+ * Generated by \`npx xds theme\`.
+ * Customize the values below, then import in your app.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import type {ThemeType as Theme} from '@xds/core/theme';
+import {
+  colorVars,
+  spacingVars,
+  sizeVars,
+  radiusVars,
+  elevationVars,
+  transitionVars,
+  typographyVars,
+  textSizeVars,
+  lineHeightVars,
+  fontWeightVars,
+} from '@xds/core/theme/tokens.stylex';
+import type {
+  BaseColorRaw,
+  BaseSpacingRaw,
+  BaseSizeRaw,
+  BaseRadiusRaw,
+  BaseElevationRaw,
+  BaseTransitionRaw,
+  BaseTypographyRaw,
+  BaseTextSizeRaw,
+  BaseLineHeightRaw,
+  BaseFontWeightRaw,
+} from '@xds/core/theme/tokens.stylex';
+
+// =============================================================================
+// Colors
+// =============================================================================
+// Edit these values to change your theme's color palette.
+// Use light-dark(lightValue, darkValue) for automatic light/dark support.
+
+const colorRaw = {
+${colorEntries}
+};
+
+// =============================================================================
+// Spacing, Size, Radius, Elevation, Transition, Typography
+// =============================================================================
+// These use XDS defaults. Override any values you want to customize.
+
+const spacingRaw = {
+  '--spacing-0': '0px',
+  '--spacing-0-5': '2px',
+  '--spacing-1': '4px',
+  '--spacing-2': '8px',
+  '--spacing-3': '12px',
+  '--spacing-4': '16px',
+  '--spacing-5': '20px',
+  '--spacing-6': '24px',
+  '--spacing-7': '28px',
+  '--spacing-8': '32px',
+  '--spacing-9': '36px',
+  '--spacing-10': '40px',
+  '--spacing-11': '44px',
+  '--spacing-12': '48px',
+};
+
+const sizeRaw = {
+  '--size-sm': '28px',
+  '--size-md': '32px',
+  '--size-lg': '36px',
+};
+
+const radiusRaw = {
+  '--radius-rounded': '9999px',
+  '--radius-container': '12px',
+  '--radius-element': '8px',
+  '--radius-content': '4px',
+  '--radius-inner': '0px',
+};
+
+const elevationRaw = {
+  '--elevation-base': '0px 0px 1px light-dark(rgba(0, 0, 0, 0.1), #111112)',
+  '--elevation-thumb': '0 1px 3px light-dark(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.4))',
+  '--elevation-dialog': '0px 2px 2px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 8px 24px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.3))',
+  '--elevation-hover': '0px 1px 2px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 2px 12px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2))',
+  '--elevation-menu': '0px 1px 1px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 2px 8px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2))',
+};
+
+const transitionRaw = {
+  '--transition-fast': '0.15s ease',
+  '--transition-normal': '0.2s ease',
+};
+
+const typographyRaw = {
+  '--font-body': '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+  '--font-code': '"SF Mono", Monaco, Consolas, monospace',
+  '--font-heading': '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+};
+
+const textSizeRaw = {
+  '--text-4xs': '0.5rem',
+  '--text-3xs': '0.625rem',
+  '--text-2xs': '0.6875rem',
+  '--text-xsm': '0.75rem',
+  '--text-sm': '0.8125rem',
+  '--text-base': '0.875rem',
+  '--text-lg': '1rem',
+  '--text-xl': '1.125rem',
+  '--text-2xl': '1.25rem',
+  '--text-3xl': '1.5rem',
+  '--text-4xl': '2rem',
+};
+
+const lineHeightRaw = {
+  '--leading-tight': '1.25',
+  '--leading-snug': '1.375',
+  '--leading-base': '1.4285714285714286',
+  '--leading-normal': '1.5',
+  '--leading-relaxed': '1.625',
+};
+
+const fontWeightRaw = {
+  '--font-weight-normal': '400',
+  '--font-weight-medium': '500',
+  '--font-weight-semibold': '600',
+  '--font-weight-bold': '700',
+};
+
+// =============================================================================
+// createTheme calls
+// =============================================================================
+
+const colorTheme = stylex.createTheme(colorVars, colorRaw as unknown as BaseColorRaw);
+const spacingTheme = stylex.createTheme(spacingVars, spacingRaw as unknown as BaseSpacingRaw);
+const sizeTheme = stylex.createTheme(sizeVars, sizeRaw as unknown as BaseSizeRaw);
+const radiusTheme = stylex.createTheme(radiusVars, radiusRaw as unknown as BaseRadiusRaw);
+const elevationTheme = stylex.createTheme(elevationVars, elevationRaw as unknown as BaseElevationRaw);
+const transitionTheme = stylex.createTheme(transitionVars, transitionRaw as unknown as BaseTransitionRaw);
+const typographyTheme = stylex.createTheme(typographyVars, typographyRaw as unknown as BaseTypographyRaw);
+const textSizeTheme = stylex.createTheme(textSizeVars, textSizeRaw as unknown as BaseTextSizeRaw);
+const lineHeightTheme = stylex.createTheme(lineHeightVars, lineHeightRaw as unknown as BaseLineHeightRaw);
+const fontWeightTheme = stylex.createTheme(fontWeightVars, fontWeightRaw as unknown as BaseFontWeightRaw);
+${componentOverrideSection}
+// =============================================================================
+// Theme Export
+// =============================================================================
+
+export const ${exportName}: Theme = {
+  name: '${name.toLowerCase().replace(/\s+/g, '-')}',
+  styles: {
+    colors: colorTheme,
+    spacing: spacingTheme,
+    size: sizeTheme,
+    radius: radiusTheme,
+    elevation: elevationTheme,
+    transition: transitionTheme,
+    typography: typographyTheme,
+    textSize: textSizeTheme,
+    lineHeight: lineHeightTheme,
+    fontWeight: fontWeightTheme,
+  },
+  raw: {
+    colors: colorRaw,
+    spacing: spacingRaw,
+    size: sizeRaw,
+    radius: radiusRaw,
+    elevation: elevationRaw,
+    transition: transitionRaw,
+    typography: typographyRaw,
+    textSize: textSizeRaw,
+    lineHeight: lineHeightRaw,
+    fontWeight: fontWeightRaw,
+  },
+${componentsField}
+};
+`;
+}
+
+/**
+ * Validate hex color input
+ */
+function isValidHex(value) {
+  return /^#?[0-9A-Fa-f]{6}$/.test(value);
+}
+
+function normalizeHex(value) {
+  const clean = value.replace('#', '');
+  return '#' + clean.toUpperCase();
+}
+
+// =============================================================================
+// Preset color palettes
+// =============================================================================
+
+const PRESETS = {
+  default: {
+    description: 'XDS branded — blue accent, system fonts',
+    accent: '#0064E0',
+  },
+  neutral: {
+    description: 'Grayscale — shadcn-inspired, minimal color',
+    accent: '#18181B',
+  },
+};
+
+// =============================================================================
+// Command registration
+// =============================================================================
+
+// Keep these exports for backwards compat with init.mjs
+export function discoverThemes(coreDir) {
+  // Check packages/theme/ (monorepo) and packages/core/src/theme/ (legacy)
+  const searchDirs = [
+    path.join(coreDir, '..', 'theme', 'src'),
+    path.join(coreDir, 'src', 'theme'),
+  ];
+
+  const themes = [];
+  for (const searchDir of searchDirs) {
+    if (!fs.existsSync(searchDir)) continue;
+
+    // Scan subdirectories for *Theme.stylex.ts
+    const entries = fs.readdirSync(searchDir, {withFileTypes: true});
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const dirPath = path.join(searchDir, entry.name);
+        const files = fs.readdirSync(dirPath);
+        for (const f of files) {
+          if (f.endsWith('Theme.stylex.ts')) {
+            const exportName = f.replace('.stylex.ts', '');
+            const name = exportName.replace('Theme', '');
+            themes.push({name, exportName});
+          }
+        }
+      } else if (entry.name.endsWith('Theme.stylex.ts')) {
+        const exportName = entry.name.replace('.stylex.ts', '');
+        const name = exportName.replace('Theme', '');
+        themes.push({name, exportName});
+      }
+    }
+  }
+
+  // Deduplicate by name
+  const seen = new Set();
+  return themes
+    .filter(t => {
+      if (seen.has(t.name)) return false;
+      seen.add(t.name);
+      return true;
     })
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
-/**
- * Write xds.config.mjs with the selected theme.
- */
 export function writeThemeConfig(targetDir, themeExportName) {
   const configPath = path.join(targetDir, 'xds.config.mjs');
   const content = `/**
@@ -48,51 +558,260 @@ export default {
 export function registerTheme(program) {
   program
     .command('theme [preset]')
-    .description('Apply a prebuilt XDS theme')
-    .option('--list', 'List available themes')
-    .action((preset, options) => {
-      const coreDir = findCoreDir(process.cwd());
-
-      if (!coreDir) {
-        console.error(
-          'Error: Could not find @xds/core package.\n' +
-            'Make sure you are inside the XDS monorepo or have @xds/core installed.',
-        );
-        process.exit(1);
-      }
-
-      const themes = discoverThemes(coreDir);
-
-      if (themes.length === 0) {
-        console.error('Error: No themes found in packages/core/src/theme/');
-        process.exit(1);
-      }
-
-      if (options.list || !preset) {
-        console.log('\nAvailable themes:\n');
-        for (const theme of themes) {
-          const label = theme.name === 'default' ? ' (default)' : '';
-          console.log(`  ${theme.name}${label} — import { ${theme.exportName} } from '@xds/core/theme'`);
+    .description('Scaffold a custom XDS theme')
+    .option('--list', 'List existing themes in this project')
+    .option('--output <path>', 'Output file path', './src/theme/customTheme.stylex.ts')
+    .action(async (preset, options) => {
+      // Non-interactive: --list
+      if (options.list) {
+        const coreDir = findCoreDir(process.cwd());
+        if (!coreDir) {
+          console.error('Error: Could not find @xds/core package.');
+          process.exit(1);
         }
-        console.log('\nUsage: xds theme <name>\n');
+
+        const themes = discoverThemes(coreDir);
+        if (themes.length === 0) {
+          console.log('\nNo themes found. Run `npx xds theme` to create one.\n');
+        } else {
+          console.log('\nExisting themes:\n');
+          for (const theme of themes) {
+            console.log(`  ${theme.name} — import { ${theme.exportName} } from '@xds/theme/${theme.name}'`);
+          }
+          console.log('');
+        }
         return;
       }
 
-      const theme = themes.find(t => t.name === preset);
+      // Non-interactive: preset name provided directly
+      if (preset && PRESETS[preset]) {
+        const colors = deriveColorPalette({
+          accent: PRESETS[preset].accent,
+          mode: 'both',
+        });
+        const exportName = `${preset}Theme`;
+        const content = generateThemeFile({
+          name: preset.charAt(0).toUpperCase() + preset.slice(1),
+          exportName,
+          colors,
+          includeComponentOverrides: false,
+          mode: 'both',
+        });
 
-      if (!theme) {
-        console.error(`Error: Unknown theme "${preset}".`);
-        console.error(`Available: ${themes.map(t => t.name).join(', ')}`);
-        process.exit(1);
+        const outputPath = path.resolve(process.cwd(), options.output);
+        fs.mkdirSync(path.dirname(outputPath), {recursive: true});
+        fs.writeFileSync(outputPath, content);
+
+        console.log(`\n✓ Generated ${path.relative(process.cwd(), outputPath)}\n`);
+        printSetupInstructions(outputPath, exportName);
+        return;
       }
 
-      const configPath = writeThemeConfig(process.cwd(), theme.exportName);
-      console.log(`\n✓ Wrote ${path.relative(process.cwd(), configPath)}\n`);
-      console.log('Add the theme provider to your root layout:\n');
-      console.log(`  import { XDSTheme, ${theme.exportName} } from '@xds/core/theme';`);
-      console.log('');
-      console.log('  <XDSTheme theme={' + theme.exportName + '}>');
-      console.log('    {children}');
-      console.log('  </XDSTheme>\n');
+      // =====================================================================
+      // Interactive mode
+      // =====================================================================
+      p.intro('XDS Theme Scaffold');
+
+      // Step 1: Choose starting point
+      const startingPoint = isCancel(
+        await p.select({
+          message: 'How would you like to start?',
+          options: [
+            {value: 'brand', label: 'Custom brand', hint: 'Pick your accent color, we derive the rest'},
+            {value: 'default', label: 'Copy Default theme', hint: 'Blue accent, full light/dark support'},
+            {value: 'neutral', label: 'Copy Neutral theme', hint: 'Grayscale, shadcn-inspired'},
+            {value: 'minimal', label: 'Minimal scaffold', hint: 'Just the structure, you fill in colors'},
+          ],
+        }),
+      );
+
+      let colors;
+      let themeName;
+      let mode = 'both';
+
+      if (startingPoint === 'brand') {
+        // Step 2a: Brand color
+        const accentInput = isCancel(
+          await p.text({
+            message: 'Accent color (hex)',
+            placeholder: '#7B61FF',
+            initialValue: '#7B61FF',
+            validate: (value) => {
+              if (!isValidHex(value)) return 'Enter a valid hex color (e.g., #7B61FF)';
+            },
+          }),
+        );
+        const accent = normalizeHex(accentInput);
+
+        // Step 2b: Color mode
+        mode = isCancel(
+          await p.select({
+            message: 'Color mode',
+            options: [
+              {value: 'both', label: 'Light + Dark', hint: 'Automatic via light-dark() — recommended'},
+              {value: 'light', label: 'Light only'},
+              {value: 'dark', label: 'Dark only'},
+            ],
+          }),
+        );
+
+        // Step 2c: Status colors
+        const customizeStatus = isCancel(
+          await p.confirm({
+            message: 'Customize status colors (positive/negative/warning)?',
+            initialValue: false,
+          }),
+        );
+
+        let positive, negative, warning;
+        if (customizeStatus) {
+          positive = normalizeHex(isCancel(
+            await p.text({
+              message: 'Positive/success color',
+              placeholder: '#0D8626',
+              initialValue: '#0D8626',
+              validate: (v) => { if (!isValidHex(v)) return 'Enter a valid hex color'; },
+            }),
+          ));
+          negative = normalizeHex(isCancel(
+            await p.text({
+              message: 'Negative/error color',
+              placeholder: '#E3193B',
+              initialValue: '#E3193B',
+              validate: (v) => { if (!isValidHex(v)) return 'Enter a valid hex color'; },
+            }),
+          ));
+          warning = normalizeHex(isCancel(
+            await p.text({
+              message: 'Warning color',
+              placeholder: '#E9AF08',
+              initialValue: '#E9AF08',
+              validate: (v) => { if (!isValidHex(v)) return 'Enter a valid hex color'; },
+            }),
+          ));
+        }
+
+        colors = deriveColorPalette({accent, positive, negative, warning, mode});
+
+        // Step 2d: Theme name
+        themeName = isCancel(
+          await p.text({
+            message: 'Theme name',
+            placeholder: 'myBrand',
+            initialValue: 'myBrand',
+            validate: (v) => {
+              if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(v)) return 'Use camelCase, letters and numbers only';
+            },
+          }),
+        );
+
+      } else if (startingPoint === 'default' || startingPoint === 'neutral') {
+        colors = deriveColorPalette({
+          accent: PRESETS[startingPoint].accent,
+          mode: 'both',
+        });
+        themeName = isCancel(
+          await p.text({
+            message: 'Theme name',
+            placeholder: `my${startingPoint.charAt(0).toUpperCase() + startingPoint.slice(1)}`,
+            initialValue: `my${startingPoint.charAt(0).toUpperCase() + startingPoint.slice(1)}`,
+            validate: (v) => {
+              if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(v)) return 'Use camelCase, letters and numbers only';
+            },
+          }),
+        );
+      } else {
+        // Minimal — use default colors as placeholder
+        colors = deriveColorPalette({accent: '#0064E0', mode: 'both'});
+        themeName = isCancel(
+          await p.text({
+            message: 'Theme name',
+            placeholder: 'myTheme',
+            initialValue: 'myTheme',
+            validate: (v) => {
+              if (!/^[a-zA-Z][a-zA-Z0-9]*$/.test(v)) return 'Use camelCase, letters and numbers only';
+            },
+          }),
+        );
+      }
+
+      // Step 3: Component overrides
+      const includeComponentOverrides = isCancel(
+        await p.confirm({
+          message: 'Include component style override scaffolding?',
+          initialValue: true,
+        }),
+      );
+
+      // Step 4: Output path
+      const exportName = `${themeName}Theme`;
+      const defaultOutput = `./src/theme/${themeName}Theme.stylex.ts`;
+      const outputPath = isCancel(
+        await p.text({
+          message: 'Output path',
+          placeholder: defaultOutput,
+          initialValue: defaultOutput,
+        }),
+      );
+
+      // Generate and write
+      const content = generateThemeFile({
+        name: themeName.charAt(0).toUpperCase() + themeName.slice(1),
+        exportName,
+        colors,
+        includeComponentOverrides,
+        mode,
+      });
+
+      const resolvedPath = path.resolve(process.cwd(), outputPath);
+      fs.mkdirSync(path.dirname(resolvedPath), {recursive: true});
+      fs.writeFileSync(resolvedPath, content);
+
+      p.log.success(`Generated ${path.relative(process.cwd(), resolvedPath)}`);
+
+      // Step 5: Setup instructions
+      const modeAttr = mode === 'dark' ? ' mode="dark"' : mode === 'light' ? ' mode="light"' : '';
+
+      p.note(
+        `import {XDSTheme} from '@xds/core';\n` +
+        `import {${exportName}} from './${path.relative(path.resolve(process.cwd(), 'src'), resolvedPath).replace('.stylex.ts', '')}';\n` +
+        `\n` +
+        `<XDSTheme theme={${exportName}}${modeAttr}>\n` +
+        `  <App />\n` +
+        `</XDSTheme>`,
+        'Add to your root layout',
+      );
+
+      if (mode !== 'both') {
+        p.log.info(
+          `Your theme is ${mode}-mode only. Make sure to set mode="${mode}" on XDSTheme.`,
+        );
+      }
+
+      p.note(
+        'Edit the colorRaw object to change colors.\n' +
+        'Edit spacingRaw, radiusRaw, etc. to customize other tokens.\n' +
+        (includeComponentOverrides
+          ? 'Uncomment sections in "Component Style Overrides" to customize components.\n'
+          : 'Run `npx xds theme` again with component overrides to customize components.\n') +
+        '\nRun `npx xds docs tokens` to see all available tokens.',
+        'Next steps',
+      );
+
+      p.outro('Theme ready!');
     });
+}
+
+/**
+ * Print setup instructions (non-interactive mode)
+ */
+function printSetupInstructions(outputPath, exportName) {
+  const relPath = path.relative(process.cwd(), outputPath).replace('.stylex.ts', '');
+  console.log('Add to your root layout:\n');
+  console.log(`  import {XDSTheme} from '@xds/core';`);
+  console.log(`  import {${exportName}} from './${relPath}';`);
+  console.log('');
+  console.log(`  <XDSTheme theme={${exportName}}>`);
+  console.log('    <App />');
+  console.log('  </XDSTheme>\n');
 }

--- a/packages/cli/src/commands/theme.test.mjs
+++ b/packages/cli/src/commands/theme.test.mjs
@@ -15,22 +15,56 @@ afterEach(() => {
 });
 
 describe('discoverThemes', () => {
-  it('discovers *Theme.stylex.ts files and returns sorted array', () => {
-    const themeDir = path.join(tmpDir, 'src', 'theme');
-    fs.mkdirSync(themeDir, {recursive: true});
-    fs.writeFileSync(path.join(themeDir, 'neutralTheme.stylex.ts'), '');
-    fs.writeFileSync(path.join(themeDir, 'defaultTheme.stylex.ts'), '');
-    fs.writeFileSync(path.join(themeDir, 'tokens.stylex.ts'), ''); // not a theme file
-    fs.writeFileSync(path.join(themeDir, 'utils.ts'), ''); // not a theme file
+  it('discovers *Theme.stylex.ts files in packages/theme/src/', () => {
+    // Simulate monorepo structure: coreDir = packages/core
+    // themes at packages/theme/src/default/defaultTheme.stylex.ts
+    const coreDir = path.join(tmpDir, 'packages', 'core');
+    const themeDir = path.join(tmpDir, 'packages', 'theme', 'src');
+    const defaultDir = path.join(themeDir, 'default');
+    const neutralDir = path.join(themeDir, 'neutral');
 
-    const result = discoverThemes(tmpDir);
+    fs.mkdirSync(coreDir, {recursive: true});
+    fs.mkdirSync(defaultDir, {recursive: true});
+    fs.mkdirSync(neutralDir, {recursive: true});
+    fs.writeFileSync(path.join(defaultDir, 'defaultTheme.stylex.ts'), '');
+    fs.writeFileSync(path.join(neutralDir, 'neutralTheme.stylex.ts'), '');
+
+    const result = discoverThemes(coreDir);
     expect(result).toEqual([
       {name: 'default', exportName: 'defaultTheme'},
       {name: 'neutral', exportName: 'neutralTheme'},
     ]);
   });
 
-  it('returns empty array when theme dir is missing', () => {
+  it('discovers *Theme.stylex.ts files in legacy location (core/src/theme/)', () => {
+    const coreDir = tmpDir;
+    const themeDir = path.join(coreDir, 'src', 'theme');
+    fs.mkdirSync(themeDir, {recursive: true});
+    fs.writeFileSync(path.join(themeDir, 'defaultTheme.stylex.ts'), '');
+    fs.writeFileSync(path.join(themeDir, 'tokens.stylex.ts'), ''); // not a theme
+
+    const result = discoverThemes(coreDir);
+    expect(result).toEqual([
+      {name: 'default', exportName: 'defaultTheme'},
+    ]);
+  });
+
+  it('deduplicates themes found in both locations', () => {
+    const coreDir = path.join(tmpDir, 'packages', 'core');
+    const legacyDir = path.join(coreDir, 'src', 'theme');
+    const newDir = path.join(tmpDir, 'packages', 'theme', 'src', 'default');
+
+    fs.mkdirSync(legacyDir, {recursive: true});
+    fs.mkdirSync(newDir, {recursive: true});
+    fs.writeFileSync(path.join(legacyDir, 'defaultTheme.stylex.ts'), '');
+    fs.writeFileSync(path.join(newDir, 'defaultTheme.stylex.ts'), '');
+
+    const result = discoverThemes(coreDir);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('default');
+  });
+
+  it('returns empty array when no theme dirs exist', () => {
     expect(discoverThemes(tmpDir)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Rewrites `npx xds theme` from a broken theme-discovery command into an interactive scaffold that generates complete, customizable theme files. Adds `npx xds docs theme` with comprehensive theme system documentation. Also adds theme-customization prompts to the vibe test harness based on #155 friction points.

## Theme CLI

The old `theme` command scanned `packages/core/src/theme/` for theme files — but themes live in `packages/theme/src/`. It always errored with "No themes found."

The new command is an interactive scaffold that generates a complete `.stylex.ts` theme file.

### `npx xds theme --list`

```
Existing themes:

  default — import { defaultTheme } from '@xds/theme/default'
  neutral — import { neutralTheme } from '@xds/theme/neutral'
```

### `npx xds theme --help`

```
Usage: xds theme [options] [preset]

Scaffold a custom XDS theme

Options:
  --list           List existing themes in this project
  --output <path>  Output file path (default:
                   "./src/theme/customTheme.stylex.ts")
  -h, --help       display help for command
```

### Non-interactive: `npx xds theme default`

```
✓ Generated src/theme/customTheme.stylex.ts

Add to your root layout:

  import {XDSTheme} from '@xds/core';
  import {defaultTheme} from './src/theme/customTheme';

  <XDSTheme theme={defaultTheme}>
    <App />
  </XDSTheme>
```

### Interactive mode: `npx xds theme`

Walks through:
1. **Starting point** — Custom brand / Copy Default / Copy Neutral / Minimal
2. **Accent color** — hex input with validation
3. **Color mode** — Light+Dark (light-dark()) / Light only / Dark only
4. **Status colors** — optional positive/negative/warning overrides
5. **Component overrides** — optional scaffold with commented examples for button, card, heading, text
6. **Output path** — where to write the file
7. **Setup instructions** — XDSTheme provider code

### Generated file

The output is a complete, self-contained theme file with:
- All ~60 color tokens derived from the accent color
- All spacing, size, radius, elevation, transition, typography tokens (XDS defaults)
- All `createTheme()` calls with correct type casts
- Optional component override scaffolding (commented out with examples)
- Proper imports from `@xds/core/theme/tokens.stylex`

## Theme Docs (`npx xds docs theme`)

New reference doc covering:
- XDSTheme provider setup and props
- Creating custom themes (scaffold CLI + manual `createTheme` pattern)
- Light/dark mode (automatic `light-dark()`, toggle button, single-mode)
- Nesting themes (dark sidebar pattern)
- Page background (`display: contents` workaround)
- Component style overrides (`declare module` pattern, available slots)
- `useXDSTheme` hook

### Tests

```
$ npx vitest run packages/cli/

 ✓ packages/cli/src/commands/template.test.mjs (3 tests)
 ✓ packages/cli/src/utils/paths.test.mjs (7 tests)
 ✓ packages/cli/src/commands/docs.test.mjs (2 tests)
 ✓ packages/cli/src/commands/swizzle.test.mjs (6 tests)
 ✓ packages/cli/src/commands/agent-docs.test.mjs (7 tests)
 ✓ packages/cli/src/commands/component.test.mjs (31 tests)
 ✓ packages/cli/src/commands/theme.test.mjs (5 tests)

 Test Files  7 passed (7)
      Tests  61 passed (61)
```

## Vibe Tests

Added 8 `theme-customization` prompts + 2 holdout prompts to `test-sets/default.json`, based on friction points from #155:

| ID | Prompt | Complexity | Tests |
|----|--------|-----------|-------|
| tc-1 | Dark mode toggle | simple | XDSTheme mode prop |
| tc-2 | Custom brand theme (purple accent) | moderate | createTheme pattern |
| tc-3 | Wash background not applying | simple | display:contents gap |
| tc-4 | Theme switcher (3 themes) | complex | Multiple theme objects |
| tc-5 | Component-level style overrides | moderate | declare module pattern |
| tc-6 | Settings page with live controls | complex | Dynamic theme generation |
| tc-7 | Nested themes (dark sidebar) | moderate | Nested XDSTheme providers |
| tc-8 | Brutalist theme | moderate | Full token customization |

### Vibe test results (5 prompts, with `npx xds docs theme`)

```
$ yarn workspace @xds/vibe-tests aggregate --iteration b97cd692

📊 Vibe Test Results - Iteration b97cd692
==================================================

Overall: 100% success (5/5)

🏆 Quality Tiers:
  🥇 Gold (pure DS):       3 (60%)
  🟢 Green (acceptable):  2 (40%)
  🟡 Yellow (anti-pattern): 0 (0%)
  🔴 Red (critical):      0 (0%)

By Category:
  theme-customization       100% (5/5) [🥇3 🟢2 🟡0 🔴0]

⏱️  Performance:
  Total time: 441.1s (avg 88.2s per test)

✓ Acceptable Escape Hatches:
  - supplemental_css: 3
```

### Before/after comparison: theme docs impact

Ran the same 5 prompts before and after adding `npx xds docs theme`:

| Metric | Before (c27d200d) | After (b97cd692) | Change |
|--------|-------------------|-------------------|--------|
| Success rate | 100% | 100% | — |
| Gold tier | 3 | 3 | — |
| Green tier | 2 | 2 | — |
| Docs read (total) | 41 | 26 | ⬇️ 37% |
| Source file reads | 13 | 3 | ⬇️ 77% |
| Total time | 608s | 441s | ⬇️ 27% |
| Input tokens (est.) | 20,740 | 13,240 | ⬇️ 36% |

Key findings:
- **Same quality, much more efficient** — agents reached the same correct answers while reading far fewer docs
- **77% fewer source file reads** — the theme docs eliminated most source-diving. tc-2 (custom brand theme) dropped from 11 docs + 6 source reads to 4 docs + 1 source read
- **All 5 agents used `npx xds docs theme`** as their primary reference for theming tasks
- **tc-5 (component overrides)**: Found the `declare module` + gradient border pattern directly from the theme docs instead of reverse-engineering from source
- **tc-3 (wash background)**: Found the `display: contents` workaround from the "Page Background" section

### Full 8-prompt run (iteration e3ce5e6d)

```
$ yarn workspace @xds/vibe-tests aggregate --iteration e3ce5e6d

📊 Vibe Test Results - Iteration e3ce5e6d
==================================================

Overall: 100% success (8/8)

🏆 Quality Tiers:
  🥇 Gold (pure DS):       5 (63%)
  🟢 Green (acceptable):  1 (13%)
  🟡 Yellow (anti-pattern): 2 (25%)
  🔴 Red (critical):      0 (0%)

By Category:
  theme-customization       100% (8/8) [🥇5 🟢1 🟡2 🔴0]
```

Relates to #155

---
*Crafted with care by Navi*