### PR TITLE
fix(Breadcrumbs): fix current item vertical centering

### DIFF
--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -75,6 +75,7 @@ const itemStyles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
     lineHeight: lineHeightVars['--leading-snug'],
+    margin: 0,
   },
   defaultSize: {
     fontSize: textSizeVars['--text-sm'],
@@ -87,7 +88,6 @@ const itemStyles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
     lineHeight: lineHeightVars['--leading-snug'],
-    paddingBlock: spacingVars['--spacing-1'],
   },
   link: {
     display: 'flex',


### PR DESCRIPTION
## Summary

The current (active) breadcrumb item was visually off-center.

## Root Cause

- The current item's inner span had `paddingBlock: spacing-1` (4px) via the `contentWrapper` style
- This extra padding caused the current item to appear vertically off-center compared to other breadcrumb items and separators

## Fix

- Remove `paddingBlock` from the `contentWrapper` style
- This makes the current item's vertical sizing consistent with the flex container's alignment

## Testing

- All 23 Breadcrumbs tests pass
- Full test suite (1433 tests) passes
