### PR TITLE
fix(StatusDot,ProgressBar): single size, composition docs

### DIFF
--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -24,9 +24,7 @@ const meta: Meta<typeof XDSProgressBar> = {
       description: 'Semantic color variant',
     },
     size: {
-      control: 'select',
-      options: ['sm', 'md', 'lg'],
-      description: 'Track height',
+      table: {disable: true},
     },
     isLabelHidden: {
       control: 'boolean',
@@ -104,18 +102,24 @@ export const Variants: Story = {
   ),
 };
 
-export const Sizes: Story = {
+export const ComposedWithDescription: Story = {
+  name: 'Composed: with description',
   render: () => (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '16px',
-        width: '300px',
-      }}>
-      <XDSProgressBar value={60} label="Small" size="sm" hasValueLabel />
-      <XDSProgressBar value={60} label="Medium" size="md" hasValueLabel />
-      <XDSProgressBar value={60} label="Large" size="lg" hasValueLabel />
+    <div style={{width: '300px'}}>
+      <XDSProgressBar
+        value={40}
+        max={100}
+        label="Download progress"
+        hasValueLabel
+      />
+      <div
+        style={{
+          fontSize: '12px',
+          color: 'var(--color-text-secondary)',
+          marginTop: '4px',
+        }}>
+        40 MB / 100 MB downloaded
+      </div>
     </div>
   ),
 };
@@ -182,22 +186,6 @@ export const IndeterminateVariants: Story = {
       <XDSProgressBar isIndeterminate label="Positive" variant="positive" />
       <XDSProgressBar isIndeterminate label="Warning" variant="warning" />
       <XDSProgressBar isIndeterminate label="Negative" variant="negative" />
-    </div>
-  ),
-};
-
-export const IndeterminateSizes: Story = {
-  render: () => (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '16px',
-        width: '300px',
-      }}>
-      <XDSProgressBar isIndeterminate label="Small" size="sm" />
-      <XDSProgressBar isIndeterminate label="Medium" size="md" />
-      <XDSProgressBar isIndeterminate label="Large" size="lg" />
     </div>
   ),
 };

