### PR TITLE
refactor(inputs): extract shared input appearance styles

### DIFF
--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -27,15 +27,21 @@ import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   sizeVars,
-  spacingVars,
   radiusVars,
   elevationVars,
-  transitionVars,
   typographyVars,
   textSizeVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
-import {XDSField, type XDSInputStatus, type XDSInputStatusType} from '../Field';
+import {
+  XDSField,
+  type XDSInputStatus,
+  type XDSInputStatusType,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '../Field';
 import {XDSIcon} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 import {
@@ -47,43 +53,6 @@ import {useXDSPopover} from '../Layer';
 import {parseDateInput, formatDisplayDate} from '../utils';
 
 const styles = stylex.create({
-  wrapper: {
-    boxSizing: 'border-box',
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: 1,
-    borderStyle: 'solid',
-    borderColor: {
-      default: colorVars['--color-divider-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-divider-high-contrast'],
-      },
-    },
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline, box-shadow',
-    transitionDuration: transitionVars['--transition-fast'],
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover'],
-      },
-    },
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
-    },
-    outlineOffset: '0',
-  },
-  wrapperDisabled: {
-    cursor: 'not-allowed',
-    opacity: 0.5,
-    borderColor: colorVars['--color-divider-emphasized'],
-  },
   iconButton: {
     display: 'flex',
     alignItems: 'center',
@@ -143,67 +112,6 @@ const sizeStyles = stylex.create({
   },
   lg: {
     height: sizeVars['--size-lg'],
-  },
-});
-
-const statusBorderStyles = stylex.create({
-  warning: {
-    borderColor: colorVars['--color-warning'],
-  },
-  error: {
-    borderColor: colorVars['--color-negative'],
-  },
-  success: {
-    borderColor: colorVars['--color-positive'],
-  },
-});
-
-const statusFocusStyles = stylex.create({
-  warning: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
-    },
-  },
-  error: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
-    },
-  },
-  success: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
-    },
-  },
-});
-const statusHoverShadowStyles = stylex.create({
-  warning: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-warning'],
-      },
-    },
-  },
-  error: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
-      },
-    },
-  },
-  success: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-success'],
-      },
-    },
   },
 });
 
@@ -568,12 +476,12 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
         <div
           ref={popover.triggerRef}
           {...stylex.props(
-            styles.wrapper,
+            inputWrapperStyles.base,
             sizeStyles[size],
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
+            isDisabled && inputWrapperStyles.disabled,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
             wrapperOverride,
           )}>
           <button

--- a/packages/core/src/Field/README.md
+++ b/packages/core/src/Field/README.md
@@ -25,18 +25,18 @@ Form field wrapper that provides label, description, and optional/required indic
 </XDSField>
 ```
 
-| Prop             | Type          | Default | Description                                           |
-| ---------------- | ------------- | ------- | ----------------------------------------------------- |
-| `label`          | `string`      | —       | Label text (required for accessibility)               |
-| `isLabelHidden`  | `boolean`     | `false` | Visually hide the label                               |
-| `description`    | `string`      | —       | Description text between label and input              |
-| `inputID`        | `string`      | —       | ID for the input (used for label's htmlFor)           |
-| `descriptionID`  | `string`      | —       | ID for the description (for aria-describedby)         |
-| `isOptional`     | `boolean`     | `false` | Show "Optional" indicator                             |
-| `isRequired`     | `boolean`     | `false` | Show "Required" indicator                             |
-| `labelStartIcon` | `XDSIconType` | —       | Icon before the label text                            |
-| `labelTooltip`   | `string`      | —       | Tooltip text for info icon at end of label            |
-| `children`       | `ReactNode`   | —       | The input or control to render                        |
+| Prop             | Type          | Default | Description                                   |
+| ---------------- | ------------- | ------- | --------------------------------------------- |
+| `label`          | `string`      | —       | Label text (required for accessibility)       |
+| `isLabelHidden`  | `boolean`     | `false` | Visually hide the label                       |
+| `description`    | `string`      | —       | Description text between label and input      |
+| `inputID`        | `string`      | —       | ID for the input (used for label's htmlFor)   |
+| `descriptionID`  | `string`      | —       | ID for the description (for aria-describedby) |
+| `isOptional`     | `boolean`     | `false` | Show "Optional" indicator                     |
+| `isRequired`     | `boolean`     | `false` | Show "Required" indicator                     |
+| `labelStartIcon` | `XDSIconType` | —       | Icon before the label text                    |
+| `labelTooltip`   | `string`      | —       | Tooltip text for info icon at end of label    |
+| `children`       | `ReactNode`   | —       | The input or control to render                |
 
 ### XDSFieldLabel
 
@@ -46,16 +46,16 @@ Standalone label component with optional/required indicators and tooltip support
 <XDSFieldLabel label="Username" inputID={id} isRequired />
 ```
 
