### PR TITLE
fix(ci): fix storyTitle array crash in PR comment generation

### DIFF
--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -211,7 +211,10 @@ function getStoryTitle(componentName) {
       return titleMatch ? titleMatch[1] : null;
     }).filter(Boolean);
 
-    return titles.length === 1 ? titles[0] : titles.length > 0 ? titles : null;
+    // Always return a single string (first match) or null — never an array.
+    // Multiple story files may match (e.g. Popover.stories.tsx + PopoverFilter.stories.tsx),
+    // but downstream code expects a string for Storybook link generation.
+    return titles.length > 0 ? titles[0] : null;
   } catch {
     return null;
   }

--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -57,7 +57,7 @@ try {
 // Build a Storybook deep link URL for a component
 // Story titles like "Core/XDSButton" become path "/docs/core-xdsbutton--docs"
 function getStorybookLink(storybookBaseUrl, storyTitle) {
-  if (!storybookBaseUrl || !storyTitle) return null;
+  if (!storybookBaseUrl || !storyTitle || typeof storyTitle !== 'string') return null;
   // Storybook converts "Core/XDSButton" to "core-xdsbutton" as the story ID prefix
   const storyPath = storyTitle.toLowerCase().replace(/\//g, '-');
   return `${storybookBaseUrl}?path=/docs/${storyPath}--docs`;


### PR DESCRIPTION
## Problem

Two CI bugs causing PR comment jobs to crash:

### 1. `getStoryTitle()` returns array instead of string

`analyze-pr.js` line 214 returned the full `titles` array when multiple story files matched a component:

```js
return titles.length === 1 ? titles[0] : titles.length > 0 ? titles : null;
```

For components like Popover (which matches `Popover.stories.tsx`, etc.), this produced an array in `storyTitle`. Then `generate-pr-comment.js` called `.toLowerCase()` on it → `TypeError: storyTitle.toLowerCase is not a function`.

This crashed both `pr-comment` and `pr-comment-update` jobs.

### 2. No defensive check in `getStorybookLink()`

Even with the root cause fixed, `getStorybookLink()` should handle unexpected types gracefully.

## Fix

1. **`analyze-pr.js`**: Always return first match as a string (or null). Multiple matches still pick the most relevant title.
2. **`generate-pr-comment.js`**: Added `typeof storyTitle !== 'string'` guard.

## Note

There's also a VRT baseline detection bug (components classified as "modified" but lacking baselines don't get auto-generated baselines). That fix requires changes to `ci.yml` which needs the `workflow` OAuth scope — will need to be applied manually or via a different auth path.
