### PR TITLE
fix: align storybook addon versions with core package

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -14,13 +14,13 @@
     "@xds/theme-neutral": "*"
   },
   "devDependencies": {
-    "@storybook/addon-essentials": "^8.4.0",
-    "@storybook/addon-interactions": "^8.4.0",
-    "@storybook/addon-links": "^8.4.0",
-    "@storybook/blocks": "^8.4.0",
-    "@storybook/react": "^8.4.0",
-    "@storybook/react-vite": "^8.4.0",
-    "@storybook/test": "^8.4.0",
+    "@storybook/addon-essentials": "^8.6.17",
+    "@storybook/addon-interactions": "^8.6.17",
+    "@storybook/addon-links": "^8.6.17",
+    "@storybook/blocks": "^8.6.17",
+    "@storybook/react": "^8.6.17",
+    "@storybook/react-vite": "^8.6.17",
+    "@storybook/test": "^8.6.17",
     "@stylexjs/unplugin": "^0.17.4",
     "storybook": "^8.6.17"
   }


### PR DESCRIPTION
## Summary

Updates all `@storybook/*` addon packages from `^8.4.0` to `^8.6.17` to match the core `storybook` package version.

## Problem

The `storybook` core package was at `^8.6.17` while all addons (`@storybook/addon-essentials`, `@storybook/react-vite`, etc.) were at `^8.4.0`. This version mismatch can cause:
- Toolbar rendering issues (globals toolbar not functioning correctly)
- Internal API incompatibilities between core and addon packages
- The dark mode toggle not working (#433)

## Fix

Align all `@storybook/*` packages to `^8.6.17`.

⚠️ **Note**: `yarn.lock` needs to be regenerated after this change. Run `yarn install` to update it.

May fix #433