-| Prop             | Type          | Default | Description                                 |
-| ---------------- | ------------- | ------- | ------------------------------------------- |
-| `label`          | `string`      | —       | Label text (required)                       |
-| `inputID`        | `string`      | —       | ID of the input this label is for           |
-| `isLabelHidden`  | `boolean`     | `false` | Visually hide the label                     |
-| `isDisabled`     | `boolean`     | `false` | Whether the associated input is disabled    |
-| `isOptional`     | `boolean`     | `false` | Show "Optional" indicator                   |
-| `isRequired`     | `boolean`     | `false` | Show "Required" indicator                   |
-| `startIcon`      | `XDSIconType` | —       | Icon before the label text                  |
-| `tooltip`        | `string`      | —       | Tooltip text for info icon at end of label  |
+| Prop            | Type          | Default | Description                                |
+| --------------- | ------------- | ------- | ------------------------------------------ |
+| `label`         | `string`      | —       | Label text (required)                      |
+| `inputID`       | `string`      | —       | ID of the input this label is for          |
+| `isLabelHidden` | `boolean`     | `false` | Visually hide the label                    |
+| `isDisabled`    | `boolean`     | `false` | Whether the associated input is disabled   |
+| `isOptional`    | `boolean`     | `false` | Show "Optional" indicator                  |
+| `isRequired`    | `boolean`     | `false` | Show "Required" indicator                  |
+| `startIcon`     | `XDSIconType` | —       | Icon before the label text                 |
+| `tooltip`       | `string`      | —       | Tooltip text for info icon at end of label |
 
 ### XDSFieldStatus
 
