### PR TITLE
docs: fix storybook @example blocks and sync theming sections

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -176,22 +176,13 @@ export interface XDSAppShellProps {
    *
    * @example
    * ```
-   * // Auto (default) — no prop needed
-   * <XDSAppShell topNav={...} sideNav={...}>
-   *
-   * // Controlled state, auto content
-   * <XDSAppShell mobileNav={{ isOpen, onOpenChange }}>
-   *
-   * // Custom toggle placement
+   * <XDSAppShell topNav={...} sideNav={...} />
+   * <XDSAppShell mobileNav={{ isOpen, onOpenChange }} />
    * <XDSAppShell mobileNav={{ hasToggle: false }}>
    *   <XDSMobileNavToggle />
    * </XDSAppShell>
-   *
-   * // Full custom drawer
-   * <XDSAppShell mobileNav={<XDSMobileNav title="Menu">...</XDSMobileNav>}>
-   *
-   * // Disable
-   * <XDSAppShell mobileNav={false}>
+   * <XDSAppShell mobileNav={<XDSMobileNav title="Menu">...</XDSMobileNav>} />
+   * <XDSAppShell mobileNav={false} />
    * ```
    */
   mobileNav?: false | XDSMobileNavConfig | ReactNode;

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -98,6 +98,7 @@ export const docs = {
   ],
   theming: {
     targets: [
+      {className: 'xds-dropdown-menu'},
       {className: 'xds-dropdown-menu-item'},
     ],
   },
@@ -422,6 +423,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
+      {className: 'xds-dropdown-menu'},
       {className: 'xds-dropdown-menu-item'},
     ],
   },

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -235,14 +235,11 @@ export interface XDSMobileNavProps extends Omit<XDSBaseProps, 'title'> {
  *
  * @example
  * ```
- * // Inside AppShell — state managed by AppShell
  * <XDSAppShell mobileNav={
  *   <XDSMobileNav header="Navigation">
  *     <XDSSideNavItem label="Home" href="/" />
  *   </XDSMobileNav>
  * }>
- *
- * // Standalone — manage state yourself
  * <XDSMobileNav isOpen={isOpen} onOpenChange={setIsOpen} header="Navigation">
  *   <XDSSideNavItem label="Home" href="/" />
  * </XDSMobileNav>

--- a/packages/core/src/MobileNav/XDSMobileNavToggle.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNavToggle.tsx
@@ -45,13 +45,10 @@ export interface XDSMobileNavToggleProps extends Pick<
  *
  * @example
  * ```
- * // In a custom toolbar
  * <div className="my-toolbar">
  *   <XDSMobileNavToggle />
  *   <h1>Page Title</h1>
  * </div>
- *
- * // With custom icon
  * <XDSMobileNavToggle label="Menu">
  *   <MyCustomMenuIcon />
  * </XDSMobileNavToggle>

--- a/packages/core/src/MoreMenu/MoreMenu.doc.mjs
+++ b/packages/core/src/MoreMenu/MoreMenu.doc.mjs
@@ -138,6 +138,11 @@ export const docs = {
     'Tooltip: shows label on hover, hidden when menu is open',
     'Custom rendering: optional children render function for custom item content',
   ],
+  theming: {
+    targets: [
+      {className: 'xds-more-menu'},
+    ],
+  },
   accessibility: [
     'Proper ARIA roles: menu and menuitem on dropdown elements.',
     'Trigger button has aria-haspopup="menu" and aria-expanded.',
@@ -291,6 +296,11 @@ export const docsZh = {
     '工具提示：悬停时显示标签，菜单打开时隐藏',
     '自定义渲染：可选的 children 渲染函数用于自定义项目内容',
   ],
+  theming: {
+    targets: [
+      {className: 'xds-more-menu'},
+    ],
+  },
   accessibility: [
     '正确的 ARIA 角色：下拉元素上设置 menu 和 menuitem。',
     '触发按钮设置了 aria-haspopup="menu" 和 aria-expanded。',

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -23,7 +23,7 @@ export const docs = {
   keyboard: 'Tab through items, Enter/Space to activate links',
   theming: {
     targets: [
-      {className: 'xds-side-nav'},
+      {className: 'xds-side-nav', visualProps: ['mode']},
       {className: 'xds-side-nav-heading'},
       {className: 'xds-side-nav-item'},
       {className: 'xds-side-nav-section'},
@@ -458,7 +458,7 @@ export const docsZh = {
   keyboard: 'Tab 切换项目，Enter/Space 激活链接',
   theming: {
     targets: [
-      {className: 'xds-side-nav'},
+      {className: 'xds-side-nav', visualProps: ['mode']},
       {className: 'xds-side-nav-heading'},
       {className: 'xds-side-nav-item'},
       {className: 'xds-side-nav-section'},

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -38,8 +38,8 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-heading', visualProps: ['level']},
-      {className: 'xds-text', visualProps: ['type']},
+      {className: 'xds-heading', visualProps: ['level', 'color']},
+      {className: 'xds-text', visualProps: ['type', 'color']},
     ],
   },
   accessibility: [
@@ -326,8 +326,8 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-heading', visualProps: ['level']},
-      {className: 'xds-text', visualProps: ['type']},
+      {className: 'xds-heading', visualProps: ['level', 'color']},
+      {className: 'xds-text', visualProps: ['type', 'color']},
     ],
   },
   accessibility: [

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -115,8 +115,8 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-top-nav'},
-      {className: 'xds-top-nav-item'},
+      {className: 'xds-top-nav', visualProps: ['mode']},
+      {className: 'xds-top-nav-item', visualProps: ['mode']},
       {className: 'xds-top-nav-heading'},
       {className: 'xds-top-nav-mega-menu'},
       {className: 'xds-top-nav-menu'},
@@ -600,8 +600,8 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-top-nav'},
-      {className: 'xds-top-nav-item'},
+      {className: 'xds-top-nav', visualProps: ['mode']},
+      {className: 'xds-top-nav-item', visualProps: ['mode']},
       {className: 'xds-top-nav-heading'},
       {className: 'xds-top-nav-mega-menu'},
       {className: 'xds-top-nav-menu'},


### PR DESCRIPTION
## What

Night Watch doc review found and fixed two categories of issues across 8 files.

### Storybook @example fixes (3 files)
Removed JS comments and blank lines from `@example` code blocks. These break Storybook's autodocs parser (blank lines end the code fence, comments confuse the markdown renderer).

| Component | Issues fixed |
|-----------|-------------|
| XDSAppShell (mobileNav prop) | 5 JS comments, 4 blank lines |
| XDSMobileNav | 2 JS comments, 1 blank line |
| XDSMobileNavToggle | 2 JS comments, 1 blank line |

### Theming section sync (5 files)
`xdsClassName()` calls in source had visualProps that weren't reflected in `.doc.mjs` theming sections. Two components had no theming section at all despite having `xdsClassName()` calls.

| File | Fix |
|------|-----|
| Text.doc.mjs | Added `color` visualProp to xds-heading and xds-text |
| SideNav.doc.mjs | Added `mode` visualProp to xds-side-nav |
| TopNav.doc.mjs | Added `mode` visualProp to xds-top-nav and xds-top-nav-item |
| DropdownMenu.doc.mjs | Added missing xds-dropdown-menu target |
| MoreMenu.doc.mjs | Added theming section (xds-more-menu target) |

## Validation
- `yarn workspace @xds/core typecheck:docs` passes
- ESM build succeeds
- No source code (.tsx/.ts) implementation changes, only JSDoc and .doc.mjs

---
*Night Watch Doc Reviewer*