### PR TITLE
feat(theme): add brutalist theme + sandbox theme switcher

### DIFF
--- a/apps/sandbox/README.md
+++ b/apps/sandbox/README.md
@@ -12,6 +12,22 @@ The sandbox is a Next.js app configured for static export (`output: 'export'`). 
 https://facebookexperimental.github.io/xds/{commit}/sandbox/
 ```
 
+## Adding a new theme package
+
+When you add a new `@xds/theme-*` package, you must also add a StyleX alias
+for it in `babel.config.js`. This is only necessary because the sandbox lives
+inside the monorepo and resolves packages from source — external consumers
+using published packages do not need this.
+
+```js
+// babel.config.js — aliases section
+'@xds/theme-newtheme/*': [path.join(rootDir, 'packages/themes/newtheme/src/*')],
+```
+
+Without this alias, the StyleX babel plugin cannot resolve the `.stylex.ts`
+token files and the sandbox build will fail with
+`"Could not resolve the path to the imported file"`.
+
 ## Adding a new page
 
 1. Create `src/app/pages/<name>/page.tsx`:

--- a/apps/sandbox/babel.config.js
+++ b/apps/sandbox/babel.config.js
@@ -13,11 +13,16 @@ module.exports = {
         runtimeInjection: false,
         genConditionalClasses: true,
         treeshakeCompensation: true,
+        // StyleX needs aliases to resolve .stylex.ts token files from source.
+        // This is only needed because the sandbox lives in the monorepo —
+        // external consumers using published packages don't need this.
+        // When adding a new @xds/theme-* package, add an alias here too.
         aliases: {
           '@xds/core/*': [path.join(rootDir, 'packages/core/src/*')],
           '@xds/core': [path.join(rootDir, 'packages/core/src')],
           '@xds/theme-default/*': [path.join(rootDir, 'packages/themes/default/src/*')],
           '@xds/theme-neutral/*': [path.join(rootDir, 'packages/themes/neutral/src/*')],
+          '@xds/theme-brutalist/*': [path.join(rootDir, 'packages/themes/brutalist/src/*')],
         },
         unstable_moduleResolution: {
           type: 'commonJS',

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -8,7 +8,7 @@ const nextConfig = {
   output: 'export',
   trailingSlash: true,
   basePath: process.env.SANDBOX_BASE_PATH || '',
-  transpilePackages: ['@xds/core', '@xds/theme-default'],
+  transpilePackages: ['@xds/core', '@xds/theme-default', '@xds/theme-neutral', '@xds/theme-brutalist'],
   images: {
     unoptimized: true,
   },

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -13,6 +13,8 @@
     "@xds/cli": "*",
     "@xds/core": "*",
     "@xds/theme-default": "*",
+    "@xds/theme-neutral": "*",
+    "@xds/theme-brutalist": "*",
     "next": "^15.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/apps/sandbox/src/app/Sidebar.tsx
+++ b/apps/sandbox/src/app/Sidebar.tsx
@@ -1,21 +1,12 @@
 'use client';
 
-import * as stylex from '@stylexjs/stylex';
 import Link from 'next/link';
 import {usePathname} from 'next/navigation';
+import {XDSSideNav, XDSSideNavSection} from '@xds/core/SideNav';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSVStack} from '@xds/core/Layout';
+import {useThemeSwitcher, themes} from './providers';
 
-/**
- * Sidebar navigation for the sandbox.
- *
- * To add a new page:
- * 1. Create `src/app/pages/<name>/page.tsx`
- * 2. Add an entry to the `pages` array below
- *
- * Note: hrefs use trailing slashes because the sandbox is a static export
- * with `trailingSlash: true` in next.config.mjs. Each route becomes a
- * directory with an `index.html` file (e.g. `/pages/example/index.html`).
- * Next.js `<Link>` handles the basePath prefix automatically.
- */
 const pages = [
   {name: 'Home', href: '/'},
   {name: 'Example', href: '/pages/example/'},
@@ -24,58 +15,79 @@ const pages = [
   {name: 'Polymorphic Link', href: '/pages/polymorphic-link/'},
 ];
 
-const styles = stylex.create({
-  sidebar: {
-    width: 220,
-    borderRight: '1px solid #e0e0e0',
-    padding: '1.5rem 1rem',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.25rem',
-  },
-  title: {
-    fontSize: '0.75rem',
-    fontWeight: 700,
-    textTransform: 'uppercase',
-    letterSpacing: '0.05em',
-    color: '#666',
-    marginBottom: '0.75rem',
-    padding: '0 0.5rem',
-  },
-  link: {
-    display: 'block',
-    padding: '0.5rem 0.75rem',
-    borderRadius: 6,
-    textDecoration: 'none',
-    fontSize: '0.875rem',
-    color: '#333',
-    transition: 'background 0.15s',
-  },
-  linkActive: {
-    backgroundColor: '#f0f0f0',
-    fontWeight: 600,
-  },
-});
+const themeItems = Object.keys(themes).map(name => ({
+  value: name,
+  label: name.charAt(0).toUpperCase() + name.slice(1),
+}));
+
+const modeItems = [
+  {value: 'system', label: 'System'},
+  {value: 'light', label: 'Light'},
+  {value: 'dark', label: 'Dark'},
+];
+
+// XDSSideNavItem uses raw <a> which doesn't handle Next.js basePath.
+// Use Next.js <Link> styled to match until the component supports a
+// custom link renderer.
+const navItemStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 'var(--spacing-2)',
+  paddingBlock: 'var(--spacing-2)',
+  paddingInline: 'var(--spacing-3)',
+  borderRadius: 'var(--radius-element)',
+  textDecoration: 'none',
+  fontSize: '0.875rem',
+  color: 'var(--color-text-primary)',
+  cursor: 'pointer',
+};
+
+const navItemSelectedStyle: React.CSSProperties = {
+  ...navItemStyle,
+  backgroundColor: 'var(--color-hover-overlay)',
+  fontWeight: 600,
+};
 
 export function Sidebar() {
   const pathname = usePathname();
+  const {themeName, mode, setThemeName, setMode} = useThemeSwitcher();
 
   return (
-    <nav {...stylex.props(styles.sidebar)}>
-      <div {...stylex.props(styles.title)}>Sandbox</div>
-      {pages.map(page => {
-        const isActive =
-          pathname === page.href ||
-          (page.href !== '/' && pathname.startsWith(page.href));
-        return (
-          <Link
-            key={page.href}
-            href={page.href}
-            {...stylex.props(styles.link, isActive && styles.linkActive)}>
-            {page.name}
-          </Link>
-        );
-      })}
-    </nav>
+    <XDSSideNav
+      header={
+        <XDSSideNavSection title="Pages">
+          {pages.map(page => {
+            const isActive =
+              pathname === page.href ||
+              (page.href !== '/' && pathname.startsWith(page.href));
+            return (
+              <Link
+                key={page.href}
+                href={page.href}
+                style={isActive ? navItemSelectedStyle : navItemStyle}>
+                {page.name}
+              </Link>
+            );
+          })}
+        </XDSSideNavSection>
+      }
+      footer={
+        <XDSVStack gap="space3">
+          <XDSSelector
+            label="Theme"
+            items={themeItems}
+            value={themeName}
+            onChange={setThemeName}
+          />
+          <XDSSelector
+            label="Mode"
+            items={modeItems}
+            value={mode}
+            onChange={value => setMode(value as 'system' | 'light' | 'dark')}
+          />
+        </XDSVStack>
+      }>
+      {null}
+    </XDSSideNav>
   );
 }

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -15,7 +15,12 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
     <html lang="en">
       <body>
         <Providers>
-          <div style={{display: 'flex', minHeight: '100vh'}}>
+          <div
+            style={{
+              display: 'flex',
+              minHeight: '100vh',
+              backgroundColor: 'var(--color-wash)',
+            }}>
             <Sidebar />
             <main style={{flex: 1, padding: '2rem'}}>{children}</main>
           </div>

--- a/apps/sandbox/src/app/pages/example/page.tsx
+++ b/apps/sandbox/src/app/pages/example/page.tsx
@@ -8,6 +8,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSBadge} from '@xds/core/Badge';
+import {XDSCard} from '@xds/core/Card';
 import {XDSDivider} from '@xds/core';
 
 const styles = stylex.create({
@@ -83,6 +84,36 @@ export default function ExamplePage() {
           <XDSText type="supporting" color="secondary">
             Supporting text in secondary color
           </XDSText>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* Cards */}
+        <XDSVStack gap="space3">
+          <XDSHeading level={2}>Cards</XDSHeading>
+          <XDSHStack gap="space3">
+            <XDSCard>
+              <XDSVStack gap="space2">
+                <XDSHeading level={3}>Card Title</XDSHeading>
+                <XDSText type="body" color="secondary">
+                  A basic card with some content inside it.
+                </XDSText>
+                <XDSButton label="Action" size="sm" />
+              </XDSVStack>
+            </XDSCard>
+            <XDSCard>
+              <XDSVStack gap="space2">
+                <XDSHeading level={3}>Another Card</XDSHeading>
+                <XDSText type="body" color="secondary">
+                  Cards pick up theme borders and shadows automatically.
+                </XDSText>
+                <XDSHStack gap="space2">
+                  <XDSBadge variant="success">Active</XDSBadge>
+                  <XDSBadge variant="info">v2.0</XDSBadge>
+                </XDSHStack>
+              </XDSVStack>
+            </XDSCard>
+          </XDSHStack>
         </XDSVStack>
 
         <XDSDivider />

--- a/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
+++ b/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
@@ -67,7 +67,7 @@ const SimulatedNextLink = forwardRef<
       href={href}
       onClick={e => {
         e.preventDefault();
-         
+
         console.log(`[SimulatedNextLink] Client-side navigate to: ${href}`);
         onClick?.(e);
       }}
@@ -92,7 +92,7 @@ const GreenLink = forwardRef<
       href={href}
       onClick={e => {
         e.preventDefault();
-         
+
         console.log(`[GreenLink] Navigate to: ${href}`);
         onClick?.(e);
       }}
@@ -196,7 +196,7 @@ export default function PolymorphicLinkPage() {
                   XDSSideNav
                 </XDSText>
                 <div {...stylex.props(styles.sidenavWrapper)}>
-                  <XDSSideNav label="Provider sidenav">
+                  <XDSSideNav aria-label="Provider sidenav">
                     <XDSSideNavItem
                       label="Dashboard"
                       href="/dashboard"

--- a/apps/sandbox/src/app/providers.tsx
+++ b/apps/sandbox/src/app/providers.tsx
@@ -1,8 +1,69 @@
 'use client';
 
+import {createContext, useContext, useState, useEffect, useMemo} from 'react';
 import {XDSTheme} from '@xds/core/theme';
+import type {ThemeType, ThemeMode} from '@xds/core/theme';
 import {defaultTheme} from '@xds/theme-default';
+import {neutralTheme} from '@xds/theme-neutral';
+import {brutalistTheme} from '@xds/theme-brutalist';
+
+export const themes: Record<string, ThemeType> = {
+  default: defaultTheme,
+  neutral: neutralTheme,
+  brutalist: brutalistTheme,
+};
+
+interface ThemeSwitcherContextValue {
+  themeName: string;
+  mode: ThemeMode;
+  setThemeName: (name: string) => void;
+  setMode: (mode: ThemeMode) => void;
+}
+
+const ThemeSwitcherContext = createContext<ThemeSwitcherContextValue>({
+  themeName: 'default',
+  mode: 'system',
+  setThemeName: () => {},
+  setMode: () => {},
+});
+
+export function useThemeSwitcher() {
+  return useContext(ThemeSwitcherContext);
+}
+
+const COLOR_SCHEME_MAP: Record<ThemeMode, string> = {
+  light: 'light',
+  dark: 'dark',
+  system: 'light dark',
+};
 
 export function Providers({children}: {children: React.ReactNode}) {
-  return <XDSTheme theme={defaultTheme}>{children}</XDSTheme>;
+  const [themeName, setThemeName] = useState('default');
+  const [mode, setMode] = useState<ThemeMode>('system');
+
+  const theme = themes[themeName] ?? defaultTheme;
+
+  // Sync color-scheme to <body> so the browser canvas background,
+  // scrollbars, and light-dark() all resolve correctly.
+  useEffect(() => {
+    document.body.style.colorScheme = COLOR_SCHEME_MAP[mode];
+    if (mode === 'system') {
+      document.body.removeAttribute('data-theme');
+    } else {
+      document.body.setAttribute('data-theme', mode);
+    }
+  }, [mode]);
+
+  const contextValue = useMemo(
+    () => ({themeName, mode, setThemeName, setMode}),
+    [themeName, mode],
+  );
+
+  return (
+    <ThemeSwitcherContext.Provider value={contextValue}>
+      <XDSTheme theme={theme} mode={mode}>
+        {children}
+      </XDSTheme>
+    </ThemeSwitcherContext.Provider>
+  );
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "e2e"
   ],
   "scripts": {
-    "build": "yarn workspace @xds/core build && yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build",
+    "build": "yarn workspace @xds/core build && yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build && yarn workspace @xds/theme-brutalist build",
     "dev": "yarn workspace @xds/storybook dev",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@xds/theme-brutalist",
+  "version": "0.0.1",
+  "private": true,
+  "description": "Techno-brutalist theme for XDS — monospace, neon accents, sharp edges",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch"
+  },
+  "dependencies": {
+    "lucide-react": "^0.575.0"
+  },
+  "peerDependencies": {
+    "@stylexjs/stylex": ">=0.10.0",
+    "@xds/core": "*",
+    "react": ">=18"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.28.5",
+    "@babel/preset-react": "^7.28.5",
+    "@babel/preset-typescript": "^7.28.5",
+    "@stylexjs/babel-plugin": "^0.17.4",
+    "esbuild-plugin-babel": "^0.2.3",
+    "tsup": "^8.3.0"
+  }
+}

--- a/packages/themes/brutalist/src/brutalistTheme.stylex.ts
+++ b/packages/themes/brutalist/src/brutalistTheme.stylex.ts
@@ -1,0 +1,458 @@
+/**
+ * Brutalist Theme
+ *
+ * Techno-brutalist aesthetic: monospace everything, neon accents on dark
+ * surfaces, zero border-radius, hard shadows, high contrast.
+ *
+ * Overrides: colors, typography, radius, elevation.
+ * Inherits defaults: spacing, size, textSize, lineHeight, fontWeight, transition.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import type {ThemeType as Theme} from '@xds/core/theme';
+import {
+  colorVars,
+  radiusVars,
+  elevationVars,
+  typographyVars,
+  textSizeVars,
+  lineHeightVars,
+  fontWeightVars,
+  spacingVars,
+  colorDefaults,
+  radiusDefaults,
+  elevationDefaults,
+  typographyDefaults,
+} from '@xds/core/theme/tokens.stylex';
+import {brutalistIconRegistry} from './icons';
+
+// =============================================================================
+// Color Overrides — neon on dark, inverted for light
+// =============================================================================
+
+const colorOverrides = {
+  // Core semantic — neon green accent
+  '--color-accent': 'light-dark(#0A0A0A, #39FF14)',
+  '--color-accent-deemphasized': 'light-dark(#0A0A0A1A, #39FF1426)',
+  '--color-accent-text': 'light-dark(#0A0A0A, #39FF14)',
+  '--color-surface': 'light-dark(#F5F5F5, #0A0A0A)',
+  '--color-wash': 'light-dark(#E8E8E8, #000000)',
+  '--color-overlay': 'light-dark(#00000080, #000000CC)',
+  '--color-hover-overlay': 'light-dark(#0000000D, #FFFFFF0D)',
+  '--color-pressed-overlay': 'light-dark(#00000019, #FFFFFF19)',
+  '--color-focus-outline': 'light-dark(#0A0A0A, #39FF14)',
+  '--color-focus-outline-error': 'light-dark(#FF003C, #FF003C)',
+  '--color-focus-outline-success': 'light-dark(#39FF14, #39FF14)',
+  '--color-focus-outline-warning': 'light-dark(#FFE600, #FFE600)',
+  '--color-deemphasized': 'light-dark(#0000000D, #FFFFFF0D)',
+
+  // Text — high contrast
+  '--color-text-primary': 'light-dark(#0A0A0A, #F0F0F0)',
+  '--color-text-secondary': 'light-dark(#555555, #999999)',
+  '--color-text-disabled': 'light-dark(#999999, #444444)',
+  '--color-text-link': 'light-dark(#0A0A0A, #39FF14)',
+  '--color-text-placeholder': 'light-dark(#777777, #555555)',
+  '--color-text-on-media': 'light-dark(#FFFFFF, #0A0A0A)',
+
+  // Icon
+  '--color-icon-primary': 'light-dark(#0A0A0A, #F0F0F0)',
+  '--color-icon-secondary': 'light-dark(#555555, #999999)',
+  '--color-icon-tertiary': 'light-dark(#777777, #666666)',
+  '--color-icon-disabled': 'light-dark(#999999, #444444)',
+  '--color-icon-on-media': 'light-dark(#FFFFFF, #0A0A0A)',
+
+  // Surface variants — dark cards with subtle neon borders
+  '--color-card': 'light-dark(#FFFFFF, #111111)',
+  '--color-popover': 'light-dark(#FFFFFF, #151515)',
+  '--color-navbar': 'light-dark(#F5F5F5, #0A0A0A)',
+
+  // Status — vivid neon tones
+  '--color-positive': 'light-dark(#00CC66, #39FF14)',
+  '--color-positive-deemphasized': 'light-dark(#00CC6626, #39FF1426)',
+  '--color-negative': 'light-dark(#FF003C, #FF003C)',
+  '--color-negative-deemphasized': 'light-dark(#FF003C26, #FF003C26)',
+  '--color-warning': 'light-dark(#FFE600, #FFE600)',
+  '--color-warning-deemphasized': 'light-dark(#FFE60026, #FFE60026)',
+  '--color-educational': 'light-dark(#BF00FF, #E040FB)',
+  '--color-educational-deemphasized': 'light-dark(#BF00FF26, #E040FB26)',
+
+  // Divider — neon-tinted borders
+  '--color-divider': 'light-dark(#0A0A0A1A, #39FF1426)',
+  '--color-divider-high-contrast': 'light-dark(#0A0A0A, #39FF14)',
+  '--color-divider-emphasized': 'light-dark(#0A0A0A33, #39FF1433)',
+
+  // Disabled/Effects
+  '--color-disabled-overlay': 'light-dark(#F5F5F580, #0A0A0A80)',
+  '--color-glimmer': 'light-dark(#CCCCCC, #333333)',
+  '--color-glimmer-high-contrast': 'light-dark(#999999, #555555)',
+  '--color-shadow-elevation':
+    'light-dark(rgba(0, 0, 0, 0.2), rgba(57, 255, 20, 0.15))',
+  '--color-hover-tint': 'light-dark(black, white)',
+
+  // Literal colors — neon palette
+  '--color-blue-background': 'light-dark(#00D4FF26, #00D4FF26)',
+  '--color-blue-border': 'light-dark(#00D4FF, #00D4FF)',
+  '--color-blue-icon': 'light-dark(#00AACC, #00D4FF)',
+  '--color-blue-text': 'light-dark(#005566, #66EEFF)',
+
+  '--color-cyan-background': 'light-dark(#00FFFF26, #00FFFF26)',
+  '--color-cyan-border': 'light-dark(#00CCCC, #00FFFF)',
+  '--color-cyan-icon': 'light-dark(#009999, #00FFFF)',
+  '--color-cyan-text': 'light-dark(#006666, #66FFFF)',
+
+  '--color-gray-background': 'light-dark(#0A0A0A1A, #FFFFFF1A)',
+  '--color-gray-border': 'light-dark(#555555, #666666)',
+  '--color-gray-icon': 'light-dark(#555555, #999999)',
+  '--color-gray-text': 'light-dark(#0A0A0A, #F0F0F0)',
+
+  '--color-green-background': 'light-dark(#39FF1426, #39FF1426)',
+  '--color-green-border': 'light-dark(#00CC66, #39FF14)',
+  '--color-green-icon': 'light-dark(#00AA44, #39FF14)',
+  '--color-green-text': 'light-dark(#005522, #88FF66)',
+
+  '--color-orange-background': 'light-dark(#FF660026, #FF660026)',
+  '--color-orange-border': 'light-dark(#FF6600, #FF8800)',
+  '--color-orange-icon': 'light-dark(#CC5500, #FF8800)',
+  '--color-orange-text': 'light-dark(#663300, #FFAA44)',
+
+  '--color-pink-background': 'light-dark(#FF00FF26, #FF00FF26)',
+  '--color-pink-border': 'light-dark(#FF00FF, #FF44FF)',
+  '--color-pink-icon': 'light-dark(#CC00CC, #FF44FF)',
+  '--color-pink-text': 'light-dark(#660066, #FF88FF)',
+
+  '--color-purple-background': 'light-dark(#BF00FF26, #E040FB26)',
+  '--color-purple-border': 'light-dark(#BF00FF, #E040FB)',
+  '--color-purple-icon': 'light-dark(#9900CC, #E040FB)',
+  '--color-purple-text': 'light-dark(#4D0066, #EE88FF)',
+
+  '--color-red-background': 'light-dark(#FF003C26, #FF003C26)',
+  '--color-red-border': 'light-dark(#FF003C, #FF003C)',
+  '--color-red-icon': 'light-dark(#CC0030, #FF003C)',
+  '--color-red-text': 'light-dark(#660018, #FF6688)',
+
+  '--color-teal-background': 'light-dark(#00FFCC26, #00FFCC26)',
+  '--color-teal-border': 'light-dark(#00CCAA, #00FFCC)',
+  '--color-teal-icon': 'light-dark(#009977, #00FFCC)',
+  '--color-teal-text': 'light-dark(#004D3D, #66FFE0)',
+
+  '--color-yellow-background': 'light-dark(#FFE60026, #FFE60026)',
+  '--color-yellow-border': 'light-dark(#FFE600, #FFE600)',
+  '--color-yellow-icon': 'light-dark(#CCBB00, #FFE600)',
+  '--color-yellow-text': 'light-dark(#665C00, #FFF066)',
+} as const;
+
+// =============================================================================
+// Typography — monospace everything
+// =============================================================================
+
+const typographyOverrides = {
+  '--font-body':
+    '"SF Mono", "Fira Code", "JetBrains Mono", Consolas, monospace',
+  '--font-code':
+    '"SF Mono", "Fira Code", "JetBrains Mono", Consolas, monospace',
+  '--font-heading':
+    '"SF Mono", "Fira Code", "JetBrains Mono", Consolas, monospace',
+} as const;
+
+// =============================================================================
+// Radius — zero. No rounded corners.
+// =============================================================================
+
+const radiusOverrides = {
+  '--radius-rounded': '0px',
+  '--radius-container': '0px',
+  '--radius-element': '0px',
+  '--radius-content': '0px',
+  '--radius-inner': '0px',
+} as const;
+
+// =============================================================================
+// Elevation — hard shadows, neon glow in dark mode
+// =============================================================================
+
+const elevationOverrides = {
+  '--elevation-base':
+    'light-dark(2px 2px 0px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(57, 255, 20, 0.2))',
+  '--elevation-thumb':
+    'light-dark(2px 2px 0px rgba(0, 0, 0, 0.25), 0 0 4px rgba(57, 255, 20, 0.3))',
+  '--elevation-dialog':
+    'light-dark(4px 4px 0px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(57, 255, 20, 0.3))',
+  '--elevation-hover':
+    'light-dark(3px 3px 0px rgba(0, 0, 0, 0.15), 0 0 8px rgba(57, 255, 20, 0.2))',
+  '--elevation-menu':
+    'light-dark(3px 3px 0px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(57, 255, 20, 0.25))',
+  '--elevation-input-hover':
+    'light-dark(inset 0 0 0 2px rgba(10, 10, 10, 0.3), inset 0 0 0 2px rgba(57, 255, 20, 0.4))',
+  '--elevation-input-hover-success':
+    'light-dark(inset 0 0 0 2px rgba(0, 204, 102, 0.4), inset 0 0 0 2px rgba(57, 255, 20, 0.5))',
+  '--elevation-input-hover-warning':
+    'light-dark(inset 0 0 0 2px rgba(255, 230, 0, 0.4), inset 0 0 0 2px rgba(255, 230, 0, 0.5))',
+  '--elevation-input-hover-error':
+    'light-dark(inset 0 0 0 2px rgba(255, 0, 60, 0.4), inset 0 0 0 2px rgba(255, 0, 60, 0.5))',
+} as const;
+
+// =============================================================================
+// createTheme calls
+// =============================================================================
+
+const colorTheme = stylex.createTheme(
+  colorVars,
+  colorOverrides as unknown as typeof colorDefaults,
+);
+
+const typographyTheme = stylex.createTheme(
+  typographyVars,
+  typographyOverrides as unknown as typeof typographyDefaults,
+);
+
+const radiusTheme = stylex.createTheme(
+  radiusVars,
+  radiusOverrides as unknown as typeof radiusDefaults,
+);
+
+const elevationTheme = stylex.createTheme(
+  elevationVars,
+  elevationOverrides as unknown as typeof elevationDefaults,
+);
+
+// =============================================================================
+// Component Style Overrides — neon borders, hard edges
+// =============================================================================
+
+const buttonVariants = stylex.create({
+  // Primary: neon accent bg, dark text
+  primary: {
+    color: 'light-dark(#FFFFFF, #0A0A0A)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  // Secondary: bordered with neon accent
+  secondary: {
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-divider-high-contrast'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+});
+
+// Card: neon border glow
+const cardStyles = stylex.create({
+  container: {
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-divider-emphasized'],
+  },
+});
+
+// Text input: neon border
+const textInputStyles = stylex.create({
+  wrapper: {
+    borderColor: colorVars['--color-divider-emphasized'],
+  },
+});
+
+/**
+ * Heading styles — monospace, uppercase for h1-h3
+ */
+const headingStyles = stylex.create({
+  h1: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-2xl'],
+    fontWeight: fontWeightVars['--font-weight-bold'],
+    lineHeight: 1.2,
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    margin: 0,
+  },
+  h2: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-xl'],
+    fontWeight: fontWeightVars['--font-weight-bold'],
+    lineHeight: 1.3333333333333333,
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    margin: 0,
+  },
+  h3: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-lg'],
+    fontWeight: fontWeightVars['--font-weight-bold'],
+    lineHeight: 1.25,
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.03em',
+    margin: 0,
+  },
+  h4: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-bold'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+  h5: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+  h6: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-xsm'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    lineHeight: 1.3333333333333333,
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    margin: 0,
+  },
+});
+
+const headingEditorialStyles = stylex.create({
+  h1: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-4xl'],
+    fontWeight: fontWeightVars['--font-weight-bold'],
+    lineHeight: 1.2,
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    margin: 0,
+  },
+  h2: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-3xl'],
+    fontWeight: fontWeightVars['--font-weight-bold'],
+    lineHeight: 1.3333333333333333,
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+    margin: 0,
+  },
+  h3: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-2xl'],
+    fontWeight: fontWeightVars['--font-weight-bold'],
+    lineHeight: 1.4,
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.04em',
+    margin: 0,
+  },
+  h4: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-lg'],
+    fontWeight: fontWeightVars['--font-weight-bold'],
+    lineHeight: 1.5,
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+  h5: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+  h6: {
+    fontFamily: typographyVars['--font-heading'],
+    fontSize: textSizeVars['--text-xsm'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    lineHeight: 1.3333333333333333,
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    margin: 0,
+  },
+});
+
+const textStyles = stylex.create({
+  body: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+  large: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-lg'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    lineHeight: 1.5,
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+  label: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-primary'],
+    textTransform: 'uppercase',
+    letterSpacing: '0.03em',
+    margin: 0,
+  },
+  supporting: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    lineHeight: 1.3333333333333333,
+    color: colorVars['--color-text-secondary'],
+    margin: 0,
+  },
+  code: {
+    fontFamily: typographyVars['--font-code'],
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    lineHeight: lineHeightVars['--leading-base'],
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+  },
+});
+
+// =============================================================================
+// Theme Export
+// =============================================================================
+
+export const brutalistTheme: Theme = {
+  name: 'brutalist',
+  icons: brutalistIconRegistry,
+  styles: {
+    colors: colorTheme,
+    typography: typographyTheme,
+    radius: radiusTheme,
+    elevation: elevationTheme,
+  },
+  raw: {
+    colors: colorOverrides,
+    typography: typographyOverrides,
+    radius: radiusOverrides,
+    elevation: elevationOverrides,
+  },
+  components: {
+    button: {
+      variants: buttonVariants,
+    },
+    card: {
+      container: cardStyles.container,
+    },
+    textInput: {
+      wrapper: textInputStyles.wrapper,
+    },
+    heading: {
+      styles: headingStyles,
+      editorialStyles: headingEditorialStyles,
+    },
+    text: {
+      styles: textStyles,
+    },
+  } as Theme['components'],
+};

--- a/packages/themes/brutalist/src/brutalistTheme.stylex.ts
+++ b/packages/themes/brutalist/src/brutalistTheme.stylex.ts
@@ -33,7 +33,7 @@ import {brutalistIconRegistry} from './icons';
 const colorOverrides = {
   // Core semantic — neon green accent
   '--color-accent': 'light-dark(#0A0A0A, #39FF14)',
-  '--color-accent-deemphasized': 'light-dark(#0A0A0A1A, #39FF1426)',
+  '--color-accent-deemphasized': 'light-dark(#0A0A0A1A, #39FF1440)',
   '--color-accent-text': 'light-dark(#0A0A0A, #39FF14)',
   '--color-surface': 'light-dark(#F5F5F5, #0A0A0A)',
   '--color-wash': 'light-dark(#E8E8E8, #000000)',
@@ -68,34 +68,34 @@ const colorOverrides = {
 
   // Status — vivid neon tones
   '--color-positive': 'light-dark(#00CC66, #39FF14)',
-  '--color-positive-deemphasized': 'light-dark(#00CC6626, #39FF1426)',
-  '--color-negative': 'light-dark(#FF003C, #FF003C)',
-  '--color-negative-deemphasized': 'light-dark(#FF003C26, #FF003C26)',
+  '--color-positive-deemphasized': 'light-dark(#00CC6640, #39FF1440)',
+  '--color-negative': 'light-dark(#FF003C, #FF2D5C)',
+  '--color-negative-deemphasized': 'light-dark(#FF003C40, #FF003C40)',
   '--color-warning': 'light-dark(#FFE600, #FFE600)',
-  '--color-warning-deemphasized': 'light-dark(#FFE60026, #FFE60026)',
+  '--color-warning-deemphasized': 'light-dark(#FFE60040, #FFE60040)',
   '--color-educational': 'light-dark(#BF00FF, #E040FB)',
-  '--color-educational-deemphasized': 'light-dark(#BF00FF26, #E040FB26)',
+  '--color-educational-deemphasized': 'light-dark(#BF00FF40, #E040FB40)',
 
   // Divider — neon-tinted borders
-  '--color-divider': 'light-dark(#0A0A0A1A, #39FF1426)',
+  '--color-divider': 'light-dark(#0A0A0A1A, #39FF1440)',
   '--color-divider-high-contrast': 'light-dark(#0A0A0A, #39FF14)',
-  '--color-divider-emphasized': 'light-dark(#0A0A0A33, #39FF1433)',
+  '--color-divider-emphasized': 'light-dark(#0A0A0A33, #39FF1466)',
 
   // Disabled/Effects
   '--color-disabled-overlay': 'light-dark(#F5F5F580, #0A0A0A80)',
   '--color-glimmer': 'light-dark(#CCCCCC, #333333)',
   '--color-glimmer-high-contrast': 'light-dark(#999999, #555555)',
   '--color-shadow-elevation':
-    'light-dark(rgba(0, 0, 0, 0.2), rgba(57, 255, 20, 0.15))',
+    'light-dark(rgba(0, 0, 0, 0.25), rgba(57, 255, 20, 0.3))',
   '--color-hover-tint': 'light-dark(black, white)',
 
   // Literal colors — neon palette
-  '--color-blue-background': 'light-dark(#00D4FF26, #00D4FF26)',
+  '--color-blue-background': 'light-dark(#00D4FF33, #00D4FF33)',
   '--color-blue-border': 'light-dark(#00D4FF, #00D4FF)',
   '--color-blue-icon': 'light-dark(#00AACC, #00D4FF)',
   '--color-blue-text': 'light-dark(#005566, #66EEFF)',
 
-  '--color-cyan-background': 'light-dark(#00FFFF26, #00FFFF26)',
+  '--color-cyan-background': 'light-dark(#00FFFF33, #00FFFF33)',
   '--color-cyan-border': 'light-dark(#00CCCC, #00FFFF)',
   '--color-cyan-icon': 'light-dark(#009999, #00FFFF)',
   '--color-cyan-text': 'light-dark(#006666, #66FFFF)',
@@ -105,37 +105,37 @@ const colorOverrides = {
   '--color-gray-icon': 'light-dark(#555555, #999999)',
   '--color-gray-text': 'light-dark(#0A0A0A, #F0F0F0)',
 
-  '--color-green-background': 'light-dark(#39FF1426, #39FF1426)',
+  '--color-green-background': 'light-dark(#39FF1433, #39FF1433)',
   '--color-green-border': 'light-dark(#00CC66, #39FF14)',
   '--color-green-icon': 'light-dark(#00AA44, #39FF14)',
   '--color-green-text': 'light-dark(#005522, #88FF66)',
 
-  '--color-orange-background': 'light-dark(#FF660026, #FF660026)',
+  '--color-orange-background': 'light-dark(#FF660033, #FF660033)',
   '--color-orange-border': 'light-dark(#FF6600, #FF8800)',
   '--color-orange-icon': 'light-dark(#CC5500, #FF8800)',
   '--color-orange-text': 'light-dark(#663300, #FFAA44)',
 
-  '--color-pink-background': 'light-dark(#FF00FF26, #FF00FF26)',
+  '--color-pink-background': 'light-dark(#FF00FF33, #FF00FF33)',
   '--color-pink-border': 'light-dark(#FF00FF, #FF44FF)',
   '--color-pink-icon': 'light-dark(#CC00CC, #FF44FF)',
   '--color-pink-text': 'light-dark(#660066, #FF88FF)',
 
-  '--color-purple-background': 'light-dark(#BF00FF26, #E040FB26)',
+  '--color-purple-background': 'light-dark(#BF00FF33, #E040FB33)',
   '--color-purple-border': 'light-dark(#BF00FF, #E040FB)',
   '--color-purple-icon': 'light-dark(#9900CC, #E040FB)',
   '--color-purple-text': 'light-dark(#4D0066, #EE88FF)',
 
-  '--color-red-background': 'light-dark(#FF003C26, #FF003C26)',
+  '--color-red-background': 'light-dark(#FF003C33, #FF003C33)',
   '--color-red-border': 'light-dark(#FF003C, #FF003C)',
   '--color-red-icon': 'light-dark(#CC0030, #FF003C)',
   '--color-red-text': 'light-dark(#660018, #FF6688)',
 
-  '--color-teal-background': 'light-dark(#00FFCC26, #00FFCC26)',
+  '--color-teal-background': 'light-dark(#00FFCC33, #00FFCC33)',
   '--color-teal-border': 'light-dark(#00CCAA, #00FFCC)',
   '--color-teal-icon': 'light-dark(#009977, #00FFCC)',
   '--color-teal-text': 'light-dark(#004D3D, #66FFE0)',
 
-  '--color-yellow-background': 'light-dark(#FFE60026, #FFE60026)',
+  '--color-yellow-background': 'light-dark(#FFE60033, #FFE60033)',
   '--color-yellow-border': 'light-dark(#FFE600, #FFE600)',
   '--color-yellow-icon': 'light-dark(#CCBB00, #FFE600)',
   '--color-yellow-text': 'light-dark(#665C00, #FFF066)',
@@ -172,23 +172,23 @@ const radiusOverrides = {
 
 const elevationOverrides = {
   '--elevation-base':
-    'light-dark(2px 2px 0px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(57, 255, 20, 0.2))',
+    'light-dark(3px 3px 0px rgba(0, 0, 0, 0.2), 0 0 8px rgba(57, 255, 20, 0.25), 0 0 0 1px rgba(57, 255, 20, 0.3))',
   '--elevation-thumb':
-    'light-dark(2px 2px 0px rgba(0, 0, 0, 0.25), 0 0 4px rgba(57, 255, 20, 0.3))',
+    'light-dark(2px 2px 0px rgba(0, 0, 0, 0.3), 0 0 10px rgba(57, 255, 20, 0.4), 0 0 2px rgba(57, 255, 20, 0.6))',
   '--elevation-dialog':
-    'light-dark(4px 4px 0px rgba(0, 0, 0, 0.2), 0 0 0 1px rgba(57, 255, 20, 0.3))',
+    'light-dark(6px 6px 0px rgba(0, 0, 0, 0.25), 0 0 20px rgba(57, 255, 20, 0.3), 0 0 0 1px rgba(57, 255, 20, 0.5))',
   '--elevation-hover':
-    'light-dark(3px 3px 0px rgba(0, 0, 0, 0.15), 0 0 8px rgba(57, 255, 20, 0.2))',
+    'light-dark(4px 4px 0px rgba(0, 0, 0, 0.2), 0 0 16px rgba(57, 255, 20, 0.35), 0 0 4px rgba(57, 255, 20, 0.5))',
   '--elevation-menu':
-    'light-dark(3px 3px 0px rgba(0, 0, 0, 0.15), 0 0 0 1px rgba(57, 255, 20, 0.25))',
+    'light-dark(4px 4px 0px rgba(0, 0, 0, 0.2), 0 0 12px rgba(57, 255, 20, 0.3), 0 0 0 1px rgba(57, 255, 20, 0.4))',
   '--elevation-input-hover':
-    'light-dark(inset 0 0 0 2px rgba(10, 10, 10, 0.3), inset 0 0 0 2px rgba(57, 255, 20, 0.4))',
+    'light-dark(inset 0 0 0 2px rgba(10, 10, 10, 0.4), inset 0 0 0 2px rgba(57, 255, 20, 0.6), 0 0 8px rgba(57, 255, 20, 0.2))',
   '--elevation-input-hover-success':
-    'light-dark(inset 0 0 0 2px rgba(0, 204, 102, 0.4), inset 0 0 0 2px rgba(57, 255, 20, 0.5))',
+    'light-dark(inset 0 0 0 2px rgba(0, 204, 102, 0.5), inset 0 0 0 2px rgba(57, 255, 20, 0.7), 0 0 8px rgba(57, 255, 20, 0.25))',
   '--elevation-input-hover-warning':
-    'light-dark(inset 0 0 0 2px rgba(255, 230, 0, 0.4), inset 0 0 0 2px rgba(255, 230, 0, 0.5))',
+    'light-dark(inset 0 0 0 2px rgba(255, 230, 0, 0.5), inset 0 0 0 2px rgba(255, 230, 0, 0.6), 0 0 8px rgba(255, 230, 0, 0.2))',
   '--elevation-input-hover-error':
-    'light-dark(inset 0 0 0 2px rgba(255, 0, 60, 0.4), inset 0 0 0 2px rgba(255, 0, 60, 0.5))',
+    'light-dark(inset 0 0 0 2px rgba(255, 0, 60, 0.5), inset 0 0 0 2px rgba(255, 0, 60, 0.6), 0 0 8px rgba(255, 0, 60, 0.2))',
 } as const;
 
 // =============================================================================
@@ -220,11 +220,13 @@ const elevationTheme = stylex.createTheme(
 // =============================================================================
 
 const buttonVariants = stylex.create({
-  // Primary: neon accent bg, dark text
+  // Primary: neon accent bg, dark text, glow on dark mode
   primary: {
     color: 'light-dark(#FFFFFF, #0A0A0A)',
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
+    boxShadow:
+      'light-dark(3px 3px 0px rgba(0, 0, 0, 0.2), 0 0 12px rgba(57, 255, 20, 0.4), 0 0 4px rgba(57, 255, 20, 0.6))',
   },
   // Secondary: bordered with neon accent
   secondary: {
@@ -233,6 +235,8 @@ const buttonVariants = stylex.create({
     borderColor: colorVars['--color-divider-high-contrast'],
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
+    boxShadow:
+      'light-dark(2px 2px 0px rgba(0, 0, 0, 0.15), 0 0 6px rgba(57, 255, 20, 0.2))',
   },
 });
 
@@ -242,13 +246,17 @@ const cardStyles = stylex.create({
     borderWidth: '1px',
     borderStyle: 'solid',
     borderColor: colorVars['--color-divider-emphasized'],
+    boxShadow:
+      'light-dark(3px 3px 0px rgba(0, 0, 0, 0.12), 0 0 10px rgba(57, 255, 20, 0.15), 0 0 2px rgba(57, 255, 20, 0.3))',
   },
 });
 
-// Text input: neon border
+// Text input: neon border + glow on focus
 const textInputStyles = stylex.create({
   wrapper: {
     borderColor: colorVars['--color-divider-emphasized'],
+    boxShadow:
+      'light-dark(2px 2px 0px rgba(0, 0, 0, 0.08), 0 0 6px rgba(57, 255, 20, 0.1))',
   },
 });
 

--- a/packages/themes/brutalist/src/icons.tsx
+++ b/packages/themes/brutalist/src/icons.tsx
@@ -1,0 +1,47 @@
+/**
+ * @file icons.tsx
+ * @input Uses lucide-react icon components, XDSIconRegistry type
+ * @output Exports brutalistIconRegistry for the brutalist theme
+ * @position Icon configuration for the brutalist theme; consumed by index.ts
+ *
+ * Maps semantic icon names to Lucide icon components.
+ * These icons are bundled with the theme, not with @xds/core.
+ */
+
+import React from 'react';
+import type {XDSIconRegistry} from '@xds/core/Icon';
+
+import {
+  X,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Check,
+  CheckCircle,
+  XCircle,
+  AlertTriangle,
+  Info,
+  Calendar,
+  Clock,
+  ExternalLink,
+} from 'lucide-react';
+
+const iconProps = {
+  size: '1em',
+  'aria-hidden': true as const,
+};
+
+export const brutalistIconRegistry: XDSIconRegistry = {
+  close: <X {...iconProps} />,
+  chevronDown: <ChevronDown {...iconProps} />,
+  chevronLeft: <ChevronLeft {...iconProps} />,
+  chevronRight: <ChevronRight {...iconProps} />,
+  check: <Check {...iconProps} />,
+  checkCircle: <CheckCircle {...iconProps} />,
+  xCircle: <XCircle {...iconProps} />,
+  warning: <AlertTriangle {...iconProps} />,
+  info: <Info {...iconProps} />,
+  calendar: <Calendar {...iconProps} />,
+  clock: <Clock {...iconProps} />,
+  externalLink: <ExternalLink {...iconProps} />,
+};

--- a/packages/themes/brutalist/src/index.ts
+++ b/packages/themes/brutalist/src/index.ts
@@ -1,0 +1,2 @@
+export {brutalistTheme} from './brutalistTheme.stylex';
+export {brutalistIconRegistry} from './icons';

--- a/packages/themes/brutalist/tsconfig.json
+++ b/packages/themes/brutalist/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "paths": {
+      "@xds/core/*": ["../../core/src/*"],
+      "@xds/core": ["../../core/src"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/themes/brutalist/tsup.config.ts
+++ b/packages/themes/brutalist/tsup.config.ts
@@ -1,0 +1,43 @@
+import {defineConfig} from 'tsup';
+import babel from 'esbuild-plugin-babel';
+import path from 'path';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: true,
+  clean: true,
+  external: ['react', 'react-dom', '@stylexjs/stylex', '@xds/core'],
+  esbuildPlugins: [
+    babel({
+      filter: /\.[jt]sx?$/,
+      config: {
+        presets: [
+          ['@babel/preset-react', {runtime: 'automatic'}],
+          '@babel/preset-typescript',
+        ],
+        plugins: [
+          [
+            '@stylexjs/babel-plugin',
+            {
+              dev: false,
+              runtimeInjection: false,
+              genConditionalClasses: true,
+              treeshakeCompensation: true,
+              aliases: {
+                '@xds/core/*': [
+                  path.join(__dirname, '..', '..', 'core', 'src', '*'),
+                ],
+              },
+              unstable_moduleResolution: {
+                type: 'commonJS',
+                rootDir: path.resolve(__dirname, '../../..'),
+              },
+            },
+          ],
+        ],
+      },
+    }),
+  ],
+});


### PR DESCRIPTION
## Summary

Adds `@xds/theme-brutalist` — a techno-brutalist theme that demonstrates partial theme overrides from #319. Also adds a theme switcher to the sandbox app.

### Brutalist Theme

Monospace everything, neon green accents (`#39FF14`), zero border-radius, hard offset shadows in light mode, neon glow in dark mode.

