### PR TITLE
fix(table): truncate overflowing cell text with ellipsis

### DIFF
--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -298,3 +298,78 @@ export const KitchenSink: Story = {
     hasHover: true,
   },
 };
+
+// =============================================================================
+// Overflow & Text Wrapping
+// =============================================================================
+
+interface OverflowRow extends Record<string, unknown> {
+  column: string;
+  truncated: string;
+  wrapped: string;
+}
+
+const overflowData: OverflowRow[] = [
+  {
+    column: 'Default (truncate)',
+    truncated:
+      'a_very_long_string_like_this_that_overflows_the_column_without_spaces',
+    wrapped:
+      'a_very_long_string_like_this_that_overflows_the_column_without_spaces',
+  },
+  {
+    column: 'Normal prose',
+    truncated:
+      'This is a longer sentence that will also get clipped by the ellipsis when it runs out of room.',
+    wrapped:
+      'This is a longer sentence that wraps naturally onto the next line when it runs out of room.',
+  },
+];
+
+/**
+ * Cells truncate overflow with an ellipsis by default.
+ * The "Wrapped" column shows how consumers can opt into wrapping
+ * by passing xstyle with white-space: normal and overflow: visible.
+ *
+ * For rich renderCell usage, wrap content in a container with the
+ * appropriate inline styles instead.
+ */
+export const OverflowBehavior: Story = {
+  render: () => {
+    const cols: XDSTableColumn<OverflowRow>[] = [
+      {key: 'column', header: 'Row', width: pixel(140)},
+      {
+        key: 'truncated',
+        header: 'Truncated (default)',
+        width: proportional(1),
+      },
+      {
+        key: 'wrapped',
+        header: 'Wrapped (xstyle override)',
+        width: proportional(1),
+        renderCell: item => (
+          <span
+            style={{
+              whiteSpace: 'normal',
+              overflow: 'visible',
+              wordBreak: 'break-word',
+              display: 'block',
+            }}>
+            {item.wrapped}
+          </span>
+        ),
+      },
+    ];
+
+    return (
+      <div style={{width: '640px'}}>
+        <XDSTable
+          data={overflowData}
+          columns={cols}
+          dividers="grid"
+          density="balanced"
+        />
+      </div>
+    );
+  },
+};

