### PR TITLE
feat: radius codemods & skeleton cleanup for v0.0.5

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.5/__tests__/migrate-radius-tokens.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.5/__tests__/migrate-radius-tokens.test.mjs
@@ -1,0 +1,84 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import('../migrate-radius-tokens.mjs');
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('migrate-radius-tokens', () => {
+  it('renames radius token string literals', async () => {
+    const input = `const x = '--radius-container';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('--radius-3');
+    expect(output).not.toContain('--radius-container');
+  });
+
+  it('renames radiusVars property access', async () => {
+    const input = `borderRadius: radiusVars['--radius-element']`;
+    const output = await applyTransform(input);
+    expect(output).toContain('--radius-2');
+    expect(output).not.toContain('--radius-element');
+  });
+
+  it('renames tokens inside var() in string literals', async () => {
+    const input = `borderRadius: 'var(--radius-content)'`;
+    const output = await applyTransform(input);
+    expect(output).toContain('var(--radius-1)');
+    expect(output).not.toContain('--radius-content');
+  });
+
+  it('renames tokens in template literals', async () => {
+    const input = 'const css = `border-radius: var(--radius-inner)`;';
+    const output = await applyTransform(input);
+    expect(output).toContain('--radius-0');
+    expect(output).not.toContain('--radius-inner');
+  });
+
+  it('renames --radius-page to --radius-4', async () => {
+    const input = `const x = '--radius-page';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('--radius-4');
+    expect(output).not.toContain('--radius-page');
+  });
+
+  it('handles defineTheme token objects', async () => {
+    const input = `defineTheme({
+      tokens: {
+        '--radius-container': '16px',
+        '--radius-element': '8px',
+      }
+    })`;
+    const output = await applyTransform(input);
+    expect(output).toContain('--radius-3');
+    expect(output).toContain('--radius-2');
+    expect(output).toContain('16px');
+    expect(output).toContain('8px');
+    expect(output).not.toContain('--radius-container');
+    expect(output).not.toContain('--radius-element');
+  });
+
+  it('does not modify --radius-rounded', async () => {
+    const input = `radiusVars['--radius-rounded']`;
+    const output = await applyTransform(input);
+    expect(output).toContain('--radius-rounded');
+  });
+
+  it('does not modify --radius-0 through --radius-4', async () => {
+    const input = `const x = '--radius-3';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('--radius-3');
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import('../migrate-radius-tokens.mjs');
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = `const x = '--radius-3';`;
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.5/__tests__/migrate-skeleton-radius.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.5/__tests__/migrate-skeleton-radius.test.mjs
@@ -1,0 +1,73 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import('../migrate-skeleton-radius.mjs');
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('migrate-skeleton-radius', () => {
+  it('converts radius="container" to radius={3}', async () => {
+    const input = '<XDSSkeleton radius="container" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('radius={3}');
+    expect(output).not.toContain('"container"');
+  });
+
+  it('converts radius="element" to radius={2}', async () => {
+    const input = '<XDSSkeleton radius="element" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('radius={2}');
+  });
+
+  it('converts radius="content" to radius={1}', async () => {
+    const input = '<XDSSkeleton radius="content" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('radius={1}');
+  });
+
+  it('converts radius="inner" to radius={0}', async () => {
+    const input = '<XDSSkeleton radius="inner" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('radius={0}');
+  });
+
+  it('converts radius={"container"} expression to radius={3}', async () => {
+    const input = '<XDSSkeleton radius={"container"} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('radius={3}');
+  });
+
+  it('does not change radius="none"', async () => {
+    const input = '<XDSSkeleton radius="none" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('radius="none"');
+  });
+
+  it('does not change radius="rounded"', async () => {
+    const input = '<XDSSkeleton radius="rounded" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('radius="rounded"');
+  });
+
+  it('does not change radius={3}', async () => {
+    const {default: transform} = await import('../migrate-skeleton-radius.mjs');
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const source = '<XDSSkeleton radius={3} />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('does not affect other components', async () => {
+    const input = '<XDSCard radius="container" />';
+    const {default: transform} = await import('../migrate-skeleton-radius.mjs');
+    const jscodeshift = (await import('jscodeshift')).default;
+    const api = {jscodeshift, stats: () => {}, report: () => {}};
+    const result = transform({source: input, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.5/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.5/index.mjs
@@ -6,10 +6,28 @@ import migrateCollapseToCollapsible, {
   meta as collapseMeta,
 } from './migrate-collapse-to-collapsible.mjs';
 
+import migrateRadiusTokens, {
+  meta as radiusTokensMeta,
+} from './migrate-radius-tokens.mjs';
+
+import migrateSkeletonRadius, {
+  meta as skeletonRadiusMeta,
+} from './migrate-skeleton-radius.mjs';
+
 export default [
   {
     name: 'migrate-collapse-to-collapsible',
     transform: migrateCollapseToCollapsible,
     meta: collapseMeta,
+  },
+  {
+    name: 'migrate-radius-tokens',
+    transform: migrateRadiusTokens,
+    meta: radiusTokensMeta,
+  },
+  {
+    name: 'migrate-skeleton-radius',
+    transform: migrateSkeletonRadius,
+    meta: skeletonRadiusMeta,
   },
 ];

--- a/packages/cli/src/codemods/transforms/v0.0.5/migrate-radius-tokens.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.5/migrate-radius-tokens.mjs
@@ -1,0 +1,80 @@
+/**
+ * @file Codemod: Migrate semantic radius tokens to numeric scale
+ *
+ * Transforms:
+ * - '--radius-inner' → '--radius-0'
+ * - '--radius-content' → '--radius-1'
+ * - '--radius-element' → '--radius-2'
+ * - '--radius-container' → '--radius-3'
+ * - '--radius-page' → '--radius-4'
+ *
+ * Handles:
+ * - String literals (e.g. '--radius-container' or 'var(--radius-container)')
+ * - Template literal quasis containing the old tokens
+ * - Property access (e.g. radiusVars['--radius-container'])
+ */
+
+export const meta = {
+  title: 'Migrate semantic radius tokens to numeric scale',
+  description:
+    'Renames --radius-inner/content/element/container/page to --radius-0/1/2/3/4.',
+};
+
+const TOKEN_MAP = {
+  '--radius-inner': '--radius-0',
+  '--radius-content': '--radius-1',
+  '--radius-element': '--radius-2',
+  '--radius-container': '--radius-3',
+  '--radius-page': '--radius-4',
+};
+
+// Build a regex that matches any old token name (as a whole token, not substring)
+const OLD_TOKENS_PATTERN = new RegExp(
+  Object.keys(TOKEN_MAP)
+    .map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|'),
+  'g',
+);
+
+function replaceTokens(str) {
+  return str.replace(OLD_TOKENS_PATTERN, (match) => TOKEN_MAP[match] || match);
+}
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Replace in string literals (StringLiteral or Literal with string value)
+  const replaceInStringNode = (path) => {
+    if (typeof path.node.value !== 'string') return;
+    const original = path.node.value;
+    const replaced = replaceTokens(original);
+    if (replaced !== original) {
+      path.node.value = replaced;
+      hasChanges = true;
+    }
+  };
+
+  root.find(j.StringLiteral).forEach(replaceInStringNode);
+  root.find(j.Literal).forEach((path) => {
+    if (typeof path.node.value === 'string') {
+      replaceInStringNode(path);
+    }
+  });
+
+  // Replace in template literal quasis
+  root.find(j.TemplateLiteral).forEach((path) => {
+    for (const quasi of path.node.quasis) {
+      const original = quasi.value.raw;
+      const replaced = replaceTokens(original);
+      if (replaced !== original) {
+        quasi.value.raw = replaced;
+        quasi.value.cooked = replaceTokens(quasi.value.cooked);
+        hasChanges = true;
+      }
+    }
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/cli/src/codemods/transforms/v0.0.5/migrate-skeleton-radius.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.5/migrate-skeleton-radius.mjs
@@ -1,0 +1,75 @@
+/**
+ * @file Codemod: Migrate XDSSkeleton radius prop to numeric scale
+ *
+ * Transforms:
+ * - radius="inner" → radius={0}
+ * - radius="content" → radius={1}
+ * - radius="element" → radius={2}
+ * - radius="container" → radius={3}
+ */
+
+export const meta = {
+  title: 'Migrate XDSSkeleton radius prop to numeric scale',
+  description:
+    'Replaces semantic radius prop values (inner, content, element, container) with numeric equivalents (0, 1, 2, 3).',
+};
+
+const RADIUS_MAP = {
+  inner: 0,
+  content: 1,
+  element: 2,
+  container: 3,
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  root
+    .find(j.JSXOpeningElement, {
+      name: {name: 'XDSSkeleton'},
+    })
+    .forEach((path) => {
+      const attrs = path.node.attributes;
+      for (const attr of attrs) {
+        if (attr.type !== 'JSXAttribute') continue;
+        if (attr.name.name !== 'radius') continue;
+
+        // Handle radius="container" (JSX string attribute — Literal or StringLiteral)
+        if (
+          attr.value &&
+          (attr.value.type === 'StringLiteral' ||
+            attr.value.type === 'Literal') &&
+          typeof attr.value.value === 'string'
+        ) {
+          const oldValue = attr.value.value;
+          if (oldValue in RADIUS_MAP) {
+            attr.value = j.jsxExpressionContainer(
+              j.numericLiteral(RADIUS_MAP[oldValue]),
+            );
+            hasChanges = true;
+          }
+        }
+
+        // Handle radius={"container"} (expression container with string)
+        if (
+          attr.value &&
+          attr.value.type === 'JSXExpressionContainer' &&
+          (attr.value.expression.type === 'StringLiteral' ||
+            attr.value.expression.type === 'Literal') &&
+          typeof attr.value.expression.value === 'string'
+        ) {
+          const oldValue = attr.value.expression.value;
+          if (oldValue in RADIUS_MAP) {
+            attr.value = j.jsxExpressionContainer(
+              j.numericLiteral(RADIUS_MAP[oldValue]),
+            );
+            hasChanges = true;
+          }
+        }
+      }
+    });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/core/src/Skeleton/Skeleton.doc.mjs
+++ b/packages/core/src/Skeleton/Skeleton.doc.mjs
@@ -26,10 +26,9 @@ export const docs = {
     },
     {
       name: 'radius',
-      type: "'none' | 'inner' | 'content' | 'element' | 'container' | 'rounded'",
-      description:
-        'Border radius using design tokens. Use none for sharp corners, rounded for fully rounded (avatars, pills, circles).',
-      default: "'container'",
+      type: "'none' | 0 | 1 | 2 | 3 | 4 | 'rounded'",
+      description: 'Border radius using design token scale. Use none for sharp corners, rounded for fully rounded (avatars, pills, circles).',
+      default: '3',
     },
     {
       name: 'index',
@@ -102,10 +101,9 @@ export const docsZh = {
     },
     {
       name: 'radius',
-      type: "'none' | 'inner' | 'content' | 'element' | 'container' | 'rounded'",
-      description:
-        '使用设计令牌的边框圆角。使用 none 表示直角，rounded 表示完全圆角（头像、药丸形、圆形）。',
-      default: "'container'",
+      type: "'none' | 0 | 1 | 2 | 3 | 4 | 'rounded'",
+      description: '使用设计令牌的边框圆角。使用 none 表示直角，rounded 表示完全圆角（头像、药丸形、圆形）。',
+      default: '3',
     },
     {
       name: 'index',
@@ -172,7 +170,7 @@ export const docsDense = {
   propDescriptions: {
     width: 'Width in pixels (number) or CSS value (string).',
     height: 'Height in pixels (number) or CSS value (string).',
-    radius: 'Border radius using design tokens. none for sharp corners, rounded for fully rounded (avatars, pills, circles).',
+    radius: 'Border radius using design tokens. none for sharp, 0-4 for scale, rounded for pills.',
     index: 'Index for staggered animation timing. Element at index n starts at DELAY_TIME + (STAGGER_TIME \u00d7 n).',
   },
 };

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -93,23 +93,6 @@ const radiusStyles = stylex.create({
   rounded: {
     borderRadius: radiusVars['--radius-rounded'],
   },
-  // Deprecated semantic aliases (backwards compat)
-  /** @deprecated Use '0' instead */
-  inner: {
-    borderRadius: radiusVars['--radius-0'],
-  },
-  /** @deprecated Use '1' instead */
-  content: {
-    borderRadius: radiusVars['--radius-1'],
-  },
-  /** @deprecated Use '2' instead */
-  element: {
-    borderRadius: radiusVars['--radius-2'],
-  },
-  /** @deprecated Use '3' instead */
-  container: {
-    borderRadius: radiusVars['--radius-3'],
-  },
 });
 
 const dynamicStyles = stylex.create({
@@ -149,18 +132,14 @@ export interface XDSSkeletonProps extends XDSBaseProps<HTMLDivElement> {
   height?: number | string;
   /**
    * Border radius of the skeleton, using design token scale.
-   * Numeric names (preferred):
    * - 'none': No border radius (sharp corners)
-   * - 0: radius-0 token
-   * - 1: radius-1 token
-   * - 2: radius-2 token
-   * - 3: radius-3 token (default)
-   * - 4: radius-4 token
+   * - 0: radius-0 token (0px)
+   * - 1: radius-1 token (4px)
+   * - 2: radius-2 token (8px)
+   * - 3: radius-3 token (12px, default)
+   * - 4: radius-4 token (16px)
    * - 'rounded': Fully rounded (for avatars, pills)
-   *
-   * Deprecated semantic aliases (still work):
-   * - 'inner' → 0, 'content' → 1, 'element' → 2, 'container' → 3
-   * @default 'container'
+   * @default 3
    */
   radius?: XDSSkeletonRadius;
   /**
@@ -192,7 +171,7 @@ export interface XDSSkeletonProps extends XDSBaseProps<HTMLDivElement> {
 export function XDSSkeleton({
   width = '100%',
   height = '100%',
-  radius: radiusProp = 'container',
+  radius: radiusProp = 3,
   index = 0,
   'data-testid': testId,
   xstyle,


### PR DESCRIPTION
## Summary

Follow-up to #686 (dynamic radius tokens). Removes deprecated backwards-compat from Skeleton and adds codemods for consumer migration.

### Skeleton Cleanup

Removes deprecated semantic radius names from `XDSSkeleton`:
- **Removed:** `inner`, `content`, `element`, `container` as `radius` prop values
- **Kept:** `none`, `0`, `1`, `2`, `3`, `4`, `rounded`
- **Default changed:** `"container"` → `3`

### Codemods (v0.0.5)

Two new codemods registered in the v0.0.5 transform manifest:

#### `migrate-radius-tokens`
Rewrites CSS custom property references from semantic to numeric:
- `--radius-inner` → `--radius-0`
- `--radius-content` → `--radius-1`
- `--radius-element` → `--radius-2`
- `--radius-container` → `--radius-3`
- `--radius-page` → `--radius-4`

Handles string literals, template literals, `radiusVars` property access, `defineTheme` token objects, and `var()` references.

#### `migrate-skeleton-radius`
Rewrites `XDSSkeleton` radius prop values:
- `radius="container"` → `radius={3}`
- `radius="element"` → `radius={2}`
- `radius="content"` → `radius={1}`
- `radius="inner"` → `radius={0}`

Handles both string attributes (`radius="container"`) and expression containers (`radius={"container"}`).

### Tests
- 9 tests for `migrate-radius-tokens`
- 9 tests for `migrate-skeleton-radius`
- All 1655 tests pass

### Usage
```bash
npx xds upgrade --from 0.0.4 --to 0.0.5 --path ./src
npx xds upgrade --from 0.0.4 --to 0.0.5 --path ./src --apply
```

---
