### PR TITLE
fix(cli): detect package manager for jscodeshift install + read version from package.json

### DIFF
--- a/packages/cli/src/codemods/ensure-jscodeshift.mjs
+++ b/packages/cli/src/codemods/ensure-jscodeshift.mjs
@@ -11,6 +11,7 @@
 
 import {execSync} from 'node:child_process';
 import * as p from '@clack/prompts';
+import {detectPackageManager} from '../utils/package-manager.mjs';
 
 /**
  * @param {object} [options]
@@ -54,9 +55,19 @@ export async function ensureJscodeshift({installDeps = false} = {}) {
 
 /** @returns {boolean} */
 function installJscodeshift() {
+  const pm = detectPackageManager();
+  const cmds = {
+    yarn: 'yarn add --dev jscodeshift',
+    pnpm: 'pnpm add -D jscodeshift',
+    bun: 'bun add -D jscodeshift',
+    npm: 'npm install --save-dev jscodeshift',
+    npx: 'npm install --save-dev jscodeshift',
+  };
+  const cmd = cmds[pm] || cmds.npm;
+
   try {
-    p.log.step('Installing jscodeshift...');
-    execSync('npm install --no-save jscodeshift', {stdio: 'pipe'});
+    p.log.step(`Installing jscodeshift via ${pm}...`);
+    execSync(cmd, {stdio: 'pipe'});
     p.log.success('jscodeshift installed.');
     return true;
   } catch (err) {

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -7,17 +7,21 @@
 
 import {Command} from 'commander';
 import {fileURLToPath} from 'node:url';
+import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {checkForUpdate} from './utils/update-check.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// Read version from package.json so it stays in sync
+const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
 
 export const program = new Command();
 
 program
   .name('xds')
   .description('XDS design system CLI — components, themes, and tooling')
-  .version('0.0.1')
+  .version(pkg.version)
   .option('--zh', 'Output docs in Chinese Simplified')
   .option('--dense', 'Output docs in compressed dense format (token-efficient)')
   .option('--lang <locale>', 'Output docs in specified language/format (en, zh, dense)')


### PR DESCRIPTION
Two fixes found during consumer-side testing of the 0.0.8 CLI:

1. **jscodeshift install uses wrong package manager** — ensure-jscodeshift.mjs was hardcoded to npm install. Fails in yarn/pnpm/bun projects. Now uses detectPackageManager() to pick the right command.

2. **xds --version reports 0.0.1** — Commander .version() was hardcoded. Now reads from package.json.