### PR TITLE
fix(Button,DropdownMenu): rename endSlot → endContent, fix icon-only dropdown trigger

### DIFF
--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof XDSButton> = {
       control: 'boolean',
       description: 'Disabled state',
     },
-    endSlot: {
+    endContent: {
       control: false,
       description: 'Content rendered after the label (e.g. icon, badge)',
     },
@@ -136,12 +136,12 @@ export const WithEndSlot: Story = {
       <XDSButton
         label="Messages"
         variant="primary"
-        endSlot={<XDSBadge variant="info" label={3} />}
+        endContent={<XDSBadge variant="info" label={3} />}
       />
       <XDSButton
         label="Notifications"
         variant="secondary"
-        endSlot={<XDSBadge variant="neutral" label="New" />}
+        endContent={<XDSBadge variant="neutral" label="New" />}
       />
     </div>
   ),
@@ -154,14 +154,14 @@ export const IconAndEndSlot: Story = {
         label="Settings"
         variant="secondary"
         icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
-        endSlot={<XDSBadge variant="info" label="New" />}>
+        endContent={<XDSBadge variant="info" label="New" />}>
         Settings
       </XDSButton>
       <XDSButton
         label="Delete"
         variant="destructive"
         icon={<TrashIcon style={{width: 16, height: 16}} />}
-        endSlot={<XDSBadge variant="error" label={5} />}>
+        endContent={<XDSBadge variant="error" label={5} />}>
         Delete
       </XDSButton>
     </div>
@@ -222,18 +222,18 @@ export const AllVariants: Story = {
         <XDSButton
           label="With Badge"
           variant="primary"
-          endSlot={<XDSBadge variant="info" label={3} />}
+          endContent={<XDSBadge variant="info" label={3} />}
         />
         <XDSButton
           label="With Badge"
           variant="secondary"
-          endSlot={<XDSBadge variant="neutral" label="New" />}
+          endContent={<XDSBadge variant="neutral" label="New" />}
         />
         <XDSButton
           label="Icon + Badge"
           variant="ghost"
           icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
-          endSlot={<XDSBadge variant="info" label={5} />}>
+          endContent={<XDSBadge variant="info" label={5} />}>
           Settings
         </XDSButton>
       </div>

--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -11,6 +11,8 @@ import {
   FolderPlusIcon,
   DocumentPlusIcon,
   UserIcon,
+  EllipsisHorizontalIcon,
+  Cog6ToothIcon,
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof XDSDropdownMenu> = {
@@ -297,5 +299,72 @@ export const CustomItemRender: Story = {
         />
       )}
     </XDSDropdownMenu>
+  ),
+};
+
+// Icon-only trigger — renders as a square icon button (e.g., "⋯" menu)
+export const IconOnly: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: 16, alignItems: 'center'}}>
+      <XDSDropdownMenu
+        button={{
+          label: 'More options',
+          icon: <EllipsisHorizontalIcon />,
+          variant: 'ghost',
+        }}
+        items={[
+          {label: 'Edit', icon: PencilIcon, onClick: () => console.log('Edit')},
+          {
+            label: 'Delete',
+            icon: TrashIcon,
+            onClick: () => console.log('Delete'),
+          },
+        ]}
+      />
+      <XDSDropdownMenu
+        button={{
+          label: 'Settings',
+          icon: <Cog6ToothIcon />,
+          variant: 'secondary',
+        }}
+        items={[
+          {label: 'Preferences', onClick: () => console.log('Preferences')},
+          {label: 'Account', onClick: () => console.log('Account')},
+        ]}
+      />
+    </div>
+  ),
+};
+
+// Icon + label together — pass children on button to get visible text with icon
+export const IconWithLabel: Story = {
+  render: () => (
+    <XDSDropdownMenu
+      button={{
+        label: 'Settings',
+        icon: <Cog6ToothIcon />,
+        variant: 'ghost',
+        children: 'Settings',
+      }}
+      items={[
+        {label: 'Preferences', onClick: () => console.log('Preferences')},
+        {label: 'Account', onClick: () => console.log('Account')},
+      ]}
+    />
+  ),
+};
+
+// No chevron — label-only trigger without dropdown indicator
+export const NoChevron: Story = {
+  render: () => (
+    <XDSDropdownMenu
+      button={{label: 'Sort by: Name', variant: 'ghost'}}
+      hasChevron={false}
+      items={[
+        {label: 'Name', onClick: () => console.log('Name')},
+        {label: 'Date', onClick: () => console.log('Date')},
+        {label: 'Size', onClick: () => console.log('Size')},
+      ]}
+    />
   ),
 };

