### PR TITLE
docs(Button): add onClick and onClickAction to props table

### DIFF
--- a/packages/core/src/Button/README.md
+++ b/packages/core/src/Button/README.md
@@ -69,6 +69,8 @@ or `<span onClick>` for accessibility (keyboard navigation, focus management, sc
 | `children`   | `ReactNode`                                                 | —             | Button content                                                                                                                                       |
 | `endSlot`    | `ReactElement<XDSIconProps> \| ReactElement<XDSBadgeProps>` | —             | Trailing icon or badge after the label. Only accepts `<XDSIcon>` or `<XDSBadge>`. Ignored for icon-only. Color is inherited from the button variant. |
 | `tooltip`    | `string`                                                    | —             | Tooltip text shown on hover                                                                                                                          |
+| `onClick`    | `(e: MouseEvent) => void`                                   | —             | Standard click handler (passed through from `ButtonHTMLAttributes`)                                                                                  |
+| `onClickAction` | `(e: MouseEvent) => void \| Promise<void>`               | —             | Async click handler. Shows loading state while the returned promise is pending.                                                                      |
 
 ## Files
 


### PR DESCRIPTION
The Button README props table was missing two click handlers:

- `onClick` — standard passthrough from `ButtonHTMLAttributes`, works on every button
- `onClickAction` — async handler that shows loading state while the returned promise is pending

**How this was found:** During a [toggle button vibe test](https://github.com/facebookexperimental/xds/issues/169#issuecomment-3981606529), all 12 LLM agents used `onClick` (from doc examples) despite it not being in the props table. The doc gap meant agents were using an undocumented-but-valid prop.

This is a docs-only change — no component code modified.