### PR TITLE
docs: add missing Badge shape, EmptyState headingLevel, Spinner shade theming

### DIFF
--- a/packages/core/src/Badge/Badge.doc.mjs
+++ b/packages/core/src/Badge/Badge.doc.mjs
@@ -26,6 +26,12 @@ export const docs = {
       type: 'ReactNode',
       description: 'Optional leading icon.',
     },
+    {
+      name: 'shape',
+      type: "'pill' | 'dot'",
+      description: "Visual shape. 'pill' is the default rounded pill for text/icon content. 'dot' renders a small circular indicator with no visible content (label becomes visually hidden for screen readers).",
+      default: "'pill'",
+    },
   ],
   examples: [
     {
@@ -43,8 +49,8 @@ export const docs = {
       code: '<XDSBadge variant="info" label={42} />',
     },
     {
-      label: 'Dot indicator (no children)',
-      code: '<XDSBadge variant="success" />',
+      label: 'Dot indicator',
+      code: '<XDSBadge variant="error" shape="dot" label="Unread" />',
     },
   ],
   theming: {
@@ -81,6 +87,12 @@ export const docsZh = {
       type: 'ReactNode',
       description: '可选的前置图标。',
     },
+    {
+      name: 'shape',
+      type: "'pill' | 'dot'",
+      description: "视觉形状。'pill' 是文本/图标内容的默认圆角药丸形状。'dot' 渲染一个无可见内容的小圆形指示器（label 变为屏幕阅读器专用的隐藏文本）。",
+      default: "'pill'",
+    },
   ],
   examples: [
     {
@@ -98,8 +110,8 @@ export const docsZh = {
       code: '<XDSBadge variant="info" label={42} />',
     },
     {
-      label: '圆点指示器（无子元素）',
-      code: '<XDSBadge variant="success" />',
+      label: '圆点指示器',
+      code: '<XDSBadge variant="error" shape="dot" label="Unread" />',
     },
   ],
   theming: {
@@ -117,5 +129,6 @@ export const docsDense = {
     label: 'badge text; omit with children for dot indicator',
     children: 'badge content; omit for dot indicator',
     icon: 'optional leading icon',
+    shape: "visual shape: 'pill' (default rounded) or 'dot' (small circular, label visually hidden)",
   },
 };

--- a/packages/core/src/EmptyState/EmptyState.doc.mjs
+++ b/packages/core/src/EmptyState/EmptyState.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   features: [
     'Uses role="status" so screen readers announce the empty state automatically',
     'Icon slot renders as decorative (aria-hidden="true") — no extra labeling needed',
-    'Title renders as an <h3> heading element for correct document outline',
+    'Title renders as a heading element (h1-h6, default h3) for correct document outline',
     'Actions are laid out horizontally by default and stack vertically in compact mode',
     'Compact variant reduces spacing for constrained content areas',
     'Accepts xstyle, className, and style props for custom container adjustments',
@@ -70,6 +70,13 @@ export const docs = {
         'Optional action buttons displayed below the description, laid out horizontally by default and stacked vertically when isCompact is true.',
     },
     {
+      name: 'headingLevel',
+      type: '1 | 2 | 3 | 4 | 5 | 6',
+      description:
+        'Controls the rendered HTML heading tag (h1-h6) to fit the document outline.',
+      default: '3',
+    },
+    {
       name: 'isCompact',
       type: 'boolean',
       description:
@@ -91,7 +98,7 @@ export const docs = {
   accessibility: [
     'Container uses role="status" to announce the empty state content to screen readers.',
     'Icon wrapper has aria-hidden="true" so decorative icons are ignored by assistive technology.',
-    'Title renders as an <h3> element, keeping it in the document heading outline.',
+    'Title renders as a heading element (h1-h6 via headingLevel prop, default h3), keeping it in the document heading outline.',
   ],
 };
 
@@ -103,7 +110,7 @@ export const docsZh = {
   features: [
     '使用 role="status"，屏幕阅读器会自动播报空状态内容',
     '图标插槽渲染为装饰性元素（aria-hidden="true"），无需额外标注',
-    '标题渲染为 <h3> 标题元素，保持正确的文档大纲',
+    '标题渲染为标题元素（h1-h6，默认 h3），保持正确的文档大纲',
     '操作按钮默认水平排列，紧凑模式下垂直堆叠',
     '紧凑变体减少间距，适用于空间受限的内容区域',
     '接受 xstyle、className 和 style 属性用于自定义容器调整',
@@ -166,6 +173,13 @@ export const docsZh = {
         '可选的操作按钮，显示在描述下方，默认水平排列，isCompact 为 true 时垂直堆叠。',
     },
     {
+      name: 'headingLevel',
+      type: '1 | 2 | 3 | 4 | 5 | 6',
+      description:
+        '控制渲染的 HTML 标题标签（h1-h6），以适配文档大纲。',
+      default: '3',
+    },
+    {
       name: 'isCompact',
       type: 'boolean',
       description:
@@ -187,7 +201,7 @@ export const docsZh = {
   accessibility: [
     '容器使用 role="status" 向屏幕阅读器播报空状态内容。',
     '图标包装器具有 aria-hidden="true"，使装饰性图标被辅助技术忽略。',
-    '标题渲染为 <h3> 元素，保持在文档标题大纲中。',
+    '标题渲染为标题元素（通过 headingLevel 属性设置 h1-h6，默认 h3），保持在文档标题大纲中。',
   ],
 };
 
@@ -198,7 +212,7 @@ export const docsDense = {
   features: [
     'role="status" so screen readers auto-announce empty state',
     'Icon slot renders decorative (aria-hidden="true"); no extra labeling needed',
-    'Title renders as <h3> for correct document outline',
+    'Title renders as heading (h1-h6, default h3) for correct document outline',
     'Actions horizontal by default; stack vertically in compact mode',
     'Compact variant reduces spacing for constrained areas',
     'Accepts xstyle, className, style for container adjustments',
@@ -207,10 +221,11 @@ export const docsDense = {
   accessibility: [
     'Container uses role="status" to announce empty state to screen readers.',
     'Icon wrapper has aria-hidden="true"; decorative icons ignored by assistive tech.',
-    'Title renders as <h3>, keeping it in document heading outline.',
+    'Title renders as heading (h1-h6 via headingLevel, default h3) in document outline.',
   ],
   propDescriptions: {
-    title: 'Primary msg rendered as <h3> inside empty state.',
+    title: 'Primary msg rendered as heading (h1-h6) inside empty state.',
+    headingLevel: 'Controls HTML heading tag (h1-h6) for document outline.',
     description: 'Optional secondary text w/ additional context below title.',
     icon: 'Optional icon/illustration above title; rendered decorative (aria-hidden="true").',
     actions: 'Optional action buttons below description; horizontal by default, vertical when isCompact.',

--- a/packages/core/src/Spinner/Spinner.doc.mjs
+++ b/packages/core/src/Spinner/Spinner.doc.mjs
@@ -47,7 +47,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-spinner', visualProps: ['size']},
+      {className: 'xds-spinner', visualProps: ['size', 'shade']},
     ],
   },
   notes: [
@@ -108,7 +108,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-spinner', visualProps: ['size']},
+      {className: 'xds-spinner', visualProps: ['size', 'shade']},
     ],
   },
   notes: [


### PR DESCRIPTION
## What

Night Watch doc review found 3 components with missing or inaccurate documentation:

| Component | Issue | Fix |
|-----------|-------|-----|
| Badge | `shape` prop undocumented | Added to docs, docsZh, docsDense + updated dot example |
| EmptyState | `headingLevel` prop undocumented; features/a11y text hardcoded `<h3>` | Added prop, updated text to reflect h1-h6 configurability |
| Spinner | `shade` missing from theming visualProps | Added to both en and zh theming targets |

Also noted (not fixed in this PR):
- OverflowList has no .doc.mjs file at all (would need full creation, not a doc fix)

## Checklist
- [x] `yarn workspace @xds/core typecheck:docs` passes
- [x] CLI output verified for Badge, EmptyState
- [x] `yarn build` passes
- [x] Translation arrays (docsZh) match English length
- [x] docsDense updated for new props

---
*Night Watch Doc Reviewer*