### PR TITLE
feat(theme): add xdsClassName targets for sub-element theming

### DIFF
--- a/packages/cli/src/lib/component-format.mjs
+++ b/packages/cli/src/lib/component-format.mjs
@@ -66,7 +66,51 @@ export function formatFull(docs) {
 
   if (docs.theming) {
     sections.push('## Theming\n');
-    sections.push(`Component key: \`${docs.theming.componentKey}\`\n`);
+    const componentKey = docs.name.toLowerCase();
+
+    // Targets table
+    if (docs.theming.targets?.length) {
+      const targetLines = [];
+      targetLines.push('| Class | Variants | States |');
+      targetLines.push('|-------|---------|--------|');
+      for (const t of docs.theming.targets) {
+        const variants = t.visualProps?.length ? t.visualProps.join(', ') : '—';
+        const states = t.states?.length ? t.states.join(', ') : '—';
+        targetLines.push(`| \`${t.className}\` | ${variants} | ${states} |`);
+      }
+      sections.push(targetLines.join('\n') + '\n');
+
+      // Generate defineTheme example with class targeting
+      const exampleLines = ['Override in defineTheme:\n```ts\ncomponents: {'];
+      const rootTarget = docs.theming.targets[0];
+      const rootKey = rootTarget.className.replace('xds-', '');
+      exampleLines.push(`  '${rootKey}': {`);
+      exampleLines.push(`    base: { /* CSS properties */ },`);
+      if (rootTarget.visualProps?.length) {
+        const firstVariant = rootTarget.visualProps[0];
+        exampleLines.push(`    '${firstVariant}:value': { /* variant-specific */ },`);
+      }
+      if (rootTarget.states?.length) {
+        const firstState = rootTarget.states[0];
+        exampleLines.push(`    '${firstState}': { /* state-specific */ },`);
+      }
+      exampleLines.push(`  },`);
+      // Show sub-element example if there are multiple targets
+      if (docs.theming.targets.length > 1) {
+        const subTarget = docs.theming.targets[1];
+        const subKey = subTarget.className.replace('xds-', '');
+        exampleLines.push(`  '${subKey}': {`);
+        exampleLines.push(`    base: { /* CSS properties */ },`);
+        if (subTarget.states?.length) {
+          const firstState = subTarget.states[0];
+          exampleLines.push(`    '${firstState}': { /* state-specific */ },`);
+        }
+        exampleLines.push(`  },`);
+      }
+      exampleLines.push('}\n```\n');
+      sections.push(exampleLines.join('\n'));
+    }
+
     if (docs.theming.surfaces?.length) {
       const surfaceLines = [];
       surfaceLines.push('| Surface | Description |');
@@ -89,12 +133,11 @@ export function formatFull(docs) {
       }
       sections.push(varLines.join('\n') + '\n');
 
-      // Show override example
+      // Show var override example
       const overridableVars = docs.theming.vars.filter(v => !v.derived);
       if (overridableVars.length > 0) {
-        const componentKey = docs.name.toLowerCase();
         const exampleVar = overridableVars[0];
-        sections.push('Override in defineTheme:\n```tsx\ncomponents: {\n  ' + componentKey + ': {\n    base: { \'' + exampleVar.name + '\': \'...\' },\n  },\n}\n```\n');
+        sections.push('Override CSS vars in defineTheme:\n```ts\ncomponents: {\n  ' + componentKey + ': {\n    base: { \'' + exampleVar.name + '\': \'...\' },\n  },\n}\n```\n');
       }
     }
   }
@@ -255,6 +298,17 @@ export function formatBrief(docs, componentName, importHint) {
     if (varNames) {
       output.push(`  Vars: ${varNames}`);
     }
+  }
+
+  // Theme targets (class names, variants, states)
+  if (docs.theming?.targets?.length) {
+    const targetParts = docs.theming.targets.map(t => {
+      const parts = [t.className];
+      if (t.visualProps?.length) parts.push(`variants: ${t.visualProps.join(', ')}`);
+      if (t.states?.length) parts.push(`states: ${t.states.join(', ')}`);
+      return parts.join(' ');
+    });
+    output.push(`  Targets: ${targetParts.join(' | ')}`);
   }
 
   // Other props

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -118,7 +118,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-banner', visualProps: ['variant']},
-      {className: 'xds-banner-icon'},
+      {className: 'xds-banner-icon', visualProps: ['status']},
     ],
     vars: [
       {name: '--banner-radius', description: 'Border radius (card variant only)', default: 'var(--radius-3)'},
@@ -248,7 +248,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-banner', visualProps: ['variant']},
-      {className: 'xds-banner-icon'},
+      {className: 'xds-banner-icon', visualProps: ['status']},
     ],
     vars: [
       {name: '--banner-radius', description: 'Border radius (card variant only)', default: 'var(--radius-3)'},

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -118,6 +118,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-banner', visualProps: ['variant']},
+      {className: 'xds-banner-icon'},
     ],
     vars: [
       {name: '--banner-radius', description: 'Border radius (card variant only)', default: 'var(--radius-3)'},
@@ -247,6 +248,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-banner', visualProps: ['variant']},
+      {className: 'xds-banner-icon'},
     ],
     vars: [
       {name: '--banner-radius', description: 'Border radius (card variant only)', default: 'var(--radius-3)'},

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -404,7 +404,7 @@ export function XDSBanner({
         )}>
         <div
           {...mergeProps(
-            xdsClassName('banner-icon'),
+            xdsClassName('banner-icon', {status}),
             stylex.props(styles.iconWrapper),
           )}
           aria-hidden="true">

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -402,7 +402,12 @@ export function XDSBanner({
           isSingleLine && styles.headerCentered,
           statusStyles[status],
         )}>
-        <div {...stylex.props(styles.iconWrapper)} aria-hidden="true">
+        <div
+          {...mergeProps(
+            xdsClassName('banner-icon'),
+            stylex.props(styles.iconWrapper),
+          )}
+          aria-hidden="true">
           {icon != null ? (
             icon
           ) : (

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -119,7 +119,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-calendar', visualProps: ['mode']},
-      {className: 'xds-calendar-day'},
+      {className: 'xds-calendar-day', states: ['selected', 'today', 'disabled', 'in-range']},
     ],
   },
   notes: [
@@ -249,7 +249,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-calendar', visualProps: ['mode']},
-      {className: 'xds-calendar-day'},
+      {className: 'xds-calendar-day', states: ['selected', 'today', 'disabled', 'in-range']},
     ],
   },
   notes: [

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -119,6 +119,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-calendar', visualProps: ['mode']},
+      {className: 'xds-calendar-day'},
     ],
   },
   notes: [
@@ -248,6 +249,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-calendar', visualProps: ['mode']},
+      {className: 'xds-calendar-day'},
     ],
   },
   notes: [

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -813,7 +813,13 @@ function DayCell({
         onMouseEnter={() => !isDisabled && onDayHover(date)}
         onMouseLeave={() => onDayHover(null)}
         {...mergeProps(
-          xdsClassName('calendar-day'),
+          xdsClassName('calendar-day', {
+            selected:
+              isSelected || isRangeStart || isRangeEnd ? 'selected' : null,
+            today: isToday ? 'today' : null,
+            disabled: isDisabled ? 'disabled' : null,
+            'in-range': isInRange ? 'in-range' : null,
+          }),
           stylex.props(
             dayCellStyles.day,
             dayCellTheme.day,

--- a/packages/core/src/Calendar/XDSCalendar.tsx
+++ b/packages/core/src/Calendar/XDSCalendar.tsx
@@ -812,21 +812,27 @@ function DayCell({
         onClick={() => !isDisabled && onDayClick(date)}
         onMouseEnter={() => !isDisabled && onDayHover(date)}
         onMouseLeave={() => onDayHover(null)}
-        {...stylex.props(
-          dayCellStyles.day,
-          dayCellTheme.day,
-          isOutside && dayCellStyles.dayOutside,
-          isOutside && dayCellTheme.dayOutside,
-          isToday && !isSelected && !isInRange && dayCellStyles.dayToday,
-          isToday && !isSelected && !isInRange && dayCellTheme.dayToday,
-          isToday && !isSelected && isInRange && dayCellStyles.dayTodayInRange,
-          isToday && !isSelected && isInRange && dayCellTheme.dayTodayInRange,
-          (isSelected || isRangeStart || isRangeEnd) &&
-            dayCellStyles.daySelected,
-          (isSelected || isRangeStart || isRangeEnd) &&
-            dayCellTheme.daySelected,
-          isDisabled && dayCellStyles.dayDisabled,
-          isDisabled && dayCellTheme.dayDisabled,
+        {...mergeProps(
+          xdsClassName('calendar-day'),
+          stylex.props(
+            dayCellStyles.day,
+            dayCellTheme.day,
+            isOutside && dayCellStyles.dayOutside,
+            isOutside && dayCellTheme.dayOutside,
+            isToday && !isSelected && !isInRange && dayCellStyles.dayToday,
+            isToday && !isSelected && !isInRange && dayCellTheme.dayToday,
+            isToday &&
+              !isSelected &&
+              isInRange &&
+              dayCellStyles.dayTodayInRange,
+            isToday && !isSelected && isInRange && dayCellTheme.dayTodayInRange,
+            (isSelected || isRangeStart || isRangeEnd) &&
+              dayCellStyles.daySelected,
+            (isSelected || isRangeStart || isRangeEnd) &&
+              dayCellTheme.daySelected,
+            isDisabled && dayCellStyles.dayDisabled,
+            isDisabled && dayCellTheme.dayDisabled,
+          ),
         )}>
         {dayNumber}
       </button>

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -188,7 +188,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-checkbox-input', visualProps: ['size']},
-      {className: 'xds-checkbox'},
+      {className: 'xds-checkbox', states: ['checked', 'disabled']},
     ],
   },
   notes: [
@@ -384,7 +384,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-checkbox-input', visualProps: ['size']},
-      {className: 'xds-checkbox'},
+      {className: 'xds-checkbox', states: ['checked', 'disabled']},
     ],
   },
   notes: [

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -387,7 +387,10 @@ export function XDSCheckboxInput({
           <div
             aria-hidden="true"
             {...mergeProps(
-              xdsClassName('checkbox'),
+              xdsClassName('checkbox', {
+                checked: isCheckedOrIndeterminate ? 'checked' : null,
+                disabled: isDisabled ? 'disabled' : null,
+              }),
               stylex.props(
                 styles.checkbox,
                 checkboxSizeStyles[size],
@@ -435,8 +438,7 @@ export function XDSCheckboxInput({
             )}
           </div>
         </div>
-        <div
-          {...stylex.props(styles.labelWrapper)}>
+        <div {...stylex.props(styles.labelWrapper)}>
           <XDSFieldLabel
             label={label}
             inputID={id}

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -111,7 +111,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-progressbar', visualProps: ['size', 'variant']},
-      {className: 'xds-progressbar-fill'},
+      {className: 'xds-progressbar-fill', visualProps: ['variant']},
     ],
   },
   accessibility: [
@@ -235,7 +235,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-progressbar', visualProps: ['size', 'variant']},
-      {className: 'xds-progressbar-fill'},
+      {className: 'xds-progressbar-fill', visualProps: ['variant']},
     ],
   },
   accessibility: [

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -111,6 +111,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-progressbar', visualProps: ['size', 'variant']},
+      {className: 'xds-progressbar-fill'},
     ],
   },
   accessibility: [
@@ -234,6 +235,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-progressbar', visualProps: ['size', 'variant']},
+      {className: 'xds-progressbar-fill'},
     ],
   },
   accessibility: [

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -319,14 +319,14 @@ export function XDSProgressBar({
         {isIndeterminate ? (
           <div
             {...mergeProps(
-              xdsClassName('progressbar-fill'),
+              xdsClassName('progressbar-fill', {variant}),
               stylex.props(styles.indeterminateFill, variantStyles[variant]),
             )}
           />
         ) : (
           <div
             {...mergeProps(
-              xdsClassName('progressbar-fill'),
+              xdsClassName('progressbar-fill', {variant}),
               stylex.props(styles.fill, variantStyles[variant]),
             )}
             style={{width: `${percentage}%`}}

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -318,11 +318,17 @@ export function XDSProgressBar({
         {...stylex.props(styles.track, sizeStyles[size])}>
         {isIndeterminate ? (
           <div
-            {...stylex.props(styles.indeterminateFill, variantStyles[variant])}
+            {...mergeProps(
+              xdsClassName('progressbar-fill'),
+              stylex.props(styles.indeterminateFill, variantStyles[variant]),
+            )}
           />
         ) : (
           <div
-            {...stylex.props(styles.fill, variantStyles[variant])}
+            {...mergeProps(
+              xdsClassName('progressbar-fill'),
+              stylex.props(styles.fill, variantStyles[variant]),
+            )}
             style={{width: `${percentage}%`}}
           />
         )}

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -88,8 +88,8 @@ export const docs = {
     targets: [
       {className: 'xds-radio-list', visualProps: ['orientation', 'size']},
       {className: 'xds-radio-list-item'},
-      {className: 'xds-radio'},
-      {className: 'xds-radio-dot'},
+      {className: 'xds-radio', visualProps: ['size']},
+      {className: 'xds-radio-dot', visualProps: ['size']},
     ],
   },
   notes: [
@@ -342,8 +342,8 @@ export const docsZh = {
     targets: [
       {className: 'xds-radio-list', visualProps: ['orientation', 'size']},
       {className: 'xds-radio-list-item'},
-      {className: 'xds-radio'},
-      {className: 'xds-radio-dot'},
+      {className: 'xds-radio', visualProps: ['size']},
+      {className: 'xds-radio-dot', visualProps: ['size']},
     ],
   },
   notes: [

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -88,6 +88,8 @@ export const docs = {
     targets: [
       {className: 'xds-radio-list', visualProps: ['orientation', 'size']},
       {className: 'xds-radio-list-item'},
+      {className: 'xds-radio'},
+      {className: 'xds-radio-dot'},
     ],
   },
   notes: [
@@ -340,6 +342,8 @@ export const docsZh = {
     targets: [
       {className: 'xds-radio-list', visualProps: ['orientation', 'size']},
       {className: 'xds-radio-list-item'},
+      {className: 'xds-radio'},
+      {className: 'xds-radio-dot'},
     ],
   },
   notes: [

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -88,7 +88,7 @@ export const docs = {
     targets: [
       {className: 'xds-radio-list', visualProps: ['orientation', 'size']},
       {className: 'xds-radio-list-item'},
-      {className: 'xds-radio', visualProps: ['size']},
+      {className: 'xds-radio', visualProps: ['size'], states: ['checked', 'disabled']},
       {className: 'xds-radio-dot', visualProps: ['size']},
     ],
   },
@@ -342,7 +342,7 @@ export const docsZh = {
     targets: [
       {className: 'xds-radio-list', visualProps: ['orientation', 'size']},
       {className: 'xds-radio-list-item'},
-      {className: 'xds-radio', visualProps: ['size']},
+      {className: 'xds-radio', visualProps: ['size'], states: ['checked', 'disabled']},
       {className: 'xds-radio-dot', visualProps: ['size']},
     ],
   },

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -290,15 +290,23 @@ export function XDSRadioListItem({
         />
         <div
           aria-hidden="true"
-          {...stylex.props(
-            styles.radio,
-            radioSizeStyles[size],
-            isChecked ? styles.radioChecked : styles.radioUnchecked,
-            isDisabled && styles.radioDisabled,
-            isDisabled && !isChecked && styles.radioDisabledUnchecked,
+          {...mergeProps(
+            xdsClassName('radio'),
+            stylex.props(
+              styles.radio,
+              radioSizeStyles[size],
+              isChecked ? styles.radioChecked : styles.radioUnchecked,
+              isDisabled && styles.radioDisabled,
+              isDisabled && !isChecked && styles.radioDisabledUnchecked,
+            ),
           )}>
           {isChecked && (
-            <div {...stylex.props(styles.innerDot, dotSizeStyles[size])} />
+            <div
+              {...mergeProps(
+                xdsClassName('radio-dot'),
+                stylex.props(styles.innerDot, dotSizeStyles[size]),
+              )}
+            />
           )}
         </div>
       </div>

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -291,7 +291,7 @@ export function XDSRadioListItem({
         <div
           aria-hidden="true"
           {...mergeProps(
-            xdsClassName('radio'),
+            xdsClassName('radio', {size}),
             stylex.props(
               styles.radio,
               radioSizeStyles[size],
@@ -303,7 +303,7 @@ export function XDSRadioListItem({
           {isChecked && (
             <div
               {...mergeProps(
-                xdsClassName('radio-dot'),
+                xdsClassName('radio-dot', {size}),
                 stylex.props(styles.innerDot, dotSizeStyles[size]),
               )}
             />

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -291,7 +291,11 @@ export function XDSRadioListItem({
         <div
           aria-hidden="true"
           {...mergeProps(
-            xdsClassName('radio', {size}),
+            xdsClassName('radio', {
+              size,
+              checked: isChecked ? 'checked' : null,
+              disabled: isDisabled ? 'disabled' : null,
+            }),
             stylex.props(
               styles.radio,
               radioSizeStyles[size],

--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -221,6 +221,13 @@ export const docs = {
         'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
     },
   ],
+  theming: {
+    targets: [
+      {className: 'xds-slider'},
+      {className: 'xds-slider-track'},
+      {className: 'xds-slider-thumb'},
+    ],
+  },
   accessibility: [
     'Uses `role="slider"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`, and `aria-valuetext` on each thumb.',
     'The label is always rendered in the DOM for accessibility even when `isLabelHidden` is true.',
@@ -460,6 +467,13 @@ export const docsZh = {
         '用于布局自定义的 StyleX 样式（边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
     },
   ],
+  theming: {
+    targets: [
+      {className: 'xds-slider'},
+      {className: 'xds-slider-track'},
+      {className: 'xds-slider-thumb'},
+    ],
+  },
   accessibility: [
     '每个滑块使用 `role="slider"`，配合 `aria-valuenow`、`aria-valuemin`、`aria-valuemax` 和 `aria-valuetext`。',
     '即使 `isLabelHidden` 为 true，标签也始终在 DOM 中渲染以确保无障碍可访问性。',

--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -223,9 +223,9 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-slider'},
-      {className: 'xds-slider-track'},
-      {className: 'xds-slider-thumb'},
+      {className: 'xds-slider', visualProps: ['orientation']},
+      {className: 'xds-slider-track', visualProps: ['orientation']},
+      {className: 'xds-slider-thumb', visualProps: ['orientation']},
     ],
   },
   accessibility: [
@@ -469,9 +469,9 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-slider'},
-      {className: 'xds-slider-track'},
-      {className: 'xds-slider-thumb'},
+      {className: 'xds-slider', visualProps: ['orientation']},
+      {className: 'xds-slider-track', visualProps: ['orientation']},
+      {className: 'xds-slider-thumb', visualProps: ['orientation']},
     ],
   },
   accessibility: [

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -576,7 +576,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
         style={positionStyle}
         onKeyDown={e => handleKeyDown(thumbIndex, e)}
         {...mergeProps(
-          xdsClassName('slider-thumb'),
+          xdsClassName('slider-thumb', {orientation}),
           stylex.props(
             styles.thumb,
             isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
@@ -657,7 +657,10 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
       className={className}
       style={style}>
       <div
-        {...mergeProps(xdsClassName('slider'), stylex.props(styles.sliderRow))}>
+        {...mergeProps(
+          xdsClassName('slider', {orientation}),
+          stylex.props(styles.sliderRow),
+        )}>
         <div
           ref={node => {
             // Merge refs
@@ -684,7 +687,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
           {/* Background track */}
           <div
             {...mergeProps(
-              xdsClassName('slider-track'),
+              xdsClassName('slider-track', {orientation}),
               stylex.props(
                 styles.track,
                 isHorizontal ? styles.trackHorizontal : styles.trackVertical,

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -34,6 +34,7 @@ import {
 import {XDSField} from '../Field/XDSField';
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import type {XDSInputStatus} from '../Field/types';
+import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
 // Types
@@ -574,12 +575,15 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
         aria-describedby={ariaDescribedBy}
         style={positionStyle}
         onKeyDown={e => handleKeyDown(thumbIndex, e)}
-        {...stylex.props(
-          styles.thumb,
-          isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
-          !isDisabled && styles.thumbHover,
-          !isDisabled && styles.thumbFocusWithin,
-          isDisabled && styles.thumbDisabled,
+        {...mergeProps(
+          xdsClassName('slider-thumb'),
+          stylex.props(
+            styles.thumb,
+            isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
+            !isDisabled && styles.thumbHover,
+            !isDisabled && styles.thumbFocusWithin,
+            isDisabled && styles.thumbDisabled,
+          ),
         )}
       />
     );
@@ -652,7 +656,8 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
       xstyle={xstyle}
       className={className}
       style={style}>
-      <div {...stylex.props(styles.sliderRow)}>
+      <div
+        {...mergeProps(xdsClassName('slider'), stylex.props(styles.sliderRow))}>
         <div
           ref={node => {
             // Merge refs
@@ -678,9 +683,12 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
           )}>
           {/* Background track */}
           <div
-            {...stylex.props(
-              styles.track,
-              isHorizontal ? styles.trackHorizontal : styles.trackVertical,
+            {...mergeProps(
+              xdsClassName('slider-track'),
+              stylex.props(
+                styles.track,
+                isHorizontal ? styles.trackHorizontal : styles.trackVertical,
+              ),
             )}
           />
 

--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -188,8 +188,8 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-switch'},
-      {className: 'xds-switch-thumb'},
+      {className: 'xds-switch', states: ['checked', 'disabled']},
+      {className: 'xds-switch-thumb', states: ['checked']},
       {className: 'xds-switch-field', visualProps: ['labelPosition', 'labelSpacing']},
     ],
   },
@@ -401,8 +401,8 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-switch'},
-      {className: 'xds-switch-thumb'},
+      {className: 'xds-switch', states: ['checked', 'disabled']},
+      {className: 'xds-switch-thumb', states: ['checked']},
       {className: 'xds-switch-field', visualProps: ['labelPosition', 'labelSpacing']},
     ],
   },

--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -189,6 +189,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-switch'},
+      {className: 'xds-switch-thumb'},
       {className: 'xds-switch-field', visualProps: ['labelPosition', 'labelSpacing']},
     ],
   },
@@ -401,6 +402,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-switch'},
+      {className: 'xds-switch-thumb'},
       {className: 'xds-switch-field', visualProps: ['labelPosition', 'labelSpacing']},
     ],
   },

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -355,7 +355,10 @@ export function XDSSwitch({
       <div
         aria-hidden="true"
         {...mergeProps(
-          xdsClassName('switch'),
+          xdsClassName('switch', {
+            checked: isOn ? 'checked' : null,
+            disabled: isDisabled ? 'disabled' : null,
+          }),
           stylex.props(
             styles.track,
             isOn ? styles.trackOn : styles.trackOff,
@@ -366,7 +369,7 @@ export function XDSSwitch({
         )}>
         <div
           {...mergeProps(
-            xdsClassName('switch-thumb'),
+            xdsClassName('switch-thumb', {checked: isOn ? 'checked' : null}),
             stylex.props(styles.thumb, isOn ? styles.thumbOn : styles.thumbOff),
           )}>
           {isBusy && <XDSSpinner size="sm" />}

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -365,9 +365,9 @@ export function XDSSwitch({
           ),
         )}>
         <div
-          {...stylex.props(
-            styles.thumb,
-            isOn ? styles.thumbOn : styles.thumbOff,
+          {...mergeProps(
+            xdsClassName('switch-thumb'),
+            stylex.props(styles.thumb, isOn ? styles.thumbOn : styles.thumbOff),
           )}>
           {isBusy && <XDSSpinner size="sm" />}
         </div>

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -91,6 +91,12 @@ export interface ThemingTarget {
    *  Themes can target specific variants via `.xds-button.secondary`.
    *  Omit if the component has no visual props (class name only). */
   visualProps?: string[];
+  /** State class names that appear on this element based on component state.
+   *  Unlike visualProps (driven by props), these reflect runtime state
+   *  (checked, selected, today, on, expanded, etc.).
+   *  Themes target them the same way as variants: `.xds-radio.checked { ... }`
+   *  Omit if the element has no state-driven classes. */
+  states?: string[];
 }
 
 /**


### PR DESCRIPTION
## What

Add 9 new `xdsClassName` targets across 6 components to enable granular sub-element theming via `defineTheme` component overrides.

Theme authors currently can't target important sub-elements like the radio circle, switch thumb, slider track, calendar day buttons, etc. This PR adds the missing class name hooks so `defineTheme` overrides can reach these elements.

## Changes

| Component | New targets | Element |
|-----------|-----------|---------|
| RadioListItem | `xds-radio`, `xds-radio-dot` | Radio circle + inner dot |
| Switch | `xds-switch-thumb` | Thumb element |
| Slider | `xds-slider`, `xds-slider-track`, `xds-slider-thumb` | Wrapper, track, thumb |
| Calendar | `xds-calendar-day` | Day button cells |
| Banner | `xds-banner-icon` | Icon wrapper |
| ProgressBar | `xds-progressbar-fill` | Fill indicator |

All targets use the `mergeProps(xdsClassName(...), stylex.props(...))` pattern consistent with existing components.

Also updates `.doc.mjs` theming.targets arrays for each component (both English and Chinese docs).

## Testing

All 1765 tests pass across 110 test files.

Closes #762
