### PR TITLE
fix(cli): detect package manager for agent docs command prefix

### DIFF
--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -10,6 +10,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {findCoreDir, CLI_ROOT} from '../utils/paths.mjs';
+import {getRunPrefix} from '../utils/package-manager.mjs';
 import {discoverComponents} from '../lib/component-discovery.mjs';
 
 const AGENTS_MD = 'AGENTS.md';
@@ -24,10 +25,11 @@ const XDS_MARKER_END = '<!-- XDS:END -->';
  * Format C (one-liner per command) chosen after testing three formats
  * against Claude Opus for AI agent usability (scored 5/5).
  */
-export function generateCompressedIndex(version, {coreDir, zh = false, lang} = {}) {
+export function generateCompressedIndex(version, {coreDir, zh = false, lang, runPrefix = 'npx'} = {}) {
+  const run = `${runPrefix} xds`;
   const lines = [XDS_MARKER_START];
 
-  lines.push(`XDS v${version}|Always run npx xds component <Name> before writing XDS component code.`);
+  lines.push(`XDS v${version}|Always run ${run} component <Name> before writing XDS component code.`);
 
   // Component count from live discovery
   let componentCount = '90+';
@@ -40,8 +42,8 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang} = {
     } catch {}
   }
 
-  lines.push(`npx xds component <Name>       props, usage, examples for any component`);
-  lines.push(`npx xds component --list       ${componentCount} components by category`);
+  lines.push(`${run} component <Name>       props, usage, examples for any component`);
+  lines.push(`${run} component --list       ${componentCount} components by category`);
 
   // Doc topics from live discovery
   const docsDir = path.join(CLI_ROOT, 'docs');
@@ -58,7 +60,7 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang} = {
         if (descMatch) desc = descMatch[1];
       } catch {}
 
-      lines.push(`npx xds docs ${topic.padEnd(20)} ${desc}`);
+      lines.push(`${run} docs ${topic.padEnd(20)} ${desc}`);
     }
   }
 
@@ -70,14 +72,14 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang} = {
       .map(e => e.name)
       .sort();
     if (templates.length > 0) {
-      lines.push(`npx xds template <name> [path]  scaffold page (${templates.join(', ')})`);
+      lines.push(`${run} template <name> [path]  scaffold page (${templates.join(', ')})`);
     }
   }
 
-  lines.push(`npx xds swizzle <Name>          eject component source (use --gap to report why)`);
-  lines.push(`npx xds upgrade --apply         run version migration codemods`);
+  lines.push(`${run} swizzle <Name>          eject component source (use --gap to report why)`);
+  lines.push(`${run} upgrade --apply         run version migration codemods`);
   lines.push(`--detail compact|brief          less output | --lang dense|zh  translation`);
-  lines.push(`RULE: after @xds/core bump, always run npx xds upgrade --apply`);
+  lines.push(`RULE: after @xds/core bump, always run ${run} upgrade --apply`);
   lines.push(`RULE: when swizzling, always use --gap to report missing capabilities`);
   lines.push(XDS_MARKER_END);
 
