### PR TITLE
fix(EmptyState): update spacing and use XDSButton in stories

### DIFF
--- a/apps/storybook/stories/EmptyState.stories.tsx
+++ b/apps/storybook/stories/EmptyState.stories.tsx
@@ -53,8 +53,8 @@ export const WithActions: Story = {
     description: 'Try adjusting your search or filters.',
     actions: (
       <>
-        <XDSButton label="Clear filters" variant="primary" />
         <XDSButton label="Go back" variant="secondary" />
+        <XDSButton label="Clear filters" variant="primary" />
       </>
     ),
   },
@@ -75,8 +75,8 @@ export const CompactWithActions: Story = {
     description: 'Add some data to get started.',
     actions: (
       <>
-        <XDSButton label="Add item" variant="primary" />
         <XDSButton label="Import" variant="secondary" />
+        <XDSButton label="Add item" variant="primary" />
       </>
     ),
     isCompact: true,
@@ -97,8 +97,8 @@ export const FullExample: Story = {
         description="When you receive notifications, they will appear here. Check back later!"
         actions={
           <>
-            <XDSButton label="Refresh" variant="primary" />
             <XDSButton label="Settings" variant="secondary" />
+            <XDSButton label="Refresh" variant="primary" />
           </>
         }
       />

--- a/apps/storybook/stories/EmptyState.stories.tsx
+++ b/apps/storybook/stories/EmptyState.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSEmptyState} from '@xds/core/EmptyState';
+import {XDSButton} from '@xds/core/Button';
 
 const meta: Meta<typeof XDSEmptyState> = {
   title: 'Core/XDSEmptyState',
@@ -52,8 +53,8 @@ export const WithActions: Story = {
     description: 'Try adjusting your search or filters.',
     actions: (
       <>
-        <button>Clear filters</button>
-        <button>Go back</button>
+        <XDSButton label="Clear filters" variant="primary" />
+        <XDSButton label="Go back" variant="secondary" />
       </>
     ),
   },
@@ -74,8 +75,8 @@ export const CompactWithActions: Story = {
     description: 'Add some data to get started.',
     actions: (
       <>
-        <button>Add item</button>
-        <button>Import</button>
+        <XDSButton label="Add item" variant="primary" />
+        <XDSButton label="Import" variant="secondary" />
       </>
     ),
     isCompact: true,
@@ -96,8 +97,8 @@ export const FullExample: Story = {
         description="When you receive notifications, they will appear here. Check back later!"
         actions={
           <>
-            <button>Refresh</button>
-            <button>Settings</button>
+            <XDSButton label="Refresh" variant="primary" />
+            <XDSButton label="Settings" variant="secondary" />
           </>
         }
       />

--- a/packages/core/src/EmptyState/XDSEmptyState.test.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.test.tsx
@@ -68,9 +68,9 @@ describe('XDSEmptyState', () => {
 
   it('does not render actions wrapper when actions is not provided', () => {
     const {container} = render(<XDSEmptyState title="No results" />);
-    // Only the container div and the heading should be present
+    // Container div + text group div, but no actions wrapper
     const divs = container.querySelectorAll('div');
-    expect(divs).toHaveLength(1); // just the container
+    expect(divs).toHaveLength(2); // container + text group
   });
 
   it('has role="status" on the container', () => {

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -29,7 +29,7 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     textAlign: 'center',
-    gap: spacingVars['--spacing-3'],
+    gap: spacingVars['--spacing-4'],
     paddingBlock: spacingVars['--spacing-8'],
     paddingInline: spacingVars['--spacing-6'],
   },
@@ -60,6 +60,11 @@ const styles = stylex.create({
   },
   descriptionCompact: {
     fontSize: textSizeVars['--text-sm'],
+  },
+  textGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
   },
   actions: {
     display: 'flex',
@@ -145,18 +150,20 @@ export const XDSEmptyState = forwardRef<HTMLDivElement, XDSEmptyStateProps>(
         )}
         {...props}>
         {icon != null && <div aria-hidden="true">{icon}</div>}
-        <h3 {...stylex.props(styles.title, isCompact && styles.titleCompact)}>
-          {title}
-        </h3>
-        {description != null && (
-          <p
-            {...stylex.props(
-              styles.description,
-              isCompact && styles.descriptionCompact,
-            )}>
-            {description}
-          </p>
-        )}
+        <div {...stylex.props(styles.textGroup)}>
+          <h3 {...stylex.props(styles.title, isCompact && styles.titleCompact)}>
+            {title}
+          </h3>
+          {description != null && (
+            <p
+              {...stylex.props(
+                styles.description,
+                isCompact && styles.descriptionCompact,
+              )}>
+              {description}
+            </p>
+          )}
+        </div>
         {actions != null && (
           <div
             {...stylex.props(


### PR DESCRIPTION
## Changes

- **Title ↔ Description gap:** Wrapped in a `textGroup` container with 0px gap for tight text pairing
- **Media ↔ Title gap:** Increased container gap from `--spacing-3` (12px) to `--spacing-4` (16px)
- **Stories:** Replaced plain `<button>` elements with `XDSButton` using `primary` and `secondary` variants

## Structure (before → after)

```
Before: icon → title → description → actions  (all same gap)
After:  icon → textGroup(title, description) → actions  (16px outer, 0px inner)
```

---
*Crafted with care by Navi*