### PR TITLE
Navi/fix/update focus outline color

### DIFF
--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -105,7 +105,7 @@ const variants = stylex.create({
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -122,7 +122,7 @@ const variants = stylex.create({
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -139,7 +139,7 @@ const variants = stylex.create({
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -156,7 +156,7 @@ const variants = stylex.create({
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-negative']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-negative']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -240,7 +240,7 @@ export const dayCellTheme = stylex.create({
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -72,7 +72,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
   },
   checkboxFocused: {
-    outline: `2px solid ${colorVars['--color-focus-outline']}`,
+    outline: `1px solid ${colorVars['--color-focus-outline']}`,
     outlineOffset: 2,
   },
   // State-dependent colors with ancestor hover behavior

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -64,7 +64,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -89,7 +89,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     outline: {
       default: 'none',
-      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: 1,
   },
@@ -154,19 +154,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -64,7 +64,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -89,7 +89,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     outline: {
       default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: 1,
   },
@@ -154,19 +154,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -66,10 +66,7 @@ const styles = stylex.create({
       default: 'none',
       ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -150,6 +150,27 @@ const statusBorderStyles = stylex.create({
   },
 });
 
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
 export type XDSDateInputSize = keyof typeof sizeStyles;
 
 // Re-export shared types for convenience
@@ -477,6 +498,7 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           <button

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -81,7 +81,7 @@ const styles = stylex.create({
     transition: `opacity ${transitionVars['--transition-normal']}, transform ${transitionVars['--transition-normal']}`,
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/Layer/useXDSPopover.tsx
+++ b/packages/core/src/Layer/useXDSPopover.tsx
@@ -74,7 +74,7 @@ const styles = stylex.create({
     cursor: 'pointer',
     borderWidth: 0,
     borderStyle: 'none',
-    outline: `2px solid ${colorVars['--color-focus-outline']}`,
+    outline: `1px solid ${colorVars['--color-focus-outline']}`,
     outlineOffset: 2,
     zIndex: 1,
     pointerEvents: 'auto', // Re-enable mouse clicks when visible

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -61,7 +61,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -59,7 +59,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -131,19 +131,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -127,6 +127,27 @@ const statusBorderStyles = stylex.create({
   },
 });
 
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
 export type XDSNumberInputSize = keyof typeof sizeStyles;
 
 // Re-export shared types for convenience
@@ -512,6 +533,7 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -59,7 +59,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -131,19 +131,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -61,10 +61,7 @@ const styles = stylex.create({
       default: 'none',
       ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -85,7 +85,7 @@ const styles = stylex.create({
   radioWrapperFocus: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -74,7 +74,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -215,19 +215,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus': `1px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus': `2px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus': `1px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus': `2px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus': `1px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -74,7 +74,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus': `1px solid ${colorVars['--color-focus-outline']}`,
+      ':focus': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -215,19 +215,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus': `2px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus': `1px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus': `2px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus': `1px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus': `2px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -76,10 +76,7 @@ const styles = stylex.create({
       default: 'none',
       ':focus': `2px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus': '1px',
-    },
+    outlineOffset: '0',
   },
   triggerDisabled: {
     cursor: 'not-allowed',

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -211,6 +211,27 @@ const statusBorderStyles = stylex.create({
   },
 });
 
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus': `2px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus': `2px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
 const STATUS_ICON_MAP: Record<XDSSelectorStatusType, XDSIconName> = {
   warning: 'warning',
   error: 'xCircle',
@@ -588,6 +609,7 @@ export function XDSSelector<T extends XDSSelectorOption>({
           isDisabled && styles.triggerDisabled,
           !selectedItem && styles.triggerPlaceholder,
           status && statusBorderStyles[status.type],
+          status && statusFocusStyles[status.type],
           triggerOverride,
         )}>
         <span>{selectedItem?.label ?? placeholder}</span>

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -221,7 +221,7 @@ const styles = stylex.create({
   thumbFocusWithin: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -91,7 +91,7 @@ const styles = stylex.create({
     boxSizing: 'border-box',
   },
   trackFocused: {
-    outline: `2px solid ${colorVars['--color-focus-outline']}`,
+    outline: `1px solid ${colorVars['--color-focus-outline']}`,
     outlineOffset: 2,
   },
   // State-dependent colors with ancestor hover behavior

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -75,7 +75,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -79,7 +79,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -178,7 +178,7 @@ const styles = stylex.create({
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
   },
   menuItemSelected: {

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -56,7 +56,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -119,19 +119,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -56,7 +56,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -119,19 +119,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -115,6 +115,27 @@ const statusBorderStyles = stylex.create({
   },
 });
 
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
 export type XDSTextAreaStatusType = 'warning' | 'error' | 'success';
 
 export interface XDSTextAreaStatus {
@@ -317,6 +338,7 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
             styles.wrapper,
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -58,10 +58,7 @@ const styles = stylex.create({
       default: 'none',
       ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -107,6 +107,27 @@ const statusBorderStyles = stylex.create({
   },
 });
 
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
 export type XDSTextInputSize = keyof typeof sizeStyles;
 
 // Re-export shared types for convenience
@@ -292,6 +313,7 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -51,10 +51,7 @@ const styles = stylex.create({
       default: 'none',
       ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -49,7 +49,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -111,19 +111,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -49,7 +49,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -111,19 +111,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -67,7 +67,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -121,7 +121,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     outline: {
       default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: 1,
   },
@@ -155,19 +155,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -67,7 +67,7 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -121,7 +121,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-element'],
     outline: {
       default: 'none',
-      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: 1,
   },
@@ -155,19 +155,19 @@ const statusFocusStyles = stylex.create({
   warning: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
     },
   },
   error: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
     },
   },
   success: {
     outline: {
       default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
     },
   },
 });

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -69,10 +69,7 @@ const styles = stylex.create({
       default: 'none',
       ':focus-within': `2px solid ${colorVars['--color-focus-outline']}`,
     },
-    outlineOffset: {
-      default: '0',
-      ':focus-within': '1px',
-    },
+    outlineOffset: '0',
   },
   wrapperDisabled: {
     cursor: 'not-allowed',

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -151,6 +151,27 @@ const statusBorderStyles = stylex.create({
   },
 });
 
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `2px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
 export type XDSTimeInputSize = keyof typeof sizeStyles;
 export type XDSTimeInputHourFormat = '12h' | '24h';
 
@@ -514,6 +535,7 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
             sizeStyles[size],
             isDisabled && styles.wrapperDisabled,
             status && statusBorderStyles[status.type],
+            status && statusFocusStyles[status.type],
             wrapperOverride,
           )}>
           <div {...stylex.props(styles.icon)}>

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -49,7 +49,7 @@ const styles = stylex.create({
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -49,7 +49,7 @@ const styles = stylex.create({
     },
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',
@@ -82,7 +82,7 @@ const styles = stylex.create({
     border: 'none',
     outline: {
       default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+      ':focus-visible': `1px solid ${colorVars['--color-focus-outline']}`,
     },
     outlineOffset: {
       default: '0',

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -25,6 +25,9 @@ export const colorRaw = {
   '--color-hover-overlay': 'light-dark(#0536590C, #FFFFFF0C)',
   '--color-pressed-overlay': 'light-dark(#05365919, #FFFFFF19)',
   '--color-focus-outline': 'light-dark(#0171E3, #2694FE)',
+  '--color-focus-outline-error': 'light-dark(#E3193B, #F5394F)',
+  '--color-focus-outline-success': 'light-dark(#0D8626, #0D8626)',
+  '--color-focus-outline-warning': 'light-dark(#F2C00B, #E9AF08)',
   '--color-deemphasized': 'light-dark(#0536590C, #1111127F)',
 
   // Text

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -24,7 +24,7 @@ export const colorRaw = {
   '--color-overlay': 'light-dark(#01122866, #11111299)',
   '--color-hover-overlay': 'light-dark(#0536590C, #FFFFFF0C)',
   '--color-pressed-overlay': 'light-dark(#05365919, #FFFFFF19)',
-  '--color-focus-outline': 'light-dark(#042F97, #AFD7FF)',
+  '--color-focus-outline': 'light-dark(#0171E3, #2694FE)',
   '--color-deemphasized': 'light-dark(#0536590C, #1111127F)',
 
   // Text

--- a/packages/themes/default/src/defaultTheme.stylex.ts
+++ b/packages/themes/default/src/defaultTheme.stylex.ts
@@ -65,7 +65,7 @@ const colorRaw = {
   '--color-overlay': 'light-dark(#01122866, #11111299)',
   '--color-hover-overlay': 'light-dark(#0536590C, #FFFFFF0C)',
   '--color-pressed-overlay': 'light-dark(#05365919, #FFFFFF19)',
-  '--color-focus-outline': 'light-dark(#042F97, #AFD7FF)',
+  '--color-focus-outline': 'light-dark(#0171E3, #2694FE)',
   '--color-focus-outline-error': 'light-dark(#E3193B, #F5394F)',
   '--color-focus-outline-success': 'light-dark(#0D8626, #0D8626)',
   '--color-focus-outline-warning': 'light-dark(#F2C00B, #E9AF08)',

--- a/packages/themes/default/src/defaultTheme.stylex.ts
+++ b/packages/themes/default/src/defaultTheme.stylex.ts
@@ -66,6 +66,9 @@ const colorRaw = {
   '--color-hover-overlay': 'light-dark(#0536590C, #FFFFFF0C)',
   '--color-pressed-overlay': 'light-dark(#05365919, #FFFFFF19)',
   '--color-focus-outline': 'light-dark(#042F97, #AFD7FF)',
+  '--color-focus-outline-error': 'light-dark(#E3193B, #F5394F)',
+  '--color-focus-outline-success': 'light-dark(#0D8626, #0D8626)',
+  '--color-focus-outline-warning': 'light-dark(#F2C00B, #E9AF08)',
   '--color-deemphasized': 'light-dark(#0536590C, #1111127F)',
 
   // Text

--- a/packages/themes/neutral/src/neutralTheme.stylex.ts
+++ b/packages/themes/neutral/src/neutralTheme.stylex.ts
@@ -70,6 +70,9 @@ const colorRaw = {
   '--color-pressed-overlay':
     'light-dark(oklch(0 0 0 / 10%), oklch(1 0 0 / 10%))',
   '--color-focus-outline': 'light-dark(oklch(0.708 0 0), oklch(0.556 0 0))',
+  '--color-focus-outline-error': 'light-dark(#E3193B, #F5394F)',
+  '--color-focus-outline-success': 'light-dark(#0D8626, #0D8626)',
+  '--color-focus-outline-warning': 'light-dark(#F2C00B, #E9AF08)',
   '--color-deemphasized': 'light-dark(oklch(0.97 0 0), oklch(0.269 0 0))',
 
   // Text


### PR DESCRIPTION
## Summary

This PR updated focus outline colors and widths across all components.

**Superseded by #256** — all changes in this PR were included in the more comprehensive `feat(inputs): add inner shadow on hover` PR, which has already been merged. Closing as redundant.

---
*Crafted with care by Navi*