### PR TITLE
feat(SideNav): animated collapse/expand via View Transitions API

### DIFF
--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -43,6 +43,8 @@ const styles = stylex.create({
     backgroundColor: 'inherit',
     boxSizing: 'border-box',
     overflow: 'hidden',
+    // View transition name for animated collapse/expand
+    viewTransitionName: 'xds-side-nav',
   },
   rootCollapsed: {
     width: 52,
@@ -325,10 +327,20 @@ export function XDSSideNav({
 
   const toggle = useCallback(() => {
     const newValue = !collapsed;
-    if (!isControlled) {
-      setUncontrolledCollapsed(newValue);
+    const update = () => {
+      if (!isControlled) {
+        setUncontrolledCollapsed(newValue);
+      }
+      onCollapsedChange?.(newValue);
+    };
+
+    // Use View Transitions API for smooth width animation when available.
+    // Falls back to instant state change in unsupported browsers.
+    if (typeof document !== 'undefined' && 'startViewTransition' in document) {
+      document.startViewTransition(update);
+    } else {
+      update();
     }
-    onCollapsedChange?.(newValue);
   }, [collapsed, isControlled, onCollapsedChange]);
 
   const collapseContext = {


### PR DESCRIPTION
## SideNav Collapse/Expand Animation

Animates the sidenav width transition between expanded (260px) and collapsed (52px) using the View Transitions API.

### How it works

1. `view-transition-name: xds-side-nav` on the nav root — tells the browser which element to track
2. `document.startViewTransition()` wraps the state change in the toggle callback
3. Browser captures before/after snapshots and interpolates off-main-thread

No JS animation loop, no `requestAnimationFrame`, no layout thrashing. The browser handles the cross-fade/morph between the two states.

### Fallback

Browsers without View Transitions support (`'startViewTransition' in document` check) get instant state change — same as before.

### Browser Support

View Transitions API: Chrome 111+, Safari 18+, Firefox 🔜 (behind flag). Progressive enhancement — animation is nice-to-have, not required.

### Open questions

- Should we customize the transition duration/easing via `::view-transition-old` / `::view-transition-new` pseudo-elements?
- Should the content area also participate in the view transition for a smoother layout shift?
- Should we suppress the animation when `prefers-reduced-motion: reduce`?

---
