### PR TITLE
feat(AppShell): add variant prop for nav/content background styles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,21 @@ Look for `<!-- SYNC: ... -->` comments and `SYNC:` in file headers as reminders.
 
 - **`@example` code fences must use plain ` ``` `, not ` ```tsx `.**
   Storybook's autodocs parser doesn't handle language-tagged fences in JSDoc correctly — the code block won't render as a proper code block. Always use untagged fences in `@example` blocks.
+
+<!-- XDS:START -->
+
+[XDS v0.0.3]|IMPORTANT: Prefer retrieval-led reasoning. Run CLI to read docs before generating code.
+|npx xds component <Name> --compact|--source Docs (props, usage) or source code
+|npx xds component --list All components by category
+|npx xds docs principles Design rules, anti-patterns, StyleX patterns
+|npx xds docs tokens Token reference (spacing, color, radius, type)
+|npx xds docs theme Theme system: XDSTheme, custom themes, overrides, nesting
+|npx xds template <name> [path] Scaffold page (blank, table, login)
+|npx xds swizzle <Name> --gap "<reason>" Copy component source for customization + file gap report
+|npx xds gap-report --component <Name> --category <cat> --reason "<why>" File gap without swizzle
+|npx xds upgrade Preview API migrations for your version
+|npx xds upgrade --apply Apply codemods to update breaking API changes
+|RULE: After bumping @xds/core version, ALWAYS run npx xds upgrade --apply to migrate breaking API changes.
+|RULE: When swizzling to unblock yourself, ALWAYS use --gap to explain what capability was missing.
+
+<!-- XDS:END -->

--- a/apps/sandbox/babel.config.js
+++ b/apps/sandbox/babel.config.js
@@ -1,29 +1,9 @@
-/* global module, process, __dirname */
-const path = require('path');
+/* global module */
 
-const rootDir = path.resolve(__dirname, '../..');
-
+/**
+ * Sandbox uses pre-compiled dist — no StyleX plugin needed.
+ * Component styles come from @xds/core/dist/xds.css.
+ */
 module.exports = {
   presets: ['next/babel'],
-  plugins: [
-    [
-      '@stylexjs/babel-plugin',
-      {
-        dev: process.env.NODE_ENV === 'development',
-        runtimeInjection: false,
-        genConditionalClasses: true,
-        treeshakeCompensation: true,
-        aliases: {
-          '@xds/core/*': [path.join(rootDir, 'packages/core/src/*')],
-          '@xds/core': [path.join(rootDir, 'packages/core/src')],
-          '@xds/theme-default/*': [path.join(rootDir, 'packages/themes/default/src/*')],
-          '@xds/theme-neutral/*': [path.join(rootDir, 'packages/themes/neutral/src/*')],
-        },
-        unstable_moduleResolution: {
-          type: 'commonJS',
-          rootDir,
-        },
-      },
-    ],
-  ],
 };

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -1,8 +1,3 @@
-import path from 'path';
-import {fileURLToPath} from 'url';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
@@ -13,19 +8,7 @@ const nextConfig = {
     unoptimized: true,
   },
   typescript: {
-    // Type errors are caught by the sandbox typecheck script.
-    // Next.js build skips tsc to avoid duplicate checking.
     ignoreBuildErrors: false,
-  },
-  webpack: (config) => {
-    config.resolve.alias = {
-      ...config.resolve.alias,
-      '@xds/core/theme/tokens.stylex': path.resolve(
-        __dirname,
-        '../../packages/core/src/theme/tokens.stylex.ts',
-      ),
-    };
-    return config;
   },
 };
 

