### PR TITLE
fix: neutralize stale review-gate check runs on approval

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -7,6 +7,10 @@ on:
     types: [submitted]
   merge_group:
 
+permissions:
+  checks: write
+  pull-requests: read
+
 jobs:
   review-gate:
     name: review-gate
@@ -78,11 +82,44 @@ jobs:
               latestReviews.set(review.user.login, review.state);
             }
 
-            for (const owner of globalOwners) {
-              if (latestReviews.get(owner) === 'APPROVED') {
-                console.log(`Code owner @${owner} has approved this PR`);
-                return;
+            const approved = [...globalOwners].some(
+              owner => latestReviews.get(owner) === 'APPROVED'
+            );
+
+            if (approved) {
+              const approver = [...globalOwners].find(
+                owner => latestReviews.get(owner) === 'APPROVED'
+              );
+              console.log(`Code owner @${approver} has approved this PR`);
+
+              // Neutralize any previous failed review-gate check runs so they
+              // don't block merge. GitHub's status rollup considers ALL check
+              // runs for a given name — a stale failure poisons the overall
+              // result even when the latest run succeeded.
+              const checkRuns = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: pr.head.sha,
+                check_name: 'review-gate',
+              });
+
+              for (const run of checkRuns.data.check_runs) {
+                if (run.conclusion === 'failure') {
+                  console.log(`Neutralizing stale failed check run ${run.id}`);
+                  await github.rest.checks.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    check_run_id: run.id,
+                    conclusion: 'neutral',
+                    output: {
+                      title: 'Superseded',
+                      summary: 'Superseded by a newer review-gate run after code owner approval.',
+                    },
+                  });
+                }
               }
+
+              return;
             }
 
             core.setFailed(


### PR DESCRIPTION
## Problem

When `review-gate` triggers on `pull_request` events (opened/synchronize/reopened), it creates a check run that fails because there's no approval yet. When a code owner later approves, the workflow re-triggers on `pull_request_review` and creates a **new** successful check run — but the old failed run persists.

GitHub's status rollup considers **all** check runs for a given name, so the stale failure poisons the overall merge status even though the latest run passed. This shows as `UNSTABLE` merge state and can block merging.

Observed on PR #442 — approved by code owner but merge status showed unstable due to the earlier failed review-gate run.

## Fix

After confirming code owner approval, the workflow now finds any previous failed `review-gate` check runs for the same commit SHA and updates their conclusion to `neutral` (superseded). This clears the stale failure from the status rollup.

Also adds explicit `permissions` (`checks: write`, `pull-requests: read`) required for the Checks API calls.

## Changes

- `.github/workflows/review-gate.yml` — Add stale check run neutralization logic after approval confirmation