### PR TITLE
fix(DropdownMenu): add 4px gap between button and popover

### DIFF
--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -58,6 +58,12 @@ const styles = stylex.create({
     minWidth: 'anchor-size(width)',
   },
 
+  // Gap between button and popover
+  popoverGap: {
+    marginBlockStart: spacingVars['--spacing-1'],
+    marginBlockEnd: spacingVars['--spacing-1'],
+  },
+
   // Custom width popover
   popoverCustomWidth: (width: string | number) => ({
     minWidth: typeof width === 'number' ? `${width}px` : width,
@@ -615,7 +621,7 @@ export function XDSDropdownMenu({
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: popoverXstyle,
+          xstyle: [popoverXstyle, styles.popoverGap],
         },
       )}
     </>


### PR DESCRIPTION
Adds `marginBlock` spacing (`--spacing-1` / 4px) to the dropdown popover container, creating a visual gap between the trigger button and the menu.

Follows the same pattern used by `XDSTooltip` and `XDSHoverCard`. Uses both `marginBlockStart` and `marginBlockEnd` so the gap works correctly when the popover flips above the button via `positionTryFallbacks`.

## Storybook Preview

| Story | Link |
|-------|------|
| Default | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--default) |
| WithIcons | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--with-icons) |
| WithSections | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--with-sections) |
| WithDividers | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--with-dividers) |
| WithDisabledItems | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--with-disabled-items) |
| Controlled | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--controlled) |
| CustomWidth | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--custom-width) |
| ButtonVariants | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--button-variants) |
| ButtonSizes | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--button-sizes) |
| WithOnClick | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--with-on-click) |
| CustomItemRender | [Preview](https://studious-broccoli-o7e61n3.pages.github.io/d950352/?path=/story/core-xdsdropdownmenu--custom-item-render) |

---
*Crafted with care by Navi*