### PR TITLE
feat(PageNav): add XDSPageNav component with header, items, and sections

### DIFF
--- a/apps/storybook/stories/PageNav.stories.tsx
+++ b/apps/storybook/stories/PageNav.stories.tsx
@@ -4,7 +4,6 @@ import {
   XDSPageNavHeader,
   XDSPageNavItem,
   XDSPageNavSection,
-  useXDSCollapsible,
 } from '@xds/core/PageNav';
 import {XDSBadge} from '@xds/core/Badge';
 import {
@@ -16,7 +15,6 @@ import {
   BellIcon,
   QuestionMarkCircleIcon,
   DocumentTextIcon,
-  ShieldCheckIcon,
   CubeIcon,
 } from '@heroicons/react/24/outline';
 import {
@@ -149,47 +147,12 @@ export const SuiteHeader: Story = {
 };
 
 // =============================================================================
-// Collapsible Sections
-// =============================================================================
-
-function CollapsibleExample() {
-  const mainCollapsible = useXDSCollapsible(true);
-  const settingsCollapsible = useXDSCollapsible(false);
-
-  return (
-    <XDSPageNav
-      header={
-        <XDSPageNavHeader
-          icon={<CubeIcon style={{width: 24, height: 24}} />}
-          title="My App"
-        />
-      }>
-      <XDSPageNavSection title="Main" collapsible={mainCollapsible}>
-        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
-        <XDSPageNavItem label="Projects" icon={FolderIcon} />
-        <XDSPageNavItem label="Analytics" icon={ChartBarIcon} />
-      </XDSPageNavSection>
-      <XDSPageNavSection title="Settings" collapsible={settingsCollapsible}>
-        <XDSPageNavItem label="General" icon={Cog6ToothIcon} />
-        <XDSPageNavItem label="Security" icon={ShieldCheckIcon} />
-      </XDSPageNavSection>
-    </XDSPageNav>
-  );
-}
-
-export const CollapsibleSections: Story = {
-  name: 'Collapsible Sections',
-  render: () => <CollapsibleExample />,
-};
-
-// =============================================================================
 // Nested Items
 // =============================================================================
 
-function NestedItemsExample() {
-  const settingsCollapsible = useXDSCollapsible(true);
-
-  return (
+export const NestedItems: Story = {
+  name: 'Nested Items',
+  render: () => (
     <XDSPageNav
       header={
         <XDSPageNavHeader
@@ -199,10 +162,7 @@ function NestedItemsExample() {
       }>
       <XDSPageNavSection title="Main">
         <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
-        <XDSPageNavItem
-          label="Settings"
-          icon={Cog6ToothIcon}
-          collapsible={settingsCollapsible}>
+        <XDSPageNavItem label="Settings" icon={Cog6ToothIcon}>
           <XDSPageNavItem label="General" href="/settings/general" />
           <XDSPageNavItem label="Security" href="/settings/security" />
           <XDSPageNavItem
@@ -212,12 +172,7 @@ function NestedItemsExample() {
         </XDSPageNavItem>
       </XDSPageNavSection>
     </XDSPageNav>
-  );
-}
-
-export const NestedItems: Story = {
-  name: 'Nested Items',
-  render: () => <NestedItemsExample />,
+  ),
 };
 
 // =============================================================================

--- a/apps/storybook/stories/PageNav.stories.tsx
+++ b/apps/storybook/stories/PageNav.stories.tsx
@@ -111,7 +111,12 @@ export const WithHeaderMenu: Story = {
         />
       }>
       <XDSPageNavSection title="Navigation">
-        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          selectedIcon={HomeIconSolid}
+          isSelected
+        />
         <XDSPageNavItem label="Settings" icon={Cog6ToothIcon} />
       </XDSPageNavSection>
     </XDSPageNav>
@@ -141,7 +146,12 @@ export const SuiteHeader: Story = {
         />
       }>
       <XDSPageNavSection title="Main">
-        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          selectedIcon={HomeIconSolid}
+          isSelected
+        />
         <XDSPageNavItem label="Projects" icon={FolderIcon} />
       </XDSPageNavSection>
     </XDSPageNav>
@@ -163,7 +173,12 @@ export const NestedItems: Story = {
         />
       }>
       <XDSPageNavSection title="Main">
-        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          selectedIcon={HomeIconSolid}
+          isSelected
+        />
         <XDSPageNavItem label="Settings" icon={Cog6ToothIcon}>
           <XDSPageNavItem label="General" href="/settings/general" />
           <XDSPageNavItem label="Security" href="/settings/security" />
@@ -208,7 +223,12 @@ export const WithFooter: Story = {
         </>
       }>
       <XDSPageNavSection title="Main">
-        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          selectedIcon={HomeIconSolid}
+          isSelected
+        />
         <XDSPageNavItem label="Projects" icon={FolderIcon} />
       </XDSPageNavSection>
     </XDSPageNav>
@@ -230,7 +250,12 @@ export const DisabledItem: Story = {
         />
       }>
       <XDSPageNavSection title="Main">
-        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          selectedIcon={HomeIconSolid}
+          isSelected
+        />
         <XDSPageNavItem label="Projects" icon={FolderIcon} />
         <XDSPageNavItem
           label="Analytics (Coming Soon)"
@@ -257,7 +282,12 @@ export const HiddenSectionHeader: Story = {
         />
       }>
       <XDSPageNavSection title="Main navigation" isHeaderHidden>
-        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          selectedIcon={HomeIconSolid}
+          isSelected
+        />
         <XDSPageNavItem label="Projects" icon={FolderIcon} />
         <XDSPageNavItem label="Analytics" icon={ChartBarIcon} />
       </XDSPageNavSection>

--- a/apps/storybook/stories/PageNav.stories.tsx
+++ b/apps/storybook/stories/PageNav.stories.tsx
@@ -6,6 +6,8 @@ import {
   XDSPageNavSection,
 } from '@xds/core/PageNav';
 import {XDSBadge} from '@xds/core/Badge';
+import {XDSButton} from '@xds/core/Button';
+import {XDSIcon} from '@xds/core/Icon';
 import {
   HomeIcon,
   FolderIcon,
@@ -50,7 +52,7 @@ export const Default: Story = {
     <XDSPageNav
       header={
         <XDSPageNavHeader
-          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          icon={<XDSIcon icon={CubeIcon} size="lg" />}
           title="My App"
           titleHref="/"
         />
@@ -98,7 +100,7 @@ export const WithHeaderMenu: Story = {
     <XDSPageNav
       header={
         <XDSPageNavHeader
-          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          icon={<XDSIcon icon={CubeIcon} size="lg" />}
           title="Product Name"
           subtitle="Business Account"
           menu={
@@ -126,7 +128,7 @@ export const SuiteHeader: Story = {
     <XDSPageNav
       header={
         <XDSPageNavHeader
-          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          icon={<XDSIcon icon={CubeIcon} size="lg" />}
           supertitle="Suite Name"
           supertitleHref="/suite"
           title="Product Name"
@@ -156,7 +158,7 @@ export const NestedItems: Story = {
     <XDSPageNav
       header={
         <XDSPageNavHeader
-          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          icon={<XDSIcon icon={CubeIcon} size="lg" />}
           title="My App"
         />
       }>
@@ -185,34 +187,24 @@ export const WithFooter: Story = {
     <XDSPageNav
       header={
         <XDSPageNavHeader
-          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          icon={<XDSIcon icon={CubeIcon} size="lg" />}
           title="My App"
         />
       }
       footerIcons={
         <>
-          <button
-            type="button"
-            aria-label="Help"
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              padding: 8,
-            }}>
-            <QuestionMarkCircleIcon style={{width: 20, height: 20}} />
-          </button>
-          <button
-            type="button"
-            aria-label="Notifications"
-            style={{
-              background: 'none',
-              border: 'none',
-              cursor: 'pointer',
-              padding: 8,
-            }}>
-            <BellIcon style={{width: 20, height: 20}} />
-          </button>
+          <XDSButton
+            label="Help"
+            icon={<XDSIcon icon={QuestionMarkCircleIcon} size="md" />}
+            variant="ghost"
+            size="sm"
+          />
+          <XDSButton
+            label="Notifications"
+            icon={<XDSIcon icon={BellIcon} size="md" />}
+            variant="ghost"
+            size="sm"
+          />
         </>
       }>
       <XDSPageNavSection title="Main">
@@ -233,7 +225,7 @@ export const DisabledItem: Story = {
     <XDSPageNav
       header={
         <XDSPageNavHeader
-          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          icon={<XDSIcon icon={CubeIcon} size="lg" />}
           title="My App"
         />
       }>
@@ -260,7 +252,7 @@ export const HiddenSectionHeader: Story = {
     <XDSPageNav
       header={
         <XDSPageNavHeader
-          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          icon={<XDSIcon icon={CubeIcon} size="lg" />}
           title="My App"
         />
       }>

--- a/apps/storybook/stories/PageNav.stories.tsx
+++ b/apps/storybook/stories/PageNav.stories.tsx
@@ -7,7 +7,10 @@ import {
 } from '@xds/core/PageNav';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSButton} from '@xds/core/Button';
+import {XDSDivider} from '@xds/core/Divider';
 import {XDSIcon} from '@xds/core/Icon';
+import {XDSText} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Stack';
 import {
   HomeIcon,
   FolderIcon,
@@ -18,6 +21,10 @@ import {
   QuestionMarkCircleIcon,
   DocumentTextIcon,
   CubeIcon,
+  BuildingOfficeIcon,
+  UserIcon,
+  PlusIcon,
+  ArrowRightStartOnRectangleIcon,
 } from '@heroicons/react/24/outline';
 import {
   HomeIcon as HomeIconSolid,
@@ -104,8 +111,39 @@ export const WithHeaderMenu: Story = {
           title="Product Name"
           subtitle="Business Account"
           menu={
-            <div style={{padding: 16}}>
-              <p>Account switcher menu</p>
+            <div style={{padding: 12}}>
+              <XDSVStack gap="space2">
+                <XDSText type="supporting" color="secondary">
+                  Switch account
+                </XDSText>
+                <XDSButton
+                  label="Personal Account"
+                  icon={<XDSIcon icon={UserIcon} size="sm" />}
+                  variant="ghost"
+                  size="sm"
+                />
+                <XDSButton
+                  label="Acme Corp"
+                  icon={<XDSIcon icon={BuildingOfficeIcon} size="sm" />}
+                  variant="ghost"
+                  size="sm"
+                />
+                <XDSDivider />
+                <XDSButton
+                  label="Add account"
+                  icon={<XDSIcon icon={PlusIcon} size="sm" />}
+                  variant="ghost"
+                  size="sm"
+                />
+                <XDSButton
+                  label="Sign out"
+                  icon={
+                    <XDSIcon icon={ArrowRightStartOnRectangleIcon} size="sm" />
+                  }
+                  variant="ghost"
+                  size="sm"
+                />
+              </XDSVStack>
             </div>
           }
         />
@@ -139,8 +177,30 @@ export const SuiteHeader: Story = {
           title="Product Name"
           titleHref="/product"
           menu={
-            <div style={{padding: 16}}>
-              <p>Product switcher</p>
+            <div style={{padding: 12}}>
+              <XDSVStack gap="space1">
+                <XDSText type="supporting" color="secondary">
+                  Switch product
+                </XDSText>
+                <XDSButton
+                  label="Analytics"
+                  icon={<XDSIcon icon={ChartBarIcon} size="sm" />}
+                  variant="ghost"
+                  size="sm"
+                />
+                <XDSButton
+                  label="Commerce"
+                  icon={<XDSIcon icon={CubeIcon} size="sm" />}
+                  variant="ghost"
+                  size="sm"
+                />
+                <XDSButton
+                  label="Team Hub"
+                  icon={<XDSIcon icon={UserGroupIcon} size="sm" />}
+                  variant="ghost"
+                  size="sm"
+                />
+              </XDSVStack>
             </div>
           }
         />

--- a/apps/storybook/stories/PageNav.stories.tsx
+++ b/apps/storybook/stories/PageNav.stories.tsx
@@ -1,0 +1,319 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  XDSPageNav,
+  XDSPageNavHeader,
+  XDSPageNavItem,
+  XDSPageNavSection,
+  useXDSCollapsible,
+} from '@xds/core/PageNav';
+import {XDSBadge} from '@xds/core/Badge';
+import {
+  HomeIcon,
+  FolderIcon,
+  Cog6ToothIcon,
+  ChartBarIcon,
+  UserGroupIcon,
+  BellIcon,
+  QuestionMarkCircleIcon,
+  DocumentTextIcon,
+  ShieldCheckIcon,
+  CubeIcon,
+} from '@heroicons/react/24/outline';
+import {
+  HomeIcon as HomeIconSolid,
+  FolderIcon as FolderIconSolid,
+} from '@heroicons/react/24/solid';
+
+const meta: Meta<typeof XDSPageNav> = {
+  title: 'Navigation/XDSPageNav',
+  component: XDSPageNav,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div style={{width: 280, height: 600, border: '1px solid #e5e7eb'}}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSPageNav>;
+
+// =============================================================================
+// Basic
+// =============================================================================
+
+export const Default: Story = {
+  render: () => (
+    <XDSPageNav
+      header={
+        <XDSPageNavHeader
+          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          title="My App"
+          titleHref="/"
+        />
+      }>
+      <XDSPageNavSection title="Main">
+        <XDSPageNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          selectedIcon={HomeIconSolid}
+          isSelected
+          href="/dashboard"
+        />
+        <XDSPageNavItem
+          label="Projects"
+          icon={FolderIcon}
+          selectedIcon={FolderIconSolid}
+          href="/projects"
+          endContent={<XDSBadge label="3" />}
+        />
+        <XDSPageNavItem
+          label="Analytics"
+          icon={ChartBarIcon}
+          href="/analytics"
+        />
+        <XDSPageNavItem label="Team" icon={UserGroupIcon} href="/team" />
+      </XDSPageNavSection>
+      <XDSPageNavSection title="Documents">
+        <XDSPageNavItem
+          label="All Documents"
+          icon={DocumentTextIcon}
+          href="/documents"
+        />
+      </XDSPageNavSection>
+    </XDSPageNav>
+  ),
+};
+
+// =============================================================================
+// With Header Menu
+// =============================================================================
+
+export const WithHeaderMenu: Story = {
+  name: 'Header with Menu',
+  render: () => (
+    <XDSPageNav
+      header={
+        <XDSPageNavHeader
+          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          title="Product Name"
+          subtitle="Business Account"
+          menu={
+            <div style={{padding: 16}}>
+              <p>Account switcher menu</p>
+            </div>
+          }
+        />
+      }>
+      <XDSPageNavSection title="Navigation">
+        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem label="Settings" icon={Cog6ToothIcon} />
+      </XDSPageNavSection>
+    </XDSPageNav>
+  ),
+};
+
+// =============================================================================
+// Suite Header
+// =============================================================================
+
+export const SuiteHeader: Story = {
+  name: 'Suite with Independent Links',
+  render: () => (
+    <XDSPageNav
+      header={
+        <XDSPageNavHeader
+          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          supertitle="Suite Name"
+          supertitleHref="/suite"
+          title="Product Name"
+          titleHref="/product"
+          menu={
+            <div style={{padding: 16}}>
+              <p>Product switcher</p>
+            </div>
+          }
+        />
+      }>
+      <XDSPageNavSection title="Main">
+        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem label="Projects" icon={FolderIcon} />
+      </XDSPageNavSection>
+    </XDSPageNav>
+  ),
+};
+
+// =============================================================================
+// Collapsible Sections
+// =============================================================================
+
+function CollapsibleExample() {
+  const mainCollapsible = useXDSCollapsible(true);
+  const settingsCollapsible = useXDSCollapsible(false);
+
+  return (
+    <XDSPageNav
+      header={
+        <XDSPageNavHeader
+          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          title="My App"
+        />
+      }>
+      <XDSPageNavSection title="Main" collapsible={mainCollapsible}>
+        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem label="Projects" icon={FolderIcon} />
+        <XDSPageNavItem label="Analytics" icon={ChartBarIcon} />
+      </XDSPageNavSection>
+      <XDSPageNavSection title="Settings" collapsible={settingsCollapsible}>
+        <XDSPageNavItem label="General" icon={Cog6ToothIcon} />
+        <XDSPageNavItem label="Security" icon={ShieldCheckIcon} />
+      </XDSPageNavSection>
+    </XDSPageNav>
+  );
+}
+
+export const CollapsibleSections: Story = {
+  name: 'Collapsible Sections',
+  render: () => <CollapsibleExample />,
+};
+
+// =============================================================================
+// Nested Items
+// =============================================================================
+
+function NestedItemsExample() {
+  const settingsCollapsible = useXDSCollapsible(true);
+
+  return (
+    <XDSPageNav
+      header={
+        <XDSPageNavHeader
+          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          title="My App"
+        />
+      }>
+      <XDSPageNavSection title="Main">
+        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem
+          label="Settings"
+          icon={Cog6ToothIcon}
+          collapsible={settingsCollapsible}>
+          <XDSPageNavItem label="General" href="/settings/general" />
+          <XDSPageNavItem label="Security" href="/settings/security" />
+          <XDSPageNavItem
+            label="Notifications"
+            href="/settings/notifications"
+          />
+        </XDSPageNavItem>
+      </XDSPageNavSection>
+    </XDSPageNav>
+  );
+}
+
+export const NestedItems: Story = {
+  name: 'Nested Items',
+  render: () => <NestedItemsExample />,
+};
+
+// =============================================================================
+// With Footer
+// =============================================================================
+
+export const WithFooter: Story = {
+  name: 'With Footer Icons',
+  render: () => (
+    <XDSPageNav
+      header={
+        <XDSPageNavHeader
+          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          title="My App"
+        />
+      }
+      footerIcons={
+        <>
+          <button
+            type="button"
+            aria-label="Help"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 8,
+            }}>
+            <QuestionMarkCircleIcon style={{width: 20, height: 20}} />
+          </button>
+          <button
+            type="button"
+            aria-label="Notifications"
+            style={{
+              background: 'none',
+              border: 'none',
+              cursor: 'pointer',
+              padding: 8,
+            }}>
+            <BellIcon style={{width: 20, height: 20}} />
+          </button>
+        </>
+      }>
+      <XDSPageNavSection title="Main">
+        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem label="Projects" icon={FolderIcon} />
+      </XDSPageNavSection>
+    </XDSPageNav>
+  ),
+};
+
+// =============================================================================
+// Disabled Item
+// =============================================================================
+
+export const DisabledItem: Story = {
+  name: 'Disabled Items',
+  render: () => (
+    <XDSPageNav
+      header={
+        <XDSPageNavHeader
+          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          title="My App"
+        />
+      }>
+      <XDSPageNavSection title="Main">
+        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem label="Projects" icon={FolderIcon} />
+        <XDSPageNavItem
+          label="Analytics (Coming Soon)"
+          icon={ChartBarIcon}
+          isDisabled
+        />
+      </XDSPageNavSection>
+    </XDSPageNav>
+  ),
+};
+
+// =============================================================================
+// Hidden Section Header
+// =============================================================================
+
+export const HiddenSectionHeader: Story = {
+  name: 'Hidden Section Header',
+  render: () => (
+    <XDSPageNav
+      header={
+        <XDSPageNavHeader
+          icon={<CubeIcon style={{width: 24, height: 24}} />}
+          title="My App"
+        />
+      }>
+      <XDSPageNavSection title="Main navigation" isHeaderHidden>
+        <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+        <XDSPageNavItem label="Projects" icon={FolderIcon} />
+        <XDSPageNavItem label="Analytics" icon={ChartBarIcon} />
+      </XDSPageNavSection>
+    </XDSPageNav>
+  ),
+};

--- a/packages/core/src/PageNav/README.md
+++ b/packages/core/src/PageNav/README.md
@@ -1,26 +1,26 @@
 # PageNav
 
-Sidebar navigation component for application pages. Supports collapsible sections, nested items, selected state, icons, and responsive collapse.
+Sidebar navigation component for application pages. Supports sections, nested items, selected state, icons, and responsive collapse.
 
 ## Components
 
-| Component           | Description                                                                                  |
-| ------------------- | -------------------------------------------------------------------------------------------- |
-| `XDSPageNav`        | Container with five zones: header, stickyContent, children (scrollable), footer, footerIcons |
-| `XDSPageNavHeader`  | Product/suite/account header with smart interaction boundary logic                           |
-| `XDSPageNavItem`    | Navigation item with icon, selected state, nesting, and collapsible support                  |
-| `XDSPageNavSection` | Section grouping with optional title, collapsible behavior, and end content                  |
+| Component           | Description                                                                               |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| `XDSPageNav`        | Container with five zones: header, topContent, children (scrollable), footer, footerIcons |
+| `XDSPageNavHeader`  | Product/suite/account header with smart interaction boundary logic                        |
+| `XDSPageNavItem`    | Navigation item with icon, selected state, and nesting                                    |
+| `XDSPageNavSection` | Section grouping with optional title and end content                                      |
 
 ## Files
 
-| File                    | Purpose                                              |
-| ----------------------- | ---------------------------------------------------- |
-| `XDSPageNav.tsx`        | Container component                                  |
-| `XDSPageNavHeader.tsx`  | Header component with popover menu support           |
-| `XDSPageNavItem.tsx`    | Navigation item component + `useXDSCollapsible` hook |
-| `XDSPageNavSection.tsx` | Section grouping component                           |
-| `XDSPageNav.test.tsx`   | Unit tests                                           |
-| `index.ts`              | Public exports                                       |
+| File                    | Purpose                                    |
+| ----------------------- | ------------------------------------------ |
+| `XDSPageNav.tsx`        | Container component                        |
+| `XDSPageNavHeader.tsx`  | Header component with popover menu support |
+| `XDSPageNavItem.tsx`    | Navigation item component                  |
+| `XDSPageNavSection.tsx` | Section grouping component                 |
+| `XDSPageNav.test.tsx`   | Unit tests                                 |
+| `index.ts`              | Public exports                             |
 
 ## Usage
 
@@ -30,12 +30,11 @@ import {
   XDSPageNavHeader,
   XDSPageNavItem,
   XDSPageNavSection,
-  useXDSCollapsible,
 } from '@xds/core/PageNav';
 
 <XDSPageNav
   header={<XDSPageNavHeader icon={<AppIcon />} title="My App" titleHref="/" />}
-  stickyContent={<XDSButton label="Create new" variant="primary" />}
+  topContent={<XDSButton label="Create new" variant="primary" />}
   footerIcons={<XDSButton icon={HelpIcon} variant="ghost" label="Help" />}>
   <XDSPageNavSection title="Main">
     <XDSPageNavItem
@@ -53,7 +52,7 @@ import {
     />
   </XDSPageNavSection>
 
-  <XDSPageNavSection title="Settings" collapsible={useXDSCollapsible()}>
+  <XDSPageNavSection title="Settings">
     <XDSPageNavItem label="General" href="/settings/general" />
     <XDSPageNavItem label="Security" href="/settings/security" />
   </XDSPageNavSection>
@@ -74,11 +73,9 @@ import {
 - `<nav aria-label="Page navigation">`
 - `aria-current="page"` on selected item
 - Sections: `role="group"` with `aria-labelledby`
-- Collapsible: `aria-expanded` on trigger
 - Keyboard: Tab through items, Enter/Space to activate
 
 ## Dependencies
 
 - `useXDSPopover` — for header menu popover
 - `XDSIcon` — for rendering icon components in nav items
-- `useXDSCollapsible` — placeholder hook (will be replaced by #187)

--- a/packages/core/src/PageNav/README.md
+++ b/packages/core/src/PageNav/README.md
@@ -1,0 +1,84 @@
+# PageNav
+
+Sidebar navigation component for application pages. Supports collapsible sections, nested items, selected state, icons, and responsive collapse.
+
+## Components
+
+| Component           | Description                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------- |
+| `XDSPageNav`        | Container with five zones: header, stickyContent, children (scrollable), footer, footerIcons |
+| `XDSPageNavHeader`  | Product/suite/account header with smart interaction boundary logic                           |
+| `XDSPageNavItem`    | Navigation item with icon, selected state, nesting, and collapsible support                  |
+| `XDSPageNavSection` | Section grouping with optional title, collapsible behavior, and end content                  |
+
+## Files
+
+| File                    | Purpose                                              |
+| ----------------------- | ---------------------------------------------------- |
+| `XDSPageNav.tsx`        | Container component                                  |
+| `XDSPageNavHeader.tsx`  | Header component with popover menu support           |
+| `XDSPageNavItem.tsx`    | Navigation item component + `useXDSCollapsible` hook |
+| `XDSPageNavSection.tsx` | Section grouping component                           |
+| `XDSPageNav.test.tsx`   | Unit tests                                           |
+| `index.ts`              | Public exports                                       |
+
+## Usage
+
+```tsx
+import {
+  XDSPageNav,
+  XDSPageNavHeader,
+  XDSPageNavItem,
+  XDSPageNavSection,
+  useXDSCollapsible,
+} from '@xds/core/PageNav';
+
+<XDSPageNav
+  header={<XDSPageNavHeader icon={<AppIcon />} title="My App" titleHref="/" />}
+  stickyContent={<XDSButton label="Create new" variant="primary" />}
+  footerIcons={<XDSButton icon={HelpIcon} variant="ghost" label="Help" />}>
+  <XDSPageNavSection title="Main">
+    <XDSPageNavItem
+      label="Dashboard"
+      icon={HomeIcon}
+      selectedIcon={HomeIconSolid}
+      isSelected
+      href="/dashboard"
+    />
+    <XDSPageNavItem
+      label="Projects"
+      icon={FolderIcon}
+      href="/projects"
+      endContent={<XDSBadge label="3" />}
+    />
+  </XDSPageNavSection>
+
+  <XDSPageNavSection title="Settings" collapsible={useXDSCollapsible()}>
+    <XDSPageNavItem label="General" href="/settings/general" />
+    <XDSPageNavItem label="Security" href="/settings/security" />
+  </XDSPageNavSection>
+</XDSPageNav>;
+```
+
+## Header Interaction Model
+
+| Props provided                          | Behavior                                                       |
+| --------------------------------------- | -------------------------------------------------------------- |
+| `titleHref` only, no menu               | Whole header is one link                                       |
+| `titleHref` + `supertitleHref`, no menu | Each text is an independent link                               |
+| `menu` only, no hrefs                   | Whole header is the popover trigger                            |
+| `menu` + hrefs                          | Links are independent `<a>`, chevron/remaining area is trigger |
+
+## Accessibility
+
+- `<nav aria-label="Page navigation">`
+- `aria-current="page"` on selected item
+- Sections: `role="group"` with `aria-labelledby`
+- Collapsible: `aria-expanded` on trigger
+- Keyboard: Tab through items, Enter/Space to activate
+
+## Dependencies
+
+- `useXDSPopover` — for header menu popover
+- `XDSIcon` — for rendering icon components in nav items
+- `useXDSCollapsible` — placeholder hook (will be replaced by #187)

--- a/packages/core/src/PageNav/XDSPageNav.test.tsx
+++ b/packages/core/src/PageNav/XDSPageNav.test.tsx
@@ -166,10 +166,10 @@ describe('XDSPageNavHeader', () => {
     expect(button).toBeInTheDocument();
   });
 
-  it('shows chevron when hasChevron is explicitly set', () => {
-    const {container} = render(<XDSPageNavHeader title="My App" hasChevron />);
+  it('does not show chevron without menu', () => {
+    const {container} = render(<XDSPageNavHeader title="My App" />);
     const svg = container.querySelector('svg');
-    expect(svg).toBeInTheDocument();
+    expect(svg).not.toBeInTheDocument();
   });
 
   it('whole header is popover trigger when menu provided without hrefs', () => {

--- a/packages/core/src/PageNav/XDSPageNav.test.tsx
+++ b/packages/core/src/PageNav/XDSPageNav.test.tsx
@@ -1,0 +1,518 @@
+/**
+ * @file XDSPageNav.test.tsx
+ * @input Uses vitest, @testing-library/react, PageNav components
+ * @output Unit tests for XDSPageNav component suite
+ * @position Testing; validates PageNav implementations
+ *
+ * SYNC: When PageNav components change, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSPageNav} from './XDSPageNav';
+import {XDSPageNavHeader} from './XDSPageNavHeader';
+import {XDSPageNavItem, useXDSCollapsible} from './XDSPageNavItem';
+import {XDSPageNavSection} from './XDSPageNavSection';
+
+// =============================================================================
+// XDSPageNav
+// =============================================================================
+
+describe('XDSPageNav', () => {
+  it('renders with navigation role', () => {
+    render(<XDSPageNav>Content</XDSPageNav>);
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+  });
+
+  it('renders aria-label for page navigation', () => {
+    render(<XDSPageNav>Content</XDSPageNav>);
+    expect(screen.getByRole('navigation')).toHaveAttribute(
+      'aria-label',
+      'Page navigation',
+    );
+  });
+
+  it('renders children in scrollable area', () => {
+    render(
+      <XDSPageNav>
+        <span data-testid="nav-content">Nav items</span>
+      </XDSPageNav>,
+    );
+    expect(screen.getByTestId('nav-content')).toBeInTheDocument();
+  });
+
+  it('renders header slot', () => {
+    render(
+      <XDSPageNav header={<span data-testid="header">Header</span>}>
+        Content
+      </XDSPageNav>,
+    );
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+  });
+
+  it('renders stickyContent slot', () => {
+    render(
+      <XDSPageNav stickyContent={<span data-testid="sticky">Sticky</span>}>
+        Content
+      </XDSPageNav>,
+    );
+    expect(screen.getByTestId('sticky')).toBeInTheDocument();
+  });
+
+  it('renders footer slot', () => {
+    render(
+      <XDSPageNav footer={<span data-testid="footer">Footer</span>}>
+        Content
+      </XDSPageNav>,
+    );
+    expect(screen.getByTestId('footer')).toBeInTheDocument();
+  });
+
+  it('renders footerIcons slot', () => {
+    render(
+      <XDSPageNav footerIcons={<span data-testid="footer-icons">Icons</span>}>
+        Content
+      </XDSPageNav>,
+    );
+    expect(screen.getByTestId('footer-icons')).toBeInTheDocument();
+  });
+
+  it('renders all slots together', () => {
+    render(
+      <XDSPageNav
+        header={<span data-testid="header">Header</span>}
+        stickyContent={<span data-testid="sticky">Sticky</span>}
+        footer={<span data-testid="footer">Footer</span>}
+        footerIcons={<span data-testid="icons">Icons</span>}>
+        <span data-testid="content">Content</span>
+      </XDSPageNav>,
+    );
+    expect(screen.getByTestId('header')).toBeInTheDocument();
+    expect(screen.getByTestId('sticky')).toBeInTheDocument();
+    expect(screen.getByTestId('content')).toBeInTheDocument();
+    expect(screen.getByTestId('footer')).toBeInTheDocument();
+    expect(screen.getByTestId('icons')).toBeInTheDocument();
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(<XDSPageNav ref={ref}>Content</XDSPageNav>);
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it('passes data-testid to root', () => {
+    render(<XDSPageNav data-testid="page-nav">Content</XDSPageNav>);
+    expect(screen.getByTestId('page-nav')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// XDSPageNavHeader
+// =============================================================================
+
+describe('XDSPageNavHeader', () => {
+  it('renders title text', () => {
+    render(<XDSPageNavHeader title="My App" />);
+    expect(screen.getByText('My App')).toBeInTheDocument();
+  });
+
+  it('renders icon', () => {
+    render(
+      <XDSPageNavHeader
+        title="My App"
+        icon={<span data-testid="app-icon">🏠</span>}
+      />,
+    );
+    expect(screen.getByTestId('app-icon')).toBeInTheDocument();
+  });
+
+  it('renders supertitle', () => {
+    render(<XDSPageNavHeader title="Product" supertitle="Suite Name" />);
+    expect(screen.getByText('Suite Name')).toBeInTheDocument();
+  });
+
+  it('renders subtitle', () => {
+    render(<XDSPageNavHeader title="Product" subtitle="Account" />);
+    expect(screen.getByText('Account')).toBeInTheDocument();
+  });
+
+  it('renders as link when titleHref is provided without menu', () => {
+    render(<XDSPageNavHeader title="My App" titleHref="/home" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/home');
+    expect(link).toHaveTextContent('My App');
+  });
+
+  it('renders independent links when titleHref and supertitleHref are provided', () => {
+    render(
+      <XDSPageNavHeader
+        title="Product"
+        titleHref="/product"
+        supertitle="Suite"
+        supertitleHref="/suite"
+      />,
+    );
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', '/suite');
+    expect(links[1]).toHaveAttribute('href', '/product');
+  });
+
+  it('shows chevron when menu is provided', () => {
+    render(<XDSPageNavHeader title="My App" menu={<div>Menu content</div>} />);
+    // The chevron SVG should be rendered
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('shows chevron when hasChevron is explicitly set', () => {
+    const {container} = render(<XDSPageNavHeader title="My App" hasChevron />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeInTheDocument();
+  });
+
+  it('whole header is popover trigger when menu provided without hrefs', () => {
+    render(<XDSPageNavHeader title="My App" menu={<div>Menu</div>} />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('toggles popover on click when menu is provided', async () => {
+    const user = userEvent.setup();
+    render(
+      <XDSPageNavHeader
+        title="My App"
+        menu={<div data-testid="menu-content">Menu</div>}
+      />,
+    );
+    const button = screen.getByRole('button');
+    await user.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('renders chevron as separate trigger when menu and hrefs are provided', () => {
+    render(
+      <XDSPageNavHeader
+        title="Product"
+        titleHref="/product"
+        menu={<div>Menu</div>}
+      />,
+    );
+    const button = screen.getByRole('button', {name: 'Open menu'});
+    expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+
+  it('passes data-testid', () => {
+    render(<XDSPageNavHeader title="My App" data-testid="nav-header" />);
+    expect(screen.getByTestId('nav-header')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// XDSPageNavItem
+// =============================================================================
+
+describe('XDSPageNavItem', () => {
+  it('renders label text', () => {
+    render(<XDSPageNavItem label="Dashboard" />);
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders as link when href is provided', () => {
+    render(<XDSPageNavItem label="Dashboard" href="/dashboard" />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/dashboard');
+  });
+
+  it('renders as button when no href', () => {
+    render(<XDSPageNavItem label="Dashboard" />);
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('sets aria-current="page" when selected', () => {
+    render(<XDSPageNavItem label="Dashboard" isSelected />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not set aria-current when not selected', () => {
+    render(<XDSPageNavItem label="Dashboard" />);
+    const button = screen.getByRole('button');
+    expect(button).not.toHaveAttribute('aria-current');
+  });
+
+  it('disables the button when isDisabled', () => {
+    render(<XDSPageNavItem label="Dashboard" isDisabled />);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('calls onClick handler', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<XDSPageNavItem label="Dashboard" onClick={handleClick} />);
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders endContent', () => {
+    render(
+      <XDSPageNavItem
+        label="Projects"
+        endContent={<span data-testid="badge">3</span>}
+      />,
+    );
+    expect(screen.getByTestId('badge')).toBeInTheDocument();
+  });
+
+  it('renders nested children', () => {
+    render(
+      <XDSPageNavItem label="Settings">
+        <XDSPageNavItem label="General" />
+        <XDSPageNavItem label="Security" />
+      </XDSPageNavItem>,
+    );
+    expect(screen.getByText('General')).toBeInTheDocument();
+    expect(screen.getByText('Security')).toBeInTheDocument();
+  });
+
+  it('passes data-testid', () => {
+    render(<XDSPageNavItem label="Dashboard" data-testid="nav-item" />);
+    expect(screen.getByTestId('nav-item')).toBeInTheDocument();
+  });
+
+  it('renders with selected link', () => {
+    render(<XDSPageNavItem label="Dashboard" href="/dashboard" isSelected />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('aria-current', 'page');
+  });
+});
+
+// =============================================================================
+// XDSPageNavItem collapsible
+// =============================================================================
+
+describe('XDSPageNavItem collapsible', () => {
+  function CollapsibleItem() {
+    const collapsible = useXDSCollapsible(true);
+    return (
+      <XDSPageNavItem label="Settings" collapsible={collapsible}>
+        <XDSPageNavItem label="General" />
+        <XDSPageNavItem label="Security" />
+      </XDSPageNavItem>
+    );
+  }
+
+  it('shows children when collapsible is open', () => {
+    render(<CollapsibleItem />);
+    expect(screen.getByText('General')).toBeInTheDocument();
+  });
+
+  it('sets aria-expanded on collapsible item', () => {
+    render(<CollapsibleItem />);
+    const buttons = screen.getAllByRole('button');
+    const settingsButton = buttons.find(b =>
+      b.textContent?.includes('Settings'),
+    );
+    expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('toggles children on click', async () => {
+    const user = userEvent.setup();
+    render(<CollapsibleItem />);
+    const buttons = screen.getAllByRole('button');
+    const settingsButton = buttons.find(b =>
+      b.textContent?.includes('Settings'),
+    )!;
+
+    await user.click(settingsButton);
+    expect(screen.queryByText('General')).not.toBeInTheDocument();
+
+    await user.click(settingsButton);
+    expect(screen.getByText('General')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// XDSPageNavSection
+// =============================================================================
+
+describe('XDSPageNavSection', () => {
+  it('renders with group role', () => {
+    render(
+      <XDSPageNavSection title="Main">
+        <XDSPageNavItem label="Dashboard" />
+      </XDSPageNavSection>,
+    );
+    expect(screen.getByRole('group')).toBeInTheDocument();
+  });
+
+  it('renders title text', () => {
+    render(
+      <XDSPageNavSection title="Main">
+        <XDSPageNavItem label="Dashboard" />
+      </XDSPageNavSection>,
+    );
+    expect(screen.getByText('Main')).toBeInTheDocument();
+  });
+
+  it('uses aria-labelledby to link title to group', () => {
+    render(
+      <XDSPageNavSection title="Main">
+        <XDSPageNavItem label="Dashboard" />
+      </XDSPageNavSection>,
+    );
+    const group = screen.getByRole('group');
+    const labelId = group.getAttribute('aria-labelledby');
+    expect(labelId).toBeTruthy();
+    const label = document.getElementById(labelId!);
+    expect(label).toHaveTextContent('Main');
+  });
+
+  it('renders subtitle', () => {
+    render(
+      <XDSPageNavSection title="Main" subtitle="Primary navigation">
+        <XDSPageNavItem label="Dashboard" />
+      </XDSPageNavSection>,
+    );
+    expect(screen.getByText('Primary navigation')).toBeInTheDocument();
+  });
+
+  it('renders endContent', () => {
+    render(
+      <XDSPageNavSection
+        title="Main"
+        endContent={<span data-testid="section-action">+</span>}>
+        <XDSPageNavItem label="Dashboard" />
+      </XDSPageNavSection>,
+    );
+    expect(screen.getByTestId('section-action')).toBeInTheDocument();
+  });
+
+  it('passes data-testid', () => {
+    render(
+      <XDSPageNavSection title="Main" data-testid="nav-section">
+        <XDSPageNavItem label="Dashboard" />
+      </XDSPageNavSection>,
+    );
+    expect(screen.getByTestId('nav-section')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// XDSPageNavSection collapsible
+// =============================================================================
+
+describe('XDSPageNavSection collapsible', () => {
+  function CollapsibleSection() {
+    const collapsible = useXDSCollapsible(true);
+    return (
+      <XDSPageNavSection title="Settings" collapsible={collapsible}>
+        <XDSPageNavItem label="General" />
+        <XDSPageNavItem label="Security" />
+      </XDSPageNavSection>
+    );
+  }
+
+  it('shows children when collapsible is open', () => {
+    render(<CollapsibleSection />);
+    expect(screen.getByText('General')).toBeInTheDocument();
+  });
+
+  it('sets aria-expanded on collapsible section header', () => {
+    render(<CollapsibleSection />);
+    const buttons = screen.getAllByRole('button');
+    const sectionButton = buttons.find(b =>
+      b.textContent?.includes('Settings'),
+    );
+    expect(sectionButton).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('toggles children on click', async () => {
+    const user = userEvent.setup();
+    render(<CollapsibleSection />);
+    const buttons = screen.getAllByRole('button');
+    const sectionButton = buttons.find(b =>
+      b.textContent?.includes('Settings'),
+    )!;
+
+    await user.click(sectionButton);
+    expect(screen.queryByText('General')).not.toBeInTheDocument();
+
+    await user.click(sectionButton);
+    expect(screen.getByText('General')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// useXDSCollapsible
+// =============================================================================
+
+describe('useXDSCollapsible', () => {
+  function TestComponent({initialIsOpen = true}: {initialIsOpen?: boolean}) {
+    const collapsible = useXDSCollapsible(initialIsOpen);
+    return (
+      <div>
+        <button onClick={collapsible.onToggle}>Toggle</button>
+        <span data-testid="state">
+          {collapsible.isOpen ? 'open' : 'closed'}
+        </span>
+      </div>
+    );
+  }
+
+  it('defaults to open', () => {
+    render(<TestComponent />);
+    expect(screen.getByTestId('state')).toHaveTextContent('open');
+  });
+
+  it('can start closed', () => {
+    render(<TestComponent initialIsOpen={false} />);
+    expect(screen.getByTestId('state')).toHaveTextContent('closed');
+  });
+
+  it('toggles state', async () => {
+    const user = userEvent.setup();
+    render(<TestComponent />);
+    expect(screen.getByTestId('state')).toHaveTextContent('open');
+
+    await user.click(screen.getByText('Toggle'));
+    expect(screen.getByTestId('state')).toHaveTextContent('closed');
+
+    await user.click(screen.getByText('Toggle'));
+    expect(screen.getByTestId('state')).toHaveTextContent('open');
+  });
+});
+
+// =============================================================================
+// Integration
+// =============================================================================
+
+describe('PageNav integration', () => {
+  it('renders a complete page nav', () => {
+    render(
+      <XDSPageNav
+        header={<XDSPageNavHeader title="My App" />}
+        stickyContent={<button>Create</button>}
+        footer={<div data-testid="promo">Promo</div>}
+        footerIcons={<button>Help</button>}>
+        <XDSPageNavSection title="Main">
+          <XDSPageNavItem label="Dashboard" isSelected />
+          <XDSPageNavItem label="Projects" />
+        </XDSPageNavSection>
+        <XDSPageNavSection title="Settings">
+          <XDSPageNavItem label="General" />
+        </XDSPageNavSection>
+      </XDSPageNav>,
+    );
+
+    expect(screen.getByRole('navigation')).toBeInTheDocument();
+    expect(screen.getByText('My App')).toBeInTheDocument();
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Projects')).toBeInTheDocument();
+    expect(screen.getByText('General')).toBeInTheDocument();
+    expect(screen.getByTestId('promo')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/PageNav/XDSPageNav.test.tsx
+++ b/packages/core/src/PageNav/XDSPageNav.test.tsx
@@ -12,7 +12,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {XDSPageNav} from './XDSPageNav';
 import {XDSPageNavHeader} from './XDSPageNavHeader';
-import {XDSPageNavItem, useXDSCollapsible} from './XDSPageNavItem';
+import {XDSPageNavItem} from './XDSPageNavItem';
 import {XDSPageNavSection} from './XDSPageNavSection';
 
 // =============================================================================
@@ -51,9 +51,9 @@ describe('XDSPageNav', () => {
     expect(screen.getByTestId('header')).toBeInTheDocument();
   });
 
-  it('renders stickyContent slot', () => {
+  it('renders topContent slot', () => {
     render(
-      <XDSPageNav stickyContent={<span data-testid="sticky">Sticky</span>}>
+      <XDSPageNav topContent={<span data-testid="sticky">Sticky</span>}>
         Content
       </XDSPageNav>,
     );
@@ -82,7 +82,7 @@ describe('XDSPageNav', () => {
     render(
       <XDSPageNav
         header={<span data-testid="header">Header</span>}
-        stickyContent={<span data-testid="sticky">Sticky</span>}
+        topContent={<span data-testid="sticky">Sticky</span>}
         footer={<span data-testid="footer">Footer</span>}
         footerIcons={<span data-testid="icons">Icons</span>}>
         <span data-testid="content">Content</span>
@@ -291,51 +291,6 @@ describe('XDSPageNavItem', () => {
 });
 
 // =============================================================================
-// XDSPageNavItem collapsible
-// =============================================================================
-
-describe('XDSPageNavItem collapsible', () => {
-  function CollapsibleItem() {
-    const collapsible = useXDSCollapsible(true);
-    return (
-      <XDSPageNavItem label="Settings" collapsible={collapsible}>
-        <XDSPageNavItem label="General" />
-        <XDSPageNavItem label="Security" />
-      </XDSPageNavItem>
-    );
-  }
-
-  it('shows children when collapsible is open', () => {
-    render(<CollapsibleItem />);
-    expect(screen.getByText('General')).toBeInTheDocument();
-  });
-
-  it('sets aria-expanded on collapsible item', () => {
-    render(<CollapsibleItem />);
-    const buttons = screen.getAllByRole('button');
-    const settingsButton = buttons.find(b =>
-      b.textContent?.includes('Settings'),
-    );
-    expect(settingsButton).toHaveAttribute('aria-expanded', 'true');
-  });
-
-  it('toggles children on click', async () => {
-    const user = userEvent.setup();
-    render(<CollapsibleItem />);
-    const buttons = screen.getAllByRole('button');
-    const settingsButton = buttons.find(b =>
-      b.textContent?.includes('Settings'),
-    )!;
-
-    await user.click(settingsButton);
-    expect(screen.queryByText('General')).not.toBeInTheDocument();
-
-    await user.click(settingsButton);
-    expect(screen.getByText('General')).toBeInTheDocument();
-  });
-});
-
-// =============================================================================
 // XDSPageNavSection
 // =============================================================================
 
@@ -402,91 +357,6 @@ describe('XDSPageNavSection', () => {
 });
 
 // =============================================================================
-// XDSPageNavSection collapsible
-// =============================================================================
-
-describe('XDSPageNavSection collapsible', () => {
-  function CollapsibleSection() {
-    const collapsible = useXDSCollapsible(true);
-    return (
-      <XDSPageNavSection title="Settings" collapsible={collapsible}>
-        <XDSPageNavItem label="General" />
-        <XDSPageNavItem label="Security" />
-      </XDSPageNavSection>
-    );
-  }
-
-  it('shows children when collapsible is open', () => {
-    render(<CollapsibleSection />);
-    expect(screen.getByText('General')).toBeInTheDocument();
-  });
-
-  it('sets aria-expanded on collapsible section header', () => {
-    render(<CollapsibleSection />);
-    const buttons = screen.getAllByRole('button');
-    const sectionButton = buttons.find(b =>
-      b.textContent?.includes('Settings'),
-    );
-    expect(sectionButton).toHaveAttribute('aria-expanded', 'true');
-  });
-
-  it('toggles children on click', async () => {
-    const user = userEvent.setup();
-    render(<CollapsibleSection />);
-    const buttons = screen.getAllByRole('button');
-    const sectionButton = buttons.find(b =>
-      b.textContent?.includes('Settings'),
-    )!;
-
-    await user.click(sectionButton);
-    expect(screen.queryByText('General')).not.toBeInTheDocument();
-
-    await user.click(sectionButton);
-    expect(screen.getByText('General')).toBeInTheDocument();
-  });
-});
-
-// =============================================================================
-// useXDSCollapsible
-// =============================================================================
-
-describe('useXDSCollapsible', () => {
-  function TestComponent({initialIsOpen = true}: {initialIsOpen?: boolean}) {
-    const collapsible = useXDSCollapsible(initialIsOpen);
-    return (
-      <div>
-        <button onClick={collapsible.onToggle}>Toggle</button>
-        <span data-testid="state">
-          {collapsible.isOpen ? 'open' : 'closed'}
-        </span>
-      </div>
-    );
-  }
-
-  it('defaults to open', () => {
-    render(<TestComponent />);
-    expect(screen.getByTestId('state')).toHaveTextContent('open');
-  });
-
-  it('can start closed', () => {
-    render(<TestComponent initialIsOpen={false} />);
-    expect(screen.getByTestId('state')).toHaveTextContent('closed');
-  });
-
-  it('toggles state', async () => {
-    const user = userEvent.setup();
-    render(<TestComponent />);
-    expect(screen.getByTestId('state')).toHaveTextContent('open');
-
-    await user.click(screen.getByText('Toggle'));
-    expect(screen.getByTestId('state')).toHaveTextContent('closed');
-
-    await user.click(screen.getByText('Toggle'));
-    expect(screen.getByTestId('state')).toHaveTextContent('open');
-  });
-});
-
-// =============================================================================
 // Integration
 // =============================================================================
 
@@ -495,7 +365,7 @@ describe('PageNav integration', () => {
     render(
       <XDSPageNav
         header={<XDSPageNavHeader title="My App" />}
-        stickyContent={<button>Create</button>}
+        topContent={<button>Create</button>}
         footer={<div data-testid="promo">Promo</div>}
         footerIcons={<button>Help</button>}>
         <XDSPageNavSection title="Main">

--- a/packages/core/src/PageNav/XDSPageNav.tsx
+++ b/packages/core/src/PageNav/XDSPageNav.tsx
@@ -4,7 +4,7 @@
  * @output Exports XDSPageNav component and XDSPageNavProps
  * @position Core implementation; consumed by index.ts, tested by XDSPageNav.test.tsx
  *
- * Sidebar navigation container with five zones: header (sticky), stickyContent (sticky),
+ * Sidebar navigation container with five zones: header (sticky), topContent (sticky),
  * children (scrollable), footer, and footerIcons.
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -48,7 +48,7 @@ const styles = stylex.create({
     zIndex: 1,
     backgroundColor: colorVars['--color-surface'],
   },
-  stickyContent: {
+  topContent: {
     flexShrink: 0,
     position: 'sticky',
     top: 0,
@@ -108,7 +108,7 @@ export interface XDSPageNavProps extends Omit<
   /**
    * Content pinned below header (e.g., create button, top-level items). Sticky.
    */
-  stickyContent?: ReactNode;
+  topContent?: ReactNode;
   /**
    * Navigation sections and items. Scrollable.
    */
@@ -145,7 +145,7 @@ export interface XDSPageNavProps extends Omit<
  * ```tsx
  * <XDSPageNav
  *   header={<XDSPageNavHeader icon={<AppIcon />} title="My App" titleHref="/" />}
- *   stickyContent={<XDSButton label="Create new" variant="primary" />}
+ *   topContent={<XDSButton label="Create new" variant="primary" />}
  *   footerIcons={<XDSButton icon={HelpIcon} variant="ghost" label="Help" />}
  * >
  *   <XDSPageNavSection title="Main">
@@ -159,7 +159,7 @@ export const XDSPageNav = forwardRef<HTMLElement, XDSPageNavProps>(
   function XDSPageNav(
     {
       header,
-      stickyContent,
+      topContent,
       children,
       footer,
       footerIcons,
@@ -181,8 +181,8 @@ export const XDSPageNav = forwardRef<HTMLElement, XDSPageNavProps>(
         {...stylex.props(styles.root, rootOverride, xstyle)}
         {...props}>
         {header && <div {...stylex.props(styles.header)}>{header}</div>}
-        {stickyContent && (
-          <div {...stylex.props(styles.stickyContent)}>{stickyContent}</div>
+        {topContent && (
+          <div {...stylex.props(styles.topContent)}>{topContent}</div>
         )}
         <div {...stylex.props(styles.scrollable)}>{children}</div>
         {footer && <div {...stylex.props(styles.footer)}>{footer}</div>}

--- a/packages/core/src/PageNav/XDSPageNav.tsx
+++ b/packages/core/src/PageNav/XDSPageNav.tsx
@@ -1,0 +1,197 @@
+/**
+ * @file XDSPageNav.tsx
+ * @input Uses React forwardRef, HTMLAttributes, ReactNode, StyleX
+ * @output Exports XDSPageNav component and XDSPageNavProps
+ * @position Core implementation; consumed by index.ts, tested by XDSPageNav.test.tsx
+ *
+ * Sidebar navigation container with five zones: header (sticky), stickyContent (sticky),
+ * children (scrollable), footer, and footerIcons.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/PageNav/README.md
+ * - /packages/core/src/PageNav/XDSPageNav.test.tsx
+ * - /packages/core/src/PageNav/index.ts
+ * - /apps/storybook/stories/PageNav.stories.tsx
+ */
+
+'use client';
+
+import {
+  forwardRef,
+  useContext,
+  type HTMLAttributes,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {ThemeContext} from '../theme/ThemeContext';
+import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    backgroundColor: colorVars['--color-surface'],
+    boxSizing: 'border-box',
+    overflow: 'hidden',
+  },
+  header: {
+    flexShrink: 0,
+    position: 'sticky',
+    top: 0,
+    zIndex: 1,
+    backgroundColor: colorVars['--color-surface'],
+  },
+  stickyContent: {
+    flexShrink: 0,
+    position: 'sticky',
+    top: 0,
+    zIndex: 1,
+    backgroundColor: colorVars['--color-surface'],
+    paddingInline: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-1'],
+  },
+  scrollable: {
+    flex: 1,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    paddingInline: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-1'],
+  },
+  footer: {
+    flexShrink: 0,
+    paddingInline: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-2'],
+  },
+  footerIcons: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-2'],
+    borderBlockStart: `1px solid ${colorVars['--color-divider']}`,
+  },
+});
+
+// =============================================================================
+// Module Augmentation
+// =============================================================================
+
+declare module '../theme/types' {
+  interface ComponentStyles {
+    pageNav?: {
+      /** Root container styles */
+      root?: ThemeStyleXStyles;
+    };
+  }
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface XDSPageNavProps extends Omit<
+  HTMLAttributes<HTMLElement>,
+  'style' | 'className'
+> {
+  /**
+   * Header area — typically XDSPageNavHeader. Sticky at top.
+   */
+  header?: ReactNode;
+  /**
+   * Content pinned below header (e.g., create button, top-level items). Sticky.
+   */
+  stickyContent?: ReactNode;
+  /**
+   * Navigation sections and items. Scrollable.
+   */
+  children: ReactNode;
+  /**
+   * Footer area above icon bar (e.g., promo cards).
+   */
+  footer?: ReactNode;
+  /**
+   * Footer icon bar (e.g., help, notifications, avatar).
+   */
+  footerIcons?: ReactNode;
+  /**
+   * StyleX overrides for the root container.
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * Test ID for the root element.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Sidebar navigation container for application pages.
+ *
+ * Provides five zones stacked vertically: a sticky header, sticky action area,
+ * scrollable nav content, footer, and footer icon bar.
+ *
+ * @example
+ * ```tsx
+ * <XDSPageNav
+ *   header={<XDSPageNavHeader icon={<AppIcon />} title="My App" titleHref="/" />}
+ *   stickyContent={<XDSButton label="Create new" variant="primary" />}
+ *   footerIcons={<XDSButton icon={HelpIcon} variant="ghost" label="Help" />}
+ * >
+ *   <XDSPageNavSection title="Main">
+ *     <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected href="/dashboard" />
+ *     <XDSPageNavItem label="Projects" icon={FolderIcon} href="/projects" />
+ *   </XDSPageNavSection>
+ * </XDSPageNav>
+ * ```
+ */
+export const XDSPageNav = forwardRef<HTMLElement, XDSPageNavProps>(
+  function XDSPageNav(
+    {
+      header,
+      stickyContent,
+      children,
+      footer,
+      footerIcons,
+      xstyle,
+      'data-testid': testId,
+      ...props
+    },
+    ref,
+  ) {
+    const themeContext = useContext(ThemeContext);
+    const rootOverride = themeContext?.theme.components?.pageNav?.root;
+
+    return (
+      <nav
+        ref={ref}
+        role="navigation"
+        aria-label="Page navigation"
+        data-testid={testId}
+        {...stylex.props(styles.root, rootOverride, xstyle)}
+        {...props}>
+        {header && <div {...stylex.props(styles.header)}>{header}</div>}
+        {stickyContent && (
+          <div {...stylex.props(styles.stickyContent)}>{stickyContent}</div>
+        )}
+        <div {...stylex.props(styles.scrollable)}>{children}</div>
+        {footer && <div {...stylex.props(styles.footer)}>{footer}</div>}
+        {footerIcons && (
+          <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
+        )}
+      </nav>
+    );
+  },
+);
+
+XDSPageNav.displayName = 'XDSPageNav';

--- a/packages/core/src/PageNav/XDSPageNav.tsx
+++ b/packages/core/src/PageNav/XDSPageNav.tsx
@@ -42,6 +42,8 @@ const styles = stylex.create({
     overflow: 'hidden',
   },
   stickyTop: {
+    display: 'flex',
+    flexDirection: 'column',
     flexShrink: 0,
     position: 'sticky',
     top: 0,

--- a/packages/core/src/PageNav/XDSPageNav.tsx
+++ b/packages/core/src/PageNav/XDSPageNav.tsx
@@ -4,8 +4,8 @@
  * @output Exports XDSPageNav component and XDSPageNavProps
  * @position Core implementation; consumed by index.ts, tested by XDSPageNav.test.tsx
  *
- * Sidebar navigation container with five zones: header (sticky), topContent (sticky),
- * children (scrollable), footer, and footerIcons.
+ * Sidebar navigation container with five zones: header + topContent (sticky together),
+ * children (scrollable), footer, and footerIcons (sticky bottom).
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/PageNav/README.md
@@ -41,7 +41,7 @@ const styles = stylex.create({
     boxSizing: 'border-box',
     overflow: 'hidden',
   },
-  header: {
+  stickyTop: {
     flexShrink: 0,
     position: 'sticky',
     top: 0,
@@ -49,11 +49,6 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-surface'],
   },
   topContent: {
-    flexShrink: 0,
-    position: 'sticky',
-    top: 0,
-    zIndex: 1,
-    backgroundColor: colorVars['--color-surface'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
   },
@@ -64,13 +59,18 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
   },
-  footer: {
+  stickyBottom: {
     flexShrink: 0,
+    marginTop: 'auto',
+    position: 'sticky',
+    bottom: 0,
+    backgroundColor: colorVars['--color-surface'],
+  },
+  footer: {
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-2'],
   },
   footerIcons: {
-    flexShrink: 0,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
@@ -138,8 +138,8 @@ export interface XDSPageNavProps extends Omit<
 /**
  * Sidebar navigation container for application pages.
  *
- * Provides five zones stacked vertically: a sticky header, sticky action area,
- * scrollable nav content, footer, and footer icon bar.
+ * Provides five zones stacked vertically: a sticky header + action area (stuck together),
+ * scrollable nav content, and a sticky bottom footer + footer icon bar.
  *
  * @example
  * ```tsx
@@ -172,6 +172,9 @@ export const XDSPageNav = forwardRef<HTMLElement, XDSPageNavProps>(
     const themeContext = useContext(ThemeContext);
     const rootOverride = themeContext?.theme.components?.pageNav?.root;
 
+    const hasStickyTop = !!(header || topContent);
+    const hasStickyBottom = !!(footer || footerIcons);
+
     return (
       <nav
         ref={ref}
@@ -180,14 +183,22 @@ export const XDSPageNav = forwardRef<HTMLElement, XDSPageNavProps>(
         data-testid={testId}
         {...stylex.props(styles.root, rootOverride, xstyle)}
         {...props}>
-        {header && <div {...stylex.props(styles.header)}>{header}</div>}
-        {topContent && (
-          <div {...stylex.props(styles.topContent)}>{topContent}</div>
+        {hasStickyTop && (
+          <div {...stylex.props(styles.stickyTop)}>
+            {header}
+            {topContent && (
+              <div {...stylex.props(styles.topContent)}>{topContent}</div>
+            )}
+          </div>
         )}
         <div {...stylex.props(styles.scrollable)}>{children}</div>
-        {footer && <div {...stylex.props(styles.footer)}>{footer}</div>}
-        {footerIcons && (
-          <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
+        {hasStickyBottom && (
+          <div {...stylex.props(styles.stickyBottom)}>
+            {footer && <div {...stylex.props(styles.footer)}>{footer}</div>}
+            {footerIcons && (
+              <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
+            )}
+          </div>
         )}
       </nav>
     );

--- a/packages/core/src/PageNav/XDSPageNavHeader.tsx
+++ b/packages/core/src/PageNav/XDSPageNavHeader.tsx
@@ -44,7 +44,6 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
     paddingBlock: spacingVars['--spacing-3'],
-    width: '100%',
     boxSizing: 'border-box',
     textDecoration: 'none',
     color: 'inherit',

--- a/packages/core/src/PageNav/XDSPageNavHeader.tsx
+++ b/packages/core/src/PageNav/XDSPageNavHeader.tsx
@@ -118,7 +118,14 @@ const styles = stylex.create({
     color: colorVars['--color-icon-secondary'],
   },
   popoverContent: {
-    minWidth: 'var(--page-nav-header-width)',
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-surface'],
+    boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
+    overflow: 'hidden',
+  },
+  popover: {
+    minWidth: 'anchor-size(width)',
+    marginBlockStart: spacingVars['--spacing-1'],
   },
 });
 
@@ -378,7 +385,10 @@ export const XDSPageNavHeader = forwardRef<
           {renderTextContent()}
           {chevronElement}
         </button>
-        {popover.render(menu, {placement: 'below', alignment: 'start'})}
+        {popover.render(
+          <div {...stylex.props(styles.popoverContent)}>{menu}</div>,
+          {placement: 'below', alignment: 'start', xstyle: styles.popover},
+        )}
       </>
     );
   }
@@ -413,7 +423,10 @@ export const XDSPageNavHeader = forwardRef<
             </button>
           )}
         </div>
-        {popover.render(menu, {placement: 'below', alignment: 'start'})}
+        {popover.render(
+          <div {...stylex.props(styles.popoverContent)}>{menu}</div>,
+          {placement: 'below', alignment: 'start', xstyle: styles.popover},
+        )}
       </>
     );
   }

--- a/packages/core/src/PageNav/XDSPageNavHeader.tsx
+++ b/packages/core/src/PageNav/XDSPageNavHeader.tsx
@@ -27,7 +27,11 @@ import {
   lineHeightVars,
   radiusVars,
 } from '../theme/tokens.stylex';
+// TODO(#264): Lazy-load useXDSPopover so the popover/layer bundle is not
+// eagerly imported when `menu` is not provided. See XDSText for an example
+// of lazy loading layer resources.
 import {useXDSPopover} from '../Layer/useXDSPopover';
+import {XDSLink} from '../Link';
 
 // =============================================================================
 // Styles
@@ -82,13 +86,6 @@ const styles = stylex.create({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-  supertitleLink: {
-    color: colorVars['--color-text-secondary'],
-    textDecoration: 'none',
-    ':hover': {
-      textDecoration: 'underline',
-    },
-  },
   title: {
     fontSize: textSizeVars['--text-base'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
@@ -99,13 +96,6 @@ const styles = stylex.create({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-  titleLink: {
-    color: colorVars['--color-text-primary'],
-    textDecoration: 'none',
-    ':hover': {
-      textDecoration: 'underline',
-    },
-  },
   subtitle: {
     fontSize: textSizeVars['--text-xsm'],
     lineHeight: lineHeightVars['--leading-snug'],
@@ -114,13 +104,6 @@ const styles = stylex.create({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-  },
-  subtitleLink: {
-    color: colorVars['--color-text-secondary'],
-    textDecoration: 'none',
-    ':hover': {
-      textDecoration: 'underline',
-    },
   },
   chevron: {
     flexShrink: 0,
@@ -170,13 +153,9 @@ export interface XDSPageNavHeaderProps {
    */
   subtitleHref?: string;
   /**
-   * Show dropdown chevron indicator.
-   * Automatically shown when `menu` is provided. Can be set explicitly.
-   */
-  hasChevron?: boolean;
-  /**
    * Menu content shown in a popover. When provided, the header composes
-   * useXDSPopover internally. The trigger boundary is determined automatically:
+   * useXDSPopover internally and shows a dropdown chevron. The trigger
+   * boundary is determined automatically:
    * - No hrefs → whole header is the trigger
    * - With hrefs → links are independent, chevron/remaining area is the trigger
    */
@@ -227,6 +206,8 @@ function ChevronDownIcon() {
  * - titleHref + supertitleHref, no menu → each is an independent link
  * - menu + hrefs → links are independent, chevron/remaining area is the trigger
  *
+ * The chevron indicator is automatically shown when `menu` is provided.
+ *
  * @example
  * ```tsx
  * // Single product
@@ -263,7 +244,6 @@ export const XDSPageNavHeader = forwardRef<
     supertitleHref,
     subtitle,
     subtitleHref,
-    hasChevron: hasChevronProp,
     menu,
     xstyle,
     'data-testid': testId,
@@ -277,7 +257,7 @@ export const XDSPageNavHeader = forwardRef<
     dialogLabel: 'Navigation menu',
   });
 
-  const showChevron = hasChevronProp ?? !!menu;
+  const showChevron = !!menu;
   const hasAnyHref = !!(titleHref || supertitleHref || subtitleHref);
 
   // Determine interaction mode
@@ -310,28 +290,36 @@ export const XDSPageNavHeader = forwardRef<
     <span {...stylex.props(styles.textContainer)}>
       {supertitle &&
         (hasAnyHref && supertitleHref && menu ? (
-          <a
+          <XDSLink
+            label={supertitle}
             href={supertitleHref}
-            {...stylex.props(styles.supertitle, styles.supertitleLink)}>
+            color="secondary"
+            size="xsm">
             {supertitle}
-          </a>
+          </XDSLink>
         ) : (
           <span {...stylex.props(styles.supertitle)}>{supertitle}</span>
         ))}
       {hasAnyHref && titleHref && menu ? (
-        <a href={titleHref} {...stylex.props(styles.title, styles.titleLink)}>
+        <XDSLink
+          label={title}
+          href={titleHref}
+          color="primary"
+          weight="semibold">
           {title}
-        </a>
+        </XDSLink>
       ) : (
         <span {...stylex.props(styles.title)}>{title}</span>
       )}
       {subtitle &&
         (hasAnyHref && subtitleHref && menu ? (
-          <a
+          <XDSLink
+            label={subtitle}
             href={subtitleHref}
-            {...stylex.props(styles.subtitle, styles.subtitleLink)}>
+            color="secondary"
+            size="xsm">
             {subtitle}
-          </a>
+          </XDSLink>
         ) : (
           <span {...stylex.props(styles.subtitle)}>{subtitle}</span>
         ))}
@@ -433,30 +421,36 @@ export const XDSPageNavHeader = forwardRef<
         <span {...stylex.props(styles.textContainer)}>
           {supertitle &&
             (supertitleHref ? (
-              <a
+              <XDSLink
+                label={supertitle}
                 href={supertitleHref}
-                {...stylex.props(styles.supertitle, styles.supertitleLink)}>
+                color="secondary"
+                size="xsm">
                 {supertitle}
-              </a>
+              </XDSLink>
             ) : (
               <span {...stylex.props(styles.supertitle)}>{supertitle}</span>
             ))}
           {titleHref ? (
-            <a
+            <XDSLink
+              label={title}
               href={titleHref}
-              {...stylex.props(styles.title, styles.titleLink)}>
+              color="primary"
+              weight="semibold">
               {title}
-            </a>
+            </XDSLink>
           ) : (
             <span {...stylex.props(styles.title)}>{title}</span>
           )}
           {subtitle &&
             (subtitleHref ? (
-              <a
+              <XDSLink
+                label={subtitle}
                 href={subtitleHref}
-                {...stylex.props(styles.subtitle, styles.subtitleLink)}>
+                color="secondary"
+                size="xsm">
                 {subtitle}
-              </a>
+              </XDSLink>
             ) : (
               <span {...stylex.props(styles.subtitle)}>{subtitle}</span>
             ))}

--- a/packages/core/src/PageNav/XDSPageNavHeader.tsx
+++ b/packages/core/src/PageNav/XDSPageNavHeader.tsx
@@ -63,6 +63,10 @@ const styles = stylex.create({
       backgroundColor: colorVars['--color-hover-overlay'],
     },
   },
+  interactiveInset: {
+    marginInline: spacingVars['--spacing-1'],
+    marginBlock: spacingVars['--spacing-1'],
+  },
   icon: {
     flexShrink: 0,
     display: 'flex',
@@ -269,7 +273,9 @@ export const XDSPageNavHeader = forwardRef<
     popover.toggle();
   }, [popover]);
 
-  // Combine refs
+  // Combine refs — always anchor popover to the full header element
+  // so the popover appears in the same position regardless of whether
+  // links are present (mixed mode) or not (whole-header trigger mode).
   const setRef = useCallback(
     (el: HTMLDivElement | null) => {
       (rootRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
@@ -278,11 +284,11 @@ export const XDSPageNavHeader = forwardRef<
       } else if (ref) {
         (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
       }
-      if (isWholeHeaderTrigger) {
+      if (menu) {
         popover.triggerRef(el);
       }
     },
-    [ref, popover, isWholeHeaderTrigger],
+    [ref, popover, menu],
   );
 
   // Render text content
@@ -339,7 +345,12 @@ export const XDSPageNavHeader = forwardRef<
         ref={ref as React.Ref<HTMLAnchorElement>}
         href={titleHref}
         data-testid={testId}
-        {...stylex.props(styles.root, styles.interactive, xstyle)}
+        {...stylex.props(
+          styles.root,
+          styles.interactive,
+          styles.interactiveInset,
+          xstyle,
+        )}
         {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
         {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
         {renderTextContent()}
@@ -358,7 +369,12 @@ export const XDSPageNavHeader = forwardRef<
           onClick={handleToggle}
           data-testid={testId}
           {...popover.triggerProps}
-          {...stylex.props(styles.root, styles.interactive, xstyle)}>
+          {...stylex.props(
+            styles.root,
+            styles.interactive,
+            styles.interactiveInset,
+            xstyle,
+          )}>
           {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
           {renderTextContent()}
           {chevronElement}
@@ -369,6 +385,8 @@ export const XDSPageNavHeader = forwardRef<
   }
 
   // Mixed mode: independent links + chevron trigger for menu
+  // Popover anchors to the full header div, not the chevron, so it
+  // appears in the same position as the no-links case.
   if (menu && hasAnyHref) {
     return (
       <>
@@ -387,7 +405,6 @@ export const XDSPageNavHeader = forwardRef<
           {renderTextContent()}
           {showChevron && (
             <button
-              ref={popover.triggerRef as React.Ref<HTMLButtonElement>}
               type="button"
               onClick={handleToggle}
               aria-label="Open menu"

--- a/packages/core/src/PageNav/XDSPageNavHeader.tsx
+++ b/packages/core/src/PageNav/XDSPageNavHeader.tsx
@@ -1,0 +1,483 @@
+/**
+ * @file XDSPageNavHeader.tsx
+ * @input Uses React forwardRef, useRef, useCallback, ReactNode, StyleX, useXDSPopover
+ * @output Exports XDSPageNavHeader component and XDSPageNavHeaderProps
+ * @position Core implementation; used inside XDSPageNav header slot
+ *
+ * Product/suite/account header with smart interaction boundary logic.
+ * Composes useXDSPopover internally when menu prop is provided.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/PageNav/README.md
+ * - /packages/core/src/PageNav/XDSPageNav.test.tsx
+ * - /packages/core/src/PageNav/index.ts
+ * - /apps/storybook/stories/PageNav.stories.tsx
+ */
+
+'use client';
+
+import {forwardRef, useCallback, useRef, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+  radiusVars,
+} from '../theme/tokens.stylex';
+import {useXDSPopover} from '../Layer/useXDSPopover';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-3'],
+    width: '100%',
+    boxSizing: 'border-box',
+    textDecoration: 'none',
+    color: 'inherit',
+    cursor: 'default',
+  },
+  interactive: {
+    cursor: 'pointer',
+    borderRadius: radiusVars['--radius-element'],
+    borderWidth: 0,
+    borderStyle: 'none',
+    backgroundColor: 'transparent',
+    fontFamily: 'inherit',
+    fontSize: 'inherit',
+    textAlign: 'start',
+    ':hover': {
+      backgroundColor: colorVars['--color-hover-overlay'],
+    },
+  },
+  icon: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: spacingVars['--spacing-8'],
+    height: spacingVars['--spacing-8'],
+  },
+  textContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minWidth: 0,
+  },
+  supertitle: {
+    fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    color: colorVars['--color-text-secondary'],
+    textDecoration: 'none',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  supertitleLink: {
+    color: colorVars['--color-text-secondary'],
+    textDecoration: 'none',
+    ':hover': {
+      textDecoration: 'underline',
+    },
+  },
+  title: {
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    color: colorVars['--color-text-primary'],
+    textDecoration: 'none',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  titleLink: {
+    color: colorVars['--color-text-primary'],
+    textDecoration: 'none',
+    ':hover': {
+      textDecoration: 'underline',
+    },
+  },
+  subtitle: {
+    fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    color: colorVars['--color-text-secondary'],
+    textDecoration: 'none',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  subtitleLink: {
+    color: colorVars['--color-text-secondary'],
+    textDecoration: 'none',
+    ':hover': {
+      textDecoration: 'underline',
+    },
+  },
+  chevron: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 16,
+    height: 16,
+    color: colorVars['--color-icon-secondary'],
+  },
+  popoverContent: {
+    minWidth: 'var(--page-nav-header-width)',
+  },
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface XDSPageNavHeaderProps {
+  /**
+   * Product/app icon.
+   */
+  icon?: ReactNode;
+  /**
+   * Product/app name.
+   */
+  title: string;
+  /**
+   * Link for the title (e.g., product home).
+   */
+  titleHref?: string;
+  /**
+   * Text above the title (e.g., suite name).
+   */
+  supertitle?: string;
+  /**
+   * Link for the supertitle (e.g., suite home).
+   */
+  supertitleHref?: string;
+  /**
+   * Text below the title (e.g., account context).
+   */
+  subtitle?: string;
+  /**
+   * Link for the subtitle.
+   */
+  subtitleHref?: string;
+  /**
+   * Show dropdown chevron indicator.
+   * Automatically shown when `menu` is provided. Can be set explicitly.
+   */
+  hasChevron?: boolean;
+  /**
+   * Menu content shown in a popover. When provided, the header composes
+   * useXDSPopover internally. The trigger boundary is determined automatically:
+   * - No hrefs → whole header is the trigger
+   * - With hrefs → links are independent, chevron/remaining area is the trigger
+   */
+  menu?: ReactNode;
+  /**
+   * StyleX overrides.
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * Test ID for the root element.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Chevron SVG
+// =============================================================================
+
+function ChevronDownIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true">
+      <path
+        d="M4 6L8 10L12 6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Product/suite/account header for XDSPageNav.
+ *
+ * Supports smart interaction boundary logic:
+ * - No hrefs + menu → whole header is the popover trigger
+ * - titleHref only, no menu → whole header is one link
+ * - titleHref + supertitleHref, no menu → each is an independent link
+ * - menu + hrefs → links are independent, chevron/remaining area is the trigger
+ *
+ * @example
+ * ```tsx
+ * // Single product
+ * <XDSPageNavHeader icon={<AppIcon />} title="My App" titleHref="/" />
+ *
+ * // Suite with menu
+ * <XDSPageNavHeader
+ *   icon={<SuiteIcon />}
+ *   supertitle="Suite Name"
+ *   supertitleHref="/suite"
+ *   title="Product Name"
+ *   titleHref="/product"
+ *   menu={<ProductSwitcher />}
+ * />
+ *
+ * // Account context with menu
+ * <XDSPageNavHeader
+ *   icon={<AppIcon />}
+ *   title="Product Name"
+ *   subtitle="Business Account"
+ *   menu={<AccountSwitcher />}
+ * />
+ * ```
+ */
+export const XDSPageNavHeader = forwardRef<
+  HTMLDivElement,
+  XDSPageNavHeaderProps
+>(function XDSPageNavHeader(
+  {
+    icon,
+    title,
+    titleHref,
+    supertitle,
+    supertitleHref,
+    subtitle,
+    subtitleHref,
+    hasChevron: hasChevronProp,
+    menu,
+    xstyle,
+    'data-testid': testId,
+    ...props
+  },
+  ref,
+) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  const popover = useXDSPopover({
+    dialogLabel: 'Navigation menu',
+  });
+
+  const showChevron = hasChevronProp ?? !!menu;
+  const hasAnyHref = !!(titleHref || supertitleHref || subtitleHref);
+
+  // Determine interaction mode
+  const isWholeHeaderTrigger = !!menu && !hasAnyHref;
+  const isWholeHeaderLink =
+    !!titleHref && !menu && !supertitleHref && !subtitleHref;
+
+  const handleToggle = useCallback(() => {
+    popover.toggle();
+  }, [popover]);
+
+  // Combine refs
+  const setRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      (rootRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
+      }
+      if (isWholeHeaderTrigger) {
+        popover.triggerRef(el);
+      }
+    },
+    [ref, popover, isWholeHeaderTrigger],
+  );
+
+  // Render text content
+  const renderTextContent = () => (
+    <span {...stylex.props(styles.textContainer)}>
+      {supertitle &&
+        (hasAnyHref && supertitleHref && menu ? (
+          <a
+            href={supertitleHref}
+            {...stylex.props(styles.supertitle, styles.supertitleLink)}>
+            {supertitle}
+          </a>
+        ) : (
+          <span {...stylex.props(styles.supertitle)}>{supertitle}</span>
+        ))}
+      {hasAnyHref && titleHref && menu ? (
+        <a href={titleHref} {...stylex.props(styles.title, styles.titleLink)}>
+          {title}
+        </a>
+      ) : (
+        <span {...stylex.props(styles.title)}>{title}</span>
+      )}
+      {subtitle &&
+        (hasAnyHref && subtitleHref && menu ? (
+          <a
+            href={subtitleHref}
+            {...stylex.props(styles.subtitle, styles.subtitleLink)}>
+            {subtitle}
+          </a>
+        ) : (
+          <span {...stylex.props(styles.subtitle)}>{subtitle}</span>
+        ))}
+    </span>
+  );
+
+  const chevronElement = showChevron && (
+    <span {...stylex.props(styles.chevron)}>
+      <ChevronDownIcon />
+    </span>
+  );
+
+  // Whole header is a link (no menu, single titleHref)
+  if (isWholeHeaderLink) {
+    return (
+      <a
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        href={titleHref}
+        data-testid={testId}
+        {...stylex.props(styles.root, styles.interactive, xstyle)}
+        {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
+        {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
+        {renderTextContent()}
+        {chevronElement}
+      </a>
+    );
+  }
+
+  // Whole header is the popover trigger (menu, no hrefs)
+  if (isWholeHeaderTrigger) {
+    return (
+      <>
+        <button
+          ref={setRef as React.Ref<HTMLButtonElement>}
+          type="button"
+          onClick={handleToggle}
+          data-testid={testId}
+          {...popover.triggerProps}
+          {...stylex.props(styles.root, styles.interactive, xstyle)}>
+          {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
+          {renderTextContent()}
+          {chevronElement}
+        </button>
+        {popover.render(menu, {placement: 'below', alignment: 'start'})}
+      </>
+    );
+  }
+
+  // Mixed mode: independent links + chevron trigger for menu
+  if (menu && hasAnyHref) {
+    return (
+      <>
+        <div
+          ref={setRef}
+          data-testid={testId}
+          {...stylex.props(styles.root, xstyle)}>
+          {icon &&
+            (titleHref ? (
+              <a href={titleHref} {...stylex.props(styles.icon)}>
+                {icon}
+              </a>
+            ) : (
+              <span {...stylex.props(styles.icon)}>{icon}</span>
+            ))}
+          {renderTextContent()}
+          {showChevron && (
+            <button
+              ref={popover.triggerRef as React.Ref<HTMLButtonElement>}
+              type="button"
+              onClick={handleToggle}
+              aria-label="Open menu"
+              {...popover.triggerProps}
+              {...stylex.props(styles.chevron, styles.interactive)}>
+              <ChevronDownIcon />
+            </button>
+          )}
+        </div>
+        {popover.render(menu, {placement: 'below', alignment: 'start'})}
+      </>
+    );
+  }
+
+  // Static header with independent links (no menu)
+  if (hasAnyHref && !isWholeHeaderLink) {
+    return (
+      <div
+        ref={ref}
+        data-testid={testId}
+        {...stylex.props(styles.root, xstyle)}
+        {...props}>
+        {icon &&
+          (titleHref ? (
+            <a href={titleHref} {...stylex.props(styles.icon)}>
+              {icon}
+            </a>
+          ) : (
+            <span {...stylex.props(styles.icon)}>{icon}</span>
+          ))}
+        <span {...stylex.props(styles.textContainer)}>
+          {supertitle &&
+            (supertitleHref ? (
+              <a
+                href={supertitleHref}
+                {...stylex.props(styles.supertitle, styles.supertitleLink)}>
+                {supertitle}
+              </a>
+            ) : (
+              <span {...stylex.props(styles.supertitle)}>{supertitle}</span>
+            ))}
+          {titleHref ? (
+            <a
+              href={titleHref}
+              {...stylex.props(styles.title, styles.titleLink)}>
+              {title}
+            </a>
+          ) : (
+            <span {...stylex.props(styles.title)}>{title}</span>
+          )}
+          {subtitle &&
+            (subtitleHref ? (
+              <a
+                href={subtitleHref}
+                {...stylex.props(styles.subtitle, styles.subtitleLink)}>
+                {subtitle}
+              </a>
+            ) : (
+              <span {...stylex.props(styles.subtitle)}>{subtitle}</span>
+            ))}
+        </span>
+        {chevronElement}
+      </div>
+    );
+  }
+
+  // Default: static header, no links, no menu
+  return (
+    <div
+      ref={ref}
+      data-testid={testId}
+      {...stylex.props(styles.root, xstyle)}
+      {...props}>
+      {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
+      {renderTextContent()}
+      {chevronElement}
+    </div>
+  );
+});
+
+XDSPageNavHeader.displayName = 'XDSPageNavHeader';

--- a/packages/core/src/PageNav/XDSPageNavItem.tsx
+++ b/packages/core/src/PageNav/XDSPageNavItem.tsx
@@ -1,10 +1,10 @@
 /**
  * @file XDSPageNavItem.tsx
  * @input Uses React forwardRef, ReactNode, StyleX, XDSIcon, XDSIconType
- * @output Exports XDSPageNavItem component, XDSPageNavItemProps, XDSCollapsibleConfig
+ * @output Exports XDSPageNavItem component and XDSPageNavItemProps
  * @position Core implementation; used inside XDSPageNav children
  *
- * Navigation item with icon, selected state, nesting, and collapsible support.
+ * Navigation item with icon, selected state, and nesting.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/PageNav/README.md
@@ -15,7 +15,7 @@
 
 'use client';
 
-import {forwardRef, useId, useState, type ReactNode} from 'react';
+import {forwardRef, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -27,39 +27,6 @@ import {
 } from '../theme/tokens.stylex';
 import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
-
-// =============================================================================
-// Collapsible Config
-// =============================================================================
-
-/**
- * Configuration for collapsible behavior.
- * When useXDSCollapsible is available, this will be its return type.
- * For now, provides a compatible interface.
- */
-export interface XDSCollapsibleConfig {
-  /** Whether the collapsible section is currently open */
-  isOpen: boolean;
-  /** Toggle the open/closed state */
-  onToggle: () => void;
-}
-
-/**
- * Simple hook to create collapsible state.
- * Placeholder until useXDSCollapsible (#187) is available.
- *
- * @param initialIsOpen - Whether the section starts open
- * @returns XDSCollapsibleConfig
- */
-export function useXDSCollapsible(
-  initialIsOpen: boolean = true,
-): XDSCollapsibleConfig {
-  const [isOpen, setIsOpen] = useState(initialIsOpen);
-  return {
-    isOpen,
-    onToggle: () => setIsOpen(prev => !prev),
-  };
-}
 
 // =============================================================================
 // Styles
@@ -122,22 +89,6 @@ const styles = stylex.create({
   children: {
     paddingInlineStart: spacingVars['--spacing-6'],
   },
-  collapseTrigger: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 16,
-    height: 16,
-    flexShrink: 0,
-    color: colorVars['--color-icon-secondary'],
-    transition: 'transform 150ms ease',
-  },
-  collapseOpen: {
-    transform: 'rotate(90deg)',
-  },
-  collapseClosed: {
-    transform: 'rotate(0deg)',
-  },
 });
 
 // =============================================================================
@@ -184,36 +135,9 @@ export interface XDSPageNavItemProps {
    */
   children?: ReactNode;
   /**
-   * Collapsible config from useXDSCollapsible.
-   */
-  collapsible?: XDSCollapsibleConfig;
-  /**
    * Test ID for the item element.
    */
   'data-testid'?: string;
-}
-
-// =============================================================================
-// Chevron Right SVG (for collapsible)
-// =============================================================================
-
-function ChevronRightIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      aria-hidden="true">
-      <path
-        d="M6 4L10 8L6 12"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
 }
 
 // =============================================================================
@@ -223,8 +147,7 @@ function ChevronRightIcon() {
 /**
  * Navigation item for XDSPageNav.
  *
- * Supports icons, selected state, nesting with collapsible sub-items,
- * and end content like badges or counts.
+ * Supports icons, selected state, nesting, and end content like badges or counts.
  *
  * @example
  * ```tsx
@@ -236,11 +159,7 @@ function ChevronRightIcon() {
  *   href="/dashboard"
  * />
  *
- * <XDSPageNavItem
- *   label="Settings"
- *   icon={CogIcon}
- *   collapsible={useXDSCollapsible()}
- * >
+ * <XDSPageNavItem label="Settings" icon={CogIcon}>
  *   <XDSPageNavItem label="General" href="/settings/general" />
  *   <XDSPageNavItem label="Security" href="/settings/security" />
  * </XDSPageNavItem>
@@ -258,15 +177,12 @@ export const XDSPageNavItem = forwardRef<HTMLElement, XDSPageNavItemProps>(
       onClick,
       endContent,
       children,
-      collapsible,
       'data-testid': testId,
     },
     ref,
   ) {
     const id = useId();
     const hasChildren = !!children;
-    const isCollapsible = !!collapsible && hasChildren;
-    const isOpen = collapsible?.isOpen ?? true;
 
     const displayIcon = isSelected && selectedIcon ? selectedIcon : icon;
 
@@ -275,23 +191,11 @@ export const XDSPageNavItem = forwardRef<HTMLElement, XDSPageNavItemProps>(
         e.preventDefault();
         return;
       }
-      if (isCollapsible) {
-        collapsible!.onToggle();
-      }
       onClick?.(e);
     };
 
     const itemContent = (
       <>
-        {isCollapsible && (
-          <span
-            {...stylex.props(
-              styles.collapseTrigger,
-              isOpen ? styles.collapseOpen : styles.collapseClosed,
-            )}>
-            <ChevronRightIcon />
-          </span>
-        )}
         {displayIcon && (
           <XDSIcon
             icon={displayIcon}
@@ -311,7 +215,6 @@ export const XDSPageNavItem = forwardRef<HTMLElement, XDSPageNavItemProps>(
     const ariaProps = {
       'aria-current': isSelected ? ('page' as const) : undefined,
       'aria-disabled': isDisabled || undefined,
-      'aria-expanded': isCollapsible ? isOpen : undefined,
       'data-testid': testId,
     };
 
@@ -348,7 +251,7 @@ export const XDSPageNavItem = forwardRef<HTMLElement, XDSPageNavItemProps>(
     return (
       <div {...stylex.props(styles.root)}>
         {itemElement}
-        {hasChildren && isOpen && (
+        {hasChildren && (
           <div
             role="group"
             aria-labelledby={`${id}-label`}

--- a/packages/core/src/PageNav/XDSPageNavItem.tsx
+++ b/packages/core/src/PageNav/XDSPageNavItem.tsx
@@ -1,0 +1,367 @@
+/**
+ * @file XDSPageNavItem.tsx
+ * @input Uses React forwardRef, ReactNode, StyleX, XDSIcon, XDSIconType
+ * @output Exports XDSPageNavItem component, XDSPageNavItemProps, XDSCollapsibleConfig
+ * @position Core implementation; used inside XDSPageNav children
+ *
+ * Navigation item with icon, selected state, nesting, and collapsible support.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/PageNav/README.md
+ * - /packages/core/src/PageNav/XDSPageNav.test.tsx
+ * - /packages/core/src/PageNav/index.ts
+ * - /apps/storybook/stories/PageNav.stories.tsx
+ */
+
+'use client';
+
+import {forwardRef, useId, useState, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+import {XDSIcon} from '../Icon';
+import type {XDSIconType} from '../Icon';
+
+// =============================================================================
+// Collapsible Config
+// =============================================================================
+
+/**
+ * Configuration for collapsible behavior.
+ * When useXDSCollapsible is available, this will be its return type.
+ * For now, provides a compatible interface.
+ */
+export interface XDSCollapsibleConfig {
+  /** Whether the collapsible section is currently open */
+  isOpen: boolean;
+  /** Toggle the open/closed state */
+  onToggle: () => void;
+}
+
+/**
+ * Simple hook to create collapsible state.
+ * Placeholder until useXDSCollapsible (#187) is available.
+ *
+ * @param initialIsOpen - Whether the section starts open
+ * @returns XDSCollapsibleConfig
+ */
+export function useXDSCollapsible(
+  initialIsOpen: boolean = true,
+): XDSCollapsibleConfig {
+  const [isOpen, setIsOpen] = useState(initialIsOpen);
+  return {
+    isOpen,
+    onToggle: () => setIsOpen(prev => !prev),
+  };
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+  },
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    width: '100%',
+    paddingInline: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-2'],
+    borderRadius: radiusVars['--radius-element'],
+    borderWidth: 0,
+    borderStyle: 'none',
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-primary'],
+    textDecoration: 'none',
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    lineHeight: lineHeightVars['--leading-base'],
+    textAlign: 'start',
+    boxSizing: 'border-box',
+    ':hover': {
+      backgroundColor: colorVars['--color-hover-overlay'],
+    },
+  },
+  selected: {
+    backgroundColor: colorVars['--color-accent-deemphasized'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    ':hover': {
+      backgroundColor: colorVars['--color-accent-deemphasized'],
+    },
+  },
+  disabled: {
+    color: colorVars['--color-text-disabled'],
+    cursor: 'not-allowed',
+    pointerEvents: 'none',
+  },
+  label: {
+    flex: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  endContent: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+  },
+  children: {
+    paddingInlineStart: spacingVars['--spacing-6'],
+  },
+  collapseTrigger: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 16,
+    height: 16,
+    flexShrink: 0,
+    color: colorVars['--color-icon-secondary'],
+    transition: 'transform 150ms ease',
+  },
+  collapseOpen: {
+    transform: 'rotate(90deg)',
+  },
+  collapseClosed: {
+    transform: 'rotate(0deg)',
+  },
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface XDSPageNavItemProps {
+  /**
+   * Item label.
+   */
+  label: string;
+  /**
+   * Icon (outline variant).
+   */
+  icon?: XDSIconType;
+  /**
+   * Icon when selected (filled variant).
+   */
+  selectedIcon?: XDSIconType;
+  /**
+   * Current page indicator.
+   * @default false
+   */
+  isSelected?: boolean;
+  /**
+   * Whether the item is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Navigation URL.
+   */
+  href?: string;
+  /**
+   * Click handler.
+   */
+  onClick?: (e: React.MouseEvent) => void;
+  /**
+   * Right-side content (badges, counts).
+   */
+  endContent?: ReactNode;
+  /**
+   * Sub-items for nesting.
+   */
+  children?: ReactNode;
+  /**
+   * Collapsible config from useXDSCollapsible.
+   */
+  collapsible?: XDSCollapsibleConfig;
+  /**
+   * Test ID for the item element.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Chevron Right SVG (for collapsible)
+// =============================================================================
+
+function ChevronRightIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true">
+      <path
+        d="M6 4L10 8L6 12"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Navigation item for XDSPageNav.
+ *
+ * Supports icons, selected state, nesting with collapsible sub-items,
+ * and end content like badges or counts.
+ *
+ * @example
+ * ```tsx
+ * <XDSPageNavItem
+ *   label="Dashboard"
+ *   icon={HomeIcon}
+ *   selectedIcon={HomeIconSolid}
+ *   isSelected
+ *   href="/dashboard"
+ * />
+ *
+ * <XDSPageNavItem
+ *   label="Settings"
+ *   icon={CogIcon}
+ *   collapsible={useXDSCollapsible()}
+ * >
+ *   <XDSPageNavItem label="General" href="/settings/general" />
+ *   <XDSPageNavItem label="Security" href="/settings/security" />
+ * </XDSPageNavItem>
+ * ```
+ */
+export const XDSPageNavItem = forwardRef<HTMLElement, XDSPageNavItemProps>(
+  function XDSPageNavItem(
+    {
+      label,
+      icon,
+      selectedIcon,
+      isSelected = false,
+      isDisabled = false,
+      href,
+      onClick,
+      endContent,
+      children,
+      collapsible,
+      'data-testid': testId,
+    },
+    ref,
+  ) {
+    const id = useId();
+    const hasChildren = !!children;
+    const isCollapsible = !!collapsible && hasChildren;
+    const isOpen = collapsible?.isOpen ?? true;
+
+    const displayIcon = isSelected && selectedIcon ? selectedIcon : icon;
+
+    const handleClick = (e: React.MouseEvent) => {
+      if (isDisabled) {
+        e.preventDefault();
+        return;
+      }
+      if (isCollapsible) {
+        collapsible!.onToggle();
+      }
+      onClick?.(e);
+    };
+
+    const itemContent = (
+      <>
+        {isCollapsible && (
+          <span
+            {...stylex.props(
+              styles.collapseTrigger,
+              isOpen ? styles.collapseOpen : styles.collapseClosed,
+            )}>
+            <ChevronRightIcon />
+          </span>
+        )}
+        {displayIcon && (
+          <XDSIcon
+            icon={displayIcon}
+            size="sm"
+            color={
+              isSelected ? 'accent' : isDisabled ? 'disabled' : 'secondary'
+            }
+          />
+        )}
+        <span {...stylex.props(styles.label)}>{label}</span>
+        {endContent && (
+          <span {...stylex.props(styles.endContent)}>{endContent}</span>
+        )}
+      </>
+    );
+
+    const ariaProps = {
+      'aria-current': isSelected ? ('page' as const) : undefined,
+      'aria-disabled': isDisabled || undefined,
+      'aria-expanded': isCollapsible ? isOpen : undefined,
+      'data-testid': testId,
+    };
+
+    const itemElement =
+      href && !isDisabled ? (
+        <a
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          onClick={handleClick}
+          {...ariaProps}
+          {...stylex.props(
+            styles.item,
+            isSelected && styles.selected,
+            isDisabled && styles.disabled,
+          )}>
+          {itemContent}
+        </a>
+      ) : (
+        <button
+          ref={ref as React.Ref<HTMLButtonElement>}
+          type="button"
+          onClick={handleClick}
+          disabled={isDisabled}
+          {...ariaProps}
+          {...stylex.props(
+            styles.item,
+            isSelected && styles.selected,
+            isDisabled && styles.disabled,
+          )}>
+          {itemContent}
+        </button>
+      );
+
+    return (
+      <div {...stylex.props(styles.root)}>
+        {itemElement}
+        {hasChildren && isOpen && (
+          <div
+            role="group"
+            aria-labelledby={`${id}-label`}
+            {...stylex.props(styles.children)}>
+            <span id={`${id}-label`} hidden>
+              {label}
+            </span>
+            {children}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+
+XDSPageNavItem.displayName = 'XDSPageNavItem';

--- a/packages/core/src/PageNav/XDSPageNavSection.tsx
+++ b/packages/core/src/PageNav/XDSPageNavSection.tsx
@@ -1,0 +1,276 @@
+/**
+ * @file XDSPageNavSection.tsx
+ * @input Uses React, StyleX, XDSCollapsibleConfig
+ * @output Exports XDSPageNavSection component and XDSPageNavSectionProps
+ * @position Core implementation; used inside XDSPageNav children
+ *
+ * Section grouping for navigation items with optional title, collapsible behavior,
+ * and end content.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/PageNav/README.md
+ * - /packages/core/src/PageNav/XDSPageNav.test.tsx
+ * - /packages/core/src/PageNav/index.ts
+ * - /apps/storybook/stories/PageNav.stories.tsx
+ */
+
+'use client';
+
+import {useId, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+import type {XDSCollapsibleConfig} from './XDSPageNavItem';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    paddingBlock: spacingVars['--spacing-1'],
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-1'],
+    cursor: 'default',
+    userSelect: 'none',
+  },
+  headerCollapsible: {
+    cursor: 'pointer',
+    borderRadius: 0,
+    borderWidth: 0,
+    borderStyle: 'none',
+    backgroundColor: 'transparent',
+    fontFamily: 'inherit',
+    fontSize: 'inherit',
+    textAlign: 'start',
+    width: '100%',
+    ':hover': {
+      backgroundColor: colorVars['--color-hover-overlay'],
+    },
+  },
+  titleContainer: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minWidth: 0,
+  },
+  title: {
+    fontSize: textSizeVars['--text-xsm'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    color: colorVars['--color-text-secondary'],
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  subtitle: {
+    fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    color: colorVars['--color-text-secondary'],
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  endContent: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+  },
+  chevron: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 16,
+    height: 16,
+    color: colorVars['--color-icon-secondary'],
+    transition: 'transform 150ms ease',
+  },
+  chevronOpen: {
+    transform: 'rotate(180deg)',
+  },
+  chevronClosed: {
+    transform: 'rotate(0deg)',
+  },
+  items: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface XDSPageNavSectionProps {
+  /**
+   * Section title.
+   */
+  title: string;
+  /**
+   * Section subtitle.
+   */
+  subtitle?: string;
+  /**
+   * Section items.
+   */
+  children: ReactNode;
+  /**
+   * Collapsible config from useXDSCollapsible.
+   */
+  collapsible?: XDSCollapsibleConfig;
+  /**
+   * Right-side content in the section header.
+   */
+  endContent?: ReactNode;
+  /**
+   * Whether the section header is visually hidden.
+   * The section title is still accessible to screen readers.
+   * @default false
+   */
+  isHeaderHidden?: boolean;
+  /**
+   * Test ID for the section element.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Chevron SVG
+// =============================================================================
+
+function ChevronDownIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true">
+      <path
+        d="M4 6L8 10L12 6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Section grouping for XDSPageNav items.
+ *
+ * Renders a labeled group of navigation items with optional collapsible behavior.
+ * Uses `role="group"` with `aria-labelledby` for accessibility.
+ *
+ * @example
+ * ```tsx
+ * <XDSPageNavSection title="Main">
+ *   <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
+ *   <XDSPageNavItem label="Projects" icon={FolderIcon} />
+ * </XDSPageNavSection>
+ *
+ * <XDSPageNavSection title="Settings" collapsible={useXDSCollapsible()}>
+ *   <XDSPageNavItem label="General" href="/settings/general" />
+ *   <XDSPageNavItem label="Security" href="/settings/security" />
+ * </XDSPageNavSection>
+ * ```
+ */
+export function XDSPageNavSection({
+  title,
+  subtitle,
+  children,
+  collapsible,
+  endContent,
+  isHeaderHidden = false,
+  'data-testid': testId,
+}: XDSPageNavSectionProps) {
+  const id = useId();
+  const titleId = `${id}-title`;
+  const isCollapsible = !!collapsible;
+  const isOpen = collapsible?.isOpen ?? true;
+
+  const headerContent = (
+    <>
+      <span {...stylex.props(styles.titleContainer)}>
+        <span id={titleId} {...stylex.props(styles.title)}>
+          {title}
+        </span>
+        {subtitle && <span {...stylex.props(styles.subtitle)}>{subtitle}</span>}
+      </span>
+      {endContent && (
+        <span {...stylex.props(styles.endContent)}>{endContent}</span>
+      )}
+      {isCollapsible && (
+        <span
+          {...stylex.props(
+            styles.chevron,
+            isOpen ? styles.chevronOpen : styles.chevronClosed,
+          )}>
+          <ChevronDownIcon />
+        </span>
+      )}
+    </>
+  );
+
+  const visuallyHiddenStyle: React.CSSProperties = isHeaderHidden
+    ? {
+        position: 'absolute',
+        width: 1,
+        height: 1,
+        padding: 0,
+        margin: -1,
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        borderWidth: 0,
+      }
+    : {};
+
+  return (
+    <div
+      role="group"
+      aria-labelledby={titleId}
+      data-testid={testId}
+      {...stylex.props(styles.root)}>
+      {isCollapsible ? (
+        <button
+          type="button"
+          onClick={collapsible!.onToggle}
+          aria-expanded={isOpen}
+          style={isHeaderHidden ? visuallyHiddenStyle : undefined}
+          {...stylex.props(styles.header, styles.headerCollapsible)}>
+          {headerContent}
+        </button>
+      ) : (
+        <div
+          style={isHeaderHidden ? visuallyHiddenStyle : undefined}
+          {...stylex.props(styles.header)}>
+          {headerContent}
+        </div>
+      )}
+      {isOpen && <div {...stylex.props(styles.items)}>{children}</div>}
+    </div>
+  );
+}
+
+XDSPageNavSection.displayName = 'XDSPageNavSection';

--- a/packages/core/src/PageNav/XDSPageNavSection.tsx
+++ b/packages/core/src/PageNav/XDSPageNavSection.tsx
@@ -55,8 +55,6 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
-    textTransform: 'uppercase' as const,
-    letterSpacing: '0.05em',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',

--- a/packages/core/src/PageNav/XDSPageNavSection.tsx
+++ b/packages/core/src/PageNav/XDSPageNavSection.tsx
@@ -1,11 +1,10 @@
 /**
  * @file XDSPageNavSection.tsx
- * @input Uses React, StyleX, XDSCollapsibleConfig
+ * @input Uses React, StyleX
  * @output Exports XDSPageNavSection component and XDSPageNavSectionProps
  * @position Core implementation; used inside XDSPageNav children
  *
- * Section grouping for navigation items with optional title, collapsible behavior,
- * and end content.
+ * Section grouping for navigation items with optional title and end content.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/PageNav/README.md
@@ -25,8 +24,6 @@ import {
   fontWeightVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
-import type {XDSCollapsibleConfig} from './XDSPageNavItem';
-
 // =============================================================================
 // Styles
 // =============================================================================
@@ -46,20 +43,7 @@ const styles = stylex.create({
     cursor: 'default',
     userSelect: 'none',
   },
-  headerCollapsible: {
-    cursor: 'pointer',
-    borderRadius: 0,
-    borderWidth: 0,
-    borderStyle: 'none',
-    backgroundColor: 'transparent',
-    fontFamily: 'inherit',
-    fontSize: 'inherit',
-    textAlign: 'start',
-    width: '100%',
-    ':hover': {
-      backgroundColor: colorVars['--color-hover-overlay'],
-    },
-  },
+
   titleContainer: {
     display: 'flex',
     flexDirection: 'column',
@@ -90,22 +74,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
   },
-  chevron: {
-    flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 16,
-    height: 16,
-    color: colorVars['--color-icon-secondary'],
-    transition: 'transform 150ms ease',
-  },
-  chevronOpen: {
-    transform: 'rotate(180deg)',
-  },
-  chevronClosed: {
-    transform: 'rotate(0deg)',
-  },
+
   items: {
     display: 'flex',
     flexDirection: 'column',
@@ -130,10 +99,6 @@ export interface XDSPageNavSectionProps {
    */
   children: ReactNode;
   /**
-   * Collapsible config from useXDSCollapsible.
-   */
-  collapsible?: XDSCollapsibleConfig;
-  /**
    * Right-side content in the section header.
    */
   endContent?: ReactNode;
@@ -150,36 +115,13 @@ export interface XDSPageNavSectionProps {
 }
 
 // =============================================================================
-// Chevron SVG
-// =============================================================================
-
-function ChevronDownIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      aria-hidden="true">
-      <path
-        d="M4 6L8 10L12 6"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-// =============================================================================
 // Component
 // =============================================================================
 
 /**
  * Section grouping for XDSPageNav items.
  *
- * Renders a labeled group of navigation items with optional collapsible behavior.
+ * Renders a labeled group of navigation items.
  * Uses `role="group"` with `aria-labelledby` for accessibility.
  *
  * @example
@@ -188,26 +130,18 @@ function ChevronDownIcon() {
  *   <XDSPageNavItem label="Dashboard" icon={HomeIcon} isSelected />
  *   <XDSPageNavItem label="Projects" icon={FolderIcon} />
  * </XDSPageNavSection>
- *
- * <XDSPageNavSection title="Settings" collapsible={useXDSCollapsible()}>
- *   <XDSPageNavItem label="General" href="/settings/general" />
- *   <XDSPageNavItem label="Security" href="/settings/security" />
- * </XDSPageNavSection>
  * ```
  */
 export function XDSPageNavSection({
   title,
   subtitle,
   children,
-  collapsible,
   endContent,
   isHeaderHidden = false,
   'data-testid': testId,
 }: XDSPageNavSectionProps) {
   const id = useId();
   const titleId = `${id}-title`;
-  const isCollapsible = !!collapsible;
-  const isOpen = collapsible?.isOpen ?? true;
 
   const headerContent = (
     <>
@@ -219,15 +153,6 @@ export function XDSPageNavSection({
       </span>
       {endContent && (
         <span {...stylex.props(styles.endContent)}>{endContent}</span>
-      )}
-      {isCollapsible && (
-        <span
-          {...stylex.props(
-            styles.chevron,
-            isOpen ? styles.chevronOpen : styles.chevronClosed,
-          )}>
-          <ChevronDownIcon />
-        </span>
       )}
     </>
   );
@@ -252,23 +177,12 @@ export function XDSPageNavSection({
       aria-labelledby={titleId}
       data-testid={testId}
       {...stylex.props(styles.root)}>
-      {isCollapsible ? (
-        <button
-          type="button"
-          onClick={collapsible!.onToggle}
-          aria-expanded={isOpen}
-          style={isHeaderHidden ? visuallyHiddenStyle : undefined}
-          {...stylex.props(styles.header, styles.headerCollapsible)}>
-          {headerContent}
-        </button>
-      ) : (
-        <div
-          style={isHeaderHidden ? visuallyHiddenStyle : undefined}
-          {...stylex.props(styles.header)}>
-          {headerContent}
-        </div>
-      )}
-      {isOpen && <div {...stylex.props(styles.items)}>{children}</div>}
+      <div
+        style={isHeaderHidden ? visuallyHiddenStyle : undefined}
+        {...stylex.props(styles.header)}>
+        {headerContent}
+      </div>
+      <div {...stylex.props(styles.items)}>{children}</div>
     </div>
   );
 }

--- a/packages/core/src/PageNav/index.ts
+++ b/packages/core/src/PageNav/index.ts
@@ -13,8 +13,8 @@ export type {XDSPageNavProps} from './XDSPageNav';
 export {XDSPageNavHeader} from './XDSPageNavHeader';
 export type {XDSPageNavHeaderProps} from './XDSPageNavHeader';
 
-export {XDSPageNavItem, useXDSCollapsible} from './XDSPageNavItem';
-export type {XDSPageNavItemProps, XDSCollapsibleConfig} from './XDSPageNavItem';
+export {XDSPageNavItem} from './XDSPageNavItem';
+export type {XDSPageNavItemProps} from './XDSPageNavItem';
 
 export {XDSPageNavSection} from './XDSPageNavSection';
 export type {XDSPageNavSectionProps} from './XDSPageNavSection';

--- a/packages/core/src/PageNav/index.ts
+++ b/packages/core/src/PageNav/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @file index.ts
+ * @input Imports PageNav components and types
+ * @output Exports XDSPageNav, XDSPageNavHeader, XDSPageNavItem, XDSPageNavSection
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/PageNav/README.md
+ */
+
+export {XDSPageNav} from './XDSPageNav';
+export type {XDSPageNavProps} from './XDSPageNav';
+
+export {XDSPageNavHeader} from './XDSPageNavHeader';
+export type {XDSPageNavHeaderProps} from './XDSPageNavHeader';
+
+export {XDSPageNavItem, useXDSCollapsible} from './XDSPageNavItem';
+export type {XDSPageNavItemProps, XDSCollapsibleConfig} from './XDSPageNavItem';
+
+export {XDSPageNavSection} from './XDSPageNavSection';
+export type {XDSPageNavSectionProps} from './XDSPageNavSection';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,7 @@ export * from './Table';
 export * from './Dialog';
 export * from './DropdownMenu';
 export * from './TopNav';
+export * from './PageNav';
 export * from './ProgressBar';
 
 // Layout utilities and components (includes XDSHStack, XDSVStack)


### PR DESCRIPTION
## Summary

Implements **XDSPageNav v1** sidebar navigation component per #84.

## Components

### XDSPageNav
Container with five zones stacked vertically:
- `header` (sticky) — typically XDSPageNavHeader
- `stickyContent` (sticky) — buttons, pinned items
- `children` (scrollable) — nav sections and items
- `footer` — promo cards, etc.
- `footerIcons` — icon buttons at bottom

### XDSPageNavHeader
Product/suite/account header with smart interaction boundary logic:
- No hrefs + menu → whole header is the popover trigger
- titleHref only, no menu → whole header is one link
- titleHref + supertitleHref, no menu → each is an independent link
- menu + hrefs → links are independent `<a>`, chevron is the trigger

Composes `useXDSPopover` internally when `menu` is provided.

### XDSPageNavItem
Navigation item with:
- `icon` / `selectedIcon` (XDSIconType)
- `isSelected` → accent background pill + `aria-current="page"`
- `isDisabled`, `href`, `onClick`, `endContent`
- Nesting via `children` + `collapsible` prop

### XDSPageNavSection
Section grouping with:
- `title`, `subtitle`, `endContent`
- `collapsible` prop for expand/collapse
- `isHeaderHidden` for visually hidden but accessible headers
- `role="group"` with `aria-labelledby`

## Also includes

- `useXDSCollapsible` placeholder hook (until #187 lands)
- 49 unit tests covering all components and interactions
- Storybook stories with 7 variants
- README documentation

## Accessibility

- `<nav aria-label="Page navigation">`
- `aria-current="page"` on selected items
- `role="group"` with `aria-labelledby` on sections
- `aria-expanded` on collapsible triggers
- Keyboard navigation support

## Dependencies

- Depends on #187 (useXDSCollapsible) — placeholder hook included for now
- Depends on #185 (XDSAppShell) — for positioning/layout context

---
*Crafted with care by Navi*