### PR TITLE
fix(Kbd): platform-aware mod key display

### DIFF
--- a/packages/core/src/Kbd/XDSKbd.test.tsx
+++ b/packages/core/src/Kbd/XDSKbd.test.tsx
@@ -2,6 +2,9 @@
  * @file XDSKbd.test.tsx
  * @input Uses React Testing Library, XDSKbd
  * @output Tests for XDSKbd component
+ *
+ * Note: Tests run in jsdom which reports a non-Mac platform,
+ * so `mod` resolves to "Ctrl" rather than "⌘".
  */
 
 import {render, screen} from '@testing-library/react';
@@ -16,9 +19,15 @@ describe('XDSKbd', () => {
 
   it('renders multiple keys separated by +', () => {
     render(<XDSKbd keys="mod+k" />);
-    // mod should render as ⌘
-    expect(screen.getByText('\u2318')).toBeInTheDocument();
+    // In jsdom (non-Mac), mod renders as "Ctrl"
+    expect(screen.getByText('Ctrl')).toBeInTheDocument();
     expect(screen.getByText('K')).toBeInTheDocument();
+  });
+
+  it('renders mod as Ctrl on non-Mac platforms', () => {
+    // jsdom is a non-Mac environment, so mod → Ctrl
+    render(<XDSKbd keys="mod" />);
+    expect(screen.getByText('Ctrl')).toBeInTheDocument();
   });
 
   it('maps modifier keys to symbols', () => {
@@ -52,7 +61,8 @@ describe('XDSKbd', () => {
 
   it('handles whitespace around keys', () => {
     render(<XDSKbd keys="mod + k" />);
-    expect(screen.getByText('\u2318')).toBeInTheDocument();
+    // In jsdom (non-Mac), mod renders as "Ctrl"
+    expect(screen.getByText('Ctrl')).toBeInTheDocument();
     expect(screen.getByText('K')).toBeInTheDocument();
   });
 

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -51,10 +51,26 @@ const styles = stylex.create({
 });
 
 /**
+ * Lazy platform detection — SSR-safe, cached after first call.
+ * Returns true on macOS, iPhone, iPad, iPod; false elsewhere (including SSR).
+ */
+let _isMac: boolean | null = null;
+function isMac(): boolean {
+  if (_isMac === null) {
+    _isMac =
+      typeof navigator !== 'undefined' &&
+      /Mac|iPhone|iPad|iPod/.test(
+        navigator.platform ?? navigator.userAgent ?? '',
+      );
+  }
+  return _isMac;
+}
+
+/**
  * Map of modifier key names to display symbols.
+ * Note: `mod` is not in this map — it resolves dynamically via `getKeyDisplay`.
  */
 const KEY_DISPLAY: Record<string, string> = {
-  mod: '\u2318', // ⌘
   ctrl: '\u2303', // ⌃
   alt: '\u2325', // ⌥
   shift: '\u21E7', // ⇧
@@ -67,6 +83,18 @@ const KEY_DISPLAY: Record<string, string> = {
   left: '\u2190',
   right: '\u2192',
 };
+
+/**
+ * Resolves a key name to its display string. Handles the platform-aware
+ * `mod` key (⌘ on macOS, Ctrl on other platforms) and falls back to
+ * KEY_DISPLAY or uppercased key name.
+ */
+function getKeyDisplay(key: string): string {
+  if (key === 'mod') {
+    return isMac() ? '\u2318' : 'Ctrl';
+  }
+  return KEY_DISPLAY[key] ?? key.toUpperCase();
+}
 
 export interface XDSKbdProps {
   /**
@@ -130,7 +158,7 @@ export function XDSKbd({keys, xstyle, className, style}: XDSKbdProps) {
       aria-hidden="true">
       {parts.map((key, i) => (
         <kbd key={i} {...stylex.props(styles.kbd)}>
-          {KEY_DISPLAY[key] ?? key.toUpperCase()}
+          {getKeyDisplay(key)}
         </kbd>
       ))}
     </span>


### PR DESCRIPTION
## Changes

Addresses P1 finding from hardening sprint #719:

- **P1: Always shows macOS ⌘, no platform detection** — The `mod` key now resolves to ⌘ on macOS and Ctrl on Windows/Linux. Detection is SSR-safe (guards `typeof navigator`) and cached after first call.

### Implementation

- Added `isMac()` helper with lazy evaluation: checks `navigator.platform` against `/Mac|iPhone|iPad|iPod/`, caches the result, and returns `false` during SSR (`typeof navigator === 'undefined'`)
- Added `getKeyDisplay()` function that handles the dynamic `mod` key resolution and falls back to the static `KEY_DISPLAY` map
- Removed `mod` from the static `KEY_DISPLAY` map — it's now resolved dynamically

### Test plan
- Updated existing tests for jsdom environment (non-Mac → expects `Ctrl`)
- Added new test for `mod` key rendering on non-Mac platforms
- All 10 tests pass