--- a/apps/sandbox/src/app/Sidebar.tsx
+++ b/apps/sandbox/src/app/Sidebar.tsx
@@ -18,6 +18,7 @@ import {usePathname} from 'next/navigation';
  */
 const pages = [
   {name: 'Home', href: '/'},
+  {name: '🔬 Shell Lab', href: '/pages/shell-lab/'},
   {name: 'Example', href: '/pages/example/'},
   {name: 'Navigation', href: '/pages/navigation/'},
   {name: 'TopNav Menu', href: '/pages/topnav-menu/'},

--- a/apps/sandbox/src/app/Sidebar.tsx
+++ b/apps/sandbox/src/app/Sidebar.tsx
@@ -1,21 +1,8 @@
 'use client';
 
-import * as stylex from '@stylexjs/stylex';
 import Link from 'next/link';
 import {usePathname} from 'next/navigation';
 
-/**
- * Sidebar navigation for the sandbox.
- *
- * To add a new page:
- * 1. Create `src/app/pages/<name>/page.tsx`
- * 2. Add an entry to the `pages` array below
- *
- * Note: hrefs use trailing slashes because the sandbox is a static export
- * with `trailingSlash: true` in next.config.mjs. Each route becomes a
- * directory with an `index.html` file (e.g. `/pages/example/index.html`).
- * Next.js `<Link>` handles the basePath prefix automatically.
- */
 const pages = [
   {name: 'Home', href: '/'},
   {name: '🔬 Shell Lab', href: '/pages/shell-lab/'},
@@ -27,45 +14,31 @@ const pages = [
   {name: 'Table Overview', href: '/pages/table-overview/'},
 ];
 
-const styles = stylex.create({
-  sidebar: {
-    width: 220,
-    borderRight: '1px solid #e0e0e0',
-    padding: '1.5rem 1rem',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: '0.25rem',
-  },
-  title: {
-    fontSize: '0.75rem',
-    fontWeight: 700,
-    textTransform: 'uppercase',
-    letterSpacing: '0.05em',
-    color: '#666',
-    marginBottom: '0.75rem',
-    padding: '0 0.5rem',
-  },
-  link: {
-    display: 'block',
-    padding: '0.5rem 0.75rem',
-    borderRadius: 6,
-    textDecoration: 'none',
-    fontSize: '0.875rem',
-    color: '#333',
-    transition: 'background 0.15s',
-  },
-  linkActive: {
-    backgroundColor: '#f0f0f0',
-    fontWeight: 600,
-  },
-});
-
 export function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <nav {...stylex.props(styles.sidebar)}>
-      <div {...stylex.props(styles.title)}>Sandbox</div>
+    <nav
+      style={{
+        width: 220,
+        borderRight: '1px solid var(--color-divider, #e0e0e0)',
+        padding: '1.5rem 1rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.25rem',
+      }}>
+      <div
+        style={{
+          fontSize: '0.75rem',
+          fontWeight: 700,
+          textTransform: 'uppercase',
+          letterSpacing: '0.05em',
+          color: 'var(--color-text-secondary, #666)',
+          marginBottom: '0.75rem',
+          padding: '0 0.5rem',
+        }}>
+        Sandbox
+      </div>
       {pages.map(page => {
         const isActive =
           pathname === page.href ||
@@ -74,7 +47,18 @@ export function Sidebar() {
           <Link
             key={page.href}
             href={page.href}
-            {...stylex.props(styles.link, isActive && styles.linkActive)}>
+            style={{
+              display: 'block',
+              padding: '0.5rem 0.75rem',
+              borderRadius: 6,
+              textDecoration: 'none',
+              fontSize: '0.875rem',
+              color: 'var(--color-text-primary, #333)',
+              backgroundColor: isActive
+                ? 'var(--color-hover-overlay, #f0f0f0)'
+                : 'transparent',
+              fontWeight: isActive ? 600 : 400,
+            }}>
             {page.name}
           </Link>
         );

--- a/apps/sandbox/src/app/globals.css
+++ b/apps/sandbox/src/app/globals.css
@@ -1,1 +1,1 @@
-@stylex;
+/* Sandbox global styles */

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type {Metadata} from 'next';
 import '@xds/core/reset.css';
 import '@xds/core/typography.css';
-import './globals.css';
+import '@xds/core/xds.css';
+import '@xds/theme-default/theme.css';
 import {Providers} from './providers';
 import {Sidebar} from './Sidebar';
 
@@ -14,12 +15,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
   return (
     <html lang="en">
       <body>
-        <Providers>
-          <div style={{display: 'flex', minHeight: '100vh'}}>
-            <Sidebar />
-            <main style={{flex: 1, padding: '2rem'}}>{children}</main>
-          </div>
-        </Providers>
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/apps/sandbox/src/app/page.tsx
+++ b/apps/sandbox/src/app/page.tsx
@@ -1,31 +1,5 @@
-'use client';
-
-import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
-import {XDSText, XDSHeading} from '@xds/core/Text';
-
-const styles = stylex.create({
-  container: {
-    maxWidth: 640,
-  },
-});
+import {redirect} from 'next/navigation';
 
 export default function Home() {
-  return (
-    <div {...stylex.props(styles.container)}>
-      <XDSVStack gap={6}>
-        <XDSVStack gap={2}>
-          <XDSHeading level={1}>XDS Sandbox</XDSHeading>
-          <XDSText type="body" color="secondary">
-            A testing ground for XDS components. Use the sidebar to explore
-            example pages, or create new ones under{' '}
-            <XDSText type="body" weight="bold">
-              src/app/pages/
-            </XDSText>
-            .
-          </XDSText>
-        </XDSVStack>
-      </XDSVStack>
-    </div>
-  );
+  redirect('/pages/shell-lab/');
 }

--- a/apps/sandbox/src/app/pages/example/page.tsx
+++ b/apps/sandbox/src/app/pages/example/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
+
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText, XDSHeading} from '@xds/core/Text';
@@ -10,11 +10,11 @@ import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSDivider} from '@xds/core';
 
-const styles = stylex.create({
+const styles = {
   container: {
     maxWidth: 640,
   },
-});
+};
 
 /**
  * Example sandbox page.
@@ -30,7 +30,7 @@ export default function ExamplePage() {
   const [updates, setUpdates] = useState(false);
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div style={styles.container}>
       <XDSVStack gap={6}>
         <XDSVStack gap={2}>
           <XDSHeading level={1}>Example Page</XDSHeading>

--- a/apps/sandbox/src/app/pages/mega-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/mega-menu/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
+
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
@@ -13,7 +13,7 @@ import {
 } from '@xds/core/TopNav';
 import {XDSNavIcon} from '@xds/core/NavIcon';
 
-const styles = stylex.create({
+const styles = {
   container: {
     maxWidth: 960,
   },
@@ -37,7 +37,7 @@ const styles = stylex.create({
     boxShadow:
       '0 -1px 3px rgba(0, 0, 0, 0.06), -1px 0 3px rgba(0, 0, 0, 0.04), 1px 0 3px rgba(0, 0, 0, 0.04)',
   },
-});
+};
 
 // =============================================================================
 // Icons
@@ -234,7 +234,7 @@ export default function MegaMenuPage() {
   const isAnyOpen1 = menuOpen1 || menuOpen2;
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div style={styles.container}>
       <XDSVStack gap={6}>
         <XDSVStack gap={2}>
           <XDSHeading level={1}>Mega Menu</XDSHeading>
@@ -248,11 +248,7 @@ export default function MegaMenuPage() {
         {/* Full mega menu with featured content */}
         <XDSVStack gap={3}>
           <XDSHeading level={2}>With Featured Content</XDSHeading>
-          <div
-            {...stylex.props(
-              styles.navWrapper,
-              isAnyOpen1 && styles.navWrapperMenuOpen,
-            )}>
+          <div style={styles.navWrapper}>
             <XDSTopNav
               label="Marketing navigation"
               heading={
@@ -307,11 +303,7 @@ export default function MegaMenuPage() {
         {/* Without featured content */}
         <XDSVStack gap={3}>
           <XDSHeading level={2}>Without Featured Content</XDSHeading>
-          <div
-            {...stylex.props(
-              styles.navWrapper,
-              menuOpen3 && styles.navWrapperMenuOpen,
-            )}>
+          <div style={styles.navWrapper}>
             <XDSTopNav
               label="Simple navigation"
               heading={<XDSTopNavHeading heading="App" href="#" />}

--- a/apps/sandbox/src/app/pages/navigation/page.tsx
+++ b/apps/sandbox/src/app/pages/navigation/page.tsx
@@ -1,14 +1,14 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
+
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSDivider} from '@xds/core';
 import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
 
-const styles = stylex.create({
+const styles = {
   container: {
     maxWidth: 960,
   },
@@ -17,7 +17,7 @@ const styles = stylex.create({
     borderRadius: 8,
     overflow: 'hidden',
   },
-});
+};
 
 type Alignment = 'start' | 'center' | 'end';
 
@@ -31,7 +31,7 @@ export default function NavigationPage() {
   const [alignment, setAlignment] = useState<Alignment>('start');
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div style={styles.container}>
       <XDSVStack gap={6}>
         <XDSVStack gap={2}>
           <XDSHeading level={1}>Navigation Alignment</XDSHeading>
@@ -71,7 +71,7 @@ export default function NavigationPage() {
         {/* Live preview */}
         <XDSVStack gap={3}>
           <XDSHeading level={2}>Preview</XDSHeading>
-          <div {...stylex.props(styles.navWrapper)}>
+          <div style={styles.navWrapper}>
             <NavPreview alignment={alignment} />
           </div>
         </XDSVStack>
@@ -86,7 +86,7 @@ export default function NavigationPage() {
             <XDSText type="supporting" weight="bold">
               Left-aligned (startContent)
             </XDSText>
-            <div {...stylex.props(styles.navWrapper)}>
+            <div style={styles.navWrapper}>
               <NavPreview alignment="start" />
             </div>
           </XDSVStack>
@@ -95,7 +95,7 @@ export default function NavigationPage() {
             <XDSText type="supporting" weight="bold">
               Center-aligned (centerContent)
             </XDSText>
-            <div {...stylex.props(styles.navWrapper)}>
+            <div style={styles.navWrapper}>
               <NavPreview alignment="center" />
             </div>
           </XDSVStack>
@@ -104,7 +104,7 @@ export default function NavigationPage() {
             <XDSText type="supporting" weight="bold">
               Right-aligned (endContent)
             </XDSText>
-            <div {...stylex.props(styles.navWrapper)}>
+            <div style={styles.navWrapper}>
               <NavPreview alignment="end" />
             </div>
           </XDSVStack>

--- a/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
+++ b/apps/sandbox/src/app/pages/polymorphic-link/page.tsx
@@ -6,7 +6,7 @@ import {
   type AnchorHTMLAttributes,
   type ReactNode,
 } from 'react';
-import * as stylex from '@stylexjs/stylex';
+
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSDivider} from '@xds/core';
@@ -20,7 +20,7 @@ import {XDSLink, XDSLinkProvider} from '@xds/core/Link';
 // Simulated framework link components
 // =============================================================================
 
-const styles = stylex.create({
+const styles = {
   container: {
     maxWidth: 960,
   },
@@ -49,7 +49,7 @@ const styles = stylex.create({
     borderRadius: 8,
     overflow: 'hidden',
   },
-});
+};
 
 /**
  * Simulated Next.js-like Link for demo purposes.
@@ -70,7 +70,7 @@ const SimulatedNextLink = forwardRef<
         console.log(`[SimulatedNextLink] Client-side navigate to: ${href}`);
         onClick?.(e);
       }}
-      {...stylex.props(styles.customLinkIndicator)}
+      style={styles.customLinkIndicator}
       {...props}>
       {children}
     </a>
@@ -110,7 +110,7 @@ export default function PolymorphicLinkPage() {
   const [tab, setTab] = useState('overview');
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div style={styles.container}>
       <XDSVStack gap={6}>
         <XDSVStack gap={2}>
           <XDSHeading level={1}>Polymorphic Link</XDSHeading>
@@ -148,7 +148,7 @@ export default function PolymorphicLinkPage() {
                 <XDSText type="supporting" weight="bold">
                   XDSTopNav
                 </XDSText>
-                <div {...stylex.props(styles.navWrapper)}>
+                <div style={styles.navWrapper}>
                   <XDSTopNav
                     label="Provider demo navigation"
                     heading={<XDSTopNavHeading heading="My App" />}
@@ -194,7 +194,7 @@ export default function PolymorphicLinkPage() {
                 <XDSText type="supporting" weight="bold">
                   XDSSideNav
                 </XDSText>
-                <div {...stylex.props(styles.sidenavWrapper)}>
+                <div style={styles.sidenavWrapper}>
                   <XDSSideNav aria-label="Provider sidenav">
                     <XDSSideNavItem
                       label="Dashboard"
@@ -242,7 +242,7 @@ export default function PolymorphicLinkPage() {
           </XDSText>
 
           <XDSLinkProvider component={SimulatedNextLink}>
-            <div {...stylex.props(styles.navWrapper)}>
+            <div style={styles.navWrapper}>
               <XDSTopNav
                 label="Override demo navigation"
                 heading={<XDSTopNavHeading heading="Override Demo" />}
@@ -277,7 +277,7 @@ export default function PolymorphicLinkPage() {
             prop, components render native {'<a>'} elements as usual.
           </XDSText>
 
-          <div {...stylex.props(styles.navWrapper)}>
+          <div style={styles.navWrapper}>
             <XDSTopNav
               label="Default navigation"
               heading={<XDSTopNavHeading heading="Default" />}

--- a/apps/sandbox/src/app/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/pages/shell-lab/page.tsx
@@ -1,0 +1,518 @@
+'use client';
+
+import {useState, useCallback} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSSideNav,
+  XDSSideNavHeading,
+  XDSSideNavItem,
+  XDSSideNavSection,
+} from '@xds/core/SideNav';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSMobileNav} from '@xds/core/MobileNav';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSSwitch} from '@xds/core/Switch';
+import {XDSSelector, XDSSelectorOption} from '@xds/core/Selector';
+import {XDSCard} from '@xds/core/Card';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSBadge} from '@xds/core/Badge';
+
+// =============================================================================
+// Configuration types
+// =============================================================================
+
+interface ShellConfig {
+  background: 'wash' | 'surface';
+  height: 'fill' | 'auto';
+  sideNavBreakpoint: 'sm' | 'md' | 'lg' | 'xl';
+  sideNavWidth: number;
+  showSideNav: boolean;
+  showTopNav: boolean;
+  showBanner: boolean;
+  showFooterIcons: boolean;
+  showTopContent: boolean;
+  showNestedItems: boolean;
+  defaultCollapsed: boolean;
+  controlledCollapse: boolean;
+  isCollapsed: boolean;
+  mobileNavMode: 'auto' | 'custom' | 'none';
+  mobileNavSide: 'start' | 'end';
+  topNavAlignment: 'start' | 'center' | 'end';
+  showTopNavHeading: boolean;
+}
+
+const DEFAULT_CONFIG: ShellConfig = {
+  background: 'wash',
+  height: 'fill',
+  sideNavBreakpoint: 'md',
+  sideNavWidth: 260,
+  showSideNav: true,
+  showTopNav: true,
+  showBanner: false,
+  showFooterIcons: true,
+  showTopContent: true,
+  showNestedItems: true,
+  defaultCollapsed: false,
+  controlledCollapse: false,
+  isCollapsed: false,
+  mobileNavMode: 'auto',
+  mobileNavSide: 'start',
+  topNavAlignment: 'start',
+  showTopNavHeading: true,
+};
+
+// =============================================================================
+// Configuration Panel
+// =============================================================================
+
+function ConfigPanel({
+  config,
+  onChange,
+}: {
+  config: ShellConfig;
+  onChange: (update: Partial<ShellConfig>) => void;
+}) {
+  return (
+    <XDSCard>
+      <XDSVStack gap={5} padding={4}>
+        <XDSHeading level={3}>Shell Configuration</XDSHeading>
+
+        {/* AppShell */}
+        <XDSVStack gap={3}>
+          <XDSText type="label" weight="bold">
+            AppShell
+          </XDSText>
+          <SelectorRow
+            label="Background"
+            value={config.background}
+            onChange={v => onChange({background: v as 'wash' | 'surface'})}
+            options={[
+              {value: 'wash', label: 'Wash'},
+              {value: 'surface', label: 'Surface'},
+            ]}
+          />
+          <SelectorRow
+            label="Height"
+            value={config.height}
+            onChange={v => onChange({height: v as 'fill' | 'auto'})}
+            options={[
+              {value: 'fill', label: 'Fill'},
+              {value: 'auto', label: 'Auto'},
+            ]}
+          />
+          <SelectorRow
+            label="Breakpoint"
+            value={config.sideNavBreakpoint}
+            onChange={v =>
+              onChange({sideNavBreakpoint: v as 'sm' | 'md' | 'lg' | 'xl'})
+            }
+            options={[
+              {value: 'sm', label: 'sm'},
+              {value: 'md', label: 'md'},
+              {value: 'lg', label: 'lg'},
+              {value: 'xl', label: 'xl'},
+            ]}
+          />
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* Visibility */}
+        <XDSVStack gap={3}>
+          <XDSText type="label" weight="bold">
+            Visibility
+          </XDSText>
+          <ToggleRow
+            label="Side Nav"
+            value={config.showSideNav}
+            onChange={v => onChange({showSideNav: v})}
+          />
+          <ToggleRow
+            label="Top Nav"
+            value={config.showTopNav}
+            onChange={v => onChange({showTopNav: v})}
+          />
+          <ToggleRow
+            label="Banner"
+            value={config.showBanner}
+            onChange={v => onChange({showBanner: v})}
+          />
+          <ToggleRow
+            label="Footer Icons"
+            value={config.showFooterIcons}
+            onChange={v => onChange({showFooterIcons: v})}
+          />
+          <ToggleRow
+            label="Top Content"
+            value={config.showTopContent}
+            onChange={v => onChange({showTopContent: v})}
+          />
+          <ToggleRow
+            label="Nested Items"
+            value={config.showNestedItems}
+            onChange={v => onChange({showNestedItems: v})}
+          />
+          <ToggleRow
+            label="TopNav Heading"
+            value={config.showTopNavHeading}
+            onChange={v => onChange({showTopNavHeading: v})}
+          />
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* Collapse */}
+        <XDSVStack gap={3}>
+          <XDSText type="label" weight="bold">
+            Collapse
+          </XDSText>
+          <ToggleRow
+            label="Default Collapsed"
+            value={config.defaultCollapsed}
+            onChange={v => onChange({defaultCollapsed: v})}
+          />
+          <ToggleRow
+            label="Controlled"
+            value={config.controlledCollapse}
+            onChange={v => onChange({controlledCollapse: v})}
+          />
+          {config.controlledCollapse && (
+            <ToggleRow
+              label="Is Collapsed"
+              value={config.isCollapsed}
+              onChange={v => onChange({isCollapsed: v})}
+            />
+          )}
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* Mobile */}
+        <XDSVStack gap={3}>
+          <XDSText type="label" weight="bold">
+            Mobile Nav
+          </XDSText>
+          <SelectorRow
+            label="Mode"
+            value={config.mobileNavMode}
+            onChange={v =>
+              onChange({mobileNavMode: v as 'auto' | 'custom' | 'none'})
+            }
+            options={[
+              {value: 'auto', label: 'Auto'},
+              {value: 'custom', label: 'Custom'},
+              {value: 'none', label: 'None'},
+            ]}
+          />
+          {config.mobileNavMode === 'custom' && (
+            <SelectorRow
+              label="Drawer Side"
+              value={config.mobileNavSide}
+              onChange={v => onChange({mobileNavSide: v as 'start' | 'end'})}
+              options={[
+                {value: 'start', label: 'Start'},
+                {value: 'end', label: 'End'},
+              ]}
+            />
+          )}
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* TopNav */}
+        <XDSVStack gap={3}>
+          <XDSText type="label" weight="bold">
+            TopNav
+          </XDSText>
+          <SelectorRow
+            label="Nav Alignment"
+            value={config.topNavAlignment}
+            onChange={v =>
+              onChange({topNavAlignment: v as 'start' | 'center' | 'end'})
+            }
+            options={[
+              {value: 'start', label: 'Start'},
+              {value: 'center', label: 'Center'},
+              {value: 'end', label: 'End'},
+            ]}
+          />
+        </XDSVStack>
+      </XDSVStack>
+    </XDSCard>
+  );
+}
+
+function ToggleRow({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <XDSHStack gap={4} vAlign="center" hAlign="between">
+      <XDSText type="body">{label}</XDSText>
+      <XDSSwitch isSelected={value} onChange={onChange} label={label} />
+    </XDSHStack>
+  );
+}
+
+function SelectorRow({
+  label,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: {value: string; label: string}[];
+}) {
+  return (
+    <XDSHStack gap={4} vAlign="center">
+      <XDSText type="body" style={{width: 140, flexShrink: 0}}>
+        {label}
+      </XDSText>
+      <XDSSelector value={value} onChange={onChange}>
+        {options.map(o => (
+          <XDSSelectorOption key={o.value} value={o.value} label={o.label} />
+        ))}
+      </XDSSelector>
+    </XDSHStack>
+  );
+}
+
+// =============================================================================
+// Sample Nav Content
+// =============================================================================
+
+function SampleSideNav({config}: {config: ShellConfig}) {
+  return (
+    <XDSSideNav
+      header={<XDSSideNavHeading heading="Shell Lab" headingHref="#" />}
+      topContent={
+        config.showTopContent ? (
+          <XDSSideNavItem label="Create New" />
+        ) : undefined
+      }
+      footerIcons={
+        config.showFooterIcons ? (
+          <>
+            <XDSSideNavItem label="Help" />
+            <XDSSideNavItem label="Settings" />
+          </>
+        ) : undefined
+      }>
+      <XDSSideNavSection heading="Navigation">
+        <XDSSideNavItem label="Dashboard" isSelected href="#" />
+        <XDSSideNavItem
+          label="Projects"
+          href="#"
+          endContent={<XDSBadge label="3" />}
+        />
+        <XDSSideNavItem label="Messages" href="#" />
+        {config.showNestedItems && (
+          <XDSSideNavItem label="Settings" href="#">
+            <XDSSideNavItem label="General" href="#" />
+            <XDSSideNavItem label="Security" href="#" />
+            <XDSSideNavItem label="Notifications" href="#" />
+          </XDSSideNavItem>
+        )}
+      </XDSSideNavSection>
+      <XDSSideNavSection heading="Resources">
+        <XDSSideNavItem label="Documentation" href="#" />
+        <XDSSideNavItem label="API Reference" href="#" />
+        <XDSSideNavItem label="Support" href="#" />
+      </XDSSideNavSection>
+    </XDSSideNav>
+  );
+}
+
+function SampleTopNav({config}: {config: ShellConfig}) {
+  const navItems = (
+    <>
+      <XDSTopNavItem label="Home" href="#" isSelected />
+      <XDSTopNavItem label="Products" href="#" />
+      <XDSTopNavItem label="Team" href="#" />
+      <XDSTopNavItem label="Reports" href="#" />
+    </>
+  );
+
+  return (
+    <XDSTopNav
+      label="Shell Lab Navigation"
+      heading={
+        config.showTopNavHeading ? (
+          <XDSTopNavHeading heading="Shell Lab" />
+        ) : undefined
+      }
+      startContent={config.topNavAlignment === 'start' ? navItems : undefined}
+      centerContent={config.topNavAlignment === 'center' ? navItems : undefined}
+      endContent={config.topNavAlignment === 'end' ? navItems : undefined}
+    />
+  );
+}
+
+// =============================================================================
+// Main Page
+// =============================================================================
+
+const pageStyles = stylex.create({
+  configOverlay: {
+    position: 'fixed',
+    top: 16,
+    right: 16,
+    width: 360,
+    maxHeight: 'calc(100vh - 32px)',
+    overflowY: 'auto',
+    zIndex: 1000,
+  },
+  content: {
+    padding: '24px',
+    maxWidth: '800px',
+  },
+  toggleButton: {
+    position: 'fixed',
+    bottom: 16,
+    right: 16,
+    zIndex: 1001,
+  },
+});
+
+export default function ShellLabPage() {
+  const [config, setConfig] = useState<ShellConfig>(DEFAULT_CONFIG);
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  const [showConfig, setShowConfig] = useState(true);
+
+  const handleConfigChange = useCallback((update: Partial<ShellConfig>) => {
+    setConfig(prev => ({...prev, ...update}));
+  }, []);
+
+  const collapseProps = config.controlledCollapse
+    ? {
+        isSideNavCollapsed: config.isCollapsed,
+        onSideNavCollapsedChange: (v: boolean) =>
+          handleConfigChange({isCollapsed: v}),
+      }
+    : {defaultIsSideNavCollapsed: config.defaultCollapsed};
+
+  const mobileNav =
+    config.mobileNavMode === 'custom' ? (
+      <XDSMobileNav
+        isOpen={isMobileNavOpen}
+        onOpenChange={setIsMobileNavOpen}
+        title="Navigation"
+        side={config.mobileNavSide}>
+        <XDSSideNavSection heading="Navigation">
+          <XDSSideNavItem label="Dashboard" isSelected href="#" />
+          <XDSSideNavItem label="Projects" href="#" />
+          <XDSSideNavItem label="Messages" href="#" />
+        </XDSSideNavSection>
+      </XDSMobileNav>
+    ) : config.mobileNavMode === 'none' ? (
+      <></>
+    ) : undefined;
+
+  return (
+    <>
+      <XDSAppShell
+        background={config.background}
+        height={config.height}
+        sideNavBreakpoint={config.sideNavBreakpoint}
+        sideNavWidth={config.sideNavWidth}
+        topNav={
+          config.showTopNav ? <SampleTopNav config={config} /> : undefined
+        }
+        sideNav={
+          config.showSideNav ? <SampleSideNav config={config} /> : undefined
+        }
+        mobileNav={mobileNav}
+        banner={
+          config.showBanner ? (
+            <div
+              style={{
+                padding: '8px 16px',
+                background: 'var(--color-accent)',
+                color: 'white',
+                textAlign: 'center',
+                fontSize: 14,
+              }}>
+              🔬 Shell Lab — System announcement banner
+            </div>
+          ) : undefined
+        }
+        {...collapseProps}>
+        <div {...stylex.props(pageStyles.content)}>
+          <XDSVStack gap={6}>
+            <XDSVStack gap={2}>
+              <XDSHeading level={1}>Shell Lab</XDSHeading>
+              <XDSText type="body" color="secondary">
+                Use the configuration panel to experiment with different shell
+                and navigation setups. Resize the browser to test responsive
+                behavior and collapse breakpoints.
+              </XDSText>
+            </XDSVStack>
+
+            <XDSCard>
+              <XDSVStack gap={3} padding={4}>
+                <XDSHeading level={3}>Active Config</XDSHeading>
+                <pre
+                  style={{
+                    fontSize: 12,
+                    overflow: 'auto',
+                    padding: 12,
+                    borderRadius: 8,
+                    background: 'var(--color-wash)',
+                  }}>
+                  {JSON.stringify(config, null, 2)}
+                </pre>
+              </XDSVStack>
+            </XDSCard>
+
+            {Array.from({length: 10}, (_, i) => (
+              <XDSCard key={i}>
+                <XDSVStack gap={2} padding={4}>
+                  <XDSHeading level={4}>Content Block {i + 1}</XDSHeading>
+                  <XDSText type="body" color="secondary">
+                    Sample content to test scroll behavior in fill vs auto
+                    height mode. The shell should handle overflow correctly
+                    regardless of content length.
+                  </XDSText>
+                </XDSVStack>
+              </XDSCard>
+            ))}
+          </XDSVStack>
+        </div>
+      </XDSAppShell>
+
+      {/* Floating config panel */}
+      {showConfig && (
+        <div {...stylex.props(pageStyles.configOverlay)}>
+          <ConfigPanel config={config} onChange={handleConfigChange} />
+        </div>
+      )}
+
+      {/* Toggle config visibility */}
+      <div {...stylex.props(pageStyles.toggleButton)}>
+        <button
+          onClick={() => setShowConfig(v => !v)}
+          style={{
+            padding: '8px 16px',
+            borderRadius: 8,
+            border: 'none',
+            background: 'var(--color-accent)',
+            color: 'white',
+            cursor: 'pointer',
+            fontSize: 14,
+            fontWeight: 600,
+          }}>
+          {showConfig ? '✕ Hide Config' : '⚙ Config'}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/apps/sandbox/src/app/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/pages/shell-lab/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {useState, useCallback} from 'react';
-import * as stylex from '@stylexjs/stylex';
+
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSSideNav,
@@ -9,15 +9,24 @@ import {
   XDSSideNavItem,
   XDSSideNavSection,
 } from '@xds/core/SideNav';
-import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+import {
+  XDSTopNav,
+  XDSTopNavHeading,
+  XDSTopNavItem,
+  XDSTopNavMenu,
+  XDSTopNavMegaMenu,
+} from '@xds/core/TopNav';
 import {XDSMobileNav} from '@xds/core/MobileNav';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSSwitch} from '@xds/core/Switch';
-import {XDSSelector, XDSSelectorOption} from '@xds/core/Selector';
+import {XDSSelector} from '@xds/core/Selector';
 import {XDSCard} from '@xds/core/Card';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSBadge} from '@xds/core/Badge';
+import {XDSButton} from '@xds/core/Button';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+import {XDSBanner} from '@xds/core/Banner';
 
 // =============================================================================
 // Configuration types
@@ -33,6 +42,7 @@ interface ShellConfig {
   showBanner: boolean;
   showFooterIcons: boolean;
   showTopContent: boolean;
+  showSideNavHeading: boolean;
   showNestedItems: boolean;
   defaultCollapsed: boolean;
   controlledCollapse: boolean;
@@ -40,6 +50,7 @@ interface ShellConfig {
   mobileNavMode: 'auto' | 'custom' | 'none';
   mobileNavSide: 'start' | 'end';
   topNavAlignment: 'start' | 'center' | 'end';
+  topNavStyle: 'items' | 'menus' | 'mega';
   showTopNavHeading: boolean;
 }
 
@@ -53,6 +64,7 @@ const DEFAULT_CONFIG: ShellConfig = {
   showBanner: false,
   showFooterIcons: true,
   showTopContent: true,
+  showSideNavHeading: true,
   showNestedItems: true,
   defaultCollapsed: false,
   controlledCollapse: false,
@@ -60,6 +72,7 @@ const DEFAULT_CONFIG: ShellConfig = {
   mobileNavMode: 'auto',
   mobileNavSide: 'start',
   topNavAlignment: 'start',
+  topNavStyle: 'items',
   showTopNavHeading: true,
 };
 
@@ -133,6 +146,11 @@ function ConfigPanel({
             label="Top Nav"
             value={config.showTopNav}
             onChange={v => onChange({showTopNav: v})}
+          />
+          <ToggleRow
+            label="SideNav Heading"
+            value={config.showSideNavHeading}
+            onChange={v => onChange({showSideNavHeading: v})}
           />
           <ToggleRow
             label="Banner"
@@ -238,6 +256,18 @@ function ConfigPanel({
               {value: 'end', label: 'End'},
             ]}
           />
+          <SelectorRow
+            label="Nav Style"
+            value={config.topNavStyle}
+            onChange={v =>
+              onChange({topNavStyle: v as 'items' | 'menus' | 'mega'})
+            }
+            options={[
+              {value: 'items', label: 'Items'},
+              {value: 'menus', label: 'Menus'},
+              {value: 'mega', label: 'Mega'},
+            ]}
+          />
         </XDSVStack>
       </XDSVStack>
     </XDSCard>
@@ -256,7 +286,7 @@ function ToggleRow({
   return (
     <XDSHStack gap={4} vAlign="center" hAlign="between">
       <XDSText type="body">{label}</XDSText>
-      <XDSSwitch isSelected={value} onChange={onChange} label={label} />
+      <XDSSwitch value={value} onChange={onChange} label={label} />
     </XDSHStack>
   );
 }
@@ -277,11 +307,13 @@ function SelectorRow({
       <XDSText type="body" style={{width: 140, flexShrink: 0}}>
         {label}
       </XDSText>
-      <XDSSelector value={value} onChange={onChange}>
-        {options.map(o => (
-          <XDSSelectorOption key={o.value} value={o.value} label={o.label} />
-        ))}
-      </XDSSelector>
+      <XDSSelector
+        label={label}
+        isLabelHidden
+        value={value}
+        onChange={onChange}
+        options={options.map(o => o.value)}
+      />
     </XDSHStack>
   );
 }
@@ -293,7 +325,28 @@ function SelectorRow({
 function SampleSideNav({config}: {config: ShellConfig}) {
   return (
     <XDSSideNav
-      header={<XDSSideNavHeading heading="Shell Lab" headingHref="#" />}
+      header={
+        config.showSideNavHeading ? (
+          <XDSSideNavHeading
+            icon={
+              <XDSNavIcon
+                icon={
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    width="16"
+                    height="16">
+                    <path d="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.36.2-.8.2-1.14 0l-7.9-4.44A.991.991 0 013 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.36-.2.8-.2 1.14 0l7.9 4.44c.32.17.53.5.53.88v9z" />
+                  </svg>
+                }
+              />
+            }
+            heading="Shell Lab"
+            headingHref="#"
+          />
+        ) : undefined
+      }
       topContent={
         config.showTopContent ? (
           <XDSSideNavItem label="Create New" />
@@ -302,8 +355,41 @@ function SampleSideNav({config}: {config: ShellConfig}) {
       footerIcons={
         config.showFooterIcons ? (
           <>
-            <XDSSideNavItem label="Help" />
-            <XDSSideNavItem label="Settings" />
+            <XDSButton
+              label="Help"
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  width="20"
+                  height="20">
+                  <circle cx="12" cy="12" r="10" />
+                  <path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3" />
+                  <circle cx="12" cy="17" r=".5" fill="currentColor" />
+                </svg>
+              }
+              variant="ghost"
+            />
+            <XDSButton
+              label="Settings"
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth={1.5}
+                  width="20"
+                  height="20">
+                  <path d="M12.22 2h-.44a2 2 0 00-2 2v.18a2 2 0 01-1 1.73l-.43.25a2 2 0 01-2 0l-.15-.08a2 2 0 00-2.73.73l-.22.38a2 2 0 00.73 2.73l.15.1a2 2 0 011 1.72v.51a2 2 0 01-1 1.74l-.15.09a2 2 0 00-.73 2.73l.22.38a2 2 0 002.73.73l.15-.08a2 2 0 012 0l.43.25a2 2 0 011 1.73V20a2 2 0 002 2h.44a2 2 0 002-2v-.18a2 2 0 011-1.73l.43-.25a2 2 0 012 0l.15.08a2 2 0 002.73-.73l.22-.39a2 2 0 00-.73-2.73l-.15-.08a2 2 0 01-1-1.74v-.5a2 2 0 011-1.74l.15-.09a2 2 0 00.73-2.73l-.22-.38a2 2 0 00-2.73-.73l-.15.08a2 2 0 01-2 0l-.43-.25a2 2 0 01-1-1.73V4a2 2 0 00-2-2z" />
+                  <circle cx="12" cy="12" r="3" />
+                </svg>
+              }
+              variant="ghost"
+            />
           </>
         ) : undefined
       }>
@@ -312,7 +398,7 @@ function SampleSideNav({config}: {config: ShellConfig}) {
         <XDSSideNavItem
           label="Projects"
           href="#"
-          endContent={<XDSBadge label="3" />}
+          endContent={<XDSBadge>3</XDSBadge>}
         />
         <XDSSideNavItem label="Messages" href="#" />
         {config.showNestedItems && (
@@ -333,7 +419,7 @@ function SampleSideNav({config}: {config: ShellConfig}) {
 }
 
 function SampleTopNav({config}: {config: ShellConfig}) {
-  const navItems = (
+  const plainItems = (
     <>
       <XDSTopNavItem label="Home" href="#" isSelected />
       <XDSTopNavItem label="Products" href="#" />
@@ -342,12 +428,97 @@ function SampleTopNav({config}: {config: ShellConfig}) {
     </>
   );
 
+  const menuItems = (
+    <>
+      <XDSTopNavItem label="Home" href="#" isSelected />
+      <XDSTopNavMenu
+        label="Products"
+        items={[
+          {
+            title: 'Analytics',
+            description: 'View metrics and dashboards',
+            href: '#',
+          },
+          {
+            title: 'Reports',
+            description: 'Generate and export reports',
+            href: '#',
+          },
+          {
+            title: 'Pipelines',
+            description: 'Data processing workflows',
+            href: '#',
+          },
+        ]}
+      />
+      <XDSTopNavItem label="Team" href="#" />
+    </>
+  );
+
+  const megaItems = (
+    <>
+      <XDSTopNavItem label="Home" href="#" isSelected />
+      <XDSTopNavMegaMenu
+        label="Products"
+        items={[
+          {
+            title: 'Analytics',
+            description: 'View metrics and dashboards',
+            href: '#',
+          },
+          {
+            title: 'Reports',
+            description: 'Generate and export reports',
+            href: '#',
+          },
+          {
+            title: 'Pipelines',
+            description: 'Data processing workflows',
+            href: '#',
+          },
+          {title: 'Integrations', description: 'Connect your tools', href: '#'},
+        ]}
+        featured={{
+          title: 'New: AI Features',
+          description:
+            'Explore our latest AI-powered analytics tools for faster insights.',
+          linkText: 'Learn more →',
+          linkHref: '#',
+        }}
+      />
+      <XDSTopNavItem label="Team" href="#" />
+    </>
+  );
+
+  const navItems =
+    config.topNavStyle === 'mega'
+      ? megaItems
+      : config.topNavStyle === 'menus'
+        ? menuItems
+        : plainItems;
+
   return (
     <XDSTopNav
       label="Shell Lab Navigation"
       heading={
         config.showTopNavHeading ? (
-          <XDSTopNavHeading heading="Shell Lab" />
+          <XDSTopNavHeading
+            heading="Shell Lab"
+            logo={
+              <XDSNavIcon
+                icon={
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="currentColor"
+                    width="16"
+                    height="16">
+                    <path d="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.36.2-.8.2-1.14 0l-7.9-4.44A.991.991 0 013 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.36-.2.8-.2 1.14 0l7.9 4.44c.32.17.53.5.53.88v9z" />
+                  </svg>
+                }
+              />
+            }
+          />
         ) : undefined
       }
       startContent={config.topNavAlignment === 'start' ? navItems : undefined}
@@ -361,27 +532,28 @@ function SampleTopNav({config}: {config: ShellConfig}) {
 // Main Page
 // =============================================================================
 
-const pageStyles = stylex.create({
+// Inline styles (sandbox uses dist, no StyleX build)
+const pageStyles = {
   configOverlay: {
-    position: 'fixed',
+    position: 'fixed' as const,
     top: 16,
     right: 16,
     width: 360,
     maxHeight: 'calc(100vh - 32px)',
-    overflowY: 'auto',
+    overflowY: 'auto' as const,
     zIndex: 1000,
   },
   content: {
-    padding: '24px',
-    maxWidth: '800px',
+    padding: 24,
+    maxWidth: 800,
   },
   toggleButton: {
-    position: 'fixed',
+    position: 'fixed' as const,
     bottom: 16,
     right: 16,
     zIndex: 1001,
   },
-});
+};
 
 export default function ShellLabPage() {
   const [config, setConfig] = useState<ShellConfig>(DEFAULT_CONFIG);
@@ -433,20 +605,16 @@ export default function ShellLabPage() {
         mobileNav={mobileNav}
         banner={
           config.showBanner ? (
-            <div
-              style={{
-                padding: '8px 16px',
-                background: 'var(--color-accent)',
-                color: 'white',
-                textAlign: 'center',
-                fontSize: 14,
-              }}>
-              🔬 Shell Lab — System announcement banner
-            </div>
+            <XDSBanner
+              status="info"
+              title="Shell Lab — System announcement banner"
+              variant="section"
+              isDismissable
+            />
           ) : undefined
         }
         {...collapseProps}>
-        <div {...stylex.props(pageStyles.content)}>
+        <div style={pageStyles.content}>
           <XDSVStack gap={6}>
             <XDSVStack gap={2}>
               <XDSHeading level={1}>Shell Lab</XDSHeading>
@@ -491,13 +659,13 @@ export default function ShellLabPage() {
 
       {/* Floating config panel */}
       {showConfig && (
-        <div {...stylex.props(pageStyles.configOverlay)}>
+        <div style={pageStyles.configOverlay}>
           <ConfigPanel config={config} onChange={handleConfigChange} />
         </div>
       )}
 
       {/* Toggle config visibility */}
-      <div {...stylex.props(pageStyles.toggleButton)}>
+      <div style={pageStyles.toggleButton}>
         <button
           onClick={() => setShowConfig(v => !v)}
           style={{

--- a/apps/sandbox/src/app/pages/table-overview/page.tsx
+++ b/apps/sandbox/src/app/pages/table-overview/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import {useState, useMemo} from 'react';
-import * as stylex from '@stylexjs/stylex';
+
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
@@ -209,7 +209,7 @@ function StatCard({
 }) {
   return (
     <XDSCard>
-      <div {...stylex.props(styles.statCard)}>
+      <div style={styles.statCard}>
         <XDSText type="supporting" color="secondary">
           {emoji ? `${emoji} ` : ''}
           {label}
@@ -238,10 +238,10 @@ const columns: XDSTableColumn<ReviewRow>[] = [
           name={item.authorName}
           size="small"
         />
-        <div {...stylex.props(styles.authorInfo)}>
+        <div style={styles.authorInfo}>
           <XDSVStack gap={1}>
-            <span {...stylex.props(styles.titleLink)}>{item.title}</span>
-            <span {...stylex.props(styles.supportingLine)}>
+            <span style={styles.titleLink}>{item.title}</span>
+            <span style={styles.supportingLine}>
               <XDSText type="supporting" color="secondary">
                 {item.diffId} · {item.lines} lines {item.reviewTime}
               </XDSText>
@@ -256,11 +256,11 @@ const columns: XDSTableColumn<ReviewRow>[] = [
     header: 'Reviewers',
     width: pixel(120),
     renderCell: (item: ReviewRow) => (
-      <div {...stylex.props(styles.avatarGroup)}>
+      <div style={styles.avatarGroup}>
         {item.reviewerAvatars.map((src: string, i: number) => (
           <div
             key={i}
-            {...stylex.props(styles.avatarOverlap)}
+            style={styles.avatarOverlap}
             style={{
               marginLeft: i > 0 ? -8 : 0,
               zIndex: item.reviewerAvatars.length - i,
@@ -313,7 +313,7 @@ const columns: XDSTableColumn<ReviewRow>[] = [
 // Styles
 // =============================================================================
 
-const styles = stylex.create({
+const styles = {
   container: {
     maxWidth: 1100,
     width: '100%',
@@ -356,7 +356,7 @@ const styles = stylex.create({
     position: 'relative',
     display: 'inline-flex',
   },
-});
+};
 
 // =============================================================================
 // Section Table (table within a collapsible)
@@ -450,7 +450,7 @@ export default function TableOverviewPage() {
   const filteredAccepted = filterRows(acceptedAndReady);
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div style={styles.container}>
       <XDSVStack gap={6}>
         <XDSVStack gap={2}>
           <XDSHeading level={1}>Table Overview</XDSHeading>
@@ -470,7 +470,7 @@ export default function TableOverviewPage() {
         />
 
         {/* Stats Row */}
-        <div {...stylex.props(styles.statsRow)}>
+        <div style={styles.statsRow}>
           <StatCard emoji="🔥" label="Review streak" value="4 days" />
           <StatCard label="Reviews today" value={6} />
           <StatCard label="Diff reviews" value={28} />

--- a/apps/sandbox/src/app/pages/topnav-menu/page.tsx
+++ b/apps/sandbox/src/app/pages/topnav-menu/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import * as stylex from '@stylexjs/stylex';
 import {XDSVStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
@@ -12,7 +11,7 @@ import {
 } from '@xds/core/TopNav';
 import {XDSNavIcon} from '@xds/core/NavIcon';
 
-const styles = stylex.create({
+const styles = {
   container: {
     maxWidth: 960,
   },
@@ -21,7 +20,7 @@ const styles = stylex.create({
     overflow: 'hidden',
     boxShadow: '0 1px 3px rgba(0, 0, 0, 0.08)',
   },
-});
+};
 
 const LogoIcon = () => (
   <svg
@@ -98,7 +97,7 @@ const scienceItems = [
  */
 export default function TopNavMenuPage() {
   return (
-    <div {...stylex.props(styles.container)}>
+    <div style={styles.container}>
       <XDSVStack gap={6}>
         <XDSVStack gap={2}>
           <XDSHeading level={1}>TopNav Menu</XDSHeading>
@@ -111,7 +110,7 @@ export default function TopNavMenuPage() {
         {/* Marketing-style nav with overflow menus */}
         <XDSVStack gap={3}>
           <XDSHeading level={2}>Marketing Nav</XDSHeading>
-          <div {...stylex.props(styles.navWrapper)}>
+          <div style={styles.navWrapper}>
             <XDSTopNav
               label="Marketing navigation"
               heading={
@@ -141,7 +140,7 @@ export default function TopNavMenuPage() {
         {/* Simple nav with one overflow menu */}
         <XDSVStack gap={3}>
           <XDSHeading level={2}>Simple Nav</XDSHeading>
-          <div {...stylex.props(styles.navWrapper)}>
+          <div style={styles.navWrapper}>
             <XDSTopNav
               label="Simple navigation"
               heading={<XDSTopNavHeading heading="App" href="#" />}


### PR DESCRIPTION
## Summary

Replace the `background` prop with a `variant` prop that controls how nav areas contrast with content. Closes #346, part of #565 shell deep review.

## Variants

| Variant | Nav areas | Content | Dividers | Border radius |
|---------|-----------|---------|----------|---------------|
| `wash` | wash | wash | no | no |
| `surface` | surface | surface | no | no |
| `section` | inherit | inherit | yes | no |
| `elevated` | wash | surface | no | top-left corner when both navs present |

## Key changes

- **`variant` prop** replaces `background` on XDSAppShell
- **`--radius-page` token** (20px) — themeable border radius for elevated content
- **`--color-navbar` token removed** — nav background now controlled by the shell variant
- **SideNav/TopNav** — no longer set their own background, inherit from shell
- **Elevated variant** uses a decorative backdrop sibling with `isolation: isolate` stacking (no z-index, no overflow clipping, preserves scroll)
- **Shell Lab** sandbox page for interactive testing of all configurations
- **Storybook** Playground story updated with variant control

## Shell Lab

Interactive sandbox page at `/pages/shell-lab/` with toggles for variant, height, collapse, mobile nav, top nav style, and visibility of all shell areas.

## Breaking changes

- `background` prop removed — use `variant` instead
- `--color-navbar` token removed — use `variant="surface"` or theme the shell