### PR TITLE
refactor(cli): replace raw HTML with XDS components in templates

### DIFF
--- a/packages/cli/templates/login/page.tsx
+++ b/packages/cli/templates/login/page.tsx
@@ -1,29 +1,13 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
 import {XDSLayout, XDSLayoutContent} from '@xds/core';
 import {XDSText} from '@xds/core';
 import {XDSTextInput} from '@xds/core';
 import {XDSButton} from '@xds/core';
-import {XDSVStack} from '@xds/core';
-
-const styles = stylex.create({
-  container: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: '100vh',
-  },
-  card: {
-    width: '100%',
-    maxWidth: '400px',
-    padding: 'var(--spacing-7)',
-    backgroundColor: 'var(--color-surface)',
-    borderRadius: 'var(--radius-3)',
-    boxShadow: 'var(--shadow-menu)',
-  },
-});
+import {XDSCard} from '@xds/core';
+import {XDSCenter} from '@xds/core';
+import {XDSFormLayout} from '@xds/core';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -38,10 +22,10 @@ export default function LoginPage() {
     <XDSLayout
       content={
         <XDSLayoutContent>
-          <div {...stylex.props(styles.container)}>
+          <XDSCenter width="100%" height="100vh">
             <form onSubmit={handleSubmit}>
-              <div {...stylex.props(styles.card)}>
-                <XDSVStack gap="space5">
+              <XDSCard maxWidth={400} width="100%">
+                <XDSFormLayout>
                   <XDSText type="large" weight="semibold">
                     Sign in
                   </XDSText>
@@ -61,10 +45,10 @@ export default function LoginPage() {
                   />
 
                   <XDSButton label="Sign in" variant="primary" type="submit" />
-                </XDSVStack>
-              </div>
+                </XDSFormLayout>
+              </XDSCard>
             </form>
-          </div>
+          </XDSCenter>
         </XDSLayoutContent>
       }
     />

--- a/packages/cli/templates/table/page.tsx
+++ b/packages/cli/templates/table/page.tsx
@@ -1,35 +1,13 @@
 'use client';
 
 import {useState} from 'react';
-import * as stylex from '@stylexjs/stylex';
 import {XDSLayout, XDSLayoutHeader, XDSLayoutContent} from '@xds/core';
 import {XDSText} from '@xds/core';
 import {XDSButton} from '@xds/core';
 import {XDSHStack} from '@xds/core';
-
-const styles = stylex.create({
-  table: {
-    width: '100%',
-    borderCollapse: 'collapse',
-  },
-  th: {
-    textAlign: 'start',
-    padding: 'var(--spacing-3) var(--spacing-4)',
-    borderBottom: '1px solid var(--color-border)',
-    color: 'var(--color-text-secondary)',
-    fontSize: 'var(--text-sm)',
-    fontWeight: 'var(--font-weight-medium)',
-  },
-  td: {
-    padding: 'var(--spacing-3) var(--spacing-4)',
-    borderBottom: '1px solid var(--color-border)',
-  },
-  row: {
-    ':hover': {
-      backgroundColor: 'var(--color-wash)',
-    },
-  },
-});
+import {XDSTable} from '@xds/core';
+import {XDSBadge} from '@xds/core';
+import type {XDSTableColumn} from '@xds/core';
 
 type Item = {
   id: string;
@@ -42,6 +20,38 @@ const SAMPLE_DATA: Item[] = [
   {id: '1', name: 'Item One', status: 'active', updatedAt: '2025-01-15'},
   {id: '2', name: 'Item Two', status: 'inactive', updatedAt: '2025-01-14'},
   {id: '3', name: 'Item Three', status: 'active', updatedAt: '2025-01-13'},
+];
+
+const columns: XDSTableColumn<Item>[] = [
+  {
+    key: 'name',
+    header: 'Name',
+    renderCell: (item: Item) => (
+      <XDSText weight="semibold">{item.name}</XDSText>
+    ),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    renderCell: (item: Item) => (
+      <XDSBadge
+        variant={item.status === 'active' ? 'success' : 'neutral'}
+        label={item.status}
+      />
+    ),
+  },
+  {
+    key: 'updatedAt',
+    header: 'Updated',
+    renderCell: (item: Item) => (
+      <XDSText color="secondary">{item.updatedAt}</XDSText>
+    ),
+  },
+  {
+    key: 'actions',
+    header: 'Actions',
+    renderCell: () => <XDSButton label="Edit" variant="secondary" size="sm" />,
+  },
 ];
 
 export default function TablePage() {
@@ -61,42 +71,7 @@ export default function TablePage() {
       }
       content={
         <XDSLayoutContent>
-          <table {...stylex.props(styles.table)}>
-            <thead>
-              <tr>
-                <th {...stylex.props(styles.th)}>Name</th>
-                <th {...stylex.props(styles.th)}>Status</th>
-                <th {...stylex.props(styles.th)}>Updated</th>
-                <th {...stylex.props(styles.th)}>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.map(item => (
-                <tr key={item.id} {...stylex.props(styles.row)}>
-                  <td {...stylex.props(styles.td)}>
-                    <XDSText type="body">{item.name}</XDSText>
-                  </td>
-                  <td {...stylex.props(styles.td)}>
-                    <XDSText
-                      type="body"
-                      color={
-                        item.status === 'active' ? 'primary' : 'secondary'
-                      }>
-                      {item.status}
-                    </XDSText>
-                  </td>
-                  <td {...stylex.props(styles.td)}>
-                    <XDSText type="body" color="secondary">
-                      {item.updatedAt}
-                    </XDSText>
-                  </td>
-                  <td {...stylex.props(styles.td)}>
-                    <XDSButton label="Edit" variant="secondary" size="sm" />
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <XDSTable<Item> data={data} columns={columns} rowKey="id" hasHover />
         </XDSLayoutContent>
       }
     />


### PR DESCRIPTION
## Summary

The CLI page templates (`xds template`) were using raw HTML elements and manual StyleX for things XDS already has components for. This converts them to proper XDS.

### Login template
| Before | After |
|--------|-------|
| `<div>` + StyleX centering | `XDSCenter` |
| `<div>` + StyleX card styles | `XDSCard` |
| `XDSVStack` for form fields | `XDSFormLayout` (semantic) |
| `@stylexjs/stylex` import | Removed |

### Table template
| Before | After |
|--------|-------|
| Raw `<table>/<thead>/<tbody>/<tr>/<td>/<th>` | `XDSTable` with column defs |
| Manual text color for status | `XDSBadge` (success/neutral) |
| 4 StyleX style blocks (table, th, td, row) | Zero — all handled by XDSTable |
| `@stylexjs/stylex` import | Removed |

### Blank template
Already clean XDS — no changes needed.

### Result
- **-86 lines removed**, +45 added (net -41)
- Zero raw HTML `<div>` for layout/presentation
- Zero manual StyleX in templates
- Templates now dogfood the components they're scaffolding for users

---
