### PR TITLE
fix(MoreMenu): add xdsClassName for theme targeting

### DIFF
--- a/packages/core/src/MoreMenu/XDSMoreMenu.test.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.test.tsx
@@ -184,4 +184,10 @@ describe('XDSMoreMenu', () => {
     expect(button).toBeInTheDocument();
     expect(button.tagName).toBe('BUTTON');
   });
+
+  it('renders xds-more-menu class on dropdown panel for theme targeting', () => {
+    render(<XDSMoreMenu items={defaultItems} />);
+    const menu = screen.getByRole('menu', {hidden: true});
+    expect(menu.className).toContain('xds-more-menu');
+  });
 });

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -44,6 +44,7 @@ import {
   typographyVars,
   textSizeVars,
 } from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
 // Styles
@@ -475,7 +476,13 @@ export function XDSMoreMenu({
         data-testid={testId}
       />
       {layer.render(
-        <div id={menuId} role="menu" {...stylex.props(styles.dropdown)}>
+        <div
+          id={menuId}
+          role="menu"
+          {...mergeProps(
+            xdsClassName('more-menu'),
+            stylex.props(styles.dropdown),
+          )}>
           {renderOptions()}
         </div>,
         {


### PR DESCRIPTION
## What

Adds `xdsClassName('more-menu')` to the MoreMenu dropdown panel element, enabling theme authors to target it via `@scope`.

## Why

XDSDropdownMenu applies `xdsClassName('dropdown-menu')` on its panel, but XDSMoreMenu (a convenience wrapper) was missing this — themes couldn't independently style the MoreMenu dropdown.

## Changes

- **XDSMoreMenu.tsx**: Import `xdsClassName` and `mergeProps` from utils; apply `xdsClassName('more-menu')` to the dropdown `<div>` using the `mergeProps` pattern
- **XDSMoreMenu.test.tsx**: Add test verifying `xds-more-menu` class is present on the dropdown panel

## Needs Review

- **List dividers**: XDSList renders inter-item dividers as raw `<hr>` elements with inline StyleX styles (`backgroundColor: colorVars['--color-divider']`) rather than using `XDSDivider`. The token usage is correct, but theme `@scope` rules targeting `.xds-divider` won't cascade to these dividers. This is a design decision — should List dividers be XDSDivider instances for full theme targeting, or is the lightweight `<hr>` approach preferred for performance?

---
