### PR TITLE
feat(vibe-tests): add XDS + Tailwind preview support

### DIFF
--- a/internal/vibe-tests/app/postcss.config.js
+++ b/internal/vibe-tests/app/postcss.config.js
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};

--- a/internal/vibe-tests/app/src/preview.tsx
+++ b/internal/vibe-tests/app/src/preview.tsx
@@ -1,3 +1,31 @@
-export default function Preview({theme: _theme}: {theme: string}) {
-  return <div>No component loaded. Use the screenshot script.</div>;
+import React, {Suspense, lazy} from 'react';
+import {XDSTheme} from '@xds/core/theme';
+import {defaultTheme} from '@xds/theme/default';
+import '@xds/core/reset.css';
+import '../tailwind.css';
+
+const params = new URLSearchParams(window.location.search);
+const file = params.get('file');
+
+const Component = file
+  ? lazy(() => import(/* @vite-ignore */ `../../results/${file}`))
+  : null;
+
+export default function Preview({theme}: {theme: string}) {
+  if (!Component) {
+    return (
+      <div>
+        No component loaded. Pass <code>?mode=preview&file=&lt;path&gt;</code>{' '}
+        to render a result file.
+      </div>
+    );
+  }
+
+  return (
+    <XDSTheme theme={defaultTheme} mode={theme === 'dark' ? 'dark' : 'light'}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <Component />
+      </Suspense>
+    </XDSTheme>
+  );
 }

--- a/internal/vibe-tests/app/tailwind.css
+++ b/internal/vibe-tests/app/tailwind.css
@@ -1,0 +1,1 @@
+@import "tailwindcss";

--- a/internal/vibe-tests/app/vite.config.preview.ts
+++ b/internal/vibe-tests/app/vite.config.preview.ts
@@ -1,0 +1,84 @@
+import path from 'path';
+import {fileURLToPath} from 'url';
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+import stylex from '@stylexjs/unplugin';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+/**
+ * Browser targets for lightningcss.
+ * Prevents lowering native light-dark() into --lightningcss-light/--lightningcss-dark
+ * polyfill variables. XDS tokens use native light-dark() which is baseline 2024:
+ * Chrome 123+, Firefox 120+, Safari 17.5+
+ *
+ * Must match the targets in apps/storybook/.storybook/main.ts
+ */
+const lightningcssTargets = {
+  chrome: 123 << 16,
+  firefox: 120 << 16,
+  safari: (17 << 16) | (5 << 8),
+};
+
+/**
+ * Vite config for the preview app.
+ *
+ * Supports BOTH StyleX (for XDS component internals) AND Tailwind
+ * (for consumer code in XDS+Tailwind results). XDS components use
+ * StyleX internally — handled by the StyleX plugin. Consumer code
+ * uses Tailwind utility classes via className — handled by PostCSS.
+ */
+export default defineConfig({
+  root: __dirname,
+  plugins: [
+    stylex.vite({
+      dev: process.env.NODE_ENV === 'development',
+      runtimeInjection: false,
+      treeshakeCompensation: true,
+      unstable_moduleResolution: {
+        type: 'commonJS',
+        rootDir: repoRoot,
+      },
+      aliases: {
+        '@xds/core/theme/tokens.stylex': path.resolve(
+          repoRoot,
+          'packages/core/src/theme/tokens.stylex.ts',
+        ),
+      },
+      lightningcssOptions: {
+        targets: lightningcssTargets,
+      },
+    }),
+    react(),
+  ],
+  css: {
+    postcss: path.resolve(__dirname, 'postcss.config.js'),
+  },
+  resolve: {
+    alias: {
+      '@xds/core/theme/tokens.stylex': path.resolve(
+        repoRoot,
+        'packages/core/src/theme/tokens.stylex.ts',
+      ),
+      '@xds/core': path.resolve(repoRoot, 'packages/core/src'),
+      '@xds/theme-default': path.resolve(
+        repoRoot,
+        'packages/themes/default/src',
+      ),
+      '@xds/theme/default': path.resolve(
+        repoRoot,
+        'packages/themes/default/src',
+      ),
+      '@xds/theme-neutral': path.resolve(
+        repoRoot,
+        'packages/themes/neutral/src',
+      ),
+      '@xds/theme/neutral': path.resolve(
+        repoRoot,
+        'packages/themes/neutral/src',
+      ),
+    },
+  },
+  server: {port: 5175, strictPort: true},
+});

--- a/internal/vibe-tests/package.json
+++ b/internal/vibe-tests/package.json
@@ -29,7 +29,9 @@
     "universal:compare": "tsx src/universal-compare.ts",
     "report:build": "tsx src/build-report.ts",
     "report:dev": "tsx src/build-report.ts --dev",
-    "report:deploy": "tsx src/deploy-report.ts"
+    "report:deploy": "tsx src/deploy-report.ts",
+    "preview:dev": "vite --config app/vite.config.preview.ts",
+    "preview:build": "vite build --config app/vite.config.preview.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.52.0",
@@ -37,6 +39,9 @@
     "commander": "^12.1.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.2.1",
+    "postcss": "^8.5.8",
+    "tailwindcss": "^4.2.1",
     "tsx": "^4.19.0"
   }
 }

