### PR TITLE
docs(theme): clarify StyleX static analysis constraints for createTheme

### DIFF
--- a/internal/vibe-tests/test-sets/default.json
+++ b/internal/vibe-tests/test-sets/default.json
@@ -618,6 +618,19 @@
       ]
     },
     {
+      "id": "tc-9",
+      "category": "theme-customization",
+      "prompt": "Create two custom XDS themes that share the same spacing and typography tokens but have different color palettes. The first theme ('ocean') should use blue tones (#0077B6 accent) and the second ('sunset') should use warm orange tones (#E76F51 accent). Keep it DRY — don't duplicate the shared token values.",
+      "expectedComponents": [
+        "XDSTheme"
+      ],
+      "complexity": "complex",
+      "followUps": [
+        "Add a theme switcher that lets the user toggle between the two themes",
+        "Add a third theme that shares colors with ocean but uses different spacing"
+      ]
+    },
+    {
       "id": "fwc-4",
       "category": "feature-with-constraint",
       "prompt": "I need a confirmation dialog that asks \"Are you sure you want to delete this item?\" with cancel and delete buttons. The delete button should be destructive-styled.",

--- a/packages/cli/docs/theme.md
+++ b/packages/cli/docs/theme.md
@@ -88,6 +88,68 @@ The `styles` field uses `stylex.createTheme()` for each token group. The `raw` f
 **Token groups** (all required in both `styles` and `raw`):
 colors, spacing, size, radius, elevation, transition, typography, textSize, lineHeight, fontWeight
 
+### ⚠️ Static Analysis Constraint
+
+StyleX's Babel plugin requires that **all values passed to `stylex.createTheme()` are inline object literals** — not variable references, spread expressions, or function return values. This is a compile-time constraint.
+
+```tsx
+// ❌ BROKEN — StyleX cannot statically analyze variable references
+const sharedSpacing = {
+  '--spacing-1': '4px',
+  '--spacing-2': '8px',
+};
+const spacingTheme = stylex.createTheme(spacingVars, sharedSpacing);
+// Error: "Only static values are allowed inside of a createTheme() call"
+
+// ❌ BROKEN — spread also fails
+const spacingTheme = stylex.createTheme(spacingVars, {...sharedSpacing});
+
+// ✅ WORKS — inline object literal
+const spacingTheme = stylex.createTheme(spacingVars, {
+  '--spacing-1': '4px',
+  '--spacing-2': '8px',
+});
+```
+
+### Sharing values across multiple themes
+
+When creating multiple themes that share token groups (e.g., same spacing, different colors), you **must duplicate the inline values** in each `createTheme()` call. This is required by StyleX's static analysis — there is no way to DRY up `createTheme` arguments.
+
+```tsx
+// ✅ Correct: each theme has its own inline createTheme calls
+// (values can be identical — that's fine, they must just be inline literals)
+
+// --- ocean theme ---
+const oceanSpacingTheme = stylex.createTheme(spacingVars, {
+  '--spacing-1': '4px',
+  '--spacing-2': '8px',
+  // ... same values, written inline
+} as unknown as BaseSpacingRaw);
+
+// --- sunset theme ---
+const sunsetSpacingTheme = stylex.createTheme(spacingVars, {
+  '--spacing-1': '4px',
+  '--spacing-2': '8px',
+  // ... same values, written inline
+} as unknown as BaseSpacingRaw);
+```
+
+The `raw` field (plain objects, not passed to StyleX) _can_ use shared variables:
+
+```tsx
+// ✅ raw values can be shared — they're not processed by StyleX
+const sharedSpacingRaw = {
+  '--spacing-1': '4px',
+  '--spacing-2': '8px',
+};
+
+export const oceanTheme: Theme = {
+  name: 'ocean',
+  styles: {spacing: oceanSpacingTheme /* ... */},
+  raw: {spacing: sharedSpacingRaw /* ... */}, // ✅ OK — not a createTheme call
+};
+```
+
 ## Light/Dark Mode
 
 ### Automatic (recommended)

--- a/packages/cli/src/commands/theme.mjs
+++ b/packages/cli/src/commands/theme.mjs
@@ -419,6 +419,10 @@ const fontWeightRaw = {
 // =============================================================================
 // createTheme calls
 // =============================================================================
+// ⚠️ StyleX CONSTRAINT: Each createTheme() call MUST receive an inline object
+// literal. Do NOT extract values into a shared variable and reference it here —
+// StyleX's Babel plugin cannot statically analyze variable references.
+// If you need multiple themes with the same tokens, duplicate the inline values.
 
 const colorTheme = stylex.createTheme(colorVars, colorRaw as unknown as BaseColorRaw);
 const spacingTheme = stylex.createTheme(spacingVars, spacingRaw as unknown as BaseSpacingRaw);


### PR DESCRIPTION
## Problem

The theme docs show how to create custom themes with `stylex.createTheme()`, but don't mention that StyleX's Babel plugin requires **all values to be inline object literals**. Developers (and AI agents) following DRY principles naturally extract shared token values into variables — which silently fails at compile time.

## Changes

### `packages/cli/docs/theme.md`
- Added **⚠️ Static Analysis Constraint** section with ❌ broken / ✅ working examples
- Added **Sharing values across multiple themes** section explaining:
  - `createTheme()` args must be duplicated inline (no way to DRY them up)
  - `raw` field values *can* be shared (they're not processed by StyleX)

### `packages/cli/src/commands/theme.mjs`
- Added warning comment in the generated theme template above the `createTheme` calls

### `internal/vibe-tests/test-sets/default.json`
- Added `tc-9` test case: multi-theme with shared tokens + "Keep it DRY" instruction — specifically designed to trigger this failure mode

## Vibe Test Validation

Ran before/after vibe tests with the tc-9 prompt:

| | Before Fix | After Fix |
|---|---|---|
| **Shared vars in `createTheme()`** | ✅ Yes (the bug) — extracted 9 shared token groups into variables, passed to `createTheme()` | ❌ No — duplicated inline values as docs recommend |
| **Would compile** | ❌ No — StyleX can't analyze variable references | ✅ Yes — all `createTheme()` args are inline literals |
| **DRY where possible** | Shared everything (broken) | Shared `raw` values only (correct) |
| **`createTheme()` calls** | 11 (9 shared + 2 color) | 20 (10 per theme, all inline) |

The "before" agent noted: *"Without the warning, 100% of developers asked to 'keep it DRY' would produce code that fails to compile."*

The "after" agent noted: *"The docs' explicit 'Sharing values across multiple themes' section with ❌/✅ examples directly addressed this exact multi-theme scenario and prevented the naive DRY instinct from producing broken code."*

Closes #285

---
*Crafted with care by Navi*