### PR TITLE
fix(a11y): dangling aria-describedby in CheckboxInput & Switch

### DIFF
--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -330,8 +330,9 @@ export function XDSCheckboxInput({
   const isCheckedOrIndeterminate = isChecked || isIndeterminate;
 
   // Build aria-describedby from description and status message
+  // Only include descriptionID when the element actually renders
   const describedByParts: string[] = [];
-  if (description) describedByParts.push(descriptionID);
+  if (description && !isLabelHidden) describedByParts.push(descriptionID);
   if (status?.message) describedByParts.push(statusMessageID);
   const ariaDescribedBy =
     describedByParts.length > 0 ? describedByParts.join(' ') : undefined;

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -131,6 +131,9 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-gray-background'],
   },
   thumb: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     borderRadius: radiusVars['--radius-rounded'],
     backgroundColor: colorVars['--color-surface'],
     transitionProperty: 'transform, width, height',
@@ -304,8 +307,9 @@ export function XDSSwitch({
   const isOn = optimisticValue === true;
 
   // Build aria-describedby from description and status message
+  // Only include descriptionID when the element actually renders
   const describedByParts: string[] = [];
-  if (description) describedByParts.push(descriptionID);
+  if (description && !isLabelHidden) describedByParts.push(descriptionID);
   if (status?.message) describedByParts.push(statusMessageID);
   const ariaDescribedBy =
     describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
@@ -353,12 +357,7 @@ export function XDSSwitch({
           {...stylex.props(
             styles.thumb,
             isOn ? styles.thumbOn : styles.thumbOff,
-          )}
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}>
+          )}>
           {isBusy && <XDSSpinner size="sm" />}
         </div>
       </div>


### PR DESCRIPTION
Both CheckboxInput and Switch add the description element's ID to `aria-describedby` whenever a `description` prop is provided. But the actual `<span>` only renders when `description && !isLabelHidden`. So if you pass both `description` and `isLabelHidden`, screen readers get a dead reference.

Fixed by matching the `aria-describedby` condition to the render condition.

Also moved the Switch thumb's static inline `style` (display:flex, alignItems, justifyContent) into StyleX.

Hardening: #718
