### PR TITLE
fix(TopNav): show mobile toggle when SideNav content is in context

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -628,12 +628,23 @@ export function XDSAppShell({
   // stays pinned while the page scrolls. The ref is used to measure header
   // height for the sideNav's sticky offset.
   // =========================================================================
-  // When below breakpoint, TopNav renders in mobile-bar mode (heading + endContent + toggle)
+  // When below breakpoint, TopNav renders in mobile-bar mode (heading + endContent + toggle).
+  // Wrap with mobile content context so TopNav knows there's SideNav content
+  // in the drawer and shows the toggle even without its own collapsible items.
   const topNavContent = hasTopNav ? (
     isBelowBreakpoint && mobileNavEnabled ? (
-      <XDSTopNavRenderContext value="mobile-bar">
-        {topNav}
-      </XDSTopNavRenderContext>
+      <XDSTopNavMobileContentContext
+        value={
+          hasSideNav ? (
+            <XDSSideNavRenderContext value="drawer-content">
+              {sideNav}
+            </XDSSideNavRenderContext>
+          ) : null
+        }>
+        <XDSTopNavRenderContext value="mobile-bar">
+          {topNav}
+        </XDSTopNavRenderContext>
+      </XDSTopNavMobileContentContext>
     ) : (
       topNav
     )

--- a/packages/core/src/TopNav/XDSTopNav.tsx
+++ b/packages/core/src/TopNav/XDSTopNav.tsx
@@ -179,6 +179,8 @@ export function XDSTopNav({
   const mobileContent = useXDSTopNavMobileContent();
   const hasCenterContent = centerContent != null;
   const hasCollapsibleContent = startContent != null || centerContent != null;
+  // Show mobile toggle when there's ANY drawer content — own items OR SideNav via context
+  const hasMobileDrawerContent = hasCollapsibleContent || mobileContent != null;
 
   // =========================================================================
   // Mobile bar mode — heading + endContent + toggle, hide nav items
@@ -199,7 +201,7 @@ export function XDSTopNav({
         {heading && <div {...stylex.props(styles.heading)}>{heading}</div>}
         <div {...stylex.props(styles.mobileBarEnd)}>
           {endContent}
-          {hasCollapsibleContent && <XDSMobileNavToggle />}
+          {hasMobileDrawerContent && <XDSMobileNavToggle />}
         </div>
       </nav>
     );


### PR DESCRIPTION
When TopNav has only a heading (no `startContent`/`centerContent`) but a SideNav exists, the mobile hamburger toggle wasn't appearing. Two issues:

1. **TopNav** only checked `hasCollapsibleContent` (own items) to decide whether to show the toggle. Now checks `hasMobileDrawerContent` which includes SideNav content passed via `XDSTopNavMobileContentContext`.

2. **AppShell** only provided `XDSTopNavMobileContentContext` around the drawer rendering of TopNav — not the mobile-bar rendering in the header. The mobile-bar TopNav couldn't detect SideNav content and never showed the toggle.

### Before
```tsx
// TopNav with heading only + SideNav → no toggle on mobile
<XDSAppShell
  topNav={<XDSTopNav label="Nav" heading={<XDSTopNavHeading heading="My App" />} />}
  sideNav={<XDSSideNav>...</XDSSideNav>}
/>
```

### After
Same code now shows the hamburger toggle on mobile. Tapping it opens the drawer with the SideNav content.

---
