### PR TITLE
feat(NavIcon): update sizes and add icon-only variant

### DIFF
--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -92,7 +92,7 @@ function AppTopNav({endContent}: {endContent?: React.ReactNode}) {
         <XDSTopNavTitle
           title="Acme App"
           logo={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
         />
       }
@@ -108,7 +108,7 @@ function AppTopNav({endContent}: {endContent?: React.ReactNode}) {
           <XDSButton
             label="Profile"
             variant="ghost"
-            icon={<UserCircleIcon style={{width: 16, height: 16}} />}
+            icon={<UserCircleIcon />}
           />
         )
       }
@@ -315,12 +315,12 @@ export const FullFeatured: Story = {
               <XDSButton
                 label="Notifications"
                 variant="ghost"
-                icon={<BellIcon style={{width: 16, height: 16}} />}
+                icon={<BellIcon />}
               />
               <XDSButton
                 label="Profile"
                 variant="ghost"
-                icon={<UserCircleIcon style={{width: 16, height: 16}} />}
+                icon={<UserCircleIcon />}
               />
             </>
           }>
@@ -430,7 +430,7 @@ export const ControlledCollapse: Story = {
               <XDSButton
                 label="Toggle sidebar"
                 variant="ghost"
-                icon={<Bars3Icon style={{width: 16, height: 16}} />}
+                icon={<Bars3Icon />}
                 onClick={() => setCollapsed(!collapsed)}
               />
             }

