### PR TITLE
Fix field labels showing as disabled when inside XDSLayout with a date input

### DIFF
--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -2,6 +2,7 @@ import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {XDSDateInput} from '@xds/core/DateInput';
 import type {ISODateString} from '@xds/core/Calendar';
+import {XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 
 const meta: Meta<typeof XDSDateInput> = {
   title: 'Form/XDSDateInput',
@@ -162,6 +163,29 @@ export const WithMinMax: Story = {
     max: '2026-02-15' as ISODateString,
     description: 'Available dates: Jan 15 - Feb 15, 2026',
     placeholder: 'Select a booking date',
+  },
+};
+
+export const WithMaxDateInLayout: Story = {
+  render: args => {
+    const [value, setValue] = useState<ISODateString | undefined>(undefined);
+    return (
+      <XDSLayout
+        height="auto"
+        content={
+          <XDSLayoutContent>
+            <XDSDateInput {...args} value={value} onChange={setValue} />
+          </XDSLayoutContent>
+        }
+      />
+    );
+  },
+  args: {
+    label: 'End date',
+    max: new Date().toISOString().slice(0, 10) as ISODateString,
+    description:
+      'Max is today — open the calendar to verify the label does not turn grey when nav buttons are disabled',
+    placeholder: 'Select an end date',
   },
 };
 

--- a/packages/core/src/DateInput/XDSDateInput.tsx
+++ b/packages/core/src/DateInput/XDSDateInput.tsx
@@ -464,6 +464,7 @@ export function XDSDateInput({
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {

--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -122,6 +122,11 @@ export interface XDSFieldProps extends Omit<
    */
   isRequired?: boolean;
   /**
+   * Whether the associated input is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
    * Icon to display before the label text.
    */
   labelIcon?: XDSIconType;
@@ -188,6 +193,7 @@ export function XDSField({
   descriptionID,
   isOptional = false,
   isRequired = false,
+  isDisabled = false,
   labelIcon,
   status,
   labelTooltip,
@@ -225,6 +231,7 @@ export function XDSField({
           label={label}
           inputID={inputID}
           isLabelHidden={isLabelHidden}
+          isDisabled={isDisabled}
           isOptional={isOptional}
           isRequired={isRequired}
           labelIcon={labelIcon}

--- a/packages/core/src/Field/XDSFieldLabel.tsx
+++ b/packages/core/src/Field/XDSFieldLabel.tsx
@@ -30,15 +30,8 @@ const styles = stylex.create({
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-label-size'],
     fontWeight: fontWeightVars['--font-weight-medium'],
-    color: {
-      default: colorVars['--color-text-primary'],
-      [stylex.when.ancestor(':has(:disabled)')]:
-        colorVars['--color-text-disabled'],
-    },
-    cursor: {
-      default: 'pointer',
-      [stylex.when.ancestor(':has(:disabled)')]: 'not-allowed',
-    },
+    color: colorVars['--color-text-primary'],
+    cursor: 'pointer',
   },
   labelDisabled: {
     color: colorVars['--color-text-disabled'],

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -444,6 +444,7 @@ export function XDSNumberInput({
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       labelIcon={labelIcon}
       status={
         status

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -201,6 +201,7 @@ export function XDSRadioList({
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -577,6 +577,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
       descriptionID={description ? descriptionId : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {

--- a/packages/core/src/Slider/XDSSlider.tsx
+++ b/packages/core/src/Slider/XDSSlider.tsx
@@ -708,6 +708,7 @@ export function XDSSlider({ref, ...props}: XDSSliderProps) {
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {

--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -339,6 +339,7 @@ export function XDSTextArea({
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -261,6 +261,7 @@ export function XDSTextInput({
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -486,6 +486,7 @@ export function XDSTimeInput({
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {

--- a/packages/core/src/Tokenizer/XDSTokenizer.tsx
+++ b/packages/core/src/Tokenizer/XDSTokenizer.tsx
@@ -526,6 +526,7 @@ export function XDSTokenizer<T extends XDSSearchableItem>({
       descriptionID={description ? descriptionId : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {

--- a/packages/core/src/Typeahead/XDSTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSTypeahead.tsx
@@ -358,6 +358,7 @@ export function XDSTypeahead<T extends XDSSearchableItem>({
       descriptionID={description ? descriptionId : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
+      isDisabled={isDisabled}
       status={
         status
           ? {


### PR DESCRIPTION
**Root cause:** XDSFieldLabel used stylex.when.ancestor(':has(:disabled)') to auto-detect disabled state. This generates a CSS rule that matches when any ancestor with the defaultMarker class contains any disabled descendant — including disabled calendar navigation buttons inside popovers. Notable this affects XDSDateInput, but probably other stuff as well.

**Fix:** Removed the stylex.when.ancestor(':has(:disabled)') CSS rule from XDSFieldLabel and instead explicitly pass isDisabled as a prop through XDSField → XDSFieldLabel. This is more predictable and avoids false positives from unrelated disabled elements. A field label should only be disabled if its associated input is disabled.

I added a storybook example that shows this issue, none of the previous ones we had reproduced it.