### PR TITLE
fix(rsc): add 'use client' directive to all components using React hooks

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -13,6 +13,8 @@
  * - /apps/storybook/stories/AppShell.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   useCallback,

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/AspectRatio.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Avatar.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Avatar/XDSAvatarSizeContext.ts
+++ b/packages/core/src/Avatar/XDSAvatarSizeContext.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/Avatar/README.md
  */
 
+'use client';
+
 import {createContext} from 'react';
 
 /**

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Avatar.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {useContext, type HTMLAttributes, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Badge.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -17,6 +17,8 @@
  * - /apps/storybook/stories/Banner.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {forwardRef, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Breadcrumbs.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   Children,

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -13,6 +13,8 @@
  * Last synced props: label, variant, size, isDisabled, isLoading, onClickAction, icon, children, tooltip, endSlot
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Calendar.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Calendar/hooks/useCalendarConstraints.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarConstraints.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/Calendar/hooks/index.ts
  */
 
+'use client';
+
 import {useCallback, useMemo} from 'react';
 import type {ISODateString} from '../XDSCalendar';
 

--- a/packages/core/src/Calendar/hooks/useCalendarDays.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarDays.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/Calendar/hooks/index.ts
  */
 
+'use client';
+
 import {useMemo} from 'react';
 import type {DayOfWeek, ISODateString} from '../XDSCalendar';
 

--- a/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/Calendar/hooks/index.ts
  */
 
+'use client';
+
 import {useState, useMemo, useCallback} from 'react';
 import type {ISODateString} from '../XDSCalendar';
 

--- a/packages/core/src/Calendar/hooks/useCalendarRovingTabindex.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarRovingTabindex.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/Calendar/hooks/index.ts
  */
 
+'use client';
+
 import {useMemo} from 'react';
 import type {ISODateString} from '../XDSCalendar';
 import type {CalendarDay} from './useCalendarDays';

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Card.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {forwardRef, useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars, elevationVars} from '../theme/tokens.stylex';

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Center.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/CheckboxInput.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Collapsible/XDSCollapsibleGroupContext.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsibleGroupContext.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Collapsible/README.md
  */
 
+'use client';
+
 import {createContext} from 'react';
 
 /**

--- a/packages/core/src/Collapsible/useXDSCollapsible.ts
+++ b/packages/core/src/Collapsible/useXDSCollapsible.ts
@@ -17,6 +17,8 @@
  * NOTE: Public hooks use the `useXDS` prefix per XDS naming conventions.
  */
 
+'use client';
+
 import {useState, useContext} from 'react';
 import {CollapsibleGroupContext} from './XDSCollapsibleGroupContext';
 

--- a/packages/core/src/CommandPalette/CommandPaletteContext.ts
+++ b/packages/core/src/CommandPalette/CommandPaletteContext.ts
@@ -5,6 +5,8 @@
  * @position Internal context; consumed by composable sub-components
  */
 
+'use client';
+
 import {createContext, useContext} from 'react';
 import type {CommandPaletteFilterFn} from './types';
 

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/CommandPalette.stories.tsx
  */
 
