### PR TITLE
fix(HoverCard): add missing xdsClassName for theme targeting

### DIFF
--- a/packages/core/src/HoverCard/useXDSHoverCard.tsx
+++ b/packages/core/src/HoverCard/useXDSHoverCard.tsx
@@ -32,6 +32,7 @@ import {
   radiusVars,
   spacingVars,
 } from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
   // Base container styles passed to useXDSLayer (includes animations)
@@ -425,7 +426,10 @@ export function useXDSHoverCard(
 
       return layer.render(
         <div
-          {...stylex.props(styles.content)}
+          {...mergeProps(
+            xdsClassName('hovercard'),
+            stylex.props(styles.content),
+          )}
           onMouseEnter={() => {
             isHoveringContentRef.current = true;
             clearTimeouts();


### PR DESCRIPTION
## Theme Audit — 2026-03-20 (batch C)

**Components audited:** HoverCard, Icon, Kbd, Layer, Layout

### Findings

| Component | CSS Vars | Primitive Reuse | xdsClassName | Status |
|-----------|----------|-----------------|--------------|--------|
| HoverCard | ✅ | ✅ | ❌ Fixed | Missing `xds-hovercard` class |
| Icon | ✅ | ✅ | ✅ | Clean |
| Kbd | ✅ | ✅ | ✅ | Clean |
| Layer | ✅ | ✅ | N/A (infra) | Clean |
| Layout | ✅ | ✅ | ✅ | Clean (all 5 sub-components) |

### Fix

**useXDSHoverCard.tsx** — The hover card content `<div>` (the visual element with background, shadow, border-radius, and padding) was missing `xdsClassName('hovercard')`. This made it impossible for themes to target hover cards via `@scope(.xds-hovercard)` selectors.

Applied `xdsClassName('hovercard')` on the content wrapper div using `mergeProps`, consistent with the pattern used by other visual components (Icon, Kbd, Layout sub-components).

### Needs Review

- **Kbd hardcoded sizing values:** `minWidth: '20px'`, `height: '20px'`, and `borderBottomWidth: '2px'` are hardcoded pixel values. These are layout-level sizing constraints (not semantic spacing/radius tokens), but worth confirming they shouldn't be tokenized for theme-level control over kbd indicator sizing.

---
