### PR TITLE
feat: add example-nextjs-tailwind (dist build, no StyleX)

### DIFF
--- a/apps/example-nextjs-tailwind/next.config.mjs
+++ b/apps/example-nextjs-tailwind/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+};
+
+export default nextConfig;

--- a/apps/example-nextjs-tailwind/package.json
+++ b/apps/example-nextjs-tailwind/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@xds/example-nextjs-tailwind",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@xds/core": "*",
+    "@xds/theme-default": "*",
+    "next": "^15.0.0",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
+  },
+  "devDependencies": {
+    "@tailwindcss/postcss": "^4",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
+    "tailwindcss": "^4",
+    "typescript": "^5.7.0"
+  },
+  "browserslist": [
+    "last 1 Chrome version"
+  ]
+}

--- a/apps/example-nextjs-tailwind/postcss.config.mjs
+++ b/apps/example-nextjs-tailwind/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/apps/example-nextjs-tailwind/src/app/globals.css
+++ b/apps/example-nextjs-tailwind/src/app/globals.css
@@ -1,0 +1,5 @@
+@import "tailwindcss";
+@import "@xds/core/reset.css";
+@import "@xds/core/typography.css";
+@import "@xds/core/xds.css";
+@import "@xds/theme-default/theme.css";

--- a/apps/example-nextjs-tailwind/src/app/layout.tsx
+++ b/apps/example-nextjs-tailwind/src/app/layout.tsx
@@ -1,0 +1,19 @@
+import type {Metadata} from 'next';
+import './globals.css';
+import {Providers} from './providers';
+
+export const metadata: Metadata = {
+  title: 'XDS Example — Next.js + Tailwind (Dist)',
+  description:
+    'Reference example consuming @xds/core pre-built dist with Tailwind for custom styles',
+};
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="en">
+      <body>
+        <Providers>{children}</Providers>
+      </body>
+    </html>
+  );
+}

--- a/apps/example-nextjs-tailwind/src/app/page.tsx
+++ b/apps/example-nextjs-tailwind/src/app/page.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSDivider} from '@xds/core';
+
+export default function Home() {
+  return (
+    <main className="flex items-center justify-center min-h-screen p-8">
+      <div className="max-w-[640px] w-full">
+        <XDSVStack gap={6}>
+          <XDSVStack gap={2}>
+            <XDSHeading level={1}>XDS + Tailwind (Dist Build)</XDSHeading>
+            <XDSText type="body" color="secondary">
+              This example consumes <XDSText type="body" weight="bold">@xds/core</XDSText>{' '}
+              as a pre-built dist package — no StyleX build plugin needed.
+              Custom layout uses Tailwind utility classes. XDS handles
+              components, theming, and design tokens.
+            </XDSText>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Buttons */}
+          <XDSVStack gap={3}>
+            <XDSHeading level={2}>Buttons</XDSHeading>
+            <XDSHStack gap={3} vAlign="center">
+              <XDSButton label="Primary" variant="primary" />
+              <XDSButton label="Secondary" variant="secondary" />
+              <XDSButton label="Ghost" variant="ghost" />
+            </XDSHStack>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Badges */}
+          <XDSVStack gap={3}>
+            <XDSHeading level={2}>Badges</XDSHeading>
+            <XDSHStack gap={3} vAlign="center">
+              <XDSBadge variant="info">Info</XDSBadge>
+              <XDSBadge variant="success">Success</XDSBadge>
+              <XDSBadge variant="warning">Warning</XDSBadge>
+              <XDSBadge variant="error">Error</XDSBadge>
+            </XDSHStack>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Text Input */}
+          <XDSVStack gap={3}>
+            <XDSHeading level={2}>Text Input</XDSHeading>
+            <XDSTextInput
+              label="Email address"
+              placeholder="you@example.com"
+            />
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Tailwind custom styling */}
+          <XDSVStack gap={3}>
+            <XDSHeading level={2}>Tailwind Integration</XDSHeading>
+            <div className="rounded-lg border border-[var(--color-divider)] p-4 bg-[var(--color-wash)]">
+              <XDSText type="body">
+                This card uses Tailwind utilities for layout with XDS
+                design tokens via CSS custom properties. No StyleX needed.
+              </XDSText>
+            </div>
+          </XDSVStack>
+
+          <XDSDivider />
+
+          {/* Typography */}
+          <XDSVStack gap={3}>
+            <XDSHeading level={2}>Typography</XDSHeading>
+            <XDSText type="large" weight="bold">
+              Large bold text
+            </XDSText>
+            <XDSText type="body">Default body text</XDSText>
+            <XDSText type="supporting" color="secondary">
+              Supporting text in secondary color
+            </XDSText>
+          </XDSVStack>
+        </XDSVStack>
+      </div>
+    </main>
+  );
+}

--- a/apps/example-nextjs-tailwind/src/app/providers.tsx
+++ b/apps/example-nextjs-tailwind/src/app/providers.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import {XDSTheme} from '@xds/core/theme';
+import {defaultTheme} from '@xds/theme-default';
+
+export function Providers({children}: {children: React.ReactNode}) {
+  return <XDSTheme theme={defaultTheme}>{children}</XDSTheme>;
+}

--- a/apps/example-nextjs-tailwind/tsconfig.json
+++ b/apps/example-nextjs-tailwind/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What

New example app showing how to consume `@xds/core` as a **pre-built dist package** with Tailwind for custom layout. No StyleX build plugin needed.

## Why

The existing examples (`example-vite`, `example-nextjs`) both compile XDS from source via the StyleX build plugin. This requires significant config (babel, postcss, lightningcss targets, optimizeDeps). Many consumers — especially internal apps and internal tools — just want to use the components without configuring a StyleX build pipeline.

This example shows the zero-config path:
- Import `@xds/core/xds.css` and `@xds/theme-default/theme.css` as static CSS
- Import components from `@xds/core/Button`, `@xds/core/Text`, etc. (resolves to pre-built dist JS)
- Use Tailwind utilities for custom layout alongside XDS components
- Use XDS design tokens as CSS custom properties in Tailwind classes (`bg-[var(--color-wash)]`)

## Setup (for consumers)

```bash
npm install @xds/core @xds/theme-default
```

```css
/* globals.css */
@import "tailwindcss";
@import "@xds/core/reset.css";
@import "@xds/core/typography.css";
@import "@xds/core/xds.css";
@import "@xds/theme-default/theme.css";
```

No babel config. No postcss StyleX plugin. No lightningcss targets.

## Tested

Built and served from tarballs as an external consumer (outside the monorepo). See [Testing Example Apps](https://github.com/facebookexperimental/xds/wiki/Testing-Example-Apps) wiki page.

- ✅ npm install — 48 packages, 0 vulnerabilities
- ✅ next build — 4.7s, 2 static routes
- ✅ CSS: 0 lightningcss polyfill vars, 91 native light-dark(), color-scheme present
- ✅ Production server responds correctly

---
