### PR TITLE
feat(cli): support external library component discovery

### DIFF
--- a/packages/cli/src/commands/component.mjs
+++ b/packages/cli/src/commands/component.mjs
@@ -11,7 +11,8 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {findCoreDir} from '../utils/paths.mjs';
+import {pathToFileURL} from 'node:url';
+import {findCoreDir, discoverExternalPackages} from '../utils/paths.mjs';
 
 /**
  * Map top-level src/ directories to display categories.
@@ -121,6 +122,33 @@ export function discoverComponents(coreDir) {
   }
 
   return ordered;
+}
+
+/**
+ * Discover components from an external package's docs directory.
+ * Scans for *.doc.mjs files and extracts component names.
+ */
+export function discoverExternalComponents(docsDir) {
+  if (!fs.existsSync(docsDir)) return [];
+
+  const components = [];
+
+  function scanDir(dirPath) {
+    if (!fs.existsSync(dirPath)) return;
+    const entries = fs.readdirSync(dirPath, {withFileTypes: true});
+    for (const entry of entries) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      if (entry.isDirectory()) {
+        scanDir(path.join(dirPath, entry.name));
+      } else if (entry.name.endsWith('.doc.mjs')) {
+        const name = entry.name.replace('.doc.mjs', '');
+        components.push(name);
+      }
+    }
+  }
+
+  scanDir(docsDir);
+  return components.sort();
 }
 
 /**

--- a/packages/cli/src/utils/paths.mjs
+++ b/packages/cli/src/utils/paths.mjs
@@ -86,3 +86,75 @@ export function listComponents(coreDir) {
     .map(e => e.name)
     .sort();
 }
+
+/**
+ * Discover external XDS-compatible packages from node_modules.
+ * Scans for packages with an "xds" field in their package.json.
+ *
+ * Returns array of:
+ *   { name: "@acme/charts", category: "Data Viz", docsDir: "/abs/path/to/src" }
+ */
+export function discoverExternalPackages(startDir = process.cwd()) {
+  const externals = [];
+  let dir = startDir;
+
+  // Find node_modules
+  let nodeModulesDir = null;
+  for (let i = 0; i < 5; i++) {
+    const candidate = path.join(dir, 'node_modules');
+    if (fs.existsSync(candidate)) {
+      nodeModulesDir = candidate;
+      break;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+
+  if (!nodeModulesDir) return externals;
+
+  // Scan scoped packages (@org/pkg) and top-level packages
+  const scanDir = (searchDir, prefix = '') => {
+    if (!fs.existsSync(searchDir)) return;
+    const entries = fs.readdirSync(searchDir, {withFileTypes: true});
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+
+      // Skip hidden dirs and common non-package dirs
+      if (entry.name.startsWith('.') || entry.name === '.bin') continue;
+
+      const fullPath = path.join(searchDir, entry.name);
+
+      // Handle scoped packages (@org/*)
+      if (entry.name.startsWith('@')) {
+        scanDir(fullPath, entry.name + '/');
+        continue;
+      }
+
+      // Check for xds field in package.json
+      const pkgJsonPath = path.join(fullPath, 'package.json');
+      if (!fs.existsSync(pkgJsonPath)) continue;
+
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'));
+
+        // Skip @xds/core itself
+        if (pkg.name === '@xds/core') continue;
+
+        if (pkg.xds && pkg.xds.docs) {
+          externals.push({
+            name: pkg.name,
+            category: pkg.xds.category || pkg.name,
+            docsDir: path.resolve(fullPath, pkg.xds.docs),
+          });
+        }
+      } catch {
+        // skip invalid JSON
+      }
+    }
+  };
+
+  scanDir(nodeModulesDir);
+  return externals;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -357,6 +357,12 @@
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.mjs",
       "require": "./dist/utils/index.js"
+    },
+    "./docs-types": {
+      "source": "./src/docs-types.ts",
+      "types": "./dist/docs-types.d.ts",
+      "import": "./dist/docs-types.mjs",
+      "require": "./dist/docs-types.js"
     }
   },
   "files": [


### PR DESCRIPTION
Libraries can now register their components with the XDS CLI by adding an `xds` field to their package.json:

```json
{
  "name": "@xds/charts",
  "xds": { "docs": "./src", "category": "Data Visualization" }
}
```

The CLI scans node_modules for packages with this field and includes their components in `xds component --list`. Components are discovered by scanning for \*.doc.mjs files in the specified docs directory.

Also exports ComponentDoc types from @xds/core so external packages can reference the doc schema:

```typescript
import type { ComponentDoc } from '@xds/core/docs-types';
```

---

This came out of a discussion with @czhang about a "marketplace" for specialized XDS libraries. See the GChat thread for context.

_sent via Joey's Navi_