### PR TITLE
feat(Icon): add sort, filter, and column icons

### DIFF
--- a/packages/core/src/Icon/defaultIcons.tsx
+++ b/packages/core/src/Icon/defaultIcons.tsx
@@ -177,4 +177,46 @@ export const defaultIcons: XDSIconRegistry = {
       <path d="M21 21l-4.35-4.35" />
     </svg>
   ),
+
+  /** ↑ — arrow up (sort ascending) */
+  arrowUp: (
+    <svg {...svgProps}>
+      <path d="M12 19V5m0 0l-7 7m7-7l7 7" />
+    </svg>
+  ),
+
+  /** ↓ — arrow down (sort descending) */
+  arrowDown: (
+    <svg {...svgProps}>
+      <path d="M12 5v14m0 0l7-7m-7 7l-7-7" />
+    </svg>
+  ),
+
+  /** ↕ — arrows up-down (unsorted / sortable indicator) */
+  arrowsUpDown: (
+    <svg {...svgProps}>
+      <path d="M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5" />
+    </svg>
+  ),
+
+  /** 🔽 — funnel (filter indicator) */
+  funnel: (
+    <svg {...svgProps}>
+      <path d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z" />
+    </svg>
+  ),
+
+  /** 👁‍🗨 — eye with slash (hidden column) */
+  eyeSlash: (
+    <svg {...svgProps}>
+      <path d="M3.98 8.223A10.477 10.477 0 001.934 12c1.292 4.338 5.31 7.5 10.066 7.5.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
+    </svg>
+  ),
+
+  /** ☐☐ — view columns (column settings) */
+  viewColumns: (
+    <svg {...svgProps}>
+      <path d="M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125z" />
+    </svg>
+  ),
 };

--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -36,7 +36,13 @@ export type XDSIconName =
   | 'externalLink'
   | 'menu'
   | 'moreHorizontal'
-  | 'search';
+  | 'search'
+  | 'arrowUp'
+  | 'arrowDown'
+  | 'arrowsUpDown'
+  | 'funnel'
+  | 'eyeSlash'
+  | 'viewColumns';
 
 /**
  * Icon registry mapping semantic names to React nodes.

--- a/packages/themes/default/src/icons.tsx
+++ b/packages/themes/default/src/icons.tsx
@@ -23,6 +23,12 @@ import {
   Bars3Icon,
   EllipsisHorizontalIcon,
   MagnifyingGlassIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  ArrowsUpDownIcon,
+  FunnelIcon,
+  EyeSlashIcon,
+  ViewColumnsIcon,
 } from '@heroicons/react/24/outline';
 
 import {
@@ -54,4 +60,10 @@ export const defaultIconRegistry: XDSIconRegistry = {
   menu: <Bars3Icon {...iconProps} />,
   moreHorizontal: <EllipsisHorizontalIcon {...iconProps} />,
   search: <MagnifyingGlassIcon {...iconProps} />,
+  arrowUp: <ArrowUpIcon {...iconProps} />,
+  arrowDown: <ArrowDownIcon {...iconProps} />,
+  arrowsUpDown: <ArrowsUpDownIcon {...iconProps} />,
+  funnel: <FunnelIcon {...iconProps} />,
+  eyeSlash: <EyeSlashIcon {...iconProps} />,
+  viewColumns: <ViewColumnsIcon {...iconProps} />,
 };

--- a/packages/themes/meta/src/icons.tsx
+++ b/packages/themes/meta/src/icons.tsx
@@ -24,6 +24,12 @@ import {
   Bars3Icon,
   EllipsisHorizontalIcon,
   MagnifyingGlassIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  ArrowsUpDownIcon,
+  FunnelIcon,
+  EyeSlashIcon,
+  ViewColumnsIcon,
 } from '@heroicons/react/24/outline';
 
 import {
@@ -55,4 +61,10 @@ export const metaIconRegistry: XDSIconRegistry = {
   menu: <Bars3Icon {...iconProps} />,
   moreHorizontal: <EllipsisHorizontalIcon {...iconProps} />,
   search: <MagnifyingGlassIcon {...iconProps} />,
+  arrowUp: <ArrowUpIcon {...iconProps} />,
+  arrowDown: <ArrowDownIcon {...iconProps} />,
+  arrowsUpDown: <ArrowsUpDownIcon {...iconProps} />,
+  funnel: <FunnelIcon {...iconProps} />,
+  eyeSlash: <EyeSlashIcon {...iconProps} />,
+  viewColumns: <ViewColumnsIcon {...iconProps} />,
 };

--- a/packages/themes/neutral/src/icons.tsx
+++ b/packages/themes/neutral/src/icons.tsx
@@ -27,6 +27,12 @@ import {
   Menu,
   MoreHorizontal,
   Search,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown,
+  Filter,
+  EyeOff,
+  Columns,
 } from 'lucide-react';
 
 const iconProps = {
@@ -50,4 +56,10 @@ export const neutralIconRegistry: XDSIconRegistry = {
   menu: <Menu {...iconProps} />,
   moreHorizontal: <MoreHorizontal {...iconProps} />,
   search: <Search {...iconProps} />,
+  arrowUp: <ArrowUp {...iconProps} />,
+  arrowDown: <ArrowDown {...iconProps} />,
+  arrowsUpDown: <ArrowUpDown {...iconProps} />,
+  funnel: <Filter {...iconProps} />,
+  eyeSlash: <EyeOff {...iconProps} />,
+  viewColumns: <Columns {...iconProps} />,
 };

--- a/packages/themes/whatsapp/src/icons.tsx
+++ b/packages/themes/whatsapp/src/icons.tsx
@@ -21,6 +21,12 @@ import {
   Bars3Icon,
   EllipsisHorizontalIcon,
   MagnifyingGlassIcon,
+  ArrowUpIcon,
+  ArrowDownIcon,
+  ArrowsUpDownIcon,
+  FunnelIcon,
+  EyeSlashIcon,
+  ViewColumnsIcon,
 } from '@heroicons/react/24/outline';
 
 import {
@@ -52,4 +58,10 @@ export const whatsappIconRegistry: XDSIconRegistry = {
   menu: <Bars3Icon {...iconProps} />,
   moreHorizontal: <EllipsisHorizontalIcon {...iconProps} />,
   search: <MagnifyingGlassIcon {...iconProps} />,
+  arrowUp: <ArrowUpIcon {...iconProps} />,
+  arrowDown: <ArrowDownIcon {...iconProps} />,
+  arrowsUpDown: <ArrowsUpDownIcon {...iconProps} />,
+  funnel: <FunnelIcon {...iconProps} />,
+  eyeSlash: <EyeSlashIcon {...iconProps} />,
+  viewColumns: <ViewColumnsIcon {...iconProps} />,
 };


### PR DESCRIPTION
6 new semantic icons for the table plugin work in #978.

| Icon | Name | Used by |
|------|------|---------|
| ↑ | `arrowUp` | Sort ascending |
| ↓ | `arrowDown` | Sort descending |
| ↕ | `arrowsUpDown` | Sortable (unsorted) |
| 🔽 | `funnel` | Active filter |
| 👁 | `eyeSlash` | Hidden column |
| ☐☐ | `viewColumns` | Column settings |

All 4 themes updated (default + meta use heroicons, neutral uses lucide, whatsapp uses heroicons). Default inline SVG fallbacks included.

Build ✅ Tests ✅

---
