### PR TITLE
fix(tokens): correct neutral gray token semantics across components

### DIFF
--- a/packages/cli/docs/tokens.md
+++ b/packages/cli/docs/tokens.md
@@ -37,14 +37,30 @@ Control heights for consistent sizing across buttons, inputs, and selectors.
 
 ### Semantic Colors
 
-| Token           | Usage                |
-| --------------- | -------------------- |
-| --color-accent  | Primary action color |
-| --color-surface | Background surface   |
-| --color-wash    | Secondary background |
-| --color-success | Success states       |
-| --color-error   | Error states         |
-| --color-warning | Warning states       |
+| Token           | Usage                                        |
+| --------------- | -------------------------------------------- |
+| --color-accent  | Primary action color                         |
+| --color-surface | Background surface                           |
+| --color-wash    | Page-level background (app shell, page body) |
+| --color-success | Success states                               |
+| --color-error   | Error states                                 |
+| --color-warning | Warning states                               |
+
+### Neutral Grays
+
+Three tokens for "gray" backgrounds. Choosing the right one depends on what the element _is_:
+
+| Token                 | Role                           | Use for                                                                                                                    |
+| --------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------- |
+| --color-secondary     | Neutral fill for elements      | Buttons (default), badges, tokens, kbd, avatar fallback, pagination dots, status dots, selected nav items, icon containers |
+| --color-muted         | Background for content areas   | Sections, code blocks, table zebra stripes, progress/slider tracks, disabled input fills, featured cards                   |
+| --color-overlay-hover | Translucent hover/active state | Hover on ghost buttons, list item highlights, menu item highlights, table row hover                                        |
+
+**Decision tree:**
+
+1. Is it a **hover/active/highlighted state**? → `--color-overlay-hover`
+2. Is it a **container with other content inside** (text, icons, controls)? → `--color-muted`
+3. Is it a **self-contained element sitting on a surface**? → `--color-secondary`
 
 ### Text Colors
 

--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/Avatar.stories.tsx (storybook stories)
  */
 
