### PR TITLE
refactor(Banner): rename endButton → endContent for API consistency

### DIFF
--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -77,7 +77,7 @@ export const WithEndButton: Story = {
     status: 'info',
     title: 'New update available',
     description: 'Version 2.0 is ready to install.',
-    endButton: <XDSButton label="Update now" variant="primary" size="sm" />,
+    endContent: <XDSButton label="Update now" variant="primary" size="sm" />,
   },
 };
 
@@ -115,7 +115,7 @@ export const CollapsibleContent: Story = {
     status: 'info',
     title: 'Emphasized Text',
     description: 'Description text',
-    endButton: <XDSButton label="Button" variant="secondary" size="sm" />,
+    endContent: <XDSButton label="Button" variant="secondary" size="sm" />,
     isDismissable: true,
     children: (
       <div
@@ -138,7 +138,7 @@ export const CollapsibleContentExpanded: Story = {
     title: 'Emphasized Text',
     description: 'Description text',
     isDefaultExpanded: true,
-    endButton: <XDSButton label="Button" variant="secondary" size="sm" />,
+    endContent: <XDSButton label="Button" variant="secondary" size="sm" />,
     isDismissable: true,
     children: (
       <div
@@ -177,7 +177,7 @@ export const ContentAreaWithAction: Story = {
     status: 'warning',
     title: 'Configuration changes detected',
     description: 'Review the changes before they take effect.',
-    endButton: <XDSButton label="Review" variant="secondary" size="sm" />,
+    endContent: <XDSButton label="Review" variant="secondary" size="sm" />,
     isDismissable: true,
     isDefaultExpanded: true,
     children: (
@@ -227,7 +227,7 @@ export const AllFeatures: Story = {
       <XDSBanner
         status="info"
         title="With action button"
-        endButton={
+        endContent={
           <XDSButton label="Learn more" variant="secondary" size="sm" />
         }
       />

--- a/packages/core/src/Banner/README.md
+++ b/packages/core/src/Banner/README.md
@@ -51,7 +51,7 @@ import {XDSBanner} from '@xds/core/Banner';
 | `icon`          | `ReactNode`                                   | —        | Override the default status icon                      |
 | `isDismissable` | `boolean`                                     | `false`  | Whether the banner can be dismissed                   |
 | `onDismiss`     | `() => void`                                  | —        | Called on dismiss (banner hides itself regardless)    |
-| `endButton`     | `ReactNode`                                   | —        | Action button in the header area (end-aligned)        |
+| `endContent`    | `ReactNode`                                   | —        | Action button in the header area (end-aligned)        |
 | `variant`       | `'card' \| 'section'`                         | `'card'` | Visual variant                                        |
 | `children`      | `ReactNode`                                   | —        | Content rendered in card-background area below header |
 | `xstyle`        | `StyleXStyles`                                | —        | StyleX overrides                                      |

--- a/packages/core/src/Banner/XDSBanner.test.tsx
+++ b/packages/core/src/Banner/XDSBanner.test.tsx
@@ -135,12 +135,12 @@ describe('XDSBanner', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders endButton', () => {
+  it('renders endContent', () => {
     render(
       <XDSBanner
         status="info"
         title="With Action"
-        endButton={<button data-testid="end-btn">Action</button>}
+        endContent={<button data-testid="end-btn">Action</button>}
       />,
     );
     expect(screen.getByTestId('end-btn')).toBeInTheDocument();

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -90,9 +90,9 @@ export interface XDSBannerProps {
    * Typically an XDSButton with a secondary or ghost variant.
    *
    * @example
-   * endButton={<XDSButton label="Retry" variant="ghost" onClick={handleRetry} />}
+   * endContent={<XDSButton label="Retry" variant="ghost" onClick={handleRetry} />}
    */
-  endButton?: ReactNode;
+  endContent?: ReactNode;
   /**
    * Visual variant of the banner.
    * - `card`: standalone card with border-radius
@@ -328,7 +328,7 @@ export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
       icon,
       isDismissable = false,
       onDismiss,
-      endButton,
+      endContent,
       variant = 'card',
       isDefaultExpanded = false,
       children,
@@ -358,10 +358,10 @@ export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
     };
 
     // Show the end area if there are actions, dismiss, or a collapsible toggle
-    const showEndArea = endButton != null || isDismissable || hasChildren;
+    const showEndArea = endContent != null || isDismissable || hasChildren;
     // Center items vertically when there's only a title (no description)
     // and the banner has action buttons
-    const hasActions = endButton != null || isDismissable;
+    const hasActions = endContent != null || isDismissable;
     const isSingleLine = description == null && hasActions;
 
     return (
@@ -397,7 +397,7 @@ export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
           </div>
           {showEndArea && (
             <div {...stylex.props(styles.endArea, edgeSignals.end)}>
-              {endButton}
+              {endContent}
               {hasChildren && (
                 <XDSButton
                   variant="ghost"


### PR DESCRIPTION
## Summary
Renames `endButton` → `endContent` on `XDSBanner` to align with the 5 other XDS components that use `endContent` for end-positioned slots:
- `XDSListItem`
- `XDSRadioListItem`
- `XDSSideNavItem`
- `XDSSideNavSection`
- `XDSTopNav`

## Why
Positional names (`endContent`) are better than semantic names (`endButton`) for flexible `ReactNode` slots. A spinner or link in `endButton` is semantically wrong — it's not a button. `endContent` describes WHERE the content goes, not WHAT it is.

This was validated by vibe testing during the Toast component spec review — `endContent` beat `action` because positional names never mislead.

## Changes
- `XDSBanner`: `endButton` → `endContent` (prop, destructuring, JSDoc, usage)
- Tests: updated prop name
- Stories: updated prop name
- README: updated prop name

## Breaking Change
This is a breaking rename. Consumers need to update `endButton` → `endContent`. Search-and-replace.

Closes #436