### PR TITLE
fix(ci): auto-generate VRT baselines and /update-baselines command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
           NEW_COMPONENTS=$(cat analysis.json | jq -r '
             if .vrtComponents and (.vrtComponents | length > 0)
             then [.newComponents[] as $dir |
-              .componentStats[$dir].exports[]? // empty |
+              .componentStats[$dir].exports? // empty |
               select(startswith("XDS"))] | unique | join("|")
             else .newComponents | map("XDS" + .) | join("|")
             end')
@@ -555,14 +555,74 @@ jobs:
           fi
 
       - name: Run visual regression tests
+        id: vrt-run
         if: steps.vrt-pattern.outputs.skip != 'true'
+        continue-on-error: true
         run: |
           npx playwright test --grep "${{ steps.vrt-pattern.outputs.pattern }}"
 
       - name: Upload diff artifacts
-        if: failure()
+        if: steps.vrt-run.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
           name: visual-regression-diffs
           path: test-results/
           retention-days: 30
+
+      - name: Comment on PR with VRT result
+        if: always() && github.event_name == 'pull_request' && steps.vrt-pattern.outputs.skip != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const passed = '${{ steps.vrt-run.outcome }}' === 'success';
+            const pattern = '${{ steps.vrt-pattern.outputs.pattern }}';
+            const components = pattern.split('|').join(', ');
+            const runUrl = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+
+            let body;
+            if (passed) {
+              body = `### ✅ Visual Regression — Passed\n\nAll screenshots match baselines for: ${components}`;
+            } else {
+              body = [
+                '### ❌ Visual Regression — Failed',
+                '',
+                `Screenshots differ from baselines for: **${components}**`,
+                '',
+                `[View diff artifacts](${runUrl}) to review the visual changes.`,
+                '',
+                '> **To accept these changes**, comment \`/update-baselines\` on this PR.',
+                '> Baselines will be regenerated and committed automatically.',
+              ].join('\n');
+            }
+
+            const prNumber = ${{ github.event.pull_request.number }};
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const marker = 'Visual Regression —';
+            const existing = comments.find(c =>
+              c.user.type === 'Bot' && c.body.includes(marker)
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: body,
+              });
+            }
+
+      - name: Fail if VRT failed
+        if: steps.vrt-run.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
           NEW_COMPONENTS=$(cat analysis.json | jq -r '
             if .vrtComponents and (.vrtComponents | length > 0)
             then [.newComponents[] as $dir |
-              .componentStats[$dir].exports? // empty |
+              .componentStats[$dir].exports[]? // empty |
               select(startswith("XDS"))] | unique | join("|")
             else .newComponents | map("XDS" + .) | join("|")
             end')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,6 +467,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -491,14 +494,70 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install chromium
 
-      - name: Run visual regression tests
+      - name: Build grep pattern from analysis
+        id: vrt-pattern
         run: |
-          COMPONENTS=$(cat analysis.json | jq -r '(.newComponents + .modifiedComponents) | map("XDS" + .) | join("|")')
+          # Use vrtComponents if available (correct component names),
+          # fall back to directory-name-based pattern
+          COMPONENTS=$(cat analysis.json | jq -r '
+            if .vrtComponents and (.vrtComponents | length > 0)
+            then .vrtComponents | join("|")
+            else (.newComponents + .modifiedComponents) | map("XDS" + .) | join("|")
+            end')
+
           if [ -z "$COMPONENTS" ] || [ "$COMPONENTS" = "" ]; then
-            echo "No components changed, skipping visual regression"
+            echo "No components to test"
+            echo "skip=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-          npx playwright test --grep "$COMPONENTS"
+
+          echo "pattern=$COMPONENTS" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "Will test components matching: $COMPONENTS"
+
+          # Detect new components (no existing baselines)
+          NEW_COMPONENTS=$(cat analysis.json | jq -r '
+            if .vrtComponents and (.vrtComponents | length > 0)
+            then [.newComponents[] as $dir |
+              .componentStats[$dir].exports[]? // empty |
+              select(startswith("XDS"))] | unique | join("|")
+            else .newComponents | map("XDS" + .) | join("|")
+            end')
+
+          echo "new_pattern=$NEW_COMPONENTS" >> $GITHUB_OUTPUT
+          echo "New components: ${NEW_COMPONENTS:-none}"
+
+      - name: Generate baselines for new components
+        if: steps.vrt-pattern.outputs.skip != 'true' && steps.vrt-pattern.outputs.new_pattern != ''
+        run: |
+          echo "Generating baselines for new components: ${{ steps.vrt-pattern.outputs.new_pattern }}"
+          npx playwright test \
+            --grep "${{ steps.vrt-pattern.outputs.new_pattern }}" \
+            --update-snapshots \
+            || true
+
+      - name: Commit new baselines
+        if: steps.vrt-pattern.outputs.skip != 'true' && steps.vrt-pattern.outputs.new_pattern != ''
+        run: |
+          # Check if any new baseline files were created
+          NEW_FILES=$(git ls-files --others --exclude-standard e2e/visual-regression.spec.ts-snapshots/)
+          if [ -n "$NEW_FILES" ]; then
+            echo "New baseline files:"
+            echo "$NEW_FILES"
+            git add e2e/visual-regression.spec.ts-snapshots/
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore(vrt): auto-generate baselines for new components"
+            git push
+            echo "Committed and pushed new baselines"
+          else
+            echo "No new baseline files to commit"
+          fi
+
+      - name: Run visual regression tests
+        if: steps.vrt-pattern.outputs.skip != 'true'
+        run: |
+          npx playwright test --grep "${{ steps.vrt-pattern.outputs.pattern }}"
 
       - name: Upload diff artifacts
         if: failure()

--- a/.github/workflows/update-baselines.yml
+++ b/.github/workflows/update-baselines.yml
@@ -1,0 +1,140 @@
+# Triggered by commenting "/update-baselines" on a PR.
+# Re-runs Playwright with --update-snapshots for modified components,
+# then commits the updated baselines back to the PR branch.
+name: Update VRT Baselines
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  update-baselines:
+    # Only run on PR comments that say "/update-baselines"
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/update-baselines')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('ref', pr.data.head.ref);
+            core.setOutput('sha', pr.data.head.sha);
+
+      - name: React to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.ref }}
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build core package
+        run: yarn build
+
+      - name: Build Storybook
+        run: yarn workspace @xds/storybook build
+
+      - name: Install Playwright Chromium
+        run: npx playwright install chromium
+
+      - name: Analyze changed components
+        run: |
+          node .github/scripts/analyze-pr.js \
+            --base origin/main \
+            --head HEAD \
+            --output analysis.json
+
+      - name: Build grep pattern
+        id: pattern
+        run: |
+          COMPONENTS=$(cat analysis.json | jq -r '
+            if .vrtComponents and (.vrtComponents | length > 0)
+            then .vrtComponents | join("|")
+            else (.newComponents + .modifiedComponents) | map("XDS" + .) | join("|")
+            end')
+
+          if [ -z "$COMPONENTS" ] || [ "$COMPONENTS" = "" ]; then
+            echo "No components to update"
+            echo "skip=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "pattern=$COMPONENTS" >> $GITHUB_OUTPUT
+          echo "skip=false" >> $GITHUB_OUTPUT
+          echo "Updating baselines for: $COMPONENTS"
+
+      - name: Update baselines
+        if: steps.pattern.outputs.skip != 'true'
+        run: |
+          npx playwright test \
+            --grep "${{ steps.pattern.outputs.pattern }}" \
+            --update-snapshots \
+            || true
+
+      - name: Commit and push updated baselines
+        if: steps.pattern.outputs.skip != 'true'
+        run: |
+          CHANGED=$(git diff --name-only e2e/visual-regression.spec.ts-snapshots/ 2>/dev/null || true)
+          NEW=$(git ls-files --others --exclude-standard e2e/visual-regression.spec.ts-snapshots/ 2>/dev/null || true)
+
+          if [ -n "$CHANGED" ] || [ -n "$NEW" ]; then
+            git add e2e/visual-regression.spec.ts-snapshots/
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore(vrt): update baselines for modified components"
+            git push
+            echo "UPDATED=true" >> $GITHUB_ENV
+            echo "Updated baselines:"
+            echo "$CHANGED"
+            echo "$NEW"
+          else
+            echo "UPDATED=false" >> $GITHUB_ENV
+            echo "No baseline changes detected"
+          fi
+
+      - name: Comment result
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const updated = process.env.UPDATED === 'true';
+            const body = updated
+              ? '✅ Baselines updated and pushed. CI will re-run automatically.'
+              : '⚠️ No baseline changes detected — screenshots already match.';
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: body,
+            });