| Token Group | Override? | What Changes |
|---|---|---|
| Colors | ✅ | Neon green accent, near-black surfaces, vivid status colors |
| Typography | ✅ | All fonts → monospace (SF Mono / Fira Code / JetBrains Mono) |
| Radius | ✅ | All → `0px` (sharp edges) |
| Elevation | ✅ | Hard offset shadows (light), neon glow (dark) |
| Spacing | ❌ | Inherits defaults |
| Size | ❌ | Inherits defaults |
| Text Size | ❌ | Inherits defaults |
| Line Height | ❌ | Inherits defaults |
| Font Weight | ❌ | Inherits defaults |
| Transition | ❌ | Inherits defaults |

Component overrides:
- Cards: neon border via `theme.components.card.container`
- Inputs: neon border via `theme.components.textInput.wrapper`
- Buttons: uppercase + letter-spacing
- Headings h1-h3: uppercase + letter-spacing
- Labels: uppercase

### Sandbox Theme Switcher

- Theme dropdown: Default / Neutral / Brutalist
- Mode dropdown: System / Light / Dark
- Sidebar now uses XDS tokens instead of hardcoded colors
- Cards section added to example page

### Test plan
- `yarn build` — all 4 theme packages build clean
- `yarn test` — all 1006 tests pass
- Switch themes in sandbox → all components re-theme correctly

---
*Crafted with care by Navi*