### PR TITLE
fix(ci): make VRT non-blocking with post-merge baseline regen

### DIFF
--- a/.github/scripts/clean-orphaned-baselines.js
+++ b/.github/scripts/clean-orphaned-baselines.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+/**
+ * Clean orphaned VRT baselines that no longer match any Storybook story.
+ *
+ * Usage: node clean-orphaned-baselines.js [--dry-run]
+ *
+ * Reads the Storybook index.json to get all current stories,
+ * then removes any baseline .png that doesn't correspond to a story.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const dryRun = process.argv.includes('--dry-run');
+
+const storybookDir = path.resolve(__dirname, '../../apps/storybook/dist');
+const snapshotsDir = path.resolve(
+  __dirname,
+  '../../e2e/visual-regression.spec.ts-snapshots',
+);
+
+// Read storybook index
+const indexPath = path.join(storybookDir, 'index.json');
+if (!fs.existsSync(indexPath)) {
+  console.error('Storybook index.json not found. Build storybook first.');
+  process.exit(1);
+}
+
+const index = JSON.parse(fs.readFileSync(indexPath, 'utf8'));
+const entries = index.entries || index.stories || {};
+const stories = Object.values(entries).filter(
+  (e) => e.type !== 'docs' && !e.id.endsWith('--docs'),
+);
+
+console.log(`Found ${stories.length} stories in Storybook index`);
+
+// Get all baseline files
+if (!fs.existsSync(snapshotsDir)) {
+  console.log('No snapshots directory found.');
+  process.exit(0);
+}
+
+const baselines = fs.readdirSync(snapshotsDir).filter((f) => f.endsWith('.png'));
+console.log(`Found ${baselines.length} baseline files`);
+
+// After running playwright --update-snapshots, the generated files are the
+// source of truth. But we can also check by trying to match story titles.
+// Playwright generates filenames by sanitizing the snapshot name arg.
+
+// For now, just report — actual cleanup happens during --update-snapshots
+// which only writes files for stories that exist.
+
+// Find baselines that were recently modified (within last run)
+const recentThreshold = Date.now() - 5 * 60 * 1000; // 5 minutes
+const recent = baselines.filter((f) => {
+  const stat = fs.statSync(path.join(snapshotsDir, f));
+  return stat.mtimeMs > recentThreshold;
+});
+
+const stale = baselines.filter((f) => {
+  const stat = fs.statSync(path.join(snapshotsDir, f));
+  return stat.mtimeMs <= recentThreshold;
+});
+
+if (recent.length > 0) {
+  console.log(`\n${recent.length} baselines were updated in the last run`);
+}
+
+if (stale.length > 0 && recent.length > 0) {
+  // If we just ran --update-snapshots and some files weren't touched,
+  // they're likely orphaned
+  console.log(`\n${stale.length} potentially orphaned baselines (not updated):`);
+  for (const f of stale) {
+    console.log(`  ${f}`);
+    if (!dryRun) {
+      fs.unlinkSync(path.join(snapshotsDir, f));
+      console.log(`    -> deleted`);
+    }
+  }
+}
+
+console.log('\nDone.');

--- a/.github/scripts/vrt-report.js
+++ b/.github/scripts/vrt-report.js
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+
+/**
+ * Process Playwright VRT results and generate a PR comment.
+ *
+ * Reads the Playwright JSON report and categorizes results into:
+ * - new: stories with no baseline (auto-generated on merge)
+ * - passed: screenshots match baselines
+ * - changed: screenshots differ from baselines
+ * - errors: stories that failed to render
+ *
+ * Usage: node vrt-report.js --results <playwright-results.json> --snapshots-dir <dir>
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const args = process.argv.slice(2);
+const getArg = (name) => {
+  const idx = args.indexOf(`--${name}`);
+  return idx !== -1 ? args[idx + 1] : null;
+};
+
+const resultsFile = getArg('results');
+const snapshotsDir = getArg('snapshots-dir');
+const runUrl = getArg('run-url') || '';
+const diffArtifactUrl = getArg('diff-artifact-url') || '';
+
+// If no results file, generate report from test output
+if (!resultsFile) {
+  console.error('Usage: node vrt-report.js --results <file> --snapshots-dir <dir>');
+  process.exit(1);
+}
+
+const results = JSON.parse(fs.readFileSync(resultsFile, 'utf8'));
+
+const categories = {
+  passed: [],
+  changed: [],
+  newStory: [],
+  errors: [],
+};
+
+for (const suite of results.suites || []) {
+  for (const spec of suite.specs ||) {
+    const title = spec.title;
+    const test = spec.tests?.[0];
+    const result = test?.results?.[0];
+
+    if (!result) continue;
+
+    if (result.status === 'passed') {
+      categories.passed.push(title);
+    } else if (result.status === 'failed') {
+      // Check if it's a "missing snapshot" error vs actual diff
+      const errorMsg = result.error?.message || '';
+      if (errorMsg.includes('A snapshot doesn\'t exist') ||
+          errorMsg.includes('missing snapshot')) {
+        categories.newStory.push(title);
+      } else if (errorMsg.includes('Screenshot comparison failed')) {
+        categories.changed.push(title);
+      } else {
+        categories.errors.push({ title, error: errorMsg.slice(0, 200) });
+      }
+    }
+  }
+}
+
+// Also handle flat specs (non-nested)
+for (const spec of results.specs || []) {
+  const title = spec.title;
+  const test = spec.tests?.[0];
+  const result = test?.results?.[0];
+
+  if (!result) continue;
+
+  if (result.status === 'passed') {
+    categories.passed.push(title);
+  } else if (result.status === 'failed') {
+    const errorMsg = result.error?.message || '';
+    if (errorMsg.includes('A snapshot doesn\'t exist') ||
+        errorMsg.includes('missing snapshot')) {
+      categories.newStory.push(title);
+    } else if (errorMsg.includes('Screenshot comparison failed')) {
+      categories.changed.push(title);
+    } else {
+      categories.errors.push({ title, error: errorMsg.slice(0, 200) });
+    }
+  }
+}
+
+// Generate markdown report
+const lines = [];
+
+const total = categories.passed.length + categories.changed.length +
+              categories.newStory.length + categories.errors.length;
+
+if (categories.changed.length === 0 && categories.errors.length === 0) {
+  lines.push('### ✅ Visual Regression — All Good');
+  lines.push('');
+  lines.push(`${categories.passed.length} screenshots match baselines.`);
+  if (categories.newStory.length > 0) {
+    lines.push(`${categories.newStory.length} new stories will get baselines when merged.`);
+  }
+} else {
+  lines.push('### ⚠️ Visual Regression — Changes Detected');
+  lines.push('');
+  lines.push(`Tested ${total} stories against baselines.`);
+}
+
+if (categories.changed.length > 0) {
+  lines.push('');
+  lines.push(`#### 🔄 Changed (${categories.changed.length})`);
+  lines.push('');
+  lines.push('These stories look different from their baselines. Review the diffs to confirm the changes are intentional.');
+  lines.push('');
+  for (const title of categories.changed) {
+    lines.push(`- \`${title}\``);
+  }
+  if (diffArtifactUrl) {
+    lines.push('');
+    lines.push(`[📸 View diff images](${diffArtifactUrl})`);
+  }
+  lines.push('');
+  lines.push('> To accept these changes, comment `/update-baselines` on this PR.');
+}
+
+if (categories.newStory.length > 0) {
+  lines.push('');
+  lines.push(`#### 🆕 New Stories (${categories.newStory.length})`);
+  lines.push('');
+  lines.push('These stories don\'t have baselines yet. Baselines will be auto-generated when this PR merges.');
+  lines.push('');
+  for (const title of categories.newStory) {
+    lines.push(`- \`${title}\``);
+  }
+}
+
+if (categories.errors.length > 0) {
+  lines.push('');
+  lines.push(`#### ❌ Errors (${categories.errors.length})`);
+  lines.push('');
+  for (const { title, error } of categories.errors) {
+    lines.push(`- \`${title}\`: ${error}`);
+  }
+}
+
+if (categories.passed.length > 0 && (categories.changed.length > 0 || categories.newStory.length > 0)) {
+  lines.push('');
+  lines.push(`<details><summary>✅ Passed (${categories.passed.length})</summary>`);
+  lines.push('');
+  for (const title of categories.passed) {
+    lines.push(`- \`${title}\``);
+  }
+  lines.push('</details>');
+}
+
+console.log(lines.join('\n'));

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -1,9 +1,14 @@
 import {test, expect} from '@playwright/test';
+import fs from 'fs';
 import path from 'path';
 import {getStories, waitForStoryReady} from './utils';
 
 const storybookDir = path.resolve(__dirname, '../apps/storybook/dist');
 const stories = getStories(storybookDir);
+const snapshotsDir = path.resolve(
+  __dirname,
+  'visual-regression.spec.ts-snapshots',
+);
 
 for (const story of stories) {
   test(`${story.title} / ${story.name}`, async ({page}) => {
@@ -12,8 +17,11 @@ for (const story of stories) {
 
     await waitForStoryReady(page);
 
+    // Generate the expected snapshot filename (matches Playwright's naming)
+    const snapshotName = `${story.title}/${story.name}.png`;
+
     await expect(page.locator('#storybook-root')).toHaveScreenshot(
-      `${story.title}/${story.name}.png`,
+      snapshotName,
     );
   });
 }


### PR DESCRIPTION
## Summary

Alternative to PR #392 (removing VRT entirely). Makes VRT non-blocking instead of removing it.

### Problem
VRT fails on every PR that touches components because:
1. **Generate-then-test race condition**: Auto-generated baselines differ from subsequent test runs (non-deterministic screenshots between Playwright runs)
2. **Orphaned baselines**: 24 stale baselines for renamed/removed stories
3. **Missing baselines**: 22 stories have no baselines (new stories on existing components not detected)
4. **Cross-platform mismatch**: Baselines generated on macOS, CI runs on Ubuntu

### Solution
Make VRT informational (⚠️ warning) instead of blocking (❌ failure):

1. **Non-blocking VRT** — Remove `exit 1`, change comment from ❌ to ⚠️
2. **Post-merge baseline regen** — New workflow regenerates baselines on main after merge
3. **Orphan cleanup** — Script detects/removes stale baselines
4. **Keep `/update-baselines`** — For intentional visual changes before merge

### What's in this PR
The scripts are pushed. The workflow changes (`ci.yml` + `regenerate-baselines.yml`) need `workflow` scope on the GitHub token to push. The full diffs are below — can be applied manually or after token upgrade.

<details>
<summary>ci.yml changes (click to expand)</summary>

Key changes:
- Remove `exit 1` at end of VRT job (line ~630)
- Remove in-PR baseline generation steps (generate + commit new baselines)
- Change PR comment from ❌ to ⚠️ for visual changes
- Add `github.event_name == 'pull_request'` condition (skip merge queue)
- Parse test output for richer PR comments (pass/fail counts)

</details>

<details>
<summary>regenerate-baselines.yml (new file, click to expand)</summary>

```yaml
# Regenerate VRT baselines after PRs merge to main.
# Ensures baselines are always generated in the CI environment (Ubuntu)
# rather than from developer machines (macOS).
name: Regenerate VRT Baselines

on:
  push:
    branches: [main]
    paths:
      - 'packages/core/src/**'
      - 'apps/storybook/stories/**'

concurrency:
  group: vrt-baselines
  cancel-in-progress: true

permissions:
  contents: write

jobs:
  regenerate:
    runs-on: ubuntu-latest
    steps:
      - name: Checkout
        uses: actions/checkout@v4
        with:
          token: ${{ secrets.GITHUB_TOKEN }}

      - name: Setup Node.js
        uses: actions/setup-node@v4
        with:
          node-version: 20
          cache: 'yarn'

      - name: Install dependencies
        run: yarn install --frozen-lockfile

      - name: Build core package
        run: yarn build

      - name: Build Storybook
        run: yarn workspace @xds/storybook build

      - name: Install Playwright Chromium
        run: npx playwright install chromium

      - name: Regenerate all baselines
        run: npx playwright test --update-snapshots 2>&1 || true

      - name: Clean orphaned baselines
        run: node .github/scripts/clean-orphaned-baselines.js

      - name: Commit updated baselines
        run: |
          git add e2e/visual-regression.spec.ts-snapshots/
          git config user.name "github-actions[bot]"
          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

          if git diff --cached --quiet; then
            echo "No baseline changes"
          else
            CHANGED=$(git diff --cached --stat | tail -1)
            git commit -m "chore(vrt): regenerate baselines

          $CHANGED"
            git push
            echo "Committed and pushed updated baselines"
          fi

```

</details>

### Why NOT remove VRT (counter to PR #392)
- VRT catches real regressions — a spacing change in XDSButton affects 50+ stories
- The fix is small (remove `exit 1`, add post-merge regen)
- Once removed, 561 baselines are gone and hard to recreate correctly
- The `/update-baselines` flow is already solid

### Token fix needed
The `GH_TOKEN` is an OAuth App token (`gho_` prefix) with `repo` scope but not `workflow`. Options:
1. Create a fine-grained PAT with `workflow` scope for the Navi bot
2. Use the Navi GitHub App's installation token (has all permissions)
3. Manually push the workflow files from a local machine
