### PR TITLE
fix(storybook): align CSS layer order with xds-reset rename

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -67,8 +67,8 @@ const config: StorybookConfig = {
         // In Vite dev mode the StyleX unplugin's transformIndexHtml injects
         // a <link> for /virtual:stylex.css before preview.tsx CSS imports
         // are processed, which would otherwise cause priority1-9 layers to
-        // be declared first (lowest priority) and reset/typography last
-        // (highest priority) — the reverse of what we need.
+        // be declared first (lowest priority) and xds-reset last
+        // (highest priority), making the reset stomp component borders.
         {
           name: 'xds-css-layer-order',
           transformIndexHtml() {
@@ -76,7 +76,7 @@ const config: StorybookConfig = {
               {
                 tag: 'style',
                 children:
-                  '@layer reset, typography, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9;',
+                  '@layer xds-reset, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9, xds-theme;',
                 injectTo: 'head-prepend',
               },
             ];


### PR DESCRIPTION
The reset.css layer was renamed from `@layer reset` to `@layer xds-reset` in #806, but the Storybook layer order declaration still referenced the old `reset` name. Since `xds-reset` wasn't in the declaration, CSS treated it as an undeclared layer and gave it the highest priority. This caused the reset's `border-width: 0` to override component borders on TextInput, Selector, and other inputs.

Also adds `xds-theme` to the layer order so runtime theme injection from `XDSTheme` slots in correctly.