### PR TITLE
feat: extract XDSKbd as standalone component

### DIFF
--- a/apps/storybook/stories/Kbd.stories.tsx
+++ b/apps/storybook/stories/Kbd.stories.tsx
@@ -1,0 +1,71 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSKbd} from '@xds/core/Kbd';
+
+const meta: Meta<typeof XDSKbd> = {
+  title: 'Core/XDSKbd',
+  component: XDSKbd,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSKbd>;
+
+/**
+ * Single modifier + key shortcut.
+ */
+export const Basic: Story = {
+  args: {
+    keys: 'mod+k',
+  },
+};
+
+/**
+ * Multi-modifier shortcut.
+ */
+export const MultiModifier: Story = {
+  args: {
+    keys: 'mod+shift+p',
+  },
+};
+
+/**
+ * Common keyboard shortcuts displayed together.
+ */
+export const CommonShortcuts: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: 24}}>
+      <XDSKbd keys="mod+c" />
+      <XDSKbd keys="mod+v" />
+      <XDSKbd keys="mod+s" />
+      <XDSKbd keys="mod+z" />
+    </div>
+  ),
+};
+
+/**
+ * Special keys like Enter, Escape, Tab, and arrow keys.
+ */
+export const SpecialKeys: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: 16}}>
+      <XDSKbd keys="enter" />
+      <XDSKbd keys="escape" />
+      <XDSKbd keys="tab" />
+      <XDSKbd keys="up" />
+      <XDSKbd keys="down" />
+      <XDSKbd keys="backspace" />
+    </div>
+  ),
+};
+
+/**
+ * Single key without modifiers.
+ */
+export const SingleKey: Story = {
+  args: {
+    keys: 'k',
+  },
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -160,6 +160,12 @@
       "import": "./dist/Icon/index.mjs",
       "require": "./dist/Icon/index.js"
     },
