### PR TITLE
refactor(icons): migrate components from useXDSIcon to getIcon

### DIFF
--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSCollapsible.tsx
- * @input Uses React, StyleX, useXDSCollapsible hook, useXDSIcon, theme tokens
+ * @input Uses React, StyleX, useXDSCollapsible hook, getIcon, theme tokens
  * @output Exports XDSCollapsible component and XDSCollapsibleProps
  * @position Collapsible content primitive — trigger toggles visibility of children
  *
@@ -27,7 +27,7 @@ import {
   spacingVars,
 } from '../theme/tokens.stylex';
 import {useXDSCollapsible} from './useXDSCollapsible';
-import {useXDSIcon} from '../Icon/IconRegistry';
+import {getIcon} from '../Icon/globalIconRegistry';
 import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
@@ -172,7 +172,7 @@ export const XDSCollapsible = forwardRef<HTMLDivElement, XDSCollapsibleProps>(
       value,
     });
 
-    const chevronIcon = useXDSIcon('chevronDown');
+    const chevronIcon = getIcon('chevronDown');
 
     return (
       <div ref={ref} className={xdsClassName('collapsible')} {...props}>

--- a/packages/core/src/Icon/IconRegistry.tsx
+++ b/packages/core/src/Icon/IconRegistry.tsx
@@ -1,11 +1,11 @@
 /**
  * @file IconRegistry.tsx
  * @input Uses React createContext, useContext
- * @output Exports IconRegistryContext, useXDSIcon hook
- * @position Client-side icon context; wraps the global registry with
- *   React Context support for tree-scoped overrides via XDSTheme.
+ * @output Exports IconRegistryContext, useXDSIcon hook (both deprecated)
+ * @position Legacy client-side icon context. Kept for backward compatibility.
  *
- * For server components, use getIcon() from globalIconRegistry.tsx instead.
+ * @deprecated All icon resolution now uses getIcon() from globalIconRegistry.tsx.
+ * Components should import { getIcon } from './globalIconRegistry' instead.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Icon/globalIconRegistry.tsx (global registry, types)
@@ -31,6 +31,9 @@ export type {XDSIconName, XDSIconRegistry} from './globalIconRegistry';
  * Context for providing theme icons to components.
  * Accepts a full or partial registry. When null, components fall back
  * to the global registry, then to built-in lightweight SVGs.
+ *
+ * @deprecated Icons are now global via registerIcons(). Context is no longer needed.
+ * Use registerIcons() from globalIconRegistry to set icons, and getIcon() to retrieve them.
  */
 export const IconRegistryContext =
   createContext<Partial<XDSIconRegistry> | null>(null);
@@ -47,11 +50,17 @@ export const IconRegistryContext =
  * 2. Global registry (via registerIcons())
  * 3. Built-in lightweight SVG fallback
  *
- * For server components, use getIcon() from iconRegistry.ts instead.
+ * @deprecated Use getIcon() from globalIconRegistry instead for RSC compatibility.
+ * getIcon() works in both server and client environments without React Context.
  *
  * @example
  * ```
+ * // Before (deprecated):
  * const closeIcon = useXDSIcon('close');
+ *
+ * // After (preferred):
+ * import { getIcon } from '@xds/core';
+ * const closeIcon = getIcon('close');
  * ```
  */
 export function useXDSIcon(name: XDSIconName): ReactNode {

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -22,7 +22,8 @@
 import {forwardRef, type ComponentType, type SVGProps} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
-import {useXDSIcon, type XDSIconName} from './IconRegistry';
+import {getIcon} from './globalIconRegistry';
+import type {XDSIconName} from './globalIconRegistry';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -210,7 +211,7 @@ XDSIcon.displayName = 'XDSIcon';
  * Internal component that resolves a semantic icon name from the registry
  * and renders it in a styled span with proper sizing.
  *
- * Extracted as a separate component so the useXDSIcon hook is only called
+ * Extracted as a separate component so getIcon is only called
  * when the icon prop is a string.
  */
 function IconFromRegistry({
@@ -222,7 +223,7 @@ function IconFromRegistry({
   color: XDSIconColor;
   size: XDSIconSize;
 }) {
-  const resolvedIcon = useXDSIcon(name);
+  const resolvedIcon = getIcon(name);
 
   if (resolvedIcon == null) {
     return null;

--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -5,9 +5,7 @@
  * @position Global icon registry; works in both server and client environments
  *
  * This module has NO 'use client' directive — it's importable from RSC.
- * Components that need icons in server components use getIcon() directly.
- * Client components use useXDSIcon() from IconRegistryContext.tsx which
- * checks context first, then falls back to this global registry.
+ * All components use getIcon() to resolve icons from this global registry.
  */
 
 import type {ReactNode} from 'react';
@@ -74,17 +72,17 @@ export function registerIcons(icons: Partial<XDSIconRegistry>): void {
 /**
  * Get an icon by name from the global registry, falling back to defaults.
  *
- * Use this in server components where hooks aren't available.
- * In client components, prefer useXDSIcon() which also checks
- * the React Context registry.
+ * Works in both server and client environments.
+ * Falls back to built-in default icons when no override is registered.
  */
 export function getIcon(name: XDSIconName): ReactNode {
   return globalRegistry[name] ?? defaultIcons[name];
 }
 
 /**
- * Get the raw global registry (internal use by useXDSIcon).
+ * Get the raw global registry (internal use).
  * @internal
+ * @deprecated Internal use only — will be removed when useXDSIcon is removed.
  */
 export function getGlobalRegistry(): Partial<XDSIconRegistry> {
   return globalRegistry;

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -19,5 +19,6 @@ export type {
 export {registerIcons, getIcon, resetIcons} from './globalIconRegistry';
 export type {XDSIconName, XDSIconRegistry} from './globalIconRegistry';
 
-// Context registry (client-only)
+// Context registry (client-only, deprecated)
+/** @deprecated Use registerIcons() and getIcon() from globalIconRegistry instead. */
 export {IconRegistryContext, useXDSIcon} from './IconRegistry';

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSMoreMenu.tsx
- * @input Uses React, StyleX, useXDSLayer, XDSButton, useXDSIcon, XDSDropdownMenuItem, XDSDivider
+ * @input Uses React, StyleX, useXDSLayer, XDSButton, getIcon, XDSDropdownMenuItem, XDSDivider
  * @output Exports XDSMoreMenu component and XDSMoreMenuProps type
  * @position Core implementation; consumed by index.ts
  *
@@ -28,7 +28,7 @@ import {
 import * as stylex from '@stylexjs/stylex';
 import {useXDSLayer} from '../Layer/useXDSLayer';
 import {XDSButton, type XDSButtonVariant, type XDSButtonSize} from '../Button';
-import {useXDSIcon} from '../Icon/IconRegistry';
+import {getIcon} from '../Icon/globalIconRegistry';
 import {XDSDropdownMenuItem} from '../DropdownMenu/XDSDropdownMenuItem';
 import {XDSDivider} from '../Divider';
 import type {
@@ -247,7 +247,7 @@ export const XDSMoreMenu = forwardRef<HTMLButtonElement, XDSMoreMenuProps>(
     },
     ref,
   ) => {
-    const moreIcon = useXDSIcon('moreHorizontal');
+    const moreIcon = getIcon('moreHorizontal');
     const buttonRef = useRef<HTMLButtonElement | null>(null);
     const menuId = useId();
     const [highlightedIndex, setHighlightedIndex] = useState(-1);

--- a/packages/core/src/theme/XDSTheme.tsx
+++ b/packages/core/src/theme/XDSTheme.tsx
@@ -29,7 +29,6 @@ import React, {useId, useInsertionEffect} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {ThemeMode} from './types';
 import {colorVars, typographyVars} from './tokens.stylex';
-import {IconRegistryContext} from '../Icon/IconRegistry';
 import {registerIcons} from '../Icon/globalIconRegistry';
 import {generateThemeCSS, type XDSDefinedTheme} from './defineTheme';
 
@@ -135,16 +134,10 @@ export function XDSTheme({
         ? wrapperStyles.light
         : wrapperStyles.system;
 
-  // Icons — register globally (for server components) AND via context (for tree-scoped overrides)
+  // Icons — register globally (works in both server and client environments)
   const icons = theme.icons;
-  let content: React.ReactNode = children;
   if (icons != null) {
     registerIcons(icons);
-    content = (
-      <IconRegistryContext.Provider value={icons}>
-        {content}
-      </IconRegistryContext.Provider>
-    );
   }
 
   return (
@@ -152,7 +145,7 @@ export function XDSTheme({
       {...stylex.props(wrapperStyles.base, colorSchemeStyle)}
       data-xds-theme={theme.name}
       data-theme={mode === 'system' ? undefined : mode}>
-      {content}
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
## What

Migrates all internal component icon resolution from `useXDSIcon()` (React Context hook) to `getIcon()` (module-level function from the global registry). This establishes a single path for icon resolution that works in both server and client environments.

Follows up on #528 which added `registerIcons()` and `getIcon()`.

## Why

`useXDSIcon()` requires React Context (`IconRegistryContext`) which only works client-side. With RSC adoption, components need icons without hooks. `getIcon()` reads from module-level state — no Context, no hooks, works everywhere.

## Changes

### Components migrated (3 files)
- **`XDSIcon.tsx`** — `IconFromRegistry` now calls `getIcon(name)` instead of `useXDSIcon(name)`
- **`XDSCollapsible.tsx`** — chevron icon via `getIcon('chevronDown')`
- **`XDSMoreMenu.tsx`** — more icon via `getIcon('moreHorizontal')`

### Theme updated (1 file)
- **`XDSTheme.tsx`** — Removed `IconRegistryContext.Provider` wrapper. Icons are now set globally via `registerIcons(icons)` only. No Context needed.

### Deprecated (1 file)
- **`IconRegistry.tsx`** — `useXDSIcon` and `IconRegistryContext` marked `@deprecated` with JSDoc. Kept exported for backward compatibility.

### Exports updated (1 file)
- **`Icon/index.ts`** — deprecated exports annotated with JSDoc comment

### Docs updated (1 file)
- **`globalIconRegistry.tsx`** — updated comments to reflect it's now the single icon resolution path

## Verification

- ✅ `yarn build` — passes
- ✅ `yarn test` — 1390 tests pass
- ✅ `yarn lint` — 0 errors (pre-existing warnings only)
- ✅ No component imports `useXDSIcon` (only the deprecated export itself)

---
