### PR TITLE
feat(core): inline StyleX style objects at build time

### DIFF
--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -369,19 +369,116 @@ function getComponentStats(componentName) {
   };
 }
 
-// Get total bundle stats
-function getTotalBundleStats() {
-  const distPath = path.join(process.cwd(), CORE_DIST);
-  const esmPath = path.join(distPath, 'index.mjs');
-  const cjsPath = path.join(distPath, 'index.js');
+// Sum file sizes matching a glob pattern in a directory
+function sumFileSizes(dir, ext) {
+  try {
+    const files = fs.readdirSync(dir).filter(f => f.endsWith(ext));
+    return files.reduce((sum, f) => {
+      const size = getFileSizeBytes(path.join(dir, f));
+      return sum + (size || 0);
+    }, 0);
+  } catch {
+    return 0;
+  }
+}
 
-  return {
-    esmSize: getFileSize(esmPath),
-    esmBytes: getFileSizeBytes(esmPath),
-    cjsSize: getFileSize(cjsPath),
-    cjsBytes: getFileSizeBytes(cjsPath),
-    gzipSize: getGzipSize(esmPath),
-  };
+// Format bytes to human readable
+function formatBytes(bytes) {
+  if (bytes == null) return 'N/A';
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(2)}MB`;
+}
+
+// Format a delta with sign and percentage
+function formatDelta(before, after) {
+  if (before == null || after == null) return 'N/A';
+  const delta = after - before;
+  const pct = before > 0 ? ((delta / before) * 100).toFixed(1) : '0.0';
+  const sign = delta > 0 ? '+' : '';
+  return `${sign}${formatBytes(Math.abs(delta))} (${sign}${pct}%)`;
+}
+
+// Get total bundle stats — measures ALL dist files, not just entry points
+function getTotalBundleStats() {
+  const packages = [
+    { name: '@xds/core', dist: path.join(process.cwd(), 'packages/core/dist') },
+    { name: '@xds/theme-default', dist: path.join(process.cwd(), 'packages/themes/default/dist') },
+    { name: '@xds/theme-neutral', dist: path.join(process.cwd(), 'packages/themes/neutral/dist') },
+  ];
+
+  const result = { packages: {}, total: { js: 0, css: 0 } };
+
+  for (const pkg of packages) {
+    if (!fs.existsSync(pkg.dist)) continue;
+
+    const jsBytes = sumFileSizes(pkg.dist, '.mjs') + sumFileSizes(pkg.dist, '.js');
+    const cssBytes = sumFileSizes(pkg.dist, '.css');
+
+    result.packages[pkg.name] = {
+      js: { bytes: jsBytes, size: formatBytes(jsBytes) },
+      css: { bytes: cssBytes, size: formatBytes(cssBytes) },
+    };
+    result.total.js += jsBytes;
+    result.total.css += cssBytes;
+  }
+
+  result.total.jsSize = formatBytes(result.total.js);
+  result.total.cssSize = formatBytes(result.total.css);
+  result.total.allBytes = result.total.js + result.total.css;
+  result.total.allSize = formatBytes(result.total.allBytes);
+
+  // Gzip the core ESM output
+  const coreDistPath = path.join(process.cwd(), 'packages/core/dist');
+  try {
+    const output = execSync(
+      `cat "${coreDistPath}"/*.mjs | gzip -c | wc -c`,
+      { encoding: 'utf8' }
+    );
+    result.total.gzip = { bytes: parseInt(output.trim(), 10), size: formatBytes(parseInt(output.trim(), 10)) };
+  } catch { /* ignore */ }
+
+  return result;
+}
+
+// Build base branch and measure for delta comparison
+function getBaseBundleStats() {
+  try {
+    const tmpDir = path.join(process.cwd(), '.base-build-tmp');
+    try {
+      console.log('Building base branch for bundle size comparison...');
+      execSync(`git worktree add "${tmpDir}" ${baseBranch} --detach`, { stdio: 'pipe' });
+      execSync('yarn install --frozen-lockfile', { cwd: tmpDir, stdio: 'pipe', timeout: 60000 });
+      execSync('yarn build', {
+        cwd: tmpDir, stdio: 'pipe', timeout: 120000,
+        env: { ...process.env, NODE_OPTIONS: '--max-old-space-size=4096' },
+      });
+
+      const packages = [
+        { name: '@xds/core', dist: path.join(tmpDir, 'packages/core/dist') },
+        { name: '@xds/theme-default', dist: path.join(tmpDir, 'packages/themes/default/dist') },
+        { name: '@xds/theme-neutral', dist: path.join(tmpDir, 'packages/themes/neutral/dist') },
+      ];
+
+      const result = { packages: {}, total: { js: 0, css: 0 } };
+      for (const pkg of packages) {
+        if (!fs.existsSync(pkg.dist)) continue;
+        const jsBytes = sumFileSizes(pkg.dist, '.mjs') + sumFileSizes(pkg.dist, '.js');
+        const cssBytes = sumFileSizes(pkg.dist, '.css');
+        result.packages[pkg.name] = { js: { bytes: jsBytes }, css: { bytes: cssBytes } };
+        result.total.js += jsBytes;
+        result.total.css += cssBytes;
+      }
+      result.total.allBytes = result.total.js + result.total.css;
+      console.log('Base branch build complete.');
+      return result;
+    } finally {
+      try { execSync(`git worktree remove "${tmpDir}" --force`, { stdio: 'pipe' }); } catch {}
+    }
+  } catch (e) {
+    console.log(`Could not build base for delta: ${e.message}`);
+    return null;
+  }
 }
 
 // Main analysis
