### PR TITLE
fix: add missing 'use client' directives

### DIFF
--- a/packages/core/src/PowerSearch/useInternalConfig.ts
+++ b/packages/core/src/PowerSearch/useInternalConfig.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file useInternalConfig.ts
  * @input PowerSearchConfig

--- a/packages/core/src/PowerSearch/usePowerSearchConfig.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchConfig.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file usePowerSearchConfig.ts
  * @input Field definitions with simplified types

--- a/packages/core/src/PowerSearch/usePowerSearchSource.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file usePowerSearchSource.ts
  * @input InternalConfig

--- a/packages/core/src/SideNav/XDSSideNavCollapseContext.ts
+++ b/packages/core/src/SideNav/XDSSideNavCollapseContext.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSSideNavCollapseContext.ts
  * @input React createContext, useContext

--- a/packages/core/src/SideNav/XDSSideNavRenderContext.ts
+++ b/packages/core/src/SideNav/XDSSideNavRenderContext.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSSideNavRenderContext.ts
  * @input React createContext, useContext

--- a/packages/core/src/SideNav/useResizable.ts
+++ b/packages/core/src/SideNav/useResizable.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file useResizable.ts
  * @input Resizable configuration (enabled, defaultWidth, onWidthChange)

--- a/packages/core/src/TopNav/TopNavContext.ts
+++ b/packages/core/src/TopNav/TopNavContext.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {createContext, useContext} from 'react';
 
 export type TopNavSlot = 'start' | 'center' | 'end';

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSTopNavMenu.tsx
  * @input Uses React, StyleX, useXDSHoverCard, XDSTopNavItem tokens

--- a/packages/core/src/TopNav/XDSTopNavMobileContentContext.ts
+++ b/packages/core/src/TopNav/XDSTopNavMobileContentContext.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSTopNavMobileContentContext.ts
  * @input React createContext, useContext

--- a/packages/core/src/TopNav/XDSTopNavRenderContext.ts
+++ b/packages/core/src/TopNav/XDSTopNavRenderContext.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSTopNavRenderContext.ts
  * @input React createContext, useContext


### PR DESCRIPTION
## Summary

Adds `'use client'` directive to 10 source files that use React client hooks but were missing it. When tsup bundles these into shared chunks for the dist path, the missing directive causes Next.js builds to fail with `createContext only works in a Client Component`.

Found by scanning all `packages/core/src/` files for React client API imports without a corresponding `'use client'` directive.

### Files fixed

- `PowerSearch/useInternalConfig.ts` — `useMemo`
- `PowerSearch/usePowerSearchConfig.ts` — `useMemo`
- `PowerSearch/usePowerSearchSource.ts` — `useMemo`
- `SideNav/XDSSideNavCollapseContext.ts` — `createContext`, `useContext`
- `SideNav/XDSSideNavRenderContext.ts` — `createContext`, `useContext`
- `SideNav/useResizable.ts` — `useState`, `useEffect`, `useRef`, `useCallback`
- `TopNav/TopNavContext.ts` — `createContext`, `useContext`
- `TopNav/XDSTopNavMenu.tsx` — `useState`, `useEffect`, `useRef`, `useCallback`, `useId`
- `TopNav/XDSTopNavMobileContentContext.ts` — `createContext`, `useContext`
- `TopNav/XDSTopNavRenderContext.ts` — `createContext`, `useContext`

Fixes the sandbox build failure in #806.

---
