### PR TITLE
fix(TreeList): add density to xdsClassName for theme targeting

### DIFF
--- a/packages/core/src/TreeList/XDSTreeListItem.tsx
+++ b/packages/core/src/TreeList/XDSTreeListItem.tsx
@@ -406,6 +406,7 @@ export function XDSTreeListItem({
         <div
           {...mergeProps(
             xdsClassName('tree-list-item', {
+              density,
               selected: isSelected ? 'selected' : null,
               disabled: isDisabled ? 'disabled' : null,
             }),


### PR DESCRIPTION
## Component Audit — 2026-03-30

Nightly component audit covering the final 2 components in the queue: **Timestamp** and **TreeList**.

### Findings

**Timestamp** — Clean. No issues found across all 9 audit dimensions.

**TreeList** — 1 issue found:
- `density` prop drives visual styles via `densityStyles[density]` in `XDSTreeListItem` but was missing from the `xdsClassName()` call. Themes couldn't target density variants (`compact`, `balanced`, `spacious`) on individual tree list items.

### Fix

Added `density` to the `xdsClassName` call in `XDSTreeListItem.tsx`:

```diff
 xdsClassName('tree-list-item', {
+  density,
   selected: isSelected ? 'selected' : null,
   disabled: isDisabled ? 'disabled' : null,
 }),
```

This enables theme selectors like `.xds-tree-list-item.compact { ... }` to work.

### Verification

- `yarn build` ✅
- `yarn test` ✅ (2138/2138 tests passing)

### Needs Review

- TreeList branch connector lines use hardcoded `LINE_WIDTH = 2` and `borderRadius: 1` / `LINE_WIDTH * 2` in `XDSTreeListBranches.tsx` and `XDSTreeListItem.tsx`. These are sub-pixel decorative values for thin tree connector lines — no token equivalent exists. Flagging for human judgment on whether these warrant tokenization.

### Audit Cycle Status

This completes the full audit queue (62 components). The queue will rebuild from scratch on the next run.

---
