### PR TITLE
feat(vibe-tests): add raw HTML target for three-way comparison

### DIFF
--- a/internal/vibe-tests/.gitignore
+++ b/internal/vibe-tests/.gitignore
@@ -6,5 +6,8 @@ AGENTS.md
 .baseline-docs/
 AGENTS.baseline.md
 
+# Raw HTML docs (generated)
+AGENTS.html.md
+
 # Test results (generated)
 results/

--- a/internal/vibe-tests/src/interactive.ts
+++ b/internal/vibe-tests/src/interactive.ts
@@ -676,6 +676,53 @@ Style with className to match the content being loaded.
 }
 
 /**
+ * Install AGENTS.html.md for raw HTML/CSS target
+ */
+function installHtmlDocs(): void {
+  const vibeTestsDir = path.join(__dirname, '..');
+  const agentsMdPath = path.join(vibeTestsDir, 'AGENTS.html.md');
+
+  if (fs.existsSync(agentsMdPath)) {
+    const stats = fs.statSync(agentsMdPath);
+    const ageMs = Date.now() - stats.mtimeMs;
+    if (ageMs < 60 * 60 * 1000) return;
+  }
+
+  const agentsMd = `# AGENTS.md
+
+Project-specific guidance for AI coding agents.
+
+## Raw HTML/CSS — No Component Library
+
+You are writing React components using ONLY:
+- Plain HTML elements (div, span, p, h1-h6, button, input, etc.)
+- Inline styles via the \`style\` prop (style={{ ... }})
+- Standard React hooks (useState, useEffect, etc.)
+
+### Rules
+
+1. Do NOT import any component library (no shadcn, no MUI, no XDS, no Radix)
+2. Do NOT use Tailwind CSS or any CSS framework
+3. Do NOT use CSS modules, styled-components, or CSS-in-JS libraries
+4. Use inline \`style={{}}\` for ALL styling
+5. Use semantic HTML elements where appropriate (button, nav, main, etc.)
+6. Handle accessibility yourself (aria-labels, roles, keyboard events)
+7. Export a default function component
+
+### Styling Guidelines
+
+- Use reasonable defaults: system font stack, 16px base, #333 text
+- Use consistent spacing: 4/8/12/16/24/32px scale
+- Use a neutral color palette: grays for backgrounds, blue for accent
+- Add border-radius for interactive elements
+- Include hover/focus states on interactive elements
+`;
+
+  fs.writeFileSync(agentsMdPath, agentsMd);
+  console.log('✓ Generated AGENTS.html.md');
+}
+
+/**
  * Install AGENTS.md for agent documentation
  */
 function installAgentsDocs(): void {
@@ -709,7 +756,7 @@ interface InteractiveConfig {
   holdout?: boolean;
   persona: 'naive' | 'experienced' | 'adversarial';
   degradation?: boolean; // Enable degradation curve testing
-  target: 'xds' | 'baseline'; // Target design system
+  target: 'xds' | 'baseline' | 'html'; // Target design system
 }
 
 interface AgentTask {
@@ -890,7 +937,11 @@ function generateSubagentPrompt(
 
   // Target-specific AGENTS.md file
   const agentsMdFile =
-    config.target === 'baseline' ? 'AGENTS.baseline.md' : 'AGENTS.md';
+    config.target === 'baseline'
+      ? 'AGENTS.baseline.md'
+      : config.target === 'html'
+        ? 'AGENTS.html.md'
+        : 'AGENTS.md';
 
   // Persona-specific framing to simulate different user types
   const personaFraming: Record<string, Record<string, string>> = {
@@ -903,6 +954,11 @@ function generateSubagentPrompt(
       naive: '', // No special framing
       experienced: `Use baseline/ui components. `,
       adversarial: `I'm used to Material UI patterns but need to use your design system. `,
+    },
+    html: {
+      naive: '', // No special framing
+      experienced: `Use only plain HTML elements and inline CSS. `,
+      adversarial: `I know React component libraries exist but I want raw HTML/CSS. `,
     },
   };
 
@@ -996,7 +1052,9 @@ async function main() {
   const degradation = args.includes('--degradation');
   const targetIndex = args.indexOf('--target');
   const target =
-    targetIndex !== -1 ? (args[targetIndex + 1] as 'xds' | 'baseline') : 'xds';
+    targetIndex !== -1
+      ? (args[targetIndex + 1] as 'xds' | 'baseline' | 'html')
+      : 'xds';
   const promptsIndex = args.indexOf('--prompts');
   const promptIds =
     promptsIndex !== -1 ? args[promptsIndex + 1].split(',') : undefined;
@@ -1014,6 +1072,8 @@ async function main() {
     installAgentsDocs();
   } else if (target === 'baseline') {
     installBaselineDocs();
+  } else if (target === 'html') {
+    installHtmlDocs();
   }
 
   // Load test set
@@ -1049,7 +1109,7 @@ async function main() {
   console.log(`Target: ${target.toUpperCase()}`);
   console.log(`Persona: ${persona}`);
   console.log(
-    `Mode: ${target === 'xds' ? 'AGENTS.md' : 'AGENTS.baseline.md'} (retrieval-led)`,
+    `Mode: ${target === 'xds' ? 'AGENTS.md' : target === 'baseline' ? 'AGENTS.baseline.md' : 'AGENTS.html.md'} (retrieval-led)`,
   );
   console.log(
     `Protocol: ${degradation ? 'Degradation (10-turn curve)' : 'One-shot'}`,


### PR DESCRIPTION
## What

Adds `html` as a third target for vibe tests alongside `xds` and `baseline`. Usage:

```bash
npx tsx src/interactive.ts --target html --prompts sd-1,fwc-1,ty-1
```

Generates `AGENTS.html.md` that constrains the LLM to plain HTML elements + inline styles only. No component libraries, no Tailwind, no CSS-in-JS.

## Three-Way Comparison (3 prompts: sd-1, fwc-1, ty-1)

```
Dimension            XDS   Base   HTML
──────────────────────────────────────
Correctness          100    100    100
Accessibility        100    100    100
Code Quality         100    100    100
Efficiency            86     88     91
Maintainability       84     90     11
──────────────────────────────────────
Overall               94     96     80
```

### The story in sub-metrics

```
              decisions/elem   code lines   semantic ratio   magic values
XDS                1.1             43           100%              0
Baseline           2.5             61           100%              0
Raw HTML           4.4            112             0%             34
```

**Efficiency:** Raw HTML scores highest (91) because it has no imports, no boilerplate, no styling blocks — just inline styles. But it requires **4.4 styling decisions per element** (vs 1.1 for XDS). Each decision is a chance for the LLM to hallucinate a color, spacing, or font value.

**Maintainability:** Raw HTML collapses to 11 — zero semantic tokens, 34 magic values. Changing "the primary color" means find-and-replace across every inline style. XDS and Baseline both score 84-90 with 100% semantic ratio and zero magic values.

**The design system value proposition:** XDS produces the most concise code (43 lines), with the fewest decisions per element (1.1), and zero magic values. It costs more tokens to generate (doc reading), but the output is more maintainable and less error-prone.

### Cost

```
              tokens    duration   output lines
XDS          ~13,645    126.6s        49
Baseline      ~9,085     81.4s        69
Raw HTML      ~5,242     67.3s       119
```

Raw HTML is cheapest to generate (fewest tokens, fastest) but produces the most output (119 lines) — all of which is unmaintainable.

---
*Crafted with care by Navi*