@@ -65,12 +65,12 @@ Status message component for form field validation feedback.
 <XDSFieldStatus type="error" message="This field is required" />
 ```
 
-| Prop      | Type                                       | Default      | Description                                     |
-| --------- | ------------------------------------------ | ------------ | ----------------------------------------------- |
-| `type`    | `'error' \| 'warning' \| 'success'`        | —            | Status type                                     |
-| `message` | `string`                                   | —            | Status message text                             |
-| `id`      | `string`                                   | —            | ID for aria-describedby association             |
-| `variant` | `'attached' \| 'detached'`                 | `'attached'` | Visual variant (overlaps vs floats below input) |
+| Prop      | Type                                | Default      | Description                                     |
+| --------- | ----------------------------------- | ------------ | ----------------------------------------------- |
+| `type`    | `'error' \| 'warning' \| 'success'` | —            | Status type                                     |
+| `message` | `string`                            | —            | Status message text                             |
+| `id`      | `string`                            | —            | ID for aria-describedby association             |
+| `variant` | `'attached' \| 'detached'`          | `'attached'` | Visual variant (overlaps vs floats below input) |
 
 ## Usage
 
@@ -167,11 +167,16 @@ const theme: Theme = {
 
 ## Files
 
-| File                | Role  | Purpose                     |
-| ------------------- | ----- | --------------------------- |
-| `index.ts`          | Entry | Exports component and types |
-| `XDSField.tsx`      | Core  | Component implementation    |
-| `XDSField.test.tsx` | Test  | Unit tests                  |
+| File                     | Role   | Purpose                                           |
+| ------------------------ | ------ | ------------------------------------------------- |
+| `index.ts`               | Entry  | Exports component, types, and shared input styles |
+| `XDSField.tsx`           | Core   | Component implementation                          |
+| `XDSFieldLabel.tsx`      | Core   | Standalone label component                        |
+| `XDSFieldStatus.tsx`     | Core   | Status message component                          |
+| `XDSField.test.tsx`      | Test   | Unit tests                                        |
+| `XDSFieldLabel.test.tsx` | Test   | Unit tests for label component                    |
+| `types.ts`               | Types  | Shared input types (status, size)                 |
+| `inputStyles.stylex.ts`  | Styles | Shared input wrapper appearance styles            |
 
 ## Implementation Notes
 

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -23,3 +23,12 @@ export type {
 
 // Shared input types
 export type {XDSInputStatus, XDSInputStatusType, XDSInputSize} from './types';
+
+// Shared input styles
+export {
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+  inputStatusFocusStyles,
+} from './inputStyles.stylex';

--- a/packages/core/src/Field/inputStyles.stylex.ts
+++ b/packages/core/src/Field/inputStyles.stylex.ts
@@ -1,0 +1,167 @@
+/**
+ * @file inputStyles.stylex.ts
+ * @input Uses theme tokens (color, spacing, radius, elevation, transition)
+ * @output Exports shared input wrapper appearance styles
+ * @position Shared styles consumed by TextInput, TextArea, NumberInput, DateInput,
+ *   TimeInput, Selector, Typeahead, and Tokenizer
+ *
+ * Centralizes the input wrapper appearance (borders, focus outlines, hover shadows,
+ * disabled state, status variants) so all input components stay in sync.
+ * Individual components layer their own overrides (padding, alignment, etc.)
+ * via stylex.props composition.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  elevationVars,
+  transitionVars,
+} from '../theme/tokens.stylex';
+
+/**
+ * Base wrapper styles shared by all input components.
+ * Components apply these as a foundation and override specific properties
+ * (e.g. padding, alignItems, gap) as needed.
+ */
+export const inputWrapperStyles = stylex.create({
+  base: {
+    boxSizing: 'border-box',
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    borderWidth: '1px',
+    borderStyle: 'solid',
+    borderColor: {
+      default: colorVars['--color-divider-emphasized'],
+      ':hover': {
+        '@media (hover: hover)': colorVars['--color-divider-high-contrast'],
+      },
+    },
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-surface'],
+    transitionProperty: 'border-color, outline, box-shadow',
+    transitionDuration: transitionVars['--transition-fast'],
+    boxShadow: {
+      default: 'none',
+      ':hover': {
+        '@media (hover: hover)': elevationVars['--elevation-input-hover'],
+      },
+    },
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: '0',
+  },
+  disabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+    borderColor: colorVars['--color-divider-emphasized'],
+  },
+});
+
+/**
+ * Status border colors for input wrappers.
+ * Keyed by XDSInputStatusType.
+ */
+export const inputStatusBorderStyles = stylex.create({
+  warning: {
+    borderColor: colorVars['--color-warning'],
+  },
+  error: {
+    borderColor: colorVars['--color-negative'],
+  },
+  success: {
+    borderColor: colorVars['--color-positive'],
+  },
+});
+
+/**
+ * Status hover shadow styles for input wrappers.
+ * Keyed by XDSInputStatusType.
+ */
+export const inputStatusHoverShadowStyles = stylex.create({
+  warning: {
+    boxShadow: {
+      default: 'none',
+      ':hover': {
+        '@media (hover: hover)':
+          elevationVars['--elevation-input-hover-warning'],
+      },
+    },
+  },
+  error: {
+    boxShadow: {
+      default: 'none',
+      ':hover': {
+        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
+      },
+    },
+  },
+  success: {
+    boxShadow: {
+      default: 'none',
+      ':hover': {
+        '@media (hover: hover)':
+          elevationVars['--elevation-input-hover-success'],
+      },
+    },
+  },
+});
+
+/**
+ * Status focus outline styles using :focus-within.
+ * Used by input wrappers that contain a child input/textarea element.
+ * Keyed by XDSInputStatusType.
+ */
+export const inputStatusFocusWithinStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});
+
+/**
+ * Status focus outline styles using :focus.
+ * Used by components where the wrapper itself receives focus (e.g. Selector button).
+ * Keyed by XDSInputStatusType.
+ */
+export const inputStatusFocusStyles = stylex.create({
+  warning: {
+    outline: {
+      default: 'none',
+      ':focus': `1px solid ${colorVars['--color-focus-outline-warning']}`,
+    },
+  },
+  error: {
+    outline: {
+      default: 'none',
+      ':focus': `1px solid ${colorVars['--color-focus-outline-error']}`,
+    },
+  },
+  success: {
+    outline: {
+      default: 'none',
+      ':focus': `1px solid ${colorVars['--color-focus-outline-success']}`,
+    },
+  },
+});

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -27,55 +27,24 @@ import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   sizeVars,
-  spacingVars,
-  radiusVars,
-  elevationVars,
-  transitionVars,
   typographyVars,
   textSizeVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
-import {XDSField, type XDSInputStatus, type XDSInputStatusType} from '../Field';
+import {
+  XDSField,
+  type XDSInputStatus,
+  type XDSInputStatusType,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '../Field';
 import {XDSIcon, type XDSIconType} from '../Icon';
 
 const styles = stylex.create({
   wrapper: {
-    boxSizing: 'border-box',
-    position: 'relative',
     zIndex: 1,
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: {
-      default: colorVars['--color-divider-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-divider-high-contrast'],
-      },
-    },
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline, box-shadow',
-    transitionDuration: transitionVars['--transition-fast'],
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover'],
-      },
-    },
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
-    },
-    outlineOffset: '0',
-  },
-  wrapperDisabled: {
-    cursor: 'not-allowed',
-    opacity: 0.5,
-    borderColor: colorVars['--color-divider-emphasized'],
   },
   input: {
     display: 'block',
@@ -118,67 +87,6 @@ const sizeStyles = stylex.create({
   },
   lg: {
     height: sizeVars['--size-lg'],
-  },
-});
-
-const statusBorderStyles = stylex.create({
-  warning: {
-    borderColor: colorVars['--color-warning'],
-  },
-  error: {
-    borderColor: colorVars['--color-negative'],
-  },
-  success: {
-    borderColor: colorVars['--color-positive'],
-  },
-});
-
-const statusFocusStyles = stylex.create({
-  warning: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
-    },
-  },
-  error: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
-    },
-  },
-  success: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
-    },
-  },
-});
-const statusHoverShadowStyles = stylex.create({
-  warning: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-warning'],
-      },
-    },
-  },
-  error: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
-      },
-    },
-  },
-  success: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-success'],
-      },
-    },
   },
 });
 
@@ -563,12 +471,13 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
         labelTooltip={labelTooltip}>
         <div
           {...stylex.props(
+            inputWrapperStyles.base,
             styles.wrapper,
             sizeStyles[size],
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
+            isDisabled && inputWrapperStyles.disabled,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -22,7 +22,11 @@ import * as stylex from '@stylexjs/stylex';
 import {useXDSLayer} from '../Layer/useXDSLayer';
 import {XDSIcon} from '../Icon';
 import type {XDSIconName} from '../Icon';
-import {XDSField} from '../Field';
+import {
+  XDSField,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+} from '../Field';
 import {XDSDivider} from '../Divider';
 import {XDSSpinner} from '../Spinner';
 import {
@@ -205,68 +209,6 @@ const sizeStyles = stylex.create({
   },
   lg: {
     height: sizeVars['--size-lg'],
-  },
-});
-
-const statusBorderStyles = stylex.create({
-  warning: {
-    borderColor: colorVars['--color-warning'],
-  },
-  error: {
-    borderColor: colorVars['--color-negative'],
-  },
-  success: {
-    borderColor: colorVars['--color-positive'],
-  },
-});
-
-const statusFocusStyles = stylex.create({
-  warning: {
-    outline: {
-      default: 'none',
-      ':focus': `1px solid ${colorVars['--color-focus-outline-warning']}`,
-    },
-  },
-  error: {
-    outline: {
-      default: 'none',
-      ':focus': `1px solid ${colorVars['--color-focus-outline-error']}`,
-    },
-  },
-  success: {
-    outline: {
-      default: 'none',
-      ':focus': `1px solid ${colorVars['--color-focus-outline-success']}`,
-    },
-  },
-});
-
-const statusHoverShadowStyles = stylex.create({
-  warning: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-warning'],
-      },
-    },
-  },
-  error: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
-      },
-    },
-  },
-  success: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-success'],
-      },
-    },
   },
 });
 
@@ -675,8 +617,8 @@ export function XDSSelector<T extends XDSSelectorOption>({
           sizeStyles[size],
           isDisabled && styles.triggerDisabled,
           !selectedItem && styles.triggerPlaceholder,
-          status && statusBorderStyles[status.type],
-          status && statusHoverShadowStyles[status.type],
+          status && inputStatusBorderStyles[status.type],
+          status && inputStatusHoverShadowStyles[status.type],
           triggerOverride,
         )}>
         <span>{selectedItem?.label ?? placeholder}</span>

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -25,14 +25,17 @@ import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   spacingVars,
-  radiusVars,
-  elevationVars,
-  transitionVars,
   typographyVars,
   textSizeVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
-import {XDSField} from '../Field';
+import {
+  XDSField,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '../Field';
 import {XDSIcon, type XDSIconType} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 import {ThemeContext} from '../theme/ThemeContext';
@@ -40,42 +43,9 @@ import type {StyleXStyles as ThemeStyleXStyles} from '../theme/types';
 
 const styles = stylex.create({
   wrapper: {
-    boxSizing: 'border-box',
-    position: 'relative',
     zIndex: 1,
-    display: 'flex',
     alignItems: 'flex-start',
-    gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: {
-      default: colorVars['--color-divider-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-divider-high-contrast'],
-      },
-    },
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline, box-shadow',
-    transitionDuration: transitionVars['--transition-fast'],
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover'],
-      },
-    },
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
-    },
-    outlineOffset: '0',
-  },
-  wrapperDisabled: {
-    cursor: 'not-allowed',
-    opacity: 0.5,
-    borderColor: colorVars['--color-divider-emphasized'],
   },
   textarea: {
     display: 'block',
@@ -109,67 +79,6 @@ const styles = stylex.create({
   },
   counterError: {
     color: colorVars['--color-negative'],
-  },
-});
-
-const statusBorderStyles = stylex.create({
-  warning: {
-    borderColor: colorVars['--color-warning'],
-  },
-  error: {
-    borderColor: colorVars['--color-negative'],
-  },
-  success: {
-    borderColor: colorVars['--color-positive'],
-  },
-});
-
-const statusFocusStyles = stylex.create({
-  warning: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
-    },
-  },
-  error: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
-    },
-  },
-  success: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
-    },
-  },
-});
-const statusHoverShadowStyles = stylex.create({
-  warning: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-warning'],
-      },
-    },
-  },
-  error: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
-      },
-    },
-  },
-  success: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-success'],
-      },
-    },
   },
 });
 
@@ -396,11 +305,12 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
         labelTooltip={labelTooltip}>
         <div
           {...stylex.props(
+            inputWrapperStyles.base,
             styles.wrapper,
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
+            isDisabled && inputWrapperStyles.disabled,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -24,56 +24,25 @@ import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   sizeVars,
-  spacingVars,
-  radiusVars,
-  elevationVars,
-  transitionVars,
   typographyVars,
   textSizeVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
-import {XDSField, type XDSInputStatus, type XDSInputStatusType} from '../Field';
+import {
+  XDSField,
+  type XDSInputStatus,
+  type XDSInputStatusType,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '../Field';
 import {XDSIcon, type XDSIconType} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 
 const styles = stylex.create({
   wrapper: {
-    boxSizing: 'border-box',
-    position: 'relative',
     zIndex: 1,
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: {
-      default: colorVars['--color-divider-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-divider-high-contrast'],
-      },
-    },
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline, box-shadow',
-    transitionDuration: transitionVars['--transition-fast'],
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover'],
-      },
-    },
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
-    },
-    outlineOffset: '0',
-  },
-  wrapperDisabled: {
-    cursor: 'not-allowed',
-    opacity: 0.5,
-    borderColor: colorVars['--color-divider-emphasized'],
   },
   input: {
     display: 'block',
@@ -106,68 +75,6 @@ const sizeStyles = stylex.create({
   },
   lg: {
     height: sizeVars['--size-lg'],
-  },
-});
-
-const statusBorderStyles = stylex.create({
-  warning: {
-    borderColor: colorVars['--color-warning'],
-  },
-  error: {
-    borderColor: colorVars['--color-negative'],
-  },
-  success: {
-    borderColor: colorVars['--color-positive'],
-  },
-});
-
-const statusHoverShadowStyles = stylex.create({
-  warning: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-warning'],
-      },
-    },
-  },
-  error: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
-      },
-    },
-  },
-  success: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-success'],
-      },
-    },
-  },
-});
-
-const statusFocusStyles = stylex.create({
-  warning: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
-    },
-  },
-  error: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
-    },
-  },
-  success: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
-    },
   },
 });
 
@@ -376,12 +283,13 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
         labelTooltip={labelTooltip}>
         <div
           {...stylex.props(
+            inputWrapperStyles.base,
             styles.wrapper,
             sizeStyles[size],
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
+            isDisabled && inputWrapperStyles.disabled,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
             wrapperOverride,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -29,15 +29,20 @@ import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   sizeVars,
-  spacingVars,
   radiusVars,
-  elevationVars,
-  transitionVars,
   typographyVars,
   textSizeVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
-import {XDSField, type XDSInputStatus, type XDSInputStatusType} from '../Field';
+import {
+  XDSField,
+  type XDSInputStatus,
+  type XDSInputStatusType,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '../Field';
 import {XDSIcon} from '../Icon';
 import {XDSSpinner} from '../Spinner';
 import {
@@ -51,43 +56,6 @@ import {
 } from '../utils';
 
 const styles = stylex.create({
-  wrapper: {
-    boxSizing: 'border-box',
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: 1,
-    borderStyle: 'solid',
-    borderColor: {
-      default: colorVars['--color-divider-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-divider-high-contrast'],
-      },
-    },
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline, box-shadow',
-    transitionDuration: transitionVars['--transition-fast'],
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover'],
-      },
-    },
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
-    },
-    outlineOffset: '0',
-  },
-  wrapperDisabled: {
-    cursor: 'not-allowed',
-    opacity: 0.5,
-    borderColor: colorVars['--color-divider-emphasized'],
-  },
   icon: {
     display: 'flex',
     alignItems: 'center',
@@ -145,67 +113,6 @@ const sizeStyles = stylex.create({
   },
   lg: {
     height: sizeVars['--size-lg'],
-  },
-});
-
-const statusBorderStyles = stylex.create({
-  warning: {
-    borderColor: colorVars['--color-warning'],
-  },
-  error: {
-    borderColor: colorVars['--color-negative'],
-  },
-  success: {
-    borderColor: colorVars['--color-positive'],
-  },
-});
-
-const statusFocusStyles = stylex.create({
-  warning: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
-    },
-  },
-  error: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
-    },
-  },
-  success: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
-    },
-  },
-});
-const statusHoverShadowStyles = stylex.create({
-  warning: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-warning'],
-      },
-    },
-  },
-  error: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
-      },
-    },
-  },
-  success: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-success'],
-      },
-    },
   },
 });
 
@@ -608,12 +515,12 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
         labelTooltip={labelTooltip}>
         <div
           {...stylex.props(
-            styles.wrapper,
+            inputWrapperStyles.base,
             sizeStyles[size],
-            isDisabled && styles.wrapperDisabled,
-            status && statusBorderStyles[status.type],
-            status && statusHoverShadowStyles[status.type],
-            status && statusFocusStyles[status.type],
+            isDisabled && inputWrapperStyles.disabled,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
             wrapperOverride,
           )}>
           <div {...stylex.props(styles.icon)}>

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -20,7 +20,14 @@ import React, {
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSBaseTypeahead} from '../Typeahead/XDSBaseTypeahead';
-import {XDSField, type XDSInputStatus} from '../Field';
+import {
+  XDSField,
+  type XDSInputStatus,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '../Field';
 import {XDSToken} from '../Token';
 import {XDSIcon} from '../Icon';
 import {
@@ -28,8 +35,6 @@ import {
   spacingVars,
   radiusVars,
   sizeVars,
-  transitionVars,
-  elevationVars,
 } from '../theme/tokens.stylex';
 import type {XDSSearchableItem, XDSSearchSource} from '../Typeahead/types';
 
@@ -114,45 +119,12 @@ export interface XDSTokenizerProps<T extends XDSSearchableItem> {
 
 const styles = stylex.create({
   wrapper: {
-    boxSizing: 'border-box',
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'center',
     flexWrap: 'wrap',
     gap: spacingVars['--spacing-1'],
     // Standard padding minus border width to prevent height jump
     // when tokens (28px) are added inside the input
     paddingBlock: `calc(${spacingVars['--spacing-1']} - 1px)`,
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: {
-      default: colorVars['--color-divider-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-divider-high-contrast'],
-      },
-    },
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline, box-shadow',
-    transitionDuration: transitionVars['--transition-fast'],
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover'],
-      },
-    },
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
-    },
-    outlineOffset: '0',
     cursor: 'text',
-  },
-  wrapperDisabled: {
-    cursor: 'not-allowed',
-    opacity: 0.5,
-    borderColor: colorVars['--color-divider-emphasized'],
   },
   tokenContainer: {
     display: 'flex',
@@ -200,68 +172,6 @@ const styles = stylex.create({
     minWidth: '40px',
     flex: '0 1 auto',
     width: '40px',
-  },
-});
-
-const statusBorderStyles = stylex.create({
-  warning: {
-    borderColor: colorVars['--color-warning'],
-  },
-  error: {
-    borderColor: colorVars['--color-negative'],
-  },
-  success: {
-    borderColor: colorVars['--color-positive'],
-  },
-});
-
-const statusHoverShadowStyles = stylex.create({
-  warning: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-warning'],
-      },
-    },
-  },
-  error: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
-      },
-    },
-  },
-  success: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-success'],
-      },
-    },
-  },
-});
-
-const statusFocusStyles = stylex.create({
-  warning: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
-    },
-  },
-  error: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
-    },
-  },
-  success: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
-    },
   },
 });
 
@@ -486,12 +396,13 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
         onClick={handleWrapperClick}
         data-testid={testId}
         {...stylex.props(
+          inputWrapperStyles.base,
           styles.wrapper,
           sizeStyle,
-          isDisabled && styles.wrapperDisabled,
-          status && statusBorderStyles[status.type],
-          status && statusHoverShadowStyles[status.type],
-          status && statusFocusStyles[status.type],
+          isDisabled && inputWrapperStyles.disabled,
+          status && inputStatusBorderStyles[status.type],
+          status && inputStatusHoverShadowStyles[status.type],
+          status && inputStatusFocusWithinStyles[status.type],
           xstyle,
         )}>
         {tokens.length > 0 && (

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -18,7 +18,14 @@ import React, {useCallback, useId, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSBaseTypeahead} from './XDSBaseTypeahead';
-import {XDSField, type XDSInputStatus} from '../Field';
+import {
+  XDSField,
+  type XDSInputStatus,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '../Field';
 import {XDSToken} from '../Token';
 import {XDSIcon} from '../Icon';
 import {
@@ -26,8 +33,6 @@ import {
   spacingVars,
   radiusVars,
   sizeVars,
-  transitionVars,
-  elevationVars,
 } from '../theme/tokens.stylex';
 import type {XDSSearchableItem, XDSSearchSource} from './types';
 import type {ReactNode} from 'react';
@@ -98,45 +103,12 @@ export interface XDSTypeaheadProps<T extends XDSSearchableItem> {
 
 const styles = stylex.create({
   wrapper: {
-    boxSizing: 'border-box',
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'center',
     flexWrap: 'wrap',
     gap: spacingVars['--spacing-1'],
     // Standard padding minus border width to prevent height jump
     // when a token (28px) is added inside the input
     paddingBlock: `calc(${spacingVars['--spacing-1']} - 1px)`,
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: '1px',
-    borderStyle: 'solid',
-    borderColor: {
-      default: colorVars['--color-divider-emphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-divider-high-contrast'],
-      },
-    },
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-surface'],
-    transitionProperty: 'border-color, outline, box-shadow',
-    transitionDuration: transitionVars['--transition-fast'],
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover'],
-      },
-    },
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline']}`,
-    },
-    outlineOffset: '0',
     cursor: 'text',
