### PR TITLE
ci: auto-create hardening issues for new components

### DIFF
--- a/.github/workflows/hardening-issue.yml
+++ b/.github/workflows/hardening-issue.yml
@@ -1,0 +1,97 @@
+# Auto-create hardening issues for new components
+#
+# When a PR merges that adds a new component directory under packages/core/src/,
+# this workflow creates a "Hardening: XDS<Name>" issue linking the hardening
+# protocol wiki — unless one already exists.
+
+name: Hardening Issue
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  issues: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  create-hardening-issues:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect new components and create hardening issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            // Get files changed in this PR
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              { owner, repo, pull_number: pr.number }
+            );
+
+            // Find new component directories: packages/core/src/<Name>/XDS<Name>.tsx
+            const newComponentPattern = /^packages\/core\/src\/([A-Z][A-Za-z]+)\/XDS\1\.tsx$/;
+            const newComponents = new Set();
+
+            for (const file of files) {
+              if (file.status === 'added') {
+                const match = file.filename.match(newComponentPattern);
+                if (match) {
+                  newComponents.add(match[1]);
+                }
+              }
+            }
+
+            if (newComponents.size === 0) {
+              console.log('No new components detected.');
+              return;
+            }
+
+            console.log(`Detected new components: ${[...newComponents].join(', ')}`);
+
+            // Check for existing hardening issues
+            for (const name of newComponents) {
+              const title = `Hardening: XDS${name}`;
+
+              const { data: existing } = await github.rest.search.issuesAndPullRequests({
+                q: `repo:${owner}/${repo} is:issue "${title}" in:title`,
+              });
+
+              if (existing.total_count > 0) {
+                console.log(`Issue already exists for ${title}, skipping.`);
+                continue;
+              }
+
+              const body = [
+                `## ${title}`,
+                '',
+                `Follow the [Component Hardening Protocol](https://github.com/${owner}/${repo}/wiki/Component-Hardening-Protocol) to harden this component.`,
+                '',
+                '### Instructions',
+                '',
+                'Complete all steps outlined in the wiki:',
+                '',
+                '1. **Automated audit** — run convention checks (tokens, naming, theming, a11y contracts, exports)',
+                '2. **Bug & visual fixes** — fix visual bugs, state coverage gaps, edge cases, internal consistency',
+                '3. **Design review** — evaluate proportions, interaction feel, composition quality, visual polish',
+                '',
+                `Refer to the [Component Hardening Protocol](https://github.com/${owner}/${repo}/wiki/Component-Hardening-Protocol) for full details on scope, methodology, and completion criteria.`,
+                '',
+                `_Auto-created from #${pr.number}_`,
+              ].join('\n');
+
+              const { data: issue } = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['hardening'],
+              });
+
+              console.log(`Created ${title}: #${issue.number}`);
+            }


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow that automatically creates hardening issues when a PR merges a new component.

## How

- Triggers on PR merge to `main`
- Detects new components by checking for added files matching `packages/core/src/<Name>/XDS<Name>.tsx`
- Searches existing issues to avoid duplicates (matches `Hardening: XDS<Name>` title pattern)
- Creates an issue with the `hardening` label linking to the [Component Hardening Protocol](https://github.com/facebookexperimental/xds/wiki/Component-Hardening-Protocol) wiki

## Why

Build → harden is the standard component lifecycle. This closes the gap automatically so no one has to remember to file the hardening issue after a build PR merges.