### PR TITLE
fix: bug bash P0 fixes — storybook controls, alignment, scrolling, accessibility

### DIFF
--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -236,12 +236,21 @@ const meta: Meta<typeof XDSAppShell> = {
       control: 'radio',
       options: ['fill', 'auto'],
     },
+    initialIsSideNavCollapsed: {
+      control: 'boolean',
+      description: 'Whether the side nav starts collapsed',
+    },
     sideNavBreakpoint: {
       control: 'radio',
       options: ['sm', 'md', 'lg', 'none'],
     },
     sideNavWidth: {
       control: 'number',
+    },
+    background: {
+      control: 'radio',
+      options: ['surface', 'wash'],
+      description: 'Background color of the shell',
     },
   },
 };

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -519,12 +519,14 @@ function ScrollingModalExample() {
             <XDSLayoutContent>
               <div
                 style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
-                {Array.from({length: 10}, (_, i) => (
+                {Array.from({length: 20}, (_, i) => (
                   <XDSText type="body" key={i}>
-                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
-                    do eiusmod tempor incididunt ut labore et dolore magna
-                    aliqua. Ut enim ad minim veniam, quis nostrud exercitation
-                    ullamco laboris nisi ut aliquip ex ea commodo consequat.
+                    {i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing
+                    elit. Sed do eiusmod tempor incididunt ut labore et dolore
+                    magna aliqua. Ut enim ad minim veniam, quis nostrud
+                    exercitation ullamco laboris nisi ut aliquip ex ea commodo
+                    consequat. Duis aute irure dolor in reprehenderit in
+                    voluptate velit esse cillum dolore eu fugiat nulla pariatur.
                   </XDSText>
                 ))}
               </div>

--- a/apps/storybook/stories/Field.stories.tsx
+++ b/apps/storybook/stories/Field.stories.tsx
@@ -354,3 +354,84 @@ export const TooltipWithOptional: Story = {
     isOptional: true,
   },
 };
+
+// =============================================================================
+// Status Variants
+// =============================================================================
+
+export const StatusVariants: Story = {
+  render: () => {
+    const [values, setValues] = useState({
+      error: 'bad-email',
+      warning: 'admin',
+      success: 'valid-user',
+    });
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '24px',
+          maxWidth: '400px',
+        }}>
+        <XDSField
+          label="Email"
+          description="Enter your work email address"
+          inputID="status-error-input"
+          status={{
+            type: 'error',
+            message: 'Please enter a valid email address',
+          }}>
+          <input
+            id="status-error-input"
+            value={values.error}
+            onChange={e => setValues(v => ({...v, error: e.target.value}))}
+            style={{
+              padding: '8px',
+              fontSize: '14px',
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
+          />
+        </XDSField>
+        <XDSField
+          label="Username"
+          description="Choose a unique username"
+          inputID="status-warning-input"
+          status={{
+            type: 'warning',
+            message: 'This username is reserved for administrators',
+          }}>
+          <input
+            id="status-warning-input"
+            value={values.warning}
+            onChange={e => setValues(v => ({...v, warning: e.target.value}))}
+            style={{
+              padding: '8px',
+              fontSize: '14px',
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
+          />
+        </XDSField>
+        <XDSField
+          label="API Key"
+          description="Paste your API key"
+          inputID="status-success-input"
+          status={{type: 'success', message: 'API key is valid and active'}}>
+          <input
+            id="status-success-input"
+            value={values.success}
+            onChange={e => setValues(v => ({...v, success: e.target.value}))}
+            style={{
+              padding: '8px',
+              fontSize: '14px',
+              width: '100%',
+              boxSizing: 'border-box',
+            }}
+          />
+        </XDSField>
+      </div>
+    );
+  },
+};

--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -19,10 +19,13 @@ export default meta;
 type Story = StoryObj<typeof XDSTabList>;
 
 export const Default: Story = {
-  render: () => {
+  args: {
+    size: 'md',
+  },
+  render: args => {
     const [value, setValue] = useState('home');
     return (
-      <XDSTabList value={value} onChange={setValue}>
+      <XDSTabList value={value} onChange={setValue} size={args.size}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTab value="settings" label="Settings" />
@@ -32,10 +35,13 @@ export const Default: Story = {
 };
 
 export const WithMenu: Story = {
-  render: () => {
+  args: {
+    size: 'md',
+  },
+  render: args => {
     const [value, setValue] = useState('home');
     return (
-      <XDSTabList value={value} onChange={setValue}>
+      <XDSTabList value={value} onChange={setValue} size={args.size}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTabMenu
@@ -52,10 +58,13 @@ export const WithMenu: Story = {
 };
 
 export const MenuWithSelectedChild: Story = {
-  render: () => {
+  args: {
+    size: 'md',
+  },
+  render: args => {
     const [value, setValue] = useState('analytics');
     return (
-      <XDSTabList value={value} onChange={setValue}>
+      <XDSTabList value={value} onChange={setValue} size={args.size}>
         <XDSTab value="home" label="Home" />
         <XDSTab value="projects" label="Projects" />
         <XDSTabMenu
@@ -111,7 +120,10 @@ export const SizeVariants: Story = {
 };
 
 export const WithIcons: Story = {
-  render: () => {
+  args: {
+    size: 'md',
+  },
+  render: args => {
     const [value, setValue] = useState('home');
 
     // Inline SVG icons for the story
@@ -132,7 +144,7 @@ export const WithIcons: Story = {
     );
 
     return (
-      <XDSTabList value={value} onChange={setValue}>
+      <XDSTabList value={value} onChange={setValue} size={args.size}>
         <XDSTab value="home" label="Home" icon={HomeIcon} />
         <XDSTab value="settings" label="Settings" icon={CogIcon} />
       </XDSTabList>

--- a/apps/storybook/stories/Text.stories.tsx
+++ b/apps/storybook/stories/Text.stories.tsx
@@ -11,6 +11,23 @@ const meta: Meta<typeof XDSText> = {
       options: ['body', 'large', 'label', 'supporting', 'code'],
       description: 'Semantic text type',
     },
+    size: {
+      control: 'select',
+      options: [
+        '4xs',
+        '3xs',
+        '2xs',
+        'xsm',
+        'sm',
+        'base',
+        'lg',
+        'xl',
+        '2xl',
+        '3xl',
+        '4xl',
+      ],
+      description: 'Explicit font size override',
+    },
     color: {
       control: 'select',
       options: [

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -233,7 +233,11 @@ const styles = stylex.create({
     top: 0,
     zIndex: 1,
   },
-  // Sticky sideNav for auto height mode
+  // Wrapper for auto height mode — stretches to full content height
+  sideNavAutoWrapper: {
+    alignSelf: 'stretch',
+  },
+  // Sticky sideNav for auto height mode — sticks within the wrapper
   sideNavSticky: {
     position: 'sticky',
     top: 'var(--appshell-header-height, 0px)',
@@ -446,7 +450,9 @@ export const XDSAppShell = forwardRef<HTMLDivElement, XDSAppShellProps>(
 
     const sideNavContent =
       sideNavPanel != null && isAuto ? (
-        <div {...stylex.props(styles.sideNavSticky)}>{sideNavPanel}</div>
+        <div {...stylex.props(styles.sideNavAutoWrapper)}>
+          <div {...stylex.props(styles.sideNavSticky)}>{sideNavPanel}</div>
+        </div>
       ) : (
         sideNavPanel
       );

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -70,7 +70,7 @@ export interface XDSBreadcrumbItemProps {
 
 const itemStyles = stylex.create({
   root: {
-    display: 'inline-flex',
+    display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
     lineHeight: lineHeightVars['--leading-snug'],
@@ -82,12 +82,12 @@ const itemStyles = stylex.create({
     fontSize: textSizeVars['--text-xsm'],
   },
   contentWrapper: {
-    display: 'inline-flex',
+    display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
   },
   link: {
-    display: 'inline-flex',
+    display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
     textDecoration: {
@@ -114,7 +114,7 @@ const itemStyles = stylex.create({
     color: colorVars['--color-text-secondary'],
   },
   icon: {
-    display: 'inline-flex',
+    display: 'flex',
     alignItems: 'center',
     flexShrink: 0,
   },

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -67,6 +67,11 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-surface'],
     borderRadius: radiusVars['--radius-container'],
     boxShadow: elevationVars['--elevation-dialog'],
+    display: {
+      default: 'none',
+      ':where([open])': 'flex',
+    },
+    flexDirection: 'column',
     overflow: 'hidden',
     height: 'fit-content',
     // Animation for opening

--- a/packages/core/src/Field/XDSField.test.tsx
+++ b/packages/core/src/Field/XDSField.test.tsx
@@ -62,7 +62,7 @@ describe('XDSField', () => {
     expect(screen.getByLabelText('Search')).toBeInTheDocument();
   });
 
-  it('hides description when isLabelHidden is true', () => {
+  it('visually hides description when isLabelHidden is true', () => {
     render(
       <XDSField
         label="Search"
@@ -73,7 +73,11 @@ describe('XDSField', () => {
         <input id="search-input" />
       </XDSField>,
     );
-    expect(screen.queryByText('Search for items')).not.toBeInTheDocument();
+    // Description should still be in the DOM for screen readers
+    const description = screen.getByText('Search for items');
+    expect(description).toBeInTheDocument();
+    // But should have the visually-hidden styles applied
+    expect(description.className).toContain('labelHidden');
   });
 
   it('shows label visually by default', () => {

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -223,10 +223,14 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
           labelIcon={labelIcon}
           labelTooltip={labelTooltip}
         />
-        {description && !isLabelHidden && (
+        {description && (
           <span
             id={descriptionID}
-            {...stylex.props(styles.description, descriptionOverride)}>
+            {...stylex.props(
+              styles.description,
+              isLabelHidden && styles.labelHidden,
+              descriptionOverride,
+            )}>
             {description}
           </span>
         )}

--- a/packages/core/src/SideNav/XDSSideNavHeader.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeader.tsx
@@ -115,8 +115,8 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    width: 16,
-    height: 16,
+    width: spacingVars['--spacing-4'],
+    height: spacingVars['--spacing-4'],
     color: colorVars['--color-icon-secondary'],
   },
   popoverContent: {


### PR DESCRIPTION
Addresses P0 items from the bug bash tracking issue #371.

## Changes

### Text & TabList — Storybook controls not working
- Added `size` control to Text story argTypes (all 11 `XDSTextSize` values)
- Wired `size` arg through TabList stories (Default, WithMenu, MenuWithSelectedChild, WithIcons) — previously the render functions ignored storybook controls

### Breadcrumbs — Leaf node offset, not vertically centered
- Changed `display: 'inline-flex'` → `display: 'flex'` on breadcrumb item elements (`root`, `contentWrapper`, `link`, `icon`), matching the separator's `flex` display for consistent vertical alignment

### SideNav — Hardcoded icon dimensions
- Replaced `width: 16, height: 16` with `spacingVars['--spacing-4']` in the chevron style (design token consistency)

### Dialog — Scrolling content doesn't scroll
- Added `display: 'flex'` and `flexDirection: 'column'` to dialog base styles — the native `<dialog>` defaults to `display: block`, which prevents the inner XDSLayout from establishing a proper height constraint for overflow scrolling
- Increased scrolling example from 10 to 20 paragraphs with numbering for clearer demonstration

### Field — `isLabelHidden` removes description from DOM
- Changed behavior: description is now *visually hidden* (same technique as label) instead of removed from the DOM, preserving screen reader access per the JSDoc contract
- Added `StatusVariants` story showing error, warning, and success states
- Updated test to verify description stays in DOM with visually-hidden class

### AppShell — Auto height sidebar cut off
- Added `sideNavAutoWrapper` with `alignSelf: 'stretch'` so the sidebar background extends to full content height in auto mode
- Added `initialIsSideNavCollapsed` and `background` controls to storybook argTypes

## Not addressed
- **Grid `minChildWidth`** — Investigated but the implementation (`repeat(auto-fit, minmax(Xpx, 1fr))`) is correct per CSS Grid spec. May need visual verification in a real browser to reproduce.
- **SideNav title spacing** (8px vs 4px from edge) — Needs design input
- **TimeInput/Field `isLabelHidden`** — Fixed via the Field change (TimeInput passes through to Field)

## Testing
All 151 tests pass across Field, Dialog, Breadcrumbs, AppShell, and SideNav test suites.

Closes items in #371.

---
*Crafted with care by Navi*