### PR TITLE
docs(Button): add icon-only button examples and guidance

### DIFF
--- a/packages/core/src/Button/README.md
+++ b/packages/core/src/Button/README.md
@@ -28,7 +28,29 @@ import { XDSButton } from '@xds/core/Button';
 
 // Destructive action
 <XDSButton label="Delete" variant="destructive" />
+
+// Icon-only button (renders as a square)
+// Pass `icon` without `children` — `label` becomes the aria-label
+<XDSButton label="Settings" icon={<GearIcon />} variant="ghost" />
+
+// Icon-only with emoji or text content
+<XDSButton label="Select rocket emoji" icon={<span>🚀</span>} variant="ghost" size="sm" />
+
+// Icon + visible label (pass children to show text alongside icon)
+<XDSButton label="Edit" icon={<PencilIcon />}>Edit</XDSButton>
 ```
+
+### Icon-Only Buttons
+
+When `icon` is provided without `children`, the button becomes **icon-only**:
+
+- Renders as a perfect square (`aspectRatio: 1/1`)
+- `label` is used as `aria-label` for accessibility (not rendered visually)
+- Works with any `ReactNode` as the icon — SVG components, emoji, or text
+
+Use icon-only buttons for toolbars, action grids, compact controls, and anywhere
+you need a small clickable element. Always prefer `XDSButton` over `<div onClick>`
+or `<span onClick>` for accessibility (keyboard navigation, focus management, screen readers).
 
 ## Props
 

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -256,7 +256,13 @@ const loadingStyles = stylex.create({
  * <XDSButton label="Click me" />
  * <XDSButton label="Primary action" variant="primary" />
  * <XDSButton label="Delete" variant="destructive" />
- * <XDSButton label="Settings" icon={<GearIcon />} />
+ *
+ * // Icon-only (square) — pass icon without children
+ * <XDSButton label="Settings" icon={<GearIcon />} variant="ghost" />
+ * <XDSButton label="Pick emoji" icon={<span>🚀</span>} variant="ghost" size="sm" />
+ *
+ * // Icon + visible label
+ * <XDSButton label="Edit" icon={<PencilIcon />}>Edit</XDSButton>
  * ```
  */
 export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(

--- a/packages/core/src/Grid/README.md
+++ b/packages/core/src/Grid/README.md
@@ -35,4 +35,14 @@ import {XDSGrid, XDSGridSpan} from '@xds/core/Grid';
   <XDSGridSpan span={2}>Wide item</XDSGridSpan>
   <div>Normal item</div>
 </XDSGrid>
+
+// Dense grid (e.g. color swatches, icon grids, compact controls)
+<XDSGrid columns={6} gap="space2">
+  {items.map(item => (
+    <XDSButton key={item.id} label={item.label} icon={item.icon} variant="ghost" size="sm" />
+  ))}
+</XDSGrid>
 ```
+
+Use `XDSGrid` for any grid layout instead of manual CSS grid (`display: 'grid'`,
+`gridTemplateColumns`). It handles gap tokens and works with any column count.


### PR DESCRIPTION
## Summary

Documents the icon-only button pattern, which was missing from the README and only briefly mentioned in the prop description.

## Problem

In [vibe test #226](https://github.com/facebookexperimental/xds/issues/226), the `cwm-3` prompt (Notion-style page header with emoji picker) produced code that used `<div onClick>` for each emoji in the picker grid instead of `XDSButton`. The LLM imported `XDSButton` and used it elsewhere in the component, but didn't realize it could pass `icon` without `children` to get a square icon-only button.

The existing docs had no examples of icon-only buttons — only `<XDSButton label="Settings" icon={<GearIcon />} />` in the JSDoc, which looks like icon-with-label.

## Changes

- Added icon-only usage examples to README (SVG icons, emoji, text)
- Added icon + visible label example
- Added dedicated "Icon-Only Buttons" section explaining the square behavior
- Added guidance to prefer XDSButton over `<div onClick>` for accessibility
- Updated JSDoc examples in XDSButton.tsx

## Evidence

Vibe test `cwm-3` generated this:
```tsx
// ❌ What the LLM did — <div onClick> with manual hover styles
<div {...stylex.props(styles.iconBtn)} onClick={() => setIcon(e)}>{e}</div>

// ✅ What it should have done — icon-only XDSButton
<XDSButton label={`Select ${e}`} icon={<span>{e}</span>} variant="ghost" size="sm" onClick={() => setIcon(e)} />
```

---
*Crafted with care by Navi*