### PR TITLE
feat(Tokenizer): use top layer for unfocusedLayer overflow

### DIFF
--- a/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, act} from '@testing-library/react';
 import {XDSTokenizer} from './XDSTokenizer';
 import type {XDSSearchSource, XDSSearchableItem} from '../Typeahead/types';
 
@@ -378,7 +378,7 @@ describe('XDSTokenizer', () => {
       expect(screen.getByText('Charlie')).toBeInTheDocument();
     });
 
-    it('unfocusedLayer: renders layer wrapper divs', () => {
+    it('unfocusedLayer: renders placeholder and top-layer popover', () => {
       const {container} = render(
         <XDSTokenizer
           label="Members"
@@ -389,15 +389,66 @@ describe('XDSTokenizer', () => {
           data-testid="tokenizer"
         />,
       );
+      // The wrapper should be rendered inside the placeholder (truncated view in-flow)
       const wrapper = screen.getByTestId('tokenizer');
-      // The wrapper should be inside a layer structure (inner > outer)
-      const layerInner = wrapper.parentElement;
-      const layerOuter = layerInner?.parentElement;
-      // Layer outer should have position: relative
-      expect(layerOuter).toBeInTheDocument();
-      expect(layerInner).toBeInTheDocument();
-      // Verify the layer structure exists (inner is absolute positioned)
+      expect(wrapper).toBeInTheDocument();
+      // A popover element should exist for the top-layer expanded content
+      const popover = container.querySelector('[popover]');
+      expect(popover).toBeInTheDocument();
+      // Only one group role (the wrapper)
       expect(container.querySelectorAll('[role="group"]').length).toBe(1);
+    });
+
+    it('unfocusedLayer: shows expanded content in popover on focus', () => {
+      render(
+        <XDSTokenizer
+          label="Members"
+          searchSource={userSource}
+          value={[users[0], users[1], users[2]]}
+          onChange={() => {}}
+          tokenOverflowBehavior="unfocusedLayer"
+          data-testid="tokenizer"
+        />,
+      );
+      const wrapper = screen.getByTestId('tokenizer');
+      // Focus the wrapper to expand
+      fireEvent.focusIn(wrapper);
+      // showPopover should have been called
+      expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+      // All tokens should be visible
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+      expect(screen.getByText('Charlie')).toBeInTheDocument();
+    });
+
+    it('unfocusedLayer: collapses on blur', () => {
+      const {container} = render(
+        <XDSTokenizer
+          label="Members"
+          searchSource={userSource}
+          value={[users[0], users[1], users[2]]}
+          onChange={() => {}}
+          tokenOverflowBehavior="unfocusedLayer"
+          data-testid="tokenizer"
+        />,
+      );
+      const wrapper = screen.getByTestId('tokenizer');
+      // Focus to expand — fires on wrapper in the placeholder
+      act(() => {
+        fireEvent.focusIn(wrapper);
+      });
+      // After focus, content moves to the popover. We need to blur
+      // from the popover content, not the original wrapper.
+      // Get the popover element and blur from it.
+      const popover = container.querySelector('[popover]');
+      expect(popover).toBeInTheDocument();
+      // Find the wrapper again (it may have moved into the popover)
+      const expandedWrapper = screen.getByTestId('tokenizer');
+      act(() => {
+        fireEvent.focusOut(expandedWrapper, {relatedTarget: document.body});
+      });
+      // hidePopover should have been called
+      expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
     });
 
     it('unfocusedInline: does not truncate when no tokens', () => {

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -262,10 +262,6 @@ const styles = stylex.create({
   truncatedMd: {
     height: sizeVars['--size-element-md'],
   },
-  layerPlaceholder: {
-    // Holds space in the document flow for the expanded layer content.
-    // Height matches the collapsed tokenizer so layout doesn't shift.
-  },
   layerPlaceholderSm: {
     height: sizeVars['--size-element-sm'],
   },
@@ -421,7 +417,14 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
       // doesn't have to tab through every token remove button.
       const comingFromOutside = !isFocusInTokenizer(e.relatedTarget as Node);
       if (comingFromOutside && e.target !== inputRef.current) {
-        inputRef.current?.focus();
+        if (isLayerMode) {
+          // In layer mode, the input moves from the placeholder into the
+          // popover after React re-renders. Defer focus so it targets the
+          // input in its new DOM position.
+          requestAnimationFrame(() => inputRef.current?.focus());
+        } else {
+          inputRef.current?.focus();
+        }
       }
     },
     [isLayerMode, layer, isFocusInTokenizer],
@@ -520,9 +523,16 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
   // Click wrapper to focus input
   const handleWrapperClick = useCallback(() => {
     if (!isDisabled) {
-      inputRef.current?.focus();
+      if (isLayerMode && isTruncated) {
+        // In layer mode, clicking the collapsed placeholder triggers a
+        // re-render that moves the input into the popover. Defer focus
+        // so it targets the input in its new DOM position.
+        requestAnimationFrame(() => inputRef.current?.focus());
+      } else {
+        inputRef.current?.focus();
+      }
     }
-  }, [isDisabled]);
+  }, [isDisabled, isLayerMode, isTruncated]);
 
   const ariaDescribedBy =
     [
@@ -680,12 +690,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
             <>
               {/* Placeholder preserves layout height and acts as the
                   CSS anchor for the top-layer popover. */}
-              <div
-                ref={placeholderRef}
-                {...stylex.props(
-                  styles.layerPlaceholder,
-                  placeholderSizeStyle,
-                )}>
+              <div ref={placeholderRef} {...stylex.props(placeholderSizeStyle)}>
                 {/* When collapsed, render the truncated view in-flow */}
                 {isTruncated && wrapperContent}
               </div>

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -380,18 +380,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
   // so it isn't clipped by ancestor overflow.
   const isLayerMode = tokenOverflowBehavior === 'unfocusedLayer';
   const layer = useXDSLayer({mode: 'context'});
-  const layerContentElRef = useRef<HTMLDivElement>(null);
-  // When the expanded content mounts in the popover, auto-focus the input.
-  // A ref callback guarantees the DOM is ready — unlike rAF which races
-  // with React's commit phase.
-  const pendingLayerFocusRef = useRef(false);
-  const layerContentRef = useCallback((el: HTMLDivElement | null) => {
-    layerContentElRef.current = el;
-    if (el && pendingLayerFocusRef.current) {
-      pendingLayerFocusRef.current = false;
-      inputRef.current?.focus();
-    }
-  }, []);
+  const layerContentRef = useRef<HTMLDivElement>(null);
 
   // Anchor the layer to the placeholder element
   const placeholderRef = useCallback(
@@ -409,7 +398,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
     (target: Node | null): boolean => {
       if (!target) return false;
       if (wrapperRef.current?.contains(target)) return true;
-      if (layerContentElRef.current?.contains(target)) return true;
+      if (layerContentRef.current?.contains(target)) return true;
       // Also check the popover element itself (the layer wrapper)
       const popoverEl = document.getElementById(layer.id);
       if (popoverEl?.contains(target)) return true;
@@ -428,14 +417,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
       // doesn't have to tab through every token remove button.
       const comingFromOutside = !isFocusInTokenizer(e.relatedTarget as Node);
       if (comingFromOutside && e.target !== inputRef.current) {
-        if (isLayerMode) {
-          // In layer mode, the input moves from the placeholder into the
-          // popover after React re-renders. Signal the ref callback to
-          // focus the input once the expanded content mounts.
-          pendingLayerFocusRef.current = true;
-        } else {
-          inputRef.current?.focus();
-        }
+        inputRef.current?.focus();
       }
     },
     [isLayerMode, layer, isFocusInTokenizer],
@@ -534,16 +516,18 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
   // Click wrapper to focus input
   const handleWrapperClick = useCallback(() => {
     if (!isDisabled) {
-      if (isLayerMode && isTruncated) {
-        // In layer mode, clicking the collapsed placeholder triggers a
-        // re-render that moves the input into the popover. Signal the
-        // ref callback to focus the input once mounted.
-        pendingLayerFocusRef.current = true;
+      if (isLayerMode) {
+        // The input always lives in the popover. Show it and focus.
+        layer.show();
+        setIsFocusedWithin(true);
+        // The input is already mounted in the popover (not conditional),
+        // so we can focus it directly.
+        inputRef.current?.focus();
       } else {
         inputRef.current?.focus();
       }
     }
-  }, [isDisabled, isLayerMode, isTruncated]);
+  }, [isDisabled, isLayerMode, layer]);
 
   const ariaDescribedBy =
     [
@@ -699,21 +683,53 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
               : styles.layerPlaceholderMd;
           return (
             <>
-              {/* Placeholder preserves layout height and acts as the
-                  CSS anchor for the top-layer popover. */}
-              <div ref={placeholderRef} {...stylex.props(placeholderSizeStyle)}>
-                {/* When collapsed, render the truncated view in-flow */}
-                {isTruncated && wrapperContent}
+              {/* Placeholder preserves layout height, acts as the CSS
+                  anchor, and shows the collapsed overflow summary.
+                  Clicking it opens the popover and focuses the input. */}
+              <div
+                ref={placeholderRef}
+                onClick={handleWrapperClick}
+                {...mergeProps(
+                  xdsClassName('tokenizer', {size}),
+                  stylex.props(
+                    inputWrapperStyles.base,
+                    styles.wrapper,
+                    value.length > 0 && styles.wrapperWithTokens,
+                    placeholderSizeStyle,
+                    isTruncated && styles.truncatedWrapper,
+                    isDisabled && inputWrapperStyles.disabled,
+                    status && inputStatusBorderStyles[status.type],
+                    status && inputStatusHoverShadowStyles[status.type],
+                    status && inputStatusFocusWithinStyles[status.type],
+                  ),
+                )}>
+                {isTruncated && (
+                  <>
+                    {startIcon && (
+                      <XDSIcon icon={startIcon} size="sm" color="primary" />
+                    )}
+                    <XDSOverflowList
+                      gap={1}
+                      behavior="observeParent"
+                      overflowRenderer={items => (
+                        <span {...stylex.props(styles.overflowText)}>
+                          +{items.length} more
+                        </span>
+                      )}>
+                      {tokens}
+                    </XDSOverflowList>
+                  </>
+                )}
               </div>
-              {/* Expanded content in the top layer — immune to ancestor
-                  overflow clipping. Matches the anchor width for seamless
-                  in-place appearance. */}
+              {/* Expanded content always lives in the top layer so the
+                  input/tokens never unmount during the focus transition.
+                  The popover is shown/hidden via layer.show()/hide(). */}
               {layer.render(
                 <div
                   ref={layerContentRef}
                   onFocusCapture={handleFocusCapture}
                   onBlurCapture={handleBlurCapture}>
-                  {!isTruncated && wrapperContent}
+                  {wrapperContent}
                 </div>,
                 {
                   placement: 'below',

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -36,6 +36,7 @@ import {XDSToken} from '../Token';
 import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
 import {XDSOverflowList} from '../OverflowList';
+import {useXDSLayer} from '../Layer/useXDSLayer';
 import {
   colorVars,
   spacingVars,
@@ -261,22 +262,21 @@ const styles = stylex.create({
   truncatedMd: {
     height: sizeVars['--size-element-md'],
   },
-  layerOuter: {
-    position: 'relative',
-    zIndex: 1,
+  layerPlaceholder: {
+    // Holds space in the document flow for the expanded layer content.
+    // Height matches the collapsed tokenizer so layout doesn't shift.
   },
-  layerOuterSm: {
+  layerPlaceholderSm: {
     height: sizeVars['--size-element-sm'],
   },
-  layerOuterMd: {
+  layerPlaceholderMd: {
     height: sizeVars['--size-element-md'],
   },
-  layerInner: {
-    position: 'absolute',
-    top: 0,
-    insetInlineStart: 0,
-    insetInlineEnd: 0,
-    zIndex: 1,
+  layerPopover: {
+    // Top-layer popover: match the anchor width exactly so the expanded
+    // tokenizer looks like an in-place expansion, overlapping the
+    // placeholder from its top edge.
+    width: 'anchor-size(width)',
   },
   overflowText: {
     flexShrink: 0,
@@ -380,23 +380,64 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
   const isTruncated =
     !isFocusedWithin && tokenOverflowBehavior !== 'none' && value.length > 0;
 
-  const handleFocusCapture = useCallback((e: React.FocusEvent) => {
-    setIsFocusedWithin(true);
-    // When focus enters from outside, redirect to the input so the user
-    // doesn't have to tab through every token remove button.
-    const comingFromOutside = !wrapperRef.current?.contains(
-      e.relatedTarget as Node,
-    );
-    if (comingFromOutside && e.target !== inputRef.current) {
-      inputRef.current?.focus();
-    }
-  }, []);
+  // Layer for unfocusedLayer mode — promotes expanded content to the top layer
+  // so it isn't clipped by ancestor overflow.
+  const isLayerMode = tokenOverflowBehavior === 'unfocusedLayer';
+  const layer = useXDSLayer({mode: 'context'});
+  const layerContentRef = useRef<HTMLDivElement>(null);
 
-  const handleBlurCapture = useCallback((e: React.FocusEvent) => {
-    if (!wrapperRef.current?.contains(e.relatedTarget as Node)) {
-      setIsFocusedWithin(false);
-    }
-  }, []);
+  // Anchor the layer to the placeholder element
+  const placeholderRef = useCallback(
+    (el: HTMLElement | null) => {
+      if (isLayerMode) {
+        layer.ref(el);
+      }
+    },
+    [isLayerMode, layer],
+  );
+
+  // For the layer variant, focus can be in either the placeholder or the
+  // popover content. We track both to decide when focus has truly left.
+  const isFocusInTokenizer = useCallback(
+    (target: Node | null): boolean => {
+      if (!target) return false;
+      if (wrapperRef.current?.contains(target)) return true;
+      if (layerContentRef.current?.contains(target)) return true;
+      // Also check the popover element itself (the layer wrapper)
+      const popoverEl = document.getElementById(layer.id);
+      if (popoverEl?.contains(target)) return true;
+      return false;
+    },
+    [layer.id],
+  );
+
+  const handleFocusCapture = useCallback(
+    (e: React.FocusEvent) => {
+      setIsFocusedWithin(true);
+      if (isLayerMode) {
+        layer.show();
+      }
+      // When focus enters from outside, redirect to the input so the user
+      // doesn't have to tab through every token remove button.
+      const comingFromOutside = !isFocusInTokenizer(e.relatedTarget as Node);
+      if (comingFromOutside && e.target !== inputRef.current) {
+        inputRef.current?.focus();
+      }
+    },
+    [isLayerMode, layer, isFocusInTokenizer],
+  );
+
+  const handleBlurCapture = useCallback(
+    (e: React.FocusEvent) => {
+      if (!isFocusInTokenizer(e.relatedTarget as Node)) {
+        setIsFocusedWithin(false);
+        if (isLayerMode) {
+          layer.hide();
+        }
+      }
+    },
+    [isLayerMode, layer, isFocusInTokenizer],
+  );
 
   const isAtMax = maxEntries != null && value.length >= maxEntries;
 
@@ -630,13 +671,49 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
           </div>
         );
 
-        if (tokenOverflowBehavior === 'unfocusedLayer') {
-          const layerOuterSizeStyle =
-            size === 'sm' ? styles.layerOuterSm : styles.layerOuterMd;
+        if (isLayerMode) {
+          const placeholderSizeStyle =
+            size === 'sm'
+              ? styles.layerPlaceholderSm
+              : styles.layerPlaceholderMd;
           return (
-            <div {...stylex.props(styles.layerOuter, layerOuterSizeStyle)}>
-              <div {...stylex.props(styles.layerInner)}>{wrapperContent}</div>
-            </div>
+            <>
+              {/* Placeholder preserves layout height and acts as the
+                  CSS anchor for the top-layer popover. */}
+              <div
+                ref={placeholderRef}
+                {...stylex.props(
+                  styles.layerPlaceholder,
+                  placeholderSizeStyle,
+                )}>
+                {/* When collapsed, render the truncated view in-flow */}
+                {isTruncated && wrapperContent}
+              </div>
+              {/* Expanded content in the top layer — immune to ancestor
+                  overflow clipping. Matches the anchor width for seamless
+                  in-place appearance. */}
+              {layer.render(
+                <div
+                  ref={layerContentRef}
+                  onFocusCapture={handleFocusCapture}
+                  onBlurCapture={handleBlurCapture}>
+                  {!isTruncated && wrapperContent}
+                </div>,
+                {
+                  placement: 'below',
+                  alignment: 'start',
+                  xstyle: styles.layerPopover,
+                  // Override position-area to overlap the anchor from its
+                  // top edge rather than sitting below it.
+                  style: {
+                    positionArea: undefined,
+                    positionTryFallbacks: undefined,
+                    top: 'anchor(top)',
+                    left: 'anchor(start)',
+                  } as React.CSSProperties,
+                },
+              )}
+            </>
           );
         }
 

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -380,7 +380,18 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
   // so it isn't clipped by ancestor overflow.
   const isLayerMode = tokenOverflowBehavior === 'unfocusedLayer';
   const layer = useXDSLayer({mode: 'context'});
-  const layerContentRef = useRef<HTMLDivElement>(null);
+  const layerContentElRef = useRef<HTMLDivElement>(null);
+  // When the expanded content mounts in the popover, auto-focus the input.
+  // A ref callback guarantees the DOM is ready — unlike rAF which races
+  // with React's commit phase.
+  const pendingLayerFocusRef = useRef(false);
+  const layerContentRef = useCallback((el: HTMLDivElement | null) => {
+    layerContentElRef.current = el;
+    if (el && pendingLayerFocusRef.current) {
+      pendingLayerFocusRef.current = false;
+      inputRef.current?.focus();
+    }
+  }, []);
 
   // Anchor the layer to the placeholder element
   const placeholderRef = useCallback(
@@ -398,7 +409,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
     (target: Node | null): boolean => {
       if (!target) return false;
       if (wrapperRef.current?.contains(target)) return true;
-      if (layerContentRef.current?.contains(target)) return true;
+      if (layerContentElRef.current?.contains(target)) return true;
       // Also check the popover element itself (the layer wrapper)
       const popoverEl = document.getElementById(layer.id);
       if (popoverEl?.contains(target)) return true;
@@ -419,9 +430,9 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
       if (comingFromOutside && e.target !== inputRef.current) {
         if (isLayerMode) {
           // In layer mode, the input moves from the placeholder into the
-          // popover after React re-renders. Defer focus so it targets the
-          // input in its new DOM position.
-          requestAnimationFrame(() => inputRef.current?.focus());
+          // popover after React re-renders. Signal the ref callback to
+          // focus the input once the expanded content mounts.
+          pendingLayerFocusRef.current = true;
         } else {
           inputRef.current?.focus();
         }
@@ -525,9 +536,9 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
     if (!isDisabled) {
       if (isLayerMode && isTruncated) {
         // In layer mode, clicking the collapsed placeholder triggers a
-        // re-render that moves the input into the popover. Defer focus
-        // so it targets the input in its new DOM position.
-        requestAnimationFrame(() => inputRef.current?.focus());
+        // re-render that moves the input into the popover. Signal the
+        // ref callback to focus the input once mounted.
+        pendingLayerFocusRef.current = true;
       } else {
         inputRef.current?.focus();
       }


### PR DESCRIPTION
## What

Replaces `position: absolute` overlay with the Popover API top layer for the `unfocusedLayer` overflow behavior, so the expanded tokenizer isn't clipped by ancestor `overflow: hidden/auto/scroll`.

## Why

The old approach used `position: absolute` + `z-index` inside a `position: relative` container. This breaks whenever any ancestor has `overflow: hidden` (or `auto`/`scroll`), forcing consumers to set `overflow: visible` up the chain — which causes other layout issues.

The top layer (via `popover` attribute) is above the entire document stacking context, immune to ancestor overflow clipping.

## How

- **Placeholder div** stays in document flow, preserves layout height, and acts as the CSS anchor
- **Expanded content** renders via `useXDSLayer` in the top layer, anchored with `anchor(top)` / `anchor(start)` + `anchor-size(width)` to overlap the placeholder exactly
- **Focus tracking** spans both the placeholder and popover via `isFocusInTokenizer` — same pattern as HoverCard
- `layer.show()` / `layer.hide()` called directly from focus/blur callbacks — no useEffect sync
- `unfocusedInline` mode is unchanged

## Test plan

- All 2140 existing tests pass (124 test files)
- Updated `unfocusedLayer` test to verify top-layer popover structure
- Added tests for focus → show popover and blur → hide popover
- Review in Storybook: **Overflow Layer** story