### PR TITLE
fix: React 19 RefObject compatibility

### DIFF
--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -645,7 +645,7 @@ function MonthGrid({
 
       {/* Days grid */}
       <div
-        ref={gridRef as React.RefObject<HTMLDivElement>}
+        ref={gridRef as React.RefObject<HTMLDivElement | null>}
         role="grid"
         aria-label={monthLabel}
         onKeyDown={handleGridKeyDown}

--- a/packages/core/src/Layer/XDSHoverCard.tsx
+++ b/packages/core/src/Layer/XDSHoverCard.tsx
@@ -243,7 +243,7 @@ export function XDSHoverCard({
   return (
     <>
       <div
-        ref={wrapperRef as React.RefObject<HTMLDivElement>}
+        ref={wrapperRef as React.RefObject<HTMLDivElement | null>}
         {...stylex.props(styles.wrapperContents)}>
         {children}
       </div>

--- a/packages/core/src/Layer/XDSTooltip.tsx
+++ b/packages/core/src/Layer/XDSTooltip.tsx
@@ -286,7 +286,7 @@ export function XDSTooltip({
   return (
     <>
       <div
-        ref={wrapperRef as React.RefObject<HTMLDivElement>}
+        ref={wrapperRef as React.RefObject<HTMLDivElement | null>}
         {...stylex.props(styles.wrapperContents)}>
         {children}
       </div>

--- a/packages/core/src/Layer/useXDSPopover.tsx
+++ b/packages/core/src/Layer/useXDSPopover.tsx
@@ -349,7 +349,7 @@ export function useXDSPopover(
     (children: ReactNode, props?: ContextRenderProps) => {
       return layer.render(
         <div
-          ref={contentRef as React.RefObject<HTMLDivElement>}
+          ref={contentRef as React.RefObject<HTMLDivElement | null>}
           role="dialog"
           aria-modal="true"
           aria-label={dialogLabel}

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -279,7 +279,7 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
       </button>
       {layer.render(
         <div
-          ref={listRef as React.RefObject<HTMLDivElement>}
+          ref={listRef as React.RefObject<HTMLDivElement | null>}
           id={menuId}
           role="menu"
           aria-label={label}


### PR DESCRIPTION
## Summary

React 19 changed `useRef()` to return `RefObject<T | null>` instead of `RefObject<T>`. This causes type errors when XDS is consumed with React 19 + TypeScript strict mode.

## Problem

With React 19's updated `@types/react`, the following patterns produce type errors:

1. `RefObject<HTMLElement>` in interfaces/props no longer accepts refs created by `useRef<HTMLElement>(null)` (which now returns `RefObject<HTMLElement | null>`)
2. `useRef<T>()` without an initial value is no longer valid — React 19 requires an explicit argument
3. `as React.RefObject<HTMLDivElement>` casts fail because the ref actually contains `null`

## Fix

- Update `RefObject<T>` → `RefObject<T | null>` in all interfaces and function signatures that receive refs
- Pass `undefined` as initial value to `useRef()` where no initial value was provided
- Update `RefObject<T>` casts in JSX ref props to `RefObject<T | null>`

## Files Changed

| File | Change |
|------|--------|
| `Selector/hooks.ts` | Interface types + `useRef` initial value |
| `Layer/XDSTooltip.tsx` | `anchorRef` prop type + ref cast |
| `Layer/XDSHoverCard.tsx` | Ref cast |
| `Layer/useXDSPopover.tsx` | Ref cast |
| `Calendar/XDSCalendar.tsx` | Ref cast |
| `TabList/XDSTabMenu.tsx` | Ref cast |
| `hooks/useGridFocus.ts` | Return type interface |
| `hooks/useListFocus.ts` | Return type interface |

## Backward Compatibility

These changes are backward compatible with React 18. `RefObject<T | null>` is a wider type that accepts both React 18 and React 19 refs.