### PR TITLE
chore: bump all packages to 0.0.8

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/cli",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "XDS design system CLI \u2014 init, swizzle, theme, templates, and agent docs",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/core",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Core XDS components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/lab",
-  "version": "0.0.5",
+  "version": "0.0.8",
   "private": true,
   "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
   "main": "./src/index.ts",

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": true,
   "description": "Brutalist theme for XDS \u2014 zero radius, monospace, heavy borders",
   "license": "MIT",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-default",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "description": "Default theme for XDS components (Heroicons)",
   "license": "MIT",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-neutral",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "private": false,
   "description": "Neutral theme for XDS components (Lucide icons)",
   "license": "MIT",


### PR DESCRIPTION
## Release v0.0.8

Bumps all publishable packages to 0.0.8:
- `@xds/core` 0.0.7 → 0.0.8
- `@xds/cli` 0.0.7 → 0.0.8
- `@xds/theme-default` 0.0.7 → 0.0.8
- `@xds/theme-neutral` 0.0.7 → 0.0.8
- `@xds/theme-brutalist` 0.0.7 → 0.0.8
- `@xds/lab` 0.0.5 → 0.0.8

### Notable changes since v0.0.7

**New components:**
- `XDSTimestamp` — relative/absolute timestamp display

**Features:**
- feat(cli): support external library component discovery (#563)
- feat(cli): add version update hints via local signals (#901)
- feat(cli): upgrade bumps @xds/* deps, installs, and refreshes agent docs (#897)
- feat(cli): configurable agent docs with tool presets and lockfile-based command prefix (#874)
- feat(storybook): Internal Web Apps Analytics dashboard (#663)

**Fixes:**
- fix: align cyan, pink, and yellow token colors with WWW (#907)
- fix(Dialog): hardening — swarm findings (#775)
- fix(Button,DropdownMenu): rename endSlot → endContent, fix icon-only dropdown trigger (#895)
- fix(Button): prevent text wrap and add ellipsis truncation (#892)
- fix(ListItem): support ReactNode for description prop, fix line-clamp (#896)
- fix(ListItem): use fixed inline padding (#887)
- fix(Table): add default minWidth for proportional columns (#891)
- fix(Slider): hardening — style clobber, a11y, pointer handling (#882)
- fix(hardening): layout + structure components (#886)
- fix(hardening): add missing xdsClassName to Token, Tokenizer, TopNavMegaMenuItem (#876)

**Refactors:**
- refactor: rename design tokens to match new naming convention (#894)

**Docs:**
- docs: consumer-facing core README + monorepo README refactor (#898)
- docs: add missing theming targets, sub-component docs, and hasChevron prop (#900)

---
