### PR TITLE
fix(ci): detect new exports within modified directories

### DIFF
--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -62,6 +62,28 @@ function componentExistsInBase(componentName) {
   }
 }
 
+// Get exports from the base branch for a component (to detect new exports in modified dirs)
+function getBaseExports(componentName) {
+  try {
+    const content = execSync(
+      `git show ${baseBranch}:${CORE_SRC}/${componentName}/index.ts`,
+      { encoding: 'utf8', stdio: 'pipe' }
+    );
+    const exportMatches = content.match(/export\s+{\s*([^}]+)\s*}/g) || [];
+    const exports = [];
+    for (const match of exportMatches) {
+      const inner = match.replace(/export\s*{\s*/, '').replace(/\s*}/, '');
+      exports.push(...inner.split(',').map(e => e.trim().split(' ')[0]));
+    }
+    if (content.includes('export default')) {
+      exports.push('default');
+    }
+    return exports.filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
 // Get file size in human readable format
 function getFileSize(filePath) {
   try {
@@ -401,6 +423,27 @@ function analyze() {
     componentStats[comp] = getComponentStats(comp);
   }
 
+  // For modified directories, detect new exports (components that exist in HEAD
+  // but not in the base branch). A directory like Layer/ may be "modified" but
+  // contain brand-new exports like XDSPopover alongside existing ones.
+  const newExports = [];
+  for (const comp of modifiedComponents) {
+    const headExports = componentStats[comp]?.exports || [];
+    const baseExports = getBaseExports(comp);
+    const added = headExports.filter(e => e.startsWith('XDS') && !baseExports.includes(e));
+    newExports.push(...added);
+  }
+
+  // Also include all XDS exports from truly new directories
+  for (const comp of newComponents) {
+    const exports = componentStats[comp]?.exports || [];
+    newExports.push(...exports.filter(e => e.startsWith('XDS')));
+  }
+
+  if (newExports.length > 0) {
+    console.log(`New exports: ${newExports.join(', ')}`);
+  }
+
   // Build visual regression grep pattern from actual exported component names
   // (not directory names — e.g., Layer/ exports XDSPopover, XDSTooltip, etc.)
   const vrtComponents = [...new Set(
@@ -411,6 +454,7 @@ function analyze() {
   const result = {
     newComponents,
     modifiedComponents,
+    newExports,
     vrtComponents,
     componentStats,
     totalBundle: getTotalBundleStats(),

--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -98,7 +98,14 @@ if (analysis.modifiedComponents && analysis.modifiedComponents.length > 0) {
     const baseStats = analysis.baseComponentStats?.[comp] || {};
     const sbLink = getStorybookLink(storybookUrl, stats.storyTitle);
     const sbBadge = sbLink ? ` · ${extLink('View in Storybook', sbLink)}` : '';
-    componentSection += `<details>\n<summary><strong>${comp}</strong>${sbBadge}</summary>\n\n`;
+
+    // Check if this modified directory has new exports
+    const newExports = analysis.newExports || [];
+    const compExports = stats.exports || [];
+    const newInComp = compExports.filter(e => newExports.includes(e));
+    const newBadge = newInComp.length > 0 ? ` · 🆕 ${newInComp.join(', ')}` : '';
+
+    componentSection += `<details>\n<summary><strong>${comp}</strong>${sbBadge}${newBadge}</summary>\n\n`;
     componentSection += `| Metric | Before | After | Delta |\n|--------|--------|-------|-------|\n`;
 
     const esmDelta = stats.esmBytes && baseStats.esmBytes


### PR DESCRIPTION
## Problem

The PR analysis (`analyze-pr.js`) classifies components at the *directory* level — a directory either exists on the base branch (→ "modified") or doesn't (→ "new"). But a single directory like `Layer/` can be "modified" while containing brand-new exports like `XDSPopover`.

This caused:
- VRT skipping baseline generation for XDSPopover (classified as modified, not new)
- PR comment not distinguishing new exports from existing ones

## Fix

### In `analyze-pr.js`:
- Added `getBaseExports()` — reads exports from the base branch's `index.ts`
- For modified directories, compares HEAD exports vs base exports to find new ones
- Outputs a `newExports` array (e.g. `["XDSPopover"]`) alongside existing `newComponents`/`modifiedComponents`

### In `generate-pr-comment.js`:
- Modified directories with new exports get a 🆕 badge showing the new component names

### In `ci.yml` (needs manual apply — requires `workflow` scope):

The VRT baseline detection should consume `newExports` instead of deriving new components from `newComponents` directories:

```diff
diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
index eeadab13..125b2a14 100644
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,17 +515,17 @@ jobs:
           echo "skip=false" >> $GITHUB_OUTPUT
           echo "Will test components matching: $COMPONENTS"
 
-          # Detect new components (no existing baselines)
+          # Detect new exports (components that don't exist in the base branch).
+          # This covers both truly new directories AND new exports within modified
+          # directories (e.g. XDSPopover added to the existing Layer/ directory).
           NEW_COMPONENTS=$(cat analysis.json | jq -r '
-            if .vrtComponents and (.vrtComponents | length > 0)
-            then [.newComponents[] as $dir |
-              .componentStats[$dir].exports[]? // empty |
-              select(startswith("XDS"))] | unique | join("|")
-            else .newComponents | map("XDS" + .) | join("|")
+            if .newExports and (.newExports | length > 0)
+            then .newExports | join("|")
+            else ""
             end')
 
           echo "new_pattern=$NEW_COMPONENTS" >> $GITHUB_OUTPUT
-          echo "New components: ${NEW_COMPONENTS:-none}"
+          echo "New exports: ${NEW_COMPONENTS:-none}"
 
       - name: Generate baselines for new components
         if: steps.vrt-pattern.outputs.skip != 'true' && steps.vrt-pattern.outputs.new_pattern != ''

```

Apply this change manually or via a token with `workflow` scope.
