### PR TITLE
fix(Dialog): hardening — swarm findings

### DIFF
--- a/packages/core/src/Dialog/XDSDialog.test.tsx
+++ b/packages/core/src/Dialog/XDSDialog.test.tsx
@@ -114,7 +114,7 @@ describe('XDSDialog', () => {
         </XDSDialog>,
       );
 
-      const dialog = screen.getByRole('dialog');
+      const dialog = screen.getByRole('alertdialog');
       const escapeEvent = new KeyboardEvent('keydown', {
         key: 'Escape',
         bubbles: true,
@@ -132,7 +132,7 @@ describe('XDSDialog', () => {
         </XDSDialog>,
       );
 
-      const dialog = screen.getByRole('dialog');
+      const dialog = screen.getByRole('alertdialog');
       const cancelEvent = new Event('cancel', {cancelable: true});
       dialog.dispatchEvent(cancelEvent);
 
@@ -217,5 +217,50 @@ describe('XDSDialog', () => {
       </XDSDialog>,
     );
     expect(screen.getByTestId('custom-dialog')).toBeInTheDocument();
+  });
+
+  it('does not forward native open prop to dialog element', () => {
+    render(
+      <XDSDialog
+        isOpen={false}
+        onOpenChange={() => {}}
+        {...({open: true} as Record<string, unknown>)}>
+        Content
+      </XDSDialog>,
+    );
+    const dialog = screen.getByRole('dialog', {hidden: true});
+    // isOpen=false controls state; native open prop must not leak through
+    expect(dialog).not.toHaveAttribute('open');
+  });
+
+  describe('alertdialog role', () => {
+    it('sets role="alertdialog" when purpose is "required"', () => {
+      render(
+        <XDSDialog isOpen={true} onOpenChange={() => {}} purpose="required">
+          Content
+        </XDSDialog>,
+      );
+      expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    });
+
+    it('does not set role="alertdialog" when purpose is "info"', () => {
+      render(
+        <XDSDialog isOpen={true} onOpenChange={() => {}} purpose="info">
+          Content
+        </XDSDialog>,
+      );
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+
+    it('does not set role="alertdialog" when purpose is "form"', () => {
+      render(
+        <XDSDialog isOpen={true} onOpenChange={() => {}} purpose="form">
+          Content
+        </XDSDialog>,
+      );
+      expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -100,7 +100,6 @@ const styles = stylex.create({
       default: 'scale(0.95) translateY(8px)',
       ':where([open])': 'scale(1) translateY(0)',
     },
-    // Include display and overlay so dialog stays visible during exit
     transitionProperty: 'opacity, transform, display, overlay',
     transitionDuration: durationVars['--duration-medium'],
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -152,7 +151,7 @@ const dynamicStyles = stylex.create({
     bottom: number | string | undefined,
     left: number | string | undefined,
   ) => ({
-    // When position is set, use explicit values and auto for unset axes
+    // When position is set, disable auto margin and use fixed positioning
     margin: 0,
     top: top !== undefined ? formatPosition(top) : 'auto',
     right: right !== undefined ? formatPosition(right) : 'auto',
@@ -348,7 +347,7 @@ export function XDSDialog({
   const isFullscreen = variant === 'fullscreen';
   const hasPosition = position != null && !isFullscreen;
 
-  // Filter out native `open` to prevent InvalidStateError when accidentally passed
+  // Filter out native open to prevent InvalidStateError when accidentally passed
   const {open: _open, ...safeProps} = props as Record<string, unknown>;
 
   return (

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/Dialog.stories.tsx (storybook stories)
  */
 
-
 import {useEffect, useRef, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
@@ -92,7 +91,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     overflow: 'hidden',
     height: 'fit-content',
-    // Animation for opening
+    // Animation for open/close
     opacity: {
       default: 0,
       ':where([open])': 1,
@@ -101,9 +100,18 @@ const styles = stylex.create({
       default: 'scale(0.95) translateY(8px)',
       ':where([open])': 'scale(1) translateY(0)',
     },
-    transitionProperty: 'opacity, transform',
+    // Include display and overlay so dialog stays visible during exit
+    transitionProperty: 'opacity, transform, display, overlay',
     transitionDuration: durationVars['--duration-medium'],
     transitionTimingFunction: easeVars['--ease-standard'],
+    transitionBehavior: 'allow-discrete',
+    '@starting-style': {
+      opacity: 0,
+      transform: 'scale(0.95) translateY(8px)',
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0s',
+    },
     outline: {
       default: null,
       ':focus-visible': `2px solid ${colorVars['--color-ring-focus']}`,
@@ -144,12 +152,12 @@ const dynamicStyles = stylex.create({
     bottom: number | string | undefined,
     left: number | string | undefined,
   ) => ({
-    // When position is set, disable auto margin and use fixed positioning
+    // When position is set, use explicit values and auto for unset axes
     margin: 0,
-    top: formatPosition(top),
-    right: formatPosition(right),
-    bottom: formatPosition(bottom),
-    left: formatPosition(left),
+    top: top !== undefined ? formatPosition(top) : 'auto',
+    right: right !== undefined ? formatPosition(right) : 'auto',
+    bottom: bottom !== undefined ? formatPosition(bottom) : 'auto',
+    left: left !== undefined ? formatPosition(left) : 'auto',
   }),
 });
 
@@ -340,12 +348,16 @@ export function XDSDialog({
   const isFullscreen = variant === 'fullscreen';
   const hasPosition = position != null && !isFullscreen;
 
+  // Filter out native `open` to prevent InvalidStateError when accidentally passed
+  const {open: _open, ...safeProps} = props as Record<string, unknown>;
+
   return (
     <dialog
       ref={setRefs}
       onClick={handleClick}
       onCancel={handleCancel}
       aria-modal="true"
+      role={purpose === 'required' ? 'alertdialog' : undefined}
       {...mergeProps(
         xdsClassName('dialog', {variant}),
         stylex.props(
@@ -365,7 +377,7 @@ export function XDSDialog({
         className,
         style,
       )}
-      {...props}>
+      {...safeProps}>
       {children}
     </dialog>
   );


### PR DESCRIPTION
Hardening fixes for XDSDialog from the swarm audit (#718). Targeted fixes, no rewrites.

-----

**Fixes:**

| Area | Fix |
|------|-----|
| Exit animation | `@starting-style` + `allow-discrete` + `overlay` transition so close animates instead of popping |
| Reduced motion | `prefers-reduced-motion: reduce` disables animation |
| alertdialog role | `role="alertdialog"` set for `purpose="required"` |
| Native open filter | Destructures and discards native `open` prop to prevent `InvalidStateError` |
| Position | Unset axes default to `auto` instead of `null` so positioned dialogs render correctly |

**Tests:** 26 passing (was 23). New tests for alertdialog role and open prop filtering.

**2 files changed**, +66 -10

| Screenshot | |
|---|---|
| Default | <img src="https://github.com/facebookexperimental/xds/releases/download/untagged-cda9d9775843f7b06ead/dialog-default.png" width="400" /> |
| Confirmation | <img src="https://github.com/facebookexperimental/xds/releases/download/untagged-cda9d9775843f7b06ead/dialog-confirmation.png" width="400" /> |
| Custom Position | <img src="https://github.com/facebookexperimental/xds/releases/download/untagged-cda9d9775843f7b06ead/dialog-position.png" width="400" /> |

**Known issue:** Scrolling content in dialogs with `maxHeight` does not scroll (pre-existing, tracked separately).

Hardening: #718