-  },
-  wrapperDisabled: {
-    cursor: 'not-allowed',
-    opacity: 0.5,
-    borderColor: colorVars['--color-divider-emphasized'],
   },
   token: {
     // Offset token so it sits 3px from the inner edge (4px from outer edge
@@ -173,68 +145,6 @@ const styles = stylex.create({
     padding: 0,
     opacity: 0,
     position: 'absolute' as const,
-  },
-});
-
-const statusBorderStyles = stylex.create({
-  warning: {
-    borderColor: colorVars['--color-warning'],
-  },
-  error: {
-    borderColor: colorVars['--color-negative'],
-  },
-  success: {
-    borderColor: colorVars['--color-positive'],
-  },
-});
-
-const statusHoverShadowStyles = stylex.create({
-  warning: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-warning'],
-      },
-    },
-  },
-  error: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)': elevationVars['--elevation-input-hover-error'],
-      },
-    },
-  },
-  success: {
-    boxShadow: {
-      default: 'none',
-      ':hover': {
-        '@media (hover: hover)':
-          elevationVars['--elevation-input-hover-success'],
-      },
-    },
-  },
-});
-
-const statusFocusStyles = stylex.create({
-  warning: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-warning']}`,
-    },
-  },
-  error: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-error']}`,
-    },
-  },
-  success: {
-    outline: {
-      default: 'none',
-      ':focus-within': `1px solid ${colorVars['--color-focus-outline-success']}`,
-    },
   },
 });
 
