### PR TITLE
chore: version packages for v0.0.6

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xds/cli",
-  "version": "0.0.5",
-  "description": "XDS design system CLI — init, swizzle, theme, templates, and agent docs",
+  "version": "0.0.6",
+  "description": "XDS design system CLI \u2014 init, swizzle, theme, templates, and agent docs",
   "type": "module",
   "bin": {
     "xds": "./bin/xds.mjs"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/core",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Core XDS components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
-  "description": "Brutalist theme for XDS — zero radius, monospace, heavy borders",
+  "description": "Brutalist theme for XDS \u2014 zero radius, monospace, heavy borders",
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/index.js",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-default",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "description": "Default theme for XDS components (Heroicons)",
   "license": "MIT",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-neutral",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "description": "Neutral theme for XDS components (Lucide icons)",
   "license": "MIT",


### PR DESCRIPTION
Bump all packages to v0.0.6. Published to npm.

Packages published:
- @xds/core@0.0.6 ✅
- @xds/cli@0.0.6 ✅
- @xds/theme-default@0.0.6 ✅
- @xds/theme-neutral@0.0.6 ✅

Note: v0.0.5 had a registry tombstone issue (E409 after unpublish), so we bumped to v0.0.6. Codemods were already at v0.0.6.

---