### PR TITLE
fix(theming): use XDSDivider in List, tokenize MobileNav header height — theme audit batch

### DIFF
--- a/packages/core/src/List/XDSList.test.tsx
+++ b/packages/core/src/List/XDSList.test.tsx
@@ -213,19 +213,20 @@ describe('XDSList', () => {
         <XDSListItem label="Item 3" />
       </XDSList>,
     );
-    const dividers = container.querySelectorAll('hr');
+    const dividers = container.querySelectorAll('[role="separator"]');
     expect(dividers).toHaveLength(2);
   });
 
-  it('dividers have aria-hidden="true"', () => {
+  it('dividers use XDSDivider with role="separator"', () => {
     const {container} = render(
       <XDSList hasDividers>
         <XDSListItem label="Item 1" />
         <XDSListItem label="Item 2" />
       </XDSList>,
     );
-    const divider = container.querySelector('hr');
-    expect(divider).toHaveAttribute('aria-hidden', 'true');
+    const divider = container.querySelector('[role="separator"]');
+    expect(divider).toBeTruthy();
+    expect(divider).toHaveAttribute('aria-orientation', 'horizontal');
   });
 
   it('does not render dividers when hasDividers is false', () => {
@@ -235,7 +236,7 @@ describe('XDSList', () => {
         <XDSListItem label="Item 2" />
       </XDSList>,
     );
-    const dividers = container.querySelectorAll('hr');
+    const dividers = container.querySelectorAll('[role="separator"]');
     expect(dividers).toHaveLength(0);
   });
 

--- a/packages/core/src/List/XDSList.test.tsx
+++ b/packages/core/src/List/XDSList.test.tsx
@@ -213,20 +213,27 @@ describe('XDSList', () => {
         <XDSListItem label="Item 3" />
       </XDSList>,
     );
-    const dividers = container.querySelectorAll('[role="separator"]');
-    expect(dividers).toHaveLength(2);
+    // Dividers are rendered as borders on <li> elements, not separate DOM nodes
+    const items = container.querySelectorAll('li');
+    expect(items).toHaveLength(3);
+    // No <hr> elements should exist
+    const hrs = container.querySelectorAll('hr');
+    expect(hrs).toHaveLength(0);
   });
 
-  it('dividers use XDSDivider with role="separator"', () => {
+  it('does not add extra DOM elements for dividers', () => {
     const {container} = render(
       <XDSList hasDividers>
         <XDSListItem label="Item 1" />
         <XDSListItem label="Item 2" />
       </XDSList>,
     );
-    const divider = container.querySelector('[role="separator"]');
-    expect(divider).toBeTruthy();
-    expect(divider).toHaveAttribute('aria-orientation', 'horizontal');
+    const list = container.querySelector('ul');
+    // Only <li> children — no <hr> or other divider elements
+    const children = list?.children;
+    expect(children).toHaveLength(2);
+    expect(children?.[0]?.tagName).toBe('LI');
+    expect(children?.[1]?.tagName).toBe('LI');
   });
 
   it('does not render dividers when hasDividers is false', () => {
@@ -236,8 +243,8 @@ describe('XDSList', () => {
         <XDSListItem label="Item 2" />
       </XDSList>,
     );
-    const dividers = container.querySelectorAll('[role="separator"]');
-    expect(dividers).toHaveLength(0);
+    const hrs = container.querySelectorAll('hr');
+    expect(hrs).toHaveLength(0);
   });
 
   // ===========================================================================

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -13,12 +13,11 @@
 
 'use client';
 
-import {useId, useMemo, Children, type ReactNode} from 'react';
+import {useId, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {XDSListContext, type XDSListDensity} from './XDSListContext';
-import {XDSDivider} from '../Divider';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -109,9 +108,6 @@ const styles = stylex.create({
   header: {
     marginBottom: spacingVars['--spacing-2'],
   },
-  divider: {
-    marginBlock: 0,
-  },
 });
 
 const listStyleTypes = stylex.create({
@@ -173,22 +169,6 @@ export function XDSList({
     [density, hasDividers, hasMarkers],
   );
 
-  // Interleave dividers between children when hasDividers is true
-  let renderedChildren = children;
-  if (hasDividers) {
-    const childArray = Children.toArray(children);
-    const withDividers: ReactNode[] = [];
-    childArray.forEach((child, i) => {
-      withDividers.push(child);
-      if (i < childArray.length - 1) {
-        withDividers.push(
-          <XDSDivider key={`divider-${i}`} xstyle={styles.divider} />,
-        );
-      }
-    });
-    renderedChildren = withDividers;
-  }
-
   return (
     <XDSListContext.Provider value={contextValue}>
       {header != null && (
@@ -212,7 +192,7 @@ export function XDSList({
           className,
           style,
         )}>
-        {renderedChildren}
+        {children}
       </Tag>
     </XDSListContext.Provider>
   );

--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -16,8 +16,9 @@
 import {useId, useMemo, Children, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {spacingVars} from '../theme/tokens.stylex';
 import {XDSListContext, type XDSListDensity} from './XDSListContext';
+import {XDSDivider} from '../Divider';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -109,10 +110,7 @@ const styles = stylex.create({
     marginBottom: spacingVars['--spacing-2'],
   },
   divider: {
-    height: '1px',
-    border: 'none',
-    margin: 0,
-    backgroundColor: colorVars['--color-border'],
+    marginBlock: 0,
   },
 });
 
@@ -184,11 +182,7 @@ export function XDSList({
       withDividers.push(child);
       if (i < childArray.length - 1) {
         withDividers.push(
-          <hr
-            key={`divider-${i}`}
-            aria-hidden="true"
-            {...stylex.props(styles.divider)}
-          />,
+          <XDSDivider key={`divider-${i}`} xstyle={styles.divider} />,
         );
       }
     });

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -147,6 +147,12 @@ const styles = stylex.create({
   noRadius: {
     borderRadius: 0,
   },
+  withDivider: {
+    borderBlockEnd: `1px solid ${colorVars['--color-border']}`,
+    ':last-child': {
+      borderBlockEnd: 'none',
+    },
+  },
   interactive: {
     cursor: 'pointer',
     transitionProperty: 'background-image',
@@ -374,6 +380,7 @@ export function XDSListItem({
           hasMarkers ? styles.itemWithMarker : styles.item,
           densityStyles[density],
           hasDividers ? styles.noRadius : styles.withRadius,
+          hasDividers && styles.withDivider,
           isInteractive && styles.interactive,
           isInteractive && styles.focusWithinOutline,
           isDisabled && styles.disabled,

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -137,7 +137,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    height: 48,
+    height: spacingVars['--spacing-12'],
     paddingInline: spacingVars['--spacing-2'],
     flexShrink: 0,
     borderBlockEndWidth: 1,


### PR DESCRIPTION
## Theme Audit Batch — 2026-03-19

### Components Audited

| Component | Status | Findings |
|-----------|--------|----------|
| **Link** | ✅ Clean | All tokens, XDSIcon/XDSText used, xdsClassName correct |
| **List** | 🔧 Fixed | Dividers used extra `<hr>` DOM nodes → border on `<li>` with color token |
| **MobileNav** | 🔧 Fixed | Hardcoded `height: 48` → `spacingVars['--spacing-12']` |
| **MoreMenu** | ✅ Clean | All tokens, uses XDSButton/XDSDropdownMenuItem/XDSDivider |
| **NavIcon** | ✅ Clean | Token usage correct, `borderRadius: '50%'` is geometric |

### Fixes

**1. XDSList — `<hr>` dividers → `borderBlockEnd` on `<li>`**
- Previously, `hasDividers` interleaved N-1 `<hr>` elements between list items
- Now uses `borderBlockEnd: 1px solid colorVars['--color-border']` on `<li>` with `:last-child` reset
- Eliminates extra DOM nodes — dividers are pure CSS on existing elements
- Border color uses the `--color-border` token for proper theming cascade

**2. XDSMobileNav — hardcoded header height → spacing token**
- Header `height: 48` replaced with `spacingVars['--spacing-12']` (same token TopNav uses for its 48px height)
- Ensures theme consumers can adjust navigation header height consistently

### Needs Review

None — both fixes are straightforward.

### Notes

- `opacity: 0.5` for disabled states (MoreMenu, ListItem, Button) is a consistent project-wide pattern, not a theming gap
- `borderRadius: '50%'` in NavIcon is a geometric circle shape, not a semantic radius
- `maxHeight: '300px'` / `minWidth: '160px'` in MoreMenu are layout constraints, not semantic spacing

---
