### PR TITLE
fix(TopNav): set 12px padding on menu popover panels

### DIFF
--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -128,8 +128,8 @@ const styles = stylex.create({
     display: 'flex',
     flexWrap: 'wrap',
     gap: spacingVars['--spacing-6'],
-    paddingBlock: spacingVars['--spacing-6'],
-    paddingInline: spacingVars['--spacing-6'],
+    paddingBlock: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-3'],
     maxWidth: 960,
   },
   menuWrapper: {

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -95,7 +95,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     gap: spacingVars['--spacing-1'],
     minWidth: 280,
-    padding: spacingVars['--spacing-1'],
+    padding: spacingVars['--spacing-3'],
     backgroundColor: colorVars['--color-popover'],
     borderRadius: radiusVars['--radius-3'],
     boxShadow: elevationVars['--elevation-menu'],

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -95,7 +95,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     gap: spacingVars['--spacing-1'],
     minWidth: 280,
-    padding: spacingVars['--spacing-3'],
+    padding: spacingVars['--spacing-1'],
     backgroundColor: colorVars['--color-popover'],
     borderRadius: radiusVars['--radius-3'],
     boxShadow: elevationVars['--elevation-menu'],


### PR DESCRIPTION
## fix(TopNav): MegaMenu panel padding → 12px

Updates the MegaMenu popover panel content padding to 12px (`--spacing-3`).

### Changes

| File | Style | Before | After |
|------|-------|--------|-------|
| `XDSTopNavMegaMenu.tsx` | `panelContent.paddingBlock` | `--spacing-6` (24px) | `--spacing-3` (12px) |
| `XDSTopNavMegaMenu.tsx` | `panelContent.paddingInline` | `--spacing-6` (24px) | `--spacing-3` (12px) |

TopNavMenu padding unchanged (stays at 4px).

---
