### PR TITLE
docs(cli): add missing leading tokens to tokens.md

### DIFF
--- a/packages/cli/docs/tokens.md
+++ b/packages/cli/docs/tokens.md
@@ -114,6 +114,16 @@ Control heights for consistent sizing across buttons, inputs, and selectors.
 - `--font-weight-semibold`: 600
 - `--font-weight-bold`: 700
 
+### Line Heights (Leading)
+
+| Token            | Value  | Usage                        |
+| ---------------- | ------ | ---------------------------- |
+| --leading-tight  | 1.25   | Display text, headings       |
+| --leading-snug   | 1.375  | Compact body text, headings  |
+| --leading-base   | 1.4286 | Body text with --text-base   |
+| --leading-normal | 1.5    | Body text, large body        |
+| --leading-relaxed| 1.625  | Editorial body, reading text |
+
 ## Usage in StyleX
 
 ```tsx


### PR DESCRIPTION
## Summary

The CLI tokens documentation was missing the line-height (leading) tokens. These tokens are defined in `packages/core/src/theme/tokens.stylex.ts` (as `lineHeightDefaults`) but were not documented in `packages/cli/docs/tokens.md`.

## Changes

Added the **Line Heights (Leading)** section to the Typography Tokens documentation:

| Token | Value | Usage |
|-------|-------|-------|
| `--leading-tight` | 1.25 | Display text, headings |
| `--leading-snug` | 1.375 | Compact body text, headings |
| `--leading-base` | 1.4286 | Body text with --text-base |
| `--leading-normal` | 1.5 | Body text, large body |
| `--leading-relaxed` | 1.625 | Editorial body, reading text |

## Test Plan

Documentation-only change. Verified the values match `lineHeightDefaults` in `tokens.stylex.ts`.