### PR TITLE
fix(CheckboxInput): use onMedia spinner shade when checked

### DIFF
--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.test.tsx
@@ -189,4 +189,16 @@ describe('XDSCheckboxInput', () => {
     const label = screen.getByText('Accept terms');
     expect(label).toBeVisible();
   });
+
+  it('sets aria-busy when loading', () => {
+    render(
+      <XDSCheckboxInput
+        label="Accept terms"
+        value={false}
+        onChange={() => {}}
+        isLoading
+      />,
+    );
+    expect(screen.getByRole('checkbox')).toHaveAttribute('aria-busy', 'true');
+  });
 });

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -405,7 +405,10 @@ export const XDSCheckboxInput = forwardRef<
                   styles.checkboxDisabledUnchecked,
               )}>
               {isBusy ? (
-                <XDSSpinner size="sm" />
+                <XDSSpinner
+                  size="sm"
+                  shade={isCheckedOrIndeterminate ? 'onMedia' : 'default'}
+                />
               ) : (
                 <>
                   <svg


### PR DESCRIPTION
## Summary

The loading spinner was invisible when using `onChangeAction` to transition a checkbox to the checked state — blue spinner on blue accent background.

## Fix

Pass `shade="onMedia"` to `XDSSpinner` when the checkbox is checked or indeterminate, so the spinner renders white against the accent background. When unchecked, the default (blue) shade is used.

## Test

Added test for `aria-busy` attribute during loading state.

Fixes #475