### PR TITLE
feat(cli): configurable agent docs with tool presets and lockfile-based command prefix

### DIFF
--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -1,10 +1,18 @@
 /**
- * @file agent-docs — Install/update AGENTS.md and CLAUDE.md
+ * @file agent-docs — Install/update agent docs for AI coding tools
  *
  * Generates a CLI cheat sheet from actual command metadata and injects
- * it into AGENTS.md and/or CLAUDE.md. Format optimized for AI coding
- * agents (Claude, Copilot, Cursor): one line per command, copy-pasteable,
- * minimal tokens.
+ * it into agent doc files. Supports multiple tools with auto-detection:
+ *
+ * - Claude Code: CLAUDE.md (root) or .claude/CLAUDE.md
+ * - Cursor: .cursorrules
+ * - Codex/generic: AGENTS.md
+ *
+ * Auto-detect: discovers existing files and updates them in place.
+ * Default (no existing files): creates .claude/CLAUDE.md.
+ *
+ * --agent <tool>: target a specific tool preset (claude, cursor, codex, all)
+ * --agent-docs-path <path>: explicit file path(s)
  */
 
 import * as fs from 'node:fs';
@@ -14,9 +22,66 @@ import {discoverComponents} from '../lib/component-discovery.mjs';
 
 const AGENTS_MD = 'AGENTS.md';
 const CLAUDE_MD = 'CLAUDE.md';
+const CLAUDE_DIR_MD = path.join('.claude', 'CLAUDE.md');
 
 const XDS_MARKER_START = '<!-- XDS:START -->';
 const XDS_MARKER_END = '<!-- XDS:END -->';
