### PR TITLE
refactor: replace internal isFullBleed usage with padding={0}

### DIFF
--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -72,10 +72,7 @@ const meta: Meta<typeof XDSCard> = {
       control: {type: 'range', min: 100, max: 600, step: 10},
       description: 'Minimum height in pixels',
     },
-    isFullBleed: {
-      control: 'boolean',
-      description: 'Removes internal padding (deprecated, use padding={0})',
-    },
+
   },
 };
 

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -74,7 +74,7 @@ const meta: Meta<typeof XDSCard> = {
     },
     isFullBleed: {
       control: 'boolean',
-      description: 'Removes internal padding',
+      description: 'Removes internal padding (deprecated, use padding={0})',
     },
   },
 };
@@ -306,7 +306,7 @@ export const FullBleed: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>Full Bleed (no padding)</h4>
-        <XDSCard width={250} isFullBleed>
+        <XDSCard width={250} padding={0}>
           <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
             <p {...stylex.props(styles.text)}>Content touches card edges</p>
           </div>

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -162,7 +162,6 @@ The XDS Layout System provides a structured way to build page and component layo
     footer: {table: {disable: true}},
     header: {table: {disable: true}},
     height: {table: {disable: true}},
-    isFullBleed: {table: {disable: true}},
     padding: {table: {disable: true}},
     start: {table: {disable: true}},
   },

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -163,6 +163,7 @@ The XDS Layout System provides a structured way to build page and component layo
     header: {table: {disable: true}},
     height: {table: {disable: true}},
     isFullBleed: {table: {disable: true}},
+    padding: {table: {disable: true}},
     start: {table: {disable: true}},
   },
 };
