### PR TITLE
fix: component audit — RadioList, Section, Selector, SideNav

### DIFF
--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -3,7 +3,7 @@
 /**
  * @file XDSRadioList.tsx
  * @input Uses React useId, createContext, ReactNode, XDSField, XDSInputStatus
- * @output Exports XDSRadioList component, XDSRadioListProps, RadioListContext
+ * @output Exports XDSRadioList component, XDSRadioListProps, XDSRadioListContext
  * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -12,7 +12,6 @@
  * - /packages/core/src/RadioList/index.ts
  * - /apps/storybook/stories/RadioList.stories.tsx
  */
-
 
 import {createContext, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
@@ -27,7 +26,7 @@ import {xdsClassName, mergeProps} from '../utils';
  */
 export type XDSRadioListSize = 'sm' | 'md';
 
-export interface RadioListContextValue {
+export interface XDSRadioListContextValue {
   name: string;
   value: string;
   onChange: (value: string) => void;
@@ -37,9 +36,8 @@ export interface RadioListContextValue {
   status?: XDSInputStatus;
 }
 
-export const RadioListContext = createContext<RadioListContextValue | null>(
-  null,
-);
+export const XDSRadioListContext =
+  createContext<XDSRadioListContextValue | null>(null);
 
 const styles = stylex.create({
   radiogroup: {
@@ -182,7 +180,7 @@ export function XDSRadioList({
   const descriptionID = useId();
   const statusMessageID = useId();
 
-  const contextValue: RadioListContextValue = {
+  const contextValue: XDSRadioListContextValue = {
     name,
     value,
     onChange,
@@ -236,11 +234,12 @@ export function XDSRadioList({
             orientation === 'vertical' ? styles.vertical : styles.horizontal,
             xstyle,
           ),
+          className,
+          style,
         )}>
-        className, style,
-        <RadioListContext.Provider value={contextValue}>
+        <XDSRadioListContext.Provider value={contextValue}>
           {children}
-        </RadioListContext.Provider>
+        </XDSRadioListContext.Provider>
       </div>
     </XDSField>
   );

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSRadioListItem.tsx
- * @input Uses React useContext, useId, RadioListContext
+ * @input Uses React useContext, useId, XDSRadioListContext
  * @output Exports XDSRadioListItem component, XDSRadioListItemProps
  * @position Core implementation; consumed by index.ts, tested by XDSRadioList.test.tsx
  *
@@ -12,7 +12,6 @@
  * - /packages/core/src/RadioList/index.ts
  * - /apps/storybook/stories/RadioList.stories.tsx
  */
-
 
 import {useContext, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
@@ -25,7 +24,7 @@ import {
   fontWeightVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
-import {RadioListContext} from './XDSRadioList';
+import {XDSRadioListContext} from './XDSRadioList';
 import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
@@ -246,7 +245,7 @@ export function XDSRadioListItem({
   endContent,
   'data-testid': dataTestId,
 }: XDSRadioListItemProps) {
-  const context = useContext(RadioListContext);
+  const context = useContext(XDSRadioListContext);
   if (!context) {
     throw new Error('XDSRadioListItem must be used within an XDSRadioList');
   }

--- a/packages/core/src/Section/XDSSection.test.tsx
+++ b/packages/core/src/Section/XDSSection.test.tsx
@@ -21,25 +21,25 @@ describe('XDSSection', () => {
 
   it('renders with variant="section" (default)', () => {
     const {container} = render(<XDSSection>Content</XDSSection>);
-    const root = container.firstElementChild!;
-    expect(root.className).toContain('xds-section');
-    expect(root.className).toContain('section');
+    const inner = container.firstElementChild!.firstElementChild!;
+    expect(inner.className).toContain('xds-section');
+    expect(inner.className).toContain('section');
   });
 
   it('renders with variant="transparent"', () => {
     const {container} = render(
       <XDSSection variant="transparent">Content</XDSSection>,
     );
-    const root = container.firstElementChild!;
-    expect(root.className).toContain('xds-section');
-    expect(root.className).toContain('transparent');
+    const inner = container.firstElementChild!.firstElementChild!;
+    expect(inner.className).toContain('xds-section');
+    expect(inner.className).toContain('transparent');
   });
 
   it('renders with variant="wash"', () => {
     const {container} = render(<XDSSection variant="wash">Content</XDSSection>);
-    const root = container.firstElementChild!;
-    expect(root.className).toContain('xds-section');
-    expect(root.className).toContain('wash');
+    const inner = container.firstElementChild!.firstElementChild!;
+    expect(inner.className).toContain('xds-section');
+    expect(inner.className).toContain('wash');
   });
 
   it('renders with dividers', () => {
@@ -100,15 +100,15 @@ describe('XDSSection', () => {
 
   it('renders xds-* class names for theme targeting', () => {
     const {container} = render(<XDSSection>Content</XDSSection>);
-    const root = container.firstElementChild!;
-    expect(root.className).toContain('xds-section');
+    const inner = container.firstElementChild!.firstElementChild!;
+    expect(inner.className).toContain('xds-section');
   });
 
   it('renders variant in xds class names', () => {
     const {container} = render(<XDSSection variant="wash">Content</XDSSection>);
-    const root = container.firstElementChild!;
-    expect(root.className).toContain('xds-section');
-    expect(root.className).toContain('wash');
+    const inner = container.firstElementChild!.firstElementChild!;
+    expect(inner.className).toContain('xds-section');
+    expect(inner.className).toContain('wash');
   });
 
   it('accepts xstyle prop without error', () => {

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -12,7 +12,6 @@
  * - /apps/storybook/stories/Section.stories.tsx (storybook stories)
  */
 
-
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -240,42 +239,50 @@ export function XDSSection({
 }: XDSSectionProps) {
   const effectivePadding = padding ?? 4;
   const paddingToken = spacingStepToToken[effectivePadding] as SpacingToken;
+  const outerStylex = stylex.props(
+    nestedStyles.outer,
+    dynamicStyles.sizing(
+      width ?? null,
+      height ?? null,
+      maxWidth ?? null,
+      minHeight ?? null,
+    ),
+    xstyle,
+  );
+
   return (
     <div
       ref={ref as React.Ref<HTMLDivElement>}
-      {...mergeProps(
-        xdsClassName('section', {variant}),
-        stylex.props(
-          nestedStyles.outer,
-          dynamicStyles.sizing(
-            width ?? null,
-            height ?? null,
-            maxWidth ?? null,
-            minHeight ?? null,
-          ),
-          xstyle,
-        ),
-        className,
-        style,
-      )}
+      className={
+        [outerStylex.className, className].filter(Boolean).join(' ') ||
+        undefined
+      }
+      style={
+        style && outerStylex.style
+          ? {...outerStylex.style, ...style}
+          : style || outerStylex.style
+      }
       {...props}>
       <div
-        {...stylex.props(
-          nestedStyles.inner,
-          ...container({
-            paddingInnerX: paddingToken,
-            paddingInnerY: paddingToken,
-            paddingOuterX: paddingToken,
-            paddingOuterY: paddingToken,
-          }),
-          effectivePadding !== 4 && paddingStyles[effectivePadding],
-          effectivePadding !== 4 &&
-            containerPaddingInlineVarStyles[effectivePadding],
-          variantStyles[variant],
-          dividers?.includes('top') && dividerStyles.top,
-          dividers?.includes('bottom') && dividerStyles.bottom,
-          dividers?.includes('start') && dividerStyles.start,
-          dividers?.includes('end') && dividerStyles.end,
+        {...mergeProps(
+          xdsClassName('section', {variant}),
+          stylex.props(
+            nestedStyles.inner,
+            ...container({
+              paddingInnerX: paddingToken,
+              paddingInnerY: paddingToken,
+              paddingOuterX: paddingToken,
+              paddingOuterY: paddingToken,
+            }),
+            effectivePadding !== 4 && paddingStyles[effectivePadding],
+            effectivePadding !== 4 &&
+              containerPaddingInlineVarStyles[effectivePadding],
+            variantStyles[variant],
+            dividers?.includes('top') && dividerStyles.top,
+            dividers?.includes('bottom') && dividerStyles.bottom,
+            dividers?.includes('start') && dividerStyles.start,
+            dividers?.includes('end') && dividerStyles.end,
+          ),
         )}>
         {children}
       </div>

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -11,7 +11,6 @@
  * - /packages/core/src/Selector/index.ts
  */
 
-
 import React, {
   useCallback,
   useId,
@@ -136,7 +135,7 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-2'],
     backgroundColor: colorVars['--color-surface'],
-    boxShadow: `0 4px 12px ${colorVars['--color-shadow']}`,
+    boxShadow: shadowVars['--shadow-menu'],
     opacity: 1,
     transition: `opacity ${durationVars['--duration-fast']}`,
   },
@@ -615,7 +614,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
         onKeyDown={onKeyDown}
         data-testid={testId}
         {...mergeProps(
-          xdsClassName('selector', {size}),
+          xdsClassName('selector', {size, status: status?.type ?? null}),
           stylex.props(
             styles.trigger,
             sizeStyles[size],

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -16,7 +16,6 @@
  * - /apps/storybook/stories/SideNav.stories.tsx
  */
 
-
 import {useCallback, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -26,6 +25,7 @@ import {
   fontWeightVars,
   lineHeightVars,
   radiusVars,
+  shadowVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
 // TODO(#264): Lazy-load useXDSPopover so the popover/layer bundle is not
@@ -131,7 +131,7 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-2'],
     backgroundColor: colorVars['--color-surface'],
-    boxShadow: `0 4px 12px ${colorVars['--color-shadow']}`,
+    boxShadow: shadowVars['--shadow-menu'],
     overflow: 'hidden',
   },
   popover: {


### PR DESCRIPTION
## Component Audit — 2026-03-22

Night Watch component audit covering **RadioList, Section, Selector, SideNav, Skeleton** (5 components).

### Fixes

**RadioList**
- **Bug fix**: `className, style,` was rendered as stray text inside JSX instead of being passed to `mergeProps()`. Now correctly merged into the radiogroup element's props.
- **Naming**: Renamed `RadioListContext` → `XDSRadioListContext` and `RadioListContextValue` → `XDSRadioListContextValue` to follow XDS naming conventions.

**Section**
- **xdsClassName placement**: Moved `xdsClassName('section', {variant})` from the outer positioning wrapper to the inner visual container, where backgroundColor, dividers, and other visual styles are applied. The outer div is purely for margin escaping and shouldn't receive the theming className.
- Updated tests to assert xds-* class names on the inner element.

**Selector**
- **Hardcoded shadow**: Replaced partially-tokenized `\`0 4px 12px ${colorVars['--color-shadow']}\`` with `shadowVars['--shadow-menu']`.
- **Missing status in xdsClassName**: Added `status: status?.type` to the `xdsClassName('selector', ...)` call so themes can target selector status variants.

**SideNav (Heading)**
- **Hardcoded shadow**: Same partially-tokenized shadow pattern → replaced with `shadowVars['--shadow-menu']`. Added `shadowVars` import.

**Skeleton** — No issues found. Clean component.

### Needs Review

- **RadioList / Section: XDSBaseProps extension** — Both components manually declare `xstyle`, `className`, `style` instead of extending `XDSBaseProps`. This is deliberate for components that wrap `XDSField` (RadioList) or have a two-div structure (Section), where exposing all HTML attributes on the root element could be confusing. Flagging for human decision on whether to migrate.

---
