### PR TITLE
feat(cli): add codemods for AppShell variant migration

### DIFF
--- a/packages/cli/src/codemods/registry.mjs
+++ b/packages/cli/src/codemods/registry.mjs
@@ -7,6 +7,7 @@
 
 const registry = new Map([
   ['0.0.2', () => import('./transforms/v0.0.2/index.mjs')],
+  ['0.0.3', () => import('./transforms/v0.0.3/index.mjs')],
 ]);
 
 /**

--- a/packages/cli/src/codemods/transforms/v0.0.3/__tests__/migrate-background-to-variant.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.3/__tests__/migrate-background-to-variant.test.mjs
@@ -1,0 +1,100 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../migrate-background-to-variant.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('migrate-background-to-variant', () => {
+  it('renames background="wash" to variant="wash"', async () => {
+    const input = '<XDSAppShell background="wash"><div /></XDSAppShell>';
+    const output = await applyTransform(input);
+    expect(output).toContain('variant="wash"');
+    expect(output).not.toContain('background=');
+  });
+
+  it('renames background="surface" to variant="surface"', async () => {
+    const input = '<XDSAppShell background="surface"><div /></XDSAppShell>';
+    const output = await applyTransform(input);
+    expect(output).toContain('variant="surface"');
+    expect(output).not.toContain('background=');
+  });
+
+  it('renames background with expression to variant', async () => {
+    const input = '<XDSAppShell background={bgValue}><div /></XDSAppShell>';
+    const output = await applyTransform(input);
+    expect(output).toContain('variant={bgValue}');
+    expect(output).not.toContain('background=');
+  });
+
+  it('adds variant="surface" when no background prop exists', async () => {
+    const input = '<XDSAppShell><div /></XDSAppShell>';
+    const output = await applyTransform(input);
+    expect(output).toContain('variant="surface"');
+  });
+
+  it('adds variant="surface" to self-closing element with no background', async () => {
+    const input = '<XDSAppShell topNav={<nav />} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('variant="surface"');
+  });
+
+  it('does not add variant if variant already exists', async () => {
+    const input = '<XDSAppShell variant="section"><div /></XDSAppShell>';
+    const output = await applyTransform(input);
+    // Should be unchanged
+    expect(output).toBe(input);
+  });
+
+  it('does not modify non-XDSAppShell components', async () => {
+    const input = '<OtherComponent background="wash" />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('preserves other props', async () => {
+    const input = '<XDSAppShell background="wash" topNav={<TopNav />} sideNav={<SideNav />}><div /></XDSAppShell>';
+    const output = await applyTransform(input);
+    expect(output).toContain('variant="wash"');
+    expect(output).toContain('topNav={<TopNav />}');
+    expect(output).toContain('sideNav={<SideNav />}');
+    expect(output).not.toContain('background=');
+  });
+
+  it('handles multiple XDSAppShell instances in one file', async () => {
+    const input = `
+      <div>
+        <XDSAppShell background="wash"><div /></XDSAppShell>
+        <XDSAppShell background="surface"><div /></XDSAppShell>
+      </div>
+    `;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('background=');
+    expect(output).toContain('variant="wash"');
+    expect(output).toContain('variant="surface"');
+  });
+
+  it('handles ternary expression in background', async () => {
+    const input = '<XDSAppShell background={isDark ? "wash" : "surface"}><div /></XDSAppShell>';
+    const output = await applyTransform(input);
+    expect(output).toContain('variant={isDark ? "wash" : "surface"}');
+    expect(output).not.toContain('background=');
+  });
+
+  it('returns undefined when no XDSAppShell found', async () => {
+    const {default: transform} = await import(
+      '../migrate-background-to-variant.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<div>Hello</div>';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.3/__tests__/remove-color-navbar-token.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.3/__tests__/remove-color-navbar-token.test.mjs
@@ -1,0 +1,99 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../remove-color-navbar-token.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+/**
+ * Strip TODO comments to check that code-level references are gone.
+ */
+function stripComments(code) {
+  return code.replace(/\/\/.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+describe('remove-color-navbar-token', () => {
+  it('replaces colorVars["--color-navbar"] with colorVars["--color-surface"]', async () => {
+    const input = `
+      const styles = stylex.create({
+        nav: {
+          backgroundColor: colorVars['--color-navbar'],
+        },
+      });
+    `;
+    const output = await applyTransform(input);
+    expect(output).toContain('--color-surface');
+    expect(stripComments(output)).not.toContain('--color-navbar');
+    expect(output).toContain('TODO(xds-codemod)');
+  });
+
+  it('removes --color-navbar from theme definition objects', async () => {
+    const input = `
+      const theme = defineTheme({
+        colors: {
+          '--color-surface': ['#fff', '#1a1a1a'],
+          '--color-navbar': ['#fff', '#1f1f22'],
+          '--color-wash': ['#f0f0f0', '#000'],
+        },
+      });
+    `;
+    const output = await applyTransform(input);
+    expect(stripComments(output)).not.toContain('--color-navbar');
+    expect(output).toContain('--color-surface');
+    expect(output).toContain('--color-wash');
+  });
+
+  it('skips files with no --color-navbar reference', async () => {
+    const {default: transform} = await import(
+      '../remove-color-navbar-token.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = `
+      const styles = stylex.create({
+        root: { backgroundColor: colorVars['--color-surface'] },
+      });
+    `;
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('handles double-quoted property access', async () => {
+    const input = `
+      const styles = stylex.create({
+        nav: {
+          backgroundColor: colorVars["--color-navbar"],
+        },
+      });
+    `;
+    const output = await applyTransform(input);
+    expect(output).toContain('--color-surface');
+    expect(stripComments(output)).not.toContain('--color-navbar');
+  });
+
+  it('handles --color-navbar as a standalone string literal', async () => {
+    const input = `
+      const token = '--color-navbar';
+    `;
+    const output = await applyTransform(input);
+    expect(output).toContain('--color-surface');
+    expect(stripComments(output)).not.toContain('--color-navbar');
+  });
+
+  it('handles multiple occurrences in one file', async () => {
+    const input = `
+      const theme = {
+        '--color-navbar': '#fff',
+      };
+      const bg = colorVars['--color-navbar'];
+    `;
+    const output = await applyTransform(input);
+    expect(stripComments(output)).not.toContain('--color-navbar');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.3/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.3/index.mjs
@@ -1,0 +1,25 @@
+/**
+ * @file v0.0.3 transform manifest
+ *
+ * Lists all codemods for the v0.0.3 release in the order they should run.
+ */
+
+import migrateBackgroundToVariant, {
+  meta as backgroundMeta,
+} from './migrate-background-to-variant.mjs';
+import removeColorNavbarToken, {
+  meta as navbarMeta,
+} from './remove-color-navbar-token.mjs';
+
+export default [
+  {
+    name: 'migrate-background-to-variant',
+    transform: migrateBackgroundToVariant,
+    meta: backgroundMeta,
+  },
+  {
+    name: 'remove-color-navbar-token',
+    transform: removeColorNavbarToken,
+    meta: navbarMeta,
+  },
+];

--- a/packages/cli/src/codemods/transforms/v0.0.3/migrate-background-to-variant.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.3/migrate-background-to-variant.mjs
@@ -1,0 +1,64 @@
+/**
+ * @file Codemod: Migrate `background` prop to `variant` on XDSAppShell
+ *
+ * Transforms:
+ * - background="wash" → variant="wash"
+ * - background="surface" → variant="surface"
+ * - background={expr} → variant={expr}
+ * - No background prop → adds variant="surface" (old default was "surface", new default is "section")
+ *
+ * @see https://github.com/facebookexperimental/xds/pull/597
+ */
+
+export const meta = {
+  title: 'Migrate background → variant on XDSAppShell',
+  description:
+    'Replaces the `background` prop with `variant` on XDSAppShell. Adds `variant="surface"` when no background was set (old default changed from "surface" to "section").',
+  pr: '#597',
+};
+
+const TARGET_COMPONENT = 'XDSAppShell';
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  root
+    .find(j.JSXOpeningElement, {
+      name: {name: TARGET_COMPONENT},
+    })
+    .forEach((path) => {
+      const attrs = path.node.attributes;
+
+      // Find background prop index
+      const bgIndex = attrs.findIndex(
+        (attr) =>
+          attr.type === 'JSXAttribute' && attr.name.name === 'background',
+      );
+
+      if (bgIndex !== -1) {
+        // Rename background → variant
+        attrs[bgIndex].name.name = 'variant';
+        hasChanges = true;
+      } else {
+        // No background prop found — check there's no variant already
+        const hasVariant = attrs.some(
+          (attr) =>
+            attr.type === 'JSXAttribute' && attr.name.name === 'variant',
+        );
+        if (!hasVariant) {
+          // Add variant="surface" (old default was "surface", new default is "section")
+          attrs.push(
+            j.jsxAttribute(
+              j.jsxIdentifier('variant'),
+              j.literal('surface'),
+            ),
+          );
+          hasChanges = true;
+        }
+      }
+    });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.3/remove-color-navbar-token.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.3/remove-color-navbar-token.mjs
@@ -1,0 +1,96 @@
+/**
+ * @file Codemod: Remove `--color-navbar` token usage
+ *
+ * The `--color-navbar` token has been removed in v0.0.3. Nav background
+ * is now controlled by the `variant` prop on XDSAppShell.
+ *
+ * Transforms:
+ * - StyleX property references: colorVars['--color-navbar'] → colorVars['--color-surface'] + TODO
+ * - Object property keys: '--color-navbar': ... → removed
+ * - Standalone string literals: '--color-navbar' → '--color-surface'
+ *
+ * @see https://github.com/facebookexperimental/xds/pull/597
+ */
+
+export const meta = {
+  title: 'Remove --color-navbar token usage',
+  description:
+    'Removes or flags usages of the `--color-navbar` token which was removed in v0.0.3. Nav background is now controlled by XDSAppShell variant prop.',
+  pr: '#597',
+};
+
+const TOKEN = '--color-navbar';
+const REPLACEMENT = '--color-surface';
+const TODO_COMMENT =
+  'TODO(xds-codemod): --color-navbar removed — nav bg now controlled by XDSAppShell variant';
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const source = file.source;
+
+  // Quick bail: skip files that don't reference the token at all
+  if (!source.includes(TOKEN)) {
+    return undefined;
+  }
+
+  const root = j(source);
+  let hasChanges = false;
+
+  // Pattern 1: colorVars['--color-navbar'] in StyleX
+  // Replace with colorVars['--color-surface']
+  root
+    .find(j.MemberExpression, {
+      property: {value: TOKEN},
+    })
+    .forEach((path) => {
+      path.node.property = j.literal(REPLACEMENT);
+      hasChanges = true;
+    });
+
+  // Pattern 2: '--color-navbar' as a key in theme objects (defineTheme, etc.)
+  // Remove the property entirely
+  root
+    .find(j.Property, {
+      key: {value: TOKEN},
+    })
+    .forEach((path) => {
+      const parent = path.parent;
+      if (parent && parent.node && Array.isArray(parent.node.properties)) {
+        const index = parent.node.properties.indexOf(path.node);
+        if (index !== -1) {
+          parent.node.properties.splice(index, 1);
+          hasChanges = true;
+        }
+      }
+    });
+
+  // Pattern 3: String literal '--color-navbar' used as a standalone value
+  root
+    .find(j.Literal, {value: TOKEN})
+    .forEach((path) => {
+      // Skip if already handled (property key or member expression)
+      if (
+        path.parent.node.type === 'Property' &&
+        path.parent.node.key === path.node
+      ) {
+        return;
+      }
+      if (path.parent.node.type === 'MemberExpression') {
+        return;
+      }
+      path.node.value = REPLACEMENT;
+      hasChanges = true;
+    });
+
+  if (!hasChanges) {
+    return undefined;
+  }
+
+  // Post-process: add TODO comment via string replacement
+  let result = root.toSource();
+  if (!result.includes(TODO_COMMENT)) {
+    result = '// ' + TODO_COMMENT + '\n' + result;
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

Adds v0.0.3 codemods for the AppShell variant migration (#597). Consumers can run `xds upgrade` to automatically migrate.

### Codemod 1: `migrate-background-to-variant`

Migrates the `background` prop to `variant` on `XDSAppShell`.

**Before:**
```tsx
<XDSAppShell background="wash">...</XDSAppShell>
<XDSAppShell background="surface">...</XDSAppShell>
<XDSAppShell>...</XDSAppShell>  {/* no background prop */}
```

**After:**
```tsx
<XDSAppShell variant="wash">...</XDSAppShell>
<XDSAppShell variant="surface">...</XDSAppShell>
<XDSAppShell variant="surface">...</XDSAppShell>  {/* explicit surface — old default */}
```

The third case is important: old default was `background="surface"`, new default is `variant="section"`. The codemod adds `variant="surface"` to preserve existing behavior.

### Codemod 2: `remove-color-navbar-token`

Removes usages of the `--color-navbar` CSS custom property token, which was removed in #597.

**Before:**
```tsx
const styles = stylex.create({
  nav: { backgroundColor: colorVars["--color-navbar"] },
});

const theme = defineTheme({
  colors: {
    "--color-navbar": ["#fff", "#1f1f22"],
  },
});
```

**After:**
```tsx
// TODO(xds-codemod): --color-navbar removed — nav bg now controlled by XDSAppShell variant
const styles = stylex.create({
  nav: { backgroundColor: colorVars["--color-surface"] },
});

const theme = defineTheme({
  colors: {},
});
```

### Changes
- New `packages/cli/src/codemods/transforms/v0.0.3/` directory with 2 codemods
- 17 tests (11 for background→variant, 6 for token removal)
- Registry updated to include v0.0.3

Stacks on #597.