### PR TITLE
fix(Table): add minimum column widths and scroll wrapper for mobile responsiveness

### DIFF
--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -25,13 +25,22 @@ import type {
   TableCellComponentProps,
   TableHeaderCellComponentProps,
 } from './types';
-import {generateColumns, defaultCellRenderer} from './columnUtils';
+import {
+  generateColumns,
+  defaultCellRenderer,
+  resolveColumnMinWidth,
+  computeTableMinWidth,
+} from './columnUtils';
 import {XDSTableRow} from './XDSTableRow';
 import {XDSTableCell} from './XDSTableCell';
 import {XDSTableHeaderCell} from './XDSTableHeaderCell';
 import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
+  scrollWrapper: {
+    overflowX: 'auto',
+    width: '100%',
+  },
   table: {
     width: '100%',
     borderCollapse: 'collapse',
@@ -208,6 +217,9 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
     styles: [styles.table],
   } as TableRenderProps);
 
+  // --- Compute table min-width for scroll behavior ---
+  const tableMinWidth = computeTableMinWidth(resolvedColumns);
+
   // --- Plugin pipeline: header cells ---
   const headerCells = resolvedColumns.map(col => {
     const cellRenderProps = applyPlugins(
@@ -227,6 +239,22 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
     );
   });
 
+  // --- Colgroup for column min-widths ---
+  const hasMinWidths = resolvedColumns.length > 0;
+  const colgroup = hasMinWidths ? (
+    <colgroup>
+      {resolvedColumns.map(col => {
+        const minW = resolveColumnMinWidth(col);
+        return (
+          <col
+            key={col.key}
+            style={minW > 0 ? {minWidth: `${minW}px`} : undefined}
+          />
+        );
+      })}
+    </colgroup>
+  ) : null;
+
   // --- Plugin pipeline: header row ---
   const headerRowRenderProps = applyPlugins(
     plugins,
@@ -242,53 +270,68 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
   const hasData = data != null && data.length > 0;
   const hasColumns = resolvedColumns.length > 0;
 
+  // Table min-width style — only set when columns define minimums
+  const tableMinWidthStyle = tableMinWidth
+    ? {minWidth: `${tableMinWidth}px`}
+    : undefined;
+
   let tableElement: ReactNode = (
-    <table
-      ref={ref}
-      {...tableRenderProps.htmlProps}
-      {...mergeProps(
-        xdsClassName('base-table'),
-        stylex.props(...tableRenderProps.styles),
-      )}>
-      {/* thead */}
-      {hasColumns && (
-        <thead>
-          <RowComponent
-            {...headerRowRenderProps.htmlProps}
-            xstyle={headerRowRenderProps.styles}>
-            {headerRowRenderProps.children}
-          </RowComponent>
-        </thead>
-      )}
+    <div {...stylex.props(styles.scrollWrapper)}>
+      <table
+        ref={ref}
+        {...tableRenderProps.htmlProps}
+        {...mergeProps(
+          xdsClassName('base-table'),
+          stylex.props(...tableRenderProps.styles),
+        )}
+        style={{
+          ...((tableRenderProps.htmlProps as Record<string, unknown>).style as
+            | React.CSSProperties
+            | undefined),
+          ...tableMinWidthStyle,
+        }}>
+        {/* colgroup for column min-widths */}
+        {colgroup}
+        {/* thead */}
+        {hasColumns && (
+          <thead>
+            <RowComponent
+              {...headerRowRenderProps.htmlProps}
+              xstyle={headerRowRenderProps.styles}>
+              {headerRowRenderProps.children}
+            </RowComponent>
+          </thead>
+        )}
 
-      {/* tbody — data-driven or children mode */}
-      <tbody>
-        {children
-          ? children
-          : hasData &&
-            data.map((item, rowIndex) => {
-              const rowKey =
-                idKey == null
-                  ? rowIndex
-                  : typeof idKey === 'function'
-                    ? idKey(item)
-                    : String(item[idKey]);
+        {/* tbody — data-driven or children mode */}
+        <tbody>
+          {children
+            ? children
+            : hasData &&
+              data.map((item, rowIndex) => {
+                const rowKey =
+                  idKey == null
+                    ? rowIndex
+                    : typeof idKey === 'function'
+                      ? idKey(item)
+                      : String(item[idKey]);
 
-              return (
-                <MemoizedTableRow<T>
-                  key={rowKey}
-                  item={item}
-                  rowIndex={rowIndex}
-                  rowKey={rowKey}
-                  columns={resolvedColumns}
-                  plugins={plugins}
-                  RowComponent={RowComponent}
-                  CellComponent={CellComponent}
-                />
-              );
-            })}
-      </tbody>
-    </table>
+                return (
+                  <MemoizedTableRow<T>
+                    key={rowKey}
+                    item={item}
+                    rowIndex={rowIndex}
+                    rowKey={rowKey}
+                    columns={resolvedColumns}
+                    plugins={plugins}
+                    RowComponent={RowComponent}
+                    CellComponent={CellComponent}
+                  />
+                );
+              })}
+        </tbody>
+      </table>
+    </div>
   );
 
   // Apply transformTableContext from each plugin (outermost-first)

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -19,6 +19,9 @@ import {
   generateColumns,
   columnWidthToCSS,
   capitalize,
+  resolveColumnMinWidth,
+  computeTableMinWidth,
+  DEFAULT_MIN_COLUMN_WIDTH,
 } from './columnUtils';
 import type {TablePlugin, XDSTableColumn} from './types';
 
@@ -117,6 +120,48 @@ describe('columnUtils', () => {
       for (const col of cols) {
         expect(col.width).toEqual({type: 'proportional', value: 1});
       }
+    });
+  });
+
+  describe('resolveColumnMinWidth', () => {
+    it('returns explicit minWidth when set', () => {
+      expect(resolveColumnMinWidth({key: 'a', minWidth: 120})).toBe(120);
+    });
+
+    it('returns pixel width value as implicit minimum', () => {
+      expect(resolveColumnMinWidth({key: 'a', width: pixel(200)})).toBe(200);
+    });
+
+    it('prefers explicit minWidth over pixel width', () => {
+      expect(
+        resolveColumnMinWidth({key: 'a', width: pixel(200), minWidth: 100}),
+      ).toBe(100);
+    });
+
+    it('returns DEFAULT_MIN_COLUMN_WIDTH for proportional columns', () => {
+      expect(resolveColumnMinWidth({key: 'a', width: proportional(1)})).toBe(
+        DEFAULT_MIN_COLUMN_WIDTH,
+      );
+    });
+
+    it('returns DEFAULT_MIN_COLUMN_WIDTH when no width is set', () => {
+      expect(resolveColumnMinWidth({key: 'a'})).toBe(DEFAULT_MIN_COLUMN_WIDTH);
+    });
+  });
+
+  describe('computeTableMinWidth', () => {
+    it('sums resolved min-widths across all columns', () => {
+      const cols: XDSTableColumn<User>[] = [
+        {key: 'name', minWidth: 120},
+        {key: 'age', width: pixel(80)},
+        {key: 'email'},
+      ];
+      // 120 + 80 + 60 (default) = 260
+      expect(computeTableMinWidth(cols)).toBe(260);
+    });
+
+    it('returns undefined for empty columns', () => {
+      expect(computeTableMinWidth([])).toBeUndefined();
     });
   });
 });
