### PR TITLE
refactor(core): replace HTMLAttributes with explicit XDSBaseProps

### DIFF
--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -12,12 +12,13 @@
 
 'use client';
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSAspectRatioProps extends HTMLAttributes<HTMLElement> {
+export interface XDSAspectRatioProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * The aspect ratio as width/height (e.g., 16/9 = 1.777..., 4/3 = 1.333..., 1 for square).
    */

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -13,7 +13,8 @@
 
 'use client';
 
-import {forwardRef, useState, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, useState, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -157,10 +158,7 @@ const dynamicStyles = stylex.create({
   }),
 });
 
-export interface XDSAvatarProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'children'
-> {
+export interface XDSAvatarProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * The alt text shown on hover and made accessible to screen readers.
    * Falls back to `name` if not provided.
@@ -252,6 +250,8 @@ export const XDSAvatar = forwardRef<HTMLDivElement, XDSAvatarProps>(
       size = 'small',
       src,
       status,
+      className,
+      style,
       ...props
     },
     ref,
@@ -277,6 +277,8 @@ export const XDSAvatar = forwardRef<HTMLDivElement, XDSAvatarProps>(
           {...mergeProps(
             xdsClassName('avatar', {size}),
             stylex.props(styles.wrapper),
+            className,
+            style,
           )}
           {...props}>
           <div

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -12,7 +12,8 @@
 
 'use client';
 
-import {useContext, type HTMLAttributes, type ReactNode} from 'react';
+import {useContext, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {XDSAvatarSizeContext} from './XDSAvatarSizeContext';
@@ -50,10 +51,7 @@ function resolveStatusDotSize(avatarSize: number): {
 
 export type XDSAvatarStatusDotVariant = 'positive' | 'neutral' | 'negative';
 
-export interface XDSAvatarStatusDotProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'children'
-> {
+export interface XDSAvatarStatusDotProps extends XDSBaseProps<HTMLSpanElement> {
   /**
    * The semantic color variant of the dot.
    * - `positive` — green dot (e.g. online, accepted)
@@ -159,6 +157,8 @@ export function XDSAvatarStatusDot({
   variant = 'positive',
   label,
   icon,
+  className,
+  style,
   ...props
 }: XDSAvatarStatusDotProps) {
   const avatarSize = useContext(XDSAvatarSizeContext);
@@ -174,6 +174,8 @@ export function XDSAvatarStatusDot({
           variantStyleMap[variant],
           dynamicStyles.size(dotSize, borderWidth),
         ),
+        className,
+        style,
       )}
       {...props}>
       {icon && iconSize > 0 && (

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -13,7 +13,8 @@
 
 'use client';
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -81,10 +82,7 @@ const variants = stylex.create({
  */
 export type XDSBadgeVariant = keyof typeof variants;
 
-export interface XDSBadgeProps extends Omit<
-  HTMLAttributes<HTMLSpanElement>,
-  'className' | 'style'
-> {
+export interface XDSBadgeProps extends XDSBaseProps<HTMLSpanElement> {
   /**
    * The visual style variant of the badge.
    * @default 'neutral'
@@ -116,7 +114,7 @@ export interface XDSBadgeProps extends Omit<
  * ```
  */
 export const XDSBadge = forwardRef<HTMLSpanElement, XDSBadgeProps>(
-  ({variant = 'neutral', children, icon, ...props}, ref) => {
+  ({variant = 'neutral', children, icon, className, style, ...props}, ref) => {
     const isDot = children == null && icon == null;
 
     return (
@@ -125,6 +123,8 @@ export const XDSBadge = forwardRef<HTMLSpanElement, XDSBadgeProps>(
         {...mergeProps(
           xdsClassName('badge', {variant}),
           stylex.props(styles.base, variants[variant], isDot && styles.dot),
+          className,
+          style,
         )}
         {...props}>
         {icon}

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -18,10 +18,10 @@
 import {
   forwardRef,
   useTransition,
-  type ButtonHTMLAttributes,
   type ReactElement,
   type ReactNode,
 } from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -195,10 +195,15 @@ export type XDSButtonVariant = keyof typeof variants;
  */
 export type XDSButtonSize = keyof typeof sizeStyles;
 
-export interface XDSButtonProps extends Omit<
-  ButtonHTMLAttributes<HTMLButtonElement>,
-  'children' | 'disabled'
-> {
+export interface XDSButtonProps extends XDSBaseProps<HTMLButtonElement> {
+  /** HTML button type attribute. @default 'button' */
+  type?: 'button' | 'submit' | 'reset';
+  /** HTML name attribute for form submission. */
+  name?: string;
+  /** HTML value attribute for form submission. */
+  value?: string | number | readonly string[];
+  /** Associates the button with a form element by ID. */
+  form?: string;
   /**
    * Accessible label for the button (required for accessibility).
    * Used as visible text, or as aria-label for icon-only buttons.
@@ -224,6 +229,11 @@ export interface XDSButtonProps extends Omit<
    * @default false
    */
   isLoading?: boolean;
+  /**
+   * Click handler. For async actions that should show a loading state,
+   * use `onClickAction` instead.
+   */
+  onClick?: React.MouseEventHandler<HTMLButtonElement>;
   /**
    * Async click action. Shows loading state while pending.
    */
@@ -320,6 +330,8 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
       children,
       endSlot,
       tooltip,
+      className,
+      style,
       ...props
     },
     ref,
@@ -370,6 +382,8 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
             edgePaddingSignal,
             edgeCompStyle,
           ),
+          className,
+          style,
         )}
         {...props}
         onClick={handleClick}>

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -20,8 +20,8 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
-  type HTMLAttributes,
 } from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
@@ -81,7 +81,7 @@ export interface XDSCalendarHandle {
 // ─── Base Props (shared across all modes) ─────────────────────
 
 interface XDSCalendarBaseProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
+  XDSBaseProps<HTMLDivElement>,
   'onChange' | 'defaultValue'
 > {
   /** Number of months to display (default: 1) */
@@ -194,6 +194,8 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
       hasWeekNumbers = false,
       hasVariableRowCount = false,
       weekStartsOn = 0,
+      className,
+      style,
       ...rest
     } = props;
 
@@ -350,6 +352,8 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
         {...mergeProps(
           xdsClassName('calendar', {mode}),
           stylex.props(calendarStyles.calendar),
+          className,
+          style,
         )}
         {...rest}>
         {/* Header with navigation */}

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -67,6 +67,14 @@ export type {SizeValue} from '../utils/types';
 
 export interface XDSCardProps {
   /**
+   * CSS class name(s) appended to the root element.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element.
+   */
+  style?: React.CSSProperties;
+  /**
    * Width of the card.
    * Numbers are treated as pixels, strings are used as-is.
    */
@@ -132,6 +140,8 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
       minHeight,
       children,
       isFullBleed = false,
+      className,
+      style,
       ...props
     },
     ref,
@@ -153,6 +163,8 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
               minHeight ?? null,
             ),
           ),
+          className,
+          style,
         )}
         {...props}>
         <div

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -12,7 +12,8 @@
 
 'use client';
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import type {SizeValue} from '../utils/types';
@@ -43,7 +44,7 @@ const dynamicStyles = stylex.create({
 
 export type CenterAxis = 'both' | 'horizontal' | 'vertical';
 
-export interface XDSCenterProps extends HTMLAttributes<HTMLDivElement> {
+export interface XDSCenterProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Center axis - which direction(s) to center.
    * - `both`: Center both horizontally and vertically (default)

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -13,13 +13,8 @@
 
 'use client';
 
-import {
-  forwardRef,
-  useEffect,
-  useRef,
-  type DialogHTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {forwardRef, useEffect, useRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -141,10 +136,7 @@ function formatPosition(value: number | string | undefined): string | null {
   return typeof value === 'number' ? `${value}px` : value;
 }
 
-export interface XDSDialogProps extends Omit<
-  DialogHTMLAttributes<HTMLDialogElement>,
-  'children'
-> {
+export interface XDSDialogProps extends XDSBaseProps<HTMLDialogElement> {
   /**
    * Whether the dialog is open.
    */
@@ -238,6 +230,8 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
       variant = 'standard',
       purpose = 'info',
       children,
+      className,
+      style,
       ...props
     },
     ref,
@@ -343,6 +337,8 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
               ),
             isFullscreen && styles.fullscreen,
           ),
+          className,
+          style,
         )}
         {...props}>
         {children}

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -12,7 +12,8 @@
 
 'use client';
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {type HTMLAttributes, forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -24,7 +25,7 @@ import {
 import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSDividerProps extends Omit<
-  HTMLAttributes<HTMLElement>,
+  XDSBaseProps<HTMLDivElement>,
   'children'
 > {
   /**

--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -13,7 +13,8 @@
 
 'use client';
 
-import {forwardRef, useMemo, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, useMemo, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
@@ -60,7 +61,7 @@ const styles = stylex.create({
 // Props
 // =============================================================================
 
-export interface XDSFormLayoutProps extends HTMLAttributes<HTMLDivElement> {
+export interface XDSFormLayoutProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Form fields to arrange. Accepts XDS inputs (XDSTextInput, XDSSelector, etc.)
    * and XDSField-wrapped custom controls.

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -12,7 +12,8 @@
 
 'use client';
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
@@ -26,7 +27,7 @@ import {xdsClassName, mergeProps} from '../utils';
 
 export type GridAlignment = 'start' | 'center' | 'end' | 'stretch';
 
-export interface XDSGridProps extends HTMLAttributes<HTMLElement> {
+export interface XDSGridProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Maximum number of columns.
    * - When only columns is set: creates fixed equal-width columns

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -10,12 +10,13 @@
  * - /apps/storybook/stories/Grid.stories.tsx
  */
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSGridSpanProps extends HTMLAttributes<HTMLElement> {
+export interface XDSGridSpanProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Number of columns to span, or 'full' to span all columns.
    * - Number: `grid-column: span N`

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -96,6 +96,14 @@ export interface XDSLayoutProps {
    * Start panel slot (left in LTR, right in RTL).
    */
   start?: ReactNode;
+  /**
+   * CSS class name(s) appended to the root element.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element.
+   */
+  style?: React.CSSProperties;
 }
 
 /**
@@ -172,6 +180,8 @@ export function XDSLayout({
   height = 'fill',
   isFullBleed = false,
   start,
+  className,
+  style,
 }: XDSLayoutProps) {
   const isFill = height === 'fill';
 
@@ -192,6 +202,8 @@ export function XDSLayout({
         {...mergeProps(
           xdsClassName('layout', {height}),
           stylex.props(styles.layoutOuter, isFill ? styles.fill : styles.auto),
+          className,
+          style,
         )}>
         <div
           {...stylex.props(

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -12,7 +12,8 @@
 
 'use client';
 
-import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
+import type {AriaRole, ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {forwardRef, useContext} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
@@ -59,10 +60,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSLayoutContentProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSLayoutContentProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Content to render inside the content area.
    */
@@ -137,7 +135,16 @@ export interface XDSLayoutContentProps extends Omit<
  */
 export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
   function XDSLayoutContent(
-    {children, isFullBleed = false, isScrollable = true, label, role, ...props},
+    {
+      children,
+      isFullBleed = false,
+      isScrollable = true,
+      label,
+      role,
+      className,
+      style,
+      ...props
+    },
     ref,
   ) {
     const {hasHeader, hasFooter, hasStart, hasEnd} = useContext(
@@ -161,6 +168,8 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
             isScrollable && styles.scrollable,
             isFullBleed && styles.fullBleed,
           ),
+          className,
+          style,
         )}
         {...props}>
         {children}

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -10,7 +10,8 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
+import type {AriaRole, ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {forwardRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
@@ -50,10 +51,7 @@ const dynamicStyles = stylex.create({
   }),
 });
 
-export interface XDSLayoutFooterProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSLayoutFooterProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Content to render inside the footer.
    */
@@ -117,6 +115,8 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
       isFullBleed = false,
       label,
       role,
+      className,
+      style,
       ...props
     },
     ref,
@@ -138,6 +138,8 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
             hasDivider && styles.divider,
             shouldCollapseSpacing && styles.collapseTop,
           ),
+          className,
+          style,
         )}
         {...props}>
         {children}

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -10,7 +10,8 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
+import type {AriaRole, ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {forwardRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
@@ -50,10 +51,7 @@ const dynamicStyles = stylex.create({
   }),
 });
 
-export interface XDSLayoutHeaderProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSLayoutHeaderProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Content to render inside the header.
    */
@@ -117,6 +115,8 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
       isFullBleed = false,
       label,
       role,
+      className,
+      style,
       ...props
     },
     ref,
@@ -138,6 +138,8 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
             hasDivider && styles.divider,
             shouldCollapseSpacing && styles.collapseBottom,
           ),
+          className,
+          style,
         )}
         {...props}>
         {children}

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -12,7 +12,8 @@
 
 'use client';
 
-import type {AriaRole, HTMLAttributes, ReactNode} from 'react';
+import type {AriaRole, ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {forwardRef, useContext} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
@@ -86,10 +87,7 @@ const dynamicStyles = stylex.create({
   }),
 });
 
-export interface XDSLayoutPanelProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className'
-> {
+export interface XDSLayoutPanelProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Content to render inside the panel.
    */
@@ -175,6 +173,8 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
       label,
       role,
       width,
+      className,
+      style,
       ...props
     },
     ref,
@@ -223,6 +223,8 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
             hasDivider && dividerStyle,
             shouldCollapseSpacing && collapseStyle,
           ),
+          className,
+          style,
         )}
         {...props}>
         {children}

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -13,12 +13,8 @@
 
 'use client';
 
