### PR TITLE
feat(confirmation-modal): add XDSConfirmationModal component

### DIFF
--- a/apps/storybook/stories/ConfirmationModal.stories.tsx
+++ b/apps/storybook/stories/ConfirmationModal.stories.tsx
@@ -1,0 +1,244 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSConfirmationModal} from '@xds/core/ConfirmationModal';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars, spacingVars} from '@xds/core/theme';
+
+const styles = stylex.create({
+  pageWrapper: {
+    backgroundColor: colorVars['--color-wash'],
+    padding: spacingVars['--spacing-6'],
+  },
+  result: {
+    marginTop: 12,
+  },
+});
+
+const meta: Meta<typeof XDSConfirmationModal> = {
+  title: 'Core/XDSConfirmationModal',
+  component: XDSConfirmationModal,
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['standard', 'destructive'],
+      description: 'Visual variant controlling the confirm button appearance',
+    },
+    isLoading: {
+      control: 'boolean',
+      description: 'External loading state',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSConfirmationModal>;
+
+/**
+ * Basic confirmation modal with default labels.
+ */
+function BasicExample() {
+  const [isShown, setIsShown] = useState(false);
+  const [confirmed, setConfirmed] = useState(false);
+
+  return (
+    <>
+      <XDSButton
+        label="Save changes"
+        variant="primary"
+        onClick={() => setIsShown(true)}
+      />
+      {confirmed && (
+        <XDSText type="body" color="primary" xstyle={styles.result}>
+          ✓ Changes saved
+        </XDSText>
+      )}
+      <XDSConfirmationModal
+        isShown={isShown}
+        title="Save changes?"
+        description="Your unsaved changes will be applied."
+        onConfirm={() => {
+          setConfirmed(true);
+          setIsShown(false);
+        }}
+        onCancel={() => setIsShown(false)}
+      />
+    </>
+  );
+}
+
+export const Default: Story = {
+  render: () => <BasicExample />,
+};
+
+/**
+ * Destructive confirmation with custom labels.
+ */
+function DestructiveExample() {
+  const [isShown, setIsShown] = useState(false);
+  const [deleted, setDeleted] = useState(false);
+
+  return (
+    <>
+      <XDSButton
+        label="Delete project"
+        variant="destructive"
+        onClick={() => setIsShown(true)}
+      />
+      {deleted && (
+        <XDSText type="body" color="primary" xstyle={styles.result}>
+          ✓ Project deleted
+        </XDSText>
+      )}
+      <XDSConfirmationModal
+        isShown={isShown}
+        title="Delete project?"
+        description="This action cannot be undone. All data associated with this project will be permanently removed."
+        onConfirm={() => {
+          setDeleted(true);
+          setIsShown(false);
+        }}
+        onCancel={() => setIsShown(false)}
+        variant="destructive"
+        confirmLabel="Delete"
+        cancelLabel="Keep"
+      />
+    </>
+  );
+}
+
+export const Destructive: Story = {
+  render: () => <DestructiveExample />,
+};
+
+/**
+ * Async confirm with automatic loading state.
+ */
+function AsyncExample() {
+  const [isShown, setIsShown] = useState(false);
+  const [removed, setRemoved] = useState(false);
+
+  const handleConfirm = async () => {
+    // Simulate async operation
+    await new Promise(resolve => setTimeout(resolve, 2000));
+    setRemoved(true);
+    setIsShown(false);
+  };
+
+  return (
+    <>
+      <XDSButton
+        label="Remove item"
+        variant="destructive"
+        onClick={() => {
+          setRemoved(false);
+          setIsShown(true);
+        }}
+      />
+      {removed && (
+        <XDSText type="body" color="primary" xstyle={styles.result}>
+          ✓ Item removed
+        </XDSText>
+      )}
+      <XDSConfirmationModal
+        isShown={isShown}
+        title="Remove item?"
+        description="This will remove the item from your list."
+        onConfirm={handleConfirm}
+        onCancel={() => setIsShown(false)}
+        variant="destructive"
+        confirmLabel="Remove"
+      />
+    </>
+  );
+}
+
+export const AsyncConfirm: Story = {
+  render: () => <AsyncExample />,
+};
+
+/**
+ * Rich description with ReactNode content.
+ */
+function RichDescriptionExample() {
+  const [isShown, setIsShown] = useState(false);
+
+  return (
+    <>
+      <XDSButton
+        label="Transfer ownership"
+        variant="secondary"
+        onClick={() => setIsShown(true)}
+      />
+      <XDSConfirmationModal
+        isShown={isShown}
+        title="Transfer ownership?"
+        description={
+          <XDSVStack gap="sm">
+            <XDSText type="body">
+              You are transferring ownership to <strong>Jane Doe</strong>.
+            </XDSText>
+            <XDSText type="body" color="secondary">
+              You will lose admin access immediately.
+            </XDSText>
+          </XDSVStack>
+        }
+        onConfirm={() => setIsShown(false)}
+        onCancel={() => setIsShown(false)}
+      />
+    </>
+  );
+}
+
+export const RichDescription: Story = {
+  render: () => <RichDescriptionExample />,
+};
+
+/**
+ * External loading state control.
+ */
+function ExternalLoadingExample() {
+  const [isShown, setIsShown] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleConfirm = () => {
+    setIsLoading(true);
+    setTimeout(() => {
+      setIsLoading(false);
+      setIsShown(false);
+    }, 2000);
+  };
+
+  return (
+    <>
+      <XDSButton
+        label="Submit form"
+        variant="primary"
+        onClick={() => setIsShown(true)}
+      />
+      <XDSConfirmationModal
+        isShown={isShown}
+        title="Submit form?"
+        description="Your form data will be submitted for review."
+        onConfirm={handleConfirm}
+        onCancel={() => setIsShown(false)}
+        isLoading={isLoading}
+        confirmLabel="Submit"
+      />
+    </>
+  );
+}
+
+export const ExternalLoading: Story = {
+  render: () => <ExternalLoadingExample />,
+};

--- a/apps/storybook/stories/ConfirmationModal.stories.tsx
+++ b/apps/storybook/stories/ConfirmationModal.stories.tsx
@@ -5,7 +5,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {XDSVStack} from '@xds/core/Layout';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, spacingVars} from '@xds/core/theme';
+import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 
 const styles = stylex.create({
   pageWrapper: {

--- a/packages/core/src/ConfirmationModal/README.md
+++ b/packages/core/src/ConfirmationModal/README.md
@@ -1,0 +1,102 @@
+# ConfirmationModal
+
+Pre-composed confirmation dialog for confirm/cancel actions. Wraps XDSDialog with opinionated defaults for the most common dialog pattern.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## Features
+
+- **Composed from primitives**: XDSDialog + XDSLayout + XDSButton + XDSText
+- **Async confirm**: `onConfirm` can return a Promise — loading state is managed automatically
+- **Destructive variant**: Red confirm button for irreversible actions
+- **Accessible**: `role="alertdialog"`, `aria-describedby`, focus management
+- **Form purpose**: Escape cancels, backdrop click blocked (prevents accidental dismissal)
+
+## Usage
+
+```tsx
+import {XDSConfirmationModal} from '@xds/core/ConfirmationModal';
+import {useState} from 'react';
+
+function Example() {
+  const [isShown, setIsShown] = useState(false);
+
+  return (
+    <>
+      <button onClick={() => setIsShown(true)}>Delete</button>
+      <XDSConfirmationModal
+        isShown={isShown}
+        title="Delete project?"
+        description="This action cannot be undone. All data will be permanently removed."
+        onConfirm={handleDelete}
+        onCancel={() => setIsShown(false)}
+        variant="destructive"
+        confirmLabel="Delete"
+      />
+    </>
+  );
+}
+```
+
+### Async confirm
+
+When `onConfirm` returns a Promise, loading state is managed automatically:
+
+```tsx
+const handleConfirm = async () => {
+  await deleteItem();
+  setIsShown(false);
+};
+
+<XDSConfirmationModal
+  isShown={isShown}
+  title="Remove item?"
+  description="This will remove the item from your list."
+  onConfirm={handleConfirm}
+  onCancel={() => setIsShown(false)}
+/>;
+```
+
+### Rich description
+
+```tsx
+<XDSConfirmationModal
+  isShown={isShown}
+  title="Transfer ownership?"
+  description={
+    <XDSVStack gap="sm">
+      <XDSText>
+        You are transferring ownership to <strong>Jane Doe</strong>.
+      </XDSText>
+      <XDSText color="secondary">
+        You will lose admin access immediately.
+      </XDSText>
+    </XDSVStack>
+  }
+  onConfirm={handleTransfer}
+  onCancel={() => setIsShown(false)}
+/>
+```
+
+## Props
+
+| Prop           | Type                          | Default      | Description                                                    |
+| -------------- | ----------------------------- | ------------ | -------------------------------------------------------------- |
+| `isShown`      | `boolean`                     | —            | Whether the modal is shown                                     |
+| `title`        | `string`                      | —            | Title text at the top of the modal                             |
+| `description`  | `ReactNode`                   | —            | Descriptive content explaining the confirmation                |
+| `onConfirm`    | `() => void \| Promise<void>` | —            | Callback on confirm. Promise return enables auto loading state |
+| `onCancel`     | `() => void`                  | —            | Callback on cancel, Escape key, or close button                |
+| `confirmLabel` | `string`                      | `"Confirm"`  | Label for the confirm button                                   |
+| `cancelLabel`  | `string`                      | `"Cancel"`   | Label for the cancel button                                    |
+| `variant`      | `'standard' \| 'destructive'` | `'standard'` | Controls confirm button appearance                             |
+| `isLoading`    | `boolean`                     | `false`      | External loading state control                                 |
+| `data-testid`  | `string`                      | —            | Test ID for the modal container                                |
+
+## Design Decisions
+
+- **`purpose="form"` hardcoded.** Confirmation modals allow Escape to cancel but block backdrop click. Prevents accidental dismissal of destructive actions.
+- **`role="alertdialog"`** instead of `role="dialog"`. Indicates the dialog requires a user response.
+- **Button order: Cancel left, Confirm right.** Follows platform convention. Destructive action on the right draws attention.
+- **No `forwardRef`.** Composed component — ref access to the underlying dialog is rarely needed. Use XDSDialog directly for that.
+- **`onCancel` naming** instead of `onHide`. Semantically clearer for confirmation flows — it's a user decision, not just closing.

--- a/packages/core/src/ConfirmationModal/XDSConfirmationModal.test.tsx
+++ b/packages/core/src/ConfirmationModal/XDSConfirmationModal.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * @file XDSConfirmationModal.test.tsx
+ * @input Uses vitest, @testing-library/react, userEvent, XDSConfirmationModal
+ * @output Unit tests for XDSConfirmationModal component
+ * @position Testing; validates XDSConfirmationModal.tsx implementation
+ *
+ * SYNC: When XDSConfirmationModal.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, waitFor, act} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {XDSConfirmationModal} from './XDSConfirmationModal';
+
+// Mock showModal and close methods since they're not fully implemented in jsdom
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+describe('XDSConfirmationModal', () => {
+  const defaultProps = {
+    isShown: true,
+    title: 'Confirm action',
+    description: 'Are you sure you want to proceed?',
+    onConfirm: vi.fn(),
+    onCancel: vi.fn(),
+  };
+
+  it('renders title and description', () => {
+    render(<XDSConfirmationModal {...defaultProps} />);
+    expect(screen.getByText('Confirm action')).toBeInTheDocument();
+    expect(
+      screen.getByText('Are you sure you want to proceed?'),
+    ).toBeInTheDocument();
+  });
+
+  it('renders default button labels', () => {
+    render(<XDSConfirmationModal {...defaultProps} />);
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+    expect(screen.getByText('Confirm')).toBeInTheDocument();
+  });
+
+  it('renders custom button labels', () => {
+    render(
+      <XDSConfirmationModal
+        {...defaultProps}
+        confirmLabel="Delete"
+        cancelLabel="Keep"
+      />,
+    );
+    expect(screen.getByText('Keep')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  it('calls onCancel when cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(<XDSConfirmationModal {...defaultProps} onCancel={onCancel} />);
+
+    await user.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onConfirm when confirm button is clicked', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    render(<XDSConfirmationModal {...defaultProps} onConfirm={onConfirm} />);
+
+    await user.click(screen.getByText('Confirm'));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders ReactNode description', () => {
+    render(
+      <XDSConfirmationModal
+        {...defaultProps}
+        description={
+          <div>
+            <strong>Warning:</strong> This is permanent.
+          </div>
+        }
+      />,
+    );
+    expect(screen.getByText('Warning:')).toBeInTheDocument();
+    expect(screen.getByText('This is permanent.')).toBeInTheDocument();
+  });
+
+  it('uses role="alertdialog"', () => {
+    render(<XDSConfirmationModal {...defaultProps} />);
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('has aria-describedby linking to description', () => {
+    render(<XDSConfirmationModal {...defaultProps} />);
+    const dialog = screen.getByRole('alertdialog');
+    const describedBy = dialog.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const descriptionEl = document.getElementById(describedBy!);
+    expect(descriptionEl).toBeInTheDocument();
+    expect(descriptionEl?.textContent).toContain(
+      'Are you sure you want to proceed?',
+    );
+  });
+
+  it('passes data-testid to dialog', () => {
+    render(
+      <XDSConfirmationModal {...defaultProps} data-testid="confirm-modal" />,
+    );
+    expect(screen.getByTestId('confirm-modal')).toBeInTheDocument();
+  });
+
+  describe('async onConfirm', () => {
+    it('manages loading state automatically for Promise-returning onConfirm', async () => {
+      let resolveConfirm: () => void;
+      const onConfirm = vi.fn(
+        () =>
+          new Promise<void>(resolve => {
+            resolveConfirm = resolve;
+          }),
+      );
+
+      render(<XDSConfirmationModal {...defaultProps} onConfirm={onConfirm} />);
+
+      const confirmButton = screen.getByText('Confirm').closest('button')!;
+
+      // Click confirm — should start loading
+      await act(async () => {
+        confirmButton.click();
+      });
+
+      expect(onConfirm).toHaveBeenCalledTimes(1);
+      expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+
+      // Resolve the promise — should stop loading
+      await act(async () => {
+        resolveConfirm!();
+      });
+
+      await waitFor(() => {
+        expect(confirmButton).not.toHaveAttribute('aria-busy', 'true');
+      });
+    });
+
+    it('clears loading state even if onConfirm rejects', async () => {
+      // Suppress expected unhandled rejection
+      const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      const onConfirm = vi.fn(() => Promise.reject(new Error('fail')));
+
+      render(<XDSConfirmationModal {...defaultProps} onConfirm={onConfirm} />);
+
+      const confirmButton = screen.getByText('Confirm').closest('button')!;
+
+      await act(async () => {
+        confirmButton.click();
+        // Wait for the microtask queue to flush
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(confirmButton).not.toHaveAttribute('aria-busy', 'true');
+      });
+
+      spy.mockRestore();
+    });
+  });
+
+  describe('external isLoading', () => {
+    it('shows loading state when isLoading is true', () => {
+      render(<XDSConfirmationModal {...defaultProps} isLoading={true} />);
+
+      const confirmButton = screen.getByText('Confirm').closest('button')!;
+      expect(confirmButton).toHaveAttribute('aria-busy', 'true');
+    });
+
+    it('disables cancel button when loading', () => {
+      render(<XDSConfirmationModal {...defaultProps} isLoading={true} />);
+
+      const cancelButton = screen.getByText('Cancel').closest('button')!;
+      expect(cancelButton).toBeDisabled();
+    });
+  });
+
+  describe('variant', () => {
+    it('renders standard variant by default', () => {
+      render(<XDSConfirmationModal {...defaultProps} />);
+      // Confirm button should exist (primary styling is default)
+      expect(screen.getByText('Confirm')).toBeInTheDocument();
+    });
+
+    it('renders destructive variant', () => {
+      render(<XDSConfirmationModal {...defaultProps} variant="destructive" />);
+      expect(screen.getByText('Confirm')).toBeInTheDocument();
+    });
+  });
+
+  it('does not render when isShown is false', () => {
+    render(<XDSConfirmationModal {...defaultProps} isShown={false} />);
+    const dialog = screen.getByRole('alertdialog', {hidden: true});
+    expect(dialog).not.toHaveAttribute('open');
+  });
+});

--- a/packages/core/src/ConfirmationModal/XDSConfirmationModal.tsx
+++ b/packages/core/src/ConfirmationModal/XDSConfirmationModal.tsx
@@ -1,0 +1,195 @@
+/**
+ * @file XDSConfirmationModal.tsx
+ * @input Uses React, XDSDialog, XDSDialogHeader, XDSLayout, XDSLayoutContent,
+ *        XDSLayoutFooter, XDSButton, XDSText, XDSHStack
+ * @output Exports XDSConfirmationModal component, XDSConfirmationModalProps,
+ *         XDSConfirmationModalVariant types
+ * @position Pre-composed confirm/cancel dialog — the most common dialog pattern.
+ *           Wraps XDSDialog with opinionated defaults for confirmation flows.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/ConfirmationModal/README.md (props table, features)
+ * - /packages/core/src/ConfirmationModal/XDSConfirmationModal.test.tsx (tests)
+ * - /packages/core/src/ConfirmationModal/index.ts (exports if types change)
+ * - /apps/storybook/stories/ConfirmationModal.stories.tsx (storybook stories)
+ */
+
+import {useCallback, useId, useRef, useState, type ReactNode} from 'react';
+import {XDSDialog} from '../Dialog';
+import {XDSDialogHeader} from '../Dialog/XDSDialogHeader';
+import {XDSLayout} from '../Layout/XDSLayout';
+import {XDSLayoutContent} from '../Layout/XDSLayoutContent';
+import {XDSLayoutFooter} from '../Layout/XDSLayoutFooter';
+import {XDSButton} from '../Button';
+import {XDSText} from '../Text/XDSText';
+import {XDSHStack} from '../Stack';
+
+/**
+ * Visual variant for the confirmation modal.
+ * Controls the appearance of the confirm button.
+ */
+export type XDSConfirmationModalVariant = 'standard' | 'destructive';
+
+export interface XDSConfirmationModalProps {
+  /**
+   * Whether the modal is shown.
+   */
+  isShown: boolean;
+
+  /**
+   * Title text displayed at the top of the modal.
+   */
+  title: string;
+
+  /**
+   * Descriptive content explaining what the user is confirming.
+   * Can be a string for simple text or ReactNode for rich content.
+   */
+  description: ReactNode;
+
+  /**
+   * Callback fired when the user confirms the action.
+   * Can return a Promise for async operations (shows loading state automatically).
+   */
+  onConfirm: () => void | Promise<void>;
+
+  /**
+   * Callback fired when the user cancels or dismisses the modal.
+   * Called on cancel button click and Escape key.
+   */
+  onCancel: () => void;
+
+  /**
+   * Label for the confirm button.
+   * @default "Confirm"
+   */
+  confirmLabel?: string;
+
+  /**
+   * Label for the cancel button.
+   * @default "Cancel"
+   */
+  cancelLabel?: string;
+
+  /**
+   * Visual variant controlling the confirm button appearance.
+   * - standard: Primary button styling
+   * - destructive: Red/danger button styling for irreversible actions
+   * @default "standard"
+   */
+  variant?: XDSConfirmationModalVariant;
+
+  /**
+   * Whether the confirm action is in progress.
+   * Disables both buttons and shows a spinner on the confirm button.
+   * Use for external loading state control. When `onConfirm` returns a Promise,
+   * loading state is managed automatically — use this only for complex flows.
+   * @default false
+   */
+  isLoading?: boolean;
+
+  /**
+   * Test ID for the modal container.
+   */
+  'data-testid'?: string;
+}
+
+/**
+ * Pre-composed confirmation dialog for confirm/cancel actions.
+ *
+ * Wraps XDSDialog with `purpose="form"` (Escape cancels, backdrop click blocked)
+ * and provides standard confirm/cancel button layout. Supports async confirm
+ * with automatic loading state.
+ *
+ * @example
+ * ```tsx
+ * <XDSConfirmationModal
+ *   isShown={isShown}
+ *   title="Delete project?"
+ *   description="This action cannot be undone."
+ *   onConfirm={handleDelete}
+ *   onCancel={() => setIsShown(false)}
+ *   variant="destructive"
+ *   confirmLabel="Delete"
+ * />
+ * ```
+ */
+export function XDSConfirmationModal({
+  isShown,
+  title,
+  description,
+  onConfirm,
+  onCancel,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  variant = 'standard',
+  isLoading: externalLoading = false,
+  'data-testid': testId,
+}: XDSConfirmationModalProps) {
+  const [internalLoading, setInternalLoading] = useState(false);
+  const isLoadingState = externalLoading || internalLoading;
+  const descriptionId = useId();
+  const cancelRef = useRef<HTMLButtonElement>(null);
+
+  const handleConfirm = useCallback(() => {
+    const result = onConfirm();
+    if (result instanceof Promise) {
+      setInternalLoading(true);
+      result
+        .catch(() => {
+          // Consumer is responsible for error handling.
+          // We only manage loading state here.
+        })
+        .finally(() => {
+          setInternalLoading(false);
+        });
+    }
+  }, [onConfirm]);
+
+  return (
+    <XDSDialog
+      isShown={isShown}
+      onHide={onCancel}
+      purpose="form"
+      width={440}
+      role="alertdialog"
+      aria-describedby={descriptionId}
+      data-testid={testId}>
+      <XDSLayout
+        header={<XDSDialogHeader title={title} onHide={onCancel} />}
+        content={
+          <XDSLayoutContent>
+            <div id={descriptionId}>
+              {typeof description === 'string' ? (
+                <XDSText type="body">{description}</XDSText>
+              ) : (
+                description
+              )}
+            </div>
+          </XDSLayoutContent>
+        }
+        footer={
+          <XDSLayoutFooter hasDivider>
+            <XDSHStack gap="space2" hAlign="end">
+              <XDSButton
+                ref={cancelRef}
+                label={cancelLabel}
+                variant="secondary"
+                onClick={onCancel}
+                isDisabled={isLoadingState}
+              />
+              <XDSButton
+                label={confirmLabel}
+                variant={variant === 'destructive' ? 'destructive' : 'primary'}
+                onClick={handleConfirm}
+                isLoading={isLoadingState}
+              />
+            </XDSHStack>
+          </XDSLayoutFooter>
+        }
+      />
+    </XDSDialog>
+  );
+}
+
+XDSConfirmationModal.displayName = 'XDSConfirmationModal';

--- a/packages/core/src/ConfirmationModal/index.ts
+++ b/packages/core/src/ConfirmationModal/index.ts
@@ -1,0 +1,14 @@
+/**
+ * @file index.ts
+ * @input Imports XDSConfirmationModal component and types
+ * @output Exports XDSConfirmationModal and related types
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/ConfirmationModal/README.md
+ */
+
+export {XDSConfirmationModal} from './XDSConfirmationModal';
+export type {
+  XDSConfirmationModalProps,
+  XDSConfirmationModalVariant,
+} from './XDSConfirmationModal';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -43,6 +43,7 @@ export * from './TimeInput';
 export * from './NumberInput';
 export * from './Table';
 export * from './Token';
+export * from './ConfirmationModal';
 export * from './Dialog';
 export * from './DropdownMenu';
 export * from './TopNav';


### PR DESCRIPTION
## Summary

Pre-composed confirmation dialog for confirm/cancel actions. Wraps XDSDialog with `purpose="form"` and provides the most common dialog pattern as a single component. 3,752 internal usages justify a dedicated component over manual composition.

## API

```tsx
// Basic confirmation
<XDSConfirmationModal
  isShown={isShown}
  title="Save changes?"
  description="Your unsaved changes will be applied."
  onConfirm={handleSave}
  onCancel={() => setIsShown(false)}
/>

// Destructive with custom labels
<XDSConfirmationModal
  isShown={isShown}
  title="Delete project?"
  description="This action cannot be undone."
  onConfirm={handleDelete}
  onCancel={() => setIsShown(false)}
  variant="destructive"
  confirmLabel="Delete"
  cancelLabel="Keep"
/>

// Async confirm — loading state managed automatically
const handleConfirm = async () => {
  await deleteItem();
  setIsShown(false);
};

<XDSConfirmationModal
  isShown={isShown}
  title="Remove item?"
  description="This will remove the item from your list."
  onConfirm={handleConfirm}
  onCancel={() => setIsShown(false)}
/>

// Rich description with ReactNode
<XDSConfirmationModal
  isShown={isShown}
  title="Transfer ownership?"
  description={
    <XDSVStack gap="sm">
      <XDSText>Transferring to <strong>Jane Doe</strong>.</XDSText>
      <XDSText color="secondary">You will lose admin access immediately.</XDSText>
    </XDSVStack>
  }
  onConfirm={handleTransfer}
  onCancel={() => setIsShown(false)}
/>
```

## Design decisions

- **`purpose="form"` hardcoded.** Escape cancels, backdrop click blocked. Prevents accidental dismissal of destructive actions.
- **`role="alertdialog"`.** Indicates the dialog requires a user response, not just informational.
- **Async `onConfirm` with auto loading.** Most confirmations involve async work. Returning a Promise is ergonomic — no separate `isLoading` state needed for simple cases. Rejections are caught internally so loading state always clears.
- **`onCancel` naming** instead of `onHide`. Semantically clearer — it is a user decision, not just closing.
- **Button order: Cancel left, Confirm right.** Platform convention. Destructive action on the right draws attention.
- **No `forwardRef`.** Composed component — consumers who need ref access should use XDSDialog directly.
- **Separate `isLoading` prop alongside Promise support.** Allows external loading state control for complex flows where auto-management is not sufficient.

## What's included

- `XDSConfirmationModal` component — composed from XDSDialog, XDSLayout, XDSButton, XDSText
- 16 tests covering render, interaction, async loading, rejection recovery, accessibility, variants
- 5 stories: Default, Destructive, AsyncConfirm, RichDescription, ExternalLoading
- README with props table, usage examples, and design decisions

Closes #172

---
*Crafted with care by Navi (night manager shift)*