--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -72,13 +72,20 @@ function createEntryFile(
 ): string {
   const entryPath = path.join(tmpDir, 'entry.tsx');
 
-  // For XDS target, wrap in theme provider and import reset
-  if (target === 'xds') {
+  // For XDS and XDS+Tailwind targets, wrap in theme provider and import reset
+  if (target === 'xds' || target === 'xds-tailwind') {
+    const tailwindImport =
+      target === 'xds-tailwind'
+        ? `import '${path
+            .resolve(VIBE_DIR, 'app/tailwind.css')
+            .replace(/\\/g, '/')}';`
+        : '';
     fs.writeFileSync(
       entryPath,
       `import React from 'react';
 import {createRoot} from 'react-dom/client';
 import '@xds/core/reset.css';
+${tailwindImport}
 import {XDSTheme} from '@xds/core/theme';
 import {defaultTheme} from '@xds/theme/default';
 import Component from '${componentPath.replace(/\\/g, '/')}';
@@ -206,12 +213,12 @@ function createIndexHtml(
 function createViteConfig(tmpDir: string, target: string): string {
   const configPath = path.join(tmpDir, 'vite.config.ts');
 
-  // For XDS previews, the generated component may use patterns that
-  // StyleX's babel plugin rejects (e.g. createTheme with type casts).
-  // We use a pre-transform plugin to strip TypeScript type assertions
-  // before StyleX processes the file.
+  // For XDS and XDS+Tailwind previews, the generated component may use
+  // patterns that StyleX's babel plugin rejects (e.g. createTheme with
+  // type casts). We use a pre-transform plugin to strip TypeScript type
+  // assertions before StyleX processes the file.
   const plugins =
-    target === 'xds'
+    target === 'xds' || target === 'xds-tailwind'
       ? `
     {
       name: 'stylex-inline-vars',
@@ -268,7 +275,9 @@ function createViteConfig(tmpDir: string, target: string): string {
         rootDir: '${REPO_ROOT.replace(/\\/g, '/')}',
       },
       aliases: {
-        '@xds/core/theme/tokens.stylex': '${path.resolve(REPO_ROOT, 'packages/core/src/theme/tokens.stylex.ts').replace(/\\/g, '/')}',
+        '@xds/core/theme/tokens.stylex': '${path
+          .resolve(REPO_ROOT, 'packages/core/src/theme/tokens.stylex.ts')
+          .replace(/\\/g, '/')}',
       },
     }),
     react(),
@@ -278,29 +287,52 @@ function createViteConfig(tmpDir: string, target: string): string {
     viteSingleFile(),`;
 
   const imports =
-    target === 'xds'
+    target === 'xds' || target === 'xds-tailwind'
       ? `import stylex from '@stylexjs/unplugin';
 import react from '@vitejs/plugin-react';
 import {viteSingleFile} from 'vite-plugin-singlefile';`
       : `import react from '@vitejs/plugin-react';
 import {viteSingleFile} from 'vite-plugin-singlefile';`;
 
+  const xdsAliases = `
+    alias: {
+      '@xds/core/theme/tokens.stylex': '${path
+        .resolve(REPO_ROOT, 'packages/core/src/theme/tokens.stylex.ts')
+        .replace(/\\/g, '/')}',
+      '@xds/core': '${path
+        .resolve(REPO_ROOT, 'packages/core/src')
+        .replace(/\\/g, '/')}',
+      '@xds/theme/default': '${path
+        .resolve(REPO_ROOT, 'packages/themes/default/src')
+        .replace(/\\/g, '/')}',
+      '@xds/theme/neutral': '${path
+        .resolve(REPO_ROOT, 'packages/themes/neutral/src')
+        .replace(/\\/g, '/')}',
+    },`;
+
   const aliases =
-    target === 'xds'
+    target === 'xds' || target === 'xds-tailwind'
+      ? xdsAliases
+      : target === 'baseline'
       ? `
     alias: {
-      '@xds/core/theme/tokens.stylex': '${path.resolve(REPO_ROOT, 'packages/core/src/theme/tokens.stylex.ts').replace(/\\/g, '/')}',
-      '@xds/core': '${path.resolve(REPO_ROOT, 'packages/core/src').replace(/\\/g, '/')}',
-      '@xds/theme/default': '${path.resolve(REPO_ROOT, 'packages/themes/default/src').replace(/\\/g, '/')}',
-      '@xds/theme/neutral': '${path.resolve(REPO_ROOT, 'packages/themes/neutral/src').replace(/\\/g, '/')}',
+      '@/components/ui': '${path
+        .resolve(VIBE_DIR, '.baseline-shims/components/ui')
+        .replace(/\\/g, '/')}',
+      '@/lib/utils': '${path
+        .resolve(VIBE_DIR, '.baseline-shims/lib/utils')
+        .replace(/\\/g, '/')}',
     },`
-      : target === 'baseline'
-        ? `
-    alias: {
-      '@/components/ui': '${path.resolve(VIBE_DIR, '.baseline-shims/components/ui').replace(/\\/g, '/')}',
-      '@/lib/utils': '${path.resolve(VIBE_DIR, '.baseline-shims/lib/utils').replace(/\\/g, '/')}',
-    },`
-        : '';
+      : '';
+
+  // XDS+Tailwind needs PostCSS with Tailwind for utility class resolution
+  const cssConfig =
+    target === 'xds-tailwind'
+      ? `
+  css: {
+    postcss: '${path.resolve(VIBE_DIR, 'app').replace(/\\/g, '/')}',
+  },`
+      : '';
 
   fs.writeFileSync(
     configPath,
@@ -310,7 +342,7 @@ ${imports}
 export default defineConfig({
   root: '${tmpDir.replace(/\\/g, '/')}',
   plugins: [${plugins}
-  ],
+  ],${cssConfig}
   resolve: {${aliases}
   },
   build: {
@@ -503,10 +535,7 @@ function buildPreview(
 ): boolean {
   // Use a unique temp directory per build to prevent race conditions
   // when multiple build-previews processes run concurrently
-  const tmpDir = path.join(
-    VIBE_DIR,
-    `.preview-tmp-${crypto.randomUUID()}`,
-  );
+  const tmpDir = path.join(VIBE_DIR, `.preview-tmp-${crypto.randomUUID()}`);
   ensureDir(tmpDir);
 
   try {
@@ -620,7 +649,9 @@ async function main() {
     0,
   );
   console.log(
-    `\n✅ Built ${totalPreviews} preview(s) for ${Object.keys(manifest).length} prompt(s)`,
+    `\n✅ Built ${totalPreviews} preview(s) for ${
+      Object.keys(manifest).length
+    } prompt(s)`,
   );
   console.log(`   Manifest: ${manifestOutPath}`);
 }

--- a/internal/vibe-tests/src/screenshot.ts
+++ b/internal/vibe-tests/src/screenshot.ts
@@ -48,15 +48,18 @@ function parseArgs(): {iteration: string; prompt?: string} {
 
 function generatePreviewCode(
   componentPath: string,
-  target: 'xds' | 'baseline',
+  target: 'xds' | 'baseline' | 'xds-tailwind',
 ): string {
   const relPath = path.relative(path.join(APP_DIR, 'src'), componentPath);
   const importPath = relPath.replace(/\.tsx$/, '').replace(/\\/g, '/');
 
-  if (target === 'xds') {
+  if (target === 'xds' || target === 'xds-tailwind') {
+    // XDS+Tailwind uses the same XDS wrapper but also imports Tailwind CSS
+    const tailwindImport =
+      target === 'xds-tailwind' ? `\nimport '../tailwind.css';` : '';
     return `
 import React from 'react';
