### PR TITLE
docs: remove JS comments from @example code blocks

### DIFF
--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -202,8 +202,8 @@ export interface XDSAvatarProps extends XDSBaseProps<HTMLDivElement> {
  * Takes the first letter of the first two words.
  * @example
  * ```
- * getInitials('John Doe') // 'JD'
- * getInitials('Alice') // 'A'
+ * getInitials('John Doe')
+ * getInitials('Alice')
  * ```
  */
 function getInitials(name: string): string {

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -112,7 +112,7 @@ export interface XDSBadgeProps extends XDSBaseProps<HTMLSpanElement> {
  * <XDSBadge>Default</XDSBadge>
  * <XDSBadge variant="success">Active</XDSBadge>
  * <XDSBadge variant="error">3</XDSBadge>
- * <XDSBadge variant="info" /> // Dot indicator
+ * <XDSBadge variant="info" />
  * ```
  */
 export function XDSBadge({


### PR DESCRIPTION
## What

Removes inline JS comments from `@example` code blocks in JSDoc docstrings. Storybook's autodocs parser can misinterpret `//` comments inside fenced code blocks, and the doc reviewer wiki guidelines flag these as issues.

### Changes

- **XDSAvatar** (`getInitials`): Removed `// 'JD'` and `// 'A'` return value comments
- **XDSBadge**: Removed `// Dot indicator` comment from variant example

These were missed by the previous storybook-compat PRs (#426, #523).

---
*Found during Night Watch doc review.*