### PR TITLE
feat(TopNav): add isEndContentFlush prop for tighter right padding

### DIFF
--- a/apps/storybook/stories/TopNav.stories.tsx
+++ b/apps/storybook/stories/TopNav.stories.tsx
@@ -286,3 +286,88 @@ export const FullExample: Story = {
     />
   ),
 };
+
+/**
+ * Ghost button end content with `isEndContentFlush` — reduces right padding
+ * from 16px to 8px. Ghost buttons have internal padding, so the tighter
+ * nav edge looks more balanced.
+ */
+export const EndContentFlush: Story = {
+  render: () => (
+    <XDSTopNav
+      label="Main navigation"
+      title={
+        <XDSTopNavTitle
+          title="Dashboard"
+          logo={
+            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+          }
+          href="#"
+        />
+      }
+      startContent={
+        <>
+          <XDSTopNavItem label="Overview" href="#" isSelected />
+          <XDSTopNavItem label="Analytics" href="#" />
+        </>
+      }
+      endContent={
+        <>
+          <XDSButton
+            label="Search"
+            variant="ghost"
+            icon={<MagnifyingGlassIcon style={{width: 16, height: 16}} />}
+          />
+          <XDSButton
+            label="Notifications"
+            variant="ghost"
+            icon={<BellIcon style={{width: 16, height: 16}} />}
+          />
+          <XDSButton
+            label="Profile"
+            variant="ghost"
+            icon={<UserCircleIcon style={{width: 16, height: 16}} />}
+          />
+        </>
+      }
+      isEndContentFlush
+    />
+  ),
+};
+
+/**
+ * Default right padding (16px) — appropriate when end content includes
+ * solid buttons or other elements without internal padding.
+ */
+export const EndContentDefault: Story = {
+  render: () => (
+    <XDSTopNav
+      label="Main navigation"
+      title={
+        <XDSTopNavTitle
+          title="Dashboard"
+          logo={
+            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+          }
+          href="#"
+        />
+      }
+      startContent={
+        <>
+          <XDSTopNavItem label="Overview" href="#" isSelected />
+          <XDSTopNavItem label="Analytics" href="#" />
+        </>
+      }
+      endContent={
+        <>
+          <XDSButton
+            label="Notifications"
+            variant="ghost"
+            icon={<BellIcon style={{width: 16, height: 16}} />}
+          />
+          <XDSButton label="Sign up" variant="primary" />
+        </>
+      }
+    />
+  ),
+};

--- a/packages/core/src/TopNav/README.md
+++ b/packages/core/src/TopNav/README.md
@@ -78,8 +78,9 @@ For the circular icon container, use `XDSNavIcon` from `@xds/core/NavIcon`.
 | -------------- | ----------- | ------- | ----------------------------------------------------- |
 | `title`        | `ReactNode` | —       | Title slot (logo, brand) - left aligned               |
 | `startContent` | `ReactNode` | —       | Start content (nav items, breadcrumbs) - left aligned |
-| `endContent`   | `ReactNode` | —       | End content (search, icons, profile) - right aligned  |
-| `label`        | `string`    | —       | Accessible label for navigation landmark              |
+| `endContent`         | `ReactNode` | —       | End content (search, icons, profile) - right aligned             |
+| `isEndContentFlush`  | `boolean`   | `false` | Reduces right padding for ghost buttons / icon-only end content  |
+| `label`              | `string`    | —       | Accessible label for navigation landmark                         |
 
 ### XDSTopNavTitle
 

--- a/packages/core/src/TopNav/XDSTopNav.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.test.tsx
@@ -147,6 +147,17 @@ describe('XDSTopNav', () => {
     // positioning context for the mega menu panel.
     expect(nav).not.toHaveStyle({position: 'relative'});
   });
