### PR TITLE
fix(badge): correct height from 24.5px to 20px

### DIFF
--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -24,7 +24,6 @@ import {
   radiusVars,
   textSizeVars,
   fontWeightVars,
-  lineHeightVars,
 } from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
 import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
@@ -43,7 +42,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-rounded'],
     fontFamily: 'inherit',
     fontSize: textSizeVars['--text-xsm'],
-    lineHeight: lineHeightVars['--leading-snug'],
+    lineHeight: '1',
     fontWeight: fontWeightVars['--font-weight-medium'],
     letterSpacing: '-0.24px',
     whiteSpace: 'nowrap',


### PR DESCRIPTION
## Problem

XDSBadge rendered at 24.5px height instead of the intended 20px.

## Root Cause

The badge used `lineHeight: --leading-snug` (1.375), which with a 12px font size and 4px block padding produced:
- 12px × 1.375 = 16.5px line height
- 16.5px + 4px + 4px = 24.5px total

## Fix

Changed `lineHeight` to `1` (no token — badges are compact UI elements where a tight line-height is appropriate):
- 12px × 1 = 12px line height
- 12px + 4px + 4px = **20px** total

Also removed the unused `lineHeightVars` import.