### PR TITLE
ci: add verify-exports check to catch broken package.json exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,9 @@ jobs:
 
       - run: yarn build
 
+      - name: Verify package exports
+        run: node scripts/verify-exports.mjs
+
       - name: Typecheck component docs
         run: yarn workspace @xds/core typecheck:docs
 
@@ -86,6 +89,9 @@ jobs:
 
       - name: Build core package
         run: yarn build
+
+      - name: Verify package exports
+        run: node scripts/verify-exports.mjs
 
       - name: Build Storybook
         run: yarn workspace @xds/storybook build

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "package:source": "node scripts/package-source.js",
     "changeset": "changeset",
     "version-packages": "changeset version",
+    "verify-exports": "node scripts/verify-exports.mjs",
     "release": "yarn build && changeset publish",
     "prepare": "husky install"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -21,12 +21,6 @@
     },
     "./reset.css": "./src/reset.css",
     "./typography.css": "./src/typography.css",
-    "./theme/tokens.stylex": {
-      "source": "./src/theme/tokens.stylex.ts",
-      "types": "./dist/theme/tokens.stylex.d.ts",
-      "import": "./dist/theme/tokens.stylex.mjs",
-      "require": "./dist/theme/tokens.stylex.js"
-    },
     "./xds.md": "./xds.md",
     "./AppShell": {
       "source": "./src/AppShell/index.ts",

--- a/scripts/verify-exports.mjs
+++ b/scripts/verify-exports.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+/**
+ * verify-exports.mjs
+ *
+ * Verifies that all package.json export fields (main, module, types, exports)
+ * resolve to files that actually exist on disk. Designed to run AFTER `yarn build`
+ * to catch cases where packages point to dist files that weren't produced.
+ *
+ * Exit code 1 if any exports are broken.
+ */
+
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(__dirname, '..');
+
+/** Fields in package.json that should point to real files */
+const TOP_LEVEL_FIELDS = ['main', 'module', 'types'];
+
+/**
+ * Export map conditions that reference source files (not built output).
+ * These are used by bundlers that compile from source — skip them.
+ */
+const SKIP_CONDITIONS = new Set(['source']);
+
+/**
+ * Find all package.json files in packages/ (including nested workspaces like packages/themes/*)
+ */
+function findPackageJsons() {
+  const results = [];
+  const packagesDir = join(rootDir, 'packages');
+
+  function walk(dir, depth = 0) {
+    if (depth > 2) return;
+    const entries = readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === 'src') continue;
+      const pkgJson = join(dir, entry.name, 'package.json');
+      if (existsSync(pkgJson)) {
+        results.push(pkgJson);
+      }
+      // Recurse for nested workspaces (e.g., packages/themes/*)
+      walk(join(dir, entry.name), depth + 1);
+    }
+  }
+
+  walk(packagesDir);
+  return results;
+}
+
+/**
+ * Check if a path resolves to an existing file, relative to the package directory.
+ */
+function checkFile(pkgDir, filePath) {
+  const resolved = resolve(pkgDir, filePath);
+  return existsSync(resolved);
+}
+
+/**
+ * Recursively check an exports map value.
+ * Handles string paths, conditional objects, and nested structures.
+ */
+function checkExportsValue(pkgDir, pkgName, exportKey, value, parentCondition) {
+  const errors = [];
+
+  if (typeof value === 'string') {
+    if (!checkFile(pkgDir, value)) {
+      const label = parentCondition
+        ? `exports["${exportKey}"].${parentCondition}`
+        : `exports["${exportKey}"]`;
+      errors.push(`  ✗ ${label} → ${value} (file not found)`);
+    }
+  } else if (typeof value === 'object' && value !== null) {
+    for (const [condition, conditionValue] of Object.entries(value)) {
+      if (SKIP_CONDITIONS.has(condition)) continue;
+      errors.push(
+        ...checkExportsValue(pkgDir, pkgName, exportKey, conditionValue, condition),
+      );
+    }
+  }
+
+  return errors;
+}
+
+// --- Main ---
+
+const packageJsons = findPackageJsons();
+let totalErrors = 0;
+let packagesChecked = 0;
+
+for (const pkgJsonPath of packageJsons) {
+  const pkgDir = dirname(pkgJsonPath);
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+
+  // Skip private packages
+  if (pkg.private) continue;
+
+  const errors = [];
+
+  // Check top-level fields (main, module, types)
+  for (const field of TOP_LEVEL_FIELDS) {
+    if (pkg[field] && !checkFile(pkgDir, pkg[field])) {
+      errors.push(`  ✗ ${field} → ${pkg[field]} (file not found)`);
+    }
+  }
+
+  // Check exports map
+  if (pkg.exports && typeof pkg.exports === 'object') {
+    for (const [exportKey, exportValue] of Object.entries(pkg.exports)) {
+      errors.push(...checkExportsValue(pkgDir, pkg.name, exportKey, exportValue));
+    }
+  }
+
+  packagesChecked++;
+
+  if (errors.length > 0) {
+    console.error(`\n❌ ${pkg.name} (${pkgJsonPath})`);
+    for (const error of errors) {
+      console.error(error);
+    }
+    totalErrors += errors.length;
+  } else {
+    console.log(`✓ ${pkg.name}`);
+  }
+}
+
+console.log(`\n${packagesChecked} packages checked.`);
+
+if (totalErrors > 0) {
+  console.error(`\n${totalErrors} broken export(s) found. Fix the paths above.`);
+  process.exit(1);
+} else {
+  console.log('All exports resolve to existing files.');
+}


