### PR TITLE
docs(table): lead with rich renderCell examples and composition hints

### DIFF
--- a/packages/core/src/Table/README.md
+++ b/packages/core/src/Table/README.md
@@ -1,6 +1,7 @@
 # Table
 
-Table components for the XDS design system.
+Data-driven table with rich cell content via `renderCell`. Compose cells with
+XDSBadge, XDSStatusDot, XDSText, XDSAvatar, and layout primitives.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
@@ -47,14 +48,52 @@ Table components for the XDS design system.
 
 ### XDSTable
 
-Styled, data-driven table with density, dividers, hover, and plugin support.
+Styled, data-driven table. Use `renderCell` on columns for rich cell content —
+compose with XDSBadge, XDSStatusDot, XDSText, XDSAvatar, and layout primitives.
 
 ```tsx
 <XDSTable
   data={users}
   columns={[
-    {key: 'name', header: 'Name'},
-    {key: 'email', header: 'Email', width: proportional(2)},
+    {
+      key: 'name',
+      header: 'Name',
+      renderCell: user => (
+        <XDSHStack gap="space2" align="center">
+          <XDSAvatar name={user.name} size="small" />
+          <XDSVStack gap="space1">
+            <XDSText type="body" weight="semibold">
+              {user.name}
+            </XDSText>
+            <XDSText type="supporting" color="secondary">
+              {user.email}
+            </XDSText>
+          </XDSVStack>
+        </XDSHStack>
+      ),
+    },
+    {
+      key: 'status',
+      header: 'Status',
+      width: pixel(140),
+      renderCell: user => (
+        <XDSHStack gap="space2" align="center">
+          <XDSStatusDot status={user.isActive ? 'positive' : 'negative'} />
+          <XDSBadge variant={user.isActive ? 'success' : 'error'}>
+            {user.isActive ? 'Active' : 'Inactive'}
+          </XDSBadge>
+        </XDSHStack>
+      ),
+    },
+    {
+      key: 'role',
+      header: 'Role',
+      renderCell: user => (
+        <XDSText type="label" color="secondary">
+          {user.role}
+        </XDSText>
+      ),
+    },
   ]}
   density="balanced"
   dividers="rows"
@@ -62,17 +101,17 @@ Styled, data-driven table with density, dividers, hover, and plugin support.
 />
 ```
 
-| Prop        | Type                              | Default      | Description                          |
-| ----------- | --------------------------------- | ------------ | ------------------------------------ |
-| `data`      | `T[]`                             | —            | Array of data items                  |
-| `columns`   | `XDSTableColumn<T>[]`             | —            | Column definitions (auto-generated if omitted) |
-| `idKey`     | `string \| (item: T) => string`   | —            | Row key for React reconciliation     |
-| `density`   | `'compact' \| 'balanced' \| 'spacious'` | `'balanced'` | Row density                   |
-| `dividers`  | `XDSTableDividers`                | `'rows'`     | Divider style                        |
-| `isStriped` | `boolean`                         | `false`      | Striped even rows                    |
-| `hasHover`  | `boolean`                         | `false`      | Hover highlight on rows              |
-| `plugins`   | `Record<string, TablePlugin<T>>`  | —            | Named plugins to extend behavior     |
-| `children`  | `ReactNode`                       | —            | Children mode (manual rows)          |
+| Prop        | Type                                    | Default      | Description                                                    |
+| ----------- | --------------------------------------- | ------------ | -------------------------------------------------------------- |
+| `data`      | `T[]`                                   | —            | Array of data items                                            |
+| `columns`   | `XDSTableColumn<T>[]`                   | —            | Column definitions with optional `renderCell` for rich content |
+| `idKey`     | `string \| (item: T) => string`         | —            | Row key for React reconciliation                               |
+| `density`   | `'compact' \| 'balanced' \| 'spacious'` | `'balanced'` | Row density                                                    |
+| `dividers`  | `XDSTableDividers`                      | `'rows'`     | Divider style                                                  |
+| `isStriped` | `boolean`                               | `false`      | Striped even rows                                              |
+| `hasHover`  | `boolean`                               | `false`      | Hover highlight on rows                                        |
+| `plugins`   | `Record<string, TablePlugin<T>>`        | —            | Named plugins to extend behavior                               |
+| `children`  | `ReactNode`                             | —            | Children mode (manual rows)                                    |
 
 ### XDSBaseTable
 
@@ -83,19 +122,19 @@ Unstyled table with colgroup, plugin pipeline, and components prop for custom re
   data={items}
   columns={columns}
   plugins={[myPlugin]}
