### PR TITLE
feat(badge): add non-semantic color variants and darken neutral grey

### DIFF
--- a/apps/storybook/stories/Badge.stories.tsx
+++ b/apps/storybook/stories/Badge.stories.tsx
@@ -1,14 +1,46 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSBadge} from '@xds/core/Badge';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars, spacingVars} from '@xds/core/theme';
+
+const pageStyles = stylex.create({
+  pageWrapper: {
+    backgroundColor: colorVars['--color-wash'],
+    padding: spacingVars['--spacing-6'],
+  },
+});
 
 const meta: Meta<typeof XDSBadge> = {
   title: 'Core/XDSBadge',
   component: XDSBadge,
   tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div {...stylex.props(pageStyles.pageWrapper)}>
+        <Story />
+      </div>
+    ),
+  ],
   argTypes: {
     variant: {
       control: 'select',
-      options: ['neutral', 'info', 'success', 'warning', 'error'],
+      options: [
+        'neutral',
+        'info',
+        'success',
+        'warning',
+        'error',
+        'blue',
+        'cyan',
+        'gray',
+        'green',
+        'orange',
+        'pink',
+        'purple',
+        'red',
+        'teal',
+        'yellow',
+      ],
       description: 'Visual style variant',
     },
     children: {
@@ -27,7 +59,7 @@ export const Default: Story = {
   },
 };
 
-export const Variants: Story = {
+export const SemanticVariants: Story = {
   render: () => (
     <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
       <XDSBadge variant="neutral">Neutral</XDSBadge>
@@ -35,6 +67,23 @@ export const Variants: Story = {
       <XDSBadge variant="success">Success</XDSBadge>
       <XDSBadge variant="warning">Warning</XDSBadge>
       <XDSBadge variant="error">Error</XDSBadge>
+    </div>
+  ),
+};
+
+export const ColorVariants: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap'}}>
+      <XDSBadge variant="blue">Blue</XDSBadge>
+      <XDSBadge variant="cyan">Cyan</XDSBadge>
+      <XDSBadge variant="gray">Gray</XDSBadge>
+      <XDSBadge variant="green">Green</XDSBadge>
+      <XDSBadge variant="orange">Orange</XDSBadge>
+      <XDSBadge variant="pink">Pink</XDSBadge>
+      <XDSBadge variant="purple">Purple</XDSBadge>
+      <XDSBadge variant="red">Red</XDSBadge>
+      <XDSBadge variant="teal">Teal</XDSBadge>
+      <XDSBadge variant="yellow">Yellow</XDSBadge>
     </div>
   ),
 };
@@ -57,6 +106,22 @@ export const DotIndicators: Story = {
       <XDSBadge variant="success" />
       <XDSBadge variant="warning" />
       <XDSBadge variant="error" />
+      <XDSBadge variant="blue" />
+      <XDSBadge variant="purple" />
+      <XDSBadge variant="pink" />
+    </div>
+  ),
+};
+
+export const CategoryTags: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', alignItems: 'center', flexWrap: 'wrap'}}>
+      <XDSBadge variant="blue">Frontend</XDSBadge>
+      <XDSBadge variant="purple">Design</XDSBadge>
+      <XDSBadge variant="teal">Infrastructure</XDSBadge>
+      <XDSBadge variant="orange">Urgent</XDSBadge>
+      <XDSBadge variant="pink">Research</XDSBadge>
+      <XDSBadge variant="green">Approved</XDSBadge>
     </div>
   ),
 };

