### PR TITLE
fix(RadioList): hardening — swarm findings

### DIFF
--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -13,7 +13,7 @@
  * - /apps/storybook/stories/Field.stories.tsx (storybook stories)
  */
 
-import {type HTMLAttributes, type ReactNode} from 'react';
+import {type HTMLAttributes, type ReactNode, useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSFieldLabel} from './XDSFieldLabel';
@@ -105,8 +105,9 @@ export interface XDSFieldProps extends Omit<
   description?: string;
   /**
    * ID for the input element (used for label's htmlFor attribute).
+   * When omitted, the label renders without htmlFor (e.g. for radiogroups).
    */
-  inputID: string;
+  inputID?: string;
   /**
    * ID for the description element (use for aria-describedby on the input).
    */
@@ -164,8 +165,9 @@ export interface XDSFieldProps extends Omit<
   style?: React.CSSProperties;
   /**
    * The input or control to render inside the field.
+   * Can be a render function receiving `{ labelID }` for aria-labelledby references.
    */
-  children: ReactNode;
+  children: ReactNode | ((props: {labelID: string}) => ReactNode);
 }
 
 /**
@@ -199,6 +201,10 @@ export function XDSField({
   ref,
   ...props
 }: XDSFieldProps) {
+  const labelID = useId();
+  const resolvedChildren =
+    typeof children === 'function' ? children({labelID}) : children;
+
   const resolvedDescriptionID =
     descriptionID ?? (description ? `${inputID}-desc` : undefined);
   const resolvedMessageID =
@@ -224,6 +230,7 @@ export function XDSField({
         <XDSFieldLabel
           label={label}
           inputID={inputID}
+          labelID={labelID}
           isLabelHidden={isLabelHidden}
           isOptional={isOptional}
           isRequired={isRequired}
@@ -243,7 +250,7 @@ export function XDSField({
       </div>
       {statusVariant === 'attached' ? (
         <div {...stylex.props(styles.inputStatusWrapper)}>
-          {children}
+          {resolvedChildren}
           {status?.message && (
             <XDSFieldStatus
               type={status.type}
@@ -255,7 +262,7 @@ export function XDSField({
         </div>
       ) : (
         <>
-          {children}
+          {resolvedChildren}
           {status?.message && (
             <XDSFieldStatus
               type={status.type}

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -75,8 +75,14 @@ export interface XDSFieldLabelProps {
   label: string;
   /**
    * ID of the input element this label is for.
+   * When omitted, the label renders without htmlFor (e.g. for radiogroups).
    */
-  inputID: string;
+  inputID?: string;
+  /**
+   * @internal Generated ID set on the label element for aria-labelledby.
+   * Not intended for public use — always generated internally by XDSField.
+   */
+  labelID?: string;
   /**
    * Whether to visually hide the label (still accessible to screen readers).
    * @default false
@@ -119,6 +125,7 @@ export interface XDSFieldLabelProps {
 export function XDSFieldLabel({
   label,
   inputID,
+  labelID,
   isLabelHidden = false,
   isDisabled = false,
   isOptional = false,
@@ -132,6 +139,7 @@ export function XDSFieldLabel({
   return (
     <label
       ref={ref}
+      id={labelID}
       htmlFor={inputID}
       {...mergeProps(
         xdsClassName('field-label'),

--- a/packages/core/src/RadioList/XDSRadioList.test.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.test.tsx
@@ -34,13 +34,17 @@ describe('XDSRadioList', () => {
     expect(screen.getAllByRole('radio')).toHaveLength(3);
   });
 
-  it('renders radiogroup role', () => {
+  it('renders radiogroup role with aria-labelledby', () => {
     render(
       <XDSRadioList label="Preference" value="" onChange={() => {}}>
         <XDSRadioListItem label="Option A" value="a" />
       </XDSRadioList>,
     );
-    expect(screen.getByRole('radiogroup')).toBeInTheDocument();
+    const radiogroup = screen.getByRole('radiogroup');
+    expect(radiogroup).toBeInTheDocument();
+    // Should use aria-labelledby, not aria-label (avoids double-announcement)
+    expect(radiogroup).toHaveAttribute('aria-labelledby');
+    expect(radiogroup).not.toHaveAttribute('aria-label');
   });
 
   it('selects the correct radio based on value prop', () => {
@@ -277,11 +281,10 @@ describe('XDSRadioList', () => {
     );
     const label = screen.getByText('Hidden label');
     expect(label).toBeInTheDocument();
-    // The radiogroup should still be labeled
-    expect(screen.getByRole('radiogroup')).toHaveAttribute(
-      'aria-label',
-      'Hidden label',
-    );
+    // The radiogroup should still be labeled via aria-labelledby
+    const radiogroup = screen.getByRole('radiogroup');
+    expect(radiogroup).toHaveAttribute('aria-labelledby');
+    expect(radiogroup).not.toHaveAttribute('aria-label');
   });
 
   it('renders description on items', () => {

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSRadioList.tsx
- * @input Uses React useId, createContext, ReactNode, XDSField, XDSInputStatus
+ * @input Uses React useId, useMemo, createContext, ReactNode, XDSField, XDSInputStatus, XDSBaseProps
  * @output Exports XDSRadioList component, XDSRadioListProps, XDSRadioListContext
  * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
  *
@@ -13,11 +13,11 @@
  * - /apps/storybook/stories/RadioList.stories.tsx
  */
 
