### PR TITLE
XDSDropdownMenu: make props consistent with XDSButton

### DIFF
--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -311,6 +311,7 @@ export const IconOnly: Story = {
           label: 'More options',
           icon: <EllipsisHorizontalIcon />,
           variant: 'ghost',
+          isLabelHidden: true,
         }}
         items={[
           {label: 'Edit', icon: PencilIcon, onClick: () => console.log('Edit')},
@@ -326,6 +327,7 @@ export const IconOnly: Story = {
           label: 'Settings',
           icon: <Cog6ToothIcon />,
           variant: 'secondary',
+          isLabelHidden: true,
         }}
         items={[
           {label: 'Preferences', onClick: () => console.log('Preferences')},
@@ -336,7 +338,7 @@ export const IconOnly: Story = {
   ),
 };
 
-// Icon + label together — pass children on button to get visible text with icon
+// Icon + label together — label is visible text alongside icon
 export const IconWithLabel: Story = {
   render: () => (
     <XDSDropdownMenu
@@ -344,7 +346,6 @@ export const IconWithLabel: Story = {
         label: 'Settings',
         icon: <Cog6ToothIcon />,
         variant: 'ghost',
-        children: 'Settings',
       }}
       items={[
         {label: 'Preferences', onClick: () => console.log('Preferences')},

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.test.tsx
@@ -352,13 +352,31 @@ describe('XDSDropdownMenu custom render', () => {
 });
 
 describe('XDSDropdownMenu icon-only mode', () => {
-  it('renders icon-only button when icon is set without children', () => {
+  it('renders icon + visible label by default when icon and label are set', () => {
+    render(
+      <XDSDropdownMenu
+        button={{
+          label: 'Settings',
+          icon: <span data-testid="icon">⚙️</span>,
+          variant: 'ghost',
+        }}
+        items={[{label: 'Preferences'}]}
+      />,
+    );
+    const button = screen.getByRole('button', {name: /Settings/});
+    // label should be visible text, not just aria-label
+    expect(button).not.toHaveAttribute('aria-label');
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('renders icon-only button when isLabelHidden is true', () => {
     render(
       <XDSDropdownMenu
         button={{
           label: 'More options',
           icon: <span data-testid="icon">⋯</span>,
           variant: 'ghost',
+          isLabelHidden: true,
         }}
         items={[{label: 'Edit'}, {label: 'Delete'}]}
       />,
@@ -366,23 +384,6 @@ describe('XDSDropdownMenu icon-only mode', () => {
     const button = screen.getByRole('button', {name: 'More options'});
     // label should be aria-label, not visible text
     expect(button).toHaveAttribute('aria-label', 'More options');
-    expect(screen.getByTestId('icon')).toBeInTheDocument();
-  });
-
-  it('renders icon + label when children are provided on button', () => {
-    render(
-      <XDSDropdownMenu
-        button={{
-          label: 'Settings',
-          icon: <span data-testid="icon">⚙️</span>,
-          variant: 'ghost',
-          children: 'Settings',
-        }}
-        items={[{label: 'Preferences'}]}
-      />,
-    );
-    const button = screen.getByRole('button', {name: /Settings/});
-    expect(button).not.toHaveAttribute('aria-label');
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -242,10 +242,18 @@ function getSelectableItems(
  * Props for customizing the dropdown button.
  * Extends XDSButtonProps but omits onClick since it's managed internally.
  *
- * When `icon` is set without `children`, renders as an icon-only button
- * (square, with `label` as aria-label). Pass `children` to get icon + visible text.
+ * When `icon` is set, `label` remains visible text (unlike XDSButton where
+ * `icon` without `children` renders icon-only). To hide the label and get
+ * a true icon-only trigger, set `isLabelHidden: true`.
  */
-export type XDSDropdownMenuButtonProps = Omit<XDSButtonProps, 'onClick'>;
+export type XDSDropdownMenuButtonProps = Omit<XDSButtonProps, 'onClick'> & {
+  /**
+   * When true, hides the label text and renders as icon-only.
+   * The `label` is still used as the accessible name (aria-label).
+   * @default false
+   */
+  isLabelHidden?: boolean;
+};
 
 export interface XDSDropdownMenuProps {
   /**
@@ -287,7 +295,7 @@ export interface XDSDropdownMenuProps {
   /**
    * Whether to show a chevron indicator on the trigger button.
    * Automatically hidden for icon-only buttons (when `button.icon` is set
-   * without `button.endContent`).
+   * without `button.label`).
    * @default true
    */
   hasChevron?: boolean;
@@ -597,9 +605,11 @@ export function XDSDropdownMenu({
     return elements;
   }, [items, renderItem]);
 
-  // Icon-only: when button has an icon and no children,
-  // XDSButton handles icon-only rendering natively.
-  const isIconOnly = button.icon != null && button.children == null;
+  // Icon-only: true when icon is present and label is explicitly hidden.
+  // Unlike XDSButton (where icon + no children = icon-only), dropdown
+  // menus show label as visible text by default.
+  const {isLabelHidden, ...buttonProps} = button;
+  const isIconOnly = buttonProps.icon != null && isLabelHidden === true;
 
   // Build endContent: use consumer's endContent if provided,
   // otherwise inject chevron (unless icon-only or hasChevron=false)
@@ -623,7 +633,18 @@ export function XDSDropdownMenu({
           ).current = el;
           layer.ref(el);
         }}
-        {...button}
+        {...buttonProps}
+        // When icon is set without children, XDSButton treats it as
+        // icon-only (label becomes aria-label only). For dropdown menus
+        // we want label to remain visible text, so we promote it to
+        // children — unless isLabelHidden is true.
+        children={
+          !isIconOnly &&
+          buttonProps.icon != null &&
+          buttonProps.children == null
+            ? buttonProps.label
+            : buttonProps.children
+        }
         endContent={resolvedEndContent}
         onClick={handleButtonClick}
         onKeyDown={handleKeyDown}


### PR DESCRIPTION
XDSDropdownMenu was inconsistent with XDSButton: it allowed both `label` and `children` which means it was confusing how to make a dropdown menu with just an icon vs. icon + label. I have changed it to work the same as XDSButton now, so it will use `label` for label, `icon` for the icon, and `isLabelHidden` for icon-only.