### PR TITLE
fix: align @xds/theme-brutalist version to 0.0.3

### DIFF
--- a/packages/themes/brutalist/CHANGELOG.md
+++ b/packages/themes/brutalist/CHANGELOG.md
@@ -1,8 +1,7 @@
 # @xds/theme-brutalist
 
-## 1.0.0
+## 0.0.3
 
 ### Patch Changes
 
-- Updated dependencies [76ac780]
-  - @xds/core@0.1.0
+- Initial release — aligned with @xds/core@0.0.3

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "1.0.0",
+  "version": "0.0.3",
   "private": false,
   "description": "Brutalist theme for XDS — zero radius, monospace, heavy borders",
   "license": "MIT",


### PR DESCRIPTION
All XDS packages must be at the same version for compatibility guarantees.

The brutalist theme was incorrectly published at `1.0.0` (changesets default for first publish) while all other packages are at `0.0.3`.

**Changes:**
- `package.json`: `1.0.0` → `0.0.3`
- `CHANGELOG.md`: Updated to reflect `0.0.3` as initial release aligned with core

The package will also need to be re-published to the internal registry at `0.0.3` to match.