-import {createContext, useId, type ReactNode} from 'react';
+import {createContext, useId, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {XDSField} from '../Field/XDSField';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import type {XDSInputStatus} from '../Field/types';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -53,7 +53,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSRadioListProps {
+export interface XDSRadioListProps extends Omit<XDSBaseProps, 'onChange'> {
   /**
    * Label text for the radio group (always rendered for accessibility).
    */
@@ -102,8 +102,8 @@ export interface XDSRadioListProps {
   status?: XDSInputStatus;
   /**
    * The size of the radio controls.
-   * - 'sm': Compact size (18px radio, 20px wrapper)
-   * - 'md': Default size (22px radio, 24px wrapper)
+   * - 'sm': Compact size (20px wrapper)
+   * - 'md': Default size (24px wrapper)
    * @default 'md'
    */
   size?: XDSRadioListSize;
@@ -111,31 +111,6 @@ export interface XDSRadioListProps {
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Test ID for the outer container.
-   */
-  'data-testid'?: string;
   /**
    * Radio list items to render.
    */
@@ -173,31 +148,31 @@ export function XDSRadioList({
   xstyle,
   className,
   style,
-  'data-testid': dataTestId,
   children,
+  ...rest
 }: XDSRadioListProps) {
   const name = useId();
-  const inputID = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
 
-  const contextValue: XDSRadioListContextValue = {
-    name,
-    value,
-    onChange,
-    isDisabled,
-    isRequired,
-    size,
-    status,
-  };
+  const contextValue: XDSRadioListContextValue = useMemo(
+    () => ({
+      name,
+      value,
+      onChange,
+      isDisabled,
+      isRequired,
+      size,
+      status,
+    }),
+    [name, value, onChange, isDisabled, isRequired, size, status],
+  );
 
   return (
     <XDSField
-      data-testid={dataTestId}
       label={label}
       isLabelHidden={isLabelHidden}
       description={description}
-      inputID={inputID}
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
@@ -214,34 +189,35 @@ export function XDSRadioList({
       statusVariant="detached"
       xstyle={xstyle}
       className={className}
-      style={style}>
-      <div
-        role="radiogroup"
-        aria-label={label}
-        aria-describedby={
-          [
-            description ? descriptionID : null,
-            status?.message ? statusMessageID : null,
-          ]
-            .filter(Boolean)
-            .join(' ') || undefined
-        }
-        aria-invalid={status?.type === 'error' ? true : undefined}
-        aria-required={isRequired || undefined}
-        {...mergeProps(
-          xdsClassName('radio-list', {orientation, size}),
-          stylex.props(
-            styles.radiogroup,
-            orientation === 'vertical' ? styles.vertical : styles.horizontal,
-            xstyle,
-          ),
-          className,
-          style,
-        )}>
-        <XDSRadioListContext.Provider value={contextValue}>
-          {children}
-        </XDSRadioListContext.Provider>
-      </div>
+      style={style}
+      {...rest}>
+      {({labelID}) => (
+        <div
+          role="radiogroup"
+          aria-labelledby={labelID}
+          aria-orientation={orientation}
+          aria-describedby={
+            [
+              description ? descriptionID : null,
+              status?.message ? statusMessageID : null,
+            ]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }
+          aria-invalid={status?.type === 'error' ? true : undefined}
+          aria-required={isRequired || undefined}
+          {...mergeProps(
+            xdsClassName('radio-list', {orientation, size}),
+            stylex.props(
+              styles.radiogroup,
+              orientation === 'vertical' ? styles.vertical : styles.horizontal,
+            ),
+          )}>
+          <XDSRadioListContext.Provider value={contextValue}>
+            {children}
+          </XDSRadioListContext.Provider>
+        </div>
+      )}
     </XDSField>
   );
 }

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -60,7 +60,10 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderRadius: '50%',
     transitionProperty: 'background-color, border-color',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
     boxSizing: 'border-box',
   },
@@ -95,11 +98,11 @@ const styles = stylex.create({
   radioWrapperFocus: {
     outline: {
       default: 'none',
-      ':focus-within': `2px solid ${colorVars['--color-accent']}`,
+      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
-      default: '0',
-      ':focus-within': '2px',
+      default: null,
+      ':has(:focus-visible)': '2px',
     },
     borderRadius: '50%',
   },
@@ -133,6 +136,7 @@ const styles = stylex.create({
   description: {
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
     color: colorVars['--color-text-secondary'],
   },
   startContent: {
@@ -151,12 +155,12 @@ const styles = stylex.create({
 // Size styles matching CheckboxInput dimensions
 const wrapperSizeStyles = stylex.create({
   sm: {
-    width: 20,
-    height: 20,
+    width: spacingVars['--spacing-5'],
+    height: spacingVars['--spacing-5'],
   },
   md: {
-    width: 24,
-    height: 24,
+    width: spacingVars['--spacing-6'],
+    height: spacingVars['--spacing-6'],
   },
 });
 


### PR DESCRIPTION
## RadioList Hardening — PR #778

Fixes from [issue #718](https://github.com/facebookexperimental/xds/issues/718) RadioList findings.

### Changes

| Finding | Severity | Fix |
|---------|----------|-----|
| `aria-label` duplicates visible label | P1 | Replaced with `aria-labelledby` pointing to XDSField label |
| `inputID` creates orphaned `htmlFor` | P1 | Removed `inputID` from XDSField (label no longer has dangling `htmlFor`) |
| `xstyle`/`className`/`style` double-applied | P1 | Removed from inner radiogroup div, kept on XDSField only |
| Does not extend XDSBaseProps | P1 | Now extends `Omit<XDSBaseProps, 'onChange'>` with `...rest` spread |
| `contextValue` recreated every render | P2 | Wrapped in `useMemo` |
| No `prefers-reduced-motion` | P2 | Added to radio transition duration |
| Focus ring uses `:focus-within` | P2 | Changed to `:has(:focus-visible)` for keyboard-only focus |
| Description missing `lineHeight` | P2 | Added `typeScaleVars['--text-supporting-leading']` |
| Radio/dot sizes hardcoded px | P2 | Wrapper sizes now use `spacingVars` tokens |

### Additional improvements
- Added `aria-orientation` to radiogroup
- XDSField: `inputID` now optional, children can be render function receiving `{ labelID }`
- XDSFieldLabel: accepts optional `labelID` for `id` attribute

### Tests
- 55 tests pass (25 RadioList + 20 Field + 10 FieldLabel)
- 1603 total core tests pass — zero regressions

### Files changed
- `packages/core/src/RadioList/XDSRadioList.tsx`
- `packages/core/src/RadioList/XDSRadioListItem.tsx`
- `packages/core/src/RadioList/XDSRadioList.test.tsx`
- `packages/core/src/Field/XDSField.tsx`
- `packages/core/src/Field/XDSFieldLabel.tsx`