### PR TITLE
fix: theme audit — Pagination dot sub-element + Popover radius token

### DIFF
--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -503,11 +503,17 @@ export function XDSPagination({
                 aria-current={i + 1 === page ? 'page' : undefined}
                 onClick={() => handlePageChange(i + 1)}
                 disabled={isDisabled}
-                {...stylex.props(
-                  styles.dot,
-                  isSm && styles.dotSm,
-                  i + 1 === page && styles.dotActive,
-                  isDisabled && styles.dotDisabled,
+                {...mergeProps(
+                  xdsClassName('pagination-dot', {
+                    active: i + 1 === page ? 'active' : null,
+                    size,
+                  }),
+                  stylex.props(
+                    styles.dot,
+                    isSm && styles.dotSm,
+                    i + 1 === page && styles.dotActive,
+                    isDisabled && styles.dotDisabled,
+                  ),
                 )}
               />
             ))}

--- a/packages/core/src/Popover/XDSPopover.tsx
+++ b/packages/core/src/Popover/XDSPopover.tsx
@@ -194,8 +194,7 @@ const styles = stylex.create({
   container: {
     backgroundColor: colorVars['--color-surface'],
     color: colorVars['--color-text-primary'],
-    '--popover-radius': radiusVars['--radius-2'],
-    borderRadius: 'var(--popover-radius)',
+    borderRadius: radiusVars['--radius-2'],
     boxShadow: shadowVars['--shadow-menu'],
   },
   contentPadding: {


### PR DESCRIPTION
## Theme Audit — 2026-03-21

Audited 5 components: **NumberInput**, **Pagination**, **Popover**, **PowerSearch** (skipped), **ProgressBar**

### Fixes

**Pagination** — Added `xdsClassName('pagination-dot')` sub-element target on dot indicators. The dots have distinct `backgroundColor` (muted for inactive, accent for active) which makes them a valid theming target. Includes active state and size variants so theme authors can target `.xds-pagination-dot`, `.xds-pagination-dot--active-active`, and `.xds-pagination-dot--size-sm`.

**Popover** — Removed unnecessary intermediate CSS custom property `--popover-radius`. The value (`radiusVars['--radius-2']`) was only used once with no `calc()` and not referenced by multiple elements. Per project standard, `xdsClassName` targeting is preferred over component CSS vars for single-use cases.

### Clean Components (no issues)

- **NumberInput** — All tokens correct (`typeScaleVars`, `colorVars`, `typographyVars`, `lineHeightVars`, `sizeVars`). `xdsClassName('number-input')` on wrapper div with size variant. Uses `XDSField`, `XDSIcon` primitives correctly.
- **ProgressBar** — All tokens correct. `xdsClassName('progressbar')` on root, `xdsClassName('progressbar-fill')` on fill sub-element with variant. Uses `colorVars`, `spacingVars`, `radiusVars`, `durationVars`, `easeVars`, `typeScaleVars`.

### Skipped

- **PowerSearch** — Composition wrapper around `XDSTokenizer`. Per theme audit guidelines, adding `xdsClassName` to the wrapper creates specificity conflicts with the inner component's theming. Skipped.

### Needs Review

- **Pagination dot sizes** — Dots use hardcoded `width: 8`/`height: 8` (md) and `width: 6`/`height: 6` (sm). These are element dimensions rather than spacing, so they fall under the "layout values" exception. However, theme authors may want to control dot size — flagging for human judgment on whether these should use tokens.
- **Popover `--popover-radius` removal** — The intermediate CSS var was removed since it's single-use. If there's an intent to have the popover arrow (or future sub-elements) share this radius, the var could be kept. Flagging in case.

---
