### PR TITLE
feat: shell hardening batch — entry animation, TopNavMenu mobile, collapsible items (#565)

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
@@ -102,7 +102,6 @@ interface ShellConfig {
   variant: 'wash' | 'surface' | 'section' | 'elevated';
   height: 'fill' | 'auto';
   sideNavBreakpoint: 'sm' | 'md' | 'lg' | 'none';
-  sideNavWidth: number;
   showSideNav: boolean;
   showTopNav: boolean;
   showBanner: boolean;
@@ -126,7 +125,6 @@ const DEFAULT_CONFIG: ShellConfig = {
   variant: 'section',
   height: 'fill',
   sideNavBreakpoint: 'md',
-  sideNavWidth: 260,
   showSideNav: true,
   showTopNav: true,
   showBanner: false,
@@ -754,13 +752,14 @@ export default function ShellLabPage() {
   // Build the mobileNav prop based on config
   const mobileNav:
     | false
-    | {hasToggle?: boolean; content?: React.ReactNode}
+    | {hasToggle?: boolean; content?: React.ReactNode; breakpoint?: string}
     | React.ReactNode
     | undefined =
     config.mobileNavMode === 'disabled'
       ? false
       : config.mobileNavMode === 'customContent'
         ? {
+            breakpoint: config.sideNavBreakpoint,
             content: (
               <XDSMobileNav header="Custom Nav" side={config.mobileNavSide}>
                 <XDSVStack gap={2} xstyle={styles.customSearchBar}>
@@ -804,8 +803,8 @@ export default function ShellLabPage() {
             ),
           }
         : config.mobileNavMode === 'customToggle'
-          ? {hasToggle: false} // auto drawer content, but no auto toggle
-          : undefined; // auto with toggle — full default behavior
+          ? {hasToggle: false, breakpoint: config.sideNavBreakpoint} // auto drawer content, but no auto toggle
+          : {breakpoint: config.sideNavBreakpoint}; // auto with breakpoint
 
   return (
     <>
@@ -813,8 +812,6 @@ export default function ShellLabPage() {
         variant={config.variant}
         height={config.height}
         contentPadding={6}
-        sideNavBreakpoint={config.sideNavBreakpoint}
-        sideNavWidth={config.sideNavWidth}
         topNav={
           config.showTopNav ? (
             <SampleTopNav

--- a/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
@@ -4,6 +4,7 @@ import {useState, useCallback} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 import {XDSAppShell} from '@xds/core/AppShell';
+import type {XDSMobileNavConfig} from '@xds/core/AppShell';
 import {
   XDSSideNav,
   XDSSideNavHeading,
@@ -750,11 +751,7 @@ export default function ShellLabPage() {
   }, []);
 
   // Build the mobileNav prop based on config
-  const mobileNav:
-    | false
-    | {hasToggle?: boolean; content?: React.ReactNode; breakpoint?: string}
-    | React.ReactNode
-    | undefined =
+  const mobileNav: false | XDSMobileNavConfig | React.ReactNode | undefined =
     config.mobileNavMode === 'disabled'
       ? false
       : config.mobileNavMode === 'customContent'

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -236,13 +236,7 @@ const meta: Meta<typeof XDSAppShell> = {
       control: 'boolean',
       description: 'Whether the side nav starts collapsed',
     },
-    sideNavBreakpoint: {
-      control: 'radio',
-      options: ['sm', 'md', 'lg', 'none'],
-    },
-    sideNavWidth: {
-      control: 'number',
-    },
+
     background: {
       control: 'radio',
       options: ['surface', 'wash'],

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   features: [
     'Two navigation slots: topNav (horizontal bar) and sideNav (vertical sidebar)',
     'Two height modes: fill (viewport-height, independent scroll containers) and auto (page-scroll with sticky nav)',
-    'Controlled and uncontrolled sideNav collapse with responsive auto-collapse via sideNavBreakpoint',
+    'Controlled and uncontrolled sideNav collapse with responsive auto-collapse via mobileNav breakpoint',
     'Mobile: collapsed sideNav renders as an overlay with backdrop',
     'Composes XDSLayout internally for automatic padding collapse, scroll containment, and slot awareness',
     'Semantic HTML: <main> with role="main", SideNav with role="navigation", skip-to-content link',
@@ -213,7 +213,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       name: 'mobileNav',
       type: 'ReactNode',
       description:
-        'Mobile navigation slot, typically an XDSMobileNav component. Rendered when the viewport is below the sideNavBreakpoint.',
+        'Mobile navigation configuration. Accepts false (disable), config object (tune auto behavior), or ReactNode (full custom drawer).',
     },
     {
       name: 'banner',
@@ -244,19 +244,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       type: '(isCollapsed: boolean) => void',
       description: 'Callback fired when the sideNav collapse state changes.',
     },
-    {
-      name: 'sideNavBreakpoint',
-      type: "'sm' | 'md' | 'lg' | 'none'",
-      description:
-        'Viewport-width breakpoint below which the sideNav auto-collapses. Use "none" to disable responsive collapse.',
-      default: "'md'",
-    },
-    {
-      name: 'sideNavWidth',
-      type: 'number',
-      description: 'Width of the sideNav panel in pixels.',
-      default: '260',
-    },
+
     {
       name: 'variant',
       type: "'wash' | 'surface' | 'section' | 'elevated'",
@@ -301,7 +289,7 @@ export const docsZh = {
   features: [
     '两个导航插槽：topNav（水平导航栏）和 sideNav（垂直侧边栏）',
     '两种高度模式：fill（视口高度，独立滚动容器）和 auto（页面滚动，导航栏吸顶）',
-    '受控和非受控的 sideNav 折叠，通过 sideNavBreakpoint 支持响应式自动折叠',
+    '受控和非受控的 sideNav 折叠，通过 mobileNav breakpoint 支持响应式自动折叠',
     '移动端：折叠的 sideNav 以带遮罩层的浮层形式展示',
     '内部组合使用 XDSLayout，自动处理内边距折叠、滚动容器和插槽感知',
     '语义化 HTML：<main> 带 role="main"，SideNav 带 role="navigation"，跳转到内容链接',
@@ -470,7 +458,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       name: 'mobileNav',
       type: 'ReactNode',
       description:
-        '移动端导航插槽，通常为 XDSMobileNav 组件。当视口宽度低于 sideNavBreakpoint 时渲染。',
+        '移动端导航配置。接受 false（禁用）、配置对象（调整自动行为）或 ReactNode（完全自定义抽屉）。',
     },
     {
       name: 'banner',
@@ -557,7 +545,7 @@ export const docsDense = {
   features: [
     'two nav slots: topNav (horizontal bar) + sideNav (vertical sidebar)',
     'two height modes: fill (viewport 100dvh, independent scroll) + auto (page-scroll w/ sticky nav)',
-    'controlled+uncontrolled sideNav collapse w/ responsive auto-collapse via sideNavBreakpoint',
+    'controlled+uncontrolled sideNav collapse w/ responsive auto-collapse via mobileNav breakpoint',
     'mobile: collapsed sideNav renders as overlay w/ backdrop',
     'composes XDSLayout internally for auto padding collapse, scroll containment, slot awareness',
     'semantic HTML: <main> role="main", SideNav role="navigation", skip-to-content link',
@@ -582,15 +570,13 @@ export const docsDense = {
     children: 'main content area, rendered inside <main>',
     topNav: 'top nav slot, typically XDSTopNav',
     sideNav: 'side nav slot, typically XDSSideNav',
-    mobileNav: 'mobile nav slot, typically XDSMobileNav; rendered below sideNavBreakpoint',
+    mobileNav: 'mobile nav config: false | MobileNavConfig | ReactNode',
     banner: 'slot for system-wide announcements above topNav',
     height:
       'fill=viewport 100dvh w/ independent scroll; auto=content-driven w/ sticky nav',
     isSideNavCollapsed: 'sideNav collapsed (controlled)',
     defaultIsSideNavCollapsed: 'initial collapsed state (uncontrolled)',
     onSideNavCollapsedChange: 'callback on sideNav collapse change',
-    sideNavBreakpoint: 'auto-collapse breakpoint; "none" disables responsive collapse',
-    sideNavWidth: 'sideNav panel width in px',
     variant:
       'nav bg style: wash=wash bg, surface=surface bg, section=dividers, elevated=wash nav w/ elevated surface content+radius',
     contentPadding:

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -238,7 +238,7 @@ describe('XDSAppShell', () => {
 
   it('tracks breakpoint changes', () => {
     render(
-      <XDSAppShell sideNav={<TestSideNav />} sideNavBreakpoint="md">
+      <XDSAppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'md'}}>
         <div>Content</div>
       </XDSAppShell>,
     );
@@ -247,9 +247,9 @@ describe('XDSAppShell', () => {
     expect(window.matchMedia).toHaveBeenCalled();
   });
 
-  it('does not track breakpoint when sideNavBreakpoint is none', () => {
+  it('does not track breakpoint when mobileNav breakpoint is none', () => {
     render(
-      <XDSAppShell sideNav={<TestSideNav />} sideNavBreakpoint="none">
+      <XDSAppShell sideNav={<TestSideNav />} mobileNav={{breakpoint: 'none'}}>
         <div>Content</div>
       </XDSAppShell>,
     );

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -718,20 +718,26 @@ export function XDSAppShell({
   // mode — it shows heading + footer icons horizontally, with the hamburger
   const autoMobileTopBar =
     shouldShowAutoToggle && !hasTopNav && hasSideNav ? (
-      <XDSLayoutHeader
-        padding={0}
-        hasDivider={navHasDividers}
-        xstyle={navAreaStyle}>
-        <div
-          {...stylex.props(styles.autoMobileTopBar)}
-          role="navigation"
-          aria-label="Mobile navigation">
-          <XDSSideNavRenderContext value="topbar">
-            {sideNav}
-          </XDSSideNavRenderContext>
-          <XDSMobileNavToggle />
-        </div>
-      </XDSLayoutHeader>
+      <div
+        {...stylex.props(
+          isAuto && styles.headerSticky,
+          isAuto && stickyBgStyle,
+        )}>
+        <XDSLayoutHeader
+          padding={0}
+          hasDivider={navHasDividers}
+          xstyle={navAreaStyle}>
+          <div
+            {...stylex.props(styles.autoMobileTopBar)}
+            role="navigation"
+            aria-label="Mobile navigation">
+            <XDSSideNavRenderContext value="topbar">
+              {sideNav}
+            </XDSSideNavRenderContext>
+            <XDSMobileNavToggle />
+          </div>
+        </XDSLayoutHeader>
+      </div>
     ) : undefined;
 
   return (

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -491,7 +491,7 @@ export function XDSAppShell({
   const contentAreaStyle =
     variant === 'wash'
       ? styles.contentBgWash
-      : variant === 'elevated' && hasTopNav && hasSideNav
+      : variant === 'elevated' && hasTopNav && hasSideNav && !isBelowBreakpoint
         ? styles.contentBgTransparent
         : variant === 'surface' || variant === 'elevated'
           ? styles.contentBgSurface

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -51,8 +51,6 @@ import {xdsClassName, mergeProps} from '../utils';
 // Constants
 // =============================================================================
 
-const DEFAULT_SIDENAV_WIDTH = 260;
-
 const BREAKPOINT_VALUES: Record<XDSAppShellBreakpoint, number> = {
   sm: 640,
   md: 768,
@@ -114,6 +112,12 @@ export interface XDSMobileNavConfig {
    * or raw children.
    */
   content?: ReactNode;
+
+  /**
+   * Breakpoint below which mobile nav activates.
+   * @default 'md'
+   */
+  breakpoint?: XDSAppShellBreakpoint;
 }
 
 export interface XDSAppShellProps {
@@ -200,18 +204,6 @@ export interface XDSAppShellProps {
    * Side navigation — typically an XDSSideNav.
    */
   sideNav?: ReactNode;
-
-  /**
-   * Breakpoint below which side nav auto-collapses.
-   * @default 'md'
-   */
-  sideNavBreakpoint?: XDSAppShellBreakpoint;
-
-  /**
-   * Width of side nav when expanded (in pixels).
-   * @default 260
-   */
-  sideNavWidth?: number;
 
   /**
    * Top navigation — typically an XDSTopNav.
@@ -428,8 +420,6 @@ export function XDSAppShell({
   height = 'fill',
   mobileNav,
   sideNav,
-  sideNavBreakpoint = 'md',
-  sideNavWidth = DEFAULT_SIDENAV_WIDTH,
   topNav,
   xstyle,
   className,
@@ -447,6 +437,8 @@ export function XDSAppShell({
     !isValidElement(mobileNav)
       ? (mobileNav as XDSMobileNavConfig)
       : null;
+  const sideNavBreakpoint: XDSAppShellBreakpoint =
+    mobileNavConfig?.breakpoint ?? 'md';
   // ReactNode shorthand — user provides <XDSMobileNav> directly as the prop
   const mobileNavReactNode: ReactNode | null =
     mobileNav != null &&

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -81,11 +81,6 @@ const styles = stylex.create({
     '::backdrop': {
       opacity: 1,
     },
-    '@starting-style': {
-      '::backdrop': {
-        opacity: 0,
-      },
-    },
   },
   drawer: {
     position: 'absolute',
@@ -114,9 +109,6 @@ const styles = stylex.create({
   },
   drawerStartOpen: {
     transform: 'translateX(0)',
-    '@starting-style': {
-      transform: 'translateX(-100%)',
-    },
   },
   drawerEnd: {
     insetInlineEnd: 0,
@@ -130,9 +122,6 @@ const styles = stylex.create({
   },
   drawerEndOpen: {
     transform: 'translateX(0)',
-    '@starting-style': {
-      transform: 'translateX(100%)',
-    },
   },
   header: {
     display: 'flex',

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -55,6 +55,9 @@ const styles = stylex.create({
     height: '100dvh',
     backgroundColor: 'transparent',
     overflow: 'hidden',
+    overscrollBehavior: 'contain',
+    // Prevent touch gestures (pull-to-refresh, background scroll) passing through
+    touchAction: 'none',
     outline: 'none',
     // Native <dialog> uses display:none when closed — we preserve that
     // by only setting display when [open] via :where() selector.
@@ -68,6 +71,7 @@ const styles = stylex.create({
   backdrop: {
     '::backdrop': {
       backgroundColor: colorVars['--color-overlay'],
+      backdropFilter: 'blur(2px)',
       opacity: 0,
       transition: `opacity ${SLIDE_DURATION} ${SLIDE_EASING}`,
     },
@@ -145,6 +149,9 @@ const styles = stylex.create({
     overflowY: 'auto',
     overflowX: 'hidden',
     overscrollBehavior: 'contain',
+    // Re-enable vertical touch scrolling inside the drawer content
+    // (dialog root has touch-action: none to block pull-to-refresh)
+    touchAction: 'pan-y',
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
   },
@@ -307,7 +314,21 @@ export function XDSMobileNav({
       if (!dialog.open) {
         dialog.showModal();
       }
+      // Lock body scroll to prevent iOS pull-to-refresh and background scrolling
+      const scrollY = window.scrollY;
+      document.body.style.overflow = 'hidden';
+      document.body.style.position = 'fixed';
+      document.body.style.top = `-${scrollY}px`;
+      document.body.style.width = '100%';
     } else if (dialog.open) {
+      // Restore body scroll position
+      const scrollY = Math.abs(parseInt(document.body.style.top || '0', 10));
+      document.body.style.overflow = '';
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
+      window.scrollTo(0, scrollY);
+
       const duration = window.matchMedia('(prefers-reduced-motion: reduce)')
         .matches
         ? 10
@@ -321,6 +342,11 @@ export function XDSMobileNav({
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
       }
+      // Ensure body scroll is restored on unmount
+      document.body.style.overflow = '';
+      document.body.style.position = '';
+      document.body.style.top = '';
+      document.body.style.width = '';
     };
   }, [isOpen]);
 

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -153,7 +153,7 @@ const styles = stylex.create({
     // (dialog root has touch-action: none to block pull-to-refresh)
     touchAction: 'pan-y',
     paddingInline: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-1'],
+    paddingBlock: spacingVars['--spacing-2'],
   },
 });
 

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -81,6 +81,11 @@ const styles = stylex.create({
     '::backdrop': {
       opacity: 1,
     },
+    '@starting-style': {
+      '::backdrop': {
+        opacity: 0,
+      },
+    },
   },
   drawer: {
     position: 'absolute',
@@ -109,6 +114,9 @@ const styles = stylex.create({
   },
   drawerStartOpen: {
     transform: 'translateX(0)',
+    '@starting-style': {
+      transform: 'translateX(-100%)',
+    },
   },
   drawerEnd: {
     insetInlineEnd: 0,
@@ -122,6 +130,9 @@ const styles = stylex.create({
   },
   drawerEndOpen: {
     transform: 'translateX(0)',
+    '@starting-style': {
+      transform: 'translateX(100%)',
+    },
   },
   header: {
     display: 'flex',

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -314,20 +314,12 @@ export function XDSMobileNav({
       if (!dialog.open) {
         dialog.showModal();
       }
-      // Lock body scroll to prevent iOS pull-to-refresh and background scrolling
-      const scrollY = window.scrollY;
-      document.body.style.overflow = 'hidden';
-      document.body.style.position = 'fixed';
-      document.body.style.top = `-${scrollY}px`;
-      document.body.style.width = '100%';
+      // Prevent background scrolling and iOS pull-to-refresh.
+      // overflow: clip avoids creating a scroll container (unlike hidden),
+      // so there's no scroll bounce and no need to save/restore scroll position.
+      document.documentElement.style.overflow = 'clip';
     } else if (dialog.open) {
-      // Restore body scroll position
-      const scrollY = Math.abs(parseInt(document.body.style.top || '0', 10));
-      document.body.style.overflow = '';
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
-      window.scrollTo(0, scrollY);
+      document.documentElement.style.overflow = '';
 
       const duration = window.matchMedia('(prefers-reduced-motion: reduce)')
         .matches
@@ -342,11 +334,7 @@ export function XDSMobileNav({
       if (closeTimeoutRef.current) {
         clearTimeout(closeTimeoutRef.current);
       }
-      // Ensure body scroll is restored on unmount
-      document.body.style.overflow = '';
-      document.body.style.position = '';
-      document.body.style.top = '';
-      document.body.style.width = '';
+      document.documentElement.style.overflow = '';
     };
   }, [isOpen]);
 

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -377,8 +377,9 @@ export function XDSMobileNav({
           xstyle,
         ),
       )}>
-      {/* Drawer panel */}
+      {/* Drawer panel — tabIndex so showModal() focuses the drawer, not the close button */}
       <div
+        tabIndex={-1}
         {...stylex.props(
           styles.drawer,
           dynamicStyles.width(width),
@@ -399,7 +400,6 @@ export function XDSMobileNav({
           <XDSButton
             variant="ghost"
             label="Close navigation"
-            tooltip="Close"
             icon={<XDSIcon icon="close" color="inherit" />}
             onClick={() => onOpenChange(false)}
           />

--- a/packages/core/src/NavItem/index.ts
+++ b/packages/core/src/NavItem/index.ts
@@ -1,0 +1,1 @@
+export {navItemStyles} from './navItemStyles.stylex';

--- a/packages/core/src/NavItem/navItemStyles.stylex.ts
+++ b/packages/core/src/NavItem/navItemStyles.stylex.ts
@@ -1,0 +1,95 @@
+/**
+ * @file navItemStyles.stylex.ts
+ * @input Uses theme tokens (color, spacing, radius, typography, transition)
+ * @output Exports shared nav item appearance styles
+ * @position Shared styles consumed by SideNavItem, TopNavItem (drawer mode),
+ *   TopNavMenu (drawer mode), and any custom nav items that need to match.
+ *
+ * Centralizes the nav item appearance (layout, colors, hover/active/selected states,
+ * disabled state) so all nav-like components stay in sync — especially important
+ * when TopNav items render inside MobileNav drawers alongside SideNav items.
+ *
+ * Individual components layer their own overrides (e.g. collapsed mode, indentation,
+ * focus outlines) via stylex.props composition.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  textSizeVars,
+  fontWeightVars,
+  lineHeightVars,
+} from '../theme/tokens.stylex';
+
+/**
+ * Base styles shared by all nav item components.
+ * Apply as a foundation and override specific properties as needed.
+ *
+ * @example
+ * ```
+ * import {navItemStyles} from '@xds/core/navItemStyles';
+ *
+ * const styles = stylex.create({
+ *   indented: { paddingInlineStart: spacingVars['--spacing-6'] },
+ * });
+ *
+ * <a {...stylex.props(navItemStyles.item, styles.indented)}>
+ *   Dashboard
+ * </a>
+ * ```
+ */
+export const navItemStyles = stylex.create({
+  /** Base interactive nav item — layout, typography, hover/active states */
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    width: '100%',
+    paddingInline: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-2'],
+    borderRadius: radiusVars['--radius-element'],
+    borderWidth: 0,
+    borderStyle: 'none',
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-primary'],
+    textDecoration: 'none',
+    cursor: 'pointer',
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    lineHeight: lineHeightVars['--leading-base'],
+    textAlign: 'start',
+    boxSizing: 'border-box',
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-hover-overlay'],
+      },
+    },
+    ':active': {
+      backgroundColor: colorVars['--color-pressed-overlay'],
+    },
+  },
+
+  /** Selected/active page indicator — deemphasized background, medium weight */
+  selected: {
+    backgroundColor: colorVars['--color-deemphasized'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-deemphasized'],
+      },
+    },
+    ':active': {
+      backgroundColor: colorVars['--color-deemphasized'],
+    },
+  },
+
+  /** Disabled state — muted color, no interaction */
+  disabled: {
+    color: colorVars['--color-text-disabled'],
+    cursor: 'not-allowed',
+    pointerEvents: 'none' as const,
+  },
+});

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -111,6 +111,20 @@ const styles = stylex.create({
     borderBlockStart: 'none',
     paddingBlockStart: 0,
   },
+  // Drawer footer — pushed to bottom of the scrollable content area
+  drawerFooter: {
+    display: 'flex',
+    flexDirection: 'column',
+    marginBlockStart: 'auto',
+    gap: spacingVars['--spacing-2'],
+    paddingBlockStart: spacingVars['--spacing-2'],
+    borderBlockStart: `1px solid ${colorVars['--color-divider']}`,
+  },
+  drawerFooterIcons: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+  },
   // Topbar mode — horizontal layout for mobile top bar
   topbar: {
     display: 'flex',
@@ -298,12 +312,23 @@ export function XDSSideNav({
   // =========================================================================
   // Drawer mode — render inside XDSMobileNav with heading as header
   // =========================================================================
+  const hasDrawerFooter = !!(footer || footerIcons);
+
   if (renderMode === 'drawer') {
     return (
       <XDSMobileNav header={header} data-testid={testId}>
         {topContent}
         {children}
-        {footer}
+        {hasDrawerFooter && (
+          <div {...stylex.props(styles.drawerFooter)}>
+            {footer}
+            {footerIcons && (
+              <div {...stylex.props(styles.drawerFooterIcons)}>
+                {footerIcons}
+              </div>
+            )}
+          </div>
+        )}
       </XDSMobileNav>
     );
   }
@@ -317,7 +342,16 @@ export function XDSSideNav({
       <>
         {topContent}
         {children}
-        {footer}
+        {hasDrawerFooter && (
+          <div {...stylex.props(styles.drawerFooter)}>
+            {footer}
+            {footerIcons && (
+              <div {...stylex.props(styles.drawerFooterIcons)}>
+                {footerIcons}
+              </div>
+            )}
+          </div>
+        )}
       </>
     );
   }

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -133,7 +133,6 @@ const styles = stylex.create({
     justifyContent: 'space-between',
     height: 48,
     width: '100%',
-    paddingInline: spacingVars['--spacing-2'],
     backgroundColor: 'inherit',
     boxSizing: 'border-box',
     overflow: 'hidden',

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -32,6 +32,7 @@ import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSTooltip} from '../Tooltip';
+import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
 import {getIcon} from '../Icon/globalIconRegistry';
 
@@ -45,55 +46,9 @@ const styles = stylex.create({
     flexDirection: 'column',
     width: '100%',
   },
-  item: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-2'],
-    width: '100%',
-    paddingInline: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-2'],
-    borderRadius: radiusVars['--radius-element'],
-    borderWidth: 0,
-    borderStyle: 'none',
-    backgroundColor: 'transparent',
-    color: colorVars['--color-text-primary'],
-    textDecoration: 'none',
-    cursor: 'pointer',
-    fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
-    fontWeight: fontWeightVars['--font-weight-normal'],
-    lineHeight: lineHeightVars['--leading-base'],
-    textAlign: 'start',
-    boxSizing: 'border-box',
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-hover-overlay'],
-      },
-    },
-    ':active': {
-      backgroundColor: colorVars['--color-pressed-overlay'],
-    },
-  },
   itemCollapsed: {
     justifyContent: 'center',
     paddingInline: spacingVars['--spacing-1'],
-  },
-  selected: {
-    backgroundColor: colorVars['--color-deemphasized'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-deemphasized'],
-      },
-    },
-    ':active': {
-      backgroundColor: colorVars['--color-deemphasized'],
-    },
-  },
-  disabled: {
-    color: colorVars['--color-text-disabled'],
-    cursor: 'not-allowed',
-    pointerEvents: 'none',
   },
   label: {
     flex: 1,
@@ -338,10 +293,10 @@ export function XDSSideNavItem({
         onClick={handleClick}
         {...ariaProps}
         {...stylex.props(
-          styles.item,
+          navItemStyles.item,
           isCollapsed && styles.itemCollapsed,
-          isSelected && styles.selected,
-          isDisabled && styles.disabled,
+          isSelected && navItemStyles.selected,
+          isDisabled && navItemStyles.disabled,
         )}>
         {itemContent}
       </LinkComponent>
@@ -353,10 +308,10 @@ export function XDSSideNavItem({
         disabled={isDisabled}
         {...ariaProps}
         {...stylex.props(
-          styles.item,
+          navItemStyles.item,
           isCollapsed && styles.itemCollapsed,
-          isSelected && styles.selected,
-          isDisabled && styles.disabled,
+          isSelected && navItemStyles.selected,
+          isDisabled && navItemStyles.disabled,
         )}>
         {itemContent}
       </button>

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -325,6 +325,8 @@ export function XDSSideNavItem({
   const ariaProps = {
     'aria-current': isSelected ? ('page' as const) : undefined,
     'aria-disabled': isDisabled || undefined,
+    'aria-expanded': isItemCollapsible ? !isItemCollapsed : undefined,
+    'aria-controls': isItemCollapsible ? `${id}-children` : undefined,
     'data-testid': testId,
   };
 
@@ -367,6 +369,7 @@ export function XDSSideNavItem({
       {itemElement}
       {hasChildren && !isCollapsed && (
         <div
+          id={`${id}-children`}
           role="group"
           aria-labelledby={`${id}-label`}
           aria-hidden={isItemCollapsed}

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -201,7 +201,7 @@ export function XDSSideNavItem({
   onClick,
   endContent,
   children,
-  collapsible: itemCollapsible = false,
+  collapsible: itemCollapsible,
   'data-testid': testId,
   ref,
 }: XDSSideNavItemProps) {
@@ -214,7 +214,7 @@ export function XDSSideNavItem({
   // Collapse state for items with children
   const itemCollapsibleConfig =
     typeof itemCollapsible === 'object' ? itemCollapsible : {};
-  const isItemCollapsible = hasChildren && !!itemCollapsible;
+  const isItemCollapsible = hasChildren && itemCollapsible !== false;
   const itemControlledCollapsed = itemCollapsibleConfig.isCollapsed;
   const isItemControlled = itemControlledCollapsed !== undefined;
   const [uncontrolledCollapsed, setUncontrolledCollapsed] = useState(

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -87,7 +87,7 @@ const styles = stylex.create({
     flexShrink: 0,
   },
   expandChevronCollapsed: {
-    transform: 'rotate(-90deg)',
+    transform: 'rotate(180deg)',
   },
 });
 

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -182,18 +182,23 @@ export interface XDSSideNavItemProps {
    */
   children?: ReactNode;
   /**
-   * Whether sub-items are expanded. Uncontrolled by default.
-   * @default true
+   * Enables collapse behavior for items with children.
+   * When true, clicking the item toggles visibility of sub-items.
+   *
+   * - `true` — collapsible with defaults (starts expanded)
+   * - Object — controlled/configured:
+   *   - `defaultIsCollapsed` — start collapsed (default: false)
+   *   - `isCollapsed` + `onCollapsedChange` — controlled mode
+   *
+   * @default false
    */
-  defaultIsExpanded?: boolean;
-  /**
-   * Controlled expanded state for sub-items.
-   */
-  isExpanded?: boolean;
-  /**
-   * Callback when expand/collapse state changes.
-   */
-  onExpandedChange?: (expanded: boolean) => void;
+  collapsible?:
+    | boolean
+    | {
+        defaultIsCollapsed?: boolean;
+        isCollapsed?: boolean;
+        onCollapsedChange?: (isCollapsed: boolean) => void;
+      };
   /**
    * Test ID for the item element.
    */
@@ -235,9 +240,7 @@ export function XDSSideNavItem({
   onClick,
   endContent,
   children,
-  defaultIsExpanded = true,
-  isExpanded: controlledExpanded,
-  onExpandedChange,
+  collapsible: itemCollapsible = false,
   'data-testid': testId,
   ref,
 }: XDSSideNavItemProps) {
@@ -247,21 +250,26 @@ export function XDSSideNavItem({
   const LinkComponent = useXDSLinkComponent(as);
   const itemRef = useRef<HTMLDivElement>(null);
 
-  // Expand/collapse state for items with children
-  const isExpandControlled = controlledExpanded !== undefined;
-  const [uncontrolledExpanded, setUncontrolledExpanded] =
-    useState(defaultIsExpanded);
-  const isItemExpanded = isExpandControlled
-    ? controlledExpanded
-    : uncontrolledExpanded;
+  // Collapse state for items with children
+  const itemCollapsibleConfig =
+    typeof itemCollapsible === 'object' ? itemCollapsible : {};
+  const isItemCollapsible = hasChildren && !!itemCollapsible;
+  const itemControlledCollapsed = itemCollapsibleConfig.isCollapsed;
+  const isItemControlled = itemControlledCollapsed !== undefined;
+  const [uncontrolledCollapsed, setUncontrolledCollapsed] = useState(
+    itemCollapsibleConfig.defaultIsCollapsed ?? false,
+  );
+  const isItemCollapsed = isItemControlled
+    ? itemControlledCollapsed
+    : uncontrolledCollapsed;
 
-  const toggleExpand = useCallback(() => {
-    const next = !isItemExpanded;
-    if (!isExpandControlled) {
-      setUncontrolledExpanded(next);
+  const toggleItemCollapse = useCallback(() => {
+    const next = !isItemCollapsed;
+    if (!isItemControlled) {
+      setUncontrolledCollapsed(next);
     }
-    onExpandedChange?.(next);
-  }, [isItemExpanded, isExpandControlled, onExpandedChange]);
+    itemCollapsibleConfig.onCollapsedChange?.(next);
+  }, [isItemCollapsed, isItemControlled, itemCollapsibleConfig]);
 
   const displayIcon = isSelected && selectedIcon ? selectedIcon : icon;
 
@@ -275,9 +283,9 @@ export function XDSSideNavItem({
       e.preventDefault();
       return;
     }
-    if (hasChildren && !isCollapsed) {
+    if (isItemCollapsible && !isCollapsed) {
       e.preventDefault();
-      toggleExpand();
+      toggleItemCollapse();
       return;
     }
     onClick?.(e);
@@ -296,11 +304,11 @@ export function XDSSideNavItem({
       {!isCollapsed && endContent && (
         <span {...stylex.props(styles.endContent)}>{endContent}</span>
       )}
-      {!isCollapsed && hasChildren && (
+      {!isCollapsed && isItemCollapsible && (
         <span
           {...stylex.props(
             styles.expandChevron,
-            !isItemExpanded && styles.expandChevronCollapsed,
+            isItemCollapsed && styles.expandChevronCollapsed,
           )}>
           {getIcon('chevronDown')}
         </span>
@@ -355,10 +363,10 @@ export function XDSSideNavItem({
         <div
           role="group"
           aria-labelledby={`${id}-label`}
-          aria-hidden={!isItemExpanded}
+          aria-hidden={isItemCollapsed}
           {...stylex.props(
             styles.childrenCollapsible,
-            !isItemExpanded && styles.childrenCollapsed,
+            isItemCollapsed && styles.childrenCollapsed,
           )}>
           <div {...stylex.props(styles.childrenInner)}>
             <span id={`${id}-label`} hidden>

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -70,6 +70,9 @@ const styles = stylex.create({
         backgroundColor: colorVars['--color-hover-overlay'],
       },
     },
+    ':active': {
+      backgroundColor: colorVars['--color-pressed-overlay'],
+    },
   },
   itemCollapsed: {
     justifyContent: 'center',
@@ -82,6 +85,9 @@ const styles = stylex.create({
       '@media (hover: hover)': {
         backgroundColor: colorVars['--color-deemphasized'],
       },
+    },
+    ':active': {
+      backgroundColor: colorVars['--color-deemphasized'],
     },
   },
   disabled: {

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -15,7 +15,7 @@
 
 'use client';
 
-import {useId, useRef, type ReactNode} from 'react';
+import {useCallback, useId, useRef, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -24,6 +24,7 @@ import {
   textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  transitionVars,
 } from '../theme/tokens.stylex';
 import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
@@ -32,6 +33,7 @@ import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSTooltip} from '../Tooltip';
 import {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
+import {getIcon} from '../Icon/globalIconRegistry';
 
 // =============================================================================
 // Styles
@@ -102,6 +104,30 @@ const styles = stylex.create({
   children: {
     paddingInlineStart: spacingVars['--spacing-6'],
   },
+  childrenCollapsible: {
+    display: 'grid',
+    gridTemplateRows: '1fr',
+    transitionProperty: 'grid-template-rows',
+    transitionDuration: transitionVars['--transition-normal'],
+  },
+  childrenCollapsed: {
+    gridTemplateRows: '0fr',
+  },
+  childrenInner: {
+    overflow: 'hidden',
+    minHeight: 0,
+    paddingInlineStart: spacingVars['--spacing-6'],
+  },
+  expandChevron: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    transitionProperty: 'transform',
+    transitionDuration: transitionVars['--transition-fast'],
+    flexShrink: 0,
+  },
+  expandChevronCollapsed: {
+    transform: 'rotate(-90deg)',
+  },
 });
 
 // =============================================================================
@@ -156,6 +182,19 @@ export interface XDSSideNavItemProps {
    */
   children?: ReactNode;
   /**
+   * Whether sub-items are expanded. Uncontrolled by default.
+   * @default true
+   */
+  defaultIsExpanded?: boolean;
+  /**
+   * Controlled expanded state for sub-items.
+   */
+  isExpanded?: boolean;
+  /**
+   * Callback when expand/collapse state changes.
+   */
+  onExpandedChange?: (expanded: boolean) => void;
+  /**
    * Test ID for the item element.
    */
   'data-testid'?: string;
@@ -196,6 +235,9 @@ export function XDSSideNavItem({
   onClick,
   endContent,
   children,
+  defaultIsExpanded = true,
+  isExpanded: controlledExpanded,
+  onExpandedChange,
   'data-testid': testId,
   ref,
 }: XDSSideNavItemProps) {
@@ -204,6 +246,22 @@ export function XDSSideNavItem({
   const hasChildren = !!children;
   const LinkComponent = useXDSLinkComponent(as);
   const itemRef = useRef<HTMLDivElement>(null);
+
+  // Expand/collapse state for items with children
+  const isExpandControlled = controlledExpanded !== undefined;
+  const [uncontrolledExpanded, setUncontrolledExpanded] =
+    useState(defaultIsExpanded);
+  const isItemExpanded = isExpandControlled
+    ? controlledExpanded
+    : uncontrolledExpanded;
+
+  const toggleExpand = useCallback(() => {
+    const next = !isItemExpanded;
+    if (!isExpandControlled) {
+      setUncontrolledExpanded(next);
+    }
+    onExpandedChange?.(next);
+  }, [isItemExpanded, isExpandControlled, onExpandedChange]);
 
   const displayIcon = isSelected && selectedIcon ? selectedIcon : icon;
 
@@ -215,6 +273,11 @@ export function XDSSideNavItem({
   const handleClick = (e: React.MouseEvent) => {
     if (isDisabled) {
       e.preventDefault();
+      return;
+    }
+    if (hasChildren && !isCollapsed) {
+      e.preventDefault();
+      toggleExpand();
       return;
     }
     onClick?.(e);
@@ -232,6 +295,15 @@ export function XDSSideNavItem({
       {!isCollapsed && <span {...stylex.props(styles.label)}>{label}</span>}
       {!isCollapsed && endContent && (
         <span {...stylex.props(styles.endContent)}>{endContent}</span>
+      )}
+      {!isCollapsed && hasChildren && (
+        <span
+          {...stylex.props(
+            styles.expandChevron,
+            !isItemExpanded && styles.expandChevronCollapsed,
+          )}>
+          {getIcon('chevronDown')}
+        </span>
       )}
     </>
   );
@@ -283,11 +355,17 @@ export function XDSSideNavItem({
         <div
           role="group"
           aria-labelledby={`${id}-label`}
-          {...stylex.props(styles.children)}>
-          <span id={`${id}-label`} hidden>
-            {label}
-          </span>
-          {children}
+          aria-hidden={!isItemExpanded}
+          {...stylex.props(
+            styles.childrenCollapsible,
+            !isItemExpanded && styles.childrenCollapsed,
+          )}>
+          <div {...stylex.props(styles.childrenInner)}>
+            <span id={`${id}-label`} hidden>
+              {label}
+            </span>
+            {children}
+          </div>
         </div>
       )}
     </div>

--- a/packages/core/src/Tooltip/useXDSTooltip.tsx
+++ b/packages/core/src/Tooltip/useXDSTooltip.tsx
@@ -299,6 +299,14 @@ export function useXDSTooltip(
 
   // Event handlers
   const handleMouseEnter = useCallback(() => {
+    // Suppress tooltips on touch devices — hover is simulated and eats a tap
+    if (
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(hover: none)').matches
+    ) {
+      return;
+    }
     scheduleShow();
   }, [scheduleShow]);
 
@@ -306,11 +314,22 @@ export function useXDSTooltip(
     scheduleHide();
   }, [scheduleHide]);
 
-  const handleFocusIn = useCallback(() => {
-    if (!isEnabled) return;
-    clearTimeouts();
-    layer.show();
-  }, [isEnabled, clearTimeouts, layer]);
+  const handleFocusIn = useCallback(
+    (e: Event) => {
+      if (!isEnabled) return;
+      // Only show tooltip for keyboard focus (:focus-visible),
+      // not programmatic focus (e.g. dialog auto-focus, touch tap)
+      const target = e.target as HTMLElement;
+      try {
+        if (!target.matches(':focus-visible')) return;
+      } catch {
+        // :focus-visible not supported — fall through to show
+      }
+      clearTimeouts();
+      layer.show();
+    },
+    [isEnabled, clearTimeouts, layer],
+  );
 
   const handleFocusOut = useCallback(() => {
     scheduleHide();

--- a/packages/core/src/Tooltip/useXDSTooltip.tsx
+++ b/packages/core/src/Tooltip/useXDSTooltip.tsx
@@ -320,11 +320,7 @@ export function useXDSTooltip(
       // Only show tooltip for keyboard focus (:focus-visible),
       // not programmatic focus (e.g. dialog auto-focus, touch tap)
       const target = e.target as HTMLElement;
-      try {
-        if (!target.matches(':focus-visible')) return;
-      } catch {
-        // :focus-visible not supported — fall through to show
-      }
+      if (!target.matches(':focus-visible')) return;
       clearTimeouts();
       layer.show();
     },

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -107,9 +107,10 @@ const styles = stylex.create({
     flexDirection: 'column',
     gap: spacingVars['--spacing-0-5'],
   },
-  drawerExtraContent: {
-    marginBlockStart: spacingVars['--spacing-1'],
+  drawerDivider: {
+    marginBlock: spacingVars['--spacing-2'],
   },
+  drawerExtraContent: {},
 });
 
 export interface XDSTopNavProps extends XDSBaseProps<HTMLElement> {
@@ -219,7 +220,11 @@ export function XDSTopNav({
             {centerContent}
           </div>
         )}
-        {hasCollapsibleContent && mobileContent && <XDSDivider />}
+        {hasCollapsibleContent && mobileContent && (
+          <div {...stylex.props(styles.drawerDivider)}>
+            <XDSDivider />
+          </div>
+        )}
         {mobileContent && (
           <div {...stylex.props(styles.drawerExtraContent)}>
             {mobileContent}

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -22,6 +22,7 @@ import {xdsClassName, mergeProps} from '../utils';
 import {TopNavSlotContext} from './TopNavContext';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
 import {useXDSTopNavMobileContent} from './XDSTopNavMobileContentContext';
+import {XDSDivider} from '../Divider/XDSDivider';
 import {XDSMobileNav} from '../MobileNav/XDSMobileNav';
 import {XDSMobileNavToggle} from '../MobileNav/XDSMobileNavToggle';
 
@@ -107,7 +108,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-0-5'],
   },
   drawerExtraContent: {
-    marginBlockStart: spacingVars['--spacing-4'],
+    marginBlockStart: spacingVars['--spacing-1'],
   },
 });
 
@@ -218,6 +219,7 @@ export function XDSTopNav({
             {centerContent}
           </div>
         )}
+        {hasCollapsibleContent && mobileContent && <XDSDivider />}
         {mobileContent && (
           <div {...stylex.props(styles.drawerExtraContent)}>
             {mobileContent}

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -84,41 +84,47 @@ const styles = stylex.create({
   iconOnly: {
     paddingInline: spacingVars['--spacing-2'],
   },
-  // Drawer mode — SideNavItem-style vertical list element
+  // Drawer mode — matches XDSSideNavItem styles exactly
   drawerItem: {
     display: 'flex',
     alignItems: 'center',
-    gap: spacingVars['--spacing-3'],
+    gap: spacingVars['--spacing-2'],
     width: '100%',
+    paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
     borderRadius: radiusVars['--radius-element'],
-    fontSize: textSizeVars['--text-base'],
-    lineHeight: lineHeightVars['--leading-base'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    color: colorVars['--color-text-secondary'],
+    borderWidth: 0,
+    borderStyle: 'none',
+    backgroundColor: 'transparent',
+    color: colorVars['--color-text-primary'],
     textDecoration: 'none',
     cursor: 'pointer',
+    fontFamily: 'inherit',
+    fontSize: textSizeVars['--text-base'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    lineHeight: lineHeightVars['--leading-base'],
+    textAlign: 'start',
     boxSizing: 'border-box',
-    backgroundColor: {
-      default: 'transparent',
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-hover-overlay'],
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-hover-overlay'],
       },
-      ':active': colorVars['--color-pressed-overlay'],
     },
     outline: {
       default: null,
       ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
     },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
   },
   drawerItemSelected: {
-    color: colorVars['--color-text-primary'],
-    fontWeight: fontWeightVars['--font-weight-semibold'],
-    backgroundColor: {
-      default: colorVars['--color-deemphasized'],
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-deemphasized'],
+    backgroundColor: colorVars['--color-deemphasized'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-deemphasized'],
       },
     },
   },

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -28,6 +28,7 @@ import {
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
+import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
@@ -76,43 +77,11 @@ const styles = stylex.create({
       ':active': colorVars['--color-deemphasized'],
     },
   },
-  disabled: {
-    color: colorVars['--color-text-disabled'],
-    cursor: 'not-allowed',
-    pointerEvents: 'none',
-  },
   iconOnly: {
     paddingInline: spacingVars['--spacing-2'],
   },
-  // Drawer mode — matches XDSSideNavItem styles exactly
-  drawerItem: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-2'],
-    width: '100%',
-    paddingInline: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-2'],
-    borderRadius: radiusVars['--radius-element'],
-    borderWidth: 0,
-    borderStyle: 'none',
-    backgroundColor: 'transparent',
-    color: colorVars['--color-text-primary'],
-    textDecoration: 'none',
-    cursor: 'pointer',
-    fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
-    fontWeight: fontWeightVars['--font-weight-normal'],
-    lineHeight: lineHeightVars['--leading-base'],
-    textAlign: 'start',
-    boxSizing: 'border-box',
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-hover-overlay'],
-      },
-    },
-    ':active': {
-      backgroundColor: colorVars['--color-pressed-overlay'],
-    },
+  // Drawer mode — focus outline (base item + selected come from navItemStyles)
+  drawerFocus: {
     outline: {
       default: null,
       ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
@@ -120,18 +89,6 @@ const styles = stylex.create({
     outlineOffset: {
       default: '0',
       ':focus-visible': '2px',
-    },
-  },
-  drawerItemSelected: {
-    backgroundColor: colorVars['--color-deemphasized'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-deemphasized'],
-      },
-    },
-    ':active': {
-      backgroundColor: colorVars['--color-deemphasized'],
     },
   },
 });
@@ -232,9 +189,10 @@ export function XDSTopNavItem({
         {...mergeProps(
           xdsClassName('top-nav-item', {mode: 'drawer'}),
           stylex.props(
-            styles.drawerItem,
-            isSelected && styles.drawerItemSelected,
-            isDisabled && styles.disabled,
+            navItemStyles.item,
+            styles.drawerFocus,
+            isSelected && navItemStyles.selected,
+            isDisabled && navItemStyles.disabled,
             xstyle,
           ),
           className,
@@ -263,7 +221,7 @@ export function XDSTopNavItem({
         stylex.props(
           styles.base,
           isSelected && styles.selected,
-          isDisabled && styles.disabled,
+          isDisabled && navItemStyles.disabled,
           isIconOnly && styles.iconOnly,
           xstyle,
         ),

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -110,6 +110,9 @@ const styles = stylex.create({
         backgroundColor: colorVars['--color-hover-overlay'],
       },
     },
+    ':active': {
+      backgroundColor: colorVars['--color-pressed-overlay'],
+    },
     outline: {
       default: null,
       ':focus-visible': `2px solid ${colorVars['--color-focus-outline']}`,
@@ -126,6 +129,9 @@ const styles = stylex.create({
       '@media (hover: hover)': {
         backgroundColor: colorVars['--color-deemphasized'],
       },
+    },
+    ':active': {
+      backgroundColor: colorVars['--color-deemphasized'],
     },
   },
 });

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -23,6 +23,7 @@ import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useListFocus} from '../hooks/useListFocus';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {xdsClassName, mergeProps} from '../utils';
+import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useTopNavSlot} from './TopNavContext';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
 import {
@@ -163,31 +164,9 @@ const drawerStyles = stylex.create({
     flexDirection: 'column',
   },
   header: {
-    display: 'flex',
-    alignItems: 'center',
     justifyContent: 'space-between',
-    width: '100%',
-    paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-2'],
-    borderRadius: radiusVars['--radius-element'],
-    fontSize: textSizeVars['--text-base'],
-    lineHeight: lineHeightVars['--leading-base'],
-    fontWeight: fontWeightVars['--font-weight-normal'],
-    color: colorVars['--color-text-primary'],
-    cursor: 'pointer',
     border: 'none',
     background: 'none',
-    fontFamily: 'inherit',
-    textAlign: 'start',
-    boxSizing: 'border-box',
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-hover-overlay'],
-      },
-    },
-    ':active': {
-      backgroundColor: colorVars['--color-pressed-overlay'],
-    },
   },
   chevron: {
     display: 'inline-flex',
@@ -211,29 +190,8 @@ const drawerStyles = stylex.create({
     minHeight: 0,
   },
   item: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-2'],
-    width: '100%',
-    paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-2'],
     paddingInlineStart: spacingVars['--spacing-6'],
-    borderRadius: radiusVars['--radius-element'],
-    fontSize: textSizeVars['--text-base'],
-    lineHeight: lineHeightVars['--leading-base'],
-    fontWeight: fontWeightVars['--font-weight-normal'],
-    color: colorVars['--color-text-primary'],
     textDecoration: 'none',
-    textAlign: 'start',
-    boxSizing: 'border-box',
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-hover-overlay'],
-      },
-    },
-    ':active': {
-      backgroundColor: colorVars['--color-pressed-overlay'],
-    },
   },
   itemIcon: {
     flexShrink: 0,
@@ -374,7 +332,7 @@ export function XDSTopNavMenu({
           onClick={() => setDrawerExpanded(v => !v)}
           aria-expanded={drawerExpanded}
           aria-controls={`${menuId}-items`}
-          {...stylex.props(drawerStyles.header)}>
+          {...stylex.props(navItemStyles.item, drawerStyles.header)}>
           {label}
           <span
             {...stylex.props(
@@ -396,7 +354,7 @@ export function XDSTopNavMenu({
                 key={i}
                 href={item.href}
                 onClick={item.onClick}
-                {...stylex.props(drawerStyles.item)}>
+                {...stylex.props(navItemStyles.item, drawerStyles.item)}>
                 {item.icon && (
                   <span {...stylex.props(drawerStyles.itemIcon)}>
                     {item.icon}

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -10,7 +10,14 @@
  * - /packages/core/src/TopNav/index.ts
  */
 
-import {useCallback, useEffect, useRef, useState, type ReactNode} from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useListFocus} from '../hooks/useListFocus';
@@ -351,6 +358,7 @@ export function XDSTopNavMenu({
 }: XDSTopNavMenuProps) {
   const renderMode = useXDSTopNavRenderMode();
   const [drawerExpanded, setDrawerExpanded] = useState(false);
+  const menuId = useId();
 
   // Mobile bar: hide menus entirely
   if (renderMode === 'mobile-bar') {
@@ -365,6 +373,7 @@ export function XDSTopNavMenu({
           type="button"
           onClick={() => setDrawerExpanded(v => !v)}
           aria-expanded={drawerExpanded}
+          aria-controls={`${menuId}-items`}
           {...stylex.props(drawerStyles.header)}>
           {label}
           <span
@@ -376,6 +385,7 @@ export function XDSTopNavMenu({
           </span>
         </button>
         <div
+          id={`${menuId}-items`}
           {...stylex.props(
             drawerStyles.items,
             drawerExpanded && drawerStyles.itemsExpanded,

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -161,23 +161,22 @@ const drawerStyles = stylex.create({
     justifyContent: 'space-between',
     width: '100%',
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-element'],
     fontSize: textSizeVars['--text-base'],
     lineHeight: lineHeightVars['--leading-base'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    color: colorVars['--color-text-secondary'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    color: colorVars['--color-text-primary'],
     cursor: 'pointer',
     border: 'none',
     background: 'none',
     fontFamily: 'inherit',
+    textAlign: 'start',
     boxSizing: 'border-box',
-    backgroundColor: {
-      default: 'transparent',
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-hover-overlay'],
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-hover-overlay'],
       },
-      ':active': colorVars['--color-pressed-overlay'],
     },
   },
   chevron: {
@@ -204,24 +203,23 @@ const drawerStyles = stylex.create({
   item: {
     display: 'flex',
     alignItems: 'center',
-    gap: spacingVars['--spacing-3'],
+    gap: spacingVars['--spacing-2'],
     width: '100%',
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
     paddingInlineStart: spacingVars['--spacing-6'],
     borderRadius: radiusVars['--radius-element'],
     fontSize: textSizeVars['--text-base'],
     lineHeight: lineHeightVars['--leading-base'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    color: colorVars['--color-text-secondary'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    color: colorVars['--color-text-primary'],
     textDecoration: 'none',
+    textAlign: 'start',
     boxSizing: 'border-box',
-    backgroundColor: {
-      default: 'transparent',
-      ':hover': {
-        '@media (hover: hover)': colorVars['--color-hover-overlay'],
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-hover-overlay'],
       },
-      ':active': colorVars['--color-pressed-overlay'],
     },
   },
   itemIcon: {

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -10,13 +10,14 @@
  * - /packages/core/src/TopNav/index.ts
  */
 
-import {useCallback, useEffect, useRef, type ReactNode} from 'react';
+import {useCallback, useEffect, useRef, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useListFocus} from '../hooks/useListFocus';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {xdsClassName, mergeProps} from '../utils';
 import {useTopNavSlot} from './TopNavContext';
+import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
 import {
   colorVars,
   spacingVars,
@@ -149,6 +150,97 @@ const styles = stylex.create({
   },
 });
 
+const drawerStyles = stylex.create({
+  section: {
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    width: '100%',
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    borderRadius: radiusVars['--radius-element'],
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-secondary'],
+    cursor: 'pointer',
+    border: 'none',
+    background: 'none',
+    fontFamily: 'inherit',
+    boxSizing: 'border-box',
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': {
+        '@media (hover: hover)': colorVars['--color-hover-overlay'],
+      },
+      ':active': colorVars['--color-pressed-overlay'],
+    },
+  },
+  chevron: {
+    display: 'inline-flex',
+    transitionProperty: 'transform',
+    transitionDuration: transitionVars['--transition-fast'],
+  },
+  chevronExpanded: {
+    transform: 'rotate(180deg)',
+  },
+  items: {
+    display: 'grid',
+    gridTemplateRows: '0fr',
+    transitionProperty: 'grid-template-rows',
+    transitionDuration: transitionVars['--transition-normal'],
+  },
+  itemsExpanded: {
+    gridTemplateRows: '1fr',
+  },
+  itemsInner: {
+    overflow: 'hidden',
+    minHeight: 0,
+  },
+  item: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-3'],
+    width: '100%',
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    paddingInlineStart: spacingVars['--spacing-6'],
+    borderRadius: radiusVars['--radius-element'],
+    fontSize: textSizeVars['--text-base'],
+    lineHeight: lineHeightVars['--leading-base'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-secondary'],
+    textDecoration: 'none',
+    boxSizing: 'border-box',
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': {
+        '@media (hover: hover)': colorVars['--color-hover-overlay'],
+      },
+      ':active': colorVars['--color-pressed-overlay'],
+    },
+  },
+  itemIcon: {
+    flexShrink: 0,
+    width: 20,
+    height: 20,
+  },
+  itemText: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
+  },
+  itemDescription: {
+    fontSize: textSizeVars['--text-sm'],
+    color: colorVars['--color-text-secondary'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+  },
+});
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -253,6 +345,66 @@ export function XDSTopNavMenu({
   delay = 150,
   hideDelay = 200,
 }: XDSTopNavMenuProps) {
+  const renderMode = useXDSTopNavRenderMode();
+  const [drawerExpanded, setDrawerExpanded] = useState(false);
+
+  // Mobile bar: hide menus entirely
+  if (renderMode === 'mobile-bar') {
+    return null;
+  }
+
+  // Drawer mode: collapsible section
+  if (renderMode === 'drawer') {
+    return (
+      <div {...stylex.props(drawerStyles.section)}>
+        <button
+          type="button"
+          onClick={() => setDrawerExpanded(v => !v)}
+          aria-expanded={drawerExpanded}
+          {...stylex.props(drawerStyles.header)}>
+          {label}
+          <span
+            {...stylex.props(
+              drawerStyles.chevron,
+              drawerExpanded && drawerStyles.chevronExpanded,
+            )}>
+            {getIcon('chevronDown')}
+          </span>
+        </button>
+        <div
+          {...stylex.props(
+            drawerStyles.items,
+            drawerExpanded && drawerStyles.itemsExpanded,
+          )}>
+          <div {...stylex.props(drawerStyles.itemsInner)}>
+            {items.map((item, i) => (
+              <a
+                key={i}
+                href={item.href}
+                onClick={item.onClick}
+                {...stylex.props(drawerStyles.item)}>
+                {item.icon && (
+                  <span {...stylex.props(drawerStyles.itemIcon)}>
+                    {item.icon}
+                  </span>
+                )}
+                <span {...stylex.props(drawerStyles.itemText)}>
+                  {item.title}
+                  {item.description && (
+                    <span {...stylex.props(drawerStyles.itemDescription)}>
+                      {item.description}
+                    </span>
+                  )}
+                </span>
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Default: desktop popover
   const slot = useTopNavSlot();
   const showTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -178,6 +178,9 @@ const drawerStyles = stylex.create({
         backgroundColor: colorVars['--color-hover-overlay'],
       },
     },
+    ':active': {
+      backgroundColor: colorVars['--color-pressed-overlay'],
+    },
   },
   chevron: {
     display: 'inline-flex',
@@ -220,6 +223,9 @@ const drawerStyles = stylex.create({
       '@media (hover: hover)': {
         backgroundColor: colorVars['--color-hover-overlay'],
       },
+    },
+    ':active': {
+      backgroundColor: colorVars['--color-pressed-overlay'],
     },
   },
   itemIcon: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export * from './EmptyState';
 export * from './Link';
 export * from './List';
 export * from './NavIcon';
+export * from './NavItem';
 export * from './Slider';
 export * from './Stack';
 export * from './Switch';

--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -328,4 +328,30 @@
   :where(html) {
     -webkit-tap-highlight-color: transparent;
   }
+
+  /* ===========================================================================
+     Touch Devices
+     =========================================================================== */
+
+  /*
+   * Suppress focus-visible outlines on touch-only devices.
+   *
+   * Focus rings exist to show keyboard users where focus is. On devices
+   * with no hover capability and a coarse pointer (phones, tablets),
+   * there's no keyboard navigation — focus rings are visual noise that
+   * can flash on tap, on dialog open (showModal auto-focus), or on
+   * programmatic focus.
+   *
+   * This targets touch-only devices specifically:
+   * - (hover: none) — no hover capability (not a mouse)
+   * - (pointer: coarse) — imprecise pointer (finger, not stylus)
+   *
+   * Hybrid devices (laptop with touchscreen) are NOT affected because
+   * their primary pointer is fine (trackpad/mouse) and hover is available.
+   */
+  @media (hover: none) and (pointer: coarse) {
+    :where(:focus-visible) {
+      outline: none;
+    }
+  }
 }


### PR DESCRIPTION
## Shell Hardening Batch — #565

Addresses remaining items from the shell & navigation deep review, plus mobile interaction hardening discovered during review.

### Features

**Collapsible SideNavItem** — items with children are now collapsible by default:
- No `collapsible` prop needed — items with children automatically get expand/collapse
- Pass `collapsible={false}` to opt out
- Animated expand/collapse via grid-template-rows transition
- Chevron icon rotates to indicate state
- `aria-expanded` + `aria-controls` linking toggle to children group

**TopNavMenu mobile drawer mode** — menus render as collapsible sections in the mobile drawer:
- Expandable header with chevron animation
- Child items indented with shared nav item styles
- `aria-expanded` + `aria-controls` for accessibility

**MobileNav `breakpoint` config** — moved `sideNavBreakpoint` and `sideNavWidth` from AppShell props into the `mobileNav` config object:
- `mobileNav={{ breakpoint: 'lg' }}` instead of `sideNavBreakpoint="lg"`
- Removed dead `sideNavWidth` prop (SideNav owns its own width)

**Shared navItemStyles** — extracted common nav item styles into `NavItem/navItemStyles.stylex.ts`:
- `navItemStyles.item` / `.selected` / `.disabled` — single source of truth
- Consumed by SideNavItem, TopNavItem (drawer), TopNavMenu (drawer)
- Exported publicly via `@xds/core/NavItem` for custom nav items

### Mobile Interaction Hardening

**Pressed states** — added `:active` to all interactive nav items via shared `navItemStyles`

**Tooltip touch suppression:**
- `mouseenter`: guarded with `(hover: none)` media query
- `focusin`: only shows when `:focus-visible` matches (keyboard only)

**MobileNav scroll lock + overlay:**
- `overflow: clip` on `<html>` when open — no scroll bounce, no save/restore needed
- `touch-action: none` on dialog, `pan-y` on content area
- `overscrollBehavior: contain` on dialog root
- `backdropFilter: blur(2px)` matching Dialog overlay style

**Focus ring suppression on touch:**
- `reset.css`: `@media (hover: none) and (pointer: coarse)` suppresses `:focus-visible` outlines
- MobileNav drawer panel gets `tabIndex={-1}` so `showModal()` focuses the drawer (outline: none), not the close button
- Removed redundant tooltip from close button

### Drawer Spacing & Content

- Drawer content padding: 8px all around (was 4px block)
- SideNav footer + footerIcons now render in both drawer modes (was missing footerIcons)
- Drawer footer pushed to bottom with `marginBlockStart: auto` + divider
- 8px block margin around divider between TopNav and SideNav items in combined drawer

### Style Consistency

TopNav items in mobile drawer now match SideNavItem via shared `navItemStyles`:
- `spacing-2` gap/padding, `font-weight-normal`, `color-text-primary`
- `XDSDivider` with 8px margin between TopNav and SideNav sections

### Removed (separate PR)

- `@starting-style` entry animations — needs manual debugging

---
