### PR TITLE
fix: rename @layer xds-reset to @layer reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ import '@xds/core/reset.css'; // Base reset — box-sizing, margins, etc.
 import '@xds/core/typography.css'; // Prose styles — headings, lists, code, etc.
 ```
 
-The reset uses `@layer reset` and typography uses `@layer typography`, so they won't conflict with component styles.
+The reset uses `@layer reset`, so it won't conflict with component styles.
 
 ### 2. Set Up the Theme Provider
 

--- a/apps/example-vite/README.md
+++ b/apps/example-vite/README.md
@@ -67,7 +67,7 @@ export default defineConfig({
           {
             tag: 'style',
             children:
-              '@layer reset, typography, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9, xds.theme;',
+              '@layer reset, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9, xds.theme;',
             injectTo: 'head-prepend',
           },
         ];

--- a/apps/example-vite/vite.config.ts
+++ b/apps/example-vite/vite.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
           {
             tag: 'style',
             children:
-              '@layer reset, typography, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9, xds.theme;',
+              '@layer reset, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9, xds.theme;',
             injectTo: 'head-prepend',
           },
         ];

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type {Metadata} from 'next';
  * XDS CSS Layer Model (dist path)
  *
  * Import order establishes CSS layer priority (lowest → highest):
- *   1. @xds/core/reset.css            → @layer xds-reset  (reset styles)
+ *   1. @xds/core/reset.css            → @layer reset  (reset styles)
  *   2. @xds/core/xds.css              → @layer xds-base   (component base styles)
  *   3. @xds/theme-default/theme.css   → @layer xds-theme  (default theme)
  *   4. @xds/theme-neutral/theme.css   → @layer xds-theme  (neutral theme)

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -76,7 +76,7 @@ const config: StorybookConfig = {
               {
                 tag: 'style',
                 children:
-                  '@layer reset, typography, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9;',
+                  '@layer reset, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9;',
                 injectTo: 'head-prepend',
               },
             ];

--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -19,11 +19,11 @@
  *    import '@xds/core/reset.css';
  *
  * 2. Combine with theme and typography:
- *    import '@xds/core/reset.css';        // @layer xds-reset  — clean slate
+ *    import '@xds/core/reset.css';        // @layer reset  — clean slate
  *    import '@xds/core/xds.css';           // @layer xds-base — component styles
  *    import '@xds/theme-default/theme.css'; // @layer xds-theme — theme overrides
  *
- * Layer order: xds-reset → xds-base → xds-theme
+ * Layer order: reset → xds-base → xds-theme
  * Consumer styles (unlayered) always override all XDS layers.
  * The reset has the lowest priority and can be overridden by any other layer.
  *
@@ -34,7 +34,7 @@
  * - modern-normalize
  */
 
-@layer xds-reset {
+@layer reset {
 
   /* ===========================================================================
      Box Model


### PR DESCRIPTION
## Problem

In Storybook, the reset CSS layer was taking precedence over StyleX priority layers. The reset layer was named `xds-reset` in `reset.css`, but the layer order declarations in storybook and example-vite declare `reset`:

```css
@layer reset, typography, priority1, priority2, ... priority9;
```

Since `xds-reset` didn't match any name in the declared order, it got implicitly ordered *after* all declared layers — giving reset styles higher precedence than component styles. That's backwards.

## Fix

Rename `@layer xds-reset` → `@layer reset` in `packages/core/src/reset.css` so it matches the existing layer order declarations. Updated all comments referencing the old name.

## Changes

- `packages/core/src/reset.css` — rename layer + update comments
- `apps/sandbox/src/app/layout.tsx` — update comment

---
