### PR TITLE
PowerSearch: focus value inputs when showing popover

### DIFF
--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -10,7 +10,7 @@
 
 'use client';
 
-import React, {useState, useCallback, useMemo} from 'react';
+import React, {useState, useCallback, useEffect, useMemo, useRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '../Button';
 import {XDSSelector} from '../Selector';
@@ -589,10 +589,24 @@ export function PowerSearchEditPopover({
 }: PowerSearchEditPopoverProps) {
   const [partialFilter, setPartialFilter] =
     useState<PartialFilter>(initialFilter);
+  const valueEditorRef = useRef<HTMLDivElement>(null);
 
   // Reset state when filter changes (new popover opened)
   React.useEffect(() => {
     setPartialFilter(initialFilter);
+  }, [initialFilter]);
+
+  // Focus the first focusable element inside the value editor after mount
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => {
+      const container = valueEditorRef.current;
+      if (!container) return;
+      const focusable = container.querySelector<HTMLElement>(
+        'input:not([disabled]), button:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])',
+      );
+      focusable?.focus();
+    });
+    return () => cancelAnimationFrame(frame);
   }, [initialFilter]);
 
   const currentOperator = partialFilter.operator
@@ -678,6 +692,17 @@ export function PowerSearchEditPopover({
 
   const isSaveDisabled = !partialFilter.operator || !partialFilter.value;
 
+  // Handle Enter key anywhere in the popover to trigger save
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !isSaveDisabled) {
+        e.preventDefault();
+        handleSave();
+      }
+    },
+    [isSaveDisabled, handleSave],
+  );
+
   const operatorValue: OperatorValue | undefined = currentOperator?.value;
   const isEmptyType = operatorValue?.type === 'empty';
   const isNestedType = operatorValue?.type === 'nested';
@@ -758,7 +783,7 @@ export function PowerSearchEditPopover({
   }
 
   return (
-    <div {...stylex.props(styles.container)}>
+    <div {...stylex.props(styles.container)} onKeyDown={handleKeyDown}>
       <div {...stylex.props(styles.content)}>
         <XDSHStack gap={2}>
           <div {...stylex.props(styles.fieldSelector)}>
@@ -786,7 +811,7 @@ export function PowerSearchEditPopover({
             </div>
           )}
           {operatorValue && !isEmptyType && (
-            <div {...stylex.props(styles.valueEditor)}>
+            <div ref={valueEditorRef} {...stylex.props(styles.valueEditor)}>
               <PowerSearchValueEditor
                 operatorValue={operatorValue}
                 filterValue={partialFilter.value}

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -93,7 +93,6 @@ function StringEditor({
       onChange={(value: string) => {
         onChange({type: 'string', value});
       }}
-      hasAutoFocus
     />
   );
 }
@@ -136,7 +135,6 @@ function StringListEditor({
         });
       }}
       placeholder="Add values..."
-      hasAutoFocus
       debounceMs={operatorValue.searchSource ? 150 : 0}
     />
   );
@@ -167,7 +165,6 @@ function IntegerEditor({
       units={operatorValue.units}
       isIntegerOnly
       placeholder="Enter number..."
-      hasAutoFocus
     />
   );
 }
@@ -196,7 +193,6 @@ function FloatEditor({
       max={operatorValue.maxValue}
       units={operatorValue.units}
       placeholder="Enter number..."
-      hasAutoFocus
     />
   );
 }
@@ -524,7 +520,6 @@ function EntityListEditor({
         });
       }}
       placeholder="Search..."
-      hasAutoFocus
       debounceMs={operatorValue.searchSource ? 150 : 0}
     />
   );

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -13,7 +13,6 @@
 
 import React, {
   useCallback,
-  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -469,7 +468,7 @@ export function XDSPowerSearch({
   const searchSource = usePowerSearchSource(config);
   const tokenizerRef = useRef<XDSTokenizerHandle>(null);
 
-  const [popoverState, setPopoverState] = useState<PopoverState>({
+  const [popoverState, setPopoverStateRaw] = useState<PopoverState>({
     type: 'idle',
   });
 
@@ -478,19 +477,28 @@ export function XDSPowerSearch({
     mode: 'context',
     lightDismiss: true,
     onHide() {
-      setPopoverState({type: 'idle'});
+      setPopoverStateRaw({type: 'idle'});
     },
   });
 
-  // Sync popover state with layer visibility
-  const isPopoverActive = popoverState.type !== 'idle';
-  useEffect(() => {
-    if (isPopoverActive) {
-      layer.show();
-    } else {
-      layer.hide();
-    }
-  }, [isPopoverActive, layer]);
+  // Wrapper that manages layer visibility and tokenizer focus alongside state
+  const setPopoverState = useCallback(
+    (state: PopoverState) => {
+      setPopoverStateRaw(state);
+      if (state.type !== 'idle') {
+        // Schedule after the current frame so React can render the popover
+        // content and the typeahead's synchronous focus() has completed
+        requestAnimationFrame(() => {
+          layer.show();
+          tokenizerRef.current?.blur();
+        });
+      } else {
+        layer.hide();
+        tokenizerRef.current?.focus();
+      }
+    },
+    [layer],
+  );
 
   // Expose imperative handle
   useImperativeHandle(ref, () => ({
@@ -628,13 +636,13 @@ export function XDSPowerSearch({
       }
       setPopoverState({type: 'idle'});
     },
-    [popoverState, filters, onChange],
+    [popoverState, filters, onChange, setPopoverState],
   );
 
   // Handle popover cancel
   const handlePopoverCancel = useCallback(() => {
     setPopoverState({type: 'idle'});
-  }, []);
+  }, [setPopoverState]);
 
   // Custom token renderer
   const renderToken = useCallback(


### PR DESCRIPTION
* When opening popover, focus the first value input. We do this in a single effect at the top level so it catches all inputs instead of relying on setting hasAutoFocus.
* Add handler for pressing Enter on input to apply the filter.

This behavior wasn't working the same as www version, now it is fixed.