### PR TITLE
docs: sync theming/props for AppShell, PowerSearch, Tokenizer

### DIFF
--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -214,6 +214,13 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       default: '260',
     },
     {
+      name: 'variant',
+      type: "'wash' | 'surface' | 'section' | 'elevated'",
+      description:
+        "Navigation background style controlling how nav areas contrast with content. 'wash' uses wash background, 'surface' uses surface background, 'section' adds dividers between nav and content, 'elevated' uses wash nav with elevated surface content and border radius.",
+      default: "'section'",
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -229,7 +236,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
   ],
   theming: {
     targets: [
-      {className: 'xds-app-shell', visualProps: ['background', 'height']},
+      {className: 'xds-app-shell', visualProps: ['variant', 'height']},
     ],
   },
   notes: [
@@ -457,6 +464,13 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       default: '260',
     },
     {
+      name: 'variant',
+      type: "'wash' | 'surface' | 'section' | 'elevated'",
+      description:
+        "导航背景样式，控制导航区域与内容之间的对比。'wash' 使用 wash 背景，'surface' 使用 surface 背景，'section' 在导航和内容之间添加分隔线，'elevated' 使用 wash 导航配合凸起的 surface 内容区域和圆角。",
+      default: "'section'",
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -472,7 +486,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
   ],
   theming: {
     targets: [
-      {className: 'xds-app-shell', visualProps: ['background', 'height']},
+      {className: 'xds-app-shell', visualProps: ['variant', 'height']},
     ],
   },
   notes: [

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -98,6 +98,18 @@ export const docs = {
         'Imperative handle with focusTypeahead() and blurTypeahead() methods.',
     },
     {
+      name: 'endContent',
+      type: 'ReactNode',
+      description:
+        'Content to display at the end of the input row. Useful for action buttons or other controls.',
+    },
+    {
+      name: 'resultCount',
+      type: 'number | string',
+      description:
+        'Number of results matching the current filters. When a number, formatted as "N results". When a string, displayed as-is.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -144,6 +144,12 @@ export const docs = {
       description: 'Callback fired when the search query text changes.',
     },
     {
+      name: 'endContent',
+      type: 'ReactNode',
+      description:
+        'Content to display at the end of the input row. Useful for buttons, result counts, or other controls.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -360,6 +366,12 @@ export const docsZh = {
       name: 'onChangeQuery',
       type: '(query: string) => void',
       description: '搜索查询文本变更时触发的回调。',
+    },
+    {
+      name: 'endContent',
+      type: 'ReactNode',
+      description:
+        '在输入行末尾显示的内容。适用于按钮、结果计数或其他控件。',
     },
     {
       name: 'xstyle',


### PR DESCRIPTION
## What

Syncs component documentation with recent source changes from PRs #597 and #593.

### Fixes

**AppShell (from #597 — variant prop)**
- Theming `visualProps` updated from `['background', 'height']` to `['variant', 'height']` — the `background` prop was replaced with `variant` but the theming doc wasn't updated
- Added `variant` prop entry with type `'wash' | 'surface' | 'section' | 'elevated'` and description
- Updated both EN and ZH doc sections

**PowerSearch (from #593 — resultCount/endContent)**
- Added missing `endContent` and `resultCount` prop entries
- Renamed `XDSPowerSearch.doc.mjs` → `PowerSearch.doc.mjs` for CLI naming convention consistency (all other doc files use directory name, not component name). This was preventing the CLI from finding PowerSearch docs.

**Tokenizer (from #593 — endContent)**
- Added missing `endContent` prop entry (both EN and ZH)

## Validation
- `yarn workspace @xds/core typecheck:docs` ✅
- CLI `--brief` output verified for AppShell, PowerSearch, Tokenizer ✅
- Theming sync audit: all in sync ✅

---
*Found during Night Watch doc review.*