### PR TITLE
chore: add CODEOWNERS for auto-review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Default reviewers for the XDS repository
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Cindy reviews everything by default
+* @cixzhang


### PR DESCRIPTION
Adds a CODEOWNERS file so @cixzhang is automatically requested as reviewer on all PRs.

This ensures no PR slips through without review.

---
*Crafted with care by Navi*