### PR TITLE
chore: migrate forwardRef to React 19 ref prop

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -14,12 +14,12 @@
  */
 
 import {
-  forwardRef,
   useCallback,
   useEffect,
   useRef,
   useState,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -58,6 +58,8 @@ const MAIN_CONTENT_ID = 'xds-app-shell-main';
 export type XDSAppShellBreakpoint = 'sm' | 'md' | 'lg' | 'none';
 
 export interface XDSAppShellProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Background color of the shell.
    * - `wash`: Page-level background — subtle gray in light, near-black in dark
@@ -287,266 +289,262 @@ const dynamicStyles = stylex.create({
  * </XDSAppShell>
  * ```
  */
-export const XDSAppShell = forwardRef<HTMLDivElement, XDSAppShellProps>(
-  function XDSAppShell(
-    {
-      background = 'surface',
-      banner,
-      children,
-      'data-testid': dataTestId,
-      height = 'fill',
-      initialIsSideNavCollapsed = false,
-      isSideNavCollapsed: controlledCollapsed,
-      onSideNavCollapsedChange,
-      sideNav,
-      sideNavBreakpoint = 'md',
-      sideNavWidth = DEFAULT_SIDENAV_WIDTH,
-      topNav,
-      xstyle,
-    },
-    ref,
-  ) {
-    // =========================================================================
-    // SideNav collapse state (controlled + uncontrolled)
-    // =========================================================================
-    const isControlled = controlledCollapsed !== undefined;
-    const [uncontrolledCollapsed, setUncontrolledCollapsed] = useState(
-      initialIsSideNavCollapsed,
-    );
-    const isCollapsed = isControlled
-      ? controlledCollapsed
-      : uncontrolledCollapsed;
+export function XDSAppShell({
+  ref,
+  background = 'surface',
+  banner,
+  children,
+  'data-testid': dataTestId,
+  height = 'fill',
+  initialIsSideNavCollapsed = false,
+  isSideNavCollapsed: controlledCollapsed,
+  onSideNavCollapsedChange,
+  sideNav,
+  sideNavBreakpoint = 'md',
+  sideNavWidth = DEFAULT_SIDENAV_WIDTH,
+  topNav,
+  xstyle,
+}: XDSAppShellProps) {
+  // =========================================================================
+  // SideNav collapse state (controlled + uncontrolled)
+  // =========================================================================
+  const isControlled = controlledCollapsed !== undefined;
+  const [uncontrolledCollapsed, setUncontrolledCollapsed] = useState(
+    initialIsSideNavCollapsed,
+  );
+  const isCollapsed = isControlled
+    ? controlledCollapsed
+    : uncontrolledCollapsed;
 
-    // Track whether we're below the breakpoint
-    const [isBelowBreakpoint, setIsBelowBreakpoint] = useState(false);
+  // Track whether we're below the breakpoint
+  const [isBelowBreakpoint, setIsBelowBreakpoint] = useState(false);
 
-    const isFill = height === 'fill';
-    const isAuto = height === 'auto';
-    const hasSideNav = sideNav != null;
-    const hasTopNav = topNav != null;
-    const hasBanner = banner != null;
+  const isFill = height === 'fill';
+  const isAuto = height === 'auto';
+  const hasSideNav = sideNav != null;
+  const hasTopNav = topNav != null;
+  const hasBanner = banner != null;
 
-    // =========================================================================
-    // Header height measurement for sticky sideNav offset (auto mode)
-    // =========================================================================
-    const headerRef = useRef<HTMLDivElement>(null);
-    const shellRef = useRef<HTMLDivElement>(null);
+  // =========================================================================
+  // Header height measurement for sticky sideNav offset (auto mode)
+  // =========================================================================
+  const headerRef = useRef<HTMLDivElement>(null);
+  const shellRef = useRef<HTMLDivElement>(null);
 
-    // Merge forwarded ref with internal shell ref
-    const setShellRef = useCallback(
-      (node: HTMLDivElement | null) => {
-        (shellRef as React.MutableRefObject<HTMLDivElement | null>).current =
-          node;
-        if (typeof ref === 'function') {
-          ref(node);
-        } else if (ref) {
-          (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
-        }
-      },
-      [ref],
-    );
-
-    useEffect(() => {
-      if (!isAuto || !headerRef.current || !shellRef.current) return;
-
-      const headerEl = headerRef.current;
-      const shellEl = shellRef.current;
-
-      const updateHeight = () => {
-        const height = headerEl.getBoundingClientRect().height;
-        shellEl.style.setProperty('--appshell-header-height', `${height}px`);
-      };
-
-      updateHeight();
-
-      const observer = new ResizeObserver(updateHeight);
-      observer.observe(headerEl);
-      return () => observer.disconnect();
-    }, [isAuto]);
-
-    // =========================================================================
-    // Responsive breakpoint handling
-    //
-    // Uses matchMedia which is event-driven — the listener only fires when the
-    // media query match state actually changes, not on every resize. This is
-    // efficient and does not over-trigger.
-    // =========================================================================
-    useEffect(() => {
-      if (sideNavBreakpoint === 'none' || !hasSideNav) return;
-
-      const breakpointPx = BREAKPOINT_VALUES[sideNavBreakpoint];
-      const mql = window.matchMedia(`(max-width: ${breakpointPx}px)`);
-
-      const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
-        const matches = 'matches' in e ? e.matches : false;
-        setIsBelowBreakpoint(matches);
-        if (matches) {
-          // Auto-collapse below breakpoint
-          if (!isControlled) {
-            setUncontrolledCollapsed(true);
-          }
-          onSideNavCollapsedChange?.(true);
-        }
-      };
-
-      // Check initial state
-      handleChange(mql);
-
-      mql.addEventListener('change', handleChange);
-      return () => mql.removeEventListener('change', handleChange);
-    }, [sideNavBreakpoint, hasSideNav, isControlled, onSideNavCollapsedChange]);
-
-    // =========================================================================
-    // Toggle handler — snaps open/closed (no transitions for now)
-    // TODO: Add ViewTransitions support with React transition API
-    // =========================================================================
-    const handleToggleCollapse = useCallback(() => {
-      const newValue = !isCollapsed;
-      if (!isControlled) {
-        setUncontrolledCollapsed(newValue);
+  // Merge forwarded ref with internal shell ref
+  const setShellRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      (shellRef as React.MutableRefObject<HTMLDivElement | null>).current =
+        node;
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
       }
-      onSideNavCollapsedChange?.(newValue);
-    }, [isCollapsed, isControlled, onSideNavCollapsedChange]);
+    },
+    [ref],
+  );
 
-    // =========================================================================
-    // Close mobile sideNav on Escape
-    // =========================================================================
-    useEffect(() => {
-      if (!isBelowBreakpoint || isCollapsed) return;
+  useEffect(() => {
+    if (!isAuto || !headerRef.current || !shellRef.current) return;
 
-      const handleKeyDown = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') {
-          e.preventDefault();
-          handleToggleCollapse();
+    const headerEl = headerRef.current;
+    const shellEl = shellRef.current;
+
+    const updateHeight = () => {
+      const height = headerEl.getBoundingClientRect().height;
+      shellEl.style.setProperty('--appshell-header-height', `${height}px`);
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(headerEl);
+    return () => observer.disconnect();
+  }, [isAuto]);
+
+  // =========================================================================
+  // Responsive breakpoint handling
+  //
+  // Uses matchMedia which is event-driven — the listener only fires when the
+  // media query match state actually changes, not on every resize. This is
+  // efficient and does not over-trigger.
+  // =========================================================================
+  useEffect(() => {
+    if (sideNavBreakpoint === 'none' || !hasSideNav) return;
+
+    const breakpointPx = BREAKPOINT_VALUES[sideNavBreakpoint];
+    const mql = window.matchMedia(`(max-width: ${breakpointPx}px)`);
+
+    const handleChange = (e: MediaQueryListEvent | MediaQueryList) => {
+      const matches = 'matches' in e ? e.matches : false;
+      setIsBelowBreakpoint(matches);
+      if (matches) {
+        // Auto-collapse below breakpoint
+        if (!isControlled) {
+          setUncontrolledCollapsed(true);
         }
-      };
+        onSideNavCollapsedChange?.(true);
+      }
+    };
 
-      document.addEventListener('keydown', handleKeyDown);
-      return () => document.removeEventListener('keydown', handleKeyDown);
-    }, [isBelowBreakpoint, isCollapsed, handleToggleCollapse]);
+    // Check initial state
+    handleChange(mql);
 
-    // =========================================================================
-    // Determine if sideNav should show as overlay (mobile) or inline
-    // =========================================================================
-    const showSideNavInline = hasSideNav && !isCollapsed && !isBelowBreakpoint;
-    const showSideNavOverlay = hasSideNav && !isCollapsed && isBelowBreakpoint;
+    mql.addEventListener('change', handleChange);
+    return () => mql.removeEventListener('change', handleChange);
+  }, [sideNavBreakpoint, hasSideNav, isControlled, onSideNavCollapsedChange]);
 
-    // =========================================================================
-    // Build header content (topNav + banner)
-    //
-    // In auto mode, the header wrapper gets sticky positioning so the topNav
-    // stays pinned while the page scrolls. The ref is used to measure header
-    // height for the sideNav's sticky offset.
-    // =========================================================================
-    const headerInner =
-      hasTopNav || hasBanner ? (
-        <XDSLayoutHeader isFullBleed hasDivider={hasTopNav}>
-          {hasBanner && <div {...stylex.props(styles.banner)}>{banner}</div>}
-          {hasTopNav && topNav}
-        </XDSLayoutHeader>
-      ) : undefined;
+  // =========================================================================
+  // Toggle handler — snaps open/closed (no transitions for now)
+  // TODO: Add ViewTransitions support with React transition API
+  // =========================================================================
+  const handleToggleCollapse = useCallback(() => {
+    const newValue = !isCollapsed;
+    if (!isControlled) {
+      setUncontrolledCollapsed(newValue);
+    }
+    onSideNavCollapsedChange?.(newValue);
+  }, [isCollapsed, isControlled, onSideNavCollapsedChange]);
 
-    const headerContent =
-      headerInner != null ? (
-        <div ref={headerRef} {...stylex.props(isAuto && styles.headerSticky)}>
-          {headerInner}
-        </div>
-      ) : undefined;
+  // =========================================================================
+  // Close mobile sideNav on Escape
+  // =========================================================================
+  useEffect(() => {
+    if (!isBelowBreakpoint || isCollapsed) return;
 
-    // =========================================================================
-    // Build sideNav content
-    //
-    // In auto mode, the sideNav panel is not internally scrollable (the page
-    // scrolls as a whole), but it gets sticky positioning so it stays pinned
-    // below the header while the main content scrolls. A wrapper div applies
-    // the sticky behavior since XDSLayoutPanel doesn't accept style/className.
-    // =========================================================================
-    const sideNavPanel = showSideNavInline ? (
-      <XDSLayoutPanel
-        isFullBleed
-        hasDivider
-        width={sideNavWidth}
-        role="navigation"
-        label="Application navigation"
-        isScrollable={isFill}>
-        {sideNav}
-      </XDSLayoutPanel>
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        handleToggleCollapse();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isBelowBreakpoint, isCollapsed, handleToggleCollapse]);
+
+  // =========================================================================
+  // Determine if sideNav should show as overlay (mobile) or inline
+  // =========================================================================
+  const showSideNavInline = hasSideNav && !isCollapsed && !isBelowBreakpoint;
+  const showSideNavOverlay = hasSideNav && !isCollapsed && isBelowBreakpoint;
+
+  // =========================================================================
+  // Build header content (topNav + banner)
+  //
+  // In auto mode, the header wrapper gets sticky positioning so the topNav
+  // stays pinned while the page scrolls. The ref is used to measure header
+  // height for the sideNav's sticky offset.
+  // =========================================================================
+  const headerInner =
+    hasTopNav || hasBanner ? (
+      <XDSLayoutHeader isFullBleed hasDivider={hasTopNav}>
+        {hasBanner && <div {...stylex.props(styles.banner)}>{banner}</div>}
+        {hasTopNav && topNav}
+      </XDSLayoutHeader>
     ) : undefined;
 
-    const sideNavContent =
-      sideNavPanel != null && isAuto ? (
-        <div {...stylex.props(styles.sideNavSticky)}>{sideNavPanel}</div>
-      ) : (
-        sideNavPanel
-      );
-
-    // =========================================================================
-    // Build main content
-    // =========================================================================
-    const mainContent = (
-      <XDSLayoutContent
-        isFullBleed
-        role="main"
-        id={MAIN_CONTENT_ID}
-        isScrollable={isFill}>
-        {children}
-      </XDSLayoutContent>
-    );
-
-    // =========================================================================
-    // Render
-    //
-    // TODO: Include root providers (ThemeProvider, ProseProvider, LayerProvider)
-    // at the app level once they're available for wrapping.
-    // =========================================================================
-    return (
-      <div
-        ref={setShellRef}
-        data-testid={dataTestId}
-        {...stylex.props(
-          styles.root,
-          background === 'wash' ? styles.rootBgWash : styles.rootBgSurface,
-          isFill ? styles.rootFill : styles.rootAuto,
-          xstyle,
-        )}>
-        {/* Skip-to-content link */}
-        <a
-          href={`#${MAIN_CONTENT_ID}`}
-          {...stylex.props(styles.skipLink)}
-          data-testid="skip-to-content">
-          Skip to content
-        </a>
-
-        <XDSLayout
-          height={height}
-          isFullBleed
-          header={headerContent}
-          start={sideNavContent}
-          content={mainContent}
-        />
-
-        {/* Mobile overlay sideNav */}
-        {showSideNavOverlay && (
-          <>
-            <div
-              {...stylex.props(styles.backdrop)}
-              onClick={handleToggleCollapse}
-              data-testid="sidenav-backdrop"
-              aria-hidden="true"
-            />
-            <nav
-              aria-label="Application navigation"
-              {...stylex.props(
-                styles.overlaySideNav,
-                dynamicStyles.sideNavWidth(sideNavWidth),
-              )}>
-              {sideNav}
-            </nav>
-          </>
-        )}
+  const headerContent =
+    headerInner != null ? (
+      <div ref={headerRef} {...stylex.props(isAuto && styles.headerSticky)}>
+        {headerInner}
       </div>
+    ) : undefined;
+
+  // =========================================================================
+  // Build sideNav content
+  //
+  // In auto mode, the sideNav panel is not internally scrollable (the page
+  // scrolls as a whole), but it gets sticky positioning so it stays pinned
+  // below the header while the main content scrolls. A wrapper div applies
+  // the sticky behavior since XDSLayoutPanel doesn't accept style/className.
+  // =========================================================================
+  const sideNavPanel = showSideNavInline ? (
+    <XDSLayoutPanel
+      isFullBleed
+      hasDivider
+      width={sideNavWidth}
+      role="navigation"
+      label="Application navigation"
+      isScrollable={isFill}>
+      {sideNav}
+    </XDSLayoutPanel>
+  ) : undefined;
+
+  const sideNavContent =
+    sideNavPanel != null && isAuto ? (
+      <div {...stylex.props(styles.sideNavSticky)}>{sideNavPanel}</div>
+    ) : (
+      sideNavPanel
     );
-  },
-);
+
+  // =========================================================================
+  // Build main content
+  // =========================================================================
+  const mainContent = (
+    <XDSLayoutContent
+      isFullBleed
+      role="main"
+      id={MAIN_CONTENT_ID}
+      isScrollable={isFill}>
+      {children}
+    </XDSLayoutContent>
+  );
+
+  // =========================================================================
+  // Render
+  //
+  // TODO: Include root providers (ThemeProvider, ProseProvider, LayerProvider)
+  // at the app level once they're available for wrapping.
+  // =========================================================================
+  return (
+    <div
+      ref={setShellRef}
+      data-testid={dataTestId}
+      {...stylex.props(
+        styles.root,
+        background === 'wash' ? styles.rootBgWash : styles.rootBgSurface,
+        isFill ? styles.rootFill : styles.rootAuto,
+        xstyle,
+      )}>
+      {/* Skip-to-content link */}
+      <a
+        href={`#${MAIN_CONTENT_ID}`}
+        {...stylex.props(styles.skipLink)}
+        data-testid="skip-to-content">
+        Skip to content
+      </a>
+
+      <XDSLayout
+        height={height}
+        isFullBleed
+        header={headerContent}
+        start={sideNavContent}
+        content={mainContent}
+      />
+
+      {/* Mobile overlay sideNav */}
+      {showSideNavOverlay && (
+        <>
+          <div
+            {...stylex.props(styles.backdrop)}
+            onClick={handleToggleCollapse}
+            data-testid="sidenav-backdrop"
+            aria-hidden="true"
+          />
+          <nav
+            aria-label="Application navigation"
+            {...stylex.props(
+              styles.overlaySideNav,
+              dynamicStyles.sideNavWidth(sideNavWidth),
+            )}>
+            {sideNav}
+          </nav>
+        </>
+      )}
+    </div>
+  );
+}
 
 XDSAppShell.displayName = 'XDSAppShell';

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSAspectRatio.tsx
- * @input Uses React forwardRef, stylex
+ * @input Uses React stylex
  * @output Exports XDSAspectRatio component and XDSAspectRatioProps
  * @position AspectRatio component; maintains a specific aspect ratio for its children
  *
@@ -10,12 +10,7 @@
  * - /apps/storybook/stories/AspectRatio.stories.tsx
  */
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {ThemeContext} from '../theme/ThemeContext';
@@ -37,6 +32,8 @@ export interface XDSAspectRatioProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * The aspect ratio as width/height (e.g., 16/9 = 1.777..., 4/3 = 1.333..., 1 for square).
    */
