### PR TITLE
feat: Meta theme + Components sandbox page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ internal/vibe-tests/results/
 apps/sandbox/.next/
 apps/sandbox/out/
 apps/sandbox/next-env.d.ts
+.npmrc

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -13,6 +13,7 @@
     "@xds/cli": "*",
     "@xds/core": "*",
     "@xds/theme-default": "*",
+    "@xds/theme-meta": "*",
     "next": "^15.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"

--- a/apps/sandbox/src/app/Sidebar.tsx
+++ b/apps/sandbox/src/app/Sidebar.tsx
@@ -24,6 +24,7 @@ const pages = [
   {name: 'Mega Menu', href: '/pages/mega-menu/'},
   {name: 'Polymorphic Link', href: '/pages/polymorphic-link/'},
   {name: 'Table Overview', href: '/pages/table-overview/'},
+  {name: 'Meta Theme', href: '/pages/meta-theme/'},
 ];
 
 const styles = stylex.create({

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -1,9 +1,16 @@
 import type {Metadata} from 'next';
+import {Figtree} from 'next/font/google';
 import '@xds/core/reset.css';
 import '@xds/core/typography.css';
 import './globals.css';
 import {Providers} from './providers';
 import {Sidebar} from './Sidebar';
+
+const figtree = Figtree({
+  subsets: ['latin'],
+  variable: '--font-figtree',
+  display: 'swap',
+});
 
 export const metadata: Metadata = {
   title: 'XDS Sandbox',
@@ -12,7 +19,7 @@ export const metadata: Metadata = {
 
 export default function RootLayout({children}: {children: React.ReactNode}) {
   return (
-    <html lang="en">
+    <html lang="en" className={figtree.variable}>
       <body>
         <Providers>
           <div style={{display: 'flex', minHeight: '100vh'}}>

--- a/apps/sandbox/src/app/pages/meta-theme/page.tsx
+++ b/apps/sandbox/src/app/pages/meta-theme/page.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import {XDSTheme} from '@xds/core/theme';
+import {metaTheme} from '@xds/theme-meta';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSBanner} from '@xds/core/Banner';
+import {XDSCard} from '@xds/core/Card';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSSwitch} from '@xds/core/Switch';
+import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
+import {XDSProgressBar} from '@xds/core/ProgressBar';
+import {XDSSpinner} from '@xds/core/Spinner';
+import {XDSSkeleton} from '@xds/core/Skeleton';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSLink} from '@xds/core/Link';
+import {XDSKbd} from '@xds/core/Kbd';
+import {XDSToken} from '@xds/core/Token';
+import {XDSStatusDot} from '@xds/core/StatusDot';
+import {XDSEmptyState} from '@xds/core/EmptyState';
+import * as stylex from '@stylexjs/stylex';
+import {useState} from 'react';
+
+const s = stylex.create({
+  page: {
+    background: 'var(--color-wash)',
+    padding: '32px 24px',
+    minHeight: '100vh',
+  },
+  inner: {maxWidth: 860, margin: '0 auto'},
+  label: {
+    fontSize: 11,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    letterSpacing: '0.08em',
+    color: 'var(--color-secondary)',
+    borderBottom: '1px solid var(--color-divider)',
+    paddingBottom: 6,
+  },
+  swatch: {
+    width: 52,
+    height: 36,
+    borderRadius: 6,
+    border: '1px solid rgba(0,0,0,0.08)',
+  },
+  col: {
+    display: 'flex',
+    flexDirection: 'column' as const,
+    alignItems: 'center',
+    gap: 3,
+  },
+  wrap: {flexWrap: 'wrap' as const},
+  flex1: {flex: 1},
+});
+
+const SWATCHES = [
+  {c: '#0064E0', l: 'Accent'},
+  {c: '#0A1317', l: 'Gray 1100'},
+  {c: '#5D6C7B', l: 'Gray 650'},
+  {c: '#DDE2E8', l: 'Gray 150'},
+  {c: '#F1F4F7', l: 'Gray 50'},
+  {c: '#D31130', l: 'Error'},
+  {c: '#147B29', l: 'Success'},
+  {c: '#965E03', l: 'Warning'},
+];
+
+const SL = ({t}: {t: string}) => <div {...stylex.props(s.label)}>{t}</div>;
+
+export default function Components() {
+  const [mode, setMode] = useState<'light' | 'dark'>('light');
+  const [inp, setInp] = useState('');
+  const [sw1, setSw1] = useState(true);
+  const [sw2, setSw2] = useState(false);
+  const [ck, setCk] = useState(true);
+  const [radio, setRadio] = useState('b');
+  const [tab, setTab] = useState('overview');
+  const [tokens, setTokens] = useState(['Design', 'System', 'XDS']);
+
+  return (
+    <XDSTheme theme={metaTheme} mode={mode}>
+      <div {...stylex.props(s.page)} style={{colorScheme: mode}}>
+        <div {...stylex.props(s.inner)}>
+          <XDSVStack gap={8}>
+            <XDSHStack
+              gap={4}
+              alignItems="center"
+              justifyContent="space-between">
+              <XDSHeading level={2}>Components</XDSHeading>
+              <XDSButton
+                label={mode === 'light' ? 'Dark Mode' : 'Light Mode'}
+                variant="secondary"
+                size="sm"
+                onPress={() => setMode(m => (m === 'light' ? 'dark' : 'light'))}
+              />
+            </XDSHStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Color / Palette" />
+              <XDSHStack gap={3} {...stylex.props(s.wrap)}>
+                {SWATCHES.map(({c, l}) => (
+                  <div key={c} {...stylex.props(s.col)}>
+                    <div {...stylex.props(s.swatch)} style={{background: c}} />
+                    <XDSText type="supporting">{l}</XDSText>
+                  </div>
+                ))}
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Typography / XDSHeading + XDSText" />
+              {([1, 2, 3, 4, 5, 6] as const).map(l => (
+                <XDSHeading key={l} level={l}>
+                  Heading {l}
+                </XDSHeading>
+              ))}
+              <XDSHStack gap={4} {...stylex.props(s.wrap)}>
+                <XDSText type="large">Large</XDSText>
+                <XDSText type="body">Body text</XDSText>
+                <XDSText type="label" weight="bold">
+                  Label bold
+                </XDSText>
+                <XDSText type="supporting" color="secondary">
+                  Supporting
+                </XDSText>
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Core / XDSButton" />
+              <XDSHStack gap={3} {...stylex.props(s.wrap)}>
+                {(
+                  ['primary', 'secondary', 'ghost', 'destructive'] as const
+                ).map(v => (
+                  <XDSButton
+                    key={v}
+                    label={v[0].toUpperCase() + v.slice(1)}
+                    variant={v}
+                    onPress={() => {}}
+                  />
+                ))}
+                <XDSButton
+                  label="Disabled"
+                  variant="primary"
+                  isDisabled
+                  onPress={() => {}}
+                />
+              </XDSHStack>
+              <XDSHStack gap={3} alignItems="center">
+                {(['sm', 'md', 'lg'] as const).map(sz => (
+                  <XDSButton
+                    key={sz}
+                    label={sz.toUpperCase()}
+                    variant="secondary"
+                    size={sz}
+                    onPress={() => {}}
+                  />
+                ))}
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Core / XDSBadge" />
+              <XDSHStack gap={3} alignItems="center" {...stylex.props(s.wrap)}>
+                <XDSBadge variant="info">Info</XDSBadge>
+                <XDSBadge variant="success">Success</XDSBadge>
+                <XDSBadge variant="warning">Warning</XDSBadge>
+                <XDSBadge variant="error">Error</XDSBadge>
+                <XDSBadge>42</XDSBadge>
+                <XDSBadge>New</XDSBadge>
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Core / XDSBanner" />
+              <XDSVStack gap={2}>
+                <XDSBanner
+                  status="info"
+                  title="Info"
+                  description="Something informational to note."
+                />
+                <XDSBanner
+                  status="success"
+                  title="Success"
+                  description="Operation completed successfully."
+                />
+                <XDSBanner
+                  status="warning"
+                  title="Warning"
+                  description="Proceed with caution."
+                />
+                <XDSBanner
+                  status="error"
+                  title="Error"
+                  description="Something went wrong."
+                />
+              </XDSVStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Layout / XDSCard" />
+              <XDSHStack gap={4}>
+                {['Card One', 'Card Two'].map(title => (
+                  <div key={title} {...stylex.props(s.flex1)}>
+                    <XDSCard>
+                      <XDSVStack gap={2} style={{padding: 16}}>
+                        <XDSHeading level={5}>{title}</XDSHeading>
+                        <XDSText type="body">
+                          Card content with supporting description text.
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSCard>
+                  </div>
+                ))}
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Core / XDSAvatar" />
+              <XDSHStack gap={4} alignItems="flex-end">
+                {(['tiny', 'xsmall', 'small', 'medium', 'large'] as const).map(
+                  size => (
+                    <div key={size} {...stylex.props(s.col)}>
+                      <XDSAvatar name="Ruby Cheung" size={size} />
+                      <XDSText type="supporting">{size}</XDSText>
+                    </div>
+                  ),
+                )}
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Form" />
+              <XDSHStack gap={4} {...stylex.props(s.wrap)}>
+                <div {...stylex.props(s.flex1)}>
+                  <XDSTextInput
+                    label="Username"
+                    placeholder="Enter username"
+                    value={inp}
+                    onChange={setInp}
+                    description="Your display name"
+                  />
+                </div>
+                <div {...stylex.props(s.flex1)}>
+                  <XDSTextInput
+                    label="Email"
+                    placeholder="Enter email"
+                    value=""
+                    onChange={() => {}}
+                    status={{type: 'error', message: 'Invalid email address'}}
+                  />
+                </div>
+              </XDSHStack>
+              <XDSHStack gap={6} {...stylex.props(s.wrap)}>
+                <XDSSwitch
+                  label="Notifications on"
+                  value={sw1}
+                  onChange={setSw1}
+                />
+                <XDSSwitch
+                  label="Marketing off"
+                  value={sw2}
+                  onChange={setSw2}
+                />
+                <XDSCheckboxInput
+                  label="Accept terms"
+                  value={ck}
+                  onChange={setCk}
+                />
+              </XDSHStack>
+              <XDSRadioList label="Plan" value={radio} onChange={setRadio}>
+                <XDSRadioListItem value="a" label="Starter" />
+                <XDSRadioListItem value="b" label="Pro" />
+                <XDSRadioListItem value="c" label="Enterprise" />
+              </XDSRadioList>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Layout / XDSDivider" />
+              <XDSDivider />
+              <XDSDivider label="Section Break" />
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Core / XDSProgressBar + XDSSpinner + XDSSkeleton" />
+              <XDSHStack
+                gap={6}
+                alignItems="flex-start"
+                {...stylex.props(s.wrap)}>
+                <XDSVStack gap={2} style={{flex: 1, minWidth: 200}}>
+                  <XDSProgressBar label="Upload" value={65} showValueLabel />
+                  <XDSProgressBar label="Processing" isIndeterminate />
+                </XDSVStack>
+                <XDSHStack gap={3} alignItems="center">
+                  {(['sm', 'md', 'lg'] as const).map(sz => (
+                    <XDSSpinner key={sz} size={sz} label={sz} />
+                  ))}
+                </XDSHStack>
+                <XDSVStack gap={2}>
+                  <XDSSkeleton width={180} height={16} />
+                  <XDSSkeleton width={140} height={16} />
+                  <XDSSkeleton width={200} height={60} />
+                </XDSVStack>
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Navigation / XDSTabList" />
+              <XDSTabList value={tab} onChange={setTab} hasDivider>
+                <XDSTab value="overview" label="Overview" />
+                <XDSTab value="components" label="Components" />
+                <XDSTab value="tokens" label="Tokens" />
+                <XDSTab value="changelog" label="Changelog" />
+              </XDSTabList>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Core / XDSKbd + XDSToken + XDSLink" />
+              <XDSHStack gap={2} alignItems="center">
+                <XDSText type="body">Save:</XDSText>
+                <XDSKbd>⌘</XDSKbd>
+                <XDSKbd>S</XDSKbd>
+              </XDSHStack>
+              <XDSHStack gap={2} alignItems="center" {...stylex.props(s.wrap)}>
+                {tokens.map(t => (
+                  <XDSToken
+                    key={t}
+                    label={t}
+                    onRemove={() => setTokens(ts => ts.filter(x => x !== t))}
+                  />
+                ))}
+              </XDSHStack>
+              <XDSHStack gap={3}>
+                <XDSLink href="#">Documentation</XDSLink>
+                <XDSLink href="#">GitHub</XDSLink>
+                <XDSLink href="#">Storybook</XDSLink>
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Core / XDSStatusDot" />
+              <XDSHStack gap={6} {...stylex.props(s.wrap)}>
+                <XDSStatusDot variant="positive" label="Positive" />
+                <XDSStatusDot variant="negative" label="Negative" />
+                <XDSStatusDot variant="warning" label="Warning" />
+                <XDSStatusDot variant="neutral" label="Neutral" />
+              </XDSHStack>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <SL t="Core / XDSEmptyState" />
+              <XDSHStack
+                gap={4}
+                alignItems="flex-start"
+                {...stylex.props(s.wrap)}>
+                <div {...stylex.props(s.flex1)}>
+                  <XDSEmptyState
+                    title="No results found"
+                    description="Try adjusting your search or filters."
+                    action={
+                      <XDSButton
+                        label="Clear filters"
+                        variant="secondary"
+                        size="sm"
+                        onPress={() => {}}
+                      />
+                    }
+                  />
+                </div>
+                <div {...stylex.props(s.flex1)}>
+                  <XDSEmptyState
+                    title="Nothing here yet"
+                    description="Create your first item to get started."
+                    action={
+                      <XDSButton
+                        label="Create item"
+                        variant="primary"
+                        size="sm"
+                        onPress={() => {}}
+                      />
+                    }
+                  />
+                </div>
+              </XDSHStack>
+            </XDSVStack>
+          </XDSVStack>
+        </div>
+      </div>
+    </XDSTheme>
+  );
+}

--- a/packages/themes/meta/package.json
+++ b/packages/themes/meta/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@xds/theme-meta",
+  "version": "0.0.1",
+  "private": false,
+  "description": "Meta theme for XDS — anchored to CDS Default (XMDS) visual language",
+  "license": "MIT",
+  "sideEffects": false,
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./theme.css": "./dist/theme.css"
+  },
+  "files": ["dist", "src"],
+  "scripts": {
+    "build": "xds build-theme src/index.ts -o dist/theme.css && tsup && rm -f dist/meta.js dist/meta.d.ts"
+  },
+  "peerDependencies": {
+    "@xds/core": "*"
+  },
+  "devDependencies": {
+    "@xds/cli": "*"
+  }
+}

--- a/packages/themes/meta/src/index.ts
+++ b/packages/themes/meta/src/index.ts
@@ -1,0 +1,288 @@
+/**
+ * XDS Meta Theme
+ *
+ * Anchored to the CDS Default (XMDS) visual language.
+ * Colors, typography scale, and radii are sourced directly from
+ * CDSDefaultThemeSource.php and CDSInternalColor.php in fbsource.
+ *
+ * Key decisions (component-level, not blind token mapping):
+ * - Primary button is #0064E0 in BOTH light and dark (CDS doesn't flip it)
+ * - Secondary button uses stroke for definition, not background fill
+ * - Radii are significantly larger than XDS defaults (card: 32px, btn: 16-22px)
+ * - Typography scale bumped to match CDS: body 15px, h3 17px, h1/2 24px
+ * - Font: Optimistic (Meta's brand font) with system fallbacks
+ */
+
+import {defineTheme} from '@xds/core/theme';
+
+export const metaTheme = defineTheme({
+  name: 'meta',
+
+  tokens: {
+    // =========================================================================
+    // Typography — Optimistic font + CDS scale
+    // CDS uses: body=15px, h3=17px, h1/2=24px, display=48px
+    // =========================================================================
+    '--font-body':
+      '"Optimistic Text", Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    '--font-heading':
+      '"Optimistic Display", "Optimistic Text", Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+
+    // Type scale — CDS values (overriding XDS defaults of 14/16/18/20px)
+    '--text-sm': '0.8125rem', // 13px — secondary label, meta (unchanged)
+    '--text-base': '0.9375rem', // 15px — body (CDS BODY token)
+    '--text-lg': '1.0625rem', // 17px — headline 3 (CDS HEADLINE_3)
+    '--text-xl': '1.25rem', // 20px — intermediate
+    '--text-2xl': '1.5rem', // 24px — headline 1/2 (CDS HEADLINE_1/2)
+
+    // =========================================================================
+    // Colors — sourced from CDSDefaultThemeSource + CDSInternalColor hex values
+    // =========================================================================
+
+    // Accent / brand blue
+    // Light: XMDS_3_BLUE_650 (#0064E0), Dark: XMDS_3_BLUE_550 (#0082FB)
+    '--color-accent': ['#0064E0', '#0082FB'],
+    '--color-accent-deemphasized': ['#0064E026', '#0082FB33'],
+    '--color-accent-text': ['#0457CB', '#4BA9FE'],
+
+    // Surfaces
+    // SURFACE_BACKGROUND: XMDS_3_WHITE / XMDS_3_GRAY_1050
+    '--color-surface': ['#FFFFFF', '#152127'],
+    // Wash/page: XMDS_3_GRAY_50 / XMDS_3_GRAY_1100
+    '--color-wash': ['#F1F4F7', '#0A1317'],
+    '--color-card': ['#FFFFFF', '#152127'],
+    '--color-popover': ['#FFFFFF', '#1C2B33'],
+    '--color-navbar': ['#FFFFFF', '#152127'],
+
+    // Text
+    // PRIMARY_TEXT: XMDS_3_GRAY_1100 (#0A1317) / XMDS_3_GRAY_50 (#F1F4F7)
+    '--color-text-primary': ['#0A1317', '#F1F4F7'],
+    // SECONDARY_TEXT: XMDS_3_GRAY_650 (#5D6C7B) / XMDS_3_GRAY_400 (#96A6B4)
+    '--color-text-secondary': ['#5D6C7B', '#96A6B4'],
+    '--color-text-disabled': ['#A4B0BC', '#5D6C7B'],
+    '--color-text-link': ['#0064E0', '#3E9EFB'],
+    '--color-text-placeholder': ['#8494A3', '#748695'],
+
+    // Icons (parallel to text)
+    '--color-icon-primary': ['#0A1317', '#F1F4F7'],
+    '--color-icon-secondary': ['#5D6C7B', '#96A6B4'],
+    '--color-icon-tertiary': ['#748695', '#8494A3'],
+    '--color-icon-disabled': ['#A4B0BC', '#5D6C7B'],
+
+    // Divider
+    // DIVIDER: XMDS_3_GRAY_150 (#DDE2E8) / XMDS_3_GRAY_800 (#3D4F5C)
+    '--color-divider': ['#DDE2E8', '#3D4F5C'],
+    '--color-divider-high-contrast': ['#8494A3', '#748695'],
+    '--color-divider-emphasized': ['#CCD3DB', '#4E606F'],
+
+    // Status
+    // NEGATIVE: XMDS_3_RED_650 (#D31130) / XMDS_3_RED_400 (#FB7D87)
+    '--color-negative': ['#D31130', '#FB7D87'],
+    '--color-negative-deemphasized': ['#D3113026', '#FB7D8733'],
+    // POSITIVE: XMDS_3_GREEN_650 (#147B29) / XMDS_3_GREEN_400 (#3CBC22)
+    '--color-positive': ['#147B29', '#3CBC22'],
+    '--color-positive-deemphasized': ['#147B2926', '#3CBC2233'],
+    // WARNING: XMDS_3_YELLOW_650 (#965E03) / XMDS_3_YELLOW_400 (#D69804)
+    '--color-warning': ['#965E03', '#D69804'],
+    '--color-warning-deemphasized': ['#965E0326', '#D6980433'],
+
+    // Effects
+    '--color-shadow-elevation': [
+      'rgba(10, 19, 23, 0.1)',
+      'rgba(0, 0, 0, 0.35)',
+    ],
+    '--color-hover-overlay': ['rgba(10,19,23,0.05)', 'rgba(241,244,247,0.05)'],
+    '--color-pressed-overlay': [
+      'rgba(10,19,23,0.10)',
+      'rgba(241,244,247,0.10)',
+    ],
+    '--color-focus-outline': ['#0064E0', '#0082FB'],
+
+    // Glimmer / skeleton
+    '--color-glimmer': ['#CCD3DB', '#3D4F5C'],
+
+    // =========================================================================
+    // Radii — CDS is significantly rounder than XDS defaults
+    // CDSCornerRadiusTokenSource values from CDSDefaultThemeSource.php
+    // =========================================================================
+
+    // Card/dialog: CDSCornerRadiusTokenSource::CARD_CONTAINER_RADIUS = 32
+    '--radius-container': '32px',
+    // Input/list cell: CDSCornerRadiusTokenSource::INPUT = 16
+    '--radius-element': '16px',
+    // Chip: CDSCornerRadiusTokenSource::CHIP = 8
+    '--radius-content': '8px',
+    // Inner (tight): CDSCornerRadiusTokenSource::DEFAULT = 4
+    '--radius-inner': '4px',
+    // Pills stay full
+    '--radius-rounded': '9999px',
+  },
+
+  components: {
+    // =========================================================================
+    // Button
+    // CDS per-size radii: BUTTON_SMALL=16, BUTTON_MEDIUM=18, BUTTON_LARGE=22
+    // PRIMARY_BUTTON_BACKGROUND = XMDS_3_BLUE_650 in BOTH light and dark
+    // SECONDARY_BUTTON: transparent bg, SECONDARY_BUTTON_STROKE border
+    // =========================================================================
+    button: {
+      // Primary: blue in both modes (CDS doesn't flip primary button color)
+      'variant:primary': {
+        backgroundColor: '#0064E0',
+        color: '#FFFFFF',
+      },
+      // Secondary: transparent with stroke
+      'variant:secondary': {
+        backgroundColor: 'transparent',
+        borderColor: 'light-dark(#CCD3DB, #445664)',
+        color: 'light-dark(#0A1317, #F1F4F7)',
+      },
+      // Ghost: accent text, no border
+      'variant:ghost': {
+        backgroundColor: 'transparent',
+        color: 'light-dark(#0064E0, #0082FB)',
+      },
+      // Sizes — match CDS button radii exactly
+      'size:sm': {borderRadius: '16px'},
+      'size:md': {borderRadius: '18px'},
+      'size:lg': {borderRadius: '22px'},
+    },
+
+    // =========================================================================
+    // Card — CARD_CONTAINER_RADIUS = 32px, subtle shadow
+    // =========================================================================
+    card: {
+      base: {
+        borderRadius: '32px',
+        boxShadow:
+          'light-dark(0 4px 12px rgba(10,19,23,0.10), 0 4px 16px rgba(0,0,0,0.35))',
+        borderWidth: '0px',
+      },
+    },
+
+    // =========================================================================
+    // Heading — CDS typography scale
+    // DISPLAY_1 = 48px, HEADLINE_1/2 = 24px, HEADLINE_3 = 17px
+    // =========================================================================
+    heading: {
+      'level:1': {
+        fontFamily:
+          '"Optimistic Display", "Optimistic Text", Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        fontSize: '1.5rem', // 24px — CDS HEADLINE_1
+        fontWeight: '600',
+        lineHeight: '1.167',
+        color: 'var(--color-text-primary)',
+        margin: '0',
+      },
+      'level:2': {
+        fontFamily:
+          '"Optimistic Display", "Optimistic Text", Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        fontSize: '1.5rem', // 24px — CDS HEADLINE_2
+        fontWeight: '600',
+        lineHeight: '1.167',
+        color: 'var(--color-text-primary)',
+        margin: '0',
+      },
+      'level:3': {
+        fontFamily:
+          '"Optimistic Text", Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        fontSize: '1.0625rem', // 17px — CDS HEADLINE_3
+        fontWeight: '600',
+        lineHeight: '1.294',
+        color: 'var(--color-text-primary)',
+        margin: '0',
+      },
+      'level:4': {
+        fontFamily:
+          '"Optimistic Text", Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        fontSize: '0.9375rem', // 15px — CDS PRIMARY_LABEL
+        fontWeight: '600',
+        lineHeight: '1.267',
+        color: 'var(--color-text-primary)',
+        margin: '0',
+      },
+      'level:5': {
+        fontFamily:
+          '"Optimistic Text", Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        fontSize: '0.9375rem',
+        fontWeight: '500',
+        lineHeight: '1.267',
+        color: 'var(--color-text-primary)',
+        margin: '0',
+      },
+      'level:6': {
+        fontFamily:
+          '"Optimistic Text", Figtree, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+        fontSize: '0.8125rem', // 13px — CDS SECONDARY_LABEL
+        fontWeight: '500',
+        lineHeight: '1.308',
+        color: 'var(--color-text-secondary)',
+        margin: '0',
+      },
+    },
+
+    // =========================================================================
+    // Text — CDS type tokens
+    // BODY = 15px/400, BODY_EMPHASIZED = 15px/700, META = 13px/400,
+    // SECONDARY_LABEL = 13px/500, TERTIARY_LABEL = 11px/500
+    // =========================================================================
+    text: {
+      'type:body': {
+        fontSize: '0.9375rem', // 15px — CDS BODY
+        fontWeight: '400',
+        lineHeight: '1.267',
+      },
+      'type:label': {
+        fontSize: '0.9375rem', // 15px — CDS PRIMARY_LABEL
+        fontWeight: '500',
+        lineHeight: '1.267',
+      },
+      'type:supporting': {
+        fontSize: '0.8125rem', // 13px — CDS META / SECONDARY_LABEL
+        fontWeight: '400',
+        lineHeight: '1.308',
+        color: 'var(--color-text-secondary)',
+      },
+      'type:code': {
+        fontFamily: '"SF Mono", Monaco, Consolas, "Courier New", monospace',
+        fontSize: '0.875rem',
+        backgroundColor: 'var(--color-wash)',
+        padding: '2px 5px',
+        borderRadius: '4px',
+      },
+    },
+
+    // =========================================================================
+    // Badge — CDS: TEXT_BADGE corner radius = 20px
+    // =========================================================================
+    badge: {
+      base: {
+        borderRadius: '20px',
+        fontWeight: '500',
+        fontSize: '0.6875rem', // 11px — CDS TERTIARY_LABEL scale
+      },
+    },
+
+    // =========================================================================
+    // Divider — 1px, DIVIDER color token
+    // =========================================================================
+    divider: {
+      base: {
+        borderTopColor: 'var(--color-divider)',
+        borderTopWidth: '1px',
+      },
+    },
+
+    // =========================================================================
+    // Section — SECTION_PADDING_VERTICAL = 14px
+    // =========================================================================
+    section: {
+      base: {
+        paddingTop: '14px',
+        paddingBottom: '14px',
+      },
+    },
+  },
+});
+
+export default metaTheme;

--- a/packages/themes/meta/tsup.config.ts
+++ b/packages/themes/meta/tsup.config.ts
@@ -1,0 +1,9 @@
+import {defineConfig} from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  clean: true,
+  external: ['@xds/core', 'react'],
+});


### PR DESCRIPTION
## What

- **`@xds/theme-meta`** — new theme package anchored to CDS Default (XMDS) visual language
  - Font: Optimistic → Figtree → system fallback
  - Colors sourced from `CDSDefaultThemeSource.php` (primary button `#0064E0` both modes, correct surfaces/text/dividers/status)
  - Radii: button 16/18/22px per size, card 32px, input 16px, badge 20px
  - Typography scale: body 15px, h3 17px, h1/2 24px
- **Sandbox Components page** at `/pages/meta-theme/` — 15 component sections grouped by Storybook category, light/dark toggle
- Figtree loaded via `next/font/google` in sandbox layout

## Preview

Once deployed: https://studious-broccoli-o7e61n3.pages.github.io/sandbox/pages/meta-theme/