### PR TITLE
fix(Table): remove dead code — columnWidthToCSS and _lastBodyRowStyles

### DIFF
--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -13,13 +13,7 @@ import {XDSBaseTable} from './XDSBaseTable';
 import {XDSTable} from './XDSTable';
 import {XDSTableRow} from './XDSTableRow';
 import {XDSTableCell} from './XDSTableCell';
-import {
-  proportional,
-  pixel,
-  generateColumns,
-  columnWidthToCSS,
-  capitalize,
-} from './columnUtils';
+import {proportional, pixel, generateColumns, capitalize} from './columnUtils';
 import type {TablePlugin, XDSTableColumn} from './types';
 
 // =============================================================================
@@ -65,20 +59,6 @@ describe('columnUtils', () => {
     it('creates a pixel width', () => {
       const w = pixel(200);
       expect(w).toEqual({type: 'pixel', value: 200});
-    });
-  });
-
-  describe('columnWidthToCSS', () => {
-    it('converts pixel width to px string', () => {
-      expect(columnWidthToCSS(pixel(100), 3)).toBe('100px');
-    });
-
-    it('converts proportional width to percentage', () => {
-      expect(columnWidthToCSS(proportional(1), 4)).toBe('25%');
-    });
-
-    it('handles proportional(2) out of 4', () => {
-      expect(columnWidthToCSS(proportional(2), 4)).toBe('50%');
     });
   });
 

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -69,15 +69,6 @@ const stripedHoverRowStyles = stylex.create({
   },
 });
 
-const _lastBodyRowStyles = stylex.create({
-  row: {
-    borderBottomStyle: {
-      default: null,
-      ':last-child': 'hidden',
-    },
-  },
-});
-
 /**
  * XDSTableRow — a `<tr>` wrapper for children/streaming mode.
  *

--- a/packages/core/src/Table/columnUtils.ts
+++ b/packages/core/src/Table/columnUtils.ts
@@ -1,6 +1,6 @@
 /**
  * @file columnUtils.ts
- * @input XDSTableColumn, ColumnWidth types from types.ts
+ * @input XDSTableColumn types from types.ts
  * @output Pure utility functions for column width and auto-generation
  * @position Utility layer; consumed by XDSBaseTable.tsx
  *
@@ -10,12 +10,7 @@
  */
 
 import type {ReactNode} from 'react';
-import type {
-  XDSTableColumn,
-  ColumnWidth,
-  ProportionalWidth,
-  PixelWidth,
-} from './types';
+import type {XDSTableColumn, ProportionalWidth, PixelWidth} from './types';
 
 /**
  * Create a proportional column width (fr-like).
@@ -40,24 +35,6 @@ export function proportional(value: number = 1): ProportionalWidth {
  */
 export function pixel(value: number): PixelWidth {
   return {type: 'pixel', value};
-}
-
-/**
- * Convert a ColumnWidth to a CSS width string for `<col>`.
- *
- * Proportional widths are converted to percentages relative to the
- * total proportional units across all columns.
- */
-export function columnWidthToCSS(
-  width: ColumnWidth,
-  totalProportional: number,
-): string {
-  if (width.type === 'pixel') {
-    return `${width.value}px`;
-  }
-  // Convert proportional to percentage
-  const pct = (width.value / totalProportional) * 100;
-  return `${pct}%`;
 }
 
 /**

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -15,12 +15,7 @@ export {XDSTableHeaderCell} from './XDSTableHeaderCell';
 export {XDSTableContext} from './XDSTableContext';
 export {useXDSTableSelection} from './plugins/selection';
 export {useXDSBaseTablePlugins} from './useXDSBaseTablePlugins';
-export {
-  proportional,
-  pixel,
-  generateColumns,
-  columnWidthToCSS,
-} from './columnUtils';
+export {proportional, pixel, generateColumns} from './columnUtils';
 export type {
   XDSTableColumn,
   ColumnWidth,


### PR DESCRIPTION
## Changes

Addresses dead code findings from hardening sprint #719:

- **P0: columnWidthToCSS dead code** — Function was exported, tested, and documented but never actually called by any component. Removed function, export, and tests.
- **P1: _lastBodyRowStyles dead code** — Style definition was never referenced. Removed.

## Test plan
- All remaining Table tests pass (87/87)
- Build clean
- Lint clean (0 errors)

---
