### PR TITLE
fix: add lightningcss targets to prevent light-dark() lowering

### DIFF
--- a/apps/example-vite/vite.config.ts
+++ b/apps/example-vite/vite.config.ts
@@ -6,6 +6,20 @@ import stylex from '@stylexjs/unplugin';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+/**
+ * Browser targets for lightningcss.
+ * Prevents lowering native light-dark() into --lightningcss-light/--lightningcss-dark
+ * polyfill variables. XDS tokens use native light-dark() which is baseline 2024:
+ * Chrome 123+, Firefox 120+, Safari 17.5+
+ *
+ * Must match the targets in apps/storybook/.storybook/main.ts
+ */
+const lightningcssTargets = {
+  chrome: 123 << 16,
+  firefox: 120 << 16,
+  safari: (17 << 16) | (5 << 8),
+};
+
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [
@@ -16,6 +30,9 @@ export default defineConfig({
       unstable_moduleResolution: {
         type: 'commonJS',
         rootDir: __dirname,
+      },
+      lightningcssOptions: {
+        targets: lightningcssTargets,
       },
     }),
     react(),

--- a/internal/vibe-tests/app/vite.config.ts
+++ b/internal/vibe-tests/app/vite.config.ts
@@ -8,6 +8,20 @@ import {viteSingleFile} from 'vite-plugin-singlefile';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../..');
 
+/**
+ * Browser targets for lightningcss.
+ * Prevents lowering native light-dark() into --lightningcss-light/--lightningcss-dark
+ * polyfill variables. XDS tokens use native light-dark() which is baseline 2024:
+ * Chrome 123+, Firefox 120+, Safari 17.5+
+ *
+ * Must match the targets in apps/storybook/.storybook/main.ts
+ */
+const lightningcssTargets = {
+  chrome: 123 << 16,
+  firefox: 120 << 16,
+  safari: (17 << 16) | (5 << 8),
+};
+
 export default defineConfig({
   plugins: [
     stylex.vite({
@@ -23,6 +37,9 @@ export default defineConfig({
           repoRoot,
           'packages/core/src/theme/tokens.stylex.ts',
         ),
+      },
+      lightningcssOptions: {
+        targets: lightningcssTargets,
       },
     }),
     react(),


### PR DESCRIPTION
## Summary

Adds `lightningcssTargets` to the StyleX unplugin config in both the vibe-tests report app and the example-vite app, matching the targets already set in the storybook config (`apps/storybook/.storybook/main.ts`).

## Problem

Without these targets, lightningcss lowers native CSS `light-dark()` values into `--lightningcss-light`/`--lightningcss-dark` polyfill variables. These polyfill variables only work when specific StyleX color-scheme classes are applied at the document root — which breaks the dark mode toggle in the vibe report and causes transparent backgrounds in modals.

XDS design tokens use native `light-dark()` throughout (`tokens.stylex.ts`), and the `XDSTheme` component sets `colorScheme: 'dark'` or `colorScheme: 'light'` to control which value is used. When `light-dark()` is lowered to polyfill variables, this mechanism breaks.

## Fix

Set `lightningcssOptions.targets` to Chrome 123+, Firefox 120+, Safari 17.5+ — browsers that natively support `light-dark()` (baseline 2024). This tells lightningcss to preserve `light-dark()` as-is instead of lowering it.

The storybook config already had this fix (with extensive comments explaining why). This PR applies the same fix to the two other Vite-based apps.

## Files Changed

- `internal/vibe-tests/app/vite.config.ts` — adds lightningcss targets to StyleX plugin
- `apps/example-vite/vite.config.ts` — adds lightningcss targets to StyleX plugin

Fixes #431, #432