### PR TITLE
feat: useConcentricRadius — measurement-based concentric corners

### DIFF
--- a/apps/storybook/stories/ConcentricRadius.stories.tsx
+++ b/apps/storybook/stories/ConcentricRadius.stories.tsx
@@ -1,0 +1,358 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSCard} from '@xds/core/Card';
+import {XDSButton} from '@xds/core/Button';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSDivider} from '@xds/core/Divider';
+import {useConcentricRadius} from '@xds/core/hooks';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  typographyVars,
+} from '@xds/core/theme/tokens.stylex';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  pageWrapper: {
+    backgroundColor: colorVars['--color-wash'],
+    padding: spacingVars['--spacing-6'],
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-6'],
+  },
+  row: {
+    display: 'flex',
+    gap: spacingVars['--spacing-4'],
+    flexWrap: 'wrap',
+    alignItems: 'flex-start',
+  },
+  label: {
+    fontFamily: typographyVars['--font-body'],
+    fontSize: '11px',
+    fontWeight: '600',
+    color: colorVars['--color-text-secondary'],
+    textTransform: 'uppercase' as const,
+    letterSpacing: '0.05em',
+    marginBottom: spacingVars['--spacing-2'],
+  },
+  // Inner sections with visible backgrounds
+  innerSection: {
+    backgroundColor: colorVars['--color-accent-deemphasized'],
+    padding: spacingVars['--spacing-4'],
+  },
+  headerSection: {
+    backgroundColor: colorVars['--color-accent'],
+    padding: spacingVars['--spacing-4'],
+    color: 'white',
+  },
+  footerSection: {
+    backgroundColor: colorVars['--color-wash'],
+    padding: spacingVars['--spacing-3'],
+    display: 'flex',
+    justifyContent: 'flex-end',
+    gap: spacingVars['--spacing-2'],
+  },
+  coverImage: {
+    width: '100%',
+    height: '120px',
+    backgroundColor: colorVars['--color-accent'],
+    backgroundImage: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: 'white',
+    fontFamily: typographyVars['--font-body'],
+    fontWeight: '600',
+    fontSize: '14px',
+  },
+  cardBody: {
+    padding: spacingVars['--spacing-4'],
+  },
+  // Halo wrapper for inner-as-reference demo
+  haloWrapper: {
+    display: 'inline-flex',
+    padding: spacingVars['--spacing-2'],
+    backgroundColor: colorVars['--color-accent-deemphasized'],
+  },
+  haloWrapperLarge: {
+    display: 'inline-flex',
+    padding: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-wash'],
+    borderWidth: 2,
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-divider'],
+  },
+  text: {
+    fontFamily: typographyVars['--font-body'],
+    color: colorVars['--color-text-primary'],
+    margin: 0,
+    fontSize: '14px',
+  },
+  textSmall: {
+    fontFamily: typographyVars['--font-body'],
+    color: colorVars['--color-text-secondary'],
+    margin: 0,
+    fontSize: '12px',
+  },
+  annotation: {
+    fontFamily: typographyVars['--font-code'],
+    fontSize: '11px',
+    color: colorVars['--color-text-secondary'],
+    marginTop: spacingVars['--spacing-1'],
+  },
+  comparisonCard: {
+    width: '280px',
+  },
+});
+
+// =============================================================================
+// Meta
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Hooks/useConcentricRadius',
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+
+// =============================================================================
+// Stories
+// =============================================================================
+
+/**
+ * Container as reference — inner element adapts to the card's radius.
+ * The inner colored section gets concentric corners that harmonize
+ * with the card's outer corners.
+ */
+export const ContainerAsReference: StoryObj = {
+  render: () => {
+    const {containerRef, innerRef} = useConcentricRadius({
+      reference: 'container',
+    });
+
+    return (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <div {...stylex.props(styles.label)}>
+          Card with concentric inner section
+        </div>
+        <XDSCard ref={containerRef} width={360} padding={3}>
+          <div ref={innerRef} {...stylex.props(styles.innerSection)}>
+            <p {...stylex.props(styles.text)}>
+              This section's corners are computed from the card's radius minus
+              the gap between them.
+            </p>
+          </div>
+        </XDSCard>
+      </div>
+    );
+  },
+};
+
+/**
+ * Card with a colored header — the header's top corners match
+ * the card's curvature.
+ */
+export const CardWithHeader: StoryObj = {
+  render: () => {
+    const {containerRef, innerRef: headerRef} = useConcentricRadius({
+      reference: 'container',
+    });
+
+    return (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <div {...stylex.props(styles.label)}>Card with colored header</div>
+        <XDSCard ref={containerRef} width={360} padding={0}>
+          <div ref={headerRef} {...stylex.props(styles.headerSection)}>
+            <p {...stylex.props(styles.text)} style={{color: 'white'}}>
+              Header with concentric corners
+            </p>
+          </div>
+          <div {...stylex.props(styles.cardBody)}>
+            <p {...stylex.props(styles.text)}>
+              Card body content. The header is flush with the card edges
+              (padding=0) so its corners match the card's corners exactly.
+            </p>
+          </div>
+        </XDSCard>
+      </div>
+    );
+  },
+};
+
+/**
+ * Cover image at the top of a card with concentric corners.
+ */
+export const CoverImage: StoryObj = {
+  render: () => {
+    const {containerRef, innerRef: imageRef} = useConcentricRadius({
+      reference: 'container',
+    });
+
+    return (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <div {...stylex.props(styles.label)}>Card with cover image</div>
+        <XDSCard ref={containerRef} width={320} padding={0}>
+          <div ref={imageRef} {...stylex.props(styles.coverImage)}>
+            Cover Image
+          </div>
+          <div {...stylex.props(styles.cardBody)}>
+            <XDSVStack gap={1}>
+              <XDSHeading level={4}>Profile Card</XDSHeading>
+              <XDSText type="supporting">
+                The cover image corners follow the card's curvature.
+              </XDSText>
+            </XDSVStack>
+          </div>
+        </XDSCard>
+      </div>
+    );
+  },
+};
+
+/**
+ * Inner element defines the shape — container adapts.
+ * A pill-shaped button wrapped in a halo that follows its curvature.
+ */
+export const InnerAsReference: StoryObj = {
+  render: () => {
+    const {containerRef: haloRef, innerRef: buttonRef} = useConcentricRadius({
+      reference: 'inner',
+    });
+
+    return (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <div {...stylex.props(styles.label)}>
+          Inner as reference — halo adapts to button shape
+        </div>
+        <div ref={haloRef} {...stylex.props(styles.haloWrapper)}>
+          <XDSButton ref={buttonRef} label="Subscribe" variant="primary" />
+        </div>
+
+        <div {...stylex.props(styles.label)}>
+          Larger padding — halo still follows the curve
+        </div>
+        <InnerRefDemo padding="--spacing-4" />
+      </div>
+    );
+  },
+};
+
+/** Helper for inner-as-reference with configurable padding */
+function InnerRefDemo({padding}: {padding: string}) {
+  const {containerRef, innerRef} = useConcentricRadius({
+    reference: 'inner',
+  });
+
+  return (
+    <div ref={containerRef} {...stylex.props(styles.haloWrapperLarge)}>
+      <XDSButton ref={innerRef} label="Get Started" variant="primary" />
+    </div>
+  );
+}
+
+/**
+ * Side-by-side comparison: with and without concentric radius.
+ */
+export const Comparison: StoryObj = {
+  render: () => {
+    const {containerRef, innerRef} = useConcentricRadius({
+      reference: 'container',
+    });
+
+    return (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <div {...stylex.props(styles.label)}>
+          Comparison: without vs with concentric radius
+        </div>
+        <div {...stylex.props(styles.row)}>
+          {/* Without concentric */}
+          <div {...stylex.props(styles.comparisonCard)}>
+            <p {...stylex.props(styles.textSmall)}>
+              Without (radius-2 on inner)
+            </p>
+            <XDSCard width={280} padding={2}>
+              <div
+                {...stylex.props(styles.innerSection)}
+                style={{borderRadius: 'var(--radius-2)'}}>
+                <p {...stylex.props(styles.text)}>
+                  Inner section uses a fixed radius token.
+                </p>
+              </div>
+            </XDSCard>
+          </div>
+
+          {/* With concentric */}
+          <div {...stylex.props(styles.comparisonCard)}>
+            <p {...stylex.props(styles.textSmall)}>
+              With concentric (computed from card)
+            </p>
+            <XDSCard ref={containerRef} width={280} padding={2}>
+              <div ref={innerRef} {...stylex.props(styles.innerSection)}>
+                <p {...stylex.props(styles.text)}>
+                  Inner section corners adapt to the card.
+                </p>
+              </div>
+            </XDSCard>
+          </div>
+        </div>
+        <p {...stylex.props(styles.annotation)}>
+          At default scale (12px radius, 8px padding), concentric = max(0, 12-8)
+          = 4px
+        </p>
+      </div>
+    );
+  },
+};
+
+/**
+ * Multiple inner elements inside one container.
+ * Each inner element can independently use the hook.
+ */
+export const MultipleInnerElements: StoryObj = {
+  render: () => {
+    const {containerRef, innerRef: headerRef} = useConcentricRadius({
+      reference: 'container',
+    });
+    const {containerRef: containerRef2, innerRef: footerRef} =
+      useConcentricRadius({reference: 'container'});
+
+    return (
+      <div {...stylex.props(styles.pageWrapper)}>
+        <div {...stylex.props(styles.label)}>
+          Header and footer both adapt to the card
+        </div>
+        <XDSCard
+          ref={(el: HTMLDivElement | null) => {
+            containerRef(el);
+            containerRef2(el);
+          }}
+          width={360}
+          padding={0}>
+          <div ref={headerRef} {...stylex.props(styles.headerSection)}>
+            <p {...stylex.props(styles.text)} style={{color: 'white'}}>
+              Header
+            </p>
+          </div>
+          <div {...stylex.props(styles.cardBody)}>
+            <p {...stylex.props(styles.text)}>Card content area</p>
+          </div>
+          <XDSDivider />
+          <div ref={footerRef} {...stylex.props(styles.footerSection)}>
+            <XDSButton label="Cancel" variant="secondary" />
+            <XDSButton label="Save" variant="primary" />
+          </div>
+        </XDSCard>
+      </div>
+    );
+  },
+};

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -17,3 +17,9 @@ export {useListFocus} from './useListFocus';
 export type {UseListFocusOptions, UseListFocusReturn} from './useListFocus';
 
 export {useMediaQuery} from './useMediaQuery';