### PR DESCRIPTION
## Summary

Overhauls the visual regression testing workflow with three improvements:

### 1. Auto-generate baselines for new components

When a PR adds a new component, CI automatically:
1. Detects which components are **new** (vs modified) from `analysis.json`
2. Runs Playwright with `--update-snapshots` to generate baseline screenshots
3. Commits the baselines back to the PR branch

No manual step needed for new components.

### 2. `/update-baselines` command for modified components

When VRT fails because a component's visuals changed intentionally:
1. CI posts a comment explaining which components failed and how to accept the changes
2. Comment `/update-baselines` on the PR
3. 🚀 reaction appears, a workflow runs Playwright with `--update-snapshots`
4. Updated baselines are committed and pushed, CI re-runs automatically

New workflow file: `.github/workflows/update-baselines.yml`

### 3. Fix VRT grep pattern

Uses `vrtComponents` from `analysis.json` (actual exported names like `XDSPopover`) instead of the old directory-name-based pattern (`XDSLayer`). Falls back gracefully for branches without `vrtComponents`.

### Flow summary

| Component type | What happens |
|---|---|
| **New** (no baselines) | Baselines auto-generated and committed by CI |
| **Modified** (baselines exist, match) | ✅ VRT passes |
| **Modified** (baselines exist, differ) | ❌ VRT fails, PR comment says to use `/update-baselines` |
| **After `/update-baselines`** | Baselines regenerated, committed, CI re-runs |
