### PR TITLE
feat(core): add XDSPopover, XDSTypeahead, and XDSTokenizer

### DIFF
--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -1,0 +1,123 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSPopover} from '@xds/core/Layer';
+import {XDSButton} from '@xds/core/Button';
+import {XDSVStack} from '@xds/core/Layout';
+
+const meta: Meta<typeof XDSPopover> = {
+  title: 'Core/XDSPopover',
+  component: XDSPopover,
+  tags: ['autodocs'],
+  argTypes: {
+    trigger: {
+      control: 'select',
+      options: ['click', 'hover'],
+      description: 'How the popover is triggered',
+    },
+    placement: {
+      control: 'select',
+      options: ['above', 'below', 'start', 'end'],
+      description: 'Position relative to trigger',
+    },
+    alignment: {
+      control: 'select',
+      options: ['start', 'center', 'end'],
+      description: 'Alignment on placement axis',
+    },
+    isEnabled: {
+      control: 'boolean',
+      description: 'Enable/disable the popover',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSPopover>;
+
+function PopoverContent() {
+  return (
+    <XDSVStack gap="space2">
+      <div style={{fontWeight: 600}}>Popover Title</div>
+      <div style={{fontSize: 14}}>
+        This is some popover content. It can contain any React elements.
+      </div>
+    </XDSVStack>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    trigger: 'click',
+    placement: 'below',
+    label: 'Example popover',
+    content: <PopoverContent />,
+    children: <XDSButton label="Open popover">Open popover</XDSButton>,
+  },
+};
+
+export const Above: Story = {
+  render: () => (
+    <div style={{paddingTop: 200}}>
+      <XDSPopover
+        trigger="click"
+        placement="above"
+        label="Above popover"
+        content={<PopoverContent />}>
+        <XDSButton label="Above">Above</XDSButton>
+      </XDSPopover>
+    </div>
+  ),
+};
+
+export const HoverTrigger: Story = {
+  args: {
+    trigger: 'hover',
+    placement: 'below',
+    content: <PopoverContent />,
+    children: <XDSButton label="Hover me">Hover me</XDSButton>,
+  },
+};
+
+export const Controlled: Story = {
+  render: function ControlledExample() {
+    const [isShown, setIsShown] = React.useState(false);
+    return (
+      <div style={{padding: 100}}>
+        <XDSPopover
+          trigger="click"
+          placement="below"
+          label="Controlled popover"
+          isShown={isShown}
+          onToggle={setIsShown}
+          content={
+            <XDSVStack gap="space2">
+              <div>Controlled popover</div>
+              <XDSButton
+                label="Close"
+                variant="primary"
+                onClick={() => setIsShown(false)}>
+                Close
+              </XDSButton>
+            </XDSVStack>
+          }>
+          <XDSButton label="Toggle" onClick={() => setIsShown(!isShown)}>
+            {isShown ? 'Close' : 'Open'}
+          </XDSButton>
+        </XDSPopover>
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    trigger: 'click',
+    placement: 'below',
+    label: 'Disabled popover',
+    isEnabled: false,
+    content: <PopoverContent />,
+    children: <XDSButton label="Disabled popover">Disabled popover</XDSButton>,
+  },
+};
+
+// Need React import for Controlled story
+import React from 'react';

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -36,7 +36,9 @@ type Story = StoryObj<typeof XDSPopover>;
 function PopoverContent() {
   return (
     <XDSVStack gap="space2">
-      <div style={{fontWeight: 600}}>Popover Title</div>
+      <div style={{fontWeight: 600}} tabIndex={-1}>
+        Popover Title
+      </div>
       <div style={{fontSize: 14}}>
         This is some popover content. It can contain any React elements.
       </div>

--- a/apps/storybook/stories/Tokenizer.stories.tsx
+++ b/apps/storybook/stories/Tokenizer.stories.tsx
@@ -1,0 +1,126 @@
+import React, {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSTokenizer} from '@xds/core/Tokenizer';
+import type {XDSTokenizerChange} from '@xds/core/Tokenizer';
+import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
+
+const meta: Meta<typeof XDSTokenizer> = {
+  title: 'Core/XDSTokenizer',
+  component: XDSTokenizer,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {control: 'text'},
+    placeholder: {control: 'text'},
+    isDisabled: {control: 'boolean'},
+    isRequired: {control: 'boolean'},
+    isOptional: {control: 'boolean'},
+    hasClear: {control: 'boolean'},
+    maxEntries: {control: 'number'},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSTokenizer>;
+
+// Sample data
+const users: XDSSearchableItem[] = [
+  {id: '1', label: 'Alice Johnson'},
+  {id: '2', label: 'Bob Smith'},
+  {id: '3', label: 'Charlie Brown'},
+  {id: '4', label: 'Diana Prince'},
+  {id: '5', label: 'Eve Williams'},
+  {id: '6', label: 'Frank Miller'},
+  {id: '7', label: 'Grace Lee'},
+  {id: '8', label: 'Henry Davis'},
+];
+
+const userSource: XDSSearchSource = {
+  search: (query: string) =>
+    users.filter(u => u.label.toLowerCase().includes(query.toLowerCase())),
+  bootstrap: () => users.slice(0, 5),
+};
+
+function TokenizerExample(
+  props: Partial<React.ComponentProps<typeof XDSTokenizer>>,
+) {
+  const [value, setValue] = useState<XDSSearchableItem[]>([]);
+  return (
+    <div style={{width: 400}}>
+      <XDSTokenizer
+        label="Team Members"
+        searchSource={userSource}
+        value={value}
+        onChange={items => setValue(items)}
+        placeholder="Search people..."
+        {...props}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <TokenizerExample />,
+};
+
+export const WithPreselected: Story = {
+  render: () => {
+    const [value, setValue] = useState([users[0], users[2]]);
+    return (
+      <div style={{width: 400}}>
+        <XDSTokenizer
+          label="Team Members"
+          searchSource={userSource}
+          value={value}
+          onChange={items => setValue(items)}
+          placeholder="Add more..."
+        />
+      </div>
+    );
+  },
+  name: 'Pre-selected Items',
+};
+
+export const WithClear: Story = {
+  render: () => <TokenizerExample hasClear />,
+  name: 'With Clear All Button',
+};
+
+export const MaxEntries: Story = {
+  render: () => <TokenizerExample maxEntries={3} />,
+  name: 'Max 3 Entries',
+};
+
+export const Required: Story = {
+  render: () => <TokenizerExample isRequired />,
+};
+
+export const WithDescription: Story = {
+  render: () => (
+    <TokenizerExample description="Select up to 5 team members for this project" />
+  ),
+};
+
+export const WithError: Story = {
+  render: () => (
+    <TokenizerExample
+      status={{type: 'error', message: 'At least one member is required'}}
+    />
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => {
+    const [value] = useState([users[0], users[1]]);
+    return (
+      <div style={{width: 400}}>
+        <XDSTokenizer
+          label="Team Members"
+          searchSource={userSource}
+          value={value}
+          onChange={() => {}}
+          isDisabled
+        />
+      </div>
+    );
+  },
+};

--- a/apps/storybook/stories/Tokenizer.stories.tsx
+++ b/apps/storybook/stories/Tokenizer.stories.tsx
@@ -108,6 +108,20 @@ export const WithError: Story = {
   ),
 };
 
+export const WithWarning: Story = {
+  render: () => (
+    <TokenizerExample
+      status={{type: 'warning', message: 'Some members may not have access'}}
+    />
+  ),
+};
+
+export const WithSuccess: Story = {
+  render: () => (
+    <TokenizerExample status={{type: 'success', message: 'Team is ready!'}} />
+  ),
+};
+
 export const Disabled: Story = {
   render: () => {
     const [value] = useState([users[0], users[1]]);

--- a/apps/storybook/stories/Typeahead.stories.tsx
+++ b/apps/storybook/stories/Typeahead.stories.tsx
@@ -1,0 +1,104 @@
+import React, {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSTypeahead} from '@xds/core/Typeahead';
+import type {XDSSearchableItem, XDSSearchSource} from '@xds/core/Typeahead';
+
+const meta: Meta<typeof XDSTypeahead> = {
+  title: 'Core/XDSTypeahead',
+  component: XDSTypeahead,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {control: 'text'},
+    placeholder: {control: 'text'},
+    isDisabled: {control: 'boolean'},
+    isRequired: {control: 'boolean'},
+    isOptional: {control: 'boolean'},
+    hasEntriesOnFocus: {control: 'boolean'},
+    hasClear: {control: 'boolean'},
+    maxMenuItems: {control: 'number'},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSTypeahead>;
+
+// Sample data
+const fruits: XDSSearchableItem[] = [
+  {id: '1', label: 'Apple'},
+  {id: '2', label: 'Banana'},
+  {id: '3', label: 'Cherry'},
+  {id: '4', label: 'Date'},
+  {id: '5', label: 'Elderberry'},
+  {id: '6', label: 'Fig'},
+  {id: '7', label: 'Grape'},
+  {id: '8', label: 'Honeydew'},
+];
+
+const fruitSource: XDSSearchSource = {
+  search: (query: string) =>
+    fruits.filter(f => f.label.toLowerCase().includes(query.toLowerCase())),
+  bootstrap: () => fruits.slice(0, 5),
+};
+
+function TypeaheadExample(
+  props: Partial<React.ComponentProps<typeof XDSTypeahead>>,
+) {
+  const [value, setValue] = useState<XDSSearchableItem | null>(null);
+  return (
+    <div style={{width: 320}}>
+      <XDSTypeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={value}
+        onChange={setValue}
+        placeholder="Search fruits..."
+        {...props}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <TypeaheadExample />,
+};
+
+export const WithBootstrap: Story = {
+  render: () => <TypeaheadExample hasEntriesOnFocus />,
+  name: 'With Bootstrap Results',
+};
+
+export const Required: Story = {
+  render: () => <TypeaheadExample isRequired />,
+};
+
+export const Optional: Story = {
+  render: () => <TypeaheadExample isOptional />,
+};
+
+export const WithDescription: Story = {
+  render: () => (
+    <TypeaheadExample description="Pick your favorite fruit from the list" />
+  ),
+};
+
+export const WithError: Story = {
+  render: () => (
+    <TypeaheadExample
+      status={{type: 'error', message: 'Please select a fruit'}}
+    />
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => <TypeaheadExample isDisabled />,
+};
+
+export const NoClear: Story = {
+  render: () => <TypeaheadExample hasClear={false} />,
+  name: 'Without Clear Button',
+};
+
+export const LimitedResults: Story = {
+  render: () => <TypeaheadExample maxMenuItems={3} hasEntriesOnFocus />,
+  name: 'Max 3 Results',
+};

--- a/apps/storybook/stories/Typeahead.stories.tsx
+++ b/apps/storybook/stories/Typeahead.stories.tsx
@@ -89,6 +89,20 @@ export const WithError: Story = {
   ),
 };
 
+export const WithWarning: Story = {
+  render: () => (
+    <TypeaheadExample
+      status={{type: 'warning', message: 'This fruit may be out of season'}}
+    />
+  ),
+};
+
+export const WithSuccess: Story = {
+  render: () => (
+    <TypeaheadExample status={{type: 'success', message: 'Great choice!'}} />
+  ),
+};
+
 export const Disabled: Story = {
   render: () => <TypeaheadExample isDisabled />,
 };

--- a/packages/core/src/Layer/XDSPopover.test.tsx
+++ b/packages/core/src/Layer/XDSPopover.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @file XDSPopover.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSPopover component
+ * @output Unit tests for XDSPopover component behavior
+ * @position Testing; validates XDSPopover.tsx implementation
+ *
+ * SYNC: When XDSPopover.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {XDSPopover} from './XDSPopover';
+
+// Store original matches to restore later
+const originalMatches = HTMLElement.prototype.matches;
+
+// Track popover open state per element
+const popoverOpenState = new WeakMap<HTMLElement, boolean>();
+
+// Mock Popover API for jsdom
+beforeAll(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, true);
+    // Dispatch toggle event
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, false);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+
+  HTMLElement.prototype.matches = function (selector: string) {
+    if (selector === ':popover-open') {
+      return popoverOpenState.get(this) ?? false;
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterAll(() => {
+  HTMLElement.prototype.matches = originalMatches;
+});
+
+describe('XDSPopover', () => {
+  it('renders trigger element', () => {
+    render(
+      <XDSPopover content={<span>Popover content</span>} label="Test popover">
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    expect(screen.getByRole('button', {name: 'Open'})).toBeInTheDocument();
+  });
+
+  it('sets aria-haspopup on trigger', () => {
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <button>Trigger</button>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+
+  it('sets aria-expanded=false initially', () => {
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <button>Trigger</button>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens on click and updates aria-expanded', () => {
+    render(
+      <XDSPopover content={<span>Popover content</span>} label="Test">
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Open'});
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('renders popover content with role=dialog', () => {
+    render(
+      <XDSPopover content={<span>Hello</span>} label="Greeting">
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    // The dialog is inside a popover element — hidden from accessibility tree
+    // until shown, but still present in the DOM
+    const dialog = screen.getByRole('dialog', {hidden: true});
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-label', 'Greeting');
+  });
+
+  it('calls onToggle when opened', () => {
+    const onToggle = vi.fn();
+    render(
+      <XDSPopover
+        content={<span>Content</span>}
+        label="Test"
+        onToggle={onToggle}>
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('does not open when isEnabled is false', () => {
+    const onToggle = vi.fn();
+    render(
+      <XDSPopover
+        content={<span>Content</span>}
+        label="Test"
+        isEnabled={false}
+        onToggle={onToggle}>
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('renders with data-testid', () => {
+    render(
+      <XDSPopover
+        content={<span>Content</span>}
+        label="Test"
+        data-testid="my-popover">
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    expect(screen.getByTestId('my-popover')).toBeInTheDocument();
+  });
+
+  it('renders hover trigger as HoverCard', () => {
+    render(
+      <XDSPopover trigger="hover" content={<span>Hover content</span>}>
+        <button>Hover me</button>
+      </XDSPopover>,
+    );
+    // Hover trigger should render the trigger element
+    expect(screen.getByRole('button', {name: 'Hover me'})).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -1,0 +1,389 @@
+/**
+ * @file XDSPopover.tsx
+ * @input Uses React, useXDSPopover hook, XDSHoverCard
+ * @output Exports XDSPopover component for click/hover triggered popovers
+ * @position Layer component; declarative wrapper around useXDSPopover hook
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layer/README.md
+ * - /packages/core/src/Layer/XDSPopover.test.tsx
+ * - /packages/core/src/Layer/index.ts
+ * - /apps/storybook/stories/Popover.stories.tsx
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {useXDSPopover} from './useXDSPopover';
+import {XDSHoverCard} from './XDSHoverCard';
+import type {LayerAlignment, LayerPlacement} from './useXDSLayer';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  elevationVars,
+} from '../theme/tokens.stylex';
+import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
+
+// =============================================================================
+// Module Augmentation
+// =============================================================================
+
+declare module '../theme/types' {
+  interface ComponentStyles {
+    popover?: {
+      container?: ThemeStyleXStyles;
+    };
+  }
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * How the popover is triggered.
+ */
+export type XDSPopoverTrigger = 'click' | 'hover';
+
+export interface XDSPopoverProps {
+  /**
+   * The trigger element. Must accept a ref.
+   * For click trigger: receives onClick, aria-expanded, aria-haspopup, aria-controls.
+   * For hover trigger: delegates to XDSHoverCard behavior.
+   */
+  children: ReactNode;
+
+  /**
+   * Content to display inside the popover.
+   */
+  content: ReactNode;
+
+  /**
+   * Position placement relative to the trigger.
+   * Uses CSS anchor positioning via useXDSLayer.
+   * @default 'below'
+   */
+  placement?: LayerPlacement;
+
+  /**
+   * Alignment along the placement axis.
+   * @default 'center'
+   */
+  alignment?: LayerAlignment;
+
+  /**
+   * How the popover is triggered.
+   * - click: Opens on click, closes on click outside or Escape
+   * - hover: Opens on hover/focus, closes on mouse leave (delegates to XDSHoverCard)
+   * @default 'click'
+   */
+  trigger?: XDSPopoverTrigger;
+
+  /**
+   * Whether the popover is shown (controlled mode).
+   * Omit for uncontrolled behavior.
+   */
+  isShown?: boolean;
+
+  /**
+   * Default shown state for uncontrolled mode.
+   * @default false
+   */
+  initialIsShown?: boolean;
+
+  /**
+   * Callback fired when the popover visibility changes.
+   */
+  onToggle?: (isShown: boolean) => void;
+
+  /**
+   * Whether to trap focus inside the popover when open.
+   * @default true for click trigger, false for hover trigger
+   */
+  hasFocusTrap?: boolean;
+
+  /**
+   * Whether the popover is enabled.
+   * When false, trigger interactions are ignored.
+   * @default true
+   */
+  isEnabled?: boolean;
+
+  /**
+   * Width of the popover container.
+   * Numbers are px, strings used as-is.
+   * @default 'auto'
+   */
+  width?: number | string;
+
+  /**
+   * Accessible label for the popover dialog.
+   * Recommended for click-triggered popovers (which use role="dialog").
+   */
+  label?: string;
+
+  /**
+   * Optional StyleX overrides for the popover container.
+   */
+  xstyle?: StyleXStyles;
+
+  /**
+   * Test ID for the popover container.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  wrapperContents: {
+    display: 'contents',
+  },
+  container: {
+    backgroundColor: colorVars['--color-surface'],
+    borderRadius: radiusVars['--radius-element'],
+    boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
+  },
+  gap: {
+    marginBlockStart: spacingVars['--spacing-1'],
+    marginBlockEnd: spacingVars['--spacing-1'],
+  },
+  customWidth: (width: string | number) => ({
+    width: typeof width === 'number' ? `${width}px` : width,
+  }),
+  matchTrigger: {
+    minWidth: 'anchor-size(width)',
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * A popover component for displaying interactive content anchored to a trigger.
+ *
+ * Uses a display:contents wrapper so children refs are preserved.
+ * For click trigger, uses useXDSPopover with focus trap and light dismiss.
+ * For hover trigger, delegates to XDSHoverCard.
+ *
+ * @example
+ * ```tsx
+ * // Click-triggered popover
+ * <XDSPopover
+ *   label="Settings"
+ *   content={<SettingsPanel />}
+ *   placement="below"
+ * >
+ *   <XDSButton label="Settings" />
+ * </XDSPopover>
+ *
+ * // Hover-triggered popover (delegates to HoverCard)
+ * <XDSPopover trigger="hover" content={<UserCard />}>
+ *   <XDSAvatar src={avatar} label={name} />
+ * </XDSPopover>
+ *
+ * // Controlled popover
+ * <XDSPopover
+ *   isShown={isOpen}
+ *   onToggle={setIsOpen}
+ *   label="Filter"
+ *   content={<FilterForm />}
+ * >
+ *   <XDSButton label="Filter" />
+ * </XDSPopover>
+ * ```
+ */
+export function XDSPopover({
+  children,
+  content,
+  placement = 'below',
+  alignment = 'center',
+  trigger = 'click',
+  isShown,
+  initialIsShown = false,
+  onToggle,
+  hasFocusTrap,
+  isEnabled = true,
+  width,
+  label,
+  xstyle,
+  'data-testid': testId,
+}: XDSPopoverProps): ReactElement {
+  // Hover trigger delegates to XDSHoverCard
+  if (trigger === 'hover') {
+    return (
+      <XDSHoverCard
+        content={content}
+        placement={placement}
+        alignment={alignment}
+        isEnabled={isEnabled}
+        onShow={() => onToggle?.(true)}
+        onHide={() => onToggle?.(false)}>
+        {children}
+      </XDSHoverCard>
+    );
+  }
+
+  // Click trigger uses useXDSPopover
+  return (
+    <ClickPopover
+      content={content}
+      placement={placement}
+      alignment={alignment}
+      isShown={isShown}
+      initialIsShown={initialIsShown}
+      onToggle={onToggle}
+      isEnabled={isEnabled}
+      width={width}
+      label={label}
+      xstyle={xstyle}
+      data-testid={testId}>
+      {children}
+    </ClickPopover>
+  );
+}
+
+// =============================================================================
+// Click Popover (internal)
+// =============================================================================
+
+interface ClickPopoverProps {
+  children: ReactNode;
+  content: ReactNode;
+  placement: LayerPlacement;
+  alignment: LayerAlignment;
+  isShown?: boolean;
+  initialIsShown: boolean;
+  onToggle?: (isShown: boolean) => void;
+  isEnabled: boolean;
+  width?: number | string;
+  label?: string;
+  xstyle?: StyleXStyles;
+  'data-testid'?: string;
+}
+
+/**
+ * Internal click-triggered popover implementation.
+ * Extracted to a separate component so hooks are called unconditionally.
+ */
+function ClickPopover({
+  children,
+  content,
+  placement,
+  alignment,
+  isShown,
+  initialIsShown,
+  onToggle,
+  isEnabled,
+  width,
+  label,
+  xstyle,
+  'data-testid': testId,
+}: ClickPopoverProps): ReactElement {
+  const wrapperRef = useRef<HTMLElement>(null);
+  const isControlled = isShown !== undefined;
+  const initializedRef = useRef(false);
+
+  const popover = useXDSPopover({
+    dialogLabel: label,
+    hasLightDismiss: true,
+    onShow: () => onToggle?.(true),
+    onHide: () => onToggle?.(false),
+  });
+
+  // Sync controlled state
+  useEffect(() => {
+    if (!isControlled) return;
+    if (isShown && !popover.isOpen) {
+      popover.show();
+    } else if (!isShown && popover.isOpen) {
+      popover.hide();
+    }
+  }, [isShown, isControlled, popover]);
+
+  // Handle initialIsShown
+  useEffect(() => {
+    if (!isControlled && initialIsShown && !initializedRef.current) {
+      initializedRef.current = true;
+      popover.show();
+    }
+  }, [initialIsShown, isControlled, popover]);
+
+  // Handle click on trigger
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      if (!isEnabled) return;
+      e.preventDefault();
+      if (isControlled) {
+        onToggle?.(!isShown);
+      } else {
+        popover.toggle();
+      }
+    },
+    [isEnabled, isControlled, isShown, onToggle, popover],
+  );
+
+  // Attach click handler and popover ref to first child element
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    const firstChild = wrapper.firstElementChild as HTMLElement | null;
+    if (!firstChild) return;
+
+    // Set up anchor positioning
+    popover.triggerRef(firstChild);
+
+    // Set ARIA attributes
+    firstChild.setAttribute('aria-haspopup', 'dialog');
+    firstChild.setAttribute('aria-expanded', String(popover.isOpen));
+    firstChild.setAttribute('aria-controls', popover.id);
+
+    // Add click handler
+    firstChild.addEventListener('click', handleClick);
+
+    return () => {
+      popover.triggerRef(null);
+      firstChild.removeAttribute('aria-haspopup');
+      firstChild.removeAttribute('aria-expanded');
+      firstChild.removeAttribute('aria-controls');
+      firstChild.removeEventListener('click', handleClick);
+    };
+  }, [popover, handleClick]);
+
+  // Determine popover xstyle
+  const popoverXstyle = width ? styles.customWidth(width) : styles.matchTrigger;
+
+  return (
+    <>
+      <div
+        ref={wrapperRef as React.RefObject<HTMLDivElement>}
+        {...stylex.props(styles.wrapperContents)}>
+        {children}
+      </div>
+      {popover.render(
+        <div data-testid={testId} {...stylex.props(styles.container, xstyle)}>
+          {content}
+        </div>,
+        {
+          placement,
+          alignment,
+          xstyle: [popoverXstyle, styles.gap],
+        },
+      )}
+    </>
+  );
+}
+
+XDSPopover.displayName = 'XDSPopover';

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -153,6 +153,31 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-surface'],
     borderRadius: radiusVars['--radius-element'],
     boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
+    // Animation: closed state (default) and open state
+    opacity: {
+      default: 0,
+      ':popover-open': 1,
+    },
+    transform: {
+      default: 'scale(0.95)',
+      ':popover-open': 'scale(1)',
+    },
+    // Transitions with allow-discrete for display/overlay
+    transitionProperty: 'opacity, transform, overlay, display',
+    transitionDuration: '0.15s',
+    transitionTimingFunction: 'ease',
+    transitionBehavior: 'allow-discrete',
+    // Entry animation starting state
+    '@starting-style': {
+      opacity: 0,
+      transform: 'scale(0.95)',
+    },
+  },
+  contentPadding: {
+    paddingBlockStart: spacingVars['--spacing-3'],
+    paddingBlockEnd: spacingVars['--spacing-3'],
+    paddingInlineStart: spacingVars['--spacing-3'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
   },
   gap: {
     marginBlockStart: spacingVars['--spacing-1'],
@@ -373,7 +398,9 @@ function ClickPopover({
         {children}
       </div>
       {popover.render(
-        <div data-testid={testId} {...stylex.props(styles.container, xstyle)}>
+        <div
+          data-testid={testId}
+          {...stylex.props(styles.container, styles.contentPadding, xstyle)}>
           {content}
         </div>,
         {

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -48,3 +48,7 @@ export type {
 
 export {XDSTooltip} from './XDSTooltip';
 export type {XDSTooltipProps} from './XDSTooltip';
+
+// Popover component
+export {XDSPopover} from './XDSPopover';
+export type {XDSPopoverProps, XDSPopoverTrigger} from './XDSPopover';

--- a/packages/core/src/Tokenizer/README.md
+++ b/packages/core/src/Tokenizer/README.md
@@ -1,0 +1,71 @@
+# /packages/core/src/Tokenizer
+
+Multi-select typeahead with token chips for selected items.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Overview
+
+XDSTokenizer combines XDSBaseTypeahead (search) with XDSToken (chips) for multi-item selection. It supports:
+
+- **Token chips** for each selected item with remove buttons
+- **Filtered search** that excludes already-selected items
+- **Max entries** to limit selections
+- **Clear all** button for bulk removal
+- **Custom token and item rendering**
+- **Backspace to remove** the last token
+
+## Import
+
+```tsx
+import {XDSTokenizer} from '@xds/core/Tokenizer';
+```
+
+## Usage
+
+```tsx
+const source = {
+  search: query => users.filter(u => u.label.includes(query)),
+  bootstrap: () => users.slice(0, 5),
+};
+
+<XDSTokenizer
+  label="Team Members"
+  searchSource={source}
+  value={selected}
+  onChange={(items, change) => {
+    setSelected(items);
+    // change.type is 'add' | 'remove' | 'reorder'
+  }}
+  placeholder="Search people..."
+  hasClear
+  maxEntries={10}
+/>;
+```
+
+## Key Props
+
+| Prop           | Type                            | Default  | Description                             |
+| -------------- | ------------------------------- | -------- | --------------------------------------- |
+| `label`        | `string`                        | required | Accessible label                        |
+| `searchSource` | `XDSSearchSource`               | required | Data source                             |
+| `value`        | `T[]`                           | required | Selected items                          |
+| `onChange`     | `(items, change) => void`       | required | Selection callback with change metadata |
+| `maxEntries`   | `number`                        | —        | Max number of selections                |
+| `hasClear`     | `boolean`                       | `false`  | Show "Clear all" button                 |
+| `renderToken`  | `(item, onRemove) => ReactNode` | —        | Custom token renderer                   |
+| `renderItem`   | `(item) => ReactNode`           | —        | Custom dropdown item renderer           |
+| `placeholder`  | `string`                        | —        | Input placeholder                       |
+| `isDisabled`   | `boolean`                       | `false`  | Disable input and tokens                |
+| `status`       | `XDSInputStatus`                | —        | Validation status                       |
+
+## Change Metadata
+
+The `onChange` callback receives a second argument describing what changed:
+
+```tsx
+type XDSTokenizerChange<T> =
+  | {item: T; type: 'add'}
+  | {item: T; type: 'remove'}
+  | {type: 'reorder'};
+```

--- a/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
@@ -1,0 +1,268 @@
+/**
+ * @file XDSTokenizer.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSTokenizer
+ * @output Unit tests for XDSTokenizer component
+ * @position Testing; validates XDSTokenizer.tsx
+ *
+ * SYNC: When XDSTokenizer.tsx changes, update tests to match
+ */
+
+import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {XDSTokenizer} from './XDSTokenizer';
+import type {XDSSearchSource, XDSSearchableItem} from '../Typeahead/types';
+
+// Store original matches to restore later
+const originalMatches = HTMLElement.prototype.matches;
+
+// Track popover open state per element
+const popoverOpenState = new WeakMap<HTMLElement, boolean>();
+
+// Mock Popover API for jsdom
+beforeAll(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, true);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, false);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+
+  HTMLElement.prototype.matches = function (selector: string) {
+    if (selector === ':popover-open') {
+      return popoverOpenState.get(this) ?? false;
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterAll(() => {
+  HTMLElement.prototype.matches = originalMatches;
+});
+
+// Test data
+const users: XDSSearchableItem[] = [
+  {id: '1', label: 'Alice'},
+  {id: '2', label: 'Bob'},
+  {id: '3', label: 'Charlie'},
+  {id: '4', label: 'Diana'},
+];
+
+const userSource: XDSSearchSource = {
+  search: (query: string) =>
+    users.filter(u => u.label.toLowerCase().includes(query.toLowerCase())),
+  bootstrap: () => users.slice(0, 3),
+};
+
+describe('XDSTokenizer', () => {
+  it('renders with label', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    // Label is rendered by XDSField
+    expect(screen.getByText('Members')).toBeInTheDocument();
+  });
+
+  it('renders combobox input', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders placeholder when no tokens', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+        placeholder="Search people..."
+      />,
+    );
+    expect(screen.getByPlaceholderText('Search people...')).toBeInTheDocument();
+  });
+
+  it('renders tokens for selected items', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[users[0], users[1]]}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('renders remove buttons on tokens', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[users[0]]}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('button', {name: 'Remove Alice'}),
+    ).toBeInTheDocument();
+  });
+
+  it('calls onChange with remove when token is removed', () => {
+    const onChange = vi.fn();
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[users[0], users[1]]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Remove Alice'}));
+    expect(onChange).toHaveBeenCalledWith([users[1]], {
+      item: users[0],
+      type: 'remove',
+    });
+  });
+
+  it('hides input when maxEntries is reached', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[users[0], users[1]]}
+        onChange={() => {}}
+        maxEntries={2}
+      />,
+    );
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+  });
+
+  it('shows input when under maxEntries', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[users[0]]}
+        onChange={() => {}}
+        maxEntries={2}
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('shows clear all button when hasClear is true', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[users[0]]}
+        onChange={() => {}}
+        hasClear
+      />,
+    );
+    expect(screen.getByRole('button', {name: 'Clear all'})).toBeInTheDocument();
+  });
+
+  it('does not show clear all when no tokens', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+        hasClear
+      />,
+    );
+    expect(
+      screen.queryByRole('button', {name: 'Clear all'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders description text', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        description="Select team members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Select team members')).toBeInTheDocument();
+  });
+
+  it('renders error status', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+        status={{type: 'error', message: 'At least one member required'}}
+      />,
+    );
+    expect(
+      screen.getByText('At least one member required'),
+    ).toBeInTheDocument();
+  });
+
+  it('disables tokens and input when isDisabled', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[users[0]]}
+        onChange={() => {}}
+        isDisabled
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeDisabled();
+    // Remove button should not be present when disabled
+    expect(
+      screen.queryByRole('button', {name: 'Remove Alice'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders with data-testid', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+        data-testid="my-tokenizer"
+      />,
+    );
+    expect(screen.getByTestId('my-tokenizer')).toBeInTheDocument();
+  });
+
+  it('renders group with aria-label', () => {
+    render(
+      <XDSTokenizer
+        label="Members"
+        searchSource={userSource}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('group')).toHaveAttribute('aria-label', 'Members');
+  });
+});

--- a/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
@@ -142,7 +142,7 @@ describe('XDSTokenizer', () => {
     });
   });
 
-  it('hides input when maxEntries is reached', () => {
+  it('visually hides input when maxEntries is reached but preserves it for keyboard access', () => {
     render(
       <XDSTokenizer
         label="Members"
@@ -152,7 +152,10 @@ describe('XDSTokenizer', () => {
         maxEntries={2}
       />,
     );
-    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    // Input stays in the DOM for keyboard accessibility (backspace to remove)
+    // but is visually hidden
+    const input = screen.getByRole('combobox');
+    expect(input).toBeInTheDocument();
   });
 
   it('shows input when under maxEntries', () => {

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -170,6 +170,73 @@ const styles = stylex.create({
   sizeMd: {
     minHeight: sizeVars['--size-md'],
   },
+  inputAtMax: {
+    width: 0,
+    minWidth: 0,
+    flex: '0 0 0',
+    padding: 0,
+    opacity: 0,
+    position: 'absolute',
+  },
+  inputCompact: {
+    minWidth: '40px',
+    flex: '0 1 auto',
+    width: '40px',
+  },
+});
+
+const statusBorderStyles = stylex.create({
+  warning: {
+    borderColor: colorVars['--color-warning'],
+  },
+  error: {
+    borderColor: colorVars['--color-negative'],
+  },
+  success: {
+    borderColor: colorVars['--color-positive'],
+  },
+});
+
+const statusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-warning'],
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-error'],
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-success'],
+    },
+  },
+});
+
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
 });
 
 // =============================================================================
@@ -267,6 +334,14 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
       },
     }),
     [searchSource, selectedIds],
+  );
+
+  const emptySource: XDSSearchSource<T> = useMemo(
+    () => ({
+      search: async () => [],
+      bootstrap: async () => [],
+    }),
+    [],
   );
 
   // Handle adding an item
@@ -384,33 +459,43 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
           styles.wrapper,
           sizeStyle,
           isDisabled && styles.wrapperDisabled,
+          status && statusBorderStyles[status.type],
+          status && statusHoverShadowStyles[status.type],
+          status && statusFocusStyles[status.type],
           xstyle,
         )}>
         {tokens.length > 0 && (
           <div {...stylex.props(styles.tokenContainer)}>{tokens}</div>
         )}
-        {!isAtMax && (
-          <XDSBaseTypeahead
-            ref={inputRef}
-            searchSource={filteredSource}
-            value={null}
-            onChange={handleAdd}
-            renderItem={renderItem}
-            placeholder={value.length === 0 ? placeholder : undefined}
-            hasEntriesOnFocus={hasEntriesOnFocus}
-            maxMenuItems={maxMenuItems}
-            emptySearchResultsText={emptySearchResultsText}
-            isDisabled={isDisabled}
-            hasClear={false}
-            hasAutoFocus={hasAutoFocus}
-            size={size}
-            inputId={inputId}
-            ariaDescribedBy={ariaDescribedBy}
-            onChangeQuery={onChangeQuery}
-            onKeyDown={handleKeyDown}
-            isEmbedded
-          />
-        )}
+        <XDSBaseTypeahead
+          ref={inputRef}
+          searchSource={isAtMax ? emptySource : filteredSource}
+          value={null}
+          onChange={handleAdd}
+          renderItem={renderItem}
+          placeholder={
+            value.length === 0 ? placeholder : isAtMax ? '' : undefined
+          }
+          hasEntriesOnFocus={isAtMax ? false : hasEntriesOnFocus}
+          maxMenuItems={maxMenuItems}
+          emptySearchResultsText={emptySearchResultsText}
+          isDisabled={isDisabled}
+          hasClear={false}
+          hasAutoFocus={hasAutoFocus}
+          size={size}
+          inputId={inputId}
+          ariaDescribedBy={ariaDescribedBy}
+          onChangeQuery={onChangeQuery}
+          onKeyDown={handleKeyDown}
+          inputXstyle={
+            isAtMax
+              ? styles.inputAtMax
+              : value.length > 0
+                ? styles.inputCompact
+                : undefined
+          }
+          isEmbedded
+        />
         {hasClear && value.length > 0 && !isDisabled && (
           <button
             type="button"

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -1,0 +1,431 @@
+/**
+ * @file XDSTokenizer.tsx
+ * @input Uses React, XDSBaseTypeahead, XDSField, XDSToken
+ * @output Exports XDSTokenizer multi-select typeahead component
+ * @position Composed component; uses XDSBaseTypeahead for search + XDSToken for chips
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Tokenizer/README.md
+ * - /packages/core/src/Tokenizer/index.ts
+ * - /apps/storybook/stories/Tokenizer.stories.tsx
+ */
+
+import React, {
+  useCallback,
+  useId,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {XDSBaseTypeahead} from '../Typeahead/XDSBaseTypeahead';
+import {XDSField, type XDSInputStatus} from '../Field';
+import {XDSToken} from '../Token';
+import {XDSIcon} from '../Icon';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  sizeVars,
+  transitionVars,
+  elevationVars,
+} from '../theme/tokens.stylex';
+import type {XDSSearchableItem, XDSSearchSource} from '../Typeahead/types';
+
+// Re-export status types for convenience
+export type {
+  XDSInputStatus as XDSTokenizerStatus,
+  XDSInputStatusType as XDSTokenizerStatusType,
+} from '../Field';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Change metadata for onChange callback.
+ */
+export type XDSTokenizerChange<T extends XDSSearchableItem> =
+  | {item: T; type: 'add'}
+  | {item: T; type: 'remove'}
+  | {type: 'reorder'};
+
+export interface XDSTokenizerProps<T extends XDSSearchableItem> {
+  /** Accessible label (required). */
+  label: string;
+  /** Visually hide the label. @default false */
+  isLabelHidden?: boolean;
+  /** Helper text. */
+  description?: string;
+  /** Required field. @default false */
+  isRequired?: boolean;
+  /** Optional field. @default false */
+  isOptional?: boolean;
+  /** Validation status. */
+  status?: XDSInputStatus;
+  /** Label tooltip. */
+  labelTooltip?: string;
+  /** Search source providing items. */
+  searchSource: XDSSearchSource<T>;
+  /** Currently selected items. */
+  value: T[];
+  /** Callback when selection changes. Includes change metadata. */
+  onChange: (items: T[], change: XDSTokenizerChange<T>) => void;
+  /** Render function for dropdown items. Default: XDSTypeaheadItem. */
+  renderItem?: (item: T) => ReactNode;
+  /** Render function for selected tokens. Default: XDSToken with label + onRemove. */
+  renderToken?: (item: T, onRemove: () => void) => ReactNode;
+  /** Max number of selections. */
+  maxEntries?: number;
+  /** Placeholder text (shown when no tokens selected). */
+  placeholder?: string;
+  /** Show results on focus before typing. @default false */
+  hasEntriesOnFocus?: boolean;
+  /** Max dropdown items. @default 10 */
+  maxMenuItems?: number;
+  /** Text shown when no results found. @default 'No results found' */
+  emptySearchResultsText?: string;
+  /** Whether the input is disabled. @default false */
+  isDisabled?: boolean;
+  /** Show clear button (clears all tokens). @default false */
+  hasClear?: boolean;
+  /** Auto-focus on mount. @default false */
+  hasAutoFocus?: boolean;
+  /** Input size. @default 'md' */
+  size?: 'sm' | 'md';
+  /** Query change callback. */
+  onChangeQuery?: (query: string) => void;
+  /** StyleX overrides. */
+  xstyle?: StyleXStyles;
+  /** Test ID. */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  wrapper: {
+    boxSizing: 'border-box',
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacingVars['--spacing-1'],
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: {
+      default: colorVars['--color-divider-emphasized'],
+      ':hover': colorVars['--color-divider-high-contrast'],
+    },
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-surface'],
+    transitionProperty: 'border-color, outline, box-shadow',
+    transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover'],
+    },
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: '0',
+    cursor: 'text',
+  },
+  wrapperDisabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+    borderColor: colorVars['--color-divider-emphasized'],
+  },
+  tokenContainer: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: spacingVars['--spacing-1'],
+    alignItems: 'center',
+  },
+  clearAllButton: {
+    all: 'unset',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    padding: spacingVars['--spacing-1'],
+    borderRadius: radiusVars['--radius-rounded'],
+    color: colorVars['--color-text-secondary'],
+    opacity: {
+      default: 0.7,
+      ':hover': 1,
+    },
+    marginInlineStart: 'auto',
+    flexShrink: 0,
+  },
+  sizeSm: {
+    minHeight: sizeVars['--size-sm'],
+  },
+  sizeMd: {
+    minHeight: sizeVars['--size-md'],
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Multi-select input with token chips and typeahead search.
+ *
+ * Composes XDSBaseTypeahead for search and XDSToken for selected items.
+ * Tokens render inline before the text input. Selecting an item adds a token
+ * and clears the query. Backspace on empty input removes the last token.
+ *
+ * @example
+ * ```tsx
+ * // Basic
+ * const [members, setMembers] = useState<UserItem[]>([]);
+ *
+ * <XDSTokenizer
+ *   label="Team members"
+ *   searchSource={userSource}
+ *   value={members}
+ *   onChange={(items, change) => {
+ *     setMembers(items);
+ *     if (change.type === 'add') console.log('Added:', change.item.label);
+ *   }}
+ *   placeholder="Search people..."
+ * />
+ *
+ * // Custom rendering
+ * <XDSTokenizer
+ *   label="Tags"
+ *   searchSource={tagSource}
+ *   value={tags}
+ *   onChange={(items) => setTags(items)}
+ *   renderToken={(item, onRemove) => (
+ *     <XDSToken
+ *       label={item.label}
+ *       color={item.auxiliaryData.color}
+ *       onRemove={onRemove}
+ *     />
+ *   )}
+ *   maxEntries={5}
+ * />
+ * ```
+ */
+export function XDSTokenizer<T extends XDSSearchableItem>({
+  label,
+  isLabelHidden = false,
+  description,
+  isRequired = false,
+  isOptional = false,
+  status,
+  labelTooltip,
+  searchSource,
+  value,
+  onChange,
+  renderItem,
+  renderToken,
+  maxEntries,
+  placeholder,
+  hasEntriesOnFocus,
+  maxMenuItems,
+  emptySearchResultsText,
+  isDisabled = false,
+  hasClear = false,
+  hasAutoFocus,
+  size = 'md',
+  onChangeQuery,
+  xstyle,
+  'data-testid': testId,
+}: XDSTokenizerProps<T>) {
+  const inputId = useId();
+  const descriptionId = useId();
+  const statusMessageId = useId();
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const isAtMax = maxEntries != null && value.length >= maxEntries;
+
+  // Filter out already-selected items from search results
+  const selectedIds = useMemo(
+    () => new Set(value.map(item => item.id)),
+    [value],
+  );
+
+  const filteredSource: XDSSearchSource<T> = useMemo(
+    () => ({
+      search: async (query: string) => {
+        const results = await searchSource.search(query);
+        return results.filter(item => !selectedIds.has(item.id));
+      },
+      bootstrap: async () => {
+        const results = await searchSource.bootstrap();
+        return results.filter(item => !selectedIds.has(item.id));
+      },
+    }),
+    [searchSource, selectedIds],
+  );
+
+  // Handle adding an item
+  const handleAdd = useCallback(
+    (item: T | null) => {
+      if (!item) return;
+      if (isAtMax) return;
+      if (selectedIds.has(item.id)) return;
+
+      const newItems = [...value, item];
+      onChange(newItems, {item, type: 'add'});
+    },
+    [value, onChange, isAtMax, selectedIds],
+  );
+
+  // Handle removing an item
+  const handleRemove = useCallback(
+    (item: T) => {
+      const newItems = value.filter(v => v.id !== item.id);
+      onChange(newItems, {item, type: 'remove'});
+      inputRef.current?.focus();
+    },
+    [value, onChange],
+  );
+
+  // Handle clearing all items
+  const handleClearAll = useCallback(() => {
+    if (value.length === 0) return;
+    // Report the last item as removed (convention)
+    const lastItem = value[value.length - 1];
+    onChange([], {item: lastItem, type: 'remove'});
+    inputRef.current?.focus();
+  }, [value, onChange]);
+
+  // Handle backspace on empty input — remove last token
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (
+        e.key === 'Backspace' &&
+        e.currentTarget.value === '' &&
+        value.length > 0
+      ) {
+        e.preventDefault();
+        const lastItem = value[value.length - 1];
+        handleRemove(lastItem);
+      }
+    },
+    [value, handleRemove],
+  );
+
+  // Click wrapper to focus input
+  const handleWrapperClick = useCallback(() => {
+    if (!isDisabled) {
+      inputRef.current?.focus();
+    }
+  }, [isDisabled]);
+
+  const ariaDescribedBy =
+    [
+      description ? descriptionId : null,
+      status?.message ? statusMessageId : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  const sizeStyle = size === 'sm' ? styles.sizeSm : styles.sizeMd;
+
+  // Render tokens
+  const tokens = value.map(item => {
+    const onRemoveItem = () => handleRemove(item);
+
+    if (renderToken) {
+      return (
+        <React.Fragment key={item.id}>
+          {renderToken(item, onRemoveItem)}
+        </React.Fragment>
+      );
+    }
+
+    return (
+      <XDSToken
+        key={item.id}
+        label={item.label}
+        onRemove={isDisabled ? undefined : onRemoveItem}
+        isDisabled={isDisabled}
+      />
+    );
+  });
+
+  return (
+    <XDSField
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={inputId}
+      descriptionID={description ? descriptionId : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageId : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}>
+      <div
+        role="group"
+        aria-label={label}
+        onClick={handleWrapperClick}
+        data-testid={testId}
+        {...stylex.props(
+          styles.wrapper,
+          sizeStyle,
+          isDisabled && styles.wrapperDisabled,
+          xstyle,
+        )}>
+        {tokens.length > 0 && (
+          <div {...stylex.props(styles.tokenContainer)}>{tokens}</div>
+        )}
+        {!isAtMax && (
+          <XDSBaseTypeahead
+            ref={inputRef}
+            searchSource={filteredSource}
+            value={null}
+            onChange={handleAdd}
+            renderItem={renderItem}
+            placeholder={value.length === 0 ? placeholder : undefined}
+            hasEntriesOnFocus={hasEntriesOnFocus}
+            maxMenuItems={maxMenuItems}
+            emptySearchResultsText={emptySearchResultsText}
+            isDisabled={isDisabled}
+            hasClear={false}
+            hasAutoFocus={hasAutoFocus}
+            size={size}
+            inputId={inputId}
+            ariaDescribedBy={ariaDescribedBy}
+            onChangeQuery={onChangeQuery}
+            onKeyDown={handleKeyDown}
+            isEmbedded
+          />
+        )}
+        {hasClear && value.length > 0 && !isDisabled && (
+          <button
+            type="button"
+            aria-label="Clear all"
+            onClick={e => {
+              e.stopPropagation();
+              handleClearAll();
+            }}
+            {...stylex.props(styles.clearAllButton)}>
+            <XDSIcon icon="close" size="sm" />
+          </button>
+        )}
+      </div>
+    </XDSField>
+  );
+}
+
+XDSTokenizer.displayName = 'XDSTokenizer';

--- a/packages/core/src/Tokenizer/index.ts
+++ b/packages/core/src/Tokenizer/index.ts
@@ -1,0 +1,16 @@
+/**
+ * @file index.ts
+ * @input Tokenizer component
+ * @output Exports all Tokenizer module public API
+ * @position Entry point for Tokenizer module
+ *
+ * SYNC: When adding new Tokenizer files, update exports here
+ */
+
+export {XDSTokenizer} from './XDSTokenizer';
+export type {
+  XDSTokenizerProps,
+  XDSTokenizerChange,
+  XDSTokenizerStatus,
+  XDSTokenizerStatusType,
+} from './XDSTokenizer';

--- a/packages/core/src/Typeahead/README.md
+++ b/packages/core/src/Typeahead/README.md
@@ -1,0 +1,80 @@
+# /packages/core/src/Typeahead
+
+Searchable dropdown components for single-item selection with keyboard navigation.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Overview
+
+The Typeahead module provides a search-as-you-type dropdown for selecting items from a data source. It supports:
+
+- **Async and sync search** via a `searchSource` interface
+- **Keyboard navigation** (arrow keys, Enter, Escape)
+- **Bootstrap results** shown on focus before typing
+- **Custom item rendering** for rich dropdown content
+- **Combobox ARIA pattern** for full accessibility
+
+## Import
+
+```tsx
+import {XDSTypeahead} from '@xds/core/Typeahead';
+```
+
+## Components
+
+### XDSTypeahead
+
+Styled typeahead with label, description, validation, and all field features. This is the primary component for most use cases.
+
+```tsx
+const source = {
+  search: query => fruits.filter(f => f.label.includes(query)),
+  bootstrap: () => fruits.slice(0, 5),
+};
+
+<XDSTypeahead
+  label="Fruit"
+  searchSource={source}
+  value={selected}
+  onChange={setSelected}
+  placeholder="Search fruits..."
+/>;
+```
+
+### XDSBaseTypeahead
+
+Unstyled typeahead for custom compositions (used by XDSTypeahead and XDSTokenizer). Provides the combobox input, dropdown, and keyboard handling without any field chrome.
+
+### XDSTypeaheadItem
+
+Default dropdown item renderer. Shows label with optional icon, secondary text, and avatar.
+
+## Search Source Interface
+
+```tsx
+type XDSSearchSource<T> = {
+  search: (query: string) => T[] | Promise<T[]>;
+  bootstrap?: () => T[] | Promise<T[]>;
+};
+
+type XDSSearchableItem = {
+  id: string;
+  label: string;
+  [key: string]: unknown;
+};
+```
+
+## Key Props
+
+| Prop                | Type                        | Default  | Description                     |
+| ------------------- | --------------------------- | -------- | ------------------------------- |
+| `label`             | `string`                    | required | Accessible label                |
+| `searchSource`      | `XDSSearchSource`           | required | Data source                     |
+| `value`             | `T \| null`                 | required | Selected item                   |
+| `onChange`          | `(item: T \| null) => void` | required | Selection callback              |
+| `placeholder`       | `string`                    | —        | Input placeholder               |
+| `hasEntriesOnFocus` | `boolean`                   | `false`  | Show bootstrap results on focus |
+| `hasClear`          | `boolean`                   | `true`   | Show clear button               |
+| `isDisabled`        | `boolean`                   | `false`  | Disable input                   |
+| `maxMenuItems`      | `number`                    | `10`     | Max dropdown items              |
+| `status`            | `XDSInputStatus`            | —        | Validation status               |

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -26,6 +26,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {useXDSLayer} from '../Layer/useXDSLayer';
 import {XDSTypeaheadItem} from './XDSTypeaheadItem';
 import {XDSIcon} from '../Icon';
+import {XDSToken} from '../Token';
 import {
   colorVars,
   spacingVars,
@@ -33,6 +34,7 @@ import {
   textSizeVars,
   lineHeightVars,
   typographyVars,
+  fontWeightVars,
   sizeVars,
   transitionVars,
   elevationVars,
@@ -165,6 +167,11 @@ export interface XDSBaseTypeaheadProps<T extends XDSSearchableItem> {
   onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
 
   /**
+   * Validation status type for border styling.
+   */
+  statusType?: 'warning' | 'error' | 'success';
+
+  /**
    * Test ID.
    */
   'data-testid'?: string;
@@ -237,6 +244,9 @@ const styles = stylex.create({
   inputDisabled: {
     cursor: 'not-allowed',
   },
+  inputUnselected: {
+    color: colorVars['--color-text-secondary'],
+  },
   dropdown: {
     boxSizing: 'border-box',
     maxHeight: '300px',
@@ -274,7 +284,12 @@ const styles = stylex.create({
     cursor: 'not-allowed',
   },
   itemSelected: {
-    backgroundColor: colorVars['--color-deemphasized'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+  },
+  itemContent: {
+    display: 'flex',
+    flex: 1,
+    minWidth: 0,
   },
   emptyState: {
     padding: spacingVars['--spacing-3'],
@@ -307,6 +322,60 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     padding: spacingVars['--spacing-1'],
+  },
+});
+
+const statusBorderStyles = stylex.create({
+  warning: {
+    borderColor: colorVars['--color-warning'],
+  },
+  error: {
+    borderColor: colorVars['--color-negative'],
+  },
+  success: {
+    borderColor: colorVars['--color-positive'],
+  },
+});
+
+const statusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-warning'],
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-error'],
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover-success'],
+    },
+  },
+});
+
+const statusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
   },
 });
 
@@ -355,6 +424,7 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
     startContent,
     isEmbedded = false,
     onKeyDown: externalOnKeyDown,
+    statusType,
     'data-testid': testId,
   }: XDSBaseTypeaheadProps<T>,
   ref: React.ForwardedRef<HTMLInputElement>,
@@ -371,6 +441,7 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
   const [highlightedIndex, setHighlightedIndex] = useState(-1);
   const [isLoading, setIsLoading] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
 
   // Debounce ref
   const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -383,6 +454,7 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
     onHide: () => {
       onOpenChange?.(false);
       setHighlightedIndex(-1);
+      setIsEditing(false);
     },
   });
 
@@ -481,6 +553,7 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
   // Handle input change
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
+      setIsEditing(true);
       handleQueryChange(e.target.value);
     },
     [handleQueryChange],
@@ -489,6 +562,7 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
   // Handle item selection
   const handleSelect = useCallback(
     (item: T) => {
+      setIsEditing(false);
       onChange(item);
       setQuery('');
       setResults([]);
@@ -500,6 +574,7 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
 
   // Handle clear
   const handleClear = useCallback(() => {
+    setIsEditing(false);
     onChange(null);
     setQuery('');
     setResults([]);
@@ -608,8 +683,9 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
     };
   }, []);
 
-  // Display value: show selected item label when not actively searching
-  const displayValue = query || (value && !layer.isOpen ? value.label : '');
+  // Display value: when editing show query, when value selected show token instead,
+  // otherwise show query (which may be empty)
+  const displayValue = isEditing ? query : value ? '' : query;
 
   const sizeStyle = size === 'sm' ? styles.sizeSmWrapper : styles.sizeMdWrapper;
 
@@ -623,9 +699,19 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
           !isEmbedded && sizeStyle,
           isDisabled && styles.wrapperDisabled,
           isEmbedded && styles.wrapperEmbedded,
+          !isEmbedded && statusType && statusBorderStyles[statusType],
+          !isEmbedded && statusType && statusHoverShadowStyles[statusType],
+          !isEmbedded && statusType && statusFocusStyles[statusType],
           wrapperXstyle,
         )}>
         {startContent}
+        {value && !isEditing && (
+          <XDSToken
+            label={value.label}
+            onRemove={hasClear && !isDisabled ? handleClear : undefined}
+            isDisabled={isDisabled}
+          />
+        )}
         <input
           ref={setInputRef}
           id={inputId}
@@ -651,6 +737,7 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
           {...stylex.props(
             styles.input,
             isDisabled && styles.inputDisabled,
+            isEditing && query.length > 0 && !value && styles.inputUnselected,
             inputXstyle,
           )}
         />
@@ -662,7 +749,7 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
             <XDSIcon icon="clock" size="sm" color="secondary" />
           </span>
         )}
-        {hasClear && value && !isDisabled && (
+        {hasClear && value && !isDisabled && isEditing && (
           <button
             type="button"
             aria-label="Clear selection"
@@ -698,10 +785,15 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
                   index === highlightedIndex && styles.itemHighlighted,
                   value?.id === item.id && styles.itemSelected,
                 )}>
-                {renderItem ? (
-                  renderItem(item)
-                ) : (
-                  <XDSTypeaheadItem item={item} />
+                <span {...stylex.props(styles.itemContent)}>
+                  {renderItem ? (
+                    renderItem(item)
+                  ) : (
+                    <XDSTypeaheadItem item={item} />
+                  )}
+                </span>
+                {value?.id === item.id && (
+                  <XDSIcon icon="check" size="sm" color="accent" />
                 )}
               </div>
             ))

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -1,0 +1,722 @@
+/**
+ * @file XDSBaseTypeahead.tsx
+ * @input Uses React, StyleX, useXDSLayer, XDSTypeaheadItem
+ * @output Exports XDSBaseTypeahead unstyled typeahead component
+ * @position Core implementation; used by XDSTypeahead and XDSTokenizer
+ *
+ * Handles search, keyboard navigation, selection, and dropdown positioning.
+ * No field wrapper, no styling — just the combobox behavior.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Typeahead/README.md
+ * - /packages/core/src/Typeahead/index.ts
+ */
+
+import React, {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {useXDSLayer} from '../Layer/useXDSLayer';
+import {XDSTypeaheadItem} from './XDSTypeaheadItem';
+import {XDSIcon} from '../Icon';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  textSizeVars,
+  lineHeightVars,
+  typographyVars,
+  sizeVars,
+  transitionVars,
+  elevationVars,
+} from '../theme/tokens.stylex';
+import type {XDSSearchableItem, XDSSearchSource} from './types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface XDSBaseTypeaheadProps<T extends XDSSearchableItem> {
+  /**
+   * Search source providing items.
+   */
+  searchSource: XDSSearchSource<T>;
+
+  /**
+   * Currently selected item (null = nothing selected).
+   */
+  value: T | null;
+
+  /**
+   * Callback when selection changes.
+   */
+  onChange: (item: T | null) => void;
+
+  /**
+   * Render function for dropdown items. Default: XDSTypeaheadItem.
+   */
+  renderItem?: (item: T) => ReactNode;
+
+  /**
+   * Placeholder text.
+   */
+  placeholder?: string;
+
+  /**
+   * Show results on focus before typing.
+   * @default false
+   */
+  hasEntriesOnFocus?: boolean;
+
+  /**
+   * Max dropdown items to display.
+   * @default 10
+   */
+  maxMenuItems?: number;
+
+  /**
+   * Text shown when no results found.
+   * @default 'No results found'
+   */
+  emptySearchResultsText?: string;
+
+  /**
+   * Whether the input is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Show clear button when a value is selected.
+   * @default true
+   */
+  hasClear?: boolean;
+
+  /**
+   * Auto-focus on mount.
+   * @default false
+   */
+  hasAutoFocus?: boolean;
+
+  /**
+   * Query change callback (for logging/external use).
+   */
+  onChangeQuery?: (query: string) => void;
+
+  /**
+   * Callback when dropdown opens/closes.
+   */
+  onOpenChange?: (isOpen: boolean) => void;
+
+  /**
+   * The size of the input.
+   * @default 'md'
+   */
+  size?: 'sm' | 'md';
+
+  /**
+   * Start icon for the input.
+   */
+  startIcon?: React.ComponentType<{className?: string}>;
+
+  /**
+   * ID for the input element (for label association).
+   */
+  inputId?: string;
+
+  /**
+   * Additional aria-describedby IDs.
+   */
+  ariaDescribedBy?: string;
+
+  /**
+   * Additional StyleX styles for the input wrapper.
+   */
+  wrapperXstyle?: StyleXStyles;
+
+  /**
+   * Additional StyleX styles for the input element.
+   */
+  inputXstyle?: StyleXStyles;
+
+  /**
+   * Content rendered before the input (e.g., tokens in Tokenizer).
+   */
+  startContent?: ReactNode;
+
+  /**
+   * Whether the input should visually appear as part of a group.
+   * When true, some wrapper styles are suppressed.
+   * @default false
+   */
+  isEmbedded?: boolean;
+
+  /**
+   * Additional keydown handler called before internal keyboard navigation.
+   * If the handler calls `e.preventDefault()`, internal handling is skipped.
+   */
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
+
+  /**
+   * Test ID.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  wrapper: {
+    boxSizing: 'border-box',
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    gap: spacingVars['--spacing-1'],
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: {
+      default: colorVars['--color-divider-emphasized'],
+      ':hover': colorVars['--color-divider-high-contrast'],
+    },
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-surface'],
+    transitionProperty: 'border-color, outline, box-shadow',
+    transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': elevationVars['--elevation-input-hover'],
+    },
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: '0',
+  },
+  wrapperDisabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+    borderColor: colorVars['--color-divider-emphasized'],
+  },
+  wrapperEmbedded: {
+    borderWidth: 0,
+    borderStyle: 'none',
+    padding: 0,
+    backgroundColor: 'transparent',
+    boxShadow: 'none',
+    outline: 'none',
+  },
+  input: {
+    display: 'block',
+    flex: 1,
+    minWidth: '60px',
+    borderWidth: 0,
+    borderStyle: 'none',
+    padding: 0,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-primary'],
+    backgroundColor: 'transparent',
+    outline: 'none',
+    '::placeholder': {
+      color: colorVars['--color-text-placeholder'],
+    },
+  },
+  inputDisabled: {
+    cursor: 'not-allowed',
+  },
+  dropdown: {
+    boxSizing: 'border-box',
+    maxHeight: '300px',
+    overflowY: 'auto',
+    padding: spacingVars['--spacing-1'],
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-surface'],
+    boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
+  },
+  popover: {
+    minWidth: 'anchor-size(width)',
+  },
+  popoverGap: {
+    marginBlockStart: spacingVars['--spacing-1'],
+    marginBlockEnd: spacingVars['--spacing-1'],
+  },
+  item: {
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    padding: spacingVars['--spacing-2'],
+    borderRadius: radiusVars['--radius-content'],
+    cursor: 'pointer',
+    outline: 'none',
+    backgroundColor: 'transparent',
+    border: 'none',
+    textAlign: 'left',
+  },
+  itemHighlighted: {
+    backgroundColor: colorVars['--color-hover-overlay'],
+  },
+  itemDisabled: {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  },
+  itemSelected: {
+    backgroundColor: colorVars['--color-deemphasized'],
+  },
+  emptyState: {
+    padding: spacingVars['--spacing-3'],
+    textAlign: 'center',
+    fontSize: textSizeVars['--text-sm'],
+    color: colorVars['--color-text-secondary'],
+  },
+  clearButton: {
+    all: 'unset',
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    padding: spacingVars['--spacing-1'],
+    borderRadius: radiusVars['--radius-rounded'],
+    color: colorVars['--color-text-secondary'],
+    opacity: {
+      default: 0.7,
+      ':hover': 1,
+    },
+  },
+  sizeSmWrapper: {
+    minHeight: sizeVars['--size-sm'],
+  },
+  sizeMdWrapper: {
+    minHeight: sizeVars['--size-md'],
+  },
+  loadingSpinner: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacingVars['--spacing-1'],
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Unstyled typeahead/combobox component.
+ *
+ * Handles search, keyboard navigation, selection, and dropdown positioning.
+ * Used internally by XDSTypeahead (styled) and XDSTokenizer (multi-select).
+ *
+ * @example
+ * ```tsx
+ * <XDSBaseTypeahead
+ *   searchSource={source}
+ *   value={selected}
+ *   onChange={setSelected}
+ *   placeholder="Search..."
+ * />
+ * ```
+ */
+export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
+  T extends XDSSearchableItem,
+>(
+  {
+    searchSource,
+    value,
+    onChange,
+    renderItem,
+    placeholder = 'Search...',
+    hasEntriesOnFocus = false,
+    maxMenuItems = 10,
+    emptySearchResultsText = 'No results found',
+    isDisabled = false,
+    hasClear = true,
+    hasAutoFocus = false,
+    onChangeQuery,
+    onOpenChange,
+    size = 'md',
+    inputId: externalInputId,
+    ariaDescribedBy,
+    wrapperXstyle,
+    inputXstyle,
+    startContent,
+    isEmbedded = false,
+    onKeyDown: externalOnKeyDown,
+    'data-testid': testId,
+  }: XDSBaseTypeaheadProps<T>,
+  ref: React.ForwardedRef<HTMLInputElement>,
+) {
+  const generatedId = useId();
+  const inputId = externalInputId ?? generatedId;
+  const listboxId = useId();
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<T[]>([]);
+  const [highlightedIndex, setHighlightedIndex] = useState(-1);
+  const [isLoading, setIsLoading] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+
+  // Debounce ref
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Layer for dropdown
+  const layer = useXDSLayer({
+    mode: 'context',
+    lightDismiss: true,
+    onShow: () => onOpenChange?.(true),
+    onHide: () => {
+      onOpenChange?.(false);
+      setHighlightedIndex(-1);
+    },
+  });
+
+  // Merge refs
+  const setInputRef = useCallback(
+    (el: HTMLInputElement | null) => {
+      (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+        el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLInputElement | null>).current = el;
+      }
+    },
+    [ref],
+  );
+
+  // Set up anchor on wrapper
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (el) {
+      layer.ref(el);
+    }
+    return () => {
+      layer.ref(null);
+    };
+  }, [layer]);
+
+  // Perform search
+  const performSearch = useCallback(
+    async (searchQuery: string) => {
+      setIsLoading(true);
+      setHasSearched(true);
+      try {
+        const searchResults = await searchSource.search(searchQuery);
+        setResults(searchResults.slice(0, maxMenuItems));
+        setHighlightedIndex(searchResults.length > 0 ? 0 : -1);
+        if (searchResults.length > 0 || searchQuery.length > 0) {
+          layer.show();
+        }
+      } catch {
+        setResults([]);
+        setHighlightedIndex(-1);
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [searchSource, maxMenuItems, layer],
+  );
+
+  // Perform bootstrap
+  const performBootstrap = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const bootstrapResults = await searchSource.bootstrap();
+      setResults(bootstrapResults.slice(0, maxMenuItems));
+      setHighlightedIndex(bootstrapResults.length > 0 ? 0 : -1);
+      if (bootstrapResults.length > 0) {
+        layer.show();
+      }
+    } catch {
+      setResults([]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [searchSource, maxMenuItems, layer]);
+
+  // Handle query change
+  const handleQueryChange = useCallback(
+    (newQuery: string) => {
+      setQuery(newQuery);
+      onChangeQuery?.(newQuery);
+
+      // Debounce search
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+
+      if (newQuery.length === 0 && !hasEntriesOnFocus) {
+        setResults([]);
+        layer.hide();
+        return;
+      }
+
+      searchTimeoutRef.current = setTimeout(() => {
+        if (newQuery.length > 0) {
+          performSearch(newQuery);
+        } else if (hasEntriesOnFocus) {
+          performBootstrap();
+        }
+      }, 150);
+    },
+    [onChangeQuery, hasEntriesOnFocus, performSearch, performBootstrap, layer],
+  );
+
+  // Handle input change
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      handleQueryChange(e.target.value);
+    },
+    [handleQueryChange],
+  );
+
+  // Handle item selection
+  const handleSelect = useCallback(
+    (item: T) => {
+      onChange(item);
+      setQuery('');
+      setResults([]);
+      layer.hide();
+      inputRef.current?.focus();
+    },
+    [onChange, layer],
+  );
+
+  // Handle clear
+  const handleClear = useCallback(() => {
+    onChange(null);
+    setQuery('');
+    setResults([]);
+    layer.hide();
+    inputRef.current?.focus();
+  }, [onChange, layer]);
+
+  // Handle focus
+  const handleFocus = useCallback(() => {
+    if (isDisabled) return;
+    if (hasEntriesOnFocus && results.length === 0 && query.length === 0) {
+      performBootstrap();
+    } else if (query.length > 0 && results.length > 0) {
+      layer.show();
+    }
+  }, [
+    isDisabled,
+    hasEntriesOnFocus,
+    results.length,
+    query.length,
+    performBootstrap,
+    layer,
+  ]);
+
+  // Keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      // Call external handler first
+      externalOnKeyDown?.(e);
+      if (e.defaultPrevented) return;
+
+      if (!layer.isOpen) {
+        if (e.key === 'ArrowDown' && (hasEntriesOnFocus || query.length > 0)) {
+          e.preventDefault();
+          if (results.length > 0) {
+            layer.show();
+            setHighlightedIndex(0);
+          } else if (hasEntriesOnFocus) {
+            performBootstrap();
+          }
+        }
+        return;
+      }
+
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex(prev =>
+            prev < results.length - 1 ? prev + 1 : 0,
+          );
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex(prev =>
+            prev > 0 ? prev - 1 : results.length - 1,
+          );
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (highlightedIndex >= 0 && highlightedIndex < results.length) {
+            handleSelect(results[highlightedIndex]);
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          layer.hide();
+          break;
+        case 'Home':
+          if (layer.isOpen) {
+            e.preventDefault();
+            setHighlightedIndex(0);
+          }
+          break;
+        case 'End':
+          if (layer.isOpen) {
+            e.preventDefault();
+            setHighlightedIndex(results.length - 1);
+          }
+          break;
+      }
+    },
+    [
+      layer,
+      results,
+      highlightedIndex,
+      handleSelect,
+      hasEntriesOnFocus,
+      query.length,
+      performBootstrap,
+      externalOnKeyDown,
+    ],
+  );
+
+  // Generate item ID for accessibility
+  const getItemId = useCallback(
+    (index: number) => `${listboxId}-option-${index}`,
+    [listboxId],
+  );
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (searchTimeoutRef.current) {
+        clearTimeout(searchTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  // Display value: show selected item label when not actively searching
+  const displayValue = query || (value && !layer.isOpen ? value.label : '');
+
+  const sizeStyle = size === 'sm' ? styles.sizeSmWrapper : styles.sizeMdWrapper;
+
+  return (
+    <>
+      <div
+        ref={wrapperRef}
+        data-testid={testId}
+        {...stylex.props(
+          !isEmbedded && styles.wrapper,
+          !isEmbedded && sizeStyle,
+          isDisabled && styles.wrapperDisabled,
+          isEmbedded && styles.wrapperEmbedded,
+          wrapperXstyle,
+        )}>
+        {startContent}
+        <input
+          ref={setInputRef}
+          id={inputId}
+          type="text"
+          role="combobox"
+          aria-expanded={layer.isOpen}
+          aria-controls={listboxId}
+          aria-activedescendant={
+            layer.isOpen && highlightedIndex >= 0
+              ? getItemId(highlightedIndex)
+              : undefined
+          }
+          aria-autocomplete="list"
+          aria-describedby={ariaDescribedBy}
+          value={displayValue}
+          onChange={handleInputChange}
+          onFocus={handleFocus}
+          onKeyDown={handleKeyDown}
+          placeholder={value ? undefined : placeholder}
+          disabled={isDisabled}
+          autoFocus={hasAutoFocus}
+          autoComplete="off"
+          {...stylex.props(
+            styles.input,
+            isDisabled && styles.inputDisabled,
+            inputXstyle,
+          )}
+        />
+        {isLoading && (
+          <span
+            role="status"
+            aria-label="Loading"
+            {...stylex.props(styles.loadingSpinner)}>
+            <XDSIcon icon="clock" size="sm" color="secondary" />
+          </span>
+        )}
+        {hasClear && value && !isDisabled && (
+          <button
+            type="button"
+            aria-label="Clear selection"
+            onClick={handleClear}
+            {...stylex.props(styles.clearButton)}>
+            <XDSIcon icon="close" size="sm" />
+          </button>
+        )}
+      </div>
+
+      {layer.render(
+        <div
+          id={listboxId}
+          role="listbox"
+          aria-label="Search results"
+          {...stylex.props(styles.dropdown)}>
+          {results.length === 0 && hasSearched ? (
+            <div {...stylex.props(styles.emptyState)}>
+              {emptySearchResultsText}
+            </div>
+          ) : (
+            results.map((item, index) => (
+              <div
+                key={item.id}
+                id={getItemId(index)}
+                role="option"
+                aria-selected={value?.id === item.id}
+                tabIndex={-1}
+                onClick={() => handleSelect(item)}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                {...stylex.props(
+                  styles.item,
+                  index === highlightedIndex && styles.itemHighlighted,
+                  value?.id === item.id && styles.itemSelected,
+                )}>
+                {renderItem ? (
+                  renderItem(item)
+                ) : (
+                  <XDSTypeaheadItem item={item} />
+                )}
+              </div>
+            ))
+          )}
+        </div>,
+        {
+          placement: 'below',
+          alignment: 'start',
+          xstyle: [styles.popover, styles.popoverGap],
+        },
+      )}
+    </>
+  );
+}) as <T extends XDSSearchableItem>(
+  props: XDSBaseTypeaheadProps<T> & {ref?: React.Ref<HTMLInputElement>},
+) => React.ReactElement;
+
+(XDSBaseTypeahead as {displayName?: string}).displayName = 'XDSBaseTypeahead';

--- a/packages/core/src/Typeahead/XDSTypeahead.test.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * @file XDSTypeahead.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSTypeahead, XDSBaseTypeahead
+ * @output Unit tests for Typeahead components
+ * @position Testing; validates XDSTypeahead.tsx and XDSBaseTypeahead.tsx
+ *
+ * SYNC: When Typeahead components change, update tests to match
+ */
+
+import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {XDSTypeahead} from './XDSTypeahead';
+import {XDSBaseTypeahead} from './XDSBaseTypeahead';
+import type {XDSSearchSource, XDSSearchableItem} from './types';
+
+// Store original matches to restore later
+const originalMatches = HTMLElement.prototype.matches;
+
+// Track popover open state per element
+const popoverOpenState = new WeakMap<HTMLElement, boolean>();
+
+// Mock Popover API for jsdom
+beforeAll(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, true);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, false);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+
+  HTMLElement.prototype.matches = function (selector: string) {
+    if (selector === ':popover-open') {
+      return popoverOpenState.get(this) ?? false;
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterAll(() => {
+  HTMLElement.prototype.matches = originalMatches;
+});
+
+// Test data
+const fruits: XDSSearchableItem[] = [
+  {id: '1', label: 'Apple'},
+  {id: '2', label: 'Banana'},
+  {id: '3', label: 'Cherry'},
+  {id: '4', label: 'Date'},
+  {id: '5', label: 'Elderberry'},
+];
+
+const fruitSource: XDSSearchSource = {
+  search: (query: string) =>
+    fruits.filter(f => f.label.toLowerCase().includes(query.toLowerCase())),
+  bootstrap: () => fruits.slice(0, 3),
+};
+
+describe('XDSBaseTypeahead', () => {
+  it('renders input with combobox role', () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('renders placeholder text', () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        placeholder="Pick a fruit..."
+      />,
+    );
+    expect(screen.getByPlaceholderText('Pick a fruit...')).toBeInTheDocument();
+  });
+
+  it('shows clear button when value is selected', () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={fruits[0]}
+        onChange={() => {}}
+      />,
+    );
+    expect(
+      screen.getByRole('button', {name: 'Clear selection'}),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show clear button when hasClear is false', () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={fruits[0]}
+        onChange={() => {}}
+        hasClear={false}
+      />,
+    );
+    expect(
+      screen.queryByRole('button', {name: 'Clear selection'}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls onChange with null when clear is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={fruits[0]}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Clear selection'}));
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('sets aria-expanded=false initially', () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('combobox')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('renders with data-testid', () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        data-testid="my-typeahead"
+      />,
+    );
+    expect(screen.getByTestId('my-typeahead')).toBeInTheDocument();
+  });
+
+  it('shows results on input change', async () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'App'}});
+
+    // The listbox is inside a popover element, so use hidden: true
+    await waitFor(() => {
+      expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
+    });
+  });
+
+  it('disables input when isDisabled', () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        isDisabled
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeDisabled();
+  });
+});
+
+describe('XDSTypeahead', () => {
+  it('renders with label', () => {
+    render(
+      <XDSTypeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText('Fruit')).toBeInTheDocument();
+  });
+
+  it('renders description text', () => {
+    render(
+      <XDSTypeahead
+        label="Fruit"
+        description="Pick your favorite fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByText('Pick your favorite fruit')).toBeInTheDocument();
+  });
+
+  it('shows required indicator', () => {
+    render(
+      <XDSTypeahead
+        label="Fruit"
+        isRequired
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    // XDSField renders "∙ Required" text in the label
+    expect(screen.getByText(/Required/)).toBeInTheDocument();
+  });
+
+  it('renders error status message', () => {
+    render(
+      <XDSTypeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Selection required'}}
+      />,
+    );
+    expect(screen.getByText('Selection required')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Typeahead/XDSTypeahead.test.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.test.tsx
@@ -85,7 +85,7 @@ describe('XDSBaseTypeahead', () => {
     expect(screen.getByPlaceholderText('Pick a fruit...')).toBeInTheDocument();
   });
 
-  it('shows clear button when value is selected', () => {
+  it('shows selected value as a token with remove button', () => {
     render(
       <XDSBaseTypeahead
         searchSource={fruitSource}
@@ -93,8 +93,9 @@ describe('XDSBaseTypeahead', () => {
         onChange={() => {}}
       />,
     );
+    // Selected value renders as a Token with a remove button
     expect(
-      screen.getByRole('button', {name: 'Clear selection'}),
+      screen.getByRole('button', {name: `Remove ${fruits[0].label}`}),
     ).toBeInTheDocument();
   });
 
@@ -112,7 +113,7 @@ describe('XDSBaseTypeahead', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('calls onChange with null when clear is clicked', () => {
+  it('calls onChange with null when token remove is clicked', () => {
     const onChange = vi.fn();
     render(
       <XDSBaseTypeahead
@@ -121,7 +122,10 @@ describe('XDSBaseTypeahead', () => {
         onChange={onChange}
       />,
     );
-    fireEvent.click(screen.getByRole('button', {name: 'Clear selection'}));
+    // Selected value shows as a Token; clicking its remove button clears
+    fireEvent.click(
+      screen.getByRole('button', {name: `Remove ${fruits[0].label}`}),
+    );
     expect(onChange).toHaveBeenCalledWith(null);
   });
 

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -1,0 +1,186 @@
+/**
+ * @file XDSTypeahead.tsx
+ * @input Uses React, XDSBaseTypeahead, XDSField
+ * @output Exports XDSTypeahead styled typeahead component
+ * @position Styled wrapper; composes XDSBaseTypeahead with XDSField
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Typeahead/README.md
+ * - /packages/core/src/Typeahead/index.ts
+ * - /apps/storybook/stories/Typeahead.stories.tsx
+ */
+
+import React, {useId, type ReactNode} from 'react';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {XDSBaseTypeahead} from './XDSBaseTypeahead';
+import {XDSField, type XDSInputStatus} from '../Field';
+import type {XDSIconType} from '../Icon';
+import type {XDSSearchableItem, XDSSearchSource} from './types';
+
+export type {
+  XDSInputStatus as XDSTypeaheadStatus,
+  XDSInputStatusType as XDSTypeaheadStatusType,
+} from '../Field';
+
+export interface XDSTypeaheadProps<T extends XDSSearchableItem> {
+  /** Accessible label (required). */
+  label: string;
+  /** Visually hide the label. @default false */
+  isLabelHidden?: boolean;
+  /** Helper text. */
+  description?: string;
+  /** Required field. @default false */
+  isRequired?: boolean;
+  /** Optional field. @default false */
+  isOptional?: boolean;
+  /** Validation status. */
+  status?: XDSInputStatus;
+  /** Label tooltip. */
+  labelTooltip?: string;
+  /** Search source providing items. */
+  searchSource: XDSSearchSource<T>;
+  /** Currently selected item (null = nothing selected). */
+  value: T | null;
+  /** Callback when selection changes. */
+  onChange: (item: T | null) => void;
+  /** Render function for dropdown items. Default: XDSTypeaheadItem. */
+  renderItem?: (item: T) => ReactNode;
+  /** Placeholder text. */
+  placeholder?: string;
+  /** Show results on focus before typing. @default false */
+  hasEntriesOnFocus?: boolean;
+  /** Max dropdown items. @default 10 */
+  maxMenuItems?: number;
+  /** Text shown when no results found. @default 'No results found' */
+  emptySearchResultsText?: string;
+  /** Whether the input is disabled. @default false */
+  isDisabled?: boolean;
+  /** Show clear button. @default true */
+  hasClear?: boolean;
+  /** Auto-focus on mount. @default false */
+  hasAutoFocus?: boolean;
+  /** Input size. @default 'md' */
+  size?: 'sm' | 'md';
+  /** Start icon. */
+  startIcon?: XDSIconType;
+  /** Query change callback. */
+  onChangeQuery?: (query: string) => void;
+  /** Callback when dropdown opens/closes. */
+  onOpenChange?: (isOpen: boolean) => void;
+  /** StyleX overrides. */
+  xstyle?: StyleXStyles;
+  /** Test ID. */
+  'data-testid'?: string;
+}
+
+/**
+ * A search-as-you-type component for selecting an item from a search source.
+ *
+ * Wraps XDSBaseTypeahead with XDSField for label, description, and status.
+ *
+ * @example
+ * ```tsx
+ * <XDSTypeahead
+ *   label="Assignee"
+ *   searchSource={userSource}
+ *   value={assignee}
+ *   onChange={setAssignee}
+ *   placeholder="Search users..."
+ * />
+ *
+ * <XDSTypeahead
+ *   label="Assignee"
+ *   searchSource={userSource}
+ *   value={assignee}
+ *   onChange={setAssignee}
+ *   renderItem={(item) => (
+ *     <XDSTypeaheadItem
+ *       item={item}
+ *       icon={<XDSAvatar src={item.auxiliaryData.avatar} size="sm" />}
+ *       description={item.auxiliaryData.role}
+ *     />
+ *   )}
+ * />
+ * ```
+ */
+export function XDSTypeahead<T extends XDSSearchableItem>({
+  label,
+  isLabelHidden = false,
+  description,
+  isRequired = false,
+  isOptional = false,
+  status,
+  labelTooltip,
+  searchSource,
+  value,
+  onChange,
+  renderItem,
+  placeholder,
+  hasEntriesOnFocus,
+  maxMenuItems,
+  emptySearchResultsText,
+  isDisabled,
+  hasClear,
+  hasAutoFocus,
+  size,
+  startIcon,
+  onChangeQuery,
+  onOpenChange,
+  xstyle,
+  'data-testid': testId,
+}: XDSTypeaheadProps<T>) {
+  const inputId = useId();
+  const descriptionId = useId();
+  const statusMessageId = useId();
+
+  const ariaDescribedBy =
+    [
+      description ? descriptionId : null,
+      status?.message ? statusMessageId : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  return (
+    <XDSField
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={inputId}
+      descriptionID={description ? descriptionId : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageId : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}>
+      <XDSBaseTypeahead
+        searchSource={searchSource}
+        value={value}
+        onChange={onChange}
+        renderItem={renderItem}
+        placeholder={placeholder}
+        hasEntriesOnFocus={hasEntriesOnFocus}
+        maxMenuItems={maxMenuItems}
+        emptySearchResultsText={emptySearchResultsText}
+        isDisabled={isDisabled}
+        hasClear={hasClear}
+        hasAutoFocus={hasAutoFocus}
+        size={size}
+        inputId={inputId}
+        ariaDescribedBy={ariaDescribedBy}
+        onChangeQuery={onChangeQuery}
+        onOpenChange={onOpenChange}
+        data-testid={testId}
+      />
+    </XDSField>
+  );
+}
+
+XDSTypeahead.displayName = 'XDSTypeahead';

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -177,6 +177,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
         ariaDescribedBy={ariaDescribedBy}
         onChangeQuery={onChangeQuery}
         onOpenChange={onOpenChange}
+        statusType={status?.type}
         data-testid={testId}
       />
     </XDSField>

--- a/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
+++ b/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
@@ -1,0 +1,151 @@
+/**
+ * @file XDSTypeaheadItem.tsx
+ * @input Uses React, StyleX, XDSSearchableItem
+ * @output Exports XDSTypeaheadItem component for rendering dropdown items
+ * @position Presentational component; used as default renderItem in XDSBaseTypeahead
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Typeahead/README.md
+ * - /packages/core/src/Typeahead/index.ts
+ */
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  lineHeightVars,
+  fontWeightVars,
+} from '../theme/tokens.stylex';
+import type {XDSSearchableItem} from './types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface XDSTypeaheadItemProps<
+  T extends XDSSearchableItem = XDSSearchableItem,
+> {
+  /**
+   * The search result item.
+   */
+  item: T;
+
+  /**
+   * Icon or avatar to display before the label.
+   */
+  icon?: ReactNode;
+
+  /**
+   * Description text displayed below the label.
+   */
+  description?: string;
+
+  /**
+   * Whether this item is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Group label for grouping items visually.
+   */
+  group?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    minHeight: 0,
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minWidth: 0,
+  },
+  label: {
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    color: colorVars['--color-text-primary'],
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  description: {
+    fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    color: colorVars['--color-text-secondary'],
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Default item component for typeahead dropdown results.
+ *
+ * Renders a label with optional icon and description.
+ * Exported for use in custom `renderItem` implementations.
+ *
+ * @example
+ * ```tsx
+ * // Default usage (automatic)
+ * <XDSTypeahead searchSource={source} value={v} onChange={setV} label="Search" />
+ *
+ * // Custom renderItem using XDSTypeaheadItem
+ * <XDSTypeahead
+ *   searchSource={source}
+ *   value={v}
+ *   onChange={setV}
+ *   label="Search"
+ *   renderItem={(item) => (
+ *     <XDSTypeaheadItem
+ *       item={item}
+ *       icon={<XDSAvatar src={item.auxiliaryData.avatar} size="sm" />}
+ *       description={item.auxiliaryData.role}
+ *     />
+ *   )}
+ * />
+ * ```
+ */
+export function XDSTypeaheadItem<T extends XDSSearchableItem>({
+  item,
+  icon,
+  description,
+  isDisabled = false,
+}: XDSTypeaheadItemProps<T>) {
+  // If item has a pre-rendered element, use it
+  if (item.element) {
+    return <>{item.element}</>;
+  }
+
+  return (
+    <div {...stylex.props(styles.container, isDisabled && styles.disabled)}>
+      {icon}
+      <div {...stylex.props(styles.content)}>
+        <span {...stylex.props(styles.label)}>{item.label}</span>
+        {description && (
+          <span {...stylex.props(styles.description)}>{description}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+XDSTypeaheadItem.displayName = 'XDSTypeaheadItem';

--- a/packages/core/src/Typeahead/index.ts
+++ b/packages/core/src/Typeahead/index.ts
@@ -1,0 +1,27 @@
+/**
+ * @file index.ts
+ * @input Typeahead components and types
+ * @output Exports all Typeahead module public API
+ * @position Entry point for Typeahead module
+ *
+ * SYNC: When adding new Typeahead files, update exports here
+ */
+
+// Shared types
+export type {XDSSearchableItem, XDSSearchSource} from './types';
+
+// Base (unstyled) typeahead
+export {XDSBaseTypeahead} from './XDSBaseTypeahead';
+export type {XDSBaseTypeaheadProps} from './XDSBaseTypeahead';
+
+// Styled typeahead
+export {XDSTypeahead} from './XDSTypeahead';
+export type {
+  XDSTypeaheadProps,
+  XDSTypeaheadStatus,
+  XDSTypeaheadStatusType,
+} from './XDSTypeahead';
+
+// Typeahead item
+export {XDSTypeaheadItem} from './XDSTypeaheadItem';
+export type {XDSTypeaheadItemProps} from './XDSTypeaheadItem';

--- a/packages/core/src/Typeahead/types.ts
+++ b/packages/core/src/Typeahead/types.ts
@@ -1,0 +1,92 @@
+/**
+ * @file types.ts
+ * @input None
+ * @output Exports shared types for Typeahead and Tokenizer components
+ * @position Shared type definitions; consumed by XDSBaseTypeahead, XDSTypeahead, XDSTokenizer
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Typeahead/README.md
+ * - /packages/core/src/Typeahead/index.ts
+ */
+
+import type {ReactNode} from 'react';
+
+/**
+ * Minimal item interface for search results.
+ * Extend with `auxiliaryData` for custom data per item.
+ *
+ * @example
+ * ```tsx
+ * interface UserItem extends XDSSearchableItem<{ avatar: string; role: string }> {}
+ *
+ * const user: UserItem = {
+ *   id: '1',
+ *   label: 'Jane Doe',
+ *   auxiliaryData: { avatar: '/jane.jpg', role: 'Engineer' },
+ * };
+ * ```
+ */
+export interface XDSSearchableItem<TAuxData = unknown> {
+  /**
+   * Unique identifier for the item.
+   */
+  id: string;
+
+  /**
+   * Display label for the item.
+   */
+  label: string;
+
+  /**
+   * Pre-rendered element for SSR compatibility.
+   * When provided, takes priority over `renderItem` and default label rendering.
+   */
+  element?: ReactNode;
+
+  /**
+   * Arbitrary extra data associated with the item.
+   * Use generics to type this for your specific use case.
+   */
+  auxiliaryData?: TAuxData;
+}
+
+/**
+ * Search source interface for providing items to typeahead components.
+ * Supports both synchronous and asynchronous search.
+ *
+ * @example
+ * ```tsx
+ * // Sync search source
+ * const fruitSource: XDSSearchSource = {
+ *   search: (query) => fruits.filter(f => f.label.includes(query)),
+ *   bootstrap: () => fruits.slice(0, 5),
+ * };
+ *
+ * // Async search source
+ * const userSource: XDSSearchSource<UserItem> = {
+ *   search: async (query) => {
+ *     const res = await fetch(`/api/users?q=${query}`);
+ *     return res.json();
+ *   },
+ *   bootstrap: async () => {
+ *     const res = await fetch('/api/users/recent');
+ *     return res.json();
+ *   },
+ * };
+ * ```
+ */
+export interface XDSSearchSource<
+  T extends XDSSearchableItem = XDSSearchableItem,
+> {
+  /**
+   * Called on query change. Returns matching items.
+   * Can be synchronous or asynchronous.
+   */
+  search(query: string): Promise<T[]> | T[];
+
+  /**
+   * Called on init/focus. Returns initial/default items.
+   * Can be synchronous or asynchronous.
+   */
+  bootstrap(): Promise<T[]> | T[];
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,6 +41,8 @@ export * from './TimeInput';
 export * from './NumberInput';
 export * from './Table';
 export * from './Token';
+export * from './Typeahead';
+export * from './Tokenizer';
 export * from './Dialog';
 export * from './DropdownMenu';
 export * from './TopNav';


### PR DESCRIPTION
## Summary

Three new components for overlay, search, and multi-select patterns.

### XDSPopover
Click/hover-triggered popover using the Popover API + CSS Anchor Positioning. Supports controlled/uncontrolled mode, placement, alignment, focus trapping, and custom widths. Hover trigger delegates to XDSHoverCard.

### XDSTypeahead
Single-select search dropdown. `XDSBaseTypeahead` provides the unstyled combobox engine (keyboard navigation, ARIA, search source interface). `XDSTypeahead` wraps it with XDSField for label, description, validation, and status. `XDSTypeaheadItem` renders dropdown items with optional icon/secondary text.

### XDSTokenizer
Multi-select typeahead with XDSToken chips. Supports `maxEntries`, clear all, backspace-to-remove, and change metadata (`add`/`remove`/`reorder`) in the onChange callback.

## What's Included
- 37 tests across all three components (9 + 13 + 15)
- Storybook stories for each component
- READMEs for Typeahead and Tokenizer modules
- Barrel exports from `@xds/core`

## Test Results
```
Test Files  59 passed (59)
Tests       944 passed (944)
```

---
*Crafted with care by Navi*