+
+export {useConcentricRadius} from './useConcentricRadius';
+export type {
+  UseConcentricRadiusOptions,
+  UseConcentricRadiusReturn,
+} from './useConcentricRadius';

--- a/packages/core/src/hooks/useConcentricRadius.test.tsx
+++ b/packages/core/src/hooks/useConcentricRadius.test.tsx
@@ -1,0 +1,199 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, act} from '@testing-library/react';
+import React from 'react';
+import {useConcentricRadius} from './useConcentricRadius';
+
+// =============================================================================
+// Test helpers
+// =============================================================================
+
+/**
+ * Mock getBoundingClientRect for an element
+ */
+function mockRect(
+  el: HTMLElement,
+  rect: {top: number; left: number; width: number; height: number},
+) {
+  vi.spyOn(el, 'getBoundingClientRect').mockReturnValue({
+    top: rect.top,
+    left: rect.left,
+    right: rect.left + rect.width,
+    bottom: rect.top + rect.height,
+    width: rect.width,
+    height: rect.height,
+    x: rect.left,
+    y: rect.top,
+    toJSON: () => ({}),
+  });
+}
+
+/**
+ * Mock getComputedStyle for border-radius
+ */
+function mockRadius(el: HTMLElement, radius: string) {
+  const original = window.getComputedStyle;
+  vi.spyOn(window, 'getComputedStyle').mockImplementation(target => {
+    if (target === el) {
+      return {
+        ...original(el),
+        borderTopLeftRadius: radius,
+        borderTopRightRadius: radius,
+        borderBottomRightRadius: radius,
+        borderBottomLeftRadius: radius,
+      } as CSSStyleDeclaration;
+    }
+    return original(target);
+  });
+}
+
+// =============================================================================
+// Test component
+// =============================================================================
+
+function TestComponent({
+  reference = 'container' as const,
+  containerRadius = '12px',
+  containerRect = {top: 0, left: 0, width: 400, height: 300},
+  innerRect = {top: 16, left: 16, width: 368, height: 268},
+}: {
+  reference?: 'container' | 'inner';
+  containerRadius?: string;
+  containerRect?: {top: number; left: number; width: number; height: number};
+  innerRect?: {top: number; left: number; width: number; height: number};
+}) {
+  const {containerRef, innerRef} = useConcentricRadius({
+    reference,
+    observe: false,
+  });
+
+  // We need to mock after render but the ref callbacks fire during render.
+  // Use a wrapper that mocks before assigning refs.
+  const containerCb = React.useCallback(
+    (el: HTMLElement | null) => {
+      if (el) {
+        mockRect(el, containerRect);
+        if (reference === 'container') {
+          mockRadius(el, containerRadius);
+        }
+      }
+      containerRef(el);
+    },
+    [containerRef, containerRect, containerRadius, reference],
+  );
+
+  const innerCb = React.useCallback(
+    (el: HTMLElement | null) => {
+      if (el) {
+        mockRect(el, innerRect);
+        if (reference === 'inner') {
+          mockRadius(el, containerRadius);
+        }
+      }
+      innerRef(el);
+    },
+    [innerRef, innerRect, containerRadius, reference],
+  );
+
+  return (
+    <div ref={containerCb} data-testid="container">
+      <div ref={innerCb} data-testid="inner">
+        Content
+      </div>
+    </div>
+  );
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useConcentricRadius', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('reference: container', () => {
+    it('computes inner radius from container radius minus gap', () => {
+      render(
+        <TestComponent
+          reference="container"
+          containerRadius="12px"
+          containerRect={{top: 0, left: 0, width: 400, height: 300}}
+          innerRect={{top: 8, left: 8, width: 384, height: 284}}
+        />,
+      );
+
+      const inner = screen.getByTestId('inner');
+      // gap = 8px on each side, container radius = 12px
+      // concentric = max(0, 12 - 8) = 4px per corner
+      expect(inner.style.borderRadius).toBe('4px 4px 4px 4px');
+    });
+
+    it('clamps to 0 when gap exceeds radius', () => {
+      render(
+        <TestComponent
+          reference="container"
+          containerRadius="12px"
+          containerRect={{top: 0, left: 0, width: 400, height: 300}}
+          innerRect={{top: 16, left: 16, width: 368, height: 268}}
+        />,
+      );
+
+      const inner = screen.getByTestId('inner');
+      // gap = 16px, container radius = 12px
+      // concentric = max(0, 12 - 16) = 0px
+      expect(inner.style.borderRadius).toBe('0px 0px 0px 0px');
+    });
+
+    it('handles asymmetric gaps', () => {
+      render(
+        <TestComponent
+          reference="container"
+          containerRadius="20px"
+          containerRect={{top: 0, left: 0, width: 400, height: 300}}
+          innerRect={{top: 4, left: 8, width: 384, height: 280}}
+        />,
+      );
+
+      const inner = screen.getByTestId('inner');
+      // top-left: max(4, 8) = 8 → 20 - 8 = 12
+      // top-right: max(4, 8) = 8 → 20 - 8 = 12
+      // bottom-right: max(16, 8) = 16 → 20 - 16 = 4
+      // bottom-left: max(16, 8) = 16 → 20 - 16 = 4
+      expect(inner.style.borderRadius).toBe('12px 12px 4px 4px');
+    });
+
+    it('produces full radius when inner is flush (zero gap)', () => {
+      render(
+        <TestComponent
+          reference="container"
+          containerRadius="12px"
+          containerRect={{top: 0, left: 0, width: 400, height: 300}}
+          innerRect={{top: 0, left: 0, width: 400, height: 300}}
+        />,
+      );
+
+      const inner = screen.getByTestId('inner');
+      // gap = 0 → concentric = 12px (same as container)
+      expect(inner.style.borderRadius).toBe('12px 12px 12px 12px');
+    });
+  });
+
+  describe('reference: inner', () => {
+    it('computes container radius from inner radius plus gap', () => {
+      render(
+        <TestComponent
+          reference="inner"
+          containerRadius="8px"
+          containerRect={{top: 0, left: 0, width: 400, height: 300}}
+          innerRect={{top: 12, left: 12, width: 376, height: 276}}
+        />,
+      );
+
+      const container = screen.getByTestId('container');
+      // inner radius = 8px, gap = 12px
+      // container = 8 + 12 = 20px per corner
+      expect(container.style.borderRadius).toBe('20px 20px 20px 20px');
+    });
+  });
+});

