### PR TITLE
fix: bug bash alignment — SideNav 8px spacing, Breadcrumbs text centering

### DIFF
--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -86,11 +86,15 @@ const itemStyles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    paddingBlock: spacingVars['--spacing-1'],
   },
   link: {
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
+    lineHeight: lineHeightVars['--leading-snug'],
+    paddingBlock: spacingVars['--spacing-1'],
     textDecoration: {
       default: 'none',
       ':hover': {

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -138,6 +138,7 @@ const separatorStyles = stylex.create({
     alignItems: 'center',
     color: colorVars['--color-text-secondary'],
     lineHeight: lineHeightVars['--leading-snug'],
+    paddingBlock: spacingVars['--spacing-1'],
     userSelect: 'none',
   },
   defaultSize: {

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -46,14 +46,14 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-surface'],
   },
   topContent: {
-    paddingInline: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
   },
   scrollable: {
     flex: 1,
     overflowY: 'auto',
     overflowX: 'hidden',
-    paddingInline: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
   },
   stickyBottom: {
@@ -64,14 +64,14 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-surface'],
   },
   footer: {
-    paddingInline: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-2'],
   },
   footerIcons: {
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-2'],
     borderBlockStart: `1px solid ${colorVars['--color-divider']}`,
   },

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -43,7 +43,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-3'],
     boxSizing: 'border-box',
     textDecoration: 'none',
@@ -66,7 +66,7 @@ const styles = stylex.create({
     },
   },
   interactiveInset: {
-    marginInline: spacingVars['--spacing-1'],
+    marginInline: spacingVars['--spacing-2'],
     marginBlock: spacingVars['--spacing-1'],
   },
   icon: {

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -46,7 +46,7 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
     width: '100%',
-    paddingInline: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-element'],
     borderWidth: 0,

--- a/packages/core/src/SideNav/XDSSideNavSection.tsx
+++ b/packages/core/src/SideNav/XDSSideNavSection.tsx
@@ -39,7 +39,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
     cursor: 'default',
     userSelect: 'none',


### PR DESCRIPTION
### SideNav — 8px from edge (#371 P0)

Container `paddingInline`: 4px → 8px, header/item `paddingInline`: 12px → 8px. Interactive area now starts 8px from the SideNav edge for both header and nav items.

| Area | Before | After |
|------|--------|-------|
| Container padding | 4px | **8px** |
| Item inner padding | 12px | **8px** |
| Edge → interactive | 4px | **8px** |
| Edge → content | 16px | 16px |

### Breadcrumbs — Text centering (#371 P1)

Added `paddingBlock` to breadcrumb items and separators so text is vertically centered within a proper visual bar area.

Addresses items in #371.