### PR TITLE
refactor(TopNav,SideNav): rename title → heading, rename components

### DIFF
--- a/apps/sandbox/src/app/pages/mega-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/mega-menu/page.tsx
@@ -7,7 +7,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {
   XDSTopNav,
-  XDSTopNavTitle,
+  XDSTopNavHeading,
   XDSTopNavItem,
   XDSTopNavMegaMenu,
 } from '@xds/core/TopNav';
@@ -255,9 +255,9 @@ export default function MegaMenuPage() {
             )}>
             <XDSTopNav
               label="Marketing navigation"
-              title={
-                <XDSTopNavTitle
-                  title="Marketing"
+              heading={
+                <XDSTopNavHeading
+                  heading="Marketing"
                   logo={<XDSNavIcon icon={<LogoIcon />} />}
                   href="#"
                 />
@@ -314,7 +314,7 @@ export default function MegaMenuPage() {
             )}>
             <XDSTopNav
               label="Simple navigation"
-              title={<XDSTopNavTitle title="App" href="#" />}
+              heading={<XDSTopNavHeading heading="App" href="#" />}
               startContent={
                 <>
                   <XDSTopNavItem label="Home" href="#" isSelected />

--- a/apps/sandbox/src/app/pages/navigation/page.tsx
+++ b/apps/sandbox/src/app/pages/navigation/page.tsx
@@ -6,7 +6,7 @@ import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSDivider} from '@xds/core';
-import {XDSTopNav, XDSTopNavTitle, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 
 const styles = stylex.create({
   container: {
@@ -126,7 +126,7 @@ function NavPreview({alignment}: {alignment: Alignment}) {
   return (
     <XDSTopNav
       label={`${alignment}-aligned navigation`}
-      title={<XDSTopNavTitle title="My App" />}
+      heading={<XDSTopNavHeading heading="My App" />}
       startContent={alignment === 'start' ? navItems : undefined}
       centerContent={alignment === 'center' ? navItems : undefined}
       endContent={alignment === 'end' ? navItems : undefined}

--- a/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
+++ b/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
@@ -10,7 +10,7 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSDivider} from '@xds/core';
-import {XDSTopNav, XDSTopNavTitle, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {XDSSideNav, XDSSideNavItem} from '@xds/core/SideNav';
 import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
@@ -151,7 +151,7 @@ export default function PolymorphicLinkPage() {
                 <div {...stylex.props(styles.navWrapper)}>
                   <XDSTopNav
                     label="Provider demo navigation"
-                    title={<XDSTopNavTitle title="My App" />}
+                    heading={<XDSTopNavHeading heading="My App" />}
                     startContent={
                       <>
                         <XDSTopNavItem label="Home" href="/" isSelected />
@@ -245,7 +245,7 @@ export default function PolymorphicLinkPage() {
             <div {...stylex.props(styles.navWrapper)}>
               <XDSTopNav
                 label="Override demo navigation"
-                title={<XDSTopNavTitle title="Override Demo" />}
+                heading={<XDSTopNavHeading heading="Override Demo" />}
                 startContent={
                   <>
                     <XDSTopNavItem label="Home" href="/" isSelected />
@@ -280,7 +280,7 @@ export default function PolymorphicLinkPage() {
           <div {...stylex.props(styles.navWrapper)}>
             <XDSTopNav
               label="Default navigation"
-              title={<XDSTopNavTitle title="Default" />}
+              heading={<XDSTopNavHeading heading="Default" />}
               startContent={
                 <>
                   <XDSTopNavItem label="Home" href="#home" isSelected />

--- a/apps/sandbox/src/app/pages/topnav-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/topnav-menu/page.tsx
@@ -6,7 +6,7 @@ import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {
   XDSTopNav,
-  XDSTopNavTitle,
+  XDSTopNavHeading,
   XDSTopNavItem,
   XDSTopNavMenu,
 } from '@xds/core/TopNav';
@@ -114,9 +114,9 @@ export default function TopNavMenuPage() {
           <div {...stylex.props(styles.navWrapper)}>
             <XDSTopNav
               label="Marketing navigation"
-              title={
-                <XDSTopNavTitle
-                  title="Marketing"
+              heading={
+                <XDSTopNavHeading
+                  heading="Marketing"
                   logo={<XDSNavIcon icon={<LogoIcon />} />}
                   href="#"
                 />
@@ -144,7 +144,7 @@ export default function TopNavMenuPage() {
           <div {...stylex.props(styles.navWrapper)}>
             <XDSTopNav
               label="Simple navigation"
-              title={<XDSTopNavTitle title="App" href="#" />}
+              heading={<XDSTopNavHeading heading="App" href="#" />}
               startContent={
                 <>
                   <XDSTopNavItem label="Home" href="#" isSelected />

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -7,11 +7,11 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSText} from '@xds/core/Text';
 import {XDSMobileNav} from '@xds/core/MobileNav';
-import {XDSTopNav, XDSTopNavTitle, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {XDSNavIcon} from '@xds/core/NavIcon';
 import {
   XDSSideNav,
-  XDSSideNavHeader,
+  XDSSideNavHeading,
   XDSSideNavItem,
   XDSSideNavSection,
 } from '@xds/core/SideNav';
@@ -84,15 +84,15 @@ function MockContent({paragraphs = 3}: {paragraphs?: number}) {
 
 /**
  * Standard TopNav used across multiple stories.
- * Provides app identity (logo + title) and top-level navigation.
+ * Provides app identity (logo + heading) and top-level navigation.
  */
 function AppTopNav({endContent}: {endContent?: React.ReactNode}) {
   return (
     <XDSTopNav
       label="Main navigation"
-      title={
-        <XDSTopNavTitle
-          title="Acme App"
+      heading={
+        <XDSTopNavHeading
+          heading="Acme App"
           logo={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
@@ -168,16 +168,16 @@ function SideNavWithoutHeader() {
 
 /**
  * SideNav WITH header — for standalone use without a TopNav.
- * The header provides app identity (icon + title) since there's no TopNav.
+ * The heading provides app identity (icon + heading) since there's no TopNav.
  */
 function SideNavWithHeader() {
   return (
     <XDSSideNav
       header={
-        <XDSSideNavHeader
+        <XDSSideNavHeading
           icon={<XDSIcon icon={CubeIcon} size="lg" />}
-          title="Acme App"
-          titleHref="#"
+          heading="Acme App"
+          headingHref="#"
         />
       }>
       <XDSSideNavSection title="Main" isHeaderHidden>
@@ -276,7 +276,7 @@ export const TopNavWithSideNav: Story = {
 };
 
 /**
- * SideNav with its own header (icon + title) and no TopNav.
+ * SideNav with its own heading (icon + heading) and no TopNav.
  * Use this layout for simpler apps where a full top bar isn't needed.
  * The SideNav header provides the app identity instead.
  */
@@ -436,7 +436,7 @@ export const ControlledCollapse: Story = {
         topNav={
           <XDSTopNav
             label="Main navigation"
-            title={<XDSTopNavTitle title="Acme App" />}
+            heading={<XDSTopNavHeading heading="Acme App" />}
             endContent={
               <XDSButton
                 label="Toggle sidebar"
@@ -558,9 +558,9 @@ export const WithMobileNav: Story = {
         topNav={
           <XDSTopNav
             label="Main navigation"
-            title={
-              <XDSTopNavTitle
-                title="Acme App"
+            heading={
+              <XDSTopNavHeading
+                heading="Acme App"
                 logo={
                   <XDSNavIcon
                     icon={<CubeIcon style={{width: 16, height: 16}} />}

--- a/apps/storybook/stories/MobileNav.stories.tsx
+++ b/apps/storybook/stories/MobileNav.stories.tsx
@@ -3,7 +3,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {XDSMobileNav} from '@xds/core/MobileNav';
 import {
   XDSSideNav,
-  XDSSideNavHeader,
+  XDSSideNavHeading,
   XDSSideNavItem,
   XDSSideNavSection,
 } from '@xds/core/SideNav';
@@ -214,14 +214,14 @@ export const ResponsivePattern: Story = {
       <div style={{width: 280, height: 600, border: '1px solid #e5e7eb'}}>
         <XDSSideNav
           header={
-            <XDSSideNavHeader
+            <XDSSideNavHeading
               icon={
                 <XDSNavIcon
                   icon={<CubeIcon style={{width: 16, height: 16}} />}
                 />
               }
-              title="My App"
-              titleHref="/"
+              heading="My App"
+              headingHref="/"
             />
           }>
           {navSections}

--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -1,7 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {
   XDSSideNav,
-  XDSSideNavHeader,
+  XDSSideNavHeading,
   XDSSideNavItem,
   XDSSideNavSection,
 } from '@xds/core/SideNav';
@@ -58,12 +58,12 @@ export const Default: Story = {
   render: () => (
     <XDSSideNav
       header={
-        <XDSSideNavHeader
+        <XDSSideNavHeading
           icon={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
-          title="My App"
-          titleHref="/"
+          heading="My App"
+          headingHref="/"
         />
       }>
       <XDSSideNavSection title="Main">
@@ -106,7 +106,7 @@ export const Default: Story = {
 export const TitleWithoutIcon: Story = {
   name: 'Title Without Icon',
   render: () => (
-    <XDSSideNav header={<XDSSideNavHeader title="My App" titleHref="/" />}>
+    <XDSSideNav header={<XDSSideNavHeading heading="My App" headingHref="/" />}>
       <XDSSideNavSection title="Main">
         <XDSSideNavItem
           label="Dashboard"
@@ -140,12 +140,12 @@ export const WithHeaderMenu: Story = {
   render: () => (
     <XDSSideNav
       header={
-        <XDSSideNavHeader
+        <XDSSideNavHeading
           icon={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
-          title="Product Name"
-          subtitle="Business Account"
+          heading="Product Name"
+          subheading="Business Account"
           menu={
             <XDSList
               density="compact"
@@ -202,14 +202,14 @@ export const SuiteHeader: Story = {
   render: () => (
     <XDSSideNav
       header={
-        <XDSSideNavHeader
+        <XDSSideNavHeading
           icon={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
-          supertitle="Suite Name"
-          supertitleHref="/suite"
-          title="Product Name"
-          titleHref="/product"
+          superheading="Suite Name"
+          superheadingHref="/suite"
+          heading="Product Name"
+          headingHref="/product"
           menu={
             <XDSList
               density="compact"
@@ -259,11 +259,11 @@ export const NestedItems: Story = {
   render: () => (
     <XDSSideNav
       header={
-        <XDSSideNavHeader
+        <XDSSideNavHeading
           icon={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
-          title="My App"
+          heading="My App"
         />
       }>
       <XDSSideNavSection title="Main">
@@ -295,11 +295,11 @@ export const WithFooter: Story = {
   render: () => (
     <XDSSideNav
       header={
-        <XDSSideNavHeader
+        <XDSSideNavHeading
           icon={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
-          title="My App"
+          heading="My App"
         />
       }
       footerIcons={
@@ -340,11 +340,11 @@ export const DisabledItem: Story = {
   render: () => (
     <XDSSideNav
       header={
-        <XDSSideNavHeader
+        <XDSSideNavHeading
           icon={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
-          title="My App"
+          heading="My App"
         />
       }>
       <XDSSideNavSection title="Main">
@@ -374,11 +374,11 @@ export const HiddenSectionHeader: Story = {
   render: () => (
     <XDSSideNav
       header={
-        <XDSSideNavHeader
+        <XDSSideNavHeading
           icon={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
-          title="My App"
+          heading="My App"
         />
       }>
       <XDSSideNavSection title="Main navigation" isHeaderHidden>

--- a/apps/storybook/stories/TopNav.stories.tsx
+++ b/apps/storybook/stories/TopNav.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSTopNav, XDSTopNavTitle, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 import {XDSNavIcon} from '@xds/core/NavIcon';
 import {XDSButton} from '@xds/core/Button';
 import {
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof XDSTopNav>;
 export const Default: Story = {
   args: {
     label: 'Main navigation',
-    title: <XDSTopNavTitle title="My App" />,
+    heading: <XDSTopNavHeading heading="My App" />,
     startContent: (
       <>
         <XDSTopNavItem label="Home" href="#" isSelected />
@@ -67,9 +67,9 @@ export const Default: Story = {
 export const WithLogo: Story = {
   args: {
     label: 'Main navigation',
-    title: (
-      <XDSTopNavTitle
-        title="Dashboard"
+    heading: (
+      <XDSTopNavHeading
+        heading="Dashboard"
         logo={
           <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
         }
@@ -96,9 +96,9 @@ export const WithLogo: Story = {
 export const TitleOnly: Story = {
   args: {
     label: 'Main navigation',
-    title: (
-      <XDSTopNavTitle
-        title="Simple App"
+    heading: (
+      <XDSTopNavHeading
+        heading="Simple App"
         logo={
           <XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />
         }
@@ -112,7 +112,7 @@ export const NavItemStates: Story = {
   render: () => (
     <XDSTopNav
       label="Navigation states demo"
-      title={<XDSTopNavTitle title="States" />}
+      heading={<XDSTopNavHeading heading="States" />}
       startContent={
         <>
           <XDSTopNavItem label="Selected" href="#" isSelected />
@@ -133,9 +133,9 @@ export const CenteredNavigation: Story = {
   render: () => (
     <XDSTopNav
       label="Main navigation"
-      title={
-        <XDSTopNavTitle
-          title="My App"
+      heading={
+        <XDSTopNavHeading
+          heading="My App"
           logo={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
@@ -171,9 +171,9 @@ export const CenteredWithStartContent: Story = {
   render: () => (
     <XDSTopNav
       label="Main navigation"
-      title={
-        <XDSTopNavTitle
-          title="Dashboard"
+      heading={
+        <XDSTopNavHeading
+          heading="Dashboard"
           logo={
             <XDSNavIcon
               icon={<ChartBarIcon style={{width: 16, height: 16}} />}
@@ -210,9 +210,9 @@ export const CenteredWithStartContent: Story = {
 export const CenterContentWithoutEnd: Story = {
   args: {
     label: 'Main navigation',
-    title: (
-      <XDSTopNavTitle
-        title="My App"
+    heading: (
+      <XDSTopNavHeading
+        heading="My App"
         logo={
           <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
         }
@@ -232,9 +232,9 @@ export const FullExample: Story = {
   render: () => (
     <XDSTopNav
       label="Main navigation"
-      title={
-        <XDSTopNavTitle
-          title="Enterprise Dashboard"
+      heading={
+        <XDSTopNavHeading
+          heading="Enterprise Dashboard"
           logo={
             <XDSNavIcon
               icon={<ChartBarIcon style={{width: 16, height: 16}} />}

--- a/apps/storybook/stories/TopNavMenu.stories.tsx
+++ b/apps/storybook/stories/TopNavMenu.stories.tsx
@@ -2,7 +2,7 @@ import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {
   XDSTopNav,
-  XDSTopNavTitle,
+  XDSTopNavHeading,
   XDSTopNavItem,
   XDSTopNavMenu,
   XDSTopNavMegaMenu,
@@ -43,9 +43,9 @@ export const Default: Story = {
   render: () => (
     <XDSTopNav
       label="Main navigation"
-      title={
-        <XDSTopNavTitle
-          title="My App"
+      heading={
+        <XDSTopNavHeading
+          heading="My App"
           logo={
             <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
           }
@@ -107,7 +107,7 @@ export const MultipleMenus: Story = {
   render: () => (
     <XDSTopNav
       label="Main navigation"
-      title={<XDSTopNavTitle title="Platform" href="#" />}
+      heading={<XDSTopNavHeading heading="Platform" href="#" />}
       startContent={
         <>
           <XDSTopNavMenu
@@ -160,9 +160,9 @@ export const MegaMenu: Story = {
       <div style={{position: 'relative'}}>
         <XDSTopNav
           label="Marketing navigation"
-          title={
-            <XDSTopNavTitle
-              title="Acme"
+          heading={
+            <XDSTopNavHeading
+              heading="Acme"
               logo={
                 <XDSNavIcon
                   icon={<CubeIcon style={{width: 16, height: 16}} />}
@@ -246,7 +246,7 @@ export const MegaMenuSimple: Story = {
     <div style={{position: 'relative'}}>
       <XDSTopNav
         label="Simple navigation"
-        title={<XDSTopNavTitle title="App" href="#" />}
+        heading={<XDSTopNavHeading heading="App" href="#" />}
         startContent={
           <>
             <XDSTopNavItem label="Home" href="#" isSelected />

--- a/internal/vibe-tests/src/universal-eval.ts
+++ b/internal/vibe-tests/src/universal-eval.ts
@@ -139,7 +139,7 @@ function discoverXDSComponents(): Set<string> {
     'XDSTopNav',
     'XDSTopNavItem',
     'XDSTopNavMenu',
-    'XDSTopNavTitle',
+    'XDSTopNavHeading',
     'XDSNavIcon',
     'XDSVStack',
     'Theme',

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -20,7 +20,7 @@ export const docs = {
   topNav={
     <XDSTopNav
       label="Main navigation"
-      title={<XDSTopNavTitle title="My App" logo={<Logo />} />}
+      heading={<XDSTopNavHeading heading="My App" logo={<Logo />} />}
       startContent={
         <>
           <XDSTopNavItem label="Home" href="/" isSelected />
@@ -59,7 +59,7 @@ export const docs = {
   sideNav={
     <XDSSideNav
       header={
-        <XDSSideNavHeader icon={<AppIcon />} title="My App" titleHref="/" />
+        <XDSSideNavHeading icon={<AppIcon />} heading="My App" headingHref="/" />
       }>
       <XDSSideNavSection title="Main" isHeaderHidden>
         <XDSSideNavItem
@@ -85,7 +85,7 @@ export const docs = {
   topNav={
     <XDSTopNav
       label="Navigation"
-      title={<XDSTopNavTitle title="Landing Page" />}
+      heading={<XDSTopNavHeading heading="Landing Page" />}
     />
   }>
   <LandingContent />
@@ -94,7 +94,7 @@ export const docs = {
     {
       label: 'Auto height for content-heavy pages',
       code: `<XDSAppShell
-  topNav={<XDSTopNav label="Docs" title={<XDSTopNavTitle title="Docs" />} />}
+  topNav={<XDSTopNav label="Docs" heading={<XDSTopNavHeading heading="Docs" />} />}
   sideNav={<XDSSideNav>...</XDSSideNav>}
   height="auto"
 >
@@ -104,7 +104,7 @@ export const docs = {
     {
       label: 'Controlled sideNav collapse',
       code: `<XDSAppShell
-  topNav={<XDSTopNav label="App" title={<XDSTopNavTitle title="App" />} />}
+  topNav={<XDSTopNav label="App" heading={<XDSTopNavHeading heading="App" />} />}
   sideNav={<XDSSideNav>...</XDSSideNav>}
   isSideNavCollapsed={collapsed}
   onSideNavCollapsedChange={setCollapsed}
@@ -121,7 +121,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
   topNav={
     <XDSTopNav
       label="Navigation"
-      title={<XDSTopNavTitle title="My App" />}
+      heading={<XDSTopNavHeading heading="My App" />}
       startContent={
         isMobile ? (
           <XDSButton
@@ -227,8 +227,8 @@ const isMobile = useMediaQuery('(max-width: 768px)');
     ],
   },
   notes: [
-    'When a TopNav is present, omit XDSSideNavHeader from the SideNav — the TopNav already provides app identity. Adding both would double the identity.',
-    'When there is no TopNav, include XDSSideNavHeader inside the SideNav so the app name and logo are present.',
+    'When a TopNav is present, omit XDSSideNavHeading from the SideNav — the TopNav already provides app identity. Adding both would double the identity.',
+    'When there is no TopNav, include XDSSideNavHeading inside the SideNav so the app name and logo are present.',
     'XDSAppShell composes XDSLayout internally: topNav + banner map to XDSLayoutHeader, sideNav maps to XDSLayoutPanel, and children map to XDSLayoutContent.',
     'SideNav collapse animations currently snap open/closed; ViewTransitions support is planned.',
     'In "auto" height mode, TopNav gets position: sticky; top: 0 and SideNav gets position: sticky; top: <header-height>.',

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -281,7 +281,7 @@ const styles = stylex.create({
  * @example
  * ```
  * <XDSAppShell
- *   topNav={<XDSTopNav label="Navigation" title={<XDSTopNavTitle title="My App" />} />}
+ *   topNav={<XDSTopNav label="Navigation" heading={<XDSTopNavHeading heading="My App" />} />}
  *   sideNav={<XDSSideNav>{navSections}</XDSSideNav>}
  *   mobileNav={
  *     <XDSMobileNav isOpen={mobileOpen} onOpenChange={(open) => setMobileOpen(open)} title="My App">

--- a/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
+++ b/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
@@ -44,12 +44,12 @@ describe('Edge Compensation', () => {
       render(
         <XDSTopNav
           label="Test nav"
-          title={<span data-testid="title">Logo</span>}
+          heading={<span data-testid="heading">Logo</span>}
         />,
       );
-      const title = screen.getByTestId('title');
-      // title > title wrapper > leftSection (with edgeSignals.start)
-      const leftSection = title.parentElement?.parentElement;
+      const heading = screen.getByTestId('heading');
+      // heading > heading wrapper > leftSection (with edgeSignals.start)
+      const leftSection = heading.parentElement?.parentElement;
       expect(leftSection).toHaveAttribute('class');
     });
   });

--- a/packages/core/src/NavIcon/NavIcon.doc.mjs
+++ b/packages/core/src/NavIcon/NavIcon.doc.mjs
@@ -5,7 +5,7 @@ export const docs = {
   description:
     'Circular icon container with accent background for navigation headers.',
   features: [
-    'Shared — used in both XDSTopNavTitle and XDSPageNavHeader',
+    'Shared — used in both XDSTopNavHeading and XDSPageNavHeader',
     'Accent background — uses --color-accent with --color-icon-on-media contrast',
     'Fixed size — renders at the medium (--size-md) design token size',
   ],
@@ -23,8 +23,8 @@ export const docs = {
       label: 'In top navigation',
       code: `import {CubeIcon} from '@heroicons/react/24/solid';
 
-<XDSTopNavTitle
-  title="My App"
+<XDSTopNavHeading
+  heading="My App"
   logo={<XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />}
 />`,
     },
@@ -34,15 +34,15 @@ export const docs = {
 
 <XDSPageNavHeader
   icon={<XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />}
-  title="My App"
+  heading="My App"
 />`,
     },
     {
       label: 'With HomeIcon',
       code: `import {HomeIcon} from '@heroicons/react/24/solid';
 
-<XDSTopNavTitle
-  title="Dashboard"
+<XDSTopNavHeading
+  heading="Dashboard"
   logo={<XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />}
 />`,
     },

--- a/packages/core/src/NavIcon/XDSNavIcon.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.tsx
@@ -53,16 +53,16 @@ export interface XDSNavIconProps extends XDSBaseProps<HTMLDivElement> {
  * ```
  * import {HomeIcon} from '@heroicons/react/24/solid';
  *
- * // In XDSTopNavTitle
- * <XDSTopNavTitle
- *   title="Dashboard"
+ * // In XDSTopNavHeading
+ * <XDSTopNavHeading
+ *   heading="Dashboard"
  *   logo={<XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />}
  * />
  *
  * // In XDSPageNavHeader
  * <XDSPageNavHeader
  *   icon={<XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />}
- *   title="My App"
+ *   heading="My App"
  * />
  * ```
  */

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -23,15 +23,15 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-side-nav'},
-      {className: 'xds-side-nav-header'},
+      {className: 'xds-side-nav-heading'},
       {className: 'xds-side-nav-item'},
       {className: 'xds-side-nav-section'},
     ],
   },
   notes: [
-    'When used inside XDSAppShell alongside XDSTopNav, omit XDSSideNavHeader — the TopNav already provides app identity and including the header would duplicate it.',
-    'Without a TopNav, include XDSSideNavHeader to provide app identity.',
-    'Header interaction model: titleHref only → whole header is one link; titleHref + supertitleHref, no menu → each text is an independent link; menu only, no hrefs → whole header is the popover trigger; menu + hrefs → links are independent <a> elements, chevron/remaining area is the popover trigger.',
+    'When used inside XDSAppShell alongside XDSTopNav, omit XDSSideNavHeading — the TopNav already provides app identity and including the header would duplicate it.',
+    'Without a TopNav, include XDSSideNavHeading to provide app identity.',
+    'Header interaction model: headingHref only → whole header is one link; headingHref + superheadingHref, no menu → each text is an independent link; menu only, no hrefs → whole header is the popover trigger; menu + hrefs → links are independent <a> elements, chevron/remaining area is the popover trigger.',
     'Depends on useXDSPopover for the header menu popover and XDSIcon for rendering icon components in nav items.',
   ],
   examples: [
@@ -39,10 +39,10 @@ export const docs = {
       label: 'With XDSAppShell + TopNav (no header)',
       code: `// TopNav provides identity → SideNav has no header
 <XDSAppShell
-  topNav={<XDSTopNav title={<XDSTopNavTitle title="My App" />} />}
+  topNav={<XDSTopNav heading={<XDSTopNavHeading heading="My App" />} />}
   sideNav={
     <XDSSideNav>
-      <XDSSideNavSection title="Main" isHeaderHidden>
+      <XDSSideNavSection heading="Main" isHeaderHidden>
         <XDSSideNavItem
           label="Dashboard"
           icon={HomeIcon}
@@ -63,11 +63,11 @@ export const docs = {
   sideNav={
     <XDSSideNav
       header={
-        <XDSSideNavHeader icon={<AppIcon />} title="My App" titleHref="/" />
+        <XDSSideNavHeading icon={<AppIcon />} heading="My App" headingHref="/" />
       }
       topContent={<XDSButton label="Create new" variant="primary" />}
       footerIcons={<XDSButton icon={HelpIcon} variant="ghost" label="Help" />}>
-      <XDSSideNavSection title="Main">
+      <XDSSideNavSection heading="Main">
         <XDSSideNavItem
           label="Dashboard"
           icon={HomeIcon}
@@ -83,7 +83,7 @@ export const docs = {
         />
       </XDSSideNavSection>
 
-      <XDSSideNavSection title="Settings">
+      <XDSSideNavSection heading="Settings">
         <XDSSideNavItem label="General" href="/settings/general" />
         <XDSSideNavItem label="Security" href="/settings/security" />
       </XDSSideNavSection>
@@ -102,7 +102,7 @@ export const docs = {
         {
           name: 'header',
           type: 'ReactNode',
-          description: 'Header area (typically XDSSideNavHeader). Sticky.',
+          description: 'Header area (typically XDSSideNavHeading). Sticky.',
         },
         {
           name: 'topContent',
@@ -129,9 +129,9 @@ export const docs = {
         {
           label: 'Basic',
           code: `<XDSSideNav
-  header={<XDSSideNavHeader icon={<AppIcon />} title="My App" titleHref="/" />}
+  header={<XDSSideNavHeading icon={<AppIcon />} heading="My App" headingHref="/" />}
   topContent={<XDSButton label="Create new" variant="primary" />}>
-  <XDSSideNavSection title="Main">
+  <XDSSideNavSection heading="Main">
     <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected href="/dashboard" />
     <XDSSideNavItem label="Projects" icon={FolderIcon} href="/projects" />
   </XDSSideNavSection>
@@ -140,12 +140,12 @@ export const docs = {
       ],
     },
     {
-      name: 'XDSSideNavHeader',
+      name: 'XDSSideNavHeading',
       description:
-        'Product/suite/account header with smart interaction boundary logic for links and a menu popover.',
+        'Product/suite/account heading with smart interaction boundary logic for links and a menu popover.',
       props: [
         {
-          name: 'title',
+          name: 'heading',
           type: 'string',
           description: 'Product/app name.',
           required: true,
@@ -156,29 +156,29 @@ export const docs = {
           description: 'Product/app icon.',
         },
         {
-          name: 'titleHref',
+          name: 'headingHref',
           type: 'string',
-          description: 'Link for the title.',
+          description: 'Link for the heading.',
         },
         {
-          name: 'supertitle',
+          name: 'superheading',
           type: 'string',
-          description: 'Text above the title.',
+          description: 'Text above the heading.',
         },
         {
-          name: 'supertitleHref',
+          name: 'superheadingHref',
           type: 'string',
-          description: 'Link for the supertitle.',
+          description: 'Link for the superheading.',
         },
         {
-          name: 'subtitle',
+          name: 'subheading',
           type: 'string',
-          description: 'Text below the title.',
+          description: 'Text below the heading.',
         },
         {
-          name: 'subtitleHref',
+          name: 'subheadingHref',
           type: 'string',
-          description: 'Link for the subtitle.',
+          description: 'Link for the subheading.',
         },
         {
           name: 'menu',
@@ -189,25 +189,25 @@ export const docs = {
       examples: [
         {
           label: 'Title link only',
-          code: `<XDSSideNavHeader icon={<AppIcon />} title="My App" titleHref="/" />`,
+          code: `<XDSSideNavHeading icon={<AppIcon />} heading="My App" headingHref="/" />`,
         },
         {
-          label: 'With supertitle and subtitle',
-          code: `<XDSSideNavHeader
+          label: 'With superheading and subheading',
+          code: `<XDSSideNavHeading
   icon={<AppIcon />}
-  supertitle="Acme Corp"
-  supertitleHref="/org"
-  title="My App"
-  titleHref="/"
-  subtitle="v2.0"
+  superheading="Acme Corp"
+  superheadingHref="/org"
+  heading="My App"
+  headingHref="/"
+  subheading="v2.0"
 />`,
         },
         {
           label: 'With menu',
-          code: `<XDSSideNavHeader
+          code: `<XDSSideNavHeading
   icon={<AppIcon />}
-  title="My App"
-  titleHref="/"
+  heading="My App"
+  headingHref="/"
   menu={<WorkspaceSwitcher />}
 />`,
         },
@@ -335,21 +335,21 @@ export const docs = {
       examples: [
         {
           label: 'Basic section',
-          code: `<XDSSideNavSection title="Main">
+          code: `<XDSSideNavSection heading="Main">
   <XDSSideNavItem label="Dashboard" href="/dashboard" />
   <XDSSideNavItem label="Projects" href="/projects" />
 </XDSSideNavSection>`,
         },
         {
           label: 'With end content and hidden header',
-          code: `<XDSSideNavSection title="Settings" endContent={<XDSBadge>New</XDSBadge>}>
+          code: `<XDSSideNavSection heading="Settings" endContent={<XDSBadge>New</XDSBadge>}>
   <XDSSideNavItem label="General" href="/settings/general" />
   <XDSSideNavItem label="Security" href="/settings/security" />
 </XDSSideNavSection>`,
         },
         {
           label: 'Hidden header (used with TopNav)',
-          code: `<XDSSideNavSection title="Main" isHeaderHidden>
+          code: `<XDSSideNavSection heading="Main" isHeaderHidden>
   <XDSSideNavItem label="Dashboard" icon={HomeIcon} isSelected href="/dashboard" />
 </XDSSideNavSection>`,
         },

--- a/packages/core/src/SideNav/XDSSideNav.test.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.test.tsx
@@ -12,7 +12,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSSideNav} from './XDSSideNav';
-import {XDSSideNavHeader} from './XDSSideNavHeader';
+import {XDSSideNavHeading} from './XDSSideNavHeading';
 import {XDSSideNavItem} from './XDSSideNavItem';
 import {XDSSideNavSection} from './XDSSideNavSection';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
@@ -119,49 +119,49 @@ describe('XDSSideNav', () => {
 });
 
 // =============================================================================
-// XDSSideNavHeader
+// XDSSideNavHeading
 // =============================================================================
 
-describe('XDSSideNavHeader', () => {
-  it('renders title text', () => {
-    render(<XDSSideNavHeader title="My App" />);
+describe('XDSSideNavHeading', () => {
+  it('renders heading text', () => {
+    render(<XDSSideNavHeading heading="My App" />);
     expect(screen.getByText('My App')).toBeInTheDocument();
   });
 
   it('renders icon', () => {
     render(
-      <XDSSideNavHeader
-        title="My App"
+      <XDSSideNavHeading
+        heading="My App"
         icon={<span data-testid="app-icon">🏠</span>}
       />,
     );
     expect(screen.getByTestId('app-icon')).toBeInTheDocument();
   });
 
-  it('renders supertitle', () => {
-    render(<XDSSideNavHeader title="Product" supertitle="Suite Name" />);
+  it('renders superheading', () => {
+    render(<XDSSideNavHeading heading="Product" superheading="Suite Name" />);
     expect(screen.getByText('Suite Name')).toBeInTheDocument();
   });
 
-  it('renders subtitle', () => {
-    render(<XDSSideNavHeader title="Product" subtitle="Account" />);
+  it('renders subheading', () => {
+    render(<XDSSideNavHeading heading="Product" subheading="Account" />);
     expect(screen.getByText('Account')).toBeInTheDocument();
   });
 
-  it('renders as link when titleHref is provided without menu', () => {
-    render(<XDSSideNavHeader title="My App" titleHref="/home" />);
+  it('renders as link when headingHref is provided without menu', () => {
+    render(<XDSSideNavHeading heading="My App" headingHref="/home" />);
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', '/home');
     expect(link).toHaveTextContent('My App');
   });
 
-  it('renders independent links when titleHref and supertitleHref are provided', () => {
+  it('renders independent links when headingHref and superheadingHref are provided', () => {
     render(
-      <XDSSideNavHeader
-        title="Product"
-        titleHref="/product"
-        supertitle="Suite"
-        supertitleHref="/suite"
+      <XDSSideNavHeading
+        heading="Product"
+        headingHref="/product"
+        superheading="Suite"
+        superheadingHref="/suite"
       />,
     );
     const links = screen.getAllByRole('link');
@@ -171,20 +171,22 @@ describe('XDSSideNavHeader', () => {
   });
 
   it('shows chevron when menu is provided', () => {
-    render(<XDSSideNavHeader title="My App" menu={<div>Menu content</div>} />);
+    render(
+      <XDSSideNavHeading heading="My App" menu={<div>Menu content</div>} />,
+    );
     // The chevron SVG should be rendered
     const button = screen.getByRole('button');
     expect(button).toBeInTheDocument();
   });
 
   it('does not show chevron without menu', () => {
-    const {container} = render(<XDSSideNavHeader title="My App" />);
+    const {container} = render(<XDSSideNavHeading heading="My App" />);
     const svg = container.querySelector('svg');
     expect(svg).not.toBeInTheDocument();
   });
 
-  it('whole header is popover trigger when menu provided without hrefs', () => {
-    render(<XDSSideNavHeader title="My App" menu={<div>Menu</div>} />);
+  it('whole heading is popover trigger when menu provided without hrefs', () => {
+    render(<XDSSideNavHeading heading="My App" menu={<div>Menu</div>} />);
     const button = screen.getByRole('button');
     expect(button).toHaveAttribute('aria-haspopup', 'dialog');
     expect(button).toHaveAttribute('aria-expanded', 'false');
@@ -193,8 +195,8 @@ describe('XDSSideNavHeader', () => {
   it('toggles popover on click when menu is provided', async () => {
     const user = userEvent.setup();
     render(
-      <XDSSideNavHeader
-        title="My App"
+      <XDSSideNavHeading
+        heading="My App"
         menu={<div data-testid="menu-content">Menu</div>}
       />,
     );
@@ -205,9 +207,9 @@ describe('XDSSideNavHeader', () => {
 
   it('renders chevron as separate trigger when menu and hrefs are provided', () => {
     render(
-      <XDSSideNavHeader
-        title="Product"
-        titleHref="/product"
+      <XDSSideNavHeading
+        heading="Product"
+        headingHref="/product"
         menu={<div>Menu</div>}
       />,
     );
@@ -216,7 +218,7 @@ describe('XDSSideNavHeader', () => {
   });
 
   it('passes data-testid', () => {
-    render(<XDSSideNavHeader title="My App" data-testid="nav-header" />);
+    render(<XDSSideNavHeading heading="My App" data-testid="nav-header" />);
     expect(screen.getByTestId('nav-header')).toBeInTheDocument();
   });
 });
@@ -341,7 +343,7 @@ describe('XDSSideNavSection', () => {
     expect(screen.getByRole('group')).toBeInTheDocument();
   });
 
-  it('renders title text', () => {
+  it('renders heading text', () => {
     render(
       <XDSSideNavSection title="Main">
         <XDSSideNavItem label="Dashboard" />
@@ -363,7 +365,7 @@ describe('XDSSideNavSection', () => {
     expect(label).toHaveTextContent('Main');
   });
 
-  it('renders subtitle', () => {
+  it('renders subheading', () => {
     render(
       <XDSSideNavSection title="Main" subtitle="Primary navigation">
         <XDSSideNavItem label="Dashboard" />
@@ -401,7 +403,7 @@ describe('SideNav integration', () => {
   it('renders a complete page nav', () => {
     render(
       <XDSSideNav
-        header={<XDSSideNavHeader title="My App" />}
+        header={<XDSSideNavHeading heading="My App" />}
         topContent={<button>Create</button>}
         footer={<div data-testid="promo">Promo</div>}
         footerIcons={<button>Help</button>}>

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -83,7 +83,7 @@ const styles = stylex.create({
 
 export interface XDSSideNavProps extends XDSBaseProps<HTMLElement> {
   /**
-   * Header area — typically XDSSideNavHeader. Sticky at top.
+   * Header area — typically XDSSideNavHeading. Sticky at top.
    */
   header?: ReactNode;
   /**
@@ -142,10 +142,10 @@ export interface XDSSideNavProps extends XDSBaseProps<HTMLElement> {
  * @example
  * ```
  * <XDSSideNav
- *   header={<XDSSideNavHeader title="My App" titleHref="/" />}
+ *   header={<XDSSideNavHeading heading="My App" headingHref="/" />}
  *   topContent={<XDSButton label="Create new" variant="primary" />}
  * >
- *   <XDSSideNavSection title="Main">
+ *   <XDSSideNavSection heading="Main">
  *     <XDSSideNavItem label="Dashboard" isSelected href="/dashboard" />
  *     <XDSSideNavItem label="Projects" href="/projects" />
  *   </XDSSideNavSection>

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -1,10 +1,10 @@
 /**
- * @file XDSSideNavHeader.tsx
+ * @file XDSSideNavHeading.tsx
  * @input Uses React forwardRef, useRef, useCallback, ReactNode, StyleX, useXDSPopover
- * @output Exports XDSSideNavHeader component and XDSSideNavHeaderProps
+ * @output Exports XDSSideNavHeading component and XDSSideNavHeadingProps
  * @position Core implementation; used inside XDSSideNav header slot
  *
- * Product/suite/account header with smart interaction boundary logic.
+ * Product/suite/account heading with smart interaction boundary logic.
  * Composes useXDSPopover internally when menu prop is provided.
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -83,7 +83,7 @@ const styles = stylex.create({
     flex: 1,
     minWidth: 0,
   },
-  supertitle: {
+  superheading: {
     fontSize: textSizeVars['--text-xsm'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
@@ -92,7 +92,7 @@ const styles = stylex.create({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-  title: {
+  heading: {
     fontSize: textSizeVars['--text-base'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-snug'],
@@ -102,7 +102,7 @@ const styles = stylex.create({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-  subtitle: {
+  subheading: {
     fontSize: textSizeVars['--text-xsm'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
@@ -136,7 +136,7 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface XDSSideNavHeaderProps {
+export interface XDSSideNavHeadingProps {
   /**
    * Product/app icon.
    */
@@ -144,27 +144,27 @@ export interface XDSSideNavHeaderProps {
   /**
    * Product/app name.
    */
-  title: string;
+  heading: string;
   /**
-   * Link for the title (e.g., product home).
+   * Link for the heading (e.g., product home).
    */
-  titleHref?: string;
+  headingHref?: string;
   /**
-   * Text above the title (e.g., suite name).
+   * Text above the heading (e.g., suite name).
    */
-  supertitle?: string;
+  superheading?: string;
   /**
-   * Link for the supertitle (e.g., suite home).
+   * Link for the superheading (e.g., suite home).
    */
-  supertitleHref?: string;
+  superheadingHref?: string;
   /**
-   * Text below the title (e.g., account context).
+   * Text below the heading (e.g., account context).
    */
-  subtitle?: string;
+  subheading?: string;
   /**
-   * Link for the subtitle.
+   * Link for the subheading.
    */
-  subtitleHref?: string;
+  subheadingHref?: string;
   /**
    * Menu content shown in a popover. When provided, the header composes
    * useXDSPopover internally and shows a dropdown chevron. The trigger
@@ -228,12 +228,12 @@ function ChevronDownIcon() {
 // =============================================================================
 
 /**
- * Product/suite/account header for XDSSideNav.
+ * Product/suite/account heading for XDSSideNav.
  *
  * Supports smart interaction boundary logic:
- * - No hrefs + menu → whole header is the popover trigger
- * - titleHref only, no menu → whole header is one link
- * - titleHref + supertitleHref, no menu → each is an independent link
+ * - No hrefs + menu → whole heading is the popover trigger
+ * - headingHref only, no menu → whole heading is one link
+ * - headingHref + superheadingHref, no menu → each is an independent link
  * - menu + hrefs → links are independent, chevron/remaining area is the trigger
  *
  * The chevron indicator is automatically shown when `menu` is provided.
@@ -241,39 +241,39 @@ function ChevronDownIcon() {
  * @example
  * ```
  * // Single product
- * <XDSSideNavHeader icon={<AppIcon />} title="My App" titleHref="/" />
+ * <XDSSideNavHeading icon={<AppIcon />} heading="My App" headingHref="/" />
  *
  * // Suite with menu
- * <XDSSideNavHeader
+ * <XDSSideNavHeading
  *   icon={<SuiteIcon />}
- *   supertitle="Suite Name"
- *   supertitleHref="/suite"
- *   title="Product Name"
- *   titleHref="/product"
+ *   superheading="Suite Name"
+ *   superheadingHref="/suite"
+ *   heading="Product Name"
+ *   headingHref="/product"
  *   menu={<ProductSwitcher />}
  * />
  *
  * // Account context with menu
- * <XDSSideNavHeader
+ * <XDSSideNavHeading
  *   icon={<AppIcon />}
- *   title="Product Name"
- *   subtitle="Business Account"
+ *   heading="Product Name"
+ *   subheading="Business Account"
  *   menu={<AccountSwitcher />}
  * />
  * ```
  */
-export const XDSSideNavHeader = forwardRef<
+export const XDSSideNavHeading = forwardRef<
   HTMLDivElement,
-  XDSSideNavHeaderProps
->(function XDSSideNavHeader(
+  XDSSideNavHeadingProps
+>(function XDSSideNavHeading(
   {
     icon,
-    title,
-    titleHref,
-    supertitle,
-    supertitleHref,
-    subtitle,
-    subtitleHref,
+    heading,
+    headingHref,
+    superheading,
+    superheadingHref,
+    subheading,
+    subheadingHref,
     menu,
     xstyle,
     className,
@@ -290,12 +290,12 @@ export const XDSSideNavHeader = forwardRef<
   });
 
   const showChevron = !!menu;
-  const hasAnyHref = !!(titleHref || supertitleHref || subtitleHref);
+  const hasAnyHref = !!(headingHref || superheadingHref || subheadingHref);
 
   // Determine interaction mode
-  const isWholeHeaderTrigger = !!menu && !hasAnyHref;
-  const isWholeHeaderLink =
-    !!titleHref && !menu && !supertitleHref && !subtitleHref;
+  const isWholeHeadingTrigger = !!menu && !hasAnyHref;
+  const isWholeHeadingLink =
+    !!headingHref && !menu && !superheadingHref && !subheadingHref;
 
   const handleToggle = useCallback(() => {
     popover.toggle();
@@ -322,40 +322,40 @@ export const XDSSideNavHeader = forwardRef<
   // Render text content
   const renderTextContent = () => (
     <span {...stylex.props(styles.textContainer)}>
-      {supertitle &&
-        (hasAnyHref && supertitleHref && menu ? (
+      {superheading &&
+        (hasAnyHref && superheadingHref && menu ? (
           <XDSLink
-            label={supertitle}
-            href={supertitleHref}
+            label={superheading}
+            href={superheadingHref}
             color="secondary"
             size="xsm">
-            {supertitle}
+            {superheading}
           </XDSLink>
         ) : (
-          <span {...stylex.props(styles.supertitle)}>{supertitle}</span>
+          <span {...stylex.props(styles.superheading)}>{superheading}</span>
         ))}
-      {hasAnyHref && titleHref && menu ? (
+      {hasAnyHref && headingHref && menu ? (
         <XDSLink
-          label={title}
-          href={titleHref}
+          label={heading}
+          href={headingHref}
           color="primary"
           weight="semibold">
-          {title}
+          {heading}
         </XDSLink>
       ) : (
-        <span {...stylex.props(styles.title)}>{title}</span>
+        <span {...stylex.props(styles.heading)}>{heading}</span>
       )}
-      {subtitle &&
-        (hasAnyHref && subtitleHref && menu ? (
+      {subheading &&
+        (hasAnyHref && subheadingHref && menu ? (
           <XDSLink
-            label={subtitle}
-            href={subtitleHref}
+            label={subheading}
+            href={subheadingHref}
             color="secondary"
             size="xsm">
-            {subtitle}
+            {subheading}
           </XDSLink>
         ) : (
-          <span {...stylex.props(styles.subtitle)}>{subtitle}</span>
+          <span {...stylex.props(styles.subheading)}>{subheading}</span>
         ))}
     </span>
   );
@@ -366,15 +366,15 @@ export const XDSSideNavHeader = forwardRef<
     </span>
   );
 
-  // Whole header is a link (no menu, single titleHref)
-  if (isWholeHeaderLink) {
+  // Whole heading is a link (no menu, single headingHref)
+  if (isWholeHeadingLink) {
     return (
       <a
         ref={ref as React.Ref<HTMLAnchorElement>}
-        href={titleHref}
+        href={headingHref}
         data-testid={testId}
         {...mergeProps(
-          xdsClassName('side-nav-header'),
+          xdsClassName('side-nav-heading'),
           stylex.props(
             styles.root,
             styles.interactive,
@@ -393,7 +393,7 @@ export const XDSSideNavHeader = forwardRef<
   }
 
   // Whole header is the popover trigger (menu, no hrefs)
-  if (isWholeHeaderTrigger) {
+  if (isWholeHeadingTrigger) {
     return (
       <>
         <button
@@ -403,7 +403,7 @@ export const XDSSideNavHeader = forwardRef<
           data-testid={testId}
           {...popover.triggerProps}
           {...mergeProps(
-            xdsClassName('side-nav-header'),
+            xdsClassName('side-nav-heading'),
             stylex.props(
               styles.root,
               styles.interactive,
@@ -426,7 +426,7 @@ export const XDSSideNavHeader = forwardRef<
   }
 
   // Mixed mode: independent links + chevron trigger for menu
-  // Popover anchors to the full header div, not the chevron, so it
+  // Popover anchors to the full heading div, not the chevron, so it
   // appears in the same position as the no-links case.
   if (menu && hasAnyHref) {
     return (
@@ -435,14 +435,14 @@ export const XDSSideNavHeader = forwardRef<
           ref={setRef}
           data-testid={testId}
           {...mergeProps(
-            xdsClassName('side-nav-header'),
+            xdsClassName('side-nav-heading'),
             stylex.props(styles.root, xstyle),
             className,
             style,
           )}>
           {icon &&
-            (titleHref ? (
-              <a href={titleHref} {...stylex.props(styles.icon)}>
+            (headingHref ? (
+              <a href={headingHref} {...stylex.props(styles.icon)}>
                 {icon}
               </a>
             ) : (
@@ -468,62 +468,62 @@ export const XDSSideNavHeader = forwardRef<
     );
   }
 
-  // Static header with independent links (no menu)
-  if (hasAnyHref && !isWholeHeaderLink) {
+  // Static heading with independent links (no menu)
+  if (hasAnyHref && !isWholeHeadingLink) {
     return (
       <div
         ref={ref}
         data-testid={testId}
         {...mergeProps(
-          xdsClassName('side-nav-header'),
+          xdsClassName('side-nav-heading'),
           stylex.props(styles.root, xstyle),
           className,
           style,
         )}
         {...props}>
         {icon &&
-          (titleHref ? (
-            <a href={titleHref} {...stylex.props(styles.icon)}>
+          (headingHref ? (
+            <a href={headingHref} {...stylex.props(styles.icon)}>
               {icon}
             </a>
           ) : (
             <span {...stylex.props(styles.icon)}>{icon}</span>
           ))}
         <span {...stylex.props(styles.textContainer)}>
-          {supertitle &&
-            (supertitleHref ? (
+          {superheading &&
+            (superheadingHref ? (
               <XDSLink
-                label={supertitle}
-                href={supertitleHref}
+                label={superheading}
+                href={superheadingHref}
                 color="secondary"
                 size="xsm">
-                {supertitle}
+                {superheading}
               </XDSLink>
             ) : (
-              <span {...stylex.props(styles.supertitle)}>{supertitle}</span>
+              <span {...stylex.props(styles.superheading)}>{superheading}</span>
             ))}
-          {titleHref ? (
+          {headingHref ? (
             <XDSLink
-              label={title}
-              href={titleHref}
+              label={heading}
+              href={headingHref}
               color="primary"
               weight="semibold">
-              {title}
+              {heading}
             </XDSLink>
           ) : (
-            <span {...stylex.props(styles.title)}>{title}</span>
+            <span {...stylex.props(styles.heading)}>{heading}</span>
           )}
-          {subtitle &&
-            (subtitleHref ? (
+          {subheading &&
+            (subheadingHref ? (
               <XDSLink
-                label={subtitle}
-                href={subtitleHref}
+                label={subheading}
+                href={subheadingHref}
                 color="secondary"
                 size="xsm">
-                {subtitle}
+                {subheading}
               </XDSLink>
             ) : (
-              <span {...stylex.props(styles.subtitle)}>{subtitle}</span>
+              <span {...stylex.props(styles.subheading)}>{subheading}</span>
             ))}
         </span>
         {chevronElement}
@@ -531,13 +531,13 @@ export const XDSSideNavHeader = forwardRef<
     );
   }
 
-  // Default: static header, no links, no menu
+  // Default: static heading, no links, no menu
   return (
     <div
       ref={ref}
       data-testid={testId}
       {...mergeProps(
-        xdsClassName('side-nav-header'),
+        xdsClassName('side-nav-heading'),
         stylex.props(styles.root, xstyle),
         className,
         style,
@@ -550,4 +550,4 @@ export const XDSSideNavHeader = forwardRef<
   );
 });
 
-XDSSideNavHeader.displayName = 'XDSSideNavHeader';
+XDSSideNavHeading.displayName = 'XDSSideNavHeading';

--- a/packages/core/src/SideNav/index.ts
+++ b/packages/core/src/SideNav/index.ts
@@ -1,7 +1,7 @@
 /**
  * @file index.ts
  * @input Imports SideNav components and types
- * @output Exports XDSSideNav, XDSSideNavHeader, XDSSideNavItem, XDSSideNavSection
+ * @output Exports XDSSideNav, XDSSideNavHeading, XDSSideNavItem, XDSSideNavSection
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/SideNav/SideNav.doc.mjs
@@ -10,8 +10,13 @@
 export {XDSSideNav} from './XDSSideNav';
 export type {XDSSideNavProps} from './XDSSideNav';
 
-export {XDSSideNavHeader} from './XDSSideNavHeader';
-export type {XDSSideNavHeaderProps} from './XDSSideNavHeader';
+export {XDSSideNavHeading} from './XDSSideNavHeading';
+export type {XDSSideNavHeadingProps} from './XDSSideNavHeading';
+
+/** @deprecated Use XDSSideNavHeading instead */
+export {XDSSideNavHeading as XDSSideNavHeader} from './XDSSideNavHeading';
+/** @deprecated Use XDSSideNavHeadingProps instead */
+export type {XDSSideNavHeadingProps as XDSSideNavHeaderProps} from './XDSSideNavHeading';
 
 export {XDSSideNavItem} from './XDSSideNavItem';
 export type {XDSSideNavItemProps} from './XDSSideNavItem';

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -5,21 +5,21 @@ export const docs = {
   description:
     'Top navigation bar component for application headers with slot-based layout and companion nav item components.',
   features: [
-    'Slot-based layout — title, startContent, centerContent, and endContent slots for flexible organization',
+    'Slot-based layout — heading, startContent, centerContent, and endContent slots for flexible organization',
     'Three-column centering — when centerContent is provided, switches to CSS grid (1fr auto 1fr) for true horizontal centering',
-    'Companion components — XDSTopNavTitle, XDSTopNavItem, XDSTopNavMenu, XDSTopNavMegaMenu',
+    'Companion components — XDSTopNavHeading, XDSTopNavItem, XDSTopNavMenu, XDSTopNavMegaMenu',
     'Accessible — uses role="navigation" with aria-label, aria-current="page" on selected items',
     'Themeable via className — target .xds-top-nav and sub-component classes',
     'Link customization — XDSTopNavItem accepts an as prop to swap the anchor element (e.g. for React Router)',
   ],
   examples: [
     {
-      label: 'Basic nav with title and items',
+      label: 'Basic nav with heading and items',
       code: `<XDSTopNav
   label="Main navigation"
-  title={
-    <XDSTopNavTitle
-      title="My App"
+  heading={
+    <XDSTopNavHeading
+      heading="My App"
       logo={<XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />}
       href="/"
     />
@@ -51,7 +51,7 @@ export const docs = {
       label: 'With centered content (three-column layout)',
       code: `<XDSTopNav
   label="Main navigation"
-  title={<XDSTopNavTitle title="My App" href="/" />}
+  heading={<XDSTopNavHeading heading="My App" href="/" />}
   startContent={<XDSTopNavItem label="Home" href="/" isSelected />}
   centerContent={<SearchBar />}
   endContent={<Avatar />}
@@ -61,7 +61,7 @@ export const docs = {
       label: 'With hover menu and mega menu',
       code: `<XDSTopNav
   label="Main navigation"
-  title={<XDSTopNavTitle title="My App" href="/" />}
+  heading={<XDSTopNavHeading heading="My App" href="/" />}
   startContent={
     <>
       <XDSTopNavItem label="Home" href="/" isSelected />
@@ -95,7 +95,7 @@ export const docs = {
   header={
     <XDSTopNav
       label="Main navigation"
-      title={<XDSTopNavTitle title="My App" logo={<Logo />} href="/" />}
+      heading={<XDSTopNavHeading heading="My App" logo={<Logo />} href="/" />}
       startContent={
         <>
           <XDSTopNavItem label="Home" href="/" isSelected />
@@ -117,7 +117,7 @@ export const docs = {
     targets: [
       {className: 'xds-top-nav'},
       {className: 'xds-top-nav-item'},
-      {className: 'xds-top-nav-title'},
+      {className: 'xds-top-nav-heading'},
       {className: 'xds-top-nav-mega-menu'},
     ],
   },
@@ -136,7 +136,7 @@ export const docs = {
   notes: [
     'Default height is 48px (--spacing-12) with 16px horizontal padding',
     'Uses --color-navbar token for background (defaults to white)',
-    'Without centerContent: title and startContent grow to push endContent right (flex layout)',
+    'Without centerContent: heading and startContent grow to push endContent right (flex layout)',
     'With centerContent: switches to CSS grid (gridTemplateColumns: 1fr auto 1fr) — the right column is always rendered even when endContent is absent to maintain the three-column structure',
     'Positioning (sticky/fixed) is handled by the layout system (e.g. XDSAppShell), not TopNav itself',
     'Dividers are controlled by the layout system (e.g. XDSLayoutHeader hasDivider), not TopNav',
@@ -148,16 +148,16 @@ export const docs = {
       description: 'Main navigation bar container with slot-based layout.',
       props: [
         {
-          name: 'title',
+          name: 'heading',
           type: 'ReactNode',
           description:
-            'Title slot content (logo, brand) — positioned at the left edge of the nav bar.',
+            'Heading slot content (logo, brand) — positioned at the left edge of the nav bar.',
         },
         {
           name: 'startContent',
           type: 'ReactNode',
           description:
-            'Start content slot for navigation items or breadcrumbs — positioned after the title, left-aligned.',
+            'Start content slot for navigation items or breadcrumbs — positioned after the heading, left-aligned.',
         },
         {
           name: 'centerContent',
@@ -183,7 +183,7 @@ export const docs = {
           label: 'Basic',
           code: `<XDSTopNav
   label="Main navigation"
-  title={<XDSTopNavTitle title="My App" href="/" />}
+  heading={<XDSTopNavHeading heading="My App" href="/" />}
   startContent={<XDSTopNavItem label="Dashboard" href="/dashboard" isSelected />}
   endContent={<XDSButton label="Profile" variant="ghost" />}
 />`,
@@ -192,7 +192,7 @@ export const docs = {
           label: 'With centered content',
           code: `<XDSTopNav
   label="Main navigation"
-  title={<XDSTopNavTitle title="My App" href="/" />}
+  heading={<XDSTopNavHeading heading="My App" href="/" />}
   centerContent={<SearchInput placeholder="Search..." />}
   endContent={<Avatar />}
 />`,
@@ -200,20 +200,20 @@ export const docs = {
       ],
     },
     {
-      name: 'XDSTopNavTitle',
+      name: 'XDSTopNavHeading',
       description:
-        'Title component for the XDSTopNav title slot — displays a logo and/or title text, optionally as a clickable link.',
+        'Heading component for the XDSTopNav heading slot — displays a logo and/or heading text, optionally as a clickable link.',
       props: [
         {
-          name: 'title',
+          name: 'heading',
           type: 'string',
-          description: 'Title text to display.',
+          description: 'Heading text to display.',
         },
         {
           name: 'logo',
           type: 'ReactNode',
           description:
-            'Logo element to display before the title text. Can be an image, XDSNavIcon, or any ReactNode.',
+            'Logo element to display before the heading text. Can be an image, XDSNavIcon, or any ReactNode.',
         },
         {
           name: 'href',
@@ -225,23 +225,23 @@ export const docs = {
       examples: [
         {
           label: 'Logo with text link',
-          code: `<XDSTopNavTitle
-  title="My App"
+          code: `<XDSTopNavHeading
+  heading="My App"
   logo={<img src="/logo.svg" alt="" width={24} height={24} />}
   href="/"
 />`,
         },
         {
           label: 'With XDSNavIcon',
-          code: `<XDSTopNavTitle
-  title="Dashboard"
+          code: `<XDSTopNavHeading
+  heading="Dashboard"
   logo={<XDSNavIcon icon={<HomeIcon style={{width: 16, height: 16}} />} />}
   href="/"
 />`,
         },
         {
           label: 'Logo only',
-          code: `<XDSTopNavTitle logo={<BrandLogo />} href="/" />`,
+          code: `<XDSTopNavHeading logo={<BrandLogo />} href="/" />`,
         },
       ],
     },

--- a/packages/core/src/TopNav/XDSTopNav.test.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.test.tsx
@@ -12,7 +12,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {forwardRef, type ComponentPropsWithoutRef} from 'react';
 import {XDSTopNav} from './XDSTopNav';
-import {XDSTopNavTitle} from './XDSTopNavTitle';
+import {XDSTopNavHeading} from './XDSTopNavHeading';
 import {XDSNavIcon} from '../NavIcon';
 import {XDSTopNavItem} from './XDSTopNavItem';
 import {XDSLinkProvider} from '../Link/XDSLinkProvider';
@@ -40,8 +40,10 @@ describe('XDSTopNav', () => {
     );
   });
 
-  it('renders title slot content', () => {
-    render(<XDSTopNav title={<span data-testid="title-content">Logo</span>} />);
+  it('renders heading slot content', () => {
+    render(
+      <XDSTopNav heading={<span data-testid="title-content">Logo</span>} />,
+    );
     expect(screen.getByTestId('title-content')).toBeInTheDocument();
   });
 
@@ -73,7 +75,7 @@ describe('XDSTopNav', () => {
   it('renders all slots together', () => {
     render(
       <XDSTopNav
-        title={<span data-testid="title">Title</span>}
+        heading={<span data-testid="title">Title</span>}
         startContent={<span data-testid="start">Start</span>}
         centerContent={<span data-testid="center">Center</span>}
         endContent={<span data-testid="end">End</span>}
@@ -88,7 +90,7 @@ describe('XDSTopNav', () => {
   it('renders without centerContent (backward compatible)', () => {
     render(
       <XDSTopNav
-        title={<span data-testid="title">Title</span>}
+        heading={<span data-testid="title">Title</span>}
         startContent={<span data-testid="start">Start</span>}
         endContent={<span data-testid="end">End</span>}
       />,
@@ -101,7 +103,7 @@ describe('XDSTopNav', () => {
   it('renders centerContent without endContent', () => {
     render(
       <XDSTopNav
-        title={<span data-testid="title">Title</span>}
+        heading={<span data-testid="title">Title</span>}
         centerContent={<span data-testid="center">Center</span>}
       />,
     );
@@ -149,21 +151,21 @@ describe('XDSTopNav', () => {
   });
 });
 
-describe('XDSTopNavTitle', () => {
-  it('renders title text', () => {
-    render(<XDSTopNavTitle title="My App" />);
+describe('XDSTopNavHeading', () => {
+  it('renders heading text', () => {
+    render(<XDSTopNavHeading heading="My App" />);
     expect(screen.getByText('My App')).toBeInTheDocument();
   });
 
   it('renders logo element', () => {
-    render(<XDSTopNavTitle logo={<span data-testid="logo">Logo</span>} />);
+    render(<XDSTopNavHeading logo={<span data-testid="logo">Logo</span>} />);
     expect(screen.getByTestId('logo')).toBeInTheDocument();
   });
 
-  it('renders both logo and title', () => {
+  it('renders both logo and heading', () => {
     render(
-      <XDSTopNavTitle
-        title="Dashboard"
+      <XDSTopNavHeading
+        heading="Dashboard"
         logo={<span data-testid="logo">Logo</span>}
       />,
     );
@@ -172,19 +174,19 @@ describe('XDSTopNavTitle', () => {
   });
 
   it('renders as anchor when href is provided', () => {
-    render(<XDSTopNavTitle title="Home" href="/" />);
+    render(<XDSTopNavHeading heading="Home" href="/" />);
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('href', '/');
   });
 
   it('renders as div when no href', () => {
-    render(<XDSTopNavTitle title="Home" />);
+    render(<XDSTopNavHeading heading="Home" />);
     expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('forwards ref correctly', () => {
     const ref = vi.fn();
-    render(<XDSTopNavTitle title="Test" ref={ref} />);
+    render(<XDSTopNavHeading heading="Test" ref={ref} />);
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
   });
 });

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -52,7 +52,7 @@ const styles = stylex.create({
     flex: '1 1 0%',
     minWidth: 0,
   },
-  title: {
+  heading: {
     display: 'flex',
     alignItems: 'center',
     flexShrink: 0,
@@ -83,18 +83,12 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSTopNavProps extends Omit<
-  XDSBaseProps<HTMLElement>,
-  'title'
-> {
+export interface XDSTopNavProps extends XDSBaseProps<HTMLElement> {
   /**
-   * Title slot content — typically XDSTopNavTitle with logo and text.
+   * Heading slot content — typically XDSTopNavHeading with logo and text.
    * Positioned at the left edge of the nav bar.
-   *
-   * Note: named `title` for now but will be renamed to `heading` to avoid
-   * collision with the HTML `title` attribute. See follow-up PR.
    */
-  title?: ReactNode;
+  heading?: ReactNode;
   /**
    * Start content slot - typically navigation items or breadcrumbs.
    * Positioned after the title, left-aligned.
@@ -122,7 +116,7 @@ export interface XDSTopNavProps extends Omit<
 /**
  * Top navigation bar for application headers.
  *
- * Slot-based layout with `title`, `startContent`, `centerContent`, and
+ * Slot-based layout with `heading`, `startContent`, `centerContent`, and
  * `endContent`. When `centerContent` is provided, the layout switches to a
  * three-column CSS grid to keep center content horizontally centered.
  *
@@ -130,7 +124,7 @@ export interface XDSTopNavProps extends Omit<
  * ```
  * <XDSTopNav
  *   label="Main navigation"
- *   title={<XDSTopNavTitle title="My App" />}
+ *   heading={<XDSTopNavHeading heading="My App" />}
  *   startContent={<XDSTopNavItem label="Home" href="/" isSelected />}
  *   endContent={<XDSButton label="Search" variant="ghost" />}
  * />
@@ -139,7 +133,7 @@ export interface XDSTopNavProps extends Omit<
 export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
   function XDSTopNav(
     {
-      title,
+      heading,
       startContent,
       centerContent,
       endContent,
@@ -170,7 +164,7 @@ export const XDSTopNav = forwardRef<HTMLElement, XDSTopNavProps>(
         )}
         {...props}>
         <div {...stylex.props(styles.leftSection, edgeSignals.start)}>
-          {title && <div {...stylex.props(styles.title)}>{title}</div>}
+          {heading && <div {...stylex.props(styles.heading)}>{heading}</div>}
           {startContent && (
             <div {...stylex.props(styles.startContent)}>{startContent}</div>
           )}

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -1,8 +1,8 @@
 /**
- * @file XDSTopNavTitle.tsx
+ * @file XDSTopNavHeading.tsx
  * @input Uses React forwardRef, HTMLAttributes, ReactNode
- * @output Exports XDSTopNavTitle component and XDSTopNavTitleProps
- * @position Companion component for XDSTopNav title slot
+ * @output Exports XDSTopNavHeading component and XDSTopNavHeadingProps
+ * @position Companion component for XDSTopNav heading slot
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/TopNav/TopNav.doc.mjs
@@ -24,7 +24,7 @@ import {
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
- * Title styles
+ * Heading styles
  */
 const styles = stylex.create({
   base: {
@@ -34,7 +34,7 @@ const styles = stylex.create({
     textDecoration: 'none',
     color: colorVars['--color-text-primary'],
   },
-  titleText: {
+  headingText: {
     fontSize: textSizeVars['--text-lg'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-tight'],
@@ -51,51 +51,51 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSTopNavTitleProps extends XDSBaseProps<HTMLElement> {
+export interface XDSTopNavHeadingProps extends XDSBaseProps<HTMLElement> {
   /**
-   * The title text to display.
+   * The heading text to display.
    */
-  title?: string;
+  heading?: string;
   /**
-   * Logo element to display before the title.
+   * Logo element to display before the heading.
    * Can be an image, XDSNavIcon, or any ReactNode.
    */
   logo?: ReactNode;
   /**
-   * URL to navigate to when the title is clicked.
+   * URL to navigate to when the heading is clicked.
    * If provided, renders as an anchor element.
    */
   href?: string;
 }
 
 /**
- * Title component for XDSTopNav.
+ * Heading component for XDSTopNav.
  *
- * Displays a logo and/or title text, optionally as a clickable link.
+ * Displays a logo and/or heading text, optionally as a clickable link.
  * Use with XDSNavIcon to create a circular icon background.
  *
  * @example
  * ```
  * // Logo with text
- * <XDSTopNavTitle
- *   title="My App"
+ * <XDSTopNavHeading
+ *   heading="My App"
  *   logo={<img src="/logo.svg" alt="" width={24} height={24} />}
  *   href="/"
  * />
  *
  * // With circular icon
- * <XDSTopNavTitle
- *   title="Dashboard"
+ * <XDSTopNavHeading
+ *   heading="Dashboard"
  *   logo={<XDSNavIcon icon={<HomeIcon />} />}
  * />
  *
  * // Logo only
- * <XDSTopNavTitle logo={<BrandLogo />} href="/" />
+ * <XDSTopNavHeading logo={<BrandLogo />} href="/" />
  * ```
  */
-export const XDSTopNavTitle = forwardRef<HTMLElement, XDSTopNavTitleProps>(
-  function XDSTopNavTitle(
-    {title, logo, href, xstyle, className, style, ...props},
+export const XDSTopNavHeading = forwardRef<HTMLElement, XDSTopNavHeadingProps>(
+  function XDSTopNavHeading(
+    {heading, logo, href, xstyle, className, style, ...props},
     ref,
   ) {
     const Element = href ? 'a' : 'div';
@@ -105,17 +105,19 @@ export const XDSTopNavTitle = forwardRef<HTMLElement, XDSTopNavTitleProps>(
         ref={ref as React.Ref<HTMLAnchorElement & HTMLDivElement>}
         href={href}
         {...mergeProps(
-          xdsClassName('top-nav-title'),
+          xdsClassName('top-nav-heading'),
           stylex.props(styles.base, href != null && styles.clickable, xstyle),
           className,
           style,
         )}
         {...props}>
         {logo && <span {...stylex.props(styles.logo)}>{logo}</span>}
-        {title && <span {...stylex.props(styles.titleText)}>{title}</span>}
+        {heading && (
+          <span {...stylex.props(styles.headingText)}>{heading}</span>
+        )}
       </Element>
     );
   },
 );
 
-XDSTopNavTitle.displayName = 'XDSTopNavTitle';
+XDSTopNavHeading.displayName = 'XDSTopNavHeading';

--- a/packages/core/src/TopNav/index.ts
+++ b/packages/core/src/TopNav/index.ts
@@ -10,8 +10,13 @@
 export {XDSTopNav} from './XDSTopNav';
 export type {XDSTopNavProps} from './XDSTopNav';
 
-export {XDSTopNavTitle} from './XDSTopNavTitle';
-export type {XDSTopNavTitleProps} from './XDSTopNavTitle';
+export {XDSTopNavHeading} from './XDSTopNavHeading';
+export type {XDSTopNavHeadingProps} from './XDSTopNavHeading';
+
+/** @deprecated Use XDSTopNavHeading instead */
+export {XDSTopNavHeading as XDSTopNavTitle} from './XDSTopNavHeading';
+/** @deprecated Use XDSTopNavHeadingProps instead */
+export type {XDSTopNavHeadingProps as XDSTopNavTitleProps} from './XDSTopNavHeading';
 
 export {XDSTopNavItem} from './XDSTopNavItem';
 export type {XDSTopNavItemProps} from './XDSTopNavItem';


### PR DESCRIPTION
## What

Renames `title` to `heading` on TopNav and SideNav heading components, and renames the components themselves to match.

### Why

The `title` prop collided with the HTML `title` attribute (string tooltip). TopNav used `Omit<XDSBaseProps, 'title'>` to work around this. Renaming eliminates the collision and makes the naming more accurate — these are headings, not tooltips.

### Prop renames

**XDSTopNav:**
- `title` → `heading` (ReactNode slot prop)
- Removes `Omit<XDSBaseProps, 'title'>` — now extends `XDSBaseProps` directly

**XDSTopNavTitle → XDSTopNavHeading:**
- `title` → `heading` (string)
- File, component, interface, displayName all renamed
- `xds-top-nav-title` → `xds-top-nav-heading` (stable class name)

**XDSSideNavHeader → XDSSideNavHeading:**
- `title` → `heading`
- `titleHref` → `headingHref`
- `supertitle` → `superheading`
- `supertitleHref` → `superheadingHref`
- `subtitle` → `subheading`
- `subtitleHref` → `subheadingHref`
- File, component, interface, displayName all renamed
- `xds-side-nav-header` → `xds-side-nav-heading` (stable class name)

### Backward compatibility

Old component names are preserved as deprecated re-exports:
- `XDSTopNavTitle` → deprecated alias for `XDSTopNavHeading`
- `XDSTopNavTitleProps` → deprecated alias for `XDSTopNavHeadingProps`
- `XDSSideNavHeader` → deprecated alias for `XDSSideNavHeading`
- `XDSSideNavHeaderProps` → deprecated alias for `XDSSideNavHeadingProps`

### Files changed (25)

**Core components:**
- `packages/core/src/TopNav/XDSTopNav.tsx` — prop rename, remove Omit workaround
- `packages/core/src/TopNav/XDSTopNavTitle.tsx` → `XDSTopNavHeading.tsx` — full rename
- `packages/core/src/TopNav/index.ts` — new exports + deprecated re-exports
- `packages/core/src/SideNav/XDSSideNavHeader.tsx` → `XDSSideNavHeading.tsx` — full rename
- `packages/core/src/SideNav/index.ts` — new exports + deprecated re-exports
- `packages/core/src/SideNav/XDSSideNav.tsx` — JSDoc updates

**Docs:**
- `packages/core/src/TopNav/TopNav.doc.mjs`
- `packages/core/src/SideNav/SideNav.doc.mjs`
- `packages/core/src/AppShell/AppShell.doc.mjs`
- `packages/core/src/AppShell/XDSAppShell.tsx` — JSDoc update
- `packages/core/src/NavIcon/NavIcon.doc.mjs`
- `packages/core/src/NavIcon/XDSNavIcon.tsx` — JSDoc update

**Tests:**
- `packages/core/src/TopNav/XDSTopNav.test.tsx`
- `packages/core/src/SideNav/XDSSideNav.test.tsx`
- `packages/core/src/Layout/__tests__/edgeCompensation.test.tsx`

**Stories:**
- `apps/storybook/stories/TopNav.stories.tsx`
- `apps/storybook/stories/SideNav.stories.tsx`
- `apps/storybook/stories/AppShell.stories.tsx`
- `apps/storybook/stories/MobileNav.stories.tsx`
- `apps/storybook/stories/TopNavMenu.stories.tsx`

**Sandbox pages:**
- `apps/sandbox/src/app/pages/mega-menu/page.tsx`
- `apps/sandbox/src/app/pages/navigation/page.tsx`
- `apps/sandbox/src/app/pages/polymorphic-link/page.tsx`
- `apps/sandbox/src/app/pages/topnav-menu/page.tsx`

**Internal:**
- `internal/vibe-tests/src/universal-eval.ts`

### Verification

- ✅ `yarn build` — passes
- ✅ `yarn test` — 1358 tests pass
- ✅ `yarn lint` — no errors (only pre-existing warnings)

---
