### PR TITLE
fix(topnav): mega menu backdrop no longer covers nav items

### DIFF
--- a/packages/core/src/TopNav/XDSTopNav.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.test.tsx
@@ -133,6 +133,14 @@ describe('XDSTopNav', () => {
     render(<XDSTopNav ref={ref} />);
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
   });
+
+  it('creates a stacking context above mega menu backdrop', () => {
+    render(<XDSTopNav label="Main navigation" />);
+    const nav = screen.getByRole('navigation');
+    expect(nav).toHaveStyle({position: 'relative'});
+    const zIndex = Number(getComputedStyle(nav).zIndex);
+    expect(zIndex).toBeGreaterThanOrEqual(100);
+  });
 });
 
 describe('XDSTopNavTitle', () => {

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -27,6 +27,9 @@ import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
  */
 const styles = stylex.create({
   base: {
+    // Creates a stacking context above MegaMenu backdrop (z-index: 99)
+    position: 'relative',
+    zIndex: 100,
     alignItems: 'center',
     width: '100%',
     height: spacingVars['--spacing-12'],


### PR DESCRIPTION
## Problem

The `XDSTopNavMegaMenu` backdrop div (`z-index: 99`) visually covers the nav bar items when the mega menu opens. The backdrop creates a unified card appearance by overlaying the entire positioned ancestor, but the nav items have no z-index and render behind it — making them invisible.

## Fix

Added `position: relative` and `zIndex: 100` to the `XDSTopNav` base style. This creates a stacking context for the nav bar so its content renders above the backdrop (99) while the mega menu panel (100, later in DOM order) still paints on top.

## Test Plan

- Added unit test verifying the nav element has `position: relative` and `z-index >= 100`
- All 1056 existing tests pass
- Lint clean, build clean