### PR TITLE
refactor: migrate components from raw text size tokens to semantic type scale tokens

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -31,7 +31,7 @@ import {
   fontWeightVars,
   radiusVars,
   spacingVars,
-  textSizeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSLayout} from '../Layout/XDSLayout';
 import {XDSLayoutHeader} from '../Layout/XDSLayoutHeader';
@@ -305,7 +305,7 @@ const styles = stylex.create({
     zIndex: 9999,
     textDecoration: 'none',
     fontWeight: fontWeightVars['--font-weight-semibold'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
   },
 
   elevatedBackdrop: {

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -20,9 +20,9 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -40,7 +40,7 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-rounded'],
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-tight'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     whiteSpace: 'nowrap',

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -37,9 +37,9 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -223,7 +223,7 @@ const styles = stylex.create({
   title: {
     margin: 0,
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-primary'],
@@ -231,7 +231,7 @@ const styles = stylex.create({
   description: {
     margin: 0,
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -18,8 +18,8 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {BreadcrumbCtx} from './XDSBreadcrumbs';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
@@ -78,10 +78,10 @@ const itemStyles = stylex.create({
     margin: 0,
   },
   defaultSize: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
   },
   supportingSize: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
   },
   contentWrapper: {
     display: 'flex',

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -78,7 +78,7 @@ const itemStyles = stylex.create({
     margin: 0,
   },
   defaultSize: {
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
   },
   supportingSize: {
     fontSize: typeScaleVars['--text-supporting-size'],

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -138,7 +138,7 @@ const separatorStyles = stylex.create({
     userSelect: 'none',
   },
   defaultSize: {
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
   },
   supportingSize: {
     fontSize: typeScaleVars['--text-supporting-size'],

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -19,8 +19,8 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSBreadcrumbItemProps} from './XDSBreadcrumbItem';
 import {xdsClassName, mergeProps} from '../utils';
@@ -138,10 +138,10 @@ const separatorStyles = stylex.create({
     userSelect: 'none',
   },
   defaultSize: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
   },
   supportingSize: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
   },
 });
 

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -25,9 +25,9 @@ import {
   radiusVars,
   durationVars,
   easeVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import {XDSSpinner} from '../Spinner';
@@ -55,7 +55,7 @@ const styles = stylex.create({
     '--button-radius': radiusVars['--radius-2'],
     borderRadius: 'var(--button-radius)',
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     cursor: 'pointer',

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -19,8 +19,8 @@ import {
   radiusVars,
   durationVars,
   easeVars,
-  textSizeVars,
   fontWeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 
 // =============================================================================
@@ -44,7 +44,7 @@ export const calendarStyles = stylex.create({
     flex: 1,
     textAlign: 'center',
     fontWeight: fontWeightVars['--font-weight-semibold'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     color: colorVars['--color-text-primary'],
   },
   monthsContainer: {
@@ -79,7 +79,7 @@ export const monthGridStyles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
   },
@@ -99,7 +99,7 @@ export const monthGridStyles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
   },
   weekRow: {
@@ -187,7 +187,7 @@ export const dayCellStyles = stylex.create({
     borderStyle: 'none',
     cursor: 'pointer',
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     padding: 0,
     position: 'relative',
     zIndex: 1,

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -187,7 +187,7 @@ export const dayCellStyles = stylex.create({
     borderStyle: 'none',
     cursor: 'pointer',
     fontFamily: 'inherit',
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
     padding: 0,
     position: 'relative',
     zIndex: 1,

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -25,12 +25,10 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
   durationVars,
   easeVars,
   typographyVars,
-  lineHeightVars,
-  fontWeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
@@ -150,9 +148,7 @@ const styles = stylex.create({
   },
   description: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
-    lineHeight: lineHeightVars['--leading-relaxed'],
-    fontWeight: fontWeightVars['--font-weight-normal'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
   },
 });

--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -25,7 +25,7 @@ import {
   typographyVars,
   fontWeightVars,
   spacingVars,
-  textSizeVars,
+  typeScaleVars,
   durationVars,
   easeVars,
 } from '../theme/tokens.stylex';
@@ -44,7 +44,7 @@ const styles = stylex.create({
     width: '100%',
     cursor: 'pointer',
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-lg'],
+    fontSize: typeScaleVars['--text-large-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     color: colorVars['--color-text-primary'],
     textAlign: 'start',

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -30,8 +30,8 @@ import {
   radiusVars,
   shadowVars,
   typographyVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {
   XDSField,
@@ -81,7 +81,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     padding: 0,
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-normal'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -19,8 +19,8 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -119,7 +119,7 @@ const labelStyles = stylex.create({
     paddingInline: spacingVars['--spacing-3'],
     backgroundColor: colorVars['--color-surface'],
     // Small secondary text styling
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-normal'],
     color: colorVars['--color-text-secondary'],
   },

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -37,7 +37,7 @@ import {
   durationVars,
   easeVars,
   typographyVars,
-  textSizeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -96,7 +96,7 @@ const styles = stylex.create({
     borderRadius:
       'max(0px, calc(var(--dropdown-radius) - var(--dropdown-padding)))',
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
     border: 'none',

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -17,9 +17,9 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -42,25 +42,25 @@ const styles = stylex.create({
   title: {
     margin: 0,
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-lg'],
+    fontSize: typeScaleVars['--text-large-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-primary'],
   },
   titleCompact: {
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
   },
   description: {
     margin: 0,
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-secondary'],
     maxWidth: '360px',
   },
   descriptionCompact: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
   },
   textGroup: {
     display: 'flex',

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -22,8 +22,8 @@ import {
   colorVars,
   fontWeightVars,
   spacingVars,
-  textSizeVars,
   typographyVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSIconType} from '../Icon';
 import {xdsClassName, mergeProps} from '../utils';
@@ -41,7 +41,7 @@ const styles = stylex.create({
   },
   label: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-primary'],
   },
@@ -62,12 +62,12 @@ const styles = stylex.create({
   },
   description: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
   },
   optionalRequired: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
     marginInlineStart: spacingVars['--spacing-1'],
   },

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -16,8 +16,8 @@ import {
   colorVars,
   fontWeightVars,
   spacingVars,
-  textSizeVars,
   typographyVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSIcon, type XDSIconType} from '../Icon';
 import {XDSTooltip} from '../Tooltip';
@@ -28,7 +28,7 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-primary'],
   },
@@ -56,7 +56,7 @@ const styles = stylex.create({
   },
   optionalRequired: {
     fontWeight: fontWeightVars['--font-weight-normal'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
   },
 });

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -16,15 +16,15 @@ import {
   lineHeightVars,
   radiusVars,
   spacingVars,
-  textSizeVars,
   typographyVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSInputStatusType} from './types';
 
 const styles = stylex.create({
   base: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   attached: {

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -16,10 +16,10 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
   typographyVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 
 const styles = stylex.create({
@@ -43,7 +43,7 @@ const styles = stylex.create({
     borderBottomColor: colorVars['--color-border'],
     color: colorVars['--color-text-secondary'],
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     lineHeight: lineHeightVars['--leading-tight'],
     userSelect: 'none',

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -21,9 +21,9 @@ import {
   colorVars,
   durationVars,
   easeVars,
-  textSizeVars,
   lineHeightVars,
   spacingVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSIcon} from '../Icon';
 import {XDSTooltip} from '../Tooltip';
@@ -79,7 +79,7 @@ const styles = stylex.create({
     pointerEvents: 'none',
   },
   standalone: {
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-base'],
   },
 });

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -20,10 +20,10 @@ import {
   colorVars,
   radiusVars,
   spacingVars,
-  textSizeVars,
   lineHeightVars,
   durationVars,
   easeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSListContext} from './XDSListContext';
 import {xdsClassName, mergeProps} from '../utils';
@@ -243,34 +243,34 @@ const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   spacious: {
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-4'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-normal'],
   },
 });
 
 const descriptionSizeStyles = stylex.create({
   compact: {
-    fontSize: textSizeVars['--text-2xs'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   balanced: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   spacious: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-normal'],
   },
 });

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -243,13 +243,13 @@ const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   spacious: {

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -43,8 +43,8 @@ import {
   durationVars,
   easeVars,
   typographyVars,
-  textSizeVars,
   shadowVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -88,7 +88,7 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-1'],
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
     border: 'none',

--- a/packages/core/src/NavItem/navItemStyles.stylex.ts
+++ b/packages/core/src/NavItem/navItemStyles.stylex.ts
@@ -18,7 +18,7 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
+  typeScaleVars,
   fontWeightVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
@@ -57,7 +57,7 @@ export const navItemStyles = stylex.create({
     textDecoration: 'none',
     cursor: 'pointer',
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     lineHeight: lineHeightVars['--leading-base'],
     textAlign: 'start',

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -28,8 +28,8 @@ import {
   colorVars,
   sizeVars,
   typographyVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {
   XDSField,
@@ -54,7 +54,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     padding: 0,
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
@@ -71,7 +71,7 @@ const styles = stylex.create({
   },
   units: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-secondary'],
     flexShrink: 0,

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -26,7 +26,7 @@ import {
   spacingVars,
   durationVars,
   easeVars,
-  textSizeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
@@ -169,13 +169,13 @@ const styles = stylex.create({
     minWidth: sizeVars['--size-md'],
     height: sizeVars['--size-md'],
     color: colorVars['--color-text-secondary'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     userSelect: 'none',
   },
   ellipsisSm: {
     minWidth: sizeVars['--size-sm'],
     height: sizeVars['--size-sm'],
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
   },
   infoText: {
     display: 'flex',

--- a/packages/core/src/Popover/useXDSPopover.tsx
+++ b/packages/core/src/Popover/useXDSPopover.tsx
@@ -33,7 +33,7 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 
 const styles = stylex.create({
@@ -70,7 +70,7 @@ const styles = stylex.create({
     // Inverted color palette (like tooltip): dark background, light text
     backgroundColor: colorVars['--color-text-primary'],
     color: colorVars['--color-surface'],
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     borderRadius: radiusVars['--radius-2'],
     cursor: 'pointer',
     borderWidth: 0,

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -22,7 +22,7 @@ import {
   colorVars,
   radiusVars,
   shadowVars,
-  textSizeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {PowerSearchValueEditor} from './PowerSearchValueEditor';
 import type {InternalConfig} from './useInternalConfig';
@@ -62,7 +62,7 @@ const styles = stylex.create({
   },
   // Nested editor styles
   nestedRootLabel: {
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
   },
   nestedFieldSelector: {
     flexShrink: 0,

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -31,8 +31,8 @@ import {useXDSLayer} from '../Layer';
 import {
   spacingVars,
   colorVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {useInternalConfig} from './useInternalConfig';
 import {usePowerSearchSource} from './usePowerSearchSource';
@@ -92,7 +92,7 @@ const popoverLayerStyles = stylex.create({
 
 const resultCountStyles = stylex.create({
   text: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
     whiteSpace: 'nowrap',

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -154,13 +154,13 @@ const styles = stylex.create({
     alignItems: 'baseline',
   },
   label: {
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-primary'],
   },
   valueLabel: {
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -20,11 +20,11 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
   durationVars,
   easeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -154,13 +154,13 @@ const styles = stylex.create({
     alignItems: 'baseline',
   },
   label: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-primary'],
   },
   valueLabel: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -18,11 +18,11 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   durationVars,
   easeVars,
   typographyVars,
   fontWeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {RadioListContext} from './XDSRadioList';
 import {xdsClassName, mergeProps} from '../utils';
@@ -121,7 +121,7 @@ const styles = stylex.create({
   },
   label: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-primary'],
     cursor: 'pointer',
@@ -132,7 +132,7 @@ const styles = stylex.create({
   },
   description: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
   },
   startContent: {

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -40,9 +40,9 @@ import {
   durationVars,
   easeVars,
   typographyVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {type XDSSelectorOptionType, type XDSSelectorOptionData} from './types';
 import {
@@ -79,7 +79,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-2'],
     backgroundColor: colorVars['--color-surface'],
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-primary'],
     cursor: 'pointer',
@@ -173,7 +173,7 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-1'],
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
     border: 'none',

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -22,10 +22,10 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
   radiusVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 // TODO(#264): Lazy-load useXDSPopover so the popover/layer bundle is not
 // eagerly imported when `menu` is not provided. See XDSText for an example
@@ -86,7 +86,7 @@ const styles = stylex.create({
     minWidth: 0,
   },
   superheading: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
     textDecoration: 'none',
@@ -95,7 +95,7 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
   },
   heading: {
-    fontSize: textSizeVars['--text-lg'],
+    fontSize: typeScaleVars['--text-large-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-primary'],
@@ -106,10 +106,10 @@ const styles = stylex.create({
   },
   // When super/sub headings are present, scale down the app name
   headingCompact: {
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
   },
   subheading: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
     textDecoration: 'none',

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -21,9 +21,8 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
   fontWeightVars,
-  lineHeightVars,
+  typeScaleVars,
   durationVars,
   easeVars,
   shadowVars,
@@ -113,10 +112,10 @@ const styles = stylex.create({
   popoverHeader: {
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     color: colorVars['--color-text-secondary'],
-    lineHeight: lineHeightVars['--leading-snug'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
   },
 });
 

--- a/packages/core/src/SideNav/XDSSideNavSection.tsx
+++ b/packages/core/src/SideNav/XDSSideNavSection.tsx
@@ -20,9 +20,9 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
@@ -53,7 +53,7 @@ const styles = stylex.create({
     minWidth: 0,
   },
   title: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
@@ -62,7 +62,7 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
   },
   subtitle: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
     overflow: 'hidden',

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -29,7 +29,7 @@ import {
   durationVars,
   easeVars,
   typographyVars,
-  textSizeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSField} from '../Field/XDSField';
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
@@ -239,7 +239,7 @@ const styles = stylex.create({
   },
   textValue: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     color: colorVars['--color-text-primary'],
     whiteSpace: 'nowrap',
     flexShrink: 0,
@@ -275,7 +275,7 @@ const styles = stylex.create({
   markLabel: {
     position: 'absolute',
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
     whiteSpace: 'nowrap',
   },

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -28,9 +28,7 @@ import {
   durationVars,
   easeVars,
   typographyVars,
-  textSizeVars,
-  lineHeightVars,
-  fontWeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
 import {XDSFieldStatus} from '../Field/XDSFieldStatus';
@@ -166,9 +164,7 @@ const styles = stylex.create({
   },
   description: {
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
-    lineHeight: lineHeightVars['--leading-relaxed'],
-    fontWeight: fontWeightVars['--font-weight-normal'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
   },
 });

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -21,9 +21,9 @@ import {
   radiusVars,
   durationVars,
   easeVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
@@ -77,7 +77,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     borderRadius: radiusVars['--radius-2'],
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -24,9 +24,9 @@ import {
   durationVars,
   easeVars,
   shadowVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {useXDSLayer} from '../Layer/useXDSLayer';
 import {useListFocus} from '../hooks/useListFocus';
@@ -72,7 +72,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     borderRadius: radiusVars['--radius-2'],
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
@@ -173,7 +173,7 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-3'],
     borderRadius: radiusVars['--radius-1'],
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-primary'],

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -14,7 +14,7 @@
 import {useContext, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, spacingVars, textSizeVars} from '../theme/tokens.stylex';
+import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
 import {XDSTableContext} from './XDSTableContext';
 import {xdsClassName, mergeProps} from '../utils';
@@ -39,19 +39,19 @@ const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     boxSizing: 'border-box',
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-body-size'],
     boxSizing: 'border-box',
   },
   spacious: {
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-4'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     boxSizing: 'border-box',
   },
 });

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -39,7 +39,7 @@ const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
     boxSizing: 'border-box',
   },
   balanced: {

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -42,13 +42,13 @@ const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-label-size'],
     boxSizing: 'border-box',
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
-    fontSize: typeScaleVars['--text-body-size'],
+    fontSize: typeScaleVars['--text-label-size'],
     boxSizing: 'border-box',
   },
   spacious: {

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -17,8 +17,8 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   fontWeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
 import {XDSTableContext} from './XDSTableContext';
@@ -42,19 +42,19 @@ const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     boxSizing: 'border-box',
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-body-size'],
     boxSizing: 'border-box',
   },
   spacious: {
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-4'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     boxSizing: 'border-box',
   },
 });

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -26,8 +26,8 @@ import {
   colorVars,
   spacingVars,
   typographyVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {
   XDSField,
@@ -53,7 +53,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     padding: 0,
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
@@ -72,7 +72,7 @@ const styles = stylex.create({
     justifyContent: 'flex-end',
     marginTop: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
   },
   counterError: {

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -20,8 +20,8 @@ import {
   colorVars,
   sizeVars,
   typographyVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {
   XDSField,
@@ -47,7 +47,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     padding: 0,
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -31,8 +31,8 @@ import {
   sizeVars,
   radiusVars,
   typographyVars,
-  textSizeVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {
   XDSField,
@@ -72,7 +72,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     padding: 0,
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-normal'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',

--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -21,9 +21,9 @@ import {
   sizeVars,
   durationVars,
   easeVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {XDSIcon} from '../Icon';
 import {xdsClassName, mergeProps} from '../utils';
@@ -144,7 +144,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     borderRadius: radiusVars['--radius-1'],
     fontFamily: 'inherit',
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     whiteSpace: 'nowrap',
@@ -242,7 +242,7 @@ const styles = stylex.create({
 const sizeStyles = stylex.create({
   sm: {
     height: `calc(${sizeVars['--size-sm']} - 8px)`,
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     paddingInline: spacingVars['--spacing-2'],
   },
   md: {

--- a/packages/core/src/Tooltip/useXDSTooltip.tsx
+++ b/packages/core/src/Tooltip/useXDSTooltip.tsx
@@ -31,7 +31,7 @@ import {
   radiusVars,
   spacingVars,
   typographyVars,
-  textSizeVars,
+  typeScaleVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName} from '../utils';
@@ -45,7 +45,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-2'],
     // Typography
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-base'],
     // Animation: closed state (default) and open state
     opacity: {

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -17,9 +17,9 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -35,7 +35,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
   },
   headingText: {
-    fontSize: textSizeVars['--text-lg'],
+    fontSize: typeScaleVars['--text-large-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-tight'],
     whiteSpace: 'nowrap',

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -22,9 +22,9 @@ import {
   radiusVars,
   durationVars,
   easeVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
@@ -43,7 +43,7 @@ const styles = stylex.create({
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
     borderRadius: radiusVars['--radius-2'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -28,10 +28,10 @@ import {
   radiusVars,
   durationVars,
   easeVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
   shadowVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {useXDSPopover} from '../Popover/useXDSPopover';
 import {XDSGrid} from '../Grid/XDSGrid';
@@ -53,7 +53,7 @@ const styles = stylex.create({
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
     borderRadius: radiusVars['--radius-2'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
@@ -134,7 +134,6 @@ const styles = stylex.create({
     flexBasis: 300,
     minWidth: 0,
   },
-
   featured: {
     flexGrow: 1,
     flexShrink: 1,

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuFeaturedCard.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuFeaturedCard.tsx
@@ -20,7 +20,7 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
+  typeScaleVars,
   fontWeightVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
@@ -47,18 +47,18 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-4'],
   },
   title: {
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-primary'],
   },
   description: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
   },
   link: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-link'],

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
@@ -20,7 +20,7 @@ import {
   radiusVars,
   durationVars,
   easeVars,
-  textSizeVars,
+  typeScaleVars,
   fontWeightVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
@@ -87,13 +87,13 @@ const styles = stylex.create({
     minWidth: 0,
   },
   desktopTitle: {
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     color: colorVars['--color-text-primary'],
   },
   desktopDescription: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
@@ -123,7 +123,7 @@ const styles = stylex.create({
     minWidth: 0,
   },
   drawerItemDescription: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
     fontWeight: fontWeightVars['--font-weight-normal'],

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -32,10 +32,10 @@ import {
   radiusVars,
   durationVars,
   easeVars,
-  textSizeVars,
   fontWeightVars,
   lineHeightVars,
   shadowVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 
 // =============================================================================
@@ -50,7 +50,7 @@ const styles = stylex.create({
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
     borderRadius: radiusVars['--radius-2'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
@@ -148,13 +148,13 @@ const styles = stylex.create({
     minWidth: 0,
   },
   menuItemTitle: {
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     color: colorVars['--color-text-primary'],
   },
   menuItemDescription: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
@@ -209,7 +209,7 @@ const drawerStyles = stylex.create({
     gap: spacingVars['--spacing-0-5'],
   },
   itemDescription: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
     fontWeight: fontWeightVars['--font-weight-normal'],
   },

--- a/packages/core/src/TreeList/XDSTreeListItem.tsx
+++ b/packages/core/src/TreeList/XDSTreeListItem.tsx
@@ -195,13 +195,13 @@ const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   spacious: {

--- a/packages/core/src/TreeList/XDSTreeListItem.tsx
+++ b/packages/core/src/TreeList/XDSTreeListItem.tsx
@@ -17,10 +17,10 @@ import {
   colorVars,
   radiusVars,
   spacingVars,
-  textSizeVars,
   lineHeightVars,
   durationVars,
   easeVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {
@@ -195,34 +195,34 @@ const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   spacious: {
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-4'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-normal'],
   },
 });
 
 const descriptionSizeStyles = stylex.create({
   compact: {
-    fontSize: textSizeVars['--text-2xs'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   balanced: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   spacious: {
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-normal'],
   },
 });

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -33,10 +33,10 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  textSizeVars,
   lineHeightVars,
   typographyVars,
   fontWeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSSearchableItem, XDSSearchSource} from './types';
 
@@ -159,7 +159,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     padding: 0,
     fontFamily: typographyVars['--font-body'],
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-base'],
     color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
@@ -214,7 +214,7 @@ const styles = stylex.create({
   emptyState: {
     padding: spacingVars['--spacing-3'],
     textAlign: 'center',
-    fontSize: textSizeVars['--text-sm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
   },
   loadingSpinner: {

--- a/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
+++ b/packages/core/src/Typeahead/XDSTypeaheadItem.tsx
@@ -14,9 +14,9 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  textSizeVars,
   lineHeightVars,
   fontWeightVars,
+  typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSSearchableItem} from './types';
 import {xdsClassName, mergeProps} from '../utils';
@@ -73,7 +73,7 @@ const styles = stylex.create({
     minWidth: 0,
   },
   label: {
-    fontSize: textSizeVars['--text-base'],
+    fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-primary'],
@@ -82,7 +82,7 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
   },
   description: {
-    fontSize: textSizeVars['--text-xsm'],
+    fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: lineHeightVars['--leading-snug'],
     color: colorVars['--color-text-secondary'],
     overflow: 'hidden',


### PR DESCRIPTION
## Changes

Migrates all component files from raw `textSizeVars` to semantic `typeScaleVars` tokens for fontSize.

**Before:** `fontSize: textSizeVars['--text-xsm']`
**After:** `fontSize: typeScaleVars['--text-supporting-size']`

This makes font sizes themeable through the type scale system — change the base size or ratio and all components follow.

### Files changed: 52
All component `.tsx`/`.ts` files that referenced `textSizeVars` directly now use `typeScaleVars` semantic tokens.

### Follow-up: lineHeight migration
Many files now pair `typeScaleVars` fontSize with raw `lineHeightVars`. Safe-to-migrate pairings where the values are identical:
- `--text-body-size` + `lineHeightVars['--leading-base']` → `typeScaleVars['--text-body-leading']`
- `--text-label-size` + `lineHeightVars['--leading-base']` → `typeScaleVars['--text-label-leading']`

Intentional overrides that should stay as raw `lineHeightVars` (different values):
- `--text-supporting-size` + `--leading-snug` (tighter than `--text-supporting-leading` for dense UI)
- `--text-large-size` + `--leading-tight` / `--leading-snug` (tighter than `--text-large-leading` for headings)

---
