### PR TITLE
refactor: migrate 6 components from useXDSLayer to useXDSPopover

### DIFF
--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSDropdownMenu.tsx
- * @input Uses React, StyleX, useXDSLayer, XDSButton, XDSIcon
+ * @input Uses React, StyleX, useXDSPopover, XDSButton, XDSIcon
  * @output Exports XDSDropdownMenu component
  * @position Core implementation; consumed by index.ts
  *
@@ -22,7 +22,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {useXDSLayer} from '../Layer/useXDSLayer';
+import {useXDSPopover} from '../Popover/useXDSPopover';
 import {XDSButton, type XDSButtonProps} from '../Button';
 import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
@@ -31,7 +31,6 @@ import {XDSDivider} from '../Divider';
 import {XDSDropdownMenuItem} from './XDSDropdownMenuItem';
 import {
   colorVars,
-  shadowVars,
   spacingVars,
   radiusVars,
   durationVars,
@@ -69,8 +68,6 @@ const styles = stylex.create({
     '--dropdown-padding': spacingVars['--spacing-1'],
     padding: spacingVars['--spacing-1'],
     borderRadius: 'var(--dropdown-radius)',
-    backgroundColor: colorVars['--color-background-surface'],
-    boxShadow: shadowVars['--shadow-low'],
     opacity: 1,
     transitionProperty: 'opacity',
     transitionDuration: durationVars['--duration-fast'],
@@ -383,40 +380,41 @@ export function XDSDropdownMenu({
     }
   }, [isControlled, onOpenChange]);
 
-  const layer = useXDSLayer({
-    mode: 'context',
-    lightDismiss: true,
+  const popover = useXDSPopover({
     onHide: handleLayerHide,
     onShow: handleLayerShow,
+    hasLightDismiss: true,
+    hasCloseButton: false,
+    hasAutoFocus: false,
   });
 
   // Sync layer with controlled state
   React.useEffect(() => {
     if (isControlled) {
-      if (controlledIsOpen && !layer.isOpen) {
-        layer.show();
-      } else if (!controlledIsOpen && layer.isOpen) {
-        layer.hide();
+      if (controlledIsOpen && !popover.isOpen) {
+        popover.show();
+      } else if (!controlledIsOpen && popover.isOpen) {
+        popover.hide();
       }
     }
-  }, [controlledIsOpen, isControlled, layer]);
+  }, [controlledIsOpen, isControlled, popover]);
 
   const handleButtonClick = useCallback(() => {
     onClick?.();
     if (isControlled) {
       onOpenChange?.(!controlledIsOpen);
     } else {
-      if (layer.isOpen) {
-        layer.hide();
+      if (popover.isOpen) {
+        popover.hide();
       } else {
-        layer.show();
+        popover.show();
       }
     }
-  }, [onClick, isControlled, onOpenChange, controlledIsOpen, layer]);
+  }, [onClick, isControlled, onOpenChange, controlledIsOpen, popover]);
 
   const closeMenu = useCallback(() => {
-    layer.hide();
-  }, [layer]);
+    popover.hide();
+  }, [popover]);
 
   // Generate item ID for accessibility
   const getItemId = useCallback(
@@ -446,10 +444,10 @@ export function XDSDropdownMenu({
   // Keyboard navigation
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (!layer.isOpen) {
+      if (!popover.isOpen) {
         if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          layer.show();
+          popover.show();
           setHighlightedIndex(0);
         }
         return;
@@ -520,7 +518,7 @@ export function XDSDropdownMenu({
           break;
       }
     },
-    [layer, selectableItems, highlightedIndex, closeMenu, handleItemClick],
+    [popover, selectableItems, highlightedIndex, closeMenu, handleItemClick],
   );
 
   // Render an individual item
@@ -621,7 +619,7 @@ export function XDSDropdownMenu({
           (
             buttonRef as React.MutableRefObject<HTMLButtonElement | null>
           ).current = el;
-          layer.ref(el);
+          popover.triggerRef(el);
         }}
         {...button}
         endContent={resolvedEndContent}
@@ -638,7 +636,7 @@ export function XDSDropdownMenu({
         data-testid={testId}
       />
 
-      {layer.render(
+      {popover.render(
         <div
           id={menuId}
           role="menu"

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -7,7 +7,7 @@
  * @position Core implementation; consumed by index.ts
  *
  * Overflow menu with a three-dot icon trigger. A convenience wrapper
- * that composes XDSButton (icon-only) + useXDSLayer for the dropdown.
+ * that composes XDSButton (icon-only) + useXDSPopover for the dropdown.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/MoreMenu/README.md
@@ -175,7 +175,7 @@ export interface XDSMoreMenuProps {
    * Same type as XDSDropdownMenu's `items` prop.
    *
    * For advanced menu content that can't be expressed as data,
-   * compose XDSButton + useXDSLayer + XDSDropdownMenuItem directly.
+   * compose XDSButton + useXDSPopover + XDSDropdownMenuItem directly.
    */
   items: XDSDropdownMenuOption[];
 
@@ -247,7 +247,7 @@ function DefaultItem({item}: {item: XDSDropdownMenuItemData}) {
  * pattern.
  *
  * For full control over trigger rendering or menu content, compose
- * XDSButton + useXDSLayer + XDSDropdownMenuItem directly.
+ * XDSButton + useXDSPopover + XDSDropdownMenuItem directly.
  *
  * @example
  * ```

--- a/packages/core/src/MoreMenu/XDSMoreMenu.tsx
+++ b/packages/core/src/MoreMenu/XDSMoreMenu.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSMoreMenu.tsx
- * @input Uses React, StyleX, useXDSLayer, XDSButton, getIcon, XDSDropdownMenuItem, XDSDivider
+ * @input Uses React, StyleX, useXDSPopover, XDSButton, getIcon, XDSDropdownMenuItem, XDSDivider
  * @output Exports XDSMoreMenu component and XDSMoreMenuProps type
  * @position Core implementation; consumed by index.ts
  *
@@ -25,7 +25,7 @@ import {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {useXDSLayer} from '../Layer/useXDSLayer';
+import {useXDSPopover} from '../Popover/useXDSPopover';
 import {XDSButton, type XDSButtonVariant, type XDSButtonSize} from '../Button';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {XDSDropdownMenuItem} from '../DropdownMenu/XDSDropdownMenuItem';
@@ -43,7 +43,6 @@ import {
   durationVars,
   easeVars,
   typographyVars,
-  shadowVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
@@ -76,9 +75,6 @@ const styles = stylex.create({
     maxHeight: '300px',
     overflowY: 'auto',
     padding: spacingVars['--spacing-1'],
-    borderRadius: radiusVars['--radius-container'],
-    backgroundColor: colorVars['--color-background-surface'],
-    boxShadow: shadowVars['--shadow-low'],
     opacity: 1,
     transitionProperty: 'opacity',
     transitionDuration: durationVars['--duration-fast'],
@@ -286,23 +282,24 @@ export function XDSMoreMenu({
     buttonRef.current?.focus();
   }, []);
 
-  const layer = useXDSLayer({
-    mode: 'context',
-    lightDismiss: true,
+  const popover = useXDSPopover({
     onHide: handleLayerHide,
+    hasLightDismiss: true,
+    hasCloseButton: false,
+    hasAutoFocus: false,
   });
 
   const handleButtonClick = useCallback(() => {
-    if (layer.isOpen) {
-      layer.hide();
+    if (popover.isOpen) {
+      popover.hide();
     } else {
-      layer.show();
+      popover.show();
     }
-  }, [layer]);
+  }, [popover]);
 
   const closeMenu = useCallback(() => {
-    layer.hide();
-  }, [layer]);
+    popover.hide();
+  }, [popover]);
 
   const getItemId = useCallback(
     (index: number) => `${menuId}-item-${index}`,
@@ -328,10 +325,10 @@ export function XDSMoreMenu({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (!layer.isOpen) {
+      if (!popover.isOpen) {
         if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
           e.preventDefault();
-          layer.show();
+          popover.show();
           setHighlightedIndex(0);
         }
         return;
@@ -400,7 +397,7 @@ export function XDSMoreMenu({
           break;
       }
     },
-    [layer, selectableItems, highlightedIndex, closeMenu, handleItemClick],
+    [popover, selectableItems, highlightedIndex, closeMenu, handleItemClick],
   );
 
   const renderItem = useCallback(
@@ -480,7 +477,7 @@ export function XDSMoreMenu({
       <XDSButton
         ref={el => {
           buttonRef.current = el;
-          layer.ref(el);
+          popover.triggerRef(el);
           if (typeof ref === 'function') {
             ref(el);
           } else if (ref) {
@@ -493,20 +490,20 @@ export function XDSMoreMenu({
         variant={variant}
         size={size}
         isDisabled={isDisabled}
-        tooltip={layer.isOpen ? undefined : label}
+        tooltip={popover.isOpen ? undefined : label}
         onClick={handleButtonClick}
         onKeyDown={handleKeyDown}
         aria-haspopup="menu"
-        aria-expanded={layer.isOpen}
+        aria-expanded={popover.isOpen}
         aria-controls={menuId}
         aria-activedescendant={
-          layer.isOpen && highlightedIndex >= 0
+          popover.isOpen && highlightedIndex >= 0
             ? getItemId(highlightedIndex)
             : undefined
         }
         data-testid={testId}
       />
-      {layer.render(
+      {popover.render(
         <div
           id={menuId}
           role="menu"

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -17,13 +17,7 @@ import {XDSSelector} from '../Selector';
 import {XDSHStack, XDSVStack} from '../Stack';
 import {XDSIcon} from '../Icon';
 import {XDSTreeList, type XDSTreeListItemData} from '../TreeList';
-import {
-  spacingVars,
-  colorVars,
-  radiusVars,
-  shadowVars,
-  typeScaleVars,
-} from '../theme/tokens.stylex';
+import {spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {PowerSearchValueEditor} from './PowerSearchValueEditor';
 import type {InternalConfig} from './useInternalConfig';
 import type {
@@ -35,9 +29,6 @@ import type {
 
 const styles = stylex.create({
   container: {
-    backgroundColor: colorVars['--color-background-surface'],
-    borderRadius: radiusVars['--radius-container'],
-    boxShadow: shadowVars['--shadow-low'],
     overflow: 'hidden',
   },
   content: {

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -31,7 +31,7 @@ import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
 import type {XDSIconName} from '../Icon/globalIconRegistry';
 import type {XDSInputStatus} from '../Field';
-import {useXDSLayer} from '../Layer';
+import {useXDSPopover} from '../Popover/useXDSPopover';
 import {spacingVars, colorVars, typeScaleVars} from '../theme/tokens.stylex';
 import {useInternalConfig} from './useInternalConfig';
 import {usePowerSearchSource} from './usePowerSearchSource';
@@ -483,10 +483,11 @@ export function XDSPowerSearch({
     setPopoverStateRaw({type: 'idle'});
   }, []);
 
-  const layer = useXDSLayer({
-    mode: 'context',
-    lightDismiss: true,
+  const popover = useXDSPopover({
     onHide: handleLayerHide,
+    hasLightDismiss: true,
+    hasCloseButton: false,
+    hasAutoFocus: false,
   });
 
   // Wrapper that manages layer visibility and tokenizer focus alongside state
@@ -497,15 +498,15 @@ export function XDSPowerSearch({
         // Schedule after the current frame so React can render the popover
         // content and the typeahead's synchronous focus() has completed
         requestAnimationFrame(() => {
-          layer.show();
+          popover.show();
           tokenizerRef.current?.blur();
         });
       } else {
-        layer.hide();
+        popover.hide();
         tokenizerRef.current?.focus();
       }
     },
-    [layer],
+    [popover],
   );
 
   // Expose imperative handle
@@ -776,7 +777,7 @@ export function XDSPowerSearch({
 
   return (
     <>
-      <div ref={layer.ref}>
+      <div ref={popover.triggerRef}>
         <XDSTokenizer
           ref={tokenizerRef}
           label={label}
@@ -802,7 +803,7 @@ export function XDSPowerSearch({
           data-testid={testId}
         />
       </div>
-      {layer.render(
+      {popover.render(
         popoverPartialFilter ? (
           <PowerSearchEditPopover
             config={config}

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -133,7 +133,6 @@ const styles = stylex.create({
     maxHeight: '300px',
     overflowY: 'auto',
     padding: spacingVars['--spacing-1'],
-    borderRadius: radiusVars['--radius-container'],
     opacity: 1,
     transition: `opacity ${durationVars['--duration-fast']}`,
   },

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSSelector.tsx
- * @input Uses React, StyleX, useXDSLayer, XDSIcon
+ * @input Uses React, StyleX, useXDSPopover, XDSIcon
  * @output Exports XDSSelector component
  * @position Core implementation; consumed by index.ts
  *
@@ -21,7 +21,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {useXDSLayer} from '../Layer/useXDSLayer';
+import {useXDSPopover} from '../Popover/useXDSPopover';
 import {XDSIcon} from '../Icon';
 import type {XDSIconName} from '../Icon';
 import {
@@ -134,8 +134,6 @@ const styles = stylex.create({
     overflowY: 'auto',
     padding: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-container'],
-    backgroundColor: colorVars['--color-background-surface'],
-    boxShadow: shadowVars['--shadow-low'],
     opacity: 1,
     transition: `opacity ${durationVars['--duration-fast']}`,
   },
@@ -442,15 +440,16 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
     triggerRef.current?.focus();
   }, []);
 
-  const layer = useXDSLayer({
-    mode: 'context',
-    lightDismiss: true,
+  const popover = useXDSPopover({
     onHide: handleLayerHide,
+    hasLightDismiss: true,
+    hasCloseButton: false,
+    hasAutoFocus: false,
   });
 
   // Calculate offset to position selected item over trigger
   const {offset: selectedItemOffset, isPositioned} = useSelectedItemOffset({
-    isOpen: layer.isOpen,
+    isOpen: popover.isOpen,
     selectedItemIndex,
     listboxId,
     listboxRef,
@@ -470,9 +469,9 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
     selectableItems,
     value,
     isDisabled,
-    isOpen: layer.isOpen,
-    onOpen: layer.show,
-    onClose: layer.hide,
+    isOpen: popover.isOpen,
+    onOpen: popover.show,
+    onClose: popover.hide,
     onSelect: useCallback(
       (newValue: string) => {
         onChange?.(newValue);
@@ -593,16 +592,16 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
           (
             triggerRef as React.MutableRefObject<HTMLButtonElement | null>
           ).current = el;
-          layer.ref(el);
+          popover.triggerRef(el);
         }}
         id={triggerId}
         type="button"
         role="combobox"
         aria-haspopup="listbox"
-        aria-expanded={layer.isOpen}
+        aria-expanded={popover.isOpen}
         aria-controls={listboxId}
         aria-activedescendant={
-          layer.isOpen && highlightedIndex >= 0
+          popover.isOpen && highlightedIndex >= 0
             ? getItemId(highlightedIndex)
             : undefined
         }
@@ -633,7 +632,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
         <span
           {...stylex.props(
             styles.triggerIcon,
-            !status && layer.isOpen && styles.triggerIconOpen,
+            !status && popover.isOpen && styles.triggerIconOpen,
             status && styles.triggerIconStatus,
           )}>
           {status ? (
@@ -648,7 +647,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
         </span>
       </button>
 
-      {layer.render(
+      {popover.render(
         <div
           ref={listboxRef}
           id={listboxId}

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSTabMenu.tsx
- * @input Uses React, StyleX, useXDSLayer, XDSTabListContext
+ * @input Uses React, StyleX, useXDSPopover, XDSTabListContext
  * @output Exports XDSTabMenu component, XDSTabMenuProps type, XDSTabMenuOption type
  * @position Menu trigger button; opens dropdown of overflow menu items
  *
@@ -23,11 +23,10 @@ import {
   radiusVars,
   durationVars,
   easeVars,
-  shadowVars,
   fontWeightVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
-import {useXDSLayer} from '../Layer/useXDSLayer';
+import {useXDSPopover} from '../Popover/useXDSPopover';
 import {useListFocus} from '../hooks/useListFocus';
 import {XDSDivider} from '../Divider';
 import {useXDSTabListContext} from './XDSTabListContext';
@@ -159,9 +158,6 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-0-5'],
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-1'],
-    backgroundColor: colorVars['--color-background-surface'],
-    borderRadius: radiusVars['--radius-container'],
-    boxShadow: shadowVars['--shadow-low'],
     minWidth: '160px',
   },
   menuItem: {
@@ -234,22 +230,23 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
   const tabListCtx = useXDSTabListContext();
   const menuId = useId();
 
-  const layer = useXDSLayer({
-    mode: 'context',
-    lightDismiss: true,
+  const popover = useXDSPopover({
+    hasLightDismiss: true,
+    hasCloseButton: false,
+    hasAutoFocus: false,
   });
 
   const {listRef, handleKeyDown: handleListKeyDown} = useListFocus({
-    onEscape: () => layer.hide(),
+    onEscape: () => popover.hide(),
   });
 
   const handleToggle = useCallback(() => {
-    if (layer.isOpen) {
-      layer.hide();
+    if (popover.isOpen) {
+      popover.hide();
     } else {
-      layer.show();
+      popover.show();
     }
-  }, [layer]);
+  }, [popover]);
 
   const selectedOption = options.find(o => o.value === tabListCtx.value);
   const triggerLabel = selectedOption?.label ?? label;
@@ -260,18 +257,18 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
   const handleSelect = useCallback(
     (value: string) => {
       tabListCtx.onChange(value);
-      layer.hide();
+      popover.hide();
     },
-    [tabListCtx, layer],
+    [tabListCtx, popover],
   );
 
   return (
     <>
       <button
-        ref={layer.ref}
+        ref={popover.triggerRef}
         type="button"
         aria-haspopup="menu"
-        aria-expanded={layer.isOpen}
+        aria-expanded={popover.isOpen}
         aria-controls={menuId}
         onClick={handleToggle}
         {...mergeProps(
@@ -298,11 +295,14 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
         </span>
         <span
           aria-hidden="true"
-          {...stylex.props(styles.chevron, layer.isOpen && styles.chevronOpen)}>
+          {...stylex.props(
+            styles.chevron,
+            popover.isOpen && styles.chevronOpen,
+          )}>
           <XDSIcon icon="chevronDown" size="sm" color="inherit" />
         </span>
       </button>
-      {layer.render(
+      {popover.render(
         <div
           ref={listRef as React.RefObject<HTMLDivElement | null>}
           id={menuId}

--- a/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/XDSBaseTypeahead.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSBaseTypeahead.tsx
- * @input Uses React, StyleX, useXDSLayer, XDSTypeaheadItem
+ * @input Uses React, StyleX, useXDSPopover, XDSTypeaheadItem
  * @output Exports XDSBaseTypeahead combobox engine component
  * @position Core implementation; used by XDSTypeahead and XDSTokenizer
  *
@@ -26,7 +26,7 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {useXDSLayer} from '../Layer/useXDSLayer';
+import {useXDSPopover} from '../Popover/useXDSPopover';
 import {XDSTypeaheadItem} from './XDSTypeaheadItem';
 import {XDSIcon} from '../Icon';
 import {
@@ -35,7 +35,6 @@ import {
   radiusVars,
   typographyVars,
   fontWeightVars,
-  shadowVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
@@ -177,9 +176,6 @@ const styles = stylex.create({
     maxHeight: '300px',
     overflowY: 'auto',
     padding: spacingVars['--spacing-1'],
-    borderRadius: radiusVars['--radius-container'],
-    backgroundColor: colorVars['--color-background-surface'],
-    boxShadow: shadowVars['--shadow-low'],
   },
   popover: {
     minWidth: 'anchor-size(width)',
@@ -285,7 +281,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
   const [isLoading, setIsLoading] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
 
-  // Track active pointer to defer layer.show() past click events.
+  // Track active pointer to defer popover.show() past click events.
   // With popover="auto", showing the popover between pointerdown and
   // pointerup/click causes the browser's light-dismiss to immediately
   // close it (the click is seen as "outside" the newly-opened popover).
@@ -305,11 +301,12 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
     searchSource.cancel?.();
   }, [onOpenChange, searchSource]);
 
-  const layer = useXDSLayer({
-    mode: 'context',
-    lightDismiss: true,
+  const popover = useXDSPopover({
     onShow: handleLayerShow,
     onHide: handleLayerHide,
+    hasLightDismiss: true,
+    hasCloseButton: false,
+    hasAutoFocus: false,
   });
 
   // Show the layer, deferring past the active click if a pointer is down.
@@ -319,13 +316,13 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
     if (pointerActiveRef.current) {
       document.addEventListener(
         'click',
-        () => requestAnimationFrame(() => layer.show()),
+        () => requestAnimationFrame(() => popover.show()),
         {once: true},
       );
     } else {
-      layer.show();
+      popover.show();
     }
-  }, [layer]);
+  }, [popover]);
 
   // Merge refs: forward ref + internal ref + fallback anchor ref
   const setInputRef = useCallback(
@@ -346,12 +343,12 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
   useEffect(() => {
     const el = anchorRef?.current ?? fallbackAnchorRef.current;
     if (el) {
-      layer.ref(el);
+      popover.triggerRef(el);
     }
     return () => {
-      layer.ref(null);
+      popover.triggerRef(null);
     };
-  }, [layer, anchorRef]);
+  }, [popover, anchorRef]);
 
   // Perform search
   const performSearch = useCallback(
@@ -407,7 +404,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
         searchSource.cancel?.();
         setResults([]);
         setHasSearched(false);
-        layer.hide();
+        popover.hide();
         return;
       }
 
@@ -430,7 +427,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
       hasEntriesOnFocus,
       performSearch,
       performBootstrap,
-      layer,
+      popover,
       debounceMs,
       searchSource,
     ],
@@ -451,10 +448,10 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
       setQuery('');
       setResults([]);
       setHasSearched(false);
-      layer.hide();
+      popover.hide();
       inputRef.current?.focus();
     },
-    [onChange, layer],
+    [onChange, popover],
   );
 
   // Handle focus
@@ -480,11 +477,11 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
       externalOnKeyDown?.(e);
       if (e.defaultPrevented) return;
 
-      if (!layer.isOpen) {
+      if (!popover.isOpen) {
         if (e.key === 'ArrowDown' && (hasEntriesOnFocus || query.length > 0)) {
           e.preventDefault();
           if (results.length > 0) {
-            layer.show();
+            popover.show();
             setHighlightedIndex(0);
           } else if (hasEntriesOnFocus) {
             performBootstrap();
@@ -514,16 +511,16 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
           break;
         case 'Escape':
           e.preventDefault();
-          layer.hide();
+          popover.hide();
           break;
         case 'Home':
-          if (layer.isOpen) {
+          if (popover.isOpen) {
             e.preventDefault();
             setHighlightedIndex(0);
           }
           break;
         case 'End':
-          if (layer.isOpen) {
+          if (popover.isOpen) {
             e.preventDefault();
             setHighlightedIndex(results.length - 1);
           }
@@ -531,7 +528,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
       }
     },
     [
-      layer,
+      popover,
       results,
       highlightedIndex,
       handleSelect,
@@ -565,10 +562,10 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
         id={inputId}
         type="text"
         role="combobox"
-        aria-expanded={layer.isOpen}
+        aria-expanded={popover.isOpen}
         aria-controls={listboxId}
         aria-activedescendant={
-          layer.isOpen && highlightedIndex >= 0
+          popover.isOpen && highlightedIndex >= 0
             ? getItemId(highlightedIndex)
             : undefined
         }
@@ -607,7 +604,7 @@ export const XDSBaseTypeahead = function XDSBaseTypeahead<
         </span>
       )}
 
-      {layer.render(
+      {popover.render(
         <div
           id={listboxId}
           role="listbox"


### PR DESCRIPTION
## Problem

Six components use `useXDSLayer` directly with manual popover surface styles (`--color-background-surface`, `--shadow-low`, `--radius-container`). Since #964 embedded these into `useXDSPopover`, they should use the hook instead — both for consistency and to pick up the correct `--color-background-popover` token.

## Changes

| Component | File | What changed |
|-----------|------|-------------|
| **DropdownMenu** | `XDSDropdownMenu.tsx` | `useXDSLayer` → `useXDSPopover`, removed manual bg/shadow |
| **MoreMenu** | `XDSMoreMenu.tsx` | Same pattern |
| **TabMenu** | `XDSTabMenu.tsx` | Same pattern |
| **Selector** | `XDSSelector.tsx` | Same pattern (kept trigger bg) |
| **BaseTypeahead** | `XDSBaseTypeahead.tsx` | Same pattern |
| **PowerSearch** | `XDSPowerSearch.tsx` + `PowerSearchEditPopover.tsx` | Layer host migrated; edit popover surface styles removed (provided by hook now) |

For each component:
1. Replaced `useXDSLayer({ mode: 'context', ... })` with `useXDSPopover({ hasCloseButton: false, hasAutoFocus: false, ... })`
2. Changed `layer.ref` → `popover.triggerRef`, `layer.*` → `popover.*`
3. Removed manual `backgroundColor`, `boxShadow`, `borderRadius` from dropdown/menu styles
4. Removed unused `shadowVars` imports
5. Updated JSDoc `@input` lines

All components use `hasCloseButton: false` and `hasAutoFocus: false` since they manage their own keyboard navigation and focus behavior.

## Test

All 2,149 tests pass. Build succeeds.

Closes #994

---
