### PR TITLE
chore: bump all packages to 0.0.7

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "XDS design system CLI \u2014 init, swizzle, theme, templates, and agent docs",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/core",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Core XDS components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "description": "Brutalist theme for XDS \u2014 zero radius, monospace, heavy borders",
   "license": "MIT",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-default",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": false,
   "description": "Default theme for XDS components (Heroicons)",
   "license": "MIT",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-neutral",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": false,
   "description": "Neutral theme for XDS components (Lucide icons)",
   "license": "MIT",


### PR DESCRIPTION
Version bump for v0.0.7 release. All packages already published to npm.

Packages published:
- @xds/core@0.0.7
- @xds/cli@0.0.7
- @xds/theme-default@0.0.7
- @xds/theme-neutral@0.0.7

(brutalist skipped — marked private)