### PR TITLE
docs: fix OverflowList examples, add missing theming sections

### DIFF
--- a/packages/core/src/OverflowList/XDSOverflowList.tsx
+++ b/packages/core/src/OverflowList/XDSOverflowList.tsx
@@ -143,8 +143,7 @@ export interface XDSOverflowListProps extends XDSBaseProps<HTMLDivElement> {
    *       button={{label: `+${overflowItems.length}`, variant: 'ghost'}}
    *       items={overflowItems.map(({index}) => ({ label: labels[index] }))}
    *     />
-   *   )}
-   * >
+   *   )}>
    *   {labels.map(l => <XDSButton key={l} label={l} />)}
    * </XDSOverflowList>
    * ```
@@ -165,8 +164,7 @@ export interface XDSOverflowListProps extends XDSBaseProps<HTMLDivElement> {
  *   gap={2}
  *   overflowRenderer={(items) => (
  *     <XDSButton label={`+${items.length} more`} variant="ghost" />
- *   )}
- * >
+ *   )}>
  *   <XDSButton label="Action 1" />
  *   <XDSButton label="Action 2" />
  *   <XDSButton label="Action 3" />

--- a/packages/core/src/TimeInput/TimeInput.doc.mjs
+++ b/packages/core/src/TimeInput/TimeInput.doc.mjs
@@ -203,6 +203,11 @@ export const docs = {
   ],
   keyboard:
     'ArrowUp / ArrowDown adjust the current time by the configured increment in minutes. Typing a time string in common formats (e.g. "2:30 PM", "14:30") is parsed on blur. Pressing the clear button returns focus to the input.',
+  theming: {
+    targets: [
+      {className: 'xds-time-input', visualProps: ['size']},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').ComponentDoc} */
@@ -409,6 +414,11 @@ export const docsZh = {
   ],
   keyboard:
     '上/下方向键按配置的分钟增量调整当前时间。以常见格式（例如 "2:30 PM"、"14:30"）输入时间字符串会在失焦时解析。按清除按钮将焦点返回到输入框。',
+  theming: {
+    targets: [
+      {className: 'xds-time-input', visualProps: ['size']},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */

--- a/packages/core/src/Tooltip/Tooltip.doc.mjs
+++ b/packages/core/src/Tooltip/Tooltip.doc.mjs
@@ -192,6 +192,11 @@ export const docs = {
       ],
     },
   ],
+  theming: {
+    targets: [
+      {className: 'xds-tooltip'},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').ComponentDoc} */
@@ -387,6 +392,11 @@ export const docsZh = {
       ],
     },
   ],
+  theming: {
+    targets: [
+      {className: 'xds-tooltip'},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */


### PR DESCRIPTION
## What

Fix Storybook compatibility issues and add missing theming documentation.

### Storybook compat
- **XDSOverflowList**: Fixed 2 `@example` blocks where bare `>` on its own line could break Storybook's markdown parser. Moved `>` to end of previous line (`)}>`).

### Missing theming sections
- **TimeInput.doc.mjs**: Added `theming` section with `xds-time-input` target (`visualProps: ['size']`) to both en and zh docs.
- **Tooltip.doc.mjs**: Added `theming` section with `xds-tooltip` target (no visual props) to both en and zh docs.

### Also noted (not fixed here)
- OverflowList has no `.doc.mjs` file yet, so its `xds-overflow-list` className can't be documented in theming.
- 3 sub-components missing `@example`: XDSSelectorItem, XDSTreeListBranches, XDSTreeListItem.
- 15 components accept `xstyle` but don't document it in `.doc.mjs` props (will address in a follow-up).

## Checklist
- [x] `yarn workspace @xds/core typecheck:docs` passes
- [x] No Storybook ```tsx` in docblocks
- [x] No blank lines, JS comments, or bare `>` inside `@example` code blocks
- [x] Theming sections match `xdsClassName()` calls in source

---
*Night Watch Doc Reviewer*