### PR TITLE
docs: fix README structure for CLI parser compatibility

### DIFF
--- a/packages/core/src/AppShell/README.md
+++ b/packages/core/src/AppShell/README.md
@@ -14,6 +14,33 @@ XDSAppShell provides the structural frame for an application: header, side navig
 import {XDSAppShell} from '@xds/core/AppShell';
 ```
 
+## Usage
+
+```tsx
+<XDSAppShell
+  topNav={
+    <XDSTopNav
+      label="Navigation"
+      title={<XDSTopNavTitle title="My App" logo={<Logo />} />}
+    />
+  }
+  sideNav={
+    <XDSSideNav>
+      <XDSSideNavSection title="Main" isHeaderHidden>
+        <XDSSideNavItem
+          label="Dashboard"
+          icon={HomeIcon}
+          isSelected
+          href="/dashboard"
+        />
+        <XDSSideNavItem label="Settings" icon={CogIcon} href="/settings" />
+      </XDSSideNavSection>
+    </XDSSideNav>
+  }>
+  <MainContent />
+</XDSAppShell>
+```
+
 ## Composition Patterns
 
 XDSAppShell has two navigation slots: `topNav` (horizontal bar) and `sideNav` (vertical sidebar). How you combine them determines where app identity lives.

--- a/packages/core/src/Avatar/README.md
+++ b/packages/core/src/Avatar/README.md
@@ -4,6 +4,12 @@ Avatar component for displaying user profile pictures with fallback support.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSAvatar, XDSAvatarStatusDot} from '@xds/core/Avatar';
+```
+
 ## Features
 
 - **Image loading**: Primary and fallback image sources

--- a/packages/core/src/Badge/README.md
+++ b/packages/core/src/Badge/README.md
@@ -2,6 +2,12 @@
 
 A badge component for displaying status indicators, counts, or labels.
 
+## Import
+
+```tsx
+import {XDSBadge} from '@xds/core/Badge';
+```
+
 ## Exports
 
 | Export            | Type      | Description          |

--- a/packages/core/src/Banner/README.md
+++ b/packages/core/src/Banner/README.md
@@ -2,6 +2,12 @@
 
 Persistent status notification for info, warning, error, or success messages.
 
+## Import
+
+```tsx
+import {XDSBanner} from '@xds/core/Banner';
+```
+
 ## Visual Structure
 
 The banner has a two-part layout:

--- a/packages/core/src/Breadcrumbs/README.md
+++ b/packages/core/src/Breadcrumbs/README.md
@@ -2,6 +2,12 @@
 
 A navigation breadcrumb trail with semantic HTML.
 
+## Import
+
+```tsx
+import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
+```
+
 ## Exports
 
 | Export                   | Type      | Description                |
@@ -38,7 +44,9 @@ Navigation container that renders a `<nav>` with an ordered list of breadcrumb i
 Individual breadcrumb item that renders as a link or plain text.
 
 ```tsx
-<XDSBreadcrumbItem href="/settings" startIcon={<XDSIcon icon={CogIcon} size="sm" />}>
+<XDSBreadcrumbItem
+  href="/settings"
+  startIcon={<XDSIcon icon={CogIcon} size="sm" />}>
   Settings
 </XDSBreadcrumbItem>
 ```

--- a/packages/core/src/Button/README.md
+++ b/packages/core/src/Button/README.md
@@ -4,6 +4,12 @@ XDSButton component with multiple variants, sizes, and isLoading state support.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSButton} from '@xds/core/Button';
+```
+
 ## Features
 
 - **Variants**: `primary`, `secondary`, `ghost`, `destructive`
@@ -58,19 +64,19 @@ or `<span onClick>` for accessibility (keyboard navigation, focus management, sc
 
 ## Props
 
-| Prop         | Type                                                        | Default       | Description                                                                                                                                          |
-| ------------ | ----------------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `label`      | `string`                                                    | —             | Accessible label (required)                                                                                                                          |
-| `variant`    | `'primary' \| 'secondary' \| 'ghost' \| 'destructive'`      | `'secondary'` | Visual style variant                                                                                                                                 |
-| `size`       | `'sm' \| 'md' \| 'lg'`                                      | `'md'`        | Size variant                                                                                                                                         |
-| `isLoading`  | `boolean`                                                   | `false`       | Shows isLoading spinner                                                                                                                              |
-| `isDisabled` | `boolean`                                                   | `false`       | Disables the button                                                                                                                                  |
-| `icon`       | `ReactNode`                                                 | —             | Icon element                                                                                                                                         |
-| `children`   | `ReactNode`                                                 | —             | Button content                                                                                                                                       |
-| `endSlot`    | `ReactElement<XDSIconProps> \| ReactElement<XDSBadgeProps>` | —             | Trailing icon or badge after the label. Only accepts `<XDSIcon>` or `<XDSBadge>`. Ignored for icon-only. Color is inherited from the button variant. |
-| `tooltip`    | `string`                                                    | —             | Tooltip text shown on hover                                                                                                                          |
-| `onClick`    | `(e: MouseEvent) => void`                                   | —             | Standard click handler (passed through from `ButtonHTMLAttributes`)                                                                                  |
-| `onClickAction` | `(e: MouseEvent) => void \| Promise<void>`               | —             | Async click handler. Shows loading state while the returned promise is pending.                                                                      |
+| Prop            | Type                                                        | Default       | Description                                                                                                                                          |
+| --------------- | ----------------------------------------------------------- | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `label`         | `string`                                                    | —             | Accessible label (required)                                                                                                                          |
+| `variant`       | `'primary' \| 'secondary' \| 'ghost' \| 'destructive'`      | `'secondary'` | Visual style variant                                                                                                                                 |
+| `size`          | `'sm' \| 'md' \| 'lg'`                                      | `'md'`        | Size variant                                                                                                                                         |
+| `isLoading`     | `boolean`                                                   | `false`       | Shows isLoading spinner                                                                                                                              |
+| `isDisabled`    | `boolean`                                                   | `false`       | Disables the button                                                                                                                                  |
+| `icon`          | `ReactNode`                                                 | —             | Icon element                                                                                                                                         |
+| `children`      | `ReactNode`                                                 | —             | Button content                                                                                                                                       |
+| `endSlot`       | `ReactElement<XDSIconProps> \| ReactElement<XDSBadgeProps>` | —             | Trailing icon or badge after the label. Only accepts `<XDSIcon>` or `<XDSBadge>`. Ignored for icon-only. Color is inherited from the button variant. |
+| `tooltip`       | `string`                                                    | —             | Tooltip text shown on hover                                                                                                                          |
+| `onClick`       | `(e: MouseEvent) => void`                                   | —             | Standard click handler (passed through from `ButtonHTMLAttributes`)                                                                                  |
+| `onClickAction` | `(e: MouseEvent) => void \| Promise<void>`                  | —             | Async click handler. Shows loading state while the returned promise is pending.                                                                      |
 
 ## Files
 

--- a/packages/core/src/Calendar/README.md
+++ b/packages/core/src/Calendar/README.md
@@ -2,6 +2,12 @@
 
 XDSCalendar component for date selection with single and range modes.
 
+## Import
+
+```tsx
+import {XDSCalendar} from '@xds/core/Calendar';
+```
+
 ## Features
 
 - **Selection Modes**: `single` (default) and `range`
@@ -45,7 +51,7 @@ import { XDSCalendar } from '@xds/core/Calendar';
 | `mode`                | `'single' \| 'range'`                | `'single'` | Selection mode                 |
 | `value`               | `ISODateString \| DateRange`         | —          | Controlled selected value      |
 | `defaultValue`        | `ISODateString \| DateRange`         | —          | Uncontrolled default value     |
-| `onChange`             | `Function`                           | —          | Selection callback             |
+| `onChange`            | `Function`                           | —          | Selection callback             |
 | `numberOfMonths`      | `1 \| 2`                             | `1`        | Number of months to display    |
 | `min`                 | `ISODateString`                      | —          | Minimum selectable date        |
 | `max`                 | `ISODateString`                      | —          | Maximum selectable date        |

--- a/packages/core/src/CheckboxInput/README.md
+++ b/packages/core/src/CheckboxInput/README.md
@@ -4,6 +4,12 @@ A checkbox input component for toggling boolean values.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+```
+
 ## Features
 
 - **Accessible**: Always includes a label (can be visually hidden)

