### PR TITLE
release: v0.0.4

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @xds/cli
 
+## 0.0.4
+
+### Features
+
+- **`xds theme build`** — Renamed from `build-theme` to `theme build`, establishing `xds theme` command group (#570)
+- **`--lang` flag** — TranslationDoc support for i18n/compressed docs (#611)
+- **`--zh` flag** — Chinese Simplified doc output (#567)
+
+### Refactors
+
+- Split `component.mjs` into `lib/` modules with lazy command registry (#613)
+
+## 0.0.3
+
+### Patch Changes
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "XDS design system CLI \u2014 init, swizzle, theme, templates, and agent docs",
   "type": "module",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,34 @@
 # @xds/core
 
+## 0.0.4
+
+### New Components
+
+- **XDSTreeList** — Hierarchical tree list component with expand/collapse (#609)
+- **XDSPowerSearch** — Advanced search component with result count, filtering (#561, #593)
+
+### Features
+
+- **AppShell variant system** — New `variant` prop (`wash`, `surface`, `section`, `elevated`) replaces `background` prop (#597)
+- **AppShell contentPadding** — New `contentPadding` prop for controlling content area padding (#612)
+- **AppShell auto height mode** — Sidenav and sticky backgrounds in auto height mode (#615)
+- **startIcon** — Added startIcon support (#584)
+
+### Fixes
+
+- Removed deprecated `isFullBleed` prop from Card and Section — use `padding={0}` instead (#610, #598)
+- Layout: `padding={0}` treated as equivalent to `isFullBleed` (#595)
+- SideNav: consistent spacing regardless of header/topContent visibility (#601)
+- Nav: consistent gap and heading text sizes (#616)
+
+### Refactors
+
+- Popover, HoverCard, Tooltip moved to top-level directories (#557)
+
+## 0.0.3
+
+### Patch Changes
+
 ## 0.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Core XDS components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/themes/brutalist/CHANGELOG.md
+++ b/packages/themes/brutalist/CHANGELOG.md
@@ -1,7 +1,8 @@
 # @xds/theme-brutalist
 
-## 0.0.3
+## 0.0.4
 
-### Patch Changes
+### Minor Changes
 
-- Initial release — aligned with @xds/core@0.0.3
+- Initial release — brutalist theme with zero radius, monospace typography, heavy borders
+- Added to Storybook (#560)

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "description": "Brutalist theme for XDS — zero radius, monospace, heavy borders",
   "license": "MIT",

--- a/packages/themes/default/CHANGELOG.md
+++ b/packages/themes/default/CHANGELOG.md
@@ -1,107 +1,11 @@
 # @xds/theme-default
 
-## 1.0.0
-
-### Minor Changes
-
-- 76ac780: ## 0.0.2 Release
-
-  ### New: CSS-based theming (replaces StyleX theme system)
-
-  The StyleX-based theme system (`stylex.createTheme`, `ComponentStyles` context) has been replaced with a CSS-based approach using `defineTheme()`.
-
-  **Migration:**
-
-  ```tsx
-  // Before (0.0.1)
-  import { defaultTheme } from '@xds/theme-default';
-  <XDSTheme theme={defaultTheme}>
-
-  // After (0.0.2) — same API, new internals
-  import { defaultTheme } from '@xds/theme-default';
-  import '@xds/theme-default/theme.css'; // NEW: import the theme CSS
-  <XDSTheme theme={defaultTheme}>
-  ```
-
-  Custom themes now use `defineTheme()`:
-
-  ```tsx
-  import {defineTheme} from '@xds/core';
-
-  const myTheme = defineTheme({
-    name: 'my-theme',
-    tokens: {
-      '--color-accent': ['#0077B6', '#48CAE4'], // [light, dark]
-    },
-    components: {
-      button: {base: {borderRadius: '999px'}},
-    },
-    icons: myIcons,
-  });
-  ```
-
-  Build theme CSS with: `npx xds theme build`
-
-  ### New: `className` and `style` props on all components
-
-  All components now accept `className` and `style` alongside `xstyle`. Use Tailwind, CSS modules, or plain CSS — no StyleX build requirement for consumers.
-
-  ```tsx
-  <XDSCard className="max-w-md shadow-lg" />
-  <XDSCard style={{ maxWidth: 400 }} />
-  <XDSCard xstyle={myStyleXOverrides} /> // still works
-  ```
-
-  ### New: Numeric spacing scale for `padding` and `gap`
-
-  Layout components accept a numeric `padding` prop. Stack and Grid `gap` migrated from string tokens to numbers.
-
-  ```tsx
-  // Before
-  <XDSStack gap="space4">
-  <XDSCard isFullBleed>
-
-  // After
-  <XDSStack gap={4}>
-  <XDSCard padding={0}>
-  ```
-
-  Scale: 0=0px, 1=4px, 2=8px, 3=12px, 4=16px (default), 6=24px, 8=32px, 10=40px.
-
-  **Codemod:** `npx xds upgrade --apply`
-
-  ### New: RSC-compatible icon registry
-
-  Icons now use a global registry instead of React Context:
-
-  ```tsx
-  import {registerIcons, getIcon} from '@xds/core';
-  registerIcons(myIcons); // works in RSC — no 'use client' needed
-  const icon = getIcon('close'); // no hooks required
-  ```
-
-  ### New: React 19 ref prop
-
-  All 64 components migrated from `forwardRef` to the React 19 `ref` prop pattern. No consumer changes needed — `ref` works the same way.
-
-  ### Breaking changes (all have codemods)
-
-  Run `npx xds upgrade --apply` to auto-migrate:
-  - `XDSTopNavTitle` → `XDSTopNavHeading`, prop `title` → `heading`
-  - `XDSSideNavHeader` → `XDSSideNavHeading`, props `title/titleHref/supertitle/subtitle` → `heading/headingHref/superheading/subheading`
-  - `useXDSIcon()` → `getIcon()`, `IconRegistryContext` removed
-  - `gap="space4"` → `gap={4}` (numeric scale)
-  - `isFullBleed` → `padding={0}` (on Card, Section, Layout\*)
-
-  ### Bug fixes
-  - Badge height fixed to 20px
-  - Token medium padding reduced to 8px
-  - Card border uses opaque color for consistency across backgrounds
-  - DateInput autocomplete disabled
-  - SideNav 8px spacing alignment
-  - Breadcrumbs text centering
+## 0.0.4
 
 ### Patch Changes
 
-- Updated dependencies [76ac780]
-  - @xds/core@0.1.0
+- Updated dependencies — aligned with @xds/core@0.0.4
+
+## 0.0.3
+
+### Patch Changes

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-default",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "description": "Default theme for XDS components (Heroicons)",
   "license": "MIT",

--- a/packages/themes/neutral/CHANGELOG.md
+++ b/packages/themes/neutral/CHANGELOG.md
@@ -1,107 +1,11 @@
 # @xds/theme-neutral
 
-## 1.0.0
-
-### Minor Changes
-
-- 76ac780: ## 0.0.2 Release
-
-  ### New: CSS-based theming (replaces StyleX theme system)
-
-  The StyleX-based theme system (`stylex.createTheme`, `ComponentStyles` context) has been replaced with a CSS-based approach using `defineTheme()`.
-
-  **Migration:**
-
-  ```tsx
-  // Before (0.0.1)
-  import { defaultTheme } from '@xds/theme-default';
-  <XDSTheme theme={defaultTheme}>
-
-  // After (0.0.2) — same API, new internals
-  import { defaultTheme } from '@xds/theme-default';
-  import '@xds/theme-default/theme.css'; // NEW: import the theme CSS
-  <XDSTheme theme={defaultTheme}>
-  ```
-
-  Custom themes now use `defineTheme()`:
-
-  ```tsx
-  import {defineTheme} from '@xds/core';
-
-  const myTheme = defineTheme({
-    name: 'my-theme',
-    tokens: {
-      '--color-accent': ['#0077B6', '#48CAE4'], // [light, dark]
-    },
-    components: {
-      button: {base: {borderRadius: '999px'}},
-    },
-    icons: myIcons,
-  });
-  ```
-
-  Build theme CSS with: `npx xds theme build`
-
-  ### New: `className` and `style` props on all components
-
-  All components now accept `className` and `style` alongside `xstyle`. Use Tailwind, CSS modules, or plain CSS — no StyleX build requirement for consumers.
-
-  ```tsx
-  <XDSCard className="max-w-md shadow-lg" />
-  <XDSCard style={{ maxWidth: 400 }} />
-  <XDSCard xstyle={myStyleXOverrides} /> // still works
-  ```
-
-  ### New: Numeric spacing scale for `padding` and `gap`
-
-  Layout components accept a numeric `padding` prop. Stack and Grid `gap` migrated from string tokens to numbers.
-
-  ```tsx
-  // Before
-  <XDSStack gap="space4">
-  <XDSCard isFullBleed>
-
-  // After
-  <XDSStack gap={4}>
-  <XDSCard padding={0}>
-  ```
-
-  Scale: 0=0px, 1=4px, 2=8px, 3=12px, 4=16px (default), 6=24px, 8=32px, 10=40px.
-
-  **Codemod:** `npx xds upgrade --apply`
-
-  ### New: RSC-compatible icon registry
-
-  Icons now use a global registry instead of React Context:
-
-  ```tsx
-  import {registerIcons, getIcon} from '@xds/core';
-  registerIcons(myIcons); // works in RSC — no 'use client' needed
-  const icon = getIcon('close'); // no hooks required
-  ```
-
-  ### New: React 19 ref prop
-
-  All 64 components migrated from `forwardRef` to the React 19 `ref` prop pattern. No consumer changes needed — `ref` works the same way.
-
-  ### Breaking changes (all have codemods)
-
-  Run `npx xds upgrade --apply` to auto-migrate:
-  - `XDSTopNavTitle` → `XDSTopNavHeading`, prop `title` → `heading`
-  - `XDSSideNavHeader` → `XDSSideNavHeading`, props `title/titleHref/supertitle/subtitle` → `heading/headingHref/superheading/subheading`
-  - `useXDSIcon()` → `getIcon()`, `IconRegistryContext` removed
-  - `gap="space4"` → `gap={4}` (numeric scale)
-  - `isFullBleed` → `padding={0}` (on Card, Section, Layout\*)
-
-  ### Bug fixes
-  - Badge height fixed to 20px
-  - Token medium padding reduced to 8px
-  - Card border uses opaque color for consistency across backgrounds
-  - DateInput autocomplete disabled
-  - SideNav 8px spacing alignment
-  - Breadcrumbs text centering
+## 0.0.4
 
 ### Patch Changes
 
-- Updated dependencies [76ac780]
-  - @xds/core@0.1.0
+- Updated dependencies — aligned with @xds/core@0.0.4
+
+## 0.0.3
+
+### Patch Changes

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-neutral",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": false,
   "description": "Neutral theme for XDS components (Lucide icons)",
   "license": "MIT",


### PR DESCRIPTION
## v0.0.4 Release

36 commits since v0.0.3.

### @xds/core

**New Components**
- `XDSTreeList` — Hierarchical tree list with expand/collapse (#609)
- `XDSPowerSearch` — Advanced search with result count, filtering (#561, #593)

**Features**
- AppShell `variant` prop: `wash`, `surface`, `section`, `elevated` — replaces `background` prop (#597)
- AppShell `contentPadding` prop (#612)
- AppShell auto height mode with sidenav and sticky backgrounds (#615)
- `startIcon` support (#584)

**Fixes**
- Removed deprecated `isFullBleed` from Card and Section — use `padding={0}` (#610, #598)
- SideNav: consistent spacing regardless of header/topContent visibility (#601)
- Nav: consistent gap and heading text sizes (#616)

**Refactors**
- Popover, HoverCard, Tooltip moved to top-level directories (#557)

### @xds/cli

- `build-theme` renamed to `theme build` (#570)
- `--lang` flag for i18n/compressed docs (#611)
- `--zh` flag for Chinese Simplified output (#567)
- Internal: split `component.mjs` into `lib/` modules with lazy command registry (#613)

### @xds/theme-brutalist (new)

- First aligned release — brutalist theme with zero radius, monospace, heavy borders

### All themes

- Updated dependencies, aligned at 0.0.4

---

**After merge:** Tag `v0.0.4`, then publish all 5 packages to `npm`.