### PR TITLE
feat(CommandPalette): add command palette component

### DIFF
--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -1,0 +1,1048 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  XDSCommandPaletteProvider,
+  useXDSCommandPaletteRegister,
+  useXDSCommandPalette,
+} from '@xds/core/CommandPalette';
+import type {XDSCommand} from '@xds/core/CommandPalette';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText} from '@xds/core/Text';
+
+const meta: Meta<typeof XDSCommandPaletteProvider> = {
+  title: 'Core/XDSCommandPalette',
+  component: XDSCommandPaletteProvider,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A command palette (Cmd+K) for searching and executing commands. Uses a provider/context pattern where any component can register searchable commands.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCommandPaletteProvider>;
+
+// =============================================================================
+// Default
+// =============================================================================
+
+function DefaultCommands() {
+  useXDSCommandPaletteRegister(
+    [
+      {
+        id: 'home',
+        label: 'Go to Home',
+        keywords: ['dashboard', 'main'],
+        onSelect: () => alert('Navigating to Home'),
+        group: 'Navigation',
+      },
+      {
+        id: 'settings',
+        label: 'Open Settings',
+        keywords: ['preferences', 'config'],
+        shortcut: 'mod+,',
+        onSelect: () => alert('Opening Settings'),
+        group: 'Navigation',
+      },
+      {
+        id: 'profile',
+        label: 'View Profile',
+        keywords: ['account', 'user'],
+        onSelect: () => alert('Viewing Profile'),
+        group: 'Navigation',
+      },
+      {
+        id: 'search',
+        label: 'Search',
+        keywords: ['find', 'lookup'],
+        shortcut: 'mod+f',
+        onSelect: () => alert('Searching'),
+        group: 'Actions',
+      },
+      {
+        id: 'new-doc',
+        label: 'Create New Document',
+        keywords: ['add', 'create', 'new'],
+        shortcut: 'mod+n',
+        onSelect: () => alert('Creating document'),
+        group: 'Actions',
+      },
+    ],
+    [],
+  );
+
+  return null;
+}
+
+function DefaultExample() {
+  const {open} = useXDSCommandPalette();
+
+  return (
+    <div style={{padding: 24}}>
+      <XDSText type="body" color="secondary">
+        Press Cmd+K (or Ctrl+K) to open the command palette, or click the button
+        below.
+      </XDSText>
+      <div style={{marginTop: 12}}>
+        <XDSButton label="Open Command Palette" onClick={() => open()} />
+      </div>
+      <DefaultCommands />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <XDSCommandPaletteProvider placeholder="What do you need?">
+      <DefaultExample />
+    </XDSCommandPaletteProvider>
+  ),
+};
+
+// =============================================================================
+// Grouped Commands
+// =============================================================================
+
+function GroupedCommands() {
+  useXDSCommandPaletteRegister(
+    [
+      {
+        id: 'bold',
+        label: 'Bold',
+        shortcut: 'mod+b',
+        onSelect: () => alert('Bold'),
+        group: 'Formatting',
+      },
+      {
+        id: 'italic',
+        label: 'Italic',
+        shortcut: 'mod+i',
+        onSelect: () => alert('Italic'),
+        group: 'Formatting',
+      },
+      {
+        id: 'underline',
+        label: 'Underline',
+        shortcut: 'mod+u',
+        onSelect: () => alert('Underline'),
+        group: 'Formatting',
+      },
+      {
+        id: 'undo',
+        label: 'Undo',
+        shortcut: 'mod+z',
+        onSelect: () => alert('Undo'),
+        group: 'Edit',
+      },
+      {
+        id: 'redo',
+        label: 'Redo',
+        shortcut: 'mod+shift+z',
+        onSelect: () => alert('Redo'),
+        group: 'Edit',
+      },
+      {
+        id: 'copy',
+        label: 'Copy',
+        shortcut: 'mod+c',
+        onSelect: () => alert('Copy'),
+        group: 'Edit',
+      },
+      {
+        id: 'paste',
+        label: 'Paste',
+        shortcut: 'mod+v',
+        onSelect: () => alert('Paste'),
+        group: 'Edit',
+      },
+    ],
+    [],
+  );
+
+  return null;
+}
+
+function GroupedExample() {
+  const {open} = useXDSCommandPalette();
+
+  return (
+    <div style={{padding: 24}}>
+      <XDSText type="body" color="secondary">
+        Commands organized into groups (Formatting, Edit).
+      </XDSText>
+      <div style={{marginTop: 12}}>
+        <XDSButton label="Open Palette" onClick={() => open()} />
+      </div>
+      <GroupedCommands />
+    </div>
+  );
+}
+
+export const GroupedCommands_: Story = {
+  name: 'Grouped Commands',
+  render: () => (
+    <XDSCommandPaletteProvider>
+      <GroupedExample />
+    </XDSCommandPaletteProvider>
+  ),
+};
+
+// =============================================================================
+// Nested Pages
+// =============================================================================
+
+function NestedPageCommands() {
+  useXDSCommandPaletteRegister(
+    [
+      {
+        id: 'theme-switcher',
+        label: 'Change Theme...',
+        onSelect: () => {},
+        page: 'Themes',
+      },
+      {
+        id: 'theme-light',
+        label: 'Light Theme',
+        onSelect: () => alert('Switched to Light'),
+        group: 'Themes',
+      },
+      {
+        id: 'theme-dark',
+        label: 'Dark Theme',
+        onSelect: () => alert('Switched to Dark'),
+        group: 'Themes',
+      },
+      {
+        id: 'theme-system',
+        label: 'System Theme',
+        onSelect: () => alert('Switched to System'),
+        group: 'Themes',
+      },
+      {
+        id: 'save',
+        label: 'Save',
+        shortcut: 'mod+s',
+        onSelect: () => alert('Saved'),
+        group: 'File',
+      },
+    ],
+    [],
+  );
+
+  return null;
+}
+
+function NestedPageExample() {
+  const {open} = useXDSCommandPalette();
+
+  return (
+    <div style={{padding: 24}}>
+      <XDSText type="body" color="secondary">
+        Select &quot;Change Theme...&quot; to open a sub-page. Press Backspace
+        on empty input or Escape to go back.
+      </XDSText>
+      <div style={{marginTop: 12}}>
+        <XDSButton label="Open Palette" onClick={() => open()} />
+      </div>
+      <NestedPageCommands />
+    </div>
+  );
+}
+
+export const NestedPages: Story = {
+  render: () => (
+    <XDSCommandPaletteProvider>
+      <NestedPageExample />
+    </XDSCommandPaletteProvider>
+  ),
+};
+
+// =============================================================================
+// With History
+// =============================================================================
+
+function HistoryCommands() {
+  useXDSCommandPaletteRegister(
+    [
+      {
+        id: 'action-a',
+        label: 'Action Alpha',
+        onSelect: () => alert('Alpha'),
+        group: 'Actions',
+      },
+      {
+        id: 'action-b',
+        label: 'Action Beta',
+        onSelect: () => alert('Beta'),
+        group: 'Actions',
+      },
+      {
+        id: 'action-c',
+        label: 'Action Charlie',
+        onSelect: () => alert('Charlie'),
+        group: 'Navigation',
+      },
+      {
+        id: 'action-d',
+        label: 'Action Delta',
+        onSelect: () => alert('Delta'),
+        group: 'Navigation',
+      },
+    ],
+    [],
+  );
+
+  return null;
+}
+
+function HistoryExample() {
+  const {open} = useXDSCommandPalette();
+
+  return (
+    <div style={{padding: 24}}>
+      <XDSText type="body" color="secondary">
+        Select some commands, then reopen the palette. Recently used commands
+        appear in a &quot;Recent&quot; group at the top with invocation count,
+        relative time, source group, and a clear (×) button. Try selecting the
+        same command multiple times to see the count increase.
+      </XDSText>
+      <div style={{marginTop: 12}}>
+        <XDSButton label="Open Palette" onClick={() => open()} />
+      </div>
+      <HistoryCommands />
+    </div>
+  );
+}
+
+export const WithHistory: Story = {
+  render: () => (
+    <XDSCommandPaletteProvider isPersistHistory>
+      <HistoryExample />
+    </XDSCommandPaletteProvider>
+  ),
+};
+
+// =============================================================================
+// Dynamic Commands (mount/unmount)
+// =============================================================================
+
+function ConditionalCommands({isActive}: {isActive: boolean}) {
+  useXDSCommandPaletteRegister(
+    isActive
+      ? [
+          {
+            id: 'dynamic-1',
+            label: 'Dynamic: Refresh Data',
+            onSelect: () => alert('Refreshing'),
+          },
+          {
+            id: 'dynamic-2',
+            label: 'Dynamic: Export Results',
+            onSelect: () => alert('Exporting'),
+          },
+        ]
+      : [],
+    [isActive],
+  );
+
+  return null;
+}
+
+function DynamicExample() {
+  const {open} = useXDSCommandPalette();
+  const [isActive, setIsActive] = useState(false);
+
+  return (
+    <div style={{padding: 24}}>
+      <XDSText type="body" color="secondary">
+        Toggle the panel to register/deregister commands dynamically. Open the
+        palette to see the difference.
+      </XDSText>
+      <div
+        style={{marginTop: 12, display: 'flex', gap: 8, alignItems: 'center'}}>
+        <XDSButton
+          label={isActive ? 'Deactivate Panel' : 'Activate Panel'}
+          variant={isActive ? 'primary' : 'secondary'}
+          onClick={() => setIsActive(prev => !prev)}
+        />
+        <XDSButton
+          label="Open Palette"
+          variant="secondary"
+          onClick={() => open()}
+        />
+      </div>
+      <ConditionalCommands isActive={isActive} />
+    </div>
+  );
+}
+
+export const DynamicCommands: Story = {
+  render: () => (
+    <XDSCommandPaletteProvider>
+      <DynamicExample />
+    </XDSCommandPaletteProvider>
+  ),
+};
+
+// =============================================================================
+// Search Highlighting
+// =============================================================================
+
+function HighlightCommands() {
+  useXDSCommandPaletteRegister(
+    [
+      {
+        id: 'hl-save',
+        label: 'Save File',
+        keywords: ['write', 'persist'],
+        onSelect: () => alert('Saving'),
+        group: 'File',
+      },
+      {
+        id: 'hl-save-as',
+        label: 'Save As...',
+        keywords: ['export', 'rename'],
+        onSelect: () => alert('Save As'),
+        group: 'File',
+      },
+      {
+        id: 'hl-open',
+        label: 'Open File',
+        keywords: ['load', 'read'],
+        onSelect: () => alert('Opening'),
+        group: 'File',
+      },
+      {
+        id: 'hl-settings',
+        label: 'Open Settings',
+        keywords: ['preferences', 'config'],
+        onSelect: () => alert('Settings'),
+        group: 'Navigation',
+      },
+      {
+        id: 'hl-export-csv',
+        label: 'Export as CSV',
+        keywords: ['download', 'spreadsheet'],
+        onSelect: () => alert('Exporting CSV'),
+        group: 'Actions',
+      },
+      {
+        id: 'hl-export-json',
+        label: 'Export as JSON',
+        keywords: ['download', 'api'],
+        onSelect: () => alert('Exporting JSON'),
+        group: 'Actions',
+      },
+      {
+        id: 'hl-docs',
+        label: 'Documentation',
+        keywords: ['help', 'wiki', 'reference'],
+        onSelect: () => alert('Docs'),
+        group: 'Navigation',
+      },
+      {
+        id: 'hl-deploy',
+        label: 'Deploy to Production',
+        keywords: ['ship', 'release'],
+        onSelect: () => alert('Deploying'),
+        group: 'Actions',
+      },
+      {
+        id: 'hl-search',
+        label: 'Search Everything',
+        keywords: ['find', 'lookup'],
+        shortcut: 'mod+shift+f',
+        onSelect: () => alert('Searching'),
+        group: 'Actions',
+      },
+      {
+        id: 'hl-format',
+        label: 'Format Document',
+        keywords: ['prettier', 'lint'],
+        shortcut: 'mod+shift+f',
+        onSelect: () => alert('Formatting'),
+        group: 'Edit',
+      },
+    ],
+    [],
+  );
+
+  return null;
+}
+
+function HighlightExample() {
+  const {open} = useXDSCommandPalette();
+
+  return (
+    <div style={{padding: 24}}>
+      <XDSText type="heading3">Search Highlighting</XDSText>
+      <div style={{marginTop: 8}}>
+        <XDSText type="body" color="secondary">
+          Type a query to see matching characters highlighted in bold. Try
+          typing &quot;exp&quot; (starts-with on Export), &quot;set&quot;
+          (starts-with on Settings), &quot;doc&quot; (starts-with on
+          Documentation), &quot;sfl&quot; (subsequence: Save File), or
+          &quot;config&quot; (keyword match, no label highlight).
+        </XDSText>
+      </div>
+      <div style={{marginTop: 16}}>
+        <XDSButton
+          label="Open Command Palette"
+          variant="primary"
+          onClick={() => open()}
+        />
+      </div>
+      <HighlightCommands />
+    </div>
+  );
+}
+
+export const SearchHighlighting: Story = {
+  render: () => (
+    <XDSCommandPaletteProvider placeholder="Try typing: exp, set, doc, sfl...">
+      <HighlightExample />
+    </XDSCommandPaletteProvider>
+  ),
+};
+
+// =============================================================================
+// Async Loading
+// =============================================================================
+
+const REMOTE_COMMANDS: Record<string, XDSCommand[]> = {
+  user: [
+    {
+      id: 'remote-user-1',
+      label: 'User: List All Users',
+      onSelect: () => alert('Listing users'),
+    },
+    {
+      id: 'remote-user-2',
+      label: 'User: Create New User',
+      onSelect: () => alert('Creating user'),
+    },
+    {
+      id: 'remote-user-3',
+      label: 'User: Edit Permissions',
+      onSelect: () => alert('Editing permissions'),
+    },
+  ],
+  report: [
+    {
+      id: 'remote-report-1',
+      label: 'Report: Monthly Revenue',
+      onSelect: () => alert('Revenue report'),
+    },
+    {
+      id: 'remote-report-2',
+      label: 'Report: User Growth',
+      onSelect: () => alert('Growth report'),
+    },
+  ],
+  deploy: [
+    {
+      id: 'remote-deploy-1',
+      label: 'Deploy: Staging Environment',
+      onSelect: () => alert('Deploying to staging'),
+    },
+    {
+      id: 'remote-deploy-2',
+      label: 'Deploy: Production Canary',
+      onSelect: () => alert('Canary deploy'),
+    },
+    {
+      id: 'remote-deploy-3',
+      label: 'Deploy: Rollback Last Release',
+      onSelect: () => alert('Rolling back'),
+    },
+  ],
+};
+
+function simulateFetch(query: string): Promise<XDSCommand[]> {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      const lowerQuery = query.toLowerCase();
+      const results: XDSCommand[] = [];
+      for (const [key, commands] of Object.entries(REMOTE_COMMANDS)) {
+        if (key.includes(lowerQuery) || lowerQuery.includes(key)) {
+          results.push(...commands);
+        } else {
+          for (const cmd of commands) {
+            if (cmd.label.toLowerCase().includes(lowerQuery)) {
+              results.push(cmd);
+            }
+          }
+        }
+      }
+      resolve(results);
+    }, 1000);
+  });
+}
+
+function AsyncLocalCommands() {
+  useXDSCommandPaletteRegister(
+    [
+      {
+        id: 'local-home',
+        label: 'Go to Home',
+        keywords: ['dashboard'],
+        onSelect: () => alert('Home'),
+        group: 'Navigation',
+      },
+      {
+        id: 'local-settings',
+        label: 'Open Settings',
+        keywords: ['preferences'],
+        shortcut: 'mod+,',
+        onSelect: () => alert('Settings'),
+        group: 'Navigation',
+      },
+      {
+        id: 'local-search',
+        label: 'Search Everything',
+        keywords: ['find'],
+        shortcut: 'mod+shift+f',
+        onSelect: () => alert('Searching'),
+        group: 'Actions',
+      },
+    ],
+    [],
+  );
+
+  return null;
+}
+
+function AsyncExample() {
+  const {open} = useXDSCommandPalette();
+
+  return (
+    <div style={{padding: 24}}>
+      <XDSText type="heading3">Async Loading</XDSText>
+      <div style={{marginTop: 8}}>
+        <XDSText type="body" color="secondary">
+          Local commands appear instantly while remote commands load with a
+          spinner. Try typing &quot;user&quot;, &quot;report&quot;, or
+          &quot;deploy&quot; to fetch remote commands (1-second simulated
+          delay). Local commands like &quot;Home&quot; and &quot;Settings&quot;
+          appear immediately.
+        </XDSText>
+      </div>
+      <div style={{marginTop: 16}}>
+        <XDSButton
+          label="Open Command Palette"
+          variant="primary"
+          onClick={() => open()}
+        />
+      </div>
+      <AsyncLocalCommands />
+    </div>
+  );
+}
+
+export const AsyncLoading: Story = {
+  render: () => (
+    <XDSCommandPaletteProvider
+      commandFetcher={simulateFetch}
+      fetchDebounceMs={200}
+      placeholder="Type to search local + remote commands...">
+      <AsyncExample />
+    </XDSCommandPaletteProvider>
+  ),
+};
+
+// =============================================================================
+// Kitchen Sink
+// =============================================================================
+
+const KS_REMOTE_COMMANDS: Record<string, XDSCommand[]> = {
+  user: [
+    {
+      id: 'ks-remote-user-list',
+      label: 'List All Users',
+      onSelect: () => alert('Listing users'),
+      group: 'Users',
+    },
+    {
+      id: 'ks-remote-user-create',
+      label: 'Create New User',
+      onSelect: () => alert('Creating user'),
+      group: 'Users',
+    },
+    {
+      id: 'ks-remote-user-perms',
+      label: 'Edit User Permissions',
+      onSelect: () => alert('Editing permissions'),
+      group: 'Users',
+    },
+  ],
+  report: [
+    {
+      id: 'ks-remote-report-rev',
+      label: 'Monthly Revenue Report',
+      onSelect: () => alert('Revenue report'),
+      group: 'Reports',
+    },
+    {
+      id: 'ks-remote-report-growth',
+      label: 'User Growth Report',
+      onSelect: () => alert('Growth report'),
+      group: 'Reports',
+    },
+  ],
+  deploy: [
+    {
+      id: 'ks-remote-deploy-staging',
+      label: 'Deploy to Staging',
+      onSelect: () => alert('Deploying to staging'),
+      group: 'DevOps',
+    },
+    {
+      id: 'ks-remote-deploy-canary',
+      label: 'Deploy Production Canary',
+      onSelect: () => alert('Canary deploy'),
+      group: 'DevOps',
+    },
+    {
+      id: 'ks-remote-deploy-rollback',
+      label: 'Rollback Last Release',
+      onSelect: () => alert('Rolling back'),
+      group: 'DevOps',
+    },
+  ],
+};
+
+function kitchenSinkFetcher(query: string): Promise<XDSCommand[]> {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      const lowerQuery = query.toLowerCase();
+      const results: XDSCommand[] = [];
+      for (const [key, commands] of Object.entries(KS_REMOTE_COMMANDS)) {
+        if (key.includes(lowerQuery) || lowerQuery.includes(key)) {
+          results.push(...commands);
+        } else {
+          for (const cmd of commands) {
+            if (cmd.label.toLowerCase().includes(lowerQuery)) {
+              results.push(cmd);
+            }
+          }
+        }
+      }
+      resolve(results);
+    }, 800);
+  });
+}
+
+function KitchenSinkCommands() {
+  useXDSCommandPaletteRegister(
+    [
+      // Navigation group
+      {
+        id: 'ks-home',
+        label: 'Go to Home',
+        keywords: ['dashboard', 'main', 'start'],
+        shortcut: 'mod+shift+h',
+        onSelect: () => alert('Home'),
+        group: 'Navigation',
+        priority: 10,
+      },
+      {
+        id: 'ks-projects',
+        label: 'Browse Projects',
+        keywords: ['repos', 'repositories', 'code'],
+        onSelect: () => alert('Projects'),
+        group: 'Navigation',
+      },
+      {
+        id: 'ks-inbox',
+        label: 'Open Inbox',
+        keywords: ['messages', 'notifications', 'mail'],
+        shortcut: 'mod+shift+i',
+        onSelect: () => alert('Inbox'),
+        group: 'Navigation',
+      },
+      {
+        id: 'ks-calendar',
+        label: 'View Calendar',
+        keywords: ['schedule', 'meetings', 'events'],
+        icon: 'calendar',
+        onSelect: () => alert('Calendar'),
+        group: 'Navigation',
+      },
+      {
+        id: 'ks-docs',
+        label: 'Documentation',
+        keywords: ['help', 'wiki', 'guides', 'reference'],
+        icon: 'externalLink',
+        onSelect: () => alert('Docs'),
+        group: 'Navigation',
+      },
+
+      // Actions group
+      {
+        id: 'ks-new-project',
+        label: 'Create New Project',
+        keywords: ['add', 'create', 'new', 'init'],
+        shortcut: 'mod+n',
+        onSelect: () => alert('New Project'),
+        group: 'Actions',
+        priority: 5,
+      },
+      {
+        id: 'ks-new-file',
+        label: 'Create New File',
+        keywords: ['add', 'create', 'file', 'document'],
+        onSelect: () => alert('New File'),
+        group: 'Actions',
+      },
+      {
+        id: 'ks-import',
+        label: 'Import Data',
+        keywords: ['upload', 'csv', 'json', 'load'],
+        onSelect: () => alert('Import'),
+        group: 'Actions',
+      },
+      {
+        id: 'ks-export',
+        label: 'Export as CSV',
+        keywords: ['download', 'save', 'csv', 'spreadsheet'],
+        onSelect: () => alert('Export CSV'),
+        group: 'Actions',
+      },
+      {
+        id: 'ks-export-json',
+        label: 'Export as JSON',
+        keywords: ['download', 'save', 'json', 'api'],
+        onSelect: () => alert('Export JSON'),
+        group: 'Actions',
+      },
+
+      // Settings — nested page
+      {
+        id: 'ks-settings',
+        label: 'Settings...',
+        keywords: ['preferences', 'config', 'options'],
+        shortcut: 'mod+,',
+        onSelect: () => {},
+        page: 'Settings',
+        group: 'System',
+        priority: 3,
+      },
+      {
+        id: 'ks-setting-general',
+        label: 'General',
+        keywords: ['language', 'region', 'locale'],
+        onSelect: () => alert('General Settings'),
+        group: 'Settings',
+      },
+      {
+        id: 'ks-setting-notifications',
+        label: 'Notifications',
+        keywords: ['alerts', 'emails', 'push'],
+        onSelect: () => alert('Notification Settings'),
+        group: 'Settings',
+      },
+      {
+        id: 'ks-setting-privacy',
+        label: 'Privacy & Security',
+        keywords: ['password', 'two-factor', '2fa', 'permissions'],
+        onSelect: () => alert('Privacy Settings'),
+        group: 'Settings',
+      },
+      {
+        id: 'ks-setting-api',
+        label: 'API Keys',
+        keywords: ['tokens', 'keys', 'credentials', 'oauth'],
+        onSelect: () => alert('API Key Settings'),
+        group: 'Settings',
+      },
+
+      // Theme — nested page
+      {
+        id: 'ks-theme',
+        label: 'Change Theme...',
+        keywords: ['appearance', 'dark', 'light', 'colors'],
+        onSelect: () => {},
+        page: 'Theme',
+        group: 'System',
+      },
+      {
+        id: 'ks-theme-light',
+        label: 'Light',
+        onSelect: () => alert('Switched to Light'),
+        group: 'Theme',
+      },
+      {
+        id: 'ks-theme-dark',
+        label: 'Dark',
+        onSelect: () => alert('Switched to Dark'),
+        group: 'Theme',
+      },
+      {
+        id: 'ks-theme-system',
+        label: 'System (auto)',
+        onSelect: () => alert('Switched to System'),
+        group: 'Theme',
+      },
+      {
+        id: 'ks-theme-high-contrast',
+        label: 'High Contrast',
+        onSelect: () => alert('Switched to High Contrast'),
+        group: 'Theme',
+      },
+
+      // Account group
+      {
+        id: 'ks-profile',
+        label: 'View Profile',
+        keywords: ['account', 'user', 'me'],
+        onSelect: () => alert('Profile'),
+        group: 'Account',
+      },
+      {
+        id: 'ks-billing',
+        label: 'Billing & Plans',
+        keywords: ['subscription', 'payment', 'upgrade', 'pricing'],
+        onSelect: () => alert('Billing'),
+        group: 'Account',
+      },
+      {
+        id: 'ks-team',
+        label: 'Team Members',
+        keywords: ['users', 'invite', 'collaborators', 'org'],
+        onSelect: () => alert('Team'),
+        group: 'Account',
+      },
+      {
+        id: 'ks-signout',
+        label: 'Sign Out',
+        keywords: ['logout', 'exit', 'leave'],
+        onSelect: () => alert('Signed out'),
+        group: 'Account',
+      },
+
+      // Developer group
+      {
+        id: 'ks-console',
+        label: 'Open Developer Console',
+        keywords: ['devtools', 'debug', 'inspect'],
+        shortcut: 'mod+shift+j',
+        onSelect: () => alert('Console'),
+        group: 'Developer',
+      },
+      {
+        id: 'ks-network',
+        label: 'View Network Requests',
+        keywords: ['api', 'http', 'fetch', 'xhr'],
+        onSelect: () => alert('Network'),
+        group: 'Developer',
+      },
+      {
+        id: 'ks-clear-cache',
+        label: 'Clear Cache',
+        keywords: ['reset', 'flush', 'storage', 'cookies'],
+        onSelect: () => alert('Cache cleared'),
+        group: 'Developer',
+      },
+
+      // Disabled command
+      {
+        id: 'ks-deploy',
+        label: 'Deploy to Production',
+        keywords: ['ship', 'release', 'publish'],
+        onSelect: () => {},
+        group: 'Actions',
+        isEnabled: false,
+      },
+    ],
+    [],
+  );
+
+  return null;
+}
+
+function KitchenSinkExample() {
+  const {open} = useXDSCommandPalette();
+
+  return (
+    <div style={{padding: 24}}>
+      <XDSText type="heading3">Kitchen Sink</XDSText>
+      <div style={{marginTop: 8}}>
+        <XDSText type="body" color="secondary">
+          A fully-loaded command palette demonstrating all features: local
+          commands appear instantly while remote commands load with a spinner.
+          Multiple groups, keyboard shortcuts, nested sub-pages (Settings,
+          Theme), search highlighting, priority ranking, icons, history tracking
+          with metadata, and disabled commands. Try &quot;export&quot; or
+          &quot;dark&quot; for local results, and &quot;user&quot;,
+          &quot;report&quot;, or &quot;deploy&quot; to see async remote commands
+          load alongside local matches.
+        </XDSText>
+      </div>
+      <div style={{marginTop: 16}}>
+        <XDSButton
+          label="Open Command Palette"
+          variant="primary"
+          onClick={() => open()}
+        />
+      </div>
+      <KitchenSinkCommands />
+    </div>
+  );
+}
+
+export const KitchenSink: Story = {
+  render: () => (
+    <XDSCommandPaletteProvider
+      isPersistHistory
+      maxHistory={5}
+      commandFetcher={kitchenSinkFetcher}
+      fetchDebounceMs={200}
+      placeholder="Type a command or search..."
+      footer={
+        <div style={{display: 'flex', gap: 16, fontSize: 12}}>
+          <span>
+            <kbd
+              style={{
+                padding: '2px 5px',
+                borderRadius: 3,
+                backgroundColor: 'var(--color-deemphasized)',
+                fontSize: 11,
+              }}>
+              &uarr;&darr;
+            </kbd>{' '}
+            Navigate
+          </span>
+          <span>
+            <kbd
+              style={{
+                padding: '2px 5px',
+                borderRadius: 3,
+                backgroundColor: 'var(--color-deemphasized)',
+                fontSize: 11,
+              }}>
+              &crarr;
+            </kbd>{' '}
+            Select
+          </span>
+          <span>
+            <kbd
+              style={{
+                padding: '2px 5px',
+                borderRadius: 3,
+                backgroundColor: 'var(--color-deemphasized)',
+                fontSize: 11,
+              }}>
+              esc
+            </kbd>{' '}
+            Close
+          </span>
+        </div>
+      }>
+      <KitchenSinkExample />
+    </XDSCommandPaletteProvider>
+  ),
+};

