### PR TITLE
feat: numeric spacing API for gap and padding props

### DIFF
--- a/apps/example-nextjs/src/app/page.tsx
+++ b/apps/example-nextjs/src/app/page.tsx
@@ -26,8 +26,8 @@ export default function Home() {
   return (
     <main {...stylex.props(styles.main)}>
       <div {...stylex.props(styles.container)}>
-        <XDSVStack gap="space6">
-          <XDSVStack gap="space2">
+        <XDSVStack gap={6}>
+          <XDSVStack gap={2}>
             <XDSHeading level={1}>XDS Example — Next.js</XDSHeading>
             <XDSText color="secondary">
               This is a reference example for consuming{' '}
@@ -40,9 +40,9 @@ export default function Home() {
           <XDSDivider />
 
           {/* Buttons */}
-          <XDSVStack gap="space3">
+          <XDSVStack gap={3}>
             <XDSHeading level={2}>Buttons</XDSHeading>
-            <XDSHStack gap="space3" align="center">
+            <XDSHStack gap={3} align="center">
               <XDSButton variant="primary">Primary</XDSButton>
               <XDSButton variant="secondary">Secondary</XDSButton>
               <XDSButton variant="ghost">Ghost</XDSButton>
@@ -52,9 +52,9 @@ export default function Home() {
           <XDSDivider />
 
           {/* Badges */}
-          <XDSVStack gap="space3">
+          <XDSVStack gap={3}>
             <XDSHeading level={2}>Badges</XDSHeading>
-            <XDSHStack gap="space3" align="center">
+            <XDSHStack gap={3} align="center">
               <XDSBadge variant="info">Info</XDSBadge>
               <XDSBadge variant="success">Success</XDSBadge>
               <XDSBadge variant="warning">Warning</XDSBadge>
@@ -65,7 +65,7 @@ export default function Home() {
           <XDSDivider />
 
           {/* Text Input */}
-          <XDSVStack gap="space3">
+          <XDSVStack gap={3}>
             <XDSHeading level={2}>Text Input</XDSHeading>
             <XDSTextInput label="Email address" placeholder="you@example.com" />
           </XDSVStack>
@@ -73,7 +73,7 @@ export default function Home() {
           <XDSDivider />
 
           {/* Typography */}
-          <XDSVStack gap="space3">
+          <XDSVStack gap={3}>
             <XDSHeading level={2}>Typography</XDSHeading>
             <XDSText type="large" weight="bold">
               Large bold text

--- a/apps/example-vite/src/App.tsx
+++ b/apps/example-vite/src/App.tsx
@@ -30,8 +30,8 @@ export default function App() {
     <XDSTheme theme={defaultTheme}>
       <main {...stylex.props(styles.main)}>
         <div {...stylex.props(styles.container)}>
-          <XDSVStack gap="space6">
-            <XDSVStack gap="space2">
+          <XDSVStack gap={6}>
+            <XDSVStack gap={2}>
               <XDSHeading level={1}>XDS Example — Vite</XDSHeading>
               <XDSText type="body" color="secondary">
                 This is a reference example for consuming{' '}
@@ -50,9 +50,9 @@ export default function App() {
             <XDSDivider />
 
             {/* Buttons */}
-            <XDSVStack gap="space3">
+            <XDSVStack gap={3}>
               <XDSHeading level={2}>Buttons</XDSHeading>
-              <XDSHStack gap="space3" vAlign="center">
+              <XDSHStack gap={3} vAlign="center">
                 <XDSButton label="Primary" variant="primary" />
                 <XDSButton label="Secondary" variant="secondary" />
                 <XDSButton label="Ghost" variant="ghost" />
@@ -62,9 +62,9 @@ export default function App() {
             <XDSDivider />
 
             {/* Badges */}
-            <XDSVStack gap="space3">
+            <XDSVStack gap={3}>
               <XDSHeading level={2}>Badges</XDSHeading>
-              <XDSHStack gap="space3" vAlign="center">
+              <XDSHStack gap={3} vAlign="center">
                 <XDSBadge variant="info">Info</XDSBadge>
                 <XDSBadge variant="success">Success</XDSBadge>
                 <XDSBadge variant="warning">Warning</XDSBadge>
@@ -75,7 +75,7 @@ export default function App() {
             <XDSDivider />
 
             {/* Text Input */}
-            <XDSVStack gap="space3">
+            <XDSVStack gap={3}>
               <XDSHeading level={2}>Text Input</XDSHeading>
               <XDSTextInput
                 label="Email address"
@@ -88,7 +88,7 @@ export default function App() {
             <XDSDivider />
 
             {/* Typography */}
-            <XDSVStack gap="space3">
+            <XDSVStack gap={3}>
               <XDSHeading level={2}>Typography</XDSHeading>
               <XDSText type="large" weight="bold">
                 Large bold text

--- a/apps/sandbox/README.md
+++ b/apps/sandbox/README.md
@@ -39,7 +39,7 @@ import {XDSVStack, XDSHeading, XDSText} from '@xds/core';
 
 export default function MyPage() {
   return (
-    <XDSVStack gap="space4">
+    <XDSVStack gap={4}>
       <XDSHeading level={1}>My Page</XDSHeading>
       <XDSText type="body">Content here</XDSText>
     </XDSVStack>

--- a/apps/sandbox/src/app/page.tsx
+++ b/apps/sandbox/src/app/page.tsx
@@ -13,8 +13,8 @@ const styles = stylex.create({
 export default function Home() {
   return (
     <div {...stylex.props(styles.container)}>
-      <XDSVStack gap="space6">
-        <XDSVStack gap="space2">
+      <XDSVStack gap={6}>
+        <XDSVStack gap={2}>
           <XDSHeading level={1}>XDS Sandbox</XDSHeading>
           <XDSText type="body" color="secondary">
             A testing ground for XDS components. Use the sidebar to explore

--- a/apps/sandbox/src/app/pages/example/page.tsx
+++ b/apps/sandbox/src/app/pages/example/page.tsx
@@ -31,8 +31,8 @@ export default function ExamplePage() {
 
   return (
     <div {...stylex.props(styles.container)}>
-      <XDSVStack gap="space6">
-        <XDSVStack gap="space2">
+      <XDSVStack gap={6}>
+        <XDSVStack gap={2}>
           <XDSHeading level={1}>Example Page</XDSHeading>
           <XDSText type="body" color="secondary">
             A scaffold showing common XDS components. Copy this file to create
@@ -43,14 +43,14 @@ export default function ExamplePage() {
         <XDSDivider />
 
         {/* Buttons */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Buttons</XDSHeading>
-          <XDSHStack gap="space3" vAlign="center">
+          <XDSHStack gap={3} vAlign="center">
             <XDSButton label="Primary" variant="primary" />
             <XDSButton label="Secondary" variant="secondary" />
             <XDSButton label="Ghost" variant="ghost" />
           </XDSHStack>
-          <XDSHStack gap="space3" vAlign="center">
+          <XDSHStack gap={3} vAlign="center">
             <XDSButton label="Small" size="sm" />
             <XDSButton label="Medium" size="md" />
             <XDSButton label="Large" size="lg" />
@@ -60,9 +60,9 @@ export default function ExamplePage() {
         <XDSDivider />
 
         {/* Badges */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Badges</XDSHeading>
-          <XDSHStack gap="space3" vAlign="center">
+          <XDSHStack gap={3} vAlign="center">
             <XDSBadge variant="info">Info</XDSBadge>
             <XDSBadge variant="success">Success</XDSBadge>
             <XDSBadge variant="warning">Warning</XDSBadge>
@@ -73,7 +73,7 @@ export default function ExamplePage() {
         <XDSDivider />
 
         {/* Typography */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Typography</XDSHeading>
           <XDSHeading level={3}>Heading 3</XDSHeading>
           <XDSText type="large" weight="bold">
@@ -88,7 +88,7 @@ export default function ExamplePage() {
         <XDSDivider />
 
         {/* Form Controls */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Form Controls</XDSHeading>
           <XDSTextInput
             label="Name"

--- a/apps/sandbox/src/app/pages/mega-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/mega-menu/page.tsx
@@ -235,8 +235,8 @@ export default function MegaMenuPage() {
 
   return (
     <div {...stylex.props(styles.container)}>
-      <XDSVStack gap="space6">
-        <XDSVStack gap="space2">
+      <XDSVStack gap={6}>
+        <XDSVStack gap={2}>
           <XDSHeading level={1}>Mega Menu</XDSHeading>
           <XDSText type="body" color="secondary">
             A top nav variation with a full-width mega menu that appears on
@@ -246,7 +246,7 @@ export default function MegaMenuPage() {
         </XDSVStack>
 
         {/* Full mega menu with featured content */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>With Featured Content</XDSHeading>
           <div
             {...stylex.props(
@@ -305,7 +305,7 @@ export default function MegaMenuPage() {
         </XDSVStack>
 
         {/* Without featured content */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Without Featured Content</XDSHeading>
           <div
             {...stylex.props(

--- a/apps/sandbox/src/app/pages/navigation/page.tsx
+++ b/apps/sandbox/src/app/pages/navigation/page.tsx
@@ -32,8 +32,8 @@ export default function NavigationPage() {
 
   return (
     <div {...stylex.props(styles.container)}>
-      <XDSVStack gap="space6">
-        <XDSVStack gap="space2">
+      <XDSVStack gap={6}>
+        <XDSVStack gap={2}>
           <XDSHeading level={1}>Navigation Alignment</XDSHeading>
           <XDSText type="body" color="secondary">
             Explore how nav items can be positioned left, center, or right using
@@ -42,7 +42,7 @@ export default function NavigationPage() {
         </XDSVStack>
 
         {/* Alignment picker */}
-        <XDSHStack gap="space3" vAlign="center">
+        <XDSHStack gap={3} vAlign="center">
           <XDSText type="body" weight="bold">
             Alignment:
           </XDSText>
@@ -69,7 +69,7 @@ export default function NavigationPage() {
         <XDSDivider />
 
         {/* Live preview */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Preview</XDSHeading>
           <div {...stylex.props(styles.navWrapper)}>
             <NavPreview alignment={alignment} />
@@ -79,10 +79,10 @@ export default function NavigationPage() {
         <XDSDivider />
 
         {/* All three side by side */}
-        <XDSVStack gap="space4">
+        <XDSVStack gap={4}>
           <XDSHeading level={2}>All Alignments</XDSHeading>
 
-          <XDSVStack gap="space2">
+          <XDSVStack gap={2}>
             <XDSText type="supporting" weight="bold">
               Left-aligned (startContent)
             </XDSText>
@@ -91,7 +91,7 @@ export default function NavigationPage() {
             </div>
           </XDSVStack>
 
-          <XDSVStack gap="space2">
+          <XDSVStack gap={2}>
             <XDSText type="supporting" weight="bold">
               Center-aligned (centerContent)
             </XDSText>
@@ -100,7 +100,7 @@ export default function NavigationPage() {
             </div>
           </XDSVStack>
 
-          <XDSVStack gap="space2">
+          <XDSVStack gap={2}>
             <XDSText type="supporting" weight="bold">
               Right-aligned (endContent)
             </XDSText>

--- a/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
+++ b/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
@@ -111,8 +111,8 @@ export default function PolymorphicLinkPage() {
 
   return (
     <div {...stylex.props(styles.container)}>
-      <XDSVStack gap="space6">
-        <XDSVStack gap="space2">
+      <XDSVStack gap={6}>
+        <XDSVStack gap={2}>
           <XDSHeading level={1}>Polymorphic Link</XDSHeading>
           <XDSText type="body" color="secondary">
             XDS components that render links can use a custom link component
@@ -130,7 +130,7 @@ export default function PolymorphicLinkPage() {
         {/* ================================================================= */}
         {/* Section 1: Provider Demo */}
         {/* ================================================================= */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Provider Demo</XDSHeading>
           <XDSText type="body" color="secondary">
             All components below are wrapped in{' '}
@@ -142,9 +142,9 @@ export default function PolymorphicLinkPage() {
           </XDSText>
 
           <XDSLinkProvider component={SimulatedNextLink}>
-            <XDSVStack gap="space4">
+            <XDSVStack gap={4}>
               {/* TopNav */}
-              <XDSVStack gap="space1">
+              <XDSVStack gap={1}>
                 <XDSText type="supporting" weight="bold">
                   XDSTopNav
                 </XDSText>
@@ -164,7 +164,7 @@ export default function PolymorphicLinkPage() {
               </XDSVStack>
 
               {/* Breadcrumbs */}
-              <XDSVStack gap="space1">
+              <XDSVStack gap={1}>
                 <XDSText type="supporting" weight="bold">
                   XDSBreadcrumbs
                 </XDSText>
@@ -178,7 +178,7 @@ export default function PolymorphicLinkPage() {
               </XDSVStack>
 
               {/* TabList */}
-              <XDSVStack gap="space1">
+              <XDSVStack gap={1}>
                 <XDSText type="supporting" weight="bold">
                   XDSTabList (with href)
                 </XDSText>
@@ -190,7 +190,7 @@ export default function PolymorphicLinkPage() {
               </XDSVStack>
 
               {/* SideNav */}
-              <XDSVStack gap="space1">
+              <XDSVStack gap={1}>
                 <XDSText type="supporting" weight="bold">
                   XDSSideNav
                 </XDSText>
@@ -208,7 +208,7 @@ export default function PolymorphicLinkPage() {
               </XDSVStack>
 
               {/* XDSLink */}
-              <XDSVStack gap="space1">
+              <XDSVStack gap={1}>
                 <XDSText type="supporting" weight="bold">
                   XDSLink
                 </XDSText>
@@ -225,7 +225,7 @@ export default function PolymorphicLinkPage() {
         {/* ================================================================= */}
         {/* Section 2: Per-component `as` override */}
         {/* ================================================================= */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Per-Component Override</XDSHeading>
           <XDSText type="body" color="secondary">
             The{' '}
@@ -267,7 +267,7 @@ export default function PolymorphicLinkPage() {
         {/* ================================================================= */}
         {/* Section 3: Default behavior (no provider) */}
         {/* ================================================================= */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Default Behavior</XDSHeading>
           <XDSText type="body" color="secondary">
             Without a provider or{' '}

--- a/apps/sandbox/src/app/pages/table-overview/page.tsx
+++ b/apps/sandbox/src/app/pages/table-overview/page.tsx
@@ -232,14 +232,14 @@ const columns: XDSTableColumn<ReviewRow>[] = [
     header: 'Author',
     width: proportional(4),
     renderCell: (item: ReviewRow) => (
-      <XDSHStack gap="space3" vAlign="center">
+      <XDSHStack gap={3} vAlign="center">
         <XDSAvatar
           src={item.authorAvatar}
           name={item.authorName}
           size="small"
         />
         <div {...stylex.props(styles.authorInfo)}>
-          <XDSVStack gap="space1">
+          <XDSVStack gap={1}>
             <span {...stylex.props(styles.titleLink)}>{item.title}</span>
             <span {...stylex.props(styles.supportingLine)}>
               <XDSText type="supporting" color="secondary">
@@ -276,7 +276,7 @@ const columns: XDSTableColumn<ReviewRow>[] = [
     header: 'Testing',
     width: pixel(110),
     renderCell: (item: ReviewRow) => (
-      <XDSHStack gap="space2" vAlign="center">
+      <XDSHStack gap={2} vAlign="center">
         <XDSStatusDot
           variant={item.testStatus === 'passed' ? 'positive' : 'negative'}
           label={item.testStatus === 'passed' ? 'Passed' : 'Failed'}
@@ -451,8 +451,8 @@ export default function TableOverviewPage() {
 
   return (
     <div {...stylex.props(styles.container)}>
-      <XDSVStack gap="space6">
-        <XDSVStack gap="space2">
+      <XDSVStack gap={6}>
+        <XDSVStack gap={2}>
           <XDSHeading level={1}>Table Overview</XDSHeading>
           <XDSText type="body" color="secondary">
             A code review dashboard demonstrating XDSTable with selection,
@@ -479,7 +479,7 @@ export default function TableOverviewPage() {
         </div>
 
         {/* Grouped Tables */}
-        <XDSVStack gap="space4">
+        <XDSVStack gap={4}>
           {filteredWaiting.length > 0 && (
             <XDSCollapsible
               trigger={

--- a/apps/sandbox/src/app/pages/topnav-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/topnav-menu/page.tsx
@@ -99,8 +99,8 @@ const scienceItems = [
 export default function TopNavMenuPage() {
   return (
     <div {...stylex.props(styles.container)}>
-      <XDSVStack gap="space6">
-        <XDSVStack gap="space2">
+      <XDSVStack gap={6}>
+        <XDSVStack gap={2}>
           <XDSHeading level={1}>TopNav Menu</XDSHeading>
           <XDSText type="body" color="secondary">
             A nav item with a hover-triggered overflow menu. Hover over
@@ -109,7 +109,7 @@ export default function TopNavMenuPage() {
         </XDSVStack>
 
         {/* Marketing-style nav with overflow menus */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Marketing Nav</XDSHeading>
           <div {...stylex.props(styles.navWrapper)}>
             <XDSTopNav
@@ -139,7 +139,7 @@ export default function TopNavMenuPage() {
         </XDSVStack>
 
         {/* Simple nav with one overflow menu */}
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={2}>Simple Nav</XDSHeading>
           <div {...stylex.props(styles.navWrapper)}>
             <XDSTopNav

--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -198,7 +198,7 @@ export const ResponsiveGrid: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Responsive grid of aspect ratio boxes
       </XDSText>
-      <XDSGrid minChildWidth={200} gap="space4">
+      <XDSGrid minChildWidth={200} gap={4}>
         {[
           {ratio: 16 / 9, label: '16:9'},
           {ratio: 4 / 3, label: '4:3'},
@@ -283,7 +283,7 @@ export const ImageGallery: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Image gallery with consistent aspect ratios
       </XDSText>
-      <XDSGrid columns={3} gap="space4">
+      <XDSGrid columns={3} gap={4}>
         {Array.from({length: 6}, (_, i) => (
           <XDSAspectRatio key={i} ratio={4 / 3}>
             <img

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -99,7 +99,7 @@ export const Default: Story = {
 export const WithSimpleContent: Story = {
   render: () => (
     <XDSCard width={320}>
-      <XDSVStack gap="space2">
+      <XDSVStack gap={2}>
         <h3 {...stylex.props(styles.text)}>Card Title</h3>
         <p {...stylex.props(styles.text, styles.textSecondary)}>
           This card contains simple content without XDSLayout. The container
@@ -129,7 +129,7 @@ export const WithInnerLayout: Story = {
         }
         footer={
           <XDSLayoutFooter hasDivider>
-            <XDSHStack gap="space2" hAlign="end">
+            <XDSHStack gap={2} hAlign="end">
               <XDSButton label="Cancel" variant="secondary">
                 Cancel
               </XDSButton>
@@ -193,7 +193,7 @@ export const FixedHeight: Story = {
 export const NestedCards: Story = {
   render: () => (
     <XDSCard width={400}>
-      <XDSVStack gap="space3">
+      <XDSVStack gap={3}>
         <h3 {...stylex.props(styles.text)}>Parent Card</h3>
         <XDSCard width="100%">
           <p {...stylex.props(styles.text, styles.textSecondary)}>
@@ -214,7 +214,7 @@ export const NestedSections: Story = {
   render: () => (
     <XDSCard width={400}>
       <XDSSection variant="transparent" dividers={['bottom']}>
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <h3 {...stylex.props(styles.text)}>First Section</h3>
           <p {...stylex.props(styles.text, styles.textSecondary)}>
             This section escapes the card padding on top and sides because it's
@@ -223,7 +223,7 @@ export const NestedSections: Story = {
         </XDSVStack>
       </XDSSection>
       <XDSSection variant="transparent" dividers={['bottom']}>
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <h3 {...stylex.props(styles.text)}>Middle Section</h3>
           <p {...stylex.props(styles.text, styles.textSecondary)}>
             Middle sections only escape horizontal padding, maintaining visual
@@ -232,7 +232,7 @@ export const NestedSections: Story = {
         </XDSVStack>
       </XDSSection>
       <XDSSection variant="transparent">
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <h3 {...stylex.props(styles.text)}>Last Section</h3>
           <p {...stylex.props(styles.text, styles.textSecondary)}>
             This section escapes the card padding on bottom and sides because
@@ -248,7 +248,7 @@ export const SingleSection: Story = {
   render: () => (
     <XDSCard width={350}>
       <XDSSection variant="wash">
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <h3 {...stylex.props(styles.text)}>
             Only Section (Full Bleed All Sides)
           </h3>
@@ -268,7 +268,7 @@ export const MixedContent: Story = {
       <div>
         <h4 {...stylex.props(styles.heading)}>Simple Content</h4>
         <XDSCard width={250}>
-          <XDSVStack gap="space2">
+          <XDSVStack gap={2}>
             <h3 {...stylex.props(styles.text)}>Card Title</h3>
             <p {...stylex.props(styles.text, styles.textSecondary)}>
               Regular content uses the card's container padding.
@@ -280,7 +280,7 @@ export const MixedContent: Story = {
         <h4 {...stylex.props(styles.heading)}>With Section</h4>
         <XDSCard width={250}>
           <XDSSection variant="wash">
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <h3 {...stylex.props(styles.text)}>Card Title</h3>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
                 Section content bleeds to the card edges.
@@ -334,7 +334,7 @@ export const OnBackgrounds: Story = {
         <h4 {...stylex.props(styles.heading)}>Cards on wash background</h4>
         <div {...stylex.props(styles.storyWrapper)}>
           <XDSCard width={250}>
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <h3 {...stylex.props(styles.text)}>Card on Wash</h3>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
                 Cards stand out clearly against the wash background, creating a
@@ -343,7 +343,7 @@ export const OnBackgrounds: Story = {
             </XDSVStack>
           </XDSCard>
           <XDSCard width={250}>
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <h3 {...stylex.props(styles.text)}>Another Card</h3>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
                 Multiple cards on wash create a dashboard-like layout.
@@ -356,7 +356,7 @@ export const OnBackgrounds: Story = {
         <h4 {...stylex.props(styles.heading)}>Cards on surface section</h4>
         <div {...stylex.props(styles.storyWrapper)}>
           <XDSCard width={250}>
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <h3 {...stylex.props(styles.text)}>Card on Surface</h3>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
                 On a surface background, cards are more subtle since both share
@@ -365,7 +365,7 @@ export const OnBackgrounds: Story = {
             </XDSVStack>
           </XDSCard>
           <XDSCard width={250}>
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <h3 {...stylex.props(styles.text)}>Another Card</h3>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
                 The card border and shadow provide separation from the surface.

--- a/apps/storybook/stories/Collapsible.stories.tsx
+++ b/apps/storybook/stories/Collapsible.stories.tsx
@@ -48,7 +48,7 @@ export const SingleMode: Story = {
   name: 'Single Mode (default)',
   render: () => (
     <XDSCollapsibleGroup type="single" defaultValue="general">
-      <XDSVStack gap="space2">
+      <XDSVStack gap={2}>
         <XDSCard>
           <XDSCollapsible trigger="General Settings" value="general">
             <p {...stylex.props(styles.text)}>
@@ -81,7 +81,7 @@ export const MultipleMode: Story = {
   name: 'Multiple Mode',
   render: () => (
     <XDSCollapsibleGroup type="multiple" defaultValue={['faq1', 'faq3']}>
-      <XDSVStack gap="space2">
+      <XDSVStack gap={2}>
         <XDSCard>
           <XDSCollapsible trigger="What is XDS?" value="faq1">
             <p {...stylex.props(styles.text)}>
@@ -118,7 +118,7 @@ export const Controlled: Story = {
           Currently open: <strong>{String(open) || '(none)'}</strong>
         </p>
         <XDSCollapsibleGroup type="single" value={open} onChange={setOpen}>
-          <XDSVStack gap="space2">
+          <XDSVStack gap={2}>
             <XDSCard>
               <XDSCollapsible trigger="Section 1" value="section1">
                 <p {...stylex.props(styles.text)}>Content for section 1.</p>
@@ -144,7 +144,7 @@ export const Controlled: Story = {
 export const StandaloneCollapsible: Story = {
   name: 'Standalone Collapsible',
   render: () => (
-    <XDSVStack gap="space2">
+    <XDSVStack gap={2}>
       <XDSCard>
         <XDSCollapsible trigger="Starts open (default)">
           <p {...stylex.props(styles.text)}>
@@ -166,7 +166,7 @@ export const StandaloneCollapsible: Story = {
 export const WithoutCard: Story = {
   name: 'Without Card (standalone)',
   render: () => (
-    <XDSVStack gap="space2">
+    <XDSVStack gap={2}>
       <XDSCollapsible trigger="Show more details">
         <p {...stylex.props(styles.text)}>
           XDSCollapsible works anywhere — it doesn't require a card wrapper.
@@ -183,7 +183,7 @@ export const FAQ: Story = {
   name: 'FAQ Page',
   render: () => (
     <XDSCollapsibleGroup type="single">
-      <XDSVStack gap="space2">
+      <XDSVStack gap={2}>
         <XDSCard>
           <XDSCollapsible trigger="How do I reset my password?" value="q1">
             <p {...stylex.props(styles.text)}>

--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -82,7 +82,7 @@ function BasicModalExample() {
           }
           footer={
             <XDSLayoutFooter hasDivider>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton
                   label="Cancel"
                   variant="secondary"
@@ -138,7 +138,7 @@ function SubtitleModalExample() {
           }
           footer={
             <XDSLayoutFooter hasDivider>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton
                   label="Cancel"
                   variant="secondary"
@@ -362,7 +362,7 @@ function FormModalExample() {
           }
           footer={
             <XDSLayoutFooter hasDivider>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton
                   label="Cancel"
                   variant="secondary"
@@ -537,7 +537,7 @@ function ScrollingModalExample() {
           }
           footer={
             <XDSLayoutFooter hasDivider>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton
                   label="Decline"
                   variant="secondary"
@@ -607,7 +607,7 @@ function ConfirmationModalExample() {
           }
           footer={
             <XDSLayoutFooter hasDivider>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton
                   label="Cancel"
                   variant="secondary"

--- a/apps/storybook/stories/Divider.stories.tsx
+++ b/apps/storybook/stories/Divider.stories.tsx
@@ -52,7 +52,7 @@ export const Default: Story = {
   render: args => (
     <XDSSection variant="wash">
       <XDSCard>
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSText type="body">Content above</XDSText>
           <XDSDivider {...args} />
           <XDSText type="body">Content below</XDSText>
@@ -69,7 +69,7 @@ export const WithLabel: Story = {
   render: args => (
     <XDSSection variant="wash">
       <XDSCard>
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSText type="body">Content above</XDSText>
           <XDSDivider {...args} />
           <XDSText type="body">Content below</XDSText>
@@ -84,13 +84,13 @@ export const Variants: Story = {
     <XDSSection variant="wash">
       <div {...stylex.props(styles.storyWrapper)}>
         <XDSCard>
-          <XDSVStack gap="space3">
+          <XDSVStack gap={3}>
             <XDSText type="supporting">Subtle (default)</XDSText>
             <XDSDivider variant="subtle" />
           </XDSVStack>
         </XDSCard>
         <XDSCard>
-          <XDSVStack gap="space3">
+          <XDSVStack gap={3}>
             <XDSText type="supporting">Strong</XDSText>
             <XDSDivider variant="strong" />
           </XDSVStack>
@@ -105,7 +105,7 @@ export const FullBleed: Story = {
     <XDSSection variant="wash">
       <div {...stylex.props(styles.storyWrapper)}>
         <XDSCard>
-          <XDSVStack gap="space3">
+          <XDSVStack gap={3}>
             <XDSText type="label">Normal divider</XDSText>
             <XDSText type="body">
               The divider respects container padding.
@@ -115,7 +115,7 @@ export const FullBleed: Story = {
           </XDSVStack>
         </XDSCard>
         <XDSCard>
-          <XDSVStack gap="space3">
+          <XDSVStack gap={3}>
             <XDSText type="label">Full bleed divider</XDSText>
             <XDSText type="body">
               The divider extends to container edges.
@@ -136,7 +136,7 @@ export const Vertical: Story = {
   render: args => (
     <XDSSection variant="wash">
       <XDSCard height={200}>
-        <XDSHStack gap="space4" xstyle={styles.fullHeight}>
+        <XDSHStack gap={4} xstyle={styles.fullHeight}>
           <XDSText type="body">Left content</XDSText>
           <XDSDivider {...args} />
           <XDSText type="body">Right content</XDSText>
@@ -154,7 +154,7 @@ export const VerticalWithLabel: Story = {
   render: args => (
     <XDSSection variant="wash">
       <XDSCard height={200}>
-        <XDSHStack gap="space4" xstyle={styles.fullHeight}>
+        <XDSHStack gap={4} xstyle={styles.fullHeight}>
           <XDSText type="body">Option A</XDSText>
           <XDSDivider {...args} />
           <XDSText type="body">Option B</XDSText>
@@ -168,7 +168,7 @@ export const InCard: Story = {
   render: () => (
     <XDSSection variant="wash">
       <XDSCard>
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSText type="label">Card Title</XDSText>
           <XDSDivider />
           <XDSText type="body">

--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -61,47 +61,17 @@ const meta: Meta<typeof XDSGrid> = {
     },
     gap: {
       control: 'select',
-      options: [
-        'space0',
-        'space0.5',
-        'space1',
-        'space2',
-        'space3',
-        'space4',
-        'space5',
-        'space6',
-        'space7',
-      ],
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description: 'Spacing between all grid items',
     },
     rowGap: {
       control: 'select',
-      options: [
-        'space0',
-        'space0.5',
-        'space1',
-        'space2',
-        'space3',
-        'space4',
-        'space5',
-        'space6',
-        'space7',
-      ],
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description: 'Spacing between rows (overrides gap)',
     },
     columnGap: {
       control: 'select',
-      options: [
-        'space0',
-        'space0.5',
-        'space1',
-        'space2',
-        'space3',
-        'space4',
-        'space5',
-        'space6',
-        'space7',
-      ],
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
       description: 'Spacing between columns (overrides gap)',
     },
     align: {
@@ -135,7 +105,7 @@ const FeaturedItem = ({children}: {children: React.ReactNode}) => (
 export const Default: Story = {
   args: {
     columns: 3,
-    gap: 'space4',
+    gap: 4,
   },
   render: args => (
     <div {...stylex.props(styles.container)}>
@@ -158,7 +128,7 @@ export const FixedColumns: Story = {
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           2 Columns
         </XDSText>
-        <XDSGrid columns={2} gap="space4">
+        <XDSGrid columns={2} gap={4}>
           <GridItem>Item 1</GridItem>
           <GridItem>Item 2</GridItem>
           <GridItem>Item 3</GridItem>
@@ -169,7 +139,7 @@ export const FixedColumns: Story = {
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           4 Columns
         </XDSText>
-        <XDSGrid columns={4} gap="space4">
+        <XDSGrid columns={4} gap={4}>
           <GridItem>Item 1</GridItem>
           <GridItem>Item 2</GridItem>
           <GridItem>Item 3</GridItem>
@@ -190,7 +160,7 @@ export const ResponsiveAutoFit: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Resize the viewport - columns adjust automatically (min 200px per item)
       </XDSText>
-      <XDSGrid minChildWidth={200} gap="space4">
+      <XDSGrid minChildWidth={200} gap={4}>
         <GridItem>Item 1</GridItem>
         <GridItem>Item 2</GridItem>
         <GridItem>Item 3</GridItem>
@@ -208,7 +178,7 @@ export const CappedResponsive: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Auto-fit with max 3 columns (min 250px per item, capped via max-width)
       </XDSText>
-      <XDSGrid columns={3} minChildWidth={250} gap="space4">
+      <XDSGrid columns={3} minChildWidth={250} gap={4}>
         <GridItem>Item 1</GridItem>
         <GridItem>Item 2</GridItem>
         <GridItem>Item 3</GridItem>
@@ -226,7 +196,7 @@ export const WithGridSpan: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Using XDSGridSpan to span multiple columns/rows
       </XDSText>
-      <XDSGrid columns={4} gap="space4">
+      <XDSGrid columns={4} gap={4}>
         <XDSGridSpan columns={2}>
           <FeaturedItem>Spans 2 columns</FeaturedItem>
         </XDSGridSpan>
@@ -250,7 +220,7 @@ export const GridSpanWithRows: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Grid items spanning both columns and rows
       </XDSText>
-      <XDSGrid columns={4} gap="space4">
+      <XDSGrid columns={4} gap={4}>
         <XDSGridSpan columns={2} rows={2}>
           <FeaturedItem>2x2 Featured</FeaturedItem>
         </XDSGridSpan>
@@ -271,7 +241,7 @@ export const GalleryExample: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Gallery/Card Grid - Responsive with min 280px cards
       </XDSText>
-      <XDSGrid minChildWidth={280} gap="space5">
+      <XDSGrid minChildWidth={280} gap={5}>
         {Array.from({length: 8}, (_, i) => (
           <XDSCard key={i}>
             <div {...stylex.props(styles.cardImage)} />
@@ -295,7 +265,7 @@ export const DifferentGaps: Story = {
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           Same gap for rows and columns (space4)
         </XDSText>
-        <XDSGrid columns={3} gap="space4">
+        <XDSGrid columns={3} gap={4}>
           <GridItem>Item 1</GridItem>
           <GridItem>Item 2</GridItem>
           <GridItem>Item 3</GridItem>
@@ -308,7 +278,7 @@ export const DifferentGaps: Story = {
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
           Different gaps: rowGap=space2, columnGap=space6
         </XDSText>
-        <XDSGrid columns={3} rowGap="space2" columnGap="space6">
+        <XDSGrid columns={3} rowGap={2} columnGap={6}>
           <GridItem>Item 1</GridItem>
           <GridItem>Item 2</GridItem>
           <GridItem>Item 3</GridItem>
@@ -327,7 +297,7 @@ export const DashboardLayout: Story = {
       <XDSText type="supporting" xstyle={styles.sectionLabel}>
         Dashboard-style layout with different sized widgets
       </XDSText>
-      <XDSGrid columns={4} gap="space4">
+      <XDSGrid columns={4} gap={4}>
         <XDSGridSpan columns={2} rows={2}>
           <XDSCard>
             <XDSText type="label" display="block">

--- a/apps/storybook/stories/HoverCard.stories.tsx
+++ b/apps/storybook/stories/HoverCard.stories.tsx
@@ -40,7 +40,7 @@ type Story = StoryObj<typeof XDSHoverCard>;
 function ProfileCard() {
   return (
     <div style={{width: 200}}>
-      <XDSVStack gap="space2">
+      <XDSVStack gap={2}>
         <div style={{fontWeight: 600}}>Jane Doe</div>
         <div style={{fontSize: 14, opacity: 0.7}}>Software Engineer</div>
         <div style={{fontSize: 13}}>
@@ -150,9 +150,9 @@ export const InteractiveContent: Story = {
       <XDSHoverCard
         placement="below"
         content={
-          <XDSVStack gap="space2">
+          <XDSVStack gap={2}>
             <div>Interactive hover card content</div>
-            <XDSHStack gap="space2">
+            <XDSHStack gap={2}>
               <XDSButton label="Follow" variant="primary">
                 Follow
               </XDSButton>
@@ -194,7 +194,7 @@ export const TextNodeMultiple: Story = {
         <XDSHoverCard
           content={
             <div style={{width: 200}}>
-              <XDSVStack gap="space2">
+              <XDSVStack gap={2}>
                 <div style={{fontWeight: 600}}>John Smith</div>
                 <div style={{fontSize: 14, opacity: 0.7}}>Product Manager</div>
               </XDSVStack>

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -406,7 +406,7 @@ export const Playground = {
               <XDSLayoutFooter
                 hasDivider={args.footerHasDivider}
                 isFullBleed={args.footerIsFullBleed}>
-                <XDSHStack gap="space2" hAlign="end">
+                <XDSHStack gap={2} hAlign="end">
                   <XDSButton label="Cancel" variant="secondary">
                     Cancel
                   </XDSButton>
@@ -453,7 +453,7 @@ export const BasicCard: Story = {
           }
           footer={
             <XDSLayoutFooter hasDivider>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton label="Cancel" variant="secondary">
                   Cancel
                 </XDSButton>
@@ -501,7 +501,7 @@ export const WithSidebar: Story = {
           }
           footer={
             <XDSLayoutFooter hasDivider>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton label="Reset" variant="secondary">
                   Reset
                 </XDSButton>
@@ -579,7 +579,7 @@ export const NoDividers: Story = {
           }
           footer={
             <XDSLayoutFooter>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton label="Continue" variant="primary">
                   Continue
                 </XDSButton>
@@ -614,7 +614,7 @@ export const FullBleedContent: Story = {
           }
           footer={
             <XDSLayoutFooter hasDivider>
-              <XDSHStack gap="space2" hAlign="end">
+              <XDSHStack gap={2} hAlign="end">
                 <XDSButton label="Close" variant="secondary">
                   Close
                 </XDSButton>
@@ -630,9 +630,9 @@ export const FullBleedContent: Story = {
 export const SectionVariants: Story = {
   name: 'Section Variants',
   render: () => (
-    <XDSVStack gap="space6" xstyle={styles.storySection}>
+    <XDSVStack gap={6} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>XDSSection Variants</p>
-      <XDSHStack gap="space4" wrap="wrap">
+      <XDSHStack gap={4} wrap="wrap">
         <XDSSection variant="section" width={300} height={250}>
           <XDSLayout
             header={
@@ -711,8 +711,8 @@ export const ContentOnly: Story = {
 export const ThemedLayout: Story = {
   name: 'Themed Layout (Neutral vs Default)',
   render: () => (
-    <XDSHStack gap="space6" xstyle={styles.storySection}>
-      <XDSVStack gap="space3">
+    <XDSHStack gap={6} xstyle={styles.storySection}>
+      <XDSVStack gap={3}>
         <p {...stylex.props(styles.sectionLabel)}>
           Default Theme (16px padding)
         </p>
@@ -734,7 +734,7 @@ export const ThemedLayout: Story = {
               }
               footer={
                 <XDSLayoutFooter hasDivider>
-                  <XDSHStack gap="space2" hAlign="end">
+                  <XDSHStack gap={2} hAlign="end">
                     <XDSButton label="Cancel" variant="secondary">
                       Cancel
                     </XDSButton>
@@ -749,7 +749,7 @@ export const ThemedLayout: Story = {
         </XDSTheme>
       </XDSVStack>
 
-      <XDSVStack gap="space3">
+      <XDSVStack gap={3}>
         <p {...stylex.props(styles.sectionLabel)}>
           Neutral Theme (12px padding)
         </p>
@@ -771,7 +771,7 @@ export const ThemedLayout: Story = {
               }
               footer={
                 <XDSLayoutFooter hasDivider>
-                  <XDSHStack gap="space2" hAlign="end">
+                  <XDSHStack gap={2} hAlign="end">
                     <XDSButton label="Cancel" variant="secondary">
                       Cancel
                     </XDSButton>
@@ -792,15 +792,15 @@ export const ThemedLayout: Story = {
 export const OuterPaddingDemo: Story = {
   name: 'Outer Padding Demonstration',
   render: () => (
-    <XDSVStack gap="space6" xstyle={styles.storySection}>
+    <XDSVStack gap={6} xstyle={styles.storySection}>
       <p {...stylex.props(styles.sectionLabel)}>Outer Padding</p>
       <p {...stylex.props(styles.bodyText)}>
         Outer padding creates space between the container edge and the layout
         content. Notice how the dividers are inset from the container edges as
         outer padding increases.
       </p>
-      <XDSHStack gap="space4" wrap="wrap">
-        <XDSVStack gap="space2">
+      <XDSHStack gap={4} wrap="wrap">
+        <XDSVStack gap={2}>
           <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing0</p>
           <div
             {...stylex.props(
@@ -833,7 +833,7 @@ export const OuterPaddingDemo: Story = {
           </div>
         </XDSVStack>
 
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing4</p>
           <div
             {...stylex.props(
@@ -866,7 +866,7 @@ export const OuterPaddingDemo: Story = {
           </div>
         </XDSVStack>
 
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <p {...stylex.props(styles.subheading)}>paddingOuterX/Y = spacing7</p>
           <div
             {...stylex.props(

--- a/apps/storybook/stories/Popover.stories.tsx
+++ b/apps/storybook/stories/Popover.stories.tsx
@@ -43,7 +43,7 @@ function SettingsContent() {
   const [sounds, setSounds] = React.useState(true);
 
   return (
-    <XDSVStack gap="space3">
+    <XDSVStack gap={3}>
       <XDSHeading level={4} tabIndex={-1}>
         Settings
       </XDSHeading>
@@ -96,7 +96,7 @@ function FilterContent({onApply}: {onApply?: () => void}) {
     setFilters(prev => ({...prev, [key]: !prev[key]}));
 
   return (
-    <XDSVStack gap="space3">
+    <XDSVStack gap={3}>
       <XDSHeading level={4} tabIndex={-1}>
         Filter by status
       </XDSHeading>
@@ -122,7 +122,7 @@ function FilterContent({onApply}: {onApply?: () => void}) {
         onChange={() => toggle('shared')}
       />
       <XDSDivider />
-      <XDSHStack gap="space2">
+      <XDSHStack gap={2}>
         <XDSButton label="Apply" variant="primary" onClick={onApply}>
           Apply
         </XDSButton>
@@ -173,7 +173,7 @@ function ConfirmContent({
   onCancel?: () => void;
 }) {
   return (
-    <XDSVStack gap="space3">
+    <XDSVStack gap={3}>
       <XDSHeading level={4} tabIndex={-1}>
         Delete project?
       </XDSHeading>
@@ -181,7 +181,7 @@ function ConfirmContent({
         This will permanently delete the project and all its data. This action
         cannot be undone.
       </XDSText>
-      <XDSHStack gap="space2">
+      <XDSHStack gap={2}>
         <XDSButton label="Delete" variant="destructive" onClick={onConfirm}>
           Delete
         </XDSButton>
@@ -235,7 +235,7 @@ export const AnchorRef: Story = {
           width={260}
           placement="below"
           content={
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <XDSHeading level={4} tabIndex={-1}>
                 Sibling mode
               </XDSHeading>
@@ -263,24 +263,24 @@ export const Above: Story = {
         label="Info"
         width={260}
         content={
-          <XDSVStack gap="space2">
+          <XDSVStack gap={2}>
             <XDSHeading level={4} tabIndex={-1}>
               Keyboard shortcuts
             </XDSHeading>
             <XDSDivider />
-            <XDSHStack gap="space3">
+            <XDSHStack gap={3}>
               <XDSText type="body" weight="bold">
                 ⌘K
               </XDSText>
               <XDSText type="body">Command palette</XDSText>
             </XDSHStack>
-            <XDSHStack gap="space3">
+            <XDSHStack gap={3}>
               <XDSText type="body" weight="bold">
                 ⌘/
               </XDSText>
               <XDSText type="body">Toggle sidebar</XDSText>
             </XDSHStack>
-            <XDSHStack gap="space3">
+            <XDSHStack gap={3}>
               <XDSText type="body" weight="bold">
                 ⌘.
               </XDSText>

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -121,7 +121,7 @@ export const Variants: Story = {
 export const WithSimpleContent: Story = {
   render: () => (
     <XDSSection variant="wash" width={320}>
-      <XDSVStack gap="space2">
+      <XDSVStack gap={2}>
         <h3 {...stylex.props(styles.text)}>Section Title</h3>
         <p {...stylex.props(styles.text, styles.textSecondary)}>
           This section contains simple content without XDSLayout. The container
@@ -151,7 +151,7 @@ export const WithInnerLayout: Story = {
         }
         footer={
           <XDSLayoutFooter hasDivider>
-            <XDSHStack gap="space2" hAlign="end">
+            <XDSHStack gap={2} hAlign="end">
               <XDSButton label="Action" variant="primary">
                 Action
               </XDSButton>
@@ -169,7 +169,7 @@ export const PageLayout: Story = {
       <XDSLayout
         header={
           <XDSLayoutHeader hasDivider>
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <h2 {...stylex.props(styles.text)}>Page Header</h2>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
                 Welcome to the application
@@ -184,7 +184,7 @@ export const PageLayout: Story = {
         }
         content={
           <XDSLayoutContent>
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <h3 {...stylex.props(styles.text)}>Main Content</h3>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
                 This demonstrates how XDSLayout can be used to create page

--- a/apps/storybook/stories/Skeleton.stories.tsx
+++ b/apps/storybook/stories/Skeleton.stories.tsx
@@ -42,7 +42,7 @@ export const Default: Story = {
 
 export const Shapes: Story = {
   render: () => (
-    <XDSHStack gap="space4" vAlign="center">
+    <XDSHStack gap={4} vAlign="center">
       <XDSSkeleton width={40} height={40} radius="rounded" />
       <XDSSkeleton width={100} height={20} radius="container" />
       <XDSSkeleton width={120} height={32} radius="element" />
@@ -53,7 +53,7 @@ export const Shapes: Story = {
 
 export const StaggeredList: Story = {
   render: () => (
-    <XDSVStack gap="space2">
+    <XDSVStack gap={2}>
       <XDSSkeleton width={300} height={16} index={0} />
       <XDSSkeleton width={280} height={16} index={1} />
       <XDSSkeleton width={320} height={16} index={2} />
@@ -66,11 +66,11 @@ export const StaggeredList: Story = {
 export const CardSkeleton: Story = {
   render: () => (
     <XDSCard width={320}>
-      <XDSVStack gap="space3">
+      <XDSVStack gap={3}>
         {/* Avatar and name row */}
-        <XDSHStack gap="space3" vAlign="center">
+        <XDSHStack gap={3} vAlign="center">
           <XDSSkeleton width={40} height={40} radius="rounded" index={0} />
-          <XDSVStack gap="space1">
+          <XDSVStack gap={1}>
             <XDSSkeleton width={120} height={14} index={1} />
             <XDSSkeleton width={80} height={12} index={2} />
           </XDSVStack>
@@ -86,9 +86,9 @@ export const CardSkeleton: Story = {
 
 export const TableRowSkeleton: Story = {
   render: () => (
-    <XDSVStack gap="space2">
+    <XDSVStack gap={2}>
       {[0, 1, 2, 3].map(rowIndex => (
-        <XDSHStack key={rowIndex} gap="space4" vAlign="center">
+        <XDSHStack key={rowIndex} gap={4} vAlign="center">
           <XDSSkeleton width={50} height={16} index={rowIndex * 4} />
           <XDSSkeleton width={180} height={16} index={rowIndex * 4 + 1} />
           <XDSSkeleton width={100} height={16} index={rowIndex * 4 + 2} />

--- a/apps/storybook/stories/Spinner.stories.tsx
+++ b/apps/storybook/stories/Spinner.stories.tsx
@@ -33,7 +33,7 @@ export const Default: Story = {
 
 export const Sizes: Story = {
   render: () => (
-    <XDSHStack gap="space4" vAlign="center">
+    <XDSHStack gap={4} vAlign="center">
       <XDSSpinner size="sm" />
       <XDSSpinner size="md" />
       <XDSSpinner size="lg" />
@@ -43,7 +43,7 @@ export const Sizes: Story = {
 
 export const Shades: Story = {
   render: () => (
-    <XDSHStack gap="space4" vAlign="center">
+    <XDSHStack gap={4} vAlign="center">
       <XDSSpinner shade="default" />
       <div
         style={{
@@ -59,7 +59,7 @@ export const Shades: Story = {
 
 export const InContext: Story = {
   render: () => (
-    <XDSVStack gap="space2" hAlign="center">
+    <XDSVStack gap={2} hAlign="center">
       <XDSSpinner size="lg" />
       <XDSText type="body" color="secondary">
         Loading...

--- a/apps/storybook/stories/Stack.stories.tsx
+++ b/apps/storybook/stories/Stack.stories.tsx
@@ -128,18 +128,8 @@ const meta: Meta<typeof XDSStack> = {
     },
     gap: {
       control: 'select',
-      options: [
-        'space0',
-        'space0.5',
-        'space1',
-        'space2',
-        'space3',
-        'space4',
-        'space5',
-        'space6',
-        'space7',
-      ],
-      description: 'Spacing token for gap between items',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description: 'Spacing step for gap between items',
     },
     hAlign: {
       control: 'select',
@@ -187,7 +177,7 @@ type Story = StoryObj<typeof XDSStack>;
 export const Default: Story = {
   args: {
     direction: 'vertical',
-    gap: 'space2',
+    gap: 2,
     children: null,
   },
   render: args => (
@@ -202,7 +192,7 @@ export const Default: Story = {
 export const Horizontal: Story = {
   args: {
     direction: 'horizontal',
-    gap: 'space2',
+    gap: 2,
   },
   render: args => (
     <XDSStack {...args}>
@@ -216,7 +206,7 @@ export const Horizontal: Story = {
 export const Vertical: Story = {
   args: {
     direction: 'vertical',
-    gap: 'space4',
+    gap: 4,
   },
   render: args => (
     <XDSStack {...args}>
@@ -240,7 +230,7 @@ export const HorizontalAlignments: Story = {
         </h4>
         <XDSStack
           direction="horizontal"
-          gap="space2"
+          gap={2}
           vAlign="start"
           xstyle={[styles.container, styles.containerHeightSmall]}>
           <Box>A</Box>
@@ -256,7 +246,7 @@ export const HorizontalAlignments: Story = {
         </h4>
         <XDSStack
           direction="horizontal"
-          gap="space2"
+          gap={2}
           vAlign="center"
           xstyle={[styles.container, styles.containerHeightSmall]}>
           <Box>A</Box>
@@ -272,7 +262,7 @@ export const HorizontalAlignments: Story = {
         </h4>
         <XDSStack
           direction="horizontal"
-          gap="space2"
+          gap={2}
           vAlign="end"
           xstyle={[styles.container, styles.containerHeightSmall]}>
           <Box>A</Box>
@@ -288,7 +278,7 @@ export const HorizontalAlignments: Story = {
         </h4>
         <XDSStack
           direction="horizontal"
-          gap="space2"
+          gap={2}
           vAlign="stretch"
           xstyle={[styles.container, styles.containerHeightSmall]}>
           <Box>A</Box>
@@ -311,7 +301,7 @@ export const VerticalAlignments: Story = {
         </h4>
         <XDSStack
           direction="vertical"
-          gap="space2"
+          gap={2}
           hAlign="start"
           xstyle={[
             styles.container,
@@ -329,7 +319,7 @@ export const VerticalAlignments: Story = {
         </h4>
         <XDSStack
           direction="vertical"
-          gap="space2"
+          gap={2}
           hAlign="center"
           xstyle={[
             styles.container,
@@ -347,7 +337,7 @@ export const VerticalAlignments: Story = {
         </h4>
         <XDSStack
           direction="vertical"
-          gap="space2"
+          gap={2}
           hAlign="end"
           xstyle={[
             styles.container,
@@ -365,7 +355,7 @@ export const VerticalAlignments: Story = {
         </h4>
         <XDSStack
           direction="vertical"
-          gap="space2"
+          gap={2}
           hAlign="stretch"
           xstyle={[
             styles.container,
@@ -388,7 +378,7 @@ export const VerticalAlignments: Story = {
 export const Wrapping: Story = {
   args: {
     direction: 'horizontal',
-    gap: 'space2',
+    gap: 2,
     wrap: 'wrap',
   },
   render: args => (
@@ -416,7 +406,7 @@ export const StackItemFillSize: Story = {
   render: () => (
     <XDSStack
       direction="horizontal"
-      gap="space2"
+      gap={2}
       xstyle={[
         styles.container,
         styles.containerWidthMedium,
@@ -441,7 +431,7 @@ export const StackItemEqualFill: Story = {
       <h4 {...stylex.props(styles.heading)}>Equal Fill (1:1:1)</h4>
       <XDSStack
         direction="horizontal"
-        gap="space2"
+        gap={2}
         xstyle={[
           styles.container,
           styles.containerWidthMedium,
@@ -465,7 +455,7 @@ export const StackItemCrossAlignSelf: Story = {
   render: () => (
     <XDSStack
       direction="horizontal"
-      gap="space2"
+      gap={2}
       xstyle={[
         styles.container,
         styles.containerHeightMedium,
@@ -495,7 +485,7 @@ export const HeaderLayout: Story = {
   render: () => (
     <XDSStack
       direction="horizontal"
-      gap="space2"
+      gap={2}
       xstyle={[
         styles.container,
         styles.containerWidthLarge,
@@ -518,7 +508,7 @@ export const SidebarLayout: Story = {
   render: () => (
     <XDSStack
       direction="horizontal"
-      gap="space2"
+      gap={2}
       xstyle={[
         styles.container,
         styles.containerWidthLarge,
@@ -537,13 +527,10 @@ export const SidebarLayout: Story = {
 
 export const PageLayout: Story = {
   render: () => (
-    <XDSStack
-      direction="vertical"
-      gap="space2"
-      xstyle={styles.containerWidthLarge}>
+    <XDSStack direction="vertical" gap={2} xstyle={styles.containerWidthLarge}>
       <XDSStack
         direction="horizontal"
-        gap="space2"
+        gap={2}
         xstyle={[styles.container, styles.containerPadding]}>
         <XDSStackItem size="static">
           <Box alt>Logo</Box>
@@ -557,7 +544,7 @@ export const PageLayout: Story = {
       </XDSStack>
       <XDSStack
         direction="horizontal"
-        gap="space2"
+        gap={2}
         xstyle={[
           styles.container,
           styles.containerHeightLarge,

--- a/apps/storybook/stories/Tooltip.stories.tsx
+++ b/apps/storybook/stories/Tooltip.stories.tsx
@@ -140,7 +140,7 @@ export const LongContent: Story = {
 export const MultipleTooltips: Story = {
   render: () => (
     <div style={{padding: 100}}>
-      <XDSHStack gap="space4">
+      <XDSHStack gap={4}>
         <XDSTooltip content="Save your changes" placement="above">
           <XDSButton label="Save">Save</XDSButton>
         </XDSTooltip>

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-gap-to-numeric.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-gap-to-numeric.test.mjs
@@ -1,0 +1,109 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../migrate-gap-to-numeric.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('migrate-gap-to-numeric', () => {
+  it('converts gap="space0" to gap={0}', async () => {
+    const input = '<XDSStack direction="vertical" gap="space0"><div /></XDSStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={0}');
+    expect(output).not.toContain('"space0"');
+  });
+
+  it('converts gap="space0.5" to gap={0.5}', async () => {
+    const input = '<XDSHStack gap="space0.5"><div /></XDSHStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={0.5}');
+    expect(output).not.toContain('"space0.5"');
+  });
+
+  it('converts gap="space4" to gap={4}', async () => {
+    const input = '<XDSVStack gap="space4"><div /></XDSVStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={4}');
+    expect(output).not.toContain('"space4"');
+  });
+
+  it('converts gap="space10" to gap={10}', async () => {
+    const input = '<XDSStack direction="horizontal" gap="space10"><div /></XDSStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={10}');
+    expect(output).not.toContain('"space10"');
+  });
+
+  it('converts rowGap and columnGap on XDSGrid', async () => {
+    const input = '<XDSGrid columns={3} rowGap="space2" columnGap="space6"><div /></XDSGrid>';
+    const output = await applyTransform(input);
+    expect(output).toContain('rowGap={2}');
+    expect(output).toContain('columnGap={6}');
+    expect(output).not.toContain('"space2"');
+    expect(output).not.toContain('"space6"');
+  });
+
+  it('converts gap on XDSGrid', async () => {
+    const input = '<XDSGrid columns={3} gap="space4"><div /></XDSGrid>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={4}');
+    expect(output).not.toContain('"space4"');
+  });
+
+  it('handles gap={"space4"} expression container form', async () => {
+    const input = '<XDSStack direction="vertical" gap={"space4"}><div /></XDSStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={4}');
+  });
+
+  it('does not modify non-gap props', async () => {
+    const input = '<XDSStack direction="vertical" gap="space2" wrap="wrap"><div /></XDSStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={2}');
+    expect(output).toContain('wrap="wrap"');
+  });
+
+  it('handles multiple components in one file', async () => {
+    const input = `
+      <div>
+        <XDSHStack gap="space2"><div /></XDSHStack>
+        <XDSVStack gap="space4"><div /></XDSVStack>
+        <XDSGrid columns={3} gap="space6"><div /></XDSGrid>
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={2}');
+    expect(output).toContain('gap={4}');
+    expect(output).toContain('gap={6}');
+    expect(output).not.toContain('"space');
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../migrate-gap-to-numeric.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSStack direction="vertical" gap={4}><div /></XDSStack>';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('does not modify unknown string values', async () => {
+    const input = '<XDSStack direction="vertical" gap="custom"><div /></XDSStack>';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap="custom"');
+  });
+
+  it('converts gap on any component with gap prop', async () => {
+    const input = '<CustomComponent gap="space3" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('gap={3}');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-isFullBleed-to-padding.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-isFullBleed-to-padding.test.mjs
@@ -1,0 +1,135 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../migrate-isFullBleed-to-padding.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('migrate-isFullBleed-to-padding', () => {
+  it('converts isFullBleed (no value) to padding={0} on XDSCard', async () => {
+    const input = '<XDSCard isFullBleed>Content</XDSCard>';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('converts isFullBleed={true} to padding={0} on XDSCard', async () => {
+    const input = '<XDSCard isFullBleed={true}>Content</XDSCard>';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('removes isFullBleed={false} on XDSCard', async () => {
+    const input = '<XDSCard isFullBleed={false}>Content</XDSCard>';
+    const output = await applyTransform(input);
+    expect(output).not.toContain('isFullBleed');
+    expect(output).not.toContain('padding');
+  });
+
+  it('converts isFullBleed on XDSSection', async () => {
+    const input = '<XDSSection isFullBleed>Content</XDSSection>';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('converts isFullBleed on XDSLayout', async () => {
+    const input = '<XDSLayout isFullBleed content={<div />} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('converts isFullBleed on XDSLayoutContent', async () => {
+    const input = '<XDSLayoutContent isFullBleed><div /></XDSLayoutContent>';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('converts isFullBleed on XDSLayoutHeader', async () => {
+    const input = '<XDSLayoutHeader isFullBleed>Header</XDSLayoutHeader>';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('converts isFullBleed on XDSLayoutFooter', async () => {
+    const input = '<XDSLayoutFooter isFullBleed>Footer</XDSLayoutFooter>';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('converts isFullBleed on XDSLayoutPanel', async () => {
+    const input = '<XDSLayoutPanel isFullBleed><nav /></XDSLayoutPanel>';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('does NOT convert isFullBleed on XDSDivider', async () => {
+    const input = '<XDSDivider isFullBleed />';
+    const output = await applyTransform(input);
+    expect(output).toContain('isFullBleed');
+    expect(output).not.toContain('padding');
+  });
+
+  it('does NOT convert isFullBleed on unknown components', async () => {
+    const input = '<CustomComponent isFullBleed />';
+    const output = await applyTransform(input);
+    expect(output).toContain('isFullBleed');
+    expect(output).not.toContain('padding');
+  });
+
+  it('handles multiple components in one file', async () => {
+    const input = `
+      <div>
+        <XDSCard isFullBleed>Card</XDSCard>
+        <XDSSection isFullBleed={true}>Section</XDSSection>
+        <XDSDivider isFullBleed />
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('isFullBleed>Card');
+    expect(output).not.toContain('isFullBleed={true}>Section');
+    // Divider's isFullBleed should remain
+    expect(output).toContain('isFullBleed');
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../migrate-isFullBleed-to-padding.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSCard padding={0}>Content</XDSCard>';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('preserves other props', async () => {
+    const input = '<XDSCard isFullBleed width={400} height={300}>Content</XDSCard>';
+    const output = await applyTransform(input);
+    expect(output).toContain('padding={0}');
+    expect(output).toContain('width={400}');
+    expect(output).toContain('height={300}');
+    expect(output).not.toContain('isFullBleed');
+  });
+
+  it('does not add padding={0} if padding already exists', async () => {
+    const input = '<XDSCard isFullBleed padding={2}>Content</XDSCard>';
+    const output = await applyTransform(input);
+    expect(output).not.toContain('isFullBleed');
+    // Should keep existing padding, not add another
+    const paddingMatches = output.match(/padding=/g);
+    expect(paddingMatches).toHaveLength(1);
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/index.mjs
@@ -31,6 +31,12 @@ import renameSideNavHeaderToHeading, {
 import migrateUseXDSIconToGetIcon, {
   meta as useXDSIconMeta,
 } from './migrate-useXDSIcon-to-getIcon.mjs';
+import migrateGapToNumeric, {
+  meta as gapMeta,
+} from './migrate-gap-to-numeric.mjs';
+import migrateIsFullBleedToPadding, {
+  meta as fullBleedMeta,
+} from './migrate-isFullBleed-to-padding.mjs';
 export default [
   {
     name: 'rename-selector-items-to-options',
@@ -76,5 +82,15 @@ export default [
     name: 'migrate-useXDSIcon-to-getIcon',
     transform: migrateUseXDSIconToGetIcon,
     meta: useXDSIconMeta,
+  },
+  {
+    name: 'migrate-gap-to-numeric',
+    transform: migrateGapToNumeric,
+    meta: gapMeta,
+  },
+  {
+    name: 'migrate-isFullBleed-to-padding',
+    transform: migrateIsFullBleedToPadding,
+    meta: fullBleedMeta,
   },
 ];

--- a/packages/cli/src/codemods/transforms/v0.0.2/migrate-gap-to-numeric.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/migrate-gap-to-numeric.mjs
@@ -1,0 +1,86 @@
+/**
+ * @file Codemod: Migrate gap/rowGap/columnGap from string tokens to numeric values
+ *
+ * Transforms:
+ * - gap="space0" → gap={0}
+ * - gap="space0.5" → gap={0.5}
+ * - gap="space1" → gap={1}
+ * - gap="space1.5" → gap={1.5}
+ * - gap="space2" → gap={2}
+ * - ... through gap="space10" → gap={10}
+ *
+ * Also handles rowGap and columnGap on XDSGrid.
+ */
+
+export const meta = {
+  title: 'Migrate gap to numeric scale',
+  description:
+    'Migrates gap, rowGap, and columnGap props from string tokens (e.g. "space4") to numeric values (e.g. 4).',
+};
+
+/**
+ * Mapping from string token to numeric value.
+ */
+const TOKEN_TO_NUMBER = {
+  space0: 0,
+  'space0.5': 0.5,
+  space1: 1,
+  'space1.5': 1.5,
+  space2: 2,
+  space3: 3,
+  space4: 4,
+  space5: 5,
+  space6: 6,
+  space7: 7,
+  space8: 8,
+  space9: 9,
+  space10: 10,
+  space11: 11,
+  space12: 12,
+};
+
+const GAP_PROPS = ['gap', 'rowGap', 'columnGap'];
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  root.find(j.JSXAttribute).forEach((path) => {
+    const attrName = path.node.name.name;
+    if (!GAP_PROPS.includes(attrName)) {
+      return;
+    }
+
+    const value = path.node.value;
+
+    // Handle gap="space4" — JSX string attributes are Literal nodes
+    if (value && (value.type === 'Literal' || value.type === 'StringLiteral')) {
+      const numericValue = TOKEN_TO_NUMBER[value.value];
+      if (numericValue !== undefined) {
+        path.node.value = j.jsxExpressionContainer(
+          j.literal(numericValue),
+        );
+        hasChanges = true;
+      }
+    }
+    // Handle gap={"space4"} (JSXExpressionContainer wrapping a string)
+    if (
+      value &&
+      value.type === 'JSXExpressionContainer' &&
+      (value.expression.type === 'Literal' ||
+        value.expression.type === 'StringLiteral')
+    ) {
+      const strValue = value.expression.value;
+      if (typeof strValue === 'string') {
+        const numericValue = TOKEN_TO_NUMBER[strValue];
+        if (numericValue !== undefined) {
+          value.expression = j.literal(numericValue);
+          hasChanges = true;
+        }
+      }
+    }
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.2/migrate-isFullBleed-to-padding.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/migrate-isFullBleed-to-padding.mjs
@@ -1,0 +1,104 @@
+/**
+ * @file Codemod: Migrate isFullBleed to padding={0}
+ *
+ * Transforms:
+ * - isFullBleed → padding={0}
+ * - isFullBleed={true} → padding={0}
+ * - isFullBleed={false} → (removed)
+ *
+ * Target components: XDSCard, XDSSection, XDSLayout, XDSLayoutContent,
+ * XDSLayoutHeader, XDSLayoutFooter, XDSLayoutPanel.
+ * Does NOT target XDSDivider (its isFullBleed uses negative margins).
+ */
+
+export const meta = {
+  title: 'Migrate isFullBleed to padding={0}',
+  description:
+    'Replaces `isFullBleed` with `padding={0}` on layout components. Does not touch XDSDivider.',
+};
+
+const TARGET_COMPONENTS = [
+  'XDSCard',
+  'XDSSection',
+  'XDSLayout',
+  'XDSLayoutContent',
+  'XDSLayoutHeader',
+  'XDSLayoutFooter',
+  'XDSLayoutPanel',
+];
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  TARGET_COMPONENTS.forEach((componentName) => {
+    root
+      .find(j.JSXOpeningElement, {
+        name: {name: componentName},
+      })
+      .forEach((path) => {
+        const attrs = path.node.attributes;
+        const isFullBleedIndex = attrs.findIndex(
+          (attr) =>
+            attr.type === 'JSXAttribute' && attr.name.name === 'isFullBleed',
+        );
+
+        if (isFullBleedIndex === -1) {
+          return;
+        }
+
+        const attr = attrs[isFullBleedIndex];
+        const value = attr.value;
+
+        // isFullBleed (no value — boolean shorthand, means true)
+        if (value === null) {
+          attrs.splice(isFullBleedIndex, 1);
+          const hasPadding = attrs.some(
+            (a) => a.type === 'JSXAttribute' && a.name.name === 'padding',
+          );
+          if (!hasPadding) {
+            attrs.push(
+              j.jsxAttribute(
+                j.jsxIdentifier('padding'),
+                j.jsxExpressionContainer(j.literal(0)),
+              ),
+            );
+          }
+          hasChanges = true;
+          return;
+        }
+
+        // isFullBleed={true} or isFullBleed={false}
+        if (
+          value &&
+          value.type === 'JSXExpressionContainer' &&
+          (value.expression.type === 'Literal' ||
+            value.expression.type === 'BooleanLiteral')
+        ) {
+          if (value.expression.value === true) {
+            // isFullBleed={true} → padding={0}
+            attrs.splice(isFullBleedIndex, 1);
+            const hasPadding = attrs.some(
+              (a) => a.type === 'JSXAttribute' && a.name.name === 'padding',
+            );
+            if (!hasPadding) {
+              attrs.push(
+                j.jsxAttribute(
+                  j.jsxIdentifier('padding'),
+                  j.jsxExpressionContainer(j.literal(0)),
+                ),
+              );
+            }
+            hasChanges = true;
+          } else if (value.expression.value === false) {
+            // isFullBleed={false} → remove entirely
+            attrs.splice(isFullBleedIndex, 1);
+            hasChanges = true;
+          }
+        }
+      });
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -39,8 +39,14 @@ export const docs = {
     {
       name: 'isFullBleed',
       type: 'boolean',
-      description: 'Removes internal padding for edge-to-edge content.',
+      description: 'Deprecated. Use `padding={0}` instead.',
       default: 'false',
+    },
+    {
+      name: 'padding',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description: 'Internal padding using the spacing scale.',
+      default: '4',
     },
   ],
   examples: [
@@ -71,7 +77,7 @@ export const docs = {
     {
       label: 'Accordion of cards',
       code: `<XDSCollapsibleGroup type="single" defaultValue="general">
-  <XDSVStack gap="space2">
+  <XDSVStack gap={2}>
     <XDSCard>
       <XDSCollapsible trigger="General" value="general">
         <GeneralSettings />

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -16,7 +16,13 @@ import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars, elevationVars} from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
-import type {SizeValue} from '../utils/types';
+import type {SpacingToken} from '../Layout/container.stylex';
+import {
+  paddingStyles,
+  containerPaddingInlineVarStyles,
+  spacingStepToToken,
+} from '../Layout/padding.stylex';
+import type {SizeValue, SpacingStep} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
 
@@ -26,7 +32,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-card'],
     borderRadius: radiusVars['--radius-container'],
     boxShadow: elevationVars['--elevation-base'],
-    // Clip content to border-radius so nested containers don't peek out corners
+    // Clip content to border-radius so nested containers don\'t peek out corners
     overflow: 'clip',
     borderWidth: 1,
     borderStyle: 'solid',
@@ -39,13 +45,6 @@ const styles = stylex.create({
   // Only enable scrolling when card has fixed height
   scrollable: {
     overflow: 'auto',
-  },
-  // Full bleed: removes all internal padding
-  fullBleed: {
-    paddingInlineStart: 0,
-    paddingInlineEnd: 0,
-    paddingBlockStart: 0,
-    paddingBlockEnd: 0,
   },
 });
 
@@ -67,7 +66,6 @@ const dynamicStyles = stylex.create({
 export type {SizeValue} from '../utils/types';
 
 export interface XDSCardProps extends XDSBaseProps {
-  /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
    * CSS class name(s) appended to the root element.
@@ -109,9 +107,17 @@ export interface XDSCardProps extends XDSBaseProps {
 
   /**
    * Removes internal padding, allowing content to touch the edges.
+   * @deprecated Use `padding={0}` instead.
    * @default false
    */
   isFullBleed?: boolean;
+
+  /**
+   * Internal padding of the card using the spacing scale.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   * @default 4 (16px)
+   */
+  padding?: SpacingStep;
 }
 
 /**
@@ -141,6 +147,7 @@ export function XDSCard({
   minHeight,
   children,
   isFullBleed = false,
+  padding,
   xstyle,
   className,
   style,
@@ -149,6 +156,10 @@ export function XDSCard({
 }: XDSCardProps) {
   // Only enable scrolling when card has a fixed height (not null/undefined and not "auto")
   const hasFixedHeight = height != null && height !== 'auto';
+
+  // Resolve effective padding: isFullBleed maps to padding=0
+  const effectivePadding = isFullBleed ? 0 : (padding ?? 4);
+  const paddingToken = spacingStepToToken[effectivePadding] as SpacingToken;
 
   return (
     <div
@@ -174,12 +185,14 @@ export function XDSCard({
           styles.cardInner,
           hasFixedHeight && styles.scrollable,
           ...container({
-            paddingInnerX: 'spacing4',
-            paddingInnerY: 'spacing4',
-            paddingOuterX: 'spacing4',
-            paddingOuterY: 'spacing4',
+            paddingInnerX: paddingToken,
+            paddingInnerY: paddingToken,
+            paddingOuterX: paddingToken,
+            paddingOuterY: paddingToken,
           }),
-          isFullBleed && styles.fullBleed,
+          effectivePadding !== 4 && paddingStyles[effectivePadding],
+          effectivePadding !== 4 &&
+            containerPaddingInlineVarStyles[effectivePadding],
         )}>
         {children}
       </div>

--- a/packages/core/src/Collapsible/Collapsible.doc.mjs
+++ b/packages/core/src/Collapsible/Collapsible.doc.mjs
@@ -61,7 +61,7 @@ export const docs = {
       label: 'Coordinated group — single mode (accordion)',
       code: `// Single mode — only one open at a time (FAQ, settings panels)
 <XDSCollapsibleGroup type="single" defaultValue="general">
-  <XDSVStack gap="space2">
+  <XDSVStack gap={2}>
     <XDSCard>
       <XDSCollapsible trigger="General Settings" value="general">
         <GeneralContent />
@@ -79,7 +79,7 @@ export const docs = {
       label: 'Coordinated group — multiple mode',
       code: `// Multiple mode — any number open
 <XDSCollapsibleGroup type="multiple" defaultValue={["s1", "s2"]}>
-  <XDSVStack gap="space2">
+  <XDSVStack gap={2}>
     <XDSCard>
       <XDSCollapsible trigger="Section 1" value="s1">...</XDSCollapsible>
     </XDSCard>

--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -135,7 +135,7 @@ export interface XDSCollapsibleProps {
  *   </XDSCollapsible>
  * </XDSCard>
  * <XDSCollapsibleGroup type="single" defaultValue="general">
- *   <XDSVStack gap="space2">
+ *   <XDSVStack gap={2}>
  *     <XDSCard>
  *       <XDSCollapsible trigger="General" value="general">
  *         <GeneralSettings />

--- a/packages/core/src/Collapsible/XDSCollapsibleGroup.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsibleGroup.tsx
@@ -57,7 +57,7 @@ export interface XDSCollapsibleGroupProps {
    * @example
    * ```
    * <XDSCollapsibleGroup type="single" defaultValue="general">
-   *   <XDSVStack gap="space2">
+   *   <XDSVStack gap={2}>
    *     <XDSCard>
    *       <XDSCollapsible trigger="General" value="general">
    *         <p>General settings content</p>
@@ -93,7 +93,7 @@ function normalizeToArray(value: string | string[] | undefined): string[] {
  * @example
  * ```
  * <XDSCollapsibleGroup type="single" defaultValue="faq1">
- *   <XDSVStack gap="space2">
+ *   <XDSVStack gap={2}>
  *     <XDSCard>
  *       <XDSCollapsible trigger="What is XDS?" value="faq1">
  *         XDS is a design system for building internal tools.

--- a/packages/core/src/Grid/Grid.doc.mjs
+++ b/packages/core/src/Grid/Grid.doc.mjs
@@ -15,7 +15,7 @@ export const docs = {
   examples: [
     {
       label: 'Fixed 3-column grid',
-      code: `<XDSGrid columns={3} gap="space4">
+      code: `<XDSGrid columns={3} gap={4}>
   <Item />
   <Item />
   <Item />
@@ -23,7 +23,7 @@ export const docs = {
     },
     {
       label: 'Responsive auto-fit',
-      code: `<XDSGrid minChildWidth={200} gap="space4">
+      code: `<XDSGrid minChildWidth={200} gap={4}>
   <Card />
   <Card />
   <Card />
@@ -31,20 +31,20 @@ export const docs = {
     },
     {
       label: 'Auto-fit with max columns cap',
-      code: `<XDSGrid minChildWidth={200} columns={4} gap="space4">
+      code: `<XDSGrid minChildWidth={200} columns={4} gap={4}>
   <Card />
 </XDSGrid>`,
     },
     {
       label: 'Grid item spanning multiple columns',
-      code: `<XDSGrid columns={3} gap="space4">
+      code: `<XDSGrid columns={3} gap={4}>
   <XDSGridSpan columns={2}>Wide item</XDSGridSpan>
   <div>Normal item</div>
 </XDSGrid>`,
     },
     {
       label: 'Dense grid (e.g. color swatches, icon grids, compact controls)',
-      code: `<XDSGrid columns={6} gap="space2">
+      code: `<XDSGrid columns={6} gap={2}>
   {items.map(item => (
     <XDSButton key={item.id} label={item.label} icon={item.icon} variant="ghost" size="sm" />
   ))}
@@ -88,17 +88,17 @@ export const docs = {
         },
         {
           name: 'gap',
-          type: 'SpacingScale',
+          type: 'SpacingStep',
           description: 'Spacing between all items.',
         },
         {
           name: 'rowGap',
-          type: 'SpacingScale',
+          type: 'SpacingStep',
           description: 'Row spacing; overrides `gap` for the row axis.',
         },
         {
           name: 'columnGap',
-          type: 'SpacingScale',
+          type: 'SpacingStep',
           description: 'Column spacing; overrides `gap` for the column axis.',
         },
         {
@@ -122,7 +122,7 @@ export const docs = {
       examples: [
         {
           label: 'Basic',
-          code: `<XDSGrid columns={3} gap="space4">
+          code: `<XDSGrid columns={3} gap={4}>
   <Item />
   <Item />
   <Item />
@@ -153,7 +153,7 @@ export const docs = {
       examples: [
         {
           label: 'Spanning two columns',
-          code: `<XDSGrid columns={3} gap="space4">
+          code: `<XDSGrid columns={3} gap={4}>
   <XDSGridSpan columns={2}>Wide item</XDSGridSpan>
   <div>Normal item</div>
 </XDSGrid>`,

--- a/packages/core/src/Grid/XDSGrid.test.tsx
+++ b/packages/core/src/Grid/XDSGrid.test.tsx
@@ -41,7 +41,7 @@ describe('XDSGrid', () => {
 
   it('renders with both columns and minChildWidth (capped)', () => {
     render(
-      <XDSGrid columns={3} minChildWidth={250} gap="space4" data-testid="grid">
+      <XDSGrid columns={3} minChildWidth={250} gap={4} data-testid="grid">
         <div>Item 1</div>
         <div>Item 2</div>
         <div>Item 3</div>
@@ -57,11 +57,7 @@ describe('XDSGrid', () => {
 
   it('renders with columns and minChildWidth using columnGap', () => {
     render(
-      <XDSGrid
-        columns={4}
-        minChildWidth={200}
-        columnGap="space6"
-        data-testid="grid">
+      <XDSGrid columns={4} minChildWidth={200} columnGap={6} data-testid="grid">
         <div>Item 1</div>
         <div>Item 2</div>
       </XDSGrid>,
@@ -73,7 +69,7 @@ describe('XDSGrid', () => {
 
   it('applies gap correctly', () => {
     render(
-      <XDSGrid columns={2} gap="space4" data-testid="grid">
+      <XDSGrid columns={2} gap={4} data-testid="grid">
         <div>Item 1</div>
         <div>Item 2</div>
       </XDSGrid>,
@@ -85,11 +81,7 @@ describe('XDSGrid', () => {
 
   it('applies rowGap and columnGap separately', () => {
     render(
-      <XDSGrid
-        columns={2}
-        rowGap="space2"
-        columnGap="space6"
-        data-testid="grid">
+      <XDSGrid columns={2} rowGap={2} columnGap={6} data-testid="grid">
         <div>Item 1</div>
         <div>Item 2</div>
       </XDSGrid>,

--- a/packages/core/src/Grid/XDSGrid.tsx
+++ b/packages/core/src/Grid/XDSGrid.tsx
@@ -18,6 +18,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import type {SpacingScale} from '../Layout';
+import type {SpacingStep} from '../utils/types';
 import type {SizeValue} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -60,21 +61,22 @@ export interface XDSGridProps extends XDSBaseProps<HTMLDivElement> {
 
   /**
    * Spacing between all grid items (both row and column).
-   * Uses XDS spacing tokens.
+   * Accepts numeric spacing steps (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10)
+   * or legacy string tokens ('space0', 'space1', etc.).
    */
-  gap?: SpacingScale;
+  gap?: SpacingStep | SpacingScale;
 
   /**
    * Spacing between rows. Overrides gap for rows.
-   * Uses XDS spacing tokens.
+   * Accepts numeric spacing steps or legacy string tokens.
    */
-  rowGap?: SpacingScale;
+  rowGap?: SpacingStep | SpacingScale;
 
   /**
    * Spacing between columns. Overrides gap for columns.
-   * Uses XDS spacing tokens.
+   * Accepts numeric spacing steps or legacy string tokens.
    */
-  columnGap?: SpacingScale;
+  columnGap?: SpacingStep | SpacingScale;
 
   /**
    * Vertical alignment of grid items (align-items).
@@ -162,6 +164,9 @@ const gapStyles = stylex.create({
   space1: {
     gap: spacingVars['--spacing-1'],
   },
+  'space1.5': {
+    gap: spacingVars['--spacing-1-5'],
+  },
   space2: {
     gap: spacingVars['--spacing-2'],
   },
@@ -206,6 +211,9 @@ const rowGapStyles = stylex.create({
   },
   space1: {
     rowGap: spacingVars['--spacing-1'],
+  },
+  'space1.5': {
+    rowGap: spacingVars['--spacing-1-5'],
   },
   space2: {
     rowGap: spacingVars['--spacing-2'],
@@ -252,6 +260,9 @@ const columnGapStyles = stylex.create({
   space1: {
     columnGap: spacingVars['--spacing-1'],
   },
+  'space1.5': {
+    columnGap: spacingVars['--spacing-1-5'],
+  },
   space2: {
     columnGap: spacingVars['--spacing-2'],
   },
@@ -287,11 +298,39 @@ const columnGapStyles = stylex.create({
   },
 });
 
+/**
+ * Maps numeric SpacingStep values to their corresponding gap style keys.
+ */
+const numericToGapKey: Record<SpacingStep, SpacingScale> = {
+  0: 'space0',
+  0.5: 'space0.5',
+  1: 'space1',
+  1.5: 'space1.5',
+  2: 'space2',
+  3: 'space3',
+  4: 'space4',
+  5: 'space5',
+  6: 'space6',
+  8: 'space8',
+  10: 'space10',
+};
+
+/**
+ * Resolves a gap value (numeric or legacy string) to a gap style key.
+ */
+function resolveGapKey(gap: SpacingStep | SpacingScale): SpacingScale {
+  if (typeof gap === 'number') {
+    return numericToGapKey[gap as SpacingStep];
+  }
+  return gap;
+}
+
 // Spacing token values in pixels for max-width calculation
 const spacingPixels: Record<SpacingScale, number> = {
   space0: 0,
   'space0.5': 2,
   space1: 4,
+  'space1.5': 6,
   space2: 8,
   space3: 12,
   space4: 16,
@@ -312,14 +351,14 @@ const spacingPixels: Record<SpacingScale, number> = {
 function calculateMaxWidth(
   columns: number,
   minChildWidth: number,
-  gap: SpacingScale | undefined,
-  columnGap: SpacingScale | undefined,
+  gap: SpacingStep | SpacingScale | undefined,
+  columnGap: SpacingStep | SpacingScale | undefined,
 ): number {
   const gapPx =
     columnGap != null
-      ? spacingPixels[columnGap]
+      ? spacingPixels[resolveGapKey(columnGap)]
       : gap != null
-        ? spacingPixels[gap]
+        ? spacingPixels[resolveGapKey(gap)]
         : 0;
   return columns * minChildWidth + (columns - 1) * gapPx;
 }
@@ -335,7 +374,7 @@ function calculateMaxWidth(
  *
  * @example
  * ```
- * <XDSGrid columns={3} gap="space4">
+ * <XDSGrid columns={3} gap={4}>
  *   <Item />
  *   <Item />
  *   <Item />
@@ -403,9 +442,9 @@ export function XDSGrid({
         xdsClassName('grid', {columns, gap, align, justify}),
         stylex.props(
           baseStyles.grid,
-          gap != null && gapStyles[gap],
-          rowGap != null && rowGapStyles[rowGap],
-          columnGap != null && columnGapStyles[columnGap],
+          gap != null && gapStyles[resolveGapKey(gap)],
+          rowGap != null && rowGapStyles[resolveGapKey(rowGap)],
+          columnGap != null && columnGapStyles[resolveGapKey(columnGap)],
           align != null && alignStyles[align],
           justify != null && justifyStyles[justify],
           xstyle,

--- a/packages/core/src/Grid/XDSGridSpan.tsx
+++ b/packages/core/src/Grid/XDSGridSpan.tsx
@@ -78,7 +78,7 @@ const baseStyles = stylex.create({
  *
  * @example
  * ```
- * <XDSGrid columns={3} gap="space4">
+ * <XDSGrid columns={3} gap={4}>
  *   <XDSGridSpan columns={2}>Wide item</XDSGridSpan>
  *   <div>Normal</div>
  * </XDSGrid>

--- a/packages/core/src/Layout/Layout.doc.mjs
+++ b/packages/core/src/Layout/Layout.doc.mjs
@@ -46,7 +46,7 @@ export const docs = {
     content={<XDSLayoutContent>Body content</XDSLayoutContent>}
     footer={
       <XDSLayoutFooter hasDivider>
-        <XDSHStack gap="space2" hAlign="end">
+        <XDSHStack gap={2} hAlign="end">
           <XDSButton variant="secondary">Cancel</XDSButton>
           <XDSButton variant="primary">Save</XDSButton>
         </XDSHStack>
@@ -353,7 +353,7 @@ export const docs = {
     content={<XDSLayoutContent>Body content</XDSLayoutContent>}
     footer={
       <XDSLayoutFooter hasDivider>
-        <XDSHStack gap="space2" hAlign="end">
+        <XDSHStack gap={2} hAlign="end">
           <XDSButton variant="secondary">Cancel</XDSButton>
           <XDSButton variant="primary">Save</XDSButton>
         </XDSHStack>
@@ -383,7 +383,7 @@ export const docs = {
       examples: [
         {
           label: 'Basic',
-          code: `<XDSHStack gap="space2" hAlign="end">
+          code: `<XDSHStack gap={2} hAlign="end">
   <XDSButton variant="secondary">Cancel</XDSButton>
   <XDSButton variant="primary">Save</XDSButton>
 </XDSHStack>`,
@@ -397,7 +397,7 @@ export const docs = {
       examples: [
         {
           label: 'Basic',
-          code: `<XDSVStack gap="space4">
+          code: `<XDSVStack gap={4}>
   <XDSCard>First</XDSCard>
   <XDSCard>Second</XDSCard>
 </XDSVStack>`,

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -23,6 +23,11 @@ import {stack} from '../Stack/stack.stylex';
 import {stackItem} from '../Stack/stackItem.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
+import type {SpacingStep} from '../utils/types';
+import {
+  layoutPaddingOuterXVarStyles,
+  layoutPaddingOuterYVarStyles,
+} from './padding.stylex';
 
 /**
  * Height behavior for the layout.
@@ -89,9 +94,17 @@ export interface XDSLayoutProps extends Omit<XDSBaseProps, 'content'> {
 
   /**
    * Removes padding at layout's outer edges, making layout touch container edges.
+   * @deprecated Use `padding={0}` instead.
    * @default false
    */
   isFullBleed?: boolean;
+
+  /**
+   * Padding at the layout's outer edges using the spacing scale.
+   * Controls both `--layout-padding-outer-x` and `--layout-padding-outer-y`.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   */
+  padding?: SpacingStep;
 
   /**
    * Start panel slot (left in LTR, right in RTL).
@@ -180,6 +193,7 @@ export function XDSLayout({
   header,
   height = 'fill',
   isFullBleed = false,
+  padding,
   start,
   xstyle,
   className,
@@ -216,7 +230,9 @@ export function XDSLayout({
             styles.layoutInner,
             ...stack({direction: 'vertical'}),
             isFill ? styles.fill : styles.auto,
-            isFullBleed && styles.fullBleed,
+            isFullBleed && padding == null && styles.fullBleed,
+            padding != null && layoutPaddingOuterXVarStyles[padding],
+            padding != null && layoutPaddingOuterYVarStyles[padding],
           )}>
           <AreaProvider area="header">{header}</AreaProvider>
           <div

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutContent.tsx
- * @input Uses React, StyleX, XDSLayoutSlotsContext
+ * @input Uses React StyleX, XDSLayoutSlotsContext
  * @output Exports XDSLayoutContent component and XDSLayoutContentProps
  * @position Scrollable main content area for XDSLayout. Wraps the primary body content
  *   with automatic scroll containment and context-aware padding.
@@ -19,6 +19,8 @@ import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutSlotsContext} from './XDSLayoutSlotsContext';
 import {xdsClassName, mergeProps} from '../utils';
+import type {SpacingStep} from '../utils/types';
+import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
 
 const styles = stylex.create({
   content: {
@@ -61,7 +63,6 @@ const styles = stylex.create({
 });
 
 export interface XDSLayoutContentProps extends XDSBaseProps<HTMLDivElement> {
-  /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
    * Content to render inside the content area.
@@ -71,9 +72,17 @@ export interface XDSLayoutContentProps extends XDSBaseProps<HTMLDivElement> {
   /**
    * Removes internal padding, allowing content to touch the edges.
    * Useful for edge-to-edge content like tables.
+   * @deprecated Use `padding={0}` instead.
    * @default false
    */
   isFullBleed?: boolean;
+
+  /**
+   * Internal padding of the content area using the spacing scale.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   * Overrides the default padding from the layout container.
+   */
+  padding?: SpacingStep;
 
   /**
    * Enables scrollable overflow for the content area.
@@ -135,6 +144,7 @@ export function XDSLayoutContent({
   children,
   isFullBleed = false,
   isScrollable = true,
+  padding,
   label,
   role,
   xstyle,
@@ -157,12 +167,14 @@ export function XDSLayoutContent({
         stylex.props(
           styles.content,
           // Outer padding on container edges (unless content is full bleed)
-          !hasStart && !isFullBleed && styles.noStart,
-          !hasEnd && !isFullBleed && styles.noEnd,
-          !hasHeader && !isFullBleed && styles.noHeader,
-          !hasFooter && !isFullBleed && styles.noFooter,
+          !hasStart && !isFullBleed && padding == null && styles.noStart,
+          !hasEnd && !isFullBleed && padding == null && styles.noEnd,
+          !hasHeader && !isFullBleed && padding == null && styles.noHeader,
+          !hasFooter && !isFullBleed && padding == null && styles.noFooter,
           isScrollable && styles.scrollable,
-          isFullBleed && styles.fullBleed,
+          isFullBleed && padding == null && styles.fullBleed,
+          padding != null && paddingStyles[padding],
+          padding != null && containerPaddingInlineVarStyles[padding],
           xstyle,
         ),
         className,

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutFooter.tsx
- * @input Uses React, StyleX
+ * @input Uses React StyleX
  * @output Exports XDSLayoutFooter component and XDSLayoutFooterProps
  * @position Bottom bar / footer area for XDSLayout. Use for action bars,
  *   pagination, status bars, or any fixed-height content at the bottom of a layout.
@@ -12,9 +12,12 @@
 
 import type {AriaRole, ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import {} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {SpacingStep} from '../utils/types';
+import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
 
 const styles = stylex.create({
   footer: {
@@ -51,7 +54,6 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSLayoutFooterProps extends XDSBaseProps<HTMLDivElement> {
-  /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
    * Content to render inside the footer.
@@ -73,9 +75,17 @@ export interface XDSLayoutFooterProps extends XDSBaseProps<HTMLDivElement> {
 
   /**
    * Removes internal padding, allowing content to touch the edges.
+   * @deprecated Use `padding={0}` instead.
    * @default false
    */
   isFullBleed?: boolean;
+
+  /**
+   * Internal padding of the footer using the spacing scale.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   * Overrides the default padding from the layout container.
+   */
+  padding?: SpacingStep;
 
   /**
    * Accessible label for the landmark.
@@ -113,6 +123,7 @@ export function XDSLayoutFooter({
   height,
   isFullBleed = false,
   label,
+  padding,
   role,
   xstyle,
   className,
@@ -121,7 +132,7 @@ export function XDSLayoutFooter({
   ...props
 }: XDSLayoutFooterProps) {
   // When no divider, collapse spacing for seamless visual flow
-  const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+  const shouldCollapseSpacing = !hasDivider && !isFullBleed && padding == null;
 
   return (
     <div
@@ -133,7 +144,9 @@ export function XDSLayoutFooter({
         stylex.props(
           styles.footer,
           dynamicStyles.sizing(height ?? null),
-          isFullBleed && styles.fullBleed,
+          isFullBleed && padding == null && styles.fullBleed,
+          padding != null && paddingStyles[padding],
+          padding != null && containerPaddingInlineVarStyles[padding],
           hasDivider && styles.divider,
           shouldCollapseSpacing && styles.collapseTop,
           xstyle,

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutHeader.tsx
- * @input Uses React, StyleX
+ * @input Uses React StyleX
  * @output Exports XDSLayoutHeader component and XDSLayoutHeaderProps
  * @position Top bar / header area for XDSLayout. Use for page titles, app bars,
  *   toolbar areas, or any fixed-height content at the top of a layout.
@@ -12,9 +12,12 @@
 
 import type {AriaRole, ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
+import {} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {SpacingStep} from '../utils/types';
+import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
 
 const styles = stylex.create({
   header: {
@@ -51,7 +54,6 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSLayoutHeaderProps extends XDSBaseProps<HTMLDivElement> {
-  /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
    * Content to render inside the header.
@@ -73,9 +75,17 @@ export interface XDSLayoutHeaderProps extends XDSBaseProps<HTMLDivElement> {
 
   /**
    * Removes internal padding, allowing content to touch the edges.
+   * @deprecated Use `padding={0}` instead.
    * @default false
    */
   isFullBleed?: boolean;
+
+  /**
+   * Internal padding of the header using the spacing scale.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   * Overrides the default padding from the layout container.
+   */
+  padding?: SpacingStep;
 
   /**
    * Accessible label for the landmark.
@@ -113,6 +123,7 @@ export function XDSLayoutHeader({
   height,
   isFullBleed = false,
   label,
+  padding,
   role,
   xstyle,
   className,
@@ -121,7 +132,7 @@ export function XDSLayoutHeader({
   ...props
 }: XDSLayoutHeaderProps) {
   // When no divider, collapse spacing for seamless visual flow
-  const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+  const shouldCollapseSpacing = !hasDivider && !isFullBleed && padding == null;
 
   return (
     <div
@@ -133,7 +144,9 @@ export function XDSLayoutHeader({
         stylex.props(
           styles.header,
           dynamicStyles.sizing(height ?? null),
-          isFullBleed && styles.fullBleed,
+          isFullBleed && padding == null && styles.fullBleed,
+          padding != null && paddingStyles[padding],
+          padding != null && containerPaddingInlineVarStyles[padding],
           hasDivider && styles.divider,
           shouldCollapseSpacing && styles.collapseBottom,
           xstyle,

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -1,6 +1,6 @@
 /**
  * @file XDSLayoutPanel.tsx
- * @input Uses React, StyleX, XDSLayoutAreaContext, XDSLayoutSlotsContext
+ * @input Uses React StyleX, XDSLayoutAreaContext, XDSLayoutSlotsContext
  * @output Exports XDSLayoutPanel component and XDSLayoutPanelProps
  * @position Sidebar panel for XDSLayout start/end slots. Use for navigation panels,
  *   settings sidebars, detail panels, or any fixed-width side content.
@@ -20,6 +20,8 @@ import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutAreaContext} from './XDSLayoutAreaContext';
 import {XDSLayoutSlotsContext} from './XDSLayoutSlotsContext';
 import {xdsClassName, mergeProps} from '../utils';
+import type {SpacingStep} from '../utils/types';
+import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
 
 const styles = stylex.create({
   panel: {
@@ -88,7 +90,6 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSLayoutPanelProps extends XDSBaseProps<HTMLDivElement> {
-  /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   /**
    * Content to render inside the panel.
@@ -106,9 +107,17 @@ export interface XDSLayoutPanelProps extends XDSBaseProps<HTMLDivElement> {
 
   /**
    * Removes internal padding, allowing content to touch the edges.
+   * @deprecated Use `padding={0}` instead.
    * @default false
    */
   isFullBleed?: boolean;
+
+  /**
+   * Internal padding of the panel using the spacing scale.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   * Overrides the default padding from the layout container.
+   */
+  padding?: SpacingStep;
 
   /**
    * Enables scrollable overflow for the panel.
@@ -171,6 +180,7 @@ export function XDSLayoutPanel({
   isFullBleed = false,
   isScrollable = true,
   label,
+  padding,
   role,
   width,
   xstyle,
@@ -187,7 +197,7 @@ export function XDSLayoutPanel({
   const isEndPanel = area === 'end';
 
   // When no divider, collapse spacing for seamless visual flow
-  const shouldCollapseSpacing = !hasDivider && !isFullBleed;
+  const shouldCollapseSpacing = !hasDivider && !isFullBleed && padding == null;
 
   // Select divider style based on position
   const dividerStyle = isStartPanel
@@ -214,12 +224,14 @@ export function XDSLayoutPanel({
           styles.panel,
           dynamicStyles.sizing(width ?? null),
           // Outer padding on container edges (unless component is full bleed)
-          isStartPanel && !isFullBleed && styles.startPanel,
-          isEndPanel && !isFullBleed && styles.endPanel,
-          !hasHeader && !isFullBleed && styles.noHeader,
-          !hasFooter && !isFullBleed && styles.noFooter,
+          isStartPanel && !isFullBleed && padding == null && styles.startPanel,
+          isEndPanel && !isFullBleed && padding == null && styles.endPanel,
+          !hasHeader && !isFullBleed && padding == null && styles.noHeader,
+          !hasFooter && !isFullBleed && padding == null && styles.noFooter,
           isScrollable && styles.scrollable,
-          isFullBleed && styles.fullBleed,
+          isFullBleed && padding == null && styles.fullBleed,
+          padding != null && paddingStyles[padding],
+          padding != null && containerPaddingInlineVarStyles[padding],
           hasDivider && dividerStyle,
           shouldCollapseSpacing && collapseStyle,
           xstyle,

--- a/packages/core/src/Layout/container.stylex.ts
+++ b/packages/core/src/Layout/container.stylex.ts
@@ -17,6 +17,7 @@ export type SpacingToken =
   | 'spacing0'
   | 'spacing0_5'
   | 'spacing1'
+  | 'spacing1_5'
   | 'spacing2'
   | 'spacing3'
   | 'spacing4'
@@ -45,6 +46,7 @@ const containerPaddingStyles = stylex.create({
   spacing0: {'--container-padding': spacingVars['--spacing-0']},
   spacing0_5: {'--container-padding': spacingVars['--spacing-0-5']},
   spacing1: {'--container-padding': spacingVars['--spacing-1']},
+  spacing1_5: {'--container-padding': spacingVars['--spacing-1-5']},
   spacing2: {'--container-padding': spacingVars['--spacing-2']},
   spacing3: {'--container-padding': spacingVars['--spacing-3']},
   spacing4: {'--container-padding': spacingVars['--spacing-4']},
@@ -69,6 +71,7 @@ const containerPaddingInlineStyles = stylex.create({
   spacing0: {'--container-padding-inline': spacingVars['--spacing-0']},
   spacing0_5: {'--container-padding-inline': spacingVars['--spacing-0-5']},
   spacing1: {'--container-padding-inline': spacingVars['--spacing-1']},
+  spacing1_5: {'--container-padding-inline': spacingVars['--spacing-1-5']},
   spacing2: {'--container-padding-inline': spacingVars['--spacing-2']},
   spacing3: {'--container-padding-inline': spacingVars['--spacing-3']},
   spacing4: {'--container-padding-inline': spacingVars['--spacing-4']},
@@ -86,6 +89,7 @@ const paddingOuterXStyles = stylex.create({
   spacing0: {'--layout-padding-outer-x': spacingVars['--spacing-0']},
   spacing0_5: {'--layout-padding-outer-x': spacingVars['--spacing-0-5']},
   spacing1: {'--layout-padding-outer-x': spacingVars['--spacing-1']},
+  spacing1_5: {'--layout-padding-outer-x': spacingVars['--spacing-1-5']},
   spacing2: {'--layout-padding-outer-x': spacingVars['--spacing-2']},
   spacing3: {'--layout-padding-outer-x': spacingVars['--spacing-3']},
   spacing4: {'--layout-padding-outer-x': spacingVars['--spacing-4']},
@@ -103,6 +107,7 @@ const paddingOuterYStyles = stylex.create({
   spacing0: {'--layout-padding-outer-y': spacingVars['--spacing-0']},
   spacing0_5: {'--layout-padding-outer-y': spacingVars['--spacing-0-5']},
   spacing1: {'--layout-padding-outer-y': spacingVars['--spacing-1']},
+  spacing1_5: {'--layout-padding-outer-y': spacingVars['--spacing-1-5']},
   spacing2: {'--layout-padding-outer-y': spacingVars['--spacing-2']},
   spacing3: {'--layout-padding-outer-y': spacingVars['--spacing-3']},
   spacing4: {'--layout-padding-outer-y': spacingVars['--spacing-4']},
@@ -120,6 +125,7 @@ const paddingInnerXStyles = stylex.create({
   spacing0: {'--layout-padding-inner-x': spacingVars['--spacing-0']},
   spacing0_5: {'--layout-padding-inner-x': spacingVars['--spacing-0-5']},
   spacing1: {'--layout-padding-inner-x': spacingVars['--spacing-1']},
+  spacing1_5: {'--layout-padding-inner-x': spacingVars['--spacing-1-5']},
   spacing2: {'--layout-padding-inner-x': spacingVars['--spacing-2']},
   spacing3: {'--layout-padding-inner-x': spacingVars['--spacing-3']},
   spacing4: {'--layout-padding-inner-x': spacingVars['--spacing-4']},
@@ -137,6 +143,7 @@ const paddingInnerYStyles = stylex.create({
   spacing0: {'--layout-padding-inner-y': spacingVars['--spacing-0']},
   spacing0_5: {'--layout-padding-inner-y': spacingVars['--spacing-0-5']},
   spacing1: {'--layout-padding-inner-y': spacingVars['--spacing-1']},
+  spacing1_5: {'--layout-padding-inner-y': spacingVars['--spacing-1-5']},
   spacing2: {'--layout-padding-inner-y': spacingVars['--spacing-2']},
   spacing3: {'--layout-padding-inner-y': spacingVars['--spacing-3']},
   spacing4: {'--layout-padding-inner-y': spacingVars['--spacing-4']},

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -23,6 +23,7 @@ export type {
   StackMainAlignment,
   StackWrap,
   SpacingScale,
+  SpacingStep,
 } from '../Stack/stack.stylex';
 
 export {stackItem} from '../Stack/stackItem.stylex';

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -1,0 +1,153 @@
+/**
+ * @file padding.stylex.ts
+ * @input Uses @stylexjs/stylex, spacing from theme
+ * @output StyleX styles for numeric padding prop on layout components
+ * @position Layout utility; used by XDSCard, XDSSection, and Layout sub-components
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {spacingVars} from '../theme/tokens.stylex';
+import type {SpacingStep} from '../utils/types';
+
+/**
+ * Maps numeric SpacingStep values to SpacingToken keys used by the container system.
+ */
+export const spacingStepToToken: Record<SpacingStep, string> = {
+  0: 'spacing0',
+  0.5: 'spacing0_5',
+  1: 'spacing1',
+  1.5: 'spacing1_5',
+  2: 'spacing2',
+  3: 'spacing3',
+  4: 'spacing4',
+  5: 'spacing5',
+  6: 'spacing6',
+  8: 'spacing8',
+  10: 'spacing10',
+};
+
+/**
+ * Padding styles for all sides using spacing tokens.
+ * Each key applies uniform padding to all four sides.
+ */
+export const paddingStyles = stylex.create({
+  0: {
+    paddingInlineStart: spacingVars['--spacing-0'],
+    paddingInlineEnd: spacingVars['--spacing-0'],
+    paddingBlockStart: spacingVars['--spacing-0'],
+    paddingBlockEnd: spacingVars['--spacing-0'],
+  },
+  0.5: {
+    paddingInlineStart: spacingVars['--spacing-0-5'],
+    paddingInlineEnd: spacingVars['--spacing-0-5'],
+    paddingBlockStart: spacingVars['--spacing-0-5'],
+    paddingBlockEnd: spacingVars['--spacing-0-5'],
+  },
+  1: {
+    paddingInlineStart: spacingVars['--spacing-1'],
+    paddingInlineEnd: spacingVars['--spacing-1'],
+    paddingBlockStart: spacingVars['--spacing-1'],
+    paddingBlockEnd: spacingVars['--spacing-1'],
+  },
+  1.5: {
+    paddingInlineStart: spacingVars['--spacing-1-5'],
+    paddingInlineEnd: spacingVars['--spacing-1-5'],
+    paddingBlockStart: spacingVars['--spacing-1-5'],
+    paddingBlockEnd: spacingVars['--spacing-1-5'],
+  },
+  2: {
+    paddingInlineStart: spacingVars['--spacing-2'],
+    paddingInlineEnd: spacingVars['--spacing-2'],
+    paddingBlockStart: spacingVars['--spacing-2'],
+    paddingBlockEnd: spacingVars['--spacing-2'],
+  },
+  3: {
+    paddingInlineStart: spacingVars['--spacing-3'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
+    paddingBlockStart: spacingVars['--spacing-3'],
+    paddingBlockEnd: spacingVars['--spacing-3'],
+  },
+  4: {
+    paddingInlineStart: spacingVars['--spacing-4'],
+    paddingInlineEnd: spacingVars['--spacing-4'],
+    paddingBlockStart: spacingVars['--spacing-4'],
+    paddingBlockEnd: spacingVars['--spacing-4'],
+  },
+  5: {
+    paddingInlineStart: spacingVars['--spacing-5'],
+    paddingInlineEnd: spacingVars['--spacing-5'],
+    paddingBlockStart: spacingVars['--spacing-5'],
+    paddingBlockEnd: spacingVars['--spacing-5'],
+  },
+  6: {
+    paddingInlineStart: spacingVars['--spacing-6'],
+    paddingInlineEnd: spacingVars['--spacing-6'],
+    paddingBlockStart: spacingVars['--spacing-6'],
+    paddingBlockEnd: spacingVars['--spacing-6'],
+  },
+  8: {
+    paddingInlineStart: spacingVars['--spacing-8'],
+    paddingInlineEnd: spacingVars['--spacing-8'],
+    paddingBlockStart: spacingVars['--spacing-8'],
+    paddingBlockEnd: spacingVars['--spacing-8'],
+  },
+  10: {
+    paddingInlineStart: spacingVars['--spacing-10'],
+    paddingInlineEnd: spacingVars['--spacing-10'],
+    paddingBlockStart: spacingVars['--spacing-10'],
+    paddingBlockEnd: spacingVars['--spacing-10'],
+  },
+});
+
+/**
+ * Container padding inline CSS variable styles for edge compensation.
+ * Sets --container-padding-inline so edge-compensating children know
+ * the inline padding to compensate against.
+ */
+export const containerPaddingInlineVarStyles = stylex.create({
+  0: {'--container-padding-inline': spacingVars['--spacing-0']},
+  0.5: {'--container-padding-inline': spacingVars['--spacing-0-5']},
+  1: {'--container-padding-inline': spacingVars['--spacing-1']},
+  1.5: {'--container-padding-inline': spacingVars['--spacing-1-5']},
+  2: {'--container-padding-inline': spacingVars['--spacing-2']},
+  3: {'--container-padding-inline': spacingVars['--spacing-3']},
+  4: {'--container-padding-inline': spacingVars['--spacing-4']},
+  5: {'--container-padding-inline': spacingVars['--spacing-5']},
+  6: {'--container-padding-inline': spacingVars['--spacing-6']},
+  8: {'--container-padding-inline': spacingVars['--spacing-8']},
+  10: {'--container-padding-inline': spacingVars['--spacing-10']},
+});
+
+/**
+ * Layout outer X padding CSS variable styles.
+ */
+export const layoutPaddingOuterXVarStyles = stylex.create({
+  0: {'--layout-padding-outer-x': spacingVars['--spacing-0']},
+  0.5: {'--layout-padding-outer-x': spacingVars['--spacing-0-5']},
+  1: {'--layout-padding-outer-x': spacingVars['--spacing-1']},
+  1.5: {'--layout-padding-outer-x': spacingVars['--spacing-1-5']},
+  2: {'--layout-padding-outer-x': spacingVars['--spacing-2']},
+  3: {'--layout-padding-outer-x': spacingVars['--spacing-3']},
+  4: {'--layout-padding-outer-x': spacingVars['--spacing-4']},
+  5: {'--layout-padding-outer-x': spacingVars['--spacing-5']},
+  6: {'--layout-padding-outer-x': spacingVars['--spacing-6']},
+  8: {'--layout-padding-outer-x': spacingVars['--spacing-8']},
+  10: {'--layout-padding-outer-x': spacingVars['--spacing-10']},
+});
+
+/**
+ * Layout outer Y padding CSS variable styles.
+ */
+export const layoutPaddingOuterYVarStyles = stylex.create({
+  0: {'--layout-padding-outer-y': spacingVars['--spacing-0']},
+  0.5: {'--layout-padding-outer-y': spacingVars['--spacing-0-5']},
+  1: {'--layout-padding-outer-y': spacingVars['--spacing-1']},
+  1.5: {'--layout-padding-outer-y': spacingVars['--spacing-1-5']},
+  2: {'--layout-padding-outer-y': spacingVars['--spacing-2']},
+  3: {'--layout-padding-outer-y': spacingVars['--spacing-3']},
+  4: {'--layout-padding-outer-y': spacingVars['--spacing-4']},
+  5: {'--layout-padding-outer-y': spacingVars['--spacing-5']},
+  6: {'--layout-padding-outer-y': spacingVars['--spacing-6']},
+  8: {'--layout-padding-outer-y': spacingVars['--spacing-8']},
+  10: {'--layout-padding-outer-y': spacingVars['--spacing-10']},
+});

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -38,7 +38,7 @@ export const docs = {
     },
     {
       label: 'Full bleed',
-      code: `<XDSSection variant="wash" isFullBleed>
+      code: `<XDSSection variant="wash" padding={0}>
   <XDSLayout
     content={<XDSLayoutContent>Edge-to-edge content</XDSLayoutContent>}
   />

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -16,7 +16,13 @@ import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
-import type {SizeValue} from '../utils/types';
+import type {SpacingToken} from '../Layout/container.stylex';
+import {
+  paddingStyles,
+  containerPaddingInlineVarStyles,
+  spacingStepToToken,
+} from '../Layout/padding.stylex';
+import type {SizeValue, SpacingStep} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
@@ -107,8 +113,7 @@ const dynamicStyles = stylex.create({
 });
 
 export interface XDSSectionProps {
-  /** Ref forwarded to the root element */
-  ref?: React.Ref<HTMLDivElement>;
+  ref?: React.Ref<HTMLElement>;
   /**
    * Visual variant of the section.
    * - 'section': Surface background color
@@ -160,9 +165,17 @@ export interface XDSSectionProps {
 
   /**
    * Removes internal padding, allowing content to touch the edges.
+   * @deprecated Use `padding={0}` instead.
    * @default false
    */
   isFullBleed?: boolean;
+
+  /**
+   * Internal padding of the section using the spacing scale.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   * @default 4 (16px)
+   */
+  padding?: SpacingStep;
 }
 
 /**
@@ -192,12 +205,16 @@ export function XDSSection({
   children,
   dividers,
   isFullBleed = false,
+  padding,
   ref,
   ...props
 }: XDSSectionProps) {
+  // Resolve effective padding: isFullBleed maps to padding=0
+  const effectivePadding = isFullBleed ? 0 : (padding ?? 4);
+  const paddingToken = spacingStepToToken[effectivePadding] as SpacingToken;
   return (
     <div
-      ref={ref}
+      ref={ref as React.Ref<HTMLDivElement>}
       {...mergeProps(
         xdsClassName('section', {variant}),
         stylex.props(
@@ -215,13 +232,15 @@ export function XDSSection({
         {...stylex.props(
           nestedStyles.inner,
           ...container({
-            paddingInnerX: 'spacing4',
-            paddingInnerY: 'spacing4',
-            paddingOuterX: 'spacing4',
-            paddingOuterY: 'spacing4',
+            paddingInnerX: paddingToken,
+            paddingInnerY: paddingToken,
+            paddingOuterX: paddingToken,
+            paddingOuterY: paddingToken,
           }),
+          effectivePadding !== 4 && paddingStyles[effectivePadding],
+          effectivePadding !== 4 &&
+            containerPaddingInlineVarStyles[effectivePadding],
           variantStyles[variant],
-          isFullBleed && nestedStyles.fullBleed,
           dividers?.includes('top') && dividerStyles.top,
           dividers?.includes('bottom') && dividerStyles.bottom,
           dividers?.includes('start') && dividerStyles.start,

--- a/packages/core/src/Spinner/Spinner.doc.mjs
+++ b/packages/core/src/Spinner/Spinner.doc.mjs
@@ -39,7 +39,7 @@ export const docs = {
     },
     {
       label: 'Composing with layout and text',
-      code: `<XDSVStack gap="space2" align="center">
+      code: `<XDSVStack gap={2} align="center">
   <XDSSpinner size="lg" />
   <XDSText color="secondary">Loading...</XDSText>
 </XDSVStack>`,

--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -14,7 +14,7 @@ export const docs = {
   examples: [
     {
       label: 'Header layout',
-      code: `<XDSHStack element="header" gap="space2">
+      code: `<XDSHStack element="header" gap={2}>
   <XDSStackItem size="static">
     <Logo />
   </XDSStackItem>
@@ -28,7 +28,7 @@ export const docs = {
     },
     {
       label: 'Sidebar layout',
-      code: `<XDSHStack gap="space4">
+      code: `<XDSHStack gap={4}>
   <XDSStackItem size="static">
     <Sidebar />
   </XDSStackItem>
@@ -39,7 +39,7 @@ export const docs = {
     },
     {
       label: 'Page layout',
-      code: `<XDSVStack element="main" gap="space6">
+      code: `<XDSVStack element="main" gap={6}>
   <XDSStackItem size="static">
     <PageHeader />
   </XDSStackItem>
@@ -63,7 +63,7 @@ export const docs = {
       code: `import {stack} from '@xds/core/Layout';
 import * as stylex from '@stylexjs/stylex';
 
-<div {...stylex.props(...stack({direction: 'horizontal', gap: 'space2'}))}>
+<div {...stylex.props(...stack({direction: 'horizontal', gap: 2}))}>
   <Child />
   <Child />
 </div>`,
@@ -77,7 +77,7 @@ import * as stylex from '@stylexjs/stylex';
   },
   notes: [
     "Import from '@xds/core/Layout': XDSHStack, XDSVStack, XDSStackItem, stack, stackItem.",
-    'The gap prop accepts spacing tokens: space0, space0.5, space1, space2, space3, space4, space5, space6, space7.',
+    'The gap prop accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
     'stack and stackItem are low-level StyleX utilities for advanced cases where the component API is insufficient.',
   ],
   components: [
@@ -88,9 +88,9 @@ import * as stylex from '@stylexjs/stylex';
       props: [
         {
           name: 'gap',
-          type: 'SpacingScale',
+          type: 'SpacingStep',
           description:
-            'Spacing token controlling the gap between items: space0, space1, space2, space3, space4, space5, space6, space7.',
+            'Numeric spacing step controlling the gap between items: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
         },
         {
           name: 'vAlign',
@@ -119,21 +119,21 @@ import * as stylex from '@stylexjs/stylex';
       examples: [
         {
           label: 'Basic horizontal stack',
-          code: `<XDSHStack gap="space2">
+          code: `<XDSHStack gap={2}>
   <Item />
   <Item />
 </XDSHStack>`,
         },
         {
           label: 'With vertical alignment',
-          code: `<XDSHStack gap="space4" vAlign="center">
+          code: `<XDSHStack gap={4} vAlign="center">
   <Item />
   <Item />
 </XDSHStack>`,
         },
         {
           label: 'Polymorphic rendering',
-          code: `<XDSHStack element="nav" gap="space2">
+          code: `<XDSHStack element="nav" gap={2}>
   <Link />
   <Link />
 </XDSHStack>`,
@@ -147,9 +147,9 @@ import * as stylex from '@stylexjs/stylex';
       props: [
         {
           name: 'gap',
-          type: 'SpacingScale',
+          type: 'SpacingStep',
           description:
-            'Spacing token controlling the gap between items: space0, space1, space2, space3, space4, space5, space6, space7.',
+            'Numeric spacing step controlling the gap between items: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
         },
         {
           name: 'hAlign',
@@ -178,21 +178,21 @@ import * as stylex from '@stylexjs/stylex';
       examples: [
         {
           label: 'Basic vertical stack',
-          code: `<XDSVStack gap="space2">
+          code: `<XDSVStack gap={2}>
   <Item />
   <Item />
 </XDSVStack>`,
         },
         {
           label: 'With horizontal alignment',
-          code: `<XDSVStack gap="space4" hAlign="center">
+          code: `<XDSVStack gap={4} hAlign="center">
   <Item />
   <Item />
 </XDSVStack>`,
         },
         {
           label: 'Polymorphic rendering',
-          code: `<XDSVStack element="main" gap="space4">
+          code: `<XDSVStack element="main" gap={4}>
   <Header />
   <Content />
 </XDSVStack>`,
@@ -232,7 +232,7 @@ import * as stylex from '@stylexjs/stylex';
       examples: [
         {
           label: 'Static and fill sizing',
-          code: `<XDSHStack gap="space2">
+          code: `<XDSHStack gap={2}>
   <XDSStackItem size="static">Logo</XDSStackItem>
   <XDSStackItem size="fill">Content</XDSStackItem>
   <XDSStackItem size="static">Actions</XDSStackItem>
@@ -266,9 +266,9 @@ import * as stylex from '@stylexjs/stylex';
         },
         {
           name: 'gap',
-          type: 'SpacingScale',
+          type: 'SpacingStep',
           description:
-            'Spacing token controlling the gap between items: space0, space1, space2, space3, space4, space5, space6, space7.',
+            'Numeric spacing step controlling the gap between items: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.',
         },
         {
           name: 'crossAlign',
@@ -288,7 +288,7 @@ import * as stylex from '@stylexjs/stylex';
           code: `import {stack} from '@xds/core/Layout';
 import * as stylex from '@stylexjs/stylex';
 
-<div {...stylex.props(...stack({direction: 'horizontal', gap: 'space2'}))}>
+<div {...stylex.props(...stack({direction: 'horizontal', gap: 2}))}>
   <Child />
   <Child />
 </div>`,

--- a/packages/core/src/Stack/XDSHStack.test.tsx
+++ b/packages/core/src/Stack/XDSHStack.test.tsx
@@ -41,7 +41,7 @@ describe('XDSHStack', () => {
 
   it('renders with gap prop', () => {
     render(
-      <XDSHStack gap="space4">
+      <XDSHStack gap={4}>
         <div>Item 1</div>
         <div>Item 2</div>
       </XDSHStack>,

--- a/packages/core/src/Stack/XDSHStack.tsx
+++ b/packages/core/src/Stack/XDSHStack.tsx
@@ -42,7 +42,7 @@ export interface XDSHStackProps extends Omit<
  *
  * @example
  * ```
- * <XDSHStack gap="space2">
+ * <XDSHStack gap={2}>
  *   <Item />
  *   <Item />
  * </XDSHStack>

--- a/packages/core/src/Stack/XDSStack.test.tsx
+++ b/packages/core/src/Stack/XDSStack.test.tsx
@@ -75,7 +75,7 @@ describe('XDSStack', () => {
 
   it('renders with gap prop', () => {
     render(
-      <XDSStack direction="vertical" gap="space4">
+      <XDSStack direction="vertical" gap={4}>
         <div>Item 1</div>
         <div>Item 2</div>
       </XDSStack>,

--- a/packages/core/src/Stack/XDSStack.tsx
+++ b/packages/core/src/Stack/XDSStack.tsx
@@ -27,6 +27,7 @@ import {
   type StackMainAlignment,
   type StackWrap,
   type SpacingScale,
+  type SpacingStep,
 } from './stack.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -71,10 +72,11 @@ export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
   vAlign?: StackAlignment;
 
   /**
-   * Spacing between items using theme spacing tokens.
-   * Use token names: 'space0', 'space1', 'space2', 'space3', 'space4', 'space5', 'space6', 'space7'
+   * Spacing between items.
+   * Accepts numeric spacing steps (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10)
+   * or legacy string tokens ('space0', 'space1', etc.).
    */
-  gap?: SpacingScale;
+  gap?: SpacingStep | SpacingScale;
 
   /**
    * Whether items should wrap.
@@ -132,11 +134,11 @@ export interface XDSStackProps extends XDSBaseProps<HTMLDivElement> {
  *
  * @example
  * ```
- * <XDSStack direction="vertical" gap="space2">
+ * <XDSStack direction="vertical" gap={2}>
  *   <Item />
  *   <Item />
  * </XDSStack>
- * <XDSStack direction="horizontal" gap="space4" vAlign="center">
+ * <XDSStack direction="horizontal" gap={4} vAlign="center">
  *   <Item />
  *   <Item />
  * </XDSStack>

--- a/packages/core/src/Stack/XDSStackItem.tsx
+++ b/packages/core/src/Stack/XDSStackItem.tsx
@@ -86,7 +86,7 @@ export interface XDSStackItemProps extends XDSBaseProps<HTMLDivElement> {
  *
  * @example
  * ```
- * <XDSHStack gap="space2">
+ * <XDSHStack gap={2}>
  *   <XDSStackItem size="static">Logo</XDSStackItem>
  *   <XDSStackItem size="fill">Content</XDSStackItem>
  *   <XDSStackItem size="static">Actions</XDSStackItem>

--- a/packages/core/src/Stack/XDSVStack.test.tsx
+++ b/packages/core/src/Stack/XDSVStack.test.tsx
@@ -41,7 +41,7 @@ describe('XDSVStack', () => {
 
   it('renders with gap prop', () => {
     render(
-      <XDSVStack gap="space4">
+      <XDSVStack gap={4}>
         <div>Item 1</div>
         <div>Item 2</div>
       </XDSVStack>,

--- a/packages/core/src/Stack/XDSVStack.tsx
+++ b/packages/core/src/Stack/XDSVStack.tsx
@@ -42,7 +42,7 @@ export interface XDSVStackProps extends Omit<
  *
  * @example
  * ```
- * <XDSVStack gap="space2">
+ * <XDSVStack gap={2}>
  *   <Item />
  *   <Item />
  * </XDSVStack>

--- a/packages/core/src/Stack/stack.stylex.ts
+++ b/packages/core/src/Stack/stack.stylex.ts
@@ -9,6 +9,7 @@
 
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
+import type {SpacingStep} from '../utils/types';
 
 const alignItemsStyles = stylex.create({
   center: {
@@ -119,6 +120,10 @@ const gapStyles = stylex.create({
     columnGap: spacingVars['--spacing-1'],
     rowGap: spacingVars['--spacing-1'],
   },
+  'space1.5': {
+    columnGap: spacingVars['--spacing-1-5'],
+    rowGap: spacingVars['--spacing-1-5'],
+  },
   space2: {
     columnGap: spacingVars['--spacing-2'],
     rowGap: spacingVars['--spacing-2'],
@@ -167,9 +172,40 @@ const gapStyles = stylex.create({
 
 /**
  * Spacing token names for gap values.
- * These match the theme's spacing token names.
+ * @deprecated Use numeric `SpacingStep` values instead (e.g., `2` instead of `'space2'`).
  */
 export type SpacingScale = keyof typeof gapStyles;
+
+/**
+ * Maps numeric SpacingStep values to their corresponding gapStyles keys.
+ */
+const numericToGapKey: Record<SpacingStep, keyof typeof gapStyles> = {
+  0: 'space0',
+  0.5: 'space0.5',
+  1: 'space1',
+  1.5: 'space1.5',
+  2: 'space2',
+  3: 'space3',
+  4: 'space4',
+  5: 'space5',
+  6: 'space6',
+  8: 'space8',
+  10: 'space10',
+};
+
+/**
+ * Resolves a gap value (numeric or legacy string) to a gapStyles key.
+ */
+function resolveGapKey(
+  gap: SpacingStep | SpacingScale,
+): keyof typeof gapStyles {
+  if (typeof gap === 'number') {
+    return numericToGapKey[gap as SpacingStep];
+  }
+  return gap;
+}
+
+export {type SpacingStep};
 
 export interface StackOptions {
   /**
@@ -185,10 +221,11 @@ export interface StackOptions {
   direction: StackDirection;
 
   /**
-   * Spacing between items using theme spacing tokens.
-   * Use token names: 'space0', 'space1', 'space2', etc.
+   * Spacing between items.
+   * Accepts numeric spacing steps (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10)
+   * or legacy string tokens ('space0', 'space1', etc.).
    */
-  gap?: SpacingScale;
+  gap?: SpacingStep | SpacingScale;
 
   /**
    * Position of items along the main-axis.
@@ -215,8 +252,8 @@ export interface StackOptions {
  * import { stack } from '@xds/core/Layout';
  * import * as stylex from '@stylexjs/stylex';
  *
- * // Horizontal stack with gap
- * <div {...stylex.props(...stack({ direction: 'horizontal', gap: 'space2' }))}>
+ * // Horizontal stack with numeric gap
+ * <div {...stylex.props(...stack({ direction: 'horizontal', gap: 2 }))}>
  *   <Child />
  *   <Child />
  * </div>
@@ -228,7 +265,7 @@ export interface StackOptions {
  * </div>
  *
  * // Wrapping horizontal stack with larger gap
- * <div {...stylex.props(...stack({ direction: 'horizontal', gap: 'space4', wrap: 'wrap' }))}>
+ * <div {...stylex.props(...stack({ direction: 'horizontal', gap: 4, wrap: 'wrap' }))}>
  *   <Child />
  *   <Child />
  *   <Child />
@@ -245,7 +282,7 @@ export function stack({
   return [
     baseStyles.stack,
     directionStyles[direction],
-    gap != null && gapStyles[gap],
+    gap != null && gapStyles[resolveGapKey(gap)],
     crossAlign != null && alignItemsStyles[crossAlign],
     mainAlign != null && justifyContentStyles[mainAlign],
     wrap != null && wrapStyles[wrap],

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -27,9 +27,9 @@ export const docs = {
       key: 'name',
       header: 'Name',
       renderCell: user => (
-        <XDSHStack gap="space2" align="center">
+        <XDSHStack gap={2} align="center">
           <XDSAvatar name={user.name} size="small" />
-          <XDSVStack gap="space1">
+          <XDSVStack gap={1}>
             <XDSText type="body" weight="semibold">
               {user.name}
             </XDSText>
@@ -45,7 +45,7 @@ export const docs = {
       header: 'Status',
       width: pixel(140),
       renderCell: user => (
-        <XDSHStack gap="space2" align="center">
+        <XDSHStack gap={2} align="center">
           <XDSStatusDot status={user.isActive ? 'positive' : 'negative'} />
           <XDSBadge variant={user.isActive ? 'success' : 'error'}>
             {user.isActive ? 'Active' : 'Inactive'}
@@ -82,7 +82,7 @@ export const docs = {
       key: 'description',
       header: 'Transaction',
       renderCell: tx => (
-        <XDSVStack gap="space1">
+        <XDSVStack gap={1}>
           <XDSText weight="semibold">{tx.description}</XDSText>
           <XDSText type="supporting" color="secondary">
             {tx.date}
@@ -129,7 +129,7 @@ export const docs = {
       code: `<XDSTable density="balanced" dividers="rows" isStriped hasHover>
   <XDSTableRow>
     <XDSTableCell>
-      <XDSHStack gap="space2" align="center">
+      <XDSHStack gap={2} align="center">
         <XDSAvatar name="Alice" size="small" />
         <XDSText weight="semibold">Alice</XDSText>
       </XDSHStack>

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -165,7 +165,7 @@ function XDSTableInner<T extends Record<string, unknown>>({
  *   data={users}
  *   columns={[
  *     { key: 'name', header: 'Name', renderCell: (u) => (
- *       <XDSHStack gap="space2" align="center">
+ *       <XDSHStack gap={2} align="center">
  *         <XDSAvatar name={u.name} size="small" />
  *         <XDSText weight="semibold">{u.name}</XDSText>
  *       </XDSHStack>

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -74,7 +74,7 @@ export interface XDSTableColumn<T extends Record<string, unknown>> {
    * @example
    * ```tsx
    * renderCell: (item) => (
-   *   <XDSHStack gap="space2" align="center">
+   *   <XDSHStack gap={2} align="center">
    *     <XDSStatusDot status={item.isActive ? 'positive' : 'negative'} />
    *     <XDSBadge variant={item.isActive ? 'success' : 'error'}>
    *       {item.isActive ? 'Active' : 'Inactive'}

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -148,6 +148,7 @@ export const spacingDefaults = {
   '--spacing-0': '0px',
   '--spacing-0-5': '2px',
   '--spacing-1': '4px',
+  '--spacing-1-5': '6px',
   '--spacing-2': '8px',
   '--spacing-3': '12px',
   '--spacing-4': '16px',

--- a/packages/core/src/utils/types.ts
+++ b/packages/core/src/utils/types.ts
@@ -9,3 +9,21 @@
  * Size value type - accepts numbers (treated as pixels) or strings (e.g., '100%', '50vh').
  */
 export type SizeValue = number | string;
+
+/**
+ * Numeric spacing step from the XDS spacing scale.
+ *
+ * Maps to CSS spacing tokens:
+ * - 0 = 0px (--spacing-0)
+ * - 0.5 = 2px (--spacing-0-5)
+ * - 1 = 4px (--spacing-1)
+ * - 1.5 = 6px (--spacing-1-5)
+ * - 2 = 8px (--spacing-2)
+ * - 3 = 12px (--spacing-3)
+ * - 4 = 16px (--spacing-4)
+ * - 5 = 20px (--spacing-5)
+ * - 6 = 24px (--spacing-6)
+ * - 8 = 32px (--spacing-8)
+ * - 10 = 40px (--spacing-10)
+ */
+export type SpacingStep = 0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10;


### PR DESCRIPTION
## Summary

Introduces a numeric spacing scale for the `gap` and `padding` props across layout components. This replaces string tokens (`'space0'` through `'space10'`) with numeric values (`0` through `10`) for a more intuitive API.

### SpacingStep type

```ts
type SpacingStep = 0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10;
```

Maps to CSS spacing tokens: 0 = 0px, 0.5 = 2px, 1 = 4px, 1.5 = 6px, 2 = 8px, 3 = 12px, 4 = 16px, 5 = 20px, 6 = 24px, 8 = 32px, 10 = 40px.

## Changes

### 1. Numeric `gap` on Stack and Grid

**Before:** `<XDSStack gap="space4">` / `<XDSGrid gap="space4">`
**After:** `<XDSStack gap={4}>` / `<XDSGrid gap={4}>`

- String tokens still work (deprecated, backward compat)
- Same for `rowGap` and `columnGap` on Grid
- Added `SpacingStep` type exported from `@xds/core/Layout`
- Added `--spacing-1-5` (6px) token to theme

### 2. Numeric `padding` on layout components

Added `padding?: SpacingStep` to:
- **XDSCard** (default: 4 = 16px)
- **XDSSection** (default: 4 = 16px)
- **XDSLayout** (controls `--layout-padding-outer-x/y`)
- **XDSLayoutContent**
- **XDSLayoutHeader**
- **XDSLayoutFooter**
- **XDSLayoutPanel**

`isFullBleed` is deprecated with `@deprecated Use padding={0} instead` JSDoc on all layout components. **XDSDivider's `isFullBleed` is NOT touched** — it uses negative margins for a different purpose.

### 3. Codemods

Two new codemods in `packages/cli/src/codemods/transforms/v0.0.2/`:

- **`migrate-gap-to-numeric`**: `gap="space4"` → `gap={4}`
- **`migrate-isFullBleed-to-padding`**: `isFullBleed` → `padding={0}`

27 tests covering both codemods.

### 4. Stories and docs

All stories and doc files updated to use numeric gap values. Doc files updated with new prop types and descriptions.

## Files changed (64)

| Category | Files |
|----------|-------|
| Core types | `utils/types.ts`, `theme/tokens.stylex.ts` |
| Stack | `stack.stylex.ts`, `XDSStack.tsx`, `XDSHStack.tsx`, `XDSVStack.tsx`, `XDSStackItem.tsx` |
| Grid | `XDSGrid.tsx`, `XDSGridSpan.tsx` |
| Layout | `padding.stylex.ts` (new), `container.stylex.ts`, `index.ts`, `XDSLayout.tsx`, `XDSLayoutContent.tsx`, `XDSLayoutHeader.tsx`, `XDSLayoutFooter.tsx`, `XDSLayoutPanel.tsx` |
| Card/Section | `XDSCard.tsx`, `XDSSection.tsx` |
| Codemods | 2 transforms + 2 test files + index update |
| Stories | 14 story files |
| Docs | 7 doc files |
| Examples | 3 example app files |

---
