### PR TITLE
codemod: migrate stylex.props spreads to sx prop

### DIFF
--- a/apps/example-nextjs/package.json
+++ b/apps/example-nextjs/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.17.4",
+    "@stylexjs/stylex": "^0.18.1",
     "@xds/core": "*",
     "@xds/theme-default": "*",
     "next": "^15.0.0",
@@ -18,8 +18,8 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.0",
     "@babel/preset-typescript": "^7.25.0",
-    "@stylexjs/babel-plugin": "^0.17.4",
-    "@stylexjs/postcss-plugin": "^0.17.4",
+    "@stylexjs/babel-plugin": "^0.18.1",
+    "@stylexjs/postcss-plugin": "^0.18.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "^5.7.0"

--- a/apps/example-nextjs/src/app/page.tsx
+++ b/apps/example-nextjs/src/app/page.tsx
@@ -24,8 +24,8 @@ const styles = stylex.create({
 
 export default function Home() {
   return (
-    <main {...stylex.props(styles.main)}>
-      <div {...stylex.props(styles.container)}>
+    <main sx={styles.main}>
+      <div sx={styles.container}>
         <XDSVStack gap="space6">
           <XDSVStack gap="space2">
             <XDSHeading level={1}>XDS Example — Next.js</XDSHeading>

--- a/apps/example-vite/package.json
+++ b/apps/example-vite/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.17.4",
+    "@stylexjs/stylex": "^0.18.1",
     "@xds/core": "*",
     "@xds/theme-default": "*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "^0.17.4",
+    "@stylexjs/unplugin": "^0.18.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.0",

--- a/apps/example-vite/src/App.tsx
+++ b/apps/example-vite/src/App.tsx
@@ -28,8 +28,8 @@ export default function App() {
 
   return (
     <XDSTheme theme={defaultTheme}>
-      <main {...stylex.props(styles.main)}>
-        <div {...stylex.props(styles.container)}>
+      <main sx={styles.main}>
+        <div sx={styles.container}>
           <XDSVStack gap="space6">
             <XDSVStack gap="space2">
               <XDSHeading level={1}>XDS Example — Vite</XDSHeading>

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -9,7 +9,7 @@
     "postinstall": "xds agent-docs"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.17.4",
+    "@stylexjs/stylex": "^0.18.1",
     "@xds/cli": "*",
     "@xds/core": "*",
     "@xds/theme-default": "*",
@@ -20,8 +20,8 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.0",
     "@babel/preset-typescript": "^7.25.0",
-    "@stylexjs/babel-plugin": "^0.17.4",
-    "@stylexjs/postcss-plugin": "^0.17.4",
+    "@stylexjs/babel-plugin": "^0.18.1",
+    "@stylexjs/postcss-plugin": "^0.18.1",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/sandbox/src/app/Sidebar.tsx
+++ b/apps/sandbox/src/app/Sidebar.tsx
@@ -63,8 +63,8 @@ export function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <nav {...stylex.props(styles.sidebar)}>
-      <div {...stylex.props(styles.title)}>Sandbox</div>
+    <nav sx={styles.sidebar}>
+      <div sx={styles.title}>Sandbox</div>
       {pages.map(page => {
         const isActive =
           pathname === page.href ||
@@ -73,7 +73,7 @@ export function Sidebar() {
           <Link
             key={page.href}
             href={page.href}
-            {...stylex.props(styles.link, isActive && styles.linkActive)}>
+            sx={[styles.link, isActive && styles.linkActive]}>
             {page.name}
           </Link>
         );

--- a/apps/sandbox/src/app/page.tsx
+++ b/apps/sandbox/src/app/page.tsx
@@ -12,7 +12,7 @@ const styles = stylex.create({
 
 export default function Home() {
   return (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSVStack gap="space6">
         <XDSVStack gap="space2">
           <XDSHeading level={1}>XDS Sandbox</XDSHeading>

--- a/apps/sandbox/src/app/pages/example/page.tsx
+++ b/apps/sandbox/src/app/pages/example/page.tsx
@@ -30,7 +30,7 @@ export default function ExamplePage() {
   const [updates, setUpdates] = useState(false);
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSVStack gap="space6">
         <XDSVStack gap="space2">
           <XDSHeading level={1}>Example Page</XDSHeading>

--- a/apps/sandbox/src/app/pages/mega-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/mega-menu/page.tsx
@@ -234,7 +234,7 @@ export default function MegaMenuPage() {
   const isAnyOpen1 = menuOpen1 || menuOpen2;
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSVStack gap="space6">
         <XDSVStack gap="space2">
           <XDSHeading level={1}>Mega Menu</XDSHeading>
@@ -248,11 +248,7 @@ export default function MegaMenuPage() {
         {/* Full mega menu with featured content */}
         <XDSVStack gap="space3">
           <XDSHeading level={2}>With Featured Content</XDSHeading>
-          <div
-            {...stylex.props(
-              styles.navWrapper,
-              isAnyOpen1 && styles.navWrapperMenuOpen,
-            )}>
+          <div sx={[styles.navWrapper, isAnyOpen1 && styles.navWrapperMenuOpen]}>
             <XDSTopNav
               label="Marketing navigation"
               title={
@@ -307,11 +303,7 @@ export default function MegaMenuPage() {
         {/* Without featured content */}
         <XDSVStack gap="space3">
           <XDSHeading level={2}>Without Featured Content</XDSHeading>
-          <div
-            {...stylex.props(
-              styles.navWrapper,
-              menuOpen3 && styles.navWrapperMenuOpen,
-            )}>
+          <div sx={[styles.navWrapper, menuOpen3 && styles.navWrapperMenuOpen]}>
             <XDSTopNav
               label="Simple navigation"
               title={<XDSTopNavTitle title="App" href="#" />}

--- a/apps/sandbox/src/app/pages/navigation/page.tsx
+++ b/apps/sandbox/src/app/pages/navigation/page.tsx
@@ -31,7 +31,7 @@ export default function NavigationPage() {
   const [alignment, setAlignment] = useState<Alignment>('start');
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSVStack gap="space6">
         <XDSVStack gap="space2">
           <XDSHeading level={1}>Navigation Alignment</XDSHeading>
@@ -71,7 +71,7 @@ export default function NavigationPage() {
         {/* Live preview */}
         <XDSVStack gap="space3">
           <XDSHeading level={2}>Preview</XDSHeading>
-          <div {...stylex.props(styles.navWrapper)}>
+          <div sx={styles.navWrapper}>
             <NavPreview alignment={alignment} />
           </div>
         </XDSVStack>
@@ -86,7 +86,7 @@ export default function NavigationPage() {
             <XDSText type="supporting" weight="bold">
               Left-aligned (startContent)
             </XDSText>
-            <div {...stylex.props(styles.navWrapper)}>
+            <div sx={styles.navWrapper}>
               <NavPreview alignment="start" />
             </div>
           </XDSVStack>
@@ -95,7 +95,7 @@ export default function NavigationPage() {
             <XDSText type="supporting" weight="bold">
               Center-aligned (centerContent)
             </XDSText>
-            <div {...stylex.props(styles.navWrapper)}>
+            <div sx={styles.navWrapper}>
               <NavPreview alignment="center" />
             </div>
           </XDSVStack>
@@ -104,7 +104,7 @@ export default function NavigationPage() {
             <XDSText type="supporting" weight="bold">
               Right-aligned (endContent)
             </XDSText>
-            <div {...stylex.props(styles.navWrapper)}>
+            <div sx={styles.navWrapper}>
               <NavPreview alignment="end" />
             </div>
           </XDSVStack>

--- a/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
+++ b/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
@@ -70,7 +70,7 @@ const SimulatedNextLink = forwardRef<
         console.log(`[SimulatedNextLink] Client-side navigate to: ${href}`);
         onClick?.(e);
       }}
-      {...stylex.props(styles.customLinkIndicator)}
+      sx={styles.customLinkIndicator}
       {...props}>
       {children}
     </a>
@@ -110,7 +110,7 @@ export default function PolymorphicLinkPage() {
   const [tab, setTab] = useState('overview');
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSVStack gap="space6">
         <XDSVStack gap="space2">
           <XDSHeading level={1}>Polymorphic Link</XDSHeading>
@@ -148,7 +148,7 @@ export default function PolymorphicLinkPage() {
                 <XDSText type="supporting" weight="bold">
                   XDSTopNav
                 </XDSText>
-                <div {...stylex.props(styles.navWrapper)}>
+                <div sx={styles.navWrapper}>
                   <XDSTopNav
                     label="Provider demo navigation"
                     title={<XDSTopNavTitle title="My App" />}
@@ -194,7 +194,7 @@ export default function PolymorphicLinkPage() {
                 <XDSText type="supporting" weight="bold">
                   XDSSideNav
                 </XDSText>
-                <div {...stylex.props(styles.sidenavWrapper)}>
+                <div sx={styles.sidenavWrapper}>
                   <XDSSideNav aria-label="Provider sidenav">
                     <XDSSideNavItem
                       label="Dashboard"
@@ -242,7 +242,7 @@ export default function PolymorphicLinkPage() {
           </XDSText>
 
           <XDSLinkProvider component={SimulatedNextLink}>
-            <div {...stylex.props(styles.navWrapper)}>
+            <div sx={styles.navWrapper}>
               <XDSTopNav
                 label="Override demo navigation"
                 title={<XDSTopNavTitle title="Override Demo" />}
@@ -277,7 +277,7 @@ export default function PolymorphicLinkPage() {
             prop, components render native {'<a>'} elements as usual.
           </XDSText>
 
-          <div {...stylex.props(styles.navWrapper)}>
+          <div sx={styles.navWrapper}>
             <XDSTopNav
               label="Default navigation"
               title={<XDSTopNavTitle title="Default" />}

--- a/apps/sandbox/src/app/pages/table-overview/page.tsx
+++ b/apps/sandbox/src/app/pages/table-overview/page.tsx
@@ -209,7 +209,7 @@ function StatCard({
 }) {
   return (
     <XDSCard>
-      <div {...stylex.props(styles.statCard)}>
+      <div sx={styles.statCard}>
         <XDSText type="supporting" color="secondary">
           {emoji ? `${emoji} ` : ''}
           {label}
@@ -238,10 +238,10 @@ const columns: XDSTableColumn<ReviewRow>[] = [
           name={item.authorName}
           size="small"
         />
-        <div {...stylex.props(styles.authorInfo)}>
+        <div sx={styles.authorInfo}>
           <XDSVStack gap="space1">
-            <span {...stylex.props(styles.titleLink)}>{item.title}</span>
-            <span {...stylex.props(styles.supportingLine)}>
+            <span sx={styles.titleLink}>{item.title}</span>
+            <span sx={styles.supportingLine}>
               <XDSText type="supporting" color="secondary">
                 {item.diffId} · {item.lines} lines {item.reviewTime}
               </XDSText>
@@ -256,11 +256,11 @@ const columns: XDSTableColumn<ReviewRow>[] = [
     header: 'Reviewers',
     width: pixel(120),
     renderCell: (item: ReviewRow) => (
-      <div {...stylex.props(styles.avatarGroup)}>
+      <div sx={styles.avatarGroup}>
         {item.reviewerAvatars.map((src: string, i: number) => (
           <div
             key={i}
-            {...stylex.props(styles.avatarOverlap)}
+            sx={styles.avatarOverlap}
             style={{
               marginLeft: i > 0 ? -8 : 0,
               zIndex: item.reviewerAvatars.length - i,
@@ -450,7 +450,7 @@ export default function TableOverviewPage() {
   const filteredAccepted = filterRows(acceptedAndReady);
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSVStack gap="space6">
         <XDSVStack gap="space2">
           <XDSHeading level={1}>Table Overview</XDSHeading>
@@ -470,7 +470,7 @@ export default function TableOverviewPage() {
         />
 
         {/* Stats Row */}
-        <div {...stylex.props(styles.statsRow)}>
+        <div sx={styles.statsRow}>
           <StatCard emoji="🔥" label="Review streak" value="4 days" />
           <StatCard label="Reviews today" value={6} />
           <StatCard label="Diff reviews" value={28} />

--- a/apps/sandbox/src/app/pages/topnav-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/topnav-menu/page.tsx
@@ -98,7 +98,7 @@ const scienceItems = [
  */
 export default function TopNavMenuPage() {
   return (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSVStack gap="space6">
         <XDSVStack gap="space2">
           <XDSHeading level={1}>TopNav Menu</XDSHeading>
@@ -111,7 +111,7 @@ export default function TopNavMenuPage() {
         {/* Marketing-style nav with overflow menus */}
         <XDSVStack gap="space3">
           <XDSHeading level={2}>Marketing Nav</XDSHeading>
-          <div {...stylex.props(styles.navWrapper)}>
+          <div sx={styles.navWrapper}>
             <XDSTopNav
               label="Marketing navigation"
               title={
@@ -141,7 +141,7 @@ export default function TopNavMenuPage() {
         {/* Simple nav with one overflow menu */}
         <XDSVStack gap="space3">
           <XDSHeading level={2}>Simple Nav</XDSHeading>
-          <div {...stylex.props(styles.navWrapper)}>
+          <div sx={styles.navWrapper}>
             <XDSTopNav
               label="Simple navigation"
               title={<XDSTopNavTitle title="App" href="#" />}

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -21,7 +21,7 @@
     "@storybook/react": "^8.6.17",
     "@storybook/react-vite": "^8.6.17",
     "@storybook/test": "^8.6.17",
-    "@stylexjs/unplugin": "^0.17.4",
+    "@stylexjs/unplugin": "^0.18.1",
     "storybook": "^8.6.17"
   }
 }

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -63,9 +63,9 @@ const styles = stylex.create({
 
 function MockContent({paragraphs = 3}: {paragraphs?: number}) {
   return (
-    <div {...stylex.props(styles.content)}>
+    <div sx={styles.content}>
       <XDSText type="large">Page Content</XDSText>
-      <div {...stylex.props(styles.longContent)}>
+      <div sx={styles.longContent}>
         {Array.from({length: paragraphs}, (_, i) => (
           <XDSText type="body" key={i}>
             Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do

--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -88,16 +88,12 @@ export const Default: Story = {
     ratio: 16 / 9,
   },
   render: args => (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         16:9 Aspect Ratio (Default)
       </XDSText>
       <XDSAspectRatio {...args}>
-        <img
-          {...stylex.props(styles.image)}
-          src={PLACEHOLDER_IMAGE}
-          alt="16:9 placeholder"
-        />
+        <img sx={styles.image} src={PLACEHOLDER_IMAGE} alt="16:9 placeholder" />
       </XDSAspectRatio>
     </div>
   ),
@@ -105,16 +101,12 @@ export const Default: Story = {
 
 export const Widescreen16x9: Story = {
   render: () => (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         16:9 - Standard widescreen (YouTube, TV)
       </XDSText>
       <XDSAspectRatio ratio={16 / 9}>
-        <img
-          {...stylex.props(styles.image)}
-          src={PLACEHOLDER_IMAGE}
-          alt="16:9 widescreen"
-        />
+        <img sx={styles.image} src={PLACEHOLDER_IMAGE} alt="16:9 widescreen" />
       </XDSAspectRatio>
     </div>
   ),
@@ -122,16 +114,12 @@ export const Widescreen16x9: Story = {
 
 export const Classic4x3: Story = {
   render: () => (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         4:3 - Classic TV and photography
       </XDSText>
       <XDSAspectRatio ratio={4 / 3}>
-        <img
-          {...stylex.props(styles.image)}
-          src={PLACEHOLDER_IMAGE}
-          alt="4:3 classic"
-        />
+        <img sx={styles.image} src={PLACEHOLDER_IMAGE} alt="4:3 classic" />
       </XDSAspectRatio>
     </div>
   ),
@@ -139,16 +127,12 @@ export const Classic4x3: Story = {
 
 export const Square1x1: Story = {
   render: () => (
-    <div {...stylex.props(styles.smallContainer)}>
+    <div sx={styles.smallContainer}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         1:1 - Square (Instagram, avatars)
       </XDSText>
       <XDSAspectRatio ratio={1}>
-        <img
-          {...stylex.props(styles.image)}
-          src={PLACEHOLDER_SQUARE}
-          alt="1:1 square"
-        />
+        <img sx={styles.image} src={PLACEHOLDER_SQUARE} alt="1:1 square" />
       </XDSAspectRatio>
     </div>
   ),
@@ -156,12 +140,12 @@ export const Square1x1: Story = {
 
 export const Ultrawide21x9: Story = {
   render: () => (
-    <div {...stylex.props(styles.wideContainer)}>
+    <div sx={styles.wideContainer}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         21:9 - Ultrawide cinematic
       </XDSText>
       <XDSAspectRatio ratio={21 / 9}>
-        <div {...stylex.props(styles.gradientPlaceholder)}>
+        <div sx={styles.gradientPlaceholder}>
           <XDSText type="label">Ultrawide 21:9</XDSText>
         </div>
       </XDSAspectRatio>
@@ -171,8 +155,8 @@ export const Ultrawide21x9: Story = {
 
 export const WithPlaceholderSkeleton: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <div {...stylex.props(styles.container)}>
+    <div sx={styles.storyWrapper}>
+      <div sx={styles.container}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           16:9 with loading skeleton
         </XDSText>
@@ -180,7 +164,7 @@ export const WithPlaceholderSkeleton: Story = {
           <XDSSkeleton width="100%" height="100%" />
         </XDSAspectRatio>
       </div>
-      <div {...stylex.props(styles.smallContainer)}>
+      <div sx={styles.smallContainer}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           1:1 with loading skeleton
         </XDSText>
@@ -194,7 +178,7 @@ export const WithPlaceholderSkeleton: Story = {
 
 export const ResponsiveGrid: Story = {
   render: () => (
-    <div {...stylex.props(styles.wideContainer)}>
+    <div sx={styles.wideContainer}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Responsive grid of aspect ratio boxes
       </XDSText>
@@ -207,9 +191,9 @@ export const ResponsiveGrid: Story = {
           {ratio: 21 / 9, label: '21:9'},
           {ratio: 2 / 3, label: '2:3 Portrait'},
         ].map(({ratio, label}) => (
-          <div key={label} {...stylex.props(styles.gridItem)}>
+          <div key={label} sx={styles.gridItem}>
             <XDSAspectRatio ratio={ratio}>
-              <div {...stylex.props(styles.placeholder)}>
+              <div sx={styles.placeholder}>
                 <XDSText type="label">{label}</XDSText>
               </div>
             </XDSAspectRatio>
@@ -222,53 +206,53 @@ export const ResponsiveGrid: Story = {
 
 export const AllRatiosComparison: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <div {...stylex.props(styles.container)}>
+    <div sx={styles.storyWrapper}>
+      <div sx={styles.container}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           16:9 (1.778) - Widescreen HD
         </XDSText>
         <XDSAspectRatio ratio={16 / 9}>
-          <div {...stylex.props(styles.placeholder)}>
+          <div sx={styles.placeholder}>
             <XDSText type="body">16:9</XDSText>
           </div>
         </XDSAspectRatio>
       </div>
-      <div {...stylex.props(styles.container)}>
+      <div sx={styles.container}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           4:3 (1.333) - Classic TV
         </XDSText>
         <XDSAspectRatio ratio={4 / 3}>
-          <div {...stylex.props(styles.placeholder)}>
+          <div sx={styles.placeholder}>
             <XDSText type="body">4:3</XDSText>
           </div>
         </XDSAspectRatio>
       </div>
-      <div {...stylex.props(styles.smallContainer)}>
+      <div sx={styles.smallContainer}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           1:1 (1.0) - Square
         </XDSText>
         <XDSAspectRatio ratio={1}>
-          <div {...stylex.props(styles.placeholder)}>
+          <div sx={styles.placeholder}>
             <XDSText type="body">1:1</XDSText>
           </div>
         </XDSAspectRatio>
       </div>
-      <div {...stylex.props(styles.container)}>
+      <div sx={styles.container}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           3:2 (1.5) - Classic 35mm Film
         </XDSText>
         <XDSAspectRatio ratio={3 / 2}>
-          <div {...stylex.props(styles.placeholder)}>
+          <div sx={styles.placeholder}>
             <XDSText type="body">3:2</XDSText>
           </div>
         </XDSAspectRatio>
       </div>
-      <div {...stylex.props(styles.wideContainer)}>
+      <div sx={styles.wideContainer}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           21:9 (2.333) - Ultrawide Cinematic
         </XDSText>
         <XDSAspectRatio ratio={21 / 9}>
-          <div {...stylex.props(styles.placeholder)}>
+          <div sx={styles.placeholder}>
             <XDSText type="body">21:9</XDSText>
           </div>
         </XDSAspectRatio>
@@ -279,7 +263,7 @@ export const AllRatiosComparison: Story = {
 
 export const ImageGallery: Story = {
   render: () => (
-    <div {...stylex.props(styles.wideContainer)}>
+    <div sx={styles.wideContainer}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Image gallery with consistent aspect ratios
       </XDSText>
@@ -287,10 +271,9 @@ export const ImageGallery: Story = {
         {Array.from({length: 6}, (_, i) => (
           <XDSAspectRatio key={i} ratio={4 / 3}>
             <img
-              {...stylex.props(styles.image)}
+              sx={styles.image}
               src={`https://picsum.photos/seed/${i + 1}/400/300`}
-              alt={`Gallery image ${i + 1}`}
-            />
+              alt={`Gallery image ${i + 1}`} />
           </XDSAspectRatio>
         ))}
       </XDSGrid>

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -99,9 +99,9 @@ export const WithImage: Story = {
 
 export const AllSizes: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>Named Sizes</h4>
-      <div {...stylex.props(styles.row)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>Named Sizes</h4>
+      <div sx={styles.row}>
         <XDSAvatar name="TY" size="tiny" />
         <XDSAvatar name="XS" size="xsmall" />
         <XDSAvatar name="SM" size="small" />
@@ -114,9 +114,9 @@ export const AllSizes: Story = {
 
 export const WithImages: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>With Images (Different Sizes)</h4>
-      <div {...stylex.props(styles.row)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>With Images (Different Sizes)</h4>
+      <div sx={styles.row}>
         <XDSAvatar
           src="https://i.pravatar.cc/150?img=1"
           name="User 1"
@@ -149,9 +149,9 @@ export const WithImages: Story = {
 
 export const InitialsFallback: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>Initials Fallback</h4>
-      <div {...stylex.props(styles.row)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>Initials Fallback</h4>
+      <div sx={styles.row}>
         <XDSAvatar name="John Doe" size="medium" />
         <XDSAvatar name="Alice" size="medium" />
         <XDSAvatar name="Bob Smith Johnson" size="medium" />
@@ -163,9 +163,9 @@ export const InitialsFallback: Story = {
 
 export const NoImageNoName: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>Default Icon (No Image or Name)</h4>
-      <div {...stylex.props(styles.row)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>Default Icon (No Image or Name)</h4>
+      <div sx={styles.row}>
         <XDSAvatar size="tiny" />
         <XDSAvatar size="xsmall" />
         <XDSAvatar size="small" />
@@ -178,11 +178,11 @@ export const NoImageNoName: Story = {
 
 export const FallbackChain: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>Fallback Chain Demo</h4>
-      <div {...stylex.props(styles.row)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>Fallback Chain Demo</h4>
+      <div sx={styles.row}>
         <div>
-          <p {...stylex.props(styles.heading)}>Valid src</p>
+          <p sx={styles.heading}>Valid src</p>
           <XDSAvatar
             src="https://i.pravatar.cc/150?img=10"
             name="Test User"
@@ -190,7 +190,7 @@ export const FallbackChain: Story = {
           />
         </div>
         <div>
-          <p {...stylex.props(styles.heading)}>
+          <p sx={styles.heading}>
             Invalid src, valid fallbackSrc
           </p>
           <XDSAvatar
@@ -201,7 +201,7 @@ export const FallbackChain: Story = {
           />
         </div>
         <div>
-          <p {...stylex.props(styles.heading)}>Both invalid, has name</p>
+          <p sx={styles.heading}>Both invalid, has name</p>
           <XDSAvatar
             src="https://invalid-url.example/broken.jpg"
             fallbackSrc="https://also-invalid.example/broken.jpg"
@@ -210,7 +210,7 @@ export const FallbackChain: Story = {
           />
         </div>
         <div>
-          <p {...stylex.props(styles.heading)}>All invalid, no name</p>
+          <p sx={styles.heading}>All invalid, no name</p>
           <XDSAvatar
             src="https://invalid-url.example/broken.jpg"
             size="large"
@@ -223,9 +223,9 @@ export const FallbackChain: Story = {
 
 export const WithStatus: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>With Status Indicators</h4>
-      <div {...stylex.props(styles.row)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>With Status Indicators</h4>
+      <div sx={styles.row}>
         <XDSAvatar
           src="https://i.pravatar.cc/150?img=20"
           name="Online User"
@@ -252,13 +252,13 @@ export const WithStatus: Story = {
 export const StatusAcrossAllSizes: Story = {
   name: 'Status Dot Across All Sizes',
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>
         Status dot scales proportionally with avatar size
       </h4>
 
-      <h4 {...stylex.props(styles.heading)}>Named Sizes</h4>
-      <div {...stylex.props(styles.row)}>
+      <h4 sx={styles.heading}>Named Sizes</h4>
+      <div sx={styles.row}>
         <XDSAvatar
           name="TY"
           size="tiny"
@@ -286,8 +286,8 @@ export const StatusAcrossAllSizes: Story = {
         />
       </div>
 
-      <h4 {...stylex.props(styles.heading)}>Numeric Sizes with Images</h4>
-      <div {...stylex.props(styles.row)}>
+      <h4 sx={styles.heading}>Numeric Sizes with Images</h4>
+      <div sx={styles.row}>
         <XDSAvatar
           src="https://i.pravatar.cc/150?img=30"
           name="U1"
@@ -326,8 +326,8 @@ export const StatusAcrossAllSizes: Story = {
         />
       </div>
 
-      <h4 {...stylex.props(styles.heading)}>All Colors at Medium</h4>
-      <div {...stylex.props(styles.row)}>
+      <h4 sx={styles.heading}>All Colors at Medium</h4>
+      <div sx={styles.row}>
         <XDSAvatar
           src="https://i.pravatar.cc/150?img=40"
           name="Positive"
@@ -353,9 +353,9 @@ export const StatusAcrossAllSizes: Story = {
 
 export const StatusWithSizes: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>Status with Different Sizes</h4>
-      <div {...stylex.props(styles.row)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>Status with Different Sizes</h4>
+      <div sx={styles.row}>
         <XDSAvatar name="AB" size="small" status={<XDSAvatarStatusDot />} />
         <XDSAvatar name="CD" size="medium" status={<XDSAvatarStatusDot />} />
         <XDSAvatar name="EF" size="large" status={<XDSAvatarStatusDot />} />
@@ -368,13 +368,13 @@ export const StatusWithSizes: Story = {
 export const StatusWithIcon: Story = {
   name: 'Status Dot with Icon',
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>
         Icon inside status dot (hidden at tiny sizes where there isn't room)
       </h4>
 
-      <h4 {...stylex.props(styles.heading)}>Named Sizes</h4>
-      <div {...stylex.props(styles.row)}>
+      <h4 sx={styles.heading}>Named Sizes</h4>
+      <div sx={styles.row}>
         <XDSAvatar
           name="TY"
           size="tiny"
@@ -434,8 +434,8 @@ export const StatusWithIcon: Story = {
         />
       </div>
 
-      <h4 {...stylex.props(styles.heading)}>Numeric Sizes with Images</h4>
-      <div {...stylex.props(styles.row)}>
+      <h4 sx={styles.heading}>Numeric Sizes with Images</h4>
+      <div sx={styles.row}>
         <XDSAvatar
           src="https://i.pravatar.cc/150?img=30"
           name="U1"
@@ -510,8 +510,8 @@ export const StatusWithIcon: Story = {
         />
       </div>
 
-      <h4 {...stylex.props(styles.heading)}>All Variants with Icons</h4>
-      <div {...stylex.props(styles.row)}>
+      <h4 sx={styles.heading}>All Variants with Icons</h4>
+      <div sx={styles.row}>
         <XDSAvatar
           src="https://i.pravatar.cc/150?img=52"
           name="Positive"
@@ -555,9 +555,9 @@ export const StatusWithIcon: Story = {
 
 export const NumericSizes: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <h4 {...stylex.props(styles.heading)}>Numeric Pixel Sizes</h4>
-      <div {...stylex.props(styles.row)}>
+    <div sx={styles.storyWrapper}>
+      <h4 sx={styles.heading}>Numeric Pixel Sizes</h4>
+      <div sx={styles.row}>
         <XDSAvatar name="16" size={16} />
         <XDSAvatar name="24" size={24} />
         <XDSAvatar name="36" size={36} />

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -50,7 +50,7 @@ const meta: Meta<typeof XDSCard> = {
   tags: ['autodocs'],
   decorators: [
     Story => (
-      <div {...stylex.props(styles.pageWrapper)}>
+      <div sx={styles.pageWrapper}>
         <Story />
       </div>
     ),
@@ -88,7 +88,7 @@ export const Default: Story = {
   },
   render: args => (
     <XDSCard {...args}>
-      <p {...stylex.props(styles.text)}>
+      <p sx={styles.text}>
         Simple content inside a card. The card provides default padding via the
         --container-padding CSS variable.
       </p>
@@ -100,8 +100,8 @@ export const WithSimpleContent: Story = {
   render: () => (
     <XDSCard width={320}>
       <XDSVStack gap="space2">
-        <h3 {...stylex.props(styles.text)}>Card Title</h3>
-        <p {...stylex.props(styles.text, styles.textSecondary)}>
+        <h3 sx={styles.text}>Card Title</h3>
+        <p sx={[styles.text, styles.textSecondary]}>
           This card contains simple content without XDSLayout. The container
           padding is applied automatically.
         </p>
@@ -116,12 +116,12 @@ export const WithInnerLayout: Story = {
       <XDSLayout
         header={
           <XDSLayoutHeader hasDivider>
-            <h3 {...stylex.props(styles.text)}>Card with Layout</h3>
+            <h3 sx={styles.text}>Card with Layout</h3>
           </XDSLayoutHeader>
         }
         content={
           <XDSLayoutContent>
-            <p {...stylex.props(styles.text, styles.textSecondary)}>
+            <p sx={[styles.text, styles.textSecondary]}>
               When using XDSLayout, the layout uses negative margin to escape
               the container padding, then manages its own padding.
             </p>
@@ -146,23 +146,23 @@ export const WithInnerLayout: Story = {
 
 export const Sizes: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div sx={styles.storyWrapper}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>Small (200px)</h4>
+        <h4 sx={styles.heading}>Small (200px)</h4>
         <XDSCard width={200}>
-          <p {...stylex.props(styles.text)}>Small card</p>
+          <p sx={styles.text}>Small card</p>
         </XDSCard>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>Medium (300px)</h4>
+        <h4 sx={styles.heading}>Medium (300px)</h4>
         <XDSCard width={300}>
-          <p {...stylex.props(styles.text)}>Medium card</p>
+          <p sx={styles.text}>Medium card</p>
         </XDSCard>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>Large (400px)</h4>
+        <h4 sx={styles.heading}>Large (400px)</h4>
         <XDSCard width={400}>
-          <p {...stylex.props(styles.text)}>Large card</p>
+          <p sx={styles.text}>Large card</p>
         </XDSCard>
       </div>
     </div>
@@ -175,12 +175,12 @@ export const FixedHeight: Story = {
       <XDSLayout
         header={
           <XDSLayoutHeader hasDivider>
-            <h3 {...stylex.props(styles.text)}>Fixed Height Card</h3>
+            <h3 sx={styles.text}>Fixed Height Card</h3>
           </XDSLayoutHeader>
         }
         content={
           <XDSLayoutContent>
-            <p {...stylex.props(styles.text, styles.textSecondary)}>
+            <p sx={[styles.text, styles.textSecondary]}>
               This card has a fixed height. Content area will scroll if needed.
             </p>
           </XDSLayoutContent>
@@ -194,14 +194,14 @@ export const NestedCards: Story = {
   render: () => (
     <XDSCard width={400}>
       <XDSVStack gap="space3">
-        <h3 {...stylex.props(styles.text)}>Parent Card</h3>
+        <h3 sx={styles.text}>Parent Card</h3>
         <XDSCard width="100%">
-          <p {...stylex.props(styles.text, styles.textSecondary)}>
+          <p sx={[styles.text, styles.textSecondary]}>
             Nested card resets --container-padding and gets its own padding.
           </p>
         </XDSCard>
         <XDSCard width="100%">
-          <p {...stylex.props(styles.text, styles.textSecondary)}>
+          <p sx={[styles.text, styles.textSecondary]}>
             Another nested card with independent padding.
           </p>
         </XDSCard>
@@ -215,8 +215,8 @@ export const NestedSections: Story = {
     <XDSCard width={400}>
       <XDSSection variant="transparent" dividers={['bottom']}>
         <XDSVStack gap="space2">
-          <h3 {...stylex.props(styles.text)}>First Section</h3>
-          <p {...stylex.props(styles.text, styles.textSecondary)}>
+          <h3 sx={styles.text}>First Section</h3>
+          <p sx={[styles.text, styles.textSecondary]}>
             This section escapes the card padding on top and sides because it's
             the first child.
           </p>
@@ -224,8 +224,8 @@ export const NestedSections: Story = {
       </XDSSection>
       <XDSSection variant="transparent" dividers={['bottom']}>
         <XDSVStack gap="space2">
-          <h3 {...stylex.props(styles.text)}>Middle Section</h3>
-          <p {...stylex.props(styles.text, styles.textSecondary)}>
+          <h3 sx={styles.text}>Middle Section</h3>
+          <p sx={[styles.text, styles.textSecondary]}>
             Middle sections only escape horizontal padding, maintaining visual
             separation from adjacent sections.
           </p>
@@ -233,8 +233,8 @@ export const NestedSections: Story = {
       </XDSSection>
       <XDSSection variant="transparent">
         <XDSVStack gap="space2">
-          <h3 {...stylex.props(styles.text)}>Last Section</h3>
-          <p {...stylex.props(styles.text, styles.textSecondary)}>
+          <h3 sx={styles.text}>Last Section</h3>
+          <p sx={[styles.text, styles.textSecondary]}>
             This section escapes the card padding on bottom and sides because
             it's the last child.
           </p>
@@ -249,10 +249,10 @@ export const SingleSection: Story = {
     <XDSCard width={350}>
       <XDSSection variant="wash">
         <XDSVStack gap="space2">
-          <h3 {...stylex.props(styles.text)}>
+          <h3 sx={styles.text}>
             Only Section (Full Bleed All Sides)
           </h3>
-          <p {...stylex.props(styles.text, styles.textSecondary)}>
+          <p sx={[styles.text, styles.textSecondary]}>
             When a section is both first and last child, it gets full bleed on
             all four sides, completely filling the card.
           </p>
@@ -264,25 +264,25 @@ export const SingleSection: Story = {
 
 export const MixedContent: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div sx={styles.storyWrapper}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>Simple Content</h4>
+        <h4 sx={styles.heading}>Simple Content</h4>
         <XDSCard width={250}>
           <XDSVStack gap="space2">
-            <h3 {...stylex.props(styles.text)}>Card Title</h3>
-            <p {...stylex.props(styles.text, styles.textSecondary)}>
+            <h3 sx={styles.text}>Card Title</h3>
+            <p sx={[styles.text, styles.textSecondary]}>
               Regular content uses the card's container padding.
             </p>
           </XDSVStack>
         </XDSCard>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>With Section</h4>
+        <h4 sx={styles.heading}>With Section</h4>
         <XDSCard width={250}>
           <XDSSection variant="wash">
             <XDSVStack gap="space2">
-              <h3 {...stylex.props(styles.text)}>Card Title</h3>
-              <p {...stylex.props(styles.text, styles.textSecondary)}>
+              <h3 sx={styles.text}>Card Title</h3>
+              <p sx={[styles.text, styles.textSecondary]}>
                 Section content bleeds to the card edges.
               </p>
             </XDSVStack>
@@ -295,20 +295,20 @@ export const MixedContent: Story = {
 
 export const FullBleed: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div sx={styles.storyWrapper}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>Default (with padding)</h4>
+        <h4 sx={styles.heading}>Default (with padding)</h4>
         <XDSCard width={250}>
           <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
-            <p {...stylex.props(styles.text)}>Content with card padding</p>
+            <p sx={styles.text}>Content with card padding</p>
           </div>
         </XDSCard>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>Full Bleed (no padding)</h4>
+        <h4 sx={styles.heading}>Full Bleed (no padding)</h4>
         <XDSCard width={250} isFullBleed>
           <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
-            <p {...stylex.props(styles.text)}>Content touches card edges</p>
+            <p sx={styles.text}>Content touches card edges</p>
           </div>
         </XDSCard>
       </div>

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -39,7 +39,7 @@ const styles = stylex.create({
 
 // Demo box component for visibility
 const Box = ({children}: {children: React.ReactNode}) => (
-  <div {...stylex.props(styles.box)}>{children}</div>
+  <div sx={styles.box}>{children}</div>
 );
 
 const meta: Meta<typeof XDSCenter> = {
@@ -164,7 +164,7 @@ export const WithIcon: Story = {
   render: args => (
     <XDSSection variant="wash">
       <XDSCenter {...args}>
-        <div {...stylex.props(styles.iconWrapper)}>
+        <div sx={styles.iconWrapper}>
           <XDSIcon icon={CheckCircleIcon} size="lg" />
         </div>
       </XDSCenter>
@@ -194,7 +194,7 @@ export const AllAxisModes: Story = {
   },
   render: () => (
     <XDSSection variant="wash">
-      <div {...stylex.props(styles.storyWrapper)}>
+      <div sx={styles.storyWrapper}>
         <XDSCard>
           <XDSText type="supporting" display="block">
             axis: both (default)

--- a/apps/storybook/stories/Collapsible.stories.tsx
+++ b/apps/storybook/stories/Collapsible.stories.tsx
@@ -34,7 +34,7 @@ const meta: Meta<typeof XDSCollapsibleGroup> = {
   tags: ['autodocs'],
   decorators: [
     Story => (
-      <div {...stylex.props(styles.pageWrapper)}>
+      <div sx={styles.pageWrapper}>
         <Story />
       </div>
     ),
@@ -51,7 +51,7 @@ export const SingleMode: Story = {
       <XDSVStack gap="space2">
         <XDSCard>
           <XDSCollapsible trigger="General Settings" value="general">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               Configure your general preferences including language, timezone,
               and display options.
             </p>
@@ -59,7 +59,7 @@ export const SingleMode: Story = {
         </XDSCard>
         <XDSCard>
           <XDSCollapsible trigger="Privacy Settings" value="privacy">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               Manage who can see your profile, activity, and personal
               information.
             </p>
@@ -67,7 +67,7 @@ export const SingleMode: Story = {
         </XDSCard>
         <XDSCard>
           <XDSCollapsible trigger="Notification Settings" value="notifications">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               Choose which notifications you receive and how they are delivered.
             </p>
           </XDSCollapsible>
@@ -84,21 +84,21 @@ export const MultipleMode: Story = {
       <XDSVStack gap="space2">
         <XDSCard>
           <XDSCollapsible trigger="What is XDS?" value="faq1">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               XDS is a design system for building internal tools and products.
             </p>
           </XDSCollapsible>
         </XDSCard>
         <XDSCard>
           <XDSCollapsible trigger="How do I install it?" value="faq2">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               Run <code>npm install @xds/core</code> to get started.
             </p>
           </XDSCollapsible>
         </XDSCard>
         <XDSCard>
           <XDSCollapsible trigger="Is it open source?" value="faq3">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               Yes! XDS is open source and available on GitHub.
             </p>
           </XDSCollapsible>
@@ -114,24 +114,24 @@ export const Controlled: Story = {
     const [open, setOpen] = useState<string | string[]>('section1');
     return (
       <div>
-        <p {...stylex.props(styles.textSecondary)}>
+        <p sx={styles.textSecondary}>
           Currently open: <strong>{String(open) || '(none)'}</strong>
         </p>
         <XDSCollapsibleGroup type="single" value={open} onChange={setOpen}>
           <XDSVStack gap="space2">
             <XDSCard>
               <XDSCollapsible trigger="Section 1" value="section1">
-                <p {...stylex.props(styles.text)}>Content for section 1.</p>
+                <p sx={styles.text}>Content for section 1.</p>
               </XDSCollapsible>
             </XDSCard>
             <XDSCard>
               <XDSCollapsible trigger="Section 2" value="section2">
-                <p {...stylex.props(styles.text)}>Content for section 2.</p>
+                <p sx={styles.text}>Content for section 2.</p>
               </XDSCollapsible>
             </XDSCard>
             <XDSCard>
               <XDSCollapsible trigger="Section 3" value="section3">
-                <p {...stylex.props(styles.text)}>Content for section 3.</p>
+                <p sx={styles.text}>Content for section 3.</p>
               </XDSCollapsible>
             </XDSCard>
           </XDSVStack>
@@ -147,14 +147,14 @@ export const StandaloneCollapsible: Story = {
     <XDSVStack gap="space2">
       <XDSCard>
         <XDSCollapsible trigger="Starts open (default)">
-          <p {...stylex.props(styles.text)}>
+          <p sx={styles.text}>
             This collapsible manages its own state. Click the trigger to toggle.
           </p>
         </XDSCollapsible>
       </XDSCard>
       <XDSCard>
         <XDSCollapsible trigger="Starts collapsed" defaultIsOpen={false}>
-          <p {...stylex.props(styles.text)}>
+          <p sx={styles.text}>
             This collapsible starts collapsed. Click to reveal.
           </p>
         </XDSCollapsible>
@@ -168,12 +168,12 @@ export const WithoutCard: Story = {
   render: () => (
     <XDSVStack gap="space2">
       <XDSCollapsible trigger="Show more details">
-        <p {...stylex.props(styles.text)}>
+        <p sx={styles.text}>
           XDSCollapsible works anywhere — it doesn't require a card wrapper.
         </p>
       </XDSCollapsible>
       <XDSCollapsible trigger="Another section" defaultIsOpen={false}>
-        <p {...stylex.props(styles.text)}>This section starts collapsed.</p>
+        <p sx={styles.text}>This section starts collapsed.</p>
       </XDSCollapsible>
     </XDSVStack>
   ),
@@ -186,7 +186,7 @@ export const FAQ: Story = {
       <XDSVStack gap="space2">
         <XDSCard>
           <XDSCollapsible trigger="How do I reset my password?" value="q1">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               Go to Settings → Security → Change Password. You'll receive a
               confirmation email.
             </p>
@@ -194,7 +194,7 @@ export const FAQ: Story = {
         </XDSCard>
         <XDSCard>
           <XDSCollapsible trigger="Can I change my username?" value="q2">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               Usernames can be changed once every 30 days from your profile
               settings.
             </p>
@@ -202,7 +202,7 @@ export const FAQ: Story = {
         </XDSCard>
         <XDSCard>
           <XDSCollapsible trigger="How do I delete my account?" value="q3">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               Account deletion is permanent. Go to Settings → Account → Delete
               Account. Your data will be removed within 30 days.
             </p>
@@ -212,7 +212,7 @@ export const FAQ: Story = {
           <XDSCollapsible
             trigger="What payment methods are accepted?"
             value="q4">
-            <p {...stylex.props(styles.text)}>
+            <p sx={styles.text}>
               We accept Visa, Mastercard, American Express, and PayPal.
             </p>
           </XDSCollapsible>

--- a/apps/storybook/stories/Divider.stories.tsx
+++ b/apps/storybook/stories/Divider.stories.tsx
@@ -82,7 +82,7 @@ export const WithLabel: Story = {
 export const Variants: Story = {
   render: () => (
     <XDSSection variant="wash">
-      <div {...stylex.props(styles.storyWrapper)}>
+      <div sx={styles.storyWrapper}>
         <XDSCard>
           <XDSVStack gap="space3">
             <XDSText type="supporting">Subtle (default)</XDSText>
@@ -103,7 +103,7 @@ export const Variants: Story = {
 export const FullBleed: Story = {
   render: () => (
     <XDSSection variant="wash">
-      <div {...stylex.props(styles.storyWrapper)}>
+      <div sx={styles.storyWrapper}>
         <XDSCard>
           <XDSVStack gap="space3">
             <XDSText type="label">Normal divider</XDSText>

--- a/apps/storybook/stories/FontWrapper.stories.tsx
+++ b/apps/storybook/stories/FontWrapper.stories.tsx
@@ -239,26 +239,21 @@ function StyleXApproachDemo() {
 
   return (
     <XDSFontWrapper>
-      <p {...stylex.props(proseStyles?.p)}>
+      <p sx={proseStyles?.p}>
         While XDSFontWrapper automatically styles native elements via CSS, you
         can also use the{' '}
-        <code {...stylex.props(proseStyles?.code)}>
+        <code sx={proseStyles?.code}>
           useXDSFontWrapperStyles
         </code>{' '}
         hook to access theme styles programmatically for StyleX-based styling:
       </p>
-
-      <h2 {...stylex.props(headingStyles?.h2)}>Styled with StyleX</h2>
-      <p {...stylex.props(proseStyles?.p)}>
+      <h2 sx={headingStyles?.h2}>Styled with StyleX</h2>
+      <p sx={proseStyles?.p}>
         This approach gives you more control and type safety, but requires
         applying styles to each element individually.
       </p>
-
-      <pre {...stylex.props(proseStyles?.pre)}>
-        <code
-          {...stylex.props(
-            proseStyles?.preCode,
-          )}>{`import { useFontWrapperStyles } from '@xds/core';
+      <pre sx={proseStyles?.pre}>
+        <code sx={proseStyles?.preCode}>{`import { useFontWrapperStyles } from '@xds/core';
 import * as stylex from '@stylexjs/stylex';
 
 function Article() {

--- a/apps/storybook/stories/FormLayout.stories.tsx
+++ b/apps/storybook/stories/FormLayout.stories.tsx
@@ -138,14 +138,14 @@ export const MixedControls: Story = {
           ]}
         />
         <XDSField label="Notifications" inputID="notif-group">
-          <div {...stylex.props(checkboxStyles.group)} id="notif-group">
-            <label {...stylex.props(checkboxStyles.label)}>
+          <div sx={checkboxStyles.group} id="notif-group">
+            <label sx={checkboxStyles.label}>
               <input type="checkbox" defaultChecked /> Email
             </label>
-            <label {...stylex.props(checkboxStyles.label)}>
+            <label sx={checkboxStyles.label}>
               <input type="checkbox" /> SMS
             </label>
-            <label {...stylex.props(checkboxStyles.label)}>
+            <label sx={checkboxStyles.label}>
               <input type="checkbox" defaultChecked /> Push
             </label>
           </div>
@@ -229,11 +229,11 @@ export const InDialog: Story = {
     const [name, setName] = useState('Jane Doe');
     const [email, setEmail] = useState('jane@example.com');
     return (
-      <div {...stylex.props(dialogStyles.container)}>
-        <div {...stylex.props(dialogStyles.header)}>
+      <div sx={dialogStyles.container}>
+        <div sx={dialogStyles.header}>
           <XDSText variant="subtitle">Edit Profile</XDSText>
         </div>
-        <div {...stylex.props(dialogStyles.body)}>
+        <div sx={dialogStyles.body}>
           <form
             id="edit-profile"
             onSubmit={e => {
@@ -246,14 +246,12 @@ export const InDialog: Story = {
             </XDSFormLayout>
           </form>
         </div>
-        <div {...stylex.props(dialogStyles.footer)}>
-          <button
-            {...stylex.props(dialogStyles.button, dialogStyles.secondary)}
-            type="button">
+        <div sx={dialogStyles.footer}>
+          <button sx={[dialogStyles.button, dialogStyles.secondary]} type="button">
             Cancel
           </button>
           <button
-            {...stylex.props(dialogStyles.button, dialogStyles.primary)}
+            sx={[dialogStyles.button, dialogStyles.primary]}
             type="submit"
             form="edit-profile">
             Save

--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -121,13 +121,13 @@ export default meta;
 type Story = StoryObj<typeof XDSGrid>;
 
 const GridItem = ({children}: {children: React.ReactNode}) => (
-  <div {...stylex.props(styles.item)}>
+  <div sx={styles.item}>
     <XDSText type="body">{children}</XDSText>
   </div>
 );
 
 const FeaturedItem = ({children}: {children: React.ReactNode}) => (
-  <div {...stylex.props(styles.featuredItem)}>
+  <div sx={styles.featuredItem}>
     <XDSText type="body">{children}</XDSText>
   </div>
 );
@@ -138,7 +138,7 @@ export const Default: Story = {
     gap: 'space4',
   },
   render: args => (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSGrid {...args}>
         <GridItem>Item 1</GridItem>
         <GridItem>Item 2</GridItem>
@@ -153,8 +153,8 @@ export const Default: Story = {
 
 export const FixedColumns: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <div {...stylex.props(styles.container)}>
+    <div sx={styles.storyWrapper}>
+      <div sx={styles.container}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           2 Columns
         </XDSText>
@@ -165,7 +165,7 @@ export const FixedColumns: Story = {
           <GridItem>Item 4</GridItem>
         </XDSGrid>
       </div>
-      <div {...stylex.props(styles.container)}>
+      <div sx={styles.container}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           4 Columns
         </XDSText>
@@ -186,7 +186,7 @@ export const FixedColumns: Story = {
 
 export const ResponsiveAutoFit: Story = {
   render: () => (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Resize the viewport - columns adjust automatically (min 200px per item)
       </XDSText>
@@ -204,7 +204,7 @@ export const ResponsiveAutoFit: Story = {
 
 export const CappedResponsive: Story = {
   render: () => (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Auto-fit with max 3 columns (min 250px per item, capped via max-width)
       </XDSText>
@@ -222,7 +222,7 @@ export const CappedResponsive: Story = {
 
 export const WithGridSpan: Story = {
   render: () => (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Using XDSGridSpan to span multiple columns/rows
       </XDSText>
@@ -246,7 +246,7 @@ export const WithGridSpan: Story = {
 
 export const GridSpanWithRows: Story = {
   render: () => (
-    <div {...stylex.props(styles.container)}>
+    <div sx={styles.container}>
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Grid items spanning both columns and rows
       </XDSText>
@@ -274,7 +274,7 @@ export const GalleryExample: Story = {
       <XDSGrid minChildWidth={280} gap="space5">
         {Array.from({length: 8}, (_, i) => (
           <XDSCard key={i}>
-            <div {...stylex.props(styles.cardImage)} />
+            <div sx={styles.cardImage} />
             <XDSText type="label" display="block">
               Card Title {i + 1}
             </XDSText>
@@ -290,8 +290,8 @@ export const GalleryExample: Story = {
 
 export const DifferentGaps: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <div {...stylex.props(styles.container)}>
+    <div sx={styles.storyWrapper}>
+      <div sx={styles.container}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           Same gap for rows and columns (space4)
         </XDSText>
@@ -304,7 +304,7 @@ export const DifferentGaps: Story = {
           <GridItem>Item 6</GridItem>
         </XDSGrid>
       </div>
-      <div {...stylex.props(styles.container)}>
+      <div sx={styles.container}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           Different gaps: rowGap=space2, columnGap=space6
         </XDSText>

--- a/apps/storybook/stories/HStack.stories.tsx
+++ b/apps/storybook/stories/HStack.stories.tsx
@@ -58,7 +58,7 @@ const Box = ({
 }: {
   children: React.ReactNode;
   alt?: boolean;
-}) => <div {...stylex.props(styles.box, alt && styles.boxAlt)}>{children}</div>;
+}) => <div sx={[styles.box, alt && styles.boxAlt]}>{children}</div>;
 
 const meta: Meta<typeof XDSHStack> = {
   title: 'Layout/XDSHStack',
@@ -201,9 +201,9 @@ export const Wrapping: Story = {
 
 export const AllAlignments: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div sx={styles.storyWrapper}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>vAlign: start</h4>
+        <h4 sx={styles.heading}>vAlign: start</h4>
         <XDSHStack
           gap="space2"
           vAlign="start"
@@ -216,7 +216,7 @@ export const AllAlignments: Story = {
         </XDSHStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>vAlign: center</h4>
+        <h4 sx={styles.heading}>vAlign: center</h4>
         <XDSHStack
           gap="space2"
           vAlign="center"
@@ -229,7 +229,7 @@ export const AllAlignments: Story = {
         </XDSHStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>vAlign: end</h4>
+        <h4 sx={styles.heading}>vAlign: end</h4>
         <XDSHStack
           gap="space2"
           vAlign="end"
@@ -242,7 +242,7 @@ export const AllAlignments: Story = {
         </XDSHStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>vAlign: stretch (default)</h4>
+        <h4 sx={styles.heading}>vAlign: stretch (default)</h4>
         <XDSHStack
           gap="space2"
           vAlign="stretch"

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -125,7 +125,7 @@ const NavItem = ({
   active?: boolean;
   children: React.ReactNode;
 }) => (
-  <div {...stylex.props(styles.navItem, active && styles.navItemActive)}>
+  <div sx={[styles.navItem, active && styles.navItemActive]}>
     {children}
   </div>
 );
@@ -338,7 +338,7 @@ export const Playground = {
     },
   },
   render: (args: PlaygroundArgs) => (
-    <div {...stylex.props(styles.pageWrapper)}>
+    <div sx={styles.pageWrapper}>
       <XDSCard width={args.cardWidth} height={args.cardHeight}>
         <XDSLayout
           isFullBleed={args.layoutIsFullBleed}
@@ -347,7 +347,7 @@ export const Playground = {
               <XDSLayoutHeader
                 hasDivider={args.headerHasDivider}
                 isFullBleed={args.headerIsFullBleed}>
-                <h3 {...stylex.props(styles.heading)}>Layout Header</h3>
+                <h3 sx={styles.heading}>Layout Header</h3>
               </XDSLayoutHeader>
             ) : undefined
           }
@@ -369,20 +369,20 @@ export const Playground = {
             <XDSLayoutContent
               isFullBleed={args.contentIsFullBleed}
               isScrollable={args.contentIsScrollable}>
-              <h4 {...stylex.props(styles.subheading)}>Main Content Area</h4>
+              <h4 sx={styles.subheading}>Main Content Area</h4>
               <br />
-              <p {...stylex.props(styles.bodyText)}>
+              <p sx={styles.bodyText}>
                 This is the main content area. Use the controls panel to toggle
                 headers, footers, side panels, and adjust their properties.
               </p>
               <br />
-              <p {...stylex.props(styles.bodyText)}>
+              <p sx={styles.bodyText}>
                 Try enabling &quot;isFullBleed&quot; to see how content can
                 extend to the edges, or toggle &quot;isScrollable&quot; to
                 change overflow behavior.
               </p>
               <br />
-              <div {...stylex.props(styles.placeholder)}>
+              <div sx={styles.placeholder}>
                 Placeholder content block
               </div>
             </XDSLayoutContent>
@@ -394,8 +394,8 @@ export const Playground = {
                 hasDivider={args.endPanelHasDivider}
                 isScrollable={args.endPanelIsScrollable}
                 role="complementary">
-                <p {...stylex.props(styles.sectionLabel)}>Details</p>
-                <p {...stylex.props(styles.bodyText)}>
+                <p sx={styles.sectionLabel}>Details</p>
+                <p sx={styles.bodyText}>
                   Additional information or actions can go in the end panel.
                 </p>
               </XDSLayoutPanel>
@@ -430,23 +430,23 @@ export const Playground = {
 export const BasicCard: Story = {
   name: 'Basic Card Layout',
   render: () => (
-    <div {...stylex.props(styles.pageWrapper)}>
+    <div sx={styles.pageWrapper}>
       <XDSCard width={400} height={350}>
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <h3 {...stylex.props(styles.heading)}>Card Title</h3>
+              <h3 sx={styles.heading}>Card Title</h3>
             </XDSLayoutHeader>
           }
           content={
             <XDSLayoutContent>
-              <p {...stylex.props(styles.bodyText)}>
+              <p sx={styles.bodyText}>
                 This is a basic card layout with a header, scrollable content
                 area, and footer. The layout automatically handles padding and
                 spacing between sections.
               </p>
               <br />
-              <p {...stylex.props(styles.bodyText)}>
+              <p sx={styles.bodyText}>
                 Try scrolling this content area when it overflows.
               </p>
             </XDSLayoutContent>
@@ -472,12 +472,12 @@ export const BasicCard: Story = {
 export const WithSidebar: Story = {
   name: 'Layout with Sidebar',
   render: () => (
-    <div {...stylex.props(styles.pageWrapper)}>
+    <div sx={styles.pageWrapper}>
       <XDSCard width={700} height={400}>
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <h3 {...stylex.props(styles.heading)}>Settings</h3>
+              <h3 sx={styles.heading}>Settings</h3>
             </XDSLayoutHeader>
           }
           start={
@@ -491,9 +491,9 @@ export const WithSidebar: Story = {
           }
           content={
             <XDSLayoutContent>
-              <h4 {...stylex.props(styles.subheading)}>General Settings</h4>
+              <h4 sx={styles.subheading}>General Settings</h4>
               <br />
-              <p {...stylex.props(styles.bodyText)}>
+              <p sx={styles.bodyText}>
                 Configure your general preferences here. The sidebar navigation
                 allows you to switch between different settings sections.
               </p>
@@ -520,17 +520,17 @@ export const WithSidebar: Story = {
 export const DualPanels: Story = {
   name: 'Dual Panel Layout',
   render: () => (
-    <div {...stylex.props(styles.pageWrapper, styles.pageWrapperTall)}>
+    <div sx={[styles.pageWrapper, styles.pageWrapperTall]}>
       <XDSCard width="100%" maxWidth={800} height={400}>
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <h3 {...stylex.props(styles.heading)}>File Browser</h3>
+              <h3 sx={styles.heading}>File Browser</h3>
             </XDSLayoutHeader>
           }
           start={
             <XDSLayoutPanel hasDivider>
-              <p {...stylex.props(styles.sectionLabel)}>Folders</p>
+              <p sx={styles.sectionLabel}>Folders</p>
               <NavItem>Documents</NavItem>
               <NavItem active>Projects</NavItem>
               <NavItem>Downloads</NavItem>
@@ -538,16 +538,16 @@ export const DualPanels: Story = {
           }
           content={
             <XDSLayoutContent>
-              <p {...stylex.props(styles.sectionLabel)}>Files</p>
-              <div {...stylex.props(styles.placeholder)}>
+              <p sx={styles.sectionLabel}>Files</p>
+              <div sx={styles.placeholder}>
                 Select a folder to view its contents
               </div>
             </XDSLayoutContent>
           }
           end={
             <XDSLayoutPanel hasDivider>
-              <p {...stylex.props(styles.sectionLabel)}>Details</p>
-              <p {...stylex.props(styles.bodyText)}>
+              <p sx={styles.sectionLabel}>Details</p>
+              <p sx={styles.bodyText}>
                 Select a file to view details
               </p>
             </XDSLayoutPanel>
@@ -561,17 +561,17 @@ export const DualPanels: Story = {
 export const NoDividers: Story = {
   name: 'Without Dividers',
   render: () => (
-    <div {...stylex.props(styles.pageWrapper)}>
+    <div sx={styles.pageWrapper}>
       <XDSCard width={400} height={350}>
         <XDSLayout
           header={
             <XDSLayoutHeader>
-              <h3 {...stylex.props(styles.heading)}>Seamless Layout</h3>
+              <h3 sx={styles.heading}>Seamless Layout</h3>
             </XDSLayoutHeader>
           }
           content={
             <XDSLayoutContent>
-              <p {...stylex.props(styles.bodyText)}>
+              <p sx={styles.bodyText}>
                 When dividers are not used, the layout automatically collapses
                 spacing between sections for a seamless visual flow.
               </p>
@@ -595,17 +595,17 @@ export const NoDividers: Story = {
 export const FullBleedContent: Story = {
   name: 'Full Bleed Content',
   render: () => (
-    <div {...stylex.props(styles.pageWrapper)}>
+    <div sx={styles.pageWrapper}>
       <XDSCard width={400} height={350}>
         <XDSLayout
           header={
             <XDSLayoutHeader hasDivider>
-              <h3 {...stylex.props(styles.heading)}>Full Bleed Example</h3>
+              <h3 sx={styles.heading}>Full Bleed Example</h3>
             </XDSLayoutHeader>
           }
           content={
             <XDSLayoutContent isFullBleed>
-              <div {...stylex.props(styles.placeholderFullBleed)}>
+              <div sx={styles.placeholderFullBleed}>
                 This content uses isFullBleed to remove padding, allowing it to
                 touch the edges. Useful for tables, images, or other
                 edge-to-edge content.
@@ -631,18 +631,18 @@ export const SectionVariants: Story = {
   name: 'Section Variants',
   render: () => (
     <XDSVStack gap="space6" xstyle={styles.storySection}>
-      <p {...stylex.props(styles.sectionLabel)}>XDSSection Variants</p>
+      <p sx={styles.sectionLabel}>XDSSection Variants</p>
       <XDSHStack gap="space4" wrap="wrap">
         <XDSSection variant="section" width={300} height={250}>
           <XDSLayout
             header={
               <XDSLayoutHeader hasDivider>
-                <p {...stylex.props(styles.subheading)}>Section</p>
+                <p sx={styles.subheading}>Section</p>
               </XDSLayoutHeader>
             }
             content={
               <XDSLayoutContent>
-                <p {...stylex.props(styles.bodyText)}>
+                <p sx={styles.bodyText}>
                   Surface background color
                 </p>
               </XDSLayoutContent>
@@ -654,12 +654,12 @@ export const SectionVariants: Story = {
           <XDSLayout
             header={
               <XDSLayoutHeader hasDivider>
-                <p {...stylex.props(styles.subheading)}>Wash</p>
+                <p sx={styles.subheading}>Wash</p>
               </XDSLayoutHeader>
             }
             content={
               <XDSLayoutContent>
-                <p {...stylex.props(styles.bodyText)}>Wash background color</p>
+                <p sx={styles.bodyText}>Wash background color</p>
               </XDSLayoutContent>
             }
           />
@@ -669,12 +669,12 @@ export const SectionVariants: Story = {
           <XDSLayout
             header={
               <XDSLayoutHeader hasDivider>
-                <p {...stylex.props(styles.subheading)}>Transparent</p>
+                <p sx={styles.subheading}>Transparent</p>
               </XDSLayoutHeader>
             }
             content={
               <XDSLayoutContent>
-                <p {...stylex.props(styles.bodyText)}>
+                <p sx={styles.bodyText}>
                   No background, shows parent
                 </p>
               </XDSLayoutContent>
@@ -689,14 +689,14 @@ export const SectionVariants: Story = {
 export const ContentOnly: Story = {
   name: 'Content Only',
   render: () => (
-    <div {...stylex.props(styles.pageWrapper)}>
+    <div sx={styles.pageWrapper}>
       <XDSCard width={400} height={350}>
         <XDSLayout
           content={
             <XDSLayoutContent>
-              <h3 {...stylex.props(styles.heading)}>Simple Content</h3>
+              <h3 sx={styles.heading}>Simple Content</h3>
               <br />
-              <p {...stylex.props(styles.bodyText)}>
+              <p sx={styles.bodyText}>
                 A layout can have just content without header or footer. This is
                 useful for simple cards or content blocks.
               </p>
@@ -713,7 +713,7 @@ export const ThemedLayout: Story = {
   render: () => (
     <XDSHStack gap="space6" xstyle={styles.storySection}>
       <XDSVStack gap="space3">
-        <p {...stylex.props(styles.sectionLabel)}>
+        <p sx={styles.sectionLabel}>
           Default Theme (16px padding)
         </p>
         <XDSTheme theme={defaultTheme}>
@@ -721,12 +721,12 @@ export const ThemedLayout: Story = {
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
-                  <h3 {...stylex.props(styles.heading)}>Default Theme</h3>
+                  <h3 sx={styles.heading}>Default Theme</h3>
                 </XDSLayoutHeader>
               }
               content={
                 <XDSLayoutContent>
-                  <p {...stylex.props(styles.bodyText)}>
+                  <p sx={styles.bodyText}>
                     This card uses the default theme with 16px padding around
                     the layout areas.
                   </p>
@@ -750,7 +750,7 @@ export const ThemedLayout: Story = {
       </XDSVStack>
 
       <XDSVStack gap="space3">
-        <p {...stylex.props(styles.sectionLabel)}>
+        <p sx={styles.sectionLabel}>
           Neutral Theme (12px padding)
         </p>
         <XDSTheme theme={neutralTheme}>
@@ -758,12 +758,12 @@ export const ThemedLayout: Story = {
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
-                  <h3 {...stylex.props(styles.heading)}>Neutral Theme</h3>
+                  <h3 sx={styles.heading}>Neutral Theme</h3>
                 </XDSLayoutHeader>
               }
               content={
                 <XDSLayoutContent>
-                  <p {...stylex.props(styles.bodyText)}>
+                  <p sx={styles.bodyText}>
                     This card uses the neutral theme with 12px padding around
                     the layout areas.
                   </p>
@@ -793,40 +793,36 @@ export const OuterPaddingDemo: Story = {
   name: 'Outer Padding Demonstration',
   render: () => (
     <XDSVStack gap="space6" xstyle={styles.storySection}>
-      <p {...stylex.props(styles.sectionLabel)}>Outer Padding</p>
-      <p {...stylex.props(styles.bodyText)}>
+      <p sx={styles.sectionLabel}>Outer Padding</p>
+      <p sx={styles.bodyText}>
         Outer padding creates space between the container edge and the layout
         content. Notice how the dividers are inset from the container edges as
         outer padding increases.
       </p>
       <XDSHStack gap="space4" wrap="wrap">
         <XDSVStack gap="space2">
-          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing0</p>
+          <p sx={styles.subheading}>paddingOuterX/Y = spacing0</p>
           <div
-            {...stylex.props(
-              ...container({
-                paddingOuterX: 'spacing0',
-                paddingOuterY: 'spacing0',
-              }),
-              styles.demoContainer,
-              styles.demoSize,
-            )}>
+            sx={[...container({
+              paddingOuterX: 'spacing0',
+              paddingOuterY: 'spacing0',
+            }), styles.demoContainer, styles.demoSize]}>
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
-                  <p {...stylex.props(styles.subheading)}>Header</p>
+                  <p sx={styles.subheading}>Header</p>
                 </XDSLayoutHeader>
               }
               content={
                 <XDSLayoutContent>
-                  <p {...stylex.props(styles.bodyText)}>
+                  <p sx={styles.bodyText}>
                     Dividers touch container edges.
                   </p>
                 </XDSLayoutContent>
               }
               footer={
                 <XDSLayoutFooter hasDivider>
-                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                  <p sx={styles.bodyText}>Footer</p>
                 </XDSLayoutFooter>
               }
             />
@@ -834,32 +830,28 @@ export const OuterPaddingDemo: Story = {
         </XDSVStack>
 
         <XDSVStack gap="space2">
-          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing4</p>
+          <p sx={styles.subheading}>paddingOuterX/Y = spacing4</p>
           <div
-            {...stylex.props(
-              ...container({
-                paddingOuterX: 'spacing4',
-                paddingOuterY: 'spacing4',
-              }),
-              styles.demoContainer,
-              styles.demoSize,
-            )}>
+            sx={[...container({
+              paddingOuterX: 'spacing4',
+              paddingOuterY: 'spacing4',
+            }), styles.demoContainer, styles.demoSize]}>
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
-                  <p {...stylex.props(styles.subheading)}>Header</p>
+                  <p sx={styles.subheading}>Header</p>
                 </XDSLayoutHeader>
               }
               content={
                 <XDSLayoutContent>
-                  <p {...stylex.props(styles.bodyText)}>
+                  <p sx={styles.bodyText}>
                     16px inset from edges.
                   </p>
                 </XDSLayoutContent>
               }
               footer={
                 <XDSLayoutFooter hasDivider>
-                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                  <p sx={styles.bodyText}>Footer</p>
                 </XDSLayoutFooter>
               }
             />
@@ -867,32 +859,28 @@ export const OuterPaddingDemo: Story = {
         </XDSVStack>
 
         <XDSVStack gap="space2">
-          <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing7</p>
+          <p sx={styles.subheading}>paddingOuterX/Y = spacing7</p>
           <div
-            {...stylex.props(
-              ...container({
-                paddingOuterX: 'spacing7',
-                paddingOuterY: 'spacing7',
-              }),
-              styles.demoContainer,
-              styles.demoSize,
-            )}>
+            sx={[...container({
+              paddingOuterX: 'spacing7',
+              paddingOuterY: 'spacing7',
+            }), styles.demoContainer, styles.demoSize]}>
             <XDSLayout
               header={
                 <XDSLayoutHeader hasDivider>
-                  <p {...stylex.props(styles.subheading)}>Header</p>
+                  <p sx={styles.subheading}>Header</p>
                 </XDSLayoutHeader>
               }
               content={
                 <XDSLayoutContent>
-                  <p {...stylex.props(styles.bodyText)}>
+                  <p sx={styles.bodyText}>
                     48px inset from edges.
                   </p>
                 </XDSLayoutContent>
               }
               footer={
                 <XDSLayoutFooter hasDivider>
-                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                  <p sx={styles.bodyText}>Footer</p>
                 </XDSLayoutFooter>
               }
             />

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -49,7 +49,7 @@ const meta: Meta<typeof XDSSection> = {
   tags: ['autodocs'],
   decorators: [
     Story => (
-      <div {...stylex.props(styles.pageWrapper)}>
+      <div sx={styles.pageWrapper}>
         <Story />
       </div>
     ),
@@ -85,7 +85,7 @@ export const Default: Story = {
   },
   render: args => (
     <XDSSection {...args}>
-      <p {...stylex.props(styles.text)}>
+      <p sx={styles.text}>
         A section with default padding. Sections are used to define distinct
         areas within a page.
       </p>
@@ -95,23 +95,23 @@ export const Default: Story = {
 
 export const Variants: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div sx={styles.storyWrapper}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>section (default)</h4>
+        <h4 sx={styles.heading}>section (default)</h4>
         <XDSSection variant="section" width={200}>
-          <p {...stylex.props(styles.text)}>Surface background</p>
+          <p sx={styles.text}>Surface background</p>
         </XDSSection>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>wash</h4>
+        <h4 sx={styles.heading}>wash</h4>
         <XDSSection variant="wash" width={200}>
-          <p {...stylex.props(styles.text)}>Wash background</p>
+          <p sx={styles.text}>Wash background</p>
         </XDSSection>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>transparent</h4>
+        <h4 sx={styles.heading}>transparent</h4>
         <XDSSection variant="transparent" width={200}>
-          <p {...stylex.props(styles.text)}>Transparent background</p>
+          <p sx={styles.text}>Transparent background</p>
         </XDSSection>
       </div>
     </div>
@@ -122,8 +122,8 @@ export const WithSimpleContent: Story = {
   render: () => (
     <XDSSection variant="wash" width={320}>
       <XDSVStack gap="space2">
-        <h3 {...stylex.props(styles.text)}>Section Title</h3>
-        <p {...stylex.props(styles.text, styles.textSecondary)}>
+        <h3 sx={styles.text}>Section Title</h3>
+        <p sx={[styles.text, styles.textSecondary]}>
           This section contains simple content without XDSLayout. The container
           padding is applied automatically.
         </p>
@@ -138,12 +138,12 @@ export const WithInnerLayout: Story = {
       <XDSLayout
         header={
           <XDSLayoutHeader hasDivider>
-            <h3 {...stylex.props(styles.text)}>Section with Layout</h3>
+            <h3 sx={styles.text}>Section with Layout</h3>
           </XDSLayoutHeader>
         }
         content={
           <XDSLayoutContent>
-            <p {...stylex.props(styles.text, styles.textSecondary)}>
+            <p sx={[styles.text, styles.textSecondary]}>
               When using XDSLayout, the layout manages its own padding
               independently from the container padding.
             </p>
@@ -170,8 +170,8 @@ export const PageLayout: Story = {
         header={
           <XDSLayoutHeader hasDivider>
             <XDSVStack gap="space2">
-              <h2 {...stylex.props(styles.text)}>Page Header</h2>
-              <p {...stylex.props(styles.text, styles.textSecondary)}>
+              <h2 sx={styles.text}>Page Header</h2>
+              <p sx={[styles.text, styles.textSecondary]}>
                 Welcome to the application
               </p>
             </XDSVStack>
@@ -179,14 +179,14 @@ export const PageLayout: Story = {
         }
         start={
           <XDSLayoutPanel hasDivider width={150}>
-            <h3 {...stylex.props(styles.text)}>Sidebar</h3>
+            <h3 sx={styles.text}>Sidebar</h3>
           </XDSLayoutPanel>
         }
         content={
           <XDSLayoutContent>
             <XDSVStack gap="space2">
-              <h3 {...stylex.props(styles.text)}>Main Content</h3>
-              <p {...stylex.props(styles.text, styles.textSecondary)}>
+              <h3 sx={styles.text}>Main Content</h3>
+              <p sx={[styles.text, styles.textSecondary]}>
                 This demonstrates how XDSLayout can be used to create page
                 layouts with header, sidebar, and content areas.
               </p>
@@ -200,20 +200,20 @@ export const PageLayout: Story = {
 
 export const FullBleed: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div sx={styles.storyWrapper}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>Default (with padding)</h4>
+        <h4 sx={styles.heading}>Default (with padding)</h4>
         <XDSSection variant="wash" width={250}>
           <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
-            <p {...stylex.props(styles.text)}>Content with section padding</p>
+            <p sx={styles.text}>Content with section padding</p>
           </div>
         </XDSSection>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>Full Bleed (no padding)</h4>
+        <h4 sx={styles.heading}>Full Bleed (no padding)</h4>
         <XDSSection variant="wash" width={250} isFullBleed>
           <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
-            <p {...stylex.props(styles.text)}>Content touches section edges</p>
+            <p sx={styles.text}>Content touches section edges</p>
           </div>
         </XDSSection>
       </div>

--- a/apps/storybook/stories/Stack.stories.tsx
+++ b/apps/storybook/stories/Stack.stories.tsx
@@ -105,13 +105,13 @@ const Box = ({
   orange?: boolean;
 }) => (
   <div
-    {...stylex.props(
+    sx={[
       styles.box,
       alt && styles.boxAlt,
       green && styles.boxGreen,
       purple && styles.boxPurple,
-      orange && styles.boxOrange,
-    )}>
+      orange && styles.boxOrange
+    ]}>
     {children}
   </div>
 );
@@ -233,9 +233,9 @@ export const Vertical: Story = {
 
 export const HorizontalAlignments: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div sx={styles.storyWrapper}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
+        <h4 sx={styles.heading}>
           direction=&quot;horizontal&quot;, vAlign: start
         </h4>
         <XDSStack
@@ -251,7 +251,7 @@ export const HorizontalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
+        <h4 sx={styles.heading}>
           direction=&quot;horizontal&quot;, vAlign: center
         </h4>
         <XDSStack
@@ -267,7 +267,7 @@ export const HorizontalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
+        <h4 sx={styles.heading}>
           direction=&quot;horizontal&quot;, vAlign: end
         </h4>
         <XDSStack
@@ -283,7 +283,7 @@ export const HorizontalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
+        <h4 sx={styles.heading}>
           direction=&quot;horizontal&quot;, vAlign: stretch (default)
         </h4>
         <XDSStack
@@ -304,9 +304,9 @@ export const HorizontalAlignments: Story = {
 
 export const VerticalAlignments: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapperRow)}>
+    <div sx={styles.storyWrapperRow}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
+        <h4 sx={styles.heading}>
           direction=&quot;vertical&quot;, hAlign: start
         </h4>
         <XDSStack
@@ -324,7 +324,7 @@ export const VerticalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
+        <h4 sx={styles.heading}>
           direction=&quot;vertical&quot;, hAlign: center
         </h4>
         <XDSStack
@@ -342,7 +342,7 @@ export const VerticalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
+        <h4 sx={styles.heading}>
           direction=&quot;vertical&quot;, hAlign: end
         </h4>
         <XDSStack
@@ -360,7 +360,7 @@ export const VerticalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
+        <h4 sx={styles.heading}>
           direction=&quot;vertical&quot;, hAlign: stretch
         </h4>
         <XDSStack
@@ -438,7 +438,7 @@ export const StackItemFillSize: Story = {
 export const StackItemEqualFill: Story = {
   render: () => (
     <div>
-      <h4 {...stylex.props(styles.heading)}>Equal Fill (1:1:1)</h4>
+      <h4 sx={styles.heading}>Equal Fill (1:1:1)</h4>
       <XDSStack
         direction="horizontal"
         gap="space2"

--- a/apps/storybook/stories/VStack.stories.tsx
+++ b/apps/storybook/stories/VStack.stories.tsx
@@ -57,7 +57,7 @@ const Box = ({
 }: {
   children: React.ReactNode;
   alt?: boolean;
-}) => <div {...stylex.props(styles.box, alt && styles.boxAlt)}>{children}</div>;
+}) => <div sx={[styles.box, alt && styles.boxAlt]}>{children}</div>;
 
 const meta: Meta<typeof XDSVStack> = {
   title: 'Layout/XDSVStack',
@@ -188,9 +188,9 @@ export const Wrapping: Story = {
 
 export const AllAlignments: Story = {
   render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
+    <div sx={styles.storyWrapper}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>hAlign: start</h4>
+        <h4 sx={styles.heading}>hAlign: start</h4>
         <XDSVStack
           gap="space2"
           hAlign="start"
@@ -205,7 +205,7 @@ export const AllAlignments: Story = {
         </XDSVStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>hAlign: center</h4>
+        <h4 sx={styles.heading}>hAlign: center</h4>
         <XDSVStack
           gap="space2"
           hAlign="center"
@@ -220,7 +220,7 @@ export const AllAlignments: Story = {
         </XDSVStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>hAlign: end</h4>
+        <h4 sx={styles.heading}>hAlign: end</h4>
         <XDSVStack
           gap="space2"
           hAlign="end"
@@ -235,7 +235,7 @@ export const AllAlignments: Story = {
         </XDSVStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>hAlign: stretch</h4>
+        <h4 sx={styles.heading}>hAlign: stretch</h4>
         <XDSVStack
           gap="space2"
           hAlign="stretch"

--- a/internal/vibe-tests/app/src/report/CodeModal.tsx
+++ b/internal/vibe-tests/app/src/report/CodeModal.tsx
@@ -58,7 +58,7 @@ export function CodeModal({
       purpose="info"
       width={800}
       aria-label={`${targetLabel} code for ${promptId}`}>
-      <div {...stylex.props(styles.header)}>
+      <div sx={styles.header}>
         <XDSVStack gap="space1">
           <XDSHeading level={3}>
             {promptId} — {targetLabel}
@@ -73,8 +73,8 @@ export function CodeModal({
           onClick={onHide}
         />
       </div>
-      <div {...stylex.props(styles.content)}>
-        <div {...stylex.props(styles.codeBlock)}>{code}</div>
+      <div sx={styles.content}>
+        <div sx={styles.codeBlock}>{code}</div>
       </div>
     </XDSDialog>
   );

--- a/internal/vibe-tests/app/src/report/CompareView.tsx
+++ b/internal/vibe-tests/app/src/report/CompareView.tsx
@@ -463,54 +463,50 @@ export function CompareView({comparison}: CompareViewProps) {
 
   return (
     <XDSVStack gap="space4">
-      <div
-        {...stylex.props(
-          isThreeWay ? styles.summaryGrid4 : styles.summaryGrid,
-        )}>
+      <div sx={isThreeWay ? styles.summaryGrid4 : styles.summaryGrid}>
         <XDSCard>
-          <div {...stylex.props(styles.winCard)}>
+          <div sx={styles.winCard}>
             <XDSVStack gap="space2">
               <XDSText type="label">XDS Wins</XDSText>
               <XDSHeading level={2}>
-                <span {...stylex.props(styles.positive)}>{xdsWins}</span>
+                <span sx={styles.positive}>{xdsWins}</span>
               </XDSHeading>
             </XDSVStack>
           </div>
         </XDSCard>
         <XDSCard>
-          <div {...stylex.props(styles.winCard)}>
+          <div sx={styles.winCard}>
             <XDSVStack gap="space2">
               <XDSText type="label">Baseline Wins</XDSText>
               <XDSHeading level={2}>
-                <span {...stylex.props(styles.negative)}>{baselineWins}</span>
+                <span sx={styles.negative}>{baselineWins}</span>
               </XDSHeading>
             </XDSVStack>
           </div>
         </XDSCard>
         {isThreeWay && (
           <XDSCard>
-            <div {...stylex.props(styles.winCard)}>
+            <div sx={styles.winCard}>
               <XDSVStack gap="space2">
                 <XDSText type="label">HTML Wins</XDSText>
                 <XDSHeading level={2}>
-                  <span {...stylex.props(styles.warning)}>{htmlWins}</span>
+                  <span sx={styles.warning}>{htmlWins}</span>
                 </XDSHeading>
               </XDSVStack>
             </div>
           </XDSCard>
         )}
         <XDSCard>
-          <div {...stylex.props(styles.winCard)}>
+          <div sx={styles.winCard}>
             <XDSVStack gap="space2">
               <XDSText type="label">Ties</XDSText>
               <XDSHeading level={2}>
-                <span {...stylex.props(styles.neutral)}>{ties}</span>
+                <span sx={styles.neutral}>{ties}</span>
               </XDSHeading>
             </XDSVStack>
           </div>
         </XDSCard>
       </div>
-
       <XDSVStack gap="space3">
         <XDSHeading level={3}>Dimension Comparison</XDSHeading>
         <XDSTable<DimRow>
@@ -521,7 +517,6 @@ export function CompareView({comparison}: CompareViewProps) {
           dividers="rows"
         />
       </XDSVStack>
-
       {catData.length > 0 && (
         <XDSVStack gap="space3">
           <XDSHeading level={3}>Category Breakdown</XDSHeading>
@@ -534,7 +529,6 @@ export function CompareView({comparison}: CompareViewProps) {
           />
         </XDSVStack>
       )}
-
       {xds.cost && baseline.cost && (
         <XDSVStack gap="space3">
           <XDSHeading level={3}>Cost Comparison</XDSHeading>

--- a/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
+++ b/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
@@ -79,7 +79,7 @@ const styles = stylex.create({
 
 function ScoreItem({label, score}: {label: string; score: number}) {
   return (
-    <div {...stylex.props(styles.scoreItem)}>
+    <div sx={styles.scoreItem}>
       <XDSStatusDot
         variant={scoreToStatusVariant(score)}
         label={`${label}: ${score}`}
@@ -94,10 +94,10 @@ function ScoreItem({label, score}: {label: string; score: number}) {
 
 function ScoreSummary({label, score}: {label: string; score: UniversalScore}) {
   return (
-    <div {...stylex.props(styles.scoreBlock)}>
+    <div sx={styles.scoreBlock}>
       <XDSVStack gap="space2">
         <XDSText type="label">{label}</XDSText>
-        <div {...stylex.props(styles.scoreGrid)}>
+        <div sx={styles.scoreGrid}>
           {ALL_DIMENSIONS.map(dim => (
             <ScoreItem
               key={dim}
@@ -125,7 +125,7 @@ function Findings({score}: {score: UniversalScore}) {
   }
 
   return (
-    <div {...stylex.props(styles.findingsGrid)}>
+    <div sx={styles.findingsGrid}>
       {allFindings.map((f, i) => (
         <>
           <XDSBadge
@@ -189,10 +189,10 @@ export function PromptDetailCard({
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.card)}>
+      <div sx={styles.card}>
         <XDSVStack gap="space3">
           {/* Header: prompt ID, prompt text, and buttons */}
-          <div {...stylex.props(styles.header)}>
+          <div sx={styles.header}>
             <XDSHeading level={4}>{promptId}</XDSHeading>
             {promptText && (
               <XDSText type="body" xstyle={styles.promptText}>
@@ -200,7 +200,7 @@ export function PromptDetailCard({
               </XDSText>
             )}
             {(hasAnyPreview || hasAnyCode) && (
-              <div {...stylex.props(styles.buttonRow)}>
+              <div sx={styles.buttonRow}>
                 {previewUrls?.xds && (
                   <XDSButton
                     variant="secondary"
@@ -255,7 +255,7 @@ export function PromptDetailCard({
 
           {/* Score summaries in constrained grid */}
           {(xdsScore || baselineScore || htmlScore) && (
-            <div {...stylex.props(scoresStyle)}>
+            <div sx={scoresStyle}>
               {xdsScore && <ScoreSummary label="XDS" score={xdsScore} />}
               {baselineScore && (
                 <ScoreSummary label="Baseline" score={baselineScore} />
@@ -268,8 +268,8 @@ export function PromptDetailCard({
           {xdsScore && (
             <>
               <XDSDivider />
-              <div {...stylex.props(styles.section)}>
-                <div {...stylex.props(styles.sectionLabel)}>
+              <div sx={styles.section}>
+                <div sx={styles.sectionLabel}>
                   <XDSText type="label">XDS Findings</XDSText>
                 </div>
                 <Findings score={xdsScore} />
@@ -280,8 +280,8 @@ export function PromptDetailCard({
           {baselineScore && (
             <>
               <XDSDivider />
-              <div {...stylex.props(styles.section)}>
-                <div {...stylex.props(styles.sectionLabel)}>
+              <div sx={styles.section}>
+                <div sx={styles.sectionLabel}>
                   <XDSText type="label">Baseline Findings</XDSText>
                 </div>
                 <Findings score={baselineScore} />
@@ -292,8 +292,8 @@ export function PromptDetailCard({
           {htmlScore && (
             <>
               <XDSDivider />
-              <div {...stylex.props(styles.section)}>
-                <div {...stylex.props(styles.sectionLabel)}>
+              <div sx={styles.section}>
+                <div sx={styles.sectionLabel}>
                   <XDSText type="label">HTML Findings</XDSText>
                 </div>
                 <Findings score={htmlScore} />

--- a/internal/vibe-tests/app/src/report/Report.tsx
+++ b/internal/vibe-tests/app/src/report/Report.tsx
@@ -60,7 +60,7 @@ const styles = stylex.create({
 
 function MetricValue({label, value}: {label: string; value: string}) {
   return (
-    <div {...stylex.props(styles.metricItem)}>
+    <div sx={styles.metricItem}>
       <XDSVStack gap="space1">
         <XDSText type="label">{label}</XDSText>
         <XDSHeading level={3}>{value}</XDSHeading>
@@ -93,10 +93,10 @@ function EfficiencyMetricsCard({
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.metricsCard)}>
+      <div sx={styles.metricsCard}>
         <XDSVStack gap="space2">
           <XDSHeading level={4}>Efficiency Metrics</XDSHeading>
-          <div {...stylex.props(styles.metricsGrid)}>
+          <div sx={styles.metricsGrid}>
             <MetricValue
               label="Decisions / Element"
               value={avgDecisions.toFixed(1)}
@@ -138,10 +138,10 @@ function MaintainabilityMetricsCard({
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.metricsCard)}>
+      <div sx={styles.metricsCard}>
         <XDSVStack gap="space2">
           <XDSHeading level={4}>Maintainability Metrics</XDSHeading>
-          <div {...stylex.props(styles.metricsGrid)}>
+          <div sx={styles.metricsGrid}>
             <MetricValue
               label="Semantic Ratio"
               value={`${(avgSemantic * 100).toFixed(0)}%`}
@@ -163,10 +163,10 @@ function CostMetricsCard({cost}: {cost: ReportData['universal']['cost']}) {
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.metricsCard)}>
+      <div sx={styles.metricsCard}>
         <XDSVStack gap="space2">
           <XDSHeading level={4}>Cost</XDSHeading>
-          <div {...stylex.props(styles.metricsGrid)}>
+          <div sx={styles.metricsGrid}>
             {cost.avgDurationMs > 0 && (
               <MetricValue
                 label="Avg Duration"
@@ -209,9 +209,9 @@ export function Report() {
   if (!data) {
     return (
       <XDSTheme theme={defaultTheme} mode={themeMode}>
-        <div {...stylex.props(styles.root)}>
-          <div {...stylex.props(styles.container)}>
-            <div {...stylex.props(styles.emptyState)}>
+        <div sx={styles.root}>
+          <div sx={styles.container}>
+            <div sx={styles.emptyState}>
               <XDSVStack gap="space4">
                 <XDSHeading level={2}>No Report Data</XDSHeading>
                 <XDSText type="body">
@@ -230,11 +230,11 @@ export function Report() {
 
   return (
     <XDSTheme theme={defaultTheme} mode={themeMode}>
-      <div {...stylex.props(styles.root)}>
-        <div {...stylex.props(styles.container)}>
+      <div sx={styles.root}>
+        <div sx={styles.container}>
           <XDSVStack gap="space5">
             {/* Header */}
-            <div {...stylex.props(styles.header)}>
+            <div sx={styles.header}>
               <XDSHStack gap="space4" hAlign="between" vAlign="center">
                 <XDSVStack gap="space1">
                   <XDSHeading level={1}>Vibe Test Report</XDSHeading>
@@ -267,7 +267,7 @@ export function Report() {
             </XDSTabList>
 
             {/* Tab Content */}
-            <div {...stylex.props(styles.tabContent)}>
+            <div sx={styles.tabContent}>
               {activeTab === 'overview' && (
                 <XDSVStack gap="space4">
                   {/* Overall score */}
@@ -289,7 +289,7 @@ export function Report() {
                   {/* Dimension scores grid */}
                   <XDSVStack gap="space3">
                     <XDSHeading level={3}>Dimensions</XDSHeading>
-                    <div {...stylex.props(styles.scoreGrid)}>
+                    <div sx={styles.scoreGrid}>
                       {ALL_DIMENSIONS.map(dim => (
                         <ScoreCard
                           key={dim}

--- a/internal/vibe-tests/app/src/report/ScoreCard.tsx
+++ b/internal/vibe-tests/app/src/report/ScoreCard.tsx
@@ -40,7 +40,7 @@ export function ScoreCard({
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.card)}>
+      <div sx={styles.card}>
         <XDSVStack gap="space2">
           <XDSText type="label">{label}</XDSText>
           <XDSHStack gap="space2" hAlign="center">

--- a/internal/vibe-tests/app/src/report/ScreenshotGallery.tsx
+++ b/internal/vibe-tests/app/src/report/ScreenshotGallery.tsx
@@ -89,20 +89,19 @@ export function ScreenshotGallery({screenshots}: ScreenshotGalleryProps) {
 
   return (
     <>
-      <div {...stylex.props(styles.grid)}>
+      <div sx={styles.grid}>
         {items.map(item => (
           <XDSCard key={item.filename}>
             <XDSVStack gap="space0">
               <img
-                {...stylex.props(styles.image)}
+                sx={styles.image}
                 src={item.src}
                 alt={`Screenshot: ${item.promptId}`}
-                onClick={() => setEnlarged(item.src)}
-              />
-              <div {...stylex.props(styles.cardContent)}>
+                onClick={() => setEnlarged(item.src)} />
+              <div sx={styles.cardContent}>
                 <XDSVStack gap="space1">
                   <XDSText type="label">{item.promptId}</XDSText>
-                  <div {...stylex.props(styles.meta)}>
+                  <div sx={styles.meta}>
                     <XDSText type="supporting">{item.viewport}</XDSText>
                     <XDSText type="supporting">{item.theme}</XDSText>
                   </div>
@@ -113,14 +112,8 @@ export function ScreenshotGallery({screenshots}: ScreenshotGalleryProps) {
         ))}
       </div>
       {enlarged && (
-        <div
-          {...stylex.props(styles.overlay)}
-          onClick={() => setEnlarged(null)}>
-          <img
-            {...stylex.props(styles.overlayImage)}
-            src={enlarged}
-            alt="Enlarged screenshot"
-          />
+        <div sx={styles.overlay} onClick={() => setEnlarged(null)}>
+          <img sx={styles.overlayImage} src={enlarged} alt="Enlarged screenshot" />
         </div>
       )}
     </>

--- a/packages/cli/templates/login/page.tsx
+++ b/packages/cli/templates/login/page.tsx
@@ -38,9 +38,9 @@ export default function LoginPage() {
     <XDSLayout
       content={
         <XDSLayoutContent>
-          <div {...stylex.props(styles.container)}>
+          <div sx={styles.container}>
             <form onSubmit={handleSubmit}>
-              <div {...stylex.props(styles.card)}>
+              <div sx={styles.card}>
                 <XDSVStack gap="space5">
                   <XDSText type="large" weight="semibold">
                     Sign in

--- a/packages/cli/templates/table/page.tsx
+++ b/packages/cli/templates/table/page.tsx
@@ -61,22 +61,22 @@ export default function TablePage() {
       }
       content={
         <XDSLayoutContent>
-          <table {...stylex.props(styles.table)}>
+          <table sx={styles.table}>
             <thead>
               <tr>
-                <th {...stylex.props(styles.th)}>Name</th>
-                <th {...stylex.props(styles.th)}>Status</th>
-                <th {...stylex.props(styles.th)}>Updated</th>
-                <th {...stylex.props(styles.th)}>Actions</th>
+                <th sx={styles.th}>Name</th>
+                <th sx={styles.th}>Status</th>
+                <th sx={styles.th}>Updated</th>
+                <th sx={styles.th}>Actions</th>
               </tr>
             </thead>
             <tbody>
               {data.map(item => (
-                <tr key={item.id} {...stylex.props(styles.row)}>
-                  <td {...stylex.props(styles.td)}>
+                <tr key={item.id} sx={styles.row}>
+                  <td sx={styles.td}>
                     <XDSText type="body">{item.name}</XDSText>
                   </td>
-                  <td {...stylex.props(styles.td)}>
+                  <td sx={styles.td}>
                     <XDSText
                       type="body"
                       color={
@@ -85,12 +85,12 @@ export default function TablePage() {
                       {item.status}
                     </XDSText>
                   </td>
-                  <td {...stylex.props(styles.td)}>
+                  <td sx={styles.td}>
                     <XDSText type="body" color="secondary">
                       {item.updatedAt}
                     </XDSText>
                   </td>
-                  <td {...stylex.props(styles.td)}>
+                  <td sx={styles.td}>
                     <XDSButton label="Edit" variant="secondary" size="sm" />
                   </td>
                 </tr>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -384,7 +384,6 @@
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
     "@stylexjs/babel-plugin": "^0.18.1",
-    "@stylexjs/esbuild-plugin": "^0.18.1",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",
     "esbuild-plugin-babel": "^0.2.3"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -383,13 +383,13 @@
     "@babel/core": "^7.28.5",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@stylexjs/babel-plugin": "^0.17.4",
-    "@stylexjs/esbuild-plugin": "^0.11.1",
+    "@stylexjs/babel-plugin": "^0.18.1",
+    "@stylexjs/esbuild-plugin": "^0.18.1",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",
     "esbuild-plugin-babel": "^0.2.3"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.17.4"
+    "@stylexjs/stylex": "^0.18.1"
   }
 }

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -418,14 +418,14 @@ export const XDSAppShell = forwardRef<HTMLDivElement, XDSAppShellProps>(
     const headerInner =
       hasTopNav || hasBanner ? (
         <XDSLayoutHeader isFullBleed hasDivider={hasTopNav}>
-          {hasBanner && <div {...stylex.props(styles.banner)}>{banner}</div>}
+          {hasBanner && <div sx={styles.banner}>{banner}</div>}
           {hasTopNav && topNav}
         </XDSLayoutHeader>
       ) : undefined;
 
     const headerContent =
       headerInner != null ? (
-        <div ref={headerRef} {...stylex.props(isAuto && styles.headerSticky)}>
+        <div ref={headerRef} sx={isAuto && styles.headerSticky}>
           {headerInner}
         </div>
       ) : undefined;
@@ -452,8 +452,8 @@ export const XDSAppShell = forwardRef<HTMLDivElement, XDSAppShellProps>(
 
     const sideNavContent =
       sideNavPanel != null && isAuto ? (
-        <div {...stylex.props(styles.sideNavAutoWrapper)}>
-          <div {...stylex.props(styles.sideNavSticky)}>{sideNavPanel}</div>
+        <div sx={styles.sideNavAutoWrapper}>
+          <div sx={styles.sideNavSticky}>{sideNavPanel}</div>
         </div>
       ) : (
         sideNavPanel
@@ -482,20 +482,19 @@ export const XDSAppShell = forwardRef<HTMLDivElement, XDSAppShellProps>(
       <div
         ref={setShellRef}
         data-testid={dataTestId}
-        {...stylex.props(
+        sx={[
           styles.root,
           background === 'wash' ? styles.rootBgWash : styles.rootBgSurface,
           isFill ? styles.rootFill : styles.rootAuto,
-          xstyle,
-        )}>
+          xstyle
+        ]}>
         {/* Skip-to-content link */}
         <a
           href={`#${MAIN_CONTENT_ID}`}
-          {...stylex.props(styles.skipLink)}
+          sx={styles.skipLink}
           data-testid="skip-to-content">
           Skip to content
         </a>
-
         <XDSLayout
           height={height}
           isFullBleed
@@ -503,7 +502,6 @@ export const XDSAppShell = forwardRef<HTMLDivElement, XDSAppShellProps>(
           start={sideNavContent}
           content={mainContent}
         />
-
         {/* Mobile nav — either explicit mobileNav or default wrapping sideNav */}
         {mobileNav}
         {useDefaultMobileNav && (

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -91,10 +91,10 @@ export const XDSAspectRatio = forwardRef<HTMLElement, XDSAspectRatioProps>(
     return (
       <div
         ref={ref as React.Ref<HTMLDivElement>}
-        {...stylex.props(styles.container, xstyle, rootOverride)}
+        sx={[styles.container, xstyle, rootOverride]}
         style={{aspectRatio: ratio}}
         {...props}>
-        <div {...stylex.props(styles.child)}>{children}</div>
+        <div sx={styles.child}>{children}</div>
       </div>
     );
   },

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -299,48 +299,37 @@ export const XDSAvatar = forwardRef<HTMLDivElement, XDSAvatarProps>(
           role="img"
           aria-label={accessibleName}
           data-testid={testId}
-          {...stylex.props(styles.wrapper, rootOverride)}
+          sx={[styles.wrapper, rootOverride]}
           {...props}>
-          <div
-            {...stylex.props(styles.content, dynamicStyles.size(numericSize))}>
+          <div sx={[styles.content, dynamicStyles.size(numericSize)]}>
             {showImage && (
               <img
                 src={src}
                 alt={accessibleName}
                 onError={() => setImageError(true)}
-                {...stylex.props(styles.image)}
-              />
+                sx={styles.image} />
             )}
             {showFallbackImage && (
               <img
                 src={fallbackSrc}
                 alt={accessibleName}
                 onError={() => setFallbackError(true)}
-                {...stylex.props(styles.image)}
-              />
+                sx={styles.image} />
             )}
             {showInitials && (
               <div
-                {...stylex.props(
-                  styles.fallback,
-                  dynamicStyles.fontSize(numericSize),
-                  fallbackOverride,
-                )}>
+                sx={[styles.fallback, dynamicStyles.fontSize(numericSize), fallbackOverride]}>
                 {getInitials(name)}
               </div>
             )}
             {showIcon && (
-              <div {...stylex.props(styles.fallback, fallbackOverride)}>
+              <div sx={[styles.fallback, fallbackOverride]}>
                 <DefaultIcon size={numericSize} />
               </div>
             )}
           </div>
           {status && (
-            <div
-              {...stylex.props(
-                styles.status,
-                dynamicStyles.statusPosition(numericSize),
-              )}>
+            <div sx={[styles.status, dynamicStyles.statusPosition(numericSize)]}>
               {status}
             </div>
           )}

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -166,16 +166,14 @@ export function XDSAvatarStatusDot({
   return (
     <div
       {...(label ? {'aria-label': label} : undefined)}
-      {...stylex.props(
+      sx={[
         styles.dot,
         variantStyleMap[variant],
-        dynamicStyles.size(dotSize, borderWidth),
-      )}
+        dynamicStyles.size(dotSize, borderWidth)
+      ]}
       {...props}>
       {icon && iconSize > 0 && (
-        <span
-          aria-hidden="true"
-          {...stylex.props(styles.icon, dynamicStyles.iconSize(iconSize))}>
+        <span aria-hidden="true" sx={[styles.icon, dynamicStyles.iconSize(iconSize)]}>
           {icon}
         </span>
       )}

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -147,13 +147,13 @@ export const XDSBadge = forwardRef<HTMLSpanElement, XDSBadgeProps>(
     return (
       <span
         ref={ref}
-        {...stylex.props(
+        sx={[
           styles.base,
           variants[variant],
           rootOverride,
           variantOverride,
-          isDot && styles.dot,
-        )}
+          isDot && styles.dot
+        ]}
         {...props}>
         {icon}
         {children}

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -373,34 +373,30 @@ export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
         ref={ref}
         role={role}
         data-testid={testId}
-        {...stylex.props(
+        sx={[
           styles.root,
           variant === 'card' && styles.card,
           variant === 'section' && styles.section,
-          xstyle,
-        )}>
+          xstyle
+        ]}>
         {/* Header: colored status background */}
         <div
-          {...stylex.props(
-            styles.header,
-            isSingleLine && styles.headerCentered,
-            statusStyles[status],
-          )}>
-          <div {...stylex.props(styles.iconWrapper)} aria-hidden="true">
+          sx={[styles.header, isSingleLine && styles.headerCentered, statusStyles[status]]}>
+          <div sx={styles.iconWrapper} aria-hidden="true">
             {icon != null ? (
               icon
             ) : (
               <XDSIcon icon={DefaultIcon} size="md" color={iconColor} />
             )}
           </div>
-          <div {...stylex.props(styles.headerContent)}>
-            <p {...stylex.props(styles.title)}>{title}</p>
+          <div sx={styles.headerContent}>
+            <p sx={styles.title}>{title}</p>
             {description != null && (
-              <p {...stylex.props(styles.description)}>{description}</p>
+              <p sx={styles.description}>{description}</p>
             )}
           </div>
           {showEndArea && (
-            <div {...stylex.props(styles.endArea, edgeSignals.end)}>
+            <div sx={[styles.endArea, edgeSignals.end]}>
               {endContent}
               {hasChildren && (
                 <XDSButton
@@ -434,11 +430,7 @@ export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
         </div>
         {/* Content area: collapsible card background for additional content */}
         {hasChildren && isExpanded && (
-          <div
-            {...stylex.props(
-              styles.contentArea,
-              variant === 'card' && styles.contentAreaCard,
-            )}>
+          <div sx={[styles.contentArea, variant === 'card' && styles.contentAreaCard]}>
             {children}
           </div>
         )}

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -150,7 +150,7 @@ export function XDSBreadcrumbItem({
 
   const content = (
     <>
-      {startIcon && <span {...stylex.props(itemStyles.icon)}>{startIcon}</span>}
+      {startIcon && <span sx={itemStyles.icon}>{startIcon}</span>}
       {children}
     </>
   );
@@ -158,19 +158,15 @@ export function XDSBreadcrumbItem({
   if (isCurrent) {
     return (
       <li
-        {...stylex.props(
+        sx={[
           itemStyles.root,
-          isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
-        )}
+          isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize
+        ]}
         data-testid={testId}>
         <span
-          {...stylex.props(
-            itemStyles.contentWrapper,
-            itemStyles.current,
-            isSupporting
-              ? itemStyles.supportingCurrent
-              : itemStyles.defaultCurrent,
-          )}
+          sx={[itemStyles.contentWrapper, itemStyles.current, isSupporting
+            ? itemStyles.supportingCurrent
+            : itemStyles.defaultCurrent]}
           aria-current="page">
           {content}
         </span>
@@ -180,18 +176,18 @@ export function XDSBreadcrumbItem({
 
   return (
     <li
-      {...stylex.props(
+      sx={[
         itemStyles.root,
-        isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
-      )}
+        isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize
+      ]}
       data-testid={testId}>
       <LinkComponent
         href={href}
         onClick={onClick}
-        {...stylex.props(
+        sx={[
           itemStyles.link,
-          isSupporting ? itemStyles.supportingLink : itemStyles.defaultLink,
-        )}>
+          isSupporting ? itemStyles.supportingLink : itemStyles.defaultLink
+        ]}>
         {content}
       </LinkComponent>
     </li>

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -195,12 +195,9 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
             key={`sep-${index}`}
             role="presentation"
             aria-hidden="true"
-            {...stylex.props(
-              separatorStyles.root,
-              isSupporting
-                ? separatorStyles.supportingSize
-                : separatorStyles.defaultSize,
-            )}>
+            sx={[separatorStyles.root, isSupporting
+              ? separatorStyles.supportingSize
+              : separatorStyles.defaultSize]}>
             {separator}
           </li>,
         );
@@ -212,8 +209,8 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
         ref={ref}
         aria-label={label}
         data-testid={testId}
-        {...stylex.props(navStyles.root, xstyle)}>
-        <ol {...stylex.props(listStyles.root)}>{rendered}</ol>
+        sx={[navStyles.root, xstyle]}>
+        <ol sx={listStyles.root}>{rendered}</ol>
       </nav>
     );
   },

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -378,7 +378,7 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
         disabled={buttonDisabled}
         aria-label={isIconOnly ? label : undefined}
         aria-busy={isLoadingState || undefined}
-        {...stylex.props(
+        sx={[
           styles.base,
           sizeStyles[size],
           variants[variant],
@@ -387,8 +387,8 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
           buttonDisabled && styles.disabled,
           isLoadingState && loadingStyles.loading,
           edgePaddingSignal,
-          edgeCompStyle,
-        )}
+          edgeCompStyle
+        ]}
         {...props}
         onClick={handleClick}>
         {isLoadingState && (
@@ -412,7 +412,7 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
         {icon}
         {children ?? (isIconOnly ? null : label)}
         {!isIconOnly && endSlot && (
-          <span {...stylex.props(styles.endSlotWrapper)}>{endSlot}</span>
+          <span sx={styles.endSlotWrapper}>{endSlot}</span>
         )}
       </button>
     );

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -360,9 +360,9 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
     );
 
     return (
-      <div {...stylex.props(calendarStyles.calendar, rootOverride)} {...rest}>
+      <div sx={[calendarStyles.calendar, rootOverride]} {...rest}>
         {/* Header with navigation */}
-        <div {...stylex.props(calendarStyles.header)}>
+        <div sx={calendarStyles.header}>
           <XDSButton
             label="Previous month"
             variant="ghost"
@@ -370,7 +370,7 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
             onClick={() => navigateMonth(-1)}
           />
 
-          <span {...stylex.props(calendarStyles.monthYearLabel)}>
+          <span sx={calendarStyles.monthYearLabel}>
             {monthYearLabel}
           </span>
 
@@ -381,9 +381,8 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
             onClick={() => navigateMonth(1)}
           />
         </div>
-
         {/* Month grids */}
-        <div {...stylex.props(calendarStyles.monthsContainer)}>
+        <div sx={calendarStyles.monthsContainer}>
           {visibleMonths.map(month => (
             <MonthGrid
               key={`${month.getFullYear()}-${month.getMonth()}`}
@@ -625,49 +624,40 @@ function MonthGrid({
   }, [month]);
 
   return (
-    <div {...stylex.props(monthGridStyles.monthGrid)}>
+    <div sx={monthGridStyles.monthGrid}>
       {/* Day names header */}
       <div
-        {...stylex.props(
+        sx={[
           monthGridStyles.weekHeader,
-          hasWeekNumbers && monthGridStyles.weekHeaderWithNumbers,
-        )}>
+          hasWeekNumbers && monthGridStyles.weekHeaderWithNumbers
+        ]}>
         {hasWeekNumbers && (
-          <div
-            {...stylex.props(
-              monthGridStyles.dayName,
-              monthGridStyles.weekNumberHeader,
-            )}
-          />
+          <div sx={[monthGridStyles.dayName, monthGridStyles.weekNumberHeader]} />
         )}
         {dayNames.map((name, i) => (
-          <div key={i} {...stylex.props(monthGridStyles.dayName)}>
+          <div key={i} sx={monthGridStyles.dayName}>
             {name}
           </div>
         ))}
       </div>
-
       {/* Days grid */}
       <div
         ref={gridRef as React.RefObject<HTMLDivElement | null>}
         role="grid"
         aria-label={monthLabel}
         onKeyDown={handleGridKeyDown}
-        {...stylex.props(
+        sx={[
           monthGridStyles.daysGrid,
-          hasWeekNumbers && monthGridStyles.daysGridWithNumbers,
-        )}>
+          hasWeekNumbers && monthGridStyles.daysGridWithNumbers
+        ]}>
         {weeks.map((week, weekIndex) => {
           const weekDate = week.find(d => !d.isOutside)?.date || week[0].date;
           const weekNum = getWeekNumber(weekDate);
 
           return (
-            <div
-              key={weekIndex}
-              role="row"
-              {...stylex.props(monthGridStyles.weekRow)}>
+            <div key={weekIndex} role="row" sx={monthGridStyles.weekRow}>
               {hasWeekNumbers && (
-                <div {...stylex.props(monthGridStyles.weekNumber)}>
+                <div sx={monthGridStyles.weekNumber}>
                   {weekNum}
                 </div>
               )}
@@ -739,7 +729,7 @@ function DayCell({
 
   // Empty cell for outside days when not showing them
   if (isOutside && !hasOutsideDays) {
-    return <div {...stylex.props(dayCellStyles.cell)} />;
+    return <div sx={dayCellStyles.cell} />;
   }
 
   const isToday = isSameDay(date, today);
@@ -776,11 +766,11 @@ function DayCell({
   const previewRoundRight = isPreviewEnd || isLastColumn;
 
   return (
-    <div {...stylex.props(dayCellStyles.cell)}>
+    <div sx={dayCellStyles.cell}>
       {/* Range background */}
       {hasRangeBackground && (
         <div
-          {...stylex.props(
+          sx={[
             dayCellStyles.rangeBg,
             dayCellTheme.rangeBg,
             roundLeft && dayCellStyles.rangeBgRadiusLeft,
@@ -788,25 +778,21 @@ function DayCell({
             isRangeStart && dayCellStyles.rangeInsetLeft,
             isRangeStart && roundRight && dayCellStyles.rangeInsetRight,
             isRangeEnd && dayCellStyles.rangeInsetRight,
-            isRangeStart && roundLeft && dayCellStyles.rangeInsetLeft,
-          )}
-        />
+            isRangeStart && roundLeft && dayCellStyles.rangeInsetLeft
+          ]} />
       )}
-
       {/* Preview range background */}
       {isInPreview && (
         <div
-          {...stylex.props(
+          sx={[
             dayCellStyles.previewBg,
             dayCellTheme.previewBg,
             previewRoundLeft && dayCellStyles.previewBgRadiusLeft,
             previewRoundRight && dayCellStyles.previewBgRadiusRight,
             isPreviewStart && dayCellStyles.previewStart,
-            isPreviewEnd && dayCellStyles.previewEnd,
-          )}
-        />
+            isPreviewEnd && dayCellStyles.previewEnd
+          ]} />
       )}
-
       {/* Day button */}
       <button
         type="button"
@@ -819,7 +805,7 @@ function DayCell({
         onClick={() => !isDisabled && onDayClick(date)}
         onMouseEnter={() => !isDisabled && onDayHover(date)}
         onMouseLeave={() => onDayHover(null)}
-        {...stylex.props(
+        sx={[
           dayCellStyles.day,
           dayCellTheme.day,
           isOutside && dayCellStyles.dayOutside,
@@ -833,8 +819,8 @@ function DayCell({
           (isSelected || isRangeStart || isRangeEnd) &&
             dayCellTheme.daySelected,
           isDisabled && dayCellStyles.dayDisabled,
-          isDisabled && dayCellTheme.dayDisabled,
-        )}>
+          isDisabled && dayCellTheme.dayDisabled
+        ]}>
         {dayNumber}
       </button>
     </div>

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -163,30 +163,20 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
     return (
       <div
         ref={ref}
-        {...stylex.props(
-          styles.cardOuter,
-          containerOverride,
-          dynamicStyles.sizing(
-            width ?? null,
-            height ?? null,
-            maxWidth ?? null,
-            minHeight ?? null,
-          ),
-        )}
+        sx={[styles.cardOuter, containerOverride, dynamicStyles.sizing(
+          width ?? null,
+          height ?? null,
+          maxWidth ?? null,
+          minHeight ?? null,
+        )]}
         {...props}>
         <div
-          {...stylex.props(
-            styles.cardInner,
-            hasFixedHeight && styles.scrollable,
-            ...container({
-              paddingInnerX: 'spacing4',
-              paddingInnerY: 'spacing4',
-              paddingOuterX: 'spacing4',
-              paddingOuterY: 'spacing4',
-            }),
-            isFullBleed && styles.fullBleed,
-            contentOverride,
-          )}>
+          sx={[styles.cardInner, hasFixedHeight && styles.scrollable, ...container({
+            paddingInnerX: 'spacing4',
+            paddingInnerY: 'spacing4',
+            paddingOuterX: 'spacing4',
+            paddingOuterY: 'spacing4',
+          }), isFullBleed && styles.fullBleed, contentOverride]}>
           {children}
         </div>
       </div>

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -356,14 +356,13 @@ export const XDSCheckboxInput = forwardRef<
     return (
       <div>
         <div
-          {...stylex.props(
+          sx={[
             styles.container,
             isLabelHidden && styles.containerLabelHidden,
             rootOverride,
-            !isDisabled && stylex.defaultMarker(),
-          )}>
-          <div
-            {...stylex.props(styles.checkboxWrapper, wrapperSizeStyles[size])}>
+            !isDisabled && stylex.defaultMarker()
+          ]}>
+          <div sx={[styles.checkboxWrapper, wrapperSizeStyles[size]]}>
             <input
               ref={ref}
               id={id}
@@ -386,15 +385,10 @@ export const XDSCheckboxInput = forwardRef<
               aria-describedby={ariaDescribedBy}
               aria-invalid={status?.type === 'error' ? true : undefined}
               aria-busy={isBusy || undefined}
-              {...stylex.props(
-                styles.input,
-                wrapperSizeStyles[size],
-                isDisabled && styles.inputDisabled,
-              )}
-            />
+              sx={[styles.input, wrapperSizeStyles[size], isDisabled && styles.inputDisabled]} />
             <div
               aria-hidden="true"
-              {...stylex.props(
+              sx={[
                 styles.checkbox,
                 checkboxSizeStyles[size],
                 checkboxOverride,
@@ -404,8 +398,8 @@ export const XDSCheckboxInput = forwardRef<
                 isDisabled && styles.checkboxDisabled,
                 isDisabled &&
                   !isCheckedOrIndeterminate &&
-                  styles.checkboxDisabledUnchecked,
-              )}>
+                  styles.checkboxDisabledUnchecked
+              ]}>
               {isBusy ? (
                 <XDSSpinner
                   size="sm"
@@ -415,11 +409,11 @@ export const XDSCheckboxInput = forwardRef<
                 <>
                   <svg
                     viewBox="0 0 10 10"
-                    {...stylex.props(
+                    sx={[
                       styles.checkmark,
                       checkmarkSizeStyles[size],
-                      isChecked && styles.checkmarkVisible,
-                    )}>
+                      isChecked && styles.checkmarkVisible
+                    ]}>
                     <path
                       d="M8.5 2.5L4 7.5L1.5 5"
                       stroke="currentColor"
@@ -430,21 +424,16 @@ export const XDSCheckboxInput = forwardRef<
                     />
                   </svg>
                   <div
-                    {...stylex.props(
+                    sx={[
                       styles.indeterminateMark,
                       indeterminateSizeStyles[size],
-                      isIndeterminate && styles.indeterminateMarkVisible,
-                    )}
-                  />
+                      isIndeterminate && styles.indeterminateMarkVisible
+                    ]} />
                 </>
               )}
             </div>
           </div>
-          <div
-            {...stylex.props(
-              styles.labelWrapper,
-              labelWrapperSizeStyles[size],
-            )}>
+          <div sx={[styles.labelWrapper, labelWrapperSizeStyles[size]]}>
             <XDSFieldLabel
               label={label}
               inputID={id}
@@ -455,7 +444,7 @@ export const XDSCheckboxInput = forwardRef<
               labelIcon={labelIcon}
             />
             {description && !isLabelHidden && (
-              <span id={descriptionID} {...stylex.props(styles.description)}>
+              <span id={descriptionID} sx={styles.description}>
                 {description}
               </span>
             )}

--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -177,17 +177,9 @@ export const XDSCollapsible = forwardRef<HTMLDivElement, XDSCollapsibleProps>(
 
     return (
       <div ref={ref} {...props}>
-        <button
-          type="button"
-          onClick={toggle}
-          aria-expanded={isOpen}
-          {...stylex.props(styles.trigger)}>
+        <button type="button" onClick={toggle} aria-expanded={isOpen} sx={styles.trigger}>
           <span>{trigger}</span>
-          <span
-            {...stylex.props(
-              styles.chevron,
-              isOpen ? styles.chevronOpen : styles.chevronClosed,
-            )}>
+          <span sx={[styles.chevron, isOpen ? styles.chevronOpen : styles.chevronClosed]}>
             {chevronIcon}
           </span>
         </button>

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -222,7 +222,7 @@ export function XDSCommandPalette({
       maxHeight={maxHeight}
       purpose="info"
       aria-label={label}
-      {...stylex.props(styles.dialog, xstyle)}>
+      sx={[styles.dialog, xstyle]}>
       <CommandPaletteContext.Provider value={contextValue}>
         {children}
       </CommandPaletteContext.Provider>

--- a/packages/core/src/CommandPalette/XDSCommandPaletteEmpty.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteEmpty.tsx
@@ -38,7 +38,7 @@ export interface XDSCommandPaletteEmptyProps {
  */
 export function XDSCommandPaletteEmpty({children}: XDSCommandPaletteEmptyProps) {
   return (
-    <div role="status" {...stylex.props(styles.empty)}>
+    <div role="status" sx={styles.empty}>
       {children}
     </div>
   );

--- a/packages/core/src/CommandPalette/XDSCommandPaletteFooter.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteFooter.tsx
@@ -51,7 +51,7 @@ export interface XDSCommandPaletteFooterProps {
  */
 export function XDSCommandPaletteFooter({children}: XDSCommandPaletteFooterProps) {
   return (
-    <div {...stylex.props(styles.footer)}>
+    <div sx={styles.footer}>
       {children}
     </div>
   );

--- a/packages/core/src/CommandPalette/XDSCommandPaletteGroup.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteGroup.tsx
@@ -67,8 +67,8 @@ export function XDSCommandPaletteGroup({
   xstyle,
 }: XDSCommandPaletteGroupProps) {
   return (
-    <div role="group" aria-label={heading} {...stylex.props(styles.group, xstyle)}>
-      <div aria-hidden="true" {...stylex.props(styles.heading)}>
+    <div role="group" aria-label={heading} sx={[styles.group, xstyle]}>
+      <div aria-hidden="true" sx={styles.heading}>
         {heading}
       </div>
       {children}

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -179,8 +179,8 @@ export function XDSCommandPaletteInput({
     highlightedIndex >= 0 ? `${listId}-item-${highlightedIndex}` : undefined;
 
   return (
-    <div {...stylex.props(styles.wrapper, xstyle)}>
-      <div {...stylex.props(styles.icon)}>
+    <div sx={[styles.wrapper, xstyle]}>
+      <div sx={styles.icon}>
         <XDSIcon icon="search" size="sm" color="secondary" />
       </div>
       <input
@@ -201,8 +201,7 @@ export function XDSCommandPaletteInput({
         autoComplete="off"
         autoCorrect="off"
         spellCheck={false}
-        {...stylex.props(styles.input)}
-      />
+        sx={styles.input} />
     </div>
   );
 }

--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
@@ -165,14 +165,14 @@ export function XDSCommandPaletteItem({
       aria-disabled={isDisabled || undefined}
       onClick={handleClick}
       onMouseEnter={handleMouseEnter}
-      {...stylex.props(
+      sx={[
         styles.item,
         !isDisabled && styles.itemHover,
         isHighlighted && styles.itemHighlighted,
         isSelected && styles.itemSelected,
         isDisabled && styles.itemDisabled,
-        xstyle,
-      )}>
+        xstyle
+      ]}>
       {children}
     </div>
   );

--- a/packages/core/src/CommandPalette/XDSCommandPaletteList.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteList.tsx
@@ -56,10 +56,7 @@ export function XDSCommandPaletteList({
   const {listId} = useCommandPaletteContext();
 
   return (
-    <div
-      id={listId}
-      role="listbox"
-      {...stylex.props(styles.list, xstyle)}>
+    <div id={listId} role="listbox" sx={[styles.list, xstyle]}>
       {children}
     </div>
   );

--- a/packages/core/src/CommandPalette/XDSCommandPaletteLoading.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteLoading.tsx
@@ -40,7 +40,7 @@ export function XDSCommandPaletteLoading({
   children = 'Loading...',
 }: XDSCommandPaletteLoadingProps) {
   return (
-    <div role="status" aria-live="polite" {...stylex.props(styles.loading)}>
+    <div role="status" aria-live="polite" sx={styles.loading}>
       {children}
     </div>
   );

--- a/packages/core/src/CommandPalette/XDSCommandPaletteProvider.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteProvider.tsx
@@ -394,9 +394,9 @@ function CommandItem({command}: {command: XDSCommand}) {
       keywords={command.keywords}
       isDisabled={command.isDisabled}>
       {command.icon && <XDSIcon icon={command.icon} size="sm" />}
-      <span {...stylex.props(commandItemStyles.label)}>{command.label}</span>
+      <span sx={commandItemStyles.label}>{command.label}</span>
       {command.description && (
-        <span {...stylex.props(commandItemStyles.description)}>
+        <span sx={commandItemStyles.description}>
           {command.description}
         </span>
       )}

--- a/packages/core/src/CommandPalette/XDSCommandPaletteShortcut.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteShortcut.tsx
@@ -88,9 +88,9 @@ export function XDSCommandPaletteShortcut({
   const parts = keys.split('+').map(key => key.trim().toLowerCase());
 
   return (
-    <span {...stylex.props(styles.wrapper)} aria-hidden="true">
+    <span sx={styles.wrapper} aria-hidden="true">
       {parts.map((key, i) => (
-        <kbd key={i} {...stylex.props(styles.kbd)}>
+        <kbd key={i} sx={styles.kbd}>
           {KEY_DISPLAY[key] ?? key.toUpperCase()}
         </kbd>
       ))}

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -477,25 +477,22 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
         labelTooltip={labelTooltip}>
         <div
           ref={popover.triggerRef}
-          {...stylex.props(
+          sx={[
             inputWrapperStyles.base,
             sizeStyles[size],
             isDisabled && inputWrapperStyles.disabled,
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
             status && inputStatusFocusWithinStyles[status.type],
-            wrapperOverride,
-          )}>
+            wrapperOverride
+          ]}>
           <button
             type="button"
             onClick={handleOpen}
             disabled={isDisabled}
             aria-label="Open calendar"
             {...popover.triggerProps}
-            {...stylex.props(
-              styles.iconButton,
-              isDisabled && styles.iconButtonDisabled,
-            )}>
+            sx={[styles.iconButton, isDisabled && styles.iconButtonDisabled]}>
             <XDSIcon icon="calendar" size="sm" color="secondary" />
           </button>
           <input
@@ -513,13 +510,12 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
             aria-busy={isBusy || undefined}
-            {...stylex.props(
+            sx={[
               styles.input,
               isDisabled && styles.inputDisabled,
               !isInputValid && styles.inputInvalid,
-              inputOverride,
-            )}
-          />
+              inputOverride
+            ]} />
           {isBusy && <XDSSpinner size="sm" />}
           {status && (
             <XDSIcon

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -346,7 +346,7 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
         onClick={handleClick}
         onCancel={handleCancel}
         aria-modal="true"
-        {...stylex.props(
+        sx={[
           styles.dialog,
           styles.backdrop,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),
@@ -358,8 +358,8 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
               position?.left,
             ),
           isFullscreen && styles.fullscreen,
-          rootOverride,
-        )}
+          rootOverride
+        ]}
         {...props}>
         {children}
       </dialog>

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -129,11 +129,11 @@ export const XDSDialogHeader = forwardRef<HTMLElement, XDSDialogHeaderProps>(
 
     return (
       <XDSLayoutHeader ref={ref} hasDivider={hasDivider}>
-        <div {...stylex.props(styles.container)}>
+        <div sx={styles.container}>
           {startContent && (
-            <div {...stylex.props(styles.actions)}>{startContent}</div>
+            <div sx={styles.actions}>{startContent}</div>
           )}
-          <div {...stylex.props(styles.titleWrapper)}>
+          <div sx={styles.titleWrapper}>
             <XDSHeading ref={titleRef} level={2} xstyle={styles.titleFocusable}>
               {title}
             </XDSHeading>
@@ -144,10 +144,10 @@ export const XDSDialogHeader = forwardRef<HTMLElement, XDSDialogHeaderProps>(
             )}
           </div>
           {(endContent || onOpenChange) && (
-            <div {...stylex.props(styles.actions)}>
+            <div sx={styles.actions}>
               {endContent}
               {onOpenChange && (
-                <div {...stylex.props(styles.closeButton)}>
+                <div sx={styles.closeButton}>
                   <XDSButton
                     variant="ghost"
                     label="Close"

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -174,43 +174,32 @@ export const XDSDivider = forwardRef<HTMLElement, XDSDividerProps>(
         ref={ref as React.Ref<HTMLDivElement>}
         role="separator"
         aria-orientation={orientation}
-        {...stylex.props(
-          isHorizontal ? baseStyles.horizontal : baseStyles.vertical,
-          isFullBleed &&
-            (isHorizontal
-              ? fullBleedStyles.horizontal
-              : fullBleedStyles.vertical),
-          rootOverride,
-          xstyle,
-        )}
+        sx={[isHorizontal ? baseStyles.horizontal : baseStyles.vertical, isFullBleed &&
+          (isHorizontal
+            ? fullBleedStyles.horizontal
+            : fullBleedStyles.vertical), rootOverride, xstyle]}
         {...props}>
         <div
-          {...stylex.props(
+          sx={[
             isHorizontal ? lineStyles.horizontalLine : lineStyles.verticalLine,
             lineStyles[variant],
-            lineOverride,
-          )}
-        />
+            lineOverride
+          ]} />
         {label && (
           <div
-            {...stylex.props(
+            sx={[
               labelStyles.label,
               !isHorizontal && labelStyles.verticalLabel,
-              labelOverride,
-            )}>
+              labelOverride
+            ]}>
             {label}
           </div>
         )}
         {label && (
           <div
-            {...stylex.props(
-              isHorizontal
-                ? lineStyles.horizontalLine
-                : lineStyles.verticalLine,
-              lineStyles[variant],
-              lineOverride,
-            )}
-          />
+            sx={[isHorizontal
+              ? lineStyles.horizontalLine
+              : lineStyles.verticalLine, lineStyles[variant], lineOverride]} />
         )}
       </div>
     );

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -516,12 +516,12 @@ export function XDSDropdownMenu({
           aria-disabled={item.isDisabled}
           onClick={() => handleItemClick(item)}
           onMouseEnter={() => handleItemMouseEnter(item, flatIndex)}
-          {...stylex.props(
+          sx={[
             styles.item,
             isHighlighted && styles.itemHighlighted,
             item.isDisabled && styles.itemDisabled,
-            itemOverride,
-          )}>
+            itemOverride
+          ]}>
           {children ? children(item) : <DefaultItem item={item} />}
         </div>
       );
@@ -578,7 +578,7 @@ export function XDSDropdownMenu({
 
   // Build chevron icon - inherits color from button text
   const chevronIcon = (
-    <span {...stylex.props(styles.chevronIcon)}>
+    <span sx={styles.chevronIcon}>
       <XDSIcon icon="chevronDown" size="sm" color="inherit" />
     </span>
   );
@@ -612,12 +612,8 @@ export function XDSDropdownMenu({
         {button.label}
         {chevronIcon}
       </XDSButton>
-
       {layer.render(
-        <div
-          id={menuId}
-          role="menu"
-          {...stylex.props(styles.dropdown, rootOverride)}>
+        <div id={menuId} role="menu" sx={[styles.dropdown, rootOverride]}>
           {renderOptions()}
         </div>,
         {

--- a/packages/core/src/DropdownMenu/XDSDropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenuItem.tsx
@@ -90,9 +90,9 @@ export function XDSDropdownMenuItem({
   xstyle,
 }: XDSDropdownMenuItemProps) {
   return (
-    <span {...stylex.props(styles.root, xstyle)}>
+    <span sx={[styles.root, xstyle]}>
       {icon && <XDSIcon icon={icon} size="sm" color="secondary" />}
-      <span {...stylex.props(styles.content)}>
+      <span sx={styles.content}>
         {typeof label === 'string' ? (
           <XDSText type="body" maxLines={1}>
             {label}

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -143,33 +143,21 @@ export const XDSEmptyState = forwardRef<HTMLDivElement, XDSEmptyStateProps>(
       <div
         ref={ref}
         role="status"
-        {...stylex.props(
-          styles.container,
-          isCompact && styles.containerCompact,
-          xstyle,
-        )}
+        sx={[styles.container, isCompact && styles.containerCompact, xstyle]}
         {...props}>
         {icon != null && <div aria-hidden="true">{icon}</div>}
-        <div {...stylex.props(styles.textGroup)}>
-          <h3 {...stylex.props(styles.title, isCompact && styles.titleCompact)}>
+        <div sx={styles.textGroup}>
+          <h3 sx={[styles.title, isCompact && styles.titleCompact]}>
             {title}
           </h3>
           {description != null && (
-            <p
-              {...stylex.props(
-                styles.description,
-                isCompact && styles.descriptionCompact,
-              )}>
+            <p sx={[styles.description, isCompact && styles.descriptionCompact]}>
               {description}
             </p>
           )}
         </div>
         {actions != null && (
-          <div
-            {...stylex.props(
-              styles.actions,
-              isCompact && styles.actionsCompact,
-            )}>
+          <div sx={[styles.actions, isCompact && styles.actionsCompact]}>
             {actions}
           </div>
         )}

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -212,10 +212,7 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
       themeContext?.theme.components?.field?.description;
 
     return (
-      <div
-        ref={ref}
-        {...stylex.props(styles.container, rootOverride)}
-        {...props}>
+      <div ref={ref} sx={[styles.container, rootOverride]} {...props}>
         <XDSFieldLabel
           label={label}
           inputID={inputID}
@@ -228,16 +225,16 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
         {description && (
           <span
             id={descriptionID}
-            {...stylex.props(
+            sx={[
               styles.description,
               isLabelHidden && styles.labelHidden,
-              descriptionOverride,
-            )}>
+              descriptionOverride
+            ]}>
             {description}
           </span>
         )}
         {statusVariant === 'attached' ? (
-          <div {...stylex.props(styles.inputStatusWrapper)}>
+          <div sx={styles.inputStatusWrapper}>
             {children}
             {status?.message && (
               <XDSFieldStatus

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -129,12 +129,12 @@ export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
       <label
         ref={ref}
         htmlFor={inputID}
-        {...stylex.props(
+        sx={[
           styles.label,
           !isDisabled && styles.labelClickable,
           isDisabled && styles.labelDisabled,
-          isLabelHidden && styles.labelHidden,
-        )}>
+          isLabelHidden && styles.labelHidden
+        ]}>
         {labelIcon && (
           <XDSIcon
             icon={labelIcon}
@@ -144,7 +144,7 @@ export const XDSFieldLabel = forwardRef<HTMLLabelElement, XDSFieldLabelProps>(
         )}
         {label}
         {statusText && (
-          <span {...stylex.props(styles.optionalRequired)}>
+          <span sx={styles.optionalRequired}>
             {' '}
             ∙ {statusText}
           </span>

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -106,11 +106,11 @@ export function XDSFieldStatus({
   return (
     <div
       id={id}
-      {...stylex.props(
+      sx={[
         styles.base,
         variant === 'attached' ? styles.attached : styles.detached,
-        colorStyles[type],
-      )}>
+        colorStyles[type]
+      ]}>
       {message}
     </div>
   );

--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -147,12 +147,12 @@ export const XDSFormLayout = forwardRef<HTMLDivElement, XDSFormLayoutProps>(
       <XDSFormLayoutContext.Provider value={contextValue}>
         <div
           ref={ref}
-          {...stylex.props(
+          sx={[
             styles.base,
             direction === 'horizontal' && styles.horizontal,
             direction === 'horizontal-labels' && styles.horizontalLabels,
-            xstyle,
-          )}
+            xstyle
+          ]}
           {...props}>
           {children}
         </div>

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -402,7 +402,7 @@ export const XDSGrid = forwardRef<HTMLElement, XDSGridProps>(function XDSGrid(
   return (
     <div
       ref={ref as React.Ref<HTMLDivElement>}
-      {...stylex.props(
+      sx={[
         baseStyles.grid,
         gap != null && gapStyles[gap],
         rowGap != null && rowGapStyles[rowGap],
@@ -410,8 +410,8 @@ export const XDSGrid = forwardRef<HTMLElement, XDSGridProps>(function XDSGrid(
         align != null && alignStyles[align],
         justify != null && justifyStyles[justify],
         xstyle,
-        rootOverride,
-      )}
+        rootOverride
+      ]}
       style={inlineStyle}
       {...props}>
       {children}

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -81,7 +81,7 @@ export const XDSGridSpan = forwardRef<HTMLElement, XDSGridSpanProps>(
     return (
       <div
         ref={ref as React.Ref<HTMLDivElement>}
-        {...stylex.props(baseStyles.span, xstyle)}
+        sx={[baseStyles.span, xstyle]}
         style={inlineStyle}
         {...props}>
         {children}

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -207,14 +207,8 @@ export const XDSIcon = forwardRef<SVGSVGElement, XDSIconProps>(
       <IconComponent
         ref={ref}
         aria-hidden="true"
-        {...stylex.props(
-          styles.root,
-          colorStyles[color],
-          sizeStyles[size],
-          rootOverride,
-        )}
-        {...props}
-      />
+        sx={[styles.root, colorStyles[color], sizeStyles[size], rootOverride]}
+        {...props} />
     );
   },
 );
@@ -249,7 +243,7 @@ function IconFromRegistry({
 
   return (
     <span
-      {...stylex.props(styles.span, colorStyles[color], spanSizeStyles[size])}
+      sx={[styles.span, colorStyles[color], spanSizeStyles[size]]}
       aria-hidden="true">
       {resolvedIcon}
     </span>

--- a/packages/core/src/Layer/XDSHoverCard.tsx
+++ b/packages/core/src/Layer/XDSHoverCard.tsx
@@ -224,11 +224,11 @@ export function XDSHoverCard({
           ref={hoverCard.ref}
           tabIndex={0}
           aria-describedby={hoverCard.describedBy}
-          {...stylex.props(
+          sx={[
             styles.wrapperInline,
             showHoverIndication && styles.hoverIndication,
-            showHoverIndication && themeHoverIndicationOverride,
-          )}>
+            showHoverIndication && themeHoverIndicationOverride
+          ]}>
           {children}
         </span>
         {hoverCard.renderHoverCard(content)}
@@ -241,7 +241,7 @@ export function XDSHoverCard({
     <>
       <div
         ref={wrapperRef as React.RefObject<HTMLDivElement | null>}
-        {...stylex.props(styles.wrapperContents)}>
+        sx={styles.wrapperContents}>
         {children}
       </div>
       {hoverCard.renderHoverCard(content)}

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -427,7 +427,7 @@ export function XDSPopover({
         {popover.render(
           <div
             data-testid={testId}
-            {...stylex.props(styles.container, styles.contentPadding, xstyle)}>
+            sx={[styles.container, styles.contentPadding, xstyle]}>
             {content}
           </div>,
           {
@@ -442,13 +442,13 @@ export function XDSPopover({
 
   return (
     <>
-      <div ref={wrapperRef} {...stylex.props(styles.anchorWrapper)}>
+      <div ref={wrapperRef} sx={styles.anchorWrapper}>
         {children}
       </div>
       {popover.render(
         <div
           data-testid={testId}
-          {...stylex.props(styles.container, styles.contentPadding, xstyle)}>
+          sx={[styles.container, styles.contentPadding, xstyle]}>
           {content}
         </div>,
         {

--- a/packages/core/src/Layer/XDSTooltip.tsx
+++ b/packages/core/src/Layer/XDSTooltip.tsx
@@ -267,11 +267,11 @@ export function XDSTooltip({
           ref={tooltip.ref}
           tabIndex={0}
           aria-describedby={tooltip.describedBy}
-          {...stylex.props(
+          sx={[
             styles.wrapperInline,
             showHoverIndication && styles.hoverIndication,
-            showHoverIndication && themeHoverIndicationOverride,
-          )}>
+            showHoverIndication && themeHoverIndicationOverride
+          ]}>
           {children}
         </span>
         {tooltip.renderTooltip(content)}
@@ -284,7 +284,7 @@ export function XDSTooltip({
     <>
       <div
         ref={wrapperRef as React.RefObject<HTMLDivElement | null>}
-        {...stylex.props(styles.wrapperContents)}>
+        sx={styles.wrapperContents}>
         {children}
       </div>
       {tooltip.renderTooltip(content)}

--- a/packages/core/src/Layer/useXDSHoverCard.tsx
+++ b/packages/core/src/Layer/useXDSHoverCard.tsx
@@ -426,7 +426,7 @@ export function useXDSHoverCard(
 
       return layer.render(
         <div
-          {...stylex.props(styles.content, themeContentOverride)}
+          sx={[styles.content, themeContentOverride]}
           onMouseEnter={() => {
             isHoveringContentRef.current = true;
             clearTimeouts();

--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -333,7 +333,7 @@ export function useXDSLayer(
           }}
           id={id}
           popover={lightDismiss ? 'auto' : 'manual'}
-          {...stylex.props(styles.base, xstyle)}
+          sx={[styles.base, xstyle]}
           style={anchorStyle}>
           {children}
         </div>
@@ -363,7 +363,7 @@ export function useXDSLayer(
           }}
           id={id}
           popover={lightDismiss ? 'auto' : 'manual'}
-          {...stylex.props(styles.base, styles.fixed)}
+          sx={[styles.base, styles.fixed]}
           style={positionStyle}>
           {children}
         </div>

--- a/packages/core/src/Layer/useXDSPopover.tsx
+++ b/packages/core/src/Layer/useXDSPopover.tsx
@@ -355,7 +355,7 @@ export function useXDSPopover(
           role="dialog"
           aria-modal="true"
           aria-label={dialogLabel}
-          {...stylex.props(styles.contentWrapper)}>
+          sx={styles.contentWrapper}>
           {children}
           {hasCloseButton && (
             <button
@@ -364,10 +364,7 @@ export function useXDSPopover(
               onFocus={() => setIsCloseButtonFocused(true)}
               onBlur={() => setIsCloseButtonFocused(false)}
               aria-label={closeButtonLabel}
-              {...stylex.props(
-                styles.closeButton,
-                isCloseButtonFocused && styles.closeButtonFocused,
-              )}>
+              sx={[styles.closeButton, isCloseButtonFocused && styles.closeButtonFocused]}>
               {closeButtonLabel}
             </button>
           )}

--- a/packages/core/src/Layer/useXDSTooltip.tsx
+++ b/packages/core/src/Layer/useXDSTooltip.tsx
@@ -391,7 +391,7 @@ export function useXDSTooltip(
       };
 
       return layer.render(
-        <div {...stylex.props(styles.content, themeContentOverride)}>
+        <div sx={[styles.content, themeContentOverride]}>
           {children}
         </div>,
         renderProps,

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -187,26 +187,18 @@ export function XDSLayout({
 
   return (
     <XDSLayoutSlotsContext.Provider value={slotsValue}>
-      <div
-        {...stylex.props(
-          styles.layoutOuter,
-          isFill ? styles.fill : styles.auto,
-        )}>
+      <div sx={[styles.layoutOuter, isFill ? styles.fill : styles.auto]}>
         <div
-          {...stylex.props(
+          sx={[
             styles.layoutInner,
             ...stack({direction: 'vertical'}),
             isFill ? styles.fill : styles.auto,
-            isFullBleed && styles.fullBleed,
-          )}>
+            isFullBleed && styles.fullBleed
+          ]}>
           <AreaProvider area="header">{header}</AreaProvider>
-          <div
-            {...stylex.props(
-              ...stack({direction: 'horizontal'}),
-              styles.middle,
-            )}>
+          <div sx={[...stack({direction: 'horizontal'}), styles.middle]}>
             <AreaProvider area="start">{start}</AreaProvider>
-            <div {...stylex.props(...stackItem({size: 'fill'}))}>
+            <div sx={stackItem({size: 'fill'})}>
               <AreaProvider area="content">{content}</AreaProvider>
             </div>
             <AreaProvider area="end">{end}</AreaProvider>

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -148,7 +148,7 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
         ref={ref as React.Ref<HTMLDivElement>}
         role={role}
         aria-label={label}
-        {...stylex.props(
+        sx={[
           styles.content,
           // Outer padding on container edges (unless content is full bleed)
           !hasStart && !isFullBleed && styles.noStart,
@@ -156,8 +156,8 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
           !hasHeader && !isFullBleed && styles.noHeader,
           !hasFooter && !isFullBleed && styles.noFooter,
           isScrollable && styles.scrollable,
-          isFullBleed && styles.fullBleed,
-        )}
+          isFullBleed && styles.fullBleed
+        ]}
         {...props}>
         {children}
       </div>

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -128,13 +128,13 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
         ref={ref as React.Ref<HTMLDivElement>}
         role={role}
         aria-label={label}
-        {...stylex.props(
+        sx={[
           styles.footer,
           dynamicStyles.sizing(height ?? null),
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,
-          shouldCollapseSpacing && styles.collapseTop,
-        )}
+          shouldCollapseSpacing && styles.collapseTop
+        ]}
         {...props}>
         {children}
       </div>

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -128,13 +128,13 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
         ref={ref as React.Ref<HTMLDivElement>}
         role={role}
         aria-label={label}
-        {...stylex.props(
+        sx={[
           styles.header,
           dynamicStyles.sizing(height ?? null),
           isFullBleed && styles.fullBleed,
           hasDivider && styles.divider,
-          shouldCollapseSpacing && styles.collapseBottom,
-        )}
+          shouldCollapseSpacing && styles.collapseBottom
+        ]}
         {...props}>
         {children}
       </div>

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -207,7 +207,7 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
         ref={ref as React.Ref<HTMLDivElement>}
         role={role}
         aria-label={label}
-        {...stylex.props(
+        sx={[
           styles.panel,
           dynamicStyles.sizing(width ?? null),
           // Outer padding on container edges (unless component is full bleed)
@@ -218,8 +218,8 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
           isScrollable && styles.scrollable,
           isFullBleed && styles.fullBleed,
           hasDivider && dividerStyle,
-          shouldCollapseSpacing && collapseStyle,
-        )}
+          shouldCollapseSpacing && collapseStyle
+        ]}
         {...props}>
         {children}
       </div>

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -283,14 +283,14 @@ export const XDSLink = forwardRef<HTMLAnchorElement, XDSLinkProps>(
         aria-label={label}
         aria-disabled={isDisabled || undefined}
         tabIndex={isDisabled ? -1 : undefined}
-        {...stylex.props(
+        sx={[
           styles.base,
           linkColorStyles[color],
           hasUnderline && styles.hasUnderline,
           isStandalone && styles.standalone,
           isDisabled && styles.disabled,
-          rootOverride,
-        )}
+          rootOverride
+        ]}
         {...props}>
         <XDSText
           type={type}

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -169,11 +169,7 @@ export const XDSList = forwardRef<
         withDividers.push(child);
         if (i < childArray.length - 1) {
           withDividers.push(
-            <hr
-              key={`divider-${i}`}
-              aria-hidden="true"
-              {...stylex.props(styles.divider)}
-            />,
+            <hr key={`divider-${i}`} aria-hidden="true" sx={styles.divider} />,
           );
         }
       });
@@ -183,7 +179,7 @@ export const XDSList = forwardRef<
     return (
       <XDSListContext.Provider value={contextValue}>
         {header != null && (
-          <div id={headerId} {...stylex.props(styles.header)}>
+          <div id={headerId} sx={styles.header}>
             {header}
           </div>
         )}
@@ -192,12 +188,12 @@ export const XDSList = forwardRef<
           data-testid={testId}
           aria-labelledby={header != null ? headerId : undefined}
           {...(listStyle === 'none' && !isOrdered ? {role: 'list'} : {})}
-          {...stylex.props(
+          sx={[
             styles.list,
             listStyleTypes[listStyle],
             hasMarkers && styles.listWithMarkers,
-            xstyle,
-          )}>
+            xstyle
+          ]}>
           {renderedChildren}
         </Tag>
       </XDSListContext.Provider>

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -290,13 +290,9 @@ export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
 
     const labelAndDescription = (
       <>
-        <span {...stylex.props(styles.label)}>{label}</span>
+        <span sx={styles.label}>{label}</span>
         {description != null && (
-          <span
-            {...stylex.props(
-              styles.description,
-              descriptionSizeStyles[density],
-            )}>
+          <span sx={[styles.description, descriptionSizeStyles[density]]}>
             {description}
           </span>
         )}
@@ -314,7 +310,7 @@ export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
     const innerContent = (
       <>
         {startContent != null && (
-          <span {...stylex.props(styles.startContent)}>{startContent}</span>
+          <span sx={styles.startContent}>{startContent}</span>
         )}
 
         {href != null ? (
@@ -323,7 +319,7 @@ export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
             target={target}
             aria-disabled={isDisabled || undefined}
             tabIndex={isDisabled ? -1 : undefined}
-            {...stylex.props(styles.invisibleAnchor)}>
+            sx={styles.invisibleAnchor}>
             {labelAndDescription}
           </a>
         ) : onClick != null ? (
@@ -331,15 +327,15 @@ export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
             type="button"
             onClick={onClick}
             disabled={isDisabled}
-            {...stylex.props(styles.invisibleButton)}>
+            sx={styles.invisibleButton}>
             {labelAndDescription}
           </button>
         ) : (
-          <span {...stylex.props(styles.content)}>{labelAndDescription}</span>
+          <span sx={styles.content}>{labelAndDescription}</span>
         )}
 
         {endContent != null && (
-          <span {...stylex.props(styles.endContent)}>{endContent}</span>
+          <span sx={styles.endContent}>{endContent}</span>
         )}
       </>
     );
@@ -350,7 +346,7 @@ export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
         data-testid={testId}
         aria-selected={isSelected || undefined}
         aria-disabled={isDisabled || undefined}
-        {...stylex.props(
+        sx={[
           hasMarkers ? styles.itemWithMarker : styles.item,
           densityStyles[density],
           hasDividers ? styles.noRadius : styles.withRadius,
@@ -358,11 +354,11 @@ export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
           isInteractive && styles.focusWithinOutline,
           isDisabled && styles.disabled,
           isSelected && styles.selected,
-          xstyle,
-        )}
+          xstyle
+        ]}
         onClick={isInteractive ? handleContainerClick : undefined}>
         {hasMarkers ? (
-          <div {...stylex.props(styles.innerWrapper)}>{innerContent}</div>
+          <div sx={styles.innerWrapper}>{innerContent}</div>
         ) : (
           innerContent
         )}

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -333,25 +333,25 @@ export const XDSMobileNav = forwardRef<HTMLDialogElement, XDSMobileNavProps>(
         aria-label={title ?? 'Navigation'}
         onClick={handleDialogClick}
         onCancel={handleCancel}
-        {...stylex.props(
+        sx={[
           styles.dialog,
           styles.backdrop,
           isOpen && styles.backdropOpen,
-          rootOverride,
-        )}>
+          rootOverride
+        ]}>
         {/* Drawer panel */}
         <div
-          {...stylex.props(
+          sx={[
             styles.drawer,
             dynamicStyles.width(width),
             isStart && styles.drawerStart,
             isStart && isOpen && styles.drawerStartOpen,
             !isStart && styles.drawerEnd,
             !isStart && isOpen && styles.drawerEndOpen,
-            drawerOverride,
-          )}>
+            drawerOverride
+          ]}>
           {/* Header with optional title and close button */}
-          <div {...stylex.props(styles.header, !title && styles.headerNoTitle)}>
+          <div sx={[styles.header, !title && styles.headerNoTitle]}>
             {title && <XDSHeading level={2}>{title}</XDSHeading>}
             <XDSButton
               variant="ghost"
@@ -363,7 +363,7 @@ export const XDSMobileNav = forwardRef<HTMLDialogElement, XDSMobileNavProps>(
           </div>
 
           {/* Scrollable content */}
-          <div {...stylex.props(styles.content)}>{children}</div>
+          <div sx={styles.content}>{children}</div>
         </div>
       </dialog>
     );

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -387,11 +387,11 @@ export const XDSMoreMenu = forwardRef<HTMLButtonElement, XDSMoreMenuProps>(
             aria-disabled={item.isDisabled}
             onClick={() => handleItemClick(item)}
             onMouseEnter={() => handleItemMouseEnter(item, flatIndex)}
-            {...stylex.props(
+            sx={[
               styles.item,
               isHighlighted && styles.itemHighlighted,
-              item.isDisabled && styles.itemDisabled,
-            )}>
+              item.isDisabled && styles.itemDisabled
+            ]}>
             {children ? children(item) : <DefaultItem item={item} />}
           </div>
         );
@@ -478,7 +478,7 @@ export const XDSMoreMenu = forwardRef<HTMLButtonElement, XDSMoreMenuProps>(
           data-testid={testId}
         />
         {layer.render(
-          <div id={menuId} role="menu" {...stylex.props(styles.dropdown)}>
+          <div id={menuId} role="menu" sx={styles.dropdown}>
             {renderOptions()}
           </div>,
           {

--- a/packages/core/src/NavIcon/XDSNavIcon.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.tsx
@@ -70,7 +70,7 @@ export interface XDSNavIconProps extends Omit<
 export const XDSNavIcon = forwardRef<HTMLSpanElement, XDSNavIconProps>(
   function XDSNavIcon({icon, ...props}, ref) {
     return (
-      <span ref={ref} {...stylex.props(styles.base)} {...props}>
+      <span ref={ref} sx={styles.base} {...props}>
         {icon}
       </span>
     );

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -472,7 +472,7 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
         }
         labelTooltip={labelTooltip}>
         <div
-          {...stylex.props(
+          sx={[
             inputWrapperStyles.base,
             styles.wrapper,
             sizeStyles[size],
@@ -480,8 +480,8 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
             status && inputStatusFocusWithinStyles[status.type],
-            wrapperOverride,
-          )}>
+            wrapperOverride
+          ]}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
           <input
             ref={setRefs}
@@ -503,14 +503,13 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
             aria-describedby={ariaDescribedBy}
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
-            {...stylex.props(
+            sx={[
               styles.input,
               isDisabled && styles.inputDisabled,
               !isInputValid && styles.inputInvalid,
-              inputOverride,
-            )}
-          />
-          {units && <span {...stylex.props(styles.units)}>{units}</span>}
+              inputOverride
+            ]} />
+          {units && <span sx={styles.units}>{units}</span>}
           {status && (
             <XDSIcon
               icon={statusIconMap[status.type]}

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -445,12 +445,8 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
                     <span
                       key={`ellipsis-${index}`}
                       aria-hidden="true"
-                      {...stylex.props(
-                        styles.ellipsis,
-                        isSm && styles.ellipsisSm,
-                      )}>
-                      …
-                    </span>
+                      sx={[styles.ellipsis, isSm && styles.ellipsisSm]}>…
+                                          </span>
                   );
                 }
                 const isActive = item === page;
@@ -475,7 +471,7 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
         case 'count': {
           if (totalItems == null) return null;
           return (
-            <span {...stylex.props(styles.infoText)}>
+            <span sx={styles.infoText}>
               <XDSText type="body" size="sm" color="secondary">
                 {`${rangeStart}\u2013${rangeEnd} of ${totalItems}`}
               </XDSText>
@@ -486,7 +482,7 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
         case 'compact': {
           if (computedTotalPages == null) return null;
           return (
-            <span {...stylex.props(styles.infoText)}>
+            <span sx={styles.infoText}>
               <XDSText type="body" size="sm" color="secondary">
                 {`Page ${page} of ${computedTotalPages}`}
               </XDSText>
@@ -497,10 +493,7 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
         case 'dots': {
           if (computedTotalPages == null) return null;
           return (
-            <div
-              {...stylex.props(styles.dotsContainer)}
-              role="group"
-              aria-label="Page indicators">
+            <div sx={styles.dotsContainer} role="group" aria-label="Page indicators">
               {Array.from({length: computedTotalPages}, (_, i) => (
                 <button
                   key={i + 1}
@@ -509,13 +502,12 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
                   aria-current={i + 1 === page ? 'page' : undefined}
                   onClick={() => handlePageChange(i + 1)}
                   disabled={isDisabled}
-                  {...stylex.props(
+                  sx={[
                     styles.dot,
                     isSm && styles.dotSm,
                     i + 1 === page && styles.dotActive,
-                    isDisabled && styles.dotDisabled,
-                  )}
-                />
+                    isDisabled && styles.dotDisabled
+                  ]} />
               ))}
             </div>
           );
@@ -532,10 +524,10 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
         ref={ref}
         aria-label={label}
         data-testid={testId}
-        {...stylex.props(styles.root, rootOverride, xstyle)}>
+        sx={[styles.root, rootOverride, xstyle]}>
         {pageSizeOptions != null && pageSizeOptions.length > 0 && (
-          <div {...stylex.props(styles.pageSizeSelector)}>
-            <div {...stylex.props(styles.pageSizeSelectorControl)}>
+          <div sx={styles.pageSizeSelector}>
+            <div sx={styles.pageSizeSelectorControl}>
               <XDSSelector
                 label="Items per page"
                 isLabelHidden
@@ -548,8 +540,7 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
             </div>
           </div>
         )}
-
-        <div {...stylex.props(styles.controls)}>
+        <div sx={styles.controls}>
           <XDSButton
             label="Go to previous page"
             variant="ghost"

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -261,31 +261,22 @@ export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
     const showValueLabel = hasValueLabel && !isIndeterminate;
 
     return (
-      <div
-        ref={ref}
-        {...stylex.props(styles.container, xstyle)}
-        data-testid={dataTestId}>
+      <div ref={ref} sx={[styles.container, xstyle]} data-testid={dataTestId}>
         {/* Label row */}
         {!isLabelHidden || showValueLabel ? (
-          <div {...stylex.props(styles.header)}>
-            <span
-              id={labelId}
-              {...stylex.props(
-                styles.label,
-                isLabelHidden && styles.visuallyHidden,
-              )}>
+          <div sx={styles.header}>
+            <span id={labelId} sx={[styles.label, isLabelHidden && styles.visuallyHidden]}>
               {label}
             </span>
             {showValueLabel && (
-              <span {...stylex.props(styles.valueLabel)}>{valueText}</span>
+              <span sx={styles.valueLabel}>{valueText}</span>
             )}
           </div>
         ) : (
-          <span id={labelId} {...stylex.props(styles.visuallyHidden)}>
+          <span id={labelId} sx={styles.visuallyHidden}>
             {label}
           </span>
         )}
-
         {/* Progress track */}
         <div
           role={isIndeterminate ? 'progressbar' : 'meter'}
@@ -294,19 +285,13 @@ export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
           aria-valuemax={isIndeterminate ? undefined : max}
           aria-labelledby={labelId}
           aria-valuetext={isIndeterminate ? undefined : valueText}
-          {...stylex.props(styles.track, sizeStyles[size])}>
+          sx={[styles.track, sizeStyles[size]]}>
           {isIndeterminate ? (
-            <div
-              {...stylex.props(
-                styles.indeterminateFill,
-                variantStyles[variant],
-              )}
-            />
+            <div sx={[styles.indeterminateFill, variantStyles[variant]]} />
           ) : (
             <div
-              {...stylex.props(styles.fill, variantStyles[variant])}
-              style={{width: `${percentage}%`}}
-            />
+              sx={[styles.fill, variantStyles[variant]]}
+              style={{width: `${percentage}%`}} />
           )}
         </div>
       </div>

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -211,7 +211,7 @@ export function XDSRadioList({
       }
       labelTooltip={labelTooltip}
       statusVariant="detached"
-      {...stylex.props(xstyle)}>
+      sx={xstyle}>
       <div
         role="radiogroup"
         aria-label={label}
@@ -225,11 +225,11 @@ export function XDSRadioList({
         }
         aria-invalid={status?.type === 'error' ? true : undefined}
         aria-required={isRequired || undefined}
-        {...stylex.props(
+        sx={[
           styles.radiogroup,
           orientation === 'vertical' ? styles.vertical : styles.horizontal,
-          rootOverride,
-        )}>
+          rootOverride
+        ]}>
         <RadioListContext.Provider value={contextValue}>
           {children}
         </RadioListContext.Provider>

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -256,19 +256,16 @@ export function XDSRadioListItem({
   return (
     <div
       data-testid={dataTestId}
-      {...stylex.props(
-        styles.container,
-        !isDisabled && stylex.defaultMarker(),
-      )}>
+      sx={[styles.container, !isDisabled && stylex.defaultMarker()]}>
       {startContent && (
-        <div {...stylex.props(styles.startContent)}>{startContent}</div>
+        <div sx={styles.startContent}>{startContent}</div>
       )}
       <div
-        {...stylex.props(
+        sx={[
           styles.radioWrapper,
           wrapperSizeStyles[size],
-          !isDisabled && styles.radioWrapperFocus,
-        )}>
+          !isDisabled && styles.radioWrapperFocus
+        ]}>
         <input
           id={id}
           type="radio"
@@ -279,40 +276,33 @@ export function XDSRadioListItem({
           required={context.isRequired}
           onChange={() => context.onChange(value)}
           aria-describedby={description ? descriptionID : undefined}
-          {...stylex.props(
-            styles.input,
-            wrapperSizeStyles[size],
-            isDisabled && styles.inputDisabled,
-          )}
-        />
+          sx={[styles.input, wrapperSizeStyles[size], isDisabled && styles.inputDisabled]} />
         <div
           aria-hidden="true"
-          {...stylex.props(
+          sx={[
             styles.radio,
             radioSizeStyles[size],
             isChecked ? styles.radioChecked : styles.radioUnchecked,
             isDisabled && styles.radioDisabled,
-            isDisabled && !isChecked && styles.radioDisabledUnchecked,
-          )}>
+            isDisabled && !isChecked && styles.radioDisabledUnchecked
+          ]}>
           {isChecked && (
-            <div {...stylex.props(styles.innerDot, dotSizeStyles[size])} />
+            <div sx={[styles.innerDot, dotSizeStyles[size]]} />
           )}
         </div>
       </div>
-      <div {...stylex.props(styles.labelWrapper, labelWrapperSizeStyles[size])}>
-        <label
-          htmlFor={id}
-          {...stylex.props(styles.label, isDisabled && styles.labelDisabled)}>
+      <div sx={[styles.labelWrapper, labelWrapperSizeStyles[size]]}>
+        <label htmlFor={id} sx={[styles.label, isDisabled && styles.labelDisabled]}>
           {label}
         </label>
         {description && (
-          <span id={descriptionID} {...stylex.props(styles.description)}>
+          <span id={descriptionID} sx={styles.description}>
             {description}
           </span>
         )}
       </div>
       {endContent && (
-        <div {...stylex.props(styles.endContent)}>{endContent}</div>
+        <div sx={styles.endContent}>{endContent}</div>
       )}
     </div>
   );

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -225,35 +225,20 @@ export const XDSSection = forwardRef<HTMLDivElement, XDSSectionProps>(
     return (
       <div
         ref={ref}
-        {...stylex.props(
-          nestedStyles.outer,
-          dynamicStyles.sizing(
-            width ?? null,
-            height ?? null,
-            maxWidth ?? null,
-            minHeight ?? null,
-          ),
-          containerOverride,
-        )}
+        sx={[nestedStyles.outer, dynamicStyles.sizing(
+          width ?? null,
+          height ?? null,
+          maxWidth ?? null,
+          minHeight ?? null,
+        ), containerOverride]}
         {...props}>
         <div
-          {...stylex.props(
-            nestedStyles.inner,
-            ...container({
-              paddingInnerX: 'spacing4',
-              paddingInnerY: 'spacing4',
-              paddingOuterX: 'spacing4',
-              paddingOuterY: 'spacing4',
-            }),
-            variantStyles[variant],
-            variantOverride,
-            isFullBleed && nestedStyles.fullBleed,
-            dividers?.includes('top') && dividerStyles.top,
-            dividers?.includes('bottom') && dividerStyles.bottom,
-            dividers?.includes('start') && dividerStyles.start,
-            dividers?.includes('end') && dividerStyles.end,
-            contentOverride,
-          )}>
+          sx={[nestedStyles.inner, ...container({
+            paddingInnerX: 'spacing4',
+            paddingInnerY: 'spacing4',
+            paddingOuterX: 'spacing4',
+            paddingOuterY: 'spacing4',
+          }), variantStyles[variant], variantOverride, isFullBleed && nestedStyles.fullBleed, dividers?.includes('top') && dividerStyles.top, dividers?.includes('bottom') && dividerStyles.bottom, dividers?.includes('start') && dividerStyles.start, dividers?.includes('end') && dividerStyles.end, contentOverride]}>
           {children}
         </div>
       </div>

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -512,13 +512,13 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
           aria-disabled={item.disabled}
           onClick={() => onItemSelect(item)}
           onMouseEnter={() => onItemMouseEnter(item, flatIndex)}
-          {...stylex.props(
+          sx={[
             styles.item,
             isHighlighted && styles.itemHighlighted,
             isSelected && styles.itemSelected,
-            item.disabled && styles.itemDisabled,
-          )}>
-          <span {...stylex.props(styles.itemContent)}>
+            item.disabled && styles.itemDisabled
+          ]}>
+          <span sx={styles.itemContent}>
             {children ? children(item) : <DefaultOption option={item} />}
           </span>
           {isSelected && <XDSIcon icon="check" size="sm" color="accent" />}
@@ -622,23 +622,23 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
         onClick={onTriggerClick}
         onKeyDown={onKeyDown}
         data-testid={testId}
-        {...stylex.props(
+        sx={[
           styles.trigger,
           sizeStyles[size],
           isDisabled && styles.triggerDisabled,
           !selectedItem && styles.triggerPlaceholder,
           status && inputStatusBorderStyles[status.type],
           status && inputStatusHoverShadowStyles[status.type],
-          triggerOverride,
-        )}>
+          triggerOverride
+        ]}>
         <span>{selectedItem?.label ?? placeholder}</span>
         {isBusy && <XDSSpinner size="sm" />}
         <span
-          {...stylex.props(
+          sx={[
             styles.triggerIcon,
             !status && layer.isOpen && styles.triggerIconOpen,
-            status && styles.triggerIconStatus,
-          )}>
+            status && styles.triggerIconStatus
+          ]}>
           {status ? (
             <XDSIcon
               icon={STATUS_ICON_MAP[status.type]}
@@ -650,19 +650,18 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
           )}
         </span>
       </button>
-
       {layer.render(
         <div
           ref={listboxRef}
           id={listboxId}
           role="listbox"
           aria-labelledby={triggerId}
-          {...stylex.props(
+          sx={[
             styles.dropdown,
             !isPositioned && styles.dropdownHidden,
             styles.dropdownOffset(-selectedItemOffset),
-            dropdownOverride,
-          )}>
+            dropdownOverride
+          ]}>
           {renderOptions()}
         </div>,
         {

--- a/packages/core/src/Selector/XDSSelectorOption.tsx
+++ b/packages/core/src/Selector/XDSSelectorOption.tsx
@@ -86,9 +86,9 @@ export function XDSSelectorOption({
   xstyle,
 }: XDSSelectorOptionProps) {
   return (
-    <span {...stylex.props(styles.root, xstyle)}>
+    <span sx={[styles.root, xstyle]}>
       {icon && <XDSIcon icon={icon} size="sm" color="secondary" />}
-      <span {...stylex.props(styles.content)}>
+      <span sx={styles.content}>
         {typeof label === 'string' ? (
           <XDSText type="body" maxLines={1}>
             {label}

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -182,22 +182,22 @@ export const XDSSideNav = forwardRef<HTMLElement, XDSSideNavProps>(
         role="navigation"
         aria-label="Side navigation"
         data-testid={testId}
-        {...stylex.props(styles.root, rootOverride, xstyle)}
+        sx={[styles.root, rootOverride, xstyle]}
         {...props}>
         {hasStickyTop && (
-          <div {...stylex.props(styles.stickyTop)}>
+          <div sx={styles.stickyTop}>
             {header}
             {topContent && (
-              <div {...stylex.props(styles.topContent)}>{topContent}</div>
+              <div sx={styles.topContent}>{topContent}</div>
             )}
           </div>
         )}
-        <div {...stylex.props(styles.scrollable)}>{children}</div>
+        <div sx={styles.scrollable}>{children}</div>
         {hasStickyBottom && (
-          <div {...stylex.props(styles.stickyBottom)}>
-            {footer && <div {...stylex.props(styles.footer)}>{footer}</div>}
+          <div sx={styles.stickyBottom}>
+            {footer && <div sx={styles.footer}>{footer}</div>}
             {footerIcons && (
-              <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
+              <div sx={styles.footerIcons}>{footerIcons}</div>
             )}
           </div>
         )}

--- a/packages/core/src/SideNav/XDSSideNavHeader.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeader.tsx
@@ -301,7 +301,7 @@ export const XDSSideNavHeader = forwardRef<
 
   // Render text content
   const renderTextContent = () => (
-    <span {...stylex.props(styles.textContainer)}>
+    <span sx={styles.textContainer}>
       {supertitle &&
         (hasAnyHref && supertitleHref && menu ? (
           <XDSLink
@@ -312,7 +312,7 @@ export const XDSSideNavHeader = forwardRef<
             {supertitle}
           </XDSLink>
         ) : (
-          <span {...stylex.props(styles.supertitle)}>{supertitle}</span>
+          <span sx={styles.supertitle}>{supertitle}</span>
         ))}
       {hasAnyHref && titleHref && menu ? (
         <XDSLink
@@ -323,7 +323,7 @@ export const XDSSideNavHeader = forwardRef<
           {title}
         </XDSLink>
       ) : (
-        <span {...stylex.props(styles.title)}>{title}</span>
+        <span sx={styles.title}>{title}</span>
       )}
       {subtitle &&
         (hasAnyHref && subtitleHref && menu ? (
@@ -335,13 +335,13 @@ export const XDSSideNavHeader = forwardRef<
             {subtitle}
           </XDSLink>
         ) : (
-          <span {...stylex.props(styles.subtitle)}>{subtitle}</span>
+          <span sx={styles.subtitle}>{subtitle}</span>
         ))}
     </span>
   );
 
   const chevronElement = showChevron && (
-    <span {...stylex.props(styles.chevron)}>
+    <span sx={styles.chevron}>
       <ChevronDownIcon />
     </span>
   );
@@ -353,14 +353,9 @@ export const XDSSideNavHeader = forwardRef<
         ref={ref as React.Ref<HTMLAnchorElement>}
         href={titleHref}
         data-testid={testId}
-        {...stylex.props(
-          styles.root,
-          styles.interactive,
-          styles.interactiveInset,
-          xstyle,
-        )}
+        sx={[styles.root, styles.interactive, styles.interactiveInset, xstyle]}
         {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
-        {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
+        {icon && <span sx={styles.icon}>{icon}</span>}
         {renderTextContent()}
         {chevronElement}
       </a>
@@ -377,18 +372,13 @@ export const XDSSideNavHeader = forwardRef<
           onClick={handleToggle}
           data-testid={testId}
           {...popover.triggerProps}
-          {...stylex.props(
-            styles.root,
-            styles.interactive,
-            styles.interactiveInset,
-            xstyle,
-          )}>
-          {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
+          sx={[styles.root, styles.interactive, styles.interactiveInset, xstyle]}>
+          {icon && <span sx={styles.icon}>{icon}</span>}
           {renderTextContent()}
           {chevronElement}
         </button>
         {popover.render(
-          <div {...stylex.props(styles.popoverContent)}>{menu}</div>,
+          <div sx={styles.popoverContent}>{menu}</div>,
           {placement: 'below', alignment: 'start', xstyle: styles.popover},
         )}
       </>
@@ -401,17 +391,14 @@ export const XDSSideNavHeader = forwardRef<
   if (menu && hasAnyHref) {
     return (
       <>
-        <div
-          ref={setRef}
-          data-testid={testId}
-          {...stylex.props(styles.root, xstyle)}>
+        <div ref={setRef} data-testid={testId} sx={[styles.root, xstyle]}>
           {icon &&
             (titleHref ? (
-              <a href={titleHref} {...stylex.props(styles.icon)}>
+              <a href={titleHref} sx={styles.icon}>
                 {icon}
               </a>
             ) : (
-              <span {...stylex.props(styles.icon)}>{icon}</span>
+              <span sx={styles.icon}>{icon}</span>
             ))}
           {renderTextContent()}
           {showChevron && (
@@ -420,13 +407,13 @@ export const XDSSideNavHeader = forwardRef<
               onClick={handleToggle}
               aria-label="Open menu"
               {...popover.triggerProps}
-              {...stylex.props(styles.chevron, styles.interactive)}>
+              sx={[styles.chevron, styles.interactive]}>
               <ChevronDownIcon />
             </button>
           )}
         </div>
         {popover.render(
-          <div {...stylex.props(styles.popoverContent)}>{menu}</div>,
+          <div sx={styles.popoverContent}>{menu}</div>,
           {placement: 'below', alignment: 'start', xstyle: styles.popover},
         )}
       </>
@@ -436,20 +423,16 @@ export const XDSSideNavHeader = forwardRef<
   // Static header with independent links (no menu)
   if (hasAnyHref && !isWholeHeaderLink) {
     return (
-      <div
-        ref={ref}
-        data-testid={testId}
-        {...stylex.props(styles.root, xstyle)}
-        {...props}>
+      <div ref={ref} data-testid={testId} sx={[styles.root, xstyle]} {...props}>
         {icon &&
           (titleHref ? (
-            <a href={titleHref} {...stylex.props(styles.icon)}>
+            <a href={titleHref} sx={styles.icon}>
               {icon}
             </a>
           ) : (
-            <span {...stylex.props(styles.icon)}>{icon}</span>
+            <span sx={styles.icon}>{icon}</span>
           ))}
-        <span {...stylex.props(styles.textContainer)}>
+        <span sx={styles.textContainer}>
           {supertitle &&
             (supertitleHref ? (
               <XDSLink
@@ -460,7 +443,7 @@ export const XDSSideNavHeader = forwardRef<
                 {supertitle}
               </XDSLink>
             ) : (
-              <span {...stylex.props(styles.supertitle)}>{supertitle}</span>
+              <span sx={styles.supertitle}>{supertitle}</span>
             ))}
           {titleHref ? (
             <XDSLink
@@ -471,7 +454,7 @@ export const XDSSideNavHeader = forwardRef<
               {title}
             </XDSLink>
           ) : (
-            <span {...stylex.props(styles.title)}>{title}</span>
+            <span sx={styles.title}>{title}</span>
           )}
           {subtitle &&
             (subtitleHref ? (
@@ -483,7 +466,7 @@ export const XDSSideNavHeader = forwardRef<
                 {subtitle}
               </XDSLink>
             ) : (
-              <span {...stylex.props(styles.subtitle)}>{subtitle}</span>
+              <span sx={styles.subtitle}>{subtitle}</span>
             ))}
         </span>
         {chevronElement}
@@ -493,12 +476,8 @@ export const XDSSideNavHeader = forwardRef<
 
   // Default: static header, no links, no menu
   return (
-    <div
-      ref={ref}
-      data-testid={testId}
-      {...stylex.props(styles.root, xstyle)}
-      {...props}>
-      {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
+    <div ref={ref} data-testid={testId} sx={[styles.root, xstyle]} {...props}>
+      {icon && <span sx={styles.icon}>{icon}</span>}
       {renderTextContent()}
       {chevronElement}
     </div>

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -219,9 +219,9 @@ export const XDSSideNavItem = forwardRef<HTMLElement, XDSSideNavItemProps>(
             }
           />
         )}
-        <span {...stylex.props(styles.label)}>{label}</span>
+        <span sx={styles.label}>{label}</span>
         {endContent && (
-          <span {...stylex.props(styles.endContent)}>{endContent}</span>
+          <span sx={styles.endContent}>{endContent}</span>
         )}
       </>
     );
@@ -239,11 +239,7 @@ export const XDSSideNavItem = forwardRef<HTMLElement, XDSSideNavItemProps>(
           href={href}
           onClick={handleClick}
           {...ariaProps}
-          {...stylex.props(
-            styles.item,
-            isSelected && styles.selected,
-            isDisabled && styles.disabled,
-          )}>
+          sx={[styles.item, isSelected && styles.selected, isDisabled && styles.disabled]}>
           {itemContent}
         </LinkComponent>
       ) : (
@@ -253,23 +249,16 @@ export const XDSSideNavItem = forwardRef<HTMLElement, XDSSideNavItemProps>(
           onClick={handleClick}
           disabled={isDisabled}
           {...ariaProps}
-          {...stylex.props(
-            styles.item,
-            isSelected && styles.selected,
-            isDisabled && styles.disabled,
-          )}>
+          sx={[styles.item, isSelected && styles.selected, isDisabled && styles.disabled]}>
           {itemContent}
         </button>
       );
 
     return (
-      <div {...stylex.props(styles.root)}>
+      <div sx={styles.root}>
         {itemElement}
         {hasChildren && (
-          <div
-            role="group"
-            aria-labelledby={`${id}-label`}
-            {...stylex.props(styles.children)}>
+          <div role="group" aria-labelledby={`${id}-label`} sx={styles.children}>
             <span id={`${id}-label`} hidden>
               {label}
             </span>

--- a/packages/core/src/SideNav/XDSSideNavSection.tsx
+++ b/packages/core/src/SideNav/XDSSideNavSection.tsx
@@ -143,14 +143,14 @@ export function XDSSideNavSection({
 
   const headerContent = (
     <>
-      <span {...stylex.props(styles.titleContainer)}>
-        <span id={titleId} {...stylex.props(styles.title)}>
+      <span sx={styles.titleContainer}>
+        <span id={titleId} sx={styles.title}>
           {title}
         </span>
-        {subtitle && <span {...stylex.props(styles.subtitle)}>{subtitle}</span>}
+        {subtitle && <span sx={styles.subtitle}>{subtitle}</span>}
       </span>
       {endContent && (
-        <span {...stylex.props(styles.endContent)}>{endContent}</span>
+        <span sx={styles.endContent}>{endContent}</span>
       )}
     </>
   );
@@ -174,13 +174,13 @@ export function XDSSideNavSection({
       role="group"
       aria-labelledby={titleId}
       data-testid={testId}
-      {...stylex.props(styles.root)}>
+      sx={styles.root}>
       <div
         style={isHeaderHidden ? visuallyHiddenStyle : undefined}
-        {...stylex.props(styles.header)}>
+        sx={styles.header}>
         {headerContent}
       </div>
-      <div {...stylex.props(styles.items)}>{children}</div>
+      <div sx={styles.items}>{children}</div>
     </div>
   );
 }

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -195,16 +195,15 @@ export const XDSSkeleton = forwardRef<HTMLDivElement, XDSSkeletonProps>(
       <div
         ref={ref}
         data-testid={testId}
-        {...stylex.props(
+        sx={[
           styles.root,
           styles.animate,
           radiusStyles[radiusProp],
           dynamicStyles.dimensions(width, height),
           dynamicStyles.animationDelay(index),
-          rootOverride,
-        )}
-        {...props}
-      />
+          rootOverride
+        ]}
+        {...props} />
     );
   },
 );

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -583,15 +583,14 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
           aria-describedby={ariaDescribedBy}
           style={positionStyle}
           onKeyDown={e => handleKeyDown(thumbIndex, e)}
-          {...stylex.props(
+          sx={[
             styles.thumb,
             isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
             !isDisabled && styles.thumbHover,
             !isDisabled && styles.thumbFocusWithin,
             isDisabled && styles.thumbDisabled,
-            thumbOverride,
-          )}
-        />
+            thumbOverride
+          ]} />
       );
 
       if (useTooltip) {
@@ -631,7 +630,7 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
     // Text value display
     const textDisplay =
       valueDisplay === 'text' ? (
-        <span {...stylex.props(styles.textValue)}>
+        <span sx={styles.textValue}>
           {isRange
             ? `${displayValue(values[0])} – ${displayValue(values[1])}`
             : displayValue(values[0])}
@@ -659,8 +658,8 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
         }
         labelTooltip={labelTooltip}
         statusVariant="detached"
-        {...stylex.props(xstyle)}>
-        <div {...stylex.props(styles.sliderRow, rootOverride)}>
+        sx={xstyle}>
+        <div sx={[styles.sliderRow, rootOverride]}>
           <div
             ref={node => {
               // Merge refs
@@ -677,43 +676,30 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
             onPointerDown={handlePointerDown}
             onPointerMove={handlePointerMove}
             onPointerUp={handlePointerUp}
-            {...stylex.props(
-              styles.trackContainer,
-              isHorizontal
-                ? styles.trackContainerHorizontal
-                : styles.trackContainerVertical,
-              isDisabled && styles.trackContainerDisabled,
-            )}>
+            sx={[styles.trackContainer, isHorizontal
+              ? styles.trackContainerHorizontal
+              : styles.trackContainerVertical, isDisabled && styles.trackContainerDisabled]}>
             {/* Background track */}
             <div
-              {...stylex.props(
+              sx={[
                 styles.track,
                 isHorizontal ? styles.trackHorizontal : styles.trackVertical,
-                trackOverride,
-              )}
-            />
+                trackOverride
+              ]} />
 
             {/* Filled track */}
             <div
               style={filledStyle}
-              {...stylex.props(
-                styles.filledTrack,
-                isHorizontal
-                  ? styles.filledTrackHorizontal
-                  : styles.filledTrackVertical,
-                filledTrackOverride,
-              )}
-            />
+              sx={[styles.filledTrack, isHorizontal
+                ? styles.filledTrackHorizontal
+                : styles.filledTrackVertical, filledTrackOverride]} />
 
             {/* Marks */}
             {marks && (
               <div
-                {...stylex.props(
-                  styles.marksContainer,
-                  isHorizontal
-                    ? styles.marksContainerHorizontal
-                    : styles.marksContainerVertical,
-                )}>
+                sx={[styles.marksContainer, isHorizontal
+                  ? styles.marksContainerHorizontal
+                  : styles.marksContainerVertical]}>
                 {marks.map(mark => {
                   const percent = getPercent(mark.value, min, max);
                   const markPos = isHorizontal
@@ -724,23 +710,16 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
                       <div
                         data-testid="slider-mark"
                         style={markPos}
-                        {...stylex.props(
-                          styles.mark,
-                          isHorizontal
-                            ? styles.markHorizontal
-                            : styles.markVertical,
-                        )}
-                      />
+                        sx={[styles.mark, isHorizontal
+                          ? styles.markHorizontal
+                          : styles.markVertical]} />
                       {mark.label && (
                         <span
                           data-testid="slider-mark-label"
                           style={markPos}
-                          {...stylex.props(
-                            styles.markLabel,
-                            isHorizontal
-                              ? styles.markLabelHorizontal
-                              : styles.markLabelVertical,
-                          )}>
+                          sx={[styles.markLabel, isHorizontal
+                            ? styles.markLabelHorizontal
+                            : styles.markLabelVertical]}>
                           {mark.label}
                         </span>
                       )}

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -185,9 +185,9 @@ export const XDSSpinner = forwardRef<HTMLSpanElement, XDSSpinnerProps>(
         role="status"
         aria-label="Loading"
         data-testid={testId}
-        {...stylex.props(styles.spinner, rootOverride)}
+        sx={[styles.spinner, rootOverride]}
         style={{width: frameSize, height: frameSize}}>
-        <canvas ref={canvasRef} {...stylex.props(styles.canvas)} />
+        <canvas ref={canvasRef} sx={styles.canvas} />
       </span>
     );
   },

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -142,16 +142,15 @@ export const XDSStatusDot = forwardRef<HTMLSpanElement, XDSStatusDotProps>(
         ref={ref}
         role="img"
         aria-label={label}
-        {...stylex.props(
+        sx={[
           styles.base,
           sizes[size],
           variants[variant],
           isPulsing && styles.pulsing,
           isPulsing && styles.reducedMotion,
-          xstyle,
-        )}
-        {...props}
-      />
+          xstyle
+        ]}
+        {...props} />
     );
   },
 );

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -321,7 +321,7 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
       describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
 
     const switchElement = (
-      <div {...stylex.props(styles.switchWrapper)}>
+      <div sx={styles.switchWrapper}>
         <input
           ref={ref}
           id={id}
@@ -345,23 +345,18 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
           aria-describedby={ariaDescribedBy}
           aria-invalid={status?.type === 'error' ? true : undefined}
           aria-busy={isBusy || undefined}
-          {...stylex.props(styles.input, isDisabled && styles.inputDisabled)}
-        />
+          sx={[styles.input, isDisabled && styles.inputDisabled]} />
         <div
           aria-hidden="true"
-          {...stylex.props(
+          sx={[
             styles.track,
             isOn ? styles.trackOn : styles.trackOff,
             isDisabled && styles.trackDisabled,
             isDisabled && !isOn && styles.trackDisabledOff,
-            trackOverride,
-          )}>
+            trackOverride
+          ]}>
           <div
-            {...stylex.props(
-              styles.thumb,
-              isOn ? styles.thumbOn : styles.thumbOff,
-              thumbOverride,
-            )}
+            sx={[styles.thumb, isOn ? styles.thumbOn : styles.thumbOff, thumbOverride]}
             style={{
               display: 'flex',
               alignItems: 'center',
@@ -374,7 +369,7 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
     );
 
     const labelElement = (
-      <div {...stylex.props(styles.labelWrapper)}>
+      <div sx={styles.labelWrapper}>
         <XDSFieldLabel
           label={label}
           inputID={id}
@@ -386,7 +381,7 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
           labelTooltip={labelTooltip}
         />
         {description && !isLabelHidden && (
-          <span id={descriptionID} {...stylex.props(styles.description)}>
+          <span id={descriptionID} sx={styles.description}>
             {description}
           </span>
         )}
@@ -396,12 +391,12 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
     return (
       <div>
         <div
-          {...stylex.props(
+          sx={[
             styles.container,
             labelSpacing === 'spread' && styles.containerSpread,
             rootOverride,
-            !isDisabled && stylex.defaultMarker(),
-          )}>
+            !isDisabled && stylex.defaultMarker()
+          ]}>
           {labelPosition === 'start' ? (
             <>
               {labelElement}
@@ -415,7 +410,7 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
           )}
         </div>
         {status?.message && (
-          <div {...stylex.props(styles.statusGap)}>
+          <div sx={styles.statusGap}>
             <XDSFieldStatus
               type={status.type}
               message={status.message}

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -192,7 +192,7 @@ export function XDSTab({
   }, [tabListCtx, value]);
 
   const iconElement = displayIcon ? (
-    <span {...stylex.props(styles.icon, iconSizeStyles[size])}>
+    <span sx={[styles.icon, iconSizeStyles[size]]}>
       {displayIcon}
     </span>
   ) : null;
@@ -209,13 +209,13 @@ export function XDSTab({
   };
 
   const hoverUnderlineElement = !isSelected ? (
-    <span {...stylex.props(styles.hoverUnderline)} />
+    <span sx={styles.hoverUnderline} />
   ) : null;
 
   const labelElement = (
-    <span {...stylex.props(styles.labelContainer)}>
-      <span {...stylex.props(styles.labelText)}>{label}</span>
-      <span aria-hidden="true" {...stylex.props(styles.labelSizer)}>
+    <span sx={styles.labelContainer}>
+      <span sx={styles.labelText}>{label}</span>
+      <span aria-hidden="true" sx={styles.labelSizer}>
         {label}
       </span>
     </span>

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -105,11 +105,7 @@ export function XDSTabList({
     <XDSTabListContext.Provider value={contextValue}>
       <nav
         aria-label="Tabs"
-        {...stylex.props(
-          styles.nav,
-          hasDivider && styles.divider,
-          rootOverride,
-        )}>
+        sx={[styles.nav, hasDivider && styles.divider, rootOverride]}>
         {children}
       </nav>
     </XDSTabListContext.Provider>

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -269,28 +269,24 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
         aria-expanded={layer.isOpen}
         aria-controls={menuId}
         onClick={handleToggle}
-        {...stylex.props(
+        sx={[
           styles.trigger,
           sizeStyles[size],
           hasSelectedOption && styles.triggerSelected,
-          !hasSelectedOption && stylex.defaultMarker(),
-        )}>
-        <span
-          {...stylex.props(
-            styles.triggerLabel,
-            hasSelectedOption && styles.underline,
-          )}>
-          <span {...stylex.props(styles.triggerLabelText)}>{triggerLabel}</span>
-          <span aria-hidden="true" {...stylex.props(styles.triggerLabelSizer)}>
+          !hasSelectedOption && stylex.defaultMarker()
+        ]}>
+        <span sx={[styles.triggerLabel, hasSelectedOption && styles.underline]}>
+          <span sx={styles.triggerLabelText}>{triggerLabel}</span>
+          <span aria-hidden="true" sx={styles.triggerLabelSizer}>
             {triggerLabel}
           </span>
           {!hasSelectedOption && (
-            <span {...stylex.props(styles.hoverUnderline)} />
+            <span sx={styles.hoverUnderline} />
           )}
         </span>
         <span
           aria-hidden="true"
-          {...stylex.props(styles.chevron, layer.isOpen && styles.chevronOpen)}>
+          sx={[styles.chevron, layer.isOpen && styles.chevronOpen]}>
           <XDSIcon icon="chevronDown" size="sm" color="inherit" />
         </span>
       </button>
@@ -301,7 +297,7 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
           role="menu"
           aria-label={label}
           onKeyDown={handleListKeyDown}
-          {...stylex.props(styles.dropdown)}>
+          sx={styles.dropdown}>
           <XDSDivider label={label} />
           {options.map(option => {
             const isSelected = tabListCtx.value === option.value;
@@ -318,11 +314,8 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
                     handleSelect(option.value);
                   }
                 }}
-                {...stylex.props(
-                  styles.menuItem,
-                  isSelected && styles.menuItemSelected,
-                )}>
-                <span {...stylex.props(styles.menuItemContent)}>
+                sx={[styles.menuItem, isSelected && styles.menuItemSelected]}>
+                <span sx={styles.menuItemContent}>
                   {option.icon && (
                     <XDSIcon icon={option.icon} size="sm" color="secondary" />
                   )}

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -246,10 +246,7 @@ function XDSBaseTableInner<T extends Record<string, unknown>>(
   const hasColumns = resolvedColumns.length > 0;
 
   let tableElement: ReactNode = (
-    <table
-      ref={ref}
-      {...tableRenderProps.htmlProps}
-      {...stylex.props(...tableRenderProps.styles)}>
+    <table ref={ref} {...tableRenderProps.htmlProps} sx={tableRenderProps.styles}>
       {/* thead */}
       {hasColumns && (
         <thead>

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -91,7 +91,7 @@ export const XDSTableCell = forwardRef<HTMLTableCellElement, XDSTableCellProps>(
 
     if (!ctx) {
       return (
-        <td ref={ref} {...props} {...stylex.props(xstyle)}>
+        <td ref={ref} {...props} sx={xstyle}>
           {children}
         </td>
       );
@@ -116,7 +116,7 @@ export const XDSTableCell = forwardRef<HTMLTableCellElement, XDSTableCellProps>(
     }
 
     return (
-      <td ref={ref} {...props} {...stylex.props(...cellStyles)}>
+      <td ref={ref} {...props} sx={cellStyles}>
         {children}
       </td>
     );

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -108,7 +108,7 @@ export const XDSTableHeaderCell = forwardRef<
 
   if (!ctx) {
     return (
-      <th ref={ref} {...props} {...stylex.props(xstyle)}>
+      <th ref={ref} {...props} sx={xstyle}>
         {children}
       </th>
     );
@@ -133,7 +133,7 @@ export const XDSTableHeaderCell = forwardRef<
   }
 
   return (
-    <th ref={ref} {...props} {...stylex.props(...cellStyles)}>
+    <th ref={ref} {...props} sx={cellStyles}>
       {children}
     </th>
   );

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -98,7 +98,7 @@ export const XDSTableRow = forwardRef<HTMLTableRowElement, XDSTableRowProps>(
 
     if (!ctx) {
       return (
-        <tr ref={ref} {...props} {...stylex.props(xstyle)}>
+        <tr ref={ref} {...props} sx={xstyle}>
           {children}
         </tr>
       );
@@ -125,7 +125,7 @@ export const XDSTableRow = forwardRef<HTMLTableRowElement, XDSTableRowProps>(
     }
 
     return (
-      <tr ref={ref} {...props} {...stylex.props(...rowStyles)}>
+      <tr ref={ref} {...props} sx={rowStyles}>
         {children}
       </tr>
     );

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -277,7 +277,7 @@ export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
       <>
         <Component
           ref={mergedRef}
-          {...stylex.props(
+          sx={[
             levelStyle,
             colorStyles[color],
             // Display: use truncation styles when maxLines > 0
@@ -295,8 +295,8 @@ export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
             // Decorations
             hasStrikethrough && decorationStyles.strikethrough,
             // User xstyle
-            xstyle,
-          )}
+            xstyle
+          ]}
           style={inlineStyle}
           title={tooltipEnabled ? truncation.fullText : undefined}
           {...ariaProps}
@@ -308,7 +308,7 @@ export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
             <LazyXDSTooltip
               anchorRef={headingRef}
               content={
-                <span {...stylex.props(truncationTooltipStyles.content)}>
+                <span sx={truncationTooltipStyles.content}>
                   {truncation.fullText}
                 </span>
               }

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -252,7 +252,7 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
     <>
       <Component
         ref={mergedRef}
-        {...stylex.props(
+        sx={[
           typeStyle,
           colorStyles[resolvedColor],
           weight && weightStyles[weight],
@@ -272,8 +272,8 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
           hasStrikethrough && decorationStyles.strikethrough,
           hasTabularNumbers && tabularNumbersStyle.enabled,
           // User xstyle
-          xstyle,
-        )}
+          xstyle
+        ]}
         style={inlineStyle}
         title={tooltipEnabled ? truncation.fullText : undefined}
         {...props}>
@@ -284,7 +284,7 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
           <LazyXDSTooltip
             anchorRef={textRef}
             content={
-              <span {...stylex.props(truncationTooltipStyles.content)}>
+              <span sx={truncationTooltipStyles.content}>
                 {truncation.fullText}
               </span>
             }

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -306,15 +306,15 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
         }
         labelTooltip={labelTooltip}>
         <div
-          {...stylex.props(
+          sx={[
             inputWrapperStyles.base,
             styles.wrapper,
             isDisabled && inputWrapperStyles.disabled,
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
             status && inputStatusFocusWithinStyles[status.type],
-            wrapperOverride,
-          )}>
+            wrapperOverride
+          ]}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
           <textarea
             ref={ref}
@@ -333,12 +333,7 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
             aria-busy={isBusy || undefined}
-            {...stylex.props(
-              styles.textarea,
-              isDisabled && styles.textareaDisabled,
-              textareaOverride,
-            )}
-          />
+            sx={[styles.textarea, isDisabled && styles.textareaDisabled, textareaOverride]} />
           {isBusy && <XDSSpinner size="sm" />}
           {status && (
             <XDSIcon
@@ -349,11 +344,7 @@ export const XDSTextArea = forwardRef<HTMLTextAreaElement, XDSTextAreaProps>(
           )}
         </div>
         {maxLength != null && (
-          <div
-            {...stylex.props(
-              styles.counter,
-              value.length > maxLength && styles.counterError,
-            )}>
+          <div sx={[styles.counter, value.length > maxLength && styles.counterError]}>
             {value.length}/{maxLength}
           </div>
         )}

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -284,7 +284,7 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
         }
         labelTooltip={labelTooltip}>
         <div
-          {...stylex.props(
+          sx={[
             inputWrapperStyles.base,
             styles.wrapper,
             sizeStyles[size],
@@ -292,8 +292,8 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
             status && inputStatusFocusWithinStyles[status.type],
-            wrapperOverride,
-          )}>
+            wrapperOverride
+          ]}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
           <input
             ref={ref}
@@ -309,12 +309,7 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
             aria-busy={isBusy || undefined}
-            {...stylex.props(
-              styles.input,
-              isDisabled && styles.inputDisabled,
-              inputOverride,
-            )}
-          />
+            sx={[styles.input, isDisabled && styles.inputDisabled, inputOverride]} />
           {isBusy && <XDSSpinner size="sm" />}
           {status && (
             <XDSIcon

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -516,16 +516,16 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
         }
         labelTooltip={labelTooltip}>
         <div
-          {...stylex.props(
+          sx={[
             inputWrapperStyles.base,
             sizeStyles[size],
             isDisabled && inputWrapperStyles.disabled,
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
             status && inputStatusFocusWithinStyles[status.type],
-            wrapperOverride,
-          )}>
-          <div {...stylex.props(styles.icon)}>
+            wrapperOverride
+          ]}>
+          <div sx={styles.icon}>
             <XDSIcon icon="clock" size="sm" color="secondary" />
           </div>
           <input
@@ -543,20 +543,19 @@ export const XDSTimeInput = forwardRef<HTMLInputElement, XDSTimeInputProps>(
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
             aria-busy={isBusy || undefined}
-            {...stylex.props(
+            sx={[
               styles.input,
               isDisabled && styles.inputDisabled,
               !isInputValid && styles.inputInvalid,
-              inputOverride,
-            )}
-          />
+              inputOverride
+            ]} />
           {isBusy && <XDSSpinner size="sm" />}
           {hasClear && value && !isDisabled && (
             <button
               type="button"
               onClick={handleClear}
               aria-label="Clear time"
-              {...stylex.props(styles.clearButton)}>
+              sx={styles.clearButton}>
               <XDSIcon icon="close" size="sm" color="secondary" />
             </button>
           )}

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -320,8 +320,7 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
     const content = (
       <>
         {icon}
-        <span
-          {...stylex.props(styles.label, isLabelHidden && styles.labelHidden)}>
+        <span sx={[styles.label, isLabelHidden && styles.labelHidden]}>
           {label}
         </span>
         {endContent}
@@ -334,7 +333,7 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
               onRemove(e);
             }}
             disabled={isDisabled}
-            {...stylex.props(styles.removeButton)}>
+            sx={styles.removeButton}>
             <XDSIcon icon="close" size="xsm" color="inherit" />
           </button>
         )}
@@ -354,14 +353,14 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
           href={href}
           aria-disabled={isDisabled || undefined}
           {...sharedProps}
-          {...stylex.props(
+          sx={[
             styles.base,
             sizeStyles[size],
             colorStyles[color],
             styles.interactive,
             isDisabled && styles.disabled,
-            xstyle,
-          )}>
+            xstyle
+          ]}>
           {content}
         </a>
       );
@@ -379,26 +378,22 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
           ref={ref as React.Ref<HTMLSpanElement>}
           onClick={isDisabled ? undefined : handleContainerClick}
           {...sharedProps}
-          {...stylex.props(
+          sx={[
             styles.base,
             sizeStyles[size],
             colorStyles[color],
             styles.interactive,
             styles.focusWithinOutline,
             isDisabled && styles.disabled,
-            xstyle,
-          )}>
+            xstyle
+          ]}>
           {icon}
           <button
             type="button"
             onClick={onClick}
             disabled={isDisabled}
-            {...stylex.props(styles.invisibleButton)}>
-            <span
-              {...stylex.props(
-                styles.label,
-                isLabelHidden && styles.labelHidden,
-              )}>
+            sx={styles.invisibleButton}>
+            <span sx={[styles.label, isLabelHidden && styles.labelHidden]}>
               {label}
             </span>
           </button>
@@ -412,7 +407,7 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
                 onRemove(e);
               }}
               disabled={isDisabled}
-              {...stylex.props(styles.removeButton)}>
+              sx={styles.removeButton}>
               <XDSIcon icon="close" size="xsm" color="inherit" />
             </button>
           )}
@@ -424,13 +419,13 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
       <span
         ref={ref as React.Ref<HTMLSpanElement>}
         {...sharedProps}
-        {...stylex.props(
+        sx={[
           styles.base,
           sizeStyles[size],
           colorStyles[color],
           isDisabled && styles.disabled,
-          xstyle,
-        )}>
+          xstyle
+        ]}>
         {content}
       </span>
     );

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -359,7 +359,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
 
     if (renderToken) {
       return (
-        <span key={item.id} {...stylex.props(styles.token)}>
+        <span key={item.id} sx={styles.token}>
           {renderToken(item, onRemoveItem)}
         </span>
       );
@@ -402,7 +402,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
         aria-label={label}
         onClick={handleWrapperClick}
         data-testid={testId}
-        {...stylex.props(
+        sx={[
           inputWrapperStyles.base,
           styles.wrapper,
           value.length > 0 && styles.wrapperWithTokens,
@@ -411,8 +411,8 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
           status && inputStatusBorderStyles[status.type],
           status && inputStatusHoverShadowStyles[status.type],
           status && inputStatusFocusWithinStyles[status.type],
-          xstyle,
-        )}>
+          xstyle
+        ]}>
         {tokens}
         <XDSBaseTypeahead
           ref={inputRef}
@@ -448,7 +448,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
               e.stopPropagation();
               handleClearAll();
             }}
-            {...stylex.props(styles.clearAllButton)}>
+            sx={styles.clearAllButton}>
             <XDSIcon icon="close" size="sm" />
           </button>
         )}

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -164,28 +164,28 @@ export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
         ref={ref}
         role="navigation"
         aria-label={label}
-        {...stylex.props(
+        sx={[
           styles.base,
           hasCenterContent ? styles.baseGrid : styles.baseFlex,
-          rootOverride,
-        )}
+          rootOverride
+        ]}
         {...props}>
-        <div {...stylex.props(styles.leftSection, edgeSignals.start)}>
-          {title && <div {...stylex.props(styles.title)}>{title}</div>}
+        <div sx={[styles.leftSection, edgeSignals.start]}>
+          {title && <div sx={styles.title}>{title}</div>}
           {startContent && (
-            <div {...stylex.props(styles.startContent)}>{startContent}</div>
+            <div sx={styles.startContent}>{startContent}</div>
           )}
         </div>
         {hasCenterContent && (
-          <div {...stylex.props(styles.centerContent)}>{centerContent}</div>
+          <div sx={styles.centerContent}>{centerContent}</div>
         )}
         {hasCenterContent ? (
-          <div {...stylex.props(styles.rightSection, edgeSignals.end)}>
+          <div sx={[styles.rightSection, edgeSignals.end]}>
             {endContent}
           </div>
         ) : (
           endContent && (
-            <div {...stylex.props(styles.endContent, edgeSignals.end)}>
+            <div sx={[styles.endContent, edgeSignals.end]}>
               {endContent}
             </div>
           )

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -163,12 +163,12 @@ export const XDSTopNavItem = forwardRef<HTMLAnchorElement, XDSTopNavItemProps>(
         aria-current={isSelected ? 'page' : undefined}
         aria-disabled={isDisabled || undefined}
         tabIndex={isDisabled ? -1 : undefined}
-        {...stylex.props(
+        sx={[
           styles.base,
           isSelected && styles.selected,
           isDisabled && styles.disabled,
-          isIconOnly && styles.iconOnly,
-        )}
+          isIconOnly && styles.iconOnly
+        ]}
         {...props}>
         {icon}
         {showLabel && (children ?? label)}

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -480,14 +480,14 @@ export function XDSTopNavMegaMenu({
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       onKeyDown={handleKeyDown}
-      {...stylex.props(styles.wrapper)}>
+      sx={styles.wrapper}>
       <button
         type="button"
         aria-haspopup="true"
         aria-expanded={isOpen}
-        {...stylex.props(styles.trigger, isOpen && styles.triggerOpen)}>
+        sx={[styles.trigger, isOpen && styles.triggerOpen]}>
         {label}
-        <span {...stylex.props(styles.chevron, isOpen && styles.chevronOpen)}>
+        <span sx={[styles.chevron, isOpen && styles.chevronOpen]}>
           <ChevronDown />
         </span>
       </button>
@@ -497,14 +497,10 @@ export function XDSTopNavMegaMenu({
           aria-label={label}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
-          {...stylex.props(styles.panelContainer)}>
-          <div {...stylex.props(styles.panelContent)}>
+          sx={styles.panelContainer}>
+          <div sx={styles.panelContent}>
             {/* Menu items section */}
-            <div
-              {...stylex.props(
-                styles.menuSection,
-                isSingleColumn && styles.menuSectionSingle,
-              )}>
+            <div sx={[styles.menuSection, isSingleColumn && styles.menuSectionSingle]}>
               {items.map((item, index) => {
                 const Element = item.href ? 'a' : 'div';
                 return (
@@ -514,18 +510,18 @@ export function XDSTopNavMegaMenu({
                     tabIndex={isOpen ? 0 : -1}
                     href={item.href}
                     onClick={item.onClick}
-                    {...stylex.props(styles.menuItem)}>
+                    sx={styles.menuItem}>
                     {item.icon && (
-                      <div {...stylex.props(styles.menuItemIcon)}>
+                      <div sx={styles.menuItemIcon}>
                         {item.icon}
                       </div>
                     )}
-                    <div {...stylex.props(styles.menuItemContent)}>
-                      <span {...stylex.props(styles.menuItemTitle)}>
+                    <div sx={styles.menuItemContent}>
+                      <span sx={styles.menuItemTitle}>
                         {item.title}
                       </span>
                       {item.description && (
-                        <span {...stylex.props(styles.menuItemDescription)}>
+                        <span sx={styles.menuItemDescription}>
                           {item.description}
                         </span>
                       )}
@@ -538,8 +534,8 @@ export function XDSTopNavMegaMenu({
             {/* Featured section */}
             {featured && (
               <>
-                <div {...stylex.props(styles.divider)} />
-                <div {...stylex.props(styles.featured)}>
+                <div sx={styles.divider} />
+                <div sx={styles.featured}>
                   {featured.children ? (
                     featured.children
                   ) : (
@@ -548,15 +544,14 @@ export function XDSTopNavMegaMenu({
                         <img
                           src={featured.image}
                           alt={featured.imageAlt ?? ''}
-                          {...stylex.props(styles.featuredImage)}
-                        />
+                          sx={styles.featuredImage} />
                       )}
-                      <div {...stylex.props(styles.featuredBody)}>
-                        <span {...stylex.props(styles.featuredTitle)}>
+                      <div sx={styles.featuredBody}>
+                        <span sx={styles.featuredTitle}>
                           {featured.title}
                         </span>
                         {featured.description && (
-                          <span {...stylex.props(styles.featuredDescription)}>
+                          <span sx={styles.featuredDescription}>
                             {featured.description}
                           </span>
                         )}
@@ -565,7 +560,7 @@ export function XDSTopNavMegaMenu({
                             href={featured.linkHref}
                             onClick={featured.onLinkClick}
                             tabIndex={isOpen ? 0 : -1}
-                            {...stylex.props(styles.featuredLink)}>
+                            sx={styles.featuredLink}>
                             {featured.linkText}
                           </a>
                         )}

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -241,14 +241,11 @@ export function XDSTopNavMenu({
         type="button"
         aria-haspopup="true"
         aria-describedby={hoverCard.describedBy}
-        {...stylex.props(styles.trigger)}>
+        sx={styles.trigger}>
         {label}
       </button>
       {hoverCard.renderHoverCard(
-        <div
-          role="menu"
-          aria-label={label}
-          {...stylex.props(styles.menuContainer)}>
+        <div role="menu" aria-label={label} sx={styles.menuContainer}>
           {items.map((item, index) => {
             const Element = item.href ? 'a' : 'div';
             return (
@@ -258,14 +255,14 @@ export function XDSTopNavMenu({
                 tabIndex={0}
                 href={item.href}
                 onClick={item.onClick}
-                {...stylex.props(styles.menuItem)}>
-                <div {...stylex.props(styles.menuItemIcon)}>{item.icon}</div>
-                <div {...stylex.props(styles.menuItemContent)}>
-                  <span {...stylex.props(styles.menuItemTitle)}>
+                sx={styles.menuItem}>
+                <div sx={styles.menuItemIcon}>{item.icon}</div>
+                <div sx={styles.menuItemContent}>
+                  <span sx={styles.menuItemTitle}>
                     {item.title}
                   </span>
                   {item.description && (
-                    <span {...stylex.props(styles.menuItemDescription)}>
+                    <span sx={styles.menuItemDescription}>
                       {item.description}
                     </span>
                   )}

--- a/packages/core/src/TopNav/XDSTopNavTitle.tsx
+++ b/packages/core/src/TopNav/XDSTopNavTitle.tsx
@@ -102,10 +102,10 @@ export const XDSTopNavTitle = forwardRef<HTMLElement, XDSTopNavTitleProps>(
       <Element
         ref={ref as React.Ref<HTMLAnchorElement & HTMLDivElement>}
         href={href}
-        {...stylex.props(styles.base, href != null && styles.clickable)}
+        sx={[styles.base, href != null && styles.clickable]}
         {...props}>
-        {logo && <span {...stylex.props(styles.logo)}>{logo}</span>}
-        {title && <span {...stylex.props(styles.titleText)}>{title}</span>}
+        {logo && <span sx={styles.logo}>{logo}</span>}
+        {title && <span sx={styles.titleText}>{title}</span>}
       </Element>
     );
   },

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -557,29 +557,20 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
         disabled={isDisabled}
         autoFocus={hasAutoFocus}
         autoComplete="off"
-        {...stylex.props(
-          styles.input,
-          isDisabled && styles.inputDisabled,
-          inputXStyle,
-        )}
-      />
+        sx={[styles.input, isDisabled && styles.inputDisabled, inputXStyle]} />
       {isLoading && (
-        <span
-          role="status"
-          aria-label="Loading"
-          {...stylex.props(styles.loadingSpinner)}>
+        <span role="status" aria-label="Loading" sx={styles.loadingSpinner}>
           <XDSIcon icon="clock" size="sm" color="secondary" />
         </span>
       )}
-
       {layer.render(
         <div
           id={listboxId}
           role="listbox"
           aria-label="Search results"
-          {...stylex.props(styles.dropdown)}>
+          sx={styles.dropdown}>
           {results.length === 0 && hasSearched ? (
-            <div {...stylex.props(styles.emptyState)}>
+            <div sx={styles.emptyState}>
               {emptySearchResultsText}
             </div>
           ) : (
@@ -592,12 +583,12 @@ export const XDSBaseTypeahead = forwardRef(function XDSBaseTypeahead<
                 tabIndex={-1}
                 onClick={() => handleSelect(item)}
                 onMouseEnter={() => setHighlightedIndex(index)}
-                {...stylex.props(
+                sx={[
                   styles.item,
                   index === highlightedIndex && styles.itemHighlighted,
-                  value?.id === item.id && styles.itemSelected,
-                )}>
-                <span {...stylex.props(styles.itemContent)}>
+                  value?.id === item.id && styles.itemSelected
+                ]}>
+                <span sx={styles.itemContent}>
                   {renderItem ? (
                     renderItem(item)
                   ) : (

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -344,7 +344,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
         data-testid={testId}
         onClick={handleWrapperClick}
         onBlur={handleBlur}
-        {...stylex.props(
+        sx={[
           inputWrapperStyles.base,
           styles.wrapper,
           sizeStyle,
@@ -352,8 +352,8 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
           status && inputStatusHoverShadowStyles[status.type],
           status && inputStatusFocusWithinStyles[status.type],
           isDisabled && inputWrapperStyles.disabled,
-          xstyle,
-        )}>
+          xstyle
+        ]}>
         {showToken && (
           <XDSToken
             ref={tokenRef}
@@ -394,7 +394,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
               e.stopPropagation();
               handleClear();
             }}
-            {...stylex.props(styles.clearButton)}>
+            sx={styles.clearButton}>
             <XDSIcon icon="close" size="sm" />
           </button>
         )}

--- a/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
+++ b/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
@@ -136,12 +136,12 @@ export function XDSTypeaheadItem<T extends XDSSearchableItem>({
   }
 
   return (
-    <div {...stylex.props(styles.container, isDisabled && styles.disabled)}>
+    <div sx={[styles.container, isDisabled && styles.disabled]}>
       {icon}
-      <div {...stylex.props(styles.content)}>
-        <span {...stylex.props(styles.label)}>{item.label}</span>
+      <div sx={styles.content}>
+        <span sx={styles.label}>{item.label}</span>
         {description && (
-          <span {...stylex.props(styles.description)}>{description}</span>
+          <span sx={styles.description}>{description}</span>
         )}
       </div>
     </div>

--- a/packages/core/src/stylex-sx.d.ts
+++ b/packages/core/src/stylex-sx.d.ts
@@ -1,0 +1,27 @@
+/**
+ * Type augmentation for StyleX `sx` prop on native HTML elements.
+ *
+ * The StyleX babel plugin (>=0.18) transforms `sx={styles}` into
+ * `{...stylex.props(styles)}` at compile time. This declaration
+ * teaches TypeScript about the prop so it doesn't report errors.
+ */
+import type {StyleXArray, StyleXClassName} from '@stylexjs/stylex';
+
+type SXProp = StyleXArray<
+  | StyleXClassName
+  | false
+  | null
+  | undefined
+  | Readonly<Record<string, StyleXClassName>>
+>;
+
+declare module 'react' {
+  interface HTMLAttributes<T> {
+    sx?: SXProp;
+  }
+  // SVG elements extend SVGAttributes, not HTMLAttributes
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  interface SVGAttributes<T> {
+    sx?: SXProp;
+  }
+}

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.28.5",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@stylexjs/babel-plugin": "^0.17.4",
+    "@stylexjs/babel-plugin": "^0.18.1",
     "esbuild-plugin-babel": "^0.2.3",
     "tsup": "^8.3.0"
   }

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -38,7 +38,7 @@
     "@babel/core": "^7.28.5",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@stylexjs/babel-plugin": "^0.17.4",
+    "@stylexjs/babel-plugin": "^0.18.1",
     "esbuild-plugin-babel": "^0.2.3",
     "tsup": "^8.3.0"
   }


### PR DESCRIPTION
Automated migration of all `{...stylex.props(...)}` JSX spreads to the new `sx=` prop syntax.

**Transforms:**
- `<div {...stylex.props(styles.foo)} />` → `<div sx={styles.foo} />`
- `<div {...stylex.props(styles.foo, styles.bar)} />` → `<div sx={[styles.foo, styles.bar]} />`
- `<Comp {...stylex.props(styles.foo)} />` → `<Comp sx={styles.foo} />`
- `<div {...stylex.props(...spread)} />` → `<div sx={spread} />`

**Does not touch:**
- `xstyle` props
- Non-JSX usages of `stylex.props()` (variable assignments, object spreads, ternaries)
- Code in comments/string templates

117 files changed, 910 insertions(+), 1256 deletions(-)