-
 import {useState, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
@@ -129,7 +128,7 @@ const styles = stylex.create({
     justifyContent: 'center',
     width: '100%',
     height: '100%',
-    backgroundColor: colorVars['--color-muted'],
+    backgroundColor: colorVars['--color-secondary'],
     color: colorVars['--color-text-secondary'],
     fontFamily: typographyVars['--font-body'],
     fontWeight: fontWeightVars['--font-weight-medium'],

--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -37,7 +37,7 @@ const styles = stylex.create({
     height: '20px',
     paddingInline: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-1'],
-    backgroundColor: colorVars['--color-wash'],
+    backgroundColor: colorVars['--color-secondary'],
     borderBottomWidth: '2px',
     borderBottomStyle: 'solid',
     borderBottomColor: colorVars['--color-border'],

--- a/packages/core/src/NavItem/navItemStyles.stylex.ts
+++ b/packages/core/src/NavItem/navItemStyles.stylex.ts
@@ -74,15 +74,15 @@ export const navItemStyles = stylex.create({
 
   /** Selected/active page indicator — deemphasized background, medium weight */
   selected: {
-    backgroundColor: colorVars['--color-muted'],
+    backgroundColor: colorVars['--color-secondary'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     ':hover': {
       '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-muted'],
+        backgroundColor: colorVars['--color-secondary'],
       },
     },
     ':active': {
-      backgroundColor: colorVars['--color-muted'],
+      backgroundColor: colorVars['--color-secondary'],
     },
   },
 

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -17,7 +17,6 @@
  *   label, data-testid, xstyle
  */
 
-
 import {useTransition} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -213,7 +212,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     padding: 0,
     borderRadius: '50%',
-    backgroundColor: colorVars['--color-muted'],
+    backgroundColor: colorVars['--color-secondary'],
     cursor: 'pointer',
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -59,7 +59,7 @@ const variantStyles = stylex.create({
     backgroundColor: 'transparent',
   },
   wash: {
-    backgroundColor: colorVars['--color-wash'],
+    backgroundColor: colorVars['--color-muted'],
   },
 });
 

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -78,7 +78,7 @@ const variants = stylex.create({
     backgroundColor: colorVars['--color-accent'],
   },
   neutral: {
-    backgroundColor: colorVars['--color-muted'],
+    backgroundColor: colorVars['--color-secondary'],
   },
 });
 

--- a/packages/core/src/Table/XDSTableRow.tsx
+++ b/packages/core/src/Table/XDSTableRow.tsx
@@ -11,7 +11,6 @@
  * - /packages/core/src/Table/index.ts
  */
 
-
 import {useContext, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
@@ -36,7 +35,7 @@ const stripedRowStyles = stylex.create({
   row: {
     backgroundColor: {
       default: null,
-      ':nth-child(even)': colorVars['--color-wash'],
+      ':nth-child(even)': colorVars['--color-muted'],
     },
   },
 });
@@ -59,7 +58,7 @@ const stripedHoverRowStyles = stylex.create({
   row: {
     backgroundColor: {
       default: null,
-      ':nth-child(even)': colorVars['--color-wash'],
+      ':nth-child(even)': colorVars['--color-muted'],
       ':hover': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },

--- a/packages/core/src/TopNav/XDSTopNavItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavItem.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/TopNav.stories.tsx
  */
 
-
 import {type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
@@ -73,11 +72,11 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     backgroundColor: {
-      default: colorVars['--color-muted'],
+      default: colorVars['--color-secondary'],
       ':hover': {
-        '@media (hover: hover)': colorVars['--color-muted'],
+        '@media (hover: hover)': colorVars['--color-secondary'],
       },
-      ':active': colorVars['--color-muted'],
+      ':active': colorVars['--color-secondary'],
     },
   },
   iconOnly: {

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
@@ -12,7 +12,6 @@
  * - /packages/core/src/TopNav/index.ts
  */
 
-
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -77,7 +76,7 @@ const styles = stylex.create({
     width: 40,
     height: 40,
     borderRadius: radiusVars['--radius-2'],
-    backgroundColor: colorVars['--color-muted'],
+    backgroundColor: colorVars['--color-secondary'],
     flexShrink: 0,
     color: colorVars['--color-icon-secondary'],
   },
@@ -112,7 +111,7 @@ const styles = stylex.create({
     width: 32,
     height: 32,
     borderRadius: radiusVars['--radius-2'],
-    backgroundColor: colorVars['--color-muted'],
+    backgroundColor: colorVars['--color-secondary'],
     flexShrink: 0,
     color: colorVars['--color-icon-secondary'],
     marginBlockStart: spacingVars['--spacing-0-5'],

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -140,7 +140,7 @@ const styles = stylex.create({
     width: 40,
     height: 40,
     borderRadius: radiusVars['--radius-2'],
-    backgroundColor: colorVars['--color-muted'],
+    backgroundColor: colorVars['--color-secondary'],
     flexShrink: 0,
   },
   menuItemContent: {

--- a/packages/lab/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/lab/src/CodeBlock/XDSCodeBlock.tsx
@@ -38,7 +38,7 @@ const styles = stylex.create({
     position: 'relative',
     margin: 0,
     borderRadius: radiusVars['--radius-2'],
-    backgroundColor: colorVars['--color-wash'],
+    backgroundColor: colorVars['--color-muted'],
     border: `1px solid ${colorVars['--color-border']}`,
     overflow: 'hidden',
   },

--- a/packages/lab/src/CodeEditor/XDSCodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/XDSCodeEditor.tsx
@@ -37,7 +37,7 @@ const styles = stylex.create({
     position: 'relative',
     display: 'flex',
     borderRadius: radiusVars['--radius-2'],
-    backgroundColor: colorVars['--color-wash'],
+    backgroundColor: colorVars['--color-muted'],
     border: `1px solid ${colorVars['--color-border']}`,
     overflow: 'hidden',
   },


### PR DESCRIPTION
## Summary

Establishes and enforces consistent rules for the three neutral gray tokens:

| Token | Role | Use for |
|-------|------|---------|
| `--color-secondary` | Neutral fill for self-contained elements | Buttons, badges, tokens, kbd, avatar, pagination dots, status dots, selected nav items, icon containers |
| `--color-muted` | Background for containers with content | Sections, code blocks, table zebra, progress/slider tracks, disabled fills, featured cards |
| `--color-overlay-hover` | Translucent hover/active feedback | Ghost button hover, list/menu highlights, table row hover |

**Decision tree:** (1) hover/active → overlay-hover, (2) container with content → muted, (3) self-contained element → secondary.

## Component Changes (12 files)

### wash → secondary (self-contained element, not a container)
- **Kbd** — keyboard shortcut badge sits on surfaces

### wash → muted (content container, not page-level)
- **Section** `wash` variant — content section with text/controls inside
- **CodeBlock** — code container
- **CodeEditor** — code container  
- **TableRow** zebra striping — row containing cells

### muted → secondary (self-contained element, not a container)
- **Avatar** fallback — icon/initials circle
- **Pagination** dot — small indicator dot
- **StatusDot** neutral — small status indicator
- **TopNavMegaMenuItem** icon circle — icon container in menu
- **TopNavMenu** icon circle — icon container in menu

### muted → secondary (resting selected state, not a hover overlay)
- **NavItem** selected — active page indicator fill
- **TopNavItem** selected — active nav item fill

### Kept as-is ✅
- All `--color-overlay-hover` usages (correct)
- ProgressBar track, Slider track/thumb, CheckboxInput/RadioList disabled (correct muted)
- TopNavMegaMenu featured cards (correct muted — content containers)
- AppShell wash variants (correct wash — page-level backgrounds)

## Documentation
- Updated `packages/cli/docs/tokens.md` with Neutral Grays section and decision tree
- Updated wiki: Theming Infrastructure + Night Watch Component Auditor with detection rules

## Test Results
All 1896 tests passing across 113 test files.

---
