### PR TITLE
fix: add prose styles to storybook and fix sandbox build config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,37 +25,44 @@ npm install @xds/core
 yarn add @xds/core
 ```
 
-### 1. Set Up the Theme Provider
+### 1. Import Base Styles
 
-Wrap your application with the `Theme` component. This sets up CSS custom properties used by all XDS components.
+Import the reset and typography stylesheets at the root of your application. These provide a clean cross-browser baseline and prose styles for native HTML elements.
 
 ```tsx
-import {Theme, defaultTheme} from '@xds/core';
+// In your root layout or entry point
+import '@xds/core/reset.css'; // Base reset — box-sizing, margins, etc.
+import '@xds/core/typography.css'; // Prose styles — headings, lists, code, etc.
+```
+
+The reset uses `@layer reset` and typography uses `@layer typography`, so they won't conflict with component styles.
+
+### 2. Set Up the Theme Provider
+
+Wrap your application with the `XDSTheme` component. This sets up CSS custom properties used by all XDS components and typography styles.
+
+```tsx
+import {XDSTheme} from '@xds/core';
+import {defaultTheme} from '@xds/theme-default';
 
 function App() {
   return (
-    <Theme theme={defaultTheme}>
+    <XDSTheme theme={defaultTheme}>
       <YourApp />
-    </Theme>
+    </XDSTheme>
   );
 }
 ```
 
-### 2. Import Typography Styles (Optional)
+### 3. Apply Typography (Optional)
 
-For styling native HTML elements (h1-h6, p, lists, code blocks, etc.), import the typography stylesheet:
-
-```tsx
-import '@xds/core/typography.css';
-```
-
-Apply to your document body or use `XDSFontWrapper` for scoped sections:
+Typography styles activate via the `xds-typography` class or the `XDSFontWrapper` component. Choose one:
 
 ```tsx
-// Option A: Global - apply to body
+// Option A: Global — apply to body
 <body className="xds-typography">
 
-// Option B: Scoped - wrap specific content
+// Option B: Scoped — wrap specific content
 import { XDSFontWrapper } from '@xds/core';
 
 <XDSFontWrapper>
@@ -75,7 +82,7 @@ The typography styles support two heading scales:
 </XDSFontWrapper>
 ```
 
-### 3. Use Components
+### 4. Use Components
 
 ```tsx
 import {XDSButton, XDSText, XDSHeading} from '@xds/core';

--- a/apps/sandbox/babel.config.js
+++ b/apps/sandbox/babel.config.js
@@ -16,7 +16,8 @@ module.exports = {
         aliases: {
           '@xds/core/*': [path.join(rootDir, 'packages/core/src/*')],
           '@xds/core': [path.join(rootDir, 'packages/core/src')],
-          '@xds/theme/*': [path.join(rootDir, 'packages/theme/src/*')],
+          '@xds/theme-default/*': [path.join(rootDir, 'packages/themes/default/src/*')],
+          '@xds/theme-neutral/*': [path.join(rootDir, 'packages/themes/neutral/src/*')],
         },
         unstable_moduleResolution: {
           type: 'commonJS',

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -8,7 +8,7 @@ const nextConfig = {
   output: 'export',
   trailingSlash: true,
   basePath: process.env.SANDBOX_BASE_PATH || '',
-  transpilePackages: ['@xds/core', '@xds/theme'],
+  transpilePackages: ['@xds/core', '@xds/theme-default'],
   images: {
     unoptimized: true,
   },

--- a/apps/sandbox/postcss.config.js
+++ b/apps/sandbox/postcss.config.js
@@ -10,7 +10,8 @@ module.exports = {
       include: [
         'src/**/*.{js,jsx,ts,tsx}',
         path.join(rootDir, 'packages/core/src/**/*.{ts,tsx}'),
-        path.join(rootDir, 'packages/theme/src/**/*.{ts,tsx}'),
+        path.join(rootDir, 'packages/themes/default/src/**/*.{ts,tsx}'),
+        path.join(rootDir, 'packages/themes/neutral/src/**/*.{ts,tsx}'),
       ],
       babelConfig: {
         babelrc: false,

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -4,8 +4,9 @@ import {XDSTheme} from '@xds/core';
 import {defaultTheme} from '@xds/theme-default';
 import {neutralTheme} from '@xds/theme-neutral';
 
-// Import the base reset stylesheet
+// Import the base reset and typography stylesheets
 import '@xds/core/reset.css';
+import '@xds/core/typography.css';
 
 // Import the pre-built StyleX CSS from the core package
 // Use relative path since @xds/core alias points to source, not dist
@@ -31,6 +32,7 @@ const withXDSTheme: Decorator = (Story, context) => {
   if (themeKey === 'none') {
     return (
       <div
+        className="xds-typography"
         style={{
           colorScheme: mode,
           padding: 16,
@@ -45,6 +47,7 @@ const withXDSTheme: Decorator = (Story, context) => {
   return (
     <XDSTheme theme={theme} mode={mode}>
       <div
+        className="xds-typography"
         style={{
           backgroundColor: 'var(--color-surface)',
           padding: 16,


### PR DESCRIPTION
## Problem

Storybook was missing typography/prose styles — the `typography.css` stylesheet was never imported, and the `xds-typography` class wasn't applied to story wrappers. This meant native HTML elements (headings, paragraphs, lists, code blocks, blockquotes) rendered without XDS styling in stories.

The sandbox app had stale build config referencing `packages/theme/` (singular) which doesn't exist — the actual path is `packages/themes/default/` and `packages/themes/neutral/`.

## Changes

### Storybook (`.storybook/preview.tsx`)
- Import `@xds/core/typography.css` alongside the existing `reset.css`
- Apply `xds-typography` class to the story wrapper `<div>` in both themed and unthemed modes

### Sandbox build config
- **`babel.config.js`** — Fix StyleX alias: `@xds/theme/*` → `@xds/theme-default/*` + `@xds/theme-neutral/*`
- **`postcss.config.js`** — Fix include path: `packages/theme/src/` → `packages/themes/default/src/` + `packages/themes/neutral/src/`
- **`next.config.mjs`** — Fix transpilePackages: `@xds/theme` → `@xds/theme-default`

### Documentation (`README.md`)
- Add reset.css as explicit step 1 in Getting Started
- Reorder setup steps: reset/typography → theme provider → apply typography class → use components
- Use correct import paths (`@xds/theme-default` instead of bare `@xds/core` for theme)