@@ -431,12 +341,13 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
         onClick={handleWrapperClick}
         onBlur={handleBlur}
         {...stylex.props(
+          inputWrapperStyles.base,
           styles.wrapper,
           sizeStyle,
-          status && statusBorderStyles[status.type],
-          status && statusHoverShadowStyles[status.type],
-          status && statusFocusStyles[status.type],
-          isDisabled && styles.wrapperDisabled,
+          status && inputStatusBorderStyles[status.type],
+          status && inputStatusHoverShadowStyles[status.type],
+          status && inputStatusFocusWithinStyles[status.type],
+          isDisabled && inputWrapperStyles.disabled,
           xstyle,
         )}>
         {showToken && (


### PR DESCRIPTION
## Summary

Extracts ~800 lines of duplicated input wrapper appearance styles into a shared module at `Field/inputStyles.stylex.ts`. All 8 input components now import from this shared module instead of defining their own copies.

Closes #260

## What changed

### New file: `Field/inputStyles.stylex.ts`

Exports 5 style objects:
- `inputWrapperStyles.base` — shared wrapper appearance (border, focus outline, hover shadow, background, transitions)
- `inputWrapperStyles.disabled` — shared disabled state
- `inputStatusBorderStyles` — status-colored borders (warning/error/success)
- `inputStatusHoverShadowStyles` — status-colored hover shadows
- `inputStatusFocusWithinStyles` — status-colored focus outlines (`:focus-within`)
- `inputStatusFocusStyles` — status-colored focus outlines (`:focus`, for button-based components like Selector)

### Refactored components (8 total)

| Component | Wrapper | Notes |
|-----------|---------|-------|
| TextInput | `inputWrapperStyles.base` + `zIndex: 1` | |
| TextArea | `inputWrapperStyles.base` + `zIndex: 1`, `alignItems: flex-start`, `paddingBlock: spacing-2` | |
| NumberInput | `inputWrapperStyles.base` + `zIndex: 1` | |
| DateInput | `inputWrapperStyles.base` (identical) | No component-specific overrides needed |
| TimeInput | `inputWrapperStyles.base` (identical) | No component-specific overrides needed |
| Typeahead | `inputWrapperStyles.base` + `flexWrap`, adjusted padding, `cursor: text` | |
| Tokenizer | `inputWrapperStyles.base` + `flexWrap`, adjusted padding, `cursor: text` | |
| Selector | Keeps its own `trigger` style (button, not wrapper) | Only status border/shadow styles shared |

### Cleanup
- Removed unused token imports (`elevationVars`, `transitionVars`, `spacingVars`, `radiusVars`) from components that no longer reference them directly
- Found and removed dead code: Selector had `statusFocusStyles` defined but never applied
- Updated `Field/README.md` file manifest

## Impact

- *Net: -513 lines* (+315 shared module, -828 removed duplication)
- *CSS bundle*: No change (StyleX already deduplicates at the atomic level)
- *JS bundle*: Slightly smaller (fewer `stylex.create()` calls)
- *Maintenance*: Future input appearance changes touch 1 file instead of 8
- *All 1135 tests pass*, types clean