### PR TITLE
fix(ci): add stable storybook/ path + protect latest deploy from cleanup

### DIFF
--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -61,6 +61,15 @@ jobs:
           MAIN_HASH=$(gh api repos/$GITHUB_REPOSITORY/commits/main --jq '.sha[:7]')
           echo "Main HEAD: ${MAIN_HASH}"
 
+          # Also protect the hash from the `latest` file — this is the
+          # last successfully deployed main build and may differ from
+          # MAIN_HASH if new commits haven't deployed yet.
+          LATEST_FILE_HASH=""
+          if [ -f "latest" ]; then
+            LATEST_FILE_HASH=$(cat latest | tr -d '[:space:]')
+            echo "Latest file hash: ${LATEST_FILE_HASH}"
+          fi
+
           # Find the most recently deployed hash dir on gh-pages.
           # This protects against a race where main HEAD has advanced
           # but its deploy hasn't finished yet — we keep the previous
@@ -117,6 +126,11 @@ jobs:
             # Keep main HEAD
             if [ "$dir" = "$MAIN_HASH" ]; then
               REASON="main HEAD"
+            fi
+
+            # Keep the hash from the `latest` file (last successful deploy)
+            if [ -z "$REASON" ] && [ -n "$LATEST_FILE_HASH" ] && [ "$dir" = "$LATEST_FILE_HASH" ]; then
+              REASON="latest file (last successful deploy)"
             fi
 
             # Keep the most recently deployed dir (in case main HEAD

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -61,15 +61,6 @@ jobs:
           MAIN_HASH=$(gh api repos/$GITHUB_REPOSITORY/commits/main --jq '.sha[:7]')
           echo "Main HEAD: ${MAIN_HASH}"
 
-          # Also protect the hash from the `latest` file — this is the
-          # last successfully deployed main build and may differ from
-          # MAIN_HASH if new commits haven't deployed yet.
-          LATEST_FILE_HASH=""
-          if [ -f "latest" ]; then
-            LATEST_FILE_HASH=$(cat latest | tr -d '[:space:]')
-            echo "Latest file hash: ${LATEST_FILE_HASH}"
-          fi
-
           # Find the most recently deployed hash dir on gh-pages.
           # This protects against a race where main HEAD has advanced
           # but its deploy hasn't finished yet — we keep the previous
@@ -126,11 +117,6 @@ jobs:
             # Keep main HEAD
             if [ "$dir" = "$MAIN_HASH" ]; then
               REASON="main HEAD"
-            fi
-
-            # Keep the hash from the `latest` file (last successful deploy)
-            if [ -z "$REASON" ] && [ -n "$LATEST_FILE_HASH" ] && [ "$dir" = "$LATEST_FILE_HASH" ]; then
-              REASON="latest file (last successful deploy)"
             fi
 
             # Keep the most recently deployed dir (in case main HEAD

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,6 +230,17 @@ jobs:
           </html>
           LANDING_EOF
 
+          # Also deploy to a stable `storybook/` directory so links like
+          # .../storybook/index.html?path=/docs/core-xdsbutton--docs
+          # never break when hash directories get cleaned up.
+          mkdir -p deploy/storybook
+          cp -r apps/storybook/dist/* deploy/storybook/
+
+          if [ -d "apps/sandbox/out" ]; then
+            mkdir -p deploy/sandbox
+            cp -r apps/sandbox/out/* deploy/sandbox/
+          fi
+
           # Write the latest deployed hash so the landing page can resolve
           # links dynamically. This survives cleanup and avoids stale links
           # when a newer main commit is pending deploy.


### PR DESCRIPTION
## Problem

Storybook links in shared docs keep breaking because:
1. The deploy workflow publishes to `<hash>/` directories
2. The cleanup workflow deletes old hash directories — including main deploys
3. The `latest` file hash and the current main HEAD can diverge, so cleanup doesn't protect the right directory

This means any direct link like `.../865f2dc/index.html?path=/docs/...` stops working within days.

## Fix

**Deploy workflow:** Also copies the Storybook build to a stable `storybook/` directory. Links like `studious-broccoli-o7e61n3.pages.github.io/storybook/index.html?path=/docs/core-xdsbutton--docs` will always work regardless of cleanup.

**Cleanup workflow:** Now reads the `latest` file and protects that hash from deletion — prevents the race where main HEAD advances but the previous deploy gets cleaned up before the new one lands.

## After merge

Shared doc links can use `/storybook/` instead of `/<hash>/` and they'll never break again.