### PR TITLE
fix(Dialog): propagate maxHeight to layout via --container-max-height (#905)

### DIFF
--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -240,10 +240,21 @@ function FullscreenModalExample() {
           }
           content={
             <XDSLayoutContent>
-              <XDSText type="body">
-                This modal takes up the entire viewport. The width, maxHeight,
-                and position props are ignored in fullscreen mode.
-              </XDSText>
+              <div
+                style={{display: 'flex', flexDirection: 'column', gap: '12px'}}>
+                <XDSText type="body">
+                  This modal takes up the entire viewport. The width, maxHeight,
+                  and position props are ignored in fullscreen mode.
+                </XDSText>
+                {Array.from({length: 30}, (_, i) => (
+                  <XDSText type="body" key={i}>
+                    {i + 1}. Lorem ipsum dolor sit amet, consectetur adipiscing
+                    elit. Sed do eiusmod tempor incididunt ut labore et dolore
+                    magna aliqua. Ut enim ad minim veniam, quis nostrud
+                    exercitation ullamco laboris.
+                  </XDSText>
+                ))}
+              </div>
             </XDSLayoutContent>
           }
           footer={

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -135,10 +135,10 @@ const styles = stylex.create({
     },
   },
   fullscreen: {
-    width: '100vw',
-    height: '100vh',
-    maxWidth: '100vw',
-    maxHeight: '100vh',
+    width: '100dvw',
+    height: '100dvh',
+    maxWidth: '100dvw',
+    maxHeight: '100dvh',
     borderRadius: 0,
     margin: 0,
     inset: 0,
@@ -378,7 +378,14 @@ export function XDSDialog({
       {...mergeProps(
         xdsClassName('dialog', {variant}),
         stylex.props(
-          ...container({padding: 'spacing0'}),
+          ...container({
+            padding: 'spacing0',
+            maxHeight: isFullscreen
+              ? undefined
+              : typeof maxHeight === 'number'
+                ? `${maxHeight}px`
+                : maxHeight,
+          }),
           styles.dialog,
           styles.backdrop,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -15,7 +15,6 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-
 import {type ReactNode, useMemo} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSLayoutAreaContext, type LayoutArea} from './XDSLayoutAreaContext';
@@ -49,6 +48,7 @@ const styles = stylex.create({
   fill: {
     // Add 2x container padding to compensate for negative margins on top/bottom
     height: 'calc(100% + 2 * var(--container-padding, 0px))',
+    maxHeight: 'var(--container-max-height, none)',
   },
   auto: {
     minHeight: '100%',

--- a/packages/core/src/Layout/container.stylex.ts
+++ b/packages/core/src/Layout/container.stylex.ts
@@ -240,6 +240,12 @@ const paddingInnerYStyles = stylex.create({
   spacing12: {'--layout-padding-inner-y': spacingVars['--spacing-12']},
 });
 
+const maxHeightStyles = stylex.create({
+  containerMaxHeight: (maxHeight: string) => ({
+    '--container-max-height': maxHeight,
+  }),
+});
+
 export interface ContainerOptions {
   /**
    * Default container padding for simple content.
@@ -290,6 +296,14 @@ export interface ContainerOptions {
    * @default undefined (uses explicit spacing token values)
    */
   useThemeDefault?: ContainerComponent;
+
+  /**
+   * Maximum height constraint for the container.
+   * Sets --container-max-height CSS variable that XDSLayout reads
+   * to enable scroll containment in fill mode.
+   * Accepts CSS length values (e.g., '75vh', '500px').
+   */
+  maxHeight?: string;
 }
 
 /**
@@ -331,7 +345,12 @@ export function container({
   paddingInnerX = 'spacing4',
   paddingInnerY = 'spacing4',
   useThemeDefault,
+  maxHeight,
 }: ContainerOptions) {
+  const maxHeightStyle = maxHeight
+    ? maxHeightStyles.containerMaxHeight(maxHeight)
+    : null;
+
   // When useThemeDefault is a component name, cascade from the component's
   // public CSS custom property (e.g. --xds-card-padding, --xds-section-padding)
   // so themes can override each component's padding independently.
@@ -345,6 +364,7 @@ export function container({
       defaults.layoutPaddingOuterY,
       defaults.layoutPaddingInnerX,
       defaults.layoutPaddingInnerY,
+      maxHeightStyle,
     ] as const;
   }
 
@@ -359,5 +379,6 @@ export function container({
     paddingOuterYStyles[paddingOuterY],
     paddingInnerXStyles[paddingInnerX],
     paddingInnerYStyles[paddingInnerY],
+    maxHeightStyle,
   ] as const;
 }


### PR DESCRIPTION
## Problem

The dialog uses `maxHeight` (default `'75vh'`) with `height: fit-content`, so percentage-based heights in the XDSLayout chain never resolve to a definite value. The layout's `fill` mode uses `height: calc(100% + ...)` which needs a definite parent height to work. Result: scrollable content doesn't scroll.

## Solution

Introduce a `--container-max-height` CSS custom property that containers can set to communicate their height constraint to XDSLayout.

### Changes

**`XDSDialog.tsx`** — Sets `--container-max-height` on the `inner` div, passing through the dialog's `maxHeight` prop value. Skipped for fullscreen dialogs.

**`XDSLayout.tsx`** — The `fill` style now reads `max-height: var(--container-max-height, none)`. When a container sets the var, the layout constrains itself. When unset, `none` preserves existing behavior.

This is a general-purpose mechanism — any container (Card, Section, etc.) can set `--container-max-height` to enable scroll containment in nested layouts.

Closes #905

---
