### PR TITLE
feat(ci): add Storybook deep links to PR Analysis Report

### DIFF
--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -175,6 +175,25 @@ function hasStories(componentName) {
   }
 }
 
+// Get the Storybook story title for a component (e.g., "Core/XDSButton")
+function getStoryTitle(componentName) {
+  const storiesDir = path.join(process.cwd(), STORYBOOK_STORIES);
+  try {
+    const files = fs.readdirSync(storiesDir);
+    const storyFile = files.find(f =>
+      f.toLowerCase().includes(componentName.toLowerCase()) &&
+      f.endsWith('.stories.tsx')
+    );
+    if (!storyFile) return null;
+
+    const content = fs.readFileSync(path.join(storiesDir, storyFile), 'utf8');
+    const titleMatch = content.match(/title:\s*['"]([^'"]+)['"]/);
+    return titleMatch ? titleMatch[1] : null;
+  } catch {
+    return null;
+  }
+}
+
 // Count lines of code in a file (excluding blank lines and comments)
 function countLOC(filePath) {
   try {
@@ -294,6 +313,7 @@ function getComponentStats(componentName) {
     propsCount: getPropsCount(componentName),
     hasTests: hasTests(componentName),
     hasStories: hasStories(componentName),
+    storyTitle: getStoryTitle(componentName),
     linesOfCode: loc.totalLOC,
     fileCount: loc.fileCount,
     complexity: complexity.score,

--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -63,6 +63,11 @@ function getStorybookLink(storybookBaseUrl, storyTitle) {
   return `${storybookBaseUrl}?path=/docs/${storyPath}--docs`;
 }
 
+// Build an external link that opens in a new tab
+function extLink(text, url) {
+  return `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+}
+
 // Build component stats section
 let componentSection = '';
 if (analysis.newComponents && analysis.newComponents.length > 0) {
@@ -70,7 +75,7 @@ if (analysis.newComponents && analysis.newComponents.length > 0) {
   for (const comp of analysis.newComponents) {
     const stats = analysis.componentStats[comp] || {};
     const sbLink = getStorybookLink(storybookUrl, stats.storyTitle);
-    const sbBadge = sbLink ? ` · [View in Storybook](${sbLink})` : '';
+    const sbBadge = sbLink ? ` · ${extLink('View in Storybook', sbLink)}` : '';
     componentSection += `<details>\n<summary><strong>${comp}</strong>${sbBadge}</summary>\n\n`;
     componentSection += `| Metric | Value |\n|--------|-------|\n`;
     componentSection += `| Bundle Size (ESM) | ${stats.esmSize || 'N/A'} |\n`;
@@ -92,7 +97,7 @@ if (analysis.modifiedComponents && analysis.modifiedComponents.length > 0) {
     const stats = analysis.componentStats[comp] || {};
     const baseStats = analysis.baseComponentStats?.[comp] || {};
     const sbLink = getStorybookLink(storybookUrl, stats.storyTitle);
-    const sbBadge = sbLink ? ` · [View in Storybook](${sbLink})` : '';
+    const sbBadge = sbLink ? ` · ${extLink('View in Storybook', sbLink)}` : '';
     componentSection += `<details>\n<summary><strong>${comp}</strong>${sbBadge}</summary>\n\n`;
     componentSection += `| Metric | Before | After | Delta |\n|--------|--------|-------|-------|\n`;
 
@@ -188,13 +193,13 @@ if (hasAffectedComponents && screenshots.length > 0) {
         if (videoUrl) {
           // Link to mp4 if available, otherwise link to gif
           const fullVideoUrl = mp4Url || videoUrl;
-          screenshotSection += `**Interaction Preview:** ([view video](${fullVideoUrl}))\n\n![${storyName} interaction](${videoUrl})\n\n`;
+          screenshotSection += `**Interaction Preview:** (${extLink('view video', fullVideoUrl)})\n\n![${storyName} interaction](${videoUrl})\n\n`;
         }
 
         // Build a direct Storybook link for this specific story
         const storyLink = storybookUrl ? `${storybookUrl}?path=/story/${shot.storyId}` : null;
         if (storyLink) {
-          screenshotSection += `[View in Storybook](${storyLink}) · `;
+          screenshotSection += `${extLink('View in Storybook', storyLink)} · `;
         }
         screenshotSection += `\`${shot.storyId}\`\n\n`;
 
@@ -211,7 +216,7 @@ let storybookSection = '';
 if (storybookUrl) {
   storybookSection = `### 📚 Storybook Preview
 
-**[View Storybook for this PR](${storybookUrl})**
+**${extLink('View Storybook for this PR', storybookUrl)}**
 
 `;
 }
@@ -221,16 +226,16 @@ let sandboxSection = '';
 if (sandboxUrl) {
   sandboxSection = `### 🧪 Sandbox Preview
 
-**[View Sandbox for this PR](${sandboxUrl})**
+**${extLink('View Sandbox for this PR', sandboxUrl)}**
 
 `;
 }
 
 // Build footer with links
 let footerLinks = [];
-if (storybookUrl) footerLinks.push(`[Storybook](${storybookUrl})`);
-if (sandboxUrl) footerLinks.push(`[Sandbox](${sandboxUrl})`);
-if (runUrl) footerLinks.push(`[View full report](${runUrl})`);
+if (storybookUrl) footerLinks.push(extLink('Storybook', storybookUrl));
+if (sandboxUrl) footerLinks.push(extLink('Sandbox', sandboxUrl));
+if (runUrl) footerLinks.push(extLink('View full report', runUrl));
 const footerLinksStr = footerLinks.length > 0 ? ` | ${footerLinks.join(' | ')}` : '';
 
 // Build the full comment

--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -54,13 +54,24 @@ try {
   console.error('Warning: Could not read screenshot URLs:', e.message);
 }
 
+// Build a Storybook deep link URL for a component
+// Story titles like "Core/XDSButton" become path "/docs/core-xdsbutton--docs"
+function getStorybookLink(storybookBaseUrl, storyTitle) {
+  if (!storybookBaseUrl || !storyTitle) return null;
+  // Storybook converts "Core/XDSButton" to "core-xdsbutton" as the story ID prefix
+  const storyPath = storyTitle.toLowerCase().replace(/\//g, '-');
+  return `${storybookBaseUrl}?path=/docs/${storyPath}--docs`;
+}
+
 // Build component stats section
 let componentSection = '';
 if (analysis.newComponents && analysis.newComponents.length > 0) {
   componentSection += `### New Components\n\n`;
   for (const comp of analysis.newComponents) {
     const stats = analysis.componentStats[comp] || {};
-    componentSection += `<details>\n<summary><strong>${comp}</strong></summary>\n\n`;
+    const sbLink = getStorybookLink(storybookUrl, stats.storyTitle);
+    const sbBadge = sbLink ? ` · [View in Storybook](${sbLink})` : '';
+    componentSection += `<details>\n<summary><strong>${comp}</strong>${sbBadge}</summary>\n\n`;
     componentSection += `| Metric | Value |\n|--------|-------|\n`;
     componentSection += `| Bundle Size (ESM) | ${stats.esmSize || 'N/A'} |\n`;
     componentSection += `| Bundle Size (CJS) | ${stats.cjsSize || 'N/A'} |\n`;
@@ -80,7 +91,9 @@ if (analysis.modifiedComponents && analysis.modifiedComponents.length > 0) {
   for (const comp of analysis.modifiedComponents) {
     const stats = analysis.componentStats[comp] || {};
     const baseStats = analysis.baseComponentStats?.[comp] || {};
-    componentSection += `<details>\n<summary><strong>${comp}</strong></summary>\n\n`;
+    const sbLink = getStorybookLink(storybookUrl, stats.storyTitle);
+    const sbBadge = sbLink ? ` · [View in Storybook](${sbLink})` : '';
+    componentSection += `<details>\n<summary><strong>${comp}</strong>${sbBadge}</summary>\n\n`;
     componentSection += `| Metric | Before | After | Delta |\n|--------|--------|-------|-------|\n`;
 
     const esmDelta = stats.esmBytes && baseStats.esmBytes
@@ -178,7 +191,12 @@ if (hasAffectedComponents && screenshots.length > 0) {
           screenshotSection += `**Interaction Preview:** ([view video](${fullVideoUrl}))\n\n![${storyName} interaction](${videoUrl})\n\n`;
         }
 
-        screenshotSection += `Run \`yarn storybook\` and navigate to: \`${shot.storyId}\`\n\n`;
+        // Build a direct Storybook link for this specific story
+        const storyLink = storybookUrl ? `${storybookUrl}?path=/story/${shot.storyId}` : null;
+        if (storyLink) {
+          screenshotSection += `[View in Storybook](${storyLink}) · `;
+        }
+        screenshotSection += `\`${shot.storyId}\`\n\n`;
 
         screenshotSection += `</details>\n\n`;
       } else {


### PR DESCRIPTION
## What

Each component listed in the PR Analysis Report now links directly to its Storybook docs page instead of just linking to the Storybook root.

### Before
- Component sections showed just the name: **Button**
- Screenshots said: `Run yarn storybook and navigate to: core-xdsbutton--default`

### After
- Component sections link to docs: **Button** · [View in Storybook](...)
- Screenshots link to the specific story: [View in Storybook](...) · `core-xdsbutton--default`

## How

1. **`analyze-pr.js`** — new `getStoryTitle()` function reads the `title` field from each component's `.stories.tsx` file and includes it in the analysis output
2. **`generate-pr-comment.js`** — new `getStorybookLink()` function converts story titles (e.g. `Core/XDSButton`) into deep link URLs (`?path=/docs/core-xdsbutton--docs`), used in both component sections and screenshot previews

Links gracefully degrade — if no story file exists or no Storybook URL is available, the link is simply omitted.

---
*Crafted with care by Navi*