### PR TITLE
fix(AppShell): content min-height in auto height mode

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -290,6 +290,9 @@ const styles = stylex.create({
   contentBgWash: {
     backgroundColor: colorVars['--color-wash'],
   },
+  contentAutoMinHeight: {
+    minHeight: 'calc(100dvh - var(--appshell-header-height, 0px))',
+  },
   contentBgTransparent: {
     backgroundColor: 'transparent',
     isolation: 'isolate',
@@ -567,7 +570,7 @@ export function XDSAppShell({
       role="main"
       id={MAIN_CONTENT_ID}
       isScrollable={isFill}
-      xstyle={contentAreaStyle}>
+      xstyle={[contentAreaStyle, isAuto && styles.contentAutoMinHeight]}>
       {children}
     </XDSLayoutContent>
   );


### PR DESCRIPTION
In auto height mode, the content area should fill at least the remaining viewport after the header. Currently short content leaves empty space below.

Adds `minHeight: calc(100dvh - var(--appshell-header-height, 0px))` to the content area in auto mode, using the existing CSS variable that's already measured via ResizeObserver.

The sidenav sticky behavior in auto mode was already implemented. This ensures the content side also fills correctly.

Part of #565