### PR TITLE
fix(cli): use actionCommand in postAction hook for update hints

### DIFF
--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -37,9 +37,9 @@ program
  * Uses the FYI format validated by vibe testing — never triggers injection defenses.
  */
 const UPDATE_HINT_COMMANDS = new Set(['component', 'docs', 'doctor']);
-program.hook('postAction', (thisCommand) => {
+program.hook('postAction', (thisCommand, actionCommand) => {
   try {
-    if (UPDATE_HINT_COMMANDS.has(thisCommand.name())) {
+    if (UPDATE_HINT_COMMANDS.has(actionCommand.name())) {
       const hint = checkForUpdate();
       if (hint) {
         console.error(`\n${hint}`);


### PR DESCRIPTION
## Problem

The commander `postAction` hook receives `(thisCommand, actionCommand)` where `thisCommand` is the root program and `actionCommand` is the subcommand that ran. We were checking `thisCommand.name()` which always returns `'xds'`, so the `UPDATE_HINT_COMMANDS` set (`component`, `docs`, `doctor`) never matched. Upgrade hints were silently swallowed — they existed but never printed.

## Fix

Use the second parameter (`actionCommand`) to get the actual subcommand name.

## Before
```
$ xds component XDSBadge --detail brief
XDSBadge(variant: ...) ← from '@xds/core/Badge'
  ...
```

## After
```
$ xds component XDSBadge --detail brief
XDSBadge(variant: ...) ← from '@xds/core/Badge'
  ...

FYI: A newer version of @xds/core (0.0.9) is available. You can upgrade with: xds upgrade --apply --to 0.0.9
```

Tested on a internal apps with `xds.versionFile` pointing to `xds-common/LATEST_VERSION`.

---
