### PR TITLE
fix(Switch): use 0s instead of 0.01s for reduced-motion duration

### DIFF
--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -96,7 +96,7 @@ const styles = stylex.create({
     transitionProperty: 'background-color',
     transitionDuration: {
       default: durationVars['--duration-fast'],
-      '@media (prefers-reduced-motion: reduce)': '0.01s',
+      '@media (prefers-reduced-motion: reduce)': '0s',
     },
     transitionTimingFunction: easeVars['--ease-standard'],
     boxSizing: 'border-box',
@@ -144,7 +144,7 @@ const styles = stylex.create({
     transitionProperty: 'transform, width, height',
     transitionDuration: {
       default: durationVars['--duration-fast'],
-      '@media (prefers-reduced-motion: reduce)': '0.01s',
+      '@media (prefers-reduced-motion: reduce)': '0s',
     },
     transitionTimingFunction: easeVars['--ease-standard'],
   },


### PR DESCRIPTION
The Switch track and thumb transitions use `0.01s` for `prefers-reduced-motion`, but there's no JS `transitionend` listener here. `0s` is correct.

Matches the fix in CheckboxInput (#734).