### PR TITLE
feat(AppShell): add contentPadding prop

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
@@ -101,7 +101,11 @@ function ConfigPanel({
           <SelectorRow
             label="Variant"
             value={config.variant}
-            onChange={v => onChange({variant: v as 'wash' | 'surface' | 'section' | 'elevated'})}
+            onChange={v =>
+              onChange({
+                variant: v as 'wash' | 'surface' | 'section' | 'elevated',
+              })
+            }
             options={[
               {value: 'wash', label: 'Wash'},
               {value: 'surface', label: 'Surface'},
@@ -536,22 +540,21 @@ function SampleTopNav({config}: {config: ShellConfig}) {
 const styles = stylex.create({
   configOverlay: {
     position: 'fixed',
-    top: 16,
-    right: 16,
+    top: '16px',
+    right: '16px',
     width: 360,
     maxHeight: 'calc(100vh - 32px)',
     overflowY: 'auto',
-    zIndex: 1000,
+    zIndex: 10000,
   },
   content: {
-    padding: 24,
     maxWidth: 800,
   },
   toggleButton: {
     position: 'fixed',
-    bottom: 16,
-    right: 16,
-    zIndex: 1001,
+    bottom: '16px',
+    right: '16px',
+    zIndex: 10001,
   },
   padding4: {
     padding: 16,
@@ -597,6 +600,7 @@ export default function ShellLabPage() {
       <XDSAppShell
         variant={config.variant}
         height={config.height}
+        contentPadding={6}
         sideNavBreakpoint={config.sideNavBreakpoint}
         sideNavWidth={config.sideNavWidth}
         topNav={
@@ -617,47 +621,45 @@ export default function ShellLabPage() {
           ) : undefined
         }
         {...collapseProps}>
-        <div {...stylex.props(styles.content)}>
-          <XDSVStack gap={6}>
-            <XDSVStack gap={2}>
-              <XDSHeading level={1}>Shell Lab</XDSHeading>
-              <XDSText type="body" color="secondary">
-                Use the configuration panel to experiment with different shell
-                and navigation setups. Resize the browser to test responsive
-                behavior and collapse breakpoints.
-              </XDSText>
-            </XDSVStack>
+        <XDSVStack gap={6} xstyle={styles.content}>
+          <XDSVStack gap={2}>
+            <XDSHeading level={1}>Shell Lab</XDSHeading>
+            <XDSText type="body" color="secondary">
+              Use the configuration panel to experiment with different shell and
+              navigation setups. Resize the browser to test responsive behavior
+              and collapse breakpoints.
+            </XDSText>
+          </XDSVStack>
 
-            <XDSCard>
-              <XDSVStack gap={3} xstyle={styles.padding4}>
-                <XDSHeading level={3}>Active Config</XDSHeading>
-                <pre
-                  style={{
-                    fontSize: 12,
-                    overflow: 'auto',
-                    padding: 12,
-                    borderRadius: 8,
-                    background: 'var(--color-wash)',
-                  }}>
-                  {JSON.stringify(config, null, 2)}
-                </pre>
+          <XDSCard>
+            <XDSVStack gap={3} xstyle={styles.padding4}>
+              <XDSHeading level={3}>Active Config</XDSHeading>
+              <pre
+                style={{
+                  fontSize: 12,
+                  overflow: 'auto',
+                  padding: 12,
+                  borderRadius: 8,
+                  background: 'var(--color-wash)',
+                }}>
+                {JSON.stringify(config, null, 2)}
+              </pre>
+            </XDSVStack>
+          </XDSCard>
+
+          {Array.from({length: 10}, (_, i) => (
+            <XDSCard key={i}>
+              <XDSVStack gap={2} xstyle={styles.padding4}>
+                <XDSHeading level={4}>Content Block {i + 1}</XDSHeading>
+                <XDSText type="body" color="secondary">
+                  Sample content to test scroll behavior in fill vs auto height
+                  mode. The shell should handle overflow correctly regardless of
+                  content length.
+                </XDSText>
               </XDSVStack>
             </XDSCard>
-
-            {Array.from({length: 10}, (_, i) => (
-              <XDSCard key={i}>
-                <XDSVStack gap={2} xstyle={styles.padding4}>
-                  <XDSHeading level={4}>Content Block {i + 1}</XDSHeading>
-                  <XDSText type="body" color="secondary">
-                    Sample content to test scroll behavior in fill vs auto
-                    height mode. The shell should handle overflow correctly
-                    regardless of content length.
-                  </XDSText>
-                </XDSVStack>
-              </XDSCard>
-            ))}
-          </XDSVStack>
-        </div>
+          ))}
+        </XDSVStack>
       </XDSAppShell>
 
       {/* Floating config panel */}

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -17,7 +17,6 @@ import {
 } from '@xds/core/SideNav';
 import {useMediaQuery} from '@xds/core/hooks';
 import * as stylex from '@stylexjs/stylex';
-import {spacingVars} from '@xds/core/theme/tokens.stylex';
 import {
   HomeIcon,
   Cog6ToothIcon,
@@ -47,9 +46,6 @@ import {
 // =============================================================================
 
 const styles = stylex.create({
-  content: {
-    padding: spacingVars['--spacing-6'],
-  },
   longContent: {
     display: 'flex',
     flexDirection: 'column' as const,
@@ -63,7 +59,7 @@ const styles = stylex.create({
 
 function MockContent({paragraphs = 3}: {paragraphs?: number}) {
   return (
-    <div {...stylex.props(styles.content)}>
+    <>
       <XDSText type="large">Page Content</XDSText>
       <div {...stylex.props(styles.longContent)}>
         {Array.from({length: paragraphs}, (_, i) => (
@@ -74,7 +70,7 @@ function MockContent({paragraphs = 3}: {paragraphs?: number}) {
           </XDSText>
         ))}
       </div>
-    </div>
+    </>
   );
 }
 
@@ -303,6 +299,7 @@ export const Playground: StoryObj<
   }) {
     return (
       <XDSAppShell
+        contentPadding={6}
         topNav={args.showTopNav ? <AppTopNav /> : undefined}
         sideNav={
           args.showSideNav ? (
@@ -332,7 +329,10 @@ export const Playground: StoryObj<
  */
 export const TopNavWithSideNav: Story = {
   render: () => (
-    <XDSAppShell topNav={<AppTopNav />} sideNav={<SideNavWithoutHeader />}>
+    <XDSAppShell
+      contentPadding={6}
+      topNav={<AppTopNav />}
+      sideNav={<SideNavWithoutHeader />}>
       <MockContent />
     </XDSAppShell>
   ),
@@ -345,7 +345,7 @@ export const TopNavWithSideNav: Story = {
  */
 export const SideNavOnly: Story = {
   render: () => (
-    <XDSAppShell sideNav={<SideNavWithHeader />}>
+    <XDSAppShell contentPadding={6} sideNav={<SideNavWithHeader />}>
       <MockContent />
     </XDSAppShell>
   ),
@@ -357,7 +357,7 @@ export const SideNavOnly: Story = {
  */
 export const TopNavOnly: Story = {
   render: () => (
-    <XDSAppShell topNav={<AppTopNav />}>
+    <XDSAppShell contentPadding={6} topNav={<AppTopNav />}>
       <MockContent paragraphs={5} />
     </XDSAppShell>
   ),
@@ -374,6 +374,7 @@ export const TopNavOnly: Story = {
 export const FullFeatured: Story = {
   render: () => (
     <XDSAppShell
+      contentPadding={6}
       topNav={<AppTopNav />}
       sideNav={
         <XDSSideNav
@@ -476,6 +477,7 @@ export const FullFeatured: Story = {
 export const AutoHeight: Story = {
   render: () => (
     <XDSAppShell
+      contentPadding={6}
       topNav={<AppTopNav />}
       sideNav={<SideNavWithoutHeader />}
       height="auto">
@@ -496,6 +498,7 @@ export const ControlledCollapse: Story = {
     const [collapsed, setCollapsed] = useState(false);
     return (
       <XDSAppShell
+        contentPadding={6}
         topNav={
           <XDSTopNav
             label="Main navigation"
@@ -525,7 +528,7 @@ export const ControlledCollapse: Story = {
  */
 export const ContentOnly: Story = {
   render: () => (
-    <XDSAppShell>
+    <XDSAppShell contentPadding={6}>
       <MockContent paragraphs={5} />
     </XDSAppShell>
   ),
@@ -538,6 +541,7 @@ export const ContentOnly: Story = {
 export const WithBanner: Story = {
   render: () => (
     <XDSAppShell
+      contentPadding={6}
       topNav={<AppTopNav />}
       sideNav={<SideNavWithoutHeader />}
       banner={
@@ -618,6 +622,7 @@ export const WithMobileNav: Story = {
 
     return (
       <XDSAppShell
+        contentPadding={6}
         topNav={
           <XDSTopNav
             label="Main navigation"

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -113,6 +113,43 @@ export const docs = {
 </XDSAppShell>`,
     },
     {
+      label: 'Padded settings page (contentPadding={4})',
+      code: `<XDSAppShell
+  contentPadding={4}
+  topNav={<XDSTopNav label="App" heading={<XDSTopNavHeading heading="Settings" />} />}
+  sideNav={<XDSSideNav>...</XDSSideNav>}
+>
+  <XDSHeading level={1}>General</XDSHeading>
+  <XDSTextInput label="App Name" />
+</XDSAppShell>`,
+    },
+    {
+      label: 'Mostly padded with a full-bleed chart (contentPadding={4})',
+      code: `<XDSAppShell
+  contentPadding={4}
+  topNav={<XDSTopNav label="App" heading={<XDSTopNavHeading heading="Dashboard" />} />}
+>
+  <XDSHeading level={1}>Overview</XDSHeading>
+  <XDSSection padding={0}>
+    <FullWidthChart />
+  </XDSSection>
+  <XDSCard>Details</XDSCard>
+</XDSAppShell>`,
+    },
+    {
+      label: 'Mostly full-bleed with padded details (contentPadding={0})',
+      code: `<XDSAppShell
+  contentPadding={0}
+  topNav={<XDSTopNav label="App" heading={<XDSTopNavHeading heading="Player" />} />}
+>
+  <FullWidthVideoPlayer />
+  <XDSSection padding={4}>
+    <XDSHeading level={1}>Video Title</XDSHeading>
+    <XDSText>Video description</XDSText>
+  </XDSSection>
+</XDSAppShell>`,
+    },
+    {
       label: 'Responsive: SideNav + MobileNav',
       code: `const [mobileOpen, setMobileOpen] = useState(false);
 const isMobile = useMediaQuery('(max-width: 768px)');
@@ -154,6 +191,13 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       name: 'children',
       type: 'ReactNode',
       description: 'Main content area, rendered inside a <main> element.',
+    },
+    {
+      name: 'contentPadding',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description:
+        'Padding for the main content area. Set based on the dominant content pattern: 4 (16px) for forms/settings/text, 0 for dashboards/maps/tables. Override individual sections with XDSSection.',
+      default: '0',
     },
     {
       name: 'topNav',
@@ -404,6 +448,13 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       name: 'children',
       type: 'ReactNode',
       description: '主内容区域，渲染在 <main> 元素内部。',
+    },
+    {
+      name: 'contentPadding',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+      description:
+        '主内容区域的内边距。根据页面主要内容模式设置：4（16px）适用于表单/设置/文本页面，0 适用于仪表盘/地图/表格。可通过 XDSSection 覆盖个别区域。',
+      default: '0',
     },
     {
       name: 'topNav',

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -546,6 +546,40 @@ describe('XDSAppShell', () => {
   });
 
   // ===========================================================================
+  // Content padding
+  // ===========================================================================
+
+  it('passes contentPadding to main content area', () => {
+    render(
+      <XDSAppShell contentPadding={4} data-testid="shell">
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+    // Main content should render — contentPadding is passed through
+    expect(screen.getByRole('main')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('defaults to contentPadding={0} when not specified', () => {
+    render(
+      <XDSAppShell data-testid="shell">
+        <div>Content</div>
+      </XDSAppShell>,
+    );
+    // Should render without error — padding=0 is the default
+    expect(screen.getByRole('main')).toBeInTheDocument();
+  });
+
+  it('supports contentPadding={0} for full-bleed content', () => {
+    render(
+      <XDSAppShell contentPadding={0} data-testid="shell">
+        <div>Full bleed content</div>
+      </XDSAppShell>,
+    );
+    expect(screen.getByText('Full bleed content')).toBeInTheDocument();
+  });
+
+  // ===========================================================================
   // Ref forwarding
   // ===========================================================================
 

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -29,6 +29,7 @@ import {XDSLayoutHeader} from '../Layout/XDSLayoutHeader';
 import {XDSLayoutPanel} from '../Layout/XDSLayoutPanel';
 import {XDSLayoutContent} from '../Layout/XDSLayoutContent';
 import {XDSMobileNav} from '../MobileNav/XDSMobileNav';
+import type {SpacingStep} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -92,6 +93,16 @@ export interface XDSAppShellProps {
    * Main content area (rendered as `<main>`).
    */
   children: ReactNode;
+
+  /**
+   * Padding for the main content area using the spacing scale.
+   * Set based on the dominant content pattern for the page:
+   * - `4` (16px) — standard padding for forms, settings, text-heavy pages
+   * - `0` — no padding, for dashboards, maps, tables that need edge-to-edge
+   * Override individual sections with `<XDSSection padding={...}>`.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   */
+  contentPadding?: SpacingStep;
 
   /**
    * Test ID for the root element.
@@ -344,6 +355,7 @@ export function XDSAppShell({
   variant = 'section',
   banner,
   children,
+  contentPadding,
   'data-testid': dataTestId,
   height = 'fill',
   defaultIsSideNavCollapsed = false,
@@ -551,7 +563,7 @@ export function XDSAppShell({
 
   const mainInner = (
     <XDSLayoutContent
-      padding={0}
+      padding={contentPadding ?? 0}
       role="main"
       id={MAIN_CONTENT_ID}
       isScrollable={isFill}


### PR DESCRIPTION
## Summary

Adds a `contentPadding` prop to `XDSAppShell` that controls the main content area padding.

## Motivation

Ran an [ad-hoc vibe test](https://github.com/facebookexperimental/xds/issues/565#issuecomment-4058077415) comparing three padding mental models (10 prompts × 3 approaches = 30 tests). `contentPadding` won on mixed layouts — the hard case — with the fewest total decisions (15 vs 16 for no-default-padding vs 19 for default-padding).

Key insight: the LLM correctly picks `contentPadding={4}` for mostly-padded pages and `contentPadding={0}` for mostly-bleed pages, then overrides only the exceptions with `XDSSection`.

## API

```tsx
// Padded settings page
<XDSAppShell contentPadding={4} topNav={...}>
  <XDSHeading level={1}>Settings</XDSHeading>
  <XDSTextInput label="Name" />
</XDSAppShell>

// Mostly padded with a full-bleed chart
<XDSAppShell contentPadding={4} topNav={...}>
  <XDSHeading level={1}>Dashboard</XDSHeading>
  <XDSSection padding={0}>
    <FullWidthChart />
  </XDSSection>
  <XDSCard>Details</XDSCard>
</XDSAppShell>

// Mostly full-bleed with padded details
<XDSAppShell contentPadding={0} topNav={...}>
  <FullWidthVideoPlayer />
  <XDSSection padding={4}>
    <XDSHeading level={1}>Video Title</XDSHeading>
  </XDSSection>
</XDSAppShell>
```

## Changes

- Add `contentPadding?: SpacingStep` to `XDSAppShellProps`
- Pass through to `XDSLayoutContent padding` (defaults to 0 for backward compat)
- Add 3 doc examples showing both directions (padded default + full-bleed override, and vice versa)
- Add 3 tests for contentPadding behavior
- Update English + Chinese docs

## Test plan

- `yarn build` ✅
- `yarn test` — 90 files, 1436 tests passing ✅

Ref #565