--- a/packages/core/src/DateInput/README.md
+++ b/packages/core/src/DateInput/README.md
@@ -2,6 +2,12 @@
 
 XDSDateInput component combining a text input with a calendar popover for date selection.
 
+## Import
+
+```tsx
+import {XDSDateInput} from '@xds/core/DateInput';
+```
+
 ## Features
 
 - **Text Input**: Manual date entry with flexible parsing (supports various formats)
@@ -73,7 +79,7 @@ import { XDSDateInput } from '@xds/core/DateInput';
 | `isRequired`      | `boolean`                                     | `false`           | Mark field as required                   |
 | `isDisabled`      | `boolean`                                     | `false`           | Disable input and calendar               |
 | `value`           | `ISODateString`                               | —                 | Selected date (YYYY-MM-DD)               |
-| `onChange`         | `(value: ISODateString \| undefined) => void` | —                 | Selection callback                       |
+| `onChange`        | `(value: ISODateString \| undefined) => void` | —                 | Selection callback                       |
 | `min`             | `ISODateString`                               | —                 | Minimum selectable date                  |
 | `max`             | `ISODateString`                               | —                 | Maximum selectable date                  |
 | `dateConstraints` | `Array<(date: Date) => boolean>`              | —                 | Custom constraint functions              |

--- a/packages/core/src/Dialog/README.md
+++ b/packages/core/src/Dialog/README.md
@@ -4,6 +4,12 @@ XDSDialog component using the native `<dialog>` element for modal dialogs.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
+```
+
 ## Features
 
 - **Native `<dialog>`**: Uses browser's built-in modal behavior
@@ -74,7 +80,11 @@ Modal dialog using the native `<dialog>` element.
     content={<XDSLayoutContent>Content goes here</XDSLayoutContent>}
     footer={
       <XDSLayoutFooter hasDivider>
-        <XDSButton label="Confirm" variant="primary" onClick={() => setIsShown(false)} />
+        <XDSButton
+          label="Confirm"
+          variant="primary"
+          onClick={() => setIsShown(false)}
+        />
       </XDSLayoutFooter>
     }
   />
@@ -104,14 +114,14 @@ Header for dialogs with title, optional subtitle, close button, and start/end co
 />
 ```
 
-| Prop           | Type             | Default | Description                                          |
-| -------------- | ---------------- | ------- | ---------------------------------------------------- |
-| `title`        | `string`         | —       | Dialog title (receives focus on open)                |
-| `subtitle`     | `string`         | —       | Subtitle below the title                             |
-| `onHide`       | `() => unknown`  | —       | Close button callback (no button if omitted)         |
-| `startContent` | `ReactNode`      | —       | Content before the title (e.g., back button)         |
-| `endContent`   | `ReactNode`      | —       | Content after the title, before close button         |
-| `hasDivider`   | `boolean`        | `true`  | Adds border at the bottom edge                       |
+| Prop           | Type            | Default | Description                                  |
+| -------------- | --------------- | ------- | -------------------------------------------- |
+| `title`        | `string`        | —       | Dialog title (receives focus on open)        |
+| `subtitle`     | `string`        | —       | Subtitle below the title                     |
+| `onHide`       | `() => unknown` | —       | Close button callback (no button if omitted) |
+| `startContent` | `ReactNode`     | —       | Content before the title (e.g., back button) |
+| `endContent`   | `ReactNode`     | —       | Content after the title, before close button |
+| `hasDivider`   | `boolean`       | `true`  | Adds border at the bottom edge               |
 
 ## Props
 

--- a/packages/core/src/DropdownMenu/README.md
+++ b/packages/core/src/DropdownMenu/README.md
@@ -4,6 +4,12 @@ A dropdown menu component for displaying actionable items in a popup menu.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSDropdownMenu, XDSDropdownMenuItem} from '@xds/core/DropdownMenu';
+```
+
 ## Features
 
 - **Button customization**: Customize the trigger button via the `button` prop (supports all XDSButton props)
@@ -101,10 +107,10 @@ const [isOpen, setIsOpen] = useState(false);
 
 ```tsx
 <XDSDropdownMenu
