### PR TITLE
fix(Dialog): lock body scroll on iOS Safari when modal is open

### DIFF
--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -300,6 +300,37 @@ export function XDSDialog({
     }
   }, [isOpen]);
 
+  // Lock body scroll when dialog is open (iOS Safari workaround)
+  // overscroll-behavior: contain doesn't work on iOS Safari, so we
+  // pin the body with position:fixed to prevent background scrolling.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+    const {body} = document;
+    const prevOverflow = body.style.overflow;
+    const prevPosition = body.style.position;
+    const prevTop = body.style.top;
+    const prevLeft = body.style.left;
+    const prevRight = body.style.right;
+
+    body.style.overflow = 'hidden';
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.left = '0';
+    body.style.right = '0';
+
+    return () => {
+      body.style.overflow = prevOverflow;
+      body.style.position = prevPosition;
+      body.style.top = prevTop;
+      body.style.left = prevLeft;
+      body.style.right = prevRight;
+      window.scrollTo(scrollX, scrollY);
+    };
+  }, [isOpen]);
+
   // Handle Escape key
   useEffect(() => {
     const dialog = dialogRef.current;

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -16,6 +16,7 @@
 import {useEffect, useRef, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
+import {useScrollLock} from '../hooks/useScrollLock';
 import {
   colorVars,
   radiusVars,
@@ -301,35 +302,7 @@ export function XDSDialog({
   }, [isOpen]);
 
   // Lock body scroll when dialog is open (iOS Safari workaround)
-  // overscroll-behavior: contain doesn't work on iOS Safari, so we
-  // pin the body with position:fixed to prevent background scrolling.
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const scrollX = window.scrollX;
-    const scrollY = window.scrollY;
-    const {body} = document;
-    const prevOverflow = body.style.overflow;
-    const prevPosition = body.style.position;
-    const prevTop = body.style.top;
-    const prevLeft = body.style.left;
-    const prevRight = body.style.right;
-
-    body.style.overflow = 'hidden';
-    body.style.position = 'fixed';
-    body.style.top = `-${scrollY}px`;
-    body.style.left = '0';
-    body.style.right = '0';
-
-    return () => {
-      body.style.overflow = prevOverflow;
-      body.style.position = prevPosition;
-      body.style.top = prevTop;
-      body.style.left = prevLeft;
-      body.style.right = prevRight;
-      window.scrollTo(scrollX, scrollY);
-    };
-  }, [isOpen]);
+  useScrollLock(isOpen);
 
   // Handle Escape key
   useEffect(() => {

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -22,3 +22,5 @@ export {useMediaQuery} from './useMediaQuery';
 
 export {useOverflow} from './useOverflow';
 export type {UseOverflowOptions, UseOverflowReturn} from './useOverflow';
+
+export {useScrollLock} from './useScrollLock';

--- a/packages/core/src/hooks/useScrollLock.ts
+++ b/packages/core/src/hooks/useScrollLock.ts
@@ -1,0 +1,59 @@
+'use client';
+
+/**
+ * @file useScrollLock.ts
+ * @input Uses React useEffect
+ * @output Exports useScrollLock hook for locking body scroll
+ * @position Core hook; used by Dialog to prevent background scrolling
+ *
+ * Locks body scroll when active by pinning the body with position:fixed.
+ * This is needed because overscroll-behavior:contain doesn't work on iOS Safari.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts
+ */
+
+import {useEffect} from 'react';
+
+/**
+ * Locks body scroll when `isLocked` is true.
+ *
+ * Pins the body with `position: fixed` to prevent background scrolling,
+ * which is necessary for iOS Safari where `overscroll-behavior: contain`
+ * does not prevent body scroll behind modals. Restores scroll position
+ * on unlock.
+ *
+ * @example
+ * ```
+ * useScrollLock(isOpen);
+ * ```
+ */
+export function useScrollLock(isLocked: boolean): void {
+  useEffect(() => {
+    if (!isLocked) return;
+
+    const scrollX = window.scrollX;
+    const scrollY = window.scrollY;
+    const {body} = document;
+    const prevOverflow = body.style.overflow;
+    const prevPosition = body.style.position;
+    const prevTop = body.style.top;
+    const prevLeft = body.style.left;
+    const prevRight = body.style.right;
+
+    body.style.overflow = 'hidden';
+    body.style.position = 'fixed';
+    body.style.top = `-${scrollY}px`;
+    body.style.left = '0';
+    body.style.right = '0';
+
+    return () => {
+      body.style.overflow = prevOverflow;
+      body.style.position = prevPosition;
+      body.style.top = prevTop;
+      body.style.left = prevLeft;
+      body.style.right = prevRight;
+      window.scrollTo(scrollX, scrollY);
+    };
+  }, [isLocked]);
+}


### PR DESCRIPTION
## Problem

When an XDSDialog modal is open on iOS Safari, scrolling on the overlay/backdrop or at the edges of modal content causes the page underneath to scroll. `overscroll-behavior: contain` (already set on the dialog) works in Chrome/Firefox but not iOS Safari.

## Solution

Adds a body scroll lock effect that activates when the dialog opens:

1. Saves current scroll position
2. Sets `document.body` to `overflow: hidden; position: fixed; top: -scrollY` — the reliable iOS Safari scroll prevention technique
3. Restores body styles and scroll position when dialog closes or unmounts

This is a well-established pattern used by most modal libraries (Radix, Headless UI, etc.) to work around iOS Safari's incomplete `overscroll-behavior` support.

## Changes

- `packages/core/src/Dialog/XDSDialog.tsx` — added `useEffect` for body scroll lock

---
