### PR TITLE
fix(NumberInput): hardening — swarm findings

### DIFF
--- a/packages/core/src/NumberInput/XDSNumberInput.test.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {HashtagIcon} from '@heroicons/react/24/outline';
 import {XDSNumberInput} from './XDSNumberInput';
@@ -311,6 +311,53 @@ describe('XDSNumberInput', () => {
       render(<XDSNumberInput label="Amount" value={100} onChange={() => {}} />);
       expect(screen.queryByText('%')).not.toBeInTheDocument();
       expect(screen.queryByText('GB')).not.toBeInTheDocument();
+    });
+
+    it('includes units id in aria-describedby when units is provided', () => {
+      render(
+        <XDSNumberInput
+          label="Discount"
+          value={10}
+          onChange={() => {}}
+          units="%"
+        />,
+      );
+      const input = screen.getByRole('spinbutton');
+      const unitsSpan = screen.getByText('%');
+      expect(unitsSpan).toHaveAttribute('id');
+      const unitsId = unitsSpan.getAttribute('id')!;
+      expect(input.getAttribute('aria-describedby')).toContain(unitsId);
+    });
+  });
+
+  describe('onWheel', () => {
+    it('blurs the input on wheel event', () => {
+      render(
+        <XDSNumberInput
+          label="Quantity"
+          value={10}
+          onChange={() => {}}
+          hasAutoFocus
+        />,
+      );
+      const input = screen.getByRole('spinbutton');
+      expect(input).toHaveFocus();
+      fireEvent.wheel(input);
+      expect(input).not.toHaveFocus();
+    });
+  });
+
+  describe('onChange with null', () => {
+    it('calls onChange with null when input is cleared', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <XDSNumberInput label="Quantity" value={42} onChange={handleChange} />,
+      );
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.clear(input);
+      expect(handleChange).toHaveBeenCalledWith(null);
     });
   });
 

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -18,7 +18,6 @@ import {
   useState,
   useMemo,
   useCallback,
-  useRef,
   type FocusEvent,
   type KeyboardEvent,
 } from 'react';
