### PR TITLE
feat(vibe-tests): remove StyleX build dependency from report app

### DIFF
--- a/internal/vibe-tests/app/index.report.html
+++ b/internal/vibe-tests/app/index.report.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>XDS Vibe Test Report</title>
+    <style>
+      #root {
+        min-height: 100%;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.report.tsx"></script>
+  </body>
+</html>

--- a/internal/vibe-tests/app/src/main.report.tsx
+++ b/internal/vibe-tests/app/src/main.report.tsx
@@ -1,0 +1,26 @@
+import React, {Suspense, lazy} from 'react';
+import {createRoot} from 'react-dom/client';
+
+/**
+ * Report entry point — no StyleX build dependency.
+ *
+ * Imports pre-compiled CSS from @xds/core dist and the default theme.
+ * Report components use plain CSS classes (report.css) instead of stylex.create.
+ *
+ * The xds.css and theme.css paths are resolved by Vite aliases in
+ * vite.config.report.ts.
+ */
+import '@xds/core/reset.css';
+import 'xds-css';
+import 'xds-theme-css';
+
+const Report = lazy(() =>
+  import('./report/Report').then(m => ({default: m.Report})),
+);
+
+const root = createRoot(document.getElementById('root')!);
+root.render(
+  <Suspense fallback={<div>Loading report...</div>}>
+    <Report />
+  </Suspense>,
+);

