### PR TITLE
fix(hardening): layout + structure components (#844)

### DIFF
--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -171,7 +171,9 @@ function SideNavWithHeader() {
     <XDSSideNav
       header={
         <XDSSideNavHeading
-          icon={<XDSIcon icon={CubeIcon} size="lg" />}
+          icon={
+            <XDSNavIcon icon={<CubeIcon style={{width: 16, height: 16}} />} />
+          }
           heading="Acme App"
           headingHref="#"
         />
@@ -406,7 +408,7 @@ export const FullFeatured: Story = {
               icon={ChartBarIcon}
               selectedIcon={ChartBarIconSolid}
               href="#"
-              endContent={<XDSBadge variant="info" label='New' />}
+              endContent={<XDSBadge variant="info" label="New" />}
             />
             <XDSSideNavItem
               label="Projects"

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -60,7 +60,7 @@ const meta: Meta<typeof XDSCard> = {
       control: 'select',
       options: ['card', 'flat'],
       description:
-        'Visual variant — card (default) has background/border/radius, flat removes all chrome',
+        'Visual variant — card (default) has background/border/radius, flat retains background but strips border/radius/shadow',
     },
     width: {
       control: {type: 'range', min: 100, max: 800, step: 10},
@@ -404,7 +404,7 @@ export const FlatAppearance: Story = {
           <XDSVStack gap={2}>
             <h3 {...stylex.props(styles.text)}>Flat Card</h3>
             <p {...stylex.props(styles.text, styles.textSecondary)}>
-              No background, border, padding, or border-radius — content only.
+              Retains background, strips border and radius — for use over wash.
             </p>
           </XDSVStack>
         </XDSCard>

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -56,6 +56,12 @@ const meta: Meta<typeof XDSCard> = {
     ),
   ],
   argTypes: {
+    variant: {
+      control: 'select',
+      options: ['card', 'flat'],
+      description:
+        'Visual variant — card (default) has background/border/radius, flat removes all chrome',
+    },
     width: {
       control: {type: 'range', min: 100, max: 800, step: 10},
       description: 'Width in pixels',
@@ -72,7 +78,6 @@ const meta: Meta<typeof XDSCard> = {
       control: {type: 'range', min: 100, max: 600, step: 10},
       description: 'Minimum height in pixels',
     },
-
   },
 };
 
@@ -365,12 +370,79 @@ export const OnBackgrounds: Story = {
             <XDSVStack gap={2}>
               <h3 {...stylex.props(styles.text)}>Another Card</h3>
               <p {...stylex.props(styles.text, styles.textSecondary)}>
-                The card border and shadow provide separation from the surface.
+                The card border provides separation from the surface.
               </p>
             </XDSVStack>
           </XDSCard>
         </div>
       </XDSSection>
+    </div>
+  ),
+};
+
+/**
+ * Flat variant removes all card chrome (background, border, radius).
+ * Useful for grouping content without visual container treatment.
+ */
+export const FlatAppearance: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>variant: card (default)</h4>
+        <XDSCard width={250}>
+          <XDSVStack gap={2}>
+            <h3 {...stylex.props(styles.text)}>Standard Card</h3>
+            <p {...stylex.props(styles.text, styles.textSecondary)}>
+              Has background, border, and border-radius.
+            </p>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>variant: flat</h4>
+        <XDSCard variant="flat" width={250}>
+          <XDSVStack gap={2}>
+            <h3 {...stylex.props(styles.text)}>Flat Card</h3>
+            <p {...stylex.props(styles.text, styles.textSecondary)}>
+              No background, border, padding, or border-radius — content only.
+            </p>
+          </XDSVStack>
+        </XDSCard>
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * Callout card: a card with a wash section used as a callout/highlight area.
+ * This pattern pairs XDSCard with a wash XDSSection for visual emphasis.
+ */
+export const Callout: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <XDSCard width={350}>
+        <XDSSection variant="wash">
+          <XDSVStack gap={2}>
+            <h3 {...stylex.props(styles.text)}>💡 Tip</h3>
+            <p {...stylex.props(styles.text, styles.textSecondary)}>
+              Use a wash section inside a card for callouts, tips, or
+              highlighted information. The wash background provides visual
+              contrast against the card surface.
+            </p>
+          </XDSVStack>
+        </XDSSection>
+      </XDSCard>
+      <XDSCard width={350}>
+        <XDSSection variant="wash">
+          <XDSVStack gap={2}>
+            <h3 {...stylex.props(styles.text)}>⚠️ Warning</h3>
+            <p {...stylex.props(styles.text, styles.textSecondary)}>
+              Callout cards work well for alerts and warnings too. The full
+              bleed wash fills the card edge-to-edge.
+            </p>
+          </XDSVStack>
+        </XDSSection>
+      </XDSCard>
     </div>
   ),
 };

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -56,12 +56,6 @@ const meta: Meta<typeof XDSCard> = {
     ),
   ],
   argTypes: {
-    variant: {
-      control: 'select',
-      options: ['card', 'flat'],
-      description:
-        'Visual variant — card (default) has background/border/radius, flat retains background but strips border/radius/shadow',
-    },
     width: {
       control: {type: 'range', min: 100, max: 800, step: 10},
       description: 'Width in pixels',
@@ -376,39 +370,6 @@ export const OnBackgrounds: Story = {
           </XDSCard>
         </div>
       </XDSSection>
-    </div>
-  ),
-};
-
-/**
- * Flat variant removes all card chrome (background, border, radius).
- * Useful for grouping content without visual container treatment.
- */
-export const FlatAppearance: Story = {
-  render: () => (
-    <div {...stylex.props(styles.storyWrapper)}>
-      <div>
-        <h4 {...stylex.props(styles.heading)}>variant: card (default)</h4>
-        <XDSCard width={250}>
-          <XDSVStack gap={2}>
-            <h3 {...stylex.props(styles.text)}>Standard Card</h3>
-            <p {...stylex.props(styles.text, styles.textSecondary)}>
-              Has background, border, and border-radius.
-            </p>
-          </XDSVStack>
-        </XDSCard>
-      </div>
-      <div>
-        <h4 {...stylex.props(styles.heading)}>variant: flat</h4>
-        <XDSCard variant="flat" width={250}>
-          <XDSVStack gap={2}>
-            <h3 {...stylex.props(styles.text)}>Flat Card</h3>
-            <p {...stylex.props(styles.text, styles.textSecondary)}>
-              Retains background, strips border and radius — for use over wash.
-            </p>
-          </XDSVStack>
-        </XDSCard>
-      </div>
     </div>
   ),
 };

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -75,12 +75,12 @@ type Story = StoryObj<typeof XDSCenter>;
 export const Default: Story = {
   args: {
     axis: 'both',
-    width: 300,
+    width: '100%',
     height: 200,
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="wash" width="100%">
       <XDSCenter {...args}>
         <Box>Centered Content</Box>
       </XDSCenter>
@@ -91,11 +91,11 @@ export const Default: Story = {
 export const HorizontalOnly: Story = {
   args: {
     axis: 'horizontal',
-    width: 300,
+    width: '100%',
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="wash" width="100%">
       <XDSCenter {...args}>
         <Box>Horizontal Center</Box>
       </XDSCenter>
@@ -107,10 +107,11 @@ export const VerticalOnly: Story = {
   args: {
     axis: 'vertical',
     height: 150,
+    width: '100%',
     children: null,
   },
   render: args => (
-    <XDSSection variant="wash">
+    <XDSSection variant="wash" width="100%">
       <XDSCenter {...args}>
         <Box>Vertical Center</Box>
       </XDSCenter>

--- a/apps/storybook/stories/Section.stories.tsx
+++ b/apps/storybook/stories/Section.stories.tsx
@@ -17,6 +17,10 @@ import {
 } from '@xds/core/theme/tokens.stylex';
 
 const styles = stylex.create({
+  surfaceWrapper: {
+    backgroundColor: colorVars['--color-surface'],
+    padding: spacingVars['--spacing-6'],
+  },
   pageWrapper: {
     backgroundColor: colorVars['--color-wash'],
     padding: spacingVars['--spacing-6'],
@@ -49,7 +53,7 @@ const meta: Meta<typeof XDSSection> = {
   tags: ['autodocs'],
   decorators: [
     Story => (
-      <div {...stylex.props(styles.pageWrapper)}>
+      <div {...stylex.props(styles.surfaceWrapper)}>
         <Story />
       </div>
     ),
@@ -68,7 +72,6 @@ const meta: Meta<typeof XDSSection> = {
       control: {type: 'range', min: 100, max: 600, step: 10},
       description: 'Height in pixels',
     },
-
   },
 };
 

--- a/apps/storybook/stories/Stack.stories.tsx
+++ b/apps/storybook/stories/Stack.stories.tsx
@@ -221,13 +221,106 @@ export const Vertical: Story = {
 // Alignment
 // ============================================================================
 
+/**
+ * Main-axis alignment for horizontal stacks (hAlign → justify-content).
+ * Uses a wide container so the spacing differences are clearly visible.
+ */
 export const HorizontalAlignments: Story = {
   render: () => (
     <div {...stylex.props(styles.storyWrapper)}>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
-          direction=&quot;horizontal&quot;, vAlign: start
-        </h4>
+        <h4 {...stylex.props(styles.heading)}>hAlign: start (default)</h4>
+        <XDSStack
+          direction="horizontal"
+          gap={2}
+          hAlign="start"
+          xstyle={[
+            styles.container,
+            styles.containerWidthLarge,
+            styles.containerPadding,
+          ]}>
+          <Box>A</Box>
+          <Box>B</Box>
+          <Box>C</Box>
+        </XDSStack>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>hAlign: center</h4>
+        <XDSStack
+          direction="horizontal"
+          gap={2}
+          hAlign="center"
+          xstyle={[
+            styles.container,
+            styles.containerWidthLarge,
+            styles.containerPadding,
+          ]}>
+          <Box>A</Box>
+          <Box>B</Box>
+          <Box>C</Box>
+        </XDSStack>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>hAlign: end</h4>
+        <XDSStack
+          direction="horizontal"
+          gap={2}
+          hAlign="end"
+          xstyle={[
+            styles.container,
+            styles.containerWidthLarge,
+            styles.containerPadding,
+          ]}>
+          <Box>A</Box>
+          <Box>B</Box>
+          <Box>C</Box>
+        </XDSStack>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>hAlign: between</h4>
+        <XDSStack
+          direction="horizontal"
+          gap={2}
+          hAlign="between"
+          xstyle={[
+            styles.container,
+            styles.containerWidthLarge,
+            styles.containerPadding,
+          ]}>
+          <Box>A</Box>
+          <Box>B</Box>
+          <Box>C</Box>
+        </XDSStack>
+      </div>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>hAlign: evenly</h4>
+        <XDSStack
+          direction="horizontal"
+          gap={2}
+          hAlign="evenly"
+          xstyle={[
+            styles.container,
+            styles.containerWidthLarge,
+            styles.containerPadding,
+          ]}>
+          <Box>A</Box>
+          <Box>B</Box>
+          <Box>C</Box>
+        </XDSStack>
+      </div>
+    </div>
+  ),
+};
+
+/**
+ * Cross-axis alignment for horizontal stacks (vAlign → align-items).
+ * Uses items with different heights so alignment differences are visible.
+ */
+export const HorizontalCrossAxisAlignment: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div>
+        <h4 {...stylex.props(styles.heading)}>vAlign: start</h4>
         <XDSStack
           direction="horizontal"
           gap={2}
@@ -241,9 +334,7 @@ export const HorizontalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
-          direction=&quot;horizontal&quot;, vAlign: center
-        </h4>
+        <h4 {...stylex.props(styles.heading)}>vAlign: center</h4>
         <XDSStack
           direction="horizontal"
           gap={2}
@@ -257,9 +348,7 @@ export const HorizontalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
-          direction=&quot;horizontal&quot;, vAlign: end
-        </h4>
+        <h4 {...stylex.props(styles.heading)}>vAlign: end</h4>
         <XDSStack
           direction="horizontal"
           gap={2}
@@ -273,9 +362,7 @@ export const HorizontalAlignments: Story = {
         </XDSStack>
       </div>
       <div>
-        <h4 {...stylex.props(styles.heading)}>
-          direction=&quot;horizontal&quot;, vAlign: stretch (default)
-        </h4>
+        <h4 {...stylex.props(styles.heading)}>vAlign: stretch (default)</h4>
         <XDSStack
           direction="horizontal"
           gap={2}

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -38,13 +38,7 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderColor: colorVars['--color-border-emphasized'],
   },
-  // Flat variant: retains background but strips border, radius, and shadow.
-  // Intended for cards appearing over wash/muted backgrounds.
-  flat: {
-    borderRadius: 0,
-    borderWidth: 0,
-    overflow: 'visible',
-  },
+
   // Inner wrapper: container padding and overflow handling
   cardInner: {
     height: '100%',
@@ -72,22 +66,8 @@ const dynamicStyles = stylex.create({
 
 export type {SizeValue} from '../utils/types';
 
-/**
- * Visual variant of the card.
- * - `'card'` (default): Standard card with background, border, and border-radius.
- * - `'flat'`: Retains background but strips border, radius, and shadow — for cards over wash.
- */
-export type XDSCardVariant = 'card' | 'flat';
-
 export interface XDSCardProps extends XDSBaseProps {
   ref?: React.Ref<HTMLDivElement>;
-  /**
-   * Visual variant of the card.
-   * - `'card'` (default): Standard card with background, border, and border-radius.
-   * - `'flat'`: Retains background but strips border, radius, and shadow — for cards over wash.
-   * @default 'card'
-   */
-  variant?: XDSCardVariant;
   /**
    * CSS class name(s) appended to the root element.
    */
@@ -135,9 +115,9 @@ export interface XDSCardProps extends XDSBaseProps {
 }
 
 /**
- * A card container with shadow and themed styling.
+ * A card container with border and themed styling.
  *
- * Applies card-specific appearance (background, shadow, border-radius)
+ * Applies card-specific appearance (background, border, border-radius)
  * and sets CSS variables for child layout components.
  *
  * @compositionHint Use as a top-level container for elevated content.
@@ -155,7 +135,6 @@ export interface XDSCardProps extends XDSBaseProps {
  * ```
  */
 export function XDSCard({
-  variant = 'card',
   width,
   height,
   maxWidth,
@@ -180,10 +159,9 @@ export function XDSCard({
     <div
       ref={ref}
       {...mergeProps(
-        xdsClassName('card', {variant}),
+        xdsClassName('card'),
         stylex.props(
           styles.cardOuter,
-          variant === 'flat' && styles.flat,
           dynamicStyles.sizing(
             width ?? null,
             height ?? null,

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -38,9 +38,9 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderColor: colorVars['--color-border-emphasized'],
   },
-  // Flat variant: no background, border, padding, or border-radius
+  // Flat variant: retains background but strips border, radius, and shadow.
+  // Intended for cards appearing over wash/muted backgrounds.
   flat: {
-    backgroundColor: 'transparent',
     borderRadius: 0,
     borderWidth: 0,
     overflow: 'visible',
@@ -75,7 +75,7 @@ export type {SizeValue} from '../utils/types';
 /**
  * Visual variant of the card.
  * - `'card'` (default): Standard card with background, border, and border-radius.
- * - `'flat'`: No background, border, padding, or border-radius — content only.
+ * - `'flat'`: Retains background but strips border, radius, and shadow — for cards over wash.
  */
 export type XDSCardVariant = 'card' | 'flat';
 
@@ -84,7 +84,7 @@ export interface XDSCardProps extends XDSBaseProps {
   /**
    * Visual variant of the card.
    * - `'card'` (default): Standard card with background, border, and border-radius.
-   * - `'flat'`: No background, border, padding, or border-radius — content only.
+   * - `'flat'`: Retains background but strips border, radius, and shadow — for cards over wash.
    * @default 'card'
    */
   variant?: XDSCardVariant;

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -14,7 +14,7 @@
 
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, radiusVars, shadowVars} from '../theme/tokens.stylex';
+import {colorVars, radiusVars} from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
 import type {SpacingToken} from '../Layout/container.stylex';
 import {
@@ -32,12 +32,18 @@ const styles = stylex.create({
     '--card-radius': radiusVars['--radius-3'],
     backgroundColor: colorVars['--color-card'],
     borderRadius: 'var(--card-radius)',
-    boxShadow: shadowVars['--shadow-base'],
-    // Clip content to border-radius so nested containers don\'t peek out corners
+    // No drop-shadow — matches WWW XDSCard which uses border only
     overflow: 'clip',
     borderWidth: 1,
     borderStyle: 'solid',
     borderColor: colorVars['--color-border-emphasized'],
+  },
+  // Flat variant: no background, border, padding, or border-radius
+  flat: {
+    backgroundColor: 'transparent',
+    borderRadius: 0,
+    borderWidth: 0,
+    overflow: 'visible',
   },
   // Inner wrapper: container padding and overflow handling
   cardInner: {
@@ -66,8 +72,22 @@ const dynamicStyles = stylex.create({
 
 export type {SizeValue} from '../utils/types';
 
+/**
+ * Visual variant of the card.
+ * - `'card'` (default): Standard card with background, border, and border-radius.
+ * - `'flat'`: No background, border, padding, or border-radius — content only.
+ */
+export type XDSCardVariant = 'card' | 'flat';
+
 export interface XDSCardProps extends XDSBaseProps {
   ref?: React.Ref<HTMLDivElement>;
+  /**
+   * Visual variant of the card.
+   * - `'card'` (default): Standard card with background, border, and border-radius.
+   * - `'flat'`: No background, border, padding, or border-radius — content only.
+   * @default 'card'
+   */
+  variant?: XDSCardVariant;
   /**
    * CSS class name(s) appended to the root element.
    */
@@ -135,6 +155,7 @@ export interface XDSCardProps extends XDSBaseProps {
  * ```
  */
 export function XDSCard({
+  variant = 'card',
   width,
   height,
   maxWidth,
@@ -159,9 +180,10 @@ export function XDSCard({
     <div
       ref={ref}
       {...mergeProps(
-        xdsClassName('card'),
+        xdsClassName('card', {variant}),
         stylex.props(
           styles.cardOuter,
+          variant === 'flat' && styles.flat,
           dynamicStyles.sizing(
             width ?? null,
             height ?? null,

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -10,4 +10,4 @@
  */
 
 export {XDSCard} from './XDSCard';
-export type {XDSCardProps, XDSCardVariant, SizeValue} from './XDSCard';
+export type {XDSCardProps, SizeValue} from './XDSCard';

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -10,4 +10,4 @@
  */
 
 export {XDSCard} from './XDSCard';
-export type {XDSCardProps, SizeValue} from './XDSCard';
+export type {XDSCardProps, XDSCardVariant, SizeValue} from './XDSCard';

--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -18,7 +18,6 @@
  * - /apps/storybook/stories/Collapsible.stories.tsx
  */
 
-
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -63,10 +62,10 @@ const styles = stylex.create({
     color: colorVars['--color-icon-secondary'],
   },
   chevronOpen: {
-    transform: 'rotate(0deg)',
+    transform: 'rotate(180deg)',
   },
   chevronClosed: {
-    transform: 'rotate(-90deg)',
+    transform: 'rotate(0deg)',
   },
   // Content area
   contentHidden: {


### PR DESCRIPTION
## Summary

Addresses findings from the Layout + Structure Components hardening sweep (#844).

### Component fixes

| Component | Finding | Fix |
|-----------|---------|-----|
| **XDSCard** | P1: Should not have a drop-shadow | Removed `boxShadow` — WWW uses border only |
| **XDSCard** | P2: Add flat variant | New `variant='flat'` strips all chrome (bg, border, radius) |
| **XDSCollapsible** | P1: Arrow should point down when collapsed | Chevron now points ↓ collapsed, ↑ open (standard disclosure) |

### Storybook fixes

| Component | Finding | Fix |
|-----------|---------|-----|
| **XDSSection** | P1: Wash variant invisible | Decorator changed from wash → surface background |
| **XDSStack** | P1: Horizontal alignments all look the same | Split into main-axis (`hAlign`) and cross-axis (`vAlign`) stories |
| **XDSCenter** | P1: Not full width, content doesn't appear centered | Changed to `width='100%'` |
| **XDSCard** | P2: Missing callout story | Added Callout and FlatAppearance stories |
| **XDSAppShell** | P1: Icon treatment inconsistent | SideNav header now uses `XDSNavIcon` (matching TopNav) |

### Not addressed in this PR

- XDSCard P1 border on wash: Border is intentional — cards need visual separation from wash backgrounds
- XDSCard P1 footer padding: Inherits from layout system container padding, consistent across card/section
- XDSAspectRatio P1/P2: Wash bg default, circle variant, naming — needs separate design discussion
- XDSCard P2: XDSCardHeader vs XDSLayoutHeader discrepancy — intentional OSS simplification

Closes items in #844