### PR TITLE
docs(theming): sync theming targets with xdsClassName() calls

### DIFF
--- a/packages/core/src/Kbd/Kbd.doc.mjs
+++ b/packages/core/src/Kbd/Kbd.doc.mjs
@@ -1,0 +1,69 @@
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'Kbd',
+  description:
+    'Displays a keyboard shortcut as styled <kbd> elements. Use in tooltips, menus, and documentation to show key combinations.',
+  features: [
+    'Key parsing — splits "mod+k" into individual styled <kbd> elements',
+    'Modifier symbols — maps mod/ctrl/alt/shift/enter/backspace/escape/arrows to platform symbols',
+    'Inline display — renders as inline-flex for use inside text, tooltips, and menus',
+    'Accessible — aria-hidden="true" since shortcuts are supplementary to visible labels',
+  ],
+  examples: [
+    {
+      label: 'Single shortcut',
+      code: '<XDSKbd keys="mod+k" />',
+    },
+    {
+      label: 'Multi-key shortcut',
+      code: '<XDSKbd keys="mod+shift+p" />',
+    },
+    {
+      label: 'In a tooltip or label',
+      code: `<span>
+  Search <XDSKbd keys="mod+k" />
+</span>`,
+    },
+  ],
+  props: [
+    {
+      name: 'keys',
+      type: 'string',
+      description:
+        'Keyboard shortcut string. Use "+" to separate keys. Special keys: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape, tab, up, down, left, right.',
+      required: true,
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
+    },
+    {
+      name: 'className',
+      type: 'string',
+      description:
+        'CSS class name for the root element. Prefer xstyle for styling — className is provided for integration with non-StyleX systems.',
+    },
+    {
+      name: 'style',
+      type: 'CSSProperties',
+      description:
+        'Inline styles for the root element. Prefer xstyle for styling — inline styles bypass StyleX optimization.',
+    },
+  ],
+  theming: {
+    targets: [{className: 'xds-kbd'}],
+  },
+  accessibility: [
+    'Renders with aria-hidden="true" — keyboard shortcuts are visual hints, not primary content',
+    'Uses semantic <kbd> elements for each key',
+  ],
+  keyboard: 'Not interactive — purely presentational',
+  notes: [
+    'Fixed 20px height with min-width 20px per key badge',
+    'Uses --color-wash background and --color-text-secondary text color',
+    'Key display symbols follow macOS conventions (⌘, ⌥, ⇧, ⌃)',
+  ],
+};

--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -183,6 +183,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-switch'},
+      {className: 'xds-switch-field'},
     ],
   },
   accessibility: [


### PR DESCRIPTION
## What

Two theming doc gaps found during Night Watch doc review:

1. **Switch** — `xdsClassName('switch-field')` exists in source but `xds-switch-field` was missing from `Switch.doc.mjs` theming targets. Added it.
2. **Kbd** — `xdsClassName('kbd')` exists in source but Kbd had no `.doc.mjs` file at all. Created `Kbd.doc.mjs` with full props, examples, theming, and accessibility docs.

## Checklist
- [x] `yarn workspace @xds/core typecheck:docs` passes
- [x] CLI `--compact` output verified for Kbd
- [x] Theming sync audit passes (all `xdsClassName()` calls have matching doc entries)
- [x] No Storybook ```tsx` in docblocks
- [x] Common props (`xstyle`, `className`, `style`) documented for Kbd

---
*Found during Night Watch doc review*