### PR TITLE
fix(Button): hardening — swarm findings

### DIFF
--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -60,7 +60,10 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     cursor: 'pointer',
     transitionProperty: 'background-image, transform',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0.01s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
     transform: {
       default: 'scale(1)',
@@ -73,6 +76,11 @@ const styles = stylex.create({
     transform: {
       default: 'none',
       ':active': 'none',
+    },
+    backgroundImage: {
+      default: null,
+      ':hover': null,
+      ':active': null,
     },
   },
   iconOnly: {
@@ -335,6 +343,7 @@ export function XDSButton({
   xstyle,
   className,
   style,
+  type = 'button',
   ref,
   ...props
 }: XDSButtonProps): ReactElement {
@@ -345,13 +354,12 @@ export function XDSButton({
   const isIconOnly = icon != null && children == null;
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    if (onClickAction) {
-      e.preventDefault();
+    props.onClick?.(e);
+    if (onClickAction && !e.defaultPrevented) {
       startTransition(async () => {
         await onClickAction(e);
       });
     }
-    props.onClick?.(e);
   };
 
   // Ghost buttons opt into edge compensation — they self-adjust margins
@@ -369,9 +377,8 @@ export function XDSButton({
   const button = (
     <button
       ref={ref}
+      type={type}
       disabled={buttonDisabled}
-      aria-label={isIconOnly ? label : undefined}
-      aria-busy={isLoadingState || undefined}
       {...mergeProps(
         xdsClassName('button', {variant, size}),
         stylex.props(
@@ -389,6 +396,8 @@ export function XDSButton({
         style,
       )}
       {...props}
+      aria-label={isIconOnly ? label : undefined}
+      aria-busy={isLoadingState || undefined}
       onClick={handleClick}>
       {isLoadingState && (
         <span {...stylex.props(loadingStyles.spinnerOverlay)}>


### PR DESCRIPTION
Hardening fixes for Button from swarm audit (#718).

| Finding | Fix |
|---------|-----|
| P0: onClickAction calls onClick after preventDefault — both fire | onClick fires first, onClickAction checks e.defaultPrevented |
| P1: type not defaulted to 'button' (JSDoc says it is, will submit forms) | Add type = 'button' default, explicit on element |
| P1: Ghost disabled + :active still shows pressed overlay | Reset backgroundImage on disabled style |
| P1: aria-label/aria-busy before ...props spread, consumer can clobber | Move aria attrs after ...props |
| P2: No prefers-reduced-motion on transitions | Add @media query with 0.01s |

### Screenshots

| Variants | Loading | End Slot |
|---|---|---|
| ![variants](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/button-variants.png) | ![loading](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/button-loading.png) | ![endslot](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/button-endslot.png) |

| Icon Only | Icon + End Slot |
|---|---|
| ![icon](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/button-icon-only.png) | ![iconend](https://github.com/facebookexperimental/xds/releases/download/untagged-16ca66ce67a146867e92/button-icon-endslot.png) |

### Not in this PR (tracked in #718)
- Loading content still in a11y tree (needs layout-safe solution)
- Calendar header role="heading" (Calendar-specific)
- Spinner size hardcoded sm
- endSlot type constraint doc-only
- Tooltip on disabled button unreachable
- Doc missing type/name/value/form/ref props

Hardening: #718