@@ -104,7 +103,7 @@ export interface XDSNumberInputProps extends Omit<
   XDSBaseProps,
   'onChange' | 'defaultValue'
 > {
-  /** Ref forwarded to the root element */
+  /** Ref forwarded to the input element */
   ref?: React.Ref<HTMLInputElement>;
   /**
    * Label text for the input (always rendered for accessibility).
@@ -158,10 +157,11 @@ export interface XDSNumberInputProps extends Omit<
    */
   size?: XDSNumberInputSize;
   /**
-   * Callback fired when the input value changes to a valid number.
-   * Only called when the entered value passes validation.
+   * Callback fired when the input value changes.
+   * Called with a valid number when the entered value passes validation,
+   * or null when the input is cleared.
    */
-  onChange: (value: number) => void;
+  onChange: (value: number | null) => void;
   /**
    * The current value of the input.
    * Use null or undefined to represent an empty/unset value.
@@ -265,6 +265,21 @@ function parseNumberInput(
   return num;
 }
 
+const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
+  warning: 'warning',
+  error: 'xCircle',
+  success: 'checkCircle',
+};
+
+const statusIconColorMap: Record<
+  XDSInputStatusType,
+  'warning' | 'negative' | 'positive'
+> = {
+  warning: 'warning',
+  error: 'negative',
+  success: 'positive',
+};
+
 /**
  * A number input component for collecting numeric user input.
  * Only calls onChange when the entered value passes validation.
@@ -309,30 +324,16 @@ export function XDSNumberInput({
   const id = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
-  const inputRef = useRef<HTMLInputElement | null>(null);
+  const unitsID = useId();
 
   // Pending input while user is typing (null = show formatted value)
   const [pendingInput, setPendingInput] = useState<string | null>(null);
-
-  const statusIconMap: Record<XDSInputStatusType, XDSIconName> = {
-    warning: 'warning',
-    error: 'xCircle',
-    success: 'checkCircle',
-  };
-
-  const statusIconColorMap: Record<
-    XDSInputStatusType,
-    'warning' | 'negative' | 'positive'
-  > = {
-    warning: 'warning',
-    error: 'negative',
-    success: 'positive',
-  };
 
   const ariaDescribedBy =
     [
       description ? descriptionID : null,
       status?.message ? statusMessageID : null,
+      units ? unitsID : null,
     ]
       .filter(Boolean)
       .join(' ') || undefined;
@@ -357,27 +358,22 @@ export function XDSNumberInput({
     return parseNumberInput(pendingInput, {min, max, isIntegerOnly}) !== null;
   }, [pendingInput, min, max, isIntegerOnly]);
 
-  // Handle input text change - update immediately if valid
+  // Handle input text change - update immediately if valid or cleared
   const handleInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const newValue = e.target.value;
       setPendingInput(newValue);
 
-      // If the input is valid, update immediately
       const parsed = parseNumberInput(newValue, {min, max, isIntegerOnly});
-      if (parsed !== null && parsed !== value) {
-        onChange(parsed);
+      if (parsed !== null) {
+        if (parsed !== value) {
+          onChange(parsed);
+        }
+      } else if (newValue.trim() === '') {
+        onChange(null);
       }
     },
     [value, onChange, min, max, isIntegerOnly],
-  );
-
-  // Handle focus
-  const handleFocus = useCallback(
-    (e: FocusEvent<HTMLInputElement>) => {
-      onFocus?.(e);
-    },
-    [onFocus],
   );
 
   // Handle blur - validate and clear pending input
@@ -425,7 +421,6 @@ export function XDSNumberInput({
   // Combine refs
   const setRefs = useCallback(
     (el: HTMLInputElement | null) => {
-      inputRef.current = el;
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
@@ -480,8 +475,9 @@ export function XDSNumberInput({
           autoComplete={autoComplete}
           value={displayValue}
           onChange={handleInputChange}
-          onFocus={handleFocus}
+          onFocus={onFocus}
           onBlur={handleBlur}
+          onWheel={e => e.currentTarget.blur()}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={isDisabled}
@@ -498,7 +494,11 @@ export function XDSNumberInput({
             !isInputValid && styles.inputInvalid,
           )}
         />
-        {units && <span {...stylex.props(styles.units)}>{units}</span>}
+        {units && (
+          <span id={unitsID} {...stylex.props(styles.units)}>
+            {units}
+          </span>
+        )}
         {status && (
           <XDSIcon
             icon={statusIconMap[status.type]}

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -10,7 +10,6 @@
  * - /packages/core/src/PowerSearch/index.ts
  */
 
-
 import React, {useCallback, useMemo} from 'react';
 import type {
   OperatorValue,
@@ -158,8 +157,8 @@ function IntegerEditor({
       label="Value"
       isLabelHidden
       value={currentValue ?? null}
-      onChange={(value: number) => {
-        onChange({type: 'integer', value});
+      onChange={(value: number | null) => {
+        if (value !== null) onChange({type: 'integer', value});
       }}
       min={operatorValue.minValue}
       max={operatorValue.maxValue}
@@ -187,8 +186,10 @@ function FloatEditor({
       label="Value"
       isLabelHidden
       value={currentValue ?? null}
-      onChange={(value: number) => {
-        onChange({type: 'float', value});
+      onChange={(value: number | null) => {
+        if (value != null) {
+          onChange({type: 'float', value});
+        }
       }}
       min={operatorValue.minValue}
       max={operatorValue.maxValue}


### PR DESCRIPTION
Hardening fixes for XDSNumberInput from the swarm audit (#718). Targeted fixes, no rewrites.

-----

**Fixes:**

| Area | Fix |
|------|-----|
| Scroll wheel | `onWheel` handler blurs input to prevent accidental value changes while scrolling |
| onChange null | `onChange` now typed as `(value: number \| null) => void`; emits `null` when cleared |
| Units a11y | Units span gets `id` and is wired into `aria-describedby` |
| Module-level maps | `statusIconMap` / `statusIconColorMap` moved out of component body |
| Dead code | Removed unused `inputRef` |
| No-op removed | `handleFocus` wrapper removed; `onFocus` passed directly |
| Ref JSDoc | Fixed to say "input element" not "root element" |

**Tests:** 47 passing (was 44). New tests for scroll wheel, onChange null, units aria-describedby.

**3 files changed**, +90 -42

| Screenshot | |
|---|---|
| Default | <img src="https://github.com/facebookexperimental/xds/releases/download/untagged-cda9d9775843f7b06ead/ni-default-v2.png" width="400" /> |
| With Units | <img src="https://github.com/facebookexperimental/xds/releases/download/untagged-cda9d9775843f7b06ead/ni-units-v2.png" width="400" /> |
| Validation States | <img src="https://github.com/facebookexperimental/xds/releases/download/untagged-cda9d9775843f7b06ead/ni-validation-v2.png" width="400" /> |

Hardening: #718
