### PR TITLE
fix(ListItem): use fixed inline padding (8px default, 12px spacious)

### DIFF
--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -254,6 +254,7 @@ const densityStyles = stylex.create({
   },
   spacious: {
     paddingBlock: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-3'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-normal'],
   },

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/List.stories.tsx
  */
 
-
 import {useContext, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -124,6 +123,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
     position: 'relative',
     boxSizing: 'border-box',
     textAlign: 'start',
@@ -132,6 +132,7 @@ const styles = stylex.create({
   // so the browser renders the ::marker. Flex layout moves to inner wrapper.
   itemWithMarker: {
     display: 'list-item',
+    paddingInline: spacingVars['--spacing-2'],
     position: 'relative',
     boxSizing: 'border-box',
     textAlign: 'start',
@@ -243,19 +244,16 @@ const styles = stylex.create({
 const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   spacious: {
     paddingBlock: spacingVars['--spacing-3'],
-    paddingInline: spacingVars['--spacing-4'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-normal'],
   },

--- a/packages/core/src/TreeList/XDSTreeListItem.tsx
+++ b/packages/core/src/TreeList/XDSTreeListItem.tsx
@@ -11,7 +11,6 @@
  * - /packages/core/src/TreeList/XDSTreeList.tsx
  */
 
-
 import {useId, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -68,6 +67,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-2'],
     outline: 'none',
     overflow: 'hidden',
     position: 'relative',
@@ -196,19 +196,17 @@ const styles = stylex.create({
 const densityStyles = stylex.create({
   compact: {
     paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   balanced: {
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-snug'],
   },
   spacious: {
     paddingBlock: spacingVars['--spacing-3'],
-    paddingInline: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-3'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: lineHeightVars['--leading-normal'],
   },


### PR DESCRIPTION
## Summary

XDSListItem and XDSTreeListItem now have fixed horizontal padding: 8px for compact/balanced, 12px for spacious.

### Before
| Density | paddingInline |
|---------|--------------|
| compact | 8px (`--spacing-2`) |
| balanced | 12px (`--spacing-3`) |
| spacious | 16px (`--spacing-4`) |

### After
| Density | paddingInline |
|---------|--------------|
| compact | **8px** (`--spacing-2`) |
| balanced | **8px** (`--spacing-2`) |
| spacious | **12px** (`--spacing-3`) |

### Changes
**XDSListItem:**
- Added `paddingInline: spacingVars['--spacing-2']` to the base `item` and `itemWithMarker` styles
- Removed `paddingInline` from compact and balanced `densityStyles`
- Spacious density keeps an explicit 12px (`--spacing-3`) override

**XDSTreeListItem:**
- Added `paddingInline: spacingVars['--spacing-2']` to the base `contentWrapper` style
- Same density pattern: compact/balanced inherit 8px, spacious overrides to 12px

Vertical padding (`paddingBlock`) still scales with density as before in both components.

### Test
- All 43 List tests pass
- All 29 TreeList tests pass

---
