### PR TITLE
feat(core): add XDSCommandPalette dialog shell

### DIFF
--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -1,0 +1,167 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSCommandPalette} from '@xds/core/CommandPalette';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText} from '@xds/core/Text';
+import {XDSDivider} from '@xds/core/Divider';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  input: {
+    width: '100%',
+    padding: '12px 16px',
+    border: 'none',
+    outline: 'none',
+    fontSize: '16px',
+    backgroundColor: 'transparent',
+    color: 'inherit',
+    fontFamily: 'inherit',
+  },
+  list: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: '8px',
+  },
+  item: {
+    padding: '8px 12px',
+    borderRadius: '6px',
+    cursor: 'pointer',
+  },
+  footer: {
+    padding: '8px 16px',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: '8px',
+  },
+});
+
+const meta: Meta<typeof XDSCommandPalette> = {
+  title: 'Core/XDSCommandPalette',
+  component: XDSCommandPalette,
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: {
+      control: 'boolean',
+      description: 'Whether the command palette is open',
+    },
+    width: {
+      control: 'number',
+      description: 'Width of the dialog',
+    },
+    maxHeight: {
+      control: 'number',
+      description: 'Maximum height of the dialog',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCommandPalette>;
+
+/**
+ * The command palette dialog shell with placeholder content.
+ * This demonstrates the structural layout — input, list, and footer slots.
+ */
+export const Default: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <XDSButton
+          label="Open Command Palette"
+          onClick={() => setIsOpen(true)}
+        />
+        <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+          <input
+            placeholder="Type a command..."
+            {...stylex.props(styles.input)}
+          />
+          <XDSDivider />
+          <div {...stylex.props(styles.list)}>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Go to Dashboard</XDSText>
+            </div>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Search Files</XDSText>
+            </div>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Toggle Dark Mode</XDSText>
+            </div>
+          </div>
+          <XDSDivider />
+          <div {...stylex.props(styles.footer)}>
+            <XDSText type="body" size="sm" color="secondary">
+              ESC to close
+            </XDSText>
+          </div>
+        </XDSCommandPalette>
+      </>
+    );
+  },
+};
+
+/**
+ * Empty state — just the dialog shell with no content.
+ */
+export const Empty: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <XDSButton label="Open Empty Palette" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+          <input
+            placeholder="No commands registered..."
+            {...stylex.props(styles.input)}
+          />
+          <XDSDivider />
+          <div {...stylex.props(styles.list)}>
+            <XDSText type="body" color="secondary">
+              No results found
+            </XDSText>
+          </div>
+        </XDSCommandPalette>
+      </>
+    );
+  },
+};
+
+/**
+ * Custom dimensions — narrower and shorter.
+ */
+export const CustomSize: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <XDSButton label="Open Small Palette" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          width={400}
+          maxHeight={300}>
+          <input
+            placeholder="Quick search..."
+            {...stylex.props(styles.input)}
+          />
+          <XDSDivider />
+          <div {...stylex.props(styles.list)}>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Option A</XDSText>
+            </div>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Option B</XDSText>
+            </div>
+          </div>
+        </XDSCommandPalette>
+      </>
+    );
+  },
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -107,6 +107,12 @@
       "import": "./dist/DateInput/index.mjs",
       "require": "./dist/DateInput/index.js"
     },
+    "./CommandPalette": {
+      "source": "./src/CommandPalette/index.ts",
+      "types": "./dist/CommandPalette/index.d.ts",
+      "import": "./dist/CommandPalette/index.mjs",
+      "require": "./dist/CommandPalette/index.js"
+    },
     "./Dialog": {
       "source": "./src/Dialog/index.ts",
       "types": "./dist/Dialog/index.d.ts",

--- a/packages/core/src/CommandPalette/CommandPalette.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPalette.doc.mjs
@@ -1,0 +1,68 @@
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'CommandPalette',
+  description:
+    'A modal dialog shell for command palette interfaces. Provides the structural container with composable slots for input, list, and footer areas.',
+  features: [
+    'Dialog shell: Wraps XDSDialog with command palette defaults (640×480, centered, info purpose)',
+    'Composable slots: Children render as a flex column — input at top, scrollable list in middle, footer at bottom',
+    'Accessible: Uses native <dialog> with aria-label for screen readers',
+    'Keyboard dismissal: Escape key closes the palette (inherited from XDSDialog purpose="info")',
+    'Configurable size: width and maxHeight props for custom dimensions',
+  ],
+  examples: [
+    {
+      label: 'Basic command palette',
+      code: `import {XDSCommandPalette} from '@xds/core/CommandPalette';
+import {useState} from 'react';
+
+function Example() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+      <input placeholder="Type a command..." />
+      <div>List of commands</div>
+    </XDSCommandPalette>
+  );
+}`,
+    },
+  ],
+  props: {
+    isOpen: {
+      type: 'boolean',
+      required: true,
+      description: 'Whether the command palette is open.',
+    },
+    onOpenChange: {
+      type: '(isOpen: boolean) => void',
+      required: true,
+      description:
+        'Called when the palette visibility changes. Called with false on Escape or backdrop click.',
+    },
+    label: {
+      type: 'string',
+      default: "'Command palette'",
+      description: 'Accessible label for the dialog.',
+    },
+    width: {
+      type: 'number | string',
+      default: '640',
+      description:
+        'Width of the dialog. Numbers are pixels, strings are CSS values.',
+    },
+    maxHeight: {
+      type: 'number | string',
+      default: '480',
+      description:
+        'Maximum height of the dialog. Numbers are pixels, strings are CSS values.',
+    },
+    children: {
+      type: 'ReactNode',
+      required: true,
+      description:
+        'Composable sub-components: input, list, footer, etc.',
+    },
+  },
+};