@@ -450,6 +547,7 @@ function analyze() {
     newExports,
     componentStats,
     totalBundle: getTotalBundleStats(),
+    baseBundleStats: getBaseBundleStats(),
     analyzedAt: new Date().toISOString(),
   };
 

--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -128,16 +128,64 @@ if (analysis.modifiedComponents && analysis.modifiedComponents.length > 0) {
 // Build accessibility section using shared module
 const a11ySection = buildA11ySection(a11yReport);
 
-// Build bundle size section
-let bundleSection = '### Bundle Size Summary\n\n';
-bundleSection += `| Package | Size (ESM) | Size (CJS) | Gzipped |\n`;
-bundleSection += `|---------|------------|------------|----------|\n`;
-bundleSection += `| @xds/core | ${analysis.totalBundle?.esmSize || 'N/A'} | ${analysis.totalBundle?.cjsSize || 'N/A'} | ${analysis.totalBundle?.gzipSize || 'N/A'} |\n\n`;
+// Helper: format byte delta with sign and percentage
+function fmtDelta(before, after) {
+  if (before == null || after == null || before === 0) return '';
+  const delta = after - before;
+  if (delta === 0) return '—';
+  const sign = delta > 0 ? '+' : '';
+  const pct = ((delta / before) * 100).toFixed(1);
+  const abs = delta < 0 ? -delta : delta;
+  const size = abs < 1024 ? `${abs}B` : `${(abs / 1024).toFixed(1)}KB`;
+  return `${sign}${delta < 0 ? '-' : ''}${size} (${sign}${pct}%)`;
+}
 
-if (analysis.bundleDelta) {
-  const delta = analysis.bundleDelta;
-  const direction = delta > 0 ? 'increased' : delta < 0 ? 'decreased' : 'unchanged';
-  bundleSection += `**Bundle size ${direction}:** ${delta > 0 ? '+' : ''}${delta} bytes\n\n`;
+// Build bundle size section
+let bundleSection = '### Bundle Size\n\n';
+const bundle = analysis.totalBundle || {};
+const baseBundleStats = analysis.baseBundleStats;
+
+if (bundle.packages) {
+  const hasBase = baseBundleStats && baseBundleStats.packages;
+
+  if (hasBase) {
+    bundleSection += `| Package | JS | Δ | CSS | Δ |\n`;
+    bundleSection += `|---|---:|---:|---:|---:|\n`;
+  } else {
+    bundleSection += `| Package | JS | CSS |\n`;
+    bundleSection += `|---|---:|---:|\n`;
+  }
+
+  for (const [name, stats] of Object.entries(bundle.packages)) {
+    const baseStats = hasBase ? baseBundleStats.packages[name] : null;
+    const jsDelta = baseStats ? fmtDelta(baseStats.js.bytes, stats.js.bytes) : '';
+    const cssDelta = baseStats ? fmtDelta(baseStats.css.bytes, stats.css.bytes) : '';
+
+    if (hasBase) {
+      bundleSection += `| ${name} | ${stats.js.size} | ${jsDelta} | ${stats.css.size} | ${cssDelta} |\n`;
+    } else {
+      bundleSection += `| ${name} | ${stats.js.size} | ${stats.css.size} |\n`;
+    }
+  }
+
+  // Total row
+  if (hasBase) {
+    const totalJsDelta = fmtDelta(baseBundleStats.total.js, bundle.total.js);
+    const totalCssDelta = fmtDelta(baseBundleStats.total.css, bundle.total.css);
+    bundleSection += `| **Total** | **${bundle.total.jsSize}** | **${totalJsDelta}** | **${bundle.total.cssSize}** | **${totalCssDelta}** |\n`;
+  } else {
+    bundleSection += `| **Total** | **${bundle.total.jsSize}** | **${bundle.total.cssSize}** |\n`;
+  }
+
+  if (bundle.total.gzip) {
+    bundleSection += `\nGzipped (core ESM): ${bundle.total.gzip.size}\n`;
+  }
+  bundleSection += '\n';
+} else {
+  // Fallback for old format
+  bundleSection += `| Package | Size (ESM) | Size (CJS) | Gzipped |\n`;
+  bundleSection += `|---------|------------|------------|----------|\n`;
+  bundleSection += `| @xds/core | ${bundle.esmSize || 'N/A'} | ${bundle.cjsSize || 'N/A'} | ${bundle.gzipSize || 'N/A'} |\n\n`;
 }
 
 // Build screenshots section with embedded images

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -373,7 +373,7 @@
     "lint": "eslint src",
     "typecheck:docs": "tsc --project tsconfig.docs.json",
     "build:css": "node ../../scripts/build-css.mjs",
-    "postbuild": "yarn build:css"
+    "postbuild": "yarn build:css && node ../../scripts/inline-stylex.mjs"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/scripts/inline-stylex.mjs
+++ b/scripts/inline-stylex.mjs
@@ -1,0 +1,178 @@
+/**
+ * @file inline-stylex.mjs
+ * Post-build transform: resolves $$css style objects into class name strings.
+ *
+ * StyleX compiles styles into objects like:
+ *   { kVAEAm: "x1n2onr6", k1xSpc: "x3nfvp2", $$css: true }
+ *
+ * At runtime, stylex.props() walks these objects to collect class names.
+ * This transform resolves them at build time so the runtime just
+ * concatenates strings.
+ *
+ * Requires: no null values in $$css objects (enforced by
+ * @xds/no-stylex-null-override lint rule).
+ *
+ * Run after tsup build: node scripts/inline-stylex.mjs [dist-dir]
+ */
+
+import { readFileSync, writeFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+const DIST_DIR = process.argv[2] || 'dist';
+const RUNTIME_FILENAME = '__stylex-runtime.mjs';
+const RUNTIME_IMPORT_NAME = '__stylexProps';
+
+// Minimal runtime — just concatenates non-falsy string arguments.
+// Also handles $$css objects from consumer xstyle passthrough.
+const RUNTIME_MODULE = `/**
+ * Minimal StyleX props runtime.
+ * Internal style objects are pre-resolved to class name strings.
+ * $$css object handling is kept for consumer xstyle passthrough.
+ */
+export function ${RUNTIME_IMPORT_NAME}() {
+  var cls = '';
+  for (var i = 0; i < arguments.length; i++) {
+    var s = arguments[i];
+    if (!s) continue;
+    if (typeof s === 'string') {
+      cls = cls ? cls + ' ' + s : s;
+    } else if (s.$$css) {
+      for (var prop in s) {
+        if (prop !== '$$css' && typeof s[prop] === 'string') {
+          cls = cls ? cls + ' ' + s[prop] : s[prop];
+        }
+      }
+    }
+  }
+  return cls ? { className: cls } : {};
+}
+`;
+
+/**
+ * Extract class name strings from a $$css style object.
+ */
+function resolveToClassNames(objSource) {
+  const classNames = [];
+  // Match: key: "value" — keys can be unquoted identifiers or quoted strings (including --custom-props)
+  const propPattern = /["']?([\w][\w-]*|--[\w-]+)["']?\s*:\s*"([^"]*?)"\s*[,}\n]/g;
+  let m;
+  while ((m = propPattern.exec(objSource)) !== null) {
+    if (m[1] === '$$css') continue;
+    classNames.push(m[2]);
+  }
+  return classNames;
+}
+
+function transformFile(filePath) {
+  let content = readFileSync(filePath, 'utf8');
+  const originalContent = content;
+  let needsRuntime = false;
+
+  // Step 1: Inline all $$css objects to strings
+  const cssObjPattern = /\{[^{}]*\$\$css:\s*true[^{}]*\}/gs;
+  content = content.replace(cssObjPattern, (match) => {
+    // Skip objects with dynamic values (ternaries, function calls)
+    if (/\?\s*"/.test(match) || /\w+\s*!=/.test(match)) {
+      return match;
+    }
+    const classNames = resolveToClassNames(match);
+    if (classNames.length === 0) return 'null'; // empty $$css → null
+    return JSON.stringify(classNames.join(' '));
+  });
+
+  // Step 2: Find and replace the stylex runtime import + props() calls.
+  // After bundling (@stylexjs/stylex is noExternal), the import becomes:
+  //   import { props } from "./chunk-XXXX.mjs";
+  // where the chunk contains the styleq runtime.
+  // We also handle the pre-bundle pattern: import * as stylex from "@stylexjs/stylex"
+
+  // Pattern A: bundled — import { props } from styleq chunk
+  // After noExternal bundling, stylex.props becomes a bare `props` import
+  // from the chunk containing the inlined styleq runtime.
+  // Strategy: replace the import source with our runtime, keeping the name.
+  const stylexChunkPattern = /import \{\s*props\s*\} from "(\.\/(chunk-[^"]+\.mjs))";/;
+  const stylexChunkImport = content.match(stylexChunkPattern);
+  if (stylexChunkImport) {
+    // Replace the chunk import with our runtime import, renaming to avoid collision
+    content = content.replace(
+      stylexChunkImport[0],
+      `import { ${RUNTIME_IMPORT_NAME} } from "./${RUNTIME_FILENAME}";`
+    );
+    // Rename all bare props( calls that came from stylex.
+    // These are never preceded by a dot (that would be obj.props) or a letter
+    // (that would be mergeProps, etc). They appear after: , ) ... = ( newline
+    content = content.replace(/([^.\w])props\(/g, `$1${RUNTIME_IMPORT_NAME}(`);
+    // Handle start-of-expression (e.g., spread: ...props()
+    content = content.replace(/\.\.\.props\(/g, `...${RUNTIME_IMPORT_NAME}(`);
+    needsRuntime = false; // import already added above
+  }
+
+  // Pattern B: pre-bundle — import * as stylex from "@stylexjs/stylex"
+  if (/stylex\d*\.props\(/.test(content)) {
+    content = content.replace(/stylex\d*\.props\(/g, `${RUNTIME_IMPORT_NAME}(`);
+    needsRuntime = true;
+  }
+  content = content.replace(/import \* as stylex\d* from ["']@stylexjs\/stylex["'];?\n?/g, '');
+  content = content.replace(/import \{[^}]*\} from ["']@stylexjs\/stylex["'];?\n?/g, '');
+
+  const modified = content !== originalContent;
+
+  // Step 4: Add runtime import
+  if (needsRuntime) {
+    const runtimeImport = `import { ${RUNTIME_IMPORT_NAME} } from "./${RUNTIME_FILENAME}";\n`;
+    const importMatches = [...content.matchAll(/^import .+$/gm)];
+    if (importMatches.length > 0) {
+      const lastImport = importMatches[importMatches.length - 1];
+      const insertPos = lastImport.index + lastImport[0].length + 1;
+      content = content.slice(0, insertPos) + runtimeImport + content.slice(insertPos);
+    } else {
+      content = runtimeImport + content;
+    }
+  }
+
+  if (modified || needsRuntime) {
+    writeFileSync(filePath, content, 'utf8');
+  }
+
+  return { modified: modified || needsRuntime, needsRuntime };
+}
+
+// Main
+console.log('Writing shared runtime...');
+writeFileSync(join(DIST_DIR, RUNTIME_FILENAME), RUNTIME_MODULE);
+
+const files = readdirSync(DIST_DIR).filter(f =>
+  f.endsWith('.mjs') && f !== RUNTIME_FILENAME
+);
+
+let stats = { transformed: 0, withRuntime: 0, inlined: 0, kept: 0 };
+
+for (const file of files) {
+  const filePath = join(DIST_DIR, file);
+  const before = readFileSync(filePath, 'utf8');
+  const cssCountBefore = (before.match(/\$\$css:\s*true/g) || []).length;
+
+  const result = transformFile(filePath);
+
+  if (result.modified) {
+    const after = readFileSync(filePath, 'utf8');
+    const cssCountAfter = (after.match(/\$\$css:\s*true/g) || []).length;
+    const inlined = cssCountBefore - cssCountAfter;
+
+    stats.transformed++;
+    stats.inlined += inlined;
+    stats.kept += cssCountAfter;
+    if (result.needsRuntime) stats.withRuntime++;
+
+    if (inlined > 0 || result.needsRuntime) {
+      console.log(`  ✓ ${file}: ${inlined}/${cssCountBefore} inlined${result.needsRuntime ? ' (+runtime)' : ''}`);
+    }
+  }
+}
+
+const runtimeSize = readFileSync(join(DIST_DIR, RUNTIME_FILENAME)).length;
+console.log(`\nResults:`);
+console.log(`  Inlined to strings: ${stats.inlined} objects`);
+console.log(`  Kept as $$css:      ${stats.kept} objects (dynamic values)`);
+console.log(`  Files transformed:  ${stats.transformed}`);
+console.log(`  Runtime size:       ${runtimeSize} bytes`);


### PR DESCRIPTION
## What

Post-build transform that resolves `$$css` style objects into pre-computed class name strings, replacing the styleq runtime with a 1.3KB shared module.

## Before / After

### XDSButton (fully inlined — no overrides)

**Before** — style objects with property keys, needs styleq dedup at runtime:
```js
import * as stylex from "@stylexjs/stylex";

var styles = {
  base: {
    kVAEAm: "x1n2onr6",
    k1xSpc: "x3nfvp2",
    kGNEyG: "x6s0dn4",
    kjj79g: "xl56j7k",
    kOIVth: "x1txdalj",
    k8WAf4: "xce4md1",
    kg3NbH: "xrrkdod",
    // ... 11 more keys
    $$css: true
  },
  iconOnly: {
    kOBAk4: "x1y5e3q9",
    kg3NbH: "xf314gf",
    $$css: true
  }
};
var sizeStyles = {
  sm: { kZKoxP: "xwfmp28", $$css: true },
  md: { kZKoxP: "x1k4gd0d", $$css: true },
  lg: { kZKoxP: "x1h5pcsu", $$css: true }
};
var variants = {
  primary: {
    kWkggS: "x1ewilqj",
    kMwMTN: "x1fee8ko",
    kKwaWg: "x18pxlv8 x1d1ta9r",
    kI3sdo: "x15mh19k",
    kInvED: "x1wfwxd8 xj3ae5l",
    $$css: true
  },
  // secondary, ghost, destructive...
};
var edgeCompStyles = {
  paddingInline2: {
    "--component-padding-inline": "x30uzy1",
    $$css: true
  },
  paddingInline3: {
    "--component-padding-inline": "x1ojg8sz",
    $$css: true
  }
};

// Runtime: stylex.props() calls styleq to walk objects, dedup by key, collect classes
stylex.props(styles.base, sizeStyles[size], variants[variant], ...)
```

**After** — plain strings, tiny runtime just concatenates:
```js
import { __stylexProps } from "./__stylex-runtime.mjs";

var styles = {
  base: "x1n2onr6 x3nfvp2 x6s0dn4 xl56j7k x1txdalj xce4md1 xrrkdod xc342km xng3xce xh6dtrn xjb2p0i x1kvm0al x1h1ro2g x1e4wzip x1ypdohk xqc8rvf x1kxdsx1 x3oybdh xk4oym4",
  iconOnly: "x1y5e3q9 xf314gf"
};
var sizeStyles = {
  sm: "xwfmp28",
  md: "x1k4gd0d",
  lg: "x1h5pcsu"
};
var variants = {
  primary: "x1ewilqj x1fee8ko x18pxlv8 x1d1ta9r x15mh19k x1wfwxd8 xj3ae5l",
  // ...
};
var edgeCompStyles = {
  paddingInline2: "x30uzy1",
  paddingInline3: "x1ojg8sz"
};

__stylexProps(styles.base, sizeStyles[size], variants[variant], ...)
```

### Components with null overrides (Button disabled, Calendar)

These are **kept as `$$css` objects** because null values need property-key deduplication:

```js
// Button disabled: k3aq6I: null removes hover transform from base
var styles = {
  base: {
    kkrTdU: "x1ypdohk",  // cursor: pointer
    k3aq6I: "x3oybdh xk4oym4",  // hover transform
    $$css: true
  },
  disabled: {
    kkrTdU: "x1h6gzvc",  // cursor: not-allowed (overrides base)
    k3aq6I: null,          // removes hover transform
    $$css: true
  }
};
```

Verified: disabled button correctly removes `cursor:pointer` and hover transform classes.

## Numbers

| Metric | Value |
|--------|-------|
| Objects inlined to strings | 661 / 717 (92.2%) |
| Objects kept as `$$css` | 56 (2 files with null overrides) |
| Runtime size | 1.3 KB (replaces 12KB stylex+styleq) |
| Chunk size delta | **-39 KB (-8.5%)** |

## Edge cases

- **Null overrides**: Files with null values keep ALL objects as `$$css` so dedup stays correct
- **`xstyle` passthrough**: Consumer `$$css` objects handled by the 1.3KB runtime
- **Dynamic conditionals** (ternaries like `size != null ? "x5lhr3w" : size`): Left as `$$css`
- **`--custom-property` keys**: Quoted keys matched correctly
- **Multi-class values** (shorthand properties): Space-separated classes joined correctly
- **Empty `$$css` objects**: Replaced with `null`