### PR TITLE
fix(vibe-tests): use unique temp dirs for preview builds

### DIFF
--- a/internal/vibe-tests/.gitignore
+++ b/internal/vibe-tests/.gitignore
@@ -14,3 +14,7 @@ AGENTS.html.md
 
 # Test results (generated)
 results/
+
+# Preview build temp dirs
+.preview-tmp*
+.baseline-shims/

--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -12,6 +12,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as crypto from 'node:crypto';
 import {execSync} from 'node:child_process';
 import {getResultsDir, ensureDir, readJson, writeJson} from './utils.js';
 
@@ -500,8 +501,12 @@ function buildPreview(
   promptId: string,
   outPath: string,
 ): boolean {
-  const tmpDir = path.join(VIBE_DIR, '.preview-tmp');
-  if (fs.existsSync(tmpDir)) fs.rmSync(tmpDir, {recursive: true});
+  // Use a unique temp directory per build to prevent race conditions
+  // when multiple build-previews processes run concurrently
+  const tmpDir = path.join(
+    VIBE_DIR,
+    `.preview-tmp-${crypto.randomUUID()}`,
+  );
   ensureDir(tmpDir);
 
   try {


### PR DESCRIPTION
## Problem

Preview files in vibe test reports sometimes show the wrong component or wrong target. For example:
- `wd-2/xds.html` renders `cwm-3`'s component instead of the form wizard
- `dd-5/xds.html` has title `dd-5 — baseline` (wrong target)

## Root Cause

`buildPreview()` uses a shared `.preview-tmp` directory for all Vite builds. When multiple `build-previews` processes run concurrently (e.g. from parallel sub-agents or overlapping Night Watch triggers), they race on the same temp directory — one build's `entry.tsx` and `index.html` get overwritten by another before Vite picks them up.

Confirmed via file timestamps: `cwm-3/xds.html` and `wd-2/xds.html` were written in the same second, proving concurrent execution.

## Fix

Use `crypto.randomUUID()` to create a unique temp directory per build invocation (`.preview-tmp-<uuid>`), eliminating the shared-state race condition.

Also adds `.preview-tmp*` and `.baseline-shims/` to `.gitignore`.

## Testing

This was discovered investigating issue #488 (March 6 vibe test). The fix is straightforward — no shared state means no race.