--- a/packages/core/src/CommandPalette/README.md
+++ b/packages/core/src/CommandPalette/README.md
@@ -1,0 +1,34 @@
+# CommandPalette
+
+Command palette dialog for quick access to commands, navigation, and search.
+
+## Architecture
+
+The command palette is built incrementally as composable pieces:
+
+1. **XDSCommandPalette** — Dialog shell with flex column layout (this PR)
+2. **XDSCommandPaletteInput** — Search input with icon (planned)
+3. **XDSCommandPaletteList / Item / Group** — Scrollable item list (planned)
+4. **XDSCommandPaletteFooter** — Keyboard shortcut hints (planned)
+5. **CommandPaletteContext** — State management provider (planned)
+
+## Files
+
+| File                         | Purpose                     |
+| ---------------------------- | --------------------------- |
+| `XDSCommandPalette.tsx`      | Root dialog shell component |
+| `index.ts`                   | Public exports              |
+| `README.md`                  | This file                   |
+| `XDSCommandPalette.test.tsx` | Unit tests                  |
+
+## Usage
+
+```tsx
+import {XDSCommandPalette} from '@xds/core/CommandPalette';
+
+const [isOpen, setIsOpen] = useState(false);
+
+<XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+  {/* Sub-components go here */}
+</XDSCommandPalette>;
+```

