### PR TITLE
fix(sandbox): add WhatsApp theme to sidebar theme picker

### DIFF
--- a/apps/sandbox/src/app/SandboxNav.tsx
+++ b/apps/sandbox/src/app/SandboxNav.tsx
@@ -58,6 +58,7 @@ export function SandboxNav() {
               {value: 'default', label: 'Default'},
               {value: 'neutral', label: 'Neutral'},
               {value: 'brutalist', label: 'Brutalist'},
+              {value: 'whatsapp', label: 'WhatsApp'},
             ]}
           />
         </div>


### PR DESCRIPTION
Follow-up to #911 — the WhatsApp theme was registered in `providers.tsx` but missing from the `SandboxNav` dropdown options list. Adds it so users can actually select it in the sidebar.