### PR TITLE
[easy] fix bug in XDSMultiSelector

### DIFF
--- a/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
@@ -321,6 +321,28 @@ describe('XDSMultiSelector', () => {
     expect(onChange).toHaveBeenCalledWith(['Apple']);
   });
 
+  it('toggles the correct item when selected items are sorted to top', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    // Orange is selected, so sorted order is: Orange, Apple, Banana
+    render(
+      <XDSMultiSelector
+        label="Fruit"
+        options={defaultOptions}
+        value={['Orange']}
+        onChange={onChange}
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    // highlightedIndex starts at 0 which is Orange (sorted first)
+    await user.keyboard('{ArrowDown}');
+    // Now at index 1 which should be Apple
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledWith(['Orange', 'Apple']);
+  });
+
   it('renders select-all checkbox when hasSelectAll', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -527,6 +527,55 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     );
   }, [selectableItems, searchQuery]);
 
+  // Sorted items for keyboard navigation — matches the visual render order.
+  // Selected-at-open items are placed first so the highlight index and the
+  // toggle target always refer to the same item the user sees.
+  const sortedItems = useMemo(() => {
+    const selectedSet = selectedAtOpenRef.current ?? new Set(optimisticValue);
+    if (searchQuery) {
+      const selected = filteredItems.filter(item =>
+        selectedSet.has(item.value),
+      );
+      const unselected = filteredItems.filter(
+        item => !selectedSet.has(item.value),
+      );
+      return [...selected, ...unselected];
+    }
+    // For non-search mode, flatten options in the same order as renderOptions
+    const result: XDSMultiSelectorOptionData[] = [];
+    let pendingFlat: XDSMultiSelectorOptionData[] = [];
+
+    const flushFlat = () => {
+      if (pendingFlat.length === 0) return;
+      const selected = pendingFlat.filter(item => selectedSet.has(item.value));
+      const unselected = pendingFlat.filter(
+        item => !selectedSet.has(item.value),
+      );
+      result.push(...selected, ...unselected);
+      pendingFlat = [];
+    };
+
+    for (const option of options) {
+      if (isDivider(option)) {
+        flushFlat();
+      } else if (isSection(option)) {
+        flushFlat();
+        const sectionOptions = option.options.map(opt => normalizeOption(opt));
+        const selected = sectionOptions.filter(item =>
+          selectedSet.has(item.value),
+        );
+        const unselected = sectionOptions.filter(
+          item => !selectedSet.has(item.value),
+        );
+        result.push(...selected, ...unselected);
+      } else if (isOptionData(option)) {
+        pendingFlat.push(normalizeOption(option));
+      }
+    }
+    flushFlat();
+    return result;
+  }, [filteredItems, searchQuery, options, optimisticValue]);
+
   // Layer for dropdown positioning
   const handleLayerHide = useCallback(() => {
     setSearchQuery('');
@@ -574,7 +623,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     onKeyDown,
     onItemMouseEnter,
   } = useMultiCombobox({
-    selectableItems: filteredItems,
+    selectableItems: sortedItems,
     isDisabled,
     isOpen: popover.isOpen,
     hasSearch,


### PR DESCRIPTION
Keyboard nav for XDSMultiSelector wasn't working (if you highlight an item and press enter it would unselect a random other item).

Root cause: useMultiCombobox received filteredItems (original option order), but renderOptions re-sorted items with selected-first ordering. The highlightedIndex tracked the visual position (sorted order), but onKeyDown's Enter handler looked up selectableItems[highlightedIndex] in the unsorted array — toggling the wrong item.

Fix: Computed a sortedItems array that matches the visual render order, and passed that to useMultiCombobox instead of the unsorted filteredItems. Now the highlight index and toggle target always refer to the same item the user sees.