### PR TITLE
fix(banner): always align header items to top when title wraps

### DIFF
--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -16,8 +16,21 @@ const meta: Meta<typeof XDSBanner> = {
     },
     container: {
       control: 'select',
-      options: ['card', 'section'],
-      description: 'Container type',
+      options: ['card', 'section', 'content'],
+      description:
+        'Container type — card (16px padding, rounded), section (full-width, no radius), content (inline with text/lists, element radius)',
+    },
+    labelVariant: {
+      control: 'select',
+      options: ['emphasized', 'regular'],
+      description:
+        'Label weight — emphasized (semibold, description allowed) or regular (normal weight, no description)',
+    },
+    endAreaVariant: {
+      control: 'select',
+      options: [undefined, 'invisibleBackground'],
+      description:
+        'Set to invisibleBackground when endContent uses a ghost button, to apply the -4px optical alignment offset',
     },
     isDismissable: {
       control: 'boolean',
@@ -107,6 +120,70 @@ export const SectionVariant: Story = {
       'The system will be undergoing maintenance on Saturday from 2:00 AM to 6:00 AM UTC.',
     container: 'section',
   },
+};
+
+export const ContentVariant: Story = {
+  name: 'Content Variant (Inline)',
+  args: {
+    status: 'info',
+    title: 'This banner lives inline with other content.',
+    description: 'Use this variant alongside text, lists, and other elements.',
+    container: 'content',
+  },
+};
+
+export const LabelRegular: Story = {
+  name: 'Label Regular Weight',
+  args: {
+    status: 'warning',
+    title: 'Regular weight label, no description.',
+    labelVariant: 'regular',
+  },
+};
+
+export const AllContainerVariants: Story = {
+  name: 'All Container Variants',
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '16px'}}>
+      <XDSBanner
+        status="info"
+        title="Card variant"
+        description="16px padding, rounded corners (radius-container)."
+        container="card"
+      />
+      <XDSBanner
+        status="info"
+        title="Section variant"
+        description="8px block / 16px inline, no border-radius."
+        container="section"
+      />
+      <XDSBanner
+        status="info"
+        title="Content variant"
+        description="8px block / 12px inline, element radius. Lives inline with text."
+        container="content"
+      />
+    </div>
+  ),
+};
+
+export const AllLabelVariants: Story = {
+  name: 'All Label Variants',
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '16px'}}>
+      <XDSBanner
+        status="info"
+        title="Emphasized with description"
+        description="Semibold label + supporting text below."
+      />
+      <XDSBanner status="info" title="Emphasized, no description" />
+      <XDSBanner
+        status="info"
+        title="Regular weight label"
+        labelVariant="regular"
+      />
+    </div>
+  ),
 };
 
 export const CollapsibleContent: Story = {
@@ -256,6 +333,18 @@ export const AllFeatures: Story = {
         title="Section container"
         description="Full-width with no border-radius."
         container="section"
+      />
+      <XDSBanner
+        status="info"
+        title="Content container"
+        description="Inline with text and lists, element radius."
+        container="content"
+      />
+      <XDSBanner
+        status="warning"
+        title="Regular weight label"
+        labelVariant="regular"
+        isDismissable
       />
     </div>
   ),

--- a/packages/core/src/Banner/XDSBanner.test.tsx
+++ b/packages/core/src/Banner/XDSBanner.test.tsx
@@ -7,10 +7,19 @@
  * SYNC: When modified, update this header
  */
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, beforeAll} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {XDSBanner} from './XDSBanner';
+
+// ResizeObserver is not available in JSDOM — mock it
+beforeAll(() => {
+  global.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
 
 describe('XDSBanner', () => {
   it('renders with title and status', () => {

--- a/packages/core/src/Banner/XDSBanner.test.tsx
+++ b/packages/core/src/Banner/XDSBanner.test.tsx
@@ -71,9 +71,9 @@ describe('XDSBanner', () => {
 
   it('does not render description when not provided', () => {
     const {container} = render(<XDSBanner status="info" title="Title Only" />);
-    // Only one <p> for the title, no description
-    const paragraphs = container.querySelectorAll('p');
-    expect(paragraphs).toHaveLength(1);
+    // Title renders, description does not
+    expect(screen.getByText('Title Only')).toBeInTheDocument();
+    expect(container.querySelector('[class*="description"]')).toBeNull();
   });
 
   it('renders dismiss button when isDismissable', () => {

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -505,9 +505,11 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Apply -8px nudge only when there is no endContent (pure ghost buttons only)
+  // Apply -8px nudge when only ghost buttons (no endContent), or when
+  // endContent is also a ghost button (opt-in via endAreaVariant='invisibleBackground')
   const applyEndAreaOffset =
-    endContent == null && (isDismissable || hasChildren);
+    (endContent == null && (isDismissable || hasChildren)) ||
+    endAreaVariant === 'invisibleBackground';
 
   return (
     <div

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -505,11 +505,9 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Apply -8px nudge when no description and ghost buttons are present.
-  // When there's a description, buttons are already visually aligned at flex-start.
+  // Apply -8px nudge whenever ghost buttons are present
   const applyEndAreaOffset =
-    description == null &&
-    (endAreaVariant === 'invisibleBackground' || isDismissable || hasChildren);
+    endAreaVariant === 'invisibleBackground' || isDismissable || hasChildren;
 
   return (
     <div

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -566,42 +566,40 @@ export function XDSBanner({
         </div>
         {showEndArea && (
           <div {...stylex.props(styles.endArea, edgeSignals.end)}>
-            {endContent}
-            {(hasChildren || isDismissable) && (
-              <div
-                {...stylex.props(
-                  styles.endAreaButtons,
-                  applyEndAreaOffset && styles.endAreaInvisibleBackground,
-                )}>
-                {hasChildren && (
-                  <XDSButton
-                    variant="ghost"
-                    size="sm"
-                    label={isExpanded ? 'Collapse' : 'Expand'}
-                    tooltip={isExpanded ? 'Collapse' : 'Expand'}
-                    icon={
-                      <XDSIcon
-                        icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
-                        size="sm"
-                        color="inherit"
-                      />
-                    }
-                    onClick={handleToggleExpand}
-                    aria-expanded={isExpanded}
-                  />
-                )}
-                {isDismissable && (
-                  <XDSButton
-                    variant="ghost"
-                    size="sm"
-                    label="Dismiss"
-                    tooltip="Dismiss"
-                    icon={<XDSIcon icon="close" size="sm" color="inherit" />}
-                    onClick={handleDismiss}
-                  />
-                )}
-              </div>
-            )}
+            <div
+              {...stylex.props(
+                styles.endAreaButtons,
+                applyEndAreaOffset && styles.endAreaInvisibleBackground,
+              )}>
+              {endContent}
+              {hasChildren && (
+                <XDSButton
+                  variant="ghost"
+                  size="sm"
+                  label={isExpanded ? 'Collapse' : 'Expand'}
+                  tooltip={isExpanded ? 'Collapse' : 'Expand'}
+                  icon={
+                    <XDSIcon
+                      icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
+                      size="sm"
+                      color="inherit"
+                    />
+                  }
+                  onClick={handleToggleExpand}
+                  aria-expanded={isExpanded}
+                />
+              )}
+              {isDismissable && (
+                <XDSButton
+                  variant="ghost"
+                  size="sm"
+                  label="Dismiss"
+                  tooltip="Dismiss"
+                  icon={<XDSIcon icon="close" size="sm" color="inherit" />}
+                  onClick={handleDismiss}
+                />
+              )}
+            </div>
           </div>
         )}
       </div>

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -505,10 +505,10 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Apply -8px nudge to the ghost buttons div when dismiss or collapse is present,
-  // or when endContent is also a ghost button (endAreaVariant='invisibleBackground').
+  // Apply -8px nudge only when text is multiline (flex-start) — not when centered.
   const applyEndAreaOffset =
-    endAreaVariant === 'invisibleBackground' || isDismissable || hasChildren;
+    !isSingleLine &&
+    (endAreaVariant === 'invisibleBackground' || isDismissable || hasChildren);
 
   return (
     <div

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -505,9 +505,11 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Apply -8px nudge only when text is multiline (flex-start) — not when centered.
+  // Apply -8px nudge only when single line (no description) and not centered.
+  // When there's a description, buttons are already visually aligned at flex-start.
   const applyEndAreaOffset =
     !isSingleLine &&
+    description == null &&
     (endAreaVariant === 'invisibleBackground' || isDismissable || hasChildren);
 
   return (

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -3,7 +3,7 @@
 /**
  * @file XDSBanner.tsx
  * @input Uses ReactuseState, @heroicons/react/24/solid icons, XDSButton, XDSIcon, StyleX
- * @output Exports XDSBanner component, XDSBannerProps, XDSBannerStatus, XDSBannerContainer types
+ * @output Exports XDSBanner component, XDSBannerProps, XDSBannerStatus, XDSBannerContainer, XDSBannerLabelVariant types
  * @position Core implementation; consumed by index.ts, tested by XDSBanner.test.tsx
  *
  * Visual structure:
@@ -74,6 +74,13 @@ export interface XDSBannerStatusMap {
 export type XDSBannerStatus = keyof XDSBannerStatusMap;
 
 /**
+ * Label variant controlling the title weight and whether description is shown.
+ * - `emphasized`: semibold title, description allowed (default)
+ * - `regular`: normal weight title, description is not rendered
+ */
+export type XDSBannerLabelVariant = 'emphasized' | 'regular';
+
+/**
  * Extensible container map for XDSBanner.
  *
  * Theme packages can add custom container types via TypeScript module augmentation:
@@ -114,7 +121,15 @@ export interface XDSBannerProps {
    */
   title: ReactNode;
   /**
+   * Controls the title weight and whether description is rendered.
+   * - `emphasized`: semibold title, description allowed (default)
+   * - `regular`: normal weight title, description is not rendered
+   * @default 'emphasized'
+   */
+  labelVariant?: XDSBannerLabelVariant;
+  /**
    * Optional description text below the title in the header area.
+   * Only rendered when labelVariant is 'emphasized' (the default).
    */
   description?: ReactNode;
   /**
@@ -291,6 +306,9 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-label-leading'],
     color: colorVars['--color-text-primary'],
   },
+  titleRegular: {
+    fontWeight: fontWeightVars['--font-weight-normal'],
+  },
   description: {
     display: 'block',
     margin: 0,
@@ -412,6 +430,7 @@ const statusStyles = stylex.create({
 export function XDSBanner({
   status,
   title,
+  labelVariant = 'emphasized',
   description,
   icon,
   isDismissable = false,
@@ -491,8 +510,14 @@ export function XDSBanner({
             )}
           </div>
           <div {...stylex.props(styles.headerContent)}>
-            <span {...stylex.props(styles.title)}>{title}</span>
-            {description != null && (
+            <span
+              {...stylex.props(
+                styles.title,
+                labelVariant === 'regular' && styles.titleRegular,
+              )}>
+              {title}
+            </span>
+            {labelVariant === 'emphasized' && description != null && (
               <span {...stylex.props(styles.description)}>{description}</span>
             )}
           </div>

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -505,10 +505,9 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Apply -8px nudge only when single line (no description) and not centered.
+  // Apply -8px nudge when no description and ghost buttons are present.
   // When there's a description, buttons are already visually aligned at flex-start.
   const applyEndAreaOffset =
-    !isSingleLine &&
     description == null &&
     (endAreaVariant === 'invisibleBackground' || isDismissable || hasChildren);
 

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -477,6 +477,10 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
+  // Auto-apply the -4px nudge when only internal ghost buttons are present.
+  // Override with endAreaVariant='invisibleBackground' when endContent is also a ghost button.
+  const applyEndAreaOffset =
+    endAreaVariant === 'invisibleBackground' || endContent == null;
 
   return (
     <div
@@ -536,8 +540,7 @@ export function XDSBanner({
           <div
             {...stylex.props(
               styles.endArea,
-              endAreaVariant === 'invisibleBackground' &&
-                styles.endAreaInvisibleBackground,
+              applyEndAreaOffset && styles.endAreaInvisibleBackground,
               edgeSignals.end,
             )}>
             {endContent}

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -533,7 +533,7 @@ export function XDSBanner({
       <div
         {...stylex.props(
           styles.header,
-          isSingleLine && styles.headerCentered,
+          isSingleLine && description == null && styles.headerCentered,
           container === 'card'
             ? styles.headerCard
             : container === 'section'

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -242,12 +242,18 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'flex-start',
     gap: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-3'],
+  },
+  // card variant: 16px on all sides
+  headerCard: {
+    paddingBlock: spacingVars['--spacing-4'],
     paddingInline: spacingVars['--spacing-4'],
-    // Publish inline padding for edge compensation (ghost buttons at edges).
-    // Uses --container-padding-inline (not --container-padding) because Banner
-    // has different block padding (spacing-3) vs inline padding (spacing-4).
     '--container-padding-inline': spacingVars['--spacing-4'],
+  },
+  // section variant: 8px block, 12px inline
+  headerSection: {
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    '--container-padding-inline': spacingVars['--spacing-3'],
   },
   // Text content area within the header
   headerContent: {
@@ -290,8 +296,6 @@ const styles = stylex.create({
   // Content area — card background for additional content below the header
   contentArea: {
     backgroundColor: colorVars['--color-background-card'],
-    paddingBlock: spacingVars['--spacing-3'],
-    paddingInline: spacingVars['--spacing-4'],
     borderLeftWidth: 1,
     borderRightWidth: 1,
     borderBottomWidth: 1,
@@ -303,8 +307,14 @@ const styles = stylex.create({
     borderBottomColor: colorVars['--color-border'],
   },
   contentAreaCard: {
+    paddingBlock: spacingVars['--spacing-4'],
+    paddingInline: spacingVars['--spacing-4'],
     borderBottomLeftRadius: 'var(--banner-radius)',
     borderBottomRightRadius: 'var(--banner-radius)',
+  },
+  contentAreaSection: {
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
   },
 });
 
@@ -429,7 +439,12 @@ export function XDSBanner({
         style,
       )}>
       {/* Header: colored status background */}
-      <div {...stylex.props(styles.header, statusStyles[status])}>
+      <div
+        {...stylex.props(
+          styles.header,
+          container === 'card' ? styles.headerCard : styles.headerSection,
+          statusStyles[status],
+        )}>
         <div
           {...mergeProps(
             xdsClassName('banner-icon', {status}),
@@ -486,7 +501,9 @@ export function XDSBanner({
         <div
           {...stylex.props(
             styles.contentArea,
-            container === 'card' && styles.contentAreaCard,
+            container === 'card'
+              ? styles.contentAreaCard
+              : styles.contentAreaSection,
           )}>
           {children}
         </div>

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -505,11 +505,9 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Apply -8px nudge when only ghost buttons (no endContent), or when
-  // endContent is also a ghost button (opt-in via endAreaVariant='invisibleBackground')
-  const applyEndAreaOffset =
-    (endContent == null && (isDismissable || hasChildren)) ||
-    endAreaVariant === 'invisibleBackground';
+  // Apply -8px nudge whenever ghost buttons (dismiss/collapse) are present.
+  // Only skipped when endContent is the sole element (primary/default button only).
+  const applyEndAreaOffset = isDismissable || hasChildren;
 
   return (
     <div

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -335,7 +335,7 @@ const styles = stylex.create({
   },
   endAreaButtons: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
     marginInlineStart: 'auto',
@@ -343,7 +343,7 @@ const styles = stylex.create({
   // Ghost buttons (collapse/dismiss) — nudged independently from endContent
   endAreaGhostButtons: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     gap: spacingVars['--spacing-2'],
   },
   endAreaInvisibleBackground: {

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -499,10 +499,13 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Auto-apply the -4px nudge when only internal ghost buttons are present.
-  // Override with endAreaVariant='invisibleBackground' when endContent is also a ghost button.
+  // Apply -8px nudge when internal ghost buttons (dismiss/collapse) are present,
+  // or when endContent is explicitly a ghost button (endAreaVariant='invisibleBackground').
   const applyEndAreaOffset =
-    endAreaVariant === 'invisibleBackground' || endContent == null;
+    endAreaVariant === 'invisibleBackground' ||
+    endContent == null ||
+    isDismissable ||
+    hasChildren;
 
   return (
     <div

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -20,7 +20,7 @@
  * - /apps/storybook/stories/Banner.stories.tsx (storybook stories)
  */
 
-import {useState, type ReactNode} from 'react';
+import {useState, useRef, useEffect, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
@@ -270,6 +270,10 @@ const styles = stylex.create({
     alignItems: 'flex-start',
     gap: spacingVars['--spacing-2'],
   },
+  // Applied when the text content is a single unwrapped line
+  headerCentered: {
+    alignItems: 'center',
+  },
   // card variant: 16px on all sides
   headerCard: {
     paddingBlock: spacingVars['--spacing-4'],
@@ -457,9 +461,27 @@ export function XDSBanner({
 }: XDSBannerProps) {
   const [isDismissed, setIsDismissed] = useState(false);
   const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
+  const [isSingleLine, setIsSingleLine] = useState(false);
+  const headerContentRef = useRef<HTMLDivElement>(null);
   const DefaultIcon = defaultIcons[status];
   const role = statusRole[status];
   const iconColor = statusIconColor[status];
+
+  // Measure whether the text content is a single unwrapped line.
+  // When single-line: center all header items vertically.
+  // When wrapped: anchor to top so icon and buttons don't float to the middle.
+  useEffect(() => {
+    const el = headerContentRef.current;
+    if (el == null) return;
+    const check = () => {
+      // scrollHeight > clientHeight means content has wrapped to multiple lines
+      setIsSingleLine(el.scrollHeight <= el.clientHeight + 2);
+    };
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [title, description]);
   const hasChildren = children != null;
 
   if (isDismissed) {
@@ -503,6 +525,7 @@ export function XDSBanner({
       <div
         {...stylex.props(
           styles.header,
+          isSingleLine && styles.headerCentered,
           container === 'card'
             ? styles.headerCard
             : container === 'section'
@@ -523,7 +546,7 @@ export function XDSBanner({
               <XDSIcon icon={DefaultIcon} size="md" color={iconColor} />
             )}
           </div>
-          <div {...stylex.props(styles.headerContent)}>
+          <div ref={headerContentRef} {...stylex.props(styles.headerContent)}>
             <span
               {...stylex.props(
                 styles.title,

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -341,7 +341,7 @@ const styles = stylex.create({
     marginInlineStart: 'auto',
   },
   endAreaInvisibleBackground: {
-    marginBlockStart: '-4px',
+    marginBlockStart: '-8px',
   },
   // dismissButton negative margin removed — edge compensation handles this
   // automatically via --edge-end signal on the endArea

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -329,6 +329,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
     marginInlineStart: 'auto',
+    marginBlockStart: '-4px',
   },
   // dismissButton negative margin removed — edge compensation handles this
   // automatically via --edge-end signal on the endArea

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -11,6 +11,7 @@
  * - Content area (optional): collapsible card background below the header for additional content (children)
  * - No left border accent — color is expressed through the full header background
  * - When children are provided, a collapse/expand toggle button appears in the end area
+ * - Header always uses alignItems: flex-start so icon and actions pin to the top when title wraps
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Banner/Banner.doc.mjs (props table, features, implementation notes)
@@ -248,10 +249,6 @@ const styles = stylex.create({
     // has different block padding (spacing-3) vs inline padding (spacing-4).
     '--container-padding-inline': spacingVars['--spacing-4'],
   },
-  // When there's only a title (no description) and actions, center everything vertically
-  headerCentered: {
-    alignItems: 'center',
-  },
   // Text content area within the header
   headerContent: {
     display: 'flex',
@@ -414,10 +411,6 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Center items vertically when there's only a title (no description)
-  // and the banner has action buttons
-  const hasActions = endContent != null || isDismissable;
-  const isSingleLine = description == null && hasActions;
 
   return (
     <div
@@ -436,12 +429,7 @@ export function XDSBanner({
         style,
       )}>
       {/* Header: colored status background */}
-      <div
-        {...stylex.props(
-          styles.header,
-          isSingleLine && styles.headerCentered,
-          statusStyles[status],
-        )}>
+      <div {...stylex.props(styles.header, statusStyles[status])}>
         <div
           {...mergeProps(
             xdsClassName('banner-icon', {status}),

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -567,13 +567,13 @@ export function XDSBanner({
         </div>
         {showEndArea && (
           <div {...stylex.props(styles.endAreaButtons, edgeSignals.end)}>
-            {endContent}
-            {(hasChildren || isDismissable) && (
+            {hasChildren || isDismissable ? (
               <div
                 {...stylex.props(
                   styles.endAreaGhostButtons,
                   applyEndAreaOffset && styles.endAreaInvisibleBackground,
                 )}>
+                {endContent}
                 {hasChildren && (
                   <XDSButton
                     variant="ghost"
@@ -602,6 +602,8 @@ export function XDSBanner({
                   />
                 )}
               </div>
+            ) : (
+              endContent
             )}
           </div>
         )}

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -340,6 +340,12 @@ const styles = stylex.create({
     flexShrink: 0,
     marginInlineStart: 'auto',
   },
+  // Ghost buttons (collapse/dismiss) — nudged independently from endContent
+  endAreaGhostButtons: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+  },
   endAreaInvisibleBackground: {
     marginBlockStart: '-8px',
   },
@@ -560,39 +566,42 @@ export function XDSBanner({
           </div>
         </div>
         {showEndArea && (
-          <div
-            {...stylex.props(
-              styles.endAreaButtons,
-              edgeSignals.end,
-              applyEndAreaOffset && styles.endAreaInvisibleBackground,
-            )}>
+          <div {...stylex.props(styles.endAreaButtons, edgeSignals.end)}>
             {endContent}
-            {hasChildren && (
-              <XDSButton
-                variant="ghost"
-                size="sm"
-                label={isExpanded ? 'Collapse' : 'Expand'}
-                tooltip={isExpanded ? 'Collapse' : 'Expand'}
-                icon={
-                  <XDSIcon
-                    icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
+            {(hasChildren || isDismissable) && (
+              <div
+                {...stylex.props(
+                  styles.endAreaGhostButtons,
+                  applyEndAreaOffset && styles.endAreaInvisibleBackground,
+                )}>
+                {hasChildren && (
+                  <XDSButton
+                    variant="ghost"
                     size="sm"
-                    color="inherit"
+                    label={isExpanded ? 'Collapse' : 'Expand'}
+                    tooltip={isExpanded ? 'Collapse' : 'Expand'}
+                    icon={
+                      <XDSIcon
+                        icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
+                        size="sm"
+                        color="inherit"
+                      />
+                    }
+                    onClick={handleToggleExpand}
+                    aria-expanded={isExpanded}
                   />
-                }
-                onClick={handleToggleExpand}
-                aria-expanded={isExpanded}
-              />
-            )}
-            {isDismissable && (
-              <XDSButton
-                variant="ghost"
-                size="sm"
-                label="Dismiss"
-                tooltip="Dismiss"
-                icon={<XDSIcon icon="close" size="sm" color="inherit" />}
-                onClick={handleDismiss}
-              />
+                )}
+                {isDismissable && (
+                  <XDSButton
+                    variant="ghost"
+                    size="sm"
+                    label="Dismiss"
+                    tooltip="Dismiss"
+                    icon={<XDSIcon icon="close" size="sm" color="inherit" />}
+                    onClick={handleDismiss}
+                  />
+                )}
+              </div>
             )}
           </div>
         )}

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -361,11 +361,11 @@ const styles = stylex.create({
     borderBottomRightRadius: 'var(--banner-radius)',
   },
   contentAreaSection: {
-    paddingBlock: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-4'],
     paddingInline: spacingVars['--spacing-4'],
   },
   contentAreaContentVariant: {
-    paddingBlock: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-3'],
     borderBottomLeftRadius: 'var(--banner-radius)',
     borderBottomRightRadius: 'var(--banner-radius)',

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -264,6 +264,7 @@ const styles = stylex.create({
     minWidth: 0,
   },
   title: {
+    display: 'block',
     margin: 0,
     fontFamily: 'inherit',
     fontSize: typeScaleVars['--text-label-size'],
@@ -272,6 +273,7 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
   },
   description: {
+    display: 'block',
     margin: 0,
     fontFamily: 'inherit',
     fontSize: typeScaleVars['--text-supporting-size'],
@@ -458,9 +460,9 @@ export function XDSBanner({
           )}
         </div>
         <div {...stylex.props(styles.headerContent)}>
-          <p {...stylex.props(styles.title)}>{title}</p>
+          <span {...stylex.props(styles.title)}>{title}</span>
           {description != null && (
-            <p {...stylex.props(styles.description)}>{description}</p>
+            <span {...stylex.props(styles.description)}>{description}</span>
           )}
         </div>
         {showEndArea && (

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -540,8 +540,8 @@ export function XDSBanner({
           <div
             {...stylex.props(
               styles.endArea,
-              applyEndAreaOffset && styles.endAreaInvisibleBackground,
               edgeSignals.end,
+              applyEndAreaOffset && styles.endAreaInvisibleBackground,
             )}>
             {endContent}
             {hasChildren && (

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -340,6 +340,11 @@ const styles = stylex.create({
     flexShrink: 0,
     marginInlineStart: 'auto',
   },
+  endAreaButtons: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+  },
   endAreaInvisibleBackground: {
     marginBlockStart: '-8px',
   },
@@ -499,13 +504,10 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Apply -8px nudge when internal ghost buttons (dismiss/collapse) are present,
-  // or when endContent is explicitly a ghost button (endAreaVariant='invisibleBackground').
+  // Apply -8px nudge to the ghost buttons div when dismiss or collapse is present,
+  // or when endContent is also a ghost button (endAreaVariant='invisibleBackground').
   const applyEndAreaOffset =
-    endAreaVariant === 'invisibleBackground' ||
-    endContent == null ||
-    isDismissable ||
-    hasChildren;
+    endAreaVariant === 'invisibleBackground' || isDismissable || hasChildren;
 
   return (
     <div
@@ -563,39 +565,42 @@ export function XDSBanner({
           </div>
         </div>
         {showEndArea && (
-          <div
-            {...stylex.props(
-              styles.endArea,
-              edgeSignals.end,
-              applyEndAreaOffset && styles.endAreaInvisibleBackground,
-            )}>
+          <div {...stylex.props(styles.endArea, edgeSignals.end)}>
             {endContent}
-            {hasChildren && (
-              <XDSButton
-                variant="ghost"
-                size="sm"
-                label={isExpanded ? 'Collapse' : 'Expand'}
-                tooltip={isExpanded ? 'Collapse' : 'Expand'}
-                icon={
-                  <XDSIcon
-                    icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
+            {(hasChildren || isDismissable) && (
+              <div
+                {...stylex.props(
+                  styles.endAreaButtons,
+                  applyEndAreaOffset && styles.endAreaInvisibleBackground,
+                )}>
+                {hasChildren && (
+                  <XDSButton
+                    variant="ghost"
                     size="sm"
-                    color="inherit"
+                    label={isExpanded ? 'Collapse' : 'Expand'}
+                    tooltip={isExpanded ? 'Collapse' : 'Expand'}
+                    icon={
+                      <XDSIcon
+                        icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
+                        size="sm"
+                        color="inherit"
+                      />
+                    }
+                    onClick={handleToggleExpand}
+                    aria-expanded={isExpanded}
                   />
-                }
-                onClick={handleToggleExpand}
-                aria-expanded={isExpanded}
-              />
-            )}
-            {isDismissable && (
-              <XDSButton
-                variant="ghost"
-                size="sm"
-                label="Dismiss"
-                tooltip="Dismiss"
-                icon={<XDSIcon icon="close" size="sm" color="inherit" />}
-                onClick={handleDismiss}
-              />
+                )}
+                {isDismissable && (
+                  <XDSButton
+                    variant="ghost"
+                    size="sm"
+                    label="Dismiss"
+                    tooltip="Dismiss"
+                    icon={<XDSIcon icon="close" size="sm" color="inherit" />}
+                    onClick={handleDismiss}
+                  />
+                )}
+              </div>
             )}
           </div>
         )}

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -563,8 +563,8 @@ export function XDSBanner({
           <div
             {...stylex.props(
               styles.endAreaButtons,
-              applyEndAreaOffset && styles.endAreaInvisibleBackground,
               edgeSignals.end,
+              applyEndAreaOffset && styles.endAreaInvisibleBackground,
             )}>
             {endContent}
             {hasChildren && (

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -286,7 +286,7 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-supporting-size'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
-    color: colorVars['--color-text-secondary'],
+    color: colorVars['--color-text-primary'],
   },
   iconWrapper: {
     display: 'flex',

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -505,9 +505,9 @@ export function XDSBanner({
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
   const showEndArea = endContent != null || isDismissable || hasChildren;
-  // Apply -8px nudge whenever ghost buttons are present
+  // Apply -8px nudge only when there is no endContent (pure ghost buttons only)
   const applyEndAreaOffset =
-    endAreaVariant === 'invisibleBackground' || isDismissable || hasChildren;
+    endContent == null && (isDismissable || hasChildren);
 
   return (
     <div

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -89,12 +89,14 @@ export type XDSBannerStatus = keyof XDSBannerStatusMap;
 export interface XDSBannerContainerMap {
   card: true;
   section: true;
+  content: true;
 }
 
 /**
  * Container type of the banner.
- * - `card`: standalone card with border-radius and shadow
- * - `section`: full-width section banner (no border-radius)
+ * - `card`: standalone card with border-radius (--radius-container) and 16px padding
+ * - `section`: full-width section banner (no border-radius) with 8px block / 16px inline padding
+ * - `content`: inline banner living alongside text and lists, uses --radius-element and 8px block / 12px inline padding
  *
  * Extensible via module augmentation of XDSBannerContainerMap.
  */
@@ -237,6 +239,10 @@ const styles = stylex.create({
   section: {
     borderRadius: '0',
   },
+  content: {
+    '--banner-radius': radiusVars['--radius-element'],
+    borderRadius: 'var(--banner-radius)',
+  },
   // Header area — colored status background with icon, title, description, actions
   header: {
     display: 'flex',
@@ -254,6 +260,12 @@ const styles = stylex.create({
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-4'],
     '--container-padding-inline': spacingVars['--spacing-4'],
+  },
+  // content variant: 8px block, 12px inline
+  headerContentVariant: {
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    '--container-padding-inline': spacingVars['--spacing-3'],
   },
   // Left group: icon + text content — grows to fill available space
   startArea: {
@@ -324,6 +336,12 @@ const styles = stylex.create({
   contentAreaSection: {
     paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-4'],
+  },
+  contentAreaContentVariant: {
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    borderBottomLeftRadius: 'var(--banner-radius)',
+    borderBottomRightRadius: 'var(--banner-radius)',
   },
 });
 
@@ -442,6 +460,7 @@ export function XDSBanner({
           styles.root,
           container === 'card' && styles.card,
           container === 'section' && styles.section,
+          container === 'content' && styles.content,
           xstyle,
         ),
         className,
@@ -451,7 +470,11 @@ export function XDSBanner({
       <div
         {...stylex.props(
           styles.header,
-          container === 'card' ? styles.headerCard : styles.headerSection,
+          container === 'card'
+            ? styles.headerCard
+            : container === 'section'
+              ? styles.headerSection
+              : styles.headerContentVariant,
           statusStyles[status],
         )}>
         <div {...stylex.props(styles.startArea)}>
@@ -514,7 +537,9 @@ export function XDSBanner({
             styles.contentArea,
             container === 'card'
               ? styles.contentAreaCard
-              : styles.contentAreaSection,
+              : container === 'section'
+                ? styles.contentAreaSection
+                : styles.contentAreaContentVariant,
           )}>
           {children}
         </div>

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -249,11 +249,11 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-4'],
     '--container-padding-inline': spacingVars['--spacing-4'],
   },
-  // section variant: 8px block, 12px inline
+  // section variant: 8px block, 16px inline
   headerSection: {
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
-    '--container-padding-inline': spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-4'],
+    '--container-padding-inline': spacingVars['--spacing-4'],
   },
   // Left group: icon + text content — grows to fill available space
   startArea: {
@@ -323,7 +323,7 @@ const styles = stylex.create({
   },
   contentAreaSection: {
     paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-4'],
   },
 });
 

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -255,12 +255,19 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-3'],
     '--container-padding-inline': spacingVars['--spacing-3'],
   },
+  // Left group: icon + text content — grows to fill available space
+  startArea: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: spacingVars['--spacing-2'],
+    flex: 1,
+    minWidth: 0,
+  },
   // Text content area within the header
   headerContent: {
     display: 'flex',
     flexDirection: 'column',
     gap: 0,
-    flex: 1,
     minWidth: 0,
   },
   title: {
@@ -447,23 +454,25 @@ export function XDSBanner({
           container === 'card' ? styles.headerCard : styles.headerSection,
           statusStyles[status],
         )}>
-        <div
-          {...mergeProps(
-            xdsClassName('banner-icon', {status}),
-            stylex.props(styles.iconWrapper),
-          )}
-          aria-hidden="true">
-          {icon != null ? (
-            icon
-          ) : (
-            <XDSIcon icon={DefaultIcon} size="md" color={iconColor} />
-          )}
-        </div>
-        <div {...stylex.props(styles.headerContent)}>
-          <span {...stylex.props(styles.title)}>{title}</span>
-          {description != null && (
-            <span {...stylex.props(styles.description)}>{description}</span>
-          )}
+        <div {...stylex.props(styles.startArea)}>
+          <div
+            {...mergeProps(
+              xdsClassName('banner-icon', {status}),
+              stylex.props(styles.iconWrapper),
+            )}
+            aria-hidden="true">
+            {icon != null ? (
+              icon
+            ) : (
+              <XDSIcon icon={DefaultIcon} size="md" color={iconColor} />
+            )}
+          </div>
+          <div {...stylex.props(styles.headerContent)}>
+            <span {...stylex.props(styles.title)}>{title}</span>
+            {description != null && (
+              <span {...stylex.props(styles.description)}>{description}</span>
+            )}
+          </div>
         </div>
         {showEndArea && (
           <div {...stylex.props(styles.endArea, edgeSignals.end)}>

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -469,6 +469,7 @@ export function XDSBanner({
   const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
   const [isSingleLine, setIsSingleLine] = useState(false);
   const headerContentRef = useRef<HTMLDivElement>(null);
+  const titleRef = useRef<HTMLSpanElement>(null);
   const DefaultIcon = defaultIcons[status];
   const role = statusRole[status];
   const iconColor = statusIconColor[status];
@@ -480,8 +481,13 @@ export function XDSBanner({
     const el = headerContentRef.current;
     if (el == null) return;
     const check = () => {
-      // scrollHeight > clientHeight means content has wrapped to multiple lines
-      setIsSingleLine(el.scrollHeight <= el.clientHeight + 2);
+      // Use getClientRects() on the title span to count actual line boxes.
+      // A single line = 1 rect. Wrapped text = multiple rects.
+      const titleEl = titleRef.current;
+      const rects = titleEl?.getClientRects() ?? [];
+      const titleIsOneLine = rects.length <= 1;
+      // Single line only when: title fits on one line AND no description
+      setIsSingleLine(titleIsOneLine && description == null);
     };
     check();
     const observer = new ResizeObserver(check);
@@ -530,7 +536,7 @@ export function XDSBanner({
       <div
         {...stylex.props(
           styles.header,
-          isSingleLine && description == null && styles.headerCentered,
+          isSingleLine && styles.headerCentered,
           container === 'card'
             ? styles.headerCard
             : container === 'section'
@@ -553,6 +559,7 @@ export function XDSBanner({
           </div>
           <div ref={headerContentRef} {...stylex.props(styles.headerContent)}>
             <span
+              ref={titleRef}
               {...stylex.props(
                 styles.title,
                 labelVariant === 'regular' && styles.titleRegular,

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -159,6 +159,12 @@ export interface XDSBannerProps {
    */
   endContent?: ReactNode;
   /**
+   * Visual variant for the end area.
+   * - `invisibleBackground`: applies a -4px block offset to optically align
+   *   ghost or icon-only buttons with the text. Omit for primary/default buttons.
+   */
+  endAreaVariant?: 'invisibleBackground';
+  /**
    * Container type of the banner.
    * - `card`: standalone card with border-radius
    * - `section`: full-width section banner (no border-radius)
@@ -329,6 +335,8 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
     marginInlineStart: 'auto',
+  },
+  endAreaInvisibleBackground: {
     marginBlockStart: '-4px',
   },
   // dismissButton negative margin removed — edge compensation handles this
@@ -437,6 +445,7 @@ export function XDSBanner({
   isDismissable = false,
   onDismiss,
   endContent,
+  endAreaVariant,
   container = 'card',
   defaultIsExpanded = false,
   children,
@@ -524,7 +533,13 @@ export function XDSBanner({
           </div>
         </div>
         {showEndArea && (
-          <div {...stylex.props(styles.endArea, edgeSignals.end)}>
+          <div
+            {...stylex.props(
+              styles.endArea,
+              endAreaVariant === 'invisibleBackground' &&
+                styles.endAreaInvisibleBackground,
+              edgeSignals.end,
+            )}>
             {endContent}
             {hasChildren && (
               <XDSButton

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -333,17 +333,12 @@ const styles = stylex.create({
     alignItems: 'center',
     flexShrink: 0,
   },
-  endArea: {
+  endAreaButtons: {
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
     marginInlineStart: 'auto',
-  },
-  endAreaButtons: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-2'],
   },
   endAreaInvisibleBackground: {
     marginBlockStart: '-8px',
@@ -565,41 +560,40 @@ export function XDSBanner({
           </div>
         </div>
         {showEndArea && (
-          <div {...stylex.props(styles.endArea, edgeSignals.end)}>
-            <div
-              {...stylex.props(
-                styles.endAreaButtons,
-                applyEndAreaOffset && styles.endAreaInvisibleBackground,
-              )}>
-              {endContent}
-              {hasChildren && (
-                <XDSButton
-                  variant="ghost"
-                  size="sm"
-                  label={isExpanded ? 'Collapse' : 'Expand'}
-                  tooltip={isExpanded ? 'Collapse' : 'Expand'}
-                  icon={
-                    <XDSIcon
-                      icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
-                      size="sm"
-                      color="inherit"
-                    />
-                  }
-                  onClick={handleToggleExpand}
-                  aria-expanded={isExpanded}
-                />
-              )}
-              {isDismissable && (
-                <XDSButton
-                  variant="ghost"
-                  size="sm"
-                  label="Dismiss"
-                  tooltip="Dismiss"
-                  icon={<XDSIcon icon="close" size="sm" color="inherit" />}
-                  onClick={handleDismiss}
-                />
-              )}
-            </div>
+          <div
+            {...stylex.props(
+              styles.endAreaButtons,
+              applyEndAreaOffset && styles.endAreaInvisibleBackground,
+              edgeSignals.end,
+            )}>
+            {endContent}
+            {hasChildren && (
+              <XDSButton
+                variant="ghost"
+                size="sm"
+                label={isExpanded ? 'Collapse' : 'Expand'}
+                tooltip={isExpanded ? 'Collapse' : 'Expand'}
+                icon={
+                  <XDSIcon
+                    icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
+                    size="sm"
+                    color="inherit"
+                  />
+                }
+                onClick={handleToggleExpand}
+                aria-expanded={isExpanded}
+              />
+            )}
+            {isDismissable && (
+              <XDSButton
+                variant="ghost"
+                size="sm"
+                label="Dismiss"
+                tooltip="Dismiss"
+                icon={<XDSIcon icon="close" size="sm" color="inherit" />}
+                onClick={handleDismiss}
+              />
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## What

A comprehensive spacing, typography, and alignment overhaul for `XDSBanner`.

---

## Changes

### Typography
- **Title and description rendered as `<span>` instead of `<p>`** — theme prose rules target `p` elements globally and were overriding the banner's StyleX font styles. Switching to `display: block` spans fixes the override.
- **Description uses primary text color** — changed from `--color-text-secondary` to `--color-text-primary`.
- **Added `labelVariant` prop** — controls title weight and whether description is rendered:
  - `emphasized` (default): semibold title, description allowed
  - `regular`: normal weight title, description suppressed

### Layout structure
- **Wrapped icon + text in a `startArea` div** — groups the icon and text content together so the gap between the start group and end buttons can be controlled independently.

### Container variants & padding
Three container types with distinct padding:

| Variant | Radius | Block | Inline |
|---------|--------|-------|--------|
| `card` | `--radius-container` (12px) | 16px | 16px |
| `section` | none | 8px | 16px |
| `content` | `--radius-element` (8px) | 8px | 12px |

Expanded content area padding:

| Variant | Padding |
|---------|---------|
| `card` | 16px |
| `section` | 16px |
| `content` | 12px |

### Header alignment
- **Always `flex-start` by default** — removed the static `isSingleLine` heuristic that applied `alignItems: center` based on the absence of a description. It couldn't predict text wrapping.
- **Dynamic centering via `ResizeObserver` + `getClientRects()`** — observes the title span at runtime. If the title fits on one line and there is no description, the header centers vertically. If the title wraps (detected via `getClientRects().length > 1`), it switches back to `flex-start` so the icon and buttons anchor to the top.

### End area button alignment
- **`-8px` `marginBlockStart` nudge on the ghost buttons group** — compensates for the 8px top padding inside ghost/icon buttons so they optically align with the title text.
- **Auto-applied** whenever dismiss or collapse buttons are present (no opt-in needed).
- **Skipped** when the header is centered (single-line title, no description) — the nudge is a no-op in that context.
- **`endAreaVariant` prop** — set to `invisibleBackground` when `endContent` is a ghost button to include it in the nudge group.

### Storybook
- Added `content` container, `labelVariant`, and `endAreaVariant` to argTypes
- Added stories: `ContentVariant`, `LabelRegular`, `AllContainerVariants`, `AllLabelVariants`
- Updated `AllFeatures` to cover all new variants