### PR DESCRIPTION
## What

Adds a CI check that verifies all `package.json` export fields (`main`, `module`, `types`, `exports`) resolve to files that actually exist on disk after build. This catches the class of bug we hit during the v0.0.2 release where theme packages had `main`/`types` pointing to `./src/` (raw TypeScript) instead of `./dist/` (compiled output).

## Changes

### New: `scripts/verify-exports.mjs`
Scans all non-private `package.json` files in `packages/` and checks:
- `main`, `module`, `types` fields point to existing files
- All paths in `exports` map resolve to existing files
- Skips `source` conditions (used by bundlers for source compilation)

Run with `yarn verify-exports` (after `yarn build`).

### Fixes found by the new check

The script immediately caught several broken exports:

| Package | Issue |
|---------|-------|
| `@xds/core` | `./theme/tokens.stylex` export pointed to non-existent dist files (tokens are bundled into `./theme` index) — removed |
| `@xds/theme-default` | `main`/`types`/`exports` pointed to `./dist/index.js` but build produces `./dist/default.js` — fixed |
| `@xds/theme-neutral` | Same issue — build produces `./dist/neutral.js` — fixed |
| `@xds/theme-brutalist` | `main`/`types` pointed to `./src/index.ts` instead of `./dist/brutalist.js` — fixed |

### CI integration (manual step needed)

⚠️ The GitHub token doesn't have `workflow` scope, so I couldn't push the CI workflow change. Please add this step to `.github/workflows/ci.yml` in both the `test` and `build` jobs, after `yarn build`:

```yaml
- name: Verify package exports
  run: node scripts/verify-exports.mjs
```

**In the `test` job** — after `- run: yarn build`:
```yaml
      - run: yarn build

      - name: Verify package exports
        run: node scripts/verify-exports.mjs

      - name: Typecheck component docs
```

**In the `build` job** — after `Build core package`:
```yaml
      - name: Build core package
        run: yarn build

      - name: Verify package exports
        run: node scripts/verify-exports.mjs

      - name: Build Storybook
```

## Testing

After `yarn build`, the script passes on all 5 packages:
```
✓ @xds/cli
✓ @xds/core
✓ @xds/theme-brutalist
✓ @xds/theme-default
✓ @xds/theme-neutral

5 packages checked.
All exports resolve to existing files.
```

---
