### PR TITLE
feat(Icon): icon registry with semantic names and theme support

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -6,6 +6,18 @@ const rootDir = path.resolve(__dirname, '../../..');
 const coreRoot = path.resolve(__dirname, '../../../packages/core/src');
 const themeRoot = path.resolve(__dirname, '../../../packages/theme/src');
 
+/**
+ * Browser targets for lightningcss.
+ * Prevents lowering native light-dark() into --lightningcss-light/--lightningcss-dark
+ * polyfill variables. XDS tokens use native light-dark() which is baseline 2024:
+ * Chrome 123+, Firefox 120+, Safari 17.5+
+ */
+const lightningcssTargets = {
+  chrome: 123 << 16,
+  firefox: 120 << 16,
+  safari: (17 << 16) | (5 << 8),
+};
+
 const config: StorybookConfig = {
   stories: [
     '../stories/**/*.mdx',
@@ -55,6 +67,18 @@ const config: StorybookConfig = {
             type: 'commonJS',
             rootDir: rootDir,
           },
+          // The StyleX unplugin runs its own internal lightningcss transform
+          // with default targets of browserslist('>= 1%') which includes
+          // Chrome 112 — a browser that doesn't support light-dark().
+          // This causes light-dark() token values to be lowered into
+          // --lightningcss-light/--lightningcss-dark polyfill variables,
+          // which only work when a StyleX color-scheme class is applied.
+          // Without XDSTheme (e.g. "none" theme in Storybook, or consumers
+          // using @xds/core without a theme), the polyfill vars are undefined
+          // and colors break. Setting targets here keeps light-dark() native.
+          lightningcssOptions: {
+            targets: lightningcssTargets,
+          },
         }),
       ],
       resolve: {
@@ -66,17 +90,11 @@ const config: StorybookConfig = {
         },
       },
       css: {
-        // Prevent LightningCSS from lowering light-dark() into
-        // --lightningcss-light/--lightningcss-dark polyfill variables.
-        // XDS tokens use native light-dark() which is baseline 2024:
-        // Chrome 123+, Firefox 120+, Safari 17.5+
+        // Also set Vite's own CSS transformer targets to match, so any
+        // non-StyleX CSS (e.g. manual .css imports) also preserves light-dark().
         transformer: 'lightningcss',
         lightningcss: {
-          targets: {
-            chrome: 123 << 16,
-            firefox: 120 << 16,
-            safari: (17 << 16) | (5 << 8),
-          },
+          targets: lightningcssTargets,
         },
       },
     };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -154,7 +154,6 @@
     "esbuild-plugin-babel": "^0.2.3"
   },
   "dependencies": {
-    "@heroicons/react": "^2.2.0",
     "@stylexjs/stylex": "^0.17.4"
   }
 }

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -23,7 +23,7 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '../Button';
-import {ChevronLeftIcon, ChevronRightIcon} from '@heroicons/react/24/outline';
+import {XDSIcon} from '../Icon';
 import {useGridFocus} from '../hooks';
 import {
   useCalendarDays,
@@ -362,7 +362,7 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
           <XDSButton
             label="Previous month"
             variant="ghost"
-            icon={<ChevronLeftIcon {...stylex.props(calendarStyles.navIcon)} />}
+            icon={<XDSIcon icon="chevronLeft" size="sm" color="inherit" />}
             onClick={() => navigateMonth(-1)}
           />
 
@@ -373,9 +373,7 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
           <XDSButton
             label="Next month"
             variant="ghost"
-            icon={
-              <ChevronRightIcon {...stylex.props(calendarStyles.navIcon)} />
-            }
+            icon={<XDSIcon icon="chevronRight" size="sm" color="inherit" />}
             onClick={() => navigateMonth(1)}
           />
         </div>

--- a/packages/core/src/CloseButton/XDSCloseButton.tsx
+++ b/packages/core/src/CloseButton/XDSCloseButton.tsx
@@ -11,11 +11,11 @@
  * - /apps/storybook/stories/CloseButton.stories.tsx (storybook stories)
  */
 
-import {forwardRef, useContext, type ButtonHTMLAttributes} from 'react';
-import {XMarkIcon} from '@heroicons/react/24/outline';
+'use client';
+
+import {forwardRef, type ButtonHTMLAttributes} from 'react';
 import {XDSButton, type XDSButtonSize} from '../Button';
-import {XDSIcon, type XDSIconType, type XDSIconSize} from '../Icon';
-import {ThemeContext} from '../theme/ThemeContext';
+import {XDSIcon, type XDSIconSize} from '../Icon';
 
 // =============================================================================
 // Types
@@ -29,19 +29,6 @@ const buttonSizeToIconSize: Record<XDSCloseButtonSize, XDSIconSize> = {
   md: 'md',
   lg: 'lg',
 };
-
-// =============================================================================
-// Module Augmentation - Register CloseButton config with ComponentStyles
-// =============================================================================
-
-declare module '../theme/types' {
-  interface ComponentStyles {
-    closeButton?: {
-      /** Custom icon component to use instead of the default XMarkIcon */
-      icon?: XDSIconType;
-    };
-  }
-}
 
 export interface XDSCloseButtonProps extends Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
@@ -69,10 +56,10 @@ export interface XDSCloseButtonProps extends Omit<
 // =============================================================================
 
 /**
- * A close button component with a configurable icon.
+ * A close button component.
  *
- * The icon can be customized via the theme's `components.closeButton.icon` setting.
- * Defaults to the Heroicons XMarkIcon (outline).
+ * The close icon is provided by the theme's icon registry.
+ * Falls back to a built-in lightweight SVG when no theme is present.
  *
  * @example
  * ```tsx
@@ -84,11 +71,6 @@ export const XDSCloseButton = forwardRef<
   HTMLButtonElement,
   XDSCloseButtonProps
 >(({size = 'md', label = 'Close', isDisabled, ...props}, ref) => {
-  // Get theme context for custom icon
-  const themeContext = useContext(ThemeContext);
-  const IconComponent =
-    themeContext?.theme.components?.closeButton?.icon ?? XMarkIcon;
-
   const iconSize = buttonSizeToIconSize[size];
 
   return (
@@ -100,7 +82,7 @@ export const XDSCloseButton = forwardRef<
       label={label}
       tooltip={label}
       isDisabled={isDisabled}
-      icon={<XDSIcon icon={IconComponent} size={iconSize} color="inherit" />}
+      icon={<XDSIcon icon="close" size={iconSize} color="inherit" />}
       {...props}
     />
   );

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -21,12 +21,7 @@ import {
   useMemo,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {CalendarDaysIcon} from '@heroicons/react/24/outline';
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-} from '@heroicons/react/24/solid';
+import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   sizeVars,
@@ -312,10 +307,10 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
     const calendarRef = useRef<XDSCalendarHandle | null>(null);
 
     // Status icon mapping
-    const statusIconMap: Record<XDSInputStatusType, typeof CalendarDaysIcon> = {
-      warning: ExclamationTriangleIcon,
-      error: XCircleIcon,
-      success: CheckCircleIcon,
+    const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+      warning: 'warning',
+      error: 'xCircle',
+      success: 'checkCircle',
     };
 
     const statusIconColorMap: Record<
@@ -494,7 +489,7 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
               styles.iconButton,
               isDisabled && styles.iconButtonDisabled,
             )}>
-            <XDSIcon icon={CalendarDaysIcon} size="sm" color="secondary" />
+            <XDSIcon icon="calendar" size="sm" color="secondary" />
           </button>
           <input
             ref={setRefs}

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -25,7 +25,7 @@ import {useXDSLayer} from '../Layer/useXDSLayer';
 import {XDSButton, type XDSButtonProps} from '../Button';
 import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
-import {ChevronDownIcon} from '@heroicons/react/16/solid';
+
 import {XDSDivider} from '../Divider';
 import {XDSDropdownMenuItem} from './XDSDropdownMenuItem';
 import {
@@ -571,7 +571,7 @@ export function XDSDropdownMenu({
   // Build chevron icon - inherits color from button text
   const chevronIcon = (
     <span {...stylex.props(styles.chevronIcon)}>
-      <XDSIcon icon={ChevronDownIcon} size="sm" color="inherit" />
+      <XDSIcon icon="chevronDown" size="sm" color="inherit" />
     </span>
   );
 

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -11,7 +11,7 @@
 
 import {forwardRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {InformationCircleIcon} from '@heroicons/react/24/outline';
+
 import {
   colorVars,
   fontWeightVars,
@@ -152,7 +152,7 @@ export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
         {tooltip && (
           <XDSTooltip content={tooltip} placement="above">
             <XDSIcon
-              icon={InformationCircleIcon}
+              icon="info"
               size="sm"
               color={isDisabled ? 'disabled' : 'secondary'}
             />

--- a/packages/core/src/Icon/IconRegistry.tsx
+++ b/packages/core/src/Icon/IconRegistry.tsx
@@ -1,0 +1,88 @@
+/**
+ * @file IconRegistry.tsx
+ * @input Uses React createContext, useContext, ReactNode
+ * @output Exports IconRegistryContext, useXDSIcon hook, XDSIconName, XDSIconRegistry types
+ * @position Core icon infrastructure; consumed by components that need internal icons
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Icon/README.md (features, usage)
+ * - /packages/core/src/Icon/index.ts (exports)
+ * - /packages/core/src/Icon/defaultIcons.tsx (fallback icon set)
+ */
+
+'use client';
+
+import {createContext, useContext, type ReactNode} from 'react';
+import {defaultIcons} from './defaultIcons';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Semantic icon names used internally by XDS components.
+ *
+ * These represent the functional purpose of each icon, not a specific
+ * visual representation. Themes provide the actual icon components.
+ */
+export type XDSIconName =
+  | 'close'
+  | 'chevronDown'
+  | 'chevronLeft'
+  | 'chevronRight'
+  | 'check'
+  | 'checkCircle'
+  | 'xCircle'
+  | 'warning'
+  | 'info'
+  | 'calendar'
+  | 'clock'
+  | 'externalLink';
+
+/**
+ * Icon registry mapping semantic names to React nodes.
+ *
+ * Themes provide this to override the built-in fallback icons.
+ * Values can be any ReactNode: SVG components, font icon spans,
+ * unicode characters, or any other renderable content.
+ */
+export type XDSIconRegistry = Record<XDSIconName, ReactNode>;
+
+// =============================================================================
+// Context
+// =============================================================================
+
+/**
+ * Context for providing theme icons to components.
+ * Accepts a full or partial registry. When null, components fall back
+ * to built-in lightweight SVGs. Partial registries fall back per-icon.
+ */
+export const IconRegistryContext =
+  createContext<Partial<XDSIconRegistry> | null>(null);
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Hook to retrieve an icon by semantic name.
+ *
+ * Resolution order:
+ * 1. Theme icon registry (via IconRegistryContext) — if the name exists
+ * 2. Built-in lightweight SVG fallback
+ *
+ * @example
+ * ```tsx
+ * const closeIcon = useXDSIcon('close');
+ * // Returns the theme's close icon, or the built-in SVG fallback
+ * ```
+ */
+export function useXDSIcon(name: XDSIconName): ReactNode {
+  const registry = useContext(IconRegistryContext);
+
+  if (registry != null && registry[name] != null) {
+    return registry[name];
+  }
+
+  return defaultIcons[name];
+}

--- a/packages/core/src/Icon/README.md
+++ b/packages/core/src/Icon/README.md
@@ -1,34 +1,49 @@
 # /packages/core/src/Icon
 
-A wrapper component for rendering Hero Icons with XDS design system colors and sizes.
+Renders icons with XDS design system colors and sizes. Supports both direct SVG icon components and semantic icon names that adapt to the active theme.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
 ## Features
 
-- **Hero Icons Integration**: Renders any Hero Icon (outline or solid) as a component
+- **Semantic Icon Names**: Use names like `'close'` or `'chevronDown'` — resolved from the theme's icon registry
+- **Direct Icon Components**: Pass any SVG icon component (heroicons, lucide, etc.) directly
+- **Theme-Adaptable**: Semantic icons automatically match the active theme's icon set
+- **Built-in Fallbacks**: 12 lightweight inline SVGs (~1.4KB) ensure icons render without a theme
 - **Theme Colors**: Color variants mapped to XDS icon color tokens
 - **Consistent Sizing**: Four size options aligned with common UI patterns
-- **Tree-shakeable**: Icons are imported individually, keeping bundle size minimal
 - **Accessible**: Icons are hidden from screen readers by default (aria-hidden)
 
 ## Usage
+
+### Semantic icon names (theme-adaptable)
+
+Use semantic names for icons that should adapt to the active theme. These resolve from the theme's icon registry, falling back to built-in SVGs when no theme is present.
+
+```tsx
+import { XDSIcon } from '@xds/core/Icon';
+
+// Semantic name — adapts to theme
+<XDSIcon icon="close" />
+<XDSIcon icon="chevronDown" size="sm" color="inherit" />
+<XDSIcon icon="checkCircle" color="positive" />
+
+// Great for building theme-adaptable UI
+<XDSIcon icon="info" size="sm" color="secondary" />
+```
+
+### Direct icon components
+
+Pass SVG icon components directly when you need a specific icon that isn't in the semantic set, or when you want full control.
 
 ```tsx
 import { XDSIcon } from '@xds/core/Icon';
 import { HomeIcon } from '@heroicons/react/24/outline';
 import { HeartIcon } from '@heroicons/react/24/solid';
 
-// Basic usage
+// Direct component
 <XDSIcon icon={HomeIcon} />
-
-// With color variant
-<XDSIcon icon={HomeIcon} color="accent" />
-
-// With size
-<XDSIcon icon={HomeIcon} size="lg" />
-
-// Solid icon with color
+<XDSIcon icon={HomeIcon} color="accent" size="lg" />
 <XDSIcon icon={HeartIcon} color="negative" />
 
 // Accessible icon with label
@@ -37,13 +52,32 @@ import { HeartIcon } from '@heroicons/react/24/solid';
 
 ## Props
 
-| Prop    | Type                                                                                                                     | Default     | Description                   |
-| ------- | ------------------------------------------------------------------------------------------------------------------------ | ----------- | ----------------------------- |
-| `icon`  | `ComponentType<SVGProps>`                                                                                                | (required)  | Hero Icon component to render |
-| `color` | `'primary' \| 'secondary' \| 'tertiary' \| 'disabled' \| 'accent' \| 'positive' \| 'negative' \| 'warning' \| 'inherit'` | `'primary'` | Color variant                 |
-| `size`  | `'xsm' \| 'sm' \| 'md' \| 'lg'`                                                                                          | `'md'`      | Icon size                     |
+| Prop    | Type                                                                                                                     | Default     | Description                         |
+| ------- | ------------------------------------------------------------------------------------------------------------------------ | ----------- | ----------------------------------- |
+| `icon`  | `XDSIconName \| ComponentType<SVGProps>`                                                                                 | (required)  | Semantic name or SVG icon component |
+| `color` | `'primary' \| 'secondary' \| 'tertiary' \| 'disabled' \| 'accent' \| 'positive' \| 'negative' \| 'warning' \| 'inherit'` | `'primary'` | Color variant                       |
+| `size`  | `'xsm' \| 'sm' \| 'md' \| 'lg'`                                                                                          | `'md'`      | Icon size                           |
 
-Additional SVG props (like `aria-label`, `role`, `className`) are passed through to the underlying SVG element.
+When `icon` is a component, additional SVG props (like `aria-label`, `role`) are passed through to the underlying SVG element.
+
+## Semantic Icon Names
+
+These names are used internally by XDS components and can be used in your own UI to build theme-adaptable interfaces. They resolve from the theme's icon registry, or fall back to built-in lightweight SVGs.
+
+| Name           | Used by                         | Description           |
+| -------------- | ------------------------------- | --------------------- |
+| `close`        | CloseButton, TimeInput          | ✕ close / dismiss     |
+| `chevronDown`  | DropdownMenu, Selector, TabMenu | ▾ expand / dropdown   |
+| `chevronLeft`  | Calendar                        | ‹ previous            |
+| `chevronRight` | Calendar                        | › next                |
+| `check`        | Selector, TabMenu               | ✓ selected item       |
+| `checkCircle`  | Input status                    | ✓○ success            |
+| `xCircle`      | Input status                    | ✕○ error              |
+| `warning`      | Input status                    | △! warning            |
+| `info`         | FieldLabel                      | ⓘ information tooltip |
+| `calendar`     | DateInput                       | 📅 date picker        |
+| `clock`        | TimeInput                       | 🕐 time picker        |
+| `externalLink` | Link                            | ↗ opens in new window |
 
 ## Color Variants
 
@@ -68,19 +102,28 @@ Additional SVG props (like `aria-label`, `role`, `className`) are passed through
 | `md`  | 20x20px    | Default, buttons, inputs     |
 | `lg`  | 24x24px    | Emphasis, standalone icons   |
 
+## How Icon Resolution Works
+
+When `icon` is a semantic name string:
+
+1. **Theme registry** — If an `XDSTheme` is active and provides an icon for that name, it's used
+2. **Built-in fallback** — Otherwise, a lightweight inline SVG is rendered
+
+This means components always render visually complete, even without a theme. Themes can override any or all icons — the registry accepts partial overrides.
+
 ## Icon Sources
 
-Import icons from Hero Icons:
+Any SVG icon component works with the direct component mode:
 
 ```tsx
-// Outline style (24x24, 1.5px stroke)
+// Heroicons
 import {HomeIcon} from '@heroicons/react/24/outline';
 
-// Solid style (24x24, filled)
-import {HomeIcon} from '@heroicons/react/24/solid';
-```
+// Lucide
+import {Home} from 'lucide-react';
 
-Browse available icons at [heroicons.com](https://heroicons.com).
+// Any component matching ComponentType<SVGProps<SVGSVGElement>>
+```
 
 ## Theming
 
@@ -106,15 +149,18 @@ const theme: Theme = {
 
 ## Files
 
-| File               | Role  | Purpose                     |
-| ------------------ | ----- | --------------------------- |
-| `index.ts`         | Entry | Exports component and types |
-| `XDSIcon.tsx`      | Core  | Component implementation    |
-| `XDSIcon.test.tsx` | Test  | Unit tests                  |
+| File               | Role     | Purpose                                  |
+| ------------------ | -------- | ---------------------------------------- |
+| `index.ts`         | Entry    | Exports component, types, and registry   |
+| `XDSIcon.tsx`      | Core     | Component implementation (both modes)    |
+| `IconRegistry.tsx` | Registry | Context, hook, and semantic name types   |
+| `defaultIcons.tsx` | Fallback | 12 lightweight inline SVG fallback icons |
+| `XDSIcon.test.tsx` | Test     | Unit tests                               |
 
 ## Implementation Notes
 
 - Uses `aria-hidden="true"` by default since icons are typically decorative
 - For meaningful icons, set `aria-hidden={false}`, `role="img"`, and `aria-label`
 - `flexShrink: 0` prevents icons from shrinking in flex containers
-- Colors are applied via the CSS `color` property, which Hero Icons inherit for stroke/fill
+- String mode wraps the resolved icon in a `<span>` with `fontSize`-based sizing so `1em`-based registry icons scale correctly
+- Component mode passes `stylex.props` directly to the SVG element for zero-overhead styling

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -1,8 +1,14 @@
 /**
  * @file XDSIcon.tsx
- * @input Uses React forwardRef, SVGProps, and @heroicons/react icon components
+ * @input Uses React forwardRef/useContext, SVGProps, icon components or semantic icon names
  * @output Exports XDSIcon component, XDSIconProps, XDSIconColor, XDSIconSize, XDSIconType types
  * @position Core implementation; consumed by index.ts, tested by XDSIcon.test.tsx
+ *
+ * Supports two modes:
+ * - Component mode: Pass an SVG icon component (e.g. from @heroicons/react) — rendered
+ *   directly with forwardRef and spread SVG props.
+ * - String mode: Pass a semantic name (e.g. 'close', 'chevronDown') — resolved from the
+ *   theme's icon registry (or built-in fallback SVGs) and wrapped in a styled span.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Icon/README.md (props table, features, implementation notes)
@@ -11,11 +17,14 @@
  * - /apps/storybook/stories/Icon.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {forwardRef, useContext, type ComponentType, type SVGProps} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
 import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
+import {useXDSIcon, type XDSIconName} from './IconRegistry';
 
 // =============================================================================
 // Styles
@@ -23,6 +32,13 @@ import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
 
 const styles = stylex.create({
   root: {
+    flexShrink: 0,
+  },
+  /** Wrapper for string-based (registry) icons */
+  span: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     flexShrink: 0,
   },
 });
