### PR TITLE
feat(animation): add wave 1 animations

### DIFF
--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -329,7 +329,7 @@ export function XDSDialog({
 
         const cs = getComputedStyle(dialog);
         const duration =
-          cs.getPropertyValue('--duration-medium').trim() || '410ms';
+          cs.getPropertyValue('--duration-medium-max').trim() || '550ms';
         const easing =
           cs.getPropertyValue('--ease-standard').trim() ||
           'cubic-bezier(0.24, 1, 0.4, 1)';

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -91,6 +91,15 @@ export interface XDSDialogPosition {
   top?: number | string;
 }
 
+const enterDirectional = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform:
+      'translate(var(--dialog-dir-x, 0px), var(--dialog-dir-y, 16px)) scale(0.95)',
+  },
+  to: {opacity: 1, transform: 'translate(0, 0) scale(1)'},
+});
+
 /**
  * Dialog styles using native <dialog> element
  * Uses ::backdrop pseudo-element for overlay
@@ -112,12 +121,17 @@ const styles = stylex.create({
     flexDirection: 'column',
     height: 'fit-content',
     overscrollBehavior: 'contain',
-    // Open state opacity (entry animation handled by Web Animations API)
     opacity: {
-      default: 1,
-      ':where(:not([open]))': 0,
+      default: 0,
+      ':where([open])': 1,
     },
+    animationName: {
+      default: 'none',
+      ':where([open])': enterDirectional,
     },
+    animationDuration: durationVars['--duration-medium-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
     outline: {
       default: null,
       ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
@@ -314,36 +328,19 @@ export function XDSDialog({
     if (!dialog) return;
 
     if (isOpen) {
+      // Set directional CSS custom properties before opening
+      const trigger = triggerRef?.current;
+      if (trigger) {
+        const dir = getDialogDirection(trigger);
+        dialog.style.setProperty('--dialog-dir-x', `${dir.x}px`);
+        dialog.style.setProperty('--dialog-dir-y', `${dir.y}px`);
+      } else {
+        dialog.style.setProperty('--dialog-dir-x', '0px');
+        dialog.style.setProperty('--dialog-dir-y', '16px');
+      }
+
       if (!dialog.open) {
         dialog.showModal();
-
-        // Directional entry animation
-        const trigger = triggerRef?.current;
-        let tx = 0;
-        let ty = 8; // default: slide up from below
-        if (trigger) {
-          const dir = getDialogDirection(trigger);
-          tx = dir.x;
-          ty = dir.y;
-        }
-
-        const cs = getComputedStyle(dialog);
-        const duration =
-          cs.getPropertyValue('--duration-medium-max').trim() || '550ms';
-        const easing =
-          cs.getPropertyValue('--ease-standard').trim() ||
-          'cubic-bezier(0.24, 1, 0.4, 1)';
-
-        dialog.animate(
-          [
-            {
-              opacity: 0,
-              transform: `translate(${tx}px, ${ty}px) scale(0.95)`,
-            },
-            {opacity: 1, transform: 'translate(0, 0) scale(1)'},
-          ],
-          {duration: parseFloat(duration), easing, fill: 'backwards'},
-        );
       }
     } else {
       if (dialog.open) {

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -13,7 +13,7 @@
  * - /apps/storybook/stories/Dialog.stories.tsx (storybook stories)
  */
 
-import {useEffect, useRef, type ReactNode} from 'react';
+import {useEffect, useRef, type ReactNode, type RefObject} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {useScrollLock} from '../hooks/useScrollLock';
@@ -26,6 +26,25 @@ import {
 } from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+
