### PR TITLE
feat(cli): rework xds component into subcommands

### DIFF
--- a/.claude/skills/writing-component-docs.md
+++ b/.claude/skills/writing-component-docs.md
@@ -108,11 +108,16 @@ The CLI merges this onto `docs`: compressed descriptions replace English ones, b
 ## CLI Flags
 
 ```bash
-npx xds component Button              # English docs (default)
-npx xds component Button --compact    # Token-optimized format
-npx xds component Button --brief      # Minimal one-line summary
-npx xds --lang zh component Button    # Chinese prose, same structure
-npx xds --lang dense component Button # Compressed prose, same structure
+npx xds component metadata Button             # description, features, notes, a11y
+npx xds component metadata Button --detail brief  # just the description
+npx xds component props Button                # full props table
+npx xds component props Button --detail brief # name: type per line
+npx xds component examples Button             # list example titles
+npx xds component example Button 3            # one example's code
+npx xds component list                        # all components by category
+npx xds component search "date"               # find by name or description
+npx xds --lang zh component metadata Button   # Chinese prose
+npx xds --lang dense component props Button   # Compressed prose
 ```
 
-`--lang` controls which prose translation is used. `--compact`, `--brief`, `--full` control how much detail. They compose independently.
+`--lang` controls which prose translation is used. `--detail brief` gives condensed output. They compose independently.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,9 @@ Look for `<!-- SYNC: ... -->` comments and `SYNC:` in file headers as reminders.
 <!-- XDS:START -->
 
 [XDS v0.0.3]|IMPORTANT: Prefer retrieval-led reasoning. Run CLI to read docs before generating code.
-|npx xds component <Name> --compact|--source Docs (props, usage) or source code
-|npx xds component --list All components by category
+|npx xds component metadata <Name> Docs (description, features, notes, a11y)
+|npx xds component props <Name> Props table
+|npx xds component list All components by category
 |npx xds docs principles Design rules, anti-patterns, StyleX patterns
 |npx xds docs tokens Token reference (spacing, color, radius, type)
 |npx xds docs theme Theme system: XDSTheme, custom themes, overrides, nesting

--- a/internal/vibe-tests/.generated/xds-tailwind-skill.md
+++ b/internal/vibe-tests/.generated/xds-tailwind-skill.md
@@ -29,9 +29,10 @@ import {XDSButton} from '@xds/core/Button';
 
 Run these commands to get detailed docs on any component:
 
-- `npx xds component <Name>` — full docs (props, usage, examples)
-- `npx xds component <Name> --compact` — condensed reference
-- `npx xds component --list` — all components by category
+- `npx xds component metadata <Name>` — description, features, notes, a11y
+- `npx xds component props <Name>` — props table
+- `npx xds component list` — all components by category
+- `npx xds component catalog` — brief summaries of all components
 - `npx xds docs tokens` — token reference (spacing, color, radius)
 - `npx xds docs theme` — theme system reference
 
@@ -68,7 +69,7 @@ Use Tailwind utilities for:
 
 ## Component Catalog
 
-Brief summaries of all available components. Run `npx xds component <Name>` for full docs.
+Brief summaries of all available components. Run `npx xds component metadata <Name>` for full docs.
 
 ### Layout
 

--- a/internal/vibe-tests/AGENTS.xds-tailwind.md
+++ b/internal/vibe-tests/AGENTS.xds-tailwind.md
@@ -5,8 +5,9 @@ Project-specific guidance for AI coding agents.
 <!-- XDS-TAILWIND:START -->
 
 [XDS + Tailwind v0.0.1]|IMPORTANT: Prefer retrieval-led reasoning. Run CLI to read docs before generating code.
-|npx xds component <Name> --compact Docs (props, usage)
-|npx xds component --list All components by category
+|npx xds component metadata <Name> Docs (description, features, notes, a11y)
+|npx xds component props <Name> Props table
+|npx xds component list All components by category
 |npx xds docs tokens Token reference (spacing, color, radius)
 |npx xds docs theme Theme system: XDSTheme, custom themes, overrides, nesting
 |RULE: Use XDS components for structure, behavior, and accessibility.

