### PR TITLE
fix(theme): update focus outline color

### DIFF
--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -107,6 +107,27 @@ const statusBorderStyles = stylex.create({
   },
 });
 
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
 export type XDSTextInputSize = keyof typeof sizeStyles;
 
 // Re-export shared types for convenience
@@ -292,6 +313,7 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -25,6 +25,9 @@ export const colorRaw = {
   '--color-hover-overlay': 'light-dark(#0536590C, #FFFFFF0C)',
   '--color-pressed-overlay': 'light-dark(#05365919, #FFFFFF19)',
   '--color-focus-outline': 'light-dark(#0171E3, #2694FE)',
+  '--color-focus-outline-error': 'light-dark(#E3193B, #F5394F)',
+  '--color-focus-outline-success': 'light-dark(#0D8626, #0D8626)',
+  '--color-focus-outline-warning': 'light-dark(#F2C00B, #E9AF08)',
   '--color-deemphasized': 'light-dark(#0536590C, #1111127F)',
 
   // Text

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -24,7 +24,7 @@ export const colorRaw = {
   '--color-overlay': 'light-dark(#01122866, #11111299)',
   '--color-hover-overlay': 'light-dark(#0536590C, #FFFFFF0C)',
   '--color-pressed-overlay': 'light-dark(#05365919, #FFFFFF19)',
-  '--color-focus-outline': 'light-dark(#042F97, #AFD7FF)',
+  '--color-focus-outline': 'light-dark(#0171E3, #2694FE)',
   '--color-deemphasized': 'light-dark(#0536590C, #1111127F)',
 
   // Text

--- a/packages/themes/default/src/defaultTheme.stylex.ts
+++ b/packages/themes/default/src/defaultTheme.stylex.ts
@@ -65,7 +65,7 @@ const colorRaw = {
   '--color-overlay': 'light-dark(#01122866, #11111299)',
   '--color-hover-overlay': 'light-dark(#0536590C, #FFFFFF0C)',
   '--color-pressed-overlay': 'light-dark(#05365919, #FFFFFF19)',
-  '--color-focus-outline': 'light-dark(#042F97, #AFD7FF)',
+  '--color-focus-outline': 'light-dark(#0171E3, #2694FE)',
   '--color-focus-outline-error': 'light-dark(#E3193B, #F5394F)',
   '--color-focus-outline-success': 'light-dark(#0D8626, #0D8626)',
   '--color-focus-outline-warning': 'light-dark(#F2C00B, #E9AF08)',

--- a/packages/themes/default/src/defaultTheme.stylex.ts
+++ b/packages/themes/default/src/defaultTheme.stylex.ts
@@ -66,6 +66,9 @@ const colorRaw = {
   '--color-hover-overlay': 'light-dark(#0536590C, #FFFFFF0C)',
   '--color-pressed-overlay': 'light-dark(#05365919, #FFFFFF19)',
   '--color-focus-outline': 'light-dark(#042F97, #AFD7FF)',
+  '--color-focus-outline-error': 'light-dark(#E3193B, #F5394F)',
+  '--color-focus-outline-success': 'light-dark(#0D8626, #0D8626)',
+  '--color-focus-outline-warning': 'light-dark(#F2C00B, #E9AF08)',
   '--color-deemphasized': 'light-dark(#0536590C, #1111127F)',
 
   // Text

--- a/packages/themes/neutral/src/neutralTheme.stylex.ts
+++ b/packages/themes/neutral/src/neutralTheme.stylex.ts
@@ -70,6 +70,9 @@ const colorRaw = {
   '--color-pressed-overlay':
     'light-dark(oklch(0 0 0 / 10%), oklch(1 0 0 / 10%))',
   '--color-focus-outline': 'light-dark(oklch(0.708 0 0), oklch(0.556 0 0))',
+  '--color-focus-outline-error': 'light-dark(#E3193B, #F5394F)',
+  '--color-focus-outline-success': 'light-dark(#0D8626, #0D8626)',
+  '--color-focus-outline-warning': 'light-dark(#F2C00B, #E9AF08)',
   '--color-deemphasized': 'light-dark(oklch(0.97 0 0), oklch(0.269 0 0))',
 
   // Text


### PR DESCRIPTION
## Summary

Updates the focus outline color system: refreshes the default focus ring color and adds status-specific focus outline tokens for error, warning, and success states.

## Changes

### 1. Updated `--color-focus-outline`

| Mode | Before | After |
|------|--------|-------|
| Light | `#042F97` | `#0171E3` |
| Dark | `#AFD7FF` | `#2694FE` |

Updated in both base tokens and the default theme (which was overriding the base value).

### 2. New status-specific focus outline tokens

| Token | Light | Dark |
|-------|-------|------|
| `--color-focus-outline-error` | `#E3193B` | `#F5394F` |
| `--color-focus-outline-success` | `#0D8626` | `#0D8626` |
| `--color-focus-outline-warning` | `#F2C00B` | `#E9AF08` |

Added to base tokens, default theme, and neutral theme.

### 3. `XDSTextInput` status focus rings

When an input has a `status` prop (error/warning/success), the focus ring now uses the matching status color instead of the default blue. Applied via a new `statusFocusStyles` StyleX object that overrides the base outline on `:focus-within`.

## Files changed

- `packages/core/src/theme/tokens.stylex.ts` — new tokens
- `packages/themes/default/src/defaultTheme.stylex.ts` — updated + new tokens
- `packages/themes/neutral/src/neutralTheme.stylex.ts` — new tokens
- `packages/core/src/TextInput/XDSTextInput.tsx` — status focus ring styles

## Note

Other input components (`XDSTextArea`, `XDSNumberInput`, `XDSDateInput`, `XDSTimeInput`) still use the default `--color-focus-outline`. They could be updated to use the status-specific tokens in a follow-up.

---
*Crafted with care by Navi*