+'use client';
+
 import {
   useCallback,
   useId,

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/CommandPalette/index.ts
  */
 
+'use client';
+
 import {useCallback, useRef, useEffect, type KeyboardEvent} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/CommandPalette/index.ts
  */
 
+'use client';
+
 import {useCallback, useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/CommandPalette/XDSCommandPaletteProvider.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteProvider.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/CommandPalette/index.ts
  */
 
+'use client';
+
 import {
   createContext,
   useCallback,

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/DateInput.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Dialog.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Dialog.stories.tsx
  */
 
+'use client';
+
 import {forwardRef, useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Divider.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/DropdownMenu.stories.tsx
  */
 
+'use client';
+
 import React, {
   useContext,
   useCallback,

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Field.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/FormLayout.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {forwardRef, useMemo, type HTMLAttributes, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/FormLayout/XDSFormLayoutContext.ts
+++ b/packages/core/src/FormLayout/XDSFormLayoutContext.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/FormLayout/README.md
  */
 
+'use client';
+
 import {createContext} from 'react';
 
 /**

--- a/packages/core/src/FormLayout/__snapshots__/XDSFormLayout.test.tsx.snap
+++ b/packages/core/src/FormLayout/__snapshots__/XDSFormLayout.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`XDSFormLayout > matches snapshot for horizontal direction 1`] = `
 <div
   class="XDSFormLayout__styles.base x78zum5 x18g69wz XDSFormLayout__styles.horizontal x1q0g3np x1a02dak"
-  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:34; @xds/core:src/FormLayout/XDSFormLayout.tsx:39"
+  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:36; @xds/core:src/FormLayout/XDSFormLayout.tsx:41"
   data-testid="layout"
 >
   <input
@@ -18,7 +18,7 @@ exports[`XDSFormLayout > matches snapshot for horizontal direction 1`] = `
 exports[`XDSFormLayout > matches snapshot for horizontal-labels direction 1`] = `
 <div
   class="XDSFormLayout__styles.base xdt5ytf XDSFormLayout__styles.horizontalLabels xrvj5dj x1pmbctz xlaq8a2 x7a106z xedohl4 x1rpgqan x1a1jff"
-  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:34; @xds/core:src/FormLayout/XDSFormLayout.tsx:43"
+  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:36; @xds/core:src/FormLayout/XDSFormLayout.tsx:45"
   data-testid="layout"
 >
   <label>
@@ -33,7 +33,7 @@ exports[`XDSFormLayout > matches snapshot for horizontal-labels direction 1`] = 
 exports[`XDSFormLayout > matches snapshot for vertical direction 1`] = `
 <div
   class="XDSFormLayout__styles.base x78zum5 xdt5ytf x18g69wz"
-  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:34"
+  data-style-src="@xds/core:src/FormLayout/XDSFormLayout.tsx:36"
   data-testid="layout"
 >
   <input

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Grid.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Layer/XDSHoverCard.tsx
+++ b/packages/core/src/Layer/XDSHoverCard.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/HoverCard.stories.tsx
  */
 
+'use client';
+
 import React, {
   useContext,
   useLayoutEffect,

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -13,6 +13,8 @@
  * - /apps/storybook/stories/Popover.stories.tsx
  */
 
+'use client';
+
 import React, {
   useCallback,
   useLayoutEffect,

--- a/packages/core/src/Layer/XDSTooltip.tsx
+++ b/packages/core/src/Layer/XDSTooltip.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Tooltip.stories.tsx
  */
 
+'use client';
+
 import React, {
   useContext,
   useLayoutEffect,

--- a/packages/core/src/Layer/useXDSHoverCard.tsx
+++ b/packages/core/src/Layer/useXDSHoverCard.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Layer/index.ts
  */
 
+'use client';
+
 import {
   useCallback,
   useContext,

--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Layer/index.ts
  */
 
+'use client';
+
 import React, {
   useCallback,
   useId,

--- a/packages/core/src/Layer/useXDSPopover.tsx
+++ b/packages/core/src/Layer/useXDSPopover.tsx
@@ -12,6 +12,8 @@
  * - /packages/core/src/Layer/index.ts
  */
 
+'use client';
+
 import React, {
   useCallback,
   useEffect,

--- a/packages/core/src/Layer/useXDSTooltip.tsx
+++ b/packages/core/src/Layer/useXDSTooltip.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Layer/index.ts
  */
 
+'use client';
+
 import {
   useCallback,
   useContext,

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -13,6 +13,8 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
+'use client';
+
 import {type ReactNode, useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSLayoutAreaContext, type LayoutArea} from './XDSLayoutAreaContext';

--- a/packages/core/src/Layout/XDSLayoutAreaContext.ts
+++ b/packages/core/src/Layout/XDSLayoutAreaContext.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/Layout/XDSLayout/README.md
  */
 
+'use client';
+
 import {createContext} from 'react';
 
 /**

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
+'use client';
+
 import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
 import {forwardRef, useContext} from 'react';
 import * as stylex from '@stylexjs/stylex';

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
+'use client';
+
 import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
 import {forwardRef, useContext} from 'react';
 import * as stylex from '@stylexjs/stylex';

--- a/packages/core/src/Layout/XDSLayoutSlotsContext.ts
+++ b/packages/core/src/Layout/XDSLayoutSlotsContext.ts
@@ -9,6 +9,8 @@
  * - /packages/core/src/Layout/XDSLayout/index.ts
  */
 
+'use client';
+
 import {createContext} from 'react';
 
 /**

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Link.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Link/XDSLinkContext.ts
+++ b/packages/core/src/Link/XDSLinkContext.ts
@@ -15,6 +15,8 @@
  * - /packages/core/src/Link/README.md
  */
 
+'use client';
+
 import {createContext} from 'react';
 import type {XDSLinkComponentType} from './types';
 

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/List.stories.tsx
  */
 
+'use client';
+
 import {forwardRef, useId, useMemo, Children, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/List/XDSListContext.tsx
+++ b/packages/core/src/List/XDSListContext.tsx
@@ -5,6 +5,8 @@
  * @position Internal context; consumed by XDSList.tsx and XDSListItem.tsx
  */
 
+'use client';
+
 import {createContext} from 'react';
 
 export type XDSListDensity = 'compact' | 'balanced' | 'spacious';

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/List.stories.tsx
  */
 
+'use client';
+
 import {forwardRef, useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -14,6 +14,8 @@
  * - /apps/storybook/stories/MoreMenu.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   useCallback,

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/NumberInput.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/ProgressBar.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {forwardRef, useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/RadioList.stories.tsx
  */
 
+'use client';
+
 import {createContext, useContext, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/RadioList.stories.tsx
  */
 
+'use client';
+
 import {useContext, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Section.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {forwardRef, useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Selector/index.ts
  */
 
+'use client';
+
 import React, {
   useCallback,
   useId,

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -4,6 +4,8 @@
  * @position Internal hooks; used by XDSSelector.tsx
  */
 
+'use client';
+
 import {useCallback, useLayoutEffect, useRef, useState} from 'react';
 import type {RefObject} from 'react';
 import type {XDSSelectorOptionData} from './types';

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Skeleton.stories.tsx
  */
 
+'use client';
+
 import {forwardRef, useContext, type HTMLAttributes} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Slider.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Spinner.stories.tsx
  */
 
+'use client';
+
 import {forwardRef, useContext, useEffect, useRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Switch.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -10,6 +10,8 @@
  * - /packages/core/src/TabList/XDSTabList.test.tsx
  */
 
+'use client';
+
 import {useContext, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';

--- a/packages/core/src/TabList/XDSTabListContext.ts
+++ b/packages/core/src/TabList/XDSTabListContext.ts
@@ -7,6 +7,8 @@
  * SYNC: When modified, update /packages/core/src/TabList/README.md
  */
 
+'use client';
+
 import {createContext, useContext} from 'react';
 
 /**

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -10,6 +10,8 @@
  * - /packages/core/src/TabList/XDSTabList.test.tsx
  */
 
+'use client';
+
 import React, {useCallback, useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSIcon} from '../Icon';

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Table.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Table/index.ts
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Table/XDSTableContext.ts
+++ b/packages/core/src/Table/XDSTableContext.ts
@@ -11,6 +11,8 @@
  * - /packages/core/src/Table/index.ts (exports if types change)
  */
 
+'use client';
+
 import {createContext} from 'react';
 
 export interface XDSTableContextValue {

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Table/index.ts
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Table/index.ts
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Table/index.ts (exports)
  */
 
+'use client';
+
 import {createContext, useContext, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../../../theme/tokens.stylex';

--- a/packages/core/src/Table/useXDSBaseTablePlugins.ts
+++ b/packages/core/src/Table/useXDSBaseTablePlugins.ts
@@ -9,6 +9,8 @@
  * - /packages/core/src/Table/XDSTable.tsx (primary consumer)
  */
 
+'use client';
+
 import {useRef} from 'react';
 import type {TablePlugin} from './types';
 

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Text.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   lazy,

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/Text.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   lazy,

--- a/packages/core/src/Text/useTruncation.ts
+++ b/packages/core/src/Text/useTruncation.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/Text/README.md
  */
 
+'use client';
+
 import {useCallback, useRef, useState, type RefCallback} from 'react';
 
 export interface UseTruncationOptions {

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/TextArea.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/TextInput.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/TimeInput.stories.tsx (storybook stories)
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -10,6 +10,8 @@
  * - /apps/storybook/stories/Tokenizer.stories.tsx
  */
 
+'use client';
+
 import React, {
   useCallback,
   useId,

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -11,6 +11,8 @@
  * - /apps/storybook/stories/TopNav.stories.tsx
  */
 
+'use client';
+
 import {
   forwardRef,
   useContext,

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -13,6 +13,8 @@
  * - /packages/core/src/Typeahead/index.ts
  */
 
+'use client';
+
 import React, {
   forwardRef,
   useCallback,

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -14,6 +14,8 @@
  * - /apps/storybook/stories/Typeahead.stories.tsx
  */
 
+'use client';
+
 import React, {useCallback, useId, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -11,6 +11,8 @@
  * - /packages/core/src/hooks/index.ts
  */
 
+'use client';
+
 import {useCallback, useEffect, useRef} from 'react';
 
 /**

--- a/packages/core/src/hooks/useGridFocus.ts
+++ b/packages/core/src/hooks/useGridFocus.ts
@@ -9,6 +9,8 @@
  * - /packages/core/src/hooks/useGridFocus.test.ts
  */
 
+'use client';
+
 import {useCallback, useRef} from 'react';
 
 /**

--- a/packages/core/src/hooks/useListFocus.ts
+++ b/packages/core/src/hooks/useListFocus.ts
@@ -8,6 +8,8 @@
  * - /packages/core/src/hooks/index.ts
  */
 
+'use client';
+
 import {useCallback, useRef} from 'react';
 
 /**

--- a/packages/core/src/hooks/useMediaQuery.ts
+++ b/packages/core/src/hooks/useMediaQuery.ts
@@ -10,6 +10,8 @@
  * - /packages/core/src/hooks/index.ts
  */
 
+'use client';
+
 import {useState, useEffect} from 'react';
 
 /**

--- a/packages/core/src/theme/ThemeContext.ts
+++ b/packages/core/src/theme/ThemeContext.ts
@@ -5,6 +5,8 @@
  * without pulling in the full theme provider implementation.
  */
 
+'use client';
+
 import {createContext} from 'react';
 import type {Theme, ThemeMode} from './types';
 

--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -16,6 +16,8 @@
  * ```
  */
 
+'use client';
+
 import React, {useContext, useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {Theme as ThemeType, ThemeMode} from './types';


### PR DESCRIPTION
## What

Adds `'use client'` to all 88 component/hook/context files that use React hooks but were missing the directive. Previously only 16 files had it.

## Why

XDS components use `useContext` (for theming), `useState`, `useRef`, etc. — all of which require client components. Without the directive, consumers importing XDS in a Server Component file get a `createContext` / `useState` error and have to figure out the fix themselves.

This came up as RSC friction from a dogfooder: a schema file importing XDS components (XDSText, XDSBadge) got pulled into a Server Component, and the error was confusing.

## Approach

Same approach as Chakra UI, MUI, and other design systems: declare the client boundary in the library so consumers don't have to add `'use client'` to their own files.

Files that don't use any hooks (pure re-exports, types, utilities, static components like XDSStatusDot) were left untouched.

## Scope

- 88 files updated (components, hooks, context files)
- 16 files already had the directive (unchanged)
- 110 files have no hooks (unchanged)
- Snapshot updates for FormLayout (line number shifts in `data-style-src`)
- All 1252 tests passing

## Future

When pre-compiled CSS lands (themes via CSS layers instead of runtime context), we can revisit which components are genuinely server-renderable and remove `'use client'` from pure presentational ones. That removal would be a non-breaking change (expanding where components can be used).

---
*Crafted with care by Navi*