### PR TITLE
fix: apply uniform border radius to MegaMenu panel container

### DIFF
--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -116,10 +116,7 @@ const styles = stylex.create({
   panelContainer: {
     backgroundColor: colorVars['--color-popover'],
     borderTop: `1px solid ${colorVars['--color-border']}`,
-    borderTopLeftRadius: 0,
-    borderTopRightRadius: 0,
-    borderBottomLeftRadius: radiusVars['--radius-3'],
-    borderBottomRightRadius: radiusVars['--radius-3'],
+    borderRadius: radiusVars['--radius-3'],
     boxShadow: shadowVars['--shadow-menu'],
     overflow: 'hidden',
   },


### PR DESCRIPTION
## Summary

The MegaMenu popover panel previously had different border radii — 0 on the top corners and `--radius-3` on the bottom corners. This made the panel look asymmetric.

Changed the `panelContainer` style to use `borderRadius: radiusVars['--radius-3']` uniformly on all corners for a consistent rounded appearance.

## Changes

- **`packages/core/src/TopNav/XDSTopNavMegaMenu.tsx`**: Replaced the four individual `borderTopLeftRadius: 0`, `borderTopRightRadius: 0`, `borderBottomLeftRadius`, `borderBottomRightRadius` declarations with a single `borderRadius: radiusVars['--radius-3']`.

## Testing

All 53 TopNav tests pass (`npx vitest run packages/core/src/TopNav/`).

---
