### PR TITLE
fix(cli): use semver-aware comparison in codemod registry

### DIFF
--- a/packages/cli/src/codemods/__tests__/registry.test.mjs
+++ b/packages/cli/src/codemods/__tests__/registry.test.mjs
@@ -1,0 +1,36 @@
+import {describe, expect, test} from 'vitest';
+import {versions, getTransformsBetween} from '../registry.mjs';
+
+describe('registry', () => {
+  describe('versions', () => {
+    test('are sorted in ascending semver order across digit boundaries', () => {
+      expect(versions).toEqual(['0.0.2', '0.0.6', '0.0.7', '0.0.8', '0.0.10']);
+    });
+  });
+
+  describe('getTransformsBetween', () => {
+    test('returns v0.0.10 transforms for range 0.0.9 to 0.0.10', async () => {
+      const results = await getTransformsBetween('0.0.9', '0.0.10');
+      expect(results.map((r) => r.version)).toEqual(['0.0.10']);
+    });
+
+    test('returns v0.0.6, v0.0.7, v0.0.8 for range 0.0.2 to 0.0.8', async () => {
+      const results = await getTransformsBetween('0.0.2', '0.0.8');
+      expect(results.map((r) => r.version)).toEqual([
+        '0.0.6',
+        '0.0.7',
+        '0.0.8',
+      ]);
+    });
+
+    test('returns empty array when from equals to', async () => {
+      const results = await getTransformsBetween('0.0.6', '0.0.6');
+      expect(results).toEqual([]);
+    });
+
+    test('returns empty array when from is greater than to', async () => {
+      const results = await getTransformsBetween('0.0.8', '0.0.2');
+      expect(results).toEqual([]);
+    });
+  });
+});

--- a/packages/cli/src/codemods/registry.mjs
+++ b/packages/cli/src/codemods/registry.mjs
@@ -14,9 +14,28 @@ const registry = new Map([
 ]);
 
 /**
+ * Compare two semver strings numerically.
+ * Returns negative if a < b, positive if a > b, 0 if equal.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {number}
+ */
+function semverCompare(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na !== nb) return na - nb;
+  }
+  return 0;
+}
+
+/**
  * All registered versions, sorted ascending.
  */
-export const versions = [...registry.keys()].sort();
+export const versions = [...registry.keys()].sort(semverCompare);
 
 /**
  * The latest version in the registry.
@@ -32,7 +51,9 @@ export const latestVersion = versions[versions.length - 1];
  * @returns {Promise<Array<{version: string, transforms: Array<{name: string, module: Function}>}>>}
  */
 export async function getTransformsBetween(from, to) {
-  const applicable = versions.filter((v) => v > from && v <= to);
+  const applicable = versions.filter(
+    (v) => semverCompare(v, from) > 0 && semverCompare(v, to) <= 0,
+  );
   const results = [];
 
   for (const version of applicable) {


### PR DESCRIPTION
## Summary

Fixes #971 — `getTransformsBetween` used JS string comparison (`>`, `<=`) which breaks at digit boundaries (`'0.0.10' > '0.0.9'` is `false` lexicographically).

## Changes

- Added lightweight `semverCompare()` using `split('.').map(Number)` — no new dependencies
- Fixed `versions` sort to use semver-aware comparator
- Fixed `getTransformsBetween` filter to use `semverCompare()` instead of string operators

## Tests

Added `packages/cli/src/codemods/__tests__/registry.test.mjs`:
- Verifies version sort order across digit boundaries (0.0.8 → 0.0.10)
- Verifies `getTransformsBetween('0.0.9', '0.0.10')` finds v0.0.10 transforms
- Verifies range exclusivity (from exclusive, to inclusive)
- Edge cases: same version, reversed range

---
