### PR TITLE
chore: bump all packages to 0.0.9

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/cli",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "XDS design system CLI \u2014 init, swizzle, theme, templates, and agent docs",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/core",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Core XDS components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/lab",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
   "main": "./src/index.ts",

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "description": "Brutalist theme for XDS \u2014 zero radius, monospace, heavy borders",
   "license": "MIT",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-default",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": false,
   "description": "Default theme for XDS components (Heroicons)",
   "license": "MIT",

--- a/packages/themes/meta/package.json
+++ b/packages/themes/meta/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-meta",
-  "version": "0.0.1",
+  "version": "0.0.9",
   "private": false,
   "description": "Meta theme for XDS components — Meta's brand identity with blue accent and clean aesthetics",
   "license": "MIT",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-neutral",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": false,
   "description": "Neutral theme for XDS components (Lucide icons)",
   "license": "MIT",

--- a/packages/themes/whatsapp/package.json
+++ b/packages/themes/whatsapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-whatsapp",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "description": "WhatsApp theme for XDS — green accent, warm grays, Roboto, rounded surfaces",
   "license": "MIT",


### PR DESCRIPTION
Bumps all package versions to 0.0.9 for npm publish.

## Published packages
- `@xds/core@0.0.9`
- `@xds/cli@0.0.9`
- `@xds/theme-default@0.0.9`
- `@xds/theme-neutral@0.0.9`
- `@xds/theme-meta@0.0.9`

(brutalist + whatsapp are private, skipped)