### PR TITLE
fix(Dialog): remove default browser outline on dialog element

### DIFF
--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -300,10 +300,11 @@
   }
 
   /*
-   * Reset dialog padding.
+   * Reset dialog padding and outline.
    */
   :where(dialog) {
     padding: 0;
+    outline: none;
   }
 
   /*


### PR DESCRIPTION
## Summary

Removes the default browser outline on the `<dialog>` element by adding `outline: none` to the dialog reset in `reset.css`.

## Problem

XDSDialog renders with a visible outline (browser default focus ring on the `<dialog>` element). The XDS `reset.css` resets dialog padding but doesn't reset its outline.

## Fix

Added `outline: none` to the existing `:where(dialog)` block in `packages/core/src/reset.css`.

Fixes #277

## Test Plan

- All 1006 existing tests pass
- Visual: dialog element no longer shows browser default outline

---
*Crafted with care by Navi*