### PR TITLE
feat(cli): add `xds upgrade` command with v0.0.2 codemods

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@vitest/coverage-v8": "^2.1.0",
     "eslint": "^9.15.0",
     "husky": "^9.1.7",
+    "jscodeshift": "^17.3.0",
     "jsdom": "^27.4.0",
     "prettier": "^3.4.0",
     "react": "^19.2.4",

--- a/packages/cli/src/codemods/ensure-jscodeshift.mjs
+++ b/packages/cli/src/codemods/ensure-jscodeshift.mjs
@@ -1,0 +1,35 @@
+/**
+ * @file Lazy jscodeshift installer
+ *
+ * Checks if jscodeshift is available and offers to install it on-demand.
+ * Keeps the CLI lean — jscodeshift is only needed for codemods.
+ */
+
+import {execSync} from 'node:child_process';
+import * as p from '@clack/prompts';
+
+export async function ensureJscodeshift() {
+  try {
+    await import('jscodeshift');
+    return true;
+  } catch {
+    p.log.warn('jscodeshift is required for codemods but not installed.');
+    const shouldInstall = await p.confirm({
+      message: 'Install jscodeshift now?',
+      initialValue: true,
+    });
+    if (p.isCancel(shouldInstall) || !shouldInstall) {
+      p.log.error('Cannot run codemods without jscodeshift.');
+      return false;
+    }
+    try {
+      p.log.step('Installing jscodeshift...');
+      execSync('npm install --no-save jscodeshift', {stdio: 'pipe'});
+      p.log.success('jscodeshift installed.');
+      return true;
+    } catch (err) {
+      p.log.error(`Failed to install jscodeshift: ${err.message}`);
+      return false;
+    }
+  }
+}

--- a/packages/cli/src/codemods/registry.mjs
+++ b/packages/cli/src/codemods/registry.mjs
@@ -1,0 +1,44 @@
+/**
+ * @file Codemod version registry
+ *
+ * Maps XDS versions to their transform manifests. Used by the upgrade
+ * command to determine which codemods to run between two versions.
+ */
+
+const registry = new Map([
+  ['0.0.2', () => import('./transforms/v0.0.2/index.mjs')],
+]);
+
+/**
+ * All registered versions, sorted ascending.
+ */
+export const versions = [...registry.keys()].sort();
+
+/**
+ * The latest version in the registry.
+ */
+export const latestVersion = versions[versions.length - 1];
+
+/**
+ * Get all transform manifests between two versions (exclusive of `from`, inclusive of `to`).
+ * Returns an array of {version, transforms} objects sorted ascending.
+ *
+ * @param {string} from - Current version (exclusive)
+ * @param {string} to - Target version (inclusive)
+ * @returns {Promise<Array<{version: string, transforms: Array<{name: string, module: Function}>}>>}
+ */
+export async function getTransformsBetween(from, to) {
+  const applicable = versions.filter((v) => v > from && v <= to);
+  const results = [];
+
+  for (const version of applicable) {
+    const loader = registry.get(version);
+    const manifest = await loader();
+    results.push({
+      version,
+      transforms: manifest.default,
+    });
+  }
+
+  return results;
+}

