### PR TITLE
docs: add "no raw divs" rule across AI guidance docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,10 @@ This project uses **Fractal Documentation** — a self-referential pattern where
 
 Look for `<!-- SYNC: ... -->` comments and `SYNC:` in file headers as reminders.
 
+## Key Rules
+
+- **No raw `<div>` elements.** Use XDS layout components (`XDSVStack`, `XDSHStack`, `XDSGrid`, `XDSCenter`, `XDSSection`, `XDSCard`, `XDSText`, etc.) instead. See `npx xds docs principles` for the full mapping. A raw `<div>` is only acceptable when no XDS component covers the use case.
+
 ## Quick Reference
 
 - **Package manager**: Yarn 1 (Classic)

--- a/internal/vibe-tests/prompts/evaluator.md
+++ b/internal/vibe-tests/prompts/evaluator.md
@@ -58,8 +58,24 @@ A response can be successful AND have acceptable escape hatches.
 **Acceptable** (noted but does NOT count against success):
 
 - `supplemental_css` — CSS for things the component system doesn't cover (layout gaps, responsive breakpoints, animations, decoration)
-- `wrapper_div` — Structural HTML needed to compose components
+- `wrapper_div` — Structural HTML needed to compose components *when no XDS layout component exists for the purpose*
 - `inline_style` — Minor inline styles for things without a component prop
+
+### Raw Div Detection
+
+Raw `<div>` elements should be flagged as escape hatches. Severity depends on whether an XDS component covers the use case:
+
+**Critical `wrapper_div`** — A `<div>` used where an XDS component exists:
+- `<div>` for vertical/horizontal stacking → should be `XDSVStack` / `XDSHStack`
+- `<div>` for grid layout → should be `XDSGrid`
+- `<div>` for centering → should be `XDSCenter`
+- `<div>` for page structure → should be `XDSLayout` / `XDSLayoutContent`
+- `<div>` for content grouping → should be `XDSSection` or `XDSCard`
+- `<div>` for text → should be `XDSText`
+- `<div>` for list items → should be `XDSList` / `XDSListItem`
+- `<div onClick>` → should be `XDSButton` or `XDSLink`
+
+**Acceptable `wrapper_div`** — A `<div>` for something XDS doesn't cover (e.g., portal target, third-party library container, or a genuinely novel structural need with no matching component).
 
 ### Key Rules
 

--- a/packages/cli/docs/principles.md
+++ b/packages/cli/docs/principles.md
@@ -16,6 +16,26 @@ React design system for internal tools. Components use `XDS` prefix.
 ❌ Hardcoded colors (#fff) → Use var(--color-_)
 ❌ Hardcoded spacing (16px) → Use spacing tokens or var(--spacing-_)
 ❌ Inventing props → Read component docs first
+❌ Raw `<div>` elements → Use XDS layout components (see below)
+
+## No Raw Divs
+
+Prefer XDS components over raw `<div>` elements. The design system covers virtually all layout needs:
+
+| Instead of…                        | Use…                                    |
+| ---------------------------------- | --------------------------------------- |
+| `<div>` for vertical stacking      | `XDSVStack`                             |
+| `<div>` for horizontal layout      | `XDSHStack`                             |
+| `<div>` for grid layout            | `XDSGrid`                               |
+| `<div>` for centering              | `XDSCenter`                             |
+| `<div>` for page structure         | `XDSLayout` / `XDSLayoutContent`        |
+| `<div>` for grouping content       | `XDSSection` or `XDSCard`               |
+| `<div>` for text wrapping          | `XDSText`                               |
+| `<div>` for list items             | `XDSList` / `XDSListItem`              |
+| `<div onClick>` for interactions   | `XDSButton` or `XDSLink`               |
+| `<hr>` / `<div>` for separators    | `XDSDivider`                            |
+
+A raw `<div>` is acceptable *only* when no XDS component exists for the purpose (e.g., a portal target, a ref container for a third-party library). When you must use one, add a comment explaining why.
 
 ## StyleX Usage
 
@@ -30,7 +50,7 @@ const styles = stylex.create({
   },
 });
 
-<div {...stylex.props(styles.container)}>
+<XDSSection xstyle={styles.container}>
 ```
 
 ## Quick Token Reference


### PR DESCRIPTION
## Summary

Adds a rule to prefer XDS layout components over raw `<div>` elements, applied at three layers:

### 1. `CLAUDE.md` — Top-level rule
New **Key Rules** section with the no-div rule. This is what Claude Code sees first.

### 2. `packages/cli/docs/principles.md` — Detailed guidance
- Added to Anti-Patterns list
- New **"No Raw Divs"** section with a full mapping table:

| Instead of… | Use… |
|---|---|
| `<div>` for vertical stacking | `XDSVStack` |
| `<div>` for horizontal layout | `XDSHStack` |
| `<div>` for grid layout | `XDSGrid` |
| `<div>` for centering | `XDSCenter` |
| `<div>` for page structure | `XDSLayout` / `XDSLayoutContent` |
| `<div>` for grouping content | `XDSSection` or `XDSCard` |
| `<div>` for text wrapping | `XDSText` |
| `<div onClick>` for interactions | `XDSButton` or `XDSLink` |

Also fixed the StyleX example that was itself using a `<div>` 😅

### 3. `internal/vibe-tests/prompts/evaluator.md` — Evaluation enforcement
- `wrapper_div` escape hatch is now **critical** when an XDS component exists for the purpose
- Only **acceptable** when no component covers the use case
- Added detailed **Raw Div Detection** rules with specific mappings

## Context

Ernest noticed during e-commerce template evaluation that generated code uses excessive raw divs instead of XDS layout components. This closes the gap between "the components exist" and "the AI actually uses them."

---
*Crafted with care by Navi*