### PR TITLE
feat: shell animations — MobileNav entry + SideNav collapse

### DIFF
--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -76,9 +76,10 @@ const styles = stylex.create({
       backgroundColor: colorVars['--color-overlay'],
       backdropFilter: 'blur(2px)',
       opacity: 0,
-      transitionProperty: 'opacity',
+      transitionProperty: 'opacity, display, overlay',
       transitionDuration: durationVars['--duration-medium'],
       transitionTimingFunction: easeVars['--ease-standard'],
+      transitionBehavior: 'allow-discrete',
     },
     '@media (prefers-reduced-motion: reduce)': {
       '::backdrop': {
@@ -89,6 +90,14 @@ const styles = stylex.create({
   backdropOpen: {
     '::backdrop': {
       opacity: 1,
+    },
+    // Entry animation — @starting-style sets the initial state when the
+    // dialog is first shown via showModal(). Without this, the backdrop
+    // snaps to opacity: 1 because CSS transitions don't fire on display changes.
+    '@starting-style': {
+      '::backdrop': {
+        opacity: 0,
+      },
     },
   },
   drawer: {
@@ -120,6 +129,9 @@ const styles = stylex.create({
   },
   drawerStartOpen: {
     transform: 'translateX(0)',
+    '@starting-style': {
+      transform: 'translateX(-100%)',
+    },
   },
   drawerEnd: {
     insetInlineEnd: 0,
@@ -133,6 +145,9 @@ const styles = stylex.create({
   },
   drawerEndOpen: {
     transform: 'translateX(0)',
+    '@starting-style': {
+      transform: 'translateX(100%)',
+    },
   },
   header: {
     display: 'flex',

--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -44,6 +44,8 @@ const styles = stylex.create({
     backgroundColor: 'inherit',
     boxSizing: 'border-box',
     overflow: 'hidden',
+    // View transition name for animated collapse/expand
+    viewTransitionName: 'xds-side-nav',
   },
   rootCollapsed: {
     width: 52,
@@ -326,10 +328,20 @@ export function XDSSideNav({
 
   const toggle = useCallback(() => {
     const newValue = !collapsed;
-    if (!isControlled) {
-      setUncontrolledCollapsed(newValue);
+    const update = () => {
+      if (!isControlled) {
+        setUncontrolledCollapsed(newValue);
+      }
+      onCollapsedChange?.(newValue);
+    };
+
+    // Use View Transitions API for smooth width animation when available.
+    // Falls back to instant state change in unsupported browsers.
+    if (typeof document !== 'undefined' && 'startViewTransition' in document) {
+      document.startViewTransition(update);
+    } else {
+      update();
     }
-    onCollapsedChange?.(newValue);
   }, [collapsed, isControlled, onCollapsedChange]);
 
   const collapseContext = {


### PR DESCRIPTION
## Shell Animations

Combines entry animation for MobileNav and collapse animation for SideNav. Replaces #694 and #695.

### MobileNav Entry Animation (`@starting-style`)

- Backdrop fades in from `opacity: 0`
- Drawer slides in from `translateX(-100%)` (start) or `translateX(100%)` (end)
- Uses `transitionBehavior: allow-discrete` so `display` and `overlay` participate in the transition
- Uses motion tokens: `durationVars['--duration-medium']`, `easeVars['--ease-standard']`

### SideNav Collapse Animation (View Transitions API)

- `view-transition-name: xds-side-nav` on the nav root
- `document.startViewTransition()` wraps the toggle state change
- Browser captures before/after snapshots and interpolates off-main-thread
- Falls back to instant state change in unsupported browsers

---
