### PR TITLE
perf(build): split DTS generation from tsup to reduce memory usage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -396,7 +396,7 @@
   ],
   "scripts": {
     "prepack": "yarn build",
-    "build": "NODE_OPTIONS='--max-old-space-size=4096' tsup",
+    "build": "tsup && tsc --project tsconfig.build.json",
     "dev": "tsup --watch",
     "test": "vitest run --root ../..",
     "test:watch": "vitest --root ../..",

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "sourceMap": false
+  },
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.doc.mjs",
+    "src/**/__tests__/**",
+    "src/**/*.perf.test.ts",
+    "src/**/*.perf.test.tsx"
+  ]
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -1,8 +1,12 @@
 /**
  * @file tsup.config.ts
  * @input Uses tsup
- * @output Bundle configuration for CJS/ESM outputs with TypeScript declarations
+ * @output Bundle configuration for CJS/ESM outputs (no DTS — see build script)
  * @position Build config; defines entry points and output formats for @xds/core
+ *
+ * DTS generation is handled separately by `tsc --project tsconfig.build.json`
+ * to avoid tsup's per-entry-point TypeScript program instantiation, which
+ * consumes excessive memory (~2-4GB) with 60+ entry points.
  *
  * SYNC: When modified, update this header and /packages/core/README.md
  */
@@ -13,7 +17,7 @@ import babel from 'esbuild-plugin-babel';
 export default defineConfig({
   entry: ['src/index.ts', 'src/*/index.ts', 'src/theme/tokens.stylex.ts'],
   format: ['cjs', 'esm'],
-  dts: true,
+  dts: false,
   splitting: true,
   clean: true,
   external: ['react', 'react-dom'],


### PR DESCRIPTION
## Problem

tsup's `dts: true` with 60+ entry points (`src/*/index.ts`) instantiates a full TypeScript program **per entry point**. This requires `NODE_OPTIONS='--max-old-space-size=4096'` and still OOMs in memory-constrained environments (sandbox, smaller CI runners).

## Solution

Split the core package build into two steps:

1. **`tsup`** — esbuild + Babel/StyleX transform → CJS/ESM bundles (~6s, low memory)
2. **`tsc --project tsconfig.build.json`** — emit `.d.ts` files in a single pass

Instead of 60+ TypeScript program instantiations, we get **one**. The `--max-old-space-size=4096` workaround is removed.

## Changes

| File | Change |
|------|--------|
| `packages/core/tsup.config.ts` | `dts: false` |
| `packages/core/package.json` | `build: tsup && tsc --project tsconfig.build.json` (removed `NODE_OPTIONS`) |
| `packages/core/tsconfig.build.json` | **New** — `emitDeclarationOnly`, excludes tests/docs |

## Output

No changes to the `dist/` layout — same JS bundles, same `.d.ts` file locations, same package exports. Just faster and lighter.

---