-import Component from '${importPath}';
+import Component from '${importPath}';${tailwindImport}
 import XDSWrapper from './xds-wrapper';
 
 export default function Preview({ theme }: { theme: string }) {
@@ -102,7 +105,7 @@ async function main() {
     prompts: Array<{id: string; category: string}>;
   }>(manifestPath);
 
-  const target = manifest.config.target as 'xds' | 'baseline';
+  const target = manifest.config.target as 'xds' | 'baseline' | 'xds-tailwind';
 
   // Determine which prompts to screenshot
   let promptIds = manifest.prompts.map(p => p.id);
@@ -146,9 +149,17 @@ async function main() {
   ensureDir(screenshotsDir);
 
   // Start Vite dev server
+  // Use the preview config for xds-tailwind (includes PostCSS/Tailwind),
+  // default config for other targets
+  const configFile =
+    target === 'xds-tailwind'
+      ? path.join(APP_DIR, 'vite.config.preview.ts')
+      : undefined;
+
   const {createServer} = await import('vite');
   const server = await createServer({
     root: APP_DIR,
+    configFile,
     server: {port: 5174, strictPort: true},
     logLevel: 'silent',
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,11 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.4.4.tgz#2856c55443d3d461693f32d2b96fb6ea92e1ffa9"
   integrity sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==
 
+"@alloc/quick-lru@^5.2.0":
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
+  integrity sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==
+
 "@ampproject/remapping@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.3.0.tgz#ed441b6fa600072520ce18b43d2c8cc8caecc7f4"
@@ -754,10 +759,25 @@
   resolved "https://registry.yarnpkg.com/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz#cd0b25b3808cd9e684cd6cd549bbf8e1dcf05ee7"
   integrity sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==
 
-"@emnapi/runtime@^1.7.0":
+"@emnapi/core@^1.7.1", "@emnapi/core@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.8.1.tgz#fd9efe721a616288345ffee17a1f26ac5dd01349"
+  integrity sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==
+  dependencies:
+    "@emnapi/wasi-threads" "1.1.0"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.7.0", "@emnapi/runtime@^1.7.1", "@emnapi/runtime@^1.8.1":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.8.1.tgz#550fa7e3c0d49c5fb175a116e8cd70614f9a22a5"
   integrity sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.1.0", "@emnapi/wasi-threads@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz#60b2102fddc9ccb78607e4a3cf8403ea69be41bf"
+  integrity sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==
   dependencies:
     tslib "^2.4.0"
 
@@ -1606,6 +1626,15 @@
   dependencies:
     "@types/mdx" "^2.0.0"
 
+"@napi-rs/wasm-runtime@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz#c3705ab549d176b8dc5172723d6156c3dc426af2"
+  integrity sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==
+  dependencies:
+    "@emnapi/core" "^1.7.1"
+    "@emnapi/runtime" "^1.7.1"
+    "@tybys/wasm-util" "^0.10.1"
+
 "@next/env@15.5.12":
   version "15.5.12"
   resolved "https://registry.yarnpkg.com/@next/env/-/env-15.5.12.tgz#e8f5be3b951ea964050e95ed9a45009d49f0f831"
@@ -2167,6 +2196,115 @@
   dependencies:
     tslib "^2.8.0"
 
+"@tailwindcss/node@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/node/-/node-4.2.1.tgz#e963ac242a885353a4660e7e3e9c695cde7d3fc9"
+  integrity sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.5"
+    enhanced-resolve "^5.19.0"
+    jiti "^2.6.1"
+    lightningcss "1.31.1"
+    magic-string "^0.30.21"
+    source-map-js "^1.2.1"
+    tailwindcss "4.2.1"
+
+"@tailwindcss/oxide-android-arm64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.1.tgz#a7c24919b607e7f884e6ab97799d12c7fb5b47bd"
+  integrity sha512-eZ7G1Zm5EC8OOKaesIKuw77jw++QJ2lL9N+dDpdQiAB/c/B2wDh0QPFHbkBVrXnwNugvrbJFk1gK2SsVjwWReg==
+
+"@tailwindcss/oxide-darwin-arm64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.1.tgz#6f6e91ff0e1b5476cc0dad0da1ea8474f4563212"
+  integrity sha512-q/LHkOstoJ7pI1J0q6djesLzRvQSIfEto148ppAd+BVQK0JYjQIFSK3JgYZJa+Yzi0DDa52ZsQx2rqytBnf8Hw==
+
+"@tailwindcss/oxide-darwin-x64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.1.tgz#1e59ef0665f6cb9e658bf0ebcb3cb50f21b2c175"
+  integrity sha512-/f/ozlaXGY6QLbpvd/kFTro2l18f7dHKpB+ieXz+Cijl4Mt9AI2rTrpq7V+t04nK+j9XBQHnSMdeQRhbGyt6fw==
+
+"@tailwindcss/oxide-freebsd-x64@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.1.tgz#6b0c75e9dac7f1a241cb9a5eaa89f0d9664835b6"
+  integrity sha512-5e/AkgYJT/cpbkys/OU2Ei2jdETCLlifwm7ogMC7/hksI2fC3iiq6OcXwjibcIjPung0kRtR3TxEITkqgn0TcA==
+
+"@tailwindcss/oxide-linux-arm-gnueabihf@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.1.tgz#717044d8fe746b1f0760485946c0c9a900174f7b"
+  integrity sha512-Uny1EcVTTmerCKt/1ZuKTkb0x8ZaiuYucg2/kImO5A5Y/kBz41/+j0gxUZl+hTF3xkWpDmHX+TaWhOtba2Fyuw==
+
+"@tailwindcss/oxide-linux-arm64-gnu@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.1.tgz#f544b0faf166d80791347911b2dd4372a893129d"
+  integrity sha512-CTrwomI+c7n6aSSQlsPL0roRiNMDQ/YzMD9EjcR+H4f0I1SQ8QqIuPnsVp7QgMkC1Qi8rtkekLkOFjo7OlEFRQ==
+
+"@tailwindcss/oxide-linux-arm64-musl@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.1.tgz#9fbaf8dc00b858a2b955526abb15d88f5678d1ef"
+  integrity sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==
+
+"@tailwindcss/oxide-linux-x64-gnu@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.1.tgz#6ab4e6b8d308d037a1155b8443df5941dbfa6aa1"
+  integrity sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==
+
+"@tailwindcss/oxide-linux-x64-musl@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.1.tgz#52c55593394dff85f1fa88172f69f8fdcde182b6"
+  integrity sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==
+
+"@tailwindcss/oxide-wasm32-wasi@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.1.tgz#7401e35f881d3654b6180badd1243d75a2702ea5"
+  integrity sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==
+  dependencies:
+    "@emnapi/core" "^1.8.1"
+    "@emnapi/runtime" "^1.8.1"
+    "@emnapi/wasi-threads" "^1.1.0"
+    "@napi-rs/wasm-runtime" "^1.1.1"
+    "@tybys/wasm-util" "^0.10.1"
+    tslib "^2.8.1"
+
+"@tailwindcss/oxide-win32-arm64-msvc@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.1.tgz#63a502e7b696dcd976aa356b94ce0f4f8f832c44"
+  integrity sha512-YlUEHRHBGnCMh4Nj4GnqQyBtsshUPdiNroZj8VPkvTZSoHsilRCwXcVKnG9kyi0ZFAS/3u+qKHBdDc81SADTRA==
+
+"@tailwindcss/oxide-win32-x64-msvc@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.1.tgz#8cc59b28ebc4dc866c0c14d7057f07f0ed04c4a8"
+  integrity sha512-rbO34G5sMWWyrN/idLeVxAZgAKWrn5LiR3/I90Q9MkA67s6T1oB0xtTe+0heoBvHSpbU9Mk7i6uwJnpo4u21XQ==
+
+"@tailwindcss/oxide@4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/oxide/-/oxide-4.2.1.tgz#43ae4217268a7e8b4736f1c056d0ef6f393c79d3"
+  integrity sha512-yv9jeEFWnjKCI6/T3Oq50yQEOqmpmpfzG1hcZsAOaXFQPfzWprWrlHSdGPEF3WQTi8zu8ohC9Mh9J470nT5pUw==
+  optionalDependencies:
+    "@tailwindcss/oxide-android-arm64" "4.2.1"
+    "@tailwindcss/oxide-darwin-arm64" "4.2.1"
+    "@tailwindcss/oxide-darwin-x64" "4.2.1"
+    "@tailwindcss/oxide-freebsd-x64" "4.2.1"
+    "@tailwindcss/oxide-linux-arm-gnueabihf" "4.2.1"
+    "@tailwindcss/oxide-linux-arm64-gnu" "4.2.1"
+    "@tailwindcss/oxide-linux-arm64-musl" "4.2.1"
+    "@tailwindcss/oxide-linux-x64-gnu" "4.2.1"
+    "@tailwindcss/oxide-linux-x64-musl" "4.2.1"
+    "@tailwindcss/oxide-wasm32-wasi" "4.2.1"
+    "@tailwindcss/oxide-win32-arm64-msvc" "4.2.1"
+    "@tailwindcss/oxide-win32-x64-msvc" "4.2.1"
+
+"@tailwindcss/postcss@^4.2.1":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@tailwindcss/postcss/-/postcss-4.2.1.tgz#efce3b23608b23324ed4848ff1aae657adfe0c5f"
+  integrity sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==
+  dependencies:
+    "@alloc/quick-lru" "^5.2.0"
+    "@tailwindcss/node" "4.2.1"
+    "@tailwindcss/oxide" "4.2.1"
+    postcss "^8.5.6"
+    tailwindcss "4.2.1"
+
 "@testing-library/dom@10.4.0":
   version "10.4.0"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.0.tgz#82a9d9462f11d240ecadbf406607c6ceeeff43a8"
@@ -2222,6 +2360,13 @@
   version "14.6.1"
   resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
   integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
+"@tybys/wasm-util@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
+  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/aria-query@^5.0.1":
   version "5.0.4"
@@ -3046,6 +3191,14 @@ emoji-regex@^9.2.2:
   version "9.2.2"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.2.2.tgz#840c8803b0d8047f4ff0cf963176b32d4ef3ed72"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
+
+enhanced-resolve@^5.19.0:
+  version "5.20.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.20.0.tgz#323c2a70d2aa7fb4bdfd6d3c24dfc705c581295d"
+  integrity sha512-/ce7+jQ1PQ6rVXwe+jKEg5hW5ciicHwIQUagZkp6IufBoY3YDgdTTY1azVs0qoRgVmvsNB+rbjLJxDAeHHtwsQ==
+  dependencies:
+    graceful-fs "^4.2.4"
+    tapable "^2.3.0"
 
 enquirer@^2.4.1:
   version "2.4.1"
@@ -3883,6 +4036,11 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+jiti@^2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.6.1.tgz#178ef2fc9a1a594248c20627cd820187a4d78d92"
+  integrity sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==
+
 joycon@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
@@ -4070,7 +4228,7 @@ lightningcss-win32-x64-msvc@1.31.1:
   resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.31.1.tgz#7f025274c81c7d659829731e09c8b6f442209837"
   integrity sha512-I9aiFrbd7oYHwlnQDqr1Roz+fTz61oDDJX7n9tYF9FJymH1cIN1DtKw3iYt6b8WZgEjoNwVSncwF4wx/ZedMhw==
 
-lightningcss@^1.29.1:
+lightningcss@1.31.1, lightningcss@^1.29.1:
   version "1.31.1"
   resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.31.1.tgz#1a19dd327b547a7eda1d5c296ebe1e72df5a184b"
   integrity sha512-l51N2r93WmGUye3WuFoN5k10zyvrVs0qfKBhyC5ogUQ6Ew6JUSswh78mbSO+IU3nTWsyOArqPCcShdQSadghBQ==
@@ -4187,7 +4345,7 @@ magic-string@^0.27.0:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.4.13"
 
-magic-string@^0.30.0, magic-string@^0.30.12, magic-string@^0.30.17:
+magic-string@^0.30.0, magic-string@^0.30.12, magic-string@^0.30.17, magic-string@^0.30.21:
   version "0.30.21"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.21.tgz#56763ec09a0fa8091df27879fd94d19078c00d91"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -4606,12 +4764,26 @@ postcss@^8.4.43, postcss@^8.4.49:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+postcss@^8.5.6, postcss@^8.5.8:
+  version "8.5.8"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.8.tgz#6230ecc8fb02e7a0f6982e53990937857e13f399"
+  integrity sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.7.1, prettier@^3.4.0:
+prettier@^2.7.1:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+prettier@^3.4.0:
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.7.4.tgz#d2f8335d4b1cec47e1c8098645411b0c9dff9c0f"
   integrity sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==
@@ -5100,6 +5272,16 @@ symbol-tree@^3.2.4:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
+tailwindcss@4.2.1, tailwindcss@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.2.1.tgz#018c4720b58baf98a6bf56b0a12aa797c6cfef1d"
+  integrity sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==
+
+tapable@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.3.0.tgz#7e3ea6d5ca31ba8e078b560f0d83ce9a14aa8be6"
+  integrity sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==
+
 term-size@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
@@ -5233,7 +5415,7 @@ tsconfig-paths@^4.2.0:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^2.0.1, tslib@^2.4.0, tslib@^2.8.0:
+tslib@^2.0.1, tslib@^2.4.0, tslib@^2.8.0, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
## What

Adds Tailwind CSS processing to the vibe test preview infrastructure, enabling rendering and screenshotting of XDS + Tailwind target results. The XDS + Tailwind target scores 92 (our best target) but couldn't be previewed until now.

## Why

Issue #538 — the preview app only supported StyleX-based results. The `xds-tailwind` target generates code that uses XDS components (which use StyleX internally) with Tailwind utility classes for layout and styling. We need both CSS systems to coexist in the preview.

## How

### New files
- **`app/postcss.config.js`** — PostCSS config with `@tailwindcss/postcss` plugin
- **`app/tailwind.css`** — Tailwind v4 entry point (`@import "tailwindcss"`)
- **`app/vite.config.preview.ts`** — Preview-specific Vite config with both StyleX plugin (for XDS component internals) and PostCSS/Tailwind (for consumer utility classes)

### Modified files
- **`app/src/preview.tsx`** — Now accepts `?file=` query param to dynamically import and render any result file, wrapped in XDS theme with Tailwind CSS available
- **`src/build-previews.ts`** — Handles `xds-tailwind` target: generates entry files with Tailwind CSS import, creates Vite configs with PostCSS pointing to the app's postcss.config.js, reuses XDS aliases
- **`src/screenshot.ts`** — Uses preview Vite config for `xds-tailwind` target so Tailwind classes resolve during dev server screenshots
- **`package.json`** — Added `tailwindcss`, `@tailwindcss/postcss`, `postcss` as dev deps; added `preview:dev` and `preview:build` scripts

### Key design decision
StyleX and Tailwind coexist in the same build:
- **StyleX** handles XDS component internals (via the StyleX Vite plugin)
- **Tailwind** handles consumer utility classes like `className="max-w-md p-6 shadow-lg"` (via PostCSS)
- The existing report build (`vite.config.ts`) is unchanged

## Usage

```bash
# Dev server for previewing results
yarn preview:dev
# Then open: http://localhost:5175?mode=preview&file=<iteration>/results/<prompt>.tsx

# Build previews for an xds-tailwind iteration
yarn preview:build
```

The `build-previews.ts` pipeline automatically detects the `xds-tailwind` target from the iteration manifest and applies the correct config.

Closes #538

---