--- a/packages/cli/src/codemods/registry.mjs
+++ b/packages/cli/src/codemods/registry.mjs
@@ -9,6 +9,7 @@ const registry = new Map([
   ['0.0.2', () => import('./transforms/v0.0.2/index.mjs')],
   ['0.0.6', () => import('./transforms/v0.0.6/index.mjs')],
   ['0.0.7', () => import('./transforms/v0.0.7/index.mjs')],
+  ['0.0.8', () => import('./transforms/v0.0.8/index.mjs')],
 ]);
 
 /**

--- a/packages/cli/src/codemods/transforms/v0.0.8/__tests__/rename-endslot-to-endcontent.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.8/__tests__/rename-endslot-to-endcontent.test.mjs
@@ -1,0 +1,96 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source, filePath = 'test.tsx') {
+  const {default: transform} = await import(
+    '../rename-endslot-to-endcontent.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const j = filePath.endsWith('.ts') || filePath.endsWith('.tsx')
+    ? jscodeshift.withParser('tsx')
+    : jscodeshift;
+  const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+  const file = {source, path: filePath};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('rename-endslot-to-endcontent', () => {
+  // JSX prop renames
+  it('renames endSlot to endContent on XDSButton', async () => {
+    const input = '<XDSButton label="Messages" endSlot={<XDSBadge label={3} />} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent={<XDSBadge label={3} />}');
+    expect(output).not.toContain('endSlot');
+  });
+
+  it('handles endSlot with expression values', async () => {
+    const input = '<XDSButton label="Edit" endSlot={badge} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent={badge}');
+  });
+
+  it('preserves other props', async () => {
+    const input = '<XDSButton label="Edit" icon={<PencilIcon />} endSlot={<XDSBadge label="New" />}>Edit</XDSButton>';
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent=');
+    expect(output).toContain('label="Edit"');
+    expect(output).toContain('icon={<PencilIcon />}');
+    expect(output).toContain('>Edit</XDSButton>');
+  });
+
+  it('does not rename endContent (already migrated)', async () => {
+    const input = '<XDSButton label="Messages" endContent={<XDSBadge label={3} />} />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  // Object property renames (e.g., DropdownMenu button prop)
+  it('renames endSlot in object literals', async () => {
+    const input = `<XDSDropdownMenu button={{ label: "Actions", endSlot: <XDSBadge label={3} /> }} items={[]} />`;
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent:');
+    expect(output).not.toContain('endSlot');
+  });
+
+  it('renames endSlot in standalone objects', async () => {
+    const input = `const props = { label: "Test", endSlot: badge };`;
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent: badge');
+    expect(output).not.toContain('endSlot');
+  });
+
+  // Destructuring renames
+  it('renames endSlot in destructuring (shorthand)', async () => {
+    const input = `const { label, endSlot } = props;`;
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent');
+    expect(output).not.toContain('endSlot');
+  });
+
+  it('renames endSlot in destructuring (with rename)', async () => {
+    const input = `const { endSlot: mySlot } = props;`;
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent: mySlot');
+    expect(output).not.toContain('endSlot');
+  });
+
+  // Should not touch unrelated components
+  it('renames endSlot on any component (covers wrappers)', async () => {
+    const input = '<MyButton endSlot={<Icon />} />';
+    const output = await applyTransform(input);
+    expect(output).toContain('endContent=');
+  });
+
+  // No-op
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import(
+      '../rename-endslot-to-endcontent.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const j = jscodeshift.withParser('tsx');
+    const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+    const source = '<XDSButton label="Messages" endContent={<XDSBadge label={3} />} />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.8/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.8/index.mjs
@@ -1,0 +1,17 @@
+/**
+ * @file v0.0.8 transform manifest
+ *
+ * Lists all codemods for the v0.0.8 release in the order they should run.
+ */
+
+import renameEndSlotToEndContent, {
+  meta as endSlotMeta,
+} from './rename-endslot-to-endcontent.mjs';
+
+export default [
+  {
+    name: 'rename-endslot-to-endcontent',
+    transform: renameEndSlotToEndContent,
+    meta: endSlotMeta,
+  },
+];

