### PR TITLE
feat(topnav): unified card appearance for mega menu without backdrop overlay

### DIFF
--- a/apps/sandbox/src/app/pages/mega-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/mega-menu/page.tsx
@@ -21,14 +21,21 @@ const styles = stylex.create({
     position: 'relative',
     borderRadius: 12,
     overflow: 'visible',
+    backgroundColor: 'var(--color-surface, #fff)',
     boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)',
-    transitionProperty: 'box-shadow',
+    transitionProperty: 'border-radius, box-shadow',
     transitionDuration: '0.2s',
+    transitionTimingFunction: 'ease-out',
   },
-  // Hide wrapper shadow when mega menu is open so the backdrop's
-  // unified card shadow takes over seamlessly.
+  // When the mega menu opens, the wrapper becomes the top half of the
+  // unified card: drop the bottom radius so it flows seamlessly into the
+  // panel, and remove the wrapper shadow (the panel provides its own
+  // shadow that visually wraps the dropdown area).
   navWrapperMenuOpen: {
-    boxShadow: 'none',
+    borderBottomLeftRadius: 0,
+    borderBottomRightRadius: 0,
+    boxShadow:
+      '0 -1px 3px rgba(0, 0, 0, 0.06), -1px 0 3px rgba(0, 0, 0, 0.04), 1px 0 3px rgba(0, 0, 0, 0.04)',
   },
 });
 

--- a/packages/core/src/TopNav/XDSTopNav.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.test.tsx
@@ -134,7 +134,7 @@ describe('XDSTopNav', () => {
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
   });
 
-  it('creates a stacking context on content sections above mega menu backdrop', () => {
+  it('does not create a stacking context on nav element', () => {
     render(
       <XDSTopNav
         label="Main navigation"
@@ -143,14 +143,9 @@ describe('XDSTopNav', () => {
       />,
     );
     const nav = screen.getByRole('navigation');
-    // Nav itself should NOT have position: relative (backdrop needs outer wrapper as ancestor)
+    // Nav itself should NOT have position: relative — the wrapper provides
+    // positioning context for the mega menu panel.
     expect(nav).not.toHaveStyle({position: 'relative'});
-    // Content section divs should have position: relative for stacking context
-    const sections = nav.querySelectorAll(':scope > div');
-    expect(sections.length).toBeGreaterThanOrEqual(1);
-    sections.forEach(section => {
-      expect(section).toHaveStyle({position: 'relative'});
-    });
   });
 });
 

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -44,9 +44,6 @@ const styles = stylex.create({
     gridTemplateColumns: '1fr auto 1fr',
   },
   leftSection: {
-    // Stacking context above MegaMenu backdrop (z-index: 99)
-    position: 'relative',
-    zIndex: 100,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-4'],
@@ -64,24 +61,18 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1'],
   },
   centerContent: {
-    position: 'relative',
-    zIndex: 100,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     gap: spacingVars['--spacing-1'],
   },
   rightSection: {
-    position: 'relative',
-    zIndex: 100,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-end',
     gap: spacingVars['--spacing-2'],
   },
   endContent: {
-    position: 'relative',
-    zIndex: 100,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -21,7 +21,6 @@ import {
   textSizeVars,
   fontWeightVars,
   lineHeightVars,
-  elevationVars,
 } from '../theme/tokens.stylex';
 
 // =============================================================================
@@ -79,28 +78,6 @@ const styles = stylex.create({
   chevronOpen: {
     transform: 'rotate(180deg)',
   },
-  // Backdrop covers the entire positioned ancestor (nav + panel area).
-  // It provides the unified card appearance: shared shadow, rounded corners,
-  // and surface background so the nav bar and panel look like one popover.
-  backdrop: {
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    zIndex: 99,
-    borderRadius: radiusVars['--radius-container'],
-    backgroundColor: colorVars['--color-surface'],
-    boxShadow: elevationVars['--elevation-hover'],
-    opacity: 0,
-    transitionProperty: 'opacity',
-    transitionDuration: '0.2s',
-    transitionTimingFunction: 'ease-out',
-    pointerEvents: 'none',
-  },
-  backdropOpen: {
-    opacity: 1,
-  },
   panel: {
     position: 'absolute',
     top: '100%',
@@ -108,11 +85,16 @@ const styles = stylex.create({
     right: 0,
     zIndex: 100,
     backgroundColor: colorVars['--color-surface'],
-    // No separate shadow or border — the backdrop provides the unified
-    // card shadow, and the panel flows seamlessly from the nav bar.
+    // Top border provides a subtle divider between the nav bar and panel
+    // while keeping them visually connected as one card.
+    borderTop: `1px solid ${colorVars['--color-divider']}`,
+    borderTopLeftRadius: 0,
+    borderTopRightRadius: 0,
     borderBottomLeftRadius: radiusVars['--radius-container'],
     borderBottomRightRadius: radiusVars['--radius-container'],
-    boxShadow: elevationVars['--elevation-hover'],
+    // Shadow wraps the panel; the wrapper handles the nav bar's card chrome.
+    // Together they create a unified card appearance without a backdrop overlay.
+    boxShadow: `0 8px 24px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.08)`,
     overflow: 'hidden',
     opacity: 0,
     transform: 'translateY(-4px)',
@@ -458,12 +440,6 @@ export function XDSTopNavMegaMenu({
           <ChevronDown />
         </span>
       </button>
-      {/* Backdrop: covers the entire positioned ancestor to create a unified
-          card appearance (shared shadow + rounded corners) for nav + panel */}
-      <div
-        aria-hidden="true"
-        {...stylex.props(styles.backdrop, isOpen && styles.backdropOpen)}
-      />
       <div
         role="menu"
         aria-label={label}


### PR DESCRIPTION
## Summary

Removes the backdrop div from `XDSTopNavMegaMenu` and replaces it with a coordinated styling approach that creates the same unified card appearance without covering nav items.

### Problem

The backdrop div (introduced for the unified card look) covered the entire positioned ancestor at `z-index: 99`, which required all nav sections to have `z-index: 100` stacking contexts to remain interactive. This was fragile and created layering complexity.

### Solution

Instead of an overlay, the unified card look is achieved by coordinating styles between the wrapper container and the dropdown panel:

1. **Wrapper** (user code, via `onOpenChange`): adjusts `border-radius` and `box-shadow` when the menu opens — drops bottom radius so the nav bar flows seamlessly into the panel
2. **Panel**: has a subtle top border (divider), no top radius, bottom rounded corners, and its own shadow — visually connects to the wrapper above
3. **TopNav sections**: removed `position: relative` + `z-index: 100` stacking context hacks (no longer needed)

### Changes

| File | What changed |
|------|-------------|
| `XDSTopNavMegaMenu.tsx` | Removed backdrop div and its styles. Panel now has top border, no top radius, explicit shadow. Removed `elevationVars` import. |
| `XDSTopNav.tsx` | Removed `position: relative` and `z-index: 100` from section wrappers — no longer needed without backdrop. |
| `XDSTopNav.test.tsx` | Updated stacking context test to match simplified behavior. |
| `mega-menu/page.tsx` | Enhanced wrapper styles: transitions `border-radius` when menu opens, uses directional shadow to maintain top/side card chrome while panel provides bottom shadow. |

## Test Plan
- ✅ Build passes
- ✅ All 1056 tests pass
- ✅ Lint passes (0 errors)
- Nav items remain fully visible and interactive (no overlay)
- Unified card appearance maintained through coordinated wrapper + panel styles