### PR TITLE
feat(inputs): add inner shadow on hover

### DIFF
--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -27,11 +27,11 @@ import {
   sizeVars,
   spacingVars,
   radiusVars,
+  elevationVars,
   transitionVars,
   typographyVars,
   textSizeVars,
   lineHeightVars,
-  elevationVars,
 } from '../theme/tokens.stylex';
 import {XDSField, type XDSInputStatus, type XDSInputStatusType} from '../Field';
 import {XDSIcon} from '../Icon';
@@ -60,16 +60,17 @@ const styles = stylex.create({
     },
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline',
+    transitionProperty: 'border-color, outline, box-shadow',
     transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover'],
+    },
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',
@@ -89,7 +90,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     outline: {
       default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: 1,
   },
@@ -147,6 +148,47 @@ const statusBorderStyles = stylex.create({
   },
   success: {
     borderColor: colorVars['--color-positive'],
+  },
+});
+
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+const statusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-warning'],
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-error'],
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-success'],
+    },
   },
 });
 
@@ -477,6 +519,8 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusHoverShadowStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           <button

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -29,6 +29,7 @@ import {
   sizeVars,
   spacingVars,
   radiusVars,
+  elevationVars,
   transitionVars,
   typographyVars,
   textSizeVars,
@@ -55,16 +56,17 @@ const styles = stylex.create({
     },
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline',
+    transitionProperty: 'border-color, outline, box-shadow',
     transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover'],
+    },
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',
@@ -124,6 +126,47 @@ const statusBorderStyles = stylex.create({
   },
   success: {
     borderColor: colorVars['--color-positive'],
+  },
+});
+
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+const statusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-warning'],
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-error'],
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-success'],
+    },
   },
 });
 
@@ -512,6 +555,8 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusHoverShadowStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -27,6 +27,7 @@ import {
   sizeVars,
   spacingVars,
   radiusVars,
+  elevationVars,
   transitionVars,
   typographyVars,
   textSizeVars,
@@ -70,16 +71,17 @@ const styles = stylex.create({
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-primary'],
     cursor: 'pointer',
-    transitionProperty: 'border-color, outline',
+    transitionProperty: 'border-color, outline, box-shadow',
     transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover'],
+    },
     outline: {
       default: 'none',
-      ':focus': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus': `1px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus': '1px',
-    },
+    outlineOffset: '0',
   },
   triggerDisabled: {
     cursor: 'not-allowed',
@@ -208,6 +210,48 @@ const statusBorderStyles = stylex.create({
   },
   success: {
     borderColor: colorVars['--color-positive'],
+  },
+});
+
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
+const statusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-warning'],
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-error'],
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-success'],
+    },
   },
 });
 
@@ -588,6 +632,7 @@ export function XDSSelector<T extends XDSSelectorOption>({
           isDisabled && styles.triggerDisabled,
           !selectedItem && styles.triggerPlaceholder,
           status && statusBorderStyles[status.type],
+          status && statusHoverShadowStyles[status.type],
           triggerOverride,
         )}>
         <span>{selectedItem?.label ?? placeholder}</span>

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -24,6 +24,7 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
+  elevationVars,
   transitionVars,
   typographyVars,
   textSizeVars,
@@ -52,16 +53,17 @@ const styles = stylex.create({
     },
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline',
+    transitionProperty: 'border-color, outline, box-shadow',
     transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover'],
+    },
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',
@@ -112,6 +114,47 @@ const statusBorderStyles = stylex.create({
   },
   success: {
     borderColor: colorVars['--color-positive'],
+  },
+});
+
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+const statusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-warning'],
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-error'],
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-success'],
+    },
   },
 });
 
@@ -317,6 +360,8 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
             styles.wrapper,
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusHoverShadowStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -19,6 +19,7 @@ import {
   sizeVars,
   spacingVars,
   radiusVars,
+  elevationVars,
   transitionVars,
   typographyVars,
   textSizeVars,
@@ -45,16 +46,17 @@ const styles = stylex.create({
     },
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline',
+    transitionProperty: 'border-color, outline, box-shadow',
     transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover'],
+    },
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',
@@ -107,23 +109,44 @@ const statusBorderStyles = stylex.create({
   },
 });
 
+const statusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-warning'],
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-error'],
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-success'],
+    },
+  },
+});
+
 const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });
@@ -313,6 +336,7 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusHoverShadowStyles[status.type],
             status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -29,6 +29,7 @@ import {
   sizeVars,
   spacingVars,
   radiusVars,
+  elevationVars,
   transitionVars,
   typographyVars,
   textSizeVars,
@@ -63,16 +64,17 @@ const styles = stylex.create({
     },
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline',
+    transitionProperty: 'border-color, outline, box-shadow',
     transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover'],
+    },
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',
@@ -121,7 +123,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     outline: {
       default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: 1,
   },
@@ -148,6 +150,47 @@ const statusBorderStyles = stylex.create({
   },
   success: {
     borderColor: colorVars['--color-positive'],
+  },
+});
+
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+const statusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-warning'],
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-error'],
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-success'],
+    },
   },
 });
 
@@ -514,6 +557,8 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusHoverShadowStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           <div {...stylex.props(styles.icon)}>

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -200,6 +200,13 @@ export const elevationRaw = {
     '0px 1px 2px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 2px 12px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2))',
   '--elevation-menu':
     '0px 1px 1px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 2px 8px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2))',
+  '--elevation-input-hover': 'inset 0px 0px 0px 2px rgba(1, 113, 227, 0.3)',
+  '--elevation-input-hover-success':
+    'inset 0px 0px 0px 2px rgba(38, 167, 86, 0.3)',
+  '--elevation-input-hover-warning':
+    'inset 0px 0px 0px 2px rgba(226, 164, 0, 0.3)',
+  '--elevation-input-hover-error':
+    'inset 0px 0px 0px 2px rgba(227, 25, 59, 0.3)',
 } as const;
 
 export const elevationVars = stylex.defineVars(elevationRaw);

--- a/packages/themes/default/src/defaultTheme.stylex.ts
+++ b/packages/themes/default/src/defaultTheme.stylex.ts
@@ -217,6 +217,13 @@ const elevationRaw = {
     '0px 1px 2px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 2px 12px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2))',
   '--elevation-menu':
     '0px 1px 1px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 2px 8px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2))',
+  '--elevation-input-hover': 'inset 0px 0px 0px 2px rgba(1, 113, 227, 0.3)',
+  '--elevation-input-hover-success':
+    'inset 0px 0px 0px 2px rgba(38, 167, 86, 0.3)',
+  '--elevation-input-hover-warning':
+    'inset 0px 0px 0px 2px rgba(226, 164, 0, 0.3)',
+  '--elevation-input-hover-error':
+    'inset 0px 0px 0px 2px rgba(227, 25, 59, 0.3)',
 } as const satisfies Record<ElevationVarName, string>;
 
 const transitionRaw = {

--- a/packages/themes/neutral/src/neutralTheme.stylex.ts
+++ b/packages/themes/neutral/src/neutralTheme.stylex.ts
@@ -260,6 +260,13 @@ const elevationRaw = {
     '0 2px 4px light-dark(oklch(0 0 0 / 5%), oklch(0 0 0 / 15%)), 0 4px 12px light-dark(oklch(0 0 0 / 10%), oklch(0 0 0 / 20%))',
   '--elevation-menu':
     '0 2px 4px light-dark(oklch(0 0 0 / 5%), oklch(0 0 0 / 15%)), 0 4px 8px light-dark(oklch(0 0 0 / 10%), oklch(0 0 0 / 20%))',
+  '--elevation-input-hover': 'inset 0px 0px 0px 2px rgba(1, 113, 227, 0.3)',
+  '--elevation-input-hover-success':
+    'inset 0px 0px 0px 2px rgba(38, 167, 86, 0.3)',
+  '--elevation-input-hover-warning':
+    'inset 0px 0px 0px 2px rgba(226, 164, 0, 0.3)',
+  '--elevation-input-hover-error':
+    'inset 0px 0px 0px 2px rgba(227, 25, 59, 0.3)',
 } as const satisfies Record<ElevationVarName, string>;
 
 const transitionRaw = {


### PR DESCRIPTION
## Summary

Adds inner shadow hover effects and focus outline refinements to all input components.

## Inner Shadow on Hover

New tokens (`inset 0 0 0 2px` at 30% opacity):

| Token | Color |
|-------|-------|
| `--elevation-input-hover` | `#0171E3` |
| `--elevation-input-hover-success` | `#26A756` |
| `--elevation-input-hover-warning` | `#E2A400` |
| `--elevation-input-hover-error` | `#E3193B` |

## Focus Outline Changes

- **Width:** 2px → 1px on all input components
- **Offset:** Removed gap (outlineOffset: 0) so the ring sits flush
- **Status colors:** Applied status-specific focus outline colors to all inputs (not just XDSTextInput)

## Components Updated

`XDSTextInput`, `XDSTextArea`, `XDSTimeInput`, `XDSNumberInput`, `XDSDateInput`, `XDSSelector`

---
*Crafted with care by Navi*