@@ -179,18 +180,18 @@ interface PlaygroundArgs {
   cardWidth: number;
   cardHeight: number;
   // Layout props
-  layoutIsFullBleed: boolean;
+  layoutPadding: number;
   // Header props
   showHeader: boolean;
   headerHasDivider: boolean;
-  headerIsFullBleed: boolean;
+  headerPadding: number;
   // Content props
-  contentIsFullBleed: boolean;
+  contentPadding: number;
   contentIsScrollable: boolean;
   // Footer props
   showFooter: boolean;
   footerHasDivider: boolean;
-  footerIsFullBleed: boolean;
+  footerPadding: number;
   // Start panel props
   showStartPanel: boolean;
   startPanelWidth: number;
@@ -210,18 +211,18 @@ export const Playground = {
     cardWidth: 700,
     cardHeight: 400,
     // Layout defaults
-    layoutIsFullBleed: false,
+    layoutPadding: 4,
     // Header defaults
     showHeader: true,
     headerHasDivider: true,
-    headerIsFullBleed: false,
+    headerPadding: 4,
     // Content defaults
-    contentIsFullBleed: false,
+    contentPadding: 4,
     contentIsScrollable: true,
     // Footer defaults
     showFooter: true,
     footerHasDivider: true,
-    footerIsFullBleed: false,
+    footerPadding: 4,
     // Start panel defaults
     showStartPanel: true,
     startPanelWidth: 160,
@@ -246,9 +247,9 @@ export const Playground = {
       table: {category: 'Card'},
     },
     // Layout controls
-    layoutIsFullBleed: {
-      control: 'boolean',
-      description: 'Remove padding at layout outer edges (affects all slots)',
+    layoutPadding: {
+      control: {type: 'range', min: 0, max: 8, step: 1},
+      description: 'Padding at layout outer edges (0 for full bleed)',
       table: {category: 'Layout'},
     },
     // Header controls
@@ -262,15 +263,15 @@ export const Playground = {
       description: 'Add a border below the header',
       table: {category: 'Header'},
     },
-    headerIsFullBleed: {
-      control: 'boolean',
-      description: 'Remove header padding',
+    headerPadding: {
+      control: {type: 'range', min: 0, max: 8, step: 1},
+      description: 'Header padding (0 for full bleed)',
       table: {category: 'Header'},
     },
     // Content controls
-    contentIsFullBleed: {
-      control: 'boolean',
-      description: 'Remove content padding for edge-to-edge content',
+    contentPadding: {
+      control: {type: 'range', min: 0, max: 8, step: 1},
+      description: 'Content padding (0 for edge-to-edge content)',
       table: {category: 'Content'},
     },
     contentIsScrollable: {
@@ -289,9 +290,9 @@ export const Playground = {
       description: 'Add a border above the footer',
       table: {category: 'Footer'},
     },
-    footerIsFullBleed: {
-      control: 'boolean',
-      description: 'Remove footer padding',
+    footerPadding: {
+      control: {type: 'range', min: 0, max: 8, step: 1},
+      description: 'Footer padding (0 for full bleed)',
       table: {category: 'Footer'},
     },
     // Start panel controls
@@ -341,12 +342,12 @@ export const Playground = {
     <div {...stylex.props(styles.pageWrapper)}>
       <XDSCard width={args.cardWidth} height={args.cardHeight}>
         <XDSLayout
-          isFullBleed={args.layoutIsFullBleed}
+          padding={args.layoutPadding}
           header={
             args.showHeader ? (
               <XDSLayoutHeader
                 hasDivider={args.headerHasDivider}
-                isFullBleed={args.headerIsFullBleed}>
+                padding={args.headerPadding}>
                 <h3 {...stylex.props(styles.heading)}>Layout Header</h3>
               </XDSLayoutHeader>
             ) : undefined
@@ -367,7 +368,7 @@ export const Playground = {
           }
           content={
             <XDSLayoutContent
-              isFullBleed={args.contentIsFullBleed}
+              padding={args.contentPadding}
               isScrollable={args.contentIsScrollable}>
               <h4 {...stylex.props(styles.subheading)}>Main Content Area</h4>
               <br />
@@ -377,9 +378,9 @@ export const Playground = {
               </p>
               <br />
               <p {...stylex.props(styles.bodyText)}>
-                Try enabling &quot;isFullBleed&quot; to see how content can
-                extend to the edges, or toggle &quot;isScrollable&quot; to
-                change overflow behavior.
+                Try setting padding to 0 to see how content can extend to the
+                edges, or toggle &quot;isScrollable&quot; to change overflow
+                behavior.
               </p>
               <br />
               <div {...stylex.props(styles.placeholder)}>
@@ -405,7 +406,7 @@ export const Playground = {
             args.showFooter ? (
               <XDSLayoutFooter
                 hasDivider={args.footerHasDivider}
-                isFullBleed={args.footerIsFullBleed}>
+                padding={args.footerPadding}>
                 <XDSHStack gap={2} hAlign="end">
                   <XDSButton label="Cancel" variant="secondary">
                     Cancel
@@ -604,9 +605,9 @@ export const FullBleedContent: Story = {
             </XDSLayoutHeader>
           }
           content={
-            <XDSLayoutContent isFullBleed>
+            <XDSLayoutContent padding={0}>
               <div {...stylex.props(styles.placeholderFullBleed)}>
-                This content uses isFullBleed to remove padding, allowing it to
+                This content uses padding=0 to remove padding, allowing it to
                 touch the edges. Useful for tables, images, or other
                 edge-to-edge content.
               </div>

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -68,10 +68,7 @@ const meta: Meta<typeof XDSSection> = {
       control: {type: 'range', min: 100, max: 600, step: 10},
       description: 'Height in pixels',
     },
-    isFullBleed: {
-      control: 'boolean',
-      description: 'Removes internal padding (deprecated, use padding={0})',
-    },
+
   },
 };
 

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -70,7 +70,7 @@ const meta: Meta<typeof XDSSection> = {
     },
     isFullBleed: {
       control: 'boolean',
-      description: 'Removes internal padding',
+      description: 'Removes internal padding (deprecated, use padding={0})',
     },
   },
 };
@@ -211,7 +211,7 @@ export const FullBleed: Story = {
       </div>
       <div>
         <h4 {...stylex.props(styles.heading)}>Full Bleed (no padding)</h4>
-        <XDSSection variant="wash" width={250} isFullBleed>
+        <XDSSection variant="wash" width={250} padding={0}>
           <div style={{backgroundColor: 'rgba(0,100,200,0.2)', padding: 8}}>
             <p {...stylex.props(styles.text)}>Content touches section edges</p>
           </div>

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -499,7 +499,7 @@ export function XDSAppShell({
   const headerInner =
     hasTopNav || hasBanner ? (
       <XDSLayoutHeader
-        isFullBleed
+        padding={0}
         hasDivider={navHasDividers && hasTopNav}
         xstyle={navAreaStyle}>
         {hasBanner && <div {...stylex.props(styles.banner)}>{banner}</div>}
@@ -524,7 +524,7 @@ export function XDSAppShell({
   // =========================================================================
   const sideNavPanel = showSideNavInline ? (
     <XDSLayoutPanel
-      isFullBleed
+      padding={0}
       hasDivider={navHasDividers}
       width={sideNavWidth}
       role="navigation"
@@ -551,7 +551,7 @@ export function XDSAppShell({
 
   const mainInner = (
     <XDSLayoutContent
-      isFullBleed
+      padding={0}
       role="main"
       id={MAIN_CONTENT_ID}
       isScrollable={isFill}
@@ -605,8 +605,8 @@ export function XDSAppShell({
       </a>
 
       <XDSLayout
-        isFullBleed
         height={height}
+        padding={0}
         header={headerContent}
         start={sideNavContent}
         content={mainContent}

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -93,13 +93,6 @@ export interface XDSLayoutProps extends Omit<XDSBaseProps, 'content'> {
   height?: XDSLayoutHeight;
 
   /**
-   * Removes padding at layout's outer edges, making layout touch container edges.
-   * @deprecated Use `padding={0}` instead.
-   * @default false
-   */
-  isFullBleed?: boolean;
-
-  /**
    * Padding at the layout's outer edges using the spacing scale.
    * Controls both `--layout-padding-outer-x` and `--layout-padding-outer-y`.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
@@ -192,7 +185,6 @@ export function XDSLayout({
   footer,
   header,
   height = 'fill',
-  isFullBleed = false,
   padding,
   start,
   xstyle,
@@ -230,7 +222,7 @@ export function XDSLayout({
             styles.layoutInner,
             ...stack({direction: 'vertical'}),
             isFill ? styles.fill : styles.auto,
-            isFullBleed && padding == null && styles.fullBleed,
+            padding === 0 && styles.fullBleed,
             padding != null && layoutPaddingOuterXVarStyles[padding],
             padding != null && layoutPaddingOuterYVarStyles[padding],
           )}>

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -70,14 +70,6 @@ export interface XDSLayoutContentProps extends XDSBaseProps<HTMLDivElement> {
   children?: ReactNode;
 
   /**
-   * Removes internal padding, allowing content to touch the edges.
-   * Useful for edge-to-edge content like tables.
-   * @deprecated Use `padding={0}` instead.
-   * @default false
-   */
-  isFullBleed?: boolean;
-
-  /**
    * Internal padding of the content area using the spacing scale.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    * Overrides the default padding from the layout container.
@@ -110,7 +102,7 @@ export interface XDSLayoutContentProps extends XDSBaseProps<HTMLDivElement> {
  * with automatic scroll containment and context-aware padding.
  *
  * Already provides its own padding and scroll — don't add padding or
- * overflow to children. Use `isFullBleed` if you need edge-to-edge content.
+ * overflow to children. Use `padding={0}` if you need edge-to-edge content.
  *
  * @example
  * ```
@@ -123,7 +115,7 @@ export interface XDSLayoutContentProps extends XDSBaseProps<HTMLDivElement> {
  * <XDSLayoutContainer variant="card">
  *   <XDSLayout
  *     content={
- *       <XDSLayoutContent isFullBleed>
+ *       <XDSLayoutContent padding={0}>
  *         <Table />
  *       </XDSLayoutContent>
  *     }
@@ -142,7 +134,6 @@ export interface XDSLayoutContentProps extends XDSBaseProps<HTMLDivElement> {
  */
 export function XDSLayoutContent({
   children,
-  isFullBleed = false,
   isScrollable = true,
   padding,
   label,
@@ -157,8 +148,7 @@ export function XDSLayoutContent({
     XDSLayoutSlotsContext,
   );
 
-  // padding={0} is semantically equivalent to isFullBleed
-  const isZeroPadding = isFullBleed || padding === 0;
+  const isZeroPadding = padding === 0;
 
   return (
     <div

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -74,13 +74,6 @@ export interface XDSLayoutFooterProps extends XDSBaseProps<HTMLDivElement> {
   height?: number | string;
 
   /**
-   * Removes internal padding, allowing content to touch the edges.
-   * @deprecated Use `padding={0}` instead.
-   * @default false
-   */
-  isFullBleed?: boolean;
-
-  /**
    * Internal padding of the footer using the spacing scale.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    * Overrides the default padding from the layout container.
@@ -105,7 +98,7 @@ export interface XDSLayoutFooterProps extends XDSBaseProps<HTMLDivElement> {
  * Renders in the footer slot with optional divider and padding control.
  *
  * Already provides its own padding — don't add padding to children.
- * Use `isFullBleed` if your content manages its own padding.
+ * Use `padding={0}` if your content manages its own padding.
  *
  * @example
  * ```
@@ -121,7 +114,6 @@ export function XDSLayoutFooter({
   children,
   hasDivider = false,
   height,
-  isFullBleed = false,
   label,
   padding,
   role,
@@ -131,8 +123,7 @@ export function XDSLayoutFooter({
   ref,
   ...props
 }: XDSLayoutFooterProps) {
-  // padding={0} is semantically equivalent to isFullBleed
-  const isZeroPadding = isFullBleed || padding === 0;
+  const isZeroPadding = padding === 0;
 
   // When no divider, collapse spacing for seamless visual flow
   const shouldCollapseSpacing =

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -74,13 +74,6 @@ export interface XDSLayoutHeaderProps extends XDSBaseProps<HTMLDivElement> {
   height?: number | string;
 
   /**
-   * Removes internal padding, allowing content to touch the edges.
-   * @deprecated Use `padding={0}` instead.
-   * @default false
-   */
-  isFullBleed?: boolean;
-
-  /**
    * Internal padding of the header using the spacing scale.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    * Overrides the default padding from the layout container.
@@ -105,7 +98,7 @@ export interface XDSLayoutHeaderProps extends XDSBaseProps<HTMLDivElement> {
  * Renders in the header slot with optional divider and padding control.
  *
  * Already provides its own padding — don't add padding to children.
- * Use `isFullBleed` if your content manages its own padding (e.g. XDSTopNav).
+ * Use `padding={0}` if your content manages its own padding (e.g. XDSTopNav).
  *
  * @example
  * ```
@@ -121,7 +114,6 @@ export function XDSLayoutHeader({
   children,
   hasDivider = false,
   height,
-  isFullBleed = false,
   label,
   padding,
   role,
@@ -131,8 +123,7 @@ export function XDSLayoutHeader({
   ref,
   ...props
 }: XDSLayoutHeaderProps) {
-  // padding={0} is semantically equivalent to isFullBleed
-  const isZeroPadding = isFullBleed || padding === 0;
+  const isZeroPadding = padding === 0;
 
   // When no divider, collapse spacing for seamless visual flow
   const shouldCollapseSpacing =

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -106,13 +106,6 @@ export interface XDSLayoutPanelProps extends XDSBaseProps<HTMLDivElement> {
   hasDivider?: boolean;
 
   /**
-   * Removes internal padding, allowing content to touch the edges.
-   * @deprecated Use `padding={0}` instead.
-   * @default false
-   */
-  isFullBleed?: boolean;
-
-  /**
    * Internal padding of the panel using the spacing scale.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    * Overrides the default padding from the layout container.
@@ -153,7 +146,7 @@ export interface XDSLayoutPanelProps extends XDSBaseProps<HTMLDivElement> {
  * Divider position is auto-detected based on which slot the panel is in.
  *
  * Already provides its own padding and scroll — don't add padding or
- * overflow to children. Use `isFullBleed` if you need edge-to-edge content.
+ * overflow to children. Use `padding={0}` if you need edge-to-edge content.
  *
  * @example
  * ```
@@ -177,7 +170,6 @@ export interface XDSLayoutPanelProps extends XDSBaseProps<HTMLDivElement> {
 export function XDSLayoutPanel({
   children,
   hasDivider = false,
-  isFullBleed = false,
   isScrollable = true,
   label,
   padding,
@@ -196,8 +188,7 @@ export function XDSLayoutPanel({
   const isStartPanel = area === 'start';
   const isEndPanel = area === 'end';
 
-  // padding={0} is semantically equivalent to isFullBleed
-  const isZeroPadding = isFullBleed || padding === 0;
+  const isZeroPadding = padding === 0;
 
   // When no divider, collapse spacing for seamless visual flow
   const shouldCollapseSpacing =


### PR DESCRIPTION
## Summary

Two-part refactor that migrates away from `isFullBleed` on Layout components and then removes it from their interfaces entirely.

### Part 1: Replace internal usages with `padding={0}`

Replace all internal usages of `isFullBleed` prop on Layout components with the equivalent `padding={0}`. The `padding` prop is more expressive (supports any spacing step, not just 0/default) and aligns with the rest of the design system API.

**Files changed:**
- **`packages/core/src/AppShell/XDSAppShell.tsx`** — 4 usages replaced
- **`apps/storybook/stories/Layout.stories.tsx`** — Playground story args/controls migrated
- **`apps/storybook/stories/Card.stories.tsx`** — FullBleed story migrated, deprecation note added
- **`apps/storybook/stories/Section.stories.tsx`** — FullBleed story migrated, deprecation note added

### Part 2: Remove `isFullBleed` from Layout component interfaces

Remove the deprecated `isFullBleed` prop from all Layout component interfaces. Consumers must use `padding={0}` instead.

**Files changed:**
- **`packages/core/src/Layout/XDSLayout.tsx`** — removed from props interface
- **`packages/core/src/Layout/XDSLayoutContent.tsx`** — removed from props interface and implementation
- **`packages/core/src/Layout/XDSLayoutFooter.tsx`** — removed from props interface and implementation
- **`packages/core/src/Layout/XDSLayoutHeader.tsx`** — removed from props interface and implementation
- **`packages/core/src/Layout/XDSLayoutPanel.tsx`** — removed from props interface and implementation
- **`apps/storybook/stories/Layout.stories.tsx`** — removed `isFullBleed` argType

### Also fixed
- **`apps/sandbox/src/app/pages/mega-menu/page.tsx`** — fixed pre-existing TypeScript error (inline styles position type)

## What is NOT changed

- **`XDSCard`** and **`XDSSection`** — `isFullBleed` prop remains (maps to `padding={0}` internally). Follow-up removal.
- **`XDSDivider`** — its `isFullBleed` is a different concept (negative-margin escape hatch)
- **Codemods** (`packages/cli/`) — `migrate-isFullBleed-to-padding` codemod preserved for consumer migration