@@ -139,9 +141,10 @@ export function injectXdsBlock(filePath, compressedIndex, {createIfMissing = fal
  * Inject or update XDS section in AGENTS.md.
  * Always creates the file if it doesn't exist.
  */
-export function injectAgentsMd(targetDir, version, {zh = false, lang} = {}) {
+export function injectAgentsMd(targetDir, version, {zh = false, lang, runPrefix} = {}) {
   const agentsPath = path.join(targetDir, AGENTS_MD);
-  const compressedIndex = generateCompressedIndex(version, {coreDir: findCoreDir(targetDir)});
+  const prefix = runPrefix ?? getRunPrefix(targetDir);
+  const compressedIndex = generateCompressedIndex(version, {coreDir: findCoreDir(targetDir), runPrefix: prefix});
   injectXdsBlock(agentsPath, compressedIndex, {
     createIfMissing: true,
     header: `# AGENTS.md\n\nProject-specific guidance for AI coding agents.`,
@@ -154,9 +157,10 @@ export function injectAgentsMd(targetDir, version, {zh = false, lang} = {}) {
  *
  * @returns {boolean} Whether the file was written
  */
-export function injectClaudeMd(targetDir, version, {zh = false, lang} = {}) {
+export function injectClaudeMd(targetDir, version, {zh = false, lang, runPrefix} = {}) {
   const claudePath = path.join(targetDir, CLAUDE_MD);
-  const compressedIndex = generateCompressedIndex(version, {coreDir: findCoreDir(targetDir)});
+  const prefix = runPrefix ?? getRunPrefix(targetDir);
+  const compressedIndex = generateCompressedIndex(version, {coreDir: findCoreDir(targetDir), runPrefix: prefix});
   return injectXdsBlock(claudePath, compressedIndex);
 }
 
@@ -223,16 +227,17 @@ export function removeAgentDocs(targetDir) {
 export function installAgentDocs(targetDir, {zh = false, lang} = {}) {
   const coreDir = findCoreDir(targetDir);
   const version = getXdsVersion(coreDir);
+  const runPrefix = getRunPrefix(targetDir);
   const hasClaudeMd = fs.existsSync(path.join(targetDir, CLAUDE_MD));
   const hasAgentsMd = fs.existsSync(path.join(targetDir, AGENTS_MD));
 
   if (hasClaudeMd) {
-    injectClaudeMd(targetDir, version, {zh, lang});
+    injectClaudeMd(targetDir, version, {zh, lang, runPrefix});
     if (hasAgentsMd) {
-      injectAgentsMd(targetDir, version, {zh, lang});
+      injectAgentsMd(targetDir, version, {zh, lang, runPrefix});
     }
   } else {
-    injectAgentsMd(targetDir, version, {zh, lang});
+    injectAgentsMd(targetDir, version, {zh, lang, runPrefix});
   }
 }
 
@@ -255,6 +260,7 @@ export function registerAgentDocs(program) {
         return;
       }
 
+      const runPrefix = getRunPrefix(targetDir);
       console.log(`\n📚 Installing XDS agent docs (v${version})...\n`);
 
       const hasClaudeMd = fs.existsSync(path.join(targetDir, CLAUDE_MD));
@@ -262,35 +268,36 @@ export function registerAgentDocs(program) {
       const targets = [];
 
       if (hasClaudeMd) {
-        injectClaudeMd(targetDir, version, {zh, lang});
+        injectClaudeMd(targetDir, version, {zh, lang, runPrefix});
         console.log(`✓ Injected compressed index into ${CLAUDE_MD}`);
         targets.push(CLAUDE_MD);
         if (hasAgentsMd) {
-          injectAgentsMd(targetDir, version, {zh, lang});
+          injectAgentsMd(targetDir, version, {zh, lang, runPrefix});
           console.log(`✓ Injected compressed index into ${AGENTS_MD}`);
           targets.push(AGENTS_MD);
         }
       } else {
-        injectAgentsMd(targetDir, version, {zh, lang});
+        injectAgentsMd(targetDir, version, {zh, lang, runPrefix});
         console.log(`✓ Injected compressed index into ${AGENTS_MD}`);
         targets.push(AGENTS_MD);
       }
 
+      const run = `${runPrefix} xds`;
       console.log(`
 ✅ XDS agent docs installed!
 
 Your AI coding agent will now:
   • See the XDS component index in ${targets.join(' and ')}
-  • Run \`npx xds component <name>\` to read detailed docs
-  • Run \`npx xds docs principles\` for design principles
-  • Run \`npx xds docs tokens\` for design token reference
+  • Run \`${run} component <name>\` to read detailed docs
+  • Run \`${run} docs principles\` for design principles
+  • Run \`${run} docs tokens\` for design token reference
   • Follow XDS patterns and avoid anti-patterns
 
 To update:
-  npx xds agent-docs
+  ${run} agent-docs
 
 To remove:
-  npx xds agent-docs --remove
+  ${run} agent-docs --remove
 `);
     });
 }

--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -43,6 +43,20 @@ describe('generateCompressedIndex', () => {
     expect(result).toContain('npx xds upgrade --apply');
     expect(result).toContain('after @xds/core bump, always run npx xds upgrade --apply');
   });
+
+  it('uses custom runPrefix when provided', () => {
+    const result = generateCompressedIndex('1.0.0', {runPrefix: 'yarn'});
+    expect(result).toContain('yarn xds component <Name>');
+    expect(result).toContain('yarn xds upgrade --apply');
+    expect(result).toContain('after @xds/core bump, always run yarn xds upgrade --apply');
+    expect(result).not.toContain('npx xds');
+  });
+
+  it('uses pnpm exec prefix', () => {
+    const result = generateCompressedIndex('1.0.0', {runPrefix: 'pnpm exec'});
+    expect(result).toContain('pnpm exec xds component <Name>');
+    expect(result).not.toContain('npx xds');
+  });
 });
 
 describe('getXdsVersion', () => {

--- a/packages/cli/src/utils/package-manager.mjs
+++ b/packages/cli/src/utils/package-manager.mjs
@@ -1,0 +1,48 @@
+/**
+ * @file Detect the project's package manager from lockfiles.
+ *
+ * Returns the correct command prefix for running package binaries
+ * (e.g. 'npx xds', 'yarn xds', 'pnpm exec xds').
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Detect the package manager used in a project directory.
+ * Walks up from targetDir looking for lockfiles.
+ *
+ * @param {string} [targetDir=process.cwd()]
+ * @returns {'yarn'|'pnpm'|'bun'|'npm'}
+ */
+export function detectPackageManager(targetDir = process.cwd()) {
+  let dir = path.resolve(targetDir);
+  const root = path.parse(dir).root;
+
+  while (dir !== root) {
+    if (fs.existsSync(path.join(dir, 'yarn.lock'))) return 'yarn';
+    if (fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))) return 'pnpm';
+    if (fs.existsSync(path.join(dir, 'bun.lockb')) || fs.existsSync(path.join(dir, 'bun.lock'))) return 'bun';
+    if (fs.existsSync(path.join(dir, 'package-lock.json'))) return 'npm';
+    dir = path.dirname(dir);
+  }
+
+  return 'npx';
+}
+
+/**
+ * Get the command prefix for running a package binary.
+ *
+ * @param {string} [targetDir]
+ * @returns {string} e.g. 'npx', 'yarn', 'pnpm exec', 'bunx'
+ */
+export function getRunPrefix(targetDir) {
+  const pm = detectPackageManager(targetDir);
+  switch (pm) {
+    case 'yarn': return 'yarn';
+    case 'pnpm': return 'pnpm exec';
+    case 'bun': return 'bunx';
+    case 'npm':
+    default: return 'npx';
+  }
+}


### PR DESCRIPTION
## Problem

Agent docs (AGENTS.md / CLAUDE.md) hardcode `npx xds ...` as the command prefix. When packages are on an internal registry, `npx` tries the public registry and fails. This breaks the primary agent workflow where AI tools read these docs and run the suggested commands.

## Fix

Detect the project's package manager from lockfiles and use the correct command prefix:

| Lockfile | Prefix |
|----------|--------|
| `yarn.lock` | `yarn xds ...` |
| `pnpm-lock.yaml` | `pnpm exec xds ...` |
| `bun.lockb` / `bun.lock` | `bunx xds ...` |
| `package-lock.json` / default | `npx xds ...` |

Since `@xds/cli` is already a project dependency, `yarn xds` resolves from `node_modules/.bin` without hitting any registry.

## Changes

| File | What |
|------|------|
| `packages/cli/src/utils/package-manager.mjs` | New utility — `detectPackageManager()` walks up from target dir looking for lockfiles, `getRunPrefix()` maps to command prefix |
| `packages/cli/src/commands/agent-docs.mjs` | `generateCompressedIndex()` accepts `runPrefix` option; all callers detect and pass it through; success message also uses detected prefix |
| `packages/cli/src/commands/agent-docs.test.mjs` | Tests for custom `runPrefix` in generated output |

## Example

A Yarn project's AGENTS.md now contains:
```
yarn xds component <Name>       props, usage, examples for any component
yarn xds upgrade --apply         run version migration codemods
RULE: after @xds/core bump, always run yarn xds upgrade --apply
```

---