--- a/packages/cli/src/codemods/runner.mjs
+++ b/packages/cli/src/codemods/runner.mjs
@@ -1,0 +1,133 @@
+/**
+ * @file Codemod runner
+ *
+ * Orchestrates running jscodeshift transforms against source files.
+ * Handles dry-run previews, file writing, and summary reporting.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as p from '@clack/prompts';
+
+/**
+ * Recursively find all source files in a directory.
+ * @param {string} dir
+ * @returns {string[]}
+ */
+function findSourceFiles(dir) {
+  const results = [];
+  const extensions = new Set(['.tsx', '.ts', '.jsx', '.js']);
+
+  function walk(currentDir) {
+    let entries;
+    try {
+      entries = fs.readdirSync(currentDir, {withFileTypes: true});
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '.git') continue;
+        walk(fullPath);
+      } else if (extensions.has(path.extname(entry.name))) {
+        results.push(fullPath);
+      }
+    }
+  }
+
+  walk(dir);
+  return results.sort();
+}
+
+/**
+ * Run codemods against source files.
+ *
+ * @param {Array<{version: string, transforms: Array}>} versionManifests
+ * @param {object} options
+ * @param {boolean} options.apply - Write changes to disk
+ * @param {string} options.path - Source directory to scan
+ * @param {string|undefined} options.codemod - Run only this specific transform
+ */
+export async function runCodemods(versionManifests, {apply, path: srcPath, codemod}) {
+  const resolvedPath = path.resolve(srcPath);
+
+  if (!fs.existsSync(resolvedPath)) {
+    p.log.error(`Source path not found: ${resolvedPath}`);
+    return;
+  }
+
+  p.log.step(`Scanning ${resolvedPath} for source files...`);
+  const files = findSourceFiles(resolvedPath);
+
+  if (files.length === 0) {
+    p.log.warn('No source files found.');
+    return;
+  }
+
+  p.log.info(`Found ${files.length} source file${files.length === 1 ? '' : 's'}`);
+
+  // Dynamically import jscodeshift
+  const jscodeshift = (await import('jscodeshift')).default;
+
+  let totalFilesChanged = 0;
+  let totalTransformsApplied = 0;
+
+  for (const {version, transforms} of versionManifests) {
+    p.log.step(`Applying v${version} codemods...`);
+
+    for (const transformEntry of transforms) {
+      // Filter by codemod name if specified
+      if (codemod && transformEntry.name !== codemod) continue;
+
+      const {name, transform, meta} = transformEntry;
+      p.log.info(`  ${meta.title}`);
+
+      let filesChanged = 0;
+
+      for (const filePath of files) {
+        const source = fs.readFileSync(filePath, 'utf-8');
+        const api = {jscodeshift, stats: () => {}, report: () => {}};
+        const file = {source, path: filePath};
+
+        const result = transform(file, api);
+
+        if (result != null && result !== source) {
+          filesChanged++;
+          totalFilesChanged++;
+          totalTransformsApplied++;
+
+          const relativePath = path.relative(process.cwd(), filePath);
+
+          if (apply) {
+            fs.writeFileSync(filePath, result, 'utf-8');
+            p.log.success(`    ✓ ${relativePath}`);
+          } else {
+            p.log.warn(`    ~ ${relativePath} (would change)`);
+          }
+        }
+      }
+
+      if (filesChanged > 0) {
+        const verb = apply ? 'Updated' : 'Would update';
+        p.log.info(`  ${verb} ${filesChanged} file${filesChanged === 1 ? '' : 's'}`);
+      }
+    }
+  }
+
+  // Summary
+  console.log('');
+  if (totalFilesChanged === 0) {
+    p.log.success('No changes needed — your code is already up to date!');
+  } else if (apply) {
+    p.log.success(
+      `Done! Applied ${totalTransformsApplied} change${totalTransformsApplied === 1 ? '' : 's'} across ${totalFilesChanged} file${totalFilesChanged === 1 ? '' : 's'}.`,
+    );
+    p.log.info('Run your type checker and tests to verify the changes.');
+  } else {
+    p.log.warn(
+      `Found ${totalTransformsApplied} change${totalTransformsApplied === 1 ? '' : 's'} across ${totalFilesChanged} file${totalFilesChanged === 1 ? '' : 's'}.`,
+    );
+    p.log.info('Run with --apply to write changes to disk.');
+  }
+}

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/rename-banner-endButton-to-endContent.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/rename-banner-endButton-to-endContent.test.mjs
@@ -1,0 +1,59 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../rename-banner-endButton-to-endContent.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('rename-banner-endButton-to-endContent', () => {
+  it('renames endButton to endContent on XDSBanner', async () => {
+    const input = '<XDSBanner endButton={<button>Close</button>} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent={<button>Close</button>}');
+    expect(output).not.toContain('endButton');
+  });
+
+  it('handles expression values', async () => {
+    const input = '<XDSBanner endButton={closeBtn} variant="info" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent={closeBtn}');
+    expect(output).toContain('variant="info"');
+  });
+
+  it('does not rename endButton on non-XDS components', async () => {
+    const input = '<Banner endButton={<button>X</button>} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('does not rename endButton on other XDS components', async () => {
+    const input = '<XDSDialog endButton={btn} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../rename-banner-endButton-to-endContent.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSBanner endContent={btn} />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('preserves other XDSBanner props', async () => {
+    const input = '<XDSBanner variant="warning" endButton={btn} title="Alert" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent={btn}');
+    expect(output).toContain('variant="warning"');
+    expect(output).toContain('title="Alert"');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/rename-form-tooltip-startIcon.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/rename-form-tooltip-startIcon.test.mjs
@@ -1,0 +1,128 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../rename-form-tooltip-startIcon.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('rename-form-tooltip-startIcon', () => {
+  // tooltip → labelTooltip
+  it('renames tooltip to labelTooltip on XDSField', async () => {
+    const input = '<XDSField tooltip="Help text" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Help text"');
+    expect(output).not.toContain(' tooltip=');
+  });
+
+  it('renames tooltip to labelTooltip on XDSFieldLabel', async () => {
+    const input = '<XDSFieldLabel tooltip="Info" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Info"');
+  });
+
+  it('renames tooltip on XDSNumberInput', async () => {
+    const input = '<XDSNumberInput tooltip="Enter a number" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Enter a number"');
+  });
+
+  it('renames tooltip on XDSCheckboxInput', async () => {
+    const input = '<XDSCheckboxInput tooltip="Check this" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Check this"');
+  });
+
+  it('renames tooltip on XDSSwitch', async () => {
+    const input = '<XDSSwitch tooltip="Toggle feature" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Toggle feature"');
+  });
+
+  it('renames tooltip on XDSDateInput', async () => {
+    const input = '<XDSDateInput tooltip="Pick a date" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Pick a date"');
+  });
+
+  it('renames tooltip on XDSTimeInput', async () => {
+    const input = '<XDSTimeInput tooltip="Pick a time" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Pick a time"');
+  });
+
+  // startIcon → labelIcon
+  it('renames startIcon to labelIcon on XDSField', async () => {
+    const input = '<XDSField startIcon={<Icon />} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelIcon={<Icon />}');
+    expect(output).not.toContain('startIcon');
+  });
+
+  it('renames startIcon on XDSNumberInput', async () => {
+    const input = '<XDSNumberInput startIcon={icon} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelIcon={icon}');
+  });
+
+  // Both renames in one element
+  it('renames both tooltip and startIcon on the same element', async () => {
+    const input = '<XDSField tooltip="Help" startIcon={icon} label="Name" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Help"');
+    expect(output).toContain('labelIcon={icon}');
+    expect(output).toContain('label="Name"');
+    expect(output).not.toContain(' tooltip=');
+    expect(output).not.toContain('startIcon');
+  });
+
+  // Negative cases
+  it('does not rename tooltip on non-form components', async () => {
+    const input = '<XDSTooltip tooltip="Hover me" />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('does not rename tooltip on non-XDS components', async () => {
+    const input = '<Field tooltip="Help" />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('does not rename startIcon on non-form components', async () => {
+    const input = '<XDSButton startIcon={icon} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../rename-form-tooltip-startIcon.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSField labelTooltip="Help" labelIcon={icon} />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('handles multiple form components in one file', async () => {
+    const input = `
+      <div>
+        <XDSField tooltip="Name help" startIcon={nameIcon} />
+        <XDSSwitch tooltip="Enable feature" />
+        <XDSDateInput startIcon={calendarIcon} />
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).toContain('labelTooltip="Name help"');
+    expect(output).toContain('labelIcon={nameIcon}');
+    expect(output).toContain('labelTooltip="Enable feature"');
+    expect(output).toContain('labelIcon={calendarIcon}');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/rename-isShown-to-isOpen.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/rename-isShown-to-isOpen.test.mjs
@@ -1,0 +1,96 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../rename-isShown-to-isOpen.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('rename-isShown-to-isOpen', () => {
+  it('renames isShown on XDSDialog', async () => {
+    const input = '<XDSDialog isShown={isShown} onOpenChange={handleChange}>Content</XDSDialog>';
+    const output = await applyTransform(input);
+    expect(output).toContain('isOpen={isShown}');
+    expect(output).not.toContain('isShown=');
+  });
+
+  it('renames isShown on XDSCommandPalette', async () => {
+    const input = '<XDSCommandPalette isShown={visible} onOpenChange={setVisible} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('isOpen={visible}');
+    expect(output).not.toContain('isShown=');
+  });
+
+  it('renames isShown on XDSPopover', async () => {
+    const input = '<XDSPopover isShown={open} onOpenChange={setOpen} content={<div />}><button /></XDSPopover>';
+    const output = await applyTransform(input);
+    expect(output).toContain('isOpen={open}');
+    expect(output).not.toContain('isShown=');
+  });
+
+  it('does not rename isShown on non-target components', async () => {
+    const input = '<Modal isShown={true} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('does not rename isShown on other XDS components', async () => {
+    const input = '<XDSTooltip isShown={true}><span /></XDSTooltip>';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('preserves other props', async () => {
+    const input = '<XDSDialog isShown={shown} onOpenChange={setShown} width={600} purpose="info">Content</XDSDialog>';
+    const output = await applyTransform(input);
+    expect(output).toContain('isOpen={shown}');
+    expect(output).toContain('onOpenChange={setShown}');
+    expect(output).toContain('width={600}');
+    expect(output).toContain('purpose="info"');
+  });
+
+  it('handles multiple target components in one file', async () => {
+    const input = `
+      <div>
+        <XDSDialog isShown={a} onOpenChange={setA}>Dialog</XDSDialog>
+        <XDSCommandPalette isShown={b} onOpenChange={setB} />
+        <XDSPopover isShown={c} onOpenChange={setC} content={<div />}><button /></XDSPopover>
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('isShown=');
+    expect(output).toContain('isOpen={a}');
+    expect(output).toContain('isOpen={b}');
+    expect(output).toContain('isOpen={c}');
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../rename-isShown-to-isOpen.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSDialog isOpen={open} onOpenChange={setOpen}>Content</XDSDialog>';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('handles boolean literal values', async () => {
+    const input = '<XDSDialog isShown={true} onOpenChange={() => {}}>Content</XDSDialog>';
+    const output = await applyTransform(input);
+    expect(output).toContain('isOpen={true}');
+    expect(output).not.toContain('isShown=');
+  });
+
+  it('handles ternary expressions', async () => {
+    const input = '<XDSDialog isShown={condition ? true : false} onOpenChange={handler}>Content</XDSDialog>';
+    const output = await applyTransform(input);
+    expect(output).toContain('isOpen={condition ? true : false}');
+    expect(output).not.toContain('isShown=');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/rename-selector-items-to-options.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/rename-selector-items-to-options.test.mjs
@@ -1,0 +1,72 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../rename-selector-items-to-options.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('rename-selector-items-to-options', () => {
+  it('renames items prop on XDSSelector', async () => {
+    const input = '<XDSSelector items={options} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('options={options}');
+    expect(output).not.toContain('items=');
+  });
+
+  it('handles items with complex expressions', async () => {
+    const input = '<XDSSelector items={data.map(d => ({label: d.name, value: d.id}))} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('options={');
+    expect(output).not.toContain('items=');
+  });
+
+  it('preserves other props', async () => {
+    const input = '<XDSSelector items={opts} onChange={handleChange} label="Pick one" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('options={opts}');
+    expect(output).toContain('onChange={handleChange}');
+    expect(output).toContain('label="Pick one"');
+  });
+
+  it('does not rename items on non-XDS components', async () => {
+    const input = '<Select items={options} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('does not rename items on other XDS components', async () => {
+    const input = '<XDSDropdownMenu items={menuItems} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../rename-selector-items-to-options.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSSelector options={opts} />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('handles multiple XDSSelector instances', async () => {
+    const input = `
+      <div>
+        <XDSSelector items={a} />
+        <XDSSelector items={b} label="second" />
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('items=');
+    expect(output).toContain('options={a}');
+    expect(output).toContain('options={b}');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/replace-hstack-vstack-with-stack.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/replace-hstack-vstack-with-stack.test.mjs
@@ -1,0 +1,155 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../replace-hstack-vstack-with-stack.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('replace-hstack-vstack-with-stack', () => {
+  // === JSX transforms ===
+
+  it('replaces XDSHStack with XDSStack direction="horizontal"', async () => {
+    const input = '<XDSHStack gap={8}><div /><div /></XDSHStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSStack');
+    expect(output).toContain('direction="horizontal"');
+    expect(output).toContain('gap={8}');
+    expect(output).not.toContain('XDSHStack');
+  });
+
+  it('replaces XDSVStack with XDSStack direction="vertical"', async () => {
+    const input = '<XDSVStack gap={12}><div /><div /></XDSVStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSStack');
+    expect(output).toContain('direction="vertical"');
+    expect(output).toContain('gap={12}');
+    expect(output).not.toContain('XDSVStack');
+  });
+
+  it('handles self-closing elements', async () => {
+    const input = '<XDSHStack gap={4} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSStack');
+    expect(output).toContain('direction="horizontal"');
+    expect(output).not.toContain('XDSHStack');
+  });
+
+  it('preserves all existing props', async () => {
+    const input = '<XDSHStack gap={8} align="center" xstyle={styles.row}><div /></XDSHStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('direction="horizontal"');
+    expect(output).toContain('gap={8}');
+    expect(output).toContain('align="center"');
+    expect(output).toContain('xstyle={styles.row}');
+  });
+
+  it('handles both HStack and VStack in the same file', async () => {
+    const input = `
+      <div>
+        <XDSHStack gap={8}><span /></XDSHStack>
+        <XDSVStack gap={12}><span /></XDSVStack>
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('XDSHStack');
+    expect(output).not.toContain('XDSVStack');
+    expect(output).toContain('direction="horizontal"');
+    expect(output).toContain('direction="vertical"');
+  });
+
+  it('does not touch non-XDS components', async () => {
+    const input = '<HStack gap={8}><div /></HStack>';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('does not touch XDSStack that already has direction', async () => {
+    const input = '<XDSStack direction="horizontal" gap={8}><div /></XDSStack>';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  // === Import transforms ===
+
+  it('replaces XDSHStack import with XDSStack', async () => {
+    const input = `import {XDSHStack} from '@xds/core/Stack';
+<XDSHStack><div /></XDSHStack>`;
+    const output = await applyTransform(input);
+    expect(output).toContain("import {XDSStack} from '@xds/core/Stack'");
+    expect(output).not.toContain('XDSHStack');
+  });
+
+  it('replaces XDSVStack import with XDSStack', async () => {
+    const input = `import {XDSVStack} from '@xds/core/Stack';
+<XDSVStack><div /></XDSVStack>`;
+    const output = await applyTransform(input);
+    expect(output).toContain("import {XDSStack} from '@xds/core/Stack'");
+    expect(output).not.toContain('XDSVStack');
+  });
+
+  it('does not duplicate XDSStack import if already present', async () => {
+    const input = `import {XDSStack, XDSHStack} from '@xds/core/Stack';
+<XDSHStack><div /></XDSHStack>`;
+    const output = await applyTransform(input);
+    // Should have XDSStack but not duplicate it
+    const matches = output.match(/XDSStack/g);
+    // XDSStack appears in import + JSX opening + JSX closing = 3
+    expect(output).not.toContain('XDSHStack');
+    expect(output).toContain('XDSStack');
+    expect(output).toContain("'@xds/core/Stack'");
+  });
+
+  it('handles both HStack and VStack imports together', async () => {
+    const input = `import {XDSHStack, XDSVStack, XDSStackItem} from '@xds/core/Stack';
+<div>
+  <XDSHStack><div /></XDSHStack>
+  <XDSVStack><div /></XDSVStack>
+</div>`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('XDSHStack');
+    expect(output).not.toContain('XDSVStack');
+    expect(output).toContain('XDSStack');
+    expect(output).toContain('XDSStackItem');
+  });
+
+  it('handles imports from @xds/core barrel', async () => {
+    const input = `import {XDSHStack, XDSButton} from '@xds/core';
+<XDSHStack><XDSButton label="Click" /></XDSHStack>`;
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSStack');
+    expect(output).toContain('XDSButton');
+    expect(output).not.toContain('XDSHStack');
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../replace-hstack-vstack-with-stack.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSStack direction="horizontal" gap={8}><div /></XDSStack>';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('handles nested stacks', async () => {
+    const input = `
+      <XDSVStack gap={16}>
+        <XDSHStack gap={8}><span /><span /></XDSHStack>
+        <XDSHStack gap={8}><span /><span /></XDSHStack>
+      </XDSVStack>
+    `;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('XDSVStack');
+    expect(output).not.toContain('XDSHStack');
+    // Should have both directions
+    expect(output).toContain('direction="vertical"');
+    expect(output).toContain('direction="horizontal"');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/unify-uncontrolled-to-defaultX.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/unify-uncontrolled-to-defaultX.test.mjs
@@ -1,0 +1,77 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../unify-uncontrolled-to-defaultX.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('unify-uncontrolled-to-defaultX', () => {
+  it('renames initialIsSideNavCollapsed on XDSAppShell', async () => {
+    const input = '<XDSAppShell initialIsSideNavCollapsed={true} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('defaultIsSideNavCollapsed={true}');
+    expect(output).not.toContain('initialIsSideNavCollapsed');
+  });
+
+  it('renames initialIsOpen on XDSCollapsible', async () => {
+    const input = '<XDSCollapsible initialIsOpen={false} title="Section" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('defaultIsOpen={false}');
+    expect(output).not.toContain('initialIsOpen');
+  });
+
+  it('renames initialIsExpanded on XDSBanner', async () => {
+    const input = '<XDSBanner initialIsExpanded={true} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('defaultIsExpanded={true}');
+    expect(output).not.toContain('initialIsExpanded');
+  });
+
+  it('preserves other props', async () => {
+    const input = '<XDSAppShell initialIsSideNavCollapsed={true} topNav={<Nav />} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('defaultIsSideNavCollapsed={true}');
+    expect(output).toContain('topNav={<Nav />}');
+  });
+
+  it('does not rename initialIsOpen on non-XDS components', async () => {
+    const input = '<Collapsible initialIsOpen={true} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('does not rename unrelated props on XDS components', async () => {
+    const input = '<XDSAppShell topNav={<Nav />} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../unify-uncontrolled-to-defaultX.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSCollapsible defaultIsOpen={true} />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('handles multiple components in one file', async () => {
+    const input = `
+      <div>
+        <XDSCollapsible initialIsOpen={true} />
+        <XDSBanner initialIsExpanded={false} />
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).toContain('defaultIsOpen={true}');
+    expect(output).toContain('defaultIsExpanded={false}');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/unify-visibility-to-onOpenChange.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/unify-visibility-to-onOpenChange.test.mjs
@@ -1,0 +1,135 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../unify-visibility-to-onOpenChange.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('unify-visibility-to-onOpenChange', () => {
+  // Simple renames
+  it('renames onHide to onOpenChange on XDSDialog', async () => {
+    const input = '<XDSDialog onHide={handleHide} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange={handleHide}');
+    expect(output).not.toContain('onHide');
+  });
+
+  it('renames onHide to onOpenChange on XDSDialogHeader', async () => {
+    const input = '<XDSDialogHeader onHide={close} title="Test" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange={close}');
+    expect(output).not.toContain('onHide');
+  });
+
+  it('renames onHide to onOpenChange on XDSCommandPalette', async () => {
+    const input = '<XDSCommandPalette onHide={() => setOpen(false)} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange=');
+    expect(output).not.toContain('onHide');
+  });
+
+  it('renames onClose to onOpenChange on XDSMobileNav', async () => {
+    const input = '<XDSMobileNav onClose={handleClose} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange={handleClose}');
+    expect(output).not.toContain('onClose');
+  });
+
+  it('renames onMenuToggle to onOpenChange on XDSDropdownMenu', async () => {
+    const input = '<XDSDropdownMenu onMenuToggle={toggle} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange={toggle}');
+    expect(output).not.toContain('onMenuToggle');
+  });
+
+  it('renames onToggle to onOpenChange on XDSPopover', async () => {
+    const input = '<XDSPopover onToggle={handleToggle} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange={handleToggle}');
+    expect(output).not.toContain('onToggle');
+  });
+
+  it('renames onToggle to onOpenChange on XDSCollapsibleGroup', async () => {
+    const input = '<XDSCollapsibleGroup onToggle={handleToggle} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange={handleToggle}');
+    expect(output).not.toContain('onToggle');
+  });
+
+  // Merge components — single prop
+  it('renames onShow to onOpenChange on XDSHoverCard when only onShow', async () => {
+    const input = '<XDSHoverCard onShow={handleShow} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange={handleShow}');
+    expect(output).not.toContain('onShow');
+  });
+
+  it('renames onHide to onOpenChange on XDSTooltip when only onHide', async () => {
+    const input = '<XDSTooltip onHide={handleHide} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('onOpenChange={handleHide}');
+    expect(output).not.toContain('onHide');
+  });
+
+  // Merge components — both props
+  it('adds TODO comment on XDSHoverCard when both onShow and onHide exist', async () => {
+    const input = '<XDSHoverCard onShow={show} onHide={hide} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('TODO');
+    // Both props should remain
+    expect(output).toContain('onShow');
+    expect(output).toContain('onHide');
+  });
+
+  it('adds TODO comment on XDSTooltip when both onShow and onHide exist', async () => {
+    const input = '<XDSTooltip onShow={show} onHide={hide} content="tip" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('TODO');
+    expect(output).toContain('onShow');
+    expect(output).toContain('onHide');
+  });
+
+  // Negative cases
+  it('does not rename onHide on non-XDS components', async () => {
+    const input = '<Dialog onHide={handleHide} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('does not rename onToggle on non-XDS components', async () => {
+    const input = '<Popover onToggle={handleToggle} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../unify-visibility-to-onOpenChange.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSDialog onOpenChange={handleChange} />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('handles multiple components in one file', async () => {
+    const input = `
+      <div>
+        <XDSDialog onHide={close} />
+        <XDSPopover onToggle={toggle} />
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('onHide');
+    expect(output).not.toContain('onToggle');
+    expect(output).toContain('onOpenChange={close}');
+    expect(output).toContain('onOpenChange={toggle}');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/index.mjs
@@ -1,0 +1,65 @@
+/**
+ * @file v0.0.2 transform manifest
+ *
+ * Lists all codemods for the v0.0.2 release in the order they should run.
+ */
+
+import renameSelectorItemsToOptions, {
+  meta as selectorMeta,
+} from './rename-selector-items-to-options.mjs';
+import unifyVisibilityToOnOpenChange, {
+  meta as visibilityMeta,
+} from './unify-visibility-to-onOpenChange.mjs';
+import unifyUncontrolledToDefaultX, {
+  meta as uncontrolledMeta,
+} from './unify-uncontrolled-to-defaultX.mjs';
+import renameBannerEndButtonToEndContent, {
+  meta as bannerMeta,
+} from './rename-banner-endButton-to-endContent.mjs';
+import renameFormTooltipStartIcon, {
+  meta as formMeta,
+} from './rename-form-tooltip-startIcon.mjs';
+import renameIsShownToIsOpen, {
+  meta as isShownMeta,
+} from './rename-isShown-to-isOpen.mjs';
+import replaceHStackVStackWithStack, {
+  meta as stackMeta,
+} from './replace-hstack-vstack-with-stack.mjs';
+
+export default [
+  {
+    name: 'rename-selector-items-to-options',
+    transform: renameSelectorItemsToOptions,
+    meta: selectorMeta,
+  },
+  {
+    name: 'unify-visibility-to-onOpenChange',
+    transform: unifyVisibilityToOnOpenChange,
+    meta: visibilityMeta,
+  },
+  {
+    name: 'unify-uncontrolled-to-defaultX',
+    transform: unifyUncontrolledToDefaultX,
+    meta: uncontrolledMeta,
+  },
+  {
+    name: 'rename-banner-endButton-to-endContent',
+    transform: renameBannerEndButtonToEndContent,
+    meta: bannerMeta,
+  },
+  {
+    name: 'rename-form-tooltip-startIcon',
+    transform: renameFormTooltipStartIcon,
+    meta: formMeta,
+  },
+  {
+    name: 'rename-isShown-to-isOpen',
+    transform: renameIsShownToIsOpen,
+    meta: isShownMeta,
+  },
+  {
+    name: 'replace-hstack-vstack-with-stack',
+    transform: replaceHStackVStackWithStack,
+    meta: stackMeta,
+  },
+];

--- a/packages/cli/src/codemods/transforms/v0.0.2/rename-banner-endButton-to-endContent.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/rename-banner-endButton-to-endContent.mjs
@@ -1,0 +1,31 @@
+/**
+ * @file Codemod: Rename XDSBanner endButton to endContent
+ * @see https://github.com/facebookexperimental/xds/pull/437
+ */
+
+export const meta = {
+  title: 'Rename Banner endButton → endContent',
+  description: 'Renames the `endButton` prop on XDSBanner to `endContent`.',
+  pr: '#437',
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  root
+    .find(j.JSXOpeningElement, {
+      name: {name: 'XDSBanner'},
+    })
+    .forEach((path) => {
+      path.node.attributes.forEach((attr) => {
+        if (attr.type === 'JSXAttribute' && attr.name.name === 'endButton') {
+          attr.name.name = 'endContent';
+          hasChanges = true;
+        }
+      });
+    });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.2/rename-form-tooltip-startIcon.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/rename-form-tooltip-startIcon.mjs
@@ -1,0 +1,51 @@
+/**
+ * @file Codemod: Rename form field tooltip → labelTooltip, startIcon → labelIcon
+ * @see https://github.com/facebookexperimental/xds/pull/375
+ *
+ * Applies to: XDSField, XDSFieldLabel, XDSNumberInput, XDSCheckboxInput,
+ * XDSSwitch, XDSDateInput, XDSTimeInput
+ */
+
+export const meta = {
+  title: 'Rename form tooltip → labelTooltip, startIcon → labelIcon',
+  description:
+    'Renames `tooltip` to `labelTooltip` and `startIcon` to `labelIcon` on form field components.',
+  pr: '#375',
+};
+
+const FORM_COMPONENTS = new Set([
+  'XDSField',
+  'XDSFieldLabel',
+  'XDSNumberInput',
+  'XDSCheckboxInput',
+  'XDSSwitch',
+  'XDSDateInput',
+  'XDSTimeInput',
+]);
+
+const PROP_RENAMES = {
+  tooltip: 'labelTooltip',
+  startIcon: 'labelIcon',
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  root.find(j.JSXOpeningElement).forEach((path) => {
+    const name = path.node.name;
+    if (name.type !== 'JSXIdentifier' || !FORM_COMPONENTS.has(name.name)) {
+      return;
+    }
+
+    path.node.attributes.forEach((attr) => {
+      if (attr.type === 'JSXAttribute' && attr.name.name in PROP_RENAMES) {
+        attr.name.name = PROP_RENAMES[attr.name.name];
+        hasChanges = true;
+      }
+    });
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.2/rename-isShown-to-isOpen.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/rename-isShown-to-isOpen.mjs
@@ -1,0 +1,36 @@
+/**
+ * @file Codemod: Rename `isShown` prop to `isOpen` on Dialog, CommandPalette, and Popover
+ * @see https://github.com/facebookexperimental/xds/pull/472
+ */
+
+export const meta = {
+  title: 'Rename isShown → isOpen',
+  description:
+    'Renames the `isShown` prop to `isOpen` on XDSDialog, XDSCommandPalette, and XDSPopover for consistency.',
+  pr: '#472',
+};
+
+const TARGET_COMPONENTS = ['XDSDialog', 'XDSCommandPalette', 'XDSPopover'];
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  TARGET_COMPONENTS.forEach((componentName) => {
+    root
+      .find(j.JSXOpeningElement, {
+        name: {name: componentName},
+      })
+      .forEach((path) => {
+        path.node.attributes.forEach((attr) => {
+          if (attr.type === 'JSXAttribute' && attr.name.name === 'isShown') {
+            attr.name.name = 'isOpen';
+            hasChanges = true;
+          }
+        });
+      });
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.2/rename-selector-items-to-options.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/rename-selector-items-to-options.mjs
@@ -1,0 +1,32 @@
+/**
+ * @file Codemod: Rename XDSSelector `items` prop to `options`
+ * @see https://github.com/facebookexperimental/xds/pull/479
+ */
+
+export const meta = {
+  title: 'Rename Selector items → options',
+  description: 'Renames the `items` prop on XDSSelector to `options`.',
+  pr: '#479',
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Find <XDSSelector items={...} /> and rename to options
+  root
+    .find(j.JSXOpeningElement, {
+      name: {name: 'XDSSelector'},
+    })
+    .forEach((path) => {
+      path.node.attributes.forEach((attr) => {
+        if (attr.type === 'JSXAttribute' && attr.name.name === 'items') {
+          attr.name.name = 'options';
+          hasChanges = true;
+        }
+      });
+    });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.2/replace-hstack-vstack-with-stack.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/replace-hstack-vstack-with-stack.mjs
@@ -1,0 +1,99 @@
+/**
+ * @file Codemod: Replace XDSHStack/XDSVStack with XDSStack + direction prop
+ * @see https://github.com/facebookexperimental/xds/pull/374
+ */
+
+export const meta = {
+  title: 'Replace XDSHStack/XDSVStack with XDSStack',
+  description:
+    'Replaces `<XDSHStack>` with `<XDSStack direction="horizontal">` and `<XDSVStack>` with `<XDSStack direction="vertical">`. Also updates imports.',
+  pr: '#374',
+};
+
+const REPLACEMENTS = {
+  XDSHStack: 'horizontal',
+  XDSVStack: 'vertical',
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Rename JSX elements: <XDSHStack> → <XDSStack direction="horizontal">
+  Object.entries(REPLACEMENTS).forEach(([oldName, direction]) => {
+    // Opening elements
+    root
+      .find(j.JSXOpeningElement, {name: {name: oldName}})
+      .forEach((path) => {
+        path.node.name.name = 'XDSStack';
+        // Add direction prop (prepend so it reads naturally)
+        const directionAttr = j.jsxAttribute(
+          j.jsxIdentifier('direction'),
+          j.stringLiteral(direction),
+        );
+        path.node.attributes.unshift(directionAttr);
+        hasChanges = true;
+      });
+
+    // Closing elements
+    root
+      .find(j.JSXClosingElement, {name: {name: oldName}})
+      .forEach((path) => {
+        path.node.name.name = 'XDSStack';
+        hasChanges = true;
+      });
+  });
+
+  // Update imports: replace XDSHStack/XDSVStack with XDSStack
+  root.find(j.ImportDeclaration).forEach((path) => {
+    const source = path.node.source.value;
+    // Match @xds/core imports (e.g. '@xds/core/Stack', '@xds/core/Layout', '@xds/core')
+    if (!source.startsWith('@xds/core')) return;
+
+    let needsXDSStack = false;
+    const specifiersToRemove = [];
+
+    path.node.specifiers.forEach((spec, index) => {
+      if (spec.type === 'ImportSpecifier') {
+        const importedName = spec.imported.name;
+        if (importedName === 'XDSHStack' || importedName === 'XDSVStack') {
+          specifiersToRemove.push(index);
+          needsXDSStack = true;
+        }
+        if (importedName === 'XDSStack') {
+          // Already importing XDSStack, just need to remove old ones
+          needsXDSStack = false;
+        }
+      }
+    });
+
+    if (specifiersToRemove.length > 0) {
+      // Check if XDSStack is already imported
+      const alreadyHasStack = path.node.specifiers.some(
+        (s) => s.type === 'ImportSpecifier' && s.imported.name === 'XDSStack',
+      );
+
+      // Remove old specifiers (reverse order to preserve indices)
+      for (let i = specifiersToRemove.length - 1; i >= 0; i--) {
+        path.node.specifiers.splice(specifiersToRemove[i], 1);
+      }
+
+      // Add XDSStack if not already present
+      if (needsXDSStack && !alreadyHasStack) {
+        path.node.specifiers.push(
+          j.importSpecifier(j.identifier('XDSStack')),
+        );
+      }
+
+      // If no specifiers left, remove the import entirely
+      if (path.node.specifiers.length === 0) {
+        j(path).remove();
+      }
+
+      hasChanges = true;
+    }
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.2/unify-uncontrolled-to-defaultX.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/unify-uncontrolled-to-defaultX.mjs
@@ -1,0 +1,54 @@
+/**
+ * @file Codemod: Rename initialX props to defaultX pattern
+ * @see https://github.com/facebookexperimental/xds/pull/470
+ *
+ * Standardizes uncontrolled state prop naming from `initialX` to `defaultX`.
+ */
+
+export const meta = {
+  title: 'Unify uncontrolled state → defaultX pattern',
+  description:
+    'Renames initialIsSideNavCollapsed, initialIsOpen, initialIsExpanded to their defaultX equivalents.',
+  pr: '#470',
+};
+
+const RENAMES = [
+  {
+    component: 'XDSAppShell',
+    oldProp: 'initialIsSideNavCollapsed',
+    newProp: 'defaultIsSideNavCollapsed',
+  },
+  {
+    component: 'XDSCollapsible',
+    oldProp: 'initialIsOpen',
+    newProp: 'defaultIsOpen',
+  },
+  {
+    component: 'XDSBanner',
+    oldProp: 'initialIsExpanded',
+    newProp: 'defaultIsExpanded',
+  },
+];
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  for (const {component, oldProp, newProp} of RENAMES) {
+    root
+      .find(j.JSXOpeningElement, {
+        name: {name: component},
+      })
+      .forEach((path) => {
+        path.node.attributes.forEach((attr) => {
+          if (attr.type === 'JSXAttribute' && attr.name.name === oldProp) {
+            attr.name.name = newProp;
+            hasChanges = true;
+          }
+        });
+      });
+  }
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.2/unify-visibility-to-onOpenChange.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/unify-visibility-to-onOpenChange.mjs
@@ -1,0 +1,101 @@
+/**
+ * @file Codemod: Unify visibility callbacks to onOpenChange
+ * @see https://github.com/facebookexperimental/xds/pull/473
+ *
+ * Renames various visibility-related callback props to the unified `onOpenChange`.
+ * For components with both onShow and onHide (HoverCard, Tooltip), handles merging
+ * when only one is present, or adds a TODO comment when both exist.
+ */
+
+export const meta = {
+  title: 'Unify visibility callbacks → onOpenChange',
+  description:
+    'Renames onHide, onClose, onShow, onToggle, onMenuToggle to onOpenChange across dialog, menu, popover, and tooltip components.',
+  pr: '#473',
+};
+
+/**
+ * Simple renames: old prop → onOpenChange (one-to-one mapping)
+ */
+const SIMPLE_RENAMES = [
+  {component: 'XDSDialog', oldProp: 'onHide'},
+  {component: 'XDSDialogHeader', oldProp: 'onHide'},
+  {component: 'XDSCommandPalette', oldProp: 'onHide'},
+  {component: 'XDSMobileNav', oldProp: 'onClose'},
+  {component: 'XDSDropdownMenu', oldProp: 'onMenuToggle'},
+  {component: 'XDSPopover', oldProp: 'onToggle'},
+  {component: 'XDSCollapsibleGroup', oldProp: 'onToggle'},
+];
+
+/**
+ * Merge renames: components with onShow/onHide that merge into onOpenChange
+ */
+const MERGE_COMPONENTS = ['XDSHoverCard', 'XDSTooltip'];
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Handle simple renames
+  for (const {component, oldProp} of SIMPLE_RENAMES) {
+    root
+      .find(j.JSXOpeningElement, {
+        name: {name: component},
+      })
+      .forEach((path) => {
+        path.node.attributes.forEach((attr) => {
+          if (attr.type === 'JSXAttribute' && attr.name.name === oldProp) {
+            attr.name.name = 'onOpenChange';
+            hasChanges = true;
+          }
+        });
+      });
+  }
+
+  // Handle merge components (onShow/onHide → onOpenChange)
+  for (const component of MERGE_COMPONENTS) {
+    root
+      .find(j.JSXOpeningElement, {
+        name: {name: component},
+      })
+      .forEach((path) => {
+        const attrs = path.node.attributes;
+        const onShowAttr = attrs.find(
+          (a) => a.type === 'JSXAttribute' && a.name.name === 'onShow',
+        );
+        const onHideAttr = attrs.find(
+          (a) => a.type === 'JSXAttribute' && a.name.name === 'onHide',
+        );
+
+        if (onShowAttr && onHideAttr) {
+          // Both exist — add a TODO comment and leave them
+          // We add the comment as a JSX expression before the element
+          const comment = j.jsxExpressionContainer(
+            j.jsxEmptyExpression(),
+          );
+          comment.expression = j.jsxEmptyExpression();
+          // Add leading comment to the onShow attribute
+          if (!onShowAttr.comments) {
+            onShowAttr.comments = [];
+          }
+          onShowAttr.comments.push(
+            j.commentBlock(
+              ' TODO: Merge onShow and onHide into a single onOpenChange={(isOpen) => { ... }} prop ',
+              false,
+              true,
+            ),
+          );
+          hasChanges = true;
+        } else if (onShowAttr && !onHideAttr) {
+          onShowAttr.name.name = 'onOpenChange';
+          hasChanges = true;
+        } else if (onHideAttr && !onShowAttr) {
+          onHideAttr.name.name = 'onOpenChange';
+          hasChanges = true;
+        }
+      });
+  }
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -31,6 +31,9 @@ export function generateCompressedIndex(version) {
 |npx xds template <name> [path]       Scaffold page (blank, table, login)
 |npx xds swizzle <Name> --gap "<reason>"  Copy component source for customization + file gap report
 |npx xds gap-report --component <Name> --category <cat> --reason "<why>"  File gap without swizzle
+|npx xds upgrade                       Preview API migrations for your version
+|npx xds upgrade --apply               Apply codemods to update breaking API changes
+|RULE: After bumping @xds/core version, ALWAYS run npx xds upgrade --apply to migrate breaking API changes.
 |RULE: When swizzling to unblock yourself, ALWAYS use --gap to explain what capability was missing.
 ${XDS_MARKER_END}`;
 }

--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -36,6 +36,13 @@ describe('generateCompressedIndex', () => {
     const result = generateCompressedIndex('1.0.0');
     expect(result).not.toContain('npx xds theme');
   });
+
+  it('includes upgrade command and migration rule', () => {
+    const result = generateCompressedIndex('1.0.0');
+    expect(result).toContain('npx xds upgrade');
+    expect(result).toContain('npx xds upgrade --apply');
+    expect(result).toContain('ALWAYS run npx xds upgrade --apply to migrate breaking API changes');
+  });
 });
 
 describe('getXdsVersion', () => {

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -21,6 +21,7 @@ import {
   versions,
 } from '../codemods/registry.mjs';
 import {runCodemods} from '../codemods/runner.mjs';
+import {installAgentDocs} from './agent-docs.mjs';
 
 /**
  * Detect the installed @xds/core version from the consumer's package.json.
@@ -146,6 +147,18 @@ export function registerUpgrade(program) {
         path: options.path,
         codemod: options.codemod,
       });
+
+      // Refresh agent docs (AGENTS.md / CLAUDE.md) with updated component index
+      if (options.apply) {
+        try {
+          installAgentDocs(process.cwd());
+          p.log.success('Agent docs updated to match new version.');
+        } catch {
+          p.log.warn(
+            'Could not update agent docs. Run `npx xds agent-docs` to update manually.',
+          );
+        }
+      }
 
       p.outro(options.apply ? 'Upgrade complete' : 'Dry run complete');
     });

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -1,0 +1,152 @@
+/**
+ * @file upgrade command — Run version-to-version codemods
+ *
+ * `xds upgrade` detects the consumer's @xds/core version and runs
+ * all codemods needed to migrate to the target version.
+ *
+ * Options:
+ *   --apply         Write changes to disk (default: dry-run)
+ *   --to <version>  Target version (default: latest in registry)
+ *   --codemod <name> Run a specific transform only
+ *   --path <dir>    Source directory (default: ./src)
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as p from '@clack/prompts';
+import {ensureJscodeshift} from '../codemods/ensure-jscodeshift.mjs';
+import {
+  getTransformsBetween,
+  latestVersion,
+  versions,
+} from '../codemods/registry.mjs';
+import {runCodemods} from '../codemods/runner.mjs';
+
+/**
+ * Detect the installed @xds/core version from the consumer's package.json.
+ * @returns {string|null}
+ */
+function detectCurrentVersion() {
+  const pkgPath = path.resolve(process.cwd(), 'package.json');
+  try {
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const deps = {
+      ...pkg.dependencies,
+      ...pkg.devDependencies,
+    };
+    const version = deps['@xds/core'];
+    if (!version) return null;
+    // Strip semver range chars (^, ~, >=, etc.)
+    return version.replace(/^[^\d]*/, '');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * List all available codemods across all versions.
+ */
+async function listCodemods() {
+  for (const version of versions) {
+    const manifests = await getTransformsBetween('0.0.0', version);
+    for (const {transforms} of manifests) {
+      for (const {name, meta} of transforms) {
+        p.log.info(`  ${name} — ${meta.title} (${meta.pr})`);
+      }
+    }
+  }
+}
+
+export function registerUpgrade(program) {
+  program
+    .command('upgrade')
+    .description('Run codemods to migrate between XDS versions')
+    .option('--apply', 'Write changes to disk (default: dry-run)', false)
+    .option('--to <version>', 'Target version', latestVersion)
+    .option('--codemod <name>', 'Run a specific transform only')
+    .option('--path <dir>', 'Source directory to scan', './src')
+    .option('--list', 'List available codemods', false)
+    .action(async (options) => {
+      p.intro('XDS Upgrade');
+
+      if (options.list) {
+        p.log.step('Available codemods:');
+        await listCodemods();
+        p.outro('Done');
+        return;
+      }
+
+      // Detect current version
+      const currentVersion = detectCurrentVersion();
+      if (!currentVersion) {
+        p.log.error(
+          'Could not detect @xds/core version. Make sure package.json is in the current directory.',
+        );
+        p.outro('Aborted');
+        process.exitCode = 1;
+        return;
+      }
+
+      const targetVersion = options.to;
+      p.log.info(`Current version: ${currentVersion}`);
+      p.log.info(`Target version:  ${targetVersion}`);
+
+      if (currentVersion >= targetVersion) {
+        p.log.success('Already up to date — no codemods to run.');
+        p.outro('Done');
+        return;
+      }
+
+      // Resolve transforms
+      const versionManifests = await getTransformsBetween(
+        currentVersion,
+        targetVersion,
+      );
+
+      if (versionManifests.length === 0) {
+        p.log.success('No codemods available for this version range.');
+        p.outro('Done');
+        return;
+      }
+
+      // Count transforms
+      let totalTransforms = 0;
+      for (const {transforms} of versionManifests) {
+        for (const t of transforms) {
+          if (!options.codemod || t.name === options.codemod) {
+            totalTransforms++;
+          }
+        }
+      }
+
+      if (totalTransforms === 0) {
+        p.log.error(
+          `Codemod "${options.codemod}" not found. Use --list to see available codemods.`,
+        );
+        p.outro('Aborted');
+        process.exitCode = 1;
+        return;
+      }
+
+      p.log.step(
+        `${totalTransforms} codemod${totalTransforms === 1 ? '' : 's'} to run${options.apply ? '' : ' (dry run)'}`,
+      );
+
+      // Ensure jscodeshift is available
+      const ready = await ensureJscodeshift();
+      if (!ready) {
+        p.outro('Aborted');
+        process.exitCode = 1;
+        return;
+      }
+
+      // Run codemods
+      await runCodemods(versionManifests, {
+        apply: options.apply,
+        path: options.path,
+        codemod: options.codemod,
+      });
+
+      p.outro(options.apply ? 'Upgrade complete' : 'Dry run complete');
+    });
+}

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -12,6 +12,7 @@ import {registerComponent} from './commands/component.mjs';
 import {registerDocs} from './commands/docs.mjs';
 import {registerTemplate} from './commands/template.mjs';
 import {registerGapReport} from './commands/gap-report.mjs';
+import {registerUpgrade} from './commands/upgrade.mjs';
 
 export const program = new Command();
 
@@ -31,6 +32,7 @@ registerSwizzle(program);
 registerAgentDocs(program);
 registerTemplate(program);
 registerGapReport(program);
+registerUpgrade(program);
 
 // Hidden command used by package.json postinstall scripts
 program

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,6 +68,15 @@
     js-tokens "^4.0.0"
     picocolors "^1.1.1"
 
+"@babel/code-frame@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.29.0.tgz#7cd7a59f15b3cc0dcd803038f7792712a7d0b15c"
+  integrity sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.28.5"
+    js-tokens "^4.0.0"
+    picocolors "^1.1.1"
+
 "@babel/compat-data@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.28.6.tgz#103f466803fa0f059e82ccac271475470570d74c"
@@ -94,6 +103,27 @@
     json5 "^2.2.3"
     semver "^6.3.1"
 
+"@babel/core@^7.24.7":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.29.0.tgz#5286ad785df7f79d656e88ce86e650d16ca5f322"
+  integrity sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-compilation-targets" "^7.28.6"
+    "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helpers" "^7.28.6"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/traverse" "^7.29.0"
+    "@babel/types" "^7.29.0"
+    "@jridgewell/remapping" "^2.3.5"
+    convert-source-map "^2.0.0"
+    debug "^4.1.0"
+    gensync "^1.0.0-beta.2"
+    json5 "^2.2.3"
+    semver "^6.3.1"
+
 "@babel/generator@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.6.tgz#48dcc65d98fcc8626a48f72b62e263d25fc3c3f1"
@@ -101,6 +131,17 @@
   dependencies:
     "@babel/parser" "^7.28.6"
     "@babel/types" "^7.28.6"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
+"@babel/generator@^7.29.0":
+  version "7.29.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.29.1.tgz#d09876290111abbb00ef962a7b83a5307fba0d50"
+  integrity sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==
+  dependencies:
+    "@babel/parser" "^7.29.0"
+    "@babel/types" "^7.29.0"
     "@jridgewell/gen-mapping" "^0.3.12"
     "@jridgewell/trace-mapping" "^0.3.28"
     jsesc "^3.0.2"
@@ -225,7 +266,14 @@
   dependencies:
     "@babel/types" "^7.28.6"
 
-"@babel/plugin-syntax-flow@^7.26.0":
+"@babel/parser@^7.24.7", "@babel/parser@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.29.0.tgz#669ef345add7d057e92b7ed15f0bac07611831b6"
+  integrity sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==
+  dependencies:
+    "@babel/types" "^7.29.0"
+
+"@babel/plugin-syntax-flow@^7.26.0", "@babel/plugin-syntax-flow@^7.27.1":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.28.6.tgz#447559a225e66c4cd477a3ffb1a74d8c1fe25a62"
   integrity sha512-D+OrJumc9McXNEBI/JmFnc/0uCM2/Y3PEBG3gfV3QIYkKv5pvnpzFrl1kYCrcHJP8nOeFB/SHi1IHz29pNGuew==
@@ -246,12 +294,51 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.28.6"
 
-"@babel/plugin-transform-modules-commonjs@^7.27.1":
+"@babel/plugin-transform-class-properties@^7.24.7":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz#d274a4478b6e782d9ea987fda09bdb6d28d66b72"
+  integrity sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+
+"@babel/plugin-transform-flow-strip-types@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.27.1.tgz#5def3e1e7730f008d683144fb79b724f92c5cdf9"
+  integrity sha512-G5eDKsu50udECw7DL2AcsysXiQyB7Nfg521t2OAJ4tbfTJ27doHLeF/vlI1NZGlLdbb/v+ibvtL1YBQqYOwJGg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/plugin-syntax-flow" "^7.27.1"
+
+"@babel/plugin-transform-modules-commonjs@^7.24.7", "@babel/plugin-transform-modules-commonjs@^7.27.1":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz#c0232e0dfe66a734cc4ad0d5e75fc3321b6fdef1"
   integrity sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==
   dependencies:
     "@babel/helper-module-transforms" "^7.28.6"
+    "@babel/helper-plugin-utils" "^7.28.6"
+
+"@babel/plugin-transform-nullish-coalescing-operator@^7.24.7":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz#9bc62096e90ab7a887f3ca9c469f6adec5679757"
+  integrity sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
+
+"@babel/plugin-transform-optional-chaining@^7.24.7":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz#926cf150bd421fc8362753e911b4a1b1ce4356cd"
+  integrity sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.28.6"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
+
+"@babel/plugin-transform-private-methods@^7.24.7":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz#c76fbfef3b86c775db7f7c106fff544610bdb411"
+  integrity sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-react-display-name@^7.28.0":
@@ -312,6 +399,15 @@
     "@babel/helper-skip-transparent-expression-wrappers" "^7.27.1"
     "@babel/plugin-syntax-typescript" "^7.28.6"
 
+"@babel/preset-flow@^7.24.7":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.27.1.tgz#3050ed7c619e8c4bfd0e0eeee87a2fa86a4bb1c6"
+  integrity sha512-ez3a2it5Fn6P54W8QkbfIyyIbxlXvcxyWHHvno1Wg0Ej5eiJY5hBb8ExttoIOJJk7V2dZE6prP7iby5q2aQ0Lg==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.27.1"
+    "@babel/helper-validator-option" "^7.27.1"
+    "@babel/plugin-transform-flow-strip-types" "^7.27.1"
+
 "@babel/preset-react@^7.25.0", "@babel/preset-react@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.28.5.tgz#6fcc0400fa79698433d653092c3919bb4b0878d9"
@@ -324,7 +420,7 @@
     "@babel/plugin-transform-react-jsx-development" "^7.27.1"
     "@babel/plugin-transform-react-pure-annotations" "^7.27.1"
 
-"@babel/preset-typescript@^7.25.0", "@babel/preset-typescript@^7.28.5":
+"@babel/preset-typescript@^7.24.7", "@babel/preset-typescript@^7.25.0", "@babel/preset-typescript@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz#540359efa3028236958466342967522fd8f2a60c"
   integrity sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==
@@ -334,6 +430,17 @@
     "@babel/plugin-syntax-jsx" "^7.27.1"
     "@babel/plugin-transform-modules-commonjs" "^7.27.1"
     "@babel/plugin-transform-typescript" "^7.28.5"
+
+"@babel/register@^7.24.6":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/register/-/register-7.28.6.tgz#f54461dd32f6a418c1eb1f583c95ed0b7266ea4c"
+  integrity sha512-pgcbbEl/dWQYb6L6Yew6F94rdwygfuv+vJ/tXfwIOYAfPB6TNWpXUMEtEq3YuTeHRdvMIhvz13bkT9CNaS+wqA==
+  dependencies:
+    clone-deep "^4.0.1"
+    find-cache-dir "^2.0.0"
+    make-dir "^2.1.0"
+    pirates "^4.0.6"
+    source-map-support "^0.5.16"
 
 "@babel/runtime@^7.12.5", "@babel/runtime@^7.17.8", "@babel/runtime@^7.5.5":
   version "7.28.6"
@@ -362,10 +469,31 @@
     "@babel/types" "^7.28.6"
     debug "^4.3.1"
 
+"@babel/traverse@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.29.0.tgz#f323d05001440253eead3c9c858adbe00b90310a"
+  integrity sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==
+  dependencies:
+    "@babel/code-frame" "^7.29.0"
+    "@babel/generator" "^7.29.0"
+    "@babel/helper-globals" "^7.28.0"
+    "@babel/parser" "^7.29.0"
+    "@babel/template" "^7.28.6"
+    "@babel/types" "^7.29.0"
+    debug "^4.3.1"
+
 "@babel/types@^7.0.0", "@babel/types@^7.18.9", "@babel/types@^7.20.7", "@babel/types@^7.25.4", "@babel/types@^7.26.8", "@babel/types@^7.27.1", "@babel/types@^7.27.3", "@babel/types@^7.28.2", "@babel/types@^7.28.5", "@babel/types@^7.28.6":
   version "7.28.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.6.tgz#c3e9377f1b155005bcc4c46020e7e394e13089df"
   integrity sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
+
+"@babel/types@^7.29.0":
+  version "7.29.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.29.0.tgz#9f5b1e838c446e72cf3cd4b918152b8c605e37c7"
+  integrity sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.28.5"
@@ -2597,6 +2725,11 @@ browserslist@^4.24.0:
     node-releases "^2.0.27"
     update-browserslist-db "^1.2.0"
 
+buffer-from@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
+  integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
+
 bundle-require@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/bundle-require/-/bundle-require-5.1.0.tgz#8db66f41950da3d77af1ef3322f4c3e04009faee"
@@ -2704,6 +2837,15 @@ client-only@0.0.1:
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"
   integrity sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==
 
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -2725,6 +2867,11 @@ commander@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
+commondir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
+  integrity sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -3251,6 +3398,22 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-cache-dir@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
+  integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^2.0.0"
+    pkg-dir "^3.0.0"
+
+find-up@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
+  integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+  dependencies:
+    locate-path "^3.0.0"
+
 find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -3288,6 +3451,11 @@ flatted@^3.2.9:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
   integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+
+flow-parser@0.*:
+  version "0.304.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.304.0.tgz#6669c95b617b2d917fbdd287a9c29663e5d92b48"
+  integrity sha512-JjHRBxQX5b5pAn0nwr/U29U+uodOQzIyAKRAFEaXpB2BUkNyW76IRRD0eCEKvZGj23sJ+zDyPuwGGRGNwWW5vQ==
 
 for-each@^0.3.5:
   version "0.3.5"
@@ -3426,7 +3594,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+graceful-fs@^4.1.2, graceful-fs@^4.1.5, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
@@ -3617,6 +3785,13 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-plain-object@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+  dependencies:
+    isobject "^3.0.1"
+
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
@@ -3662,6 +3837,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+isobject@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+  integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.2:
   version "3.2.2"
@@ -3727,6 +3907,30 @@ js-yaml@^4.1.1:
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
+
+jscodeshift@^17.3.0:
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/jscodeshift/-/jscodeshift-17.3.0.tgz#b9ea1d8d1c9255103bfc4cb42ddb46e18cb2415c"
+  integrity sha512-LjFrGOIORqXBU+jwfC9nbkjmQfFldtMIoS6d9z2LG/lkmyNXsJAySPT+2SWXJEoE68/bCWcxKpXH37npftgmow==
+  dependencies:
+    "@babel/core" "^7.24.7"
+    "@babel/parser" "^7.24.7"
+    "@babel/plugin-transform-class-properties" "^7.24.7"
+    "@babel/plugin-transform-modules-commonjs" "^7.24.7"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.24.7"
+    "@babel/plugin-transform-optional-chaining" "^7.24.7"
+    "@babel/plugin-transform-private-methods" "^7.24.7"
+    "@babel/preset-flow" "^7.24.7"
+    "@babel/preset-typescript" "^7.24.7"
+    "@babel/register" "^7.24.6"
+    flow-parser "0.*"
+    graceful-fs "^4.2.4"
+    micromatch "^4.0.7"
+    neo-async "^2.5.0"
+    picocolors "^1.0.1"
+    recast "^0.23.11"
+    tmp "^0.2.3"
+    write-file-atomic "^5.0.1"
 
 jsdoc-type-pratt-parser@^4.0.0:
   version "4.8.0"
@@ -3797,6 +4001,11 @@ keyv@^4.5.4:
   integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
   dependencies:
     json-buffer "3.0.1"
+
+kind-of@^6.0.2:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
+  integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
 
 levn@^0.4.1:
   version "0.4.1"
@@ -3895,6 +4104,14 @@ load-tsconfig@^0.2.3:
   resolved "https://registry.yarnpkg.com/load-tsconfig/-/load-tsconfig-0.2.5.tgz#453b8cd8961bfb912dea77eb6c168fe8cca3d3a1"
   integrity sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==
 
+locate-path@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-3.0.0.tgz#dbec3b3ab759758071b58fe59fc41871af21400e"
+  integrity sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+  dependencies:
+    p-locate "^3.0.0"
+    path-exists "^3.0.0"
+
 locate-path@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
@@ -3986,6 +4203,14 @@ magicast@^0.3.5:
     "@babel/types" "^7.25.4"
     source-map-js "^1.2.0"
 
+make-dir@^2.0.0, make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
+
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -4020,7 +4245,7 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.8:
+micromatch@^4.0.7, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -4096,6 +4321,11 @@ natural-compare@^1.4.0:
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
+neo-async@^2.5.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
 next@^15.0.0:
   version "15.5.12"
   resolved "https://registry.yarnpkg.com/next/-/next-15.5.12.tgz#af68c24b6f5535fcf37dbb913194db02c4d0a3ec"
@@ -4160,7 +4390,7 @@ p-filter@^2.1.0:
   dependencies:
     p-map "^2.0.0"
 
-p-limit@^2.2.0:
+p-limit@^2.0.0, p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -4173,6 +4403,13 @@ p-limit@^3.0.2:
   integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
   dependencies:
     yocto-queue "^0.1.0"
+
+p-locate@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
+  integrity sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+  dependencies:
+    p-limit "^2.0.0"
 
 p-locate@^4.1.0:
   version "4.1.0"
@@ -4224,6 +4461,11 @@ parse5@^8.0.0:
   dependencies:
     entities "^6.0.0"
 
+path-exists@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
+  integrity sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==
+
 path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
@@ -4267,7 +4509,7 @@ pathval@^2.0.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
   integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
-picocolors@^1.0.0, picocolors@^1.1.0, picocolors@^1.1.1:
+picocolors@^1.0.0, picocolors@^1.0.1, picocolors@^1.1.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -4287,10 +4529,17 @@ pify@^4.0.1:
   resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pirates@^4.0.1:
+pirates@^4.0.1, pirates@^4.0.6:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/pirates/-/pirates-4.0.7.tgz#643b4a18c4257c8a65104b73f3049ce9a0a15e22"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkg-dir@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-3.0.0.tgz#2749020f239ed990881b1f71210d51eb6523bea3"
+  integrity sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==
+  dependencies:
+    find-up "^3.0.0"
 
 pkg-types@^1.3.1:
   version "1.3.1"
@@ -4466,7 +4715,7 @@ readdirp@^4.0.1:
   resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
   integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
-recast@^0.23.5:
+recast@^0.23.11, recast@^0.23.5:
   version "0.23.11"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.23.11.tgz#8885570bb28cf773ba1dc600da7f502f7883f73f"
   integrity sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==
@@ -4586,6 +4835,11 @@ scheduler@^0.27.0:
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
   integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
+semver@^5.6.0:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
 semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -4607,6 +4861,13 @@ set-function-length@^1.2.2:
     get-intrinsic "^1.2.4"
     gopd "^1.0.1"
     has-property-descriptors "^1.0.2"
+
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
 
 sharp@^0.34.3:
   version "0.34.5"
@@ -4679,15 +4940,23 @@ source-map-js@^1.0.1, source-map-js@^1.0.2, source-map-js@^1.2.0, source-map-js@
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+source-map-support@^0.5.16:
+  version "0.5.21"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.21.tgz#04fe7c7f9e1ed2d662233c28cb2b35b9f63f6e4f"
+  integrity sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
+source-map@^0.6.0, source-map@~0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 source-map@^0.7.6:
   version "0.7.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.6.tgz#a3658ab87e5b6429c8a1f3ba0083d4c61ca3ef02"
   integrity sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==
-
-source-map@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
-  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spawndamnit@^3.0.1:
   version "3.0.1"
@@ -4908,6 +5177,11 @@ tldts@^7.0.5:
   integrity sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==
   dependencies:
     tldts-core "^7.0.19"
+
+tmp@^0.2.3:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
+  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -5208,6 +5482,14 @@ wrap-ansi@^8.1.0:
     ansi-styles "^6.1.0"
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
+
+write-file-atomic@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.1.tgz#68df4717c55c6fa4281a7860b4c2ba0a6d2b11e7"
+  integrity sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==
+  dependencies:
+    imurmurhash "^0.1.4"
+    signal-exit "^4.0.1"
 
 ws@^8.18.3, ws@^8.2.3:
   version "8.19.0"


### PR DESCRIPTION
## What

Adds an `xds upgrade` CLI command that runs version-to-version codemods using jscodeshift to automate API migrations. Also adds the upgrade command to the agent docs injection so LLMs know to run codemods after version bumps.

## CLI Usage

```bash
# Dry run (default) — shows what would change
npx xds upgrade

# Apply changes
npx xds upgrade --apply

# Target a specific version
npx xds upgrade --to 0.0.2

# Run a single codemod
npx xds upgrade --codemod rename-selector-items-to-options

# Scan a custom directory
npx xds upgrade --path ./app

# List available codemods
npx xds upgrade --list
```

## How it works

1. Detects the consumer's `@xds/core` version from their `package.json`
2. Resolves which codemods need to run between current → target version
3. Lazy-installs `jscodeshift` on first use (keeps the CLI lean — no heavy deps by default)
4. Runs transforms against source files, reporting changes
5. In dry-run mode (default), shows what would change without writing files

## v0.0.2 Transforms

| Codemod | What it does | PR |
|---------|-------------|-----|
| `rename-selector-items-to-options` | `XDSSelector`: `items` → `options` | #479 |
| `unify-visibility-to-onOpenChange` | Renames `onHide`, `onClose`, `onToggle`, `onMenuToggle`, `onShow` → `onOpenChange` across 9 components | #473 |
| `unify-uncontrolled-to-defaultX` | `initialIsSideNavCollapsed` → `defaultIsSideNavCollapsed`, `initialIsOpen` → `defaultIsOpen`, `initialIsExpanded` → `defaultIsExpanded` | #470 |
| `rename-banner-endButton-to-endContent` | `XDSBanner`: `endButton` → `endContent` | #437 |
| `rename-form-tooltip-startIcon` | Form fields: `tooltip` → `labelTooltip`, `startIcon` → `labelIcon` (7 components) | #375 |
| `rename-isShown-to-isOpen` | `XDSDialog`, `XDSCommandPalette`, `XDSPopover`: `isShown` → `isOpen` | #472 |

### Visibility codemod details

The `unify-visibility-to-onOpenChange` transform handles the most complex case:

- **Simple renames** (1:1): `XDSDialog.onHide`, `XDSDialogHeader.onHide`, `XDSCommandPalette.onHide`, `XDSMobileNav.onClose`, `XDSDropdownMenu.onMenuToggle`, `XDSPopover.onToggle`, `XDSCollapsibleGroup.onToggle`
- **Merge handling** (XDSHoverCard, XDSTooltip): If only `onShow` or only `onHide` exists, renames to `onOpenChange`. If both exist, adds a TODO comment and leaves them for manual resolution.

## Agent docs update

Added `npx xds upgrade` and `npx xds upgrade --apply` to the compressed index injected into AGENTS.md/CLAUDE.md, with a RULE:

> After bumping @xds/core version, ALWAYS run npx xds upgrade --apply to migrate breaking API changes.

## Architecture

```
packages/cli/src/
├── commands/
│   └── upgrade.mjs              # CLI command (Commander)
└── codemods/
    ├── registry.mjs              # Version → transforms mapping
    ├── runner.mjs                # Orchestration: glob, run, report
    ├── ensure-jscodeshift.mjs    # Lazy-install on first use
    └── transforms/
        └── v0.0.2/
            ├── index.mjs         # Manifest
            ├── 6 transform files
            └── __tests__/
                └── 6 test files (61 tests total)
```

## Adding future codemods

To add codemods for a new version:

1. Create `transforms/v{X.Y.Z}/` with transform files and an `index.mjs` manifest
2. Add the version to `registry.mjs`
3. The upgrade command automatically picks up new versions

## Tests

61 tests covering all 6 transforms — positive cases, negative cases (non-XDS components), edge cases, and undefined-return-on-no-change verification.

Closes #484

---
*Crafted with care by Navi*