@@ -57,6 +73,10 @@ const colorStyles = stylex.create({
   },
 });
 
+/**
+ * Size styles for direct SVG icon components.
+ * Uses width/height only — SVG components handle their own viewBox scaling.
+ */
 const sizeStyles = stylex.create({
   xsm: {
     width: 12,
@@ -73,6 +93,33 @@ const sizeStyles = stylex.create({
   lg: {
     width: 24,
     height: 24,
+  },
+});
+
+/**
+ * Size styles for string-based (registry) icons.
+ * Includes fontSize so that 1em-based icons from the registry scale correctly.
+ */
+const spanSizeStyles = stylex.create({
+  xsm: {
+    width: 12,
+    height: 12,
+    fontSize: 12,
+  },
+  sm: {
+    width: 16,
+    height: 16,
+    fontSize: 16,
+  },
+  md: {
+    width: 20,
+    height: 20,
+    fontSize: 20,
+  },
+  lg: {
+    width: 24,
+    height: 24,
+    fontSize: 24,
   },
 });
 
@@ -103,17 +150,18 @@ declare module '../theme/types' {
 
 /**
  * Props for XDSIcon component.
- * Extends SVGProps to allow passing additional SVG attributes.
+ * Extends SVGProps to allow passing additional SVG attributes (used when icon is a component).
  */
 export interface XDSIconProps extends Omit<
   SVGProps<SVGSVGElement>,
   'ref' | 'color'
 > {
   /**
-   * The Hero Icon component to render.
-   * Import from @heroicons/react/24/outline or @heroicons/react/24/solid.
+   * Icon to render. Can be:
+   * - A semantic name string (e.g. 'close', 'chevronDown') — resolved from theme or built-in fallback
+   * - An SVG icon component (e.g. from @heroicons/react) — rendered directly
    */
-  icon: XDSIconType;
+  icon: XDSIconType | XDSIconName;
   /**
    * The color variant of the icon.
    * @default 'primary'
@@ -135,11 +183,18 @@ export interface XDSIconProps extends Omit<
 // =============================================================================
 
 export const XDSIcon = forwardRef<SVGSVGElement, XDSIconProps>(
-  ({icon: IconComponent, color = 'primary', size = 'md', ...props}, ref) => {
+  ({icon, color = 'primary', size = 'md', ...props}, ref) => {
     // Get theme context for component-level overrides (optional)
     const themeContext = useContext(ThemeContext);
     const rootOverride = themeContext?.theme.components?.icon?.root;
 
+    // String mode: resolve from icon registry, wrap in styled span
+    if (typeof icon === 'string') {
+      return <IconFromRegistry name={icon} color={color} size={size} />;
+    }
+
+    // Component mode: render SVG component directly with ref forwarding
+    const IconComponent = icon;
     return (
       <IconComponent
         ref={ref}
@@ -157,3 +212,38 @@ export const XDSIcon = forwardRef<SVGSVGElement, XDSIconProps>(
 );
 
 XDSIcon.displayName = 'XDSIcon';
+
+// =============================================================================
+// Internal: Registry Icon Renderer
+// =============================================================================
+
+/**
+ * Internal component that resolves a semantic icon name from the registry
+ * and renders it in a styled span with proper sizing.
+ *
+ * Extracted as a separate component so the useXDSIcon hook is only called
+ * when the icon prop is a string.
+ */
+function IconFromRegistry({
+  name,
+  color,
+  size,
+}: {
+  name: XDSIconName;
+  color: XDSIconColor;
+  size: XDSIconSize;
+}) {
+  const resolvedIcon = useXDSIcon(name);
+
+  if (resolvedIcon == null) {
+    return null;
+  }
+
+  return (
+    <span
+      {...stylex.props(styles.span, colorStyles[color], spanSizeStyles[size])}
+      aria-hidden="true">
+      {resolvedIcon}
+    </span>
+  );
+}

--- a/packages/core/src/Icon/defaultIcons.tsx
+++ b/packages/core/src/Icon/defaultIcons.tsx
@@ -1,0 +1,132 @@
+/**
+ * @file defaultIcons.tsx
+ * @input Uses React JSX for inline SVGs
+ * @output Exports defaultIcons registry with lightweight SVG fallbacks
+ * @position Fallback icons used when no theme provides an icon registry
+ *
+ * These are intentionally minimal inline SVGs (~1.4KB total) that provide
+ * basic visual completeness without any external icon library dependency.
+ * Themes should override these with higher-quality icons from a proper
+ * icon library (heroicons, lucide, Material Symbols, etc.).
+ *
+ * All icons:
+ * - Use a 24x24 viewBox
+ * - Use currentColor for stroke/fill (inherits from parent)
+ * - Are aria-hidden (decorative by default)
+ * - Use stroke-based rendering with 1.5px stroke width (matching heroicons outline style)
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Icon/IconRegistry.tsx (XDSIconName type if names change)
+ * - /packages/core/src/Icon/README.md (fallback icon documentation)
+ */
+
+import type {XDSIconRegistry} from './IconRegistry';
+
+const svgProps = {
+  xmlns: 'http://www.w3.org/2000/svg',
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  strokeWidth: 1.5,
+  strokeLinecap: 'round' as const,
+  strokeLinejoin: 'round' as const,
+  width: '1em',
+  height: '1em',
+  'aria-hidden': true as const,
+};
+
+export const defaultIcons: XDSIconRegistry = {
+  /** ✕ — two diagonal lines */
+  close: (
+    <svg {...svgProps}>
+      <path d="M6 6l12 12M6 18L18 6" />
+    </svg>
+  ),
+
+  /** ▾ — downward chevron */
+  chevronDown: (
+    <svg {...svgProps}>
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  ),
+
+  /** ‹ — left chevron */
+  chevronLeft: (
+    <svg {...svgProps}>
+      <path d="M15 6l-6 6 6 6" />
+    </svg>
+  ),
+
+  /** › — right chevron */
+  chevronRight: (
+    <svg {...svgProps}>
+      <path d="M9 6l6 6-6 6" />
+    </svg>
+  ),
+
+  /** ✓ — checkmark */
+  check: (
+    <svg {...svgProps}>
+      <path d="M5 13l4 4L19 7" />
+    </svg>
+  ),
+
+  /** ✓ in circle — success */
+  checkCircle: (
+    <svg {...svgProps}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M9 12l2 2 4-4" />
+    </svg>
+  ),
+
+  /** ✕ in circle — error */
+  xCircle: (
+    <svg {...svgProps}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M15 9l-6 6M9 9l6 6" />
+    </svg>
+  ),
+
+  /** △ with ! — warning */
+  warning: (
+    <svg {...svgProps}>
+      <path d="M12 3L2 21h20L12 3z" />
+      <path d="M12 10v4" />
+      <circle cx="12" cy="17" r="0.5" fill="currentColor" stroke="none" />
+    </svg>
+  ),
+
+  /** ⓘ — information */
+  info: (
+    <svg {...svgProps}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 11v5" />
+      <circle cx="12" cy="8" r="0.5" fill="currentColor" stroke="none" />
+    </svg>
+  ),
+
+  /** 📅 — calendar */
+  calendar: (
+    <svg {...svgProps}>
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <path d="M16 2v4M8 2v4M3 10h18" />
+    </svg>
+  ),
+
+  /** 🕐 — clock */
+  clock: (
+    <svg {...svgProps}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 3" />
+    </svg>
+  ),
+
+  /** ↗ — external link arrow */
+  externalLink: (
+    <svg {...svgProps}>
+      <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6" />
+      <path d="M15 3h6v6" />
+      <path d="M10 14L21 3" />
+    </svg>
+  ),
+};

--- a/packages/core/src/Icon/defaultIcons.tsx
+++ b/packages/core/src/Icon/defaultIcons.tsx
@@ -14,6 +14,7 @@
  * - Use currentColor for stroke/fill (inherits from parent)
  * - Are aria-hidden (decorative by default)
  * - Use stroke-based rendering with 1.5px stroke width (matching heroicons outline style)
+ * - Status icons (checkCircle, xCircle, warning) use solid fills for better color visibility
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Icon/IconRegistry.tsx (XDSIconName type if names change)
@@ -30,6 +31,21 @@ const svgProps = {
   strokeWidth: 1.5,
   strokeLinecap: 'round' as const,
   strokeLinejoin: 'round' as const,
+  width: '1em',
+  height: '1em',
+  'aria-hidden': true as const,
+};
+
+/**
+ * Props for solid/filled SVG icons.
+ * Status icons (checkCircle, xCircle, warning) use solid fills for better
+ * color visibility at small sizes, matching the heroicons solid style
+ * used by themes.
+ */
+const solidSvgProps = {
+  xmlns: 'http://www.w3.org/2000/svg',
+  viewBox: '0 0 24 24',
+  fill: 'currentColor',
   width: '1em',
   height: '1em',
   'aria-hidden': true as const,
@@ -71,28 +87,36 @@ export const defaultIcons: XDSIconRegistry = {
     </svg>
   ),
 
-  /** ✓ in circle — success */
+  /** ✓ in circle — success (solid fill for status visibility) */
   checkCircle: (
-    <svg {...svgProps}>
-      <circle cx="12" cy="12" r="9" />
-      <path d="M9 12l2 2 4-4" />
+    <svg {...solidSvgProps}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 3a9 9 0 100 18 9 9 0 000-18zm4.06 6.56a.75.75 0 00-1.12-1l-3.94 4.4-1.94-1.94a.75.75 0 00-1.06 1.06l2.5 2.5a.75.75 0 001.09-.03l4.47-5z"
+      />
     </svg>
   ),
 
-  /** ✕ in circle — error */
+  /** ✕ in circle — error (solid fill for status visibility) */
   xCircle: (
-    <svg {...svgProps}>
-      <circle cx="12" cy="12" r="9" />
-      <path d="M15 9l-6 6M9 9l6 6" />
+    <svg {...solidSvgProps}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M12 3a9 9 0 100 18 9 9 0 000-18zm-2.47 5.47a.75.75 0 00-1.06 1.06L10.94 12l-2.47 2.47a.75.75 0 101.06 1.06L12 13.06l2.47 2.47a.75.75 0 101.06-1.06L13.06 12l2.47-2.47a.75.75 0 00-1.06-1.06L12 10.94l-2.47-2.47z"
+      />
     </svg>
   ),
 
-  /** △ with ! — warning */
+  /** △ with ! — warning (solid fill for status visibility) */
   warning: (
-    <svg {...svgProps}>
-      <path d="M12 3L2 21h20L12 3z" />
-      <path d="M12 10v4" />
-      <circle cx="12" cy="17" r="0.5" fill="currentColor" stroke="none" />
+    <svg {...solidSvgProps}>
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10.29 3.86L2.07 19.05A2 2 0 003.78 22h16.44a2 2 0 001.71-2.95L13.71 3.86a2 2 0 00-3.42 0zM12 9a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0112 9zm0 9a1 1 0 100-2 1 1 0 000 2z"
+      />
     </svg>
   ),
 

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -1,7 +1,7 @@
 /**
  * @file index.ts
- * @input Imports XDSIcon component and types from XDSIcon.tsx
- * @output Exports XDSIcon, XDSIconProps, XDSIconColor, XDSIconSize, XDSIconType
+ * @input Imports XDSIcon component/types and IconRegistry types
+ * @output Exports XDSIcon, its prop types, icon registry context, and semantic name types
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Icon/README.md
@@ -14,3 +14,5 @@ export type {
   XDSIconSize,
   XDSIconType,
 } from './XDSIcon';
+export type {XDSIconName, XDSIconRegistry} from './IconRegistry';
+export {IconRegistryContext} from './IconRegistry';

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -19,7 +19,6 @@ import {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {ArrowTopRightOnSquareIcon} from '@heroicons/react/16/solid';
 
 import {
   colorVars,
@@ -263,11 +262,7 @@ export const XDSLink = forwardRef<HTMLAnchorElement, XDSLinkProps>(
           {children}
         </XDSText>
         {isExternalLink && (
-          <XDSIcon
-            icon={ArrowTopRightOnSquareIcon}
-            size="xsm"
-            color="inherit"
-          />
+          <XDSIcon icon="externalLink" size="xsm" color="inherit" />
         )}
       </a>
     );

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -23,11 +23,7 @@ import {
   type KeyboardEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-} from '@heroicons/react/24/solid';
+import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   sizeVars,
@@ -186,7 +182,7 @@ export interface XDSNumberInputProps {
   isDisabled?: boolean;
   /**
    * Icon to display at the start of the input.
-   * Import from @heroicons/react/24/outline or @heroicons/react/24/solid.
+   * Pass an SVG icon component (e.g. from heroicons, lucide, etc.).
    */
   startIcon?: XDSIconType;
   /**
@@ -369,10 +365,10 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
     // Pending input while user is typing (null = show formatted value)
     const [pendingInput, setPendingInput] = useState<string | null>(null);
 
-    const statusIconMap: Record<XDSInputStatusType, XDSIconType> = {
-      warning: ExclamationTriangleIcon,
-      error: XCircleIcon,
-      success: CheckCircleIcon,
+    const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+      warning: 'warning',
+      error: 'xCircle',
+      success: 'checkCircle',
     };
 
     const statusIconColorMap: Record<

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -19,13 +19,7 @@ import React, {
 import * as stylex from '@stylexjs/stylex';
 import {useXDSLayer} from '../Layer/useXDSLayer';
 import {XDSIcon} from '../Icon';
-import type {XDSIconType} from '../Icon';
-import {CheckIcon, ChevronDownIcon} from '@heroicons/react/16/solid';
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-} from '@heroicons/react/24/solid';
+import type {XDSIconName} from '../Icon';
 import {XDSField} from '../Field';
 import {XDSDivider} from '../Divider';
 import {
@@ -217,10 +211,10 @@ const statusBorderStyles = stylex.create({
   },
 });
 
-const STATUS_ICON_MAP: Record<XDSSelectorStatusType, XDSIconType> = {
-  warning: ExclamationTriangleIcon,
-  error: XCircleIcon,
-  success: CheckCircleIcon,
+const STATUS_ICON_MAP: Record<XDSSelectorStatusType, XDSIconName> = {
+  warning: 'warning',
+  error: 'xCircle',
+  success: 'checkCircle',
 };
 
 const STATUS_ICON_COLOR_MAP: Record<
@@ -488,7 +482,7 @@ export function XDSSelector<T extends XDSSelectorOption>({
           <span {...stylex.props(styles.itemContent)}>
             {children ? children(item) : <DefaultItem item={item} />}
           </span>
-          {isSelected && <CheckIcon {...stylex.props(styles.itemCheckmark)} />}
+          {isSelected && <XDSIcon icon="check" size="sm" color="accent" />}
         </div>
       );
     },
@@ -610,7 +604,7 @@ export function XDSSelector<T extends XDSSelectorOption>({
               color={STATUS_ICON_COLOR_MAP[status.type]}
             />
           ) : (
-            <ChevronDownIcon />
+            <XDSIcon icon="chevronDown" size="sm" color="inherit" />
           )}
         </span>
       </button>

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -12,7 +12,8 @@
 
 import React, {useCallback, useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {CheckIcon, ChevronDownIcon} from '@heroicons/react/16/solid';
+import {XDSIcon} from '../Icon';
+import type {XDSIconType} from '../Icon';
 import {
   colorVars,
   spacingVars,
@@ -26,8 +27,6 @@ import {
 } from '../theme/tokens.stylex';
 import {useXDSLayer} from '../Layer/useXDSLayer';
 import {useListFocus} from '../hooks/useListFocus';
-import {XDSIcon} from '../Icon';
-import type {XDSIconType} from '../Icon';
 import {XDSDivider} from '../Divider';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
@@ -272,10 +271,11 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
             <span {...stylex.props(styles.hoverUnderline)} />
           )}
         </span>
-        <ChevronDownIcon
+        <span
           aria-hidden="true"
-          {...stylex.props(styles.chevron, layer.isOpen && styles.chevronOpen)}
-        />
+          {...stylex.props(styles.chevron, layer.isOpen && styles.chevronOpen)}>
+          <XDSIcon icon="chevronDown" size="sm" color="inherit" />
+        </span>
       </button>
       {layer.render(
         <div
@@ -312,7 +312,7 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
                   {option.label}
                 </span>
                 {isSelected && (
-                  <CheckIcon {...stylex.props(styles.itemCheckmark)} />
+                  <XDSIcon icon="check" size="sm" color="accent" />
                 )}
               </div>
             );

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -19,11 +19,7 @@ import {
   type ClipboardEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-} from '@heroicons/react/24/solid';
+import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   spacingVars,
@@ -204,7 +200,7 @@ export interface XDSTextAreaProps {
   labelTooltip?: string;
   /**
    * Icon to display at the start of the textarea.
-   * Import from @heroicons/react/24/outline or @heroicons/react/24/solid.
+   * Pass an SVG icon component (e.g. from heroicons, lucide, etc.).
    */
   startIcon?: XDSIconType;
   /**
@@ -274,10 +270,10 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
     const descriptionID = useId();
     const statusMessageID = useId();
 
-    const statusIconMap: Record<XDSTextAreaStatusType, XDSIconType> = {
-      warning: ExclamationTriangleIcon,
-      error: XCircleIcon,
-      success: CheckCircleIcon,
+    const statusIconMap: Record<XDSTextAreaStatusType, XDSIconName> = {
+      warning: 'warning',
+      error: 'xCircle',
+      success: 'checkCircle',
     };
 
     const statusIconColorMap: Record<

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -13,11 +13,7 @@
 
 import {forwardRef, useContext, useId, type ChangeEvent} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-} from '@heroicons/react/24/solid';
+import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   sizeVars,
@@ -166,7 +162,7 @@ export interface XDSTextInputProps {
   isDisabled?: boolean;
   /**
    * Icon to display at the start of the input.
-   * Import from @heroicons/react/24/outline or @heroicons/react/24/solid.
+   * Pass an SVG icon component (e.g. from heroicons, lucide, etc.).
    */
   startIcon?: XDSIconType;
   /**
@@ -248,10 +244,10 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
     const descriptionID = useId();
     const statusMessageID = useId();
 
-    const statusIconMap: Record<XDSInputStatusType, XDSIconType> = {
-      warning: ExclamationTriangleIcon,
-      error: XCircleIcon,
-      success: CheckCircleIcon,
+    const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+      warning: 'warning',
+      error: 'xCircle',
+      success: 'checkCircle',
     };
 
     const statusIconColorMap: Record<

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -23,12 +23,7 @@ import {
   type FocusEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {ClockIcon, XMarkIcon} from '@heroicons/react/24/outline';
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-} from '@heroicons/react/24/solid';
+import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   sizeVars,
@@ -332,10 +327,10 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
     const inputRef = useRef<HTMLInputElement | null>(null);
 
     // Status icon mapping
-    const statusIconMap: Record<XDSInputStatusType, typeof XCircleIcon> = {
-      warning: ExclamationTriangleIcon,
-      error: XCircleIcon,
-      success: CheckCircleIcon,
+    const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+      warning: 'warning',
+      error: 'xCircle',
+      success: 'checkCircle',
     };
 
     const statusIconColorMap: Record<
@@ -522,7 +517,7 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
             wrapperOverride,
           )}>
           <div {...stylex.props(styles.icon)}>
-            <XDSIcon icon={ClockIcon} size="sm" color="secondary" />
+            <XDSIcon icon="clock" size="sm" color="secondary" />
           </div>
           <input
             ref={setRefs}
@@ -551,7 +546,7 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
               onClick={handleClear}
               aria-label="Clear time"
               {...stylex.props(styles.clearButton)}>
-              <XDSIcon icon={XMarkIcon} size="sm" color="secondary" />
+              <XDSIcon icon="close" size="sm" color="secondary" />
             </button>
           )}
           {status && (

--- a/packages/core/src/theme/README.md
+++ b/packages/core/src/theme/README.md
@@ -6,15 +6,17 @@ XDS theme provider and design tokens.
 
 ## Features
 
-- **XDSTheme Provider**: Wraps app to provide CSS variables
+- **XDSTheme Provider**: Wraps app to provide CSS variables and icon registry
 - **Design Tokens**: Colors, spacing, radius, typography via StyleX
-- **Multiple Themes**: defaultTheme, neutralTheme
+- **Icon Registry**: Themes provide icons to components via context
+- **Multiple Themes**: defaultTheme, neutralTheme (from `@xds/theme`)
 - **useXDSTheme Hook**: Access current theme in components
 
 ## Usage
 
 ```tsx
-import {XDSTheme, defaultTheme} from '@xds/core';
+import {XDSTheme} from '@xds/core';
+import {defaultTheme} from '@xds/theme/default';
 
 function App() {
   return (
@@ -35,8 +37,68 @@ function App() {
 
 ## Available Themes
 
-- `defaultTheme` - XDS branded colors
-- `neutralTheme` - Grayscale palette
+From `@xds/theme`:
+
+- `defaultTheme` — XDS branded colors + heroicons
+- `neutralTheme` — Grayscale palette + heroicons
+
+## Theme Object
+
+A theme provides:
+
+```ts
+interface Theme {
+  name: string;
+  styles: ThemeStyles; // StyleX CSS variable overrides
+  raw: ThemeRaw; // Raw CSS values for programmatic access
+  components?: ComponentStyles; // Component-level style overrides
+  icons?: Partial<XDSIconRegistry>; // Icon overrides for XDSIcon semantic names
+}
+```
+
+### Icons
+
+Themes can provide icons for XDS's 12 semantic icon names. These are used internally by components (CloseButton, Calendar, inputs, etc.) and can also be used directly via `<XDSIcon icon="close" />`.
+
+```ts
+import type { XDSIconRegistry } from '@xds/core/Icon';
+
+// Full registry (all 12 icons)
+const icons: XDSIconRegistry = {
+  close: <XMarkIcon />,
+  chevronDown: <ChevronDownIcon />,
+  // ... all 12 names
+};
+
+// Partial override (only some icons)
+const icons: Partial<XDSIconRegistry> = {
+  close: <MyCustomCloseIcon />,
+  // Others fall back to built-in SVGs
+};
+```
+
+When no theme is active, components use built-in lightweight SVG fallbacks.
+
+See the [Icon README](../Icon/README.md) for the full list of semantic names.
+
+### Adding icons to a custom theme
+
+```ts
+import { MyCloseIcon, MyChevronIcon } from './my-icons';
+
+const myTheme: Theme = {
+  name: 'my-brand',
+  icons: {
+    close: <MyCloseIcon width="1em" height="1em" aria-hidden />,
+    chevronDown: <MyChevronIcon width="1em" height="1em" aria-hidden />,
+    // ... provide as many or as few as needed
+  },
+  styles: { /* ... */ },
+  raw: { /* ... */ },
+};
+```
+
+Icons should use `width="1em"` and `height="1em"` so they scale with the `XDSIcon` size prop.
 
 ## useXDSTheme Hook
 
@@ -45,7 +107,9 @@ Access current theme in components:
 ```tsx
 import {useXDSTheme} from '@xds/core';
 
-const {theme, mode} = useXDSTheme();
+const themeContext = useXDSTheme();
+// themeContext?.theme — current Theme object
+// themeContext?.mode — current ThemeMode
 ```
 
 ## CSS Variables
@@ -63,3 +127,29 @@ const styles = stylex.create({
 ```
 
 See `.xds-docs/tokens.md` for the full token reference.
+
+## Files
+
+| File               | Role     | Purpose                             |
+| ------------------ | -------- | ----------------------------------- |
+| `index.ts`         | Entry    | Exports provider, hook, and types   |
+| `XDSTheme.tsx`     | Provider | Theme provider with icon registry   |
+| `ThemeContext.ts`  | Context  | React context for theme values      |
+| `types.ts`         | Types    | Theme, ThemeStyles, ComponentStyles |
+| `tokens.stylex.ts` | Tokens   | StyleX CSS variable definitions     |
+
+## For Contributors
+
+### How the icon registry works
+
+1. `XDSTheme` reads `theme.icons` and wraps children in `IconRegistryContext.Provider`
+2. `XDSIcon` with a semantic name string calls `useXDSIcon(name)` which checks the context
+3. If the theme provides that icon, it's used. Otherwise, the built-in fallback SVG renders.
+
+### Adding a new semantic icon name
+
+1. Add the name to `XDSIconName` in `Icon/IconRegistry.tsx`
+2. Add a fallback SVG in `Icon/defaultIcons.tsx`
+3. Add the icon to both theme registries (`@xds/theme` default + neutral)
+4. Use it in your component: `<XDSIcon icon="newName" />`
+5. Update the Icon README's semantic names table

--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -21,6 +21,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {Theme as ThemeType, ThemeMode} from './types';
 import {ThemeContext, type ThemeContextValue} from './ThemeContext';
 import {colorVars, typographyVars} from './tokens.stylex';
+import {IconRegistryContext} from '../Icon/IconRegistry';
 
 // Re-export for backwards compatibility
 export {ThemeContext} from './ThemeContext';
@@ -101,13 +102,22 @@ export function XDSTheme({
     theme.styles.typography,
   );
 
+  let content: React.ReactNode = children;
+  if (theme.icons != null) {
+    content = (
+      <IconRegistryContext.Provider value={theme.icons}>
+        {content}
+      </IconRegistryContext.Provider>
+    );
+  }
+
   return (
     <ThemeContext.Provider value={contextValue}>
       <div
         className={stylexProps.className}
         style={stylexProps.style}
         data-theme={mode === 'system' ? undefined : mode}>
-        {children}
+        {content}
       </div>
     </ThemeContext.Provider>
   );

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -2,6 +2,8 @@
  * XDS Theme Type Definitions
  */
 
+import type {XDSIconRegistry} from '../Icon/IconRegistry';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type StyleXStyles = any;
 
@@ -228,4 +230,6 @@ export interface Theme {
   raw: ThemeRaw;
   /** Component-specific style overrides (optional) */
   components?: ComponentStyles;
+  /** Optional icon registry for overriding built-in fallback icons */
+  icons?: Partial<XDSIconRegistry>;
 }

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -25,6 +25,9 @@
     "build": "tsup",
     "dev": "tsup --watch"
   },
+  "dependencies": {
+    "@heroicons/react": "^2.2.0"
+  },
   "peerDependencies": {
     "@stylexjs/stylex": ">=0.10.0",
     "@xds/core": "*",

--- a/packages/theme/src/default/defaultTheme.stylex.ts
+++ b/packages/theme/src/default/defaultTheme.stylex.ts
@@ -587,12 +587,15 @@ const proseElementStyles = stylex.create({
   },
 });
 
+import {defaultIconRegistry} from './icons';
+
 // =============================================================================
 // Theme Export
 // =============================================================================
 
 export const defaultTheme: Theme = {
   name: 'default',
+  icons: defaultIconRegistry,
   styles: {
     colors: colorTheme,
     spacing: spacingTheme,

--- a/packages/theme/src/default/defaultTheme.stylex.ts
+++ b/packages/theme/src/default/defaultTheme.stylex.ts
@@ -47,6 +47,7 @@ import type {
   BaseLineHeightRaw,
   BaseFontWeightRaw,
 } from '@xds/core/theme/tokens.stylex';
+import {defaultIconRegistry} from './icons';
 
 // =============================================================================
 // Raw Theme Values
@@ -586,8 +587,6 @@ const proseElementStyles = stylex.create({
     marginBottom: 0,
   },
 });
-
-import {defaultIconRegistry} from './icons';
 
 // =============================================================================
 // Theme Export

--- a/packages/theme/src/default/icons.tsx
+++ b/packages/theme/src/default/icons.tsx
@@ -1,0 +1,51 @@
+/**
+ * @file icons.tsx
+ * @input Uses @heroicons/react outline and solid icon components, XDSIconRegistry type
+ * @output Exports defaultIconRegistry for the default theme
+ * @position Icon configuration for the default theme; consumed by index.ts
+ *
+ * Maps semantic icon names to Heroicons components.
+ * These icons are bundled with the theme, not with @xds/core.
+ */
+
+import React from 'react';
+import type {XDSIconRegistry} from '@xds/core/Icon';
+
+import {
+  XMarkIcon,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CheckIcon,
+  CalendarDaysIcon,
+  ClockIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline';
+
+import {
+  CheckCircleIcon,
+  XCircleIcon,
+  ExclamationTriangleIcon,
+  ArrowTopRightOnSquareIcon,
+} from '@heroicons/react/24/solid';
+
+const iconProps = {
+  width: '1em',
+  height: '1em',
+  'aria-hidden': true as const,
+};
+
+export const defaultIconRegistry: XDSIconRegistry = {
+  close: <XMarkIcon {...iconProps} />,
+  chevronDown: <ChevronDownIcon {...iconProps} />,
+  chevronLeft: <ChevronLeftIcon {...iconProps} />,
+  chevronRight: <ChevronRightIcon {...iconProps} />,
+  check: <CheckIcon {...iconProps} />,
+  checkCircle: <CheckCircleIcon {...iconProps} />,
+  xCircle: <XCircleIcon {...iconProps} />,
+  warning: <ExclamationTriangleIcon {...iconProps} />,
+  info: <InformationCircleIcon {...iconProps} />,
+  calendar: <CalendarDaysIcon {...iconProps} />,
+  clock: <ClockIcon {...iconProps} />,
+  externalLink: <ArrowTopRightOnSquareIcon {...iconProps} />,
+};

--- a/packages/theme/src/default/index.ts
+++ b/packages/theme/src/default/index.ts
@@ -1,1 +1,2 @@
 export {defaultTheme} from './defaultTheme.stylex';
+export {defaultIconRegistry} from './icons';

--- a/packages/theme/src/neutral/icons.tsx
+++ b/packages/theme/src/neutral/icons.tsx
@@ -1,0 +1,51 @@
+/**
+ * @file icons.tsx
+ * @input Uses @heroicons/react outline and solid icon components, XDSIconRegistry type
+ * @output Exports neutralIconRegistry for the neutral theme
+ * @position Icon configuration for the neutral theme; consumed by index.ts
+ *
+ * Maps semantic icon names to Heroicons components.
+ * These icons are bundled with the theme, not with @xds/core.
+ */
+
+import React from 'react';
+import type {XDSIconRegistry} from '@xds/core/Icon';
+
+import {
+  XMarkIcon,
+  ChevronDownIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CheckIcon,
+  CalendarDaysIcon,
+  ClockIcon,
+  InformationCircleIcon,
+} from '@heroicons/react/24/outline';
+
+import {
+  CheckCircleIcon,
+  XCircleIcon,
+  ExclamationTriangleIcon,
+  ArrowTopRightOnSquareIcon,
+} from '@heroicons/react/24/solid';
+
+const iconProps = {
+  width: '1em',
+  height: '1em',
+  'aria-hidden': true as const,
+};
+
+export const neutralIconRegistry: XDSIconRegistry = {
+  close: <XMarkIcon {...iconProps} />,
+  chevronDown: <ChevronDownIcon {...iconProps} />,
+  chevronLeft: <ChevronLeftIcon {...iconProps} />,
+  chevronRight: <ChevronRightIcon {...iconProps} />,
+  check: <CheckIcon {...iconProps} />,
+  checkCircle: <CheckCircleIcon {...iconProps} />,
+  xCircle: <XCircleIcon {...iconProps} />,
+  warning: <ExclamationTriangleIcon {...iconProps} />,
+  info: <InformationCircleIcon {...iconProps} />,
+  calendar: <CalendarDaysIcon {...iconProps} />,
+  clock: <ClockIcon {...iconProps} />,
+  externalLink: <ArrowTopRightOnSquareIcon {...iconProps} />,
+};

--- a/packages/theme/src/neutral/index.ts
+++ b/packages/theme/src/neutral/index.ts
@@ -1,1 +1,2 @@
 export {neutralTheme} from './neutralTheme.stylex';
+export {neutralIconRegistry} from './icons';

--- a/packages/theme/src/neutral/neutralTheme.stylex.ts
+++ b/packages/theme/src/neutral/neutralTheme.stylex.ts
@@ -49,6 +49,7 @@ import type {
   BaseLineHeightRaw,
   BaseFontWeightRaw,
 } from '@xds/core/theme/tokens.stylex';
+import {neutralIconRegistry} from './icons';
 
 // =============================================================================
 // Raw Theme Values
@@ -553,8 +554,6 @@ const textStyles = stylex.create({
     margin: 0,
   },
 });
-
-import {neutralIconRegistry} from './icons';
 
 // =============================================================================
 // Theme Export

--- a/packages/theme/src/neutral/neutralTheme.stylex.ts
+++ b/packages/theme/src/neutral/neutralTheme.stylex.ts
@@ -554,12 +554,15 @@ const textStyles = stylex.create({
   },
 });
 
+import {neutralIconRegistry} from './icons';
+
 // =============================================================================
 // Theme Export
 // =============================================================================
 
 export const neutralTheme: Theme = {
   name: 'neutral',
+  icons: neutralIconRegistry,
   styles: {
     colors: colorTheme,
     spacing: spacingTheme,


### PR DESCRIPTION
## Summary

Implements the icon architecture from [issue #44](https://github.com/facebookexperimental/xds/issues/44) — decoupling icons from `@xds/core` and making them theme-provided.

### What changed

**New: Icon Registry System**
- `XDSIcon` now accepts semantic string names (`'close'`, `'chevronDown'`, etc.) alongside direct SVG components
- `IconRegistryContext` + `useXDSIcon` hook resolve icons from theme → built-in fallback
- 12 lightweight inline SVG fallbacks (~1.4KB total) ship with core for no-theme usage
- `XDSTheme` provider wires `theme.icons` into the registry context

**Theme icons**
- Default and neutral themes provide icon registries using heroicons
- `@heroicons/react` moved from `@xds/core` dependency to `@xds/theme` dependency
- Themes export their icon registries (`defaultIconRegistry`, `neutralIconRegistry`)

**Component migrations**
- 12 component files migrated from direct heroicon imports to semantic names:
  Calendar, CloseButton, DateInput, DropdownMenu, FieldLabel, Link, NumberInput, Selector, TabMenu, TextArea, TextInput, TimeInput
- CloseButton's ad-hoc `theme.components.closeButton.icon` override removed in favor of the registry

### Three-layer icon resolution

1. **Prop override** — `<XDSButton icon={<XDSIcon icon={MyIcon} />} />`
2. **Theme icon registry** — theme provides icons via context
3. **Built-in fallback** — lightweight inline SVGs, always available

### Semantic icon names (12)

| Name | Used by |
|------|---------|
| `close` | CloseButton, TimeInput |
| `chevronDown` | DropdownMenu, Selector, TabMenu |
| `chevronLeft` | Calendar |
| `chevronRight` | Calendar |
| `check` | Selector, TabMenu |
| `checkCircle` | Input status (success) |
| `xCircle` | Input status (error) |
| `warning` | Input status (warning) |
| `info` | FieldLabel |
| `calendar` | DateInput |
| `clock` | TimeInput |
| `externalLink` | Link |

### No-theme behavior

Components render built-in lightweight SVGs — always visually complete without a theme.

Resolves #44

---
*Crafted with care by Navi*