+    "./Kbd": {
+      "source": "./src/Kbd/index.ts",
+      "types": "./dist/Kbd/index.d.ts",
+      "import": "./dist/Kbd/index.mjs",
+      "require": "./dist/Kbd/index.js"
+    },
     "./Layer": {
       "source": "./src/Layer/index.ts",
       "types": "./dist/Layer/index.d.ts",

--- a/packages/core/src/Kbd/XDSKbd.test.tsx
+++ b/packages/core/src/Kbd/XDSKbd.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * @file XDSKbd.test.tsx
+ * @input Uses React Testing Library, XDSKbd
+ * @output Tests for XDSKbd component
+ */
+
+import {render, screen} from '@testing-library/react';
+import {XDSKbd} from './XDSKbd';
+
+describe('XDSKbd', () => {
+  it('renders a single key', () => {
+    render(<XDSKbd keys="k" />);
+    const kbd = screen.getByText('K');
+    expect(kbd.tagName).toBe('KBD');
+  });
+
+  it('renders multiple keys separated by +', () => {
+    render(<XDSKbd keys="mod+k" />);
+    // mod should render as ⌘
+    expect(screen.getByText('\u2318')).toBeInTheDocument();
+    expect(screen.getByText('K')).toBeInTheDocument();
+  });
+
+  it('maps modifier keys to symbols', () => {
+    render(<XDSKbd keys="ctrl+alt+shift+k" />);
+    expect(screen.getByText('\u2303')).toBeInTheDocument(); // ⌃
+    expect(screen.getByText('\u2325')).toBeInTheDocument(); // ⌥
+    expect(screen.getByText('\u21E7')).toBeInTheDocument(); // ⇧
+    expect(screen.getByText('K')).toBeInTheDocument();
+  });
+
+  it('maps special keys', () => {
+    render(<XDSKbd keys="enter" />);
+    expect(screen.getByText('\u21B5')).toBeInTheDocument(); // ↵
+  });
+
+  it('renders escape as text', () => {
+    render(<XDSKbd keys="escape" />);
+    expect(screen.getByText('Esc')).toBeInTheDocument();
+  });
+
+  it('is aria-hidden', () => {
+    const {container} = render(<XDSKbd keys="mod+k" />);
+    const wrapper = container.firstChild as HTMLElement;
+    expect(wrapper.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('uppercases unknown keys', () => {
+    render(<XDSKbd keys="f1" />);
+    expect(screen.getByText('F1')).toBeInTheDocument();
+  });
+
+  it('handles whitespace around keys', () => {
+    render(<XDSKbd keys="mod + k" />);
+    expect(screen.getByText('\u2318')).toBeInTheDocument();
+    expect(screen.getByText('K')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -1,0 +1,112 @@
+/**
+ * @file XDSKbd.tsx
+ * @input Uses React, StyleX, theme tokens
+ * @output Exports XDSKbd component and XDSKbdProps
+ * @position Core implementation; renders styled keyboard shortcut indicators
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Kbd/README.md
+ * - /packages/core/src/Kbd/index.ts
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  textSizeVars,
+  typographyVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+
+const styles = stylex.create({
+  wrapper: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    flexShrink: 0,
+  },
+  kbd: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    minWidth: '20px',
+    height: '20px',
+    paddingInline: spacingVars['--spacing-1'],
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-wash'],
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    lineHeight: lineHeightVars['--leading-tight'],
+    userSelect: 'none',
+  },
+});
+
+/**
+ * Map of modifier key names to display symbols.
+ */
+const KEY_DISPLAY: Record<string, string> = {
+  mod: '\u2318', // ⌘
+  ctrl: '\u2303', // ⌃
+  alt: '\u2325', // ⌥
+  shift: '\u21E7', // ⇧
+  enter: '\u21B5', // ↵
+  backspace: '\u232B', // ⌫
+  escape: 'Esc',
+  tab: '\u21E5', // ⇥
+  up: '\u2191',
+  down: '\u2193',
+  left: '\u2190',
+  right: '\u2192',
+};
+
+export interface XDSKbdProps {
+  /**
+   * Keyboard shortcut string. Use "+" to separate keys.
+   * Special keys: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape.
+   *
+   * @example
+   * ```
+   * "mod+k"
+   * "mod+shift+p"
+   * "enter"
+   * ```
+   */
+  keys: string;
+
+  /**
+   * StyleX overrides for the wrapper element.
+   */
+  xstyle?: StyleXStyles;
+}
+
+/**
+ * Displays a keyboard shortcut as styled <kbd> elements.
+ *
+ * A general-purpose component for rendering keyboard shortcuts
+ * anywhere in the system — tooltips, menus, documentation, etc.
+ *
+ * @example
+ * ```
+ * <XDSKbd keys="mod+k" />
+ * ```
+ */
+export function XDSKbd({keys, xstyle}: XDSKbdProps) {
+  const parts = keys.split('+').map(key => key.trim().toLowerCase());
+
+  return (
+    <span {...stylex.props(styles.wrapper, xstyle)} aria-hidden="true">
+      {parts.map((key, i) => (
+        <kbd key={i} {...stylex.props(styles.kbd)}>
+          {KEY_DISPLAY[key] ?? key.toUpperCase()}
+        </kbd>
+      ))}
+    </span>
+  );
+}
+
+XDSKbd.displayName = 'XDSKbd';

--- a/packages/core/src/Kbd/index.ts
+++ b/packages/core/src/Kbd/index.ts
@@ -1,0 +1,9 @@
+/**
+ * @file index.ts
+ * @input Imports XDSKbd component and types
+ * @output Exports public API for @xds/core Kbd
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ */
+
+export {XDSKbd} from './XDSKbd';
+export type {XDSKbdProps} from './XDSKbd';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export * from './Grid';
 export * from './Section';
 export * from './Selector';
 export * from './Icon';
+export * from './Kbd';
 export * from './Text';
 export * from './TextInput';
 export * from './TabList';


### PR DESCRIPTION
Extracts keyboard shortcut rendering from CommandPalette into a general-purpose `XDSKbd` component. This is a prerequisite for the CommandPalette surface area cleanup — landing it separately keeps that PR clean.

## What

`XDSKbd` renders keyboard shortcuts as styled `<kbd>` elements with platform-appropriate modifier symbols (⌘, ⌃, ⌥, ⇧, etc.). Useful anywhere shortcuts need to be displayed — command palettes, tooltips, menus, documentation.

## Files

| File | Purpose |
|------|---------|
| `packages/core/src/Kbd/XDSKbd.tsx` | Component implementation |
| `packages/core/src/Kbd/XDSKbd.test.tsx` | 8 tests |
| `packages/core/src/Kbd/index.ts` | Public exports |
| `packages/core/src/index.ts` | Re-export from core barrel |
| `packages/core/package.json` | Subpath export (via sync-exports) |
| `apps/storybook/stories/Kbd.stories.tsx` | Story with autodocs |

## API

```tsx
<XDSKbd keys="mod+k" />       // ⌘ K
<XDSKbd keys="mod+shift+p" /> // ⌘ ⇧ P
<XDSKbd keys="escape" />      // Esc
```

Props: `keys: string`, `xstyle?: StyleXStyles`. Always `aria-hidden` (decorative).

---
