### PR TITLE
fix(build): inject 'use client' into dist chunks + CI check

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -416,7 +416,7 @@
     "typecheck:docs": "tsc --project tsconfig.docs.json",
     "build:css": "node ../../scripts/build-css.mjs",
     "inject:css": "node ../../scripts/inject-css-imports.mjs",
-    "postbuild": "yarn build:css && yarn inject:css"
+    "postbuild": "yarn build:css && yarn inject:css && node ../../scripts/check-use-client.mjs"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -16,6 +16,9 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
+  banner: {
+    js: '"use client";',
+  },
   external: ['react', 'react-dom'],
   noExternal: ['@stylexjs/stylex', 'styleq'],
   esbuildPlugins: [

--- a/scripts/check-use-client.mjs
+++ b/scripts/check-use-client.mjs
@@ -1,0 +1,72 @@
+/**
+ * Post-build check: verify all dist files using React client APIs
+ * have "use client" directive.
+ *
+ * Run after `yarn build` to catch missing directives in shared chunks.
+ */
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const CLIENT_APIS = [
+  'createContext',
+  'useContext',
+  'useState',
+  'useEffect',
+  'useRef',
+  'useCallback',
+  'useMemo',
+  'useReducer',
+  'useId',
+  'useTransition',
+  'useOptimistic',
+  'useSyncExternalStore',
+];
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST_DIR = path.resolve(__dirname, '..', 'packages/core/dist');
+
+function findMjsFiles(dir) {
+  const entries = fs.readdirSync(dir, {withFileTypes: true, recursive: true});
+  return entries
+    .filter(e => !e.isDirectory() && e.name.endsWith('.mjs'))
+    .map(e => path.join(e.parentPath ?? e.path, e.name));
+}
+
+function check() {
+  if (!fs.existsSync(DIST_DIR)) {
+    console.error(`❌ Dist directory not found: ${DIST_DIR}`);
+    console.error('   Run "yarn build" first.');
+    process.exit(1);
+  }
+
+  const files = findMjsFiles(DIST_DIR);
+  const failures = [];
+
+  for (const file of files) {
+    const content = fs.readFileSync(file, 'utf-8');
+    const usesClientAPI = CLIENT_APIS.some(api => content.includes(api));
+    if (!usesClientAPI) continue;
+
+    const firstLine = content.split('\n')[0].trim();
+    const hasDirective =
+      firstLine === '"use client";' || firstLine === "'use client';";
+    if (!hasDirective) {
+      failures.push(path.relative(DIST_DIR, file));
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('❌ Missing "use client" directive in dist files:');
+    for (const f of failures) {
+      console.error(`   ${f}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(
+    `✅ All ${files.length} dist .mjs files checked — "use client" directives present where needed.`,
+  );
+}
+
+check();


### PR DESCRIPTION
## Summary

Fixes missing `"use client"` directives in tsup shared chunks that break Next.js builds.

### Root cause
tsup with `splitting: true` extracts shared code into chunk files. The `"use client"` directive from source files doesn't propagate — chunks containing `createContext`/`useState` etc. are missing the directive, causing Next.js to error.

### Fix
- **tsup banner**: `banner: { js: '"use client";' }` injects the directive at the top of every output file, including chunks
- **CI check**: `scripts/check-use-client.mjs` scans all `.mjs` files in dist for React client APIs without the directive. Runs post-build to catch regressions.

Fixes the sandbox build failure in #806.

---