-  button={{ label: 'Actions' }}
+  button={{label: 'Actions'}}
   items={[
-    { label: 'Edit', icon: PencilIcon, onClick: () => handleEdit() },
-    { label: 'Delete', icon: TrashIcon, onClick: () => handleDelete() },
+    {label: 'Edit', icon: PencilIcon, onClick: () => handleEdit()},
+    {label: 'Delete', icon: TrashIcon, onClick: () => handleDelete()},
   ]}
 />
 ```

--- a/packages/core/src/EmptyState/README.md
+++ b/packages/core/src/EmptyState/README.md
@@ -2,6 +2,12 @@
 
 An empty state placeholder for content areas with no data. Displays an icon or illustration, title, optional description, and action buttons.
 
+## Import
+
+```tsx
+import {XDSEmptyState} from '@xds/core/EmptyState';
+```
+
 ## Exports
 
 | Export               | Type      | Description                |

--- a/packages/core/src/Field/README.md
+++ b/packages/core/src/Field/README.md
@@ -4,6 +4,12 @@ A form field wrapper component that provides label and description.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSField, XDSFieldLabel} from '@xds/core/Field';
+```
+
 ## Features
 
 - **Label Support**: Required label for accessibility (can be visually hidden)
@@ -25,18 +31,18 @@ Form field wrapper that provides label, description, and optional/required indic
 </XDSField>
 ```
 
-| Prop             | Type          | Default | Description                                           |
-| ---------------- | ------------- | ------- | ----------------------------------------------------- |
-| `label`          | `string`      | —       | Label text (required for accessibility)               |
-| `isLabelHidden`  | `boolean`     | `false` | Visually hide the label                               |
-| `description`    | `string`      | —       | Description text between label and input              |
-| `inputID`        | `string`      | —       | ID for the input (used for label's htmlFor)           |
-| `descriptionID`  | `string`      | —       | ID for the description (for aria-describedby)         |
-| `isOptional`     | `boolean`     | `false` | Show "Optional" indicator                             |
-| `isRequired`     | `boolean`     | `false` | Show "Required" indicator                             |
-| `labelStartIcon` | `XDSIconType` | —       | Icon before the label text                            |
-| `labelTooltip`   | `string`      | —       | Tooltip text for info icon at end of label            |
-| `children`       | `ReactNode`   | —       | The input or control to render                        |
+| Prop             | Type          | Default | Description                                   |
+| ---------------- | ------------- | ------- | --------------------------------------------- |
+| `label`          | `string`      | —       | Label text (required for accessibility)       |
+| `isLabelHidden`  | `boolean`     | `false` | Visually hide the label                       |
+| `description`    | `string`      | —       | Description text between label and input      |
+| `inputID`        | `string`      | —       | ID for the input (used for label's htmlFor)   |
+| `descriptionID`  | `string`      | —       | ID for the description (for aria-describedby) |
+| `isOptional`     | `boolean`     | `false` | Show "Optional" indicator                     |
+| `isRequired`     | `boolean`     | `false` | Show "Required" indicator                     |
+| `labelStartIcon` | `XDSIconType` | —       | Icon before the label text                    |
+| `labelTooltip`   | `string`      | —       | Tooltip text for info icon at end of label    |
+| `children`       | `ReactNode`   | —       | The input or control to render                |
 
 ### XDSFieldLabel
 
@@ -46,16 +52,16 @@ Standalone label component with optional/required indicators and tooltip support
 <XDSFieldLabel label="Username" inputID={id} isRequired />
 ```
 
-| Prop             | Type          | Default | Description                                 |
-| ---------------- | ------------- | ------- | ------------------------------------------- |
-| `label`          | `string`      | —       | Label text (required)                       |
-| `inputID`        | `string`      | —       | ID of the input this label is for           |
-| `isLabelHidden`  | `boolean`     | `false` | Visually hide the label                     |
-| `isDisabled`     | `boolean`     | `false` | Whether the associated input is disabled    |
-| `isOptional`     | `boolean`     | `false` | Show "Optional" indicator                   |
-| `isRequired`     | `boolean`     | `false` | Show "Required" indicator                   |
-| `startIcon`      | `XDSIconType` | —       | Icon before the label text                  |
-| `tooltip`        | `string`      | —       | Tooltip text for info icon at end of label  |
+| Prop            | Type          | Default | Description                                |
+| --------------- | ------------- | ------- | ------------------------------------------ |
+| `label`         | `string`      | —       | Label text (required)                      |
+| `inputID`       | `string`      | —       | ID of the input this label is for          |
+| `isLabelHidden` | `boolean`     | `false` | Visually hide the label                    |
+| `isDisabled`    | `boolean`     | `false` | Whether the associated input is disabled   |
+| `isOptional`    | `boolean`     | `false` | Show "Optional" indicator                  |
+| `isRequired`    | `boolean`     | `false` | Show "Required" indicator                  |
+| `startIcon`     | `XDSIconType` | —       | Icon before the label text                 |
+| `tooltip`       | `string`      | —       | Tooltip text for info icon at end of label |
 
 ### XDSFieldStatus
 
@@ -65,12 +71,12 @@ Status message component for form field validation feedback.
 <XDSFieldStatus type="error" message="This field is required" />
 ```
 
-| Prop      | Type                                       | Default      | Description                                     |
-| --------- | ------------------------------------------ | ------------ | ----------------------------------------------- |
-| `type`    | `'error' \| 'warning' \| 'success'`        | —            | Status type                                     |
-| `message` | `string`                                   | —            | Status message text                             |
-| `id`      | `string`                                   | —            | ID for aria-describedby association             |
-| `variant` | `'attached' \| 'detached'`                 | `'attached'` | Visual variant (overlaps vs floats below input) |
+| Prop      | Type                                | Default      | Description                                     |
+| --------- | ----------------------------------- | ------------ | ----------------------------------------------- |
+| `type`    | `'error' \| 'warning' \| 'success'` | —            | Status type                                     |
+| `message` | `string`                            | —            | Status message text                             |
+| `id`      | `string`                            | —            | ID for aria-describedby association             |
+| `variant` | `'attached' \| 'detached'`          | `'attached'` | Visual variant (overlaps vs floats below input) |
 
 ## Usage
 

--- a/packages/core/src/Icon/README.md
+++ b/packages/core/src/Icon/README.md
@@ -4,6 +4,12 @@ Renders icons with XDS design system colors and sizes. Supports both direct SVG 
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSIcon} from '@xds/core/Icon';
+```
+
 ## Features
 
 - **Semantic Icon Names**: Use names like `'close'` or `'chevronDown'` — resolved from the theme's icon registry

