### PR TITLE
fix: deploy job runs even when sync-exports fails

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,7 @@ jobs:
 
   deploy:
     needs: test
+    if: always() && !cancelled() && needs.test.result == 'success'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
The deploy job was being skipped because `sync-exports` failure caused the whole workflow to be marked as failed, even though `test` passed. This is why the GH Pages landing page (#679) hasn't deployed.

Adds `if: always() && !cancelled() && needs.test.result == 'success'` to the deploy job so it runs whenever tests pass, regardless of sync-exports status.

---
