### PR TITLE
fix(Card): use divider color borders on all cards

### DIFF
--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -41,16 +41,13 @@ const styles = stylex.create({
     boxShadow: elevationVars['--elevation-base'],
     // Clip content to border-radius so nested containers don't peek out corners
     overflow: 'clip',
-    // Use inherited --card-border-color if set by ancestor, otherwise transparent
     borderWidth: 1,
     borderStyle: 'solid',
-    borderColor: 'var(--card-border-color, transparent)',
+    borderColor: colorVars['--color-divider'],
   },
   // Inner wrapper: container padding and overflow handling
   cardInner: {
     height: '100%',
-    // Cards have surface background, so nested cards need visible borders
-    '--card-border-color': colorVars['--color-divider'],
   },
   // Only enable scrolling when card has fixed height
   scrollable: {

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -43,17 +43,12 @@ declare module '../theme/types' {
 const variantStyles = stylex.create({
   section: {
     backgroundColor: colorVars['--color-surface'],
-    // Surface background: nested cards need visible borders
-    '--card-border-color': colorVars['--color-divider'],
   },
   transparent: {
     backgroundColor: 'transparent',
-    // Transparent inherits --card-border-color from parent
   },
   wash: {
     backgroundColor: colorVars['--color-wash'],
-    // Wash background: nested cards don't need borders
-    '--card-border-color': 'transparent',
   },
 });
 


### PR DESCRIPTION
## What

Cards now always show `--color-divider` borders instead of relying on CSS variable inheritance for conditional borders.

**Before:** Top-level cards had transparent borders (just shadow), nested cards got divider borders via `--card-border-color` inheritance. Section variants (`wash`, `transparent`) also manipulated this variable.

**After:** All cards show divider borders directly. Removed the `--card-border-color` CSS variable cascade from Card and Section.

### Changes
- `XDSCard`: `borderColor` uses `colorVars['--color-divider']` directly instead of `var(--card-border-color, transparent)`
- `XDSCard`: Removed `--card-border-color` setting from `cardInner`
- `XDSSection`: Removed `--card-border-color` settings from all variants (`section`, `transparent`, `wash`)

Split from #407.

---
*Crafted with care by Navi*