### PR TITLE
fix(api): unify visibility callbacks to onOpenChange (#464)

### DIFF
--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -604,7 +604,7 @@ export const WithMobileNav: Story = {
         mobileNav={
           <XDSMobileNav
             isOpen={mobileNavOpen}
-            onClose={() => setMobileNavOpen(false)}
+            onOpenChange={open => setMobileNavOpen(open)}
             title="Acme App">
             {navSections}
           </XDSMobileNav>

--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -43,34 +43,49 @@ export const Composable: Story = {
 
     return (
       <>
-        <XDSButton label="Open Command Palette (⌘K)" onClick={() => setIsShown(true)} />
-        <XDSCommandPalette isShown={isShown} onHide={() => setIsShown(false)}>
+        <XDSButton
+          label="Open Command Palette (⌘K)"
+          onClick={() => setIsShown(true)}
+        />
+        <XDSCommandPalette
+          isShown={isShown}
+          onOpenChange={open => setIsShown(open)}>
           <XDSCommandPaletteInput placeholder="Type a command or search..." />
           <XDSCommandPaletteList>
             <XDSCommandPaletteGroup heading="Navigation">
-              <XDSCommandPaletteItem value="home" onSelect={() => setIsShown(false)}>
+              <XDSCommandPaletteItem
+                value="home"
+                onSelect={() => setIsShown(false)}>
                 <XDSIcon icon="home" size="sm" />
                 <span style={{flex: 1}}>Go Home</span>
                 <XDSCommandPaletteShortcut keys="mod+h" />
               </XDSCommandPaletteItem>
-              <XDSCommandPaletteItem value="settings" onSelect={() => setIsShown(false)}>
+              <XDSCommandPaletteItem
+                value="settings"
+                onSelect={() => setIsShown(false)}>
                 <XDSIcon icon="settings" size="sm" />
                 <span style={{flex: 1}}>Settings</span>
                 <XDSCommandPaletteShortcut keys="mod+," />
               </XDSCommandPaletteItem>
-              <XDSCommandPaletteItem value="profile" onSelect={() => setIsShown(false)}>
+              <XDSCommandPaletteItem
+                value="profile"
+                onSelect={() => setIsShown(false)}>
                 <XDSIcon icon="person" size="sm" />
                 <span style={{flex: 1}}>Profile</span>
               </XDSCommandPaletteItem>
             </XDSCommandPaletteGroup>
             <XDSCommandPaletteSeparator />
             <XDSCommandPaletteGroup heading="Actions">
-              <XDSCommandPaletteItem value="new-file" onSelect={() => setIsShown(false)}>
+              <XDSCommandPaletteItem
+                value="new-file"
+                onSelect={() => setIsShown(false)}>
                 <XDSIcon icon="add" size="sm" />
                 <span style={{flex: 1}}>New File</span>
                 <XDSCommandPaletteShortcut keys="mod+n" />
               </XDSCommandPaletteItem>
-              <XDSCommandPaletteItem value="save" onSelect={() => setIsShown(false)}>
+              <XDSCommandPaletteItem
+                value="save"
+                onSelect={() => setIsShown(false)}>
                 <XDSIcon icon="check" size="sm" />
                 <span style={{flex: 1}}>Save</span>
                 <XDSCommandPaletteShortcut keys="mod+s" />
@@ -99,16 +114,25 @@ export const DisabledItems: Story = {
     return (
       <>
         <XDSButton label="Open Palette" onClick={() => setIsShown(true)} />
-        <XDSCommandPalette isShown={isShown} onHide={() => setIsShown(false)}>
+        <XDSCommandPalette
+          isShown={isShown}
+          onOpenChange={open => setIsShown(open)}>
           <XDSCommandPaletteInput />
           <XDSCommandPaletteList>
-            <XDSCommandPaletteItem value="enabled" onSelect={() => setIsShown(false)}>
+            <XDSCommandPaletteItem
+              value="enabled"
+              onSelect={() => setIsShown(false)}>
               Enabled Action
             </XDSCommandPaletteItem>
-            <XDSCommandPaletteItem value="disabled" isDisabled onSelect={() => {}}>
+            <XDSCommandPaletteItem
+              value="disabled"
+              isDisabled
+              onSelect={() => {}}>
               Disabled Action (no permission)
             </XDSCommandPaletteItem>
-            <XDSCommandPaletteItem value="another" onSelect={() => setIsShown(false)}>
+            <XDSCommandPaletteItem
+              value="another"
+              onSelect={() => setIsShown(false)}>
               Another Action
             </XDSCommandPaletteItem>
           </XDSCommandPaletteList>
@@ -127,20 +151,38 @@ export const Filtering: Story = {
 
     const items = [
       {value: 'dashboard', label: 'Dashboard', keywords: ['home', 'overview']},
-      {value: 'users', label: 'User Management', keywords: ['people', 'accounts']},
-      {value: 'analytics', label: 'Analytics', keywords: ['data', 'reports', 'charts']},
+      {
+        value: 'users',
+        label: 'User Management',
+        keywords: ['people', 'accounts'],
+      },
+      {
+        value: 'analytics',
+        label: 'Analytics',
+        keywords: ['data', 'reports', 'charts'],
+      },
       {value: 'billing', label: 'Billing', keywords: ['payments', 'invoices']},
-      {value: 'notifications', label: 'Notification Settings', keywords: ['alerts', 'emails']},
-      {value: 'api-keys', label: 'API Keys', keywords: ['tokens', 'credentials']},
+      {
+        value: 'notifications',
+        label: 'Notification Settings',
+        keywords: ['alerts', 'emails'],
+      },
+      {
+        value: 'api-keys',
+        label: 'API Keys',
+        keywords: ['tokens', 'credentials'],
+      },
     ];
 
     return (
       <>
         <XDSButton label="Open Palette" onClick={() => setIsShown(true)} />
-        <XDSCommandPalette isShown={isShown} onHide={() => setIsShown(false)}>
+        <XDSCommandPalette
+          isShown={isShown}
+          onOpenChange={open => setIsShown(open)}>
           <XDSCommandPaletteInput placeholder="Search pages..." />
           <XDSCommandPaletteList>
-            {items.map((item) => (
+            {items.map(item => (
               <XDSCommandPaletteItem
                 key={item.value}
                 value={item.value}
@@ -163,17 +205,50 @@ export const Filtering: Story = {
 
 function NavigationCommands() {
   useXDSCommandPaletteRegister([
-    {id: 'nav-home', label: 'Go Home', icon: 'home', group: 'Navigation', onSelect: () => alert('Home')},
-    {id: 'nav-settings', label: 'Settings', icon: 'settings', shortcut: 'mod+,', group: 'Navigation', onSelect: () => alert('Settings')},
-    {id: 'nav-profile', label: 'Profile', icon: 'person', group: 'Navigation', onSelect: () => alert('Profile')},
+    {
+      id: 'nav-home',
+      label: 'Go Home',
+      icon: 'home',
+      group: 'Navigation',
+      onSelect: () => alert('Home'),
+    },
+    {
+      id: 'nav-settings',
+      label: 'Settings',
+      icon: 'settings',
+      shortcut: 'mod+,',
+      group: 'Navigation',
+      onSelect: () => alert('Settings'),
+    },
+    {
+      id: 'nav-profile',
+      label: 'Profile',
+      icon: 'person',
+      group: 'Navigation',
+      onSelect: () => alert('Profile'),
+    },
   ]);
   return null;
 }
 
 function ActionCommands() {
   useXDSCommandPaletteRegister([
-    {id: 'act-new', label: 'New File', icon: 'add', shortcut: 'mod+n', group: 'Actions', onSelect: () => alert('New File')},
-    {id: 'act-save', label: 'Save', icon: 'check', shortcut: 'mod+s', group: 'Actions', onSelect: () => alert('Save')},
+    {
+      id: 'act-new',
+      label: 'New File',
+      icon: 'add',
+      shortcut: 'mod+n',
+      group: 'Actions',
+      onSelect: () => alert('New File'),
+    },
+    {
+      id: 'act-save',
+      label: 'Save',
+      icon: 'check',
+      shortcut: 'mod+s',
+      group: 'Actions',
+      onSelect: () => alert('Save'),
+    },
   ]);
   return null;
 }
@@ -210,7 +285,9 @@ export const Loading: Story = {
     return (
       <>
         <XDSButton label="Open Palette" onClick={() => setIsShown(true)} />
-        <XDSCommandPalette isShown={isShown} onHide={() => setIsShown(false)}>
+        <XDSCommandPalette
+          isShown={isShown}
+          onOpenChange={open => setIsShown(open)}>
           <XDSCommandPaletteInput placeholder="Search..." />
           <XDSCommandPaletteList>
             <XDSCommandPaletteLoading>Searching...</XDSCommandPaletteLoading>

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -63,12 +63,12 @@ function BasicModalExample() {
         variant="primary"
         onClick={() => setIsShown(true)}
       />
-      <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
+      <XDSDialog isShown={isShown} onOpenChange={open => setIsShown(open)}>
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Modal Title"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={
@@ -119,13 +119,13 @@ function SubtitleModalExample() {
         variant="secondary"
         onClick={() => setIsShown(true)}
       />
-      <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
+      <XDSDialog isShown={isShown} onOpenChange={open => setIsShown(open)}>
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Edit User Profile"
               subtitle="Make changes to your account settings"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={
@@ -175,12 +175,15 @@ function WideModalExample() {
         variant="secondary"
         onClick={() => setIsShown(true)}
       />
-      <XDSDialog isShown={isShown} onHide={() => setIsShown(false)} width={600}>
+      <XDSDialog
+        isShown={isShown}
+        onOpenChange={open => setIsShown(open)}
+        width={600}>
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Wide Modal"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={
@@ -226,13 +229,13 @@ function FullscreenModalExample() {
       />
       <XDSDialog
         isShown={isShown}
-        onHide={() => setIsShown(false)}
+        onOpenChange={open => setIsShown(open)}
         variant="fullscreen">
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Fullscreen Modal"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={
@@ -290,7 +293,7 @@ function RequiredModalExample() {
       )}
       <XDSDialog
         isShown={isShown}
-        onHide={() => setIsShown(false)}
+        onOpenChange={open => setIsShown(open)}
         purpose="required">
         <XDSLayout
           header={<XDSDialogHeader title="Accept Terms" />}
@@ -338,14 +341,14 @@ function FormModalExample() {
       />
       <XDSDialog
         isShown={isShown}
-        onHide={() => setIsShown(false)}
+        onOpenChange={open => setIsShown(open)}
         purpose="form"
         width={500}>
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Edit Profile"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={
@@ -398,13 +401,13 @@ function InfoModalExample() {
       />
       <XDSDialog
         isShown={isShown}
-        onHide={() => setIsShown(false)}
+        onOpenChange={open => setIsShown(open)}
         purpose="info">
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Information"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={
@@ -452,14 +455,14 @@ function PositionedModalExample() {
       />
       <XDSDialog
         isShown={isShown}
-        onHide={() => setIsShown(false)}
+        onOpenChange={open => setIsShown(open)}
         position={{top: 100, right: 20}}
         width={350}>
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Positioned Modal"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={
@@ -506,13 +509,13 @@ function ScrollingModalExample() {
       />
       <XDSDialog
         isShown={isShown}
-        onHide={() => setIsShown(false)}
+        onOpenChange={open => setIsShown(open)}
         maxHeight="50vh">
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Terms and Conditions"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={
@@ -584,14 +587,14 @@ function ConfirmationModalExample() {
       )}
       <XDSDialog
         isShown={isShown}
-        onHide={() => setIsShown(false)}
+        onOpenChange={open => setIsShown(open)}
         width={350}
         purpose="form">
         <XDSLayout
           header={
             <XDSDialogHeader
               title="Confirm Delete"
-              onHide={() => setIsShown(false)}
+              onOpenChange={open => setIsShown(open)}
             />
           }
           content={

--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -177,7 +177,7 @@ export const Controlled: Story = {
         <XDSDropdownMenu
           button={{label: 'Controlled Menu'}}
           isMenuOpen={isOpen}
-          onMenuToggle={setIsOpen}
+          onOpenChange={setIsOpen}
           items={[
             {label: 'Item 1', onClick: () => console.log('Item 1')},
             {label: 'Item 2', onClick: () => console.log('Item 2')},

--- a/apps/storybook/stories/MobileNav.stories.tsx
+++ b/apps/storybook/stories/MobileNav.stories.tsx
@@ -57,7 +57,7 @@ export const Default: Story = {
         />
         <XDSMobileNav
           isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
+          onOpenChange={open => setIsOpen(open)}
           title="Navigation">
           <XDSSideNavSection title="Main">
             <XDSSideNavItem
@@ -139,7 +139,7 @@ export const WithSideNavChildren: Story = {
         <XDSButton label="Open Drawer" onClick={() => setIsOpen(true)} />
         <XDSMobileNav
           isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
+          onOpenChange={open => setIsOpen(open)}
           title="My App">
           {navSections}
         </XDSMobileNav>
@@ -202,7 +202,7 @@ export const ResponsivePattern: Story = {
           />
           <XDSMobileNav
             isOpen={drawerOpen}
-            onClose={() => setDrawerOpen(false)}
+            onOpenChange={open => setDrawerOpen(open)}
             title="My App">
             {navSections}
           </XDSMobileNav>
@@ -244,7 +244,7 @@ export const EndSide: Story = {
         <XDSButton label="Open from Right" onClick={() => setIsOpen(true)} />
         <XDSMobileNav
           isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
+          onOpenChange={open => setIsOpen(open)}
           title="Settings"
           side="end">
           <XDSSideNavSection title="Settings">
@@ -274,7 +274,7 @@ export const CustomWidth: Story = {
         <XDSButton label="Open Wide Drawer" onClick={() => setIsOpen(true)} />
         <XDSMobileNav
           isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
+          onOpenChange={open => setIsOpen(open)}
           title="Wide Navigation"
           width={360}>
           <XDSSideNavSection title="Main">
@@ -313,7 +313,7 @@ export const WithoutTitle: Story = {
           variant="ghost"
           onClick={() => setIsOpen(true)}
         />
-        <XDSMobileNav isOpen={isOpen} onClose={() => setIsOpen(false)}>
+        <XDSMobileNav isOpen={isOpen} onOpenChange={open => setIsOpen(open)}>
           <XDSSideNavSection title="Main">
             <XDSSideNavItem
               label="Dashboard"

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -153,7 +153,7 @@ export const FilterPanel: Story = {
         label="Filter"
         width={240}
         isShown={isShown}
-        onToggle={setIsShown}
+        onOpenChange={setIsShown}
         content={<FilterContent onApply={() => setIsShown(false)} />}>
         <XDSButton label="Filter">Filter</XDSButton>
       </XDSPopover>
@@ -202,7 +202,7 @@ export const Confirmation: Story = {
         label="Confirm deletion"
         width={300}
         isShown={isShown}
-        onToggle={setIsShown}
+        onOpenChange={setIsShown}
         content={
           <ConfirmContent
             onConfirm={() => setIsShown(false)}

--- a/packages/core/src/AppShell/README.md
+++ b/packages/core/src/AppShell/README.md
@@ -114,7 +114,7 @@ On desktop the SideNav renders inline; on mobile AppShell hides the SideNav
 (via `sideNavBreakpoint`) and the consumer shows an XDSMobileNav drawer instead.
 
 Pass a fully composed `<XDSMobileNav>` — AppShell just renders it, same as
-every other slot. All drawer props (`isOpen`, `onClose`, `title`) stay on
+every other slot. All drawer props (`isOpen`, `onOpenChange`, `title`) stay on
 XDSMobileNav where they belong.
 
 ```tsx
@@ -144,7 +144,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
   mobileNav={
     <XDSMobileNav
       isOpen={mobileOpen}
-      onClose={() => setMobileOpen(false)}
+      onOpenChange={open => setMobileOpen(open)}
       title="My App">
       {navSections}
     </XDSMobileNav>

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -477,7 +477,7 @@ describe('XDSAppShell', () => {
         mobileNav={
           <XDSMobileNav
             isOpen={true}
-            onClose={() => {}}
+            onOpenChange={() => {}}
             title="Test App"
             data-testid="appshell-mobile-nav">
             <div>Mobile Nav Content</div>
@@ -509,7 +509,7 @@ describe('XDSAppShell', () => {
         mobileNav={
           <XDSMobileNav
             isOpen={false}
-            onClose={() => {}}
+            onOpenChange={() => {}}
             data-testid="appshell-mobile-nav">
             <div>Mobile Nav</div>
           </XDSMobileNav>
@@ -525,13 +525,13 @@ describe('XDSAppShell', () => {
     expect(screen.getByTestId('appshell-mobile-nav')).toBeInTheDocument();
   });
 
-  it('mobileNav onClose is called when close button is clicked', () => {
+  it('mobileNav onOpenChange is called when close button is clicked', () => {
     const onClose = vi.fn();
     render(
       <XDSAppShell
         sideNav={<div>Side Nav</div>}
         mobileNav={
-          <XDSMobileNav isOpen={true} onClose={onClose} title="Nav">
+          <XDSMobileNav isOpen={true} onOpenChange={onClose} title="Nav">
             <div>Mobile Nav</div>
           </XDSMobileNav>
         }>

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -264,7 +264,7 @@ const styles = stylex.create({
  *   topNav={<XDSTopNav label="Navigation" title={<XDSTopNavTitle title="My App" />} />}
  *   sideNav={<XDSSideNav>{navSections}</XDSSideNav>}
  *   mobileNav={
- *     <XDSMobileNav isOpen={mobileOpen} onClose={() => setMobileOpen(false)} title="My App">
+ *     <XDSMobileNav isOpen={mobileOpen} onOpenChange={(open) => setMobileOpen(open)} title="My App">
  *       {navSections}
  *     </XDSMobileNav>
  *   }
@@ -507,7 +507,7 @@ export const XDSAppShell = forwardRef<HTMLDivElement, XDSAppShellProps>(
         {useDefaultMobileNav && (
           <XDSMobileNav
             isOpen={!isCollapsed}
-            onClose={handleToggleCollapse}
+            onOpenChange={() => handleToggleCollapse()}
             width={sideNavWidth}
             data-testid="sidenav-mobile">
             {sideNav}

--- a/packages/core/src/CommandPalette/CommandPaletteContext.ts
+++ b/packages/core/src/CommandPalette/CommandPaletteContext.ts
@@ -34,7 +34,7 @@ export interface CommandPaletteContextValue {
   /** Select an item by value. */
   selectItem: (value: string) => void;
   /** Close the palette. */
-  onHide: () => void;
+  onClose: () => void;
 }
 
 export const CommandPaletteContext =

--- a/packages/core/src/CommandPalette/README.md
+++ b/packages/core/src/CommandPalette/README.md
@@ -12,35 +12,35 @@ Three layers, each building on the last:
 
 ## File Manifest
 
-| File | Purpose |
-|------|---------|
-| `index.ts` | Public exports |
-| `types.ts` | Shared types (XDSCommand, filter function) |
-| `filter.ts` | Default substring filter |
-| `CommandPaletteContext.ts` | Internal context for compound components |
-| `XDSCommandPalette.tsx` | Root component (wraps XDSDialog) |
-| `XDSCommandPaletteInput.tsx` | Search input with combobox ARIA |
-| `XDSCommandPaletteList.tsx` | Scrollable results container (listbox) |
-| `XDSCommandPaletteItem.tsx` | Selectable item (option) |
-| `XDSCommandPaletteGroup.tsx` | Visual grouping with heading |
-| `XDSCommandPaletteEmpty.tsx` | Empty state |
-| `XDSCommandPaletteLoading.tsx` | Loading indicator |
-| `XDSCommandPaletteSeparator.tsx` | Visual divider (wraps XDSDivider) |
-| `XDSCommandPaletteShortcut.tsx` | Keyboard shortcut display |
-| `XDSCommandPaletteFooter.tsx` | Footer bar |
-| `XDSCommandPaletteProvider.tsx` | Registry provider + hooks |
-| `useXDSCommandPaletteHistory.ts` | Optional history hook |
+| File                             | Purpose                                    |
+| -------------------------------- | ------------------------------------------ |
+| `index.ts`                       | Public exports                             |
+| `types.ts`                       | Shared types (XDSCommand, filter function) |
+| `filter.ts`                      | Default substring filter                   |
+| `CommandPaletteContext.ts`       | Internal context for compound components   |
+| `XDSCommandPalette.tsx`          | Root component (wraps XDSDialog)           |
+| `XDSCommandPaletteInput.tsx`     | Search input with combobox ARIA            |
+| `XDSCommandPaletteList.tsx`      | Scrollable results container (listbox)     |
+| `XDSCommandPaletteItem.tsx`      | Selectable item (option)                   |
+| `XDSCommandPaletteGroup.tsx`     | Visual grouping with heading               |
+| `XDSCommandPaletteEmpty.tsx`     | Empty state                                |
+| `XDSCommandPaletteLoading.tsx`   | Loading indicator                          |
+| `XDSCommandPaletteSeparator.tsx` | Visual divider (wraps XDSDivider)          |
+| `XDSCommandPaletteShortcut.tsx`  | Keyboard shortcut display                  |
+| `XDSCommandPaletteFooter.tsx`    | Footer bar                                 |
+| `XDSCommandPaletteProvider.tsx`  | Registry provider + hooks                  |
+| `useXDSCommandPaletteHistory.ts` | Optional history hook                      |
 
 ## Usage
 
 ### Layer 1: Composable
 
 ```tsx
-<XDSCommandPalette isShown={isShown} onHide={() => setIsShown(false)}>
+<XDSCommandPalette isShown={isShown} onOpenChange={open => setIsShown(open)}>
   <XDSCommandPaletteInput placeholder="Search..." />
   <XDSCommandPaletteList>
     <XDSCommandPaletteGroup heading="Navigation">
-      <XDSCommandPaletteItem value="home" onSelect={() => navigate("/")}>
+      <XDSCommandPaletteItem value="home" onSelect={() => navigate('/')}>
         <XDSIcon icon="home" size="sm" />
         <span>Go Home</span>
         <XDSCommandPaletteShortcut keys="mod+h" />
@@ -61,20 +61,25 @@ Three layers, each building on the last:
 // Wrap your app
 <XDSCommandPaletteProvider shortcut="mod+k">
   <App />
-</XDSCommandPaletteProvider>
+</XDSCommandPaletteProvider>;
 
 // Register commands from anywhere
 function Navigation() {
   useXDSCommandPaletteRegister([
-    { id: "home", label: "Go Home", icon: "home", onSelect: () => navigate("/") },
-    { id: "settings", label: "Settings", shortcut: "mod+,", onSelect: () => navigate("/settings") },
+    {id: 'home', label: 'Go Home', icon: 'home', onSelect: () => navigate('/')},
+    {
+      id: 'settings',
+      label: 'Settings',
+      shortcut: 'mod+,',
+      onSelect: () => navigate('/settings'),
+    },
   ]);
   return <nav>...</nav>;
 }
 
 // Imperative control
 function SearchButton() {
-  const { open } = useXDSCommandPalette();
+  const {open} = useXDSCommandPalette();
   return <XDSButton label="Search" onClick={open} />;
 }
 ```
@@ -82,7 +87,7 @@ function SearchButton() {
 ### Layer 3: History
 
 ```tsx
-const { history, record, clear } = useXDSCommandPaletteHistory({
+const {history, record, clear} = useXDSCommandPaletteHistory({
   persist: true,
   maxEntries: 10,
 });

--- a/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
@@ -19,7 +19,6 @@ import {XDSCommandPaletteLoading} from './XDSCommandPaletteLoading';
 import {useXDSCommandPaletteHistory} from './useXDSCommandPaletteHistory';
 import {defaultFilter} from './filter';
 
-
 // Mock showModal and close methods since they're not fully implemented in jsdom
 beforeEach(() => {
   HTMLDialogElement.prototype.showModal = vi.fn(function (
@@ -95,7 +94,7 @@ describe('XDSCommandPaletteShortcut', () => {
 describe('XDSCommandPalette (composable)', () => {
   it('renders when isShown is true', () => {
     render(
-      <XDSCommandPalette isShown={true} onHide={vi.fn()}>
+      <XDSCommandPalette isShown={true} onOpenChange={vi.fn()}>
         <XDSCommandPaletteInput />
         <XDSCommandPaletteList>
           <XDSCommandPaletteItem value="test" onSelect={vi.fn()}>
@@ -110,7 +109,7 @@ describe('XDSCommandPalette (composable)', () => {
 
   it('renders groups with headings', () => {
     render(
-      <XDSCommandPalette isShown={true} onHide={vi.fn()}>
+      <XDSCommandPalette isShown={true} onOpenChange={vi.fn()}>
         <XDSCommandPaletteInput />
         <XDSCommandPaletteList>
           <XDSCommandPaletteGroup heading="Navigation">
@@ -127,7 +126,7 @@ describe('XDSCommandPalette (composable)', () => {
 
   it('renders empty state', () => {
     render(
-      <XDSCommandPalette isShown={true} onHide={vi.fn()}>
+      <XDSCommandPalette isShown={true} onOpenChange={vi.fn()}>
         <XDSCommandPaletteInput />
         <XDSCommandPaletteList>
           <XDSCommandPaletteEmpty>No results found</XDSCommandPaletteEmpty>
@@ -139,7 +138,7 @@ describe('XDSCommandPalette (composable)', () => {
 
   it('renders loading state', () => {
     render(
-      <XDSCommandPalette isShown={true} onHide={vi.fn()}>
+      <XDSCommandPalette isShown={true} onOpenChange={vi.fn()}>
         <XDSCommandPaletteInput />
         <XDSCommandPaletteList>
           <XDSCommandPaletteLoading>Searching...</XDSCommandPaletteLoading>
@@ -151,7 +150,7 @@ describe('XDSCommandPalette (composable)', () => {
 
   it('renders footer', () => {
     render(
-      <XDSCommandPalette isShown={true} onHide={vi.fn()}>
+      <XDSCommandPalette isShown={true} onOpenChange={vi.fn()}>
         <XDSCommandPaletteInput />
         <XDSCommandPaletteList>
           <XDSCommandPaletteItem value="test" onSelect={vi.fn()}>
@@ -169,7 +168,7 @@ describe('XDSCommandPalette (composable)', () => {
   it('calls onSelect when item is clicked', () => {
     const onSelect = vi.fn();
     render(
-      <XDSCommandPalette isShown={true} onHide={vi.fn()}>
+      <XDSCommandPalette isShown={true} onOpenChange={vi.fn()}>
         <XDSCommandPaletteInput />
         <XDSCommandPaletteList>
           <XDSCommandPaletteItem value="test" onSelect={onSelect}>
@@ -185,13 +184,10 @@ describe('XDSCommandPalette (composable)', () => {
   it('does not call onSelect for disabled items', () => {
     const onSelect = vi.fn();
     render(
-      <XDSCommandPalette isShown={true} onHide={vi.fn()}>
+      <XDSCommandPalette isShown={true} onOpenChange={vi.fn()}>
         <XDSCommandPaletteInput />
         <XDSCommandPaletteList>
-          <XDSCommandPaletteItem
-            value="test"
-            onSelect={onSelect}
-            isDisabled>
+          <XDSCommandPaletteItem value="test" onSelect={onSelect} isDisabled>
             Disabled Item
           </XDSCommandPaletteItem>
         </XDSCommandPaletteList>
@@ -203,7 +199,10 @@ describe('XDSCommandPalette (composable)', () => {
 
   it('has correct ARIA attributes', () => {
     render(
-      <XDSCommandPalette isShown={true} onHide={vi.fn()} label="Test palette">
+      <XDSCommandPalette
+        isShown={true}
+        onOpenChange={vi.fn()}
+        label="Test palette">
         <XDSCommandPaletteInput placeholder="Search..." />
         <XDSCommandPaletteList>
           <XDSCommandPaletteItem value="test" onSelect={vi.fn()}>

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -40,10 +40,11 @@ export interface XDSCommandPaletteProps {
   isShown: boolean;
 
   /**
-   * Called when the palette requests to close.
+   * Callback fired when the command palette visibility changes.
+   * Called with `false` when the palette requests to close.
    * Matches XDSDialog convention.
    */
-  onHide: () => void;
+  onOpenChange: (isOpen: boolean) => unknown;
 
   /**
    * Controlled selected value.
@@ -96,7 +97,7 @@ export interface XDSCommandPaletteProps {
    *
    * @example
    * ```
-   * <XDSCommandPalette isShown={isShown} onHide={() => setIsShown(false)}>
+   * <XDSCommandPalette isShown={isShown} onOpenChange={(open) => setIsShown(open)}>
    *   <XDSCommandPaletteInput placeholder="Search commands..." />
    *   <XDSCommandPaletteList>
    *     <XDSCommandPaletteItem value="home" onSelect={() => navigate("/")}>
@@ -121,7 +122,7 @@ export interface XDSCommandPaletteProps {
  */
 export function XDSCommandPalette({
   isShown,
-  onHide,
+  onOpenChange,
   value: controlledValue,
   onValueChange,
   filter = defaultFilter,
@@ -152,13 +153,10 @@ export function XDSCommandPalette({
 
   const registerItem = useCallback(
     (itemValue: string, isDisabled?: boolean) => {
-      itemsRef.current = [
-        ...itemsRef.current,
-        {value: itemValue, isDisabled},
-      ];
+      itemsRef.current = [...itemsRef.current, {value: itemValue, isDisabled}];
       return () => {
         itemsRef.current = itemsRef.current.filter(
-          (item) => item.value !== itemValue,
+          item => item.value !== itemValue,
         );
       };
     },
@@ -172,12 +170,17 @@ export function XDSCommandPalette({
     [setValue],
   );
 
-  // Reset search and highlight when opening/closing
-  const handleHide = useCallback(() => {
-    setSearch('');
-    setHighlightedIndex(0);
-    onHide();
-  }, [onHide]);
+  // Reset search and highlight when closing, then forward to consumer
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        setSearch('');
+        setHighlightedIndex(0);
+      }
+      onOpenChange(open);
+    },
+    [onOpenChange],
+  );
 
   const contextValue = useMemo(
     () => ({
@@ -193,7 +196,7 @@ export function XDSCommandPalette({
       items: itemsRef.current,
       registerItem,
       selectItem,
-      onHide: handleHide,
+      onClose: () => handleOpenChange(false),
     }),
     [
       search,
@@ -205,14 +208,14 @@ export function XDSCommandPalette({
       highlightedIndex,
       registerItem,
       selectItem,
-      handleHide,
+      handleOpenChange,
     ],
   );
 
   return (
     <XDSDialog
       isShown={isShown}
-      onHide={handleHide}
+      onOpenChange={handleOpenChange}
       width={width}
       maxHeight={maxHeight}
       purpose="info"

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -22,7 +22,6 @@ import {
 import {XDSIcon} from '../Icon';
 import {useCommandPaletteContext} from './CommandPaletteContext';
 
-
 const styles = stylex.create({
   wrapper: {
     display: 'flex',
@@ -73,7 +72,7 @@ export interface XDSCommandPaletteInputProps {
  *
  * @example
  * ```
- * <XDSCommandPalette isShown={isShown} onHide={onHide}>
+ * <XDSCommandPalette isShown={isShown} onOpenChange={(open) => setIsShown(open)}>
  *   <XDSCommandPaletteInput placeholder="Search commands..." />
  *   <XDSCommandPaletteList>...</XDSCommandPaletteList>
  * </XDSCommandPalette>
@@ -91,7 +90,7 @@ export function XDSCommandPaletteInput({
     setHighlightedIndex,
     items,
     selectItem,
-    onHide,
+    onClose,
   } = useCommandPaletteContext();
 
   const inputRef = useRef<HTMLInputElement>(null);
@@ -166,12 +165,12 @@ export function XDSCommandPaletteInput({
         }
         case 'Escape': {
           e.preventDefault();
-          onHide();
+          onClose();
           break;
         }
       }
     },
-    [highlightedIndex, items, setHighlightedIndex, selectItem, onHide],
+    [highlightedIndex, items, setHighlightedIndex, selectItem, onClose],
   );
 
   const activeDescendant =
@@ -186,7 +185,7 @@ export function XDSCommandPaletteInput({
         ref={inputRef}
         type="text"
         value={search}
-        onChange={(e) => {
+        onChange={e => {
           setSearch(e.target.value);
           setHighlightedIndex(0);
         }}

--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
@@ -125,14 +125,12 @@ export function XDSCommandPaletteItem({
   }, [value, isDisabled, ctx.registerItem]);
 
   // Determine this item's index in the items array
-  const itemIndex = ctx.items.findIndex((item) => item.value === value);
+  const itemIndex = ctx.items.findIndex(item => item.value === value);
   const isHighlighted = itemIndex === ctx.highlightedIndex;
   const isSelected = ctx.value === value;
 
   // Filter: check if this item matches the search
-  const score = ctx.isFiltered
-    ? ctx.filter(value, ctx.search, keywords)
-    : 1;
+  const score = ctx.isFiltered ? ctx.filter(value, ctx.search, keywords) : 1;
 
   // Scroll highlighted item into view
   useEffect(() => {
@@ -145,7 +143,7 @@ export function XDSCommandPaletteItem({
     if (isDisabled) return;
     onSelect?.(value);
     ctx.selectItem(value);
-    ctx.onHide();
+    ctx.onClose();
   }, [isDisabled, value, onSelect, ctx]);
 
   const handleMouseEnter = useCallback(() => {

--- a/packages/core/src/CommandPalette/XDSCommandPaletteProvider.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteProvider.tsx
@@ -29,10 +29,7 @@ import {XDSCommandPaletteShortcut} from './XDSCommandPaletteShortcut';
 import {XDSCommandPaletteFooter} from './XDSCommandPaletteFooter';
 import {XDSCommandPaletteLoading} from './XDSCommandPaletteLoading';
 import * as stylex from '@stylexjs/stylex';
-import {
-  colorVars,
-  textSizeVars,
-} from '../theme/tokens.stylex';
+import {colorVars, textSizeVars} from '../theme/tokens.stylex';
 import {XDSIcon} from '../Icon';
 import type {XDSCommand, CommandPaletteFilterFn} from './types';
 
@@ -205,17 +202,17 @@ export function XDSCommandPaletteProvider({
   }, []);
 
   const register = useCallback((newCommands: XDSCommand[]) => {
-    setCommands((prev) => [...prev, ...newCommands]);
+    setCommands(prev => [...prev, ...newCommands]);
     return () => {
-      setCommands((prev) =>
-        prev.filter((cmd) => !newCommands.some((nc) => nc.id === cmd.id)),
+      setCommands(prev =>
+        prev.filter(cmd => !newCommands.some(nc => nc.id === cmd.id)),
       );
     };
   }, []);
 
   // Keyboard shortcut listener
   useEffect(() => {
-    const parts = shortcut.split('+').map((p) => p.trim().toLowerCase());
+    const parts = shortcut.split('+').map(p => p.trim().toLowerCase());
     const key = parts[parts.length - 1];
     const needsMod = parts.includes('mod');
     const needsShift = parts.includes('shift');
@@ -230,7 +227,7 @@ export function XDSCommandPaletteProvider({
         (!needsAlt || e.altKey)
       ) {
         e.preventDefault();
-        setIsOpen((prev) => !prev);
+        setIsOpen(prev => !prev);
       }
     };
 
@@ -305,7 +302,7 @@ export function XDSCommandPaletteProvider({
 
   const handleValueChange = useCallback(
     (value: string) => {
-      const cmd = allCommands.find((c) => c.id === value);
+      const cmd = allCommands.find(c => c.id === value);
       if (cmd && !cmd.isDisabled) {
         cmd.onSelect();
         close();
@@ -328,18 +325,20 @@ export function XDSCommandPaletteProvider({
       {children}
       <XDSCommandPalette
         isShown={isOpen}
-        onHide={close}
+        onOpenChange={open => {
+          if (!open) close();
+        }}
         onValueChange={handleValueChange}
         filter={filter}>
         <XDSCommandPaletteInput placeholder={placeholder} />
         <XDSCommandPaletteList>
-          {groupedCommands.ungrouped.map((cmd) => (
+          {groupedCommands.ungrouped.map(cmd => (
             <CommandItem key={cmd.id} command={cmd} />
           ))}
           {Array.from(groupedCommands.groups.entries()).map(
             ([groupName, cmds]) => (
               <XDSCommandPaletteGroup key={groupName} heading={groupName}>
-                {cmds.map((cmd) => (
+                {cmds.map(cmd => (
                   <CommandItem key={cmd.id} command={cmd} />
                 ))}
               </XDSCommandPaletteGroup>
@@ -399,7 +398,9 @@ function CommandItem({command}: {command: XDSCommand}) {
           {command.description}
         </span>
       )}
-      {command.shortcut && <XDSCommandPaletteShortcut keys={command.shortcut} />}
+      {command.shortcut && (
+        <XDSCommandPaletteShortcut keys={command.shortcut} />
+      )}
     </XDSCommandPaletteItem>
   );
 }

--- a/packages/core/src/Dialog/README.md
+++ b/packages/core/src/Dialog/README.md
@@ -36,7 +36,7 @@ function Example() {
     <>
       <XDSButton label="Open Dialog" onClick={() => setIsShown(true)} />
 
-      <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
+      <XDSDialog isShown={isShown} onOpenChange={open => setIsShown(open)}>
         <XDSLayout
           header={<XDSLayoutHeader hasDivider>Title</XDSLayoutHeader>}
           content={<XDSLayoutContent>Content goes here</XDSLayoutContent>}
@@ -68,29 +68,33 @@ function Example() {
 Modal dialog using the native `<dialog>` element.
 
 ```tsx
-<XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
+<XDSDialog isShown={isShown} onOpenChange={open => setIsShown(open)}>
   <XDSLayout
     header={<XDSLayoutHeader hasDivider>Title</XDSLayoutHeader>}
     content={<XDSLayoutContent>Content goes here</XDSLayoutContent>}
     footer={
       <XDSLayoutFooter hasDivider>
-        <XDSButton label="Confirm" variant="primary" onClick={() => setIsShown(false)} />
+        <XDSButton
+          label="Confirm"
+          variant="primary"
+          onClick={() => setIsShown(false)}
+        />
       </XDSLayoutFooter>
     }
   />
 </XDSDialog>
 ```
 
-| Prop        | Type                             | Default      | Description                                      |
-| ----------- | -------------------------------- | ------------ | ------------------------------------------------ |
-| `isShown`   | `boolean`                        | —            | Whether the dialog is shown (required)           |
-| `onHide`    | `() => unknown`                  | —            | Callback when dialog requests to hide (required) |
-| `width`     | `number \| string`               | `400`        | Width of the dialog (px or CSS value)            |
-| `maxHeight` | `number \| string`               | `'75vh'`     | Maximum height of the dialog                     |
-| `position`  | `XDSDialogPosition`              | —            | Static position (centered by default)            |
-| `variant`   | `'standard' \| 'fullscreen'`     | `'standard'` | Dialog variant                                   |
-| `purpose`   | `'required' \| 'form' \| 'info'` | `'info'`     | Dismissal behavior                               |
-| `children`  | `ReactNode`                      | —            | Dialog content (required)                        |
+| Prop           | Type                             | Default      | Description                                        |
+| -------------- | -------------------------------- | ------------ | -------------------------------------------------- |
+| `isShown`      | `boolean`                        | —            | Whether the dialog is shown (required)             |
+| `onOpenChange` | `(isOpen: boolean) => unknown`   | —            | Callback when dialog visibility changes (required) |
+| `width`        | `number \| string`               | `400`        | Width of the dialog (px or CSS value)              |
+| `maxHeight`    | `number \| string`               | `'75vh'`     | Maximum height of the dialog                       |
+| `position`     | `XDSDialogPosition`              | —            | Static position (centered by default)              |
+| `variant`      | `'standard' \| 'fullscreen'`     | `'standard'` | Dialog variant                                     |
+| `purpose`      | `'required' \| 'form' \| 'info'` | `'info'`     | Dismissal behavior                                 |
+| `children`     | `ReactNode`                      | —            | Dialog content (required)                          |
 
 ### XDSDialogHeader
 
@@ -100,31 +104,31 @@ Header for dialogs with title, optional subtitle, close button, and start/end co
 <XDSDialogHeader
   title="Confirm Action"
   subtitle="This cannot be undone"
-  onHide={() => setIsShown(false)}
+  onOpenChange={open => setIsShown(open)}
 />
 ```
 
-| Prop           | Type             | Default | Description                                          |
-| -------------- | ---------------- | ------- | ---------------------------------------------------- |
-| `title`        | `string`         | —       | Dialog title (receives focus on open)                |
-| `subtitle`     | `string`         | —       | Subtitle below the title                             |
-| `onHide`       | `() => unknown`  | —       | Close button callback (no button if omitted)         |
-| `startContent` | `ReactNode`      | —       | Content before the title (e.g., back button)         |
-| `endContent`   | `ReactNode`      | —       | Content after the title, before close button         |
-| `hasDivider`   | `boolean`        | `true`  | Adds border at the bottom edge                       |
+| Prop           | Type                           | Default | Description                                       |
+| -------------- | ------------------------------ | ------- | ------------------------------------------------- |
+| `title`        | `string`                       | —       | Dialog title (receives focus on open)             |
+| `subtitle`     | `string`                       | —       | Subtitle below the title                          |
+| `onOpenChange` | `(isOpen: boolean) => unknown` | —       | Visibility change callback (no button if omitted) |
+| `startContent` | `ReactNode`                    | —       | Content before the title (e.g., back button)      |
+| `endContent`   | `ReactNode`                    | —       | Content after the title, before close button      |
+| `hasDivider`   | `boolean`                      | `true`  | Adds border at the bottom edge                    |
 
 ## Props
 
-| Prop        | Type                             | Default      | Description                                      |
-| ----------- | -------------------------------- | ------------ | ------------------------------------------------ |
-| `isShown`   | `boolean`                        | —            | Whether the dialog is shown (required)           |
-| `onHide`    | `() => unknown`                  | —            | Callback when dialog requests to hide (required) |
-| `width`     | `number \| string`               | `400`        | Width of the dialog (px or CSS value)            |
-| `maxHeight` | `number \| string`               | `'75vh'`     | Maximum height of the dialog                     |
-| `position`  | `XDSDialogPosition`              | —            | Static position (centered by default)            |
-| `variant`   | `'standard' \| 'fullscreen'`     | `'standard'` | Dialog variant                                   |
-| `purpose`   | `'required' \| 'form' \| 'info'` | `'info'`     | Dismissal behavior                               |
-| `children`  | `ReactNode`                      | —            | Dialog content (required)                        |
+| Prop           | Type                             | Default      | Description                                        |
+| -------------- | -------------------------------- | ------------ | -------------------------------------------------- |
+| `isShown`      | `boolean`                        | —            | Whether the dialog is shown (required)             |
+| `onOpenChange` | `(isOpen: boolean) => unknown`   | —            | Callback when dialog visibility changes (required) |
+| `width`        | `number \| string`               | `400`        | Width of the dialog (px or CSS value)              |
+| `maxHeight`    | `number \| string`               | `'75vh'`     | Maximum height of the dialog                       |
+| `position`     | `XDSDialogPosition`              | —            | Static position (centered by default)              |
+| `variant`      | `'standard' \| 'fullscreen'`     | `'standard'` | Dialog variant                                     |
+| `purpose`      | `'required' \| 'form' \| 'info'` | `'info'`     | Dismissal behavior                                 |
+| `children`     | `ReactNode`                      | —            | Dialog content (required)                          |
 
 ## Purpose Prop
 
@@ -145,7 +149,7 @@ Configure a static position instead of centering:
 ```tsx
 <XDSDialog
   isShown={isShown}
-  onHide={() => setIsShown(false)}
+  onOpenChange={open => setIsShown(open)}
   position={{top: 100, right: 20}}>
   {/* content */}
 </XDSDialog>

--- a/packages/core/src/Dialog/XDSDialog.test.tsx
+++ b/packages/core/src/Dialog/XDSDialog.test.tsx
@@ -26,7 +26,7 @@ beforeEach(() => {
 describe('XDSDialog', () => {
   it('renders when isShown is true', () => {
     render(
-      <XDSDialog isShown={true} onHide={() => {}}>
+      <XDSDialog isShown={true} onOpenChange={() => {}}>
         Dialog content
       </XDSDialog>,
     );
@@ -36,7 +36,7 @@ describe('XDSDialog', () => {
 
   it('calls showModal when opened', () => {
     render(
-      <XDSDialog isShown={true} onHide={() => {}}>
+      <XDSDialog isShown={true} onOpenChange={() => {}}>
         Content
       </XDSDialog>,
     );
@@ -45,7 +45,7 @@ describe('XDSDialog', () => {
 
   it('does not show when isShown is false', () => {
     render(
-      <XDSDialog isShown={false} onHide={() => {}}>
+      <XDSDialog isShown={false} onOpenChange={() => {}}>
         Hidden content
       </XDSDialog>,
     );
@@ -55,7 +55,7 @@ describe('XDSDialog', () => {
 
   it('has aria-modal attribute', () => {
     render(
-      <XDSDialog isShown={true} onHide={() => {}}>
+      <XDSDialog isShown={true} onOpenChange={() => {}}>
         Content
       </XDSDialog>,
     );
@@ -63,11 +63,11 @@ describe('XDSDialog', () => {
   });
 
   describe('purpose: info (default)', () => {
-    it('calls onHide when Escape is pressed', () => {
+    it('calls onOpenChange(false) when Escape is pressed', () => {
       const handleHide = vi.fn();
 
       render(
-        <XDSDialog isShown={true} onHide={handleHide} purpose="info">
+        <XDSDialog isShown={true} onOpenChange={handleHide} purpose="info">
           Content
         </XDSDialog>,
       );
@@ -84,11 +84,11 @@ describe('XDSDialog', () => {
   });
 
   describe('purpose: form', () => {
-    it('calls onHide when Escape is pressed', () => {
+    it('calls onOpenChange(false) when Escape is pressed', () => {
       const handleHide = vi.fn();
 
       render(
-        <XDSDialog isShown={true} onHide={handleHide} purpose="form">
+        <XDSDialog isShown={true} onOpenChange={handleHide} purpose="form">
           Content
         </XDSDialog>,
       );
@@ -105,11 +105,11 @@ describe('XDSDialog', () => {
   });
 
   describe('purpose: required', () => {
-    it('does not call onHide when Escape is pressed', () => {
+    it('does not call onOpenChange when Escape is pressed', () => {
       const handleHide = vi.fn();
 
       render(
-        <XDSDialog isShown={true} onHide={handleHide} purpose="required">
+        <XDSDialog isShown={true} onOpenChange={handleHide} purpose="required">
           Content
         </XDSDialog>,
       );
@@ -127,7 +127,7 @@ describe('XDSDialog', () => {
     it('prevents default on cancel event', () => {
       const handleHide = vi.fn();
       render(
-        <XDSDialog isShown={true} onHide={handleHide} purpose="required">
+        <XDSDialog isShown={true} onOpenChange={handleHide} purpose="required">
           Content
         </XDSDialog>,
       );
@@ -144,7 +144,7 @@ describe('XDSDialog', () => {
   describe('variant: standard', () => {
     it('renders with default variant', () => {
       render(
-        <XDSDialog isShown={true} onHide={() => {}}>
+        <XDSDialog isShown={true} onOpenChange={() => {}}>
           Content
         </XDSDialog>,
       );
@@ -153,7 +153,7 @@ describe('XDSDialog', () => {
 
     it('accepts custom width', () => {
       render(
-        <XDSDialog isShown={true} onHide={() => {}} width={600}>
+        <XDSDialog isShown={true} onOpenChange={() => {}} width={600}>
           Content
         </XDSDialog>,
       );
@@ -162,7 +162,7 @@ describe('XDSDialog', () => {
 
     it('accepts custom maxHeight', () => {
       render(
-        <XDSDialog isShown={true} onHide={() => {}} maxHeight="50vh">
+        <XDSDialog isShown={true} onOpenChange={() => {}} maxHeight="50vh">
           Content
         </XDSDialog>,
       );
@@ -173,7 +173,7 @@ describe('XDSDialog', () => {
   describe('variant: fullscreen', () => {
     it('renders fullscreen variant', () => {
       render(
-        <XDSDialog isShown={true} onHide={() => {}} variant="fullscreen">
+        <XDSDialog isShown={true} onOpenChange={() => {}} variant="fullscreen">
           Content
         </XDSDialog>,
       );
@@ -186,7 +186,7 @@ describe('XDSDialog', () => {
       render(
         <XDSDialog
           isShown={true}
-          onHide={() => {}}
+          onOpenChange={() => {}}
           position={{top: 100, right: 20}}>
           Content
         </XDSDialog>,
@@ -198,7 +198,7 @@ describe('XDSDialog', () => {
       render(
         <XDSDialog
           isShown={true}
-          onHide={() => {}}
+          onOpenChange={() => {}}
           position={{top: '10vh', left: '5vw'}}>
           Content
         </XDSDialog>,
@@ -209,7 +209,10 @@ describe('XDSDialog', () => {
 
   it('forwards additional props to dialog element', () => {
     render(
-      <XDSDialog isShown={true} onHide={() => {}} data-testid="custom-dialog">
+      <XDSDialog
+        isShown={true}
+        onOpenChange={() => {}}
+        data-testid="custom-dialog">
         Content
       </XDSDialog>,
     );

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -163,13 +163,14 @@ export interface XDSDialogProps extends Omit<
   isShown: boolean;
 
   /**
-   * Callback fired when the dialog requests to be hidden.
-   * This is called based on the `purpose` prop configuration:
+   * Callback fired when the dialog visibility changes.
+   * Called with `false` when the dialog requests to be hidden.
+   * Behavior depends on the `purpose` prop:
    * - required: Never called automatically
    * - form: Called on Escape key only
    * - info: Called on Escape key and backdrop click
    */
-  onHide: () => unknown;
+  onOpenChange: (isOpen: boolean) => unknown;
 
   /**
    * The width of the dialog.
@@ -229,9 +230,9 @@ export interface XDSDialogProps extends Omit<
  * ```
  * const [isShown, setIsShown] = useState(false);
  *
- * <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
+ * <XDSDialog isShown={isShown} onOpenChange={(open) => setIsShown(open)}>
  *   <XDSLayout
- *     header={<XDSDialogHeader title="Title" onHide={() => setIsShown(false)} />}
+ *     header={<XDSDialogHeader title="Title" onOpenChange={(open) => setIsShown(open)} />}
  *     content={<XDSLayoutContent>Content</XDSLayoutContent>}
  *     footer={<XDSLayoutFooter hasDivider>Actions</XDSLayoutFooter>}
  *   />
@@ -242,7 +243,7 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
   (
     {
       isShown,
-      onHide,
+      onOpenChange,
       width = 400,
       maxHeight = '75vh',
       position,
@@ -295,14 +296,14 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
         if (event.key === 'Escape') {
           event.preventDefault();
           if (allowEscape) {
-            onHide();
+            onOpenChange(false);
           }
         }
       };
 
       dialog.addEventListener('keydown', handleKeyDown);
       return () => dialog.removeEventListener('keydown', handleKeyDown);
-    }, [isShown, allowEscape, onHide]);
+    }, [isShown, allowEscape, onOpenChange]);
 
     // Handle backdrop click
     const handleClick = (event: React.MouseEvent<HTMLDialogElement>) => {
@@ -318,7 +319,7 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
         event.clientY > rect.bottom;
 
       if (isBackdropClick && allowBackdropClick) {
-        onHide();
+        onOpenChange(false);
       }
     };
 
@@ -326,7 +327,7 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
     const handleCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
       event.preventDefault();
       if (allowEscape) {
-        onHide();
+        onOpenChange(false);
       }
     };
 

--- a/packages/core/src/Dialog/XDSDialogHeader.test.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.test.tsx
@@ -48,22 +48,22 @@ describe('XDSDialogHeader', () => {
     expect(screen.queryByText('This is a subtitle')).not.toBeInTheDocument();
   });
 
-  it('renders close button when onHide is provided', () => {
-    render(<XDSDialogHeader title="Title" onHide={() => {}} />);
+  it('renders close button when onOpenChange is provided', () => {
+    render(<XDSDialogHeader title="Title" onOpenChange={() => {}} />);
     expect(screen.getByRole('button', {name: /close/i})).toBeInTheDocument();
   });
 
-  it('does not render close button when onHide is not provided', () => {
+  it('does not render close button when onOpenChange is not provided', () => {
     render(<XDSDialogHeader title="Title" />);
     expect(
       screen.queryByRole('button', {name: /close/i}),
     ).not.toBeInTheDocument();
   });
 
-  it('calls onHide when close button is clicked', async () => {
+  it('calls onOpenChange(false) when close button is clicked', async () => {
     const user = userEvent.setup();
     const handleHide = vi.fn();
-    render(<XDSDialogHeader title="Title" onHide={handleHide} />);
+    render(<XDSDialogHeader title="Title" onOpenChange={handleHide} />);
 
     await user.click(screen.getByRole('button', {name: /close/i}));
     expect(handleHide).toHaveBeenCalledTimes(1);
@@ -92,7 +92,7 @@ describe('XDSDialogHeader', () => {
     render(
       <XDSDialogHeader
         title="Title"
-        onHide={() => {}}
+        onOpenChange={() => {}}
         endContent={<button>Custom Action</button>}
       />,
     );
@@ -115,7 +115,7 @@ describe('XDSDialogHeader', () => {
         title="Title"
         startContent={<button>Back</button>}
         endContent={<button>Save</button>}
-        onHide={() => {}}
+        onOpenChange={() => {}}
       />,
     );
     expect(screen.getByRole('button', {name: 'Back'})).toBeInTheDocument();

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -59,10 +59,11 @@ export interface XDSDialogHeaderProps {
   subtitle?: string;
 
   /**
-   * Callback fired when the close button is clicked.
+   * Callback fired when the dialog visibility changes.
+   * Called with `false` when the close button is clicked.
    * If not provided, no close button will be rendered.
    */
-  onHide?: () => unknown;
+  onOpenChange?: (isOpen: boolean) => unknown;
 
   /**
    * Content to render before the title (e.g., a back button).
@@ -93,9 +94,9 @@ export interface XDSDialogHeaderProps {
  *
  * @example
  * ```
- * <XDSDialog isShown={isShown} onHide={() => setIsShown(false)}>
+ * <XDSDialog isShown={isShown} onOpenChange={(open) => setIsShown(open)}>
  *   <XDSLayout
- *     header={<XDSDialogHeader title="Modal Title" onHide={() => setIsShown(false)} />}
+ *     header={<XDSDialogHeader title="Modal Title" onOpenChange={(open) => setIsShown(open)} />}
  *     content={<XDSLayoutContent>Content</XDSLayoutContent>}
  *     footer={<XDSLayoutFooter hasDivider>Actions</XDSLayoutFooter>}
  *   />
@@ -104,7 +105,14 @@ export interface XDSDialogHeaderProps {
  */
 export const XDSDialogHeader = forwardRef<HTMLElement, XDSDialogHeaderProps>(
   function XDSDialogHeader(
-    {title, subtitle, onHide, startContent, endContent, hasDivider = true},
+    {
+      title,
+      subtitle,
+      onOpenChange,
+      startContent,
+      endContent,
+      hasDivider = true,
+    },
     ref,
   ) {
     const titleRef = useRef<HTMLHeadingElement>(null);
@@ -133,17 +141,17 @@ export const XDSDialogHeader = forwardRef<HTMLElement, XDSDialogHeaderProps>(
               </XDSText>
             )}
           </div>
-          {(endContent || onHide) && (
+          {(endContent || onOpenChange) && (
             <div {...stylex.props(styles.actions)}>
               {endContent}
-              {onHide && (
+              {onOpenChange && (
                 <div {...stylex.props(styles.closeButton)}>
                   <XDSButton
                     variant="ghost"
                     label="Close"
                     tooltip="Close"
                     icon={<XDSIcon icon="close" color="inherit" />}
-                    onClick={onHide}
+                    onClick={() => onOpenChange?.(false)}
                   />
                 </div>
               )}

--- a/packages/core/src/DropdownMenu/README.md
+++ b/packages/core/src/DropdownMenu/README.md
@@ -8,7 +8,7 @@ A dropdown menu component for displaying actionable items in a popup menu.
 
 - **Button customization**: Customize the trigger button via the `button` prop (supports all XDSButton props)
 - **Data-driven items**: Pass items via the `items` prop with support for sections and dividers
-- **Controlled/Uncontrolled**: Supports both controlled (`isMenuOpen`/`onMenuToggle`) and uncontrolled modes
+- **Controlled/Uncontrolled**: Supports both controlled (`isMenuOpen`/`onOpenChange`) and uncontrolled modes
 - **Custom menu width**: Override default width (matches button) via `menuWidth` prop
 - **Sections**: Group related items with optional headers using `XDSDropdownMenuSection`
 - **Keyboard navigation**: Full keyboard support (Arrow keys, Home, End, Enter, Space, Escape)
@@ -77,7 +77,7 @@ const [isOpen, setIsOpen] = useState(false);
   button={{ label: 'Options' }}
   items={[...]}
   isMenuOpen={isOpen}
-  onMenuToggle={setIsOpen}
+  onOpenChange={setIsOpen}
 />
 
 // Custom item rendering with XDSDropdownMenuItem
@@ -101,10 +101,10 @@ const [isOpen, setIsOpen] = useState(false);
 
 ```tsx
 <XDSDropdownMenu
-  button={{ label: 'Actions' }}
+  button={{label: 'Actions'}}
   items={[
-    { label: 'Edit', icon: PencilIcon, onClick: () => handleEdit() },
-    { label: 'Delete', icon: TrashIcon, onClick: () => handleDelete() },
+    {label: 'Edit', icon: PencilIcon, onClick: () => handleEdit()},
+    {label: 'Delete', icon: TrashIcon, onClick: () => handleDelete()},
   ]}
 />
 ```
@@ -114,7 +114,7 @@ const [isOpen, setIsOpen] = useState(false);
 | `button`       | `XDSDropdownMenuButtonProps`                   | `{ label: 'Menu' }` | Props for the trigger button (XDSButton props except onClick) |
 | `items`        | `XDSDropdownMenuOption[]`                      | —                   | Menu items (items, dividers, or sections)                     |
 | `isMenuOpen`   | `boolean`                                      | —                   | Controlled open state                                         |
-| `onMenuToggle` | `(isOpen: boolean) => void`                    | —                   | Callback when open state changes                              |
+| `onOpenChange` | `(isOpen: boolean) => void`                    | —                   | Callback when menu visibility changes                         |
 | `menuWidth`    | `number \| string`                             | —                   | Custom menu width (default: matches button)                   |
 | `onClick`      | `() => void`                                   | —                   | Callback when button is clicked                               |
 | `children`     | `(item: XDSDropdownMenuItemData) => ReactNode` | —                   | Custom render function for items                              |

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
@@ -116,7 +116,7 @@ describe('XDSDropdownMenu controlled mode', () => {
         button={{label: 'Actions'}}
         items={[{label: 'Item 1'}]}
         isMenuOpen={false}
-        onMenuToggle={handleToggle}
+        onOpenChange={handleToggle}
       />,
     );
 
@@ -128,14 +128,14 @@ describe('XDSDropdownMenu controlled mode', () => {
         button={{label: 'Actions'}}
         items={[{label: 'Item 1'}]}
         isMenuOpen={true}
-        onMenuToggle={handleToggle}
+        onOpenChange={handleToggle}
       />,
     );
 
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
   });
 
-  it('calls onMenuToggle when button is clicked', async () => {
+  it('calls onOpenChange when button is clicked', async () => {
     const user = userEvent.setup();
     const handleToggle = vi.fn();
     render(
@@ -143,7 +143,7 @@ describe('XDSDropdownMenu controlled mode', () => {
         button={{label: 'Actions'}}
         items={[{label: 'Item 1'}]}
         isMenuOpen={false}
-        onMenuToggle={handleToggle}
+        onOpenChange={handleToggle}
       />,
     );
 

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -257,9 +257,9 @@ export interface XDSDropdownMenuProps {
   isMenuOpen?: boolean;
 
   /**
-   * Callback when menu open state changes (controlled mode).
+   * Callback fired when the menu visibility changes (controlled mode).
    */
-  onMenuToggle?: (isOpen: boolean) => void;
+  onOpenChange?: (isOpen: boolean) => void;
 
   /**
    * Width of the dropdown menu.
@@ -318,7 +318,7 @@ export function XDSDropdownMenu({
   button = {label: 'Menu'},
   items,
   isMenuOpen: controlledIsOpen,
-  onMenuToggle,
+  onOpenChange,
   menuWidth,
   onClick,
   children,
@@ -351,7 +351,7 @@ export function XDSDropdownMenu({
     lightDismiss: true,
     onHide: () => {
       if (isControlled) {
-        onMenuToggle?.(false);
+        onOpenChange?.(false);
       } else {
         setInternalIsOpen(false);
       }
@@ -360,7 +360,7 @@ export function XDSDropdownMenu({
     },
     onShow: () => {
       if (isControlled) {
-        onMenuToggle?.(true);
+        onOpenChange?.(true);
       } else {
         setInternalIsOpen(true);
       }
@@ -381,7 +381,7 @@ export function XDSDropdownMenu({
   const handleButtonClick = useCallback(() => {
     onClick?.();
     if (isControlled) {
-      onMenuToggle?.(!controlledIsOpen);
+      onOpenChange?.(!controlledIsOpen);
     } else {
       if (layer.isOpen) {
         layer.hide();
@@ -389,7 +389,7 @@ export function XDSDropdownMenu({
         layer.show();
       }
     }
-  }, [onClick, isControlled, onMenuToggle, controlledIsOpen, layer]);
+  }, [onClick, isControlled, onOpenChange, controlledIsOpen, layer]);
 
   const closeMenu = useCallback(() => {
     layer.hide();

--- a/packages/core/src/Layer/README.md
+++ b/packages/core/src/Layer/README.md
@@ -97,18 +97,19 @@ Component wrapper for tooltip display on hover/focus.
 </XDSTooltip>
 ```
 
-| Prop                 | Type                            | Default   | Description                                        |
-| -------------------- | ------------------------------- | --------- | -------------------------------------------------- |
-| `children`           | `ReactNode`                     | —         | Trigger element(s)                                 |
-| `anchorRef`          | `RefObject<HTMLElement>`        | —         | External anchor ref (sibling mode)                 |
-| `content`            | `ReactNode`                     | —         | Tooltip content (typically short text)             |
-| `placement`          | `LayerPlacement`                | `'above'` | Position relative to anchor                        |
-| `alignment`          | `LayerAlignment`                | `'center'`| Alignment on placement axis                        |
-| `delay`              | `number`                        | `200`     | Show delay in ms                                   |
-| `hideDelay`          | `number`                        | `0`       | Hide delay in ms                                   |
-| `focusTrigger`       | `'auto' \| 'always' \| 'never'` | `'auto'`  | When to trigger on focus                           |
-| `isEnabled`          | `boolean`                       | `true`    | Enable/disable triggers                            |
-| `hasHoverIndication` | `'auto' \| boolean`             | `'auto'`  | Show dashed underline on trigger                   |
+| Prop                 | Type                            | Default    | Description                            |
+| -------------------- | ------------------------------- | ---------- | -------------------------------------- |
+| `children`           | `ReactNode`                     | —          | Trigger element(s)                     |
+| `anchorRef`          | `RefObject<HTMLElement>`        | —          | External anchor ref (sibling mode)     |
+| `content`            | `ReactNode`                     | —          | Tooltip content (typically short text) |
+| `placement`          | `LayerPlacement`                | `'above'`  | Position relative to anchor            |
+| `alignment`          | `LayerAlignment`                | `'center'` | Alignment on placement axis            |
+| `delay`              | `number`                        | `200`      | Show delay in ms                       |
+| `hideDelay`          | `number`                        | `0`        | Hide delay in ms                       |
+| `focusTrigger`       | `'auto' \| 'always' \| 'never'` | `'auto'`   | When to trigger on focus               |
+| `isEnabled`          | `boolean`                       | `true`     | Enable/disable triggers                |
+| `hasHoverIndication` | `'auto' \| boolean`             | `'auto'`   | Show dashed underline on trigger       |
+| `onOpenChange`       | `(isOpen: boolean) => void`     | —          | Callback when visibility changes       |
 
 ### XDSHoverCard
 
@@ -130,6 +131,7 @@ Component wrapper for simpler hover card usage.
 | `hideDelay`    | `number`                        | `200`     | Hide delay in ms                  |
 | `focusTrigger` | `'auto' \| 'always' \| 'never'` | `'auto'`  | Focus listener behavior           |
 | `isEnabled`    | `boolean`                       | `true`    | Enable/disable triggers           |
+| `onOpenChange` | `(isOpen: boolean) => void`     | —         | Callback when visibility changes  |
 
 ## Position Values
 

--- a/packages/core/src/Layer/XDSHoverCard.test.tsx
+++ b/packages/core/src/Layer/XDSHoverCard.test.tsx
@@ -81,12 +81,12 @@ describe('XDSHoverCard', () => {
     expect(describedBy).toContain('existing-id');
   });
 
-  it('calls onShow callback when shown', async () => {
-    const onShow = vi.fn();
+  it('calls onOpenChange(true) when shown', async () => {
+    const onOpenChange = vi.fn();
     render(
       <XDSHoverCard
         content={<span>Card content</span>}
-        onShow={onShow}
+        onOpenChange={onOpenChange}
         delay={0}>
         <button>Trigger</button>
       </XDSHoverCard>,
@@ -96,16 +96,16 @@ describe('XDSHoverCard', () => {
     fireEvent.mouseEnter(trigger);
 
     await waitFor(() => {
-      expect(onShow).toHaveBeenCalled();
+      expect(onOpenChange).toHaveBeenCalledWith(true);
     });
   });
 
   it('respects isEnabled prop', async () => {
-    const onShow = vi.fn();
+    const onOpenChange = vi.fn();
     render(
       <XDSHoverCard
         content={<span>Card content</span>}
-        onShow={onShow}
+        onOpenChange={onOpenChange}
         isEnabled={false}
         delay={0}>
         <button>Trigger</button>
@@ -115,9 +115,9 @@ describe('XDSHoverCard', () => {
     const trigger = screen.getByRole('button', {name: 'Trigger'});
     fireEvent.mouseEnter(trigger);
 
-    // Wait a bit and verify onShow was not called
+    // Wait a bit and verify onOpenChange was not called
     await new Promise(resolve => setTimeout(resolve, 50));
-    expect(onShow).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it('supports text-only children with inline wrapper', () => {
@@ -136,14 +136,14 @@ describe('XDSHoverCard', () => {
 
   describe('Escape key behavior', () => {
     it('hides hover card when Escape is pressed on trigger', async () => {
-      const onHide = vi.fn();
+      const onOpenChange = vi.fn();
       // Reset the mock before this test
       vi.mocked(HTMLElement.prototype.hidePopover).mockClear();
 
       render(
         <XDSHoverCard
           content={<span>Card content</span>}
-          onHide={onHide}
+          onOpenChange={onOpenChange}
           delay={0}
           hideDelay={0}>
           <button>Trigger</button>
@@ -228,11 +228,11 @@ describe('XDSHoverCard', () => {
     });
 
     it('does not re-show hover card after Escape dismiss and refocus', async () => {
-      const onShow = vi.fn();
+      const onOpenChange = vi.fn();
       render(
         <XDSHoverCard
           content={<button>Interactive button</button>}
-          onShow={onShow}
+          onOpenChange={onOpenChange}
           delay={0}
           hideDelay={0}>
           <button>Trigger</button>
@@ -244,7 +244,7 @@ describe('XDSHoverCard', () => {
       // Show the hover card via focus
       fireEvent.focus(trigger);
       await waitFor(() => {
-        expect(onShow).toHaveBeenCalledTimes(1);
+        expect(onOpenChange).toHaveBeenCalledTimes(1);
       });
 
       // Focus the content button
@@ -252,14 +252,15 @@ describe('XDSHoverCard', () => {
       (contentButton as HTMLElement).focus();
 
       // Clear the mock to track new calls
-      onShow.mockClear();
+      onOpenChange.mockClear();
 
       // Press Escape - this refocuses trigger but shouldn't re-show
       fireEvent.keyDown(contentButton, {key: 'Escape'});
 
-      // Wait a bit and verify onShow was not called again
+      // Wait a bit and verify onOpenChange was not called with true (re-show)
+      // It may be called with false (dismiss), which is expected
       await new Promise(resolve => setTimeout(resolve, 50));
-      expect(onShow).not.toHaveBeenCalled();
+      expect(onOpenChange).not.toHaveBeenCalledWith(true);
     });
   });
 });

--- a/packages/core/src/Layer/XDSHoverCard.tsx
+++ b/packages/core/src/Layer/XDSHoverCard.tsx
@@ -95,14 +95,10 @@ export interface XDSHoverCardProps {
   isEnabled?: boolean;
 
   /**
-   * Callback fired when hover card is shown
+   * Callback fired when hover card visibility changes.
+   * Called with `true` when shown and `false` when hidden.
    */
-  onShow?: () => void;
-
-  /**
-   * Callback fired when hover card is hidden
-   */
-  onHide?: () => void;
+  onOpenChange?: (isOpen: boolean) => void;
 
   /**
    * Whether to show hover indication (dashed underline) on the trigger.
@@ -161,8 +157,7 @@ export function XDSHoverCard({
   hideDelay = 200,
   focusTrigger = 'auto',
   isEnabled = true,
-  onShow,
-  onHide,
+  onOpenChange,
   hasHoverIndication = 'auto',
 }: XDSHoverCardProps): ReactElement {
   const wrapperRef = useRef<HTMLElement>(null);
@@ -185,8 +180,8 @@ export function XDSHoverCard({
     hideDelay,
     focusTrigger,
     isEnabled,
-    onShow,
-    onHide,
+    onShow: onOpenChange ? () => onOpenChange(true) : undefined,
+    onHide: onOpenChange ? () => onOpenChange(false) : undefined,
   });
 
   // For element children with display:contents, attach ref to first child

--- a/packages/core/src/Layer/XDSPopover.test.tsx
+++ b/packages/core/src/Layer/XDSPopover.test.tsx
@@ -100,33 +100,33 @@ describe('XDSPopover', () => {
     expect(dialog).toHaveAttribute('aria-label', 'Greeting');
   });
 
-  it('calls onToggle when opened', () => {
-    const onToggle = vi.fn();
+  it('calls onOpenChange when opened', () => {
+    const onOpenChange = vi.fn();
     render(
       <XDSPopover
         content={<span>Content</span>}
         label="Test"
-        onToggle={onToggle}>
+        onOpenChange={onOpenChange}>
         <button>Open</button>
       </XDSPopover>,
     );
     fireEvent.click(screen.getByRole('button', {name: 'Open'}));
-    expect(onToggle).toHaveBeenCalledWith(true);
+    expect(onOpenChange).toHaveBeenCalledWith(true);
   });
 
   it('does not open when isEnabled is false', () => {
-    const onToggle = vi.fn();
+    const onOpenChange = vi.fn();
     render(
       <XDSPopover
         content={<span>Content</span>}
         label="Test"
         isEnabled={false}
-        onToggle={onToggle}>
+        onOpenChange={onOpenChange}>
         <button>Open</button>
       </XDSPopover>,
     );
     fireEvent.click(screen.getByRole('button', {name: 'Open'}));
-    expect(onToggle).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalled();
   });
 
   it('renders with data-testid', () => {

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -115,7 +115,7 @@ export interface XDSPopoverProps {
   /**
    * Callback fired when the popover visibility changes.
    */
-  onToggle?: (isShown: boolean) => void;
+  onOpenChange?: (isOpen: boolean) => void;
 
   /**
    * Whether the popover is enabled.
@@ -236,7 +236,7 @@ const styles = stylex.create({
  * // Controlled popover
  * <XDSPopover
  *   isShown={isOpen}
- *   onToggle={setIsOpen}
+ *   onOpenChange={setIsOpen}
  *   label="Filter"
  *   content={<FilterForm />}
  * >
@@ -259,7 +259,7 @@ export function XDSPopover({
   placement = 'below',
   alignment = 'start',
   isShown,
-  onToggle,
+  onOpenChange,
   isEnabled = true,
   width,
   label,
@@ -275,10 +275,10 @@ export function XDSPopover({
   const popover = useXDSPopover({
     dialogLabel: label,
     hasLightDismiss: true,
-    onShow: () => onToggle?.(true),
+    onShow: () => onOpenChange?.(true),
     onHide: () => {
       lastHideTimeRef.current = Date.now();
-      onToggle?.(false);
+      onOpenChange?.(false);
     },
   });
 

--- a/packages/core/src/Layer/XDSTooltip.tsx
+++ b/packages/core/src/Layer/XDSTooltip.tsx
@@ -106,14 +106,10 @@ export interface XDSTooltipProps {
   isEnabled?: boolean;
 
   /**
-   * Callback fired when tooltip is shown
+   * Callback fired when tooltip visibility changes.
+   * Called with `true` when shown and `false` when hidden.
    */
-  onShow?: () => void;
-
-  /**
-   * Callback fired when tooltip is hidden
-   */
-  onHide?: () => void;
+  onOpenChange?: (isOpen: boolean) => void;
 
   /**
    * Whether to show hover indication (dashed underline) on the trigger.
@@ -171,8 +167,7 @@ export function XDSTooltip({
   hideDelay = 0,
   focusTrigger = 'auto',
   isEnabled = true,
-  onShow,
-  onHide,
+  onOpenChange,
   hasHoverIndication = 'auto',
 }: XDSTooltipProps): ReactElement {
   const wrapperRef = useRef<HTMLElement>(null);
@@ -195,8 +190,8 @@ export function XDSTooltip({
     hideDelay,
     focusTrigger,
     isEnabled,
-    onShow,
-    onHide,
+    onShow: onOpenChange ? () => onOpenChange(true) : undefined,
+    onHide: onOpenChange ? () => onOpenChange(false) : undefined,
   });
 
   // Sibling mode: attach to external anchorRef

--- a/packages/core/src/MobileNav/README.md
+++ b/packages/core/src/MobileNav/README.md
@@ -36,7 +36,7 @@ const [isOpen, setIsOpen] = useState(false);
 
 <XDSMobileNav
   isOpen={isOpen}
-  onClose={() => setIsOpen(false)}
+  onOpenChange={(open) => setIsOpen(open)}
   title="Navigation"
 >
   <XDSSideNavSection title="Main">
@@ -79,7 +79,7 @@ const navSections = (
       />
       <XDSMobileNav
         isOpen={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
+        onOpenChange={open => setDrawerOpen(open)}
         title="My App">
         {navSections}
       </XDSMobileNav>
@@ -118,7 +118,7 @@ const [drawerOpen, setDrawerOpen] = useState(false);
   }
 />
 
-<XDSMobileNav isOpen={drawerOpen} onClose={() => setDrawerOpen(false)}>
+<XDSMobileNav isOpen={drawerOpen} onOpenChange={(open) => setDrawerOpen(open)}>
   <XDSSideNavSection title="Navigation">
     <XDSSideNavItem label="Home" href="/" isSelected />
     <XDSSideNavItem label="Products" href="/products" />
@@ -129,15 +129,15 @@ const [drawerOpen, setDrawerOpen] = useState(false);
 
 ## Props
 
-| Prop          | Type               | Default | Description                                       |
-| ------------- | ------------------ | ------- | ------------------------------------------------- |
-| `isOpen`      | `boolean`          | —       | Whether the drawer is open (required)             |
-| `onClose`     | `() => void`       | —       | Called on backdrop click, escape, or close button |
-| `children`    | `ReactNode`        | —       | Drawer content (XDSSideNavSection, items, etc.)   |
-| `title`       | `string`           | —       | Optional title at the top of the drawer           |
-| `width`       | `number`           | `280`   | Drawer width in pixels (capped at 85vw)           |
-| `side`        | `'start' \| 'end'` | `start` | Which side the drawer slides from                 |
-| `data-testid` | `string`           | —       | Test ID for the root element                      |
+| Prop           | Type                        | Default | Description                                     |
+| -------------- | --------------------------- | ------- | ----------------------------------------------- |
+| `isOpen`       | `boolean`                   | —       | Whether the drawer is open (required)           |
+| `onOpenChange` | `(isOpen: boolean) => void` | —       | Called when drawer visibility changes           |
+| `children`     | `ReactNode`                 | —       | Drawer content (XDSSideNavSection, items, etc.) |
+| `title`        | `string`                    | —       | Optional title at the top of the drawer         |
+| `width`        | `number`                    | `280`   | Drawer width in pixels (capped at 85vw)         |
+| `side`         | `'start' \| 'end'`          | `start` | Which side the drawer slides from               |
+| `data-testid`  | `string`                    | —       | Test ID for the root element                    |
 
 ## Accessibility
 
@@ -166,5 +166,5 @@ const sections = (
 <XDSSideNav>{sections}</XDSSideNav>
 
 // Mobile: drawer
-<XDSMobileNav isOpen={open} onClose={close}>{sections}</XDSMobileNav>
+<XDSMobileNav isOpen={open} onOpenChange={(open) => { if (!open) close(); }}>{sections}</XDSMobileNav>
 ```

--- a/packages/core/src/MobileNav/XDSMobileNav.test.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.test.tsx
@@ -28,7 +28,7 @@ beforeAll(() => {
 describe('XDSMobileNav', () => {
   it('renders when isOpen is true', () => {
     render(
-      <XDSMobileNav isOpen={true} onClose={() => {}}>
+      <XDSMobileNav isOpen={true} onOpenChange={() => {}}>
         <span>Nav content</span>
       </XDSMobileNav>,
     );
@@ -38,7 +38,10 @@ describe('XDSMobileNav', () => {
 
   it('does not show dialog as open when isOpen is false', () => {
     render(
-      <XDSMobileNav isOpen={false} onClose={() => {}} data-testid="mobile-nav">
+      <XDSMobileNav
+        isOpen={false}
+        onOpenChange={() => {}}
+        data-testid="mobile-nav">
         <span>Nav content</span>
       </XDSMobileNav>,
     );
@@ -48,10 +51,10 @@ describe('XDSMobileNav', () => {
     expect(dialog).not.toHaveAttribute('open');
   });
 
-  it('calls onClose on native cancel event (Escape)', () => {
+  it('calls onOpenChange(false) on native cancel event (Escape)', () => {
     const handleClose = vi.fn();
     render(
-      <XDSMobileNav isOpen={true} onClose={handleClose}>
+      <XDSMobileNav isOpen={true} onOpenChange={handleClose}>
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -63,12 +66,12 @@ describe('XDSMobileNav', () => {
     expect(handleClose).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onClose on backdrop click (click on dialog itself)', () => {
+  it('calls onOpenChange(false) on backdrop click (click on dialog itself)', () => {
     const handleClose = vi.fn();
     render(
       <XDSMobileNav
         isOpen={true}
-        onClose={handleClose}
+        onOpenChange={handleClose}
         data-testid="mobile-nav">
         <span>Content</span>
       </XDSMobileNav>,
@@ -83,7 +86,7 @@ describe('XDSMobileNav', () => {
   it('does not close on drawer content click', () => {
     const handleClose = vi.fn();
     render(
-      <XDSMobileNav isOpen={true} onClose={handleClose}>
+      <XDSMobileNav isOpen={true} onOpenChange={handleClose}>
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -94,7 +97,7 @@ describe('XDSMobileNav', () => {
 
   it('renders close button', () => {
     render(
-      <XDSMobileNav isOpen={true} onClose={() => {}}>
+      <XDSMobileNav isOpen={true} onOpenChange={() => {}}>
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -103,10 +106,10 @@ describe('XDSMobileNav', () => {
     expect(closeButton).toBeInTheDocument();
   });
 
-  it('calls onClose when close button is clicked', () => {
+  it('calls onOpenChange(false) when close button is clicked', () => {
     const handleClose = vi.fn();
     render(
-      <XDSMobileNav isOpen={true} onClose={handleClose}>
+      <XDSMobileNav isOpen={true} onOpenChange={handleClose}>
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -118,7 +121,7 @@ describe('XDSMobileNav', () => {
 
   it('renders title when provided', () => {
     render(
-      <XDSMobileNav isOpen={true} onClose={() => {}} title="Navigation">
+      <XDSMobileNav isOpen={true} onOpenChange={() => {}} title="Navigation">
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -128,7 +131,10 @@ describe('XDSMobileNav', () => {
 
   it('forwards data-testid', () => {
     render(
-      <XDSMobileNav isOpen={true} onClose={() => {}} data-testid="custom-nav">
+      <XDSMobileNav
+        isOpen={true}
+        onOpenChange={() => {}}
+        data-testid="custom-nav">
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -138,7 +144,10 @@ describe('XDSMobileNav', () => {
 
   it('uses native dialog element', () => {
     render(
-      <XDSMobileNav isOpen={true} onClose={() => {}} data-testid="mobile-nav">
+      <XDSMobileNav
+        isOpen={true}
+        onOpenChange={() => {}}
+        data-testid="mobile-nav">
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -149,7 +158,7 @@ describe('XDSMobileNav', () => {
 
   it('sets aria-label from title', () => {
     render(
-      <XDSMobileNav isOpen={true} onClose={() => {}} title="My Nav">
+      <XDSMobileNav isOpen={true} onOpenChange={() => {}} title="My Nav">
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -159,7 +168,7 @@ describe('XDSMobileNav', () => {
 
   it('defaults aria-label to Navigation when no title', () => {
     render(
-      <XDSMobileNav isOpen={true} onClose={() => {}}>
+      <XDSMobileNav isOpen={true} onOpenChange={() => {}}>
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -172,7 +181,10 @@ describe('XDSMobileNav', () => {
 
   it('opens dialog via showModal when isOpen becomes true', () => {
     const {rerender} = render(
-      <XDSMobileNav isOpen={false} onClose={() => {}} data-testid="mobile-nav">
+      <XDSMobileNav
+        isOpen={false}
+        onOpenChange={() => {}}
+        data-testid="mobile-nav">
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -181,7 +193,10 @@ describe('XDSMobileNav', () => {
     expect(dialog).not.toHaveAttribute('open');
 
     rerender(
-      <XDSMobileNav isOpen={true} onClose={() => {}} data-testid="mobile-nav">
+      <XDSMobileNav
+        isOpen={true}
+        onOpenChange={() => {}}
+        data-testid="mobile-nav">
         <span>Content</span>
       </XDSMobileNav>,
     );

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -185,9 +185,11 @@ export interface XDSMobileNavProps {
   isOpen: boolean;
 
   /**
-   * Called when the drawer should close (backdrop click, escape, close button).
+   * Callback fired when the drawer visibility changes.
+   * Called with `false` when the drawer should close
+   * (backdrop click, escape, close button).
    */
-  onClose: () => void;
+  onOpenChange: (isOpen: boolean) => void;
 
   /**
    * Drawer content — typically XDSSideNavSection/XDSSideNavItem, or any ReactNode.
@@ -240,7 +242,7 @@ export interface XDSMobileNavProps {
  *
  * <XDSMobileNav
  *   isOpen={isOpen}
- *   onClose={() => setIsOpen(false)}
+ *   onOpenChange={(open) => setIsOpen(open)}
  *   title="Navigation"
  * >
  *   <XDSSideNavSection title="Main">
@@ -254,7 +256,7 @@ export const XDSMobileNav = forwardRef<HTMLDialogElement, XDSMobileNavProps>(
   function XDSMobileNav(
     {
       isOpen,
-      onClose,
+      onOpenChange,
       children,
       title,
       width = 280,
@@ -296,13 +298,13 @@ export const XDSMobileNav = forwardRef<HTMLDialogElement, XDSMobileNavProps>(
       }
     }, [isOpen]);
 
-    // Handle native cancel event (Escape key) — prevent default and route through onClose
+    // Handle native cancel event (Escape key) — prevent default and route through onOpenChange
     const handleCancel = useCallback(
       (event: React.SyntheticEvent<HTMLDialogElement>) => {
         event.preventDefault();
-        onClose();
+        onOpenChange(false);
       },
-      [onClose],
+      [onOpenChange],
     );
 
     // Handle clicks on the dialog backdrop area (outside the drawer)
@@ -311,10 +313,10 @@ export const XDSMobileNav = forwardRef<HTMLDialogElement, XDSMobileNavProps>(
         // Only close if click was directly on the dialog element (the transparent overlay),
         // not on the drawer or its children
         if (event.target === event.currentTarget) {
-          onClose();
+          onOpenChange(false);
         }
       },
-      [onClose],
+      [onOpenChange],
     );
 
     // Get theme context for component-level overrides
@@ -356,7 +358,7 @@ export const XDSMobileNav = forwardRef<HTMLDialogElement, XDSMobileNavProps>(
               label="Close navigation"
               tooltip="Close"
               icon={<XDSIcon icon="close" color="inherit" />}
-              onClick={onClose}
+              onClick={() => onOpenChange(false)}
             />
           </div>
 


### PR DESCRIPTION
## Summary

Unifies all visibility callback props across overlay/dialog components to use a consistent `onOpenChange(isOpen: boolean)` pattern.

Closes #464

## Changes

| Component | Before | After |
|-----------|--------|-------|
| **XDSDialog** | `onHide: () => unknown` | `onOpenChange: (isOpen: boolean) => unknown` |
| **XDSDialogHeader** | `onHide?: () => unknown` | `onOpenChange?: (isOpen: boolean) => unknown` |
| **XDSHoverCard** | `onShow?: () => void` + `onHide?: () => void` | `onOpenChange?: (isOpen: boolean) => void` |
| **XDSTooltip** | `onShow?: () => void` + `onHide?: () => void` | `onOpenChange?: (isOpen: boolean) => void` |
| **XDSPopover** | `onToggle?: (isShown: boolean) => void` | `onOpenChange?: (isOpen: boolean) => void` |
| **XDSDropdownMenu** | `onMenuToggle?: (isOpen: boolean) => void` | `onOpenChange?: (isOpen: boolean) => void` |
| **XDSMobileNav** | `onClose: () => void` | `onOpenChange: (isOpen: boolean) => void` |

## What changed

- **Components**: Updated prop types, destructuring, and internal usage
- **Tests**: Updated all test files to use new prop names and verify correct behavior
- **Stories**: Updated all Storybook stories
- **READMEs**: Updated props tables and code examples in all component READMEs
- **Cross-references**: Updated AppShell (uses MobileNav internally)

## What was NOT changed

- **Internal hooks** (`useXDSHoverCard`, `useXDSTooltip`, `useXDSPopover`, `useXDSLayer`): These still use `onShow`/`onHide` internally — they are implementation details, not public API
- **CommandPalette**: Handled in a separate session
- **MoreMenu**: Uses `useXDSLayer` hook directly (internal API), no public callback props to rename
- **DateInput**: Uses `useXDSPopover` hook internally (not a public prop)

## Testing

- All 1242 tests pass
- Lint passes (0 errors)
