### PR TITLE
fix(Typeahead): reset hasSearched on item selection

### DIFF
--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -15,7 +15,6 @@
  * - /packages/core/src/Typeahead/index.ts
  */
 
-
 import React, {
   useCallback,
   useEffect,
@@ -407,6 +406,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
       if (newQuery.length === 0 && !hasEntriesOnFocus) {
         searchSource.cancel?.();
         setResults([]);
+        setHasSearched(false);
         layer.hide();
         return;
       }
@@ -450,6 +450,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
       onChange(item);
       setQuery('');
       setResults([]);
+      setHasSearched(false);
       layer.hide();
       inputRef.current?.focus();
     },

--- a/packages/core/src/Typeahead/XDSTypeahead.test.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.test.tsx
@@ -310,6 +310,71 @@ describe('XDSBaseTypeahead hasEntriesOnFocus', () => {
   });
 });
 
+describe('XDSBaseTypeahead hasSearched reset', () => {
+  it('does not show "No results found" after selecting an item and re-entering', async () => {
+    const onChange = vi.fn();
+    const {rerender} = render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+
+    // Type a query that returns results
+    fireEvent.change(input, {target: {value: 'Apple'}});
+    await waitFor(() => {
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+    });
+
+    // Select the item
+    fireEvent.click(screen.getByText('Apple'));
+    expect(onChange).toHaveBeenCalledWith(fruits[0]);
+
+    // Re-render with the selected value
+    rerender(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={fruits[0]}
+        onChange={onChange}
+        debounceMs={0}
+      />,
+    );
+
+    // Focus the input again — "No results found" should NOT appear
+    fireEvent.focus(input);
+
+    // The empty state text should not be visible since hasSearched was reset
+    expect(screen.queryByText('No results found')).not.toBeInTheDocument();
+  });
+
+  it('resets hasSearched when query is cleared without hasEntriesOnFocus', async () => {
+    render(
+      <XDSBaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+
+    // Type a query that returns no results
+    fireEvent.change(input, {target: {value: 'xyz'}});
+    await waitFor(() => {
+      expect(screen.getByText('No results found')).toBeInTheDocument();
+    });
+
+    // Clear the query
+    fireEvent.change(input, {target: {value: ''}});
+
+    // "No results found" should disappear since hasSearched is reset
+    expect(screen.queryByText('No results found')).not.toBeInTheDocument();
+  });
+});
+
 describe('XDSTypeahead edit mode', () => {
   it('enters edit mode on token container click', () => {
     const onChange = vi.fn();


### PR DESCRIPTION
## What

Fixes #830 — "No results found" persists after selecting a typeahead item.

## Why

In `XDSBaseTypeahead`, the `hasSearched` flag is set to `true` in `performSearch` but never reset when:
1. An item is selected via `handleSelect`
2. The query is cleared in `handleQueryChange` (when `hasEntriesOnFocus` is false)

After selecting an item, re-entering the typeahead shows "No results found" because `results.length === 0 && hasSearched` evaluates to `true`.

## How

- Added `setHasSearched(false)` in `handleSelect` after clearing query and results
- Added `setHasSearched(false)` in the `handleQueryChange` clear-query branch (when `hasEntriesOnFocus` is false)
- Added 2 test cases covering both scenarios

## Test plan

- `yarn test` — 20/20 tests pass (2 new)
- `yarn lint` — 0 errors