### PR TITLE
fix(SideNav): reduce container inline padding from 8px to 4px

### DIFF
--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -51,14 +51,14 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-surface'],
   },
   topContent: {
-    paddingInline: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-1'],
     paddingBlock: spacingVars['--spacing-1'],
   },
   scrollable: {
     flex: 1,
     overflowY: 'auto',
     overflowX: 'hidden',
-    paddingInline: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-1'],
     paddingBlock: spacingVars['--spacing-1'],
   },
   stickyBottom: {
@@ -69,14 +69,14 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-surface'],
   },
   footer: {
-    paddingInline: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-1'],
     paddingBlock: spacingVars['--spacing-2'],
   },
   footerIcons: {
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-1'],
     paddingBlock: spacingVars['--spacing-2'],
     borderBlockStart: `1px solid ${colorVars['--color-divider']}`,
   },


### PR DESCRIPTION
Reduces the left/right padding of the `XDSSideNav` container areas from 8px to 4px.

## Change

```diff
- paddingInline: spacingVars['--spacing-2'],  // 8px
+ paddingInline: spacingVars['--spacing-1'],  // 4px
```

Applied to all four container styles:
- `topContent` — area above the scrollable section
- `scrollable` — main nav item scroll area
- `footer` — footer content area
- `footerIcons` — footer icon bar

---
*Crafted with care by Navi*