### PR TITLE
fix(docs): remove incorrect specificity claim from className JSDoc

### DIFF
--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -17,10 +17,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSAspectRatioProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSAspectRatioProps extends HTMLAttributes<HTMLElement> {
   /**
    * The aspect ratio as width/height (e.g., 16/9 = 1.777..., 4/3 = 1.333..., 1 for square).
    */
@@ -33,9 +30,27 @@ export interface XDSAspectRatioProps extends Omit<
   children: ReactNode;
 
   /**
-   * StyleX styles to apply to the aspect ratio container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 }
 
 const styles = stylex.create({
@@ -67,15 +82,19 @@ const styles = stylex.create({
  * ```
  */
 export const XDSAspectRatio = forwardRef<HTMLElement, XDSAspectRatioProps>(
-  function XDSAspectRatio({ratio, children, xstyle, ...props}, ref) {
+  function XDSAspectRatio(
+    {ratio, children, xstyle, className, style, ...props},
+    ref,
+  ) {
     return (
       <div
         ref={ref as React.Ref<HTMLDivElement>}
         {...mergeProps(
           xdsClassName('aspect-ratio'),
           stylex.props(styles.container, xstyle),
+          className,
+          {...style, aspectRatio: ratio},
         )}
-        style={{aspectRatio: ratio}}
         {...props}>
         <div {...stylex.props(styles.child)}>{children}</div>
       </div>

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -41,8 +41,7 @@ export interface XDSAspectRatioProps extends HTMLAttributes<HTMLElement> {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -118,9 +118,27 @@ export interface XDSBannerProps {
    */
   children?: ReactNode;
   /**
-   * StyleX override styles applied to the root element.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /**
    * Test ID for the root element.
    */
@@ -338,6 +356,8 @@ export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
       defaultIsExpanded = false,
       children,
       xstyle,
+      className,
+      style,
       'data-testid': testId,
     },
     ref,
@@ -382,6 +402,8 @@ export const XDSBanner = forwardRef<HTMLDivElement, XDSBannerProps>(
             variant === 'section' && styles.section,
             xstyle,
           ),
+          className,
+          style,
         )}>
         {/* Header: colored status background */}
         <div

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -129,8 +129,7 @@ export interface XDSBannerProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -90,8 +90,7 @@ export interface XDSBreadcrumbsProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -79,9 +79,27 @@ export interface XDSBreadcrumbsProps {
    */
   variant?: XDSBreadcrumbsVariant;
   /**
-   * StyleX styles to apply to the nav container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /**
    * Accessible label for the nav landmark.
    * @default 'Breadcrumb'
@@ -158,6 +176,8 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
       separator = '/',
       variant = 'default',
       xstyle,
+      className,
+      style,
       label = 'Breadcrumb',
       'data-testid': testId,
     },
@@ -216,6 +236,8 @@ export const XDSBreadcrumbs = forwardRef<HTMLElement, XDSBreadcrumbsProps>(
         {...mergeProps(
           xdsClassName('breadcrumbs', {variant}),
           stylex.props(navStyles.root, xstyle),
+          className,
+          style,
         )}>
         <ol {...stylex.props(listStyles.root)}>{rendered}</ol>
       </nav>

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -43,10 +43,7 @@ const dynamicStyles = stylex.create({
 
 export type CenterAxis = 'both' | 'horizontal' | 'vertical';
 
-export interface XDSCenterProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'style' | 'className'
-> {
+export interface XDSCenterProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Center axis - which direction(s) to center.
    * - `both`: Center both horizontally and vertically (default)
@@ -80,9 +77,27 @@ export interface XDSCenterProps extends Omit<
   children: ReactNode;
 
   /**
-   * StyleX styles to apply to the container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 }
 
 /**
@@ -107,6 +122,8 @@ export const XDSCenter = forwardRef<HTMLDivElement, XDSCenterProps>(
       isInline = false,
       children,
       xstyle,
+      className,
+      style,
       ...props
     },
     ref,
@@ -121,6 +138,8 @@ export const XDSCenter = forwardRef<HTMLDivElement, XDSCenterProps>(
         dynamicStyles.sizing(width ?? null, height ?? null),
         xstyle,
       ),
+      className,
+      style,
     );
 
     return (

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -88,8 +88,7 @@ export interface XDSCenterProps extends HTMLAttributes<HTMLDivElement> {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -25,7 +25,7 @@ import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSDividerProps extends Omit<
   HTMLAttributes<HTMLElement>,
-  'style' | 'className' | 'children'
+  'children'
 > {
   /**
    * Orientation of the divider.
@@ -55,9 +55,27 @@ export interface XDSDividerProps extends Omit<
   isFullBleed?: boolean;
 
   /**
-   * StyleX styles to apply to the divider container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 }
 
 const baseStyles = stylex.create({
@@ -137,6 +155,8 @@ export const XDSDivider = forwardRef<HTMLElement, XDSDividerProps>(
       variant = 'subtle',
       isFullBleed = false,
       xstyle,
+      className,
+      style,
       ...props
     },
     ref,
@@ -158,6 +178,8 @@ export const XDSDivider = forwardRef<HTMLElement, XDSDividerProps>(
                 : fullBleedStyles.vertical),
             xstyle,
           ),
+          className,
+          style,
         )}
         {...props}>
         <div

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -66,8 +66,7 @@ export interface XDSDividerProps extends Omit<
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -104,9 +104,27 @@ export interface XDSEmptyStateProps {
    */
   isCompact?: boolean;
   /**
-   * StyleX override styles applied to the container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /**
    * Test ID for the container element.
    */
@@ -137,7 +155,17 @@ export interface XDSEmptyStateProps {
  */
 export const XDSEmptyState = forwardRef<HTMLDivElement, XDSEmptyStateProps>(
   (
-    {title, description, icon, actions, isCompact = false, xstyle, ...props},
+    {
+      title,
+      description,
+      icon,
+      actions,
+      isCompact = false,
+      xstyle,
+      className,
+      style,
+      ...props
+    },
     ref,
   ) => {
     return (
@@ -151,6 +179,8 @@ export const XDSEmptyState = forwardRef<HTMLDivElement, XDSEmptyStateProps>(
             isCompact && styles.containerCompact,
             xstyle,
           ),
+          className,
+          style,
         )}
         {...props}>
         {icon != null && <div aria-hidden="true">{icon}</div>}

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -115,8 +115,7 @@ export interface XDSEmptyStateProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -162,8 +162,7 @@ export interface XDSFieldProps extends Omit<
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -15,6 +15,7 @@
 
 import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSFieldLabel} from './XDSFieldLabel';
 import {XDSFieldStatus} from './XDSFieldStatus';
 import {
@@ -150,6 +151,28 @@ export interface XDSFieldProps extends Omit<
    */
   statusVariant?: 'attached' | 'detached';
   /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
+  /**
    * The input or control to render inside the field.
    */
   children: ReactNode;
@@ -181,7 +204,10 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
       status,
       labelTooltip,
       statusVariant = 'attached',
+      xstyle,
       children,
+      className,
+      style,
       ...props
     },
     ref,
@@ -189,7 +215,12 @@ export const XDSField = forwardRef<HTMLDivElement, XDSFieldProps>(
     return (
       <div
         ref={ref}
-        {...mergeProps(xdsClassName('field'), stylex.props(styles.container))}
+        {...mergeProps(
+          xdsClassName('field'),
+          stylex.props(styles.container, xstyle),
+          className,
+          style,
+        )}
         {...props}>
         <XDSFieldLabel
           label={label}

--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -92,8 +92,7 @@ export interface XDSFormLayoutProps extends HTMLAttributes<HTMLDivElement> {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -60,10 +60,7 @@ const styles = stylex.create({
 // Props
 // =============================================================================
 
-export interface XDSFormLayoutProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'style' | 'className'
-> {
+export interface XDSFormLayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Form fields to arrange. Accepts XDS inputs (XDSTextInput, XDSSelector, etc.)
    * and XDSField-wrapped custom controls.
@@ -84,9 +81,27 @@ export interface XDSFormLayoutProps extends Omit<
   direction?: XDSFormLayoutDirection;
 
   /**
-   * StyleX styles to apply to the layout container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Test ID for the root element.
@@ -118,7 +133,7 @@ export interface XDSFormLayoutProps extends Omit<
  */
 export const XDSFormLayout = forwardRef<HTMLDivElement, XDSFormLayoutProps>(
   function XDSFormLayout(
-    {children, direction = 'vertical', xstyle, ...props},
+    {children, direction = 'vertical', xstyle, className, style, ...props},
     ref,
   ) {
     const contextValue = useMemo(() => ({direction}), [direction]);
@@ -135,6 +150,8 @@ export const XDSFormLayout = forwardRef<HTMLDivElement, XDSFormLayoutProps>(
               direction === 'horizontal-labels' && styles.horizontalLabels,
               xstyle,
             ),
+            className,
+            style,
           )}
           {...props}>
           {children}

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -97,8 +97,7 @@ export interface XDSGridProps extends HTMLAttributes<HTMLElement> {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -26,10 +26,7 @@ import {xdsClassName, mergeProps} from '../utils';
 
 export type GridAlignment = 'start' | 'center' | 'end' | 'stretch';
 
-export interface XDSGridProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSGridProps extends HTMLAttributes<HTMLElement> {
   /**
    * Maximum number of columns.
    * - When only columns is set: creates fixed equal-width columns
@@ -89,9 +86,27 @@ export interface XDSGridProps extends Omit<
   justify?: GridAlignment;
 
   /**
-   * StyleX styles to apply to the grid container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Content to render inside the grid.
@@ -337,6 +352,8 @@ export const XDSGrid = forwardRef<HTMLElement, XDSGridProps>(function XDSGrid(
     align,
     justify,
     xstyle,
+    className,
+    style,
     children,
     ...props
   },
@@ -393,8 +410,9 @@ export const XDSGrid = forwardRef<HTMLElement, XDSGridProps>(function XDSGrid(
           justify != null && justifyStyles[justify],
           xstyle,
         ),
+        className,
+        {...style, ...inlineStyle},
       )}
-      style={inlineStyle}
       {...props}>
       {children}
     </div>

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -41,8 +41,7 @@ export interface XDSGridSpanProps extends HTMLAttributes<HTMLElement> {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -15,10 +15,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSGridSpanProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSGridSpanProps extends HTMLAttributes<HTMLElement> {
   /**
    * Number of columns to span, or 'full' to span all columns.
    * - Number: `grid-column: span N`
@@ -33,9 +30,27 @@ export interface XDSGridSpanProps extends Omit<
   rows?: number;
 
   /**
-   * StyleX styles to apply to the grid span element.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Content to render inside the grid span.
@@ -68,7 +83,10 @@ const baseStyles = stylex.create({
  * ```
  */
 export const XDSGridSpan = forwardRef<HTMLElement, XDSGridSpanProps>(
-  function XDSGridSpan({columns, rows, xstyle, children, ...props}, ref) {
+  function XDSGridSpan(
+    {columns, rows, xstyle, className, style, children, ...props},
+    ref,
+  ) {
     // Build inline style for grid spanning
     const inlineStyle: React.CSSProperties = {
       ...(columns != null && {
@@ -85,8 +103,9 @@ export const XDSGridSpan = forwardRef<HTMLElement, XDSGridSpanProps>(
         {...mergeProps(
           xdsClassName('grid-span'),
           stylex.props(baseStyles.span, xstyle),
+          className,
+          {...style, ...inlineStyle},
         )}
-        style={inlineStyle}
         {...props}>
         {children}
       </div>

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -80,9 +80,27 @@ export interface XDSKbdProps {
   keys: string;
 
   /**
-   * StyleX overrides for the wrapper element.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 }
 
 /**
@@ -96,12 +114,17 @@ export interface XDSKbdProps {
  * <XDSKbd keys="mod+k" />
  * ```
  */
-export function XDSKbd({keys, xstyle}: XDSKbdProps) {
+export function XDSKbd({keys, xstyle, className, style}: XDSKbdProps) {
   const parts = keys.split('+').map(key => key.trim().toLowerCase());
 
   return (
     <span
-      {...mergeProps(xdsClassName('kbd'), stylex.props(styles.wrapper, xstyle))}
+      {...mergeProps(
+        xdsClassName('kbd'),
+        stylex.props(styles.wrapper, xstyle),
+        className,
+        style,
+      )}
       aria-hidden="true">
       {parts.map((key, i) => (
         <kbd key={i} {...stylex.props(styles.kbd)}>

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -91,8 +91,7 @@ export interface XDSKbdProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -64,9 +64,27 @@ export interface XDSListProps {
   listStyle?: XDSListStyle;
 
   /**
-   * StyleX styles to apply to the list container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Test ID for testing frameworks.
@@ -147,6 +165,8 @@ export const XDSList = forwardRef<
       header,
       listStyle = 'none',
       xstyle,
+      className,
+      style,
       'data-testid': testId,
     },
     ref,
@@ -201,6 +221,8 @@ export const XDSList = forwardRef<
               hasMarkers && styles.listWithMarkers,
               xstyle,
             ),
+            className,
+            style,
           )}>
           {renderedChildren}
         </Tag>

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -75,8 +75,7 @@ export interface XDSListProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -94,8 +94,7 @@ export interface XDSListItemProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -83,9 +83,27 @@ export interface XDSListItemProps {
   isSelected?: boolean;
 
   /**
-   * StyleX styles to apply to the list item.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Test ID for testing frameworks.
@@ -279,6 +297,8 @@ export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
       isDisabled = false,
       isSelected = false,
       xstyle,
+      className,
+      style,
       'data-testid': testId,
     },
     ref,
@@ -363,6 +383,8 @@ export const XDSListItem = forwardRef<HTMLLIElement, XDSListItemProps>(
             isSelected && styles.selected,
             xstyle,
           ),
+          className,
+          style,
         )}
         onClick={isInteractive ? handleContainerClick : undefined}>
         {hasMarkers ? (

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -120,8 +120,28 @@ export interface XDSPaginationProps {
   // --- Standard XDS ---
   /** Test ID for automated testing. */
   'data-testid'?: string;
-  /** StyleX overrides for the root element. */
+  /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
+   */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 }
 
 // =============================================================================
@@ -316,6 +336,8 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
       label = 'Pagination',
       'data-testid': testId,
       xstyle,
+      className,
+      style,
     },
     ref,
   ) {
@@ -491,6 +513,8 @@ export const XDSPagination = forwardRef<HTMLElement, XDSPaginationProps>(
         {...mergeProps(
           xdsClassName('pagination', {variant, size}),
           stylex.props(styles.root, xstyle),
+          className,
+          style,
         )}>
         {pageSizeOptions != null && pageSizeOptions.length > 0 && (
           <div {...stylex.props(styles.pageSizeSelector)}>

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -132,8 +132,7 @@ export interface XDSPaginationProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -106,8 +106,7 @@ export interface XDSProgressBarProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -95,9 +95,27 @@ export interface XDSProgressBarProps {
    */
   isIndeterminate?: boolean;
   /**
-   * StyleX styles to apply to the outer container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /**
    * Test ID for testing utilities.
    */
@@ -249,6 +267,8 @@ export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
       size = 'md',
       isIndeterminate = false,
       xstyle,
+      className,
+      style,
       'data-testid': dataTestId,
     },
     ref,
@@ -267,6 +287,8 @@ export const XDSProgressBar = forwardRef<HTMLDivElement, XDSProgressBarProps>(
         {...mergeProps(
           xdsClassName('progressbar', {variant, size}),
           stylex.props(styles.container, xstyle),
+          className,
+          style,
         )}
         data-testid={dataTestId}>
         {/* Label row */}

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -112,9 +112,27 @@ export interface XDSRadioListProps {
    */
   labelTooltip?: string;
   /**
-   * Additional styles for the outer container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /**
    * Test ID for the outer container.
    */
@@ -155,6 +173,8 @@ export function XDSRadioList({
   status,
   labelTooltip,
   xstyle,
+  className,
+  style,
   'data-testid': dataTestId,
   children,
 }: XDSRadioListProps) {
@@ -194,7 +214,9 @@ export function XDSRadioList({
       }
       labelTooltip={labelTooltip}
       statusVariant="detached"
-      {...stylex.props(xstyle)}>
+      xstyle={xstyle}
+      className={className}
+      style={style}>
       <div
         role="radiogroup"
         aria-label={label}

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -123,8 +123,7 @@ export interface XDSRadioListProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -113,8 +113,7 @@ export interface XDSSideNavProps extends HTMLAttributes<HTMLElement> {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -80,10 +80,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSSideNavProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSSideNavProps extends HTMLAttributes<HTMLElement> {
   /**
    * Header area — typically XDSSideNavHeader. Sticky at top.
    */
@@ -105,9 +102,27 @@ export interface XDSSideNavProps extends Omit<
    */
   footerIcons?: ReactNode;
   /**
-   * StyleX overrides for the root container.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /**
    * Test ID for the root element.
    */
@@ -146,6 +161,8 @@ export const XDSSideNav = forwardRef<HTMLElement, XDSSideNavProps>(
       footer,
       footerIcons,
       xstyle,
+      className,
+      style,
       'data-testid': testId,
       ...props
     },
@@ -163,6 +180,8 @@ export const XDSSideNav = forwardRef<HTMLElement, XDSSideNavProps>(
         {...mergeProps(
           xdsClassName('side-nav'),
           stylex.props(styles.root, xstyle),
+          className,
+          style,
         )}
         {...props}>
         {hasStickyTop && (

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -82,8 +82,7 @@ export interface XDSSliderBaseProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -70,8 +70,28 @@ export interface XDSSliderBaseProps {
   valueDisplay?: 'tooltip' | 'text' | 'none';
   /** Tick marks at specified positions with optional labels. */
   marks?: Array<{value: number; label?: string}>;
-  /** Additional styles. */
+  /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
+   */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /** Test ID for the root element. */
   'data-testid'?: string;
 }
@@ -320,6 +340,8 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
       valueDisplay = 'tooltip',
       marks,
       xstyle,
+      className,
+      style,
       'data-testid': testId,
       value,
       onChange,
@@ -630,7 +652,9 @@ export const XDSSlider = forwardRef<HTMLDivElement, XDSSliderProps>(
         }
         labelTooltip={labelTooltip}
         statusVariant="detached"
-        {...stylex.props(xstyle)}>
+        xstyle={xstyle}
+        className={className}
+        style={style}>
         <div {...stylex.props(styles.sliderRow)}>
           <div
             ref={node => {

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -42,10 +42,7 @@ import {xdsClassName, mergeProps} from '../utils';
  */
 export type StackAlignment = StackMainAlignment | StackCrossAlignment;
 
-export interface XDSStackProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSStackProps extends HTMLAttributes<HTMLElement> {
   /**
    * Direction of the stack layout.
    * - `horizontal`: Items flow left-to-right (like XDSHStack)
@@ -93,9 +90,27 @@ export interface XDSStackProps extends Omit<
   element?: ElementType;
 
   /**
-   * StyleX styles to apply to the stack.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Content to render inside the stack.
@@ -139,6 +154,8 @@ export const XDSStack = forwardRef<HTMLElement, XDSStackProps>(
       wrap,
       element = 'div',
       xstyle,
+      className,
+      style,
       children,
       ...props
     },
@@ -172,6 +189,8 @@ export const XDSStack = forwardRef<HTMLElement, XDSStackProps>(
         ...mergeProps(
           xdsClassName('stack', {direction, gap, wrap}),
           stylexProps,
+          className,
+          style,
         ),
         ...props,
       },

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -101,8 +101,7 @@ export interface XDSStackProps extends HTMLAttributes<HTMLElement> {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Stack/XDSStackItem.tsx
+++ b/packages/core/src/Stack/XDSStackItem.tsx
@@ -61,8 +61,7 @@ export interface XDSStackItemProps extends HTMLAttributes<HTMLElement> {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Stack/XDSStackItem.tsx
+++ b/packages/core/src/Stack/XDSStackItem.tsx
@@ -27,10 +27,7 @@ import {
 } from './stackItem.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSStackItemProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSStackItemProps extends HTMLAttributes<HTMLElement> {
   /**
    * Overrides the default cross-alignment for this item.
    * (hAlign for VStack, vAlign for HStack)
@@ -53,9 +50,27 @@ export interface XDSStackItemProps extends Omit<
   element?: ElementType;
 
   /**
-   * StyleX styles to apply to the stack item.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Content to render inside the stack item.
@@ -79,7 +94,16 @@ export interface XDSStackItemProps extends Omit<
  */
 export const XDSStackItem = forwardRef<HTMLElement, XDSStackItemProps>(
   function XDSStackItem(
-    {crossAlignSelf, size, element = 'div', xstyle, children, ...props},
+    {
+      crossAlignSelf,
+      size,
+      element = 'div',
+      xstyle,
+      className,
+      style,
+      children,
+      ...props
+    },
     ref,
   ) {
     const stylexProps = stylex.props(
@@ -91,7 +115,12 @@ export const XDSStackItem = forwardRef<HTMLElement, XDSStackItemProps>(
       element,
       {
         ref: ref as Ref<Element>,
-        ...mergeProps(xdsClassName('stack-item', {size}), stylexProps),
+        ...mergeProps(
+          xdsClassName('stack-item', {size}),
+          stylexProps,
+          className,
+          style,
+        ),
         ...props,
       },
       children,

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -114,9 +114,27 @@ export interface XDSStatusDotProps {
    */
   isPulsing?: boolean;
   /**
-   * Optional StyleX styles override.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /**
    * Optional test ID for testing.
    */
@@ -137,7 +155,19 @@ export interface XDSStatusDotProps {
  * ```
  */
 export const XDSStatusDot = forwardRef<HTMLSpanElement, XDSStatusDotProps>(
-  ({variant, size = 'md', label, isPulsing = false, xstyle, ...props}, ref) => {
+  (
+    {
+      variant,
+      size = 'md',
+      label,
+      isPulsing = false,
+      xstyle,
+      className,
+      style,
+      ...props
+    },
+    ref,
+  ) => {
     return (
       <span
         ref={ref}
@@ -153,6 +183,8 @@ export const XDSStatusDot = forwardRef<HTMLSpanElement, XDSStatusDotProps>(
             isPulsing && styles.reducedMotion,
             xstyle,
           ),
+          className,
+          style,
         )}
         {...props}
       />

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -125,8 +125,7 @@ export interface XDSStatusDotProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -152,8 +152,7 @@ export interface XDSHeadingProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -141,11 +141,27 @@ export interface XDSHeadingProps {
   hasStrikethrough?: boolean;
 
   /**
-   * Constrained styles for layout integration.
-   * Allows margins, width constraints, flex child props, text alignment.
-   * Typography properties (fontSize, fontWeight, color, etc.) should NOT be used.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Heading content
@@ -199,6 +215,8 @@ export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
       hasCapsize = false,
       hasStrikethrough = false,
       xstyle,
+      className,
+      style,
       children,
       ...props
     },
@@ -278,8 +296,9 @@ export const XDSHeading = forwardRef<HTMLHeadingElement, XDSHeadingProps>(
               // User xstyle
               xstyle,
             ),
+            className,
+            {...style, ...inlineStyle},
           )}
-          style={inlineStyle}
           title={tooltipEnabled ? truncation.fullText : undefined}
           {...ariaProps}
           {...props}>

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -136,11 +136,27 @@ export interface XDSTextProps {
   hasTabularNumbers?: boolean;
 
   /**
-   * Constrained styles for layout integration.
-   * Allows margins, width constraints, flex child props, text alignment.
-   * Typography properties (fontSize, fontWeight, color, etc.) should NOT be used.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 
   /**
    * Text content
@@ -195,6 +211,8 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
     hasStrikethrough = false,
     hasTabularNumbers = false,
     xstyle,
+    className,
+    style,
     as: Component = 'span',
     children,
     ...props
@@ -270,8 +288,9 @@ export const XDSText = forwardRef<HTMLElement, XDSTextProps>(function XDSText(
             // User xstyle
             xstyle,
           ),
+          className,
+          {...style, ...inlineStyle},
         )}
-        style={inlineStyle}
         title={tooltipEnabled ? truncation.fullText : undefined}
         {...props}>
         {children}

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -147,8 +147,7 @@ export interface XDSTextProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -112,8 +112,7 @@ export interface XDSTokenProps {
    */
   xstyle?: StyleXStyles;
   /**
-   * CSS class name(s) to append to the root element. Applied after StyleX
-   * classes, so Tailwind or utility classes will win in specificity.
+   * CSS class name(s) appended to the root element.
    * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
    */
   className?: string;

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -101,9 +101,27 @@ export interface XDSTokenProps {
    */
   isLabelHidden?: boolean;
   /**
-   * Additional StyleX styles to apply to the root element.
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```tsx
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
    */
   xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) to append to the root element. Applied after StyleX
+   * classes, so Tailwind or utility classes will win in specificity.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
   /**
    * Test ID for testing frameworks.
    */
@@ -314,6 +332,8 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
       endContent,
       isLabelHidden = false,
       xstyle,
+      className,
+      style,
       'data-testid': testId,
     },
     ref,
@@ -365,6 +385,8 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
               isDisabled && styles.disabled,
               xstyle,
             ),
+            className,
+            style,
           )}>
           {content}
         </a>
@@ -394,6 +416,8 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
               isDisabled && styles.disabled,
               xstyle,
             ),
+            className,
+            style,
           )}>
           {icon}
           <button
@@ -440,6 +464,8 @@ export const XDSToken = forwardRef<HTMLElement, XDSTokenProps>(
             isDisabled && styles.disabled,
             xstyle,
           ),
+          className,
+          style,
         )}>
         {content}
       </span>

--- a/packages/core/src/utils/mergeProps.ts
+++ b/packages/core/src/utils/mergeProps.ts
@@ -1,24 +1,40 @@
 /**
- * Merge stylex.props result with an xds-* class name.
+ * Merge xds-* class name, stylex.props result, and optional consumer className/style.
  *
  * stylex.props() returns { className, style }. This merges the xds-*
  * class name into the className string so both StyleX styles and the
  * stable theme-targeting class are applied.
  *
+ * Consumer className is appended last so utility classes (e.g. Tailwind) win.
+ * Consumer style is spread last so inline overrides win.
+ *
  * @example
  * ```tsx
  * <div {...mergeProps(
  *   xdsClassName('button', { variant }),
- *   stylex.props(styles.base, variants[variant])
+ *   stylex.props(styles.base, variants[variant]),
+ *   className,
+ *   style,
  * )} />
  * ```
  */
 export function mergeProps(
   xdsClass: string,
   stylexResult: {className?: string; style?: object},
+  className?: string,
+  style?: React.CSSProperties,
 ): {className: string; style?: object} {
-  const merged = stylexResult.className
+  let cls = stylexResult.className
     ? `${xdsClass} ${stylexResult.className}`
     : xdsClass;
-  return {className: merged, style: stylexResult.style};
+  if (className) {
+    cls = `${cls} ${className}`;
+  }
+
+  const mergedStyle =
+    style && stylexResult.style
+      ? {...stylexResult.style, ...style}
+      : style || stylexResult.style;
+
+  return {className: cls, style: mergedStyle};
 }

--- a/packages/core/src/utils/mergeProps.ts
+++ b/packages/core/src/utils/mergeProps.ts
@@ -5,7 +5,7 @@
  * class name into the className string so both StyleX styles and the
  * stable theme-targeting class are applied.
  *
- * Consumer className is appended last so utility classes (e.g. Tailwind) win.
+ * Consumer className is appended after StyleX and xds-* classes.
  * Consumer style is spread last so inline overrides win.
  *
  * @example


### PR DESCRIPTION
Fixes incorrect claim in #514 that class name ordering in the HTML `class` attribute affects CSS specificity.

## What changed

The `className` JSDoc across 24 components said:

> Applied after StyleX classes, so Tailwind or utility classes will win in specificity.

Class name ordering in the `class` attribute has no effect on CSS specificity — specificity is determined by the selectors in the stylesheet and their source order, not by where a class appears in the HTML attribute.

**Before:**
```ts
/**
 * CSS class name(s) to append to the root element. Applied after StyleX
 * classes, so Tailwind or utility classes will win in specificity.
 * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
 */
```

**After:**
```ts
/**
 * CSS class name(s) appended to the root element.
 * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
 */
```

Also updated the `mergeProps` utility comment similarly.

## Files changed (25)

24 component files + `mergeProps.ts`