### PR TITLE
feat(Table): add named slots to HeaderCellRenderProps

### DIFF
--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -223,10 +223,16 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
 
   // --- Plugin pipeline: header cells ---
   const headerCells = resolvedColumns.map(col => {
+    const headerContent = col.header ?? col.key;
+
     const cellRenderProps = applyPlugins(
       plugins,
       p => p.transformHeaderCell,
-      {htmlProps: {}, styles: []} as HeaderCellRenderProps,
+      {
+        htmlProps: {},
+        styles: [],
+        content: headerContent,
+      } as HeaderCellRenderProps,
       col,
     );
 
@@ -251,11 +257,15 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
         }
       : cellRenderProps.htmlProps;
 
-    const headerContent = col.header ?? col.key;
+    // Resolve header content from slots — plugins write to named slots
+    // to avoid conflicts (e.g. sort writes `after`, resize writes `overlay`)
+    const resolvedContent = cellRenderProps.content ?? headerContent;
     const headerTitleProp =
-      typeof headerContent === 'string' && headerContent.length > 0
-        ? {title: headerContent}
+      typeof resolvedContent === 'string' && resolvedContent.length > 0
+        ? {title: resolvedContent}
         : {};
+    const {before, after, overlay} = cellRenderProps;
+    const hasSlots = before != null || after != null || overlay != null;
 
     return (
       <HeaderCellComponent
@@ -263,7 +273,16 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
         {...mergedHtmlProps}
         {...headerTitleProp}
         xstyle={cellRenderProps.styles}>
-        {headerContent}
+        {hasSlots ? (
+          <>
+            {before}
+            {resolvedContent}
+            {after}
+            {overlay}
+          </>
+        ) : (
+          resolvedContent
+        )}
       </HeaderCellComponent>
     );
   });

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -103,10 +103,31 @@ export interface HeaderRowRenderProps {
   children: ReactNode;
 }
 
-/** Props passed through the plugin pipeline for each `<th>` */
+/**
+ * Props passed through the plugin pipeline for each `<th>`.
+ *
+ * Uses named slots so multiple plugins can contribute content without
+ * conflicts. Each plugin writes to its own slot; XDSBaseTable renders
+ * them in order: `before | content | after`, with `overlay` positioned
+ * absolutely on top.
+ *
+ * Slot semantics:
+ * - **before** — content before the label (e.g. selection checkbox)
+ * - **content** — the header label; plugins may wrap (e.g. sort button)
+ * - **after** — content after the label (e.g. sort icon, filter icon)
+ * - **overlay** — absolutely positioned layer (e.g. resize handle)
+ */
 export interface HeaderCellRenderProps {
   htmlProps: ThHTMLAttributes<HTMLTableCellElement>;
   styles: StyleXStyles[];
+  /** Content rendered before the header label. */
+  before?: ReactNode;
+  /** The header label content. Initialized from `column.header ?? column.key`. Plugins may wrap or replace. */
+  content?: ReactNode;
+  /** Content rendered after the header label (e.g. sort icon, filter trigger). */
+  after?: ReactNode;
+  /** Absolutely positioned overlay content (e.g. resize handle). */
+  overlay?: ReactNode;
 }
 
 /** Props passed through the plugin pipeline for each body `<tr>` */


### PR DESCRIPTION
Adds 4 named slots to `HeaderCellRenderProps` so table plugins can contribute header content without conflicts:

| Slot | Purpose | Example plugin |
|------|---------|---------------|
| `before` | Before label | selection checkbox |
| `content` | The label (wrappable) | sort button |
| `after` | After label | sort icon, filter icon |
| `overlay` | Absolutely positioned | resize handle |

XDSBaseTable seeds `content` from `column.header` and renders: `before | content | after` + `overlay`. When no slots are used, no wrapper fragment — zero overhead for tables without plugins.

107 tests pass ✅ Build passes ✅

Prerequisite for #978 plugin PRs (#1010, #1011, #1012).

---