--- a/packages/core/src/CommandPalette/README.md
+++ b/packages/core/src/CommandPalette/README.md
@@ -1,0 +1,195 @@
+# /packages/core/src/CommandPalette
+
+Command palette component (Cmd+K) for searching and executing commands.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Provider/Context pattern**: Any component in the tree can register commands
+- **Lifecycle-aware**: Commands register on mount, deregister on unmount
+- **Fuzzy search**: Scores by exact match, starts-with, contains, aliases, and keywords
+- **Search highlighting**: Contiguous matching portions are bolded in results via `<mark>` elements
+- **Async command loading**: Fetch commands from external sources with loading spinner
+- **Keyboard navigation**: ArrowUp/Down, Enter, Escape, Home/End
+- **Grouped results**: Commands organized by group with "Recent" at top
+- **Nested pages**: Commands can open sub-pages for hierarchical navigation
+- **History tracking**: Recently used commands with invocation count, relative timestamps, source group, per-entry clearing, and optional localStorage persistence
+- **Shortcut display**: Keyboard shortcut hints rendered as `<kbd>` elements
+- **Accessible**: Proper ARIA roles (combobox, listbox, option), keyboard-driven
+
+## Usage
+
+```tsx
+import {
+  XDSCommandPaletteProvider,
+  useXDSCommandPaletteRegister,
+  useXDSCommandPalette,
+} from '@xds/core/CommandPalette';
+
+// 1. Wrap your app with the provider
+function App() {
+  return (
+    <XDSCommandPaletteProvider>
+      <Navigation />
+      <MainContent />
+    </XDSCommandPaletteProvider>
+  );
+}
+
+// 2. Register commands from any component
+function Navigation() {
+  useXDSCommandPaletteRegister([
+    {
+      id: 'home',
+      label: 'Go to Home',
+      icon: 'home',
+      onSelect: () => navigate('/'),
+    },
+    {
+      id: 'settings',
+      label: 'Settings',
+      icon: 'settings',
+      onSelect: () => navigate('/settings'),
+    },
+  ]);
+
+  return <nav>...</nav>;
+}
+
+// 3. Programmatically open/close
+function SearchButton() {
+  const {open} = useXDSCommandPalette();
+  return <button onClick={() => open()}>Search (Cmd+K)</button>;
+}
+```
+
+### Async command loading
+
+```tsx
+async function fetchCommands(query: string): Promise<XDSCommand[]> {
+  const response = await fetch(`/api/commands?q=${query}`);
+  return response.json();
+}
+
+<XDSCommandPaletteProvider commandFetcher={fetchCommands} fetchDebounceMs={200}>
+  <App />
+</XDSCommandPaletteProvider>;
+```
+
+Local commands appear instantly while remote commands load with a spinner. Fetched commands are deduplicated against locally registered commands (local takes precedence).
+
+## Provider Props
+
+| Prop               | Type                                       | Default                | Description                       |
+| ------------------ | ------------------------------------------ | ---------------------- | --------------------------------- |
+| `children`         | `ReactNode`                                | --                     | Application content (required)    |
+| `shortcut`         | `string`                                   | `"mod+k"`              | Keyboard shortcut to open palette |
+| `isPersistHistory` | `boolean`                                  | `false`                | Persist history to localStorage   |
+| `maxHistory`       | `number`                                   | `10`                   | Maximum history entries           |
+| `placeholder`      | `string`                                   | `"Search commands..."` | Search input placeholder          |
+| `emptyContent`     | `ReactNode`                                | `"No results found"`   | Content when no results match     |
+| `footer`           | `ReactNode`                                | --                     | Footer content                    |
+| `xstyle`           | `StyleXStyles`                             | --                     | StyleX overrides                  |
+| `commandFetcher`   | `(query: string) => Promise<XDSCommand[]>` | --                     | Async function to fetch commands  |
+| `fetchDebounceMs`  | `number`                                   | `200`                  | Debounce delay before fetching    |
+| `data-testid`      | `string`                                   | --                     | Test ID                           |
+
+## XDSCommand
+
+| Property    | Type          | Default | Description                             |
+| ----------- | ------------- | ------- | --------------------------------------- |
+| `id`        | `string`      | --      | Unique identifier (required)            |
+| `label`     | `string`      | --      | Display label (required)                |
+| `onSelect`  | `() => void`  | --      | Selection callback (required)           |
+| `aliases`   | `string[]`    | --      | Alternative names (matched like labels) |
+| `keywords`  | `string[]`    | --      | Additional search terms                 |
+| `group`     | `string`      | --      | Group name for visual grouping          |
+| `icon`      | `XDSIconType` | --      | Icon before the label                   |
+| `shortcut`  | `string`      | --      | Display-only shortcut hint              |
+| `page`      | `string`      | --      | Opens sub-page instead of executing     |
+| `priority`  | `number`      | `0`     | Higher = ranked higher in results       |
+| `isEnabled` | `boolean`     | `true`  | Whether the command is available        |
+
+## Types
+
+### `MatchRange`
+
+Represents a character range in a label where the search query matched.
+
+| Property | Type     | Description             |
+| -------- | -------- | ----------------------- |
+| `start`  | `number` | Start index (inclusive) |
+| `end`    | `number` | End index (exclusive)   |
+
+### `ScoredCommand`
+
+A command paired with its fuzzy search score and match ranges.
+
+| Property      | Type           | Description                          |
+| ------------- | -------------- | ------------------------------------ |
+| `command`     | `XDSCommand`   | The matched command                  |
+| `score`       | `number`       | Match score (higher = better)        |
+| `matchRanges` | `MatchRange[]` | Where the query matched in the label |
+
+### `HistoryEntry`
+
+A recorded history entry for recently used commands.
+
+| Property    | Type     | Description                                  |
+| ----------- | -------- | -------------------------------------------- |
+| `id`        | `string` | The command ID that was selected             |
+| `timestamp` | `number` | When the command was last selected           |
+| `count`     | `number` | How many times this command has been invoked |
+
+## Hooks
+
+### `useXDSCommandPaletteRegister(commands, deps?)`
+
+Register commands on mount, deregister on unmount. Re-registers when `deps` change.
+
+### `useXDSCommandPalette()`
+
+Returns `{ open, close, isOpen }` for imperative control.
+
+## Theming
+
+Themes can override CommandPalette styles via `ComponentStyles`:
+
+```tsx
+const theme: Theme = {
+  components: {
+    commandPalette: {
+      root: myStyles,
+    },
+  },
+};
+```
+
+### Available surfaces
+
+| Surface | Description              |
+| ------- | ------------------------ |
+| `root`  | Container element styles |
+
+## Accessibility
+
+- Search input uses `role="combobox"` with `aria-autocomplete="list"`
+- Results list uses `role="listbox"` with `role="option"` items
+- Active item tracked via `aria-activedescendant`
+- Shortcut hints use `aria-hidden="true"` (decorative)
+- Full keyboard navigation: ArrowUp/Down, Enter, Escape, Home/End, Backspace (back)
+
+## Files
+
+| File                              | Role     | Purpose                                                     |
+| --------------------------------- | -------- | ----------------------------------------------------------- |
+| `index.ts`                        | Entry    | Public exports                                              |
+| `types.ts`                        | Types    | Shared type definitions                                     |
+| `fuzzySearch.ts`                  | Utility  | Search scoring algorithm with match ranges                  |
+| `XDSCommandPaletteContext.tsx`    | Context  | React context definition                                    |
+| `XDSCommandPaletteProvider.tsx`   | Provider | Registry, keyboard listener, history, async fetching        |
+| `useXDSCommandPaletteRegister.ts` | Hook     | Register commands on mount                                  |
+| `useXDSCommandPalette.ts`         | Hook     | Imperative open/close API                                   |
+| `XDSCommandPalette.tsx`           | UI       | Modal search input, result list, keyboard nav, highlighting |
+| `XDSCommandPalette.test.tsx`      | Test     | Unit tests                                                  |

