### PR TITLE
docs: update CLI token & theme reference with radius scale

### DIFF
--- a/internal/vibe-tests/prompts/evaluator.md
+++ b/internal/vibe-tests/prompts/evaluator.md
@@ -78,7 +78,7 @@ XDS uses specific CSS variable naming. **Any variable not matching these pattern
 | ------------- | ---------------------------------------------- | ------------------------------------------------------------ |
 | Colors        | `--color-*`                                    | `--color-surface`, `--color-text-primary`, `--color-accent`  |
 | Spacing       | `--spacing-*`                                  | `--spacing-0` through `--spacing-7`                          |
-| Radius        | `--radius-*`                                   | `--radius-container`, `--radius-element`, `--radius-content` |
+| Radius        | `--radius-*`                                   | `--radius-0`, `--radius-1`, `--radius-2`, `--radius-3`, `--radius-4`, `--radius-rounded` |
 | Elevation     | `--elevation-*`                                | `--elevation-base`, `--elevation-dialog`, `--elevation-menu` |
 | Transitions   | `--transition-*`                               | `--transition-fast`, `--transition-normal`                   |
 | Font families | `--font-body`, `--font-code`, `--font-heading` | (only these three)                                           |

--- a/packages/cli/docs/theme.doc.mjs
+++ b/packages/cli/docs/theme.doc.mjs
@@ -115,6 +115,41 @@ export const myTheme: Theme = {
       ],
     },
     {
+      title: 'defineTheme (recommended)',
+      content: [
+        {
+          type: 'prose',
+          text: "defineTheme is a higher-level API that wraps the raw stylex.createTheme pattern. It supports scale configs that generate tokens from parameters. Explicit token overrides always take precedence over scale-generated values.",
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'defineTheme with scale configs',
+          code: `import {defineTheme} from '@xds/core/theme';
+
+const myTheme = defineTheme({
+  name: 'my-theme',
+  typeScale: { base: 14, ratio: 1.2 },       // generates heading + text tokens
+  radiusScale: { base: 4, multiplier: 1 },    // generates radius tokens
+  tokens: {
+    '--color-accent': ['#7B61FF', '#9B85FF'], // explicit overrides win
+  },
+  components: {
+    button: { 'variant:primary': { color: 'white' } },
+  },
+});`,
+        },
+        {
+          type: 'table',
+          headers: ['Config', 'Generates', 'Parameters'],
+          rows: [
+            ['typeScale', '--heading-*-size/weight/leading, --text-*-size/weight/leading', 'base (px), ratio, weights?'],
+            ['radiusScale', '--radius-0 through --radius-4, --radius-rounded', 'base (px), multiplier (0–2)'],
+          ],
+        },
+      ],
+    },
+    {
       title: 'Light/Dark Mode',
       content: [
         {

--- a/packages/cli/docs/theme.md
+++ b/packages/cli/docs/theme.md
@@ -122,6 +122,45 @@ export const myTheme: Theme = {
 };
 ```
 
+### defineTheme (recommended for new themes)
+
+`defineTheme` is a higher-level API that wraps the raw `stylex.createTheme` pattern. It supports scale configs that generate tokens from parameters.
+
+```tsx
+import {defineTheme} from '@xds/core/theme';
+
+const myTheme = defineTheme({
+  name: 'my-theme',
+
+  // Type scale — generates heading and text tokens from base size + ratio
+  typeScale: { base: 14, ratio: 1.2 },
+
+  // Radius scale — generates radius tokens from base unit + multiplier
+  radiusScale: { base: 4, multiplier: 1 },
+
+  // Explicit token overrides (highest precedence — overrides scale values)
+  tokens: {
+    '--color-accent': ['#7B61FF', '#9B85FF'],
+  },
+
+  // Component-level style overrides
+  components: {
+    button: {
+      'variant:primary': { color: 'white' },
+    },
+  },
+});
+```
+
+**Scale configs:**
+
+| Config | What it generates | Parameters |
+| --- | --- | --- |
+| `typeScale` | `--heading-*-size/weight/leading`, `--text-*-size/weight/leading` | `base` (px), `ratio`, `weights?` |
+| `radiusScale` | `--radius-0` through `--radius-4`, `--radius-rounded` | `base` (px), `multiplier` (0–2) |
+
+Explicit `tokens` overrides always take precedence over scale-generated values.
+
 ## Light/Dark Mode
 
 ### Automatic (recommended)

--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -97,15 +97,43 @@ export const docs = {
       title: 'Radius Tokens',
       content: [
         {
+          type: 'prose',
+          text: 'Numeric scale based on a 4dp base unit. Tokens 1–4 scale with the theme\'s radiusScale multiplier; tokens 0 and rounded are fixed.',
+        },
+        {
           type: 'table',
-          headers: ['Token', 'Value', 'Usage'],
+          headers: ['Token', 'Value', 'Usage', 'Scales'],
           rows: [
-            ['--radius-rounded', '9999px', 'Pills, avatars'],
-            ['--radius-3', '12px', 'Cards, modals'],
-            ['--radius-2', '8px', 'Buttons, inputs'],
-            ['--radius-1', '4px', 'Small elements'],
-            ['--radius-0', '0px', 'No radius'],
+            ['--radius-0', '0px', 'No radius (dividers, table cells)', 'No'],
+            ['--radius-1', '4px', 'Code blocks, inner content', 'Yes'],
+            ['--radius-2', '8px', 'Buttons, inputs, text areas', 'Yes'],
+            ['--radius-3', '12px', 'Cards, modals, popovers, dropdowns', 'Yes'],
+            ['--radius-4', '16px', 'Page sections, large containers', 'Yes'],
+            ['--radius-rounded', '9999px', 'Badges, avatars, status dots, toggles', 'No'],
           ],
+        },
+        {
+          type: 'prose',
+          text: 'Use radiusScale in defineTheme to generate all radius tokens from a base unit and multiplier: defineTheme({ radiusScale: { base: 4, multiplier: 1.5 } }). Multiplier 0 = sharp, 1 = default, 1.5 = rounded, 2 = pill-like. Explicit token overrides take precedence over radiusScale values.',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'radiusScale example',
+          code: `import {defineTheme} from '@xds/core/theme';
+
+// Rounded theme — all scalable radii increased by 50%
+const roundedTheme = defineTheme({
+  name: 'rounded',
+  radiusScale: { base: 4, multiplier: 1.5 },
+});
+
+// Sharp/brutalist theme — all scalable radii become 0
+const sharpTheme = defineTheme({
+  name: 'sharp',
+  radiusScale: { base: 4, multiplier: 0 },
+  tokens: { '--radius-rounded': '0px' }, // even pills are sharp
+});`,
         },
       ],
     },

--- a/packages/cli/docs/tokens.md
+++ b/packages/cli/docs/tokens.md
@@ -65,13 +65,45 @@ Control heights for consistent sizing across buttons, inputs, and selectors.
 
 ## Radius Tokens
 
-| Token            | Value  | Usage           |
-| ---------------- | ------ | --------------- |
-| --radius-rounded | 9999px | Pills, avatars  |
-| --radius-3       | 12px   | Cards, modals   |
-| --radius-2       | 8px    | Buttons, inputs |
-| --radius-1       | 4px    | Small elements  |
-| --radius-0       | 0px    | No radius       |
+Numeric scale based on a 4dp base unit. Tokens 1–4 scale with the theme's `radiusScale` multiplier; tokens 0 and rounded are fixed.
+
+| Token            | Value  | Usage                                 | Scales |
+| ---------------- | ------ | ------------------------------------- | ------ |
+| --radius-0       | 0px    | No radius (dividers, table cells)     | No     |
+| --radius-1       | 4px    | Code blocks, inner content            | Yes    |
+| --radius-2       | 8px    | Buttons, inputs, text areas           | Yes    |
+| --radius-3       | 12px   | Cards, modals, popovers, dropdowns    | Yes    |
+| --radius-4       | 16px   | Page sections, large containers       | Yes    |
+| --radius-rounded | 9999px | Badges, avatars, status dots, toggles | No     |
+
+### radiusScale (via defineTheme)
+
+Generate all radius tokens from a base unit and multiplier:
+
+```tsx
+import {defineTheme} from '@xds/core/theme';
+
+const roundedTheme = defineTheme({
+  name: 'rounded',
+  radiusScale: { base: 4, multiplier: 1.5 },
+  // Produces: radius-1=6px, radius-2=12px, radius-3=18px, radius-4=24px
+  // radius-0 stays 0px, radius-rounded stays 9999px
+});
+
+const sharpTheme = defineTheme({
+  name: 'sharp',
+  radiusScale: { base: 4, multiplier: 0 },
+  // All scalable radii become 0px
+});
+```
+
+| Multiplier | Effect    | radius-3 becomes |
+| ---------- | --------- | ---------------- |
+| 0          | Sharp     | 0px              |
+| 0.5        | Subtle    | 6px              |
+| 1 (default)| Default   | 12px             |
+| 1.5        | Rounded   | 18px             |
+| 2          | Pill-like | 24px             |
 
 ## Elevation Tokens
 


### PR DESCRIPTION
## Summary

Updates the CLI documentation to reflect the new radius token system from #686.

### Token Reference (`tokens.md` / `tokens.doc.mjs`)
- Added `--radius-4` (16px) — was missing from the table
- Added "Scales" column showing which tokens are affected by the multiplier
- Added description of the numeric scale (4dp base unit)
- Added `radiusScale` section with `defineTheme` examples and multiplier table

### Theme Reference (`theme.md` / `theme.doc.mjs`)
- Added `defineTheme` section documenting the higher-level theme API
- Covers both `typeScale` and `radiusScale` configs with code example
- Table showing what each scale config generates

### Vibe Test Evaluator
- Updated `evaluator.md` valid radius token examples from old semantic names to new numeric names

---
