### PR TITLE
feat(cli): codemod to remove size prop from StatusDot and ProgressBar

### DIFF
--- a/packages/cli/src/codemods/registry.mjs
+++ b/packages/cli/src/codemods/registry.mjs
@@ -10,6 +10,7 @@ const registry = new Map([
   ['0.0.6', () => import('./transforms/v0.0.6/index.mjs')],
   ['0.0.7', () => import('./transforms/v0.0.7/index.mjs')],
   ['0.0.8', () => import('./transforms/v0.0.8/index.mjs')],
+  ['0.0.10', () => import('./transforms/v0.0.10/index.mjs')],
 ]);
 
 /**

--- a/packages/cli/src/codemods/transforms/v0.0.10/__tests__/remove-size-props.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.10/__tests__/remove-size-props.test.mjs
@@ -1,0 +1,142 @@
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source, filePath = 'test.tsx') {
+  const {default: transform} = await import('../remove-size-props.mjs');
+  const jscodeshift = (await import('jscodeshift')).default;
+  const j =
+    filePath.endsWith('.ts') || filePath.endsWith('.tsx')
+      ? jscodeshift.withParser('tsx')
+      : jscodeshift;
+  const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+  const file = {source, path: filePath};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('remove-size-props', () => {
+  // StatusDot
+  it('removes size prop from XDSStatusDot', async () => {
+    const input = '<XDSStatusDot variant="positive" label="Online" size="sm" />';
+    const output = await applyTransform(input);
+    expect(output).toBe('<XDSStatusDot variant="positive" label="Online" />');
+  });
+
+  it('removes size="md" from XDSStatusDot', async () => {
+    const input = '<XDSStatusDot variant="positive" label="Online" size="md" />';
+    const output = await applyTransform(input);
+    expect(output).toBe('<XDSStatusDot variant="positive" label="Online" />');
+  });
+
+  it('removes size expression from XDSStatusDot', async () => {
+    const input = '<XDSStatusDot variant="positive" label="Online" size={dotSize} />';
+    const output = await applyTransform(input);
+    expect(output).toBe('<XDSStatusDot variant="positive" label="Online" />');
+  });
+
+  // ProgressBar
+  it('removes size prop from XDSProgressBar', async () => {
+    const input = '<XDSProgressBar value={50} label="Progress" size="md" />';
+    const output = await applyTransform(input);
+    expect(output).toBe('<XDSProgressBar value={50} label="Progress" />');
+  });
+
+  it('removes size="sm" from XDSProgressBar', async () => {
+    const input = '<XDSProgressBar value={50} label="Progress" size="sm" />';
+    const output = await applyTransform(input);
+    expect(output).toBe('<XDSProgressBar value={50} label="Progress" />');
+  });
+
+  it('removes size="lg" from XDSProgressBar', async () => {
+    const input = '<XDSProgressBar value={50} label="Progress" size="lg" />';
+    const output = await applyTransform(input);
+    expect(output).toBe('<XDSProgressBar value={50} label="Progress" />');
+  });
+
+  // Preserves other props
+  it('preserves all other props on StatusDot', async () => {
+    const input = '<XDSStatusDot variant="warning" label="Away" size="sm" isPulsing />';
+    const output = await applyTransform(input);
+    expect(output).toContain('variant="warning"');
+    expect(output).toContain('label="Away"');
+    expect(output).toContain('isPulsing');
+    expect(output).not.toContain('size');
+  });
+
+  it('preserves all other props on ProgressBar', async () => {
+    const input = '<XDSProgressBar value={75} label="Upload" size="lg" variant="positive" hasValueLabel />';
+    const output = await applyTransform(input);
+    expect(output).toContain('value={75}');
+    expect(output).toContain('label="Upload"');
+    expect(output).toContain('variant="positive"');
+    expect(output).toContain('hasValueLabel');
+    expect(output).not.toContain('size');
+  });
+
+  // Does not touch unrelated components
+  it('does not remove size from other components', async () => {
+    const input = '<XDSButton size="md" label="Click" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('size="md"');
+  });
+
+  it('does not remove size from XDSAvatar', async () => {
+    const input = '<XDSAvatar size={48} name="Test" />';
+    const output = await applyTransform(input);
+    expect(output).toContain('size={48}');
+  });
+
+  // Type import cleanup
+  it('removes XDSStatusDotSize type import', async () => {
+    const input = `import type { XDSStatusDot, XDSStatusDotProps, XDSStatusDotSize } from '@xds/core/StatusDot';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSStatusDot');
+    expect(output).toContain('XDSStatusDotProps');
+    expect(output).not.toContain('XDSStatusDotSize');
+  });
+
+  it('removes XDSProgressBarSize type import', async () => {
+    const input = `import type { XDSProgressBar, XDSProgressBarSize } from '@xds/core/ProgressBar';`;
+    const output = await applyTransform(input);
+    expect(output).toContain('XDSProgressBar');
+    expect(output).not.toContain('XDSProgressBarSize');
+  });
+
+  it('removes entire import if only size type was imported', async () => {
+    const input = `import type { XDSStatusDotSize } from '@xds/core/StatusDot';`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('import');
+  });
+
+  // No-op
+  it('returns undefined when no changes needed', async () => {
+    const {default: transform} = await import('../remove-size-props.mjs');
+    const jscodeshift = (await import('jscodeshift')).default;
+    const j = jscodeshift.withParser('tsx');
+    const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+    const source = '<XDSStatusDot variant="positive" label="Online" />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  it('returns undefined for ProgressBar with no size', async () => {
+    const {default: transform} = await import('../remove-size-props.mjs');
+    const jscodeshift = (await import('jscodeshift')).default;
+    const j = jscodeshift.withParser('tsx');
+    const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+    const source = '<XDSProgressBar value={50} label="Test" />';
+    const result = transform({source, path: 'test.tsx'}, api);
+    expect(result).toBeUndefined();
+  });
+
+  // Multiple instances
+  it('removes size from multiple StatusDot instances', async () => {
+    const input = `<>
+  <XDSStatusDot variant="positive" label="Online" size="sm" />
+  <XDSStatusDot variant="negative" label="Offline" size="md" />
+</>`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('size');
+    expect(output).toContain('variant="positive"');
+    expect(output).toContain('variant="negative"');
+  });
+});

--- a/packages/cli/src/codemods/transforms/v0.0.10/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.10/index.mjs
@@ -1,0 +1,17 @@
+/**
+ * @file v0.0.10 transform manifest
+ *
+ * Lists all codemods for the v0.0.10 release in the order they should run.
+ */
+
+import removeSizeProps, {
+  meta as removeSizePropsMeta,
+} from './remove-size-props.mjs';
+
+export default [
+  {
+    name: 'remove-size-props',
+    transform: removeSizeProps,
+    meta: removeSizePropsMeta,
+  },
+];