--- a/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
@@ -7,7 +7,7 @@
  * SYNC: When CommandPalette files change, update tests to match new behavior
  */
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import {XDSCommandPaletteProvider} from './XDSCommandPaletteProvider';
 import {useXDSCommandPaletteRegister} from './useXDSCommandPaletteRegister';
@@ -15,6 +15,18 @@ import {useXDSCommandPalette} from './useXDSCommandPalette';
 import {useState} from 'react';
 import type {XDSCommand} from './types';
 import {fuzzySearch} from './fuzzySearch';
+
+// Mock showModal and close methods since they're not fully implemented in jsdom
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
 
 // Helper component that registers commands
 function TestCommands({commands}: {commands: XDSCommand[]}) {
@@ -500,7 +512,7 @@ describe('XDSCommandPalette', () => {
     expect(options[0]).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('closes when clicking the overlay', () => {
+  it('uses XDSDialog with purpose="info" for backdrop click dismiss', () => {
     render(
       <XDSCommandPaletteProvider data-testid="palette">
         <TestCommands
@@ -511,13 +523,10 @@ describe('XDSCommandPalette', () => {
     );
 
     fireEvent.click(screen.getByText('Open'));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-
-    // Click the overlay (the presentation div)
-    const overlay = screen.getByRole('presentation');
-    fireEvent.click(overlay);
-
-    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog.tagName).toBe('DIALOG');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
   });
 });
 

--- a/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
@@ -1,0 +1,846 @@
+/**
+ * @file XDSCommandPalette.test.tsx
+ * @input Uses vitest, @testing-library/react, CommandPalette components
+ * @output Unit tests for XDSCommandPalette behavior
+ * @position Testing; validates CommandPalette implementation
+ *
+ * SYNC: When CommandPalette files change, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
+import {XDSCommandPaletteProvider} from './XDSCommandPaletteProvider';
+import {useXDSCommandPaletteRegister} from './useXDSCommandPaletteRegister';
+import {useXDSCommandPalette} from './useXDSCommandPalette';
+import {useState} from 'react';
+import type {XDSCommand} from './types';
+import {fuzzySearch} from './fuzzySearch';
+
+// Helper component that registers commands
+function TestCommands({commands}: {commands: XDSCommand[]}) {
+  useXDSCommandPaletteRegister(commands, [commands]);
+  return null;
+}
+
+// Helper component with open button
+function TestOpener() {
+  const {open} = useXDSCommandPalette();
+  return <button onClick={() => open()}>Open</button>;
+}
+
+/**
+ * Find an option element by its text content (handles text split by <mark>).
+ */
+function getOptionByLabel(label: string): HTMLElement | undefined {
+  const options = screen.getAllByRole('option');
+  return options.find(o => o.textContent?.includes(label));
+}
+
+const defaultCommands: XDSCommand[] = [
+  {id: 'save', label: 'Save File', onSelect: vi.fn(), shortcut: 'mod+s'},
+  {id: 'open', label: 'Open File', onSelect: vi.fn(), shortcut: 'mod+o'},
+  {
+    id: 'settings',
+    label: 'Open Settings',
+    onSelect: vi.fn(),
+    group: 'Navigation',
+  },
+];
+
+describe('XDSCommandPalette', () => {
+  it('renders provider without error', () => {
+    render(
+      <XDSCommandPaletteProvider>
+        <div>App content</div>
+      </XDSCommandPaletteProvider>,
+    );
+    expect(screen.getByText('App content')).toBeInTheDocument();
+  });
+
+  it('opens the palette with Cmd+K', () => {
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={defaultCommands} />
+      </XDSCommandPaletteProvider>,
+    );
+
+    // Palette should not be visible
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
+    // Fire Cmd+K (use ctrlKey since jsdom is not Mac)
+    fireEvent.keyDown(document, {key: 'k', ctrlKey: true});
+
+    // Palette should now be visible
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('closes the palette with Escape', () => {
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={defaultCommands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    // Open via button
+    fireEvent.click(screen.getByText('Open'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Press Escape on the input
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'Escape'});
+
+    // Palette should be gone
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows registered commands', () => {
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={defaultCommands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    expect(screen.getByText('Save File')).toBeInTheDocument();
+    expect(screen.getByText('Open File')).toBeInTheDocument();
+    expect(screen.getByText('Open Settings')).toBeInTheDocument();
+  });
+
+  it('filters commands with search', () => {
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={defaultCommands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'save'}});
+
+    // Text may be split by <mark> elements, so check option content
+    const option = getOptionByLabel('Save File');
+    expect(option).toBeDefined();
+    expect(screen.queryByText('Open Settings')).not.toBeInTheDocument();
+  });
+
+  it('supports keyboard navigation', () => {
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={defaultCommands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+
+    // First item should be highlighted
+    const firstOption = screen.getAllByRole('option')[0];
+    expect(firstOption).toHaveAttribute('aria-selected', 'true');
+
+    // Arrow down
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    const secondOption = screen.getAllByRole('option')[1];
+    expect(secondOption).toHaveAttribute('aria-selected', 'true');
+
+    // Arrow up
+    fireEvent.keyDown(input, {key: 'ArrowUp'});
+    expect(firstOption).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('selects command with Enter', () => {
+    const onSelect = vi.fn();
+    const commands = [{id: 'test', label: 'Test Command', onSelect}];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'Enter'});
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('deregisters commands on unmount', () => {
+    function ToggleCommands() {
+      const [isShown, setIsShown] = useState(true);
+      return (
+        <>
+          {isShown && (
+            <TestCommands
+              commands={[
+                {id: 'temp', label: 'Temporary Command', onSelect: vi.fn()},
+              ]}
+            />
+          )}
+          <button onClick={() => setIsShown(false)}>Remove</button>
+        </>
+      );
+    }
+
+    render(
+      <XDSCommandPaletteProvider>
+        <ToggleCommands />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    // Open and verify command exists
+    fireEvent.click(screen.getByText('Open'));
+    expect(screen.getByText('Temporary Command')).toBeInTheDocument();
+
+    // Close palette
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'Escape'});
+
+    // Unmount the commands
+    fireEvent.click(screen.getByText('Remove'));
+
+    // Reopen — command should be gone
+    fireEvent.click(screen.getByText('Open'));
+    expect(screen.queryByText('Temporary Command')).not.toBeInTheDocument();
+  });
+
+  it('hides commands with isEnabled: false', () => {
+    const commands = [
+      {id: 'enabled', label: 'Enabled Command', onSelect: vi.fn()},
+      {
+        id: 'disabled',
+        label: 'Disabled Command',
+        onSelect: vi.fn(),
+        isEnabled: false,
+      },
+    ];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    expect(screen.getByText('Enabled Command')).toBeInTheDocument();
+    expect(screen.queryByText('Disabled Command')).not.toBeInTheDocument();
+  });
+
+  it('opens to a specific page via command', () => {
+    const commands = [
+      {
+        id: 'theme',
+        label: 'Change Theme',
+        onSelect: vi.fn(),
+        page: 'Themes',
+      },
+      {
+        id: 'dark',
+        label: 'Dark Mode',
+        onSelect: vi.fn(),
+        group: 'Themes',
+      },
+      {
+        id: 'light',
+        label: 'Light Mode',
+        onSelect: vi.fn(),
+        group: 'Themes',
+      },
+    ];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    // Select the "Change Theme" page command
+    fireEvent.click(screen.getByText('Change Theme'));
+
+    // Should now show theme sub-page commands
+    expect(screen.getByText('Dark Mode')).toBeInTheDocument();
+    expect(screen.getByText('Light Mode')).toBeInTheDocument();
+    expect(screen.queryByText('Change Theme')).not.toBeInTheDocument();
+  });
+
+  it('navigates back from a sub-page with Backspace on empty input', () => {
+    const commands = [
+      {
+        id: 'theme',
+        label: 'Change Theme',
+        onSelect: vi.fn(),
+        page: 'Themes',
+      },
+      {
+        id: 'dark',
+        label: 'Dark Mode',
+        onSelect: vi.fn(),
+        group: 'Themes',
+      },
+    ];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    // Go to sub-page
+    fireEvent.click(screen.getByText('Change Theme'));
+    expect(screen.getByText('Dark Mode')).toBeInTheDocument();
+
+    // Press Backspace on empty input to go back
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'Backspace'});
+
+    // Should be back on main page
+    expect(screen.getByText('Change Theme')).toBeInTheDocument();
+  });
+
+  it('records history when a command is selected', () => {
+    const onSelect = vi.fn();
+    const commands = [
+      {id: 'cmd1', label: 'Command One', onSelect},
+      {id: 'cmd2', label: 'Command Two', onSelect: vi.fn()},
+    ];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    // Select a command
+    fireEvent.click(screen.getByText('Open'));
+    fireEvent.click(screen.getByText('Command One'));
+
+    // Reopen — the selected command should appear in "Recent" group
+    fireEvent.click(screen.getByText('Open'));
+    expect(screen.getByText('Recent')).toBeInTheDocument();
+  });
+
+  it('shows relative time and clear button for recent commands', () => {
+    const onSelect = vi.fn();
+    const commands = [
+      {id: 'cmd1', label: 'Command One', onSelect, group: 'Tools'},
+      {id: 'cmd2', label: 'Command Two', onSelect: vi.fn()},
+    ];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    // Select a command
+    fireEvent.click(screen.getByText('Open'));
+    fireEvent.click(screen.getByText('Command One'));
+
+    // Reopen
+    fireEvent.click(screen.getByText('Open'));
+
+    // Should show relative time
+    expect(screen.getByText('just now')).toBeInTheDocument();
+
+    // Should show group context
+    expect(screen.getByText('Tools')).toBeInTheDocument();
+
+    // Should have a clear button
+    expect(
+      screen.getByLabelText('Remove Command One from recent'),
+    ).toBeInTheDocument();
+  });
+
+  it('increments count on repeated command selections', () => {
+    const onSelect = vi.fn();
+    const commands = [{id: 'cmd1', label: 'Command One', onSelect}];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    // Select the same command 3 times
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByText('Open'));
+      fireEvent.click(screen.getByText('Command One'));
+    }
+
+    // Reopen — count should be displayed
+    fireEvent.click(screen.getByText('Open'));
+    expect(screen.getByText('3×')).toBeInTheDocument();
+  });
+
+  it('clears a single history entry with the clear button', () => {
+    const onSelect = vi.fn();
+    const commands = [
+      {id: 'cmd1', label: 'Command One', onSelect},
+      {id: 'cmd2', label: 'Command Two', onSelect: vi.fn()},
+    ];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    // Select both commands
+    fireEvent.click(screen.getByText('Open'));
+    fireEvent.click(screen.getByText('Command One'));
+    fireEvent.click(screen.getByText('Open'));
+    fireEvent.click(screen.getByText('Command Two'));
+
+    // Reopen — both should be in Recent
+    fireEvent.click(screen.getByText('Open'));
+    expect(screen.getByText('Recent')).toBeInTheDocument();
+
+    // Clear Command One from history
+    fireEvent.click(screen.getByLabelText('Remove Command One from recent'));
+
+    // Command Two should still be in Recent, Command One should not
+    const options = screen.getAllByRole('option');
+    const recentLabels = options.map(o => o.textContent);
+    expect(recentLabels.some(l => l?.includes('Command Two'))).toBe(true);
+    // Recent group should still exist for Command Two
+    expect(screen.getByText('Recent')).toBeInTheDocument();
+  });
+
+  it('uses custom placeholder', () => {
+    render(
+      <XDSCommandPaletteProvider placeholder="Type a command...">
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+    expect(
+      screen.getByPlaceholderText('Type a command...'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows empty content when no results', () => {
+    render(
+      <XDSCommandPaletteProvider emptyContent="Nothing here">
+        <TestCommands
+          commands={[{id: 'test', label: 'Test', onSelect: vi.fn()}]}
+        />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'zzzzz'}});
+
+    expect(screen.getByText('Nothing here')).toBeInTheDocument();
+  });
+
+  it('renders footer content', () => {
+    render(
+      <XDSCommandPaletteProvider footer={<span>Tip: Use arrow keys</span>}>
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+    expect(screen.getByText('Tip: Use arrow keys')).toBeInTheDocument();
+  });
+
+  it('supports Home and End keys', () => {
+    const commands = [
+      {id: 'a', label: 'Alpha', onSelect: vi.fn()},
+      {id: 'b', label: 'Beta', onSelect: vi.fn()},
+      {id: 'c', label: 'Charlie', onSelect: vi.fn()},
+    ];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+
+    // Press End
+    fireEvent.keyDown(input, {key: 'End'});
+    const options = screen.getAllByRole('option');
+    expect(options[options.length - 1]).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    // Press Home
+    fireEvent.keyDown(input, {key: 'Home'});
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('closes when clicking the overlay', () => {
+    render(
+      <XDSCommandPaletteProvider data-testid="palette">
+        <TestCommands
+          commands={[{id: 'test', label: 'Test', onSelect: vi.fn()}]}
+        />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    // Click the overlay (the presentation div)
+    const overlay = screen.getByRole('presentation');
+    fireEvent.click(overlay);
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// fuzzySearch match range tests
+// =============================================================================
+
+describe('fuzzySearch match ranges', () => {
+  it('returns match ranges for exact match', () => {
+    const commands = [{id: '1', label: 'Save', onSelect: vi.fn()}];
+    const results = fuzzySearch(commands, 'save', []);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(100);
+    expect(results[0].matchRanges).toEqual([{start: 0, end: 4}]);
+  });
+
+  it('returns match ranges for starts-with match', () => {
+    const commands = [{id: '1', label: 'Save File', onSelect: vi.fn()}];
+    const results = fuzzySearch(commands, 'save', []);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(80);
+    expect(results[0].matchRanges).toEqual([{start: 0, end: 4}]);
+  });
+
+  it('returns match ranges for contains match', () => {
+    const commands = [{id: '1', label: 'Open Settings', onSelect: vi.fn()}];
+    const results = fuzzySearch(commands, 'sett', []);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(70);
+    expect(results[0].matchRanges).toEqual([{start: 5, end: 9}]);
+  });
+
+  it('does not match scattered subsequences', () => {
+    const commands = [{id: '1', label: 'Save File', onSelect: vi.fn()}];
+    const results = fuzzySearch(commands, 'sfl', []);
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty match ranges for keyword-only match', () => {
+    const commands = [
+      {id: '1', label: 'Settings', keywords: ['config'], onSelect: vi.fn()},
+    ];
+    const results = fuzzySearch(commands, 'config', []);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(40);
+    expect(results[0].matchRanges).toEqual([]);
+  });
+
+  it('returns all commands with empty ranges when query is empty', () => {
+    const commands = [
+      {id: '1', label: 'Save', onSelect: vi.fn()},
+      {id: '2', label: 'Open', onSelect: vi.fn()},
+    ];
+    const results = fuzzySearch(commands, '', []);
+
+    expect(results).toHaveLength(2);
+    expect(results[0].matchRanges).toEqual([]);
+    expect(results[1].matchRanges).toEqual([]);
+  });
+
+  it('matches aliases with label-level scoring but no highlighting', () => {
+    const commands = [
+      {
+        id: '1',
+        label: 'Settings',
+        aliases: ['Preferences'],
+        onSelect: vi.fn(),
+      },
+    ];
+    const results = fuzzySearch(commands, 'pref', []);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(80); // starts-with on alias
+    expect(results[0].matchRanges).toEqual([]); // no label highlighting
+  });
+
+  it('prefers label match over alias match', () => {
+    const commands = [
+      {
+        id: '1',
+        label: 'Settings',
+        aliases: ['Settings Panel'],
+        onSelect: vi.fn(),
+      },
+    ];
+    const results = fuzzySearch(commands, 'settings', []);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(100); // exact label match
+    expect(results[0].matchRanges).toEqual([{start: 0, end: 8}]); // label highlighting
+  });
+
+  it('falls through to keywords when no label or alias match', () => {
+    const commands = [
+      {
+        id: '1',
+        label: 'Settings',
+        aliases: ['Preferences'],
+        keywords: ['config'],
+        onSelect: vi.fn(),
+      },
+    ];
+    const results = fuzzySearch(commands, 'config', []);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBe(40); // keyword match
+    expect(results[0].matchRanges).toEqual([]);
+  });
+});
+
+// =============================================================================
+// Highlight rendering tests
+// =============================================================================
+
+describe('search highlight rendering', () => {
+  it('renders mark elements for matching text', () => {
+    const commands = [{id: '1', label: 'Save File', onSelect: vi.fn()}];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'save'}});
+
+    // The matching "Save" portion should be in a <mark> element
+    const marks = document.querySelectorAll('mark');
+    expect(marks.length).toBeGreaterThan(0);
+    expect(marks[0].textContent).toBe('Save');
+  });
+
+  it('renders mark for contiguous substring match', () => {
+    const commands = [{id: '1', label: 'Open Settings', onSelect: vi.fn()}];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'sett'}});
+
+    const marks = document.querySelectorAll('mark');
+    expect(marks.length).toBe(1);
+    expect(marks[0].textContent).toBe('Sett');
+  });
+
+  it('does not render mark elements when no query', () => {
+    const commands = [{id: '1', label: 'Save File', onSelect: vi.fn()}];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    // No query, no marks
+    const marks = document.querySelectorAll('mark');
+    expect(marks.length).toBe(0);
+  });
+
+  it('does not render mark elements for keyword-only matches', () => {
+    const commands = [
+      {id: '1', label: 'Settings', keywords: ['config'], onSelect: vi.fn()},
+    ];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'config'}});
+
+    // Keyword match — no label highlighting
+    const marks = document.querySelectorAll('mark');
+    expect(marks.length).toBe(0);
+  });
+
+  it('does not match commands with scattered subsequence queries', () => {
+    const commands = [{id: '1', label: 'Save File', onSelect: vi.fn()}];
+
+    render(
+      <XDSCommandPaletteProvider>
+        <TestCommands commands={commands} />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'sfl'}});
+
+    // No results — scattered subsequence not supported
+    expect(screen.queryAllByRole('option')).toHaveLength(0);
+  });
+});
+
+// =============================================================================
+// Async loading tests
+// =============================================================================
+
+describe('async command loading', () => {
+  it('shows loading spinner while fetching', async () => {
+    let resolveFetch: (commands: XDSCommand[]) => void;
+    const fetcher = vi.fn(
+      () =>
+        new Promise<XDSCommand[]>(resolve => {
+          resolveFetch = resolve;
+        }),
+    );
+
+    render(
+      <XDSCommandPaletteProvider commandFetcher={fetcher} fetchDebounceMs={0}>
+        <TestCommands
+          commands={[{id: 'local', label: 'Local Command', onSelect: vi.fn()}]}
+        />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'test'}});
+
+    // Wait for debounce (0ms) + fetcher to be called
+    await waitFor(() => {
+      expect(fetcher).toHaveBeenCalledWith('test');
+    });
+
+    // Resolve the fetch
+    await act(async () => {
+      resolveFetch!([
+        {id: 'remote', label: 'Remote Test Command', onSelect: vi.fn()},
+      ]);
+    });
+
+    // Remote command should appear in results (text may be split by <mark>)
+    await waitFor(() => {
+      const option = getOptionByLabel('Remote Test Command');
+      expect(option).toBeDefined();
+    });
+  });
+
+  it('merges local and fetched commands', async () => {
+    const fetcher = vi.fn(() =>
+      Promise.resolve([
+        {id: 'remote-1', label: 'Remote Alpha', onSelect: vi.fn()},
+      ]),
+    );
+
+    render(
+      <XDSCommandPaletteProvider commandFetcher={fetcher} fetchDebounceMs={0}>
+        <TestCommands
+          commands={[{id: 'local-1', label: 'Local Alpha', onSelect: vi.fn()}]}
+        />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'alpha'}});
+
+    await waitFor(() => {
+      const options = screen.getAllByRole('option');
+      const labels = options.map(o => o.textContent);
+      expect(labels.some(l => l?.includes('Local Alpha'))).toBe(true);
+      expect(labels.some(l => l?.includes('Remote Alpha'))).toBe(true);
+    });
+  });
+
+  it('deduplicates fetched commands with same id as local', async () => {
+    const fetcher = vi.fn(() =>
+      Promise.resolve([
+        {id: 'shared', label: 'Remote Version', onSelect: vi.fn()},
+      ]),
+    );
+
+    render(
+      <XDSCommandPaletteProvider commandFetcher={fetcher} fetchDebounceMs={0}>
+        <TestCommands
+          commands={[{id: 'shared', label: 'Local Version', onSelect: vi.fn()}]}
+        />
+        <TestOpener />
+      </XDSCommandPaletteProvider>,
+    );
+
+    fireEvent.click(screen.getByText('Open'));
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'version'}});
+
+    await waitFor(() => {
+      const options = screen.getAllByRole('option');
+      const labels = options.map(o => o.textContent);
+      // Local command takes precedence
+      expect(labels.some(l => l?.includes('Local Version'))).toBe(true);
+      expect(labels.some(l => l?.includes('Remote Version'))).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -177,22 +177,6 @@ const styles = stylex.create({
     fontSize: textSizeVars['--text-xsm'],
     color: colorVars['--color-text-secondary'],
   },
-  footerButton: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
-    border: 'none',
-    backgroundColor: 'transparent',
-    cursor: 'pointer',
-    padding: `${spacingVars['--spacing-0-5']} ${spacingVars['--spacing-1']}`,
-    borderRadius: radiusVars['--radius-content'],
-    fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-2xs'],
-    color: colorVars['--color-text-placeholder'],
-    ':hover': {
-      color: colorVars['--color-text-secondary'],
-    },
-  },
   shortcutRow: {
     boxSizing: 'border-box',
     display: 'flex',
@@ -230,19 +214,8 @@ const styles = stylex.create({
     opacity: 0.5,
   },
   clearButton: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    border: 'none',
-    backgroundColor: 'transparent',
-    cursor: 'pointer',
-    padding: `0 ${spacingVars['--spacing-0-5']}`,
-    marginLeft: spacingVars['--spacing-0-5'],
-    color: colorVars['--color-text-placeholder'],
-    lineHeight: lineHeightVars['--leading-tight'],
     opacity: 0,
     transition: `opacity ${transitionVars['--transition-fast']}`,
-    borderRadius: radiusVars['--radius-content'],
   },
   // Show clear button when hovering its parent item
   itemHoverClearVisible: {
@@ -383,20 +356,23 @@ function CommandPaletteRecentMeta({
           <span>{command.group}</span>
         </>
       )}
-      <button
-        type="button"
+      <span
         {...stylex.props(
           styles.clearButton,
           isHighlighted && styles.itemHoverClearVisible,
-        )}
-        onClick={e => {
-          e.stopPropagation();
-          onClear(command.id);
-        }}
-        aria-label={`Remove ${command.label} from recent`}
-        tabIndex={-1}>
-        <XDSIcon icon="close" size="xsm" color="inherit" />
-      </button>
+        )}>
+        <XDSButton
+          label={`Remove ${command.label} from recent`}
+          variant="ghost"
+          size="sm"
+          icon={<XDSIcon icon="close" size="xsm" color="inherit" />}
+          onClick={e => {
+            e.stopPropagation();
+            onClear(command.id);
+          }}
+          tabIndex={-1}
+        />
+      </span>
     </span>
   );
 }
