### PR TITLE
feat(AppShell): add wash-gray background variant

### DIFF
--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -458,6 +458,21 @@ export const ContentOnly: Story = {
 };
 
 /**
+ * Wash-gray background — uses a neutral translucent gray instead of the
+ * blue-tinted wash. Creates a softer, more neutral page feel.
+ */
+export const WashGrayBackground: Story = {
+  render: () => (
+    <XDSAppShell
+      background="wash-gray"
+      topNav={<AppTopNav />}
+      sideNav={<SideNavWithoutHeader />}>
+      <MockContent />
+    </XDSAppShell>
+  ),
+};
+
+/**
  * Banner with TopNav + SideNav. Shows how the banner sits between
  * the TopNav and the content/sidenav area.
  */

--- a/packages/core/src/AppShell/README.md
+++ b/packages/core/src/AppShell/README.md
@@ -141,20 +141,21 @@ For landing pages or simple apps that don't need secondary navigation.
 
 ## Props
 
-| Prop                        | Type                             | Default  | Description                                 |
-| --------------------------- | -------------------------------- | -------- | ------------------------------------------- |
-| `children`                  | `ReactNode`                      | —        | Main content area (rendered as `<main>`)    |
-| `topNav`                    | `ReactNode`                      | —        | Top navigation slot (typically XDSTopNav)   |
-| `sideNav`                   | `ReactNode`                      | —        | Side navigation slot (typically XDSSideNav) |
-| `banner`                    | `ReactNode`                      | —        | Banner slot for system-wide announcements   |
-| `height`                    | `'fill' \| 'auto'`               | `'fill'` | Height behavior                             |
-| `isSideNavCollapsed`        | `boolean`                        | —        | Whether sideNav is collapsed (controlled)   |
-| `initialIsSideNavCollapsed` | `boolean`                        | `false`  | Initial collapsed state (uncontrolled)      |
-| `onSideNavCollapsedChange`  | `(isCollapsed: boolean) => void` | —        | Collapse change callback                    |
-| `sideNavBreakpoint`         | `'sm' \| 'md' \| 'lg' \| 'none'` | `'md'`   | Breakpoint for auto-collapse                |
-| `sideNavWidth`              | `number`                         | `260`    | SideNav width in pixels                     |
-| `xstyle`                    | `StyleXStyles`                   | —        | StyleX overrides                            |
-| `data-testid`               | `string`                         | —        | Test ID                                     |
+| Prop                        | Type                                 | Default     | Description                                 |
+| --------------------------- | ------------------------------------ | ----------- | ------------------------------------------- |
+| `background`                | `'wash' \| 'wash-gray' \| 'surface'` | `'surface'` | Background color of the shell               |
+| `children`                  | `ReactNode`                          | —           | Main content area (rendered as `<main>`)    |
+| `topNav`                    | `ReactNode`                          | —           | Top navigation slot (typically XDSTopNav)   |
+| `sideNav`                   | `ReactNode`                          | —           | Side navigation slot (typically XDSSideNav) |
+| `banner`                    | `ReactNode`                          | —           | Banner slot for system-wide announcements   |
+| `height`                    | `'fill' \| 'auto'`                   | `'fill'`    | Height behavior                             |
+| `isSideNavCollapsed`        | `boolean`                            | —           | Whether sideNav is collapsed (controlled)   |
+| `initialIsSideNavCollapsed` | `boolean`                            | `false`     | Initial collapsed state (uncontrolled)      |
+| `onSideNavCollapsedChange`  | `(isCollapsed: boolean) => void`     | —           | Collapse change callback                    |
+| `sideNavBreakpoint`         | `'sm' \| 'md' \| 'lg' \| 'none'`     | `'md'`      | Breakpoint for auto-collapse                |
+| `sideNavWidth`              | `number`                             | `260`       | SideNav width in pixels                     |
+| `xstyle`                    | `StyleXStyles`                       | —           | StyleX overrides                            |
+| `data-testid`               | `string`                             | —           | Test ID                                     |
 
 ## Height Modes
 

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -139,6 +139,15 @@ describe('XDSAppShell', () => {
     expect(screen.getByTestId('my-shell')).toBeInTheDocument();
   });
 
+  it('renders with wash-gray background', () => {
+    render(
+      <XDSAppShell background="wash-gray" data-testid="shell">
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+    expect(screen.getByTestId('shell')).toBeInTheDocument();
+  });
+
   // ===========================================================================
   // Skip-to-content link
   // ===========================================================================

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -60,11 +60,12 @@ export type XDSAppShellBreakpoint = 'sm' | 'md' | 'lg' | 'none';
 export interface XDSAppShellProps {
   /**
    * Background color of the shell.
-   * - `wash`: Page-level background — subtle gray in light, near-black in dark
+   * - `wash`: Page-level background — subtle blue-gray in light, near-black in dark
+   * - `wash-gray`: Neutral gray wash — translucent gray for a softer, neutral feel
    * - `surface`: Card/panel background — white in light, dark gray in dark
    * @default 'surface'
    */
-  background?: 'wash' | 'surface';
+  background?: 'wash' | 'wash-gray' | 'surface';
 
   /**
    * Optional banner slot for system-wide announcements.
@@ -146,6 +147,9 @@ const styles = stylex.create({
   },
   rootBgWash: {
     backgroundColor: colorVars['--color-wash'],
+  },
+  rootBgWashGray: {
+    backgroundColor: colorVars['--color-gray-background'],
   },
   rootBgSurface: {
     backgroundColor: colorVars['--color-surface'],
@@ -538,7 +542,9 @@ export const XDSAppShell = forwardRef<HTMLDivElement, XDSAppShellProps>(
         data-testid={dataTestId}
         {...stylex.props(
           styles.root,
-          background === 'wash' ? styles.rootBgWash : styles.rootBgSurface,
+          background === 'wash' && styles.rootBgWash,
+          background === 'wash-gray' && styles.rootBgWashGray,
+          background === 'surface' && styles.rootBgSurface,
           isFill ? styles.rootFill : styles.rootAuto,
           xstyle,
         )}>


### PR DESCRIPTION
Adds a new \`wash-gray\` background variant to \`XDSAppShell\` that uses the \`--color-gray-background\` token for a neutral, translucent gray feel.

## Changes

- **\`XDSAppShell.tsx\`** — Added \`'wash-gray'\` to the \`background\` prop union type, added \`rootBgWashGray\` style using \`--color-gray-background\`, updated render logic
- **\`XDSAppShell.test.tsx\`** — Added test for \`wash-gray\` background rendering
- **\`AppShell.stories.tsx\`** — Added \`WashGrayBackground\` story
- **\`README.md\`** — Documented the \`background\` prop (was previously missing from the props table)

## Usage

\`\`\`tsx
<XDSAppShell background="wash-gray" topNav={...} sideNav={...}>
  <Content />
</XDSAppShell>
\`\`\`

## Token Reference

| Variant | Token | Light | Dark |
|---------|-------|-------|------|
| \`surface\` | \`--color-surface\` | \`#FFFFFF\` | \`#1F1F22\` |
| \`wash\` | \`--color-wash\` | \`#F1F4F7\` | \`#111112\` |
| \`wash-gray\` | \`--color-gray-background\` | \`#0A131733\` | \`#666A724C\` |

---
*Crafted with care by Navi*