### PR TITLE
feat(core): add XDSToggleButton component

### DIFF
--- a/apps/storybook/stories/ToggleButton.stories.tsx
+++ b/apps/storybook/stories/ToggleButton.stories.tsx
@@ -374,6 +374,201 @@ export const IconSwap: Story = {
 };
 
 // =============================================================================
+// Pressed icon color — semantic coloring
+// =============================================================================
+
+export const PressedIconColor: Story = {
+  name: 'Pressed Icon Color — Semantic',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        maxWidth: '600px',
+      }}>
+      <div style={{fontSize: 12, color: '#4E606F', marginBottom: 4}}>
+        Icons change to semantic colors when pressed — yellow star, pink heart,
+        blue bookmark. The color only affects the icon, not the label text.
+      </div>
+      <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+        <ToggleButtonDemo
+          label="Favorite"
+          icon={<StarIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<StarIconSolid style={{width: 16, height: 16}} />}
+          pressedIconColor="#F2C00B"
+        />
+        <ToggleButtonDemo
+          label="Like"
+          icon={<HeartIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<HeartIconSolid style={{width: 16, height: 16}} />}
+          pressedIconColor="#E91E63"
+        />
+        <ToggleButtonDemo
+          label="Bookmark"
+          icon={<BookmarkIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<BookmarkIconSolid style={{width: 16, height: 16}} />}
+          pressedIconColor="#0064E0"
+        />
+        <ToggleButtonDemo
+          label="Notifications"
+          icon={<BellIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<BellIconSolid style={{width: 16, height: 16}} />}
+          pressedIconColor="#0D8626"
+        />
+      </div>
+      <div style={{fontSize: 12, color: '#4E606F', marginTop: 4}}>
+        With visible labels — icon gets color, text stays default:
+      </div>
+      <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+        <ToggleButtonDemo
+          label="Favorite"
+          icon={<StarIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<StarIconSolid style={{width: 16, height: 16}} />}
+          pressedIconColor="#F2C00B"
+          defaultPressed>
+          Favorite
+        </ToggleButtonDemo>
+        <ToggleButtonDemo
+          label="Like"
+          icon={<HeartIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<HeartIconSolid style={{width: 16, height: 16}} />}
+          pressedIconColor="#E91E63">
+          Like
+        </ToggleButtonDemo>
+      </div>
+    </div>
+  ),
+};
+
+// =============================================================================
+// Read-only state
+// =============================================================================
+
+export const ReadOnly: Story = {
+  name: 'Read-Only State',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        maxWidth: '600px',
+      }}>
+      <div style={{fontSize: 12, color: '#4E606F', marginBottom: 4}}>
+        Read-only buttons show state but can&apos;t be toggled. No opacity
+        reduction (unlike disabled), no hover/active effects. Useful for viewing
+        someone else&apos;s favorites.
+      </div>
+      <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+        <ToggleButtonDemo
+          label="Favorited by user"
+          icon={<StarIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<StarIconSolid style={{width: 16, height: 16}} />}
+          pressedIconColor="#F2C00B"
+          isReadOnly
+          defaultPressed
+        />
+        <ToggleButtonDemo
+          label="Not bookmarked"
+          icon={<BookmarkIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<BookmarkIconSolid style={{width: 16, height: 16}} />}
+          isReadOnly
+        />
+        <ToggleButtonDemo
+          label="Active"
+          variant="outline"
+          isReadOnly
+          defaultPressed>
+          Active
+        </ToggleButtonDemo>
+        <ToggleButtonDemo label="Archived" variant="outline" isReadOnly>
+          Archived
+        </ToggleButtonDemo>
+      </div>
+      <div style={{fontSize: 12, color: '#4E606F'}}>
+        Compare: disabled (50% opacity) vs read-only (full opacity, no
+        interaction)
+      </div>
+      <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+        <ToggleButtonDemo
+          label="Disabled"
+          icon={<StarIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<StarIconSolid style={{width: 16, height: 16}} />}
+          isDisabled
+          defaultPressed
+        />
+        <ToggleButtonDemo
+          label="Read-only"
+          icon={<StarIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<StarIconSolid style={{width: 16, height: 16}} />}
+          isReadOnly
+          defaultPressed
+        />
+      </div>
+    </div>
+  ),
+};
+
+// =============================================================================
+// Async action
+// =============================================================================
+
+export const AsyncAction: Story = {
+  name: 'Async Action — API Toggle',
+  render: () => {
+    function AsyncToggleDemo() {
+      const [isFavorited, setIsFavorited] = useState(false);
+      const [isBookmarked, setIsBookmarked] = useState(true);
+
+      return (
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '16px',
+            maxWidth: '600px',
+          }}>
+          <div style={{fontSize: 12, color: '#4E606F', marginBottom: 4}}>
+            These buttons simulate an API call with a 1.5s delay. The button
+            shows a loading spinner during the transition. Try clicking rapidly
+            — the button is disabled while pending.
+          </div>
+          <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+            <XDSToggleButton
+              label="Favorite"
+              icon={<StarIcon style={{width: 16, height: 16}} />}
+              pressedIcon={<StarIconSolid style={{width: 16, height: 16}} />}
+              pressedIconColor="#F2C00B"
+              isPressed={isFavorited}
+              onPressedChange={setIsFavorited}
+              onPressedChangeAction={async () => {
+                await new Promise(r => setTimeout(r, 1500));
+              }}
+            />
+            <XDSToggleButton
+              label="Bookmark"
+              icon={<BookmarkIcon style={{width: 16, height: 16}} />}
+              pressedIcon={
+                <BookmarkIconSolid style={{width: 16, height: 16}} />
+              }
+              pressedIconColor="#0064E0"
+              isPressed={isBookmarked}
+              onPressedChange={setIsBookmarked}
+              onPressedChangeAction={async () => {
+                await new Promise(r => setTimeout(r, 1500));
+              }}>
+              Bookmark
+            </XDSToggleButton>
+          </div>
+        </div>
+      );
+    }
+    return <AsyncToggleDemo />;
+  },
+};
+
+// =============================================================================
 // Emphasized text — font-weight shift on press
 // =============================================================================
 

