### PR TITLE
fix(vibe-tests): disable lightningcss in report build — fixes missing styles

### DIFF
--- a/internal/vibe-tests/app/vite.config.report.ts
+++ b/internal/vibe-tests/app/vite.config.report.ts
@@ -39,32 +39,50 @@ export default defineConfig({
     rollupOptions: {
       input: path.resolve(__dirname, 'index.report.html'),
     },
-    cssMinify: 'lightningcss',
-  },
-  css: {
-    lightningcss: {
-      targets: lightningcssTargets,
-    },
+    // Don't use lightningcss for minification — it lowers light-dark()
+    // into --lightningcss-light/--lightningcss-dark polyfill variables
+    // which breaks theming. The pre-compiled CSS is already minified.
+    cssMinify: false,
   },
   resolve: {
-    alias: {
+    alias: [
       // Pre-compiled CSS — no StyleX build needed
-      'xds-css': path.resolve(repoRoot, 'packages/core/dist/xds.css'),
-      'xds-theme-css': path.resolve(
-        repoRoot,
-        'packages/themes/default/dist/theme.css',
-      ),
+      {
+        find: 'xds-css',
+        replacement: path.resolve(repoRoot, 'packages/core/dist/xds.css'),
+      },
+      {
+        find: 'xds-theme-css',
+        replacement: path.resolve(
+          repoRoot,
+          'packages/themes/default/dist/theme.css',
+        ),
+      },
+      // Core CSS files live in src/
+      {
+        find: /^@xds\/core\/(.+\.css)$/,
+        replacement: path.resolve(repoRoot, 'packages/core/src/$1'),
+      },
+      // Core subpath imports → dist (bypasses "source" condition in exports map)
+      {
+        find: /^@xds\/core\/(.+)$/,
+        replacement: path.resolve(repoRoot, 'packages/core/dist/$1/index.mjs'),
+      },
+      // Core root import
+      {
+        find: '@xds/core',
+        replacement: path.resolve(repoRoot, 'packages/core/dist/index.mjs'),
+      },
       // Theme: resolve to source (no StyleX usage, just defineTheme + icons).
-      // The dist is incomplete (missing icons.js), so source is needed.
-      '@xds/theme-default': path.resolve(
-        repoRoot,
-        'packages/themes/default/src',
-      ),
-      '@xds/theme/default': path.resolve(
-        repoRoot,
-        'packages/themes/default/src',
-      ),
-    },
+      {
+        find: '@xds/theme-default',
+        replacement: path.resolve(repoRoot, 'packages/themes/default/src'),
+      },
+      {
+        find: '@xds/theme/default',
+        replacement: path.resolve(repoRoot, 'packages/themes/default/src'),
+      },
+    ],
   },
   server: {port: 5174, strictPort: true},
 });


### PR DESCRIPTION
## Problem

Vibe test reports have no visible styles. All theme colors are invisible.

## Root Cause

LightningCSS (used as `cssMinify`) was lowering native `light-dark()` into polyfill variables (`--lightningcss-light`/`--lightningcss-dark`). These polyfill variables are never initialized in the report HTML, so all token values resolve to empty — making everything invisible.

The `lightningcssTargets` config was supposed to prevent this, but lightningcss still lowered `light-dark()` during CSS transformation.

## Fix

Disable CSS minification in the report build (`cssMinify: false`). The pre-compiled CSS from `@xds/core/dist/xds.css` is already production-ready.

Also cleans up the resolve aliases to use regex-based matching for `@xds/core` subpath imports.

## Verification

Before: `--color-wash:var(--lightningcss-light,#f1f4f7)var(--lightningcss-dark,#111112)`
After: `--color-wash:light-dark(#F1F4F7, #111112)`