-  components={{ Row: XDSTableRow, Cell: XDSTableCell }}
+  components={{Row: XDSTableRow, Cell: XDSTableCell}}
 />
 ```
 
-| Prop         | Type                       | Default | Description                               |
-| ------------ | -------------------------- | ------- | ----------------------------------------- |
-| `data`       | `T[]`                      | —       | Array of data items                       |
-| `columns`    | `XDSTableColumn<T>[]`      | —       | Column definitions                        |
-| `idKey`      | `string \| (item: T) => string` | —  | Row key for React reconciliation          |
-| `plugins`    | `TablePlugin<T>[]`         | —       | Ordered plugins for transform pipeline    |
-| `components` | `{Row?, Cell?, HeaderCell?}` | —     | Component overrides for table elements    |
-| `children`   | `ReactNode`                | —       | Children mode                             |
-| `tableProps` | `HTMLAttributes`           | —       | Additional attrs for `<table>` element    |
+| Prop         | Type                            | Default | Description                            |
+| ------------ | ------------------------------- | ------- | -------------------------------------- |
+| `data`       | `T[]`                           | —       | Array of data items                    |
+| `columns`    | `XDSTableColumn<T>[]`           | —       | Column definitions                     |
+| `idKey`      | `string \| (item: T) => string` | —       | Row key for React reconciliation       |
+| `plugins`    | `TablePlugin<T>[]`              | —       | Ordered plugins for transform pipeline |
+| `components` | `{Row?, Cell?, HeaderCell?}`    | —       | Component overrides for table elements |
+| `children`   | `ReactNode`                     | —       | Children mode                          |
+| `tableProps` | `HTMLAttributes`                | —       | Additional attrs for `<table>` element |
 
 ### XDSTableRow
 
@@ -115,15 +154,22 @@ Unstyled table with colgroup, plugin pipeline, and components prop for custom re
 
 ### XDSTableCell
 
-`<td>` wrapper with context-aware styling and xstyle support.
+`<td>` wrapper with context-aware styling and xstyle support. Accepts any ReactNode
+as children — compose rich content with XDS components like XDSBadge, XDSStatusDot,
+XDSText, XDSAvatar, and layout primitives.
 
 ```tsx
-<XDSTableCell>Cell content</XDSTableCell>
+<XDSTableCell>
+  <XDSHStack gap="space2" align="center">
+    <XDSStatusDot status="positive" />
+    <XDSText weight="semibold">Active</XDSText>
+  </XDSHStack>
+</XDSTableCell>
 ```
 
-| Prop       | Type                             | Default | Description     |
-| ---------- | -------------------------------- | ------- | --------------- |
-| `children` | `ReactNode`                      | —       | Cell content    |
+| Prop       | Type                           | Default | Description     |
+| ---------- | ------------------------------ | ------- | --------------- |
+| `children` | `ReactNode`                    | —       | Cell content    |
 | `xstyle`   | `StyleXStyles \| StyleXStyles` | —       | Style overrides |
 
 ### XDSTableHeaderCell
@@ -141,7 +187,60 @@ Unstyled table with colgroup, plugin pipeline, and components prop for custom re
 
 ## Usage Patterns
 
-### Data-driven table
+### Rich cell content with renderCell
+
+Use `renderCell` to compose XDS components inside table cells. This is the
+recommended pattern for any table that displays more than plain text.
+
+```tsx
+const columns = [
+  {
+    key: 'transaction',
+    header: 'Transaction',
+    renderCell: item => (
+      <XDSVStack gap="space1">
+        <XDSText type="body" weight="semibold">
+          {item.description}
+        </XDSText>
+        <XDSText type="supporting" color="secondary">
+          {item.date}
+        </XDSText>
+      </XDSVStack>
+    ),
+  },
+  {
+    key: 'amount',
+    header: 'Amount',
+    width: pixel(120),
+    renderCell: item => (
+      <XDSText
+        type="body"
+        weight="semibold"
+        color={item.amount > 0 ? 'positive' : 'primary'}>
+        {item.amount > 0 ? '+' : ''}
+        {item.amount.toFixed(2)}
+      </XDSText>
+    ),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    width: pixel(140),
+    renderCell: item => (
+      <XDSHStack gap="space2" align="center">
+        <XDSStatusDot status={statusMap[item.status]} />
+        <XDSBadge variant={badgeMap[item.status]}>{item.status}</XDSBadge>
+      </XDSHStack>
+    ),
+  },
+];
+
+<XDSTable data={transactions} columns={columns} hasHover dividers="rows" />;
+```
+
+### Data-driven table (plain text)
+
+For simple tables where plain text is sufficient, columns default to `String(item[key])`:
 
 ```tsx
 <XDSTable
@@ -166,11 +265,20 @@ Unstyled table with colgroup, plugin pipeline, and components prop for custom re
 
 ### Children mode
 
