### PR TITLE
feat(core): add CommandPalette List, Item, Group, Footer

### DIFF
--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -3,30 +3,13 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {
   XDSCommandPalette,
   XDSCommandPaletteInput,
+  XDSCommandPaletteList,
+  XDSCommandPaletteItem,
+  XDSCommandPaletteGroup,
+  XDSCommandPaletteFooter,
 } from '@xds/core/CommandPalette';
 import {XDSButton} from '@xds/core/Button';
-import {XDSText} from '@xds/core/Text';
 import {XDSDivider} from '@xds/core/Divider';
-import * as stylex from '@stylexjs/stylex';
-
-const styles = stylex.create({
-  list: {
-    flex: 1,
-    overflowY: 'auto',
-    padding: '8px',
-  },
-  item: {
-    padding: '8px 12px',
-    borderRadius: '6px',
-    cursor: 'pointer',
-  },
-  footer: {
-    padding: '8px 16px',
-    display: 'flex',
-    justifyContent: 'flex-end',
-    gap: '8px',
-  },
-});
 
 const meta: Meta<typeof XDSCommandPalette> = {
   title: 'Core/XDSCommandPalette',
@@ -55,24 +38,35 @@ const meta: Meta<typeof XDSCommandPalette> = {
 export default meta;
 type Story = StoryObj<typeof XDSCommandPalette>;
 
+const ALL_ITEMS = [
+  {value: 'dashboard', label: 'Go to Dashboard', group: 'Navigation'},
+  {value: 'settings', label: 'Open Settings', group: 'Navigation'},
+  {value: 'profile', label: 'View Profile', group: 'Navigation'},
+  {value: 'dark-mode', label: 'Toggle Dark Mode', group: 'Actions'},
+  {value: 'new-file', label: 'Create New File', group: 'Actions'},
+  {value: 'search', label: 'Search Files', group: 'Actions'},
+];
+
 /**
- * The command palette with the real input component and placeholder list content.
+ * Full command palette with input, grouped items, and footer.
  */
 export const Default: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
     const [search, setSearch] = useState('');
+    const [highlighted, setHighlighted] = useState(0);
 
-    const items = [
-      'Go to Dashboard',
-      'Search Files',
-      'Toggle Dark Mode',
-      'Open Settings',
-      'Create New File',
-    ];
+    const filtered = ALL_ITEMS.filter(item =>
+      item.label.toLowerCase().includes(search.toLowerCase()),
+    );
 
-    const filtered = items.filter(item =>
-      item.toLowerCase().includes(search.toLowerCase()),
+    const groups = filtered.reduce(
+      (acc, item) => {
+        if (!acc[item.group]) acc[item.group] = [];
+        acc[item.group].push(item);
+        return acc;
+      },
+      {} as Record<string, typeof ALL_ITEMS>,
     );
 
     return (
@@ -84,29 +78,35 @@ export const Default: Story = {
         <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
           <XDSCommandPaletteInput
             value={search}
-            onValueChange={setSearch}
+            onValueChange={v => {
+              setSearch(v);
+              setHighlighted(0);
+            }}
             placeholder="Type a command..."
           />
           <XDSDivider />
-          <div {...stylex.props(styles.list)}>
-            {filtered.length > 0 ? (
-              filtered.map(item => (
-                <div key={item} {...stylex.props(styles.item)}>
-                  <XDSText type="body">{item}</XDSText>
-                </div>
-              ))
-            ) : (
-              <XDSText type="body" color="secondary">
-                No results found
-              </XDSText>
-            )}
-          </div>
-          <XDSDivider />
-          <div {...stylex.props(styles.footer)}>
-            <XDSText type="body" size="sm" color="secondary">
-              ESC to close
-            </XDSText>
-          </div>
+          <XDSCommandPaletteList>
+            {Object.entries(groups).map(([group, items]) => (
+              <XDSCommandPaletteGroup key={group} heading={group}>
+                {items.map(item => {
+                  const flatIndex = filtered.indexOf(item);
+                  return (
+                    <XDSCommandPaletteItem
+                      key={item.value}
+                      value={item.value}
+                      isHighlighted={flatIndex === highlighted}
+                      onSelect={() => {
+                        setIsOpen(false);
+                        setSearch('');
+                      }}>
+                      {item.label}
+                    </XDSCommandPaletteItem>
+                  );
+                })}
+              </XDSCommandPaletteGroup>
+            ))}
+          </XDSCommandPaletteList>
+          <XDSCommandPaletteFooter />
         </XDSCommandPalette>
       </>
     );
@@ -114,23 +114,34 @@ export const Default: Story = {
 };
 
 /**
- * Empty state — just the shell with input and no items.
+ * Flat list without groups.
  */
-export const Empty: Story = {
+export const FlatList: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
 
     return (
       <>
-        <XDSButton label="Open Empty Palette" onClick={() => setIsOpen(true)} />
+        <XDSButton label="Open Flat Palette" onClick={() => setIsOpen(true)} />
         <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
-          <XDSCommandPaletteInput placeholder="No commands registered..." />
+          <XDSCommandPaletteInput placeholder="Search..." />
           <XDSDivider />
-          <div {...stylex.props(styles.list)}>
-            <XDSText type="body" color="secondary">
-              No results found
-            </XDSText>
-          </div>
+          <XDSCommandPaletteList>
+            <XDSCommandPaletteItem
+              value="home"
+              onSelect={() => setIsOpen(false)}>
+              Go Home
+            </XDSCommandPaletteItem>
+            <XDSCommandPaletteItem
+              value="settings"
+              onSelect={() => setIsOpen(false)}>
+              Settings
+            </XDSCommandPaletteItem>
+            <XDSCommandPaletteItem value="disabled" isDisabled>
+              Disabled Item
+            </XDSCommandPaletteItem>
+          </XDSCommandPaletteList>
+          <XDSCommandPaletteFooter />
         </XDSCommandPalette>
       </>
     );
@@ -138,30 +149,29 @@ export const Empty: Story = {
 };
 
 /**
- * Custom dimensions — narrower and shorter.
+ * With custom footer content.
  */
-export const CustomSize: Story = {
+export const CustomFooter: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
 
     return (
       <>
-        <XDSButton label="Open Small Palette" onClick={() => setIsOpen(true)} />
-        <XDSCommandPalette
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          width={400}
-          maxHeight={300}>
-          <XDSCommandPaletteInput placeholder="Quick search..." />
+        <XDSButton label="Open Custom Footer" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+          <XDSCommandPaletteInput placeholder="Search..." />
           <XDSDivider />
-          <div {...stylex.props(styles.list)}>
-            <div {...stylex.props(styles.item)}>
-              <XDSText type="body">Option A</XDSText>
-            </div>
-            <div {...stylex.props(styles.item)}>
-              <XDSText type="body">Option B</XDSText>
-            </div>
-          </div>
+          <XDSCommandPaletteList>
+            <XDSCommandPaletteItem value="a" onSelect={() => setIsOpen(false)}>
+              Option A
+            </XDSCommandPaletteItem>
+            <XDSCommandPaletteItem value="b" onSelect={() => setIsOpen(false)}>
+              Option B
+            </XDSCommandPaletteItem>
+          </XDSCommandPaletteList>
+          <XDSCommandPaletteFooter>
+            <span>Tip: Use ⌘K to open this palette</span>
+          </XDSCommandPaletteFooter>
         </XDSCommandPalette>
       </>
     );

--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -1,0 +1,167 @@
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {XDSCommandPalette} from '@xds/core/CommandPalette';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText} from '@xds/core/Text';
+import {XDSDivider} from '@xds/core/Divider';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  input: {
+    width: '100%',
+    padding: '12px 16px',
+    border: 'none',
+    outline: 'none',
+    fontSize: '16px',
+    backgroundColor: 'transparent',
+    color: 'inherit',
+    fontFamily: 'inherit',
+  },
+  list: {
+    flex: 1,
+    overflowY: 'auto',
+    padding: '8px',
+  },
+  item: {
+    padding: '8px 12px',
+    borderRadius: '6px',
+    cursor: 'pointer',
+  },
+  footer: {
+    padding: '8px 16px',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: '8px',
+  },
+});
+
+const meta: Meta<typeof XDSCommandPalette> = {
+  title: 'Core/XDSCommandPalette',
+  component: XDSCommandPalette,
+  tags: ['autodocs'],
+  argTypes: {
+    isOpen: {
+      control: 'boolean',
+      description: 'Whether the command palette is open',
+    },
+    width: {
+      control: 'number',
+      description: 'Width of the dialog',
+    },
+    maxHeight: {
+      control: 'number',
+      description: 'Maximum height of the dialog',
+    },
+    label: {
+      control: 'text',
+      description: 'Accessible label',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof XDSCommandPalette>;
+
+/**
+ * The command palette dialog shell with placeholder content.
+ * This demonstrates the structural layout — input, list, and footer slots.
+ */
+export const Default: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <XDSButton
+          label="Open Command Palette"
+          onClick={() => setIsOpen(true)}
+        />
+        <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+          <input
+            placeholder="Type a command..."
+            {...stylex.props(styles.input)}
+          />
+          <XDSDivider />
+          <div {...stylex.props(styles.list)}>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Go to Dashboard</XDSText>
+            </div>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Search Files</XDSText>
+            </div>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Toggle Dark Mode</XDSText>
+            </div>
+          </div>
+          <XDSDivider />
+          <div {...stylex.props(styles.footer)}>
+            <XDSText type="body" size="sm" color="secondary">
+              ESC to close
+            </XDSText>
+          </div>
+        </XDSCommandPalette>
+      </>
+    );
+  },
+};
+
+/**
+ * Empty state — just the dialog shell with no content.
+ */
+export const Empty: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <XDSButton label="Open Empty Palette" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+          <input
+            placeholder="No commands registered..."
+            {...stylex.props(styles.input)}
+          />
+          <XDSDivider />
+          <div {...stylex.props(styles.list)}>
+            <XDSText type="body" color="secondary">
+              No results found
+            </XDSText>
+          </div>
+        </XDSCommandPalette>
+      </>
+    );
+  },
+};
+
+/**
+ * Custom dimensions — narrower and shorter.
+ */
+export const CustomSize: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <>
+        <XDSButton label="Open Small Palette" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          width={400}
+          maxHeight={300}>
+          <input
+            placeholder="Quick search..."
+            {...stylex.props(styles.input)}
+          />
+          <XDSDivider />
+          <div {...stylex.props(styles.list)}>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Option A</XDSText>
+            </div>
+            <div {...stylex.props(styles.item)}>
+              <XDSText type="body">Option B</XDSText>
+            </div>
+          </div>
+        </XDSCommandPalette>
+      </>
+    );
+  },
+};

