### PR TITLE
docs: document hook naming convention (useXDS prefix)

### DIFF
--- a/.context/decisions/api-guidance.md
+++ b/.context/decisions/api-guidance.md
@@ -82,6 +82,19 @@ Every component file includes a structured header for traceability:
 
 ---
 
+## Hook Naming
+
+Public hooks use the `useXDS` prefix:
+
+| Prefix | Scope | Examples |
+|--------|-------|---------|
+| `useXDS` | Public API | `useXDSCollapsible`, `useXDSPopover`, `useXDSTheme` |
+| `use` (no prefix) | Internal only | `useFocusTrap`, `useControllableState` |
+
+Utility hooks that can be generally applied and have no strict connection to XDS concepts can skip the prefix (e.g., `useGridFocus`, `useListFocus`).
+
+---
+
 ## Prop Naming
 
 ### Booleans


### PR DESCRIPTION
## Summary

Adds a **Hook Naming** section to the API guidance decision doc (`.context/decisions/api-guidance.md`), documenting the `useXDS` prefix convention for public hooks.

### Convention

| Prefix | Scope | Examples |
|--------|-------|---------|
| `useXDS` | Public API | `useXDSCollapsible`, `useXDSPopover`, `useXDSTheme` |
| `use` (no prefix) | Internal only | `useFocusTrap`, `useControllableState` |

Utility hooks with no strict connection to XDS concepts can skip the prefix (e.g., `useGridFocus`, `useListFocus`).

Fixes #269

---
*Crafted with care by Navi*