### PR TITLE
fix: migrate remaining Badge children to label prop

### DIFF
--- a/apps/storybook/stories/OverflowList.stories.tsx
+++ b/apps/storybook/stories/OverflowList.stories.tsx
@@ -123,13 +123,13 @@ export const WithBadges: Story = {
       <XDSOverflowList
         gap={1}
         overflowRenderer={overflowItems => (
-          <XDSBadge variant="neutral">+{overflowItems.length}</XDSBadge>
+          <XDSBadge variant="neutral" label={`+${overflowItems.length}`} />
         )}>
-        <XDSBadge variant="info">React</XDSBadge>
-        <XDSBadge variant="success">TypeScript</XDSBadge>
-        <XDSBadge variant="warning">StyleX</XDSBadge>
-        <XDSBadge variant="neutral">Storybook</XDSBadge>
-        <XDSBadge variant="error">Vitest</XDSBadge>
+        <XDSBadge variant="info" label="React" />
+        <XDSBadge variant="success" label="TypeScript" />
+        <XDSBadge variant="warning" label="StyleX" />
+        <XDSBadge variant="neutral" label="Storybook" />
+        <XDSBadge variant="error" label="Vitest" />
       </XDSOverflowList>
     </div>
   ),

--- a/apps/storybook/stories/ThemeEditor.stories.tsx
+++ b/apps/storybook/stories/ThemeEditor.stories.tsx
@@ -1219,7 +1219,7 @@ function LandingPagePreview() {
     <div style={{display: 'flex', flexDirection: 'column', gap: '48px'}}>
       {/* Hero */}
       <div style={{textAlign: 'center', padding: '48px 24px'}}>
-        <XDSBadge variant="accent">New Release</XDSBadge>
+        <XDSBadge variant="accent" label="New Release" />
         <XDSHeading level={1} style={{marginTop: 16, marginBottom: 12}}>
           Ship faster with XDS
         </XDSHeading>

--- a/internal/vibe-tests/app/src/report/CompareView.tsx
+++ b/internal/vibe-tests/app/src/report/CompareView.tsx
@@ -233,9 +233,10 @@ function CostComparisonSection({
       key: 'winner',
       header: 'Lower Cost',
       renderCell: row => (
-        <XDSBadge variant={winnerBadgeVariant(row.winner)}>
-          {row.winner === 'tie' ? '—' : winnerLabel(row.winner)}
-        </XDSBadge>
+        <XDSBadge
+          variant={winnerBadgeVariant(row.winner)}
+          label={row.winner === 'tie' ? '—' : winnerLabel(row.winner)}
+        />
       ),
     },
   ];
@@ -320,9 +321,10 @@ export function CompareView({comparison}: CompareViewProps) {
       key: 'winner',
       header: 'Winner',
       renderCell: row => (
-        <XDSBadge variant={winnerBadgeVariant(row.winner)}>
-          {winnerLabel(row.winner)}
-        </XDSBadge>
+        <XDSBadge
+          variant={winnerBadgeVariant(row.winner)}
+          label={winnerLabel(row.winner)}
+        />
       ),
     },
   ];

--- a/packages/core/src/Badge/XDSBadge.test.tsx
+++ b/packages/core/src/Badge/XDSBadge.test.tsx
@@ -22,7 +22,7 @@ describe('XDSBadge', () => {
     expect(screen.getByText('Info')).toBeInTheDocument();
   });
 
-  it('renders as dot when no children provided', () => {
+  it('renders as dot when no label provided', () => {
     const {container} = render(<XDSBadge variant="success" />);
     const badge = container.querySelector('span');
     expect(badge).toBeInTheDocument();

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -338,8 +338,8 @@ const edgeCompStyles = stylex.create({
  * <XDSButton label="Settings" icon={<GearIcon />} variant="ghost" />
  * <XDSButton label="Pick emoji" icon={<span>🚀</span>} variant="ghost" size="sm" />
  * <XDSButton label="Edit" icon={<PencilIcon />}>Edit</XDSButton>
- * <XDSButton label="Messages" endSlot={<XDSBadge>3</XDSBadge>} />
- * <XDSButton label="Edit" icon={<PencilIcon />} endSlot={<XDSBadge>New</XDSBadge>}>Edit</XDSButton>
+ * <XDSButton label="Messages" endSlot={<XDSBadge label={3} />} />
+ * <XDSButton label="Edit" icon={<PencilIcon />} endSlot={<XDSBadge label="New" />}>Edit</XDSButton>
  * ```
  */
 export function XDSButton({

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -171,9 +171,7 @@ function XDSTableInner<T extends Record<string, unknown>>({
  *       </XDSHStack>
  *     )},
  *     { key: 'status', header: 'Status', renderCell: (u) => (
- *       <XDSBadge variant={u.active ? 'success' : 'error'}>
- *         {u.active ? 'Active' : 'Inactive'}
- *       </XDSBadge>
+ *       <XDSBadge variant={u.active ? 'success' : 'error'} label={u.active ? 'Active' : 'Inactive'} />
  *     )},
  *   ]}
  *   density="compact"

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -76,9 +76,7 @@ export interface XDSTableColumn<T extends Record<string, unknown>> {
    * renderCell: (item) => (
    *   <XDSHStack gap={2} align="center">
    *     <XDSStatusDot status={item.isActive ? 'positive' : 'negative'} />
-   *     <XDSBadge variant={item.isActive ? 'success' : 'error'}>
-   *       {item.isActive ? 'Active' : 'Inactive'}
-   *     </XDSBadge>
+   *     <XDSBadge variant={item.isActive ? 'success' : 'error'} label={item.isActive ? 'Active' : 'Inactive'} />
    *   </XDSHStack>
    * )
    * ```


### PR DESCRIPTION
Migrate all remaining `<XDSBadge>children</XDSBadge>` usages to `<XDSBadge label={...} />`.

## Changes

| File | What |
|------|------|
| `OverflowList.stories.tsx` | 6 static badges + 1 dynamic overflow badge |
| `ThemeEditor.stories.tsx` | 1 badge in landing page preview |
| `CompareView.tsx` | 2 dynamic badges (vibe test report) |
| `XDSButton.tsx` | 2 JSDoc examples |
| `XDSTable.tsx` | 1 JSDoc example |
| `Table/types.ts` | 1 JSDoc example |
| `XDSBadge.test.tsx` | Fix test description ('no children' → 'no label') |

Companion codemod already exists at `packages/cli/src/codemods/transforms/v0.0.6/migrate-badge-children-to-label.mjs` for external consumers.

---
