### PR TITLE
fix(DropdownMenu): use elevation token and add xdsClassName

### DIFF
--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -31,12 +31,14 @@ import {XDSDivider} from '../Divider';
 import {XDSDropdownMenuItem} from './XDSDropdownMenuItem';
 import {
   colorVars,
+  elevationVars,
   spacingVars,
   radiusVars,
   transitionVars,
   typographyVars,
   textSizeVars,
 } from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
   // Dropdown container
@@ -47,7 +49,7 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-element'],
     backgroundColor: colorVars['--color-surface'],
-    boxShadow: `0 4px 12px ${colorVars['--color-shadow-elevation']}`,
+    boxShadow: elevationVars['--elevation-menu'],
     opacity: 1,
     transition: `opacity ${transitionVars['--transition-fast']}`,
   },
@@ -593,7 +595,13 @@ export function XDSDropdownMenu({
       </XDSButton>
 
       {layer.render(
-        <div id={menuId} role="menu" {...stylex.props(styles.dropdown)}>
+        <div
+          id={menuId}
+          role="menu"
+          {...mergeProps(
+            xdsClassName('dropdown-menu'),
+            stylex.props(styles.dropdown),
+          )}>
           {renderOptions()}
         </div>,
         {


### PR DESCRIPTION
## Theme Audit — DropdownMenu

**Findings:**

1. **Hardcoded boxShadow** — `boxShadow: \`0 4px 12px \${colorVars['--color-shadow-elevation']}\``` used a hardcoded shadow structure with only the color tokenized. Replaced with `elevationVars['--elevation-menu']` so the full shadow (offsets, blur, spread, color) is controlled by the theme.

2. **Missing xdsClassName** — The dropdown menu container (`role="menu"` div) had no `xdsClassName`, making it invisible to `@scope`-based theme selectors. Added `xdsClassName('dropdown-menu')` via `mergeProps`.

---