--- a/packages/core/src/Link/README.md
+++ b/packages/core/src/Link/README.md
@@ -4,6 +4,12 @@ XDSLink component for styled anchor links with multiple variants and features, p
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSLink, XDSLinkProvider} from '@xds/core/Link';
+```
+
 ## Features
 
 - **Variants**: `default`, `subtle`, `inherit`
@@ -23,7 +29,9 @@ XDSLink component for styled anchor links with multiple variants and features, p
 Styled anchor link with variants, external link support, and polymorphic rendering.
 
 ```tsx
-<XDSLink label="Documentation" href="/docs">Documentation</XDSLink>
+<XDSLink label="Documentation" href="/docs">
+  Documentation
+</XDSLink>
 ```
 
 | Prop             | Type                                 | Default     | Description                                 |
@@ -51,10 +59,10 @@ Provider that sets the default link component for all XDS link components in the
 </XDSLinkProvider>
 ```
 
-| Prop        | Type                   | Default | Description                                      |
-| ----------- | ---------------------- | ------- | ------------------------------------------------ |
-| `component` | `XDSLinkComponentType` | —       | Component to use for all link elements (required)|
-| `children`  | `ReactNode`            | —       | Subtree                                          |
+| Prop        | Type                   | Default | Description                                       |
+| ----------- | ---------------------- | ------- | ------------------------------------------------- |
+| `component` | `XDSLinkComponentType` | —       | Component to use for all link elements (required) |
+| `children`  | `ReactNode`            | —       | Subtree                                           |
 
 ## Usage
 

--- a/packages/core/src/List/README.md
+++ b/packages/core/src/List/README.md
@@ -2,6 +2,12 @@
 
 Vertical list component for rendering collections of items with consistent spacing, dividers, and marker styles. Uses a composition model: `XDSList` wraps `XDSListItem` sub-components.
 
+## Import
+
+```tsx
+import {XDSList, XDSListItem} from '@xds/core/List';
+```
+
 ## Files
 
 <!-- SYNC: Update when files are added/removed -->

--- a/packages/core/src/NavIcon/README.md
+++ b/packages/core/src/NavIcon/README.md
@@ -1,8 +1,14 @@
-# /packages/core/src/NavIcon
+# NavIcon
 
 Circular icon container for navigation headers.
 
 <!-- SYNC: When files in this directory change, update this document. -->
+
+## Import
+
+```tsx
+import {XDSNavIcon} from '@xds/core/NavIcon';
+```
 
 ## Features
 

--- a/packages/core/src/NumberInput/README.md
+++ b/packages/core/src/NumberInput/README.md
@@ -4,6 +4,12 @@ A number input component for collecting numeric user input with validation.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSNumberInput} from '@xds/core/NumberInput';
+```
+
 ## Features
 
 - **Label Support**: Required label for accessibility (can be visually hidden)

--- a/packages/core/src/ProgressBar/README.md
+++ b/packages/core/src/ProgressBar/README.md
@@ -2,6 +2,12 @@
 
 A progress bar for displaying determinate or indeterminate progress.
 
+## Import
+
+```tsx
+import {XDSProgressBar} from '@xds/core/ProgressBar';
+```
+
 ## Exports
 
 | Export                  | Type      | Description                 |

--- a/packages/core/src/RadioList/README.md
+++ b/packages/core/src/RadioList/README.md
@@ -4,6 +4,12 @@ A radio group component for single-value selection from a list of options.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
+```
+
 ## Features
 
 - **Accessible**: Uses native `<input type="radio">` with proper `role="radiogroup"` and ARIA attributes
@@ -89,7 +95,10 @@ import { XDSRadioList, XDSRadioListItem } from '@xds/core/RadioList';
 Radio group container with field integration for label, description, and status.
 
 ```tsx
-<XDSRadioList label="Notification preference" value={selected} onChange={setSelected}>
+<XDSRadioList
+  label="Notification preference"
+  value={selected}
+  onChange={setSelected}>
   <XDSRadioListItem label="Email" value="email" />
   <XDSRadioListItem label="SMS" value="sms" />
 </XDSRadioList>

--- a/packages/core/src/Selector/README.md
+++ b/packages/core/src/Selector/README.md
@@ -2,6 +2,12 @@
 
 Dropdown selector for choosing from a list of options. Follows XDS input conventions with label, status, and field props.
 
+## Import
+
+```tsx
+import {XDSSelector, XDSSelectorItem} from '@xds/core/Selector';
+```
+
 ## Usage
 
 ```tsx
@@ -110,18 +116,14 @@ Dropdown selector for choosing from a list of options.
 Helper for custom item rendering:
 
 ```tsx
-<XDSSelectorItem
-  icon={UserIcon}
-  label="Primary text"
-  description="Secondary"
-/>
+<XDSSelectorItem icon={UserIcon} label="Primary text" description="Secondary" />
 ```
 
-| Prop          | Type          | Default | Description                       |
-| ------------- | ------------- | ------- | --------------------------------- |
-| `icon`        | `XDSIconType` | —       | Icon before the label             |
-| `label`       | `ReactNode`   | —       | Primary label text (required)     |
-| `description` | `ReactNode`   | —       | Secondary description text        |
+| Prop          | Type          | Default | Description                   |
+| ------------- | ------------- | ------- | ----------------------------- |
+| `icon`        | `XDSIconType` | —       | Icon before the label         |
+| `label`       | `ReactNode`   | —       | Primary label text (required) |
+| `description` | `ReactNode`   | —       | Secondary description text    |
 
 ## Keyboard
 

--- a/packages/core/src/SideNav/README.md
+++ b/packages/core/src/SideNav/README.md
@@ -2,6 +2,17 @@
 
 Sidebar navigation component for application pages. Supports sections, nested items, selected state, icons, and responsive collapse.
 
+## Import
+
+```tsx
+import {
+  XDSSideNav,
+  XDSSideNavHeader,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
+```
+
 ## Components
 
 ### XDSSideNav
@@ -13,21 +24,26 @@ Container with five zones: header, topContent, children (scrollable), footer, fo
   header={<XDSSideNavHeader icon={<AppIcon />} title="My App" titleHref="/" />}
   topContent={<XDSButton label="Create new" variant="primary" />}>
   <XDSSideNavSection title="Main">
