### PR TITLE
fix(type-scale): use Math.round for 4px grid snap in line-height computation

### DIFF
--- a/packages/core/src/theme/expandTypeScale.ts
+++ b/packages/core/src/theme/expandTypeScale.ts
@@ -172,7 +172,10 @@ function computeSize(base: number, ratio: number, step: number): number {
  */
 function computeLeading(fontSize: number, targetRatio: number): number {
   const rawLh = fontSize * targetRatio;
-  const snappedLh = Math.max(Math.ceil(rawLh / 4) * 4, fontSize + 4);
+  const snappedLh = Math.max(
+    Math.round(rawLh / 4) * 4,
+    Math.ceil((fontSize + 4) / 4) * 4,
+  );
   // Round to 4 decimal places for clean CSS output
   return Math.round((snappedLh / fontSize) * 10000) / 10000;
 }

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -369,16 +369,16 @@ export const typeScaleDefaults = {
   // Text tokens — body/label/code at base, large one step up, supporting one step down
   '--text-body-size': 'var(--text-base)', // 14px
   '--text-body-weight': 'var(--font-weight-normal)',
-  '--text-body-leading': '1.7143',
+  '--text-body-leading': '1.4286',
   '--text-large-size': '17px', // 14 × 1.2¹ (no matching --text-* token)
   '--text-large-weight': 'var(--font-weight-semibold)',
-  '--text-large-leading': '1.6471',
+  '--text-large-leading': '1.4118',
   '--text-label-size': 'var(--text-base)', // 14px
   '--text-label-weight': 'var(--font-weight-medium)',
   '--text-label-leading': '1.4286',
   '--text-code-size': 'var(--text-base)', // 14px
   '--text-code-weight': 'var(--font-weight-normal)',
-  '--text-code-leading': '1.7143',
+  '--text-code-leading': '1.4286',
   '--text-supporting-size': 'var(--text-xsm)', // 12px
   '--text-supporting-weight': 'var(--font-weight-normal)',
   '--text-supporting-leading': '1.6667',


### PR DESCRIPTION
## Summary

Fixes a bug in `computeLeading` where `Math.ceil` was used instead of `Math.round` for 4px grid snapping, producing overly generous line-heights.

The [exploration in PR #555](https://github.com/facebookexperimental/xds/pull/555) specified `Math.round` (round-to-nearest), but the implementation in PR #638 used `Math.ceil` (always round up). This caused body text at 14px to get a 24px line-height instead of the intended 20px.

### Changes

**`expandTypeScale.ts`** — `computeLeading()`:
- Main snap: `Math.ceil(rawLh / 4) * 4` → `Math.round(rawLh / 4) * 4`
- Minimum: `fontSize + 4` → `Math.ceil((fontSize + 4) / 4) * 4` (grid-aligns the minimum too)

**`tokens.stylex.ts`** — Updated 3 default leading values:

| Token | Before | After |
|---|---|---|
| `--text-body-leading` | 1.7143 (24px) | **1.4286 (20px)** |
| `--text-large-leading` | 1.6471 (28px) | **1.4118 (24px)** |
| `--text-code-leading` | 1.7143 (24px) | **1.4286 (20px)** |

All 1505 tests pass (92/92 test files).

---
