### PR TITLE
spec(Table): plugin specs for sortable, filtering, pagination, columnSettings, columnResize #978

### DIFF
--- a/packages/core/src/Table/plugins/columnResize/SPEC.md
+++ b/packages/core/src/Table/plugins/columnResize/SPEC.md
@@ -1,0 +1,410 @@
+# useXDSTableColumnResize — Plugin Specification
+
+## 1. WWW Reference Analysis
+
+### API Surface
+
+```ts
+hook useXDSTableColumnResize<TItem, TColumnKey>(
+  config: XDSTableColumnResizeConfig<TColumnKey>
+): XDSTableColumnResize<TItem, TColumnKey>
+```
+
+**Config type:**
+
+```ts
+interface XDSTableColumnResizeConfig<TColumnKey> {
+  /** Map of column keys to their current size specs */
+  columnSizes: XDSColumnSizeSpecMap<TColumnKey>;
+  /** Callback when a column resize operation completes */
+  onColumnResizeEnd?: XDSTableOnColumnResizeEnd<TColumnKey>;
+}
+
+type XDSColumnSizeSpecMap<TColumnKey> = Map<TColumnKey, XDSTableColumnSizeSpec>;
+type XDSTableColumnSizeSpec = { width: number };
+type XDSTableOnColumnResizeEnd<TColumnKey> = (event: {
+  columnKey: TColumnKey;
+  newColumnWidth: number;
+}) => void;
+```
+
+### Interaction Model (WWW)
+
+- **Resize handle**: 6px invisible hit area positioned at the right edge of each header cell
+- **Hover**: `cursor: ew-resize`, handle opacity transitions from 0 to 1
+- **Dragging**: 1px colored line indicator visible during drag, uses theme colors via `useXDSTheme()`
+- **StyleX**: Handle is `position: absolute`, `right: 0`, full height, `opacity: 0 → 1` on hover/active
+
+### State Flow (WWW)
+
+1. User hovers header cell right edge → handle becomes visible
+2. `mousedown` on handle → begin drag, capture pointer
+3. `mousemove` → update column width in real-time (pixel-based delta)
+4. `mouseup` → finalize width, fire `onColumnResizeEnd` callback
+5. During resize, proportional columns convert to pixel widths
+
+---
+
+## 2. XDS OSS Plugin API
+
+### Hook Signature
+
+```ts
+function useXDSTableColumnResize<T extends Record<string, unknown>>(
+  config: UseXDSTableColumnResizeConfig
+): TablePlugin<T>
+```
+
+### Config Type
+
+```ts
+interface UseXDSTableColumnResizeConfig {
+  /**
+   * Column width overrides from resize operations.
+   * Keys are column `key` strings. Values are pixel widths.
+   * When a column key is present here, it overrides the column's
+   * declared `width` (proportional or pixel).
+   *
+   * Controlled: consumer owns this state and persists as needed.
+   */
+  columnWidths?: Record<string, number>;
+
+  /**
+   * Called when a resize operation completes (mouseup / pointerup).
+   * Consumer updates their `columnWidths` state here.
+   */
+  onColumnResizeEnd?: (event: {
+    columnKey: string;
+    newWidth: number;
+  }) => void;
+
+  /**
+   * Minimum column width in pixels during resize.
+   * @default 50
+   */
+  minWidth?: number;
+
+  /**
+   * Maximum column width in pixels during resize.
+   * @default Infinity (no max)
+   */
+  maxWidth?: number;
+}
+```
+
+### Design Decisions
+
+**Why `Record<string, number>` instead of `Map`?**
+XDS OSS uses plain objects for config throughout (see selection plugin). Maps add serialization friction and don't match the existing API patterns. Column keys are already `string` in `XDSTableColumn`.
+
+**Why controlled state?**
+The selection plugin pattern uses controlled state (`getIsItemSelected`, `onSelectItem`). Column resize follows the same principle — the consumer owns `columnWidths` in their state and updates it via `onColumnResizeEnd`. This makes persistence (localStorage, URL params, server) trivial.
+
+**Proportional → Pixel Conversion on Resize:**
+When a user starts resizing a proportional column, the plugin must resolve its current rendered pixel width (via `getBoundingClientRect()` on the `<th>`) and operate in pixel space from that point forward. The `onColumnResizeEnd` callback reports the final pixel width. The consumer's `columnWidths` state then overrides the original proportional width for that column.
+
+Columns that are never resized keep their original `proportional()` or `pixel()` width — only resized columns get pixel overrides.
+
+**Double-Click Auto-Fit:**
+Double-clicking the resize handle should auto-size the column to fit its content. Implementation approach:
+1. On `dblclick`, measure the natural content width of all visible cells in the column
+2. Create an off-screen measurement element, render cell content, read `scrollWidth`
+3. Clamp to `[minWidth, maxWidth]`, fire `onColumnResizeEnd` with the result
+
+This is a P1 follow-up, not required for initial implementation.
+
+### Plugin Transforms Used
+
+| Transform | Purpose |
+|---|---|
+| `transformHeaderCell` | Inject resize handle element into each header cell; apply `position: relative` so handle can be absolutely positioned; apply `width` style override from `columnWidths` |
+| `transformTable` | Add `user-select: none` to `<table>` during active drag to prevent text selection |
+
+The plugin does NOT use:
+- `transformHeaderRow` — no row-level changes needed
+- `transformBodyRow` — body rows don't need modification
+- `transformBodyCell` — column widths are controlled via `<th>` with `table-layout: fixed`
+- `transformTableContext` — no context provider needed (resize state is internal to the hook)
+
+### Colgroup Strategy
+
+The current `XDSBaseTable` uses `table-layout: fixed` and sets widths via `<th>` `minWidth` styles. The resize plugin continues this pattern: overridden widths are applied as inline `width` + `minWidth` + `maxWidth` (all set to the same pixel value) on the `<th>` via `transformHeaderCell`. This locks the column to the resized width under `table-layout: fixed`.
+
+No `<colgroup>` is introduced. This keeps the plugin self-contained and avoids structural changes to `XDSBaseTable`.
+
+### Persist Model
+
+The plugin is **stateless** — it receives `columnWidths` and reports changes via `onColumnResizeEnd`. Persistence is the consumer's responsibility:
+
+```tsx
+// Example: useState persistence
+const [columnWidths, setColumnWidths] = useState<Record<string, number>>({});
+
+const resizePlugin = useXDSTableColumnResize({
+  columnWidths,
+  onColumnResizeEnd: ({ columnKey, newWidth }) => {
+    setColumnWidths(prev => ({ ...prev, [columnKey]: newWidth }));
+  },
+});
+
+// Example: localStorage persistence
+const [columnWidths, setColumnWidths] = useState<Record<string, number>>(() => {
+  const saved = localStorage.getItem('table-widths');
+  return saved ? JSON.parse(saved) : {};
+});
+
+const resizePlugin = useXDSTableColumnResize({
+  columnWidths,
+  onColumnResizeEnd: ({ columnKey, newWidth }) => {
+    setColumnWidths(prev => {
+      const next = { ...prev, [columnKey]: newWidth };
+      localStorage.save('table-widths', JSON.stringify(next));
+      return next;
+    });
+  },
+});
+```
+
+### Reset API
+
+Consumers can reset column widths by clearing their state:
+
+```tsx
+// Reset single column
+setColumnWidths(prev => {
+  const { [columnKey]: _, ...rest } = prev;
+  return rest;
+});
+
+// Reset all
+setColumnWidths({});
+```
+
+No special reset API is needed in the plugin.
+
+---
+
+## 3. Behavioral Spec
+
+### 3.1 Hover
+
+| State | Visual |
+|---|---|
+| Mouse not near right edge of `<th>` | No resize indicator visible |
+| Mouse enters 6px hit area at right edge | `cursor: ew-resize`; resize handle fades in (1px vertical line, theme accent color) |
+| Mouse leaves hit area | Handle fades out |
+
+The hit area extends 3px inside and 3px outside the cell border to make it easy to target.
+
+### 3.2 Drag (Pointer-Based Resize)
+
+| Step | Behavior |
+|---|---|
+| `pointerdown` on handle | Capture pointer (`setPointerCapture`). Record initial column width and pointer X. Add `user-select: none` to table. |
+| `pointermove` | Calculate delta = `currentX - startX`. New width = `max(minWidth, min(maxWidth, initialWidth + delta))`. Apply width to `<th>` via inline style (live preview). |
+| `pointerup` | Release pointer capture. Remove `user-select: none`. Fire `onColumnResizeEnd({ columnKey, newWidth })`. |
+| Drag below `minWidth` | Column clamps to `minWidth`; cursor continues tracking but width doesn't decrease further. |
+| Drag above `maxWidth` | Column clamps to `maxWidth`. |
+| `pointercancel` / blur | Abort resize; revert to width before drag started. |
+
+**Why pointer events, not mouse events?**
+Pointer events provide `setPointerCapture`, which ensures `pointermove`/`pointerup` fire on the handle element even when the pointer moves outside the element or the window. This eliminates the need for document-level event listeners and works correctly with touch input.
+
+### 3.3 Release
+
+- On `pointerup`, the final width is committed via `onColumnResizeEnd`.
+- The `<th>` inline style applied during drag remains in place (it matches the committed width).
+- Adjacent columns reflow naturally under `table-layout: fixed` — their proportional widths redistribute within remaining space.
+
+### 3.4 Double-Click (Auto-Fit) — P1 Follow-Up
+
+| Step | Behavior |
+|---|---|
+| `dblclick` on resize handle | Measure natural content width of all visible cells in the column. Clamp to `[minWidth, maxWidth]`. Fire `onColumnResizeEnd`. |
+
+### 3.5 Keyboard Accessibility
+
+| Key | Behavior |
+|---|---|
+| `Tab` | Resize handle is focusable (rendered as a `<div role="separator" tabIndex={0}>`) |
+| `Enter` / `Space` | Activate resize mode (equivalent to pointerdown) |
+| `ArrowLeft` | Decrease column width by 10px (clamped to minWidth) |
+| `ArrowRight` | Increase column width by 10px (clamped to maxWidth) |
+| `Shift+ArrowLeft/Right` | Decrease/increase by 50px |
+| `Escape` | Cancel resize, revert to width before activation |
+| `Enter` (while active) | Commit current width, exit resize mode |
+
+**ARIA attributes on the handle:**
+```tsx
+<div
+  role="separator"
+  aria-orientation="vertical"
+  aria-valuenow={currentWidth}
+  aria-valuemin={minWidth}
+  aria-valuemax={maxWidth}
+  aria-label={`Resize column ${columnHeader}`}
+  tabIndex={0}
+/>
+```
+
+### 3.6 RTL Support
+
+In RTL layouts, the resize handle appears at the left edge of the header cell (logical "end" edge). Drag direction is inverted: dragging left increases width, dragging right decreases.
+
+Use CSS logical properties (`inset-inline-end: 0`) for handle positioning so RTL works automatically.
+
+### 3.7 Touch Support
+
+Pointer events handle touch natively. The 6px hit area may be too small for touch — consider increasing to 16px on touch devices via `@media (pointer: coarse)`.
+
+---
+
+## 4. Competitive Analysis
+
+### 4.1 WWW XDS Internal (`useXDSTableColumnResize`)
+
+- **Architecture**: Wraps `useWebTableColumnResize` with XDS theming
+- **Width model**: `Map<TColumnKey, { width: number }>` — pixel-only after resize
+- **Handle**: 6px absolute-positioned div, opacity animation
+- **Callback**: `onColumnResizeEnd({ columnKey, newColumnWidth })`
+- **Strengths**: Proven in production, theme-integrated
+- **Gaps**: No keyboard a11y, no auto-fit, no RTL consideration documented
+
+### 4.2 AG Grid
+
+- **Architecture**: Built into column definition; `resizable: true` per column
+- **Width model**: Pixel widths with `minWidth`/`maxWidth` per column
+- **Handle**: Appears between column headers
+- **Auto-fit**: `autoSizeColumn()` / `autoSizeAllColumns()` API
+- **Callback**: `onColumnResized` event with `{ column, finished, source }`
+- **Strengths**: `source` field distinguishes user vs API resize; auto-size API; `suppressAutoSize` per column
+- **Gaps**: Heavy abstraction, not composable as a plugin
+
+### 4.3 Mantine Table
+
+- **Architecture**: `columnSizing` state in `useReactTable` (TanStack-based)
+- **Width model**: `columnSizingInfo` tracks delta during drag
+- **Handle**: CSS class on th, styled separator
+- **Callback**: `onColumnSizingChange` state updater
+- **Strengths**: TanStack integration, declarative state
+- **Gaps**: Tightly coupled to TanStack table internals
+
+### 4.4 TanStack Table
+
+- **Architecture**: `columnResizing` feature; `enableResizing` per column
+- **Width model**: Tracks `deltaOffset` during drag, `columnSizingInfo` state
+- **Resize modes**: `onChange` (live) and `onEnd` (commit on release)
+- **Handle**: Consumer renders using `header.getResizeHandler()`
+- **Callback**: `onColumnSizingChange`, `onColumnSizingInfoChange`
+- **Strengths**: Headless — complete rendering control; two resize modes; works with any framework
+- **Gaps**: Consumer responsible for all rendering; no built-in a11y
+
+### Summary
+
+| Feature | WWW | AG Grid | Mantine | TanStack | XDS OSS (proposed) |
+|---|---|---|---|---|---|
+| Plugin/composable | Yes | No (built-in) | No (TanStack) | Yes (headless) | Yes |
+| Controlled state | Yes | Partial | Yes | Yes | Yes |
+| Min/max constraints | No | Yes | No | No | Yes |
+| Keyboard a11y | No | Yes | No | No | Yes |
+| Auto-fit | No | Yes | No | No | P1 |
+| RTL | Unknown | Yes | Unknown | No | Yes |
+| Live preview | Yes | Yes | Optional | Optional | Yes |
+| Persist model | Consumer | Built-in | Consumer | Consumer | Consumer |
+
+---
+
+## 5. Component Dependencies
+
+### Required (exist in XDS OSS)
+
+| Dependency | Location | Purpose |
+|---|---|---|
+| `TablePlugin<T>` | `Table/types.ts` | Plugin interface — hook return type |
+| `HeaderCellRenderProps` | `Table/types.ts` | Transform target for header cells |
+| `TableRenderProps` | `Table/types.ts` | Transform target for table element |
+| `XDSTableColumn<T>` | `Table/types.ts` | Column definition (passed to `transformHeaderCell`) |
+| `colorVars` | `theme/tokens.stylex.ts` | Theme color tokens for handle styling |
+| `spacingVars` | `theme/tokens.stylex.ts` | Theme spacing tokens |
+| `stylex` | `@stylexjs/stylex` | Style definitions |
+
+### Used from Platform
+
+| Dependency | Purpose |
+|---|---|
+| `React.useRef` | Track drag state, store refs |
+| `React.useMemo` | Stable plugin object |
+| `React.useCallback` | Stable event handlers |
+| `PointerEvent` | Cross-platform drag handling |
+
+### Not Required
+
+- No new components needed — the resize handle is a plain `<div>` rendered inside the existing `<th>`
+- No context provider needed — drag state is local to the hook
+- No external libraries — pointer events are sufficient for drag handling
+
+---
+
+## 6. Test Specification
+
+### 6.1 Unit Tests — Hook Behavior
+
+| # | Test | Assertion |
+|---|---|---|
+| 1 | Returns a stable `TablePlugin` object across re-renders | `plugin` reference identity does not change when config callbacks change |
+| 2 | `transformHeaderCell` adds resize handle to each header cell | Rendered header cell contains a `[role="separator"]` element |
+| 3 | `transformHeaderCell` applies width override when `columnWidths` has entry | `<th>` has inline `width` style matching the override value |
+| 4 | `transformHeaderCell` does not override width when `columnWidths` is empty | `<th>` has no inline `width` style from the plugin |
+| 5 | `transformTable` does not add `user-select: none` when not dragging | Table element has normal `user-select` |
+
+### 6.2 Integration Tests — Resize Interaction
+
+| # | Test | Assertion |
+|---|---|---|
+| 6 | Pointer drag resizes column | Simulate `pointerdown` → `pointermove(+100px)` → `pointerup` on handle. `onColumnResizeEnd` called with `{ columnKey, newWidth: initialWidth + 100 }` |
+| 7 | Drag respects `minWidth` | Drag left past `minWidth`. `onColumnResizeEnd` reports `minWidth`, not a smaller value |
+| 8 | Drag respects `maxWidth` | Drag right past `maxWidth`. `onColumnResizeEnd` reports `maxWidth` |
+| 9 | Live preview during drag | During `pointermove`, the `<th>` inline style updates to reflect current drag position |
+| 10 | Cancel on Escape during drag | Press `Escape` during drag. Width reverts to pre-drag value. `onColumnResizeEnd` is NOT called |
+| 11 | Cancel on pointer cancel | Fire `pointercancel` during drag. Width reverts. No callback |
+| 12 | Double-click calls onColumnResizeEnd (P1) | `dblclick` on handle fires callback with auto-fit width |
+
+### 6.3 Integration Tests — Table Rendering
+
+| # | Test | Assertion |
+|---|---|---|
+| 13 | Plugin composes with selection plugin | Table with both `useXDSTableSelection` and `useXDSTableColumnResize` renders correctly — selection checkbox column and resize handles both present |
+| 14 | Proportional columns get correct initial pixel width | Render table with `proportional(2)` and `proportional(1)` columns. Start resize on the 2:1 column. Initial width captured via `getBoundingClientRect` is approximately 2/3 of table width |
+| 15 | Resized column persists across re-renders | Set `columnWidths` state, trigger parent re-render. Column retains pixel width |
+| 16 | Reset column width | Remove a key from `columnWidths`. Column reverts to its declared `proportional()` or `pixel()` width |
+
+### 6.4 Keyboard Accessibility Tests
+
+| # | Test | Assertion |
+|---|---|---|
+| 17 | Handle is focusable via Tab | `Tab` to resize handle. Element receives focus |
+| 18 | Enter activates resize mode | Focus handle, press `Enter`. Resize mode is active (aria state updates) |
+| 19 | Arrow keys adjust width | In resize mode, `ArrowRight` increases width by 10px. `ArrowLeft` decreases by 10px |
+| 20 | Shift+Arrow for large steps | `Shift+ArrowRight` increases by 50px |
+| 21 | Escape cancels keyboard resize | Activate resize, press `ArrowRight` twice, then `Escape`. Width reverts to original |
+| 22 | Enter commits keyboard resize | Activate resize, press `ArrowRight` three times, press `Enter`. `onColumnResizeEnd` called with `+30px` |
+
+### 6.5 ARIA Tests
+
+| # | Test | Assertion |
+|---|---|---|
+| 23 | Handle has `role="separator"` | Resize handle element has `role="separator"` |
+| 24 | Handle has `aria-orientation="vertical"` | Attribute present |
+| 25 | Handle has `aria-valuenow` | Value matches current column width |
+| 26 | Handle has `aria-label` | Label includes column header text |
+
+### 6.6 Edge Cases
+
+| # | Test | Assertion |
+|---|---|---|
+| 27 | No columns → no crash | Plugin with empty columns array renders without error |
+| 28 | Single column resize | Table with one column can be resized (doesn't collapse table) |
+| 29 | Rapid sequential resizes | Multiple quick resize operations don't produce stale state |
+| 30 | Column reorder after resize | If columns prop changes (reorder), `columnWidths` keys still map correctly |
+| 31 | `user-select: none` is cleaned up | After drag ends (including cancel), `user-select` is removed from table |
+| 32 | Touch drag works | `pointerdown` with `pointerType: "touch"` works the same as mouse |

--- a/packages/core/src/Table/plugins/columnSettings/SPEC.md
+++ b/packages/core/src/Table/plugins/columnSettings/SPEC.md
@@ -1,0 +1,757 @@
+# useXDSTableColumnSettings — Plugin Specification
+
+> **Status:** Draft
+> **Issue:** #978
+> **Author:** spec-page-cols
+> **Date:** 2026-03-30
+
+---
+
+## 1. WWW Reference Analysis
+
+### WWW API Surface
+
+WWW has two layers for column customization:
+
+#### Layer 1: `useXDSTableCustomColumns` (Core Logic)
+
+```flow
+hook useXDSTableCustomColumns<TItem, TColumnKey>({
+  activeColumnKeys: ReadonlyArray<TColumnKey>,
+  isColumnDisabled: TColumnKey => boolean,
+  setActiveColumnKeys: (ReadonlyArray<TColumnKey>) => void,
+  viewConfiguration?: XDSTableViewConfiguration<TColumnKey>,
+}): XDSTableCustomColumnsPlugin<TItem, TColumnKey>
+```
+
+**Returns:**
+```flow
+{
+  activeColumnKeys: ReadonlyArray<TColumnKey>,
+  isColumnDisabled: (TColumnKey) => boolean,
+  plugin: TablePlugin<TItem>,           // filters columns to only active ones
+  setActiveColumnKeys: (ReadonlyArray<TColumnKey>) => void,
+  viewConfiguration?: XDSTableViewConfiguration<TColumnKey>,
+}
+```
+
+**State flow:**
+1. Consumer provides `activeColumnKeys` (which columns are visible) and `setActiveColumnKeys` (state setter)
+2. The hook returns a `plugin` that transforms the table's columns to only include active keys
+3. `isColumnDisabled` prevents certain columns from being hidden (e.g., "Name" column is always visible)
+4. Column order in the table matches the order in `activeColumnKeys`
+
+#### Layer 2: `XDSTableViewConfiguration` (Saved Views / Presets)
+
+```flow
+type XDSTableViewConfiguration<TColumnKey> = {
+  views: Array<{
+    uniqueID: string,
+    label: string,
+    columnKeys: ReadonlyArray<TColumnKey>,
+    isDeleteDisabled?: boolean,
+  }>,
+  onCreateView: (label: string, columnKeys: ReadonlyArray<TColumnKey>) => void,
+  onDeleteView: (uniqueID: string) => void,
+  onUpdateInitialView: (uniqueID: string) => void,
+  systemDefaultColumns: ReadonlyArray<TColumnKey>,
+  initialViewID?: string,
+}
+```
+
+**State flow:**
+1. Views are saved presets (e.g., "Compact View", "Detailed View") with predefined column sets
+2. User selects a view → `setActiveColumnKeys` is called with that view's `columnKeys`
+3. User can create/delete views; `systemDefaultColumns` provides the "Reset to default" column set
+4. `initialViewID` sets which view is active on mount
+
+#### Layer 3: `XDSTableCustomColumnsDropdown` (UI Component)
+
+```flow
+component XDSTableCustomColumnsDropdown({
+  customColumns: XDSTableCustomColumnsPlugin,  // return value of useXDSTableCustomColumns
+  options: Array<{ label: string, value: TColumnKey }>,
+  label: string,
+  hasSelectAll?: boolean,
+})
+```
+
+- Uses `XDSMultiSelector` to render a dropdown for toggling columns
+- Active columns shown as checked, disabled columns can't be unchecked
+- Optional "Select all" toggle
+
+#### Layer 4: `XDSTableColumnSettingsViewOption` (Advanced UI)
+
+```flow
+// Used within XDSTableViewOptionsMenu
+// Supports:
+//   - Column reordering via drag-and-drop
+//   - Grouped columns (collapsible sections)
+//   - Saved views/presets
+//   - URL query param persistence
+//   - localStorage fallback
+```
+
+### Key Observations from WWW
+
+1. **Headless pattern** — `useXDSTableCustomColumns` is pure logic; UI is separate
+2. **Column filtering is a plugin transform** — the plugin filters the `columns` array
+3. **Column order = array order** — reordering columns means reordering `activeColumnKeys`
+4. **Views are optional** — basic column toggle works without `viewConfiguration`
+5. **No drag-and-drop in core** — DnD is in the advanced `ViewOption` component, not the hook
+
+---
+
+## 2. XDS OSS Plugin API (TypeScript)
+
+### Design Decisions
+
+1. **Plugin filters columns** — The plugin uses a new `transformColumns` concept. However, the current `TablePlugin<T>` interface does not have a `transformColumns` method. **Two approaches:**
+   - **Option A: Consumer filters columns** — the hook returns `activeColumns` and the consumer passes those to `<XDSTable columns={activeColumns}>`. The plugin is used only for side effects (context, UI). This is simpler and works today.
+   - **Option B: Extend TablePlugin with `transformColumns`** — add a new transform to the plugin interface. This is more powerful but requires modifying the core type.
+
+   **Recommendation: Option A** — consumer filters columns. This avoids extending the plugin interface and follows the principle of least surprise. The hook provides the filtered/reordered columns as a convenience.
+
+2. **Views are optional** — basic column toggle should work without views. Views layer on top.
+
+3. **No drag-and-drop in this spec** — DnD for column reordering is out of scope for the core hook. Column order is controlled by `activeColumnKeys` array order; consumers can implement reordering UI on top.
+
+### Config Interface
+
+```typescript
+/**
+ * Definition of a column for the column settings UI.
+ * Separate from XDSTableColumn because the settings UI needs metadata
+ * (label, group, disableability) that the table column doesn't carry.
+ */
+export interface XDSColumnSettingsOption<TColumnKey extends string = string> {
+  /** Column key — must match XDSTableColumn.key */
+  key: TColumnKey;
+  /** Human-readable label for the column settings UI */
+  label: string;
+  /**
+   * Whether this column can be hidden.
+   * When true, the column is always visible and its checkbox is disabled.
+   * Use for essential columns like "Name" or "ID".
+   * @default false
+   */
+  isAlwaysVisible?: boolean;
+  /**
+   * Optional group name for organized column lists.
+   * Columns with the same group are rendered together under a heading.
+   */
+  group?: string;
+}
+
+/**
+ * A saved view preset — a named set of active columns.
+ */
+export interface XDSColumnSettingsView<TColumnKey extends string = string> {
+  /** Unique identifier for this view */
+  id: string;
+  /** Display label (e.g., "Compact View", "Detailed View") */
+  label: string;
+  /** Column keys included in this view, in display order */
+  columnKeys: ReadonlyArray<TColumnKey>;
+  /**
+   * Whether the user can delete this view.
+   * System-provided views (like "Default") should be non-deletable.
+   * @default false
+   */
+  isDeleteDisabled?: boolean;
+}
+
+/**
+ * Configuration for saved views / presets.
+ * Optional — omit for basic column toggle without views.
+ */
+export interface XDSColumnSettingsViewConfig<TColumnKey extends string = string> {
+  /** Available saved views */
+  views: ReadonlyArray<XDSColumnSettingsView<TColumnKey>>;
+  /**
+   * Called when the user creates a new view.
+   * Consumer persists the view and updates the `views` array.
+   */
+  onCreateView: (label: string, columnKeys: ReadonlyArray<TColumnKey>) => void;
+  /**
+   * Called when the user deletes a view.
+   * Consumer removes the view from persistence and updates the `views` array.
+   */
+  onDeleteView: (id: string) => void;
+  /**
+   * Called when the user sets a view as the default/initial view.
+   */
+  onSetDefaultView?: (id: string) => void;
+  /**
+   * The system default column set. Used for "Reset to default" functionality.
+   * This is the column set used when no view is selected or when the user resets.
+   */
+  defaultColumnKeys: ReadonlyArray<TColumnKey>;
+  /**
+   * Which view is active on mount.
+   * If not provided, `defaultColumnKeys` are used as the initial active columns.
+   */
+  initialViewId?: string;
+}
+
+/**
+ * Configuration for useXDSTableColumnSettings.
+ *
+ * Headless column visibility and ordering management for XDSTable.
+ * The consumer owns all state. The hook provides filtered columns
+ * and a plugin for table integration.
+ *
+ * @template T - The row data type
+ * @template TColumnKey - String literal union of column keys
+ *
+ * @example Basic column toggle
+ * ```
+ * const allColumns = [
+ *   { key: 'name', header: 'Name' },
+ *   { key: 'email', header: 'Email' },
+ *   { key: 'role', header: 'Role' },
+ *   { key: 'status', header: 'Status' },
+ *   { key: 'lastLogin', header: 'Last Login' },
+ * ];
+ *
+ * const [activeKeys, setActiveKeys] = useState(['name', 'email', 'role']);
+ *
+ * const columnSettings = useXDSTableColumnSettings({
+ *   columns: [
+ *     { key: 'name', label: 'Name', isAlwaysVisible: true },
+ *     { key: 'email', label: 'Email' },
+ *     { key: 'role', label: 'Role' },
+ *     { key: 'status', label: 'Status' },
+ *     { key: 'lastLogin', label: 'Last Login' },
+ *   ],
+ *   activeColumnKeys: activeKeys,
+ *   onChangeActiveColumnKeys: setActiveKeys,
+ * });
+ *
+ * <XDSTable
+ *   data={data}
+ *   columns={columnSettings.activeColumns(allColumns)}
+ *   plugins={{ columnSettings: columnSettings.plugin }}
+ * />
+ * ```
+ *
+ * @example With saved views
+ * ```
+ * const columnSettings = useXDSTableColumnSettings({
+ *   columns: columnOptions,
+ *   activeColumnKeys: activeKeys,
+ *   onChangeActiveColumnKeys: setActiveKeys,
+ *   viewConfig: {
+ *     views: savedViews,
+ *     onCreateView: (label, keys) => createView(label, keys),
+ *     onDeleteView: (id) => deleteView(id),
+ *     defaultColumnKeys: ['name', 'email', 'role'],
+ *   },
+ * });
+ * ```
+ *
+ * @example With XDSDropdownMenu for column toggle UI
+ * ```
+ * <XDSDropdownMenu
+ *   button={{ label: 'Columns', icon: 'columns' }}
+ *   items={columnSettings.dropdownItems}
+ * />
+ * ```
+ */
+export interface UseXDSTableColumnSettingsConfig<
+  TColumnKey extends string = string,
+> {
+  /**
+   * All available columns with metadata for the settings UI.
+   * This defines the universe of columns the user can toggle.
+   */
+  columns: ReadonlyArray<XDSColumnSettingsOption<TColumnKey>>;
+
+  /**
+   * Currently active column keys, in display order.
+   * Only columns with keys in this array are shown in the table.
+   * The array order determines column display order.
+   */
+  activeColumnKeys: ReadonlyArray<TColumnKey>;
+
+  /**
+   * Called when active columns change (toggle, reorder, view selection).
+   * Consumer updates their own state.
+   */
+  onChangeActiveColumnKeys: (keys: ReadonlyArray<TColumnKey>) => void;
+
+  /**
+   * Optional saved views / presets configuration.
+   * Enables saving and loading named column configurations.
+   */
+  viewConfig?: XDSColumnSettingsViewConfig<TColumnKey>;
+}
+```
+
+### Return Type
+
+```typescript
+/**
+ * Return value of useXDSTableColumnSettings.
+ */
+export interface UseXDSTableColumnSettingsReturn<
+  T extends Record<string, unknown>,
+  TColumnKey extends string = string,
+> {
+  /** The TablePlugin to pass to XDSTable's plugins prop. */
+  plugin: TablePlugin<T>;
+
+  /**
+   * Filters and reorders the full columns array based on activeColumnKeys.
+   * Returns only active columns, in the order specified by activeColumnKeys.
+   *
+   * @example
+   * ```
+   * <XDSTable columns={columnSettings.activeColumns(allColumns)} ... />
+   * ```
+   */
+  activeColumns: (columns: XDSTableColumn<T>[]) => XDSTableColumn<T>[];
+
+  /**
+   * Toggle a column's visibility.
+   * If the column is active, removes it. If inactive, adds it to the end.
+   * No-op for columns with `isAlwaysVisible: true`.
+   */
+  toggleColumn: (key: TColumnKey) => void;
+
+  /**
+   * Whether a specific column is currently active (visible).
+   */
+  isColumnActive: (key: TColumnKey) => boolean;
+
+  /**
+   * Whether a specific column can be toggled.
+   * Returns false for columns with `isAlwaysVisible: true`.
+   */
+  isColumnToggleable: (key: TColumnKey) => boolean;
+
+  /**
+   * Show all columns.
+   */
+  showAllColumns: () => void;
+
+  /**
+   * Reset to the default column set.
+   * Uses `viewConfig.defaultColumnKeys` if views are configured,
+   * otherwise shows all columns.
+   */
+  resetToDefault: () => void;
+
+  /**
+   * Pre-built dropdown items for use with XDSDropdownMenu.
+   * Each item represents a column with a checkbox indicator.
+   * Disabled items represent `isAlwaysVisible` columns.
+   *
+   * @example
+   * ```
+   * <XDSDropdownMenu
+   *   button={{ label: 'Columns' }}
+   *   items={columnSettings.dropdownItems}
+   * />
+   * ```
+   */
+  dropdownItems: XDSDropdownMenuOption[];
+
+  /**
+   * Currently active column keys (pass-through from config).
+   */
+  activeColumnKeys: ReadonlyArray<TColumnKey>;
+
+  /**
+   * View management methods (only present when viewConfig is provided).
+   */
+  views?: {
+    /** All available views */
+    list: ReadonlyArray<XDSColumnSettingsView<TColumnKey>>;
+    /** Apply a saved view's column configuration */
+    applyView: (viewId: string) => void;
+    /** Create a new view from the current active columns */
+    createView: (label: string) => void;
+    /** Delete a saved view */
+    deleteView: (viewId: string) => void;
+    /** Set a view as the default */
+    setDefaultView?: (viewId: string) => void;
+    /** Reset to the system default columns */
+    resetToDefault: () => void;
+  };
+}
+```
+
+### Plugin Transform Methods Used
+
+| Transform Method | Used | Purpose |
+|---|---|---|
+| `transformTable` | No | — |
+| `transformHeaderRow` | No | — |
+| `transformHeaderCell` | No | — |
+| `transformBodyRow` | No | — |
+| `transformBodyCell` | No | — |
+| `transformTableContext` | **Yes** | Provides column settings context (for nested components that need access to column state) |
+
+> **Note:** The plugin intentionally does NOT filter columns via a transform. Column filtering is done by the `activeColumns()` helper that the consumer passes to `<XDSTable columns={...}>`. This keeps the plugin interface minimal and avoids needing a `transformColumns` method on `TablePlugin<T>`.
+
+### Implementation Skeleton
+
+```typescript
+export function useXDSTableColumnSettings<
+  T extends Record<string, unknown>,
+  TColumnKey extends string = string,
+>(
+  config: UseXDSTableColumnSettingsConfig<TColumnKey>,
+): UseXDSTableColumnSettingsReturn<T, TColumnKey> {
+  const { columns, activeColumnKeys, onChangeActiveColumnKeys, viewConfig } = config;
+
+  // Build lookup sets for fast checks
+  const activeSet = useMemo(
+    () => new Set(activeColumnKeys),
+    [activeColumnKeys],
+  );
+
+  const alwaysVisibleSet = useMemo(
+    () => new Set(columns.filter(c => c.isAlwaysVisible).map(c => c.key)),
+    [columns],
+  );
+
+  // --- Column operations ---
+
+  const toggleColumn = useCallback((key: TColumnKey) => {
+    if (alwaysVisibleSet.has(key)) return; // Can't toggle always-visible columns
+    if (activeSet.has(key)) {
+      onChangeActiveColumnKeys(activeColumnKeys.filter(k => k !== key));
+    } else {
+      onChangeActiveColumnKeys([...activeColumnKeys, key]);
+    }
+  }, [activeColumnKeys, onChangeActiveColumnKeys, activeSet, alwaysVisibleSet]);
+
+  const isColumnActive = useCallback(
+    (key: TColumnKey) => activeSet.has(key),
+    [activeSet],
+  );
+
+  const isColumnToggleable = useCallback(
+    (key: TColumnKey) => !alwaysVisibleSet.has(key),
+    [alwaysVisibleSet],
+  );
+
+  const showAllColumns = useCallback(() => {
+    onChangeActiveColumnKeys(columns.map(c => c.key));
+  }, [columns, onChangeActiveColumnKeys]);
+
+  const resetToDefault = useCallback(() => {
+    if (viewConfig?.defaultColumnKeys) {
+      onChangeActiveColumnKeys([...viewConfig.defaultColumnKeys]);
+    } else {
+      showAllColumns();
+    }
+  }, [viewConfig, onChangeActiveColumnKeys, showAllColumns]);
+
+  // --- Column filtering helper ---
+
+  const activeColumns = useCallback(
+    (allColumns: XDSTableColumn<T>[]): XDSTableColumn<T>[] => {
+      const columnMap = new Map(allColumns.map(c => [c.key, c]));
+      return activeColumnKeys
+        .map(key => columnMap.get(key))
+        .filter((c): c is XDSTableColumn<T> => c != null);
+    },
+    [activeColumnKeys],
+  );
+
+  // --- Dropdown items ---
+
+  const dropdownItems = useMemo((): XDSDropdownMenuOption[] => {
+    // Group columns if any have a group defined
+    const hasGroups = columns.some(c => c.group);
+
+    if (!hasGroups) {
+      return columns.map(col => ({
+        label: `${activeSet.has(col.key) ? '✓ ' : '  '}${col.label}`,
+        onClick: () => toggleColumn(col.key),
+        isDisabled: alwaysVisibleSet.has(col.key),
+      }));
+    }
+
+    // Build grouped sections
+    const groups = new Map<string, XDSColumnSettingsOption<TColumnKey>[]>();
+    const ungrouped: XDSColumnSettingsOption<TColumnKey>[] = [];
+
+    for (const col of columns) {
+      if (col.group) {
+        const group = groups.get(col.group) ?? [];
+        group.push(col);
+        groups.set(col.group, group);
+      } else {
+        ungrouped.push(col);
+      }
+    }
+
+    const items: XDSDropdownMenuOption[] = [];
+
+    for (const [groupName, groupCols] of groups) {
+      items.push({
+        type: 'section',
+        title: groupName,
+        items: groupCols.map(col => ({
+          label: `${activeSet.has(col.key) ? '✓ ' : '  '}${col.label}`,
+          onClick: () => toggleColumn(col.key),
+          isDisabled: alwaysVisibleSet.has(col.key),
+        })),
+      });
+    }
+
+    if (ungrouped.length > 0) {
+      for (const col of ungrouped) {
+        items.push({
+          label: `${activeSet.has(col.key) ? '✓ ' : '  '}${col.label}`,
+          onClick: () => toggleColumn(col.key),
+          isDisabled: alwaysVisibleSet.has(col.key),
+        });
+      }
+    }
+
+    return items;
+  }, [columns, activeSet, alwaysVisibleSet, toggleColumn]);
+
+  // --- Views ---
+
+  const views = viewConfig ? {
+    list: viewConfig.views,
+    applyView: (viewId: string) => {
+      const view = viewConfig.views.find(v => v.id === viewId);
+      if (view) onChangeActiveColumnKeys([...view.columnKeys]);
+    },
+    createView: (label: string) => {
+      viewConfig.onCreateView(label, activeColumnKeys);
+    },
+    deleteView: (viewId: string) => {
+      viewConfig.onDeleteView(viewId);
+    },
+    setDefaultView: viewConfig.onSetDefaultView
+      ? (viewId: string) => viewConfig.onSetDefaultView!(viewId)
+      : undefined,
+    resetToDefault: () => {
+      onChangeActiveColumnKeys([...viewConfig.defaultColumnKeys]);
+    },
+  } : undefined;
+
+  // --- Plugin (minimal — context provider for nested access) ---
+
+  const plugin = useMemo((): TablePlugin<T> => ({
+    // The plugin provides context so that custom header cell renderers
+    // or toolbar components nested inside the table can access column state.
+    // Column filtering is handled by activeColumns(), not by the plugin.
+    transformTableContext(children: ReactNode) {
+      return children; // No-op for now; context can be added when needed
+    },
+  }), []);
+
+  return {
+    plugin,
+    activeColumns,
+    toggleColumn,
+    isColumnActive,
+    isColumnToggleable,
+    showAllColumns,
+    resetToDefault,
+    dropdownItems,
+    activeColumnKeys,
+    views,
+  };
+}
+```
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Column Toggle
+
+| Trigger | Render | Accessibility | Edge Cases |
+|---|---|---|---|
+| User clicks column in dropdown | Column toggles visibility; table re-renders with updated columns | Checkbox role with checked/unchecked state | No-op for `isAlwaysVisible` columns |
+| User clicks disabled column | No action | `aria-disabled="true"` on the item | Visual indicator (dimmed) that column can't be toggled |
+| All optional columns hidden | Only `isAlwaysVisible` columns remain | — | At least one column should always be visible (enforced by `isAlwaysVisible`) |
+| Unknown key in `activeColumnKeys` | `activeColumns()` filters it out silently | — | Does not crash; key is simply not found in column map |
+
+### 3.2 Column Ordering
+
+| Trigger | Render | Accessibility | Edge Cases |
+|---|---|---|---|
+| `activeColumnKeys` order changes | Table columns render in new order | Column headers maintain correct labels | Empty `activeColumnKeys` → no columns (only `isAlwaysVisible` should prevent this) |
+| Column re-added after removal | Appears at the end of the table | — | Consumer can control position by inserting at specific index |
+
+### 3.3 Show All / Reset
+
+| Trigger | Render | Accessibility | Edge Cases |
+|---|---|---|---|
+| "Show all" action | All columns become visible in the order defined by `columns` config | — | No-op if all columns already visible |
+| "Reset to default" action | Active columns reset to `defaultColumnKeys` (or all if no views) | — | No-op if already at default |
+
+### 3.4 Saved Views
+
+| Trigger | Render | Accessibility | Edge Cases |
+|---|---|---|---|
+| User selects a saved view | `activeColumnKeys` updates to the view's `columnKeys` | — | No-op if view not found |
+| User creates a view | `onCreateView` called with label and current `activeColumnKeys` | — | Consumer handles persistence (localStorage, server, etc.) |
+| User deletes a view | `onDeleteView` called with view ID | — | No-op for views with `isDeleteDisabled: true` |
+| User sets default view | `onSetDefaultView` called with view ID | — | Optional — only available if `onSetDefaultView` provided |
+| View's columns reference removed columns | `activeColumns()` silently filters out missing columns | — | View may render fewer columns than expected |
+
+### 3.5 Interaction with Other Plugins
+
+| Plugin | Interaction |
+|---|---|
+| **Selection** | Selection checkbox column is prepended by the selection plugin's `transformHeaderRow`/`transformBodyRow`. Column settings does not affect it — selection column is not in `columns`. |
+| **Pagination** | No interaction — pagination operates on data, column settings operates on columns |
+| **Sorting (future)** | Sort state should be keyed by column key. Hiding a sorted column should not break sort state. |
+
+### 3.6 Dropdown UI Pattern
+
+The `dropdownItems` return value is designed for use with `XDSDropdownMenu`:
+
+```tsx
+<XDSDropdownMenu
+  button={{ label: 'Columns', icon: 'settings' }}
+  items={columnSettings.dropdownItems}
+/>
+```
+
+Each item shows a checkmark prefix (`✓` or space) to indicate active state. Disabled items (always-visible columns) show the checkmark but can't be toggled.
+
+**Future enhancement:** When `XDSMultiSelector` or a checkbox-based dropdown exists, the dropdown items could use checkbox rendering instead of text checkmarks. The `dropdownItems` API is forward-compatible — it can be extended to include `isSelected` state.
+
+---
+
+## 4. Competitive Analysis
+
+| Feature | WWW XDS Internal | XDS OSS (this spec) | shadcn/ui | Mantine | AG Grid |
+|---|---|---|---|---|---|
+| **Integration model** | Hook + separate UI | Hook + dropdown items helper | DataTable column toggle | No built-in | Built-in column API |
+| **Column visibility** | ✅ via `activeColumnKeys` | ✅ via `activeColumnKeys` | ✅ via column `isVisible` | ❌ | ✅ `columnApi.setColumnVisible` |
+| **Column ordering** | ✅ array order | ✅ array order | ❌ | ❌ | ✅ `columnApi.moveColumn` |
+| **Always-visible columns** | ✅ `isColumnDisabled` | ✅ `isAlwaysVisible` | ❌ | ❌ | ✅ `lockVisible` |
+| **Grouped columns** | ✅ via `groupedColumns` | ✅ via `group` on options | ❌ | ❌ | ✅ column groups |
+| **Saved views** | ✅ `viewConfiguration` | ✅ `viewConfig` (optional) | ❌ | ❌ | ❌ |
+| **Drag-and-drop reorder** | ✅ in ViewOption UI | ❌ (out of scope) | ❌ | ❌ | ✅ native |
+| **Persistence** | URL params + localStorage | Consumer-owned | ❌ | ❌ | Consumer-owned |
+| **UI component** | `XDSTableCustomColumnsDropdown` | `dropdownItems` for `XDSDropdownMenu` | Custom toggle buttons | N/A | Built-in sidebar |
+| **Headless** | ✅ | ✅ | Partially | N/A | ❌ (grid-coupled) |
+
+### Key Differentiators
+
+1. **Headless with UI helpers** — Unlike AG Grid's coupled approach, XDS OSS provides the logic headlessly with `dropdownItems` as a convenient bridge to existing UI components
+2. **Saved views** — shadcn and Mantine don't support saved view presets; XDS OSS matches WWW capability
+3. **`activeColumns()` helper** — Clean separation: the hook provides the filtered/ordered column array, the consumer passes it to the table. No magic transforms.
+4. **Grouped columns** — Column groups in the settings UI help organize large column sets
+
+---
+
+## 5. XDS Component Dependencies
+
+| Component | Path | Exists | Usage |
+|---|---|---|---|
+| `XDSDropdownMenu` | `packages/core/src/DropdownMenu/XDSDropdownMenu.tsx` | ✅ | Renders column toggle dropdown (via `dropdownItems`) |
+| `XDSCheckboxInput` | `packages/core/src/CheckboxInput/XDSCheckboxInput.tsx` | ✅ | Potential future use for checkbox-style items in dropdown |
+| `XDSText` | `packages/core/src/Text/XDSText.tsx` | ✅ | Labels in dropdown sections |
+| `XDSButton` | `packages/core/src/Button/` | ✅ | Trigger button (used by XDSDropdownMenu) |
+| `XDSIcon` | `packages/core/src/Icon/` | ✅ | Icons in dropdown trigger |
+
+**Missing (non-blocking):**
+
+| Component | Status | Impact |
+|---|---|---|
+| `XDSMultiSelector` | ❌ Does not exist | Would improve column toggle UX with proper checkbox items instead of text checkmarks. The `dropdownItems` pattern with `XDSDropdownMenu` is the interim solution. |
+| `XDSDragAndDrop` | ❌ Does not exist | Column reordering via drag-and-drop is out of scope. Consumers can implement via `activeColumnKeys` array manipulation. |
+
+**No blocking prerequisites.** All required components exist. The text-checkmark pattern in `dropdownItems` is a pragmatic solution until `XDSMultiSelector` is built.
+
+---
+
+## 6. Test Specification
+
+### Unit Tests (`useXDSTableColumnSettings.test.tsx`)
+
+#### Hook Return Value
+- `returns plugin object` — verify the plugin shape has `transformTableContext`
+- `returns activeColumns function` — verify it exists and is callable
+- `returns toggleColumn function` — verify callable
+- `returns isColumnActive function` — verify callable
+- `returns isColumnToggleable function` — verify callable
+- `returns activeColumnKeys passthrough` — verify it matches config
+- `returns views when viewConfig is provided` — verify views object shape
+- `returns undefined views when viewConfig is omitted` — verify no views
+
+#### `activeColumns` Helper
+- `filters columns to only active keys` — 5 columns, 3 active → returns 3
+- `preserves activeColumnKeys order` — keys=['c','a','b'] → columns ordered c, a, b
+- `handles unknown keys gracefully` — activeColumnKeys includes key not in columns → filtered out
+- `returns empty array for empty activeColumnKeys` — no columns shown
+- `returns all columns when all keys active` — full set
+- `maintains XDSTableColumn shape` — returned columns have key, header, renderCell, width
+
+#### `toggleColumn`
+- `removes active column` — toggles 'email' off → activeColumnKeys excludes 'email'
+- `adds inactive column` — toggles 'status' on → activeColumnKeys includes 'status'
+- `adds column at end` — newly toggled column appears last
+- `no-op for isAlwaysVisible columns` — toggling 'name' does nothing
+- `calls onChangeActiveColumnKeys with new array` — verify callback fired
+
+#### `isColumnActive`
+- `returns true for active columns` — key in activeColumnKeys
+- `returns false for inactive columns` — key not in activeColumnKeys
+
+#### `isColumnToggleable`
+- `returns true for normal columns` — no isAlwaysVisible flag
+- `returns false for always-visible columns` — isAlwaysVisible: true
+
+#### `showAllColumns`
+- `sets all column keys as active` — all keys from columns config
+- `preserves columns config order` — order matches columns array, not prior activeColumnKeys
+
+#### `resetToDefault`
+- `resets to defaultColumnKeys when viewConfig provided` — uses viewConfig.defaultColumnKeys
+- `shows all columns when no viewConfig` — falls back to showAllColumns behavior
+
+#### `dropdownItems`
+- `generates one item per column` — columns.length items for ungrouped
+- `marks active columns with checkmark prefix` — '✓ Name' vs '  Email'
+- `marks always-visible columns as disabled` — isDisabled: true
+- `each item onClick calls toggleColumn` — verify toggle fires
+- `groups columns by group field` — items with sections
+- `ungrouped columns appear after sections` — correct ordering
+
+#### Views
+- `applyView sets activeColumnKeys to view's columnKeys` — view selection works
+- `applyView no-ops for unknown view ID` — no crash
+- `createView calls onCreateView with label and current keys` — passes through
+- `deleteView calls onDeleteView with view ID` — passes through
+- `setDefaultView calls onSetDefaultView` — passes through when configured
+- `resetToDefault uses defaultColumnKeys` — resets to system defaults
+- `views.list reflects viewConfig.views` — passthrough
+
+#### Integration with XDSTable
+- `table renders only active columns` — 3 of 5 columns visible
+- `column order matches activeColumnKeys order` — visual order correct
+- `toggling column re-renders table` — column appears/disappears
+- `works alongside selection plugin` — selection checkbox column unaffected
+- `works alongside pagination plugin` — no conflicts
+
+#### Edge Cases
+- `handles empty columns config` — no items, no errors
+- `handles single column with isAlwaysVisible` — can't toggle, always shown
+- `handles all columns isAlwaysVisible` — all shown, none toggleable
+- `handles activeColumnKeys with duplicates` — deduplicated in activeColumns output
+- `memoizes dropdownItems` — reference stable when deps unchanged
+- `memoizes activeColumns callback` — reference stable when deps unchanged
+- `plugin reference is stable` — does not change across renders
+
+### Accessibility Tests
+- `dropdown trigger has aria-haspopup` — via XDSDropdownMenu
+- `dropdown items have aria-disabled for always-visible columns` — via isDisabled
+- `dropdown menu has role="menu"` — via XDSDropdownMenu
+- `keyboard navigation works in dropdown` — via XDSDropdownMenu (arrow keys, enter, escape)

--- a/packages/core/src/Table/plugins/filtering/SPEC.md
+++ b/packages/core/src/Table/plugins/filtering/SPEC.md
@@ -1,0 +1,843 @@
+# useXDSTableFiltering — Plugin Specification
+
+> **Status:** Draft · **Target:** XDS OSS · **Issue:** #978
+> **Author:** spec-generated · **Date:** 2026-03-30
+
+---
+
+## Table of Contents
+
+1. [WWW Reference Analysis](#1-www-reference-analysis)
+2. [XDS OSS Plugin API (TypeScript)](#2-xds-oss-plugin-api-typescript)
+3. [Behavioral Specification](#3-behavioral-specification)
+4. [Competitive Analysis](#4-competitive-analysis)
+5. [XDS Component Dependencies](#5-xds-component-dependencies)
+6. [Test Specification](#6-test-specification)
+
+---
+
+## 1. WWW Reference Analysis
+
+### WWW API Surface
+
+```flow
+hook useXDSTableFiltering<TColumnKey, TValue>({
+  getValue: TColumnKey => TValue | null,
+  onChange: (TColumnKey, TValue) => unknown,
+  variant?: 'default' | 'always-visible' | 'always-visible-compact',
+}): XDSTableFiltering<any, TColumnKey>
+```
+
+**Plugin integration:** Uses `transformHeaderCell` to inject filter UI into or below header cells.
+
+**Variant modes:**
+
+| Variant | Behavior |
+|---|---|
+| `'default'` | Funnel icon in header; clicking opens dropdown/popover with filter controls |
+| `'always-visible'` | Filter input rendered directly below header text (inline in header cell) |
+| `'always-visible-compact'` | Same as always-visible but with compact sizing |
+
+**Filter types (configured per-column via `filtering_EXPERIMENTAL`):**
+
+| Type | Control | Description |
+|---|---|---|
+| `'selector'` | Single-select dropdown | Pick one value from a list |
+| `'multi-selector'` | Multi-select checkboxes | Pick multiple values; optional select-all |
+| `'searchable-selector'` | Typeahead single-select | Search + pick one |
+| `'searchable-multi-selector'` | Typeahead multi-select | Search + pick multiple |
+| `'text-input'` | Free text field | Free-form text search |
+| `'number-search-input'` | Numeric field | Search by exact number |
+| `'number-min-max-input'` | Two numeric fields | Range filter (min/max) |
+| `'date-range'` | Date range picker | Temporal filter (dates) |
+| `'datetime-range'` | Datetime range picker | Temporal filter (datetime) |
+| `'time-range'` | Time range picker | Temporal filter (times) |
+
+**State management:**
+
+- Consumer provides `getValue(columnKey)` to read current filter value for a column
+- Consumer provides `onChange(columnKey, value)` to handle filter changes
+- `value` is `null` when filter is cleared
+- Filter TYPE is on the column definition, not the plugin config
+
+**Visual behaviors:**
+
+- Default variant: funnel icon in header cell; icon is accent-colored when filter has a value
+- Clicking active funnel icon calls `onChange(key, null)` to clear the filter
+- Always-visible variant: filter input rendered below header text
+- Columns without filter config: render empty placeholder in always-visible mode
+
+### XDS OSS Approach vs. WWW
+
+1. **Phase 1 scope:** Support `'text'`, `'number'`, `'number-range'`, `'selector'`, `'multi-selector'` filter types. Date/time filters deferred (XDS OSS lacks date picker component).
+2. **Typed filter values:** Each filter type has a specific TypeScript value type (string, number, range object, string[], etc.) rather than generic `TValue`.
+3. **Variant naming:** `'popover'` (instead of `'default'`) and `'inline'` (instead of `'always-visible'`). Clearer intent.
+4. **Options source:** Selector filter options provided per-column, not derived from data. Consumer controls options.
+
+---
+
+## 2. XDS OSS Plugin API (TypeScript)
+
+### Type Definitions
+
+```typescript
+// =============================================================================
+// Filter Value Types
+// =============================================================================
+
+/**
+ * Value types for each filter kind.
+ * Each filter type has a specific value shape — no generic `unknown`.
+ */
+
+/** Text filter: free-form string search */
+export type XDSTableFilterTextValue = string;
+
+/** Number filter: exact numeric match */
+export type XDSTableFilterNumberValue = number;
+
+/** Number range filter: min/max bounds (either or both may be set) */
+export interface XDSTableFilterNumberRangeValue {
+  min?: number;
+  max?: number;
+}
+
+/** Selector filter: single selected value */
+export type XDSTableFilterSelectorValue = string;
+
+/** Multi-selector filter: set of selected values */
+export type XDSTableFilterMultiSelectorValue = string[];
+
+/** Union of all filter value types */
+export type XDSTableFilterValue =
+  | XDSTableFilterTextValue
+  | XDSTableFilterNumberValue
+  | XDSTableFilterNumberRangeValue
+  | XDSTableFilterSelectorValue
+  | XDSTableFilterMultiSelectorValue;
+
+// =============================================================================
+// Filter Type Discriminated Union (per-column config)
+// =============================================================================
+
+/**
+ * Option for selector-based filters.
+ */
+export interface XDSTableFilterOption {
+  /** The value stored when this option is selected */
+  value: string;
+  /** Display label. Defaults to `value` if omitted. */
+  label?: string;
+  /** Optional icon component */
+  icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
+
+/**
+ * Text filter — free-form text input.
+ */
+export interface XDSTableFilterTypeText {
+  type: 'text';
+  /** Placeholder text for the input. @default 'Filter...' */
+  placeholder?: string;
+}
+
+/**
+ * Number filter — numeric input for exact match.
+ */
+export interface XDSTableFilterTypeNumber {
+  type: 'number';
+  /** Placeholder text. @default 'Filter...' */
+  placeholder?: string;
+  /** Minimum allowed value */
+  min?: number;
+  /** Maximum allowed value */
+  max?: number;
+  /** Step increment. @default 1 */
+  step?: number;
+}
+
+/**
+ * Number range filter — two numeric inputs for min/max bounds.
+ */
+export interface XDSTableFilterTypeNumberRange {
+  type: 'number-range';
+  /** Placeholder for min input. @default 'Min' */
+  minPlaceholder?: string;
+  /** Placeholder for max input. @default 'Max' */
+  maxPlaceholder?: string;
+  /** Minimum allowed value */
+  min?: number;
+  /** Maximum allowed value */
+  max?: number;
+  /** Step increment. @default 1 */
+  step?: number;
+}
+
+/**
+ * Selector filter — single-select dropdown.
+ */
+export interface XDSTableFilterTypeSelector {
+  type: 'selector';
+  /** Available options */
+  options: XDSTableFilterOption[];
+  /** Placeholder when no value is selected. @default 'All' */
+  placeholder?: string;
+}
+
+/**
+ * Multi-selector filter — multi-select checkboxes.
+ */
+export interface XDSTableFilterTypeMultiSelector {
+  type: 'multi-selector';
+  /** Available options */
+  options: XDSTableFilterOption[];
+  /** Show a "Select all" option. @default true */
+  hasSelectAll?: boolean;
+  /** Enable typeahead search within options. @default false */
+  isSearchable?: boolean;
+  /** Placeholder when no values are selected. @default 'All' */
+  placeholder?: string;
+}
+
+/**
+ * Discriminated union of all filter type configs.
+ */
+export type XDSTableFilterType =
+  | XDSTableFilterTypeText
+  | XDSTableFilterTypeNumber
+  | XDSTableFilterTypeNumberRange
+  | XDSTableFilterTypeSelector
+  | XDSTableFilterTypeMultiSelector;
+
+// =============================================================================
+// Column Extension
+// =============================================================================
+
+/**
+ * Added to XDSTableColumn<T> in types.ts.
+ */
+export interface XDSTableColumn<T extends Record<string, unknown>> {
+  // ... existing fields ...
+
+  /**
+   * Filter configuration for this column.
+   * Defines the filter type, options, and constraints.
+   * Omit to make the column non-filterable.
+   *
+   * @example
+   * ```
+   * // Text filter
+   * { key: 'name', header: 'Name', filter: { type: 'text' } }
+   *
+   * // Selector filter
+   * { key: 'status', header: 'Status', filter: {
+   *   type: 'selector',
+   *   options: [
+   *     { value: 'active', label: 'Active' },
+   *     { value: 'inactive', label: 'Inactive' },
+   *   ],
+   * }}
+   *
+   * // Number range filter
+   * { key: 'age', header: 'Age', filter: { type: 'number-range', min: 0, max: 120 } }
+   * ```
+   */
+  filter?: XDSTableFilterType;
+}
+
+// =============================================================================
+// Filter State Map
+// =============================================================================
+
+/**
+ * Complete filter state — a map from column key to filter value.
+ * Missing keys or `undefined` values mean "no filter applied" for that column.
+ *
+ * The value type depends on the filter type configured on the column:
+ * - `'text'` → `string`
+ * - `'number'` → `number`
+ * - `'number-range'` → `{ min?: number; max?: number }`
+ * - `'selector'` → `string`
+ * - `'multi-selector'` → `string[]`
+ *
+ * @example
+ * ```
+ * const filters: XDSTableFilterState = {
+ *   name: 'alice',                    // text filter
+ *   status: 'active',                 // selector filter
+ *   age: { min: 18, max: 65 },        // number-range filter
+ *   tags: ['admin', 'user'],          // multi-selector filter
+ * };
+ * ```
+ */
+export type XDSTableFilterState = Record<string, XDSTableFilterValue | undefined>;
+
+// =============================================================================
+// Hook Config
+// =============================================================================
+
+/**
+ * Display variant for the filter UI.
+ *
+ * - `'popover'` — filter icon in header; clicking opens a popover with the filter control
+ * - `'inline'` — filter control rendered directly below header text inside the header cell
+ * - `'inline-compact'` — same as inline but with compact-sized controls
+ */
+export type XDSTableFilterVariant = 'popover' | 'inline' | 'inline-compact';
+
+/**
+ * Configuration for useXDSTableFiltering.
+ *
+ * Follows XDS headless plugin conventions: the consumer owns all filter state
+ * and provides callbacks. The plugin never holds internal filter state.
+ *
+ * @example
+ * ```
+ * const [filters, setFilters] = useState<XDSTableFilterState>({});
+ *
+ * const filterPlugin = useXDSTableFiltering({
+ *   filters,
+ *   onFilterChange: (columnKey, value) => {
+ *     setFilters(prev => {
+ *       const next = { ...prev };
+ *       if (value == null) {
+ *         delete next[columnKey];
+ *       } else {
+ *         next[columnKey] = value;
+ *       }
+ *       return next;
+ *     });
+ *   },
+ * });
+ *
+ * <XDSTable plugins={{ filter: filterPlugin }} ... />
+ * ```
+ */
+export interface UseXDSTableFilteringConfig {
+  /**
+   * Current filter state — map from column key to filter value.
+   * Missing/undefined keys = no filter applied for that column.
+   */
+  filters: XDSTableFilterState;
+
+  /**
+   * Called when the user changes a filter value.
+   *
+   * @param columnKey - The column key whose filter changed
+   * @param value - The new filter value, or `null` to clear the filter
+   */
+  onFilterChange: (columnKey: string, value: XDSTableFilterValue | null) => void;
+
+  /**
+   * Display variant for filter controls.
+   *
+   * - `'popover'` — icon button in header; filter opens in popover (default)
+   * - `'inline'` — filter rendered below header text directly in the cell
+   * - `'inline-compact'` — inline with compact-sized controls
+   *
+   * @default 'popover'
+   */
+  variant?: XDSTableFilterVariant;
+}
+```
+
+### Hook Signature
+
+```typescript
+/**
+ * useXDSTableFiltering — table plugin for column filtering.
+ *
+ * Returns a stable TablePlugin<T> that transforms header cells to add
+ * filter controls. Follows the headless pattern: consumer owns filter state,
+ * plugin provides UI and interaction.
+ *
+ * Filter types are configured per-column via the `filter` field on
+ * XDSTableColumn<T>. The plugin reads filter config from columns and
+ * renders the appropriate control (text input, selector, etc.).
+ *
+ * @template T - Row data type
+ *
+ * @example
+ * ```
+ * const [filters, setFilters] = useState<XDSTableFilterState>({});
+ *
+ * const filterPlugin = useXDSTableFiltering({
+ *   filters,
+ *   onFilterChange: (key, value) => {
+ *     setFilters(prev => ({
+ *       ...prev,
+ *       [key]: value ?? undefined,
+ *     }));
+ *   },
+ *   variant: 'popover',
+ * });
+ *
+ * <XDSTable
+ *   data={users}
+ *   columns={[
+ *     { key: 'name', header: 'Name', filter: { type: 'text' } },
+ *     { key: 'status', header: 'Status', filter: {
+ *       type: 'selector',
+ *       options: [{ value: 'active' }, { value: 'inactive' }],
+ *     }},
+ *     { key: 'age', header: 'Age', filter: { type: 'number-range', min: 0 } },
+ *   ]}
+ *   plugins={{ filter: filterPlugin }}
+ * />
+ * ```
+ */
+export function useXDSTableFiltering<
+  T extends Record<string, unknown>,
+>(
+  config: UseXDSTableFilteringConfig,
+): TablePlugin<T>;
+```
+
+### Plugin Transform Strategy
+
+| Transform Method | Used? | Purpose |
+|---|---|---|
+| `transformTable` | No | — |
+| `transformHeaderRow` | No | — |
+| `transformHeaderCell` | **Yes** | Injects filter UI (icon/popover or inline controls) into header cells |
+| `transformBodyRow` | No | — |
+| `transformBodyCell` | No | — |
+| `transformTableContext` | **Yes** | Provides filter context so popover filter components can read config without prop drilling |
+
+**Why `transformTableContext`?** The popover variant renders filter controls inside a `<XDSPopover>`. These popover-rendered components need access to `filters` state and `onFilterChange` callback. Rather than closing over stale config, a context provider (backed by a ref, as in the selection plugin) ensures filter components always read the latest config.
+
+### Internal Architecture
+
+```
+useXDSTableFiltering(config)
+  │
+  ├── configRef ← useRef(config)          // Always-fresh config
+  │
+  ├── filterStoreRef ← useRef(store)      // External store for popover components
+  │
+  └── useMemo(() => plugin, [store])      // Stable plugin object
+        │
+        ├── transformTableContext(children)
+        │     └── <FilterStoreContext.Provider value={store}>
+        │           {children}
+        │         </FilterStoreContext.Provider>
+        │
+        └── transformHeaderCell(props, column)
+              │
+              ├── column.filter undefined? → return props unchanged
+              │     (except in inline variant: render empty placeholder div)
+              │
+              ├── Read filter value: configRef.current.filters[column.key]
+              │
+              ├── variant === 'popover'?
+              │     └── Inject filter icon button after header content
+              │         ├── No active filter → muted funnel icon
+              │         ├── Active filter → accent funnel icon (click to clear)
+              │         └── Click muted icon → open popover with filter control
+              │
+              └── variant === 'inline' | 'inline-compact'?
+                    └── Append filter control below header content
+                        └── <div> with appropriate filter component
+```
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Popover Variant (`variant: 'popover'`)
+
+#### Filter icon — no active filter
+
+- **Trigger:** Column has `filter` config, `filters[column.key]` is `undefined`/missing.
+- **Render:** Muted funnel icon (`color="secondary"`) after header text. Icon visible on hover.
+- **Click:** Opens popover anchored to the header cell with the filter control inside.
+- **Accessibility:** `<button aria-label="Filter {header}" aria-haspopup="dialog">`.
+
+#### Filter icon — active filter
+
+- **Trigger:** Column has `filter` config, `filters[column.key]` has a value.
+- **Render:** Accent-colored funnel icon (`color="accent"`) — always visible (not just hover).
+- **Click:** Clears the filter by calling `onFilterChange(column.key, null)`.
+- **Accessibility:** `<button aria-label="Clear filter for {header}">`.
+
+#### Popover content
+
+- **Trigger:** Click on muted funnel icon (no active filter) or long-press/right-click on active icon (TBD — initial implementation: click inactive icon only).
+- **Render:** `<XDSPopover>` positioned below the header cell, containing the appropriate filter control based on `column.filter.type`.
+- **Dismiss:** Click outside, Escape key, or applying a filter value.
+- **Accessibility:** `role="dialog"`, `aria-label="Filter {header}"`, focus trapped within popover.
+
+### 3.2 Inline Variant (`variant: 'inline'` or `'inline-compact'`)
+
+#### Filter control — below header text
+
+- **Trigger:** Column has `filter` config.
+- **Render:** Filter control rendered directly below the header text inside the `<th>`. Header cell layout becomes vertical (flex-direction: column).
+- **Compact:** `'inline-compact'` uses `size="sm"` on all input components.
+- **Accessibility:** Input has `aria-label="Filter {header}"`.
+
+#### Non-filterable column in inline mode
+
+- **Trigger:** Column has no `filter` config, variant is `'inline'` or `'inline-compact'`.
+- **Render:** Empty placeholder `<div>` with matching height to keep headers aligned.
+- **Accessibility:** Placeholder is `aria-hidden="true"`.
+
+### 3.3 Filter Controls by Type
+
+#### `'text'` filter
+
+- **Component:** `XDSTextInput`
+- **Props:** `label="Filter {header}"`, `isLabelHidden`, `value={filters[key] ?? ''}`, `placeholder`, `size` (sm for compact, md for inline, sm for popover), `startIcon={searchIcon}`.
+- **Behavior:** Calls `onFilterChange(key, value)` on every keystroke. Calls `onFilterChange(key, null)` when cleared to empty string.
+- **Debounce:** Not built into plugin. Consumer can debounce in `onFilterChange` if needed.
+
+#### `'number'` filter
+
+- **Component:** `XDSNumberInput`
+- **Props:** `label="Filter {header}"`, `isLabelHidden`, `value={filters[key] ?? null}`, `placeholder`, `min`, `max`, `step`, `size`.
+- **Behavior:** Calls `onFilterChange(key, value)` on valid number input. Calls `onFilterChange(key, null)` when cleared.
+
+#### `'number-range'` filter
+
+- **Components:** Two `XDSNumberInput` side by side.
+- **Layout:** `display: flex; gap: spacing-2`. Labels: "Min" and "Max" (hidden, used as aria-labels).
+- **Behavior:** Calls `onFilterChange(key, { min, max })` when either input changes. If both are empty, calls `onFilterChange(key, null)`.
+
+#### `'selector'` filter
+
+- **Component:** `XDSSelector`
+- **Props:** `label="Filter {header}"`, `isLabelHidden`, `options`, `value={filters[key] ?? ''}`, `placeholder`, `size`.
+- **Behavior:** Calls `onFilterChange(key, selectedValue)` on selection. Selecting placeholder/empty calls `onFilterChange(key, null)`.
+
+#### `'multi-selector'` filter
+
+- **Component:** Custom multi-select built with `XDSPopover` + `XDSCheckboxInput` list.
+- **Reason:** `XDSSelector` is single-select only. Multi-select requires a custom control.
+- **Layout:**
+  - Trigger: button showing selected count or "All" (e.g., "3 selected").
+  - Popover content: optional search input (if `isSearchable`), optional "Select all" checkbox (if `hasSelectAll`), list of `XDSCheckboxInput` for each option.
+- **Behavior:**
+  - Toggling checkbox adds/removes value from array.
+  - "Select all" toggles all options on/off.
+  - Search filters the visible options (does not affect selection).
+  - Calls `onFilterChange(key, selectedValues)` on every toggle. Empty array calls `onFilterChange(key, null)`.
+- **Accessibility:** Trigger has `aria-haspopup="dialog"`. Popover has `role="dialog"` with `aria-label="Filter {header}"`. Checkboxes are standard form controls.
+
+### 3.4 Header Cell DOM Structure
+
+#### Popover variant — inactive filter
+
+```html
+<th scope="col">
+  <div class="xds-filter-header" style="display: flex; align-items: center; justify-content: space-between;">
+    <span>Name</span>
+    <button
+      type="button"
+      class="xds-filter-trigger"
+      aria-label="Filter Name"
+      aria-haspopup="dialog"
+    >
+      <XDSIcon icon={funnelIcon} size="xsm" color="secondary" />
+    </button>
+  </div>
+</th>
+```
+
+#### Popover variant — active filter
+
+```html
+<th scope="col">
+  <div class="xds-filter-header" style="display: flex; align-items: center; justify-content: space-between;">
+    <span>Name</span>
+    <button
+      type="button"
+      class="xds-filter-trigger"
+      aria-label="Clear filter for Name"
+    >
+      <XDSIcon icon={funnelIcon} size="xsm" color="accent" />
+    </button>
+  </div>
+</th>
+```
+
+#### Inline variant
+
+```html
+<th scope="col">
+  <div class="xds-filter-header-inline" style="display: flex; flex-direction: column; gap: 4px;">
+    <span>Name</span>
+    <XDSTextInput
+      label="Filter Name"
+      isLabelHidden
+      value="alice"
+      placeholder="Filter..."
+      size="sm"
+    />
+  </div>
+</th>
+```
+
+#### Inline variant — non-filterable column placeholder
+
+```html
+<th scope="col">
+  <div class="xds-filter-header-inline" style="display: flex; flex-direction: column; gap: 4px;">
+    <span>Avatar</span>
+    <div class="xds-filter-placeholder" aria-hidden="true" style="height: 32px;" />
+  </div>
+</th>
+```
+
+### 3.5 Styling Details
+
+**Popover variant filter icon button:**
+
+- No visible button chrome (transparent background, no border)
+- `cursor: pointer`
+- `display: inline-flex; align-items: center; justify-content: center`
+- `padding: spacing-1` (small clickable area)
+- Inactive: icon visible on header hover only (`opacity: 0` → `opacity: 1` on `th:hover`)
+- Active: icon always visible
+- Focus-visible: standard XDS focus ring
+
+**Inline variant header cell:**
+
+- `display: flex; flex-direction: column; gap: spacing-1`
+- Filter control takes full width of header cell
+- Compact variant: inputs use `size="sm"`; standard inline: inputs use `size="md"`
+
+**Popover content:**
+
+- `width: 240px` (default, overridable via future config)
+- `padding: spacing-3`
+- Contains a single filter control, no title/header (column name is context enough)
+- For multi-selector: list is scrollable if >8 options, `max-height: 320px`
+
+### 3.6 Interaction with Sort Plugin
+
+When both `sortable` and `filter` plugins are active on the same column:
+
+**Popover variant:** Sort button wraps header text. Filter icon button is adjacent (after the sort icon). DOM order: `[sort-button: [header-text, sort-icon], filter-icon-button]`.
+
+**Inline variant:** Sort button wraps header text (top). Filter control is below. DOM order: `[sort-button: [header-text, sort-icon], filter-control]`.
+
+**Plugin composition:** The sort plugin transforms first (it's registered first in the plugins record). The filter plugin then receives the already-transformed header cell props and wraps/appends to the existing children. This works because `transformHeaderCell` receives the current `props` (including children from prior plugins) and can wrap/augment them.
+
+**Recommendation:** Document recommended plugin registration order: `{ sort: sortPlugin, filter: filterPlugin }`. Sort transforms header content (wraps in button), filter adds adjacent/below controls.
+
+### 3.7 Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| No columns have `filter` config | Plugin is a no-op in popover mode; renders empty placeholders in inline mode (for alignment) |
+| `filters` has key not matching any column | Ignored — no visual indicator. State is preserved. |
+| Column removed but filter state persists | No crash. Consumer should clean up state. |
+| All filter values are empty/undefined | No active filter indicators. All icons muted (popover) or inputs empty (inline). |
+| `filters` has wrong value type for column's filter type | Best-effort rendering. Type mismatch may cause input to show unexpected value. Consumer responsibility to match types. |
+| Popover variant with empty options for selector | Selector shows placeholder only. No options to select. |
+| Multi-selector with all options selected | "Select all" checkbox shows checked. Trigger button shows "All" or full count. |
+| Multi-selector with `isSearchable` + search query | Only matching options visible in list. Selection state of hidden options preserved. |
+| Inline variant with very long filter placeholder | Text truncated with ellipsis (input has `overflow: hidden; text-overflow: ellipsis`). |
+| data is empty or undefined | Filter controls still render in headers. |
+
+---
+
+## 4. Competitive Analysis
+
+### Comparison Matrix
+
+| Feature | WWW XDS | XDS OSS (this spec) | TanStack Table | Mantine DataTable | AG Grid |
+|---|---|---|---|---|---|
+| **Filter types** | 10 types | 5 types (Phase 1) | Custom (user-defined) | Text only | 20+ built-in |
+| **Display modes** | 3 variants | 3 variants | N/A (headless) | Header only | Header + sidebar |
+| **State ownership** | External | External | Internal (managed) | Internal | Internal |
+| **Plugin architecture** | Transform pipeline | Transform pipeline | Feature system | Monolithic | Monolithic |
+| **Multi-select filter** | ✅ | ✅ | User-defined | ❌ | ✅ |
+| **Searchable filter** | ✅ | ✅ (multi-selector) | User-defined | ❌ | ✅ |
+| **Number range** | ✅ | ✅ | User-defined | ❌ | ✅ |
+| **Date filters** | ✅ | ❌ (Phase 2) | User-defined | ❌ | ✅ |
+| **Active filter indicator** | Funnel icon | Funnel icon | N/A | N/A | Icon + badge |
+| **Clear individual filter** | Click icon | Click icon | User-defined | Clear button | Click icon |
+| **Typed filter values** | Generic TValue | Discriminated union | Generic | string | Internal |
+
+### Key Differentiators
+
+**vs. TanStack Table:**
+TanStack is headless — it provides sort/filter *state management* but no UI. Consumers must build all filter inputs from scratch. XDS OSS provides both the headless state model AND ready-made filter controls via the plugin. This is a higher-level abstraction: declare `filter: { type: 'selector', options }` on a column, and the plugin renders the entire filter UI.
+
+**vs. Mantine DataTable:**
+Mantine only supports basic text filtering via `textFilter` prop. No multi-select, no number range, no popover variant. XDS provides 5 filter types with 3 display variants.
+
+**vs. AG Grid:**
+AG Grid has the most comprehensive filtering (20+ filter types, floating filters, filter sidebar). However, it's a monolithic component with a large bundle. XDS achieves the most common filter patterns through a lightweight plugin that tree-shakes unused filter types.
+
+**vs. WWW XDS:**
+WWW has more filter types (date ranges, datetime, time) but uses generic `TValue`. XDS OSS uses discriminated union types for type safety — each filter type has a specific value shape. The `'popover'` / `'inline'` naming is clearer than `'default'` / `'always-visible'`.
+
+**XDS OSS advantage:** Composable plugin architecture where filtering, sorting, and selection are independent plugins. Each plugin only touches `transformHeaderCell` (and optionally `transformTableContext`), so they compose cleanly. Type-safe filter values via discriminated unions prevent runtime type mismatches.
+
+---
+
+## 5. XDS Component Dependencies
+
+### Required Components
+
+| Component | Import | Usage | Props Used |
+|---|---|---|---|
+| `XDSIcon` | `@xds/core` | Filter indicator (funnel icon) | `icon`, `size="xsm"`, `color="secondary"\|"accent"` |
+| `XDSPopover` | `@xds/core` | Popover variant filter container | `content`, `placement="below"`, `alignment="start"`, `label`, `width` |
+| `XDSTextInput` | `@xds/core` | Text filter control | `label`, `isLabelHidden`, `value`, `onChange`, `placeholder`, `size`, `startIcon` |
+| `XDSNumberInput` | `@xds/core` | Number and number-range filter controls | `label`, `isLabelHidden`, `value`, `onChange`, `placeholder`, `min`, `max`, `step`, `size` |
+| `XDSSelector` | `@xds/core` | Selector (single-select) filter control | `label`, `isLabelHidden`, `options`, `value`, `onChange`, `placeholder`, `size` |
+| `XDSCheckboxInput` | `@xds/core` | Multi-selector filter option checkboxes | `label`, `value` (boolean), `onChange`, `size="sm"` |
+| `XDSButton` | `@xds/core` | Multi-selector trigger button (shows count) | `label`, `variant="secondary"`, `size`, `endContent` (chevron icon) |
+
+### Required Icons
+
+| Icon | Purpose | Status |
+|---|---|---|
+| Funnel / Filter | Filter indicator in popover variant | **MISSING** — needs to be added to XDS icon set |
+| Search | `startIcon` for text filter and searchable multi-selector | **EXISTS** — `'search'` in XDSIconName registry |
+
+**Recommendation:** Add `'funnel'` (or `'filter'`) to the XDS icon registry. This is a standard UI icon used widely for filter affordances. Bundle as private SVG if adding to the public icon set is not desired.
+
+### Required Theme Tokens
+
+| Token | Source | Usage |
+|---|---|---|
+| `spacingVars['--spacing-1']` | `theme/tokens.stylex` | Gap in header layout, icon button padding |
+| `spacingVars['--spacing-2']` | `theme/tokens.stylex` | Number-range input gap |
+| `spacingVars['--spacing-3']` | `theme/tokens.stylex` | Popover content padding |
+| `colorVars['--color-text-secondary']` | `theme/tokens.stylex` | Inactive filter icon color |
+| `colorVars['--color-accent']` | `theme/tokens.stylex` | Active filter icon color |
+
+### Missing Prerequisites
+
+| Prerequisite | Impact | Mitigation |
+|---|---|---|
+| Funnel/filter icon SVG | Blocker for popover variant | Add to icon set or bundle privately |
+| Multi-select component | Multi-selector filter needs custom implementation | Build within plugin using XDSPopover + XDSCheckboxInput |
+| Sort icon SVGs (arrowUp, arrowDown, arrowUpDown) | Blocker for sort plugin (co-dependency) | See sortable SPEC.md §5 |
+
+### Component Availability Verification
+
+All components listed above exist in `packages/core/src/`:
+
+- `XDSIcon` — ✅ verified at `Icon/XDSIcon.tsx`
+- `XDSPopover` — ✅ verified at `Popover/XDSPopover.tsx`
+- `XDSTextInput` — ✅ verified at `TextInput/XDSTextInput.tsx`
+- `XDSNumberInput` — ✅ verified at `NumberInput/XDSNumberInput.tsx`
+- `XDSSelector` — ✅ verified at `Selector/XDSSelector.tsx` (single-select only)
+- `XDSCheckboxInput` — ✅ verified at `CheckboxInput/XDSCheckboxInput.tsx`
+- `XDSButton` — ✅ verified at `Button/XDSButton.tsx`
+
+---
+
+## 6. Test Specification
+
+### Rendering Tests — Popover Variant
+
+| Test | What It Verifies |
+|---|---|
+| `renders filter icon for filterable columns (popover)` | Filterable columns show funnel icon; non-filterable do not |
+| `renders muted icon when no active filter` | Inactive funnel icon uses secondary color |
+| `renders accent icon when filter has value` | Active funnel icon uses accent color |
+| `does not render filter UI for columns without filter config` | Non-filterable columns unchanged |
+| `renders filter icons when data is empty` | Headers show filter UI with empty/undefined data |
+
+### Rendering Tests — Inline Variant
+
+| Test | What It Verifies |
+|---|---|
+| `renders text input below header for text filter (inline)` | XDSTextInput appears below header text |
+| `renders selector below header for selector filter (inline)` | XDSSelector appears below header text |
+| `renders number input below header for number filter (inline)` | XDSNumberInput appears below header text |
+| `renders two number inputs for number-range filter (inline)` | Min and max XDSNumberInput rendered side by side |
+| `renders placeholder for non-filterable columns (inline)` | Empty div with matching height rendered for alignment |
+| `uses compact size for inline-compact variant` | Filter controls use size="sm" |
+
+### Rendering Tests — Filter Controls
+
+| Test | What It Verifies |
+|---|---|
+| `text filter shows current value from filters state` | XDSTextInput value matches `filters[key]` |
+| `number filter shows current value from filters state` | XDSNumberInput value matches `filters[key]` |
+| `number-range filter shows min and max from filters state` | Both inputs match `filters[key].min` and `filters[key].max` |
+| `selector filter shows selected value from filters state` | XDSSelector value matches `filters[key]` |
+| `multi-selector shows selected count on trigger` | Button shows "N selected" based on `filters[key].length` |
+
+### Interaction Tests — Popover Variant
+
+| Test | What It Verifies |
+|---|---|
+| `clicking inactive filter icon opens popover` | Popover with filter control appears |
+| `clicking active filter icon clears filter` | `onFilterChange(key, null)` called |
+| `popover closes on Escape` | Popover dismissed, focus returns to icon |
+| `popover closes on click outside` | Popover dismissed |
+
+### Interaction Tests — Text Filter
+
+| Test | What It Verifies |
+|---|---|
+| `typing in text filter calls onFilterChange` | Each keystroke calls `onFilterChange(key, value)` |
+| `clearing text filter calls onFilterChange with null` | Empty string → `onFilterChange(key, null)` |
+
+### Interaction Tests — Number Filter
+
+| Test | What It Verifies |
+|---|---|
+| `entering number calls onFilterChange` | Valid number → `onFilterChange(key, number)` |
+| `clearing number filter calls onFilterChange with null` | Empty → `onFilterChange(key, null)` |
+| `respects min/max constraints` | Input constrained to configured bounds |
+
+### Interaction Tests — Number Range Filter
+
+| Test | What It Verifies |
+|---|---|
+| `changing min calls onFilterChange with updated range` | `onFilterChange(key, { min: newMin, max: existingMax })` |
+| `changing max calls onFilterChange with updated range` | `onFilterChange(key, { min: existingMin, max: newMax })` |
+| `clearing both inputs calls onFilterChange with null` | Both empty → `onFilterChange(key, null)` |
+
+### Interaction Tests — Selector Filter
+
+| Test | What It Verifies |
+|---|---|
+| `selecting option calls onFilterChange` | `onFilterChange(key, selectedValue)` |
+| `selecting placeholder/empty clears filter` | `onFilterChange(key, null)` |
+
+### Interaction Tests — Multi-Selector Filter
+
+| Test | What It Verifies |
+|---|---|
+| `toggling checkbox adds value to selection` | `onFilterChange(key, [...existing, newValue])` |
+| `toggling checkbox removes value from selection` | `onFilterChange(key, existing.filter(...))` |
+| `select all checks all options` | `onFilterChange(key, allValues)` |
+| `deselect all unchecks all options` | `onFilterChange(key, null)` |
+| `search filters visible options but preserves selection` | Hidden options remain in `filters[key]` |
+| `clearing all values calls onFilterChange with null` | Empty array → `onFilterChange(key, null)` |
+
+### Accessibility Tests
+
+| Test | What It Verifies |
+|---|---|
+| `filter icon button has aria-label (popover)` | `aria-label="Filter {header}"` on inactive; `"Clear filter for {header}"` on active |
+| `filter icon button has aria-haspopup (popover)` | `aria-haspopup="dialog"` on inactive filter button |
+| `popover has role="dialog" and aria-label` | Correct dialog semantics |
+| `inline filter input has aria-label` | `aria-label="Filter {header}"` |
+| `placeholder div is aria-hidden (inline)` | Non-filterable column placeholder has `aria-hidden="true"` |
+| `focus trapped in popover when open` | Tab cycles within popover content |
+| `Escape closes popover and returns focus` | Focus returns to trigger button |
+| `filter controls are keyboard accessible` | Tab into inline filters; Enter/Space on selector options |
+
+### Edge Case Tests
+
+| Test | What It Verifies |
+|---|---|
+| `handles filters state with key not matching any column` | No crash; unmatched key ignored |
+| `handles empty filters state` | All filter controls show empty/default state |
+| `plugin object is referentially stable across renders` | useMemo returns same object when config changes |
+| `works with no filterable columns` | Plugin is no-op (popover) or renders only placeholders (inline) |
+| `composes correctly with sort plugin` | Both sort and filter UI appear on same column |
+| `works when column.filter.options is empty array` | Selector renders with placeholder only |
+| `multi-selector with hasSelectAll=false hides select all` | No select all checkbox rendered |
+| `inline variant header cells align vertically` | All headers same height regardless of filter presence |

--- a/packages/core/src/Table/plugins/pagination/SPEC.md
+++ b/packages/core/src/Table/plugins/pagination/SPEC.md
@@ -1,0 +1,523 @@
+# useXDSTablePagination — Plugin Specification
+
+> **Status:** Draft
+> **Issue:** #978
+> **Author:** spec-page-cols
+> **Date:** 2026-03-30
+
+---
+
+## 1. WWW Reference Analysis
+
+### WWW API Surface
+
+In WWW, pagination is a **prop** on `XDSTable`, not a plugin:
+
+```flow
+pagination?: XDSTablePagination (= WebTablePaginationConfig)
+```
+
+The table renders pagination controls internally when this prop is provided. The config object contains:
+
+- `page` / `onPageChange` — current page and callback
+- `pageSize` / `onPageSizeChange` — items per page and callback
+- `totalItems` — total count for calculating page range
+- `variant` — display style ('pages' | 'count' | 'compact')
+
+**State flow in WWW:**
+1. Consumer passes `pagination` prop to `XDSTable`
+2. Table internally slices `data` to `data.slice(start, end)` for the current page
+3. Table renders `<XDSPagination>` below the `<table>` element
+4. User clicks next/prev → `onPageChange` fires → consumer updates state → table re-renders with new slice
+
+**Key observations:**
+- WWW couples pagination to the table — it's not composable with other layouts
+- The table owns data slicing logic
+- Pagination controls are always rendered below the table
+- No support for server-side pagination where the consumer controls data fetching
+
+### Design Decision: Plugin vs. Prop
+
+#### Option A: Prop (like WWW)
+
+```tsx
+<XDSTable pagination={{ page, onPageChange, totalItems, pageSize }} ... />
+```
+
+**Pros:**
+- Matches WWW API — easier migration
+- Single declaration point — less boilerplate
+- Table can own data slicing internally
+
+**Cons:**
+- Not composable — pagination is locked to the table's render tree
+- Can't place pagination controls elsewhere (e.g., in a toolbar above the table)
+- Breaks the plugin architecture pattern
+- Mixes data concerns (slicing) with display concerns (controls)
+
+#### Option B: Plugin (recommended) ✅
+
+```tsx
+const pagination = useXDSTablePagination({ page, onChange, totalItems, pageSize });
+<XDSTable plugins={{ pagination: pagination.plugin }} data={pagination.paginatedData(data)} ... />
+<XDSPagination {...pagination.paginationProps} />
+```
+
+**Pros:**
+- Composable — pagination controls can be placed anywhere
+- Follows established plugin pattern (like `useXDSTableSelection`)
+- Separation of concerns — consumer controls data slicing
+- Works for both client-side (full data) and server-side (pre-sliced data) pagination
+- Plugin can still use `transformTableContext` to render controls in a default position
+
+**Cons:**
+- More boilerplate than a single prop
+- Consumer must wire up `paginatedData()` or handle slicing themselves
+
+#### Recommendation: **Plugin (Option B)**
+
+The plugin approach is more aligned with XDS OSS's composable architecture. The slight verbosity is offset by flexibility. A convenience `<XDSTableWithPagination>` wrapper could be added later if demand warrants it.
+
+---
+
+## 2. XDS OSS Plugin API (TypeScript)
+
+### Config Interface
+
+```typescript
+/**
+ * Configuration for useXDSTablePagination.
+ *
+ * Headless pagination state management for XDSTable. The consumer owns all
+ * state — this hook provides data helpers and a plugin that integrates with
+ * the table's plugin pipeline.
+ *
+ * @template T - The row data type
+ *
+ * @example Basic client-side pagination
+ * ```
+ * const [page, setPage] = useState(1);
+ * const [pageSize, setPageSize] = useState(20);
+ *
+ * const pagination = useXDSTablePagination({
+ *   page,
+ *   onPageChange: setPage,
+ *   totalItems: data.length,
+ *   pageSize,
+ * });
+ *
+ * <XDSTable
+ *   data={pagination.paginatedData(data)}
+ *   columns={columns}
+ *   plugins={{ pagination: pagination.plugin }}
+ * />
+ * <XDSPagination {...pagination.paginationProps} />
+ * ```
+ *
+ * @example Server-side pagination
+ * ```
+ * const pagination = useXDSTablePagination({
+ *   page,
+ *   onPageChange: (p) => fetchPage(p),
+ *   totalItems: serverTotal,
+ *   pageSize: 25,
+ * });
+ *
+ * // Data is already sliced by the server — don't use paginatedData()
+ * <XDSTable
+ *   data={serverData}
+ *   columns={columns}
+ *   plugins={{ pagination: pagination.plugin }}
+ * />
+ * <XDSPagination {...pagination.paginationProps} />
+ * ```
+ *
+ * @example With page size selector
+ * ```
+ * const pagination = useXDSTablePagination({
+ *   page,
+ *   onPageChange: setPage,
+ *   totalItems: data.length,
+ *   pageSize,
+ *   onPageSizeChange: setPageSize,
+ *   pageSizeOptions: [10, 25, 50, 100],
+ * });
+ * ```
+ *
+ * @example Cursor-based (infinite) pagination
+ * ```
+ * const pagination = useXDSTablePagination({
+ *   page,
+ *   onPageChange: setPage,
+ *   hasMore: cursor != null,
+ *   pageSize: 20,
+ * });
+ * ```
+ */
+export interface UseXDSTablePaginationConfig {
+  // --- Core (required) ---
+
+  /** Current page number (1-based). */
+  page: number;
+
+  /** Called when the page changes. Consumer updates their own state. */
+  onPageChange: (page: number) => void;
+
+  // --- Data shape (provide one) ---
+
+  /**
+   * Total number of items across all pages.
+   * Used to calculate total page count and "X–Y of Z" display.
+   * Takes precedence over `totalPages` if both are provided.
+   */
+  totalItems?: number;
+
+  /**
+   * Total number of pages. Use when you know the page count but not item count.
+   */
+  totalPages?: number;
+
+  /**
+   * Whether more pages exist after the current one.
+   * Use for cursor-based pagination where the total is unknown.
+   * Mutually exclusive with totalItems/totalPages.
+   */
+  hasMore?: boolean;
+
+  // --- Page size ---
+
+  /**
+   * Number of items per page.
+   * @default 10
+   */
+  pageSize?: number;
+
+  /**
+   * Called when the user changes the page size via the page size selector.
+   * When provided alongside `pageSizeOptions`, a page size dropdown is shown.
+   */
+  onPageSizeChange?: (pageSize: number) => void;
+
+  /**
+   * Available page size options. Shows a page size selector when provided.
+   * @example [10, 25, 50, 100]
+   */
+  pageSizeOptions?: number[];
+
+  // --- Display ---
+
+  /**
+   * Visual variant for the pagination controls.
+   * Passed through to XDSPagination.
+   * @default 'pages'
+   */
+  variant?: 'pages' | 'count' | 'compact' | 'dots' | 'none';
+
+  /**
+   * Size of the pagination controls.
+   * @default 'md'
+   */
+  size?: 'sm' | 'md';
+
+  /**
+   * Where to render the pagination controls relative to the table.
+   * - 'below' — renders pagination after the table (default)
+   * - 'above' — renders pagination before the table
+   * - 'both' — renders pagination above and below the table
+   * - 'none' — does not auto-render; use `paginationProps` manually
+   *
+   * Only applies when using the plugin's `transformTableContext`.
+   * @default 'below'
+   */
+  position?: 'below' | 'above' | 'both' | 'none';
+
+  // --- Accessibility ---
+
+  /**
+   * Accessible label for the pagination nav landmark.
+   * @default 'Table pagination'
+   */
+  label?: string;
+}
+```
+
+### Return Type
+
+```typescript
+/**
+ * Return value of useXDSTablePagination.
+ */
+export interface UseXDSTablePaginationReturn<T extends Record<string, unknown>> {
+  /** The TablePlugin to pass to XDSTable's plugins prop. */
+  plugin: TablePlugin<T>;
+
+  /**
+   * Props to spread onto an XDSPagination component.
+   * Use this when `position` is 'none' and you want to render
+   * pagination controls in a custom location.
+   *
+   * @example
+   * ```
+   * <div className="toolbar">
+   *   <XDSPagination {...pagination.paginationProps} />
+   * </div>
+   * ```
+   */
+  paginationProps: XDSPaginationProps;
+
+  /**
+   * Slices the full data array for the current page.
+   * Use for client-side pagination where you have all the data.
+   * For server-side pagination (data already sliced), pass data directly.
+   *
+   * @example
+   * ```
+   * <XDSTable data={pagination.paginatedData(allData)} ... />
+   * ```
+   */
+  paginatedData: (data: T[]) => T[];
+
+  /** Current page number (1-based). */
+  page: number;
+
+  /** Computed total number of pages (undefined for cursor-based). */
+  totalPages: number | undefined;
+
+  /** Current page size. */
+  pageSize: number;
+}
+```
+
+### Plugin Transform Methods Used
+
+| Transform Method | Used | Purpose |
+|---|---|---|
+| `transformTable` | No | — |
+| `transformHeaderRow` | No | — |
+| `transformHeaderCell` | No | — |
+| `transformBodyRow` | No | — |
+| `transformBodyCell` | No | — |
+| `transformTableContext` | **Yes** | Wraps the table with pagination controls above/below based on `position` config |
+
+### Implementation Skeleton
+
+```typescript
+export function useXDSTablePagination<T extends Record<string, unknown>>(
+  config: UseXDSTablePaginationConfig,
+): UseXDSTablePaginationReturn<T> {
+  const {
+    page,
+    onPageChange,
+    totalItems,
+    totalPages: totalPagesProp,
+    hasMore,
+    pageSize = 10,
+    onPageSizeChange,
+    pageSizeOptions,
+    variant = 'pages',
+    size = 'md',
+    position = 'below',
+    label = 'Table pagination',
+  } = config;
+
+  const computedTotalPages = totalPagesProp ??
+    (totalItems != null ? Math.ceil(totalItems / pageSize) : undefined);
+
+  // Build XDSPagination props from config
+  const paginationProps: XDSPaginationProps = {
+    page,
+    onChange: onPageChange,
+    totalItems,
+    totalPages: computedTotalPages,
+    hasMore,
+    pageSize,
+    onPageSizeChange,
+    pageSizeOptions,
+    variant,
+    size,
+    label,
+  };
+
+  // Client-side data slicing helper
+  const paginatedData = useCallback((data: T[]): T[] => {
+    const start = (page - 1) * pageSize;
+    return data.slice(start, start + pageSize);
+  }, [page, pageSize]);
+
+  // Stable plugin via useMemo
+  const plugin = useMemo((): TablePlugin<T> => ({
+    transformTableContext(children: ReactNode) {
+      if (position === 'none') return children;
+
+      const paginationElement = <XDSPagination {...paginationProps} />;
+
+      return (
+        <>
+          {(position === 'above' || position === 'both') && paginationElement}
+          {children}
+          {(position === 'below' || position === 'both') && paginationElement}
+        </>
+      );
+    },
+  }), [/* deps: paginationProps, position */]);
+
+  return { plugin, paginationProps, paginatedData, page, totalPages: computedTotalPages, pageSize };
+}
+```
+
+> **Note:** The plugin reference will change when pagination state changes. This is acceptable because pagination state changes require a full table re-render anyway (new data slice). This differs from the selection plugin, which needs a stable reference to avoid re-rendering all rows.
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Page Navigation
+
+| Trigger | Render | Accessibility | Edge Cases |
+|---|---|---|---|
+| User clicks page number button | Table re-renders with new data slice; active page button shows `variant='primary'` | `aria-current="page"` on active button; `aria-label="Go to page N"` | No-op if clicking current page |
+| User clicks "Previous" | Navigates to `page - 1` | `aria-label="Go to previous page"` | Button disabled when `page === 1` |
+| User clicks "Next" | Navigates to `page + 1` | `aria-label="Go to next page"` | Button disabled when `page === totalPages` or `hasMore === false` |
+| User clicks ellipsis | No action (decorative) | `aria-hidden="true"` | — |
+
+### 3.2 Page Size Change
+
+| Trigger | Render | Accessibility | Edge Cases |
+|---|---|---|---|
+| User selects new page size from dropdown | `onPageSizeChange` fires; page resets to 1; table re-renders | `aria-label="Items per page"` on selector (hidden label) | If current page would exceed new total, reset to page 1 |
+| `pageSizeOptions` not provided | No page size selector rendered | — | — |
+
+### 3.3 Client-Side Data Slicing (`paginatedData`)
+
+| Trigger | Render | Accessibility | Edge Cases |
+|---|---|---|---|
+| `paginatedData(data)` called | Returns `data.slice(start, start + pageSize)` | — | Empty array if `data` is empty |
+| Page beyond data range | Returns empty array `[]` | — | Consumer should prevent this via `totalItems` |
+| `data` changes while on page > 1 | Consumer must handle — if new data is shorter, consumer should reset page | — | Page may be out of bounds if consumer doesn't handle |
+
+### 3.4 Position Rendering
+
+| `position` | Behavior |
+|---|---|
+| `'below'` (default) | `<table>` then `<XDSPagination>` |
+| `'above'` | `<XDSPagination>` then `<table>` |
+| `'both'` | `<XDSPagination>` then `<table>` then `<XDSPagination>` |
+| `'none'` | No auto-rendering; consumer uses `paginationProps` to place controls manually |
+
+### 3.5 Interaction with Selection Plugin
+
+When both pagination and selection plugins are active:
+- Selection state should be scoped to the current page (consumer's responsibility)
+- "Select all" applies to visible (current page) rows only
+- Changing pages does NOT clear selection — consumer decides this behavior
+- The `transformTableContext` ordering matters: selection's context provider should wrap pagination's context wrapper. Plugin order in the `plugins` record determines this.
+
+### 3.6 Empty / Loading States
+
+| State | Behavior |
+|---|---|
+| `totalItems === 0` | `XDSPagination` returns `null` (built-in behavior) |
+| `totalPages === 0` | `XDSPagination` returns `null` |
+| `totalPages === 1` | Pagination renders but prev/next are both disabled; only page 1 shown |
+| Data loading (no items yet) | Consumer should set `totalItems` to trigger null render or show a loading state |
+
+---
+
+## 4. Competitive Analysis
+
+| Feature | WWW XDS Internal | XDS OSS (this spec) | shadcn/ui | Mantine | AG Grid |
+|---|---|---|---|---|---|
+| **Integration model** | Table prop | Table plugin | Standalone component | Table prop | Built-in grid feature |
+| **Data slicing** | Table owns | Consumer owns (helper provided) | Consumer owns | Table owns | Grid owns |
+| **Control placement** | Fixed (below table) | Configurable (`position`) | Consumer places | Fixed (below table) | Fixed (grid footer) |
+| **Server-side pagination** | Yes (via callbacks) | Yes (skip `paginatedData`) | Yes | Yes | Yes (datasource API) |
+| **Cursor-based (infinite)** | Limited | Yes (`hasMore` prop) | No | No | Yes (infinite row model) |
+| **Page size selector** | Yes | Yes (via `pageSizeOptions`) | Yes | Yes | Yes |
+| **Variants** | Limited | 5 variants (pages/count/compact/dots/none) | Pages only | Pages only | Pages only |
+| **Selection interaction** | Coupled | Decoupled (consumer decides) | N/A | Coupled | Coupled |
+| **React transitions** | No | Yes (via `onChangeAction`) | No | No | No |
+| **Composability** | Low (locked to table) | High (plugin + manual placement) | High (standalone) | Low (table prop) | Low (built-in) |
+
+### Key Differentiators
+
+1. **Plugin model** — Unlike WWW/Mantine/AG Grid which couple pagination to the table, XDS OSS uses a composable plugin that can be used standalone or integrated
+2. **Variant support** — 5 display variants vs. competitors' 1-2
+3. **`paginatedData` helper** — Bridges client-side slicing convenience with server-side flexibility
+4. **Position control** — No competitor offers `above`/`both`/`none` placement options
+
+---
+
+## 5. XDS Component Dependencies
+
+| Component | Path | Exists | Usage |
+|---|---|---|---|
+| `XDSPagination` | `packages/core/src/Pagination/XDSPagination.tsx` | ✅ | Renders pagination controls |
+| `XDSButton` | `packages/core/src/Button/` | ✅ | Used internally by XDSPagination |
+| `XDSIcon` | `packages/core/src/Icon/` | ✅ | Chevron icons in XDSPagination |
+| `XDSSelector` | `packages/core/src/Selector/XDSSelector.tsx` | ✅ | Page size dropdown in XDSPagination |
+| `XDSText` | `packages/core/src/Text/XDSText.tsx` | ✅ | Count/compact variant text |
+
+**No missing prerequisites.** All components used by this plugin already exist. The plugin itself is a thin hook that composes `XDSPagination` — no new UI components needed.
+
+---
+
+## 6. Test Specification
+
+### Unit Tests (`useXDSTablePagination.test.tsx`)
+
+#### Hook Return Value
+- `returns plugin object with transformTableContext` — verify the plugin shape
+- `returns paginationProps matching config` — verify all config props flow through
+- `returns paginatedData function` — verify it exists and is callable
+- `returns computed totalPages from totalItems and pageSize` — verify `Math.ceil(100 / 25) === 4`
+- `returns totalPages directly when totalPagesProp is provided` — verify passthrough
+- `returns undefined totalPages when using hasMore` — cursor-based mode
+- `defaults pageSize to 10` — verify default
+- `defaults variant to 'pages'` — verify default
+- `defaults position to 'below'` — verify default
+
+#### `paginatedData` Helper
+- `slices data for page 1` — `data.slice(0, pageSize)`
+- `slices data for page 2` — `data.slice(pageSize, pageSize * 2)`
+- `slices data for last page with partial data` — e.g., 23 items, page 3, pageSize 10 → 3 items
+- `returns empty array for empty data` — `paginatedData([])` → `[]`
+- `returns empty array when page exceeds data` — page 5 of 10-item dataset with pageSize 10
+- `updates slice when page changes` — re-render with new page → new slice
+- `updates slice when pageSize changes` — re-render with new pageSize → new slice
+
+#### Plugin Behavior
+- `transformTableContext renders XDSPagination below table by default` — position='below'
+- `transformTableContext renders XDSPagination above table` — position='above'
+- `transformTableContext renders XDSPagination above and below` — position='both'
+- `transformTableContext does not render XDSPagination when position is none` — passthrough
+- `paginationProps include pageSizeOptions when provided` — verify selector appears
+- `paginationProps exclude pageSizeOptions when not provided` — no selector
+
+#### Integration with XDSTable
+- `renders table with paginated data` — full integration: hook + XDSTable + data slicing
+- `page change re-renders table with new data` — verify rows update
+- `page size change resets to page 1` — XDSPagination built-in behavior
+- `works alongside selection plugin` — both plugins active, no conflicts
+- `plugin order does not break rendering` — pagination before/after selection
+- `empty data renders pagination as null` — totalItems=0
+
+#### Props Passthrough to XDSPagination
+- `passes variant prop` — verify each variant renders correctly
+- `passes size prop` — verify sm/md sizing
+- `passes label prop` — verify aria-label on nav element
+- `passes hasMore for cursor-based pagination` — next button enabled/disabled
+- `passes onPageSizeChange and pageSizeOptions` — selector appears with options
+
+#### Edge Cases
+- `handles totalItems=0 gracefully` — no pagination rendered
+- `handles totalPages=1` — pagination renders, both nav buttons disabled
+- `handles page=1 with no totalItems or totalPages` — cursor mode, prev disabled
+- `handles rapid page changes` — no stale closures
+- `memoizes paginatedData callback` — reference stability when deps unchanged
+- `handles data shorter than pageSize` — single page, no slicing artifacts
+
+### Accessibility Tests
+- `pagination nav has correct aria-label` — default "Table pagination"
+- `page buttons have aria-label "Go to page N"` — via XDSPagination
+- `current page has aria-current="page"` — via XDSPagination
+- `disabled prev/next buttons have aria-disabled` — via XDSButton

--- a/packages/core/src/Table/plugins/sortable/SPEC.md
+++ b/packages/core/src/Table/plugins/sortable/SPEC.md
@@ -1,0 +1,571 @@
+# useXDSTableSortable — Plugin Specification
+
+> **Status:** Draft · **Target:** XDS OSS · **Issue:** #978
+> **Author:** spec-generated · **Date:** 2026-03-30
+
+---
+
+## Table of Contents
+
+1. [WWW Reference Analysis](#1-www-reference-analysis)
+2. [XDS OSS Plugin API (TypeScript)](#2-xds-oss-plugin-api-typescript)
+3. [Behavioral Specification](#3-behavioral-specification)
+4. [Competitive Analysis](#4-competitive-analysis)
+5. [XDS Component Dependencies](#5-xds-component-dependencies)
+6. [Test Specification](#6-test-specification)
+
+---
+
+## 1. WWW Reference Analysis
+
+### WWW API Surface
+
+```flow
+hook useXDSTableSortable<TItem, TColumnKey, TSortKey>({
+  allowUnsortedState?: boolean,
+  setSort: (XDSTableSortableState<TSortKey>) => void,
+  sort: XDSTableSortableState<TSortKey>,
+}): XDSTableSortable<TItem, TColumnKey>
+```
+
+**State types:**
+
+- `XDSTableSortableDirection = 'ascending' | 'descending'`
+- `XDSTableSortableState<TSortKey> = { sortKey: TSortKey, direction: XDSTableSortableDirection }`
+
+**Column config:** Each column declares sortability via `sortable?: [{ sortKey: string }]`.
+
+**Plugin integration:** Delegates to `useWebTableStructuredHeadersSortable_EXPERIMENTAL`. Uses `transformHeaderCell` to inject clickable sort indicators into header cells.
+
+**Visual indicators:** Three icon states:
+
+| State | Icon | Meaning |
+|-------|------|---------|
+| Unsorted | `arrow-up-down` | Column is sortable but not active |
+| Ascending | `arrow-up` | Sorted A→Z / low→high |
+| Descending | `arrow-down` | Sorted Z→A / high→low |
+
+**Interaction model:** Click header → cycles sort direction. If `allowUnsortedState` is true, cycle is: unsorted → ascending → descending → unsorted. If false, cycle is: ascending → descending → ascending.
+
+**Limitations of WWW:**
+
+- **Single-sort only** — one column active at a time
+- Sort key is a separate concept from column key (indirection via `sortable` config)
+- State is externally managed via `sort` / `setSort` (headless pattern ✓)
+
+### XDS OSS Improvements Over WWW
+
+1. **Multi-sort support** — state is an ordered array of sort entries; first = primary sort
+2. **Simpler column config** — `sortKey` on column definition directly, no nested array
+3. **Sort priority indicator** — optional numeric badge showing sort rank in multi-sort mode
+4. **Keyboard accessibility** — full keyboard interaction on header cells
+
+---
+
+## 2. XDS OSS Plugin API (TypeScript)
+
+### Type Definitions
+
+```typescript
+// =============================================================================
+// Sort Direction & State
+// =============================================================================
+
+/**
+ * Sort direction for a single column.
+ */
+export type XDSTableSortDirection = 'ascending' | 'descending';
+
+/**
+ * A single sort entry in the sort state array.
+ * Represents one column being sorted in a specific direction.
+ */
+export interface XDSTableSortEntry<TSortKey extends string = string> {
+  /** The sort key identifying which column (or derived value) to sort by. */
+  sortKey: TSortKey;
+  /** The sort direction. */
+  direction: XDSTableSortDirection;
+}
+
+/**
+ * Complete sort state — an ordered array of sort entries.
+ * The first entry is the primary sort; subsequent entries are tiebreakers.
+ *
+ * - Single sort: array of length 0 or 1
+ * - Multi-sort: array of length 0..N
+ * - Empty array: no sort applied (unsorted state)
+ *
+ * @example
+ * ```
+ * // Primary sort by name ascending, secondary by age descending
+ * const sort: XDSTableSortState = [
+ *   { sortKey: 'name', direction: 'ascending' },
+ *   { sortKey: 'age', direction: 'descending' },
+ * ];
+ * ```
+ */
+export type XDSTableSortState<TSortKey extends string = string> =
+  XDSTableSortEntry<TSortKey>[];
+
+// =============================================================================
+// Column Extension
+// =============================================================================
+
+/**
+ * Sortable column configuration.
+ * Added to XDSTableColumn<T> via the `sortable` field.
+ *
+ * When a column has `sortable` set, the plugin renders a sort indicator
+ * in the header cell and makes the header clickable.
+ */
+export interface XDSTableSortableColumnConfig {
+  /**
+   * The sort key for this column. Must match a key used in XDSTableSortState.
+   * Allows decoupling column identity from sort identity (e.g., a "Full Name"
+   * column might sort by `'lastName'`).
+   *
+   * @default column.key — if omitted, uses the column's `key` property
+   */
+  sortKey?: string;
+}
+
+// =============================================================================
+// Hook Config
+// =============================================================================
+
+/**
+ * Configuration for useXDSTableSortable.
+ *
+ * Follows XDS headless plugin conventions: the consumer owns all state
+ * and provides callbacks. The plugin never holds internal sort state.
+ *
+ * @template TSortKey - Union of valid sort key strings
+ *
+ * @example
+ * ```
+ * const [sort, setSort] = useState<XDSTableSortState>([
+ *   { sortKey: 'name', direction: 'ascending' },
+ * ]);
+ *
+ * const sortPlugin = useXDSTableSortable({
+ *   sort,
+ *   onSortChange: setSort,
+ * });
+ *
+ * <XDSTable plugins={{ sort: sortPlugin }} ... />
+ * ```
+ */
+export interface UseXDSTableSortableConfig<
+  TSortKey extends string = string,
+> {
+  /**
+   * Current sort state — ordered array of active sort entries.
+   * Empty array = unsorted. First entry = primary sort.
+   */
+  sort: XDSTableSortState<TSortKey>;
+
+  /**
+   * Called when the user changes sort via header click.
+   * Receives the complete new sort state array.
+   *
+   * For single-sort mode: array will have 0 or 1 entries.
+   * For multi-sort mode: array may have multiple entries.
+   */
+  onSortChange: (sort: XDSTableSortState<TSortKey>) => void;
+
+  /**
+   * Allow returning to unsorted state.
+   * When true, clicking a sorted column cycles: asc → desc → unsorted.
+   * When false, clicking cycles: asc → desc → asc.
+   *
+   * @default false
+   */
+  allowUnsortedState?: boolean;
+
+  /**
+   * Enable multi-sort via modifier key (Shift+click).
+   * When true, Shift+click adds/toggles a column as a secondary sort.
+   * Regular click still replaces the entire sort state (single-sort behavior).
+   * When false, only single-sort is available.
+   *
+   * @default false
+   */
+  isMultiSortEnabled?: boolean;
+}
+
+// =============================================================================
+// Hook Return Type
+// =============================================================================
+
+// The hook returns TablePlugin<T> — no additional API surface.
+// All interaction is through the config callbacks.
+```
+
+### Column Definition Extension
+
+The `XDSTableColumn<T>` interface needs a new optional field:
+
+```typescript
+// Added to XDSTableColumn<T> in types.ts
+export interface XDSTableColumn<T extends Record<string, unknown>> {
+  // ... existing fields ...
+
+  /**
+   * Sortable configuration for this column.
+   * Set to `true` for default behavior (sortKey = column.key),
+   * or provide an object with a custom sortKey.
+   * Omit or set to `undefined`/`false` to make the column non-sortable.
+   *
+   * @example
+   * ```
+   * // Simple: sort key matches column key
+   * { key: 'name', header: 'Name', sortable: true }
+   *
+   * // Custom sort key
+   * { key: 'fullName', header: 'Full Name', sortable: { sortKey: 'lastName' } }
+   * ```
+   */
+  sortable?: boolean | XDSTableSortableColumnConfig;
+}
+```
+
+### Hook Signature
+
+```typescript
+/**
+ * useXDSTableSortable — table plugin for column sorting.
+ *
+ * Returns a stable TablePlugin<T> that transforms header cells to add
+ * clickable sort indicators. Follows the headless pattern: consumer owns
+ * sort state, plugin provides UI and interaction.
+ *
+ * Supports single-sort (default) and multi-sort (Shift+click) modes.
+ *
+ * @template T - Row data type
+ * @template TSortKey - Union of valid sort key strings
+ *
+ * @example
+ * ```
+ * const [sort, setSort] = useState<XDSTableSortState>([]);
+ * const sortPlugin = useXDSTableSortable({ sort, onSortChange: setSort });
+ *
+ * <XDSTable
+ *   data={users}
+ *   columns={[
+ *     { key: 'name', header: 'Name', sortable: true },
+ *     { key: 'age', header: 'Age', sortable: true },
+ *     { key: 'avatar', header: '', sortable: false }, // not sortable
+ *   ]}
+ *   plugins={{ sort: sortPlugin }}
+ * />
+ * ```
+ */
+export function useXDSTableSortable<
+  T extends Record<string, unknown>,
+  TSortKey extends string = string,
+>(
+  config: UseXDSTableSortableConfig<TSortKey>,
+): TablePlugin<T>;
+```
+
+### Plugin Transform Strategy
+
+| Transform Method | Used? | Purpose |
+|---|---|---|
+| `transformTable` | No | — |
+| `transformHeaderRow` | No | — |
+| `transformHeaderCell` | **Yes** | Wraps header content with sort button + icon indicator |
+| `transformBodyRow` | No | — |
+| `transformBodyCell` | No | — |
+| `transformTableContext` | No | No context needed — state is fully external |
+
+**Why only `transformHeaderCell`?** Unlike selection (which needs a new column and row-level state), sorting only modifies existing header cells. The sort indicator and click handler are injected into each sortable column's `<th>`. No new columns, rows, or context providers are needed.
+
+### Internal Architecture
+
+```
+useXDSTableSortable(config)
+  │
+  ├── configRef ← useRef(config)     // Always-fresh config without re-creating plugin
+  │
+  └── useMemo(() => plugin, [])      // Stable plugin object (never changes)
+        │
+        └── transformHeaderCell(props, column)
+              │
+              ├── column.sortable falsy? → return props unchanged
+              │
+              ├── Resolve sortKey: column.sortable.sortKey ?? column.key
+              │
+              ├── Find entry in configRef.current.sort matching sortKey
+              │
+              ├── Build onClick handler:
+              │     ├── Regular click → single-sort cycle
+              │     └── Shift+click (if isMultiSortEnabled) → multi-sort toggle
+              │
+              ├── Wrap header children in clickable container:
+              │     <button> (for accessibility)
+              │       {original header content}
+              │       <XDSIcon icon={sortIcon} size="xsm" />
+              │       {multiSortRank > 0 && <span>{rank}</span>}
+              │     </button>
+              │
+              └── Merge aria-sort onto htmlProps
+```
+
+---
+
+## 3. Behavioral Specification
+
+### 3.1 Sort Indicator Rendering
+
+#### Sortable column — unsorted
+
+- **Trigger:** Column has `sortable` config but no matching entry in `sort` state.
+- **Render:** Header text + subtle `arrow-up-down` icon (color: `secondary`/muted). Icon only visible on hover by default.
+- **Accessibility:** `<th>` has no `aria-sort`. Header content wrapped in `<button>` with `aria-label="Sort by {header}"`.
+
+#### Sortable column — ascending
+
+- **Trigger:** `sort` array contains entry with matching `sortKey` and `direction: 'ascending'`.
+- **Render:** Header text + `arrow-up` icon (color: `primary`/accent). Icon always visible.
+- **Accessibility:** `<th aria-sort="ascending">`. Button `aria-label="Sort by {header}, sorted ascending"`.
+
+#### Sortable column — descending
+
+- **Trigger:** `sort` array contains entry with matching `sortKey` and `direction: 'descending'`.
+- **Render:** Header text + `arrow-down` icon (color: `primary`/accent). Icon always visible.
+- **Accessibility:** `<th aria-sort="descending">`. Button `aria-label="Sort by {header}, sorted descending"`.
+
+#### Non-sortable column
+
+- **Trigger:** Column has no `sortable` config (undefined/false).
+- **Render:** Header content unchanged. No icon, no button wrapper.
+- **Accessibility:** No `aria-sort` attribute.
+
+#### Multi-sort rank indicator
+
+- **Trigger:** `isMultiSortEnabled` is true AND `sort` array has >1 entries AND column is in the array.
+- **Render:** Small numeric badge (1-based index) next to the sort icon showing priority. Primary sort = "1", secondary = "2", etc.
+- **Accessibility:** `aria-label` includes rank: `"Sort by {header}, sorted ascending, priority 1 of 3"`.
+
+### 3.2 Click Interactions
+
+#### Single-sort click (default behavior)
+
+| Current State | `allowUnsortedState` | Action | New State |
+|---|---|---|---|
+| Unsorted | any | Click | `[{ sortKey, direction: 'ascending' }]` |
+| Ascending | false | Click | `[{ sortKey, direction: 'descending' }]` |
+| Ascending | true | Click | `[{ sortKey, direction: 'descending' }]` |
+| Descending | false | Click | `[{ sortKey, direction: 'ascending' }]` |
+| Descending | true | Click | `[]` (unsorted) |
+
+When clicking a *different* column in single-sort mode, the entire sort array is replaced with the new column ascending.
+
+#### Multi-sort Shift+click
+
+When `isMultiSortEnabled` is true and user Shift+clicks:
+
+| Column in sort array? | Current direction | Result |
+|---|---|---|
+| No | — | Append `{ sortKey, direction: 'ascending' }` to array |
+| Yes, ascending | ascending | Toggle to `descending` in place |
+| Yes, descending (allowUnsortedState=true) | descending | Remove from array |
+| Yes, descending (allowUnsortedState=false) | descending | Toggle to `ascending` in place |
+
+Sort priority (array order) is preserved. New columns are appended at the end (lowest priority).
+
+### 3.3 Keyboard Navigation
+
+| Key | Context | Action |
+|---|---|---|
+| `Enter` | Sort button focused | Same as click |
+| `Space` | Sort button focused | Same as click |
+| `Shift+Enter` | Sort button focused, multi-sort enabled | Same as Shift+click |
+| `Tab` | Header row | Move focus between sortable headers (native focus order) |
+
+The sort button inside each `<th>` is a native `<button>`, so keyboard navigation is handled by the browser. No custom key handling needed beyond Shift detection.
+
+### 3.4 Header Cell DOM Structure
+
+```html
+<!-- Sortable column, currently ascending, multi-sort rank 1 -->
+<th aria-sort="ascending" scope="col">
+  <button
+    type="button"
+    class="xds-sort-button"
+    aria-label="Sort by Name, sorted ascending, priority 1 of 2"
+    onClick={handleClick}
+  >
+    <span class="xds-sort-label">Name</span>
+    <XDSIcon icon="arrow-up" size="xsm" color="accent" />
+    <span class="xds-sort-rank" aria-hidden="true">1</span>
+  </button>
+</th>
+
+<!-- Non-sortable column -->
+<th scope="col">
+  Status
+</th>
+```
+
+### 3.5 Styling Details
+
+The sort button must:
+
+- Fill the entire header cell (full width/height clickable area)
+- Use `display: flex; align-items: center; gap: spacing-1`
+- Have no visible button chrome (background: transparent, border: none)
+- Show `cursor: pointer`
+- Inherit header cell typography (font-weight, color, size from XDSTableHeaderCell)
+- Show hover state: sort icon becomes visible (for unsorted columns)
+- Show focus-visible outline (standard XDS focus ring)
+
+The sort icon:
+
+- Uses `XDSIcon` with `size="xsm"` (12px)
+- Unsorted: `color="secondary"`, `opacity: 0` by default, `opacity: 1` on header hover/focus
+- Active sort: `color="accent"`, always visible
+
+The rank badge (multi-sort only):
+
+- Tiny inline text (`font-size: 10px`, `line-height: 1`)
+- Color: `accent`
+- Positioned as flex child after the icon
+
+### 3.6 Edge Cases
+
+| Scenario | Behavior |
+|---|---|
+| No columns have `sortable` config | Plugin is a no-op; no headers are transformed |
+| `sort` contains a key not matching any column | Ignored — no visual indicator. `onSortChange` may still include it. |
+| Column removed from table but still in `sort` | No crash. Entry is invisible but preserved in state. Consumer should clean up. |
+| Empty `sort` array | All sortable columns show unsorted indicators |
+| `sort` has one entry + `isMultiSortEnabled=false` | Single-sort mode; rank badge not shown |
+| Header content is ReactNode (not string) | Wrapped in sort button as-is. `aria-label` should still be provided via column config or fallback to `column.key`. |
+| `data` is empty or undefined | Sort indicators still render in headers |
+
+---
+
+## 4. Competitive Analysis
+
+### Comparison Matrix
+
+| Feature | WWW XDS | XDS OSS (this spec) | TanStack Table | Mantine DataTable | AG Grid |
+|---|---|---|---|---|---|
+| **Single sort** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **Multi-sort** | ❌ | ✅ (Shift+click) | ✅ (built-in) | ❌ | ✅ |
+| **Unsorted state** | Optional | Optional | ✅ | ✅ | ✅ |
+| **State ownership** | External | External | Internal (managed) | Internal | Internal |
+| **Plugin architecture** | Transform pipeline | Transform pipeline | Feature system | Monolithic | Monolithic |
+| **Sort indicators** | 3 icons | 3 icons + rank badge | CSS classes | Icons | Icons + rank |
+| **Accessibility** | Basic | Full (aria-sort, labels) | Partial | Partial | Full |
+| **Framework coupling** | React (FB internal) | React | Framework-agnostic core | React | Framework-agnostic |
+
+### Key Differentiators
+
+**vs. TanStack Table (used by shadcn/NDS):**
+TanStack owns sort state internally via `useReactTable({ state: { sorting } })`. Columns declare `enableSorting`. The sort model is tightly coupled to TanStack's column definition system. XDS OSS uses a transform pipeline where the sort plugin is composed alongside other plugins without knowledge of each other. XDS's headless callbacks (`onSortChange`) are simpler than TanStack's `onSortingChange` which uses an updater function pattern.
+
+**vs. Mantine DataTable:**
+Mantine provides `sortStatus` + `onSortStatusChange` props directly on the table component — not a plugin. No multi-sort. XDS keeps sorting as a composable plugin, avoiding prop bloat on the table component.
+
+**vs. AG Grid:**
+AG Grid has comprehensive built-in sorting with multi-sort, custom comparators, and sort priority indicators. However, it's a monolithic component. XDS achieves similar multi-sort UX through a lightweight plugin that composes with the existing transform pipeline.
+
+**XDS OSS advantage:** The plugin transform pipeline allows sort, selection, and filtering to compose independently without awareness of each other. Each plugin only touches the render props it needs. This is architecturally cleaner than monolithic approaches where sort/filter/select are all baked into one component API.
+
+---
+
+## 5. XDS Component Dependencies
+
+### Required Components
+
+| Component | Import | Usage | Props Used |
+|---|---|---|---|
+| `XDSIcon` | `@xds/core` | Sort direction indicators | `icon` (component), `size="xsm"`, `color="secondary"\|"accent"` |
+| `XDSTableHeaderCell` | `../XDSTableHeaderCell` | Not consumed directly — plugin transforms props passed *to* it | — |
+
+### Required Icons
+
+The plugin needs three sort icon SVG components. These are **not** in the `XDSIconName` registry (which only has `'chevronDown'`, `'close'`, `'search'`, etc.).
+
+| Icon | Purpose | Status |
+|---|---|---|
+| Arrow Up | Ascending sort indicator | **MISSING** — needs to be added to XDS icon set or bundled with plugin |
+| Arrow Down | Descending sort indicator | **MISSING** — needs to be added to XDS icon set or bundled with plugin |
+| Arrow Up-Down | Unsorted/sortable indicator | **MISSING** — needs to be added to XDS icon set or bundled with plugin |
+
+**Recommendation:** Add `'arrowUp'`, `'arrowDown'`, and `'arrowUpDown'` to the XDS icon registry (`packages/core/src/Icon/icons/`). These are general-purpose icons useful beyond just table sorting. Alternatively, bundle them as private SVG components within the sortable plugin directory.
+
+### Required Theme Tokens
+
+| Token | Source | Usage |
+|---|---|---|
+| `spacingVars['--spacing-1']` | `theme/tokens.stylex` | Gap between header text and sort icon |
+| `colorVars['--color-text-secondary']` | `theme/tokens.stylex` | Unsorted icon color |
+| `colorVars['--color-accent']` | `theme/tokens.stylex` | Active sort icon color |
+
+### No Missing Prerequisites (Beyond Icons)
+
+All other dependencies (StyleX, React hooks, `TablePlugin<T>` interface) exist. The `XDSTableColumn<T>` interface in `types.ts` needs the `sortable` field added (see §2).
+
+---
+
+## 6. Test Specification
+
+### Rendering Tests
+
+| Test | What It Verifies |
+|---|---|
+| `renders sort icon for sortable columns` | Sortable columns show sort indicator; non-sortable columns do not |
+| `renders ascending icon when sort state is ascending` | Arrow-up icon appears for ascending sort entry |
+| `renders descending icon when sort state is descending` | Arrow-down icon appears for descending sort entry |
+| `renders unsorted icon when column is sortable but not in sort state` | Arrow-up-down icon appears for inactive sortable columns |
+| `renders no sort UI for columns without sortable config` | Non-sortable columns have no button wrapper or icon |
+| `renders sort button wrapping header content` | Header content is inside a `<button>` element |
+| `renders rank badge in multi-sort mode` | When isMultiSortEnabled and sort has >1 entry, rank numbers appear |
+| `does not render rank badge in single-sort mode` | Even with sort state, no rank badge when isMultiSortEnabled=false |
+| `renders sort indicators when data is empty` | Headers still show sort UI with empty/undefined data |
+| `uses custom sortKey from column config` | Column with `sortable: { sortKey: 'custom' }` matches sort state by 'custom', not column key |
+| `uses column key as default sortKey` | Column with `sortable: true` matches sort state by column.key |
+
+### Interaction Tests
+
+| Test | What It Verifies |
+|---|---|
+| `clicking unsorted column calls onSortChange with ascending` | First click on unsorted column produces `[{ sortKey, direction: 'ascending' }]` |
+| `clicking ascending column toggles to descending` | Click on ascending column produces descending |
+| `clicking descending column toggles to ascending (allowUnsortedState=false)` | Default cycle wraps to ascending |
+| `clicking descending column clears sort (allowUnsortedState=true)` | With allowUnsortedState, third click produces `[]` |
+| `clicking different column replaces sort in single-sort mode` | Clicking column B while A is sorted produces `[{ sortKey: B, ... }]` |
+| `shift+click adds column to multi-sort` | With isMultiSortEnabled, Shift+click appends to sort array |
+| `shift+click toggles existing column in multi-sort` | Shift+click on already-sorted column toggles direction in place |
+| `shift+click removes descending column in multi-sort (allowUnsortedState=true)` | Shift+click on descending column removes it from array |
+| `regular click in multi-sort mode replaces entire sort` | Non-shift click replaces array even when isMultiSortEnabled |
+| `clicking non-sortable column header does nothing` | No onSortChange call for non-sortable columns |
+
+### Accessibility Tests
+
+| Test | What It Verifies |
+|---|---|
+| `sets aria-sort="ascending" on sorted ascending th` | `<th>` has correct aria-sort |
+| `sets aria-sort="descending" on sorted descending th` | `<th>` has correct aria-sort |
+| `does not set aria-sort on unsorted columns` | No aria-sort attribute on inactive columns |
+| `does not set aria-sort on non-sortable columns` | Non-sortable columns have no aria-sort |
+| `sort button has accessible aria-label` | Button includes column name and current sort state |
+| `sort button is keyboard accessible (Enter)` | Enter key triggers sort change |
+| `sort button is keyboard accessible (Space)` | Space key triggers sort change |
+| `focus-visible outline appears on sort button` | Visual focus indicator present |
+
+### Edge Case Tests
+
+| Test | What It Verifies |
+|---|---|
+| `handles sort state with key not matching any column` | No crash; unmatched key is ignored visually |
+| `handles empty sort array` | All sortable columns show unsorted state |
+| `plugin object is referentially stable across renders` | useMemo returns same object reference when config changes |
+| `works with no sortable columns` | Plugin is no-op; no errors |
+| `works with ReactNode header content` | Non-string headers wrapped correctly in sort button |
+| `preserves plugin pipeline order with other plugins` | Sort transforms compose with selection plugin without conflict |
+| `sort state with multiple entries but isMultiSortEnabled=false` | Renders all entries (state is source of truth) but click behavior is single-sort |


### PR DESCRIPTION
## Build-Ready Plugin Specifications

5 XDSTable plugin specs, each referencing the WWW XDS internal implementation as the authoritative source. These are specifications only — no implementation code.

### Plugins Specified

| Plugin | Lines | WWW Reference | Key Decision |
|--------|-------|---------------|-------------|
| `useXDSTableSortable` | 571 | `useXDSTableSortable` | Multi-sort support (array of sort entries, Shift+click) |
| `useXDSTableFiltering` | 843 | `useXDSTableFiltering.experimental` | Per-column filter types, always-visible + dropdown variants |
| `useXDSTablePagination` | 523 | `pagination` prop | Plugin approach (not prop) — composes with `XDSPagination` |
| `useXDSTableColumnSettings` | 757 | `useXDSTableCustomColumns` + `ViewOptions` | Column visibility + saved views/presets |
| `useXDSTableColumnResize` | 410 | `useXDSTableColumnResize.experimental` | Pointer capture drag, proportional→pixel conversion |

### Each Spec Contains
1. **WWW Reference Analysis** — full API surface from the internal implementation
2. **XDS OSS Plugin API** — complete TypeScript types (copy-pasteable)
3. **Behavioral Specification** — trigger/render/a11y/edge cases per interaction
4. **Competitive Analysis** — vs WWW, other internal library/shadcn, Mantine, AG Grid
5. **Component Dependencies** — verified against XDS source
6. **Test Specification** — 150+ test cases total

### Architecture
All plugins follow the established `useXDSTableSelection` hook pattern: config in, `TablePlugin<T>` out. Each is independent and composable.

### Flagged Prerequisites
- 3 sort icons needed (`arrowUp`, `arrowDown`, `arrowUpDown`)
- `XDSMultiSelector` doesn't exist yet (non-blocking for columnSettings)

Closes #978 (spec phase)

---
