### PR TITLE
docs(cli): document xstyle unified override formats

### DIFF
--- a/packages/cli/docs/principles.md
+++ b/packages/cli/docs/principles.md
@@ -10,9 +10,50 @@ React design system for internal tools. Components use `XDS` prefix.
 4. CSS variables for colors, not hex
 5. Form inputs are controlled (value + onChange)
 
+## Style Overrides: xstyle prop
+
+Most XDS components accept an `xstyle` prop for customizing styles.
+It supports three formats — pick the one that fits:
+
+**Inline styles** — for simple one-off overrides:
+
+```tsx
+<XDSTextInput label="Name" xstyle={{ maxWidth: 300 }} />
+<XDSCard xstyle={{ height: 200, padding: 16 }} />
+```
+
+**StyleX styles** — for complex, reusable, or pseudo-class overrides:
+
+```tsx
+import * as stylex from '@stylexjs/stylex';
+const overrides = stylex.create({
+  hoverCard: {
+    boxShadow: {
+      default: 'none',
+      ':hover': {'@media (hover: hover)': '0 4px 12px rgba(0,0,0,0.15)'},
+    },
+  },
+});
+<XDSCard xstyle={overrides.hoverCard} />;
+```
+
+**CSS class name** — for Tailwind, CSS Modules, or external CSS:
+
+```tsx
+<XDSCard xstyle="my-custom-card" />
+<XDSCard xstyle={styles.customCard} />  // CSS Module
+```
+
+Rules of thumb:
+
+- 1-2 simple properties → inline
+- 3+ properties, reusable, or named → `stylex.create`
+- Pseudo-classes (`:hover`, `:focus-visible`) → `stylex.create` (required)
+- All `:hover` MUST use `@media (hover: hover)` guards
+
 ## Anti-Patterns
 
-❌ Inline styles → Use StyleX
+❌ Inline styles on raw elements → Use `xstyle` on XDS components
 ❌ Hardcoded colors (#fff) → Use var(--color-_)
 ❌ Hardcoded spacing (16px) → Use spacing tokens or var(--spacing-_)
 ❌ Inventing props → Read component docs first

--- a/packages/cli/src/commands/component.mjs
+++ b/packages/cli/src/commands/component.mjs
@@ -617,6 +617,14 @@ export function extractBriefAll(coreDir) {
   const components = discoverComponents(coreDir);
   const output = [];
 
+  // Add xstyle override hint at the top
+  output.push(
+    `> **Style overrides:** Most components accept an \`xstyle\` prop.`,
+    `> Use inline objects for simple overrides: \`xstyle={{ maxWidth: 300 }}\``,
+    `> Use \`stylex.create()\` for pseudo-classes/media queries or 3+ properties.`,
+    `> See \`npx xds docs principles\` for details.\n`,
+  );
+
   for (const [category, comps] of Object.entries(components)) {
     output.push(`## ${category}\n`);
     for (const comp of comps) {


### PR DESCRIPTION
## Summary

Documents that `xstyle` accepts three formats for style overrides, not just StyleX objects.

## Changes

### `packages/cli/docs/principles.md`
Added "Style Overrides: xstyle prop" section with:
- **Inline styles** — `xstyle={{ maxWidth: 300 }}` for simple one-offs
- **StyleX styles** — `stylex.create()` for pseudo-classes, media queries, or 3+ properties
- **CSS class names** — `xstyle="my-class"` for Tailwind/CSS Modules/external CSS
- Rules of thumb for when to use each format
- Updated anti-patterns to reference `xstyle` instead of generic "Use StyleX"

### `packages/cli/src/commands/component.mjs`
Added xstyle hint banner to `--brief-all` output:
```
> **Style overrides:** Most components accept an `xstyle` prop.
> Use inline objects for simple overrides: `xstyle={{ maxWidth: 300 }}`
> Use `stylex.create()` for pseudo-classes/media queries or 3+ properties.
> See `npx xds docs principles` for details.
```

## Why

Vibe tested three style override API options (`xstyle` StyleX-only, `className`, `overrideStyle` unified). Key findings:

1. All approaches scored identically (4.3/5 confidence, zero escapes)
2. When `xstyle` docs included all three formats, the LLM naturally picked inline for simple cases and StyleX for complex ones — same behavior as the "unified" prop
3. The prop name doesn't matter; the documented formats drive LLM behavior
4. No reason to rename, add a new prop, or change the API — just document what StyleX already supports

Full analysis: #373

Refs #373

---
*Crafted by Navi* 🧚