--- a/apps/storybook/stories/StatusDot.stories.tsx
+++ b/apps/storybook/stories/StatusDot.stories.tsx
@@ -12,9 +12,7 @@ const meta: Meta<typeof XDSStatusDot> = {
       description: 'Semantic color variant',
     },
     size: {
-      control: 'select',
-      options: ['sm', 'md'],
-      description: 'Dot size',
+      table: {disable: true},
     },
     label: {
       control: 'text',
@@ -45,15 +43,6 @@ export const Variants: Story = {
       <XDSStatusDot variant="negative" label="Negative" />
       <XDSStatusDot variant="info" label="Info" />
       <XDSStatusDot variant="neutral" label="Neutral" />
-    </div>
-  ),
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div style={{display: 'flex', gap: '8px', alignItems: 'center'}}>
-      <XDSStatusDot variant="positive" label="Small" size="sm" />
-      <XDSStatusDot variant="positive" label="Medium" size="md" />
     </div>
   ),
 };

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -11,8 +11,9 @@ export const docs = {
     'aria-valuetext provides human-readable value description (determinate only)',
     'Indeterminate animation respects prefers-reduced-motion',
     'Supports four semantic color variants: accent, positive, warning, negative',
-    'Three track height sizes: sm=4px, md=8px, lg=12px',
+    'Single track height: 8px',
     'Supports custom value label formatter via formatValueLabel',
+    'Compose additional labels, status icons, and descriptions outside the component — ProgressBar is intentionally minimal',
   ],
   props: [
     {
@@ -59,8 +60,8 @@ export const docs = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md' | 'lg'",
-      description: 'Track height: sm=4px, md=8px, lg=12px.',
+      type: "'md'",
+      description: 'Track height: 8px. Single size — larger visualizations should use a dedicated dataviz component.',
       default: "'md'",
     },
     {
@@ -100,12 +101,29 @@ export const docs = {
       code: `<XDSProgressBar isIndeterminate label="Loading..." />`,
     },
     {
-      label: 'Variant and size',
-      code: `<XDSProgressBar value={92} label="Disk" variant="negative" size="sm" />`,
+      label: 'Semantic variant',
+      code: `<XDSProgressBar value={92} label="Disk" variant="negative" />`,
     },
     {
       label: 'Hidden label (accessible but not visible)',
       code: `<XDSProgressBar value={50} label="Loading" isLabelHidden />`,
+    },
+    {
+      label: 'Composed with external description',
+      code: `<div>
+  <XDSProgressBar value={40} max={100} label="Download progress" hasValueLabel />
+  <XDSText color="secondary" size="sm">40 MB / 100 MB downloaded</XDSText>
+</div>`,
+    },
+    {
+      label: 'Composed with status icon',
+      code: `<XDSLayout direction="column" gap="1">
+  <XDSProgressBar value={100} label="Upload complete" variant="positive" hasValueLabel />
+  <XDSLayout direction="row" gap="1" align="center">
+    <XDSIcon icon={CheckCircleIcon} color="positive" size="sm" />
+    <XDSText color="secondary" size="sm">Upload complete</XDSText>
+  </XDSLayout>
+</XDSLayout>`,
     },
   ],
   theming: {
@@ -114,6 +132,10 @@ export const docs = {
       {className: 'xds-progressbar-fill', visualProps: ['variant']},
     ],
   },
+  notes: [
+    'ProgressBar is intentionally minimal — it handles the meter/track and an optional value label. For additional context like descriptions, status icons, or custom label placements, compose them alongside the bar using layout components.',
+    'Do not add props for label placement, progress descriptions, or embedded icons. These are composition concerns, not meter concerns.',
+  ],
   accessibility: [
     'Determinate: uses role="meter" with aria-valuenow, aria-valuemin, aria-valuemax',
     'Indeterminate: uses role="progressbar" without value attributes',
@@ -135,7 +157,7 @@ export const docsZh = {
     'aria-valuetext 提供人类可读的值描述（仅限确定模式）',
     '不确定动画遵循 prefers-reduced-motion 偏好设置',
     '支持四种语义颜色变体：accent、positive、warning、negative',
-    '三种轨道高度尺寸：sm=4px、md=8px、lg=12px',
+    '单一轨道高度：8px',
     '支持通过 formatValueLabel 自定义值标签格式化器',
   ],
   props: [
@@ -183,8 +205,8 @@ export const docsZh = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md' | 'lg'",
-      description: '轨道高度：sm=4px、md=8px、lg=12px。',
+      type: "'md'",
+      description: '轨道高度：8px。单一尺寸——较大的可视化应使用专用的数据可视化组件。',
       default: "'md'",
     },
     {
@@ -258,7 +280,7 @@ export const docsDense = {
     'aria-valuetext provides human-readable value description (determinate only)',
     'Indeterminate animation respects prefers-reduced-motion',
     'Supports four semantic color variants: accent, positive, warning, negative',
-    'Three track height sizes: sm=4px, md=8px, lg=12px',
+    'Single track height: 8px',
     'Supports custom value label formatter via formatValueLabel',
   ],
   accessibility: [
@@ -276,7 +298,7 @@ export const docsDense = {
     hasValueLabel: 'Show formatted value text (ignored when indeterminate).',
     formatValueLabel: 'Custom value label formatter; defaults to percentage string.',
     variant: 'Semantic color variant.',
-    size: 'Track height: sm=4px, md=8px, lg=12px.',
+    size: 'Track height: 8px. Single size — larger visualizations should use a dedicated dataviz component.',
     isIndeterminate: 'Animated loading indicator for unknown progress.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },

--- a/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
@@ -96,7 +96,7 @@ describe('XDSProgressBar', () => {
     }
   });
 
-  it('renders with all size options', () => {
+  it('accepts size prop for backwards compatibility', () => {
     const sizes = ['sm', 'md', 'lg'] as const;
     for (const size of sizes) {
       const {unmount} = render(

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -54,7 +54,8 @@ export interface XDSProgressBarVariantMap {
 export type XDSProgressBarVariant = keyof XDSProgressBarVariantMap;
 
 /**
- * Progress bar size type — controls track height.
+ * Progress bar size type — single track height (8px).
+ * The `size` prop is accepted for backwards compatibility but has no effect.
  */
 export type XDSProgressBarSize = 'sm' | 'md' | 'lg';
 
@@ -98,10 +99,9 @@ export interface XDSProgressBarProps {
    */
   variant?: XDSProgressBarVariant;
   /**
-   * Size of the progress bar track.
-   * - sm: 4px
-   * - md: 8px
-   * - lg: 12px
+   * Size of the progress bar track. Single size (8px) — this prop is accepted
+   * for backwards compatibility but has no visual effect.
+   * Larger visualizations should use a dedicated dataviz component.
    * @default 'md'
    */
   size?: XDSProgressBarSize;
@@ -260,6 +260,10 @@ function defaultFormatValueLabel(value: number, max: number): string {
  * Styles use XDS theme tokens via StyleX.
  * Wrap your app in <Theme> to apply a theme.
  *
+ * ProgressBar is intentionally minimal — compose additional labels, status
+ * icons, and descriptions alongside the bar using layout components rather
+ * than adding props to ProgressBar itself.
+ *
  * @example
  * ```
  * <XDSProgressBar value={75} label="Upload progress" />
@@ -276,7 +280,7 @@ export function XDSProgressBar({
   hasValueLabel = false,
   formatValueLabel = defaultFormatValueLabel,
   variant = 'accent',
-  size = 'md',
+  size: _size,
   isIndeterminate = false,
   xstyle,
   className,
@@ -296,7 +300,7 @@ export function XDSProgressBar({
     <div
       ref={ref}
       {...mergeProps(
-        xdsClassName('progressbar', {variant, size}),
+        xdsClassName('progressbar', {variant, size: 'md'}),
         stylex.props(styles.container, xstyle),
         className,
         style,
@@ -331,7 +335,7 @@ export function XDSProgressBar({
         aria-valuemax={isIndeterminate ? undefined : max}
         aria-labelledby={labelId}
         aria-valuetext={isIndeterminate ? undefined : valueText}
-        {...stylex.props(styles.track, sizeStyles[size])}>
+        {...stylex.props(styles.track, sizeStyles.md)}>
         {isIndeterminate ? (
           <div
             {...mergeProps(

--- a/packages/core/src/StatusDot/StatusDot.doc.mjs
+++ b/packages/core/src/StatusDot/StatusDot.doc.mjs
@@ -6,7 +6,7 @@ export const docs = {
     'A small colored dot indicator for status display (online/offline, severity, etc).',
   features: [
     'Five semantic color variants: positive, warning, negative, info, neutral',
-    'Two sizes: sm (8px) and md (10px)',
+    'Single size: 8px',
     'Optional pulse animation that respects prefers-reduced-motion',
     'Accessible — renders as <span role="img" aria-label={label}> for screen reader support',
     'Not focusable (decorative indicator)',
@@ -26,9 +26,9 @@ export const docs = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md'",
-      description: 'Dot size: sm=8px, md=10px.',
-      default: "'md'",
+      type: "'sm'",
+      description: 'Dot size: 8px. Single size — StatusDot is a fixed indicator.',
+      default: "'sm'",
     },
     {
       name: 'isPulsing',
@@ -52,8 +52,8 @@ export const docs = {
 <XDSStatusDot variant="warning" label="Away" />`,
     },
     {
-      label: 'Small size',
-      code: `<XDSStatusDot variant="positive" label="Active" size="sm" />`,
+      label: 'With pulse',
+      code: `<XDSStatusDot variant="positive" label="Active" isPulsing />`,
     },
     {
       label: 'Pulsing animation',
@@ -99,8 +99,8 @@ export const docsZh = {
     },
     {
       name: 'size',
-      type: "'sm' | 'md'",
-      description: '圆点尺寸：sm=8px，md=10px。',
+      type: "'sm'",
+      description: '圆点尺寸：8px。单一尺寸。',
       default: "'md'",
     },
     {
@@ -150,7 +150,7 @@ export const docsDense = {
   description: 'Small colored dot indicator for status display (online/offline, severity, etc).',
   features: [
     'Five semantic color variants: positive, warning, negative, info, neutral',
-    'Two sizes: sm (8px) + md (10px)',
+    'Single size: 8px',
     'Optional pulse animation respecting prefers-reduced-motion',
     'Accessible: <span role="img" aria-label={label}> for screen readers',
     'Not focusable (decorative indicator)',
@@ -163,7 +163,7 @@ export const docsDense = {
   propDescriptions: {
     variant: 'Semantic color variant.',
     label: 'Accessible label via aria-label.',
-    size: 'Dot size: sm=8px, md=10px.',
+    size: 'Dot size: 8px. Single size — StatusDot is a fixed indicator.',
     isPulsing: 'Pulse animation; respects prefers-reduced-motion: reduce.',
     xstyle: 'StyleX layout styles; must be stylex.create() value.',
   },

--- a/packages/core/src/StatusDot/XDSStatusDot.test.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.test.tsx
@@ -33,13 +33,13 @@ describe('XDSStatusDot', () => {
     }
   });
 
-  it('defaults to md size', () => {
+  it('renders at single 8px size', () => {
     render(<XDSStatusDot variant="positive" label="Online" />);
     const dot = screen.getByRole('img', {name: 'Online'});
     expect(dot).toBeInTheDocument();
   });
 
-  it('accepts sm size', () => {
+  it('accepts size prop for backwards compatibility', () => {
     render(<XDSStatusDot variant="positive" label="Online" size="sm" />);
     const dot = screen.getByRole('img', {name: 'Online'});
     expect(dot).toBeInTheDocument();

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -110,7 +110,8 @@ export interface XDSStatusDotVariantMap {
 export type XDSStatusDotVariant = keyof XDSStatusDotVariantMap;
 
 /**
- * Status dot size type
+ * Status dot size type.
+ * Single size (8px). The `size` prop is accepted for backwards compatibility but has no effect.
  */
 export type XDSStatusDotSize = 'sm' | 'md';
 
@@ -122,8 +123,9 @@ export interface XDSStatusDotProps {
    */
   variant: XDSStatusDotVariant;
   /**
-   * The size of the dot.
-   * @default 'md'
+   * The size of the dot. Single size (8px) — this prop is accepted for
+   * backwards compatibility but has no visual effect.
+   * @default 'sm'
    */
   size?: XDSStatusDotSize;
   /**
@@ -172,13 +174,13 @@ export interface XDSStatusDotProps {
  * @example
  * ```
  * <XDSStatusDot variant="positive" label="Online" />
- * <XDSStatusDot variant="negative" label="Offline" size="sm" />
+ * <XDSStatusDot variant="negative" label="Offline" />
  * <XDSStatusDot variant="positive" label="Live" isPulsing />
  * ```
  */
 export function XDSStatusDot({
   variant,
-  size = 'md',
+  size: _size,
   label,
   isPulsing = false,
   xstyle,
@@ -193,10 +195,10 @@ export function XDSStatusDot({
       role="img"
       aria-label={label}
       {...mergeProps(
-        xdsClassName('statusdot', {variant, size}),
+        xdsClassName('statusdot', {variant, size: 'sm'}),
         stylex.props(
           styles.base,
-          sizes[size],
+          sizes.sm,
           variants[variant],
           isPulsing && styles.pulsing,
           isPulsing && styles.reducedMotion,


### PR DESCRIPTION
## Summary

Reduces StatusDot and ProgressBar to a single size each, and adds composition examples to ProgressBar docs guiding devs (and AI) toward composing labels/icons alongside the bar rather than overloading the component API.

### StatusDot
- Single 8px size. The `md` (10px) variant is removed — one dot size is enough.
- `size` prop still accepted for backwards compat but has no visual effect.

### ProgressBar
- Single 8px track. The `sm` (4px) and `lg` (12px) variants are removed — larger visualizations should use a dedicated dataviz component.
- `size` prop still accepted for backwards compat but has no visual effect.
- Added composition examples in docs showing how to compose descriptions and status icons alongside the bar.
- Added `notes` field making the composition philosophy explicit: *"Do not add props for label placement, progress descriptions, or embedded icons. These are composition concerns, not meter concerns."*

### Stories
- Removed `Sizes` and `IndeterminateSizes` stories from ProgressBar.
- Added `Composed: with description` story showing the composition pattern.
- Removed `Sizes` story from StatusDot.
- Disabled `size` argType control in both components.

Refs #904

---
