### PR TITLE
ci: add review gate for code owner approval

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -1,0 +1,82 @@
+name: Review Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  review-gate:
+    name: review-gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout CODEOWNERS
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/CODEOWNERS
+          sparse-checkout-cone-mode: false
+
+      - name: Check review requirement
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+
+            // Parse CODEOWNERS for global owners (* pattern)
+            const codeowners = fs.readFileSync('.github/CODEOWNERS', 'utf8');
+            const globalOwners = new Set();
+            for (const line of codeowners.split('\n')) {
+              const trimmed = line.trim();
+              if (trimmed.startsWith('#') || !trimmed) continue;
+              const parts = trimmed.split(/\s+/);
+              if (parts[0] === '*') {
+                for (let i = 1; i < parts.length; i++) {
+                  globalOwners.add(parts[i].replace('@', ''));
+                }
+              }
+            }
+
+            if (globalOwners.size === 0) {
+              core.setFailed('No global code owners found in CODEOWNERS');
+              return;
+            }
+
+            console.log(`Code owners: ${[...globalOwners].join(', ')}`);
+
+            const pr = context.payload.pull_request
+              ?? (await github.rest.pulls.get({
+                   owner: context.repo.owner,
+                   repo: context.repo.repo,
+                   pull_number: context.payload.review?.pull_request?.number
+                                ?? context.issue.number,
+                 })).data;
+
+            // Auto-pass for code owners' own PRs
+            if (globalOwners.has(pr.user.login)) {
+              console.log(`PR author ${pr.user.login} is a code owner — auto-approved`);
+              return;
+            }
+
+            // For everyone else, require an approving review from a code owner
+            const reviews = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+            });
+
+            const latestReviews = new Map();
+            for (const review of reviews.data) {
+              latestReviews.set(review.user.login, review.state);
+            }
+
+            for (const owner of globalOwners) {
+              if (latestReviews.get(owner) === 'APPROVED') {
+                console.log(`Code owner @${owner} has approved this PR`);
+                return;
+              }
+            }
+
+            core.setFailed(
+              `Requires an approving review from a code owner (${[...globalOwners].map(o => '@' + o).join(', ')}) before merging.`
+            );


### PR DESCRIPTION
Adds a GitHub Actions workflow that enforces code owner review as a required status check:

- *Auto-passes* for PRs authored by a global code owner (from `.github/CODEOWNERS`)
- *Blocks* all other PRs until a code owner approves
- Re-evaluates on new pushes and review submissions
- `review-gate` is already added as a required status check in the CI ruleset

This replaces the branch protection / ruleset review requirement approach, which didn't support per-user bypass with the merge queue.