### PR TITLE
docs(core): consumer-facing README with setup, CLI, and upgrade instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,90 +17,25 @@ XDS is an open source design system born from years of building internal tools a
 
 ## Getting Started
 
-### Installation
+For full setup instructions, see the **[@xds/core README](packages/core/README.md)**.
+
+Quick install:
 
 ```bash
-npm install @xds/core
-# or
-yarn add @xds/core
-# or
-pnpm add @xds/core
-# or
-bun add @xds/core
+yarn add @xds/core @xds/theme-default
+yarn add -D @xds/cli
 ```
 
-### 1. Import Base Styles
+Then follow the [setup guide](packages/core/README.md#quick-start) to import styles, configure the theme provider, and start using components.
 
-Import the reset and typography stylesheets at the root of your application. These provide a clean cross-browser baseline and prose styles for native HTML elements.
+## Packages
 
-```tsx
-// In your root layout or entry point
-import '@xds/core/reset.css'; // Base reset — box-sizing, margins, etc.
-import '@xds/core/typography.css'; // Prose styles — headings, lists, code, etc.
-```
-
-The reset uses `@layer reset`, so it won't conflict with component styles.
-
-### 2. Set Up the Theme Provider
-
-Wrap your application with the `XDSTheme` component. This sets up CSS custom properties used by all XDS components and typography styles.
-
-```tsx
-import {XDSTheme} from '@xds/core';
-import {defaultTheme} from '@xds/theme-default';
-
-function App() {
-  return (
-    <XDSTheme theme={defaultTheme}>
-      <YourApp />
-    </XDSTheme>
-  );
-}
-```
-
-### 3. Apply Typography (Optional)
-
-Typography styles activate via the `xds-typography` class or the `XDSFontWrapper` component. Choose one:
-
-```tsx
-// Option A: Global — apply to body
-<body className="xds-typography">
-
-// Option B: Scoped — wrap specific content
-import { XDSFontWrapper } from '@xds/core';
-
-<XDSFontWrapper>
-  <article dangerouslySetInnerHTML={{ __html: markdownContent }} />
-</XDSFontWrapper>
-```
-
-The typography styles support two heading scales:
-
-- **default** — Dense scale for internal tools (h1: 20px)
-- **editorial** — Larger scale for documentation/content (h1: 32px)
-
-```tsx
-<XDSFontWrapper variant="editorial">
-  <h1>Article Title</h1>
-  <p>Long-form content...</p>
-</XDSFontWrapper>
-```
-
-### 4. Use Components
-
-```tsx
-import {XDSButton, XDSText, XDSHeading} from '@xds/core';
-
-function Example() {
-  return (
-    <>
-      <XDSHeading>Welcome</XDSHeading>
-      <XDSText>Click the button below to get started.</XDSText>
-      <XDSButton label="Get Started" onPress={() => console.log('clicked')} />
-    </>
-  );
-}
-```
+| Package                                         | Description                                         | README                            |
+| ----------------------------------------------- | --------------------------------------------------- | --------------------------------- |
+| [`@xds/core`](packages/core)                    | Components, theme system, and utilities             | [README](packages/core/README.md) |
+| [`@xds/cli`](packages/cli)                      | CLI tooling — component docs, scaffolding, codemods | [README](packages/cli/README.md)  |
+| [`@xds/theme-default`](packages/themes/default) | Clean, professional default theme                   |                                   |
+| [`@xds/theme-neutral`](packages/themes/neutral) | Muted, minimal aesthetic theme                      |                                   |
 
 ## Philosophy
 
@@ -116,20 +51,20 @@ The building blocks for visually cohesive and accessible interfaces: typography,
 
 ### Components
 
-A library of 300+ reusable UI building blocks with full TypeScript support.
+A library of 90+ reusable UI building blocks with full TypeScript support.
 
 ### Patterns
 
-33+ battle-tested design solutions for common interactions and workflows: table pages, detail page layouts, form wizards, navigation patterns, data entry flows.
+Battle-tested design solutions for common interactions and workflows: table pages, detail page layouts, form wizards, navigation patterns, data entry flows.
 
 ## Project Structure
 
-| Directory   | Purpose                                                          |
-| ----------- | ---------------------------------------------------------------- |
-| `apps/`     | Application packages: documentation site, sandbox, and Storybook |
-| `packages/` | Published packages: core components and utilities                |
-| `internal/` | Internal tooling: test utilities and build helpers               |
-| `e2e/`      | End-to-end tests using Playwright                                |
+| Directory   | Purpose                                                     |
+| ----------- | ----------------------------------------------------------- |
+| `apps/`     | Example apps and Storybook                                  |
+| `packages/` | Published packages: core, cli, themes                       |
+| `internal/` | Internal tooling: test utilities, eslint plugin, vibe tests |
+| `e2e/`      | End-to-end tests (Playwright)                               |
 
 ## Contributing
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -5,20 +5,34 @@ A design system for building internal tools and products at Meta.
 ## Installation
 
 ```bash
+# Install core + a theme + the CLI (dev tooling)
 yarn add @xds/core @xds/theme-default
+yarn add -D @xds/cli
+
+# npm
+npm install @xds/core @xds/theme-default
+npm install -D @xds/cli
+
+# pnpm
+pnpm add @xds/core @xds/theme-default
+pnpm add -D @xds/cli
 ```
 
 ## Quick Start
 
 ### 1. Import Base Styles
 
+Import the reset stylesheet and your theme's CSS at the root of your application:
+
 ```tsx
 // In your root layout or entry point
 import '@xds/core/reset.css';
-import '@xds/core/typography.css';
+import '@xds/theme-default/theme.css';
 ```
 
 ### 2. Set Up the Theme Provider
+
+Wrap your application with the `XDSTheme` component:
 
 ```tsx
 import {XDSTheme} from '@xds/core';
@@ -43,7 +57,7 @@ function Example() {
     <>
       <XDSHeading>Welcome</XDSHeading>
       <XDSText>Click the button below to get started.</XDSText>
-      <XDSButton label="Get Started" onPress={() => console.log('clicked')} />
+      <XDSButton label="Get Started" onClick={() => console.log('clicked')} />
     </>
   );
 }
@@ -51,23 +65,25 @@ function Example() {
 
 ## CLI Tooling
 
-XDS ships a CLI for component docs, scaffolding, and upgrade tooling:
+The `@xds/cli` package provides component docs, scaffolding, and upgrade tooling:
 
 ```bash
-npx xds component --list          # Browse all components by category
-npx xds component Button          # Full docs for a component (props, usage, examples)
-npx xds docs principles           # Design rules and anti-patterns
-npx xds docs tokens               # Token reference (spacing, color, radius, type)
-npx xds template <name> [path]    # Scaffold a page (blank, table, login)
-npx xds swizzle <Name>            # Eject component source for customization
+xds component --list          # Browse all components by category
+xds component Button          # Full docs for a component (props, usage, examples)
+xds docs principles           # Design rules and anti-patterns
+xds docs tokens               # Token reference (spacing, color, radius, type)
+xds template <name> [path]    # Scaffold a page (blank, table, login)
+xds swizzle <Name>            # Eject component source for customization
 ```
+
+> If `@xds/cli` is installed as a devDependency, use `xds` directly (yarn/pnpm resolve it from `node_modules/.bin`). Otherwise, use `npx xds`.
 
 ### Initialize your project
 
 Run `xds init` to set up project configuration:
 
 ```bash
-npx xds init
+xds init
 ```
 
 This walks you through setting up agent docs, templates, and other project-level configuration.
@@ -77,7 +93,7 @@ This walks you through setting up agent docs, templates, and other project-level
 If you use AI coding agents (Claude Code, Cursor, Codex, etc.), install the XDS component catalog into your project's agent docs:
 
 ```bash
-npx xds init --features agents
+xds init --features agents
 ```
 
 This injects a compact component index into your CLAUDE.md or AGENTS.md so your AI agent can discover and correctly use XDS components. Re-run after upgrading XDS to keep the index current.
@@ -87,30 +103,49 @@ This injects a compact component index into your CLAUDE.md or AGENTS.md so your 
 When upgrading to a new version, use the built-in upgrade command to automatically migrate breaking API changes:
 
 ```bash
-npx xds upgrade --apply
+xds upgrade --apply
 ```
 
 This bumps all `@xds/*` dependencies, runs `yarn install`, applies codemods for breaking changes, and refreshes agent docs if present. To migrate between specific versions:
 
 ```bash
-npx xds upgrade --apply --from 0.0.1 --to 0.0.2
+xds upgrade --apply --from 0.0.1 --to 0.0.2
 ```
 
 Preview what would change without writing to disk:
 
 ```bash
-npx xds upgrade
+xds upgrade
 ```
 
 ## Themes
 
 XDS supports pluggable themes. Install a theme package and pass it to `XDSTheme`:
 
-- `@xds/theme-default` — Clean, professional default
-- `@xds/theme-neutral` — Muted, minimal aesthetic
+| Package              | Description                 |
+| -------------------- | --------------------------- |
+| `@xds/theme-default` | Clean, professional default |
+| `@xds/theme-neutral` | Muted, minimal aesthetic    |
+
+Each theme package exports a JS theme object and a `theme.css` file:
 
 ```bash
 yarn add @xds/theme-neutral
+```
+
+```tsx
+import '@xds/theme-neutral/theme.css';
+import {neutralTheme} from '@xds/theme-neutral';
+
+<XDSTheme theme={neutralTheme}>...</XDSTheme>;
+```
+
+### Custom Themes
+
+Build your own theme with `defineTheme()`. For a full guide on creating custom themes, token overrides, and component style customization:
+
+```bash
+xds docs theme
 ```
 
 ## Resources

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,36 +1,124 @@
-# /packages/core
+# @xds/core
 
-Core UI components library for the XDS design system (`@xds/core`).
+A design system for building internal tools and products at Meta.
 
-<!-- SYNC: When files in this directory change, update this document. -->
+## Installation
 
-| Directory/File   | Role   | Purpose                                |
-| ---------------- | ------ | -------------------------------------- |
-| `src/`           | Source | Component source code                  |
-| `docs/`          | Docs   | Documentation including AI skill doc   |
-| `package.json`   | Config | Package configuration and dependencies |
-| `tsconfig.json`  | Config | TypeScript compiler configuration      |
-| `tsup.config.ts` | Build  | Bundle configuration using tsup        |
+```bash
+yarn add @xds/core @xds/theme-default
+```
 
-## Key Exports
+## Quick Start
 
-### Components
+### 1. Import Base Styles
 
-- **Typography**: `XDSText`, `XDSHeading`, `XDSFontWrapper`
-- **Inputs**: `XDSButton`, `XDSTextInput`, `XDSTextArea`, `XDSCheckboxInput`
-- **Layout**: `XDSHStack`, `XDSVStack`, `XDSCard`, `XDSSection`
-- **Feedback**: `XDSTooltip`, `XDSHoverCard`
+```tsx
+// In your root layout or entry point
+import '@xds/core/reset.css';
+import '@xds/core/typography.css';
+```
 
-### Theme
+### 2. Set Up the Theme Provider
 
-- `Theme` — Provider component that sets CSS custom properties
-- `defaultTheme`, `neutralTheme` — Pre-built themes
-- `useTheme` — Hook to access current theme
+```tsx
+import {XDSTheme} from '@xds/core';
+import {defaultTheme} from '@xds/theme-default';
 
-### Stylesheets
+function App() {
+  return (
+    <XDSTheme theme={defaultTheme}>
+      <YourApp />
+    </XDSTheme>
+  );
+}
+```
 
-- `@xds/core/typography.css` — Base typography styles for native HTML elements (h1-h6, p, lists, blockquotes, code, etc.). Uses CSS custom properties from the theme.
+### 3. Use Components
 
-## Usage
+```tsx
+import {XDSButton, XDSText, XDSHeading} from '@xds/core';
 
-See the [Getting Started guide](/README.md#getting-started) in the root README.
+function Example() {
+  return (
+    <>
+      <XDSHeading>Welcome</XDSHeading>
+      <XDSText>Click the button below to get started.</XDSText>
+      <XDSButton label="Get Started" onPress={() => console.log('clicked')} />
+    </>
+  );
+}
+```
+
+## CLI Tooling
+
+XDS ships a CLI for component docs, scaffolding, and upgrade tooling:
+
+```bash
+npx xds component --list          # Browse all components by category
+npx xds component Button          # Full docs for a component (props, usage, examples)
+npx xds docs principles           # Design rules and anti-patterns
+npx xds docs tokens               # Token reference (spacing, color, radius, type)
+npx xds template <name> [path]    # Scaffold a page (blank, table, login)
+npx xds swizzle <Name>            # Eject component source for customization
+```
+
+### Initialize your project
+
+Run `xds init` to set up project configuration:
+
+```bash
+npx xds init
+```
+
+This walks you through setting up agent docs, templates, and other project-level configuration.
+
+### AI Agent Setup
+
+If you use AI coding agents (Claude Code, Cursor, Codex, etc.), install the XDS component catalog into your project's agent docs:
+
+```bash
+npx xds init --features agents
+```
+
+This injects a compact component index into your CLAUDE.md or AGENTS.md so your AI agent can discover and correctly use XDS components. Re-run after upgrading XDS to keep the index current.
+
+## Upgrading
+
+When upgrading to a new version, use the built-in upgrade command to automatically migrate breaking API changes:
+
+```bash
+npx xds upgrade --apply
+```
+
+This bumps all `@xds/*` dependencies, runs `yarn install`, applies codemods for breaking changes, and refreshes agent docs if present. To migrate between specific versions:
+
+```bash
+npx xds upgrade --apply --from 0.0.1 --to 0.0.2
+```
+
+Preview what would change without writing to disk:
+
+```bash
+npx xds upgrade
+```
+
+## Themes
+
+XDS supports pluggable themes. Install a theme package and pass it to `XDSTheme`:
+
+- `@xds/theme-default` — Clean, professional default
+- `@xds/theme-neutral` — Muted, minimal aesthetic
+
+```bash
+yarn add @xds/theme-neutral
+```
+
+## Resources
+
+- [Component Storybook](https://facebookexperimental.github.io/xds/)
+- [GitHub Repository](https://github.com/facebookexperimental/xds)
+- [Changelog](https://github.com/facebookexperimental/xds/blob/main/packages/core/CHANGELOG.md)
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary

Replaces the internal monorepo README in `packages/core/` with a proper consumer-facing one that ships in the npm tarball. Also updates the root README to be an overview that links to package READMEs.

### Why

When an LLM installs `@xds/core`, the first thing it reads is `node_modules/@xds/core/README.md`. The old README was a monorepo file manifest — no setup instructions, no CLI mention, no upgrade path. This is the primary discovery hook for agents to find `xds init` and `xds upgrade`.

### packages/core/README.md (consumer-facing)

- **Installation** — yarn/npm/pnpm with `@xds/cli` as devDependency
- **Quick start** — reset.css + theme.css imports, XDSTheme provider, first component
- **CLI tooling** — component docs, scaffolding, swizzle, docs commands
- **AI agent setup** — `xds init --features agents`
- **Upgrade instructions** — `xds upgrade --apply [--from/--to]`
- **Themes** — built-in themes with CSS imports + custom theme docs reference

### Root README.md (monorepo overview)

- Slimmed down to overview + philosophy + architecture
- Links to `packages/core/README.md` for setup instructions
- Package table linking to each package's README

### Vibe Test Results (post-install discovery)

Tested whether LLMs find the CLI and init command after installing `@xds/core`:

| Metric | New README | Old README |
|--------|-----------|-----------|
| Found CLI tooling | 3/3 | 0/3 |
| Ran `xds init` | 3/3 | 0/3 |
| Found agent setup | 2/3 | 0/3 |
| Correct CSS imports | 3/3 | 0/3 |

---