+
+  it('renders with isEndContentFlush', () => {
+    render(
+      <XDSTopNav
+        label="Main navigation"
+        endContent={<span data-testid="end">Actions</span>}
+        isEndContentFlush
+      />,
+    );
+    expect(screen.getByTestId('end')).toBeInTheDocument();
+  });
 });
 
 describe('XDSTopNavTitle', () => {

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -34,6 +34,9 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-navbar'],
     boxSizing: 'border-box',
   },
+  endContentFlush: {
+    paddingInlineEnd: spacingVars['--spacing-2'],
+  },
   // Flex layout (default, used when no centerContent)
   baseFlex: {
     display: 'flex',
@@ -120,6 +123,14 @@ export interface XDSTopNavProps extends Omit<
    */
   endContent?: ReactNode;
   /**
+   * Reduces the right padding from 16px to 8px, pulling end content closer
+   * to the nav edge. Use when end content contains ghost buttons or icon-only
+   * actions that have their own internal padding — the default 16px creates
+   * too much visual space since ghost buttons already include hit-area padding.
+   * @default false
+   */
+  isEndContentFlush?: boolean;
+  /**
    * Accessible label for the navigation landmark.
    * Helps screen readers identify the navigation area.
    */
@@ -161,6 +172,19 @@ export interface XDSTopNavProps extends Omit<
  *   }
  * />
  *
+ * // Ghost buttons — use isEndContentFlush to reduce right padding
+ * <XDSTopNav
+ *   label="Main navigation"
+ *   title={<XDSTopNavTitle title="My App" logo={<Logo />} />}
+ *   endContent={
+ *     <>
+ *       <XDSButton label="Notifications" icon={<BellIcon />} variant="ghost" />
+ *       <XDSButton label="Profile" icon={<UserIcon />} variant="ghost" />
+ *     </>
+ *   }
+ *   isEndContentFlush
+ * />
+ *
  * // Centered layout (left + center + right)
  * <XDSTopNav
  *   label="Main navigation"
@@ -177,7 +201,7 @@ export interface XDSTopNavProps extends Omit<
  */
 export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
   function XDSTopNav(
-    {title, startContent, centerContent, endContent, label, ...props},
+    {title, startContent, centerContent, endContent, isEndContentFlush = false, label, ...props},
     ref,
   ) {
     const themeContext = useContext(ThemeContext);
@@ -191,6 +215,7 @@ export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
         aria-label={label}
         {...stylex.props(
           styles.base,
+          isEndContentFlush && styles.endContentFlush,
           hasCenterContent ? styles.baseGrid : styles.baseFlex,
           rootOverride,
         )}


### PR DESCRIPTION
Adds `isEndContentFlush` prop to `XDSTopNav` for tighter right padding when end content uses ghost buttons.

## Problem

Ghost buttons have their own internal hit-area padding. Combined with the nav's default 16px right padding, this creates too much visual space between ghost button icons and the nav edge. But non-ghost end content (solid buttons, avatars) needs the full 16px to look right.

## Alternatives considered

| Approach | Verdict |
|----------|---------|
| Always reduce right padding | ❌ Breaks non-ghost end content (solid buttons, avatars need 16px) |
| Negative margin on ghost buttons | ❌ Fragile — breaks if last item isn't ghost |
| CSS `:has()` to detect ghost buttons | ❌ Couples TopNav to Button class name internals |
| *Consumer-controlled prop* | ✅ Explicit, no magic, consumer knows their content |

## Solution

New `isEndContentFlush` boolean prop. When true, reduces right padding from 16px (`--spacing-4`) to 8px (`--spacing-2`).

```tsx
// Ghost buttons — use isEndContentFlush
<XDSTopNav
  endContent={
    <>
      <XDSButton label="Notifications" icon={<BellIcon />} variant="ghost" />
      <XDSButton label="Profile" icon={<UserIcon />} variant="ghost" />
    </>
  }
  isEndContentFlush
/>

// Solid buttons — default padding is fine
<XDSTopNav
  endContent={<XDSButton label="Sign up" variant="primary" />}
/>
```

### Files changed
- **`XDSTopNav.tsx`** — New `isEndContentFlush` prop, `endContentFlush` style
- **`XDSTopNav.test.tsx`** — Test for `isEndContentFlush` rendering
- **`README.md`** — Updated props table

---
*Crafted with care by Navi*