### PR TITLE
docs: update create-component command to reference Component Lifecycle wiki

### DIFF
--- a/.claude/commands/create-component.md
+++ b/.claude/commands/create-component.md
@@ -8,10 +8,11 @@ $ARGUMENTS
 
 ## Instructions
 
-Follow the two-phase protocol documented on the XDS wiki:
+Follow the full component lifecycle documented on the XDS wiki:
 
-1. **Specification Protocol**: https://github.com/facebookexperimental/xds/wiki/Component-Specification-Protocol
-2. **Build Protocol**: https://github.com/facebookexperimental/xds/wiki/Component-Build-Protocol
+- **Lifecycle Overview**: https://github.com/facebookexperimental/xds/wiki/Component-Lifecycle
+- **Specification Protocol**: https://github.com/facebookexperimental/xds/wiki/Component-Specification-Protocol
+- **Build Protocol**: https://github.com/facebookexperimental/xds/wiki/Component-Build-Protocol
 
 ### Quick reference
 


### PR DESCRIPTION
The component wiki pages were consolidated — **Component Lifecycle** is now the canonical entry point covering the full Specify → Build → Harden → Maintain loop.

This PR updates the Claude Code `create-component` command to link to it instead of the old two-page split.

### Wiki changes (already pushed)
- Merged 'Before You Start' triage and 'Common Pitfalls' from Creating-New-Components into Component-Lifecycle
- Replaced Creating-New-Components with a redirect to Component-Lifecycle
- Updated all references across 7 wiki pages: Home, Component-Authoring-Guide, Component-Build-Protocol, Component-Specification-Protocol, Contributing-with-AI-Assistants, System-Architecture, XDS-Philosophy

### What stays the same
- **Component Build Protocol** — detailed build phases + 27-item self-review checklist (unchanged)
- **Component Authoring Guide** — implementation cookbook: file structure, StyleX, tokens, templates (unchanged)
- **Component Specification Protocol** — 8-phase spec protocol (unchanged)

---
