### PR TITLE
fix(Collapsible): replace hardcoded fontSize and transition with theme tokens

### DIFF
--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -25,6 +25,8 @@ import {
   typographyVars,
   fontWeightVars,
   spacingVars,
+  textSizeVars,
+  transitionVars,
 } from '../theme/tokens.stylex';
 import {useXDSCollapsible} from './useXDSCollapsible';
 import {getIcon} from '../Icon/globalIconRegistry';
@@ -41,7 +43,7 @@ const styles = stylex.create({
     width: '100%',
     cursor: 'pointer',
     fontFamily: typographyVars['--font-body'],
-    fontSize: 16,
+    fontSize: textSizeVars['--text-lg'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     color: colorVars['--color-text-primary'],
     textAlign: 'start',
@@ -53,7 +55,7 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
-    transition: 'transform 150ms ease',
+    transition: `transform ${transitionVars['--transition-fast']}`,
     color: colorVars['--color-icon-secondary'],
   },
   chevronOpen: {


### PR DESCRIPTION
## Theme Audit — 2026-03-18

Batch audit of 5 components: **CheckboxInput**, **Collapsible**, **DateInput**, **Dialog**, **Divider**.

### Findings

**Collapsible** — 2 hardcoded values replaced with tokens:
- `fontSize: 16` → `textSizeVars['--text-lg']` (trigger text) — same 1rem/16px value, but now themeable
- `transition: 'transform 150ms ease'` → `transitionVars['--transition-fast']` (chevron rotation) — now respects theme transition speed

### Clean Components (no issues found)

- **CheckboxInput** — all colors, spacing, radius use tokens. Size dimensions (18-24px) are structural intrinsic sizing, not semantic spacing. Inline SVG checkmark is the component's own visual, not an icon registry candidate. Uses XDSFieldLabel, XDSFieldStatus, XDSSpinner correctly. xdsClassName on root with size variant. ✅
- **DateInput** — fully tokenized (colorVars, radiusVars, typographyVars, textSizeVars, etc.). Uses XDSIcon, XDSCalendar, XDSField, XDSSpinner. xdsClassName on input wrapper (the visual element). ✅
- **Dialog** — uses colorVars, radiusVars, transitionVars, elevationVars. `borderRadius: 0` in fullscreen is intentional (0 is an allowed exception). xdsClassName on `<dialog>` with variant. ✅
- **DialogHeader** — uses XDSButton(ghost) for close, XDSIcon for close icon, XDSHeading/XDSText for title/subtitle. All spacing from spacingVars. ✅
- **Divider** — fully tokenized. xdsClassName with variant and orientation. ✅

### Needs Review

None — both fixes are straightforward token replacements with identical default values.

---
