### PR TITLE
[easy] Add `type` prop to XDSTextInput

### DIFF
--- a/apps/storybook/stories/TextInput.stories.tsx
+++ b/apps/storybook/stories/TextInput.stories.tsx
@@ -441,6 +441,18 @@ export const WithTooltip: Story = {
   },
 };
 
+export const Password: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? '');
+    return <XDSTextInput {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    type: 'password',
+    label: 'Password',
+    placeholder: 'Enter your password',
+  },
+};
+
 export const TooltipWithOptional: Story = {
   render: args => {
     const [value, setValue] = useState(args.value ?? '');

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -26,6 +26,10 @@ export const docs = {
       code: '<XDSTextInput label="Email" value={email} onChange={setEmail} placeholder="email@example.com" />',
     },
     {
+      label: 'Password input',
+      code: '<XDSTextInput type="password" label="Password" value={password} onChange={setPassword} />',
+    },
+    {
       label: 'Hidden label',
       code: '<XDSTextInput label="Search" isLabelHidden value={query} onChange={setQuery} placeholder="Search..." />',
     },
@@ -75,6 +79,13 @@ export const docs = {
     },
   ],
   props: [
+    {
+      name: 'type',
+      type: "'text' | 'password' | 'email'",
+      description:
+        'The HTML input type.',
+      default: "'text'",
+    },
     {
       name: 'label',
       type: 'string',
@@ -278,6 +289,12 @@ export const docsZh = {
   ],
   props: [
     {
+      name: 'type',
+      type: "'text' | 'password' | 'email'",
+      description: 'HTML 输入框类型。',
+      default: "'text'",
+    },
+    {
       name: 'label',
       type: 'string',
       description:
@@ -432,6 +449,7 @@ export const docsDense = {
     'aria-busy set during optimistic update or isLoading.',
   ],
   propDescriptions: {
+    type: 'HTML input type.',
     label: 'Label text for input; always rendered for a11y.',
     value: 'Current input value.',
     onChange: 'Fired on input value change.',

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -83,12 +83,19 @@ export type {
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
 
+export type XDSTextInputType = 'text' | 'password' | 'email';
+
 export interface XDSTextInputProps extends Omit<
   XDSBaseProps,
   'onChange' | 'defaultValue'
 > {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLInputElement>;
+  /**
+   * The HTML input type.
+   * @default 'text'
+   */
+  type?: XDSTextInputType;
   /**
    * Label text for the input (always rendered for accessibility).
    */
@@ -180,6 +187,7 @@ export interface XDSTextInputProps extends Omit<
  * ```
  */
 export function XDSTextInput({
+  type = 'text',
   label,
   isLabelHidden = false,
   description,
@@ -284,7 +292,7 @@ export function XDSTextInput({
           ref={ref}
           id={id}
           name={htmlName}
-          type="text"
+          type={type}
           value={String(optimisticValue)}
           onChange={handleChange}
           placeholder={placeholder}

--- a/packages/core/src/TextInput/index.ts
+++ b/packages/core/src/TextInput/index.ts
@@ -12,6 +12,7 @@
 export {XDSTextInput} from './XDSTextInput';
 export type {
   XDSTextInputProps,
+  XDSTextInputType,
   XDSTextInputSize,
   XDSTextInputStatus,
   XDSTextInputStatusType,


### PR DESCRIPTION
Added a `type` prop limited to `'text' | 'password' | 'email'` - this matches what www supports. This way `XDSTextInput` can be used for password inputs.