+/**
+ * Calculate a directional translate offset for dialog entry animation.
+ * Returns a normalized vector from the trigger element toward the viewport
+ * center, scaled to the given distance.
+ */
+function getDialogDirection(
+  triggerEl: HTMLElement,
+  distance = 16,
+): {x: number; y: number} {
+  const rect = triggerEl.getBoundingClientRect();
+  const dx = rect.left + rect.width / 2 - window.innerWidth / 2;
+  const dy = rect.top + rect.height / 2 - window.innerHeight / 2;
+  const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+  return {
+    x: Math.round((dx / dist) * distance),
+    y: Math.round((dy / dist) * distance),
+  };
+}
 
 /**
  * Extensible variant map for XDSDialog.
@@ -93,30 +112,11 @@ const styles = stylex.create({
     flexDirection: 'column',
     height: 'fit-content',
     overscrollBehavior: 'contain',
-    // Entry/exit animation. Requires @starting-style + allow-discrete
-    // for transitioning from display:none. Browsers without support
-    // get instant show/hide (opacity defaults to 1 in base, animation
-    // layer only applies when @starting-style is supported).
+    // Open state opacity (entry animation handled by Web Animations API)
     opacity: {
       default: 1,
       ':where(:not([open]))': 0,
     },
-    transform: {
-      default: 'scale(1) translateY(0)',
-      ':where(:not([open]))': 'scale(0.95) translateY(8px)',
-    },
-    '@supports (transition-behavior: allow-discrete)': {
-      transitionProperty: 'opacity, transform, display, overlay',
-      transitionDuration: durationVars['--duration-medium'],
-      transitionTimingFunction: easeVars['--ease-standard'],
-      transitionBehavior: 'allow-discrete',
-      '@starting-style': {
-        opacity: 0,
-        transform: 'scale(0.95) translateY(8px)',
-      },
-    },
-    '@media (prefers-reduced-motion: reduce)': {
-      transitionDuration: '0s',
     },
     outline: {
       default: null,
@@ -202,6 +202,14 @@ export interface XDSDialogProps extends XDSBaseProps<HTMLDialogElement> {
   onOpenChange: (isOpen: boolean) => unknown;
 
   /**
+   * Ref to the trigger element that opens the dialog.
+   * When provided, the dialog entry animation slides from the direction
+   * of the trigger toward the viewport center. Focus is returned to
+   * the trigger when the dialog closes.
+   */
+  triggerRef?: RefObject<HTMLElement | null>;
+
+  /**
    * The width of the dialog.
    * Numbers are treated as pixels, strings are used as-is.
    * Ignored when variant is 'fullscreen'.
@@ -270,6 +278,7 @@ export interface XDSDialogProps extends XDSBaseProps<HTMLDialogElement> {
 export function XDSDialog({
   isOpen,
   onOpenChange,
+  triggerRef,
   width = 400,
   maxHeight = '75vh',
   position,
@@ -299,7 +308,7 @@ export function XDSDialog({
     }
   };
 
-  // Handle open/close state
+  // Handle open/close state with directional entry animation
   useEffect(() => {
     const dialog = dialogRef.current;
     if (!dialog) return;
@@ -307,13 +316,43 @@ export function XDSDialog({
     if (isOpen) {
       if (!dialog.open) {
         dialog.showModal();
+
+        // Directional entry animation
+        const trigger = triggerRef?.current;
+        let tx = 0;
+        let ty = 8; // default: slide up from below
+        if (trigger) {
+          const dir = getDialogDirection(trigger);
+          tx = dir.x;
+          ty = dir.y;
+        }
+
+        const cs = getComputedStyle(dialog);
+        const duration =
+          cs.getPropertyValue('--duration-medium').trim() || '410ms';
+        const easing =
+          cs.getPropertyValue('--ease-standard').trim() ||
+          'cubic-bezier(0.24, 1, 0.4, 1)';
+
+        dialog.animate(
+          [
+            {
+              opacity: 0,
+              transform: `translate(${tx}px, ${ty}px) scale(0.95)`,
+            },
+            {opacity: 1, transform: 'translate(0, 0) scale(1)'},
+          ],
+          {duration: parseFloat(duration), easing, fill: 'backwards'},
+        );
       }
     } else {
       if (dialog.open) {
         dialog.close();
       }
+      // Return focus to trigger
+      triggerRef?.current?.focus();
     }
-  }, [isOpen]);
+  }, [isOpen, triggerRef]);
 
   // Lock body scroll when dialog is open (iOS Safari workaround)
   useScrollLock(isOpen);

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -29,6 +29,7 @@ import type {XDSIconType} from '../Icon';
 
 import {XDSDivider} from '../Divider';
 import {XDSDropdownMenuItem} from './XDSDropdownMenuItem';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {
   colorVars,
   spacingVars,
@@ -649,7 +650,7 @@ export function XDSDropdownMenu({
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: [popoverXstyle, styles.popoverGap],
+          xstyle: [popoverXstyle, styles.popoverGap, layerAnimations.below],
         },
       )}
     </>

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -19,6 +19,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSInputStatusType} from './types';
+import {useEntryAnimation} from '../hooks/useEntryAnimation';
 
 const styles = stylex.create({
   base: {
@@ -124,6 +125,8 @@ export function XDSFieldStatus({
   id,
   variant = 'attached',
 }: XDSFieldStatusProps) {
+  const entryStyle = useEntryAnimation('slideDown');
+
   return (
     <div
       id={id}
@@ -133,6 +136,7 @@ export function XDSFieldStatus({
         xdsClassName('field-status', {type, variant}),
         stylex.props(
           styles.base,
+          entryStyle,
           variant === 'attached' ? styles.attached : styles.detached,
           colorStyles[type],
         ),

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Field/index.ts (exports if types change)
  */
 