--- a/apps/storybook/stories/ToggleButton.stories.tsx
+++ b/apps/storybook/stories/ToggleButton.stories.tsx
@@ -1,0 +1,426 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSToggleButton} from '@xds/core/ToggleButton';
+import {
+  BoldIcon,
+  ItalicIcon,
+  UnderlineIcon,
+  Bars3BottomLeftIcon,
+  ListBulletIcon,
+  NumberedListIcon,
+  FunnelIcon,
+  StarIcon,
+  BookmarkIcon,
+  HeartIcon,
+  BellIcon,
+  EyeIcon,
+} from '@heroicons/react/24/outline';
+
+const meta: Meta<typeof XDSToggleButton> = {
+  title: 'Core/XDSToggleButton',
+  component: XDSToggleButton,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Accessible label (required)',
+    },
+    variant: {
+      control: 'select',
+      options: ['ghost', 'secondary', 'outline'],
+      description: 'Visual style variant',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Size variant',
+    },
+    isPressed: {
+      control: 'boolean',
+      description: 'Whether the button is pressed',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Disabled state',
+    },
+    isLoading: {
+      control: 'boolean',
+      description: 'Loading state',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSToggleButton>;
+
+// =============================================================================
+// Interactive wrapper for stateful stories
+// =============================================================================
+
+function ToggleButtonDemo(
+  props: Omit<
+    React.ComponentProps<typeof XDSToggleButton>,
+    'isPressed' | 'onPressedChange'
+  > & {defaultPressed?: boolean},
+) {
+  const {defaultPressed = false, ...rest} = props;
+  const [isPressed, setIsPressed] = useState(defaultPressed);
+  return (
+    <XDSToggleButton
+      {...rest}
+      isPressed={isPressed}
+      onPressedChange={setIsPressed}
+    />
+  );
+}
+
+// =============================================================================
+// Basic stories
+// =============================================================================
+
+export const Default: Story = {
+  args: {
+    label: 'Toggle',
+    isPressed: false,
+  },
+  render: args => {
+    const [isPressed, setIsPressed] = useState(args.isPressed);
+    return (
+      <XDSToggleButton
+        {...args}
+        isPressed={isPressed}
+        onPressedChange={setIsPressed}
+      />
+    );
+  },
+};
+
+export const Ghost: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <ToggleButtonDemo label="Unpressed" variant="ghost" />
+      <ToggleButtonDemo label="Pressed" variant="ghost" defaultPressed />
+    </div>
+  ),
+};
+
+export const Secondary: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <ToggleButtonDemo label="Unpressed" variant="secondary" />
+      <ToggleButtonDemo label="Pressed" variant="secondary" defaultPressed />
+    </div>
+  ),
+};
+
+export const Outline: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <ToggleButtonDemo label="Unpressed" variant="outline" />
+      <ToggleButtonDemo label="Pressed" variant="outline" defaultPressed />
+    </div>
+  ),
+};
+
+// =============================================================================
+// Icon-only
+// =============================================================================
+
+export const IconOnly: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+      <ToggleButtonDemo
+        label="Bold"
+        icon={<BoldIcon style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Italic"
+        icon={<ItalicIcon style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Underline"
+        icon={<UnderlineIcon style={{width: 16, height: 16}} />}
+      />
+    </div>
+  ),
+};
+
+export const IconOnlyPressed: Story = {
+  name: 'Icon Only (Pressed)',
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+      <ToggleButtonDemo
+        label="Bold"
+        icon={<BoldIcon style={{width: 16, height: 16}} />}
+        defaultPressed
+      />
+      <ToggleButtonDemo
+        label="Italic"
+        icon={<ItalicIcon style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Underline"
+        icon={<UnderlineIcon style={{width: 16, height: 16}} />}
+        defaultPressed
+      />
+    </div>
+  ),
+};
+
+// =============================================================================
+// Icon + Label
+// =============================================================================
+
+export const IconWithLabel: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <ToggleButtonDemo
+        label="Bookmark"
+        icon={<BookmarkIcon style={{width: 16, height: 16}} />}>
+        Bookmark
+      </ToggleButtonDemo>
+      <ToggleButtonDemo
+        label="Favorite"
+        icon={<HeartIcon style={{width: 16, height: 16}} />}
+        defaultPressed>
+        Favorite
+      </ToggleButtonDemo>
+    </div>
+  ),
+};
+
+// =============================================================================
+// Sizes
+// =============================================================================
+
+export const SizeVariants: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <ToggleButtonDemo
+        label="Small"
+        size="sm"
+        icon={<StarIcon style={{width: 14, height: 14}} />}
+      />
+      <ToggleButtonDemo
+        label="Medium"
+        size="md"
+        icon={<StarIcon style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Large"
+        size="lg"
+        icon={<StarIcon style={{width: 20, height: 20}} />}
+      />
+    </div>
+  ),
+};
+
+// =============================================================================
+// States
+// =============================================================================
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <ToggleButtonDemo label="Disabled unpressed" isDisabled />
+      <ToggleButtonDemo label="Disabled pressed" isDisabled defaultPressed />
+    </div>
+  ),
+};
+
+export const Loading: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <ToggleButtonDemo label="Loading" isLoading />
+      <ToggleButtonDemo
+        label="Loading"
+        isLoading
+        icon={<BellIcon style={{width: 16, height: 16}} />}
+      />
+    </div>
+  ),
+};
+
+// =============================================================================
+// Outline variant showcase
+// =============================================================================
+
+export const OutlineFilters: Story = {
+  name: 'Outline — Filter Chips',
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+      <ToggleButtonDemo
+        label="Active"
+        variant="outline"
+        icon={<FunnelIcon style={{width: 16, height: 16}} />}
+        defaultPressed>
+        Active
+      </ToggleButtonDemo>
+      <ToggleButtonDemo label="Starred" variant="outline">
+        Starred
+      </ToggleButtonDemo>
+      <ToggleButtonDemo label="Unread" variant="outline">
+        Unread
+      </ToggleButtonDemo>
+      <ToggleButtonDemo label="Archived" variant="outline">
+        Archived
+      </ToggleButtonDemo>
+    </div>
+  ),
+};
+
+// =============================================================================
+// Toolbar example
+// =============================================================================
+
+export const FormattingToolbar: Story = {
+  name: 'Example — Formatting Toolbar',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '4px',
+        alignItems: 'center',
+        padding: '4px',
+        borderRadius: '8px',
+        backgroundColor: 'var(--xds-color-wash, #F1F4F7)',
+      }}>
+      <ToggleButtonDemo
+        label="Bold"
+        icon={<BoldIcon style={{width: 16, height: 16}} />}
+        defaultPressed
+      />
+      <ToggleButtonDemo
+        label="Italic"
+        icon={<ItalicIcon style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Underline"
+        icon={<UnderlineIcon style={{width: 16, height: 16}} />}
+      />
+      <div
+        style={{
+          width: 1,
+          height: 20,
+          backgroundColor: 'var(--xds-color-divider, #05365919)',
+          margin: '0 4px',
+        }}
+      />
+      <ToggleButtonDemo
+        label="Align left"
+        icon={<Bars3BottomLeftIcon style={{width: 16, height: 16}} />}
+        defaultPressed
+      />
+      <ToggleButtonDemo
+        label="Bulleted list"
+        icon={<ListBulletIcon style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Numbered list"
+        icon={<NumberedListIcon style={{width: 16, height: 16}} />}
+      />
+    </div>
+  ),
+};
+
+// =============================================================================
+// All variants matrix
+// =============================================================================
+
+export const AllVariants: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        maxWidth: '700px',
+      }}>
+      <div>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            marginBottom: 8,
+            color: '#4E606F',
+          }}>
+          Ghost
+        </div>
+        <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+          <ToggleButtonDemo label="Default" variant="ghost" />
+          <ToggleButtonDemo label="Pressed" variant="ghost" defaultPressed />
+          <ToggleButtonDemo label="Disabled" variant="ghost" isDisabled />
+          <ToggleButtonDemo
+            label="Icon"
+            variant="ghost"
+            icon={<EyeIcon style={{width: 16, height: 16}} />}
+          />
+          <ToggleButtonDemo
+            label="Icon pressed"
+            variant="ghost"
+            icon={<EyeIcon style={{width: 16, height: 16}} />}
+            defaultPressed
+          />
+        </div>
+      </div>
+      <div>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            marginBottom: 8,
+            color: '#4E606F',
+          }}>
+          Secondary
+        </div>
+        <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+          <ToggleButtonDemo label="Default" variant="secondary" />
+          <ToggleButtonDemo
+            label="Pressed"
+            variant="secondary"
+            defaultPressed
+          />
+          <ToggleButtonDemo label="Disabled" variant="secondary" isDisabled />
+          <ToggleButtonDemo
+            label="Icon"
+            variant="secondary"
+            icon={<EyeIcon style={{width: 16, height: 16}} />}
+          />
+          <ToggleButtonDemo
+            label="Icon pressed"
+            variant="secondary"
+            icon={<EyeIcon style={{width: 16, height: 16}} />}
+            defaultPressed
+          />
+        </div>
+      </div>
+      <div>
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 600,
+            marginBottom: 8,
+            color: '#4E606F',
+          }}>
+          Outline
+        </div>
+        <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+          <ToggleButtonDemo label="Default" variant="outline" />
+          <ToggleButtonDemo label="Pressed" variant="outline" defaultPressed />
+          <ToggleButtonDemo label="Disabled" variant="outline" isDisabled />
+          <ToggleButtonDemo
+            label="Icon"
+            variant="outline"
+            icon={<EyeIcon style={{width: 16, height: 16}} />}
+          />
+          <ToggleButtonDemo
+            label="Icon pressed"
+            variant="outline"
+            icon={<EyeIcon style={{width: 16, height: 16}} />}
+            defaultPressed
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/apps/storybook/stories/ToggleButton.stories.tsx
+++ b/apps/storybook/stories/ToggleButton.stories.tsx
@@ -15,6 +15,16 @@ import {
   BellIcon,
   EyeIcon,
 } from '@heroicons/react/24/outline';
