### PR TITLE
fix(Banner): remove dismiss button wrapper div

### DIFF
--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -209,9 +209,6 @@ const styles = stylex.create({
     flexShrink: 0,
     marginInlineStart: 'auto',
   },
-  dismissButton: {
-    margin: `calc(-1 * ${spacingVars['--spacing-2']})`,
-  },
   // Content area — card background for additional content below the header
   contentArea: {
     backgroundColor: colorVars['--color-card'],
@@ -363,16 +360,14 @@ export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
             <div {...stylex.props(styles.endArea)}>
               {endButton}
               {isDismissable && (
-                <div {...stylex.props(styles.dismissButton)}>
-                  <XDSButton
-                    variant="ghost"
-                    size="sm"
-                    label="Dismiss"
-                    tooltip="Dismiss"
-                    icon={<XDSIcon icon="close" size="sm" color="inherit" />}
-                    onClick={handleDismiss}
-                  />
-                </div>
+                <XDSButton
+                  variant="ghost"
+                  size="sm"
+                  label="Dismiss"
+                  tooltip="Dismiss"
+                  icon={<XDSIcon icon="close" size="sm" color="inherit" />}
+                  onClick={handleDismiss}
+                />
               )}
             </div>
           )}


### PR DESCRIPTION
Removes the negative-margin wrapper `<div>` around the dismiss button in XDSBanner, letting it sit naturally in the `endArea` flex container.

This aligns with how the Dialog close button works (no negative margin compensation).

## Changes

- Removed `dismissButton` StyleX style
- Removed wrapper `<div>` around dismiss `<XDSButton>`

---
*Crafted with care by Navi*