### PR TITLE
refactor(MobileNav): combine title and header into single header prop

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
@@ -762,7 +762,7 @@ export default function ShellLabPage() {
       : config.mobileNavMode === 'customContent'
         ? {
             content: (
-              <XDSMobileNav title="Custom Nav" side={config.mobileNavSide}>
+              <XDSMobileNav header="Custom Nav" side={config.mobileNavSide}>
                 <XDSVStack gap={2} xstyle={styles.customSearchBar}>
                   <input
                     type="search"

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -487,7 +487,7 @@ describe('XDSAppShell', () => {
       <XDSAppShell
         sideNav={<TestSideNav />}
         mobileNav={
-          <XDSMobileNav isOpen={true} onOpenChange={onClose} title="Nav">
+          <XDSMobileNav isOpen={true} onOpenChange={onClose} header="Nav">
             <div>Mobile Nav</div>
           </XDSMobileNav>
         }>

--- a/packages/core/src/MobileNav/XDSMobileNav.test.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.test.tsx
@@ -119,9 +119,9 @@ describe('XDSMobileNav', () => {
     expect(handleClose).toHaveBeenCalledTimes(1);
   });
 
-  it('renders title when provided', () => {
+  it('renders header string when provided', () => {
     render(
-      <XDSMobileNav isOpen={true} onOpenChange={() => {}} title="Navigation">
+      <XDSMobileNav isOpen={true} onOpenChange={() => {}} header="Navigation">
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -156,9 +156,9 @@ describe('XDSMobileNav', () => {
     expect(dialog.tagName).toBe('DIALOG');
   });
 
-  it('sets aria-label from title', () => {
+  it('sets aria-label from header string', () => {
     render(
-      <XDSMobileNav isOpen={true} onOpenChange={() => {}} title="My Nav">
+      <XDSMobileNav isOpen={true} onOpenChange={() => {}} header="My Nav">
         <span>Content</span>
       </XDSMobileNav>,
     );
@@ -166,7 +166,7 @@ describe('XDSMobileNav', () => {
     expect(screen.getByRole('dialog')).toHaveAttribute('aria-label', 'My Nav');
   });
 
-  it('defaults aria-label to Navigation when no title', () => {
+  it('defaults aria-label to Navigation when no header', () => {
     render(
       <XDSMobileNav isOpen={true} onOpenChange={() => {}}>
         <span>Content</span>

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -183,14 +183,9 @@ export interface XDSMobileNavProps extends Omit<XDSBaseProps, 'title'> {
   children: ReactNode;
 
   /**
-   * Optional title shown at the top of the drawer.
-   * For simple text headers. Use `header` for custom content.
-   */
-  title?: string;
-
-  /**
-   * Custom header content rendered in the header area next to the close button.
-   * Replaces `title` when provided. Use for logos, SideNavHeading, search bars, etc.
+   * Header content for the drawer. Rendered next to the close button.
+   * Pass a string for a simple text heading, or a ReactNode for
+   * custom content (logo, SideNavHeading, search bar, etc.).
    */
   header?: ReactNode;
 
@@ -207,7 +202,7 @@ export interface XDSMobileNavProps extends Omit<XDSBaseProps, 'title'> {
   side?: 'start' | 'end';
 
   /**
-   * Accessible label for the drawer. Falls back to title, then 'Navigation'.
+   * Accessible label for the drawer. Falls back to header string, then 'Navigation'.
    */
   label?: string;
 
@@ -239,13 +234,13 @@ export interface XDSMobileNavProps extends Omit<XDSBaseProps, 'title'> {
  * ```
  * // Inside AppShell — state managed by AppShell
  * <XDSAppShell mobileNav={
- *   <XDSMobileNav title="Navigation">
+ *   <XDSMobileNav header="Navigation">
  *     <XDSSideNavItem label="Home" href="/" />
  *   </XDSMobileNav>
  * }>
  *
  * // Standalone — manage state yourself
- * <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} title="Navigation">
+ * <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} header="Navigation">
  *   <XDSSideNavItem label="Home" href="/" />
  * </XDSMobileNav>
  * ```
@@ -254,7 +249,6 @@ export function XDSMobileNav({
   isOpen: isOpenProp,
   onOpenChange: onOpenChangeProp,
   children,
-  title,
   header,
   width = 320,
   side = 'end',
@@ -354,7 +348,7 @@ export function XDSMobileNav({
     <dialog
       ref={setRefs}
       data-testid={testId}
-      aria-label={label ?? title ?? 'Navigation'}
+      aria-label={label ?? (typeof header === 'string' ? header : 'Navigation')}
       onClick={handleDialogClick}
       onCancel={handleCancel}
       {...mergeProps(
@@ -376,14 +370,13 @@ export function XDSMobileNav({
           !isStart && styles.drawerEnd,
           !isStart && isOpen && styles.drawerEndOpen,
         )}>
-        {/* Header — custom content or title + close button */}
-        <div
-          {...stylex.props(
-            styles.header,
-            !title && !header && styles.headerNoTitle,
-          )}>
-          {header ??
-            (title ? <XDSHeading level={2}>{title}</XDSHeading> : null)}
+        {/* Header — content + close button */}
+        <div {...stylex.props(styles.header, !header && styles.headerNoTitle)}>
+          {typeof header === 'string' ? (
+            <XDSHeading level={2}>{header}</XDSHeading>
+          ) : (
+            (header ?? null)
+          )}
           <XDSButton
             variant="ghost"
             label="Close navigation"

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -137,6 +137,9 @@ const styles = stylex.create({
   headerNoTitle: {
     justifyContent: 'flex-end',
   },
+  headerText: {
+    marginInlineStart: spacingVars['--spacing-1'],
+  },
   content: {
     flex: 1,
     overflowY: 'auto',
@@ -373,7 +376,9 @@ export function XDSMobileNav({
         {/* Header — content + close button */}
         <div {...stylex.props(styles.header, !header && styles.headerNoTitle)}>
           {typeof header === 'string' ? (
-            <XDSHeading level={2}>{header}</XDSHeading>
+            <span {...stylex.props(styles.headerText)}>
+              <XDSHeading level={2}>{header}</XDSHeading>
+            </span>
           ) : (
             (header ?? null)
           )}


### PR DESCRIPTION
## What

Combines the separate `title` (string) and `header` (ReactNode) props on `XDSMobileNav` into a single `header` prop that accepts both.

### Before

```tsx
<XDSMobileNav title="Navigation">
<XDSMobileNav header={<XDSSideNavHeading heading="My App" />}>
```

### After

```tsx
// String — renders as XDSHeading
<XDSMobileNav header="Navigation">

// ReactNode — renders as-is
<XDSMobileNav header={<XDSSideNavHeading heading="My App" icon={<Logo />} />}>

// No header — just close button
<XDSMobileNav>
```

### Details

- `header?: ReactNode` — string renders as `<XDSHeading level={2}>`, ReactNode renders as-is, omit for close-button-only
- `aria-label` falls back to `header` when it's a string, then `'Navigation'`
- Updated all tests, shell lab, and doc examples

---
