### PR TITLE
fix(themes): add tsup build to produce proper JS/TS module output

### DIFF
--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -5,10 +5,15 @@
   "description": "Brutalist theme for XDS — zero radius, monospace, heavy borders",
   "license": "MIT",
   "sideEffects": false,
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
     "./theme.css": "./dist/theme.css"
   },
   "files": [
@@ -16,7 +21,7 @@
     "src"
   ],
   "scripts": {
-    "build": "xds build-theme src/index.ts -o dist/theme.css"
+    "build": "xds build-theme src/index.ts -o dist/theme.css && tsup && rm -f dist/brutalist.js dist/brutalist.d.ts"
   },
   "peerDependencies": {
     "@xds/core": "*"

--- a/packages/themes/brutalist/tsup.config.ts
+++ b/packages/themes/brutalist/tsup.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: false, // Don't clean — xds build-theme already put theme.css in dist/
+  external: ['@xds/core', '@stylexjs/stylex', 'react'],
+});

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -9,9 +9,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./theme.css": "./dist/theme.css"
   },
@@ -20,7 +20,7 @@
     "src"
   ],
   "scripts": {
-    "build": "xds build-theme src/defaultTheme.ts -o dist/theme.css"
+    "build": "xds build-theme src/defaultTheme.ts -o dist/theme.css && tsup && rm -f dist/default.js dist/default.d.ts"
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0"

--- a/packages/themes/default/tsup.config.ts
+++ b/packages/themes/default/tsup.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: false, // Don't clean — xds build-theme already put theme.css in dist/
+  external: ['@xds/core', '@stylexjs/stylex', 'react', '@heroicons/react'],
+});

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -9,9 +9,9 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.js"
     },
     "./theme.css": "./dist/theme.css"
   },
@@ -20,7 +20,7 @@
     "src"
   ],
   "scripts": {
-    "build": "xds build-theme src/neutralTheme.ts -o dist/theme.css"
+    "build": "xds build-theme src/neutralTheme.ts -o dist/theme.css && tsup && rm -f dist/neutral.js dist/neutral.d.ts"
   },
   "dependencies": {
     "lucide-react": "^0.575.0"

--- a/packages/themes/neutral/tsup.config.ts
+++ b/packages/themes/neutral/tsup.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: false, // Don't clean — xds build-theme already put theme.css in dist/
+  external: ['@xds/core', '@stylexjs/stylex', 'react', 'lucide-react'],
+});


### PR DESCRIPTION
## Problem

Theme packages (`@xds/theme-default`, `@xds/theme-neutral`, `@xds/theme-brutalist`) only ran `xds build-theme` which produces CSS and theme-named JS files (e.g. `default.js`, `neutral.js`). But `package.json` exports point to `index.js`/`index.mjs`/`index.d.ts` which didn't exist.

The v0.0.2 release manually patched `package.json` to point to `default.js`/`neutral.js`, but the underlying build was still broken — those files reference `./icons` which doesn't exist in `dist/`.

## Fix

Each theme package now runs both build steps:

1. **`xds build-theme`** — produces `theme.css` (the CSS custom properties)
2. **`tsup`** — compiles `src/index.ts` to proper CJS/ESM/DTS output

### Changes

- **Added `tsup.config.ts`** to each theme package (`default`, `neutral`, `brutalist`)
  - Entry: `src/index.ts`
  - Formats: CJS + ESM
  - DTS generation enabled
  - `clean: false` to preserve `theme.css` from the prior build step
  - External: `@xds/core`, `@stylexjs/stylex`, `react`, and theme-specific icon libraries

- **Updated build scripts** to chain both commands and clean up stale artifacts:
  ```
  xds build-theme src/defaultTheme.ts -o dist/theme.css && tsup && rm -f dist/default.js dist/default.d.ts
  ```

- **Fixed brutalist `package.json`** — was pointing `main`/`types`/`exports` at `./src/index.ts` instead of `dist/` output

- **Fixed exports condition ordering** — `types` now comes before `import`/`require` (matches `@xds/core` convention, avoids esbuild warnings)

### Output

Each theme now produces:
```
dist/
  index.js      # CJS
  index.mjs     # ESM
  index.d.ts    # TypeScript declarations
  index.d.mts   # TypeScript declarations (ESM)
  theme.css     # CSS custom properties
```

### Verification

- `yarn build` ✅ — all packages build successfully
- `yarn test` ✅ — 89 test files, 1428 tests pass
- `yarn lint` ✅ — 0 errors (pre-existing warnings only)
- All theme `dist/` directories contain the expected files
- No stale `default.js`/`neutral.js`/`brutalist.js` artifacts remain

---
