### PR TITLE
Use XDSTreeList in XDSPowerSearch

### DIFF
--- a/apps/storybook/stories/TreeList.stories.tsx
+++ b/apps/storybook/stories/TreeList.stories.tsx
@@ -20,11 +20,6 @@ const meta: Meta<typeof XDSTreeList> = {
       options: ['compact', 'balanced', 'spacious'],
       description: 'Spacing density for tree list items',
     },
-    branchAlignment: {
-      control: 'select',
-      options: ['center', 'top'],
-      description: 'Where branch lines connect to items',
-    },
   },
 };
 
@@ -219,7 +214,6 @@ export const TopAligned: Story = {
       {id: 'pkg', label: 'package.json'},
       {id: 'readme', label: 'README.md'},
     ],
-    branchAlignment: 'top',
   },
 };
 

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -16,11 +16,13 @@ import {XDSButton} from '../Button';
 import {XDSSelector} from '../Selector';
 import {XDSHStack, XDSVStack} from '../Stack';
 import {XDSIcon} from '../Icon';
+import {XDSTreeList, type XDSTreeListItemData} from '../TreeList';
 import {
   spacingVars,
   colorVars,
   radiusVars,
   elevationVars,
+  textSizeVars,
 } from '../theme/tokens.stylex';
 import {PowerSearchValueEditor} from './PowerSearchValueEditor';
 import type {InternalConfig} from './useInternalConfig';
