### PR TITLE
fix: bump React peer dependency to >=19.0.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -325,8 +325,8 @@
     "lint": "eslint src"
   },
   "peerDependencies": {
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=19.0.0",
+    "react-dom": ">=19.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@stylexjs/stylex": ">=0.10.0",
     "@xds/core": "*",
-    "react": ">=18"
+    "react": ">=19"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@stylexjs/stylex": ">=0.10.0",
     "@xds/core": "*",
-    "react": ">=18"
+    "react": ">=19"
   },
   "devDependencies": {
     "@babel/core": "^7.28.5",

--- a/scripts/package-source.js
+++ b/scripts/package-source.js
@@ -186,7 +186,7 @@ This package contains the raw TypeScript source files for XDS components.
 
 - **TypeScript** >= 5.0
 - **StyleX Babel Plugin** - \`@stylexjs/babel-plugin\`
-- **React** >= 18.0.0
+- **React** >= 19.0.0
 
 ## StyleX Configuration
 


### PR DESCRIPTION
## Problem

`useOptimistic` (used in 7 input components) is a React 19-only hook, but the peer dependency was set to `>=18.0.0`. React 18 consumers hit a runtime crash:

> useOptimistic is not a function or its return value is not iterable

### Affected components
- XDSTextInput
- XDSTextArea
- XDSCheckboxInput
- XDSSwitch
- XDSSelector
- XDSDateInput
- XDSTimeInput

## Fix

1. Bumps `peerDependencies` in `packages/core/package.json` to `react >= 19.0.0`

Unblocks #308