### PR TITLE
fix(DialogHeader): re-add capsize with visual adjustment (#955)

### DIFF
--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -41,7 +41,7 @@ const styles = stylex.create({
     // buttonCenter = -edgeCompensation + size-element-md/2 = -8 + 16 = 8px
     // titleCenter = heading-2-size * heading-2-leading / 2 = 14px
     // adjustment = 8 - 14 = -6px
-    marginBlockStart: `calc(${sizeVars['--size-element-md']} / 2 - ${spacingVars['--spacing-2']} - ${typeScaleVars['--text-heading-2-size']} * ${typeScaleVars['--text-heading-2-leading']} / 2)`,
+    marginBlock: `calc(${sizeVars['--size-element-md']} / 2 - ${spacingVars['--spacing-2']} - ${typeScaleVars['--text-heading-2-size']} * ${typeScaleVars['--text-heading-2-leading']} / 2)`,
   },
   titleFocusable: {
     outline: 'none',

--- a/packages/core/src/Dialog/XDSDialogHeader.tsx
+++ b/packages/core/src/Dialog/XDSDialogHeader.tsx
@@ -15,7 +15,7 @@
 
 import {useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {spacingVars} from '../theme/tokens.stylex';
+import {spacingVars, sizeVars, typeScaleVars} from '../theme/tokens.stylex';
 import {XDSLayoutHeader} from '../Layout/XDSLayoutHeader';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
@@ -37,9 +37,11 @@ const styles = stylex.create({
   titleWrapper: {
     flex: 1,
     minWidth: 0,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 0,
+    // Visual centering: align title center with close button center
+    // buttonCenter = -edgeCompensation + size-element-md/2 = -8 + 16 = 8px
+    // titleCenter = heading-2-size * heading-2-leading / 2 = 14px
+    // adjustment = 8 - 14 = -6px
+    marginBlockStart: `calc(${sizeVars['--size-element-md']} / 2 - ${spacingVars['--spacing-2']} - ${typeScaleVars['--text-heading-2-size']} * ${typeScaleVars['--text-heading-2-leading']} / 2)`,
   },
   titleFocusable: {
     outline: 'none',
@@ -137,10 +139,7 @@ export function XDSDialogHeader({
           <div {...stylex.props(styles.actions)}>{startContent}</div>
         )}
         <div {...stylex.props(styles.titleWrapper)}>
-          <XDSHeading
-            ref={titleRef}
-            level={2}
-            xstyle={styles.titleFocusable}>
+          <XDSHeading ref={titleRef} level={2} xstyle={styles.titleFocusable}>
             {title}
           </XDSHeading>
           {subtitle && (


### PR DESCRIPTION
## Summary

Re-adds capsize-style visual centering to the dialog header title, with proper spacing alignment to the close button.

## Changes

1. **Visual centering calc** — `marginBlock: calc((buttonMd - edgeCompensation - headingFontSize × leading) / 2)` trims both top and bottom of the title wrapper to align the title center with the close button icon center
2. **Token-driven** — uses `--size-element-md`, `--spacing-2`, `--text-heading-2-size`, and `--text-heading-2-leading` so the adjustment adapts if sizes change

The `marginBlock` shorthand applies the same -6px adjustment to both block edges, keeping the title vertically centered with the button and trimming excess leading below.

Closes #955

---
