### PR TITLE
fix(Spinner,Slider): escape hatches and xdsClassName completeness

### DIFF
--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/Slider.stories.tsx
  */
 
-
 import {
   useId,
   useRef,
@@ -577,7 +576,10 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
         style={positionStyle}
         onKeyDown={e => handleKeyDown(thumbIndex, e)}
         {...mergeProps(
-          xdsClassName('slider-thumb', {orientation}),
+          xdsClassName('slider-thumb', {
+            orientation,
+            disabled: isDisabled ? 'disabled' : null,
+          }),
           stylex.props(
             styles.thumb,
             isHorizontal ? styles.thumbHorizontal : styles.thumbVertical,
@@ -659,7 +661,10 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
       style={style}>
       <div
         {...mergeProps(
-          xdsClassName('slider', {orientation}),
+          xdsClassName('slider', {
+            orientation,
+            disabled: isDisabled ? 'disabled' : null,
+          }),
           stylex.props(styles.sliderRow),
         )}>
         <div

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -13,9 +13,9 @@
  * - /apps/storybook/stories/Spinner.stories.tsx
  */
 
-
 import {useEffect, useRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -89,6 +89,22 @@ export interface XDSSpinnerProps {
    */
   shade?: XDSSpinnerShade;
   /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) appended to the root element.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
    * Test ID for the root element.
    */
   'data-testid'?: string;
@@ -111,6 +127,8 @@ export interface XDSSpinnerProps {
 export function XDSSpinner({
   size = 'md',
   shade = 'default',
+  xstyle,
+  className,
   'data-testid': testId,
   ref,
 }: XDSSpinnerProps) {
@@ -179,8 +197,9 @@ export function XDSSpinner({
       aria-label="Loading"
       data-testid={testId}
       {...mergeProps(
-        xdsClassName('spinner', {size}),
-        stylex.props(styles.spinner),
+        xdsClassName('spinner', {size, shade}),
+        stylex.props(styles.spinner, xstyle),
+        className,
       )}
       style={{width: frameSize, height: frameSize}}>
       <canvas ref={canvasRef} {...stylex.props(styles.canvas)} />


### PR DESCRIPTION
## Component Audit — 2026-03-23

Nightly audit of **Slider**, **Spinner**, **Stack**, **StatusDot**, **Switch**.

### Changes

**Spinner** (`XDSSpinner.tsx`)
- Added `xstyle` and `className` props — Spinner was the only visual component missing style escape hatches
- Added `shade` to `xdsClassName` call so themes can target `xds-spinner[data-shade="onMedia"]`

**Slider** (`XDSSlider.tsx`)
- Added `disabled` to `xdsClassName` on both `slider` and `slider-thumb` elements — `isDisabled` drives visual styles (opacity, cursor) but was missing from the className, preventing theme overrides

### Components Passing Audit (no issues)
- **Stack** (XDSStack, XDSHStack, XDSVStack, XDSStackItem) — clean across all checks. Proper token usage, xdsClassName with all visual props, extends XDSBaseProps, correct exports.
- **StatusDot** — clean. Uses colorVars for all variant colors, proper xdsClassName with variant+size, label for a11y, extensible variant map pattern.
- **Switch** — clean. Full field props, proper xdsClassName with checked+disabled, accessible wiring, XDSBaseProps extension.

### Needs Review

1. **Spinner canvas background ring uses hardcoded rgba colors** (`rgba(0, 0, 0, 0.1)` for default, `rgba(255, 255, 255, 0.3)` for onMedia). The active ring color correctly resolves from CSS variables via `getComputedStyle`, but the background ring does not. No existing token is a close match — `--color-overlay-hover` is ~5% opacity vs the needed 10%/30%. May warrant a dedicated `--color-spinner-ring` token or resolving from a new overlay token. Leaving as-is to avoid visual regression.

### Verification
- `yarn build` ✅
- `yarn test` ✅ (1864 tests, 113 files)