### PR TITLE
fix(a11y): CheckboxInput & Switch focus rings + indeterminate aria

### DIFF
--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -73,9 +73,16 @@ const styles = stylex.create({
     transitionProperty: 'background-color, border-color',
     transitionDuration: transitionVars['--transition-fast'],
   },
-  checkboxFocused: {
-    outline: `2px solid ${colorVars['--color-focus-outline']}`,
-    outlineOffset: 2,
+  checkboxFocus: {
+    outline: {
+      default: 'none',
+      [stylex.when.ancestor(':focus-within')]:
+        `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: null,
+      [stylex.when.ancestor(':focus-within')]: '2px',
+    },
   },
   // State-dependent colors with ancestor hover behavior
   checkboxUnchecked: {
@@ -355,6 +362,7 @@ export function XDSCheckboxInput({
             }}
             onFocus={onFocus}
             onBlur={onBlur}
+            aria-checked={isIndeterminate ? 'mixed' : undefined}
             aria-describedby={ariaDescribedBy}
             aria-invalid={status?.type === 'error' ? true : undefined}
             aria-busy={isBusy || undefined}
@@ -369,6 +377,7 @@ export function XDSCheckboxInput({
             {...stylex.props(
               styles.checkbox,
               checkboxSizeStyles[size],
+              !isDisabled && styles.checkboxFocus,
               isCheckedOrIndeterminate
                 ? styles.checkboxChecked
                 : styles.checkboxUnchecked,

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -94,9 +94,16 @@ const styles = stylex.create({
     transitionDuration: transitionVars['--transition-fast'],
     boxSizing: 'border-box',
   },
-  trackFocused: {
-    outline: `2px solid ${colorVars['--color-focus-outline']}`,
-    outlineOffset: 2,
+  trackFocus: {
+    outline: {
+      default: 'none',
+      [stylex.when.ancestor(':focus-within')]:
+        `2px solid ${colorVars['--color-focus-outline']}`,
+    },
+    outlineOffset: {
+      default: null,
+      [stylex.when.ancestor(':focus-within')]: '2px',
+    },
   },
   // State-dependent colors with ancestor hover behavior
   trackOff: {
@@ -334,6 +341,7 @@ export function XDSSwitch({
           stylex.props(
             styles.track,
             isOn ? styles.trackOn : styles.trackOff,
+            !isDisabled && styles.trackFocus,
             isDisabled && styles.trackDisabled,
             isDisabled && !isOn && styles.trackDisabledOff,
           ),


### PR DESCRIPTION
## #587 P0 Fixes — Inputs & Form Controls

Three P0 accessibility fixes from the [hardening sprint](https://github.com/facebookexperimental/xds/wiki/Hardening-Tracker).

### 1. CheckboxInput focus ring (P0)

`styles.checkboxFocused` was defined but never applied in JSX. Keyboard users saw no focus indicator.

Fixed with `stylex.when.ancestor(':focus-within')` on the visual checkbox div, matching RadioList's existing pattern.

![checkbox-focus-ring](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/checkbox-focus-ring.png)

### 2. Switch focus ring (P0)

Same issue. `styles.trackFocused` defined but never referenced. Fixed with the same ancestor pattern on the track div.

![switch-focus-ring](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-focus-ring.png)

### 3. CheckboxInput indeterminate a11y (P0)

`value: 'indeterminate'` rendered visually but no `aria-checked="mixed"` on the native input. Screen readers couldn't distinguish indeterminate from unchecked.

![checkbox-indeterminate](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/checkbox-indeterminate-focus.png)

---

*Hardening tracker: https://github.com/facebookexperimental/xds/wiki/Hardening-Tracker*
