### PR TITLE
fix(Dialog): provide container styles for child layout components

### DIFF
--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSDialog.tsx
- * @input Uses React, DialogHTMLAttributes, ReactNode
+ * @input Uses React, DialogHTMLAttributes, ReactNode, container (Layout)
  * @output Exports XDSDialog component, XDSDialogProps, XDSDialogVariant, XDSDialogPurpose types
  * @position Core implementation; consumed by index.ts, tested by XDSDialog.test.tsx
  *
@@ -23,6 +23,7 @@ import {
   easeVars,
   shadowVars,
 } from '../theme/tokens.stylex';
+import {container} from '../Layout/container.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
@@ -360,6 +361,7 @@ export function XDSDialog({
       {...mergeProps(
         xdsClassName('dialog', {variant}),
         stylex.props(
+          ...container({}),
           styles.dialog,
           styles.backdrop,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),


### PR DESCRIPTION
## Problem

`XDSDialog` was missing `container()` styles, so the CSS variables that layout sub-components depend on for padding were never set:

- `--layout-padding-inner-x/y`
- `--layout-padding-outer-x/y`  
- `--container-padding`
- `--container-padding-inline`

This caused **zero padding** inside any dialog using `XDSLayout` → `XDSLayoutContent`. The `var()` fallback chain (e.g. `var(--layout-padding-inner-x, var(--spacing-4))`) resolved to nothing when the spacing tokens weren't loaded via `xds.css`.

Found while debugging the BugNub dialog in `xds_oss_leaf_node_app` internally.

## Fix

Apply `container({})` with default `spacing4` values to the `<dialog>` element — the same pattern `XDSCard` and `XDSSection` already use as layout container boundaries.

3-line change. All existing Dialog tests pass.

---
