### PR TITLE
fix: sync package.json exports (add NavItem, remove typography.css)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -208,6 +208,12 @@
       "import": "./dist/NavIcon/index.mjs",
       "require": "./dist/NavIcon/index.js"
     },
+    "./NavItem": {
+      "source": "./src/NavItem/index.ts",
+      "types": "./dist/NavItem/index.d.ts",
+      "import": "./dist/NavItem/index.mjs",
+      "require": "./dist/NavItem/index.js"
+    },
     "./NumberInput": {
       "source": "./src/NumberInput/index.ts",
       "types": "./dist/NumberInput/index.d.ts",

--- a/scripts/sync-exports.js
+++ b/scripts/sync-exports.js
@@ -43,7 +43,6 @@ const UTILITY_DIRS = new Set(['hooks', 'theme', 'utils']);
  */
 const STATIC_EXPORTS = {
   './reset.css': './src/reset.css',
-  './typography.css': './src/typography.css',
   './xds.css': './dist/xds.css',
   './theme/tokens.stylex': {
     source: './src/theme/tokens.stylex.ts',


### PR DESCRIPTION
The `sync-exports` check was failing because two entries were out of sync in `packages/core/package.json`:

**Added:**
- `./NavItem` — component has `src/NavItem/index.ts` but was missing from the exports map

**Removed:**
- `./typography.css` — referenced in `STATIC_EXPORTS` in `sync-exports.js` but the file no longer exists. Removed from both the script and the generated exports.

Generated by running `node scripts/sync-exports.js` after cleaning up the stale static export.

---
