### PR TITLE
fix: rename dist CSS layer to @layer xds.core.base

### DIFF
--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -21,7 +21,7 @@
  * 2. Combine with theme and typography:
  *    import '@xds/core/reset.css';        // @layer reset  — clean slate
  *    import '@xds/core/typography.css';    // @layer typography — prose styles
- *    import '@xds/core/xds.css';           // @layer xds — component styles
+ *    import '@xds/core/xds.css';           // @layer xds.core.base — component styles
  *    import '@xds/theme-default/theme.css'; // @layer xds.theme — theme overrides
  *
  * Layer order: reset → typography → xds → xds.theme

--- a/scripts/build-css.mjs
+++ b/scripts/build-css.mjs
@@ -1,14 +1,14 @@
 /**
  * @file build-css.mjs
  * Post-build script that extracts StyleX CSS from compiled source files
- * and outputs a single xds.css wrapped in @layer xds.
+ * and outputs a single xds.css wrapped in @layer xds.core.base.
  *
  * Usage: node scripts/build-css.mjs
  *
  * This script:
  * 1. Runs Babel with the StyleX plugin over all source files
  * 2. Collects the CSS rules StyleX generates
- * 3. Wraps them in @layer xds { ... }
+ * 3. Wraps them in @layer xds.core.base { ... }
  * 4. Writes to packages/core/dist/xds.css
  *
  * The resulting CSS file can be imported by consumers who don't have
@@ -92,12 +92,12 @@ async function collectStyleXCSS() {
   // Use StyleX's built-in CSS processor to sort and dedupe rules
   const css = stylexBabelPlugin.processStylexRules(allRules, false);
 
-  // Wrap in @layer xds
+  // Wrap in @layer xds.core.base
   const layeredCSS = `/* XDS Pre-compiled StyleX CSS */
 /* This file is auto-generated. Do not edit manually. */
 /* Consumer styles (unlayered) always override these styles. */
 
-@layer xds {
+@layer xds.core.base {
 ${css.split('\n').map(line => '  ' + line).join('\n')}
 }
 `;


### PR DESCRIPTION
## Problem

`@layer xds.theme` was a sub-layer of `@layer xds`, meaning it had **lower** priority than the parent's direct styles. Theme overrides in `xds.theme` couldn't beat component base styles in `xds` — the opposite of what we want.

This is per the CSS spec: within a parent layer, sub-layers always have lower priority than the parent's direct styles.

## Fix

Rename the dist CSS layer from `@layer xds` to `@layer xds.core.base`.

Now `xds.core.base` and `xds.theme` are both sub-layers of `xds` at different nesting depths:
- `xds.core.base` — deeper nesting, lower priority
- `xds.theme` — shallower, always wins

This works **regardless of declaration order** — no fragile layer ordering declarations needed.

The same pattern extends to the source compilation path (future): StyleX priority layers would become `xds.core.priority1-9`, all at the same depth as `xds.core.base`, all losing to `xds.theme`.

## Verified

Tested as external consumer with tarballs on Next.js + Tailwind. Theme `@scope` overrides (e.g. `.xds-button.secondary`) now correctly beat StyleX component base styles.

---