@@ -82,20 +79,24 @@ const styles = stylex.create({
  * </XDSAspectRatio>
  * ```
  */
-export const XDSAspectRatio = forwardRef<HTMLElement, XDSAspectRatioProps>(
-  function XDSAspectRatio({ratio, children, xstyle, ...props}, ref) {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.aspectRatio?.root;
-    return (
-      <div
-        ref={ref as React.Ref<HTMLDivElement>}
-        {...stylex.props(styles.container, xstyle, rootOverride)}
-        style={{aspectRatio: ratio}}
-        {...props}>
-        <div {...stylex.props(styles.child)}>{children}</div>
-      </div>
-    );
-  },
-);
+export function XDSAspectRatio({
+  ref,
+  ratio,
+  children,
+  xstyle,
+  ...props
+}: XDSAspectRatioProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.aspectRatio?.root;
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      {...stylex.props(styles.container, xstyle, rootOverride)}
+      style={{aspectRatio: ratio}}
+      {...props}>
+      <div {...stylex.props(styles.child)}>{children}</div>
+    </div>
+  );
+}
 
 XDSAspectRatio.displayName = 'XDSAspectRatio';

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSAvatar.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode, useState
+ * @input Uses React HTMLAttributes, ReactNode, useState
  * @output Exports XDSAvatar component, XDSAvatarProps, XDSAvatarSize types
  * @position Core implementation; consumed by index.ts
  *
@@ -12,11 +12,11 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useState,
   type HTMLAttributes,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -179,6 +179,8 @@ export interface XDSAvatarProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'children'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * The alt text shown on hover and made accessible to screen readers.
    * Falls back to `name` if not provided.
@@ -257,92 +259,87 @@ function DefaultIcon({size}: {size: number}) {
  * <XDSAvatar src="/user.jpg" status={<OnlineIndicator />} />
  * ```
  */
-export const XDSAvatar = forwardRef<HTMLDivElement, XDSAvatarProps>(
-  (
-    {
-      alt,
-      'data-testid': testId,
-      fallbackSrc,
-      name,
-      size = 'small',
-      src,
-      status,
-      ...props
-    },
-    ref,
-  ) => {
-    const [imageError, setImageError] = useState(false);
-    const [fallbackError, setFallbackError] = useState(false);
+export function XDSAvatar({
+  ref,
+  alt,
+  'data-testid': testId,
+  fallbackSrc,
+  name,
+  size = 'small',
+  src,
+  status,
+  ...props
+}: XDSAvatarProps) {
+  const [imageError, setImageError] = useState(false);
+  const [fallbackError, setFallbackError] = useState(false);
 
-    const showImage = src && !imageError;
-    const showFallbackImage = !showImage && fallbackSrc && !fallbackError;
-    const showInitials = !showImage && !showFallbackImage && name;
-    const showIcon = !showImage && !showFallbackImage && !name;
+  const showImage = src && !imageError;
+  const showFallbackImage = !showImage && fallbackSrc && !fallbackError;
+  const showInitials = !showImage && !showFallbackImage && name;
+  const showIcon = !showImage && !showFallbackImage && !name;
 
-    const accessibleName = alt || name || 'Avatar';
-    const numericSize = resolveSize(size);
+  const accessibleName = alt || name || 'Avatar';
+  const numericSize = resolveSize(size);
 
-    // Get theme context for component-level overrides (optional)
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.avatar?.root;
-    const fallbackOverride = themeContext?.theme.components?.avatar?.fallback;
+  // Get theme context for component-level overrides (optional)
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.avatar?.root;
+  const fallbackOverride = themeContext?.theme.components?.avatar?.fallback;
 
-    return (
-      <XDSAvatarSizeContext.Provider value={numericSize}>
-        <div
-          ref={ref}
-          role="img"
-          aria-label={accessibleName}
-          data-testid={testId}
-          {...stylex.props(styles.wrapper, rootOverride)}
-          {...props}>
-          <div
-            {...stylex.props(styles.content, dynamicStyles.size(numericSize))}>
-            {showImage && (
-              <img
-                src={src}
-                alt={accessibleName}
-                onError={() => setImageError(true)}
-                {...stylex.props(styles.image)}
-              />
-            )}
-            {showFallbackImage && (
-              <img
-                src={fallbackSrc}
-                alt={accessibleName}
-                onError={() => setFallbackError(true)}
-                {...stylex.props(styles.image)}
-              />
-            )}
-            {showInitials && (
-              <div
-                {...stylex.props(
-                  styles.fallback,
-                  dynamicStyles.fontSize(numericSize),
-                  fallbackOverride,
-                )}>
-                {getInitials(name)}
-              </div>
-            )}
-            {showIcon && (
-              <div {...stylex.props(styles.fallback, fallbackOverride)}>
-                <DefaultIcon size={numericSize} />
-              </div>
-            )}
-          </div>
-          {status && (
+  return (
+    <XDSAvatarSizeContext.Provider value={numericSize}>
+      <div
+        ref={ref}
+        role="img"
+        aria-label={accessibleName}
+        data-testid={testId}
+        {...stylex.props(styles.wrapper, rootOverride)}
+        {...props}>
+        <div {...stylex.props(styles.content, dynamicStyles.size(numericSize))}>
+          {showImage && (
+            <img
+              src={src}
+              alt={accessibleName}
+              onError={() => setImageError(true)}
+              {...stylex.props(styles.image)}
+            />
+          )}
+          {showFallbackImage && (
+            <img
+              src={fallbackSrc}
+              alt={accessibleName}
+              onError={() => setFallbackError(true)}
+              {...stylex.props(styles.image)}
+            />
+          )}
+          {showInitials && (
             <div
               {...stylex.props(
-                styles.status,
-                dynamicStyles.statusPosition(numericSize),
+                styles.fallback,
+                dynamicStyles.fontSize(numericSize),
+                fallbackOverride,
               )}>
-              {status}
+              {getInitials(name)}
+            </div>
+          )}
+          {showIcon && (
+            <div {...stylex.props(styles.fallback, fallbackOverride)}>
+              <DefaultIcon size={numericSize} />
             </div>
           )}
         </div>
-      </XDSAvatarSizeContext.Provider>
-    );
-  },
-);
+        {status && (
+          <div
+            {...stylex.props(
+              styles.status,
+              dynamicStyles.statusPosition(numericSize),
+            )}>
+            {status}
+          </div>
+        )}
+      </div>
+    </XDSAvatarSizeContext.Provider>
+  );
+}
 
 XDSAvatar.displayName = 'XDSAvatar';

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSBadge.tsx
- * @input Uses React forwardRef, HTMLAttributes
+ * @input Uses React HTMLAttributes
  * @output Exports XDSBadge component, XDSBadgeProps, XDSBadgeVariant types
  * @position Core implementation; consumed by index.ts
  *
@@ -11,12 +11,7 @@
  * - /apps/storybook/stories/Badge.stories.tsx (storybook stories)
  */
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -102,6 +97,8 @@ export interface XDSBadgeProps extends Omit<
   HTMLAttributes<HTMLSpanElement>,
   'className' | 'style'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLSpanElement>;
   /**
    * The visual style variant of the badge.
    * @default 'neutral'
@@ -132,32 +129,36 @@ export interface XDSBadgeProps extends Omit<
  * <XDSBadge variant="info" /> // Dot indicator
  * ```
  */
-export const XDSBadge = forwardRef<HTMLSpanElement, XDSBadgeProps>(
-  ({variant = 'neutral', children, icon, ...props}, ref) => {
-    const isDot = children == null && icon == null;
+export function XDSBadge({
+  ref,
+  variant = 'neutral',
+  children,
+  icon,
+  ...props
+}: XDSBadgeProps) {
+  const isDot = children == null && icon == null;
 
-    // Get theme context for component-level overrides (optional)
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.badge?.root;
-    const variantOverride =
-      themeContext?.theme.components?.badge?.variants?.[variant];
+  // Get theme context for component-level overrides (optional)
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.badge?.root;
+  const variantOverride =
+    themeContext?.theme.components?.badge?.variants?.[variant];
 
-    return (
-      <span
-        ref={ref}
-        {...stylex.props(
-          styles.base,
-          variants[variant],
-          rootOverride,
-          variantOverride,
-          isDot && styles.dot,
-        )}
-        {...props}>
-        {icon}
-        {children}
-      </span>
-    );
-  },
-);
+  return (
+    <span
+      ref={ref}
+      {...stylex.props(
+        styles.base,
+        variants[variant],
+        rootOverride,
+        variantOverride,
+        isDot && styles.dot,
+      )}
+      {...props}>
+      {icon}
+      {children}
+    </span>
+  );
+}
 
 XDSBadge.displayName = 'XDSBadge';

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSBanner.tsx
- * @input Uses React forwardRef/useState, @heroicons/react/24/solid icons, XDSButton, XDSIcon, StyleX
+ * @input Uses React /useState, @heroicons/react/24/solid icons, XDSButton, XDSIcon, StyleX
  * @output Exports XDSBanner component, XDSBannerProps, XDSBannerStatus, XDSBannerVariant types
  * @position Core implementation; consumed by index.ts, tested by XDSBanner.test.tsx
  *
@@ -17,7 +17,7 @@
  * - /apps/storybook/stories/Banner.stories.tsx (storybook stories)
  */
 
-import {forwardRef, useState, type ReactNode} from 'react';
+import {useState, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -56,6 +56,8 @@ export type XDSBannerStatus = 'info' | 'warning' | 'error' | 'success';
 export type XDSBannerVariant = 'card' | 'section';
 
 export interface XDSBannerProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Status type controlling the icon and color scheme.
    */
@@ -315,130 +317,126 @@ const statusStyles = stylex.create({
  * </XDSBanner>
  * ```
  */
-export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
-  (
-    {
-      status,
-      title,
-      description,
-      icon,
-      isDismissable = false,
-      onDismiss,
-      endButton,
-      variant = 'card',
-      isDefaultExpanded = false,
-      children,
-      xstyle,
-      'data-testid': testId,
-    },
-    ref,
-  ) => {
-    const [isDismissed, setIsDismissed] = useState(false);
-    const [isExpanded, setIsExpanded] = useState(isDefaultExpanded);
-    const DefaultIcon = defaultIcons[status];
-    const role = statusRole[status];
-    const iconColor = statusIconColor[status];
-    const hasChildren = children != null;
+export function XDSBanner({
+  ref,
+  status,
+  title,
+  description,
+  icon,
+  isDismissable = false,
+  onDismiss,
+  endButton,
+  variant = 'card',
+  isDefaultExpanded = false,
+  children,
+  xstyle,
+  'data-testid': testId,
+}: XDSBannerProps) {
+  const [isDismissed, setIsDismissed] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(isDefaultExpanded);
+  const DefaultIcon = defaultIcons[status];
+  const role = statusRole[status];
+  const iconColor = statusIconColor[status];
+  const hasChildren = children != null;
 
-    if (isDismissed) {
-      return null;
-    }
+  if (isDismissed) {
+    return null;
+  }
 
-    const handleDismiss = () => {
-      setIsDismissed(true);
-      onDismiss?.();
-    };
+  const handleDismiss = () => {
+    setIsDismissed(true);
+    onDismiss?.();
+  };
 
-    const handleToggleExpand = () => {
-      setIsExpanded(prev => !prev);
-    };
+  const handleToggleExpand = () => {
+    setIsExpanded(prev => !prev);
+  };
 
-    // Show the end area if there are actions, dismiss, or a collapsible toggle
-    const showEndArea = endButton != null || isDismissable || hasChildren;
-    // Center items vertically when there's only a title (no description)
-    // and the banner has action buttons
-    const hasActions = endButton != null || isDismissable;
-    const isSingleLine = description == null && hasActions;
+  // Show the end area if there are actions, dismiss, or a collapsible toggle
+  const showEndArea = endButton != null || isDismissable || hasChildren;
+  // Center items vertically when there's only a title (no description)
+  // and the banner has action buttons
+  const hasActions = endButton != null || isDismissable;
+  const isSingleLine = description == null && hasActions;
 
-    return (
+  return (
+    <div
+      ref={ref}
+      role={role}
+      data-testid={testId}
+      {...stylex.props(
+        styles.root,
+        variant === 'card' && styles.card,
+        variant === 'section' && styles.section,
+        xstyle,
+      )}>
+      {/* Header: colored status background */}
       <div
-        ref={ref}
-        role={role}
-        data-testid={testId}
         {...stylex.props(
-          styles.root,
-          variant === 'card' && styles.card,
-          variant === 'section' && styles.section,
-          xstyle,
+          styles.header,
+          isSingleLine && styles.headerCentered,
+          statusStyles[status],
         )}>
-        {/* Header: colored status background */}
-        <div
-          {...stylex.props(
-            styles.header,
-            isSingleLine && styles.headerCentered,
-            statusStyles[status],
-          )}>
-          <div {...stylex.props(styles.iconWrapper)} aria-hidden="true">
-            {icon != null ? (
-              icon
-            ) : (
-              <XDSIcon icon={DefaultIcon} size="md" color={iconColor} />
+        <div {...stylex.props(styles.iconWrapper)} aria-hidden="true">
+          {icon != null ? (
+            icon
+          ) : (
+            <XDSIcon icon={DefaultIcon} size="md" color={iconColor} />
+          )}
+        </div>
+        <div {...stylex.props(styles.headerContent)}>
+          <p {...stylex.props(styles.title)}>{title}</p>
+          {description != null && (
+            <p {...stylex.props(styles.description)}>{description}</p>
+          )}
+        </div>
+        {showEndArea && (
+          <div {...stylex.props(styles.endArea)}>
+            {endButton}
+            {hasChildren && (
+              <XDSButton
+                variant="ghost"
+                size="sm"
+                label={isExpanded ? 'Collapse' : 'Expand'}
+                tooltip={isExpanded ? 'Collapse' : 'Expand'}
+                icon={
+                  <XDSIcon
+                    icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
+                    size="sm"
+                    color="inherit"
+                  />
+                }
+                onClick={handleToggleExpand}
+                aria-expanded={isExpanded}
+              />
             )}
-          </div>
-          <div {...stylex.props(styles.headerContent)}>
-            <p {...stylex.props(styles.title)}>{title}</p>
-            {description != null && (
-              <p {...stylex.props(styles.description)}>{description}</p>
-            )}
-          </div>
-          {showEndArea && (
-            <div {...stylex.props(styles.endArea)}>
-              {endButton}
-              {hasChildren && (
+            {isDismissable && (
+              <div {...stylex.props(styles.dismissButton)}>
                 <XDSButton
                   variant="ghost"
                   size="sm"
-                  label={isExpanded ? 'Collapse' : 'Expand'}
-                  tooltip={isExpanded ? 'Collapse' : 'Expand'}
-                  icon={
-                    <XDSIcon
-                      icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
-                      size="sm"
-                      color="inherit"
-                    />
-                  }
-                  onClick={handleToggleExpand}
-                  aria-expanded={isExpanded}
+                  label="Dismiss"
+                  tooltip="Dismiss"
+                  icon={<XDSIcon icon="close" size="sm" color="inherit" />}
+                  onClick={handleDismiss}
                 />
-              )}
-              {isDismissable && (
-                <div {...stylex.props(styles.dismissButton)}>
-                  <XDSButton
-                    variant="ghost"
-                    size="sm"
-                    label="Dismiss"
-                    tooltip="Dismiss"
-                    icon={<XDSIcon icon="close" size="sm" color="inherit" />}
-                    onClick={handleDismiss}
-                  />
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-        {/* Content area: collapsible card background for additional content */}
-        {hasChildren && isExpanded && (
-          <div
-            {...stylex.props(
-              styles.contentArea,
-              variant === 'card' && styles.contentAreaCard,
-            )}>
-            {children}
+              </div>
+            )}
           </div>
         )}
       </div>
-    );
-  },
-);
+      {/* Content area: collapsible card background for additional content */}
+      {hasChildren && isExpanded && (
+        <div
+          {...stylex.props(
+            styles.contentArea,
+            variant === 'card' && styles.contentAreaCard,
+          )}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
 
 XDSBanner.displayName = 'XDSBanner';

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSBreadcrumbs.tsx
- * @input Uses React forwardRef, Children, createContext, stylex, theme tokens
+ * @input Uses React Children, createContext, stylex, theme tokens
  * @output Exports XDSBreadcrumbs component, XDSBreadcrumbsProps, BreadcrumbCtx
  * @position Core container component; consumed by index.ts
  *
@@ -12,11 +12,11 @@
  */
 
 import {
-  forwardRef,
   Children,
   isValidElement,
   createContext,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -59,6 +59,8 @@ export const BreadcrumbCtx = createContext<BreadcrumbContextValue>({
 // =============================================================================
 
 export interface XDSBreadcrumbsProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * XDSBreadcrumbItem elements to render as breadcrumb trail.
    */
@@ -148,73 +150,69 @@ const separatorStyles = stylex.create({
  * </XDSBreadcrumbs>
  * ```
  */
-export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
-  function XDSBreadcrumbs(
-    {
-      children,
-      separator = '/',
-      variant = 'default',
-      xstyle,
-      label = 'Breadcrumb',
-      'data-testid': testId,
-    },
-    ref,
-  ) {
-    const items = Children.toArray(children);
-    const isSupporting = variant === 'supporting';
+export function XDSBreadcrumbs({
+  ref,
+  children,
+  separator = '/',
+  variant = 'default',
+  xstyle,
+  label = 'Breadcrumb',
+  'data-testid': testId,
+}: XDSBreadcrumbsProps) {
+  const items = Children.toArray(children);
+  const isSupporting = variant === 'supporting';
 
-    // Check if any child has isCurrent explicitly set
-    const hasExplicitCurrent = items.some(
-      child =>
-        isValidElement<XDSBreadcrumbItemProps>(child) &&
-        child.props.isCurrent === true,
+  // Check if any child has isCurrent explicitly set
+  const hasExplicitCurrent = items.some(
+    child =>
+      isValidElement<XDSBreadcrumbItemProps>(child) &&
+      child.props.isCurrent === true,
+  );
+
+  const rendered: ReactNode[] = [];
+
+  items.forEach((child, index) => {
+    const isLast = index === items.length - 1;
+
+    const ctxValue: BreadcrumbContextValue = {
+      isAutoLast: !hasExplicitCurrent && isLast,
+      variant,
+    };
+
+    rendered.push(
+      <BreadcrumbCtx.Provider key={`item-${index}`} value={ctxValue}>
+        {child}
+      </BreadcrumbCtx.Provider>,
     );
 
-    const rendered: ReactNode[] = [];
-
-    items.forEach((child, index) => {
-      const isLast = index === items.length - 1;
-
-      const ctxValue: BreadcrumbContextValue = {
-        isAutoLast: !hasExplicitCurrent && isLast,
-        variant,
-      };
-
+    // Add separator between items (not after the last one)
+    if (!isLast) {
       rendered.push(
-        <BreadcrumbCtx.Provider key={`item-${index}`} value={ctxValue}>
-          {child}
-        </BreadcrumbCtx.Provider>,
+        <li
+          key={`sep-${index}`}
+          role="presentation"
+          aria-hidden="true"
+          {...stylex.props(
+            separatorStyles.root,
+            isSupporting
+              ? separatorStyles.supportingSize
+              : separatorStyles.defaultSize,
+          )}>
+          {separator}
+        </li>,
       );
+    }
+  });
 
-      // Add separator between items (not after the last one)
-      if (!isLast) {
-        rendered.push(
-          <li
-            key={`sep-${index}`}
-            role="presentation"
-            aria-hidden="true"
-            {...stylex.props(
-              separatorStyles.root,
-              isSupporting
-                ? separatorStyles.supportingSize
-                : separatorStyles.defaultSize,
-            )}>
-            {separator}
-          </li>,
-        );
-      }
-    });
-
-    return (
-      <nav
-        ref={ref}
-        aria-label={label}
-        data-testid={testId}
-        {...stylex.props(navStyles.root, xstyle)}>
-        <ol {...stylex.props(listStyles.root)}>{rendered}</ol>
-      </nav>
-    );
-  },
-);
+  return (
+    <nav
+      ref={ref}
+      aria-label={label}
+      data-testid={testId}
+      {...stylex.props(navStyles.root, xstyle)}>
+      <ol {...stylex.props(listStyles.root)}>{rendered}</ol>
+    </nav>
+  );
+}
 
 XDSBreadcrumbs.displayName = 'XDSBreadcrumbs';

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSButton.tsx
- * @input Uses React, forwardRef, ButtonHTMLAttributes, ReactNode
+ * @input Uses React, ButtonHTMLAttributes, ReactNode
  * @output Exports XDSButton component, XDSButtonProps, XDSButtonVariant types
  * @position Core implementation; consumed by index.ts, tested by XDSButton.test.tsx
  *
@@ -14,12 +14,12 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useTransition,
   type ButtonHTMLAttributes,
   type ReactElement,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -211,6 +211,8 @@ export interface XDSButtonProps extends Omit<
   ButtonHTMLAttributes<HTMLButtonElement>,
   'children' | 'disabled'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLButtonElement>;
   /**
    * Accessible label for the button (required for accessibility).
    * Used as visible text, or as aria-label for icon-only buttons.
@@ -304,97 +306,93 @@ const loadingStyles = stylex.create({
  * <XDSButton label="Edit" icon={<PencilIcon />} endSlot={<XDSBadge>New</XDSBadge>}>Edit</XDSButton>
  * ```
  */
-export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
-  (
-    {
-      label,
-      variant = 'secondary',
-      size = 'md',
-      isDisabled = false,
-      isLoading = false,
-      onClickAction,
-      icon,
-      children,
-      endSlot,
-      tooltip,
-      ...props
-    },
-    ref,
-  ): ReactElement => {
-    const [isPending, startTransition] = useTransition();
-    const isLoadingState = isLoading || isPending;
-    const buttonDisabled = isDisabled || isLoadingState;
-    const useLightSpinner = variant === 'primary' || variant === 'destructive';
-    const isIconOnly = icon != null && children == null;
+export function XDSButton({
+  ref,
+  label,
+  variant = 'secondary',
+  size = 'md',
+  isDisabled = false,
+  isLoading = false,
+  onClickAction,
+  icon,
+  children,
+  endSlot,
+  tooltip,
+  ...props
+}: XDSButtonProps) {
+  const [isPending, startTransition] = useTransition();
+  const isLoadingState = isLoading || isPending;
+  const buttonDisabled = isDisabled || isLoadingState;
+  const useLightSpinner = variant === 'primary' || variant === 'destructive';
+  const isIconOnly = icon != null && children == null;
 
-    // Get theme context for component-level overrides (optional)
-    const themeContext = useContext(ThemeContext);
-    const themeVariantOverride =
-      themeContext?.theme.components?.button?.variants?.[variant];
+  // Get theme context for component-level overrides (optional)
+  const themeContext = useContext(ThemeContext);
+  const themeVariantOverride =
+    themeContext?.theme.components?.button?.variants?.[variant];
 
-    const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-      if (onClickAction) {
-        e.preventDefault();
-        startTransition(async () => {
-          await onClickAction(e);
-        });
-      }
-      props.onClick?.(e);
-    };
-
-    const button = (
-      <button
-        ref={ref}
-        disabled={buttonDisabled}
-        aria-label={isIconOnly ? label : undefined}
-        aria-busy={isLoadingState || undefined}
-        {...stylex.props(
-          styles.base,
-          sizeStyles[size],
-          variants[variant],
-          themeVariantOverride,
-          isIconOnly && styles.iconOnly,
-          buttonDisabled && styles.disabled,
-          isLoadingState && loadingStyles.loading,
-        )}
-        {...props}
-        onClick={handleClick}>
-        {isLoadingState && (
-          <span
-            style={{
-              position: 'absolute',
-              top: 0,
-              left: 0,
-              right: 0,
-              bottom: 0,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}>
-            <XDSSpinner
-              size="sm"
-              shade={useLightSpinner ? 'onMedia' : 'default'}
-            />
-          </span>
-        )}
-        {icon}
-        {children ?? (isIconOnly ? null : label)}
-        {!isIconOnly && endSlot && (
-          <span {...stylex.props(styles.endSlotWrapper)}>{endSlot}</span>
-        )}
-      </button>
-    );
-
-    if (tooltip) {
-      return (
-        <XDSTooltip content={tooltip} placement="above">
-          {button}
-        </XDSTooltip>
-      );
+  const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    if (onClickAction) {
+      e.preventDefault();
+      startTransition(async () => {
+        await onClickAction(e);
+      });
     }
+    props.onClick?.(e);
+  };
 
-    return button;
-  },
-);
+  const button = (
+    <button
+      ref={ref}
+      disabled={buttonDisabled}
+      aria-label={isIconOnly ? label : undefined}
+      aria-busy={isLoadingState || undefined}
+      {...stylex.props(
+        styles.base,
+        sizeStyles[size],
+        variants[variant],
+        themeVariantOverride,
+        isIconOnly && styles.iconOnly,
+        buttonDisabled && styles.disabled,
+        isLoadingState && loadingStyles.loading,
+      )}
+      {...props}
+      onClick={handleClick}>
+      {isLoadingState && (
+        <span
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            right: 0,
+            bottom: 0,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+          <XDSSpinner
+            size="sm"
+            shade={useLightSpinner ? 'onMedia' : 'default'}
+          />
+        </span>
+      )}
+      {icon}
+      {children ?? (isIconOnly ? null : label)}
+      {!isIconOnly && endSlot && (
+        <span {...stylex.props(styles.endSlotWrapper)}>{endSlot}</span>
+      )}
+    </button>
+  );
+
+  if (tooltip) {
+    return (
+      <XDSTooltip content={tooltip} placement="above">
+        {button}
+      </XDSTooltip>
+    );
+  }
+
+  return button;
+}
 
 XDSButton.displayName = 'XDSButton';

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSCalendar.tsx
- * @input Uses React useState, useMemo, useCallback, forwardRef, hooks
+ * @input Uses React useState, useMemo, useCallback, hooks
  * @output Exports XDSCalendar component and related types
  * @position Core implementation; consumed by index.ts, tested by XDSCalendar.test.tsx
  *
@@ -12,14 +12,13 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useState,
   useMemo,
   useCallback,
   useEffect,
-  useImperativeHandle,
   type HTMLAttributes,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '../Button';
@@ -68,9 +67,11 @@ export interface DateRange {
   end: ISODateString;
 }
 
-/** Imperative handle for XDSCalendar ref */
+/**
+ * @deprecated Use the `focusDate` and `onFocusDateChange` props instead.
+ */
 export interface XDSCalendarHandle {
-  /** Navigate the calendar to show the month containing the given date */
+  /** @deprecated Use `focusDate` prop instead. */
   navigateTo: (date: ISODateString) => void;
 }
 
@@ -80,6 +81,8 @@ interface XDSCalendarBaseProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'onChange' | 'defaultValue'
 > {
+  /** Ref to the root container element. */
+  ref?: Ref<HTMLDivElement>;
   /** Number of months to display (default: 1) */
   numberOfMonths?: 1 | 2;
 
@@ -183,236 +186,219 @@ export type XDSCalendarProps = XDSCalendarSingleProps | XDSCalendarRangeProps;
  * @example
  * <XDSCalendar value={selectedDate} onChange={setSelectedDate} />
  */
-export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
-  (props, ref) => {
-    const {
-      mode = 'single',
-      value,
-      defaultValue,
-      onChange,
-      numberOfMonths = 1,
-      min,
-      max,
-      dateConstraints,
-      focusDate: focusDateProp,
-      onFocusDateChange,
-      hasOutsideDays = true,
-      hasWeekNumbers = false,
-      hasVariableRowCount = false,
-      weekStartsOn = 0,
-      ...rest
-    } = props;
+export function XDSCalendar({
+  ref,
+  mode = 'single',
+  value,
+  defaultValue,
+  onChange,
+  numberOfMonths = 1,
+  min,
+  max,
+  dateConstraints,
+  focusDate: focusDateProp,
+  onFocusDateChange,
+  hasOutsideDays = true,
+  hasWeekNumbers = false,
+  hasVariableRowCount = false,
+  weekStartsOn = 0,
+  ...rest
+}: XDSCalendarProps) {
+  // Get theme context for component-level overrides
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.calendar?.root;
 
-    // Get theme context for component-level overrides
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.calendar?.root;
+  // Today's date (memoized)
+  const today = useMemo(() => new Date(), []);
 
-    // Today's date (memoized)
-    const today = useMemo(() => new Date(), []);
+  // Internal state for uncontrolled mode
+  const [internalValue, setInternalValue] = useState<
+    ISODateString | DateRange | undefined
+  >(defaultValue);
 
-    // Internal state for uncontrolled mode
-    const [internalValue, setInternalValue] = useState<
-      ISODateString | DateRange | undefined
-    >(defaultValue);
+  // Range selection in progress (first click made, waiting for second)
+  const [rangeSelectionStart, setRangeSelectionStart] =
+    useState<ISODateString | null>(null);
 
-    // Range selection in progress (first click made, waiting for second)
-    const [rangeSelectionStart, setRangeSelectionStart] =
-      useState<ISODateString | null>(null);
+  // Hovered date for range preview
+  const [hoveredDate, setHoveredDate] = useState<ISODateString | null>(null);
 
-    // Hovered date for range preview
-    const [hoveredDate, setHoveredDate] = useState<ISODateString | null>(null);
+  // Pending focus target after month navigation
+  const [pendingFocus, setPendingFocus] = useState<ISODateString | null>(null);
 
-    // Pending focus target after month navigation
-    const [pendingFocus, setPendingFocus] = useState<ISODateString | null>(
-      null,
-    );
+  // Determine effective value
+  const effectiveValue = value !== undefined ? value : internalValue;
 
-    // Determine effective value
-    const effectiveValue = value !== undefined ? value : internalValue;
-
-    // Focus date state (which month is visible)
-    const [internalFocusDate, setInternalFocusDate] = useState<Date>(() => {
-      if (focusDateProp) return parseISO(focusDateProp);
-      if (effectiveValue) {
-        if (typeof effectiveValue === 'string') {
-          return parseISO(effectiveValue);
-        } else {
-          return parseISO(effectiveValue.start);
-        }
+  // Focus date state (which month is visible)
+  const [internalFocusDate, setInternalFocusDate] = useState<Date>(() => {
+    if (focusDateProp) return parseISO(focusDateProp);
+    if (effectiveValue) {
+      if (typeof effectiveValue === 'string') {
+        return parseISO(effectiveValue);
+      } else {
+        return parseISO(effectiveValue.start);
       }
-      return new Date();
+    }
+    return new Date();
+  });
+
+  // Use controlled focusDate if callback is provided, otherwise use internal state
+  const isControlledFocus =
+    focusDateProp !== undefined && onFocusDateChange !== undefined;
+  const focusDate = isControlledFocus
+    ? parseISO(focusDateProp)
+    : internalFocusDate;
+
+  // Base month (first day of focus month)
+  const baseMonth = useMemo(() => {
+    const d = new Date(focusDate);
+    d.setDate(1);
+    return d;
+  }, [focusDate]);
+
+  // Generate visible months
+  const visibleMonths = useMemo(() => {
+    return Array.from({length: numberOfMonths}, (_, i) => {
+      const m = new Date(baseMonth);
+      m.setMonth(baseMonth.getMonth() + i);
+      return m;
     });
+  }, [baseMonth, numberOfMonths]);
 
-    // Use controlled focusDate if callback is provided, otherwise use internal state
-    const isControlledFocus =
-      focusDateProp !== undefined && onFocusDateChange !== undefined;
-    const focusDate = isControlledFocus
-      ? parseISO(focusDateProp)
-      : internalFocusDate;
+  // Format month header
+  const monthYearLabel = useMemo(() => {
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      year: 'numeric',
+      month: 'long',
+    });
+    if (numberOfMonths === 1) {
+      return formatter.format(visibleMonths[0]);
+    }
+    return visibleMonths.map(m => formatter.format(m)).join(' – ');
+  }, [visibleMonths, numberOfMonths]);
 
-    // Expose imperative handle for external navigation
-    useImperativeHandle(
-      ref,
-      () => ({
-        navigateTo: (date: ISODateString) => {
-          if (isControlledFocus) {
-            onFocusDateChange?.(date);
-          } else {
-            setInternalFocusDate(parseISO(date));
-          }
-        },
-      }),
-      [isControlledFocus, onFocusDateChange],
-    );
+  // Navigation handlers
+  const navigateMonth = useCallback(
+    (delta: number, focusedDate?: ISODateString, offset?: number) => {
+      const newDate = new Date(baseMonth);
+      newDate.setMonth(baseMonth.getMonth() + delta);
+      const newISO = dateToISO(newDate);
 
-    // Base month (first day of focus month)
-    const baseMonth = useMemo(() => {
-      const d = new Date(focusDate);
-      d.setDate(1);
-      return d;
-    }, [focusDate]);
-
-    // Generate visible months
-    const visibleMonths = useMemo(() => {
-      return Array.from({length: numberOfMonths}, (_, i) => {
-        const m = new Date(baseMonth);
-        m.setMonth(baseMonth.getMonth() + i);
-        return m;
-      });
-    }, [baseMonth, numberOfMonths]);
-
-    // Format month header
-    const monthYearLabel = useMemo(() => {
-      const formatter = new Intl.DateTimeFormat(undefined, {
-        year: 'numeric',
-        month: 'long',
-      });
-      if (numberOfMonths === 1) {
-        return formatter.format(visibleMonths[0]);
+      // Calculate target focus date if a focused date was provided
+      if (focusedDate) {
+        const currentDate = parseISO(focusedDate);
+        const daysToMove = offset ?? 7;
+        currentDate.setDate(currentDate.getDate() + delta * daysToMove);
+        setPendingFocus(dateToISO(currentDate));
       }
-      return visibleMonths.map(m => formatter.format(m)).join(' – ');
-    }, [visibleMonths, numberOfMonths]);
 
-    // Navigation handlers
-    const navigateMonth = useCallback(
-      (delta: number, focusedDate?: ISODateString, offset?: number) => {
-        const newDate = new Date(baseMonth);
-        newDate.setMonth(baseMonth.getMonth() + delta);
-        const newISO = dateToISO(newDate);
+      if (onFocusDateChange) {
+        onFocusDateChange(newISO);
+      } else {
+        setInternalFocusDate(newDate);
+      }
+    },
+    [baseMonth, onFocusDateChange],
+  );
 
-        // Calculate target focus date if a focused date was provided
-        if (focusedDate) {
-          const currentDate = parseISO(focusedDate);
-          const daysToMove = offset ?? 7;
-          currentDate.setDate(currentDate.getDate() + delta * daysToMove);
-          setPendingFocus(dateToISO(currentDate));
-        }
+  // Day click handler
+  const handleDayClick = useCallback(
+    (date: Date) => {
+      const iso = dateToISO(date);
 
-        if (onFocusDateChange) {
-          onFocusDateChange(newISO);
+      if (mode === 'single') {
+        setInternalValue(iso);
+        (onChange as XDSCalendarSingleProps['onChange'])?.(iso, date);
+      } else {
+        // Range mode
+        if (rangeSelectionStart === null) {
+          // First click - start the range
+          setRangeSelectionStart(iso);
         } else {
-          setInternalFocusDate(newDate);
-        }
-      },
-      [baseMonth, onFocusDateChange],
-    );
+          // Second click - complete the range
+          const startDate = parseISO(rangeSelectionStart);
+          let start: ISODateString;
+          let end: ISODateString;
 
-    // Day click handler
-    const handleDayClick = useCallback(
-      (date: Date) => {
-        const iso = dateToISO(date);
-
-        if (mode === 'single') {
-          setInternalValue(iso);
-          (onChange as XDSCalendarSingleProps['onChange'])?.(iso, date);
-        } else {
-          // Range mode
-          if (rangeSelectionStart === null) {
-            // First click - start the range
-            setRangeSelectionStart(iso);
+          // Ensure start <= end
+          if (date < startDate) {
+            start = iso;
+            end = rangeSelectionStart;
           } else {
-            // Second click - complete the range
-            const startDate = parseISO(rangeSelectionStart);
-            let start: ISODateString;
-            let end: ISODateString;
-
-            // Ensure start <= end
-            if (date < startDate) {
-              start = iso;
-              end = rangeSelectionStart;
-            } else {
-              start = rangeSelectionStart;
-              end = iso;
-            }
-
-            const range: DateRange = {start, end};
-            setInternalValue(range);
-            setRangeSelectionStart(null);
-            (onChange as XDSCalendarRangeProps['onChange'])?.(range);
+            start = rangeSelectionStart;
+            end = iso;
           }
+
+          const range: DateRange = {start, end};
+          setInternalValue(range);
+          setRangeSelectionStart(null);
+          (onChange as XDSCalendarRangeProps['onChange'])?.(range);
         }
-      },
-      [mode, onChange, rangeSelectionStart],
-    );
+      }
+    },
+    [mode, onChange, rangeSelectionStart],
+  );
 
-    return (
-      <div {...stylex.props(calendarStyles.calendar, rootOverride)} {...rest}>
-        {/* Header with navigation */}
-        <div {...stylex.props(calendarStyles.header)}>
-          <XDSButton
-            label="Previous month"
-            variant="ghost"
-            icon={<XDSIcon icon="chevronLeft" size="sm" color="inherit" />}
-            onClick={() => navigateMonth(-1)}
-          />
+  return (
+    <div
+      ref={ref}
+      {...stylex.props(calendarStyles.calendar, rootOverride)}
+      {...rest}>
+      {/* Header with navigation */}
+      <div {...stylex.props(calendarStyles.header)}>
+        <XDSButton
+          label="Previous month"
+          variant="ghost"
+          icon={<XDSIcon icon="chevronLeft" size="sm" color="inherit" />}
+          onClick={() => navigateMonth(-1)}
+        />
 
-          <span {...stylex.props(calendarStyles.monthYearLabel)}>
-            {monthYearLabel}
-          </span>
+        <span {...stylex.props(calendarStyles.monthYearLabel)}>
+          {monthYearLabel}
+        </span>
 
-          <XDSButton
-            label="Next month"
-            variant="ghost"
-            icon={<XDSIcon icon="chevronRight" size="sm" color="inherit" />}
-            onClick={() => navigateMonth(1)}
-          />
-        </div>
-
-        {/* Month grids */}
-        <div {...stylex.props(calendarStyles.monthsContainer)}>
-          {visibleMonths.map(month => (
-            <MonthGrid
-              key={`${month.getFullYear()}-${month.getMonth()}`}
-              month={month}
-              value={effectiveValue}
-              mode={mode}
-              rangeSelectionStart={rangeSelectionStart}
-              hoveredDate={hoveredDate}
-              min={min}
-              max={max}
-              dateConstraints={dateConstraints}
-              hasOutsideDays={hasOutsideDays}
-              hasWeekNumbers={hasWeekNumbers}
-              hasVariableRowCount={hasVariableRowCount}
-              weekStartsOn={weekStartsOn}
-              onDayClick={handleDayClick}
-              onDayHover={date => setHoveredDate(date ? dateToISO(date) : null)}
-              today={today}
-              onNavigatePrevious={(focusedDate, offset) =>
-                navigateMonth(-1, focusedDate, offset)
-              }
-              onNavigateNext={(focusedDate, offset) =>
-                navigateMonth(1, focusedDate, offset)
-              }
-              pendingFocus={pendingFocus}
-              onPendingFocusHandled={() => setPendingFocus(null)}
-            />
-          ))}
-        </div>
+        <XDSButton
+          label="Next month"
+          variant="ghost"
+          icon={<XDSIcon icon="chevronRight" size="sm" color="inherit" />}
+          onClick={() => navigateMonth(1)}
+        />
       </div>
-    );
-  },
-);
+
+      {/* Month grids */}
+      <div {...stylex.props(calendarStyles.monthsContainer)}>
+        {visibleMonths.map(month => (
+          <MonthGrid
+            key={`${month.getFullYear()}-${month.getMonth()}`}
+            month={month}
+            value={effectiveValue}
+            mode={mode}
+            rangeSelectionStart={rangeSelectionStart}
+            hoveredDate={hoveredDate}
+            min={min}
+            max={max}
+            dateConstraints={dateConstraints}
+            hasOutsideDays={hasOutsideDays}
+            hasWeekNumbers={hasWeekNumbers}
+            hasVariableRowCount={hasVariableRowCount}
+            weekStartsOn={weekStartsOn}
+            onDayClick={handleDayClick}
+            onDayHover={date => setHoveredDate(date ? dateToISO(date) : null)}
+            today={today}
+            onNavigatePrevious={(focusedDate, offset) =>
+              navigateMonth(-1, focusedDate, offset)
+            }
+            onNavigateNext={(focusedDate, offset) =>
+              navigateMonth(1, focusedDate, offset)
+            }
+            pendingFocus={pendingFocus}
+            onPendingFocusHandled={() => setPendingFocus(null)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
 
 XDSCalendar.displayName = 'XDSCalendar';
 

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -10,7 +10,7 @@
  * - /apps/storybook/stories/Card.stories.tsx (storybook stories)
  */
 
-import {forwardRef, useContext, type ReactNode} from 'react';
+import {useContext, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars, elevationVars} from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
@@ -80,6 +80,8 @@ const dynamicStyles = stylex.create({
 export type {SizeValue} from '../utils/types';
 
 export interface XDSCardProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Width of the card.
    * Numbers are treated as pixels, strings are used as-is.
@@ -137,59 +139,55 @@ export interface XDSCardProps {
  * </XDSCard>
  * ```
  */
-export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
-  function XDSCard(
-    {
-      width,
-      height,
-      maxWidth,
-      minHeight,
-      children,
-      isFullBleed = false,
-      ...props
-    },
-    ref,
-  ) {
-    // Get theme context for component-level overrides
-    const themeContext = useContext(ThemeContext);
-    const containerOverride = themeContext?.theme.components?.card?.container;
-    const contentOverride = themeContext?.theme.components?.card?.content;
+export function XDSCard({
+  ref,
+  width,
+  height,
+  maxWidth,
+  minHeight,
+  children,
+  isFullBleed = false,
+  ...props
+}: XDSCardProps) {
+  // Get theme context for component-level overrides
+  const themeContext = useContext(ThemeContext);
+  const containerOverride = themeContext?.theme.components?.card?.container;
+  const contentOverride = themeContext?.theme.components?.card?.content;
 
-    // Only enable scrolling when card has a fixed height (not null/undefined and not "auto")
-    const hasFixedHeight = height != null && height !== 'auto';
+  // Only enable scrolling when card has a fixed height (not null/undefined and not "auto")
+  const hasFixedHeight = height != null && height !== 'auto';
 
-    return (
+  return (
+    <div
+      ref={ref}
+      {...stylex.props(
+        styles.cardOuter,
+        containerOverride,
+        dynamicStyles.sizing(
+          width ?? null,
+          height ?? null,
+          maxWidth ?? null,
+          minHeight ?? null,
+        ),
+      )}
+      {...props}>
       <div
-        ref={ref}
         {...stylex.props(
-          styles.cardOuter,
-          containerOverride,
-          dynamicStyles.sizing(
-            width ?? null,
-            height ?? null,
-            maxWidth ?? null,
-            minHeight ?? null,
-          ),
-        )}
-        {...props}>
-        <div
-          {...stylex.props(
-            styles.cardInner,
-            hasFixedHeight && styles.scrollable,
-            ...container({
-              paddingInnerX: 'spacing4',
-              paddingInnerY: 'spacing4',
-              paddingOuterX: 'spacing4',
-              paddingOuterY: 'spacing4',
-            }),
-            isFullBleed && styles.fullBleed,
-            contentOverride,
-          )}>
-          {children}
-        </div>
+          styles.cardInner,
+          hasFixedHeight && styles.scrollable,
+          ...container({
+            paddingInnerX: 'spacing4',
+            paddingInnerY: 'spacing4',
+            paddingOuterX: 'spacing4',
+            paddingOuterY: 'spacing4',
+          }),
+          isFullBleed && styles.fullBleed,
+          contentOverride,
+        )}>
+        {children}
       </div>
-    );
-  },
-);
+    </div>
+  );
+}
 
 XDSCard.displayName = 'XDSCard';

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSCenter.tsx
- * @input Uses React forwardRef, StyleX for centering styles
+ * @input Uses React StyleX for centering styles
  * @output Exports XDSCenter component and XDSCenterProps
  * @position Center component for centering children horizontally/vertically
  *
@@ -10,12 +10,7 @@
  * - /apps/storybook/stories/Center.stories.tsx
  */
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {SizeValue} from '../utils/types';
@@ -63,6 +58,8 @@ export interface XDSCenterProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Center axis - which direction(s) to center.
    * - `both`: Center both horizontally and vertically (default)
@@ -114,37 +111,33 @@ export interface XDSCenterProps extends Omit<
  * </XDSCenter>
  * ```
  */
-export const XDSCenter = forwardRef<HTMLDivElement, XDSCenterProps>(
-  function XDSCenter(
-    {
-      axis = 'both',
-      width,
-      height,
-      isInline = false,
-      children,
-      xstyle,
-      ...props
-    },
-    ref,
-  ) {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.center?.root;
+export function XDSCenter({
+  ref,
+  axis = 'both',
+  width,
+  height,
+  isInline = false,
+  children,
+  xstyle,
+  ...props
+}: XDSCenterProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.center?.root;
 
-    const stylexProps = stylex.props(
-      isInline ? styles.inline : styles.base,
-      (axis === 'both' || axis === 'vertical') && styles.alignItemsCenter,
-      (axis === 'both' || axis === 'horizontal') && styles.justifyContentCenter,
-      dynamicStyles.sizing(width ?? null, height ?? null),
-      xstyle,
-      rootOverride,
-    );
+  const stylexProps = stylex.props(
+    isInline ? styles.inline : styles.base,
+    (axis === 'both' || axis === 'vertical') && styles.alignItemsCenter,
+    (axis === 'both' || axis === 'horizontal') && styles.justifyContentCenter,
+    dynamicStyles.sizing(width ?? null, height ?? null),
+    xstyle,
+    rootOverride,
+  );
 
-    return (
-      <div ref={ref} {...stylexProps} {...props}>
-        {children}
-      </div>
-    );
-  },
-);
+  return (
+    <div ref={ref} {...stylexProps} {...props}>
+      {children}
+    </div>
+  );
+}
 
 XDSCenter.displayName = 'XDSCenter';

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSCheckboxInput.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, XDSFieldLabel, XDSFieldStatus, XDSIconType, XDSInputStatus
+ * @input Uses React useId, ChangeEvent, XDSFieldLabel, XDSFieldStatus, XDSIconType, XDSInputStatus
  * @output Exports XDSCheckboxInput component, XDSCheckboxInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSCheckboxInput.test.tsx
  *
@@ -12,13 +12,13 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useId,
   useOptimistic,
   useTransition,
   type ChangeEvent,
   type FocusEvent,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -211,6 +211,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSCheckboxInputProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLInputElement>;
   /**
    * Label text for the checkbox (always rendered for accessibility).
    */
@@ -303,170 +305,159 @@ export interface XDSCheckboxInputProps {
  * />
  * ```
  */
-export const XDSCheckboxInput = forwardRef<
-  HTMLInputElement,
-  XDSCheckboxInputProps
->(
-  (
-    {
-      label,
-      isLabelHidden = false,
-      description,
-      onChange,
-      onChangeAction,
-      isLoading = false,
-      value,
-      isDisabled = false,
-      isOptional = false,
-      isRequired = false,
-      size = 'md',
-      onFocus,
-      onBlur,
-      labelIcon,
-      status,
-    },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.checkboxInput?.root;
-    const checkboxOverride =
-      themeContext?.theme.components?.checkboxInput?.checkbox;
+export function XDSCheckboxInput({
+  ref,
+  label,
+  isLabelHidden = false,
+  description,
+  onChange,
+  onChangeAction,
+  isLoading = false,
+  value,
+  isDisabled = false,
+  isOptional = false,
+  isRequired = false,
+  size = 'md',
+  onFocus,
+  onBlur,
+  labelIcon,
+  status,
+}: XDSCheckboxInputProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.checkboxInput?.root;
+  const checkboxOverride =
+    themeContext?.theme.components?.checkboxInput?.checkbox;
 
-    const id = useId();
-    const descriptionID = useId();
-    const statusMessageID = useId();
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
 
-    const [, startTransition] = useTransition();
-    const [optimisticValue, setOptimisticValue] = useOptimistic(value);
-    const isBusy = isLoading || optimisticValue !== value;
+  const [, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  const isBusy = isLoading || optimisticValue !== value;
 
-    const isIndeterminate = optimisticValue === 'indeterminate';
-    const isChecked = optimisticValue === true;
-    const isCheckedOrIndeterminate = isChecked || isIndeterminate;
+  const isIndeterminate = optimisticValue === 'indeterminate';
+  const isChecked = optimisticValue === true;
+  const isCheckedOrIndeterminate = isChecked || isIndeterminate;
 
-    // Build aria-describedby from description and status message
-    const describedByParts: string[] = [];
-    if (description) describedByParts.push(descriptionID);
-    if (status?.message) describedByParts.push(statusMessageID);
-    const ariaDescribedBy =
-      describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
+  // Build aria-describedby from description and status message
+  const describedByParts: string[] = [];
+  if (description) describedByParts.push(descriptionID);
+  if (status?.message) describedByParts.push(statusMessageID);
+  const ariaDescribedBy =
+    describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
 
-    return (
-      <div>
-        <div
-          {...stylex.props(
-            styles.container,
-            isLabelHidden && styles.containerLabelHidden,
-            rootOverride,
-            !isDisabled && stylex.defaultMarker(),
-          )}>
-          <div
-            {...stylex.props(styles.checkboxWrapper, wrapperSizeStyles[size])}>
-            <input
-              ref={ref}
-              id={id}
-              type="checkbox"
-              checked={isChecked}
-              disabled={isDisabled}
-              required={isRequired}
-              onChange={e => {
-                const checked = e.target.checked;
-                onChange?.(checked, e);
-                if (onChangeAction && !e.defaultPrevented) {
-                  startTransition(async () => {
-                    setOptimisticValue(checked);
-                    await onChangeAction(checked, e);
-                  });
-                }
-              }}
-              onFocus={onFocus}
-              onBlur={onBlur}
-              aria-describedby={ariaDescribedBy}
-              aria-invalid={status?.type === 'error' ? true : undefined}
-              aria-busy={isBusy || undefined}
-              {...stylex.props(
-                styles.input,
-                wrapperSizeStyles[size],
-                isDisabled && styles.inputDisabled,
-              )}
-            />
-            <div
-              aria-hidden="true"
-              {...stylex.props(
-                styles.checkbox,
-                checkboxSizeStyles[size],
-                checkboxOverride,
-                isCheckedOrIndeterminate
-                  ? styles.checkboxChecked
-                  : styles.checkboxUnchecked,
-                isDisabled && styles.checkboxDisabled,
-                isDisabled &&
-                  !isCheckedOrIndeterminate &&
-                  styles.checkboxDisabledUnchecked,
-              )}>
-              {isBusy ? (
-                <XDSSpinner size="sm" />
-              ) : (
-                <>
-                  <svg
-                    viewBox="0 0 10 10"
-                    {...stylex.props(
-                      styles.checkmark,
-                      checkmarkSizeStyles[size],
-                      isChecked && styles.checkmarkVisible,
-                    )}>
-                    <path
-                      d="M8.5 2.5L4 7.5L1.5 5"
-                      stroke="currentColor"
-                      strokeWidth="1.5"
-                      fill="none"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                  <div
-                    {...stylex.props(
-                      styles.indeterminateMark,
-                      indeterminateSizeStyles[size],
-                      isIndeterminate && styles.indeterminateMarkVisible,
-                    )}
-                  />
-                </>
-              )}
-            </div>
-          </div>
-          <div
+  return (
+    <div>
+      <div
+        {...stylex.props(
+          styles.container,
+          isLabelHidden && styles.containerLabelHidden,
+          rootOverride,
+          !isDisabled && stylex.defaultMarker(),
+        )}>
+        <div {...stylex.props(styles.checkboxWrapper, wrapperSizeStyles[size])}>
+          <input
+            ref={ref}
+            id={id}
+            type="checkbox"
+            checked={isChecked}
+            disabled={isDisabled}
+            required={isRequired}
+            onChange={e => {
+              const checked = e.target.checked;
+              onChange?.(checked, e);
+              if (onChangeAction && !e.defaultPrevented) {
+                startTransition(async () => {
+                  setOptimisticValue(checked);
+                  await onChangeAction(checked, e);
+                });
+              }
+            }}
+            onFocus={onFocus}
+            onBlur={onBlur}
+            aria-describedby={ariaDescribedBy}
+            aria-invalid={status?.type === 'error' ? true : undefined}
+            aria-busy={isBusy || undefined}
             {...stylex.props(
-              styles.labelWrapper,
-              labelWrapperSizeStyles[size],
+              styles.input,
+              wrapperSizeStyles[size],
+              isDisabled && styles.inputDisabled,
+            )}
+          />
+          <div
+            aria-hidden="true"
+            {...stylex.props(
+              styles.checkbox,
+              checkboxSizeStyles[size],
+              checkboxOverride,
+              isCheckedOrIndeterminate
+                ? styles.checkboxChecked
+                : styles.checkboxUnchecked,
+              isDisabled && styles.checkboxDisabled,
+              isDisabled &&
+                !isCheckedOrIndeterminate &&
+                styles.checkboxDisabledUnchecked,
             )}>
-            <XDSFieldLabel
-              label={label}
-              inputID={id}
-              isLabelHidden={isLabelHidden}
-              isDisabled={isDisabled}
-              isOptional={isOptional}
-              isRequired={isRequired}
-              labelIcon={labelIcon}
-            />
-            {description && !isLabelHidden && (
-              <span id={descriptionID} {...stylex.props(styles.description)}>
-                {description}
-              </span>
+            {isBusy ? (
+              <XDSSpinner size="sm" />
+            ) : (
+              <>
+                <svg
+                  viewBox="0 0 10 10"
+                  {...stylex.props(
+                    styles.checkmark,
+                    checkmarkSizeStyles[size],
+                    isChecked && styles.checkmarkVisible,
+                  )}>
+                  <path
+                    d="M8.5 2.5L4 7.5L1.5 5"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    fill="none"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                <div
+                  {...stylex.props(
+                    styles.indeterminateMark,
+                    indeterminateSizeStyles[size],
+                    isIndeterminate && styles.indeterminateMarkVisible,
+                  )}
+                />
+              </>
             )}
           </div>
         </div>
-        {status?.message && (
-          <XDSFieldStatus
-            type={status.type}
-            message={status.message}
-            id={statusMessageID}
-            variant="detached"
+        <div
+          {...stylex.props(styles.labelWrapper, labelWrapperSizeStyles[size])}>
+          <XDSFieldLabel
+            label={label}
+            inputID={id}
+            isLabelHidden={isLabelHidden}
+            isDisabled={isDisabled}
+            isOptional={isOptional}
+            isRequired={isRequired}
+            labelIcon={labelIcon}
           />
-        )}
+          {description && !isLabelHidden && (
+            <span id={descriptionID} {...stylex.props(styles.description)}>
+              {description}
+            </span>
+          )}
+        </div>
       </div>
-    );
-  },
-);
+      {status?.message && (
+        <XDSFieldStatus
+          type={status.type}
+          message={status.message}
+          id={statusMessageID}
+          variant="detached"
+        />
+      )}
+    </div>
+  );
+}
 
 XDSCheckboxInput.displayName = 'XDSCheckboxInput';

--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -18,7 +18,7 @@
 
 'use client';
 
-import {forwardRef, type ReactNode} from 'react';
+import {type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -71,6 +71,8 @@ const styles = stylex.create({
 });
 
 export interface XDSCollapsibleProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Content shown in the trigger area (always visible).
    * Rendered inside a button with aria-expanded and a chevron indicator.
@@ -149,57 +151,53 @@ export interface XDSCollapsibleProps {
  * </XDSCollapsibleGroup>
  * ```
  */
-export const XDSCollapsible = forwardRef<HTMLDivElement, XDSCollapsibleProps>(
-  function XDSCollapsible(
-    {
-      trigger,
-      children,
-      initialIsOpen,
-      isOpen: controlledIsOpen,
-      onOpenChange,
-      value,
-      ...props
-    },
-    ref,
-  ) {
-    // Build the config for the hook
-    const collapsibleConfig =
-      controlledIsOpen !== undefined
-        ? {isOpen: controlledIsOpen, onOpenChange}
-        : {initialIsOpen: initialIsOpen ?? true, onOpenChange};
+export function XDSCollapsible({
+  ref,
+  trigger,
+  children,
+  initialIsOpen,
+  isOpen: controlledIsOpen,
+  onOpenChange,
+  value,
+  ...props
+}: XDSCollapsibleProps) {
+  // Build the config for the hook
+  const collapsibleConfig =
+    controlledIsOpen !== undefined
+      ? {isOpen: controlledIsOpen, onOpenChange}
+      : {initialIsOpen: initialIsOpen ?? true, onOpenChange};
 
-    const {isOpen, toggle} = useXDSCollapsible({
-      isCollapsible: collapsibleConfig,
-      value,
-    });
+  const {isOpen, toggle} = useXDSCollapsible({
+    isCollapsible: collapsibleConfig,
+    value,
+  });
 
-    const chevronIcon = useXDSIcon('chevronDown');
+  const chevronIcon = useXDSIcon('chevronDown');
 
-    return (
-      <div ref={ref} {...props}>
-        <button
-          type="button"
-          onClick={toggle}
-          aria-expanded={isOpen}
-          {...stylex.props(styles.trigger)}>
-          <span>{trigger}</span>
-          <span
-            {...stylex.props(
-              styles.chevron,
-              isOpen ? styles.chevronOpen : styles.chevronClosed,
-            )}>
-            {chevronIcon}
-          </span>
-        </button>
-        <div
-          {...(isOpen
-            ? stylex.props(styles.content)
-            : stylex.props(styles.content, styles.contentHidden))}>
-          {children}
-        </div>
+  return (
+    <div ref={ref} {...props}>
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={isOpen}
+        {...stylex.props(styles.trigger)}>
+        <span>{trigger}</span>
+        <span
+          {...stylex.props(
+            styles.chevron,
+            isOpen ? styles.chevronOpen : styles.chevronClosed,
+          )}>
+          {chevronIcon}
+        </span>
+      </button>
+      <div
+        {...(isOpen
+          ? stylex.props(styles.content)
+          : stylex.props(styles.content, styles.contentHidden))}>
+        {children}
       </div>
-    );
-  },
-);
+    </div>
+  );
+}
 
 XDSCollapsible.displayName = 'XDSCollapsible';

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSDateInput.tsx
- * @input Uses React forwardRef, useId, useState, useEffect, useCallback, useRef, XDSField, XDSIcon, XDSCalendar, useXDSPopover
+ * @input Uses React useId, useState, useEffect, useCallback, useRef, XDSField, XDSIcon, XDSCalendar, useXDSPopover
  * @output Exports XDSDateInput component, XDSDateInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSDateInput.test.tsx
  *
@@ -12,7 +12,6 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useId,
   useState,
@@ -21,6 +20,7 @@ import {
   useMemo,
   useOptimistic,
   useTransition,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSIconName} from '../Icon';
@@ -38,11 +38,7 @@ import {
 import {XDSField, type XDSInputStatus, type XDSInputStatusType} from '../Field';
 import {XDSIcon} from '../Icon';
 import {XDSSpinner} from '../Spinner';
-import {
-  XDSCalendar,
-  type ISODateString,
-  type XDSCalendarHandle,
-} from '../Calendar';
+import {XDSCalendar, type ISODateString} from '../Calendar';
 import {useXDSPopover} from '../Layer';
 import {parseDateInput, formatDisplayDate} from '../utils';
 
@@ -232,6 +228,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSDateInputProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLInputElement>;
   /**
    * Label text for the input (required for accessibility).
    */
@@ -348,293 +346,292 @@ export interface XDSDateInputProps {
  * />
  * ```
  */
-export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
-  (
-    {
-      label,
-      isLabelHidden = false,
-      description,
-      isOptional = false,
-      isRequired = false,
-      isDisabled = false,
-      value,
-      onChange,
-      onChangeAction,
-      isLoading = false,
-      min,
-      max,
-      dateConstraints,
-      placeholder = 'Select a date',
-      size = 'md',
-      status,
-      labelTooltip,
-      numberOfMonths = 1,
+export function XDSDateInput({
+  ref,
+  label,
+  isLabelHidden = false,
+  description,
+  isOptional = false,
+  isRequired = false,
+  isDisabled = false,
+  value,
+  onChange,
+  onChangeAction,
+  isLoading = false,
+  min,
+  max,
+  dateConstraints,
+  placeholder = 'Select a date',
+  size = 'md',
+  status,
+  labelTooltip,
+  numberOfMonths = 1,
+}: XDSDateInputProps) {
+  const themeContext = useContext(ThemeContext);
+  const wrapperOverride = themeContext?.theme.components?.dateInput?.wrapper;
+  const inputOverride = themeContext?.theme.components?.dateInput?.input;
+
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [calendarFocusDate, setCalendarFocusDate] = useState<
+    ISODateString | undefined
+  >(value);
+
+  const [, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  const isBusy = isLoading || optimisticValue !== value;
+
+  // Status icon mapping
+  const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+    warning: 'warning',
+    error: 'xCircle',
+    success: 'checkCircle',
+  };
+
+  const statusIconColorMap: Record<
+    XDSInputStatusType,
+    'warning' | 'negative' | 'positive'
+  > = {
+    warning: 'warning',
+    error: 'negative',
+    success: 'positive',
+  };
+
+  const ariaDescribedBy =
+    [
+      description ? descriptionID : null,
+      status?.message ? statusMessageID : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  // Pending input while user is typing (null = show formatted value)
+  const [pendingInput, setPendingInput] = useState<string | null>(null);
+
+  // Display value: pending input if typing, otherwise formatted value
+  const displayValue = useMemo(() => {
+    if (pendingInput !== null) {
+      return pendingInput;
+    }
+    return optimisticValue ? formatDisplayDate(optimisticValue) : '';
+  }, [pendingInput, optimisticValue]);
+
+  // Check if current input is valid (for styling purposes)
+  const isInputValid = useMemo(() => {
+    // Only check pending input for validity styling
+    if (pendingInput === null || !pendingInput.trim()) {
+      return true;
+    }
+    return parseDateInput(pendingInput) !== null;
+  }, [pendingInput]);
+
+  // Use XDSPopover for popover rendering, positioning, and focus trapping
+  const popover = useXDSPopover({
+    xstyle: styles.popover,
+    dialogLabel: 'Choose date',
+    closeButtonLabel: 'Close calendar',
+    onHide: () => {
+      // Return focus to input when popover closes
+      inputRef.current?.focus();
     },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const wrapperOverride = themeContext?.theme.components?.dateInput?.wrapper;
-    const inputOverride = themeContext?.theme.components?.dateInput?.input;
+  });
 
-    const id = useId();
-    const descriptionID = useId();
-    const statusMessageID = useId();
-    const inputRef = useRef<HTMLInputElement | null>(null);
-    const calendarRef = useRef<XDSCalendarHandle | null>(null);
+  // Handle opening the popover from button click (focus calendar)
+  const handleOpen = useCallback(() => {
+    if (!isDisabled && !popover.isOpen) {
+      popover.show();
+    }
+  }, [isDisabled, popover]);
 
-    const [, startTransition] = useTransition();
-    const [optimisticValue, setOptimisticValue] = useOptimistic(value);
-    const isBusy = isLoading || optimisticValue !== value;
+  // Handle opening the popover from input click (keep focus in input)
+  const handleInputClick = useCallback(() => {
+    if (!isDisabled && !popover.isOpen) {
+      popover.show({skipAutoFocus: true});
+    }
+  }, [isDisabled, popover]);
 
-    // Status icon mapping
-    const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
-      warning: 'warning',
-      error: 'xCircle',
-      success: 'checkCircle',
-    };
-
-    const statusIconColorMap: Record<
-      XDSInputStatusType,
-      'warning' | 'negative' | 'positive'
-    > = {
-      warning: 'warning',
-      error: 'negative',
-      success: 'positive',
-    };
-
-    const ariaDescribedBy =
-      [
-        description ? descriptionID : null,
-        status?.message ? statusMessageID : null,
-      ]
-        .filter(Boolean)
-        .join(' ') || undefined;
-
-    // Pending input while user is typing (null = show formatted value)
-    const [pendingInput, setPendingInput] = useState<string | null>(null);
-
-    // Display value: pending input if typing, otherwise formatted value
-    const displayValue = useMemo(() => {
-      if (pendingInput !== null) {
-        return pendingInput;
+  // Unified change handler that fires both onChange and onChangeAction
+  const fireChange = useCallback(
+    (newValue: ISODateString | undefined) => {
+      onChange?.(newValue);
+      if (onChangeAction) {
+        startTransition(async () => {
+          setOptimisticValue(newValue);
+          await onChangeAction(newValue);
+        });
       }
-      return optimisticValue ? formatDisplayDate(optimisticValue) : '';
-    }, [pendingInput, optimisticValue]);
+    },
+    [onChange, onChangeAction, startTransition, setOptimisticValue],
+  );
 
-    // Check if current input is valid (for styling purposes)
-    const isInputValid = useMemo(() => {
-      // Only check pending input for validity styling
-      if (pendingInput === null || !pendingInput.trim()) {
-        return true;
-      }
-      return parseDateInput(pendingInput) !== null;
-    }, [pendingInput]);
-
-    // Use XDSPopover for popover rendering, positioning, and focus trapping
-    const popover = useXDSPopover({
-      xstyle: styles.popover,
-      dialogLabel: 'Choose date',
-      closeButtonLabel: 'Close calendar',
-      onHide: () => {
-        // Return focus to input when popover closes
-        inputRef.current?.focus();
-      },
-    });
-
-    // Handle opening the popover from button click (focus calendar)
-    const handleOpen = useCallback(() => {
-      if (!isDisabled && !popover.isOpen) {
-        popover.show();
-      }
-    }, [isDisabled, popover]);
-
-    // Handle opening the popover from input click (keep focus in input)
-    const handleInputClick = useCallback(() => {
-      if (!isDisabled && !popover.isOpen) {
-        popover.show({skipAutoFocus: true});
-      }
-    }, [isDisabled, popover]);
-
-    // Unified change handler that fires both onChange and onChangeAction
-    const fireChange = useCallback(
-      (newValue: ISODateString | undefined) => {
-        onChange?.(newValue);
-        if (onChangeAction) {
-          startTransition(async () => {
-            setOptimisticValue(newValue);
-            await onChangeAction(newValue);
-          });
-        }
-      },
-      [onChange, onChangeAction, startTransition, setOptimisticValue],
-    );
-
-    // Handle date selection from calendar
-    const handleDateSelect = useCallback(
-      (selectedDate: ISODateString) => {
-        fireChange(selectedDate);
-        setPendingInput(null);
-        popover.hide();
-      },
-      [fireChange, popover],
-    );
-
-    // Handle input text change - update immediately if valid
-    const handleInputChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) => {
-        const newValue = e.target.value;
-        setPendingInput(newValue);
-
-        // If the input is valid, update immediately (don't wait for blur)
-        const parsed = parseDateInput(newValue);
-        if (parsed && parsed !== value) {
-          fireChange(parsed);
-          // Navigate calendar to show the parsed date's month
-          calendarRef.current?.navigateTo(parsed);
-        }
-      },
-      [value, fireChange],
-    );
-
-    // Handle blur - validate and clear pending input
-    const handleBlur = useCallback(() => {
-      if (pendingInput === null) {
-        return;
-      }
-
-      if (!pendingInput.trim()) {
-        // Empty input clears the value
-        if (value !== undefined) {
-          fireChange(undefined);
-        }
-        setPendingInput(null);
-        return;
-      }
-
-      const parsed = parseDateInput(pendingInput);
-      if (parsed) {
-        // Valid date - update if different
-        if (parsed !== value) {
-          fireChange(parsed);
-        }
-      }
-      // Clear pending input - display will revert to formatted value
+  // Handle date selection from calendar
+  const handleDateSelect = useCallback(
+    (selectedDate: ISODateString) => {
+      fireChange(selectedDate);
       setPendingInput(null);
-    }, [pendingInput, value, fireChange]);
+      popover.hide();
+    },
+    [fireChange, popover],
+  );
 
-    // Handle keyboard events on input
-    const handleInputKeyDown = useCallback(
-      (e: React.KeyboardEvent) => {
-        if (e.key === 'Escape' && popover.isOpen) {
-          e.preventDefault();
-          popover.hide();
-        }
-      },
-      [popover],
-    );
+  // Handle input text change - update immediately if valid
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setPendingInput(newValue);
 
-    // Combine refs
-    const setRefs = useCallback(
-      (el: HTMLInputElement | null) => {
-        inputRef.current = el;
-        if (typeof ref === 'function') {
-          ref(el);
-        } else if (ref) {
-          ref.current = el;
-        }
-      },
-      [ref],
-    );
+      // If the input is valid, update immediately (don't wait for blur)
+      const parsed = parseDateInput(newValue);
+      if (parsed && parsed !== value) {
+        fireChange(parsed);
+        // Navigate calendar to show the parsed date's month
+        setCalendarFocusDate(parsed);
+      }
+    },
+    [value, fireChange],
+  );
 
-    return (
-      <XDSField
-        label={label}
-        isLabelHidden={isLabelHidden}
-        description={description}
-        inputID={id}
-        descriptionID={description ? descriptionID : undefined}
-        isOptional={isOptional}
-        isRequired={isRequired}
-        status={
-          status
-            ? {
-                type: status.type,
-                message: status.message,
-                messageID: status.message ? statusMessageID : undefined,
-              }
-            : undefined
-        }
-        labelTooltip={labelTooltip}>
-        <div
-          ref={popover.triggerRef}
+  // Handle blur - validate and clear pending input
+  const handleBlur = useCallback(() => {
+    if (pendingInput === null) {
+      return;
+    }
+
+    if (!pendingInput.trim()) {
+      // Empty input clears the value
+      if (value !== undefined) {
+        fireChange(undefined);
+      }
+      setPendingInput(null);
+      return;
+    }
+
+    const parsed = parseDateInput(pendingInput);
+    if (parsed) {
+      // Valid date - update if different
+      if (parsed !== value) {
+        fireChange(parsed);
+      }
+    }
+    // Clear pending input - display will revert to formatted value
+    setPendingInput(null);
+  }, [pendingInput, value, fireChange]);
+
+  // Handle keyboard events on input
+  const handleInputKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape' && popover.isOpen) {
+        e.preventDefault();
+        popover.hide();
+      }
+    },
+    [popover],
+  );
+
+  // Combine refs
+  const setRefs = useCallback(
+    (el: HTMLInputElement | null) => {
+      inputRef.current = el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        ref.current = el;
+      }
+    },
+    [ref],
+  );
+
+  return (
+    <XDSField
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={id}
+      descriptionID={description ? descriptionID : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageID : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}>
+      <div
+        ref={popover.triggerRef}
+        {...stylex.props(
+          styles.wrapper,
+          sizeStyles[size],
+          isDisabled && styles.wrapperDisabled,
+          status && statusBorderStyles[status.type],
+          status && statusHoverShadowStyles[status.type],
+          status && statusFocusStyles[status.type],
+          wrapperOverride,
+        )}>
+        <button
+          type="button"
+          onClick={handleOpen}
+          disabled={isDisabled}
+          aria-label="Open calendar"
+          {...popover.triggerProps}
           {...stylex.props(
-            styles.wrapper,
-            sizeStyles[size],
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
-            wrapperOverride,
+            styles.iconButton,
+            isDisabled && styles.iconButtonDisabled,
           )}>
-          <button
-            type="button"
-            onClick={handleOpen}
-            disabled={isDisabled}
-            aria-label="Open calendar"
-            {...popover.triggerProps}
-            {...stylex.props(
-              styles.iconButton,
-              isDisabled && styles.iconButtonDisabled,
-            )}>
-            <XDSIcon icon="calendar" size="sm" color="secondary" />
-          </button>
-          <input
-            ref={setRefs}
-            id={id}
-            type="text"
-            value={displayValue}
-            onChange={handleInputChange}
-            onBlur={handleBlur}
-            onClick={handleInputClick}
-            onKeyDown={handleInputKeyDown}
-            placeholder={placeholder}
-            disabled={isDisabled}
-            aria-describedby={ariaDescribedBy}
-            aria-required={isRequired === true ? 'true' : undefined}
-            aria-invalid={status?.type === 'error' ? 'true' : undefined}
-            aria-busy={isBusy || undefined}
-            {...stylex.props(
-              styles.input,
-              isDisabled && styles.inputDisabled,
-              !isInputValid && styles.inputInvalid,
-              inputOverride,
-            )}
-          />
-          {isBusy && <XDSSpinner size="sm" />}
-          {status && (
-            <XDSIcon
-              icon={statusIconMap[status.type]}
-              size="md"
-              color={statusIconColorMap[status.type]}
-            />
+          <XDSIcon icon="calendar" size="sm" color="secondary" />
+        </button>
+        <input
+          ref={setRefs}
+          id={id}
+          type="text"
+          value={displayValue}
+          onChange={handleInputChange}
+          onBlur={handleBlur}
+          onClick={handleInputClick}
+          onKeyDown={handleInputKeyDown}
+          placeholder={placeholder}
+          disabled={isDisabled}
+          aria-describedby={ariaDescribedBy}
+          aria-required={isRequired === true ? 'true' : undefined}
+          aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          aria-busy={isBusy || undefined}
+          {...stylex.props(
+            styles.input,
+            isDisabled && styles.inputDisabled,
+            !isInputValid && styles.inputInvalid,
+            inputOverride,
           )}
-        </div>
-        {popover.render(
-          <XDSCalendar
-            ref={calendarRef}
-            mode="single"
-            value={value}
-            onChange={handleDateSelect}
-            min={min}
-            max={max}
-            dateConstraints={dateConstraints}
-            numberOfMonths={numberOfMonths}
-          />,
-          {placement: 'below', alignment: 'start'},
+        />
+        {isBusy && <XDSSpinner size="sm" />}
+        {status && (
+          <XDSIcon
+            icon={statusIconMap[status.type]}
+            size="md"
+            color={statusIconColorMap[status.type]}
+          />
         )}
-      </XDSField>
-    );
-  },
-);
+      </div>
+      {popover.render(
+        <XDSCalendar
+          mode="single"
+          value={value}
+          onChange={handleDateSelect}
+          focusDate={calendarFocusDate}
+          onFocusDateChange={setCalendarFocusDate}
+          min={min}
+          max={max}
+          dateConstraints={dateConstraints}
+          numberOfMonths={numberOfMonths}
+        />,
+        {placement: 'below', alignment: 'start'},
+      )}
+    </XDSField>
+  );
+}
 
 XDSDateInput.displayName = 'XDSDateInput';

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSDialog.tsx
- * @input Uses React forwardRef, DialogHTMLAttributes, ReactNode
+ * @input Uses React DialogHTMLAttributes, ReactNode
  * @output Exports XDSDialog component, XDSDialogProps, XDSDialogVariant, XDSDialogPurpose types
  * @position Core implementation; consumed by index.ts, tested by XDSDialog.test.tsx
  *
@@ -12,12 +12,12 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useEffect,
   useRef,
   type DialogHTMLAttributes,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -152,6 +152,8 @@ export interface XDSDialogProps extends Omit<
   DialogHTMLAttributes<HTMLDialogElement>,
   'children'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDialogElement>;
   /**
    * Whether the dialog is shown.
    */
@@ -233,130 +235,126 @@ export interface XDSDialogProps extends Omit<
  * </XDSDialog>
  * ```
  */
-export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
-  (
-    {
-      isShown,
-      onHide,
-      width = 400,
-      maxHeight = '75vh',
-      position,
-      variant = 'standard',
-      purpose = 'info',
-      children,
-      ...props
-    },
-    ref,
-  ) => {
-    const dialogRef = useRef<HTMLDialogElement>(null);
+export function XDSDialog({
+  ref,
+  isShown,
+  onHide,
+  width = 400,
+  maxHeight = '75vh',
+  position,
+  variant = 'standard',
+  purpose = 'info',
+  children,
+  ...props
+}: XDSDialogProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
 
-    // Derive dismissal behavior from purpose
-    const allowEscape = purpose !== 'required';
-    const allowBackdropClick = purpose === 'info';
+  // Derive dismissal behavior from purpose
+  const allowEscape = purpose !== 'required';
+  const allowBackdropClick = purpose === 'info';
 
-    // Merge refs
-    const setRefs = (element: HTMLDialogElement | null) => {
-      (dialogRef as React.MutableRefObject<HTMLDialogElement | null>).current =
-        element;
-      if (typeof ref === 'function') {
-        ref(element);
-      } else if (ref) {
-        ref.current = element;
+  // Merge refs
+  const setRefs = (element: HTMLDialogElement | null) => {
+    (dialogRef as React.MutableRefObject<HTMLDialogElement | null>).current =
+      element;
+    if (typeof ref === 'function') {
+      ref(element);
+    } else if (ref) {
+      ref.current = element;
+    }
+  };
+
+  // Handle open/close state
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+
+    if (isShown) {
+      if (!dialog.open) {
+        dialog.showModal();
+      }
+    } else {
+      if (dialog.open) {
+        dialog.close();
+      }
+    }
+  }, [isShown]);
+
+  // Handle Escape key
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog || !isShown) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (allowEscape) {
+          onHide();
+        }
       }
     };
 
-    // Handle open/close state
-    useEffect(() => {
-      const dialog = dialogRef.current;
-      if (!dialog) return;
+    dialog.addEventListener('keydown', handleKeyDown);
+    return () => dialog.removeEventListener('keydown', handleKeyDown);
+  }, [isShown, allowEscape, onHide]);
 
-      if (isShown) {
-        if (!dialog.open) {
-          dialog.showModal();
-        }
-      } else {
-        if (dialog.open) {
-          dialog.close();
-        }
-      }
-    }, [isShown]);
+  // Handle backdrop click
+  const handleClick = (event: React.MouseEvent<HTMLDialogElement>) => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
 
-    // Handle Escape key
-    useEffect(() => {
-      const dialog = dialogRef.current;
-      if (!dialog || !isShown) return;
+    // Check if click was on the backdrop (dialog element itself, not content)
+    const rect = dialog.getBoundingClientRect();
+    const isBackdropClick =
+      event.clientX < rect.left ||
+      event.clientX > rect.right ||
+      event.clientY < rect.top ||
+      event.clientY > rect.bottom;
 
-      const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === 'Escape') {
-          event.preventDefault();
-          if (allowEscape) {
-            onHide();
-          }
-        }
-      };
+    if (isBackdropClick && allowBackdropClick) {
+      onHide();
+    }
+  };
 
-      dialog.addEventListener('keydown', handleKeyDown);
-      return () => dialog.removeEventListener('keydown', handleKeyDown);
-    }, [isShown, allowEscape, onHide]);
+  // Handle native cancel event (browser Escape handling)
+  const handleCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
+    event.preventDefault();
+    if (allowEscape) {
+      onHide();
+    }
+  };
 
-    // Handle backdrop click
-    const handleClick = (event: React.MouseEvent<HTMLDialogElement>) => {
-      const dialog = dialogRef.current;
-      if (!dialog) return;
+  const isFullscreen = variant === 'fullscreen';
+  const hasPosition = position != null && !isFullscreen;
 
-      // Check if click was on the backdrop (dialog element itself, not content)
-      const rect = dialog.getBoundingClientRect();
-      const isBackdropClick =
-        event.clientX < rect.left ||
-        event.clientX > rect.right ||
-        event.clientY < rect.top ||
-        event.clientY > rect.bottom;
+  // Get theme context for component-level overrides (optional)
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.dialog?.root;
 
-      if (isBackdropClick && allowBackdropClick) {
-        onHide();
-      }
-    };
-
-    // Handle native cancel event (browser Escape handling)
-    const handleCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
-      event.preventDefault();
-      if (allowEscape) {
-        onHide();
-      }
-    };
-
-    const isFullscreen = variant === 'fullscreen';
-    const hasPosition = position != null && !isFullscreen;
-
-    // Get theme context for component-level overrides (optional)
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.dialog?.root;
-
-    return (
-      <dialog
-        ref={setRefs}
-        onClick={handleClick}
-        onCancel={handleCancel}
-        aria-modal="true"
-        {...stylex.props(
-          styles.dialog,
-          styles.backdrop,
-          !isFullscreen && dynamicStyles.sizing(width, maxHeight),
-          hasPosition &&
-            dynamicStyles.position(
-              position?.top,
-              position?.right,
-              position?.bottom,
-              position?.left,
-            ),
-          isFullscreen && styles.fullscreen,
-          rootOverride,
-        )}
-        {...props}>
-        {children}
-      </dialog>
-    );
-  },
-);
+  return (
+    <dialog
+      ref={setRefs}
+      onClick={handleClick}
+      onCancel={handleCancel}
+      aria-modal="true"
+      {...stylex.props(
+        styles.dialog,
+        styles.backdrop,
+        !isFullscreen && dynamicStyles.sizing(width, maxHeight),
+        hasPosition &&
+          dynamicStyles.position(
+            position?.top,
+            position?.right,
+            position?.bottom,
+            position?.left,
+          ),
+        isFullscreen && styles.fullscreen,
+        rootOverride,
+      )}
+      {...props}>
+      {children}
+    </dialog>
+  );
+}
 
 XDSDialog.displayName = 'XDSDialog';

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSDialogHeader.tsx
- * @input Uses React forwardRef, useEffect, useRef, XDSLayoutHeader, XDSButton, XDSIcon, XDSHeading, XDSText
+ * @input Uses React useEffect, useRef, XDSLayoutHeader, XDSButton, XDSIcon, XDSHeading, XDSText
  * @output Exports XDSDialogHeader component and XDSDialogHeaderProps
  * @position Dialog header component; used with XDSDialog and XDSLayout
  *
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/Dialog.stories.tsx
  */
 
-import {forwardRef, useEffect, useRef, type ReactNode} from 'react';
+import {useEffect, useRef, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutHeader} from '../Layout/XDSLayoutHeader';
@@ -47,6 +47,8 @@ const styles = stylex.create({
 });
 
 export interface XDSDialogHeaderProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * The title of the dialog.
    * This title receives focus when the dialog opens for screen reader accessibility.
@@ -102,57 +104,60 @@ export interface XDSDialogHeaderProps {
  * </XDSDialog>
  * ```
  */
-export const XDSDialogHeader = forwardRef<HTMLElement, XDSDialogHeaderProps>(
-  function XDSDialogHeader(
-    {title, subtitle, onHide, startContent, endContent, hasDivider = true},
-    ref,
-  ) {
-    const titleRef = useRef<HTMLHeadingElement>(null);
+export function XDSDialogHeader({
+  ref,
+  title,
+  subtitle,
+  onHide,
+  startContent,
+  endContent,
+  hasDivider = true,
+}: XDSDialogHeaderProps) {
+  const titleRef = useRef<HTMLHeadingElement>(null);
 
-    // Auto-focus the title when mounted for screen reader accessibility
-    useEffect(() => {
-      if (titleRef.current) {
-        titleRef.current.tabIndex = -1;
-        titleRef.current.focus();
-      }
-    }, []);
+  // Auto-focus the title when mounted for screen reader accessibility
+  useEffect(() => {
+    if (titleRef.current) {
+      titleRef.current.tabIndex = -1;
+      titleRef.current.focus();
+    }
+  }, []);
 
-    return (
-      <XDSLayoutHeader ref={ref} hasDivider={hasDivider}>
-        <div {...stylex.props(styles.container)}>
-          {startContent && (
-            <div {...stylex.props(styles.actions)}>{startContent}</div>
-          )}
-          <div {...stylex.props(styles.titleWrapper)}>
-            <XDSHeading ref={titleRef} level={2} xstyle={styles.titleFocusable}>
-              {title}
-            </XDSHeading>
-            {subtitle && (
-              <XDSText type="body" size="sm" color="secondary">
-                {subtitle}
-              </XDSText>
-            )}
-          </div>
-          {(endContent || onHide) && (
-            <div {...stylex.props(styles.actions)}>
-              {endContent}
-              {onHide && (
-                <div {...stylex.props(styles.closeButton)}>
-                  <XDSButton
-                    variant="ghost"
-                    label="Close"
-                    tooltip="Close"
-                    icon={<XDSIcon icon="close" color="inherit" />}
-                    onClick={onHide}
-                  />
-                </div>
-              )}
-            </div>
+  return (
+    <XDSLayoutHeader ref={ref} hasDivider={hasDivider}>
+      <div {...stylex.props(styles.container)}>
+        {startContent && (
+          <div {...stylex.props(styles.actions)}>{startContent}</div>
+        )}
+        <div {...stylex.props(styles.titleWrapper)}>
+          <XDSHeading ref={titleRef} level={2} xstyle={styles.titleFocusable}>
+            {title}
+          </XDSHeading>
+          {subtitle && (
+            <XDSText type="body" size="sm" color="secondary">
+              {subtitle}
+            </XDSText>
           )}
         </div>
-      </XDSLayoutHeader>
-    );
-  },
-);
+        {(endContent || onHide) && (
+          <div {...stylex.props(styles.actions)}>
+            {endContent}
+            {onHide && (
+              <div {...stylex.props(styles.closeButton)}>
+                <XDSButton
+                  variant="ghost"
+                  label="Close"
+                  tooltip="Close"
+                  icon={<XDSIcon icon="close" color="inherit" />}
+                  onClick={onHide}
+                />
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </XDSLayoutHeader>
+  );
+}
 
 XDSDialogHeader.displayName = 'XDSDialogHeader';

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSDivider.tsx
- * @input Uses React forwardRef, stylex, spacing and color tokens
+ * @input Uses React stylex, spacing and color tokens
  * @output Exports XDSDivider component and XDSDividerProps
  * @position Divider component; provides visual separation with optional label
  *
@@ -10,12 +10,7 @@
  * - /apps/storybook/stories/Divider.stories.tsx
  */
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -45,6 +40,8 @@ export interface XDSDividerProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className' | 'children'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Orientation of the divider.
    * @default 'horizontal'
@@ -147,41 +144,56 @@ const fullBleedStyles = stylex.create({
  * <XDSDivider label="or" />
  * ```
  */
-export const XDSDivider = forwardRef<HTMLElement, XDSDividerProps>(
-  function XDSDivider(
-    {
-      orientation = 'horizontal',
-      label,
-      variant = 'subtle',
-      isFullBleed = false,
-      xstyle,
-      ...props
-    },
-    ref,
-  ) {
-    const isHorizontal = orientation === 'horizontal';
+export function XDSDivider({
+  ref,
+  orientation = 'horizontal',
+  label,
+  variant = 'subtle',
+  isFullBleed = false,
+  xstyle,
+  ...props
+}: XDSDividerProps) {
+  const isHorizontal = orientation === 'horizontal';
 
-    // Get theme context for component-level overrides (optional)
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.divider?.root;
-    const lineOverride = themeContext?.theme.components?.divider?.line;
-    const labelOverride = themeContext?.theme.components?.divider?.label;
+  // Get theme context for component-level overrides (optional)
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.divider?.root;
+  const lineOverride = themeContext?.theme.components?.divider?.line;
+  const labelOverride = themeContext?.theme.components?.divider?.label;
 
-    return (
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      role="separator"
+      aria-orientation={orientation}
+      {...stylex.props(
+        isHorizontal ? baseStyles.horizontal : baseStyles.vertical,
+        isFullBleed &&
+          (isHorizontal
+            ? fullBleedStyles.horizontal
+            : fullBleedStyles.vertical),
+        rootOverride,
+        xstyle,
+      )}
+      {...props}>
       <div
-        ref={ref as React.Ref<HTMLDivElement>}
-        role="separator"
-        aria-orientation={orientation}
         {...stylex.props(
-          isHorizontal ? baseStyles.horizontal : baseStyles.vertical,
-          isFullBleed &&
-            (isHorizontal
-              ? fullBleedStyles.horizontal
-              : fullBleedStyles.vertical),
-          rootOverride,
-          xstyle,
+          isHorizontal ? lineStyles.horizontalLine : lineStyles.verticalLine,
+          lineStyles[variant],
+          lineOverride,
         )}
-        {...props}>
+      />
+      {label && (
+        <div
+          {...stylex.props(
+            labelStyles.label,
+            !isHorizontal && labelStyles.verticalLabel,
+            labelOverride,
+          )}>
+          {label}
+        </div>
+      )}
+      {label && (
         <div
           {...stylex.props(
             isHorizontal ? lineStyles.horizontalLine : lineStyles.verticalLine,
@@ -189,30 +201,9 @@ export const XDSDivider = forwardRef<HTMLElement, XDSDividerProps>(
             lineOverride,
           )}
         />
-        {label && (
-          <div
-            {...stylex.props(
-              labelStyles.label,
-              !isHorizontal && labelStyles.verticalLabel,
-              labelOverride,
-            )}>
-            {label}
-          </div>
-        )}
-        {label && (
-          <div
-            {...stylex.props(
-              isHorizontal
-                ? lineStyles.horizontalLine
-                : lineStyles.verticalLine,
-              lineStyles[variant],
-              lineOverride,
-            )}
-          />
-        )}
-      </div>
-    );
-  },
-);
+      )}
+    </div>
+  );
+}
 
 XDSDivider.displayName = 'XDSDivider';

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -19,6 +19,7 @@ import React, {
   useRef,
   useState,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useXDSLayer} from '../Layer/useXDSLayer';

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSEmptyState.tsx
- * @input Uses React forwardRef, HTMLAttributes
+ * @input Uses React HTMLAttributes
  * @output Exports XDSEmptyState component, XDSEmptyStateProps type
  * @position Core implementation; consumed by index.ts
  *
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/EmptyState.stories.tsx (storybook stories)
  */
 
-import {forwardRef, type ReactNode} from 'react';
+import {type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -79,6 +79,8 @@ const styles = stylex.create({
 });
 
 export interface XDSEmptyStateProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * The primary message displayed in the empty state.
    */
@@ -134,48 +136,49 @@ export interface XDSEmptyStateProps {
  * />
  * ```
  */
-export const XDSEmptyState = forwardRef<HTMLDivElement, XDSEmptyStateProps>(
-  (
-    {title, description, icon, actions, isCompact = false, xstyle, ...props},
-    ref,
-  ) => {
-    return (
-      <div
-        ref={ref}
-        role="status"
-        {...stylex.props(
-          styles.container,
-          isCompact && styles.containerCompact,
-          xstyle,
-        )}
-        {...props}>
-        {icon != null && <div aria-hidden="true">{icon}</div>}
-        <div {...stylex.props(styles.textGroup)}>
-          <h3 {...stylex.props(styles.title, isCompact && styles.titleCompact)}>
-            {title}
-          </h3>
-          {description != null && (
-            <p
-              {...stylex.props(
-                styles.description,
-                isCompact && styles.descriptionCompact,
-              )}>
-              {description}
-            </p>
-          )}
-        </div>
-        {actions != null && (
-          <div
+export function XDSEmptyState({
+  ref,
+  title,
+  description,
+  icon,
+  actions,
+  isCompact = false,
+  xstyle,
+  ...props
+}: XDSEmptyStateProps) {
+  return (
+    <div
+      ref={ref}
+      role="status"
+      {...stylex.props(
+        styles.container,
+        isCompact && styles.containerCompact,
+        xstyle,
+      )}
+      {...props}>
+      {icon != null && <div aria-hidden="true">{icon}</div>}
+      <div {...stylex.props(styles.textGroup)}>
+        <h3 {...stylex.props(styles.title, isCompact && styles.titleCompact)}>
+          {title}
+        </h3>
+        {description != null && (
+          <p
             {...stylex.props(
-              styles.actions,
-              isCompact && styles.actionsCompact,
+              styles.description,
+              isCompact && styles.descriptionCompact,
             )}>
-            {actions}
-          </div>
+            {description}
+          </p>
         )}
       </div>
-    );
-  },
-);
+      {actions != null && (
+        <div
+          {...stylex.props(styles.actions, isCompact && styles.actionsCompact)}>
+          {actions}
+        </div>
+      )}
+    </div>
+  );
+}
 
 XDSEmptyState.displayName = 'XDSEmptyState';

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSField.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode, XDSFieldLabel, XDSIconType
+ * @input Uses React HTMLAttributes, ReactNode, XDSFieldLabel, XDSIconType
  * @output Exports XDSField component, XDSFieldProps
  * @position Core implementation; consumed by index.ts, tested by XDSField.test.tsx
  *
@@ -11,12 +11,7 @@
  * - /apps/storybook/stories/Field.stories.tsx (storybook stories)
  */
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSFieldLabel} from './XDSFieldLabel';
 import {XDSFieldStatus} from './XDSFieldStatus';
@@ -115,6 +110,8 @@ export interface XDSFieldProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'children'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Label text for the field (always rendered for accessibility).
    */
@@ -185,79 +182,72 @@ export interface XDSFieldProps extends Omit<
  * </XDSField>
  * ```
  */
-export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
-  (
-    {
-      label,
-      isLabelHidden = false,
-      description,
-      inputID,
-      descriptionID,
-      isOptional = false,
-      isRequired = false,
-      labelIcon,
-      status,
-      labelTooltip,
-      statusVariant = 'attached',
-      children,
-      ...props
-    },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.field?.root;
-    const descriptionOverride =
-      themeContext?.theme.components?.field?.description;
+export function XDSField({
+  ref,
+  label,
+  isLabelHidden = false,
+  description,
+  inputID,
+  descriptionID,
+  isOptional = false,
+  isRequired = false,
+  labelIcon,
+  status,
+  labelTooltip,
+  statusVariant = 'attached',
+  children,
+  ...props
+}: XDSFieldProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.field?.root;
+  const descriptionOverride =
+    themeContext?.theme.components?.field?.description;
 
-    return (
-      <div
-        ref={ref}
-        {...stylex.props(styles.container, rootOverride)}
-        {...props}>
-        <XDSFieldLabel
-          label={label}
-          inputID={inputID}
-          isLabelHidden={isLabelHidden}
-          isOptional={isOptional}
-          isRequired={isRequired}
-          labelIcon={labelIcon}
-          labelTooltip={labelTooltip}
-        />
-        {description && !isLabelHidden && (
-          <span
-            id={descriptionID}
-            {...stylex.props(styles.description, descriptionOverride)}>
-            {description}
-          </span>
-        )}
-        {statusVariant === 'attached' ? (
-          <div {...stylex.props(styles.inputStatusWrapper)}>
-            {children}
-            {status?.message && (
-              <XDSFieldStatus
-                type={status.type}
-                message={status.message}
-                id={status.messageID}
-                variant="attached"
-              />
-            )}
-          </div>
-        ) : (
-          <>
-            {children}
-            {status?.message && (
-              <XDSFieldStatus
-                type={status.type}
-                message={status.message}
-                id={status.messageID}
-                variant="detached"
-              />
-            )}
-          </>
-        )}
-      </div>
-    );
-  },
-);
+  return (
+    <div ref={ref} {...stylex.props(styles.container, rootOverride)} {...props}>
+      <XDSFieldLabel
+        label={label}
+        inputID={inputID}
+        isLabelHidden={isLabelHidden}
+        isOptional={isOptional}
+        isRequired={isRequired}
+        labelIcon={labelIcon}
+        labelTooltip={labelTooltip}
+      />
+      {description && !isLabelHidden && (
+        <span
+          id={descriptionID}
+          {...stylex.props(styles.description, descriptionOverride)}>
+          {description}
+        </span>
+      )}
+      {statusVariant === 'attached' ? (
+        <div {...stylex.props(styles.inputStatusWrapper)}>
+          {children}
+          {status?.message && (
+            <XDSFieldStatus
+              type={status.type}
+              message={status.message}
+              id={status.messageID}
+              variant="attached"
+            />
+          )}
+        </div>
+      ) : (
+        <>
+          {children}
+          {status?.message && (
+            <XDSFieldStatus
+              type={status.type}
+              message={status.message}
+              id={status.messageID}
+              variant="detached"
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}
 
 XDSField.displayName = 'XDSField';

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSFieldLabel.tsx
- * @input Uses React forwardRef, XDSIcon, XDSIconType
+ * @input Uses React XDSIcon, XDSIconType
  * @output Exports XDSFieldLabel component, XDSFieldLabelProps
  * @position Core label implementation; used by XDSField, XDSCheckboxInput
  *
@@ -9,7 +9,7 @@
  * - /packages/core/src/Field/index.ts (exports if types change)
  */
 
-import {forwardRef} from 'react';
+import {type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 import {
@@ -62,6 +62,8 @@ const styles = stylex.create({
 });
 
 export interface XDSFieldLabelProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLLabelElement>;
   /**
    * Label text (always rendered for accessibility).
    */
@@ -109,58 +111,51 @@ export interface XDSFieldLabelProps {
  * <XDSFieldLabel label="Hidden label" inputID={inputId} isLabelHidden />
  * ```
  */
-export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
-  (
-    {
-      label,
-      inputID,
-      isLabelHidden = false,
-      isDisabled = false,
-      isOptional = false,
-      isRequired = false,
-      labelIcon,
-      labelTooltip,
-    },
-    ref,
-  ) => {
-    const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
+export function XDSFieldLabel({
+  ref,
+  label,
+  inputID,
+  isLabelHidden = false,
+  isDisabled = false,
+  isOptional = false,
+  isRequired = false,
+  labelIcon,
+  labelTooltip,
+}: XDSFieldLabelProps) {
+  const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
 
-    return (
-      <label
-        ref={ref}
-        htmlFor={inputID}
-        {...stylex.props(
-          styles.label,
-          !isDisabled && styles.labelClickable,
-          isDisabled && styles.labelDisabled,
-          isLabelHidden && styles.labelHidden,
-        )}>
-        {labelIcon && (
+  return (
+    <label
+      ref={ref}
+      htmlFor={inputID}
+      {...stylex.props(
+        styles.label,
+        !isDisabled && styles.labelClickable,
+        isDisabled && styles.labelDisabled,
+        isLabelHidden && styles.labelHidden,
+      )}>
+      {labelIcon && (
+        <XDSIcon
+          icon={labelIcon}
+          size="sm"
+          color={isDisabled ? 'disabled' : 'primary'}
+        />
+      )}
+      {label}
+      {statusText && (
+        <span {...stylex.props(styles.optionalRequired)}> ∙ {statusText}</span>
+      )}
+      {labelTooltip && (
+        <XDSTooltip content={labelTooltip} placement="above">
           <XDSIcon
-            icon={labelIcon}
+            icon="info"
             size="sm"
-            color={isDisabled ? 'disabled' : 'primary'}
+            color={isDisabled ? 'disabled' : 'secondary'}
           />
-        )}
-        {label}
-        {statusText && (
-          <span {...stylex.props(styles.optionalRequired)}>
-            {' '}
-            ∙ {statusText}
-          </span>
-        )}
-        {labelTooltip && (
-          <XDSTooltip content={labelTooltip} placement="above">
-            <XDSIcon
-              icon="info"
-              size="sm"
-              color={isDisabled ? 'disabled' : 'secondary'}
-            />
-          </XDSTooltip>
-        )}
-      </label>
-    );
-  },
-);
+        </XDSTooltip>
+      )}
+    </label>
+  );
+}
 
 XDSFieldLabel.displayName = 'XDSFieldLabel';

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSGrid.tsx
- * @input Uses React forwardRef, stylex, spacing tokens
+ * @input Uses React stylex, spacing tokens
  * @output Exports XDSGrid component and XDSGridProps
  * @position Grid component; provides CSS Grid-based layout
  *
@@ -10,12 +10,7 @@
  * - /apps/storybook/stories/Grid.stories.tsx
  */
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
@@ -45,6 +40,8 @@ export interface XDSGridProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Maximum number of columns.
    * - When only columns is set: creates fixed equal-width columns
@@ -340,23 +337,21 @@ function calculateMaxWidth(
  * </XDSGrid>
  * ```
  */
-export const XDSGrid = forwardRef<HTMLElement, XDSGridProps>(function XDSGrid(
-  {
-    columns,
-    minChildWidth = 0,
-    width,
-    height,
-    gap,
-    rowGap,
-    columnGap,
-    align,
-    justify,
-    xstyle,
-    children,
-    ...props
-  },
+export function XDSGrid({
   ref,
-) {
+  columns,
+  minChildWidth = 0,
+  width,
+  height,
+  gap,
+  rowGap,
+  columnGap,
+  align,
+  justify,
+  xstyle,
+  children,
+  ...props
+}: XDSGridProps) {
   const themeContext = useContext(ThemeContext);
   const rootOverride = themeContext?.theme.components?.grid?.root;
 
@@ -415,6 +410,6 @@ export const XDSGrid = forwardRef<HTMLElement, XDSGridProps>(function XDSGrid(
       {children}
     </div>
   );
-});
+}
 
 XDSGrid.displayName = 'XDSGrid';

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSGridSpan.tsx
- * @input Uses React forwardRef, stylex
+ * @input Uses React stylex
  * @output Exports XDSGridSpan component and XDSGridSpanProps
  * @position Grid span component; controls grid item span
  *
@@ -10,7 +10,7 @@
  * - /apps/storybook/stories/Grid.stories.tsx
  */
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 
@@ -18,6 +18,8 @@ export interface XDSGridSpanProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Number of columns to span, or 'full' to span all columns.
    * - Number: `grid-column: span N`
@@ -66,28 +68,33 @@ const baseStyles = stylex.create({
  * </XDSGrid>
  * ```
  */
-export const XDSGridSpan = forwardRef<HTMLElement, XDSGridSpanProps>(
-  function XDSGridSpan({columns, rows, xstyle, children, ...props}, ref) {
-    // Build inline style for grid spanning
-    const inlineStyle: React.CSSProperties = {
-      ...(columns != null && {
-        gridColumn: columns === 'full' ? '1 / -1' : `span ${columns}`,
-      }),
-      ...(rows != null && {
-        gridRow: `span ${rows}`,
-      }),
-    };
+export function XDSGridSpan({
+  ref,
+  columns,
+  rows,
+  xstyle,
+  children,
+  ...props
+}: XDSGridSpanProps) {
+  // Build inline style for grid spanning
+  const inlineStyle: React.CSSProperties = {
+    ...(columns != null && {
+      gridColumn: columns === 'full' ? '1 / -1' : `span ${columns}`,
+    }),
+    ...(rows != null && {
+      gridRow: `span ${rows}`,
+    }),
+  };
 
-    return (
-      <div
-        ref={ref as React.Ref<HTMLDivElement>}
-        {...stylex.props(baseStyles.span, xstyle)}
-        style={inlineStyle}
-        {...props}>
-        {children}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      {...stylex.props(baseStyles.span, xstyle)}
+      style={inlineStyle}
+      {...props}>
+      {children}
+    </div>
+  );
+}
 
 XDSGridSpan.displayName = 'XDSGridSpan';

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -1,12 +1,12 @@
 /**
  * @file XDSIcon.tsx
- * @input Uses React forwardRef/useContext, SVGProps, icon components or semantic icon names
+ * @input Uses React useContext, SVGProps, icon components or semantic icon names
  * @output Exports XDSIcon component, XDSIconProps, XDSIconColor, XDSIconSize, XDSIconType types
  * @position Core implementation; consumed by index.ts, tested by XDSIcon.test.tsx
  *
  * Supports two modes:
  * - Component mode: Pass an SVG icon component (e.g. from @heroicons/react) — rendered
- *   directly with forwardRef and spread SVG props.
+ *   directly with ref prop and spread SVG props.
  * - String mode: Pass a semantic name (e.g. 'close', 'chevronDown') — resolved from the
  *   theme's icon registry (or built-in fallback SVGs) and wrapped in a styled span.
  *
@@ -19,7 +19,7 @@
 
 'use client';
 
-import {forwardRef, useContext, type ComponentType, type SVGProps} from 'react';
+import {useContext, type ComponentType, type SVGProps, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
@@ -156,6 +156,8 @@ export interface XDSIconProps extends Omit<
   SVGProps<SVGSVGElement>,
   'ref' | 'color'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<SVGSVGElement>;
   /**
    * Icon to render. Can be:
    * - A semantic name string (e.g. 'close', 'chevronDown') — resolved from theme or built-in fallback
@@ -190,34 +192,38 @@ export interface XDSIconProps extends Omit<
  * <XDSIcon icon="close" size="md" color="primary" />
  * ```
  */
-export const XDSIcon = forwardRef<SVGSVGElement, XDSIconProps>(
-  ({icon, color = 'primary', size = 'md', ...props}, ref) => {
-    // Get theme context for component-level overrides (optional)
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.icon?.root;
+export function XDSIcon({
+  ref,
+  icon,
+  color = 'primary',
+  size = 'md',
+  ...props
+}: XDSIconProps) {
+  // Get theme context for component-level overrides (optional)
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.icon?.root;
 
-    // String mode: resolve from icon registry, wrap in styled span
-    if (typeof icon === 'string') {
-      return <IconFromRegistry name={icon} color={color} size={size} />;
-    }
+  // String mode: resolve from icon registry, wrap in styled span
+  if (typeof icon === 'string') {
+    return <IconFromRegistry name={icon} color={color} size={size} />;
+  }
 
-    // Component mode: render SVG component directly with ref forwarding
-    const IconComponent = icon;
-    return (
-      <IconComponent
-        ref={ref}
-        aria-hidden="true"
-        {...stylex.props(
-          styles.root,
-          colorStyles[color],
-          sizeStyles[size],
-          rootOverride,
-        )}
-        {...props}
-      />
-    );
-  },
-);
+  // Component mode: render SVG component directly with ref forwarding
+  const IconComponent = icon;
+  return (
+    <IconComponent
+      ref={ref}
+      aria-hidden="true"
+      {...stylex.props(
+        styles.root,
+        colorStyles[color],
+        sizeStyles[size],
+        rootOverride,
+      )}
+      {...props}
+    />
+  );
+}
 
 XDSIcon.displayName = 'XDSIcon';
 

--- a/packages/core/src/Layer/XDSHoverCard.tsx
+++ b/packages/core/src/Layer/XDSHoverCard.tsx
@@ -17,6 +17,7 @@ import React, {
   useRef,
   type ReactElement,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {ThemeContext} from '../theme/ThemeContext';

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -19,6 +19,7 @@ import React, {
   useRef,
   type ReactElement,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/Layer/XDSTooltip.tsx
+++ b/packages/core/src/Layer/XDSTooltip.tsx
@@ -17,6 +17,7 @@ import React, {
   useRef,
   type ReactElement,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {ThemeContext} from '../theme/ThemeContext';

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutContent.tsx
- * @input Uses React forwardRef, StyleX, XDSLayoutSlotsContext
+ * @input Uses React StyleX, XDSLayoutSlotsContext
  * @output Exports XDSLayoutContent component and XDSLayoutContentProps
  * @position Scrollable main content area for XDSLayout. Wraps the primary body content
  *   with automatic scroll containment and context-aware padding.
@@ -10,8 +10,8 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
-import {forwardRef, useContext} from 'react';
+import type {AriaRole, HTMLAttributes, ReactNode, Ref} from 'react';
+import {useContext} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutSlotsContext} from './XDSLayoutSlotsContext';
@@ -60,6 +60,8 @@ export interface XDSLayoutContentProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Content to render inside the content area.
    */
@@ -132,35 +134,38 @@ export interface XDSLayoutContentProps extends Omit<
  * </XDSLayoutContainer>
  * ```
  */
-export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
-  function XDSLayoutContent(
-    {children, isFullBleed = false, isScrollable = true, label, role, ...props},
-    ref,
-  ) {
-    const {hasHeader, hasFooter, hasStart, hasEnd} = useContext(
-      XDSLayoutSlotsContext,
-    );
+export function XDSLayoutContent({
+  ref,
+  children,
+  isFullBleed = false,
+  isScrollable = true,
+  label,
+  role,
+  ...props
+}: XDSLayoutContentProps) {
+  const {hasHeader, hasFooter, hasStart, hasEnd} = useContext(
+    XDSLayoutSlotsContext,
+  );
 
-    return (
-      <div
-        ref={ref as React.Ref<HTMLDivElement>}
-        role={role}
-        aria-label={label}
-        {...stylex.props(
-          styles.content,
-          // Outer padding on container edges (unless content is full bleed)
-          !hasStart && !isFullBleed && styles.noStart,
-          !hasEnd && !isFullBleed && styles.noEnd,
-          !hasHeader && !isFullBleed && styles.noHeader,
-          !hasFooter && !isFullBleed && styles.noFooter,
-          isScrollable && styles.scrollable,
-          isFullBleed && styles.fullBleed,
-        )}
-        {...props}>
-        {children}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      role={role}
+      aria-label={label}
+      {...stylex.props(
+        styles.content,
+        // Outer padding on container edges (unless content is full bleed)
+        !hasStart && !isFullBleed && styles.noStart,
+        !hasEnd && !isFullBleed && styles.noEnd,
+        !hasHeader && !isFullBleed && styles.noHeader,
+        !hasFooter && !isFullBleed && styles.noFooter,
+        isScrollable && styles.scrollable,
+        isFullBleed && styles.fullBleed,
+      )}
+      {...props}>
+      {children}
+    </div>
+  );
+}
 
 XDSLayoutContent.displayName = 'XDSLayoutContent';

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutFooter.tsx
- * @input Uses React forwardRef, StyleX
+ * @input Uses React StyleX
  * @output Exports XDSLayoutFooter component and XDSLayoutFooterProps
  * @position Bottom bar / footer area for XDSLayout. Use for action bars,
  *   pagination, status bars, or any fixed-height content at the bottom of a layout.
@@ -10,8 +10,7 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
-import {forwardRef} from 'react';
+import type {AriaRole, HTMLAttributes, ReactNode, Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 
@@ -53,6 +52,8 @@ export interface XDSLayoutFooterProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Content to render inside the footer.
    */
@@ -107,39 +108,35 @@ export interface XDSLayoutFooterProps extends Omit<
  * </XDSLayoutContainer>
  * ```
  */
-export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
-  function XDSLayoutFooter(
-    {
-      children,
-      hasDivider = false,
-      height,
-      isFullBleed = false,
-      label,
-      role,
-      ...props
-    },
-    ref,
-  ) {
-    // When no divider, collapse spacing for seamless visual flow
-    const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+export function XDSLayoutFooter({
+  ref,
+  children,
+  hasDivider = false,
+  height,
+  isFullBleed = false,
+  label,
+  role,
+  ...props
+}: XDSLayoutFooterProps) {
+  // When no divider, collapse spacing for seamless visual flow
+  const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
-    return (
-      <div
-        ref={ref as React.Ref<HTMLDivElement>}
-        role={role}
-        aria-label={label}
-        {...stylex.props(
-          styles.footer,
-          dynamicStyles.sizing(height ?? null),
-          isFullBleed && styles.fullBleed,
-          hasDivider && styles.divider,
-          shouldCollapseSpacing && styles.collapseTop,
-        )}
-        {...props}>
-        {children}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      role={role}
+      aria-label={label}
+      {...stylex.props(
+        styles.footer,
+        dynamicStyles.sizing(height ?? null),
+        isFullBleed && styles.fullBleed,
+        hasDivider && styles.divider,
+        shouldCollapseSpacing && styles.collapseTop,
+      )}
+      {...props}>
+      {children}
+    </div>
+  );
+}
 
 XDSLayoutFooter.displayName = 'XDSLayoutFooter';

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutHeader.tsx
- * @input Uses React forwardRef, StyleX
+ * @input Uses React StyleX
  * @output Exports XDSLayoutHeader component and XDSLayoutHeaderProps
  * @position Top bar / header area for XDSLayout. Use for page titles, app bars,
  *   toolbar areas, or any fixed-height content at the top of a layout.
@@ -10,8 +10,7 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
-import {forwardRef} from 'react';
+import type {AriaRole, HTMLAttributes, ReactNode, Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 
@@ -53,6 +52,8 @@ export interface XDSLayoutHeaderProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Content to render inside the header.
    */
@@ -107,39 +108,35 @@ export interface XDSLayoutHeaderProps extends Omit<
  * </XDSLayoutContainer>
  * ```
  */
-export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
-  function XDSLayoutHeader(
-    {
-      children,
-      hasDivider = false,
-      height,
-      isFullBleed = false,
-      label,
-      role,
-      ...props
-    },
-    ref,
-  ) {
-    // When no divider, collapse spacing for seamless visual flow
-    const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+export function XDSLayoutHeader({
+  ref,
+  children,
+  hasDivider = false,
+  height,
+  isFullBleed = false,
+  label,
+  role,
+  ...props
+}: XDSLayoutHeaderProps) {
+  // When no divider, collapse spacing for seamless visual flow
+  const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
-    return (
-      <div
-        ref={ref as React.Ref<HTMLDivElement>}
-        role={role}
-        aria-label={label}
-        {...stylex.props(
-          styles.header,
-          dynamicStyles.sizing(height ?? null),
-          isFullBleed && styles.fullBleed,
-          hasDivider && styles.divider,
-          shouldCollapseSpacing && styles.collapseBottom,
-        )}
-        {...props}>
-        {children}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      role={role}
+      aria-label={label}
+      {...stylex.props(
+        styles.header,
+        dynamicStyles.sizing(height ?? null),
+        isFullBleed && styles.fullBleed,
+        hasDivider && styles.divider,
+        shouldCollapseSpacing && styles.collapseBottom,
+      )}
+      {...props}>
+      {children}
+    </div>
+  );
+}
 
 XDSLayoutHeader.displayName = 'XDSLayoutHeader';

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutPanel.tsx
- * @input Uses React forwardRef, StyleX, XDSLayoutAreaContext, XDSLayoutSlotsContext
+ * @input Uses React StyleX, XDSLayoutAreaContext, XDSLayoutSlotsContext
  * @output Exports XDSLayoutPanel component and XDSLayoutPanelProps
  * @position Sidebar panel for XDSLayout start/end slots. Use for navigation panels,
  *   settings sidebars, detail panels, or any fixed-width side content.
@@ -10,8 +10,8 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
-import {forwardRef, useContext} from 'react';
+import type {AriaRole, HTMLAttributes, ReactNode, Ref} from 'react';
+import {useContext} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutAreaContext} from './XDSLayoutAreaContext';
@@ -87,6 +87,8 @@ export interface XDSLayoutPanelProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Content to render inside the panel.
    */
@@ -162,67 +164,63 @@ export interface XDSLayoutPanelProps extends Omit<
  * </XDSLayoutContainer>
  * ```
  */
-export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
-  function XDSLayoutPanel(
-    {
-      children,
-      hasDivider = false,
-      isFullBleed = false,
-      isScrollable = true,
-      label,
-      role,
-      width,
-      ...props
-    },
-    ref,
-  ) {
-    const area = useContext(XDSLayoutAreaContext);
-    const {hasHeader, hasFooter} = useContext(XDSLayoutSlotsContext);
+export function XDSLayoutPanel({
+  ref,
+  children,
+  hasDivider = false,
+  isFullBleed = false,
+  isScrollable = true,
+  label,
+  role,
+  width,
+  ...props
+}: XDSLayoutPanelProps) {
+  const area = useContext(XDSLayoutAreaContext);
+  const {hasHeader, hasFooter} = useContext(XDSLayoutSlotsContext);
 
-    // Determine panel position
-    const isStartPanel = area === 'start';
-    const isEndPanel = area === 'end';
+  // Determine panel position
+  const isStartPanel = area === 'start';
+  const isEndPanel = area === 'end';
 
-    // When no divider, collapse spacing for seamless visual flow
-    const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+  // When no divider, collapse spacing for seamless visual flow
+  const shouldCollapseSpacing = !hasDivider && !isFullBleed;
 
-    // Select divider style based on position
-    const dividerStyle = isStartPanel
-      ? styles.dividerEnd
-      : isEndPanel
-        ? styles.dividerStart
-        : null;
+  // Select divider style based on position
+  const dividerStyle = isStartPanel
+    ? styles.dividerEnd
+    : isEndPanel
+      ? styles.dividerStart
+      : null;
 
-    // Select collapse style based on position (collapse the side where divider would be)
-    const collapseStyle = isStartPanel
-      ? styles.collapseEnd
-      : isEndPanel
-        ? styles.collapseStart
-        : null;
+  // Select collapse style based on position (collapse the side where divider would be)
+  const collapseStyle = isStartPanel
+    ? styles.collapseEnd
+    : isEndPanel
+      ? styles.collapseStart
+      : null;
 
-    return (
-      <div
-        ref={ref as React.Ref<HTMLDivElement>}
-        role={role}
-        aria-label={label}
-        {...stylex.props(
-          styles.panel,
-          dynamicStyles.sizing(width ?? null),
-          // Outer padding on container edges (unless component is full bleed)
-          isStartPanel && !isFullBleed && styles.startPanel,
-          isEndPanel && !isFullBleed && styles.endPanel,
-          !hasHeader && !isFullBleed && styles.noHeader,
-          !hasFooter && !isFullBleed && styles.noFooter,
-          isScrollable && styles.scrollable,
-          isFullBleed && styles.fullBleed,
-          hasDivider && dividerStyle,
-          shouldCollapseSpacing && collapseStyle,
-        )}
-        {...props}>
-        {children}
-      </div>
-    );
-  },
-);
+  return (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      role={role}
+      aria-label={label}
+      {...stylex.props(
+        styles.panel,
+        dynamicStyles.sizing(width ?? null),
+        // Outer padding on container edges (unless component is full bleed)
+        isStartPanel && !isFullBleed && styles.startPanel,
+        isEndPanel && !isFullBleed && styles.endPanel,
+        !hasHeader && !isFullBleed && styles.noHeader,
+        !hasFooter && !isFullBleed && styles.noFooter,
+        isScrollable && styles.scrollable,
+        isFullBleed && styles.fullBleed,
+        hasDivider && dividerStyle,
+        shouldCollapseSpacing && collapseStyle,
+      )}
+      {...props}>
+      {children}
+    </div>
+  );
+}
 
 XDSLayoutPanel.displayName = 'XDSLayoutPanel';

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLink.tsx
- * @input Uses React forwardRef, AnchorHTMLAttributes, ReactNode
+ * @input Uses React AnchorHTMLAttributes, ReactNode
  * @output Exports XDSLink component, XDSLinkProps
  * @position Core implementation; consumed by index.ts, tested by XDSLink.test.tsx
  *
@@ -12,11 +12,11 @@
  */
 
 import {
-  forwardRef,
   useContext,
   type AnchorHTMLAttributes,
   type MouseEventHandler,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 
@@ -127,6 +127,8 @@ export interface XDSLinkProps extends Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
   'children'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLAnchorElement>;
   /**
    * Custom component to render instead of `<a>`.
    * Overrides the provider-level default set by XDSLinkProvider.
@@ -233,89 +235,85 @@ export interface XDSLinkProps extends Omit<
  * <XDSLink label="Privacy Policy" href="/privacy" hasUnderline>Privacy Policy</XDSLink>
  * ```
  */
-export const XDSLink = forwardRef<HTMLAnchorElement, XDSLinkProps>(
-  (
-    {
-      as,
-      label,
-      href,
-      hasUnderline = false,
-      isDisabled = false,
-      isExternalLink = false,
-      target,
-      onClick,
-      tooltip,
-      isStandalone = false,
-      type = 'body',
-      size,
-      weight,
-      color = 'active',
-      display = 'inline',
-      maxLines = 0,
-      children,
-      rel,
-      ...props
-    },
-    ref,
-  ) => {
-    const LinkComponent = useXDSLinkComponent(as);
-    // Determine target and rel based on isExternalLink
-    const computedTarget = isExternalLink ? '_blank' : target;
-    const computedRel = isExternalLink
-      ? rel
-        ? `${rel} noopener noreferrer`
-        : 'noopener noreferrer'
-      : rel;
+export function XDSLink({
+  ref,
+  as,
+  label,
+  href,
+  hasUnderline = false,
+  isDisabled = false,
+  isExternalLink = false,
+  target,
+  onClick,
+  tooltip,
+  isStandalone = false,
+  type = 'body',
+  size,
+  weight,
+  color = 'active',
+  display = 'inline',
+  maxLines = 0,
+  children,
+  rel,
+  ...props
+}: XDSLinkProps) {
+  const LinkComponent = useXDSLinkComponent(as);
+  // Determine target and rel based on isExternalLink
+  const computedTarget = isExternalLink ? '_blank' : target;
+  const computedRel = isExternalLink
+    ? rel
+      ? `${rel} noopener noreferrer`
+      : 'noopener noreferrer'
+    : rel;
 
-    // Get theme context for component-level overrides (optional)
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.link?.root;
+  // Get theme context for component-level overrides (optional)
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.link?.root;
 
-    const linkElement = (
-      <LinkComponent
-        ref={ref}
-        href={href}
-        target={computedTarget}
-        rel={computedRel}
-        onClick={onClick}
-        aria-label={label}
-        aria-disabled={isDisabled || undefined}
-        tabIndex={isDisabled ? -1 : undefined}
-        {...stylex.props(
-          styles.base,
-          linkColorStyles[color],
-          hasUnderline && styles.hasUnderline,
-          isStandalone && styles.standalone,
-          isDisabled && styles.disabled,
-          rootOverride,
-        )}
-        {...props}>
-        <XDSText
-          type={type}
-          size={size}
-          weight={weight}
-          color={color}
-          display={display}
-          maxLines={maxLines}>
-          {children}
-        </XDSText>
-        {isExternalLink && (
-          <XDSIcon icon="externalLink" size="xsm" color="inherit" />
-        )}
-      </LinkComponent>
+  const linkElement = (
+    <LinkComponent
+      ref={ref}
+      href={href}
+      target={computedTarget}
+      rel={computedRel}
+      onClick={onClick}
+      aria-label={label}
+      aria-disabled={isDisabled || undefined}
+      tabIndex={isDisabled ? -1 : undefined}
+      {...stylex.props(
+        styles.base,
+        linkColorStyles[color],
+        hasUnderline && styles.hasUnderline,
+        isStandalone && styles.standalone,
+        isDisabled && styles.disabled,
+        rootOverride,
+      )}
+      {...props}>
+      <XDSText
+        type={type}
+        size={size}
+        weight={weight}
+        color={color}
+        display={display}
+        maxLines={maxLines}>
+        {children}
+      </XDSText>
+      {isExternalLink && (
+        <XDSIcon icon="externalLink" size="xsm" color="inherit" />
+      )}
+    </LinkComponent>
+  );
+
+  // Wrap with tooltip if provided
+  if (tooltip) {
+    return (
+      <XDSTooltip content={tooltip} placement="above">
+        {linkElement}
+      </XDSTooltip>
     );
+  }
 
-    // Wrap with tooltip if provided
-    if (tooltip) {
-      return (
-        <XDSTooltip content={tooltip} placement="above">
-          {linkElement}
-        </XDSTooltip>
-      );
-    }
-
-    return linkElement;
-  },
-);
+  return linkElement;
+}
 
 XDSLink.displayName = 'XDSLink';

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSList.tsx
- * @input Uses React forwardRef, ReactNode, StyleXStyles, theme tokens, XDSListContext
+ * @input Uses React ReactNode, StyleXStyles, theme tokens, XDSListContext
  * @output Exports XDSList component, XDSListProps, XDSListDensity, XDSListStyle types
  * @position Core implementation; consumed by index.ts, tested by XDSList.test.tsx
  *
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/List.stories.tsx
  */
 
-import {forwardRef, useId, useMemo, Children, type ReactNode} from 'react';
+import {useId, useMemo, Children, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
@@ -27,6 +27,8 @@ export type XDSListStyle = 'none' | 'disc' | 'decimal' | 'circle';
 export {type XDSListDensity} from './XDSListContext';
 
 export interface XDSListProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLUListElement | HTMLOListElement>;
   /**
    * List items. Should be XDSListItem components.
    */
@@ -132,75 +134,68 @@ const listStyleTypes = stylex.create({
  * </XDSList>
  * ```
  */
-export const XDSList = forwardRef<
-  HTMLUListElement | HTMLOListElement,
-  XDSListProps
->(
-  (
-    {
-      children,
-      density = 'balanced',
-      hasDividers = false,
-      header,
-      listStyle = 'none',
-      xstyle,
-      'data-testid': testId,
-    },
-    ref,
-  ) => {
-    const headerId = useId();
-    const isOrdered = listStyle === 'decimal';
-    const hasMarkers = listStyle !== 'none';
-    const Tag = isOrdered ? 'ol' : 'ul';
+export function XDSList({
+  ref,
+  children,
+  density = 'balanced',
+  hasDividers = false,
+  header,
+  listStyle = 'none',
+  xstyle,
+  'data-testid': testId,
+}: XDSListProps) {
+  const headerId = useId();
+  const isOrdered = listStyle === 'decimal';
+  const hasMarkers = listStyle !== 'none';
+  const Tag = isOrdered ? 'ol' : 'ul';
 
-    const contextValue = useMemo(
-      () => ({density, hasDividers, hasMarkers}),
-      [density, hasDividers, hasMarkers],
-    );
+  const contextValue = useMemo(
+    () => ({density, hasDividers, hasMarkers}),
+    [density, hasDividers, hasMarkers],
+  );
 
-    // Interleave dividers between children when hasDividers is true
-    let renderedChildren = children;
-    if (hasDividers) {
-      const childArray = Children.toArray(children);
-      const withDividers: ReactNode[] = [];
-      childArray.forEach((child, i) => {
-        withDividers.push(child);
-        if (i < childArray.length - 1) {
-          withDividers.push(
-            <hr
-              key={`divider-${i}`}
-              aria-hidden="true"
-              {...stylex.props(styles.divider)}
-            />,
-          );
-        }
-      });
-      renderedChildren = withDividers;
-    }
+  // Interleave dividers between children when hasDividers is true
+  let renderedChildren = children;
+  if (hasDividers) {
+    const childArray = Children.toArray(children);
+    const withDividers: ReactNode[] = [];
+    childArray.forEach((child, i) => {
+      withDividers.push(child);
+      if (i < childArray.length - 1) {
+        withDividers.push(
+          <hr
+            key={`divider-${i}`}
+            aria-hidden="true"
+            {...stylex.props(styles.divider)}
+          />,
+        );
+      }
+    });
+    renderedChildren = withDividers;
+  }
 
-    return (
-      <XDSListContext.Provider value={contextValue}>
-        {header != null && (
-          <div id={headerId} {...stylex.props(styles.header)}>
-            {header}
-          </div>
-        )}
-        <Tag
-          ref={ref as React.Ref<HTMLUListElement & HTMLOListElement>}
-          data-testid={testId}
-          aria-labelledby={header != null ? headerId : undefined}
-          {...(listStyle === 'none' && !isOrdered ? {role: 'list'} : {})}
-          {...stylex.props(
-            styles.list,
-            listStyleTypes[listStyle],
-            hasMarkers && styles.listWithMarkers,
-            xstyle,
-          )}>
-          {renderedChildren}
-        </Tag>
-      </XDSListContext.Provider>
-    );
-  },
-);
+  return (
+    <XDSListContext.Provider value={contextValue}>
+      {header != null && (
+        <div id={headerId} {...stylex.props(styles.header)}>
+          {header}
+        </div>
+      )}
+      <Tag
+        ref={ref as React.Ref<HTMLUListElement & HTMLOListElement>}
+        data-testid={testId}
+        aria-labelledby={header != null ? headerId : undefined}
+        {...(listStyle === 'none' && !isOrdered ? {role: 'list'} : {})}
+        {...stylex.props(
+          styles.list,
+          listStyleTypes[listStyle],
+          hasMarkers && styles.listWithMarkers,
+          xstyle,
+        )}>
+        {renderedChildren}
+      </Tag>
+    </XDSListContext.Provider>
+  );
+}
 
 XDSList.displayName = 'XDSList';

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSListItem.tsx
- * @input Uses React forwardRef, ReactNode, StyleXStyles, theme tokens
+ * @input Uses React ReactNode, StyleXStyles, theme tokens
  * @output Exports XDSListItem component, XDSListItemProps type
  * @position Core implementation; consumed by XDSList, index.ts, tested by XDSList.test.tsx
  *
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/List.stories.tsx
  */
 
-import {forwardRef, useContext, type ReactNode} from 'react';
+import {useContext, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -29,6 +29,8 @@ import {XDSListContext} from './XDSListContext';
 // =============================================================================
 
 export interface XDSListItemProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLLIElement>;
   /**
    * Primary text label for the item.
    */
@@ -263,110 +265,103 @@ const descriptionSizeStyles = stylex.create({
  * <XDSListItem label="Docs" href="/docs" target="_blank" />
  * ```
  */
-export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
-  (
-    {
-      label,
-      description,
-      startContent,
-      endContent,
-      onClick,
-      href,
-      target,
-      isDisabled = false,
-      isSelected = false,
-      xstyle,
-      'data-testid': testId,
-    },
-    ref,
-  ) => {
-    const ctx = useContext(XDSListContext);
-    const density = ctx?.density ?? 'balanced';
-    const hasDividers = ctx?.hasDividers ?? false;
-    const hasMarkers = ctx?.hasMarkers ?? false;
-    const isInteractive = onClick != null || href != null;
+export function XDSListItem({
+  ref,
+  label,
+  description,
+  startContent,
+  endContent,
+  onClick,
+  href,
+  target,
+  isDisabled = false,
+  isSelected = false,
+  xstyle,
+  'data-testid': testId,
+}: XDSListItemProps) {
+  const ctx = useContext(XDSListContext);
+  const density = ctx?.density ?? 'balanced';
+  const hasDividers = ctx?.hasDividers ?? false;
+  const hasMarkers = ctx?.hasMarkers ?? false;
+  const isInteractive = onClick != null || href != null;
 
-    const labelAndDescription = (
-      <>
-        <span {...stylex.props(styles.label)}>{label}</span>
-        {description != null && (
-          <span
-            {...stylex.props(
-              styles.description,
-              descriptionSizeStyles[density],
-            )}>
-            {description}
-          </span>
-        )}
-      </>
-    );
+  const labelAndDescription = (
+    <>
+      <span {...stylex.props(styles.label)}>{label}</span>
+      {description != null && (
+        <span
+          {...stylex.props(styles.description, descriptionSizeStyles[density])}>
+          {description}
+        </span>
+      )}
+    </>
+  );
 
-    const handleContainerClick = (e: React.MouseEvent) => {
-      if (isDisabled) return;
-      const target = e.target as HTMLElement;
-      // Don't fire onClick if click originated from an interactive child
-      if (target.closest('button, a, input, select, textarea')) return;
-      onClick?.(e);
-    };
+  const handleContainerClick = (e: React.MouseEvent) => {
+    if (isDisabled) return;
+    const target = e.target as HTMLElement;
+    // Don't fire onClick if click originated from an interactive child
+    if (target.closest('button, a, input, select, textarea')) return;
+    onClick?.(e);
+  };
 
-    const innerContent = (
-      <>
-        {startContent != null && (
-          <span {...stylex.props(styles.startContent)}>{startContent}</span>
-        )}
+  const innerContent = (
+    <>
+      {startContent != null && (
+        <span {...stylex.props(styles.startContent)}>{startContent}</span>
+      )}
 
-        {href != null ? (
-          <a
-            href={href}
-            target={target}
-            aria-disabled={isDisabled || undefined}
-            tabIndex={isDisabled ? -1 : undefined}
-            {...stylex.props(styles.invisibleAnchor)}>
-            {labelAndDescription}
-          </a>
-        ) : onClick != null ? (
-          <button
-            type="button"
-            onClick={onClick}
-            disabled={isDisabled}
-            {...stylex.props(styles.invisibleButton)}>
-            {labelAndDescription}
-          </button>
-        ) : (
-          <span {...stylex.props(styles.content)}>{labelAndDescription}</span>
-        )}
+      {href != null ? (
+        <a
+          href={href}
+          target={target}
+          aria-disabled={isDisabled || undefined}
+          tabIndex={isDisabled ? -1 : undefined}
+          {...stylex.props(styles.invisibleAnchor)}>
+          {labelAndDescription}
+        </a>
+      ) : onClick != null ? (
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={isDisabled}
+          {...stylex.props(styles.invisibleButton)}>
+          {labelAndDescription}
+        </button>
+      ) : (
+        <span {...stylex.props(styles.content)}>{labelAndDescription}</span>
+      )}
 
-        {endContent != null && (
-          <span {...stylex.props(styles.endContent)}>{endContent}</span>
-        )}
-      </>
-    );
+      {endContent != null && (
+        <span {...stylex.props(styles.endContent)}>{endContent}</span>
+      )}
+    </>
+  );
 
-    return (
-      <li
-        ref={ref}
-        data-testid={testId}
-        aria-selected={isSelected || undefined}
-        aria-disabled={isDisabled || undefined}
-        {...stylex.props(
-          hasMarkers ? styles.itemWithMarker : styles.item,
-          densityStyles[density],
-          hasDividers ? styles.noRadius : styles.withRadius,
-          isInteractive && styles.interactive,
-          isInteractive && styles.focusWithinOutline,
-          isDisabled && styles.disabled,
-          isSelected && styles.selected,
-          xstyle,
-        )}
-        onClick={isInteractive ? handleContainerClick : undefined}>
-        {hasMarkers ? (
-          <div {...stylex.props(styles.innerWrapper)}>{innerContent}</div>
-        ) : (
-          innerContent
-        )}
-      </li>
-    );
-  },
-);
+  return (
+    <li
+      ref={ref}
+      data-testid={testId}
+      aria-selected={isSelected || undefined}
+      aria-disabled={isDisabled || undefined}
+      {...stylex.props(
+        hasMarkers ? styles.itemWithMarker : styles.item,
+        densityStyles[density],
+        hasDividers ? styles.noRadius : styles.withRadius,
+        isInteractive && styles.interactive,
+        isInteractive && styles.focusWithinOutline,
+        isDisabled && styles.disabled,
+        isSelected && styles.selected,
+        xstyle,
+      )}
+      onClick={isInteractive ? handleContainerClick : undefined}>
+      {hasMarkers ? (
+        <div {...stylex.props(styles.innerWrapper)}>{innerContent}</div>
+      ) : (
+        innerContent
+      )}
+    </li>
+  );
+}
 
 XDSListItem.displayName = 'XDSListItem';

--- a/packages/core/src/NavIcon/XDSNavIcon.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSNavIcon.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode
+ * @input Uses React HTMLAttributes, ReactNode
  * @output Exports XDSNavIcon component and XDSNavIconProps
  * @position Shared circular icon container for navigation headers (TopNav, PageNav)
  *
@@ -12,7 +12,7 @@
  * - /apps/storybook/stories/PageNav.stories.tsx
  */
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, sizeVars} from '../theme/tokens.stylex';
 
@@ -37,6 +37,8 @@ export interface XDSNavIconProps extends Omit<
   HTMLAttributes<HTMLSpanElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLSpanElement>;
   /**
    * The icon element to render inside the circular background.
    * Should be an XDSIcon or similar icon component.
@@ -67,14 +69,12 @@ export interface XDSNavIconProps extends Omit<
  * />
  * ```
  */
-export const XDSNavIcon = forwardRef<HTMLSpanElement, XDSNavIconProps>(
-  function XDSNavIcon({icon, ...props}, ref) {
-    return (
-      <span ref={ref} {...stylex.props(styles.base)} {...props}>
-        {icon}
-      </span>
-    );
-  },
-);
+export function XDSNavIcon({ref, icon, ...props}: XDSNavIconProps) {
+  return (
+    <span ref={ref} {...stylex.props(styles.base)} {...props}>
+      {icon}
+    </span>
+  );
+}
 
 XDSNavIcon.displayName = 'XDSNavIcon';

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSNumberInput.tsx
- * @input Uses React forwardRef, useId, useState, useMemo, useCallback, XDSField, XDSIcon
+ * @input Uses React useId, useState, useMemo, useCallback, XDSField, XDSIcon
  * @output Exports XDSNumberInput component, XDSNumberInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSNumberInput.test.tsx
  *
@@ -12,7 +12,6 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useId,
   useState,
@@ -21,6 +20,7 @@ import {
   useRef,
   type FocusEvent,
   type KeyboardEvent,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSIconName} from '../Icon';
@@ -207,6 +207,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSNumberInputProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLInputElement>;
   /**
    * Label text for the input (always rendered for accessibility).
    */
@@ -376,119 +378,138 @@ function parseNumberInput(
  * <XDSNumberInput label="Price" value={price} onChange={setPrice} min={0} step={0.01} />
  * ```
  */
-export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
-  (
-    {
-      label,
-      isLabelHidden = false,
-      description,
-      isOptional = false,
-      isRequired = false,
-      isDisabled = false,
-      startIcon,
-      labelIcon,
-      status,
-      size = 'md',
-      onChange,
-      value,
-      placeholder,
-      labelTooltip,
-      hasAutoFocus = false,
-      htmlName,
-      autoComplete,
-      min,
-      max,
-      step,
-      units,
-      isIntegerOnly = false,
-      onFocus,
-      onBlur,
-      onEnter,
+export function XDSNumberInput({
+  ref,
+  label,
+  isLabelHidden = false,
+  description,
+  isOptional = false,
+  isRequired = false,
+  isDisabled = false,
+  startIcon,
+  labelIcon,
+  status,
+  size = 'md',
+  onChange,
+  value,
+  placeholder,
+  labelTooltip,
+  hasAutoFocus = false,
+  htmlName,
+  autoComplete,
+  min,
+  max,
+  step,
+  units,
+  isIntegerOnly = false,
+  onFocus,
+  onBlur,
+  onEnter,
+}: XDSNumberInputProps) {
+  const themeContext = useContext(ThemeContext);
+  const wrapperOverride = themeContext?.theme.components?.numberInput?.wrapper;
+  const inputOverride = themeContext?.theme.components?.numberInput?.input;
+
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  // Pending input while user is typing (null = show formatted value)
+  const [pendingInput, setPendingInput] = useState<string | null>(null);
+
+  const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+    warning: 'warning',
+    error: 'xCircle',
+    success: 'checkCircle',
+  };
+
+  const statusIconColorMap: Record<
+    XDSInputStatusType,
+    'warning' | 'negative' | 'positive'
+  > = {
+    warning: 'warning',
+    error: 'negative',
+    success: 'positive',
+  };
+
+  const ariaDescribedBy =
+    [
+      description ? descriptionID : null,
+      status?.message ? statusMessageID : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  // Display value: pending input if typing, otherwise the raw value
+  // Note: With type="number", we can't use formatted display values
+  const displayValue = useMemo(() => {
+    if (pendingInput !== null) {
+      return pendingInput;
+    }
+    if (value == null) {
+      return '';
+    }
+    return String(value);
+  }, [pendingInput, value]);
+
+  // Check if current pending input is valid (for styling purposes)
+  const isInputValid = useMemo(() => {
+    if (pendingInput === null || !pendingInput.trim()) {
+      return true;
+    }
+    return parseNumberInput(pendingInput, {min, max, isIntegerOnly}) !== null;
+  }, [pendingInput, min, max, isIntegerOnly]);
+
+  // Handle input text change - update immediately if valid
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setPendingInput(newValue);
+
+      // If the input is valid, update immediately
+      const parsed = parseNumberInput(newValue, {min, max, isIntegerOnly});
+      if (parsed !== null && parsed !== value) {
+        onChange(parsed);
+      }
     },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const wrapperOverride =
-      themeContext?.theme.components?.numberInput?.wrapper;
-    const inputOverride = themeContext?.theme.components?.numberInput?.input;
+    [value, onChange, min, max, isIntegerOnly],
+  );
 
-    const id = useId();
-    const descriptionID = useId();
-    const statusMessageID = useId();
-    const inputRef = useRef<HTMLInputElement | null>(null);
+  // Handle focus
+  const handleFocus = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
+      onFocus?.(e);
+    },
+    [onFocus],
+  );
 
-    // Pending input while user is typing (null = show formatted value)
-    const [pendingInput, setPendingInput] = useState<string | null>(null);
-
-    const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
-      warning: 'warning',
-      error: 'xCircle',
-      success: 'checkCircle',
-    };
-
-    const statusIconColorMap: Record<
-      XDSInputStatusType,
-      'warning' | 'negative' | 'positive'
-    > = {
-      warning: 'warning',
-      error: 'negative',
-      success: 'positive',
-    };
-
-    const ariaDescribedBy =
-      [
-        description ? descriptionID : null,
-        status?.message ? statusMessageID : null,
-      ]
-        .filter(Boolean)
-        .join(' ') || undefined;
-
-    // Display value: pending input if typing, otherwise the raw value
-    // Note: With type="number", we can't use formatted display values
-    const displayValue = useMemo(() => {
+  // Handle blur - validate and clear pending input
+  const handleBlur = useCallback(
+    (e: FocusEvent<HTMLInputElement>) => {
       if (pendingInput !== null) {
-        return pendingInput;
-      }
-      if (value == null) {
-        return '';
-      }
-      return String(value);
-    }, [pendingInput, value]);
-
-    // Check if current pending input is valid (for styling purposes)
-    const isInputValid = useMemo(() => {
-      if (pendingInput === null || !pendingInput.trim()) {
-        return true;
-      }
-      return parseNumberInput(pendingInput, {min, max, isIntegerOnly}) !== null;
-    }, [pendingInput, min, max, isIntegerOnly]);
-
-    // Handle input text change - update immediately if valid
-    const handleInputChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) => {
-        const newValue = e.target.value;
-        setPendingInput(newValue);
-
-        // If the input is valid, update immediately
-        const parsed = parseNumberInput(newValue, {min, max, isIntegerOnly});
+        const parsed = parseNumberInput(pendingInput, {
+          min,
+          max,
+          isIntegerOnly,
+        });
         if (parsed !== null && parsed !== value) {
           onChange(parsed);
         }
-      },
-      [value, onChange, min, max, isIntegerOnly],
-    );
+      }
 
-    // Handle focus
-    const handleFocus = useCallback(
-      (e: FocusEvent<HTMLInputElement>) => {
-        onFocus?.(e);
-      },
-      [onFocus],
-    );
+      // Clear pending input - display will revert to formatted value
+      setPendingInput(null);
+      onBlur?.(e);
+    },
+    [pendingInput, value, onChange, min, max, isIntegerOnly, onBlur],
+  );
 
-    // Handle blur - validate and clear pending input
-    const handleBlur = useCallback(
-      (e: FocusEvent<HTMLInputElement>) => {
+  // Handle keyboard events
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter') {
+        // Validate and commit on Enter
         if (pendingInput !== null) {
           const parsed = parseNumberInput(pendingInput, {
             min,
@@ -499,118 +520,94 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
             onChange(parsed);
           }
         }
+        onEnter?.();
+      }
+    },
+    [pendingInput, value, onChange, min, max, isIntegerOnly, onEnter],
+  );
 
-        // Clear pending input - display will revert to formatted value
-        setPendingInput(null);
-        onBlur?.(e);
-      },
-      [pendingInput, value, onChange, min, max, isIntegerOnly, onBlur],
-    );
+  // Combine refs
+  const setRefs = useCallback(
+    (el: HTMLInputElement | null) => {
+      inputRef.current = el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        ref.current = el;
+      }
+    },
+    [ref],
+  );
 
-    // Handle keyboard events
-    const handleKeyDown = useCallback(
-      (e: KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'Enter') {
-          // Validate and commit on Enter
-          if (pendingInput !== null) {
-            const parsed = parseNumberInput(pendingInput, {
-              min,
-              max,
-              isIntegerOnly,
-            });
-            if (parsed !== null && parsed !== value) {
-              onChange(parsed);
+  return (
+    <XDSField
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={id}
+      descriptionID={description ? descriptionID : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      labelIcon={labelIcon}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageID : undefined,
             }
-          }
-          onEnter?.();
-        }
-      },
-      [pendingInput, value, onChange, min, max, isIntegerOnly, onEnter],
-    );
-
-    // Combine refs
-    const setRefs = useCallback(
-      (el: HTMLInputElement | null) => {
-        inputRef.current = el;
-        if (typeof ref === 'function') {
-          ref(el);
-        } else if (ref) {
-          ref.current = el;
-        }
-      },
-      [ref],
-    );
-
-    return (
-      <XDSField
-        label={label}
-        isLabelHidden={isLabelHidden}
-        description={description}
-        inputID={id}
-        descriptionID={description ? descriptionID : undefined}
-        isOptional={isOptional}
-        isRequired={isRequired}
-        labelIcon={labelIcon}
-        status={
-          status
-            ? {
-                type: status.type,
-                message: status.message,
-                messageID: status.message ? statusMessageID : undefined,
-              }
-            : undefined
-        }
-        labelTooltip={labelTooltip}>
-        <div
+          : undefined
+      }
+      labelTooltip={labelTooltip}>
+      <div
+        {...stylex.props(
+          styles.wrapper,
+          sizeStyles[size],
+          isDisabled && styles.wrapperDisabled,
+          status && statusBorderStyles[status.type],
+          status && statusHoverShadowStyles[status.type],
+          status && statusFocusStyles[status.type],
+          wrapperOverride,
+        )}>
+        {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
+        <input
+          ref={setRefs}
+          id={id}
+          name={htmlName}
+          type="number"
+          autoComplete={autoComplete}
+          value={displayValue}
+          onChange={handleInputChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          disabled={isDisabled}
+          autoFocus={hasAutoFocus}
+          min={min ?? undefined}
+          max={max ?? undefined}
+          step={step ?? undefined}
+          aria-describedby={ariaDescribedBy}
+          aria-required={isRequired === true ? 'true' : undefined}
+          aria-invalid={status?.type === 'error' ? 'true' : undefined}
           {...stylex.props(
-            styles.wrapper,
-            sizeStyles[size],
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
-            wrapperOverride,
-          )}>
-          {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
-          <input
-            ref={setRefs}
-            id={id}
-            name={htmlName}
-            type="number"
-            autoComplete={autoComplete}
-            value={displayValue}
-            onChange={handleInputChange}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            onKeyDown={handleKeyDown}
-            placeholder={placeholder}
-            disabled={isDisabled}
-            autoFocus={hasAutoFocus}
-            min={min ?? undefined}
-            max={max ?? undefined}
-            step={step ?? undefined}
-            aria-describedby={ariaDescribedBy}
-            aria-required={isRequired === true ? 'true' : undefined}
-            aria-invalid={status?.type === 'error' ? 'true' : undefined}
-            {...stylex.props(
-              styles.input,
-              isDisabled && styles.inputDisabled,
-              !isInputValid && styles.inputInvalid,
-              inputOverride,
-            )}
-          />
-          {units && <span {...stylex.props(styles.units)}>{units}</span>}
-          {status && (
-            <XDSIcon
-              icon={statusIconMap[status.type]}
-              size="md"
-              color={statusIconColorMap[status.type]}
-            />
+            styles.input,
+            isDisabled && styles.inputDisabled,
+            !isInputValid && styles.inputInvalid,
+            inputOverride,
           )}
-        </div>
-      </XDSField>
-    );
-  },
-);
+        />
+        {units && <span {...stylex.props(styles.units)}>{units}</span>}
+        {status && (
+          <XDSIcon
+            icon={statusIconMap[status.type]}
+            size="md"
+            color={statusIconColorMap[status.type]}
+          />
+        )}
+      </div>
+    </XDSField>
+  );
+}
 
 XDSNumberInput.displayName = 'XDSNumberInput';

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSProgressBar.tsx
- * @input Uses React forwardRef, useId, stylex, color/spacing/radius/transition tokens
+ * @input Uses React useId, stylex, color/spacing/radius/transition tokens
  * @output Exports XDSProgressBar component, XDSProgressBarProps, XDSProgressBarVariant, XDSProgressBarSize types
  * @position Core implementation; consumed by index.ts
  *
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/ProgressBar.stories.tsx (storybook stories)
  */
 
-import {forwardRef, useId} from 'react';
+import {useId, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -39,6 +39,8 @@ export type XDSProgressBarVariant =
 export type XDSProgressBarSize = 'sm' | 'md' | 'lg';
 
 export interface XDSProgressBarProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Current value of the progress bar.
    * Ignored when `isIndeterminate` is true.
@@ -233,83 +235,76 @@ function defaultFormatValueLabel(value: number, max: number): string {
  *   formatValueLabel={(v, m) => `${v} GB / ${m} GB`} />
  * ```
  */
-export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
-  function XDSProgressBar(
-    {
-      value = 0,
-      max = 100,
-      label,
-      isLabelHidden = false,
-      hasValueLabel = false,
-      formatValueLabel = defaultFormatValueLabel,
-      variant = 'accent',
-      size = 'md',
-      isIndeterminate = false,
-      xstyle,
-      'data-testid': dataTestId,
-    },
-    ref,
-  ) {
-    const labelId = useId();
-    const clampedValue = Math.min(Math.max(0, value), max);
-    const percentage = max > 0 ? (clampedValue / max) * 100 : 0;
-    const valueText = formatValueLabel(clampedValue, max);
+export function XDSProgressBar({
+  ref,
+  value = 0,
+  max = 100,
+  label,
+  isLabelHidden = false,
+  hasValueLabel = false,
+  formatValueLabel = defaultFormatValueLabel,
+  variant = 'accent',
+  size = 'md',
+  isIndeterminate = false,
+  xstyle,
+  'data-testid': dataTestId,
+}: XDSProgressBarProps) {
+  const labelId = useId();
+  const clampedValue = Math.min(Math.max(0, value), max);
+  const percentage = max > 0 ? (clampedValue / max) * 100 : 0;
+  const valueText = formatValueLabel(clampedValue, max);
 
-    // In indeterminate mode, don't show value label
-    const showValueLabel = hasValueLabel && !isIndeterminate;
+  // In indeterminate mode, don't show value label
+  const showValueLabel = hasValueLabel && !isIndeterminate;
 
-    return (
-      <div
-        ref={ref}
-        {...stylex.props(styles.container, xstyle)}
-        data-testid={dataTestId}>
-        {/* Label row */}
-        {!isLabelHidden || showValueLabel ? (
-          <div {...stylex.props(styles.header)}>
-            <span
-              id={labelId}
-              {...stylex.props(
-                styles.label,
-                isLabelHidden && styles.visuallyHidden,
-              )}>
-              {label}
-            </span>
-            {showValueLabel && (
-              <span {...stylex.props(styles.valueLabel)}>{valueText}</span>
-            )}
-          </div>
-        ) : (
-          <span id={labelId} {...stylex.props(styles.visuallyHidden)}>
+  return (
+    <div
+      ref={ref}
+      {...stylex.props(styles.container, xstyle)}
+      data-testid={dataTestId}>
+      {/* Label row */}
+      {!isLabelHidden || showValueLabel ? (
+        <div {...stylex.props(styles.header)}>
+          <span
+            id={labelId}
+            {...stylex.props(
+              styles.label,
+              isLabelHidden && styles.visuallyHidden,
+            )}>
             {label}
           </span>
-        )}
-
-        {/* Progress track */}
-        <div
-          role={isIndeterminate ? 'progressbar' : 'meter'}
-          aria-valuenow={isIndeterminate ? undefined : clampedValue}
-          aria-valuemin={isIndeterminate ? undefined : 0}
-          aria-valuemax={isIndeterminate ? undefined : max}
-          aria-labelledby={labelId}
-          aria-valuetext={isIndeterminate ? undefined : valueText}
-          {...stylex.props(styles.track, sizeStyles[size])}>
-          {isIndeterminate ? (
-            <div
-              {...stylex.props(
-                styles.indeterminateFill,
-                variantStyles[variant],
-              )}
-            />
-          ) : (
-            <div
-              {...stylex.props(styles.fill, variantStyles[variant])}
-              style={{width: `${percentage}%`}}
-            />
+          {showValueLabel && (
+            <span {...stylex.props(styles.valueLabel)}>{valueText}</span>
           )}
         </div>
+      ) : (
+        <span id={labelId} {...stylex.props(styles.visuallyHidden)}>
+          {label}
+        </span>
+      )}
+
+      {/* Progress track */}
+      <div
+        role={isIndeterminate ? 'progressbar' : 'meter'}
+        aria-valuenow={isIndeterminate ? undefined : clampedValue}
+        aria-valuemin={isIndeterminate ? undefined : 0}
+        aria-valuemax={isIndeterminate ? undefined : max}
+        aria-labelledby={labelId}
+        aria-valuetext={isIndeterminate ? undefined : valueText}
+        {...stylex.props(styles.track, sizeStyles[size])}>
+        {isIndeterminate ? (
+          <div
+            {...stylex.props(styles.indeterminateFill, variantStyles[variant])}
+          />
+        ) : (
+          <div
+            {...stylex.props(styles.fill, variantStyles[variant])}
+            style={{width: `${percentage}%`}}
+          />
+        )}
       </div>
-    );
-  },
-);
+    </div>
+  );
+}
 
 XDSProgressBar.displayName = 'XDSProgressBar';

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -10,7 +10,7 @@
  * - /apps/storybook/stories/Section.stories.tsx (storybook stories)
  */
 
-import {forwardRef, useContext, type ReactNode} from 'react';
+import {useContext, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
@@ -123,6 +123,8 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSSectionProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Visual variant of the section.
    * - 'section': Surface background color
@@ -194,66 +196,61 @@ export interface XDSSectionProps {
  * </XDSSection>
  * ```
  */
-export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
-  function XDSSection(
-    {
-      variant = 'section',
-      width,
-      height,
-      maxWidth,
-      minHeight,
-      children,
-      dividers,
-      isFullBleed = false,
-      ...props
-    },
-    ref,
-  ) {
-    // Get theme context for component-level overrides
-    const themeContext = useContext(ThemeContext);
-    const containerOverride =
-      themeContext?.theme.components?.section?.container;
-    const contentOverride = themeContext?.theme.components?.section?.content;
-    const variantOverride =
-      themeContext?.theme.components?.section?.variants?.[variant];
+export function XDSSection({
+  ref,
+  variant = 'section',
+  width,
+  height,
+  maxWidth,
+  minHeight,
+  children,
+  dividers,
+  isFullBleed = false,
+  ...props
+}: XDSSectionProps) {
+  // Get theme context for component-level overrides
+  const themeContext = useContext(ThemeContext);
+  const containerOverride = themeContext?.theme.components?.section?.container;
+  const contentOverride = themeContext?.theme.components?.section?.content;
+  const variantOverride =
+    themeContext?.theme.components?.section?.variants?.[variant];
 
-    return (
+  return (
+    <div
+      ref={ref}
+      {...stylex.props(
+        nestedStyles.outer,
+        dynamicStyles.sizing(
+          width ?? null,
+          height ?? null,
+          maxWidth ?? null,
+          minHeight ?? null,
+        ),
+        containerOverride,
+      )}
+      {...props}>
       <div
-        ref={ref}
         {...stylex.props(
-          nestedStyles.outer,
-          dynamicStyles.sizing(
-            width ?? null,
-            height ?? null,
-            maxWidth ?? null,
-            minHeight ?? null,
-          ),
-          containerOverride,
-        )}
-        {...props}>
-        <div
-          {...stylex.props(
-            nestedStyles.inner,
-            ...container({
-              paddingInnerX: 'spacing4',
-              paddingInnerY: 'spacing4',
-              paddingOuterX: 'spacing4',
-              paddingOuterY: 'spacing4',
-            }),
-            variantStyles[variant],
-            variantOverride,
-            isFullBleed && nestedStyles.fullBleed,
-            dividers?.includes('top') && dividerStyles.top,
-            dividers?.includes('bottom') && dividerStyles.bottom,
-            dividers?.includes('start') && dividerStyles.start,
-            dividers?.includes('end') && dividerStyles.end,
-            contentOverride,
-          )}>
-          {children}
-        </div>
+          nestedStyles.inner,
+          ...container({
+            paddingInnerX: 'spacing4',
+            paddingInnerY: 'spacing4',
+            paddingOuterX: 'spacing4',
+            paddingOuterY: 'spacing4',
+          }),
+          variantStyles[variant],
+          variantOverride,
+          isFullBleed && nestedStyles.fullBleed,
+          dividers?.includes('top') && dividerStyles.top,
+          dividers?.includes('bottom') && dividerStyles.bottom,
+          dividers?.includes('start') && dividerStyles.start,
+          dividers?.includes('end') && dividerStyles.end,
+          contentOverride,
+        )}>
+        {children}
       </div>
-    );
-  },
-);
+    </div>
+  );
+}
 
 XDSSection.displayName = 'XDSSection';

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -17,6 +17,7 @@ import React, {
   useRef,
   useTransition,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useXDSLayer} from '../Layer/useXDSLayer';

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSideNav.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode, StyleX
+ * @input Uses React HTMLAttributes, ReactNode, StyleX
  * @output Exports XDSSideNav component and XDSSideNavProps
  * @position Core implementation; consumed by index.ts, tested by XDSSideNav.test.tsx
  *
@@ -16,12 +16,7 @@
 
 'use client';
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
@@ -103,6 +98,8 @@ export interface XDSSideNavProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Header area — typically XDSSideNavHeader. Sticky at top.
    */
@@ -156,54 +153,50 @@ export interface XDSSideNavProps extends Omit<
  * </XDSSideNav>
  * ```
  */
-export const XDSSideNav = forwardRef<HTMLElement, XDSSideNavProps>(
-  function XDSSideNav(
-    {
-      header,
-      topContent,
-      children,
-      footer,
-      footerIcons,
-      xstyle,
-      'data-testid': testId,
-      ...props
-    },
-    ref,
-  ) {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.sideNav?.root;
+export function XDSSideNav({
+  ref,
+  header,
+  topContent,
+  children,
+  footer,
+  footerIcons,
+  xstyle,
+  'data-testid': testId,
+  ...props
+}: XDSSideNavProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.sideNav?.root;
 
-    const hasStickyTop = !!(header || topContent);
-    const hasStickyBottom = !!(footer || footerIcons);
+  const hasStickyTop = !!(header || topContent);
+  const hasStickyBottom = !!(footer || footerIcons);
 
-    return (
-      <nav
-        ref={ref}
-        role="navigation"
-        aria-label="Side navigation"
-        data-testid={testId}
-        {...stylex.props(styles.root, rootOverride, xstyle)}
-        {...props}>
-        {hasStickyTop && (
-          <div {...stylex.props(styles.stickyTop)}>
-            {header}
-            {topContent && (
-              <div {...stylex.props(styles.topContent)}>{topContent}</div>
-            )}
-          </div>
-        )}
-        <div {...stylex.props(styles.scrollable)}>{children}</div>
-        {hasStickyBottom && (
-          <div {...stylex.props(styles.stickyBottom)}>
-            {footer && <div {...stylex.props(styles.footer)}>{footer}</div>}
-            {footerIcons && (
-              <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
-            )}
-          </div>
-        )}
-      </nav>
-    );
-  },
-);
+  return (
+    <nav
+      ref={ref}
+      role="navigation"
+      aria-label="Side navigation"
+      data-testid={testId}
+      {...stylex.props(styles.root, rootOverride, xstyle)}
+      {...props}>
+      {hasStickyTop && (
+        <div {...stylex.props(styles.stickyTop)}>
+          {header}
+          {topContent && (
+            <div {...stylex.props(styles.topContent)}>{topContent}</div>
+          )}
+        </div>
+      )}
+      <div {...stylex.props(styles.scrollable)}>{children}</div>
+      {hasStickyBottom && (
+        <div {...stylex.props(styles.stickyBottom)}>
+          {footer && <div {...stylex.props(styles.footer)}>{footer}</div>}
+          {footerIcons && (
+            <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
+          )}
+        </div>
+      )}
+    </nav>
+  );
+}
 
 XDSSideNav.displayName = 'XDSSideNav';

--- a/packages/core/src/SideNav/XDSSideNavHeader.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeader.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSideNavHeader.tsx
- * @input Uses React forwardRef, useRef, useCallback, ReactNode, StyleX, useXDSPopover
+ * @input Uses React useRef, useCallback, ReactNode, StyleX, useXDSPopover
  * @output Exports XDSSideNavHeader component and XDSSideNavHeaderProps
  * @position Core implementation; used inside XDSSideNav header slot
  *
@@ -16,7 +16,7 @@
 
 'use client';
 
-import {forwardRef, useCallback, useRef, type ReactNode} from 'react';
+import {useCallback, useRef, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -136,6 +136,8 @@ const styles = stylex.create({
 // =============================================================================
 
 export interface XDSSideNavHeaderProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Product/app icon.
    */
@@ -244,25 +246,20 @@ function ChevronDownIcon() {
  * />
  * ```
  */
-export const XDSSideNavHeader = forwardRef<
-  HTMLDivElement,
-  XDSSideNavHeaderProps
->(function XDSSideNavHeader(
-  {
-    icon,
-    title,
-    titleHref,
-    supertitle,
-    supertitleHref,
-    subtitle,
-    subtitleHref,
-    menu,
-    xstyle,
-    'data-testid': testId,
-    ...props
-  },
+export function XDSSideNavHeader({
   ref,
-) {
+  icon,
+  title,
+  titleHref,
+  supertitle,
+  supertitleHref,
+  subtitle,
+  subtitleHref,
+  menu,
+  xstyle,
+  'data-testid': testId,
+  ...props
+}: XDSSideNavHeaderProps) {
   const rootRef = useRef<HTMLDivElement>(null);
 
   const popover = useXDSPopover({
@@ -503,6 +500,6 @@ export const XDSSideNavHeader = forwardRef<
       {chevronElement}
     </div>
   );
-});
+}
 
 XDSSideNavHeader.displayName = 'XDSSideNavHeader';

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSideNavItem.tsx
- * @input Uses React forwardRef, ReactNode, StyleX, XDSIcon, XDSIconType
+ * @input Uses React ReactNode, StyleX, XDSIcon, XDSIconType
  * @output Exports XDSSideNavItem component and XDSSideNavItemProps
  * @position Core implementation; used inside XDSSideNav children
  *
@@ -15,7 +15,7 @@
 
 'use client';
 
-import {forwardRef, useId, type ReactNode} from 'react';
+import {useId, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -102,6 +102,8 @@ const styles = stylex.create({
 // =============================================================================
 
 export interface XDSSideNavItemProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Custom component to render instead of `<a>` for link items.
    * Overrides the provider-level default set by XDSLinkProvider.
@@ -177,108 +179,102 @@ export interface XDSSideNavItemProps {
  * </XDSSideNavItem>
  * ```
  */
-export const XDSSideNavItem = forwardRef<HTMLElement, XDSSideNavItemProps>(
-  function XDSSideNavItem(
-    {
-      as,
-      label,
-      icon,
-      selectedIcon,
-      isSelected = false,
-      isDisabled = false,
-      href,
-      onClick,
-      endContent,
-      children,
-      'data-testid': testId,
-    },
-    ref,
-  ) {
-    const id = useId();
-    const hasChildren = !!children;
-    const LinkComponent = useXDSLinkComponent(as);
+export function XDSSideNavItem({
+  ref,
+  as,
+  label,
+  icon,
+  selectedIcon,
+  isSelected = false,
+  isDisabled = false,
+  href,
+  onClick,
+  endContent,
+  children,
+  'data-testid': testId,
+}: XDSSideNavItemProps) {
+  const id = useId();
+  const hasChildren = !!children;
+  const LinkComponent = useXDSLinkComponent(as);
 
-    const displayIcon = isSelected && selectedIcon ? selectedIcon : icon;
+  const displayIcon = isSelected && selectedIcon ? selectedIcon : icon;
 
-    const handleClick = (e: React.MouseEvent) => {
-      if (isDisabled) {
-        e.preventDefault();
-        return;
-      }
-      onClick?.(e);
-    };
+  const handleClick = (e: React.MouseEvent) => {
+    if (isDisabled) {
+      e.preventDefault();
+      return;
+    }
+    onClick?.(e);
+  };
 
-    const itemContent = (
-      <>
-        {displayIcon && (
-          <XDSIcon
-            icon={displayIcon}
-            size="sm"
-            color={
-              isSelected ? 'primary' : isDisabled ? 'disabled' : 'secondary'
-            }
-          />
-        )}
-        <span {...stylex.props(styles.label)}>{label}</span>
-        {endContent && (
-          <span {...stylex.props(styles.endContent)}>{endContent}</span>
-        )}
-      </>
+  const itemContent = (
+    <>
+      {displayIcon && (
+        <XDSIcon
+          icon={displayIcon}
+          size="sm"
+          color={isSelected ? 'primary' : isDisabled ? 'disabled' : 'secondary'}
+        />
+      )}
+      <span {...stylex.props(styles.label)}>{label}</span>
+      {endContent && (
+        <span {...stylex.props(styles.endContent)}>{endContent}</span>
+      )}
+    </>
+  );
+
+  const ariaProps = {
+    'aria-current': isSelected ? ('page' as const) : undefined,
+    'aria-disabled': isDisabled || undefined,
+    'data-testid': testId,
+  };
+
+  const itemElement =
+    href && !isDisabled ? (
+      <LinkComponent
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        href={href}
+        onClick={handleClick}
+        {...ariaProps}
+        {...stylex.props(
+          styles.item,
+          isSelected && styles.selected,
+          isDisabled && styles.disabled,
+        )}>
+        {itemContent}
+      </LinkComponent>
+    ) : (
+      <button
+        ref={ref as React.Ref<HTMLButtonElement>}
+        type="button"
+        onClick={handleClick}
+        disabled={isDisabled}
+        {...ariaProps}
+        {...stylex.props(
+          styles.item,
+          isSelected && styles.selected,
+          isDisabled && styles.disabled,
+        )}>
+        {itemContent}
+      </button>
     );
 
-    const ariaProps = {
-      'aria-current': isSelected ? ('page' as const) : undefined,
-      'aria-disabled': isDisabled || undefined,
-      'data-testid': testId,
-    };
-
-    const itemElement =
-      href && !isDisabled ? (
-        <LinkComponent
-          ref={ref as React.Ref<HTMLAnchorElement>}
-          href={href}
-          onClick={handleClick}
-          {...ariaProps}
-          {...stylex.props(
-            styles.item,
-            isSelected && styles.selected,
-            isDisabled && styles.disabled,
-          )}>
-          {itemContent}
-        </LinkComponent>
-      ) : (
-        <button
-          ref={ref as React.Ref<HTMLButtonElement>}
-          type="button"
-          onClick={handleClick}
-          disabled={isDisabled}
-          {...ariaProps}
-          {...stylex.props(
-            styles.item,
-            isSelected && styles.selected,
-            isDisabled && styles.disabled,
-          )}>
-          {itemContent}
-        </button>
-      );
-
-    return (
-      <div {...stylex.props(styles.root)}>
-        {itemElement}
-        {hasChildren && (
-          <div
-            role="group"
-            aria-labelledby={`${id}-label`}
-            {...stylex.props(styles.children)}>
-            <span id={`${id}-label`} hidden>
-              {label}
-            </span>
-            {children}
-          </div>
-        )}
-      </div>
-    );
-  },
-);
+  return (
+    <div {...stylex.props(styles.root)}>
+      {itemElement}
+      {hasChildren && (
+        <div
+          role="group"
+          aria-labelledby={`${id}-label`}
+          {...stylex.props(styles.children)}>
+          <span id={`${id}-label`} hidden>
+            {label}
+          </span>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
 
 XDSSideNavItem.displayName = 'XDSSideNavItem';

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -10,7 +10,7 @@
  * - /apps/storybook/stories/Skeleton.stories.tsx
  */
 
-import {forwardRef, useContext, type HTMLAttributes} from 'react';
+import {useContext, type HTMLAttributes, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
@@ -126,6 +126,8 @@ export interface XDSSkeletonProps extends Omit<
   HTMLAttributes<HTMLDivElement>,
   'className' | 'style'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /**
    * Width of the skeleton.
    * Accepts a number (pixels) or string (any CSS value).
@@ -175,36 +177,32 @@ export interface XDSSkeletonProps extends Omit<
  * <XDSSkeleton width={280} height={16} index={1} />
  * ```
  */
-export const XDSSkeleton = forwardRef<HTMLDivElement, XDSSkeletonProps>(
-  (
-    {
-      width = '100%',
-      height = '100%',
-      radius: radiusProp = 'container',
-      index = 0,
-      'data-testid': testId,
-      ...props
-    },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.skeleton?.root;
-    return (
-      <div
-        ref={ref}
-        data-testid={testId}
-        {...stylex.props(
-          styles.root,
-          styles.animate,
-          radiusStyles[radiusProp],
-          dynamicStyles.dimensions(width, height),
-          dynamicStyles.animationDelay(index),
-          rootOverride,
-        )}
-        {...props}
-      />
-    );
-  },
-);
+export function XDSSkeleton({
+  ref,
+  width = '100%',
+  height = '100%',
+  radius: radiusProp = 'container',
+  index = 0,
+  'data-testid': testId,
+  ...props
+}: XDSSkeletonProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.skeleton?.root;
+  return (
+    <div
+      ref={ref}
+      data-testid={testId}
+      {...stylex.props(
+        styles.root,
+        styles.animate,
+        radiusStyles[radiusProp],
+        dynamicStyles.dimensions(width, height),
+        dynamicStyles.animationDelay(index),
+        rootOverride,
+      )}
+      {...props}
+    />
+  );
+}
 
 XDSSkeleton.displayName = 'XDSSkeleton';

--- a/packages/core/src/Slider/README.md
+++ b/packages/core/src/Slider/README.md
@@ -175,7 +175,7 @@ const theme: Theme = {
 
 ## Implementation Notes
 
-- The component uses `forwardRef` — the ref is merged with an internal `trackRef` for pointer position calculations
+- The component accepts a `ref` prop — the ref is merged with an internal `trackRef` for pointer position calculations
 - Pointer capture is used during drag for smooth interaction even when the cursor leaves the track
 - `snapToStep` rounds to the nearest valid step value; `clamp` enforces min/max bounds
 - In range mode, the closest thumb is selected on track click based on distance to each thumb

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSlider.tsx
- * @input Uses React forwardRef, useId, useRef, useCallback, XDSField, XDSTooltip
+ * @input Uses React useId, useRef, useCallback, XDSField, XDSTooltip
  * @output Exports XDSSlider component, XDSSliderProps, XDSSliderSingleProps, XDSSliderRangeProps, XDSSliderBaseProps
  * @position Core implementation; consumed by index.ts, tested by XDSSlider.test.tsx
  *
@@ -12,13 +12,13 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useId,
   useRef,
   useCallback,
   type KeyboardEvent,
   type PointerEvent,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -59,6 +59,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSSliderBaseProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLDivElement>;
   /** Label text for the slider (always rendered for accessibility). */
   label: string;
   /** Whether to visually hide the label (still accessible to screen readers). @default false */
@@ -320,443 +322,440 @@ function getPercent(val: number, min: number, max: number): number {
  * <XDSSlider label="Price range" value={[20, 80]} onChange={setRange} />
  * ```
  */
-export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
-  (props, ref) => {
-    const {
-      label,
-      isLabelHidden = false,
-      description,
-      isDisabled = false,
-      isOptional = false,
-      isRequired = false,
-      status,
-      labelTooltip,
-      min = 0,
-      max = 100,
-      step = 1,
-      orientation = 'horizontal',
-      formatValue,
-      valueDisplay = 'tooltip',
-      marks,
-      xstyle,
-      'data-testid': testId,
-      value,
-      onChange,
-      onChangeEnd,
-    } = props;
+export function XDSSlider({ref, ...props}: XDSSliderProps) {
+  const {
+    label,
+    isLabelHidden = false,
+    description,
+    isDisabled = false,
+    isOptional = false,
+    isRequired = false,
+    status,
+    labelTooltip,
+    min = 0,
+    max = 100,
+    step = 1,
+    orientation = 'horizontal',
+    formatValue,
+    valueDisplay = 'tooltip',
+    marks,
+    xstyle,
+    'data-testid': testId,
+    value,
+    onChange,
+    onChangeEnd,
+  } = props;
 
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.slider?.root;
-    const trackOverride = themeContext?.theme.components?.slider?.track;
-    const filledTrackOverride =
-      themeContext?.theme.components?.slider?.filledTrack;
-    const thumbOverride = themeContext?.theme.components?.slider?.thumb;
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.slider?.root;
+  const trackOverride = themeContext?.theme.components?.slider?.track;
+  const filledTrackOverride =
+    themeContext?.theme.components?.slider?.filledTrack;
+  const thumbOverride = themeContext?.theme.components?.slider?.thumb;
 
-    const isRange = Array.isArray(value);
-    const minStepsBetweenThumbs =
-      isRange && 'minStepsBetweenThumbs' in props
-        ? ((props as XDSSliderRangeProps).minStepsBetweenThumbs ?? 0)
-        : 0;
+  const isRange = Array.isArray(value);
+  const minStepsBetweenThumbs =
+    isRange && 'minStepsBetweenThumbs' in props
+      ? ((props as XDSSliderRangeProps).minStepsBetweenThumbs ?? 0)
+      : 0;
 
-    const isHorizontal = orientation === 'horizontal';
+  const isHorizontal = orientation === 'horizontal';
 
-    const id = useId();
-    const descriptionID = useId();
-    const statusMessageID = useId();
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
 
-    const trackRef = useRef<HTMLDivElement>(null);
-    const draggingThumbRef = useRef<number | null>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const draggingThumbRef = useRef<number | null>(null);
 
-    // Build aria-describedby
-    const describedByParts: string[] = [];
-    if (description) describedByParts.push(descriptionID);
-    if (status?.message) describedByParts.push(statusMessageID);
-    const ariaDescribedBy =
-      describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
+  // Build aria-describedby
+  const describedByParts: string[] = [];
+  if (description) describedByParts.push(descriptionID);
+  if (status?.message) describedByParts.push(statusMessageID);
+  const ariaDescribedBy =
+    describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
 
-    // Value helpers
-    const values: number[] = isRange
-      ? (value as [number, number])
-      : [value as number];
+  // Value helpers
+  const values: number[] = isRange
+    ? (value as [number, number])
+    : [value as number];
 
-    const getValueFromPosition = useCallback(
-      (clientX: number, clientY: number): number => {
-        const track = trackRef.current;
-        if (!track) return min;
-        const rect = track.getBoundingClientRect();
+  const getValueFromPosition = useCallback(
+    (clientX: number, clientY: number): number => {
+      const track = trackRef.current;
+      if (!track) return min;
+      const rect = track.getBoundingClientRect();
 
-        let percent: number;
-        if (isHorizontal) {
-          percent = (clientX - rect.left) / rect.width;
-        } else {
-          // Vertical: bottom = min, top = max
-          percent = 1 - (clientY - rect.top) / rect.height;
-        }
-        percent = clamp(percent, 0, 1);
-        const raw = min + percent * (max - min);
-        return clamp(snapToStep(raw, min, step), min, max);
-      },
-      [min, max, step, isHorizontal],
-    );
-
-    const getClosestThumb = useCallback(
-      (newValue: number): number => {
-        if (!isRange) return 0;
-        const [v0, v1] = values;
-        const d0 = Math.abs(newValue - v0);
-        const d1 = Math.abs(newValue - v1);
-        // Prefer the lower thumb if equidistant
-        return d0 <= d1 ? 0 : 1;
-      },
-      [isRange, values],
-    );
-
-    const updateValue = useCallback(
-      (thumbIndex: number, newVal: number) => {
-        if (isDisabled) return;
-        const clamped = clamp(snapToStep(newVal, min, step), min, max);
-
-        if (isRange) {
-          const currentValues = [...values] as [number, number];
-          currentValues[thumbIndex] = clamped;
-
-          // Enforce minStepsBetweenThumbs
-          const minGap = minStepsBetweenThumbs * step;
-          if (thumbIndex === 0) {
-            currentValues[0] = Math.min(
-              currentValues[0],
-              currentValues[1] - minGap,
-            );
-          } else {
-            currentValues[1] = Math.max(
-              currentValues[1],
-              currentValues[0] + minGap,
-            );
-          }
-
-          // Keep within bounds
-          currentValues[0] = clamp(currentValues[0], min, max);
-          currentValues[1] = clamp(currentValues[1], min, max);
-
-          (onChange as XDSSliderRangeProps['onChange'])?.(currentValues);
-        } else {
-          (onChange as XDSSliderSingleProps['onChange'])?.(clamped);
-        }
-      },
-      [
-        isDisabled,
-        isRange,
-        values,
-        min,
-        max,
-        step,
-        minStepsBetweenThumbs,
-        onChange,
-      ],
-    );
-
-    const fireChangeEnd = useCallback(() => {
-      if (isRange) {
-        (onChangeEnd as XDSSliderRangeProps['onChangeEnd'])?.(
-          values as unknown as [number, number],
-        );
-      } else {
-        (onChangeEnd as XDSSliderSingleProps['onChangeEnd'])?.(values[0]);
-      }
-    }, [isRange, values, onChangeEnd]);
-
-    // Pointer handlers
-    const handlePointerDown = useCallback(
-      (e: PointerEvent<HTMLDivElement>) => {
-        if (isDisabled) return;
-        e.preventDefault();
-        const newVal = getValueFromPosition(e.clientX, e.clientY);
-        const thumbIndex = getClosestThumb(newVal);
-        draggingThumbRef.current = thumbIndex;
-        updateValue(thumbIndex, newVal);
-        if (
-          typeof (e.currentTarget as HTMLElement).setPointerCapture ===
-          'function'
-        ) {
-          (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-        }
-      },
-      [isDisabled, getValueFromPosition, getClosestThumb, updateValue],
-    );
-
-    const handlePointerMove = useCallback(
-      (e: PointerEvent<HTMLDivElement>) => {
-        if (draggingThumbRef.current === null || isDisabled) return;
-        const newVal = getValueFromPosition(e.clientX, e.clientY);
-        updateValue(draggingThumbRef.current, newVal);
-      },
-      [isDisabled, getValueFromPosition, updateValue],
-    );
-
-    const handlePointerUp = useCallback(
-      (_e: PointerEvent<HTMLDivElement>) => {
-        if (draggingThumbRef.current !== null) {
-          draggingThumbRef.current = null;
-          fireChangeEnd();
-        }
-      },
-      [fireChangeEnd],
-    );
-
-    // Keyboard handler
-    const handleKeyDown = useCallback(
-      (thumbIndex: number, e: KeyboardEvent<HTMLDivElement>) => {
-        if (isDisabled) return;
-        const currentVal = values[thumbIndex];
-        let newVal = currentVal;
-
-        switch (e.key) {
-          case 'ArrowRight':
-          case 'ArrowUp':
-            newVal = currentVal + step;
-            break;
-          case 'ArrowLeft':
-          case 'ArrowDown':
-            newVal = currentVal - step;
-            break;
-          case 'PageUp':
-            newVal = currentVal + step * 10;
-            break;
-          case 'PageDown':
-            newVal = currentVal - step * 10;
-            break;
-          case 'Home':
-            newVal = min;
-            break;
-          case 'End':
-            newVal = max;
-            break;
-          default:
-            return;
-        }
-
-        e.preventDefault();
-        updateValue(thumbIndex, newVal);
-      },
-      [isDisabled, values, step, min, max, updateValue],
-    );
-
-    // Format display value
-    const displayValue = (val: number): string => {
-      if (formatValue) return formatValue(val);
-      return String(val);
-    };
-
-    // Render a thumb
-    const renderThumb = (thumbIndex: number) => {
-      const val = values[thumbIndex];
-      const percent = getPercent(val, min, max);
-
-      const positionStyle = isHorizontal
-        ? {left: `${percent}%`}
-        : {bottom: `${percent}%`, left: '50%'};
-
-      const thumbLabel = isRange
-        ? thumbIndex === 0
-          ? 'Minimum value'
-          : 'Maximum value'
-        : label;
-
-      const useTooltip = valueDisplay === 'tooltip';
-      const tooltipPlacement = isHorizontal ? 'above' : 'start';
-
-      const thumbElement = (
-        <div
-          key={thumbIndex}
-          role="slider"
-          tabIndex={isDisabled ? -1 : 0}
-          aria-valuemin={min}
-          aria-valuemax={max}
-          aria-valuenow={val}
-          aria-valuetext={formatValue ? formatValue(val) : undefined}
-          aria-orientation={orientation}
-          aria-disabled={isDisabled || undefined}
-          aria-invalid={status?.type === 'error' ? true : undefined}
-          aria-label={thumbLabel}
-          aria-describedby={ariaDescribedBy}
-          style={positionStyle}
-          onKeyDown={e => handleKeyDown(thumbIndex, e)}
-          {...stylex.props(
-            styles.thumb,
-            isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
-            !isDisabled && styles.thumbHover,
-            !isDisabled && styles.thumbFocusWithin,
-            isDisabled && styles.thumbDisabled,
-            thumbOverride,
-          )}
-        />
-      );
-
-      if (useTooltip) {
-        return (
-          <XDSTooltip
-            key={thumbIndex}
-            content={displayValue(val)}
-            placement={tooltipPlacement}
-            delay={0}
-            focusTrigger="always">
-            {thumbElement}
-          </XDSTooltip>
-        );
-      }
-
-      return thumbElement;
-    };
-
-    // Filled track position
-    const filledStyle = (() => {
-      if (isRange) {
-        const [v0, v1] = values;
-        const p0 = getPercent(v0, min, max);
-        const p1 = getPercent(v1, min, max);
-        if (isHorizontal) {
-          return {left: `${p0}%`, width: `${p1 - p0}%`};
-        }
-        return {bottom: `${p0}%`, height: `${p1 - p0}%`};
-      }
-      const p = getPercent(values[0], min, max);
+      let percent: number;
       if (isHorizontal) {
-        return {left: '0%', width: `${p}%`};
+        percent = (clientX - rect.left) / rect.width;
+      } else {
+        // Vertical: bottom = min, top = max
+        percent = 1 - (clientY - rect.top) / rect.height;
       }
-      return {bottom: '0%', height: `${p}%`};
-    })();
+      percent = clamp(percent, 0, 1);
+      const raw = min + percent * (max - min);
+      return clamp(snapToStep(raw, min, step), min, max);
+    },
+    [min, max, step, isHorizontal],
+  );
 
-    // Text value display
-    const textDisplay =
-      valueDisplay === 'text' ? (
-        <span {...stylex.props(styles.textValue)}>
-          {isRange
-            ? `${displayValue(values[0])} – ${displayValue(values[1])}`
-            : displayValue(values[0])}
-        </span>
-      ) : null;
+  const getClosestThumb = useCallback(
+    (newValue: number): number => {
+      if (!isRange) return 0;
+      const [v0, v1] = values;
+      const d0 = Math.abs(newValue - v0);
+      const d1 = Math.abs(newValue - v1);
+      // Prefer the lower thumb if equidistant
+      return d0 <= d1 ? 0 : 1;
+    },
+    [isRange, values],
+  );
 
-    return (
-      <XDSField
-        data-testid={testId}
-        label={label}
-        isLabelHidden={isLabelHidden}
-        description={description}
-        inputID={id}
-        descriptionID={description ? descriptionID : undefined}
-        isOptional={isOptional}
-        isRequired={isRequired}
-        status={
-          status
-            ? {
-                type: status.type,
-                message: status.message,
-                messageID: status.message ? statusMessageID : undefined,
-              }
-            : undefined
+  const updateValue = useCallback(
+    (thumbIndex: number, newVal: number) => {
+      if (isDisabled) return;
+      const clamped = clamp(snapToStep(newVal, min, step), min, max);
+
+      if (isRange) {
+        const currentValues = [...values] as [number, number];
+        currentValues[thumbIndex] = clamped;
+
+        // Enforce minStepsBetweenThumbs
+        const minGap = minStepsBetweenThumbs * step;
+        if (thumbIndex === 0) {
+          currentValues[0] = Math.min(
+            currentValues[0],
+            currentValues[1] - minGap,
+          );
+        } else {
+          currentValues[1] = Math.max(
+            currentValues[1],
+            currentValues[0] + minGap,
+          );
         }
-        labelTooltip={labelTooltip}
-        statusVariant="detached"
-        {...stylex.props(xstyle)}>
-        <div {...stylex.props(styles.sliderRow, rootOverride)}>
+
+        // Keep within bounds
+        currentValues[0] = clamp(currentValues[0], min, max);
+        currentValues[1] = clamp(currentValues[1], min, max);
+
+        (onChange as XDSSliderRangeProps['onChange'])?.(currentValues);
+      } else {
+        (onChange as XDSSliderSingleProps['onChange'])?.(clamped);
+      }
+    },
+    [
+      isDisabled,
+      isRange,
+      values,
+      min,
+      max,
+      step,
+      minStepsBetweenThumbs,
+      onChange,
+    ],
+  );
+
+  const fireChangeEnd = useCallback(() => {
+    if (isRange) {
+      (onChangeEnd as XDSSliderRangeProps['onChangeEnd'])?.(
+        values as unknown as [number, number],
+      );
+    } else {
+      (onChangeEnd as XDSSliderSingleProps['onChangeEnd'])?.(values[0]);
+    }
+  }, [isRange, values, onChangeEnd]);
+
+  // Pointer handlers
+  const handlePointerDown = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (isDisabled) return;
+      e.preventDefault();
+      const newVal = getValueFromPosition(e.clientX, e.clientY);
+      const thumbIndex = getClosestThumb(newVal);
+      draggingThumbRef.current = thumbIndex;
+      updateValue(thumbIndex, newVal);
+      if (
+        typeof (e.currentTarget as HTMLElement).setPointerCapture === 'function'
+      ) {
+        (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+      }
+    },
+    [isDisabled, getValueFromPosition, getClosestThumb, updateValue],
+  );
+
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLDivElement>) => {
+      if (draggingThumbRef.current === null || isDisabled) return;
+      const newVal = getValueFromPosition(e.clientX, e.clientY);
+      updateValue(draggingThumbRef.current, newVal);
+    },
+    [isDisabled, getValueFromPosition, updateValue],
+  );
+
+  const handlePointerUp = useCallback(
+    (_e: PointerEvent<HTMLDivElement>) => {
+      if (draggingThumbRef.current !== null) {
+        draggingThumbRef.current = null;
+        fireChangeEnd();
+      }
+    },
+    [fireChangeEnd],
+  );
+
+  // Keyboard handler
+  const handleKeyDown = useCallback(
+    (thumbIndex: number, e: KeyboardEvent<HTMLDivElement>) => {
+      if (isDisabled) return;
+      const currentVal = values[thumbIndex];
+      let newVal = currentVal;
+
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowUp':
+          newVal = currentVal + step;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowDown':
+          newVal = currentVal - step;
+          break;
+        case 'PageUp':
+          newVal = currentVal + step * 10;
+          break;
+        case 'PageDown':
+          newVal = currentVal - step * 10;
+          break;
+        case 'Home':
+          newVal = min;
+          break;
+        case 'End':
+          newVal = max;
+          break;
+        default:
+          return;
+      }
+
+      e.preventDefault();
+      updateValue(thumbIndex, newVal);
+    },
+    [isDisabled, values, step, min, max, updateValue],
+  );
+
+  // Format display value
+  const displayValue = (val: number): string => {
+    if (formatValue) return formatValue(val);
+    return String(val);
+  };
+
+  // Render a thumb
+  const renderThumb = (thumbIndex: number) => {
+    const val = values[thumbIndex];
+    const percent = getPercent(val, min, max);
+
+    const positionStyle = isHorizontal
+      ? {left: `${percent}%`}
+      : {bottom: `${percent}%`, left: '50%'};
+
+    const thumbLabel = isRange
+      ? thumbIndex === 0
+        ? 'Minimum value'
+        : 'Maximum value'
+      : label;
+
+    const useTooltip = valueDisplay === 'tooltip';
+    const tooltipPlacement = isHorizontal ? 'above' : 'start';
+
+    const thumbElement = (
+      <div
+        key={thumbIndex}
+        role="slider"
+        tabIndex={isDisabled ? -1 : 0}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={val}
+        aria-valuetext={formatValue ? formatValue(val) : undefined}
+        aria-orientation={orientation}
+        aria-disabled={isDisabled || undefined}
+        aria-invalid={status?.type === 'error' ? true : undefined}
+        aria-label={thumbLabel}
+        aria-describedby={ariaDescribedBy}
+        style={positionStyle}
+        onKeyDown={e => handleKeyDown(thumbIndex, e)}
+        {...stylex.props(
+          styles.thumb,
+          isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
+          !isDisabled && styles.thumbHover,
+          !isDisabled && styles.thumbFocusWithin,
+          isDisabled && styles.thumbDisabled,
+          thumbOverride,
+        )}
+      />
+    );
+
+    if (useTooltip) {
+      return (
+        <XDSTooltip
+          key={thumbIndex}
+          content={displayValue(val)}
+          placement={tooltipPlacement}
+          delay={0}
+          focusTrigger="always">
+          {thumbElement}
+        </XDSTooltip>
+      );
+    }
+
+    return thumbElement;
+  };
+
+  // Filled track position
+  const filledStyle = (() => {
+    if (isRange) {
+      const [v0, v1] = values;
+      const p0 = getPercent(v0, min, max);
+      const p1 = getPercent(v1, min, max);
+      if (isHorizontal) {
+        return {left: `${p0}%`, width: `${p1 - p0}%`};
+      }
+      return {bottom: `${p0}%`, height: `${p1 - p0}%`};
+    }
+    const p = getPercent(values[0], min, max);
+    if (isHorizontal) {
+      return {left: '0%', width: `${p}%`};
+    }
+    return {bottom: '0%', height: `${p}%`};
+  })();
+
+  // Text value display
+  const textDisplay =
+    valueDisplay === 'text' ? (
+      <span {...stylex.props(styles.textValue)}>
+        {isRange
+          ? `${displayValue(values[0])} – ${displayValue(values[1])}`
+          : displayValue(values[0])}
+      </span>
+    ) : null;
+
+  return (
+    <XDSField
+      data-testid={testId}
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={id}
+      descriptionID={description ? descriptionID : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageID : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}
+      statusVariant="detached"
+      {...stylex.props(xstyle)}>
+      <div {...stylex.props(styles.sliderRow, rootOverride)}>
+        <div
+          ref={node => {
+            // Merge refs
+            (
+              trackRef as React.MutableRefObject<HTMLDivElement | null>
+            ).current = node;
+            if (typeof ref === 'function') {
+              ref(node);
+            } else if (ref) {
+              (ref as React.MutableRefObject<HTMLDivElement | null>).current =
+                node;
+            }
+          }}
+          onPointerDown={handlePointerDown}
+          onPointerMove={handlePointerMove}
+          onPointerUp={handlePointerUp}
+          {...stylex.props(
+            styles.trackContainer,
+            isHorizontal
+              ? styles.trackContainerHorizontal
+              : styles.trackContainerVertical,
+            isDisabled && styles.trackContainerDisabled,
+          )}>
+          {/* Background track */}
           <div
-            ref={node => {
-              // Merge refs
-              (
-                trackRef as React.MutableRefObject<HTMLDivElement | null>
-              ).current = node;
-              if (typeof ref === 'function') {
-                ref(node);
-              } else if (ref) {
-                (ref as React.MutableRefObject<HTMLDivElement | null>).current =
-                  node;
-              }
-            }}
-            onPointerDown={handlePointerDown}
-            onPointerMove={handlePointerMove}
-            onPointerUp={handlePointerUp}
             {...stylex.props(
-              styles.trackContainer,
+              styles.track,
+              isHorizontal ? styles.trackHorizontal : styles.trackVertical,
+              trackOverride,
+            )}
+          />
+
+          {/* Filled track */}
+          <div
+            style={filledStyle}
+            {...stylex.props(
+              styles.filledTrack,
               isHorizontal
-                ? styles.trackContainerHorizontal
-                : styles.trackContainerVertical,
-              isDisabled && styles.trackContainerDisabled,
-            )}>
-            {/* Background track */}
-            <div
-              {...stylex.props(
-                styles.track,
-                isHorizontal ? styles.trackHorizontal : styles.trackVertical,
-                trackOverride,
-              )}
-            />
+                ? styles.filledTrackHorizontal
+                : styles.filledTrackVertical,
+              filledTrackOverride,
+            )}
+          />
 
-            {/* Filled track */}
+          {/* Marks */}
+          {marks && (
             <div
-              style={filledStyle}
               {...stylex.props(
-                styles.filledTrack,
+                styles.marksContainer,
                 isHorizontal
-                  ? styles.filledTrackHorizontal
-                  : styles.filledTrackVertical,
-                filledTrackOverride,
-              )}
-            />
-
-            {/* Marks */}
-            {marks && (
-              <div
-                {...stylex.props(
-                  styles.marksContainer,
-                  isHorizontal
-                    ? styles.marksContainerHorizontal
-                    : styles.marksContainerVertical,
-                )}>
-                {marks.map(mark => {
-                  const percent = getPercent(mark.value, min, max);
-                  const markPos = isHorizontal
-                    ? {left: `${percent}%`}
-                    : {bottom: `${percent}%`};
-                  return (
-                    <div key={mark.value}>
-                      <div
-                        data-testid="slider-mark"
+                  ? styles.marksContainerHorizontal
+                  : styles.marksContainerVertical,
+              )}>
+              {marks.map(mark => {
+                const percent = getPercent(mark.value, min, max);
+                const markPos = isHorizontal
+                  ? {left: `${percent}%`}
+                  : {bottom: `${percent}%`};
+                return (
+                  <div key={mark.value}>
+                    <div
+                      data-testid="slider-mark"
+                      style={markPos}
+                      {...stylex.props(
+                        styles.mark,
+                        isHorizontal
+                          ? styles.markHorizontal
+                          : styles.markVertical,
+                      )}
+                    />
+                    {mark.label && (
+                      <span
+                        data-testid="slider-mark-label"
                         style={markPos}
                         {...stylex.props(
-                          styles.mark,
+                          styles.markLabel,
                           isHorizontal
-                            ? styles.markHorizontal
-                            : styles.markVertical,
-                        )}
-                      />
-                      {mark.label && (
-                        <span
-                          data-testid="slider-mark-label"
-                          style={markPos}
-                          {...stylex.props(
-                            styles.markLabel,
-                            isHorizontal
-                              ? styles.markLabelHorizontal
-                              : styles.markLabelVertical,
-                          )}>
-                          {mark.label}
-                        </span>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            )}
+                            ? styles.markLabelHorizontal
+                            : styles.markLabelVertical,
+                        )}>
+                        {mark.label}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
 
-            {/* Thumbs */}
-            {values.map((_, i) => renderThumb(i))}
-          </div>
-
-          {textDisplay}
+          {/* Thumbs */}
+          {values.map((_, i) => renderThumb(i))}
         </div>
-      </XDSField>
-    );
-  },
-);
+
+        {textDisplay}
+      </div>
+    </XDSField>
+  );
+}
 
 XDSSlider.displayName = 'XDSSlider';

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/Spinner.stories.tsx
  */
 
-import {forwardRef, useContext, useEffect, useRef} from 'react';
+import {useContext, useEffect, useRef, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
@@ -81,6 +81,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSSpinnerProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLSpanElement>;
   /**
    * Spinner size.
    * - 'sm': 10px diameter
@@ -115,80 +117,82 @@ export interface XDSSpinnerProps {
  * <XDSSpinner size="lg" shade="onMedia" />
  * ```
  */
-export const XDSSpinner = forwardRef<HTMLSpanElement, XDSSpinnerProps>(
-  ({size = 'md', shade = 'default', 'data-testid': testId}, ref) => {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.spinner?.root;
-    const canvasRef = useRef<HTMLCanvasElement>(null);
+export function XDSSpinner({
+  ref,
+  size = 'md',
+  shade = 'default',
+  'data-testid': testId,
+}: XDSSpinnerProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.spinner?.root;
+  const canvasRef = useRef<HTMLCanvasElement>(null);
 
-    useEffect(() => {
-      const canvas = canvasRef.current;
-      if (canvas == null) return;
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (canvas == null) return;
 
-      const context = canvas.getContext('2d');
-      if (!context) return;
-
-      const {border, diameter} = SIZES[size];
-      const pixelRatio = window.devicePixelRatio || 1;
-
-      // Resolve colors from CSS custom properties
-      const computedStyle = getComputedStyle(canvas);
-      const activeColor =
-        shade === 'onMedia'
-          ? computedStyle.getPropertyValue(
-              colorVars['--color-icon-on-media'],
-            ) || '#FFFFFF'
-          : computedStyle.getPropertyValue(colorVars['--color-accent']) ||
-            '#0064E0';
-      const backgroundColor =
-        shade === 'onMedia' ? 'rgba(255, 255, 255, 0.3)' : 'rgba(0, 0, 0, 0.1)';
-
-      const radius = (diameter / 2) * pixelRatio;
-      const lineWidth = border * pixelRatio;
-      const frameSize = (radius + lineWidth) * 2;
-
-      canvas.height = canvas.width = frameSize;
-      canvas.style.width = canvas.style.height = frameSize / pixelRatio + 'px';
-
-      context.lineCap = 'round';
-      context.lineWidth = lineWidth;
-
-      const center = frameSize / 2;
-
-      // Background circle (full ring, faded)
-      context.beginPath();
-      context.arc(center, center, radius, 0, 2 * Math.PI);
-      context.strokeStyle = backgroundColor;
-      context.stroke();
-
-      // Active arc (partial ring, colored)
-      context.beginPath();
-      context.arc(
-        center,
-        center,
-        radius,
-        START_POINT * Math.PI,
-        ((START_POINT + SPREAD) % 2) * Math.PI,
-      );
-      context.strokeStyle = activeColor;
-      context.stroke();
-    }, [shade, size]);
+    const context = canvas.getContext('2d');
+    if (!context) return;
 
     const {border, diameter} = SIZES[size];
-    const frameSize = diameter + border * 2;
+    const pixelRatio = window.devicePixelRatio || 1;
 
-    return (
-      <span
-        ref={ref}
-        role="status"
-        aria-label="Loading"
-        data-testid={testId}
-        {...stylex.props(styles.spinner, rootOverride)}
-        style={{width: frameSize, height: frameSize}}>
-        <canvas ref={canvasRef} {...stylex.props(styles.canvas)} />
-      </span>
+    // Resolve colors from CSS custom properties
+    const computedStyle = getComputedStyle(canvas);
+    const activeColor =
+      shade === 'onMedia'
+        ? computedStyle.getPropertyValue(colorVars['--color-icon-on-media']) ||
+          '#FFFFFF'
+        : computedStyle.getPropertyValue(colorVars['--color-accent']) ||
+          '#0064E0';
+    const backgroundColor =
+      shade === 'onMedia' ? 'rgba(255, 255, 255, 0.3)' : 'rgba(0, 0, 0, 0.1)';
+
+    const radius = (diameter / 2) * pixelRatio;
+    const lineWidth = border * pixelRatio;
+    const frameSize = (radius + lineWidth) * 2;
+
+    canvas.height = canvas.width = frameSize;
+    canvas.style.width = canvas.style.height = frameSize / pixelRatio + 'px';
+
+    context.lineCap = 'round';
+    context.lineWidth = lineWidth;
+
+    const center = frameSize / 2;
+
+    // Background circle (full ring, faded)
+    context.beginPath();
+    context.arc(center, center, radius, 0, 2 * Math.PI);
+    context.strokeStyle = backgroundColor;
+    context.stroke();
+
+    // Active arc (partial ring, colored)
+    context.beginPath();
+    context.arc(
+      center,
+      center,
+      radius,
+      START_POINT * Math.PI,
+      ((START_POINT + SPREAD) % 2) * Math.PI,
     );
-  },
-);
+    context.strokeStyle = activeColor;
+    context.stroke();
+  }, [shade, size]);
+
+  const {border, diameter} = SIZES[size];
+  const frameSize = diameter + border * 2;
+
+  return (
+    <span
+      ref={ref}
+      role="status"
+      aria-label="Loading"
+      data-testid={testId}
+      {...stylex.props(styles.spinner, rootOverride)}
+      style={{width: frameSize, height: frameSize}}>
+      <canvas ref={canvasRef} {...stylex.props(styles.canvas)} />
+    </span>
+  );
+}
 
 XDSSpinner.displayName = 'XDSSpinner';

--- a/packages/core/src/Stack/XDSHStack.tsx
+++ b/packages/core/src/Stack/XDSHStack.tsx
@@ -10,7 +10,7 @@
  * - /apps/storybook/stories/HStack.stories.tsx
  */
 
-import {forwardRef} from 'react';
+import {type Ref} from 'react';
 import {XDSStack, type XDSStackProps} from './XDSStack';
 import type {StackCrossAlignment, StackMainAlignment} from './stack.stylex';
 
@@ -18,6 +18,8 @@ export interface XDSHStackProps extends Omit<
   XDSStackProps,
   'direction' | 'hAlign' | 'vAlign'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Horizontal alignment of items (main-axis for horizontal stack).
    * - `start`: Align to start (left in LTR)
@@ -50,10 +52,8 @@ export interface XDSHStackProps extends Omit<
  * <XDSStack direction="horizontal" gap="space2">...</XDSStack>
  * ```
  */
-export const XDSHStack = forwardRef<HTMLElement, XDSHStackProps>(
-  function XDSHStack(props, ref) {
-    return <XDSStack {...props} direction="horizontal" ref={ref} />;
-  },
-);
+export function XDSHStack({ref, ...props}: XDSStackProps) {
+  return <XDSStack {...props} direction="horizontal" ref={ref} />;
+}
 
 XDSHStack.displayName = 'XDSHStack';

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSStack.tsx
- * @input Uses React forwardRef, ElementType, stack utility
+ * @input Uses React ElementType, stack utility
  * @output Exports XDSStack polymorphic component and XDSStackProps
  * @position Layout/Stack component; uses stack.stylex.ts
  *
@@ -11,7 +11,6 @@
  */
 
 import {
-  forwardRef,
   createElement,
   type ElementType,
   type HTMLAttributes,
@@ -45,6 +44,8 @@ export interface XDSStackProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Direction of the stack layout.
    * - `horizontal`: Items flow left-to-right (like XDSHStack)
@@ -128,52 +129,48 @@ export interface XDSStackProps extends Omit<
  * </XDSStack>
  * ```
  */
-export const XDSStack = forwardRef<HTMLElement, XDSStackProps>(
-  function XDSStack(
-    {
+export function XDSStack({
+  ref,
+  direction,
+  hAlign,
+  vAlign,
+  gap,
+  wrap,
+  element = 'div',
+  xstyle,
+  children,
+  ...props
+}: XDSStackProps) {
+  // Map hAlign/vAlign to mainAlign/crossAlign based on direction
+  const mainAlign =
+    direction === 'horizontal'
+      ? (hAlign as StackMainAlignment | undefined)
+      : (vAlign as StackMainAlignment | undefined);
+  const crossAlign =
+    direction === 'horizontal'
+      ? (vAlign as StackCrossAlignment | undefined)
+      : (hAlign as StackCrossAlignment | undefined);
+
+  const stylexProps = stylex.props(
+    ...stack({
       direction,
-      hAlign,
-      vAlign,
+      crossAlign,
+      mainAlign,
       gap,
       wrap,
-      element = 'div',
-      xstyle,
-      children,
-      ...props
+    }),
+    xstyle,
+  );
+
+  return createElement(
+    element,
+    {
+      ref: ref as Ref<Element>,
+      ...stylexProps,
+      ...props,
     },
-    ref,
-  ) {
-    // Map hAlign/vAlign to mainAlign/crossAlign based on direction
-    const mainAlign =
-      direction === 'horizontal'
-        ? (hAlign as StackMainAlignment | undefined)
-        : (vAlign as StackMainAlignment | undefined);
-    const crossAlign =
-      direction === 'horizontal'
-        ? (vAlign as StackCrossAlignment | undefined)
-        : (hAlign as StackCrossAlignment | undefined);
-
-    const stylexProps = stylex.props(
-      ...stack({
-        direction,
-        crossAlign,
-        mainAlign,
-        gap,
-        wrap,
-      }),
-      xstyle,
-    );
-
-    return createElement(
-      element,
-      {
-        ref: ref as Ref<Element>,
-        ...stylexProps,
-        ...props,
-      },
-      children,
-    );
-  },
-);
+    children,
+  );
+}
 
 XDSStack.displayName = 'XDSStack';

--- a/packages/core/src/Stack/XDSStackItem.tsx
+++ b/packages/core/src/Stack/XDSStackItem.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSStackItem.tsx
- * @input Uses React forwardRef, ElementType, stackItem utility
+ * @input Uses React ElementType, stackItem utility
  * @output Exports XDSStackItem polymorphic component and XDSStackItemProps
  * @position Layout/Stack component; uses stackItem.stylex.ts
  *
@@ -11,7 +11,6 @@
  */
 
 import {
-  forwardRef,
   createElement,
   type ElementType,
   type HTMLAttributes,
@@ -30,6 +29,8 @@ export interface XDSStackItemProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Overrides the default cross-alignment for this item.
    * (hAlign for VStack, vAlign for HStack)
@@ -76,26 +77,29 @@ export interface XDSStackItemProps extends Omit<
  * </XDSHStack>
  * ```
  */
-export const XDSStackItem = forwardRef<HTMLElement, XDSStackItemProps>(
-  function XDSStackItem(
-    {crossAlignSelf, size, element = 'div', xstyle, children, ...props},
-    ref,
-  ) {
-    const stylexProps = stylex.props(
-      ...stackItem({crossAlignSelf, size}),
-      xstyle,
-    );
+export function XDSStackItem({
+  ref,
+  crossAlignSelf,
+  size,
+  element = 'div',
+  xstyle,
+  children,
+  ...props
+}: XDSStackItemProps) {
+  const stylexProps = stylex.props(
+    ...stackItem({crossAlignSelf, size}),
+    xstyle,
+  );
 
-    return createElement(
-      element,
-      {
-        ref: ref as Ref<Element>,
-        ...stylexProps,
-        ...props,
-      },
-      children,
-    );
-  },
-);
+  return createElement(
+    element,
+    {
+      ref: ref as Ref<Element>,
+      ...stylexProps,
+      ...props,
+    },
+    children,
+  );
+}
 
 XDSStackItem.displayName = 'XDSStackItem';

--- a/packages/core/src/Stack/XDSVStack.tsx
+++ b/packages/core/src/Stack/XDSVStack.tsx
@@ -10,7 +10,7 @@
  * - /apps/storybook/stories/VStack.stories.tsx
  */
 
-import {forwardRef} from 'react';
+import {type Ref} from 'react';
 import {XDSStack, type XDSStackProps} from './XDSStack';
 import type {StackCrossAlignment, StackMainAlignment} from './stack.stylex';
 
@@ -18,6 +18,8 @@ export interface XDSVStackProps extends Omit<
   XDSStackProps,
   'direction' | 'hAlign' | 'vAlign'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Horizontal alignment of items (cross-axis for vertical stack).
    * @default 'stretch'
@@ -50,10 +52,8 @@ export interface XDSVStackProps extends Omit<
  * <XDSStack direction="vertical" gap="space2">...</XDSStack>
  * ```
  */
-export const XDSVStack = forwardRef<HTMLElement, XDSVStackProps>(
-  function XDSVStack(props, ref) {
-    return <XDSStack {...props} direction="vertical" ref={ref} />;
-  },
-);
+export function XDSVStack({ref, ...props}: XDSStackProps) {
+  return <XDSStack {...props} direction="vertical" ref={ref} />;
+}
 
 XDSVStack.displayName = 'XDSVStack';

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSStatusDot.tsx
- * @input Uses React forwardRef
+ * @input Uses React
  * @output Exports XDSStatusDot component, XDSStatusDotProps, XDSStatusDotVariant, XDSStatusDotSize types
  * @position Core implementation; consumed by index.ts
  *
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/StatusDot.stories.tsx (storybook stories)
  */
 
-import {forwardRef} from 'react';
+import {type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
@@ -93,6 +93,8 @@ export type XDSStatusDotVariant = keyof typeof variants;
 export type XDSStatusDotSize = 'sm' | 'md';
 
 export interface XDSStatusDotProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLSpanElement>;
   /**
    * The semantic color variant.
    */
@@ -135,25 +137,31 @@ export interface XDSStatusDotProps {
  * <XDSStatusDot variant="positive" label="Live" isPulsing />
  * ```
  */
-export const XDSStatusDot = forwardRef<HTMLSpanElement, XDSStatusDotProps>(
-  ({variant, size = 'md', label, isPulsing = false, xstyle, ...props}, ref) => {
-    return (
-      <span
-        ref={ref}
-        role="img"
-        aria-label={label}
-        {...stylex.props(
-          styles.base,
-          sizes[size],
-          variants[variant],
-          isPulsing && styles.pulsing,
-          isPulsing && styles.reducedMotion,
-          xstyle,
-        )}
-        {...props}
-      />
-    );
-  },
-);
+export function XDSStatusDot({
+  ref,
+  variant,
+  size = 'md',
+  label,
+  isPulsing = false,
+  xstyle,
+  ...props
+}: XDSStatusDotProps) {
+  return (
+    <span
+      ref={ref}
+      role="img"
+      aria-label={label}
+      {...stylex.props(
+        styles.base,
+        sizes[size],
+        variants[variant],
+        isPulsing && styles.pulsing,
+        isPulsing && styles.reducedMotion,
+        xstyle,
+      )}
+      {...props}
+    />
+  );
+}
 
 XDSStatusDot.displayName = 'XDSStatusDot';

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSSwitch.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, XDSFieldLabel, XDSFieldStatus, XDSIconType, XDSInputStatus
+ * @input Uses React useId, ChangeEvent, XDSFieldLabel, XDSFieldStatus, XDSIconType, XDSInputStatus
  * @output Exports XDSSwitch component, XDSSwitchProps, XDSSwitchLabelPosition, XDSSwitchLabelSpacing
  * @position Core implementation; consumed by index.ts, tested by XDSSwitch.test.tsx
  *
@@ -12,13 +12,13 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useId,
   useOptimistic,
   useTransition,
   type ChangeEvent,
   type FocusEvent,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -170,6 +170,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSSwitchProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLInputElement>;
   /**
    * Label text for the switch (always rendered for accessibility).
    */
@@ -273,158 +275,154 @@ export interface XDSSwitchProps {
  * />
  * ```
  */
-export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
-  (
-    {
-      label,
-      isLabelHidden = false,
-      description,
-      onChange,
-      onChangeAction,
-      isLoading = false,
-      value,
-      isDisabled = false,
-      isOptional = false,
-      isRequired = false,
-      onFocus,
-      onBlur,
-      labelIcon,
-      labelTooltip,
-      labelPosition = 'end',
-      labelSpacing = 'default',
-      status,
-    },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.switch?.root;
-    const trackOverride = themeContext?.theme.components?.switch?.track;
-    const thumbOverride = themeContext?.theme.components?.switch?.thumb;
+export function XDSSwitch({
+  ref,
+  label,
+  isLabelHidden = false,
+  description,
+  onChange,
+  onChangeAction,
+  isLoading = false,
+  value,
+  isDisabled = false,
+  isOptional = false,
+  isRequired = false,
+  onFocus,
+  onBlur,
+  labelIcon,
+  labelTooltip,
+  labelPosition = 'end',
+  labelSpacing = 'default',
+  status,
+}: XDSSwitchProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.switch?.root;
+  const trackOverride = themeContext?.theme.components?.switch?.track;
+  const thumbOverride = themeContext?.theme.components?.switch?.thumb;
 
-    const id = useId();
-    const descriptionID = useId();
-    const statusMessageID = useId();
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
 
-    const [, startTransition] = useTransition();
-    const [optimisticValue, setOptimisticValue] = useOptimistic(value);
-    const isBusy = isLoading || optimisticValue !== value;
+  const [, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  const isBusy = isLoading || optimisticValue !== value;
 
-    const isOn = optimisticValue === true;
+  const isOn = optimisticValue === true;
 
-    // Build aria-describedby from description and status message
-    const describedByParts: string[] = [];
-    if (description) describedByParts.push(descriptionID);
-    if (status?.message) describedByParts.push(statusMessageID);
-    const ariaDescribedBy =
-      describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
+  // Build aria-describedby from description and status message
+  const describedByParts: string[] = [];
+  if (description) describedByParts.push(descriptionID);
+  if (status?.message) describedByParts.push(statusMessageID);
+  const ariaDescribedBy =
+    describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
 
-    const switchElement = (
-      <div {...stylex.props(styles.switchWrapper)}>
-        <input
-          ref={ref}
-          id={id}
-          type="checkbox"
-          role="switch"
-          checked={isOn}
-          disabled={isDisabled}
-          required={isRequired}
-          onChange={e => {
-            const checked = e.target.checked;
-            onChange?.(checked, e);
-            if (onChangeAction && !e.defaultPrevented) {
-              startTransition(async () => {
-                setOptimisticValue(checked);
-                await onChangeAction(checked, e);
-              });
-            }
-          }}
-          onFocus={onFocus}
-          onBlur={onBlur}
-          aria-describedby={ariaDescribedBy}
-          aria-invalid={status?.type === 'error' ? true : undefined}
-          aria-busy={isBusy || undefined}
-          {...stylex.props(styles.input, isDisabled && styles.inputDisabled)}
-        />
-        <div
-          aria-hidden="true"
-          {...stylex.props(
-            styles.track,
-            isOn ? styles.trackOn : styles.trackOff,
-            isDisabled && styles.trackDisabled,
-            isDisabled && !isOn && styles.trackDisabledOff,
-            trackOverride,
-          )}>
-          <div
-            {...stylex.props(
-              styles.thumb,
-              isOn ? styles.thumbOn : styles.thumbOff,
-              thumbOverride,
-            )}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}>
-            {isBusy && <XDSSpinner size="sm" />}
-          </div>
-        </div>
-      </div>
-    );
-
-    const labelElement = (
-      <div {...stylex.props(styles.labelWrapper)}>
-        <XDSFieldLabel
-          label={label}
-          inputID={id}
-          isLabelHidden={isLabelHidden}
-          isDisabled={isDisabled}
-          isOptional={isOptional}
-          isRequired={isRequired}
-          labelIcon={labelIcon}
-          labelTooltip={labelTooltip}
-        />
-        {description && !isLabelHidden && (
-          <span id={descriptionID} {...stylex.props(styles.description)}>
-            {description}
-          </span>
-        )}
-      </div>
-    );
-
-    return (
-      <div>
+  const switchElement = (
+    <div {...stylex.props(styles.switchWrapper)}>
+      <input
+        ref={ref}
+        id={id}
+        type="checkbox"
+        role="switch"
+        checked={isOn}
+        disabled={isDisabled}
+        required={isRequired}
+        onChange={e => {
+          const checked = e.target.checked;
+          onChange?.(checked, e);
+          if (onChangeAction && !e.defaultPrevented) {
+            startTransition(async () => {
+              setOptimisticValue(checked);
+              await onChangeAction(checked, e);
+            });
+          }
+        }}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        aria-describedby={ariaDescribedBy}
+        aria-invalid={status?.type === 'error' ? true : undefined}
+        aria-busy={isBusy || undefined}
+        {...stylex.props(styles.input, isDisabled && styles.inputDisabled)}
+      />
+      <div
+        aria-hidden="true"
+        {...stylex.props(
+          styles.track,
+          isOn ? styles.trackOn : styles.trackOff,
+          isDisabled && styles.trackDisabled,
+          isDisabled && !isOn && styles.trackDisabledOff,
+          trackOverride,
+        )}>
         <div
           {...stylex.props(
-            styles.container,
-            labelSpacing === 'spread' && styles.containerSpread,
-            rootOverride,
-            !isDisabled && stylex.defaultMarker(),
-          )}>
-          {labelPosition === 'start' ? (
-            <>
-              {labelElement}
-              {switchElement}
-            </>
-          ) : (
-            <>
-              {switchElement}
-              {labelElement}
-            </>
+            styles.thumb,
+            isOn ? styles.thumbOn : styles.thumbOff,
+            thumbOverride,
           )}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+          {isBusy && <XDSSpinner size="sm" />}
         </div>
-        {status?.message && (
-          <div {...stylex.props(styles.statusGap)}>
-            <XDSFieldStatus
-              type={status.type}
-              message={status.message}
-              id={statusMessageID}
-              variant="detached"
-            />
-          </div>
+      </div>
+    </div>
+  );
+
+  const labelElement = (
+    <div {...stylex.props(styles.labelWrapper)}>
+      <XDSFieldLabel
+        label={label}
+        inputID={id}
+        isLabelHidden={isLabelHidden}
+        isDisabled={isDisabled}
+        isOptional={isOptional}
+        isRequired={isRequired}
+        labelIcon={labelIcon}
+        labelTooltip={labelTooltip}
+      />
+      {description && !isLabelHidden && (
+        <span id={descriptionID} {...stylex.props(styles.description)}>
+          {description}
+        </span>
+      )}
+    </div>
+  );
+
+  return (
+    <div>
+      <div
+        {...stylex.props(
+          styles.container,
+          labelSpacing === 'spread' && styles.containerSpread,
+          rootOverride,
+          !isDisabled && stylex.defaultMarker(),
+        )}>
+        {labelPosition === 'start' ? (
+          <>
+            {labelElement}
+            {switchElement}
+          </>
+        ) : (
+          <>
+            {switchElement}
+            {labelElement}
+          </>
         )}
       </div>
-    );
-  },
-);
+      {status?.message && (
+        <div {...stylex.props(styles.statusGap)}>
+          <XDSFieldStatus
+            type={status.type}
+            message={status.message}
+            id={statusMessageID}
+            variant="detached"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
 
 XDSSwitch.displayName = 'XDSSwitch';

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -10,13 +10,7 @@
  * - /packages/core/src/Table/index.ts (exports if types change)
  */
 
-import {
-  forwardRef,
-  memo,
-  type ReactElement,
-  type ReactNode,
-  type Ref,
-} from 'react';
+import {memo, type ReactElement, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {
   XDSBaseTableProps,
@@ -182,18 +176,16 @@ const MemoizedTableRow = memo(TableRowInner, areRowPropsEqual) as <
 /**
  * Inner XDSBaseTable implementation (generic-preserving).
  */
-function XDSBaseTableInner<T extends Record<string, unknown>>(
-  {
-    data,
-    columns: columnsProp,
-    idKey,
-    plugins: pluginsProp,
-    components,
-    children,
-    tableProps: userTableProps,
-  }: XDSBaseTableProps<T>,
-  ref: Ref<HTMLTableElement>,
-): ReactElement {
+export function XDSBaseTable<T extends Record<string, unknown>>({
+  data,
+  columns: columnsProp,
+  idKey,
+  plugins: pluginsProp,
+  components,
+  children,
+  tableProps: userTableProps,
+  ref,
+}: XDSBaseTableProps<T> & {ref?: Ref<HTMLTableElement>}): ReactElement {
   // Use stable empty array when no plugins provided
   const plugins = pluginsProp ?? (EMPTY_PLUGINS as TablePlugin<T>[]);
 
@@ -319,11 +311,4 @@ function XDSBaseTableInner<T extends Record<string, unknown>>(
  * />
  * ```
  */
-export const XDSBaseTable = forwardRef(XDSBaseTableInner) as <
-  T extends Record<string, unknown>,
->(
-  props: XDSBaseTableProps<T> & {ref?: Ref<HTMLTableElement>},
-) => ReactElement;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(XDSBaseTable as any).displayName = 'XDSBaseTable';
+XDSBaseTable.displayName = 'XDSBaseTable';

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -11,13 +11,7 @@
  * - /apps/storybook/stories/Table.stories.tsx (storybook stories)
  */
 
-import {
-  forwardRef,
-  useContext,
-  useMemo,
-  type ReactElement,
-  type Ref,
-} from 'react';
+import {useContext, useMemo, type ReactElement, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {XDSBaseTable} from './XDSBaseTable';
@@ -126,19 +120,17 @@ const xdsComponents = {
 // XDSTable Component
 // =============================================================================
 
-function XDSTableInner<T extends Record<string, unknown>>(
-  {
-    density = 'balanced',
-    dividers = 'rows',
-    isStriped = false,
-    hasHover = false,
-    plugins: userPlugins,
-    columns,
-    data,
-    ...rest
-  }: XDSTableProps<T>,
-  ref: Ref<HTMLTableElement>,
-): ReactElement {
+export function XDSTable<T extends Record<string, unknown>>({
+  density = 'balanced',
+  dividers = 'rows',
+  isStriped = false,
+  hasHover = false,
+  plugins: userPlugins,
+  columns,
+  data,
+  ref,
+  ...rest
+}: XDSTableProps<T> & {ref?: Ref<HTMLTableElement>}): ReactElement {
   // Get theme context for component-level overrides
   const themeContext = useContext(ThemeContext);
   const rootOverride = themeContext?.theme.components?.table?.root;
@@ -208,11 +200,4 @@ function XDSTableInner<T extends Record<string, unknown>>(
  * />
  * ```
  */
-export const XDSTable = forwardRef(XDSTableInner) as <
-  T extends Record<string, unknown>,
->(
-  props: XDSTableProps<T> & {ref?: Ref<HTMLTableElement>},
-) => ReactElement;
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-(XDSTable as any).displayName = 'XDSTable';
+XDSTable.displayName = 'XDSTable';

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -10,10 +10,10 @@
  */
 
 import {
-  forwardRef,
   useContext,
   type TdHTMLAttributes,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, textSizeVars} from '../theme/tokens.stylex';
@@ -25,6 +25,8 @@ export interface XDSTableCellProps extends Omit<
   TdHTMLAttributes<HTMLTableCellElement>,
   'className' | 'style'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLTableCellElement>;
   children?: ReactNode;
   xstyle?: StyleXStyles | StyleXStyles[];
 }
@@ -83,42 +85,45 @@ const dividerColumnStyles = stylex.create({
  * </XDSTableRow>
  * ```
  */
-export const XDSTableCell = forwardRef<HTMLTableCellElement, XDSTableCellProps>(
-  ({children, xstyle, ...props}, ref) => {
-    const ctx = useContext(XDSTableContext);
+export function XDSTableCell({
+  ref,
+  children,
+  xstyle,
+  ...props
+}: XDSTableCellProps) {
+  const ctx = useContext(XDSTableContext);
 
-    if (!ctx) {
-      return (
-        <td ref={ref} {...props} {...stylex.props(xstyle)}>
-          {children}
-        </td>
-      );
-    }
-
-    const cellStyles: StyleXStyles[] = [densityStyles[ctx.density]];
-
-    if (ctx.dividers === 'rows' || ctx.dividers === 'grid') {
-      cellStyles.push(dividerRowStyles.cell);
-    }
-
-    if (ctx.dividers === 'columns' || ctx.dividers === 'grid') {
-      cellStyles.push(dividerColumnStyles.cell);
-    }
-
-    if (xstyle) {
-      if (Array.isArray(xstyle)) {
-        cellStyles.push(...xstyle);
-      } else {
-        cellStyles.push(xstyle);
-      }
-    }
-
+  if (!ctx) {
     return (
-      <td ref={ref} {...props} {...stylex.props(...cellStyles)}>
+      <td ref={ref} {...props} {...stylex.props(xstyle)}>
         {children}
       </td>
     );
-  },
-);
+  }
+
+  const cellStyles: StyleXStyles[] = [densityStyles[ctx.density]];
+
+  if (ctx.dividers === 'rows' || ctx.dividers === 'grid') {
+    cellStyles.push(dividerRowStyles.cell);
+  }
+
+  if (ctx.dividers === 'columns' || ctx.dividers === 'grid') {
+    cellStyles.push(dividerColumnStyles.cell);
+  }
+
+  if (xstyle) {
+    if (Array.isArray(xstyle)) {
+      cellStyles.push(...xstyle);
+    } else {
+      cellStyles.push(xstyle);
+    }
+  }
+
+  return (
+    <td ref={ref} {...props} {...stylex.props(...cellStyles)}>
+      {children}
+    </td>
+  );
+}
 
 XDSTableCell.displayName = 'XDSTableCell';

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -10,10 +10,10 @@
  */
 
 import {
-  forwardRef,
   useContext,
   type ThHTMLAttributes,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -27,6 +27,8 @@ import {XDSTableContext} from './XDSTableContext';
 
 /** Props for XDSTableHeaderCell — `<th>` wrapper with context-aware styling */
 export interface XDSTableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLTableCellElement>;
   children?: ReactNode;
   xstyle?: StyleXStyles | StyleXStyles[];
 }
@@ -98,10 +100,12 @@ const dividerColumnStyles = stylex.create({
  * </thead>
  * ```
  */
-export const XDSTableHeaderCell = forwardRef<
-  HTMLTableCellElement,
-  XDSTableHeaderCellProps
->(({children, xstyle, ...props}, ref) => {
+export function XDSTableHeaderCell({
+  ref,
+  children,
+  xstyle,
+  ...props
+}: XDSTableHeaderCellProps) {
   const ctx = useContext(XDSTableContext);
 
   if (!ctx) {
@@ -135,6 +139,6 @@ export const XDSTableHeaderCell = forwardRef<
       {children}
     </th>
   );
-});
+}
 
 XDSTableHeaderCell.displayName = 'XDSTableHeaderCell';

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -9,12 +9,7 @@
  * - /packages/core/src/Table/index.ts
  */
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, transitionVars} from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
@@ -25,6 +20,8 @@ export interface XDSTableRowProps extends Omit<
   HTMLAttributes<HTMLTableRowElement>,
   'className' | 'style'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLTableRowElement>;
   children: ReactNode;
   xstyle?: StyleXStyles[];
 }
@@ -90,44 +87,47 @@ const _lastBodyRowStyles = stylex.create({
  * </XDSTable>
  * ```
  */
-export const XDSTableRow = forwardRef<HTMLTableRowElement, XDSTableRowProps>(
-  ({children, xstyle, ...props}, ref) => {
-    const ctx = useContext(XDSTableContext);
+export function XDSTableRow({
+  ref,
+  children,
+  xstyle,
+  ...props
+}: XDSTableRowProps) {
+  const ctx = useContext(XDSTableContext);
 
-    if (!ctx) {
-      return (
-        <tr ref={ref} {...props} {...stylex.props(xstyle)}>
-          {children}
-        </tr>
-      );
-    }
-
-    const rowStyles: StyleXStyles[] = [];
-
-    // Handle striped + hover combination to avoid backgroundColor conflicts
-    if (ctx.isStriped && ctx.hasHover) {
-      rowStyles.push(stripedHoverRowStyles.row);
-    } else if (ctx.isStriped) {
-      rowStyles.push(stripedRowStyles.row);
-    } else if (ctx.hasHover) {
-      rowStyles.push(hoverRowStyles.row);
-    }
-
-    if (ctx.dividers === 'rows' || ctx.dividers === 'grid') {
-      // Note: last-body-row border removal is handled by XDSTableCell
-      // to avoid affecting the header row in <thead>.
-    }
-
-    if (xstyle) {
-      rowStyles.push(...xstyle);
-    }
-
+  if (!ctx) {
     return (
-      <tr ref={ref} {...props} {...stylex.props(...rowStyles)}>
+      <tr ref={ref} {...props} {...stylex.props(xstyle)}>
         {children}
       </tr>
     );
-  },
-);
+  }
+
+  const rowStyles: StyleXStyles[] = [];
+
+  // Handle striped + hover combination to avoid backgroundColor conflicts
+  if (ctx.isStriped && ctx.hasHover) {
+    rowStyles.push(stripedHoverRowStyles.row);
+  } else if (ctx.isStriped) {
+    rowStyles.push(stripedRowStyles.row);
+  } else if (ctx.hasHover) {
+    rowStyles.push(hoverRowStyles.row);
+  }
+
+  if (ctx.dividers === 'rows' || ctx.dividers === 'grid') {
+    // Note: last-body-row border removal is handled by XDSTableCell
+    // to avoid affecting the header row in <thead>.
+  }
+
+  if (xstyle) {
+    rowStyles.push(...xstyle);
+  }
+
+  return (
+    <tr ref={ref} {...props} {...stylex.props(...rowStyles)}>
+      {children}
+    </tr>
+  );
+}
 
 XDSTableRow.displayName = 'XDSTableRow';

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSHeading.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode
+ * @input Uses React HTMLAttributes, ReactNode
  * @output Exports XDSHeading component, XDSHeadingProps, XDSHeadingLevel, XDSHeadingVariant types
  * @position Core implementation; consumed by index.ts, tested by XDSHeading.test.tsx
  *
@@ -12,13 +12,13 @@
  */
 
 import {
-  forwardRef,
   lazy,
   Suspense,
   useCallback,
   useContext,
   useRef,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -58,6 +58,8 @@ export type XDSHeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
 export type XDSHeadingVariant = 'default' | 'editorial';
 
 export interface XDSHeadingProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLHeadingElement>;
   /**
    * Visual heading level (1-6). Determines styling from theme.
    * Required to ensure intentional visual hierarchy.
@@ -191,130 +193,126 @@ const levelToKey: Record<XDSHeadingLevel, HeadingLevel> = {
  * <XDSHeading level={3} color="secondary">Muted Heading</XDSHeading>
  * ```
  */
-export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
-  function XDSHeading(
-    {
-      level,
-      accessibilityLevel,
-      variant = 'default',
-      color = 'primary',
-      display = 'block',
-      maxLines = 0,
-      hasTruncateTooltip = true,
-      wordBreak,
-      textWrap,
-      hasCapsize = false,
-      hasStrikethrough = false,
-      xstyle,
-      children,
-      ...props
+export function XDSHeading({
+  ref,
+  level,
+  accessibilityLevel,
+  variant = 'default',
+  color = 'primary',
+  display = 'block',
+  maxLines = 0,
+  hasTruncateTooltip = true,
+  wordBreak,
+  textWrap,
+  hasCapsize = false,
+  hasStrikethrough = false,
+  xstyle,
+  children,
+  ...props
+}: XDSHeadingProps) {
+  const themeContext = useContext(ThemeContext);
+  const Component = levelToTag[level];
+  const levelKey = levelToKey[level];
+
+  const headingConfig = themeContext?.theme?.components?.heading;
+  const headingStyles =
+    variant === 'editorial'
+      ? headingConfig?.editorialStyles
+      : headingConfig?.styles;
+  const levelStyle = headingStyles?.[levelKey];
+
+  // If accessibilityLevel differs from visual level, use aria-level
+  const ariaProps =
+    accessibilityLevel && accessibilityLevel !== level
+      ? {'aria-level': accessibilityLevel}
+      : {};
+
+  // Resolve wordBreak with smart default
+  const resolvedWordBreak =
+    wordBreak ?? (maxLines === 1 ? 'break-all' : 'break-word');
+
+  // Resolve display - force block when maxLines > 0 or hasCapsize
+  const resolvedDisplay = maxLines > 0 || hasCapsize ? 'block' : display;
+
+  // Truncation detection
+  const truncation = useTruncation({maxLines});
+
+  // Tooltip for truncated text
+  const tooltipPlacement: LayerPlacement =
+    typeof hasTruncateTooltip === 'string' ? hasTruncateTooltip : 'above';
+  const tooltipEnabled =
+    maxLines > 0 && hasTruncateTooltip !== false && truncation.isTruncated;
+
+  // Ref for the heading element (used as tooltip anchor)
+  const headingRef = useRef<HTMLHeadingElement>(null);
+
+  // Merge refs: ref, truncation.ref, headingRef
+  const mergedRef = useCallback(
+    (element: HTMLHeadingElement | null) => {
+      // Forward ref
+      if (typeof ref === 'function') {
+        ref(element);
+      } else if (ref) {
+        ref.current = element;
+      }
+      // Truncation ref
+      truncation.ref(element);
+      // Local ref for tooltip anchor
+      (
+        headingRef as React.MutableRefObject<HTMLHeadingElement | null>
+      ).current = element;
     },
-    forwardedRef,
-  ) {
-    const themeContext = useContext(ThemeContext);
-    const Component = levelToTag[level];
-    const levelKey = levelToKey[level];
+    [ref, truncation.ref],
+  );
 
-    const headingConfig = themeContext?.theme?.components?.heading;
-    const headingStyles =
-      variant === 'editorial'
-        ? headingConfig?.editorialStyles
-        : headingConfig?.styles;
-    const levelStyle = headingStyles?.[levelKey];
+  // Build inline style for -webkit-line-clamp (dynamic value)
+  const inlineStyle = maxLines > 1 ? {WebkitLineClamp: maxLines} : undefined;
 
-    // If accessibilityLevel differs from visual level, use aria-level
-    const ariaProps =
-      accessibilityLevel && accessibilityLevel !== level
-        ? {'aria-level': accessibilityLevel}
-        : {};
-
-    // Resolve wordBreak with smart default
-    const resolvedWordBreak =
-      wordBreak ?? (maxLines === 1 ? 'break-all' : 'break-word');
-
-    // Resolve display - force block when maxLines > 0 or hasCapsize
-    const resolvedDisplay = maxLines > 0 || hasCapsize ? 'block' : display;
-
-    // Truncation detection
-    const truncation = useTruncation({maxLines});
-
-    // Tooltip for truncated text
-    const tooltipPlacement: LayerPlacement =
-      typeof hasTruncateTooltip === 'string' ? hasTruncateTooltip : 'above';
-    const tooltipEnabled =
-      maxLines > 0 && hasTruncateTooltip !== false && truncation.isTruncated;
-
-    // Ref for the heading element (used as tooltip anchor)
-    const headingRef = useRef<HTMLHeadingElement>(null);
-
-    // Merge refs: forwardedRef, truncation.ref, headingRef
-    const mergedRef = useCallback(
-      (element: HTMLHeadingElement | null) => {
-        // Forward ref
-        if (typeof forwardedRef === 'function') {
-          forwardedRef(element);
-        } else if (forwardedRef) {
-          forwardedRef.current = element;
-        }
-        // Truncation ref
-        truncation.ref(element);
-        // Local ref for tooltip anchor
-        (
-          headingRef as React.MutableRefObject<HTMLHeadingElement | null>
-        ).current = element;
-      },
-      [forwardedRef, truncation.ref],
-    );
-
-    // Build inline style for -webkit-line-clamp (dynamic value)
-    const inlineStyle = maxLines > 1 ? {WebkitLineClamp: maxLines} : undefined;
-
-    return (
-      <>
-        <Component
-          ref={mergedRef}
-          {...stylex.props(
-            levelStyle,
-            colorStyles[color],
-            // Display: use truncation styles when maxLines > 0
-            maxLines === 1
-              ? truncationStyles.singleLine
-              : maxLines > 1
-                ? truncationStyles.multiLine
-                : displayStyles[resolvedDisplay],
-            // Word break when truncating
-            maxLines > 0 && wordBreakStyles[resolvedWordBreak],
-            // Text wrap
-            textWrap && textWrapStyles[textWrap],
-            // Capsize
-            hasCapsize && capsizeStyles.enabled,
-            // Decorations
-            hasStrikethrough && decorationStyles.strikethrough,
-            // User xstyle
-            xstyle,
-          )}
-          style={inlineStyle}
-          title={tooltipEnabled ? truncation.fullText : undefined}
-          {...ariaProps}
-          {...props}>
-          {children}
-        </Component>
-        {tooltipEnabled && (
-          <Suspense fallback={null}>
-            <LazyXDSTooltip
-              anchorRef={headingRef}
-              content={
-                <span {...stylex.props(truncationTooltipStyles.content)}>
-                  {truncation.fullText}
-                </span>
-              }
-              placement={tooltipPlacement}
-            />
-          </Suspense>
+  return (
+    <>
+      <Component
+        ref={mergedRef}
+        {...stylex.props(
+          levelStyle,
+          colorStyles[color],
+          // Display: use truncation styles when maxLines > 0
+          maxLines === 1
+            ? truncationStyles.singleLine
+            : maxLines > 1
+              ? truncationStyles.multiLine
+              : displayStyles[resolvedDisplay],
+          // Word break when truncating
+          maxLines > 0 && wordBreakStyles[resolvedWordBreak],
+          // Text wrap
+          textWrap && textWrapStyles[textWrap],
+          // Capsize
+          hasCapsize && capsizeStyles.enabled,
+          // Decorations
+          hasStrikethrough && decorationStyles.strikethrough,
+          // User xstyle
+          xstyle,
         )}
-      </>
-    );
-  },
-);
+        style={inlineStyle}
+        title={tooltipEnabled ? truncation.fullText : undefined}
+        {...ariaProps}
+        {...props}>
+        {children}
+      </Component>
+      {tooltipEnabled && (
+        <Suspense fallback={null}>
+          <LazyXDSTooltip
+            anchorRef={headingRef}
+            content={
+              <span {...stylex.props(truncationTooltipStyles.content)}>
+                {truncation.fullText}
+              </span>
+            }
+            placement={tooltipPlacement}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}
 
 XDSHeading.displayName = 'XDSHeading';

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSText.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode
+ * @input Uses React HTMLAttributes, ReactNode
  * @output Exports XDSText component, XDSTextProps, XDSTextType, XDSTextSize types
  * @position Core implementation; consumed by index.ts, tested by XDSText.test.tsx
  *
@@ -12,13 +12,13 @@
  */
 
 import {
-  forwardRef,
   lazy,
   Suspense,
   useCallback,
   useContext,
   useRef,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -54,6 +54,8 @@ const LazyXDSTooltip = lazy(() =>
 export type {XDSTextType, XDSTextSize};
 
 export interface XDSTextProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Semantic text type. Determines size, weight, and line-height from theme.
    * Required to ensure semantic usage.
@@ -179,27 +181,25 @@ const defaultColorByType: Record<XDSTextType, XDSTextColor> = {
  * <XDSText type="body" color="secondary" weight="bold">Styled text</XDSText>
  * ```
  */
-export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
-  {
-    type,
-    size: _size,
-    color,
-    weight,
-    display = 'inline',
-    maxLines = 0,
-    hasTruncateTooltip = true,
-    wordBreak,
-    textWrap,
-    hasCapsize = false,
-    hasStrikethrough = false,
-    hasTabularNumbers = false,
-    xstyle,
-    as: Component = 'span',
-    children,
-    ...props
-  },
-  forwardedRef,
-) {
+export function XDSText({
+  ref,
+  type,
+  size: _size,
+  color,
+  weight,
+  display = 'inline',
+  maxLines = 0,
+  hasTruncateTooltip = true,
+  wordBreak,
+  textWrap,
+  hasCapsize = false,
+  hasStrikethrough = false,
+  hasTabularNumbers = false,
+  xstyle,
+  as: Component = 'span',
+  children,
+  ...props
+}: XDSTextProps) {
   const themeContext = useContext(ThemeContext);
   const textStyles = themeContext?.theme?.components?.text?.styles;
   const typeStyle = textStyles?.[type];
@@ -226,21 +226,21 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
   // Ref for the text element (used as tooltip anchor)
   const textRef = useRef<HTMLElement>(null);
 
-  // Merge refs: forwardedRef, truncation.ref, textRef
+  // Merge refs: ref, truncation.ref, textRef
   const mergedRef = useCallback(
     (element: HTMLElement | null) => {
       // Forward ref
-      if (typeof forwardedRef === 'function') {
-        forwardedRef(element);
-      } else if (forwardedRef) {
-        forwardedRef.current = element;
+      if (typeof ref === 'function') {
+        ref(element);
+      } else if (ref) {
+        ref.current = element;
       }
       // Truncation ref
       truncation.ref(element);
       // Local ref for tooltip anchor
       (textRef as React.MutableRefObject<HTMLElement | null>).current = element;
     },
-    [forwardedRef, truncation.ref],
+    [ref, truncation.ref],
   );
 
   // Build inline style for -webkit-line-clamp (dynamic value)
@@ -292,6 +292,6 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
       )}
     </>
   );
-});
+}
 
 XDSText.displayName = 'XDSText';

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSTextArea.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, ClipboardEvent, XDSField, XDSIcon
+ * @input Uses React useId, ChangeEvent, ClipboardEvent, XDSField, XDSIcon
  * @output Exports XDSTextArea component, XDSTextAreaProps, XDSTextAreaStatus, XDSTextAreaStatusType
  * @position Core implementation; consumed by index.ts, tested by XDSTextArea.test.tsx
  *
@@ -12,13 +12,13 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useId,
   useOptimistic,
   useTransition,
   type ChangeEvent,
   type ClipboardEvent,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSIconName} from '../Icon';
@@ -201,6 +201,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSTextAreaProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLTextAreaElement>;
   /**
    * Label text for the textarea (always rendered for accessibility).
    */
@@ -303,151 +305,147 @@ export interface XDSTextAreaProps {
  * <XDSTextArea label="Notes" rows={5} value={notes} onChange={setNotes} />
  * ```
  */
-export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
-  (
-    {
-      label,
-      isLabelHidden = false,
-      description,
-      isOptional = false,
-      isRequired = false,
-      onChange,
-      onChangeAction,
-      isLoading = false,
-      value,
-      placeholder,
-      rows = 3,
-      isDisabled = false,
-      status,
-      labelTooltip,
-      startIcon,
-      hasSpellCheck = true,
-      onPaste,
-      maxLength,
-      hasAutoFocus = false,
-      htmlName,
-    },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const wrapperOverride = themeContext?.theme.components?.textArea?.wrapper;
-    const textareaOverride = themeContext?.theme.components?.textArea?.textarea;
+export function XDSTextArea({
+  ref,
+  label,
+  isLabelHidden = false,
+  description,
+  isOptional = false,
+  isRequired = false,
+  onChange,
+  onChangeAction,
+  isLoading = false,
+  value,
+  placeholder,
+  rows = 3,
+  isDisabled = false,
+  status,
+  labelTooltip,
+  startIcon,
+  hasSpellCheck = true,
+  onPaste,
+  maxLength,
+  hasAutoFocus = false,
+  htmlName,
+}: XDSTextAreaProps) {
+  const themeContext = useContext(ThemeContext);
+  const wrapperOverride = themeContext?.theme.components?.textArea?.wrapper;
+  const textareaOverride = themeContext?.theme.components?.textArea?.textarea;
 
-    const id = useId();
-    const descriptionID = useId();
-    const statusMessageID = useId();
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
 
-    const [, startTransition] = useTransition();
-    const [optimisticValue, setOptimisticValue] = useOptimistic(value);
-    const isBusy = isLoading || optimisticValue !== value;
+  const [, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  const isBusy = isLoading || optimisticValue !== value;
 
-    const statusIconMap: Record<XDSTextAreaStatusType, XDSIconName> = {
-      warning: 'warning',
-      error: 'xCircle',
-      success: 'checkCircle',
-    };
+  const statusIconMap: Record<XDSTextAreaStatusType, XDSIconName> = {
+    warning: 'warning',
+    error: 'xCircle',
+    success: 'checkCircle',
+  };
 
-    const statusIconColorMap: Record<
-      XDSTextAreaStatusType,
-      'warning' | 'negative' | 'positive'
-    > = {
-      warning: 'warning',
-      error: 'negative',
-      success: 'positive',
-    };
+  const statusIconColorMap: Record<
+    XDSTextAreaStatusType,
+    'warning' | 'negative' | 'positive'
+  > = {
+    warning: 'warning',
+    error: 'negative',
+    success: 'positive',
+  };
 
-    const ariaDescribedBy =
-      [
-        description ? descriptionID : null,
-        status?.message ? statusMessageID : null,
-      ]
-        .filter(Boolean)
-        .join(' ') || undefined;
+  const ariaDescribedBy =
+    [
+      description ? descriptionID : null,
+      status?.message ? statusMessageID : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
-    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-      const newValue = e.target.value;
-      onChange?.(newValue, e);
-      if (onChangeAction && !e.defaultPrevented) {
-        startTransition(async () => {
-          setOptimisticValue(newValue);
-          await onChangeAction(newValue, e);
-        });
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    onChange?.(newValue, e);
+    if (onChangeAction && !e.defaultPrevented) {
+      startTransition(async () => {
+        setOptimisticValue(newValue);
+        await onChangeAction(newValue, e);
+      });
+    }
+  };
+
+  return (
+    <XDSField
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={id}
+      descriptionID={description ? descriptionID : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageID : undefined,
+            }
+          : undefined
       }
-    };
-
-    return (
-      <XDSField
-        label={label}
-        isLabelHidden={isLabelHidden}
-        description={description}
-        inputID={id}
-        descriptionID={description ? descriptionID : undefined}
-        isOptional={isOptional}
-        isRequired={isRequired}
-        status={
-          status
-            ? {
-                type: status.type,
-                message: status.message,
-                messageID: status.message ? statusMessageID : undefined,
-              }
-            : undefined
-        }
-        labelTooltip={labelTooltip}>
+      labelTooltip={labelTooltip}>
+      <div
+        {...stylex.props(
+          styles.wrapper,
+          isDisabled && styles.wrapperDisabled,
+          status && statusBorderStyles[status.type],
+          status && statusHoverShadowStyles[status.type],
+          status && statusFocusStyles[status.type],
+          wrapperOverride,
+        )}>
+        {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
+        <textarea
+          ref={ref}
+          id={id}
+          name={htmlName}
+          value={String(optimisticValue)}
+          onChange={handleChange}
+          onPaste={onPaste}
+          placeholder={placeholder}
+          rows={rows}
+          disabled={isDisabled}
+          spellCheck={hasSpellCheck}
+          maxLength={maxLength}
+          autoFocus={hasAutoFocus}
+          aria-describedby={ariaDescribedBy}
+          aria-required={isRequired === true ? 'true' : undefined}
+          aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          aria-busy={isBusy || undefined}
+          {...stylex.props(
+            styles.textarea,
+            isDisabled && styles.textareaDisabled,
+            textareaOverride,
+          )}
+        />
+        {isBusy && <XDSSpinner size="sm" />}
+        {status && (
+          <XDSIcon
+            icon={statusIconMap[status.type]}
+            size="md"
+            color={statusIconColorMap[status.type]}
+          />
+        )}
+      </div>
+      {maxLength != null && (
         <div
           {...stylex.props(
-            styles.wrapper,
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
-            wrapperOverride,
+            styles.counter,
+            value.length > maxLength && styles.counterError,
           )}>
-          {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
-          <textarea
-            ref={ref}
-            id={id}
-            name={htmlName}
-            value={String(optimisticValue)}
-            onChange={handleChange}
-            onPaste={onPaste}
-            placeholder={placeholder}
-            rows={rows}
-            disabled={isDisabled}
-            spellCheck={hasSpellCheck}
-            maxLength={maxLength}
-            autoFocus={hasAutoFocus}
-            aria-describedby={ariaDescribedBy}
-            aria-required={isRequired === true ? 'true' : undefined}
-            aria-invalid={status?.type === 'error' ? 'true' : undefined}
-            aria-busy={isBusy || undefined}
-            {...stylex.props(
-              styles.textarea,
-              isDisabled && styles.textareaDisabled,
-              textareaOverride,
-            )}
-          />
-          {isBusy && <XDSSpinner size="sm" />}
-          {status && (
-            <XDSIcon
-              icon={statusIconMap[status.type]}
-              size="md"
-              color={statusIconColorMap[status.type]}
-            />
-          )}
+          {value.length}/{maxLength}
         </div>
-        {maxLength != null && (
-          <div
-            {...stylex.props(
-              styles.counter,
-              value.length > maxLength && styles.counterError,
-            )}>
-            {value.length}/{maxLength}
-          </div>
-        )}
-      </XDSField>
-    );
-  },
-);
+      )}
+    </XDSField>
+  );
+}
 
 XDSTextArea.displayName = 'XDSTextArea';

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSTextInput.tsx
- * @input Uses React forwardRef, useId, ChangeEvent, XDSField, XDSIcon
+ * @input Uses React useId, ChangeEvent, XDSField, XDSIcon
  * @output Exports XDSTextInput component, XDSTextInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSTextInput.test.tsx
  *
@@ -12,12 +12,12 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useId,
   useOptimistic,
   useTransition,
   type ChangeEvent,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSIconName} from '../Icon';
@@ -196,6 +196,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSTextInputProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLInputElement>;
   /**
    * Label text for the input (always rendered for accessibility).
    */
@@ -286,137 +288,133 @@ export interface XDSTextInputProps {
  * <XDSTextInput label="Search" isLabelHidden value={query} onChange={setQuery} />
  * ```
  */
-export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
-  (
-    {
-      label,
-      isLabelHidden = false,
-      description,
-      isOptional = false,
-      isRequired = false,
-      isDisabled = false,
-      startIcon,
-      status,
-      size = 'md',
-      onChange,
-      onChangeAction,
-      isLoading = false,
-      value,
-      placeholder,
-      labelTooltip,
-      hasAutoFocus = false,
-      htmlName,
-    },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const wrapperOverride = themeContext?.theme.components?.textInput?.wrapper;
-    const inputOverride = themeContext?.theme.components?.textInput?.input;
+export function XDSTextInput({
+  ref,
+  label,
+  isLabelHidden = false,
+  description,
+  isOptional = false,
+  isRequired = false,
+  isDisabled = false,
+  startIcon,
+  status,
+  size = 'md',
+  onChange,
+  onChangeAction,
+  isLoading = false,
+  value,
+  placeholder,
+  labelTooltip,
+  hasAutoFocus = false,
+  htmlName,
+}: XDSTextInputProps) {
+  const themeContext = useContext(ThemeContext);
+  const wrapperOverride = themeContext?.theme.components?.textInput?.wrapper;
+  const inputOverride = themeContext?.theme.components?.textInput?.input;
 
-    const id = useId();
-    const descriptionID = useId();
-    const statusMessageID = useId();
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
 
-    const [, startTransition] = useTransition();
-    const [optimisticValue, setOptimisticValue] = useOptimistic(value);
-    const isBusy = isLoading || optimisticValue !== value;
+  const [, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  const isBusy = isLoading || optimisticValue !== value;
 
-    const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
-      warning: 'warning',
-      error: 'xCircle',
-      success: 'checkCircle',
-    };
+  const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+    warning: 'warning',
+    error: 'xCircle',
+    success: 'checkCircle',
+  };
 
-    const statusIconColorMap: Record<
-      XDSInputStatusType,
-      'warning' | 'negative' | 'positive'
-    > = {
-      warning: 'warning',
-      error: 'negative',
-      success: 'positive',
-    };
+  const statusIconColorMap: Record<
+    XDSInputStatusType,
+    'warning' | 'negative' | 'positive'
+  > = {
+    warning: 'warning',
+    error: 'negative',
+    success: 'positive',
+  };
 
-    const ariaDescribedBy =
-      [
-        description ? descriptionID : null,
-        status?.message ? statusMessageID : null,
-      ]
-        .filter(Boolean)
-        .join(' ') || undefined;
+  const ariaDescribedBy =
+    [
+      description ? descriptionID : null,
+      status?.message ? statusMessageID : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-      const newValue = e.target.value;
-      onChange?.(newValue, e);
-      if (onChangeAction && !e.defaultPrevented) {
-        startTransition(async () => {
-          setOptimisticValue(newValue);
-          await onChangeAction(newValue, e);
-        });
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    onChange?.(newValue, e);
+    if (onChangeAction && !e.defaultPrevented) {
+      startTransition(async () => {
+        setOptimisticValue(newValue);
+        await onChangeAction(newValue, e);
+      });
+    }
+  };
+
+  return (
+    <XDSField
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={id}
+      descriptionID={description ? descriptionID : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageID : undefined,
+            }
+          : undefined
       }
-    };
-
-    return (
-      <XDSField
-        label={label}
-        isLabelHidden={isLabelHidden}
-        description={description}
-        inputID={id}
-        descriptionID={description ? descriptionID : undefined}
-        isOptional={isOptional}
-        isRequired={isRequired}
-        status={
-          status
-            ? {
-                type: status.type,
-                message: status.message,
-                messageID: status.message ? statusMessageID : undefined,
-              }
-            : undefined
-        }
-        labelTooltip={labelTooltip}>
-        <div
+      labelTooltip={labelTooltip}>
+      <div
+        {...stylex.props(
+          styles.wrapper,
+          sizeStyles[size],
+          isDisabled && styles.wrapperDisabled,
+          status && statusBorderStyles[status.type],
+          status && statusHoverShadowStyles[status.type],
+          status && statusFocusStyles[status.type],
+          wrapperOverride,
+        )}>
+        {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
+        <input
+          ref={ref}
+          id={id}
+          name={htmlName}
+          type="text"
+          value={String(optimisticValue)}
+          onChange={handleChange}
+          placeholder={placeholder}
+          disabled={isDisabled}
+          autoFocus={hasAutoFocus}
+          aria-describedby={ariaDescribedBy}
+          aria-required={isRequired === true ? 'true' : undefined}
+          aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          aria-busy={isBusy || undefined}
           {...stylex.props(
-            styles.wrapper,
-            sizeStyles[size],
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
-            wrapperOverride,
-          )}>
-          {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
-          <input
-            ref={ref}
-            id={id}
-            name={htmlName}
-            type="text"
-            value={String(optimisticValue)}
-            onChange={handleChange}
-            placeholder={placeholder}
-            disabled={isDisabled}
-            autoFocus={hasAutoFocus}
-            aria-describedby={ariaDescribedBy}
-            aria-required={isRequired === true ? 'true' : undefined}
-            aria-invalid={status?.type === 'error' ? 'true' : undefined}
-            aria-busy={isBusy || undefined}
-            {...stylex.props(
-              styles.input,
-              isDisabled && styles.inputDisabled,
-              inputOverride,
-            )}
-          />
-          {isBusy && <XDSSpinner size="sm" />}
-          {status && (
-            <XDSIcon
-              icon={statusIconMap[status.type]}
-              size="md"
-              color={statusIconColorMap[status.type]}
-            />
+            styles.input,
+            isDisabled && styles.inputDisabled,
+            inputOverride,
           )}
-        </div>
-      </XDSField>
-    );
-  },
-);
+        />
+        {isBusy && <XDSSpinner size="sm" />}
+        {status && (
+          <XDSIcon
+            icon={statusIconMap[status.type]}
+            size="md"
+            color={statusIconColorMap[status.type]}
+          />
+        )}
+      </div>
+    </XDSField>
+  );
+}
 
 XDSTextInput.displayName = 'XDSTextInput';

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSTimeInput.tsx
- * @input Uses React forwardRef, useId, useState, useEffect, useCallback, useRef, XDSField, XDSIcon
+ * @input Uses React useId, useState, useEffect, useCallback, useRef, XDSField, XDSIcon
  * @output Exports XDSTimeInput component, XDSTimeInputProps
  * @position Core implementation; consumed by index.ts, tested by XDSTimeInput.test.tsx
  *
@@ -12,7 +12,6 @@
  */
 
 import {
-  forwardRef,
   useContext,
   useId,
   useState,
@@ -23,6 +22,7 @@ import {
   useTransition,
   type KeyboardEvent,
   type FocusEvent,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSIconName} from '../Icon';
@@ -235,6 +235,8 @@ declare module '../theme/types' {
   }
 }
 export interface XDSTimeInputProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLInputElement>;
   /**
    * Label text for the input (required for accessibility).
    */
@@ -368,300 +370,296 @@ export interface XDSTimeInputProps {
  * />
  * ```
  */
-export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
-  (
-    {
-      label,
-      isLabelHidden = false,
-      description,
-      isOptional = false,
-      isRequired = false,
-      isDisabled = false,
-      value,
-      onChange,
-      onChangeAction,
-      isLoading = false,
-      min,
-      max,
-      hasSeconds = false,
-      hasClear = false,
-      hourFormat = '12h',
-      increment = 1,
-      placeholder = 'Select a time',
-      size = 'md',
-      status,
-      labelTooltip,
+export function XDSTimeInput({
+  ref,
+  label,
+  isLabelHidden = false,
+  description,
+  isOptional = false,
+  isRequired = false,
+  isDisabled = false,
+  value,
+  onChange,
+  onChangeAction,
+  isLoading = false,
+  min,
+  max,
+  hasSeconds = false,
+  hasClear = false,
+  hourFormat = '12h',
+  increment = 1,
+  placeholder = 'Select a time',
+  size = 'md',
+  status,
+  labelTooltip,
+}: XDSTimeInputProps) {
+  const themeContext = useContext(ThemeContext);
+  const wrapperOverride = themeContext?.theme.components?.timeInput?.wrapper;
+  const inputOverride = themeContext?.theme.components?.timeInput?.input;
+
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const [, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  const isBusy = isLoading || optimisticValue !== value;
+
+  // Status icon mapping
+  const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+    warning: 'warning',
+    error: 'xCircle',
+    success: 'checkCircle',
+  };
+
+  const statusIconColorMap: Record<
+    XDSInputStatusType,
+    'warning' | 'negative' | 'positive'
+  > = {
+    warning: 'warning',
+    error: 'negative',
+    success: 'positive',
+  };
+
+  const ariaDescribedBy =
+    [
+      description ? descriptionID : null,
+      status?.message ? statusMessageID : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+  // Pending input while user is typing (null = show formatted value)
+  const [pendingInput, setPendingInput] = useState<string | null>(null);
+  const [isFocused, setIsFocused] = useState(false);
+
+  // Format function based on hourFormat
+  const formatDisplayTime =
+    hourFormat === '12h' ? formatDisplayTime12h : formatDisplayTime24h;
+
+  // Unified change handler that fires both onChange and onChangeAction
+  const fireChange = useCallback(
+    (newValue: ISOTimeString | undefined) => {
+      onChange?.(newValue);
+      if (onChangeAction) {
+        startTransition(async () => {
+          setOptimisticValue(newValue);
+          await onChangeAction(newValue);
+        });
+      }
     },
-    ref,
-  ) => {
-    const themeContext = useContext(ThemeContext);
-    const wrapperOverride = themeContext?.theme.components?.timeInput?.wrapper;
-    const inputOverride = themeContext?.theme.components?.timeInput?.input;
+    [onChange, onChangeAction, startTransition, setOptimisticValue],
+  );
 
-    const id = useId();
-    const descriptionID = useId();
-    const statusMessageID = useId();
-    const inputRef = useRef<HTMLInputElement | null>(null);
+  // Display value: pending input if typing, otherwise formatted value
+  const displayValue = useMemo(() => {
+    if (pendingInput !== null) {
+      return pendingInput;
+    }
+    return optimisticValue
+      ? formatDisplayTime(optimisticValue, hasSeconds)
+      : '';
+  }, [pendingInput, value, formatDisplayTime, hasSeconds]);
 
-    const [, startTransition] = useTransition();
-    const [optimisticValue, setOptimisticValue] = useOptimistic(value);
-    const isBusy = isLoading || optimisticValue !== value;
+  // Check if current input is valid (for styling purposes)
+  const isInputValid = useMemo(() => {
+    // Only check pending input for validity styling
+    if (pendingInput === null || !pendingInput.trim()) {
+      return true;
+    }
+    const parsed = parseTimeInput(pendingInput, hasSeconds);
+    if (!parsed) {
+      return false;
+    }
+    // Also check min/max range
+    return isTimeInRange(parsed, min, max);
+  }, [pendingInput, hasSeconds, min, max]);
 
-    // Status icon mapping
-    const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
-      warning: 'warning',
-      error: 'xCircle',
-      success: 'checkCircle',
-    };
+  // Placeholder that shows format hint when focused and empty
+  const displayPlaceholder = useMemo(() => {
+    if (isFocused && !displayValue) {
+      return hourFormat === '12h' ? 'e.g., 2:30 PM' : 'e.g., 14:30';
+    }
+    return placeholder;
+  }, [isFocused, displayValue, hourFormat, placeholder]);
 
-    const statusIconColorMap: Record<
-      XDSInputStatusType,
-      'warning' | 'negative' | 'positive'
-    > = {
-      warning: 'warning',
-      error: 'negative',
-      success: 'positive',
-    };
+  // Handle input text change - update immediately if valid
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const newValue = e.target.value;
+      setPendingInput(newValue);
 
-    const ariaDescribedBy =
-      [
-        description ? descriptionID : null,
-        status?.message ? statusMessageID : null,
-      ]
-        .filter(Boolean)
-        .join(' ') || undefined;
+      // If the input is valid, update immediately (don't wait for blur)
+      const parsed = parseTimeInput(newValue, hasSeconds);
+      if (parsed && isTimeInRange(parsed, min, max) && parsed !== value) {
+        fireChange(parsed);
+      }
+    },
+    [hasSeconds, min, max, value, fireChange],
+  );
 
-    // Pending input while user is typing (null = show formatted value)
-    const [pendingInput, setPendingInput] = useState<string | null>(null);
-    const [isFocused, setIsFocused] = useState(false);
+  // Handle focus
+  const handleFocus = useCallback(() => {
+    setIsFocused(true);
+  }, []);
 
-    // Format function based on hourFormat
-    const formatDisplayTime =
-      hourFormat === '12h' ? formatDisplayTime12h : formatDisplayTime24h;
+  // Handle blur - validate and clear pending input
+  const handleBlur = useCallback(
+    (_e: FocusEvent<HTMLInputElement>) => {
+      setIsFocused(false);
 
-    // Unified change handler that fires both onChange and onChangeAction
-    const fireChange = useCallback(
-      (newValue: ISOTimeString | undefined) => {
-        onChange?.(newValue);
-        if (onChangeAction) {
-          startTransition(async () => {
-            setOptimisticValue(newValue);
-            await onChangeAction(newValue);
-          });
+      if (pendingInput === null) {
+        return;
+      }
+
+      if (!pendingInput.trim()) {
+        // Empty input clears the value
+        if (value !== undefined) {
+          fireChange(undefined);
         }
-      },
-      [onChange, onChangeAction, startTransition, setOptimisticValue],
-    );
-
-    // Display value: pending input if typing, otherwise formatted value
-    const displayValue = useMemo(() => {
-      if (pendingInput !== null) {
-        return pendingInput;
+        setPendingInput(null);
+        return;
       }
-      return optimisticValue
-        ? formatDisplayTime(optimisticValue, hasSeconds)
-        : '';
-    }, [pendingInput, value, formatDisplayTime, hasSeconds]);
 
-    // Check if current input is valid (for styling purposes)
-    const isInputValid = useMemo(() => {
-      // Only check pending input for validity styling
-      if (pendingInput === null || !pendingInput.trim()) {
-        return true;
-      }
       const parsed = parseTimeInput(pendingInput, hasSeconds);
-      if (!parsed) {
-        return false;
-      }
-      // Also check min/max range
-      return isTimeInRange(parsed, min, max);
-    }, [pendingInput, hasSeconds, min, max]);
-
-    // Placeholder that shows format hint when focused and empty
-    const displayPlaceholder = useMemo(() => {
-      if (isFocused && !displayValue) {
-        return hourFormat === '12h' ? 'e.g., 2:30 PM' : 'e.g., 14:30';
-      }
-      return placeholder;
-    }, [isFocused, displayValue, hourFormat, placeholder]);
-
-    // Handle input text change - update immediately if valid
-    const handleInputChange = useCallback(
-      (e: React.ChangeEvent<HTMLInputElement>) => {
-        const newValue = e.target.value;
-        setPendingInput(newValue);
-
-        // If the input is valid, update immediately (don't wait for blur)
-        const parsed = parseTimeInput(newValue, hasSeconds);
-        if (parsed && isTimeInRange(parsed, min, max) && parsed !== value) {
+      if (parsed && isTimeInRange(parsed, min, max)) {
+        // Valid time - update if different
+        if (parsed !== value) {
           fireChange(parsed);
         }
-      },
-      [hasSeconds, min, max, value, fireChange],
-    );
+      }
+      // Clear pending input - display will revert to formatted value
+      setPendingInput(null);
+    },
+    [pendingInput, value, fireChange, hasSeconds, min, max],
+  );
 
-    // Handle focus
-    const handleFocus = useCallback(() => {
-      setIsFocused(true);
-    }, []);
+  // Handle keyboard navigation on input
+  const handleInputKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+        e.preventDefault();
 
-    // Handle blur - validate and clear pending input
-    const handleBlur = useCallback(
-      (_e: FocusEvent<HTMLInputElement>) => {
-        setIsFocused(false);
-
-        if (pendingInput === null) {
-          return;
+        // Get current time or default to now
+        let currentTime = value;
+        if (!currentTime) {
+          const now = new Date();
+          currentTime = formatISOTime(
+            {
+              hour: now.getHours(),
+              minute: now.getMinutes(),
+              second: now.getSeconds(),
+            },
+            hasSeconds,
+          );
         }
 
-        if (!pendingInput.trim()) {
-          // Empty input clears the value
-          if (value !== undefined) {
-            fireChange(undefined);
-          }
-          setPendingInput(null);
-          return;
+        const delta = e.key === 'ArrowUp' ? increment : -increment;
+        const newTime = adjustTime(currentTime, delta, hasSeconds);
+
+        // Check if within range
+        if (isTimeInRange(newTime, min, max)) {
+          fireChange(newTime);
         }
+      }
+    },
+    [value, hasSeconds, increment, min, max, fireChange],
+  );
 
-        const parsed = parseTimeInput(pendingInput, hasSeconds);
-        if (parsed && isTimeInRange(parsed, min, max)) {
-          // Valid time - update if different
-          if (parsed !== value) {
-            fireChange(parsed);
-          }
-        }
-        // Clear pending input - display will revert to formatted value
-        setPendingInput(null);
-      },
-      [pendingInput, value, fireChange, hasSeconds, min, max],
-    );
+  // Handle clear button click
+  const handleClear = useCallback(() => {
+    fireChange(undefined);
+    inputRef.current?.focus();
+  }, [fireChange]);
 
-    // Handle keyboard navigation on input
-    const handleInputKeyDown = useCallback(
-      (e: KeyboardEvent<HTMLInputElement>) => {
-        if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-          e.preventDefault();
+  // Combine refs
+  const setRefs = useCallback(
+    (el: HTMLInputElement | null) => {
+      inputRef.current = el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        ref.current = el;
+      }
+    },
+    [ref],
+  );
 
-          // Get current time or default to now
-          let currentTime = value;
-          if (!currentTime) {
-            const now = new Date();
-            currentTime = formatISOTime(
-              {
-                hour: now.getHours(),
-                minute: now.getMinutes(),
-                second: now.getSeconds(),
-              },
-              hasSeconds,
-            );
-          }
-
-          const delta = e.key === 'ArrowUp' ? increment : -increment;
-          const newTime = adjustTime(currentTime, delta, hasSeconds);
-
-          // Check if within range
-          if (isTimeInRange(newTime, min, max)) {
-            fireChange(newTime);
-          }
-        }
-      },
-      [value, hasSeconds, increment, min, max, fireChange],
-    );
-
-    // Handle clear button click
-    const handleClear = useCallback(() => {
-      fireChange(undefined);
-      inputRef.current?.focus();
-    }, [fireChange]);
-
-    // Combine refs
-    const setRefs = useCallback(
-      (el: HTMLInputElement | null) => {
-        inputRef.current = el;
-        if (typeof ref === 'function') {
-          ref(el);
-        } else if (ref) {
-          ref.current = el;
-        }
-      },
-      [ref],
-    );
-
-    return (
-      <XDSField
-        label={label}
-        isLabelHidden={isLabelHidden}
-        description={description}
-        inputID={id}
-        descriptionID={description ? descriptionID : undefined}
-        isOptional={isOptional}
-        isRequired={isRequired}
-        status={
-          status
-            ? {
-                type: status.type,
-                message: status.message,
-                messageID: status.message ? statusMessageID : undefined,
-              }
-            : undefined
-        }
-        labelTooltip={labelTooltip}>
-        <div
-          {...stylex.props(
-            styles.wrapper,
-            sizeStyles[size],
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
-            wrapperOverride,
-          )}>
-          <div {...stylex.props(styles.icon)}>
-            <XDSIcon icon="clock" size="sm" color="secondary" />
-          </div>
-          <input
-            ref={setRefs}
-            id={id}
-            type="text"
-            value={displayValue}
-            onChange={handleInputChange}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            onKeyDown={handleInputKeyDown}
-            placeholder={displayPlaceholder}
-            disabled={isDisabled}
-            aria-describedby={ariaDescribedBy}
-            aria-required={isRequired === true ? 'true' : undefined}
-            aria-invalid={status?.type === 'error' ? 'true' : undefined}
-            aria-busy={isBusy || undefined}
-            {...stylex.props(
-              styles.input,
-              isDisabled && styles.inputDisabled,
-              !isInputValid && styles.inputInvalid,
-              inputOverride,
-            )}
-          />
-          {isBusy && <XDSSpinner size="sm" />}
-          {hasClear && value && !isDisabled && (
-            <button
-              type="button"
-              onClick={handleClear}
-              aria-label="Clear time"
-              {...stylex.props(styles.clearButton)}>
-              <XDSIcon icon="close" size="sm" color="secondary" />
-            </button>
-          )}
-          {status && (
-            <XDSIcon
-              icon={statusIconMap[status.type]}
-              size="md"
-              color={statusIconColorMap[status.type]}
-            />
-          )}
+  return (
+    <XDSField
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={id}
+      descriptionID={description ? descriptionID : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageID : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}>
+      <div
+        {...stylex.props(
+          styles.wrapper,
+          sizeStyles[size],
+          isDisabled && styles.wrapperDisabled,
+          status && statusBorderStyles[status.type],
+          status && statusHoverShadowStyles[status.type],
+          status && statusFocusStyles[status.type],
+          wrapperOverride,
+        )}>
+        <div {...stylex.props(styles.icon)}>
+          <XDSIcon icon="clock" size="sm" color="secondary" />
         </div>
-      </XDSField>
-    );
-  },
-);
+        <input
+          ref={setRefs}
+          id={id}
+          type="text"
+          value={displayValue}
+          onChange={handleInputChange}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          onKeyDown={handleInputKeyDown}
+          placeholder={displayPlaceholder}
+          disabled={isDisabled}
+          aria-describedby={ariaDescribedBy}
+          aria-required={isRequired === true ? 'true' : undefined}
+          aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          aria-busy={isBusy || undefined}
+          {...stylex.props(
+            styles.input,
+            isDisabled && styles.inputDisabled,
+            !isInputValid && styles.inputInvalid,
+            inputOverride,
+          )}
+        />
+        {isBusy && <XDSSpinner size="sm" />}
+        {hasClear && value && !isDisabled && (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="Clear time"
+            {...stylex.props(styles.clearButton)}>
+            <XDSIcon icon="close" size="sm" color="secondary" />
+          </button>
+        )}
+        {status && (
+          <XDSIcon
+            icon={statusIconMap[status.type]}
+            size="md"
+            color={statusIconColorMap[status.type]}
+          />
+        )}
+      </div>
+    </XDSField>
+  );
+}
 
 XDSTimeInput.displayName = 'XDSTimeInput';

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSToken.tsx
- * @input Uses React forwardRef, ReactNode, StyleXStyles
+ * @input Uses React ReactNode, StyleXStyles
  * @output Exports XDSToken component, XDSTokenProps, XDSTokenColor types
  * @position Core implementation; consumed by index.ts, tested by XDSToken.test.tsx
  *
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/Token.stories.tsx (storybook stories)
  */
 
-import {forwardRef, type ReactNode} from 'react';
+import {type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -49,6 +49,8 @@ export type XDSTokenColor =
 export type XDSTokenSize = 'sm' | 'md';
 
 export interface XDSTokenProps {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * The text label displayed in the token.
    */
@@ -288,31 +290,102 @@ const colorStyles = stylex.create({
  * <XDSToken label="Link" href="/path" />
  * ```
  */
-export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
-  (
-    {
-      label,
-      size = 'md',
-      color = 'default',
-      icon,
-      isDisabled = false,
-      onRemove,
-      onClick,
-      href,
-      description,
-      endContent,
-      isLabelHidden = false,
-      xstyle,
-      'data-testid': testId,
-    },
-    ref,
-  ) => {
-    const content = (
-      <>
+export function XDSToken({
+  ref,
+  label,
+  size = 'md',
+  color = 'default',
+  icon,
+  isDisabled = false,
+  onRemove,
+  onClick,
+  href,
+  description,
+  endContent,
+  isLabelHidden = false,
+  xstyle,
+  'data-testid': testId,
+}: XDSTokenProps) {
+  const content = (
+    <>
+      {icon}
+      <span {...(isLabelHidden ? stylex.props(styles.labelHidden) : {})}>
+        {label}
+      </span>
+      {endContent}
+      {onRemove != null && (
+        <button
+          type="button"
+          aria-label={`Remove ${label}`}
+          onClick={e => {
+            e.stopPropagation();
+            onRemove(e);
+          }}
+          disabled={isDisabled}
+          {...stylex.props(styles.removeButton)}>
+          <XDSIcon icon="close" size="xsm" color="inherit" />
+        </button>
+      )}
+    </>
+  );
+
+  const sharedProps = {
+    'data-testid': testId,
+    'aria-label': isLabelHidden ? label : undefined,
+    'aria-description': description,
+  };
+
+  if (href != null) {
+    return (
+      <a
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        href={href}
+        aria-disabled={isDisabled || undefined}
+        {...sharedProps}
+        {...stylex.props(
+          styles.base,
+          sizeStyles[size],
+          colorStyles[color],
+          styles.interactive,
+          isDisabled && styles.disabled,
+          xstyle,
+        )}>
+        {content}
+      </a>
+    );
+  }
+
+  if (onClick != null) {
+    const handleContainerClick = (e: React.MouseEvent) => {
+      const target = e.target as HTMLElement;
+      if (target.closest('button, a')) return;
+      onClick(e);
+    };
+
+    return (
+      <span
+        ref={ref as React.Ref<HTMLSpanElement>}
+        onClick={isDisabled ? undefined : handleContainerClick}
+        {...sharedProps}
+        {...stylex.props(
+          styles.base,
+          sizeStyles[size],
+          colorStyles[color],
+          styles.interactive,
+          styles.focusWithinOutline,
+          isDisabled && styles.disabled,
+          xstyle,
+        )}>
         {icon}
-        <span {...(isLabelHidden ? stylex.props(styles.labelHidden) : {})}>
-          {label}
-        </span>
+        <button
+          type="button"
+          onClick={onClick}
+          disabled={isDisabled}
+          {...stylex.props(styles.invisibleButton)}>
+          <span {...(isLabelHidden ? stylex.props(styles.labelHidden) : {})}>
+            {label}
+          </span>
+        </button>
         {endContent}
         {onRemove != null && (
           <button
@@ -327,99 +400,24 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
             <XDSIcon icon="close" size="xsm" color="inherit" />
           </button>
         )}
-      </>
-    );
-
-    const sharedProps = {
-      'data-testid': testId,
-      'aria-label': isLabelHidden ? label : undefined,
-      'aria-description': description,
-    };
-
-    if (href != null) {
-      return (
-        <a
-          ref={ref as React.Ref<HTMLAnchorElement>}
-          href={href}
-          aria-disabled={isDisabled || undefined}
-          {...sharedProps}
-          {...stylex.props(
-            styles.base,
-            sizeStyles[size],
-            colorStyles[color],
-            styles.interactive,
-            isDisabled && styles.disabled,
-            xstyle,
-          )}>
-          {content}
-        </a>
-      );
-    }
-
-    if (onClick != null) {
-      const handleContainerClick = (e: React.MouseEvent) => {
-        const target = e.target as HTMLElement;
-        if (target.closest('button, a')) return;
-        onClick(e);
-      };
-
-      return (
-        <span
-          ref={ref as React.Ref<HTMLSpanElement>}
-          onClick={isDisabled ? undefined : handleContainerClick}
-          {...sharedProps}
-          {...stylex.props(
-            styles.base,
-            sizeStyles[size],
-            colorStyles[color],
-            styles.interactive,
-            styles.focusWithinOutline,
-            isDisabled && styles.disabled,
-            xstyle,
-          )}>
-          {icon}
-          <button
-            type="button"
-            onClick={onClick}
-            disabled={isDisabled}
-            {...stylex.props(styles.invisibleButton)}>
-            <span {...(isLabelHidden ? stylex.props(styles.labelHidden) : {})}>
-              {label}
-            </span>
-          </button>
-          {endContent}
-          {onRemove != null && (
-            <button
-              type="button"
-              aria-label={`Remove ${label}`}
-              onClick={e => {
-                e.stopPropagation();
-                onRemove(e);
-              }}
-              disabled={isDisabled}
-              {...stylex.props(styles.removeButton)}>
-              <XDSIcon icon="close" size="xsm" color="inherit" />
-            </button>
-          )}
-        </span>
-      );
-    }
-
-    return (
-      <span
-        ref={ref as React.Ref<HTMLSpanElement>}
-        {...sharedProps}
-        {...stylex.props(
-          styles.base,
-          sizeStyles[size],
-          colorStyles[color],
-          isDisabled && styles.disabled,
-          xstyle,
-        )}>
-        {content}
       </span>
     );
-  },
-);
+  }
+
+  return (
+    <span
+      ref={ref as React.Ref<HTMLSpanElement>}
+      {...sharedProps}
+      {...stylex.props(
+        styles.base,
+        sizeStyles[size],
+        colorStyles[color],
+        isDisabled && styles.disabled,
+        xstyle,
+      )}>
+      {content}
+    </span>
+  );
+}
 
 XDSToken.displayName = 'XDSToken';

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSTopNav.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode
+ * @input Uses React HTMLAttributes, ReactNode
  * @output Exports XDSTopNav component and XDSTopNavProps
  * @position Core implementation; consumed by index.ts
  *
@@ -11,12 +11,7 @@
  * - /apps/storybook/stories/TopNav.stories.tsx
  */
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {useContext, type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {ThemeContext} from '../theme/ThemeContext';
@@ -97,6 +92,8 @@ export interface XDSTopNavProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className' | 'title'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * Title slot content - typically XDSTopNavTitle with logo and text.
    * Positioned at the left edge of the nav bar.
@@ -143,45 +140,48 @@ export interface XDSTopNavProps extends Omit<
  * />
  * ```
  */
-export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
-  function XDSTopNav(
-    {title, startContent, centerContent, endContent, label, ...props},
-    ref,
-  ) {
-    const themeContext = useContext(ThemeContext);
-    const rootOverride = themeContext?.theme.components?.topNav?.root;
-    const hasCenterContent = centerContent != null;
+export function XDSTopNav({
+  ref,
+  title,
+  startContent,
+  centerContent,
+  endContent,
+  label,
+  ...props
+}: XDSTopNavProps) {
+  const themeContext = useContext(ThemeContext);
+  const rootOverride = themeContext?.theme.components?.topNav?.root;
+  const hasCenterContent = centerContent != null;
 
-    return (
-      <nav
-        ref={ref}
-        role="navigation"
-        aria-label={label}
-        {...stylex.props(
-          styles.base,
-          hasCenterContent ? styles.baseGrid : styles.baseFlex,
-          rootOverride,
+  return (
+    <nav
+      ref={ref}
+      role="navigation"
+      aria-label={label}
+      {...stylex.props(
+        styles.base,
+        hasCenterContent ? styles.baseGrid : styles.baseFlex,
+        rootOverride,
+      )}
+      {...props}>
+      <div {...stylex.props(styles.leftSection)}>
+        {title && <div {...stylex.props(styles.title)}>{title}</div>}
+        {startContent && (
+          <div {...stylex.props(styles.startContent)}>{startContent}</div>
         )}
-        {...props}>
-        <div {...stylex.props(styles.leftSection)}>
-          {title && <div {...stylex.props(styles.title)}>{title}</div>}
-          {startContent && (
-            <div {...stylex.props(styles.startContent)}>{startContent}</div>
-          )}
-        </div>
-        {hasCenterContent && (
-          <div {...stylex.props(styles.centerContent)}>{centerContent}</div>
-        )}
-        {hasCenterContent ? (
-          <div {...stylex.props(styles.rightSection)}>{endContent}</div>
-        ) : (
-          endContent && (
-            <div {...stylex.props(styles.endContent)}>{endContent}</div>
-          )
-        )}
-      </nav>
-    );
-  },
-);
+      </div>
+      {hasCenterContent && (
+        <div {...stylex.props(styles.centerContent)}>{centerContent}</div>
+      )}
+      {hasCenterContent ? (
+        <div {...stylex.props(styles.rightSection)}>{endContent}</div>
+      ) : (
+        endContent && (
+          <div {...stylex.props(styles.endContent)}>{endContent}</div>
+        )
+      )}
+    </nav>
+  );
+}
 
 XDSTopNav.displayName = 'XDSTopNav';

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSTopNavItem.tsx
- * @input Uses React forwardRef, AnchorHTMLAttributes, ReactNode
+ * @input Uses React AnchorHTMLAttributes, ReactNode
  * @output Exports XDSTopNavItem component and XDSTopNavItemProps
  * @position Navigation item component for XDSTopNav startContent
  *
@@ -13,7 +13,7 @@
 
 'use client';
 
-import {forwardRef, type AnchorHTMLAttributes, type ReactNode} from 'react';
+import {type AnchorHTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -87,6 +87,8 @@ export interface XDSTopNavItemProps extends Omit<
   AnchorHTMLAttributes<HTMLAnchorElement>,
   'style' | 'className'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLAnchorElement>;
   /**
    * Custom component to render instead of `<a>`.
    * Overrides the provider-level default set by XDSLinkProvider.
@@ -139,42 +141,38 @@ export interface XDSTopNavItemProps extends Omit<
  * />
  * ```
  */
-export const XDSTopNavItem = forwardRef<HTMLAnchorElement, XDSTopNavItemProps>(
-  function XDSTopNavItem(
-    {
-      as,
-      label,
-      isSelected = false,
-      isDisabled = false,
-      icon,
-      children,
-      ...props
-    },
-    ref,
-  ) {
-    const LinkComponent = useXDSLinkComponent(as);
-    const isIconOnly = icon != null && children == null && !label;
-    const showLabel = !isIconOnly;
+export function XDSTopNavItem({
+  ref,
+  as,
+  label,
+  isSelected = false,
+  isDisabled = false,
+  icon,
+  children,
+  ...props
+}: XDSTopNavItemProps) {
+  const LinkComponent = useXDSLinkComponent(as);
+  const isIconOnly = icon != null && children == null && !label;
+  const showLabel = !isIconOnly;
 
-    return (
-      <LinkComponent
-        ref={ref}
-        aria-label={isIconOnly ? label : undefined}
-        aria-current={isSelected ? 'page' : undefined}
-        aria-disabled={isDisabled || undefined}
-        tabIndex={isDisabled ? -1 : undefined}
-        {...stylex.props(
-          styles.base,
-          isSelected && styles.selected,
-          isDisabled && styles.disabled,
-          isIconOnly && styles.iconOnly,
-        )}
-        {...props}>
-        {icon}
-        {showLabel && (children ?? label)}
-      </LinkComponent>
-    );
-  },
-);
+  return (
+    <LinkComponent
+      ref={ref}
+      aria-label={isIconOnly ? label : undefined}
+      aria-current={isSelected ? 'page' : undefined}
+      aria-disabled={isDisabled || undefined}
+      tabIndex={isDisabled ? -1 : undefined}
+      {...stylex.props(
+        styles.base,
+        isSelected && styles.selected,
+        isDisabled && styles.disabled,
+        isIconOnly && styles.iconOnly,
+      )}
+      {...props}>
+      {icon}
+      {showLabel && (children ?? label)}
+    </LinkComponent>
+  );
+}
 
 XDSTopNavItem.displayName = 'XDSTopNavItem';

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -11,7 +11,14 @@
 
 'use client';
 
-import {useCallback, useEffect, useRef, useState, type ReactNode} from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,

--- a/packages/core/src/TopNav/XDSTopNavTitle.tsx
+++ b/packages/core/src/TopNav/XDSTopNavTitle.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSTopNavTitle.tsx
- * @input Uses React forwardRef, HTMLAttributes, ReactNode
+ * @input Uses React HTMLAttributes, ReactNode
  * @output Exports XDSTopNavTitle component and XDSTopNavTitleProps
  * @position Companion component for XDSTopNav title slot
  *
@@ -11,7 +11,7 @@
  * - /apps/storybook/stories/TopNav.stories.tsx
  */
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {type HTMLAttributes, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -53,6 +53,8 @@ export interface XDSTopNavTitleProps extends Omit<
   HTMLAttributes<HTMLElement>,
   'style' | 'className' | 'title'
 > {
+  /** Ref to the root element. */
+  ref?: Ref<HTMLElement>;
   /**
    * The title text to display.
    */
@@ -94,21 +96,25 @@ export interface XDSTopNavTitleProps extends Omit<
  * <XDSTopNavTitle logo={<BrandLogo />} href="/" />
  * ```
  */
-export const XDSTopNavTitle = forwardRef<HTMLElement, XDSTopNavTitleProps>(
-  function XDSTopNavTitle({title, logo, href, ...props}, ref) {
-    const Element = href ? 'a' : 'div';
+export function XDSTopNavTitle({
+  ref,
+  title,
+  logo,
+  href,
+  ...props
+}: XDSTopNavTitleProps) {
+  const Element = href ? 'a' : 'div';
 
-    return (
-      <Element
-        ref={ref as React.Ref<HTMLAnchorElement & HTMLDivElement>}
-        href={href}
-        {...stylex.props(styles.base, href != null && styles.clickable)}
-        {...props}>
-        {logo && <span {...stylex.props(styles.logo)}>{logo}</span>}
-        {title && <span {...stylex.props(styles.titleText)}>{title}</span>}
-      </Element>
-    );
-  },
-);
+  return (
+    <Element
+      ref={ref as React.Ref<HTMLAnchorElement & HTMLDivElement>}
+      href={href}
+      {...stylex.props(styles.base, href != null && styles.clickable)}
+      {...props}>
+      {logo && <span {...stylex.props(styles.logo)}>{logo}</span>}
+      {title && <span {...stylex.props(styles.titleText)}>{title}</span>}
+    </Element>
+  );
+}
 
 XDSTopNavTitle.displayName = 'XDSTopNavTitle';

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -14,13 +14,13 @@
  */
 
 import React, {
-  forwardRef,
   useCallback,
   useEffect,
   useId,
   useRef,
   useState,
   type ReactNode,
+  type Ref,
   type RefObject,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
@@ -44,6 +44,8 @@ import type {XDSSearchableItem, XDSSearchSource} from './types';
 // =============================================================================
 
 export interface XDSBaseTypeaheadProps<T extends XDSSearchableItem> {
+  /** Ref to the input element. */
+  ref?: Ref<HTMLInputElement>;
   /**
    * Search source providing items.
    */
@@ -247,31 +249,27 @@ const styles = stylex.create({
  * />
  * ```
  */
-export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
-  T extends XDSSearchableItem,
->(
-  {
-    searchSource,
-    value,
-    onChange,
-    renderItem,
-    placeholder = 'Search...',
-    hasEntriesOnFocus = false,
-    maxMenuItems = 10,
-    emptySearchResultsText = 'No results found',
-    isDisabled = false,
-    hasAutoFocus = false,
-    onChangeQuery,
-    onOpenChange,
-    inputId: externalInputId,
-    ariaDescribedBy,
-    inputXStyle,
-    anchorRef,
-    onKeyDown: externalOnKeyDown,
-    debounceMs = 150,
-  }: XDSBaseTypeaheadProps<T>,
-  ref: React.ForwardedRef<HTMLInputElement>,
-) {
+export function XDSBaseTypeahead<T extends XDSSearchableItem>({
+  ref,
+  searchSource,
+  value,
+  onChange,
+  renderItem,
+  placeholder = 'Search...',
+  hasEntriesOnFocus = false,
+  maxMenuItems = 10,
+  emptySearchResultsText = 'No results found',
+  isDisabled = false,
+  hasAutoFocus = false,
+  onChangeQuery,
+  onOpenChange,
+  inputId: externalInputId,
+  ariaDescribedBy,
+  inputXStyle,
+  anchorRef,
+  onKeyDown: externalOnKeyDown,
+  debounceMs = 150,
+}: XDSBaseTypeaheadProps<T>) {
   const generatedId = useId();
   const inputId = externalInputId ?? generatedId;
   const listboxId = useId();
@@ -617,8 +615,6 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
       )}
     </>
   );
-}) as <T extends XDSSearchableItem>(
-  props: XDSBaseTypeaheadProps<T> & {ref?: React.Ref<HTMLInputElement>},
-) => React.ReactElement;
+}
 
-(XDSBaseTypeahead as {displayName?: string}).displayName = 'XDSBaseTypeahead';
+XDSBaseTypeahead.displayName = 'XDSBaseTypeahead';


### PR DESCRIPTION
## Summary

Migrates all 59 component files from `forwardRef` to React 19's `ref` as a regular prop.

### Before
```tsx
export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
  (props, ref) => { ... }
);
XDSButton.displayName = 'XDSButton';
```

### After
```tsx
export function XDSButton({ref, label, ...props}: XDSButtonProps) { ... }
XDSButton.displayName = 'XDSButton';
```

### Changes
- Remove `forwardRef` from all 59 component files
- Add `ref?: Ref<T>` to props interfaces
- Convert `export const X = forwardRef(...)` → `export function X(...)`
- **XDSCalendar**: Remove `useImperativeHandle` (redundant — `focusDate` prop does the same thing). `XDSCalendarHandle` deprecated but kept for backwards compat.
- **XDSDateInput**: Use controlled `focusDate`/`onFocusDateChange` instead of `calendarRef.navigateTo()`
- **XDSBaseTable/XDSTable**: No longer need the `forwardRef + as` cast pattern for generics
- **API Conventions wiki**: Already updated to document the new pattern

### Test plan
- [x] `yarn build` — 0 errors
- [x] `yarn test --run` — 62 files, 1071 tests pass
- [ ] Storybook smoke test

### Stats
65 files changed, ~500 insertions, ~580 deletions (net reduction)

Fixes #415

cc @cixzhang