### PR TITLE
fix(sandbox): add dual dev modes — source (hot reload) and watch (correct theming)

### DIFF
--- a/apps/sandbox/README.md
+++ b/apps/sandbox/README.md
@@ -51,14 +51,39 @@ export default function MyPage() {
 
 The page will appear in the sidebar and get its own URL in the PR deployment.
 
-## Local development
+## Development
+
+Three ways to run the sandbox locally, depending on what you're iterating on:
+
+### Quick start (build once, then dev)
 
 ```bash
-# From repo root
-yarn workspace @xds/sandbox dev
-# or
-cd apps/sandbox && yarn dev
+yarn dev:sandbox
 ```
+
+Builds `@xds/core` once, then starts the sandbox. Edits to `packages/core/src/` require a manual rebuild (`yarn build`). Good for working on sandbox pages themselves without touching core components.
+
+### Source mode (fast hot reload, no theming)
+
+```bash
+yarn dev:sandbox:source
+```
+
+Resolves `@xds/core` from TypeScript source directly via the `"source"` exports condition. Edits to component source hot-reload instantly (~200ms). **Theming and CSS layers don't work** in this mode because the CSS `@layer` wrapping only exists in the built dist output. Use for layout and behavior iteration only.
+
+### Watch mode (correct theming, near-hot-reload)
+
+Run in two terminals:
+
+```bash
+# Terminal 1: watch core for changes, rebuild dist incrementally
+yarn workspace @xds/core dev
+
+# Terminal 2: start sandbox (uses dist with correct CSS layers)
+yarn workspace @xds/sandbox dev
+```
+
+Best of both worlds — edits trigger incremental dist rebuilds via tsup (a few seconds), and CSS layer ordering is correct. Theming works properly.
 
 ## File manifest
 

--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -1,11 +1,28 @@
+/**
+ * @file next.config.mjs
+ * @description Next.js configuration for the XDS sandbox app.
+ *
+ * Supports two dev modes controlled by the XDS_SOURCE env var:
+ *
+ * - **Default** (XDS_SOURCE unset): Resolves @xds/core from dist/.
+ *   CSS layers and theming work correctly. Pair with `yarn workspace @xds/core dev`
+ *   in a second terminal for near-hot-reload via incremental dist rebuilds.
+ *
+ * - **Source mode** (XDS_SOURCE=1): Resolves @xds/core from TypeScript source.
+ *   Instant hot reload (~200ms), but CSS layer separation is lost — theming
+ *   won't work. Best for layout and behavior iteration.
+ */
+
+const useSource = process.env.XDS_SOURCE === '1';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
   trailingSlash: true,
   basePath: process.env.SANDBOX_BASE_PATH || '',
-  // Theme packages still need transpilation for defineTheme() calls.
-  // @xds/core uses pre-built dist — no transpilation needed.
   transpilePackages: [
+    // Only transpile @xds/core in source mode — in dist mode, it's pre-built.
+    ...(useSource ? ['@xds/core'] : []),
     '@xds/theme-default',
     '@xds/theme-neutral',
     '@xds/theme-brutalist',
@@ -16,6 +33,34 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  webpack: useSource
+    ? (config) => {
+        // Prefer "source" exports condition so @xds/core resolves to src/ TypeScript.
+        // This enables hot reload when editing packages/core/src/ files.
+        config.resolve.conditionNames = [
+          'source',
+          'import',
+          'require',
+          'default',
+        ];
+
+        // Remove packages/core from snapshot managedPaths so webpack
+        // doesn't treat it as an immutable dependency.
+        config.snapshot = {
+          ...config.snapshot,
+          managedPaths: [],
+        };
+
+        // Poll as fallback — FSEvents can miss changes through symlinks.
+        config.watchOptions = {
+          ...config.watchOptions,
+          poll: 1000,
+          followSymlinks: true,
+        };
+
+        return config;
+      }
+    : undefined,
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "version-packages": "changeset version",
     "verify-exports": "node scripts/verify-exports.mjs",
     "release": "yarn build && changeset publish",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "dev:sandbox": "yarn workspace @xds/core build && yarn workspace @xds/sandbox dev",
+    "dev:sandbox:source": "XDS_SOURCE=1 yarn workspace @xds/sandbox dev"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.11.1",


### PR DESCRIPTION
## Summary

Offer two sandbox dev modes so developers can choose the right trade-off between speed and correctness:

| Mode | Command | Hot reload | Theming/CSS layers | Best for |
|------|---------|-----------|-------------------|----------|
| **Quick start** | `yarn dev:sandbox` | ❌ manual rebuild | ✅ correct | Working on sandbox pages only |
| **Source** | `yarn dev:sandbox:source` | ✅ instant (~200ms) | ❌ broken | Layout & behavior iteration |
| **Watch** | Two terminals (see below) | ⚡ near-instant (few sec) | ✅ correct | Full development |

## The Problem

The original PR unconditionally applied source-resolution webpack config (`conditionNames: ["source", ...]`), which gives instant hot reload but breaks CSS layer separation. When webpack compiles `@xds/core` from TypeScript source, the `@layer xds.base { ... }` wrapping that exists in the built dist CSS is lost — so theming stops working.

## The Fix

Make source-resolution **opt-in** via `XDS_SOURCE=1` env var:

- **Default** (`XDS_SOURCE` unset): Resolves `@xds/core` from `dist/`. CSS layers and theming work correctly. No webpack customization applied.
- **Source mode** (`XDS_SOURCE=1`): Applies `conditionNames`, `managedPaths`, and `watchOptions` overrides for instant hot reload from TypeScript source.

### Changes

1. **`apps/sandbox/next.config.mjs`** — All source-resolution config gated on `process.env.XDS_SOURCE === "1"`. `@xds/core` is only added to `transpilePackages` in source mode.

2. **`package.json`** (root) — Two new scripts:
   - `dev:sandbox` — builds core once, then starts sandbox (standard workflow)
   - `dev:sandbox:source` — sets `XDS_SOURCE=1` and starts sandbox (fast hot reload, no theming)

3. **`apps/sandbox/README.md`** — Documents all three dev workflows with clear trade-offs.

### Watch mode (two terminals)

For the best development experience with correct theming:

```bash
# Terminal 1: incremental dist rebuilds via tsup
yarn workspace @xds/core dev

# Terminal 2: sandbox dev server
yarn workspace @xds/sandbox dev
```

This gives near-hot-reload speed (tsup rebuilds in a few seconds) with correct CSS layer ordering.

## Testing

- `yarn lint` — 0 errors (34 pre-existing warnings)
- `yarn test` — 1926/1926 tests pass (113 test files)
