### PR TITLE
fix(sandbox): generate AGENTS.md on install via postinstall

### DIFF
--- a/apps/sandbox/README.md
+++ b/apps/sandbox/README.md
@@ -4,6 +4,22 @@ XDS component sandbox for designer exploration and vibe testing. Deployed alongs
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Setup
+
+Before writing any code, install dependencies:
+
+```bash
+npm install
+```
+
+This automatically generates `AGENTS.md` with the XDS component index via `xds agent-docs`. **Read `AGENTS.md` for all XDS component documentation** — it contains CLI commands to browse components, tokens, themes, and design rules.
+
+If `AGENTS.md` is missing, regenerate it:
+
+```bash
+npx xds agent-docs
+```
+
 ## How it works
 
 The sandbox is a Next.js app configured for static export (`output: 'export'`). On PRs, the CI workflow builds it and deploys to GitHub Pages at a versioned URL:

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "postinstall": "xds postinstall"
+    "postinstall": "xds agent-docs"
   },
   "dependencies": {
     "@stylexjs/stylex": "^0.17.4",


### PR DESCRIPTION
## Summary

LLMs opening the sandbox have no XDS docs because `AGENTS.md` is gitignored (correctly — it's generated). The postinstall script ran `xds postinstall` which only printed a welcome banner.

## Changes

1. **`apps/sandbox/package.json`** — postinstall now runs `xds agent-docs` instead of `xds postinstall`. This generates `AGENTS.md` with the component index on `npm install`.

2. **`apps/sandbox/README.md`** — Added setup section directing LLMs to run `npm install` first and read `AGENTS.md` for all XDS documentation. Includes fallback command (`npx xds agent-docs`) if the file is missing.

## Why

- `AGENTS.md` is gitignored (generated, not committed) ✓
- `@xds/cli` is already a dependency ✓
- `xds agent-docs` command and `installAgentDocs()` function already exist ✓
- The only missing piece was wiring postinstall to actually generate the docs

Closes #398