--- a/internal/vibe-tests/scripts/generate-skill-doc.sh
+++ b/internal/vibe-tests/scripts/generate-skill-doc.sh
@@ -3,8 +3,7 @@
 # @position internal/vibe-tests/scripts/generate-skill-doc.sh
 #
 # Generates a skill doc by combining CLI outputs:
-#   - agent-docs framing (AGENTS.md index)
-#   - component --brief-all (component catalog)
+#   - component list (component catalog with brief summaries)
 #   - docs principles (design rules)
 #   - docs tokens (token reference)
 #   - docs theme (theme system)
@@ -19,9 +18,6 @@ REPO_ROOT="$(cd "$VIBE_DIR/../.." && pwd)"
 CLI="$REPO_ROOT/packages/cli/bin/xds.mjs"
 OUT_DIR="$VIBE_DIR/.generated"
 OUT_FILE="$OUT_DIR/xds-skill.md"
-
-# No CLI rebuild needed — the CLI uses raw .mjs files and discovers
-# components by scanning packages/core/src/ directly via readdirSync.
 
 mkdir -p "$OUT_DIR"
 
@@ -38,9 +34,12 @@ React design system for building internal tools. All components use the `XDS` pr
 ## CLI Reference
 
 Run these commands to get detailed docs on any component:
-- `npx xds component <Name>` — full docs (props, usage, examples)
-- `npx xds component <Name> --compact` — condensed reference
-- `npx xds component --list` — all components by category
+- `npx xds component metadata <Name>` — description, features, notes, a11y
+- `npx xds component props <Name>` — props table
+- `npx xds component examples <Name>` — list example titles
+- `npx xds component example <Name> N` — get example code
+- `npx xds component list` — all components by category
+- `npx xds component search "<query>"` — find by name or description
 - `npx xds docs principles` — design rules and anti-patterns
 - `npx xds docs tokens` — token reference (spacing, color, radius)
 - `npx xds docs theme` — theme system reference
@@ -53,12 +52,12 @@ echo "" >> "$OUT_FILE"
 node "$CLI" docs principles 2>/dev/null | tail -n +3 >> "$OUT_FILE"
 echo "" >> "$OUT_FILE"
 
-# Component catalog
+# Component catalog (brief summaries)
 echo "## Component Catalog" >> "$OUT_FILE"
 echo "" >> "$OUT_FILE"
-echo "Brief summaries of all available components. Run \`npx xds component <Name>\` for full docs." >> "$OUT_FILE"
+echo "Brief summaries of all available components. Run \`npx xds component metadata <Name>\` for full docs." >> "$OUT_FILE"
 echo "" >> "$OUT_FILE"
-node "$CLI" component --brief-all 2>/dev/null >> "$OUT_FILE"
+node "$CLI" component catalog 2>/dev/null >> "$OUT_FILE"
 echo "" >> "$OUT_FILE"
 
 # Tokens

