### PR TITLE
chore: mark theme packages as publishable

### DIFF
--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xds/theme-default",
   "version": "0.0.1",
-  "private": true,
+  "private": false,
   "description": "Default theme for XDS components (Heroicons)",
   "license": "MIT",
   "sideEffects": false,

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xds/theme-neutral",
   "version": "0.0.1",
-  "private": true,
+  "private": false,
   "description": "Neutral theme for XDS components (Lucide icons)",
   "license": "MIT",
   "sideEffects": false,


### PR DESCRIPTION
Sets `private: false` on `@xds/theme-default` and `@xds/theme-neutral` so they can be published to the internal NPM registry.

Both packages have been published to `npmuat.thefacebook.com` at version `0.0.1`.