### PR TITLE
fix(Switch): hardening — swarm findings

### DIFF
--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -14,6 +14,7 @@ export const docs = {
     'Status messages — error, warning, success, or info message boxes below the switch',
     'Async action support — onChangeAction with optimistic UI and built-in loading spinner',
     'Accessibility — native checkbox with role="switch", aria-describedby, aria-invalid, aria-busy',
+    'Reduced motion — respects prefers-reduced-motion for track and thumb transitions',
   ],
   examples: [
     {
@@ -75,6 +76,11 @@ export const docs = {
     },
   ],
   props: [
+    {
+      name: 'ref',
+      type: 'React.Ref<HTMLInputElement>',
+      description: 'Ref forwarded to the underlying <input> element.',
+    },
     {
       name: 'label',
       type: 'string',
@@ -183,7 +189,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-switch'},
-      {className: 'xds-switch-field'},
+      {className: 'xds-switch-field', visualProps: ['labelPosition', 'labelSpacing']},
     ],
   },
   accessibility: [
@@ -201,6 +207,8 @@ export const docs = {
     'onChangeAction uses React useTransition and useOptimistic for seamless async toggling',
     'labelPosition="start" with labelSpacing="spread" produces a settings panel style layout',
     'Follows the same patterns as XDSCheckboxInput for structural consistency',
+    'Interaction is blocked during busy state (loading or pending async action) to prevent double-toggling',
+    'Track and thumb transitions respect prefers-reduced-motion (0.01s duration when reduced motion preferred)',
   ],
 };
 
@@ -280,6 +288,11 @@ export const docsZh = {
     },
   ],
   props: [
+    {
+      name: 'ref',
+      type: 'React.Ref<HTMLInputElement>',
+      description: '转发至底层 <input> 元素的 ref。',
+    },
     {
       name: 'label',
       type: 'string',
@@ -388,7 +401,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-switch'},
-      {className: 'xds-switch-field'},
+      {className: 'xds-switch-field', visualProps: ['labelPosition', 'labelSpacing']},
     ],
   },
   accessibility: [
@@ -440,6 +453,7 @@ export const docsDense = {
   ],
   keyboard: 'Space=toggle; Tab/Shift+Tab=move focus in/out.',
   propDescriptions: {
+    ref: 'ref forwarded to underlying <input>',
     label: 'Label text (always rendered for a11y).',
     value: 'Whether switch is on or off.',
     onChange: 'Fired when switch state changes.',

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -29,6 +29,8 @@ import {
   easeVars,
   typographyVars,
   textSizeVars,
+  lineHeightVars,
+  fontWeightVars,
 } from '../theme/tokens.stylex';
 import {XDSFieldLabel} from '../Field/XDSFieldLabel';
 import {XDSFieldStatus} from '../Field/XDSFieldStatus';
@@ -92,7 +94,10 @@ const styles = stylex.create({
     padding: TRACK_PADDING,
     borderRadius: radiusVars['--radius-rounded'],
     transitionProperty: 'background-color',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0.01s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
     boxSizing: 'border-box',
   },
@@ -137,7 +142,10 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-rounded'],
     backgroundColor: colorVars['--color-surface'],
     transitionProperty: 'transform, width, height',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0.01s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   thumbOff: {
@@ -159,6 +167,8 @@ const styles = stylex.create({
   description: {
     fontFamily: typographyVars['--font-body'],
     fontSize: textSizeVars['--text-xsm'],
+    lineHeight: lineHeightVars['--leading-relaxed'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
   },
 });
@@ -325,6 +335,7 @@ export function XDSSwitch({
         disabled={isDisabled}
         required={isRequired}
         onChange={e => {
+          if (isBusy) return;
           const checked = e.target.checked;
           onChange?.(checked, e);
           if (onChangeAction && !e.defaultPrevented) {
@@ -387,7 +398,7 @@ export function XDSSwitch({
   return (
     <div
       {...mergeProps(
-        xdsClassName('switch-field'),
+        xdsClassName('switch-field', {labelPosition, labelSpacing}),
         stylex.props(xstyle),
         className,
         style,


### PR DESCRIPTION
Hardening fixes for Switch from swarm audit (#718). Addresses all component-specific findings.

| Finding | Fix |
|---------|-----|
| Track + thumb transitions ignore prefers-reduced-motion | Add @media query with 0.01s (matches MobileNav) |
| Clickable during async action | Guard onChange with isBusy early return |
| Description style missing lineHeight/fontWeight | Add lineHeightVars and fontWeightVars |
| xdsClassName('switch-field') has no variants | Add {labelPosition, labelSpacing} |
| Doc missing ref prop | Add ref to docs, docsZh, docsDense |
| Doc missing reduced-motion info | Add feature + notes |
| Theming targets missing visualProps | Add visualProps for switch-field |

### Screenshots

| All Variations | Spread Layout | Status |
|---|---|---|
| ![all](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-all.png) | ![spread](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-spread.png) | ![status](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-status.png) |

| Description | Label Positions |
|---|---|
| ![desc](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-description.png) | ![positions](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/switch-label-positions.png) |

### Not in this PR (cross-cutting, tracked in #718)
- Spinner inside aria-hidden
- Empty label='' validation
- XDSBaseProps attrs silently dropped (no ...rest spread)

Hardening: #718
