### PR TITLE
fix: make popover background transparent by default

### DIFF
--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -44,6 +44,8 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     overflow: 'visible',
+    // Override browser default [popover] background (canvas color)
+    backgroundColor: 'transparent',
   },
   // Fixed positioning mode
   fixed: {

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -92,7 +92,6 @@ const styles = stylex.create({
   },
   // Animation styles applied to the layer's popover element.
   panelAnimation: {
-    backgroundColor: 'transparent',
     opacity: {
       default: 0,
       ':popover-open': 1,

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -99,7 +99,6 @@ const styles = stylex.create({
   },
   menuOffset: {
     marginBlockStart: spacingVars['--spacing-1'],
-    backgroundColor: 'transparent',
   },
   menuItem: {
     display: 'flex',


### PR DESCRIPTION
## Summary

The browser's `[popover]` attribute applies a default background color (`canvas`), which causes popover/layer elements to show an opaque background. Multiple shell components had to manually set `backgroundColor: 'transparent'` on their popover containers as a workaround.

## Changes

### Root fix: `useXDSLayer.tsx`
Added `backgroundColor: 'transparent'` to the `styles.base` block that resets all layer/popover elements. This sits alongside the existing resets for margin, padding, border, and overflow.

### Cleaned up redundant overrides
Removed `backgroundColor: 'transparent'` from popover xstyles that were only there to work around the browser default:
- **`XDSTopNavMegaMenu`** — `panelAnimation` style (passed as `xstyle` to popover)
- **`XDSTopNavMenu`** — `menuOffset` style (passed as `xstyle` to popover)

### Not changed (intentional transparent backgrounds)
- **`XDSMobileNav`** — `<dialog>` element uses transparent bg so the backdrop provides overlay color
- **`XDSSideNav`** — drag handle starts transparent (visual design, not popover)
- **`XDSSideNavHeading`** — button reset style (not popover-related)
- Various button/input components — button/input reset styles (not popover-related)

### Not affected (already override their own background)
- **`XDSDialog`** — uses `<dialog>` with `showModal()`, sets `backgroundColor: colorVars['--color-surface']` explicitly
- **`useXDSTooltip`** — passes `backgroundColor: colorVars['--color-text-primary']` as popover xstyle
- **`XDSDropdownMenu` / `XDSMoreMenu`** — set background on child container, benefit from transparent popover base

## Testing
All 73 test files, 1370 tests pass.

---
