### PR TITLE
ci: add code owner gate workflow

### DIFF
--- a/.github/workflows/codeowner-gate.yml
+++ b/.github/workflows/codeowner-gate.yml
@@ -1,0 +1,76 @@
+# Code owner gate: blocks merge unless a code owner has approved
+# Code owners themselves can merge freely (auto-pass)
+#
+# Add "codeowner-gate" as a required status check in the branch
+# protection settings to enforce this.
+name: Code Owner Gate
+
+on:
+  pull_request:
+    branches: ["main"]
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: read
+  contents: read
+
+jobs:
+  codeowner-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check code owner status
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // --- Configuration ---
+            // Keep this list in sync with .github/CODEOWNERS
+            const CODE_OWNERS = ['cixzhang', 'josephfarina'];
+
+            // --- Resolve PR author ---
+            let prNumber, prAuthor;
+
+            if (context.eventName === 'pull_request') {
+              prNumber = context.payload.pull_request.number;
+              prAuthor = context.payload.pull_request.user.login;
+            } else if (context.eventName === 'pull_request_review') {
+              prNumber = context.payload.pull_request.number;
+              prAuthor = context.payload.pull_request.user.login;
+            }
+
+            console.log(`PR #${prNumber} by @${prAuthor}`);
+
+            // --- Code owners pass immediately ---
+            if (CODE_OWNERS.includes(prAuthor)) {
+              console.log(`✅ @${prAuthor} is a code owner — approved automatically`);
+              return;
+            }
+
+            // --- Non-owners need a code owner approval ---
+            console.log(`@${prAuthor} is not a code owner — checking for code owner approval...`);
+
+            const { data: reviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+
+            // Find the latest review state per reviewer
+            const latestReviews = new Map();
+            for (const review of reviews) {
+              latestReviews.set(review.user.login, review.state);
+            }
+
+            const approvedBy = [...latestReviews.entries()]
+              .filter(([user, state]) => state === 'APPROVED' && CODE_OWNERS.includes(user))
+              .map(([user]) => user);
+
+            if (approvedBy.length > 0) {
+              console.log(`✅ Approved by code owner(s): ${approvedBy.map(u => '@' + u).join(', ')}`);
+              return;
+            }
+
+            core.setFailed(
+              `❌ This PR requires approval from a code owner (${CODE_OWNERS.map(u => '@' + u).join(', ')}) before merging.`
+            );


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that enforces code owner review for non-owners while letting code owners merge freely.

### How it works

- **PR author is a code owner** → check passes immediately, merge away
- **PR author is not a code owner** → check fails until a code owner (`@cixzhang` or `@josephfarina`) approves

### Setup required

After merging, add `codeowner-gate` as a **required status check** in the branch protection settings:
[internal link removed]

---