### PR TITLE
fix: avatar status dot sizes + icon non-semantic colors (#929)

### DIFF
--- a/apps/storybook/stories/Icon.stories.tsx
+++ b/apps/storybook/stories/Icon.stories.tsx
@@ -246,3 +246,116 @@ export const InheritColor: Story = {
     </div>
   ),
 };
+
+export const NonSemanticColors: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: '16px',
+        alignItems: 'center',
+        flexWrap: 'wrap',
+      }}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="blue" />
+        <span style={{fontSize: '11px'}}>blue</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="red" />
+        <span style={{fontSize: '11px'}}>red</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="green" />
+        <span style={{fontSize: '11px'}}>green</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="gray" />
+        <span style={{fontSize: '11px'}}>gray</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="cyan" />
+        <span style={{fontSize: '11px'}}>cyan</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="teal" />
+        <span style={{fontSize: '11px'}}>teal</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="yellow" />
+        <span style={{fontSize: '11px'}}>yellow</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="orange" />
+        <span style={{fontSize: '11px'}}>orange</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="pink" />
+        <span style={{fontSize: '11px'}}>pink</span>
+      </div>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          gap: '4px',
+        }}>
+        <XDSIcon icon={StarIcon} color="purple" />
+        <span style={{fontSize: '11px'}}>purple</span>
+      </div>
+    </div>
+  ),
+};

--- a/apps/storybook/stories/Icon.stories.tsx
+++ b/apps/storybook/stories/Icon.stories.tsx
@@ -1,5 +1,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSIcon} from '@xds/core/Icon';
+import {XDSHStack, XDSVStack} from '@xds/core/Layout';
+import {XDSText} from '@xds/core/Text';
 import {
   HomeIcon,
   HeartIcon,
@@ -249,113 +251,13 @@ export const InheritColor: Story = {
 
 export const NonSemanticColors: Story = {
   render: () => (
-    <div
-      style={{
-        display: 'flex',
-        gap: '16px',
-        alignItems: 'center',
-        flexWrap: 'wrap',
-      }}>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="blue" />
-        <span style={{fontSize: '11px'}}>blue</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="red" />
-        <span style={{fontSize: '11px'}}>red</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="green" />
-        <span style={{fontSize: '11px'}}>green</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="gray" />
-        <span style={{fontSize: '11px'}}>gray</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="cyan" />
-        <span style={{fontSize: '11px'}}>cyan</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="teal" />
-        <span style={{fontSize: '11px'}}>teal</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="yellow" />
-        <span style={{fontSize: '11px'}}>yellow</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="orange" />
-        <span style={{fontSize: '11px'}}>orange</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="pink" />
-        <span style={{fontSize: '11px'}}>pink</span>
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          gap: '4px',
-        }}>
-        <XDSIcon icon={StarIcon} color="purple" />
-        <span style={{fontSize: '11px'}}>purple</span>
-      </div>
-    </div>
+    <XDSHStack gap={4} wrap="wrap">
+      {(['blue', 'red', 'green', 'gray', 'cyan', 'teal', 'yellow', 'orange', 'pink', 'purple'] as const).map(color => (
+        <XDSVStack key={color} gap={1} hAlign="center">
+          <XDSIcon icon={StarIcon} color={color} />
+          <XDSText type="supporting">{color}</XDSText>
+        </XDSVStack>
+      ))}
+    </XDSHStack>
   ),
 };

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -28,9 +28,9 @@ import {xdsClassName, mergeProps} from '../utils';
  *
  *   | Avatar size  | Dot  | Border | Icon |
  *   |--------------|------|--------|------|
- *   | ≤ 36px       | 8px  | 1px    | —    |
- *   | 40–72px      | 16px | 2px    | 10px |
- *   | ≥ 96px       | 24px | 4px    | 14px |
+ *   | ≤ 36px       | 10px | 1px    | —    |
+ *   | 40–72px      | 20px | 2px    | 12px |
+ *   | ≥ 96px       | 32px | 4px    | 18px |
  *
  * Icons are not rendered at the smallest tier — there isn't enough
  * room for them to be legible.
