### PR TITLE
feat(vibe-tests): show prompt text in report cards

### DIFF
--- a/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
+++ b/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
@@ -7,7 +7,7 @@ import {XDSStatusDot} from '@xds/core/StatusDot';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSButton} from '@xds/core/Button';
 import {XDSDivider} from '@xds/core/Divider';
-import {spacingVars} from '@xds/core/theme/tokens.stylex';
+import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
 import type {UniversalScore} from './types';
 import {
   ALL_DIMENSIONS,
@@ -24,6 +24,9 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     gap: spacingVars['--spacing-2'],
+  },
+  promptText: {
+    color: colorVars['--color-text-secondary'],
   },
   scoreGrid: {
     display: 'grid',
@@ -142,6 +145,8 @@ function Findings({score}: {score: UniversalScore}) {
 
 interface PromptDetailCardProps {
   promptId: string;
+  /** The actual prompt text shown to the agent */
+  promptText?: string;
   xdsScore?: UniversalScore;
   baselineScore?: UniversalScore;
   hasXdsCode: boolean;
@@ -154,6 +159,7 @@ interface PromptDetailCardProps {
 
 export function PromptDetailCard({
   promptId,
+  promptText,
   xdsScore,
   baselineScore,
   hasXdsCode,
@@ -171,9 +177,14 @@ export function PromptDetailCard({
     <XDSCard>
       <div {...stylex.props(styles.card)}>
         <XDSVStack gap="space3">
-          {/* Header: prompt ID on its own line, buttons below */}
+          {/* Header: prompt ID, prompt text, and buttons */}
           <div {...stylex.props(styles.header)}>
             <XDSHeading level={4}>{promptId}</XDSHeading>
+            {promptText && (
+              <XDSText type="body" xstyle={styles.promptText}>
+                {promptText}
+              </XDSText>
+            )}
             {(hasAnyPreview || hasAnyCode) && (
               <div {...stylex.props(styles.buttonRow)}>
                 {previewUrls?.xds && (

--- a/internal/vibe-tests/app/src/report/Report.tsx
+++ b/internal/vibe-tests/app/src/report/Report.tsx
@@ -322,6 +322,7 @@ export function Report() {
                       <PromptDetailCard
                         key={promptId}
                         promptId={promptId}
+                        promptText={data.prompts?.[promptId]}
                         xdsScore={universal.byPrompt[promptId]}
                         baselineScore={comparison?.baseline.byPrompt[promptId]}
                         hasXdsCode={!!data.sourceCode?.[promptId]}

--- a/internal/vibe-tests/app/src/report/types.ts
+++ b/internal/vibe-tests/app/src/report/types.ts
@@ -31,6 +31,8 @@ export interface ReportData {
   htmlSourceCode?: Record<string, string>;
   /** Map of promptId → { target → relative URL } */
   previews?: Record<string, Record<string, string>>;
+  /** Map of promptId → prompt text */
+  prompts?: Record<string, string>;
   iterationId?: string;
   target?: string;
 }

--- a/internal/vibe-tests/src/build-report.ts
+++ b/internal/vibe-tests/src/build-report.ts
@@ -99,6 +99,23 @@ function ensureComparison(
 }
 
 /**
+ * Extract prompt text from the manifest's prompts array.
+ * Returns a map of promptId → prompt text.
+ */
+function extractPrompts(manifest: unknown): Record<string, string> {
+  const prompts: Record<string, string> = {};
+  const m = manifest as {prompts?: Array<{id: string; prompt: string}>};
+  if (m.prompts && Array.isArray(m.prompts)) {
+    for (const p of m.prompts) {
+      if (p.id && p.prompt) {
+        prompts[p.id] = p.prompt;
+      }
+    }
+  }
+  return prompts;
+}
+
+/**
  * Build the report data as a <script> tag to inject into the HTML.
  * This runs before the app bundle, so window.__REPORT_DATA__ is
  * guaranteed to exist when React renders.
@@ -113,6 +130,7 @@ function buildDataScript(opts: {
   baselineSourceCode?: Record<string, string>;
   htmlSourceCode?: Record<string, string>;
   previews?: Record<string, Record<string, string>>;
+  prompts?: Record<string, string>;
 }): string {
   const reportData = {
     universal: opts.iterationData,
@@ -123,6 +141,7 @@ function buildDataScript(opts: {
     baselineSourceCode: opts.baselineSourceCode,
     htmlSourceCode: opts.htmlSourceCode,
     previews: opts.previews,
+    prompts: opts.prompts,
   };
 
   return `<script>window.__REPORT_DATA__=${JSON.stringify(reportData)};</script>`;
@@ -246,6 +265,14 @@ async function main() {
     );
   }
 
+  // Extract prompt text from manifest
+  const prompts = extractPrompts(manifest);
+  if (Object.keys(prompts).length > 0) {
+    console.log(
+      `  ✓ Prompt text loaded (${Object.keys(prompts).length} prompts)`,
+    );
+  }
+
   // Step 4: Build the data script
   const dataScript = buildDataScript({
     iteration,
@@ -257,6 +284,7 @@ async function main() {
     baselineSourceCode,
     htmlSourceCode,
     previews,
+    prompts,
   });
   console.log(`  ✓ ${(dataScript.length / 1024).toFixed(0)} KB of report data`);
 
@@ -270,6 +298,7 @@ async function main() {
       comparison: comparison ?? undefined,
       iterationId: iteration,
       target: (manifest as {config?: {target?: string}})?.config?.target,
+      prompts,
     };
     fs.writeFileSync(
       path.join(dataDir, 'report-data.ts'),


### PR DESCRIPTION
## Summary

Shows the actual prompt text in each prompt detail card in the vibe test report, so you can see what the agent was asked without cross-referencing the test set.

## Changes

- **`types.ts`** — Added `prompts?: Record<string, string>` to `ReportData`
- **`build-report.ts`** — Extracts prompt text from the iteration manifest and includes it in the report data (both prod build and dev mode)
- **`PromptDetailCard.tsx`** — New `promptText` prop rendered below the prompt ID in secondary text color
- **`Report.tsx`** — Passes `data.prompts?.[promptId]` to each card

## Before / After

**Before:** Cards only show the prompt ID (e.g. `fwc-1`)
**After:** Cards show the prompt ID *and* the full prompt text below it (e.g. *"I need a banner that warns users their trial expires in X days and lets them upgrade"*)