### PR TITLE
fix(topnav): move mega menu stacking context to nav sections

### DIFF
--- a/packages/core/src/TopNav/XDSTopNav.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.test.tsx
@@ -134,12 +134,23 @@ describe('XDSTopNav', () => {
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
   });
 
-  it('creates a stacking context above mega menu backdrop', () => {
-    render(<XDSTopNav label="Main navigation" />);
+  it('creates a stacking context on content sections above mega menu backdrop', () => {
+    render(
+      <XDSTopNav
+        label="Main navigation"
+        startContent={<span>Start</span>}
+        endContent={<span>End</span>}
+      />,
+    );
     const nav = screen.getByRole('navigation');
-    expect(nav).toHaveStyle({position: 'relative'});
-    const zIndex = Number(getComputedStyle(nav).zIndex);
-    expect(zIndex).toBeGreaterThanOrEqual(100);
+    // Nav itself should NOT have position: relative (backdrop needs outer wrapper as ancestor)
+    expect(nav).not.toHaveStyle({position: 'relative'});
+    // Content section divs should have position: relative for stacking context
+    const sections = nav.querySelectorAll(':scope > div');
+    expect(sections.length).toBeGreaterThanOrEqual(1);
+    sections.forEach(section => {
+      expect(section).toHaveStyle({position: 'relative'});
+    });
   });
 });
 

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -27,9 +27,6 @@ import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
  */
 const styles = stylex.create({
   base: {
-    // Creates a stacking context above MegaMenu backdrop (z-index: 99)
-    position: 'relative',
-    zIndex: 100,
     alignItems: 'center',
     width: '100%',
     height: spacingVars['--spacing-12'],
@@ -47,6 +44,9 @@ const styles = stylex.create({
     gridTemplateColumns: '1fr auto 1fr',
   },
   leftSection: {
+    // Stacking context above MegaMenu backdrop (z-index: 99)
+    position: 'relative',
+    zIndex: 100,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-4'],
@@ -64,18 +64,24 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1'],
   },
   centerContent: {
+    position: 'relative',
+    zIndex: 100,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     gap: spacingVars['--spacing-1'],
   },
   rightSection: {
+    position: 'relative',
+    zIndex: 100,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
     gap: spacingVars['--spacing-2'],
   },
   endContent: {
+    position: 'relative',
+    zIndex: 100,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],


### PR DESCRIPTION
## Problem

PR #377 added `position: relative` + `zIndex: 100` to the `<nav>` element to fix the mega menu backdrop covering nav items. This was incorrect — it made the `<nav>` the positioned ancestor for the backdrop, changing the backdrop's coverage area and breaking the unified card visual.

## Fix

Moved the stacking context from the `<nav>` element to its content sections (`leftSection`, `centerContent`, `rightSection`, `endContent`). This way:
- The backdrop still positions relative to the outer wrapper (preserving the unified card effect)
- Each content section creates its own stacking context above the backdrop (z-index 99)
- Nav items remain visible and interactive when the mega menu is open

## Test Plan

- Updated unit test to verify content sections have `position: relative` (not the nav element)
- All 1056 tests pass
- Build and lint clean