### PR TITLE
fix(vibe-tests): disable lightningcss in preview builds

### DIFF
--- a/internal/vibe-tests/app/vite.config.preview.ts
+++ b/internal/vibe-tests/app/vite.config.preview.ts
@@ -31,6 +31,12 @@ const lightningcssTargets = {
  */
 export default defineConfig({
   root: __dirname,
+  build: {
+    // Don't use lightningcss for minification — it lowers light-dark()
+    // into --lightningcss-light/--lightningcss-dark polyfill variables
+    // which breaks theming. The StyleX plugin handles its own CSS.
+    cssMinify: false,
+  },
   plugins: [
     stylex.vite({
       dev: process.env.NODE_ENV === 'development',

--- a/internal/vibe-tests/app/vite.config.ts
+++ b/internal/vibe-tests/app/vite.config.ts
@@ -23,6 +23,12 @@ const lightningcssTargets = {
 };
 
 export default defineConfig({
+  build: {
+    // Don't use lightningcss for minification — it lowers light-dark()
+    // into --lightningcss-light/--lightningcss-dark polyfill variables
+    // which breaks theming. The StyleX plugin handles its own CSS.
+    cssMinify: false,
+  },
   plugins: [
     stylex.vite({
       dev: process.env.NODE_ENV === 'development',


### PR DESCRIPTION
Same fix as the report build (PR #558) — lightningcss mangles `light-dark()` into polyfill variables that never get set, causing XDS styles to be invisible in previews.

## Problem

The preview Vite configs (`vite.config.ts` and `vite.config.preview.ts`) have `lightningcssTargets` set in the StyleX plugin options, but Vite's default CSS minifier still runs lightningcss during the build phase. This mangles `light-dark(#F1F4F7, #111112)` into `var(--lightningcss-light,#f1f4f7)var(--lightningcss-dark,#111112)` — polyfill variables that never get initialized, so every color is empty.

## Fix

Add `cssMinify: false` to the build config in both preview configs. The StyleX plugin already handles CSS extraction with proper targets — we just need to prevent Vite from running lightningcss again during the final build step.

## Files changed

- `internal/vibe-tests/app/vite.config.ts` — main preview config
- `internal/vibe-tests/app/vite.config.preview.ts` — XDS + Tailwind preview config

Fixes the nightly vibe test preview styling issue.