### PR TITLE
Add yarn xds shortcut and fix no-args exit code

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docs": "yarn workspace @xds/docs dev",
     "sync:exports": "node scripts/sync-exports.js",
     "sync:exports:check": "node scripts/sync-exports.js --check",
+    "xds": "yarn workspace @xds/cli xds",
     "validate-readmes": "node scripts/validate-readmes.mjs",
     "package:source": "node scripts/package-source.js",
     "changeset": "changeset",

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -20,7 +20,10 @@ program
   .name('xds')
   .description('XDS design system CLI — components, themes, and tooling')
   .version('0.0.1')
-  .addHelpCommand('help', 'Show all commands');
+  .addHelpCommand('help', 'Show all commands')
+  .action(() => {
+    program.help();
+  });
 
 registerInit(program);
 registerComponent(program);


### PR DESCRIPTION
## Summary

- Add `yarn xds` script to root `package.json` so the CLI can be invoked from the repo root without global installation
- Fix Commander's default behavior of exiting with code 1 when no subcommand is given — now shows help cleanly with exit code 0

## Test plan

- [x] `yarn xds` — shows help, no error output
- [x] `yarn xds component Button --brief` — works correctly
- [x] All 61 CLI tests pass (`npx vitest run packages/cli`)