### PR TITLE
fix(vibe-tests): prevent lightningcss from mangling light-dark() in previews

### DIFF
--- a/internal/vibe-tests/app/vite.config.preview.ts
+++ b/internal/vibe-tests/app/vite.config.preview.ts
@@ -31,7 +31,12 @@ const lightningcssTargets = {
  */
 export default defineConfig({
   root: __dirname,
-  build: {},
+  build: {
+    // Don't use lightningcss for minification — it lowers light-dark()
+    // into --lightningcss-light/--lightningcss-dark polyfill variables
+    // which breaks theming. The StyleX plugin handles its own CSS.
+    cssMinify: false,
+  },
   plugins: [
     stylex.vite({
       dev: process.env.NODE_ENV === 'development',

--- a/internal/vibe-tests/app/vite.config.report.ts
+++ b/internal/vibe-tests/app/vite.config.report.ts
@@ -39,6 +39,18 @@ export default defineConfig({
     rollupOptions: {
       input: path.resolve(__dirname, 'index.report.html'),
     },
+    // Don't use lightningcss for minification — it lowers light-dark()
+    // into --lightningcss-light/--lightningcss-dark polyfill variables
+    // which breaks theming. The pre-compiled CSS is already minified.
+    cssMinify: false,
+  },
+  css: {
+    // Set Vite's own CSS transformer targets so any CSS processing
+    // (including dev server) preserves native light-dark().
+    transformer: 'lightningcss',
+    lightningcss: {
+      targets: lightningcssTargets,
+    },
   },
   resolve: {
     alias: [

--- a/internal/vibe-tests/app/vite.config.ts
+++ b/internal/vibe-tests/app/vite.config.ts
@@ -23,7 +23,12 @@ const lightningcssTargets = {
 };
 
 export default defineConfig({
-  build: {},
+  build: {
+    // Don't use lightningcss for minification — it lowers light-dark()
+    // into --lightningcss-light/--lightningcss-dark polyfill variables
+    // which breaks theming. The StyleX plugin handles its own CSS.
+    cssMinify: false,
+  },
   plugins: [
     stylex.vite({
       dev: process.env.NODE_ENV === 'development',

--- a/internal/vibe-tests/src/build-previews.ts
+++ b/internal/vibe-tests/src/build-previews.ts
@@ -21,6 +21,21 @@ const VIBE_DIR = path.resolve(__dirname, '..');
 const _APP_DIR = path.join(VIBE_DIR, 'app');
 const REPO_ROOT = path.resolve(VIBE_DIR, '../..');
 
+/**
+ * Browser targets for lightningcss.
+ * Prevents lowering native light-dark() into --lightningcss-light/--lightningcss-dark
+ * polyfill variables. XDS tokens use native light-dark() which is baseline 2024:
+ * Chrome 123+, Firefox 120+, Safari 17.5+
+ *
+ * Must match the targets in apps/storybook/.storybook/main.ts and
+ * internal/vibe-tests/app/vite.config.*.ts
+ */
+const LIGHTNINGCSS_TARGETS_JS = `{
+  chrome: 123 << 16,
+  firefox: 120 << 16,
+  safari: (17 << 16) | (5 << 8),
+}`;
+
 interface PreviewManifest {
   [promptId: string]: {
     [target: string]: string; // relative path to preview HTML
@@ -279,6 +294,9 @@ function createViteConfig(tmpDir: string, target: string): string {
           .resolve(REPO_ROOT, 'packages/core/src/theme/tokens.stylex.ts')
           .replace(/\\/g, '/')}',
       },
+      lightningcssOptions: {
+        targets: ${LIGHTNINGCSS_TARGETS_JS},
+      },
     }),
     react(),
     viteSingleFile(),`
@@ -348,6 +366,10 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    // Don't use lightningcss for minification — it lowers light-dark()
+    // into --lightningcss-light/--lightningcss-dark polyfill variables
+    // which breaks XDS theming.
+    cssMinify: false,
   },
   logLevel: 'warn',
 });


### PR DESCRIPTION
## Problem

Vibe test report and preview builds were missing lightningcss protections. Native `light-dark()` CSS values in XDS tokens were being lowered into `--lightningcss-light`/`--lightningcss-dark` polyfill variables, which break theming because the polyfill only works when `color-scheme` is in the same CSS bundle.

## Root Cause

Four separate gaps in the vibe test build pipeline:

1. **`vite.config.report.ts`** — `lightningcssTargets` was defined but never actually used (dead code). No `cssMinify: false` either, so both the transform and minification paths could mangle `light-dark()`.

2. **`vite.config.ts`** — StyleX plugin had `lightningcssOptions.targets` (good), but Vite's own CSS minifier had no protection. Missing `cssMinify: false`.

3. **`vite.config.preview.ts`** — Same issue as above.

4. **`build-previews.ts`** — The dynamically generated Vite configs for per-prompt preview page builds had **zero** lightningcss handling. No `lightningcssOptions` on the StyleX plugin, no `cssMinify: false`.

## Fix

- Added `cssMinify: false` to all four build configs
- Added `lightningcssOptions.targets` to the StyleX plugin in `build-previews.ts`
- Added `css.transformer: 'lightningcss'` with targets to `vite.config.report.ts` (matches storybook pattern)
- The `lightningcssTargets` constant in `vite.config.report.ts` is now actually used

## Testing

These are internal vibe test tools — the fix aligns with the same pattern already working in `apps/storybook/.storybook/main.ts` and the published `@xds/core` build.

---
