### PR TITLE
feat(MobileNav): entry animation via @starting-style

### DIFF
--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -75,9 +75,10 @@ const styles = stylex.create({
       backgroundColor: colorVars['--color-overlay'],
       backdropFilter: 'blur(2px)',
       opacity: 0,
-      transitionProperty: 'opacity',
+      transitionProperty: 'opacity, display, overlay',
       transitionDuration: durationVars['--duration-medium'],
       transitionTimingFunction: easeVars['--ease-standard'],
+      transitionBehavior: 'allow-discrete',
     },
     '@media (prefers-reduced-motion: reduce)': {
       '::backdrop': {
@@ -88,6 +89,14 @@ const styles = stylex.create({
   backdropOpen: {
     '::backdrop': {
       opacity: 1,
+    },
+    // Entry animation — @starting-style sets the initial state when the
+    // dialog is first shown via showModal(). Without this, the backdrop
+    // snaps to opacity: 1 because CSS transitions don't fire on display changes.
+    '@starting-style': {
+      '::backdrop': {
+        opacity: 0,
+      },
     },
   },
   drawer: {
@@ -119,6 +128,9 @@ const styles = stylex.create({
   },
   drawerStartOpen: {
     transform: 'translateX(0)',
+    '@starting-style': {
+      transform: 'translateX(-100%)',
+    },
   },
   drawerEnd: {
     insetInlineEnd: 0,
@@ -132,6 +144,9 @@ const styles = stylex.create({
   },
   drawerEndOpen: {
     transform: 'translateX(0)',
+    '@starting-style': {
+      transform: 'translateX(100%)',
+    },
   },
   header: {
     display: 'flex',


### PR DESCRIPTION
## MobileNav Entry Animation

Adds entry animations to the mobile nav drawer using CSS `@starting-style`.

### Problem

Exit animations work (CSS transitions on transform), but entry didn't — `showModal()` changes `display: none → flex` and CSS transitions don't fire on display changes.

### Solution

`@starting-style` declares the initial state for newly-rendered elements:

- **Backdrop**: fades in from `opacity: 0`
- **Drawer (start)**: slides in from `translateX(-100%)`
- **Drawer (end)**: slides in from `translateX(100%)`

The backdrop also gets `transitionBehavior: allow-discrete` so the `display` and `overlay` properties participate in the transition.

### Browser Support

`@starting-style`: Chrome 117+, Safari 17.5+, Firefox 129+ — covers all modern browsers.

### Note

This is the starting point — may need tweaking for timing, easing, or interaction with the scroll lock. The branch is yours to adjust.

---
