### PR TITLE
fix(deploy): clean deploys, PR previews at /pr/<number>/, stable sandbox URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,30 +99,26 @@ jobs:
       - name: Build Storybook
         run: yarn workspace @xds/storybook build
 
-      - name: Compute short hash
+      - name: Compute PR preview path
         if: github.event_name == 'pull_request'
-        id: hash
+        id: urls
         run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
           COMMIT_HASH="${{ github.event.pull_request.head.sha }}"
-          echo "short_hash=${COMMIT_HASH:0:7}" >> $GITHUB_OUTPUT
+          SHORT_HASH="${COMMIT_HASH:0:7}"
+          REPO_NAME="${{ github.event.repository.name }}"
+          REPO_OWNER="${{ github.repository_owner }}"
+
+          echo "short_hash=${SHORT_HASH}" >> $GITHUB_OUTPUT
+          echo "pr_number=${PR_NUMBER}" >> $GITHUB_OUTPUT
+          echo "storybook_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/" >> $GITHUB_OUTPUT
+          echo "sandbox_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/pr/${PR_NUMBER}/sandbox/" >> $GITHUB_OUTPUT
 
       - name: Build Sandbox
         if: github.event_name == 'pull_request'
         run: yarn workspace @xds/sandbox build
         env:
-          SANDBOX_BASE_PATH: /${{ steps.hash.outputs.short_hash }}/sandbox
-
-      - name: Compute URLs
-        if: github.event_name == 'pull_request'
-        id: urls
-        run: |
-          SHORT_HASH="${{ steps.hash.outputs.short_hash }}"
-          REPO_NAME="${{ github.event.repository.name }}"
-          REPO_OWNER="${{ github.repository_owner }}"
-
-          echo "short_hash=${SHORT_HASH}" >> $GITHUB_OUTPUT
-          echo "storybook_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/${SHORT_HASH}/" >> $GITHUB_OUTPUT
-          echo "sandbox_url=https://${REPO_OWNER}.github.io/${REPO_NAME}/${SHORT_HASH}/sandbox/" >> $GITHUB_OUTPUT
+          SANDBOX_BASE_PATH: /pr/${{ steps.urls.outputs.pr_number }}/sandbox
 
       - name: Upload Storybook artifact
         if: github.event_name == 'pull_request'
@@ -132,22 +128,22 @@ jobs:
           path: apps/storybook/dist/
           retention-days: 30
 
-      - name: Prepare and deploy Storybook preview
+      - name: Prepare and deploy PR preview
         if: github.event_name == 'pull_request'
         run: |
-          SHORT_HASH="${{ steps.urls.outputs.short_hash }}"
+          PR_NUMBER="${{ steps.urls.outputs.pr_number }}"
 
