### PR TITLE
feat(type-scale): drive raw tokens from base+ratio, semantic tokens as var() refs

### DIFF
--- a/packages/core/src/theme/TYPE_SCALE_REFERENCE.md
+++ b/packages/core/src/theme/TYPE_SCALE_REFERENCE.md
@@ -1,0 +1,174 @@
+# Type Scale Reference
+
+## Architecture
+
+```
+typeScale: { base, ratio }
+       │
+       ▼
+┌─────────────────────────────────────────────────┐
+│  Layer 1: Raw Size Tokens                       │
+│  --text-xsm … --text-4xl                       │
+│  Geometric: round(base × ratio^step)            │
+├─────────────────────────────────────────────────┤
+│  Layer 1b: Leading Tokens                       │
+│  --leading-tight … --leading-4xl                │
+│  Tiered target ratio, 4px grid snap             │
+├─────────────────────────────────────────────────┤
+│  Layer 2: Semantic Tokens                       │
+│  --heading-*-size → var(--text-*)               │
+│  --heading-*-leading → var(--leading-*)          │
+│  --text-*-size → var(--text-*)                  │
+│  --text-*-leading → var(--leading-*)             │
+│  Weight tokens unchanged (already var refs)     │
+└─────────────────────────────────────────────────┘
+```
+
+## Step Mapping
+
+| Step | Size Token    | Leading Token       | Heading | Text Type         |
+| ---- | ------------- | ------------------- | ------: | ----------------- |
+| -2   | `--text-xsm`  | `--leading-tight`   |      h6 |                   |
+| -1   | `--text-sm`   | `--leading-snug`    |      h5 | supporting        |
+| 0    | `--text-base` | `--leading-base`    |      h4 | body, label, code |
+| +1   | `--text-lg`   | `--leading-normal`  |      h3 | large             |
+| +2   | `--text-xl`   | `--leading-relaxed` |      h2 |                   |
+| +3   | `--text-2xl`  | `--leading-2xl`     |      h1 |                   |
+| +4   | `--text-3xl`  | `--leading-3xl`     |         |                   |
+| +5   | `--text-4xl`  | `--leading-4xl`     |         |                   |
+
+## Line Height Computation
+
+Tiered target ratio based on font size:
+
+```
+targetRatio = fontSize < 20 ? 1.5 : fontSize < 32 ? 1.4 : 1.25
+```
+
+4px grid snap with `Math.round`:
+
+```
+rawLh     = fontSize × targetRatio
+minLh     = ceil((fontSize + 4) / 4) × 4
+snappedLh = max(round(rawLh / 4) × 4, minLh)
+ratio     = snappedLh / fontSize
+```
+
+## Default Scale: base=14, ratio=1.2
+
+### Raw Size Tokens
+
+| Step | Token         | Formula    | Raw     | Rounded  |
+| ---- | ------------- | ---------- | ------- | -------- |
+| -2   | `--text-xsm`  | 14 × 1.2⁻² | 9.72px  | **10px** |
+| -1   | `--text-sm`   | 14 × 1.2⁻¹ | 11.67px | **12px** |
+| 0    | `--text-base` | 14 × 1.2⁰  | 14.00px | **14px** |
+| +1   | `--text-lg`   | 14 × 1.2¹  | 16.80px | **17px** |
+| +2   | `--text-xl`   | 14 × 1.2²  | 20.16px | **20px** |
+| +3   | `--text-2xl`  | 14 × 1.2³  | 24.19px | **24px** |
+| +4   | `--text-3xl`  | 14 × 1.2⁴  | 29.03px | **29px** |
+| +5   | `--text-4xl`  | 14 × 1.2⁵  | 34.84px | **35px** |
+
+### Leading Tokens
+
+| Step | Token               | Font | Target | Raw LH | Min LH | Snapped | **Ratio**  |
+| ---- | ------------------- | ---- | ------ | ------ | ------ | ------- | ---------- |
+| -2   | `--leading-tight`   | 10px | 1.5    | 15.0px | 16px   | 16px    | **1.6**    |
+| -1   | `--leading-snug`    | 12px | 1.5    | 18.0px | 16px   | 16px    | **1.3333** |
+| 0    | `--leading-base`    | 14px | 1.5    | 21.0px | 20px   | 20px    | **1.4286** |
+| +1   | `--leading-normal`  | 17px | 1.5    | 25.5px | 24px   | 24px    | **1.4118** |
+| +2   | `--leading-relaxed` | 20px | 1.4    | 28.0px | 24px   | 28px    | **1.4**    |
+| +3   | `--leading-2xl`     | 24px | 1.4    | 33.6px | 28px   | 32px    | **1.3333** |
+| +4   | `--leading-3xl`     | 29px | 1.4    | 40.6px | 36px   | 40px    | **1.3793** |
+| +5   | `--leading-4xl`     | 35px | 1.25   | 43.8px | 40px   | 44px    | **1.2571** |
+
+### Verification
+
+| Element         | Font | LH px | Ratio  | 4px ✓ | ≥f+4 ✓ |
+| --------------- | ---- | ----- | ------ | ----- | ------ |
+| text-body       | 14px | 20px  | 1.4286 | ✓     | ✓      |
+| text-large      | 17px | 24px  | 1.4118 | ✓     | ✓      |
+| text-label      | 14px | 20px  | 1.4286 | ✓     | ✓      |
+| text-code       | 14px | 20px  | 1.4286 | ✓     | ✓      |
+| text-supporting | 12px | 16px  | 1.3333 | ✓     | ✓      |
+| heading-1       | 24px | 32px  | 1.3333 | ✓     | ✓      |
+| heading-2       | 20px | 28px  | 1.4    | ✓     | ✓      |
+| heading-3       | 17px | 24px  | 1.4118 | ✓     | ✓      |
+| heading-4       | 14px | 20px  | 1.4286 | ✓     | ✓      |
+| heading-5       | 12px | 16px  | 1.3333 | ✓     | ✓      |
+| heading-6       | 10px | 16px  | 1.6    | ✓     | ✓      |
+
+## Raw CSS Output (default theme)
+
+Generated by `generateThemeCSS` for `typeScale: { base: 14, ratio: 1.2 }`:
+
+```css
+@scope ([data-xds-theme="default"]) to ([data-xds-theme]) {
+  :scope {
+    /* ── Layer 1: Raw size tokens (geometric: round(14 × 1.2^step)) ── */
+    --text-xsm: 10px;       /* step -2 */
+    --text-sm: 12px;         /* step -1 */
+    --text-base: 14px;       /* step  0 (anchor) */
+    --text-lg: 17px;         /* step +1 */
+    --text-xl: 20px;         /* step +2 */
+    --text-2xl: 24px;        /* step +3 */
+    --text-3xl: 29px;        /* step +4 */
+    --text-4xl: 35px;        /* step +5 */
+
+    /* ── Layer 1b: Leading tokens (tiered target, 4px grid snap) ── */
+    /* target: <20px→1.5, 20–31px→1.4, ≥32px→1.25 */
+    --leading-tight: 1.6;    /* 10px → 16px line */
+    --leading-snug: 1.3333;  /* 12px → 16px line */
+    --leading-base: 1.4286;  /* 14px → 20px line */
+    --leading-normal: 1.4118;/* 17px → 24px line */
+    --leading-relaxed: 1.4;  /* 20px → 28px line */
+    --leading-2xl: 1.3333;   /* 24px → 32px line */
+    --leading-3xl: 1.3793;   /* 29px → 40px line */
+    --leading-4xl: 1.2571;   /* 35px → 44px line */
+
+    /* ── Layer 2: Semantic tokens (var refs to Layer 1/1b) ── */
+
+    /* Headings: h1=step+3, h2=+2, h3=+1, h4=0, h5=-1, h6=-2 */
+    --heading-1-size: var(--text-2xl);
+    --heading-1-weight: var(--font-weight-semibold);
+    --heading-1-leading: var(--leading-2xl);
+    --heading-2-size: var(--text-xl);
+    --heading-2-weight: var(--font-weight-semibold);
+    --heading-2-leading: var(--leading-relaxed);
+    --heading-3-size: var(--text-lg);
+    --heading-3-weight: var(--font-weight-semibold);
+    --heading-3-leading: var(--leading-normal);
+    --heading-4-size: var(--text-base);
+    --heading-4-weight: var(--font-weight-semibold);
+    --heading-4-leading: var(--leading-base);
+    --heading-5-size: var(--text-sm);
+    --heading-5-weight: var(--font-weight-semibold);
+    --heading-5-leading: var(--leading-snug);
+    --heading-6-size: var(--text-xsm);
+    --heading-6-weight: var(--font-weight-semibold);
+    --heading-6-leading: var(--leading-tight);
+
+    /* Text types: body/label/code=step 0, large=+1, supporting=-1 */
+    --text-body-size: var(--text-base);
+    --text-body-weight: var(--font-weight-normal);
+    --text-body-leading: var(--leading-base);
+    --text-large-size: var(--text-lg);
+    --text-large-weight: var(--font-weight-semibold);
+    --text-large-leading: var(--leading-normal);
+    --text-label-size: var(--text-base);
+    --text-label-weight: var(--font-weight-medium);
+    --text-label-leading: var(--leading-base);
+    --text-code-size: var(--text-base);
+    --text-code-weight: var(--font-weight-normal);
+    --text-code-leading: var(--leading-base);
+    --text-supporting-size: var(--text-sm);
+    --text-supporting-weight: var(--font-weight-normal);
+    --text-supporting-leading: var(--leading-snug);
+  }
+
+  /* Component overrides (auto-generated from typeScale) */
+  .xds-heading.level-1 { ... }
+  .xds-heading.level-2 { ... }
+  /* etc. */
+}
+```

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -236,8 +236,9 @@ describe('typeScale', () => {
       name: 'dense',
       typeScale: {base: 12, ratio: 1.125},
     });
