### PR TITLE
ci: loosen code owner gate for sandbox & storybook changes

### DIFF
--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -227,7 +227,16 @@ function getStoryTitle(componentName) {
 
     if (storyFiles.length === 0) return null;
 
-    const titles = storyFiles.map(storyFile => {
+    // Prefer exact filename match (e.g. "Table.stories.tsx" for "Table")
+    // over substring matches (e.g. "PowerSearchWithTable.stories.tsx")
+    const exactMatch = storyFiles.find(f =>
+      searchNames.some(name => f.toLowerCase() === `${name.toLowerCase()}.stories.tsx`)
+    );
+    const orderedFiles = exactMatch
+      ? [exactMatch, ...storyFiles.filter(f => f !== exactMatch)]
+      : storyFiles;
+
+    const titles = orderedFiles.map(storyFile => {
       const content = fs.readFileSync(path.join(storiesDir, storyFile), 'utf8');
       const titleMatch = content.match(/title:\s*['"]([^'"]+)['"]/);
       return titleMatch ? titleMatch[1] : null;

--- a/.github/workflows/codeowner-gate.yml
+++ b/.github/workflows/codeowner-gate.yml
@@ -38,6 +38,26 @@ jobs:
 
             console.log(`PR #${prNumber} by @${prAuthor} (${headSha.slice(0, 7)})`);
 
+            // --- Paths that don't require code owner review ---
+            // Sandbox and storybook apps are relaxed — core packages,
+            // CLI, and repo infra still require code owner approval.
+            const RELAXED_PATHS = [
+              'apps/sandbox/',
+              'apps/storybook/',
+            ];
+
+            // Fetch changed files
+            const { data: files } = await github.rest.pulls.listFiles({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+            const changedFiles = files.map(f => f.filename);
+            const onlyRelaxedPaths = changedFiles.length > 0 && changedFiles.every(
+              f => RELAXED_PATHS.some(prefix => f.startsWith(prefix))
+            );
+
             // --- Determine result ---
             let conclusion = 'failure';
             let summary = '';
@@ -45,6 +65,9 @@ jobs:
             if (CODE_OWNERS.includes(prAuthor)) {
               conclusion = 'success';
               summary = `@${prAuthor} is a code owner — approved automatically.`;
+            } else if (onlyRelaxedPaths) {
+              conclusion = 'success';
+              summary = `Only stories/pages changes — code owner review not required.\nFiles: ${changedFiles.join(', ')}`;
             } else {
               // Check for code owner approval
               const { data: reviews } = await github.rest.pulls.listReviews({


### PR DESCRIPTION
Two fixes:

### 1. Auto-pass code owner gate for sandbox/storybook PRs

PRs that **only** touch files under `apps/sandbox/` or `apps/storybook/` no longer require code owner approval to merge. This lets designers iterate on demos and stories without waiting for review.

Core packages, CLI, and repo infra still require code owner approval. The gate re-evaluates on every push, so if a PR grows beyond these paths it'll require review again.

### 2. Fix broken storybook deep links in PR comments

The PR enrichment script matches component names to story files by substring. When multiple stories match (e.g. `Table.stories.tsx` and `PowerSearchWithTable.stories.tsx`), the first alphabetical match wins — which linked Table to the 'Dune' page story instead of 'Core/XDSTable'.

Fix: prefer an exact filename match before falling back to substring.

---