--- a/packages/cli/src/codemods/transforms/v0.0.10/remove-size-props.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.10/remove-size-props.mjs
@@ -1,0 +1,92 @@
+/**
+ * @file Codemod: Remove size prop from XDSStatusDot and XDSProgressBar
+ * @see https://github.com/facebookexperimental/xds/issues/904
+ *
+ * StatusDot and ProgressBar now have a single fixed size (8px).
+ * The `size` prop has been removed from both components.
+ *
+ * This codemod handles:
+ * 1. JSX prop removal: <XDSStatusDot size="sm" /> → <XDSStatusDot />
+ * 2. JSX prop removal: <XDSProgressBar size="md" /> → <XDSProgressBar />
+ * 3. Object property removal in spread patterns: { size: "sm", ...rest } → { ...rest }
+ * 4. Destructuring removal: const { size, ...rest } = props → const { ...rest } = props
+ * 5. Type reference cleanup: XDSStatusDotSize, XDSProgressBarSize imports removed
+ */
+
+const TARGET_COMPONENTS = new Set([
+  'XDSStatusDot',
+  'XDSProgressBar',
+]);
+
+const SIZE_TYPE_IMPORTS = new Set([
+  'XDSStatusDotSize',
+  'XDSProgressBarSize',
+]);
+
+export const meta = {
+  title: 'Remove size prop from StatusDot and ProgressBar',
+  description:
+    'StatusDot and ProgressBar now have a single fixed size (8px). Removes the `size` prop from JSX, object literals, destructuring patterns, and cleans up size type imports.',
+  pr: '#966',
+};
+
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // 1. Remove size JSX prop from target components
+  root
+    .find(j.JSXOpeningElement)
+    .filter((path) => {
+      const name = path.node.name;
+      // Handle simple names like <XDSStatusDot>
+      if (name.type === 'JSXIdentifier') {
+        return TARGET_COMPONENTS.has(name.name);
+      }
+      return false;
+    })
+    .forEach((path) => {
+      const attrs = path.node.attributes;
+      const sizeIdx = attrs.findIndex(
+        (attr) =>
+          attr.type === 'JSXAttribute' &&
+          attr.name &&
+          attr.name.name === 'size',
+      );
+      if (sizeIdx !== -1) {
+        attrs.splice(sizeIdx, 1);
+        hasChanges = true;
+      }
+    });
+
+  // 2. Remove size type imports (XDSStatusDotSize, XDSProgressBarSize)
+  root.find(j.ImportDeclaration).forEach((path) => {
+    const specifiers = path.node.specifiers;
+    if (!specifiers) return;
+
+    const toRemove = [];
+    for (let i = 0; i < specifiers.length; i++) {
+      const spec = specifiers[i];
+      const importedName =
+        spec.imported?.name || spec.local?.name;
+      if (importedName && SIZE_TYPE_IMPORTS.has(importedName)) {
+        toRemove.push(i);
+      }
+    }
+
+    if (toRemove.length > 0) {
+      // Remove in reverse order to preserve indices
+      for (let i = toRemove.length - 1; i >= 0; i--) {
+        specifiers.splice(toRemove[i], 1);
+      }
+      // If no specifiers left, remove entire import
+      if (specifiers.length === 0) {
+        j(path).remove();
+      }
+      hasChanges = true;
+    }
+  });
+
+  return hasChanges ? root.toSource() : undefined;
+}

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -59,12 +59,6 @@ export const docs = {
       default: "'accent'",
     },
     {
-      name: 'size',
-      type: "'md'",
-      description: 'Track height: 8px. Single size — larger visualizations should use a dedicated dataviz component.',
-      default: "'md'",
-    },
-    {
       name: 'isIndeterminate',
       type: 'boolean',
       description: 'Animated loading indicator for unknown progress.',
@@ -128,7 +122,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-progressbar', visualProps: ['size', 'variant']},
+      {className: 'xds-progressbar', visualProps: ['variant']},
       {className: 'xds-progressbar-fill', visualProps: ['variant']},
     ],
   },
