### PR TITLE
feat(cli): codemod Badge dot mode → StatusDot

### DIFF
--- a/apps/storybook/stories/Badge.stories.tsx
+++ b/apps/storybook/stories/Badge.stories.tsx
@@ -1,6 +1,8 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSBadge} from '@xds/core/Badge';
 
+import {XDSStatusDot} from '@xds/core/StatusDot';
+
 const meta: Meta<typeof XDSBadge> = {
   title: 'Core/XDSBadge',
   component: XDSBadge,
@@ -57,11 +59,11 @@ export const Counts: Story = {
 export const DotIndicators: Story = {
   render: () => (
     <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
-      <XDSBadge variant="neutral" shape="dot" label="Neutral" />
-      <XDSBadge variant="info" shape="dot" label="Info" />
-      <XDSBadge variant="success" shape="dot" label="Online" />
-      <XDSBadge variant="warning" shape="dot" label="Away" />
-      <XDSBadge variant="error" shape="dot" label="Busy" />
+      <XDSStatusDot variant="neutral" label="Neutral" />
+      <XDSStatusDot variant="info" label="Info" />
+      <XDSStatusDot variant="positive" label="Online" />
+      <XDSStatusDot variant="warning" label="Away" />
+      <XDSStatusDot variant="negative" label="Busy" />
     </div>
   ),
 };

--- a/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-badge-dot-to-statusdot.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/__tests__/migrate-badge-dot-to-statusdot.test.mjs
@@ -1,0 +1,135 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../migrate-badge-dot-to-statusdot.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const api = {jscodeshift, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+function getRawResult(source) {
+  return import('../migrate-badge-dot-to-statusdot.mjs').then(
+    async ({default: transform}) => {
+      const jscodeshift = (await import('jscodeshift')).default;
+      const api = {jscodeshift, stats: () => {}, report: () => {}};
+      return transform({source, path: 'test.tsx'}, api);
+    },
+  );
+}
+
+describe('migrate-badge-dot-to-statusdot', () => {
+  it('transforms shape="dot" badge to StatusDot', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="warning" shape="dot" label="Away" />`;
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSStatusDot');
+    expect(output).toContain('variant="warning"');
+    expect(output).toContain('label="Away"');
+    expect(output).not.toContain('shape');
+    expect(output).not.toContain('XDSBadge');
+  });
+
+  it('maps success to positive and error to negative', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="success" shape="dot" label="Online" />`;
+    const output = await applyTransform(input);
+    expect(output).toContain('variant="positive"');
+
+    const input2 = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="error" shape="dot" label="Offline" />`;
+    const output2 = await applyTransform(input2);
+    expect(output2).toContain('variant="negative"');
+  });
+
+  it('does NOT transform badge without shape="dot"', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="error" label="3" />`;
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSBadge');
+    expect(output).not.toContain('XDSStatusDot');
+  });
+
+  it('does NOT transform badge with icon prop even if shape="dot"', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="success" shape="dot" label="Active" icon={checkIcon} />`;
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSBadge');
+    expect(output).not.toContain('XDSStatusDot');
+  });
+
+  it('adds StatusDot import', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="neutral" shape="dot" label="Idle" />`;
+    const output = await applyTransform(input);
+    expect(output).toMatch(/from ['"]@xds\/core\/StatusDot['"]/);
+    expect(output).toContain('XDSStatusDot');
+  });
+
+  it('removes Badge import when no other usages remain', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="info" shape="dot" label="Info" />`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain("from '@xds/core/Badge'");
+    expect(output).not.toContain('XDSBadge');
+  });
+
+  it('keeps Badge import when mixed dot + pill usages exist', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<div>
+  <XDSBadge variant="error" shape="dot" label="Unread" />
+  <XDSBadge variant="success" label="5" />
+</div>`;
+    const output = await applyTransform(input);
+    expect(output).toContain("from '@xds/core/Badge'");
+    expect(output).toMatch(/from ['"]@xds\/core\/StatusDot['"]/);
+    // The dot mode one should be converted
+    expect(output).toContain('XDSStatusDot');
+    // The pill one should remain
+    expect(output).toContain('XDSBadge');
+  });
+
+  it('does not transform non-XDS component with shape="dot"', async () => {
+    const input = '<Badge variant="error" shape="dot" label="x" />';
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('returns undefined when no changes needed', async () => {
+    const result = await getRawResult('<XDSButton>Click</XDSButton>');
+    expect(result).toBeUndefined();
+  });
+
+  it('preserves other props (xstyle, className, data-testid, ref)', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="error" shape="dot" label="Status" xstyle={styles.dot} className="my-badge" data-testid="status-dot" ref={badgeRef} />`;
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSStatusDot');
+    expect(output).toContain('variant="negative"');
+    expect(output).toContain('label="Status"');
+    expect(output).toContain('xstyle={styles.dot}');
+    expect(output).toContain('className="my-badge"');
+    expect(output).toContain('data-testid="status-dot"');
+    expect(output).toContain('ref={badgeRef}');
+    expect(output).not.toContain('shape');
+  });
+
+  it('defaults to neutral when no variant prop', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge shape="dot" label="Unknown" />`;
+    const output = await applyTransform(input);
+    expect(output).toContain('variant="neutral"');
+    expect(output).toContain('label="Unknown"');
+  });
+
+  it('passes through label prop (not replaced with placeholder)', async () => {
+    const input = `import {XDSBadge} from '@xds/core/Badge';
+<XDSBadge variant="error" shape="dot" label="Unread" />`;
+    const output = await applyTransform(input);
+    expect(output).toContain('label="Unread"');
+    expect(output).not.toContain('label="status"');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.2/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/index.mjs
@@ -37,6 +37,9 @@ import migrateGapToNumeric, {
 import migrateIsFullBleedToPadding, {
   meta as fullBleedMeta,
 } from './migrate-isFullBleed-to-padding.mjs';
+import migrateBadgeDotToStatusDot, {
+  meta as badgeDotMeta,
+} from './migrate-badge-dot-to-statusdot.mjs';
 export default [
   {
     name: 'rename-selector-items-to-options',
@@ -92,5 +95,10 @@ export default [
     name: 'migrate-isFullBleed-to-padding',
     transform: migrateIsFullBleedToPadding,
     meta: fullBleedMeta,
+  },
+  {
+    name: 'migrate-badge-dot-to-statusdot',
+    transform: migrateBadgeDotToStatusDot,
+    meta: badgeDotMeta,
   },
 ];

--- a/packages/cli/src/codemods/transforms/v0.0.2/migrate-badge-dot-to-statusdot.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.2/migrate-badge-dot-to-statusdot.mjs
@@ -1,0 +1,226 @@
+/**
+ * @file Codemod: Migrate Badge dot mode → StatusDot
+ * @see https://github.com/facebookexperimental/xds/pull/945
+ *
+ * Converts XDSBadge with shape="dot" to XDSStatusDot.
+ * Variant mapping: success→positive, error→negative, others unchanged.
+ * Passes through label prop for a11y.
+ */
+
+export const meta = {
+  title: 'Migrate Badge dot → StatusDot',
+  description: 'Converts XDSBadge shape="dot" to XDSStatusDot.',
+  pr: '#945',
+};
+
+const VARIANT_MAP = {
+  success: 'positive',
+  error: 'negative',
+  warning: 'warning',
+  info: 'info',
+  neutral: 'neutral',
+};
+
+function isDotMode(path) {
+  const opening = path.node.openingElement;
+
+  // Dot mode is indicated by shape="dot" prop
+  const hasShapeDot = opening.attributes.some(
+    (attr) =>
+      attr.type === 'JSXAttribute' &&
+      attr.name.type === 'JSXIdentifier' &&
+      attr.name.name === 'shape' &&
+      attr.value &&
+      (attr.value.type === 'Literal' || attr.value.type === 'StringLiteral') &&
+      attr.value.value === 'dot',
+  );
+  if (!hasShapeDot) return false;
+
+  // If icon prop is present, leave alone
+  const hasIcon = opening.attributes.some(
+    (attr) =>
+      attr.type === 'JSXAttribute' &&
+      attr.name.type === 'JSXIdentifier' &&
+      attr.name.name === 'icon',
+  );
+  if (hasIcon) return false;
+
+  return true;
+}
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Find all XDSBadge JSX elements
+  root.find(j.JSXElement).forEach((path) => {
+    const opening = path.node.openingElement;
+    if (
+      opening.name.type !== 'JSXIdentifier' ||
+      opening.name.name !== 'XDSBadge'
+    ) {
+      return;
+    }
+
+    if (!isDotMode(path)) return;
+
+    // Map variant
+    const variantAttr = opening.attributes.find(
+      (attr) =>
+        attr.type === 'JSXAttribute' &&
+        attr.name.name === 'variant',
+    );
+
+    let newVariantValue = 'neutral'; // default
+    if (variantAttr) {
+      if (
+        variantAttr.value &&
+        (variantAttr.value.type === 'StringLiteral' ||
+          variantAttr.value.type === 'Literal')
+      ) {
+        const oldVariant = variantAttr.value.value;
+        newVariantValue =
+          Object.hasOwn(VARIANT_MAP, oldVariant)
+            ? VARIANT_MAP[oldVariant]
+            : oldVariant;
+      } else if (
+        variantAttr.value &&
+        variantAttr.value.type === 'JSXExpressionContainer'
+      ) {
+        // Dynamic variant — pass through as-is, no mapping possible
+        newVariantValue = null;
+      }
+    }
+
+    // Build new attributes
+    const newAttributes = [];
+
+    // Add mapped variant
+    if (newVariantValue !== null) {
+      newAttributes.push(
+        j.jsxAttribute(
+          j.jsxIdentifier('variant'),
+          j.stringLiteral(newVariantValue),
+        ),
+      );
+    } else if (variantAttr) {
+      // Dynamic variant — keep original attribute
+      newAttributes.push(variantAttr);
+    }
+
+    // Pass through other props (skip variant and shape since we handled them)
+    for (const attr of opening.attributes) {
+      if (attr.type === 'JSXSpreadAttribute') {
+        newAttributes.push(attr);
+        continue;
+      }
+      if (attr.name.name === 'variant') continue;
+      if (attr.name.name === 'shape') continue;
+      newAttributes.push(attr);
+    }
+
+    // Replace with self-closing XDSStatusDot
+    const newElement = j.jsxElement(
+      j.jsxOpeningElement(
+        j.jsxIdentifier('XDSStatusDot'),
+        newAttributes,
+        true,
+      ),
+      null,
+      [],
+    );
+
+    j(path).replaceWith(newElement);
+    hasChanges = true;
+  });
+
+  if (!hasChanges) return undefined;
+
+  // Handle imports
+  const badgeImports = root.find(j.ImportDeclaration).filter((path) => {
+    const source = path.node.source.value;
+    return (
+      typeof source === 'string' &&
+      (source === '@xds/core' ||
+        source === '@xds/core/Badge' ||
+        source.endsWith('/Badge'))
+    );
+  });
+
+  // Check if any XDSBadge usages remain
+  const remainingBadgeUsages = root
+    .find(j.JSXIdentifier, {name: 'XDSBadge'})
+    .size();
+
+  // Add XDSStatusDot import if not already present
+  const hasStatusDotImport =
+    root
+      .find(j.ImportSpecifier, {
+        imported: {name: 'XDSStatusDot'},
+      })
+      .size() > 0 ||
+    root
+      .find(j.ImportDefaultSpecifier)
+      .filter(
+        (path) => path.node.local.name === 'XDSStatusDot',
+      )
+      .size() > 0;
+
+  if (!hasStatusDotImport) {
+    const newImport = j.importDeclaration(
+      [j.importSpecifier(j.identifier('XDSStatusDot'))],
+      j.stringLiteral('@xds/core/StatusDot'),
+    );
+
+    // Insert after the last existing xds import, or at the top
+    const xdsImports = root.find(j.ImportDeclaration).filter((path) => {
+      const source = path.node.source.value;
+      return typeof source === 'string' && source.includes('@xds/core');
+    });
+
+    if (xdsImports.size() > 0) {
+      xdsImports.at(-1).insertAfter(newImport);
+    } else {
+      const allImports = root.find(j.ImportDeclaration);
+      if (allImports.size() > 0) {
+        allImports.at(-1).insertAfter(newImport);
+      } else {
+        root.get().node.program.body.unshift(newImport);
+      }
+    }
+  }
+
+  // Remove XDSBadge import if no remaining usages
+  if (remainingBadgeUsages === 0) {
+    badgeImports.forEach((path) => {
+      const specifiers = path.node.specifiers;
+      if (!specifiers) return;
+
+      const filtered = specifiers.filter((s) => {
+        if (
+          s.type === 'ImportSpecifier' &&
+          s.imported.type === 'Identifier' &&
+          s.imported.name === 'XDSBadge'
+        ) {
+          return false;
+        }
+        if (
+          s.type === 'ImportDefaultSpecifier' &&
+          s.local.name === 'XDSBadge'
+        ) {
+          return false;
+        }
+        return true;
+      });
+
+      if (filtered.length === 0) {
+        j(path).remove();
+      } else if (filtered.length !== specifiers.length) {
+        path.node.specifiers = filtered;
+      }
+    });
+  }
+
+  return root.toSource();
+}


### PR DESCRIPTION
## Summary

Adds a codemod that migrates `XDSBadge` dot mode (`shape="dot"`) to `XDSStatusDot`.

### What it does
- Detects `shape="dot"` prop on XDSBadge
- Converts to XDSStatusDot with variant mapping: `success→positive`, `error→negative`, others unchanged
- Passes through `label` directly (no placeholder needed — Badge already has it)
- Handles imports: adds StatusDot, removes Badge only when no other usages remain
- Passes through all other props (xstyle, className, ref, data-testid, spreads)
- Removes `shape` prop (StatusDot doesn't have it)

### Scope
This codemod **only** converts `shape="dot"` Badge usages to StatusDot. It does **not**:
- Remove the `shape` prop from XDSBadge itself (separate breaking change)
- Rename Badge's own variant enums (`success`/`error` stay as-is on pill badges)

The variant mapping (`success→positive`, `error→negative`) only applies during the Badge→StatusDot migration, since StatusDot uses different variant names.

### Test coverage
12 test cases covering: basic transform, variant mapping, pill badge exclusion, icon badge exclusion, import handling, mixed usage, prop passthrough, default variant, label passthrough.

### Dogfooding
Ran on the XDS repo — `Badge.stories.tsx` dot examples migrated correctly. Badge's own test file was also transformed (expected) but reverted since those tests should keep testing `shape="dot"` until the prop is removed.

Closes #945

---