--- a/apps/storybook/stories/Badge.stories.tsx
+++ b/apps/storybook/stories/Badge.stories.tsx
@@ -1,7 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSBadge} from '@xds/core/Badge';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, spacingVars} from '@xds/core/theme';
+import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 
 const pageStyles = stylex.create({
   pageWrapper: {

--- a/packages/core/src/Badge/README.md
+++ b/packages/core/src/Badge/README.md
@@ -14,7 +14,7 @@ A badge component for displaying status indicators, counts, or labels.
 
 | Prop       | Type                                                       | Default     | Description                           |
 | ---------- | ---------------------------------------------------------- | ----------- | ------------------------------------- |
-| `variant`  | `'neutral' \| 'info' \| 'success' \| 'warning' \| 'error'` | `'neutral'` | Visual style variant                  |
+| `variant`  | `'neutral' \| 'info' \| 'success' \| 'warning' \| 'error' \| 'blue' \| 'cyan' \| 'gray' \| 'green' \| 'orange' \| 'pink' \| 'purple' \| 'red' \| 'teal' \| 'yellow'` | `'neutral'` | Visual style variant                  |
 | `children` | `ReactNode`                                                | -           | Badge content. Omit for dot indicator |
 | `icon`     | `ReactNode`                                                | -           | Optional leading icon                 |
 
@@ -34,9 +34,22 @@ import {XDSBadge} from '@xds/core/Badge';
 // Count badge
 <XDSBadge variant="info">42</XDSBadge>
 
+// Non-semantic color variants (for tags, categories, labels)
+<XDSBadge variant="blue">Frontend</XDSBadge>
+<XDSBadge variant="purple">Design</XDSBadge>
+<XDSBadge variant="teal">Infrastructure</XDSBadge>
+
 // Dot indicator (no children)
 <XDSBadge variant="success" />
 ```
+
+### Variant categories
+
+**Semantic variants** use solid backgrounds with on-media text for status meaning:
+`neutral` · `info` · `success` · `warning` · `error`
+
+**Non-semantic color variants** use tinted backgrounds with colored text for categorization:
+`blue` · `cyan` · `gray` · `green` · `orange` · `pink` · `purple` · `red` · `teal` · `yellow`
 
 ## Theming
 

--- a/packages/core/src/Badge/XDSBadge.test.tsx
+++ b/packages/core/src/Badge/XDSBadge.test.tsx
@@ -8,7 +8,7 @@ describe('XDSBadge', () => {
     expect(screen.getByText('Default')).toBeInTheDocument();
   });
 
-  it('renders with different variants', () => {
+  it('renders with semantic variants', () => {
     const {rerender} = render(<XDSBadge variant="success">Success</XDSBadge>);
     expect(screen.getByText('Success')).toBeInTheDocument();
 
@@ -20,6 +20,31 @@ describe('XDSBadge', () => {
 
     rerender(<XDSBadge variant="info">Info</XDSBadge>);
     expect(screen.getByText('Info')).toBeInTheDocument();
+  });
+
+  it('renders with non-semantic color variants', () => {
+    const colors = [
+      'blue',
+      'cyan',
+      'gray',
+      'green',
+      'orange',
+      'pink',
+      'purple',
+      'red',
+      'teal',
+      'yellow',
+    ] as const;
+
+    const {rerender} = render(
+      <XDSBadge variant={colors[0]}>{colors[0]}</XDSBadge>,
+    );
+    expect(screen.getByText(colors[0])).toBeInTheDocument();
+
+    for (const color of colors.slice(1)) {
+      rerender(<XDSBadge variant={color}>{color}</XDSBadge>);
+      expect(screen.getByText(color)).toBeInTheDocument();
+    }
   });
 
   it('renders as dot when no children provided', () => {

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -55,11 +55,16 @@ const styles = stylex.create({
 });
 
 /**
- * Variant styles for different badge appearances
+ * Variant styles for different badge appearances.
+ *
+ * Semantic variants use solid backgrounds with on-media text.
+ * Non-semantic variants use tinted backgrounds with colored text
+ * for softer categorization (tags, labels, filters).
  */
 const variants = stylex.create({
+  // Semantic variants
   neutral: {
-    backgroundColor: colorVars['--color-deemphasized'],
+    backgroundColor: colorVars['--color-gray-background'],
     color: colorVars['--color-text-primary'],
   },
   info: {
@@ -77,6 +82,48 @@ const variants = stylex.create({
   error: {
     backgroundColor: colorVars['--color-negative'],
     color: colorVars['--color-text-on-media'],
+  },
+
+  // Non-semantic color variants
+  blue: {
+    backgroundColor: colorVars['--color-blue-background'],
+    color: colorVars['--color-blue-text'],
+  },
+  cyan: {
+    backgroundColor: colorVars['--color-cyan-background'],
+    color: colorVars['--color-cyan-text'],
+  },
+  gray: {
+    backgroundColor: colorVars['--color-gray-background'],
+    color: colorVars['--color-gray-text'],
+  },
+  green: {
+    backgroundColor: colorVars['--color-green-background'],
+    color: colorVars['--color-green-text'],
+  },
+  orange: {
+    backgroundColor: colorVars['--color-orange-background'],
+    color: colorVars['--color-orange-text'],
+  },
+  pink: {
+    backgroundColor: colorVars['--color-pink-background'],
+    color: colorVars['--color-pink-text'],
+  },
+  purple: {
+    backgroundColor: colorVars['--color-purple-background'],
+    color: colorVars['--color-purple-text'],
+  },
+  red: {
+    backgroundColor: colorVars['--color-red-background'],
+    color: colorVars['--color-red-text'],
+  },
+  teal: {
+    backgroundColor: colorVars['--color-teal-background'],
+    color: colorVars['--color-teal-text'],
+  },
+  yellow: {
+    backgroundColor: colorVars['--color-yellow-background'],
+    color: colorVars['--color-yellow-text'],
   },
 });
 


### PR DESCRIPTION
## Summary

Add 10 non-semantic color variants to XDSBadge and darken the neutral grey from `--color-deemphasized` (~5% opacity) to `--color-gray-background` (~20% opacity).

## API

```tsx
// Semantic variants (existing) — solid backgrounds, status meaning
<XDSBadge variant="success">Active</XDSBadge>
<XDSBadge variant="error">Failed</XDSBadge>

// Non-semantic color variants (new) — tinted backgrounds, categorization
<XDSBadge variant="blue">Frontend</XDSBadge>
<XDSBadge variant="purple">Design</XDSBadge>
<XDSBadge variant="teal">Infrastructure</XDSBadge>
<XDSBadge variant="orange">Urgent</XDSBadge>
```

Full variant set: `neutral` · `info` · `success` · `warning` · `error` · `blue` · `cyan` · `gray` · `green` · `orange` · `pink` · `purple` · `red` · `teal` · `yellow`

## Design decisions

- **Semantic vs non-semantic distinction.** Semantic variants (info, success, warning, error) use solid backgrounds with on-media text. Non-semantic variants use tinted backgrounds with colored text. Softer treatment signals "category" rather than "status."
- **No new tokens.** All 10 color variants map directly to existing `--color-{name}-background` and `--color-{name}-text` token pairs.
- **Neutral darkened.** Swapped `--color-deemphasized` → `--color-gray-background` for ~4x better contrast. Matches the internal docs tool reference.
- **Type derives automatically.** `XDSBadgeVariant = keyof typeof variants` — adding entries to the StyleX object updates the type union with zero manual changes.

## What's included

- Component — 10 new color variant styles + neutral fix
- Tests — non-semantic variant rendering coverage
- Stories — ColorVariants gallery, CategoryTags usage example, updated argTypes
- Docs — README updated with variant categories and examples

Closes #244

*Crafted with care by Navi*