@@ -59,6 +61,17 @@ const styles = stylex.create({
     minWidth: 0,
   },
   // Nested editor styles
+  nestedRootLabel: {
+    fontSize: textSizeVars['--text-base'],
+  },
+  nestedFieldSelector: {
+    flexShrink: 0,
+    width: 200,
+  },
+  nestedOperatorSelector: {
+    flexShrink: 0,
+    width: 180,
+  },
   nestedRow: {
     width: '100%',
   },
@@ -110,7 +123,6 @@ interface NestedSubFilterRowProps {
   config: InternalConfig;
   subFilter: PartialFilter;
   onChange: (subFilter: PartialFilter) => void;
-  onRemove: () => void;
   isReadOnly: boolean;
 }
 
@@ -118,7 +130,6 @@ function NestedSubFilterRow({
   config,
   subFilter,
   onChange,
-  onRemove,
   isReadOnly,
 }: NestedSubFilterRowProps) {
   // Exclude nested fields from sub-filter field options to avoid infinite nesting
@@ -189,7 +200,7 @@ function NestedSubFilterRow({
 
   return (
     <XDSHStack gap={2} vAlign="center">
-      <div {...stylex.props(styles.fieldSelector)}>
+      <div {...stylex.props(styles.nestedFieldSelector)}>
         <XDSSelector
           label="Field"
           isLabelHidden
@@ -201,7 +212,7 @@ function NestedSubFilterRow({
         />
       </div>
       {operatorOptions.length > 0 && (
-        <div {...stylex.props(styles.operatorSelector)}>
+        <div {...stylex.props(styles.nestedOperatorSelector)}>
           <XDSSelector
             label="Operator"
             isLabelHidden
@@ -223,15 +234,6 @@ function NestedSubFilterRow({
             isDisabled={isReadOnly}
           />
         </div>
-      )}
-      {!isReadOnly && (
-        <button
-          type="button"
-          aria-label="Remove filter"
-          onClick={onRemove}
-          {...stylex.props(styles.removeButton)}>
-          <XDSIcon icon="close" size="sm" />
-        </button>
       )}
     </XDSHStack>
   );
@@ -349,9 +351,46 @@ function NestedEditor({
     });
   }, [config, syncToParent]);
 
-  return (
-    <XDSVStack gap={2}>
-      {operatorOptions.length > 1 && (
+  const treeChildren: XDSTreeListItemData[] = subFilters.map(
+    (subFilter, idx) => ({
+      id: `filter-${idx}`,
+      label: (
+        <NestedSubFilterRow
+          config={config}
+          subFilter={subFilter}
+          onChange={updated => handleSubFilterChange(idx, updated)}
+          isReadOnly={isReadOnly}
+        />
+      ),
+      endContent: !isReadOnly ? (
+        <button
+          type="button"
+          aria-label="Remove filter"
+          onClick={() => handleSubFilterRemove(idx)}
+          {...stylex.props(styles.removeButton)}>
+          <XDSIcon icon="close" size="sm" />
+        </button>
+      ) : undefined,
+    }),
+  );
+
+  if (!isReadOnly) {
+    treeChildren.push({
+      id: 'add-filter',
+      label: (
+        <XDSButton
+          label="+ Add filter"
+          onClick={handleAddSubFilter}
+          variant="ghost"
+          size="sm"
+        />
+      ),
+    });
+  }
+
+  const rootLabel = (
+    <div {...stylex.props(styles.nestedRootLabel)}>
+      {operatorOptions.length > 1 ? (
         <div {...stylex.props(styles.operatorSelector)}>
           <XDSSelector
             label="Group operator"
@@ -363,27 +402,22 @@ function NestedEditor({
             size="md"
           />
         </div>
+      ) : (
+        (operatorOptions[0]?.label ?? 'Group')
       )}
-      {subFilters.map((subFilter, idx) => (
-        <NestedSubFilterRow
-          key={idx}
-          config={config}
-          subFilter={subFilter}
-          onChange={updated => handleSubFilterChange(idx, updated)}
-          onRemove={() => handleSubFilterRemove(idx)}
-          isReadOnly={isReadOnly}
-        />
-      ))}
-      {!isReadOnly && (
-        <XDSButton
-          label="+ Add filter"
-          onClick={handleAddSubFilter}
-          variant="ghost"
-          size="sm"
-        />
-      )}
-    </XDSVStack>
+    </div>
   );
+
+  const items: XDSTreeListItemData[] = [
+    {
+      id: 'nested-root',
+      label: rootLabel,
+      isExpanded: true,
+      children: treeChildren,
+    },
+  ];
+
+  return <XDSTreeList items={items} density="balanced" />;
 }
 
 // =============================================================================

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -61,7 +61,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-tree-list', visualProps: ['density', 'branchAlignment']},
+      {className: 'xds-tree-list', visualProps: ['density']},
     ],
   },
   notes: [
@@ -100,12 +100,6 @@ export const docs = {
           type: "'compact' | 'balanced' | 'spacious'",
           description: 'Spacing density for items.',
           default: "'balanced'",
-        },
-        {
-          name: 'branchAlignment',
-          type: "'center' | 'top'",
-          description: 'Where branch lines connect to items.',
-          default: "'center'",
         },
         {
           name: 'header',

--- a/packages/core/src/TreeList/XDSTreeList.test.tsx
+++ b/packages/core/src/TreeList/XDSTreeList.test.tsx
@@ -307,15 +307,6 @@ describe('XDSTreeList', () => {
   });
 
   // ===========================================================================
-  // Branch alignment
-  // ===========================================================================
-
-  it('renders with top branch alignment', () => {
-    render(<XDSTreeList items={nestedItemsExpanded} branchAlignment="top" />);
-    expect(screen.getByText('Child 1')).toBeInTheDocument();
-  });
-
-  // ===========================================================================
   // xds class name
   // ===========================================================================
 

--- a/packages/core/src/TreeList/XDSTreeList.tsx
+++ b/packages/core/src/TreeList/XDSTreeList.tsx
@@ -18,20 +18,13 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSTreeListItem} from './XDSTreeListItem';
-import type {
-  XDSTreeListItemData,
-  XDSTreeListDensity,
-  XDSTreeListBranchAlignment,
-} from './XDSTreeListTypes';
+import type {XDSTreeListItemData, XDSTreeListDensity} from './XDSTreeListTypes';
 
 // =============================================================================
 // Types
 // =============================================================================
 
-export {
-  type XDSTreeListDensity,
-  type XDSTreeListBranchAlignment,
-} from './XDSTreeListTypes';
+export {type XDSTreeListDensity} from './XDSTreeListTypes';
 
 export interface XDSTreeListProps {
   /** Ref forwarded to the root element */
@@ -51,14 +44,6 @@ export interface XDSTreeListProps {
    * @default 'balanced'
    */
   density?: XDSTreeListDensity;
-
-  /**
-   * Controls where tree branch lines connect to items.
-   * - 'center': Lines terminate at vertical center of items
-   * - 'top': Lines terminate at the top of items
-   * @default 'center'
-   */
-  branchAlignment?: XDSTreeListBranchAlignment;
 
   /**
    * Header content rendered above the tree list.
@@ -155,7 +140,6 @@ function collectExpandedKeys(items: XDSTreeListItemData[]): string[] {
 export function XDSTreeList({
   items,
   density = 'balanced',
-  branchAlignment = 'center',
   header,
   xstyle,
   className,
@@ -223,7 +207,6 @@ export function XDSTreeList({
           isExpanded={isExpanded}
           onToggle={handleToggle}
           density={density}
-          branchAlignment={branchAlignment}
           renderedChildren={renderedChildren}
         />
       );
@@ -235,7 +218,7 @@ export function XDSTreeList({
       ref={ref}
       data-testid={testId}
       {...mergeProps(
-        xdsClassName('tree-list', {density, branchAlignment}),
+        xdsClassName('tree-list', {density}),
         stylex.props(styles.root, xstyle),
         className,
         style,

--- a/packages/core/src/TreeList/XDSTreeListBranches.tsx
+++ b/packages/core/src/TreeList/XDSTreeListBranches.tsx
@@ -12,18 +12,8 @@
 
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
-import type {
-  XDSTreeListBranchAlignment,
-  XDSTreeListDensity,
-} from './XDSTreeListTypes';
 
 const LINE_WIDTH = 2;
-
-// Content row heights per density (paddingBlock * 2 + line-height).
-// These must stay in sync with densityStyles in XDSTreeListItem.tsx.
-const LABEL_ROW_HEIGHT_COMPACT = 28;
-const LABEL_ROW_HEIGHT_BALANCED = 36;
-const LABEL_ROW_HEIGHT_SPACIOUS = 48;
 
 const styles = stylex.create({
   container: {
@@ -43,11 +33,22 @@ const styles = stylex.create({
   verticalFull: {
     height: 'calc(100% + 1px)',
   },
+  verticalToHalf: {
+    height: '50%',
+  },
+  connectorContainer: {
+    position: 'absolute',
+    width: 20,
+    height: '100%',
+    top: 0,
+  },
   horizontalLine: {
     borderRadius: 1,
     height: LINE_WIDTH,
     left: '50%',
     position: 'absolute',
+    top: '50%',
+    transform: 'translateY(-50%)',
     width: '50%',
     backgroundColor: colorVars['--color-divider-emphasized'],
   },
@@ -56,87 +57,35 @@ const styles = stylex.create({
   },
 });
 
-// Vertical line from top to chevron center of content row (L-connector for last child)
-const verticalToCenter = stylex.create({
-  compact: {height: LABEL_ROW_HEIGHT_COMPACT / 2 - 2 + LINE_WIDTH},
-  balanced: {height: LABEL_ROW_HEIGHT_BALANCED / 2 - 2 + LINE_WIDTH},
-  spacious: {height: LABEL_ROW_HEIGHT_SPACIOUS / 2 - 2 + LINE_WIDTH},
-});
-
-// Horizontal line positioned to align with chevron center
-const horizontalAtCenter = stylex.create({
-  compact: {top: LABEL_ROW_HEIGHT_COMPACT / 2 - 2},
-  balanced: {top: LABEL_ROW_HEIGHT_BALANCED / 2 - 2},
-  spacious: {top: LABEL_ROW_HEIGHT_SPACIOUS / 2 - 2},
-});
-
 // =============================================================================
 // Types
 // =============================================================================
 
 interface XDSTreeListBranchesProps {
   ancestorsIsLast: ReadonlyArray<boolean>;
-  branchAlignment: XDSTreeListBranchAlignment;
-  density: XDSTreeListDensity;
-  hasChildren: boolean;
   isLast: boolean;
   levelIndent: number;
   marginLeft: number;
   nestedLevel: number;
 }
 
-interface BranchItemProps {
-  density: XDSTreeListDensity;
-  hasChildren?: boolean;
-  leftPosition: number;
-  type: 'parentToParentSibling' | 'parentToChildAndSibling' | 'parentToChild';
+interface XDSTreeListHorizontalConnectorProps {
+  hasChildren: boolean;
+  levelIndent: number;
+  marginLeft: number;
+  nestedLevel: number;
 }
 
 // =============================================================================
 // Components
 // =============================================================================
 
-function TreeListBranchItem({
-  density,
-  hasChildren,
-  leftPosition,
-  type,
-}: BranchItemProps) {
-  return (
-    <div {...stylex.props(styles.container)} style={{left: leftPosition}}>
-      <div
-        {...stylex.props(
-          styles.verticalLine,
-          type === 'parentToParentSibling' || type === 'parentToChildAndSibling'
-            ? styles.verticalFull
-            : verticalToCenter[density],
-        )}
-      />
-      {(type === 'parentToChildAndSibling' || type === 'parentToChild') && (
-        <div
-          {...stylex.props(
-            styles.horizontalLine,
-            hasChildren === false && styles.horizontalLineFull,
-            horizontalAtCenter[density],
-          )}
-        />
-      )}
-    </div>
-  );
-}
-
 /**
- * Renders lines showing parent-child relationships in the tree.
- *
- * Line types:
- * 1. Pass-through vertical lines for non-last ancestors
- * 2. Parent-to-child connector (L-shaped for last child, T-shaped otherwise)
+ * Renders vertical lines showing parent-child relationships in the tree.
+ * Positioned in a full-height container to span the entire item including children.
  */
 export function XDSTreeListBranches({
   ancestorsIsLast,
-  branchAlignment: _branchAlignment,
-  density,
-  hasChildren,
   isLast,
   levelIndent,
   marginLeft,
@@ -147,22 +96,55 @@ export function XDSTreeListBranches({
       {ancestorsIsLast.map(
         (ancestorIsLast, level) =>
           !ancestorIsLast && (
-            <TreeListBranchItem
+            <div
               key={level}
-              density={density}
-              leftPosition={marginLeft + level * levelIndent}
-              type="parentToParentSibling"
-            />
+              {...stylex.props(styles.container)}
+              style={{left: marginLeft + level * levelIndent}}>
+              <div
+                {...stylex.props(styles.verticalLine, styles.verticalFull)}
+              />
+            </div>
           ),
       )}
       {nestedLevel > 0 && (
-        <TreeListBranchItem
-          density={density}
-          hasChildren={hasChildren}
-          leftPosition={marginLeft + (nestedLevel - 1) * levelIndent}
-          type={isLast ? 'parentToChild' : 'parentToChildAndSibling'}
-        />
+        <div
+          {...stylex.props(styles.container)}
+          style={{left: marginLeft + (nestedLevel - 1) * levelIndent}}>
+          <div
+            {...stylex.props(
+              styles.verticalLine,
+              isLast ? styles.verticalToHalf : styles.verticalFull,
+            )}
+          />
+        </div>
       )}
     </>
+  );
+}
+
+/**
+ * Renders the horizontal connector line from a parent branch to a child item.
+ * Must be rendered inside a container whose height matches the content row,
+ * so that top: 50% centers on the label, not the full item including children.
+ */
+export function XDSTreeListHorizontalConnector({
+  hasChildren,
+  levelIndent,
+  marginLeft,
+  nestedLevel,
+}: XDSTreeListHorizontalConnectorProps) {
+  if (nestedLevel <= 0) return null;
+
+  return (
+    <div
+      {...stylex.props(styles.connectorContainer)}
+      style={{left: marginLeft + (nestedLevel - 1) * levelIndent}}>
+      <div
+        {...stylex.props(
+          styles.horizontalLine,
+          !hasChildren && styles.horizontalLineFull,
+        )}
+      />
+    </div>
   );
 }

--- a/packages/core/src/TreeList/XDSTreeListItem.tsx
+++ b/packages/core/src/TreeList/XDSTreeListItem.tsx
@@ -22,11 +22,11 @@ import {
   transitionVars,
 } from '../theme/tokens.stylex';
 import {getIcon} from '../Icon/globalIconRegistry';
-import {XDSTreeListBranches} from './XDSTreeListBranches';
-import type {
-  XDSTreeListBranchAlignment,
-  XDSTreeListDensity,
-} from './XDSTreeListTypes';
+import {
+  XDSTreeListBranches,
+  XDSTreeListHorizontalConnector,
+} from './XDSTreeListBranches';
+import type {XDSTreeListDensity} from './XDSTreeListTypes';
 
 // =============================================================================
 // Constants
@@ -56,6 +56,9 @@ const styles = stylex.create({
   },
   treeBranches: {
     paddingInlineStart: BRANCH_MARGIN_LEFT,
+  },
+  rowWrapper: {
+    position: 'relative',
   },
   contentWrapper: {
     borderRadius: radiusVars['--radius-content'],
@@ -249,7 +252,6 @@ export interface XDSTreeListItemInternalProps {
   isExpanded: boolean;
   onToggle?: (id: string) => void;
   density: XDSTreeListDensity;
-  branchAlignment: XDSTreeListBranchAlignment;
   /** Pre-rendered children subtree (rendered by the parent recursion) */
   renderedChildren?: ReactNode;
 }
@@ -276,7 +278,6 @@ export function XDSTreeListItem({
   isExpanded,
   onToggle,
   density,
-  branchAlignment,
   renderedChildren,
 }: XDSTreeListItemInternalProps) {
   const labelId = useId();
@@ -404,29 +405,34 @@ export function XDSTreeListItem({
       <div {...stylex.props(styles.treeBranches)}>
         <XDSTreeListBranches
           ancestorsIsLast={ancestorsIsLast}
-          branchAlignment={branchAlignment}
-          density={density}
-          hasChildren={hasChildren}
           isLast={isLast}
           levelIndent={INDENT}
           marginLeft={BRANCH_MARGIN_LEFT}
           nestedLevel={nestedLevel}
         />
       </div>
-      <div
-        {...stylex.props(
-          styles.contentWrapper,
-          densityStyles[density],
-          (isInteractive || (hasChildren && onClick == null)) &&
-            styles.interactive,
-          (isInteractive || (hasChildren && onClick == null)) &&
-            styles.focusWithinOutline,
-          isDisabled && styles.disabled,
-          isSelected && styles.selected,
-        )}
-        style={{marginLeft: computedMarginLeft}}
-        onClick={handleClick}>
-        {innerContent}
+      <div {...stylex.props(styles.rowWrapper)}>
+        <XDSTreeListHorizontalConnector
+          hasChildren={hasChildren}
+          levelIndent={INDENT}
+          marginLeft={BRANCH_MARGIN_LEFT}
+          nestedLevel={nestedLevel}
+        />
+        <div
+          {...stylex.props(
+            styles.contentWrapper,
+            densityStyles[density],
+            (isInteractive || (hasChildren && onClick == null)) &&
+              styles.interactive,
+            (isInteractive || (hasChildren && onClick == null)) &&
+              styles.focusWithinOutline,
+            isDisabled && styles.disabled,
+            isSelected && styles.selected,
+          )}
+          style={{marginLeft: computedMarginLeft}}
+          onClick={handleClick}>
+          {innerContent}
+        </div>
       </div>
       {isExpanded && renderedChildren != null && (
         <ul role="group" {...stylex.props(styles.childGroup)}>

--- a/packages/core/src/TreeList/XDSTreeListTypes.ts
+++ b/packages/core/src/TreeList/XDSTreeListTypes.ts
@@ -14,9 +14,6 @@ import type {ReactNode} from 'react';
 /** Spacing density for tree list items. */
 export type XDSTreeListDensity = 'compact' | 'balanced' | 'spacious';
 
-/** Branch alignment mode for tree connector lines. */
-export type XDSTreeListBranchAlignment = 'center' | 'top';
-
 /** Recursive item configuration for XDSTreeList. */
 export interface XDSTreeListItemData {
   /** Unique identifier for the item. Used as React key and for expansion tracking. */

--- a/packages/core/src/TreeList/index.ts
+++ b/packages/core/src/TreeList/index.ts
@@ -8,9 +8,5 @@
  */
 
 export {XDSTreeList} from './XDSTreeList';
-export type {
-  XDSTreeListProps,
-  XDSTreeListDensity,
-  XDSTreeListBranchAlignment,
-} from './XDSTreeList';
+export type {XDSTreeListProps, XDSTreeListDensity} from './XDSTreeList';
 export type {XDSTreeListItemData} from './XDSTreeListTypes';


### PR DESCRIPTION
Now that we have XDSTreeList we can swap it in for the editing popover in XDSPowerSearch.

I made some adjustments to the branch line placement in XDSTreeList to make it look nicer with non-text labels.

<img width="754" height="433" alt="image" src="https://github.com/user-attachments/assets/44ccd7ff-3209-4020-bdae-4da73f48ab16" />
