### PR TITLE
XDSSpinner: add 36px "xl" size option

### DIFF
--- a/apps/storybook/stories/Spinner.stories.tsx
+++ b/apps/storybook/stories/Spinner.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof XDSSpinner> = {
   argTypes: {
     size: {
       control: 'select',
-      options: ['sm', 'md', 'lg'],
+      options: ['sm', 'md', 'lg', 'xl'],
       description: 'Spinner size',
     },
     shade: {
@@ -37,6 +37,7 @@ export const Sizes: Story = {
       <XDSSpinner size="sm" />
       <XDSSpinner size="md" />
       <XDSSpinner size="lg" />
+      <XDSSpinner size="xl" />
     </XDSHStack>
   ),
 };

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -32,6 +32,7 @@ const SIZES = {
   sm: {diameter: 10, border: 3},
   md: {diameter: 14, border: 3},
   lg: {diameter: 18, border: 3},
+  xl: {diameter: 28, border: 4},
 };
 
 // =============================================================================
@@ -79,6 +80,7 @@ export interface XDSSpinnerProps {
    * - 'sm': 10px diameter
    * - 'md': 14px diameter
    * - 'lg': 18px diameter
+   * - 'xl': 36px diameter
    * @default 'md'
    */
   size?: XDSSpinnerSize;


### PR DESCRIPTION
This is a larger size that works better for full-page placeholders. Ruby suggested 36px would be fine