### PR TITLE
fix(SideNav): consistent spacing regardless of header/topContent visibility

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
@@ -43,7 +43,7 @@ interface ShellConfig {
   showBanner: boolean;
   showFooterIcons: boolean;
   showTopContent: boolean;
-  showSideNavHeading: boolean;
+  sideNavHeadingStyle: 'none' | 'simple' | 'link' | 'menu' | 'full';
   showNestedItems: boolean;
   defaultCollapsed: boolean;
   controlledCollapse: boolean;
@@ -65,7 +65,7 @@ const DEFAULT_CONFIG: ShellConfig = {
   showBanner: false,
   showFooterIcons: true,
   showTopContent: true,
-  showSideNavHeading: true,
+  sideNavHeadingStyle: 'link',
   showNestedItems: true,
   defaultCollapsed: false,
   controlledCollapse: false,
@@ -152,10 +152,21 @@ function ConfigPanel({
             value={config.showTopNav}
             onChange={v => onChange({showTopNav: v})}
           />
-          <ToggleRow
+          <SelectorRow
             label="SideNav Heading"
-            value={config.showSideNavHeading}
-            onChange={v => onChange({showSideNavHeading: v})}
+            value={config.sideNavHeadingStyle}
+            onChange={v =>
+              onChange({
+                sideNavHeadingStyle: v as ShellConfig['sideNavHeadingStyle'],
+              })
+            }
+            options={[
+              {value: 'none', label: 'None'},
+              {value: 'simple', label: 'Simple'},
+              {value: 'link', label: 'Link'},
+              {value: 'menu', label: 'Menu'},
+              {value: 'full', label: 'Full'},
+            ]}
           />
           <ToggleRow
             label="Banner"
@@ -328,30 +339,63 @@ function SelectorRow({
 // =============================================================================
 
 function SampleSideNav({config}: {config: ShellConfig}) {
+  const appIcon = (
+    <XDSNavIcon
+      icon={
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          width="16"
+          height="16">
+          <path d="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.36.2-.8.2-1.14 0l-7.9-4.44A.991.991 0 013 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.36-.2.8-.2 1.14 0l7.9 4.44c.32.17.53.5.53.88v9z" />
+        </svg>
+      }
+    />
+  );
+
+  const headingMenu = (
+    <XDSVStack gap={1}>
+      <XDSSideNavItem label="Switch to Project A" />
+      <XDSSideNavItem label="Switch to Project B" />
+      <XDSSideNavItem label="Switch to Project C" />
+    </XDSVStack>
+  );
+
+  const heading =
+    config.sideNavHeadingStyle === 'none' ? undefined : (
+      <XDSSideNavHeading
+        icon={appIcon}
+        heading="Shell Lab"
+        headingHref={
+          config.sideNavHeadingStyle === 'link' ||
+          config.sideNavHeadingStyle === 'full'
+            ? '#'
+            : undefined
+        }
+        superheading={
+          config.sideNavHeadingStyle === 'full' ? 'Acme Suite' : undefined
+        }
+        superheadingHref={
+          config.sideNavHeadingStyle === 'full' ? '#' : undefined
+        }
+        subheading={
+          config.sideNavHeadingStyle === 'full'
+            ? 'Business Account'
+            : undefined
+        }
+        menu={
+          config.sideNavHeadingStyle === 'menu' ||
+          config.sideNavHeadingStyle === 'full'
+            ? headingMenu
+            : undefined
+        }
+      />
+    );
+
   return (
     <XDSSideNav
-      header={
-        config.showSideNavHeading ? (
-          <XDSSideNavHeading
-            icon={
-              <XDSNavIcon
-                icon={
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    width="16"
-                    height="16">
-                    <path d="M21 16.5c0 .38-.21.71-.53.88l-7.9 4.44c-.36.2-.8.2-1.14 0l-7.9-4.44A.991.991 0 013 16.5v-9c0-.38.21-.71.53-.88l7.9-4.44c.36-.2.8-.2 1.14 0l7.9 4.44c.32.17.53.5.53.88v9z" />
-                  </svg>
-                }
-              />
-            }
-            heading="Shell Lab"
-            headingHref="#"
-          />
-        ) : undefined
-      }
+      header={heading}
       topContent={
         config.showTopContent ? (
           <XDSSideNavItem label="Create New" />

--- a/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
@@ -41,6 +41,7 @@ interface ShellConfig {
   showSideNav: boolean;
   showTopNav: boolean;
   showBanner: boolean;
+  showFooter: boolean;
   showFooterIcons: boolean;
   showTopContent: boolean;
   sideNavHeadingStyle: 'none' | 'simple' | 'link' | 'menu' | 'full';
@@ -63,6 +64,7 @@ const DEFAULT_CONFIG: ShellConfig = {
   showSideNav: true,
   showTopNav: true,
   showBanner: false,
+  showFooter: false,
   showFooterIcons: true,
   showTopContent: true,
   sideNavHeadingStyle: 'link',
@@ -107,8 +109,10 @@ function ConfigPanel({
               })
             }
             options={[
+              {value: 'section', label: 'Section'},
               {value: 'wash', label: 'Wash'},
               {value: 'surface', label: 'Surface'},
+              {value: 'elevated', label: 'Elevated'},
             ]}
           />
           <SelectorRow
@@ -172,6 +176,11 @@ function ConfigPanel({
             label="Banner"
             value={config.showBanner}
             onChange={v => onChange({showBanner: v})}
+          />
+          <ToggleRow
+            label="Footer"
+            value={config.showFooter}
+            onChange={v => onChange({showFooter: v})}
           />
           <ToggleRow
             label="Footer Icons"
@@ -380,9 +389,7 @@ function SampleSideNav({config}: {config: ShellConfig}) {
           config.sideNavHeadingStyle === 'full' ? '#' : undefined
         }
         subheading={
-          config.sideNavHeadingStyle === 'full'
-            ? 'Business Account'
-            : undefined
+          config.sideNavHeadingStyle === 'full' ? 'Business Account' : undefined
         }
         menu={
           config.sideNavHeadingStyle === 'menu' ||
@@ -399,6 +406,14 @@ function SampleSideNav({config}: {config: ShellConfig}) {
       topContent={
         config.showTopContent ? (
           <XDSSideNavItem label="Create New" />
+        ) : undefined
+      }
+      footer={
+        config.showFooter ? (
+          <XDSSideNavSection title="Account">
+            <XDSSideNavItem label="Jane Smith" />
+            <XDSSideNavItem label="Upgrade to Pro" />
+          </XDSSideNavSection>
         ) : undefined
       }
       footerIcons={
@@ -708,13 +723,22 @@ export default function ShellLabPage() {
 
       {/* Floating config panel */}
       {showConfig && (
-        <div {...stylex.props(styles.configOverlay)}>
+        <div
+          style={{
+            position: 'fixed',
+            top: 16,
+            right: 16,
+            width: 360,
+            maxHeight: 'calc(100vh - 32px)',
+            overflowY: 'auto' as const,
+            zIndex: 10000,
+          }}>
           <ConfigPanel config={config} onChange={handleConfigChange} />
         </div>
       )}
 
       {/* Toggle config visibility */}
-      <div {...stylex.props(styles.toggleButton)}>
+      <div style={{position: 'fixed', bottom: 16, right: 16, zIndex: 10001}}>
         <button
           onClick={() => setShowConfig(v => !v)}
           style={{

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -44,30 +44,41 @@ const styles = stylex.create({
     top: 0,
     zIndex: 1,
     backgroundColor: 'inherit',
-  },
-  topContent: {
-    paddingInline: spacingVars['--spacing-2'],
     paddingBlockStart: spacingVars['--spacing-2'],
+    paddingBlockEnd: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    gap: spacingVars['--spacing-2'],
   },
+  topContent: {},
   scrollable: {
     flex: 1,
     overflowY: 'auto',
     overflowX: 'hidden',
     paddingInline: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-1'],
+  },
+  scrollableNoTop: {
+    paddingBlockStart: spacingVars['--spacing-2'],
+  },
+  scrollableWithTop: {
+    paddingBlockStart: spacingVars['--spacing-1'],
+  },
+  scrollableNoBottom: {
+    paddingBlockEnd: spacingVars['--spacing-2'],
+  },
+  scrollableWithBottom: {
+    paddingBlockEnd: spacingVars['--spacing-1'],
   },
   stickyBottom: {
+    display: 'flex',
+    flexDirection: 'column',
     flexShrink: 0,
     marginTop: 'auto',
     position: 'sticky',
     bottom: 0,
     backgroundColor: 'inherit',
-  },
-  stickyBottomInner: {
-    display: 'flex',
-    flexDirection: 'column',
     gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],
+    paddingBlockStart: spacingVars['--spacing-1'],
     paddingBlockEnd: spacingVars['--spacing-2'],
     borderBlockStart: `1px solid ${colorVars['--color-divider']}`,
   },
@@ -191,15 +202,22 @@ export function XDSSideNav({
           )}
         </div>
       )}
-      <div {...stylex.props(styles.scrollable)}>{children}</div>
+      <div
+        {...stylex.props(
+          styles.scrollable,
+          hasStickyTop ? styles.scrollableWithTop : styles.scrollableNoTop,
+          hasStickyBottom
+            ? styles.scrollableWithBottom
+            : styles.scrollableNoBottom,
+        )}>
+        {children}
+      </div>
       {hasStickyBottom && (
         <div {...stylex.props(styles.stickyBottom)}>
-          <div {...stylex.props(styles.stickyBottomInner)}>
-            {footer}
-            {footerIcons && (
-              <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
-            )}
-          </div>
+          {footer}
+          {footerIcons && (
+            <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
+          )}
         </div>
       )}
     </nav>

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -47,7 +47,7 @@ const styles = stylex.create({
   },
   topContent: {
     paddingInline: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-1'],
+    paddingBlockStart: spacingVars['--spacing-2'],
   },
   scrollable: {
     flex: 1,
@@ -63,17 +63,18 @@ const styles = stylex.create({
     bottom: 0,
     backgroundColor: 'inherit',
   },
-  footer: {
+  stickyBottomInner: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-2'],
+    paddingBlockEnd: spacingVars['--spacing-2'],
+    borderBlockStart: `1px solid ${colorVars['--color-divider']}`,
   },
   footerIcons: {
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-2'],
-    borderBlockStart: `1px solid ${colorVars['--color-divider']}`,
   },
 });
 
@@ -193,10 +194,12 @@ export function XDSSideNav({
       <div {...stylex.props(styles.scrollable)}>{children}</div>
       {hasStickyBottom && (
         <div {...stylex.props(styles.stickyBottom)}>
-          {footer && <div {...stylex.props(styles.footer)}>{footer}</div>}
-          {footerIcons && (
-            <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
-          )}
+          <div {...stylex.props(styles.stickyBottomInner)}>
+            {footer}
+            {footerIcons && (
+              <div {...stylex.props(styles.footerIcons)}>{footerIcons}</div>
+            )}
+          </div>
         </div>
       )}
     </nav>

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -65,10 +65,6 @@ const styles = stylex.create({
       },
     },
   },
-  interactiveInset: {
-    marginInline: spacingVars['--spacing-2'],
-    marginBlock: spacingVars['--spacing-1'],
-  },
   icon: {
     flexShrink: 0,
     display: 'flex',
@@ -367,12 +363,7 @@ export function XDSSideNavHeading({
         data-testid={testId}
         {...mergeProps(
           xdsClassName('side-nav-heading'),
-          stylex.props(
-            styles.root,
-            styles.interactive,
-            styles.interactiveInset,
-            xstyle,
-          ),
+          stylex.props(styles.root, styles.interactive, xstyle),
           className,
           style,
         )}
@@ -396,12 +387,7 @@ export function XDSSideNavHeading({
           {...popover.triggerProps}
           {...mergeProps(
             xdsClassName('side-nav-heading'),
-            stylex.props(
-              styles.root,
-              styles.interactive,
-              styles.interactiveInset,
-              xstyle,
-            ),
+            stylex.props(styles.root, styles.interactive, xstyle),
             className,
             style,
           )}>

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -44,7 +44,7 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-2'],
     boxSizing: 'border-box',
     textDecoration: 'none',
     color: 'inherit',

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -32,6 +32,7 @@ import {
 // of lazy loading layer resources.
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {XDSLink} from '../Link';
+import {getIcon} from '../Icon/globalIconRegistry';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -112,11 +113,12 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    width: spacingVars['--spacing-4'],
-    height: spacingVars['--spacing-4'],
+    minWidth: spacingVars['--spacing-7'],
+    minHeight: spacingVars['--spacing-7'],
     color: colorVars['--color-icon-secondary'],
   },
   popoverContent: {
+    padding: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-surface'],
     boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
@@ -199,27 +201,6 @@ export interface XDSSideNavHeadingProps {
 }
 
 // =============================================================================
-// Chevron SVG
-// =============================================================================
-
-function ChevronDownIcon() {
-  return (
-    <svg
-      width="16"
-      height="16"
-      viewBox="0 0 16 16"
-      fill="none"
-      aria-hidden="true">
-      <path
-        d="M4 6L8 10L12 6"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
 
 // =============================================================================
 // Component
@@ -349,9 +330,7 @@ export function XDSSideNavHeading({
   );
 
   const chevronElement = showChevron && (
-    <span {...stylex.props(styles.chevron)}>
-      <ChevronDownIcon />
-    </span>
+    <span {...stylex.props(styles.chevron)}>{getIcon('chevronDown')}</span>
   );
 
   // Whole heading is a link (no menu, single headingHref)
@@ -434,7 +413,7 @@ export function XDSSideNavHeading({
               aria-label="Open menu"
               {...popover.triggerProps}
               {...stylex.props(styles.chevron, styles.interactive)}>
-              <ChevronDownIcon />
+              {getIcon('chevronDown')}
             </button>
           )}
         </div>

--- a/packages/core/src/SideNav/XDSSideNavSection.tsx
+++ b/packages/core/src/SideNav/XDSSideNavSection.tsx
@@ -77,6 +77,7 @@ const styles = stylex.create({
   items: {
     display: 'flex',
     flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
   },
 });
 


### PR DESCRIPTION
## Summary

Fixes spacing inconsistencies in SideNav and updates the Shell Lab sandbox page for better experimentation. Addresses the sidenav spacing items from #565.

## SideNav Spacing Changes

### Header area (`stickyTop` container)
- Container now owns all spacing: 8px padding top/sides, 4px bottom, 8px gap between children
- Heading and topContent no longer manage their own margins — the container gap handles vertical rhythm
- Consistent layout regardless of heading interactivity (simple, link, menu, full)

### Scrollable body
- 8px top/bottom padding when no adjacent sticky area (it's the edge)
- 4px top/bottom padding when adjacent to sticky header/footer (4px + 4px from sticky = 8px total)

### Footer area
- Mirrors header: 4px top padding, 8px sides/bottom, 8px gap
- Removed extra wrapper div — `stickyBottom` now has all styles directly
- Border-top divider between body and footer

### Heading (`XDSSideNavHeading`)
- Removed all margins from heading — container handles spacing
- Layout is now independent of interactivity (simple/link/menu/full all have the same position)
- `interactive` style only adds visual behavior (hover, cursor, border-radius), no layout changes
- Removed `interactiveInset` style entirely

### Spacing Matrix

| Configuration | Top of body | Bottom of body |
|---|---|---|
| No header, no footer | 8px | 8px |
| Header only | 4px (+ 4px from header bottom = 8px gap) | 8px |
| Footer only | 8px | 4px (+ 4px from footer top = 8px gap) |
| Header + Footer | 4px | 4px |

## Shell Lab Changes

### New options
- **SideNav Heading Style** selector: none / simple / link / menu / full (replaces boolean toggle)
  - Simple: icon + heading text only
  - Link: icon + heading with href
  - Menu: icon + heading + popover menu with chevron
  - Full: superheading + heading + subheading + menu
- **Footer** toggle: shows sample footer content (account section) above footer icons
- **All four AppShell variants**: section, wash, surface, elevated (was missing section + elevated)

### Fixes
- Config panel and toggle button use inline styles for position (StyleX wasn't compiling fixed position properties)
- Config panel z-index bumped to 10000/10001 to sit above all shell layers

## Test plan

- Tested all heading style variants in Shell Lab
- Tested with/without header, footer, topContent, footerIcons in all combinations
- Verified spacing is consistent regardless of which zones are visible

Fixes parts of #565 (sidenav spacing)