--- a/packages/cli/docs/theme.md
+++ b/packages/cli/docs/theme.md
@@ -254,7 +254,7 @@ export const myTheme: Theme = {
 | Text      | `text`    | `styles` (body, large, label, supporting, code)                            | Font, size, weight, color per type     |
 | Prose     | `prose`   | `base`, `styles` (p, ul, ol, li, blockquote, code, pre, hr, strong, em, a) | Prose element styling                  |
 
-Run `npx xds component <Name> --compact` to see a component's themeable slots.
+Run `npx xds component metadata <Name>` to see a component's themeable slots.
 
 ### The `as Theme['components']` cast
 

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -26,8 +26,10 @@ export function generateCompressedIndex(version, {zh = false, lang} = {}) {
   // For now, zh mode outputs the same English content as a placeholder
   return `${XDS_MARKER_START}
 [XDS v${version}]|IMPORTANT: Prefer retrieval-led reasoning. Run CLI to read docs before generating code.
-|npx xds component <Name> --compact|--source   Docs (props, usage) or source code
-|npx xds component --list             All components by category
+|npx xds component metadata <Name>    Docs (description, features, notes, a11y)
+|npx xds component props <Name>       Props table
+|npx xds component list               All components by category
+|npx xds component search "<query>"   Find components by name or description
 |npx xds docs principles              Design rules, anti-patterns, StyleX patterns
 |npx xds docs tokens                  Token reference (spacing, color, radius, type)
 |npx xds docs theme                   Theme system: XDSTheme, custom themes, overrides, nesting
@@ -238,7 +240,7 @@ export function registerAgentDocs(program) {
 
 Your AI coding agent will now:
   • See the XDS component index in ${targets.join(' and ')}
-  • Run \`npx xds component <name>\` to read detailed docs
+  • Run \`npx xds component metadata <name>\` to read detailed docs
   • Run \`npx xds docs principles\` for design principles
   • Run \`npx xds docs tokens\` for design token reference
   • Follow XDS patterns and avoid anti-patterns

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -1,5 +1,5 @@
 /**
- * @file component command — List components and print component docs
+ * @file component command — XDS component documentation
  *
  * Subcommands: list, search, metadata, props, examples, example, source
  * Global options: --detail brief|normal, --lang en|zh|dense
@@ -26,156 +26,388 @@ import {
   cleanReadme,
   extractCompact,
   extractBrief,
-  extractBriefAll,
-  ensureImportStatement,
   extractProps,
 } from '../../lib/component-legacy.mjs';
 import {findClosestComponents} from '../../lib/string-utils.mjs';
 
-export function registerComponent(program) {
-  program
-    .command('component [name]')
-    .description('List components or print component docs')
-    .option('--list', 'List all components grouped by category')
-    .option('--category <category>', 'List components in a specific category')
-    .option('--compact', 'Token-optimized output for LLMs')
-    .option('--brief', 'Minimal LLM output: signature + props + one example (~200 chars)')
-    .option('--brief-all', 'Brief summaries of ALL components in one output')
-    .option('--props', 'Print only the props table')
-    .option('--source', 'Print component source code')
-    .action(async (name, options) => {
-      const coreDir = findCoreDir(process.cwd());
-      const zh = program.opts().zh || false;
-      const dense = program.opts().dense || false;
-      const lang = program.opts().lang || null;
+/**
+ * Resolve a component name to its doc path, with fuzzy matching.
+ * Exits with an error if not found.
+ */
+function resolveComponent(coreDir, name) {
+  const dirName = name.replace(/^XDS/, '');
+  let readmePath = findComponentReadme(coreDir, dirName);
+  let resolvedName = dirName;
 
-      if (!coreDir) {
-        console.error(
-          'Error: Could not find @xds/core package.\n' +
-            'Make sure you are inside the XDS monorepo or have @xds/core installed.',
+  if (!readmePath) {
+    const components = discoverComponents(coreDir);
+    const closest = findClosestComponents(dirName, components);
+
+    if (closest.length === 1) {
+      resolvedName = closest[0].name;
+      readmePath = findComponentReadme(coreDir, resolvedName);
+      if (readmePath) {
+        console.error(`Did you mean ${resolvedName}?\n`);
+      }
+    } else if (closest.length > 1) {
+      console.error(`Component "${name}" not found. Did you mean one of these?\n`);
+      for (const match of closest) {
+        console.error(`  ${match.name}`);
+      }
+      console.error('');
+      process.exit(1);
+    }
+
+    if (!readmePath) {
+      console.error(`Error: Component "${name}" not found.`);
+      console.error('Run \`npx xds component list\` to see available components.');
+      process.exit(1);
+    }
+  }
+
+  return {readmePath, resolvedName};
+}
+
+/**
+ * Get coreDir or exit with error.
+ */
+function requireCoreDir() {
+  const coreDir = findCoreDir(process.cwd());
+  if (!coreDir) {
+    console.error(
+      'Error: Could not find @xds/core package.\n' +
+        'Make sure you are inside the XDS monorepo or have @xds/core installed.',
+    );
+    process.exit(1);
+  }
+  return coreDir;
+}
+
+/**
+ * Get lang options from the root program.
+ */
+function getLangOpts(program) {
+  const opts = program.opts();
+  return {
+    zh: opts.zh || false,
+    dense: opts.dense || false,
+    lang: opts.lang || null,
+  };
+}
+
+export function registerComponent(program) {
+  const component = program
+    .command('component')
+    .description('XDS component documentation');
+
+  // --- list ---
+  component
+    .command('list')
+    .description('List all components grouped by category')
+    .option('--category <category>', 'Filter to a specific category')
+    .option('--detail <level>', 'Output detail level: brief or normal', 'normal')
+    .action((options) => {
+      const coreDir = requireCoreDir();
+      const components = discoverComponents(coreDir);
+
+      if (options.category) {
+        const cat = options.category;
+        const match = Object.entries(components).find(
+          ([key]) => key.toLowerCase() === cat.toLowerCase(),
         );
+        if (!match) {
+          console.error(`Error: Unknown category "${cat}".`);
+          console.error(
+            `Available categories: ${Object.keys(components).join(', ')}`,
+          );
+          process.exit(1);
+        }
+        console.log(`\n${match[0]}:`);
+        for (const comp of match[1]) {
+          console.log(`  ${comp}`);
+        }
+        console.log('');
+        return;
+      }
+
+      if (options.detail === 'brief') {
+        // Just names, no categories
+        const all = Object.values(components).flat();
+        for (const comp of all) {
+          console.log(comp);
+        }
+        return;
+      }
+
+      console.log('');
+      for (const [category, comps] of Object.entries(components)) {
+        console.log(`${category}:`);
+        for (const comp of comps) {
+          console.log(`  ${comp}`);
+        }
+        console.log('');
+      }
+    });
+
+  // --- search ---
+  component
+    .command('search <query>')
+    .description('Search components by name or description')
+    .option('--detail <level>', 'Output detail level: brief or normal', 'normal')
+    .action(async (query, options) => {
+      const coreDir = requireCoreDir();
+      const langOpts = getLangOpts(program);
+      const components = discoverComponents(coreDir);
+      const allComps = Object.values(components).flat();
+      const q = query.toLowerCase();
+
+      const matches = [];
+
+      for (const comp of allComps) {
+        const nameMatch = comp.toLowerCase().includes(q);
+        let descMatch = false;
+        let description = '';
+
+        if (!nameMatch || options.detail === 'normal') {
+          const readmePath = findComponentReadme(coreDir, comp);
+          if (readmePath && readmePath.endsWith('.doc.mjs')) {
+            try {
+              const docs = await loadDocs(readmePath, langOpts);
+              description = docs.description || '';
+              descMatch = description.toLowerCase().includes(q);
+            } catch (e) {}
+          }
+        }
+
+        if (nameMatch || descMatch) {
+          matches.push({name: comp, description});
+        }
+      }
+
+      if (matches.length === 0) {
+        console.error(`No components matching "${query}".`);
         process.exit(1);
       }
 
-      if (options.briefAll) {
-        console.log(await formatBriefAll(coreDir, {zh, lang}));
-        return;
-      }
-
-      if (options.category || options.list || !name) {
-        const components = discoverComponents(coreDir);
-
-        if (options.category) {
-          const cat = options.category;
-          const match = Object.entries(components).find(
-            ([key]) => key.toLowerCase() === cat.toLowerCase(),
-          );
-          if (!match) {
-            console.error(`Error: Unknown category "${cat}".`);
-            console.error(
-              `Available categories: ${Object.keys(components).join(', ')}`,
-            );
-            process.exit(1);
-          }
-          console.log(`\n${match[0]}:`);
-          for (const comp of match[1]) {
-            console.log(`  ${comp}`);
-          }
-          console.log('');
-          return;
-        }
-
-        console.log('');
-        for (const [category, comps] of Object.entries(components)) {
-          console.log(`${category}:`);
-          for (const comp of comps) {
-            console.log(`  ${comp}`);
-          }
-          console.log('');
-        }
-        console.log('Usage: npx xds component <name>');
-        console.log('');
-        return;
-      }
-
-      // Normalize: strip XDS prefix for directory lookup
-      const dirName = name.replace(/^XDS/, '');
-
-      if (options.source) {
-        const sourcePath = findComponentSource(coreDir, dirName);
-        if (!sourcePath) {
-          console.error(`Error: Source for "${name}" not found.`);
-          process.exit(1);
-        }
-        const source = fs.readFileSync(sourcePath, 'utf-8');
-        console.log(source);
-        return;
-      }
-
-      let readmePath = findComponentReadme(coreDir, dirName);
-      let resolvedName = dirName;
-
-      if (!readmePath) {
-        // Try fuzzy matching
-        const components = discoverComponents(coreDir);
-        const closest = findClosestComponents(dirName, components);
-
-        if (closest.length === 1) {
-          resolvedName = closest[0].name;
-          readmePath = findComponentReadme(coreDir, resolvedName);
-          if (readmePath) {
-            console.log(`Did you mean ${resolvedName}?\n`);
-          }
-        } else if (closest.length > 1) {
-          console.error(`Component "${name}" not found. Did you mean one of these?\n`);
-          for (const match of closest) {
-            console.error(`  ${match.name}`);
-          }
-          console.error('');
-          process.exit(1);
-        }
-
-        if (!readmePath) {
-          console.error(`Error: Component "${name}" not found.`);
-          console.error('Run `npx xds component --list` to see available components.');
-          process.exit(1);
-        }
-      }
-
-      if (readmePath.endsWith('.doc.mjs')) {
-        const docs = await loadDocs(readmePath, {zh, dense, lang});
-        const importHint = resolveImportPath(coreDir, resolvedName);
-        if (options.props) {
-          console.log(formatProps(docs, resolvedName));
-        } else if (options.brief) {
-          console.log(formatBrief(docs, resolvedName, importHint));
-        } else if (options.compact) {
-          console.log(formatCompact(docs, resolvedName, importHint));
+      for (const m of matches) {
+        if (options.detail === 'brief') {
+          console.log(m.name);
         } else {
-          console.log(formatFull(docs));
-        }
-      } else {
-        // Legacy path for README.md files
-        const content = fs.readFileSync(readmePath, 'utf-8');
-        if (options.props) {
-          console.log(extractProps(content, resolvedName));
-        } else if (options.brief) {
-          console.log(extractBrief(content, resolvedName));
-        } else if (options.compact) {
-          const compact = extractCompact(content, resolvedName);
-          console.log(ensureImportStatement(compact, resolvedName, coreDir));
-        } else {
-          console.log(cleanReadme(content, resolvedName));
+          console.log(`${m.name}${m.description ? ' — ' + m.description : ''}`);
         }
       }
     });
+
+  // --- metadata ---
+  component
+    .command('metadata <name>')
+    .description('Get component description, features, notes, accessibility, keyboard')
+    .option('--detail <level>', 'Output detail level: brief or normal', 'normal')
+    .action(async (name, options) => {
+      const coreDir = requireCoreDir();
+      const langOpts = getLangOpts(program);
+      const {readmePath, resolvedName} = resolveComponent(coreDir, name);
+
+      if (readmePath.endsWith('.doc.mjs')) {
+        const docs = await loadDocs(readmePath, langOpts);
+
+        if (options.detail === 'brief') {
+          console.log(`${resolvedName}: ${docs.description || ''}`);
+          return;
+        }
+
+        // Normal: full metadata (description, features, notes, a11y, keyboard, theming)
+        // but NOT props or examples
+        const lines = [];
+        lines.push(`# ${resolvedName}\n`);
+        lines.push(docs.description || '');
+        lines.push('');
+
+        if (docs.features && docs.features.length > 0) {
+          lines.push('## Features\n');
+          for (const f of docs.features) {
+            lines.push(`- ${f}`);
+          }
+          lines.push('');
+        }
+
+        if (docs.accessibility && docs.accessibility.length > 0) {
+          lines.push('## Accessibility\n');
+          for (const a of docs.accessibility) {
+            lines.push(`- ${a}`);
+          }
+          lines.push('');
+        }
+
+        if (docs.keyboard) {
+          lines.push('## Keyboard\n');
+          lines.push(docs.keyboard);
+          lines.push('');
+        }
+
+        if (docs.notes && docs.notes.length > 0) {
+          lines.push('## Notes\n');
+          for (const n of docs.notes) {
+            lines.push(`- ${n}`);
+          }
+          lines.push('');
+        }
+
+        if (docs.theming && docs.theming.targets) {
+          lines.push('## Theming\n');
+          for (const t of docs.theming.targets) {
+            const vp = t.visualProps ? ` (${t.visualProps.join(', ')})` : '';
+            lines.push(`- \`.${t.className}\`${vp}`);
+          }
+          lines.push('');
+        }
+
+        console.log(lines.join('\n'));
+      } else {
+        // Legacy: just dump the cleaned readme
+        const content = fs.readFileSync(readmePath, 'utf-8');
+        console.log(cleanReadme(content, resolvedName));
+      }
+    });
+
+  // --- props ---
+  component
+    .command('props <name>')
+    .description('List props for a component')
+    .option('--detail <level>', 'Output detail level: brief or normal', 'normal')
+    .action(async (name, options) => {
+      const coreDir = requireCoreDir();
+      const langOpts = getLangOpts(program);
+      const {readmePath, resolvedName} = resolveComponent(coreDir, name);
+
+      if (readmePath.endsWith('.doc.mjs')) {
+        const docs = await loadDocs(readmePath, langOpts);
+
+        if (options.detail === 'brief') {
+          // Just prop names and types, one per line
+          const props = docs.props || (docs.components ? docs.components.flatMap(c => c.props || []) : []);
+          for (const p of props) {
+            const req = p.required ? ' (required)' : '';
+            const def = p.default ? ` = ${p.default}` : '';
+            console.log(`${p.name}: ${p.type}${def}${req}`);
+          }
+          return;
+        }
+
+        console.log(formatProps(docs, resolvedName));
+      } else {
+        const content = fs.readFileSync(readmePath, 'utf-8');
+        console.log(extractProps(content, resolvedName));
+      }
+    });
+
+  // --- examples ---
+  component
+    .command('examples <name>')
+    .description('List example titles for a component')
+    .action(async (name) => {
+      const coreDir = requireCoreDir();
+      const {readmePath, resolvedName} = resolveComponent(coreDir, name);
+
+      if (!readmePath.endsWith('.doc.mjs')) {
+        console.error('Examples listing only available for .doc.mjs components.');
+        process.exit(1);
+      }
+
+      const docs = await loadDocs(readmePath, {});
+      const examples = docs.examples || [];
+
+      // Also gather sub-component examples
+      const subExamples = [];
+      if (docs.components) {
+        for (const comp of docs.components) {
+          if (comp.examples) {
+            for (const ex of comp.examples) {
+              subExamples.push({...ex, component: comp.name});
+            }
+          }
+        }
+      }
+
+      let num = 1;
+      if (examples.length > 0) {
+        for (const ex of examples) {
+          console.log(`${num}. ${ex.label || '(untitled)'}`);
+          num++;
+        }
+      }
+      if (subExamples.length > 0) {
+        for (const ex of subExamples) {
+          console.log(`${num}. [${ex.component}] ${ex.label || '(untitled)'}`);
+          num++;
+        }
+      }
+
+      if (num === 1) {
+        console.log('No examples found.');
+      }
+    });
+
+  // --- example ---
+  component
+    .command('example <name> [num]')
+    .description('Show code for a specific example (use examples command to see numbers)')
+    .action(async (name, num) => {
+      const coreDir = requireCoreDir();
+      const {readmePath, resolvedName} = resolveComponent(coreDir, name);
+
+      if (!readmePath.endsWith('.doc.mjs')) {
+        console.error('Example lookup only available for .doc.mjs components.');
+        process.exit(1);
+      }
+
+      const docs = await loadDocs(readmePath, {});
+
+      // Build flat list of all examples
+      const allExamples = [...(docs.examples || [])];
+      if (docs.components) {
+        for (const comp of docs.components) {
+          if (comp.examples) {
+            for (const ex of comp.examples) {
+              allExamples.push({...ex, component: comp.name});
+            }
+          }
+        }
+      }
+
+      const idx = num ? parseInt(num, 10) - 1 : 0;
+      if (idx < 0 || idx >= allExamples.length) {
+        console.error(`Example ${num || 1} not found. ${resolvedName} has ${allExamples.length} examples.`);
+        console.error(`Run \`npx xds component examples ${resolvedName}\` to see them.`);
+        process.exit(1);
+      }
+
+      const ex = allExamples[idx];
+      if (ex.label) {
+        console.log(`// ${ex.component ? ex.component + ': ' : ''}${ex.label}`);
+      }
+      console.log(ex.code);
+    });
+
+  // --- source ---
+  component
+    .command('source <name>')
+    .description('Print component source code')
+    .action((name) => {
+      const coreDir = requireCoreDir();
+      const dirName = name.replace(/^XDS/, '');
+      const sourcePath = findComponentSource(coreDir, dirName);
+      if (!sourcePath) {
+        console.error(`Error: Source for "${name}" not found.`);
+        process.exit(1);
+      }
+      console.log(fs.readFileSync(sourcePath, 'utf-8'));
+    });
 }
 