@@ -251,9 +296,53 @@ describe('XDSBaseTable', () => {
     expect(screen.getAllByRole('row')).toHaveLength(1);
   });
 
-  it('does not render colgroup', () => {
+  it('renders colgroup with col elements for column min-widths', () => {
     const {container} = render(<XDSBaseTable data={users} columns={columns} />);
-    expect(container.querySelector('colgroup')).toBeNull();
+    const colgroup = container.querySelector('colgroup');
+    expect(colgroup).toBeInTheDocument();
+    const cols = colgroup?.querySelectorAll('col');
+    expect(cols).toHaveLength(3);
+  });
+
+  describe('mobile responsiveness', () => {
+    it('wraps the table in a scroll container', () => {
+      const {container} = render(
+        <XDSBaseTable data={users} columns={columns} />,
+      );
+      const table = container.querySelector('table');
+      expect(table?.parentElement?.tagName).toBe('DIV');
+    });
+
+    it('sets min-width on the table based on column minimums', () => {
+      const cols: XDSTableColumn<User>[] = [
+        {key: 'name', minWidth: 150},
+        {key: 'age', width: pixel(80)},
+        {key: 'email', minWidth: 200},
+      ];
+      const {container} = render(<XDSBaseTable data={users} columns={cols} />);
+      const table = container.querySelector('table');
+      // 150 + 80 + 200 = 430
+      expect(table?.style.minWidth).toBe('430px');
+    });
+
+    it('renders colgroup with min-width on col elements', () => {
+      const cols: XDSTableColumn<User>[] = [
+        {key: 'name', minWidth: 150},
+        {key: 'age', width: pixel(80)},
+      ];
+      const {container} = render(<XDSBaseTable data={users} columns={cols} />);
+      const colElements = container.querySelectorAll('col');
+      expect(colElements).toHaveLength(2);
+      expect(colElements[0]?.style.minWidth).toBe('150px');
+      expect(colElements[1]?.style.minWidth).toBe('80px');
+    });
+
+    it('applies default minWidth to columns without explicit minWidth', () => {
+      const cols: XDSTableColumn<User>[] = [{key: 'name'}];
+      const {container} = render(<XDSBaseTable data={users} columns={cols} />);
+      const colElement = container.querySelector('col');
+      expect(colElement?.style.minWidth).toBe(`${DEFAULT_MIN_COLUMN_WIDTH}px`);
+    });
   });
 
   it('forwards ref to the table element', () => {

--- a/packages/core/src/Table/columnUtils.ts
+++ b/packages/core/src/Table/columnUtils.ts
@@ -18,6 +18,13 @@ import type {
 } from './types';
 
 /**
+ * Default minimum column width in pixels.
+ * Applied to proportional-width columns that don't specify a custom minWidth.
+ * Pixel-width columns use their pixel value as the implicit minimum.
+ */
+export const DEFAULT_MIN_COLUMN_WIDTH = 60;
+
+/**
  * Create a proportional column width (fr-like).
  * Columns share available space proportionally.
  *
@@ -79,6 +86,37 @@ export function defaultCellRenderer<T extends Record<string, unknown>>(
   const value = item[key];
   if (value == null) return '';
   return String(value);
+}
+
+/**
+ * Resolve the effective minimum width (in px) for a single column.
+ *
+ * Priority:
+ * 1. Explicit `minWidth` on the column definition
+ * 2. Pixel-width columns use their pixel value as the implicit minimum
+ * 3. Falls back to `DEFAULT_MIN_COLUMN_WIDTH`
+ */
+export function resolveColumnMinWidth<T extends Record<string, unknown>>(
+  column: XDSTableColumn<T>,
+): number {
+  if (column.minWidth != null) return column.minWidth;
+  if (column.width?.type === 'pixel') return column.width.value;
+  return DEFAULT_MIN_COLUMN_WIDTH;
+}
+
+/**
+ * Compute the total minimum table width from all columns.
+ * Returns undefined if the total equals 0 (no columns).
+ */
+export function computeTableMinWidth<T extends Record<string, unknown>>(
+  columns: XDSTableColumn<T>[],
+): number | undefined {
+  if (columns.length === 0) return undefined;
+  const total = columns.reduce(
+    (sum, col) => sum + resolveColumnMinWidth(col),
+    0,
+  );
+  return total > 0 ? total : undefined;
 }
 
 /**

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -20,6 +20,9 @@ export {
   pixel,
   generateColumns,
   columnWidthToCSS,
+  resolveColumnMinWidth,
+  computeTableMinWidth,
+  DEFAULT_MIN_COLUMN_WIDTH,
 } from './columnUtils';
 export type {
   XDSTableColumn,

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -60,6 +60,15 @@ export interface XDSTableColumn<T extends Record<string, unknown>> {
   /** Column width. Defaults to `proportional(1)`. */
   width?: ColumnWidth;
   /**
+   * Minimum column width in pixels. Prevents columns from compressing
+   * below this threshold on small screens. When the sum of all column
+   * minimums exceeds the container width, the table scrolls horizontally.
+   *
+   * @default 60 (px) for proportional-width columns; pixel-width columns
+   *   use their pixel value as the implicit minimum.
+   */
+  minWidth?: number;
+  /**
    * Custom cell renderer. Receives the row item and returns rich JSX content.
    * Defaults to `String(item[key])` — use renderCell for rich content like
    * badges, status dots, formatted text, icons, or composed layouts.


### PR DESCRIPTION
## Summary

Fixes #276 — table columns overlapping on small screens.

### What changed

1. **Scroll wrapper** — Wraps `<table>` in a `<div>` with `overflow-x: auto` so the table scrolls horizontally instead of compressing columns into each other on narrow viewports.

2. **`minWidth` on column config** — New optional `minWidth` property on `XDSTableColumn` lets consumers set per-column minimum widths. Defaults:
   - Proportional-width columns: **60px** (new `DEFAULT_MIN_COLUMN_WIDTH`)
   - Pixel-width columns: their pixel value as implicit minimum
   - Explicit `minWidth` overrides both

3. **`<colgroup>` rendering** — Renders `<col>` elements with `min-width` styles and sets a table-level `min-width` (sum of all column minimums) to trigger the horizontal scroll.

### New exports

- `resolveColumnMinWidth(column)` — resolves effective min-width for a column
- `computeTableMinWidth(columns)` — computes total table min-width
- `DEFAULT_MIN_COLUMN_WIDTH` — the 60px constant

### Files changed

| File | Change |
|------|--------|
| `types.ts` | Added `minWidth?: number` to `XDSTableColumn` |
| `columnUtils.ts` | Added min-width utilities and constant |
| `XDSBaseTable.tsx` | Scroll wrapper, colgroup, table min-width |
| `index.ts` | New exports |
| `XDSTable.test.tsx` | 11 new tests |

### Testing

All 1477 tests pass (91 test files), including 101 Table-specific tests and perf benchmarks.

---
*Crafted with care by Navi* 🧚