### PR TITLE
fix(TabList, TextArea): hardening — xdsClassName, escape hatches

### DIFF
--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -12,7 +12,6 @@
  * - /packages/core/src/TabList/XDSTabList.test.tsx
  */
 
-
 import React, {useCallback, useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSIcon} from '../Icon';
@@ -34,6 +33,7 @@ import {useListFocus} from '../hooks/useListFocus';
 import {XDSDivider} from '../Divider';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
+import {xdsClassName, mergeProps} from '../utils';
 
 export interface XDSTabMenuOption {
   value: string;
@@ -275,11 +275,14 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
         aria-expanded={layer.isOpen}
         aria-controls={menuId}
         onClick={handleToggle}
-        {...stylex.props(
-          styles.trigger,
-          sizeStyles[size],
-          hasSelectedOption && styles.triggerSelected,
-          !hasSelectedOption && stylex.defaultMarker(),
+        {...mergeProps(
+          xdsClassName('tab-menu'),
+          stylex.props(
+            styles.trigger,
+            sizeStyles[size],
+            hasSelectedOption && styles.triggerSelected,
+            !hasSelectedOption && stylex.defaultMarker(),
+          ),
         )}>
         <span
           {...stylex.props(
@@ -307,7 +310,10 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
           role="menu"
           aria-label={label}
           onKeyDown={handleListKeyDown}
-          {...stylex.props(styles.dropdown)}>
+          {...mergeProps(
+            xdsClassName('tab-menu-dropdown'),
+            stylex.props(styles.dropdown),
+          )}>
           <XDSDivider label={label} />
           {options.map(option => {
             const isSelected = tabListCtx.value === option.value;
@@ -324,9 +330,12 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
                     handleSelect(option.value);
                   }
                 }}
-                {...stylex.props(
-                  styles.menuItem,
-                  isSelected && styles.menuItemSelected,
+                {...mergeProps(
+                  xdsClassName('tab-menu-item'),
+                  stylex.props(
+                    styles.menuItem,
+                    isSelected && styles.menuItemSelected,
+                  ),
                 )}>
                 <span {...stylex.props(styles.menuItemContent)}>
                   {option.icon && (

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/TextArea.stories.tsx (storybook stories)
  */
 
-
 import {
   useId,
   useOptimistic,
@@ -39,6 +38,8 @@ import {
 } from '../Field';
 import {XDSIcon, type XDSIconType} from '../Icon';
 import {XDSSpinner} from '../Spinner';
+import {xdsClassName, mergeProps} from '../utils';
+import type {StyleXStyles} from '@stylexjs/stylex';
 
 const styles = stylex.create({
   wrapper: {
@@ -188,6 +189,27 @@ export interface XDSTextAreaProps {
    * Useful for form submissions.
    */
   htmlName?: string;
+  /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) appended to the root element.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 }
 
 /**
@@ -220,6 +242,9 @@ export function XDSTextArea({
   maxLength,
   hasAutoFocus = false,
   htmlName,
+  xstyle,
+  className,
+  style,
   ref,
 }: XDSTextAreaProps) {
   const id = useId();
@@ -284,13 +309,19 @@ export function XDSTextArea({
       }
       labelTooltip={labelTooltip}>
       <div
-        {...stylex.props(
-          inputWrapperStyles.base,
-          styles.wrapper,
-          isDisabled && inputWrapperStyles.disabled,
-          status && inputStatusBorderStyles[status.type],
-          status && inputStatusHoverShadowStyles[status.type],
-          status && inputStatusFocusWithinStyles[status.type],
+        {...mergeProps(
+          xdsClassName('text-area'),
+          stylex.props(
+            inputWrapperStyles.base,
+            styles.wrapper,
+            isDisabled && inputWrapperStyles.disabled,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
+            xstyle,
+          ),
+          className,
+          style,
         )}>
         {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
         <textarea


### PR DESCRIPTION
## Component Audit — 2026-03-24

Audited 5 components: **TabList**, **Table**, **Text**, **TextArea**, **TextInput**.

### Fixes

**XDSTabMenu** (3 issues — missing-classname)
- Trigger button: added `xdsClassName('tab-menu')` + `mergeProps` for theme targeting
- Dropdown container: added `xdsClassName('tab-menu-dropdown')` + `mergeProps`
- Menu items: added `xdsClassName('tab-menu-item')` + `mergeProps`

**XDSTextArea** (2 issues — missing-classname, structure-issue)
- Wrapper div: added `xdsClassName('text-area')` + `mergeProps` (consistent with XDSTextInput)
- Added `xstyle`, `className`, `style` escape hatch props (XDSTextInput has these, TextArea was missing them)

### No Issues Found
- **Table** — all sub-components (XDSTable, XDSBaseTable, XDSTableRow, XDSTableCell, XDSTableHeaderCell) use proper tokens, xdsClassName, mergeProps, displayName. Types and exports are clean.
- **TextInput** — fully compliant. Extends XDSBaseProps, proper tokens, xdsClassName, escape hatches, input field props, a11y wiring.

### Needs Review

1. **XDSText / XDSHeading** — Neither extends `XDSBaseProps`. They manually define `xstyle`, `className`, `style` instead. This is arguably intentional: these components render as various elements (`span`/`p`/`div`/`label`/`h1-h6`) and have unique props (`type`, `maxLines`, `hasCapsize`). Extending `XDSBaseProps` would expose many HTML attributes that may not be appropriate. Human judgment needed on whether to extend or keep the manual approach.

2. **XDSTextArea size prop** — XDSTextInput supports `size='sm'|'md'|'lg'` but TextArea has no equivalent. TextArea height is controlled by `rows`, but a density-level `size` prop (controlling padding/font-size like other inputs) might still be appropriate for consistency.

---