--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -60,7 +60,7 @@ export const Default: Story = {
       header={
         <XDSSideNavHeader
           icon={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
           title="My App"
           titleHref="/"
@@ -142,7 +142,7 @@ export const WithHeaderMenu: Story = {
       header={
         <XDSSideNavHeader
           icon={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
           title="Product Name"
           subtitle="Business Account"
@@ -204,7 +204,7 @@ export const SuiteHeader: Story = {
       header={
         <XDSSideNavHeader
           icon={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
           supertitle="Suite Name"
           supertitleHref="/suite"
@@ -261,7 +261,7 @@ export const NestedItems: Story = {
       header={
         <XDSSideNavHeader
           icon={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
           title="My App"
         />
@@ -297,7 +297,7 @@ export const WithFooter: Story = {
       header={
         <XDSSideNavHeader
           icon={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
           title="My App"
         />
@@ -342,7 +342,7 @@ export const DisabledItem: Story = {
       header={
         <XDSSideNavHeader
           icon={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
           title="My App"
         />
@@ -376,7 +376,7 @@ export const HiddenSectionHeader: Story = {
       header={
         <XDSSideNavHeader
           icon={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
           title="My App"
         />

--- a/apps/storybook/stories/TopNav.stories.tsx
+++ b/apps/storybook/stories/TopNav.stories.tsx
@@ -47,17 +47,17 @@ export const Default: Story = {
         <XDSButton
           label="Search"
           variant="ghost"
-          icon={<MagnifyingGlassIcon style={{width: 16, height: 16}} />}
+          icon={<MagnifyingGlassIcon />}
         />
         <XDSButton
           label="Notifications"
           variant="ghost"
-          icon={<BellIcon style={{width: 16, height: 16}} />}
+          icon={<BellIcon />}
         />
         <XDSButton
           label="Profile"
           variant="ghost"
-          icon={<UserCircleIcon style={{width: 16, height: 16}} />}
+          icon={<UserCircleIcon />}
         />
       </>
     ),
@@ -71,7 +71,7 @@ export const WithLogo: Story = {
       <XDSTopNavTitle
         title="Dashboard"
         logo={
-          <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+          <XDSNavIcon icon={<CubeIcon />} />
         }
         href="#"
       />
@@ -87,7 +87,7 @@ export const WithLogo: Story = {
       <XDSButton
         label="Profile"
         variant="ghost"
-        icon={<UserCircleIcon style={{width: 16, height: 16}} />}
+        icon={<UserCircleIcon />}
       />
     ),
   },
@@ -100,7 +100,7 @@ export const TitleOnly: Story = {
       <XDSTopNavTitle
         title="Simple App"
         logo={
-          <XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />
+          <XDSNavIcon icon={<HomeIcon />} />
         }
       />
     ),
@@ -121,7 +121,7 @@ export const NavItemStates: Story = {
           <XDSTopNavItem
             label="With Icon"
             href="#"
-            icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
+            icon={<Cog6ToothIcon />}
           />
         </>
       }
@@ -137,7 +137,7 @@ export const CenteredNavigation: Story = {
         <XDSTopNavTitle
           title="My App"
           logo={
-            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+            <XDSNavIcon icon={<CubeIcon />} />
           }
           href="#"
         />
@@ -154,12 +154,12 @@ export const CenteredNavigation: Story = {
           <XDSButton
             label="Search"
             variant="ghost"
-            icon={<MagnifyingGlassIcon style={{width: 16, height: 16}} />}
+            icon={<MagnifyingGlassIcon />}
           />
           <XDSButton
             label="Profile"
             variant="ghost"
-            icon={<UserCircleIcon style={{width: 16, height: 16}} />}
+            icon={<UserCircleIcon />}
           />
         </>
       }
@@ -176,7 +176,7 @@ export const CenteredWithStartContent: Story = {
           title="Dashboard"
           logo={
             <XDSNavIcon
-              icon={<ChartBarIcon style={{width: 16, height: 16}} />}
+              icon={<ChartBarIcon />}
             />
           }
           href="#"
@@ -186,7 +186,7 @@ export const CenteredWithStartContent: Story = {
         <XDSTopNavItem
           label="Back"
           href="#"
-          icon={<HomeIcon style={{width: 16, height: 16}} />}
+          icon={<HomeIcon />}
         />
       }
       centerContent={
@@ -200,7 +200,7 @@ export const CenteredWithStartContent: Story = {
         <XDSButton
           label="Profile"
           variant="ghost"
-          icon={<UserCircleIcon style={{width: 16, height: 16}} />}
+          icon={<UserCircleIcon />}
         />
       }
     />
@@ -214,7 +214,7 @@ export const CenterContentWithoutEnd: Story = {
       <XDSTopNavTitle
         title="My App"
         logo={
-          <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+          <XDSNavIcon icon={<CubeIcon />} />
         }
         href="#"
       />
@@ -237,7 +237,7 @@ export const FullExample: Story = {
           title="Enterprise Dashboard"
           logo={
             <XDSNavIcon
-              icon={<ChartBarIcon style={{width: 16, height: 16}} />}
+              icon={<ChartBarIcon />}
             />
           }
           href="#"
@@ -249,22 +249,22 @@ export const FullExample: Story = {
             label="Dashboard"
             href="#"
             isSelected
-            icon={<HomeIcon style={{width: 16, height: 16}} />}
+            icon={<HomeIcon />}
           />
           <XDSTopNavItem
             label="Reports"
             href="#"
-            icon={<DocumentTextIcon style={{width: 16, height: 16}} />}
+            icon={<DocumentTextIcon />}
           />
           <XDSTopNavItem
             label="Analytics"
             href="#"
-            icon={<ChartBarIcon style={{width: 16, height: 16}} />}
+            icon={<ChartBarIcon />}
           />
           <XDSTopNavItem
             label="Settings"
             href="#"
-            icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
+            icon={<Cog6ToothIcon />}
           />
         </>
       }
@@ -273,12 +273,12 @@ export const FullExample: Story = {
           <XDSButton
             label="Search"
             variant="ghost"
-            icon={<MagnifyingGlassIcon style={{width: 16, height: 16}} />}
+            icon={<MagnifyingGlassIcon />}
           />
           <XDSButton
             label="Notifications"
             variant="ghost"
-            icon={<BellIcon style={{width: 16, height: 16}} />}
+            icon={<BellIcon />}
           />
           <XDSButton label="Upgrade" variant="primary" />
         </>

--- a/apps/storybook/stories/TopNav.stories.tsx
+++ b/apps/storybook/stories/TopNav.stories.tsx
@@ -93,6 +93,39 @@ export const WithLogo: Story = {
   },
 };
 
+/**
+ * Icon-only logo — no circular background. Uses primary icon color.
+ * Lighter feel for apps that don't need the accent circle.
+ */
+export const WithIconOnlyLogo: Story = {
+  args: {
+    label: 'Main navigation',
+    title: (
+      <XDSTopNavTitle
+        title="Dashboard"
+        logo={
+          <XDSNavIcon icon={<CubeIcon />} variant="icon" />
+        }
+        href="#"
+      />
+    ),
+    startContent: (
+      <>
+        <XDSTopNavItem label="Overview" href="#" isSelected />
+        <XDSTopNavItem label="Analytics" href="#" />
+        <XDSTopNavItem label="Reports" href="#" />
+      </>
+    ),
+    endContent: (
+      <XDSButton
+        label="Profile"
+        variant="ghost"
+        icon={<UserCircleIcon />}
+      />
+    ),
+  },
+};
+
 export const TitleOnly: Story = {
   args: {
     label: 'Main navigation',

--- a/packages/core/src/NavIcon/README.md
+++ b/packages/core/src/NavIcon/README.md
@@ -1,14 +1,14 @@
 # /packages/core/src/NavIcon
 
-Circular icon container for navigation headers.
+Icon container for navigation headers with circle and icon-only variants.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
 ## Features
 
 - **Shared** — used in both XDSTopNavTitle and XDSPageNavHeader
-- **Accent background** — uses `--color-accent` with `--color-icon-on-media` contrast
-- **Fixed size** — renders at the medium (`--size-md`) design token size
+- **Two variants** — `circle` (36px accent background with 24px icon) and `icon` (24px icon only)
+- **Auto-sized icons** — icons are automatically constrained to 24×24px
 
 ## Usage
 
@@ -16,35 +16,36 @@ Circular icon container for navigation headers.
 import {XDSNavIcon} from '@xds/core/NavIcon';
 import {CubeIcon} from '@heroicons/react/24/solid';
 
-// In top navigation
+// Circle variant (default) — 36px accent circle with 24px icon
 <XDSTopNavTitle
   title="My App"
-  logo={<XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />}
+  logo={<XDSNavIcon icon={<CubeIcon />} />}
 />
 
-// In side navigation
-<XDSPageNavHeader
-  icon={<XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />}
+// Icon-only variant — 24px icon, no background
+<XDSTopNavTitle
   title="My App"
+  logo={<XDSNavIcon icon={<CubeIcon />} variant="icon" />}
 />
 ```
 
 ## Components
 
-- **XDSNavIcon** — Circular icon container with accent background
+- **XDSNavIcon** — Icon container with circle or icon-only presentation
 
 ## Props
 
 ### XDSNavIcon
 
-| Prop   | Type        | Default | Description             |
-| ------ | ----------- | ------- | ----------------------- |
-| `icon` | `ReactNode` | —       | Icon element (required) |
+| Prop      | Type                   | Default    | Description                                          |
+| --------- | ---------------------- | ---------- | ---------------------------------------------------- |
+| `icon`    | `ReactNode`            | —          | Icon element (required). Auto-sized to 24×24px.      |
+| `variant` | `'circle' \| 'icon'`   | `'circle'` | `circle`: 36px accent background. `icon`: icon only. |
 
 ## Files
 
 | File                  | Role  | Purpose                     |
 | --------------------- | ----- | --------------------------- |
 | `index.ts`            | Entry | Exports component and types |
-| `XDSNavIcon.tsx`      | Core  | Circular icon container     |
+| `XDSNavIcon.tsx`      | Core  | Icon container component    |
 | `XDSNavIcon.test.tsx` | Test  | Unit tests                  |

--- a/packages/core/src/NavIcon/XDSNavIcon.test.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.test.tsx
@@ -27,4 +27,23 @@ describe('XDSNavIcon', () => {
     render(<XDSNavIcon icon={<span>Icon</span>} data-testid="nav-icon" />);
     expect(screen.getByTestId('nav-icon')).toBeInTheDocument();
   });
+
+  it('defaults to circle variant', () => {
+    render(
+      <XDSNavIcon icon={<span>Icon</span>} data-testid="nav-icon" />,
+    );
+    expect(screen.getByTestId('nav-icon')).toBeInTheDocument();
+  });
+
+  it('renders with icon variant', () => {
+    render(
+      <XDSNavIcon
+        icon={<span data-testid="icon">Icon</span>}
+        variant="icon"
+        data-testid="nav-icon"
+      />,
+    );
+    expect(screen.getByTestId('nav-icon')).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
 });

--- a/packages/core/src/NavIcon/XDSNavIcon.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.tsx
@@ -2,7 +2,8 @@
  * @file XDSNavIcon.tsx
  * @input Uses React forwardRef, HTMLAttributes, ReactNode
  * @output Exports XDSNavIcon component and XDSNavIconProps
- * @position Shared circular icon container for navigation headers (TopNav, PageNav)
+ * @position Shared icon container for navigation headers (TopNav, PageNav).
+ *   Supports a circular accent background variant and an icon-only variant.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/NavIcon/README.md
@@ -16,62 +17,101 @@ import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, sizeVars} from '../theme/tokens.stylex';
 
-/**
- * NavIcon styles
- */
+// =============================================================================
+// Constants
+// =============================================================================
+
+const ICON_SIZE = 24;
+
+// =============================================================================
+// Styles
+// =============================================================================
+
 const styles = stylex.create({
   base: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
+    flexShrink: 0,
+  },
+  circle: {
     borderRadius: '50%',
     backgroundColor: colorVars['--color-accent'],
     color: colorVars['--color-icon-on-media'],
-    flexShrink: 0,
-    width: sizeVars['--size-md'],
-    height: sizeVars['--size-md'],
+    width: sizeVars['--size-lg'],
+    height: sizeVars['--size-lg'],
+  },
+  icon: {
+    color: colorVars['--color-icon-primary'],
+    width: ICON_SIZE,
+    height: ICON_SIZE,
+  },
+  iconInner: {
+    width: ICON_SIZE,
+    height: ICON_SIZE,
   },
 });
+
+// =============================================================================
+// Types
+// =============================================================================
 
 export interface XDSNavIconProps extends Omit<
   HTMLAttributes<HTMLSpanElement>,
   'style' | 'className'
 > {
   /**
-   * The icon element to render inside the circular background.
-   * Should be an XDSIcon or similar icon component.
+   * The icon element to render.
+   * The icon is automatically sized to 24\u00d724px.
    */
   icon: ReactNode;
+
+  /**
+   * Visual variant.
+   * - `circle`: 36px accent-colored circle with 24px icon (default)
+   * - `icon`: 24px icon only, no background \u2014 uses primary icon color
+   * @default 'circle'
+   */
+  variant?: 'circle' | 'icon';
 }
 
 /**
- * Circular icon container for navigation headers.
+ * Icon container for navigation headers.
  *
- * Wraps an icon with a circular accent-colored background, suitable for
- * use as a logo in top navigation or side navigation title areas.
+ * Two variants:
+ * - `circle` (default): 36px accent-colored circular background with a 24px icon.
+ *   Suitable for app identity / logo in navigation headers.
+ * - `icon`: 24px icon only, no background. Uses primary icon color.
+ *   Suitable for lighter branding or when a background circle is too heavy.
  *
  * @example
  * ```tsx
  * import {HomeIcon} from '@heroicons/react/24/solid';
  *
- * // In XDSTopNavTitle
+ * // Circle variant (default) \u2014 36px circle with 24px icon
  * <XDSTopNavTitle
  *   title="Dashboard"
- *   logo={<XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />}
+ *   logo={<XDSNavIcon icon={<HomeIcon />} />}
  * />
  *
- * // In XDSPageNavHeader
- * <XDSPageNavHeader
- *   icon={<XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />}
- *   title="My App"
+ * // Icon-only variant \u2014 24px icon, no background
+ * <XDSTopNavTitle
+ *   title="Dashboard"
+ *   logo={<XDSNavIcon icon={<HomeIcon />} variant="icon" />}
  * />
  * ```
  */
 export const XDSNavIcon = forwardRef<HTMLSpanElement, XDSNavIconProps>(
-  function XDSNavIcon({icon, ...props}, ref) {
+  function XDSNavIcon({icon, variant = 'circle', ...props}, ref) {
     return (
-      <span ref={ref} {...stylex.props(styles.base)} {...props}>
-        {icon}
+      <span
+        ref={ref}
+        {...stylex.props(
+          styles.base,
+          variant === 'circle' ? styles.circle : styles.icon,
+        )}
+        {...props}>
+        <span {...stylex.props(styles.iconInner)}>{icon}</span>
       </span>
     );
   },


### PR DESCRIPTION
Updates `XDSNavIcon` with new sizing and an icon-only variant.

## Changes

### Size update
- Circle background: 32px (`--size-md`) → 36px (`--size-lg`)
- Icon inside: 16px → 24px (auto-sized, no more manual `style={{width: 16, height: 16}}`)

### New `variant` prop
| Variant | Size | Background | Icon color |
|---------|------|------------|------------|
| `circle` (default) | 36px | `--color-accent` | `--color-icon-on-media` |
| `icon` | 24px | None | `--color-icon-primary` |

### Usage

```tsx
// Circle (default) — 36px accent circle, 24px icon
<XDSNavIcon icon={<CubeIcon />} />

// Icon only — 24px icon, no background
<XDSNavIcon icon={<CubeIcon />} variant="icon" />
```

### Files changed
- **`XDSNavIcon.tsx`** — New sizes, `variant` prop, `iconInner` wrapper for auto-sizing
- **`XDSNavIcon.test.tsx`** — Tests for both variants
- **`README.md`** — Updated docs and props table
- **`TopNav.stories.tsx`** — Removed manual 16px icon sizing
- **`AppShell.stories.tsx`** — Removed manual 16px icon sizing
- **`SideNav.stories.tsx`** — Removed manual 16px icon sizing

---
*Crafted with care by Navi*