### PR TITLE
XDSText: fix weight prop not being applied

### DIFF
--- a/packages/core/src/Text/XDSText.tsx
+++ b/packages/core/src/Text/XDSText.tsx
@@ -13,7 +13,6 @@
  * - /apps/storybook/stories/Text.stories.tsx (storybook stories)
  */
 
-
 import {lazy, Suspense, useCallback, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -28,6 +27,7 @@ import type {
 } from '../theme/types';
 import {
   colorStyles,
+  defaultWeightByTypeStyles,
   weightStyles,
   displayStyles,
   truncationStyles,
@@ -267,6 +267,7 @@ export function XDSText({
           xdsClassName('text', {type, color: resolvedColor}),
           stylex.props(
             colorStyles[resolvedColor],
+            defaultWeightByTypeStyles[type],
             weight && weightStyles[weight],
             // Display: use truncation styles when maxLines > 0
             maxLines === 1

--- a/packages/core/src/Text/text.stylex.ts
+++ b/packages/core/src/Text/text.stylex.ts
@@ -9,7 +9,7 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, fontWeightVars} from '../theme/tokens.stylex';
+import {colorVars, fontWeightVars, typeScaleVars} from '../theme/tokens.stylex';
 
 // =============================================================================
 // Color Styles
@@ -52,6 +52,37 @@ export const weightStyles = stylex.create({
   },
   bold: {
     fontWeight: fontWeightVars['--font-weight-bold'],
+  },
+});
+
+// =============================================================================
+// Default Weight by Type (matches theme type-scale tokens)
+// =============================================================================
+
+export const defaultWeightByTypeStyles = stylex.create({
+  body: {
+    fontWeight: typeScaleVars['--text-body-weight'],
+  },
+  large: {
+    fontWeight: typeScaleVars['--text-large-weight'],
+  },
+  label: {
+    fontWeight: typeScaleVars['--text-label-weight'],
+  },
+  code: {
+    fontWeight: typeScaleVars['--text-code-weight'],
+  },
+  supporting: {
+    fontWeight: typeScaleVars['--text-supporting-weight'],
+  },
+  'display-1': {
+    fontWeight: typeScaleVars['--text-display-1-weight'],
+  },
+  'display-2': {
+    fontWeight: typeScaleVars['--text-display-2-weight'],
+  },
+  'display-3': {
+    fontWeight: typeScaleVars['--text-display-3-weight'],
   },
 });
 

--- a/packages/core/src/theme/expandTypeScale.ts
+++ b/packages/core/src/theme/expandTypeScale.ts
@@ -395,7 +395,6 @@ export function generateTypeScaleComponents(
     textRules[`type:${type}`] = {
       fontFamily: TEXT_FONT_FAMILIES[type],
       fontSize: `var(--text-${type}-size)`,
-      fontWeight: `var(--text-${type}-weight)`,
       lineHeight: `var(--text-${type}-leading)`,
     };
   }


### PR DESCRIPTION
you can see currently it's not applied:
<img width="272" height="211" alt="image" src="https://github.com/user-attachments/assets/09ac071c-d3b3-4596-83ba-8f9b9e8d210b" />

after this change we have the weights applied:
<img width="219" height="205" alt="image" src="https://github.com/user-attachments/assets/08588b54-b445-461d-833b-d3a80dc0fdb2" />

The issue is that we have a generated two-class selector: `.xds-text.body { font-weight: var(--text-body-weight) }` which overrides the stylex weight selected here. So in this PR we remove that and instead apply the weight via stylex directly. I'm not 100% sure this is the best way to do it though so LMK if you have other ideas.

