### PR TITLE
fix(AppShell): replace hardcoded spacing with spacingVars tokens in skip link

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -22,6 +22,7 @@ import {
   colorVars,
   fontWeightVars,
   radiusVars,
+  spacingVars,
   textSizeVars,
 } from '../theme/tokens.stylex';
 import {XDSLayout} from '../Layout/XDSLayout';
@@ -216,9 +217,13 @@ const styles = stylex.create({
       default: '1px',
       ':focus': 'auto',
     },
-    padding: {
+    paddingBlock: {
       default: 0,
-      ':focus': '8px 16px',
+      ':focus': spacingVars['--spacing-2'],
+    },
+    paddingInline: {
+      default: 0,
+      ':focus': spacingVars['--spacing-4'],
     },
     margin: {
       default: '-1px',
@@ -240,11 +245,11 @@ const styles = stylex.create({
     // Focus styles
     top: {
       default: 0,
-      ':focus': '8px',
+      ':focus': spacingVars['--spacing-2'],
     },
     insetInlineStart: {
       default: 0,
-      ':focus': '8px',
+      ':focus': spacingVars['--spacing-2'],
     },
     backgroundColor: colorVars['--color-surface'],
     color: colorVars['--color-accent-text'],


### PR DESCRIPTION
## What

Theme audit for `XDSAppShell` — the skip-to-content link used hardcoded pixel values for spacing in its `:focus` state. This PR replaces them with `spacingVars` tokens so theme authors can control skip link positioning through the token system.

## Changes

| Property | Before | After |
|----------|--------|-------|
| `padding` | `'8px 16px'` | `paddingBlock: spacingVars['--spacing-2']` / `paddingInline: spacingVars['--spacing-4']` |
| `top` | `'8px'` | `spacingVars['--spacing-2']` |
| `insetInlineStart` | `'8px'` | `spacingVars['--spacing-2']` |

Also adds `spacingVars` to the import from `tokens.stylex`.

## Audit Summary

Full theme audit of `XDSAppShell`:
- ✅ **Colors**: All use `colorVars` tokens
- ✅ **Radii**: Uses `radiusVars['--radius-page']`
- ✅ **Typography**: Uses `fontWeightVars`, `textSizeVars`
- ✅ **Component reuse**: No raw buttons/dividers/icons — shell is a layout component
- ✅ **xdsClassName**: Applied on root div with variant info (`app-shell`, `{height, variant}`)
- 🔧 **Spacing**: 3 hardcoded values in skip link → fixed in this PR

## Needs Review

The skip-to-content link is an **accessibility pattern** that only appears on keyboard focus. The hardcoded `8px` / `16px` values are small, unobtrusive positioning — not semantic UI spacing. While converting to tokens is technically correct and consistent, it does mean theme authors could inadvertently affect the skip link by changing global spacing tokens.

**Question for maintainers:** Should the skip link spacing follow the token system (this PR), or should it be considered an a11y exception with fixed values? If fixed values are preferred, this PR can be reverted.

## Testing

- ✅ All 31 AppShell tests pass
- ✅ Lint clean (0 errors)

---
