### PR TITLE
fix(ListItem): support ReactNode for description prop, fix whiteSpace nowrap breaking line-clamp

### DIFF
--- a/packages/core/src/List/List.doc.mjs
+++ b/packages/core/src/List/List.doc.mjs
@@ -146,8 +146,9 @@ export const docs = {
         },
         {
           name: 'description',
-          type: 'string',
-          description: 'Secondary text displayed below the label.',
+          type: 'ReactNode',
+          description:
+            'Secondary content below the label. A plain string gets single-line truncation automatically; a ReactNode lets child components control their own wrapping and line-clamp behavior.',
         },
         {
           name: 'startContent',
@@ -340,8 +341,9 @@ export const docsZh = {
         },
         {
           name: 'description',
-          type: 'string',
-          description: '显示在标签下方的次要文本。',
+          type: 'ReactNode',
+          description:
+            '标签下方的次要内容。纯字符串会自动应用单行截断；ReactNode 允许子组件自行控制换行和多行截断行为。',
         },
         {
           name: 'startContent',

--- a/packages/core/src/List/XDSList.test.tsx
+++ b/packages/core/src/List/XDSList.test.tsx
@@ -571,4 +571,43 @@ describe('XDSList', () => {
     expect(screen.getByText('Label Only')).toBeInTheDocument();
     expect(screen.queryByText('undefined')).not.toBeInTheDocument();
   });
+
+  // ===========================================================================
+  // ReactNode description
+  // ===========================================================================
+
+  it('accepts ReactNode as description', () => {
+    render(
+      <XDSList>
+        <XDSListItem
+          label="Item"
+          description={
+            <div>
+              <span>Rich</span> <span>description</span>
+            </div>
+          }
+        />
+      </XDSList>,
+    );
+    expect(screen.getByText('Rich')).toBeInTheDocument();
+    expect(screen.getByText('description')).toBeInTheDocument();
+  });
+
+  it('still accepts string description', () => {
+    render(
+      <XDSList>
+        <XDSListItem label="Item" description="Simple text" />
+      </XDSList>,
+    );
+    expect(screen.getByText('Simple text')).toBeInTheDocument();
+  });
+
+  it('accepts number as description (ReactNode)', () => {
+    render(
+      <XDSList>
+        <XDSListItem label="Count" description={42} />
+      </XDSList>,
+    );
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
 });

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -41,9 +41,13 @@ export interface XDSListItemProps {
   label: string;
 
   /**
-   * Secondary description text below the label.
+   * Secondary description below the label.
+   *
+   * Accepts a plain string (single-line truncation applied automatically)
+   * or a ReactNode for rich/multi-line content (no wrapping constraints
+   * applied — child components control their own text behavior).
    */
-  description?: string;
+  description?: ReactNode;
 
   /**
    * Content rendered before the item (icon, avatar, checkbox).
@@ -225,6 +229,9 @@ const styles = stylex.create({
   description: {
     color: colorVars['--color-text-secondary'],
     overflow: 'hidden',
+    minWidth: 0,
+  },
+  descriptionString: {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
@@ -315,12 +322,18 @@ export function XDSListItem({
   const hasMarkers = ctx?.hasMarkers ?? false;
   const isInteractive = onClick != null || href != null;
 
+  const isStringDescription = typeof description === 'string';
+
   const labelAndDescription = (
     <>
       <span {...stylex.props(styles.label)}>{label}</span>
       {description != null && (
         <span
-          {...stylex.props(styles.description, descriptionSizeStyles[density])}>
+          {...stylex.props(
+            styles.description,
+            isStringDescription && styles.descriptionString,
+            descriptionSizeStyles[density],
+          )}>
           {description}
         </span>
       )}


### PR DESCRIPTION
## Summary

Fixes #890 — two related issues with `XDSListItem`:

### 1. `description` prop now accepts `ReactNode`

Changed from `string` to `ReactNode` so consumers can pass rich content (multiple text elements, conditional rendering, inline truncation):

```tsx
<XDSListItem
  label={item.title}
  description={
    <div>
      {item.snippet != null && (
        <XDSText type="supporting" maxLines={2}>{item.snippet}</XDSText>
      )}
      {item.creationTime != null && (
        <XDSText type="supporting">
          {formatRelativeTime(item.creationTime)}
        </XDSText>
      )}
    </div>
  }
/>
```

**Backward compatible** — plain strings still work exactly as before (single-line truncation applied automatically).

### 2. Fix `whiteSpace: 'nowrap'` breaking `-webkit-line-clamp`

The description wrapper previously applied `whiteSpace: 'nowrap'` unconditionally. This silently broke any child component using `-webkit-line-clamp` (e.g. `maxLines` on `XDSText`) because line-clamp requires text to be allowed to wrap.

**Fix:** Split into two style objects — `descriptionString` (with `whiteSpace: nowrap` + `textOverflow: ellipsis`) applied only when description is a plain string; the base `description` style has no wrapping constraints for ReactNode.

## Changes

- `packages/core/src/List/XDSListItem.tsx` — type change, split description styles, conditional style application
- `packages/core/src/List/List.doc.mjs` — updated description prop type in docs
- `packages/core/src/List/XDSList.test.tsx` — 3 new tests for ReactNode description variants

---
