### PR TITLE
fix(cli): use tsx parser for .ts files in codemod runner

### DIFF
--- a/packages/cli/src/codemods/runner.mjs
+++ b/packages/cli/src/codemods/runner.mjs
@@ -171,7 +171,7 @@ export async function runCodemods(versionManifests, {apply, path: srcPath, codem
           const source = fs.readFileSync(filePath, 'utf-8');
           // Configure parser based on file extension
           const ext = path.extname(filePath);
-          const parser = ext === '.tsx' ? 'tsx' : ext === '.jsx' ? 'babel' : 'babel';
+          const parser = (ext === '.tsx' || ext === '.ts') ? 'tsx' : 'babel';
           const j = jscodeshift.withParser(parser);
           const api = {
             jscodeshift: j,

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -45,6 +45,7 @@ function detectCurrentVersion() {
   try {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
     const deps = {
+      ...pkg.peerDependencies,
       ...pkg.dependencies,
       ...pkg.devDependencies,
     };


### PR DESCRIPTION
## What

Two fixes for the upgrade command when running against consumer repos like `xds-common`:

### 1. Parser selection bug in `runner.mjs`

The codemod runner was using the `babel` parser for `.ts` files:

```js
// before
const parser = ext === '.tsx' ? 'tsx' : ext === '.jsx' ? 'babel' : 'babel';

// after
const parser = (ext === '.tsx' || ext === '.ts') ? 'tsx' : 'babel';
```

The `babel` parser doesn't enable the TypeScript plugin, so every plain `.ts` file failed with errors like:
- `This experimental syntax requires enabling one of the following parser plugin(s): "typescript"`
- `Missing semicolon` on TypeScript enums
- `Unexpected token` on type annotations

jscodeshift's `tsx` parser handles both `.tsx` and `.ts` files.

### 2. `detectCurrentVersion()` misses peerDependencies

`xds-common` declares `@xds/core` as a `peerDependency`, not a direct dependency. The version detector only checked `dependencies` and `devDependencies`, so it failed with:

> Could not detect @xds/core version.

Now checks `peerDependencies` too.

## Testing

Smoke-tested against `nest/libs/xds-common` (87 source files):
- **Before:** Every `.ts` file failed to parse (hundreds of errors)
- **After:** All 87 files parsed cleanly, zero errors

---