-    <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected href="/dashboard" />
+    <XDSSideNavItem
+      label="Dashboard"
+      icon={HomeIcon}
+      isSelected
+      href="/dashboard"
+    />
     <XDSSideNavItem label="Projects" icon={FolderIcon} href="/projects" />
   </XDSSideNavSection>
 </XDSSideNav>
 ```
 
-| Prop          | Type           | Default | Description                                  |
-| ------------- | -------------- | ------- | -------------------------------------------- |
-| `header`      | `ReactNode`    | —       | Header area (XDSSideNavHeader). Sticky       |
-| `topContent`  | `ReactNode`    | —       | Content below header (e.g., create button)   |
-| `children`    | `ReactNode`    | —       | Navigation sections and items. Scrollable    |
-| `footer`      | `ReactNode`    | —       | Footer area above icon bar                   |
-| `footerIcons` | `ReactNode`    | —       | Footer icon bar                              |
-| `xstyle`      | `StyleXStyles` | —       | StyleX overrides                             |
-| `data-testid` | `string`       | —       | Test ID                                      |
+| Prop          | Type           | Default | Description                                |
+| ------------- | -------------- | ------- | ------------------------------------------ |
+| `header`      | `ReactNode`    | —       | Header area (XDSSideNavHeader). Sticky     |
+| `topContent`  | `ReactNode`    | —       | Content below header (e.g., create button) |
+| `children`    | `ReactNode`    | —       | Navigation sections and items. Scrollable  |
+| `footer`      | `ReactNode`    | —       | Footer area above icon bar                 |
+| `footerIcons` | `ReactNode`    | —       | Footer icon bar                            |
+| `xstyle`      | `StyleXStyles` | —       | StyleX overrides                           |
+| `data-testid` | `string`       | —       | Test ID                                    |
 
 ### XDSSideNavHeader
 
@@ -37,18 +53,18 @@ Product/suite/account header with smart interaction boundary logic.
 <XDSSideNavHeader icon={<AppIcon />} title="My App" titleHref="/" />
 ```
 
-| Prop             | Type           | Default | Description                       |
-| ---------------- | -------------- | ------- | --------------------------------- |
-| `icon`           | `ReactNode`    | —       | Product/app icon                  |
-| `title`          | `string`       | —       | Product/app name (required)       |
-| `titleHref`      | `string`       | —       | Link for the title                |
-| `supertitle`     | `string`       | —       | Text above the title              |
-| `supertitleHref` | `string`       | —       | Link for the supertitle           |
-| `subtitle`       | `string`       | —       | Text below the title              |
-| `subtitleHref`   | `string`       | —       | Link for the subtitle             |
-| `menu`           | `ReactNode`    | —       | Menu content in a popover         |
-| `xstyle`         | `StyleXStyles` | —       | StyleX overrides                  |
-| `data-testid`    | `string`       | —       | Test ID                           |
+| Prop             | Type           | Default | Description                 |
+| ---------------- | -------------- | ------- | --------------------------- |
+| `icon`           | `ReactNode`    | —       | Product/app icon            |
+| `title`          | `string`       | —       | Product/app name (required) |
+| `titleHref`      | `string`       | —       | Link for the title          |
+| `supertitle`     | `string`       | —       | Text above the title        |
+| `supertitleHref` | `string`       | —       | Link for the supertitle     |
+| `subtitle`       | `string`       | —       | Text below the title        |
+| `subtitleHref`   | `string`       | —       | Link for the subtitle       |
+| `menu`           | `ReactNode`    | —       | Menu content in a popover   |
+| `xstyle`         | `StyleXStyles` | —       | StyleX overrides            |
+| `data-testid`    | `string`       | —       | Test ID                     |
 
 ### XDSSideNavItem
 
@@ -65,19 +81,19 @@ Navigation item with icon, selected state, and nesting support.
 />
 ```
 
-| Prop           | Type                   | Default | Description                          |
-| -------------- | ---------------------- | ------- | ------------------------------------ |
-| `as`           | `XDSLinkComponentType` | —       | Custom link component                |
-| `label`        | `string`               | —       | Item label (required)                |
-| `icon`         | `XDSIconType`          | —       | Icon (outline variant)               |
-| `selectedIcon` | `XDSIconType`          | —       | Icon when selected (filled variant)  |
-| `isSelected`   | `boolean`              | `false` | Current page indicator               |
-| `isDisabled`   | `boolean`              | `false` | Disabled state                       |
-| `href`         | `string`               | —       | Navigation URL                       |
-| `onClick`      | `(e: MouseEvent) => void` | —    | Click handler                        |
-| `endContent`   | `ReactNode`            | —       | Right-side content (badges, counts)  |
-| `children`     | `ReactNode`            | —       | Sub-items for nesting                |
-| `data-testid`  | `string`               | —       | Test ID                              |
+| Prop           | Type                      | Default | Description                         |
+| -------------- | ------------------------- | ------- | ----------------------------------- |
+| `as`           | `XDSLinkComponentType`    | —       | Custom link component               |
+| `label`        | `string`                  | —       | Item label (required)               |
+| `icon`         | `XDSIconType`             | —       | Icon (outline variant)              |
+| `selectedIcon` | `XDSIconType`             | —       | Icon when selected (filled variant) |
+| `isSelected`   | `boolean`                 | `false` | Current page indicator              |
+| `isDisabled`   | `boolean`                 | `false` | Disabled state                      |
+| `href`         | `string`                  | —       | Navigation URL                      |
+| `onClick`      | `(e: MouseEvent) => void` | —       | Click handler                       |
+| `endContent`   | `ReactNode`               | —       | Right-side content (badges, counts) |
+| `children`     | `ReactNode`               | —       | Sub-items for nesting               |
+| `data-testid`  | `string`                  | —       | Test ID                             |
 
 ### XDSSideNavSection
 
@@ -90,14 +106,14 @@ Section grouping with optional title and end content.
 </XDSSideNavSection>
 ```
 
