### PR TITLE
feat(topnav): add XDSTopNavMegaMenu component

### DIFF
--- a/apps/sandbox/src/app/Sidebar.tsx
+++ b/apps/sandbox/src/app/Sidebar.tsx
@@ -21,6 +21,7 @@ const pages = [
   {name: 'Example', href: '/pages/example/'},
   {name: 'Navigation', href: '/pages/navigation/'},
   {name: 'TopNav Menu', href: '/pages/topnav-menu/'},
+  {name: 'Mega Menu', href: '/pages/mega-menu/'},
   {name: 'Polymorphic Link', href: '/pages/polymorphic-link/'},
 ];
 

--- a/apps/sandbox/src/app/pages/mega-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/mega-menu/page.tsx
@@ -1,0 +1,325 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {
+  XDSTopNav,
+  XDSTopNavTitle,
+  XDSTopNavItem,
+  XDSTopNavMegaMenu,
+} from '@xds/core/TopNav';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+
+const styles = stylex.create({
+  container: {
+    maxWidth: 960,
+  },
+  navWrapper: {
+    position: 'relative',
+    borderRadius: 12,
+    overflow: 'visible',
+    boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)',
+  },
+});
+
+// =============================================================================
+// Icons
+// =============================================================================
+
+const LogoIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <circle cx="12" cy="12" r="3" />
+    <circle cx="12" cy="5" r="1.5" />
+    <circle cx="18.5" cy="8.5" r="1.5" />
+    <circle cx="18.5" cy="15.5" r="1.5" />
+    <circle cx="12" cy="19" r="1.5" />
+    <circle cx="5.5" cy="15.5" r="1.5" />
+    <circle cx="5.5" cy="8.5" r="1.5" />
+  </svg>
+);
+
+const ChartIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="M3 3v18h18" />
+    <path d="M18 17V9" />
+    <path d="M13 17V5" />
+    <path d="M8 17v-3" />
+  </svg>
+);
+
+const LayersIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="M12 2L2 7l10 5 10-5-10-5z" />
+    <path d="M2 17l10 5 10-5" />
+    <path d="M2 12l10 5 10-5" />
+  </svg>
+);
+
+const ShieldIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+  </svg>
+);
+
+const ZapIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2" />
+  </svg>
+);
+
+const CodeIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <polyline points="16 18 22 12 16 6" />
+    <polyline points="8 6 2 12 8 18" />
+  </svg>
+);
+
+const GlobeIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <circle cx="12" cy="12" r="10" />
+    <line x1="2" y1="12" x2="22" y2="12" />
+    <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
+  </svg>
+);
+
+// =============================================================================
+// Demo Data
+// =============================================================================
+
+const productItems = [
+  {
+    title: 'Analytics',
+    description: 'Track and analyze user behavior across your applications',
+    icon: <ChartIcon />,
+    href: '#analytics',
+  },
+  {
+    title: 'Platform',
+    description: 'End-to-end infrastructure for building at scale',
+    icon: <LayersIcon />,
+    href: '#platform',
+  },
+  {
+    title: 'Security',
+    description: 'Enterprise-grade protection for your data and users',
+    icon: <ShieldIcon />,
+    href: '#security',
+  },
+  {
+    title: 'Automation',
+    description: 'Streamline workflows with intelligent automation tools',
+    icon: <ZapIcon />,
+    href: '#automation',
+  },
+  {
+    title: 'Developer Tools',
+    description: 'APIs, SDKs, and CLI tools for seamless integration',
+    icon: <CodeIcon />,
+    href: '#dev-tools',
+  },
+  {
+    title: 'Global Network',
+    description: 'Low-latency edge infrastructure in 40+ regions',
+    icon: <GlobeIcon />,
+    href: '#network',
+  },
+];
+
+const solutionItems = [
+  {
+    title: 'Enterprise',
+    description: 'Solutions for large-scale organizations',
+    icon: <LayersIcon />,
+    href: '#enterprise',
+  },
+  {
+    title: 'Startups',
+    description: 'Get started fast with startup-friendly pricing',
+    icon: <ZapIcon />,
+    href: '#startups',
+  },
+  {
+    title: 'Developers',
+    description: 'Build with powerful APIs and documentation',
+    icon: <CodeIcon />,
+    href: '#developers',
+  },
+];
+
+// =============================================================================
+// Page
+// =============================================================================
+
+/**
+ * Demo page for XDSTopNavMegaMenu — a nav item with a full-width mega menu.
+ */
+export default function MegaMenuPage() {
+  return (
+    <div {...stylex.props(styles.container)}>
+      <XDSVStack gap="space6">
+        <XDSVStack gap="space2">
+          <XDSHeading level={1}>Mega Menu</XDSHeading>
+          <XDSText type="body" color="secondary">
+            A top nav variation with a full-width mega menu that appears on
+            hover. Hover over &quot;Products&quot; or &quot;Solutions&quot; to
+            see the dropdown panel with categorized items and a featured content
+            area.
+          </XDSText>
+        </XDSVStack>
+
+        {/* Full mega menu with featured content */}
+        <XDSVStack gap="space3">
+          <XDSHeading level={2}>With Featured Content</XDSHeading>
+          <div {...stylex.props(styles.navWrapper)}>
+            <XDSTopNav
+              label="Marketing navigation"
+              title={
+                <XDSTopNavTitle
+                  title="Marketing"
+                  logo={<XDSNavIcon icon={<LogoIcon />} />}
+                  href="#"
+                />
+              }
+              startContent={
+                <>
+                  <XDSTopNavMegaMenu
+                    label="Products"
+                    items={productItems}
+                    featured={{
+                      image:
+                        'https://images.unsplash.com/photo-1551434678-e076c223a692?w=560&h=280&fit=crop',
+                      imageAlt: 'Team collaboration',
+                      title: 'What\u2019s new in v4.0',
+                      description:
+                        'Explore the latest features including AI-powered analytics and real-time collaboration.',
+                      linkText: 'Read the announcement \u2192',
+                      linkHref: '#announcement',
+                    }}
+                  />
+                  <XDSTopNavMegaMenu
+                    label="Solutions"
+                    items={solutionItems}
+                    featured={{
+                      title: 'Customer Stories',
+                      description:
+                        'See how leading companies are building with our platform.',
+                      linkText: 'View case studies \u2192',
+                      linkHref: '#case-studies',
+                    }}
+                  />
+                  <XDSTopNavItem label="Learn" href="#" />
+                </>
+              }
+              endContent={
+                <>
+                  <XDSButton label="Login" variant="ghost" />
+                  <XDSButton label="Get started" variant="primary" />
+                </>
+              }
+            />
+          </div>
+        </XDSVStack>
+
+        {/* Without featured content */}
+        <XDSVStack gap="space3">
+          <XDSHeading level={2}>Without Featured Content</XDSHeading>
+          <div {...stylex.props(styles.navWrapper)}>
+            <XDSTopNav
+              label="Simple navigation"
+              title={<XDSTopNavTitle title="App" href="#" />}
+              startContent={
+                <>
+                  <XDSTopNavItem label="Home" href="#" isSelected />
+                  <XDSTopNavMegaMenu
+                    label="Features"
+                    items={[
+                      {
+                        title: 'Dashboard',
+                        description: 'Overview of your key metrics',
+                        icon: <ChartIcon />,
+                        href: '#dashboard',
+                      },
+                      {
+                        title: 'Integrations',
+                        description: 'Connect with your favorite tools',
+                        icon: <CodeIcon />,
+                        href: '#integrations',
+                      },
+                      {
+                        title: 'API Access',
+                        description: 'Programmatic access to all features',
+                        icon: <GlobeIcon />,
+                        href: '#api',
+                      },
+                    ]}
+                    singleColumn
+                  />
+                  <XDSTopNavItem label="Pricing" href="#" />
+                </>
+              }
+              endContent={<XDSButton label="Sign in" variant="primary" />}
+            />
+          </div>
+        </XDSVStack>
+      </XDSVStack>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/pages/mega-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/mega-menu/page.tsx
@@ -310,7 +310,7 @@ export default function MegaMenuPage() {
                         href: '#api',
                       },
                     ]}
