### PR TITLE
fix(sandbox): use Next.js Link for card hrefs to respect basePath

### DIFF
--- a/apps/sandbox/src/app/ProjectCard.tsx
+++ b/apps/sandbox/src/app/ProjectCard.tsx
@@ -1,20 +1,17 @@
 'use client';
 
+import Link from 'next/link';
 import {XDSText} from '@xds/core/Text';
 import type {SandboxPage} from './sandboxPages';
 import {ImageIcon} from './icons';
 
 export function ProjectCard({page}: {page: SandboxPage}) {
   return (
-    <a
+    <Link
       href={page.href}
       target="_blank"
       rel="noopener noreferrer"
-      style={{
-        textDecoration: 'none',
-        color: 'inherit',
-        display: 'flex',
-      }}>
+      style={{textDecoration: 'none', color: 'inherit', display: 'flex'}}>
       <div
         style={{
           display: 'flex',
@@ -69,6 +66,6 @@ export function ProjectCard({page}: {page: SandboxPage}) {
           </XDSText>
         </div>
       </div>
-    </a>
+    </Link>
   );
 }

--- a/apps/sandbox/src/app/SandboxNav.tsx
+++ b/apps/sandbox/src/app/SandboxNav.tsx
@@ -69,10 +69,9 @@ function SandboxHeader() {
         <XDSDropdownMenu
           button={{
             label: 'Theme',
-            icon: <PaletteIcon />,
+            icon: <PaletteIcon width={16} height={16} style={{color: 'var(--color-icon-secondary)'}} />,
             variant: 'ghost',
             size: 'sm',
-            children: 'Theme',
           }}
           menuWidth={160}
           items={themeItems}
@@ -80,10 +79,14 @@ function SandboxHeader() {
         <XDSDropdownMenu
           button={{
             label: mode === 'dark' ? 'Dark mode' : 'Light mode',
-            icon: mode === 'dark' ? <MoonIcon /> : <SunIcon />,
+            icon:
+              mode === 'dark' ? (
+                <MoonIcon width={16} height={16} style={{color: 'var(--color-icon-secondary)'}} />
+              ) : (
+                <SunIcon width={16} height={16} style={{color: 'var(--color-icon-secondary)'}} />
+              ),
             variant: 'ghost',
             size: 'sm',
-            children: mode === 'dark' ? 'Dark' : 'Light',
           }}
           menuWidth={160}
           items={modeItems}

--- a/apps/sandbox/src/app/SandboxNav.tsx
+++ b/apps/sandbox/src/app/SandboxNav.tsx
@@ -72,6 +72,7 @@ function SandboxHeader() {
             icon: <PaletteIcon />,
             variant: 'ghost',
             size: 'sm',
+            children: 'Theme',
           }}
           menuWidth={160}
           items={themeItems}
@@ -82,6 +83,7 @@ function SandboxHeader() {
             icon: mode === 'dark' ? <MoonIcon /> : <SunIcon />,
             variant: 'ghost',
             size: 'sm',
+            children: mode === 'dark' ? 'Dark' : 'Light',
           }}
           menuWidth={160}
           items={modeItems}


### PR DESCRIPTION
Cards were linking to raw paths like `/pages/navigation/` but the sandbox is deployed under a `/sandbox/` base path. Switching from plain `<a>` to Next.js `<Link>` so the basePath is automatically prepended.