### PR TITLE
fix: CheckboxInput & Switch hardening — swarm findings

### DIFF
--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -29,7 +29,10 @@ import {
   durationVars,
   easeVars,
   typographyVars,
+  lineHeightVars,
+  fontWeightVars,
 } from '../theme/tokens.stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
 import {XDSFieldStatus} from '../Field/XDSFieldStatus';
 import type {XDSIconType} from '../Icon';
@@ -40,7 +43,7 @@ import {xdsClassName, mergeProps} from '../utils';
 const styles = stylex.create({
   container: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: spacingVars['--spacing-2'],
   },
   containerLabelHidden: {
@@ -72,7 +75,10 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderRadius: radiusVars['--radius-1'],
     transitionProperty: 'background-color, border-color',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0.01s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   checkboxFocus: {
@@ -145,6 +151,8 @@ const styles = stylex.create({
   description: {
     fontFamily: typographyVars['--font-body'],
     fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-relaxed'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
   },
 });
@@ -194,18 +202,14 @@ const indeterminateSizeStyles = stylex.create({
 });
 
 const labelWrapperSizeStyles = stylex.create({
-  sm: {
-    marginTop: 1,
-  },
-  md: {
-    marginTop: 3,
-  },
+  sm: {},
+  md: {},
 });
 
 export type XDSCheckboxInputSize = keyof typeof wrapperSizeStyles;
 
-export interface XDSCheckboxInputProps {
-  /** Ref forwarded to the root element */
+export interface XDSCheckboxInputProps extends Omit<XDSBaseProps, 'onChange'> {
+  /** Ref forwarded to the underlying `<input>` element */
   ref?: React.Ref<HTMLInputElement>;
   /**
    * Label text for the checkbox (always rendered for accessibility).
@@ -315,6 +319,9 @@ export function XDSCheckboxInput({
   onBlur,
   labelIcon,
   status,
+  xstyle,
+  className,
+  style,
   ref,
 }: XDSCheckboxInputProps) {
   const id = useId();
@@ -338,7 +345,13 @@ export function XDSCheckboxInput({
     describedByParts.length > 0 ? describedByParts.join(' ') : undefined;
 
   return (
-    <div className={xdsClassName('checkbox-input', {size})}>
+    <div
+      {...mergeProps(
+        xdsClassName('checkbox-input', {size}),
+        stylex.props(xstyle),
+        className,
+        style,
+      )}>
       <div
         {...stylex.props(
           styles.container,
@@ -354,6 +367,10 @@ export function XDSCheckboxInput({
             disabled={isDisabled}
             required={isRequired}
             onChange={e => {
+              if (isBusy) {
+                e.preventDefault();
+                return;
+              }
               const checked = e.target.checked;
               onChange?.(checked, e);
               if (onChangeAction && !e.defaultPrevented) {
@@ -377,17 +394,20 @@ export function XDSCheckboxInput({
           />
           <div
             aria-hidden="true"
-            {...stylex.props(
-              styles.checkbox,
-              checkboxSizeStyles[size],
-              !isDisabled && styles.checkboxFocus,
-              isCheckedOrIndeterminate
-                ? styles.checkboxChecked
-                : styles.checkboxUnchecked,
-              isDisabled && styles.checkboxDisabled,
-              isDisabled &&
-                !isCheckedOrIndeterminate &&
-                styles.checkboxDisabledUnchecked,
+            {...mergeProps(
+              xdsClassName('checkbox'),
+              stylex.props(
+                styles.checkbox,
+                checkboxSizeStyles[size],
+                !isDisabled && styles.checkboxFocus,
+                isCheckedOrIndeterminate
+                  ? styles.checkboxChecked
+                  : styles.checkboxUnchecked,
+                isDisabled && styles.checkboxDisabled,
+                isDisabled &&
+                  !isCheckedOrIndeterminate &&
+                  styles.checkboxDisabledUnchecked,
+              ),
             )}>
             {isBusy ? (
               <XDSSpinner

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -29,6 +29,8 @@ import {
   easeVars,
   typographyVars,
   textSizeVars,
+  lineHeightVars,
+  fontWeightVars,
 } from '../theme/tokens.stylex';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
 import {XDSFieldStatus} from '../Field/XDSFieldStatus';
@@ -53,7 +55,7 @@ const THUMB_TRAVEL_ON =
 const styles = stylex.create({
   container: {
     display: 'flex',
-    alignItems: 'flex-start',
+    alignItems: 'center',
     gap: spacingVars['--spacing-2'],
   },
   containerSpread: {
@@ -92,7 +94,10 @@ const styles = stylex.create({
     padding: TRACK_PADDING,
     borderRadius: radiusVars['--radius-rounded'],
     transitionProperty: 'background-color',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0.01s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
     boxSizing: 'border-box',
   },
@@ -137,7 +142,10 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-rounded'],
     backgroundColor: colorVars['--color-surface'],
     transitionProperty: 'transform, width, height',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0.01s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   thumbOff: {
@@ -154,11 +162,12 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     gap: spacingVars['--spacing-0-5'],
-    marginTop: 3,
   },
   description: {
     fontFamily: typographyVars['--font-body'],
     fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-relaxed'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
   },
 });
@@ -325,6 +334,10 @@ export function XDSSwitch({
         disabled={isDisabled}
         required={isRequired}
         onChange={e => {
+          if (isBusy) {
+            e.preventDefault();
+            return;
+          }
           const checked = e.target.checked;
           onChange?.(checked, e);
           if (onChangeAction && !e.defaultPrevented) {
@@ -387,7 +400,7 @@ export function XDSSwitch({
   return (
     <div
       {...mergeProps(
-        xdsClassName('switch-field'),
+        xdsClassName('switch-field', {labelPosition, labelSpacing}),
         stylex.props(xstyle),
         className,
         style,


### PR DESCRIPTION
Hardening fixes for CheckboxInput and Switch from swarm audit (#718).

-----

### CheckboxInput

| Finding | Fix |
|---------|-----|
| No xstyle/className/style support (Switch has it) | Extend Omit<XDSBaseProps, 'onChange'>, wire up mergeProps on root div |
| mergeProps imported but never used | Now used on root div and visual checkbox |
| No xdsClassName on visual checkbox (Switch has one on track) | Add xdsClassName('checkbox') via mergeProps |
| Clickable during async action (Button disables, CheckboxInput didn't) | Guard onChange with isBusy check |
| Checkbox transition ignores prefers-reduced-motion | Add @media query with 0.01s (matches MobileNav) |
| Description style missing lineHeight/fontWeight | Add lineHeightVars and fontWeightVars |
| Ref JSDoc says "root element" but goes to input | Fix JSDoc |
| Checkbox not centered with label+description | alignItems center, remove marginTop nudges |

### Switch

| Finding | Fix |
|---------|-----|
| Clickable during async action | Same isBusy guard in onChange |
| Track + thumb transitions ignore prefers-reduced-motion | Add @media query, 0.01s |
| Description style missing lineHeight/fontWeight | Same tokens as CheckboxInput |
| xdsClassName('switch-field') has no variants | Add {labelPosition, labelSpacing} |
| Switch not centered with label+description | Same alignment fix as CheckboxInput |

-----

### Screenshots

#### CheckboxInput
| All Variations | Sizes | Status |
|---|---|---|
| ![all](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/checkbox-all.png) | ![sizes](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/checkbox-sizes.png) | ![status](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/checkbox-status.png) |

| Description | Indeterminate |
|---|---|
| ![desc](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/checkbox-description.png) | ![indet](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/checkbox-indeterminate.png) |

#### Switch
| All Variations | Spread Layout | Status |
|---|---|---|
| ![all](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-all.png) | ![spread](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-spread.png) | ![status](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-status.png) |

| Description | Label Positions |
|---|---|
| ![desc](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-description.png) | ![positions](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-label-positions.png) |

-----

Hardening: #718