-                    singleColumn
+                    isSingleColumn
                   />
                   <XDSTopNavItem label="Pricing" href="#" />
                 </>

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -278,8 +278,8 @@ export interface XDSTopNavMegaMenuProps {
   delay?: number;
   /** Delay before hiding the menu after mouse leaves (ms). @default 250 */
   hideDelay?: number;
-  /** Whether to use single column layout for items. @default false */
-  singleColumn?: boolean;
+  /** Whether to use single-column layout for items. @default false */
+  isSingleColumn?: boolean;
 }
 
 // =============================================================================
@@ -346,7 +346,7 @@ export function XDSTopNavMegaMenu({
   featured,
   delay = 150,
   hideDelay = 250,
-  singleColumn = false,
+  isSingleColumn = false,
 }: XDSTopNavMegaMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -429,7 +429,7 @@ export function XDSTopNavMegaMenu({
           <div
             {...stylex.props(
               styles.menuSection,
-              singleColumn && styles.menuSectionSingle,
+              isSingleColumn && styles.menuSectionSingle,
             )}>
             {items.map((item, index) => {
               const Element = item.href ? 'a' : 'div';

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -1,0 +1,510 @@
+/**
+ * @file XDSTopNavMegaMenu.tsx
+ * @input Uses React, StyleX, custom hover logic
+ * @output Exports XDSTopNavMegaMenu component and related types
+ * @position Navigation item with hover-triggered full-width mega menu for XDSTopNav
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/TopNav/README.md
+ * - /packages/core/src/TopNav/index.ts
+ */
+
+'use client';
+
+import {useCallback, useEffect, useRef, useState, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  transitionVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+  elevationVars,
+} from '../theme/tokens.stylex';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  wrapper: {
+    // position: static so the panel positions relative to the nearest
+    // positioned ancestor (the nav bar wrapper), not this div.
+    position: 'static',
+  },
+  trigger: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    borderRadius: radiusVars['--radius-element'],
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-secondary'],
+    textDecoration: 'none',
+    cursor: 'pointer',
+    transitionProperty: 'background-color, color',
+    transitionDuration: transitionVars['--transition-fast'],
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': {
+        '@media (hover: hover)': colorVars['--color-hover-overlay'],
+      },
+    },
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
+    border: 'none',
+    fontFamily: 'inherit',
+  },
+  triggerOpen: {
+    color: colorVars['--color-text-primary'],
+    backgroundColor: colorVars['--color-hover-overlay'],
+  },
+  chevron: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    transitionProperty: 'transform',
+    transitionDuration: transitionVars['--transition-fast'],
+  },
+  chevronOpen: {
+    transform: 'rotate(180deg)',
+  },
+  panel: {
+    position: 'absolute',
+    top: '100%',
+    left: 0,
+    right: 0,
+    zIndex: 100,
+    backgroundColor: colorVars['--color-surface'],
+    boxShadow: elevationVars['--elevation-menu'],
+    borderBottomLeftRadius: radiusVars['--radius-container'],
+    borderBottomRightRadius: radiusVars['--radius-container'],
+    overflow: 'hidden',
+    opacity: 0,
+    transform: 'translateY(-4px)',
+    transitionProperty: 'opacity, transform',
+    transitionDuration: '0.2s',
+    transitionTimingFunction: 'ease-out',
+    pointerEvents: 'none',
+  },
+  panelOpen: {
+    opacity: 1,
+    transform: 'translateY(0)',
+    pointerEvents: 'auto',
+  },
+  panelContent: {
+    display: 'flex',
+    gap: spacingVars['--spacing-6'],
+    paddingBlock: spacingVars['--spacing-6'],
+    paddingInline: spacingVars['--spacing-6'],
+    maxWidth: 960,
+    marginInline: 'auto',
+  },
+  menuSection: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: spacingVars['--spacing-2'],
+    flex: 1,
+  },
+  menuSectionSingle: {
+    gridTemplateColumns: '1fr',
+  },
+  menuItem: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-3'],
+    borderRadius: radiusVars['--radius-element'],
+    textDecoration: 'none',
+    cursor: 'pointer',
+    transitionProperty: 'background-color',
+    transitionDuration: transitionVars['--transition-fast'],
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': {
+        '@media (hover: hover)': colorVars['--color-hover-overlay'],
+      },
+    },
+    border: 'none',
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
+    color: 'inherit',
+  },
+  menuItemIcon: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 40,
+    height: 40,
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-deemphasized'],
+    flexShrink: 0,
+    color: colorVars['--color-icon-secondary'],
+  },
+  menuItemContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+    minWidth: 0,
+  },
+  menuItemTitle: {
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    color: colorVars['--color-text-primary'],
+  },
+  menuItemDescription: {
+    fontSize: textSizeVars['--text-sm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    color: colorVars['--color-text-secondary'],
+  },
+  featured: {
+    width: 280,
+    flexShrink: 0,
+    borderRadius: radiusVars['--radius-container'],
+    backgroundColor: colorVars['--color-deemphasized'],
+    overflow: 'hidden',
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  featuredImage: {
+    width: '100%',
+    height: 140,
+    objectFit: 'cover',
+    display: 'block',
+  },
+  featuredBody: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-4'],
+  },
+  featuredTitle: {
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    color: colorVars['--color-text-primary'],
+  },
+  featuredDescription: {
+    fontSize: textSizeVars['--text-sm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    color: colorVars['--color-text-secondary'],
+  },
+  featuredLink: {
+    fontSize: textSizeVars['--text-sm'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    color: colorVars['--color-accent-text'],
+    textDecoration: 'none',
+    cursor: 'pointer',
+    marginBlockStart: spacingVars['--spacing-1'],
+  },
+  divider: {
+    width: 1,
+    backgroundColor: colorVars['--color-divider'],
+    flexShrink: 0,
+  },
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * An item in the mega menu.
+ */
+export interface XDSTopNavMegaMenuItemData {
+  /** Display title for the menu item. */
+  title: string;
+  /** Optional description text displayed below the title. */
+  description?: string;
+  /** Optional icon element displayed to the left. */
+  icon?: ReactNode;
+  /** URL to navigate to when clicked. */
+  href?: string;
+  /** Callback when item is clicked. */
+  onClick?: () => void;
+}
+
+/**
+ * Featured content for the right side of the mega menu.
+ */
+export interface XDSTopNavMegaMenuFeatured {
+  /** Image URL for the featured area. */
+  image?: string;
+  /** Alt text for the featured image. */
+  imageAlt?: string;
+  /** Featured content title. */
+  title: string;
+  /** Featured content description. */
+  description?: string;
+  /** Call-to-action link text. */
+  linkText?: string;
+  /** Call-to-action link URL. */
+  linkHref?: string;
+  /** Callback when CTA is clicked. */
+  onLinkClick?: () => void;
+  /** Custom content to render instead of the default layout. */
+  children?: ReactNode;
+}
+
+export interface XDSTopNavMegaMenuProps {
+  /** The visible label for the nav item trigger. */
+  label: string;
+  /** Menu items to display in the mega menu panel. */
+  items: XDSTopNavMegaMenuItemData[];
+  /** Optional featured content on the right side. */
+  featured?: XDSTopNavMegaMenuFeatured;
+  /** Delay before showing the menu on hover (ms). @default 150 */
+  delay?: number;
+  /** Delay before hiding the menu after mouse leaves (ms). @default 250 */
+  hideDelay?: number;
+  /** Whether to use single column layout for items. @default false */
+  singleColumn?: boolean;
+}
+
+// =============================================================================
+// Chevron Icon
+// =============================================================================
+
+function ChevronDown() {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round">
+      <path d="M3 4.5L6 7.5L9 4.5" />
+    </svg>
+  );
+}
+
+// =============================================================================
+// XDSTopNavMegaMenu
+// =============================================================================
+
+/**
+ * A navigation item that displays a full-width mega menu on hover.
+ *
+ * Renders as a nav item trigger in XDSTopNav's startContent slot. On hover,
+ * shows a full-width panel below the nav bar with menu items organized in
+ * columns and an optional featured content area on the right.
+ *
+ * The panel positions itself relative to the nearest positioned ancestor
+ * (typically the nav bar wrapper). For correct full-width behavior, wrap
+ * the XDSTopNav in a container with `position: relative`.
+ *
+ * @example
+ * ```tsx
+ * <div style={{ position: 'relative' }}>
+ *   <XDSTopNav
+ *     startContent={
+ *       <XDSTopNavMegaMenu
+ *         label="Products"
+ *         items={[
+ *           { title: 'Analytics', description: 'Track behavior', icon: <ChartIcon /> },
+ *           { title: 'Messaging', description: 'Real-time comms', icon: <ChatIcon /> },
+ *         ]}
+ *         featured={{
+ *           title: 'New: AI Features',
+ *           description: 'Explore our latest AI-powered tools.',
+ *           linkText: 'Learn more →',
+ *           linkHref: '/ai',
+ *         }}
+ *       />
+ *     }
+ *   />
+ * </div>
+ * ```
+ */
+export function XDSTopNavMegaMenu({
+  label,
+  items,
+  featured,
+  delay = 150,
+  hideDelay = 250,
+  singleColumn = false,
+}: XDSTopNavMegaMenuProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wrapperRef = useRef<HTMLDivElement | null>(null);
+
+  const clearTimeouts = useCallback(() => {
+    if (showTimeoutRef.current) {
+      clearTimeout(showTimeoutRef.current);
+      showTimeoutRef.current = null;
+    }
+    if (hideTimeoutRef.current) {
+      clearTimeout(hideTimeoutRef.current);
+      hideTimeoutRef.current = null;
+    }
+  }, []);
+
+  const scheduleShow = useCallback(() => {
+    clearTimeouts();
+    showTimeoutRef.current = setTimeout(() => {
+      setIsOpen(true);
+    }, delay);
+  }, [clearTimeouts, delay]);
+
+  const scheduleHide = useCallback(() => {
+    clearTimeouts();
+    hideTimeoutRef.current = setTimeout(() => {
+      setIsOpen(false);
+    }, hideDelay);
+  }, [clearTimeouts, hideDelay]);
+
+  const handleMouseEnter = useCallback(() => {
+    scheduleShow();
+  }, [scheduleShow]);
+
+  const handleMouseLeave = useCallback(() => {
+    scheduleHide();
+  }, [scheduleHide]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation();
+        clearTimeouts();
+        setIsOpen(false);
+      }
+    },
+    [clearTimeouts],
+  );
+
+  useEffect(() => {
+    return () => {
+      clearTimeouts();
+    };
+  }, [clearTimeouts]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      onKeyDown={handleKeyDown}
+      {...stylex.props(styles.wrapper)}>
+      <button
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={isOpen}
+        {...stylex.props(styles.trigger, isOpen && styles.triggerOpen)}>
+        {label}
+        <span {...stylex.props(styles.chevron, isOpen && styles.chevronOpen)}>
+          <ChevronDown />
+        </span>
+      </button>
+      <div
+        role="menu"
+        aria-label={label}
+        {...stylex.props(styles.panel, isOpen && styles.panelOpen)}>
+        <div {...stylex.props(styles.panelContent)}>
+          {/* Menu items section */}
+          <div
+            {...stylex.props(
+              styles.menuSection,
+              singleColumn && styles.menuSectionSingle,
+            )}>
+            {items.map((item, index) => {
+              const Element = item.href ? 'a' : 'div';
+              return (
+                <Element
+                  key={index}
+                  role="menuitem"
+                  tabIndex={isOpen ? 0 : -1}
+                  href={item.href}
+                  onClick={item.onClick}
+                  {...stylex.props(styles.menuItem)}>
+                  {item.icon && (
+                    <div {...stylex.props(styles.menuItemIcon)}>
+                      {item.icon}
+                    </div>
+                  )}
+                  <div {...stylex.props(styles.menuItemContent)}>
+                    <span {...stylex.props(styles.menuItemTitle)}>
+                      {item.title}
+                    </span>
+                    {item.description && (
+                      <span {...stylex.props(styles.menuItemDescription)}>
+                        {item.description}
+                      </span>
+                    )}
+                  </div>
+                </Element>
+              );
+            })}
+          </div>
+
+          {/* Featured section */}
+          {featured && (
+            <>
+              <div {...stylex.props(styles.divider)} />
+              <div {...stylex.props(styles.featured)}>
+                {featured.children ? (
+                  featured.children
+                ) : (
+                  <>
+                    {featured.image && (
+                      <img
+                        src={featured.image}
+                        alt={featured.imageAlt ?? ''}
+                        {...stylex.props(styles.featuredImage)}
+                      />
+                    )}
+                    <div {...stylex.props(styles.featuredBody)}>
+                      <span {...stylex.props(styles.featuredTitle)}>
+                        {featured.title}
+                      </span>
+                      {featured.description && (
+                        <span {...stylex.props(styles.featuredDescription)}>
+                          {featured.description}
+                        </span>
+                      )}
+                      {featured.linkText && (
+                        <a
+                          href={featured.linkHref}
+                          onClick={featured.onLinkClick}
+                          tabIndex={isOpen ? 0 : -1}
+                          {...stylex.props(styles.featuredLink)}>
+                          {featured.linkText}
+                        </a>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+XDSTopNavMegaMenu.displayName = 'XDSTopNavMegaMenu';

--- a/packages/core/src/TopNav/index.ts
+++ b/packages/core/src/TopNav/index.ts
@@ -18,3 +18,10 @@ export type {XDSTopNavItemProps} from './XDSTopNavItem';
 
 export {XDSTopNavMenu} from './XDSTopNavMenu';
 export type {XDSTopNavMenuProps, XDSTopNavMenuItemData} from './XDSTopNavMenu';
+
+export {XDSTopNavMegaMenu} from './XDSTopNavMegaMenu';
+export type {
+  XDSTopNavMegaMenuProps,
+  XDSTopNavMegaMenuItemData,
+  XDSTopNavMegaMenuFeatured,
+} from './XDSTopNavMegaMenu';


### PR DESCRIPTION
## Summary

Adds a full-width mega menu variant for the top navigation bar. On hover over a nav item, a panel drops down with menu items organized in a two-column grid and an optional featured content area on the right.

## New Component: `XDSTopNavMegaMenu`

### Features
- **Hover trigger** — nav item with chevron indicator that opens a full-width panel below the nav bar
- **Two-column item grid** — menu items with icon, title, and description
- **Featured content area** — optional right-side panel with image, title, description, and CTA link
- **Smooth animation** — fade + slide-up transition on open/close
- **Configurable timing** — `delay` and `hideDelay` props for hover behavior
- **Single column mode** — `singleColumn` prop for fewer items
- **Keyboard support** — Escape to dismiss
- **Accessible** — `aria-haspopup`, `aria-expanded`, `role="menu"`, `role="menuitem"`

### Usage

Wrap `XDSTopNav` in a container with `position: relative` so the mega menu panel spans the full nav width:

```tsx
<div style={{ position: 'relative' }}>
  <XDSTopNav
    startContent={
      <XDSTopNavMegaMenu
        label="Products"
        items={[
          { title: 'Analytics', description: 'Track behavior', icon: <ChartIcon /> },
          { title: 'Messaging', description: 'Real-time comms', icon: <ChatIcon /> },
        ]}
        featured={{
          image: '/promo.jpg',
          title: "What's new in v4.0",
          description: 'Explore the latest features.',
          linkText: 'Learn more →',
          linkHref: '/blog/v4',
        }}
      />
    }
  />
</div>
```

### Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `label` | `string` | — | Trigger button label (required) |
| `items` | `XDSTopNavMegaMenuItemData[]` | — | Menu items (required) |
| `featured` | `XDSTopNavMegaMenuFeatured` | — | Optional featured content area |
| `delay` | `number` | `150` | Show delay on hover (ms) |
| `hideDelay` | `number` | `250` | Hide delay after mouse leaves (ms) |
| `singleColumn` | `boolean` | `false` | Use single column layout |

## Test Plan

- `npx tsc --noEmit` — clean
- All 36 existing TopNav tests pass
- Sandbox demo page at `/pages/mega-menu/` with two examples:
  1. Marketing nav with featured content (Products + Solutions menus)
  2. Simple nav without featured content (Features menu, single column)

## Files Changed

| File | Change |
|------|--------|
| `packages/core/src/TopNav/XDSTopNavMegaMenu.tsx` | New component |
| `packages/core/src/TopNav/index.ts` | Added exports |
| `apps/sandbox/src/app/pages/mega-menu/page.tsx` | New demo page |
| `apps/sandbox/src/app/Sidebar.tsx` | Added sidebar link |

---
*Crafted with care by Navi*