-| Prop             | Type        | Default | Description                                 |
-| ---------------- | ----------- | ------- | ------------------------------------------- |
-| `title`          | `string`    | —       | Section title (required)                    |
-| `subtitle`       | `string`    | —       | Section subtitle                            |
-| `children`       | `ReactNode` | —       | Section items                               |
-| `endContent`     | `ReactNode` | —       | Right-side content in section header        |
-| `isHeaderHidden` | `boolean`   | `false` | Visually hide header (still accessible)     |
-| `data-testid`    | `string`    | —       | Test ID                                     |
+| Prop             | Type        | Default | Description                             |
+| ---------------- | ----------- | ------- | --------------------------------------- |
+| `title`          | `string`    | —       | Section title (required)                |
+| `subtitle`       | `string`    | —       | Section subtitle                        |
+| `children`       | `ReactNode` | —       | Section items                           |
+| `endContent`     | `ReactNode` | —       | Right-side content in section header    |
+| `isHeaderHidden` | `boolean`   | `false` | Visually hide header (still accessible) |
+| `data-testid`    | `string`    | —       | Test ID                                 |
 
 ## Usage
 

--- a/packages/core/src/Skeleton/README.md
+++ b/packages/core/src/Skeleton/README.md
@@ -4,6 +4,12 @@ A placeholder loading component that displays an animated pulsing effect while c
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSSkeleton} from '@xds/core/Skeleton';
+```
+
 ## Features
 
 - **Pulsing Animation**: Smooth opacity animation using stepped timing for a subtle shimmer effect

--- a/packages/core/src/Slider/README.md
+++ b/packages/core/src/Slider/README.md
@@ -4,6 +4,12 @@ A slider component for selecting numeric values or ranges with full keyboard and
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSSlider} from '@xds/core/Slider';
+```
+
 ## Features
 
 - **Single & range modes**: Pass a `number` for single thumb, `[number, number]` for range

--- a/packages/core/src/Spinner/README.md
+++ b/packages/core/src/Spinner/README.md
@@ -4,6 +4,12 @@ A pure spinner component for indicating loading state. No layout, no text — ju
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSSpinner} from '@xds/core/Spinner';
+```
+
 ## Features
 
 - **CSS Border Animation**: Lightweight border-based spinner with smooth 360° rotation

--- a/packages/core/src/StatusDot/README.md
+++ b/packages/core/src/StatusDot/README.md
@@ -2,25 +2,31 @@
 
 A small colored dot indicator for status display (online/offline, severity, etc).
 
+## Import
+
+```tsx
+import {XDSStatusDot} from '@xds/core/StatusDot';
+```
+
 ## Exports
 
-| Export                | Type      | Description              |
-| --------------------- | --------- | ------------------------ |
+| Export                | Type      | Description               |
+| --------------------- | --------- | ------------------------- |
 | `XDSStatusDot`        | Component | Main status dot component |
-| `XDSStatusDotProps`   | Type      | Props interface          |
-| `XDSStatusDotVariant` | Type      | Variant union type       |
-| `XDSStatusDotSize`    | Type      | Size union type          |
+| `XDSStatusDotProps`   | Type      | Props interface           |
+| `XDSStatusDotVariant` | Type      | Variant union type        |
+| `XDSStatusDotSize`    | Type      | Size union type           |
 
 ## Props
 
-| Prop          | Type                                                              | Default  | Description                                      |
-| ------------- | ----------------------------------------------------------------- | -------- | ------------------------------------------------ |
-| `variant`     | `'positive' \| 'warning' \| 'negative' \| 'info' \| 'neutral'`   | -        | Semantic color variant (required)                |
-| `size`        | `'sm' \| 'md'`                                                    | `'md'`   | Dot size: sm=8px, md=10px                        |
-| `label`       | `string`                                                          | -        | Accessible label (required)                      |
-| `isPulsing`   | `boolean`                                                         | `false`  | Pulse animation, respects prefers-reduced-motion |
-| `xstyle`      | `StyleXStyles`                                                    | -        | Optional StyleX style override                   |
-| `data-testid` | `string`                                                          | -        | Optional test ID                                 |
+| Prop          | Type                                                           | Default | Description                                      |
+| ------------- | -------------------------------------------------------------- | ------- | ------------------------------------------------ |
+| `variant`     | `'positive' \| 'warning' \| 'negative' \| 'info' \| 'neutral'` | -       | Semantic color variant (required)                |
+| `size`        | `'sm' \| 'md'`                                                 | `'md'`  | Dot size: sm=8px, md=10px                        |
+| `label`       | `string`                                                       | -       | Accessible label (required)                      |
+| `isPulsing`   | `boolean`                                                      | `false` | Pulse animation, respects prefers-reduced-motion |
+| `xstyle`      | `StyleXStyles`                                                 | -       | Optional StyleX style override                   |
+| `data-testid` | `string`                                                       | -       | Optional test ID                                 |
 
 ## Usage
 

--- a/packages/core/src/Switch/README.md
+++ b/packages/core/src/Switch/README.md
@@ -4,6 +4,12 @@ A toggle switch component for boolean values with integrated label support.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSSwitch} from '@xds/core/Switch';
+```
+
 ## Features
 
 - **Boolean Toggle**: Clean on/off switch for boolean values (40x24px with 20px thumb)

--- a/packages/core/src/TabList/README.md
+++ b/packages/core/src/TabList/README.md
@@ -4,6 +4,12 @@ XDSTabList component for tab navigation with overflow menu support.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSTabList, XDSTab, XDSTabMenu} from '@xds/core/TabList';
+```
+
 ## Features
 
 - **Context-based communication**: `XDSTabListContext` passes value/onChange/size from XDSTabList to children

--- a/packages/core/src/Table/README.md
+++ b/packages/core/src/Table/README.md
@@ -5,6 +5,17 @@ XDSBadge, XDSStatusDot, XDSText, XDSAvatar, and layout primitives.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {
+  XDSTable,
+  XDSTableRow,
+  XDSTableCell,
+  XDSTableHeaderCell,
+} from '@xds/core/Table';
+```
+
 ## Components
 
 | File                     | Export               | Purpose                                                      |

--- a/packages/core/src/Text/README.md
+++ b/packages/core/src/Text/README.md
@@ -4,6 +4,12 @@ Typography components for the XDS design system.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSText, XDSHeading} from '@xds/core/Text';
+```
+
 ## Components
 
 | File                 | Export                    | Purpose                                                    |
@@ -27,50 +33,54 @@ Typography components for the XDS design system.
 Body text with semantic variants and truncation support.
 
 ```tsx
