### PR TITLE
fix(sandbox): fix type errors and add monorepo-wide typecheck

### DIFF
--- a/apps/sandbox/src/app/pages/navigation/page.tsx
+++ b/apps/sandbox/src/app/pages/navigation/page.tsx
@@ -50,19 +50,19 @@ export default function NavigationPage() {
             label="Left"
             variant={alignment === 'start' ? 'primary' : 'secondary'}
             size="sm"
-            onPress={() => setAlignment('start')}
+            onClick={() => setAlignment('start')}
           />
           <XDSButton
             label="Center"
             variant={alignment === 'center' ? 'primary' : 'secondary'}
             size="sm"
-            onPress={() => setAlignment('center')}
+            onClick={() => setAlignment('center')}
           />
           <XDSButton
             label="Right"
             variant={alignment === 'end' ? 'primary' : 'secondary'}
             size="sm"
-            onPress={() => setAlignment('end')}
+            onClick={() => setAlignment('end')}
           />
         </XDSHStack>
 


### PR DESCRIPTION
## Problem

PR #240 introduced a type error in the sandbox app (onPress instead of onClick on XDSButton). CI didn't catch it because the sandbox build has continue-on-error: true and there is no standalone type-check step.

## Changes

### Commit 1: Fix sandbox type error
- apps/sandbox/src/app/pages/navigation/page.tsx: onPress to onClick (3 occurrences)

### Commit 2: Add monorepo-wide typecheck infrastructure
- Add typecheck: tsc --noEmit to 5 workspace package.json files (core, themes/default, themes/neutral, sandbox, storybook)
- Add root typecheck script that chains all workspaces
- Create committed apps/sandbox/env.d.ts with Next.js type references (since next-env.d.ts is gitignored)
- Fix pre-existing type errors in storybook stories:
  - XDSBadge: label prop to children (5 instances)
  - XDSAvatar: size md to size medium (3 instances)

### Still needed: CI workflow change
The ci.yml change (adding the typecheck job) requires the workflow OAuth scope. Should be committed directly or via a PAT with workflow scope. The job is simple: checkout, setup node, yarn install, yarn typecheck. No continue-on-error.

## Verification

yarn typecheck passes across all 5 workspaces (~14s).