### PR TITLE
fix(ci): add merge_group trigger to review-gate workflow

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -5,19 +5,27 @@ on:
     types: [opened, synchronize, reopened]
   pull_request_review:
     types: [submitted]
+  merge_group:
 
 jobs:
   review-gate:
     name: review-gate
     runs-on: ubuntu-latest
     steps:
+      # In merge queue context, the review already passed on the PR — auto-pass
+      - name: Auto-pass for merge queue
+        if: github.event_name == 'merge_group'
+        run: echo "Merge queue — review already validated on the PR"
+
       - name: Checkout CODEOWNERS
+        if: github.event_name != 'merge_group'
         uses: actions/checkout@v4
         with:
           sparse-checkout: .github/CODEOWNERS
           sparse-checkout-cone-mode: false
 
       - name: Check review requirement
+        if: github.event_name != 'merge_group'
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
## Summary

The `review-gate` workflow (added in #413) only triggers on `pull_request` and `pull_request_review` events. Since `review-gate` is a required status check, the merge queue never receives this check and boots PRs after the 10-minute timeout.

This is the same class of issue we fixed in Feb for `check-components`, `pr-comment`, `pr-screenshots`, `pr-a11y`, and `pr-comment-update`.

## Changes

- Add `merge_group:` to the workflow triggers
- Auto-pass in merge queue context (review already validated on the PR)
- Gate existing checkout + check steps to PR events only

## Impact

Fixes #416 being booted from the merge queue. Unblocks all future merge queue usage.

Fixes: #416 (merge queue failure)