### PR TITLE
fix(theming): TreeList item xdsClassName + Typeahead shadow token

### DIFF
--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -62,6 +62,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-tree-list', visualProps: ['density']},
+      {className: 'xds-tree-list-item', states: ['selected', 'disabled']},
     ],
   },
   notes: [
@@ -187,6 +188,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-tree-list', visualProps: ['density']},
+      {className: 'xds-tree-list-item', states: ['selected', 'disabled']},
     ],
   },
   notes: [

--- a/packages/core/src/TreeList/XDSTreeListItem.tsx
+++ b/packages/core/src/TreeList/XDSTreeListItem.tsx
@@ -23,6 +23,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {getIcon} from '../Icon/globalIconRegistry';
+import {xdsClassName, mergeProps} from '../utils';
 import {
   XDSTreeListBranches,
   XDSTreeListHorizontalConnector,
@@ -416,15 +417,21 @@ export function XDSTreeListItem({
           nestedLevel={nestedLevel}
         />
         <div
-          {...stylex.props(
-            styles.contentWrapper,
-            densityStyles[density],
-            (isInteractive || (hasChildren && onClick == null)) &&
-              styles.interactive,
-            (isInteractive || (hasChildren && onClick == null)) &&
-              styles.focusWithinOutline,
-            isDisabled && styles.disabled,
-            isSelected && styles.selected,
+          {...mergeProps(
+            xdsClassName('tree-list-item', {
+              selected: isSelected ? 'selected' : null,
+              disabled: isDisabled ? 'disabled' : null,
+            }),
+            stylex.props(
+              styles.contentWrapper,
+              densityStyles[density],
+              (isInteractive || (hasChildren && onClick == null)) &&
+                styles.interactive,
+              (isInteractive || (hasChildren && onClick == null)) &&
+                styles.focusWithinOutline,
+              isDisabled && styles.disabled,
+              isSelected && styles.selected,
+            ),
           )}
           style={{marginLeft: computedMarginLeft}}
           onClick={handleClick}>

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -36,6 +36,7 @@ import {
   lineHeightVars,
   typographyVars,
   fontWeightVars,
+  shadowVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSSearchableItem, XDSSearchSource} from './types';
@@ -178,7 +179,7 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-2'],
     backgroundColor: colorVars['--color-surface'],
-    boxShadow: `0 4px 12px ${colorVars['--color-shadow']}`,
+    boxShadow: shadowVars['--shadow-menu'],
   },
   popover: {
     minWidth: 'anchor-size(width)',


### PR DESCRIPTION
Theme audit batch — final 3 components in the queue (TopNav, TreeList, Typeahead).

## Changes

**TreeList** — add `xdsClassName('tree-list-item')` with selected/disabled states on the visual content wrapper. Tree list items have distinct selected, hover, and disabled appearances that theme authors would need to target independently. Updated doc.mjs theming targets to match.

**Typeahead** — replace hardcoded shadow `0 4px 12px ${colorVars['--color-shadow']}` with `shadowVars['--shadow-menu']`. The previous implementation only tokenized the shadow color while keeping the offsets and blur hardcoded. This matches the pattern established in #746 and #670.

**TopNav** — audited clean. All sub-components (XDSTopNav, XDSTopNavHeading, XDSTopNavItem, XDSTopNavMegaMenu) use design tokens, hover guards, and xdsClassName correctly.

## Audit notes

This completes the full component audit cycle — all components in packages/core/src/ have been audited at least once. The queue will restart from the beginning on the next run.
