### PR TITLE
fix(reset): use CSS variable for placeholder color

### DIFF
--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -238,11 +238,11 @@
 
   /*
    * Normalize placeholder opacity (Firefox renders at reduced opacity)
-   * and set a sensible default color.
+   * and set a sensible default color using the XDS text-placeholder token.
    */
   :where(input::placeholder, textarea::placeholder) {
     opacity: 1;
-    color: #9ca3af;
+    color: var(--color-text-placeholder, #9ca3af);
   }
 
   /*


### PR DESCRIPTION
## Summary

Replace the hardcoded `#9ca3af` placeholder color in `reset.css` with `var(--color-text-placeholder)`, referencing the XDS theme token.

## Changes

```css
/* Before */
color: #9ca3af;

/* After */
color: var(--color-text-placeholder, #9ca3af);
```

## Why

- The hardcoded `#9ca3af` (Tailwind gray-400) doesn't match the XDS palette and ignores dark mode
- The `--color-text-placeholder` token resolves to `light-dark(#4E606F, #AAAFB5)`, which adapts to the active theme
- Follows the same pattern used in `typography.css` for referencing theme tokens from plain CSS
- Falls back to `#9ca3af` when no theme is present (reset used standalone)