### PR TITLE
fix(Button): prevent text wrap in constrained layouts

### DIFF
--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -240,3 +240,52 @@ export const AllVariants: Story = {
     </div>
   ),
 };
+
+/**
+ * Demonstrates button text truncation in constrained containers.
+ * When a button's container is narrower than the button's natural width,
+ * the label truncates with an ellipsis instead of wrapping to multiple lines.
+ */
+export const Truncation: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '16px'}}>
+      <div>
+        <p style={{fontSize: 12, color: '#666', marginBottom: 8}}>
+          200px container — label truncates with ellipsis
+        </p>
+        <div style={{width: 200, border: '1px dashed #ccc', padding: 4}}>
+          <XDSButton
+            label="A very long button label that overflows"
+            variant="primary"
+            icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
+          />
+        </div>
+      </div>
+      <div>
+        <p style={{fontSize: 12, color: '#666', marginBottom: 8}}>
+          Flex row with limited space — button shrinks gracefully
+        </p>
+        <div style={{display: 'flex', gap: 8, maxWidth: 320}}>
+          <div style={{flex: 1, minWidth: 0}}>
+            <XDSButton
+              label="Submit this extremely long form action"
+              variant="primary"
+              xstyle={{width: '100%'}}
+            />
+          </div>
+          <XDSButton label="Cancel" variant="secondary" />
+        </div>
+      </div>
+      <div>
+        <p style={{fontSize: 12, color: '#666', marginBottom: 8}}>
+          Unconstrained — renders at natural width
+        </p>
+        <XDSButton
+          label="A very long button label that shows fully"
+          variant="primary"
+          icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
+        />
+      </div>
+    </div>
+  ),
+};

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -58,6 +58,7 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-label-size'],
     lineHeight: lineHeightVars['--leading-base'],
     fontWeight: fontWeightVars['--font-weight-medium'],
+    whiteSpace: 'nowrap',
     cursor: 'pointer',
     transitionProperty: 'background-image, transform',
     transitionDuration: {
@@ -100,6 +101,11 @@ const styles = stylex.create({
   },
   contentWrapper: {
     display: 'contents',
+  },
+  labelText: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    minWidth: 0,
   },
   visuallyHidden: {
     position: 'absolute',
@@ -489,7 +495,9 @@ export function XDSButton({
         {...stylex.props(styles.contentWrapper)}
         aria-hidden={isLoadingState || undefined}>
         {icon}
-        {children ?? (isIconOnly ? null : label)}
+        {isIconOnly ? null : (
+          <span {...stylex.props(styles.labelText)}>{children ?? label}</span>
+        )}
         {!isIconOnly && endSlot && (
           <span {...stylex.props(styles.endSlotWrapper)}>{endSlot}</span>
         )}


### PR DESCRIPTION
## Problem

Button text wraps to a second line when placed in constrained flex layouts, causing the icon to appear disproportionately large.

Spotted by @cixzhang in #888 — the "New item" button in the WithActions TabList story wraps at narrow viewports:

![Screenshot](https://github.com/user-attachments/assets/e95d6bf9-fc3c-47d8-9ce9-556f37261640)

## Fix

Two changes to the button base styles:

1. **`whiteSpace: 'nowrap'`** on the button container — prevents text from wrapping to a second line
2. **Label text wrapper** with `overflow: hidden` + `textOverflow: ellipsis` — so constrained buttons truncate with an ellipsis instead of clipping silently

## Story

Adds a `Truncation` story to `Core/XDSButton` demonstrating:
- 200px container with a long label → truncates with ellipsis
- Flex row with limited space → button shrinks gracefully
- Unconstrained → renders at natural width

---