+import {
+  BoldIcon as BoldIconSolid,
+  ItalicIcon as ItalicIconSolid,
+  UnderlineIcon as UnderlineIconSolid,
+  StarIcon as StarIconSolid,
+  BookmarkIcon as BookmarkIconSolid,
+  HeartIcon as HeartIconSolid,
+  BellIcon as BellIconSolid,
+  EyeIcon as EyeIconSolid,
+} from '@heroicons/react/24/solid';
 
 const meta: Meta<typeof XDSToggleButton> = {
   title: 'Core/XDSToggleButton',
@@ -288,15 +298,18 @@ export const FormattingToolbar: Story = {
       <ToggleButtonDemo
         label="Bold"
         icon={<BoldIcon style={{width: 16, height: 16}} />}
+        pressedIcon={<BoldIconSolid style={{width: 16, height: 16}} />}
         defaultPressed
       />
       <ToggleButtonDemo
         label="Italic"
         icon={<ItalicIcon style={{width: 16, height: 16}} />}
+        pressedIcon={<ItalicIconSolid style={{width: 16, height: 16}} />}
       />
       <ToggleButtonDemo
         label="Underline"
         icon={<UnderlineIcon style={{width: 16, height: 16}} />}
+        pressedIcon={<UnderlineIconSolid style={{width: 16, height: 16}} />}
       />
       <div
         style={{
@@ -318,6 +331,43 @@ export const FormattingToolbar: Story = {
       <ToggleButtonDemo
         label="Numbered list"
         icon={<NumberedListIcon style={{width: 16, height: 16}} />}
+      />
+    </div>
+  ),
+};
+
+// =============================================================================
+// Icon swap — outline to filled
+// =============================================================================
+
+export const IconSwap: Story = {
+  name: 'Icon Swap — Outline to Filled',
+  render: () => (
+    <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
+      <ToggleButtonDemo
+        label="Favorite"
+        icon={<HeartIcon style={{width: 16, height: 16}} />}
+        pressedIcon={<HeartIconSolid style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Bookmark"
+        icon={<BookmarkIcon style={{width: 16, height: 16}} />}
+        pressedIcon={<BookmarkIconSolid style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Star"
+        icon={<StarIcon style={{width: 16, height: 16}} />}
+        pressedIcon={<StarIconSolid style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Notifications"
+        icon={<BellIcon style={{width: 16, height: 16}} />}
+        pressedIcon={<BellIconSolid style={{width: 16, height: 16}} />}
+      />
+      <ToggleButtonDemo
+        label="Watching"
+        icon={<EyeIcon style={{width: 16, height: 16}} />}
+        pressedIcon={<EyeIconSolid style={{width: 16, height: 16}} />}
       />
     </div>
   ),
@@ -354,11 +404,13 @@ export const AllVariants: Story = {
             label="Icon"
             variant="ghost"
             icon={<EyeIcon style={{width: 16, height: 16}} />}
+            pressedIcon={<EyeIconSolid style={{width: 16, height: 16}} />}
           />
           <ToggleButtonDemo
             label="Icon pressed"
             variant="ghost"
             icon={<EyeIcon style={{width: 16, height: 16}} />}
+            pressedIcon={<EyeIconSolid style={{width: 16, height: 16}} />}
             defaultPressed
           />
         </div>
@@ -385,11 +437,13 @@ export const AllVariants: Story = {
             label="Icon"
             variant="secondary"
             icon={<EyeIcon style={{width: 16, height: 16}} />}
+            pressedIcon={<EyeIconSolid style={{width: 16, height: 16}} />}
           />
           <ToggleButtonDemo
             label="Icon pressed"
             variant="secondary"
             icon={<EyeIcon style={{width: 16, height: 16}} />}
+            pressedIcon={<EyeIconSolid style={{width: 16, height: 16}} />}
             defaultPressed
           />
         </div>
@@ -412,11 +466,13 @@ export const AllVariants: Story = {
             label="Icon"
             variant="outline"
             icon={<EyeIcon style={{width: 16, height: 16}} />}
+            pressedIcon={<EyeIconSolid style={{width: 16, height: 16}} />}
           />
           <ToggleButtonDemo
             label="Icon pressed"
             variant="outline"
             icon={<EyeIcon style={{width: 16, height: 16}} />}
+            pressedIcon={<EyeIconSolid style={{width: 16, height: 16}} />}
             defaultPressed
           />
         </div>

--- a/apps/storybook/stories/ToggleButton.stories.tsx
+++ b/apps/storybook/stories/ToggleButton.stories.tsx
@@ -374,6 +374,82 @@ export const IconSwap: Story = {
 };
 
 // =============================================================================
+// Emphasized text — font-weight shift on press
+// =============================================================================
+
+export const EmphasizedText: Story = {
+  name: 'Emphasized Text — No Layout Shift',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        maxWidth: '600px',
+      }}>
+      <div
+        style={{
+          fontSize: 12,
+          color: '#4E606F',
+          marginBottom: 4,
+        }}>
+        Toggle these buttons — the text goes semibold when pressed, but the
+        button width stays constant (no layout shift). A hidden pseudo-element
+        reserves the semibold width at all times.
+      </div>
+      <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+        <ToggleButtonDemo label="Notifications" variant="ghost" />
+        <ToggleButtonDemo label="Following" variant="ghost" defaultPressed />
+        <ToggleButtonDemo label="Mentions" variant="ghost" />
+      </div>
+      <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+        <ToggleButtonDemo label="Active" variant="secondary" defaultPressed />
+        <ToggleButtonDemo label="Pending" variant="secondary" />
+        <ToggleButtonDemo label="Archived" variant="secondary" />
+      </div>
+      <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+        <ToggleButtonDemo label="All" variant="outline" />
+        <ToggleButtonDemo label="Published" variant="outline" defaultPressed />
+        <ToggleButtonDemo label="Drafts" variant="outline" />
+        <ToggleButtonDemo label="Scheduled" variant="outline" />
+      </div>
+      <div
+        style={{
+          fontSize: 12,
+          color: '#4E606F',
+          marginTop: 8,
+        }}>
+        Icon + label combo with both icon swap and emphasized text:
+      </div>
+      <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
+        <ToggleButtonDemo
+          label="Favorite"
+          variant="ghost"
+          icon={<HeartIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<HeartIconSolid style={{width: 16, height: 16}} />}>
+          Favorite
+        </ToggleButtonDemo>
+        <ToggleButtonDemo
+          label="Bookmark"
+          variant="ghost"
+          icon={<BookmarkIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<BookmarkIconSolid style={{width: 16, height: 16}} />}
+          defaultPressed>
+          Bookmark
+        </ToggleButtonDemo>
+        <ToggleButtonDemo
+          label="Watch"
+          variant="outline"
+          icon={<EyeIcon style={{width: 16, height: 16}} />}
+          pressedIcon={<EyeIconSolid style={{width: 16, height: 16}} />}>
+          Watch
+        </ToggleButtonDemo>
+      </div>
+    </div>
+  ),
+};
+
+// =============================================================================
 // All variants matrix
 // =============================================================================
 

--- a/packages/core/src/ToggleButton/README.md
+++ b/packages/core/src/ToggleButton/README.md
@@ -14,6 +14,7 @@ For on/off settings, use XDSSwitch. For regular actions, use XDSButton.
 - **Pressed state**: Visual indicator with `aria-pressed` for accessibility
 - **Loading state**: Shows spinner, disables interaction
 - **Icon-only mode**: Square button with `aria-label` and default tooltip
+- **Icon swap**: Optional `pressedIcon` for outline-to-filled icon transitions
 - **Tooltip**: Automatic for icon-only buttons, opt-in for labeled buttons
 - **Theme overrides**: Supports component-level variant overrides via `theme.components.toggleButton.variants`
 
@@ -63,6 +64,7 @@ const [isBold, setIsBold] = useState(false);
 | `isDisabled`      | `boolean`                             | `false`   | Disables the button                            |
 | `isLoading`       | `boolean`                             | `false`   | Shows loading spinner                          |
 | `icon`            | `ReactNode`                           | —         | Icon element                                   |
+| `pressedIcon`     | `ReactNode`                           | —         | Icon shown when pressed (outline→filled swap)  |
 | `children`        | `ReactNode`                           | —         | Visible label content                          |
 | `tooltip`         | `string`                              | —         | Tooltip text (defaults to label for icon-only) |
 | `value`           | `string`                              | —         | Value identifier for use in groups             |

--- a/packages/core/src/ToggleButton/README.md
+++ b/packages/core/src/ToggleButton/README.md
@@ -15,6 +15,7 @@ For on/off settings, use XDSSwitch. For regular actions, use XDSButton.
 - **Loading state**: Shows spinner, disables interaction
 - **Icon-only mode**: Square button with `aria-label` and default tooltip
 - **Icon swap**: Optional `pressedIcon` for outline-to-filled icon transitions
+- **Emphasized text**: Label text goes semibold when pressed, with hidden pseudo-element to prevent layout shift
 - **Tooltip**: Automatic for icon-only buttons, opt-in for labeled buttons
 - **Theme overrides**: Supports component-level variant overrides via `theme.components.toggleButton.variants`
 
@@ -98,6 +99,7 @@ const [isBold, setIsBold] = useState(false);
 ## Implementation Notes
 
 - Pressed state uses `--color-pressed-overlay` for background, `--color-icon-primary` / `--color-text-primary` for text/icon color
+- Pressed label text uses `--font-weight-semibold` (vs `--font-weight-medium` unpressed). A hidden `<span>` with semibold weight reserves the wider width to prevent layout shift when toggling — same technique used by Material UI's bottom navigation
 - Outline variant uses `--color-divider-emphasized` for border in all states (default, hover, pressed) — only the fill changes
 - Hover/active states layer overlays via `backgroundImage` (same pattern as XDSButton)
 - `value` prop is reserved for future XDSToggleButtonGroup integration

--- a/packages/core/src/ToggleButton/README.md
+++ b/packages/core/src/ToggleButton/README.md
@@ -1,0 +1,101 @@
+# /packages/core/src/ToggleButton
+
+XDSToggleButton component — a button that toggles between pressed and unpressed states.
+
+Use for toolbar actions, view mode switches, and formatting controls.
+For on/off settings, use XDSSwitch. For regular actions, use XDSButton.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Variants**: `ghost`, `secondary`, `outline` — outline formalizes the pattern previously hacked via XDSInputGroup styling
+- **Sizes**: `sm` (28px), `md` (32px), `lg` (36px)
+- **Pressed state**: Visual indicator with `aria-pressed` for accessibility
+- **Loading state**: Shows spinner, disables interaction
+- **Icon-only mode**: Square button with `aria-label` and default tooltip
+- **Tooltip**: Automatic for icon-only buttons, opt-in for labeled buttons
+- **Theme overrides**: Supports component-level variant overrides via `theme.components.toggleButton.variants`
+
+## Usage
+
+```tsx
+import { XDSToggleButton } from '@xds/core/ToggleButton';
+
+// Icon-only toggle (most common — toolbar usage)
+const [isBold, setIsBold] = useState(false);
+<XDSToggleButton
+  label="Bold"
+  icon={<BoldIcon />}
+  isPressed={isBold}
+  onPressedChange={setIsBold}
+/>
+
+// With visible label
+<XDSToggleButton
+  label="Show details"
+  isPressed={showDetails}
+  onPressedChange={setShowDetails}
+>
+  Show details
+</XDSToggleButton>
+
+// Outline variant — chip-like toggle for filters
+<XDSToggleButton
+  label="Active"
+  variant="outline"
+  isPressed={isActive}
+  onPressedChange={setIsActive}
+>
+  Active
+</XDSToggleButton>
+```
+
+## Props
+
+| Prop              | Type                                  | Default   | Description                                    |
+| ----------------- | ------------------------------------- | --------- | ---------------------------------------------- |
+| `label`           | `string`                              | —         | Accessible label (required)                    |
+| `isPressed`       | `boolean`                             | —         | Whether the button is pressed (required)       |
+| `onPressedChange` | `(isPressed: boolean) => void`        | —         | Pressed state change handler (required)        |
+| `variant`         | `'ghost' \| 'secondary' \| 'outline'` | `'ghost'` | Visual style variant                           |
+| `size`            | `'sm' \| 'md' \| 'lg'`                | `'md'`    | Size variant                                   |
+| `isDisabled`      | `boolean`                             | `false`   | Disables the button                            |
+| `isLoading`       | `boolean`                             | `false`   | Shows loading spinner                          |
+| `icon`            | `ReactNode`                           | —         | Icon element                                   |
+| `children`        | `ReactNode`                           | —         | Visible label content                          |
+| `tooltip`         | `string`                              | —         | Tooltip text (defaults to label for icon-only) |
+| `value`           | `string`                              | —         | Value identifier for use in groups             |
+| `data-testid`     | `string`                              | —         | Test ID                                        |
+
+## Accessibility
+
+- Uses `aria-pressed="true/false"` for toggle state
+- Icon-only buttons use `aria-label` from `label` prop
+- Keyboard: Space/Enter toggles pressed state (native `<button>` behavior)
+- Focus ring visible on keyboard focus (`:focus-visible`)
+
+## Design Decisions
+
+| Decision                      | Choice                 | Rationale                                                                                  |
+| ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
+| Separate component            | Yes                    | Different semantics (toggle state), different ARIA (`aria-pressed`), different variant set |
+| `isPressed` naming            | Follows `aria-pressed` | WAI-ARIA terminology. `isSelected` implies listbox pattern.                                |
+| Outline variant in v1         | Included               | Formalizes the pattern previously achieved by hacking XDSInputGroup borders onto buttons   |
+| No `primary`/`destructive`    | Intentional            | Toggle buttons are mode switches, not primary actions or destructive operations            |
+| Default tooltip for icon-only | Yes                    | Icon-only buttons need tooltips for discoverability                                        |
+
+## Files
+
+| File                       | Role  | Purpose                                     |
+| -------------------------- | ----- | ------------------------------------------- |
+| `index.ts`                 | Entry | Exports XDSToggleButton component and types |
+| `XDSToggleButton.tsx`      | Core  | XDSToggleButton component implementation    |
+| `XDSToggleButton.test.tsx` | Test  | Unit tests for XDSToggleButton component    |
+
+## Implementation Notes
+
+- Pressed state uses `--color-pressed-overlay` for background, `--color-icon-primary` / `--color-text-primary` for text/icon color
+- Outline variant uses `--color-divider-emphasized` for border in all states (default, hover, pressed) — only the fill changes
+- Hover/active states layer overlays via `backgroundImage` (same pattern as XDSButton)
+- `value` prop is reserved for future XDSToggleButtonGroup integration

--- a/packages/core/src/ToggleButton/README.md
+++ b/packages/core/src/ToggleButton/README.md
@@ -2,7 +2,9 @@
 
 XDSToggleButton component — a button that toggles between pressed and unpressed states.
 
-Use for toolbar actions, view mode switches, and formatting controls.
+Use for toolbar actions, view mode switches, formatting controls, and icon toggles
+(favorite, bookmark, like). Subsumes the XDSToggleIcon pattern (#186) into a single component.
+
 For on/off settings, use XDSSwitch. For regular actions, use XDSButton.
 
 <!-- SYNC: When files in this directory change, update this document. -->
@@ -12,11 +14,14 @@ For on/off settings, use XDSSwitch. For regular actions, use XDSButton.
 - **Variants**: `ghost`, `secondary`, `outline` — outline formalizes the pattern previously hacked via XDSInputGroup styling
 - **Sizes**: `sm` (28px), `md` (32px), `lg` (36px)
 - **Pressed state**: Visual indicator with `aria-pressed` for accessibility
+- **Icon swap**: Optional `pressedIcon` for outline-to-filled icon transitions
+- **Pressed icon color**: Semantic icon coloring when pressed (yellow star, pink heart)
+- **Emphasized text**: Label text goes semibold when pressed, with hidden element to prevent layout shift
+- **Read-only state**: Show toggle state without allowing interaction (e.g., viewing someone else's favorites)
+- **Async transitions**: `onPressedChangeAction` for API-backed toggles with automatic loading state
 - **Loading state**: Shows spinner, disables interaction
 - **Icon-only mode**: Square button with `aria-label` and default tooltip
-- **Icon swap**: Optional `pressedIcon` for outline-to-filled icon transitions
-- **Emphasized text**: Label text goes semibold when pressed, with hidden pseudo-element to prevent layout shift
-- **Tooltip**: Automatic for icon-only buttons, opt-in for labeled buttons
+- **Tooltip control**: Automatic for icon-only buttons, controllable via `hasTooltip`
 - **Theme overrides**: Supports component-level variant overrides via `theme.components.toggleButton.variants`
 
 ## Usage
@@ -24,7 +29,7 @@ For on/off settings, use XDSSwitch. For regular actions, use XDSButton.
 ```tsx
 import { XDSToggleButton } from '@xds/core/ToggleButton';
 
-// Icon-only toggle (most common — toolbar usage)
+// Icon-only toggle (toolbar usage)
 const [isBold, setIsBold] = useState(false);
 <XDSToggleButton
   label="Bold"
@@ -33,14 +38,38 @@ const [isBold, setIsBold] = useState(false);
   onPressedChange={setIsBold}
 />
 
-// With visible label
+// Favorite with icon swap and semantic color
 <XDSToggleButton
-  label="Show details"
-  isPressed={showDetails}
-  onPressedChange={setShowDetails}
->
-  Show details
-</XDSToggleButton>
+  label="Favorite"
+  icon={<StarIcon />}
+  pressedIcon={<StarIconSolid />}
+  pressedIconColor="#F2C00B"
+  isPressed={isFavorited}
+  onPressedChange={setIsFavorited}
+/>
+
+// Async toggle with API call
+<XDSToggleButton
+  label="Bookmark"
+  icon={<BookmarkIcon />}
+  pressedIcon={<BookmarkIconSolid />}
+  isPressed={isBookmarked}
+  onPressedChange={setIsBookmarked}
+  onPressedChangeAction={async (newState) => {
+    await api.bookmark(itemId, newState);
+  }}
+/>
+
+// Read-only (viewing someone else's favorites)
+<XDSToggleButton
+  label="Favorited by user"
+  icon={<StarIcon />}
+  pressedIcon={<StarIconSolid />}
+  pressedIconColor="#F2C00B"
+  isPressed={true}
+  onPressedChange={() => {}}
+  isReadOnly
+/>
 
 // Outline variant — chip-like toggle for filters
 <XDSToggleButton
@@ -55,38 +84,48 @@ const [isBold, setIsBold] = useState(false);
 
 ## Props
 
-| Prop              | Type                                  | Default   | Description                                    |
-| ----------------- | ------------------------------------- | --------- | ---------------------------------------------- |
-| `label`           | `string`                              | —         | Accessible label (required)                    |
-| `isPressed`       | `boolean`                             | —         | Whether the button is pressed (required)       |
-| `onPressedChange` | `(isPressed: boolean) => void`        | —         | Pressed state change handler (required)        |
-| `variant`         | `'ghost' \| 'secondary' \| 'outline'` | `'ghost'` | Visual style variant                           |
-| `size`            | `'sm' \| 'md' \| 'lg'`                | `'md'`    | Size variant                                   |
-| `isDisabled`      | `boolean`                             | `false`   | Disables the button                            |
-| `isLoading`       | `boolean`                             | `false`   | Shows loading spinner                          |
-| `icon`            | `ReactNode`                           | —         | Icon element                                   |
-| `pressedIcon`     | `ReactNode`                           | —         | Icon shown when pressed (outline→filled swap)  |
-| `children`        | `ReactNode`                           | —         | Visible label content                          |
-| `tooltip`         | `string`                              | —         | Tooltip text (defaults to label for icon-only) |
-| `value`           | `string`                              | —         | Value identifier for use in groups             |
-| `data-testid`     | `string`                              | —         | Test ID                                        |
+| Prop                    | Type                                    | Default   | Description                                            |
+| ----------------------- | --------------------------------------- | --------- | ------------------------------------------------------ |
+| `label`                 | `string`                                | —         | Accessible label (required)                            |
+| `isPressed`             | `boolean`                               | —         | Whether the button is pressed (required)               |
+| `onPressedChange`       | `(isPressed: boolean) => void`          | —         | Pressed state change handler (required)                |
+| `onPressedChangeAction` | `(isPressed: boolean) => Promise<void>` | —         | Async action with React 19 transitions                 |
+| `variant`               | `'ghost' \| 'secondary' \| 'outline'`   | `'ghost'` | Visual style variant                                   |
+| `size`                  | `'sm' \| 'md' \| 'lg'`                  | `'md'`    | Size variant                                           |
+| `isDisabled`            | `boolean`                               | `false`   | Disables the button                                    |
+| `isLoading`             | `boolean`                               | `false`   | Shows loading spinner                                  |
+| `isReadOnly`            | `boolean`                               | `false`   | Shows state without interaction                        |
+| `icon`                  | `ReactNode`                             | —         | Icon element                                           |
+| `pressedIcon`           | `ReactNode`                             | —         | Icon shown when pressed (outline→filled swap)          |
+| `pressedIconColor`      | `string`                                | —         | CSS color for icon when pressed (e.g., `"#F2C00B"`)    |
+| `children`              | `ReactNode`                             | —         | Visible label content                                  |
+| `tooltip`               | `string`                                | —         | Tooltip text (defaults to label for icon-only)         |
+| `hasTooltip`            | `boolean`                               | auto      | Control tooltip visibility (auto = true for icon-only) |
+| `value`                 | `string`                                | —         | Value identifier for use in groups                     |
+| `data-testid`           | `string`                                | —         | Test ID                                                |
 
 ## Accessibility
 
 - Uses `aria-pressed="true/false"` for toggle state
 - Icon-only buttons use `aria-label` from `label` prop
+- Read-only uses `aria-readonly="true"` — focusable but not interactive
+- Async pending state uses native `disabled` to prevent re-click
 - Keyboard: Space/Enter toggles pressed state (native `<button>` behavior)
 - Focus ring visible on keyboard focus (`:focus-visible`)
+- `pressedIconColor` is not the sole indicator — icon shape change provides redundant visual cue
 
 ## Design Decisions
 
-| Decision                      | Choice                 | Rationale                                                                                  |
-| ----------------------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
-| Separate component            | Yes                    | Different semantics (toggle state), different ARIA (`aria-pressed`), different variant set |
-| `isPressed` naming            | Follows `aria-pressed` | WAI-ARIA terminology. `isSelected` implies listbox pattern.                                |
-| Outline variant in v1         | Included               | Formalizes the pattern previously achieved by hacking XDSInputGroup borders onto buttons   |
-| No `primary`/`destructive`    | Intentional            | Toggle buttons are mode switches, not primary actions or destructive operations            |
-| Default tooltip for icon-only | Yes                    | Icon-only buttons need tooltips for discoverability                                        |
+| Decision                        | Choice                 | Rationale                                                                                  |
+| ------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------ |
+| Separate component              | Yes                    | Different semantics (toggle state), different ARIA (`aria-pressed`), different variant set |
+| Subsumes XDSToggleIcon (#186)   | Yes                    | `pressedIcon` + `pressedIconColor` cover icon toggle patterns without a separate component |
+| `isPressed` naming              | Follows `aria-pressed` | WAI-ARIA terminology. `isSelected` implies listbox pattern.                                |
+| Outline variant in v1           | Included               | Formalizes the pattern previously achieved by hacking XDSInputGroup borders onto buttons   |
+| No `primary`/`destructive`      | Intentional            | Toggle buttons are mode switches, not primary actions or destructive operations            |
+| `pressedIconColor` on icon only | Intentional            | Semantic color applies to icon, not label text — label uses standard text color            |
+| `isReadOnly` vs `isDisabled`    | Both supported         | Read-only shows state at full opacity, disabled reduces opacity. Different use cases.      |
+| `hasTooltip` default            | Auto (icon-only=true)  | Icon-only buttons need tooltips; labeled buttons don't by default                          |
 
 ## Files
 
@@ -100,6 +139,9 @@ const [isBold, setIsBold] = useState(false);
 
 - Pressed state uses `--color-pressed-overlay` for background, `--color-icon-primary` / `--color-text-primary` for text/icon color
 - Pressed label text uses `--font-weight-semibold` (vs `--font-weight-medium` unpressed). A hidden `<span>` with semibold weight reserves the wider width to prevent layout shift when toggling — same technique used by Material UI's bottom navigation
+- `pressedIconColor` wraps the icon in a `<span>` with inline `color` style — SVG icons inherit `currentColor`
+- Read-only removes hover/active overlays and sets `cursor: default`. Not `disabled` so it remains focusable.
+- `onPressedChangeAction` uses React's `useTransition` — the button shows a spinner and is disabled while the promise is pending
 - Outline variant uses `--color-divider-emphasized` for border in all states (default, hover, pressed) — only the fill changes
 - Hover/active states layer overlays via `backgroundImage` (same pattern as XDSButton)
 - `value` prop is reserved for future XDSToggleButtonGroup integration

--- a/packages/core/src/ToggleButton/XDSToggleButton.test.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.test.tsx
@@ -117,6 +117,40 @@ describe('XDSToggleButton', () => {
   });
 
   // =========================================================================
+  // pressedIconColor
+  // =========================================================================
+
+  it('applies pressedIconColor to icon wrapper when pressed', () => {
+    render(
+      <XDSToggleButton
+        label="Favorite"
+        isPressed={true}
+        onPressedChange={() => {}}
+        icon={<span data-testid="icon">★</span>}
+        pressedIconColor="#F2C00B"
+      />,
+    );
+    const icon = screen.getByTestId('icon');
+    const wrapper = icon.parentElement;
+    expect(wrapper).toHaveStyle({color: '#F2C00B'});
+  });
+
+  it('does not apply pressedIconColor when not pressed', () => {
+    render(
+      <XDSToggleButton
+        label="Favorite"
+        isPressed={false}
+        onPressedChange={() => {}}
+        icon={<span data-testid="icon">☆</span>}
+        pressedIconColor="#F2C00B"
+      />,
+    );
+    const icon = screen.getByTestId('icon');
+    // Icon should not be wrapped in a color span
+    expect(icon.parentElement?.tagName).toBe('BUTTON');
+  });
+
+  // =========================================================================
   // Emphasized text (font-weight shift prevention)
   // =========================================================================
 
@@ -129,7 +163,6 @@ describe('XDSToggleButton', () => {
       />,
     );
     const button = screen.getByRole('button');
-    // The hidden width-reservation span should exist with aria-hidden
     const hiddenSpan = button.querySelector('[aria-hidden="true"]');
     expect(hiddenSpan).toBeInTheDocument();
     expect(hiddenSpan).toHaveTextContent('Bold');
@@ -246,6 +279,28 @@ describe('XDSToggleButton', () => {
   });
 
   // =========================================================================
+  // onPressedChangeAction (async transitions)
+  // =========================================================================
+
+  it('calls onPressedChangeAction with new state', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const handleAction = vi.fn().mockResolvedValue(undefined);
+    render(
+      <XDSToggleButton
+        label="Favorite"
+        isPressed={false}
+        onPressedChange={handleChange}
+        onPressedChangeAction={handleAction}
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleChange).toHaveBeenCalledWith(true);
+    expect(handleAction).toHaveBeenCalledWith(true);
+  });
+
+  // =========================================================================
   // Disabled state
   // =========================================================================
 
@@ -279,6 +334,83 @@ describe('XDSToggleButton', () => {
 
     await user.click(screen.getByRole('button'));
     expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Read-only state
+  // =========================================================================
+
+  it('does not fire events when read-only', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSToggleButton
+        label="Favorite"
+        isPressed={true}
+        onPressedChange={handleChange}
+        isReadOnly
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('sets aria-readonly when read-only', () => {
+    render(
+      <XDSToggleButton
+        label="Favorite"
+        isPressed={true}
+        onPressedChange={() => {}}
+        isReadOnly
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-readonly', 'true');
+  });
+
+  it('is not disabled when read-only (preserves focusability)', () => {
+    render(
+      <XDSToggleButton
+        label="Favorite"
+        isPressed={true}
+        onPressedChange={() => {}}
+        isReadOnly
+      />,
+    );
+    expect(screen.getByRole('button')).not.toBeDisabled();
+  });
+
+  // =========================================================================
+  // hasTooltip
+  // =========================================================================
+
+  it('does not render tooltip when hasTooltip is false for icon-only', () => {
+    const {container} = render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+        icon={<span>B</span>}
+        hasTooltip={false}
+      />,
+    );
+    // Without tooltip, the button should be rendered directly (no tooltip wrapper)
+    const button = screen.getByRole('button');
+    expect(button.parentElement).toBe(container);
+  });
+
+  it('renders tooltip when hasTooltip is true for labeled button', () => {
+    const {container} = render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+        hasTooltip={true}
+      />,
+    );
+    // With tooltip, the button should be wrapped
+    const button = screen.getByRole('button');
+    expect(button.parentElement).not.toBe(container);
   });
 
   // =========================================================================

--- a/packages/core/src/ToggleButton/XDSToggleButton.test.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.test.tsx
@@ -73,6 +73,50 @@ describe('XDSToggleButton', () => {
   });
 
   // =========================================================================
+  // pressedIcon
+  // =========================================================================
+
+  it('renders pressedIcon when pressed', () => {
+    render(
+      <XDSToggleButton
+        label="Favorite"
+        isPressed={true}
+        onPressedChange={() => {}}
+        icon={<span data-testid="outline-icon">♡</span>}
+        pressedIcon={<span data-testid="filled-icon">♥</span>}
+      />,
+    );
+    expect(screen.getByTestId('filled-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('outline-icon')).not.toBeInTheDocument();
+  });
+
+  it('renders icon when not pressed even if pressedIcon provided', () => {
+    render(
+      <XDSToggleButton
+        label="Favorite"
+        isPressed={false}
+        onPressedChange={() => {}}
+        icon={<span data-testid="outline-icon">♡</span>}
+        pressedIcon={<span data-testid="filled-icon">♥</span>}
+      />,
+    );
+    expect(screen.getByTestId('outline-icon')).toBeInTheDocument();
+    expect(screen.queryByTestId('filled-icon')).not.toBeInTheDocument();
+  });
+
+  it('falls back to icon when pressed and no pressedIcon', () => {
+    render(
+      <XDSToggleButton
+        label="Star"
+        isPressed={true}
+        onPressedChange={() => {}}
+        icon={<span data-testid="default-icon">☆</span>}
+      />,
+    );
+    expect(screen.getByTestId('default-icon')).toBeInTheDocument();
+  });
+
+  // =========================================================================
   // aria-pressed
   // =========================================================================
 

--- a/packages/core/src/ToggleButton/XDSToggleButton.test.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.test.tsx
@@ -1,0 +1,274 @@
+/**
+ * @file XDSToggleButton.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSToggleButton component
+ * @output Unit tests for XDSToggleButton component behavior
+ * @position Testing; validates XDSToggleButton.tsx implementation
+ *
+ * SYNC: When XDSToggleButton.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSToggleButton} from './XDSToggleButton';
+
+describe('XDSToggleButton', () => {
+  // =========================================================================
+  // Rendering
+  // =========================================================================
+
+  it('renders label as visible text', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button', {name: 'Bold'})).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveTextContent('Bold');
+  });
+
+  it('renders children instead of label when provided', () => {
+    render(
+      <XDSToggleButton
+        label="Toggle bold"
+        isPressed={false}
+        onPressedChange={() => {}}>
+        Custom content
+      </XDSToggleButton>,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toHaveTextContent('Custom content');
+  });
+
+  it('renders icon-only button with aria-label', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+        icon={<span data-testid="icon">B</span>}
+      />,
+    );
+    const button = screen.getByRole('button', {name: 'Bold'});
+    expect(button).toHaveAttribute('aria-label', 'Bold');
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('renders icon with text when both icon and children provided', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+        icon={<span data-testid="icon">B</span>}>
+        Bold
+      </XDSToggleButton>,
+    );
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveAttribute('aria-label');
+    expect(button).toHaveTextContent('Bold');
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // aria-pressed
+  // =========================================================================
+
+  it('sets aria-pressed=false when not pressed', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('sets aria-pressed=true when pressed', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={true}
+        onPressedChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  // =========================================================================
+  // Interaction
+  // =========================================================================
+
+  it('calls onPressedChange with true when clicking unpressed button', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={handleChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onPressedChange with false when clicking pressed button', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={true}
+        onPressedChange={handleChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(false);
+  });
+
+  it('calls onClick in addition to onPressedChange', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    const handleChange = vi.fn();
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={handleChange}
+        onClick={handleClick}
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+
+  // =========================================================================
+  // Disabled state
+  // =========================================================================
+
+  it('does not fire events when disabled', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={handleChange}
+        isDisabled
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('does not fire events when loading', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={handleChange}
+        isLoading
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // Variants
+  // =========================================================================
+
+  it('renders with different variants', () => {
+    const {rerender} = render(
+      <XDSToggleButton
+        label="Toggle"
+        isPressed={false}
+        onPressedChange={() => {}}
+        variant="ghost"
+      />,
+    );
+    expect(screen.getByRole('button')).toBeInTheDocument();
+
+    rerender(
+      <XDSToggleButton
+        label="Toggle"
+        isPressed={false}
+        onPressedChange={() => {}}
+        variant="secondary"
+      />,
+    );
+    expect(screen.getByRole('button')).toBeInTheDocument();
+
+    rerender(
+      <XDSToggleButton
+        label="Toggle"
+        isPressed={false}
+        onPressedChange={() => {}}
+        variant="outline"
+      />,
+    );
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // Ref forwarding
+  // =========================================================================
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+        ref={ref}
+      />,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLButtonElement));
+  });
+
+  // =========================================================================
+  // Button type
+  // =========================================================================
+
+  it('has type="button" to prevent form submission', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+
+  // =========================================================================
+  // data-testid
+  // =========================================================================
+
+  it('passes data-testid through', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+        data-testid="bold-toggle"
+      />,
+    );
+    expect(screen.getByTestId('bold-toggle')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/ToggleButton/XDSToggleButton.test.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.test.tsx
@@ -117,6 +117,55 @@ describe('XDSToggleButton', () => {
   });
 
   // =========================================================================
+  // Emphasized text (font-weight shift prevention)
+  // =========================================================================
+
+  it('renders width reservation element for label text', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+      />,
+    );
+    const button = screen.getByRole('button');
+    // The hidden width-reservation span should exist with aria-hidden
+    const hiddenSpan = button.querySelector('[aria-hidden="true"]');
+    expect(hiddenSpan).toBeInTheDocument();
+    expect(hiddenSpan).toHaveTextContent('Bold');
+  });
+
+  it('renders width reservation element for children text', () => {
+    render(
+      <XDSToggleButton
+        label="Toggle bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+        icon={<span data-testid="icon">B</span>}>
+        Bold
+      </XDSToggleButton>,
+    );
+    const button = screen.getByRole('button');
+    const hiddenSpan = button.querySelector('[aria-hidden="true"]');
+    expect(hiddenSpan).toBeInTheDocument();
+    expect(hiddenSpan).toHaveTextContent('Bold');
+  });
+
+  it('does not render width reservation for icon-only buttons', () => {
+    render(
+      <XDSToggleButton
+        label="Bold"
+        isPressed={false}
+        onPressedChange={() => {}}
+        icon={<span data-testid="icon">B</span>}
+      />,
+    );
+    const button = screen.getByRole('button');
+    const hiddenSpan = button.querySelector('[aria-hidden="true"]');
+    expect(hiddenSpan).not.toBeInTheDocument();
+  });
+
+  // =========================================================================
   // aria-pressed
   // =========================================================================
 

--- a/packages/core/src/ToggleButton/XDSToggleButton.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.tsx
@@ -273,6 +273,13 @@ export interface XDSToggleButtonProps extends Omit<
   icon?: ReactNode;
 
   /**
+   * Icon element to render when the button is pressed.
+   * Use to swap between outline (unpressed) and filled (pressed) icon styles.
+   * Falls back to `icon` if not provided.
+   */
+  pressedIcon?: ReactNode;
+
+  /**
    * Optional visible content. If omitted and icon is provided,
    * button becomes icon-only with label used as aria-label.
    */
@@ -362,6 +369,7 @@ export const XDSToggleButton = forwardRef<
       isDisabled = false,
       isLoading = false,
       icon,
+      pressedIcon,
       children,
       tooltip,
       value: _value,
@@ -372,6 +380,7 @@ export const XDSToggleButton = forwardRef<
   ): ReactElement => {
     const buttonDisabled = isDisabled || isLoading;
     const isIconOnly = icon != null && children == null;
+    const resolvedIcon = isPressed && pressedIcon ? pressedIcon : icon;
 
     // Default tooltip to label for icon-only buttons
     const resolvedTooltip = tooltip ?? (isIconOnly ? label : undefined);
@@ -424,7 +433,7 @@ export const XDSToggleButton = forwardRef<
             <XDSSpinner size="sm" shade="default" />
           </span>
         )}
-        {icon}
+        {resolvedIcon}
         {children ?? (isIconOnly ? null : label)}
       </button>
     );

--- a/packages/core/src/ToggleButton/XDSToggleButton.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.tsx
@@ -15,6 +15,7 @@ import {
   forwardRef,
   useCallback,
   useContext,
+  useState,
   type ButtonHTMLAttributes,
   type ReactElement,
   type ReactNode,
@@ -69,6 +70,13 @@ const styles = stylex.create({
   disabled: {
     cursor: 'not-allowed',
     opacity: 0.5,
+    transform: {
+      default: null,
+      ':active': null,
+    },
+  },
+  readOnly: {
+    cursor: 'default',
     transform: {
       default: null,
       ':active': null,
@@ -154,6 +162,34 @@ const variants = stylex.create({
 });
 
 // =============================================================================
+// Read-only variant overrides — remove hover/active overlays
+// =============================================================================
+
+const readOnlyVariants = stylex.create({
+  ghost: {
+    backgroundImage: {
+      default: null,
+      ':hover': null,
+      ':active': null,
+    },
+  },
+  secondary: {
+    backgroundImage: {
+      default: null,
+      ':hover': null,
+      ':active': null,
+    },
+  },
+  outline: {
+    backgroundImage: {
+      default: null,
+      ':hover': null,
+      ':active': null,
+    },
+  },
+});
+
+// =============================================================================
 // Pressed state styles — applied on top of variant when isPressed=true
 // =============================================================================
 
@@ -226,8 +262,7 @@ export interface XDSToggleButtonProps extends Omit<
 > {
   /**
    * Accessible label for the button (required for accessibility).
-   * Used as visible text when `isLabelVisible` is true,
-   * or as aria-label for icon-only buttons.
+   * Used as visible text, or as aria-label for icon-only buttons.
    */
   label: string;
 
@@ -240,6 +275,24 @@ export interface XDSToggleButtonProps extends Omit<
    * Called when the pressed state should change.
    */
   onPressedChange: (isPressed: boolean) => void;
+
+  /**
+   * Async action handler for API-backed toggles.
+   * The button shows a loading spinner and is disabled while the promise is pending.
+   *
+   * @example
+   * ```tsx
+   * <XDSToggleButton
+   *   label="Favorite"
+   *   isPressed={isFavorited}
+   *   onPressedChange={setIsFavorited}
+   *   onPressedChangeAction={async (newState) => {
+   *     await api.setFavorite(itemId, newState);
+   *   }}
+   * />
+   * ```
+   */
+  onPressedChangeAction?: (isPressed: boolean) => Promise<void>;
 
   /**
    * The visual style variant of the toggle button.
@@ -266,8 +319,17 @@ export interface XDSToggleButtonProps extends Omit<
   isLoading?: boolean;
 
   /**
+   * Whether the button is read-only.
+   * Shows the current state but prevents interaction.
+   * Visually distinct from disabled — no opacity reduction.
+   * Useful for showing someone else's favorites/bookmarks.
+   * @default false
+   */
+  isReadOnly?: boolean;
+
+  /**
    * Icon element to render in the button.
-   * When provided without children and isLabelVisible is false,
+   * When provided without children,
    * button becomes icon-only (square).
    */
   icon?: ReactNode;
@@ -280,6 +342,22 @@ export interface XDSToggleButtonProps extends Omit<
   pressedIcon?: ReactNode;
 
   /**
+   * Color applied to the icon when pressed.
+   * Use for semantic icon coloring like yellow stars or pink hearts.
+   * Accepts any CSS color value or XDS token.
+   * Only affects the icon, not the label text.
+   *
+   * @example
+   * ```tsx
+   * // Yellow star
+   * <XDSToggleButton pressedIconColor="#F2C00B" ... />
+   * // Pink heart
+   * <XDSToggleButton pressedIconColor="#E91E63" ... />
+   * ```
+   */
+  pressedIconColor?: string;
+
+  /**
    * Optional visible content. If omitted and icon is provided,
    * button becomes icon-only with label used as aria-label.
    */
@@ -289,6 +367,14 @@ export interface XDSToggleButtonProps extends Omit<
    * Tooltip text shown on hover. Defaults to label for icon-only buttons.
    */
   tooltip?: string;
+
+  /**
+   * Whether to show a tooltip on hover/focus.
+   * Defaults to true for icon-only buttons, false for labeled buttons.
+   * Set to false to opt out of the automatic tooltip.
+   * @default undefined (auto — true for icon-only, false for labeled)
+   */
+  hasTooltip?: boolean;
 
   /**
    * Value identifier when used inside XDSToggleButtonGroup.
@@ -303,18 +389,14 @@ export interface XDSToggleButtonProps extends Omit<
 }
 
 // =============================================================================
-// Loading styles
-// =============================================================================
-
-// =============================================================================
 // Label width reservation — prevents layout shift on font-weight change
 // =============================================================================
 
 /**
- * The label wrapper uses a ::after pseudo-element trick to prevent layout shift
+ * The label wrapper uses a hidden span to prevent layout shift
  * when toggling between medium (unpressed) and semibold (pressed) font weights.
  *
- * The ::after renders the same text at semibold weight but is visually hidden
+ * The hidden span renders the same text at semibold weight but is visually hidden
  * (height: 0, overflow: hidden). This reserves the wider semibold width at all
  * times, so the button never changes size when toggled.
  */
@@ -331,7 +413,6 @@ const labelStyles = stylex.create({
     height: 0,
     overflow: 'hidden',
     visibility: 'hidden',
-    // Prevent the hidden text from affecting pointer events
     pointerEvents: 'none',
   },
   pressed: {
@@ -353,13 +434,15 @@ const loadingStyles = stylex.create({
 /**
  * A button that toggles between pressed and unpressed states.
  * Use for toolbar actions, view mode switches, and formatting controls.
+ * Also handles icon toggle patterns (favorite, bookmark, like) with
+ * pressedIcon and pressedIconColor props.
  *
  * For on/off settings, use XDSSwitch instead.
  * For regular actions, use XDSButton instead.
  *
  * @example
  * ```tsx
- * // Icon-only toggle (most common — toolbar usage)
+ * // Icon-only toggle (toolbar)
  * const [isBold, setIsBold] = useState(false);
  * <XDSToggleButton
  *   label="Bold"
@@ -368,24 +451,27 @@ const loadingStyles = stylex.create({
  *   onPressedChange={setIsBold}
  * />
  *
- * // With visible label
+ * // Favorite with icon swap and color
  * <XDSToggleButton
- *   label="Show details"
- *   isPressed={showDetails}
- *   onPressedChange={setShowDetails}
- * >
- *   Show details
- * </XDSToggleButton>
+ *   label="Favorite"
+ *   icon={<StarIcon />}
+ *   pressedIcon={<StarIconSolid />}
+ *   pressedIconColor="#F2C00B"
+ *   isPressed={isFavorited}
+ *   onPressedChange={setIsFavorited}
+ * />
  *
- * // Outline variant
+ * // Async toggle with API call
  * <XDSToggleButton
- *   label="Filter active"
- *   variant="outline"
- *   isPressed={isActive}
- *   onPressedChange={setIsActive}
- * >
- *   Active
- * </XDSToggleButton>
+ *   label="Bookmark"
+ *   icon={<BookmarkIcon />}
+ *   pressedIcon={<BookmarkIconSolid />}
+ *   isPressed={isBookmarked}
+ *   onPressedChange={setIsBookmarked}
+ *   onPressedChangeAction={async (newState) => {
+ *     await api.bookmark(itemId, newState);
+ *   }}
+ * />
  * ```
  */
 export const XDSToggleButton = forwardRef<
@@ -397,26 +483,35 @@ export const XDSToggleButton = forwardRef<
       label,
       isPressed,
       onPressedChange,
+      onPressedChangeAction,
       variant = 'ghost',
       size = 'md',
       isDisabled = false,
       isLoading = false,
+      isReadOnly = false,
       icon,
       pressedIcon,
+      pressedIconColor,
       children,
       tooltip,
+      hasTooltip,
       value: _value,
       onClick,
       ...props
     },
     ref,
   ): ReactElement => {
-    const buttonDisabled = isDisabled || isLoading;
+    const [isPending, setIsPending] = useState(false);
     const isIconOnly = icon != null && children == null;
+    const buttonDisabled = isDisabled || isLoading || isPending;
+    const buttonNonInteractive = buttonDisabled || isReadOnly;
     const resolvedIcon = isPressed && pressedIcon ? pressedIcon : icon;
+    const showLoading = isLoading || isPending;
 
-    // Default tooltip to label for icon-only buttons
-    const resolvedTooltip = tooltip ?? (isIconOnly ? label : undefined);
+    // Tooltip logic: explicit hasTooltip overrides, otherwise auto for icon-only
+    const shouldShowTooltip =
+      hasTooltip !== undefined ? hasTooltip : isIconOnly;
+    const resolvedTooltip = shouldShowTooltip ? (tooltip ?? label) : tooltip;
 
     // Get theme context for component-level overrides (optional)
     const themeContext = useContext(ThemeContext);
@@ -425,12 +520,38 @@ export const XDSToggleButton = forwardRef<
 
     const handleClick = useCallback(
       (e: React.MouseEvent<HTMLButtonElement>) => {
-        if (buttonDisabled) return;
+        if (buttonNonInteractive) return;
         onClick?.(e);
-        onPressedChange(!isPressed);
+        const newState = !isPressed;
+        onPressedChange(newState);
+
+        if (onPressedChangeAction) {
+          setIsPending(true);
+          onPressedChangeAction(newState).finally(() => {
+            setIsPending(false);
+          });
+        }
       },
-      [buttonDisabled, onClick, onPressedChange, isPressed],
+      [
+        buttonNonInteractive,
+        onClick,
+        onPressedChange,
+        onPressedChangeAction,
+        isPressed,
+      ],
     );
+
+    // Render the icon, optionally wrapped with pressedIconColor
+    const iconElement =
+      resolvedIcon != null ? (
+        isPressed && pressedIconColor ? (
+          <span style={{color: pressedIconColor, display: 'inline-flex'}}>
+            {resolvedIcon}
+          </span>
+        ) : (
+          resolvedIcon
+        )
+      ) : null;
 
     const button = (
       <button
@@ -439,6 +560,7 @@ export const XDSToggleButton = forwardRef<
         disabled={buttonDisabled}
         aria-pressed={isPressed}
         aria-label={isIconOnly ? label : undefined}
+        aria-readonly={isReadOnly || undefined}
         onClick={handleClick}
         {...stylex.props(
           styles.base,
@@ -446,12 +568,14 @@ export const XDSToggleButton = forwardRef<
           variants[variant],
           themeVariantOverride,
           isPressed && pressedStyles[variant],
+          isReadOnly && readOnlyVariants[variant],
+          isReadOnly && styles.readOnly,
           isIconOnly && styles.iconOnly,
           buttonDisabled && styles.disabled,
-          isLoading && loadingStyles.loading,
+          showLoading && loadingStyles.loading,
         )}
         {...props}>
-        {isLoading && (
+        {showLoading && (
           <span
             style={{
               position: 'absolute',
@@ -466,7 +590,7 @@ export const XDSToggleButton = forwardRef<
             <XDSSpinner size="sm" shade="default" />
           </span>
         )}
-        {resolvedIcon}
+        {iconElement}
         {children != null ? (
           <span {...stylex.props(labelStyles.wrapper)}>
             <span {...stylex.props(isPressed && labelStyles.pressed)}>

--- a/packages/core/src/ToggleButton/XDSToggleButton.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.tsx
@@ -306,6 +306,39 @@ export interface XDSToggleButtonProps extends Omit<
 // Loading styles
 // =============================================================================
 
+// =============================================================================
+// Label width reservation — prevents layout shift on font-weight change
+// =============================================================================
+
+/**
+ * The label wrapper uses a ::after pseudo-element trick to prevent layout shift
+ * when toggling between medium (unpressed) and semibold (pressed) font weights.
+ *
+ * The ::after renders the same text at semibold weight but is visually hidden
+ * (height: 0, overflow: hidden). This reserves the wider semibold width at all
+ * times, so the button never changes size when toggled.
+ */
+const labelStyles = stylex.create({
+  wrapper: {
+    display: 'inline-flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  widthReservation: {
+    display: 'block',
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    height: 0,
+    overflow: 'hidden',
+    visibility: 'hidden',
+    // Prevent the hidden text from affecting pointer events
+    pointerEvents: 'none',
+  },
+  pressed: {
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+  },
+});
+
 const loadingStyles = stylex.create({
   loading: {
     position: 'relative',
@@ -434,7 +467,29 @@ export const XDSToggleButton = forwardRef<
           </span>
         )}
         {resolvedIcon}
-        {children ?? (isIconOnly ? null : label)}
+        {children != null ? (
+          <span {...stylex.props(labelStyles.wrapper)}>
+            <span {...stylex.props(isPressed && labelStyles.pressed)}>
+              {children}
+            </span>
+            <span
+              {...stylex.props(labelStyles.widthReservation)}
+              aria-hidden="true">
+              {children}
+            </span>
+          </span>
+        ) : isIconOnly ? null : (
+          <span {...stylex.props(labelStyles.wrapper)}>
+            <span {...stylex.props(isPressed && labelStyles.pressed)}>
+              {label}
+            </span>
+            <span
+              {...stylex.props(labelStyles.widthReservation)}
+              aria-hidden="true">
+              {label}
+            </span>
+          </span>
+        )}
       </button>
     );
 

--- a/packages/core/src/ToggleButton/XDSToggleButton.tsx
+++ b/packages/core/src/ToggleButton/XDSToggleButton.tsx
@@ -1,0 +1,444 @@
+/**
+ * @file XDSToggleButton.tsx
+ * @input Uses React forwardRef, ButtonHTMLAttributes, StyleX, theme tokens
+ * @output Exports XDSToggleButton component, XDSToggleButtonProps, XDSToggleButtonVariant, XDSToggleButtonSize types
+ * @position Core implementation; consumed by index.ts, tested by XDSToggleButton.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/ToggleButton/README.md (props table, features, implementation notes)
+ * - /packages/core/src/ToggleButton/XDSToggleButton.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/ToggleButton/index.ts (exports if types change)
+ * - /apps/storybook/stories/ToggleButton.stories.tsx (storybook stories)
+ */
+
+import {
+  forwardRef,
+  useCallback,
+  useContext,
+  type ButtonHTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  sizeVars,
+  spacingVars,
+  radiusVars,
+  transitionVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+import {ThemeContext} from '../theme/ThemeContext';
+import {XDSTooltip} from '../Layer/XDSTooltip';
+import {XDSSpinner} from '../Spinner';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+/**
+ * Base toggle button styles.
+ * Shares the same foundation as XDSButton but with toggle-specific interaction.
+ */
+const styles = stylex.create({
+  base: {
+    position: 'relative',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    borderWidth: 0,
+    borderStyle: 'none',
+    borderRadius: radiusVars['--radius-element'],
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    cursor: 'pointer',
+    transitionProperty: 'background-image, transform, background-color',
+    transitionDuration: transitionVars['--transition-fast'],
+    transform: {
+      default: 'scale(1)',
+      ':active': 'scale(0.98)',
+    },
+  },
+  disabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+    transform: {
+      default: null,
+      ':active': null,
+    },
+  },
+  iconOnly: {
+    aspectRatio: '1 / 1',
+    paddingInline: spacingVars['--spacing-2'],
+  },
+});
+
+const sizeStyles = stylex.create({
+  sm: {
+    height: sizeVars['--size-sm'],
+  },
+  md: {
+    height: sizeVars['--size-md'],
+  },
+  lg: {
+    height: sizeVars['--size-lg'],
+  },
+});
+
+// =============================================================================
+// Variant styles — unpressed state
+// =============================================================================
+
+const variants = stylex.create({
+  ghost: {
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-primary'],
+    backgroundImage: {
+      default: null,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
+    },
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '3px',
+    },
+  },
+  secondary: {
+    backgroundColor: colorVars['--color-deemphasized'],
+    color: colorVars['--color-text-primary'],
+    backgroundImage: {
+      default: null,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
+    },
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '3px',
+    },
+  },
+  outline: {
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-primary'],
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-divider-emphasized'],
+    backgroundImage: {
+      default: null,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
+    },
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '3px',
+    },
+  },
+});
+
+// =============================================================================
+// Pressed state styles — applied on top of variant when isPressed=true
+// =============================================================================
+
+const pressedStyles = stylex.create({
+  ghost: {
+    backgroundColor: colorVars['--color-pressed-overlay'],
+    color: colorVars['--color-icon-primary'],
+    backgroundImage: {
+      default: null,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
+    },
+  },
+  secondary: {
+    backgroundColor: colorVars['--color-pressed-overlay'],
+    color: colorVars['--color-icon-primary'],
+    backgroundImage: {
+      default: null,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
+    },
+  },
+  outline: {
+    backgroundColor: colorVars['--color-pressed-overlay'],
+    color: colorVars['--color-icon-primary'],
+    borderColor: colorVars['--color-divider-emphasized'],
+    backgroundImage: {
+      default: null,
+      ':hover': `linear-gradient(${colorVars['--color-hover-overlay']}, ${colorVars['--color-hover-overlay']})`,
+      ':active': `linear-gradient(${colorVars['--color-pressed-overlay']}, ${colorVars['--color-pressed-overlay']})`,
+    },
+  },
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Toggle button variant type.
+ * Limited to ghost, secondary, and outline — primary and destructive
+ * are not appropriate for toggle buttons.
+ */
+export type XDSToggleButtonVariant = keyof typeof variants;
+
+/**
+ * Toggle button size type.
+ */
+export type XDSToggleButtonSize = keyof typeof sizeStyles;
+
+// =============================================================================
+// Module Augmentation
+// =============================================================================
+
+declare module '../theme/types' {
+  interface ComponentStyles {
+    toggleButton?: {
+      variants?: Partial<Record<XDSToggleButtonVariant, StyleXStyles>>;
+    };
+  }
+}
+
+// =============================================================================
+// Props
+// =============================================================================
+
+export interface XDSToggleButtonProps extends Omit<
+  ButtonHTMLAttributes<HTMLButtonElement>,
+  'children' | 'disabled'
+> {
+  /**
+   * Accessible label for the button (required for accessibility).
+   * Used as visible text when `isLabelVisible` is true,
+   * or as aria-label for icon-only buttons.
+   */
+  label: string;
+
+  /**
+   * Whether the button is currently pressed/active.
+   */
+  isPressed: boolean;
+
+  /**
+   * Called when the pressed state should change.
+   */
+  onPressedChange: (isPressed: boolean) => void;
+
+  /**
+   * The visual style variant of the toggle button.
+   * @default 'ghost'
+   */
+  variant?: XDSToggleButtonVariant;
+
+  /**
+   * The size of the toggle button.
+   * @default 'md'
+   */
+  size?: XDSToggleButtonSize;
+
+  /**
+   * Whether the button is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Whether the button is in a loading state.
+   * @default false
+   */
+  isLoading?: boolean;
+
+  /**
+   * Icon element to render in the button.
+   * When provided without children and isLabelVisible is false,
+   * button becomes icon-only (square).
+   */
+  icon?: ReactNode;
+
+  /**
+   * Optional visible content. If omitted and icon is provided,
+   * button becomes icon-only with label used as aria-label.
+   */
+  children?: ReactNode;
+
+  /**
+   * Tooltip text shown on hover. Defaults to label for icon-only buttons.
+   */
+  tooltip?: string;
+
+  /**
+   * Value identifier when used inside XDSToggleButtonGroup.
+   * Required when used in a group.
+   */
+  value?: string;
+
+  /**
+   * Test ID for testing frameworks.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Loading styles
+// =============================================================================
+
+const loadingStyles = stylex.create({
+  loading: {
+    position: 'relative',
+    color: 'transparent',
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * A button that toggles between pressed and unpressed states.
+ * Use for toolbar actions, view mode switches, and formatting controls.
+ *
+ * For on/off settings, use XDSSwitch instead.
+ * For regular actions, use XDSButton instead.
+ *
+ * @example
+ * ```tsx
+ * // Icon-only toggle (most common — toolbar usage)
+ * const [isBold, setIsBold] = useState(false);
+ * <XDSToggleButton
+ *   label="Bold"
+ *   icon={<BoldIcon />}
+ *   isPressed={isBold}
+ *   onPressedChange={setIsBold}
+ * />
+ *
+ * // With visible label
+ * <XDSToggleButton
+ *   label="Show details"
+ *   isPressed={showDetails}
+ *   onPressedChange={setShowDetails}
+ * >
+ *   Show details
+ * </XDSToggleButton>
+ *
+ * // Outline variant
+ * <XDSToggleButton
+ *   label="Filter active"
+ *   variant="outline"
+ *   isPressed={isActive}
+ *   onPressedChange={setIsActive}
+ * >
+ *   Active
+ * </XDSToggleButton>
+ * ```
+ */
+export const XDSToggleButton = forwardRef<
+  HTMLButtonElement,
+  XDSToggleButtonProps
+>(
+  (
+    {
+      label,
+      isPressed,
+      onPressedChange,
+      variant = 'ghost',
+      size = 'md',
+      isDisabled = false,
+      isLoading = false,
+      icon,
+      children,
+      tooltip,
+      value: _value,
+      onClick,
+      ...props
+    },
+    ref,
+  ): ReactElement => {
+    const buttonDisabled = isDisabled || isLoading;
+    const isIconOnly = icon != null && children == null;
+
+    // Default tooltip to label for icon-only buttons
+    const resolvedTooltip = tooltip ?? (isIconOnly ? label : undefined);
+
+    // Get theme context for component-level overrides (optional)
+    const themeContext = useContext(ThemeContext);
+    const themeVariantOverride =
+      themeContext?.theme.components?.toggleButton?.variants?.[variant];
+
+    const handleClick = useCallback(
+      (e: React.MouseEvent<HTMLButtonElement>) => {
+        if (buttonDisabled) return;
+        onClick?.(e);
+        onPressedChange(!isPressed);
+      },
+      [buttonDisabled, onClick, onPressedChange, isPressed],
+    );
+
+    const button = (
+      <button
+        ref={ref}
+        type="button"
+        disabled={buttonDisabled}
+        aria-pressed={isPressed}
+        aria-label={isIconOnly ? label : undefined}
+        onClick={handleClick}
+        {...stylex.props(
+          styles.base,
+          sizeStyles[size],
+          variants[variant],
+          themeVariantOverride,
+          isPressed && pressedStyles[variant],
+          isIconOnly && styles.iconOnly,
+          buttonDisabled && styles.disabled,
+          isLoading && loadingStyles.loading,
+        )}
+        {...props}>
+        {isLoading && (
+          <span
+            style={{
+              position: 'absolute',
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}>
+            <XDSSpinner size="sm" shade="default" />
+          </span>
+        )}
+        {icon}
+        {children ?? (isIconOnly ? null : label)}
+      </button>
+    );
+
+    if (resolvedTooltip) {
+      return (
+        <XDSTooltip content={resolvedTooltip} placement="above">
+          {button}
+        </XDSTooltip>
+      );
+    }
+
+    return button;
+  },
+);
+
+XDSToggleButton.displayName = 'XDSToggleButton';

--- a/packages/core/src/ToggleButton/index.ts
+++ b/packages/core/src/ToggleButton/index.ts
@@ -1,0 +1,15 @@
+/**
+ * @file index.ts
+ * @input Imports XDSToggleButton component and types from XDSToggleButton.tsx
+ * @output Exports XDSToggleButton, XDSToggleButtonProps, XDSToggleButtonVariant, XDSToggleButtonSize
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/ToggleButton/README.md
+ */
+
+export {XDSToggleButton} from './XDSToggleButton';
+export type {
+  XDSToggleButtonProps,
+  XDSToggleButtonVariant,
+  XDSToggleButtonSize,
+} from './XDSToggleButton';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,6 +19,7 @@ export * from './Center';
 export * from './CheckboxInput';
 export * from './RadioList';
 export * from './CloseButton';
+export * from './ToggleButton';
 export * from './Divider';
 export * from './EmptyState';
 export * from './Link';


### PR DESCRIPTION
## XDSToggleButton

A button that toggles between pressed/unpressed states. For toolbar actions, view mode switches, and formatting controls.

### What's included

- **XDSToggleButton** — standalone toggle with `isPressed` / `onPressedChange`
- **Variants:** `ghost`, `secondary`, `outline`
- **Sizes:** `sm`, `md`, `lg`
- **Icon-only mode** with automatic tooltip
- **Loading state** with spinner overlay
- **Theme overrides** via `components.toggleButton.variants`
- **Full test suite** (15 tests)
- **Storybook stories** with interactive examples

### Design decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Separate component | Yes | Different semantics (`aria-pressed`), different variant set, consistent with OSS structure |
| Outline variant | Included in v1 | Formalizes pattern previously hacked via XDSInputGroup |
| Pressed state tokens | `--color-pressed-overlay` bg, `--color-icon-primary` / `--color-text-primary` text | Neutral, understated toggle — no accent coloring.  Mimics `isDepressed` state visuals |
| Outline border | `--color-divider-emphasized` in all states | Only the fill changes, border stays constant |
| No primary/destructive | Intentional | Toggle buttons are mode switches, not primary actions |

### Accessibility

- `aria-pressed="true/false"` for toggle state
- `aria-label` for icon-only buttons
- Keyboard: Space/Enter toggles (native `<button>`)
- Focus ring via `:focus-visible`

### What's next

`XDSToggleButtonGroup` (single + multiple selection modes with discriminated union types) will follow in a separate PR.

Partially addresses #169.

---
*Crafted with care by Navi*