-          mkdir -p deploy/${SHORT_HASH}
-          cp -r apps/storybook/dist/* deploy/${SHORT_HASH}/
+          mkdir -p deploy/pr/${PR_NUMBER}
+          cp -r apps/storybook/dist/* deploy/pr/${PR_NUMBER}/
 
           if [ -d "apps/sandbox/out" ]; then
-            mkdir -p deploy/${SHORT_HASH}/sandbox
-            cp -r apps/sandbox/out/* deploy/${SHORT_HASH}/sandbox/
+            mkdir -p deploy/pr/${PR_NUMBER}/sandbox
+            cp -r apps/sandbox/out/* deploy/pr/${PR_NUMBER}/sandbox/
           fi
 
           touch deploy/.nojekyll
 
-      - name: Deploy Storybook preview to GitHub Pages
+      - name: Deploy PR preview to GitHub Pages
         if: github.event_name == 'pull_request'
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -27,80 +27,82 @@ jobs:
           ref: gh-pages
           fetch-depth: 1
 
-      - name: Cleanup stale preview directories
+      - name: Cleanup stale deployments
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: |
           # ---------------------------------------------------------------
-          # Retention policy:
-          #   KEEP  — latest main commit dir (from API)
-          #         — most recently deployed dir (from git log)
-          #         — latest head commit dir for each open/draft PR
-          #         — reports/ (vibe test reports)
-          #         — root files (.nojekyll, index.html, latest, assets/)
-          #   DELETE — everything else
+          # gh-pages layout:
+          #   /storybook/    — stable (managed by deploy.yml, never cleaned)
+          #   /sandbox/      — stable (managed by deploy.yml, never cleaned)
+          #   /pr/<number>/  — PR previews (cleaned when PR closes)
+          #   /reports/      — vibe test reports (never cleaned)
+          #   /assets/       — landing page CSS (never cleaned)
+          #   /index.html    — landing page (never cleaned)
+          #   /latest        — deploy hash pointer (never cleaned)
+          #
+          # Legacy: 7-char hex dirs from old deploy format are always deleted.
           # ---------------------------------------------------------------
 
-          echo "Cleanup policy: keep main + open PR heads + reports"
           echo "Dry run: ${DRY_RUN}"
           echo ""
 
-          # Get all 7-char hex directories (preview deployments)
-          mapfile -t DIRS < <(ls -d [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f] 2>/dev/null)
-          TOTAL=${#DIRS[@]}
-          echo "Found ${TOTAL} preview directories"
+          DELETED=0
 
-          if [ "$TOTAL" -eq 0 ]; then
-            echo "Nothing to clean up."
-            exit 0
+          # ----- Clean legacy hash directories -----
+          # Old deploy format put previews at /<7-char-hex>/. These are all
+          # stale now that PRs deploy to /pr/<number>/.
+          mapfile -t HASH_DIRS < <(ls -d [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f] 2>/dev/null)
+          if [ ${#HASH_DIRS[@]} -gt 0 ]; then
+            echo "Found ${#HASH_DIRS[@]} legacy hash directories — removing all"
+            for dir in "${HASH_DIRS[@]}"; do
+              echo "  DELETE ${dir} (legacy)"
+              if [ "$DRY_RUN" != "true" ]; then
+                git rm -rf --quiet "$dir"
+              fi
+              DELETED=$((DELETED + 1))
+            done
+            echo ""
           fi
 
-          # Get the latest main commit short hash
-          MAIN_HASH=$(gh api repos/$GITHUB_REPOSITORY/commits/main --jq '.sha[:7]')
-          echo "Main HEAD: ${MAIN_HASH}"
+          # ----- Clean closed PR previews -----
+          if [ -d "pr" ]; then
+            mapfile -t PR_DIRS < <(ls pr/ 2>/dev/null)
+            echo "Found ${#PR_DIRS[@]} PR preview(s)"
 
-          # Find the most recently deployed hash dir on gh-pages.
-          # This protects against a race where main HEAD has advanced
-          # but its deploy hasn't finished yet — we keep the previous
-          # deploy that's actually serving traffic.
-          LATEST_DEPLOYED=""
-          for dir in "${DIRS[@]}"; do
-            # git log for the dir — most recently touched = most recent deploy
-            DIR_DATE=$(git log -1 --format='%ct' -- "$dir" 2>/dev/null || echo "0")
-            if [ -z "$LATEST_DEPLOYED" ]; then
-              LATEST_DEPLOYED="$dir"
-              LATEST_DATE="$DIR_DATE"
-            elif [ "$DIR_DATE" -gt "$LATEST_DATE" ]; then
-              LATEST_DEPLOYED="$dir"
-              LATEST_DATE="$DIR_DATE"
-            fi
-          done
-          echo "Latest deployed: ${LATEST_DEPLOYED}"
+            # Get open PR numbers
+            OPEN_PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number --jq '.[].number' || true)
 
-          # Get open/draft PR head commit short hashes
-          OPEN_PR_HASHES=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json headRefOid,number --jq '.[] | .headRefOid[:7]' || true)
-          OPEN_COUNT=$(echo "$OPEN_PR_HASHES" | grep -c . || echo 0)
-          echo "Open/draft PRs: ${OPEN_COUNT}"
-          echo ""
+            for pr_num in "${PR_DIRS[@]}"; do
+              if echo "$OPEN_PRS" | grep -qx "$pr_num"; then
+                echo "  KEEP  pr/${pr_num} — open"
+              else
+                echo "  DELETE pr/${pr_num} — closed/merged"
+                if [ "$DRY_RUN" != "true" ]; then
+                  git rm -rf --quiet "pr/${pr_num}"
+                fi
+                DELETED=$((DELETED + 1))
+              fi
+            done
+            echo ""
+          fi
 
-          # Clean up stale root-level storybook files (from old deploy format)
-          # These are files/dirs at the gh-pages root that aren't hash dirs,
-          # index.html, .nojekyll, or reports/
-          # NOTE: `assets/` is NOT stale — it contains CSS referenced by the
-          # landing page (index.html): reset.css, xds.css, theme.css
+          # ----- Clean stale root-level files -----
+          # Leftovers from old Storybook-at-root deploy format
           ROOT_STALE=0
           for item in favicon.svg iframe.html index.json project.json \
                       nunito-sans-bold-italic.woff2 nunito-sans-bold.woff2 \
                       nunito-sans-italic.woff2 nunito-sans-regular.woff2 \
-                      sandbox sb-addons sb-common-assets sb-manager; do
+                      sb-addons sb-common-assets sb-manager; do
             if [ -e "$item" ]; then
-              echo "  DELETE root/$item (stale root-level file)"
+              echo "  DELETE root/$item (stale)"
               if [ "$DRY_RUN" != "true" ]; then
                 git rm -rf --quiet "$item"
               fi
               ROOT_STALE=$((ROOT_STALE + 1))
+              DELETED=$((DELETED + 1))
             fi
           done
           if [ "$ROOT_STALE" -gt 0 ]; then
@@ -108,42 +110,8 @@ jobs:
             echo ""
           fi
 
-          DELETED=0
-          KEPT=0
-
-          for dir in "${DIRS[@]}"; do
-            REASON=""
-
-            # Keep main HEAD
-            if [ "$dir" = "$MAIN_HASH" ]; then
-              REASON="main HEAD"
-            fi
-
-            # Keep the most recently deployed dir (in case main HEAD
-            # hasn't deployed yet, this is what's actually serving)
-            if [ -z "$REASON" ] && [ "$dir" = "$LATEST_DEPLOYED" ]; then
-              REASON="latest deployed"
-            fi
-
-            # Keep open/draft PR heads
-            if [ -z "$REASON" ] && echo "$OPEN_PR_HASHES" | grep -qx "$dir"; then
-              REASON="open PR"
-            fi
-
-            if [ -n "$REASON" ]; then
-              echo "  KEEP  ${dir} — ${REASON}"
-              KEPT=$((KEPT + 1))
-            else
-              echo "  DELETE ${dir}"
-              if [ "$DRY_RUN" != "true" ]; then
-                git rm -rf --quiet "$dir"
-              fi
-              DELETED=$((DELETED + 1))
-            fi
-          done
-
-          echo ""
-          echo "Summary: ${DELETED} deleted, ${KEPT} kept (of ${TOTAL})"
+          # ----- Summary -----
+          echo "Summary: ${DELETED} items deleted"
 
           if [ "$DRY_RUN" = "true" ]; then
             echo "Dry run — no changes committed"
@@ -153,7 +121,7 @@ jobs:
           if [ "$DELETED" -gt 0 ]; then
             git config user.name "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git commit -m "chore: cleanup ${DELETED} stale preview deployments"
+            git commit -m "chore: cleanup ${DELETED} stale deployments"
             git push origin gh-pages
             echo "Pushed cleanup commit"
           else

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,17 @@
-# Deploy Storybook to GitHub Pages
+# Deploy Storybook + Sandbox to GitHub Pages
 # Only runs on push to main — simple and sequential: sync → test → deploy
+#
+# Deployment layout on gh-pages:
+#   /storybook/    — stable Storybook (always latest main)
+#   /sandbox/      — stable Sandbox (always latest main)
+#   /pr/<number>/  — PR preview dirs (managed by ci.yml, preserved here)
+#   /reports/      — vibe test reports (preserved)
+#   /assets/       — landing page CSS
+#   /index.html    — landing page
+#   /latest        — short hash of latest deploy
+#
+# Uses keep_files:false — each deploy is a clean slate. PR previews and
+# reports are preserved by copying them from gh-pages before deploying.
 name: Deploy
 
 on:
@@ -71,27 +83,57 @@ jobs:
       - name: Build Storybook
         run: yarn workspace @xds/storybook build
 
-      - name: Compute short hash
-        id: hash
-        run: echo "short_hash=${GITHUB_SHA:0:7}" >> $GITHUB_OUTPUT
-
       - name: Build Sandbox
         run: yarn workspace @xds/sandbox build
         env:
-          SANDBOX_BASE_PATH: /${{ steps.hash.outputs.short_hash }}/sandbox
+          SANDBOX_BASE_PATH: /sandbox
+
+      - name: Preserve PR previews and reports from gh-pages
+        run: |
+          # Clone current gh-pages to rescue PR previews and reports
+          # before the clean deploy wipes everything.
+          git clone --depth=1 --single-branch --branch gh-pages \
+            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
+            /tmp/gh-pages 2>/dev/null || true
+
+          if [ -d "/tmp/gh-pages" ]; then
+            # Preserve PR preview directories
+            if [ -d "/tmp/gh-pages/pr" ]; then
+              echo "Preserving PR previews"
+              cp -r /tmp/gh-pages/pr /tmp/preserved-pr
+            fi
+
+            # Preserve vibe test reports
+            if [ -d "/tmp/gh-pages/reports" ]; then
+              echo "Preserving reports"
+              cp -r /tmp/gh-pages/reports /tmp/preserved-reports
+            fi
+
+            rm -rf /tmp/gh-pages
+          fi
 
       - name: Prepare deployment
         run: |
           SHORT_HASH="${GITHUB_SHA:0:7}"
-          REPO_NAME="${{ github.event.repository.name }}"
-          REPO_OWNER="${{ github.repository_owner }}"
 
-          mkdir -p deploy/${SHORT_HASH}
-          cp -r apps/storybook/dist/* deploy/${SHORT_HASH}/
+          # Stable storybook
+          mkdir -p deploy/storybook
+          cp -r apps/storybook/dist/* deploy/storybook/
 
+          # Stable sandbox (built with basePath=/sandbox)
           if [ -d "apps/sandbox/out" ]; then
-            mkdir -p deploy/${SHORT_HASH}/sandbox
-            cp -r apps/sandbox/out/* deploy/${SHORT_HASH}/sandbox/
+            mkdir -p deploy/sandbox
+            cp -r apps/sandbox/out/* deploy/sandbox/
+          fi
+
+          # Restore preserved PR previews and reports
+          if [ -d "/tmp/preserved-pr" ]; then
+            cp -r /tmp/preserved-pr deploy/pr
+            echo "Restored $(ls deploy/pr/ | wc -l) PR preview(s)"
+          fi
+          if [ -d "/tmp/preserved-reports" ]; then
+            cp -r /tmp/preserved-reports deploy/reports
+            echo "Restored reports"
           fi
 
           # Copy XDS dist CSS for the landing page
@@ -150,14 +192,14 @@ jobs:
               <h1>XDS Design System</h1>
               <p>Component library for building internal tools. Select an environment below.</p>
               <div class="links">
-                <a class="card" id="storybook-link" href="#">
+                <a class="card" href="storybook/index.html">
                   <div>
                     <div class="card-title">📖 Storybook</div>
                     <div class="card-desc">Component docs, props, and interactive examples</div>
                   </div>
                   <span class="arrow">→</span>
                 </a>
-                <a class="card" id="sandbox-link" href="#">
+                <a class="card" href="sandbox/index.html">
                   <div>
                     <div class="card-title">🏗️ Sandbox</div>
                     <div class="card-desc">Full app demo with theme editor</div>
@@ -172,50 +214,17 @@ jobs:
                   <span class="arrow">→</span>
                 </a>
               </div>
-              <div class="hash" id="commit-hash"></div>
+              <div class="hash">Build: DEPLOY_HASH_PLACEHOLDER</div>
             </div>
-            <script>
-              // Resolve links from the `latest` file so they always point
-              // to the most recently deployed hash — even if a newer main
-              // commit is still building and the sed-injected hash is stale.
-              fetch('latest')
-                .then(r => r.ok ? r.text() : null)
-                .then(hash => {
-                  if (!hash) return;
-                  hash = hash.trim();
-                  const sb = document.getElementById('storybook-link');
-                  const bx = document.getElementById('sandbox-link');
-                  const cm = document.getElementById('commit-hash');
-                  if (sb) sb.href = hash + '/index.html';
-                  if (bx) bx.href = hash + '/sandbox/index.html';
-                  if (cm) cm.textContent = 'Build: ' + hash;
-                })
-                .catch(() => {}); // fallback to sed-injected links
-            </script>
           </body>
           </html>
           LANDING_EOF
 
-          # Also deploy to a stable `storybook/` directory so links like
-          # .../storybook/index.html?path=/docs/core-xdsbutton--docs
-          # never break when hash directories get cleaned up.
-          mkdir -p deploy/storybook
-          cp -r apps/storybook/dist/* deploy/storybook/
+          # Inject the short hash into the landing page
+          sed -i "s|DEPLOY_HASH_PLACEHOLDER|${SHORT_HASH}|" deploy/index.html
 
-          if [ -d "apps/sandbox/out" ]; then
-            mkdir -p deploy/sandbox
-            cp -r apps/sandbox/out/* deploy/sandbox/
-          fi
-
-          # Write the latest deployed hash so the landing page can resolve
-          # links dynamically. This survives cleanup and avoids stale links
-          # when a newer main commit is pending deploy.
+          # Write the latest deployed hash (used by PR comment links, etc.)
           echo -n "${SHORT_HASH}" > deploy/latest
-
-          # Inject the short hash into the landing page as a fallback
-          sed -i "s|id=\"storybook-link\" href=\"#\"|id=\"storybook-link\" href=\"${SHORT_HASH}/index.html\"|" deploy/index.html
-          sed -i "s|id=\"sandbox-link\" href=\"#\"|id=\"sandbox-link\" href=\"${SHORT_HASH}/sandbox/index.html\"|" deploy/index.html
-          sed -i "s|id=\"commit-hash\"|id=\"commit-hash\">Build: ${SHORT_HASH}</div><!--done|" deploy/index.html
 
           touch deploy/.nojekyll
 
@@ -224,5 +233,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./deploy
-          keep_files: true
+          keep_files: false
           destination_dir: .


### PR DESCRIPTION
## Problem

Three issues with the current gh-pages deploy:

1. **`storybook/` has 2,656 accumulated files** (vs ~192 per build — 14x bloat). `keep_files: true` means old content-hashed chunks are never removed.

2. **`/sandbox/` is deleted daily by the cleanup workflow** then recreated by deploy with the wrong `basePath`. It was listed as a "stale root-level item" alongside old Storybook files like `favicon.svg`.

3. **PR preview dirs use commit hashes** (`/<7-char-hex>/`) which are hard to identify and require GitHub API calls to match to PRs during cleanup.

## Solution

### `deploy.yml` — switch to `keep_files: false`

Each deploy is now a clean slate. Before deploying, the workflow clones gh-pages and preserves `/pr/` and `/reports/` dirs, then copies them into the fresh `deploy/` directory.

- Sandbox builds with `basePath=/sandbox` (stable, self-contained URL)
- Landing page links directly to `storybook/index.html` and `sandbox/index.html` — no JS resolution needed
- No more hash-versioned main deploy (`/<hash>/`) — stable paths are the canonical URLs

### `ci.yml` — PR previews at `/pr/<number>/`

PR previews now deploy to `/pr/<number>/` instead of `/<commit-hash>/`. Benefits:
- Easy to identify which PR a directory belongs to
- Stable URL across force-pushes (same PR number, content gets overwritten)
- Trivial cleanup — just match PR numbers against open PRs list

### `cleanup-previews.yml` — simplified

- Delete `/pr/<number>/` dirs for closed/merged PRs
- Delete all legacy 7-char hex directories (one-time migration)
- **Stop deleting `/sandbox/`** — it's no longer stale, it's a stable deploy target
- No more complex hash-dir retention logic (main HEAD, latest deployed, etc.)

## gh-pages layout after this PR

```
/storybook/    — stable (always latest main, clean each deploy)
/sandbox/      — stable (always latest main, clean each deploy)
/pr/<number>/  — PR previews (cleaned when PR closes)
/reports/      — vibe test reports (preserved across deploys)
/assets/       — landing page CSS
/index.html    — landing page
/latest        — short hash pointer
```

Supersedes most of #913 (that PR can be narrowed to just the `BuildStatus` component if still wanted).