### PR TITLE
fix(core): ensure dist/ is always built and included in published package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -353,7 +353,13 @@
       "require": "./dist/utils/index.js"
     }
   },
+  "files": [
+    "dist",
+    "src",
+    "xds.md"
+  ],
   "scripts": {
+    "prepack": "yarn build",
     "build": "NODE_OPTIONS='--max-old-space-size=4096' tsup",
     "dev": "tsup --watch",
     "test": "vitest run --root ../..",


### PR DESCRIPTION
## Problem

`@xds/core` was published to the internal npm registry without its `dist/` directory — only `src/` exists. The `package.json` exports point to `./dist/index.js` and `./dist/index.mjs` which don't exist in the published package, so consumers can't actually import anything.

## Root Cause

1. `packages/core/package.json` had no `"files"` field — unlike the theme packages which already have `"files": ["dist", "src"]`
2. No `prepack` script to ensure `dist/` is built before `npm pack`/`npm publish`
3. `dist/` is in the root `.gitignore` (correctly) — but this means it must be built before publishing

## Fix

- Add `"files": ["dist", "src", "xds.md"]` to explicitly declare what gets published
- Add `"prepack": "yarn build"` to ensure `dist/` is always generated before packing/publishing

This matches the pattern already used by `@xds/theme-default` and `@xds/theme-neutral`.

## Verification

`npm pack --dry-run` confirms `dist/` files are now included in the package tarball.

---
*Crafted with care by Navi*