### PR TITLE
fix(Timestamp,TreeList): extend XDSBaseProps, add xdsClassName to Timestamp

### DIFF
--- a/packages/core/src/Timestamp/XDSTimestamp.tsx
+++ b/packages/core/src/Timestamp/XDSTimestamp.tsx
@@ -23,7 +23,7 @@ import type {
   XDSTextWeight,
 } from '../theme/types';
 import {xdsClassName, mergeProps} from '../utils';
-import type {StyleXStyles} from '@stylexjs/stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const LazyXDSTooltip = lazy(() =>
   import('../Tooltip/XDSTooltip').then(mod => ({default: mod.XDSTooltip})),
@@ -43,8 +43,8 @@ export type XDSTimestampFormat =
   | 'system_date_time'
   | 'system_time';
 
-export interface XDSTimestampProps {
-  /** Ref forwarded to the root element. */
+export interface XDSTimestampProps extends XDSBaseProps<HTMLTimeElement> {
+  /** Ref forwarded to the root `<time>` element. */
   ref?: React.Ref<HTMLTimeElement>;
   /** The date/time to display. Accepts Unix timestamps (seconds) or ISO 8601 strings. */
   value: string | number;
@@ -100,18 +100,6 @@ export interface XDSTimestampProps {
    * Font weight override.
    */
   weight?: XDSTextWeight;
-  /**
-   * StyleX styles created via `stylex.create()`.
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element.
-   */
-  style?: React.CSSProperties;
   /** Test ID for testing frameworks. */
   'data-testid'?: string;
 }
@@ -382,6 +370,8 @@ export function XDSTimestamp({
 
   const showTooltip = hasTooltip && effectiveFormat === 'relative';
 
+  const timestampClass = xdsClassName('timestamp', {format: effectiveFormat});
+
   const timeElement = (
     <XDSText
       type={type}
@@ -389,7 +379,7 @@ export function XDSTimestamp({
       color={color}
       weight={weight}
       xstyle={xstyle}
-      className={className}
+      className={[timestampClass, className].filter(Boolean).join(' ')}
       style={style}>
       <time
         ref={combinedRef}

--- a/packages/core/src/TreeList/XDSTreeList.tsx
+++ b/packages/core/src/TreeList/XDSTreeList.tsx
@@ -12,12 +12,11 @@
  * - /apps/storybook/stories/TreeList.stories.tsx
  */
 
-
 import {useId, useState, useMemo, useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {XDSTreeListItem} from './XDSTreeListItem';
 import type {XDSTreeListItemData, XDSTreeListDensity} from './XDSTreeListTypes';
 
@@ -27,7 +26,7 @@ import type {XDSTreeListItemData, XDSTreeListDensity} from './XDSTreeListTypes';
 
 export {type XDSTreeListDensity} from './XDSTreeListTypes';
 
-export interface XDSTreeListProps {
+export interface XDSTreeListProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
 
@@ -51,24 +50,6 @@ export interface XDSTreeListProps {
    * Semantically associated via aria-labelledby.
    */
   header?: ReactNode;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   */
-  xstyle?: StyleXStyles;
-
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 
   /**
    * Test ID for testing frameworks.


### PR DESCRIPTION
## Component Audit — 2026-03-29

Nightly audit of **Timestamp** and **TreeList** — the final 2 components in the audit queue.

### Findings & Fixes

#### Timestamp
- **`missing-classname`**: Added `xdsClassName('timestamp', {format: effectiveFormat})` so themes can target timestamp elements with variant-aware selectors
- **`structure-issue`**: Extended `XDSBaseProps<HTMLTimeElement>` — removes manually declared `xstyle`/`className`/`style` in favor of the shared base interface

#### TreeList
- **`structure-issue`**: Extended `XDSBaseProps<HTMLDivElement>` — removes manually declared `xstyle`/`className`/`style` in favor of the shared base interface

### Clean Audits (no issues)

Both components passed all other checks:
- ✅ CSS variables — all tokens used correctly (colorVars, spacingVars, radiusVars, typeScaleVars)
- ✅ xdsClassName — TreeList already had correct `xdsClassName('tree-list', {density})` and `xdsClassName('tree-list-item', {selected, disabled})`
- ✅ Component reuse — TreeList uses `getIcon('chevronRight')` from the icon registry
- ✅ Prop naming — booleans use `is`/`has` prefix, callbacks follow `on{Verb}` pattern, directional props use `start`/`end`
- ✅ Type naming — `XDSTimestampProps`, `XDSTimestampFormat`, `XDSTreeListProps`, `XDSTreeListItemData`, `XDSTreeListDensity`
- ✅ Component structure — `displayName` set, file headers present, `'use client'` directives, `mergeProps` usage
- ✅ Accessibility — `<time>` with `dateTime` and `aria-label`, TreeList has `role="tree"`/`role="treeitem"`/`role="group"`, `aria-expanded`/`aria-selected`/`aria-disabled`
- ✅ Export hygiene — both in `src/index.ts` and covered by tsup glob entries

### Needs Review

- **Timestamp `XDSBaseProps` element type**: `XDSTimestampProps` now extends `XDSBaseProps<HTMLTimeElement>`, but the component's outer element is `XDSText` (a `<span>`), while the `<time>` is a child element. The HTML attribute types from `HTMLTimeElement` and `HTMLSpanElement` are identical in practice (no `<time>`-specific DOM attributes), so this is safe — but worth noting the element type doesn't match the outermost DOM node.

### Audit Queue

This completes the full component audit cycle (60+ components). The queue will be rebuilt from scratch on the next run.

---
