### PR TITLE
Exploration: Ratio-based type scale system

### DIFF
--- a/.context/explorations/ratio-based-type-scale.md
+++ b/.context/explorations/ratio-based-type-scale.md
@@ -1,0 +1,210 @@
+# Exploration: Ratio-Based Type Scale
+
+**Status:** Draft  
+**Author:** Navi  
+**Date:** 2025-03-09
+
+## Problem Statement
+
+XDS currently has two parallel type scale systems:
+
+1. **Default scale** — Dense, optimized for internal tools (base: 14px)
+2. **Editorial scale** — Larger, optimized for content-heavy pages
+
+This creates confusion:
+
+- "When do I use editorial vs regular?"
+- "Do I need to support both in my component?"
+- "What if I want something in between?"
+
+Products have varying needs — some want dense admin UIs, others want more editorial layouts. Today, they must choose between two fixed scales or manually override tokens.
+
+## Proposed Solution
+
+Replace explicit font size tokens with a **ratio-based type scale** system, inspired by [typescale.com](https://typescale.com/).
+
+### How It Works
+
+Instead of explicit tokens:
+
+```typescript
+// Current approach
+textSizeDefaults = {
+  '--text-xsm': '0.75rem', // 12px
+  '--text-sm': '0.8125rem', // 13px
+  '--text-base': '0.875rem', // 14px
+  '--text-lg': '1rem', // 16px
+  // ...
+};
+```
+
+Define a base and ratio:
+
+```typescript
+// Proposed approach
+typeScale: {
+  base: 16,        // Base font size in px
+  ratio: 1.25,     // Major Third scale
+  lineHeightGrid: 4, // Snap line heights to 4px grid
+}
+```
+
+The system generates sizes mathematically:
+
+```
+base × ratio^-2 = 10.24px → 10px (xs)
+base × ratio^-1 = 12.8px  → 13px (sm)
+base × ratio^0  = 16px    → 16px (md/base)
+base × ratio^1  = 20px    → 20px (lg)
+base × ratio^2  = 25px    → 25px (xl)
+base × ratio^3  = 31.25px → 31px (2xl)
+```
+
+### Theme Presets
+
+Products choose their density by adjusting two values:
+
+| Preset    | Base | Ratio                  | Character                 |
+| --------- | ---- | ---------------------- | ------------------------- |
+| Dense     | 14px | 1.125 (Minor Second)   | Tight, data-heavy         |
+| Default   | 16px | 1.25 (Major Third)     | Balanced                  |
+| Editorial | 18px | 1.333 (Perfect Fourth) | Dramatic, content-focused |
+
+Same semantic tokens (`fontSize.md`, `fontSize.lg`), different computed output.
+
+### Line Height: 4px Grid Snapping
+
+For each computed font size, line height snaps to the nearest 4px grid value within a readable range (1.2–1.6×):
+
+```typescript
+function computeLineHeight(fontSize: number, grid = 4): number {
+  // Target ratio varies by size (tighter for large text)
+  const targetRatio = fontSize < 20 ? 1.5 : fontSize < 32 ? 1.4 : 1.25;
+  const ideal = fontSize * targetRatio;
+  const snapped = Math.round(ideal / grid) * grid;
+
+  // Ensure minimum breathing room
+  const minimum = Math.ceil((fontSize + 4) / grid) * grid;
+  return Math.max(snapped, minimum);
+}
+```
+
+## Trade-off Analysis
+
+### Advantages
+
+| Benefit                       | Why It Matters                                                     |
+| ----------------------------- | ------------------------------------------------------------------ |
+| **Unified system**            | Eliminates editorial vs default confusion — one scale, themed      |
+| **Mathematical harmony**      | Ratios create inherent visual rhythm — sizes feel "related"        |
+| **Simpler theming**           | Change 2 values (base, ratio) instead of 10+ individual tokens     |
+| **Density spectrum**          | Products can be anywhere on dense↔editorial spectrum               |
+| **Scales naturally**          | Responsive scaling: change base at breakpoints, everything adjusts |
+| **Fewer arbitrary decisions** | "What should fontSize500 be?" is answered by math, not debate      |
+
+### Disadvantages
+
+| Drawback                   | Why It Hurts                                                           |
+| -------------------------- | ---------------------------------------------------------------------- |
+| **Fractional pixels**      | `ratio^n` rarely lands on whole pixels — requires rounding             |
+| **Loss of fine control**   | Can't say "I need exactly 14px" without breaking the system            |
+| **Awkward gaps**           | Some ratios produce sizes too close (13, 14) or too far apart (20, 28) |
+| **Line height tension**    | 4px grid + ratio-derived sizes = compromises (see below)               |
+| **Harder to match specs**  | Designers often spec exact sizes; ratio math may not hit them          |
+| **Semantic meaning drift** | `fontSize.sm` means different things in different themes               |
+
+## The Core Tension: Ratios vs. Grids
+
+**Ratios are multiplicative. Grids are additive.**
+
+A 1.25 ratio from 16px: 16, 20, 25, 31.25, 39.06...  
+A 4px grid wants: 16, 20, 24, 28, 32, 36, 40...
+
+They don't align perfectly. We must choose:
+
+1. **Round font sizes to grid** → breaks ratio's visual harmony
+2. **Keep exact ratios** → accept non-grid font sizes, only snap line-height
+3. **Hybrid** → use ratio as a guide, manually adjust to "close enough" grid values
+
+This exploration recommends option 2: keep ratio-derived font sizes (rounded to nearest pixel), snap only line heights to the 4px grid.
+
+## Computed Examples
+
+### Dense Theme (14px base, 1.125 ratio)
+
+| Token | Exponent | Raw     | Rounded | Line Height |
+| ----- | -------- | ------- | ------- | ----------- |
+| xs    | -2       | 11.06px | 11px    | 16px (1.45) |
+| sm    | -1       | 12.44px | 12px    | 16px (1.33) |
+| md    | 0        | 14px    | 14px    | 20px (1.43) |
+| lg    | 1        | 15.75px | 16px    | 24px (1.50) |
+| xl    | 2        | 17.72px | 18px    | 24px (1.33) |
+| 2xl   | 3        | 19.93px | 20px    | 28px (1.40) |
+| 3xl   | 4        | 22.43px | 22px    | 32px (1.45) |
+
+### Default Theme (16px base, 1.25 ratio)
+
+| Token | Exponent | Raw     | Rounded | Line Height |
+| ----- | -------- | ------- | ------- | ----------- |
+| xs    | -2       | 10.24px | 10px    | 16px (1.60) |
+| sm    | -1       | 12.8px  | 13px    | 20px (1.54) |
+| md    | 0        | 16px    | 16px    | 24px (1.50) |
+| lg    | 1        | 20px    | 20px    | 28px (1.40) |
+| xl    | 2        | 25px    | 25px    | 36px (1.44) |
+| 2xl   | 3        | 31.25px | 31px    | 44px (1.42) |
+| 3xl   | 4        | 39.06px | 39px    | 52px (1.33) |
+
+### Editorial Theme (18px base, 1.333 ratio)
+
+| Token | Exponent | Raw     | Rounded | Line Height |
+| ----- | -------- | ------- | ------- | ----------- |
+| xs    | -2       | 10.13px | 10px    | 16px (1.60) |
+| sm    | -1       | 13.5px  | 14px    | 20px (1.43) |
+| md    | 0        | 18px    | 18px    | 28px (1.56) |
+| lg    | 1        | 23.99px | 24px    | 32px (1.33) |
+| xl    | 2        | 31.98px | 32px    | 40px (1.25) |
+| 2xl   | 3        | 42.63px | 43px    | 52px (1.21) |
+| 3xl   | 4        | 56.83px | 57px    | 68px (1.19) |
+
+## Open Questions
+
+1. **Collision handling**: With tight ratios (1.125), adjacent sizes can round to the same value. Enforce minimum step (2px)?
+
+2. **Escape hatch**: How do products specify exact sizes when needed? Raw values break theming.
+
+3. **Token naming**: Keep numeric (`--text-100`, `--text-200`) or switch to semantic (`--text-xs`, `--text-sm`)?
+
+4. **Runtime vs build-time**: Generate at build time (static CSS) or runtime (CSS custom properties with calc())?
+
+5. **Migration path**: How do existing consumers migrate from explicit tokens to ratio-based?
+
+## Prototype
+
+A working prototype is available in the sandbox app at `/pages/type-scale-explorer/`.
+
+It allows interactive adjustment of:
+
+- Base font size (12–24px)
+- Type ratio (1.067–1.618)
+- Line height grid (2px, 4px, 8px)
+
+With live preview of the computed scale applied to real typography.
+
+## Recommendation
+
+This approach **makes sense for XDS** given the goal of themeable density:
+
+| Goal                                     | Achieved?                                       |
+| ---------------------------------------- | ----------------------------------------------- |
+| Eliminate editorial vs default confusion | ✅ Yes                                          |
+| Enable dense ↔ editorial spectrum        | ✅ Yes                                          |
+| Preserve 4px grid alignment              | ⚠️ Mostly (line heights snap, font sizes round) |
+| Simple theming                           | ✅ Yes (2 values vs 10+)                        |
+| Pixel-perfect control                    | ❌ No (trading precision for flexibility)       |
+
+**Next steps:**
+
+1. Validate the prototype feels right across different theme presets
+2. Decide on collision handling and escape hatch strategies
+3. Design the token API surface
+4. Plan migration path from current tokens

--- a/.context/explorations/ratio-based-type-scale.md
+++ b/.context/explorations/ratio-based-type-scale.md
@@ -64,11 +64,11 @@ base × ratio^3  = 31.25px → 31px (2xl)
 
 Products choose their density by adjusting two values:
 
-| Preset    | Base | Ratio                  | Character                 |
-| --------- | ---- | ---------------------- | ------------------------- |
-| Dense     | 14px | 1.125 (Minor Second)   | Tight, data-heavy         |
-| Default   | 16px | 1.25 (Major Third)     | Balanced                  |
-| Editorial | 18px | 1.333 (Perfect Fourth) | Dramatic, content-focused |
+| Preset    | Base | Ratio                | Character                 |
+| --------- | ---- | -------------------- | ------------------------- |
+| Dense     | 14px | 1.125 (Minor Second) | Tight, data-heavy         |
+| Default   | 16px | 1.25 (Major Third)   | Balanced                  |
+| Editorial | 16px | 1.25 (Major Third)   | Dramatic, content-focused |
 
 Same semantic tokens (`fontSize.md`, `fontSize.lg`), different computed output.
 
@@ -130,41 +130,41 @@ This exploration recommends option 2: keep ratio-derived font sizes (rounded to 
 
 ## Computed Examples
 
-### Dense Theme (14px base, 1.125 ratio)
+### Dense Theme (12px base, 1.125 ratio)
+
+| Token | Exponent | Raw     | Rounded | Line Height |
+| ----- | -------- | ------- | ------- | ----------- |
+| xs    | -2       | 9.48px  | 9px     | 16px (1.78) |
+| sm    | -1       | 10.67px | 11px    | 16px (1.45) |
+| md    | 0        | 12.00px | 12px    | 16px (1.33) |
+| lg    | 1        | 13.50px | 14px    | 20px (1.43) |
+| xl    | 2        | 15.19px | 15px    | 24px (1.60) |
+| 2xl   | 3        | 17.09px | 17px    | 24px (1.41) |
+| 3xl   | 4        | 19.22px | 19px    | 28px (1.47) |
+
+### Default Theme (14px base, 1.125 ratio)
 
 | Token | Exponent | Raw     | Rounded | Line Height |
 | ----- | -------- | ------- | ------- | ----------- |
 | xs    | -2       | 11.06px | 11px    | 16px (1.45) |
 | sm    | -1       | 12.44px | 12px    | 16px (1.33) |
-| md    | 0        | 14px    | 14px    | 20px (1.43) |
+| md    | 0        | 14.00px | 14px    | 20px (1.43) |
 | lg    | 1        | 15.75px | 16px    | 24px (1.50) |
-| xl    | 2        | 17.72px | 18px    | 24px (1.33) |
+| xl    | 2        | 17.72px | 18px    | 28px (1.56) |
 | 2xl   | 3        | 19.93px | 20px    | 28px (1.40) |
 | 3xl   | 4        | 22.43px | 22px    | 32px (1.45) |
 
-### Default Theme (16px base, 1.25 ratio)
+### Editorial Theme (16px base, 1.25 ratio)
 
 | Token | Exponent | Raw     | Rounded | Line Height |
 | ----- | -------- | ------- | ------- | ----------- |
 | xs    | -2       | 10.24px | 10px    | 16px (1.60) |
-| sm    | -1       | 12.8px  | 13px    | 20px (1.54) |
-| md    | 0        | 16px    | 16px    | 24px (1.50) |
-| lg    | 1        | 20px    | 20px    | 28px (1.40) |
-| xl    | 2        | 25px    | 25px    | 36px (1.44) |
+| sm    | -1       | 12.80px | 13px    | 20px (1.54) |
+| md    | 0        | 16.00px | 16px    | 24px (1.50) |
+| lg    | 1        | 20.00px | 20px    | 28px (1.40) |
+| xl    | 2        | 25.00px | 25px    | 36px (1.44) |
 | 2xl   | 3        | 31.25px | 31px    | 44px (1.42) |
-| 3xl   | 4        | 39.06px | 39px    | 52px (1.33) |
-
-### Editorial Theme (18px base, 1.333 ratio)
-
-| Token | Exponent | Raw     | Rounded | Line Height |
-| ----- | -------- | ------- | ------- | ----------- |
-| xs    | -2       | 10.13px | 10px    | 16px (1.60) |
-| sm    | -1       | 13.5px  | 14px    | 20px (1.43) |
-| md    | 0        | 18px    | 18px    | 28px (1.56) |
-| lg    | 1        | 23.99px | 24px    | 32px (1.33) |
-| xl    | 2        | 31.98px | 32px    | 40px (1.25) |
-| 2xl   | 3        | 42.63px | 43px    | 52px (1.21) |
-| 3xl   | 4        | 56.83px | 57px    | 68px (1.19) |
+| 3xl   | 4        | 39.06px | 39px    | 48px (1.23) |
 
 ## Open Questions
 

--- a/.context/explorations/ratio-based-type-scale.md
+++ b/.context/explorations/ratio-based-type-scale.md
@@ -166,17 +166,21 @@ This exploration recommends option 2: keep ratio-derived font sizes (rounded to 
 | 2xl   | 3        | 31.25px | 31px    | 44px (1.42) |
 | 3xl   | 4        | 39.06px | 39px    | 48px (1.23) |
 
+## Decisions
+
+1. **Collision handling**: Enforce a **1px minimum step** between adjacent sizes. If two steps round to the same value, nudge the smaller one down or larger one up.
+
+2. **Escape hatch**: Still open — how do products specify exact sizes when the ratio doesn't produce what they need? Needs further discussion.
+
+3. **Token naming**: Keep **semantic names** (`--text-xs`, `--text-sm`, `--text-base`, etc.) — consistent with current XDS convention.
+
+4. **Build vs runtime**: Generate at **build time** — static CSS output, no runtime calc() overhead. Themes define base + ratio, the build step computes concrete pixel values.
+
 ## Open Questions
 
-1. **Collision handling**: With tight ratios (1.125), adjacent sizes can round to the same value. Enforce minimum step (2px)?
+1. **Escape hatch** — How do products specify exact sizes when the ratio doesn't produce what they need? Raw values break theming.
 
-2. **Escape hatch**: How do products specify exact sizes when needed? Raw values break theming.
-
-3. **Token naming**: Keep numeric (`--text-100`, `--text-200`) or switch to semantic (`--text-xs`, `--text-sm`)?
-
-4. **Runtime vs build-time**: Generate at build time (static CSS) or runtime (CSS custom properties with calc())?
-
-5. **Migration path**: How do existing consumers migrate from explicit tokens to ratio-based?
+2. **Migration path** — How do existing consumers migrate from explicit tokens to ratio-based?
 
 ## Prototype
 

--- a/.context/explorations/ratio-based-type-scale.md
+++ b/.context/explorations/ratio-based-type-scale.md
@@ -8,7 +8,7 @@
 
 XDS currently has two parallel type scale systems:
 
-1. **Default scale** — Dense, optimized for internal tools (base: 14px)
+1. **Default scale** — Functional, optimized for internal tools (base: 14px)
 2. **Editorial scale** — Larger, optimized for content-heavy pages
 
 This creates confusion:
@@ -17,7 +17,7 @@ This creates confusion:
 - "Do I need to support both in my component?"
 - "What if I want something in between?"
 
-Products have varying needs — some want dense admin UIs, others want more editorial layouts. Today, they must choose between two fixed scales or manually override tokens.
+Products have varying needs — some want functional admin UIs, others want more editorial layouts. Today, they must choose between two fixed scales or manually override tokens.
 
 ## Proposed Solution
 
@@ -64,11 +64,11 @@ base × ratio^3  = 31.25px → 31px (2xl)
 
 Products choose their density by adjusting two values:
 
-| Preset    | Base | Ratio                | Character                 |
-| --------- | ---- | -------------------- | ------------------------- |
-| Dense     | 14px | 1.125 (Minor Second) | Tight, data-heavy         |
-| Default   | 16px | 1.25 (Major Third)   | Balanced                  |
-| Editorial | 16px | 1.25 (Major Third)   | Dramatic, content-focused |
+| Preset     | Base | Ratio                | Character                 |
+| ---------- | ---- | -------------------- | ------------------------- |
+| Functional | 12px | 1.125 (Major Second) | Tight, data-heavy         |
+| Default    | 16px | 1.25 (Major Third)   | Balanced                  |
+| Editorial  | 16px | 1.25 (Major Third)   | Dramatic, content-focused |
 
 Same semantic tokens (`fontSize.md`, `fontSize.lg`), different computed output.
 
@@ -98,7 +98,7 @@ function computeLineHeight(fontSize: number, grid = 4): number {
 | **Unified system**            | Eliminates editorial vs default confusion — one scale, themed      |
 | **Mathematical harmony**      | Ratios create inherent visual rhythm — sizes feel "related"        |
 | **Simpler theming**           | Change 2 values (base, ratio) instead of 10+ individual tokens     |
-| **Density spectrum**          | Products can be anywhere on dense↔editorial spectrum               |
+| **Density spectrum**          | Products can be anywhere on functional↔editorial spectrum          |
 | **Scales naturally**          | Responsive scaling: change base at breakpoints, everything adjusts |
 | **Fewer arbitrary decisions** | "What should fontSize500 be?" is answered by math, not debate      |
 
@@ -130,7 +130,7 @@ This exploration recommends option 2: keep ratio-derived font sizes (rounded to 
 
 ## Computed Examples
 
-### Dense Theme (12px base, 1.125 ratio)
+### Functional Theme (12px base, 1.125 ratio)
 
 | Token | Exponent | Raw     | Rounded | Line Height |
 | ----- | -------- | ------- | ------- | ----------- |
@@ -197,7 +197,7 @@ This approach **makes sense for XDS** given the goal of themeable density:
 | Goal                                     | Achieved?                                       |
 | ---------------------------------------- | ----------------------------------------------- |
 | Eliminate editorial vs default confusion | ✅ Yes                                          |
-| Enable dense ↔ editorial spectrum        | ✅ Yes                                          |
+| Enable functional ↔ editorial spectrum   | ✅ Yes                                          |
 | Preserve 4px grid alignment              | ⚠️ Mostly (line heights snap, font sizes round) |
 | Simple theming                           | ✅ Yes (2 values vs 10+)                        |
 | Pixel-perfect control                    | ❌ No (trading precision for flexibility)       |

--- a/apps/sandbox/src/app/Sidebar.tsx
+++ b/apps/sandbox/src/app/Sidebar.tsx
@@ -24,6 +24,7 @@ const pages = [
   {name: 'Mega Menu', href: '/pages/mega-menu/'},
   {name: 'Polymorphic Link', href: '/pages/polymorphic-link/'},
   {name: 'Table Overview', href: '/pages/table-overview/'},
+  {name: 'Type Scale Explorer', href: '/pages/type-scale-explorer/'},
 ];
 
 const styles = stylex.create({

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -181,6 +181,7 @@ function generateRawScale(config: TypeScaleConfig): RawScaleStep[] {
 const PRESETS: Record<string, TypeScaleConfig> = {
   functional: {base: 12, ratio: 1.125, lineHeightGrid: 4},
   default: {base: 14, ratio: 1.125, lineHeightGrid: 4},
+  'default-proposed': {base: 14, ratio: 1.2, lineHeightGrid: 4},
   editorial: {base: 16, ratio: 1.25, lineHeightGrid: 4},
 };
 
@@ -194,6 +195,16 @@ const RATIOS: Record<string, number> = {
   'Perfect Fifth (1.5)': 1.5,
   'Golden Ratio (1.618)': 1.618,
 };
+
+function presetLabel(key: string): string {
+  const labels: Record<string, string> = {
+    functional: 'Functional',
+    default: 'Default',
+    'default-proposed': 'Default (Proposed)',
+    editorial: 'Editorial',
+  };
+  return labels[key] ?? key.charAt(0).toUpperCase() + key.slice(1);
+}
 
 // =============================================================================
 // Styles
@@ -599,7 +610,7 @@ export default function TypeScaleExplorerPage() {
                       activePreset === name && st.presetBtnActive,
                     )}
                     onClick={() => setConfig(preset)}>
-                    {name.charAt(0).toUpperCase() + name.slice(1)}
+                    {presetLabel(name)}
                   </button>
                 ))}
               </XDSHStack>
@@ -1103,9 +1114,7 @@ export default function TypeScaleExplorerPage() {
                 return (
                   <div key={name} style={{flex: 1}}>
                     <XDSVStack gap={2}>
-                      <XDSText type="label">
-                        {name.charAt(0).toUpperCase() + name.slice(1)}
-                      </XDSText>
+                      <XDSText type="label">{presetLabel(name)}</XDSText>
                       <XDSText type="supporting" color="secondary">
                         {preset.base}px base, {preset.ratio} ratio
                       </XDSText>

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -51,13 +51,13 @@ const TYPE_ROLES: Array<{
   {name: 'h5', role: 'heading', exponent: -1, weight: 600},
   {name: 'h6', role: 'heading', exponent: -2, weight: 600},
   // Body
-  {name: 'body-lg', role: 'body', exponent: 0, weight: 400},
-  {name: 'body', role: 'body', exponent: -1, weight: 400},
-  {name: 'body-sm', role: 'body', exponent: -2, weight: 400},
-  {name: 'label', role: 'body', exponent: -1, weight: 500},
+  {name: 'body-lg', role: 'body', exponent: 1, weight: 400},
+  {name: 'body', role: 'body', exponent: 0, weight: 400},
+  {name: 'body-sm', role: 'body', exponent: -1, weight: 400},
+  {name: 'label', role: 'body', exponent: 0, weight: 500},
   // Supporting
-  {name: 'supporting', role: 'supporting', exponent: -2, weight: 400},
-  {name: 'caption', role: 'supporting', exponent: -3, weight: 400},
+  {name: 'supporting', role: 'supporting', exponent: -1, weight: 400},
+  {name: 'caption', role: 'supporting', exponent: -2, weight: 400},
 ];
 
 function computeLineHeight(

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -67,9 +67,9 @@ function generateTypeScale(config: TypeScaleConfig): TypeScaleStep[] {
 // =============================================================================
 
 const PRESETS: Record<string, TypeScaleConfig> = {
-  dense: {base: 14, ratio: 1.125, lineHeightGrid: 4},
-  default: {base: 16, ratio: 1.25, lineHeightGrid: 4},
-  editorial: {base: 18, ratio: 1.333, lineHeightGrid: 4},
+  dense: {base: 12, ratio: 1.125, lineHeightGrid: 4},
+  default: {base: 14, ratio: 1.125, lineHeightGrid: 4},
+  editorial: {base: 16, ratio: 1.25, lineHeightGrid: 4},
 };
 
 const RATIOS: Record<string, number> = {

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -942,8 +942,8 @@ export default function TypeScaleExplorerPage() {
                   <span
                     key={link}
                     style={{
-                      fontSize: getStyle('body-sm').fontSize,
-                      fontWeight: getStyle('body-sm').weight,
+                      fontSize: getStyle('body').fontSize,
+                      fontWeight: getStyle('body').weight,
                     }}
                     {...stylex.props(st.landingNavLink)}>
                     {link}
@@ -955,7 +955,7 @@ export default function TypeScaleExplorerPage() {
             <div {...stylex.props(st.landingHero)}>
               <p
                 style={{
-                  fontSize: getStyle('supporting').fontSize,
+                  fontSize: getStyle('body-sm').fontSize,
                   fontWeight: 500,
                   letterSpacing: '0.08em',
                   textTransform: 'uppercase',
@@ -989,9 +989,9 @@ export default function TypeScaleExplorerPage() {
               </div>
               <p
                 style={{
-                  fontSize: getStyle('caption').fontSize,
-                  lineHeight: `${getStyle('caption').lineHeight}px`,
-                  fontWeight: getStyle('caption').weight,
+                  fontSize: getStyle('body-sm').fontSize,
+                  lineHeight: `${getStyle('body-sm').lineHeight}px`,
+                  fontWeight: getStyle('body-sm').weight,
                   marginTop: 16,
                   color: 'light-dark(#999, #666)',
                 }}>
@@ -1061,9 +1061,9 @@ export default function TypeScaleExplorerPage() {
                     </h3>
                     <p
                       style={{
-                        fontSize: getStyle('body-sm').fontSize,
-                        lineHeight: `${getStyle('body-sm').lineHeight}px`,
-                        fontWeight: getStyle('body-sm').weight,
+                        fontSize: getStyle('body').fontSize,
+                        lineHeight: `${getStyle('body').lineHeight}px`,
+                        fontWeight: getStyle('body').weight,
                       }}
                       {...stylex.props(st.landingFeatureDesc)}>
                       {feature.desc}
@@ -1253,14 +1253,13 @@ const TABLE_DATA = [
 const BAR_HEIGHTS = [45, 62, 38, 78, 55, 42, 88, 65, 50, 72, 58, 82];
 
 function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
-  const caption = getStyle('caption');
-  const supporting = getStyle('supporting');
   const bodySm = getStyle('body-sm');
   const body = getStyle('body');
   const label = getStyle('label');
   const h3 = getStyle('h3');
   const h4 = getStyle('h4');
   const h1 = getStyle('h1');
+  const display3 = getStyle('display-3');
 
   return (
     <div {...stylex.props(st.dashPreview)}>
@@ -1272,7 +1271,7 @@ function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
           Analytics Dashboard
         </span>
         <span
-          style={{fontSize: caption.fontSize, fontWeight: caption.weight}}
+          style={{fontSize: bodySm.fontSize, fontWeight: bodySm.weight}}
           {...stylex.props(st.landingNavLink)}>
           Last 30 days · Jan 1 – Jan 30, 2026
         </span>
@@ -1294,9 +1293,9 @@ function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
             </h2>
             <p
               style={{
-                fontSize: supporting.fontSize,
-                lineHeight: `${supporting.lineHeight}px`,
-                fontWeight: supporting.weight,
+                fontSize: bodySm.fontSize,
+                lineHeight: `${bodySm.lineHeight}px`,
+                fontWeight: bodySm.weight,
                 margin: '4px 0 0 0',
                 color: 'light-dark(#666, #aaa)',
               }}>
@@ -1332,8 +1331,8 @@ function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
             <div key={kpi.label} {...stylex.props(st.dashKpiCard)}>
               <p
                 style={{
-                  fontSize: caption.fontSize,
-                  lineHeight: `${caption.lineHeight}px`,
+                  fontSize: bodySm.fontSize,
+                  lineHeight: `${bodySm.lineHeight}px`,
                   fontWeight: 500,
                   textTransform: 'uppercase',
                   letterSpacing: '0.04em',
@@ -1343,17 +1342,17 @@ function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
               </p>
               <p
                 style={{
-                  fontSize: h4.fontSize,
-                  lineHeight: `${h4.lineHeight}px`,
-                  fontWeight: h4.weight,
+                  fontSize: display3.fontSize,
+                  lineHeight: `${display3.lineHeight}px`,
+                  fontWeight: display3.weight,
                 }}
                 {...stylex.props(st.dashKpiValue)}>
                 {kpi.value}
               </p>
               <p
                 style={{
-                  fontSize: caption.fontSize,
-                  lineHeight: `${caption.lineHeight}px`,
+                  fontSize: bodySm.fontSize,
+                  lineHeight: `${bodySm.lineHeight}px`,
                   fontWeight: 500,
                   color: kpi.up
                     ? 'light-dark(#0D8626, #26A756)'
@@ -1396,21 +1395,21 @@ function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
               }}>
               <span
                 style={{
-                  fontSize: caption.fontSize,
+                  fontSize: bodySm.fontSize,
                   color: 'light-dark(#999, #666)',
                 }}>
                 Jan
               </span>
               <span
                 style={{
-                  fontSize: caption.fontSize,
+                  fontSize: bodySm.fontSize,
                   color: 'light-dark(#999, #666)',
                 }}>
                 Jun
               </span>
               <span
                 style={{
-                  fontSize: caption.fontSize,
+                  fontSize: bodySm.fontSize,
                   color: 'light-dark(#999, #666)',
                 }}>
                 Dec
@@ -1442,7 +1441,7 @@ function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
               </p>
               <p
                 style={{
-                  fontSize: caption.fontSize,
+                  fontSize: bodySm.fontSize,
                   margin: '2px 0 0 0',
                   color: 'light-dark(#666, #aaa)',
                 }}>
@@ -1472,7 +1471,7 @@ function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
             </h3>
             <span
               style={{
-                fontSize: caption.fontSize,
+                fontSize: bodySm.fontSize,
                 color: 'light-dark(#0064E0, #2694FE)',
                 cursor: 'pointer',
               }}>
@@ -1488,7 +1487,7 @@ function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
                       <th
                         key={col}
                         style={{
-                          fontSize: caption.fontSize,
+                          fontSize: bodySm.fontSize,
                           fontWeight: 600,
                           textTransform: 'uppercase',
                           letterSpacing: '0.04em',

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -1,0 +1,479 @@
+'use client';
+
+import {useState, useMemo} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSDivider} from '@xds/core';
+
+// =============================================================================
+// Type Scale Computation
+// =============================================================================
+
+interface TypeScaleConfig {
+  base: number;
+  ratio: number;
+  lineHeightGrid: number;
+}
+
+interface TypeScaleStep {
+  name: string;
+  exponent: number;
+  rawSize: number;
+  fontSize: number;
+  lineHeight: number;
+  lineHeightRatio: number;
+}
+
+const SCALE_STEPS = [
+  {name: 'xs', exponent: -2},
+  {name: 'sm', exponent: -1},
+  {name: 'md', exponent: 0},
+  {name: 'lg', exponent: 1},
+  {name: 'xl', exponent: 2},
+  {name: '2xl', exponent: 3},
+  {name: '3xl', exponent: 4},
+];
+
+function computeLineHeight(fontSize: number, grid: number): number {
+  // Target ratio varies by size (tighter for large text)
+  const targetRatio = fontSize < 20 ? 1.5 : fontSize < 32 ? 1.4 : 1.25;
+  const ideal = fontSize * targetRatio;
+  const snapped = Math.round(ideal / grid) * grid;
+
+  // Ensure minimum breathing room
+  const minimum = Math.ceil((fontSize + 4) / grid) * grid;
+  return Math.max(snapped, minimum);
+}
+
+function generateTypeScale(config: TypeScaleConfig): TypeScaleStep[] {
+  return SCALE_STEPS.map(step => {
+    const rawSize = config.base * Math.pow(config.ratio, step.exponent);
+    const fontSize = Math.round(rawSize);
+    const lineHeight = computeLineHeight(fontSize, config.lineHeightGrid);
+
+    return {
+      ...step,
+      rawSize,
+      fontSize,
+      lineHeight,
+      lineHeightRatio: lineHeight / fontSize,
+    };
+  });
+}
+
+// =============================================================================
+// Preset Configurations
+// =============================================================================
+
+const PRESETS: Record<string, TypeScaleConfig> = {
+  dense: {base: 14, ratio: 1.125, lineHeightGrid: 4},
+  default: {base: 16, ratio: 1.25, lineHeightGrid: 4},
+  editorial: {base: 18, ratio: 1.333, lineHeightGrid: 4},
+};
+
+const RATIOS: Record<string, number> = {
+  'Minor Second (1.067)': 1.067,
+  'Major Second (1.125)': 1.125,
+  'Minor Third (1.2)': 1.2,
+  'Major Third (1.25)': 1.25,
+  'Perfect Fourth (1.333)': 1.333,
+  'Augmented Fourth (1.414)': 1.414,
+  'Perfect Fifth (1.5)': 1.5,
+  'Golden Ratio (1.618)': 1.618,
+};
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  container: {
+    maxWidth: 1200,
+  },
+  controls: {
+    padding: 16,
+    backgroundColor: 'light-dark(#f5f5f5, #2a2a2a)',
+    borderRadius: 8,
+  },
+  controlGroup: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 4,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: 600,
+    color: 'light-dark(#666, #aaa)',
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
+  },
+  select: {
+    padding: '8px 12px',
+    fontSize: 14,
+    borderRadius: 6,
+    border: '1px solid light-dark(#ddd, #444)',
+    backgroundColor: 'light-dark(#fff, #333)',
+    color: 'light-dark(#333, #eee)',
+    cursor: 'pointer',
+    minWidth: 180,
+  },
+  slider: {
+    width: '100%',
+    accentColor: 'light-dark(#0064E0, #2694FE)',
+  },
+  sliderValue: {
+    fontSize: 14,
+    fontWeight: 500,
+    color: 'light-dark(#333, #eee)',
+    minWidth: 50,
+    textAlign: 'right',
+  },
+  presetButton: {
+    padding: '8px 16px',
+    fontSize: 13,
+    fontWeight: 500,
+    borderRadius: 6,
+    border: '1px solid light-dark(#ddd, #444)',
+    backgroundColor: 'light-dark(#fff, #333)',
+    color: 'light-dark(#333, #eee)',
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+  },
+  presetButtonActive: {
+    backgroundColor: 'light-dark(#0064E0, #2694FE)',
+    borderColor: 'light-dark(#0064E0, #2694FE)',
+    color: '#fff',
+  },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontSize: 14,
+  },
+  th: {
+    textAlign: 'left',
+    padding: '12px 16px',
+    borderBottom: '2px solid light-dark(#ddd, #444)',
+    fontWeight: 600,
+    color: 'light-dark(#333, #eee)',
+  },
+  td: {
+    padding: '12px 16px',
+    borderBottom: '1px solid light-dark(#eee, #333)',
+    color: 'light-dark(#333, #eee)',
+  },
+  tdMono: {
+    fontFamily: 'SF Mono, Monaco, Consolas, monospace',
+    fontSize: 13,
+  },
+  preview: {
+    padding: 24,
+    backgroundColor: 'light-dark(#fff, #1a1a1a)',
+    borderRadius: 8,
+    border: '1px solid light-dark(#ddd, #333)',
+  },
+  sampleText: {
+    margin: 0,
+    color: 'light-dark(#333, #eee)',
+  },
+  badge: {
+    display: 'inline-block',
+    padding: '2px 6px',
+    fontSize: 10,
+    fontWeight: 600,
+    borderRadius: 4,
+    backgroundColor: 'light-dark(#e0e0e0, #444)',
+    color: 'light-dark(#666, #aaa)',
+    marginLeft: 8,
+  },
+  collisionWarning: {
+    backgroundColor: 'light-dark(#fff3cd, #4a3f00)',
+    color: 'light-dark(#856404, #ffc107)',
+  },
+  sectionHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  },
+  formula: {
+    fontFamily: 'SF Mono, Monaco, Consolas, monospace',
+    fontSize: 13,
+    padding: '12px 16px',
+    backgroundColor: 'light-dark(#f5f5f5, #2a2a2a)',
+    borderRadius: 6,
+    color: 'light-dark(#333, #eee)',
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export default function TypeScaleExplorerPage() {
+  const [config, setConfig] = useState<TypeScaleConfig>(PRESETS.default);
+
+  const scale = useMemo(() => generateTypeScale(config), [config]);
+
+  // Detect collisions (adjacent sizes that round to same value)
+  const collisions = useMemo(() => {
+    const seen = new Set<number>();
+    const collided = new Set<number>();
+    for (const step of scale) {
+      if (seen.has(step.fontSize)) {
+        collided.add(step.fontSize);
+      }
+      seen.add(step.fontSize);
+    }
+    return collided;
+  }, [scale]);
+
+  const activePreset = Object.entries(PRESETS).find(
+    ([, preset]) =>
+      preset.base === config.base &&
+      Math.abs(preset.ratio - config.ratio) < 0.001 &&
+      preset.lineHeightGrid === config.lineHeightGrid,
+  )?.[0];
+
+  return (
+    <div {...stylex.props(styles.container)}>
+      <XDSVStack gap={8}>
+        {/* Header */}
+        <XDSVStack gap={2}>
+          <XDSHeading level={1}>Type Scale Explorer</XDSHeading>
+          <XDSText type="body" color="secondary">
+            Experiment with ratio-based type scales. Adjust the base size and
+            ratio to see how they affect the generated scale. Line heights snap
+            to the nearest grid value.
+          </XDSText>
+        </XDSVStack>
+
+        {/* Controls */}
+        <div {...stylex.props(styles.controls)}>
+          <XDSVStack gap={4}>
+            {/* Presets */}
+            <div {...stylex.props(styles.controlGroup)}>
+              <span {...stylex.props(styles.label)}>Presets</span>
+              <XDSHStack gap={2}>
+                {Object.entries(PRESETS).map(([name, preset]) => (
+                  <button
+                    key={name}
+                    {...stylex.props(
+                      styles.presetButton,
+                      activePreset === name && styles.presetButtonActive,
+                    )}
+                    onClick={() => setConfig(preset)}>
+                    {name.charAt(0).toUpperCase() + name.slice(1)}
+                  </button>
+                ))}
+              </XDSHStack>
+            </div>
+
+            <XDSHStack gap={6}>
+              {/* Base Size */}
+              <div {...stylex.props(styles.controlGroup)}>
+                <span {...stylex.props(styles.label)}>Base Size</span>
+                <XDSHStack gap={3} vAlign="center">
+                  <input
+                    type="range"
+                    min={10}
+                    max={24}
+                    step={1}
+                    value={config.base}
+                    onChange={e =>
+                      setConfig(c => ({...c, base: Number(e.target.value)}))
+                    }
+                    {...stylex.props(styles.slider)}
+                  />
+                  <span {...stylex.props(styles.sliderValue)}>
+                    {config.base}px
+                  </span>
+                </XDSHStack>
+              </div>
+
+              {/* Ratio */}
+              <div {...stylex.props(styles.controlGroup)}>
+                <span {...stylex.props(styles.label)}>Scale Ratio</span>
+                <select
+                  value={
+                    Object.entries(RATIOS).find(
+                      ([, v]) => Math.abs(v - config.ratio) < 0.001,
+                    )?.[0] || ''
+                  }
+                  onChange={e =>
+                    setConfig(c => ({...c, ratio: RATIOS[e.target.value]}))
+                  }
+                  {...stylex.props(styles.select)}>
+                  {Object.entries(RATIOS).map(([name, value]) => (
+                    <option key={name} value={name}>
+                      {name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Grid */}
+              <div {...stylex.props(styles.controlGroup)}>
+                <span {...stylex.props(styles.label)}>Line Height Grid</span>
+                <select
+                  value={config.lineHeightGrid}
+                  onChange={e =>
+                    setConfig(c => ({
+                      ...c,
+                      lineHeightGrid: Number(e.target.value),
+                    }))
+                  }
+                  {...stylex.props(styles.select)}>
+                  <option value={2}>2px</option>
+                  <option value={4}>4px (default)</option>
+                  <option value={8}>8px</option>
+                </select>
+              </div>
+            </XDSHStack>
+
+            {/* Formula */}
+            <div {...stylex.props(styles.formula)}>
+              fontSize = {config.base} × {config.ratio.toFixed(3)}
+              <sup>n</sup> → round to nearest pixel
+              <br />
+              lineHeight = snap(fontSize × 1.25–1.5, {config.lineHeightGrid}px
+              grid)
+            </div>
+          </XDSVStack>
+        </div>
+
+        <XDSDivider />
+
+        {/* Scale Table */}
+        <XDSVStack gap={3}>
+          <div {...stylex.props(styles.sectionHeader)}>
+            <XDSHeading level={2}>Computed Scale</XDSHeading>
+            {collisions.size > 0 && (
+              <span {...stylex.props(styles.badge, styles.collisionWarning)}>
+                ⚠️ {collisions.size} collision{collisions.size > 1 ? 's' : ''}
+              </span>
+            )}
+          </div>
+
+          <table {...stylex.props(styles.table)}>
+            <thead>
+              <tr>
+                <th {...stylex.props(styles.th)}>Token</th>
+                <th {...stylex.props(styles.th)}>Exponent</th>
+                <th {...stylex.props(styles.th)}>Raw</th>
+                <th {...stylex.props(styles.th)}>Font Size</th>
+                <th {...stylex.props(styles.th)}>Line Height</th>
+                <th {...stylex.props(styles.th)}>LH Ratio</th>
+              </tr>
+            </thead>
+            <tbody>
+              {scale.map(step => (
+                <tr key={step.name}>
+                  <td {...stylex.props(styles.td)}>
+                    <code>--text-{step.name}</code>
+                    {collisions.has(step.fontSize) && (
+                      <span
+                        {...stylex.props(
+                          styles.badge,
+                          styles.collisionWarning,
+                        )}>
+                        collision
+                      </span>
+                    )}
+                  </td>
+                  <td {...stylex.props(styles.td, styles.tdMono)}>
+                    {step.exponent >= 0 ? '+' : ''}
+                    {step.exponent}
+                  </td>
+                  <td {...stylex.props(styles.td, styles.tdMono)}>
+                    {step.rawSize.toFixed(2)}px
+                  </td>
+                  <td {...stylex.props(styles.td, styles.tdMono)}>
+                    {step.fontSize}px
+                  </td>
+                  <td {...stylex.props(styles.td, styles.tdMono)}>
+                    {step.lineHeight}px
+                  </td>
+                  <td {...stylex.props(styles.td, styles.tdMono)}>
+                    {step.lineHeightRatio.toFixed(2)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* Live Preview */}
+        <XDSVStack gap={3}>
+          <XDSHeading level={2}>Live Preview</XDSHeading>
+
+          <div {...stylex.props(styles.preview)}>
+            <XDSVStack gap={4}>
+              {scale
+                .slice()
+                .reverse()
+                .map(step => (
+                  <p
+                    key={step.name}
+                    style={{
+                      fontSize: step.fontSize,
+                      lineHeight: `${step.lineHeight}px`,
+                    }}
+                    {...stylex.props(styles.sampleText)}>
+                    <strong>{step.name}</strong> — The quick brown fox jumps
+                    over the lazy dog ({step.fontSize}px / {step.lineHeight}px)
+                  </p>
+                ))}
+            </XDSVStack>
+          </div>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* Side-by-Side Comparison */}
+        <XDSVStack gap={3}>
+          <XDSHeading level={2}>Preset Comparison</XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            See how the same semantic tokens render across different theme
+            presets.
+          </XDSText>
+
+          <XDSHStack gap={4}>
+            {Object.entries(PRESETS).map(([name, preset]) => {
+              const presetScale = generateTypeScale(preset);
+              return (
+                <div key={name} style={{flex: 1}}>
+                  <XDSVStack gap={2}>
+                    <XDSText type="label">
+                      {name.charAt(0).toUpperCase() + name.slice(1)}
+                    </XDSText>
+                    <XDSText type="supporting" color="secondary">
+                      {preset.base}px base, {preset.ratio} ratio
+                    </XDSText>
+                    <div {...stylex.props(styles.preview)}>
+                      <XDSVStack gap={2}>
+                        {presetScale.slice(2, 6).map(step => (
+                          <p
+                            key={step.name}
+                            style={{
+                              fontSize: step.fontSize,
+                              lineHeight: `${step.lineHeight}px`,
+                              margin: 0,
+                            }}
+                            {...stylex.props(styles.sampleText)}>
+                            {step.name}: {step.fontSize}px
+                          </p>
+                        ))}
+                      </XDSVStack>
+                    </div>
+                  </XDSVStack>
+                </div>
+              );
+            })}
+          </XDSHStack>
+        </XDSVStack>
+      </XDSVStack>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -47,7 +47,7 @@ function computeLineHeight(fontSize: number, grid: number): number {
 }
 
 function generateTypeScale(config: TypeScaleConfig): TypeScaleStep[] {
-  return SCALE_STEPS.map(step => {
+  const steps = SCALE_STEPS.map(step => {
     const rawSize = config.base * Math.pow(config.ratio, step.exponent);
     const fontSize = Math.round(rawSize);
     const lineHeight = computeLineHeight(fontSize, config.lineHeightGrid);
@@ -60,6 +60,20 @@ function generateTypeScale(config: TypeScaleConfig): TypeScaleStep[] {
       lineHeightRatio: lineHeight / fontSize,
     };
   });
+
+  // Enforce 1px minimum step between adjacent sizes
+  for (let i = 1; i < steps.length; i++) {
+    if (steps[i].fontSize <= steps[i - 1].fontSize) {
+      steps[i].fontSize = steps[i - 1].fontSize + 1;
+      steps[i].lineHeight = computeLineHeight(
+        steps[i].fontSize,
+        config.lineHeightGrid,
+      );
+      steps[i].lineHeightRatio = steps[i].lineHeight / steps[i].fontSize;
+    }
+  }
+
+  return steps;
 }
 
 // =============================================================================

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -5,6 +5,7 @@ import * as stylex from '@stylexjs/stylex';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSDivider} from '@xds/core';
+import {XDSButton} from '@xds/core/Button';
 
 // =============================================================================
 // Type Scale Computation
@@ -16,44 +17,71 @@ interface TypeScaleConfig {
   lineHeightGrid: number;
 }
 
-interface TypeScaleStep {
+interface TypeStyle {
   name: string;
+  role: 'heading' | 'body' | 'supporting';
   exponent: number;
+  weight: number;
   rawSize: number;
   fontSize: number;
   lineHeight: number;
   lineHeightRatio: number;
 }
 
-const SCALE_STEPS = [
-  {name: 'xs', exponent: -2},
-  {name: 'sm', exponent: -1},
-  {name: 'md', exponent: 0},
-  {name: 'lg', exponent: 1},
-  {name: 'xl', exponent: 2},
-  {name: '2xl', exponent: 3},
-  {name: '3xl', exponent: 4},
+// Semantic type roles mapped to scale exponents
+const TYPE_ROLES: Array<{
+  name: string;
+  role: 'heading' | 'body' | 'supporting';
+  exponent: number;
+  weight: number;
+}> = [
+  {name: 'h1', role: 'heading', exponent: 4, weight: 600},
+  {name: 'h2', role: 'heading', exponent: 3, weight: 600},
+  {name: 'h3', role: 'heading', exponent: 2, weight: 600},
+  {name: 'h4', role: 'heading', exponent: 1, weight: 600},
+  {name: 'h5', role: 'heading', exponent: 0, weight: 600},
+  {name: 'h6', role: 'heading', exponent: -1, weight: 600},
+  {name: 'body-lg', role: 'body', exponent: 1, weight: 400},
+  {name: 'body', role: 'body', exponent: 0, weight: 400},
+  {name: 'body-sm', role: 'body', exponent: -1, weight: 400},
+  {name: 'label', role: 'body', exponent: 0, weight: 500},
+  {name: 'supporting', role: 'supporting', exponent: -1, weight: 400},
+  {name: 'caption', role: 'supporting', exponent: -2, weight: 400},
 ];
 
-function computeLineHeight(fontSize: number, grid: number): number {
-  // Target ratio varies by size (tighter for large text)
-  const targetRatio = fontSize < 20 ? 1.5 : fontSize < 32 ? 1.4 : 1.25;
+function computeLineHeight(
+  fontSize: number,
+  grid: number,
+  role: 'heading' | 'body' | 'supporting',
+): number {
+  // Tighter line heights for headings, more relaxed for body
+  let targetRatio: number;
+  if (role === 'heading') {
+    targetRatio = fontSize < 24 ? 1.3 : fontSize < 32 ? 1.25 : 1.2;
+  } else {
+    targetRatio = fontSize < 16 ? 1.4 : 1.5;
+  }
+
   const ideal = fontSize * targetRatio;
   const snapped = Math.round(ideal / grid) * grid;
 
   // Ensure minimum breathing room
-  const minimum = Math.ceil((fontSize + 4) / grid) * grid;
+  const minimum = Math.ceil((fontSize + 2) / grid) * grid;
   return Math.max(snapped, minimum);
 }
 
-function generateTypeScale(config: TypeScaleConfig): TypeScaleStep[] {
-  const steps = SCALE_STEPS.map(step => {
-    const rawSize = config.base * Math.pow(config.ratio, step.exponent);
+function generateTypeStyles(config: TypeScaleConfig): TypeStyle[] {
+  const styles = TYPE_ROLES.map(role => {
+    const rawSize = config.base * Math.pow(config.ratio, role.exponent);
     const fontSize = Math.round(rawSize);
-    const lineHeight = computeLineHeight(fontSize, config.lineHeightGrid);
+    const lineHeight = computeLineHeight(
+      fontSize,
+      config.lineHeightGrid,
+      role.role,
+    );
 
     return {
-      ...step,
+      ...role,
       rawSize,
       fontSize,
       lineHeight,
@@ -61,19 +89,22 @@ function generateTypeScale(config: TypeScaleConfig): TypeScaleStep[] {
     };
   });
 
-  // Enforce 1px minimum step between adjacent sizes
-  for (let i = 1; i < steps.length; i++) {
-    if (steps[i].fontSize <= steps[i - 1].fontSize) {
-      steps[i].fontSize = steps[i - 1].fontSize + 1;
-      steps[i].lineHeight = computeLineHeight(
-        steps[i].fontSize,
+  // Enforce 1px minimum step between heading sizes
+  const headings = styles.filter(s => s.role === 'heading');
+  for (let i = 1; i < headings.length; i++) {
+    if (headings[i].fontSize >= headings[i - 1].fontSize) {
+      headings[i].fontSize = headings[i - 1].fontSize - 1;
+      headings[i].lineHeight = computeLineHeight(
+        headings[i].fontSize,
         config.lineHeightGrid,
+        'heading',
       );
-      steps[i].lineHeightRatio = steps[i].lineHeight / steps[i].fontSize;
+      headings[i].lineHeightRatio =
+        headings[i].lineHeight / headings[i].fontSize;
     }
   }
 
-  return steps;
+  return styles;
 }
 
 // =============================================================================
@@ -103,7 +134,12 @@ const RATIOS: Record<string, number> = {
 
 const styles = stylex.create({
   container: {
-    maxWidth: 1200,
+    maxWidth: 1400,
+  },
+  twoColumn: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: 32,
   },
   controls: {
     padding: 16,
@@ -162,23 +198,35 @@ const styles = stylex.create({
   table: {
     width: '100%',
     borderCollapse: 'collapse',
-    fontSize: 14,
+    fontSize: 13,
   },
   th: {
     textAlign: 'left',
-    padding: '12px 16px',
+    padding: '10px 12px',
     borderBottom: '2px solid light-dark(#ddd, #444)',
     fontWeight: 600,
     color: 'light-dark(#333, #eee)',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.05em',
   },
   td: {
-    padding: '12px 16px',
+    padding: '10px 12px',
     borderBottom: '1px solid light-dark(#eee, #333)',
     color: 'light-dark(#333, #eee)',
   },
   tdMono: {
     fontFamily: 'SF Mono, Monaco, Consolas, monospace',
-    fontSize: 13,
+    fontSize: 12,
+  },
+  roleHeading: {
+    backgroundColor: 'light-dark(#f0f7ff, #1a2a3a)',
+  },
+  roleBody: {
+    backgroundColor: 'light-dark(#fff, #1f1f22)',
+  },
+  roleSupporting: {
+    backgroundColor: 'light-dark(#f9f9f9, #252528)',
   },
   preview: {
     padding: 24,
@@ -190,32 +238,116 @@ const styles = stylex.create({
     margin: 0,
     color: 'light-dark(#333, #eee)',
   },
-  badge: {
-    display: 'inline-block',
-    padding: '2px 6px',
-    fontSize: 10,
-    fontWeight: 600,
-    borderRadius: 4,
-    backgroundColor: 'light-dark(#e0e0e0, #444)',
-    color: 'light-dark(#666, #aaa)',
-    marginLeft: 8,
-  },
-  collisionWarning: {
-    backgroundColor: 'light-dark(#fff3cd, #4a3f00)',
-    color: 'light-dark(#856404, #ffc107)',
-  },
-  sectionHeader: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-  },
   formula: {
     fontFamily: 'SF Mono, Monaco, Consolas, monospace',
-    fontSize: 13,
+    fontSize: 12,
     padding: '12px 16px',
     backgroundColor: 'light-dark(#f5f5f5, #2a2a2a)',
     borderRadius: 6,
     color: 'light-dark(#333, #eee)',
+  },
+  // Landing page preview styles
+  landingPreview: {
+    backgroundColor: 'light-dark(#fff, #111)',
+    borderRadius: 8,
+    border: '1px solid light-dark(#ddd, #333)',
+    overflow: 'hidden',
+    minHeight: 600,
+  },
+  landingNav: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '16px 24px',
+    borderBottom: '1px solid light-dark(#eee, #333)',
+  },
+  landingLogo: {
+    fontWeight: 700,
+    color: 'light-dark(#333, #eee)',
+  },
+  landingNavLinks: {
+    display: 'flex',
+    gap: 24,
+  },
+  landingNavLink: {
+    color: 'light-dark(#666, #aaa)',
+    textDecoration: 'none',
+    cursor: 'pointer',
+  },
+  landingHero: {
+    padding: '64px 24px',
+    textAlign: 'center',
+    maxWidth: 600,
+    margin: '0 auto',
+  },
+  landingHeroTitle: {
+    margin: '0 0 16px 0',
+    color: 'light-dark(#111, #fff)',
+  },
+  landingHeroSubtitle: {
+    margin: '0 0 32px 0',
+    color: 'light-dark(#666, #aaa)',
+  },
+  landingHeroButtons: {
+    display: 'flex',
+    gap: 12,
+    justifyContent: 'center',
+  },
+  landingFeatures: {
+    padding: '48px 24px',
+    backgroundColor: 'light-dark(#f9f9f9, #1a1a1a)',
+  },
+  landingFeaturesTitle: {
+    textAlign: 'center',
+    margin: '0 0 8px 0',
+    color: 'light-dark(#111, #fff)',
+  },
+  landingFeaturesSubtitle: {
+    textAlign: 'center',
+    margin: '0 0 32px 0',
+    color: 'light-dark(#666, #aaa)',
+  },
+  landingFeatureGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(3, 1fr)',
+    gap: 24,
+    maxWidth: 900,
+    margin: '0 auto',
+  },
+  landingFeatureCard: {
+    padding: 20,
+    backgroundColor: 'light-dark(#fff, #252528)',
+    borderRadius: 8,
+    border: '1px solid light-dark(#eee, #333)',
+  },
+  landingFeatureTitle: {
+    margin: '0 0 8px 0',
+    color: 'light-dark(#111, #fff)',
+  },
+  landingFeatureDesc: {
+    margin: 0,
+    color: 'light-dark(#666, #aaa)',
+  },
+  tabBar: {
+    display: 'flex',
+    gap: 0,
+    borderBottom: '1px solid light-dark(#ddd, #444)',
+    marginBottom: 16,
+  },
+  tab: {
+    padding: '12px 20px',
+    fontSize: 14,
+    fontWeight: 500,
+    color: 'light-dark(#666, #aaa)',
+    backgroundColor: 'transparent',
+    border: 'none',
+    borderBottom: '2px solid transparent',
+    cursor: 'pointer',
+    marginBottom: -1,
+  },
+  tabActive: {
+    color: 'light-dark(#0064E0, #2694FE)',
+    borderBottomColor: 'light-dark(#0064E0, #2694FE)',
   },
 });
 
@@ -223,23 +355,18 @@ const styles = stylex.create({
 // Component
 // =============================================================================
 
+type PreviewTab = 'scale' | 'landing' | 'comparison';
+
 export default function TypeScaleExplorerPage() {
   const [config, setConfig] = useState<TypeScaleConfig>(PRESETS.default);
+  const [activeTab, setActiveTab] = useState<PreviewTab>('scale');
 
-  const scale = useMemo(() => generateTypeScale(config), [config]);
+  const typeStyles = useMemo(() => generateTypeStyles(config), [config]);
 
-  // Detect collisions (adjacent sizes that round to same value)
-  const collisions = useMemo(() => {
-    const seen = new Set<number>();
-    const collided = new Set<number>();
-    for (const step of scale) {
-      if (seen.has(step.fontSize)) {
-        collided.add(step.fontSize);
-      }
-      seen.add(step.fontSize);
-    }
-    return collided;
-  }, [scale]);
+  const headings = typeStyles.filter(s => s.role === 'heading');
+  const bodyStyles = typeStyles.filter(
+    s => s.role === 'body' || s.role === 'supporting',
+  );
 
   const activePreset = Object.entries(PRESETS).find(
     ([, preset]) =>
@@ -248,16 +375,18 @@ export default function TypeScaleExplorerPage() {
       preset.lineHeightGrid === config.lineHeightGrid,
   )?.[0];
 
+  const getStyle = (name: string) =>
+    typeStyles.find(s => s.name === name) || typeStyles[0];
+
   return (
     <div {...stylex.props(styles.container)}>
-      <XDSVStack gap={8}>
+      <XDSVStack gap={6}>
         {/* Header */}
         <XDSVStack gap={2}>
           <XDSHeading level={1}>Type Scale Explorer</XDSHeading>
           <XDSText type="body" color="secondary">
-            Experiment with ratio-based type scales. Adjust the base size and
-            ratio to see how they affect the generated scale. Line heights snap
-            to the nearest grid value.
+            Experiment with ratio-based type scales. Combines font size, line
+            height, and weight into semantic type styles.
           </XDSText>
         </XDSVStack>
 
@@ -317,7 +446,7 @@ export default function TypeScaleExplorerPage() {
                     setConfig(c => ({...c, ratio: RATIOS[e.target.value]}))
                   }
                   {...stylex.props(styles.select)}>
-                  {Object.entries(RATIOS).map(([name, value]) => (
+                  {Object.entries(RATIOS).map(([name]) => (
                     <option key={name} value={name}>
                       {name}
                     </option>
@@ -343,150 +472,341 @@ export default function TypeScaleExplorerPage() {
                 </select>
               </div>
             </XDSHStack>
-
-            {/* Formula */}
-            <div {...stylex.props(styles.formula)}>
-              fontSize = {config.base} × {config.ratio.toFixed(3)}
-              <sup>n</sup> → round to nearest pixel
-              <br />
-              lineHeight = snap(fontSize × 1.25–1.5, {config.lineHeightGrid}px
-              grid)
-            </div>
           </XDSVStack>
         </div>
 
-        <XDSDivider />
-
-        {/* Scale Table */}
-        <XDSVStack gap={3}>
-          <div {...stylex.props(styles.sectionHeader)}>
-            <XDSHeading level={2}>Computed Scale</XDSHeading>
-            {collisions.size > 0 && (
-              <span {...stylex.props(styles.badge, styles.collisionWarning)}>
-                ⚠️ {collisions.size} collision{collisions.size > 1 ? 's' : ''}
-              </span>
+        {/* Tab Bar */}
+        <div {...stylex.props(styles.tabBar)}>
+          <button
+            {...stylex.props(
+              styles.tab,
+              activeTab === 'scale' && styles.tabActive,
             )}
-          </div>
+            onClick={() => setActiveTab('scale')}>
+            Type Scale
+          </button>
+          <button
+            {...stylex.props(
+              styles.tab,
+              activeTab === 'landing' && styles.tabActive,
+            )}
+            onClick={() => setActiveTab('landing')}>
+            Landing Page
+          </button>
+          <button
+            {...stylex.props(
+              styles.tab,
+              activeTab === 'comparison' && styles.tabActive,
+            )}
+            onClick={() => setActiveTab('comparison')}>
+            Preset Comparison
+          </button>
+        </div>
 
-          <table {...stylex.props(styles.table)}>
-            <thead>
-              <tr>
-                <th {...stylex.props(styles.th)}>Token</th>
-                <th {...stylex.props(styles.th)}>Exponent</th>
-                <th {...stylex.props(styles.th)}>Raw</th>
-                <th {...stylex.props(styles.th)}>Font Size</th>
-                <th {...stylex.props(styles.th)}>Line Height</th>
-                <th {...stylex.props(styles.th)}>LH Ratio</th>
-              </tr>
-            </thead>
-            <tbody>
-              {scale.map(step => (
-                <tr key={step.name}>
-                  <td {...stylex.props(styles.td)}>
-                    <code>--text-{step.name}</code>
-                    {collisions.has(step.fontSize) && (
-                      <span
-                        {...stylex.props(
-                          styles.badge,
-                          styles.collisionWarning,
-                        )}>
-                        collision
-                      </span>
-                    )}
-                  </td>
-                  <td {...stylex.props(styles.td, styles.tdMono)}>
-                    {step.exponent >= 0 ? '+' : ''}
-                    {step.exponent}
-                  </td>
-                  <td {...stylex.props(styles.td, styles.tdMono)}>
-                    {step.rawSize.toFixed(2)}px
-                  </td>
-                  <td {...stylex.props(styles.td, styles.tdMono)}>
-                    {step.fontSize}px
-                  </td>
-                  <td {...stylex.props(styles.td, styles.tdMono)}>
-                    {step.lineHeight}px
-                  </td>
-                  <td {...stylex.props(styles.td, styles.tdMono)}>
-                    {step.lineHeightRatio.toFixed(2)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </XDSVStack>
-
-        <XDSDivider />
-
-        {/* Live Preview */}
-        <XDSVStack gap={3}>
-          <XDSHeading level={2}>Live Preview</XDSHeading>
-
-          <div {...stylex.props(styles.preview)}>
+        {/* Tab Content */}
+        {activeTab === 'scale' && (
+          <div {...stylex.props(styles.twoColumn)}>
+            {/* Scale Table */}
             <XDSVStack gap={4}>
-              {scale
-                .slice()
-                .reverse()
-                .map(step => (
-                  <p
-                    key={step.name}
-                    style={{
-                      fontSize: step.fontSize,
-                      lineHeight: `${step.lineHeight}px`,
-                    }}
-                    {...stylex.props(styles.sampleText)}>
-                    <strong>{step.name}</strong> — The quick brown fox jumps
-                    over the lazy dog ({step.fontSize}px / {step.lineHeight}px)
-                  </p>
-                ))}
+              <XDSHeading level={3}>Headings</XDSHeading>
+              <table {...stylex.props(styles.table)}>
+                <thead>
+                  <tr>
+                    <th {...stylex.props(styles.th)}>Style</th>
+                    <th {...stylex.props(styles.th)}>Size</th>
+                    <th {...stylex.props(styles.th)}>Line H</th>
+                    <th {...stylex.props(styles.th)}>Weight</th>
+                    <th {...stylex.props(styles.th)}>Preview</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {headings.map(style => (
+                    <tr key={style.name} {...stylex.props(styles.roleHeading)}>
+                      <td {...stylex.props(styles.td)}>{style.name}</td>
+                      <td {...stylex.props(styles.td, styles.tdMono)}>
+                        {style.fontSize}px
+                      </td>
+                      <td {...stylex.props(styles.td, styles.tdMono)}>
+                        {style.lineHeight}px
+                      </td>
+                      <td {...stylex.props(styles.td, styles.tdMono)}>
+                        {style.weight}
+                      </td>
+                      <td {...stylex.props(styles.td)}>
+                        <span
+                          style={{
+                            fontSize: style.fontSize,
+                            lineHeight: `${style.lineHeight}px`,
+                            fontWeight: style.weight,
+                          }}>
+                          Aa
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+
+              <XDSHeading level={3}>Body &amp; Supporting</XDSHeading>
+              <table {...stylex.props(styles.table)}>
+                <thead>
+                  <tr>
+                    <th {...stylex.props(styles.th)}>Style</th>
+                    <th {...stylex.props(styles.th)}>Size</th>
+                    <th {...stylex.props(styles.th)}>Line H</th>
+                    <th {...stylex.props(styles.th)}>Weight</th>
+                    <th {...stylex.props(styles.th)}>Preview</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {bodyStyles.map(style => (
+                    <tr
+                      key={style.name}
+                      {...stylex.props(
+                        style.role === 'body'
+                          ? styles.roleBody
+                          : styles.roleSupporting,
+                      )}>
+                      <td {...stylex.props(styles.td)}>{style.name}</td>
+                      <td {...stylex.props(styles.td, styles.tdMono)}>
+                        {style.fontSize}px
+                      </td>
+                      <td {...stylex.props(styles.td, styles.tdMono)}>
+                        {style.lineHeight}px
+                      </td>
+                      <td {...stylex.props(styles.td, styles.tdMono)}>
+                        {style.weight}
+                      </td>
+                      <td {...stylex.props(styles.td)}>
+                        <span
+                          style={{
+                            fontSize: style.fontSize,
+                            lineHeight: `${style.lineHeight}px`,
+                            fontWeight: style.weight,
+                          }}>
+                          The quick brown fox
+                        </span>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </XDSVStack>
+
+            {/* Live Preview */}
+            <XDSVStack gap={4}>
+              <XDSHeading level={3}>Live Preview</XDSHeading>
+              <div {...stylex.props(styles.preview)}>
+                <XDSVStack gap={4}>
+                  {headings.map(style => (
+                    <p
+                      key={style.name}
+                      style={{
+                        fontSize: style.fontSize,
+                        lineHeight: `${style.lineHeight}px`,
+                        fontWeight: style.weight,
+                        margin: 0,
+                      }}
+                      {...stylex.props(styles.sampleText)}>
+                      {style.name}: A wizard&apos;s job is to vex chumps quickly
+                      in fog
+                    </p>
+                  ))}
+                  <XDSDivider />
+                  {bodyStyles.slice(0, 3).map(style => (
+                    <p
+                      key={style.name}
+                      style={{
+                        fontSize: style.fontSize,
+                        lineHeight: `${style.lineHeight}px`,
+                        fontWeight: style.weight,
+                        margin: 0,
+                      }}
+                      {...stylex.props(styles.sampleText)}>
+                      {style.name}: The quick brown fox jumps over the lazy dog.
+                      Pack my box with five dozen liquor jugs.
+                    </p>
+                  ))}
+                </XDSVStack>
+              </div>
             </XDSVStack>
           </div>
-        </XDSVStack>
+        )}
 
-        <XDSDivider />
+        {activeTab === 'landing' && (
+          <div {...stylex.props(styles.landingPreview)}>
+            {/* Nav */}
+            <nav {...stylex.props(styles.landingNav)}>
+              <span
+                style={{
+                  fontSize: getStyle('body').fontSize,
+                  fontWeight: 700,
+                }}
+                {...stylex.props(styles.landingLogo)}>
+                Acme Inc
+              </span>
+              <div {...stylex.props(styles.landingNavLinks)}>
+                {['Features', 'Pricing', 'About', 'Contact'].map(link => (
+                  <span
+                    key={link}
+                    style={{
+                      fontSize: getStyle('body-sm').fontSize,
+                      fontWeight: getStyle('body-sm').weight,
+                    }}
+                    {...stylex.props(styles.landingNavLink)}>
+                    {link}
+                  </span>
+                ))}
+              </div>
+            </nav>
 
-        {/* Side-by-Side Comparison */}
-        <XDSVStack gap={3}>
-          <XDSHeading level={2}>Preset Comparison</XDSHeading>
-          <XDSText type="supporting" color="secondary">
-            See how the same semantic tokens render across different theme
-            presets.
-          </XDSText>
+            {/* Hero */}
+            <div {...stylex.props(styles.landingHero)}>
+              <h1
+                style={{
+                  fontSize: getStyle('h1').fontSize,
+                  lineHeight: `${getStyle('h1').lineHeight}px`,
+                  fontWeight: getStyle('h1').weight,
+                }}
+                {...stylex.props(styles.landingHeroTitle)}>
+                Your digital transformation begins here
+              </h1>
+              <p
+                style={{
+                  fontSize: getStyle('body-lg').fontSize,
+                  lineHeight: `${getStyle('body-lg').lineHeight}px`,
+                  fontWeight: getStyle('body-lg').weight,
+                }}
+                {...stylex.props(styles.landingHeroSubtitle)}>
+                Unlock the full potential of your business. Start your journey
+                today and experience the future of business software.
+              </p>
+              <div {...stylex.props(styles.landingHeroButtons)}>
+                <XDSButton label="Explore features" variant="secondary" />
+                <XDSButton label="Get started" variant="primary" />
+              </div>
+              <p
+                style={{
+                  fontSize: getStyle('caption').fontSize,
+                  lineHeight: `${getStyle('caption').lineHeight}px`,
+                  fontWeight: getStyle('caption').weight,
+                  marginTop: 16,
+                  color: 'light-dark(#999, #666)',
+                }}>
+                No credit card required
+              </p>
+            </div>
 
-          <XDSHStack gap={4}>
-            {Object.entries(PRESETS).map(([name, preset]) => {
-              const presetScale = generateTypeScale(preset);
-              return (
-                <div key={name} style={{flex: 1}}>
-                  <XDSVStack gap={2}>
-                    <XDSText type="label">
-                      {name.charAt(0).toUpperCase() + name.slice(1)}
-                    </XDSText>
-                    <XDSText type="supporting" color="secondary">
-                      {preset.base}px base, {preset.ratio} ratio
-                    </XDSText>
-                    <div {...stylex.props(styles.preview)}>
-                      <XDSVStack gap={2}>
-                        {presetScale.slice(2, 6).map(step => (
-                          <p
-                            key={step.name}
-                            style={{
-                              fontSize: step.fontSize,
-                              lineHeight: `${step.lineHeight}px`,
-                              margin: 0,
-                            }}
-                            {...stylex.props(styles.sampleText)}>
-                            {step.name}: {step.fontSize}px
-                          </p>
-                        ))}
-                      </XDSVStack>
-                    </div>
-                  </XDSVStack>
-                </div>
-              );
-            })}
-          </XDSHStack>
-        </XDSVStack>
+            {/* Features */}
+            <div {...stylex.props(styles.landingFeatures)}>
+              <h2
+                style={{
+                  fontSize: getStyle('h2').fontSize,
+                  lineHeight: `${getStyle('h2').lineHeight}px`,
+                  fontWeight: getStyle('h2').weight,
+                }}
+                {...stylex.props(styles.landingFeaturesTitle)}>
+                SaaS solutions that drive results
+              </h2>
+              <p
+                style={{
+                  fontSize: getStyle('body').fontSize,
+                  lineHeight: `${getStyle('body').lineHeight}px`,
+                  fontWeight: getStyle('body').weight,
+                }}
+                {...stylex.props(styles.landingFeaturesSubtitle)}>
+                Explore our suite of powerful software solutions.
+              </p>
+
+              <div {...stylex.props(styles.landingFeatureGrid)}>
+                {[
+                  {
+                    title: 'Enterprise planning',
+                    desc: 'Seamlessly manage and integrate all core business processes.',
+                  },
+                  {
+                    title: 'Project management',
+                    desc: 'Ensure project success by efficiently planning and tracking.',
+                  },
+                  {
+                    title: 'Analytics dashboard',
+                    desc: 'Leverage data-driven insights to make informed decisions.',
+                  },
+                ].map(feature => (
+                  <div
+                    key={feature.title}
+                    {...stylex.props(styles.landingFeatureCard)}>
+                    <h3
+                      style={{
+                        fontSize: getStyle('h4').fontSize,
+                        lineHeight: `${getStyle('h4').lineHeight}px`,
+                        fontWeight: getStyle('h4').weight,
+                      }}
+                      {...stylex.props(styles.landingFeatureTitle)}>
+                      {feature.title}
+                    </h3>
+                    <p
+                      style={{
+                        fontSize: getStyle('body-sm').fontSize,
+                        lineHeight: `${getStyle('body-sm').lineHeight}px`,
+                        fontWeight: getStyle('body-sm').weight,
+                      }}
+                      {...stylex.props(styles.landingFeatureDesc)}>
+                      {feature.desc}
+                    </p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {activeTab === 'comparison' && (
+          <XDSVStack gap={4}>
+            <XDSText type="supporting" color="secondary">
+              See how the same semantic styles render across different theme
+              presets.
+            </XDSText>
+
+            <XDSHStack gap={4}>
+              {Object.entries(PRESETS).map(([name, preset]) => {
+                const presetStyles = generateTypeStyles(preset);
+                const presetHeadings = presetStyles.filter(
+                  s => s.role === 'heading',
+                );
+                return (
+                  <div key={name} style={{flex: 1}}>
+                    <XDSVStack gap={2}>
+                      <XDSText type="label">
+                        {name.charAt(0).toUpperCase() + name.slice(1)}
+                      </XDSText>
+                      <XDSText type="supporting" color="secondary">
+                        {preset.base}px base, {preset.ratio} ratio
+                      </XDSText>
+                      <div {...stylex.props(styles.preview)}>
+                        <XDSVStack gap={2}>
+                          {presetHeadings.slice(0, 4).map(style => (
+                            <p
+                              key={style.name}
+                              style={{
+                                fontSize: style.fontSize,
+                                lineHeight: `${style.lineHeight}px`,
+                                fontWeight: style.weight,
+                                margin: 0,
+                              }}
+                              {...stylex.props(styles.sampleText)}>
+                              {style.name}: {style.fontSize}px
+                            </p>
+                          ))}
+                        </XDSVStack>
+                      </div>
+                    </XDSVStack>
+                  </div>
+                );
+              })}
+            </XDSHStack>
+          </XDSVStack>
+        )}
       </XDSVStack>
     </div>
   );

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -19,7 +19,7 @@ interface TypeScaleConfig {
 
 interface TypeStyle {
   name: string;
-  role: 'display' | 'heading' | 'body' | 'supporting';
+  role: TypeRole;
   exponent: number;
   weight: number;
   rawSize: number;
@@ -32,6 +32,7 @@ interface TypeStyle {
 type TypeRole = 'display' | 'heading' | 'body' | 'supporting';
 
 // Semantic type roles mapped to scale exponents
+// H4 is the baseline (exponent 0), scale extrapolates from there
 const TYPE_ROLES: Array<{
   name: string;
   role: TypeRole;
@@ -39,24 +40,24 @@ const TYPE_ROLES: Array<{
   weight: number;
 }> = [
   // Display — hero, marketing, splash
-  {name: 'display-1', role: 'display', exponent: 7, weight: 700},
-  {name: 'display-2', role: 'display', exponent: 6, weight: 700},
-  {name: 'display-3', role: 'display', exponent: 5, weight: 600},
-  // Headings
-  {name: 'h1', role: 'heading', exponent: 4, weight: 600},
-  {name: 'h2', role: 'heading', exponent: 3, weight: 600},
-  {name: 'h3', role: 'heading', exponent: 2, weight: 600},
-  {name: 'h4', role: 'heading', exponent: 1, weight: 600},
-  {name: 'h5', role: 'heading', exponent: 0, weight: 600},
-  {name: 'h6', role: 'heading', exponent: -1, weight: 600},
+  {name: 'display-1', role: 'display', exponent: 6, weight: 700},
+  {name: 'display-2', role: 'display', exponent: 5, weight: 700},
+  {name: 'display-3', role: 'display', exponent: 4, weight: 600},
+  // Headings — h4 is base (exponent 0)
+  {name: 'h1', role: 'heading', exponent: 3, weight: 600},
+  {name: 'h2', role: 'heading', exponent: 2, weight: 600},
+  {name: 'h3', role: 'heading', exponent: 1, weight: 600},
+  {name: 'h4', role: 'heading', exponent: 0, weight: 600},
+  {name: 'h5', role: 'heading', exponent: -1, weight: 600},
+  {name: 'h6', role: 'heading', exponent: -2, weight: 600},
   // Body
-  {name: 'body-lg', role: 'body', exponent: 1, weight: 400},
-  {name: 'body', role: 'body', exponent: 0, weight: 400},
-  {name: 'body-sm', role: 'body', exponent: -1, weight: 400},
-  {name: 'label', role: 'body', exponent: 0, weight: 500},
+  {name: 'body-lg', role: 'body', exponent: 0, weight: 400},
+  {name: 'body', role: 'body', exponent: -1, weight: 400},
+  {name: 'body-sm', role: 'body', exponent: -2, weight: 400},
+  {name: 'label', role: 'body', exponent: -1, weight: 500},
   // Supporting
-  {name: 'supporting', role: 'supporting', exponent: -1, weight: 400},
-  {name: 'caption', role: 'supporting', exponent: -2, weight: 400},
+  {name: 'supporting', role: 'supporting', exponent: -2, weight: 400},
+  {name: 'caption', role: 'supporting', exponent: -3, weight: 400},
 ];
 
 function computeLineHeight(
@@ -75,7 +76,6 @@ function computeLineHeight(
 
   const ideal = fontSize * targetRatio;
   const snapped = Math.round(ideal / grid) * grid;
-
   const minimum = Math.ceil((fontSize + 2) / grid) * grid;
   return Math.max(snapped, minimum);
 }
@@ -100,7 +100,6 @@ function generateTypeStyles(config: TypeScaleConfig): TypeStyle[] {
     };
   });
 
-  // Enforce 1px minimum step within each group that should be monotonically decreasing
   const enforceMinStep = (group: TypeStyle[]) => {
     for (let i = 1; i < group.length; i++) {
       if (group[i].fontSize >= group[i - 1].fontSize) {
@@ -116,9 +115,8 @@ function generateTypeStyles(config: TypeScaleConfig): TypeStyle[] {
     }
   };
 
-  // Also enforce display > h1 continuity
-  const displays = allStyles.filter(s => s.role === 'display');
-  const headings = allStyles.filter(s => s.role === 'heading');
+  const displays = allStyles.filter(t => t.role === 'display');
+  const headings = allStyles.filter(t => t.role === 'heading');
   enforceMinStep(displays);
   enforceMinStep(headings);
 
@@ -135,7 +133,6 @@ function generateTypeStyles(config: TypeScaleConfig): TypeStyle[] {
       smallestDisplay.lineHeightRatio =
         smallestDisplay.lineHeight / smallestDisplay.fontSize;
       smallestDisplay.wasNudged = true;
-      // Re-enforce display chain upward
       for (let i = displays.length - 2; i >= 0; i--) {
         if (displays[i].fontSize <= displays[i + 1].fontSize) {
           displays[i].fontSize = displays[i + 1].fontSize + 1;
@@ -156,7 +153,7 @@ function generateTypeStyles(config: TypeScaleConfig): TypeStyle[] {
 }
 
 // Raw scale steps for the calculations tab
-const RAW_SCALE_STEPS = Array.from({length: 12}, (_, i) => i - 3);
+const RAW_SCALE_STEPS = Array.from({length: 12}, (_, i) => i - 4);
 
 interface RawScaleStep {
   exponent: number;
@@ -202,25 +199,15 @@ const RATIOS: Record<string, number> = {
 // Styles
 // =============================================================================
 
-const s = stylex.create({
-  container: {
-    maxWidth: 1400,
-  },
-  twoColumn: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: 32,
-  },
+const st = stylex.create({
+  container: {maxWidth: 1400},
+  twoColumn: {display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 32},
   controls: {
     padding: 16,
     backgroundColor: 'light-dark(#f5f5f5, #2a2a2a)',
     borderRadius: 8,
   },
-  controlGroup: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 4,
-  },
+  controlGroup: {display: 'flex', flexDirection: 'column', gap: 4},
   label: {
     fontSize: 12,
     fontWeight: 600,
@@ -238,10 +225,7 @@ const s = stylex.create({
     cursor: 'pointer',
     minWidth: 180,
   },
-  slider: {
-    width: '100%',
-    accentColor: 'light-dark(#0064E0, #2694FE)',
-  },
+  slider: {width: '100%', accentColor: 'light-dark(#0064E0, #2694FE)'},
   sliderValue: {
     fontSize: 14,
     fontWeight: 500,
@@ -265,11 +249,7 @@ const s = stylex.create({
     borderColor: 'light-dark(#0064E0, #2694FE)',
     color: '#fff',
   },
-  table: {
-    width: '100%',
-    borderCollapse: 'collapse',
-    fontSize: 13,
-  },
+  table: {width: '100%', borderCollapse: 'collapse', fontSize: 13},
   th: {
     textAlign: 'left',
     padding: '10px 12px',
@@ -280,43 +260,25 @@ const s = stylex.create({
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
   },
-  thRight: {
-    textAlign: 'right',
-  },
+  thRight: {textAlign: 'right'},
   td: {
     padding: '10px 12px',
     borderBottom: '1px solid light-dark(#eee, #333)',
     color: 'light-dark(#333, #eee)',
   },
-  tdRight: {
-    textAlign: 'right',
-  },
-  tdMono: {
-    fontFamily: 'SF Mono, Monaco, Consolas, monospace',
-    fontSize: 12,
-  },
-  roleDisplay: {
-    backgroundColor: 'light-dark(#fef3f0, #2a1f1a)',
-  },
-  roleHeading: {
-    backgroundColor: 'light-dark(#f0f7ff, #1a2a3a)',
-  },
-  roleBody: {
-    backgroundColor: 'light-dark(#fff, #1f1f22)',
-  },
-  roleSupporting: {
-    backgroundColor: 'light-dark(#f9f9f9, #252528)',
-  },
+  tdRight: {textAlign: 'right'},
+  tdMono: {fontFamily: 'SF Mono, Monaco, Consolas, monospace', fontSize: 12},
+  roleDisplay: {backgroundColor: 'light-dark(#fef3f0, #2a1f1a)'},
+  roleHeading: {backgroundColor: 'light-dark(#f0f7ff, #1a2a3a)'},
+  roleBody: {backgroundColor: 'light-dark(#fff, #1f1f22)'},
+  roleSupporting: {backgroundColor: 'light-dark(#f9f9f9, #252528)'},
   preview: {
     padding: 24,
     backgroundColor: 'light-dark(#fff, #1a1a1a)',
     borderRadius: 8,
     border: '1px solid light-dark(#ddd, #333)',
   },
-  sampleText: {
-    margin: 0,
-    color: 'light-dark(#333, #eee)',
-  },
+  sampleText: {margin: 0, color: 'light-dark(#333, #eee)'},
   nudgedBadge: {
     display: 'inline-block',
     padding: '1px 5px',
@@ -327,7 +289,6 @@ const s = stylex.create({
     color: 'light-dark(#856404, #ffc107)',
     marginLeft: 6,
   },
-  // Raw calc tab
   rawFormula: {
     fontFamily: 'SF Mono, Monaco, Consolas, monospace',
     fontSize: 12,
@@ -369,14 +330,8 @@ const s = stylex.create({
     padding: '16px 24px',
     borderBottom: '1px solid light-dark(#eee, #333)',
   },
-  landingLogo: {
-    fontWeight: 700,
-    color: 'light-dark(#333, #eee)',
-  },
-  landingNavLinks: {
-    display: 'flex',
-    gap: 24,
-  },
+  landingLogo: {fontWeight: 700, color: 'light-dark(#333, #eee)'},
+  landingNavLinks: {display: 'flex', gap: 24},
   landingNavLink: {
     color: 'light-dark(#666, #aaa)',
     textDecoration: 'none',
@@ -388,19 +343,9 @@ const s = stylex.create({
     maxWidth: 720,
     margin: '0 auto',
   },
-  landingHeroTitle: {
-    margin: '0 0 16px 0',
-    color: 'light-dark(#111, #fff)',
-  },
-  landingHeroSubtitle: {
-    margin: '0 0 32px 0',
-    color: 'light-dark(#666, #aaa)',
-  },
-  landingHeroButtons: {
-    display: 'flex',
-    gap: 12,
-    justifyContent: 'center',
-  },
+  landingHeroTitle: {margin: '0 0 16px 0', color: 'light-dark(#111, #fff)'},
+  landingHeroSubtitle: {margin: '0 0 32px 0', color: 'light-dark(#666, #aaa)'},
+  landingHeroButtons: {display: 'flex', gap: 12, justifyContent: 'center'},
   landingFeatures: {
     padding: '48px 24px',
     backgroundColor: 'light-dark(#f9f9f9, #1a1a1a)',
@@ -432,9 +377,121 @@ const s = stylex.create({
     margin: '0 0 8px 0',
     color: 'light-dark(#111, #fff)',
   },
-  landingFeatureDesc: {
+  landingFeatureDesc: {margin: 0, color: 'light-dark(#666, #aaa)'},
+  // Dashboard
+  dashPreview: {
+    backgroundColor: 'light-dark(#f5f5f5, #111)',
+    borderRadius: 8,
+    border: '1px solid light-dark(#ddd, #333)',
+    overflow: 'hidden',
+    minHeight: 600,
+  },
+  dashTopbar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: '12px 20px',
+    backgroundColor: 'light-dark(#fff, #1a1a1a)',
+    borderBottom: '1px solid light-dark(#eee, #333)',
+  },
+  dashContent: {padding: 20},
+  dashHeader: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'flex-end',
+    marginBottom: 20,
+  },
+  dashKpiGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(4, 1fr)',
+    gap: 16,
+    marginBottom: 20,
+  },
+  dashKpiCard: {
+    padding: 16,
+    backgroundColor: 'light-dark(#fff, #1f1f22)',
+    borderRadius: 8,
+    border: '1px solid light-dark(#eee, #333)',
+  },
+  dashKpiValue: {
+    margin: '4px 0 2px 0',
+    color: 'light-dark(#111, #fff)',
+  },
+  dashKpiLabel: {
     margin: 0,
     color: 'light-dark(#666, #aaa)',
+  },
+  dashKpiDelta: {
+    margin: 0,
+  },
+  dashChartRow: {
+    display: 'grid',
+    gridTemplateColumns: '2fr 1fr',
+    gap: 16,
+    marginBottom: 20,
+  },
+  dashCard: {
+    padding: 16,
+    backgroundColor: 'light-dark(#fff, #1f1f22)',
+    borderRadius: 8,
+    border: '1px solid light-dark(#eee, #333)',
+  },
+  dashCardTitle: {
+    margin: '0 0 12px 0',
+    color: 'light-dark(#333, #eee)',
+  },
+  dashChartPlaceholder: {
+    height: 160,
+    backgroundColor: 'light-dark(#f9f9f9, #252528)',
+    borderRadius: 6,
+    display: 'flex',
+    alignItems: 'flex-end',
+    padding: '0 8px 8px',
+    gap: 6,
+  },
+  dashBar: {
+    flex: 1,
+    borderRadius: '3px 3px 0 0',
+    backgroundColor: 'light-dark(#0064E0, #2694FE)',
+    opacity: 0.8,
+  },
+  dashDonut: {
+    width: 120,
+    height: 120,
+    borderRadius: '50%',
+    border: '16px solid light-dark(#0064E0, #2694FE)',
+    borderTopColor: 'light-dark(#e0e0e0, #444)',
+    margin: '12px auto',
+  },
+  dashTableContainer: {
+    overflow: 'auto',
+  },
+  dashTable: {
+    width: '100%',
+    borderCollapse: 'collapse',
+  },
+  dashTh: {
+    textAlign: 'left',
+    padding: '8px 12px',
+    borderBottom: '2px solid light-dark(#eee, #333)',
+    color: 'light-dark(#666, #aaa)',
+  },
+  dashThRight: {
+    textAlign: 'right',
+  },
+  dashTd: {
+    padding: '8px 12px',
+    borderBottom: '1px solid light-dark(#f0f0f0, #2a2a2a)',
+    color: 'light-dark(#333, #eee)',
+  },
+  dashTdRight: {
+    textAlign: 'right',
+  },
+  dashTdPositive: {
+    color: 'light-dark(#0D8626, #26A756)',
+  },
+  dashTdNegative: {
+    color: 'light-dark(#E3193B, #F5394F)',
   },
   // Tabs
   tabBar: {
@@ -468,20 +525,16 @@ const s = stylex.create({
   },
 });
 
-// =============================================================================
-// Helper to get role row style
-// =============================================================================
-
-function roleStyle(role: TypeRole) {
+function roleRowStyle(role: TypeRole) {
   switch (role) {
     case 'display':
-      return s.roleDisplay;
+      return st.roleDisplay;
     case 'heading':
-      return s.roleHeading;
+      return st.roleHeading;
     case 'body':
-      return s.roleBody;
+      return st.roleBody;
     case 'supporting':
-      return s.roleSupporting;
+      return st.roleSupporting;
   }
 }
 
@@ -489,7 +542,12 @@ function roleStyle(role: TypeRole) {
 // Component
 // =============================================================================
 
-type PreviewTab = 'scale' | 'calculations' | 'landing' | 'comparison';
+type PreviewTab =
+  | 'scale'
+  | 'calculations'
+  | 'landing'
+  | 'dashboard'
+  | 'comparison';
 
 export default function TypeScaleExplorerPage() {
   const [config, setConfig] = useState<TypeScaleConfig>(PRESETS.default);
@@ -516,29 +574,29 @@ export default function TypeScaleExplorerPage() {
   const maxRawSize = Math.max(...rawScale.map(r => r.roundedSize));
 
   return (
-    <div {...stylex.props(s.container)}>
+    <div {...stylex.props(st.container)}>
       <XDSVStack gap={6}>
         {/* Header */}
         <XDSVStack gap={2}>
           <XDSHeading level={1}>Type Scale Explorer</XDSHeading>
           <XDSText type="body" color="secondary">
-            Experiment with ratio-based type scales. Combines font size, line
-            height, and weight into semantic type styles.
+            Ratio-based type scale with semantic roles. H4 is the baseline
+            (exponent 0) — the scale extrapolates up and down from there.
           </XDSText>
         </XDSVStack>
 
         {/* Controls */}
-        <div {...stylex.props(s.controls)}>
+        <div {...stylex.props(st.controls)}>
           <XDSVStack gap={4}>
-            <div {...stylex.props(s.controlGroup)}>
-              <span {...stylex.props(s.label)}>Presets</span>
+            <div {...stylex.props(st.controlGroup)}>
+              <span {...stylex.props(st.label)}>Presets</span>
               <XDSHStack gap={2}>
                 {Object.entries(PRESETS).map(([name, preset]) => (
                   <button
                     key={name}
                     {...stylex.props(
-                      s.presetBtn,
-                      activePreset === name && s.presetBtnActive,
+                      st.presetBtn,
+                      activePreset === name && st.presetBtnActive,
                     )}
                     onClick={() => setConfig(preset)}>
                     {name.charAt(0).toUpperCase() + name.slice(1)}
@@ -548,8 +606,8 @@ export default function TypeScaleExplorerPage() {
             </div>
 
             <XDSHStack gap={6}>
-              <div {...stylex.props(s.controlGroup)}>
-                <span {...stylex.props(s.label)}>Base Size</span>
+              <div {...stylex.props(st.controlGroup)}>
+                <span {...stylex.props(st.label)}>Base Size (= H4)</span>
                 <XDSHStack gap={3} vAlign="center">
                   <input
                     type="range"
@@ -560,14 +618,14 @@ export default function TypeScaleExplorerPage() {
                     onChange={e =>
                       setConfig(c => ({...c, base: Number(e.target.value)}))
                     }
-                    {...stylex.props(s.slider)}
+                    {...stylex.props(st.slider)}
                   />
-                  <span {...stylex.props(s.sliderValue)}>{config.base}px</span>
+                  <span {...stylex.props(st.sliderValue)}>{config.base}px</span>
                 </XDSHStack>
               </div>
 
-              <div {...stylex.props(s.controlGroup)}>
-                <span {...stylex.props(s.label)}>Scale Ratio</span>
+              <div {...stylex.props(st.controlGroup)}>
+                <span {...stylex.props(st.label)}>Scale Ratio</span>
                 <select
                   value={
                     Object.entries(RATIOS).find(
@@ -577,7 +635,7 @@ export default function TypeScaleExplorerPage() {
                   onChange={e =>
                     setConfig(c => ({...c, ratio: RATIOS[e.target.value]}))
                   }
-                  {...stylex.props(s.select)}>
+                  {...stylex.props(st.select)}>
                   {Object.entries(RATIOS).map(([name]) => (
                     <option key={name} value={name}>
                       {name}
@@ -586,8 +644,8 @@ export default function TypeScaleExplorerPage() {
                 </select>
               </div>
 
-              <div {...stylex.props(s.controlGroup)}>
-                <span {...stylex.props(s.label)}>Line Height Grid</span>
+              <div {...stylex.props(st.controlGroup)}>
+                <span {...stylex.props(st.label)}>Line Height Grid</span>
                 <select
                   value={config.lineHeightGrid}
                   onChange={e =>
@@ -596,7 +654,7 @@ export default function TypeScaleExplorerPage() {
                       lineHeightGrid: Number(e.target.value),
                     }))
                   }
-                  {...stylex.props(s.select)}>
+                  {...stylex.props(st.select)}>
                   <option value={2}>2px</option>
                   <option value={4}>4px (default)</option>
                   <option value={8}>8px</option>
@@ -607,18 +665,19 @@ export default function TypeScaleExplorerPage() {
         </div>
 
         {/* Tab Bar */}
-        <div {...stylex.props(s.tabBar)}>
+        <div {...stylex.props(st.tabBar)}>
           {(
             [
               ['scale', 'Type Scale'],
               ['calculations', 'Raw Calculations'],
               ['landing', 'Landing Page'],
+              ['dashboard', 'Dashboard'],
               ['comparison', 'Preset Comparison'],
             ] as const
           ).map(([key, label]) => (
             <button
               key={key}
-              {...stylex.props(s.tab, activeTab === key && s.tabActive)}
+              {...stylex.props(st.tab, activeTab === key && st.tabActive)}
               onClick={() => setActiveTab(key)}>
               {label}
             </button>
@@ -629,53 +688,45 @@ export default function TypeScaleExplorerPage() {
         {/* TYPE SCALE TAB                                                     */}
         {/* ================================================================= */}
         {activeTab === 'scale' && (
-          <div {...stylex.props(s.twoColumn)}>
-            {/* Tables */}
+          <div {...stylex.props(st.twoColumn)}>
             <XDSVStack gap={4}>
-              <table {...stylex.props(s.table)}>
+              <table {...stylex.props(st.table)}>
                 <thead>
                   <tr>
-                    <th {...stylex.props(s.th)}>Style</th>
-                    <th {...stylex.props(s.th)}>Size</th>
-                    <th {...stylex.props(s.th)}>Line H</th>
-                    <th {...stylex.props(s.th)}>Weight</th>
-                    <th {...stylex.props(s.th)}>Preview</th>
+                    <th {...stylex.props(st.th)}>Style</th>
+                    <th {...stylex.props(st.th)}>Size</th>
+                    <th {...stylex.props(st.th)}>Line H</th>
+                    <th {...stylex.props(st.th)}>Weight</th>
+                    <th {...stylex.props(st.th)}>Preview</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {/* Display */}
                   <tr>
-                    <td colSpan={5} {...stylex.props(s.roleSectionLabel)}>
+                    <td colSpan={5} {...stylex.props(st.roleSectionLabel)}>
                       Display
                     </td>
                   </tr>
                   {displays.map(t => (
                     <TypeRow key={t.name} style={t} />
                   ))}
-
-                  {/* Headings */}
                   <tr>
-                    <td colSpan={5} {...stylex.props(s.roleSectionLabel)}>
-                      Headings
+                    <td colSpan={5} {...stylex.props(st.roleSectionLabel)}>
+                      Headings (h4 = base)
                     </td>
                   </tr>
                   {headings.map(t => (
                     <TypeRow key={t.name} style={t} />
                   ))}
-
-                  {/* Body */}
                   <tr>
-                    <td colSpan={5} {...stylex.props(s.roleSectionLabel)}>
+                    <td colSpan={5} {...stylex.props(st.roleSectionLabel)}>
                       Body
                     </td>
                   </tr>
                   {bodyStyles.map(t => (
                     <TypeRow key={t.name} style={t} />
                   ))}
-
-                  {/* Supporting */}
                   <tr>
-                    <td colSpan={5} {...stylex.props(s.roleSectionLabel)}>
+                    <td colSpan={5} {...stylex.props(st.roleSectionLabel)}>
                       Supporting
                     </td>
                   </tr>
@@ -686,10 +737,9 @@ export default function TypeScaleExplorerPage() {
               </table>
             </XDSVStack>
 
-            {/* Live Preview */}
             <XDSVStack gap={4}>
               <XDSHeading level={3}>Live Preview</XDSHeading>
-              <div {...stylex.props(s.preview)}>
+              <div {...stylex.props(st.preview)}>
                 <XDSVStack gap={3}>
                   {displays.map(t => (
                     <p
@@ -700,7 +750,7 @@ export default function TypeScaleExplorerPage() {
                         fontWeight: t.weight,
                         margin: 0,
                       }}
-                      {...stylex.props(s.sampleText)}>
+                      {...stylex.props(st.sampleText)}>
                       {t.name}
                     </p>
                   ))}
@@ -714,7 +764,7 @@ export default function TypeScaleExplorerPage() {
                         fontWeight: t.weight,
                         margin: 0,
                       }}
-                      {...stylex.props(s.sampleText)}>
+                      {...stylex.props(st.sampleText)}>
                       {t.name}: A wizard&apos;s job is to vex chumps
                     </p>
                   ))}
@@ -728,9 +778,8 @@ export default function TypeScaleExplorerPage() {
                         fontWeight: t.weight,
                         margin: 0,
                       }}
-                      {...stylex.props(s.sampleText)}>
+                      {...stylex.props(st.sampleText)}>
                       {t.name}: The quick brown fox jumps over the lazy dog.
-                      Pack my box with five dozen liquor jugs.
                     </p>
                   ))}
                 </XDSVStack>
@@ -744,31 +793,29 @@ export default function TypeScaleExplorerPage() {
         {/* ================================================================= */}
         {activeTab === 'calculations' && (
           <XDSVStack gap={6}>
-            {/* Formula */}
-            <div {...stylex.props(s.rawFormula)}>
+            <div {...stylex.props(st.rawFormula)}>
               <strong>Formula:</strong> fontSize = base × ratio
               <sup>exponent</sup>
               <br />
-              base = {config.base}px &nbsp;|&nbsp; ratio = {config.ratio}
+              base = {config.base}px (= h4) &nbsp;|&nbsp; ratio = {config.ratio}
               &nbsp;|&nbsp; grid = {config.lineHeightGrid}px
             </div>
 
-            <div {...stylex.props(s.twoColumn)}>
-              {/* Raw scale */}
+            <div {...stylex.props(st.twoColumn)}>
               <XDSVStack gap={3}>
                 <XDSHeading level={3}>Raw Scale</XDSHeading>
                 <XDSText type="supporting" color="secondary">
-                  Pure mathematical output before any role mapping or collision
+                  Pure mathematical output before role mapping or collision
                   handling.
                 </XDSText>
-                <table {...stylex.props(s.table)}>
+                <table {...stylex.props(st.table)}>
                   <thead>
                     <tr>
-                      <th {...stylex.props(s.th)}>Exp</th>
-                      <th {...stylex.props(s.th)}>Formula</th>
-                      <th {...stylex.props(s.th, s.thRight)}>Raw</th>
-                      <th {...stylex.props(s.th, s.thRight)}>Rounded</th>
-                      <th {...stylex.props(s.th)}>Scale</th>
+                      <th {...stylex.props(st.th)}>Exp</th>
+                      <th {...stylex.props(st.th)}>Formula</th>
+                      <th {...stylex.props(st.th, st.thRight)}>Raw</th>
+                      <th {...stylex.props(st.th, st.thRight)}>Rounded</th>
+                      <th {...stylex.props(st.th)}>Scale</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -777,25 +824,25 @@ export default function TypeScaleExplorerPage() {
                       return (
                         <tr
                           key={step.exponent}
-                          {...stylex.props(isBase && s.rawHighlight)}>
-                          <td {...stylex.props(s.td, s.tdMono)}>
+                          {...stylex.props(isBase && st.rawHighlight)}>
+                          <td {...stylex.props(st.td, st.tdMono)}>
                             {step.exponent >= 0 ? '+' : ''}
                             {step.exponent}
                           </td>
-                          <td {...stylex.props(s.td, s.tdMono)}>
+                          <td {...stylex.props(st.td, st.tdMono)}>
                             {step.formula}
                           </td>
-                          <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                          <td {...stylex.props(st.td, st.tdMono, st.tdRight)}>
                             {step.rawSize.toFixed(2)}px
                           </td>
-                          <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                          <td {...stylex.props(st.td, st.tdMono, st.tdRight)}>
                             {step.roundedSize}px
                             {isBase && ' ●'}
                           </td>
-                          <td {...stylex.props(s.td)}>
-                            <div {...stylex.props(s.rawBarContainer)}>
+                          <td {...stylex.props(st.td)}>
+                            <div {...stylex.props(st.rawBarContainer)}>
                               <div
-                                {...stylex.props(s.rawBar)}
+                                {...stylex.props(st.rawBar)}
                                 style={{
                                   width: `${(step.roundedSize / maxRawSize) * 100}%`,
                                 }}
@@ -809,47 +856,48 @@ export default function TypeScaleExplorerPage() {
                 </table>
               </XDSVStack>
 
-              {/* Role mapping */}
               <XDSVStack gap={3}>
                 <XDSHeading level={3}>Role Mapping</XDSHeading>
                 <XDSText type="supporting" color="secondary">
                   How raw scale steps map to semantic roles, with collision
                   handling applied.
                 </XDSText>
-                <table {...stylex.props(s.table)}>
+                <table {...stylex.props(st.table)}>
                   <thead>
                     <tr>
-                      <th {...stylex.props(s.th)}>Role</th>
-                      <th {...stylex.props(s.th)}>Exp</th>
-                      <th {...stylex.props(s.th, s.thRight)}>Raw</th>
-                      <th {...stylex.props(s.th, s.thRight)}>Final</th>
-                      <th {...stylex.props(s.th, s.thRight)}>LH</th>
-                      <th {...stylex.props(s.th)}>Wt</th>
+                      <th {...stylex.props(st.th)}>Role</th>
+                      <th {...stylex.props(st.th)}>Exp</th>
+                      <th {...stylex.props(st.th, st.thRight)}>Raw</th>
+                      <th {...stylex.props(st.th, st.thRight)}>Final</th>
+                      <th {...stylex.props(st.th, st.thRight)}>LH</th>
+                      <th {...stylex.props(st.th)}>Wt</th>
                     </tr>
                   </thead>
                   <tbody>
                     {typeStyles.map(t => (
-                      <tr key={t.name} {...stylex.props(roleStyle(t.role))}>
-                        <td {...stylex.props(s.td)}>
+                      <tr key={t.name} {...stylex.props(roleRowStyle(t.role))}>
+                        <td {...stylex.props(st.td)}>
                           {t.name}
                           {t.wasNudged && (
-                            <span {...stylex.props(s.nudgedBadge)}>nudged</span>
+                            <span {...stylex.props(st.nudgedBadge)}>
+                              nudged
+                            </span>
                           )}
                         </td>
-                        <td {...stylex.props(s.td, s.tdMono)}>
+                        <td {...stylex.props(st.td, st.tdMono)}>
                           {t.exponent >= 0 ? '+' : ''}
                           {t.exponent}
                         </td>
-                        <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                        <td {...stylex.props(st.td, st.tdMono, st.tdRight)}>
                           {t.rawSize.toFixed(1)}
                         </td>
-                        <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                        <td {...stylex.props(st.td, st.tdMono, st.tdRight)}>
                           {t.fontSize}px
                         </td>
-                        <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                        <td {...stylex.props(st.td, st.tdMono, st.tdRight)}>
                           {t.lineHeight}px
                         </td>
-                        <td {...stylex.props(s.td, s.tdMono)}>{t.weight}</td>
+                        <td {...stylex.props(st.td, st.tdMono)}>{t.weight}</td>
                       </tr>
                     ))}
                   </tbody>
@@ -857,8 +905,7 @@ export default function TypeScaleExplorerPage() {
               </XDSVStack>
             </div>
 
-            {/* Line height explanation */}
-            <div {...stylex.props(s.rawFormula)}>
+            <div {...stylex.props(st.rawFormula)}>
               <strong>Line Height Algorithm:</strong>
               <br />
               {'Display: target ≈ 1.1–1.15× → snap to '}
@@ -880,18 +927,17 @@ export default function TypeScaleExplorerPage() {
         {/* LANDING PAGE TAB                                                   */}
         {/* ================================================================= */}
         {activeTab === 'landing' && (
-          <div {...stylex.props(s.landingPreview)}>
-            {/* Nav */}
-            <nav {...stylex.props(s.landingNav)}>
+          <div {...stylex.props(st.landingPreview)}>
+            <nav {...stylex.props(st.landingNav)}>
               <span
                 style={{
                   fontSize: getStyle('body').fontSize,
                   fontWeight: 700,
                 }}
-                {...stylex.props(s.landingLogo)}>
+                {...stylex.props(st.landingLogo)}>
                 Acme Inc
               </span>
-              <div {...stylex.props(s.landingNavLinks)}>
+              <div {...stylex.props(st.landingNavLinks)}>
                 {['Features', 'Pricing', 'About', 'Contact'].map(link => (
                   <span
                     key={link}
@@ -899,15 +945,14 @@ export default function TypeScaleExplorerPage() {
                       fontSize: getStyle('body-sm').fontSize,
                       fontWeight: getStyle('body-sm').weight,
                     }}
-                    {...stylex.props(s.landingNavLink)}>
+                    {...stylex.props(st.landingNavLink)}>
                     {link}
                   </span>
                 ))}
               </div>
             </nav>
 
-            {/* Hero */}
-            <div {...stylex.props(s.landingHero)}>
+            <div {...stylex.props(st.landingHero)}>
               <p
                 style={{
                   fontSize: getStyle('supporting').fontSize,
@@ -925,7 +970,7 @@ export default function TypeScaleExplorerPage() {
                   lineHeight: `${getStyle('display-2').lineHeight}px`,
                   fontWeight: getStyle('display-2').weight,
                 }}
-                {...stylex.props(s.landingHeroTitle)}>
+                {...stylex.props(st.landingHeroTitle)}>
                 Your digital transformation begins here
               </h1>
               <p
@@ -934,11 +979,11 @@ export default function TypeScaleExplorerPage() {
                   lineHeight: `${getStyle('body-lg').lineHeight}px`,
                   fontWeight: getStyle('body-lg').weight,
                 }}
-                {...stylex.props(s.landingHeroSubtitle)}>
+                {...stylex.props(st.landingHeroSubtitle)}>
                 Unlock the full potential of your business. Start your journey
                 today and experience the future of enterprise software.
               </p>
-              <div {...stylex.props(s.landingHeroButtons)}>
+              <div {...stylex.props(st.landingHeroButtons)}>
                 <XDSButton label="Explore features" variant="secondary" />
                 <XDSButton label="Get started" variant="primary" />
               </div>
@@ -954,8 +999,7 @@ export default function TypeScaleExplorerPage() {
               </p>
             </div>
 
-            {/* Features */}
-            <div {...stylex.props(s.landingFeatures)}>
+            <div {...stylex.props(st.landingFeatures)}>
               <p
                 style={{
                   fontSize: getStyle('label').fontSize,
@@ -974,7 +1018,7 @@ export default function TypeScaleExplorerPage() {
                   lineHeight: `${getStyle('h2').lineHeight}px`,
                   fontWeight: getStyle('h2').weight,
                 }}
-                {...stylex.props(s.landingFeaturesTitle)}>
+                {...stylex.props(st.landingFeaturesTitle)}>
                 SaaS solutions that drive results
               </h2>
               <p
@@ -983,12 +1027,12 @@ export default function TypeScaleExplorerPage() {
                   lineHeight: `${getStyle('body').lineHeight}px`,
                   fontWeight: getStyle('body').weight,
                 }}
-                {...stylex.props(s.landingFeaturesSubtitle)}>
+                {...stylex.props(st.landingFeaturesSubtitle)}>
                 Explore our suite of powerful software solutions designed to
                 streamline your operations.
               </p>
 
-              <div {...stylex.props(s.landingFeatureGrid)}>
+              <div {...stylex.props(st.landingFeatureGrid)}>
                 {[
                   {
                     title: 'Enterprise Planning',
@@ -1005,14 +1049,14 @@ export default function TypeScaleExplorerPage() {
                 ].map(feature => (
                   <div
                     key={feature.title}
-                    {...stylex.props(s.landingFeatureCard)}>
+                    {...stylex.props(st.landingFeatureCard)}>
                     <h3
                       style={{
                         fontSize: getStyle('h4').fontSize,
                         lineHeight: `${getStyle('h4').lineHeight}px`,
                         fontWeight: getStyle('h4').weight,
                       }}
-                      {...stylex.props(s.landingFeatureTitle)}>
+                      {...stylex.props(st.landingFeatureTitle)}>
                       {feature.title}
                     </h3>
                     <p
@@ -1021,7 +1065,7 @@ export default function TypeScaleExplorerPage() {
                         lineHeight: `${getStyle('body-sm').lineHeight}px`,
                         fontWeight: getStyle('body-sm').weight,
                       }}
-                      {...stylex.props(s.landingFeatureDesc)}>
+                      {...stylex.props(st.landingFeatureDesc)}>
                       {feature.desc}
                     </p>
                   </div>
@@ -1030,6 +1074,11 @@ export default function TypeScaleExplorerPage() {
             </div>
           </div>
         )}
+
+        {/* ================================================================= */}
+        {/* DASHBOARD TAB                                                      */}
+        {/* ================================================================= */}
+        {activeTab === 'dashboard' && <DashboardPreview getStyle={getStyle} />}
 
         {/* ================================================================= */}
         {/* PRESET COMPARISON TAB                                              */}
@@ -1060,7 +1109,7 @@ export default function TypeScaleExplorerPage() {
                       <XDSText type="supporting" color="secondary">
                         {preset.base}px base, {preset.ratio} ratio
                       </XDSText>
-                      <div {...stylex.props(s.preview)}>
+                      <div {...stylex.props(st.preview)}>
                         <XDSVStack gap={2}>
                           {pDisplays.slice(1, 3).map(t => (
                             <p
@@ -1071,7 +1120,7 @@ export default function TypeScaleExplorerPage() {
                                 fontWeight: t.weight,
                                 margin: 0,
                               }}
-                              {...stylex.props(s.sampleText)}>
+                              {...stylex.props(st.sampleText)}>
                               {t.name}: {t.fontSize}px
                             </p>
                           ))}
@@ -1084,7 +1133,7 @@ export default function TypeScaleExplorerPage() {
                                 fontWeight: t.weight,
                                 margin: 0,
                               }}
-                              {...stylex.props(s.sampleText)}>
+                              {...stylex.props(st.sampleText)}>
                               {t.name}: {t.fontSize}px
                             </p>
                           ))}
@@ -1098,7 +1147,7 @@ export default function TypeScaleExplorerPage() {
                                 margin: 0,
                                 marginTop: 8,
                               }}
-                              {...stylex.props(s.sampleText)}>
+                              {...stylex.props(st.sampleText)}>
                               Body text at {t.fontSize}px
                             </p>
                           ))}
@@ -1122,28 +1171,390 @@ export default function TypeScaleExplorerPage() {
 
 function TypeRow({style: t}: {style: TypeStyle}) {
   return (
-    <tr {...stylex.props(roleStyle(t.role))}>
-      <td {...stylex.props(s.td)}>
+    <tr {...stylex.props(roleRowStyle(t.role))}>
+      <td {...stylex.props(st.td)}>
         {t.name}
-        {t.wasNudged && <span {...stylex.props(s.nudgedBadge)}>nudged</span>}
+        {t.wasNudged && <span {...stylex.props(st.nudgedBadge)}>nudged</span>}
       </td>
-      <td {...stylex.props(s.td, s.tdMono)}>{t.fontSize}px</td>
-      <td {...stylex.props(s.td, s.tdMono)}>{t.lineHeight}px</td>
-      <td {...stylex.props(s.td, s.tdMono)}>{t.weight}</td>
-      <td {...stylex.props(s.td)}>
+      <td {...stylex.props(st.td, st.tdMono)}>{t.fontSize}px</td>
+      <td {...stylex.props(st.td, st.tdMono)}>{t.lineHeight}px</td>
+      <td {...stylex.props(st.td, st.tdMono)}>{t.weight}</td>
+      <td {...stylex.props(st.td)}>
         <span
           style={{
             fontSize: t.fontSize,
             lineHeight: `${t.lineHeight}px`,
             fontWeight: t.weight,
           }}>
-          {t.role === 'display'
+          {t.role === 'display' || t.role === 'heading'
             ? 'Aa'
-            : t.role === 'heading'
-              ? 'Aa'
-              : 'The quick brown fox'}
+            : 'The quick brown fox'}
         </span>
       </td>
     </tr>
+  );
+}
+
+// =============================================================================
+// Dashboard Preview Component
+// =============================================================================
+
+const TABLE_DATA = [
+  {
+    name: 'Organic Search',
+    visitors: '5,432',
+    revenue: '$12,890',
+    conv: '3.2%',
+    delta: '+12.5%',
+    up: true,
+  },
+  {
+    name: 'Direct',
+    visitors: '3,218',
+    revenue: '$8,450',
+    conv: '4.1%',
+    delta: '+8.3%',
+    up: true,
+  },
+  {
+    name: 'Social Media',
+    visitors: '2,876',
+    revenue: '$5,230',
+    conv: '2.8%',
+    delta: '-3.1%',
+    up: false,
+  },
+  {
+    name: 'Email Campaign',
+    visitors: '1,943',
+    revenue: '$6,120',
+    conv: '5.6%',
+    delta: '+15.2%',
+    up: true,
+  },
+  {
+    name: 'Paid Search',
+    visitors: '1,654',
+    revenue: '$4,890',
+    conv: '2.1%',
+    delta: '-1.8%',
+    up: false,
+  },
+  {
+    name: 'Referral',
+    visitors: '987',
+    revenue: '$2,340',
+    conv: '3.9%',
+    delta: '+6.7%',
+    up: true,
+  },
+];
+
+const BAR_HEIGHTS = [45, 62, 38, 78, 55, 42, 88, 65, 50, 72, 58, 82];
+
+function DashboardPreview({getStyle}: {getStyle: (name: string) => TypeStyle}) {
+  const caption = getStyle('caption');
+  const supporting = getStyle('supporting');
+  const bodySm = getStyle('body-sm');
+  const body = getStyle('body');
+  const label = getStyle('label');
+  const h3 = getStyle('h3');
+  const h4 = getStyle('h4');
+  const h1 = getStyle('h1');
+
+  return (
+    <div {...stylex.props(st.dashPreview)}>
+      {/* Top bar */}
+      <div {...stylex.props(st.dashTopbar)}>
+        <span
+          style={{fontSize: label.fontSize, fontWeight: 600}}
+          {...stylex.props(st.sampleText)}>
+          Analytics Dashboard
+        </span>
+        <span
+          style={{fontSize: caption.fontSize, fontWeight: caption.weight}}
+          {...stylex.props(st.landingNavLink)}>
+          Last 30 days · Jan 1 – Jan 30, 2026
+        </span>
+      </div>
+
+      <div {...stylex.props(st.dashContent)}>
+        {/* Page header */}
+        <div {...stylex.props(st.dashHeader)}>
+          <div>
+            <h2
+              style={{
+                fontSize: h3.fontSize,
+                lineHeight: `${h3.lineHeight}px`,
+                fontWeight: h3.weight,
+                margin: 0,
+              }}
+              {...stylex.props(st.sampleText)}>
+              Overview
+            </h2>
+            <p
+              style={{
+                fontSize: supporting.fontSize,
+                lineHeight: `${supporting.lineHeight}px`,
+                fontWeight: supporting.weight,
+                margin: '4px 0 0 0',
+                color: 'light-dark(#666, #aaa)',
+              }}>
+              Key metrics and performance indicators
+            </p>
+          </div>
+          <XDSButton label="Export" variant="secondary" size="sm" />
+        </div>
+
+        {/* KPI Cards */}
+        <div {...stylex.props(st.dashKpiGrid)}>
+          {[
+            {
+              label: 'Total Revenue',
+              value: '$48,920',
+              delta: '+12.5%',
+              up: true,
+            },
+            {label: 'Active Users', value: '16,110', delta: '+8.3%', up: true},
+            {
+              label: 'Conversion Rate',
+              value: '3.24%',
+              delta: '-0.4%',
+              up: false,
+            },
+            {
+              label: 'Avg. Order Value',
+              value: '$64.20',
+              delta: '+2.1%',
+              up: true,
+            },
+          ].map(kpi => (
+            <div key={kpi.label} {...stylex.props(st.dashKpiCard)}>
+              <p
+                style={{
+                  fontSize: caption.fontSize,
+                  lineHeight: `${caption.lineHeight}px`,
+                  fontWeight: 500,
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.04em',
+                }}
+                {...stylex.props(st.dashKpiLabel)}>
+                {kpi.label}
+              </p>
+              <p
+                style={{
+                  fontSize: h4.fontSize,
+                  lineHeight: `${h4.lineHeight}px`,
+                  fontWeight: h4.weight,
+                }}
+                {...stylex.props(st.dashKpiValue)}>
+                {kpi.value}
+              </p>
+              <p
+                style={{
+                  fontSize: caption.fontSize,
+                  lineHeight: `${caption.lineHeight}px`,
+                  fontWeight: 500,
+                  color: kpi.up
+                    ? 'light-dark(#0D8626, #26A756)'
+                    : 'light-dark(#E3193B, #F5394F)',
+                }}
+                {...stylex.props(st.dashKpiDelta)}>
+                {kpi.delta} vs last period
+              </p>
+            </div>
+          ))}
+        </div>
+
+        {/* Chart row */}
+        <div {...stylex.props(st.dashChartRow)}>
+          {/* Bar chart */}
+          <div {...stylex.props(st.dashCard)}>
+            <h3
+              style={{
+                fontSize: h4.fontSize,
+                lineHeight: `${h4.lineHeight}px`,
+                fontWeight: h4.weight,
+              }}
+              {...stylex.props(st.dashCardTitle)}>
+              Revenue Over Time
+            </h3>
+            <div {...stylex.props(st.dashChartPlaceholder)}>
+              {BAR_HEIGHTS.map((h, i) => (
+                <div
+                  key={i}
+                  {...stylex.props(st.dashBar)}
+                  style={{height: `${h}%`}}
+                />
+              ))}
+            </div>
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'space-between',
+                marginTop: 6,
+              }}>
+              <span
+                style={{
+                  fontSize: caption.fontSize,
+                  color: 'light-dark(#999, #666)',
+                }}>
+                Jan
+              </span>
+              <span
+                style={{
+                  fontSize: caption.fontSize,
+                  color: 'light-dark(#999, #666)',
+                }}>
+                Jun
+              </span>
+              <span
+                style={{
+                  fontSize: caption.fontSize,
+                  color: 'light-dark(#999, #666)',
+                }}>
+                Dec
+              </span>
+            </div>
+          </div>
+
+          {/* Donut chart */}
+          <div {...stylex.props(st.dashCard)}>
+            <h3
+              style={{
+                fontSize: h4.fontSize,
+                lineHeight: `${h4.lineHeight}px`,
+                fontWeight: h4.weight,
+              }}
+              {...stylex.props(st.dashCardTitle)}>
+              Traffic Sources
+            </h3>
+            <div {...stylex.props(st.dashDonut)} />
+            <div style={{textAlign: 'center'}}>
+              <p
+                style={{
+                  fontSize: h1.fontSize,
+                  fontWeight: h1.weight,
+                  margin: 0,
+                }}
+                {...stylex.props(st.sampleText)}>
+                68%
+              </p>
+              <p
+                style={{
+                  fontSize: caption.fontSize,
+                  margin: '2px 0 0 0',
+                  color: 'light-dark(#666, #aaa)',
+                }}>
+                Organic traffic
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Data table */}
+        <div {...stylex.props(st.dashCard)}>
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: 12,
+            }}>
+            <h3
+              style={{
+                fontSize: h4.fontSize,
+                lineHeight: `${h4.lineHeight}px`,
+                fontWeight: h4.weight,
+              }}
+              {...stylex.props(st.dashCardTitle)}>
+              Acquisition Channels
+            </h3>
+            <span
+              style={{
+                fontSize: caption.fontSize,
+                color: 'light-dark(#0064E0, #2694FE)',
+                cursor: 'pointer',
+              }}>
+              View all →
+            </span>
+          </div>
+          <div {...stylex.props(st.dashTableContainer)}>
+            <table {...stylex.props(st.dashTable)}>
+              <thead>
+                <tr>
+                  {['Channel', 'Visitors', 'Revenue', 'Conv.', 'Trend'].map(
+                    (col, i) => (
+                      <th
+                        key={col}
+                        style={{
+                          fontSize: caption.fontSize,
+                          fontWeight: 600,
+                          textTransform: 'uppercase',
+                          letterSpacing: '0.04em',
+                        }}
+                        {...stylex.props(st.dashTh, i > 0 && st.dashThRight)}>
+                        {col}
+                      </th>
+                    ),
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {TABLE_DATA.map(row => (
+                  <tr key={row.name}>
+                    <td
+                      style={{
+                        fontSize: bodySm.fontSize,
+                        lineHeight: `${bodySm.lineHeight}px`,
+                        fontWeight: 500,
+                      }}
+                      {...stylex.props(st.dashTd)}>
+                      {row.name}
+                    </td>
+                    <td
+                      style={{
+                        fontSize: bodySm.fontSize,
+                        fontFamily: 'SF Mono, Monaco, Consolas, monospace',
+                      }}
+                      {...stylex.props(st.dashTd, st.dashTdRight)}>
+                      {row.visitors}
+                    </td>
+                    <td
+                      style={{
+                        fontSize: bodySm.fontSize,
+                        fontFamily: 'SF Mono, Monaco, Consolas, monospace',
+                      }}
+                      {...stylex.props(st.dashTd, st.dashTdRight)}>
+                      {row.revenue}
+                    </td>
+                    <td
+                      style={{
+                        fontSize: bodySm.fontSize,
+                        fontFamily: 'SF Mono, Monaco, Consolas, monospace',
+                      }}
+                      {...stylex.props(st.dashTd, st.dashTdRight)}>
+                      {row.conv}
+                    </td>
+                    <td
+                      style={{
+                        fontSize: bodySm.fontSize,
+                        fontWeight: 500,
+                      }}
+                      {...stylex.props(
+                        st.dashTd,
+                        st.dashTdRight,
+                        row.up ? st.dashTdPositive : st.dashTdNegative,
+                      )}>
+                      {row.delta}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -67,7 +67,7 @@ function generateTypeScale(config: TypeScaleConfig): TypeScaleStep[] {
 // =============================================================================
 
 const PRESETS: Record<string, TypeScaleConfig> = {
-  dense: {base: 12, ratio: 1.125, lineHeightGrid: 4},
+  functional: {base: 12, ratio: 1.125, lineHeightGrid: 4},
   default: {base: 14, ratio: 1.125, lineHeightGrid: 4},
   editorial: {base: 16, ratio: 1.25, lineHeightGrid: 4},
 };

--- a/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
+++ b/apps/sandbox/src/app/pages/type-scale-explorer/page.tsx
@@ -19,32 +19,42 @@ interface TypeScaleConfig {
 
 interface TypeStyle {
   name: string;
-  role: 'heading' | 'body' | 'supporting';
+  role: 'display' | 'heading' | 'body' | 'supporting';
   exponent: number;
   weight: number;
   rawSize: number;
   fontSize: number;
   lineHeight: number;
   lineHeightRatio: number;
+  wasNudged: boolean;
 }
+
+type TypeRole = 'display' | 'heading' | 'body' | 'supporting';
 
 // Semantic type roles mapped to scale exponents
 const TYPE_ROLES: Array<{
   name: string;
-  role: 'heading' | 'body' | 'supporting';
+  role: TypeRole;
   exponent: number;
   weight: number;
 }> = [
+  // Display — hero, marketing, splash
+  {name: 'display-1', role: 'display', exponent: 7, weight: 700},
+  {name: 'display-2', role: 'display', exponent: 6, weight: 700},
+  {name: 'display-3', role: 'display', exponent: 5, weight: 600},
+  // Headings
   {name: 'h1', role: 'heading', exponent: 4, weight: 600},
   {name: 'h2', role: 'heading', exponent: 3, weight: 600},
   {name: 'h3', role: 'heading', exponent: 2, weight: 600},
   {name: 'h4', role: 'heading', exponent: 1, weight: 600},
   {name: 'h5', role: 'heading', exponent: 0, weight: 600},
   {name: 'h6', role: 'heading', exponent: -1, weight: 600},
+  // Body
   {name: 'body-lg', role: 'body', exponent: 1, weight: 400},
   {name: 'body', role: 'body', exponent: 0, weight: 400},
   {name: 'body-sm', role: 'body', exponent: -1, weight: 400},
   {name: 'label', role: 'body', exponent: 0, weight: 500},
+  // Supporting
   {name: 'supporting', role: 'supporting', exponent: -1, weight: 400},
   {name: 'caption', role: 'supporting', exponent: -2, weight: 400},
 ];
@@ -52,11 +62,12 @@ const TYPE_ROLES: Array<{
 function computeLineHeight(
   fontSize: number,
   grid: number,
-  role: 'heading' | 'body' | 'supporting',
+  role: TypeRole,
 ): number {
-  // Tighter line heights for headings, more relaxed for body
   let targetRatio: number;
-  if (role === 'heading') {
+  if (role === 'display') {
+    targetRatio = fontSize < 48 ? 1.15 : 1.1;
+  } else if (role === 'heading') {
     targetRatio = fontSize < 24 ? 1.3 : fontSize < 32 ? 1.25 : 1.2;
   } else {
     targetRatio = fontSize < 16 ? 1.4 : 1.5;
@@ -65,13 +76,12 @@ function computeLineHeight(
   const ideal = fontSize * targetRatio;
   const snapped = Math.round(ideal / grid) * grid;
 
-  // Ensure minimum breathing room
   const minimum = Math.ceil((fontSize + 2) / grid) * grid;
   return Math.max(snapped, minimum);
 }
 
 function generateTypeStyles(config: TypeScaleConfig): TypeStyle[] {
-  const styles = TYPE_ROLES.map(role => {
+  const allStyles = TYPE_ROLES.map(role => {
     const rawSize = config.base * Math.pow(config.ratio, role.exponent);
     const fontSize = Math.round(rawSize);
     const lineHeight = computeLineHeight(
@@ -86,25 +96,85 @@ function generateTypeStyles(config: TypeScaleConfig): TypeStyle[] {
       fontSize,
       lineHeight,
       lineHeightRatio: lineHeight / fontSize,
+      wasNudged: false,
     };
   });
 
-  // Enforce 1px minimum step between heading sizes
-  const headings = styles.filter(s => s.role === 'heading');
-  for (let i = 1; i < headings.length; i++) {
-    if (headings[i].fontSize >= headings[i - 1].fontSize) {
-      headings[i].fontSize = headings[i - 1].fontSize - 1;
-      headings[i].lineHeight = computeLineHeight(
-        headings[i].fontSize,
+  // Enforce 1px minimum step within each group that should be monotonically decreasing
+  const enforceMinStep = (group: TypeStyle[]) => {
+    for (let i = 1; i < group.length; i++) {
+      if (group[i].fontSize >= group[i - 1].fontSize) {
+        group[i].fontSize = group[i - 1].fontSize - 1;
+        group[i].lineHeight = computeLineHeight(
+          group[i].fontSize,
+          config.lineHeightGrid,
+          group[i].role,
+        );
+        group[i].lineHeightRatio = group[i].lineHeight / group[i].fontSize;
+        group[i].wasNudged = true;
+      }
+    }
+  };
+
+  // Also enforce display > h1 continuity
+  const displays = allStyles.filter(s => s.role === 'display');
+  const headings = allStyles.filter(s => s.role === 'heading');
+  enforceMinStep(displays);
+  enforceMinStep(headings);
+
+  // Ensure smallest display > largest heading
+  if (displays.length > 0 && headings.length > 0) {
+    const smallestDisplay = displays[displays.length - 1];
+    if (smallestDisplay.fontSize <= headings[0].fontSize) {
+      smallestDisplay.fontSize = headings[0].fontSize + 1;
+      smallestDisplay.lineHeight = computeLineHeight(
+        smallestDisplay.fontSize,
         config.lineHeightGrid,
-        'heading',
+        'display',
       );
-      headings[i].lineHeightRatio =
-        headings[i].lineHeight / headings[i].fontSize;
+      smallestDisplay.lineHeightRatio =
+        smallestDisplay.lineHeight / smallestDisplay.fontSize;
+      smallestDisplay.wasNudged = true;
+      // Re-enforce display chain upward
+      for (let i = displays.length - 2; i >= 0; i--) {
+        if (displays[i].fontSize <= displays[i + 1].fontSize) {
+          displays[i].fontSize = displays[i + 1].fontSize + 1;
+          displays[i].lineHeight = computeLineHeight(
+            displays[i].fontSize,
+            config.lineHeightGrid,
+            'display',
+          );
+          displays[i].lineHeightRatio =
+            displays[i].lineHeight / displays[i].fontSize;
+          displays[i].wasNudged = true;
+        }
+      }
     }
   }
 
-  return styles;
+  return allStyles;
+}
+
+// Raw scale steps for the calculations tab
+const RAW_SCALE_STEPS = Array.from({length: 12}, (_, i) => i - 3);
+
+interface RawScaleStep {
+  exponent: number;
+  rawSize: number;
+  roundedSize: number;
+  formula: string;
+}
+
+function generateRawScale(config: TypeScaleConfig): RawScaleStep[] {
+  return RAW_SCALE_STEPS.map(exp => {
+    const rawSize = config.base * Math.pow(config.ratio, exp);
+    return {
+      exponent: exp,
+      rawSize,
+      roundedSize: Math.round(rawSize),
+      formula: `${config.base} × ${config.ratio}^${exp}`,
+    };
+  });
 }
 
 // =============================================================================
@@ -132,7 +202,7 @@ const RATIOS: Record<string, number> = {
 // Styles
 // =============================================================================
 
-const styles = stylex.create({
+const s = stylex.create({
   container: {
     maxWidth: 1400,
   },
@@ -179,7 +249,7 @@ const styles = stylex.create({
     minWidth: 50,
     textAlign: 'right',
   },
-  presetButton: {
+  presetBtn: {
     padding: '8px 16px',
     fontSize: 13,
     fontWeight: 500,
@@ -190,7 +260,7 @@ const styles = stylex.create({
     cursor: 'pointer',
     transition: 'all 0.15s',
   },
-  presetButtonActive: {
+  presetBtnActive: {
     backgroundColor: 'light-dark(#0064E0, #2694FE)',
     borderColor: 'light-dark(#0064E0, #2694FE)',
     color: '#fff',
@@ -210,14 +280,23 @@ const styles = stylex.create({
     textTransform: 'uppercase',
     letterSpacing: '0.05em',
   },
+  thRight: {
+    textAlign: 'right',
+  },
   td: {
     padding: '10px 12px',
     borderBottom: '1px solid light-dark(#eee, #333)',
     color: 'light-dark(#333, #eee)',
   },
+  tdRight: {
+    textAlign: 'right',
+  },
   tdMono: {
     fontFamily: 'SF Mono, Monaco, Consolas, monospace',
     fontSize: 12,
+  },
+  roleDisplay: {
+    backgroundColor: 'light-dark(#fef3f0, #2a1f1a)',
   },
   roleHeading: {
     backgroundColor: 'light-dark(#f0f7ff, #1a2a3a)',
@@ -238,15 +317,44 @@ const styles = stylex.create({
     margin: 0,
     color: 'light-dark(#333, #eee)',
   },
-  formula: {
+  nudgedBadge: {
+    display: 'inline-block',
+    padding: '1px 5px',
+    fontSize: 9,
+    fontWeight: 600,
+    borderRadius: 3,
+    backgroundColor: 'light-dark(#fff3cd, #4a3f00)',
+    color: 'light-dark(#856404, #ffc107)',
+    marginLeft: 6,
+  },
+  // Raw calc tab
+  rawFormula: {
     fontFamily: 'SF Mono, Monaco, Consolas, monospace',
     fontSize: 12,
-    padding: '12px 16px',
+    padding: '16px 20px',
     backgroundColor: 'light-dark(#f5f5f5, #2a2a2a)',
-    borderRadius: 6,
+    borderRadius: 8,
     color: 'light-dark(#333, #eee)',
+    lineHeight: 1.8,
   },
-  // Landing page preview styles
+  rawBar: {
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: 'light-dark(#0064E0, #2694FE)',
+    transition: 'width 0.2s ease',
+  },
+  rawBarContainer: {
+    width: 120,
+    height: 8,
+    borderRadius: 4,
+    backgroundColor: 'light-dark(#eee, #333)',
+    overflow: 'hidden',
+  },
+  rawHighlight: {
+    backgroundColor: 'light-dark(#e8f0fe, #1a2a3a)',
+    fontWeight: 600,
+  },
+  // Landing page
   landingPreview: {
     backgroundColor: 'light-dark(#fff, #111)',
     borderRadius: 8,
@@ -275,9 +383,9 @@ const styles = stylex.create({
     cursor: 'pointer',
   },
   landingHero: {
-    padding: '64px 24px',
+    padding: '80px 24px',
     textAlign: 'center',
-    maxWidth: 600,
+    maxWidth: 720,
     margin: '0 auto',
   },
   landingHeroTitle: {
@@ -328,6 +436,7 @@ const styles = stylex.create({
     margin: 0,
     color: 'light-dark(#666, #aaa)',
   },
+  // Tabs
   tabBar: {
     display: 'flex',
     gap: 0,
@@ -349,24 +458,50 @@ const styles = stylex.create({
     color: 'light-dark(#0064E0, #2694FE)',
     borderBottomColor: 'light-dark(#0064E0, #2694FE)',
   },
+  roleSectionLabel: {
+    fontSize: 10,
+    fontWeight: 700,
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    color: 'light-dark(#999, #666)',
+    padding: '8px 12px 4px',
+  },
 });
+
+// =============================================================================
+// Helper to get role row style
+// =============================================================================
+
+function roleStyle(role: TypeRole) {
+  switch (role) {
+    case 'display':
+      return s.roleDisplay;
+    case 'heading':
+      return s.roleHeading;
+    case 'body':
+      return s.roleBody;
+    case 'supporting':
+      return s.roleSupporting;
+  }
+}
 
 // =============================================================================
 // Component
 // =============================================================================
 
-type PreviewTab = 'scale' | 'landing' | 'comparison';
+type PreviewTab = 'scale' | 'calculations' | 'landing' | 'comparison';
 
 export default function TypeScaleExplorerPage() {
   const [config, setConfig] = useState<TypeScaleConfig>(PRESETS.default);
   const [activeTab, setActiveTab] = useState<PreviewTab>('scale');
 
   const typeStyles = useMemo(() => generateTypeStyles(config), [config]);
+  const rawScale = useMemo(() => generateRawScale(config), [config]);
 
-  const headings = typeStyles.filter(s => s.role === 'heading');
-  const bodyStyles = typeStyles.filter(
-    s => s.role === 'body' || s.role === 'supporting',
-  );
+  const displays = typeStyles.filter(t => t.role === 'display');
+  const headings = typeStyles.filter(t => t.role === 'heading');
+  const bodyStyles = typeStyles.filter(t => t.role === 'body');
+  const supportingStyles = typeStyles.filter(t => t.role === 'supporting');
 
   const activePreset = Object.entries(PRESETS).find(
     ([, preset]) =>
@@ -376,10 +511,12 @@ export default function TypeScaleExplorerPage() {
   )?.[0];
 
   const getStyle = (name: string) =>
-    typeStyles.find(s => s.name === name) || typeStyles[0];
+    typeStyles.find(t => t.name === name) || typeStyles[0];
+
+  const maxRawSize = Math.max(...rawScale.map(r => r.roundedSize));
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div {...stylex.props(s.container)}>
       <XDSVStack gap={6}>
         {/* Header */}
         <XDSVStack gap={2}>
@@ -391,18 +528,17 @@ export default function TypeScaleExplorerPage() {
         </XDSVStack>
 
         {/* Controls */}
-        <div {...stylex.props(styles.controls)}>
+        <div {...stylex.props(s.controls)}>
           <XDSVStack gap={4}>
-            {/* Presets */}
-            <div {...stylex.props(styles.controlGroup)}>
-              <span {...stylex.props(styles.label)}>Presets</span>
+            <div {...stylex.props(s.controlGroup)}>
+              <span {...stylex.props(s.label)}>Presets</span>
               <XDSHStack gap={2}>
                 {Object.entries(PRESETS).map(([name, preset]) => (
                   <button
                     key={name}
                     {...stylex.props(
-                      styles.presetButton,
-                      activePreset === name && styles.presetButtonActive,
+                      s.presetBtn,
+                      activePreset === name && s.presetBtnActive,
                     )}
                     onClick={() => setConfig(preset)}>
                     {name.charAt(0).toUpperCase() + name.slice(1)}
@@ -412,9 +548,8 @@ export default function TypeScaleExplorerPage() {
             </div>
 
             <XDSHStack gap={6}>
-              {/* Base Size */}
-              <div {...stylex.props(styles.controlGroup)}>
-                <span {...stylex.props(styles.label)}>Base Size</span>
+              <div {...stylex.props(s.controlGroup)}>
+                <span {...stylex.props(s.label)}>Base Size</span>
                 <XDSHStack gap={3} vAlign="center">
                   <input
                     type="range"
@@ -425,17 +560,14 @@ export default function TypeScaleExplorerPage() {
                     onChange={e =>
                       setConfig(c => ({...c, base: Number(e.target.value)}))
                     }
-                    {...stylex.props(styles.slider)}
+                    {...stylex.props(s.slider)}
                   />
-                  <span {...stylex.props(styles.sliderValue)}>
-                    {config.base}px
-                  </span>
+                  <span {...stylex.props(s.sliderValue)}>{config.base}px</span>
                 </XDSHStack>
               </div>
 
-              {/* Ratio */}
-              <div {...stylex.props(styles.controlGroup)}>
-                <span {...stylex.props(styles.label)}>Scale Ratio</span>
+              <div {...stylex.props(s.controlGroup)}>
+                <span {...stylex.props(s.label)}>Scale Ratio</span>
                 <select
                   value={
                     Object.entries(RATIOS).find(
@@ -445,7 +577,7 @@ export default function TypeScaleExplorerPage() {
                   onChange={e =>
                     setConfig(c => ({...c, ratio: RATIOS[e.target.value]}))
                   }
-                  {...stylex.props(styles.select)}>
+                  {...stylex.props(s.select)}>
                   {Object.entries(RATIOS).map(([name]) => (
                     <option key={name} value={name}>
                       {name}
@@ -454,9 +586,8 @@ export default function TypeScaleExplorerPage() {
                 </select>
               </div>
 
-              {/* Grid */}
-              <div {...stylex.props(styles.controlGroup)}>
-                <span {...stylex.props(styles.label)}>Line Height Grid</span>
+              <div {...stylex.props(s.controlGroup)}>
+                <span {...stylex.props(s.label)}>Line Height Grid</span>
                 <select
                   value={config.lineHeightGrid}
                   onChange={e =>
@@ -465,7 +596,7 @@ export default function TypeScaleExplorerPage() {
                       lineHeightGrid: Number(e.target.value),
                     }))
                   }
-                  {...stylex.props(styles.select)}>
+                  {...stylex.props(s.select)}>
                   <option value={2}>2px</option>
                   <option value={4}>4px (default)</option>
                   <option value={8}>8px</option>
@@ -476,118 +607,80 @@ export default function TypeScaleExplorerPage() {
         </div>
 
         {/* Tab Bar */}
-        <div {...stylex.props(styles.tabBar)}>
-          <button
-            {...stylex.props(
-              styles.tab,
-              activeTab === 'scale' && styles.tabActive,
-            )}
-            onClick={() => setActiveTab('scale')}>
-            Type Scale
-          </button>
-          <button
-            {...stylex.props(
-              styles.tab,
-              activeTab === 'landing' && styles.tabActive,
-            )}
-            onClick={() => setActiveTab('landing')}>
-            Landing Page
-          </button>
-          <button
-            {...stylex.props(
-              styles.tab,
-              activeTab === 'comparison' && styles.tabActive,
-            )}
-            onClick={() => setActiveTab('comparison')}>
-            Preset Comparison
-          </button>
+        <div {...stylex.props(s.tabBar)}>
+          {(
+            [
+              ['scale', 'Type Scale'],
+              ['calculations', 'Raw Calculations'],
+              ['landing', 'Landing Page'],
+              ['comparison', 'Preset Comparison'],
+            ] as const
+          ).map(([key, label]) => (
+            <button
+              key={key}
+              {...stylex.props(s.tab, activeTab === key && s.tabActive)}
+              onClick={() => setActiveTab(key)}>
+              {label}
+            </button>
+          ))}
         </div>
 
-        {/* Tab Content */}
+        {/* ================================================================= */}
+        {/* TYPE SCALE TAB                                                     */}
+        {/* ================================================================= */}
         {activeTab === 'scale' && (
-          <div {...stylex.props(styles.twoColumn)}>
-            {/* Scale Table */}
+          <div {...stylex.props(s.twoColumn)}>
+            {/* Tables */}
             <XDSVStack gap={4}>
-              <XDSHeading level={3}>Headings</XDSHeading>
-              <table {...stylex.props(styles.table)}>
+              <table {...stylex.props(s.table)}>
                 <thead>
                   <tr>
-                    <th {...stylex.props(styles.th)}>Style</th>
-                    <th {...stylex.props(styles.th)}>Size</th>
-                    <th {...stylex.props(styles.th)}>Line H</th>
-                    <th {...stylex.props(styles.th)}>Weight</th>
-                    <th {...stylex.props(styles.th)}>Preview</th>
+                    <th {...stylex.props(s.th)}>Style</th>
+                    <th {...stylex.props(s.th)}>Size</th>
+                    <th {...stylex.props(s.th)}>Line H</th>
+                    <th {...stylex.props(s.th)}>Weight</th>
+                    <th {...stylex.props(s.th)}>Preview</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {headings.map(style => (
-                    <tr key={style.name} {...stylex.props(styles.roleHeading)}>
-                      <td {...stylex.props(styles.td)}>{style.name}</td>
-                      <td {...stylex.props(styles.td, styles.tdMono)}>
-                        {style.fontSize}px
-                      </td>
-                      <td {...stylex.props(styles.td, styles.tdMono)}>
-                        {style.lineHeight}px
-                      </td>
-                      <td {...stylex.props(styles.td, styles.tdMono)}>
-                        {style.weight}
-                      </td>
-                      <td {...stylex.props(styles.td)}>
-                        <span
-                          style={{
-                            fontSize: style.fontSize,
-                            lineHeight: `${style.lineHeight}px`,
-                            fontWeight: style.weight,
-                          }}>
-                          Aa
-                        </span>
-                      </td>
-                    </tr>
+                  {/* Display */}
+                  <tr>
+                    <td colSpan={5} {...stylex.props(s.roleSectionLabel)}>
+                      Display
+                    </td>
+                  </tr>
+                  {displays.map(t => (
+                    <TypeRow key={t.name} style={t} />
                   ))}
-                </tbody>
-              </table>
 
-              <XDSHeading level={3}>Body &amp; Supporting</XDSHeading>
-              <table {...stylex.props(styles.table)}>
-                <thead>
+                  {/* Headings */}
                   <tr>
-                    <th {...stylex.props(styles.th)}>Style</th>
-                    <th {...stylex.props(styles.th)}>Size</th>
-                    <th {...stylex.props(styles.th)}>Line H</th>
-                    <th {...stylex.props(styles.th)}>Weight</th>
-                    <th {...stylex.props(styles.th)}>Preview</th>
+                    <td colSpan={5} {...stylex.props(s.roleSectionLabel)}>
+                      Headings
+                    </td>
                   </tr>
-                </thead>
-                <tbody>
-                  {bodyStyles.map(style => (
-                    <tr
-                      key={style.name}
-                      {...stylex.props(
-                        style.role === 'body'
-                          ? styles.roleBody
-                          : styles.roleSupporting,
-                      )}>
-                      <td {...stylex.props(styles.td)}>{style.name}</td>
-                      <td {...stylex.props(styles.td, styles.tdMono)}>
-                        {style.fontSize}px
-                      </td>
-                      <td {...stylex.props(styles.td, styles.tdMono)}>
-                        {style.lineHeight}px
-                      </td>
-                      <td {...stylex.props(styles.td, styles.tdMono)}>
-                        {style.weight}
-                      </td>
-                      <td {...stylex.props(styles.td)}>
-                        <span
-                          style={{
-                            fontSize: style.fontSize,
-                            lineHeight: `${style.lineHeight}px`,
-                            fontWeight: style.weight,
-                          }}>
-                          The quick brown fox
-                        </span>
-                      </td>
-                    </tr>
+                  {headings.map(t => (
+                    <TypeRow key={t.name} style={t} />
+                  ))}
+
+                  {/* Body */}
+                  <tr>
+                    <td colSpan={5} {...stylex.props(s.roleSectionLabel)}>
+                      Body
+                    </td>
+                  </tr>
+                  {bodyStyles.map(t => (
+                    <TypeRow key={t.name} style={t} />
+                  ))}
+
+                  {/* Supporting */}
+                  <tr>
+                    <td colSpan={5} {...stylex.props(s.roleSectionLabel)}>
+                      Supporting
+                    </td>
+                  </tr>
+                  {supportingStyles.map(t => (
+                    <TypeRow key={t.name} style={t} />
                   ))}
                 </tbody>
               </table>
@@ -596,34 +689,47 @@ export default function TypeScaleExplorerPage() {
             {/* Live Preview */}
             <XDSVStack gap={4}>
               <XDSHeading level={3}>Live Preview</XDSHeading>
-              <div {...stylex.props(styles.preview)}>
-                <XDSVStack gap={4}>
-                  {headings.map(style => (
+              <div {...stylex.props(s.preview)}>
+                <XDSVStack gap={3}>
+                  {displays.map(t => (
                     <p
-                      key={style.name}
+                      key={t.name}
                       style={{
-                        fontSize: style.fontSize,
-                        lineHeight: `${style.lineHeight}px`,
-                        fontWeight: style.weight,
+                        fontSize: t.fontSize,
+                        lineHeight: `${t.lineHeight}px`,
+                        fontWeight: t.weight,
                         margin: 0,
                       }}
-                      {...stylex.props(styles.sampleText)}>
-                      {style.name}: A wizard&apos;s job is to vex chumps quickly
-                      in fog
+                      {...stylex.props(s.sampleText)}>
+                      {t.name}
                     </p>
                   ))}
                   <XDSDivider />
-                  {bodyStyles.slice(0, 3).map(style => (
+                  {headings.map(t => (
                     <p
-                      key={style.name}
+                      key={t.name}
                       style={{
-                        fontSize: style.fontSize,
-                        lineHeight: `${style.lineHeight}px`,
-                        fontWeight: style.weight,
+                        fontSize: t.fontSize,
+                        lineHeight: `${t.lineHeight}px`,
+                        fontWeight: t.weight,
                         margin: 0,
                       }}
-                      {...stylex.props(styles.sampleText)}>
-                      {style.name}: The quick brown fox jumps over the lazy dog.
+                      {...stylex.props(s.sampleText)}>
+                      {t.name}: A wizard&apos;s job is to vex chumps
+                    </p>
+                  ))}
+                  <XDSDivider />
+                  {[...bodyStyles, ...supportingStyles].map(t => (
+                    <p
+                      key={t.name}
+                      style={{
+                        fontSize: t.fontSize,
+                        lineHeight: `${t.lineHeight}px`,
+                        fontWeight: t.weight,
+                        margin: 0,
+                      }}
+                      {...stylex.props(s.sampleText)}>
+                      {t.name}: The quick brown fox jumps over the lazy dog.
                       Pack my box with five dozen liquor jugs.
                     </p>
                   ))}
@@ -633,19 +739,159 @@ export default function TypeScaleExplorerPage() {
           </div>
         )}
 
+        {/* ================================================================= */}
+        {/* RAW CALCULATIONS TAB                                               */}
+        {/* ================================================================= */}
+        {activeTab === 'calculations' && (
+          <XDSVStack gap={6}>
+            {/* Formula */}
+            <div {...stylex.props(s.rawFormula)}>
+              <strong>Formula:</strong> fontSize = base × ratio
+              <sup>exponent</sup>
+              <br />
+              base = {config.base}px &nbsp;|&nbsp; ratio = {config.ratio}
+              &nbsp;|&nbsp; grid = {config.lineHeightGrid}px
+            </div>
+
+            <div {...stylex.props(s.twoColumn)}>
+              {/* Raw scale */}
+              <XDSVStack gap={3}>
+                <XDSHeading level={3}>Raw Scale</XDSHeading>
+                <XDSText type="supporting" color="secondary">
+                  Pure mathematical output before any role mapping or collision
+                  handling.
+                </XDSText>
+                <table {...stylex.props(s.table)}>
+                  <thead>
+                    <tr>
+                      <th {...stylex.props(s.th)}>Exp</th>
+                      <th {...stylex.props(s.th)}>Formula</th>
+                      <th {...stylex.props(s.th, s.thRight)}>Raw</th>
+                      <th {...stylex.props(s.th, s.thRight)}>Rounded</th>
+                      <th {...stylex.props(s.th)}>Scale</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {rawScale.map(step => {
+                      const isBase = step.exponent === 0;
+                      return (
+                        <tr
+                          key={step.exponent}
+                          {...stylex.props(isBase && s.rawHighlight)}>
+                          <td {...stylex.props(s.td, s.tdMono)}>
+                            {step.exponent >= 0 ? '+' : ''}
+                            {step.exponent}
+                          </td>
+                          <td {...stylex.props(s.td, s.tdMono)}>
+                            {step.formula}
+                          </td>
+                          <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                            {step.rawSize.toFixed(2)}px
+                          </td>
+                          <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                            {step.roundedSize}px
+                            {isBase && ' ●'}
+                          </td>
+                          <td {...stylex.props(s.td)}>
+                            <div {...stylex.props(s.rawBarContainer)}>
+                              <div
+                                {...stylex.props(s.rawBar)}
+                                style={{
+                                  width: `${(step.roundedSize / maxRawSize) * 100}%`,
+                                }}
+                              />
+                            </div>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </XDSVStack>
+
+              {/* Role mapping */}
+              <XDSVStack gap={3}>
+                <XDSHeading level={3}>Role Mapping</XDSHeading>
+                <XDSText type="supporting" color="secondary">
+                  How raw scale steps map to semantic roles, with collision
+                  handling applied.
+                </XDSText>
+                <table {...stylex.props(s.table)}>
+                  <thead>
+                    <tr>
+                      <th {...stylex.props(s.th)}>Role</th>
+                      <th {...stylex.props(s.th)}>Exp</th>
+                      <th {...stylex.props(s.th, s.thRight)}>Raw</th>
+                      <th {...stylex.props(s.th, s.thRight)}>Final</th>
+                      <th {...stylex.props(s.th, s.thRight)}>LH</th>
+                      <th {...stylex.props(s.th)}>Wt</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {typeStyles.map(t => (
+                      <tr key={t.name} {...stylex.props(roleStyle(t.role))}>
+                        <td {...stylex.props(s.td)}>
+                          {t.name}
+                          {t.wasNudged && (
+                            <span {...stylex.props(s.nudgedBadge)}>nudged</span>
+                          )}
+                        </td>
+                        <td {...stylex.props(s.td, s.tdMono)}>
+                          {t.exponent >= 0 ? '+' : ''}
+                          {t.exponent}
+                        </td>
+                        <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                          {t.rawSize.toFixed(1)}
+                        </td>
+                        <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                          {t.fontSize}px
+                        </td>
+                        <td {...stylex.props(s.td, s.tdMono, s.tdRight)}>
+                          {t.lineHeight}px
+                        </td>
+                        <td {...stylex.props(s.td, s.tdMono)}>{t.weight}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </XDSVStack>
+            </div>
+
+            {/* Line height explanation */}
+            <div {...stylex.props(s.rawFormula)}>
+              <strong>Line Height Algorithm:</strong>
+              <br />
+              {'Display: target ≈ 1.1–1.15× → snap to '}
+              {config.lineHeightGrid}px grid
+              <br />
+              {'Heading: target ≈ 1.2–1.3× → snap to '}
+              {config.lineHeightGrid}px grid
+              <br />
+              {'Body/Supporting: target ≈ 1.4–1.5× → snap to '}
+              {config.lineHeightGrid}px grid
+              <br />
+              Minimum: ceil((fontSize + 2) / {config.lineHeightGrid}) ×{' '}
+              {config.lineHeightGrid}
+            </div>
+          </XDSVStack>
+        )}
+
+        {/* ================================================================= */}
+        {/* LANDING PAGE TAB                                                   */}
+        {/* ================================================================= */}
         {activeTab === 'landing' && (
-          <div {...stylex.props(styles.landingPreview)}>
+          <div {...stylex.props(s.landingPreview)}>
             {/* Nav */}
-            <nav {...stylex.props(styles.landingNav)}>
+            <nav {...stylex.props(s.landingNav)}>
               <span
                 style={{
                   fontSize: getStyle('body').fontSize,
                   fontWeight: 700,
                 }}
-                {...stylex.props(styles.landingLogo)}>
+                {...stylex.props(s.landingLogo)}>
                 Acme Inc
               </span>
-              <div {...stylex.props(styles.landingNavLinks)}>
+              <div {...stylex.props(s.landingNavLinks)}>
                 {['Features', 'Pricing', 'About', 'Contact'].map(link => (
                   <span
                     key={link}
@@ -653,7 +899,7 @@ export default function TypeScaleExplorerPage() {
                       fontSize: getStyle('body-sm').fontSize,
                       fontWeight: getStyle('body-sm').weight,
                     }}
-                    {...stylex.props(styles.landingNavLink)}>
+                    {...stylex.props(s.landingNavLink)}>
                     {link}
                   </span>
                 ))}
@@ -661,14 +907,25 @@ export default function TypeScaleExplorerPage() {
             </nav>
 
             {/* Hero */}
-            <div {...stylex.props(styles.landingHero)}>
+            <div {...stylex.props(s.landingHero)}>
+              <p
+                style={{
+                  fontSize: getStyle('supporting').fontSize,
+                  fontWeight: 500,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  margin: '0 0 12px 0',
+                  color: 'light-dark(#0064E0, #2694FE)',
+                }}>
+                Introducing Acme Platform
+              </p>
               <h1
                 style={{
-                  fontSize: getStyle('h1').fontSize,
-                  lineHeight: `${getStyle('h1').lineHeight}px`,
-                  fontWeight: getStyle('h1').weight,
+                  fontSize: getStyle('display-2').fontSize,
+                  lineHeight: `${getStyle('display-2').lineHeight}px`,
+                  fontWeight: getStyle('display-2').weight,
                 }}
-                {...stylex.props(styles.landingHeroTitle)}>
+                {...stylex.props(s.landingHeroTitle)}>
                 Your digital transformation begins here
               </h1>
               <p
@@ -677,11 +934,11 @@ export default function TypeScaleExplorerPage() {
                   lineHeight: `${getStyle('body-lg').lineHeight}px`,
                   fontWeight: getStyle('body-lg').weight,
                 }}
-                {...stylex.props(styles.landingHeroSubtitle)}>
+                {...stylex.props(s.landingHeroSubtitle)}>
                 Unlock the full potential of your business. Start your journey
-                today and experience the future of business software.
+                today and experience the future of enterprise software.
               </p>
-              <div {...stylex.props(styles.landingHeroButtons)}>
+              <div {...stylex.props(s.landingHeroButtons)}>
                 <XDSButton label="Explore features" variant="secondary" />
                 <XDSButton label="Get started" variant="primary" />
               </div>
@@ -693,19 +950,31 @@ export default function TypeScaleExplorerPage() {
                   marginTop: 16,
                   color: 'light-dark(#999, #666)',
                 }}>
-                No credit card required
+                No credit card required · Free 14-day trial
               </p>
             </div>
 
             {/* Features */}
-            <div {...stylex.props(styles.landingFeatures)}>
+            <div {...stylex.props(s.landingFeatures)}>
+              <p
+                style={{
+                  fontSize: getStyle('label').fontSize,
+                  fontWeight: 600,
+                  letterSpacing: '0.05em',
+                  textTransform: 'uppercase',
+                  textAlign: 'center',
+                  margin: '0 0 8px 0',
+                  color: 'light-dark(#0064E0, #2694FE)',
+                }}>
+                Features
+              </p>
               <h2
                 style={{
                   fontSize: getStyle('h2').fontSize,
                   lineHeight: `${getStyle('h2').lineHeight}px`,
                   fontWeight: getStyle('h2').weight,
                 }}
-                {...stylex.props(styles.landingFeaturesTitle)}>
+                {...stylex.props(s.landingFeaturesTitle)}>
                 SaaS solutions that drive results
               </h2>
               <p
@@ -714,35 +983,36 @@ export default function TypeScaleExplorerPage() {
                   lineHeight: `${getStyle('body').lineHeight}px`,
                   fontWeight: getStyle('body').weight,
                 }}
-                {...stylex.props(styles.landingFeaturesSubtitle)}>
-                Explore our suite of powerful software solutions.
+                {...stylex.props(s.landingFeaturesSubtitle)}>
+                Explore our suite of powerful software solutions designed to
+                streamline your operations.
               </p>
 
-              <div {...stylex.props(styles.landingFeatureGrid)}>
+              <div {...stylex.props(s.landingFeatureGrid)}>
                 {[
                   {
-                    title: 'Enterprise planning',
-                    desc: 'Seamlessly manage and integrate all core business processes.',
+                    title: 'Enterprise Planning',
+                    desc: 'Seamlessly manage and integrate all core business processes with our unified platform.',
                   },
                   {
-                    title: 'Project management',
-                    desc: 'Ensure project success by efficiently planning and tracking.',
+                    title: 'Project Management',
+                    desc: 'Ensure project success by efficiently planning, tracking, and delivering on time.',
                   },
                   {
-                    title: 'Analytics dashboard',
-                    desc: 'Leverage data-driven insights to make informed decisions.',
+                    title: 'Analytics Dashboard',
+                    desc: 'Leverage data-driven insights to make informed decisions and measure impact.',
                   },
                 ].map(feature => (
                   <div
                     key={feature.title}
-                    {...stylex.props(styles.landingFeatureCard)}>
+                    {...stylex.props(s.landingFeatureCard)}>
                     <h3
                       style={{
                         fontSize: getStyle('h4').fontSize,
                         lineHeight: `${getStyle('h4').lineHeight}px`,
                         fontWeight: getStyle('h4').weight,
                       }}
-                      {...stylex.props(styles.landingFeatureTitle)}>
+                      {...stylex.props(s.landingFeatureTitle)}>
                       {feature.title}
                     </h3>
                     <p
@@ -751,7 +1021,7 @@ export default function TypeScaleExplorerPage() {
                         lineHeight: `${getStyle('body-sm').lineHeight}px`,
                         fontWeight: getStyle('body-sm').weight,
                       }}
-                      {...stylex.props(styles.landingFeatureDesc)}>
+                      {...stylex.props(s.landingFeatureDesc)}>
                       {feature.desc}
                     </p>
                   </div>
@@ -761,6 +1031,9 @@ export default function TypeScaleExplorerPage() {
           </div>
         )}
 
+        {/* ================================================================= */}
+        {/* PRESET COMPARISON TAB                                              */}
+        {/* ================================================================= */}
         {activeTab === 'comparison' && (
           <XDSVStack gap={4}>
             <XDSText type="supporting" color="secondary">
@@ -771,9 +1044,13 @@ export default function TypeScaleExplorerPage() {
             <XDSHStack gap={4}>
               {Object.entries(PRESETS).map(([name, preset]) => {
                 const presetStyles = generateTypeStyles(preset);
-                const presetHeadings = presetStyles.filter(
-                  s => s.role === 'heading',
+                const pDisplays = presetStyles.filter(
+                  t => t.role === 'display',
                 );
+                const pHeadings = presetStyles.filter(
+                  t => t.role === 'heading',
+                );
+                const pBody = presetStyles.filter(t => t.name === 'body');
                 return (
                   <div key={name} style={{flex: 1}}>
                     <XDSVStack gap={2}>
@@ -783,19 +1060,46 @@ export default function TypeScaleExplorerPage() {
                       <XDSText type="supporting" color="secondary">
                         {preset.base}px base, {preset.ratio} ratio
                       </XDSText>
-                      <div {...stylex.props(styles.preview)}>
+                      <div {...stylex.props(s.preview)}>
                         <XDSVStack gap={2}>
-                          {presetHeadings.slice(0, 4).map(style => (
+                          {pDisplays.slice(1, 3).map(t => (
                             <p
-                              key={style.name}
+                              key={t.name}
                               style={{
-                                fontSize: style.fontSize,
-                                lineHeight: `${style.lineHeight}px`,
-                                fontWeight: style.weight,
+                                fontSize: t.fontSize,
+                                lineHeight: `${t.lineHeight}px`,
+                                fontWeight: t.weight,
                                 margin: 0,
                               }}
-                              {...stylex.props(styles.sampleText)}>
-                              {style.name}: {style.fontSize}px
+                              {...stylex.props(s.sampleText)}>
+                              {t.name}: {t.fontSize}px
+                            </p>
+                          ))}
+                          {pHeadings.slice(0, 4).map(t => (
+                            <p
+                              key={t.name}
+                              style={{
+                                fontSize: t.fontSize,
+                                lineHeight: `${t.lineHeight}px`,
+                                fontWeight: t.weight,
+                                margin: 0,
+                              }}
+                              {...stylex.props(s.sampleText)}>
+                              {t.name}: {t.fontSize}px
+                            </p>
+                          ))}
+                          {pBody.map(t => (
+                            <p
+                              key={t.name}
+                              style={{
+                                fontSize: t.fontSize,
+                                lineHeight: `${t.lineHeight}px`,
+                                fontWeight: t.weight,
+                                margin: 0,
+                                marginTop: 8,
+                              }}
+                              {...stylex.props(s.sampleText)}>
+                              Body text at {t.fontSize}px
                             </p>
                           ))}
                         </XDSVStack>
@@ -809,5 +1113,37 @@ export default function TypeScaleExplorerPage() {
         )}
       </XDSVStack>
     </div>
+  );
+}
+
+// =============================================================================
+// TypeRow Component
+// =============================================================================
+
+function TypeRow({style: t}: {style: TypeStyle}) {
+  return (
+    <tr {...stylex.props(roleStyle(t.role))}>
+      <td {...stylex.props(s.td)}>
+        {t.name}
+        {t.wasNudged && <span {...stylex.props(s.nudgedBadge)}>nudged</span>}
+      </td>
+      <td {...stylex.props(s.td, s.tdMono)}>{t.fontSize}px</td>
+      <td {...stylex.props(s.td, s.tdMono)}>{t.lineHeight}px</td>
+      <td {...stylex.props(s.td, s.tdMono)}>{t.weight}</td>
+      <td {...stylex.props(s.td)}>
+        <span
+          style={{
+            fontSize: t.fontSize,
+            lineHeight: `${t.lineHeight}px`,
+            fontWeight: t.weight,
+          }}>
+          {t.role === 'display'
+            ? 'Aa'
+            : t.role === 'heading'
+              ? 'Aa'
+              : 'The quick brown fox'}
+        </span>
+      </td>
+    </tr>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4778,12 +4778,7 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.7.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
-
-prettier@^3.4.0:
+prettier@^2.7.1, prettier@^3.4.0:
   version "3.7.4"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.7.4.tgz#d2f8335d4b1cec47e1c8098645411b0c9dff9c0f"
   integrity sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==


### PR DESCRIPTION
## Motivation

XDS currently maintains two parallel type scale systems — **default** (dense, for internal tools) and **editorial** (larger, for content-heavy pages). This creates confusion:

- "When do I use editorial vs regular?"
- "Do I need to support both in my component?"
- "What if I want something *in between*?"

Products have varying density needs, but today they must choose between two fixed scales or manually override individual tokens.

## Proposal

Replace explicit font size tokens with a **ratio-based type scale** inspired by [typescale.com](https://typescale.com/). Instead of defining 10+ individual size tokens, a theme defines just two values:

```typescript
typeScale: {
  base: 14,        // Base font size in px
  ratio: 1.125,    // Major Second scale
}
```

The system generates all sizes mathematically (`base × ratio^n`) and snaps line heights to a **4px grid** for vertical rhythm.

### Theme Presets

| Preset | Base | Ratio | Character |
|--------|------|-------|-----------|
| Functional | 12px | 1.125 (Major Second) | VS Code, Photoshop, Figma — maximum information density |
| Default | 14px | 1.125 (Major Second) | Balanced — matches current XDS base |
| Editorial | 16px | 1.25 (Major Third) | Spacious, content-focused |

Same semantic tokens (`--text-md`, `--text-lg`), different computed output. **One system instead of two.**

The spectrum — **Functional → Default → Editorial** — maps naturally to how products think about their UI density. Functional makes things. Editorial tells stories.

## Trade-offs

### ✅ Advantages
- **Eliminates editorial vs default confusion** — one scale, themed by product
- **Simpler theming** — 2 values instead of 10+ individual tokens
- **Mathematical harmony** — sizes feel inherently related
- **Density spectrum** — products can land anywhere between functional and editorial
- **Responsive scaling** — change base at breakpoints, everything adjusts

### ⚠️ Concerns
- **Fractional pixels** — `ratio^n` rarely lands on whole pixels, requires rounding
- **Loss of fine control** — can't specify "exactly 14px" without breaking the system
- **Ratio × grid tension** — ratios are multiplicative, grids are additive; they don't naturally align
- **Semantic drift** — `--text-sm` means different px values in different themes (intentional but requires mental model shift)

## Decisions

| Question | Decision |
|----------|----------|
| **Collision handling** | Enforce **1px minimum step** between adjacent sizes |
| **Token naming** | Keep **semantic names** (`--text-xs`, `--text-sm`, etc.) — consistent with current XDS |
| **Build vs runtime** | Generate at **build time** — static CSS, no runtime calc() overhead |

## What's Included

### Exploration Document
`.context/explorations/ratio-based-type-scale.md` — full analysis including:
- Computed examples for all three presets
- Line height snapping algorithm
- 1px minimum step collision enforcement
- Decisions and remaining open questions

### Interactive Prototype
Sandbox page at `/pages/type-scale-explorer/` with:
- Adjustable base size (10–24px slider)
- Scale ratio selector (Minor Second through Golden Ratio)
- Line height grid selector (2px, 4px, 8px)
- Functional / Default / Editorial preset buttons
- Computed scale table with collision warnings
- 1px minimum step enforcement between adjacent sizes
- Live typography preview
- Side-by-side preset comparison

## Open Questions

1. **Escape hatch** — How do products specify exact sizes when the ratio doesn't produce what they need?
2. **Migration path** — How do existing consumers migrate from explicit tokens to ratio-based?

## Screenshots

*Run the sandbox app and navigate to Type Scale Explorer to see the interactive prototype.*