### PR TITLE
docs: fix storybook docblock compat and README titles

### DIFF
--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -108,32 +108,11 @@ export interface XDSFormLayoutProps extends Omit<
  * Supports nesting — a horizontal layout inside a vertical layout works naturally.
  *
  * @example
- * ```tsx
- * // Vertical (default) — simple form
+ * ```
  * <XDSFormLayout>
  *   <XDSTextInput label="Name" value={name} onChange={setName} />
  *   <XDSTextInput label="Email" value={email} onChange={setEmail} />
  * </XDSFormLayout>
- *
- * // Horizontal — related fields side by side
- * <XDSFormLayout direction="horizontal">
- *   <XDSTextInput label="First Name" value={first} onChange={setFirst} />
- *   <XDSTextInput label="Last Name" value={last} onChange={setLast} />
- * </XDSFormLayout>
- *
- * // Horizontal labels — settings panel pattern
- * <XDSFormLayout direction="horizontal-labels">
- *   <XDSTextInput label="Display Name" value={name} onChange={setName} />
- *   <XDSSelector label="Timezone" value={tz} onChange={setTz} options={tzs} />
- * </XDSFormLayout>
- *
- * // Dialog composition via HTML form attribute
- * <form id="edit-form" onSubmit={handleSubmit}>
- *   <XDSFormLayout>
- *     <XDSTextInput label="Name" value={name} onChange={setName} />
- *   </XDSFormLayout>
- * </form>
- * <XDSButton label="Save" type="submit" form="edit-form" />
  * ```
  */
 export const XDSFormLayout = forwardRef<HTMLDivElement, XDSFormLayoutProps>(

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -235,11 +235,7 @@ export interface XDSMobileNavProps {
  * No manual z-index needed — the browser's top layer handles stacking.
  *
  * @example
- * ```tsx
- * const [isOpen, setIsOpen] = useState(false);
- *
- * <XDSButton label="Menu" onClick={() => setIsOpen(true)} />
- *
+ * ```
  * <XDSMobileNav
  *   isOpen={isOpen}
  *   onOpenChange={(open) => setIsOpen(open)}

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -302,40 +302,12 @@ export function generatePageRange(
  * or cursor-based pagination.
  *
  * @example
- * ```tsx
- * // Page number buttons (default)
+ * ```
  * <XDSPagination
  *   page={page}
  *   onChange={setPage}
  *   totalItems={200}
  *   pageSize={20}
- * />
- *
- * // Count display below a table
- * <XDSPagination
- *   page={page}
- *   onChange={setPage}
- *   totalItems={200}
- *   pageSize={20}
- *   variant="count"
- *   pageSizeOptions={[10, 20, 50]}
- *   onPageSizeChange={setPageSize}
- *   size="sm"
- * />
- *
- * // Cursor-based (no total known)
- * <XDSPagination
- *   page={page}
- *   onChange={setPage}
- *   hasMore={data.hasNextPage}
- * />
- *
- * // Carousel dots
- * <XDSPagination
- *   page={slideIndex}
- *   onChange={setSlideIndex}
- *   totalPages={slides.length}
- *   variant="dots"
  * />
  * ```
  */

--- a/packages/core/src/Tokenizer/README.md
+++ b/packages/core/src/Tokenizer/README.md
@@ -1,4 +1,4 @@
-# /packages/core/src/Tokenizer
+# Tokenizer
 
 Multi-select typeahead with token chips for selected items.
 

--- a/packages/core/src/Typeahead/README.md
+++ b/packages/core/src/Typeahead/README.md
@@ -1,4 +1,4 @@
-# /packages/core/src/Typeahead
+# Typeahead
 
 Searchable dropdown components for single-item selection with keyboard navigation.
 


### PR DESCRIPTION
## What

Fixes Storybook autodocs compatibility and README title format issues found during Night Watch doc review.

### Storybook compat
- **FormLayout, MobileNav, Pagination**: `@example` blocks used ````tsx``` language tag — Storybook autodocs parser chokes on it. Changed to bare ```````.
- Consolidated multiple examples to single concise example per component (Storybook renders one block per `@example`).

### README titles
- **Tokenizer**: `# /packages/core/src/Tokenizer` → `# Tokenizer`
- **Typeahead**: `# /packages/core/src/Typeahead` → `# Typeahead`

Source path prefixes in titles leak into CLI output and confuse LLMs into generating bad imports (see #310).

## Checklist
- [x] No ````tsx``` in docblocks
- [x] Single concise `@example` per component
- [x] README titles use component name only

---
*Found during Night Watch doc review*