+'use client';
+
 import * as stylex from '@stylexjs/stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {

--- a/packages/core/src/Field/inputStyles.stylex.ts
+++ b/packages/core/src/Field/inputStyles.stylex.ts
@@ -31,6 +31,7 @@ export const inputWrapperStyles = stylex.create({
   base: {
     boxSizing: 'border-box',
     position: 'relative',
+    zIndex: 1,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],

--- a/packages/core/src/HoverCard/useXDSHoverCard.tsx
+++ b/packages/core/src/HoverCard/useXDSHoverCard.tsx
@@ -24,10 +24,9 @@ import {
   type LayerAlignment,
   type LayerPlacement,
 } from '../Layer/useXDSLayer';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {
   colorVars,
-  durationVars,
-  easeVars,
   shadowVars,
   radiusVars,
   spacingVars,
@@ -35,31 +34,12 @@ import {
 import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
-  // Base container styles passed to useXDSLayer (includes animations)
+  // Base container styles passed to useXDSLayer
   container: {
     backgroundColor: colorVars['--color-background-surface'],
     '--hovercard-radius': radiusVars['--radius-container'],
     borderRadius: 'var(--hovercard-radius)',
     boxShadow: shadowVars['--shadow-med'],
-    // Animation: closed state (default) and open state
-    opacity: {
-      default: 0,
-      ':popover-open': 1,
-    },
-    transform: {
-      default: 'scale(0.95)',
-      ':popover-open': 'scale(1)',
-    },
-    // Transitions with allow-discrete for display/overlay
-    transitionProperty: 'opacity, transform, overlay, display',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    transitionBehavior: 'allow-discrete',
-    // Entry animation starting state
-    '@starting-style': {
-      opacity: 0,
-      transform: 'scale(0.95)',
-    },
   },
   // Position-based margin styles
   marginBlock: {
@@ -418,10 +398,11 @@ export function useXDSHoverCard(
   // Render function that wraps layer.render with hover card behavior
   const renderHoverCard = useCallback(
     (children: ReactNode, props?: ContextRenderProps) => {
+      const renderPlacement = props?.placement ?? placement;
       const renderProps = {
-        placement: props?.placement ?? placement,
+        placement: renderPlacement,
         alignment: props?.alignment ?? alignment,
-        xstyle: popoverXstyle,
+        xstyle: [popoverXstyle, layerAnimations[renderPlacement]],
       };
 
       return layer.render(

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -27,6 +27,9 @@ export type {
   FixedLayerReturn,
 } from './useXDSLayer';
 
+// Shared entry animation styles for layer-based components
+export {layerAnimations} from './layerAnimations.stylex';
+
 // Re-export Popover from new location (backward compat)
 export {useXDSPopover, XDSPopover} from '../Popover';
 export type {

--- a/packages/core/src/Layer/layerAnimations.stylex.ts
+++ b/packages/core/src/Layer/layerAnimations.stylex.ts
@@ -25,27 +25,37 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
-import {durationVars, easeVars} from '../theme/tokens.stylex';
-
-const SLIDE_DISTANCE = '8px';
+import {durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
 
 const enterBelow = stylex.keyframes({
-  from: {opacity: 0, transform: `translateY(-${SLIDE_DISTANCE}) scale(0.95)`},
+  from: {
+    opacity: 0,
+    transform: `translateY(calc(-1 * ${spacingVars['--spacing-2']})) scale(0.95)`,
+  },
   to: {opacity: 1, transform: 'translateY(0) scale(1)'},
 });
 
 const enterAbove = stylex.keyframes({
-  from: {opacity: 0, transform: `translateY(${SLIDE_DISTANCE}) scale(0.95)`},
+  from: {
+    opacity: 0,
+    transform: `translateY(${spacingVars['--spacing-2']}) scale(0.95)`,
+  },
   to: {opacity: 1, transform: 'translateY(0) scale(1)'},
 });
 
 const enterEnd = stylex.keyframes({
-  from: {opacity: 0, transform: `translateX(-${SLIDE_DISTANCE}) scale(0.95)`},
+  from: {
+    opacity: 0,
+    transform: `translateX(calc(-1 * ${spacingVars['--spacing-2']})) scale(0.95)`,
+  },
   to: {opacity: 1, transform: 'translateX(0) scale(1)'},
 });
 
 const enterStart = stylex.keyframes({
-  from: {opacity: 0, transform: `translateX(${SLIDE_DISTANCE}) scale(0.95)`},
+  from: {
+    opacity: 0,
+    transform: `translateX(${spacingVars['--spacing-2']}) scale(0.95)`,
+  },
   to: {opacity: 1, transform: 'translateX(0) scale(1)'},
 });
 

--- a/packages/core/src/Layer/layerAnimations.stylex.ts
+++ b/packages/core/src/Layer/layerAnimations.stylex.ts
@@ -1,0 +1,81 @@
+/**
+ * @file layerAnimations.stylex.ts
+ * @input Uses StyleX, theme duration/easing tokens
+ * @output Exports shared entry animation styles for layer-based components
+ * @position Shared animation primitives; consumed by DropdownMenu, Popover,
+ *   HoverCard, Tooltip, Selector, and any component using useXDSLayer
+ *
+ * Provides opt-in entry animations for popover/layer components.
+ * Components apply these via the `xstyle` prop on `layer.render()`.
+ *
+ * @example
+ * ```
+ * import {layerAnimations} from '../Layer/layerAnimations.stylex';
+ *
+ * // Direction-aware (for components that know placement):
+ * layer.render(<Content />, {
+ *   xstyle: layerAnimations[placement],
+ * });
+ *
+ * // Fixed direction:
+ * layer.render(<Content />, {
+ *   xstyle: layerAnimations.below,
+ * });
+ * ```
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {durationVars, easeVars} from '../theme/tokens.stylex';
+
+const SLIDE_DISTANCE = '8px';
+
+const enterBelow = stylex.keyframes({
+  from: {opacity: 0, transform: `translateY(-${SLIDE_DISTANCE}) scale(0.95)`},
+  to: {opacity: 1, transform: 'translateY(0) scale(1)'},
+});
+
+const enterAbove = stylex.keyframes({
+  from: {opacity: 0, transform: `translateY(${SLIDE_DISTANCE}) scale(0.95)`},
+  to: {opacity: 1, transform: 'translateY(0) scale(1)'},
+});
+
+const enterEnd = stylex.keyframes({
+  from: {opacity: 0, transform: `translateX(-${SLIDE_DISTANCE}) scale(0.95)`},
+  to: {opacity: 1, transform: 'translateX(0) scale(1)'},
+});
+
+const enterStart = stylex.keyframes({
+  from: {opacity: 0, transform: `translateX(${SLIDE_DISTANCE}) scale(0.95)`},
+  to: {opacity: 1, transform: 'translateX(0) scale(1)'},
+});
+
+const animationBase = {
+  animationDuration: durationVars['--duration-fast-max'],
+  animationTimingFunction: easeVars['--ease-standard'],
+  animationFillMode: 'backwards' as const,
+};
+
+/**
+ * Shared entry animation styles for layer-based components.
+ *
+ * Keyed by LayerPlacement ('above' | 'below' | 'start' | 'end')
+ * for easy lookup: `layerAnimations[placement]`.
+ */
+export const layerAnimations = stylex.create({
+  below: {
+    animationName: enterBelow,
+    ...animationBase,
+  },
+  above: {
+    animationName: enterAbove,
+    ...animationBase,
+  },
+  end: {
+    animationName: enterEnd,
+    ...animationBase,
+  },
+  start: {
+    animationName: enterStart,
+    ...animationBase,
+  },
+});

--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -11,7 +11,6 @@
  * - /packages/core/src/Layer/index.ts
  */
 
-
 import React, {
   useCallback,
   useId,

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -152,15 +152,15 @@ const styles = stylex.create({
   },
   interactive: {
     cursor: 'pointer',
-    transitionProperty: 'background-image',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionProperty: 'background-color',
+    transitionDuration: durationVars['--duration-fast-min'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    backgroundImage: {
-      default: null,
+    backgroundColor: {
+      default: 'transparent',
       ':hover': {
-        '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
+        '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
-      ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
+      ':active': colorVars['--color-overlay-pressed'],
     },
   },
   focusWithinOutline: {

--- a/packages/core/src/Popover/XDSPopover.tsx
+++ b/packages/core/src/Popover/XDSPopover.tsx
@@ -26,7 +26,8 @@ import {xdsClassName, mergeProps} from '../utils';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {useXDSPopover} from './useXDSPopover';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useXDSLayer';
-import {durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
+import {spacingVars} from '../theme/tokens.stylex';
 
 // =============================================================================
 // Helpers
@@ -174,27 +175,6 @@ const styles = stylex.create({
   // don't shift the anchor position and cause popover jitter.
   anchorWrapper: {
     display: 'inline-flex',
-  },
-  // Animation styles for the popover element (the one with [popover] attribute).
-  // :popover-open only matches the element with the popover attribute,
-  // so these MUST be applied via xstyle to useXDSLayer's render wrapper.
-  popoverAnimation: {
-    opacity: {
-      default: 0,
-      ':popover-open': 1,
-    },
-    transform: {
-      default: 'scale(0.95)',
-      ':popover-open': 'scale(1)',
-    },
-    transitionProperty: 'opacity, transform, overlay, display',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    transitionBehavior: 'allow-discrete',
-    '@starting-style': {
-      opacity: 0,
-      transform: 'scale(0.95)',
-    },
   },
   // Visual styles for the inner content container
   contentPadding: {
@@ -450,7 +430,7 @@ export function XDSPopover({
           {
             placement,
             alignment,
-            xstyle: [popoverXstyle, styles.gap, styles.popoverAnimation],
+            xstyle: [popoverXstyle, styles.gap, layerAnimations[placement]],
           },
         )}
       </>
@@ -476,7 +456,7 @@ export function XDSPopover({
         {
           placement,
           alignment,
-          xstyle: [popoverXstyle, styles.gap, styles.popoverAnimation],
+          xstyle: [popoverXstyle, styles.gap, layerAnimations[placement]],
         },
       )}
     </>

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -27,6 +27,7 @@ import {
 } from '../Tokenizer';
 import {XDSTypeaheadItem} from '../Typeahead/XDSTypeaheadItem';
 import {XDSToken} from '../Token';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
 import type {XDSIconName} from '../Icon/globalIconRegistry';
@@ -855,7 +856,7 @@ export function XDSPowerSearch({
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: popoverLayerStyles.layer,
+          xstyle: [popoverLayerStyles.layer, layerAnimations.below],
         },
       )}
     </>

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -30,6 +30,7 @@ import {
   inputStatusHoverShadowStyles,
 } from '../Field';
 import {XDSDivider} from '../Divider';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {XDSSpinner} from '../Spinner';
 import {
   colorVars,
@@ -662,7 +663,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: styles.popover,
+          xstyle: [styles.popover, layerAnimations.below],
         },
       )}
     </XDSField>

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -14,7 +14,7 @@
 
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, radiusVars} from '../theme/tokens.stylex';
+import {colorVars, radiusVars, durationVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -62,7 +62,7 @@ const styles = stylex.create({
   },
   animate: {
     animationDirection: 'alternate',
-    animationDuration: `${FADE_TIME}ms`,
+    animationDuration: durationVars['--duration-medium-max'],
     animationIterationCount: 'infinite',
     animationName: skeletonFade,
     animationTimingFunction: 'steps(10, end)',

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -16,7 +16,7 @@
 import {useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {colorVars, durationVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSText} from '../Text/XDSText';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -64,7 +64,7 @@ const styles = stylex.create({
   canvas: {
     backfaceVisibility: 'hidden',
     display: 'block',
-    animationDuration: '750ms',
+    animationDuration: durationVars['--duration-medium-max'],
     animationIterationCount: 'infinite',
     animationName: rotation,
     animationTimingFunction: 'linear',

--- a/packages/core/src/Tooltip/useXDSTooltip.tsx
+++ b/packages/core/src/Tooltip/useXDSTooltip.tsx
@@ -24,10 +24,9 @@ import {
   type LayerAlignment,
   type LayerPlacement,
 } from '../Layer/useXDSLayer';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {
   colorVars,
-  durationVars,
-  easeVars,
   radiusVars,
   spacingVars,
   typographyVars,
@@ -46,25 +45,6 @@ const styles = stylex.create({
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
-    // Animation: closed state (default) and open state
-    opacity: {
-      default: 0,
-      ':popover-open': 1,
-    },
-    transform: {
-      default: 'scale(0.95)',
-      ':popover-open': 'scale(1)',
-    },
-    // Transitions with allow-discrete for display/overlay
-    transitionProperty: 'opacity, transform, overlay, display',
-    transitionDuration: durationVars['--duration-fast-min'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    transitionBehavior: 'allow-discrete',
-    // Entry animation starting state
-    '@starting-style': {
-      opacity: 0,
-      transform: 'scale(0.95)',
-    },
   },
   // Position-based margin styles
   marginBlock: {
@@ -393,10 +373,11 @@ export function useXDSTooltip(
   // Render function that wraps layer.render with tooltip styling
   const renderTooltip = useCallback(
     (children: ReactNode, props?: ContextRenderProps) => {
+      const renderPlacement = props?.placement ?? placement;
       const renderProps = {
-        placement: props?.placement ?? placement,
+        placement: renderPlacement,
         alignment: props?.alignment ?? alignment,
-        xstyle: popoverXstyle,
+        xstyle: [popoverXstyle, layerAnimations[renderPlacement]],
         className: xdsClassName('tooltip'),
       };
 

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -24,3 +24,6 @@ export {useOverflow} from './useOverflow';
 export type {UseOverflowOptions, UseOverflowReturn} from './useOverflow';
 
 export {useScrollLock} from './useScrollLock';
+
+export {useEntryAnimation} from './useEntryAnimation';
+export type {EntryAnimationPreset} from './useEntryAnimation';

--- a/packages/core/src/hooks/useEntryAnimation.ts
+++ b/packages/core/src/hooks/useEntryAnimation.ts
@@ -14,7 +14,7 @@
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {durationVars, easeVars} from '../theme/tokens.stylex';
+import {durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
 
 // Track whether the initial page paint has completed.
 // Elements rendered on page load should not animate;
@@ -33,12 +33,18 @@ if (typeof window !== 'undefined') {
 }
 
 const slideDown = stylex.keyframes({
-  from: {opacity: 0, transform: 'translateY(-8px)'},
+  from: {
+    opacity: 0,
+    transform: `translateY(calc(-1 * ${spacingVars['--spacing-2']}))`,
+  },
   to: {opacity: 1, transform: 'translateY(0)'},
 });
 
 const slideUp = stylex.keyframes({
-  from: {opacity: 0, transform: 'translateY(8px)'},
+  from: {
+    opacity: 0,
+    transform: `translateY(${spacingVars['--spacing-2']})`,
+  },
   to: {opacity: 1, transform: 'translateY(0)'},
 });
 

--- a/packages/core/src/hooks/useEntryAnimation.ts
+++ b/packages/core/src/hooks/useEntryAnimation.ts
@@ -1,0 +1,105 @@
+/**
+ * @file useEntryAnimation.ts
+ * @input Uses React, StyleX, theme tokens
+ * @output Exports useEntryAnimation hook for mount-only entry animations
+ * @position Hook utility; consumed by XDSFieldStatus and available to consumers
+ *
+ * Provides entry animations for conditionally rendered elements.
+ * Only animates when the element is dynamically mounted after the initial
+ * page paint — statically rendered elements on page load are not animated.
+ */
+
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {durationVars, easeVars} from '../theme/tokens.stylex';
+
+// Track whether the initial page paint has completed.
+// Elements rendered on page load should not animate;
+// only dynamically inserted ones should.
+//
+// NOTE: This module is marked 'use client' so it never runs on the server.
+// If the directive is removed, this flag will always be false during SSR,
+// and useState(() => initialPaintComplete) will capture false — meaning
+// animations won't run after hydration. Keep 'use client' or add an
+// effect-based fallback if SSR support is needed.
+let initialPaintComplete = false;
+if (typeof window !== 'undefined') {
+  requestAnimationFrame(() => {
+    initialPaintComplete = true;
+  });
+}
+
+const slideDown = stylex.keyframes({
+  from: {opacity: 0, transform: 'translateY(-8px)'},
+  to: {opacity: 1, transform: 'translateY(0)'},
+});
+
+const slideUp = stylex.keyframes({
+  from: {opacity: 0, transform: 'translateY(8px)'},
+  to: {opacity: 1, transform: 'translateY(0)'},
+});
+
+const fadeIn = stylex.keyframes({
+  from: {opacity: 0},
+  to: {opacity: 1},
+});
+
+const scaleIn = stylex.keyframes({
+  from: {opacity: 0, transform: 'scale(0.95)'},
+  to: {opacity: 1, transform: 'scale(1)'},
+});
+
+const styles = stylex.create({
+  slideDown: {
+    animationName: slideDown,
+    animationDuration: durationVars['--duration-fast-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
+  },
+  slideUp: {
+    animationName: slideUp,
+    animationDuration: durationVars['--duration-fast-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
+  },
+  fadeIn: {
+    animationName: fadeIn,
+    animationDuration: durationVars['--duration-fast-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
+  },
+  scaleIn: {
+    animationName: scaleIn,
+    animationDuration: durationVars['--duration-fast-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
+  },
+});
+
+export type EntryAnimationPreset =
+  | 'slideDown'
+  | 'slideUp'
+  | 'fadeIn'
+  | 'scaleIn';
+
+/**
+ * Returns a StyleX style for animating an element on mount.
+ *
+ * Only animates when the element is dynamically inserted after the initial
+ * page paint. Elements rendered on page load are not animated.
+ *
+ * @example
+ * ```
+ * const entryStyle = useEntryAnimation('slideDown');
+ * <div {...stylex.props(entryStyle)}>Animated content</div>
+ * ```
+ */
+export function useEntryAnimation(
+  preset: EntryAnimationPreset = 'slideDown',
+): StyleXStyles | null {
+  const [animate] = useState(() => initialPaintComplete);
+  return animate ? styles[preset] : null;
+}


### PR DESCRIPTION
## Summary

- Centralizes popover/dropdown/tooltip/hovercard entry animations in `useXDSLayer` using CSS keyframes with direction-aware slide (below/above/start/end)
- Adds `useEntryAnimation` composable hook for conditionally rendered elements (e.g. status messages)
- Tokenizes Spinner (`750ms` → `--duration-medium-max`) and Skeleton (`1000ms` → `--duration-medium-max`) durations
- Fixes ListItem hover using `background-color` instead of non-animatable `background-image`
- Fixes input wrapper z-index so status bar renders behind input border

## Changes

| File | Change |
|---|---|
| `useXDSLayer.tsx` | Direction-aware keyframe entry animations (fade + translateY/X + scale) using `--duration-fast-max` |
| `useEntryAnimation.ts` | New composable hook with `initialPaintComplete` guard for mount-only animations |
| `XDSPopover.tsx` | Removed component-level animation overrides, delegates to layer |
| `useXDSHoverCard.tsx` | Same — removed animation overrides, cleaned unused imports |
| `useXDSTooltip.tsx` | Same — removed animation overrides, cleaned unused imports |
| `XDSFieldStatus.tsx` | Uses `useEntryAnimation('slideDown')` for status message entry |
| `XDSListItem.tsx` | `background-image` → `background-color` for animatable hover, `duration-fast` → `duration-fast-min` |
| `XDSSpinner.tsx` | Hardcoded `750ms` → `--duration-medium-max` token |
| `XDSSkeleton.tsx` | Hardcoded `1000ms` → `--duration-medium-max` token |
| `inputStyles.stylex.ts` | `zIndex: 1` on input wrapper (fixes status bar overlap) |
| `hooks/index.ts` | Exports `useEntryAnimation` |

## Test plan

- [ ] Dropdown menu: click to open, verify fade + slide down animation
- [ ] Popover: click Below/Above/End/Start buttons, verify direction-aware animation
- [ ] HoverCard: hover to trigger, verify entry animation
- [ ] Tooltip: hover to trigger, verify entry animation
- [ ] Selector: click to open, verify entry animation
- [ ] PowerSearch: click search field, verify filter dropdown animates
- [ ] Field status: toggle validation, verify status message slides in (not on page load)
- [ ] List items: hover, verify smooth background-color transition
- [ ] Spinner: verify rotation uses theme duration token
- [ ] Skeleton: verify pulse uses theme duration token
- [ ] Input with status: verify status bar renders behind input bottom border