### PR TITLE
fix(Layout): forward ref and remove dead code

### DIFF
--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -65,6 +65,11 @@ const styles = stylex.create({
 
 export interface XDSLayoutProps extends Omit<XDSBaseProps, 'content'> {
   /**
+   * Ref forwarded to the root DOM element.
+   */
+  ref?: React.Ref<HTMLDivElement>;
+
+  /**
    * Main content area (center).
    */
   content?: ReactNode;
@@ -186,6 +191,7 @@ export function XDSLayout({
   header,
   height = 'fill',
   padding,
+  ref,
   start,
   xstyle,
   className,
@@ -207,6 +213,7 @@ export function XDSLayout({
   return (
     <XDSLayoutSlotsContext.Provider value={slotsValue}>
       <div
+        ref={ref}
         {...mergeProps(
           xdsClassName('layout', {height}),
           stylex.props(

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -69,15 +69,6 @@ const stripedHoverRowStyles = stylex.create({
   },
 });
 
-const _lastBodyRowStyles = stylex.create({
-  row: {
-    borderBottomStyle: {
-      default: null,
-      ':last-child': 'hidden',
-    },
-  },
-});
-
 /**
  * XDSTableRow — a `<tr>` wrapper for children/streaming mode.
  *


### PR DESCRIPTION
## Changes

Addresses remaining Layout findings from hardening sprint #719:

- **P1: Does not forward ref** — Added `ref` prop to `XDSLayout` following React 19 ref-as-prop pattern
- **P2: `_lastBodyRowStyles` dead code** — Removed unused styles from `XDSTableRow` (was defined but never referenced)

## Test plan
- All Layout tests pass (12/12)
- All Table tests pass (90/90)
- Lint clean (0 errors)

---
