### PR TITLE
fix(ci): preserve assets/ and latest deploy during gh-pages cleanup

### DIFF
--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -35,10 +35,11 @@ jobs:
         run: |
           # ---------------------------------------------------------------
           # Retention policy:
-          #   KEEP  — latest main commit dir
+          #   KEEP  — latest main commit dir (from API)
+          #         — most recently deployed dir (from git log)
           #         — latest head commit dir for each open/draft PR
           #         — reports/ (vibe test reports)
-          #         — root files (.nojekyll, index.html)
+          #         — root files (.nojekyll, index.html, latest, assets/)
           #   DELETE — everything else
           # ---------------------------------------------------------------
 
@@ -60,6 +61,24 @@ jobs:
           MAIN_HASH=$(gh api repos/$GITHUB_REPOSITORY/commits/main --jq '.sha[:7]')
           echo "Main HEAD: ${MAIN_HASH}"
 
+          # Find the most recently deployed hash dir on gh-pages.
+          # This protects against a race where main HEAD has advanced
+          # but its deploy hasn't finished yet — we keep the previous
+          # deploy that's actually serving traffic.
+          LATEST_DEPLOYED=""
+          for dir in "${DIRS[@]}"; do
+            # git log for the dir — most recently touched = most recent deploy
+            DIR_DATE=$(git log -1 --format='%ct' -- "$dir" 2>/dev/null || echo "0")
+            if [ -z "$LATEST_DEPLOYED" ]; then
+              LATEST_DEPLOYED="$dir"
+              LATEST_DATE="$DIR_DATE"
+            elif [ "$DIR_DATE" -gt "$LATEST_DATE" ]; then
+              LATEST_DEPLOYED="$dir"
+              LATEST_DATE="$DIR_DATE"
+            fi
+          done
+          echo "Latest deployed: ${LATEST_DEPLOYED}"
+
           # Get open/draft PR head commit short hashes
           OPEN_PR_HASHES=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json headRefOid,number --jq '.[] | .headRefOid[:7]' || true)
           OPEN_COUNT=$(echo "$OPEN_PR_HASHES" | grep -c . || echo 0)
@@ -69,8 +88,10 @@ jobs:
           # Clean up stale root-level storybook files (from old deploy format)
           # These are files/dirs at the gh-pages root that aren't hash dirs,
           # index.html, .nojekyll, or reports/
+          # NOTE: `assets/` is NOT stale — it contains CSS referenced by the
+          # landing page (index.html): reset.css, xds.css, theme.css
           ROOT_STALE=0
-          for item in assets favicon.svg iframe.html index.json project.json \
+          for item in favicon.svg iframe.html index.json project.json \
                       nunito-sans-bold-italic.woff2 nunito-sans-bold.woff2 \
                       nunito-sans-italic.woff2 nunito-sans-regular.woff2 \
                       sandbox sb-addons sb-common-assets sb-manager; do
@@ -93,9 +114,15 @@ jobs:
           for dir in "${DIRS[@]}"; do
             REASON=""
 
-            # Keep main
+            # Keep main HEAD
             if [ "$dir" = "$MAIN_HASH" ]; then
-              REASON="main"
+              REASON="main HEAD"
+            fi
+
+            # Keep the most recently deployed dir (in case main HEAD
+            # hasn't deployed yet, this is what's actually serving)
+            if [ -z "$REASON" ] && [ "$dir" = "$LATEST_DEPLOYED" ]; then
+              REASON="latest deployed"
             fi
 
             # Keep open/draft PR heads

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -209,13 +209,33 @@ jobs:
               <div class="hash" id="commit-hash"></div>
             </div>
             <script>
-              // Links are set by the deploy script — SHORT_HASH is injected
+              // Resolve links from the `latest` file so they always point
+              // to the most recently deployed hash — even if a newer main
+              // commit is still building and the sed-injected hash is stale.
+              fetch('latest')
+                .then(r => r.ok ? r.text() : null)
+                .then(hash => {
+                  if (!hash) return;
+                  hash = hash.trim();
+                  const sb = document.getElementById('storybook-link');
+                  const bx = document.getElementById('sandbox-link');
+                  const cm = document.getElementById('commit-hash');
+                  if (sb) sb.href = hash + '/index.html';
+                  if (bx) bx.href = hash + '/sandbox/index.html';
+                  if (cm) cm.textContent = 'Build: ' + hash;
+                })
+                .catch(() => {}); // fallback to sed-injected links
             </script>
           </body>
           </html>
           LANDING_EOF
 
-          # Inject the short hash into the landing page links
+          # Write the latest deployed hash so the landing page can resolve
+          # links dynamically. This survives cleanup and avoids stale links
+          # when a newer main commit is pending deploy.
+          echo -n "${SHORT_HASH}" > deploy/latest
+
+          # Inject the short hash into the landing page as a fallback
           sed -i "s|id=\"storybook-link\" href=\"#\"|id=\"storybook-link\" href=\"${SHORT_HASH}/index.html\"|" deploy/index.html
           sed -i "s|id=\"sandbox-link\" href=\"#\"|id=\"sandbox-link\" href=\"${SHORT_HASH}/sandbox/index.html\"|" deploy/index.html
           sed -i "s|id=\"commit-hash\"|id=\"commit-hash\">Build: ${SHORT_HASH}</div><!--done|" deploy/index.html


### PR DESCRIPTION
## Problem

Three related issues with the gh-pages cleanup + deploy lifecycle:

1. **`assets/` deleted** — The cleanup workflow listed `assets` as a stale root-level storybook file, but it contains CSS (`reset.css`, `xds.css`, `theme.css`) referenced by the landing page.

2. **Race condition** — Cleanup looks up main HEAD via GitHub API and keeps only that hash directory. But if main HEAD's deploy is still pending, the directory doesn't exist yet — so cleanup deletes the *previous* deploy that's actually serving traffic. Result: 404 on the storybook.

3. **Stale landing page links** — `index.html` has links baked in via `sed` at deploy time. Between deploys, these can point to a cleaned-up directory.

## Fix

### cleanup-previews.yml
- Remove `assets` from the stale items delete list
- Keep the **most recently deployed** hash dir (by git log date), not just main HEAD — so the previous deploy survives until the new one lands

### deploy.yml
- Write a `latest` file containing the deployed hash
- Landing page fetches `latest` and rewrites links dynamically, with the sed-injected hash as fallback

---
