### PR TITLE
feat(token): match close icon color to start icon

### DIFF
--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -188,10 +188,6 @@ const styles = stylex.create({
     width: '16px',
     height: '16px',
     color: 'inherit',
-    opacity: {
-      default: 0.7,
-      ':hover': 1,
-    },
     outline: {
       default: null,
       ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
@@ -308,7 +304,7 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
             }}
             disabled={isDisabled}
             {...stylex.props(styles.removeButton)}>
-            <XDSIcon icon="close" size="xsm" />
+            <XDSIcon icon="close" size="xsm" color="inherit" />
           </button>
         )}
       </>
@@ -380,7 +376,7 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
               }}
               disabled={isDisabled}
               {...stylex.props(styles.removeButton)}>
-              <XDSIcon icon="close" size="xsm" />
+              <XDSIcon icon="close" size="xsm" color="inherit" />
             </button>
           )}
         </span>


### PR DESCRIPTION
## Summary

The XDSToken remove/close button had `opacity: 0.7` which made the close icon appear dimmer than the start icon. This removes the opacity reduction so both icons render at the same color intensity.

## Changes

- Removed `opacity` style from the `removeButton` in `XDSToken.tsx`

## Test Plan

- Existing tests pass
- Visual: close icon now matches the start icon color

---
*Crafted with care by Navi*