-import {
-  forwardRef,
-  type AnchorHTMLAttributes,
-  type MouseEventHandler,
-  type ReactNode,
-} from 'react';
+import {forwardRef, type MouseEventHandler, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 
 import {
@@ -111,10 +107,7 @@ const linkColorStyles = stylex.create({
   },
 });
 
-export interface XDSLinkProps extends Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  'children'
-> {
+export interface XDSLinkProps extends XDSBaseProps<HTMLAnchorElement> {
   /**
    * Custom component to render instead of `<a>`.
    * Overrides the provider-level default set by XDSLinkProvider.
@@ -153,9 +146,23 @@ export interface XDSLinkProps extends Omit<
    */
   target?: string;
   /**
-   * Click event handler.
+   * Link relationship (e.g. "noopener noreferrer").
+   * Automatically includes "noopener noreferrer" when isExternalLink is true.
    */
-  onClick?: MouseEventHandler<HTMLAnchorElement>;
+  rel?: string;
+  /**
+   * Causes the browser to download the linked URL. A string value
+   * specifies the suggested filename.
+   */
+  download?: string | boolean;
+  /**
+   * Referrer policy for the link.
+   */
+  referrerPolicy?: React.HTMLAttributeReferrerPolicy;
+  /**
+   * Click handler. Fires before navigation.
+   */
+  onClick?: React.MouseEventHandler<HTMLAnchorElement>;
   /**
    * Tooltip text to display on hover.
    */

--- a/packages/core/src/NavIcon/XDSNavIcon.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.tsx
@@ -12,7 +12,8 @@
  * - /apps/storybook/stories/PageNav.stories.tsx
  */
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, sizeVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
@@ -34,10 +35,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSNavIconProps extends Omit<
-  HTMLAttributes<HTMLSpanElement>,
-  'style' | 'className'
-> {
+export interface XDSNavIconProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * The icon element to render inside the circular background.
    * Should be an XDSIcon or similar icon component.
@@ -69,11 +67,16 @@ export interface XDSNavIconProps extends Omit<
  * ```
  */
 export const XDSNavIcon = forwardRef<HTMLSpanElement, XDSNavIconProps>(
-  function XDSNavIcon({icon, ...props}, ref) {
+  function XDSNavIcon({icon, className, style, ...props}, ref) {
     return (
       <span
         ref={ref}
-        {...mergeProps(xdsClassName('navicon'), stylex.props(styles.base))}
+        {...mergeProps(
+          xdsClassName('navicon'),
+          stylex.props(styles.base),
+          className,
+          style,
+        )}
         {...props}>
         {icon}
       </span>

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -16,7 +16,8 @@
 
 'use client';
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
@@ -80,7 +81,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSSideNavProps extends HTMLAttributes<HTMLElement> {
+export interface XDSSideNavProps extends XDSBaseProps<HTMLElement> {
   /**
    * Header area — typically XDSSideNavHeader. Sticky at top.
    */

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -12,7 +12,8 @@
 
 'use client';
 
-import {forwardRef, type HTMLAttributes} from 'react';
+import {forwardRef} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
@@ -111,10 +112,7 @@ export type XDSSkeletonRadius = keyof typeof radiusStyles;
 // Component
 // =============================================================================
 
-export interface XDSSkeletonProps extends Omit<
-  HTMLAttributes<HTMLDivElement>,
-  'className' | 'style'
-> {
+export interface XDSSkeletonProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Width of the skeleton.
    * Accepts a number (pixels) or string (any CSS value).
@@ -172,6 +170,8 @@ export const XDSSkeleton = forwardRef<HTMLDivElement, XDSSkeletonProps>(
       radius: radiusProp = 'container',
       index = 0,
       'data-testid': testId,
+      className,
+      style,
       ...props
     },
     ref,
@@ -189,6 +189,8 @@ export const XDSSkeleton = forwardRef<HTMLDivElement, XDSSkeletonProps>(
             dynamicStyles.dimensions(width, height),
             dynamicStyles.animationDelay(index),
           ),
+          className,
+          style,
         )}
         {...props}
       />

--- a/packages/core/src/Stack/XDSStack.test.tsx
+++ b/packages/core/src/Stack/XDSStack.test.tsx
@@ -165,15 +165,4 @@ describe('XDSStack', () => {
     const element = screen.getByTestId('stack');
     expect(element).toHaveAttribute('aria-label', 'Stack container');
   });
-
-  it('passes through event handlers', () => {
-    const onClick = vi.fn();
-    render(
-      <XDSStack direction="vertical" data-testid="stack" onClick={onClick}>
-        <div>Item</div>
-      </XDSStack>,
-    );
-    screen.getByTestId('stack').click();
-    expect(onClick).toHaveBeenCalledTimes(1);
-  });
 });

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -18,6 +18,7 @@ import {
   type ReactNode,
   type Ref,
 } from 'react';
+import {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -42,7 +43,7 @@ import {xdsClassName, mergeProps} from '../utils';
  */
 export type StackAlignment = StackMainAlignment | StackCrossAlignment;
 
-export interface XDSStackProps extends HTMLAttributes<HTMLElement> {
+export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Direction of the stack layout.
    * - `horizontal`: Items flow left-to-right (like XDSHStack)

--- a/packages/core/src/Stack/XDSStackItem.tsx
+++ b/packages/core/src/Stack/XDSStackItem.tsx
@@ -18,6 +18,7 @@ import {
   type ReactNode,
   type Ref,
 } from 'react';
+import {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -27,7 +28,7 @@ import {
 } from './stackItem.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
-export interface XDSStackItemProps extends HTMLAttributes<HTMLElement> {
+export interface XDSStackItemProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Overrides the default cross-alignment for this item.
    * (hAlign for VStack, vAlign for HStack)

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -29,6 +29,7 @@ import type {
   BodyCellRenderProps,
   TableRowComponentProps,
   TableCellComponentProps,
+  TableHeaderCellComponentProps,
 } from './types';
 import {generateColumns, defaultCellRenderer} from './columnUtils';
 import {XDSTableRow} from './XDSTableRow';
@@ -198,9 +199,12 @@ function XDSBaseTableInner<T extends Record<string, unknown>>(
   // Use stable empty array when no plugins provided
   const plugins = pluginsProp ?? (EMPTY_PLUGINS as TablePlugin<T>[]);
 
-  const RowComponent = components?.Row ?? XDSTableRow;
-  const CellComponent = components?.Cell ?? XDSTableCell;
-  const HeaderCellComponent = components?.HeaderCell ?? XDSTableHeaderCell;
+  const RowComponent = (components?.Row ??
+    XDSTableRow) as React.ComponentType<TableRowComponentProps>;
+  const CellComponent = (components?.Cell ??
+    XDSTableCell) as React.ComponentType<TableCellComponentProps>;
+  const HeaderCellComponent = (components?.HeaderCell ??
+    XDSTableHeaderCell) as React.ComponentType<TableHeaderCellComponentProps>;
 
   // Resolve columns: explicit > auto-generated from data
   const resolvedColumns: XDSTableColumn<T>[] =

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -22,7 +22,14 @@ import {XDSTableCell} from './XDSTableCell';
 import {XDSTableHeaderCell} from './XDSTableHeaderCell';
 import {XDSTableContext} from './XDSTableContext';
 import {useXDSBaseTablePlugins} from './useXDSBaseTablePlugins';
-import type {XDSBaseTableProps, TablePlugin, TableRenderProps} from './types';
+import type {
+  XDSBaseTableProps,
+  TablePlugin,
+  TableRenderProps,
+  TableRowComponentProps,
+  TableCellComponentProps,
+  TableHeaderCellComponentProps,
+} from './types';
 
 // =============================================================================
 // XDSTable Types
@@ -87,11 +94,15 @@ function buildTableStylePlugin<
   };
 }
 
-// Stable component references for the components prop
+// Stable component references for the components prop.
+// XDSTable* components accept XDSBaseProps (narrower than the internal
+// Table*ComponentProps interfaces), but they spread ...props on their HTML
+// elements, so extra attributes from the plugin pipeline pass through safely.
 const xdsComponents = {
-  Row: XDSTableRow,
-  Cell: XDSTableCell,
-  HeaderCell: XDSTableHeaderCell,
+  Row: XDSTableRow as unknown as React.ComponentType<TableRowComponentProps>,
+  Cell: XDSTableCell as unknown as React.ComponentType<TableCellComponentProps>,
+  HeaderCell:
+    XDSTableHeaderCell as unknown as React.ComponentType<TableHeaderCellComponentProps>,
 };
 
 // =============================================================================

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -11,12 +11,8 @@
 
 'use client';
 
-import {
-  forwardRef,
-  useContext,
-  type TdHTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {forwardRef, useContext, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, textSizeVars} from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
@@ -24,10 +20,11 @@ import {XDSTableContext} from './XDSTableContext';
 import {xdsClassName, mergeProps} from '../utils';
 
 /** Props for XDSTableCell — thin `<td>` wrapper */
-export interface XDSTableCellProps extends Omit<
-  TdHTMLAttributes<HTMLTableCellElement>,
-  'className' | 'style'
-> {
+export interface XDSTableCellProps extends XDSBaseProps<HTMLTableCellElement> {
+  /** Specifies which cells this cell relates to (used on `<td>` acting as a row header). */
+  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
+  /** Space-separated list of header cell IDs this cell is described by. */
+  headers?: string;
   children?: ReactNode;
   xstyle?: StyleXStyles | StyleXStyles[];
 }

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -11,12 +11,8 @@
 
 'use client';
 
-import {
-  forwardRef,
-  useContext,
-  type ThHTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {forwardRef, useContext, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -29,7 +25,9 @@ import {XDSTableContext} from './XDSTableContext';
 import {xdsClassName, mergeProps} from '../utils';
 
 /** Props for XDSTableHeaderCell — `<th>` wrapper with context-aware styling */
-export interface XDSTableHeaderCellProps extends ThHTMLAttributes<HTMLTableCellElement> {
+export interface XDSTableHeaderCellProps extends XDSBaseProps<HTMLTableCellElement> {
+  /** Specifies which cells this header relates to. */
+  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup';
   children?: ReactNode;
   xstyle?: StyleXStyles | StyleXStyles[];
 }

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -11,12 +11,8 @@
 
 'use client';
 
-import {
-  forwardRef,
-  useContext,
-  type HTMLAttributes,
-  type ReactNode,
-} from 'react';
+import {forwardRef, useContext, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, transitionVars} from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
@@ -24,10 +20,7 @@ import {XDSTableContext} from './XDSTableContext';
 import {xdsClassName, mergeProps} from '../utils';
 
 /** Props for XDSTableRow — thin `<tr>` wrapper */
-export interface XDSTableRowProps extends Omit<
-  HTMLAttributes<HTMLTableRowElement>,
-  'className' | 'style'
-> {
+export interface XDSTableRowProps extends XDSBaseProps<HTMLTableRowElement> {
   children: ReactNode;
   xstyle?: StyleXStyles[];
 }

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -13,7 +13,8 @@
 
 'use client';
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {edgeSignals} from '../Layout/edgeCompensation.stylex';
@@ -83,12 +84,15 @@ const styles = stylex.create({
 });
 
 export interface XDSTopNavProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className' | 'title'
+  XDSBaseProps<HTMLElement>,
+  'title'
 > {
   /**
-   * Title slot content - typically XDSTopNavTitle with logo and text.
+   * Title slot content — typically XDSTopNavTitle with logo and text.
    * Positioned at the left edge of the nav bar.
+   *
+   * Note: named `title` for now but will be renamed to `heading` to avoid
+   * collision with the HTML `title` attribute. See follow-up PR.
    */
   title?: ReactNode;
   /**
@@ -134,7 +138,16 @@ export interface XDSTopNavProps extends Omit<
  */
 export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
   function XDSTopNav(
-    {title, startContent, centerContent, endContent, label, ...props},
+    {
+      title,
+      startContent,
+      centerContent,
+      endContent,
+      label,
+      className,
+      style,
+      ...props
+    },
     ref,
   ) {
     const hasCenterContent = centerContent != null;
@@ -150,6 +163,8 @@ export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
             styles.base,
             hasCenterContent ? styles.baseGrid : styles.baseFlex,
           ),
+          className,
+          style,
         )}
         {...props}>
         <div {...stylex.props(styles.leftSection, edgeSignals.start)}>

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -13,7 +13,8 @@
 
 'use client';
 
-import {forwardRef, type AnchorHTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -84,10 +85,17 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSTopNavItemProps extends Omit<
-  AnchorHTMLAttributes<HTMLAnchorElement>,
-  'style' | 'className'
-> {
+export interface XDSTopNavItemProps extends XDSBaseProps<HTMLAnchorElement> {
+  /** Link destination URL. */
+  href?: string;
+  /** Where to open the linked document. */
+  target?: string;
+  /** Link relationship. */
+  rel?: string;
+  /** Causes the browser to download the linked URL. */
+  download?: string | boolean;
+  /** Referrer policy for the link. */
+  referrerPolicy?: React.HTMLAttributeReferrerPolicy;
   /**
    * Custom component to render instead of `<a>`.
    * Overrides the provider-level default set by XDSLinkProvider.

--- a/packages/core/src/TopNav/XDSTopNavTitle.tsx
+++ b/packages/core/src/TopNav/XDSTopNavTitle.tsx
@@ -11,7 +11,8 @@
  * - /apps/storybook/stories/TopNav.stories.tsx
  */
 
-import {forwardRef, type HTMLAttributes, type ReactNode} from 'react';
+import {forwardRef, type ReactNode} from 'react';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -50,10 +51,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSTopNavTitleProps extends Omit<
-  HTMLAttributes<HTMLElement>,
-  'style' | 'className' | 'title'
-> {
+export interface XDSTopNavTitleProps extends XDSBaseProps<HTMLElement> {
   /**
    * The title text to display.
    */
@@ -96,7 +94,10 @@ export interface XDSTopNavTitleProps extends Omit<
  * ```
  */
 export const XDSTopNavTitle = forwardRef<HTMLElement, XDSTopNavTitleProps>(
-  function XDSTopNavTitle({title, logo, href, ...props}, ref) {
+  function XDSTopNavTitle(
+    {title, logo, href, className, style, ...props},
+    ref,
+  ) {
     const Element = href ? 'a' : 'div';
 
     return (
@@ -106,6 +107,8 @@ export const XDSTopNavTitle = forwardRef<HTMLElement, XDSTopNavTitleProps>(
         {...mergeProps(
           xdsClassName('top-nav-title'),
           stylex.props(styles.base, href != null && styles.clickable),
+          className,
+          style,
         )}
         {...props}>
         {logo && <span {...stylex.props(styles.logo)}>{logo}</span>}

--- a/packages/core/src/XDSBaseProps.ts
+++ b/packages/core/src/XDSBaseProps.ts
@@ -1,0 +1,41 @@
+/**
+ * @file XDSBaseProps.ts
+ * @input None (pure type definitions)
+ * @output Exports XDSBaseProps — the shared base interface for all XDS components
+ * @position Type foundation; extended by all component prop interfaces
+ *
+ * Starts with full HTMLAttributes and omits the handful of props that make
+ * no sense on design system components. Consumers get drag-and-drop, pointer
+ * events, keyboard handlers, clipboard events — everything they'd expect
+ * from a DOM element, without contentEditable or dangerouslySetInnerHTML.
+ */
+
+import type React from 'react';
+import type {StyleXStyles} from '@stylexjs/stylex';
+
+/**
+ * Base props shared by all XDS components.
+ *
+ * Extends HTMLAttributes minus the genuinely irrelevant props. Components
+ * extend this and re-declare common props with better JSDoc where useful
+ * (e.g. Button re-declares onClick with its specific event type).
+ */
+export interface XDSBaseProps<T extends HTMLElement = HTMLElement> extends Omit<
+  React.HTMLAttributes<T>,
+  | 'contentEditable'
+  | 'dangerouslySetInnerHTML'
+  | 'suppressContentEditableWarning'
+  | 'suppressHydrationWarning'
+> {
+  /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
+   */
+  xstyle?: StyleXStyles;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,9 @@
  * SYNC: When modified, update this header and /packages/core/src/README.md
  */
 
+// Base types
+export type {XDSBaseProps} from './XDSBaseProps';
+
 // Components
 export * from './AppShell';
 export * from './AspectRatio';


### PR DESCRIPTION
## Summary

Introduces `XDSBaseProps` — a shared base interface that all components extend instead of raw `HTMLAttributes`. 

`XDSBaseProps` = `HTMLAttributes` minus the handful of props that make no sense on design system components (`contentEditable`, `dangerouslySetInnerHTML`, suppression flags). Also adds `xstyle` to the base so every component gets it for free.

Consumers keep full DOM event access (drag, pointer, keyboard, clipboard, etc.) with zero maintenance burden for new DOM features.

### XDSBaseProps

```tsx
export interface XDSBaseProps
  extends Omit<
    React.HTMLAttributes<HTMLElement>,
    | "contentEditable"
    | "dangerouslySetInnerHTML"
    | "suppressContentEditableWarning"
    | "suppressHydrationWarning"
  > {
  xstyle?: StyleXStyles;
}
```

### Prop collision pattern

When a component uses a prop name that collides with HTMLAttributes (e.g. `title` as ReactNode), it Omits the conflict:

```tsx
// TopNav uses title as a ReactNode slot, not the HTML tooltip string
export interface XDSTopNavProps extends Omit<XDSBaseProps, "title"> {
  title?: ReactNode;
}
```

Current collisions: TopNav (`title`), Calendar (`onChange`, `defaultValue`). TopNav will be resolved by renaming `title` → `heading` in a follow-up PR.

### Re-declaring common props

Components re-declare inherited props with better JSDoc where useful:

```tsx
export interface XDSButtonProps extends XDSBaseProps {
  /** Click handler. For async actions, use onClickAction instead. */
  onClick?: React.MouseEventHandler<HTMLButtonElement>;
  // ...
}
```

### className/style wired through mergeProps

All updated components now properly wire `className` and `style` through `mergeProps()` so consumer styles are merged (not overwritten by `...props` spread).

### Components updated

**Semantic components** — Avatar, AvatarStatusDot, Badge, Button, Calendar, Dialog, Link, TableCell, TableHeaderCell, TableRow, TopNav, TopNavItem, TopNavTitle

**Layout primitives** — AspectRatio, Card, Center, Divider, FormLayout, Grid, GridSpan, Layout, LayoutContent, LayoutFooter, LayoutHeader, LayoutPanel, NavIcon, SideNav, Skeleton, Stack, StackItem

### Table-specific props

- `XDSTableRow` — `onClick` (row selection/navigation)
- `XDSTableCell` — `scope`, `headers` (accessibility)
- `XDSTableHeaderCell` — `scope` (accessibility)

All three override `xstyle` with array variant (`StyleXStyles[]`) for the plugin pipeline.

### Also

- Added `download` and `referrerPolicy` to Link and TopNavItem
- Updated API Conventions wiki with XDSBaseProps decision

## Test plan
- 1372 tests pass
- Build succeeds (CJS, ESM, DTS)
- 0 lint errors