### PR TITLE
fix(dialog): scrollable content, mobile visibility, container styles

### DIFF
--- a/packages/core/src/Dialog/XDSDialog.test.tsx
+++ b/packages/core/src/Dialog/XDSDialog.test.tsx
@@ -263,4 +263,18 @@ describe('XDSDialog', () => {
       expect(screen.getByRole('dialog')).toBeInTheDocument();
     });
   });
+
+  describe('inner flex wrapper', () => {
+    it('wraps children in a flex container for scroll support', () => {
+      render(
+        <XDSDialog isOpen={true} onOpenChange={() => {}}>
+          <div data-testid="child">Content</div>
+        </XDSDialog>,
+      );
+      const child = screen.getByTestId('child');
+      const wrapper = child.parentElement!;
+      expect(wrapper.tagName).toBe('DIV');
+      expect(wrapper.parentElement!.tagName).toBe('DIALOG');
+    });
+  });
 });

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -91,6 +91,7 @@ const styles = stylex.create({
     },
     flexDirection: 'column',
     height: 'fit-content',
+    overscrollBehavior: 'contain',
     // Entry/exit animation. Requires @starting-style + allow-discrete
     // for transitioning from display:none. Browsers without support
     // get instant show/hide (opacity defaults to 1 in base, animation

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -89,24 +89,28 @@ const styles = stylex.create({
       ':where([open])': 'flex',
     },
     flexDirection: 'column',
-    overflow: 'hidden',
     height: 'fit-content',
-    // Animation for open/close
+    // Entry/exit animation. Requires @starting-style + allow-discrete
+    // for transitioning from display:none. Browsers without support
+    // get instant show/hide (opacity defaults to 1 in base, animation
+    // layer only applies when @starting-style is supported).
     opacity: {
-      default: 0,
-      ':where([open])': 1,
+      default: 1,
+      ':where(:not([open]))': 0,
     },
     transform: {
-      default: 'scale(0.95) translateY(8px)',
-      ':where([open])': 'scale(1) translateY(0)',
+      default: 'scale(1) translateY(0)',
+      ':where(:not([open]))': 'scale(0.95) translateY(8px)',
     },
-    transitionProperty: 'opacity, transform, display, overlay',
-    transitionDuration: durationVars['--duration-medium'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    transitionBehavior: 'allow-discrete',
-    '@starting-style': {
-      opacity: 0,
-      transform: 'scale(0.95) translateY(8px)',
+    '@supports (transition-behavior: allow-discrete)': {
+      transitionProperty: 'opacity, transform, display, overlay',
+      transitionDuration: durationVars['--duration-medium'],
+      transitionTimingFunction: easeVars['--ease-standard'],
+      transitionBehavior: 'allow-discrete',
+      '@starting-style': {
+        opacity: 0,
+        transform: 'scale(0.95) translateY(8px)',
+      },
     },
     '@media (prefers-reduced-motion: reduce)': {
       transitionDuration: '0s',
@@ -135,6 +139,14 @@ const styles = stylex.create({
     borderRadius: 0,
     margin: 0,
     inset: 0,
+  },
+  inner: {
+    display: 'flex',
+    flexDirection: 'column',
+    flex: '1 1 auto',
+    minHeight: 0,
+    overflow: 'hidden',
+    borderRadius: 'inherit',
   },
 });
 
@@ -377,7 +389,7 @@ export function XDSDialog({
         style,
       )}
       {...safeProps}>
-      {children}
+      <div {...stylex.props(styles.inner)}>{children}</div>
     </dialog>
   );
 }

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -373,7 +373,7 @@ export function XDSDialog({
       {...mergeProps(
         xdsClassName('dialog', {variant}),
         stylex.props(
-          ...container({}),
+          ...container({padding: 'spacing0'}),
           styles.dialog,
           styles.backdrop,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSDialog.tsx
- * @input Uses React, DialogHTMLAttributes, ReactNode
+ * @input Uses React, DialogHTMLAttributes, ReactNode, container (Layout)
  * @output Exports XDSDialog component, XDSDialogProps, XDSDialogVariant, XDSDialogPurpose types
  * @position Core implementation; consumed by index.ts, tested by XDSDialog.test.tsx
  *
@@ -23,6 +23,7 @@ import {
   easeVars,
   shadowVars,
 } from '../theme/tokens.stylex';
+import {container} from '../Layout/container.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
@@ -360,6 +361,7 @@ export function XDSDialog({
       {...mergeProps(
         xdsClassName('dialog', {variant}),
         stylex.props(
+          ...container({}),
           styles.dialog,
           styles.backdrop,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -144,7 +144,7 @@ export function XDSDialogHeader({
             {title}
           </XDSHeading>
           {subtitle && (
-            <XDSText type="body" size="sm" color="secondary">
+            <XDSText type="body" size="sm" color="secondary" hasCapsize>
               {subtitle}
             </XDSText>
           )}

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/Dialog.stories.tsx
  */
 
-
 import {useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
@@ -33,6 +32,9 @@ const styles = stylex.create({
   titleWrapper: {
     flex: 1,
     minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
   },
   titleFocusable: {
     outline: 'none',
@@ -134,7 +136,11 @@ export function XDSDialogHeader({
           <div {...stylex.props(styles.actions)}>{startContent}</div>
         )}
         <div {...stylex.props(styles.titleWrapper)}>
-          <XDSHeading ref={titleRef} level={2} xstyle={styles.titleFocusable}>
+          <XDSHeading
+            ref={titleRef}
+            level={2}
+            hasCapsize
+            xstyle={styles.titleFocusable}>
             {title}
           </XDSHeading>
           {subtitle && (

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -15,7 +15,7 @@
 
 import {useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {sizeVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
+import {spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutHeader} from '../Layout/XDSLayoutHeader';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
@@ -28,9 +28,6 @@ const styles = stylex.create({
     alignItems: 'flex-start',
     justifyContent: 'space-between',
     gap: spacingVars['--spacing-3'],
-    // Optical centering: align title cap-height with button icon center.
-    // (buttonMd - layoutPaddingOuter/2 - headingFontSize) / 2
-    paddingBlockStart: `calc((${sizeVars['--size-element-md']} - var(--layout-padding-outer-y, ${spacingVars['--spacing-4']}) / 2 - ${typeScaleVars['--text-heading-2-size']}) / 2)`,
   },
   // Compensate for the icon button's visual padding on the actions area
   actionsCompensation: {
@@ -42,7 +39,7 @@ const styles = stylex.create({
     minWidth: 0,
     display: 'flex',
     flexDirection: 'column',
-    gap: spacingVars['--spacing-2'],
+    gap: 0,
   },
   titleFocusable: {
     outline: 'none',
@@ -143,12 +140,11 @@ export function XDSDialogHeader({
           <XDSHeading
             ref={titleRef}
             level={2}
-            hasCapsize
             xstyle={styles.titleFocusable}>
             {title}
           </XDSHeading>
           {subtitle && (
-            <XDSText type="body" size="sm" color="secondary" hasCapsize>
+            <XDSText type="body" size="sm" color="secondary">
               {subtitle}
             </XDSText>
           )}

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -28,6 +28,7 @@ const styles = stylex.create({
     alignItems: 'flex-start',
     justifyContent: 'space-between',
     gap: spacingVars['--spacing-3'],
+    paddingBlockStart: '2px',
   },
   // Compensate for the icon button's visual padding on the actions area
   actionsCompensation: {

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -15,7 +15,7 @@
 
 import {useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {spacingVars} from '../theme/tokens.stylex';
+import {sizeVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {XDSLayoutHeader} from '../Layout/XDSLayoutHeader';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
@@ -28,7 +28,9 @@ const styles = stylex.create({
     alignItems: 'flex-start',
     justifyContent: 'space-between',
     gap: spacingVars['--spacing-3'],
-    paddingBlockStart: '2px',
+    // Optical centering: align title cap-height with button icon center.
+    // (buttonMd - layoutPaddingOuter/2 - headingFontSize) / 2
+    paddingBlockStart: `calc((${sizeVars['--size-element-md']} - var(--layout-padding-outer-y, ${spacingVars['--spacing-4']}) / 2 - ${typeScaleVars['--text-heading-2-size']}) / 2)`,
   },
   // Compensate for the icon button's visual padding on the actions area
   actionsCompensation: {

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -29,9 +29,8 @@ const styles = stylex.create({
     justifyContent: 'space-between',
     gap: spacingVars['--spacing-3'],
   },
-  // When the close button is rendered, pull the container tighter
-  // to compensate for the icon button's visual padding
-  containerWithClose: {
+  // Compensate for the icon button's visual padding on the actions area
+  actionsCompensation: {
     marginBlock: `calc(-1 * ${spacingVars['--spacing-2']})`,
     marginInlineEnd: `calc(-1 * ${spacingVars['--spacing-2']})`,
   },
@@ -133,11 +132,7 @@ export function XDSDialogHeader({
 
   return (
     <XDSLayoutHeader ref={ref} hasDivider={hasDivider}>
-      <div
-        {...stylex.props(
-          styles.container,
-          onOpenChange && styles.containerWithClose,
-        )}>
+      <div {...stylex.props(styles.container)}>
         {startContent && (
           <div {...stylex.props(styles.actions)}>{startContent}</div>
         )}
@@ -156,7 +151,11 @@ export function XDSDialogHeader({
           )}
         </div>
         {(endContent || onOpenChange) && (
-          <div {...stylex.props(styles.actions)}>
+          <div
+            {...stylex.props(
+              styles.actions,
+              onOpenChange && styles.actionsCompensation,
+            )}>
             {endContent}
             {onOpenChange && (
               <XDSButton

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -39,7 +39,7 @@ const styles = stylex.create({
     minWidth: 0,
     display: 'flex',
     flexDirection: 'column',
-    gap: spacingVars['--spacing-1'],
+    gap: spacingVars['--spacing-2'],
   },
   titleFocusable: {
     outline: 'none',

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -29,6 +29,12 @@ const styles = stylex.create({
     justifyContent: 'space-between',
     gap: spacingVars['--spacing-3'],
   },
+  // When the close button is rendered, pull the container tighter
+  // to compensate for the icon button's visual padding
+  containerWithClose: {
+    marginBlock: `calc(-1 * ${spacingVars['--spacing-2']})`,
+    marginInlineEnd: `calc(-1 * ${spacingVars['--spacing-2']})`,
+  },
   titleWrapper: {
     flex: 1,
     minWidth: 0,
@@ -44,10 +50,6 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
-  },
-  closeButton: {
-    marginTop: `calc(-1 * ${spacingVars['--spacing-2']})`,
-    marginRight: `calc(-1 * ${spacingVars['--spacing-2']})`,
   },
 });
 
@@ -131,7 +133,11 @@ export function XDSDialogHeader({
 
   return (
     <XDSLayoutHeader ref={ref} hasDivider={hasDivider}>
-      <div {...stylex.props(styles.container)}>
+      <div
+        {...stylex.props(
+          styles.container,
+          onOpenChange && styles.containerWithClose,
+        )}>
         {startContent && (
           <div {...stylex.props(styles.actions)}>{startContent}</div>
         )}
@@ -153,15 +159,13 @@ export function XDSDialogHeader({
           <div {...stylex.props(styles.actions)}>
             {endContent}
             {onOpenChange && (
-              <div {...stylex.props(styles.closeButton)}>
-                <XDSButton
-                  variant="ghost"
-                  label="Close"
-                  tooltip="Close"
-                  icon={<XDSIcon icon="close" color="inherit" />}
-                  onClick={() => onOpenChange?.(false)}
-                />
-              </div>
+              <XDSButton
+                variant="ghost"
+                label="Close"
+                tooltip="Close"
+                icon={<XDSIcon icon="close" color="inherit" />}
+                onClick={() => onOpenChange?.(false)}
+              />
             )}
           </div>
         )}


### PR DESCRIPTION
## Three dialog fixes in one

### 1. Scrolling content with maxHeight (#905)

When a dialog has `maxHeight` set and content exceeds it, the content should scroll internally while header/footer stay fixed. Instead, content was clipped.

**Root cause:** Native `<dialog>` gets `height: fit-content` from the UA stylesheet. This makes `height: 100%` on XDSLayout children resolve to `auto` — the layout blows out to full content height and gets clipped by `overflow: hidden`.

**Fix:** Inner flex wrapper (`flex: 1 1 auto; min-height: 0`) so XDSLayout fills via flex instead of percentage height. `overflow: hidden` moved from the dialog to the wrapper so `XDSLayoutContent` `overflow: auto` can activate.

### 2. Dialog invisible on mobile (pre-existing)

On mobile browsers without `@starting-style` support, the dialog showed only the overlay backdrop — the dialog box itself was invisible.

**Root cause:** Entry animation used `opacity: 0` as the default state, transitioning to `1` on `[open]` via `@starting-style` + `allow-discrete`. Browsers without support never triggered the transition, leaving `opacity: 0`.

**Fix:** Inverted the logic — `opacity` defaults to `1`, `:not([open])` sets `0`. Transitions gated behind `@supports (transition-behavior: allow-discrete)`. Unsupported browsers get instant show/hide.

### 3. Missing container styles for child layout (#941)

`XDSDialog` was missing `container()` styles, so CSS variables that layout sub-components depend on for padding (`--layout-padding-inner-x/y`, `--container-padding`, etc.) were never set. This caused zero padding inside any dialog using `XDSLayout` → `XDSLayoutContent`.

**Fix:** Apply `container({})` to the dialog element — same pattern `XDSCard` and `XDSSection` use.

---

Closes #905 · Supersedes #941