--- a/internal/vibe-tests/app/src/report/CodeModal.tsx
+++ b/internal/vibe-tests/app/src/report/CodeModal.tsx
@@ -1,36 +1,10 @@
-import * as stylex from '@stylexjs/stylex';
 import {XDSDialog} from '@xds/core/Dialog';
 import {XDSVStack} from '@xds/core/Stack';
 import {XDSText} from '@xds/core/Text';
 import {XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
-import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
-
-const styles = stylex.create({
-  header: {
-    padding: spacingVars['--spacing-4'],
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'flex-start',
-  },
-  content: {
-    padding: spacingVars['--spacing-4'],
-    paddingBlockStart: 0,
-  },
-  codeBlock: {
-    fontFamily: 'ui-monospace, "SF Mono", Menlo, monospace',
-    fontSize: '13px',
-    lineHeight: '1.5',
-    backgroundColor: colorVars['--color-wash'],
-    borderRadius: '6px',
-    padding: spacingVars['--spacing-3'],
-    overflow: 'auto',
-    maxHeight: '70vh',
-    whiteSpace: 'pre',
-    tabSize: 2,
-  },
-});
+import './report.css';
 
 interface CodeModalProps {
   isOpen: boolean;
@@ -58,7 +32,7 @@ export function CodeModal({
       purpose="info"
       width={800}
       aria-label={`${targetLabel} code for ${promptId}`}>
-      <div {...stylex.props(styles.header)}>
+      <div className="report-codeModal-header">
         <XDSVStack gap="space1">
           <XDSHeading level={3}>
             {promptId} — {targetLabel}
@@ -73,8 +47,8 @@ export function CodeModal({
           onClick={onHide}
         />
       </div>
-      <div {...stylex.props(styles.content)}>
-        <div {...stylex.props(styles.codeBlock)}>{code}</div>
+      <div className="report-codeModal-content">
+        <div className="report-codeModal-codeBlock">{code}</div>
       </div>
     </XDSDialog>
   );

--- a/internal/vibe-tests/app/src/report/CompareView.tsx
+++ b/internal/vibe-tests/app/src/report/CompareView.tsx
@@ -1,63 +1,17 @@
-import * as stylex from '@stylexjs/stylex';
 import {XDSCard} from '@xds/core/Card';
 import {XDSVStack} from '@xds/core/Stack';
 import {XDSText} from '@xds/core/Text';
 import {XDSHeading} from '@xds/core/Text';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSTable} from '@xds/core/Table';
-import type {XDSTableColumn} from '@xds/core/Table/types';
-import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
+import type {XDSTableColumn} from '@xds/core/Table';
 import type {
   UniversalComparison,
   UniversalDimension,
   CostMetrics,
 } from './types';
 import {ALL_DIMENSIONS, DIMENSION_LABELS, formatScore} from './utils';
-
-const styles = stylex.create({
-  summaryGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(3, 1fr)',
-    gap: spacingVars['--spacing-3'],
-  },
-  summaryGrid4: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(4, 1fr)',
-    gap: spacingVars['--spacing-3'],
-  },
-  winCard: {
-    padding: spacingVars['--spacing-3'],
-    textAlign: 'center',
-  },
-  positive: {
-    color: colorVars['--color-positive'],
-  },
-  negative: {
-    color: colorVars['--color-negative'],
-  },
-  neutral: {
-    color: colorVars['--color-text-secondary'],
-  },
-  warning: {
-    color: colorVars['--color-warning'],
-  },
-  costGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
-    gap: spacingVars['--spacing-3'],
-  },
-  costCard: {
-    padding: spacingVars['--spacing-3'],
-  },
-  costLabel: {
-    marginBlockEnd: spacingVars['--spacing-1'],
-  },
-  costValues: {
-    display: 'flex',
-    gap: spacingVars['--spacing-3'],
-    alignItems: 'baseline',
-  },
-});
+import './report.css';
 
 type WinnerType = 'xds' | 'baseline' | 'html' | 'tie';
 
@@ -139,6 +93,12 @@ function winnerLabel(w: string): string {
     default:
       return 'Tie';
   }
+}
+
+function deltaClassName(delta: number): string {
+  if (delta > 0) return 'report-color-positive';
+  if (delta < 0) return 'report-color-negative';
+  return 'report-color-neutral';
 }
 
 function CostComparisonSection({
@@ -350,15 +310,7 @@ export function CompareView({comparison}: CompareViewProps) {
       key: 'delta',
       header: 'Delta (XDS−Base)',
       renderCell: row => (
-        <XDSText
-          type="body"
-          xstyle={
-            row.delta > 0
-              ? styles.positive
-              : row.delta < 0
-                ? styles.negative
-                : styles.neutral
-          }>
+        <XDSText type="body" className={deltaClassName(row.delta)}>
           {row.delta > 0 ? '+' : ''}
           {formatScore(row.delta)}
         </XDSText>
@@ -445,15 +397,7 @@ export function CompareView({comparison}: CompareViewProps) {
       key: 'delta',
       header: 'Delta (XDS−Base)',
       renderCell: row => (
-        <XDSText
-          type="body"
-          xstyle={
-            row.delta > 0
-              ? styles.positive
-              : row.delta < 0
-                ? styles.negative
-                : styles.neutral
-          }>
+        <XDSText type="body" className={deltaClassName(row.delta)}>
           {row.delta > 0 ? '+' : ''}
           {formatScore(row.delta)}
         </XDSText>
@@ -464,47 +408,49 @@ export function CompareView({comparison}: CompareViewProps) {
   return (
     <XDSVStack gap="space4">
       <div
-        {...stylex.props(
-          isThreeWay ? styles.summaryGrid4 : styles.summaryGrid,
-        )}>
+        className={
+          isThreeWay
+            ? 'report-compare-summaryGrid4'
+            : 'report-compare-summaryGrid'
+        }>
         <XDSCard>
-          <div {...stylex.props(styles.winCard)}>
+          <div className="report-compare-winCard">
             <XDSVStack gap="space2">
               <XDSText type="label">XDS Wins</XDSText>
               <XDSHeading level={2}>
-                <span {...stylex.props(styles.positive)}>{xdsWins}</span>
+                <span className="report-color-positive">{xdsWins}</span>
               </XDSHeading>
             </XDSVStack>
           </div>
         </XDSCard>
         <XDSCard>
-          <div {...stylex.props(styles.winCard)}>
+          <div className="report-compare-winCard">
             <XDSVStack gap="space2">
               <XDSText type="label">Baseline Wins</XDSText>
               <XDSHeading level={2}>
-                <span {...stylex.props(styles.negative)}>{baselineWins}</span>
+                <span className="report-color-negative">{baselineWins}</span>
               </XDSHeading>
             </XDSVStack>
           </div>
         </XDSCard>
         {isThreeWay && (
           <XDSCard>
-            <div {...stylex.props(styles.winCard)}>
+            <div className="report-compare-winCard">
               <XDSVStack gap="space2">
                 <XDSText type="label">HTML Wins</XDSText>
                 <XDSHeading level={2}>
-                  <span {...stylex.props(styles.warning)}>{htmlWins}</span>
+                  <span className="report-color-warning">{htmlWins}</span>
                 </XDSHeading>
               </XDSVStack>
             </div>
           </XDSCard>
         )}
         <XDSCard>
-          <div {...stylex.props(styles.winCard)}>
+          <div className="report-compare-winCard">
             <XDSVStack gap="space2">
               <XDSText type="label">Ties</XDSText>
               <XDSHeading level={2}>
-                <span {...stylex.props(styles.neutral)}>{ties}</span>
+                <span className="report-color-neutral">{ties}</span>
               </XDSHeading>
             </XDSVStack>
           </div>

--- a/internal/vibe-tests/app/src/report/DimensionTable.tsx
+++ b/internal/vibe-tests/app/src/report/DimensionTable.tsx
@@ -2,7 +2,7 @@ import {XDSTable} from '@xds/core/Table';
 import {XDSStatusDot} from '@xds/core/StatusDot';
 import {XDSHStack} from '@xds/core/Stack';
 import {XDSText} from '@xds/core/Text';
-import type {XDSTableColumn} from '@xds/core/Table/types';
+import type {XDSTableColumn} from '@xds/core/Table';
 import type {UniversalScore} from './types';
 import {
   ALL_DIMENSIONS,

--- a/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
+++ b/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
@@ -1,4 +1,3 @@
-import * as stylex from '@stylexjs/stylex';
 import {XDSCard} from '@xds/core/Card';
 import {XDSVStack} from '@xds/core/Stack';
 import {XDSText} from '@xds/core/Text';
@@ -7,7 +6,6 @@ import {XDSStatusDot} from '@xds/core/StatusDot';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSButton} from '@xds/core/Button';
 import {XDSDivider} from '@xds/core/Divider';
-import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
 import type {UniversalScore} from './types';
 import {
   ALL_DIMENSIONS,
@@ -15,71 +13,11 @@ import {
   computeOverall,
   scoreToStatusVariant,
 } from './utils';
-
-const styles = stylex.create({
-  card: {
-    padding: spacingVars['--spacing-4'],
-  },
-  header: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-2'],
-  },
-  promptText: {
-    color: colorVars['--color-text-secondary'],
-  },
-  scoreGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(3, 1fr)',
-    gap: spacingVars['--spacing-2'],
-  },
-  scoreItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
-    whiteSpace: 'nowrap',
-  },
-  scoresRow: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: spacingVars['--spacing-3'],
-  },
-  scoresRow3: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr 1fr',
-    gap: spacingVars['--spacing-3'],
-  },
-  scoresRowSingle: {
-    display: 'grid',
-    gridTemplateColumns: '1fr',
-    gap: spacingVars['--spacing-3'],
-  },
-  scoreBlock: {
-    minWidth: 0,
-    overflow: 'hidden',
-  },
-  findingsGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr',
-    gap: `${spacingVars['--spacing-1']} ${spacingVars['--spacing-2']}`,
-    alignItems: 'baseline',
-  },
-  section: {
-    paddingBlockStart: spacingVars['--spacing-2'],
-  },
-  sectionLabel: {
-    paddingBlockEnd: spacingVars['--spacing-1'],
-  },
-  buttonRow: {
-    display: 'flex',
-    gap: spacingVars['--spacing-2'],
-    flexWrap: 'wrap',
-  },
-});
+import './report.css';
 
 function ScoreItem({label, score}: {label: string; score: number}) {
   return (
-    <div {...stylex.props(styles.scoreItem)}>
+    <div className="report-promptDetail-scoreItem">
       <XDSStatusDot
         variant={scoreToStatusVariant(score)}
         label={`${label}: ${score}`}
@@ -94,10 +32,10 @@ function ScoreItem({label, score}: {label: string; score: number}) {
 
 function ScoreSummary({label, score}: {label: string; score: UniversalScore}) {
   return (
-    <div {...stylex.props(styles.scoreBlock)}>
+    <div className="report-promptDetail-scoreBlock">
       <XDSVStack gap="space2">
         <XDSText type="label">{label}</XDSText>
-        <div {...stylex.props(styles.scoreGrid)}>
+        <div className="report-promptDetail-scoreGrid">
           {ALL_DIMENSIONS.map(dim => (
             <ScoreItem
               key={dim}
@@ -125,7 +63,7 @@ function Findings({score}: {score: UniversalScore}) {
   }
 
   return (
-    <div {...stylex.props(styles.findingsGrid)}>
+    <div className="report-promptDetail-findingsGrid">
       {allFindings.map((f, i) => (
         <>
           <XDSBadge
@@ -181,26 +119,26 @@ export function PromptDetailCard({
     previewUrls?.xds || previewUrls?.baseline || previewUrls?.html;
   const hasAnyCode = hasXdsCode || hasBaselineCode || hasHtmlCode;
 
-  const scoresStyle = hasAll
-    ? styles.scoresRow3
+  const scoresClassName = hasAll
+    ? 'report-promptDetail-scoresRow3'
     : hasBoth
-      ? styles.scoresRow
-      : styles.scoresRowSingle;
+      ? 'report-promptDetail-scoresRow'
+      : 'report-promptDetail-scoresRowSingle';
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.card)}>
+      <div className="report-promptDetail-card">
         <XDSVStack gap="space3">
           {/* Header: prompt ID, prompt text, and buttons */}
-          <div {...stylex.props(styles.header)}>
+          <div className="report-promptDetail-header">
             <XDSHeading level={4}>{promptId}</XDSHeading>
             {promptText && (
-              <XDSText type="body" xstyle={styles.promptText}>
+              <XDSText type="body" className="report-promptDetail-promptText">
                 {promptText}
               </XDSText>
             )}
             {(hasAnyPreview || hasAnyCode) && (
-              <div {...stylex.props(styles.buttonRow)}>
+              <div className="report-promptDetail-buttonRow">
                 {previewUrls?.xds && (
                   <XDSButton
                     variant="secondary"
@@ -255,7 +193,7 @@ export function PromptDetailCard({
 
           {/* Score summaries in constrained grid */}
           {(xdsScore || baselineScore || htmlScore) && (
-            <div {...stylex.props(scoresStyle)}>
+            <div className={scoresClassName}>
               {xdsScore && <ScoreSummary label="XDS" score={xdsScore} />}
               {baselineScore && (
                 <ScoreSummary label="Baseline" score={baselineScore} />
@@ -268,8 +206,8 @@ export function PromptDetailCard({
           {xdsScore && (
             <>
               <XDSDivider />
-              <div {...stylex.props(styles.section)}>
-                <div {...stylex.props(styles.sectionLabel)}>
+              <div className="report-promptDetail-section">
+                <div className="report-promptDetail-sectionLabel">
                   <XDSText type="label">XDS Findings</XDSText>
                 </div>
                 <Findings score={xdsScore} />
@@ -280,8 +218,8 @@ export function PromptDetailCard({
           {baselineScore && (
             <>
               <XDSDivider />
-              <div {...stylex.props(styles.section)}>
-                <div {...stylex.props(styles.sectionLabel)}>
+              <div className="report-promptDetail-section">
+                <div className="report-promptDetail-sectionLabel">
                   <XDSText type="label">Baseline Findings</XDSText>
                 </div>
                 <Findings score={baselineScore} />
@@ -292,8 +230,8 @@ export function PromptDetailCard({
           {htmlScore && (
             <>
               <XDSDivider />
-              <div {...stylex.props(styles.section)}>
-                <div {...stylex.props(styles.sectionLabel)}>
+              <div className="report-promptDetail-section">
+                <div className="report-promptDetail-sectionLabel">
                   <XDSText type="label">HTML Findings</XDSText>
                 </div>
                 <Findings score={htmlScore} />

--- a/internal/vibe-tests/app/src/report/Report.tsx
+++ b/internal/vibe-tests/app/src/report/Report.tsx
@@ -1,5 +1,4 @@
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
 import {XDSTheme} from '@xds/core/theme';
 import {XDSVStack} from '@xds/core/Stack';
 import {XDSHStack} from '@xds/core/Stack';
@@ -9,8 +8,7 @@ import {XDSTabList} from '@xds/core/TabList';
 import {XDSTab} from '@xds/core/TabList';
 import {XDSCard} from '@xds/core/Card';
 import {XDSButton} from '@xds/core/Button';
-import {defaultTheme} from '@xds/theme/default';
-import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
+import {defaultTheme} from '@xds/theme-default';
 import type {ReportData} from './types';
 import {ALL_DIMENSIONS, DIMENSION_LABELS} from './utils';
 import {ScoreCard} from './ScoreCard';
@@ -19,48 +17,11 @@ import {PromptDetailCard} from './PromptDetailCard';
 import {CodeModal} from './CodeModal';
 import {CompareView} from './CompareView';
 import {ScreenshotGallery} from './ScreenshotGallery';
-
-const styles = stylex.create({
-  root: {
-    minHeight: '100vh',
-    backgroundColor: colorVars['--color-wash'],
-  },
-  container: {
-    maxWidth: '1200px',
-    marginInline: 'auto',
-    padding: spacingVars['--spacing-5'],
-  },
-  header: {
-    paddingBlock: spacingVars['--spacing-3'],
-  },
-  scoreGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
-    gap: spacingVars['--spacing-3'],
-  },
-  metricsCard: {
-    padding: spacingVars['--spacing-3'],
-  },
-  metricsGrid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(140px, 1fr))',
-    gap: spacingVars['--spacing-3'],
-  },
-  metricItem: {
-    textAlign: 'center',
-  },
-  tabContent: {
-    paddingBlockStart: spacingVars['--spacing-3'],
-  },
-  emptyState: {
-    padding: spacingVars['--spacing-8'],
-    textAlign: 'center',
-  },
-});
+import './report.css';
 
 function MetricValue({label, value}: {label: string; value: string}) {
   return (
-    <div {...stylex.props(styles.metricItem)}>
+    <div className="report-metricItem">
       <XDSVStack gap="space1">
         <XDSText type="label">{label}</XDSText>
         <XDSHeading level={3}>{value}</XDSHeading>
@@ -93,10 +54,10 @@ function EfficiencyMetricsCard({
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.metricsCard)}>
+      <div className="report-metricsCard">
         <XDSVStack gap="space2">
           <XDSHeading level={4}>Efficiency Metrics</XDSHeading>
-          <div {...stylex.props(styles.metricsGrid)}>
+          <div className="report-metricsGrid">
             <MetricValue
               label="Decisions / Element"
               value={avgDecisions.toFixed(1)}
@@ -138,10 +99,10 @@ function MaintainabilityMetricsCard({
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.metricsCard)}>
+      <div className="report-metricsCard">
         <XDSVStack gap="space2">
           <XDSHeading level={4}>Maintainability Metrics</XDSHeading>
-          <div {...stylex.props(styles.metricsGrid)}>
+          <div className="report-metricsGrid">
             <MetricValue
               label="Semantic Ratio"
               value={`${(avgSemantic * 100).toFixed(0)}%`}
@@ -163,10 +124,10 @@ function CostMetricsCard({cost}: {cost: ReportData['universal']['cost']}) {
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.metricsCard)}>
+      <div className="report-metricsCard">
         <XDSVStack gap="space2">
           <XDSHeading level={4}>Cost</XDSHeading>
-          <div {...stylex.props(styles.metricsGrid)}>
+          <div className="report-metricsGrid">
             {cost.avgDurationMs > 0 && (
               <MetricValue
                 label="Avg Duration"
@@ -209,9 +170,9 @@ export function Report() {
   if (!data) {
     return (
       <XDSTheme theme={defaultTheme} mode={themeMode}>
-        <div {...stylex.props(styles.root)}>
-          <div {...stylex.props(styles.container)}>
-            <div {...stylex.props(styles.emptyState)}>
+        <div className="report-root">
+          <div className="report-container">
+            <div className="report-emptyState">
               <XDSVStack gap="space4">
                 <XDSHeading level={2}>No Report Data</XDSHeading>
                 <XDSText type="body">
@@ -230,11 +191,11 @@ export function Report() {
 
   return (
     <XDSTheme theme={defaultTheme} mode={themeMode}>
-      <div {...stylex.props(styles.root)}>
-        <div {...stylex.props(styles.container)}>
+      <div className="report-root">
+        <div className="report-container">
           <XDSVStack gap="space5">
             {/* Header */}
-            <div {...stylex.props(styles.header)}>
+            <div className="report-header">
               <XDSHStack gap="space4" hAlign="between" vAlign="center">
                 <XDSVStack gap="space1">
                   <XDSHeading level={1}>Vibe Test Report</XDSHeading>
@@ -267,7 +228,7 @@ export function Report() {
             </XDSTabList>
 
             {/* Tab Content */}
-            <div {...stylex.props(styles.tabContent)}>
+            <div className="report-tabContent">
               {activeTab === 'overview' && (
                 <XDSVStack gap="space4">
                   {/* Overall score */}
@@ -289,7 +250,7 @@ export function Report() {
                   {/* Dimension scores grid */}
                   <XDSVStack gap="space3">
                     <XDSHeading level={3}>Dimensions</XDSHeading>
-                    <div {...stylex.props(styles.scoreGrid)}>
+                    <div className="report-scoreGrid">
                       {ALL_DIMENSIONS.map(dim => (
                         <ScoreCard
                           key={dim}

--- a/internal/vibe-tests/app/src/report/ScoreCard.tsx
+++ b/internal/vibe-tests/app/src/report/ScoreCard.tsx
@@ -1,33 +1,23 @@
-import * as stylex from '@stylexjs/stylex';
 import {XDSCard} from '@xds/core/Card';
 import {XDSVStack} from '@xds/core/Stack';
 import {XDSHStack} from '@xds/core/Stack';
 import {XDSText} from '@xds/core/Text';
 import {XDSHeading} from '@xds/core/Text';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
-import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
 import {formatScore, scoreToProgressVariant} from './utils';
-
-const styles = stylex.create({
-  card: {
-    padding: spacingVars['--spacing-3'],
-  },
-  deltaPositive: {
-    color: colorVars['--color-positive'],
-  },
-  deltaNegative: {
-    color: colorVars['--color-negative'],
-  },
-  deltaNeutral: {
-    color: colorVars['--color-text-secondary'],
-  },
-});
+import './report.css';
 
 interface ScoreCardProps {
   label: string;
   score: number;
   compareScore?: number;
   compareLabel?: string;
+}
+
+function deltaClassName(delta: number): string {
+  if (delta > 0) return 'report-color-positive';
+  if (delta < 0) return 'report-color-negative';
+  return 'report-color-neutral';
 }
 
 export function ScoreCard({
@@ -40,21 +30,13 @@ export function ScoreCard({
 
   return (
     <XDSCard>
-      <div {...stylex.props(styles.card)}>
+      <div className="report-scoreCard-card">
         <XDSVStack gap="space2">
           <XDSText type="label">{label}</XDSText>
           <XDSHStack gap="space2" hAlign="center">
             <XDSHeading level={2}>{formatScore(score)}</XDSHeading>
             {delta != null && (
-              <XDSText
-                type="supporting"
-                xstyle={
-                  delta > 0
-                    ? styles.deltaPositive
-                    : delta < 0
-                      ? styles.deltaNegative
-                      : styles.deltaNeutral
-                }>
+              <XDSText type="supporting" className={deltaClassName(delta)}>
                 {delta > 0 ? '+' : ''}
                 {formatScore(delta)}
                 {compareLabel ? ` vs ${compareLabel}` : ''}

--- a/internal/vibe-tests/app/src/report/ScreenshotGallery.tsx
+++ b/internal/vibe-tests/app/src/report/ScreenshotGallery.tsx
@@ -1,50 +1,8 @@
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
 import {XDSCard} from '@xds/core/Card';
 import {XDSVStack} from '@xds/core/Stack';
 import {XDSText} from '@xds/core/Text';
-import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
-
-const styles = stylex.create({
-  grid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
-    gap: spacingVars['--spacing-4'],
-  },
-  cardContent: {
-    padding: spacingVars['--spacing-3'],
-  },
-  image: {
-    width: '100%',
-    height: 'auto',
-    display: 'block',
-    cursor: 'pointer',
-    borderRadius: spacingVars['--spacing-1'],
-  },
-  overlay: {
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    right: 0,
-    bottom: 0,
-    backgroundColor: colorVars['--color-overlay'],
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    zIndex: 9999,
-    cursor: 'pointer',
-  },
-  overlayImage: {
-    maxWidth: '90vw',
-    maxHeight: '90vh',
-    objectFit: 'contain',
-  },
-  meta: {
-    display: 'flex',
-    gap: spacingVars['--spacing-2'],
-    flexWrap: 'wrap',
-  },
-});
+import './report.css';
 
 interface ScreenshotGalleryProps {
   screenshots: Record<string, string>;
@@ -89,20 +47,20 @@ export function ScreenshotGallery({screenshots}: ScreenshotGalleryProps) {
 
   return (
     <>
-      <div {...stylex.props(styles.grid)}>
+      <div className="report-gallery-grid">
         {items.map(item => (
           <XDSCard key={item.filename}>
             <XDSVStack gap="space0">
               <img
-                {...stylex.props(styles.image)}
+                className="report-gallery-image"
                 src={item.src}
                 alt={`Screenshot: ${item.promptId}`}
                 onClick={() => setEnlarged(item.src)}
               />
-              <div {...stylex.props(styles.cardContent)}>
+              <div className="report-gallery-cardContent">
                 <XDSVStack gap="space1">
                   <XDSText type="label">{item.promptId}</XDSText>
-                  <div {...stylex.props(styles.meta)}>
+                  <div className="report-gallery-meta">
                     <XDSText type="supporting">{item.viewport}</XDSText>
                     <XDSText type="supporting">{item.theme}</XDSText>
                   </div>
@@ -114,10 +72,10 @@ export function ScreenshotGallery({screenshots}: ScreenshotGalleryProps) {
       </div>
       {enlarged && (
         <div
-          {...stylex.props(styles.overlay)}
+          className="report-gallery-overlay"
           onClick={() => setEnlarged(null)}>
           <img
-            {...stylex.props(styles.overlayImage)}
+            className="report-gallery-overlayImage"
             src={enlarged}
             alt="Enlarged screenshot"
           />

--- a/internal/vibe-tests/app/src/report/report.css
+++ b/internal/vibe-tests/app/src/report/report.css
@@ -1,0 +1,233 @@
+/**
+ * Report-specific styles.
+ *
+ * Plain CSS replacement for StyleX styles previously used in report components.
+ * Uses XDS CSS custom properties (defined in xds.css) directly.
+ */
+
+/* === CodeModal === */
+.report-codeModal-header {
+  padding: var(--spacing-4);
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+}
+
+.report-codeModal-content {
+  padding: var(--spacing-4);
+  padding-block-start: 0;
+}
+
+.report-codeModal-codeBlock {
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  background-color: var(--color-wash);
+  border-radius: 6px;
+  padding: var(--spacing-3);
+  overflow: auto;
+  max-height: 70vh;
+  white-space: pre;
+  tab-size: 2;
+}
+
+/* === CompareView === */
+.report-compare-summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-3);
+}
+
+.report-compare-summaryGrid4 {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--spacing-3);
+}
+
+.report-compare-winCard {
+  padding: var(--spacing-3);
+  text-align: center;
+}
+
+.report-color-positive {
+  color: var(--color-positive);
+}
+
+.report-color-negative {
+  color: var(--color-negative);
+}
+
+.report-color-neutral {
+  color: var(--color-text-secondary);
+}
+
+.report-color-warning {
+  color: var(--color-warning);
+}
+
+/* === PromptDetailCard === */
+.report-promptDetail-card {
+  padding: var(--spacing-4);
+}
+
+.report-promptDetail-header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-2);
+}
+
+.report-promptDetail-promptText {
+  color: var(--color-text-secondary);
+}
+
+.report-promptDetail-scoreGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-2);
+}
+
+.report-promptDetail-scoreItem {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-1);
+  white-space: nowrap;
+}
+
+.report-promptDetail-scoresRow {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--spacing-3);
+}
+
+.report-promptDetail-scoresRow3 {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: var(--spacing-3);
+}
+
+.report-promptDetail-scoresRowSingle {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--spacing-3);
+}
+
+.report-promptDetail-scoreBlock {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.report-promptDetail-findingsGrid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: var(--spacing-1) var(--spacing-2);
+  align-items: baseline;
+}
+
+.report-promptDetail-section {
+  padding-block-start: var(--spacing-2);
+}
+
+.report-promptDetail-sectionLabel {
+  padding-block-end: var(--spacing-1);
+}
+
+.report-promptDetail-buttonRow {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}
+
+/* === Report === */
+.report-root {
+  min-height: 100vh;
+  background-color: var(--color-wash);
+}
+
+.report-container {
+  max-width: 1200px;
+  margin-inline: auto;
+  padding: var(--spacing-5);
+}
+
+.report-header {
+  padding-block: var(--spacing-3);
+}
+
+.report-scoreGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.report-metricsCard {
+  padding: var(--spacing-3);
+}
+
+.report-metricsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: var(--spacing-3);
+}
+
+.report-metricItem {
+  text-align: center;
+}
+
+.report-tabContent {
+  padding-block-start: var(--spacing-3);
+}
+
+.report-emptyState {
+  padding: var(--spacing-8);
+  text-align: center;
+}
+
+/* === ScoreCard === */
+.report-scoreCard-card {
+  padding: var(--spacing-3);
+}
+
+/* === ScreenshotGallery === */
+.report-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: var(--spacing-4);
+}
+
+.report-gallery-cardContent {
+  padding: var(--spacing-3);
+}
+
+.report-gallery-image {
+  width: 100%;
+  height: auto;
+  display: block;
+  cursor: pointer;
+  border-radius: var(--spacing-1);
+}
+
+.report-gallery-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: var(--color-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+  cursor: pointer;
+}
+
+.report-gallery-overlayImage {
+  max-width: 90vw;
+  max-height: 90vh;
+  object-fit: contain;
+}
+
+.report-gallery-meta {
+  display: flex;
+  gap: var(--spacing-2);
+  flex-wrap: wrap;
+}

--- a/internal/vibe-tests/app/vite.config.report.ts
+++ b/internal/vibe-tests/app/vite.config.report.ts
@@ -1,0 +1,70 @@
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+import {viteSingleFile} from 'vite-plugin-singlefile';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+/**
+ * Vite config for building reports ONLY — no StyleX plugin required.
+ *
+ * Reports use pre-compiled CSS from @xds/core/dist/xds.css and
+ * @xds/theme-default/dist/theme.css. XDS component JS is loaded from
+ * the built dist (which has stylex.create already compiled away by tsup).
+ * Report-specific styles live in plain CSS (report.css).
+ *
+ * This makes report builds fast and removes the StyleX build-time dependency.
+ * The full vite.config.ts (with StyleX) is still used for preview builds.
+ */
+
+/**
+ * Browser targets for lightningcss.
+ * Prevents lowering native light-dark() into --lightningcss-light/--lightningcss-dark
+ * polyfill variables. XDS tokens use native light-dark() which is baseline 2024:
+ * Chrome 123+, Firefox 120+, Safari 17.5+
+ *
+ * Must match the targets in apps/storybook/.storybook/main.ts
+ */
+const lightningcssTargets = {
+  chrome: 123 << 16,
+  firefox: 120 << 16,
+  safari: (17 << 16) | (5 << 8),
+};
+
+export default defineConfig({
+  plugins: [react(), viteSingleFile()],
+  build: {
+    rollupOptions: {
+      input: path.resolve(__dirname, 'index.report.html'),
+    },
+    cssMinify: 'lightningcss',
+  },
+  css: {
+    lightningcss: {
+      targets: lightningcssTargets,
+    },
+  },
+  resolve: {
+    alias: {
+      // Pre-compiled CSS — no StyleX build needed
+      'xds-css': path.resolve(repoRoot, 'packages/core/dist/xds.css'),
+      'xds-theme-css': path.resolve(
+        repoRoot,
+        'packages/themes/default/dist/theme.css',
+      ),
+      // Theme: resolve to source (no StyleX usage, just defineTheme + icons).
+      // The dist is incomplete (missing icons.js), so source is needed.
+      '@xds/theme-default': path.resolve(
+        repoRoot,
+        'packages/themes/default/src',
+      ),
+      '@xds/theme/default': path.resolve(
+        repoRoot,
+        'packages/themes/default/src',
+      ),
+    },
+  },
+  server: {port: 5174, strictPort: true},
+});

--- a/internal/vibe-tests/src/build-report.ts
+++ b/internal/vibe-tests/src/build-report.ts
@@ -322,22 +322,23 @@ async function main() {
     const {createServer} = await import('vite');
     const server = await createServer({
       root: APP_DIR,
+      configFile: path.join(APP_DIR, 'vite.config.report.ts'),
       server: {port: 5173, strictPort: true},
     });
     await server.listen();
     server.printUrls();
-    console.log('\nOpen http://localhost:5173?mode=report to view the report.');
+    console.log('\nOpen http://localhost:5173 to view the report.');
     console.log('Press Ctrl+C to stop.\n');
   } else {
     console.log('\n🏗️  Step 5: Building static report...');
-    execSync('npx vite build', {
+    execSync('npx vite build --config vite.config.report.ts', {
       cwd: APP_DIR,
       stdio: 'inherit',
     });
 
     // Step 5: Inject data and styles into the built HTML
     const distDir = path.join(APP_DIR, 'dist');
-    const reportHtml = path.join(distDir, 'index.html');
+    const reportHtml = path.join(distDir, 'index.report.html');
     if (fs.existsSync(reportHtml)) {
       console.log('💉 Step 6: Injecting report data and styles...');
       injectDataIntoHtml(reportHtml, dataScript);
@@ -347,7 +348,7 @@ async function main() {
       fs.copyFileSync(reportHtml, destPath);
       console.log(`\n✅ Report saved to: ${destPath}`);
     } else {
-      console.error('Build succeeded but no index.html found in dist/');
+      console.error('Build succeeded but no index.report.html found in dist/');
     }
   }
 }


### PR DESCRIPTION
## What

Removes the StyleX Vite plugin from the vibe test report build pipeline. Reports are data visualization (charts, tables, score cards) — they don't need StyleX at build time.

## How

**New report-specific build config** (`vite.config.report.ts`):
- No `@stylexjs/unplugin` — just `@vitejs/plugin-react` + `vite-plugin-singlefile`
- XDS components resolve to pre-compiled dist (tsup already compiles `stylex.create` away)
- Pre-compiled CSS (`xds.css` + `theme.css`) provides all XDS styles
- Separate HTML entry (`index.report.html`) and JS entry (`main.report.tsx`)

**Report components converted from StyleX to plain CSS** (`report.css`):
- Removed all `import * as stylex from '@stylexjs/stylex'`
- Removed all `import {...} from '@xds/core/theme/tokens.stylex'`
- Replaced `{...stylex.props(styles.X)}` → `className="report-X"`
- Replaced `xstyle={styles.X}` → `className="report-X"` on XDS components
- CSS custom properties (`var(--spacing-4)`, `var(--color-positive)`) used directly

**Build pipeline updated** (`build-report.ts`):
- Uses `vite.config.report.ts` for builds
- Updated output path for `index.report.html`

## What's preserved

- `vite.config.ts` unchanged — preview builds still use StyleX plugin
- `main.tsx` unchanged — preview entry point works as before
- All XDS component usage unchanged — same components, same props
- Report visual output identical (same CSS properties, just applied via className instead of StyleX)

## Build comparison

| | Before | After |
|---|---|---|
| StyleX plugin | Required | Not needed |
| Build time | ~2.2s | ~1.3s |
| Output size | ~287 KB | ~360 KB (includes full xds.css) |

The output is slightly larger because it includes the full pre-compiled `xds.css` rather than only the StyleX rules used by the app. This is a reasonable tradeoff for removing the build dependency.

## Files changed

| File | Change |
|---|---|
| `app/vite.config.report.ts` | New — report Vite config without StyleX |
| `app/index.report.html` | New — report HTML entry |
| `app/src/main.report.tsx` | New — report JS entry (imports xds.css) |
| `app/src/report/report.css` | New — plain CSS for report layout |
| `app/src/report/*.tsx` | Removed StyleX, use className |
| `src/build-report.ts` | Use report config, updated output path |

---
