### PR TITLE
fix(PowerSearch): add xdsClassName for theme targeting

### DIFF
--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -38,6 +38,7 @@ import {useInternalConfig} from './useInternalConfig';
 import {usePowerSearchSource} from './usePowerSearchSource';
 import {formatFilterValue} from './formatFilterValue';
 import {PowerSearchEditPopover} from './PowerSearchEditPopover';
+import {xdsClassName} from '../utils';
 import type {
   PowerSearchConfig,
   PowerSearchFilter,
@@ -768,7 +769,7 @@ export function XDSPowerSearch({
 
   return (
     <>
-      <div ref={layer.ref}>
+      <div ref={layer.ref} {...xdsClassName('power-search')}>
         <XDSTokenizer
           ref={tokenizerRef}
           label={label}


### PR DESCRIPTION
## Theme Audit Finding

PowerSearch was missing `xdsClassName` on its root wrapper div. Theme authors couldn't target it with `@scope`-based theme rules.

### Change

- Add `xdsClassName('power-search')` to the wrapper `<div>` that contains the Tokenizer
- Import `xdsClassName` from `../utils`

### Context

Found during Night Watch Theme Auditor pass (NumberInput, Pagination, Popover, PowerSearch, ProgressBar). PowerSearch was the only component in this batch missing xdsClassName.
