### PR TITLE
[easy] fix app shell when mobileNav is passed in as a direct react node

### DIFF
--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -493,7 +493,10 @@ export function XDSAppShell({
   const hasTopNav = topNav != null;
   const hasSideNav = sideNav != null;
   const hasNavContent = hasSideNav || hasTopNav;
-  const mobileNavEnabled = !mobileNavDisabled && hasNavContent;
+  // Mobile nav auto-management is enabled when not disabled, there's nav content,
+  // AND the user hasn't provided a ReactNode (full escape hatch = user owns everything)
+  const mobileNavEnabled =
+    !mobileNavDisabled && hasNavContent && mobileNavReactNode == null;
   const navHasDividers = variant === 'section';
   const isElevated = variant === 'elevated';
   const navAreaStyle =


### PR DESCRIPTION
The "With Mobile Nav" example wasn't working (hamburger menu didn't actually do anything). This is because the auto mobile nav management shouldn't have been enabled when explicitly passing in XDSMobileNav