-<XDSText type="body" color="primary">Body text content.</XDSText>
+<XDSText type="body" color="primary">
+  Body text content.
+</XDSText>
 ```
 
-| Prop                 | Type                                    | Default    | Description                                   |
-| -------------------- | --------------------------------------- | ---------- | --------------------------------------------- |
-| `type`               | `XDSTextType`                           | —          | Semantic text type (body, supporting, label)  |
-| `size`               | `XDSTextSize`                           | —          | Explicit font size override                   |
-| `color`              | `XDSTextColor`                          | —          | Text color (defaults vary by type)            |
-| `weight`             | `XDSTextWeight`                         | —          | Font weight override                          |
-| `display`            | `XDSTextDisplay`                        | `'inline'` | Display type                                  |
-| `maxLines`           | `number`                                | `0`        | Max lines before truncation                   |
-| `hasTruncateTooltip` | `boolean \| LayerPlacement`             | `true`     | Tooltip for truncated text                    |
-| `wordBreak`          | `XDSWordBreak`                          | —          | Word break behavior                           |
-| `textWrap`           | `XDSTextWrap`                           | —          | Text wrapping behavior                        |
-| `hasCapsize`         | `boolean`                               | `false`    | Enable optical alignment (text-box-trim)      |
-| `hasStrikethrough`   | `boolean`                               | `false`    | Strikethrough decoration                      |
-| `hasTabularNumbers`  | `boolean`                               | `false`    | Use tabular (monospace) numbers               |
-| `as`                 | `'span' \| 'p' \| 'div' \| 'label'`    | `'span'`   | HTML element to render                        |
-| `xstyle`             | `StyleXStyles`                          | —          | Constrained styles for layout integration     |
-| `children`           | `ReactNode`                             | —          | Text content                                  |
+| Prop                 | Type                                | Default    | Description                                  |
+| -------------------- | ----------------------------------- | ---------- | -------------------------------------------- |
+| `type`               | `XDSTextType`                       | —          | Semantic text type (body, supporting, label) |
+| `size`               | `XDSTextSize`                       | —          | Explicit font size override                  |
+| `color`              | `XDSTextColor`                      | —          | Text color (defaults vary by type)           |
+| `weight`             | `XDSTextWeight`                     | —          | Font weight override                         |
+| `display`            | `XDSTextDisplay`                    | `'inline'` | Display type                                 |
+| `maxLines`           | `number`                            | `0`        | Max lines before truncation                  |
+| `hasTruncateTooltip` | `boolean \| LayerPlacement`         | `true`     | Tooltip for truncated text                   |
+| `wordBreak`          | `XDSWordBreak`                      | —          | Word break behavior                          |
+| `textWrap`           | `XDSTextWrap`                       | —          | Text wrapping behavior                       |
+| `hasCapsize`         | `boolean`                           | `false`    | Enable optical alignment (text-box-trim)     |
+| `hasStrikethrough`   | `boolean`                           | `false`    | Strikethrough decoration                     |
+| `hasTabularNumbers`  | `boolean`                           | `false`    | Use tabular (monospace) numbers              |
+| `as`                 | `'span' \| 'p' \| 'div' \| 'label'` | `'span'`   | HTML element to render                       |
+| `xstyle`             | `StyleXStyles`                      | —          | Constrained styles for layout integration    |
+| `children`           | `ReactNode`                         | —          | Text content                                 |
 
 ### XDSHeading
 
 Headings with level-based styling and optional accessibility level override.
 
 ```tsx
-<XDSHeading level={1} size="2xl">Page Title</XDSHeading>
+<XDSHeading level={1} size="2xl">
+  Page Title
+</XDSHeading>
 ```
 
-| Prop                 | Type                        | Default     | Description                                    |
-| -------------------- | --------------------------- | ----------- | ---------------------------------------------- |
-| `level`              | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | —        | Visual heading level (required)                |
-| `accessibilityLevel` | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | same as `level` | ARIA level override               |
-| `variant`            | `'default' \| 'editorial'`  | `'default'` | Visual variant (dense vs editorial scale)      |
-| `color`              | `XDSTextColor`              | `'primary'` | Text color                                     |
-| `display`            | `XDSTextDisplay`            | `'block'`   | Display type                                   |
-| `maxLines`           | `number`                    | `0`         | Max lines before truncation                    |
-| `hasTruncateTooltip` | `boolean \| LayerPlacement` | `true`      | Tooltip for truncated text                     |
-| `wordBreak`          | `XDSWordBreak`              | —           | Word break behavior                            |
-| `textWrap`           | `XDSTextWrap`               | —           | Text wrapping behavior                         |
-| `hasCapsize`         | `boolean`                   | `false`     | Enable optical alignment                       |
-| `hasStrikethrough`   | `boolean`                   | `false`     | Strikethrough decoration                       |
-| `xstyle`             | `StyleXStyles`              | —           | Constrained styles for layout integration      |
-| `children`           | `ReactNode`                 | —           | Heading content                                |
+| Prop                 | Type                         | Default         | Description                               |
+| -------------------- | ---------------------------- | --------------- | ----------------------------------------- |
+| `level`              | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | —               | Visual heading level (required)           |
+| `accessibilityLevel` | `1 \| 2 \| 3 \| 4 \| 5 \| 6` | same as `level` | ARIA level override                       |
+| `variant`            | `'default' \| 'editorial'`   | `'default'`     | Visual variant (dense vs editorial scale) |
+| `color`              | `XDSTextColor`               | `'primary'`     | Text color                                |
+| `display`            | `XDSTextDisplay`             | `'block'`       | Display type                              |
+| `maxLines`           | `number`                     | `0`             | Max lines before truncation               |
+| `hasTruncateTooltip` | `boolean \| LayerPlacement`  | `true`          | Tooltip for truncated text                |
+| `wordBreak`          | `XDSWordBreak`               | —               | Word break behavior                       |
+| `textWrap`           | `XDSTextWrap`                | —               | Text wrapping behavior                    |
+| `hasCapsize`         | `boolean`                    | `false`         | Enable optical alignment                  |
+| `hasStrikethrough`   | `boolean`                    | `false`         | Strikethrough decoration                  |
+| `xstyle`             | `StyleXStyles`               | —               | Constrained styles for layout integration |
+| `children`           | `ReactNode`                  | —               | Heading content                           |
 
 ### XDSFontWrapper
 
@@ -82,11 +92,11 @@ Wrapper that applies typography styles to native HTML (for user content/markdown
 </XDSFontWrapper>
 ```
 
