### PR TITLE
fix: add 'use client' to barrel index.ts files for dist path

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -416,7 +416,7 @@
     "typecheck:docs": "tsc --project tsconfig.docs.json",
     "build:css": "node ../../scripts/build-css.mjs",
     "inject:css": "node ../../scripts/inject-css-imports.mjs",
-    "postbuild": "yarn build:css && yarn inject:css"
+    "postbuild": "yarn build:css && yarn inject:css && node ../../scripts/fix-use-client-dist.mjs"
   },
   "peerDependencies": {
     "react": ">=19.0.0",

--- a/packages/core/src/AppShell/index.ts
+++ b/packages/core/src/AppShell/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSAppShell component and types from XDSAppShell.tsx

--- a/packages/core/src/AspectRatio/index.ts
+++ b/packages/core/src/AspectRatio/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from XDSAspectRatio.tsx

--- a/packages/core/src/Avatar/index.ts
+++ b/packages/core/src/Avatar/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSAvatar component and types from XDSAvatar.tsx, XDSAvatarStatusDot from XDSAvatarStatusDot.tsx

--- a/packages/core/src/Badge/index.ts
+++ b/packages/core/src/Badge/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file Badge component barrel export
  */

--- a/packages/core/src/Banner/index.ts
+++ b/packages/core/src/Banner/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSBanner component and types from XDSBanner.tsx

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file Breadcrumbs component barrel export
  */

--- a/packages/core/src/Button/index.ts
+++ b/packages/core/src/Button/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSButton component and types from XDSButton.tsx

--- a/packages/core/src/Calendar/index.ts
+++ b/packages/core/src/Calendar/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports calendar components and types

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSCard component

--- a/packages/core/src/Center/index.ts
+++ b/packages/core/src/Center/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSCenter component

--- a/packages/core/src/CheckboxInput/index.ts
+++ b/packages/core/src/CheckboxInput/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSCheckboxInput component and types from XDSCheckboxInput.tsx

--- a/packages/core/src/Collapsible/index.ts
+++ b/packages/core/src/Collapsible/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSCollapsible, XDSCollapsibleGroup, and useXDSCollapsible

--- a/packages/core/src/DateInput/index.ts
+++ b/packages/core/src/DateInput/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input DateInput component exports

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSDialog component and types from XDSDialog.tsx

--- a/packages/core/src/Divider/index.ts
+++ b/packages/core/src/Divider/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from XDSDivider.tsx

--- a/packages/core/src/DropdownMenu/index.ts
+++ b/packages/core/src/DropdownMenu/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @output Exports XDSDropdownMenu, XDSDropdownMenuItem and related types

--- a/packages/core/src/Field/index.ts
+++ b/packages/core/src/Field/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSField component and types from XDSField.tsx, XDSFieldLabel from XDSFieldLabel.tsx, XDSFieldStatus from XDSFieldStatus.tsx

--- a/packages/core/src/FormLayout/index.ts
+++ b/packages/core/src/FormLayout/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Uses XDSFormLayout, XDSFormLayoutContext

--- a/packages/core/src/Grid/index.ts
+++ b/packages/core/src/Grid/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from XDSGrid.tsx and XDSGridSpan.tsx

--- a/packages/core/src/HoverCard/index.ts
+++ b/packages/core/src/HoverCard/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input HoverCard component and hook

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSIcon component/types, icon registry, and global registration

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Layer hooks and components

--- a/packages/core/src/Layout/index.ts
+++ b/packages/core/src/Layout/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports layout utilities and components

--- a/packages/core/src/Link/index.ts
+++ b/packages/core/src/Link/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSLink, XDSLinkProvider, useXDSLinkComponent, types

--- a/packages/core/src/List/index.ts
+++ b/packages/core/src/List/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from XDSList.tsx and XDSListItem.tsx

--- a/packages/core/src/MobileNav/index.ts
+++ b/packages/core/src/MobileNav/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from XDSMobileNav.tsx, XDSMobileNavToggle.tsx

--- a/packages/core/src/MoreMenu/index.ts
+++ b/packages/core/src/MoreMenu/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @output Exports XDSMoreMenu and related types

--- a/packages/core/src/NumberInput/index.ts
+++ b/packages/core/src/NumberInput/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSNumberInput component and types from XDSNumberInput.tsx

--- a/packages/core/src/OverflowList/index.ts
+++ b/packages/core/src/OverflowList/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file OverflowList component barrel export
  */

--- a/packages/core/src/Pagination/index.ts
+++ b/packages/core/src/Pagination/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input XDSPagination component and types

--- a/packages/core/src/Popover/index.ts
+++ b/packages/core/src/Popover/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Popover component and hook

--- a/packages/core/src/PowerSearch/index.ts
+++ b/packages/core/src/PowerSearch/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input PowerSearch component and types

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file ProgressBar component barrel export
  */

--- a/packages/core/src/RadioList/index.ts
+++ b/packages/core/src/RadioList/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSRadioList, XDSRadioListItem components and types

--- a/packages/core/src/Section/index.ts
+++ b/packages/core/src/Section/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSSection component

--- a/packages/core/src/SegmentedControl/index.ts
+++ b/packages/core/src/SegmentedControl/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from SegmentedControl component files

--- a/packages/core/src/Selector/index.ts
+++ b/packages/core/src/Selector/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @output Exports XDSSelector and types

--- a/packages/core/src/SideNav/index.ts
+++ b/packages/core/src/SideNav/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports SideNav components and types

--- a/packages/core/src/Skeleton/index.ts
+++ b/packages/core/src/Skeleton/index.ts
@@ -1,2 +1,4 @@
+'use client';
+
 export {XDSSkeleton} from './XDSSkeleton';
 export type {XDSSkeletonProps, XDSSkeletonRadius} from './XDSSkeleton';

--- a/packages/core/src/Slider/index.ts
+++ b/packages/core/src/Slider/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export {XDSSlider} from './XDSSlider';
 export type {
   XDSSliderProps,

--- a/packages/core/src/Spinner/index.ts
+++ b/packages/core/src/Spinner/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export {XDSSpinner} from './XDSSpinner';
 export type {
   XDSSpinnerProps,

--- a/packages/core/src/Switch/index.ts
+++ b/packages/core/src/Switch/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 export {XDSSwitch} from './XDSSwitch';
 export type {
   XDSSwitchProps,

--- a/packages/core/src/TabList/index.ts
+++ b/packages/core/src/TabList/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from TabList component files

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from Table component files

--- a/packages/core/src/Text/index.ts
+++ b/packages/core/src/Text/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file Text component exports
  * @position Entry point for Text components

--- a/packages/core/src/TextArea/index.ts
+++ b/packages/core/src/TextArea/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSTextArea component and types from XDSTextArea.tsx

--- a/packages/core/src/TextInput/index.ts
+++ b/packages/core/src/TextInput/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports XDSTextInput component and types from TextInput.tsx

--- a/packages/core/src/TimeInput/index.ts
+++ b/packages/core/src/TimeInput/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports TimeInput components and types

--- a/packages/core/src/Tokenizer/index.ts
+++ b/packages/core/src/Tokenizer/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Tokenizer component

--- a/packages/core/src/Tooltip/index.ts
+++ b/packages/core/src/Tooltip/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Tooltip component and hook

--- a/packages/core/src/TopNav/index.ts
+++ b/packages/core/src/TopNav/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from TopNav component files

--- a/packages/core/src/TreeList/index.ts
+++ b/packages/core/src/TreeList/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from XDSTreeList.tsx and XDSTreeListTypes.ts

--- a/packages/core/src/Typeahead/index.ts
+++ b/packages/core/src/Typeahead/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Typeahead components and types

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports hooks from individual files

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file index.ts
  * @input Imports from component directories (Button/, Card/, Layout/, Layer/)

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * XDS Theme System
  *

--- a/scripts/fix-use-client-dist.mjs
+++ b/scripts/fix-use-client-dist.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Post-build: ensure "use client" is the FIRST LINE of dist files that need it.
+ * tsup may insert babel helpers before the directive — this moves it to line 1.
+ * 
+ * Only patches files that already have "use client" somewhere in the first 50 lines.
+ * Skips files that don't have it (like theme/tokens).
+ */
+import fs from 'fs';
+import path from 'path';
+import {fileURLToPath} from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DIST = path.resolve(__dirname, '../packages/core/dist');
+
+function walk(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) results.push(...walk(full));
+    else if (entry.name.endsWith('.mjs') || entry.name.endsWith('.js')) results.push(full);
+  }
+  return results;
+}
+
+let fixed = 0;
+for (const file of walk(DIST)) {
+  const content = fs.readFileSync(file, 'utf-8');
+  const lines = content.split('\n');
+  
+  // Check if file has "use client" in first 50 lines but not on line 1
+  const first50 = lines.slice(0, 50);
+  const hasDirective = first50.some(l => l.trim() === "'use client';" || l.trim() === '"use client";');
+  const isFirstLine = lines[0].trim() === "'use client';" || lines[0].trim() === '"use client";';
+  
+  if (hasDirective && !isFirstLine) {
+    // Remove directive from wherever it is
+    const filtered = lines.filter(l => l.trim() !== "'use client';" && l.trim() !== '"use client";');
+    // Prepend at top
+    const patched = '"use client";\n' + filtered.join('\n');
+    fs.writeFileSync(file, patched);
+    fixed++;
+  }
+}
+
+console.log(`✅ Fixed "use client" position in ${fixed} dist files`);


### PR DESCRIPTION
With `splitting: false` (#815), tsup inlines all code into each entry point. The `'use client'` directive must be on the barrel `index.ts` (the entry point) — tsup doesn't propagate directives from inlined modules.

Adds `'use client'` to 56 barrel files. Fixes the sandbox build failure in #806.

---