--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -328,13 +328,14 @@ const overflowData: OverflowRow[] = [
 
 /**
  * Cells truncate overflow with an ellipsis by default.
- * The default renderer wraps cell text in XDSText with maxLines={1}, which
- * automatically shows a tooltip when the text is actually truncated.
+ * The default renderer adds a native title tooltip so truncated text
+ * is still accessible on hover.
+ *
+ * For the full XDS tooltip experience (only shows when actually truncated),
+ * use renderCell with <XDSText maxLines={1}>.
  *
  * The "Wrapped" column shows how consumers can opt into wrapping
  * via renderCell with white-space: normal and overflow: visible.
- * renderCell columns own their own overflow disclosure — use
- * XDSText maxLines={1} inside renderCell for the same tooltip behavior.
  */
 export const OverflowBehavior: Story = {
   render: () => {

--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -328,11 +328,13 @@ const overflowData: OverflowRow[] = [
 
 /**
  * Cells truncate overflow with an ellipsis by default.
- * The "Wrapped" column shows how consumers can opt into wrapping
- * by passing xstyle with white-space: normal and overflow: visible.
+ * Hover any truncated cell to see its full value via the native title tooltip —
+ * this is automatically applied when using the default renderer.
  *
- * For rich renderCell usage, wrap content in a container with the
- * appropriate inline styles instead.
+ * The "Wrapped" column shows how consumers can opt into wrapping
+ * via renderCell with white-space: normal and overflow: visible.
+ * Note: renderCell columns do not get an automatic title — the consumer
+ * owns overflow disclosure for rich cell content.
  */
 export const OverflowBehavior: Story = {
   render: () => {

--- a/apps/storybook/stories/Table.stories.tsx
+++ b/apps/storybook/stories/Table.stories.tsx
@@ -328,13 +328,13 @@ const overflowData: OverflowRow[] = [
 
 /**
  * Cells truncate overflow with an ellipsis by default.
- * Hover any truncated cell to see its full value via the native title tooltip —
- * this is automatically applied when using the default renderer.
+ * The default renderer wraps cell text in XDSText with maxLines={1}, which
+ * automatically shows a tooltip when the text is actually truncated.
  *
  * The "Wrapped" column shows how consumers can opt into wrapping
  * via renderCell with white-space: normal and overflow: visible.
- * Note: renderCell columns do not get an automatic title — the consumer
- * owns overflow disclosure for rich cell content.
+ * renderCell columns own their own overflow disclosure — use
+ * XDSText maxLines={1} inside renderCell for the same tooltip behavior.
  */
 export const OverflowBehavior: Story = {
   render: () => {

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -31,6 +31,7 @@ import {
   DEFAULT_MIN_COLUMN_WIDTH,
 } from './columnUtils';
 import {XDSTableRow} from './XDSTableRow';
+import {XDSText} from '../Text';
 import {XDSTableCell} from './XDSTableCell';
 import {XDSTableHeaderCell} from './XDSTableHeaderCell';
 import {xdsClassName, mergeProps} from '../utils';
@@ -102,26 +103,22 @@ function TableRowInner<T extends Record<string, unknown>>({
       item,
     );
 
-    const isDefaultRenderer = !col.renderCell;
     const content = col.renderCell
       ? col.renderCell(item)
       : defaultCellRenderer(item, col.key);
-
-    // When using the default renderer (plain string), add title so truncated
-    // text is accessible on hover — consumers who use renderCell are
-    // responsible for their own overflow disclosure.
-    const titleProp =
-      isDefaultRenderer && typeof content === 'string' && content.length > 0
-        ? {title: content}
-        : {};
 
     return (
       <CellComponent
         key={col.key}
         {...cellRenderProps.htmlProps}
-        {...titleProp}
         xstyle={cellRenderProps.styles}>
-        {content}
+        {col.renderCell ? (
+          content
+        ) : (
+          <XDSText type="body" maxLines={1}>
+            {content}
+          </XDSText>
+        )}
       </CellComponent>
     );
   });
@@ -253,18 +250,19 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
       : cellRenderProps.htmlProps;
 
     const headerContent = col.header ?? col.key;
-    const headerTitleProp =
-      typeof headerContent === 'string' && headerContent.length > 0
-        ? {title: headerContent}
-        : {};
 
     return (
       <HeaderCellComponent
         key={col.key}
         {...mergedHtmlProps}
-        {...headerTitleProp}
         xstyle={cellRenderProps.styles}>
-        {headerContent}
+        {typeof headerContent === 'string' ? (
+          <XDSText type="label" maxLines={1} weight="semibold">
+            {headerContent}
+          </XDSText>
+        ) : (
+          headerContent
+        )}
       </HeaderCellComponent>
     );
   });

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -102,14 +102,24 @@ function TableRowInner<T extends Record<string, unknown>>({
       item,
     );
 
+    const isDefaultRenderer = !col.renderCell;
     const content = col.renderCell
       ? col.renderCell(item)
       : defaultCellRenderer(item, col.key);
+
+    // When using the default renderer (plain string), add title so truncated
+    // text is accessible on hover — consumers who use renderCell are
+    // responsible for their own overflow disclosure.
+    const titleProp =
+      isDefaultRenderer && typeof content === 'string' && content.length > 0
+        ? {title: content}
+        : {};
 
     return (
       <CellComponent
         key={col.key}
         {...cellRenderProps.htmlProps}
+        {...titleProp}
         xstyle={cellRenderProps.styles}>
         {content}
       </CellComponent>
@@ -242,12 +252,19 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
         }
       : cellRenderProps.htmlProps;
 
+    const headerContent = col.header ?? col.key;
+    const headerTitleProp =
+      typeof headerContent === 'string' && headerContent.length > 0
+        ? {title: headerContent}
+        : {};
+
     return (
       <HeaderCellComponent
         key={col.key}
         {...mergedHtmlProps}
+        {...headerTitleProp}
         xstyle={cellRenderProps.styles}>
-        {col.header ?? col.key}
+        {headerContent}
       </HeaderCellComponent>
     );
   });

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -31,7 +31,6 @@ import {
   DEFAULT_MIN_COLUMN_WIDTH,
 } from './columnUtils';
 import {XDSTableRow} from './XDSTableRow';
-import {XDSText} from '../Text';
 import {XDSTableCell} from './XDSTableCell';
 import {XDSTableHeaderCell} from './XDSTableHeaderCell';
 import {xdsClassName, mergeProps} from '../utils';
@@ -107,18 +106,21 @@ function TableRowInner<T extends Record<string, unknown>>({
       ? col.renderCell(item)
       : defaultCellRenderer(item, col.key);
 
+    // Default renderer: add title so truncated text is accessible on hover.
+    // For the full XDS tooltip experience, use renderCell with
+    // <XDSText maxLines={1}> — the title attr is the zero-cost safety net.
+    const titleProp =
+      !col.renderCell && typeof content === 'string' && content.length > 0
+        ? {title: content}
+        : {};
+
     return (
       <CellComponent
         key={col.key}
         {...cellRenderProps.htmlProps}
+        {...titleProp}
         xstyle={cellRenderProps.styles}>
-        {col.renderCell ? (
-          content
-        ) : (
-          <XDSText type="body" maxLines={1}>
-            {content}
-          </XDSText>
-        )}
+        {content}
       </CellComponent>
     );
   });
@@ -250,19 +252,18 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
       : cellRenderProps.htmlProps;
 
     const headerContent = col.header ?? col.key;
+    const headerTitleProp =
+      typeof headerContent === 'string' && headerContent.length > 0
+        ? {title: headerContent}
+        : {};
 
     return (
       <HeaderCellComponent
         key={col.key}
         {...mergedHtmlProps}
+        {...headerTitleProp}
         xstyle={cellRenderProps.styles}>
-        {typeof headerContent === 'string' ? (
-          <XDSText type="label" maxLines={1} weight="semibold">
-            {headerContent}
-          </XDSText>
-        ) : (
-          headerContent
-        )}
+        {headerContent}
       </HeaderCellComponent>
     );
   });

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -684,6 +684,45 @@ describe('XDSTable', () => {
       'a_very_long_string_without_spaces_that_would_overflow_a_fixed_width_column',
     );
   });
+
+  it('sets title attribute on default-rendered cells for overflow accessibility', () => {
+    const longData = [
+      {name: 'a_very_long_string_that_may_be_truncated', value: '42'},
+    ];
+    render(<XDSTable data={longData} />);
+    const cells = screen.getAllByRole('cell');
+    expect(cells[0]).toHaveAttribute(
+      'title',
+      'a_very_long_string_that_may_be_truncated',
+    );
+    expect(cells[1]).toHaveAttribute('title', '42');
+  });
+
+  it('does not set title attribute on renderCell columns', () => {
+    const cols: XDSTableColumn<User>[] = [
+      {
+        key: 'name',
+        header: 'Name',
+        renderCell: item => <span>{item.name}</span>,
+      },
+      {key: 'email', header: 'Email'},
+    ];
+    render(<XDSTable data={users} columns={cols} />);
+    const cells = screen.getAllByRole('cell');
+    // renderCell column: consumer owns disclosure, no title injected
+    expect(cells[0]).not.toHaveAttribute('title');
+    // default renderer: title present
+    expect(cells[1]).toHaveAttribute('title', users[0].email);
+  });
+
+  it('sets title attribute on header cells', () => {
+    render(<XDSTable data={users} columns={columns} />);
+    const headers = screen.getAllByRole('columnheader');
+    // columns fixture order: name, age, email
+    expect(headers[0]).toHaveAttribute('title', 'Name');
+    expect(headers[1]).toHaveAttribute('title', 'Age');
+    expect(headers[2]).toHaveAttribute('title', 'Email');
+  });
 });
 
 // =============================================================================

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -664,6 +664,22 @@ describe('XDSTable', () => {
     expect(idKey).toHaveBeenCalledWith(users[1]);
     expect(idKey).toHaveBeenCalledWith(users[2]);
   });
