### PR TITLE
feat: redesign Theme Editor panel with accordion layout

### DIFF
--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -402,17 +402,6 @@ function getTokenLabel(tokenName: string): string {
 // Section Indicator Colors — maps each token group to a dot color
 // =============================================================================
 
-const SECTION_DOT_COLORS: Record<string, string> = {
-  colors: '#3B82F6',
-  spacing: '#10B981',
-  radius: '#F59E0B',
-  typography: '#8B5CF6',
-  size: '#EC4899',
-  shadow: '#6366F1',
-  duration: '#14B8A6',
-  easing: '#F97316',
-};
-
 // =============================================================================
 // Compact Color Swatch — matching the mockup design
 // =============================================================================
@@ -1719,6 +1708,34 @@ function ThemeEditorComponent() {
   // =========================================================================
   // Build the accordion sections
   // =========================================================================
+  // Count how many tokens in a group match the search query
+  const groupHasSearchMatch = React.useCallback(
+    (groupKey: TokenGroupKey) => {
+      if (!searchQuery) return true;
+      const q = searchQuery.toLowerCase();
+      const group = TOKEN_GROUPS[groupKey];
+
+      // For colors, check across all color categories
+      if (groupKey === 'colors') {
+        return Object.values(COLOR_CATEGORIES).some(catTokens =>
+          catTokens.some(
+            t =>
+              t.toLowerCase().includes(q) ||
+              getTokenLabel(t).toLowerCase().includes(q),
+          ),
+        );
+      }
+
+      // For other groups, check the group's tokens directly
+      return Object.keys(group.tokens).some(
+        t =>
+          t.toLowerCase().includes(q) ||
+          getTokenLabel(t).toLowerCase().includes(q),
+      );
+    },
+    [searchQuery],
+  );
+
   const sectionRenderers: Record<TokenGroupKey, () => React.ReactNode> = {
     colors: renderColorTokens,
     spacing: () => renderSpacingTokens(spacingDefaults),
@@ -1759,7 +1776,6 @@ function ThemeEditorComponent() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'space-between',
-              borderBottom: '1px solid var(--color-border)',
             }}>
             {isEditingName ? (
               <input
@@ -1850,14 +1866,25 @@ function ThemeEditorComponent() {
               overflow: 'auto',
               padding: '8px 12px',
             }}>
-            <XDSCollapsibleGroup type="multiple" defaultValue={['colors']}>
+            <XDSCollapsibleGroup
+              type="multiple"
+              defaultValue={
+                searchQuery
+                  ? (Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).filter(k =>
+                      groupHasSearchMatch(k),
+                    )
+                  : ['colors']
+              }>
               <XDSVStack gap={0.5}>
                 {(Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).map(
                   groupKey => {
                     const group = TOKEN_GROUPS[groupKey];
-                    const dotColor =
-                      SECTION_DOT_COLORS[groupKey] || 'var(--color-accent)';
                     const modified = modifiedCount(group.tokens);
+
+                    // Hide sections with no search matches
+                    if (searchQuery && !groupHasSearchMatch(groupKey)) {
+                      return null;
+                    }
 
                     return (
                       <XDSCollapsible
@@ -1869,15 +1896,6 @@ function ThemeEditorComponent() {
                             gap={2}
                             vAlign="center"
                             style={{width: '100%'}}>
-                            <div
-                              style={{
-                                width: '8px',
-                                height: '8px',
-                                borderRadius: '50%',
-                                backgroundColor: dotColor,
-                                flexShrink: 0,
-                              }}
-                            />
                             <XDSText
                               type="label"
                               style={{flex: 1, textAlign: 'start'}}>

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -1934,33 +1934,6 @@ function ThemeEditorComponent() {
             flexDirection: 'column',
             overflow: 'hidden',
           }}>
-          {/* Preview header */}
-          <div
-            style={{
-              padding: '12px 24px',
-              borderBottom: '1px solid var(--color-border)',
-              backgroundColor: 'var(--color-surface)',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-            }}>
-            <XDSHeading level={4}>Live Preview</XDSHeading>
-            <XDSHStack gap={1}>
-              <XDSButton
-                label="Light"
-                variant={mode === 'light' ? 'primary' : 'ghost'}
-                size="sm"
-                onClick={() => setMode('light')}
-              />
-              <XDSButton
-                label="Dark"
-                variant={mode === 'dark' ? 'primary' : 'ghost'}
-                size="sm"
-                onClick={() => setMode('dark')}
-              />
-            </XDSHStack>
-          </div>
-
           {/* Code panel (collapsible) */}
           {showCode && (
             <div

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -21,12 +21,7 @@ import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 import {XDSTable} from '@xds/core/Table';
 import type {XDSTableColumn} from '@xds/core/Table';
 import {XDSDivider} from '@xds/core/Divider';
-import {
-  XDSTheme,
-  defineTheme,
-  expandTypeScale,
-  xdsTokenDefaults,
-} from '@xds/core/theme';
+import {XDSTheme, expandTypeScale, xdsTokenDefaults} from '@xds/core/theme';
 import {
   colorDefaults,
   spacingDefaults,
@@ -42,7 +37,7 @@ import {
   easeDefaults,
   transitionDefaults,
 } from '@xds/core/theme';
-import {defaultTheme, defaultIconRegistry} from '@xds/theme-default';
+import {defaultTheme} from '@xds/theme-default';
 import {neutralTheme} from '@xds/theme-neutral';
 import {brutalistTheme} from '@xds/theme-brutalist';
 import {XDSCollapsible} from '@xds/core/Collapsible';
@@ -1393,28 +1388,28 @@ function ThemeEditorComponent() {
     setTypeScaleRatio(1.2);
   }, [selectedThemeKey]);
 
-  // Theme generation
-  const typeScaleKeys = React.useMemo(
-    () => new Set(Object.keys(typeScaleDefaults)),
-    [],
-  );
-
   const currentTheme = React.useMemo(() => {
-    const tokenOverrides: Record<string, string> = {};
+    const baseTheme = AVAILABLE_THEMES[selectedThemeKey].theme;
+
+    // Find tokens the user has manually changed vs the selected theme's values
+    const userOverrides: Record<string, string> = {};
     for (const [key, value] of Object.entries(tokens)) {
-      if (typeScaleKeys.has(key) || value !== allDefaults[key]) {
-        tokenOverrides[key] = value;
+      if (value !== themeTokens[key]) {
+        userOverrides[key] = value;
       }
     }
-    const baseTheme = AVAILABLE_THEMES[selectedThemeKey].theme;
-    return defineTheme({
-      name: themeName,
-      typeScale: {base: typeScaleBase, ratio: typeScaleRatio},
-      tokens: tokenOverrides as Partial<Record<string, string>>,
-      icons: baseTheme.icons || defaultIconRegistry,
-      components: baseTheme.components,
-    });
-  }, [tokens, themeName, allDefaults, selectedThemeKey]);
+
+    // If user hasn't changed anything, use the base theme directly
+    if (Object.keys(userOverrides).length === 0) {
+      return baseTheme;
+    }
+
+    // Otherwise, layer user overrides on top of the base theme's tokens
+    return {
+      ...baseTheme,
+      tokens: {...baseTheme.tokens, ...userOverrides},
+    };
+  }, [tokens, themeTokens, selectedThemeKey]);
 
   // Count modified tokens per group (compared to the selected theme's values)
   const modifiedCount = React.useCallback(

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -21,7 +21,12 @@ import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 import {XDSTable} from '@xds/core/Table';
 import type {XDSTableColumn} from '@xds/core/Table';
 import {XDSDivider} from '@xds/core/Divider';
-import {XDSTheme, defineTheme, expandTypeScale} from '@xds/core/theme';
+import {
+  XDSTheme,
+  defineTheme,
+  expandTypeScale,
+  xdsTokenDefaults,
+} from '@xds/core/theme';
 import {
   colorDefaults,
   spacingDefaults,
@@ -37,12 +42,34 @@ import {
   easeDefaults,
   transitionDefaults,
 } from '@xds/core/theme';
-import {defaultIconRegistry} from '@xds/theme-default';
+import {defaultTheme, defaultIconRegistry} from '@xds/theme-default';
+import {neutralTheme} from '@xds/theme-neutral';
+import {brutalistTheme} from '@xds/theme-brutalist';
 import {XDSCollapsible} from '@xds/core/Collapsible';
 import {XDSCollapsibleGroup} from '@xds/core/Collapsible';
 import {XDSIcon} from '@xds/core/Icon';
 import {XDSVStack} from '@xds/core/Stack';
 import {XDSHStack} from '@xds/core/Stack';
+
+// =============================================================================
+// Available themes
+// =============================================================================
+
+const AVAILABLE_THEMES = {
+  default: {label: 'Default', theme: defaultTheme},
+  neutral: {label: 'Neutral', theme: neutralTheme},
+  brutalist: {label: 'Brutalist', theme: brutalistTheme},
+} as const;
+
+type ThemeKey = keyof typeof AVAILABLE_THEMES;
+
+/**
+ * Resolve a theme to its full token map (defaults + overrides).
+ */
+function resolveThemeTokens(themeKey: ThemeKey): Record<string, string> {
+  const theme = AVAILABLE_THEMES[themeKey].theme;
+  return {...xdsTokenDefaults, ...theme.tokens};
+}
 
 // =============================================================================
 // Token Groups for the Editor
@@ -1301,8 +1328,8 @@ ${parts.join('\n')}
 function ThemeEditorComponent() {
   const [activeTypographyCategory, setActiveTypographyCategory] =
     React.useState<string>('Heading 1');
-  const [themeName, setThemeName] = React.useState('Custom');
-  const [isEditingName, setIsEditingName] = React.useState(false);
+  const [selectedThemeKey, setSelectedThemeKey] =
+    React.useState<ThemeKey>('default');
 
   const [mode, setMode] = React.useState<'light' | 'dark'>('light');
   const [showCode, setShowCode] = React.useState(false);
@@ -1310,7 +1337,7 @@ function ThemeEditorComponent() {
   const [showSearch, setShowSearch] = React.useState(false);
   const [isPanelCollapsed, setIsPanelCollapsed] = React.useState(false);
 
-  // Collect all defaults
+  // Collect all defaults (bare token defaults, not theme-specific)
   const allDefaults = React.useMemo(
     () => ({
       ...colorDefaults,
@@ -1330,12 +1357,28 @@ function ThemeEditorComponent() {
     [],
   );
 
+  // Resolved tokens for the selected theme (defaults + theme overrides)
+  const themeTokens = React.useMemo(
+    () => resolveThemeTokens(selectedThemeKey),
+    [selectedThemeKey],
+  );
+
+  // The theme name from the selected theme
+  const themeName = AVAILABLE_THEMES[selectedThemeKey].theme.name;
+
   // Type scale state
   const [typeScaleBase, setTypeScaleBase] = React.useState(14);
   const [typeScaleRatio, setTypeScaleRatio] = React.useState(1.2);
 
-  const [tokens, setTokens] =
-    React.useState<Record<string, string>>(allDefaults);
+  const [tokens, setTokens] = React.useState<Record<string, string>>(() =>
+    resolveThemeTokens('default'),
+  );
+
+  // When the selected theme changes, update all token values
+  React.useEffect(() => {
+    const resolved = resolveThemeTokens(selectedThemeKey);
+    setTokens(resolved);
+  }, [selectedThemeKey]);
 
   const handleTokenChange = React.useCallback(
     (tokenName: string, value: string) => {
@@ -1345,10 +1388,10 @@ function ThemeEditorComponent() {
   );
 
   const handleReset = React.useCallback(() => {
-    setTokens(allDefaults);
+    setTokens(resolveThemeTokens(selectedThemeKey));
     setTypeScaleBase(14);
     setTypeScaleRatio(1.2);
-  }, [allDefaults]);
+  }, [selectedThemeKey]);
 
   // Theme generation
   const typeScaleKeys = React.useMemo(
@@ -1363,24 +1406,26 @@ function ThemeEditorComponent() {
         tokenOverrides[key] = value;
       }
     }
+    const baseTheme = AVAILABLE_THEMES[selectedThemeKey].theme;
     return defineTheme({
       name: themeName,
       typeScale: {base: typeScaleBase, ratio: typeScaleRatio},
       tokens: tokenOverrides as Partial<Record<string, string>>,
-      icons: defaultIconRegistry,
+      icons: baseTheme.icons || defaultIconRegistry,
+      components: baseTheme.components,
     });
-  }, [tokens, themeName, allDefaults]);
+  }, [tokens, themeName, allDefaults, selectedThemeKey]);
 
-  // Count modified tokens per group
+  // Count modified tokens per group (compared to the selected theme's values)
   const modifiedCount = React.useCallback(
     (groupTokens: Record<string, string>) => {
       let count = 0;
-      for (const [key, defaultVal] of Object.entries(groupTokens)) {
-        if (tokens[key] !== defaultVal) count++;
+      for (const key of Object.keys(groupTokens)) {
+        if (tokens[key] !== themeTokens[key]) count++;
       }
       return count;
     },
-    [tokens],
+    [tokens, themeTokens],
   );
 
   // =========================================================================
@@ -1802,94 +1847,81 @@ function ThemeEditorComponent() {
             </div>
           ) : (
             <>
-              {/* Panel header — shows editable theme name */}
+              {/* Panel header — theme name + selector */}
               <div
                 style={{
                   padding: '16px 20px 12px',
                   display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
+                  flexDirection: 'column',
+                  gap: '8px',
                 }}>
-                {isEditingName ? (
-                  <input
-                    autoFocus
-                    type="text"
-                    value={themeName}
-                    onChange={e => setThemeName(e.target.value)}
-                    onBlur={() => setIsEditingName(false)}
-                    onKeyDown={e => {
-                      if (e.key === 'Enter') setIsEditingName(false);
-                    }}
-                    style={{
-                      all: 'unset',
-                      fontSize: 'var(--heading-3-size, 17px)',
-                      fontWeight: 600,
-                      color: 'var(--color-text-primary)',
-                      borderBottom: '2px solid var(--color-accent)',
-                      paddingBottom: '2px',
-                      width: '160px',
-                    }}
-                  />
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => setIsEditingName(true)}
-                    style={{
-                      all: 'unset',
-                      cursor: 'pointer',
-                      fontSize: 'var(--heading-3-size, 17px)',
-                      fontWeight: 600,
-                      fontFamily: 'var(--font-heading, var(--font-body))',
-                      color: 'var(--color-text-primary)',
-                      lineHeight: 'var(--heading-3-leading, 1.3)',
-                    }}>
-                    {themeName} Theme
-                  </button>
-                )}
-                <XDSHStack gap={0.5} vAlign="center">
-                  <button
-                    type="button"
-                    onClick={() => setShowSearch(!showSearch)}
-                    style={{
-                      all: 'unset',
-                      cursor: 'pointer',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: '32px',
-                      height: '32px',
-                      borderRadius: '6px',
-                      color: 'var(--color-icon-secondary)',
-                    }}
-                    title="Search tokens">
-                    <XDSIcon icon="search" size="sm" color="secondary" />
-                  </button>
-                  {/* Mode toggle */}
-                  <XDSButton
-                    label={mode === 'light' ? '☀' : '☾'}
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
-                  />
-                  {/* Collapse panel */}
-                  <button
-                    type="button"
-                    onClick={() => setIsPanelCollapsed(true)}
-                    style={{
-                      all: 'unset',
-                      cursor: 'pointer',
-                      display: 'inline-flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                      width: '32px',
-                      height: '32px',
-                      borderRadius: '6px',
-                      color: 'var(--color-icon-secondary)',
-                    }}
-                    title="Collapse panel">
-                    <XDSIcon icon="chevronLeft" size="sm" color="secondary" />
-                  </button>
-                </XDSHStack>
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}>
+                  <XDSHeading level={3}>
+                    {AVAILABLE_THEMES[selectedThemeKey].label} Theme
+                  </XDSHeading>
+                  <XDSHStack gap={0.5} vAlign="center">
+                    <button
+                      type="button"
+                      onClick={() => setShowSearch(!showSearch)}
+                      style={{
+                        all: 'unset',
+                        cursor: 'pointer',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        width: '32px',
+                        height: '32px',
+                        borderRadius: '6px',
+                        color: 'var(--color-icon-secondary)',
+                      }}
+                      title="Search tokens">
+                      <XDSIcon icon="search" size="sm" color="secondary" />
+                    </button>
+                    {/* Mode toggle */}
+                    <XDSButton
+                      label={mode === 'light' ? '☀' : '☾'}
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        setMode(mode === 'light' ? 'dark' : 'light')
+                      }
+                    />
+                    {/* Collapse panel */}
+                    <button
+                      type="button"
+                      onClick={() => setIsPanelCollapsed(true)}
+                      style={{
+                        all: 'unset',
+                        cursor: 'pointer',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        width: '32px',
+                        height: '32px',
+                        borderRadius: '6px',
+                        color: 'var(--color-icon-secondary)',
+                      }}
+                      title="Collapse panel">
+                      <XDSIcon icon="chevronLeft" size="sm" color="secondary" />
+                    </button>
+                  </XDSHStack>
+                </div>
+                {/* Theme selector */}
+                <XDSSelector
+                  label="Theme"
+                  isLabelHidden
+                  size="sm"
+                  options={Object.entries(AVAILABLE_THEMES).map(
+                    ([key, {label}]) => ({value: key, label}),
+                  )}
+                  value={selectedThemeKey}
+                  onChange={v => setSelectedThemeKey(v as ThemeKey)}
+                />
               </div>
 
               {/* Search bar — expandable */}

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -38,6 +38,11 @@ import {
   transitionDefaults,
 } from '@xds/core/theme';
 import {defaultIconRegistry} from '@xds/theme-default';
+import {XDSCollapsible} from '@xds/core/Collapsible';
+import {XDSCollapsibleGroup} from '@xds/core/Collapsible';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSVStack} from '@xds/core/Stack';
+import {XDSHStack} from '@xds/core/Stack';
 
 // =============================================================================
 // Token Groups for the Editor
@@ -393,6 +398,25 @@ function getTokenLabel(tokenName: string): string {
 // Token Editor Components
 // =============================================================================
 
+// =============================================================================
+// Section Indicator Colors — maps each token group to a dot color
+// =============================================================================
+
+const SECTION_DOT_COLORS: Record<string, string> = {
+  colors: '#3B82F6',
+  spacing: '#10B981',
+  radius: '#F59E0B',
+  typography: '#8B5CF6',
+  size: '#EC4899',
+  shadow: '#6366F1',
+  duration: '#14B8A6',
+  easing: '#F97316',
+};
+
+// =============================================================================
+// Compact Color Swatch — matching the mockup design
+// =============================================================================
+
 interface ColorSwatchProps {
   tokenName: string;
   value: string;
@@ -408,7 +432,6 @@ function ColorSwatch({tokenName, value, onChange, mode}: ColorSwatchProps) {
       : parsed.dark
     : value;
 
-  // Parse color with alpha
   const colorParsed = parseColorWithAlpha(displayValue);
   const hasColorPicker = colorParsed !== null;
 
@@ -429,108 +452,76 @@ function ColorSwatch({tokenName, value, onChange, mode}: ColorSwatchProps) {
     }
   };
 
+  const label = getTokenLabel(tokenName);
+
   return (
     <div
       style={{
         display: 'flex',
         alignItems: 'center',
-        gap: '12px',
-        padding: '8px 12px',
-        borderRadius: '8px',
-        backgroundColor: 'var(--color-wash)',
+        gap: '10px',
+        padding: '6px 0',
       }}>
+      {/* Color swatch — clickable if we have a color picker */}
+      <div style={{position: 'relative', flexShrink: 0}}>
+        <div
+          style={{
+            width: '28px',
+            height: '28px',
+            borderRadius: '6px',
+            border: '1px solid var(--color-border)',
+            overflow: 'hidden',
+            // Checkerboard for alpha
+            backgroundImage:
+              colorParsed && colorParsed.alpha < 1
+                ? `linear-gradient(45deg, #ccc 25%, transparent 25%), 
+                   linear-gradient(-45deg, #ccc 25%, transparent 25%), 
+                   linear-gradient(45deg, transparent 75%, #ccc 75%), 
+                   linear-gradient(-45deg, transparent 75%, #ccc 75%)`
+                : undefined,
+            backgroundSize: '6px 6px',
+            backgroundPosition: '0 0, 0 3px, 3px -3px, -3px 0px',
+          }}>
+          <div
+            style={{
+              width: '100%',
+              height: '100%',
+              backgroundColor: displayValue,
+            }}
+          />
+        </div>
+        {hasColorPicker && (
+          <input
+            type="color"
+            value={colorParsed?.hex ?? '#000000'}
+            onChange={e => handleColorChange(e.target.value)}
+            style={{
+              position: 'absolute',
+              inset: 0,
+              opacity: 0,
+              width: '100%',
+              height: '100%',
+              cursor: 'pointer',
+              border: 'none',
+              padding: 0,
+            }}
+          />
+        )}
+      </div>
+
+      {/* Label */}
+      <XDSText type="body" style={{flex: 1, minWidth: 0, fontSize: '13px'}}>
+        {label}
+      </XDSText>
+
+      {/* Value + alpha */}
       <div
         style={{
-          width: '32px',
-          height: '32px',
-          borderRadius: '6px',
-          backgroundColor: displayValue,
-          border: '1px solid var(--color-border-emphasized)',
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
           flexShrink: 0,
-          // Checkerboard pattern for alpha preview
-          backgroundImage:
-            colorParsed && colorParsed.alpha < 1
-              ? `linear-gradient(45deg, #ccc 25%, transparent 25%), 
-                 linear-gradient(-45deg, #ccc 25%, transparent 25%), 
-                 linear-gradient(45deg, transparent 75%, #ccc 75%), 
-                 linear-gradient(-45deg, transparent 75%, #ccc 75%)`
-              : undefined,
-          backgroundSize: '8px 8px',
-          backgroundPosition: '0 0, 0 4px, 4px -4px, -4px 0px',
         }}>
-        <div
-          style={{
-            width: '100%',
-            height: '100%',
-            borderRadius: '6px',
-            backgroundColor: displayValue,
-          }}
-        />
-      </div>
-      <div style={{flex: 1, minWidth: 0}}>
-        <div
-          style={{
-            fontSize: '13px',
-            fontWeight: 500,
-            color: 'var(--color-text-primary)',
-            marginBottom: '2px',
-          }}>
-          {getTokenLabel(tokenName)}
-        </div>
-        <code
-          style={{
-            fontSize: '11px',
-            color: 'var(--color-text-secondary)',
-            fontFamily: 'var(--font-code)',
-          }}>
-          {tokenName}
-        </code>
-      </div>
-      <div style={{display: 'flex', alignItems: 'center', gap: '6px'}}>
-        {hasColorPicker && colorParsed && (
-          <>
-            <input
-              type="color"
-              value={colorParsed.hex}
-              onChange={e => handleColorChange(e.target.value)}
-              style={{
-                width: '28px',
-                height: '28px',
-                padding: 0,
-                border: 'none',
-                borderRadius: '4px',
-                cursor: 'pointer',
-              }}
-            />
-            <input
-              type="number"
-              min="0"
-              max="100"
-              step="1"
-              value={Math.round(colorParsed.alpha * 100)}
-              onChange={e => handleAlphaChange(Number(e.target.value) / 100)}
-              title="Alpha %"
-              style={{
-                width: '50px',
-                padding: '4px 6px',
-                fontSize: '12px',
-                fontFamily: 'var(--font-code)',
-                border: '1px solid var(--color-border-emphasized)',
-                borderRadius: '4px',
-                backgroundColor: 'var(--color-surface)',
-                color: 'var(--color-text-primary)',
-                textAlign: 'center',
-              }}
-            />
-            <span
-              style={{
-                fontSize: '11px',
-                color: 'var(--color-text-secondary)',
-              }}>
-              %
-            </span>
-          </>
-        )}
         <input
           type="text"
           value={displayValue}
@@ -543,16 +534,44 @@ function ColorSwatch({tokenName, value, onChange, mode}: ColorSwatchProps) {
             onChange(tokenName, newValue);
           }}
           style={{
-            width: '100px',
-            padding: '4px 8px',
-            fontSize: '12px',
+            width: '82px',
+            padding: '3px 6px',
+            fontSize: '11px',
             fontFamily: 'var(--font-code)',
-            border: '1px solid var(--color-border-emphasized)',
+            border: '1px solid var(--color-border)',
             borderRadius: '4px',
             backgroundColor: 'var(--color-surface)',
             color: 'var(--color-text-primary)',
+            textAlign: 'center',
           }}
         />
+        {hasColorPicker && colorParsed && (
+          <div style={{display: 'flex', alignItems: 'center', gap: '2px'}}>
+            <input
+              type="number"
+              min="0"
+              max="100"
+              step="1"
+              value={Math.round(colorParsed.alpha * 100)}
+              onChange={e => handleAlphaChange(Number(e.target.value) / 100)}
+              title="Alpha %"
+              style={{
+                width: '38px',
+                padding: '3px 4px',
+                fontSize: '11px',
+                fontFamily: 'var(--font-code)',
+                border: '1px solid var(--color-border)',
+                borderRadius: '4px',
+                backgroundColor: 'var(--color-surface)',
+                color: 'var(--color-text-primary)',
+                textAlign: 'center',
+              }}
+            />
+            <XDSText type="supporting" color="secondary">
+              %
+            </XDSText>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -1291,15 +1310,15 @@ ${parts.join('\n')}
 // =============================================================================
 
 function ThemeEditorComponent() {
-  const [activeGroup, setActiveGroup] = React.useState<TokenGroupKey>('colors');
-  const [activeColorCategory, setActiveColorCategory] =
-    React.useState<string>('Core Semantic');
   const [activeTypographyCategory, setActiveTypographyCategory] =
     React.useState<string>('Heading 1');
-  const [themeName] = React.useState('custom');
+  const [themeName, setThemeName] = React.useState('Custom');
+  const [isEditingName, setIsEditingName] = React.useState(false);
 
   const [mode, setMode] = React.useState<'light' | 'dark'>('light');
   const [showCode, setShowCode] = React.useState(false);
+  const [searchQuery, setSearchQuery] = React.useState('');
+  const [showSearch, setShowSearch] = React.useState(false);
 
   // Collect all defaults
   const allDefaults = React.useMemo(
@@ -1321,7 +1340,7 @@ function ThemeEditorComponent() {
     [],
   );
 
-  // Type scale state — base and ratio for the interactive type scale editor
+  // Type scale state
   const [typeScaleBase, setTypeScaleBase] = React.useState(14);
   const [typeScaleRatio, setTypeScaleRatio] = React.useState(1.2);
 
@@ -1341,14 +1360,7 @@ function ThemeEditorComponent() {
     setTypeScaleRatio(1.2);
   }, [allDefaults]);
 
-  // Create a theme from current tokens.
-  // Uses defaultTheme's component overrides so that type scale tokens
-  // (--heading-1-size, --text-body-size, etc.) are consumed by the
-  // heading/text CSS rules in the preview.
-  //
-  // Type scale tokens are ALWAYS included (even at default values) because
-  // the component overrides reference var(--heading-1-size) etc., and those
-  // unhashed CSS custom properties only exist when the theme explicitly sets them.
+  // Theme generation
   const typeScaleKeys = React.useMemo(
     () => new Set(Object.keys(typeScaleDefaults)),
     [],
@@ -1357,8 +1369,6 @@ function ThemeEditorComponent() {
   const currentTheme = React.useMemo(() => {
     const tokenOverrides: Record<string, string> = {};
     for (const [key, value] of Object.entries(tokens)) {
-      // Always include type scale tokens — the component CSS rules reference
-      // var(--heading-1-size) etc. which only exist when the theme sets them.
       if (typeScaleKeys.has(key) || value !== allDefaults[key]) {
         tokenOverrides[key] = value;
       }
@@ -1371,343 +1381,275 @@ function ThemeEditorComponent() {
     });
   }, [tokens, themeName, allDefaults]);
 
-  const renderTokenEditor = () => {
-    const group = TOKEN_GROUPS[activeGroup];
+  // Count modified tokens per group
+  const modifiedCount = React.useCallback(
+    (groupTokens: Record<string, string>) => {
+      let count = 0;
+      for (const [key, defaultVal] of Object.entries(groupTokens)) {
+        if (tokens[key] !== defaultVal) count++;
+      }
+      return count;
+    },
+    [tokens],
+  );
 
-    if (activeGroup === 'colors') {
-      const categoryTokens =
-        COLOR_CATEGORIES[
-          activeColorCategory as keyof typeof COLOR_CATEGORIES
-        ] || [];
+  // =========================================================================
+  // Render the color tokens section with sub-categories
+  // =========================================================================
+  const renderColorTokens = () => {
+    const filteredCategories = Object.entries(COLOR_CATEGORIES).filter(
+      ([, catTokens]) => {
+        if (!searchQuery) return true;
+        const q = searchQuery.toLowerCase();
+        return catTokens.some(
+          t =>
+            t.toLowerCase().includes(q) ||
+            getTokenLabel(t).toLowerCase().includes(q),
+        );
+      },
+    );
 
-      return (
-        <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
-          {/* Color category selector */}
-          <XDSSelector
-            label="Color Category"
-            isLabelHidden
-            options={Object.keys(COLOR_CATEGORIES).map(category => ({
-              value: category,
-              label: category,
-            }))}
-            value={activeColorCategory}
-            onChange={v => setActiveColorCategory(v)}
-          />
+    return (
+      <XDSVStack gap={1}>
+        {filteredCategories.map(([category, categoryTokens]) => {
+          const filtered = searchQuery
+            ? categoryTokens.filter(
+                t =>
+                  t.toLowerCase().includes(searchQuery.toLowerCase()) ||
+                  getTokenLabel(t)
+                    .toLowerCase()
+                    .includes(searchQuery.toLowerCase()),
+              )
+            : categoryTokens;
 
-          {categoryTokens.map(tokenName => (
-            <ColorSwatch
-              key={tokenName}
-              tokenName={tokenName}
-              value={tokens[tokenName] || ''}
-              onChange={handleTokenChange}
-              mode={mode}
-            />
-          ))}
-        </div>
-      );
-    }
+          if (filtered.length === 0) return null;
 
-    if (activeGroup === 'spacing' || activeGroup === 'size') {
-      return (
-        <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
-          {Object.keys(group.tokens).map(tokenName => (
-            <SpacingEditor
-              key={tokenName}
-              tokenName={tokenName}
-              value={tokens[tokenName] || ''}
-              onChange={handleTokenChange}
-            />
-          ))}
-        </div>
-      );
-    }
-
-    if (activeGroup === 'radius') {
-      return (
-        <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
-          {Object.keys(group.tokens).map(tokenName => (
-            <RadiusEditor
-              key={tokenName}
-              tokenName={tokenName}
-              value={tokens[tokenName] || ''}
-              onChange={handleTokenChange}
-            />
-          ))}
-        </div>
-      );
-    }
-
-    if (activeGroup === 'typography') {
-      // Type scale controls
-      const applyTypeScale = (base: number, ratio: number) => {
-        setTypeScaleBase(base);
-        setTypeScaleRatio(ratio);
-        setTokens(prev => ({...prev, ...expandTypeScale({base, ratio})}));
-      };
-
-      // Named ratio options from musical/mathematical intervals
-      const RATIO_OPTIONS = [
-        {value: 1.067, label: '1.067 — Minor Second'},
-        {value: 1.125, label: '1.125 — Major Second'},
-        {value: 1.2, label: '1.200 — Minor Third'},
-        {value: 1.25, label: '1.250 — Major Third'},
-        {value: 1.333, label: '1.333 — Perfect Fourth'},
-        {value: 1.414, label: '1.414 — Augmented Fourth'},
-        {value: 1.5, label: '1.500 — Perfect Fifth'},
-        {value: 1.618, label: '1.618 — Golden Ratio'},
-      ];
-      const isCustomRatio = !RATIO_OPTIONS.some(
-        o => Math.abs(o.value - typeScaleRatio) < 0.001,
-      );
-
-      const typeScaleSection = (
-        <div
-          style={{
-            padding: '12px',
-            borderRadius: '8px',
-            backgroundColor: 'var(--color-wash)',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '10px',
-            marginBottom: '16px',
-          }}>
-          <XDSText type="label" color="secondary">
-            Type Scale
-          </XDSText>
-          <XDSSlider
-            label="Base Size"
-            min={10}
-            max={24}
-            step={1}
-            value={typeScaleBase}
-            onChange={v => applyTypeScale(v, typeScaleRatio)}
-            formatValue={v => `${v}px`}
-            valueDisplay="text"
-          />
-          <XDSSelector
-            label="Scale Ratio"
-            options={[
-              ...RATIO_OPTIONS.map(opt => ({
-                value: String(opt.value),
-                label: opt.label,
-              })),
-              {
-                value: 'custom',
-                label: isCustomRatio
-                  ? `Custom — ${typeScaleRatio.toFixed(3)}`
-                  : 'Custom…',
-              },
-            ]}
-            value={isCustomRatio ? 'custom' : String(typeScaleRatio)}
-            onChange={v => {
-              if (v === 'custom') return;
-              applyTypeScale(typeScaleBase, Number(v));
-            }}
-          />
-          {isCustomRatio && (
-            <XDSSlider
-              label="Custom Ratio"
-              isLabelHidden
-              min={1050}
-              max={1700}
-              step={1}
-              value={Math.round(typeScaleRatio * 1000)}
-              onChange={v => applyTypeScale(typeScaleBase, v / 1000)}
-              formatValue={v => (v / 1000).toFixed(3)}
-              valueDisplay="text"
-            />
-          )}
-          <div>
-            <XDSText
-              type="supporting"
-              display="block"
-              style={{marginBottom: '4px'}}>
-              Recommended values
-            </XDSText>
-            <div style={{display: 'flex', gap: '4px', flexWrap: 'wrap'}}>
-              <XDSButton
-                label="Functional"
-                variant={
-                  typeScaleBase === 12 && typeScaleRatio === 1.125
-                    ? 'primary'
-                    : 'ghost'
-                }
-                size="sm"
-                onClick={() => applyTypeScale(12, 1.125)}
-              />
-              <XDSButton
-                label="Default"
-                variant={
-                  typeScaleBase === 14 && typeScaleRatio === 1.2
-                    ? 'primary'
-                    : 'ghost'
-                }
-                size="sm"
-                onClick={() => applyTypeScale(14, 1.2)}
-              />
-              <XDSButton
-                label="Editorial"
-                variant={
-                  typeScaleBase === 16 && typeScaleRatio === 1.25
-                    ? 'primary'
-                    : 'ghost'
-                }
-                size="sm"
-                onClick={() => applyTypeScale(16, 1.25)}
-              />
+          return (
+            <div key={category}>
+              <XDSText
+                type="supporting"
+                weight="semibold"
+                color="secondary"
+                display="block"
+                style={{
+                  padding: '8px 0 4px',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  fontSize: '10px',
+                }}>
+                {category}
+              </XDSText>
+              {filtered.map(tokenName => (
+                <ColorSwatch
+                  key={tokenName}
+                  tokenName={tokenName}
+                  value={tokens[tokenName] || ''}
+                  onChange={handleTokenChange}
+                  mode={mode}
+                />
+              ))}
             </div>
-          </div>
-          {/* Compact heading preview */}
-          <div
-            style={{
-              padding: '8px 12px',
-              borderRadius: '6px',
-              border: '1px solid var(--color-border)',
-              backgroundColor: 'var(--color-surface)',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: '2px',
-            }}>
-            {[1, 2, 3, 4, 5, 6].map(level => {
-              const size = tokens[`--heading-${level}-size`] || '';
-              return (
-                <div
-                  key={level}
-                  style={{
-                    display: 'flex',
-                    alignItems: 'baseline',
-                    gap: '8px',
-                  }}>
-                  <XDSText
-                    type="code"
-                    color="secondary"
-                    style={{width: '18px', flexShrink: 0}}>
-                    h{level}
-                  </XDSText>
-                  <span
-                    style={{
-                      fontSize: size,
-                      fontWeight: 600,
-                      lineHeight: 1.3,
-                      color: 'var(--color-text-primary)',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}>
-                    Heading
-                  </span>
-                  <XDSText
-                    type="code"
-                    color="secondary"
-                    style={{marginLeft: 'auto', flexShrink: 0}}>
-                    {size}
-                  </XDSText>
-                </div>
-              );
-            })}
-          </div>
-          <XDSText type="code" color="secondary">
-            size = {typeScaleBase} × {typeScaleRatio.toFixed(3)}^step · h4 =
-            anchor
-          </XDSText>
-        </div>
-      );
+          );
+        })}
+      </XDSVStack>
+    );
+  };
 
-      const categoryValue = TYPOGRAPHY_CATEGORIES[
-        activeTypographyCategory as keyof typeof TYPOGRAPHY_CATEGORIES
-      ] as TypographyCategoryValue | undefined;
-
-      // Get the list of tokens for this category
-      const categoryTokens: string[] = categoryValue
-        ? Array.isArray(categoryValue)
-          ? categoryValue
-          : categoryValue.tokens
-        : [];
-
-      const categoryDescription =
-        categoryValue && !Array.isArray(categoryValue)
-          ? categoryValue.description
-          : null;
-
-      // Determine sample text rendering for semantic categories
-      const isSemanticStyle = categoryValue && !Array.isArray(categoryValue);
-
+  // =========================================================================
+  // Render spacing/size tokens
+  // =========================================================================
+  const renderSpacingTokens = (groupTokens: Record<string, string>) => {
+    const filtered = Object.keys(groupTokens).filter(t => {
+      if (!searchQuery) return true;
+      const q = searchQuery.toLowerCase();
       return (
-        <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
-          {typeScaleSection}
+        t.toLowerCase().includes(q) ||
+        getTokenLabel(t).toLowerCase().includes(q)
+      );
+    });
 
-          {/* Typography category selector */}
-          <XDSSelector
-            label="Typography Category"
-            isLabelHidden
-            options={[
-              {
-                type: 'section' as const,
-                title: 'Semantic Styles',
-                options: Object.keys(TYPOGRAPHY_CATEGORIES)
-                  .filter(
-                    k =>
-                      !Array.isArray(
-                        TYPOGRAPHY_CATEGORIES[
-                          k as keyof typeof TYPOGRAPHY_CATEGORIES
-                        ],
-                      ),
-                  )
-                  .map(category => ({value: category, label: category})),
-              },
-              {
-                type: 'section' as const,
-                title: 'Raw Tokens',
-                options: Object.keys(TYPOGRAPHY_CATEGORIES)
-                  .filter(k =>
-                    Array.isArray(
+    return (
+      <XDSVStack gap={0.5}>
+        {filtered.map(tokenName => (
+          <SpacingEditor
+            key={tokenName}
+            tokenName={tokenName}
+            value={tokens[tokenName] || ''}
+            onChange={handleTokenChange}
+          />
+        ))}
+      </XDSVStack>
+    );
+  };
+
+  // =========================================================================
+  // Render radius tokens
+  // =========================================================================
+  const renderRadiusTokens = () => {
+    const filtered = Object.keys(radiusDefaults).filter(t => {
+      if (!searchQuery) return true;
+      const q = searchQuery.toLowerCase();
+      return (
+        t.toLowerCase().includes(q) ||
+        getTokenLabel(t).toLowerCase().includes(q)
+      );
+    });
+
+    return (
+      <XDSVStack gap={0.5}>
+        {filtered.map(tokenName => (
+          <RadiusEditor
+            key={tokenName}
+            tokenName={tokenName}
+            value={tokens[tokenName] || ''}
+            onChange={handleTokenChange}
+          />
+        ))}
+      </XDSVStack>
+    );
+  };
+
+  // =========================================================================
+  // Render typography tokens (with type scale + category selector)
+  // =========================================================================
+  const renderTypographyTokens = () => {
+    const applyTypeScale = (base: number, ratio: number) => {
+      setTypeScaleBase(base);
+      setTypeScaleRatio(ratio);
+      setTokens(prev => ({...prev, ...expandTypeScale({base, ratio})}));
+    };
+
+    const categoryValue = TYPOGRAPHY_CATEGORIES[
+      activeTypographyCategory as keyof typeof TYPOGRAPHY_CATEGORIES
+    ] as TypographyCategoryValue | undefined;
+
+    const categoryTokens: string[] = categoryValue
+      ? Array.isArray(categoryValue)
+        ? categoryValue
+        : categoryValue.tokens
+      : [];
+
+    const categoryDescription =
+      categoryValue && !Array.isArray(categoryValue)
+        ? categoryValue.description
+        : null;
+
+    const isSemanticStyle = categoryValue && !Array.isArray(categoryValue);
+
+    return (
+      <XDSVStack gap={2}>
+        {/* Type scale quick-picks */}
+        <div>
+          <XDSText
+            type="supporting"
+            weight="semibold"
+            color="secondary"
+            display="block"
+            style={{
+              padding: '4px 0',
+              textTransform: 'uppercase',
+              letterSpacing: '0.05em',
+              fontSize: '10px',
+            }}>
+            Type Scale Presets
+          </XDSText>
+          <XDSHStack gap={1} style={{flexWrap: 'wrap', paddingTop: '4px'}}>
+            <XDSButton
+              label="Functional"
+              variant={
+                typeScaleBase === 12 && typeScaleRatio === 1.125
+                  ? 'primary'
+                  : 'ghost'
+              }
+              size="sm"
+              onClick={() => applyTypeScale(12, 1.125)}
+            />
+            <XDSButton
+              label="Default"
+              variant={
+                typeScaleBase === 14 && typeScaleRatio === 1.2
+                  ? 'primary'
+                  : 'ghost'
+              }
+              size="sm"
+              onClick={() => applyTypeScale(14, 1.2)}
+            />
+            <XDSButton
+              label="Editorial"
+              variant={
+                typeScaleBase === 16 && typeScaleRatio === 1.25
+                  ? 'primary'
+                  : 'ghost'
+              }
+              size="sm"
+              onClick={() => applyTypeScale(16, 1.25)}
+            />
+          </XDSHStack>
+        </div>
+
+        {/* Category selector */}
+        <XDSSelector
+          label="Typography Category"
+          isLabelHidden
+          size="sm"
+          options={[
+            {
+              type: 'section' as const,
+              title: 'Semantic Styles',
+              options: Object.keys(TYPOGRAPHY_CATEGORIES)
+                .filter(
+                  k =>
+                    !Array.isArray(
                       TYPOGRAPHY_CATEGORIES[
                         k as keyof typeof TYPOGRAPHY_CATEGORIES
                       ],
                     ),
-                  )
-                  .map(category => ({value: category, label: category})),
-              },
-            ]}
-            value={activeTypographyCategory}
-            onChange={v => setActiveTypographyCategory(v)}
-          />
+                )
+                .map(category => ({value: category, label: category})),
+            },
+            {
+              type: 'section' as const,
+              title: 'Raw Tokens',
+              options: Object.keys(TYPOGRAPHY_CATEGORIES)
+                .filter(k =>
+                  Array.isArray(
+                    TYPOGRAPHY_CATEGORIES[
+                      k as keyof typeof TYPOGRAPHY_CATEGORIES
+                    ],
+                  ),
+                )
+                .map(category => ({value: category, label: category})),
+            },
+          ]}
+          value={activeTypographyCategory}
+          onChange={v => setActiveTypographyCategory(v)}
+        />
 
-          {/* Description for semantic styles */}
-          {categoryDescription && (
-            <XDSText
-              type="supporting"
-              display="block"
-              style={{marginBottom: '4px'}}>
-              {categoryDescription}
-            </XDSText>
-          )}
+        {categoryDescription && (
+          <XDSText type="supporting" color="secondary">
+            {categoryDescription}
+          </XDSText>
+        )}
 
-          {/* Sample text preview for semantic styles */}
-          {isSemanticStyle && (
+        {/* Sample text preview */}
+        {isSemanticStyle && (
+          <XDSCard padding={2}>
             <div
               style={{
-                padding: '16px',
-                borderRadius: '8px',
-                backgroundColor: 'var(--color-wash)',
-                border: '1px solid var(--color-border)',
-                marginBottom: '8px',
+                fontSize: tokens[categoryTokens[0]] || 'inherit',
+                fontWeight: tokens[categoryTokens[1]] || 'inherit',
+                lineHeight: tokens[categoryTokens[2]] || 'inherit',
+                color: 'var(--color-text-primary)',
               }}>
-              <div
-                style={{
-                  fontSize: tokens[categoryTokens[0]] || 'inherit',
-                  fontWeight: tokens[categoryTokens[1]] || 'inherit',
-                  lineHeight: tokens[categoryTokens[2]] || 'inherit',
-                  color: 'var(--color-text-primary)',
-                }}>
-                {activeTypographyCategory === 'Code Text'
-                  ? 'const theme = defineTheme({...});'
-                  : `The quick brown fox jumps over the lazy dog`}
-              </div>
+              {activeTypographyCategory === 'Code Text'
+                ? 'const theme = defineTheme({...});'
+                : 'The quick brown fox jumps over the lazy dog'}
             </div>
-          )}
+          </XDSCard>
+        )}
 
-          {/* Token editors */}
+        {/* Token editors */}
+        <XDSVStack gap={0.5}>
           {categoryTokens.map(tokenName => (
             <TypographyEditor
               key={tokenName}
@@ -1716,62 +1658,76 @@ function ThemeEditorComponent() {
               onChange={handleTokenChange}
             />
           ))}
-        </div>
-      );
-    }
+        </XDSVStack>
+      </XDSVStack>
+    );
+  };
 
-    // Default: generic text input
+  // =========================================================================
+  // Render generic tokens (shadow, duration, easing)
+  // =========================================================================
+  const renderGenericTokens = (groupTokens: Record<string, string>) => {
+    const filtered = Object.keys(groupTokens).filter(t => {
+      if (!searchQuery) return true;
+      const q = searchQuery.toLowerCase();
+      return (
+        t.toLowerCase().includes(q) ||
+        getTokenLabel(t).toLowerCase().includes(q)
+      );
+    });
+
     return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
-        {Object.keys(group.tokens).map(tokenName => (
-          <div
+      <XDSVStack gap={0.5}>
+        {filtered.map(tokenName => (
+          <XDSHStack
             key={tokenName}
+            gap={2}
+            vAlign="center"
             style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              padding: '8px 12px',
-              borderRadius: '8px',
-              backgroundColor: 'var(--color-wash)',
+              padding: '6px 0',
             }}>
-            <div style={{flex: 1, minWidth: 0}}>
-              <div
-                style={{
-                  fontSize: '13px',
-                  fontWeight: 500,
-                  color: 'var(--color-text-primary)',
-                  marginBottom: '2px',
-                }}>
+            <XDSVStack gap={0} style={{flex: 1, minWidth: 0}}>
+              <XDSText type="body" style={{fontSize: '13px'}}>
                 {getTokenLabel(tokenName)}
-              </div>
-              <code
-                style={{
-                  fontSize: '11px',
-                  color: 'var(--color-text-secondary)',
-                  fontFamily: 'var(--font-code)',
-                }}>
+              </XDSText>
+              <XDSText type="code" color="secondary" style={{fontSize: '10px'}}>
                 {tokenName}
-              </code>
-            </div>
+              </XDSText>
+            </XDSVStack>
             <input
               type="text"
               value={tokens[tokenName] || ''}
               onChange={e => handleTokenChange(tokenName, e.target.value)}
               style={{
-                width: '200px',
+                width: '140px',
                 padding: '4px 8px',
-                fontSize: '12px',
+                fontSize: '11px',
                 fontFamily: 'var(--font-code)',
-                border: '1px solid var(--color-border-emphasized)',
+                border: '1px solid var(--color-border)',
                 borderRadius: '4px',
                 backgroundColor: 'var(--color-surface)',
                 color: 'var(--color-text-primary)',
+                flexShrink: 0,
               }}
             />
-          </div>
+          </XDSHStack>
         ))}
-      </div>
+      </XDSVStack>
     );
+  };
+
+  // =========================================================================
+  // Build the accordion sections
+  // =========================================================================
+  const sectionRenderers: Record<TokenGroupKey, () => React.ReactNode> = {
+    colors: renderColorTokens,
+    spacing: () => renderSpacingTokens(spacingDefaults),
+    radius: renderRadiusTokens,
+    typography: renderTypographyTokens,
+    size: () => renderSpacingTokens(sizeDefaults),
+    shadow: () => renderGenericTokens(shadowDefaults),
+    duration: () => renderGenericTokens(durationDefaults),
+    easing: () => renderGenericTokens(easeDefaults),
   };
 
   return (
@@ -1783,74 +1739,191 @@ function ThemeEditorComponent() {
         overflow: 'hidden',
         backgroundColor: 'var(--color-wash)',
       }}>
-      {/* Left Panel - Token Editor */}
+      {/* ================================================================= */}
+      {/* Left Panel — Accordion-based Token Editor                         */}
+      {/* ================================================================= */}
       <div
         style={{
-          width: '400px',
-          borderRight: '1px solid var(--color-border-emphasized)',
+          width: '380px',
           display: 'flex',
           flexDirection: 'column',
           backgroundColor: 'var(--color-surface)',
+          borderRight: '1px solid var(--color-border)',
+          overflow: 'hidden',
         }}>
-        {/* Token group tabs */}
+        {/* Panel header — shows editable theme name */}
         <div
           style={{
-            padding: '16px 16px 12px',
-            borderBottom: '1px solid var(--color-border)',
+            padding: '16px 20px 12px',
             display: 'flex',
-            gap: '4px',
-            flexWrap: 'wrap',
-          }}>
-          {(Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).map(groupKey => (
-            <XDSButton
-              key={groupKey}
-              label={TOKEN_GROUPS[groupKey].label}
-              variant={activeGroup === groupKey ? 'primary' : 'ghost'}
-              size="sm"
-              onClick={() => setActiveGroup(groupKey)}
-            />
-          ))}
-        </div>
-
-        {/* Group description */}
-        <div
-          style={{
-            padding: '12px 16px',
+            alignItems: 'center',
+            justifyContent: 'space-between',
             borderBottom: '1px solid var(--color-border)',
           }}>
-          <XDSText type="supporting">
-            {TOKEN_GROUPS[activeGroup].description}
-          </XDSText>
+          {isEditingName ? (
+            <input
+              autoFocus
+              type="text"
+              value={themeName}
+              onChange={e => setThemeName(e.target.value)}
+              onBlur={() => setIsEditingName(false)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') setIsEditingName(false);
+              }}
+              style={{
+                all: 'unset',
+                fontSize: 'var(--heading-3-size, 17px)',
+                fontWeight: 600,
+                color: 'var(--color-text-primary)',
+                borderBottom: '2px solid var(--color-accent)',
+                paddingBottom: '2px',
+                width: '160px',
+              }}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => setIsEditingName(true)}
+              style={{
+                all: 'unset',
+                cursor: 'pointer',
+                fontSize: 'var(--heading-3-size, 17px)',
+                fontWeight: 600,
+                fontFamily: 'var(--font-heading, var(--font-body))',
+                color: 'var(--color-text-primary)',
+                lineHeight: 'var(--heading-3-leading, 1.3)',
+              }}>
+              {themeName} Theme
+            </button>
+          )}
+          <XDSHStack gap={1} vAlign="center">
+            <button
+              type="button"
+              onClick={() => setShowSearch(!showSearch)}
+              style={{
+                all: 'unset',
+                cursor: 'pointer',
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: '32px',
+                height: '32px',
+                borderRadius: '6px',
+                color: 'var(--color-icon-secondary)',
+              }}
+              title="Search tokens">
+              <XDSIcon icon="search" size="sm" color="secondary" />
+            </button>
+            {/* Mode toggle */}
+            <XDSButton
+              label={mode === 'light' ? '☀' : '☾'}
+              variant="ghost"
+              size="sm"
+              onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
+            />
+          </XDSHStack>
         </div>
 
-        {/* Token list */}
+        {/* Search bar — expandable */}
+        {showSearch && (
+          <div
+            style={{
+              padding: '8px 16px',
+              borderBottom: '1px solid var(--color-border)',
+            }}>
+            <XDSTextInput
+              label="Search tokens"
+              isLabelHidden
+              placeholder="Search tokens…"
+              value={searchQuery}
+              onChange={setSearchQuery}
+              size="sm"
+            />
+          </div>
+        )}
+
+        {/* Accordion sections */}
         <div
           style={{
             flex: 1,
             overflow: 'auto',
-            padding: '16px',
+            padding: '8px 12px',
           }}>
-          {renderTokenEditor()}
+          <XDSCollapsibleGroup type="multiple" defaultValue={['colors']}>
+            <XDSVStack gap={0.5}>
+              {(Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).map(groupKey => {
+                const group = TOKEN_GROUPS[groupKey];
+                const dotColor =
+                  SECTION_DOT_COLORS[groupKey] || 'var(--color-accent)';
+                const modified = modifiedCount(group.tokens);
+
+                return (
+                  <XDSCollapsible
+                    key={groupKey}
+                    value={groupKey}
+                    defaultIsOpen={groupKey === 'colors'}
+                    trigger={
+                      <XDSHStack
+                        gap={2}
+                        vAlign="center"
+                        style={{width: '100%'}}>
+                        <div
+                          style={{
+                            width: '8px',
+                            height: '8px',
+                            borderRadius: '50%',
+                            backgroundColor: dotColor,
+                            flexShrink: 0,
+                          }}
+                        />
+                        <XDSText
+                          type="label"
+                          style={{flex: 1, textAlign: 'start'}}>
+                          {group.label}
+                        </XDSText>
+                        {modified > 0 && (
+                          <XDSBadge variant="info">{modified}</XDSBadge>
+                        )}
+                      </XDSHStack>
+                    }>
+                    <div style={{padding: '4px 0 8px'}}>
+                      {sectionRenderers[groupKey]()}
+                    </div>
+                  </XDSCollapsible>
+                );
+              })}
+            </XDSVStack>
+          </XDSCollapsibleGroup>
         </div>
 
-        {/* Actions */}
+        {/* Bottom actions */}
         <div
           style={{
-            padding: '16px',
+            padding: '12px 16px',
             borderTop: '1px solid var(--color-border)',
             display: 'flex',
             gap: '8px',
           }}>
-          <XDSButton label="Reset All" variant="ghost" onClick={handleReset} />
           <XDSButton
-            label={showCode ? 'Hide Code' : 'Export Code'}
+            label="Reset"
             variant="secondary"
+            size="sm"
+            onClick={handleReset}
+            style={{flex: 1}}
+          />
+          <XDSButton
+            label={showCode ? 'Hide code' : 'View code →'}
+            variant="primary"
+            size="sm"
             onClick={() => setShowCode(!showCode)}
+            style={{flex: 1}}
           />
         </div>
       </div>
 
-      {/* Right Panel - Preview */}
+      {/* ================================================================= */}
+      {/* Right Panel — Live Preview                                        */}
+      {/* ================================================================= */}
       <div
         style={{
           flex: 1,
@@ -1869,7 +1942,7 @@ function ThemeEditorComponent() {
             justifyContent: 'space-between',
           }}>
           <XDSHeading level={4}>Live Preview</XDSHeading>
-          <div style={{display: 'flex', gap: '4px'}}>
+          <XDSHStack gap={1}>
             <XDSButton
               label="Light"
               variant={mode === 'light' ? 'primary' : 'ghost'}
@@ -1882,7 +1955,7 @@ function ThemeEditorComponent() {
               size="sm"
               onClick={() => setMode('dark')}
             />
-          </div>
+          </XDSHStack>
         </div>
 
         {/* Code panel (collapsible) */}
@@ -1895,9 +1968,7 @@ function ThemeEditorComponent() {
               maxHeight: '300px',
               overflow: 'auto',
             }}>
-            <XDSText
-              type="label"
-              style={{marginBottom: '8px', display: 'block'}}>
+            <XDSText type="label" display="block" style={{marginBottom: '8px'}}>
               Generated Theme Code
             </XDSText>
             <pre
@@ -1924,11 +1995,7 @@ function ThemeEditorComponent() {
         )}
 
         {/* Preview content */}
-        <div
-          style={{
-            flex: 1,
-            overflow: 'auto',
-          }}>
+        <div style={{flex: 1, overflow: 'auto'}}>
           <XDSTheme theme={currentTheme} mode={mode}>
             <div
               style={{

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -1731,272 +1731,277 @@ function ThemeEditorComponent() {
   };
 
   return (
-    <div
-      style={{
-        display: 'flex',
-        position: 'fixed',
-        inset: 0,
-        overflow: 'hidden',
-        backgroundColor: 'var(--color-wash)',
-      }}>
-      {/* ================================================================= */}
-      {/* Left Panel — Accordion-based Token Editor                         */}
-      {/* ================================================================= */}
+    <XDSTheme theme={currentTheme} mode={mode}>
       <div
         style={{
-          width: '380px',
           display: 'flex',
-          flexDirection: 'column',
-          backgroundColor: 'var(--color-surface)',
-          borderRight: '1px solid var(--color-border)',
+          position: 'fixed',
+          inset: 0,
           overflow: 'hidden',
+          backgroundColor: 'var(--color-wash)',
         }}>
-        {/* Panel header — shows editable theme name */}
+        {/* ================================================================= */}
+        {/* Left Panel — Accordion-based Token Editor                         */}
+        {/* ================================================================= */}
         <div
           style={{
-            padding: '16px 20px 12px',
+            width: '380px',
             display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            borderBottom: '1px solid var(--color-border)',
+            flexDirection: 'column',
+            backgroundColor: 'var(--color-surface)',
+            borderRight: '1px solid var(--color-border)',
+            overflow: 'hidden',
           }}>
-          {isEditingName ? (
-            <input
-              autoFocus
-              type="text"
-              value={themeName}
-              onChange={e => setThemeName(e.target.value)}
-              onBlur={() => setIsEditingName(false)}
-              onKeyDown={e => {
-                if (e.key === 'Enter') setIsEditingName(false);
-              }}
-              style={{
-                all: 'unset',
-                fontSize: 'var(--heading-3-size, 17px)',
-                fontWeight: 600,
-                color: 'var(--color-text-primary)',
-                borderBottom: '2px solid var(--color-accent)',
-                paddingBottom: '2px',
-                width: '160px',
-              }}
-            />
-          ) : (
-            <button
-              type="button"
-              onClick={() => setIsEditingName(true)}
-              style={{
-                all: 'unset',
-                cursor: 'pointer',
-                fontSize: 'var(--heading-3-size, 17px)',
-                fontWeight: 600,
-                fontFamily: 'var(--font-heading, var(--font-body))',
-                color: 'var(--color-text-primary)',
-                lineHeight: 'var(--heading-3-leading, 1.3)',
-              }}>
-              {themeName} Theme
-            </button>
-          )}
-          <XDSHStack gap={1} vAlign="center">
-            <button
-              type="button"
-              onClick={() => setShowSearch(!showSearch)}
-              style={{
-                all: 'unset',
-                cursor: 'pointer',
-                display: 'inline-flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                width: '32px',
-                height: '32px',
-                borderRadius: '6px',
-                color: 'var(--color-icon-secondary)',
-              }}
-              title="Search tokens">
-              <XDSIcon icon="search" size="sm" color="secondary" />
-            </button>
-            {/* Mode toggle */}
-            <XDSButton
-              label={mode === 'light' ? '☀' : '☾'}
-              variant="ghost"
-              size="sm"
-              onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
-            />
-          </XDSHStack>
-        </div>
-
-        {/* Search bar — expandable */}
-        {showSearch && (
+          {/* Panel header — shows editable theme name */}
           <div
             style={{
-              padding: '8px 16px',
+              padding: '16px 20px 12px',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
               borderBottom: '1px solid var(--color-border)',
             }}>
-            <XDSTextInput
-              label="Search tokens"
-              isLabelHidden
-              placeholder="Search tokens…"
-              value={searchQuery}
-              onChange={setSearchQuery}
+            {isEditingName ? (
+              <input
+                autoFocus
+                type="text"
+                value={themeName}
+                onChange={e => setThemeName(e.target.value)}
+                onBlur={() => setIsEditingName(false)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') setIsEditingName(false);
+                }}
+                style={{
+                  all: 'unset',
+                  fontSize: 'var(--heading-3-size, 17px)',
+                  fontWeight: 600,
+                  color: 'var(--color-text-primary)',
+                  borderBottom: '2px solid var(--color-accent)',
+                  paddingBottom: '2px',
+                  width: '160px',
+                }}
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setIsEditingName(true)}
+                style={{
+                  all: 'unset',
+                  cursor: 'pointer',
+                  fontSize: 'var(--heading-3-size, 17px)',
+                  fontWeight: 600,
+                  fontFamily: 'var(--font-heading, var(--font-body))',
+                  color: 'var(--color-text-primary)',
+                  lineHeight: 'var(--heading-3-leading, 1.3)',
+                }}>
+                {themeName} Theme
+              </button>
+            )}
+            <XDSHStack gap={1} vAlign="center">
+              <button
+                type="button"
+                onClick={() => setShowSearch(!showSearch)}
+                style={{
+                  all: 'unset',
+                  cursor: 'pointer',
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  width: '32px',
+                  height: '32px',
+                  borderRadius: '6px',
+                  color: 'var(--color-icon-secondary)',
+                }}
+                title="Search tokens">
+                <XDSIcon icon="search" size="sm" color="secondary" />
+              </button>
+              {/* Mode toggle */}
+              <XDSButton
+                label={mode === 'light' ? '☀' : '☾'}
+                variant="ghost"
+                size="sm"
+                onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
+              />
+            </XDSHStack>
+          </div>
+
+          {/* Search bar — expandable */}
+          {showSearch && (
+            <div
+              style={{
+                padding: '8px 16px',
+                borderBottom: '1px solid var(--color-border)',
+              }}>
+              <XDSTextInput
+                label="Search tokens"
+                isLabelHidden
+                placeholder="Search tokens…"
+                value={searchQuery}
+                onChange={setSearchQuery}
+                size="sm"
+              />
+            </div>
+          )}
+
+          {/* Accordion sections */}
+          <div
+            style={{
+              flex: 1,
+              overflow: 'auto',
+              padding: '8px 12px',
+            }}>
+            <XDSCollapsibleGroup type="multiple" defaultValue={['colors']}>
+              <XDSVStack gap={0.5}>
+                {(Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).map(
+                  groupKey => {
+                    const group = TOKEN_GROUPS[groupKey];
+                    const dotColor =
+                      SECTION_DOT_COLORS[groupKey] || 'var(--color-accent)';
+                    const modified = modifiedCount(group.tokens);
+
+                    return (
+                      <XDSCollapsible
+                        key={groupKey}
+                        value={groupKey}
+                        defaultIsOpen={groupKey === 'colors'}
+                        trigger={
+                          <XDSHStack
+                            gap={2}
+                            vAlign="center"
+                            style={{width: '100%'}}>
+                            <div
+                              style={{
+                                width: '8px',
+                                height: '8px',
+                                borderRadius: '50%',
+                                backgroundColor: dotColor,
+                                flexShrink: 0,
+                              }}
+                            />
+                            <XDSText
+                              type="label"
+                              style={{flex: 1, textAlign: 'start'}}>
+                              {group.label}
+                            </XDSText>
+                            {modified > 0 && (
+                              <XDSBadge variant="info">{modified}</XDSBadge>
+                            )}
+                          </XDSHStack>
+                        }>
+                        <div style={{padding: '4px 0 8px'}}>
+                          {sectionRenderers[groupKey]()}
+                        </div>
+                      </XDSCollapsible>
+                    );
+                  },
+                )}
+              </XDSVStack>
+            </XDSCollapsibleGroup>
+          </div>
+
+          {/* Bottom actions */}
+          <div
+            style={{
+              padding: '12px 16px',
+              borderTop: '1px solid var(--color-border)',
+              display: 'flex',
+              gap: '8px',
+            }}>
+            <XDSButton
+              label="Reset"
+              variant="secondary"
               size="sm"
+              onClick={handleReset}
+              style={{flex: 1}}
+            />
+            <XDSButton
+              label={showCode ? 'Hide code' : 'View code →'}
+              variant="primary"
+              size="sm"
+              onClick={() => setShowCode(!showCode)}
+              style={{flex: 1}}
             />
           </div>
-        )}
+        </div>
 
-        {/* Accordion sections */}
+        {/* ================================================================= */}
+        {/* Right Panel — Live Preview                                        */}
+        {/* ================================================================= */}
         <div
           style={{
             flex: 1,
-            overflow: 'auto',
-            padding: '8px 12px',
-          }}>
-          <XDSCollapsibleGroup type="multiple" defaultValue={['colors']}>
-            <XDSVStack gap={0.5}>
-              {(Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).map(groupKey => {
-                const group = TOKEN_GROUPS[groupKey];
-                const dotColor =
-                  SECTION_DOT_COLORS[groupKey] || 'var(--color-accent)';
-                const modified = modifiedCount(group.tokens);
-
-                return (
-                  <XDSCollapsible
-                    key={groupKey}
-                    value={groupKey}
-                    defaultIsOpen={groupKey === 'colors'}
-                    trigger={
-                      <XDSHStack
-                        gap={2}
-                        vAlign="center"
-                        style={{width: '100%'}}>
-                        <div
-                          style={{
-                            width: '8px',
-                            height: '8px',
-                            borderRadius: '50%',
-                            backgroundColor: dotColor,
-                            flexShrink: 0,
-                          }}
-                        />
-                        <XDSText
-                          type="label"
-                          style={{flex: 1, textAlign: 'start'}}>
-                          {group.label}
-                        </XDSText>
-                        {modified > 0 && (
-                          <XDSBadge variant="info">{modified}</XDSBadge>
-                        )}
-                      </XDSHStack>
-                    }>
-                    <div style={{padding: '4px 0 8px'}}>
-                      {sectionRenderers[groupKey]()}
-                    </div>
-                  </XDSCollapsible>
-                );
-              })}
-            </XDSVStack>
-          </XDSCollapsibleGroup>
-        </div>
-
-        {/* Bottom actions */}
-        <div
-          style={{
-            padding: '12px 16px',
-            borderTop: '1px solid var(--color-border)',
             display: 'flex',
-            gap: '8px',
+            flexDirection: 'column',
+            overflow: 'hidden',
           }}>
-          <XDSButton
-            label="Reset"
-            variant="secondary"
-            size="sm"
-            onClick={handleReset}
-            style={{flex: 1}}
-          />
-          <XDSButton
-            label={showCode ? 'Hide code' : 'View code →'}
-            variant="primary"
-            size="sm"
-            onClick={() => setShowCode(!showCode)}
-            style={{flex: 1}}
-          />
-        </div>
-      </div>
-
-      {/* ================================================================= */}
-      {/* Right Panel — Live Preview                                        */}
-      {/* ================================================================= */}
-      <div
-        style={{
-          flex: 1,
-          display: 'flex',
-          flexDirection: 'column',
-          overflow: 'hidden',
-        }}>
-        {/* Preview header */}
-        <div
-          style={{
-            padding: '12px 24px',
-            borderBottom: '1px solid var(--color-border)',
-            backgroundColor: 'var(--color-surface)',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-          }}>
-          <XDSHeading level={4}>Live Preview</XDSHeading>
-          <XDSHStack gap={1}>
-            <XDSButton
-              label="Light"
-              variant={mode === 'light' ? 'primary' : 'ghost'}
-              size="sm"
-              onClick={() => setMode('light')}
-            />
-            <XDSButton
-              label="Dark"
-              variant={mode === 'dark' ? 'primary' : 'ghost'}
-              size="sm"
-              onClick={() => setMode('dark')}
-            />
-          </XDSHStack>
-        </div>
-
-        {/* Code panel (collapsible) */}
-        {showCode && (
+          {/* Preview header */}
           <div
             style={{
-              padding: '16px 24px',
+              padding: '12px 24px',
               borderBottom: '1px solid var(--color-border)',
-              backgroundColor: 'var(--color-wash)',
-              maxHeight: '300px',
-              overflow: 'auto',
+              backgroundColor: 'var(--color-surface)',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
             }}>
-            <XDSText type="label" display="block" style={{marginBottom: '8px'}}>
-              Generated Theme Code
-            </XDSText>
-            <pre
-              style={{
-                padding: '16px',
-                borderRadius: '8px',
-                backgroundColor: 'var(--color-surface)',
-                border: '1px solid var(--color-border-emphasized)',
-                fontSize: '12px',
-                fontFamily: 'var(--font-code)',
-                overflow: 'auto',
-                margin: 0,
-                color: 'var(--color-text-primary)',
-              }}>
-              {generateThemeCode(
-                themeName,
-                tokens,
-                allDefaults,
-                typeScaleBase,
-                typeScaleRatio,
-              )}
-            </pre>
+            <XDSHeading level={4}>Live Preview</XDSHeading>
+            <XDSHStack gap={1}>
+              <XDSButton
+                label="Light"
+                variant={mode === 'light' ? 'primary' : 'ghost'}
+                size="sm"
+                onClick={() => setMode('light')}
+              />
+              <XDSButton
+                label="Dark"
+                variant={mode === 'dark' ? 'primary' : 'ghost'}
+                size="sm"
+                onClick={() => setMode('dark')}
+              />
+            </XDSHStack>
           </div>
-        )}
 
-        {/* Preview content */}
-        <div style={{flex: 1, overflow: 'auto'}}>
-          <XDSTheme theme={currentTheme} mode={mode}>
+          {/* Code panel (collapsible) */}
+          {showCode && (
+            <div
+              style={{
+                padding: '16px 24px',
+                borderBottom: '1px solid var(--color-border)',
+                backgroundColor: 'var(--color-wash)',
+                maxHeight: '300px',
+                overflow: 'auto',
+              }}>
+              <XDSText
+                type="label"
+                display="block"
+                style={{marginBottom: '8px'}}>
+                Generated Theme Code
+              </XDSText>
+              <pre
+                style={{
+                  padding: '16px',
+                  borderRadius: '8px',
+                  backgroundColor: 'var(--color-surface)',
+                  border: '1px solid var(--color-border-emphasized)',
+                  fontSize: '12px',
+                  fontFamily: 'var(--font-code)',
+                  overflow: 'auto',
+                  margin: 0,
+                  color: 'var(--color-text-primary)',
+                }}>
+                {generateThemeCode(
+                  themeName,
+                  tokens,
+                  allDefaults,
+                  typeScaleBase,
+                  typeScaleRatio,
+                )}
+              </pre>
+            </div>
+          )}
+
+          {/* Preview content */}
+          <div style={{flex: 1, overflow: 'auto'}}>
             <div
               style={{
                 backgroundColor: 'var(--color-surface)',
@@ -2004,10 +2009,10 @@ function ThemeEditorComponent() {
               }}>
               <ComponentPreview />
             </div>
-          </XDSTheme>
+          </div>
         </div>
       </div>
-    </div>
+    </XDSTheme>
   );
 }
 
@@ -2032,8 +2037,8 @@ type Story = StoryObj;
 export const ThemeEditor: Story = {
   render: () => <ThemeEditorComponent />,
   parameters: {
-    // Use default theme for the editor chrome (left panel).
-    // The preview panel wraps its own <XDSTheme theme={currentTheme}>.
-    xdsTheme: 'default',
+    // The entire editor (both panels) is wrapped in <XDSTheme>
+    // so the editor chrome reflects token changes in real-time.
+    xdsTheme: 'none',
   },
 };

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -1308,6 +1308,7 @@ function ThemeEditorComponent() {
   const [showCode, setShowCode] = React.useState(false);
   const [searchQuery, setSearchQuery] = React.useState('');
   const [showSearch, setShowSearch] = React.useState(false);
+  const [isPanelCollapsed, setIsPanelCollapsed] = React.useState(false);
 
   // Collect all defaults
   const allDefaults = React.useMemo(
@@ -1758,65 +1759,32 @@ function ThemeEditorComponent() {
           backgroundColor: 'var(--color-wash)',
         }}>
         {/* ================================================================= */}
-        {/* Left Panel — Accordion-based Token Editor                         */}
+        {/* Left Panel — Accordion-based Token Editor (collapsible)           */}
         {/* ================================================================= */}
         <div
           style={{
-            width: '380px',
+            width: isPanelCollapsed ? '48px' : '380px',
+            transition: 'width 0.2s ease',
             display: 'flex',
             flexDirection: 'column',
             backgroundColor: 'var(--color-surface)',
             borderRight: '1px solid var(--color-border)',
             overflow: 'hidden',
+            flexShrink: 0,
           }}>
-          {/* Panel header — shows editable theme name */}
-          <div
-            style={{
-              padding: '16px 20px 12px',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-            }}>
-            {isEditingName ? (
-              <input
-                autoFocus
-                type="text"
-                value={themeName}
-                onChange={e => setThemeName(e.target.value)}
-                onBlur={() => setIsEditingName(false)}
-                onKeyDown={e => {
-                  if (e.key === 'Enter') setIsEditingName(false);
-                }}
-                style={{
-                  all: 'unset',
-                  fontSize: 'var(--heading-3-size, 17px)',
-                  fontWeight: 600,
-                  color: 'var(--color-text-primary)',
-                  borderBottom: '2px solid var(--color-accent)',
-                  paddingBottom: '2px',
-                  width: '160px',
-                }}
-              />
-            ) : (
+          {isPanelCollapsed ? (
+            /* Collapsed state — just a vertical strip with expand button */
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                paddingTop: '12px',
+                gap: '8px',
+              }}>
               <button
                 type="button"
-                onClick={() => setIsEditingName(true)}
-                style={{
-                  all: 'unset',
-                  cursor: 'pointer',
-                  fontSize: 'var(--heading-3-size, 17px)',
-                  fontWeight: 600,
-                  fontFamily: 'var(--font-heading, var(--font-body))',
-                  color: 'var(--color-text-primary)',
-                  lineHeight: 'var(--heading-3-leading, 1.3)',
-                }}>
-                {themeName} Theme
-              </button>
-            )}
-            <XDSHStack gap={1} vAlign="center">
-              <button
-                type="button"
-                onClick={() => setShowSearch(!showSearch)}
+                onClick={() => setIsPanelCollapsed(false)}
                 style={{
                   all: 'unset',
                   cursor: 'pointer',
@@ -1828,118 +1796,203 @@ function ThemeEditorComponent() {
                   borderRadius: '6px',
                   color: 'var(--color-icon-secondary)',
                 }}
-                title="Search tokens">
-                <XDSIcon icon="search" size="sm" color="secondary" />
+                title="Expand editor panel">
+                <XDSIcon icon="chevronRight" size="sm" color="secondary" />
               </button>
-              {/* Mode toggle */}
-              <XDSButton
-                label={mode === 'light' ? '☀' : '☾'}
-                variant="ghost"
-                size="sm"
-                onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
-              />
-            </XDSHStack>
-          </div>
-
-          {/* Search bar — expandable */}
-          {showSearch && (
-            <div
-              style={{
-                padding: '8px 16px',
-                borderBottom: '1px solid var(--color-border)',
-              }}>
-              <XDSTextInput
-                label="Search tokens"
-                isLabelHidden
-                placeholder="Search tokens…"
-                value={searchQuery}
-                onChange={setSearchQuery}
-                size="sm"
-              />
             </div>
-          )}
-
-          {/* Accordion sections */}
-          <div
-            style={{
-              flex: 1,
-              overflow: 'auto',
-              padding: '8px 12px',
-            }}>
-            <XDSCollapsibleGroup
-              type="multiple"
-              defaultValue={
-                searchQuery
-                  ? (Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).filter(k =>
-                      groupHasSearchMatch(k),
-                    )
-                  : ['colors']
-              }>
-              <XDSVStack gap={0.5}>
-                {(Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).map(
-                  groupKey => {
-                    const group = TOKEN_GROUPS[groupKey];
-                    const modified = modifiedCount(group.tokens);
-
-                    // Hide sections with no search matches
-                    if (searchQuery && !groupHasSearchMatch(groupKey)) {
-                      return null;
-                    }
-
-                    return (
-                      <XDSCollapsible
-                        key={groupKey}
-                        value={groupKey}
-                        defaultIsOpen={groupKey === 'colors'}
-                        trigger={
-                          <XDSHStack
-                            gap={2}
-                            vAlign="center"
-                            style={{width: '100%'}}>
-                            <XDSText
-                              type="label"
-                              style={{flex: 1, textAlign: 'start'}}>
-                              {group.label}
-                            </XDSText>
-                            {modified > 0 && (
-                              <XDSBadge variant="info">{modified}</XDSBadge>
-                            )}
-                          </XDSHStack>
-                        }>
-                        <div style={{padding: '4px 0 8px'}}>
-                          {sectionRenderers[groupKey]()}
-                        </div>
-                      </XDSCollapsible>
-                    );
-                  },
+          ) : (
+            <>
+              {/* Panel header — shows editable theme name */}
+              <div
+                style={{
+                  padding: '16px 20px 12px',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                }}>
+                {isEditingName ? (
+                  <input
+                    autoFocus
+                    type="text"
+                    value={themeName}
+                    onChange={e => setThemeName(e.target.value)}
+                    onBlur={() => setIsEditingName(false)}
+                    onKeyDown={e => {
+                      if (e.key === 'Enter') setIsEditingName(false);
+                    }}
+                    style={{
+                      all: 'unset',
+                      fontSize: 'var(--heading-3-size, 17px)',
+                      fontWeight: 600,
+                      color: 'var(--color-text-primary)',
+                      borderBottom: '2px solid var(--color-accent)',
+                      paddingBottom: '2px',
+                      width: '160px',
+                    }}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setIsEditingName(true)}
+                    style={{
+                      all: 'unset',
+                      cursor: 'pointer',
+                      fontSize: 'var(--heading-3-size, 17px)',
+                      fontWeight: 600,
+                      fontFamily: 'var(--font-heading, var(--font-body))',
+                      color: 'var(--color-text-primary)',
+                      lineHeight: 'var(--heading-3-leading, 1.3)',
+                    }}>
+                    {themeName} Theme
+                  </button>
                 )}
-              </XDSVStack>
-            </XDSCollapsibleGroup>
-          </div>
+                <XDSHStack gap={0.5} vAlign="center">
+                  <button
+                    type="button"
+                    onClick={() => setShowSearch(!showSearch)}
+                    style={{
+                      all: 'unset',
+                      cursor: 'pointer',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: '32px',
+                      height: '32px',
+                      borderRadius: '6px',
+                      color: 'var(--color-icon-secondary)',
+                    }}
+                    title="Search tokens">
+                    <XDSIcon icon="search" size="sm" color="secondary" />
+                  </button>
+                  {/* Mode toggle */}
+                  <XDSButton
+                    label={mode === 'light' ? '☀' : '☾'}
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setMode(mode === 'light' ? 'dark' : 'light')}
+                  />
+                  {/* Collapse panel */}
+                  <button
+                    type="button"
+                    onClick={() => setIsPanelCollapsed(true)}
+                    style={{
+                      all: 'unset',
+                      cursor: 'pointer',
+                      display: 'inline-flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      width: '32px',
+                      height: '32px',
+                      borderRadius: '6px',
+                      color: 'var(--color-icon-secondary)',
+                    }}
+                    title="Collapse panel">
+                    <XDSIcon icon="chevronLeft" size="sm" color="secondary" />
+                  </button>
+                </XDSHStack>
+              </div>
 
-          {/* Bottom actions */}
-          <div
-            style={{
-              padding: '12px 16px',
-              borderTop: '1px solid var(--color-border)',
-              display: 'flex',
-              gap: '8px',
-            }}>
-            <XDSButton
-              label="Reset"
-              variant="secondary"
-              size="sm"
-              onClick={handleReset}
-              style={{flex: 1}}
-            />
-            <XDSButton
-              label={showCode ? 'Hide code' : 'View code →'}
-              variant="primary"
-              size="sm"
-              onClick={() => setShowCode(!showCode)}
-              style={{flex: 1}}
-            />
-          </div>
+              {/* Search bar — expandable */}
+              {showSearch && (
+                <div
+                  style={{
+                    padding: '8px 16px',
+                    borderBottom: '1px solid var(--color-border)',
+                  }}>
+                  <XDSTextInput
+                    label="Search tokens"
+                    isLabelHidden
+                    placeholder="Search tokens…"
+                    value={searchQuery}
+                    onChange={setSearchQuery}
+                    size="sm"
+                  />
+                </div>
+              )}
+
+              {/* Accordion sections */}
+              <div
+                style={{
+                  flex: 1,
+                  overflow: 'auto',
+                  padding: '8px 12px',
+                }}>
+                <XDSCollapsibleGroup
+                  type="multiple"
+                  defaultValue={
+                    searchQuery
+                      ? (Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).filter(
+                          k => groupHasSearchMatch(k),
+                        )
+                      : ['colors']
+                  }>
+                  <XDSVStack gap={0.5}>
+                    {(Object.keys(TOKEN_GROUPS) as TokenGroupKey[]).map(
+                      groupKey => {
+                        const group = TOKEN_GROUPS[groupKey];
+                        const modified = modifiedCount(group.tokens);
+
+                        // Hide sections with no search matches
+                        if (searchQuery && !groupHasSearchMatch(groupKey)) {
+                          return null;
+                        }
+
+                        return (
+                          <XDSCollapsible
+                            key={groupKey}
+                            value={groupKey}
+                            defaultIsOpen={groupKey === 'colors'}
+                            trigger={
+                              <XDSHStack
+                                gap={2}
+                                vAlign="center"
+                                style={{width: '100%'}}>
+                                <XDSText
+                                  type="label"
+                                  style={{flex: 1, textAlign: 'start'}}>
+                                  {group.label}
+                                </XDSText>
+                                {modified > 0 && (
+                                  <XDSBadge variant="info">{modified}</XDSBadge>
+                                )}
+                              </XDSHStack>
+                            }>
+                            <div style={{padding: '4px 0 8px'}}>
+                              {sectionRenderers[groupKey]()}
+                            </div>
+                          </XDSCollapsible>
+                        );
+                      },
+                    )}
+                  </XDSVStack>
+                </XDSCollapsibleGroup>
+              </div>
+
+              {/* Bottom actions */}
+              <div
+                style={{
+                  padding: '12px 16px',
+                  borderTop: '1px solid var(--color-border)',
+                  display: 'flex',
+                  gap: '8px',
+                }}>
+                <XDSButton
+                  label="Reset"
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleReset}
+                  style={{flex: 1}}
+                />
+                <XDSButton
+                  label={showCode ? 'Hide code' : 'View code →'}
+                  variant="primary"
+                  size="sm"
+                  onClick={() => setShowCode(!showCode)}
+                  style={{flex: 1}}
+                />
+              </div>
+            </>
+          )}
         </div>
 
         {/* ================================================================= */}


### PR DESCRIPTION
## Summary

Redesigns the Theme Editor's left panel from flat button tabs to an accordion-based layout, matching the new design mockup.

### Changes

**Panel structure:**
- Replaced flat button tabs with `XDSCollapsibleGroup` accordion sections
- Each token group (Colors, Spacing, Radius, Typography, Size, Elevation, Duration, Easing) is a collapsible section
- Colored dot indicators differentiate each section at a glance
- Modified token count shown via `XDSBadge` on each section header

**Panel header:**
- Shows editable theme name (click to rename, e.g. "Custom Theme")
- Search icon toggles an expandable search bar that filters tokens across all sections
- Light/dark mode toggle icon

**Color tokens:**
- Sub-categories (Text, Icon, Core Semantic, etc.) rendered as uppercase section headings within the Colors accordion
- Compact color swatch layout: rounded swatch + label + hex input + alpha percentage
- Click swatch to open native color picker

**Typography:**
- Retains type scale preset buttons (Functional, Default, Editorial) and category selector
- Sample text preview in an `XDSCard`

**Bottom bar:**
- Reset (secondary) and View Code (primary) buttons

### XDS Components Used

`XDSCollapsible`, `XDSCollapsibleGroup`, `XDSIcon`, `XDSVStack`, `XDSHStack`, `XDSBadge`, `XDSCard`, `XDSText`, `XDSHeading`, `XDSButton`, `XDSSelector`, `XDSTextInput`
