### PR TITLE
feat(core): add XDSPopover component

### DIFF
--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -150,7 +150,6 @@ export const FilterPanel: Story = {
     return (
       <XDSPopover
         placement="below"
-        alignment="start"
         label="Filter"
         width={240}
         isShown={isShown}

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -13,11 +13,6 @@ const meta: Meta<typeof XDSPopover> = {
   component: XDSPopover,
   tags: ['autodocs'],
   argTypes: {
-    trigger: {
-      control: 'select',
-      options: ['click', 'hover'],
-      description: 'How the popover is triggered',
-    },
     placement: {
       control: 'select',
       options: ['above', 'below', 'start', 'end'],
@@ -49,7 +44,9 @@ function SettingsContent() {
 
   return (
     <XDSVStack gap="space3">
-      <XDSHeading level={4}>Settings</XDSHeading>
+      <XDSHeading level={4} tabIndex={-1}>
+        Settings
+      </XDSHeading>
       <XDSDivider />
       <XDSSwitch
         label="Notifications"
@@ -75,7 +72,6 @@ function SettingsContent() {
 
 export const Default: Story = {
   args: {
-    trigger: 'click',
     placement: 'below',
     label: 'Settings',
     width: 280,
@@ -101,7 +97,9 @@ function FilterContent({onApply}: {onApply?: () => void}) {
 
   return (
     <XDSVStack gap="space3">
-      <XDSHeading level={4}>Filter by status</XDSHeading>
+      <XDSHeading level={4} tabIndex={-1}>
+        Filter by status
+      </XDSHeading>
       <XDSDivider />
       <XDSCheckboxInput
         label="Active"
@@ -151,7 +149,6 @@ export const FilterPanel: Story = {
     const [isShown, setIsShown] = React.useState(false);
     return (
       <XDSPopover
-        trigger="click"
         placement="below"
         alignment="start"
         label="Filter"
@@ -178,7 +175,9 @@ function ConfirmContent({
 }) {
   return (
     <XDSVStack gap="space3">
-      <XDSHeading level={4}>Delete project?</XDSHeading>
+      <XDSHeading level={4} tabIndex={-1}>
+        Delete project?
+      </XDSHeading>
       <XDSText type="body">
         This will permanently delete the project and all its data. This action
         cannot be undone.
@@ -200,7 +199,6 @@ export const Confirmation: Story = {
     const [isShown, setIsShown] = React.useState(false);
     return (
       <XDSPopover
-        trigger="click"
         placement="below"
         label="Confirm deletion"
         width={300}
@@ -221,34 +219,36 @@ export const Confirmation: Story = {
 };
 
 // =============================================================================
-// Hover Profile Card
+// Sibling Mode (anchorRef)
 // =============================================================================
 
-function ProfileContent() {
-  return (
-    <XDSVStack gap="space2">
-      <XDSHeading level={4}>Jane Doe</XDSHeading>
-      <XDSText type="supporting" color="secondary">
-        Software Engineer · Design Systems
-      </XDSText>
-      <XDSText type="body">
-        Building great products with great people. Based in Menlo Park, CA.
-      </XDSText>
-    </XDSVStack>
-  );
-}
-
-export const HoverTrigger: Story = {
-  args: {
-    trigger: 'hover',
-    placement: 'below',
-    width: 260,
-    content: <ProfileContent />,
-    children: (
-      <XDSButton label="Jane Doe" variant="ghost">
-        Jane Doe
-      </XDSButton>
-    ),
+export const AnchorRef: Story = {
+  render: function AnchorRefStory() {
+    const buttonRef = React.useRef<HTMLButtonElement>(null);
+    return (
+      <>
+        <XDSButton ref={buttonRef} label="Anchor button">
+          Anchor button
+        </XDSButton>
+        <XDSPopover
+          anchorRef={buttonRef as React.RefObject<HTMLElement>}
+          label="Sibling popover"
+          width={260}
+          placement="below"
+          content={
+            <XDSVStack gap="space2">
+              <XDSHeading level={4} tabIndex={-1}>
+                Sibling mode
+              </XDSHeading>
+              <XDSText type="body">
+                This popover uses anchorRef to attach to the button as a
+                sibling, without wrapping it.
+              </XDSText>
+            </XDSVStack>
+          }
+        />
+      </>
+    );
   },
 };
 
@@ -260,13 +260,14 @@ export const Above: Story = {
   render: () => (
     <div style={{paddingTop: 200}}>
       <XDSPopover
-        trigger="click"
         placement="above"
         label="Info"
         width={260}
         content={
           <XDSVStack gap="space2">
-            <XDSHeading level={4}>Keyboard shortcuts</XDSHeading>
+            <XDSHeading level={4} tabIndex={-1}>
+              Keyboard shortcuts
+            </XDSHeading>
             <XDSDivider />
             <XDSHStack gap="space3">
               <XDSText type="body" weight="bold">
@@ -300,7 +301,6 @@ export const Above: Story = {
 
 export const Disabled: Story = {
   args: {
-    trigger: 'click',
     placement: 'below',
     label: 'Disabled popover',
     isEnabled: false,

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -1,0 +1,125 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSPopover} from '@xds/core/Layer';
+import {XDSButton} from '@xds/core/Button';
+import {XDSVStack} from '@xds/core/Layout';
+
+const meta: Meta<typeof XDSPopover> = {
+  title: 'Core/XDSPopover',
+  component: XDSPopover,
+  tags: ['autodocs'],
+  argTypes: {
+    trigger: {
+      control: 'select',
+      options: ['click', 'hover'],
+      description: 'How the popover is triggered',
+    },
+    placement: {
+      control: 'select',
+      options: ['above', 'below', 'start', 'end'],
+      description: 'Position relative to trigger',
+    },
+    alignment: {
+      control: 'select',
+      options: ['start', 'center', 'end'],
+      description: 'Alignment on placement axis',
+    },
+    isEnabled: {
+      control: 'boolean',
+      description: 'Enable/disable the popover',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSPopover>;
+
+function PopoverContent() {
+  return (
+    <XDSVStack gap="space2">
+      <div style={{fontWeight: 600}} tabIndex={-1}>
+        Popover Title
+      </div>
+      <div style={{fontSize: 14}}>
+        This is some popover content. It can contain any React elements.
+      </div>
+    </XDSVStack>
+  );
+}
+
+export const Default: Story = {
+  args: {
+    trigger: 'click',
+    placement: 'below',
+    label: 'Example popover',
+    content: <PopoverContent />,
+    children: <XDSButton label="Open popover">Open popover</XDSButton>,
+  },
+};
+
+export const Above: Story = {
+  render: () => (
+    <div style={{paddingTop: 200}}>
+      <XDSPopover
+        trigger="click"
+        placement="above"
+        label="Above popover"
+        content={<PopoverContent />}>
+        <XDSButton label="Above">Above</XDSButton>
+      </XDSPopover>
+    </div>
+  ),
+};
+
+export const HoverTrigger: Story = {
+  args: {
+    trigger: 'hover',
+    placement: 'below',
+    content: <PopoverContent />,
+    children: <XDSButton label="Hover me">Hover me</XDSButton>,
+  },
+};
+
+export const Controlled: Story = {
+  render: function ControlledExample() {
+    const [isShown, setIsShown] = React.useState(false);
+    return (
+      <div style={{padding: 100}}>
+        <XDSPopover
+          trigger="click"
+          placement="below"
+          label="Controlled popover"
+          isShown={isShown}
+          onToggle={setIsShown}
+          content={
+            <XDSVStack gap="space2">
+              <div>Controlled popover</div>
+              <XDSButton
+                label="Close"
+                variant="primary"
+                onClick={() => setIsShown(false)}>
+                Close
+              </XDSButton>
+            </XDSVStack>
+          }>
+          <XDSButton label="Toggle" onClick={() => setIsShown(!isShown)}>
+            {isShown ? 'Close' : 'Open'}
+          </XDSButton>
+        </XDSPopover>
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    trigger: 'click',
+    placement: 'below',
+    label: 'Disabled popover',
+    isEnabled: false,
+    content: <PopoverContent />,
+    children: <XDSButton label="Disabled popover">Disabled popover</XDSButton>,
+  },
+};
+
+// Need React import for Controlled story
+import React from 'react';

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -1,7 +1,12 @@
+import React from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSPopover} from '@xds/core/Layer';
 import {XDSButton} from '@xds/core/Button';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSSwitch} from '@xds/core/Switch';
+import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+import {XDSDivider} from '@xds/core/Divider';
 
 const meta: Meta<typeof XDSPopover> = {
   title: 'Core/XDSPopover',
@@ -33,15 +38,37 @@ const meta: Meta<typeof XDSPopover> = {
 export default meta;
 type Story = StoryObj<typeof XDSPopover>;
 
-function PopoverContent() {
+// =============================================================================
+// Settings Panel
+// =============================================================================
+
+function SettingsContent() {
+  const [notifications, setNotifications] = React.useState(true);
+  const [darkMode, setDarkMode] = React.useState(false);
+  const [sounds, setSounds] = React.useState(true);
+
   return (
-    <XDSVStack gap="space2">
-      <div style={{fontWeight: 600}} tabIndex={-1}>
-        Popover Title
-      </div>
-      <div style={{fontSize: 14}}>
-        This is some popover content. It can contain any React elements.
-      </div>
+    <XDSVStack gap="space3">
+      <XDSHeading level={4}>Settings</XDSHeading>
+      <XDSDivider />
+      <XDSSwitch
+        label="Notifications"
+        description="Receive push notifications"
+        value={notifications}
+        onChange={setNotifications}
+      />
+      <XDSSwitch
+        label="Dark mode"
+        description="Use dark color theme"
+        value={darkMode}
+        onChange={setDarkMode}
+      />
+      <XDSSwitch
+        label="Sounds"
+        description="Play sounds for actions"
+        value={sounds}
+        onChange={setSounds}
+      />
     </XDSVStack>
   );
 }
@@ -50,11 +77,184 @@ export const Default: Story = {
   args: {
     trigger: 'click',
     placement: 'below',
-    label: 'Example popover',
-    content: <PopoverContent />,
-    children: <XDSButton label="Open popover">Open popover</XDSButton>,
+    label: 'Settings',
+    width: 280,
+    content: <SettingsContent />,
+    children: <XDSButton label="Settings">Settings</XDSButton>,
   },
 };
+
+// =============================================================================
+// Filter Panel
+// =============================================================================
+
+function FilterContent({onApply}: {onApply?: () => void}) {
+  const [filters, setFilters] = React.useState({
+    active: true,
+    archived: false,
+    drafts: true,
+    shared: false,
+  });
+
+  const toggle = (key: keyof typeof filters) =>
+    setFilters(prev => ({...prev, [key]: !prev[key]}));
+
+  return (
+    <XDSVStack gap="space3">
+      <XDSHeading level={4}>Filter by status</XDSHeading>
+      <XDSDivider />
+      <XDSCheckboxInput
+        label="Active"
+        value={filters.active}
+        onChange={() => toggle('active')}
+      />
+      <XDSCheckboxInput
+        label="Archived"
+        value={filters.archived}
+        onChange={() => toggle('archived')}
+      />
+      <XDSCheckboxInput
+        label="Drafts"
+        value={filters.drafts}
+        onChange={() => toggle('drafts')}
+      />
+      <XDSCheckboxInput
+        label="Shared with me"
+        value={filters.shared}
+        onChange={() => toggle('shared')}
+      />
+      <XDSDivider />
+      <XDSHStack gap="space2">
+        <XDSButton label="Apply" variant="primary" onClick={onApply}>
+          Apply
+        </XDSButton>
+        <XDSButton
+          label="Reset"
+          variant="ghost"
+          onClick={() =>
+            setFilters({
+              active: true,
+              archived: false,
+              drafts: true,
+              shared: false,
+            })
+          }>
+          Reset
+        </XDSButton>
+      </XDSHStack>
+    </XDSVStack>
+  );
+}
+
+export const FilterPanel: Story = {
+  render: function FilterPanelStory() {
+    const [isShown, setIsShown] = React.useState(false);
+    return (
+      <XDSPopover
+        trigger="click"
+        placement="below"
+        alignment="start"
+        label="Filter"
+        width={240}
+        isShown={isShown}
+        onToggle={setIsShown}
+        content={<FilterContent onApply={() => setIsShown(false)} />}>
+        <XDSButton label="Filter">Filter</XDSButton>
+      </XDSPopover>
+    );
+  },
+};
+
+// =============================================================================
+// Confirmation
+// =============================================================================
+
+function ConfirmContent({
+  onConfirm,
+  onCancel,
+}: {
+  onConfirm?: () => void;
+  onCancel?: () => void;
+}) {
+  return (
+    <XDSVStack gap="space3">
+      <XDSHeading level={4}>Delete project?</XDSHeading>
+      <XDSText type="body">
+        This will permanently delete the project and all its data. This action
+        cannot be undone.
+      </XDSText>
+      <XDSHStack gap="space2">
+        <XDSButton label="Delete" variant="destructive" onClick={onConfirm}>
+          Delete
+        </XDSButton>
+        <XDSButton label="Cancel" variant="ghost" onClick={onCancel}>
+          Cancel
+        </XDSButton>
+      </XDSHStack>
+    </XDSVStack>
+  );
+}
+
+export const Confirmation: Story = {
+  render: function ConfirmationStory() {
+    const [isShown, setIsShown] = React.useState(false);
+    return (
+      <XDSPopover
+        trigger="click"
+        placement="below"
+        label="Confirm deletion"
+        width={300}
+        isShown={isShown}
+        onToggle={setIsShown}
+        content={
+          <ConfirmContent
+            onConfirm={() => setIsShown(false)}
+            onCancel={() => setIsShown(false)}
+          />
+        }>
+        <XDSButton label="Delete project" variant="destructive">
+          Delete project
+        </XDSButton>
+      </XDSPopover>
+    );
+  },
+};
+
+// =============================================================================
+// Hover Profile Card
+// =============================================================================
+
+function ProfileContent() {
+  return (
+    <XDSVStack gap="space2">
+      <XDSHeading level={4}>Jane Doe</XDSHeading>
+      <XDSText type="supporting" color="secondary">
+        Software Engineer · Design Systems
+      </XDSText>
+      <XDSText type="body">
+        Building great products with great people. Based in Menlo Park, CA.
+      </XDSText>
+    </XDSVStack>
+  );
+}
+
+export const HoverTrigger: Story = {
+  args: {
+    trigger: 'hover',
+    placement: 'below',
+    width: 260,
+    content: <ProfileContent />,
+    children: (
+      <XDSButton label="Jane Doe" variant="ghost">
+        Jane Doe
+      </XDSButton>
+    ),
+  },
+};
+
+// =============================================================================
+// Placement: Above
+// =============================================================================
 
 export const Above: Story = {
   render: () => (
@@ -62,53 +262,41 @@ export const Above: Story = {
       <XDSPopover
         trigger="click"
         placement="above"
-        label="Above popover"
-        content={<PopoverContent />}>
-        <XDSButton label="Above">Above</XDSButton>
+        label="Info"
+        width={260}
+        content={
+          <XDSVStack gap="space2">
+            <XDSHeading level={4}>Keyboard shortcuts</XDSHeading>
+            <XDSDivider />
+            <XDSHStack gap="space3">
+              <XDSText type="body" weight="bold">
+                ⌘K
+              </XDSText>
+              <XDSText type="body">Command palette</XDSText>
+            </XDSHStack>
+            <XDSHStack gap="space3">
+              <XDSText type="body" weight="bold">
+                ⌘/
+              </XDSText>
+              <XDSText type="body">Toggle sidebar</XDSText>
+            </XDSHStack>
+            <XDSHStack gap="space3">
+              <XDSText type="body" weight="bold">
+                ⌘.
+              </XDSText>
+              <XDSText type="body">Quick actions</XDSText>
+            </XDSHStack>
+          </XDSVStack>
+        }>
+        <XDSButton label="Shortcuts">Shortcuts</XDSButton>
       </XDSPopover>
     </div>
   ),
 };
 
-export const HoverTrigger: Story = {
-  args: {
-    trigger: 'hover',
-    placement: 'below',
-    content: <PopoverContent />,
-    children: <XDSButton label="Hover me">Hover me</XDSButton>,
-  },
-};
-
-export const Controlled: Story = {
-  render: function ControlledExample() {
-    const [isShown, setIsShown] = React.useState(false);
-    return (
-      <div style={{padding: 100}}>
-        <XDSPopover
-          trigger="click"
-          placement="below"
-          label="Controlled popover"
-          isShown={isShown}
-          onToggle={setIsShown}
-          content={
-            <XDSVStack gap="space2">
-              <div>Controlled popover</div>
-              <XDSButton
-                label="Close"
-                variant="primary"
-                onClick={() => setIsShown(false)}>
-                Close
-              </XDSButton>
-            </XDSVStack>
-          }>
-          <XDSButton label="Toggle" onClick={() => setIsShown(!isShown)}>
-            {isShown ? 'Close' : 'Open'}
-          </XDSButton>
-        </XDSPopover>
-      </div>
-    );
-  },
-};
+// =============================================================================
+// Disabled
+// =============================================================================
 
 export const Disabled: Story = {
   args: {
@@ -116,10 +304,7 @@ export const Disabled: Story = {
     placement: 'below',
     label: 'Disabled popover',
     isEnabled: false,
-    content: <PopoverContent />,
-    children: <XDSButton label="Disabled popover">Disabled popover</XDSButton>,
+    content: <XDSText type="body">This should not appear.</XDSText>,
+    children: <XDSButton label="Disabled popover">Disabled</XDSButton>,
   },
 };
-
-// Need React import for Controlled story
-import React from 'react';

--- a/packages/core/src/Layer/XDSPopover.test.tsx
+++ b/packages/core/src/Layer/XDSPopover.test.tsx
@@ -9,6 +9,7 @@
 
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
+import React from 'react';
 import {XDSPopover} from './XDSPopover';
 
 // Store original matches to restore later
@@ -140,13 +141,23 @@ describe('XDSPopover', () => {
     expect(screen.getByTestId('my-popover')).toBeInTheDocument();
   });
 
-  it('renders hover trigger as HoverCard', () => {
-    render(
-      <XDSPopover trigger="hover" content={<span>Hover content</span>}>
-        <button>Hover me</button>
-      </XDSPopover>,
-    );
-    // Hover trigger should render the trigger element
-    expect(screen.getByRole('button', {name: 'Hover me'})).toBeInTheDocument();
+  it('supports anchorRef sibling mode', () => {
+    function AnchorRefTest() {
+      const ref = React.useRef<HTMLButtonElement>(null);
+      return (
+        <>
+          <button ref={ref}>Anchor</button>
+          <XDSPopover
+            anchorRef={ref as React.RefObject<HTMLElement>}
+            content={<span>Sibling content</span>}
+            label="Sibling"
+          />
+        </>
+      );
+    }
+    render(<AnchorRefTest />);
+    const anchor = screen.getByRole('button', {name: 'Anchor'});
+    expect(anchor).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(anchor).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/packages/core/src/Layer/XDSPopover.test.tsx
+++ b/packages/core/src/Layer/XDSPopover.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * @file XDSPopover.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSPopover component
+ * @output Unit tests for XDSPopover component behavior
+ * @position Testing; validates XDSPopover.tsx implementation
+ *
+ * SYNC: When XDSPopover.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {XDSPopover} from './XDSPopover';
+
+// Store original matches to restore later
+const originalMatches = HTMLElement.prototype.matches;
+
+// Track popover open state per element
+const popoverOpenState = new WeakMap<HTMLElement, boolean>();
+
+// Mock Popover API for jsdom
+beforeAll(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, true);
+    // Dispatch toggle event
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    popoverOpenState.set(this, false);
+    const event = new Event('toggle');
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+
+  HTMLElement.prototype.matches = function (selector: string) {
+    if (selector === ':popover-open') {
+      return popoverOpenState.get(this) ?? false;
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterAll(() => {
+  HTMLElement.prototype.matches = originalMatches;
+});
+
+describe('XDSPopover', () => {
+  it('renders trigger element', () => {
+    render(
+      <XDSPopover content={<span>Popover content</span>} label="Test popover">
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    expect(screen.getByRole('button', {name: 'Open'})).toBeInTheDocument();
+  });
+
+  it('sets aria-haspopup on trigger', () => {
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <button>Trigger</button>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+  });
+
+  it('sets aria-expanded=false initially', () => {
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <button>Trigger</button>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens on click and updates aria-expanded', () => {
+    render(
+      <XDSPopover content={<span>Popover content</span>} label="Test">
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Open'});
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('renders popover content with role=dialog', () => {
+    render(
+      <XDSPopover content={<span>Hello</span>} label="Greeting">
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    // The dialog is inside a popover element — hidden from accessibility tree
+    // until shown, but still present in the DOM
+    const dialog = screen.getByRole('dialog', {hidden: true});
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAttribute('aria-label', 'Greeting');
+  });
+
+  it('calls onToggle when opened', () => {
+    const onToggle = vi.fn();
+    render(
+      <XDSPopover
+        content={<span>Content</span>}
+        label="Test"
+        onToggle={onToggle}>
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('does not open when isEnabled is false', () => {
+    const onToggle = vi.fn();
+    render(
+      <XDSPopover
+        content={<span>Content</span>}
+        label="Test"
+        isEnabled={false}
+        onToggle={onToggle}>
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    fireEvent.click(screen.getByRole('button', {name: 'Open'}));
+    expect(onToggle).not.toHaveBeenCalled();
+  });
+
+  it('renders with data-testid', () => {
+    render(
+      <XDSPopover
+        content={<span>Content</span>}
+        label="Test"
+        data-testid="my-popover">
+        <button>Open</button>
+      </XDSPopover>,
+    );
+    expect(screen.getByTestId('my-popover')).toBeInTheDocument();
+  });
+
+  it('renders hover trigger as HoverCard', () => {
+    render(
+      <XDSPopover trigger="hover" content={<span>Hover content</span>}>
+        <button>Hover me</button>
+      </XDSPopover>,
+    );
+    // Hover trigger should render the trigger element
+    expect(screen.getByRole('button', {name: 'Hover me'})).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Layer/XDSPopover.test.tsx
+++ b/packages/core/src/Layer/XDSPopover.test.tsx
@@ -160,4 +160,69 @@ describe('XDSPopover', () => {
     expect(anchor).toHaveAttribute('aria-haspopup', 'dialog');
     expect(anchor).toHaveAttribute('aria-expanded', 'false');
   });
+
+  it('finds button inside wrapper and attaches ARIA', () => {
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <div>
+          <button>Nested button</button>
+        </div>
+      </XDSPopover>,
+    );
+    const button = screen.getByRole('button', {name: 'Nested button'});
+    expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('finds role="button" elements and attaches ARIA', () => {
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <div role="button" tabIndex={0}>
+          Custom trigger
+        </div>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Custom trigger'});
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('opens on click for role="button" elements', () => {
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <div role="button" tabIndex={0}>
+          Custom trigger
+        </div>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Custom trigger'});
+    fireEvent.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('opens on Enter/Space for role="button" elements', () => {
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <div role="button" tabIndex={0}>
+          Custom trigger
+        </div>
+      </XDSPopover>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Custom trigger'});
+    fireEvent.keyDown(trigger, {key: 'Enter'});
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('warns in dev when children have no button', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <XDSPopover content={<span>Content</span>} label="Test">
+        <span>Not a button</span>
+      </XDSPopover>,
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('must contain a <button> or [role="button"]'),
+    );
+    warnSpy.mockRestore();
+  });
 });

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -134,12 +134,10 @@ const styles = stylex.create({
   wrapperContents: {
     display: 'contents',
   },
-  container: {
-    backgroundColor: colorVars['--color-surface'],
-    color: colorVars['--color-text-primary'],
-    borderRadius: radiusVars['--radius-element'],
-    boxShadow: elevationVars['--elevation-menu'],
-    // Animation: closed state (default) and open state
+  // Animation styles for the popover element (the one with [popover] attribute).
+  // :popover-open only matches the element with the popover attribute,
+  // so these MUST be applied via xstyle to useXDSLayer's render wrapper.
+  popoverAnimation: {
     opacity: {
       default: 0,
       ':popover-open': 1,
@@ -148,16 +146,21 @@ const styles = stylex.create({
       default: 'scale(0.95)',
       ':popover-open': 'scale(1)',
     },
-    // Transitions with allow-discrete for display/overlay
     transitionProperty: 'opacity, transform, overlay, display',
     transitionDuration: '0.15s',
     transitionTimingFunction: 'ease',
     transitionBehavior: 'allow-discrete',
-    // Entry animation starting state
     '@starting-style': {
       opacity: 0,
       transform: 'scale(0.95)',
     },
+  },
+  // Visual styles for the inner content container
+  container: {
+    backgroundColor: colorVars['--color-surface'],
+    color: colorVars['--color-text-primary'],
+    borderRadius: radiusVars['--radius-element'],
+    boxShadow: elevationVars['--elevation-menu'],
   },
   contentPadding: {
     paddingBlockStart: spacingVars['--spacing-3'],
@@ -356,7 +359,7 @@ export function XDSPopover({
           {
             placement,
             alignment,
-            xstyle: [popoverXstyle, styles.gap],
+            xstyle: [popoverXstyle, styles.gap, styles.popoverAnimation],
           },
         )}
       </>
@@ -379,7 +382,7 @@ export function XDSPopover({
         {
           placement,
           alignment,
-          xstyle: [popoverXstyle, styles.gap],
+          xstyle: [popoverXstyle, styles.gap, styles.popoverAnimation],
         },
       )}
     </>

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -131,8 +131,13 @@ export interface XDSPopoverProps {
 // =============================================================================
 
 const styles = stylex.create({
-  wrapperContents: {
-    display: 'contents',
+  // Stable anchor wrapper — uses inline-flex to generate a box for CSS
+  // anchor positioning without affecting layout. The trigger element (e.g.
+  // XDSButton) renders inside this wrapper. Because the wrapper itself is
+  // the anchor, pressed-state transforms on the child (e.g. :active scale)
+  // don't shift the anchor position and cause popover jitter.
+  anchorWrapper: {
+    display: 'inline-flex',
   },
   // Animation styles for the popover element (the one with [popover] attribute).
   // :popover-open only matches the element with the popover attribute,
@@ -187,7 +192,9 @@ const styles = stylex.create({
 /**
  * A click-triggered popover for displaying interactive content anchored to a trigger.
  *
- * Uses a display:contents wrapper so children refs are preserved.
+ * Uses an inline-flex wrapper as the CSS anchor. This wrapper is stable —
+ * it doesn't receive pressed-state transforms (e.g. `:active { scale(0.98) }`)
+ * that the child trigger element may have, preventing popover position jitter.
  * Focus is trapped inside the popover when open.
  * Supports light dismiss (click outside or Escape to close).
  *
@@ -294,20 +301,23 @@ export function XDSPopover({
     };
   }, [anchorRef, popover, handleClick]);
 
-  // Children mode: attach to first child element via display:contents wrapper
+  // Children mode: use wrapper as anchor, attach ARIA + click to child.
+  // The wrapper is the CSS anchor (stable, no transforms), while the child
+  // element (e.g. XDSButton) gets the ARIA attributes and click handler.
   useLayoutEffect(() => {
     if (anchorRef) return; // Skip if using anchorRef mode
 
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
 
+    // Use the wrapper itself as the anchor — it doesn't receive
+    // pressed-state transforms, so the anchor position stays stable.
+    popover.triggerRef(wrapper);
+
     const firstChild = wrapper.firstElementChild as HTMLElement | null;
     if (!firstChild) return;
 
-    // Set up anchor positioning
-    popover.triggerRef(firstChild);
-
-    // Set ARIA attributes
+    // ARIA attributes go on the interactive child element
     firstChild.setAttribute(
       'aria-haspopup',
       popover.triggerProps['aria-haspopup'],
@@ -321,7 +331,7 @@ export function XDSPopover({
       popover.triggerProps['aria-controls'],
     );
 
-    // Add click handler
+    // Click handler goes on the interactive child element
     firstChild.addEventListener('click', handleClick);
 
     return () => {
@@ -370,7 +380,7 @@ export function XDSPopover({
     <>
       <div
         ref={wrapperRef as React.RefObject<HTMLDivElement>}
-        {...stylex.props(styles.wrapperContents)}>
+        {...stylex.props(styles.anchorWrapper)}>
         {children}
       </div>
       {popover.render(

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -1,8 +1,10 @@
 /**
  * @file XDSPopover.tsx
- * @input Uses React, useXDSPopover hook, XDSHoverCard
- * @output Exports XDSPopover component for click/hover triggered popovers
+ * @input Uses React, useXDSPopover hook
+ * @output Exports XDSPopover component for click-triggered popovers
  * @position Layer component; declarative wrapper around useXDSPopover hook
+ *
+ * For hover-triggered overlays, use XDSHoverCard instead.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Layer/README.md
@@ -13,7 +15,6 @@
 
 import React, {
   useCallback,
-  useEffect,
   useLayoutEffect,
   useRef,
   type ReactElement,
@@ -22,14 +23,8 @@ import React, {
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {useXDSPopover} from './useXDSPopover';
-import {XDSHoverCard} from './XDSHoverCard';
 import type {LayerAlignment, LayerPlacement} from './useXDSLayer';
-import {
-  colorVars,
-  spacingVars,
-  radiusVars,
-  elevationVars,
-} from '../theme/tokens.stylex';
+import {colorVars, spacingVars, radiusVars} from '../theme/tokens.stylex';
 import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
 
 // =============================================================================
@@ -48,18 +43,23 @@ declare module '../theme/types' {
 // Types
 // =============================================================================
 
-/**
- * How the popover is triggered.
- */
-export type XDSPopoverTrigger = 'click' | 'hover';
-
 export interface XDSPopoverProps {
   /**
    * The trigger element. Must accept a ref.
-   * For click trigger: receives onClick, aria-expanded, aria-haspopup, aria-controls.
-   * For hover trigger: delegates to XDSHoverCard behavior.
+   * Receives onClick, aria-expanded, aria-haspopup, aria-controls.
+   *
+   * When `anchorRef` is provided, children can be omitted and the popover
+   * attaches to the external ref element as a sibling.
    */
-  children: ReactNode;
+  children?: ReactNode;
+
+  /**
+   * External ref to use as the popover anchor.
+   * When provided (and no children), the popover attaches to this element
+   * instead of wrapping children. This enables sibling-mode rendering,
+   * useful when the trigger element is managed externally.
+   */
+  anchorRef?: React.RefObject<HTMLElement>;
 
   /**
    * Content to display inside the popover.
@@ -80,35 +80,15 @@ export interface XDSPopoverProps {
   alignment?: LayerAlignment;
 
   /**
-   * How the popover is triggered.
-   * - click: Opens on click, closes on click outside or Escape
-   * - hover: Opens on hover/focus, closes on mouse leave (delegates to XDSHoverCard)
-   * @default 'click'
-   */
-  trigger?: XDSPopoverTrigger;
-
-  /**
    * Whether the popover is shown (controlled mode).
    * Omit for uncontrolled behavior.
    */
   isShown?: boolean;
 
   /**
-   * Default shown state for uncontrolled mode.
-   * @default false
-   */
-  initialIsShown?: boolean;
-
-  /**
    * Callback fired when the popover visibility changes.
    */
   onToggle?: (isShown: boolean) => void;
-
-  /**
-   * Whether to trap focus inside the popover when open.
-   * @default true for click trigger, false for hover trigger
-   */
-  hasFocusTrap?: boolean;
 
   /**
    * Whether the popover is enabled.
@@ -126,7 +106,7 @@ export interface XDSPopoverProps {
 
   /**
    * Accessible label for the popover dialog.
-   * Recommended for click-triggered popovers (which use role="dialog").
+   * Recommended for accessibility (used as aria-label on the dialog).
    */
   label?: string;
 
@@ -151,6 +131,7 @@ const styles = stylex.create({
   },
   container: {
     backgroundColor: colorVars['--color-surface'],
+    color: colorVars['--color-text-primary'],
     borderRadius: radiusVars['--radius-element'],
     boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
     // Animation: closed state (default) and open state
@@ -196,26 +177,19 @@ const styles = stylex.create({
 // =============================================================================
 
 /**
- * A popover component for displaying interactive content anchored to a trigger.
+ * A click-triggered popover for displaying interactive content anchored to a trigger.
  *
  * Uses a display:contents wrapper so children refs are preserved.
- * For click trigger, uses useXDSPopover with focus trap and light dismiss.
- * For hover trigger, delegates to XDSHoverCard.
+ * Focus is trapped inside the popover when open.
+ * Supports light dismiss (click outside or Escape to close).
+ *
+ * For hover-triggered overlays, use {@link XDSHoverCard} instead.
  *
  * @example
  * ```tsx
- * // Click-triggered popover
- * <XDSPopover
- *   label="Settings"
- *   content={<SettingsPanel />}
- *   placement="below"
- * >
+ * // Basic popover
+ * <XDSPopover label="Settings" content={<SettingsPanel />} placement="below">
  *   <XDSButton label="Settings" />
- * </XDSPopover>
- *
- * // Hover-triggered popover (delegates to HoverCard)
- * <XDSPopover trigger="hover" content={<UserCard />}>
- *   <XDSAvatar src={avatar} label={name} />
  * </XDSPopover>
  *
  * // Controlled popover
@@ -227,98 +201,32 @@ const styles = stylex.create({
  * >
  *   <XDSButton label="Filter" />
  * </XDSPopover>
+ *
+ * // Sibling mode with anchorRef
+ * <XDSPopover
+ *   anchorRef={myButtonRef}
+ *   label="Actions"
+ *   content={<ActionMenu />}
+ *   placement="below"
+ * />
  * ```
  */
 export function XDSPopover({
   children,
+  anchorRef,
   content,
   placement = 'below',
   alignment = 'center',
-  trigger = 'click',
   isShown,
-  initialIsShown = false,
   onToggle,
-  hasFocusTrap,
   isEnabled = true,
   width,
   label,
   xstyle,
   'data-testid': testId,
 }: XDSPopoverProps): ReactElement {
-  // Hover trigger delegates to XDSHoverCard
-  if (trigger === 'hover') {
-    return (
-      <XDSHoverCard
-        content={content}
-        placement={placement}
-        alignment={alignment}
-        isEnabled={isEnabled}
-        onShow={() => onToggle?.(true)}
-        onHide={() => onToggle?.(false)}>
-        {children}
-      </XDSHoverCard>
-    );
-  }
-
-  // Click trigger uses useXDSPopover
-  return (
-    <ClickPopover
-      content={content}
-      placement={placement}
-      alignment={alignment}
-      isShown={isShown}
-      initialIsShown={initialIsShown}
-      onToggle={onToggle}
-      isEnabled={isEnabled}
-      width={width}
-      label={label}
-      xstyle={xstyle}
-      data-testid={testId}>
-      {children}
-    </ClickPopover>
-  );
-}
-
-// =============================================================================
-// Click Popover (internal)
-// =============================================================================
-
-interface ClickPopoverProps {
-  children: ReactNode;
-  content: ReactNode;
-  placement: LayerPlacement;
-  alignment: LayerAlignment;
-  isShown?: boolean;
-  initialIsShown: boolean;
-  onToggle?: (isShown: boolean) => void;
-  isEnabled: boolean;
-  width?: number | string;
-  label?: string;
-  xstyle?: StyleXStyles;
-  'data-testid'?: string;
-}
-
-/**
- * Internal click-triggered popover implementation.
- * Extracted to a separate component so hooks are called unconditionally.
- */
-function ClickPopover({
-  children,
-  content,
-  placement,
-  alignment,
-  isShown,
-  initialIsShown,
-  onToggle,
-  isEnabled,
-  width,
-  label,
-  xstyle,
-  'data-testid': testId,
-}: ClickPopoverProps): ReactElement {
   const wrapperRef = useRef<HTMLElement>(null);
   const isControlled = isShown !== undefined;
-  const initializedRef = useRef(false);
 
   const popover = useXDSPopover({
     dialogLabel: label,
@@ -327,40 +235,52 @@ function ClickPopover({
     onHide: () => onToggle?.(false),
   });
 
-  // Sync controlled state
-  useEffect(() => {
-    if (!isControlled) return;
-    if (isShown && !popover.isOpen) {
-      popover.show();
-    } else if (!isShown && popover.isOpen) {
-      popover.hide();
-    }
-  }, [isShown, isControlled, popover]);
-
-  // Handle initialIsShown
-  useEffect(() => {
-    if (!isControlled && initialIsShown && !initializedRef.current) {
-      initializedRef.current = true;
-      popover.show();
-    }
-  }, [initialIsShown, isControlled, popover]);
-
-  // Handle click on trigger
+  // Handle click on trigger — delegates to hook's toggle.
+  // In controlled mode, the useLayoutEffect below syncs isShown → hook state,
+  // and the hook's onShow/onHide callbacks propagate back to onToggle.
   const handleClick = useCallback(
     (e: MouseEvent) => {
       if (!isEnabled) return;
       e.preventDefault();
-      if (isControlled) {
-        onToggle?.(!isShown);
-      } else {
-        popover.toggle();
-      }
+      popover.toggle();
     },
-    [isEnabled, isControlled, isShown, onToggle, popover],
+    [isEnabled, popover],
   );
 
-  // Attach click handler and popover ref to first child element
+  // Sibling mode: attach to external anchorRef
   useLayoutEffect(() => {
+    if (!anchorRef) return;
+
+    const el = anchorRef.current;
+    if (!el) return;
+
+    // Set up anchor positioning
+    popover.triggerRef(el);
+
+    // Set ARIA attributes
+    el.setAttribute('aria-haspopup', popover.triggerProps['aria-haspopup']);
+    el.setAttribute(
+      'aria-expanded',
+      String(popover.triggerProps['aria-expanded']),
+    );
+    el.setAttribute('aria-controls', popover.triggerProps['aria-controls']);
+
+    // Add click handler
+    el.addEventListener('click', handleClick);
+
+    return () => {
+      popover.triggerRef(null);
+      el.removeAttribute('aria-haspopup');
+      el.removeAttribute('aria-expanded');
+      el.removeAttribute('aria-controls');
+      el.removeEventListener('click', handleClick);
+    };
+  }, [anchorRef, popover, handleClick]);
+
+  // Children mode: attach to first child element via display:contents wrapper
+  useLayoutEffect(() => {
+    if (anchorRef) return; // Skip if using anchorRef mode
+
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
 
@@ -371,9 +291,18 @@ function ClickPopover({
     popover.triggerRef(firstChild);
 
     // Set ARIA attributes
-    firstChild.setAttribute('aria-haspopup', 'dialog');
-    firstChild.setAttribute('aria-expanded', String(popover.isOpen));
-    firstChild.setAttribute('aria-controls', popover.id);
+    firstChild.setAttribute(
+      'aria-haspopup',
+      popover.triggerProps['aria-haspopup'],
+    );
+    firstChild.setAttribute(
+      'aria-expanded',
+      String(popover.triggerProps['aria-expanded']),
+    );
+    firstChild.setAttribute(
+      'aria-controls',
+      popover.triggerProps['aria-controls'],
+    );
 
     // Add click handler
     firstChild.addEventListener('click', handleClick);
@@ -385,10 +314,40 @@ function ClickPopover({
       firstChild.removeAttribute('aria-controls');
       firstChild.removeEventListener('click', handleClick);
     };
-  }, [popover, handleClick]);
+  }, [anchorRef, popover, handleClick]);
+
+  // Sync controlled state
+  useLayoutEffect(() => {
+    if (!isControlled) return;
+    if (isShown && !popover.isOpen) {
+      popover.show();
+    } else if (!isShown && popover.isOpen) {
+      popover.hide();
+    }
+  }, [isShown, isControlled, popover]);
 
   // Determine popover xstyle
   const popoverXstyle = width ? styles.customWidth(width) : styles.matchTrigger;
+
+  // Sibling mode: render only the popover (no wrapper needed)
+  if (anchorRef && children == null) {
+    return (
+      <>
+        {popover.render(
+          <div
+            data-testid={testId}
+            {...stylex.props(styles.container, styles.contentPadding, xstyle)}>
+            {content}
+          </div>,
+          {
+            placement,
+            alignment,
+            xstyle: [popoverXstyle, styles.gap],
+          },
+        )}
+      </>
+    );
+  }
 
   return (
     <>

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -1,0 +1,416 @@
+/**
+ * @file XDSPopover.tsx
+ * @input Uses React, useXDSPopover hook, XDSHoverCard
+ * @output Exports XDSPopover component for click/hover triggered popovers
+ * @position Layer component; declarative wrapper around useXDSPopover hook
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Layer/README.md
+ * - /packages/core/src/Layer/XDSPopover.test.tsx
+ * - /packages/core/src/Layer/index.ts
+ * - /apps/storybook/stories/Popover.stories.tsx
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {useXDSPopover} from './useXDSPopover';
+import {XDSHoverCard} from './XDSHoverCard';
+import type {LayerAlignment, LayerPlacement} from './useXDSLayer';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  elevationVars,
+} from '../theme/tokens.stylex';
+import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
+
+// =============================================================================
+// Module Augmentation
+// =============================================================================
+
+declare module '../theme/types' {
+  interface ComponentStyles {
+    popover?: {
+      container?: ThemeStyleXStyles;
+    };
+  }
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * How the popover is triggered.
+ */
+export type XDSPopoverTrigger = 'click' | 'hover';
+
+export interface XDSPopoverProps {
+  /**
+   * The trigger element. Must accept a ref.
+   * For click trigger: receives onClick, aria-expanded, aria-haspopup, aria-controls.
+   * For hover trigger: delegates to XDSHoverCard behavior.
+   */
+  children: ReactNode;
+
+  /**
+   * Content to display inside the popover.
+   */
+  content: ReactNode;
+
+  /**
+   * Position placement relative to the trigger.
+   * Uses CSS anchor positioning via useXDSLayer.
+   * @default 'below'
+   */
+  placement?: LayerPlacement;
+
+  /**
+   * Alignment along the placement axis.
+   * @default 'center'
+   */
+  alignment?: LayerAlignment;
+
+  /**
+   * How the popover is triggered.
+   * - click: Opens on click, closes on click outside or Escape
+   * - hover: Opens on hover/focus, closes on mouse leave (delegates to XDSHoverCard)
+   * @default 'click'
+   */
+  trigger?: XDSPopoverTrigger;
+
+  /**
+   * Whether the popover is shown (controlled mode).
+   * Omit for uncontrolled behavior.
+   */
+  isShown?: boolean;
+
+  /**
+   * Default shown state for uncontrolled mode.
+   * @default false
+   */
+  initialIsShown?: boolean;
+
+  /**
+   * Callback fired when the popover visibility changes.
+   */
+  onToggle?: (isShown: boolean) => void;
+
+  /**
+   * Whether to trap focus inside the popover when open.
+   * @default true for click trigger, false for hover trigger
+   */
+  hasFocusTrap?: boolean;
+
+  /**
+   * Whether the popover is enabled.
+   * When false, trigger interactions are ignored.
+   * @default true
+   */
+  isEnabled?: boolean;
+
+  /**
+   * Width of the popover container.
+   * Numbers are px, strings used as-is.
+   * @default 'auto'
+   */
+  width?: number | string;
+
+  /**
+   * Accessible label for the popover dialog.
+   * Recommended for click-triggered popovers (which use role="dialog").
+   */
+  label?: string;
+
+  /**
+   * Optional StyleX overrides for the popover container.
+   */
+  xstyle?: StyleXStyles;
+
+  /**
+   * Test ID for the popover container.
+   */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  wrapperContents: {
+    display: 'contents',
+  },
+  container: {
+    backgroundColor: colorVars['--color-surface'],
+    borderRadius: radiusVars['--radius-element'],
+    boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
+    // Animation: closed state (default) and open state
+    opacity: {
+      default: 0,
+      ':popover-open': 1,
+    },
+    transform: {
+      default: 'scale(0.95)',
+      ':popover-open': 'scale(1)',
+    },
+    // Transitions with allow-discrete for display/overlay
+    transitionProperty: 'opacity, transform, overlay, display',
+    transitionDuration: '0.15s',
+    transitionTimingFunction: 'ease',
+    transitionBehavior: 'allow-discrete',
+    // Entry animation starting state
+    '@starting-style': {
+      opacity: 0,
+      transform: 'scale(0.95)',
+    },
+  },
+  contentPadding: {
+    paddingBlockStart: spacingVars['--spacing-3'],
+    paddingBlockEnd: spacingVars['--spacing-3'],
+    paddingInlineStart: spacingVars['--spacing-3'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
+  },
+  gap: {
+    marginBlockStart: spacingVars['--spacing-1'],
+    marginBlockEnd: spacingVars['--spacing-1'],
+  },
+  customWidth: (width: string | number) => ({
+    width: typeof width === 'number' ? `${width}px` : width,
+  }),
+  matchTrigger: {
+    minWidth: 'anchor-size(width)',
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * A popover component for displaying interactive content anchored to a trigger.
+ *
+ * Uses a display:contents wrapper so children refs are preserved.
+ * For click trigger, uses useXDSPopover with focus trap and light dismiss.
+ * For hover trigger, delegates to XDSHoverCard.
+ *
+ * @example
+ * ```tsx
+ * // Click-triggered popover
+ * <XDSPopover
+ *   label="Settings"
+ *   content={<SettingsPanel />}
+ *   placement="below"
+ * >
+ *   <XDSButton label="Settings" />
+ * </XDSPopover>
+ *
+ * // Hover-triggered popover (delegates to HoverCard)
+ * <XDSPopover trigger="hover" content={<UserCard />}>
+ *   <XDSAvatar src={avatar} label={name} />
+ * </XDSPopover>
+ *
+ * // Controlled popover
+ * <XDSPopover
+ *   isShown={isOpen}
+ *   onToggle={setIsOpen}
+ *   label="Filter"
+ *   content={<FilterForm />}
+ * >
+ *   <XDSButton label="Filter" />
+ * </XDSPopover>
+ * ```
+ */
+export function XDSPopover({
+  children,
+  content,
+  placement = 'below',
+  alignment = 'center',
+  trigger = 'click',
+  isShown,
+  initialIsShown = false,
+  onToggle,
+  hasFocusTrap,
+  isEnabled = true,
+  width,
+  label,
+  xstyle,
+  'data-testid': testId,
+}: XDSPopoverProps): ReactElement {
+  // Hover trigger delegates to XDSHoverCard
+  if (trigger === 'hover') {
+    return (
+      <XDSHoverCard
+        content={content}
+        placement={placement}
+        alignment={alignment}
+        isEnabled={isEnabled}
+        onShow={() => onToggle?.(true)}
+        onHide={() => onToggle?.(false)}>
+        {children}
+      </XDSHoverCard>
+    );
+  }
+
+  // Click trigger uses useXDSPopover
+  return (
+    <ClickPopover
+      content={content}
+      placement={placement}
+      alignment={alignment}
+      isShown={isShown}
+      initialIsShown={initialIsShown}
+      onToggle={onToggle}
+      isEnabled={isEnabled}
+      width={width}
+      label={label}
+      xstyle={xstyle}
+      data-testid={testId}>
+      {children}
+    </ClickPopover>
+  );
+}
+
+// =============================================================================
+// Click Popover (internal)
+// =============================================================================
+
+interface ClickPopoverProps {
+  children: ReactNode;
+  content: ReactNode;
+  placement: LayerPlacement;
+  alignment: LayerAlignment;
+  isShown?: boolean;
+  initialIsShown: boolean;
+  onToggle?: (isShown: boolean) => void;
+  isEnabled: boolean;
+  width?: number | string;
+  label?: string;
+  xstyle?: StyleXStyles;
+  'data-testid'?: string;
+}
+
+/**
+ * Internal click-triggered popover implementation.
+ * Extracted to a separate component so hooks are called unconditionally.
+ */
+function ClickPopover({
+  children,
+  content,
+  placement,
+  alignment,
+  isShown,
+  initialIsShown,
+  onToggle,
+  isEnabled,
+  width,
+  label,
+  xstyle,
+  'data-testid': testId,
+}: ClickPopoverProps): ReactElement {
+  const wrapperRef = useRef<HTMLElement>(null);
+  const isControlled = isShown !== undefined;
+  const initializedRef = useRef(false);
+
+  const popover = useXDSPopover({
+    dialogLabel: label,
+    hasLightDismiss: true,
+    onShow: () => onToggle?.(true),
+    onHide: () => onToggle?.(false),
+  });
+
+  // Sync controlled state
+  useEffect(() => {
+    if (!isControlled) return;
+    if (isShown && !popover.isOpen) {
+      popover.show();
+    } else if (!isShown && popover.isOpen) {
+      popover.hide();
+    }
+  }, [isShown, isControlled, popover]);
+
+  // Handle initialIsShown
+  useEffect(() => {
+    if (!isControlled && initialIsShown && !initializedRef.current) {
+      initializedRef.current = true;
+      popover.show();
+    }
+  }, [initialIsShown, isControlled, popover]);
+
+  // Handle click on trigger
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      if (!isEnabled) return;
+      e.preventDefault();
+      if (isControlled) {
+        onToggle?.(!isShown);
+      } else {
+        popover.toggle();
+      }
+    },
+    [isEnabled, isControlled, isShown, onToggle, popover],
+  );
+
+  // Attach click handler and popover ref to first child element
+  useLayoutEffect(() => {
+    const wrapper = wrapperRef.current;
+    if (!wrapper) return;
+
+    const firstChild = wrapper.firstElementChild as HTMLElement | null;
+    if (!firstChild) return;
+
+    // Set up anchor positioning
+    popover.triggerRef(firstChild);
+
+    // Set ARIA attributes
+    firstChild.setAttribute('aria-haspopup', 'dialog');
+    firstChild.setAttribute('aria-expanded', String(popover.isOpen));
+    firstChild.setAttribute('aria-controls', popover.id);
+
+    // Add click handler
+    firstChild.addEventListener('click', handleClick);
+
+    return () => {
+      popover.triggerRef(null);
+      firstChild.removeAttribute('aria-haspopup');
+      firstChild.removeAttribute('aria-expanded');
+      firstChild.removeAttribute('aria-controls');
+      firstChild.removeEventListener('click', handleClick);
+    };
+  }, [popover, handleClick]);
+
+  // Determine popover xstyle
+  const popoverXstyle = width ? styles.customWidth(width) : styles.matchTrigger;
+
+  return (
+    <>
+      <div
+        ref={wrapperRef as React.RefObject<HTMLDivElement>}
+        {...stylex.props(styles.wrapperContents)}>
+        {children}
+      </div>
+      {popover.render(
+        <div
+          data-testid={testId}
+          {...stylex.props(styles.container, styles.contentPadding, xstyle)}>
+          {content}
+        </div>,
+        {
+          placement,
+          alignment,
+          xstyle: [popoverXstyle, styles.gap],
+        },
+      )}
+    </>
+  );
+}
+
+XDSPopover.displayName = 'XDSPopover';

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -50,8 +50,10 @@ declare module '../theme/types' {
 
 export interface XDSPopoverProps {
   /**
-   * The trigger element. Must accept a ref.
-   * Receives onClick, aria-expanded, aria-haspopup, aria-controls.
+   * The trigger element. Rendered inside an anchor wrapper that handles
+   * click interactions and CSS anchor positioning. Click events from
+   * children bubble up to the wrapper, so buttons work naturally with
+   * both mouse and keyboard (Enter/Space).
    *
    * When `anchorRef` is provided, children can be omitted and the popover
    * attaches to the external ref element as a sibling.
@@ -136,6 +138,10 @@ const styles = stylex.create({
   // XDSButton) renders inside this wrapper. Because the wrapper itself is
   // the anchor, pressed-state transforms on the child (e.g. :active scale)
   // don't shift the anchor position and cause popover jitter.
+  //
+  // Click events from children bubble up to this wrapper, so keyboard
+  // interactions (Enter/Space on buttons) work naturally without needing
+  // imperative addEventListener on child DOM elements.
   anchorWrapper: {
     display: 'inline-flex',
   },
@@ -192,9 +198,12 @@ const styles = stylex.create({
 /**
  * A click-triggered popover for displaying interactive content anchored to a trigger.
  *
- * Uses an inline-flex wrapper as the CSS anchor. This wrapper is stable —
- * it doesn't receive pressed-state transforms (e.g. `:active { scale(0.98) }`)
- * that the child trigger element may have, preventing popover position jitter.
+ * Uses an inline-flex wrapper as the CSS anchor. The wrapper serves two purposes:
+ * 1. Stable anchor — doesn't receive pressed-state transforms (e.g. `:active { scale(0.98) }`)
+ *    that the child trigger element may have, preventing popover position jitter.
+ * 2. Click target — handles click events via React's event system (bubbled from children),
+ *    so keyboard interactions (Enter/Space on buttons) work naturally.
+ *
  * Focus is trapped inside the popover when open.
  * Supports light dismiss (click outside or Escape to close).
  *
@@ -240,7 +249,7 @@ export function XDSPopover({
   xstyle,
   'data-testid': testId,
 }: XDSPopoverProps): ReactElement {
-  const wrapperRef = useRef<HTMLElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
   const isControlled = isShown !== undefined;
   // Track when the popover was last hidden by light dismiss to prevent
   // the trigger click from immediately re-opening it.
@@ -256,13 +265,12 @@ export function XDSPopover({
     },
   });
 
-  // Handle click on trigger — delegates to hook's toggle.
-  // In controlled mode, the useLayoutEffect below syncs isShown → hook state,
-  // and the hook's onShow/onHide callbacks propagate back to onToggle.
+  // Handle click on the anchor wrapper. Click events from children (e.g.
+  // XDSButton) bubble up here, including keyboard-synthesized clicks
+  // (Enter/Space on native buttons). No imperative addEventListener needed.
   const handleClick = useCallback(
-    (e: MouseEvent) => {
+    (_e: React.MouseEvent) => {
       if (!isEnabled) return;
-      e.preventDefault();
       // If the popover was just closed by light dismiss (clicking outside),
       // the trigger click fires in the same event — skip re-opening.
       if (Date.now() - lastHideTimeRef.current < 50) return;
@@ -289,35 +297,42 @@ export function XDSPopover({
     );
     el.setAttribute('aria-controls', popover.triggerProps['aria-controls']);
 
-    // Add click handler
-    el.addEventListener('click', handleClick);
+    // Add click handler (imperative for sibling mode since we don't wrap)
+    const handleSiblingClick = () => {
+      if (!isEnabled) return;
+      if (Date.now() - lastHideTimeRef.current < 50) return;
+      popover.toggle();
+    };
+    el.addEventListener('click', handleSiblingClick);
 
     return () => {
       popover.triggerRef(null);
       el.removeAttribute('aria-haspopup');
       el.removeAttribute('aria-expanded');
       el.removeAttribute('aria-controls');
-      el.removeEventListener('click', handleClick);
+      el.removeEventListener('click', handleSiblingClick);
     };
-  }, [anchorRef, popover, handleClick]);
+  }, [anchorRef, popover, isEnabled]);
 
-  // Children mode: use wrapper as anchor, attach ARIA + click to child.
-  // The wrapper is the CSS anchor (stable, no transforms), while the child
-  // element (e.g. XDSButton) gets the ARIA attributes and click handler.
+  // Children mode: set up the wrapper as the CSS anchor and apply ARIA
+  // attributes to the first child (the interactive trigger element).
+  // Click handling is on the wrapper via React onClick — no imperative
+  // event listeners needed.
   useLayoutEffect(() => {
     if (anchorRef) return; // Skip if using anchorRef mode
 
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
 
-    // Use the wrapper itself as the anchor — it doesn't receive
-    // pressed-state transforms, so the anchor position stays stable.
+    // Use the wrapper as the anchor — it doesn't receive pressed-state
+    // transforms, so the anchor position stays stable.
     popover.triggerRef(wrapper);
 
+    // ARIA attributes go on the interactive child element (the button),
+    // not the wrapper, for correct screen reader announcements.
     const firstChild = wrapper.firstElementChild as HTMLElement | null;
     if (!firstChild) return;
 
-    // ARIA attributes go on the interactive child element
     firstChild.setAttribute(
       'aria-haspopup',
       popover.triggerProps['aria-haspopup'],
@@ -331,17 +346,13 @@ export function XDSPopover({
       popover.triggerProps['aria-controls'],
     );
 
-    // Click handler goes on the interactive child element
-    firstChild.addEventListener('click', handleClick);
-
     return () => {
       popover.triggerRef(null);
       firstChild.removeAttribute('aria-haspopup');
       firstChild.removeAttribute('aria-expanded');
       firstChild.removeAttribute('aria-controls');
-      firstChild.removeEventListener('click', handleClick);
     };
-  }, [anchorRef, popover, handleClick]);
+  }, [anchorRef, popover]);
 
   // Sync controlled state
   useLayoutEffect(() => {
@@ -379,7 +390,8 @@ export function XDSPopover({
   return (
     <>
       <div
-        ref={wrapperRef as React.RefObject<HTMLDivElement>}
+        ref={wrapperRef}
+        onClick={handleClick}
         {...stylex.props(styles.anchorWrapper)}>
         {children}
       </div>

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -45,15 +45,34 @@ declare module '../theme/types' {
 }
 
 // =============================================================================
+// Helpers
+// =============================================================================
+
+const BUTTON_SELECTOR = 'button, [role="button"]';
+
+/**
+ * Find the trigger button inside a container element.
+ * Looks for `<button>` or `[role="button"]` — either the element itself
+ * or the first matching descendant.
+ */
+function findTriggerButton(el: HTMLElement): HTMLElement | null {
+  if (el.matches(BUTTON_SELECTOR)) return el;
+  return el.querySelector<HTMLElement>(BUTTON_SELECTOR);
+}
+
+// =============================================================================
 // Types
 // =============================================================================
 
 export interface XDSPopoverProps {
   /**
-   * The trigger element. Rendered inside an anchor wrapper that handles
-   * click interactions and CSS anchor positioning. Click events from
-   * children bubble up to the wrapper, so buttons work naturally with
-   * both mouse and keyboard (Enter/Space).
+   * The trigger element. Must contain a `<button>` or `[role="button"]`
+   * element — the popover locates it and applies click/keydown handlers
+   * and ARIA attributes (`aria-haspopup`, `aria-expanded`, `aria-controls`).
+   *
+   * The trigger is rendered inside an anchor wrapper used for CSS anchor
+   * positioning. The wrapper is stable (no pressed-state transforms),
+   * preventing popover position jitter.
    *
    * When `anchorRef` is provided, children can be omitted and the popover
    * attaches to the external ref element as a sibling.
@@ -63,8 +82,9 @@ export interface XDSPopoverProps {
   /**
    * External ref to use as the popover anchor.
    * When provided (and no children), the popover attaches to this element
-   * instead of wrapping children. This enables sibling-mode rendering,
-   * useful when the trigger element is managed externally.
+   * instead of wrapping children. The referenced element must be a
+   * `<button>` or `[role="button"]` — the popover applies click/keydown
+   * handlers and ARIA attributes to it directly.
    */
   anchorRef?: React.RefObject<HTMLElement>;
 
@@ -138,10 +158,6 @@ const styles = stylex.create({
   // XDSButton) renders inside this wrapper. Because the wrapper itself is
   // the anchor, pressed-state transforms on the child (e.g. :active scale)
   // don't shift the anchor position and cause popover jitter.
-  //
-  // Click events from children bubble up to this wrapper, so keyboard
-  // interactions (Enter/Space on buttons) work naturally without needing
-  // imperative addEventListener on child DOM elements.
   anchorWrapper: {
     display: 'inline-flex',
   },
@@ -198,11 +214,12 @@ const styles = stylex.create({
 /**
  * A click-triggered popover for displaying interactive content anchored to a trigger.
  *
- * Uses an inline-flex wrapper as the CSS anchor. The wrapper serves two purposes:
- * 1. Stable anchor — doesn't receive pressed-state transforms (e.g. `:active { scale(0.98) }`)
- *    that the child trigger element may have, preventing popover position jitter.
- * 2. Click target — handles click events via React's event system (bubbled from children),
- *    so keyboard interactions (Enter/Space on buttons) work naturally.
+ * Implements the button + dialog ARIA pattern. The trigger must contain a
+ * `<button>` or `[role="button"]` element — the popover finds it and applies
+ * click/keydown handlers and ARIA attributes automatically.
+ *
+ * Uses an inline-flex wrapper as the CSS anchor for stable positioning
+ * (immune to pressed-state transforms like `:active { scale(0.98) }`).
  *
  * Focus is trapped inside the popover when open.
  * Supports light dismiss (click outside or Escape to close).
@@ -265,18 +282,69 @@ export function XDSPopover({
     },
   });
 
-  // Handle click on the anchor wrapper. Click events from children (e.g.
-  // XDSButton) bubble up here, including keyboard-synthesized clicks
-  // (Enter/Space on native buttons). No imperative addEventListener needed.
-  const handleClick = useCallback(
-    (_e: React.MouseEvent) => {
-      if (!isEnabled) return;
-      // If the popover was just closed by light dismiss (clicking outside),
-      // the trigger click fires in the same event — skip re-opening.
-      if (Date.now() - lastHideTimeRef.current < 50) return;
-      popover.toggle();
+  // Shared handler for click events on the trigger button.
+  const handleTriggerClick = useCallback(() => {
+    if (!isEnabled) return;
+    // If the popover was just closed by light dismiss (clicking outside),
+    // the trigger click fires in the same event — skip re-opening.
+    if (Date.now() - lastHideTimeRef.current < 50) return;
+    popover.toggle();
+  }, [isEnabled, popover]);
+
+  // Shared handler for keydown events on role="button" elements.
+  // Native <button> synthesizes click on Enter/Space, but role="button"
+  // does not — we need to handle it explicitly.
+  const handleTriggerKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        handleTriggerClick();
+      }
     },
-    [isEnabled, popover],
+    [handleTriggerClick],
+  );
+
+  /**
+   * Attach click/keydown handlers and ARIA attributes to a trigger button.
+   * Used by both sibling mode and children mode.
+   */
+  const attachTrigger = useCallback(
+    (button: HTMLElement) => {
+      // ARIA attributes
+      button.setAttribute(
+        'aria-haspopup',
+        popover.triggerProps['aria-haspopup'],
+      );
+      button.setAttribute(
+        'aria-expanded',
+        String(popover.triggerProps['aria-expanded']),
+      );
+      button.setAttribute(
+        'aria-controls',
+        popover.triggerProps['aria-controls'],
+      );
+
+      // Event handlers
+      button.addEventListener('click', handleTriggerClick);
+      // Only add keydown for role="button" — native <button> already
+      // synthesizes click events for Enter/Space.
+      const needsKeyDown =
+        button.tagName !== 'BUTTON' && button.getAttribute('role') === 'button';
+      if (needsKeyDown) {
+        button.addEventListener('keydown', handleTriggerKeyDown);
+      }
+
+      return () => {
+        button.removeAttribute('aria-haspopup');
+        button.removeAttribute('aria-expanded');
+        button.removeAttribute('aria-controls');
+        button.removeEventListener('click', handleTriggerClick);
+        if (needsKeyDown) {
+          button.removeEventListener('keydown', handleTriggerKeyDown);
+        }
+      };
+    },
+    [popover, handleTriggerClick, handleTriggerKeyDown],
   );
 
   // Sibling mode: attach to external anchorRef
@@ -286,73 +354,56 @@ export function XDSPopover({
     const el = anchorRef.current;
     if (!el) return;
 
-    // Set up anchor positioning
+    const button = findTriggerButton(el);
+    if (process.env.NODE_ENV !== 'production' && !button) {
+      console.warn(
+        'XDSPopover: anchorRef must reference a <button> or [role="button"] element. ' +
+          'The popover trigger implements the button + dialog ARIA pattern.',
+      );
+    }
+    if (!button) return;
+
+    // Set up anchor positioning on the anchorRef element itself
     popover.triggerRef(el);
 
-    // Set ARIA attributes
-    el.setAttribute('aria-haspopup', popover.triggerProps['aria-haspopup']);
-    el.setAttribute(
-      'aria-expanded',
-      String(popover.triggerProps['aria-expanded']),
-    );
-    el.setAttribute('aria-controls', popover.triggerProps['aria-controls']);
-
-    // Add click handler (imperative for sibling mode since we don't wrap)
-    const handleSiblingClick = () => {
-      if (!isEnabled) return;
-      if (Date.now() - lastHideTimeRef.current < 50) return;
-      popover.toggle();
-    };
-    el.addEventListener('click', handleSiblingClick);
+    // Attach handlers + ARIA to the button
+    const detach = attachTrigger(button);
 
     return () => {
       popover.triggerRef(null);
-      el.removeAttribute('aria-haspopup');
-      el.removeAttribute('aria-expanded');
-      el.removeAttribute('aria-controls');
-      el.removeEventListener('click', handleSiblingClick);
+      detach();
     };
-  }, [anchorRef, popover, isEnabled]);
+  }, [anchorRef, popover, attachTrigger]);
 
-  // Children mode: set up the wrapper as the CSS anchor and apply ARIA
-  // attributes to the first child (the interactive trigger element).
-  // Click handling is on the wrapper via React onClick — no imperative
-  // event listeners needed.
+  // Children mode: use wrapper as CSS anchor, find button inside for
+  // ARIA + event handlers.
   useLayoutEffect(() => {
     if (anchorRef) return; // Skip if using anchorRef mode
 
     const wrapper = wrapperRef.current;
     if (!wrapper) return;
 
-    // Use the wrapper as the anchor — it doesn't receive pressed-state
+    // Use the wrapper as the CSS anchor — it doesn't receive pressed-state
     // transforms, so the anchor position stays stable.
     popover.triggerRef(wrapper);
 
-    // ARIA attributes go on the interactive child element (the button),
-    // not the wrapper, for correct screen reader announcements.
-    const firstChild = wrapper.firstElementChild as HTMLElement | null;
-    if (!firstChild) return;
+    // Find the button inside the wrapper
+    const button = findTriggerButton(wrapper);
+    if (process.env.NODE_ENV !== 'production' && !button) {
+      console.warn(
+        'XDSPopover: children must contain a <button> or [role="button"] element. ' +
+          'The popover trigger implements the button + dialog ARIA pattern.',
+      );
+    }
+    if (!button) return;
 
-    firstChild.setAttribute(
-      'aria-haspopup',
-      popover.triggerProps['aria-haspopup'],
-    );
-    firstChild.setAttribute(
-      'aria-expanded',
-      String(popover.triggerProps['aria-expanded']),
-    );
-    firstChild.setAttribute(
-      'aria-controls',
-      popover.triggerProps['aria-controls'],
-    );
+    const detach = attachTrigger(button);
 
     return () => {
       popover.triggerRef(null);
-      firstChild.removeAttribute('aria-haspopup');
-      firstChild.removeAttribute('aria-expanded');
-      firstChild.removeAttribute('aria-controls');
+      detach();
     };
-  }, [anchorRef, popover]);
+  }, [anchorRef, popover, attachTrigger]);
 
   // Sync controlled state
   useLayoutEffect(() => {
@@ -389,10 +440,7 @@ export function XDSPopover({
 
   return (
     <>
-      <div
-        ref={wrapperRef}
-        onClick={handleClick}
-        {...stylex.props(styles.anchorWrapper)}>
+      <div ref={wrapperRef} {...stylex.props(styles.anchorWrapper)}>
         {children}
       </div>
       {popover.render(

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -24,7 +24,12 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {useXDSPopover} from './useXDSPopover';
 import type {LayerAlignment, LayerPlacement} from './useXDSLayer';
-import {colorVars, spacingVars, radiusVars} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  elevationVars,
+} from '../theme/tokens.stylex';
 import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
 
 // =============================================================================
@@ -75,7 +80,7 @@ export interface XDSPopoverProps {
 
   /**
    * Alignment along the placement axis.
-   * @default 'center'
+   * @default 'start'
    */
   alignment?: LayerAlignment;
 
@@ -133,7 +138,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-surface'],
     color: colorVars['--color-text-primary'],
     borderRadius: radiusVars['--radius-element'],
-    boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
+    boxShadow: elevationVars['--elevation-menu'],
     // Animation: closed state (default) and open state
     opacity: {
       default: 0,
@@ -216,7 +221,7 @@ export function XDSPopover({
   anchorRef,
   content,
   placement = 'below',
-  alignment = 'center',
+  alignment = 'start',
   isShown,
   onToggle,
   isEnabled = true,
@@ -227,12 +232,18 @@ export function XDSPopover({
 }: XDSPopoverProps): ReactElement {
   const wrapperRef = useRef<HTMLElement>(null);
   const isControlled = isShown !== undefined;
+  // Track when the popover was last hidden by light dismiss to prevent
+  // the trigger click from immediately re-opening it.
+  const lastHideTimeRef = useRef(0);
 
   const popover = useXDSPopover({
     dialogLabel: label,
     hasLightDismiss: true,
     onShow: () => onToggle?.(true),
-    onHide: () => onToggle?.(false),
+    onHide: () => {
+      lastHideTimeRef.current = Date.now();
+      onToggle?.(false);
+    },
   });
 
   // Handle click on trigger — delegates to hook's toggle.
@@ -242,6 +253,9 @@ export function XDSPopover({
     (e: MouseEvent) => {
       if (!isEnabled) return;
       e.preventDefault();
+      // If the popover was just closed by light dismiss (clicking outside),
+      // the trigger click fires in the same event — skip re-opening.
+      if (Date.now() - lastHideTimeRef.current < 50) return;
       popover.toggle();
     },
     [isEnabled, popover],

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -355,7 +355,7 @@ export function XDSPopover({
     if (!el) return;
 
     const button = findTriggerButton(el);
-    if (process.env.NODE_ENV !== 'production' && !button) {
+    if (!button) {
       console.warn(
         'XDSPopover: anchorRef must reference a <button> or [role="button"] element. ' +
           'The popover trigger implements the button + dialog ARIA pattern.',
@@ -389,7 +389,7 @@ export function XDSPopover({
 
     // Find the button inside the wrapper
     const button = findTriggerButton(wrapper);
-    if (process.env.NODE_ENV !== 'production' && !button) {
+    if (!button) {
       console.warn(
         'XDSPopover: children must contain a <button> or [role="button"] element. ' +
           'The popover trigger implements the button + dialog ARIA pattern.',

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -48,3 +48,7 @@ export type {
 
 export {XDSTooltip} from './XDSTooltip';
 export type {XDSTooltipProps} from './XDSTooltip';
+
+// Popover component
+export {XDSPopover} from './XDSPopover';
+export type {XDSPopoverProps, XDSPopoverTrigger} from './XDSPopover';

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -51,4 +51,4 @@ export type {XDSTooltipProps} from './XDSTooltip';
 
 // Popover component
 export {XDSPopover} from './XDSPopover';
-export type {XDSPopoverProps, XDSPopoverTrigger} from './XDSPopover';
+export type {XDSPopoverProps} from './XDSPopover';


### PR DESCRIPTION
Extracts XDSPopover from #286 so it can land independently. Typeahead and Tokenizer will follow in a separate PR.

## What's included

- `XDSPopover` component built on `useXDSLayer`
- 12 placement options with anchored positioning
- Click-outside and Escape to dismiss
- Focus management (auto-focus first focusable element or heading)
- Entry animation (fade + slide)
- Default padding matching HoverCard
- Accessible: `role=dialog`, `aria-labelledby`, focus trap
- Tests and Storybook stories

## What's NOT included (stays in #286)

- `XDSTypeahead` — will be a follow-up PR
- `XDSTokenizer` — will be a follow-up PR

Closes #175

---
*Crafted with care by Navi*