### PR TITLE
feat(vibe-tests): live preview pages and report UI improvements

### DIFF
--- a/internal/vibe-tests/app/src/report/CodeModal.tsx
+++ b/internal/vibe-tests/app/src/report/CodeModal.tsx
@@ -35,7 +35,7 @@ interface CodeModalProps {
   isShown: boolean;
   onHide: () => void;
   promptId: string;
-  target: 'xds' | 'baseline';
+  target: 'xds' | 'baseline' | 'html';
   code: string;
 }
 
@@ -46,7 +46,8 @@ export function CodeModal({
   target,
   code,
 }: CodeModalProps) {
-  const targetLabel = target === 'xds' ? 'XDS' : 'Baseline';
+  const targetLabel =
+    target === 'xds' ? 'XDS' : target === 'baseline' ? 'Baseline' : 'HTML';
   const lineCount = code.split('\n').length;
 
   return (

--- a/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
+++ b/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
@@ -146,7 +146,10 @@ interface PromptDetailCardProps {
   baselineScore?: UniversalScore;
   hasXdsCode: boolean;
   hasBaselineCode: boolean;
-  onViewCode: (target: 'xds' | 'baseline') => void;
+  hasHtmlCode: boolean;
+  onViewCode: (target: 'xds' | 'baseline' | 'html') => void;
+  /** Relative preview URLs keyed by target (e.g. { xds: "previews/sd-1/xds.html" }) */
+  previewUrls?: Record<string, string>;
 }
 
 export function PromptDetailCard({
@@ -155,9 +158,14 @@ export function PromptDetailCard({
   baselineScore,
   hasXdsCode,
   hasBaselineCode,
+  hasHtmlCode,
   onViewCode,
+  previewUrls,
 }: PromptDetailCardProps) {
   const hasBoth = !!(xdsScore && baselineScore);
+  const hasAnyPreview =
+    previewUrls?.xds || previewUrls?.baseline || previewUrls?.html;
+  const hasAnyCode = hasXdsCode || hasBaselineCode || hasHtmlCode;
 
   return (
     <XDSCard>
@@ -166,22 +174,54 @@ export function PromptDetailCard({
           {/* Header: prompt ID on its own line, buttons below */}
           <div {...stylex.props(styles.header)}>
             <XDSHeading level={4}>{promptId}</XDSHeading>
-            {(hasXdsCode || hasBaselineCode) && (
+            {(hasAnyPreview || hasAnyCode) && (
               <div {...stylex.props(styles.buttonRow)}>
-                {hasXdsCode && (
+                {previewUrls?.xds && (
                   <XDSButton
                     variant="secondary"
                     size="sm"
+                    onClick={() => window.open(previewUrls.xds, '_blank')}>
+                    XDS Preview
+                  </XDSButton>
+                )}
+                {previewUrls?.baseline && (
+                  <XDSButton
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => window.open(previewUrls.baseline, '_blank')}>
+                    Baseline Preview
+                  </XDSButton>
+                )}
+                {previewUrls?.html && (
+                  <XDSButton
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => window.open(previewUrls.html, '_blank')}>
+                    HTML Preview
+                  </XDSButton>
+                )}
+                {hasXdsCode && (
+                  <XDSButton
+                    variant="ghost"
+                    size="sm"
                     onClick={() => onViewCode('xds')}>
-                    View XDS Code
+                    XDS Code
                   </XDSButton>
                 )}
                 {hasBaselineCode && (
                   <XDSButton
-                    variant="secondary"
+                    variant="ghost"
                     size="sm"
                     onClick={() => onViewCode('baseline')}>
-                    View Baseline Code
+                    Baseline Code
+                  </XDSButton>
+                )}
+                {hasHtmlCode && (
+                  <XDSButton
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => onViewCode('html')}>
+                    HTML Code
                   </XDSButton>
                 )}
               </div>

--- a/internal/vibe-tests/app/src/report/Report.tsx
+++ b/internal/vibe-tests/app/src/report/Report.tsx
@@ -198,7 +198,7 @@ export function Report() {
   const [activeTab, setActiveTab] = useState('overview');
   const [codeModal, setCodeModal] = useState<{
     promptId: string;
-    target: 'xds' | 'baseline';
+    target: 'xds' | 'baseline' | 'html';
   } | null>(null);
 
   const data: ReportData | undefined = window.__REPORT_DATA__;
@@ -326,7 +326,9 @@ export function Report() {
                         baselineScore={comparison?.baseline.byPrompt[promptId]}
                         hasXdsCode={!!data.sourceCode?.[promptId]}
                         hasBaselineCode={!!data.baselineSourceCode?.[promptId]}
+                        hasHtmlCode={!!data.htmlSourceCode?.[promptId]}
                         onViewCode={target => setCodeModal({promptId, target})}
+                        previewUrls={data.previews?.[promptId]}
                       />
                     ))}
                   </XDSVStack>
@@ -339,7 +341,9 @@ export function Report() {
                   const code =
                     codeModal.target === 'xds'
                       ? data.sourceCode?.[codeModal.promptId]
-                      : data.baselineSourceCode?.[codeModal.promptId];
+                      : codeModal.target === 'baseline'
+                        ? data.baselineSourceCode?.[codeModal.promptId]
+                        : data.htmlSourceCode?.[codeModal.promptId];
                   return code ? (
                     <CodeModal
                       isShown

--- a/internal/vibe-tests/app/src/report/types.ts
+++ b/internal/vibe-tests/app/src/report/types.ts
@@ -28,6 +28,9 @@ export interface ReportData {
   screenshots?: Record<string, string>;
   sourceCode?: Record<string, string>;
   baselineSourceCode?: Record<string, string>;
+  htmlSourceCode?: Record<string, string>;
+  /** Map of promptId → { target → relative URL } */
+  previews?: Record<string, Record<string, string>>;
   iterationId?: string;
   target?: string;
 }

--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -1,0 +1,626 @@
+#!/usr/bin/env node
+/**
+ * @file Build live preview pages from vibe test results
+ *
+ * Takes .tsx result files and builds each into a standalone HTML page
+ * that renders the component. Supports XDS, baseline, and raw HTML targets.
+ *
+ * Usage:
+ *   tsx src/build-previews.ts --iterations 8734233a,d4ff8c2c,68ef2a62
+ *   tsx src/build-previews.ts --iterations 8734233a --prompts tc-4
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {execSync} from 'node:child_process';
+import {getResultsDir, ensureDir, readJson, writeJson} from './utils.js';
+
+const __dirname = path.dirname(new URL(import.meta.url).pathname);
+const VIBE_DIR = path.resolve(__dirname, '..');
+const APP_DIR = path.join(VIBE_DIR, 'app');
+const REPO_ROOT = path.resolve(VIBE_DIR, '../..');
+
+interface PreviewManifest {
+  [promptId: string]: {
+    [target: string]: string; // relative path to preview HTML
+  };
+}
+
+function parseArgs(): {
+  iterations: string[];
+  prompts?: string[];
+  outDir: string;
+} {
+  const args = process.argv.slice(2);
+  let iterations: string[] = [];
+  let prompts: string[] | undefined;
+  let outDir = '';
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--iterations' && args[i + 1]) {
+      iterations = args[++i].split(',');
+    } else if (args[i] === '--prompts' && args[i + 1]) {
+      prompts = args[++i].split(',');
+    } else if (args[i] === '--out' && args[i + 1]) {
+      outDir = args[++i];
+    }
+  }
+
+  if (iterations.length === 0) {
+    console.error(
+      'Usage: tsx src/build-previews.ts --iterations <id1,id2,...> [--prompts <p1,p2,...>] [--out <dir>]',
+    );
+    process.exit(1);
+  }
+
+  // Default output to first iteration's directory
+  if (!outDir) {
+    outDir = path.join(getResultsDir(), iterations[0], 'previews');
+  }
+
+  return {iterations, prompts, outDir};
+}
+
+/**
+ * Create a temporary entry file that imports and renders the component
+ */
+function createEntryFile(
+  componentPath: string,
+  target: string,
+  tmpDir: string,
+): string {
+  const entryPath = path.join(tmpDir, 'entry.tsx');
+
+  // For XDS target, wrap in theme provider and import reset
+  if (target === 'xds') {
+    fs.writeFileSync(
+      entryPath,
+      `import React from 'react';
+import {createRoot} from 'react-dom/client';
+import '@xds/core/reset.css';
+import {XDSTheme} from '@xds/core/theme';
+import {defaultTheme} from '@xds/theme/default';
+import Component from '${componentPath.replace(/\\/g, '/')}';
+
+function App() {
+  return (
+    <XDSTheme theme={defaultTheme} mode="light">
+      <Component />
+    </XDSTheme>
+  );
+}
+
+createRoot(document.getElementById('root')!).render(<App />);
+`,
+    );
+  } else {
+    // Baseline and HTML: just render directly
+    fs.writeFileSync(
+      entryPath,
+      `import React from 'react';
+import {createRoot} from 'react-dom/client';
+import Component from '${componentPath.replace(/\\/g, '/')}';
+
+createRoot(document.getElementById('root')!).render(<Component />);
+`,
+    );
+  }
+
+  return entryPath;
+}
+
+/**
+ * Create a minimal index.html for the preview
+ */
+function createIndexHtml(
+  tmpDir: string,
+  title: string,
+  target: string,
+): string {
+  const htmlPath = path.join(tmpDir, 'index.html');
+
+  // Baseline previews need Tailwind CSS for styling
+  const tailwindCdn =
+    target === 'baseline'
+      ? `\n  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      --background: 0 0% 100%;
+      --foreground: 222.2 84% 4.9%;
+      --card: 0 0% 100%;
+      --card-foreground: 222.2 84% 4.9%;
+      --popover: 0 0% 100%;
+      --popover-foreground: 222.2 84% 4.9%;
+      --primary: 222.2 47.4% 11.2%;
+      --primary-foreground: 210 40% 98%;
+      --secondary: 210 40% 96.1%;
+      --secondary-foreground: 222.2 47.4% 11.2%;
+      --muted: 210 40% 96.1%;
+      --muted-foreground: 215.4 16.3% 46.9%;
+      --accent: 210 40% 96.1%;
+      --accent-foreground: 222.2 47.4% 11.2%;
+      --destructive: 0 84.2% 60.2%;
+      --destructive-foreground: 210 40% 98%;
+      --border: 214.3 31.8% 91.4%;
+      --input: 214.3 31.8% 91.4%;
+      --ring: 222.2 84% 4.9%;
+      --radius: 0.5rem;
+    }
+  </style>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            border: 'hsl(var(--border))',
+            input: 'hsl(var(--input))',
+            ring: 'hsl(var(--ring))',
+            background: 'hsl(var(--background))',
+            foreground: 'hsl(var(--foreground))',
+            primary: { DEFAULT: 'hsl(var(--primary))', foreground: 'hsl(var(--primary-foreground))' },
+            secondary: { DEFAULT: 'hsl(var(--secondary))', foreground: 'hsl(var(--secondary-foreground))' },
+            destructive: { DEFAULT: 'hsl(var(--destructive))', foreground: 'hsl(var(--destructive-foreground))' },
+            muted: { DEFAULT: 'hsl(var(--muted))', foreground: 'hsl(var(--muted-foreground))' },
+            accent: { DEFAULT: 'hsl(var(--accent))', foreground: 'hsl(var(--accent-foreground))' },
+            popover: { DEFAULT: 'hsl(var(--popover))', foreground: 'hsl(var(--popover-foreground))' },
+            card: { DEFAULT: 'hsl(var(--card))', foreground: 'hsl(var(--card-foreground))' },
+          },
+          borderRadius: {
+            lg: 'var(--radius)',
+            md: 'calc(var(--radius) - 2px)',
+            sm: 'calc(var(--radius) - 4px)',
+          },
+        },
+      },
+    }
+  </script>`
+      : '';
+
+  fs.writeFileSync(
+    htmlPath,
+    `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${title}</title>${tailwindCdn}
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; }
+    #root { min-height: 100%; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="module" src="./entry.tsx"></script>
+</body>
+</html>`,
+  );
+  return htmlPath;
+}
+
+/**
+ * Create a Vite config for building the preview
+ */
+function createViteConfig(tmpDir: string, target: string): string {
+  const configPath = path.join(tmpDir, 'vite.config.ts');
+
+  // For XDS previews, the generated component may use patterns that
+  // StyleX's babel plugin rejects (e.g. createTheme with type casts).
+  // We use a pre-transform plugin to strip TypeScript type assertions
+  // before StyleX processes the file.
+  const plugins =
+    target === 'xds'
+      ? `
+    {
+      name: 'stylex-inline-vars',
+      enforce: 'pre',
+      transform(code, id) {
+        if (!id.endsWith('.tsx') || !id.includes('/results/')) return null;
+
+        let result = code;
+
+        // Step 1: Collect all 'const xxxRaw = { ... } as const;' blocks
+        // so we can inline them into createTheme calls
+        const varBlocks = new Map();
+        const blockRe = /const\\s+(\\w+Raw)\\s*=\\s*(\\{[\\s\\S]*?\\})\\s*as\\s+const;/g;
+        let match;
+        while ((match = blockRe.exec(code)) !== null) {
+          varBlocks.set(match[1], match[2]);
+        }
+
+        // Step 2: Inline variable references in createTheme calls
+        // Pattern: stylex.createTheme(vars, someRaw as unknown as SomeType)
+        // Replace with: stylex.createTheme(vars, { ...inlined object... })
+        for (const [varName, objLiteral] of varBlocks) {
+          // Match the variable reference with optional type cast
+          const refRe = new RegExp(
+            varName + '(?:\\\\s+as\\\\s+unknown\\\\s+as\\\\s+\\\\w+)?',
+            'g'
+          );
+          // Only replace in createTheme contexts (second arg)
+          result = result.replace(
+            new RegExp(
+              '(createTheme\\\\([^,]+,\\\\s*)' + varName + '(?:\\\\s+as\\\\s+unknown\\\\s+as\\\\s+\\\\w+)?\\\\s*\\\\)',
+              'g'
+            ),
+            '$1' + objLiteral + ')'
+          );
+        }
+
+        // Step 3: Strip remaining type casts (but not in import lines)
+        result = result.split('\\n').map(line => {
+          if (line.trimStart().startsWith('import ')) return line;
+          line = line.replace(/\\s+as\\s+unknown\\s+as\\s+\\w+/g, '');
+          return line;
+        }).join('\\n');
+
+        return { code: result, map: null };
+      },
+    },
+    stylex.vite({
+      dev: false,
+      runtimeInjection: false,
+      treeshakeCompensation: true,
+      unstable_moduleResolution: {
+        type: 'commonJS',
+        rootDir: '${REPO_ROOT.replace(/\\/g, '/')}',
+      },
+      aliases: {
+        '@xds/core/theme/tokens.stylex': '${path.resolve(REPO_ROOT, 'packages/core/src/theme/tokens.stylex.ts').replace(/\\/g, '/')}',
+      },
+    }),
+    react(),
+    viteSingleFile(),`
+      : `
+    react(),
+    viteSingleFile(),`;
+
+  const imports =
+    target === 'xds'
+      ? `import stylex from '@stylexjs/unplugin';
+import react from '@vitejs/plugin-react';
+import {viteSingleFile} from 'vite-plugin-singlefile';`
+      : `import react from '@vitejs/plugin-react';
+import {viteSingleFile} from 'vite-plugin-singlefile';`;
+
+  const aliases =
+    target === 'xds'
+      ? `
+    alias: {
+      '@xds/core/theme/tokens.stylex': '${path.resolve(REPO_ROOT, 'packages/core/src/theme/tokens.stylex.ts').replace(/\\/g, '/')}',
+      '@xds/core': '${path.resolve(REPO_ROOT, 'packages/core/src').replace(/\\/g, '/')}',
+      '@xds/theme/default': '${path.resolve(REPO_ROOT, 'packages/themes/default/src').replace(/\\/g, '/')}',
+      '@xds/theme/neutral': '${path.resolve(REPO_ROOT, 'packages/themes/neutral/src').replace(/\\/g, '/')}',
+    },`
+      : target === 'baseline'
+        ? `
+    alias: {
+      '@/components/ui': '${path.resolve(VIBE_DIR, '.baseline-shims/components/ui').replace(/\\/g, '/')}',
+      '@/lib/utils': '${path.resolve(VIBE_DIR, '.baseline-shims/lib/utils').replace(/\\/g, '/')}',
+    },`
+        : '';
+
+  fs.writeFileSync(
+    configPath,
+    `import {defineConfig} from 'vite';
+${imports}
+
+export default defineConfig({
+  root: '${tmpDir.replace(/\\/g, '/')}',
+  plugins: [${plugins}
+  ],
+  resolve: {${aliases}
+  },
+  build: {
+    outDir: 'dist',
+    emptyOutDir: true,
+  },
+  logLevel: 'warn',
+});
+`,
+  );
+
+  return configPath;
+}
+
+/**
+ * Create baseline component shims so imports resolve
+ */
+function ensureBaselineShims(): void {
+  const shimsDir = path.join(VIBE_DIR, '.baseline-shims');
+  const componentsDir = path.join(shimsDir, 'components', 'ui');
+  const libDir = path.join(shimsDir, 'lib');
+
+  if (fs.existsSync(path.join(libDir, 'utils.ts'))) return;
+
+  ensureDir(componentsDir);
+  ensureDir(libDir);
+
+  // cn() utility
+  fs.writeFileSync(
+    path.join(libDir, 'utils.ts'),
+    `export function cn(...classes: (string | boolean | undefined | null)[]) {
+  return classes.filter(Boolean).join(' ');
+}
+`,
+  );
+
+  // Generic shim components — render as plain HTML with basic styling
+  const components: Record<string, string> = {
+    button: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Button({className, variant, size, children, ...props}: any) {
+  return <button className={cn('px-4 py-2 rounded-md text-sm font-medium', className)} {...props}>{children}</button>;
+}
+export const buttonVariants = () => '';
+`,
+    card: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Card({className, children, ...props}: any) { return <div className={cn('rounded-lg border bg-white shadow-sm', className)} {...props}>{children}</div>; }
+export function CardHeader({className, children, ...props}: any) { return <div className={cn('flex flex-col space-y-1.5 p-6', className)} {...props}>{children}</div>; }
+export function CardTitle({className, children, ...props}: any) { return <h3 className={cn('text-2xl font-semibold', className)} {...props}>{children}</h3>; }
+export function CardDescription({className, children, ...props}: any) { return <p className={cn('text-sm text-gray-500', className)} {...props}>{children}</p>; }
+export function CardContent({className, children, ...props}: any) { return <div className={cn('p-6 pt-0', className)} {...props}>{children}</div>; }
+export function CardFooter({className, children, ...props}: any) { return <div className={cn('flex items-center p-6 pt-0', className)} {...props}>{children}</div>; }
+`,
+    badge: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Badge({className, variant, children, ...props}: any) {
+  return <span className={cn('inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold', className)} {...props}>{children}</span>;
+}
+`,
+    input: `import React from 'react';
+import {cn} from '@/lib/utils';
+export const Input = React.forwardRef<HTMLInputElement, any>(({className, ...props}, ref) => {
+  return <input ref={ref} className={cn('flex h-10 w-full rounded-md border px-3 py-2 text-sm', className)} {...props} />;
+});
+Input.displayName = 'Input';
+`,
+    label: `import React from 'react';
+import {cn} from '@/lib/utils';
+export const Label = React.forwardRef<HTMLLabelElement, any>(({className, ...props}, ref) => {
+  return <label ref={ref} className={cn('text-sm font-medium', className)} {...props} />;
+});
+Label.displayName = 'Label';
+`,
+    checkbox: `import React from 'react';
+export function Checkbox({checked, onCheckedChange, ...props}: any) {
+  return <input type="checkbox" checked={checked} onChange={e => onCheckedChange?.(e.target.checked)} {...props} />;
+}
+`,
+    select: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Select({children, value, onValueChange, ...props}: any) { return <div {...props}>{children}</div>; }
+export function SelectTrigger({className, children, ...props}: any) { return <button className={cn('flex h-10 w-full items-center justify-between rounded-md border px-3 py-2 text-sm', className)} {...props}>{children}</button>; }
+export function SelectValue({placeholder}: any) { return <span>{placeholder}</span>; }
+export function SelectContent({children}: any) { return <div>{children}</div>; }
+export function SelectItem({value, children}: any) { return <div data-value={value}>{children}</div>; }
+`,
+    progress: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Progress({value = 0, className, ...props}: any) {
+  return <div className={cn('relative h-4 w-full overflow-hidden rounded-full bg-gray-200', className)} {...props}>
+    <div className="h-full bg-blue-600 transition-all" style={{width: \`\${value}%\`}} />
+  </div>;
+}
+`,
+    skeleton: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Skeleton({className, ...props}: any) {
+  return <div className={cn('animate-pulse rounded-md bg-gray-200', className)} {...props} />;
+}
+`,
+    separator: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Separator({className, orientation = 'horizontal', ...props}: any) {
+  return <div className={cn(orientation === 'horizontal' ? 'h-px w-full' : 'h-full w-px', 'bg-gray-200', className)} {...props} />;
+}
+`,
+    tabs: `import React, {useState, createContext, useContext} from 'react';
+import {cn} from '@/lib/utils';
+const TabsContext = createContext<{value: string; onChange: (v: string) => void}>({value: '', onChange: () => {}});
+export function Tabs({defaultValue, value: controlledValue, onValueChange, children, className, ...props}: any) {
+  const [internal, setInternal] = useState(defaultValue ?? '');
+  const value = controlledValue ?? internal;
+  const onChange = onValueChange ?? setInternal;
+  return <TabsContext.Provider value={{value, onChange}}><div className={className} {...props}>{children}</div></TabsContext.Provider>;
+}
+export function TabsList({className, children, ...props}: any) { return <div className={cn('inline-flex h-10 items-center justify-center rounded-md bg-gray-100 p-1', className)} {...props}>{children}</div>; }
+export function TabsTrigger({value, className, children, ...props}: any) {
+  const ctx = useContext(TabsContext);
+  return <button className={cn('inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium', ctx.value === value && 'bg-white shadow-sm', className)} onClick={() => ctx.onChange(value)} {...props}>{children}</button>;
+}
+export function TabsContent({value, className, children, ...props}: any) {
+  const ctx = useContext(TabsContext);
+  if (ctx.value !== value) return null;
+  return <div className={className} {...props}>{children}</div>;
+}
+`,
+    table: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Table({className, children, ...props}: any) { return <div className="relative w-full overflow-auto"><table className={cn('w-full caption-bottom text-sm', className)} {...props}>{children}</table></div>; }
+export function TableHeader({className, children, ...props}: any) { return <thead className={cn('[&_tr]:border-b', className)} {...props}>{children}</thead>; }
+export function TableBody({className, children, ...props}: any) { return <tbody className={cn('[&_tr:last-child]:border-0', className)} {...props}>{children}</tbody>; }
+export function TableRow({className, children, ...props}: any) { return <tr className={cn('border-b transition-colors hover:bg-gray-50', className)} {...props}>{children}</tr>; }
+export function TableHead({className, children, ...props}: any) { return <th className={cn('h-12 px-4 text-left align-middle font-medium text-gray-500', className)} {...props}>{children}</th>; }
+export function TableCell({className, children, ...props}: any) { return <td className={cn('p-4 align-middle', className)} {...props}>{children}</td>; }
+export function TableCaption({className, children, ...props}: any) { return <caption className={cn('mt-4 text-sm text-gray-500', className)} {...props}>{children}</caption>; }
+`,
+    sheet: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Sheet({children, open, onOpenChange}: any) { return <>{children}</>; }
+export function SheetTrigger({children, asChild, ...props}: any) { return <>{children}</>; }
+export function SheetContent({className, children, side = 'right', ...props}: any) {
+  return <div className={cn('fixed inset-y-0 z-50 flex flex-col bg-white p-6 shadow-lg', side === 'right' ? 'right-0' : 'left-0', className)} style={{width: 300}} {...props}>{children}</div>;
+}
+export function SheetHeader({className, children, ...props}: any) { return <div className={cn('flex flex-col space-y-2', className)} {...props}>{children}</div>; }
+export function SheetTitle({className, children, ...props}: any) { return <h2 className={cn('text-lg font-semibold', className)} {...props}>{children}</h2>; }
+export function SheetDescription({className, children, ...props}: any) { return <p className={cn('text-sm text-gray-500', className)} {...props}>{children}</p>; }
+export function SheetClose({children, asChild, ...props}: any) { return <>{children}</>; }
+`,
+    'dropdown-menu': `import React, {useState} from 'react';
+import {cn} from '@/lib/utils';
+export function DropdownMenu({children}: any) { return <div className="relative inline-block">{children}</div>; }
+export function DropdownMenuTrigger({children, asChild}: any) { return <>{children}</>; }
+export function DropdownMenuContent({className, children, ...props}: any) { return <div className={cn('z-50 min-w-[8rem] rounded-md border bg-white p-1 shadow-md', className)} {...props}>{children}</div>; }
+export function DropdownMenuItem({className, children, ...props}: any) { return <div className={cn('relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm hover:bg-gray-100', className)} {...props}>{children}</div>; }
+export function DropdownMenuLabel({className, children, ...props}: any) { return <div className={cn('px-2 py-1.5 text-sm font-semibold', className)} {...props}>{children}</div>; }
+export function DropdownMenuSeparator({className, ...props}: any) { return <div className={cn('-mx-1 my-1 h-px bg-gray-200', className)} {...props} />; }
+export function DropdownMenuCheckboxItem({className, children, checked, ...props}: any) { return <div className={cn('relative flex cursor-pointer items-center rounded-sm py-1.5 pl-8 pr-2 text-sm', className)} {...props}>{children}</div>; }
+export function DropdownMenuRadioGroup({children}: any) { return <>{children}</>; }
+export function DropdownMenuRadioItem({className, children, ...props}: any) { return <div className={cn('relative flex cursor-pointer items-center rounded-sm py-1.5 pl-8 pr-2 text-sm', className)} {...props}>{children}</div>; }
+export function DropdownMenuSub({children}: any) { return <>{children}</>; }
+export function DropdownMenuSubTrigger({className, children, ...props}: any) { return <div className={cn('flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm', className)} {...props}>{children}</div>; }
+export function DropdownMenuSubContent({className, children, ...props}: any) { return <div className={cn('z-50 min-w-[8rem] rounded-md border bg-white p-1 shadow-md', className)} {...props}>{children}</div>; }
+`,
+    dialog: `import React from 'react';
+import {cn} from '@/lib/utils';
+export function Dialog({children, open, onOpenChange}: any) { if (!open) return null; return <>{children}</>; }
+export function DialogTrigger({children, asChild}: any) { return <>{children}</>; }
+export function DialogContent({className, children, ...props}: any) { return <div className="fixed inset-0 z-50 flex items-center justify-center"><div className="fixed inset-0 bg-black/50" /><div className={cn('relative z-50 w-full max-w-lg rounded-lg bg-white p-6 shadow-lg', className)} {...props}>{children}</div></div>; }
+export function DialogHeader({className, children, ...props}: any) { return <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props}>{children}</div>; }
+export function DialogTitle({className, children, ...props}: any) { return <h2 className={cn('text-lg font-semibold', className)} {...props}>{children}</h2>; }
+export function DialogDescription({className, children, ...props}: any) { return <p className={cn('text-sm text-gray-500', className)} {...props}>{children}</p>; }
+export function DialogFooter({className, children, ...props}: any) { return <div className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)} {...props}>{children}</div>; }
+`,
+  };
+
+  for (const [name, content] of Object.entries(components)) {
+    fs.writeFileSync(path.join(componentsDir, `${name}.tsx`), content);
+  }
+}
+
+/**
+ * Build a single preview page
+ */
+function buildPreview(
+  componentPath: string,
+  target: string,
+  promptId: string,
+  outPath: string,
+): boolean {
+  const tmpDir = path.join(VIBE_DIR, '.preview-tmp');
+  if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, {recursive: true});
+  ensureDir(tmpDir);
+
+  try {
+    createEntryFile(componentPath, target, tmpDir);
+    createIndexHtml(tmpDir, `${promptId} — ${target}`, target);
+    createViteConfig(tmpDir, target);
+
+    execSync(`npx vite build --config ${path.join(tmpDir, 'vite.config.ts')}`, {
+      cwd: VIBE_DIR,
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    });
+
+    const distHtml = path.join(tmpDir, 'dist', 'index.html');
+    if (!fs.existsSync(distHtml)) {
+      console.error(`  ✗ Build produced no output for ${promptId}/${target}`);
+      return false;
+    }
+
+    // Inline any CSS files
+    const assetsDir = path.join(tmpDir, 'dist', 'assets');
+    if (fs.existsSync(assetsDir)) {
+      let html = fs.readFileSync(distHtml, 'utf-8');
+      const cssFiles = fs
+        .readdirSync(assetsDir)
+        .filter(f => f.endsWith('.css'));
+      for (const cssFile of cssFiles) {
+        const css = fs.readFileSync(path.join(assetsDir, cssFile), 'utf-8');
+        html = html.replace('</head>', `<style>${css}</style>\n</head>`);
+      }
+      fs.writeFileSync(distHtml, html);
+    }
+
+    ensureDir(path.dirname(outPath));
+    fs.copyFileSync(distHtml, outPath);
+    return true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`  ✗ Failed to build ${promptId}/${target}: ${msg}`);
+    return false;
+  } finally {
+    if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, {recursive: true});
+  }
+}
+
+async function main() {
+  const {iterations, prompts, outDir} = parseArgs();
+  const resultsDir = getResultsDir();
+
+  console.log('\n🖼️  Building Preview Pages');
+  console.log('='.repeat(40));
+
+  const manifest: PreviewManifest = {};
+
+  for (const iterationId of iterations) {
+    const iterDir = path.join(resultsDir, iterationId);
+    const manifestPath = path.join(iterDir, 'manifest.json');
+
+    if (!fs.existsSync(manifestPath)) {
+      console.error(`  ⚠ No manifest for ${iterationId}, skipping`);
+      continue;
+    }
+
+    const iterManifest = readJson<{config?: {target?: string}}>(manifestPath);
+    const target = iterManifest.config?.target ?? 'xds';
+    const codeDir = path.join(iterDir, 'results');
+
+    if (!fs.existsSync(codeDir)) continue;
+
+    const files = fs.readdirSync(codeDir).filter(f => f.endsWith('.tsx'));
+
+    for (const file of files) {
+      const promptId = path.basename(file, '.tsx');
+      if (prompts && !prompts.includes(promptId)) continue;
+
+      const componentPath = path.resolve(codeDir, file);
+      const previewFile = `${promptId}/${target}.html`;
+      const previewPath = path.join(outDir, previewFile);
+
+      console.log(`  📄 ${promptId} (${target})...`);
+
+      if (target === 'baseline') {
+        ensureBaselineShims();
+      }
+
+      const ok = buildPreview(componentPath, target, promptId, previewPath);
+      if (ok) {
+        if (!manifest[promptId]) manifest[promptId] = {};
+        manifest[promptId][target] = `previews/${previewFile}`;
+        console.log(`  ✓ ${previewFile}`);
+      }
+    }
+  }
+
+  // Merge with existing manifest if present
+  const manifestOutPath = path.join(outDir, 'manifest.json');
+  ensureDir(outDir);
+  if (fs.existsSync(manifestOutPath)) {
+    const existing = readJson<PreviewManifest>(manifestOutPath);
+    for (const [promptId, targets] of Object.entries(existing)) {
+      if (!manifest[promptId]) manifest[promptId] = {};
+      for (const [target, url] of Object.entries(targets)) {
+        if (!manifest[promptId][target]) manifest[promptId][target] = url;
+      }
+    }
+  }
+  writeJson(manifestOutPath, manifest);
+
+  const totalPreviews = Object.values(manifest).reduce(
+    (sum, targets) => sum + Object.keys(targets).length,
+    0,
+  );
+  console.log(
+    `\n✅ Built ${totalPreviews} preview(s) for ${Object.keys(manifest).length} prompt(s)`,
+  );
+  console.log(`   Manifest: ${manifestOutPath}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/internal/vibe-tests/src/build-report.ts
+++ b/internal/vibe-tests/src/build-report.ts
@@ -24,12 +24,14 @@ const APP_DIR = path.join(import.meta.dirname, '..', 'app');
 function parseArgs(): {
   iteration: string;
   baseline?: string;
+  html?: string;
   withScreenshots: boolean;
   dev: boolean;
 } {
   const args = process.argv.slice(2);
   let iteration = '';
   let baseline: string | undefined;
+  let html: string | undefined;
   let withScreenshots = false;
   let dev = false;
 
@@ -39,6 +41,9 @@ function parseArgs(): {
       i++;
     } else if (args[i] === '--baseline' && args[i + 1]) {
       baseline = args[i + 1];
+      i++;
+    } else if (args[i] === '--html' && args[i + 1]) {
+      html = args[i + 1];
       i++;
     } else if (args[i] === '--with-screenshots') {
       withScreenshots = true;
@@ -106,6 +111,8 @@ function buildDataScript(opts: {
   manifest: unknown;
   sourceCode?: Record<string, string>;
   baselineSourceCode?: Record<string, string>;
+  htmlSourceCode?: Record<string, string>;
+  previews?: Record<string, Record<string, string>>;
 }): string {
   const reportData = {
     universal: opts.iterationData,
@@ -114,6 +121,8 @@ function buildDataScript(opts: {
     target: (opts.manifest as {config?: {target?: string}})?.config?.target,
     sourceCode: opts.sourceCode,
     baselineSourceCode: opts.baselineSourceCode,
+    htmlSourceCode: opts.htmlSourceCode,
+    previews: opts.previews,
   };
 
   return `<script>window.__REPORT_DATA__=${JSON.stringify(reportData)};</script>`;
@@ -156,7 +165,7 @@ function inlineCss(htmlPath: string, distDir: string): void {
 }
 
 async function main() {
-  const {iteration, baseline, withScreenshots, dev} = parseArgs();
+  const {iteration, baseline, html, withScreenshots, dev} = parseArgs();
   const resultsDir = getResultsDir();
   const iterDir = path.join(resultsDir, iteration);
   const manifestPath = path.join(iterDir, 'manifest.json');
@@ -210,6 +219,33 @@ async function main() {
     }
   }
 
+  let htmlSourceCode: Record<string, string> | undefined;
+  if (html) {
+    htmlSourceCode = {};
+    const htmlCodeDir = path.join(resultsDir, html, 'results');
+    if (fs.existsSync(htmlCodeDir)) {
+      for (const file of fs
+        .readdirSync(htmlCodeDir)
+        .filter(f => f.endsWith('.tsx'))) {
+        const promptId = path.basename(file, '.tsx');
+        htmlSourceCode[promptId] = fs.readFileSync(
+          path.join(htmlCodeDir, file),
+          'utf-8',
+        );
+      }
+    }
+  }
+
+  // Load preview manifest if available
+  const previewManifestPath = path.join(iterDir, 'previews', 'manifest.json');
+  let previews: Record<string, Record<string, string>> | undefined;
+  if (fs.existsSync(previewManifestPath)) {
+    previews = JSON.parse(fs.readFileSync(previewManifestPath, 'utf-8'));
+    console.log(
+      `  ✓ Preview manifest loaded (${Object.keys(previews!).length} prompts)`,
+    );
+  }
+
   // Step 4: Build the data script
   const dataScript = buildDataScript({
     iteration,
@@ -219,6 +255,8 @@ async function main() {
     manifest,
     sourceCode,
     baselineSourceCode,
+    htmlSourceCode,
+    previews,
   });
   console.log(`  ✓ ${(dataScript.length / 1024).toFixed(0)} KB of report data`);
 

--- a/internal/vibe-tests/src/deploy-report.ts
+++ b/internal/vibe-tests/src/deploy-report.ts
@@ -22,31 +22,39 @@ const VIBE_DIR = path.resolve(import.meta.dirname, '..');
 function parseArgs(): {
   iteration: string;
   baseline?: string;
+  html?: string;
   dryRun: boolean;
+  skipPreviews: boolean;
 } {
   const args = process.argv.slice(2);
   let iteration = '';
   let baseline: string | undefined;
+  let html: string | undefined;
   let dryRun = false;
+  let skipPreviews = false;
 
   for (let i = 0; i < args.length; i++) {
     if (args[i] === '--iteration' && args[i + 1]) {
       iteration = args[++i];
     } else if (args[i] === '--baseline' && args[i + 1]) {
       baseline = args[++i];
+    } else if (args[i] === '--html' && args[i + 1]) {
+      html = args[++i];
     } else if (args[i] === '--dry-run') {
       dryRun = true;
+    } else if (args[i] === '--skip-previews') {
+      skipPreviews = true;
     }
   }
 
   if (!iteration) {
     console.error(
-      'Usage: tsx src/deploy-report.ts --iteration <id> [--baseline <id>] [--dry-run]',
+      'Usage: tsx src/deploy-report.ts --iteration <id> [--baseline <id>] [--html <id>] [--dry-run] [--skip-previews]',
     );
     process.exit(1);
   }
 
-  return {iteration, baseline, dryRun};
+  return {iteration, baseline, html, dryRun, skipPreviews};
 }
 
 function run(cmd: string, opts?: {cwd?: string; silent?: boolean}): string {
@@ -60,7 +68,7 @@ function runSilent(cmd: string, opts?: {cwd?: string}): string {
 }
 
 async function main() {
-  const {iteration, baseline, dryRun} = parseArgs();
+  const {iteration, baseline, html, dryRun, skipPreviews} = parseArgs();
 
   const deployPath = `reports/${iteration}`;
 
@@ -71,10 +79,41 @@ async function main() {
   if (dryRun) console.log(`   ⚠️  DRY RUN — will build but not push`);
   console.log('');
 
-  // Step 1: Build the report
-  console.log('🏗️  Step 1: Building report...');
+  // Step 1: Build previews if .tsx result files exist
+  if (!skipPreviews) {
+    const iterationsWithCode: string[] = [];
+    for (const id of [iteration, baseline, html].filter(Boolean) as string[]) {
+      const codeDir = path.join(VIBE_DIR, 'results', id, 'results');
+      if (
+        fs.existsSync(codeDir) &&
+        fs.readdirSync(codeDir).some(f => f.endsWith('.tsx'))
+      ) {
+        iterationsWithCode.push(id);
+      }
+    }
+
+    if (iterationsWithCode.length > 0) {
+      const previewsOut = path.join(VIBE_DIR, 'results', iteration, 'previews');
+      console.log('🖼️  Step 1: Building preview pages...');
+      try {
+        run(
+          `npx tsx src/build-previews.ts --iterations ${iterationsWithCode.join(',')} --out ${previewsOut}`,
+          {cwd: VIBE_DIR},
+        );
+      } catch {
+        console.warn(
+          '   ⚠️  Preview build had errors (continuing without some previews)',
+        );
+      }
+      console.log('');
+    }
+  }
+
+  // Step 2: Build the report
+  console.log('🏗️  Step 2: Building report...');
   const buildArgs = [`--iteration ${iteration}`];
   if (baseline) buildArgs.push(`--baseline ${baseline}`);
+  if (html) buildArgs.push(`--html ${html}`);
 
   run(`npx tsx src/build-report.ts ${buildArgs.join(' ')}`, {cwd: VIBE_DIR});
 
@@ -93,8 +132,8 @@ async function main() {
     return;
   }
 
-  // Step 2: Deploy to gh-pages
-  console.log('🚀 Step 2: Deploying to gh-pages...');
+  // Step 3: Deploy to gh-pages
+  console.log('🚀 Step 3: Deploying to gh-pages...');
 
   const tmpDir = path.join(REPO_ROOT, '.deploy-tmp');
   if (fs.existsSync(tmpDir)) {
@@ -113,6 +152,15 @@ async function main() {
     const targetDir = path.join(tmpDir, deployPath);
     fs.mkdirSync(targetDir, {recursive: true});
     fs.copyFileSync(reportHtml, path.join(targetDir, 'index.html'));
+
+    // Deploy previews if they exist
+    const previewsDir = path.join(VIBE_DIR, 'results', iteration, 'previews');
+    if (fs.existsSync(previewsDir)) {
+      const targetPreviewsDir = path.join(targetDir, 'previews');
+      copyDirRecursive(previewsDir, targetPreviewsDir);
+      const previewCount = countFiles(targetPreviewsDir, '.html');
+      console.log(`   ✓ ${previewCount} preview pages copied`);
+    }
 
     updateReportsIndex(tmpDir);
 
@@ -141,6 +189,32 @@ async function main() {
   } finally {
     fs.rmSync(tmpDir, {recursive: true, force: true});
   }
+}
+
+function copyDirRecursive(src: string, dest: string): void {
+  fs.mkdirSync(dest, {recursive: true});
+  for (const entry of fs.readdirSync(src, {withFileTypes: true})) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirRecursive(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function countFiles(dir: string, ext: string): number {
+  let count = 0;
+  if (!fs.existsSync(dir)) return 0;
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    if (entry.isDirectory()) {
+      count += countFiles(path.join(dir, entry.name), ext);
+    } else if (entry.name.endsWith(ext)) {
+      count++;
+    }
+  }
+  return count;
 }
 
 function updateReportsIndex(ghPagesDir: string): void {


### PR DESCRIPTION
## Summary

Adds live preview pages to vibe test reports — each generated component is built into a standalone HTML page that renders it live. Also improves the report UI with better per-prompt detail cards.

### Live report with previews
📊 https://facebookexperimental.github.io/xds/reports/8734233a/

Click the preview buttons in the "By Prompt" tab to see rendered components for XDS, Baseline, and raw HTML targets side by side.

### What's new

**Preview Pages**
- `build-previews.ts` — builds `.tsx` result files into standalone single-file HTML via Vite
- XDS previews use a `stylex-inline-vars` plugin to handle AI-generated `createTheme()` calls with variable references (see #285)
- Baseline previews inject Tailwind CDN + shadcn CSS variable tokens
- `deploy-report.ts` auto-builds previews when `.tsx` files exist (`--skip-previews` to bypass)

**Report UI**
- Per-prompt detail cards with StatusDot scores, findings, preview + code buttons
- Button hierarchy: preview = secondary, code = ghost
- Three-way support: `--html <id>` flag for HTML target code viewing
- Grid layouts for scores (3-col) and findings (auto + 1fr) 
- Imported `@xds/core/reset.css` (fixes dialog outline, landscape text inflation)

**Pipeline**
- `deploy-report.ts` is now a 3-step pipeline: previews → report → deploy
- All steps are automatic; errors in preview builds are non-fatal

### Related
- #285 — StyleX createTheme static analysis constraints (discovered during preview builds)
- #276 — Table column min-widths
- #277 — Dialog outline reset

---
*Crafted with care by Navi*