### PR TITLE
XDSPopover: use XDSButton + support closeButtonLabel

### DIFF
--- a/packages/core/src/Popover/Popover.doc.mjs
+++ b/packages/core/src/Popover/Popover.doc.mjs
@@ -150,6 +150,18 @@ export const docs = {
           description: 'Accessible label for the popover dialog.',
         },
         {
+          name: 'hasCloseButton',
+          type: 'boolean',
+          description: 'Whether to include a hidden close button for accessibility.',
+          default: 'true',
+        },
+        {
+          name: 'closeButtonLabel',
+          type: 'string',
+          description: 'Label for the hidden close button.',
+          default: "'Close popover'",
+        },
+        {
           name: 'xstyle',
           type: 'StyleXStyles',
           description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value — not an inline style object like style={{}}.',
@@ -201,6 +213,12 @@ export const docs = {
           type: 'boolean',
           description: 'Whether to include a hidden close button for accessibility.',
           default: 'true',
+        },
+        {
+          name: 'closeButtonLabel',
+          type: 'string',
+          description: 'Label for the hidden close button.',
+          default: "'Close popover'",
         },
         {
           name: 'dialogLabel',
@@ -370,6 +388,18 @@ export const docsZh = {
           type: 'string',
           description: '弹出框对话框的无障碍标签。',
         },
+        {
+          name: 'hasCloseButton',
+          type: 'boolean',
+          description: '是否包含用于无障碍访问的隐藏关闭按钮。',
+          default: 'true',
+        },
+        {
+          name: 'closeButtonLabel',
+          type: 'string',
+          description: '隐藏关闭按钮的标签。',
+          default: "'Close popover'",
+        },
       ],
     },
     {
@@ -417,6 +447,12 @@ export const docsZh = {
           type: 'boolean',
           description: '是否包含用于无障碍访问的隐藏关闭按钮。',
           default: 'true',
+        },
+        {
+          name: 'closeButtonLabel',
+          type: 'string',
+          description: '隐藏关闭按钮的标签。',
+          default: "'Close popover'",
         },
         {
           name: 'dialogLabel',
@@ -479,6 +515,8 @@ export const docsDense = {
         isEnabled: 'When false, trigger interactions ignored.',
         width: 'Popover container width.',
         label: 'Accessible label for popover dialog.',
+        hasCloseButton: 'Whether to include hidden close button for accessibility.',
+        closeButtonLabel: 'Label for hidden close button.',
       },
     },
     {
@@ -491,6 +529,7 @@ export const docsDense = {
         hasLightDismiss: 'Whether clicking outside dismisses popover.',
         hasAutoFocus: 'Whether to auto-focus first focusable element when opened.',
         hasCloseButton: 'Whether to include hidden close button for accessibility.',
+        closeButtonLabel: 'Label for hidden close button.',
         dialogLabel: 'Accessible label for dialog.',
       },
     },

--- a/packages/core/src/Popover/XDSPopover.tsx
+++ b/packages/core/src/Popover/XDSPopover.tsx
@@ -144,6 +144,19 @@ export interface XDSPopoverProps {
   style?: React.CSSProperties;
 
   /**
+   * Whether to include a hidden close button for accessibility.
+   * The button appears when keyboard users tab past the last element.
+   * @default true
+   */
+  hasCloseButton?: boolean;
+
+  /**
+   * Label for the hidden close button.
+   * @default "Close popover"
+   */
+  closeButtonLabel?: string;
+
+  /**
    * Test ID for the popover container.
    */
   'data-testid'?: string;
@@ -252,6 +265,8 @@ export function XDSPopover({
   isEnabled = true,
   width,
   label,
+  hasCloseButton,
+  closeButtonLabel,
   xstyle,
   className,
   style,
@@ -275,6 +290,8 @@ export function XDSPopover({
   const popover = useXDSPopover({
     dialogLabel: label,
     hasLightDismiss: true,
+    hasCloseButton,
+    closeButtonLabel,
     onShow: handlePopoverShow,
     onHide: handlePopoverHide,
   });

--- a/packages/core/src/Popover/useXDSPopover.tsx
+++ b/packages/core/src/Popover/useXDSPopover.tsx
@@ -13,13 +13,7 @@
  * - /packages/core/src/Popover/index.ts
  */
 
-import React, {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type ReactNode,
-} from 'react';
+import React, {useCallback, useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   useXDSLayer,
@@ -34,8 +28,8 @@ import {
   spacingVars,
   radiusVars,
   shadowVars,
-  typeScaleVars,
 } from '../theme/tokens.stylex';
+import {XDSButton} from '../Button';
 
 const styles = stylex.create({
   // Default popover surface — background, radius, shadow.
@@ -50,44 +44,38 @@ const styles = stylex.create({
   contentWrapper: {
     position: 'relative',
   },
-  // Hidden close button - visually hidden until focused
-  closeButton: {
-    position: 'absolute',
-    width: 1,
-    height: 1,
-    padding: 0,
-    margin: -1,
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
-    pointerEvents: 'none', // Prevent mouse clicks when hidden
-  },
-  // Revealed state when focused - positioned bottom center, outside popover
-  closeButtonFocused: {
+  // Hidden close button wrapper - sr-only until focused, then positioned below popover
+  closeButtonWrapper: {
     position: 'absolute',
     bottom: 0,
     left: '50%',
     transform: 'translate(-50%, 100%)',
-    width: 'auto',
-    height: 'auto',
-    padding: spacingVars['--spacing-2'],
-    margin: 0,
-    overflow: 'visible',
-    clip: 'auto',
-    whiteSpace: 'nowrap',
-    // Inverted color palette (like tooltip): dark background, light text
-    backgroundColor: colorVars['--color-text-primary'],
-    color: colorVars['--color-background-surface'],
-    fontSize: typeScaleVars['--text-supporting-size'],
-    borderRadius: radiusVars['--radius-element'],
-    cursor: 'pointer',
-    borderWidth: 0,
-    borderStyle: 'none',
-    outline: `2px solid ${colorVars['--color-accent']}`,
-    outlineOffset: 2,
     zIndex: 1,
-    pointerEvents: 'auto', // Re-enable mouse clicks when visible
+    // sr-only by default
+    width: {
+      default: 1,
+      ':focus-within': 'auto',
+    },
+    height: {
+      default: 1,
+      ':focus-within': 'auto',
+    },
+    overflow: {
+      default: 'hidden',
+      ':focus-within': 'visible',
+    },
+    clipPath: {
+      default: 'inset(50%)',
+      ':focus-within': 'none',
+    },
+    pointerEvents: {
+      default: 'none',
+      ':focus-within': 'auto',
+    },
+    paddingBlockStart: {
+      default: 0,
+      ':focus-within': spacingVars['--spacing-1'],
+    },
   },
 });
 
@@ -133,14 +121,12 @@ export interface UseXDSPopoverOptions {
   /**
    * Whether to include a hidden close button for accessibility.
    * The button appears when keyboard users tab past the last element.
-   * Set to false for menus or selectors with different focus behavior.
    * @default true
    */
   hasCloseButton?: boolean;
 
   /**
    * Label for the hidden close button.
-   * Only used when hasCloseButton is true.
    * @default "Close popover"
    */
   closeButtonLabel?: string;
@@ -287,14 +273,11 @@ export function useXDSPopover(
     xstyle,
     hasLightDismiss = true,
     hasAutoFocus = true,
-    hasCloseButton = true,
     hasSurface = true,
+    hasCloseButton = true,
     closeButtonLabel = 'Close popover',
     dialogLabel,
   } = options;
-
-  // Track whether close button is focused (to show tooltip)
-  const [isCloseButtonFocused, setIsCloseButtonFocused] = useState(false);
 
   // Track the trigger element for returning focus
   const triggerElementRef = useRef<HTMLElement | null>(null);
@@ -329,13 +312,6 @@ export function useXDSPopover(
       skipAutoFocusRef.current = false;
     }
   }, [layer.isOpen, hasAutoFocus, focusFirst]);
-
-  // Reset close button focus state when popover closes
-  useEffect(() => {
-    if (!layer.isOpen) {
-      setIsCloseButtonFocused(false);
-    }
-  }, [layer.isOpen]);
 
   // Combined ref for trigger element (layer anchor + our ref)
   const triggerRef = useCallback(
@@ -387,18 +363,13 @@ export function useXDSPopover(
           )}>
           {children}
           {hasCloseButton && (
-            <button
-              type="button"
-              onClick={layer.hide}
-              onFocus={() => setIsCloseButtonFocused(true)}
-              onBlur={() => setIsCloseButtonFocused(false)}
-              aria-label={closeButtonLabel}
-              {...stylex.props(
-                styles.closeButton,
-                isCloseButtonFocused && styles.closeButtonFocused,
-              )}>
-              {closeButtonLabel}
-            </button>
+            <div {...stylex.props(styles.closeButtonWrapper)}>
+              <XDSButton
+                variant="secondary"
+                label={closeButtonLabel}
+                onClick={layer.hide}
+              />
+            </div>
           )}
         </div>,
         {...props, xstyle: props?.xstyle},
@@ -409,7 +380,6 @@ export function useXDSPopover(
       hasCloseButton,
       hasSurface,
       closeButtonLabel,
-      isCloseButtonFocused,
       contentRef,
       dialogLabel,
       xstyle,


### PR DESCRIPTION
1. Use XDSButton in `useXDSPopover` for the close button. It was showing an unstyled button so it didn't match the theme.
2. I added `closeButtonLabel` to `<XDSPopover>`, not just the hook. As part of this I removed `hasCloseButton` -- this is now indicated just by setting `closeButtonLabel={null}`, which I think is nicer rather than having two props where one depends on the other. I added a codemod to migrate code to the new version (not sure if that's necessary?)