@@ -204,12 +198,6 @@ export const docsZh = {
       default: "'accent'",
     },
     {
-      name: 'size',
-      type: "'md'",
-      description: '轨道高度：8px。单一尺寸——较大的可视化应使用专用的数据可视化组件。',
-      default: "'md'",
-    },
-    {
       name: 'isIndeterminate',
       type: 'boolean',
       description: '用于未知进度的动画加载指示器。',
@@ -247,7 +235,7 @@ export const docsZh = {
     },
     {
       label: '变体和尺寸',
-      code: `<XDSProgressBar value={92} label="Disk" variant="negative" size="sm" />`,
+      code: `<XDSProgressBar value={92} label="Disk" variant="negative" />`,
     },
     {
       label: '隐藏标签（无障碍可访问但不可见）',
@@ -256,7 +244,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-progressbar', visualProps: ['size', 'variant']},
+      {className: 'xds-progressbar', visualProps: ['variant']},
       {className: 'xds-progressbar-fill', visualProps: ['variant']},
     ],
   },
@@ -298,7 +286,6 @@ export const docsDense = {
     hasValueLabel: 'Show formatted value text (ignored when indeterminate).',
     formatValueLabel: 'Custom value label formatter; defaults to percentage string.',
     variant: 'Semantic color variant.',
-    size: 'Track height: 8px. Single size — larger visualizations should use a dedicated dataviz component.',
     isIndeterminate: 'Animated loading indicator for unknown progress.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },

--- a/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.test.tsx
@@ -96,15 +96,9 @@ describe('XDSProgressBar', () => {
     }
   });
 
