### PR TITLE
fix(Popover): embed surface styles in useXDSPopover hook

### DIFF
--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -28,7 +28,6 @@ import {
   colorVars,
   sizeVars,
   radiusVars,
-  shadowVars,
   typographyVars,
   typeScaleVars,
   borderVars,
@@ -96,11 +95,6 @@ const styles = stylex.create({
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],
-  },
-  popover: {
-    backgroundColor: colorVars['--color-background-popover'],
-    borderRadius: radiusVars['--radius-container'],
-    boxShadow: shadowVars['--shadow-low'],
   },
 });
 
@@ -340,7 +334,6 @@ export function XDSDateInput({
       : parseDateInput(pendingInput) !== null;
 
   const popover = useXDSPopover({
-    xstyle: styles.popover,
     dialogLabel: 'Choose date',
     closeButtonLabel: 'Close calendar',
     onHide: () => inputRef.current?.focus(),

--- a/packages/core/src/Popover/XDSPopover.tsx
+++ b/packages/core/src/Popover/XDSPopover.tsx
@@ -26,14 +26,7 @@ import {xdsClassName, mergeProps} from '../utils';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {useXDSPopover} from './useXDSPopover';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useXDSLayer';
-import {
-  colorVars,
-  durationVars,
-  easeVars,
-  spacingVars,
-  radiusVars,
-  shadowVars,
-} from '../theme/tokens.stylex';
+import {durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
 
 // =============================================================================
 // Helpers
@@ -191,12 +184,6 @@ const styles = stylex.create({
     },
   },
   // Visual styles for the inner content container
-  container: {
-    backgroundColor: colorVars['--color-background-surface'],
-    color: colorVars['--color-text-primary'],
-    borderRadius: radiusVars['--radius-element'],
-    boxShadow: shadowVars['--shadow-low'],
-  },
   contentPadding: {
     paddingBlockStart: spacingVars['--spacing-3'],
     paddingBlockEnd: spacingVars['--spacing-3'],
@@ -437,7 +424,7 @@ export function XDSPopover({
             data-testid={testId}
             {...mergeProps(
               xdsClassName('popover'),
-              stylex.props(styles.container, styles.contentPadding, xstyle),
+              stylex.props(styles.contentPadding, xstyle),
               className,
               style,
             )}>
@@ -463,7 +450,7 @@ export function XDSPopover({
           data-testid={testId}
           {...mergeProps(
             xdsClassName('popover'),
-            stylex.props(styles.container, styles.contentPadding, xstyle),
+            stylex.props(styles.contentPadding, xstyle),
             className,
             style,
           )}>

--- a/packages/core/src/Popover/useXDSPopover.tsx
+++ b/packages/core/src/Popover/useXDSPopover.tsx
@@ -33,10 +33,19 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
+  shadowVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
 
 const styles = stylex.create({
+  // Default popover surface — background, radius, shadow.
+  // Applied automatically unless hasSurface is false.
+  // Consumers that need a raw positioned layer should use useXDSLayer instead.
+  surface: {
+    backgroundColor: colorVars['--color-background-popover'],
+    borderRadius: radiusVars['--radius-container'],
+    boxShadow: shadowVars['--shadow-low'],
+  },
   // Focus trap container
   contentWrapper: {
     position: 'relative',
@@ -100,7 +109,12 @@ export interface UseXDSPopoverOptions {
   onHide?: () => void;
 
   /**
-   * StyleX styles for the popover container
+   * StyleX styles applied to the popover's content wrapper.
+   * Merges after the surface styles (when hasSurface is true), so these
+   * can override background, radius, etc.
+   *
+   * For styles on the layer's positioned element (e.g., animations using
+   * `:popover-open`), pass `xstyle` via the `render()` call's props instead.
    */
   xstyle?: StyleXStyles;
 
@@ -136,6 +150,18 @@ export interface UseXDSPopoverOptions {
    * Required for screen readers to announce the dialog purpose.
    */
   dialogLabel?: string;
+
+  /**
+   * Whether to apply the default popover surface (background, border-radius,
+   * box-shadow) to the content wrapper.
+   *
+   * Set to false when the popover content provides its own surface styling
+   * (e.g., mega menus with custom layouts). If you find yourself opting out,
+   * consider whether useXDSLayer is a better fit.
+   *
+   * @default true
+   */
+  hasSurface?: boolean;
 }
 
 /**
@@ -262,6 +288,7 @@ export function useXDSPopover(
     hasLightDismiss = true,
     hasAutoFocus = true,
     hasCloseButton = true,
+    hasSurface = true,
     closeButtonLabel = 'Close popover',
     dialogLabel,
   } = options;
@@ -344,7 +371,7 @@ export function useXDSPopover(
     'aria-controls': layer.id,
   };
 
-  // Wrapped render function that includes optional hidden close button
+  // Wrapped render function that includes surface styles and optional hidden close button
   const render = useCallback(
     (children: ReactNode, props?: ContextRenderProps) => {
       return layer.render(
@@ -353,7 +380,11 @@ export function useXDSPopover(
           role="dialog"
           aria-modal="true"
           aria-label={dialogLabel}
-          {...stylex.props(styles.contentWrapper)}>
+          {...stylex.props(
+            styles.contentWrapper,
+            hasSurface && styles.surface,
+            xstyle,
+          )}>
           {children}
           {hasCloseButton && (
             <button
@@ -370,12 +401,13 @@ export function useXDSPopover(
             </button>
           )}
         </div>,
-        {...props, xstyle: xstyle ?? props?.xstyle},
+        {...props, xstyle: props?.xstyle},
       );
     },
     [
       layer,
       hasCloseButton,
+      hasSurface,
       closeButtonLabel,
       isCloseButtonFocused,
       contentRef,

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -24,7 +24,6 @@ import {
   spacingVars,
   fontWeightVars,
   radiusVars,
-  shadowVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
 // TODO(#264): Lazy-load useXDSPopover so the popover/layer bundle is not
@@ -128,9 +127,6 @@ const styles = stylex.create({
   },
   popoverContent: {
     padding: spacingVars['--spacing-1'],
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-background-surface'],
-    boxShadow: shadowVars['--shadow-low'],
     overflow: 'hidden',
   },
   popover: {

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -20,12 +20,10 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  radiusVars,
   fontWeightVars,
   typeScaleVars,
   durationVars,
   easeVars,
-  shadowVars,
   borderVars,
 } from '../theme/tokens.stylex';
 import {XDSIcon} from '../Icon';
@@ -99,12 +97,9 @@ const styles = stylex.create({
   },
   // Popover surface for collapsed items with children
   popoverSurface: {
-    backgroundColor: colorVars['--color-background-popover'],
     borderWidth: borderVars['--border-width'],
     borderStyle: 'solid',
     borderColor: colorVars['--color-border'],
-    borderRadius: radiusVars['--radius-element'],
-    boxShadow: shadowVars['--shadow-low'],
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-1'],
     marginInlineStart: spacingVars['--spacing-1'],

--- a/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMegaMenu.tsx
@@ -338,7 +338,10 @@ function DefaultMegaMenu({
 
   const popover = useXDSPopover({
     dialogLabel: label,
-    xstyle: styles.panelAnimation,
+    // hasSurface: false — mega menu provides its own surface (panelContainer)
+    // with border-top and custom overflow. Animation is applied via the
+    // render() call's xstyle prop (panelAnimation), not the hook options.
+    hasSurface: false,
     onShow: handlePopoverShow,
     onHide: handlePopoverHide,
   });

--- a/packages/core/src/TopNav/XDSTopNavMenu.tsx
+++ b/packages/core/src/TopNav/XDSTopNavMenu.tsx
@@ -35,7 +35,6 @@ import {
   durationVars,
   easeVars,
   fontWeightVars,
-  shadowVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
 
@@ -97,9 +96,6 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1'],
     minWidth: 280,
     padding: spacingVars['--spacing-1'],
-    backgroundColor: colorVars['--color-background-popover'],
-    borderRadius: radiusVars['--radius-container'],
-    boxShadow: shadowVars['--shadow-low'],
   },
   menuOffset: {
     marginBlockStart: spacingVars['--spacing-1'],


### PR DESCRIPTION
## Problem

`useXDSPopover`'s `render()` function produced a transparent container — every consumer had to independently apply popover surface styles (background, border-radius, shadow). This led to:

1. **Token mismatch** — `XDSPopover` used `--color-background-surface` (`#1F1F22` dark) while internal consumers used `--color-background-popover` (`#28292C` dark). In dark mode, `XDSPopover` blended into the page background instead of floating above it. Same with `--radius-element` (8px) vs `--radius-container` (12px).

2. **Duplicated surface** — DateInput, SideNavItem, SideNavHeading, TopNavMenu, and TopNavMegaMenu all independently declared the same bg/shadow/radius pattern, with minor inconsistencies between them.

## Solution

The hook's `render()` now applies a standard popover surface (`--color-background-popover`, `--radius-container`, `--shadow-low`) to the content wrapper by default.

- **`hasSurface`** option (default `true`) — set to `false` for consumers that provide their own surface (e.g. mega menus with custom border-top layouts). The JSDoc nudges those consumers toward `useXDSLayer` instead.
- **`xstyle`** on the hook now applies to the content wrapper (surface-level overrides), not the layer element. Layer-level xstyle remains available via the `render()` call's props.

### Changes by file

| File | Change |
|------|--------|
| `useXDSPopover.tsx` | Add `surface` style + `hasSurface` option, apply to content wrapper |
| `XDSPopover.tsx` | Remove `container` style (hook provides it now) |
| `XDSDateInput.tsx` | Remove `popover` surface style + `xstyle` prop |
| `XDSSideNavItem.tsx` | Remove bg/radius/shadow from `popoverSurface` (keep border, padding) |
| `XDSSideNavHeading.tsx` | Remove bg/radius/shadow from `popoverContent` |
| `XDSTopNavMenu.tsx` | Remove bg/radius/shadow from `menuContainer` |
| `XDSTopNavMegaMenu.tsx` | Use `hasSurface: false` (custom surface with border-top) |

## Test

All 165 tests across Popover, DateInput, SideNav, and TopNav suites pass.

---