@@ -41,12 +41,12 @@ function resolveStatusDotSize(avatarSize: number): {
   iconSize: number;
 } {
   if (avatarSize <= 36) {
-    return {dotSize: 8, borderWidth: 1, iconSize: 0};
+    return {dotSize: 10, borderWidth: 1, iconSize: 0};
   }
   if (avatarSize <= 72) {
-    return {dotSize: 16, borderWidth: 2, iconSize: 10};
+    return {dotSize: 20, borderWidth: 2, iconSize: 12};
   }
-  return {dotSize: 24, borderWidth: 4, iconSize: 14};
+  return {dotSize: 32, borderWidth: 4, iconSize: 18};
 }
 
 /**

--- a/packages/core/src/Icon/XDSIcon.test.tsx
+++ b/packages/core/src/Icon/XDSIcon.test.tsx
@@ -54,6 +54,34 @@ describe('XDSIcon', () => {
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
 
+  it('renders with non-semantic color variants', () => {
+    const nonSemanticColors = [
+      'blue',
+      'red',
+      'green',
+      'gray',
+      'cyan',
+      'teal',
+      'yellow',
+      'orange',
+      'pink',
+      'purple',
+    ] as const;
+    const {rerender} = render(
+      <XDSIcon
+        icon={HomeIcon}
+        color={nonSemanticColors[0]}
+        data-testid="icon"
+      />,
+    );
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+
+    for (const c of nonSemanticColors.slice(1)) {
+      rerender(<XDSIcon icon={HomeIcon} color={c} data-testid="icon" />);
+      expect(screen.getByTestId('icon')).toBeInTheDocument();
+    }
+  });
+
   it('renders with different size variants', () => {
     const {rerender} = render(
       <XDSIcon icon={HomeIcon} size="xsm" data-testid="icon" />,

--- a/packages/core/src/Icon/XDSIcon.tsx
+++ b/packages/core/src/Icon/XDSIcon.tsx
@@ -19,7 +19,6 @@
  * - /apps/storybook/stories/Icon.stories.tsx (storybook stories)
  */
 
-
 import {type ComponentType, type SVGProps} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
@@ -71,6 +70,37 @@ const colorStyles = stylex.create({
   },
   inherit: {
     color: 'inherit',
+  },
+  // Non-semantic colors
+  blue: {
+    color: colorVars['--color-icon-blue'],
+  },
+  red: {
+    color: colorVars['--color-icon-red'],
+  },
+  green: {
+    color: colorVars['--color-icon-green'],
+  },
+  gray: {
+    color: colorVars['--color-icon-gray'],
+  },
+  cyan: {
+    color: colorVars['--color-icon-cyan'],
+  },
+  teal: {
+    color: colorVars['--color-icon-teal'],
+  },
+  yellow: {
+    color: colorVars['--color-icon-yellow'],
+  },
+  orange: {
+    color: colorVars['--color-icon-orange'],
+  },
+  pink: {
+    color: colorVars['--color-icon-pink'],
+  },
+  purple: {
+    color: colorVars['--color-icon-purple'],
   },
 });
 


### PR DESCRIPTION
## Fixes from #929 — Hardening: Content and Display Components

### 1. Avatar status dot sizes (P1)

Updated `resolveStatusDotSize()` in `XDSAvatarStatusDot.tsx` to match WWW reference sizes:

| Avatar size | Dot (old → new) | Inner (old → new) | Border | Icon (old → new) |
|-------------|------------------|--------------------|--------|-------------------|
| ≤ 36px      | 8 → **10px**     | 6 → **8px**        | 1px    | — (too small)     |
| 40–72px     | 16 → **20px**    | 12 → **16px**      | 2px    | 10 → **12px**     |
| ≥ 96px      | 24 → **32px**    | 16 → **24px**      | 4px    | 14 → **18px**     |

Updated JSDoc table to match.

### 2. Icon non-semantic colors (P1)

Added 10 non-semantic color options to `XDSIcon`: `blue`, `red`, `green`, `gray`, `cyan`, `teal`, `yellow`, `orange`, `pink`, `purple`.

All map to existing `--color-icon-*` theme tokens already defined in `tokens.stylex.ts`. The `XDSIconColor` type automatically includes these since it derives from `keyof typeof colorStyles`.

### Tests

- All 2084 tests pass across 119 test files
- Added test coverage for non-semantic icon color variants

---
