### PR TITLE
fix(AppShell): replace hardcoded px values in autoMobileTopBar with spacing tokens

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -364,8 +364,8 @@ const styles = stylex.create({
   autoMobileTopBar: {
     display: 'flex',
     alignItems: 'center',
-    height: 48,
-    paddingInline: 8,
+    height: spacingVars['--spacing-12'],
+    paddingInline: spacingVars['--spacing-2'],
   },
   // Sticky header for auto height mode
   headerSticky: {


### PR DESCRIPTION
## Summary

The `autoMobileTopBar` style in `XDSAppShell` used hardcoded pixel values that don't respond to theme overrides:

```ts
// Before
autoMobileTopBar: {
  height: 48,        // ❌ hardcoded
  paddingInline: 8,  // ❌ hardcoded
}

// After
autoMobileTopBar: {
  height: spacingVars['--spacing-12'],   // ✅ 48px via token
  paddingInline: spacingVars['--spacing-2'],  // ✅ 8px via token
}
```

This ensures the mobile top bar respects theme spacing overrides, so custom themes that adjust spacing scale will have the mobile nav bar respond correctly.

## Checklist
- [x] CSS variable usage — all visual properties use tokens
- [x] No change to component reuse patterns
- [x] xdsClassName placement unchanged (root element, correct)

---

*Night Watch — Theme Auditor |
