### PR TITLE
fix(storybook): sync color-scheme to document root for dark mode toggle

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -21,12 +21,25 @@ const themes = {
 };
 
 /**
- * Decorator that wraps all stories in the XDS Theme provider
+ * Decorator that wraps all stories in the XDS Theme provider.
+ *
+ * Sets `color-scheme` on the document root so that CSS `light-dark()`
+ * resolves correctly at every level of the page — not just inside the
+ * XDSTheme wrapper div.  Without this, the iframe's `<html>` and
+ * `<body>` keep the browser-default `color-scheme` (typically "light")
+ * and toggling the toolbar has no visible effect.
  */
 const withXDSTheme: Decorator = (Story, context) => {
   // Get theme selection from toolbar
   const themeKey = (context.globals?.xdsTheme || 'default') as string;
   const mode = context.globals?.colorMode === 'dark' ? 'dark' : 'light';
+
+  // Sync color-scheme to the document root so light-dark() works
+  // everywhere, including on <html>/<body> backgrounds and any
+  // elements rendered outside the XDSTheme wrapper.
+  React.useEffect(() => {
+    document.documentElement.style.setProperty('color-scheme', mode);
+  }, [mode]);
 
   // No theme — render with just base defineVars defaults
   if (themeKey === 'none') {


### PR DESCRIPTION
## Problem

The dark/light mode toggle in Storybook's toolbar does nothing — clicking it has no visible effect on the page theme.

Fixes #433

## Root Cause

XDS tokens use CSS `light-dark()` which resolves based on the `color-scheme` property. `XDSTheme` sets `color-scheme` on a wrapper `<div>` with `display: contents`, but the Storybook iframe's `<html>` element keeps the browser default (`color-scheme: normal`, which resolves as `light`). Since `light-dark()` resolves per-element based on the computed `color-scheme`, the page-level background and any elements outside the wrapper never switch.

## Fix

Add a `useEffect` in the Storybook decorator that sets `color-scheme` on `document.documentElement` whenever the toolbar mode changes. This ensures `light-dark()` resolves correctly at every level of the document — not just inside the XDSTheme wrapper.

## Verification

- `yarn storybook:build` — builds successfully
- `yarn test` — all 1360 tests pass

---