+
+/**
+ * Agent tool presets — maps tool names to their file search paths.
+ * Order matters: first existing file wins, last entry is the default (created if none exist).
+ */
+const AGENT_PRESETS = {
+  claude: [CLAUDE_MD, CLAUDE_DIR_MD],
+  cursor: ['.cursorrules', AGENTS_MD],
+  codex: [AGENTS_MD],
+};
+
+/**
+ * Find all existing agent doc files in a directory.
+ * Searches all known locations (AGENTS.md, CLAUDE.md, .claude/CLAUDE.md, .cursorrules).
+ * @param {string} targetDir
+ * @returns {string[]} Relative paths of existing agent doc files
+ */
+export function discoverAgentDocs(targetDir) {
+  const allPaths = [AGENTS_MD, CLAUDE_MD, CLAUDE_DIR_MD, '.cursorrules'];
+  return allPaths.filter(p => fs.existsSync(path.join(targetDir, p)));
+}
+
+/**
+ * Resolve which file(s) to write for a given agent tool preset.
+ * Searches for existing files first, falls back to default creation path.
+ *
+ * @param {string} targetDir
+ * @param {string} agent - Preset name: 'claude', 'cursor', 'codex', 'all'
+ * @returns {{inject: string[], create: string[]}} Files to inject into vs create fresh
+ */
+export function resolveAgentPaths(targetDir, agent) {
+  if (agent === 'all') {
+    // Inject into all existing files, create defaults for each tool
+    const existing = discoverAgentDocs(targetDir);
+    if (existing.length > 0) {
+      return {inject: existing, create: []};
+    }
+    // Nothing exists — create default for each tool
+    return {inject: [], create: [AGENTS_MD, CLAUDE_DIR_MD]};
+  }
+
+  const searchPaths = AGENT_PRESETS[agent];
+  if (!searchPaths) {
+    return {inject: [], create: [AGENTS_MD]};
+  }
+
+  // Find first existing file from search order
+  for (const p of searchPaths) {
+    if (fs.existsSync(path.join(targetDir, p))) {
+      return {inject: [p], create: []};
+    }
+  }
+
+  // None found — create the last entry (default location)
+  return {inject: [], create: [searchPaths[searchPaths.length - 1]]};
+}
 
 /**
  * Generate the agent cheat sheet from live CLI metadata.
@@ -192,55 +257,117 @@ export function removeXdsBlock(filePath, {deleteIfEmpty = false} = {}) {
 }
 
 /**
- * Remove XDS section from AGENTS.md and CLAUDE.md.
+ * Remove XDS section from all known agent doc files.
  */
 export function removeAgentDocs(targetDir) {
-  const agentsPath = path.join(targetDir, AGENTS_MD);
-  const claudePath = path.join(targetDir, CLAUDE_MD);
+  const allPaths = discoverAgentDocs(targetDir);
 
-  if (removeXdsBlock(agentsPath, {deleteIfEmpty: true})) {
-    if (!fs.existsSync(agentsPath)) {
-      console.log(`✓ Removed empty ${AGENTS_MD}`);
-    } else {
-      console.log(`✓ Removed XDS section from ${AGENTS_MD}`);
+  for (const p of allPaths) {
+    const filePath = path.join(targetDir, p);
+    // Delete if empty for files we created (AGENTS.md, .claude/CLAUDE.md)
+    const deleteIfEmpty = p === AGENTS_MD || p === CLAUDE_DIR_MD;
+    if (removeXdsBlock(filePath, {deleteIfEmpty})) {
+      if (!fs.existsSync(filePath)) {
+        console.log(`✓ Removed empty ${p}`);
+      } else {
+        console.log(`✓ Removed XDS section from ${p}`);
+      }
     }
-  }
-
-  if (removeXdsBlock(claudePath)) {
-    console.log(`✓ Removed XDS section from ${CLAUDE_MD}`);
   }
 }
 
 /**
  * Programmatic entry point for installing agent docs.
- * Used by the init wizard.
+ * Used by the init wizard, upgrade command, and agent-docs command.
  *
- * Strategy:
- * - If CLAUDE.md exists, inject there (don't create AGENTS.md)
- * - If only AGENTS.md exists (or neither), inject into AGENTS.md
- * - If both exist, inject into both
+ * Strategy (when no agent/paths specified):
+ * - Discover all existing agent doc files and update them
+ * - If nothing found, create .claude/CLAUDE.md as default
+ *
+ * @param {string} targetDir
+ * @param {object} [options]
+ * @param {boolean} [options.zh]
+ * @param {string} [options.lang]
+ * @param {string} [options.agent] - Tool preset: 'claude', 'cursor', 'codex', 'all'
+ * @param {string[]} [options.paths] - Explicit paths (overrides agent/auto-detect)
+ * @returns {string[]} List of files written
  */
-export function installAgentDocs(targetDir, {zh = false, lang} = {}) {
+export function installAgentDocs(targetDir, {zh = false, lang, agent, paths} = {}) {
   const coreDir = findCoreDir(targetDir);
   const version = getXdsVersion(coreDir);
-  const hasClaudeMd = fs.existsSync(path.join(targetDir, CLAUDE_MD));
-  const hasAgentsMd = fs.existsSync(path.join(targetDir, AGENTS_MD));
+  const compressedIndex = generateCompressedIndex(version, {coreDir, zh, lang});
+  const written = [];
 
-  if (hasClaudeMd) {
-    injectClaudeMd(targetDir, version, {zh, lang});
-    if (hasAgentsMd) {
-      injectAgentsMd(targetDir, version, {zh, lang});
+  // Explicit paths override everything
+  if (paths && paths.length > 0) {
+    for (const p of paths) {
+      const filePath = path.join(targetDir, p);
+      const dir = path.dirname(filePath);
+      if (dir !== targetDir) {
+        fs.mkdirSync(dir, {recursive: true});
+      }
+      injectXdsBlock(filePath, compressedIndex, {
+        createIfMissing: true,
+        header: `# ${path.basename(p, path.extname(p))}\n\nProject-specific guidance for AI coding agents.`,
+      });
+      written.push(p);
     }
-  } else {
-    injectAgentsMd(targetDir, version, {zh, lang});
+    return written;
   }
+
+  // Agent preset
+  if (agent) {
+    const {inject, create} = resolveAgentPaths(targetDir, agent);
+    for (const p of inject) {
+      injectXdsBlock(path.join(targetDir, p), compressedIndex);
+      written.push(p);
+    }
+    for (const p of create) {
+      const filePath = path.join(targetDir, p);
+      const dir = path.dirname(filePath);
+      if (dir !== targetDir) {
+        fs.mkdirSync(dir, {recursive: true});
+      }
+      injectXdsBlock(filePath, compressedIndex, {
+        createIfMissing: true,
+        header: `# ${path.basename(p, path.extname(p))}\n\nProject-specific guidance for AI coding agents.`,
+      });
+      written.push(p);
+    }
+    return written;
+  }
+
+  // Auto-detect: update all existing agent doc files
+  const existing = discoverAgentDocs(targetDir);
+
+  if (existing.length > 0) {
+    for (const p of existing) {
+      injectXdsBlock(path.join(targetDir, p), compressedIndex);
+      written.push(p);
+    }
+    return written;
+  }
+
+  // Nothing exists — create .claude/CLAUDE.md as default
+  const defaultPath = CLAUDE_DIR_MD;
+  fs.mkdirSync(path.join(targetDir, '.claude'), {recursive: true});
+  injectXdsBlock(path.join(targetDir, defaultPath), compressedIndex, {
+    createIfMissing: true,
+    header: `# CLAUDE.md\n\nProject-specific guidance for AI coding agents.`,
+  });
+  written.push(defaultPath);
+  return written;
 }
+
+const VALID_AGENTS = ['claude', 'cursor', 'codex', 'all'];
 
 export function registerAgentDocs(program) {
   program
     .command('agent-docs')
-    .description('Install/update XDS component index in AGENTS.md (and CLAUDE.md if present)')
-    .option('--remove', 'Remove XDS section from AGENTS.md and CLAUDE.md')
+    .description('Install/update XDS component index for AI coding agents')
+    .option('--remove', 'Remove XDS section from all agent doc files')
+    .option('--agent <tool>', 'Target tool: claude, cursor, codex, all')
+    .option('--agent-docs-path <path...>', 'Explicit file path(s) to write to')
     .action(options => {
       const targetDir = process.cwd();
       const coreDir = findCoreDir(targetDir);
@@ -255,25 +382,31 @@ export function registerAgentDocs(program) {
         return;
       }
 
+      // Validate --agent
+      if (options.agent && !VALID_AGENTS.includes(options.agent)) {
+        console.error(`Error: Unknown agent "${options.agent}". Valid: ${VALID_AGENTS.join(', ')}`);
+        process.exitCode = 1;
+        return;
+      }
+
       console.log(`\n📚 Installing XDS agent docs (v${version})...\n`);
 
-      const hasClaudeMd = fs.existsSync(path.join(targetDir, CLAUDE_MD));
-      const hasAgentsMd = fs.existsSync(path.join(targetDir, AGENTS_MD));
-      const targets = [];
+      // Collect explicit paths from --agent-docs-path (commander parses variadic as array or single)
+      const explicitPaths = options.agentDocsPath
+        ? Array.isArray(options.agentDocsPath)
+          ? options.agentDocsPath
+          : [options.agentDocsPath]
+        : undefined;
 
-      if (hasClaudeMd) {
-        injectClaudeMd(targetDir, version, {zh, lang});
-        console.log(`✓ Injected compressed index into ${CLAUDE_MD}`);
-        targets.push(CLAUDE_MD);
-        if (hasAgentsMd) {
-          injectAgentsMd(targetDir, version, {zh, lang});
-          console.log(`✓ Injected compressed index into ${AGENTS_MD}`);
-          targets.push(AGENTS_MD);
-        }
-      } else {
-        injectAgentsMd(targetDir, version, {zh, lang});
-        console.log(`✓ Injected compressed index into ${AGENTS_MD}`);
-        targets.push(AGENTS_MD);
+      const targets = installAgentDocs(targetDir, {
+        zh,
+        lang,
+        agent: options.agent,
+        paths: explicitPaths,
+      });
+
+      for (const t of targets) {
+        console.log(`✓ ${t}`);
       }
 
       console.log(`

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -18,6 +18,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {findCoreDir, CLI_ROOT} from '../utils/paths.mjs';
+import {getRunPrefix} from '../utils/package-manager.mjs';
 import {discoverComponents} from '../lib/component-discovery.mjs';
 
 const AGENTS_MD = 'AGENTS.md';
@@ -89,10 +90,11 @@ export function resolveAgentPaths(targetDir, agent) {
  * Format C (one-liner per command) chosen after testing three formats
  * against Claude Opus for AI agent usability (scored 5/5).
  */
-export function generateCompressedIndex(version, {coreDir, zh = false, lang} = {}) {
+export function generateCompressedIndex(version, {coreDir, zh = false, lang, runPrefix = 'npx'} = {}) {
+  const run = `${runPrefix} xds`;
   const lines = [XDS_MARKER_START];
 
-  lines.push(`XDS v${version}|Always run npx xds component <Name> before writing XDS component code.`);
+  lines.push(`XDS v${version}|Always run ${run} component <Name> before writing XDS component code.`);
 
   // Component count from live discovery
   let componentCount = '90+';
@@ -105,8 +107,8 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang} = {
     } catch {}
   }
 
-  lines.push(`npx xds component <Name>       props, usage, examples for any component`);
-  lines.push(`npx xds component --list       ${componentCount} components by category`);
+  lines.push(`${run} component <Name>       props, usage, examples for any component`);
+  lines.push(`${run} component --list       ${componentCount} components by category`);
 
   // Doc topics from live discovery
   const docsDir = path.join(CLI_ROOT, 'docs');
@@ -123,7 +125,7 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang} = {
         if (descMatch) desc = descMatch[1];
       } catch {}
 
-      lines.push(`npx xds docs ${topic.padEnd(20)} ${desc}`);
+      lines.push(`${run} docs ${topic.padEnd(20)} ${desc}`);
     }
   }
 
@@ -135,14 +137,14 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang} = {
       .map(e => e.name)
       .sort();
     if (templates.length > 0) {
-      lines.push(`npx xds template <name> [path]  scaffold page (${templates.join(', ')})`);
+      lines.push(`${run} template <name> [path]  scaffold page (${templates.join(', ')})`);
     }
   }
 
-  lines.push(`npx xds swizzle <Name>          eject component source (use --gap to report why)`);
-  lines.push(`npx xds upgrade --apply         run version migration codemods`);
+  lines.push(`${run} swizzle <Name>          eject component source (use --gap to report why)`);
+  lines.push(`${run} upgrade --apply         run version migration codemods`);
   lines.push(`--detail compact|brief          less output | --lang dense|zh  translation`);
-  lines.push(`RULE: after @xds/core bump, always run npx xds upgrade --apply`);
+  lines.push(`RULE: after @xds/core bump, always run ${run} upgrade --apply`);
   lines.push(`RULE: when swizzling, always use --gap to report missing capabilities`);
   lines.push(XDS_MARKER_END);
 
@@ -295,7 +297,8 @@ export function removeAgentDocs(targetDir) {
 export function installAgentDocs(targetDir, {zh = false, lang, agent, paths} = {}) {
   const coreDir = findCoreDir(targetDir);
   const version = getXdsVersion(coreDir);
-  const compressedIndex = generateCompressedIndex(version, {coreDir, zh, lang});
+  const runPrefix = getRunPrefix(targetDir);
+  const compressedIndex = generateCompressedIndex(version, {coreDir, zh, lang, runPrefix});
   const written = [];
 
   // Explicit paths override everything
@@ -405,6 +408,9 @@ export function registerAgentDocs(program) {
         paths: explicitPaths,
       });
 
+      const runPrefix = getRunPrefix(targetDir);
+      const run = `${runPrefix} xds`;
+
       for (const t of targets) {
         console.log(`✓ ${t}`);
       }
@@ -414,16 +420,16 @@ export function registerAgentDocs(program) {
 
 Your AI coding agent will now:
   • See the XDS component index in ${targets.join(' and ')}
-  • Run \`npx xds component <name>\` to read detailed docs
-  • Run \`npx xds docs principles\` for design principles
-  • Run \`npx xds docs tokens\` for design token reference
+  • Run \`${run} component <name>\` to read detailed docs
+  • Run \`${run} docs principles\` for design principles
+  • Run \`${run} docs tokens\` for design token reference
   • Follow XDS patterns and avoid anti-patterns
 
 To update:
-  npx xds agent-docs
+  ${run} agent-docs
 
 To remove:
-  npx xds agent-docs --remove
+  ${run} agent-docs --remove
 `);
     });
 }

--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -11,6 +11,8 @@ import {
   injectXdsBlock,
   removeAgentDocs,
   removeXdsBlock,
+  discoverAgentDocs,
+  resolveAgentPaths,
 } from './agent-docs.mjs';
 
 let tmpDir;
@@ -270,37 +272,146 @@ describe('installAgentDocs', () => {
     );
   }
 
-  it('creates AGENTS.md when neither file exists', () => {
+  it('creates .claude/CLAUDE.md when no agent docs exist', () => {
     setupCorePackage(tmpDir);
 
-    installAgentDocs(tmpDir);
+    const written = installAgentDocs(tmpDir);
 
-    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
-    expect(fs.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(false);
+    expect(written).toEqual(['.claude/CLAUDE.md']);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
+    const content = fs.readFileSync(path.join(tmpDir, '.claude', 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain('<!-- XDS:START -->');
   });
 
-  it('injects into CLAUDE.md and skips creating AGENTS.md when only CLAUDE.md exists', () => {
+  it('injects into CLAUDE.md at root when it exists', () => {
     setupCorePackage(tmpDir);
     fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Claude\n\nProject rules.\n');
 
-    installAgentDocs(tmpDir);
+    const written = installAgentDocs(tmpDir);
 
+    expect(written).toEqual(['CLAUDE.md']);
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
     const claudeContent = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
     expect(claudeContent).toContain('<!-- XDS:START -->');
     expect(claudeContent).toContain('Project rules.');
   });
 
-  it('injects into both when both files exist', () => {
+  it('injects into all existing agent doc files', () => {
     setupCorePackage(tmpDir);
     fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), '# Agents\n\nAgent rules.\n');
     fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Claude\n\nClaude rules.\n');
 
-    installAgentDocs(tmpDir);
+    const written = installAgentDocs(tmpDir);
 
+    expect(written).toContain('AGENTS.md');
+    expect(written).toContain('CLAUDE.md');
     const agentsContent = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
     const claudeContent = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8');
     expect(agentsContent).toContain('<!-- XDS:START -->');
     expect(claudeContent).toContain('<!-- XDS:START -->');
+  });
+
+  it('updates existing .claude/CLAUDE.md', () => {
+    setupCorePackage(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, '.claude'), {recursive: true});
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'CLAUDE.md'), '# Project\n\nExisting content.\n');
+
+    const written = installAgentDocs(tmpDir);
+
+    expect(written).toEqual(['.claude/CLAUDE.md']);
+    const content = fs.readFileSync(path.join(tmpDir, '.claude', 'CLAUDE.md'), 'utf-8');
+    expect(content).toContain('Existing content.');
+    expect(content).toContain('<!-- XDS:START -->');
+  });
+
+  it('respects --agent claude preset: finds existing CLAUDE.md', () => {
+    setupCorePackage(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Claude\n\nRules.\n');
+
+    const written = installAgentDocs(tmpDir, {agent: 'claude'});
+
+    expect(written).toEqual(['CLAUDE.md']);
+  });
+
+  it('respects --agent claude preset: creates .claude/CLAUDE.md when nothing exists', () => {
+    setupCorePackage(tmpDir);
+
+    const written = installAgentDocs(tmpDir, {agent: 'claude'});
+
+    expect(written).toEqual(['.claude/CLAUDE.md']);
+    expect(fs.existsSync(path.join(tmpDir, '.claude', 'CLAUDE.md'))).toBe(true);
+  });
+
+  it('respects --agent codex preset: creates AGENTS.md', () => {
+    setupCorePackage(tmpDir);
+
+    const written = installAgentDocs(tmpDir, {agent: 'codex'});
+
+    expect(written).toEqual(['AGENTS.md']);
+    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
+  });
+
+  it('respects explicit --paths', () => {
+    setupCorePackage(tmpDir);
+
+    const written = installAgentDocs(tmpDir, {paths: ['custom/AGENT.md']});
+
+    expect(written).toEqual(['custom/AGENT.md']);
+    expect(fs.existsSync(path.join(tmpDir, 'custom', 'AGENT.md'))).toBe(true);
+  });
+});
+
+describe('discoverAgentDocs', () => {
+  it('finds AGENTS.md and CLAUDE.md at root', () => {
+    fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), '');
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '');
+
+    const found = discoverAgentDocs(tmpDir);
+
+    expect(found).toContain('AGENTS.md');
+    expect(found).toContain('CLAUDE.md');
+  });
+
+  it('finds .claude/CLAUDE.md', () => {
+    fs.mkdirSync(path.join(tmpDir, '.claude'), {recursive: true});
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'CLAUDE.md'), '');
+
+    const found = discoverAgentDocs(tmpDir);
+
+    expect(found).toContain('.claude/CLAUDE.md');
+  });
+
+  it('returns empty when nothing exists', () => {
+    expect(discoverAgentDocs(tmpDir)).toEqual([]);
+  });
+});
+
+describe('resolveAgentPaths', () => {
+  it('claude preset finds existing CLAUDE.md at root', () => {
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '');
+    const result = resolveAgentPaths(tmpDir, 'claude');
+    expect(result).toEqual({inject: ['CLAUDE.md'], create: []});
+  });
+
+  it('claude preset falls back to .claude/CLAUDE.md', () => {
+    const result = resolveAgentPaths(tmpDir, 'claude');
+    expect(result).toEqual({inject: [], create: ['.claude/CLAUDE.md']});
+  });
+
+  it('all preset discovers existing files', () => {
+    fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), '');
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '');
+    const result = resolveAgentPaths(tmpDir, 'all');
+    expect(result.inject).toContain('AGENTS.md');
+    expect(result.inject).toContain('CLAUDE.md');
+    expect(result.create).toEqual([]);
+  });
+
+  it('all preset creates defaults when nothing exists', () => {
+    const result = resolveAgentPaths(tmpDir, 'all');
+    expect(result.inject).toEqual([]);
+    expect(result.create).toContain('AGENTS.md');
+    expect(result.create).toContain('.claude/CLAUDE.md');
   });
 });

