### PR TITLE
sandbox: vertical rhythm audit — 32px controls vs 36px content rows

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
@@ -31,6 +31,8 @@ import {
 } from '@heroicons/react/24/outline';
 import * as stylex from '@stylexjs/stylex';
 
+// ─── Styles ─────────────────────────────────────────────────────────────────
+
 const styles = stylex.create({
   container: {
     maxWidth: 960,
@@ -56,14 +58,14 @@ const styles = stylex.create({
     minWidth: 0,
   },
   sideNavContainer: {
-    width: 240,
+    width: '100%',
     height: 400,
     border: '1px solid #e0e0e0',
     borderRadius: 8,
     overflow: 'hidden',
   },
   sideNavWithListContainer: {
-    width: 280,
+    width: '100%',
     border: '1px solid #e0e0e0',
     borderRadius: 8,
     overflow: 'auto',
@@ -81,28 +83,57 @@ const styles = stylex.create({
   listInSidebar: {
     padding: '0 8px 8px',
   },
+  resizable: {
+    resize: 'horizontal',
+    overflow: 'auto',
+    minWidth: 200,
+    maxWidth: '100%',
+    borderRight: '3px solid #ccc',
+    paddingRight: 8,
+  },
 });
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+const noop = () => {};
 
 function ScenarioBox({
   label,
   verdict,
+  resizable = true,
   children,
 }: {
   label: string;
   verdict: string;
+  resizable?: boolean;
   children: React.ReactNode;
 }) {
+  const inner = (
+    <div {...stylex.props(styles.scenarioInner, styles.bgStripe)}>
+      {children}
+    </div>
+  );
+
   return (
     <div {...stylex.props(styles.scenario)}>
       <div {...stylex.props(styles.scenarioLabel)}>
         {verdict} {label}
+        {resizable && (
+          <span style={{float: 'right', opacity: 0.5}}>
+            ↔ drag right edge to resize
+          </span>
+        )}
       </div>
-      <div {...stylex.props(styles.scenarioInner, styles.bgStripe)}>
-        {children}
-      </div>
+      {resizable ? (
+        <div {...stylex.props(styles.resizable)}>{inner}</div>
+      ) : (
+        inner
+      )}
     </div>
   );
 }
+
+// ─── Page ───────────────────────────────────────────────────────────────────
 
 export default function VerticalRhythmPage() {
   const [page, setPage] = useState(1);
@@ -118,11 +149,14 @@ export default function VerticalRhythmPage() {
           <XDSHeading level={1}>Vertical Rhythm Audit</XDSHeading>
           <XDSText type="body" color="secondary">
             Visual testing of sizing compositions between 32px controls and 36px
-            content rows. 4px grid lines shown in background.
+            content rows. 4px grid lines shown in background. Drag the right
+            edge of each scenario to resize and inspect how start/end content
+            compresses.
           </XDSText>
           <XDSText type="supporting" color="secondary">
             Size tokens: sm=28px, md=32px, lg=36px. Controls default to md
-            (32px). List/menu/nav items land at 36px (8px pad + 20px text).
+            (32px). List/menu/nav items land at 36px (8px pad + 20px text). All
+            list items are interactive — hover to see visual boundaries.
           </XDSText>
         </XDSVStack>
 
@@ -200,15 +234,16 @@ export default function VerticalRhythmPage() {
           </XDSHeading>
           <XDSText type="supporting" color="secondary">
             List items, menu items, and nav items all naturally land at 36px.
+            Hover to see boundaries.
           </XDSText>
 
           <ScenarioBox
             label="ListItem (balanced) — single line rows"
             verdict="✅ 36px each">
             <XDSList>
-              <XDSListItem label="Dashboard" />
-              <XDSListItem label="Settings" />
-              <XDSListItem label="Users" />
+              <XDSListItem label="Dashboard" onClick={noop} />
+              <XDSListItem label="Settings" onClick={noop} />
+              <XDSListItem label="Users" onClick={noop} />
             </XDSList>
           </ScenarioBox>
 
@@ -216,9 +251,9 @@ export default function VerticalRhythmPage() {
             label="ListItem (compact) — 28px rows matching sm controls"
             verdict="✅ 28px each">
             <XDSList density="compact">
-              <XDSListItem label="Dashboard" />
-              <XDSListItem label="Settings" />
-              <XDSListItem label="Users" />
+              <XDSListItem label="Dashboard" onClick={noop} />
+              <XDSListItem label="Settings" onClick={noop} />
+              <XDSListItem label="Users" onClick={noop} />
             </XDSList>
           </ScenarioBox>
 
@@ -226,9 +261,9 @@ export default function VerticalRhythmPage() {
             label="ListItem (spacious) — taller rows"
             verdict="📏 ~45px each">
             <XDSList density="spacious">
-              <XDSListItem label="Dashboard" />
-              <XDSListItem label="Settings" />
-              <XDSListItem label="Users" />
+              <XDSListItem label="Dashboard" onClick={noop} />
+              <XDSListItem label="Settings" onClick={noop} />
+              <XDSListItem label="Users" onClick={noop} />
             </XDSList>
           </ScenarioBox>
 
@@ -238,9 +273,9 @@ export default function VerticalRhythmPage() {
             <XDSDropdownMenu
               button={{label: 'Actions', variant: 'secondary'}}
               items={[
-                {label: 'Edit', onClick: () => {}},
-                {label: 'Duplicate', onClick: () => {}},
-                {label: 'Archive', onClick: () => {}},
+                {label: 'Edit', onClick: noop},
+                {label: 'Duplicate', onClick: noop},
+                {label: 'Archive', onClick: noop},
               ]}
             />
           </ScenarioBox>
@@ -253,7 +288,7 @@ export default function VerticalRhythmPage() {
           <XDSHeading level={2}>3. Controls Inside Content Rows</XDSHeading>
           <XDSText type="supporting" color="secondary">
             32px controls inside 36px content rows should have natural
-            clearance.
+            clearance. Hover rows to see boundary vs nested control.
           </XDSText>
 
           <ScenarioBox
@@ -263,11 +298,13 @@ export default function VerticalRhythmPage() {
               <XDSListItem
                 label="Notifications"
                 description="Manage how you receive alerts"
+                onClick={noop}
                 endContent={<XDSButton label="Configure" size="md" />}
               />
               <XDSListItem
                 label="Privacy"
                 description="Control who sees your data"
+                onClick={noop}
                 endContent={<XDSButton label="Edit" size="md" />}
               />
             </XDSList>
@@ -280,11 +317,13 @@ export default function VerticalRhythmPage() {
               <XDSListItem
                 label="Notifications"
                 description="Manage how you receive alerts"
+                onClick={noop}
                 endContent={<XDSButton label="Configure" size="sm" />}
               />
               <XDSListItem
                 label="Privacy"
                 description="Control who sees your data"
+                onClick={noop}
                 endContent={<XDSButton label="Edit" size="sm" />}
               />
             </XDSList>
@@ -310,6 +349,7 @@ export default function VerticalRhythmPage() {
               <XDSListItem
                 label="API Keys"
                 description="Manage application credentials"
+                onClick={noop}
                 endContent={
                   <XDSButton
                     label="More options"
@@ -322,6 +362,7 @@ export default function VerticalRhythmPage() {
               <XDSListItem
                 label="Webhooks"
                 description="Configure event notifications"
+                onClick={noop}
                 endContent={
                   <XDSButton
                     label="More options"
@@ -352,7 +393,10 @@ export default function VerticalRhythmPage() {
               <XDSButton label="Large action" variant="primary" size="lg" />
               <div {...stylex.props(styles.flex1)}>
                 <XDSList>
-                  <XDSListItem label="Item aligned with lg button" />
+                  <XDSListItem
+                    label="Item aligned with lg button"
+                    onClick={noop}
+                  />
                 </XDSList>
               </div>
             </XDSHStack>
@@ -365,7 +409,7 @@ export default function VerticalRhythmPage() {
               <XDSButton label="Action" variant="primary" size="md" />
               <div {...stylex.props(styles.flex1)}>
                 <XDSList>
-                  <XDSListItem label="Item next to md button" />
+                  <XDSListItem label="Item next to md button" onClick={noop} />
                 </XDSList>
               </div>
             </XDSHStack>
@@ -378,7 +422,10 @@ export default function VerticalRhythmPage() {
               <XDSButton label="Small" size="sm" />
               <div {...stylex.props(styles.flex1)}>
                 <XDSList density="compact">
-                  <XDSListItem label="Compact item next to sm button" />
+                  <XDSListItem
+                    label="Compact item next to sm button"
+                    onClick={noop}
+                  />
                 </XDSList>
               </div>
             </XDSHStack>
@@ -392,6 +439,7 @@ export default function VerticalRhythmPage() {
           <XDSHeading level={2}>5. Inline Editing Scenarios</XDSHeading>
           <XDSText type="supporting" color="secondary">
             TextInput/Selector placed inside list rows for inline editing.
+            Resize to see how label and controls compress.
           </XDSText>
 
           <ScenarioBox
@@ -400,6 +448,7 @@ export default function VerticalRhythmPage() {
             <XDSList>
               <XDSListItem
                 label="Display Name"
+                onClick={noop}
                 endContent={
                   <XDSTextInput
                     label="Name"
@@ -412,6 +461,7 @@ export default function VerticalRhythmPage() {
               />
               <XDSListItem
                 label="Timezone"
+                onClick={noop}
                 endContent={
                   <XDSSelector
                     label="Zone"
@@ -448,8 +498,8 @@ export default function VerticalRhythmPage() {
                   Standalone List (12px paddingInline):
                 </XDSText>
                 <XDSList>
-                  <XDSListItem label="Settings" onClick={() => {}} />
-                  <XDSListItem label="Preferences" onClick={() => {}} />
+                  <XDSListItem label="Settings" onClick={noop} />
+                  <XDSListItem label="Preferences" onClick={noop} />
                 </XDSList>
               </XDSVStack>
               <XDSVStack gap={1}>
@@ -459,8 +509,8 @@ export default function VerticalRhythmPage() {
                 <XDSDropdownMenu
                   button={{label: 'Menu', variant: 'secondary'}}
                   items={[
-                    {label: 'Settings', onClick: () => {}},
-                    {label: 'Preferences', onClick: () => {}},
+                    {label: 'Settings', onClick: noop},
+                    {label: 'Preferences', onClick: noop},
                   ]}
                 />
               </XDSVStack>
@@ -487,12 +537,9 @@ export default function VerticalRhythmPage() {
                   List items in the same sidebar:
                 </XDSText>
                 <XDSList>
-                  <XDSListItem label="Recent: Q4 Report" onClick={() => {}} />
-                  <XDSListItem
-                    label="Recent: Team Metrics"
-                    onClick={() => {}}
-                  />
-                  <XDSListItem label="Recent: API Usage" onClick={() => {}} />
+                  <XDSListItem label="Recent: Q4 Report" onClick={noop} />
+                  <XDSListItem label="Recent: Team Metrics" onClick={noop} />
+                  <XDSListItem label="Recent: API Usage" onClick={noop} />
                 </XDSList>
               </div>
             </div>
@@ -510,7 +557,8 @@ export default function VerticalRhythmPage() {
 
           <ScenarioBox
             label="TopNav with Button + TextInput in end slot"
-            verdict="✅ 8px breathing room per side">
+            verdict="✅ 8px breathing room per side"
+            resizable={false}>
             <div {...stylex.props(styles.navWrapper)}>
               <XDSTopNav
                 label="App with search"
@@ -543,7 +591,8 @@ export default function VerticalRhythmPage() {
 
           <ScenarioBox
             label="TopNav with Tabs in center + Button in end"
-            verdict="✅ Tabs (32px) centered in 48px bar">
+            verdict="✅ Tabs (32px) centered in 48px bar"
+            resizable={false}>
             <div {...stylex.props(styles.navWrapper)}>
               <XDSTopNav
                 label="Tab navigation"
@@ -631,7 +680,8 @@ export default function VerticalRhythmPage() {
         <XDSVStack gap={4}>
           <XDSHeading level={2}>9. Realistic Compositions</XDSHeading>
           <XDSText type="supporting" color="secondary">
-            How these elements actually compose in real app layouts.
+            How these elements actually compose in real app layouts. Resize to
+            see how content reflows at narrow widths.
           </XDSText>
 
           <ScenarioBox
@@ -654,9 +704,9 @@ export default function VerticalRhythmPage() {
               <XDSDropdownMenu
                 button={{label: 'Sort', variant: 'secondary'}}
                 items={[
-                  {label: 'Name A-Z', onClick: () => {}},
-                  {label: 'Date created', onClick: () => {}},
-                  {label: 'Last modified', onClick: () => {}},
+                  {label: 'Name A-Z', onClick: noop},
+                  {label: 'Date created', onClick: noop},
+                  {label: 'Last modified', onClick: noop},
                 ]}
               />
               <XDSButton label="Create" variant="primary" />
@@ -670,18 +720,21 @@ export default function VerticalRhythmPage() {
               <XDSListItem
                 label="Production"
                 description="us-east-1 · 12 instances"
+                onClick={noop}
                 startContent={<XDSIcon icon={ServerIcon} color="primary" />}
                 endContent={<XDSBadge variant="success" label="Healthy" />}
               />
               <XDSListItem
                 label="Staging"
                 description="us-west-2 · 3 instances"
+                onClick={noop}
                 startContent={<XDSIcon icon={ServerIcon} color="primary" />}
                 endContent={<XDSBadge variant="warning" label="Degraded" />}
               />
               <XDSListItem
                 label="Development"
                 description="eu-west-1 · 1 instance"
+                onClick={noop}
                 startContent={<XDSIcon icon={ServerIcon} color="primary" />}
                 endContent={
                   <XDSHStack gap={2} vAlign="center">
@@ -722,6 +775,7 @@ export default function VerticalRhythmPage() {
                   <XDSListItem
                     label="Alice Chen"
                     description="Owner"
+                    onClick={noop}
                     endContent={
                       <XDSButton label="Remove" size="sm" variant="ghost" />
                     }
@@ -729,6 +783,7 @@ export default function VerticalRhythmPage() {
                   <XDSListItem
                     label="Bob Park"
                     description="Editor"
+                    onClick={noop}
                     endContent={
                       <XDSButton label="Remove" size="sm" variant="ghost" />
                     }
@@ -736,6 +791,7 @@ export default function VerticalRhythmPage() {
                   <XDSListItem
                     label="Carol Wu"
                     description="Viewer"
+                    onClick={noop}
                     endContent={
                       <XDSButton label="Remove" size="sm" variant="ghost" />
                     }
@@ -750,9 +806,21 @@ export default function VerticalRhythmPage() {
             verdict="✅ 32px pagination below 36px rows">
             <XDSVStack gap={3}>
               <XDSList hasDividers>
-                <XDSListItem label="Item 1" description="First result" />
-                <XDSListItem label="Item 2" description="Second result" />
-                <XDSListItem label="Item 3" description="Third result" />
+                <XDSListItem
+                  label="Item 1"
+                  description="First result"
+                  onClick={noop}
+                />
+                <XDSListItem
+                  label="Item 2"
+                  description="Second result"
+                  onClick={noop}
+                />
+                <XDSListItem
+                  label="Item 3"
+                  description="Third result"
+                  onClick={noop}
+                />
               </XDSList>
               <XDSHStack gap={0} hAlign="center">
                 <XDSPagination page={page} totalPages={10} onChange={setPage} />

--- a/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
@@ -348,7 +348,7 @@ export default function VerticalRhythmPage() {
                 endContent={
                   <XDSButton
                     label="More options"
-                    icon={<XDSIcon icon={EllipsisHorizontalIcon} size="sm" />}
+                    icon={<XDSIcon icon={EllipsisHorizontalIcon} />}
                     variant="ghost"
                     size="md"
                   />
@@ -360,7 +360,7 @@ export default function VerticalRhythmPage() {
                 endContent={
                   <XDSButton
                     label="More options"
-                    icon={<XDSIcon icon={EllipsisHorizontalIcon} size="sm" />}
+                    icon={<XDSIcon icon={EllipsisHorizontalIcon} />}
                     variant="ghost"
                     size="md"
                   />
@@ -574,7 +574,7 @@ export default function VerticalRhythmPage() {
                     />
                     <XDSButton
                       label="Settings"
-                      icon={<XDSIcon icon={Cog6ToothIcon} size="sm" />}
+                      icon={<XDSIcon icon={Cog6ToothIcon} />}
                       variant="ghost"
                     />
                   </>
@@ -650,7 +650,7 @@ export default function VerticalRhythmPage() {
                     endContent={
                       <XDSButton
                         label="Add"
-                        icon={<XDSIcon icon={PlusIcon} size="xsm" />}
+                        icon={<XDSIcon icon={PlusIcon} />}
                         variant="ghost"
                         size="sm"
                       />

--- a/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
@@ -353,7 +353,7 @@ export default function VerticalRhythmPage() {
                 endContent={
                   <XDSButton
                     label="More options"
-                    icon={<XDSIcon icon={EllipsisHorizontalIcon} />}
+                    icon={<XDSIcon icon={EllipsisHorizontalIcon} size="sm" />}
                     variant="ghost"
                     size="md"
                   />
@@ -366,7 +366,7 @@ export default function VerticalRhythmPage() {
                 endContent={
                   <XDSButton
                     label="More options"
-                    icon={<XDSIcon icon={EllipsisHorizontalIcon} />}
+                    icon={<XDSIcon icon={EllipsisHorizontalIcon} size="sm" />}
                     variant="ghost"
                     size="md"
                   />
@@ -580,7 +580,7 @@ export default function VerticalRhythmPage() {
                     />
                     <XDSButton
                       label="Settings"
-                      icon={<XDSIcon icon={Cog6ToothIcon} />}
+                      icon={<XDSIcon icon={Cog6ToothIcon} size="sm" />}
                       variant="ghost"
                     />
                   </>
@@ -646,7 +646,7 @@ export default function VerticalRhythmPage() {
 
           <ScenarioBox
             label="SideNav items with endContent buttons"
-            verdict="✅ 32px ghost buttons in 36px nav rows">
+            verdict="✅ sm icon buttons in 36px nav rows">
             <div {...stylex.props(styles.sideNavContainer)}>
               <XDSSideNav>
                 <XDSSideNavSection title="Workspace">
@@ -656,7 +656,7 @@ export default function VerticalRhythmPage() {
                     endContent={
                       <XDSButton
                         label="Add"
-                        icon={<XDSIcon icon={PlusIcon} />}
+                        icon={<XDSIcon icon={PlusIcon} size="xsm" />}
                         variant="ghost"
                         size="sm"
                       />

--- a/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
@@ -297,13 +297,11 @@ export default function VerticalRhythmPage() {
             <XDSList>
               <XDSListItem
                 label="Notifications"
-                description="Manage how you receive alerts"
                 onClick={noop}
                 endContent={<XDSButton label="Configure" size="md" />}
               />
               <XDSListItem
                 label="Privacy"
-                description="Control who sees your data"
                 onClick={noop}
                 endContent={<XDSButton label="Edit" size="md" />}
               />
@@ -316,13 +314,11 @@ export default function VerticalRhythmPage() {
             <XDSList>
               <XDSListItem
                 label="Notifications"
-                description="Manage how you receive alerts"
                 onClick={noop}
                 endContent={<XDSButton label="Configure" size="sm" />}
               />
               <XDSListItem
                 label="Privacy"
-                description="Control who sees your data"
                 onClick={noop}
                 endContent={<XDSButton label="Edit" size="sm" />}
               />
@@ -348,7 +344,6 @@ export default function VerticalRhythmPage() {
             <XDSList>
               <XDSListItem
                 label="API Keys"
-                description="Manage application credentials"
                 onClick={noop}
                 endContent={
                   <XDSButton
@@ -361,7 +356,6 @@ export default function VerticalRhythmPage() {
               />
               <XDSListItem
                 label="Webhooks"
-                description="Configure event notifications"
                 onClick={noop}
                 endContent={
                   <XDSButton
@@ -719,21 +713,18 @@ export default function VerticalRhythmPage() {
             <XDSList hasDividers>
               <XDSListItem
                 label="Production"
-                description="us-east-1 · 12 instances"
                 onClick={noop}
                 startContent={<XDSIcon icon={ServerIcon} color="primary" />}
                 endContent={<XDSBadge variant="success" label="Healthy" />}
               />
               <XDSListItem
                 label="Staging"
-                description="us-west-2 · 3 instances"
                 onClick={noop}
                 startContent={<XDSIcon icon={ServerIcon} color="primary" />}
                 endContent={<XDSBadge variant="warning" label="Degraded" />}
               />
               <XDSListItem
                 label="Development"
-                description="eu-west-1 · 1 instance"
                 onClick={noop}
                 startContent={<XDSIcon icon={ServerIcon} color="primary" />}
                 endContent={
@@ -774,7 +765,6 @@ export default function VerticalRhythmPage() {
                 <XDSList hasDividers>
                   <XDSListItem
                     label="Alice Chen"
-                    description="Owner"
                     onClick={noop}
                     endContent={
                       <XDSButton label="Remove" size="sm" variant="ghost" />
@@ -782,7 +772,6 @@ export default function VerticalRhythmPage() {
                   />
                   <XDSListItem
                     label="Bob Park"
-                    description="Editor"
                     onClick={noop}
                     endContent={
                       <XDSButton label="Remove" size="sm" variant="ghost" />
@@ -790,7 +779,6 @@ export default function VerticalRhythmPage() {
                   />
                   <XDSListItem
                     label="Carol Wu"
-                    description="Viewer"
                     onClick={noop}
                     endContent={
                       <XDSButton label="Remove" size="sm" variant="ghost" />
@@ -806,21 +794,9 @@ export default function VerticalRhythmPage() {
             verdict="✅ 32px pagination below 36px rows">
             <XDSVStack gap={3}>
               <XDSList hasDividers>
-                <XDSListItem
-                  label="Item 1"
-                  description="First result"
-                  onClick={noop}
-                />
-                <XDSListItem
-                  label="Item 2"
-                  description="Second result"
-                  onClick={noop}
-                />
-                <XDSListItem
-                  label="Item 3"
-                  description="Third result"
-                  onClick={noop}
-                />
+                <XDSListItem label="Item 1" onClick={noop} />
+                <XDSListItem label="Item 2" onClick={noop} />
+                <XDSListItem label="Item 3" onClick={noop} />
               </XDSList>
               <XDSHStack gap={0} hAlign="center">
                 <XDSPagination page={page} totalPages={10} onChange={setPage} />

--- a/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
@@ -174,7 +174,7 @@ export default function VerticalRhythmPage() {
           <ScenarioBox
             label="Button + TextInput + Selector side by side"
             verdict="✅">
-            <XDSHStack gap={3} vAlign="center">
+            <XDSHStack gap={2} vAlign="center">
               <XDSButton label="Submit" variant="primary" />
               <XDSTextInput
                 label="Search"
@@ -195,7 +195,7 @@ export default function VerticalRhythmPage() {
           </ScenarioBox>
 
           <ScenarioBox label="Button + Tab row" verdict="✅">
-            <XDSHStack gap={4} vAlign="center">
+            <XDSHStack gap={2} vAlign="center">
               <XDSTabList value={tab} onChange={setTab}>
                 <XDSTab value="tab1" label="Overview" />
                 <XDSTab value="tab2" label="Details" />
@@ -208,7 +208,7 @@ export default function VerticalRhythmPage() {
           <ScenarioBox
             label="All three button sizes: sm (28) / md (32) / lg (36)"
             verdict="📏 Reference">
-            <XDSHStack gap={3} vAlign="center">
+            <XDSHStack gap={2} vAlign="center">
               <XDSButton label="Small 28px" size="sm" />
               <XDSButton label="Medium 32px" size="md" />
               <XDSButton label="Large 36px" size="lg" />
@@ -218,7 +218,7 @@ export default function VerticalRhythmPage() {
           <ScenarioBox
             label="Pagination buttons alongside regular buttons"
             verdict="✅">
-            <XDSHStack gap={4} vAlign="center">
+            <XDSHStack gap={2} vAlign="center">
               <XDSPagination page={page} totalPages={10} onChange={setPage} />
               <XDSButton label="Export" variant="secondary" />
             </XDSHStack>
@@ -332,7 +332,7 @@ export default function VerticalRhythmPage() {
           <ScenarioBox
             label="Badge inside Button endSlot"
             verdict="✅ Badge (20px) centered in 32px button">
-            <XDSHStack gap={3} vAlign="center">
+            <XDSHStack gap={2} vAlign="center">
               <XDSButton label="Messages" endSlot={<XDSBadge label={3} />} />
               <XDSButton
                 label="Alerts"
@@ -389,7 +389,7 @@ export default function VerticalRhythmPage() {
           <ScenarioBox
             label="Button (lg/36px) alongside ListItem (balanced/36px)"
             verdict="✅ Escape hatch — both 36px">
-            <XDSHStack gap={4} vAlign="start">
+            <XDSHStack gap={2} vAlign="start">
               <XDSButton label="Large action" variant="primary" size="lg" />
               <div {...stylex.props(styles.flex1)}>
                 <XDSList>
@@ -405,7 +405,7 @@ export default function VerticalRhythmPage() {
           <ScenarioBox
             label="Button (md/32px) next to ListItem (balanced/36px) — default mismatch"
             verdict="⚠️ 4px height difference">
-            <XDSHStack gap={4} vAlign="start">
+            <XDSHStack gap={2} vAlign="start">
               <XDSButton label="Action" variant="primary" size="md" />
               <div {...stylex.props(styles.flex1)}>
                 <XDSList>
@@ -418,7 +418,7 @@ export default function VerticalRhythmPage() {
           <ScenarioBox
             label="Compact ListItem (28px) next to Button (sm/28px)"
             verdict="✅ Dense pairing">
-            <XDSHStack gap={4} vAlign="start">
+            <XDSHStack gap={2} vAlign="start">
               <XDSButton label="Small" size="sm" />
               <div {...stylex.props(styles.flex1)}>
                 <XDSList density="compact">
@@ -687,7 +687,7 @@ export default function VerticalRhythmPage() {
           <ScenarioBox
             label="Toolbar: Tabs + Search + Button + Dropdown"
             verdict="✅ All controls 32px">
-            <XDSHStack gap={3} vAlign="center">
+            <XDSHStack gap={2} vAlign="center">
               <XDSTabList value={tab} onChange={setTab}>
                 <XDSTab value="tab1" label="All" />
                 <XDSTab value="tab2" label="Active" />
@@ -750,7 +750,7 @@ export default function VerticalRhythmPage() {
             label="Settings page: form controls + list in same view"
             verdict="✅ Controls 32px, list rows 36px">
             <XDSVStack gap={4}>
-              <XDSHStack gap={3} vAlign="end">
+              <XDSHStack gap={2} vAlign="end">
                 <div {...stylex.props(styles.flex1)}>
                   <XDSTextInput
                     label="Project Name"

--- a/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/vertical-rhythm/page.tsx
@@ -1,0 +1,766 @@
+'use client';
+
+import {useState} from 'react';
+
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSPagination} from '@xds/core/Pagination';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
+import {XDSIcon} from '@xds/core/Icon';
+import {XDSDivider} from '@xds/core';
+import {
+  HomeIcon,
+  FolderIcon,
+  UsersIcon,
+  Cog6ToothIcon,
+  PuzzlePieceIcon,
+  CreditCardIcon,
+  PlusIcon,
+  ChartBarIcon,
+  DocumentIcon,
+  ServerIcon,
+  EllipsisHorizontalIcon,
+} from '@heroicons/react/24/outline';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  container: {
+    maxWidth: 960,
+  },
+  scenario: {
+    border: '1px solid #e0e0e0',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  scenarioInner: {
+    padding: 16,
+  },
+  scenarioLabel: {
+    padding: '8px 12px',
+    backgroundColor: '#f5f5f5',
+    borderBottom: '1px solid #e0e0e0',
+    fontFamily: 'monospace',
+    fontSize: 11,
+    color: '#666',
+  },
+  flex1: {
+    flex: 1,
+    minWidth: 0,
+  },
+  sideNavContainer: {
+    width: 240,
+    height: 400,
+    border: '1px solid #e0e0e0',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  sideNavWithListContainer: {
+    width: 280,
+    border: '1px solid #e0e0e0',
+    borderRadius: 8,
+    overflow: 'auto',
+  },
+  navWrapper: {
+    border: '1px solid #e0e0e0',
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  bgStripe: {
+    background:
+      'repeating-linear-gradient(0deg, transparent, transparent 3px, rgba(0,0,255,0.03) 3px, rgba(0,0,255,0.03) 4px)',
+    backgroundSize: '100% 4px',
+  },
+  listInSidebar: {
+    padding: '0 8px 8px',
+  },
+});
+
+function ScenarioBox({
+  label,
+  verdict,
+  children,
+}: {
+  label: string;
+  verdict: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div {...stylex.props(styles.scenario)}>
+      <div {...stylex.props(styles.scenarioLabel)}>
+        {verdict} {label}
+      </div>
+      <div {...stylex.props(styles.scenarioInner, styles.bgStripe)}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default function VerticalRhythmPage() {
+  const [page, setPage] = useState(1);
+  const [tab, setTab] = useState('tab1');
+  const [search, setSearch] = useState('');
+  const [name, setName] = useState('');
+  const [selector, setSelector] = useState<string | undefined>(undefined);
+
+  return (
+    <div {...stylex.props(styles.container)}>
+      <XDSVStack gap={8}>
+        <XDSVStack gap={2}>
+          <XDSHeading level={1}>Vertical Rhythm Audit</XDSHeading>
+          <XDSText type="body" color="secondary">
+            Visual testing of sizing compositions between 32px controls and 36px
+            content rows. 4px grid lines shown in background.
+          </XDSText>
+          <XDSText type="supporting" color="secondary">
+            Size tokens: sm=28px, md=32px, lg=36px. Controls default to md
+            (32px). List/menu/nav items land at 36px (8px pad + 20px text).
+          </XDSText>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 1: Peer control alignment ─────────────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>
+            1. Peer Control Alignment (32px tier)
+          </XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            All controls at default md size should be the same height.
+          </XDSText>
+
+          <ScenarioBox
+            label="Button + TextInput + Selector side by side"
+            verdict="✅">
+            <XDSHStack gap={3} vAlign="center">
+              <XDSButton label="Submit" variant="primary" />
+              <XDSTextInput
+                label="Search"
+                isLabelHidden
+                placeholder="Search..."
+                value={search}
+                onChange={setSearch}
+              />
+              <XDSSelector
+                label="Status"
+                isLabelHidden
+                options={['Active', 'Inactive', 'Pending']}
+                value={selector}
+                onChange={setSelector}
+                placeholder="Status"
+              />
+            </XDSHStack>
+          </ScenarioBox>
+
+          <ScenarioBox label="Button + Tab row" verdict="✅">
+            <XDSHStack gap={4} vAlign="center">
+              <XDSTabList value={tab} onChange={setTab}>
+                <XDSTab value="tab1" label="Overview" />
+                <XDSTab value="tab2" label="Details" />
+                <XDSTab value="tab3" label="Activity" />
+              </XDSTabList>
+              <XDSButton label="Add new" variant="primary" size="md" />
+            </XDSHStack>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="All three button sizes: sm (28) / md (32) / lg (36)"
+            verdict="📏 Reference">
+            <XDSHStack gap={3} vAlign="center">
+              <XDSButton label="Small 28px" size="sm" />
+              <XDSButton label="Medium 32px" size="md" />
+              <XDSButton label="Large 36px" size="lg" />
+            </XDSHStack>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="Pagination buttons alongside regular buttons"
+            verdict="✅">
+            <XDSHStack gap={4} vAlign="center">
+              <XDSPagination page={page} totalPages={10} onChange={setPage} />
+              <XDSButton label="Export" variant="secondary" />
+            </XDSHStack>
+          </ScenarioBox>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 2: Content row alignment ──────────────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>
+            2. Content Row Alignment (36px tier)
+          </XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            List items, menu items, and nav items all naturally land at 36px.
+          </XDSText>
+
+          <ScenarioBox
+            label="ListItem (balanced) — single line rows"
+            verdict="✅ 36px each">
+            <XDSList>
+              <XDSListItem label="Dashboard" />
+              <XDSListItem label="Settings" />
+              <XDSListItem label="Users" />
+            </XDSList>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="ListItem (compact) — 28px rows matching sm controls"
+            verdict="✅ 28px each">
+            <XDSList density="compact">
+              <XDSListItem label="Dashboard" />
+              <XDSListItem label="Settings" />
+              <XDSListItem label="Users" />
+            </XDSList>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="ListItem (spacious) — taller rows"
+            verdict="📏 ~45px each">
+            <XDSList density="spacious">
+              <XDSListItem label="Dashboard" />
+              <XDSListItem label="Settings" />
+              <XDSListItem label="Users" />
+            </XDSList>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="DropdownMenu items (click to open)"
+            verdict="✅ 36px per item">
+            <XDSDropdownMenu
+              button={{label: 'Actions', variant: 'secondary'}}
+              items={[
+                {label: 'Edit', onClick: () => {}},
+                {label: 'Duplicate', onClick: () => {}},
+                {label: 'Archive', onClick: () => {}},
+              ]}
+            />
+          </ScenarioBox>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 3: Controls nested in content rows ────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>3. Controls Inside Content Rows</XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            32px controls inside 36px content rows should have natural
+            clearance.
+          </XDSText>
+
+          <ScenarioBox
+            label="Button (md/32px) in ListItem endContent"
+            verdict="✅ 2px clearance per side">
+            <XDSList>
+              <XDSListItem
+                label="Notifications"
+                description="Manage how you receive alerts"
+                endContent={<XDSButton label="Configure" size="md" />}
+              />
+              <XDSListItem
+                label="Privacy"
+                description="Control who sees your data"
+                endContent={<XDSButton label="Edit" size="md" />}
+              />
+            </XDSList>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="Button (sm/28px) in ListItem endContent"
+            verdict="✅ More breathing room">
+            <XDSList>
+              <XDSListItem
+                label="Notifications"
+                description="Manage how you receive alerts"
+                endContent={<XDSButton label="Configure" size="sm" />}
+              />
+              <XDSListItem
+                label="Privacy"
+                description="Control who sees your data"
+                endContent={<XDSButton label="Edit" size="sm" />}
+              />
+            </XDSList>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="Badge inside Button endSlot"
+            verdict="✅ Badge (20px) centered in 32px button">
+            <XDSHStack gap={3} vAlign="center">
+              <XDSButton label="Messages" endSlot={<XDSBadge label={3} />} />
+              <XDSButton
+                label="Alerts"
+                variant="primary"
+                endSlot={<XDSBadge label="New" />}
+              />
+            </XDSHStack>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="Icon button in ListItem endContent"
+            verdict="✅ 32px square in 36px row">
+            <XDSList>
+              <XDSListItem
+                label="API Keys"
+                description="Manage application credentials"
+                endContent={
+                  <XDSButton
+                    label="More options"
+                    icon={<XDSIcon icon={EllipsisHorizontalIcon} />}
+                    variant="ghost"
+                    size="md"
+                  />
+                }
+              />
+              <XDSListItem
+                label="Webhooks"
+                description="Configure event notifications"
+                endContent={
+                  <XDSButton
+                    label="More options"
+                    icon={<XDSIcon icon={EllipsisHorizontalIcon} />}
+                    variant="ghost"
+                    size="md"
+                  />
+                }
+              />
+            </XDSList>
+          </ScenarioBox>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 4: Cross-tier peer composition ────────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>4. Cross-Tier Peer Composition</XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            What happens when 32px controls and 36px content rows are side by
+            side as peers.
+          </XDSText>
+
+          <ScenarioBox
+            label="Button (lg/36px) alongside ListItem (balanced/36px)"
+            verdict="✅ Escape hatch — both 36px">
+            <XDSHStack gap={4} vAlign="start">
+              <XDSButton label="Large action" variant="primary" size="lg" />
+              <div {...stylex.props(styles.flex1)}>
+                <XDSList>
+                  <XDSListItem label="Item aligned with lg button" />
+                </XDSList>
+              </div>
+            </XDSHStack>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="Button (md/32px) next to ListItem (balanced/36px) — default mismatch"
+            verdict="⚠️ 4px height difference">
+            <XDSHStack gap={4} vAlign="start">
+              <XDSButton label="Action" variant="primary" size="md" />
+              <div {...stylex.props(styles.flex1)}>
+                <XDSList>
+                  <XDSListItem label="Item next to md button" />
+                </XDSList>
+              </div>
+            </XDSHStack>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="Compact ListItem (28px) next to Button (sm/28px)"
+            verdict="✅ Dense pairing">
+            <XDSHStack gap={4} vAlign="start">
+              <XDSButton label="Small" size="sm" />
+              <div {...stylex.props(styles.flex1)}>
+                <XDSList density="compact">
+                  <XDSListItem label="Compact item next to sm button" />
+                </XDSList>
+              </div>
+            </XDSHStack>
+          </ScenarioBox>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 5: Input inside list row ──────────────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>5. Inline Editing Scenarios</XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            TextInput/Selector placed inside list rows for inline editing.
+          </XDSText>
+
+          <ScenarioBox
+            label="TextInput (md/32px) in ListItem endContent"
+            verdict="✅ Fits in 36px row">
+            <XDSList>
+              <XDSListItem
+                label="Display Name"
+                endContent={
+                  <XDSTextInput
+                    label="Name"
+                    isLabelHidden
+                    placeholder="Enter name"
+                    value={name}
+                    onChange={setName}
+                  />
+                }
+              />
+              <XDSListItem
+                label="Timezone"
+                endContent={
+                  <XDSSelector
+                    label="Zone"
+                    isLabelHidden
+                    options={['UTC', 'PST', 'EST', 'CET']}
+                    value={selector}
+                    onChange={setSelector}
+                    placeholder="Select"
+                  />
+                }
+              />
+            </XDSList>
+          </ScenarioBox>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 6: Inline padding / text alignment ─────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>
+            6. Inline Padding &amp; Text Alignment
+          </XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            Checking whether text start positions align when different
+            components are stacked vertically.
+          </XDSText>
+
+          <ScenarioBox
+            label="DropdownMenu container (4px) + item (8px) vs ListItem (12px)"
+            verdict="✅ Both 12px from edge">
+            <XDSVStack gap={4}>
+              <XDSVStack gap={1}>
+                <XDSText type="supporting" weight="bold">
+                  Standalone List (12px paddingInline):
+                </XDSText>
+                <XDSList>
+                  <XDSListItem label="Settings" onClick={() => {}} />
+                  <XDSListItem label="Preferences" onClick={() => {}} />
+                </XDSList>
+              </XDSVStack>
+              <XDSVStack gap={1}>
+                <XDSText type="supporting" weight="bold">
+                  DropdownMenu (open to compare item padding):
+                </XDSText>
+                <XDSDropdownMenu
+                  button={{label: 'Menu', variant: 'secondary'}}
+                  items={[
+                    {label: 'Settings', onClick: () => {}},
+                    {label: 'Preferences', onClick: () => {}},
+                  ]}
+                />
+              </XDSVStack>
+            </XDSVStack>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="SideNavItem (8px pad) vs ListItem (12px pad) in same panel"
+            verdict="⚠️ 4px text-start offset">
+            <div {...stylex.props(styles.sideNavWithListContainer)}>
+              <XDSSideNav>
+                <XDSSideNavSection title="Navigation">
+                  <XDSSideNavItem
+                    label="Dashboard"
+                    icon={HomeIcon}
+                    isSelected
+                  />
+                  <XDSSideNavItem label="Analytics" icon={ChartBarIcon} />
+                  <XDSSideNavItem label="Reports" icon={DocumentIcon} />
+                </XDSSideNavSection>
+              </XDSSideNav>
+              <div {...stylex.props(styles.listInSidebar)}>
+                <XDSText type="supporting" weight="bold" color="secondary">
+                  List items in the same sidebar:
+                </XDSText>
+                <XDSList>
+                  <XDSListItem label="Recent: Q4 Report" onClick={() => {}} />
+                  <XDSListItem
+                    label="Recent: Team Metrics"
+                    onClick={() => {}}
+                  />
+                  <XDSListItem label="Recent: API Usage" onClick={() => {}} />
+                </XDSList>
+              </div>
+            </div>
+          </ScenarioBox>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 7: TopNav compositions ────────────────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>7. TopNav Compositions</XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            32px controls centered in 48px TopNav bar.
+          </XDSText>
+
+          <ScenarioBox
+            label="TopNav with Button + TextInput in end slot"
+            verdict="✅ 8px breathing room per side">
+            <div {...stylex.props(styles.navWrapper)}>
+              <XDSTopNav
+                label="App with search"
+                heading={<XDSTopNavHeading heading="My App" />}
+                startContent={
+                  <>
+                    <XDSTopNavItem label="Home" href="#" isSelected />
+                    <XDSTopNavItem label="Projects" href="#" />
+                  </>
+                }
+                endContent={
+                  <>
+                    <XDSTextInput
+                      label="Search"
+                      isLabelHidden
+                      placeholder="Search..."
+                      value={search}
+                      onChange={setSearch}
+                    />
+                    <XDSButton
+                      label="Settings"
+                      icon={<XDSIcon icon={Cog6ToothIcon} />}
+                      variant="ghost"
+                    />
+                  </>
+                }
+              />
+            </div>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="TopNav with Tabs in center + Button in end"
+            verdict="✅ Tabs (32px) centered in 48px bar">
+            <div {...stylex.props(styles.navWrapper)}>
+              <XDSTopNav
+                label="Tab navigation"
+                heading={<XDSTopNavHeading heading="Dashboard" />}
+                centerContent={
+                  <XDSTabList value={tab} onChange={setTab}>
+                    <XDSTab value="tab1" label="Overview" />
+                    <XDSTab value="tab2" label="Analytics" />
+                    <XDSTab value="tab3" label="Reports" />
+                  </XDSTabList>
+                }
+                endContent={
+                  <XDSButton label="New Report" variant="primary" size="md" />
+                }
+              />
+            </div>
+          </ScenarioBox>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 8: SideNav compositions ───────────────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>8. SideNav Compositions</XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            Nav items (36px) with nested children and varying density.
+          </XDSText>
+
+          <ScenarioBox
+            label="Standard SideNav with sections"
+            verdict="✅ Consistent 36px rows">
+            <div {...stylex.props(styles.sideNavContainer)}>
+              <XDSSideNav>
+                <XDSSideNavSection title="Main">
+                  <XDSSideNavItem
+                    label="Dashboard"
+                    icon={HomeIcon}
+                    isSelected
+                  />
+                  <XDSSideNavItem label="Projects" icon={FolderIcon} />
+                  <XDSSideNavItem label="Teams" icon={UsersIcon} />
+                </XDSSideNavSection>
+                <XDSSideNavSection title="Settings">
+                  <XDSSideNavItem label="General" icon={Cog6ToothIcon} />
+                  <XDSSideNavItem label="Integrations" icon={PuzzlePieceIcon} />
+                  <XDSSideNavItem label="Billing" icon={CreditCardIcon} />
+                </XDSSideNavSection>
+              </XDSSideNav>
+            </div>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="SideNav items with endContent buttons"
+            verdict="✅ 32px ghost buttons in 36px nav rows">
+            <div {...stylex.props(styles.sideNavContainer)}>
+              <XDSSideNav>
+                <XDSSideNavSection title="Workspace">
+                  <XDSSideNavItem
+                    label="Projects"
+                    icon={FolderIcon}
+                    endContent={
+                      <XDSButton
+                        label="Add"
+                        icon={<XDSIcon icon={PlusIcon} />}
+                        variant="ghost"
+                        size="sm"
+                      />
+                    }
+                  />
+                  <XDSSideNavItem
+                    label="Teams"
+                    icon={UsersIcon}
+                    endContent={<XDSBadge label={5} />}
+                  />
+                  <XDSSideNavItem label="Settings" icon={Cog6ToothIcon} />
+                </XDSSideNavSection>
+              </XDSSideNav>
+            </div>
+          </ScenarioBox>
+        </XDSVStack>
+
+        <XDSDivider />
+
+        {/* ── SECTION 9: Realistic compositions ─────────────────── */}
+        <XDSVStack gap={4}>
+          <XDSHeading level={2}>9. Realistic Compositions</XDSHeading>
+          <XDSText type="supporting" color="secondary">
+            How these elements actually compose in real app layouts.
+          </XDSText>
+
+          <ScenarioBox
+            label="Toolbar: Tabs + Search + Button + Dropdown"
+            verdict="✅ All controls 32px">
+            <XDSHStack gap={3} vAlign="center">
+              <XDSTabList value={tab} onChange={setTab}>
+                <XDSTab value="tab1" label="All" />
+                <XDSTab value="tab2" label="Active" />
+                <XDSTab value="tab3" label="Archived" />
+              </XDSTabList>
+              <div style={{flex: 1}} />
+              <XDSTextInput
+                label="Search"
+                isLabelHidden
+                placeholder="Filter..."
+                value={search}
+                onChange={setSearch}
+              />
+              <XDSDropdownMenu
+                button={{label: 'Sort', variant: 'secondary'}}
+                items={[
+                  {label: 'Name A-Z', onClick: () => {}},
+                  {label: 'Date created', onClick: () => {}},
+                  {label: 'Last modified', onClick: () => {}},
+                ]}
+              />
+              <XDSButton label="Create" variant="primary" />
+            </XDSHStack>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="List with mixed actions — buttons, badges, selectors"
+            verdict="✅ 32px controls nested in 36px rows">
+            <XDSList hasDividers>
+              <XDSListItem
+                label="Production"
+                description="us-east-1 · 12 instances"
+                startContent={<XDSIcon icon={ServerIcon} color="primary" />}
+                endContent={<XDSBadge variant="success" label="Healthy" />}
+              />
+              <XDSListItem
+                label="Staging"
+                description="us-west-2 · 3 instances"
+                startContent={<XDSIcon icon={ServerIcon} color="primary" />}
+                endContent={<XDSBadge variant="warning" label="Degraded" />}
+              />
+              <XDSListItem
+                label="Development"
+                description="eu-west-1 · 1 instance"
+                startContent={<XDSIcon icon={ServerIcon} color="primary" />}
+                endContent={
+                  <XDSHStack gap={2} vAlign="center">
+                    <XDSBadge variant="error" label="Down" />
+                    <XDSButton label="Restart" size="sm" variant="primary" />
+                  </XDSHStack>
+                }
+              />
+            </XDSList>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="Settings page: form controls + list in same view"
+            verdict="✅ Controls 32px, list rows 36px">
+            <XDSVStack gap={4}>
+              <XDSHStack gap={3} vAlign="end">
+                <div {...stylex.props(styles.flex1)}>
+                  <XDSTextInput
+                    label="Project Name"
+                    value={name}
+                    onChange={setName}
+                    placeholder="My Project"
+                  />
+                </div>
+                <XDSSelector
+                  label="Visibility"
+                  options={['Public', 'Private', 'Internal']}
+                  value={selector}
+                  onChange={setSelector}
+                  placeholder="Choose"
+                />
+                <XDSButton label="Save" variant="primary" />
+              </XDSHStack>
+              <XDSDivider />
+              <XDSVStack gap={2}>
+                <XDSHeading level={3}>Team Members</XDSHeading>
+                <XDSList hasDividers>
+                  <XDSListItem
+                    label="Alice Chen"
+                    description="Owner"
+                    endContent={
+                      <XDSButton label="Remove" size="sm" variant="ghost" />
+                    }
+                  />
+                  <XDSListItem
+                    label="Bob Park"
+                    description="Editor"
+                    endContent={
+                      <XDSButton label="Remove" size="sm" variant="ghost" />
+                    }
+                  />
+                  <XDSListItem
+                    label="Carol Wu"
+                    description="Viewer"
+                    endContent={
+                      <XDSButton label="Remove" size="sm" variant="ghost" />
+                    }
+                  />
+                </XDSList>
+              </XDSVStack>
+            </XDSVStack>
+          </ScenarioBox>
+
+          <ScenarioBox
+            label="Pagination below a list"
+            verdict="✅ 32px pagination below 36px rows">
+            <XDSVStack gap={3}>
+              <XDSList hasDividers>
+                <XDSListItem label="Item 1" description="First result" />
+                <XDSListItem label="Item 2" description="Second result" />
+                <XDSListItem label="Item 3" description="Third result" />
+              </XDSList>
+              <XDSHStack gap={0} hAlign="center">
+                <XDSPagination page={page} totalPages={10} onChange={setPage} />
+              </XDSHStack>
+            </XDSVStack>
+          </ScenarioBox>
+        </XDSVStack>
+      </XDSVStack>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/SandboxNav.tsx
+++ b/apps/sandbox/src/app/SandboxNav.tsx
@@ -22,6 +22,7 @@ const pages = [
   {name: 'Mega Menu', href: '/pages/mega-menu/'},
   {name: 'Polymorphic Link', href: '/pages/polymorphic-link/'},
   {name: 'Table Overview', href: '/pages/table-overview/'},
+  {name: 'Vertical Rhythm', href: '/pages/vertical-rhythm/'},
 ];
 
 export function SandboxNav() {

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -91,7 +91,8 @@ const styles = stylex.create({
   iconOnly: {
     '--button-icon-only-aspect': '1 / 1',
     aspectRatio: 'var(--button-icon-only-aspect)',
-    paddingInline: spacingVars['--spacing-2'],
+    paddingBlock: 0,
+    paddingInline: 0,
   },
   endSlotWrapper: {
     display: 'inline-flex',
@@ -347,6 +348,9 @@ const loadingStyles = stylex.create({
  * compensation stays in sync.
  */
 const edgeCompStyles = stylex.create({
+  paddingInline0: {
+    '--component-padding-inline': spacingVars['--spacing-0'],
+  },
   paddingInline2: {
     '--component-padding-inline': spacingVars['--spacing-2'],
   },
@@ -441,7 +445,7 @@ export function XDSButton({
   const edgeCompStyle = isFlat ? edgeCompensation.self : null;
   const edgePaddingSignal = isFlat
     ? isIconOnly
-      ? edgeCompStyles.paddingInline2
+      ? edgeCompStyles.paddingInline0
       : edgeCompStyles.paddingInline3
     : null;
 


### PR DESCRIPTION
## Vertical Rhythm Audit Page

Visual testing page for inspecting sizing compositions after the OSS shift from 36px (WWW) to 32px default controls.

### What this tests

| Section | What it covers |
|---------|---------------|
| 1. Peer Control Alignment | Button + Input + Selector + Tabs + Pagination — all 32px |
| 2. Content Row Alignment | List densities (compact/balanced/spacious), dropdown items |
| 3. Controls Inside Content Rows | Buttons/badges/icons in ListItem endContent |
| 4. Cross-Tier Peer Composition | 32px controls next to 36px content rows as siblings |
| 5. Inline Editing | TextInput/Selector embedded in list rows |
| 6. Inline Padding & Text Alignment | Container nesting math (dropdown 4+8 vs list 12), SideNav vs List |
| 7. TopNav Compositions | Search + buttons + tabs in 48px nav bar |
| 8. SideNav Compositions | Sections, endContent buttons, badges in nav items |
| 9. Realistic Layouts | Toolbar, settings page, server list, pagination below list |

### Key findings from analysis

- **32px tier** (controls): Button, TextInput, Selector, Tab, Pagination
- **36px tier** (content rows): ListItem balanced, MenuItem, NavItem
- The 4px gap = exactly `--spacing-1`. A 32px button fits inside a 36px row with 2px clearance per side.
- DropdownMenu container padding (4px) + item padding (8px) = 12px, matching ListItem standalone padding (12px) ✅
- SideNav items (8px inline) vs ListItem (12px inline) shows a 4px text-start offset when composed in the same panel ⚠️

### How to inspect

Navigate to **Vertical Rhythm** in the sandbox sidebar. Each scenario has:
- A monospace label with verdict (✅ / ⚠️ / 📏)
- A subtle 4px grid background for visual alignment checking

> **Draft PR** — sandbox-only change for visual testing, no core changes.