-| Prop          | Type                         | Default     | Description                     |
-| ------------- | ---------------------------- | ----------- | ------------------------------- |
-| `variant`     | `'default' \| 'editorial'`   | `'default'` | Heading scale variant           |
-| `children`    | `ReactNode`                  | —           | Content to style                |
-| `data-testid` | `string`                     | —           | Test ID                         |
+| Prop          | Type                       | Default     | Description           |
+| ------------- | -------------------------- | ----------- | --------------------- |
+| `variant`     | `'default' \| 'editorial'` | `'default'` | Heading scale variant |
+| `children`    | `ReactNode`                | —           | Content to style      |
+| `data-testid` | `string`                   | —           | Test ID               |
 
 ### useXDSFontWrapperStyles
 

--- a/packages/core/src/TextArea/README.md
+++ b/packages/core/src/TextArea/README.md
@@ -4,6 +4,12 @@ A multi-line text input component for collecting longer user input.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSTextArea} from '@xds/core/TextArea';
+```
+
 ## Features
 
 - **Label Support**: Required label for accessibility (can be visually hidden)

--- a/packages/core/src/TextInput/README.md
+++ b/packages/core/src/TextInput/README.md
@@ -4,6 +4,12 @@ A text input component for collecting user text input.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSTextInput} from '@xds/core/TextInput';
+```
+
 ## Features
 
 - **Label Support**: Required label for accessibility (can be visually hidden)

--- a/packages/core/src/Token/README.md
+++ b/packages/core/src/Token/README.md
@@ -2,6 +2,12 @@
 
 A chip/tag component for displaying entities inline. Renders as a `<span>` by default, `<button>` when `onClick` is provided, or `<a>` when `href` is provided.
 
+## Import
+
+```tsx
+import {XDSToken} from '@xds/core/Token';
+```
+
 ## Exports
 
 | Export          | Type      | Description          |

--- a/packages/core/src/Tokenizer/README.md
+++ b/packages/core/src/Tokenizer/README.md
@@ -1,4 +1,4 @@
-# /packages/core/src/Tokenizer
+# Tokenizer
 
 Multi-select typeahead with token chips for selected items.
 
@@ -43,7 +43,7 @@ const source = {
 />;
 ```
 
-## Key Props
+## Props
 
 | Prop           | Type                            | Default  | Description                             |
 | -------------- | ------------------------------- | -------- | --------------------------------------- |

--- a/packages/core/src/TopNav/README.md
+++ b/packages/core/src/TopNav/README.md
@@ -4,6 +4,12 @@ Top navigation bar component for application headers.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSTopNav, XDSTopNavTitle, XDSTopNavItem} from '@xds/core/TopNav';
+```
+
 ## Features
 
 - **Slot-based layout**: `title`, `startContent`, `endContent` for flexible organization
@@ -69,7 +75,9 @@ For the circular icon container, use `XDSNavIcon` from `@xds/core/NavIcon`.
 <XDSTopNav
   label="Main navigation"
   title={<XDSTopNavTitle title="My App" href="/" />}
-  startContent={<XDSTopNavItem label="Dashboard" href="/dashboard" isSelected />}
+  startContent={
+    <XDSTopNavItem label="Dashboard" href="/dashboard" isSelected />
+  }
   endContent={<XDSButton label="Profile" variant="ghost" />}
 />
 ```
@@ -84,7 +92,11 @@ For the circular icon container, use `XDSNavIcon` from `@xds/core/NavIcon`.
 ### XDSTopNavTitle
 
 ```tsx
-<XDSTopNavTitle title="My App" logo={<XDSNavIcon icon={<HomeIcon />} />} href="/" />
+<XDSTopNavTitle
+  title="My App"
+  logo={<XDSNavIcon icon={<HomeIcon />} />}
+  href="/"
+/>
 ```
 
 | Prop    | Type        | Default | Description                      |
@@ -96,7 +108,12 @@ For the circular icon container, use `XDSNavIcon` from `@xds/core/NavIcon`.
 ### XDSTopNavItem
 
 ```tsx
-<XDSTopNavItem label="Dashboard" href="/dashboard" isSelected icon={<HomeIcon />} />
+<XDSTopNavItem
+  label="Dashboard"
+  href="/dashboard"
+  isSelected
+  icon={<HomeIcon />}
+/>
 ```
 
 | Prop         | Type        | Default | Description                     |

--- a/packages/core/src/Typeahead/README.md
+++ b/packages/core/src/Typeahead/README.md
@@ -1,4 +1,4 @@
-# /packages/core/src/Typeahead
+# Typeahead
 
 Searchable dropdown components for single-item selection with keyboard navigation.
 
@@ -64,7 +64,7 @@ type XDSSearchableItem = {
 };
 ```
 
-## Key Props
+## Props
 
 | Prop                | Type                        | Default  | Description                     |
 | ------------------- | --------------------------- | -------- | ------------------------------- |

--- a/packages/core/src/theme/README.md
+++ b/packages/core/src/theme/README.md
@@ -4,6 +4,12 @@ XDS theme provider and design tokens.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
+## Import
+
+```tsx
+import {XDSTheme, useXDSTheme} from '@xds/core/theme';
+```
+
 ## Features
 
 - **XDSTheme Provider**: Wraps app to provide CSS variables and icon registry


### PR DESCRIPTION
## What

Fixes README structure issues that break the XDS CLI's doc parser (`xds component --brief`, `--compact`, `--props`).

### Changes

- **Fix old path-style titles** in 3 READMEs — `# /packages/core/src/Foo` → `# Foo`
- **Rename `Key Props` → `Props`** in 2 READMEs — CLI's `extractBrief()` regex doesn't match `Key Props`
- **Add `## Import` sections** to 34 READMEs — correct import paths from `package.json` exports
- **Add `## Usage` section** to AppShell README

### Why

The CLI parser uses specific regex patterns to extract props, examples, and descriptions from READMEs. These structural issues caused silent data loss in CLI output — props tables that exist in the README but don't show up in `--brief` mode.

## Checklist
- [ ] CLI `--brief` output shows props for Tokenizer and Typeahead
- [ ] All READMEs have `## Import` with correct paths
- [ ] No `# /` path-style titles remain
- [ ] `yarn build` passes

---
*Crafted with care by Navi — Night Watch Doc Reviewer*