### PR TITLE
fix: API audit — XDSAvatarStatusDot displayName + a11y role

### DIFF
--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -187,7 +187,7 @@ export function XDSAvatarStatusDot({
 
   return (
     <div
-      {...(label ? {'aria-label': label} : undefined)}
+      {...(label ? {role: 'img', 'aria-label': label} : undefined)}
       {...mergeProps(
         xdsClassName('avatar-status-dot', {variant}),
         stylex.props(
@@ -210,3 +210,5 @@ export function XDSAvatarStatusDot({
     </div>
   );
 }
+
+XDSAvatarStatusDot.displayName = 'XDSAvatarStatusDot';


### PR DESCRIPTION
## API Audit — 2026-03-21

Audited first batch: **AppShell, AspectRatio, Avatar, Badge, Banner**

### Fixes Applied

**XDSAvatarStatusDot** (`packages/core/src/Avatar/XDSAvatarStatusDot.tsx`):
1. **Missing `displayName`** — added `XDSAvatarStatusDot.displayName = 'XDSAvatarStatusDot'` (convention compliance)
2. **Missing `role` for screen readers** — added `role="img"` when `label` is provided, so screen readers properly announce the status indicator

### Clean Components (no issues found)

- **AspectRatio** — extends XDSBaseProps, displayName set, all types prefixed, exports clean
- **Badge** — extends XDSBaseProps, displayName set, all types prefixed, exports clean

### Needs Review

These are convention gaps that need human judgment before fixing:

1. **XDSAppShellProps does not extend XDSBaseProps** (`packages/core/src/AppShell/XDSAppShell.tsx`)
   - Missing standard HTML attribute passthrough (data-\*, aria-\*, event handlers). Only `data-testid` is explicitly declared.
   - AppShell is a complex top-level component — may be intentionally restricted. Should it extend XDSBaseProps?

2. **XDSBannerProps does not extend XDSBaseProps** (`packages/core/src/Banner/XDSBanner.tsx`)
   - Same as above — only `data-testid` is explicit. Missing general HTML attribute passthrough.
   - Banner has domain-specific props (status, title, isDismissable). Should it also accept arbitrary HTML attrs?

---
