### PR TITLE
feat(core): add xds.css export for pre-compiled CSS

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,6 +20,7 @@
       "require": "./dist/index.js"
     },
     "./reset.css": "./src/reset.css",
+    "./xds.css": "./dist/xds.css",
     "./typography.css": "./src/typography.css",
     "./theme/tokens.stylex": {
       "source": "./src/theme/tokens.stylex.ts",


### PR DESCRIPTION
## Summary

Adds `./xds.css` to the `@xds/core` exports map, pointing to `dist/xds.css`.

## Why

Dist consumers need to import the pre-compiled StyleX CSS (component styles + token defaults) without the StyleX build pipeline. The file already exists in the package (`dist/xds.css`, ~60KB), but the exports map blocked the bare specifier:

```
@import '@xds/core/xds.css';  // ❌ blocked by exports map
@import '../../node_modules/@xds/core/dist/xds.css';  // ✅ worked but ugly
```

After this change:
```css
@import '@xds/core/xds.css';  // ✅ works
```

## Context

Validated in the [xds_sandbox](https://github.com/cixzhang/xds_sandbox/compare/main...try-dist-build) — a Next.js app consuming `@xds/core` entirely from dist. No `transpilePackages`, no StyleX aliases, no PostCSS scanning of `@xds/core` source. Just import the CSS and use the pre-compiled components.

Refs #448

---
*Crafted by Navi* 🧚