### PR TITLE
fix(core): add stable token export path

### DIFF
--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -11,7 +11,7 @@ import {defineConfig} from 'tsup';
 import babel from 'esbuild-plugin-babel';
 
 export default defineConfig({
-  entry: ['src/index.ts', 'src/*/index.ts'],
+  entry: ['src/index.ts', 'src/*/index.ts', 'src/theme/tokens.stylex.ts'],
   format: ['cjs', 'esm'],
   dts: true,
   splitting: true,


### PR DESCRIPTION
## Problem

The package.json exports map claims `./theme/tokens.stylex` resolves to `dist/theme/tokens.stylex.mjs`, but tsup chunks `tokens.stylex.ts` into a random hash file (e.g. `dist/chunk-PCB6APBW.mjs`) instead of producing a standalone module. Consumers importing `@xds/core/theme/tokens.stylex` get a resolution error.

## Fix

Add `src/theme/tokens.stylex.ts` as an explicit entry point in `tsup.config.ts`. This tells tsup to emit it as a standalone module at the expected path (`dist/theme/tokens.stylex.{mjs,js}`) instead of chunking it.

One-line change:
```diff
-  entry: ['src/index.ts', 'src/*/index.ts'],
+  entry: ['src/index.ts', 'src/*/index.ts', 'src/theme/tokens.stylex.ts'],
```

## Verification

After building, all expected files exist:
- `dist/theme/tokens.stylex.mjs` ✅
- `dist/theme/tokens.stylex.js` ✅
- `dist/theme/tokens.stylex.d.ts` ✅
- `dist/theme/tokens.stylex.d.mts` ✅

---