@@ -827,13 +803,13 @@ export function XDSCommandPalette({
         {/* Footer */}
         <div {...stylex.props(styles.footer)}>
           <div>{footer}</div>
-          <button
-            type="button"
-            {...stylex.props(styles.footerButton)}
+          <XDSButton
+            label={isShowShortcuts ? 'Back to commands' : 'Keyboard shortcuts'}
+            variant="ghost"
+            size="sm"
             onClick={() => setIsShowShortcuts(prev => !prev)}
-            tabIndex={-1}>
-            {isShowShortcuts ? 'Back to commands' : 'Keyboard shortcuts'}
-          </button>
+            tabIndex={-1}
+          />
         </div>
       </div>
     </XDSDialog>

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -1,0 +1,865 @@
+/**
+ * @file XDSCommandPalette.tsx
+ * @input Uses React, StyleX, XDSIcon, XDSSpinner, types
+ * @output Exports XDSCommandPalette component
+ * @position Modal UI; rendered by XDSCommandPaletteProvider
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md (features, accessibility)
+ * - /packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
+ * - /apps/storybook/stories/CommandPalette.stories.tsx
+ */
+
+import {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSIcon} from '../Icon';
+import {XDSSpinner} from '../Spinner';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  elevationVars,
+  transitionVars,
+  textSizeVars,
+  typographyVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+import {ThemeContext} from '../theme/ThemeContext';
+import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
+import type {
+  XDSCommand,
+  HistoryEntry,
+  ScoredCommand,
+  MatchRange,
+} from './types';
+
+// =============================================================================
+// Module Augmentation
+// =============================================================================
+
+declare module '../theme/types' {
+  interface ComponentStyles {
+    commandPalette?: {
+      root?: ThemeStyleXStyles;
+    };
+  }
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  // Fixed overlay: covers viewport, flexbox centers the palette
+  overlay: {
+    position: 'fixed',
+    inset: 0,
+    zIndex: 9999,
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    paddingTop: '15vh',
+    backgroundColor: colorVars['--color-overlay'],
+    backdropFilter: 'blur(2px)',
+  },
+  // The palette panel itself
+  panel: {
+    width: '560px',
+    maxWidth: '90vw',
+    maxHeight: '60vh',
+    display: 'flex',
+    flexDirection: 'column',
+    backgroundColor: colorVars['--color-surface'],
+    borderRadius: radiusVars['--radius-container'],
+    boxShadow: elevationVars['--elevation-dialog'],
+    overflow: 'hidden',
+    // Open animation
+    opacity: 1,
+    transform: 'scale(1) translateY(0)',
+    transition: `opacity ${transitionVars['--transition-normal']}, transform ${transitionVars['--transition-normal']}`,
+  },
+  inputWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    padding: `${spacingVars['--spacing-3']} ${spacingVars['--spacing-4']}`,
+    borderBottom: `1px solid ${colorVars['--color-divider']}`,
+  },
+  inputIcon: {
+    flexShrink: 0,
+    color: colorVars['--color-icon-secondary'],
+  },
+  input: {
+    flex: 1,
+    border: 'none',
+    outline: 'none',
+    backgroundColor: 'transparent',
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    color: colorVars['--color-text-primary'],
+    lineHeight: lineHeightVars['--leading-normal'],
+    '::placeholder': {
+      color: colorVars['--color-text-placeholder'],
+    },
+  },
+  resultList: {
+    overflowY: 'auto',
+    padding: spacingVars['--spacing-1'],
+    flex: 1,
+  },
+  groupLabel: {
+    padding: `${spacingVars['--spacing-2']} ${spacingVars['--spacing-3']} ${spacingVars['--spacing-1']}`,
+    marginTop: spacingVars['--spacing-2'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+  },
+  groupDivider: {
+    height: '1px',
+    backgroundColor: colorVars['--color-divider'],
+    margin: `${spacingVars['--spacing-1']} ${spacingVars['--spacing-3']}`,
+  },
+  item: {
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    width: '100%',
+    padding: `${spacingVars['--spacing-2']} ${spacingVars['--spacing-3']}`,
+    borderRadius: radiusVars['--radius-content'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    color: colorVars['--color-text-primary'],
+    backgroundColor: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    textAlign: 'left' as const,
+    outline: 'none',
+    transition: `background-color ${transitionVars['--transition-fast']}`,
+  },
+  itemHighlighted: {
+    backgroundColor: colorVars['--color-hover-overlay'],
+  },
+  itemLabel: {
+    flex: 1,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap' as const,
+  },
+  highlightMark: {
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-primary'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+  },
+  shortcut: {
+    display: 'flex',
+    gap: spacingVars['--spacing-0-5'],
+    flexShrink: 0,
+  },
+  kbd: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: '20px',
+    height: '20px',
+    padding: `0 ${spacingVars['--spacing-1']}`,
+    borderRadius: radiusVars['--radius-content'],
+    backgroundColor: colorVars['--color-deemphasized'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+    lineHeight: lineHeightVars['--leading-tight'],
+  },
+  empty: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacingVars['--spacing-8'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-sm'],
+    color: colorVars['--color-text-secondary'],
+  },
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacingVars['--spacing-4'],
+  },
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: `${spacingVars['--spacing-2']} ${spacingVars['--spacing-4']}`,
+    borderTop: `1px solid ${colorVars['--color-divider']}`,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+  },
+  footerButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    border: 'none',
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+    padding: `${spacingVars['--spacing-0-5']} ${spacingVars['--spacing-1']}`,
+    borderRadius: radiusVars['--radius-content'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-2xs'],
+    color: colorVars['--color-text-placeholder'],
+    ':hover': {
+      color: colorVars['--color-text-secondary'],
+    },
+  },
+  shortcutRow: {
+    boxSizing: 'border-box',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    padding: `${spacingVars['--spacing-1-5']} ${spacingVars['--spacing-3']}`,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-sm'],
+    color: colorVars['--color-text-primary'],
+  },
+  pageHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    padding: `${spacingVars['--spacing-2']} ${spacingVars['--spacing-3']}`,
+    borderBottom: `1px solid ${colorVars['--color-divider']}`,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-sm'],
+    color: colorVars['--color-text-secondary'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+  },
+  backButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: 'none',
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+    padding: spacingVars['--spacing-1'],
+    borderRadius: radiusVars['--radius-content'],
+    color: colorVars['--color-icon-secondary'],
+    ':hover': {
+      backgroundColor: colorVars['--color-hover-overlay'],
+    },
+  },
+  recentMeta: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    flexShrink: 0,
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-2xs'],
+    color: colorVars['--color-text-placeholder'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    letterSpacing: '0.01em',
+  },
+  recentMetaSeparator: {
+    opacity: 0.5,
+  },
+  clearButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    border: 'none',
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+    padding: `0 ${spacingVars['--spacing-0-5']}`,
+    marginLeft: spacingVars['--spacing-0-5'],
+    color: colorVars['--color-text-placeholder'],
+    fontSize: textSizeVars['--text-2xs'],
+    lineHeight: lineHeightVars['--leading-tight'],
+    opacity: 0,
+    transition: `opacity ${transitionVars['--transition-fast']}`,
+    borderRadius: radiusVars['--radius-content'],
+  },
+  // Show clear button when hovering its parent item
+  itemHoverClearVisible: {
+    opacity: 1,
+  },
+});
+
+// =============================================================================
+// Shortcut display helpers
+// =============================================================================
+
+const MOD_SYMBOLS: Record<string, string> = {
+  mod:
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad/.test(navigator.userAgent)
+      ? '\u2318'
+      : 'Ctrl',
+  ctrl: 'Ctrl',
+  meta: '\u2318',
+  shift: '\u21E7',
+  alt:
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad/.test(navigator.userAgent)
+      ? '\u2325'
+      : 'Alt',
+};
+
+function formatShortcutKey(key: string): string {
+  return MOD_SYMBOLS[key.toLowerCase()] ?? key.toUpperCase();
+}
+
+// =============================================================================
+// Highlight rendering
+// =============================================================================
+
+function renderHighlightedLabel(
+  label: string,
+  matchRanges: MatchRange[],
+): ReactNode {
+  if (matchRanges.length === 0) {
+    return label;
+  }
+
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+
+  for (let i = 0; i < matchRanges.length; i++) {
+    const range = matchRanges[i];
+    // Text before this match
+    if (range.start > lastIndex) {
+      parts.push(label.slice(lastIndex, range.start));
+    }
+    // Matched text
+    parts.push(
+      <mark key={i} {...stylex.props(styles.highlightMark)}>
+        {label.slice(range.start, range.end)}
+      </mark>,
+    );
+    lastIndex = range.end;
+  }
+
+  // Text after last match
+  if (lastIndex < label.length) {
+    parts.push(label.slice(lastIndex));
+  }
+
+  return parts;
+}
+
+// =============================================================================
+// Relative time formatting
+// =============================================================================
+
+function formatRelativeTime(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+// =============================================================================
+// Props
+// =============================================================================
+
+interface XDSCommandPaletteProps {
+  isOpen: boolean;
+  onClose: () => void;
+  scoredCommands: ScoredCommand[];
+  isLoading: boolean;
+  query: string;
+  onQueryChange: (query: string) => void;
+  getHistory: () => HistoryEntry[];
+  recordHistory: (commandId: string) => void;
+  clearHistoryEntry: (commandId: string) => void;
+  pageStack: string[];
+  onPageStackChange: (pages: string[]) => void;
+  placeholder?: string;
+  emptyContent?: ReactNode;
+  footer?: ReactNode;
+  xstyle?: stylex.StyleXStyles;
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * The modal UI for the command palette.
+ * Rendered internally by XDSCommandPaletteProvider.
+ *
+ * Uses a fixed overlay with flexbox centering rather than the native
+ * <dialog> element, for robust cross-browser positioning.
+ */
+export function XDSCommandPalette({
+  isOpen,
+  onClose,
+  scoredCommands,
+  isLoading,
+  query,
+  onQueryChange,
+  getHistory,
+  recordHistory,
+  clearHistoryEntry,
+  pageStack,
+  onPageStackChange,
+  placeholder = 'Search commands...',
+  emptyContent,
+  footer,
+  xstyle,
+  'data-testid': testId,
+}: XDSCommandPaletteProps) {
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const [isShowShortcuts, setIsShowShortcuts] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.commandPalette?.root;
+
+  const currentPage =
+    pageStack.length > 0 ? pageStack[pageStack.length - 1] : null;
+
+  const historyEntries = getHistory();
+  const historyMap = useMemo(() => {
+    const map = new Map<string, HistoryEntry>();
+    for (const entry of historyEntries) {
+      map.set(entry.id, entry);
+    }
+    return map;
+  }, [historyEntries]);
+
+  // Group commands for display
+  let grouped: {group: string | null; items: ScoredCommand[]}[];
+
+  if (query.length > 0) {
+    // When searching, don't show groups — flat list
+    grouped = [{group: null, items: scoredCommands}];
+  } else {
+    // Show "Recent" group first when no query
+    const recentIds = new Set(historyEntries.map(h => h.id));
+    const recent = scoredCommands.filter(sc => recentIds.has(sc.command.id));
+    const rest = scoredCommands.filter(sc => !recentIds.has(sc.command.id));
+
+    const groups: {group: string | null; items: ScoredCommand[]}[] = [];
+
+    if (recent.length > 0) {
+      groups.push({group: 'Recent', items: recent});
+    }
+
+    // Group remaining by their group property
+    const byGroup = new Map<string | null, ScoredCommand[]>();
+    for (const sc of rest) {
+      const key = sc.command.group ?? null;
+      const list = byGroup.get(key);
+      if (list) {
+        list.push(sc);
+      } else {
+        byGroup.set(key, [sc]);
+      }
+    }
+
+    for (const [group, items] of byGroup) {
+      groups.push({group, items});
+    }
+
+    grouped = groups;
+  }
+
+  // Flat list for keyboard navigation
+  const flatItems = grouped.flatMap(g => g.items);
+
+  // Reset state when opening/closing
+  useEffect(() => {
+    if (isOpen) {
+      setHighlightedIndex(0);
+      setIsShowShortcuts(false);
+      // Focus input on next frame
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [isOpen]);
+
+  // Lock body scroll when open
+  useEffect(() => {
+    if (!isOpen) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [isOpen]);
+
+  // Reset highlighted index when results change
+  useEffect(() => {
+    setHighlightedIndex(0);
+  }, [query]);
+
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (!listRef.current) return;
+    const items = listRef.current.querySelectorAll('[role="option"]');
+    const item = items[highlightedIndex] as HTMLElement | undefined;
+    item?.scrollIntoView?.({block: 'nearest'});
+  }, [highlightedIndex]);
+
+  const handleSelect = useCallback(
+    (command: XDSCommand) => {
+      if (command.page) {
+        onPageStackChange([...pageStack, command.page]);
+        onQueryChange('');
+        setHighlightedIndex(0);
+        return;
+      }
+
+      recordHistory(command.id);
+      onClose();
+      command.onSelect();
+    },
+    [pageStack, onPageStackChange, onQueryChange, recordHistory, onClose],
+  );
+
+  const goBack = useCallback(() => {
+    if (pageStack.length > 0) {
+      onPageStackChange(pageStack.slice(0, -1));
+      onQueryChange('');
+      setHighlightedIndex(0);
+    }
+  }, [pageStack, onPageStackChange, onQueryChange]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault();
+          setHighlightedIndex(prev =>
+            prev < flatItems.length - 1 ? prev + 1 : prev,
+          );
+          break;
+        case 'ArrowUp':
+          e.preventDefault();
+          setHighlightedIndex(prev => (prev > 0 ? prev - 1 : prev));
+          break;
+        case 'Home':
+          e.preventDefault();
+          setHighlightedIndex(0);
+          break;
+        case 'End':
+          e.preventDefault();
+          setHighlightedIndex(Math.max(0, flatItems.length - 1));
+          break;
+        case 'Enter':
+          e.preventDefault();
+          if (highlightedIndex >= 0 && highlightedIndex < flatItems.length) {
+            handleSelect(flatItems[highlightedIndex].command);
+          }
+          break;
+        case 'Backspace':
+          if (query === '' && pageStack.length > 0) {
+            e.preventDefault();
+            goBack();
+          }
+          break;
+        case 'Escape':
+          e.preventDefault();
+          if (isShowShortcuts) {
+            setIsShowShortcuts(false);
+          } else if (pageStack.length > 0) {
+            goBack();
+          } else {
+            onClose();
+          }
+          break;
+      }
+    },
+    [
+      flatItems,
+      highlightedIndex,
+      handleSelect,
+      query,
+      pageStack,
+      goBack,
+      onClose,
+      isShowShortcuts,
+    ],
+  );
+
+  // Click on overlay (outside panel) closes palette
+  const handleOverlayClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!isOpen) return null;
+
+  // Build flat index for mapping grouped items
+  let flatIndex = 0;
+
+  return (
+    <div
+      {...stylex.props(styles.overlay)}
+      onClick={handleOverlayClick}
+      data-testid={testId}
+      role="presentation">
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+        {...stylex.props(styles.panel, rootOverride, xstyle)}>
+        {/* Page header with back button */}
+        {currentPage && (
+          <div {...stylex.props(styles.pageHeader)}>
+            <button
+              type="button"
+              onClick={goBack}
+              {...stylex.props(styles.backButton)}
+              aria-label="Go back">
+              <XDSIcon icon="chevronLeft" size="sm" color="inherit" />
+            </button>
+            {currentPage}
+          </div>
+        )}
+
+        {/* Search input */}
+        <div {...stylex.props(styles.inputWrapper)}>
+          <span {...stylex.props(styles.inputIcon)}>
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+          </span>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={e => onQueryChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            role="combobox"
+            aria-expanded={flatItems.length > 0}
+            aria-controls="command-palette-list"
+            aria-activedescendant={
+              highlightedIndex >= 0
+                ? `command-palette-item-${highlightedIndex}`
+                : undefined
+            }
+            aria-autocomplete="list"
+            {...stylex.props(styles.input)}
+          />
+        </div>
+
+        {/* Result list */}
+        <div
+          ref={listRef}
+          id="command-palette-list"
+          role={isShowShortcuts ? 'list' : 'listbox'}
+          aria-label={isShowShortcuts ? 'Keyboard shortcuts' : 'Commands'}
+          {...stylex.props(styles.resultList)}>
+          {isShowShortcuts ? (
+            // Shortcuts panel
+            (() => {
+              const withShortcuts = scoredCommands
+                .filter(sc => sc.command.shortcut)
+                .sort((a, b) => a.command.label.localeCompare(b.command.label));
+              if (withShortcuts.length === 0) {
+                return (
+                  <div {...stylex.props(styles.empty)}>
+                    No keyboard shortcuts
+                  </div>
+                );
+              }
+              // Group by command group
+              const groups = new Map<string, typeof withShortcuts>();
+              for (const sc of withShortcuts) {
+                const group = sc.command.group ?? '';
+                const list = groups.get(group);
+                if (list) {
+                  list.push(sc);
+                } else {
+                  groups.set(group, [sc]);
+                }
+              }
+              let groupIdx = 0;
+              return Array.from(groups.entries()).map(([group, items]) => (
+                <div key={group || 'ungrouped'}>
+                  {groupIdx++ > 0 && (
+                    <div
+                      {...stylex.props(styles.groupDivider)}
+                      role="separator"
+                    />
+                  )}
+                  {group && (
+                    <div {...stylex.props(styles.groupLabel)}>{group}</div>
+                  )}
+                  {items.map(sc => (
+                    <div
+                      key={sc.command.id}
+                      {...stylex.props(styles.shortcutRow)}
+                      role="listitem">
+                      <span>{sc.command.label}</span>
+                      <span
+                        {...stylex.props(styles.shortcut)}
+                        aria-hidden="true">
+                        {sc.command.shortcut!.split('+').map((key, i) => (
+                          <kbd key={i} {...stylex.props(styles.kbd)}>
+                            {formatShortcutKey(key)}
+                          </kbd>
+                        ))}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              ));
+            })()
+          ) : flatItems.length === 0 && !isLoading ? (
+            <div {...stylex.props(styles.empty)}>
+              {emptyContent ?? 'No results found'}
+            </div>
+          ) : (
+            grouped.map((section, sectionIdx) => {
+              const isRecentSection = section.group === 'Recent';
+              const sectionElements = section.items.map(scored => {
+                const cmd = scored.command;
+                const idx = flatIndex++;
+                const isHighlighted = idx === highlightedIndex;
+                const historyEntry = isRecentSection
+                  ? historyMap.get(cmd.id)
+                  : undefined;
+
+                return (
+                  <div
+                    key={cmd.id}
+                    id={`command-palette-item-${idx}`}
+                    role="option"
+                    aria-selected={isHighlighted}
+                    onClick={() => handleSelect(cmd)}
+                    onMouseEnter={() => setHighlightedIndex(idx)}
+                    {...stylex.props(
+                      styles.item,
+                      isHighlighted && styles.itemHighlighted,
+                    )}>
+                    {cmd.icon && (
+                      <XDSIcon icon={cmd.icon} size="sm" color="secondary" />
+                    )}
+                    <span {...stylex.props(styles.itemLabel)}>
+                      {renderHighlightedLabel(cmd.label, scored.matchRanges)}
+                    </span>
+                    {historyEntry && (
+                      <span
+                        {...stylex.props(styles.recentMeta)}
+                        aria-label={`Used ${historyEntry.count} time${historyEntry.count !== 1 ? 's' : ''}`}>
+                        {historyEntry.count > 1 && (
+                          <>
+                            <span>{historyEntry.count}×</span>
+                            <span {...stylex.props(styles.recentMetaSeparator)}>
+                              ·
+                            </span>
+                          </>
+                        )}
+                        <span>
+                          {formatRelativeTime(historyEntry.timestamp)}
+                        </span>
+                        {cmd.group && (
+                          <>
+                            <span {...stylex.props(styles.recentMetaSeparator)}>
+                              ·
+                            </span>
+                            <span>{cmd.group}</span>
+                          </>
+                        )}
+                        <button
+                          type="button"
+                          {...stylex.props(
+                            styles.clearButton,
+                            isHighlighted && styles.itemHoverClearVisible,
+                          )}
+                          onClick={e => {
+                            e.stopPropagation();
+                            clearHistoryEntry(cmd.id);
+                          }}
+                          aria-label={`Remove ${cmd.label} from recent`}
+                          tabIndex={-1}>
+                          ×
+                        </button>
+                      </span>
+                    )}
+                    {!historyEntry && cmd.page && (
+                      <XDSIcon icon="chevronRight" size="sm" color="tertiary" />
+                    )}
+                  </div>
+                );
+              });
+
+              return (
+                <div key={section.group ?? `ungrouped-${sectionIdx}`}>
+                  {sectionIdx > 0 && (
+                    <div
+                      {...stylex.props(styles.groupDivider)}
+                      role="separator"
+                    />
+                  )}
+                  {section.group && (
+                    <div {...stylex.props(styles.groupLabel)}>
+                      {section.group}
+                    </div>
+                  )}
+                  {sectionElements}
+                </div>
+              );
+            })
+          )}
+          {isLoading && (
+            <div
+              {...stylex.props(styles.loading)}
+              data-testid="command-palette-loading">
+              <XDSSpinner size="sm" />
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div {...stylex.props(styles.footer)}>
+          <div>{footer}</div>
+          <button
+            type="button"
+            {...stylex.props(styles.footerButton)}
+            onClick={() => setIsShowShortcuts(prev => !prev)}
+            tabIndex={-1}>
+            {isShowShortcuts ? 'Back to commands' : 'Keyboard shortcuts'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+XDSCommandPalette.displayName = 'XDSCommandPalette';

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSCommandPalette.tsx
- * @input Uses React, StyleX, XDSIcon, XDSSpinner, types
+ * @input Uses React, StyleX, XDSDialog, XDSButton, XDSIcon, XDSDivider, XDSSpinner, types
  * @output Exports XDSCommandPalette component
  * @position Modal UI; rendered by XDSCommandPaletteProvider
  *
@@ -20,13 +20,15 @@ import {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
+import {XDSDialog} from '../Dialog';
+import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
+import {XDSDivider} from '../Divider';
 import {XDSSpinner} from '../Spinner';
 import {
   colorVars,
   spacingVars,
   radiusVars,
-  elevationVars,
   transitionVars,
   textSizeVars,
   typographyVars,
@@ -59,33 +61,12 @@ declare module '../theme/types' {
 // =============================================================================
 
 const styles = stylex.create({
-  // Fixed overlay: covers viewport, flexbox centers the palette
-  overlay: {
-    position: 'fixed',
-    inset: 0,
-    zIndex: 9999,
-    display: 'flex',
-    alignItems: 'flex-start',
-    justifyContent: 'center',
-    paddingTop: '15vh',
-    backgroundColor: colorVars['--color-overlay'],
-    backdropFilter: 'blur(2px)',
-  },
-  // The palette panel itself
-  panel: {
-    width: '560px',
-    maxWidth: '90vw',
-    maxHeight: '60vh',
+  // The dialog content container
+  dialogContent: {
     display: 'flex',
     flexDirection: 'column',
-    backgroundColor: colorVars['--color-surface'],
-    borderRadius: radiusVars['--radius-container'],
-    boxShadow: elevationVars['--elevation-dialog'],
     overflow: 'hidden',
-    // Open animation
-    opacity: 1,
-    transform: 'scale(1) translateY(0)',
-    transition: `opacity ${transitionVars['--transition-normal']}, transform ${transitionVars['--transition-normal']}`,
+    height: '100%',
   },
   inputWrapper: {
     display: 'flex',
@@ -93,10 +74,6 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     padding: `${spacingVars['--spacing-3']} ${spacingVars['--spacing-4']}`,
     borderBottom: `1px solid ${colorVars['--color-divider']}`,
-  },
-  inputIcon: {
-    flexShrink: 0,
-    color: colorVars['--color-icon-secondary'],
   },
   input: {
     flex: 1,
@@ -123,11 +100,6 @@ const styles = stylex.create({
     fontSize: textSizeVars['--text-xsm'],
     color: colorVars['--color-text-secondary'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
-  },
-  groupDivider: {
-    height: '1px',
-    backgroundColor: colorVars['--color-divider'],
-    margin: `${spacingVars['--spacing-1']} ${spacingVars['--spacing-3']}`,
   },
   item: {
     boxSizing: 'border-box',
@@ -227,7 +199,7 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     width: '100%',
-    padding: `${spacingVars['--spacing-1-5']} ${spacingVars['--spacing-3']}`,
+    padding: `${spacingVars['--spacing-1']} ${spacingVars['--spacing-3']}`,
     fontFamily: typographyVars['--font-body'],
     fontSize: textSizeVars['--text-sm'],
     color: colorVars['--color-text-primary'],
@@ -242,20 +214,6 @@ const styles = stylex.create({
     fontSize: textSizeVars['--text-sm'],
     color: colorVars['--color-text-secondary'],
     fontWeight: fontWeightVars['--font-weight-medium'],
-  },
-  backButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    border: 'none',
-    backgroundColor: 'transparent',
-    cursor: 'pointer',
-    padding: spacingVars['--spacing-1'],
-    borderRadius: radiusVars['--radius-content'],
-    color: colorVars['--color-icon-secondary'],
-    ':hover': {
-      backgroundColor: colorVars['--color-hover-overlay'],
-    },
   },
   recentMeta: {
     display: 'flex',
@@ -281,7 +239,6 @@ const styles = stylex.create({
     padding: `0 ${spacingVars['--spacing-0-5']}`,
     marginLeft: spacingVars['--spacing-0-5'],
     color: colorVars['--color-text-placeholder'],
-    fontSize: textSizeVars['--text-2xs'],
     lineHeight: lineHeightVars['--leading-tight'],
     opacity: 0,
     transition: `opacity ${transitionVars['--transition-fast']}`,
@@ -334,11 +291,9 @@ function renderHighlightedLabel(
 
   for (let i = 0; i < matchRanges.length; i++) {
     const range = matchRanges[i];
-    // Text before this match
     if (range.start > lastIndex) {
       parts.push(label.slice(lastIndex, range.start));
     }
-    // Matched text
     parts.push(
       <mark key={i} {...stylex.props(styles.highlightMark)}>
         {label.slice(range.start, range.end)}
@@ -347,7 +302,6 @@ function renderHighlightedLabel(
     lastIndex = range.end;
   }
 
-  // Text after last match
   if (lastIndex < label.length) {
     parts.push(label.slice(lastIndex));
   }
@@ -369,6 +323,139 @@ function formatRelativeTime(timestamp: number): string {
   const days = Math.floor(hours / 24);
   return `${days}d ago`;
 }
+
+// =============================================================================
+// Sub-components
+// =============================================================================
+
+/**
+ * Renders a single shortcut display row within the shortcuts panel.
+ */
+function CommandPaletteShortcutRow({command}: {command: XDSCommand}) {
+  return (
+    <div
+      {...stylex.props(styles.shortcutRow)}
+      role="option"
+      aria-selected={false}>
+      <span>{command.label}</span>
+      <span {...stylex.props(styles.shortcut)} aria-hidden="true">
+        {command.shortcut!.split('+').map((key, i) => (
+          <kbd key={i} {...stylex.props(styles.kbd)}>
+            {formatShortcutKey(key)}
+          </kbd>
+        ))}
+      </span>
+    </div>
+  );
+}
+
+CommandPaletteShortcutRow.displayName = 'CommandPaletteShortcutRow';
+
+/**
+ * Renders the history metadata (count, relative time, group, clear button)
+ * shown on recently-used command items.
+ */
+function CommandPaletteRecentMeta({
+  command,
+  historyEntry,
+  isHighlighted,
+  onClear,
+}: {
+  command: XDSCommand;
+  historyEntry: HistoryEntry;
+  isHighlighted: boolean;
+  onClear: (id: string) => void;
+}) {
+  return (
+    <span
+      {...stylex.props(styles.recentMeta)}
+      aria-label={`Used ${historyEntry.count} time${historyEntry.count !== 1 ? 's' : ''}`}>
+      {historyEntry.count > 1 && (
+        <>
+          <span>{historyEntry.count}×</span>
+          <span {...stylex.props(styles.recentMetaSeparator)}>·</span>
+        </>
+      )}
+      <span>{formatRelativeTime(historyEntry.timestamp)}</span>
+      {command.group && (
+        <>
+          <span {...stylex.props(styles.recentMetaSeparator)}>·</span>
+          <span>{command.group}</span>
+        </>
+      )}
+      <button
+        type="button"
+        {...stylex.props(
+          styles.clearButton,
+          isHighlighted && styles.itemHoverClearVisible,
+        )}
+        onClick={e => {
+          e.stopPropagation();
+          onClear(command.id);
+        }}
+        aria-label={`Remove ${command.label} from recent`}
+        tabIndex={-1}>
+        <XDSIcon icon="close" size="xsm" color="inherit" />
+      </button>
+    </span>
+  );
+}
+
+CommandPaletteRecentMeta.displayName = 'CommandPaletteRecentMeta';
+
+/**
+ * Renders a single command option row in the palette list.
+ */
+function CommandPaletteItem({
+  command,
+  scored,
+  index,
+  isHighlighted,
+  historyEntry,
+  onSelect,
+  onHighlight,
+  onClearHistory,
+}: {
+  command: XDSCommand;
+  scored: ScoredCommand;
+  index: number;
+  isHighlighted: boolean;
+  historyEntry?: HistoryEntry;
+  onSelect: (command: XDSCommand) => void;
+  onHighlight: (index: number) => void;
+  onClearHistory: (id: string) => void;
+}) {
+  return (
+    <div
+      key={command.id}
+      id={`command-palette-item-${index}`}
+      role="option"
+      aria-selected={isHighlighted}
+      onClick={() => onSelect(command)}
+      onMouseEnter={() => onHighlight(index)}
+      {...stylex.props(styles.item, isHighlighted && styles.itemHighlighted)}>
+      {command.icon && (
+        <XDSIcon icon={command.icon} size="sm" color="secondary" />
+      )}
+      <span {...stylex.props(styles.itemLabel)}>
+        {renderHighlightedLabel(command.label, scored.matchRanges)}
+      </span>
+      {historyEntry && (
+        <CommandPaletteRecentMeta
+          command={command}
+          historyEntry={historyEntry}
+          isHighlighted={isHighlighted}
+          onClear={onClearHistory}
+        />
+      )}
+      {!historyEntry && command.page && (
+        <XDSIcon icon="chevronRight" size="sm" color="tertiary" />
+      )}
+    </div>
+  );
+}
+
+CommandPaletteItem.displayName = 'CommandPaletteItem';
 
 // =============================================================================
 // Props
@@ -401,8 +488,8 @@ interface XDSCommandPaletteProps {
  * The modal UI for the command palette.
  * Rendered internally by XDSCommandPaletteProvider.
  *
- * Uses a fixed overlay with flexbox centering rather than the native
- * <dialog> element, for robust cross-browser positioning.
+ * Uses XDSDialog (native <dialog> element) for overlay, scroll lock,
+ * and backdrop click handling.
  */
 export function XDSCommandPalette({
   isOpen,
@@ -426,7 +513,6 @@ export function XDSCommandPalette({
   const [isShowShortcuts, setIsShowShortcuts] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
 
   const themeContext = useContext(ThemeContext);
   const rootOverride = themeContext?.theme.components?.commandPalette?.root;
@@ -447,10 +533,8 @@ export function XDSCommandPalette({
   let grouped: {group: string | null; items: ScoredCommand[]}[];
 
   if (query.length > 0) {
-    // When searching, don't show groups — flat list
     grouped = [{group: null, items: scoredCommands}];
   } else {
-    // Show "Recent" group first when no query
     const recentIds = new Set(historyEntries.map(h => h.id));
     const recent = scoredCommands.filter(sc => recentIds.has(sc.command.id));
     const rest = scoredCommands.filter(sc => !recentIds.has(sc.command.id));
@@ -461,7 +545,6 @@ export function XDSCommandPalette({
       groups.push({group: 'Recent', items: recent});
     }
 
-    // Group remaining by their group property
     const byGroup = new Map<string | null, ScoredCommand[]>();
     for (const sc of rest) {
       const key = sc.command.group ?? null;
@@ -483,26 +566,15 @@ export function XDSCommandPalette({
   // Flat list for keyboard navigation
   const flatItems = grouped.flatMap(g => g.items);
 
-  // Reset state when opening/closing
+  // Reset state when opening
   useEffect(() => {
     if (isOpen) {
       setHighlightedIndex(0);
       setIsShowShortcuts(false);
-      // Focus input on next frame
       requestAnimationFrame(() => {
         inputRef.current?.focus();
       });
     }
-  }, [isOpen]);
-
-  // Lock body scroll when open
-  useEffect(() => {
-    if (!isOpen) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      document.body.style.overflow = prev;
-    };
   }, [isOpen]);
 
   // Reset highlighted index when results change
@@ -576,14 +648,19 @@ export function XDSCommandPalette({
           }
           break;
         case 'Escape':
-          e.preventDefault();
+          // Layered Escape: shortcuts panel → page stack → close (via XDSDialog)
           if (isShowShortcuts) {
+            e.preventDefault();
+            e.stopPropagation();
+            e.nativeEvent.stopPropagation();
             setIsShowShortcuts(false);
           } else if (pageStack.length > 0) {
+            e.preventDefault();
+            e.stopPropagation();
+            e.nativeEvent.stopPropagation();
             goBack();
-          } else {
-            onClose();
           }
+          // Otherwise let the event bubble to XDSDialog's Escape handler
           break;
       }
     },
@@ -594,69 +671,41 @@ export function XDSCommandPalette({
       query,
       pageStack,
       goBack,
-      onClose,
       isShowShortcuts,
     ],
   );
-
-  // Click on overlay (outside panel) closes palette
-  const handleOverlayClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
-        onClose();
-      }
-    },
-    [onClose],
-  );
-
-  if (!isOpen) return null;
 
   // Build flat index for mapping grouped items
   let flatIndex = 0;
 
   return (
-    <div
-      {...stylex.props(styles.overlay)}
-      onClick={handleOverlayClick}
-      data-testid={testId}
-      role="presentation">
-      <div
-        ref={panelRef}
-        role="dialog"
-        aria-modal="true"
-        aria-label="Command palette"
-        {...stylex.props(styles.panel, rootOverride, xstyle)}>
+    <XDSDialog
+      isShown={isOpen}
+      onHide={onClose}
+      width={560}
+      maxHeight="60vh"
+      position={{top: '15vh'}}
+      purpose="info"
+      aria-label="Command palette"
+      data-testid={testId}>
+      <div {...stylex.props(styles.dialogContent, rootOverride, xstyle)}>
         {/* Page header with back button */}
         {currentPage && (
           <div {...stylex.props(styles.pageHeader)}>
-            <button
-              type="button"
+            <XDSButton
+              label="Go back"
+              variant="ghost"
+              size="sm"
+              icon={<XDSIcon icon="chevronLeft" size="sm" color="inherit" />}
               onClick={goBack}
-              {...stylex.props(styles.backButton)}
-              aria-label="Go back">
-              <XDSIcon icon="chevronLeft" size="sm" color="inherit" />
-            </button>
+            />
             {currentPage}
           </div>
         )}
 
         {/* Search input */}
         <div {...stylex.props(styles.inputWrapper)}>
-          <span {...stylex.props(styles.inputIcon)}>
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true">
-              <circle cx="11" cy="11" r="8" />
-              <line x1="21" y1="21" x2="16.65" y2="16.65" />
-            </svg>
-          </span>
+          <XDSIcon icon="search" size="sm" color="secondary" />
           <input
             ref={inputRef}
             type="text"
@@ -677,11 +726,11 @@ export function XDSCommandPalette({
           />
         </div>
 
-        {/* Result list */}
+        {/* Result list — always role="listbox" for combobox pattern */}
         <div
           ref={listRef}
           id="command-palette-list"
-          role={isShowShortcuts ? 'list' : 'listbox'}
+          role="listbox"
           aria-label={isShowShortcuts ? 'Keyboard shortcuts' : 'Commands'}
           {...stylex.props(styles.resultList)}>
           {isShowShortcuts ? (
@@ -697,7 +746,6 @@ export function XDSCommandPalette({
                   </div>
                 );
               }
-              // Group by command group
               const groups = new Map<string, typeof withShortcuts>();
               for (const sc of withShortcuts) {
                 const group = sc.command.group ?? '';
@@ -711,31 +759,15 @@ export function XDSCommandPalette({
               let groupIdx = 0;
               return Array.from(groups.entries()).map(([group, items]) => (
                 <div key={group || 'ungrouped'}>
-                  {groupIdx++ > 0 && (
-                    <div
-                      {...stylex.props(styles.groupDivider)}
-                      role="separator"
-                    />
-                  )}
+                  {groupIdx++ > 0 && <XDSDivider />}
                   {group && (
                     <div {...stylex.props(styles.groupLabel)}>{group}</div>
                   )}
                   {items.map(sc => (
-                    <div
+                    <CommandPaletteShortcutRow
                       key={sc.command.id}
-                      {...stylex.props(styles.shortcutRow)}
-                      role="listitem">
-                      <span>{sc.command.label}</span>
-                      <span
-                        {...stylex.props(styles.shortcut)}
-                        aria-hidden="true">
-                        {sc.command.shortcut!.split('+').map((key, i) => (
-                          <kbd key={i} {...stylex.props(styles.kbd)}>
-                            {formatShortcutKey(key)}
-                          </kbd>
-                        ))}
-                      </span>
-                    </div>
+                      command={sc.command}
+                    />
                   ))}
                 </div>
               ));
@@ -756,77 +788,23 @@ export function XDSCommandPalette({
                   : undefined;
 
                 return (
-                  <div
+                  <CommandPaletteItem
                     key={cmd.id}
-                    id={`command-palette-item-${idx}`}
-                    role="option"
-                    aria-selected={isHighlighted}
-                    onClick={() => handleSelect(cmd)}
-                    onMouseEnter={() => setHighlightedIndex(idx)}
-                    {...stylex.props(
-                      styles.item,
-                      isHighlighted && styles.itemHighlighted,
-                    )}>
-                    {cmd.icon && (
-                      <XDSIcon icon={cmd.icon} size="sm" color="secondary" />
-                    )}
-                    <span {...stylex.props(styles.itemLabel)}>
-                      {renderHighlightedLabel(cmd.label, scored.matchRanges)}
-                    </span>
-                    {historyEntry && (
-                      <span
-                        {...stylex.props(styles.recentMeta)}
-                        aria-label={`Used ${historyEntry.count} time${historyEntry.count !== 1 ? 's' : ''}`}>
-                        {historyEntry.count > 1 && (
-                          <>
-                            <span>{historyEntry.count}×</span>
-                            <span {...stylex.props(styles.recentMetaSeparator)}>
-                              ·
-                            </span>
-                          </>
-                        )}
-                        <span>
-                          {formatRelativeTime(historyEntry.timestamp)}
-                        </span>
-                        {cmd.group && (
-                          <>
-                            <span {...stylex.props(styles.recentMetaSeparator)}>
-                              ·
-                            </span>
-                            <span>{cmd.group}</span>
-                          </>
-                        )}
-                        <button
-                          type="button"
-                          {...stylex.props(
-                            styles.clearButton,
-                            isHighlighted && styles.itemHoverClearVisible,
-                          )}
-                          onClick={e => {
-                            e.stopPropagation();
-                            clearHistoryEntry(cmd.id);
-                          }}
-                          aria-label={`Remove ${cmd.label} from recent`}
-                          tabIndex={-1}>
-                          ×
-                        </button>
-                      </span>
-                    )}
-                    {!historyEntry && cmd.page && (
-                      <XDSIcon icon="chevronRight" size="sm" color="tertiary" />
-                    )}
-                  </div>
+                    command={cmd}
+                    scored={scored}
+                    index={idx}
+                    isHighlighted={isHighlighted}
+                    historyEntry={historyEntry}
+                    onSelect={handleSelect}
+                    onHighlight={setHighlightedIndex}
+                    onClearHistory={clearHistoryEntry}
+                  />
                 );
               });
 
               return (
                 <div key={section.group ?? `ungrouped-${sectionIdx}`}>
-                  {sectionIdx > 0 && (
-                    <div
-                      {...stylex.props(styles.groupDivider)}
-                      role="separator"
-                    />
-                  )}
+                  {sectionIdx > 0 && <XDSDivider />}
                   {section.group && (
                     <div {...stylex.props(styles.groupLabel)}>
                       {section.group}
@@ -858,7 +836,7 @@ export function XDSCommandPalette({
           </button>
         </div>
       </div>
-    </div>
+    </XDSDialog>
   );
 }
 

--- a/packages/core/src/CommandPalette/XDSCommandPaletteContext.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteContext.tsx
@@ -1,0 +1,19 @@
+/**
+ * @file XDSCommandPaletteContext.tsx
+ * @input Uses React createContext, XDSCommandPaletteContextValue type
+ * @output Exports CommandPaletteContext
+ * @position Context definition; consumed by provider and hooks
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md
+ */
+
+import {createContext} from 'react';
+import type {XDSCommandPaletteContextValue} from './types';
+
+/**
+ * Context for the command palette.
+ * Null when no provider is present in the tree.
+ */
+export const CommandPaletteContext =
+  createContext<XDSCommandPaletteContextValue | null>(null);

--- a/packages/core/src/CommandPalette/XDSCommandPaletteProvider.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteProvider.tsx
@@ -1,0 +1,371 @@
+/**
+ * @file XDSCommandPaletteProvider.tsx
+ * @input Uses React, XDSCommandPaletteContext, XDSCommandPalette, fuzzySearch, types
+ * @output Exports XDSCommandPaletteProvider component and XDSCommandPaletteProviderProps
+ * @position Provider component; wraps application to enable command palette
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md (props table, features)
+ * - /packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
+ * - /packages/core/src/CommandPalette/index.ts (exports if types change)
+ * - /apps/storybook/stories/CommandPalette.stories.tsx
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useTransition,
+  type ReactNode,
+} from 'react';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {CommandPaletteContext} from './XDSCommandPaletteContext';
+import {XDSCommandPalette} from './XDSCommandPalette';
+import {fuzzySearch} from './fuzzySearch';
+import type {XDSCommand, HistoryEntry, ScoredCommand} from './types';
+
+const STORAGE_KEY = 'xds-command-palette-history';
+
+export interface XDSCommandPaletteProviderProps {
+  /**
+   * Application content.
+   */
+  children: ReactNode;
+
+  /**
+   * Keyboard shortcut to open the palette.
+   * @default "mod+k"
+   */
+  shortcut?: string;
+
+  /**
+   * Whether to persist command history to localStorage.
+   * @default false
+   */
+  isPersistHistory?: boolean;
+
+  /**
+   * Maximum number of history entries to keep.
+   * @default 10
+   */
+  maxHistory?: number;
+
+  /**
+   * Placeholder text for the search input.
+   */
+  placeholder?: string;
+
+  /**
+   * Content displayed when no results match.
+   */
+  emptyContent?: ReactNode;
+
+  /**
+   * Footer content displayed at the bottom of the palette.
+   */
+  footer?: ReactNode;
+
+  /**
+   * StyleX overrides for the palette container.
+   */
+  xstyle?: StyleXStyles;
+
+  /**
+   * Async function to fetch additional commands based on the search query.
+   * Fetched commands are merged with locally registered commands.
+   */
+  commandFetcher?: (query: string) => Promise<XDSCommand[]>;
+
+  /**
+   * Debounce delay in ms before calling commandFetcher.
+   * @default 200
+   */
+  fetchDebounceMs?: number;
+
+  /**
+   * Test ID for testing frameworks.
+   */
+  'data-testid'?: string;
+}
+
+/**
+ * Parse a shortcut string like "mod+k" into modifier flags and a key.
+ */
+function parseShortcut(shortcut: string): {
+  meta: boolean;
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  key: string;
+} {
+  const parts = shortcut.toLowerCase().split('+');
+  const key = parts[parts.length - 1];
+  const mods = new Set(parts.slice(0, -1));
+  const isMac =
+    typeof navigator !== 'undefined' &&
+    /Mac|iPhone|iPad/.test(navigator.userAgent);
+
+  return {
+    meta: mods.has('mod') ? isMac : mods.has('meta'),
+    ctrl: mods.has('mod') ? !isMac : mods.has('ctrl'),
+    shift: mods.has('shift'),
+    alt: mods.has('alt'),
+    key,
+  };
+}
+
+/**
+ * Provider that enables the command palette for its children.
+ *
+ * Manages command registration, keyboard shortcut listening,
+ * open/close state, history tracking, and async command fetching.
+ *
+ * @example
+ * ```tsx
+ * <XDSCommandPaletteProvider>
+ *   <App />
+ * </XDSCommandPaletteProvider>
+ * ```
+ */
+export function XDSCommandPaletteProvider({
+  children,
+  shortcut = 'mod+k',
+  isPersistHistory = false,
+  maxHistory = 10,
+  placeholder,
+  emptyContent,
+  footer,
+  xstyle,
+  commandFetcher,
+  fetchDebounceMs = 200,
+  'data-testid': testId,
+}: XDSCommandPaletteProviderProps) {
+  const registryRef = useRef<Map<string, XDSCommand>>(new Map());
+  const [isOpen, setIsOpen] = useState(false);
+  const [pageStack, setPageStack] = useState<string[]>([]);
+  const [query, setQuery] = useState('');
+  const [fetchedCommands, setFetchedCommands] = useState<XDSCommand[]>([]);
+  const [isFetchPending, startFetchTransition] = useTransition();
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  // Initialize history from localStorage if persisting
+  const [history, setHistory] = useState<HistoryEntry[]>(() => {
+    if (isPersistHistory && typeof window !== 'undefined') {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        if (stored) {
+          return JSON.parse(stored);
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+    return [];
+  });
+
+  // Persist history to localStorage when it changes
+  useEffect(() => {
+    if (isPersistHistory && typeof window !== 'undefined') {
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(history));
+      } catch {
+        // Ignore write errors
+      }
+    }
+  }, [history, isPersistHistory]);
+
+  const register = useCallback((commands: XDSCommand[]) => {
+    const registry = registryRef.current;
+    for (const cmd of commands) {
+      registry.set(cmd.id, cmd);
+    }
+    return () => {
+      for (const cmd of commands) {
+        registry.delete(cmd.id);
+      }
+    };
+  }, []);
+
+  const open = useCallback((page?: string) => {
+    setIsOpen(true);
+    setQuery('');
+    setFetchedCommands([]);
+    if (page) {
+      setPageStack([page]);
+    } else {
+      setPageStack([]);
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+    setPageStack([]);
+    setQuery('');
+    setFetchedCommands([]);
+  }, []);
+
+  const recordHistory = useCallback(
+    (commandId: string) => {
+      setHistory(prev => {
+        const existing = prev.find(h => h.id === commandId);
+        const filtered = prev.filter(h => h.id !== commandId);
+        const entry: HistoryEntry = {
+          id: commandId,
+          timestamp: Date.now(),
+          count: (existing?.count ?? 0) + 1,
+        };
+        const next = [entry, ...filtered].slice(0, maxHistory);
+        return next;
+      });
+    },
+    [maxHistory],
+  );
+
+  const clearHistoryEntry = useCallback((commandId: string) => {
+    setHistory(prev => prev.filter(h => h.id !== commandId));
+  }, []);
+
+  const getCommands = useCallback(() => {
+    return Array.from(registryRef.current.values()).filter(
+      cmd => cmd.isEnabled !== false,
+    );
+  }, []);
+
+  const getHistory = useCallback(() => {
+    return history;
+  }, [history]);
+
+  // Debounced async command fetching
+  useEffect(() => {
+    if (!commandFetcher) return;
+
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+    }
+
+    if (query.length === 0) {
+      setFetchedCommands([]);
+      return;
+    }
+
+    debounceTimerRef.current = setTimeout(() => {
+      const currentQuery = query;
+      startFetchTransition(() => {
+        commandFetcher(currentQuery).then(commands => {
+          setFetchedCommands(commands);
+        });
+      });
+    }, fetchDebounceMs);
+
+    return () => {
+      if (debounceTimerRef.current) {
+        clearTimeout(debounceTimerRef.current);
+      }
+    };
+  }, [query, commandFetcher, fetchDebounceMs]);
+
+  // Compute scored commands: merge local + fetched, filter by page, run fuzzySearch
+  const currentPage =
+    pageStack.length > 0 ? pageStack[pageStack.length - 1] : null;
+  const localCommands = getCommands();
+
+  // Deduplicate: local commands take precedence over fetched ones
+  const localIds = new Set(localCommands.map(c => c.id));
+  const uniqueFetched = fetchedCommands.filter(c => !localIds.has(c.id));
+  const allCommands = [...localCommands, ...uniqueFetched];
+
+  const pageCommands = currentPage
+    ? allCommands.filter(cmd => cmd.group === currentPage)
+    : allCommands;
+
+  const scoredCommands: ScoredCommand[] = fuzzySearch(
+    pageCommands,
+    query,
+    history,
+  );
+
+  // Global keyboard shortcut
+  useEffect(() => {
+    const parsed = parseShortcut(shortcut);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const matchesMods =
+        e.metaKey === parsed.meta &&
+        e.ctrlKey === parsed.ctrl &&
+        e.shiftKey === parsed.shift &&
+        e.altKey === parsed.alt;
+
+      if (matchesMods && e.key.toLowerCase() === parsed.key) {
+        e.preventDefault();
+        e.stopPropagation();
+        e.stopImmediatePropagation();
+        setIsOpen(prev => {
+          if (prev) {
+            // Closing
+            setQuery('');
+            setFetchedCommands([]);
+            setPageStack([]);
+          }
+          return !prev;
+        });
+      }
+    };
+
+    // Use capture phase so we fire before Storybook's own Cmd+K handler
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, [shortcut]);
+
+  const contextValue = useMemo(
+    () => ({
+      register,
+      open,
+      close,
+      isOpen,
+      recordHistory,
+      clearHistoryEntry,
+      getCommands,
+      getHistory,
+    }),
+    [
+      register,
+      open,
+      close,
+      isOpen,
+      recordHistory,
+      clearHistoryEntry,
+      getCommands,
+      getHistory,
+    ],
+  );
+
+  return (
+    <CommandPaletteContext.Provider value={contextValue}>
+      {children}
+      <XDSCommandPalette
+        isOpen={isOpen}
+        onClose={close}
+        scoredCommands={scoredCommands}
+        isLoading={isFetchPending}
+        query={query}
+        onQueryChange={setQuery}
+        getHistory={getHistory}
+        recordHistory={recordHistory}
+        clearHistoryEntry={clearHistoryEntry}
+        pageStack={pageStack}
+        onPageStackChange={setPageStack}
+        placeholder={placeholder}
+        emptyContent={emptyContent}
+        footer={footer}
+        xstyle={xstyle}
+        data-testid={testId}
+      />
+    </CommandPaletteContext.Provider>
+  );
+}
+
+XDSCommandPaletteProvider.displayName = 'XDSCommandPaletteProvider';

--- a/packages/core/src/CommandPalette/fuzzySearch.ts
+++ b/packages/core/src/CommandPalette/fuzzySearch.ts
@@ -1,0 +1,116 @@
+/**
+ * @file fuzzySearch.ts
+ * @input Uses XDSCommand, HistoryEntry, MatchRange, ScoredCommand types
+ * @output Exports fuzzySearch scoring utility with match ranges
+ * @position Utility; consumed by XDSCommandPaletteProvider.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md
+ */
+
+import type {
+  XDSCommand,
+  HistoryEntry,
+  MatchRange,
+  ScoredCommand,
+} from './types';
+
+/**
+ * Score a single text against a query, returning a score and match ranges.
+ * Only contiguous matches are supported: exact, starts-with, and contains.
+ */
+function scoreText(
+  query: string,
+  text: string,
+): {score: number; matchRanges: MatchRange[]} {
+  const lowerQuery = query.toLowerCase();
+  const lowerText = text.toLowerCase();
+
+  if (lowerText === lowerQuery) {
+    return {score: 100, matchRanges: [{start: 0, end: text.length}]};
+  }
+
+  if (lowerText.startsWith(lowerQuery)) {
+    return {score: 80, matchRanges: [{start: 0, end: query.length}]};
+  }
+
+  const containsIndex = lowerText.indexOf(lowerQuery);
+  if (containsIndex !== -1) {
+    return {
+      score: 70,
+      matchRanges: [{start: containsIndex, end: containsIndex + query.length}],
+    };
+  }
+
+  return {score: 0, matchRanges: []};
+}
+
+/**
+ * Score and filter commands against a search query, returning match ranges.
+ *
+ * Scoring (higher is better):
+ * 1. Exact label match: 100
+ * 2. Label starts-with: 80
+ * 3. Label contains (contiguous substring): 70
+ * 4. Alias match (same tiers as label, no highlighting): 100/80/70
+ * 5. Keyword match: 40
+ * 6. History boost: +10
+ * 7. Priority tiebreaker: +priority
+ *
+ * All matches require contiguous substrings. Scattered subsequence
+ * matching is intentionally not supported to avoid false positives.
+ */
+export function fuzzySearch(
+  commands: XDSCommand[],
+  query: string,
+  history: HistoryEntry[],
+): ScoredCommand[] {
+  if (query.length === 0) {
+    return commands.map(command => ({command, score: 0, matchRanges: []}));
+  }
+
+  const lowerQuery = query.toLowerCase();
+  const historySet = new Set(history.map(h => h.id));
+  const scored: ScoredCommand[] = [];
+
+  for (const command of commands) {
+    // Score against label first
+    const labelResult = scoreText(query, command.label);
+    let score = labelResult.score;
+    let matchRanges = labelResult.matchRanges;
+
+    // If no label match, try aliases (same scoring tiers, no highlighting)
+    if (score === 0 && command.aliases) {
+      for (const alias of command.aliases) {
+        const aliasResult = scoreText(query, alias);
+        if (aliasResult.score > score) {
+          score = aliasResult.score;
+          matchRanges = []; // No label highlighting for alias matches
+        }
+      }
+    }
+
+    // If no label or alias match, try keywords
+    if (score === 0) {
+      if (command.keywords?.some(kw => kw.toLowerCase().includes(lowerQuery))) {
+        score = 40;
+        matchRanges = [];
+      }
+    }
+
+    if (score === 0) continue;
+
+    // History boost
+    if (historySet.has(command.id)) {
+      score += 10;
+    }
+
+    // Priority tiebreaker
+    score += (command.priority ?? 0) * 0.1;
+
+    scored.push({command, score, matchRanges});
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored;
+}

--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @file index.ts
+ * @input Imports from CommandPalette component files
+ * @output Exports provider, hooks, and types for the CommandPalette
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/CommandPalette/README.md
+ */
+
+export {XDSCommandPaletteProvider} from './XDSCommandPaletteProvider';
+export type {XDSCommandPaletteProviderProps} from './XDSCommandPaletteProvider';
+export {useXDSCommandPaletteRegister} from './useXDSCommandPaletteRegister';
+export {useXDSCommandPalette} from './useXDSCommandPalette';
+export type {
+  XDSCommand,
+  MatchRange,
+  ScoredCommand,
+  HistoryEntry,
+} from './types';

--- a/packages/core/src/CommandPalette/types.ts
+++ b/packages/core/src/CommandPalette/types.ts
@@ -1,0 +1,161 @@
+/**
+ * @file types.ts
+ * @input None
+ * @output Exports shared types for the CommandPalette component
+ * @position Type definitions; consumed by all CommandPalette files
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md (types section)
+ * - /packages/core/src/CommandPalette/index.ts (exports if types change)
+ */
+
+import type {XDSIconType, XDSIconName} from '../Icon';
+
+/**
+ * A character range within a label where the search query matched.
+ */
+export interface MatchRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * A command paired with its fuzzy search score and match ranges.
+ */
+export interface ScoredCommand {
+  command: XDSCommand;
+  score: number;
+  matchRanges: MatchRange[];
+}
+
+/**
+ * A command that can be registered with the command palette.
+ */
+export interface XDSCommand {
+  /**
+   * Unique identifier for the command.
+   */
+  id: string;
+
+  /**
+   * Display label shown in the palette.
+   */
+  label: string;
+
+  /**
+   * Alternative names for the command.
+   * Aliases are matched with the same scoring tiers as the label
+   * (exact, starts-with, contains, subsequence) but don't produce
+   * label highlighting since the alias text isn't displayed.
+   */
+  aliases?: string[];
+
+  /**
+   * Additional search keywords for matching.
+   */
+  keywords?: string[];
+
+  /**
+   * Group name for visual grouping in the palette.
+   */
+  group?: string;
+
+  /**
+   * Icon displayed before the label.
+   * Can be a semantic name string (e.g. 'close', 'chevronDown') or an SVG component.
+   */
+  icon?: XDSIconType | XDSIconName;
+
+  /**
+   * Keyboard shortcut display hint (e.g. "mod+shift+c").
+   * This is display-only and does not register a global listener.
+   */
+  shortcut?: string;
+
+  /**
+   * Callback executed when the command is selected.
+   */
+  onSelect: () => void;
+
+  /**
+   * Opens a sub-page in the palette instead of executing onSelect.
+   */
+  page?: string;
+
+  /**
+   * Higher values are ranked higher in results.
+   * @default 0
+   */
+  priority?: number;
+
+  /**
+   * Whether the command is available.
+   * @default true
+   */
+  isEnabled?: boolean;
+}
+
+/**
+ * Context value provided by XDSCommandPaletteProvider.
+ */
+export interface XDSCommandPaletteContextValue {
+  /**
+   * Register commands with the palette. Returns an unregister function.
+   */
+  register: (commands: XDSCommand[]) => () => void;
+
+  /**
+   * Open the command palette, optionally to a specific page.
+   */
+  open: (page?: string) => void;
+
+  /**
+   * Close the command palette.
+   */
+  close: () => void;
+
+  /**
+   * Whether the palette is currently open.
+   */
+  isOpen: boolean;
+
+  /**
+   * Record a command selection to history.
+   */
+  recordHistory: (commandId: string) => void;
+
+  /**
+   * Remove a single command from history.
+   */
+  clearHistoryEntry: (commandId: string) => void;
+
+  /**
+   * Get all registered commands.
+   */
+  getCommands: () => XDSCommand[];
+
+  /**
+   * Get history entries ordered by most recent.
+   */
+  getHistory: () => HistoryEntry[];
+}
+
+/**
+ * A recorded history entry for recently used commands.
+ */
+export interface HistoryEntry {
+  /**
+   * The command ID that was selected.
+   */
+  id: string;
+
+  /**
+   * When the command was last selected.
+   */
+  timestamp: number;
+
+  /**
+   * How many times this command has been invoked.
+   */
+  count: number;
+}

--- a/packages/core/src/CommandPalette/useXDSCommandPalette.ts
+++ b/packages/core/src/CommandPalette/useXDSCommandPalette.ts
@@ -1,0 +1,45 @@
+/**
+ * @file useXDSCommandPalette.ts
+ * @input Uses React useContext, CommandPaletteContext
+ * @output Exports useXDSCommandPalette hook
+ * @position Hook; consumed by application components for imperative control
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ */
+
+import {useContext} from 'react';
+import {CommandPaletteContext} from './XDSCommandPaletteContext';
+
+/**
+ * Imperative API to control the command palette.
+ *
+ * @example
+ * ```tsx
+ * const { open, close, isOpen } = useXDSCommandPalette();
+ *
+ * return <button onClick={() => open()}>Open Palette</button>;
+ * ```
+ */
+export function useXDSCommandPalette(): {
+  open: (page?: string) => void;
+  close: () => void;
+  isOpen: boolean;
+} {
+  const context = useContext(CommandPaletteContext);
+
+  if (!context) {
+    return {
+      open: () => {},
+      close: () => {},
+      isOpen: false,
+    };
+  }
+
+  return {
+    open: context.open,
+    close: context.close,
+    isOpen: context.isOpen,
+  };
+}

--- a/packages/core/src/CommandPalette/useXDSCommandPaletteRegister.ts
+++ b/packages/core/src/CommandPalette/useXDSCommandPaletteRegister.ts
@@ -1,0 +1,43 @@
+/**
+ * @file useXDSCommandPaletteRegister.ts
+ * @input Uses React useEffect, useContext, CommandPaletteContext
+ * @output Exports useXDSCommandPaletteRegister hook
+ * @position Hook; consumed by application components to register commands
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ */
+
+import {useContext, useEffect, type DependencyList} from 'react';
+import {CommandPaletteContext} from './XDSCommandPaletteContext';
+import type {XDSCommand} from './types';
+
+/**
+ * Register commands with the command palette.
+ *
+ * Commands are registered on mount and automatically deregistered
+ * on unmount. Re-registers when `deps` change.
+ *
+ * @example
+ * ```tsx
+ * useXDSCommandPaletteRegister([
+ *   { id: 'save', label: 'Save', onSelect: handleSave },
+ *   { id: 'export', label: 'Export', onSelect: handleExport },
+ * ]);
+ * ```
+ */
+export function useXDSCommandPaletteRegister(
+  commands: XDSCommand[],
+  deps?: DependencyList,
+): void {
+  const context = useContext(CommandPaletteContext);
+
+  useEffect(
+    () => {
+      if (!context) return;
+      return context.register(commands);
+    },
+    deps ?? [commands],
+  );  
+}

--- a/packages/core/src/Icon/IconRegistry.tsx
+++ b/packages/core/src/Icon/IconRegistry.tsx
@@ -37,7 +37,8 @@ export type XDSIconName =
   | 'info'
   | 'calendar'
   | 'clock'
-  | 'externalLink';
+  | 'externalLink'
+  | 'search';
 
 /**
  * Icon registry mapping semantic names to React nodes.

--- a/packages/core/src/Icon/defaultIcons.tsx
+++ b/packages/core/src/Icon/defaultIcons.tsx
@@ -153,4 +153,12 @@ export const defaultIcons: XDSIconRegistry = {
       <path d="M10 14L21 3" />
     </svg>
   ),
+
+  /** 🔍 — search / magnifying glass */
+  search: (
+    <svg {...svgProps}>
+      <circle cx="11" cy="11" r="8" />
+      <path d="M21 21l-4.35-4.35" />
+    </svg>
+  ),
 };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,6 +48,7 @@ export * from './DropdownMenu';
 export * from './TopNav';
 export * from './SideNav';
 export * from './ProgressBar';
+export * from './CommandPalette';
 
 // Layout utilities and components (includes XDSHStack, XDSVStack)
 export * from './Layout';

--- a/packages/themes/default/src/icons.tsx
+++ b/packages/themes/default/src/icons.tsx
@@ -20,6 +20,7 @@ import {
   CalendarDaysIcon,
   ClockIcon,
   InformationCircleIcon,
+  MagnifyingGlassIcon,
 } from '@heroicons/react/24/outline';
 
 import {
@@ -48,4 +49,5 @@ export const defaultIconRegistry: XDSIconRegistry = {
   calendar: <CalendarDaysIcon {...iconProps} />,
   clock: <ClockIcon {...iconProps} />,
   externalLink: <ArrowTopRightOnSquareIcon {...iconProps} />,
+  search: <MagnifyingGlassIcon {...iconProps} />,
 };

--- a/packages/themes/neutral/src/icons.tsx
+++ b/packages/themes/neutral/src/icons.tsx
@@ -24,6 +24,7 @@ import {
   Calendar,
   Clock,
   ExternalLink,
+  Search,
 } from 'lucide-react';
 
 const iconProps = {
@@ -44,4 +45,5 @@ export const neutralIconRegistry: XDSIconRegistry = {
   calendar: <Calendar {...iconProps} />,
   clock: <Clock {...iconProps} />,
   externalLink: <ExternalLink {...iconProps} />,
+  search: <Search {...iconProps} />,
 };


### PR DESCRIPTION
## Summary

- Adds `XDSCommandPalette` — a Cmd+K command palette using provider/context pattern for distributed command registration
- Fuzzy search with contiguous match highlighting (exact, starts-with, contains), alias and keyword matching
- Async command fetching with debounce and loading spinner (React 19 `useTransition`)
- Recent commands section with invocation count, relative timestamps, source group, and per-entry clear button
- Keyboard shortcuts panel accessible from footer
- Nested sub-pages, grouped results, full keyboard navigation, ARIA accessibility
- Optional localStorage history persistence, StyleX theming support
- 37 tests, 8 Storybook stories (including Kitchen Sink with sync + async loading)

## Test plan

- [x] `yarn workspace @xds/core test -- --run CommandPalette` — 37 tests pass
- [x] `yarn workspace @xds/core build` — compiles without errors
- [ ] Storybook — verify all 8 stories render correctly
- [ ] Storybook — Kitchen Sink: test sync commands appear instantly, async commands ("user", "report", "deploy") load with spinner
- [ ] Storybook — WithHistory: select commands multiple times, verify count/time/group metadata and clear button
- [ ] Keyboard navigation: ArrowUp/Down, Enter, Escape, Home/End, Backspace (back from sub-page)

cc @rubyycheung @cixzhang for design review