### PR TITLE
docs: add cssProperties to doc infrastructure, move container padding docs to component docs

### DIFF
--- a/packages/cli/src/lib/component-format.mjs
+++ b/packages/cli/src/lib/component-format.mjs
@@ -192,6 +192,17 @@ export function formatFull(docs, options = {}) {
       sections.push(`Component key: \`${docs.theming.componentKey}\`\n`);
     }
 
+    // Public CSS custom properties
+    if (docs.theming?.cssProperties?.length) {
+      const propLines = [];
+      propLines.push('| CSS Property | Description | Default |');
+      propLines.push('|-------------|-------------|---------|');
+      for (const p of docs.theming.cssProperties) {
+        propLines.push(`| \`${p.name}\` | ${p.description} | ${p.default || '—'} |`);
+      }
+      sections.push(propLines.join('\n') + '\n');
+    }
+
     // Component CSS vars
     if (docs.theming?.vars?.length) {
       const varLines = [];
@@ -292,6 +303,18 @@ export function formatCompact(docs, componentName, importHint) {
     sections.push(docs.notes.map(n => `- ${n}`).join('\n') + '\n');
   }
 
+  // CSS custom properties (compact includes these for theme consumers)
+  if (docs.theming?.cssProperties?.length) {
+    sections.push('## CSS Properties\n');
+    const propLines = [];
+    propLines.push('| CSS Property | Description | Default |');
+    propLines.push('|-------------|-------------|---------|');
+    for (const p of docs.theming.cssProperties) {
+      propLines.push(`| \`${p.name}\` | ${p.description} | ${p.default || '—'} |`);
+    }
+    sections.push(propLines.join('\n') + '\n');
+  }
+
   return sections.join('\n');
 }
 
@@ -371,6 +394,14 @@ export function formatBrief(docs, componentName, importHint, options = {}) {
     if (varNames) {
       output.push(`  Vars: ${varNames}`);
     }
+  }
+
+  // CSS custom properties (if any)
+  if (docs.theming?.cssProperties?.length) {
+    const cssPropNames = docs.theming.cssProperties
+      .map(p => `${p.name} (${p.default || '—'})`)
+      .join(', ');
+    output.push(`  CSS Props: ${cssPropNames}`);
   }
 
 // Theme targets (class names, variants, states) with theme variant merging

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -93,6 +93,14 @@ export const docs = {
     vars: [
       {name: '--card-radius', description: 'Border radius of the card', default: 'var(--radius-3)'},
     ],
+    cssProperties: [
+      {
+        name: '--xds-container-padding',
+        description:
+          "Controls Card container padding. Set in theme component overrides via `card: { base: { '--xds-container-padding': 'var(--spacing-3)' } }`. Cascades to all internal layout padding variables. Do not use `--layout-padding-*` vars directly.",
+        default: 'var(--spacing-4)',
+      },
+    ],
   },
 };
 
@@ -189,6 +197,14 @@ export const docsZh = {
     ],
     vars: [
       {name: '--card-radius', description: 'Border radius of the card', default: 'var(--radius-3)'},
+    ],
+    cssProperties: [
+      {
+        name: '--xds-container-padding',
+        description:
+          "Controls Card container padding. Set in theme component overrides via `card: { base: { '--xds-container-padding': 'var(--spacing-3)' } }`. Cascades to all internal layout padding variables. Do not use `--layout-padding-*` vars directly.",
+        default: 'var(--spacing-4)',
+      },
     ],
   },
 };

--- a/packages/core/src/Section/Section.doc.mjs
+++ b/packages/core/src/Section/Section.doc.mjs
@@ -100,6 +100,14 @@ export const docs = {
     targets: [
       {className: 'xds-section', visualProps: ['variant']},
     ],
+    cssProperties: [
+      {
+        name: '--xds-container-padding',
+        description:
+          "Controls Section container padding. Set in theme component overrides via `section: { base: { '--xds-container-padding': 'var(--spacing-3)' } }`. Cascades to all internal layout padding variables. Do not use `--layout-padding-*` vars directly.",
+        default: 'var(--spacing-4)',
+      },
+    ],
   },
 };
 
@@ -203,6 +211,14 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-section', visualProps: ['variant']},
+    ],
+    cssProperties: [
+      {
+        name: '--xds-container-padding',
+        description:
+          "Controls Section container padding. Set in theme component overrides via `section: { base: { '--xds-container-padding': 'var(--spacing-3)' } }`. Cascades to all internal layout padding variables. Do not use `--layout-padding-*` vars directly.",
+        default: 'var(--spacing-4)',
+      },
     ],
   },
 };

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -100,6 +100,24 @@ export interface ThemingTarget {
 }
 
 /**
+ * Documents a public CSS custom property that themes can set on a component
+ * via component style overrides in `defineTheme`.
+ *
+ * @example
+ * ```
+ * {name: '--xds-container-padding', description: 'Controls container padding. Cascades to internal layout vars.', default: 'var(--spacing-4)'}
+ * ```
+ */
+export interface CSSPropertyDoc {
+  /** The CSS custom property name. Always starts with `--xds-`. */
+  name: string;
+  /** What this property controls, in 1-2 sentences. */
+  description: string;
+  /** Default value if not set by theme. e.g. `"var(--spacing-4)"` */
+  default?: string;
+}
+
+/**
  * Documents a CSS custom property exposed by a component for theming.
  * These vars are set on the component's root element and can be overridden
  * via `defineTheme` component overrides.
@@ -177,6 +195,10 @@ interface BaseDoc {
     targets: ThemingTarget[];
     /** CSS custom properties exposed for theming. */
     vars?: ComponentVar[];
+    /** Public CSS custom properties that themes can set on this component
+     *  via component overrides. Only document supported public properties —
+     *  internal variables must not be listed here. */
+    cssProperties?: CSSPropertyDoc[];
   };
   /** Accessibility notes — ARIA patterns, screen reader behavior.
    *  Each string is one self-contained, declarative note.


### PR DESCRIPTION
## Summary

Adds infrastructure for documenting component-specific CSS custom properties via `cssProperties` in doc files, and moves `--xds-container-padding` documentation from general theme docs into Card and Section component docs where it belongs.

## Changes

### `packages/core/src/docs-types.ts`
- New `CSSPropertyDoc` interface for documenting public CSS custom properties
- Added `cssProperties?: CSSPropertyDoc[]` to `BaseDoc.theming`

### `packages/cli/src/lib/component-format.mjs`
- `formatFull`: renders cssProperties as a markdown table in the Theming section
- `formatCompact`: adds a CSS Properties section with the same table
- `formatBrief`: adds a `CSS Props:` line summarizing custom properties

### `packages/core/src/Card/Card.doc.mjs`
- Added `cssProperties` with `--xds-container-padding` to theming (docs + docsZh)

### `packages/core/src/Section/Section.doc.mjs`
- Added `cssProperties` with `--xds-container-padding` to theming (docs + docsZh)

### Reverted
- `packages/cli/docs/theme.md` — removed container padding section (now in component docs)
- `packages/cli/docs/tokens.md` — removed component CSS properties section (now in component docs)
- `packages/core/src/theme/README.md` — removed component-level CSS properties table (now in component docs)

## Context

PR #847 introduced `--xds-container-padding` as the public API for theme padding overrides. The original PR #850 documented it in general theme docs, but component-specific tokens belong in component docs so they're discoverable via `npx xds component Card` etc.