### PR TITLE
fix(core): wire xstyle/className/style through mergeProps on all components

### DIFF
--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -250,6 +250,7 @@ export const XDSAvatar = forwardRef<HTMLDivElement, XDSAvatarProps>(
       size = 'small',
       src,
       status,
+      xstyle,
       className,
       style,
       ...props
@@ -276,7 +277,7 @@ export const XDSAvatar = forwardRef<HTMLDivElement, XDSAvatarProps>(
           data-testid={testId}
           {...mergeProps(
             xdsClassName('avatar', {size}),
-            stylex.props(styles.wrapper),
+            stylex.props(styles.wrapper, xstyle),
             className,
             style,
           )}

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -157,6 +157,7 @@ export function XDSAvatarStatusDot({
   variant = 'positive',
   label,
   icon,
+  xstyle,
   className,
   style,
   ...props
@@ -173,6 +174,7 @@ export function XDSAvatarStatusDot({
           styles.dot,
           variantStyleMap[variant],
           dynamicStyles.size(dotSize, borderWidth),
+          xstyle,
         ),
         className,
         style,

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -114,7 +114,10 @@ export interface XDSBadgeProps extends XDSBaseProps<HTMLSpanElement> {
  * ```
  */
 export const XDSBadge = forwardRef<HTMLSpanElement, XDSBadgeProps>(
-  ({variant = 'neutral', children, icon, className, style, ...props}, ref) => {
+  (
+    {variant = 'neutral', children, icon, xstyle, className, style, ...props},
+    ref,
+  ) => {
     const isDot = children == null && icon == null;
 
     return (
@@ -122,7 +125,12 @@ export const XDSBadge = forwardRef<HTMLSpanElement, XDSBadgeProps>(
         ref={ref}
         {...mergeProps(
           xdsClassName('badge', {variant}),
-          stylex.props(styles.base, variants[variant], isDot && styles.dot),
+          stylex.props(
+            styles.base,
+            variants[variant],
+            isDot && styles.dot,
+            xstyle,
+          ),
           className,
           style,
         )}

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -330,6 +330,7 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
       children,
       endSlot,
       tooltip,
+      xstyle,
       className,
       style,
       ...props
@@ -381,6 +382,7 @@ export const XDSButton = forwardRef<HTMLButtonElement, XDSButtonProps>(
             isLoadingState && loadingStyles.loading,
             edgePaddingSignal,
             edgeCompStyle,
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -194,6 +194,7 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
       hasWeekNumbers = false,
       hasVariableRowCount = false,
       weekStartsOn = 0,
+      xstyle,
       className,
       style,
       ...rest
@@ -351,7 +352,7 @@ export const XDSCalendar = forwardRef<XDSCalendarHandle, XDSCalendarProps>(
       <div
         {...mergeProps(
           xdsClassName('calendar', {mode}),
-          stylex.props(calendarStyles.calendar),
+          stylex.props(calendarStyles.calendar, xstyle),
           className,
           style,
         )}

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -18,6 +18,7 @@ import {colorVars, radiusVars, elevationVars} from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
 import type {SizeValue} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   // Outer wrapper: visual styling with clip for border-radius
@@ -65,7 +66,7 @@ const dynamicStyles = stylex.create({
 
 export type {SizeValue} from '../utils/types';
 
-export interface XDSCardProps {
+export interface XDSCardProps extends XDSBaseProps {
   /**
    * CSS class name(s) appended to the root element.
    */
@@ -140,6 +141,7 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
       minHeight,
       children,
       isFullBleed = false,
+      xstyle,
       className,
       style,
       ...props
@@ -162,6 +164,7 @@ export const XDSCard = forwardRef<HTMLDivElement, XDSCardProps>(
               maxWidth ?? null,
               minHeight ?? null,
             ),
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -125,8 +125,12 @@ export type {
   XDSInputStatusType as XDSDateInputStatusType,
 } from '../Field';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSDateInputProps {
+export interface XDSDateInputProps extends Omit<
+  XDSBaseProps,
+  'onChange' | 'defaultValue'
+> {
   /**
    * Label text for the input (required for accessibility).
    */
@@ -264,6 +268,9 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
       status,
       labelTooltip,
       numberOfMonths = 1,
+      xstyle,
+      className,
+      style,
     },
     ref,
   ) => {
@@ -467,7 +474,10 @@ export const XDSDateInput = forwardRef<HTMLInputElement, XDSDateInputProps>(
               status && inputStatusBorderStyles[status.type],
               status && inputStatusHoverShadowStyles[status.type],
               status && inputStatusFocusWithinStyles[status.type],
+              xstyle,
             ),
+            className,
+            style,
           )}>
           <button
             type="button"

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -230,6 +230,7 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
       variant = 'standard',
       purpose = 'info',
       children,
+      xstyle,
       className,
       style,
       ...props
@@ -336,6 +337,7 @@ export const XDSDialog = forwardRef<HTMLDialogElement, XDSDialogProps>(
                 position?.left,
               ),
             isFullscreen && styles.fullscreen,
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -22,6 +22,7 @@ import {XDSLayoutSlotsContext, type LayoutSlots} from './XDSLayoutSlotsContext';
 import {stack} from '../Stack/stack.stylex';
 import {stackItem} from '../Stack/stackItem.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSBaseProps} from '../XDSBaseProps';
 
 /**
  * Height behavior for the layout.
@@ -57,7 +58,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSLayoutProps {
+export interface XDSLayoutProps extends Omit<XDSBaseProps, 'content'> {
   /**
    * Main content area (center).
    */
@@ -180,6 +181,7 @@ export function XDSLayout({
   height = 'fill',
   isFullBleed = false,
   start,
+  xstyle,
   className,
   style,
 }: XDSLayoutProps) {
@@ -201,7 +203,11 @@ export function XDSLayout({
       <div
         {...mergeProps(
           xdsClassName('layout', {height}),
-          stylex.props(styles.layoutOuter, isFill ? styles.fill : styles.auto),
+          stylex.props(
+            styles.layoutOuter,
+            isFill ? styles.fill : styles.auto,
+            xstyle,
+          ),
           className,
           style,
         )}>

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -141,6 +141,7 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
       isScrollable = true,
       label,
       role,
+      xstyle,
       className,
       style,
       ...props
@@ -167,6 +168,7 @@ export const XDSLayoutContent = forwardRef<HTMLElement, XDSLayoutContentProps>(
             !hasFooter && !isFullBleed && styles.noFooter,
             isScrollable && styles.scrollable,
             isFullBleed && styles.fullBleed,
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -115,6 +115,7 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
       isFullBleed = false,
       label,
       role,
+      xstyle,
       className,
       style,
       ...props
@@ -137,6 +138,7 @@ export const XDSLayoutFooter = forwardRef<HTMLElement, XDSLayoutFooterProps>(
             isFullBleed && styles.fullBleed,
             hasDivider && styles.divider,
             shouldCollapseSpacing && styles.collapseTop,
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -115,6 +115,7 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
       isFullBleed = false,
       label,
       role,
+      xstyle,
       className,
       style,
       ...props
@@ -137,6 +138,7 @@ export const XDSLayoutHeader = forwardRef<HTMLElement, XDSLayoutHeaderProps>(
             isFullBleed && styles.fullBleed,
             hasDivider && styles.divider,
             shouldCollapseSpacing && styles.collapseBottom,
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -173,6 +173,7 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
       label,
       role,
       width,
+      xstyle,
       className,
       style,
       ...props
@@ -222,6 +223,7 @@ export const XDSLayoutPanel = forwardRef<HTMLElement, XDSLayoutPanelProps>(
             isFullBleed && styles.fullBleed,
             hasDivider && dividerStyle,
             shouldCollapseSpacing && collapseStyle,
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -249,6 +249,9 @@ export const XDSLink = forwardRef<HTMLAnchorElement, XDSLinkProps>(
       maxLines = 0,
       children,
       rel,
+      xstyle,
+      className,
+      style,
       ...props
     },
     ref,
@@ -280,7 +283,10 @@ export const XDSLink = forwardRef<HTMLAnchorElement, XDSLinkProps>(
             hasUnderline && styles.hasUnderline,
             isStandalone && styles.standalone,
             isDisabled && styles.disabled,
+            xstyle,
           ),
+          className,
+          style,
         )}
         {...props}>
         <XDSText

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -36,6 +36,7 @@ import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
 import {XDSHeading} from '../Text/XDSHeading';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Styles
@@ -161,7 +162,7 @@ const dynamicStyles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSMobileNavProps {
+export interface XDSMobileNavProps extends Omit<XDSBaseProps, 'title'> {
   /**
    * Whether the drawer is open.
    */
@@ -241,6 +242,9 @@ export const XDSMobileNav = forwardRef<HTMLDialogElement, XDSMobileNavProps>(
       width = 280,
       side = 'start',
       'data-testid': testId,
+      xstyle,
+      className,
+      style,
     },
     ref,
   ) {
@@ -313,8 +317,10 @@ export const XDSMobileNav = forwardRef<HTMLDialogElement, XDSMobileNavProps>(
             styles.dialog,
             styles.backdrop,
             isOpen && styles.backdropOpen,
+            xstyle,
           ),
         )}>
+        xstyle, className, style,
         {/* Drawer panel */}
         <div
           {...stylex.props(

--- a/packages/core/src/NavIcon/XDSNavIcon.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.tsx
@@ -67,13 +67,13 @@ export interface XDSNavIconProps extends XDSBaseProps<HTMLDivElement> {
  * ```
  */
 export const XDSNavIcon = forwardRef<HTMLSpanElement, XDSNavIconProps>(
-  function XDSNavIcon({icon, className, style, ...props}, ref) {
+  function XDSNavIcon({icon, xstyle, className, style, ...props}, ref) {
     return (
       <span
         ref={ref}
         {...mergeProps(
           xdsClassName('navicon'),
-          stylex.props(styles.base),
+          stylex.props(styles.base, xstyle),
           className,
           style,
         )}

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -100,8 +100,12 @@ export type {
   XDSInputStatusType as XDSNumberInputStatusType,
 } from '../Field';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSNumberInputProps {
+export interface XDSNumberInputProps extends Omit<
+  XDSBaseProps,
+  'onChange' | 'defaultValue'
+> {
   /**
    * Label text for the input (always rendered for accessibility).
    */
@@ -299,6 +303,9 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
       onFocus,
       onBlur,
       onEnter,
+      xstyle,
+      className,
+      style,
     },
     ref,
   ) => {
@@ -462,7 +469,10 @@ export const XDSNumberInput = forwardRef<HTMLInputElement, XDSNumberInputProps>(
               status && inputStatusBorderStyles[status.type],
               status && inputStatusHoverShadowStyles[status.type],
               status && inputStatusFocusWithinStyles[status.type],
+              xstyle,
             ),
+            className,
+            style,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
           <input

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -234,8 +234,10 @@ export function XDSRadioList({
           stylex.props(
             styles.radiogroup,
             orientation === 'vertical' ? styles.vertical : styles.horizontal,
+            xstyle,
           ),
         )}>
+        className, style,
         <RadioListContext.Provider value={contextValue}>
           {children}
         </RadioListContext.Provider>

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -54,6 +54,7 @@ import {
 import {useCombobox, useSelectedItemOffset} from './hooks';
 import {XDSSelectorOption} from './XDSSelectorOption';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   // Trigger button
@@ -245,7 +246,7 @@ export interface XDSSelectorStatus {
 
 export interface XDSSelectorProps<
   T extends XDSSelectorOptionType = XDSSelectorOptionType,
-> {
+> extends Omit<XDSBaseProps, 'onChange' | 'defaultValue' | 'children'> {
   /**
    * Label text for the selector (always rendered for accessibility).
    */
@@ -389,6 +390,9 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
   labelTooltip,
   children,
   'data-testid': testId,
+  xstyle,
+  className,
+  style,
 }: XDSSelectorProps<T>) {
   const triggerId = useId();
   const listboxId = useId();
@@ -612,7 +616,10 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
             !selectedItem && styles.triggerPlaceholder,
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
+            xstyle,
           ),
+          className,
+          style,
         )}>
         <span>{selectedItem?.label ?? placeholder}</span>
         {isBusy && <XDSSpinner size="sm" />}

--- a/packages/core/src/SideNav/XDSSideNavHeader.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeader.tsx
@@ -381,6 +381,8 @@ export const XDSSideNavHeader = forwardRef<
             styles.interactiveInset,
             xstyle,
           ),
+          className,
+          style,
         )}
         {...(props as React.AnchorHTMLAttributes<HTMLAnchorElement>)}>
         {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
@@ -408,6 +410,8 @@ export const XDSSideNavHeader = forwardRef<
               styles.interactiveInset,
               xstyle,
             ),
+            className,
+            style,
           )}>
           {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}
           {renderTextContent()}
@@ -535,6 +539,8 @@ export const XDSSideNavHeader = forwardRef<
       {...mergeProps(
         xdsClassName('side-nav-header'),
         stylex.props(styles.root, xstyle),
+        className,
+        style,
       )}
       {...props}>
       {icon && <span {...stylex.props(styles.icon)}>{icon}</span>}

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -170,6 +170,7 @@ export const XDSSkeleton = forwardRef<HTMLDivElement, XDSSkeletonProps>(
       radius: radiusProp = 'container',
       index = 0,
       'data-testid': testId,
+      xstyle,
       className,
       style,
       ...props
@@ -188,6 +189,7 @@ export const XDSSkeleton = forwardRef<HTMLDivElement, XDSSkeletonProps>(
             radiusStyles[radiusProp],
             dynamicStyles.dimensions(width, height),
             dynamicStyles.animationDelay(index),
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -36,6 +36,7 @@ import type {XDSIconType} from '../Icon';
 import type {XDSInputStatus} from '../Field/types';
 import {XDSSpinner} from '../Spinner';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSBaseProps} from '../XDSBaseProps';
 
 // Fixed dimensions: 40px width, 24px height, 16px thumb (off), 20px thumb (on)
 const SWITCH_WIDTH = 40;
@@ -154,7 +155,7 @@ export type XDSSwitchLabelPosition = 'start' | 'end';
 
 export type XDSSwitchLabelSpacing = 'default' | 'spread';
 
-export interface XDSSwitchProps {
+export interface XDSSwitchProps extends Omit<XDSBaseProps, 'onChange'> {
   /**
    * Label text for the switch (always rendered for accessibility).
    */
@@ -278,6 +279,9 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
       labelPosition = 'end',
       labelSpacing = 'default',
       status,
+      xstyle,
+      className,
+      style,
     },
     ref,
   ) => {
@@ -373,7 +377,13 @@ export const XDSSwitch = forwardRef<HTMLInputElement, XDSSwitchProps>(
     );
 
     return (
-      <div>
+      <div
+        {...mergeProps(
+          xdsClassName('switch-field'),
+          stylex.props(xstyle),
+          className,
+          style,
+        )}>
         <div
           {...stylex.props(
             styles.container,

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -88,8 +88,12 @@ export type {
   XDSInputStatusType as XDSTextInputStatusType,
 } from '../Field';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSBaseProps} from '../XDSBaseProps';
 
-export interface XDSTextInputProps {
+export interface XDSTextInputProps extends Omit<
+  XDSBaseProps,
+  'onChange' | 'defaultValue'
+> {
   /**
    * Label text for the input (always rendered for accessibility).
    */
@@ -200,6 +204,9 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
       labelTooltip,
       hasAutoFocus = false,
       htmlName,
+      xstyle,
+      className,
+      style,
     },
     ref,
   ) => {
@@ -275,7 +282,10 @@ export const XDSTextInput = forwardRef<HTMLInputElement, XDSTextInputProps>(
               status && inputStatusBorderStyles[status.type],
               status && inputStatusHoverShadowStyles[status.type],
               status && inputStatusFocusWithinStyles[status.type],
+              xstyle,
             ),
+            className,
+            style,
           )}>
           {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
           <input

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -144,6 +144,7 @@ export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
       centerContent,
       endContent,
       label,
+      xstyle,
       className,
       style,
       ...props
@@ -162,6 +163,7 @@ export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
           stylex.props(
             styles.base,
             hasCenterContent ? styles.baseGrid : styles.baseFlex,
+            xstyle,
           ),
           className,
           style,

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -157,6 +157,9 @@ export const XDSTopNavItem = forwardRef<HTMLAnchorElement, XDSTopNavItemProps>(
       isDisabled = false,
       icon,
       children,
+      xstyle,
+      className,
+      style,
       ...props
     },
     ref,
@@ -179,7 +182,10 @@ export const XDSTopNavItem = forwardRef<HTMLAnchorElement, XDSTopNavItemProps>(
             isSelected && styles.selected,
             isDisabled && styles.disabled,
             isIconOnly && styles.iconOnly,
+            xstyle,
           ),
+          className,
+          style,
         )}
         {...props}>
         {icon}

--- a/packages/core/src/TopNav/XDSTopNavTitle.tsx
+++ b/packages/core/src/TopNav/XDSTopNavTitle.tsx
@@ -95,7 +95,7 @@ export interface XDSTopNavTitleProps extends XDSBaseProps<HTMLElement> {
  */
 export const XDSTopNavTitle = forwardRef<HTMLElement, XDSTopNavTitleProps>(
   function XDSTopNavTitle(
-    {title, logo, href, className, style, ...props},
+    {title, logo, href, xstyle, className, style, ...props},
     ref,
   ) {
     const Element = href ? 'a' : 'div';
@@ -106,7 +106,7 @@ export const XDSTopNavTitle = forwardRef<HTMLElement, XDSTopNavTitleProps>(
         href={href}
         {...mergeProps(
           xdsClassName('top-nav-title'),
-          stylex.props(styles.base, href != null && styles.clickable),
+          stylex.props(styles.base, href != null && styles.clickable, xstyle),
           className,
           style,
         )}


### PR DESCRIPTION
## Summary

Ensures all three styling props (xstyle, className, style) are properly wired through `mergeProps` on every component.

### What changed

- 26 components now correctly wire xstyle into `stylex.props()` and className/style as `mergeProps()` args
- Input components (TextInput, NumberInput, DateInput, Selector, Switch) target the **input boundary element** — not the XDSField wrapper — since that's what builders rationally expect to style
- Components with standalone interfaces now extend `XDSBaseProps` (Card, DateInput, NumberInput, Selector, Switch, TextInput, Layout)

### Prop collisions (Omit)

Components that redefine HTML attribute names with different types:
- Calendar, DateInput, NumberInput: `onChange`, `defaultValue`
- Selector: `onChange`, `defaultValue`, `children` (render function)
- Switch: `onChange`
- Layout: `content`
- TopNav: `title` (follow-up: rename to heading)

### Not in this PR (follow-up)

- Internal sub-components (RadioListItem, SideNavItem, SideNavSection, Tab, TabList, TypeaheadItem, etc.)
- Table components (plugin pipeline pattern)
- TopNav heading rename

## Test plan
- 1372 tests pass
- Build succeeds (CJS, ESM, DTS)