### PR TITLE
fix(MoreMenu): use shadow token instead of hardcoded boxShadow — theme audit batch

### DIFF
--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -44,6 +44,7 @@ import {
   easeVars,
   typographyVars,
   textSizeVars,
+  shadowVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -59,7 +60,7 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-2'],
     backgroundColor: colorVars['--color-surface'],
-    boxShadow: `0 4px 12px ${colorVars['--color-shadow']}`,
+    boxShadow: shadowVars['--shadow-menu'],
     opacity: 1,
     transitionProperty: 'opacity',
     transitionDuration: durationVars['--duration-fast'],


### PR DESCRIPTION
## Theme Audit — Batch 2026-03-20 (Run B)

Audited 5 components: **Link**, **List**, **MobileNav**, **MoreMenu**, **NavIcon**.

### Fix

**MoreMenu** — replaced hardcoded `boxShadow: \`0 4px 12px \${colorVars['--color-shadow']}\``` with `shadowVars['--shadow-menu']`. The `--shadow-menu` token provides a multi-layer shadow that's fully themeable, rather than a single-layer shadow using a color token for the spread value.

### Clean Components (no issues found)

- **Link** — all CSS values use tokens (`colorVars`, `spacingVars`, `durationVars`, `textSizeVars`, `lineHeightVars`); uses `XDSIcon`, `XDSTooltip`, `XDSText` for composition; `xdsClassName('link', {color})` applied correctly
- **List** — all spacing uses `spacingVars`; `xdsClassName('list', {density, listStyle})` applied on the `<ul>`/`<ol>` element
- **ListItem** — all visual values use tokens; `xdsClassName('list-item')` applied on the `<li>`; dividers use `borderBlockEnd` with `colorVars['--color-border']` per the preferred pattern
- **MobileNav** — all values use tokens; uses `XDSButton` (ghost) for close button, `XDSIcon` for icons, `XDSHeading` for header; `xdsClassName('mobile-nav', {side})` applied on `<dialog>`
- **NavIcon** — all values use tokens (`colorVars`, `sizeVars`); `xdsClassName('navicon')` applied on the `<span>` root

### Skipped

- **MobileNavToggle** — composition wrapper around `XDSButton`; adding `xdsClassName` would create specificity conflicts with `XDSButton`'s own theming (per audit guidelines)

### Needs Review

- The same hardcoded shadow pattern (`0 4px 12px \${colorVars['--color-shadow']}`) appears in **Selector**, **SideNavHeading**, and **Typeahead**. Those components are later in the audit queue and will be fixed in future runs. Just noting the pattern for awareness.

---