--- a/packages/cli/src/codemods/transforms/v0.0.8/rename-endslot-to-endcontent.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.8/rename-endslot-to-endcontent.mjs
@@ -1,0 +1,57 @@
+/**
+ * @file Codemod: Rename XDSButton endSlot to endContent
+ * @see https://github.com/facebookexperimental/xds/pull/895
+ *
+ * XDSButton's `endSlot` prop was renamed to `endContent` to align with
+ * the naming convention used by all other XDS components (ListItem,
+ * Banner, Dialog, SideNav, Token, TopNav). The type was also widened
+ * from `ReactElement<XDSIconProps | XDSBadgeProps>` to `ReactNode`.
+ *
+ * This codemod handles:
+ * 1. JSX prop rename: <XDSButton endSlot={...} /> → <XDSButton endContent={...} />
+ * 2. Object property rename in spread patterns: { endSlot: ... } → { endContent: ... }
+ *    (covers DropdownMenu button prop objects like `button={{ endSlot: <Badge /> }}`)
+ * 3. Destructuring rename: const { endSlot } = props → const { endContent } = props
+ */
+
+export const meta = {
+  title: 'Rename Button endSlot → endContent',
+  description:
+    'Renames the `endSlot` prop on XDSButton to `endContent`. Also renames `endSlot` in object literals passed to components that forward props to XDSButton (e.g., XDSDropdownMenu button prop).',
+  pr: '#895',
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // 1. Rename JSX prop: <XDSButton endSlot={...} /> → <XDSButton endContent={...} />
+  root.find(j.JSXAttribute, {name: {name: 'endSlot'}}).forEach((path) => {
+    path.node.name.name = 'endContent';
+    hasChanges = true;
+  });
+
+  // 2. Rename in all Identifier nodes named 'endSlot' that are object keys
+  //    This covers both Property and ObjectProperty (parser-dependent),
+  //    object literals, destructuring patterns, etc.
+  root.find(j.Identifier, {name: 'endSlot'}).forEach((path) => {
+    const parent = path.parent.node;
+
+    // Object property key: { endSlot: value } or { endSlot } (shorthand)
+    const isPropertyKey =
+      (parent.type === 'Property' || parent.type === 'ObjectProperty') &&
+      parent.key === path.node;
+
+    if (isPropertyKey) {
+      path.node.name = 'endContent';
+      // If shorthand, also rename the value identifier
+      if (parent.shorthand && parent.value?.type === 'Identifier' && parent.value.name === 'endSlot') {
+        parent.value.name = 'endContent';
+      }
+      hasChanges = true;
+    }
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -83,7 +83,7 @@ export const docs = {
         'Button content. When provided alongside icon, the text is rendered next to the icon.',
     },
     {
-      name: 'endSlot',
+      name: 'endContent',
       type: 'ReactElement<XDSIconProps> | ReactElement<XDSBadgeProps>',
       description:
         'Trailing icon or badge rendered after the label. Only accepts <XDSIcon> or <XDSBadge>. Ignored for icon-only buttons. Color is inherited from the button variant.',
@@ -138,16 +138,16 @@ export const docs = {
       code: '<XDSButton label="Edit" icon={<PencilIcon />}>Edit</XDSButton>',
     },
     {
-      label: 'endSlot — badge after label',
-      code: '<XDSButton label="Messages" endSlot={<XDSBadge label={3} />} />',
+      label: 'endContent — badge after label',
+      code: '<XDSButton label="Messages" endContent={<XDSBadge label={3} />} />',
     },
     {
-      label: 'endSlot — icon, label, and badge',
-      code: '<XDSButton label="Edit" icon={<PencilIcon />} endSlot={<XDSBadge label="New" />}>Edit</XDSButton>',
+      label: 'endContent — icon, label, and badge',
+      code: '<XDSButton label="Edit" icon={<PencilIcon />} endContent={<XDSBadge label="New" />}>Edit</XDSButton>',
     },
     {
-      label: 'endSlot — settings with badge',
-      code: `<XDSButton label="Settings" icon={<GearIcon />} endSlot={<XDSBadge label="New" />}>
+      label: 'endContent — settings with badge',
+      code: `<XDSButton label="Settings" icon={<GearIcon />} endContent={<XDSBadge label="New" />}>
   Settings
 </XDSButton>`,
     },
@@ -179,9 +179,9 @@ export const docs = {
     'XDSButtonVariant type is derived from the variants StyleX object using keyof typeof variants.',
     'Hover/active states use backgroundImage with linear-gradient to layer overlay colors on top of the base background.',
     'Destructive variant uses colorTokens.negative for its focus outline color.',
-    'endSlot is wrapped in a <span> with color: inherit so icons/badges match the button text color across all variants.',
+    'endContent is wrapped in a <span> with color: inherit so icons/badges match the button text color across all variants.',
     'When icon is provided without children, the button becomes icon-only: it renders as a perfect square (aspectRatio: 1/1), and label is used as aria-label (not rendered visually). Works with any ReactNode as the icon — SVG components, emoji, or text.',
-    'endSlot is ignored for icon-only buttons (when icon is provided without children) to preserve the square aspect ratio.',
+    'endContent is ignored for icon-only buttons (when icon is provided without children) to preserve the square aspect ratio.',
     'Prefer XDSButton over <div onClick> or <span onClick> for accessibility — it provides keyboard navigation, focus management, and screen reader support.',
     'Icon-only buttons are suitable for toolbars, action grids, and compact controls.',
     'onClick fires before onClickAction; calling preventDefault in onClick prevents onClickAction from running.',
@@ -274,7 +274,7 @@ export const docsZh = {
         '按钮内容。与 icon 同时提供时，文本渲染在图标旁边。',
     },
     {
-      name: 'endSlot',
+      name: 'endContent',
       type: 'ReactElement<XDSIconProps> | ReactElement<XDSBadgeProps>',
       description:
         '标签后方渲染的尾部图标或徽章。仅接受 <XDSIcon> 或 <XDSBadge>。纯图标按钮时忽略。颜色继承自按钮变体。',
@@ -329,16 +329,16 @@ export const docsZh = {
       code: '<XDSButton label="Edit" icon={<PencilIcon />}>Edit</XDSButton>',
     },
     {
-      label: 'endSlot——标签后的徽章',
-      code: '<XDSButton label="Messages" endSlot={<XDSBadge label={3} />} />',
+      label: 'endContent——标签后的徽章',
+      code: '<XDSButton label="Messages" endContent={<XDSBadge label={3} />} />',
     },
     {
-      label: 'endSlot——图标、标签和徽章',
-      code: '<XDSButton label="Edit" icon={<PencilIcon />} endSlot={<XDSBadge label="New" />}>Edit</XDSButton>',
+      label: 'endContent——图标、标签和徽章',
+      code: '<XDSButton label="Edit" icon={<PencilIcon />} endContent={<XDSBadge label="New" />}>Edit</XDSButton>',
     },
     {
-      label: 'endSlot——带徽章的设置按钮',
-      code: `<XDSButton label="Settings" icon={<GearIcon />} endSlot={<XDSBadge label="New" />}>
+      label: 'endContent——带徽章的设置按钮',
+      code: `<XDSButton label="Settings" icon={<GearIcon />} endContent={<XDSBadge label="New" />}>
   Settings
 </XDSButton>`,
     },
@@ -370,9 +370,9 @@ export const docsZh = {
     'XDSButtonVariant 类型通过 keyof typeof variants 从 variants StyleX 对象派生。',
     '悬停/激活状态使用 backgroundImage 和 linear-gradient 在基础背景上叠加覆盖颜色。',
     'destructive 变体使用 colorTokens.negative 作为焦点轮廓颜色。',
-    'endSlot 包裹在带有 color: inherit 的 <span> 中，使图标/徽章在所有变体中匹配按钮文本颜色。',
+    'endContent 包裹在带有 color: inherit 的 <span> 中，使图标/徽章在所有变体中匹配按钮文本颜色。',
     '仅提供 icon 而不提供 children 时，按钮变为纯图标模式：渲染为正方形（aspectRatio: 1/1），label 用作 aria-label（不可视渲染）。支持任何 ReactNode 作为图标——SVG 组件、emoji 或文本。',
-    '纯图标按钮（提供 icon 但不提供 children 时）会忽略 endSlot，以保持正方形的宽高比。',
+    '纯图标按钮（提供 icon 但不提供 children 时）会忽略 endContent，以保持正方形的宽高比。',
     '为了无障碍性，优先使用 XDSButton 而非 <div onClick> 或 <span onClick>——它提供键盘导航、焦点管理和屏幕阅读器支持。',
     '纯图标按钮适用于工具栏、操作网格和紧凑控件。',
     'onClick 在 onClickAction 之前触发；在 onClick 中调用 preventDefault 会阻止 onClickAction 运行。',
@@ -409,9 +409,9 @@ export const docsDense = {
     'XDSButtonVariant derived from keyof typeof variants StyleX object',
     'hover/active use backgroundImage linear-gradient overlay on base bg',
     'destructive variant uses colorTokens.negative for focus outline',
-    'endSlot wrapped in <span> w/ color:inherit, matches button text across variants',
+    'endContent wrapped in <span> w/ color:inherit, matches button text across variants',
     'icon w/o children=icon-only: square (aspectRatio:1/1), label=aria-label, any ReactNode as icon',
-    'endSlot ignored for icon-only to preserve square ratio',
+    'endContent ignored for icon-only to preserve square ratio',
     'prefer XDSButton over <div onClick> for a11y: keyboard nav, focus management, screen reader',
     'icon-only suits toolbars, action grids, compact controls',
     'onClick fires before onClickAction; preventDefault in onClick stops onClickAction',
@@ -429,7 +429,7 @@ export const docsDense = {
     isLoading: 'shows spinner+disables interaction; announces via live region',
     icon: 'icon element; w/o children renders square icon-only button',
     children: 'w/ icon, text rendered next to icon',
-    endSlot: 'trailing icon/badge after label; accepts XDSIcon or XDSBadge; ignored for icon-only; color inherited',
+    endContent: 'trailing icon/badge after label; accepts XDSIcon or XDSBadge; ignored for icon-only; color inherited',
     tooltip: 'tooltip on hover',
     onClick: 'standard click handler; fires before onClickAction',
     onClickAction: 'async click handler; shows loading while promise pending',

--- a/packages/core/src/Button/XDSButton.test.tsx
+++ b/packages/core/src/Button/XDSButton.test.tsx
@@ -100,12 +100,12 @@ describe('XDSButton', () => {
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLButtonElement));
   });
 
-  // endSlot tests
-  it('renders endSlot after label', () => {
+  // endContent tests
+  it('renders endContent after label', () => {
     render(
       <XDSButton
         label="Click me"
-        endSlot={<XDSBadge data-testid="end" label={3} />}
+        endContent={<XDSBadge data-testid="end" label={3} />}
       />,
     );
     const button = screen.getByRole('button');
@@ -114,11 +114,11 @@ describe('XDSButton', () => {
     expect(screen.getByTestId('end')).toHaveTextContent('3');
   });
 
-  it('renders endSlot with children', () => {
+  it('renders endContent with children', () => {
     render(
       <XDSButton
         label="Accessible name"
-        endSlot={<XDSBadge data-testid="end" label="New" />}>
+        endContent={<XDSBadge data-testid="end" label="New" />}>
         Custom content
       </XDSButton>,
     );
@@ -127,12 +127,12 @@ describe('XDSButton', () => {
     expect(screen.getByTestId('end')).toBeInTheDocument();
   });
 
-  it('renders endSlot with icon and children', () => {
+  it('renders endContent with icon and children', () => {
     render(
       <XDSButton
         label="Settings"
         icon={<span data-testid="icon">⚙</span>}
-        endSlot={<XDSBadge data-testid="end" label="New" />}>
+        endContent={<XDSBadge data-testid="end" label="New" />}>
         Settings
       </XDSButton>,
     );
@@ -142,23 +142,23 @@ describe('XDSButton', () => {
     expect(screen.getByTestId('end')).toBeInTheDocument();
   });
 
-  it('does not render endSlot for icon-only buttons', () => {
+  it('does not render endContent for icon-only buttons', () => {
     render(
       <XDSButton
         label="Settings"
         icon={<span data-testid="icon">⚙</span>}
-        endSlot={<XDSBadge data-testid="end" label={3} />}
+        endContent={<XDSBadge data-testid="end" label={3} />}
       />,
     );
     expect(screen.getByTestId('icon')).toBeInTheDocument();
     expect(screen.queryByTestId('end')).not.toBeInTheDocument();
   });
 
-  it('wraps endSlot in a container for color inheritance', () => {
+  it('wraps endContent in a container for color inheritance', () => {
     render(
       <XDSButton
         label="Test"
-        endSlot={<XDSBadge data-testid="end" label={3} />}
+        endContent={<XDSBadge data-testid="end" label={3} />}
       />,
     );
     const badge = screen.getByTestId('end');
@@ -167,15 +167,15 @@ describe('XDSButton', () => {
     expect(wrapper?.tagName).toBe('SPAN');
   });
 
-  it('hides endSlot content when loading', () => {
+  it('hides endContent content when loading', () => {
     render(
       <XDSButton
         label="Submit"
         isLoading
-        endSlot={<XDSBadge data-testid="end" label={3} />}
+        endContent={<XDSBadge data-testid="end" label={3} />}
       />,
     );
-    // endSlot should still be in the DOM
+    // endContent should still be in the DOM
     expect(screen.getByTestId('end')).toBeInTheDocument();
     // Button should be disabled and have aria-busy
     const button = screen.getByRole('button');

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -12,10 +12,10 @@
  * - /packages/core/src/Button/index.ts (exports if types change)
  * - /apps/storybook/stories/Button.stories.tsx (storybook stories)
  *
- * Last synced props: label, variant, size, isDisabled, isLoading, onClickAction, icon, children, tooltip, endSlot
+ * Last synced props: label, variant, size, isDisabled, isLoading, onClickAction, icon, children, tooltip, endContent
  */
 
-import {useRef, useTransition, type ReactElement, type ReactNode} from 'react';
+import {useRef, useTransition, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -31,8 +31,7 @@ import {
 } from '../theme/tokens.stylex';
 import {XDSTooltip} from '../Tooltip/XDSTooltip';
 import {XDSSpinner} from '../Spinner';
-import type {XDSIconProps} from '../Icon/XDSIcon';
-import type {XDSBadgeProps} from '../Badge/XDSBadge';
+
 import {edgeCompensation} from '../Layout/edgeCompensation.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -94,7 +93,7 @@ const styles = stylex.create({
     aspectRatio: 'var(--button-icon-only-aspect)',
     paddingInline: spacingVars['--spacing-2'],
   },
-  endSlotWrapper: {
+  endContentWrapper: {
     display: 'inline-flex',
     alignItems: 'center',
     color: 'inherit',
@@ -310,16 +309,13 @@ export interface XDSButtonProps extends XDSBaseProps<HTMLButtonElement> {
    */
   children?: ReactNode;
   /**
-   * Content rendered after the label text.
-   * Only accepts `<XDSIcon>` or `<XDSBadge>` elements.
+   * Content rendered after the label text (badge, icon, chevron, etc.).
    * Ignored for icon-only buttons to preserve square aspect ratio.
    *
-   * The endSlot is wrapped in a container that inherits the button's text
-   * color, so `<XDSIcon>` elements will match the button variant's color
-   * (e.g., white on primary/destructive) without needing an explicit
-   * `color` prop.
+   * Wrapped in a container that inherits the button's text color,
+   * so child elements match the button variant's color automatically.
    */
-  endSlot?: ReactElement<XDSIconProps> | ReactElement<XDSBadgeProps>;
+  endContent?: ReactNode;
   /**
    * Tooltip text shown on hover.
    */
@@ -376,8 +372,8 @@ const edgeCompStyles = stylex.create({
  * <XDSButton label="Settings" icon={<GearIcon />} variant="ghost" />
  * <XDSButton label="Pick emoji" icon={<span>🚀</span>} variant="ghost" size="sm" />
  * <XDSButton label="Edit" icon={<PencilIcon />}>Edit</XDSButton>
- * <XDSButton label="Messages" endSlot={<XDSBadge label={3} />} />
- * <XDSButton label="Edit" icon={<PencilIcon />} endSlot={<XDSBadge label="New" />}>Edit</XDSButton>
+ * <XDSButton label="Messages" endContent={<XDSBadge label={3} />} />
+ * <XDSButton label="Edit" icon={<PencilIcon />} endContent={<XDSBadge label="New" />}>Edit</XDSButton>
  * ```
  */
 export function XDSButton({
@@ -390,14 +386,14 @@ export function XDSButton({
   onClickAction,
   icon,
   children,
-  endSlot,
+  endContent,
   tooltip,
   xstyle,
   className,
   style,
   ref,
   ...props
-}: XDSButtonProps): ReactElement {
+}: XDSButtonProps): ReactNode {
   const [isPending, startTransition] = useTransition();
   const actionInFlightRef = useRef(false);
   const isLoadingState = isLoading || isPending;
@@ -498,8 +494,8 @@ export function XDSButton({
         {isIconOnly ? null : (
           <span {...stylex.props(styles.labelText)}>{children ?? label}</span>
         )}
-        {!isIconOnly && endSlot && (
-          <span {...stylex.props(styles.endSlotWrapper)}>{endSlot}</span>
+        {!isIconOnly && endContent && (
+          <span {...stylex.props(styles.endContentWrapper)}>{endContent}</span>
         )}
       </span>
       {/* Live region for loading state announcements */}

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -115,7 +115,7 @@ export const docs = {
   ],
   notes: [
     'Uses `useXDSLayer` with `mode: "context"` for CSS anchor positioning',
-    'Uses `XDSButton` internally with `ChevronDownIcon` that inherits button text color',
+    'Uses `XDSButton` internally — chevron is passed via `endContent` and auto-hidden for icon-only buttons',
     'Items are tracked via the `items` prop to enable keyboard navigation',
     'Light dismiss is enabled by default (clicking outside closes menu)',
   ],
@@ -444,7 +444,7 @@ export const docsZh = {
   ],
   notes: [
     '使用 `useXDSLayer` 配合 `mode: "context"` 进行 CSS 锚点定位',
-    '内部使用 `XDSButton` 和 `ChevronDownIcon`，图标继承按钮文字颜色',
+    '内部使用 `XDSButton`——chevron 通过 `endContent` 传递，图标按钮自动隐藏',
     '通过 `items` 属性跟踪菜单项以启用键盘导航',
     '默认启用轻量关闭（点击外部关闭菜单）',
   ],
@@ -678,7 +678,7 @@ export const docsDense = {
   ],
   notes: [
     'uses useXDSLayer w/ mode:"context" for CSS anchor positioning',
-    'uses XDSButton internally w/ ChevronDownIcon inheriting text color',
+    'uses XDSButton internally — chevron via endContent, auto-hidden for icon-only',
     'items tracked via items prop for keyboard nav',
     'light dismiss enabled by default (click outside closes)',
   ],

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
@@ -350,3 +350,55 @@ describe('XDSDropdownMenu custom render', () => {
     expect(screen.getByTestId('custom-Delete')).toBeInTheDocument();
   });
 });
+
+describe('XDSDropdownMenu icon-only mode', () => {
+  it('renders icon-only button when icon is set without children', () => {
+    render(
+      <XDSDropdownMenu
+        button={{
+          label: 'More options',
+          icon: <span data-testid="icon">⋯</span>,
+          variant: 'ghost',
+        }}
+        items={[{label: 'Edit'}, {label: 'Delete'}]}
+      />,
+    );
+    const button = screen.getByRole('button', {name: 'More options'});
+    // label should be aria-label, not visible text
+    expect(button).toHaveAttribute('aria-label', 'More options');
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('renders icon + label when children are provided on button', () => {
+    render(
+      <XDSDropdownMenu
+        button={{
+          label: 'Settings',
+          icon: <span data-testid="icon">⚙️</span>,
+          variant: 'ghost',
+          children: 'Settings',
+        }}
+        items={[{label: 'Preferences'}]}
+      />,
+    );
+    const button = screen.getByRole('button', {name: /Settings/});
+    expect(button).not.toHaveAttribute('aria-label');
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+});
+
+describe('XDSDropdownMenu hasChevron', () => {
+  it('hides chevron when hasChevron is false', () => {
+    const {container} = render(
+      <XDSDropdownMenu
+        button={{label: 'Sort by'}}
+        hasChevron={false}
+        items={[{label: 'Name'}, {label: 'Date'}]}
+      />,
+    );
+    // No chevron SVG in the button's endContent wrapper
+    const button = screen.getByRole('button', {name: /Sort by/});
+    const endContentWrapper = button.querySelector('[class*="endContent"]');
+    expect(endContentWrapper).toBeNull();
+  });
+});

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/DropdownMenu.stories.tsx
  */
 
-
 import React, {
   useCallback,
   useId,
@@ -111,13 +110,6 @@ const styles = stylex.create({
   itemDisabled: {
     opacity: 0.5,
     cursor: 'not-allowed',
-  },
-
-  // Chevron icon styling
-  chevronIcon: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
   },
 });
 
@@ -224,12 +216,12 @@ function getSelectableItems(
 
 /**
  * Props for customizing the dropdown button.
- * Extends XDSButtonProps but omits onClick, href since those are managed internally.
+ * Extends XDSButtonProps but omits onClick since it's managed internally.
+ *
+ * When `icon` is set without `children`, renders as an icon-only button
+ * (square, with `label` as aria-label). Pass `children` to get icon + visible text.
  */
-export type XDSDropdownMenuButtonProps = Omit<
-  XDSButtonProps,
-  'onClick' | 'children'
->;
+export type XDSDropdownMenuButtonProps = Omit<XDSButtonProps, 'onClick'>;
 
 export interface XDSDropdownMenuProps {
   /**
@@ -267,6 +259,14 @@ export interface XDSDropdownMenuProps {
    * Callback when the button is clicked.
    */
   onClick?: () => void;
+
+  /**
+   * Whether to show a chevron indicator on the trigger button.
+   * Automatically hidden for icon-only buttons (when `button.icon` is set
+   * without `button.endContent`).
+   * @default true
+   */
+  hasChevron?: boolean;
 
   /**
    * Custom render function for items.
@@ -316,6 +316,7 @@ export function XDSDropdownMenu({
   onOpenChange,
   menuWidth,
   onClick,
+  hasChevron = true,
   children,
   'data-testid': testId,
 }: XDSDropdownMenuProps) {
@@ -568,12 +569,17 @@ export function XDSDropdownMenu({
     return elements;
   }, [items, renderItem]);
 
-  // Build chevron icon - inherits color from button text
-  const chevronIcon = (
-    <span {...stylex.props(styles.chevronIcon)}>
+  // Icon-only: when button has an icon and no children,
+  // XDSButton handles icon-only rendering natively.
+  const isIconOnly = button.icon != null && button.children == null;
+
+  // Build endContent: use consumer's endContent if provided,
+  // otherwise inject chevron (unless icon-only or hasChevron=false)
+  const resolvedEndContent =
+    button.endContent ??
+    (hasChevron && !isIconOnly ? (
       <XDSIcon icon="chevronDown" size="sm" color="inherit" />
-    </span>
-  );
+    ) : undefined);
 
   // Determine popover xstyle
   const popoverXstyle = menuWidth
@@ -590,6 +596,7 @@ export function XDSDropdownMenu({
           layer.ref(el);
         }}
         {...button}
+        endContent={resolvedEndContent}
         onClick={handleButtonClick}
         onKeyDown={handleKeyDown}
         aria-haspopup="menu"
@@ -600,10 +607,8 @@ export function XDSDropdownMenu({
             ? getItemId(highlightedIndex)
             : undefined
         }
-        data-testid={testId}>
-        {button.label}
-        {chevronIcon}
-      </XDSButton>
+        data-testid={testId}
+      />
 
       {layer.render(
         <div


### PR DESCRIPTION
## What

Fixes #856 — icon-only dropdown triggers now work correctly. Also standardizes `endSlot` → `endContent` across the design system, with a codemod for consumers.

## Changes

### XDSButton
- **Rename `endSlot` → `endContent`** — aligns with the `endContent` naming convention used by ListItem, Banner, Dialog, SideNav, Token, and TopNav.
- **Widen type** from `ReactElement<XDSIconProps | XDSBadgeProps>` to `ReactNode` — no reason to constrain what goes in the trailing slot.

### XDSDropdownMenu
- **Fix icon-only mode** — previously, the dropdown always injected `{button.label}{chevronIcon}` as children into XDSButton, which meant `children != null` always, so XDSButton's native icon-only detection (`icon != null && children == null`) never activated. Now the dropdown stops injecting children and passes the chevron via `endContent` instead.
- **Add `hasChevron` prop** (default `true`) — opt out of the chevron indicator with `hasChevron={false}`.
- **Un-omit `children` from button props** — enables icon + visible label triggers by passing `children` on the button.

### Codemod (v0.0.8)
- Registered `rename-endslot-to-endcontent` transform in the CLI codemod registry.
- Handles: JSX props, object literals, destructuring patterns.
- Run via: `npx @xds/cli upgrade --from 0.0.7 --to 0.0.8`

## Usage

```tsx
// Icon-only (the bug fix)
<XDSDropdownMenu
  button={{ label: "More options", icon: <EllipsisIcon />, variant: "ghost" }}
  items={[...]}
/>

// Label-only (standard, unchanged)
<XDSDropdownMenu
  button={{ label: "Actions" }}
  items={[...]}
/>

// Icon + label (opt in via children)
<XDSDropdownMenu
  button={{ label: "Settings", icon: <GearIcon />, children: "Settings" }}
  items={[...]}
/>

// No chevron
<XDSDropdownMenu
  button={{ label: "Sort by: Name" }}
  hasChevron={false}
  items={[...]}
/>
```

## Test plan

- All 47 existing + new component tests pass
- All 10 codemod tests pass
- Build passes
- Grep confirms zero remaining `endSlot` references in codebase (outside codemod files)