+For fully custom row layouts, use children mode with XDSTableRow and XDSTableCell:
+
 ```tsx
 <XDSTable density="balanced" dividers="rows" isStriped hasHover>
   <XDSTableRow>
-    <XDSTableCell>Alice</XDSTableCell>
-    <XDSTableCell>30</XDSTableCell>
+    <XDSTableCell>
+      <XDSHStack gap="space2" align="center">
+        <XDSAvatar name="Alice" size="small" />
+        <XDSText weight="semibold">Alice</XDSText>
+      </XDSHStack>
+    </XDSTableCell>
+    <XDSTableCell>
+      <XDSBadge variant="success">Active</XDSBadge>
+    </XDSTableCell>
   </XDSTableRow>
 </XDSTable>
 ```

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -180,17 +180,30 @@ function XDSTableInner<T extends Record<string, unknown>>(
  * Density, dividers, striped rows, and hover effects are applied via
  * design tokens in the component styles.
  *
+ * @compositionHint Use renderCell on columns to compose rich cell content.
+ * Combine with XDSBadge (status labels), XDSStatusDot (colored indicators),
+ * XDSText (formatted values), XDSAvatar (user cells), and XDSHStack/XDSVStack
+ * (multi-element cell layouts). Without renderCell, cells render as plain text.
+ *
  * @example
  * ```
  * <XDSTable
  *   data={users}
  *   columns={[
- *     { key: 'name', header: 'Name' },
- *     { key: 'email', header: 'Email' },
+ *     { key: 'name', header: 'Name', renderCell: (u) => (
+ *       <XDSHStack gap="space2" align="center">
+ *         <XDSAvatar name={u.name} size="small" />
+ *         <XDSText weight="semibold">{u.name}</XDSText>
+ *       </XDSHStack>
+ *     )},
+ *     { key: 'status', header: 'Status', renderCell: (u) => (
+ *       <XDSBadge variant={u.active ? 'success' : 'error'}>
+ *         {u.active ? 'Active' : 'Inactive'}
+ *       </XDSBadge>
+ *     )},
  *   ]}
  *   density="compact"
  *   dividers="grid"
- *   isStriped
  *   hasHover
  * />
  * ```

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -60,8 +60,28 @@ export interface XDSTableColumn<T extends Record<string, unknown>> {
   /** Column width. Defaults to `proportional(1)`. */
   width?: ColumnWidth;
   /**
-   * Custom cell renderer. Receives the row item.
-   * Defaults to `String(item[key])`.
+   * Custom cell renderer. Receives the row item and returns rich JSX content.
+   * Defaults to `String(item[key])` — use renderCell for rich content like
+   * badges, status dots, formatted text, icons, or composed layouts.
+   *
+   * @compositionHint Use renderCell to compose rich table cells:
+   * - XDSBadge for status labels (success/warning/error variants)
+   * - XDSStatusDot for colored indicators
+   * - XDSText with color="positive"|"negative" for formatted values
+   * - XDSHStack to combine multiple elements in a cell
+   * - XDSAvatar for user/entity cells
+   *
+   * @example
+   * ```tsx
+   * renderCell: (item) => (
+   *   <XDSHStack gap="space2" align="center">
+   *     <XDSStatusDot status={item.isActive ? 'positive' : 'negative'} />
+   *     <XDSBadge variant={item.isActive ? 'success' : 'error'}>
+   *       {item.isActive ? 'Active' : 'Inactive'}
+   *     </XDSBadge>
+   *   </XDSHStack>
+   * )
+   * ```
    */
   renderCell?: (item: T) => ReactNode;
 }


### PR DESCRIPTION
## What

Updates Table README, JSDoc, and types to prioritize rich cell content via `renderCell`.

## Why

Vibe tests showed XDS table cells were consistently less rich than baseline (shadcn/HTML). Root cause: the documented happy path produced plain text cells — `renderCell` existed but was a secondary pattern agents didn't always reach for.

Two specific issues:
- **Wrong prop name**: 2/5 agents used `render:` instead of `renderCell:` — custom renderers silently failed, falling back to `String(item[key])`
- **Plain text default**: Without prominent `renderCell` examples, agents defaulted to data-driven mode with no custom rendering

## Changes

1. **README**: First example now shows `renderCell` with `XDSBadge`, `XDSStatusDot`, `XDSText`, `XDSAvatar`, and `XDSHStack` composition
2. **Top-level description**: Changed from generic "Table components" to mention `renderCell` and composable cells — this flows into the CLI brief docs
3. **JSDoc on `XDSTableColumn.renderCell`**: Added `@compositionHint` listing common cell components
4. **JSDoc on `XDSTable`**: Added `@compositionHint` and rich example in the component docstring
5. **XDSTableCell description**: Updated to mention rich content composition

## Vibe Test Results

Focused test on 5 table-heavy prompts, before (main docs) vs after (this PR):

| Prompt | Before | After | Δ |
|--------|--------|-------|---|
| dd-1 (users table) | 5 | 26 | +21 ✅ |
| dd-2 (transactions) | 15 | 21 | +6 ✅ |
| dd-5 (email inbox) | 16 | 21 | +5 ✅ |
| wd-4 (TodoTracker) | 22 | 24 | +2 ✅ |
| fwc-5 (row actions) | 0 | 21 | +21 ✅ |

**After wins 5/5 prompts. +95% richness score overall.**

Key wins:
- 0 wrong prop names (vs 2/5 before)
- XDSBadge usage: 1.4 → 3.4 avg per file (+143%)
- XDSHStack in cells: 0.4 → 1.6 avg (+300%)
- dd-1 went from 0 renderCell (all plain text) to 5 renderCell with Avatar + Badge + formatted Text
