### PR TITLE
docs: add missing Slider disabled states and TabMenu theming targets

### DIFF
--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -223,9 +223,9 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-slider', visualProps: ['orientation']},
+      {className: 'xds-slider', visualProps: ['orientation'], states: ['disabled']},
       {className: 'xds-slider-track', visualProps: ['orientation']},
-      {className: 'xds-slider-thumb', visualProps: ['orientation']},
+      {className: 'xds-slider-thumb', visualProps: ['orientation'], states: ['disabled']},
     ],
   },
   accessibility: [
@@ -469,9 +469,9 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-slider', visualProps: ['orientation']},
+      {className: 'xds-slider', visualProps: ['orientation'], states: ['disabled']},
       {className: 'xds-slider-track', visualProps: ['orientation']},
-      {className: 'xds-slider-thumb', visualProps: ['orientation']},
+      {className: 'xds-slider-thumb', visualProps: ['orientation'], states: ['disabled']},
     ],
   },
   accessibility: [

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -63,6 +63,9 @@ export const docs = {
     targets: [
       {className: 'xds-tab-list', visualProps: ['size']},
       {className: 'xds-tab'},
+      {className: 'xds-tab-menu'},
+      {className: 'xds-tab-menu-dropdown'},
+      {className: 'xds-tab-menu-item'},
     ],
   },
   accessibility: [
@@ -303,6 +306,9 @@ export const docsZh = {
     targets: [
       {className: 'xds-tab-list', visualProps: ['size']},
       {className: 'xds-tab'},
+      {className: 'xds-tab-menu'},
+      {className: 'xds-tab-menu-dropdown'},
+      {className: 'xds-tab-menu-item'},
     ],
   },
   accessibility: [


### PR DESCRIPTION
## What

Two theming documentation gaps found during Night Watch doc review.

**Slider** (Slider.doc.mjs)
- `xds-slider` and `xds-slider-thumb` both emit a `disabled` state class in source via `xdsClassName('slider', {disabled: isDisabled ? 'disabled' : null})`
- The theming docs only listed `orientation` as a `visualProp`, missing the `disabled` state entirely
- Added `states: ['disabled']` to both targets in English and Chinese docs

**TabList** (TabList.doc.mjs)  
- `XDSTabMenu` renders three class names: `xds-tab-menu`, `xds-tab-menu-dropdown`, `xds-tab-menu-item`
- Only `xds-tab-list` and `xds-tab` were in the theming targets
- Added all three missing targets in English and Chinese docs

## Validation
- `yarn workspace @xds/core typecheck:docs` passes
- `yarn build` passes
- CLI component output verified

---
*Night Watch Doc Reviewer*