### PR TITLE
docs: fix Badge/Selector theming drift, add SegmentedControl translations

### DIFF
--- a/packages/core/src/Badge/Badge.doc.mjs
+++ b/packages/core/src/Badge/Badge.doc.mjs
@@ -49,7 +49,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-badge', visualProps: ['variant']},
+      {className: 'xds-badge', visualProps: ['variant', 'shape']},
     ],
   },
 };
@@ -104,7 +104,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-badge', visualProps: ['variant']},
+      {className: 'xds-badge', visualProps: ['variant', 'shape']},
     ],
   },
 };

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -183,3 +183,136 @@ export const docs = {
     },
   ],
 };
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsZh = {
+  description:
+    '分段按钮组，用于单选，具有单选组语义。外观类似标签栏，但控制的是值而非视图。',
+  features: [
+    '基于上下文通信：XDSSegmentedControlContext 将 value/onChange/size/isDisabled 从父组件传递给子组件',
+    '单选组语义：role="radiogroup" 配合 role="radio" 子项和 aria-checked',
+    '漫游焦点：仅选中项可通过 Tab 访问（tabIndex=0），其余为 tabIndex=-1',
+    '键盘导航：ArrowLeft/ArrowRight 导航并选中，Home/End 跳转到首尾，循环切换',
+    '动画指示器：选中项具有带 box-shadow 的凸起表面背景',
+    '图标+文本或纯图标项（isLabelHidden 隐藏文本，保留为 aria-label）',
+    '尺寸变体：sm（紧凑，适用于工具栏）、md（默认）、lg（更大触摸目标）',
+    '禁用状态：可禁用整组或单个项，使用 aria-disabled 保持可聚焦性',
+    '悬停状态：未选中项悬停时显示覆盖层，使用 @media (hover: hover) 保护',
+  ],
+  accessibility: [
+    '容器具有 role="radiogroup"，aria-label 来自 label 属性（不会渲染为可见内容）',
+    '子项具有 role="radio"，aria-checked 表示选中状态',
+    '漫游焦点：选中项 tabIndex=0，其余 tabIndex=-1',
+    '方向键同时导航和选中（单选组模式）',
+    '禁用项使用 aria-disabled（非原生 disabled）以保持可聚焦性',
+    '纯图标项使用 isLabelHidden，label 变为 aria-label',
+  ],
+  keyboard:
+    'ArrowRight/ArrowLeft 导航并选中（循环）。Home/End 跳转到首尾项。仅选中项在 Tab 顺序中。',
+  notes: [
+    '仅受控模式，v1 无非受控模式',
+    '仅水平方向，v1 无垂直方向',
+    '不允许取消选中（单选语义，始终有一项选中）',
+    '使用 aria-disabled 替代原生 disabled 以保持键盘可聚焦性',
+    '键盘导航会跳过禁用项',
+    '轨道背景使用 --color-secondary，选中指示器使用 --color-surface 配合 --shadow-base',
+    'XDSSegmentedControl 的 label 属性仅用于 aria（类似 XDSTabList 的 aria-label），不会渲染为可见内容',
+  ],
+  components: [
+    {
+      name: 'XDSSegmentedControl',
+      description:
+        '容器包装组件，通过上下文向 XDSSegmentedControlItem 子组件提供 value、onChange、size、isDisabled。',
+      propDescriptions: {
+        value: '当前选中值（受控）。',
+        onChange: '选中分段时触发的回调。',
+        label: '单选组的无障碍标签（用作 aria-label，不会渲染为可见内容）。',
+        size: '控件的尺寸变体。',
+        isDisabled: '是否禁用整个控件。',
+        children: 'XDSSegmentedControlItem 子组件。',
+        xstyle: '容器的额外 StyleX 样式。',
+      },
+    },
+    {
+      name: 'XDSSegmentedControlItem',
+      description:
+        '单个分段项，在分段控件中渲染为单选按钮。',
+      propDescriptions: {
+        value: '该分段的唯一值，与父组件的 value 匹配。',
+        label: '该分段的无障碍标签。除非 isLabelHidden 为 true，否则渲染为可见文本。',
+        isLabelHidden: '是否在视觉上隐藏标签。为 true 时仅显示图标，label 用作 aria-label。',
+        icon: '显示在标签前的图标元素。',
+        isDisabled: '是否禁用该单个项。',
+      },
+    },
+  ],
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description: 'segmented button group; single selection w/ radio group semantics; resembles tab bar but controls value not view',
+  features: [
+    'context-based: XDSSegmentedControlContext passes value/onChange/size/isDisabled to children',
+    'radio group semantics: role="radiogroup" w/ role="radio" items+aria-checked',
+    'roving tabindex: selected=tabIndex=0; others tabIndex=-1',
+    'keyboard: ArrowLeft/Right navigate+select; Home/End first/last; wraps',
+    'animated indicator: selected item raised surface bg w/ box-shadow',
+    'icon+label or icon-only (isLabelHidden hides label visually; keeps aria-label)',
+    'sizes: sm (compact/toolbars) md (default) lg (larger touch)',
+    'disabled: group or individual via aria-disabled (maintains focusability)',
+    'hover: unselected items show overlay; @media (hover: hover) guard',
+  ],
+  accessibility: [
+    'container: role="radiogroup" w/ aria-label from label prop (never rendered)',
+    'items: role="radio" w/ aria-checked for selection',
+    'roving tabindex: selected=tabIndex=0; others=-1',
+    'arrows navigate+select simultaneously (radio group pattern)',
+    'disabled items use aria-disabled not native disabled; maintains focusability',
+    'icon-only: isLabelHidden; label becomes aria-label',
+  ],
+  keyboard: 'ArrowRight/Left navigate+select (wrap). Home/End first/last. Only selected in tab order.',
+  notes: [
+    'controlled-only; no uncontrolled v1',
+    'horizontal-only; no vertical v1',
+    'no deselection (radio semantics; always one selected)',
+    'aria-disabled not native disabled; maintains keyboard focusability',
+    'keyboard nav skips disabled items',
+    'track bg: --color-secondary; selected indicator: --color-surface+--shadow-base',
+    'label prop aria-only (like XDSTabList aria-label); never rendered',
+  ],
+  propDescriptions: {
+    value: 'currently selected value (controlled)',
+    onChange: 'callback on segment selection',
+    label: 'aria-label for radio group (never rendered)',
+    size: 'size variant',
+    isDisabled: 'disables entire control',
+    children: 'XDSSegmentedControlItem children',
+    xstyle: 'additional StyleX styles for container',
+  },
+  components: [
+    {
+      name: 'XDSSegmentedControl',
+      description: 'container; provides context (value/onChange/size/isDisabled) to children',
+      propDescriptions: {
+        value: 'selected value (controlled)',
+        onChange: 'selection callback',
+        label: 'aria-label for radio group (not rendered)',
+        size: 'size variant',
+        isDisabled: 'disables entire control',
+        children: 'XDSSegmentedControlItem children',
+        xstyle: 'extra StyleX styles',
+      },
+    },
+    {
+      name: 'XDSSegmentedControlItem',
+      description: 'individual segment; renders as radio button in control',
+      propDescriptions: {
+        value: 'unique segment value; matched against parent',
+        label: 'segment label; visible unless isLabelHidden',
+        isLabelHidden: 'hides label visually; label becomes aria-label',
+        icon: 'icon before label',
+        isDisabled: 'disables this item',
+      },
+    },
+  ],
+};

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -22,7 +22,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-selector', visualProps: ['size']},
+      {className: 'xds-selector', visualProps: ['size', 'status']},
       {className: 'xds-selector-option'},
     ],
   },
@@ -255,7 +255,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-selector', visualProps: ['size']},
+      {className: 'xds-selector', visualProps: ['size', 'status']},
       {className: 'xds-selector-option'},
     ],
   },


### PR DESCRIPTION
## What

Night Watch doc review found 3 issues:

**Badge theming drift** — `xdsClassName('badge', {variant, shape})` passes both `variant` and `shape`, but the doc only listed `['variant']` in visualProps. Added `shape`.

**Selector theming drift** — `xdsClassName('selector', {size, status: status?.type ?? null})` passes `status` as a conditional variant class, but the doc only listed `['size']`. Added `status`.

**SegmentedControl missing translations** — Only component without `docsZh` and `docsDense` exports. Added both following the TranslationDoc shape.

## Validation
- `yarn workspace @xds/core typecheck:docs` passes
- CLI `--lang zh` and `--lang dense` output verified for SegmentedControl
- `yarn build` passes
- No source code (.tsx) modified, only .doc.mjs files

*Night Watch Doc Reviewer*