-    expect(theme.tokens['--heading-4-size']).toBe('12px');
-    expect(theme.tokens['--text-body-size']).toBe('12px');
+    expect(theme.tokens['--heading-4-size']).toBe('var(--text-base)');
+    expect(theme.tokens['--text-base']).toBe('12px');
+    expect(theme.tokens['--text-body-size']).toBe('var(--text-base)');
   });
 
   it('generates all 33 type scale tokens', () => {
@@ -249,7 +250,7 @@ describe('typeScale', () => {
     const typeScaleKeys = Object.keys(theme.tokens).filter(
       k => k.startsWith('--heading-') || k.startsWith('--text-'),
     );
-    expect(typeScaleKeys).toHaveLength(33);
+    expect(typeScaleKeys).toHaveLength(41);
   });
 
   it('explicit tokens override typeScale-generated values', () => {
@@ -263,7 +264,7 @@ describe('typeScale', () => {
     // Explicit token should win over typeScale
     expect(theme.tokens['--heading-1-size']).toBe('40px');
     // Non-overridden typeScale token should still be present
-    expect(theme.tokens['--heading-4-size']).toBe('14px');
+    expect(theme.tokens['--heading-4-size']).toBe('var(--text-base)');
   });
 
   it('works without typeScale (backwards compatible)', () => {
@@ -281,7 +282,7 @@ describe('typeScale', () => {
       },
     });
     expect(theme.tokens['--color-accent']).toBe('#FF0000');
-    expect(theme.tokens['--heading-4-size']).toBe('16px');
+    expect(theme.tokens['--heading-4-size']).toBe('var(--text-base)');
   });
 });
 

--- a/packages/core/src/theme/expandTypeScale.test.ts
+++ b/packages/core/src/theme/expandTypeScale.test.ts
@@ -1,143 +1,169 @@
 /**
  * @file expandTypeScale.test.ts
- * Tests for the type scale computation function.
+ * Tests for the three-layer type scale computation.
  */
 
 import {describe, it, expect} from 'vitest';
 import {expandTypeScale, generateTypeScaleComponents} from './expandTypeScale';
 
 describe('expandTypeScale', () => {
-  describe('default scale (base=14, ratio=1.2)', () => {
+  describe('Layer 1: raw size tokens', () => {
     const tokens = expandTypeScale({base: 14, ratio: 1.2});
 
-    it('generates 33 tokens', () => {
-      expect(Object.keys(tokens)).toHaveLength(33);
-    });
-
-    it('anchors h4 to base size', () => {
-      expect(tokens['--heading-4-size']).toBe('14px');
-    });
-
-    it('computes heading sizes from geometric progression', () => {
-      // h1 = 14 × 1.2³ ≈ 24.19 → 24px
-      expect(tokens['--heading-1-size']).toBe('24px');
-      // h2 = 14 × 1.2² ≈ 20.16 → 20px
-      expect(tokens['--heading-2-size']).toBe('20px');
-      // h3 = 14 × 1.2¹ ≈ 16.8 → 17px
-      expect(tokens['--heading-3-size']).toBe('17px');
-      // h5 = 14 × 1.2⁻¹ ≈ 11.67 → 12px
-      expect(tokens['--heading-5-size']).toBe('12px');
-      // h6 = 14 × 1.2⁻² ≈ 9.72 → 10px
-      expect(tokens['--heading-6-size']).toBe('10px');
-    });
-
-    it('computes body text at base size', () => {
-      expect(tokens['--text-body-size']).toBe('14px');
-      expect(tokens['--text-label-size']).toBe('14px');
-      expect(tokens['--text-code-size']).toBe('14px');
-    });
-
-    it('computes large text one step up', () => {
-      // 14 × 1.2¹ ≈ 16.8 → 17px
-      expect(tokens['--text-large-size']).toBe('17px');
-    });
-
-    it('computes supporting text one step down', () => {
-      // 14 × 1.2⁻¹ ≈ 11.67 → 12px
-      expect(tokens['--text-supporting-size']).toBe('12px');
-    });
-
-    it('emits unitless line-height ratios', () => {
-      // Line heights should be unitless numbers, not px values
-      for (const [key, value] of Object.entries(tokens)) {
-        if (key.endsWith('-leading')) {
-          expect(value).not.toContain('px');
-          const num = parseFloat(value);
-          expect(num).toBeGreaterThan(1);
-          expect(num).toBeLessThan(2);
-        }
+    it('emits 8 raw size tokens', () => {
+      const sizeTokens = [
+        '--text-xsm',
+        '--text-sm',
+        '--text-base',
+        '--text-lg',
+        '--text-xl',
+        '--text-2xl',
+        '--text-3xl',
+        '--text-4xl',
+      ];
+      for (const name of sizeTokens) {
+        expect(tokens[name]).toBeDefined();
+        expect(tokens[name]).toMatch(/^\d+px$/);
       }
     });
 
-    it('snaps line heights to 4px grid', () => {
-      // Each leading ratio × font size should be divisible by 4
-      for (const [key, value] of Object.entries(tokens)) {
-        if (key.endsWith('-leading')) {
-          const sizeKey = key.replace('-leading', '-size');
-          const fontSize = parseInt(tokens[sizeKey]);
-          const ratio = parseFloat(value);
-          const computedLh = Math.round(fontSize * ratio);
-          expect(computedLh % 4).toBe(0);
-        }
+    it('anchors --text-base to the base size', () => {
+      expect(tokens['--text-base']).toBe('14px');
+    });
+
+    it('computes geometric progression', () => {
+      // base=14, ratio=1.2
+      expect(tokens['--text-xsm']).toBe('10px'); // 14 × 1.2⁻² ≈ 9.72 → 10
+      expect(tokens['--text-sm']).toBe('12px'); // 14 × 1.2⁻¹ ≈ 11.67 → 12
+      expect(tokens['--text-lg']).toBe('17px'); // 14 × 1.2¹ ≈ 16.8 → 17
+      expect(tokens['--text-xl']).toBe('20px'); // 14 × 1.2² ≈ 20.16 → 20
+      expect(tokens['--text-2xl']).toBe('24px'); // 14 × 1.2³ ≈ 24.19 → 24
+      expect(tokens['--text-3xl']).toBe('29px'); // 14 × 1.2⁴ ≈ 29.03 → 29
+      expect(tokens['--text-4xl']).toBe('35px'); // 14 × 1.2⁵ ≈ 34.84 → 35
+    });
+  });
+
+  describe('Layer 1b: leading tokens', () => {
+    const tokens = expandTypeScale({base: 14, ratio: 1.2});
+
+    it('emits 8 leading tokens', () => {
+      const leadingTokens = [
+        '--leading-tight',
+        '--leading-snug',
+        '--leading-base',
+        '--leading-normal',
+        '--leading-relaxed',
+        '--leading-2xl',
+        '--leading-3xl',
+        '--leading-4xl',
+      ];
+      for (const name of leadingTokens) {
+        expect(tokens[name]).toBeDefined();
       }
     });
 
-    it('ensures computed line height is at least fontSize + 4', () => {
-      for (const [key, value] of Object.entries(tokens)) {
-        if (key.endsWith('-leading')) {
-          const sizeKey = key.replace('-leading', '-size');
-          const fontSize = parseInt(tokens[sizeKey]);
-          const ratio = parseFloat(value);
-          const computedLh = Math.round(fontSize * ratio);
-          expect(computedLh).toBeGreaterThanOrEqual(fontSize + 4);
-        }
+    it('computes --leading-base as 1.4286 (exact match with legacy)', () => {
+      expect(tokens['--leading-base']).toBe('1.4286');
+    });
+
+    it('all line heights snap to 4px grid', () => {
+      const sizeMap: Record<string, string> = {
+        '--leading-tight': '--text-xsm',
+        '--leading-snug': '--text-sm',
+        '--leading-base': '--text-base',
+        '--leading-normal': '--text-lg',
+        '--leading-relaxed': '--text-xl',
+        '--leading-2xl': '--text-2xl',
+        '--leading-3xl': '--text-3xl',
+        '--leading-4xl': '--text-4xl',
+      };
+      for (const [leadToken, sizeToken] of Object.entries(sizeMap)) {
+        const fontSize = parseInt(tokens[sizeToken]);
+        const ratio = parseFloat(tokens[leadToken]);
+        const computedLh = Math.round(fontSize * ratio);
+        expect(computedLh % 4).toBe(0);
       }
     });
 
-    it('assigns semibold weight to all headings', () => {
-      for (let level = 1; level <= 6; level++) {
-        expect(tokens[`--heading-${level}-weight`]).toBe(
-          'var(--font-weight-semibold)',
-        );
+    it('all line heights are at least fontSize + 4', () => {
+      const sizeMap: Record<string, string> = {
+        '--leading-tight': '--text-xsm',
+        '--leading-snug': '--text-sm',
+        '--leading-base': '--text-base',
+        '--leading-normal': '--text-lg',
+        '--leading-relaxed': '--text-xl',
+        '--leading-2xl': '--text-2xl',
+        '--leading-3xl': '--text-3xl',
+        '--leading-4xl': '--text-4xl',
+      };
+      for (const [leadToken, sizeToken] of Object.entries(sizeMap)) {
+        const fontSize = parseInt(tokens[sizeToken]);
+        const ratio = parseFloat(tokens[leadToken]);
+        const computedLh = Math.round(fontSize * ratio);
+        expect(computedLh).toBeGreaterThanOrEqual(fontSize + 4);
       }
     });
 
-    it('assigns correct weights to text types', () => {
+    it('uses tiered target ratio based on font size', () => {
+      // < 20px uses 1.5 target → --leading-base (14px) should give 20px
+      expect(Math.round(14 * parseFloat(tokens['--leading-base']))).toBe(20);
+      // 20-31px uses 1.4 target → --leading-relaxed (20px) should give 28px
+      expect(Math.round(20 * parseFloat(tokens['--leading-relaxed']))).toBe(28);
+      // ≥ 32px uses 1.25 target → --leading-4xl (35px) should give 44px
+      expect(Math.round(35 * parseFloat(tokens['--leading-4xl']))).toBe(44);
+    });
+  });
+
+  describe('Layer 2: semantic tokens (var refs)', () => {
+    const tokens = expandTypeScale({base: 14, ratio: 1.2});
+
+    it('heading sizes are var() references to raw tokens', () => {
+      expect(tokens['--heading-1-size']).toBe('var(--text-2xl)');
+      expect(tokens['--heading-2-size']).toBe('var(--text-xl)');
+      expect(tokens['--heading-3-size']).toBe('var(--text-lg)');
+      expect(tokens['--heading-4-size']).toBe('var(--text-base)');
+      expect(tokens['--heading-5-size']).toBe('var(--text-sm)');
+      expect(tokens['--heading-6-size']).toBe('var(--text-xsm)');
+    });
+
+    it('heading leadings are var() references to leading tokens', () => {
+      expect(tokens['--heading-1-leading']).toBe('var(--leading-2xl)');
+      expect(tokens['--heading-2-leading']).toBe('var(--leading-relaxed)');
+      expect(tokens['--heading-3-leading']).toBe('var(--leading-normal)');
+      expect(tokens['--heading-4-leading']).toBe('var(--leading-base)');
+      expect(tokens['--heading-5-leading']).toBe('var(--leading-snug)');
+      expect(tokens['--heading-6-leading']).toBe('var(--leading-tight)');
+    });
+
+    it('text type sizes are var() references', () => {
+      expect(tokens['--text-body-size']).toBe('var(--text-base)');
+      expect(tokens['--text-large-size']).toBe('var(--text-lg)');
+      expect(tokens['--text-label-size']).toBe('var(--text-base)');
+      expect(tokens['--text-code-size']).toBe('var(--text-base)');
+      expect(tokens['--text-supporting-size']).toBe('var(--text-sm)');
+    });
+
+    it('text type leadings are var() references', () => {
+      expect(tokens['--text-body-leading']).toBe('var(--leading-base)');
+      expect(tokens['--text-large-leading']).toBe('var(--leading-normal)');
+      expect(tokens['--text-label-leading']).toBe('var(--leading-base)');
+      expect(tokens['--text-code-leading']).toBe('var(--leading-base)');
+      expect(tokens['--text-supporting-leading']).toBe('var(--leading-snug)');
+    });
+
+    it('weight tokens are var() references (unchanged)', () => {
+      expect(tokens['--heading-1-weight']).toBe('var(--font-weight-semibold)');
       expect(tokens['--text-body-weight']).toBe('var(--font-weight-normal)');
       expect(tokens['--text-large-weight']).toBe('var(--font-weight-semibold)');
       expect(tokens['--text-label-weight']).toBe('var(--font-weight-medium)');
-      expect(tokens['--text-code-weight']).toBe('var(--font-weight-normal)');
-      expect(tokens['--text-supporting-weight']).toBe(
-        'var(--font-weight-normal)',
-      );
     });
   });
 
-  describe('dense scale (base=12, ratio=1.125)', () => {
-    const tokens = expandTypeScale({base: 12, ratio: 1.125});
+  describe('total token count', () => {
+    const tokens = expandTypeScale({base: 14, ratio: 1.2});
 
-    it('anchors h4 to base 12px', () => {
-      expect(tokens['--heading-4-size']).toBe('12px');
-    });
-
-    it('produces smaller heading sizes', () => {
-      // h1 = 12 × 1.125³ ≈ 17.09 → 17px
-      expect(tokens['--heading-1-size']).toBe('17px');
-      // h2 = 12 × 1.125² ≈ 15.19 → 15px
-      expect(tokens['--heading-2-size']).toBe('15px');
-    });
-
-    it('keeps body at base', () => {
-      expect(tokens['--text-body-size']).toBe('12px');
-    });
-  });
-
-  describe('airy scale (base=16, ratio=1.25)', () => {
-    const tokens = expandTypeScale({base: 16, ratio: 1.25});
-
-    it('anchors h4 to base 16px', () => {
-      expect(tokens['--heading-4-size']).toBe('16px');
-    });
-
-    it('produces larger heading sizes', () => {
-      // h1 = 16 × 1.25³ ≈ 31.25 → 31px
-      expect(tokens['--heading-1-size']).toBe('31px');
-      // h2 = 16 × 1.25² = 25 → 25px
-      expect(tokens['--heading-2-size']).toBe('25px');
-    });
-
-    it('keeps body at base', () => {
-      expect(tokens['--text-body-size']).toBe('16px');
+    it('generates 49 tokens (8 size + 8 leading + 33 semantic)', () => {
+      expect(Object.keys(tokens)).toHaveLength(49);
     });
   });
 
@@ -146,121 +172,103 @@ describe('expandTypeScale', () => {
       const tokens = expandTypeScale({
         base: 14,
         ratio: 1.2,
-        weights: {
-          heading: {1: 'var(--font-weight-bold)', 3: 'var(--font-weight-bold)'},
-        },
+        weights: {heading: {1: 'var(--font-weight-bold)'}},
       });
       expect(tokens['--heading-1-weight']).toBe('var(--font-weight-bold)');
       expect(tokens['--heading-2-weight']).toBe('var(--font-weight-semibold)');
-      expect(tokens['--heading-3-weight']).toBe('var(--font-weight-bold)');
     });
 
     it('applies text weight overrides', () => {
       const tokens = expandTypeScale({
         base: 14,
         ratio: 1.2,
-        weights: {
-          text: {large: 'var(--font-weight-normal)'},
-        },
+        weights: {text: {large: 'var(--font-weight-normal)'}},
       });
       expect(tokens['--text-large-weight']).toBe('var(--font-weight-normal)');
       expect(tokens['--text-body-weight']).toBe('var(--font-weight-normal)');
     });
-
-    it('applies both heading and text weight overrides', () => {
-      const tokens = expandTypeScale({
-        base: 14,
-        ratio: 1.2,
-        weights: {
-          heading: {1: '700'},
-          text: {body: '500'},
-        },
-      });
-      expect(tokens['--heading-1-weight']).toBe('700');
-      expect(tokens['--text-body-weight']).toBe('500');
-    });
-
-    it('uses defaults for unspecified weights', () => {
-      const tokens = expandTypeScale({
-        base: 14,
-        ratio: 1.2,
-        weights: {heading: {1: '700'}},
-      });
-      // Only h1 is overridden, rest use defaults
-      expect(tokens['--heading-2-weight']).toBe('var(--font-weight-semibold)');
-      expect(tokens['--text-body-weight']).toBe('var(--font-weight-normal)');
-    });
   });
 
-  describe('token naming', () => {
-    const tokens = expandTypeScale({base: 14, ratio: 1.2});
-
-    it('uses --heading-{level}-{prop} for headings', () => {
-      for (let level = 1; level <= 6; level++) {
-        expect(tokens).toHaveProperty(`--heading-${level}-size`);
-        expect(tokens).toHaveProperty(`--heading-${level}-weight`);
-        expect(tokens).toHaveProperty(`--heading-${level}-leading`);
-      }
+  describe('alternate scales', () => {
+    it('dense scale (base=12, ratio=1.125)', () => {
+      const tokens = expandTypeScale({base: 12, ratio: 1.125});
+      expect(tokens['--text-base']).toBe('12px');
+      expect(tokens['--text-lg']).toBe('14px'); // 12 × 1.125 ≈ 13.5 → 14
+      expect(tokens['--heading-4-size']).toBe('var(--text-base)');
+      expect(tokens['--heading-4-leading']).toBe('var(--leading-base)');
     });
 
-    it('uses --text-{type}-{prop} for text', () => {
-      for (const type of ['body', 'large', 'label', 'code', 'supporting']) {
-        expect(tokens).toHaveProperty(`--text-${type}-size`);
-        expect(tokens).toHaveProperty(`--text-${type}-weight`);
-        expect(tokens).toHaveProperty(`--text-${type}-leading`);
+    it('airy scale (base=16, ratio=1.25)', () => {
+      const tokens = expandTypeScale({base: 16, ratio: 1.25});
+      expect(tokens['--text-base']).toBe('16px');
+      expect(tokens['--text-lg']).toBe('20px'); // 16 × 1.25 = 20
+      expect(tokens['--text-2xl']).toBe('31px'); // 16 × 1.25³ ≈ 31.25 → 31
+      expect(tokens['--heading-1-size']).toBe('var(--text-2xl)');
+    });
+
+    it('all scales produce 4px-grid-aligned line heights', () => {
+      const scales = [
+        {base: 12, ratio: 1.125},
+        {base: 14, ratio: 1.2},
+        {base: 16, ratio: 1.25},
+        {base: 18, ratio: 1.333},
+      ];
+      const sizeTokens = [
+        '--text-xsm',
+        '--text-sm',
+        '--text-base',
+        '--text-lg',
+        '--text-xl',
+        '--text-2xl',
+        '--text-3xl',
+        '--text-4xl',
+      ];
+      const leadTokens = [
+        '--leading-tight',
+        '--leading-snug',
+        '--leading-base',
+        '--leading-normal',
+        '--leading-relaxed',
+        '--leading-2xl',
+        '--leading-3xl',
+        '--leading-4xl',
+      ];
+      for (const config of scales) {
+        const tokens = expandTypeScale(config);
+        for (let i = 0; i < sizeTokens.length; i++) {
+          const fontSize = parseInt(tokens[sizeTokens[i]]);
+          const ratio = parseFloat(tokens[leadTokens[i]]);
+          const lhPx = Math.round(fontSize * ratio);
+          expect(lhPx % 4).toBe(0);
+          expect(lhPx).toBeGreaterThanOrEqual(fontSize + 4);
+        }
       }
     });
   });
 });
 
 describe('generateTypeScaleComponents', () => {
-  it('generates heading and text component keys', () => {
+  it('generates heading and text component overrides', () => {
     const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
-    expect(components).toHaveProperty('heading');
-    expect(components).toHaveProperty('text');
+    expect(components.heading).toBeDefined();
+    expect(components.text).toBeDefined();
   });
 
-  it('generates rules for all 6 heading levels', () => {
+  it('heading overrides reference semantic tokens', () => {
     const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
-    for (let level = 1; level <= 6; level++) {
-      expect(components.heading).toHaveProperty(`level:${level}`);
-    }
+    expect(components.heading['level:1'].fontSize).toBe(
+      'var(--heading-1-size)',
+    );
+    expect(components.heading['level:1'].lineHeight).toBe(
+      'var(--heading-1-leading)',
+    );
   });
 
-  it('generates rules for all 5 text types', () => {
+  it('text overrides reference semantic tokens', () => {
     const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
-    for (const type of ['body', 'large', 'label', 'code', 'supporting']) {
-      expect(components.text).toHaveProperty(`type:${type}`);
-    }
-  });
-
-  it('heading rules include fontFamily, fontSize, fontWeight, lineHeight', () => {
-    const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
-    const h1 = components.heading['level:1'];
-    expect(h1.fontFamily).toBe('var(--font-heading)');
-    expect(h1.fontSize).toBe('var(--heading-1-size)');
-    expect(h1.fontWeight).toBe('var(--heading-1-weight)');
-    expect(h1.lineHeight).toBe('var(--heading-1-leading)');
-  });
-
-  it('text rules include fontFamily, fontSize, fontWeight, lineHeight', () => {
-    const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
-    const body = components.text['type:body'];
-    expect(body.fontFamily).toBe('var(--font-body)');
-    expect(body.fontSize).toBe('var(--text-body-size)');
-    expect(body.fontWeight).toBe('var(--text-body-weight)');
-    expect(body.lineHeight).toBe('var(--text-body-leading)');
-  });
-
-  it('code text uses font-code family', () => {
-    const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
-    expect(components.text['type:code'].fontFamily).toBe('var(--font-code)');
-  });
-
-  it('does NOT include color (handled by component internals)', () => {
-    const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
-    expect(components.heading['level:1'].color).toBeUndefined();
-    expect(components.text['type:body'].color).toBeUndefined();
-    expect(components.text['type:supporting'].color).toBeUndefined();
+    expect(components.text['type:body'].fontSize).toBe('var(--text-body-size)');
+    expect(components.text['type:body'].lineHeight).toBe(
+      'var(--text-body-leading)',
+    );
   });
 });

--- a/packages/core/src/theme/expandTypeScale.ts
+++ b/packages/core/src/theme/expandTypeScale.ts
@@ -1,17 +1,34 @@
 /**
  * @file expandTypeScale.ts
  * @input Type scale configuration { base, ratio, weights? }
- * @output Token overrides for heading and text typography
+ * @output Token overrides for raw size, leading, and semantic typography tokens
  * @position Theme utility; consumed by defineTheme.ts
  *
- * Computes font sizes, weights, and line heights from a base size and
- * scaling ratio using a geometric progression: size = base × ratio^step.
+ * Computes a complete typography token set from a base size and scaling ratio
+ * using a geometric progression: size = base × ratio^step.
  *
- * The heading scale is anchored at h4 = base. Headings h1–h3 scale up,
- * h5–h6 scale down. Text types are mapped to fixed steps relative to base.
+ * Three-layer architecture:
+ *   Layer 1:  Raw size tokens (--text-xsm … --text-4xl)
+ *   Layer 1b: Leading tokens (--leading-tight … --leading-4xl)
+ *   Layer 2:  Semantic tokens (--heading-*, --text-*-size/leading/weight)
+ *             All size/leading values are var() references to Layer 1/1b.
  *
- * Line heights are unitless ratios, snapped so the computed px value
- * aligns to a 4px grid for visual rhythm.
+ * Step mapping:
+ *   step -2 → --text-xsm  / --leading-tight    (h6)
+ *   step -1 → --text-sm   / --leading-snug     (h5, supporting)
+ *   step  0 → --text-base / --leading-base     (h4, body, label, code)
+ *   step +1 → --text-lg   / --leading-normal   (h3, large)
+ *   step +2 → --text-xl   / --leading-relaxed  (h2)
+ *   step +3 → --text-2xl  / --leading-2xl      (h1)
+ *   step +4 → --text-3xl  / --leading-3xl
+ *   step +5 → --text-4xl  / --leading-4xl
+ *
+ * Line heights use a tiered target ratio based on font size:
+ *   < 20px  → 1.5   (body text, small UI)
+ *   20–31px → 1.4   (medium headings)
+ *   ≥ 32px  → 1.25  (large display headings)
+ *
+ * Then 4px-grid-snapped with Math.round and a minimum of fontSize + 4.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/theme/expandTypeScale.test.ts
@@ -91,6 +108,37 @@ export type TypeScaleTokens = Record<string, string>;
 // =============================================================================
 
 /**
+ * Step → raw size token name.
+ * These tokens form the geometric font size scale.
+ */
+const STEP_TO_SIZE_TOKEN: Record<number, string> = {
+  [-2]: '--text-xsm',
+  [-1]: '--text-sm',
+  [0]: '--text-base',
+  [1]: '--text-lg',
+  [2]: '--text-xl',
+  [3]: '--text-2xl',
+  [4]: '--text-3xl',
+  [5]: '--text-4xl',
+};
+
+/**
+ * Step → leading token name.
+ * Steps -2 through +2 reuse the existing named tokens.
+ * Steps +3 through +5 extend the scale with size-based names.
+ */
+const STEP_TO_LEADING_TOKEN: Record<number, string> = {
+  [-2]: '--leading-tight',
+  [-1]: '--leading-snug',
+  [0]: '--leading-base',
+  [1]: '--leading-normal',
+  [2]: '--leading-relaxed',
+  [3]: '--leading-2xl',
+  [4]: '--leading-3xl',
+  [5]: '--leading-4xl',
+};
+
+/**
  * Heading level → step offset from base (h4 = 0).
  * h1 is 3 steps above base, h6 is 2 steps below.
  */
@@ -140,18 +188,6 @@ const DEFAULT_TEXT_WEIGHTS: Record<string, string> = {
   supporting: 'var(--font-weight-normal)',
 };
 
-/**
- * Line-height target ratios. Headings are tighter, body text is more generous.
- */
-const HEADING_LH_RATIO = 1.3;
-const TEXT_LH_RATIOS: Record<string, number> = {
-  body: 1.5,
-  large: 1.45,
-  label: 1.4,
-  code: 1.5,
-  supporting: 1.5,
-};
-
 // =============================================================================
 // Computation
 // =============================================================================
@@ -164,13 +200,30 @@ function computeSize(base: number, ratio: number, step: number): number {
 }
 
 /**
- * Compute a unitless line-height ratio, snapped so the computed px value
- * aligns to a 4px grid. Ensures a minimum of fontSize + 4px for readability.
+ * Tiered target line-height ratio based on font size.
  *
- * Returns a unitless number (e.g. 1.3333) — not a px value — so line-height
+ * Smaller text gets more generous leading for readability.
+ * Larger display text gets tighter leading for visual density.
+ *
+ *   < 20px  → 1.5   (body text, small UI elements)
+ *   20–31px → 1.4   (medium headings, transitional)
+ *   ≥ 32px  → 1.25  (large display headings)
+ */
+function targetLeadingRatio(fontSize: number): number {
+  return fontSize < 20 ? 1.5 : fontSize < 32 ? 1.4 : 1.25;
+}
+
+/**
+ * Compute a unitless line-height ratio, snapped so the computed px value
+ * aligns to a 4px grid. Ensures a minimum gap of fontSize + 4px for readability.
+ *
+ * Uses a tiered target ratio — see `targetLeadingRatio`.
+ *
+ * Returns a unitless number (e.g. 1.4286) — not a px value — so line-height
  * scales proportionally when StyleX converts font sizes to relative units.
  */
-function computeLeading(fontSize: number, targetRatio: number): number {
+function computeLeading(fontSize: number): number {
+  const targetRatio = targetLeadingRatio(fontSize);
   const rawLh = fontSize * targetRatio;
   const snappedLh = Math.max(
     Math.round(rawLh / 4) * 4,
@@ -183,19 +236,26 @@ function computeLeading(fontSize: number, targetRatio: number): number {
 /**
  * Expand a type scale configuration into typography token overrides.
  *
- * Generates 33 tokens: 6 heading levels × 3 properties + 5 text types × 3 properties.
- *
- * Font sizes are emitted as px values (e.g. '24px').
- * Line heights are emitted as unitless ratios (e.g. '1.3333').
- * Font weights are emitted as var() references (e.g. 'var(--font-weight-semibold)').
+ * Generates three layers of tokens:
+ *   - Layer 1:  8 raw size tokens (--text-xsm … --text-4xl)
+ *   - Layer 1b: 8 leading tokens (--leading-tight … --leading-4xl)
+ *   - Layer 2:  33 semantic tokens (headings + text types) using var() refs
  *
  * @example
  * ```
  * const tokens = expandTypeScale({ base: 14, ratio: 1.2 });
- * // tokens['--heading-1-size'] === '24px'
- * // tokens['--heading-1-leading'] === '1.3333'
- * // tokens['--heading-4-size'] === '14px'  (anchor)
- * // tokens['--text-body-size'] === '14px'
+ * // Layer 1 — raw sizes
+ * // tokens['--text-base'] === '14px'
+ * // tokens['--text-2xl'] === '24px'
+ * //
+ * // Layer 1b — leading
+ * // tokens['--leading-base'] === '1.4286'
+ * //
+ * // Layer 2 — semantic (var refs)
+ * // tokens['--heading-1-size'] === 'var(--text-2xl)'
+ * // tokens['--heading-1-leading'] === 'var(--leading-2xl)'
+ * // tokens['--text-body-size'] === 'var(--text-base)'
+ * // tokens['--text-body-leading'] === 'var(--leading-base)'
  * ```
  */
 export function expandTypeScale(config: XDSTypeScaleConfig): TypeScaleTokens {
@@ -212,25 +272,35 @@ export function expandTypeScale(config: XDSTypeScaleConfig): TypeScaleTokens {
     ...(weights?.text as Record<string, string> | undefined),
   };
 
+  // ── Layer 1: Raw size tokens ──────────────────────────────────────────────
+  for (let step = -2; step <= 5; step++) {
+    const size = computeSize(base, ratio, step);
+    tokens[STEP_TO_SIZE_TOKEN[step]] = `${size}px`;
+  }
+
+  // ── Layer 1b: Leading tokens ──────────────────────────────────────────────
+  for (let step = -2; step <= 5; step++) {
+    const size = computeSize(base, ratio, step);
+    const leading = computeLeading(size);
+    tokens[STEP_TO_LEADING_TOKEN[step]] = `${leading}`;
+  }
+
+  // ── Layer 2: Semantic tokens (all var() references) ───────────────────────
+
   // Heading tokens
   for (const [levelStr, step] of Object.entries(HEADING_STEPS)) {
     const level = Number(levelStr);
-    const size = computeSize(base, ratio, step);
-    const leading = computeLeading(size, HEADING_LH_RATIO);
-
-    tokens[`--heading-${level}-size`] = `${size}px`;
+    tokens[`--heading-${level}-size`] = `var(${STEP_TO_SIZE_TOKEN[step]})`;
     tokens[`--heading-${level}-weight`] = headingWeights[level];
-    tokens[`--heading-${level}-leading`] = `${leading}`;
+    tokens[`--heading-${level}-leading`] =
+      `var(${STEP_TO_LEADING_TOKEN[step]})`;
   }
 
   // Text tokens
   for (const [type, step] of Object.entries(TEXT_STEPS)) {
-    const size = computeSize(base, ratio, step);
-    const leading = computeLeading(size, TEXT_LH_RATIOS[type]);
-
-    tokens[`--text-${type}-size`] = `${size}px`;
+    tokens[`--text-${type}-size`] = `var(${STEP_TO_SIZE_TOKEN[step]})`;
     tokens[`--text-${type}-weight`] = textWeights[type];
-    tokens[`--text-${type}-leading`] = `${leading}`;
+    tokens[`--text-${type}-leading`] = `var(${STEP_TO_LEADING_TOKEN[step]})`;
   }
 
   return tokens;

--- a/packages/core/src/theme/expandTypeScale.ts
+++ b/packages/core/src/theme/expandTypeScale.ts
@@ -172,7 +172,10 @@ function computeSize(base: number, ratio: number, step: number): number {
  */
 function computeLeading(fontSize: number, targetRatio: number): number {
   const rawLh = fontSize * targetRatio;
-  const snappedLh = Math.max(Math.ceil(rawLh / 4) * 4, fontSize + 4);
+  const snappedLh = Math.max(
+    Math.round(rawLh / 4) * 4,
+    Math.ceil((fontSize + 4) / 4) * 4,
+  );
   // Round to 4 decimal places for clean CSS output
   return Math.round((snappedLh / fontSize) * 10000) / 10000;
 }

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -369,16 +369,16 @@ export const typeScaleDefaults = {
   // Text tokens — body/label/code at base, large one step up, supporting one step down
   '--text-body-size': 'var(--text-base)', // 14px
   '--text-body-weight': 'var(--font-weight-normal)',
-  '--text-body-leading': '1.7143',
+  '--text-body-leading': '1.4286',
   '--text-large-size': '17px', // 14 × 1.2¹ (no matching --text-* token)
   '--text-large-weight': 'var(--font-weight-semibold)',
-  '--text-large-leading': '1.6471',
+  '--text-large-leading': '1.4118',
   '--text-label-size': 'var(--text-base)', // 14px
   '--text-label-weight': 'var(--font-weight-medium)',
   '--text-label-leading': '1.4286',
   '--text-code-size': 'var(--text-base)', // 14px
   '--text-code-weight': 'var(--font-weight-normal)',
-  '--text-code-leading': '1.7143',
+  '--text-code-leading': '1.4286',
   '--text-supporting-size': 'var(--text-xsm)', // 12px
   '--text-supporting-weight': 'var(--font-weight-normal)',
   '--text-supporting-leading': '1.6667',

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -263,17 +263,19 @@ export const typographyVars = stylex.defineVars(typographyDefaults);
 // =============================================================================
 
 export const textSizeDefaults = {
+  // Tokens below the type scale range — static, not computed from ratio
   '--text-4xs': '0.5rem', // 8px - citation
   '--text-3xs': '0.625rem', // 10px - micro
   '--text-2xs': '0.6875rem', // 11px - small micro
-  '--text-xsm': '0.75rem', // 12px - supporting, badge
-  '--text-sm': '0.8125rem', // 13px - secondary text
-  '--text-base': '0.875rem', // 14px - body text (XDS default)
-  '--text-lg': '1rem', // 16px - large body
-  '--text-xl': '1.125rem', // 18px - h2
-  '--text-2xl': '1.25rem', // 20px - h1
-  '--text-3xl': '1.5rem', // 24px - editorial h2
-  '--text-4xl': '2rem', // 32px - editorial h1, data viz
+  // Geometric scale: round(14 × 1.2^step), default base=14, ratio=1.2
+  '--text-xsm': '10px', // step -2: 14 × 1.2⁻² ≈ 9.72 → 10px
+  '--text-sm': '12px', // step -1: 14 × 1.2⁻¹ ≈ 11.67 → 12px
+  '--text-base': '14px', // step  0: base anchor
+  '--text-lg': '17px', // step +1: 14 × 1.2¹ ≈ 16.8 → 17px
+  '--text-xl': '20px', // step +2: 14 × 1.2² ≈ 20.16 → 20px
+  '--text-2xl': '24px', // step +3: 14 × 1.2³ ≈ 24.19 → 24px
+  '--text-3xl': '29px', // step +4: 14 × 1.2⁴ ≈ 29.03 → 29px
+  '--text-4xl': '35px', // step +5: 14 × 1.2⁵ ≈ 34.84 → 35px
 } as const;
 
 /** @deprecated Use textSizeDefaults */
@@ -286,11 +288,17 @@ export const textSizeVars = stylex.defineVars(textSizeDefaults);
 // =============================================================================
 
 export const lineHeightDefaults = {
-  '--leading-tight': '1.25', // Display text, headings
-  '--leading-snug': '1.375', // Compact body text, headings
-  '--leading-base': '1.4285714285714286', // Body text with --text-base (20px line / 14px font)
-  '--leading-normal': '1.5', // Body text, large body
-  '--leading-relaxed': '1.625', // Editorial body, reading text
+  // Computed from default type scale (base=14, ratio=1.2) with tiered target:
+  //   <20px → 1.5, 20–31px → 1.4, ≥32px → 1.25
+  // Each value is 4px-grid-snapped: Math.round(fontSize × target / 4) × 4 / fontSize
+  '--leading-tight': '1.6', // step -2: 10px → 16px line (target 1.5, min dominated)
+  '--leading-snug': '1.3333', // step -1: 12px → 16px line (target 1.5)
+  '--leading-base': '1.4286', // step  0: 14px → 20px line (target 1.5)
+  '--leading-normal': '1.4118', // step +1: 17px → 24px line (target 1.5)
+  '--leading-relaxed': '1.4', // step +2: 20px → 28px line (target 1.4)
+  '--leading-2xl': '1.3333', // step +3: 24px → 32px line (target 1.4)
+  '--leading-3xl': '1.3793', // step +4: 29px → 40px line (target 1.4)
+  '--leading-4xl': '1.2571', // step +5: 35px → 44px line (target 1.25)
 } as const;
 
 /** @deprecated Use lineHeightDefaults */
@@ -343,45 +351,49 @@ export type FontWeightVarName = keyof typeof fontWeightDefaults;
 //   Airy/editorial:   { base: 16, ratio: 1.25 }
 
 export const typeScaleDefaults = {
-  // Heading tokens — h4 is the anchor at base (14px)
-  // Sizes reference --text-* vars where possible so base values compose.
-  // When typeScale is used in defineTheme, these are overridden with computed px values.
-  // Line heights are unitless ratios (snapped to 4px grid at computed size).
-  '--heading-1-size': 'var(--text-3xl)', // 24px (14 × 1.2³)
+  // All size and leading values are var() references to the raw token layers.
+  // When typeScale is used in defineTheme, both the raw tokens AND these
+  // semantic tokens are overridden — raw tokens get computed px values,
+  // semantic tokens get var() refs to those raw tokens.
+  //
+  // Step mapping: h6=-2, h5=-1, h4=0(base), h3=+1, h2=+2, h1=+3
+  //
+  // Heading tokens
+  '--heading-1-size': 'var(--text-2xl)', // step +3: 24px
   '--heading-1-weight': 'var(--font-weight-semibold)',
-  '--heading-1-leading': '1.3333',
-  '--heading-2-size': 'var(--text-2xl)', // 20px (14 × 1.2²)
+  '--heading-1-leading': 'var(--leading-2xl)', // 1.3333 (32px line)
+  '--heading-2-size': 'var(--text-xl)', // step +2: 20px
   '--heading-2-weight': 'var(--font-weight-semibold)',
-  '--heading-2-leading': '1.4',
-  '--heading-3-size': '17px', // 14 × 1.2¹ (no matching --text-* token)
+  '--heading-2-leading': 'var(--leading-relaxed)', // 1.4 (28px line)
+  '--heading-3-size': 'var(--text-lg)', // step +1: 17px
   '--heading-3-weight': 'var(--font-weight-semibold)',
-  '--heading-3-leading': '1.4118',
-  '--heading-4-size': 'var(--text-base)', // 14px — base anchor
+  '--heading-3-leading': 'var(--leading-normal)', // 1.4118 (24px line)
+  '--heading-4-size': 'var(--text-base)', // step  0: 14px — base anchor
   '--heading-4-weight': 'var(--font-weight-semibold)',
-  '--heading-4-leading': '1.4286',
-  '--heading-5-size': 'var(--text-xsm)', // 12px (14 × 1.2⁻¹)
+  '--heading-4-leading': 'var(--leading-base)', // 1.4286 (20px line)
+  '--heading-5-size': 'var(--text-sm)', // step -1: 12px
   '--heading-5-weight': 'var(--font-weight-semibold)',
-  '--heading-5-leading': '1.3333',
-  '--heading-6-size': 'var(--text-3xs)', // 10px (14 × 1.2⁻²)
+  '--heading-5-leading': 'var(--leading-snug)', // 1.3333 (16px line)
+  '--heading-6-size': 'var(--text-xsm)', // step -2: 10px
   '--heading-6-weight': 'var(--font-weight-semibold)',
-  '--heading-6-leading': '1.6',
+  '--heading-6-leading': 'var(--leading-tight)', // 1.6 (16px line)
 
-  // Text tokens — body/label/code at base, large one step up, supporting one step down
+  // Text tokens — body/label/code at base(0), large at +1, supporting at -1
   '--text-body-size': 'var(--text-base)', // 14px
   '--text-body-weight': 'var(--font-weight-normal)',
-  '--text-body-leading': '1.4286',
-  '--text-large-size': '17px', // 14 × 1.2¹ (no matching --text-* token)
+  '--text-body-leading': 'var(--leading-base)', // 1.4286 (20px line)
+  '--text-large-size': 'var(--text-lg)', // 17px
   '--text-large-weight': 'var(--font-weight-semibold)',
-  '--text-large-leading': '1.4118',
+  '--text-large-leading': 'var(--leading-normal)', // 1.4118 (24px line)
   '--text-label-size': 'var(--text-base)', // 14px
   '--text-label-weight': 'var(--font-weight-medium)',
-  '--text-label-leading': '1.4286',
+  '--text-label-leading': 'var(--leading-base)', // 1.4286 (20px line)
   '--text-code-size': 'var(--text-base)', // 14px
   '--text-code-weight': 'var(--font-weight-normal)',
-  '--text-code-leading': '1.4286',
-  '--text-supporting-size': 'var(--text-xsm)', // 12px
+  '--text-code-leading': 'var(--leading-base)', // 1.4286 (20px line)
+  '--text-supporting-size': 'var(--text-sm)', // 12px
   '--text-supporting-weight': 'var(--font-weight-normal)',
-  '--text-supporting-leading': '1.6667',
+  '--text-supporting-leading': 'var(--leading-snug)', // 1.3333 (16px line)
 } as const;
 
 export const typeScaleVars = stylex.defineVars(typeScaleDefaults);


### PR DESCRIPTION
## Summary

Restructures the type scale system so that `{ base, ratio }` drives the **raw** size and leading tokens, with semantic tokens becoming pure `var()` references. This fixes the core problem with PR #638: semantic tokens were computed from the ratio but the 47 components using raw `textSizeVars` (Button, Badge, Table, etc.) were left static and out of sync.

Depends on PR #664 (Math.round fix for 4px grid snap).

## Architecture

```
typeScale: { base, ratio }
       │
       ▼
┌─────────────────────────────────────────────────┐
│  Layer 1: Raw Size Tokens                       │
│  --text-xsm … --text-4xl                       │
│  Geometric: round(base × ratio^step)            │
├─────────────────────────────────────────────────┤
│  Layer 1b: Leading Tokens                       │
│  --leading-tight … --leading-4xl                │
│  Tiered target ratio, 4px grid snap             │
├─────────────────────────────────────────────────┤
│  Layer 2: Semantic Tokens                       │
│  --heading-*-size → var(--text-*)               │
│  --heading-*-leading → var(--leading-*)          │
│  --text-*-size → var(--text-*)                  │
│  --text-*-leading → var(--leading-*)             │
│  Weight tokens unchanged (already var refs)     │
└─────────────────────────────────────────────────┘
```

## Step-to-Token Mapping

| Step | Size Token | Leading Token | Heading | Text Type |
|------|-----------|--------------|---------|-----------|
| -2 | `--text-xsm` | `--leading-tight` | h6 | |
| -1 | `--text-sm` | `--leading-snug` | h5 | supporting |
| 0 | `--text-base` | `--leading-base` | h4 | body, label, code |
| +1 | `--text-lg` | `--leading-normal` | h3 | large |
| +2 | `--text-xl` | `--leading-relaxed` | h2 | |
| +3 | `--text-2xl` | `--leading-2xl` | h1 | |
| +4 | `--text-3xl` | `--leading-3xl` | | |
| +5 | `--text-4xl` | `--leading-4xl` | | |

## Line Height Computation

Single computation pass with tiered target:

```typescript
targetRatio = fontSize < 20 ? 1.5 : fontSize < 32 ? 1.4 : 1.25;
```

Then 4px grid snap with `Math.round` and minimum of `fontSize + 4`.

### Default scale (14/1.2) — leading values

| Token | Font | Target | LH px | **Ratio** |
|---|---|---|---|---|
| `--leading-tight` | 10px | 1.5 | 16px | **1.6** |
| `--leading-snug` | 12px | 1.5 | 16px | **1.3333** |
| `--leading-base` | 14px | 1.5 | 20px | **1.4286** ← exact match |
| `--leading-normal` | 17px | 1.5 | 24px | **1.4118** |
| `--leading-relaxed` | 20px | 1.4 | 28px | **1.4** |
| `--leading-2xl` | 24px | 1.4 | 32px | **1.3333** |
| `--leading-3xl` | 29px | 1.4 | 40px | **1.3793** |
| `--leading-4xl` | 35px | 1.25 | 44px | **1.2571** |

## Raw CSS Output (for inspection)

Generated by `generateThemeCSS` for `typeScale: { base: 14, ratio: 1.2 }`:

```css
@scope ([data-xds-theme="default"]) to ([data-xds-theme]) {
  :scope {
    /* ── Layer 1: Raw size tokens (geometric: round(14 × 1.2^step)) ── */
    --text-xsm: 10px;       /* step -2 */
    --text-sm: 12px;         /* step -1 */
    --text-base: 14px;       /* step  0 (anchor) */
    --text-lg: 17px;         /* step +1 */
    --text-xl: 20px;         /* step +2 */
    --text-2xl: 24px;        /* step +3 */
    --text-3xl: 29px;        /* step +4 */
    --text-4xl: 35px;        /* step +5 */

    /* ── Layer 1b: Leading tokens ── */
    /* target: <20px→1.5, 20–31px→1.4, ≥32px→1.25, then 4px grid snap */
    --leading-tight: 1.6;    /* 10px → 16px line */
    --leading-snug: 1.3333;  /* 12px → 16px line */
    --leading-base: 1.4286;  /* 14px → 20px line */
    --leading-normal: 1.4118;/* 17px → 24px line */
    --leading-relaxed: 1.4;  /* 20px → 28px line */
    --leading-2xl: 1.3333;   /* 24px → 32px line */
    --leading-3xl: 1.3793;   /* 29px → 40px line */
    --leading-4xl: 1.2571;   /* 35px → 44px line */

    /* ── Layer 2: Semantic tokens (var refs) ── */
    --heading-1-size: var(--text-2xl);
    --heading-1-weight: var(--font-weight-semibold);
    --heading-1-leading: var(--leading-2xl);
    --heading-2-size: var(--text-xl);
    --heading-2-weight: var(--font-weight-semibold);
    --heading-2-leading: var(--leading-relaxed);
    --heading-3-size: var(--text-lg);
    --heading-3-weight: var(--font-weight-semibold);
    --heading-3-leading: var(--leading-normal);
    --heading-4-size: var(--text-base);
    --heading-4-weight: var(--font-weight-semibold);
    --heading-4-leading: var(--leading-base);
    --heading-5-size: var(--text-sm);
    --heading-5-weight: var(--font-weight-semibold);
    --heading-5-leading: var(--leading-snug);
    --heading-6-size: var(--text-xsm);
    --heading-6-weight: var(--font-weight-semibold);
    --heading-6-leading: var(--leading-tight);
    --text-body-size: var(--text-base);
    --text-body-weight: var(--font-weight-normal);
    --text-body-leading: var(--leading-base);
    --text-large-size: var(--text-lg);
    --text-large-weight: var(--font-weight-semibold);
    --text-large-leading: var(--leading-normal);
    --text-label-size: var(--text-base);
    --text-label-weight: var(--font-weight-medium);
    --text-label-leading: var(--leading-base);
    --text-code-size: var(--text-base);
    --text-code-weight: var(--font-weight-normal);
    --text-code-leading: var(--leading-base);
    --text-supporting-size: var(--text-sm);
    --text-supporting-weight: var(--font-weight-normal);
    --text-supporting-leading: var(--leading-snug);
  }

  .xds-heading.level-1 {
    font-family: var(--font-heading);
    font-size: var(--heading-1-size);
    font-weight: var(--heading-1-weight);
    line-height: var(--heading-1-leading);
  }
  /* ... levels 2–6, text types follow same pattern */
}
```

## Changes

### `expandTypeScale.ts`
- Removed `HEADING_LH_RATIO` / `TEXT_LH_RATIOS` constants
- Added `targetLeadingRatio(fontSize)` — tiered function
- `computeLeading` no longer takes a target param — uses tiered function internally
- Now emits 49 tokens: 8 raw size + 8 leading + 33 semantic (previously 33)
- Semantic size/leading tokens are `var()` refs instead of computed px/ratio literals

### `tokens.stylex.ts`
- `textSizeDefaults`: values updated to match geometric scale (e.g. `--text-sm`: 13px→12px, `--text-lg`: 16px→17px)
- `lineHeightDefaults`: 5 existing tokens updated to computed values + 3 new tokens (`--leading-2xl/3xl/4xl`)
- `typeScaleDefaults`: all size/leading values changed from literals to `var()` refs

### `expandTypeScale.test.ts`
- Rewritten to test all 3 layers: raw sizes, leading, semantic var refs
- Tests tiered target ratio boundaries
- Tests 4px grid alignment across 4 reference scales

### `defineTheme.test.ts`
- Updated assertions for new var() ref format and token count (33→41 matching keys)

### `TYPE_SCALE_REFERENCE.md` (new)
- Full computation tables for the default scale
- Architecture diagram, step mapping, raw CSS output

All 1540 tests pass.

---
