### PR TITLE
feat(core): add XDSCommandPaletteInput component

### DIFF
--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -1,22 +1,15 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSCommandPalette} from '@xds/core/CommandPalette';
+import {
+  XDSCommandPalette,
+  XDSCommandPaletteInput,
+} from '@xds/core/CommandPalette';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {XDSDivider} from '@xds/core/Divider';
 import * as stylex from '@stylexjs/stylex';
 
 const styles = stylex.create({
-  input: {
-    width: '100%',
-    padding: '12px 16px',
-    border: 'none',
-    outline: 'none',
-    fontSize: '16px',
-    backgroundColor: 'transparent',
-    color: 'inherit',
-    fontFamily: 'inherit',
-  },
   list: {
     flex: 1,
     overflowY: 'auto',
@@ -63,12 +56,24 @@ export default meta;
 type Story = StoryObj<typeof XDSCommandPalette>;
 
 /**
- * The command palette dialog shell with placeholder content.
- * This demonstrates the structural layout — input, list, and footer slots.
+ * The command palette with the real input component and placeholder list content.
  */
 export const Default: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
+    const [search, setSearch] = useState('');
+
+    const items = [
+      'Go to Dashboard',
+      'Search Files',
+      'Toggle Dark Mode',
+      'Open Settings',
+      'Create New File',
+    ];
+
+    const filtered = items.filter(item =>
+      item.toLowerCase().includes(search.toLowerCase()),
+    );
 
     return (
       <>
@@ -77,21 +82,24 @@ export const Default: Story = {
           onClick={() => setIsOpen(true)}
         />
         <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
-          <input
+          <XDSCommandPaletteInput
+            value={search}
+            onValueChange={setSearch}
             placeholder="Type a command..."
-            {...stylex.props(styles.input)}
           />
           <XDSDivider />
           <div {...stylex.props(styles.list)}>
-            <div {...stylex.props(styles.item)}>
-              <XDSText type="body">Go to Dashboard</XDSText>
-            </div>
-            <div {...stylex.props(styles.item)}>
-              <XDSText type="body">Search Files</XDSText>
-            </div>
-            <div {...stylex.props(styles.item)}>
-              <XDSText type="body">Toggle Dark Mode</XDSText>
-            </div>
+            {filtered.length > 0 ? (
+              filtered.map(item => (
+                <div key={item} {...stylex.props(styles.item)}>
+                  <XDSText type="body">{item}</XDSText>
+                </div>
+              ))
+            ) : (
+              <XDSText type="body" color="secondary">
+                No results found
+              </XDSText>
+            )}
           </div>
           <XDSDivider />
           <div {...stylex.props(styles.footer)}>
@@ -106,7 +114,7 @@ export const Default: Story = {
 };
 
 /**
- * Empty state — just the dialog shell with no content.
+ * Empty state — just the shell with input and no items.
  */
 export const Empty: Story = {
   render: function Render() {
@@ -116,10 +124,7 @@ export const Empty: Story = {
       <>
         <XDSButton label="Open Empty Palette" onClick={() => setIsOpen(true)} />
         <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
-          <input
-            placeholder="No commands registered..."
-            {...stylex.props(styles.input)}
-          />
+          <XDSCommandPaletteInput placeholder="No commands registered..." />
           <XDSDivider />
           <div {...stylex.props(styles.list)}>
             <XDSText type="body" color="secondary">
@@ -147,10 +152,7 @@ export const CustomSize: Story = {
           onOpenChange={setIsOpen}
           width={400}
           maxHeight={300}>
-          <input
-            placeholder="Quick search..."
-            {...stylex.props(styles.input)}
-          />
+          <XDSCommandPaletteInput placeholder="Quick search..." />
           <XDSDivider />
           <div {...stylex.props(styles.list)}>
             <div {...stylex.props(styles.item)}>

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @file XDSCommandPaletteInput.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSCommandPaletteInput
+ * @output Unit tests for XDSCommandPaletteInput component
+ * @position Testing; validates XDSCommandPaletteInput.tsx implementation
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {XDSCommandPaletteInput} from './XDSCommandPaletteInput';
+
+describe('XDSCommandPaletteInput', () => {
+  it('renders with default placeholder', () => {
+    render(<XDSCommandPaletteInput />);
+    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+  });
+
+  it('renders with custom placeholder', () => {
+    render(<XDSCommandPaletteInput placeholder="Type a command..." />);
+    expect(
+      screen.getByPlaceholderText('Type a command...'),
+    ).toBeInTheDocument();
+  });
+
+  it('has combobox role', () => {
+    render(<XDSCommandPaletteInput />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('calls onValueChange when typing', () => {
+    const handleChange = vi.fn();
+    render(<XDSCommandPaletteInput onValueChange={handleChange} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'test'}});
+
+    expect(handleChange).toHaveBeenCalledWith('test');
+  });
+
+  it('displays controlled value', () => {
+    render(<XDSCommandPaletteInput value="hello" onValueChange={() => {}} />);
+    expect(screen.getByRole('combobox')).toHaveValue('hello');
+  });
+
+  it('forwards native onChange alongside onValueChange', () => {
+    const handleChange = vi.fn();
+    const handleNativeChange = vi.fn();
+
+    render(
+      <XDSCommandPaletteInput
+        onValueChange={handleChange}
+        onChange={handleNativeChange}
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'x'}});
+
+    expect(handleChange).toHaveBeenCalledWith('x');
+    expect(handleNativeChange).toHaveBeenCalled();
+  });
+
+  it('has aria-expanded and aria-autocomplete', () => {
+    render(<XDSCommandPaletteInput />);
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -1,0 +1,163 @@
+/**
+ * @file XDSCommandPaletteInput.tsx
+ * @input Uses React, StyleX, XDSIcon
+ * @output Exports XDSCommandPaletteInput component and props
+ * @position Search input for the command palette
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ * - /apps/storybook/stories/CommandPalette.stories.tsx
+ */
+
+'use client';
+
+import {forwardRef, useEffect, useRef, type InputHTMLAttributes} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSIcon} from '../Icon';
+import {
+  colorVars,
+  lineHeightVars,
+  spacingVars,
+  typographyVars,
+  textSizeVars,
+} from '../theme/tokens.stylex';
+
+const styles = stylex.create({
+  wrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-4'],
+    paddingBlock: spacingVars['--spacing-3'],
+    flexShrink: 0,
+  },
+  icon: {
+    flexShrink: 0,
+    color: colorVars['--color-text-secondary'],
+  },
+  input: {
+    flex: 1,
+    minWidth: 0,
+    border: 'none',
+    outline: 'none',
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-primary'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-normal'],
+    padding: 0,
+    '::placeholder': {
+      color: colorVars['--color-text-secondary'],
+    },
+  },
+});
+
+export interface XDSCommandPaletteInputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'role' | 'children' | 'autoFocus'
+> {
+  /**
+   * The current search value.
+   */
+  value?: string;
+
+  /**
+   * Called when the search value changes.
+   */
+  onValueChange?: (value: string) => void;
+
+  /**
+   * Placeholder text for the input.
+   * @default 'Search...'
+   */
+  placeholder?: string;
+
+  /**
+   * Whether to auto-focus the input when mounted.
+   * @default true
+   */
+  hasAutoFocus?: boolean;
+}
+
+/**
+ * Search input for the command palette.
+ *
+ * Renders a search icon and a text input. Auto-focuses when mounted
+ * so users can start typing immediately.
+ *
+ * @compositionHint Place as the first child of XDSCommandPalette.
+ *
+ * @example
+ * ```
+ * <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+ *   <XDSCommandPaletteInput
+ *     value={search}
+ *     onValueChange={setSearch}
+ *     placeholder="Search commands..."
+ *   />
+ * </XDSCommandPalette>
+ * ```
+ */
+export const XDSCommandPaletteInput = forwardRef<
+  HTMLInputElement,
+  XDSCommandPaletteInputProps
+>(function XDSCommandPaletteInput(
+  {
+    value,
+    onValueChange,
+    placeholder = 'Search...',
+    hasAutoFocus = true,
+    onChange,
+    ...props
+  },
+  ref,
+) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Merge refs
+  const setRefs = (element: HTMLInputElement | null) => {
+    (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+      element;
+    if (typeof ref === 'function') {
+      ref(element);
+    } else if (ref) {
+      ref.current = element;
+    }
+  };
+
+  // Auto-focus on mount
+  useEffect(() => {
+    if (hasAutoFocus && inputRef.current) {
+      // Use requestAnimationFrame to ensure dialog is open first
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [hasAutoFocus]);
+
+  return (
+    <div {...stylex.props(styles.wrapper)}>
+      <span {...stylex.props(styles.icon)}>
+        <XDSIcon icon="search" size="sm" color="inherit" />
+      </span>
+      <input
+        ref={setRefs}
+        type="text"
+        role="combobox"
+        aria-expanded={true}
+        aria-autocomplete="list"
+        placeholder={placeholder}
+        value={value}
+        onChange={e => {
+          onValueChange?.(e.target.value);
+          onChange?.(e);
+        }}
+        {...stylex.props(styles.input)}
+        {...props}
+      />
+    </div>
+  );
+});
+
+XDSCommandPaletteInput.displayName = 'XDSCommandPaletteInput';

--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -9,3 +9,6 @@
 
 export {XDSCommandPalette} from './XDSCommandPalette';
 export type {XDSCommandPaletteProps} from './XDSCommandPalette';
+
+export {XDSCommandPaletteInput} from './XDSCommandPaletteInput';
+export type {XDSCommandPaletteInputProps} from './XDSCommandPaletteInput';


### PR DESCRIPTION
## Summary

Adds the search input component for the command palette.

**PR 2 of 4** in the incremental command palette rebuild:
1. ✅ Dialog shell (#501)
2. ✅ **Input component** (this PR)
3. ⬜ List, Item, Group, Footer
4. ⬜ Context provider

## What's included

- `XDSCommandPaletteInput` — search icon + text input
- Auto-focus on mount (`hasAutoFocus`, default `true`)
- Controlled value via `value`/`onValueChange`
- `combobox` role with `aria-expanded`/`aria-autocomplete`
- Token-based styling (spacing, typography, colors)
- 7 unit tests
- Updated storybook stories to use real input component

## API

```tsx
<XDSCommandPaletteInput
  value={search}
  onValueChange={setSearch}
  placeholder="Search commands..."
/>
```

## Depends on

- #501 (dialog shell)