### PR TITLE
docs: fix @example code fences for Storybook autodocs compatibility

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -149,7 +149,7 @@ export interface XDSAppShellProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/AspectRatio/XDSAspectRatio.tsx
+++ b/packages/core/src/AspectRatio/XDSAspectRatio.tsx
@@ -35,7 +35,7 @@ export interface XDSAspectRatioProps extends XDSBaseProps<HTMLDivElement> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -122,7 +122,7 @@ export interface XDSBannerProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -83,7 +83,7 @@ export interface XDSBreadcrumbsProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Center/XDSCenter.tsx
+++ b/packages/core/src/Center/XDSCenter.tsx
@@ -82,7 +82,7 @@ export interface XDSCenterProps extends XDSBaseProps<HTMLDivElement> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -60,7 +60,7 @@ export interface XDSDividerProps extends Omit<
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/DropdownMenu/XDSDropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenuItem.tsx
@@ -61,7 +61,7 @@ export interface XDSDropdownMenuItemProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -108,7 +108,7 @@ export interface XDSEmptyStateProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -155,7 +155,7 @@ export interface XDSFieldProps extends Omit<
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/FormLayout/XDSFormLayout.tsx
+++ b/packages/core/src/FormLayout/XDSFormLayout.tsx
@@ -86,7 +86,7 @@ export interface XDSFormLayoutProps extends XDSBaseProps<HTMLDivElement> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -91,7 +91,7 @@ export interface XDSGridProps extends XDSBaseProps<HTMLDivElement> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -35,7 +35,7 @@ export interface XDSGridSpanProps extends XDSBaseProps<HTMLDivElement> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -84,7 +84,7 @@ export interface XDSKbdProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Layer/XDSPopover.tsx
+++ b/packages/core/src/Layer/XDSPopover.tsx
@@ -132,7 +132,7 @@ export interface XDSPopoverProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -68,7 +68,7 @@ export interface XDSListProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -87,7 +87,7 @@ export interface XDSListItemProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -125,7 +125,7 @@ export interface XDSPaginationProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -99,7 +99,7 @@ export interface XDSProgressBarProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -116,7 +116,7 @@ export interface XDSRadioListProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Selector/XDSSelectorOption.tsx
+++ b/packages/core/src/Selector/XDSSelectorOption.tsx
@@ -55,7 +55,7 @@ export interface XDSSelectorOptionProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -107,7 +107,7 @@ export interface XDSSideNavProps extends XDSBaseProps<HTMLElement> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/SideNav/XDSSideNavHeader.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeader.tsx
@@ -178,7 +178,7 @@ export interface XDSSideNavHeaderProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -75,7 +75,7 @@ export interface XDSSliderBaseProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -95,7 +95,7 @@ export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Stack/XDSStackItem.tsx
+++ b/packages/core/src/Stack/XDSStackItem.tsx
@@ -55,7 +55,7 @@ export interface XDSStackItemProps extends XDSBaseProps<HTMLDivElement> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -118,7 +118,7 @@ export interface XDSStatusDotProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Text/XDSHeading.tsx
+++ b/packages/core/src/Text/XDSHeading.tsx
@@ -145,7 +145,7 @@ export interface XDSHeadingProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -140,7 +140,7 @@ export interface XDSTextProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -105,7 +105,7 @@ export interface XDSTokenProps {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -116,7 +116,7 @@ export interface XDSTokenizerProps<T extends XDSSearchableItem> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -100,7 +100,7 @@ export interface XDSTypeaheadProps<T extends XDSSearchableItem> {
    * base styles inside a single `stylex.props()` call for optimal deduplication.
    *
    * @example
-   * ```tsx
+   * ```
    * const overrides = stylex.create({ root: { marginBottom: 8 } });
    * <Component xstyle={overrides.root} />
    * ```

--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -7,7 +7,7 @@
  * - Component overrides scoped via @scope'd CSS selectors on .xds-* classes
  *
  * Usage:
- * ```tsx
+ * ```
  * const ocean = defineTheme({
  *   name: 'ocean',
  *   tokens: { '--color-accent': ['#0077B6', '#48CAE4'] },


### PR DESCRIPTION
## What

Replaces ` ```tsx ` with bare ` ``` ` in JSDoc `@example` blocks across 32 component files.

Storybook's autodocs parser doesn't support language tags on code fences inside docblocks — the `tsx` tag prevents examples from rendering in the Storybook UI.

## Files Changed

32 component `.tsx` files — one-character change each (removing `tsx` from the code fence).

## Checklist
- [x] Mechanical find/replace — no behavioral changes
- [x] No Storybook ` ```tsx ` in docblocks
- [x] Single concise `@example` per component

---
*Found during Night Watch doc review.*