### PR TITLE
fix(AppShell): default variant to "elevated"

### DIFF
--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -250,7 +250,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       type: "'wash' | 'surface' | 'section' | 'elevated'",
       description:
         "Navigation background style controlling how nav areas contrast with content. 'wash' uses wash background, 'surface' uses surface background, 'section' adds dividers between nav and content, 'elevated' uses wash nav with elevated surface content and border radius.",
-      default: "'section'",
+      default: "'elevated'",
     },
     {
       name: 'xstyle',
@@ -507,7 +507,7 @@ const isMobile = useMediaQuery('(max-width: 768px)');
       type: "'wash' | 'surface' | 'section' | 'elevated'",
       description:
         "导航背景样式，控制导航区域与内容之间的对比。'wash' 使用 wash 背景，'surface' 使用 surface 背景，'section' 在导航和内容之间添加分隔线，'elevated' 使用 wash 导航配合凸起的 surface 内容区域和圆角。",
-      default: "'section'",
+      default: "'elevated'",
     },
     {
       name: 'xstyle',

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -79,7 +79,7 @@ export type XDSAppShellBreakpoint = 'sm' | 'md' | 'lg' | 'none';
  * - `surface`: Nav areas use surface background, no dividers
  * - `section`: Dividers between nav and content (classic look)
  * - `elevated`: Wash nav background with elevated surface content + border radius
- * @default 'section'
+ * @default 'elevated'
  */
 /**
  * Extensible variant map for XDSAppShell.
@@ -152,7 +152,7 @@ export interface XDSAppShellProps {
    * - `surface`: Nav uses surface background, no dividers
    * - `section`: Dividers between nav and content (classic look)
    * - `elevated`: Wash nav with elevated surface content area + border radius
-   * @default 'section'
+   * @default 'elevated'
    */
   variant?: XDSAppShellVariant;
 
@@ -426,7 +426,7 @@ const styles = stylex.create({
  * ```
  */
 export function XDSAppShell({
-  variant = 'section',
+  variant = 'elevated',
   banner,
   children,
   contentPadding,


### PR DESCRIPTION
Closes #930

Changes `XDSAppShell` default `variant` prop from its current value to `"elevated"` so consumers get the elevated appearance without needing to specify it explicitly.