### PR TITLE
fix(Button): convert spinner overlay to StyleX — theme audit batch 2026-03-20

### DIFF
--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -275,6 +275,16 @@ const loadingStyles = stylex.create({
     position: 'relative',
     color: 'transparent',
   },
+  spinnerOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
 });
 
 /**
@@ -381,17 +391,7 @@ export function XDSButton({
       {...props}
       onClick={handleClick}>
       {isLoadingState && (
-        <span
-          style={{
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}>
+        <span {...stylex.props(loadingStyles.spinnerOverlay)}>
           <XDSSpinner
             size="sm"
             shade={useLightSpinner ? 'onMedia' : 'default'}


### PR DESCRIPTION
## Theme Audit — Batch 2026-03-20

**Components audited:** Breadcrumbs, Button, Calendar, Card, Center

### Findings

| Component | Status | Notes |
|-----------|--------|-------|
| Breadcrumbs | ✅ Clean | All colors, spacing, typography use token vars. xdsClassName on nav and each item. |
| Button | 🔧 Fixed | Loading spinner overlay used inline `style={{}}` — converted to StyleX `loadingStyles.spinnerOverlay`. |
| Calendar | ✅ Clean | Uses XDSButton + XDSIcon for nav. All colors/spacing/typography via tokens. DayCell `<button>` is correct (grid cell, not standalone button). |
| Card | ✅ Clean | All visual props use tokens (colorVars, radiusVars, shadowVars). xdsClassName on outer div. |
| Center | ✅ Clean | Pure layout component, no visual/theme values. xdsClassName applied correctly. |

### Fix Details

**Button — inline spinner overlay → StyleX** (XDSButton.tsx)
- The loading state spinner overlay used a hardcoded `style={{position: 'absolute', ...}}` object
- Converted to `stylex.props(loadingStyles.spinnerOverlay)` for proper StyleX deduplication and theme overridability
- No visual change — same CSS properties, just via StyleX now

### Needs Review

No ambiguous cases this batch. All components are well-tokenized.

---