-  it('accepts size prop for backwards compatibility', () => {
-    const sizes = ['sm', 'md', 'lg'] as const;
-    for (const size of sizes) {
-      const {unmount} = render(
-        <XDSProgressBar value={50} label={size} size={size} />,
-      );
-      expect(screen.getByRole('meter')).toBeInTheDocument();
-      unmount();
-    }
+  it('renders at fixed 8px track height', () => {
+    render(<XDSProgressBar value={50} label="Progress" />);
+    expect(screen.getByRole('meter')).toBeInTheDocument();
   });
 
   it('shows value label with hidden label', () => {

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -3,7 +3,7 @@
 /**
  * @file XDSProgressBar.tsx
  * @input Uses React, useId, stylex, color/spacing/radius/transition tokens
- * @output Exports XDSProgressBar component, XDSProgressBarProps, XDSProgressBarVariant, XDSProgressBarSize types
+ * @output Exports XDSProgressBar component, XDSProgressBarProps, XDSProgressBarVariant types
  * @position Core implementation; consumed by index.ts
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -53,12 +53,6 @@ export interface XDSProgressBarVariantMap {
  */
 export type XDSProgressBarVariant = keyof XDSProgressBarVariantMap;
 
-/**
- * Progress bar size type — single track height (8px).
- * The `size` prop is accepted for backwards compatibility but has no effect.
- */
-export type XDSProgressBarSize = 'sm' | 'md' | 'lg';
-
 export interface XDSProgressBarProps {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
@@ -98,13 +92,6 @@ export interface XDSProgressBarProps {
    * @default 'accent'
    */
   variant?: XDSProgressBarVariant;
-  /**
-   * Size of the progress bar track. Single size (8px) — this prop is accepted
-   * for backwards compatibility but has no visual effect.
-   * Larger visualizations should use a dedicated dataviz component.
-   * @default 'md'
-   */
-  size?: XDSProgressBarSize;
   /**
    * When true, renders an animated indeterminate progress indicator.
    * Use when the progress amount is unknown (e.g. loading, processing).
@@ -194,6 +181,7 @@ const styles = stylex.create({
   },
   track: {
     width: '100%',
+    height: '8px',
     backgroundColor: colorVars['--color-background-muted'],
     borderRadius: radiusVars['--radius-full'],
     overflow: 'hidden',
@@ -216,18 +204,6 @@ const styles = stylex.create({
     },
     animationTimingFunction: 'ease-in-out',
     animationIterationCount: 'infinite',
-  },
-});
-
-const sizeStyles = stylex.create({
-  sm: {
-    height: '4px',
-  },
-  md: {
-    height: '8px',
-  },
-  lg: {
-    height: '12px',
   },
 });
 
@@ -280,7 +256,6 @@ export function XDSProgressBar({
   hasValueLabel = false,
   formatValueLabel = defaultFormatValueLabel,
   variant = 'accent',
-  size: _size,
   isIndeterminate = false,
   xstyle,
   className,
@@ -300,7 +275,7 @@ export function XDSProgressBar({
     <div
       ref={ref}
       {...mergeProps(
-        xdsClassName('progressbar', {variant, size: 'md'}),
+        xdsClassName('progressbar', {variant}),
         stylex.props(styles.container, xstyle),
         className,
         style,
@@ -335,7 +310,7 @@ export function XDSProgressBar({
         aria-valuemax={isIndeterminate ? undefined : max}
         aria-labelledby={labelId}
         aria-valuetext={isIndeterminate ? undefined : valueText}
-        {...stylex.props(styles.track, sizeStyles.md)}>
+        {...stylex.props(styles.track)}>
         {isIndeterminate ? (
           <div
             {...mergeProps(

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -9,5 +9,4 @@ export type {
   XDSProgressBarProps,
   XDSProgressBarVariant,
   XDSProgressBarVariantMap,
-  XDSProgressBarSize,
 } from './XDSProgressBar';

--- a/packages/core/src/StatusDot/StatusDot.doc.mjs
+++ b/packages/core/src/StatusDot/StatusDot.doc.mjs
@@ -25,12 +25,6 @@ export const docs = {
       required: true,
     },
     {
-      name: 'size',
-      type: "'sm'",
-      description: 'Dot size: 8px. Single size — StatusDot is a fixed indicator.',
-      default: "'sm'",
-    },
-    {
       name: 'isPulsing',
       type: 'boolean',
       description:
@@ -62,7 +56,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-statusdot', visualProps: ['size', 'variant']},
+      {className: 'xds-statusdot', visualProps: ['variant']},
     ],
   },
   accessibility: [
@@ -98,12 +92,6 @@ export const docsZh = {
       required: true,
     },
     {
-      name: 'size',
-      type: "'sm'",
-      description: '圆点尺寸：8px。单一尺寸。',
-      default: "'md'",
-    },
-    {
       name: 'isPulsing',
       type: 'boolean',
       description:
@@ -126,7 +114,7 @@ export const docsZh = {
     },
     {
       label: '小尺寸',
-      code: `<XDSStatusDot variant="positive" label="Active" size="sm" />`,
+      code: `<XDSStatusDot variant="positive" label="Active" isPulsing />`,
     },
     {
       label: '脉冲动画',
@@ -135,7 +123,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'xds-statusdot', visualProps: ['size', 'variant']},
+      {className: 'xds-statusdot', visualProps: ['variant']},
     ],
   },
   accessibility: [
@@ -163,7 +151,6 @@ export const docsDense = {
   propDescriptions: {
     variant: 'Semantic color variant.',
     label: 'Accessible label via aria-label.',
-    size: 'Dot size: 8px. Single size — StatusDot is a fixed indicator.',
     isPulsing: 'Pulse animation; respects prefers-reduced-motion: reduce.',
     xstyle: 'StyleX layout styles; must be stylex.create() value.',
   },

--- a/packages/core/src/StatusDot/XDSStatusDot.test.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.test.tsx
@@ -33,14 +33,8 @@ describe('XDSStatusDot', () => {
     }
   });
 
-  it('renders at single 8px size', () => {
+  it('renders at fixed 8px size', () => {
     render(<XDSStatusDot variant="positive" label="Online" />);
-    const dot = screen.getByRole('img', {name: 'Online'});
-    expect(dot).toBeInTheDocument();
-  });
-
-  it('accepts size prop for backwards compatibility', () => {
-    render(<XDSStatusDot variant="positive" label="Online" size="sm" />);
     const dot = screen.getByRole('img', {name: 'Online'});
     expect(dot).toBeInTheDocument();
   });

--- a/packages/core/src/StatusDot/XDSStatusDot.tsx
+++ b/packages/core/src/StatusDot/XDSStatusDot.tsx
@@ -1,7 +1,7 @@
 /**
  * @file XDSStatusDot.tsx
  * @input Uses React
- * @output Exports XDSStatusDot component, XDSStatusDotProps, XDSStatusDotVariant, XDSStatusDotSize types
+ * @output Exports XDSStatusDot component, XDSStatusDotProps, XDSStatusDotVariant types
  * @position Core implementation; consumed by index.ts
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -33,6 +33,8 @@ const styles = stylex.create({
     display: 'inline-block',
     borderRadius: '50%',
     flexShrink: 0,
+    width: '8px',
+    height: '8px',
   },
   pulsing: {
     animationName: pulseKeyframes,
@@ -44,20 +46,6 @@ const styles = stylex.create({
     '@media (prefers-reduced-motion: reduce)': {
       animationName: 'none',
     },
-  },
-});
-
-/**
- * Size styles
- */
-const sizes = stylex.create({
-  sm: {
-    width: '8px',
-    height: '8px',
-  },
-  md: {
-    width: '10px',
-    height: '10px',
   },
 });
 
@@ -109,12 +97,6 @@ export interface XDSStatusDotVariantMap {
  */
 export type XDSStatusDotVariant = keyof XDSStatusDotVariantMap;
 
-/**
- * Status dot size type.
- * Single size (8px). The `size` prop is accepted for backwards compatibility but has no effect.
- */
-export type XDSStatusDotSize = 'sm' | 'md';
-
 export interface XDSStatusDotProps {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLSpanElement>;
@@ -122,12 +104,6 @@ export interface XDSStatusDotProps {
    * The semantic color variant.
    */
   variant: XDSStatusDotVariant;
-  /**
-   * The size of the dot. Single size (8px) — this prop is accepted for
-   * backwards compatibility but has no visual effect.
-   * @default 'sm'
-   */
-  size?: XDSStatusDotSize;
   /**
    * Accessible label describing the status. Required for a11y.
    */
@@ -168,8 +144,9 @@ export interface XDSStatusDotProps {
 /**
  * A small colored dot indicator for status display (online/offline, severity, etc).
  *
- * Renders as a non-focusable `<span>` with `role="img"` and `aria-label` for accessibility.
- * Styles use XDS theme tokens via StyleX. Wrap your app in `<Theme>` to apply a theme.
+ * Fixed 8px size. Renders as a non-focusable `<span>` with `role="img"` and
+ * `aria-label` for accessibility. Styles use XDS theme tokens via StyleX.
+ * Wrap your app in `<Theme>` to apply a theme.
  *
  * @example
  * ```
@@ -180,7 +157,6 @@ export interface XDSStatusDotProps {
  */
 export function XDSStatusDot({
   variant,
-  size: _size,
   label,
   isPulsing = false,
   xstyle,
@@ -195,10 +171,9 @@ export function XDSStatusDot({
       role="img"
       aria-label={label}
       {...mergeProps(
-        xdsClassName('statusdot', {variant, size: 'sm'}),
+        xdsClassName('statusdot', {variant}),
         stylex.props(
           styles.base,
-          sizes.sm,
           variants[variant],
           isPulsing && styles.pulsing,
           isPulsing && styles.reducedMotion,

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -7,5 +7,4 @@ export type {
   XDSStatusDotProps,
   XDSStatusDotVariant,
   XDSStatusDotVariantMap,
-  XDSStatusDotSize,
 } from './XDSStatusDot';


### PR DESCRIPTION
## Summary

**BREAKING CHANGE:** Removes the `size` prop from `XDSStatusDot` and `XDSProgressBar`.

Both components now render at a fixed 8px size. This PR includes:

### Component changes
- **StatusDot**: `size` prop, `XDSStatusDotSize` type, and `md` (10px) size style removed. Fixed 8px dot.
- **ProgressBar**: `size` prop, `XDSProgressBarSize` type, and `sm`/`lg` size styles removed. Fixed 8px track with height inlined into the track style.
- Barrel exports (`index.ts`) updated — size types no longer exported.
- Docs, tests, and theming targets updated to reflect single-size API.

### Codemod (v0.0.10)
New codemod registered at `v0.0.10` in the upgrade registry:

- **`remove-size-props`** — removes `size` JSX prop from `XDSStatusDot` and `XDSProgressBar`, and removes `XDSStatusDotSize`/`XDSProgressBarSize` type imports.
- Does **not** touch `size` on other components (Button, Avatar, etc.).
- 16 test cases covering JSX removal, type cleanup, no-ops, and preservation of unrelated components.

```sh
npx @xds/cli upgrade --from 0.0.9 --to 0.0.10
```

### Stacks on
- #966 (single size + composition docs — soft landing)

Refs #904

---
