### PR TITLE
feat(theme): extensible variant types via module augmentation

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -81,7 +81,30 @@ export type XDSAppShellBreakpoint = 'sm' | 'md' | 'lg' | 'none';
  * - `elevated`: Wash nav background with elevated surface content + border radius
  * @default 'section'
  */
-export type XDSAppShellVariant = 'wash' | 'surface' | 'section' | 'elevated';
+/**
+ * Extensible variant map for XDSAppShell.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/AppShell' {
+ *   interface XDSAppShellVariantMap {
+ *     'glass': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSAppShellVariantMap {
+  wash: true;
+  surface: true;
+  section: true;
+  elevated: true;
+}
+
+/**
+ * Navigation background style. Extensible via module augmentation of XDSAppShellVariantMap.
+ */
+export type XDSAppShellVariant = keyof XDSAppShellVariantMap;
 
 /**
  * Configuration object for mobile navigation behavior.
@@ -736,6 +759,7 @@ export function XDSAppShell({
       <div
         ref={setShellRef}
         data-testid={dataTestId}
+        data-variant={variant}
         {...mergeProps(
           xdsClassName('app-shell', {height, variant}),
           stylex.props(

--- a/packages/core/src/AppShell/index.ts
+++ b/packages/core/src/AppShell/index.ts
@@ -12,6 +12,7 @@ export type {
   XDSAppShellProps,
   XDSAppShellBreakpoint,
   XDSAppShellVariant,
+  XDSAppShellVariantMap,
   XDSMobileNavConfig,
 } from './XDSAppShell';
 export {

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -49,7 +49,29 @@ function resolveStatusDotSize(avatarSize: number): {
   return {dotSize: 24, borderWidth: 4, iconSize: 14};
 }
 
-export type XDSAvatarStatusDotVariant = 'positive' | 'neutral' | 'negative';
+/**
+ * Extensible variant map for XDSAvatarStatusDot.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Avatar' {
+ *   interface XDSAvatarStatusDotVariantMap {
+ *     'away': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSAvatarStatusDotVariantMap {
+  positive: true;
+  neutral: true;
+  negative: true;
+}
+
+/**
+ * AvatarStatusDot variant type. Extensible via module augmentation of XDSAvatarStatusDotVariantMap.
+ */
+export type XDSAvatarStatusDotVariant = keyof XDSAvatarStatusDotVariantMap;
 
 export interface XDSAvatarStatusDotProps extends XDSBaseProps<HTMLSpanElement> {
   /**
@@ -122,12 +144,13 @@ const dynamicStyles = stylex.create({
   }),
 });
 
-const variantStyleMap: Record<XDSAvatarStatusDotVariant, stylex.StyleXStyles> =
-  {
-    positive: styles.positive,
-    neutral: styles.neutral,
-    negative: styles.negative,
-  };
+const variantStyleMap: Partial<
+  Record<XDSAvatarStatusDotVariant, stylex.StyleXStyles>
+> = {
+  positive: styles.positive,
+  neutral: styles.neutral,
+  negative: styles.negative,
+};
 
 /**
  * A status indicator dot that automatically scales to match the parent
@@ -165,6 +188,7 @@ export function XDSAvatarStatusDot({
   return (
     <div
       {...(label ? {'aria-label': label} : undefined)}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('avatar-status-dot', {variant}),
         stylex.props(

--- a/packages/core/src/Avatar/index.ts
+++ b/packages/core/src/Avatar/index.ts
@@ -13,4 +13,5 @@ export {XDSAvatarStatusDot} from './XDSAvatarStatusDot';
 export type {
   XDSAvatarStatusDotProps,
   XDSAvatarStatusDotVariant,
+  XDSAvatarStatusDotVariantMap,
 } from './XDSAvatarStatusDot';

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -77,9 +77,31 @@ const variants = stylex.create({
 });
 
 /**
- * Badge variant type derived from the variants StyleX object
+ * Extensible variant map for XDSBadge.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Badge' {
+ *   interface XDSBadgeVariantMap {
+ *     'premium': true;
+ *   }
+ * }
+ * ```
  */
-export type XDSBadgeVariant = keyof typeof variants;
+export interface XDSBadgeVariantMap {
+  neutral: true;
+  info: true;
+  success: true;
+  warning: true;
+  error: true;
+}
+
+/**
+ * Badge variant type derived from XDSBadgeVariantMap.
+ * Extensible via module augmentation of XDSBadgeVariantMap.
+ */
+export type XDSBadgeVariant = keyof XDSBadgeVariantMap;
 
 export interface XDSBadgeProps extends XDSBaseProps<HTMLSpanElement> {
   /** Ref forwarded to the root element */
@@ -130,6 +152,7 @@ export function XDSBadge({
   return (
     <span
       ref={ref}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('badge', {variant}),
         stylex.props(

--- a/packages/core/src/Badge/index.ts
+++ b/packages/core/src/Badge/index.ts
@@ -3,4 +3,8 @@
  */
 
 export {XDSBadge} from './XDSBadge';
-export type {XDSBadgeProps, XDSBadgeVariant} from './XDSBadge';
+export type {
+  XDSBadgeProps,
+  XDSBadgeVariant,
+  XDSBadgeVariantMap,
+} from './XDSBadge';

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -53,11 +53,31 @@ import {xdsClassName, mergeProps} from '../utils';
 export type XDSBannerStatus = 'info' | 'warning' | 'error' | 'success';
 
 /**
+ * Extensible variant map for XDSBanner.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Banner' {
+ *   interface XDSBannerVariantMap {
+ *     'floating': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSBannerVariantMap {
+  card: true;
+  section: true;
+}
+
+/**
  * Visual variant of the banner.
  * - `card`: standalone card with border-radius and shadow
  * - `section`: full-width section banner (no border-radius)
+ *
+ * Extensible via module augmentation of XDSBannerVariantMap.
  */
-export type XDSBannerVariant = 'card' | 'section';
+export type XDSBannerVariant = keyof XDSBannerVariantMap;
 
 export interface XDSBannerProps {
   /** Ref forwarded to the root element */
@@ -384,6 +404,7 @@ export function XDSBanner({
       ref={ref}
       role={role}
       data-testid={testId}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('banner', {variant}),
         stylex.props(

--- a/packages/core/src/Banner/index.ts
+++ b/packages/core/src/Banner/index.ts
@@ -12,4 +12,5 @@ export type {
   XDSBannerProps,
   XDSBannerStatus,
   XDSBannerVariant,
+  XDSBannerVariantMap,
 } from './XDSBanner';

--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbs.tsx
@@ -30,11 +30,31 @@ import {xdsClassName, mergeProps} from '../utils';
 // =============================================================================
 
 /**
+ * Extensible variant map for XDSBreadcrumbs.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Breadcrumbs' {
+ *   interface XDSBreadcrumbsVariantMap {
+ *     'compact': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSBreadcrumbsVariantMap {
+  default: true;
+  supporting: true;
+}
+
+/**
  * Visual variant for the breadcrumb trail.
  * - `'default'`: Standard text styling
  * - `'supporting'`: Smaller, secondary text for supporting context
+ *
+ * Extensible via module augmentation of XDSBreadcrumbsVariantMap.
  */
-export type XDSBreadcrumbsVariant = 'default' | 'supporting';
+export type XDSBreadcrumbsVariant = keyof XDSBreadcrumbsVariantMap;
 
 // =============================================================================
 // Context shared with XDSBreadcrumbItem
@@ -226,6 +246,7 @@ export function XDSBreadcrumbs({
       ref={ref}
       aria-label={label}
       data-testid={testId}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('breadcrumbs', {variant}),
         stylex.props(navStyles.root, xstyle),

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -6,6 +6,7 @@ export {XDSBreadcrumbs} from './XDSBreadcrumbs';
 export type {
   XDSBreadcrumbsProps,
   XDSBreadcrumbsVariant,
+  XDSBreadcrumbsVariantMap,
 } from './XDSBreadcrumbs';
 export {XDSBreadcrumbItem} from './XDSBreadcrumbItem';
 export type {XDSBreadcrumbItemProps} from './XDSBreadcrumbItem';

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -184,9 +184,30 @@ const variants = stylex.create({
 });
 
 /**
- * Button variant type derived from the variants StyleX object
+ * Extensible variant map for XDSButton.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Button' {
+ *   interface XDSButtonVariantMap {
+ *     'primary-muted': true;
+ *   }
+ * }
+ * ```
  */
-export type XDSButtonVariant = keyof typeof variants;
+export interface XDSButtonVariantMap {
+  primary: true;
+  secondary: true;
+  ghost: true;
+  destructive: true;
+}
+
+/**
+ * Button variant type derived from XDSButtonVariantMap.
+ * Extensible via module augmentation of XDSButtonVariantMap.
+ */
+export type XDSButtonVariant = keyof XDSButtonVariantMap;
 
 /**
  * Button size type derived from the sizeStyles StyleX object
@@ -372,6 +393,7 @@ export function XDSButton({
       disabled={buttonDisabled}
       aria-label={isIconOnly ? label : undefined}
       aria-busy={isLoadingState || undefined}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('button', {variant, size}),
         stylex.props(

--- a/packages/core/src/Button/index.ts
+++ b/packages/core/src/Button/index.ts
@@ -13,3 +13,4 @@ export type {
   XDSButtonVariant,
   XDSButtonSize,
 } from './XDSButton';
+export type {XDSButtonVariantMap} from './XDSButton';

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -26,11 +26,31 @@ import {
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
+ * Extensible variant map for XDSDialog.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Dialog' {
+ *   interface XDSDialogVariantMap {
+ *     'drawer': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSDialogVariantMap {
+  standard: true;
+  fullscreen: true;
+}
+
+/**
  * Dialog variant type
  * - standard: Normal dialog with configurable width/height
  * - fullscreen: Takes up the entire viewport
+ *
+ * Extensible via module augmentation of XDSDialogVariantMap.
  */
-export type XDSDialogVariant = 'standard' | 'fullscreen';
+export type XDSDialogVariant = keyof XDSDialogVariantMap;
 
 /**
  * Dialog purpose type - controls dismissal behavior
@@ -325,6 +345,7 @@ export function XDSDialog({
       onClick={handleClick}
       onCancel={handleCancel}
       aria-modal="true"
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('dialog', {variant}),
         stylex.props(

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -11,6 +11,7 @@ export {XDSDialog} from './XDSDialog';
 export type {
   XDSDialogProps,
   XDSDialogVariant,
+  XDSDialogVariantMap,
   XDSDialogPurpose,
   XDSDialogPosition,
 } from './XDSDialog';

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -24,6 +24,29 @@ import {
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
+/**
+ * Extensible variant map for XDSDivider.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Divider' {
+ *   interface XDSDividerVariantMap {
+ *     'accent': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSDividerVariantMap {
+  subtle: true;
+  strong: true;
+}
+
+/**
+ * Divider variant type. Extensible via module augmentation of XDSDividerVariantMap.
+ */
+export type XDSDividerVariant = keyof XDSDividerVariantMap;
+
 export interface XDSDividerProps extends Omit<
   XDSBaseProps<HTMLDivElement>,
   'children'
@@ -48,7 +71,7 @@ export interface XDSDividerProps extends Omit<
    * - 'strong': Uses --color-border-emphasized
    * @default 'subtle'
    */
-  variant?: 'subtle' | 'strong';
+  variant?: XDSDividerVariant;
 
   /**
    * Makes the divider escape its parent's container padding.
@@ -167,6 +190,7 @@ export function XDSDivider({
       ref={ref as React.Ref<HTMLDivElement>}
       role="separator"
       aria-orientation={orientation}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('divider', {variant, orientation}),
         stylex.props(

--- a/packages/core/src/Divider/index.ts
+++ b/packages/core/src/Divider/index.ts
@@ -8,4 +8,8 @@
  */
 
 export {XDSDivider} from './XDSDivider';
-export type {XDSDividerProps} from './XDSDivider';
+export type {
+  XDSDividerProps,
+  XDSDividerVariant,
+  XDSDividerVariantMap,
+} from './XDSDivider';

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -58,7 +58,28 @@ const colorStyles = stylex.create({
   },
 });
 
-export type XDSFieldStatusVariant = 'attached' | 'detached';
+/**
+ * Extensible variant map for XDSFieldStatus.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Field' {
+ *   interface XDSFieldStatusVariantMap {
+ *     'inline': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSFieldStatusVariantMap {
+  attached: true;
+  detached: true;
+}
+
+/**
+ * FieldStatus variant type. Extensible via module augmentation of XDSFieldStatusVariantMap.
+ */
+export type XDSFieldStatusVariant = keyof XDSFieldStatusVariantMap;
 
 export interface XDSFieldStatusProps {
   /**
@@ -107,6 +128,7 @@ export function XDSFieldStatus({
   return (
     <div
       id={id}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('field-status', {type, variant}),
         stylex.props(

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -19,6 +19,7 @@ export {XDSFieldStatus as XDSFieldStatusComponent} from './XDSFieldStatus';
 export type {
   XDSFieldStatusProps,
   XDSFieldStatusVariant,
+  XDSFieldStatusVariantMap,
 } from './XDSFieldStatus';
 
 // Shared input types

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -38,13 +38,31 @@ import {xdsClassName, mergeProps} from '../utils';
 // Types
 // =============================================================================
 
-/** Visual variant controlling what appears between prev/next buttons. */
-export type XDSPaginationVariant =
-  | 'pages'
-  | 'count'
-  | 'compact'
-  | 'dots'
-  | 'none';
+/**
+ * Extensible variant map for XDSPagination.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Pagination' {
+ *   interface XDSPaginationVariantMap {
+ *     'progress': true;
+ *   }
+ * }
+ * ```
+ */
+export interface XDSPaginationVariantMap {
+  pages: true;
+  count: true;
+  compact: true;
+  dots: true;
+  none: true;
+}
+
+/** Visual variant controlling what appears between prev/next buttons.
+ * Extensible via module augmentation of XDSPaginationVariantMap.
+ */
+export type XDSPaginationVariant = keyof XDSPaginationVariantMap;
 
 /** Size of the pagination controls. */
 export type XDSPaginationSize = 'sm' | 'md';
@@ -508,6 +526,7 @@ export function XDSPagination({
       ref={ref}
       aria-label={label}
       data-testid={testId}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('pagination', {variant, size}),
         stylex.props(styles.root, xstyle),

--- a/packages/core/src/Pagination/index.ts
+++ b/packages/core/src/Pagination/index.ts
@@ -9,5 +9,6 @@ export {XDSPagination, generatePageRange} from './XDSPagination';
 export type {
   XDSPaginationProps,
   XDSPaginationVariant,
+  XDSPaginationVariantMap,
   XDSPaginationSize,
 } from './XDSPagination';

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -29,13 +29,30 @@ import {
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
- * Progress bar variant type — maps to semantic color tokens.
+ * Extensible variant map for XDSProgressBar.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/ProgressBar' {
+ *   interface XDSProgressBarVariantMap {
+ *     'brand': true;
+ *   }
+ * }
+ * ```
  */
-export type XDSProgressBarVariant =
-  | 'accent'
-  | 'positive'
-  | 'warning'
-  | 'negative';
+export interface XDSProgressBarVariantMap {
+  accent: true;
+  positive: true;
+  warning: true;
+  negative: true;
+}
+
+/**
+ * Progress bar variant type — maps to semantic color tokens.
+ * Extensible via module augmentation of XDSProgressBarVariantMap.
+ */
+export type XDSProgressBarVariant = keyof XDSProgressBarVariantMap;
 
 /**
  * Progress bar size type — controls track height.
@@ -279,6 +296,7 @@ export function XDSProgressBar({
   return (
     <div
       ref={ref}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('progressbar', {variant, size}),
         stylex.props(styles.container, xstyle),

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -6,5 +6,6 @@ export {XDSProgressBar} from './XDSProgressBar';
 export type {
   XDSProgressBarProps,
   XDSProgressBarVariant,
+  XDSProgressBarVariantMap,
   XDSProgressBarSize,
 } from './XDSProgressBar';

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -27,9 +27,29 @@ import type {SizeValue, SpacingStep} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
- * Visual variant for the section.
+ * Extensible variant map for XDSSection.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/Section' {
+ *   interface XDSSectionVariantMap {
+ *     'elevated': true;
+ *   }
+ * }
+ * ```
  */
-export type XDSSectionVariant = 'section' | 'transparent' | 'wash';
+export interface XDSSectionVariantMap {
+  section: true;
+  transparent: true;
+  wash: true;
+}
+
+/**
+ * Visual variant for the section.
+ * Extensible via module augmentation of XDSSectionVariantMap.
+ */
+export type XDSSectionVariant = keyof XDSSectionVariantMap;
 
 const variantStyles = stylex.create({
   section: {
@@ -222,6 +242,7 @@ export function XDSSection({
   return (
     <div
       ref={ref as React.Ref<HTMLDivElement>}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('section', {variant}),
         stylex.props(

--- a/packages/core/src/Section/index.ts
+++ b/packages/core/src/Section/index.ts
@@ -8,4 +8,8 @@
  */
 
 export {XDSSection} from './XDSSection';
-export type {XDSSectionProps, XDSSectionVariant} from './XDSSection';
+export type {
+  XDSSectionProps,
+  XDSSectionVariant,
+  XDSSectionVariantMap,
+} from './XDSSection';

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -83,9 +83,31 @@ const variants = stylex.create({
 });
 
 /**
- * Status dot variant type
+ * Extensible variant map for XDSStatusDot.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@xds/core/StatusDot' {
+ *   interface XDSStatusDotVariantMap {
+ *     'critical': true;
+ *   }
+ * }
+ * ```
  */
-export type XDSStatusDotVariant = keyof typeof variants;
+export interface XDSStatusDotVariantMap {
+  positive: true;
+  warning: true;
+  negative: true;
+  info: true;
+  neutral: true;
+}
+
+/**
+ * Status dot variant type derived from XDSStatusDotVariantMap.
+ * Extensible via module augmentation of XDSStatusDotVariantMap.
+ */
+export type XDSStatusDotVariant = keyof XDSStatusDotVariantMap;
 
 /**
  * Status dot size type
@@ -170,6 +192,7 @@ export function XDSStatusDot({
       ref={ref}
       role="img"
       aria-label={label}
+      data-variant={variant}
       {...mergeProps(
         xdsClassName('statusdot', {variant, size}),
         stylex.props(

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -6,5 +6,6 @@ export {XDSStatusDot} from './XDSStatusDot';
 export type {
   XDSStatusDotProps,
   XDSStatusDotVariant,
+  XDSStatusDotVariantMap,
   XDSStatusDotSize,
 } from './XDSStatusDot';


### PR DESCRIPTION
## What

Replaces union type variant props with an interface registry + `keyof` pattern across all 13 components with variant props. This enables theme packages to extend variant types via TypeScript module augmentation — a zero-runtime-cost approach to type-safe extensibility.

Closes #759

## Why

Theme packages need to add custom variants (e.g. `primary-muted`, `glass`, `brand`) but the existing string union types are closed — there's no way to extend them without forking the core package. The interface registry pattern solves this at the type level.

## How

### Pattern

Before:
```ts
export type XDSButtonVariant = 'primary' | 'secondary' | 'ghost' | 'destructive';
```

After:
```ts
export interface XDSButtonVariantMap {
  primary: true;
  secondary: true;
  ghost: true;
  destructive: true;
}
export type XDSButtonVariant = keyof XDSButtonVariantMap;
```

### Theme package augmentation example

A theme package can now extend any component's variants:
```ts
// In @xds/theme-brand or any theme package:
declare module '@xds/core/Button' {
  interface XDSButtonVariantMap {
    'primary-muted': true;
    'brand': true;
  }
}

// Now TypeScript accepts these as valid variants:
<XDSButton variant="brand" label="Brand action" />
```

The theme CSS targets the variant via the `data-variant` attribute:
```css
.xds-button[data-variant="brand"] {
  background-color: var(--color-brand);
  color: var(--color-text-on-brand);
}
```

### Components updated (13 total)

| Component | Variants | Source |
|---|---|---|
| Button | primary, secondary, ghost, destructive | `keyof typeof variants` → VariantMap |
| Badge | neutral, info, success, warning, error | `keyof typeof variants` → VariantMap |
| StatusDot | positive, warning, negative, info, neutral | `keyof typeof variants` → VariantMap |
| Banner | card, section | string union → VariantMap |
| Dialog | standard, fullscreen | string union → VariantMap |
| AppShell | wash, surface, section, elevated | string union → VariantMap |
| Breadcrumbs | default, supporting | string union → VariantMap |
| FieldStatus | attached, detached | string union → VariantMap |
| Pagination | pages, count, compact, dots, none | string union → VariantMap |
| ProgressBar | accent, positive, warning, negative | string union → VariantMap |
| Section | section, transparent, wash | string union → VariantMap |
| AvatarStatusDot | positive, neutral, negative | string union → VariantMap |
| Divider | subtle, strong | inline union → VariantMap |

### Runtime safety

Unknown variants (added via augmentation but not yet in the StyleX object) gracefully apply base styles only:
- `variants[variant]` returns `undefined` for unknown keys
- `stylex.props(undefined)` ignores undefined values — no crash
- Conditional checks like `variant === 'card'` simply don't match — falls through to defaults

### data-variant attribute

Every component now renders `data-variant={variant}` on its root element, enabling theme CSS to target variants via attribute selectors: `[data-variant="brand"]`.

## Test plan

All 1765 tests pass across 110 test files. No type errors.