-
 // Re-export lib functions for backward compatibility
-// (agent-docs.mjs, tests, and generate-skill-doc.sh import from here)
 export {discoverComponents, findComponentReadme, findComponentSource, resolveImportPath} from '../../lib/component-discovery.mjs';
 export {loadDocs} from '../../lib/component-loader.mjs';
 export {formatFull, formatCompact, formatBrief, formatProps, formatBriefAll} from '../../lib/component-format.mjs';
-export {cleanReadme, extractCompact, extractBrief, extractBriefAll, ensureImportStatement, extractProps} from '../../lib/component-legacy.mjs';
+export {cleanReadme, extractCompact, extractBrief, extractProps} from '../../lib/component-legacy.mjs';
 export {levenshteinDistance, findClosestComponents} from '../../lib/string-utils.mjs';

--- a/packages/cli/src/commands/component/index.mjs
+++ b/packages/cli/src/commands/component/index.mjs
@@ -98,14 +98,15 @@ function getLangOpts(program) {
 export function registerComponent(program) {
   const component = program
     .command('component')
-    .description('XDS component documentation');
+    .description('XDS component documentation')
+    ;
 
   // --- list ---
   component
     .command('list')
     .description('List all components grouped by category')
     .option('--category <category>', 'Filter to a specific category')
-    .option('--detail <level>', 'Output detail level: brief or normal', 'normal')
+    .option('--detail <level>', 'Output detail: brief (names only) or normal (by category)', 'normal')
     .action((options) => {
       const coreDir = requireCoreDir();
       const components = discoverComponents(coreDir);
@@ -131,7 +132,6 @@ export function registerComponent(program) {
       }
 
       if (options.detail === 'brief') {
-        // Just names, no categories
         const all = Object.values(components).flat();
         for (const comp of all) {
           console.log(comp);
@@ -149,11 +149,20 @@ export function registerComponent(program) {
       }
     });
 
+  // --- catalog ---
+  component
+    .command('catalog')
+    .description('Brief summaries of all components (name, description, key props, one example)')
+    .action(async () => {
+      const coreDir = requireCoreDir();
+      const langOpts = getLangOpts(program);
+      console.log(await formatBriefAll(coreDir, langOpts));
+    });
+
   // --- search ---
   component
     .command('search <query>')
     .description('Search components by name or description')
-    .option('--detail <level>', 'Output detail level: brief or normal', 'normal')
     .action(async (query, options) => {
       const coreDir = requireCoreDir();
       const langOpts = getLangOpts(program);
@@ -202,7 +211,6 @@ export function registerComponent(program) {
   component
     .command('metadata <name>')
     .description('Get component description, features, notes, accessibility, keyboard')
-    .option('--detail <level>', 'Output detail level: brief or normal', 'normal')
     .action(async (name, options) => {
       const coreDir = requireCoreDir();
       const langOpts = getLangOpts(program);
@@ -274,7 +282,6 @@ export function registerComponent(program) {
   component
     .command('props <name>')
     .description('List props for a component')
-    .option('--detail <level>', 'Output detail level: brief or normal', 'normal')
     .action(async (name, options) => {
       const coreDir = requireCoreDir();
       const langOpts = getLangOpts(program);

--- a/packages/cli/src/commands/theme.mjs
+++ b/packages/cli/src/commands/theme.mjs
@@ -220,7 +220,7 @@ function generateThemeFile({name, exportName, colors, includeComponentOverrides,
 // Each component reads its overrides from theme.components.<name>.
 //
 // To discover what's themeable for a component, run:
-//   npx xds component <Name> --compact
+//   npx xds component metadata <Name>
 // and look for the "Theme Overrides" section.
 
 // --- Button ---

--- a/packages/core/xds.md
+++ b/packages/core/xds.md
@@ -7,10 +7,11 @@ XDS is a design system for building internal tools and products.
 Use the XDS CLI for component docs, scaffolding, and tooling:
 
 ```bash
-npx xds component --list          # browse all components by category
-npx xds component Button          # full docs for a component
-npx xds component --brief-all     # LLM-optimized summary of all components
-npx xds docs                      # principles and tokens reference
+npx xds component list                # browse all components by category
+npx xds component metadata Button     # description, features, notes for a component
+npx xds component props Button        # props table
+npx xds component list --detail summary  # brief summary of all components
+npx xds docs                          # principles and tokens reference
 ```
 
 ### For AI-assisted development


### PR DESCRIPTION
Replaces the single `xds component [name]` command (with a bunch of flags) with focused subcommands. Based on Meta's internal `meta xds.component` pattern.

## New API

```
xds component list                        # names by category
xds component list --detail brief         # just names
xds component list --category Layout      # filter by category
xds component search "date"               # find by name or description
xds component metadata Button             # description, features, notes, a11y, keyboard
xds component metadata Button --detail brief  # just the description
xds component props Button                # full props table
xds component props Button --detail brief # name: type per line
xds component examples Button             # list example titles
xds component example Button 3            # one example's code
xds component source Button               # raw source
```

## Global flags

`--detail brief|normal` and `--lang dense|zh` compose with every subcommand:

```
xds --lang dense component metadata Button       # compressed prose
xds --lang zh component props Button --detail brief  # Chinese, just name:type
```

## Test plan

```
$ xds component list | head -5
Layout:
  AspectRatio
  Center
  Grid
  GridSpan

$ xds component list --detail brief | head -3
AspectRatio
Center
Grid

$ xds component search date
DateInput — XDSDateInput component combining a text input with a calendar popover for date selection.
Calendar — XDSCalendar component for date selection with single and range modes.

$ xds component metadata Button --detail brief
Button: XDSButton component with multiple variants, sizes, and isLoading state support.

$ xds component props Button --detail brief
label: string (required)
variant: 'primary' | 'secondary' | 'ghost' | 'destructive' = 'secondary'
size: 'sm' | 'md' | 'lg' = 'md'
...

$ xds component examples Button
1. Basic
2. With size
3. Loading state
...

$ xds component example Button 3
// Loading state
<XDSButton label="Saving..." variant="primary" isLoading />

$ xds --lang dense component metadata Button | head -5
# Button

button w/ multiple variants, sizes, loading state

## Features
```

## Follow-ups

- Levenshtein fuzzy matching in search (currently substring only)
- Deep content search across features, notes, a11y
- Tests for new subcommands

-----

Depends on #613 (CLI refactor). All 1436 tests passing.