--- a/packages/core/src/hooks/useConcentricRadius.ts
+++ b/packages/core/src/hooks/useConcentricRadius.ts
@@ -1,0 +1,258 @@
+'use client';
+
+import {useLayoutEffect, useRef, useCallback, useState} from 'react';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface UseConcentricRadiusOptions {
+  /**
+   * Which element is the source of truth for the radius relationship.
+   *
+   * - `'container'`: The container's border-radius defines the outer curve.
+   *   The inner element's border-radius is computed as
+   *   `max(0, containerCornerRadius - gap)` per corner.
+   *
+   * - `'inner'`: The inner element's shape defines the relationship.
+   *   The container's border-radius is computed as
+   *   `innerCornerRadius + gap` per corner. Handles pill-shaped elements
+   *   by measuring `min(width, height) / 2` when radius >= 9999px.
+   *
+   * @default 'container'
+   */
+  reference?: 'container' | 'inner';
+
+  /**
+   * Whether to observe size changes and recompute.
+   * Uses ResizeObserver when true.
+   * @default true
+   */
+  observe?: boolean;
+}
+
+export interface UseConcentricRadiusReturn {
+  /** Ref to attach to the outer container element */
+  containerRef: React.RefCallback<HTMLElement>;
+  /** Ref to attach to the inner element */
+  innerRef: React.RefCallback<HTMLElement>;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Parse border-radius from computed style into per-corner values.
+ * getComputedStyle always returns resolved px values in the form:
+ * "12px" (uniform) or "12px 8px 8px 12px" (per-corner: TL TR BR BL)
+ */
+function parseCornerRadii(el: HTMLElement): [number, number, number, number] {
+  const style = getComputedStyle(el);
+  const tl = parseFloat(style.borderTopLeftRadius) || 0;
+  const tr = parseFloat(style.borderTopRightRadius) || 0;
+  const br = parseFloat(style.borderBottomRightRadius) || 0;
+  const bl = parseFloat(style.borderBottomLeftRadius) || 0;
+  return [tl, tr, br, bl];
+}
+
+/**
+ * Check if an element has pill-shaped radius (9999px or very large).
+ */
+function isPillShaped(radii: [number, number, number, number]): boolean {
+  return radii.some(r => r >= 9999);
+}
+
+/**
+ * Get the effective radius of a pill-shaped element.
+ * For pills, the actual visual radius is min(width, height) / 2.
+ */
+function getPillRadius(el: HTMLElement): number {
+  const rect = el.getBoundingClientRect();
+  return Math.min(rect.width, rect.height) / 2;
+}
+
+/**
+ * Compute the per-corner gap between container and inner element.
+ * Returns [topLeft, topRight, bottomRight, bottomLeft] gaps.
+ * Each corner gap is the max of the two edge distances meeting at that corner.
+ */
+function computeCornerGaps(
+  cRect: DOMRect,
+  iRect: DOMRect,
+): [number, number, number, number] {
+  const gapTop = iRect.top - cRect.top;
+  const gapRight = cRect.right - iRect.right;
+  const gapBottom = cRect.bottom - iRect.bottom;
+  const gapLeft = iRect.left - cRect.left;
+
+  return [
+    Math.max(gapTop, gapLeft), // top-left
+    Math.max(gapTop, gapRight), // top-right
+    Math.max(gapBottom, gapRight), // bottom-right
+    Math.max(gapBottom, gapLeft), // bottom-left
+  ];
+}
+
+/**
+ * Apply border-radius to an element, skipping if values haven't changed.
+ */
+function applyRadius(
+  el: HTMLElement,
+  radii: [number, number, number, number],
+): void {
+  const value = `${radii[0]}px ${radii[1]}px ${radii[2]}px ${radii[3]}px`;
+  if (el.style.borderRadius !== value) {
+    el.style.borderRadius = value;
+  }
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Computes concentric border-radius between a container and inner element.
+ *
+ * Measures the position of both elements and computes per-corner radii
+ * that maintain visual harmony between nested rounded rectangles.
+ *
+ * @example
+ * ```tsx
+ * // Container defines the radius, inner element adapts
+ * const {containerRef, innerRef} = useConcentricRadius({reference: 'container'});
+ *
+ * <XDSCard ref={containerRef}>
+ *   <div ref={innerRef} style={{background: 'var(--color-wash)'}}>
+ *     Content with concentric corners
+ *   </div>
+ * </XDSCard>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Inner element defines the shape, container adapts
+ * const {containerRef, innerRef} = useConcentricRadius({reference: 'inner'});
+ *
+ * <div ref={containerRef} style={{padding: 8, background: 'var(--color-wash)'}}>
+ *   <XDSButton ref={innerRef}>Pill Button</XDSButton>
+ * </div>
+ * ```
+ */
+export function useConcentricRadius(
+  options: UseConcentricRadiusOptions = {},
+): UseConcentricRadiusReturn {
+  const {reference = 'container', observe = true} = options;
+
+  const containerElRef = useRef<HTMLElement | null>(null);
+  const innerElRef = useRef<HTMLElement | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const compute = useCallback(() => {
+    const container = containerElRef.current;
+    const inner = innerElRef.current;
+    if (!container || !inner) return;
+
+    const cRect = container.getBoundingClientRect();
+    const iRect = inner.getBoundingClientRect();
+
+    // Skip if either element has zero size (not yet laid out)
+    if (cRect.width === 0 || iRect.width === 0) return;
+
+    const gaps = computeCornerGaps(cRect, iRect);
+
+    if (reference === 'container') {
+      // Container is source of truth — compute inner radii
+      const cRadii = parseCornerRadii(container);
+
+      const innerRadii: [number, number, number, number] = [
+        Math.max(0, cRadii[0] - gaps[0]),
+        Math.max(0, cRadii[1] - gaps[1]),
+        Math.max(0, cRadii[2] - gaps[2]),
+        Math.max(0, cRadii[3] - gaps[3]),
+      ];
+
+      applyRadius(inner, innerRadii);
+    } else {
+      // Inner is source of truth — compute container radii
+      let iRadii = parseCornerRadii(inner);
+
+      // Handle pill-shaped elements
+      if (isPillShaped(iRadii)) {
+        const pillR = getPillRadius(inner);
+        iRadii = [pillR, pillR, pillR, pillR];
+      }
+
+      const containerRadii: [number, number, number, number] = [
+        iRadii[0] + gaps[0],
+        iRadii[1] + gaps[1],
+        iRadii[2] + gaps[2],
+        iRadii[3] + gaps[3],
+      ];
+
+      applyRadius(container, containerRadii);
+    }
+  }, [reference]);
+
+  // Set up ResizeObserver to recompute on size changes
+  const setupObserver = useCallback(() => {
+    if (!observe) return;
+
+    // Clean up previous observer
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+
+    const container = containerElRef.current;
+    const inner = innerElRef.current;
+    if (!container || !inner) return;
+
+    const observer = new ResizeObserver(() => {
+      compute();
+    });
+
+    observer.observe(container);
+    observer.observe(inner);
+    observerRef.current = observer;
+
+    return () => {
+      observer.disconnect();
+      observerRef.current = null;
+    };
+  }, [compute, observe]);
+
+  // Ref callbacks — compute immediately when both elements are available
+  const containerRef = useCallback(
+    (el: HTMLElement | null) => {
+      containerElRef.current = el;
+      if (el && innerElRef.current) {
+        compute();
+        setupObserver();
+      }
+    },
+    [compute, setupObserver],
+  );
+
+  const innerRef = useCallback(
+    (el: HTMLElement | null) => {
+      innerElRef.current = el;
+      if (el && containerElRef.current) {
+        compute();
+        setupObserver();
+      }
+    },
+    [compute, setupObserver],
+  );
+
+  // Clean up observer on unmount
+  useLayoutEffect(() => {
+    return () => {
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+      }
+    };
+  }, []);
+
+  return {containerRef, innerRef};
+}


### PR DESCRIPTION
## Summary

Adds a `useConcentricRadius` hook that computes per-corner concentric border-radius between a container and inner element. Part of #669.

### How it works

The hook measures both elements' positions via `getBoundingClientRect()` and computes per-corner gaps. No CSS variables, no token redefinition — just geometry.

```tsx
import {useConcentricRadius} from '@xds/core/hooks';

// Container defines the radius, inner element adapts
const {containerRef, innerRef} = useConcentricRadius({reference: 'container'});

<XDSCard ref={containerRef}>
  <div ref={innerRef} style={{background: 'var(--color-wash)'}}>
    Corners harmonize with the card
  </div>
</XDSCard>

// Inner defines the shape, container adapts (handles pills)
const {containerRef, innerRef} = useConcentricRadius({reference: 'inner'});

<div ref={containerRef} style={{padding: 8, background: 'var(--color-wash)'}}>
  <XDSButton ref={innerRef}>Pill button</XDSButton>
</div>
```

### Two modes

| Mode | Source of truth | Computes | Use case |
|---|---|---|---|
| `reference: 'container'` | Container's border-radius | Inner element's radius = `max(0, containerRadius - gap)` per corner | Colored sections, headers, cover images inside cards |
| `reference: 'inner'` | Inner element's shape | Container's radius = `innerRadius + gap` per corner | Halo/glow wrapper around a pill button or avatar |

### Per-corner computation

Uses `getBoundingClientRect()` on both elements to compute the gap at each corner:
- Handles **asymmetric padding** (different top/bottom/left/right)
- Handles **offset children** (flex layouts, non-centered content)
- Handles **pill-shaped elements** (`border-radius: 9999px` → measures `min(width, height) / 2`)

### Why measurement-based?

We explored several alternatives (full analysis):
- **CSS vars** (`--radius-concentric`): resolves to 0px at default scale (padding ≥ radius)
- **Token redefinition** on containers: cascading issues (buttons in middle of card get wrong radius)
- **Theme-time computation**: can't handle pills or dynamic layouts

Measurement via refs is the only approach that handles all cases correctly, including pill-shaped elements where the effective radius depends on rendered dimensions.

### Storybook

6 stories demonstrating the hook:
- `ContainerAsReference` — basic inner section
- `CardWithHeader` — colored header matching card corners
- `CoverImage` — gradient image at top of card
- `InnerAsReference` — halo wrapper adapting to button shape
- `Comparison` — side-by-side with/without concentric
- `MultipleInnerElements` — header + footer both adapting

### Tests

5 unit tests covering:
- Symmetric gap computation
- Clamping to 0 when gap exceeds radius
- Asymmetric gaps (per-corner values)
- Flush elements (zero gap = full radius)
- Inner-as-reference mode

---
