### PR TITLE
docs: add missing props for Badge, Section, SideNavItem

### DIFF
--- a/packages/core/src/Badge/Badge.doc.mjs
+++ b/packages/core/src/Badge/Badge.doc.mjs
@@ -17,6 +17,11 @@ export const docs = {
       description: 'Badge content. Omit for dot indicator.',
     },
     {
+      name: 'label',
+      type: 'ReactNode',
+      description: 'Badge text content. When both label and children are omitted, renders as a dot indicator.',
+    },
+    {
       name: 'icon',
       type: 'ReactNode',
       description: 'Optional leading icon.',
@@ -67,6 +72,11 @@ export const docsZh = {
       description: '徽章内容。省略则显示圆点指示器。',
     },
     {
+      name: 'label',
+      type: 'ReactNode',
+      description: '徽章文本内容。当 label 和 children 都省略时，渲染为圆点指示器。',
+    },
+    {
       name: 'icon',
       type: 'ReactNode',
       description: '可选的前置图标。',
@@ -104,6 +114,7 @@ export const docsDense = {
   description: 'badge for status indicators, counts, or labels',
   propDescriptions: {
     variant: 'visual style variant',
+    label: 'badge text; omit with children for dot indicator',
     children: 'badge content; omit for dot indicator',
     icon: 'optional leading icon',
   },

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -84,6 +84,17 @@ export const docs = {
       type: "Array<'top' | 'bottom' | 'start' | 'end'>",
       description: 'Which sides of the section have divider borders.',
     },
+    {
+      name: 'padding',
+      type: 'SpacingStep',
+      description: 'Internal padding using the spacing scale (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10). Use padding={0} for edge-to-edge content.',
+      default: '4',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object.',
+    },
   ],
   theming: {
     targets: [
@@ -177,6 +188,17 @@ export const docsZh = {
       type: "Array<'top' | 'bottom' | 'start' | 'end'>",
       description: '区域的哪些边具有分隔线边框。',
     },
+    {
+      name: 'padding',
+      type: 'SpacingStep',
+      description: '使用间距比例的内部内边距（0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10）。使用 padding={0} 实现全宽内容。',
+      default: '4',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description: '用于布局自定义的 StyleX 样式（外边距、定位、尺寸）。必须是 stylex.create() 的值，不能是内联样式对象。',
+    },
   ],
   theming: {
     targets: [
@@ -204,5 +226,7 @@ export const docsDense = {
     minHeight: 'Minimum height of section.',
     children: 'Content rendered inside section.',
     dividers: 'Which sides of section have divider borders.',
+    padding: 'Internal padding via spacing scale; 0 for edge-to-edge content.',
+    xstyle: 'StyleX styles for layout customization; must be stylex.create() value.',
   },
 };

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -306,6 +306,12 @@ export const docs = {
           type: 'ReactNode',
           description: 'Sub-items for nesting.',
         },
+        {
+          name: 'collapsible',
+          type: 'boolean | { defaultIsCollapsed?: boolean, isCollapsed?: boolean, onCollapsedChange?: (isCollapsed: boolean) => void }',
+          description: 'Enables collapse behavior for items with children. Pass true for uncontrolled (starts expanded), or an object for controlled mode.',
+          default: 'false',
+        },
       ],
       examples: [
         {
@@ -324,8 +330,8 @@ export const docs = {
 />`,
         },
         {
-          label: 'Nested items',
-          code: `<XDSSideNavItem label="Settings" icon={GearIcon} href="/settings">
+          label: 'Collapsible nested items',
+          code: `<XDSSideNavItem label="Settings" icon={GearIcon} collapsible>
   <XDSSideNavItem label="General" href="/settings/general" />
   <XDSSideNavItem label="Security" href="/settings/security" />
 </XDSSideNavItem>`,
@@ -741,6 +747,12 @@ export const docsZh = {
           type: 'ReactNode',
           description: '用于嵌套的子项。',
         },
+        {
+          name: 'collapsible',
+          type: 'boolean | { defaultIsCollapsed?: boolean, isCollapsed?: boolean, onCollapsedChange?: (isCollapsed: boolean) => void }',
+          description: '启用带子项的折叠行为。传 true 为非受控模式（默认展开），或传对象用于受控模式。',
+          default: 'false',
+        },
       ],
       examples: [
         {
@@ -759,8 +771,8 @@ export const docsZh = {
 />`,
         },
         {
-          label: '嵌套项',
-          code: `<XDSSideNavItem label="Settings" icon={GearIcon} href="/settings">
+          label: '可折叠嵌套项',
+          code: `<XDSSideNavItem label="Settings" icon={GearIcon} collapsible>
   <XDSSideNavItem label="General" href="/settings/general" />
   <XDSSideNavItem label="Security" href="/settings/security" />
 </XDSSideNavItem>`,
@@ -936,6 +948,7 @@ export const docsDense = {
         onClick: 'Click handler.',
         endContent: 'Right-side content such as badges or counts.',
         children: 'Sub-items for nesting.',
+        collapsible: 'Enables collapse for items w/ children. true=uncontrolled, object=controlled mode.',
       },
     },
     {


### PR DESCRIPTION
## What

Prop drift fixes found during Night Watch doc review (2026-03-20).

Three components had user-facing props that weren't documented in their `.doc.mjs` files:

| Component | Missing Prop | Source |
|-----------|-------------|--------|
| Badge | `label` | PR #709 (feat: add label prop) |
| Section | `xstyle`, `padding` | PR #721 (fix: add xstyle prop) |
| SideNavItem | `collapsible` | PR #680 (feat: popover for collapsed items) |

All three translation layers (English, Chinese, Dense) updated for each prop.

SideNavItem's nested items example updated to show the `collapsible` prop instead of plain nesting.

## Checklist
- [x] `yarn workspace @xds/core typecheck:docs` passes
- [x] CLI `--props` output verified for Badge, Section, SideNav
- [x] All three translation layers updated (English, Chinese, Dense)
- [x] No source code (.tsx) modified

---
*Night Watch Doc Reviewer*