### PR TITLE
fix(sandbox): exclude @xds/core dist from StyleX babel plugin

### DIFF
--- a/apps/sandbox/babel.config.js
+++ b/apps/sandbox/babel.config.js
@@ -20,4 +20,9 @@ module.exports = {
       },
     ],
   ],
+  // Don't run StyleX babel plugin on pre-built dist files —
+  // their CSS is already compiled and shipped via xds.css imports.
+  ignore: [
+    '**/packages/core/dist/**',
+  ],
 };


### PR DESCRIPTION
The sandbox's StyleX babel plugin was reprocessing pre-built dist files from `@xds/core`. The dist CSS is already compiled and shipped via `xds.css` — the babel plugin interferes with the compiled class names, causing styles to not apply (components render but with no styling).

Adds `ignore: ['**/packages/core/dist/**']` to `babel.config.js` so the plugin only processes sandbox-specific StyleX code.

---