--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -45,6 +45,20 @@ describe('generateCompressedIndex', () => {
     expect(result).toContain('npx xds upgrade --apply');
     expect(result).toContain('after @xds/core bump, always run npx xds upgrade --apply');
   });
+
+  it('uses custom runPrefix when provided', () => {
+    const result = generateCompressedIndex('1.0.0', {runPrefix: 'yarn'});
+    expect(result).toContain('yarn xds component <Name>');
+    expect(result).toContain('yarn xds upgrade --apply');
+    expect(result).toContain('after @xds/core bump, always run yarn xds upgrade --apply');
+    expect(result).not.toContain('npx xds');
+  });
+
+  it('uses pnpm exec prefix', () => {
+    const result = generateCompressedIndex('1.0.0', {runPrefix: 'pnpm exec'});
+    expect(result).toContain('pnpm exec xds component <Name>');
+    expect(result).not.toContain('npx xds');
+  });
 });
 
 describe('getXdsVersion', () => {

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -30,13 +30,19 @@ function isCancel(value) {
 
 // ─── Feature: agents ─────────────────────────────────────────────────────────
 
-function runAgents(targetDir, {interactive = true} = {}) {
+function runAgents(targetDir, {interactive = true, agent, agentDocsPath} = {}) {
   try {
-    installAgentDocs(targetDir);
+    const paths = agentDocsPath
+      ? Array.isArray(agentDocsPath)
+        ? agentDocsPath
+        : [agentDocsPath]
+      : undefined;
+    const written = installAgentDocs(targetDir, {agent, paths});
+    const summary = written.join(', ');
     if (interactive) {
-      p.log.success('AI agent docs installed');
+      p.log.success(`AI agent docs installed → ${summary}`);
     } else {
-      console.log('✓ AI agent docs installed');
+      console.log(`✓ AI agent docs installed → ${summary}`);
     }
   } catch {
     const msg = 'Could not install agent docs. Try again with `npx xds init --features agents`.';
@@ -144,7 +150,9 @@ export function registerInit(program) {
     .description('Initialize XDS in your project')
     .option('--features <list>', 'Comma-separated features to install (agents, theme, template)')
     .option('--all', 'Install all features, no prompts')
-    .option('--remove-agents', 'Remove AI agent docs from AGENTS.md/CLAUDE.md')
+    .option('--remove-agents', 'Remove AI agent docs from all agent doc files')
+    .option('--agent <tool>', 'Target AI tool for agent docs: claude, cursor, codex, all')
+    .option('--agent-docs-path <path...>', 'Explicit file path(s) for agent docs')
     .action(async (options) => {
       const targetDir = process.cwd();
 
@@ -169,7 +177,11 @@ export function registerInit(program) {
         }
 
         for (const feature of features) {
-          if (feature === 'agents') runAgents(targetDir, {interactive: false});
+          if (feature === 'agents') runAgents(targetDir, {
+            interactive: false,
+            agent: options.agent,
+            agentDocsPath: options.agentDocsPath,
+          });
           if (feature === 'theme') await runTheme({interactive: false});
           if (feature === 'template') await runTemplate(targetDir, {interactive: false});
         }

--- a/packages/cli/src/utils/package-manager.mjs
+++ b/packages/cli/src/utils/package-manager.mjs
@@ -1,0 +1,48 @@
+/**
+ * @file Detect the project's package manager from lockfiles.
+ *
+ * Returns the correct command prefix for running package binaries
+ * (e.g. 'npx xds', 'yarn xds', 'pnpm exec xds').
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Detect the package manager used in a project directory.
+ * Walks up from targetDir looking for lockfiles.
+ *
+ * @param {string} [targetDir=process.cwd()]
+ * @returns {'yarn'|'pnpm'|'bun'|'npm'}
+ */
+export function detectPackageManager(targetDir = process.cwd()) {
+  let dir = path.resolve(targetDir);
+  const root = path.parse(dir).root;
+
+  while (dir !== root) {
+    if (fs.existsSync(path.join(dir, 'yarn.lock'))) return 'yarn';
+    if (fs.existsSync(path.join(dir, 'pnpm-lock.yaml'))) return 'pnpm';
+    if (fs.existsSync(path.join(dir, 'bun.lockb')) || fs.existsSync(path.join(dir, 'bun.lock'))) return 'bun';
+    if (fs.existsSync(path.join(dir, 'package-lock.json'))) return 'npm';
+    dir = path.dirname(dir);
+  }
+
+  return 'npx';
+}
+
+/**
+ * Get the command prefix for running a package binary.
+ *
+ * @param {string} [targetDir]
+ * @returns {string} e.g. 'npx', 'yarn', 'pnpm exec', 'bunx'
+ */
+export function getRunPrefix(targetDir) {
+  const pm = detectPackageManager(targetDir);
+  switch (pm) {
+    case 'yarn': return 'yarn';
+    case 'pnpm': return 'pnpm exec';
+    case 'bun': return 'bunx';
+    case 'npm':
+    default: return 'npx';
+  }
+}


### PR DESCRIPTION
## Summary

Two features for the agent docs system:

1. **Configurable output paths** with tool presets and auto-detection
2. **Lockfile-based command prefix** — `yarn xds` instead of `npx xds` when appropriate

## Commit 1: Configurable agent docs output

- **`--agent <tool>`** preset flag: `claude`, `cursor`, `codex`, `all`
  - `claude`: searches `CLAUDE.md` → `.claude/CLAUDE.md`, creates `.claude/CLAUDE.md` if none found
  - `cursor`: searches `.cursorrules` → `AGENTS.md`
  - `codex`: writes `AGENTS.md`
  - `all`: discovers + updates all existing, or creates defaults for each tool
- **`--agent-docs-path <path>`** for explicit file targets
- **Auto-detect**: `discoverAgentDocs()` finds all existing agent doc files and updates them in place
- **New default**: creates `.claude/CLAUDE.md` instead of `AGENTS.md` when nothing exists
- `xds upgrade --apply` now updates all discovered agent doc locations
- `xds init --features agents --agent claude` works end-to-end

## Commit 2: Lockfile-based command prefix

Agent docs hardcoded `npx xds ...` which can fail when packages are on an internal registry. `npx` tries to fetch from the public registry.

Now detects the package manager from lockfiles:

| Lockfile | Command prefix |
|----------|---------------|
| `yarn.lock` | `yarn xds ...` |
| `pnpm-lock.yaml` | `pnpm exec xds ...` |
| `bun.lockb` / `bun.lock` | `bunx xds ...` |
| `package-lock.json` / default | `npx xds ...` |

Since `@xds/cli` is already a project dependency, `yarn xds` resolves from `node_modules/.bin` without hitting any registry.

## Files Changed

| File | What |
|------|------|
| `packages/cli/src/commands/agent-docs.mjs` | Tool presets, auto-detect, configurable paths, runPrefix |
| `packages/cli/src/commands/agent-docs.test.mjs` | Tests for new behavior (34 tests) |
| `packages/cli/src/commands/init.mjs` | Pass `--agent` and `--agent-docs-path` through |
| `packages/cli/src/utils/package-manager.mjs` | New — `detectPackageManager()` + `getRunPrefix()` |

## Usage

```bash
# Auto-detect (updates existing files, or creates .claude/CLAUDE.md)
npx xds agent-docs

# Target Claude Code specifically
npx xds init --features agents --agent claude

# Target all tools
npx xds agent-docs --agent all

# Explicit path
npx xds agent-docs --agent-docs-path custom/AI.md
```

A Yarn project's agent docs now contain:
```
yarn xds component <Name>       props, usage, examples for any component
yarn xds upgrade --apply         run version migration codemods
RULE: after @xds/core bump, always run yarn xds upgrade --apply
```

Closes #872

---