--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -1,22 +1,15 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSCommandPalette} from '@xds/core/CommandPalette';
+import {
+  XDSCommandPalette,
+  XDSCommandPaletteInput,
+} from '@xds/core/CommandPalette';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
 import {XDSDivider} from '@xds/core/Divider';
 import * as stylex from '@stylexjs/stylex';
 
 const styles = stylex.create({
-  input: {
-    width: '100%',
-    padding: '12px 16px',
-    border: 'none',
-    outline: 'none',
-    fontSize: '16px',
-    backgroundColor: 'transparent',
-    color: 'inherit',
-    fontFamily: 'inherit',
-  },
   list: {
     flex: 1,
     overflowY: 'auto',
@@ -63,12 +56,24 @@ export default meta;
 type Story = StoryObj<typeof XDSCommandPalette>;
 
 /**
- * The command palette dialog shell with placeholder content.
- * This demonstrates the structural layout — input, list, and footer slots.
+ * The command palette with the real input component and placeholder list content.
  */
 export const Default: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
+    const [search, setSearch] = useState('');
+
+    const items = [
+      'Go to Dashboard',
+      'Search Files',
+      'Toggle Dark Mode',
+      'Open Settings',
+      'Create New File',
+    ];
+
+    const filtered = items.filter(item =>
+      item.toLowerCase().includes(search.toLowerCase()),
+    );
 
     return (
       <>
@@ -77,21 +82,24 @@ export const Default: Story = {
           onClick={() => setIsOpen(true)}
         />
         <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
-          <input
+          <XDSCommandPaletteInput
+            value={search}
+            onValueChange={setSearch}
             placeholder="Type a command..."
-            {...stylex.props(styles.input)}
           />
           <XDSDivider />
           <div {...stylex.props(styles.list)}>
-            <div {...stylex.props(styles.item)}>
-              <XDSText type="body">Go to Dashboard</XDSText>
-            </div>
-            <div {...stylex.props(styles.item)}>
-              <XDSText type="body">Search Files</XDSText>
-            </div>
-            <div {...stylex.props(styles.item)}>
-              <XDSText type="body">Toggle Dark Mode</XDSText>
-            </div>
+            {filtered.length > 0 ? (
+              filtered.map(item => (
+                <div key={item} {...stylex.props(styles.item)}>
+                  <XDSText type="body">{item}</XDSText>
+                </div>
+              ))
+            ) : (
+              <XDSText type="body" color="secondary">
+                No results found
+              </XDSText>
+            )}
           </div>
           <XDSDivider />
           <div {...stylex.props(styles.footer)}>
@@ -106,7 +114,7 @@ export const Default: Story = {
 };
 
 /**
- * Empty state — just the dialog shell with no content.
+ * Empty state — just the shell with input and no items.
  */
 export const Empty: Story = {
   render: function Render() {
@@ -116,10 +124,7 @@ export const Empty: Story = {
       <>
         <XDSButton label="Open Empty Palette" onClick={() => setIsOpen(true)} />
         <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
-          <input
-            placeholder="No commands registered..."
-            {...stylex.props(styles.input)}
-          />
+          <XDSCommandPaletteInput placeholder="No commands registered..." />
           <XDSDivider />
           <div {...stylex.props(styles.list)}>
             <XDSText type="body" color="secondary">
@@ -147,10 +152,7 @@ export const CustomSize: Story = {
           onOpenChange={setIsOpen}
           width={400}
           maxHeight={300}>
-          <input
-            placeholder="Quick search..."
-            {...stylex.props(styles.input)}
-          />
+          <XDSCommandPaletteInput placeholder="Quick search..." />
           <XDSDivider />
           <div {...stylex.props(styles.list)}>
             <div {...stylex.props(styles.item)}>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -107,6 +107,12 @@
       "import": "./dist/DateInput/index.mjs",
       "require": "./dist/DateInput/index.js"
     },
+    "./CommandPalette": {
+      "source": "./src/CommandPalette/index.ts",
+      "types": "./dist/CommandPalette/index.d.ts",
+      "import": "./dist/CommandPalette/index.mjs",
+      "require": "./dist/CommandPalette/index.js"
+    },
     "./Dialog": {
       "source": "./src/Dialog/index.ts",
       "types": "./dist/Dialog/index.d.ts",

--- a/packages/core/src/CommandPalette/CommandPalette.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPalette.doc.mjs
@@ -1,0 +1,68 @@
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'CommandPalette',
+  description:
+    'A modal dialog shell for command palette interfaces. Provides the structural container with composable slots for input, list, and footer areas.',
+  features: [
+    'Dialog shell: Wraps XDSDialog with command palette defaults (640×480, centered, info purpose)',
+    'Composable slots: Children render as a flex column — input at top, scrollable list in middle, footer at bottom',
+    'Accessible: Uses native <dialog> with aria-label for screen readers',
+    'Keyboard dismissal: Escape key closes the palette (inherited from XDSDialog purpose="info")',
+    'Configurable size: width and maxHeight props for custom dimensions',
+  ],
+  examples: [
+    {
+      label: 'Basic command palette',
+      code: `import {XDSCommandPalette} from '@xds/core/CommandPalette';
+import {useState} from 'react';
+
+function Example() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+      <input placeholder="Type a command..." />
+      <div>List of commands</div>
+    </XDSCommandPalette>
+  );
+}`,
+    },
+  ],
+  props: {
+    isOpen: {
+      type: 'boolean',
+      required: true,
+      description: 'Whether the command palette is open.',
+    },
+    onOpenChange: {
+      type: '(isOpen: boolean) => void',
+      required: true,
+      description:
+        'Called when the palette visibility changes. Called with false on Escape or backdrop click.',
+    },
+    label: {
+      type: 'string',
+      default: "'Command palette'",
+      description: 'Accessible label for the dialog.',
+    },
+    width: {
+      type: 'number | string',
+      default: '640',
+      description:
+        'Width of the dialog. Numbers are pixels, strings are CSS values.',
+    },
+    maxHeight: {
+      type: 'number | string',
+      default: '480',
+      description:
+        'Maximum height of the dialog. Numbers are pixels, strings are CSS values.',
+    },
+    children: {
+      type: 'ReactNode',
+      required: true,
+      description:
+        'Composable sub-components: input, list, footer, etc.',
+    },
+  },
+};

--- a/packages/core/src/CommandPalette/README.md
+++ b/packages/core/src/CommandPalette/README.md
@@ -1,0 +1,34 @@
+# CommandPalette
+
+Command palette dialog for quick access to commands, navigation, and search.
+
+## Architecture
+
+The command palette is built incrementally as composable pieces:
+
+1. **XDSCommandPalette** — Dialog shell with flex column layout (this PR)
+2. **XDSCommandPaletteInput** — Search input with icon (planned)
+3. **XDSCommandPaletteList / Item / Group** — Scrollable item list (planned)
+4. **XDSCommandPaletteFooter** — Keyboard shortcut hints (planned)
+5. **CommandPaletteContext** — State management provider (planned)
+
+## Files
+
+| File                         | Purpose                     |
+| ---------------------------- | --------------------------- |
+| `XDSCommandPalette.tsx`      | Root dialog shell component |
+| `index.ts`                   | Public exports              |
+| `README.md`                  | This file                   |
+| `XDSCommandPalette.test.tsx` | Unit tests                  |
+
+## Usage
+
+```tsx
+import {XDSCommandPalette} from '@xds/core/CommandPalette';
+
+const [isOpen, setIsOpen] = useState(false);
+
+<XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+  {/* Sub-components go here */}
+</XDSCommandPalette>;
+```

--- a/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @file XDSCommandPalette.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSCommandPalette
+ * @output Unit tests for XDSCommandPalette dialog shell
+ * @position Testing; validates XDSCommandPalette.tsx implementation
+ *
+ * SYNC: When XDSCommandPalette.tsx changes, update tests to match
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSCommandPalette} from './XDSCommandPalette';
+
+// Mock showModal and close since jsdom doesn't implement them
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+});
+
+describe('XDSCommandPalette', () => {
+  it('renders when isOpen is true', () => {
+    render(
+      <XDSCommandPalette isOpen={true} onOpenChange={() => {}}>
+        <div>Content</div>
+      </XDSCommandPalette>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('does not show content when isOpen is false', () => {
+    render(
+      <XDSCommandPalette isOpen={false} onOpenChange={() => {}}>
+        <div>Hidden</div>
+      </XDSCommandPalette>,
+    );
+    const dialog = screen.getByRole('dialog', {hidden: true});
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  it('has correct aria-label', () => {
+    render(
+      <XDSCommandPalette isOpen={true} onOpenChange={() => {}}>
+        <div>Content</div>
+      </XDSCommandPalette>,
+    );
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-label',
+      'Command palette',
+    );
+  });
+
+  it('supports custom label', () => {
+    render(
+      <XDSCommandPalette
+        isOpen={true}
+        onOpenChange={() => {}}
+        label="Quick search">
+        <div>Content</div>
+      </XDSCommandPalette>,
+    );
+    expect(screen.getByRole('dialog')).toHaveAttribute(
+      'aria-label',
+      'Quick search',
+    );
+  });
+
+  it('renders children as composable slots', () => {
+    render(
+      <XDSCommandPalette isOpen={true} onOpenChange={() => {}}>
+        <div data-testid="input-slot">Input</div>
+        <div data-testid="list-slot">List</div>
+        <div data-testid="footer-slot">Footer</div>
+      </XDSCommandPalette>,
+    );
+    expect(screen.getByTestId('input-slot')).toBeInTheDocument();
+    expect(screen.getByTestId('list-slot')).toBeInTheDocument();
+    expect(screen.getByTestId('footer-slot')).toBeInTheDocument();
+  });
+
+  it('calls onOpenChange(false) when Escape is pressed', () => {
+    const handleOpenChange = vi.fn();
+
+    render(
+      <XDSCommandPalette isOpen={true} onOpenChange={handleOpenChange}>
+        <div>Content</div>
+      </XDSCommandPalette>,
+    );
+
+    const dialog = screen.getByRole('dialog');
+    const escapeEvent = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    dialog.dispatchEvent(escapeEvent);
+
+    expect(handleOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -1,0 +1,137 @@
+/**
+ * @file XDSCommandPalette.tsx
+ * @input Uses React, StyleX, XDSDialog
+ * @output Exports XDSCommandPalette root component and props
+ * @position Core root component; dialog shell with slots for sub-components
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ * - /apps/storybook/stories/CommandPalette.stories.tsx
+ */
+
+'use client';
+
+import {type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSDialog} from '../Dialog';
+
+const styles = stylex.create({
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    overflow: 'hidden',
+  },
+});
+
+// =============================================================================
+// Module Augmentation - Register CommandPalette's style surfaces
+// =============================================================================
+
+declare module '../theme/types' {
+  interface ComponentStyles {
+    commandPalette?: {
+      root?: import('../theme/types').StyleXStyles;
+    };
+  }
+}
+
+export interface XDSCommandPaletteProps {
+  /**
+   * Whether the command palette is open.
+   */
+  isOpen: boolean;
+
+  /**
+   * Called when the command palette visibility changes.
+   * Called with `false` when the palette requests to close
+   * (via Escape key or backdrop click).
+   */
+  onOpenChange: (isOpen: boolean) => void;
+
+  /**
+   * Accessible label for the command palette dialog.
+   * @default 'Command palette'
+   */
+  label?: string;
+
+  /**
+   * Width of the command palette dialog.
+   * Numbers are treated as pixels, strings are used as-is.
+   * @default 640
+   */
+  width?: number | string;
+
+  /**
+   * Maximum height of the command palette dialog.
+   * Numbers are treated as pixels, strings are used as-is.
+   * @default 480
+   */
+  maxHeight?: number | string;
+
+  /**
+   * Composable content slots.
+   * Typically includes XDSCommandPaletteInput, a list area, and XDSCommandPaletteFooter.
+   *
+   * @example
+   * ```
+   * <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+   *   <XDSCommandPaletteInput placeholder="Search commands..." />
+   *   <XDSCommandPaletteList>
+   *     <XDSCommandPaletteItem value="home">Go Home</XDSCommandPaletteItem>
+   *   </XDSCommandPaletteList>
+   *   <XDSCommandPaletteFooter />
+   * </XDSCommandPalette>
+   * ```
+   */
+  children: ReactNode;
+}
+
+/**
+ * Command palette dialog shell.
+ *
+ * A modal dialog pre-configured for command palette usage.
+ * Renders an XDSDialog with appropriate defaults (centered, info purpose,
+ * no close button) and a flex column layout for composable children.
+ *
+ * This component is purely structural — it provides the dialog container
+ * and layout. State management (search, filtering, selection, keyboard
+ * navigation) is handled by a separate context provider.
+ *
+ * @compositionHint Compose with XDSCommandPaletteInput (search),
+ *   XDSCommandPaletteList (scrollable items), and XDSCommandPaletteFooter
+ *   (keyboard hints) as children.
+ *
+ * @example
+ * ```
+ * const [isOpen, setIsOpen] = useState(false);
+ *
+ * <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+ *   <input placeholder="Type a command..." />
+ *   <div>Item list goes here</div>
+ * </XDSCommandPalette>
+ * ```
+ */
+export function XDSCommandPalette({
+  isOpen,
+  onOpenChange,
+  label = 'Command palette',
+  width = 640,
+  maxHeight = 480,
+  children,
+}: XDSCommandPaletteProps) {
+  return (
+    <XDSDialog
+      isOpen={isOpen}
+      onOpenChange={onOpenChange}
+      width={width}
+      maxHeight={maxHeight}
+      purpose="info"
+      aria-label={label}>
+      <div {...stylex.props(styles.wrapper)}>{children}</div>
+    </XDSDialog>
+  );
+}
+
+XDSCommandPalette.displayName = 'XDSCommandPalette';

--- a/packages/core/src/CommandPalette/XDSCommandPaletteFooter.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteFooter.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @file XDSCommandPaletteFooter.test.tsx
+ * @input Uses vitest, @testing-library/react
+ * @output Unit tests for XDSCommandPaletteFooter
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSCommandPaletteFooter} from './XDSCommandPaletteFooter';
+
+describe('XDSCommandPaletteFooter', () => {
+  it('renders default keyboard hints', () => {
+    render(<XDSCommandPaletteFooter />);
+    expect(screen.getByText(/Navigate/)).toBeInTheDocument();
+    expect(screen.getByText(/Select/)).toBeInTheDocument();
+    expect(screen.getByText(/Close/)).toBeInTheDocument();
+  });
+
+  it('renders custom children instead of defaults', () => {
+    render(
+      <XDSCommandPaletteFooter>
+        <span>Custom footer content</span>
+      </XDSCommandPaletteFooter>,
+    );
+    expect(screen.getByText('Custom footer content')).toBeInTheDocument();
+    expect(screen.queryByText(/Navigate/)).not.toBeInTheDocument();
+  });
+
+  it('renders a divider', () => {
+    render(<XDSCommandPaletteFooter />);
+    expect(screen.getByRole('separator')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPaletteFooter.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteFooter.tsx
@@ -1,0 +1,87 @@
+/**
+ * @file XDSCommandPaletteFooter.tsx
+ * @input Uses React, StyleX, XDSKbd
+ * @output Exports XDSCommandPaletteFooter component
+ * @position Sub-component; footer with keyboard hints
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ */
+
+'use client';
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  typographyVars,
+} from '../theme/tokens.stylex';
+import {XDSDivider} from '../Divider';
+
+const styles = stylex.create({
+  footer: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-4'],
+    paddingBlock: spacingVars['--spacing-2'],
+    flexShrink: 0,
+  },
+  hint: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    color: colorVars['--color-text-secondary'],
+  },
+});
+
+export interface XDSCommandPaletteFooterProps {
+  /**
+   * Footer content. When provided, renders custom content instead of default hints.
+   * When omitted, renders default keyboard navigation hints.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * Footer for the command palette showing keyboard navigation hints.
+ *
+ * When no children are provided, renders default hints for
+ * arrow keys, Enter to select, and Escape to close.
+ *
+ * @compositionHint Place as the last child of XDSCommandPalette.
+ *
+ * @example
+ * ```
+ * <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+ *   <XDSCommandPaletteInput />
+ *   <XDSCommandPaletteList>...</XDSCommandPaletteList>
+ *   <XDSCommandPaletteFooter />
+ * </XDSCommandPalette>
+ * ```
+ */
+export function XDSCommandPaletteFooter({
+  children,
+}: XDSCommandPaletteFooterProps) {
+  return (
+    <>
+      <XDSDivider />
+      <div {...stylex.props(styles.footer)}>
+        {children ?? (
+          <>
+            <span {...stylex.props(styles.hint)}>↑↓ Navigate</span>
+            <span {...stylex.props(styles.hint)}>↵ Select</span>
+            <span {...stylex.props(styles.hint)}>Esc Close</span>
+          </>
+        )}
+      </div>
+    </>
+  );
+}
+
+XDSCommandPaletteFooter.displayName = 'XDSCommandPaletteFooter';

--- a/packages/core/src/CommandPalette/XDSCommandPaletteGroup.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteGroup.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * @file XDSCommandPaletteGroup.test.tsx
+ * @input Uses vitest, @testing-library/react
+ * @output Unit tests for XDSCommandPaletteGroup
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSCommandPaletteGroup} from './XDSCommandPaletteGroup';
+
+describe('XDSCommandPaletteGroup', () => {
+  it('renders heading', () => {
+    render(
+      <XDSCommandPaletteGroup heading="Navigation">
+        <div>Item</div>
+      </XDSCommandPaletteGroup>,
+    );
+    expect(screen.getByText('Navigation')).toBeInTheDocument();
+  });
+
+  it('renders children', () => {
+    render(
+      <XDSCommandPaletteGroup heading="Group">
+        <div>Child 1</div>
+        <div>Child 2</div>
+      </XDSCommandPaletteGroup>,
+    );
+    expect(screen.getByText('Child 1')).toBeInTheDocument();
+    expect(screen.getByText('Child 2')).toBeInTheDocument();
+  });
+
+  it('has group role with aria-label', () => {
+    render(
+      <XDSCommandPaletteGroup heading="Actions">
+        <div>Item</div>
+      </XDSCommandPaletteGroup>,
+    );
+    expect(screen.getByRole('group')).toHaveAttribute('aria-label', 'Actions');
+  });
+
+  it('heading is aria-hidden', () => {
+    render(
+      <XDSCommandPaletteGroup heading="Hidden Heading">
+        <div>Item</div>
+      </XDSCommandPaletteGroup>,
+    );
+    expect(screen.getByText('Hidden Heading')).toHaveAttribute(
+      'aria-hidden',
+      'true',
+    );
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPaletteGroup.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteGroup.tsx
@@ -1,0 +1,92 @@
+/**
+ * @file XDSCommandPaletteGroup.tsx
+ * @input Uses React, StyleX
+ * @output Exports XDSCommandPaletteGroup component
+ * @position Sub-component; visual grouping with heading
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ */
+
+'use client';
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  textSizeVars,
+  typographyVars,
+  fontWeightVars,
+} from '../theme/tokens.stylex';
+
+const styles = stylex.create({
+  group: {
+    paddingBlock: spacingVars['--spacing-1'],
+  },
+  heading: {
+    paddingInline: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-1'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-xsm'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    color: colorVars['--color-text-secondary'],
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    userSelect: 'none',
+  },
+});
+
+export interface XDSCommandPaletteGroupProps {
+  /**
+   * Group heading text.
+   */
+  heading: string;
+
+  /**
+   * Items within this group.
+   */
+  children: ReactNode;
+
+  /**
+   * StyleX overrides for the group container.
+   */
+  xstyle?: StyleXStyles;
+}
+
+/**
+ * Visual grouping for command palette items with a heading label.
+ *
+ * @compositionHint Place inside XDSCommandPaletteList.
+ *   Contains XDSCommandPaletteItem children.
+ *
+ * @example
+ * ```
+ * <XDSCommandPaletteGroup heading="Navigation">
+ *   <XDSCommandPaletteItem value="home" onSelect={goHome}>
+ *     Home
+ *   </XDSCommandPaletteItem>
+ * </XDSCommandPaletteGroup>
+ * ```
+ */
+export function XDSCommandPaletteGroup({
+  heading,
+  children,
+  xstyle,
+}: XDSCommandPaletteGroupProps) {
+  return (
+    <div
+      role="group"
+      aria-label={heading}
+      {...stylex.props(styles.group, xstyle)}>
+      <div aria-hidden="true" {...stylex.props(styles.heading)}>
+        {heading}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+XDSCommandPaletteGroup.displayName = 'XDSCommandPaletteGroup';

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * @file XDSCommandPaletteInput.test.tsx
+ * @input Uses vitest, @testing-library/react, XDSCommandPaletteInput
+ * @output Unit tests for XDSCommandPaletteInput component
+ * @position Testing; validates XDSCommandPaletteInput.tsx implementation
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {XDSCommandPaletteInput} from './XDSCommandPaletteInput';
+
+describe('XDSCommandPaletteInput', () => {
+  it('renders with default placeholder', () => {
+    render(<XDSCommandPaletteInput />);
+    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+  });
+
+  it('renders with custom placeholder', () => {
+    render(<XDSCommandPaletteInput placeholder="Type a command..." />);
+    expect(
+      screen.getByPlaceholderText('Type a command...'),
+    ).toBeInTheDocument();
+  });
+
+  it('has combobox role', () => {
+    render(<XDSCommandPaletteInput />);
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('calls onValueChange when typing', () => {
+    const handleChange = vi.fn();
+    render(<XDSCommandPaletteInput onValueChange={handleChange} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'test'}});
+
+    expect(handleChange).toHaveBeenCalledWith('test');
+  });
+
+  it('displays controlled value', () => {
+    render(<XDSCommandPaletteInput value="hello" onValueChange={() => {}} />);
+    expect(screen.getByRole('combobox')).toHaveValue('hello');
+  });
+
+  it('forwards native onChange alongside onValueChange', () => {
+    const handleChange = vi.fn();
+    const handleNativeChange = vi.fn();
+
+    render(
+      <XDSCommandPaletteInput
+        onValueChange={handleChange}
+        onChange={handleNativeChange}
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'x'}});
+
+    expect(handleChange).toHaveBeenCalledWith('x');
+    expect(handleNativeChange).toHaveBeenCalled();
+  });
+
+  it('has aria-expanded and aria-autocomplete', () => {
+    render(<XDSCommandPaletteInput />);
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    expect(input).toHaveAttribute('aria-autocomplete', 'list');
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -1,0 +1,163 @@
+/**
+ * @file XDSCommandPaletteInput.tsx
+ * @input Uses React, StyleX, XDSIcon
+ * @output Exports XDSCommandPaletteInput component and props
+ * @position Search input for the command palette
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ * - /apps/storybook/stories/CommandPalette.stories.tsx
+ */
+
+'use client';
+
+import {forwardRef, useEffect, useRef, type InputHTMLAttributes} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSIcon} from '../Icon';
+import {
+  colorVars,
+  lineHeightVars,
+  spacingVars,
+  typographyVars,
+  textSizeVars,
+} from '../theme/tokens.stylex';
+
+const styles = stylex.create({
+  wrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-4'],
+    paddingBlock: spacingVars['--spacing-3'],
+    flexShrink: 0,
+  },
+  icon: {
+    flexShrink: 0,
+    color: colorVars['--color-text-secondary'],
+  },
+  input: {
+    flex: 1,
+    minWidth: 0,
+    border: 'none',
+    outline: 'none',
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-primary'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-normal'],
+    padding: 0,
+    '::placeholder': {
+      color: colorVars['--color-text-secondary'],
+    },
+  },
+});
+
+export interface XDSCommandPaletteInputProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'role' | 'children' | 'autoFocus'
+> {
+  /**
+   * The current search value.
+   */
+  value?: string;
+
+  /**
+   * Called when the search value changes.
+   */
+  onValueChange?: (value: string) => void;
+
+  /**
+   * Placeholder text for the input.
+   * @default 'Search...'
+   */
+  placeholder?: string;
+
+  /**
+   * Whether to auto-focus the input when mounted.
+   * @default true
+   */
+  hasAutoFocus?: boolean;
+}
+
+/**
+ * Search input for the command palette.
+ *
+ * Renders a search icon and a text input. Auto-focuses when mounted
+ * so users can start typing immediately.
+ *
+ * @compositionHint Place as the first child of XDSCommandPalette.
+ *
+ * @example
+ * ```
+ * <XDSCommandPalette isOpen={isOpen} onOpenChange={setIsOpen}>
+ *   <XDSCommandPaletteInput
+ *     value={search}
+ *     onValueChange={setSearch}
+ *     placeholder="Search commands..."
+ *   />
+ * </XDSCommandPalette>
+ * ```
+ */
+export const XDSCommandPaletteInput = forwardRef<
+  HTMLInputElement,
+  XDSCommandPaletteInputProps
+>(function XDSCommandPaletteInput(
+  {
+    value,
+    onValueChange,
+    placeholder = 'Search...',
+    hasAutoFocus = true,
+    onChange,
+    ...props
+  },
+  ref,
+) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Merge refs
+  const setRefs = (element: HTMLInputElement | null) => {
+    (inputRef as React.MutableRefObject<HTMLInputElement | null>).current =
+      element;
+    if (typeof ref === 'function') {
+      ref(element);
+    } else if (ref) {
+      ref.current = element;
+    }
+  };
+
+  // Auto-focus on mount
+  useEffect(() => {
+    if (hasAutoFocus && inputRef.current) {
+      // Use requestAnimationFrame to ensure dialog is open first
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [hasAutoFocus]);
+
+  return (
+    <div {...stylex.props(styles.wrapper)}>
+      <span {...stylex.props(styles.icon)}>
+        <XDSIcon icon="search" size="sm" color="inherit" />
+      </span>
+      <input
+        ref={setRefs}
+        type="text"
+        role="combobox"
+        aria-expanded={true}
+        aria-autocomplete="list"
+        placeholder={placeholder}
+        value={value}
+        onChange={e => {
+          onValueChange?.(e.target.value);
+          onChange?.(e);
+        }}
+        {...stylex.props(styles.input)}
+        {...props}
+      />
+    </div>
+  );
+});
+
+XDSCommandPaletteInput.displayName = 'XDSCommandPaletteInput';

--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * @file XDSCommandPaletteItem.test.tsx
+ * @input Uses vitest, @testing-library/react
+ * @output Unit tests for XDSCommandPaletteItem
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {XDSCommandPaletteItem} from './XDSCommandPaletteItem';
+
+describe('XDSCommandPaletteItem', () => {
+  it('renders children', () => {
+    render(
+      <XDSCommandPaletteItem value="test">Test Item</XDSCommandPaletteItem>,
+    );
+    expect(screen.getByText('Test Item')).toBeInTheDocument();
+  });
+
+  it('has option role', () => {
+    render(<XDSCommandPaletteItem value="test">Item</XDSCommandPaletteItem>);
+    expect(screen.getByRole('option')).toBeInTheDocument();
+  });
+
+  it('calls onSelect when clicked', () => {
+    const handleSelect = vi.fn();
+    render(
+      <XDSCommandPaletteItem value="test" onSelect={handleSelect}>
+        Item
+      </XDSCommandPaletteItem>,
+    );
+    fireEvent.click(screen.getByRole('option'));
+    expect(handleSelect).toHaveBeenCalledWith('test');
+  });
+
+  it('does not call onSelect when disabled', () => {
+    const handleSelect = vi.fn();
+    render(
+      <XDSCommandPaletteItem value="test" onSelect={handleSelect} isDisabled>
+        Item
+      </XDSCommandPaletteItem>,
+    );
+    fireEvent.click(screen.getByRole('option'));
+    expect(handleSelect).not.toHaveBeenCalled();
+  });
+
+  it('sets aria-disabled when disabled', () => {
+    render(
+      <XDSCommandPaletteItem value="test" isDisabled>
+        Item
+      </XDSCommandPaletteItem>,
+    );
+    expect(screen.getByRole('option')).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('sets aria-selected when highlighted', () => {
+    render(
+      <XDSCommandPaletteItem value="test" isHighlighted>
+        Item
+      </XDSCommandPaletteItem>,
+    );
+    expect(screen.getByRole('option')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('sets data-value attribute', () => {
+    render(
+      <XDSCommandPaletteItem value="my-value">Item</XDSCommandPaletteItem>,
+    );
+    expect(screen.getByRole('option')).toHaveAttribute(
+      'data-value',
+      'my-value',
+    );
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
@@ -1,0 +1,159 @@
+/**
+ * @file XDSCommandPaletteItem.tsx
+ * @input Uses React, StyleX
+ * @output Exports XDSCommandPaletteItem component
+ * @position Sub-component; individual selectable item
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ */
+
+'use client';
+
+import {forwardRef, useCallback, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  typographyVars,
+  textSizeVars,
+} from '../theme/tokens.stylex';
+
+const HOVER_HOVER = '@media (hover: hover)';
+
+const styles = stylex.create({
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    width: '100%',
+    paddingInline: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-2'],
+    borderRadius: radiusVars['--radius-content'],
+    fontFamily: typographyVars['--font-body'],
+    fontSize: textSizeVars['--text-base'],
+    color: colorVars['--color-text-primary'],
+    backgroundColor: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    textAlign: 'left',
+    outline: 'none',
+    userSelect: 'none',
+  },
+  itemHover: {
+    ':hover': {
+      [HOVER_HOVER]: {
+        backgroundColor: colorVars['--color-hover-overlay'],
+      },
+    },
+  },
+  itemHighlighted: {
+    backgroundColor: colorVars['--color-hover-overlay'],
+  },
+  itemDisabled: {
+    opacity: 0.5,
+    cursor: 'not-allowed',
+  },
+  itemSelected: {
+    backgroundColor: colorVars['--color-accent-deemphasized'],
+  },
+});
+
+export interface XDSCommandPaletteItemProps {
+  /**
+   * Unique value for identification and selection.
+   */
+  value: string;
+
+  /**
+   * Called when this item is selected (via click or Enter).
+   */
+  onSelect?: (value: string) => void;
+
+  /**
+   * Whether this item is visually highlighted (e.g., via keyboard navigation).
+   * @default false
+   */
+  isHighlighted?: boolean;
+
+  /**
+   * Whether this item is currently selected.
+   * @default false
+   */
+  isSelected?: boolean;
+
+  /**
+   * Whether the item is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Item content. Fully custom — render icons, descriptions, shortcuts, etc.
+   */
+  children: ReactNode;
+
+  /**
+   * StyleX overrides for the item.
+   */
+  xstyle?: StyleXStyles;
+}
+
+/**
+ * A selectable item in the command palette.
+ * Accepts arbitrary children for full rendering control.
+ *
+ * @compositionHint Place inside XDSCommandPaletteList or XDSCommandPaletteGroup.
+ *
+ * @example
+ * ```
+ * <XDSCommandPaletteItem value="settings" onSelect={() => navigate('/settings')}>
+ *   Settings
+ * </XDSCommandPaletteItem>
+ * ```
+ */
+export const XDSCommandPaletteItem = forwardRef<
+  HTMLDivElement,
+  XDSCommandPaletteItemProps
+>(function XDSCommandPaletteItem(
+  {
+    value,
+    onSelect,
+    isHighlighted = false,
+    isSelected = false,
+    isDisabled = false,
+    children,
+    xstyle,
+  },
+  ref,
+) {
+  const handleClick = useCallback(() => {
+    if (isDisabled) return;
+    onSelect?.(value);
+  }, [isDisabled, value, onSelect]);
+
+  return (
+    <div
+      ref={ref}
+      role="option"
+      aria-selected={isHighlighted}
+      aria-disabled={isDisabled || undefined}
+      data-value={value}
+      onClick={handleClick}
+      {...stylex.props(
+        styles.item,
+        !isDisabled && styles.itemHover,
+        isHighlighted && styles.itemHighlighted,
+        isSelected && styles.itemSelected,
+        isDisabled && styles.itemDisabled,
+        xstyle,
+      )}>
+      {children}
+    </div>
+  );
+});
+
+XDSCommandPaletteItem.displayName = 'XDSCommandPaletteItem';

--- a/packages/core/src/CommandPalette/XDSCommandPaletteList.test.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteList.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @file XDSCommandPaletteList.test.tsx
+ * @input Uses vitest, @testing-library/react
+ * @output Unit tests for XDSCommandPaletteList
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSCommandPaletteList} from './XDSCommandPaletteList';
+
+describe('XDSCommandPaletteList', () => {
+  it('renders children', () => {
+    render(
+      <XDSCommandPaletteList>
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </XDSCommandPaletteList>,
+    );
+    expect(screen.getByText('Item 1')).toBeInTheDocument();
+    expect(screen.getByText('Item 2')).toBeInTheDocument();
+  });
+
+  it('has listbox role', () => {
+    render(
+      <XDSCommandPaletteList>
+        <div>Item</div>
+      </XDSCommandPaletteList>,
+    );
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+  });
+
+  it('has default aria-label', () => {
+    render(
+      <XDSCommandPaletteList>
+        <div>Item</div>
+      </XDSCommandPaletteList>,
+    );
+    expect(screen.getByRole('listbox')).toHaveAttribute(
+      'aria-label',
+      'Commands',
+    );
+  });
+
+  it('supports custom label', () => {
+    render(
+      <XDSCommandPaletteList label="Search results">
+        <div>Item</div>
+      </XDSCommandPaletteList>,
+    );
+    expect(screen.getByRole('listbox')).toHaveAttribute(
+      'aria-label',
+      'Search results',
+    );
+  });
+});

--- a/packages/core/src/CommandPalette/XDSCommandPaletteList.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteList.tsx
@@ -1,0 +1,77 @@
+/**
+ * @file XDSCommandPaletteList.tsx
+ * @input Uses React, StyleX
+ * @output Exports XDSCommandPaletteList component
+ * @position Sub-component; scrollable results container
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/CommandPalette/README.md
+ * - /packages/core/src/CommandPalette/index.ts
+ */
+
+'use client';
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {spacingVars} from '../theme/tokens.stylex';
+
+const styles = stylex.create({
+  list: {
+    overflowY: 'auto',
+    maxHeight: '100%',
+    padding: spacingVars['--spacing-1'],
+    flex: 1,
+  },
+});
+
+export interface XDSCommandPaletteListProps {
+  /**
+   * Command palette items, groups, empty states, etc.
+   */
+  children: ReactNode;
+
+  /**
+   * Accessible label for the listbox.
+   * @default 'Commands'
+   */
+  label?: string;
+
+  /**
+   * StyleX overrides for the list container.
+   */
+  xstyle?: StyleXStyles;
+}
+
+/**
+ * Scrollable results container for the command palette.
+ * Renders as a listbox for ARIA compliance.
+ *
+ * @compositionHint Place inside XDSCommandPalette, after XDSCommandPaletteInput.
+ *   Contains XDSCommandPaletteItem and XDSCommandPaletteGroup children.
+ *
+ * @example
+ * ```
+ * <XDSCommandPaletteList>
+ *   <XDSCommandPaletteItem value="home" onSelect={goHome}>
+ *     Go Home
+ *   </XDSCommandPaletteItem>
+ * </XDSCommandPaletteList>
+ * ```
+ */
+export function XDSCommandPaletteList({
+  children,
+  label = 'Commands',
+  xstyle,
+}: XDSCommandPaletteListProps) {
+  return (
+    <div
+      role="listbox"
+      aria-label={label}
+      {...stylex.props(styles.list, xstyle)}>
+      {children}
+    </div>
+  );
+}
+
+XDSCommandPaletteList.displayName = 'XDSCommandPaletteList';

--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -1,7 +1,7 @@
 /**
  * @file index.ts
- * @input Imports XDSCommandPalette component and types
- * @output Exports XDSCommandPalette and related types
+ * @input Imports CommandPalette components and types
+ * @output Exports all CommandPalette components and types
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header
@@ -12,3 +12,15 @@ export type {XDSCommandPaletteProps} from './XDSCommandPalette';
 
 export {XDSCommandPaletteInput} from './XDSCommandPaletteInput';
 export type {XDSCommandPaletteInputProps} from './XDSCommandPaletteInput';
+
+export {XDSCommandPaletteList} from './XDSCommandPaletteList';
+export type {XDSCommandPaletteListProps} from './XDSCommandPaletteList';
+
+export {XDSCommandPaletteItem} from './XDSCommandPaletteItem';
+export type {XDSCommandPaletteItemProps} from './XDSCommandPaletteItem';
+
+export {XDSCommandPaletteGroup} from './XDSCommandPaletteGroup';
+export type {XDSCommandPaletteGroupProps} from './XDSCommandPaletteGroup';
+
+export {XDSCommandPaletteFooter} from './XDSCommandPaletteFooter';
+export type {XDSCommandPaletteFooterProps} from './XDSCommandPaletteFooter';

--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input Imports XDSCommandPalette component and types
+ * @output Exports XDSCommandPalette and related types
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header
+ */
+
+export {XDSCommandPalette} from './XDSCommandPalette';
+export type {XDSCommandPaletteProps} from './XDSCommandPalette';

--- a/packages/core/src/CommandPalette/index.ts
+++ b/packages/core/src/CommandPalette/index.ts
@@ -9,3 +9,6 @@
 
 export {XDSCommandPalette} from './XDSCommandPalette';
 export type {XDSCommandPaletteProps} from './XDSCommandPalette';
+
+export {XDSCommandPaletteInput} from './XDSCommandPaletteInput';
+export type {XDSCommandPaletteInputProps} from './XDSCommandPaletteInput';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -53,6 +53,7 @@ export * from './TreeList';
 
 // Keyboard shortcut display
 export * from './Kbd';
+export * from './CommandPalette';
 export * from './Dialog';
 export * from './DropdownMenu';
 export * from './MoreMenu';


### PR DESCRIPTION
## Summary

Adds the presentational sub-components for the command palette.

**PR 3 of 4** in the incremental command palette rebuild:
1. ✅ Dialog shell (#501)
2. ✅ Input component (#502)
3. ✅ **List, Item, Group, Footer** (this PR)
4. ⬜ Context provider

## Components

| Component | Purpose |
|-----------|---------|
| `XDSCommandPaletteList` | Scrollable `listbox` container |
| `XDSCommandPaletteItem` | Selectable `option` with highlight/select/disabled states |
| `XDSCommandPaletteGroup` | Labeled grouping with heading |
| `XDSCommandPaletteFooter` | Keyboard hints (default or custom content) |

## Design decisions

- *All components are purely presentational* — no context dependency. Highlight, selection, and filtering are controlled via props.
- `XDSCommandPaletteItem` uses `isHighlighted`/`isSelected`/`isDisabled` props. The context provider (PR 4) will manage these.
- `:hover` styles use `@media (hover: hover)` guard per XDS convention.
- `XDSCommandPaletteFooter` includes a built-in `XDSDivider` and default keyboard hints (↑↓ Navigate, ↵ Select, Esc Close). Custom children override defaults.

## Tests

18 new tests (31 total across all CommandPalette tests).

## Depends on

- #502 (input)