+
+  it('renders cells that contain long strings without crashing', () => {
+    const longData = [
+      {
+        name: 'a_very_long_string_without_spaces_that_would_overflow_a_fixed_width_column',
+        value: '42',
+      },
+    ];
+    render(<XDSTable data={longData} />);
+    const cell = screen.getAllByRole('cell')[0];
+    expect(cell).toBeInTheDocument();
+    // Long unbroken text renders without breaking layout
+    expect(cell).toHaveTextContent(
+      'a_very_long_string_without_spaces_that_would_overflow_a_fixed_width_column',
+    );
+  });
 });
 
 // =============================================================================

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -665,7 +665,10 @@ describe('XDSTable', () => {
     expect(idKey).toHaveBeenCalledWith(users[2]);
   });
 
-  it('renders cells that contain long strings without crashing', () => {
+  it('applies overflow truncation styles to body cells', () => {
+    // text-overflow: ellipsis + overflow: hidden + white-space: nowrap are applied
+    // via StyleX class names. We verify a class is present on the cell; the actual
+    // CSS rendering is covered by visual/e2e tests (jsdom doesn't compute layout).
     const longData = [
       {
         name: 'a_very_long_string_without_spaces_that_would_overflow_a_fixed_width_column',
@@ -674,8 +677,9 @@ describe('XDSTable', () => {
     ];
     render(<XDSTable data={longData} />);
     const cell = screen.getAllByRole('cell')[0];
-    expect(cell).toBeInTheDocument();
-    // Long unbroken text renders without breaking layout
+    // Cell should have at least one StyleX-generated class applied
+    expect(cell.className.length).toBeGreaterThan(0);
+    // Text content is present in the DOM (truncation is purely visual)
     expect(cell).toHaveTextContent(
       'a_very_long_string_without_spaces_that_would_overflow_a_fixed_width_column',
     );

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -685,20 +685,16 @@ describe('XDSTable', () => {
     );
   });
 
-  it('sets title attribute on default-rendered cells for overflow accessibility', () => {
-    const longData = [
-      {name: 'a_very_long_string_that_may_be_truncated', value: '42'},
-    ];
-    render(<XDSTable data={longData} />);
+  it('wraps default-rendered cells in XDSText with maxLines=1', () => {
+    render(<XDSTable data={users} columns={columns} />);
     const cells = screen.getAllByRole('cell');
-    expect(cells[0]).toHaveAttribute(
-      'title',
-      'a_very_long_string_that_may_be_truncated',
-    );
-    expect(cells[1]).toHaveAttribute('title', '42');
+    // Default renderer wraps content in XDSText which renders a <span>
+    const textSpan = cells[0].querySelector('.xds-text');
+    expect(textSpan).toBeInTheDocument();
+    expect(textSpan).toHaveTextContent('Alice');
   });
 
-  it('does not set title attribute on renderCell columns', () => {
+  it('does not wrap renderCell content in XDSText', () => {
     const cols: XDSTableColumn<User>[] = [
       {
         key: 'name',
@@ -709,19 +705,19 @@ describe('XDSTable', () => {
     ];
     render(<XDSTable data={users} columns={cols} />);
     const cells = screen.getAllByRole('cell');
-    // renderCell column: consumer owns disclosure, no title injected
-    expect(cells[0]).not.toHaveAttribute('title');
-    // default renderer: title present
-    expect(cells[1]).toHaveAttribute('title', users[0].email);
+    // renderCell column: raw content, no XDSText wrapper
+    expect(cells[0].querySelector('.xds-text')).not.toBeInTheDocument();
+    expect(cells[0]).toHaveTextContent('Alice');
+    // default column: has XDSText wrapper
+    expect(cells[1].querySelector('.xds-text')).toBeInTheDocument();
   });
 
-  it('sets title attribute on header cells', () => {
+  it('wraps string header cells in XDSText with maxLines=1', () => {
     render(<XDSTable data={users} columns={columns} />);
     const headers = screen.getAllByRole('columnheader');
-    // columns fixture order: name, age, email
-    expect(headers[0]).toHaveAttribute('title', 'Name');
-    expect(headers[1]).toHaveAttribute('title', 'Age');
-    expect(headers[2]).toHaveAttribute('title', 'Email');
+    const textSpan = headers[0].querySelector('.xds-text');
+    expect(textSpan).toBeInTheDocument();
+    expect(textSpan).toHaveTextContent('Name');
   });
 });
 

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -685,16 +685,15 @@ describe('XDSTable', () => {
     );
   });
 
-  it('wraps default-rendered cells in XDSText with maxLines=1', () => {
+  it('sets title attribute on default-rendered cells for overflow accessibility', () => {
     render(<XDSTable data={users} columns={columns} />);
     const cells = screen.getAllByRole('cell');
-    // Default renderer wraps content in XDSText which renders a <span>
-    const textSpan = cells[0].querySelector('.xds-text');
-    expect(textSpan).toBeInTheDocument();
-    expect(textSpan).toHaveTextContent('Alice');
+    // Default renderer adds title for native hover tooltip on truncated text
+    expect(cells[0]).toHaveAttribute('title', 'Alice');
+    expect(cells[1]).toHaveAttribute('title', '30');
   });
 
-  it('does not wrap renderCell content in XDSText', () => {
+  it('does not set title attribute on renderCell columns', () => {
     const cols: XDSTableColumn<User>[] = [
       {
         key: 'name',
@@ -705,19 +704,19 @@ describe('XDSTable', () => {
     ];
     render(<XDSTable data={users} columns={cols} />);
     const cells = screen.getAllByRole('cell');
-    // renderCell column: raw content, no XDSText wrapper
-    expect(cells[0].querySelector('.xds-text')).not.toBeInTheDocument();
-    expect(cells[0]).toHaveTextContent('Alice');
-    // default column: has XDSText wrapper
-    expect(cells[1].querySelector('.xds-text')).toBeInTheDocument();
+    // renderCell column: consumer owns disclosure
+    expect(cells[0]).not.toHaveAttribute('title');
+    // default column: title present
+    expect(cells[1]).toHaveAttribute('title', users[0].email);
   });
 
-  it('wraps string header cells in XDSText with maxLines=1', () => {
+  it('sets title attribute on string header cells', () => {
     render(<XDSTable data={users} columns={columns} />);
     const headers = screen.getAllByRole('columnheader');
-    const textSpan = headers[0].querySelector('.xds-text');
-    expect(textSpan).toBeInTheDocument();
-    expect(textSpan).toHaveTextContent('Name');
+    // columns fixture order: name, age, email
+    expect(headers[0]).toHaveAttribute('title', 'Name');
+    expect(headers[1]).toHaveAttribute('title', 'Age');
+    expect(headers[2]).toHaveAttribute('title', 'Email');
   });
 });
 

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -79,6 +79,7 @@ const dividerColumnStyles = stylex.create({
     borderRightColor: colorVars['--color-border'],
   },
 });
+
 const overflowStyles = stylex.create({
   cell: {
     overflow: 'hidden',

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -79,6 +79,14 @@ const dividerColumnStyles = stylex.create({
     borderRightColor: colorVars['--color-border'],
   },
 });
+const overflowStyles = stylex.create({
+  cell: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: '0',
+  },
+});
 
 /**
  * XDSTableCell — a `<td>` wrapper for children/streaming mode.
@@ -113,7 +121,10 @@ export function XDSTableCell({
     );
   }
 
-  const cellStyles: StyleXStyles[] = [densityStyles[ctx.density]];
+  const cellStyles: StyleXStyles[] = [
+    densityStyles[ctx.density],
+    overflowStyles.cell,
+  ];
 
   if (ctx.dividers === 'rows' || ctx.dividers === 'grid') {
     cellStyles.push(dividerRowStyles.cell);

--- a/packages/core/src/Table/XDSTableCell.tsx
+++ b/packages/core/src/Table/XDSTableCell.tsx
@@ -22,6 +22,7 @@ import {
 } from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
 import {XDSTableContext} from './XDSTableContext';
+import {overflowStyles} from './table.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 /** Props for XDSTableCell — thin `<td>` wrapper */
@@ -80,14 +81,7 @@ const dividerColumnStyles = stylex.create({
   },
 });
 
-const overflowStyles = stylex.create({
-  cell: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    maxWidth: '0',
-  },
-});
+// Shared overflow styles — see table.stylex.ts for rationale
 
 /**
  * XDSTableCell — a `<td>` wrapper for children/streaming mode.

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -23,6 +23,7 @@ import {
 } from '../theme/tokens.stylex';
 import type {StyleXStyles} from '../theme/types';
 import {XDSTableContext} from './XDSTableContext';
+import {overflowStyles} from './table.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 /** Props for XDSTableHeaderCell — `<th>` wrapper with context-aware styling */
@@ -86,14 +87,8 @@ const dividerColumnStyles = stylex.create({
     borderRightColor: colorVars['--color-border'],
   },
 });
-const overflowStyles = stylex.create({
-  cell: {
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    maxWidth: '0',
-  },
-});
+
+// Shared overflow styles — see table.stylex.ts for rationale
 
 /**
  * XDSTableHeaderCell — a `<th>` wrapper for header cells.

--- a/packages/core/src/Table/XDSTableHeaderCell.tsx
+++ b/packages/core/src/Table/XDSTableHeaderCell.tsx
@@ -86,6 +86,14 @@ const dividerColumnStyles = stylex.create({
     borderRightColor: colorVars['--color-border'],
   },
 });
+const overflowStyles = stylex.create({
+  cell: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: '0',
+  },
+});
 
 /**
  * XDSTableHeaderCell — a `<th>` wrapper for header cells.
@@ -136,6 +144,7 @@ export function XDSTableHeaderCell({
     headerStyles.cell,
     densityStyles[ctx.density],
     headerDividerStyles.cell,
+    overflowStyles.cell,
   ];
 
   if (ctx.dividers === 'columns' || ctx.dividers === 'grid') {

--- a/packages/core/src/Table/table.stylex.ts
+++ b/packages/core/src/Table/table.stylex.ts
@@ -1,0 +1,25 @@
+/**
+ * @file table.stylex.ts
+ * @input StyleX, theme tokens
+ * @output Shared table styles used by XDSTableCell and XDSTableHeaderCell
+ * @position Utility styles; consumed by cell components
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+/**
+ * Overflow truncation for table cells.
+ *
+ * Applied at the <td>/<th> level as a CSS safety net. For data-driven
+ * tables, the default renderer also adds a title attribute so truncated
+ * text is accessible on hover. For the full XDS tooltip experience,
+ * use renderCell with <XDSText maxLines={1}>.
+ */
+export const overflowStyles = stylex.create({
+  cell: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    maxWidth: '0',
+  },
+});


### PR DESCRIPTION
## Problem

With `table-layout: fixed`, long unbreakable strings (like `a_very_long_string_like_this`, URLs, IDs) blow past column boundaries instead of being contained. The text isn't truncated or wrapped — it just overflows and breaks the layout.

## Root Cause

`XDSBaseTable` sets `tableLayout: 'fixed'` on the `<table>` element, which is required for column width control. But `XDSTableCell` and `XDSTableHeaderCell` had no overflow handling, so the browser rendered overflowing text without clipping.

## Fix

Add an `overflowStyles` block to both `XDSTableCell` and `XDSTableHeaderCell`:

```ts
const overflowStyles = stylex.create({
  cell: {
    overflow: 'hidden',
    textOverflow: 'ellipsis',
    whiteSpace: 'nowrap',
    maxWidth: '0',
  },
});
```

**Why `maxWidth: 0`?** This is the CSS trick for making `text-overflow: ellipsis` work inside `table-layout: fixed` cells. Without a definite `max-width`, the browser doesn't know the cell has overflowed, so `text-overflow` is a no-op. Setting `max-width: 0` lets the table layout algorithm still control the actual rendered width (via the `<col>` elements), while telling the cell content that it has no extra room — triggering ellipsis correctly.

## Tests

Added a test that verifies long unbreakable strings render without crashing.

---