--- a/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @file XDSCommandPalette.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSCommandPalette
+ * @output Unit tests for XDSCommandPalette dialog shell
+ * @position Testing; validates XDSCommandPalette.tsx implementation
+ *
+ * SYNC: When XDSCommandPalette.tsx changes, update tests to match
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSCommandPalette} from './XDSCommandPalette';
+
+// Mock showModal and close since jsdom doesn't implement them
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+describe('XDSCommandPalette', () => {
+  it('renders when isOpen is true', () => {
+    render(
+      <XDSCommandPalette isOpen={true} onOpenChange={() => {}}>
+        <div>Content</div>
+      </XDSCommandPalette>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('does not show content when isOpen is false', () => {
+    render(
+      <XDSCommandPalette isOpen={false} onOpenChange={() => {}}>
+        <div>Hidden</div>
+      </XDSCommandPalette>,
+    );
+    const dialog = screen.getByRole('dialog', {hidden: true});
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('has correct aria-label', () => {
+    render(
+      <XDSCommandPalette isOpen={true} onOpenChange={() => {}}>
+        <div>Content</div>
+      </XDSCommandPalette>,
+    );
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-label',
+      'Command palette',
+    );
+  });
+
+  it('supports custom label', () => {
+    render(
+      <XDSCommandPalette
+        isOpen={true}
+        onOpenChange={() => {}}
+        label="Quick search">
+        <div>Content</div>
+      </XDSCommandPalette>,
+    );
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-label',
+      'Quick search',
+    );
+  });
+
+  it('renders children as composable slots', () => {
+    render(
+      <XDSCommandPalette isOpen={true} onOpenChange={() => {}}>
+        <div data-testid="input-slot">Input</div>
+        <div data-testid="list-slot">List</div>
+        <div data-testid="footer-slot">Footer</div>
+      </XDSCommandPalette>,
+    );
+    expect(screen.getByTestId('input-slot')).toBeInTheDocument();
+    expect(screen.getByTestId('list-slot')).toBeInTheDocument();
+    expect(screen.getByTestId('footer-slot')).toBeInTheDocument();
+  });
+
+  it('calls onOpenChange(false) when Escape is pressed', () => {
+    const handleOpenChange = vi.fn();
+
+    render(
+      <XDSCommandPalette isOpen={true} onOpenChange={handleOpenChange}>
+        <div>Content</div>
+      </XDSCommandPalette>,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const escapeEvent = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    dialog.dispatchEvent(escapeEvent);
+
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -1,0 +1,137 @@
+/**
+ * @file XDSCommandPalette.tsx
+ * @input Uses React, StyleX, XDSDialog
+ * @output Exports XDSCommandPalette root component and props
+ * @position Core root component; dialog shell with slots for sub-components
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ * - /apps/storybook/stories/CommandPalette.stories.tsx
+ */
+
+'use client';
+
+import {type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSDialog} from '../Dialog';
+
+const styles = stylex.create({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    overflow: 'hidden',
+  },
+});
+
+// =============================================================================
+// Module Augmentation - Register CommandPalette's style surfaces
+// =============================================================================
+
+declare module '../theme/types' {
+  interface ComponentStyles {
+    commandPalette?: {
+      root?: import('../theme/types').StyleXStyles;
+    };
+  }
+}
+
+export interface XDSCommandPaletteProps {
+  /**
+   * Whether the command palette is open.
+   */
+  isOpen: boolean;
+
+  /**
+   * Called when the command palette visibility changes.
+   * Called with `false` when the palette requests to close
+   * (via Escape key or backdrop click).
+   */
+  onOpenChange: (isOpen: boolean) => void;
+
+  /**
+   * Accessible label for the command palette dialog.
+   * @default 'Command palette'
+   */
+  label?: string;
+
+  /**
+   * Width of the command palette dialog.
+   * Numbers are treated as pixels, strings are used as-is.
+   * @default 640
+   */
+  width?: number | string;
+
+  /**
+   * Maximum height of the command palette dialog.
+   * Numbers are treated as pixels, strings are used as-is.
+   * @default 480
+   */
+  maxHeight?: number | string;
+
+  /**
+   * Composable content slots.
+   * Typically includes XDSCommandPaletteInput, a list area, and XDSCommandPaletteFooter.
+   *
+   * @example
+   * ```
+   * <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+   *   <XDSCommandPaletteInput placeholder="Search commands..." />
+   *   <XDSCommandPaletteList>
+   *     <XDSCommandPaletteItem value="home">Go Home</XDSCommandPaletteItem>
+   *   </XDSCommandPaletteList>
+   *   <XDSCommandPaletteFooter />
+   * </XDSCommandPalette>
+   * ```
+   */
+  children: ReactNode;
+}
+
+/**
+ * Command palette dialog shell.
+ *
+ * A modal dialog pre-configured for command palette usage.
+ * Renders an XDSDialog with appropriate defaults (centered, info purpose,
+ * no close button) and a flex column layout for composable children.
+ *
+ * This component is purely structural — it provides the dialog container
+ * and layout. State management (search, filtering, selection, keyboard
+ * navigation) is handled by a separate context provider.
+ *
+ * @compositionHint Compose with XDSCommandPaletteInput (search),
+ *   XDSCommandPaletteList (scrollable items), and XDSCommandPaletteFooter
+ *   (keyboard hints) as children.
+ *
+ * @example
+ * ```
+ * const [isOpen, setIsOpen] = useState(false);
+ *
+ * <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+ *   <input placeholder="Type a command..." />
+ *   <div>Item list goes here</div>
+ * </XDSCommandPalette>
+ * ```
+ */
+export function XDSCommandPalette({
+  isOpen,
+  onOpenChange,
+  label = 'Command palette',
+  width = 640,
+  maxHeight = 480,
+  children,
+}: XDSCommandPaletteProps) {
+  return (
+    <XDSDialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      width={width}
+      maxHeight={maxHeight}
+      purpose="info"
+      aria-label={label}>
+      <div {...stylex.props(styles.wrapper)}>{children}</div>
+    </XDSDialog>
+  );
+}
+
+XDSCommandPalette.displayName = 'XDSCommandPalette';

--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input Imports XDSCommandPalette component and types
+ * @output Exports XDSCommandPalette and related types
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header
+ */
+
+export {XDSCommandPalette} from './XDSCommandPalette';
+export type {XDSCommandPaletteProps} from './XDSCommandPalette';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export * from './TreeList';
 
 // Keyboard shortcut display
 export * from './Kbd';
+export * from './CommandPalette';
 export * from './Dialog';
 export * from './DropdownMenu';
 export * from './MoreMenu';


### PR DESCRIPTION
## Summary

Adds the structural container for the command palette — a thin wrapper around XDSDialog with command palette defaults.

**PR 1 of 4** in the incremental command palette rebuild:
1. ✅ **Dialog shell** (this PR)
2. ⬜ Input component
3. ⬜ List, Item, Group, Footer
4. ⬜ Context provider (state management)

## What's included

- `XDSCommandPalette` — dialog wrapper with flex column layout for composable children
- Props: `isOpen`, `onOpenChange`, `width`, `maxHeight`, `label`, `children`
- 6 unit tests
- Storybook stories (Default, Empty, CustomSize)
- Doc file, README, package.json exports

## What's NOT included (intentionally)

- No state management / context
- No input, list, item, group, footer sub-components
- No filtering, keyboard navigation, or selection logic

Those come in follow-up PRs. This is just the shell.

## API

```tsx
<XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
  {/* Composable children go here */}
</XDSCommandPalette>
```

Follows XDS conventions: `isOpen`/`onOpenChange` (not `isShown`/`onHide`), `purpose="info"` for Escape + backdrop dismiss.