### PR TITLE
fix(Banner): expose status on root xdsClassName for theme targeting

### DIFF
--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -117,7 +117,7 @@ export const docs = {
 
   theming: {
     targets: [
-      {className: 'xds-banner', visualProps: ['variant']},
+      {className: 'xds-banner', visualProps: ['variant', 'status']},
       {className: 'xds-banner-icon', visualProps: ['status']},
     ],
     vars: [
@@ -247,7 +247,7 @@ export const docsZh = {
 
   theming: {
     targets: [
-      {className: 'xds-banner', visualProps: ['variant']},
+      {className: 'xds-banner', visualProps: ['variant', 'status']},
       {className: 'xds-banner-icon', visualProps: ['status']},
     ],
     vars: [

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -405,7 +405,7 @@ export function XDSBanner({
       role={role}
       data-testid={testId}
       {...mergeProps(
-        xdsClassName('banner', {variant}),
+        xdsClassName('banner', {variant, status}),
         stylex.props(
           styles.root,
           variant === 'card' && styles.card,


### PR DESCRIPTION
## Summary

Adds `status` to the root element's `xdsClassName('banner', {variant, status})` call. This lets themes override per-status styles (like background color) via component overrides in `defineTheme`, eliminating the need for the `--banner-status-bg` CSS custom property escape hatch.

### Before
```tsx
xdsClassName('banner', {variant})
// Generates: class="xds-banner card"
```

### After
```tsx
xdsClassName('banner', {variant, status})
// Generates: class="xds-banner card info"
```

### Theme usage
```ts
// In defineTheme — override all statuses to use card background
components: {
  banner: {
    'status:info': { backgroundColor: 'var(--color-card)' },
    'status:warning': { backgroundColor: 'var(--color-card)' },
    'status:error': { backgroundColor: 'var(--color-card)' },
    'status:success': { backgroundColor: 'var(--color-card)' },
  },
}
```

### Changes
- **XDSBanner.tsx**: `xdsClassName('banner', {variant})` → `xdsClassName('banner', {variant, status})`
- **Banner.doc.mjs**: Added `status` to `xds-banner` theming targets (both en and zh sections)

Ref: PR #692 (Meta Theme) identified this gap — the theme needed `--banner-status-bg` because status wasn't targetable on the root element.

---
