### PR TITLE
chore: run gh-pages cleanup daily instead of weekly

### DIFF
--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -2,7 +2,7 @@ name: Cleanup Preview Deployments
 
 on:
   schedule:
-    - cron: '0 6 * * 1' # Weekly Monday 6am UTC
+    - cron: '0 6 * * *' # Daily 6am UTC
   workflow_dispatch:
     inputs:
       dry_run:


### PR DESCRIPTION
Preview deployments accumulate quickly with the current PR cadence. Switch from weekly Monday to daily cleanup to keep gh-pages lean.

---
