### PR TITLE
chore(tokens): remove unused --color-disabled-overlay and --elevation-thumb

### DIFF
--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -141,7 +141,6 @@ const COLOR_CATEGORIES = {
     '--color-divider-emphasized',
   ],
   Effects: [
-    '--color-disabled-overlay',
     '--color-glimmer',
     '--color-glimmer-high-contrast',
     '--color-shadow-elevation',

--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -117,7 +117,6 @@ export const docs = {
           headers: ['Token', 'Usage'],
           rows: [
             ['--elevation-base', 'Subtle shadow'],
-            ['--elevation-thumb', 'Slider thumbs'],
             ['--elevation-menu', 'Dropdowns, menus'],
             ['--elevation-dialog', 'Modals, dialogs'],
             ['--elevation-hover', 'Hover states'],

--- a/packages/cli/src/commands/theme.mjs
+++ b/packages/cli/src/commands/theme.mjs
@@ -146,8 +146,7 @@ function deriveColorPalette({accent, positive, negative, warning, mode}) {
     '--color-divider-high-contrast': ld('#647685', '#6F747C'),
     '--color-divider-emphasized': ld('#CCD3DB', '#494D53'),
 
-    // Disabled/Effects
-    '--color-disabled-overlay': ld('#FFFFFF7F', '#1F1F227F'),
+    // Effects
     '--color-glimmer': ld('#CCD3DB', '#5A5E66'),
     '--color-glimmer-high-contrast': ld('#A4B0BC', '#8C939B'),
     '--color-shadow-elevation': ld('rgba(5, 54, 89, 0.1)', 'rgba(0, 0, 0, 0.3)'),

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -64,8 +64,7 @@ export const colorDefaults = {
   '--color-divider-high-contrast': 'light-dark(#647685, #6F747C)',
   '--color-divider-emphasized': 'light-dark(#CCD3DB, #494D53)',
 
-  // Disabled/Effects
-  '--color-disabled-overlay': 'light-dark(#FFFFFF7F, #1F1F227F)',
+  // Effects
   '--color-glimmer': 'light-dark(#CCD3DB, #5A5E66)',
   '--color-glimmer-high-contrast': 'light-dark(#A4B0BC, #8C939B)',
   '--color-shadow-elevation':
@@ -205,8 +204,6 @@ export const radiusVars = stylex.defineVars(radiusDefaults);
 
 export const elevationDefaults = {
   '--elevation-base': '0px 0px 1px light-dark(rgba(0, 0, 0, 0.1), #111112)',
-  '--elevation-thumb':
-    '0 1px 3px light-dark(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.4))',
   '--elevation-dialog':
     '0px 2px 2px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.2)), 0px 8px 24px light-dark(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.3))',
   '--elevation-hover':

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -104,11 +104,7 @@ export const neutralTheme = defineTheme({
     '--color-divider-high-contrast': ['oklch(0.708 0 0)', 'oklch(0.556 0 0)'],
     '--color-divider-emphasized': ['oklch(0.85 0 0)', 'oklch(0.371 0 0)'],
 
-    // Disabled/Effects
-    '--color-disabled-overlay': [
-      'oklch(1 0 0 / 50%)',
-      'oklch(0.145 0 0 / 50%)',
-    ],
+    // Effects
     '--color-glimmer': ['oklch(0.922 0 0)', 'oklch(0.371 0 0)'],
     '--color-glimmer-high-contrast': ['oklch(0.85 0 0)', 'oklch(0.439 0 0)'],
     '--color-shadow-elevation': ['oklch(0 0 0 / 10%)', 'oklch(0 0 0 / 30%)'],
@@ -272,8 +268,6 @@ export const neutralTheme = defineTheme({
     // =========================================================================
     '--elevation-base':
       '0 1px 2px light-dark(oklch(0 0 0 / 5%), oklch(0 0 0 / 20%))',
-    '--elevation-thumb':
-      '0 1px 3px light-dark(oklch(0 0 0 / 10%), oklch(0 0 0 / 30%))',
     '--elevation-dialog':
       '0 4px 6px light-dark(oklch(0 0 0 / 10%), oklch(0 0 0 / 25%)), 0 12px 24px light-dark(oklch(0 0 0 / 15%), oklch(0 0 0 / 35%))',
     '--elevation-hover':


### PR DESCRIPTION
## What

Removes 2 dead design tokens that are defined but not consumed by any component.

## Tokens removed

| Token | Why unused |
|-------|-----------|
| `--color-disabled-overlay` | No component references it — disabled states use `opacity: 0.5` instead |
| `--elevation-thumb` | No component references it — Slider/Switch define their own shadow styles |

## Files changed

- `packages/core/src/theme/tokens.stylex.ts` — removed from defaults
- `packages/themes/neutral/src/neutralTheme.ts` — removed theme overrides
- `apps/storybook/stories/ThemeEditor.stories.tsx` — removed from editor list
- `packages/cli/src/commands/theme.mjs` — removed from scaffold template
- `packages/cli/docs/tokens.doc.mjs` — removed from docs table

---
