### PR TITLE
fix: remove isFullBleed prop from Card and Section

### DIFF
--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
     'Top-level container for elevated content',
     'Provides card-specific appearance: background, shadow, and border-radius',
     'Sets CSS variables for child layout components',
-    'Supports optional full-bleed mode to remove internal padding for edge-to-edge content',
+    'Supports `padding={0}` for edge-to-edge content',
     'Composable with XDSLayout, XDSCollapsible, and XDSCollapsibleGroup',
   ],
   props: [
@@ -101,7 +101,7 @@ export const docsZh = {
     '用于承载内容的顶层容器',
     '提供卡片特有的外观：背景、阴影和圆角',
     '为子布局组件设置 CSS 变量',
-    '支持可选的全出血模式，移除内边距以实现边到边内容',
+    '支持 `padding={0}` 实现边到边内容',
     '可与 XDSLayout、XDSCollapsible 和 XDSCollapsibleGroup 组合使用',
   ],
   props: [

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -106,13 +106,6 @@ export interface XDSCardProps extends XDSBaseProps {
   children?: ReactNode;
 
   /**
-   * Removes internal padding, allowing content to touch the edges.
-   * @deprecated Use `padding={0}` instead.
-   * @default false
-   */
-  isFullBleed?: boolean;
-
-  /**
    * Internal padding of the card using the spacing scale.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    * @default 4 (16px)
@@ -146,7 +139,6 @@ export function XDSCard({
   maxWidth,
   minHeight,
   children,
-  isFullBleed = false,
   padding,
   xstyle,
   className,
@@ -157,8 +149,7 @@ export function XDSCard({
   // Only enable scrolling when card has a fixed height (not null/undefined and not "auto")
   const hasFixedHeight = height != null && height !== 'auto';
 
-  // Resolve effective padding: isFullBleed maps to padding=0
-  const effectivePadding = isFullBleed ? 0 : (padding ?? 4);
+  const effectivePadding = padding ?? 4;
   const paddingToken = spacingStepToToken[effectivePadding] as SpacingToken;
 
   return (

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -9,7 +9,7 @@ export const docs = {
     'Automatically escapes parent container padding for edge-to-edge fills',
     'Supports divider borders on any combination of sides (top, bottom, start, end)',
     'Flexible sizing via SizeValue for width, height, maxWidth, and minHeight',
-    'Full-bleed mode removes internal padding for edge-to-edge content',
+    'Supports `padding={0}` for edge-to-edge content',
   ],
   examples: [
     {
@@ -102,7 +102,7 @@ export const docsZh = {
     '自动突破父容器内边距实现全宽填充',
     '支持在任意边的组合上设置分隔线边框（top、bottom、start、end）',
     '通过 SizeValue 灵活设置宽度、高度、最大宽度和最小高度',
-    '全出血模式移除内部内边距以实现全宽内容',
+    '支持 `padding={0}` 实现全宽内容',
   ],
   examples: [
     {

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -64,13 +64,6 @@ const nestedStyles = stylex.create({
     '--container-padding': '0px',
     height: '100%',
   },
-  // Full bleed: removes all internal padding
-  fullBleed: {
-    paddingInlineStart: 0,
-    paddingInlineEnd: 0,
-    paddingBlockStart: 0,
-    paddingBlockEnd: 0,
-  },
 });
 
 // Divider styles for each side
@@ -164,13 +157,6 @@ export interface XDSSectionProps {
   dividers?: Array<'top' | 'bottom' | 'start' | 'end'>;
 
   /**
-   * Removes internal padding, allowing content to touch the edges.
-   * @deprecated Use `padding={0}` instead.
-   * @default false
-   */
-  isFullBleed?: boolean;
-
-  /**
    * Internal padding of the section using the spacing scale.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
    * @default 4 (16px)
@@ -204,13 +190,11 @@ export function XDSSection({
   minHeight,
   children,
   dividers,
-  isFullBleed = false,
   padding,
   ref,
   ...props
 }: XDSSectionProps) {
-  // Resolve effective padding: isFullBleed maps to padding=0
-  const effectivePadding = isFullBleed ? 0 : (padding ?? 4);
+  const effectivePadding = padding ?? 4;
   const paddingToken = spacingStepToToken[effectivePadding] as SpacingToken;
   return (
     <div


### PR DESCRIPTION
## Summary

Remove the deprecated `isFullBleed` prop from `XDSCard` and `XDSSection`. Consumers should use `padding={0}` instead.

## Changes

- Remove `isFullBleed` from `XDSCardProps` interface and component body
- Remove `isFullBleed` from `XDSSectionProps` interface and component body
- Remove unused `fullBleed` style in Section's `nestedStyles`
- Simplify `effectivePadding` to `padding ?? 4` (no more ternary)
- Update doc features to reference `padding={0}` instead of "full-bleed mode"

## Not affected

- **`XDSDivider.isFullBleed`** — different concept (negative margin escape), evaluated separately per #599
- **Codemod** — `migrate-isFullBleed-to-padding` already exists in v0.0.2 transforms for consumers
- **CHANGELOG** — existing entries remain as historical references

## Test plan

- `yarn build` ✅
- `yarn test` — 90 files, 1433 tests passing ✅

Closes #599