### PR TITLE
fix(hardening): xdsClassName audit — Token, Tokenizer, TopNavMegaMenuItem, TopNavMegaMenuFeaturedCard

### DIFF
--- a/packages/core/src/Token/XDSToken.tsx
+++ b/packages/core/src/Token/XDSToken.tsx
@@ -376,7 +376,7 @@ export function XDSToken({
         aria-disabled={isDisabled || undefined}
         {...sharedProps}
         {...mergeProps(
-          xdsClassName('token', {color}),
+          xdsClassName('token', {color, size}),
           stylex.props(
             styles.base,
             sizeStyles[size],
@@ -406,7 +406,7 @@ export function XDSToken({
         onClick={isDisabled ? undefined : handleContainerClick}
         {...sharedProps}
         {...mergeProps(
-          xdsClassName('token', {color}),
+          xdsClassName('token', {color, size}),
           stylex.props(
             styles.base,
             sizeStyles[size],
@@ -456,7 +456,7 @@ export function XDSToken({
       ref={ref as React.Ref<HTMLSpanElement>}
       {...sharedProps}
       {...mergeProps(
-        xdsClassName('token', {color}),
+        xdsClassName('token', {color, size}),
         stylex.props(
           styles.base,
           sizeStyles[size],

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -12,7 +12,6 @@
  * - /apps/storybook/stories/Tokenizer.stories.tsx
  */
 
-
 import React, {
   useCallback,
   useId,
@@ -42,6 +41,7 @@ import {
   sizeVars,
 } from '../theme/tokens.stylex';
 import type {XDSSearchableItem, XDSSearchSource} from '../Typeahead/types';
+import {xdsClassName, mergeProps} from '../utils';
 
 // Re-export status types for convenience
 export type {
@@ -465,15 +465,18 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
         aria-label={label}
         onClick={handleWrapperClick}
         data-testid={testId}
-        {...stylex.props(
-          inputWrapperStyles.base,
-          styles.wrapper,
-          value.length > 0 && styles.wrapperWithTokens,
-          sizeStyle,
-          isDisabled && inputWrapperStyles.disabled,
-          status && inputStatusBorderStyles[status.type],
-          status && inputStatusHoverShadowStyles[status.type],
-          status && inputStatusFocusWithinStyles[status.type],
+        {...mergeProps(
+          xdsClassName('tokenizer', {size}),
+          stylex.props(
+            inputWrapperStyles.base,
+            styles.wrapper,
+            value.length > 0 && styles.wrapperWithTokens,
+            sizeStyle,
+            isDisabled && inputWrapperStyles.disabled,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
+          ),
         )}>
         {startIcon && <XDSIcon icon={startIcon} size="sm" color="primary" />}
         {tokens}

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuFeaturedCard.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuFeaturedCard.tsx
@@ -15,7 +15,6 @@
  * - /packages/core/src/TopNav/index.ts
  */
 
-
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -25,6 +24,7 @@ import {
   fontWeightVars,
   lineHeightVars,
 } from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
 // Styles
@@ -127,7 +127,11 @@ export function XDSTopNavMegaMenuFeaturedCard({
   children,
 }: XDSTopNavMegaMenuFeaturedCardProps) {
   return (
-    <div {...stylex.props(styles.root)}>
+    <div
+      {...mergeProps(
+        xdsClassName('top-nav-mega-menu-featured-card'),
+        stylex.props(styles.root),
+      )}>
       {image && (
         <img src={image} alt={imageAlt ?? ''} {...stylex.props(styles.image)} />
       )}

--- a/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenuItem.tsx
@@ -28,6 +28,7 @@ import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {useXDSTopNavRenderMode} from './XDSTopNavRenderContext';
+import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
 // Styles
@@ -208,7 +209,10 @@ export function XDSTopNavMegaMenuItem({
         href={href}
         onClick={onClick}
         {...elementProps}
-        {...stylex.props(navItemStyles.item, styles.drawerItem)}>
+        {...mergeProps(
+          xdsClassName('top-nav-mega-menu-item', {mode: 'drawer'}),
+          stylex.props(navItemStyles.item, styles.drawerItem),
+        )}>
         {icon && <div {...stylex.props(styles.drawerItemIcon)}>{icon}</div>}
         <div {...stylex.props(styles.drawerItemContent)}>
           {title}
@@ -231,7 +235,10 @@ export function XDSTopNavMegaMenuItem({
       href={href}
       onClick={onClick}
       tabIndex={tabIndex}
-      {...stylex.props(styles.desktop)}>
+      {...mergeProps(
+        xdsClassName('top-nav-mega-menu-item'),
+        stylex.props(styles.desktop),
+      )}>
       {icon && <div {...stylex.props(styles.desktopIcon)}>{icon}</div>}
       <div {...stylex.props(styles.desktopContent)}>
         <span {...stylex.props(styles.desktopTitle)}>{title}</span>


### PR DESCRIPTION
## Component Audit — Batch 11 (2026-03-25)

Audited 5 components: **TimeInput**, **Token**, **Tokenizer**, **Tooltip**, **TopNav** (+ sub-components).

### Fixes

| Component | Issue | Fix |
|-----------|-------|-----|
| **Token** | `size` prop missing from `xdsClassName` — drives visual styles via `sizeStyles[size]` but themes cannot target size variants | Added `size` to all three `xdsClassName` call sites (link, click, static renders) |
| **Tokenizer** | Missing `xdsClassName` entirely on the visual input wrapper div | Added `xdsClassName('tokenizer', {size})` + `mergeProps` to the wrapper |
| **TopNavMegaMenuItem** | Missing `xdsClassName` on both desktop and drawer render elements | Added `xdsClassName` to both render paths |
| **TopNavMegaMenuFeaturedCard** | Missing `xdsClassName` on the root element | Added `xdsClassName('top-nav-mega-menu-featured-card')` to root div |

### No Issues Found

- **TimeInput** — all checks pass (tokens, xdsClassName with size, proper input props, a11y wiring, exports)
- **Tooltip** / **useXDSTooltip** — all checks pass (tokens, xdsClassName, a11y with describedBy)
- **TopNav** (main) — all checks pass (xdsClassName, mergeProps, XDSBaseProps, label prop)
- **TopNavHeading** — all checks pass
- **TopNavItem** — all checks pass
- **TopNavMenu** — all checks pass
- **TopNavMegaMenu** — all checks pass (delegates to sub-components)

### Needs Review

- **TimeInput `size` variants**: TimeInput supports `sm | md | lg` sizes. The audit checklist says input sizes should be `sm | md`, but all other inputs (TextInput, NumberInput, DateInput) also support `lg`. This seems intentional — the checklist may need updating.

---
