### PR TITLE
fix(Table): column widths not applied correctly

### DIFF
--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -236,26 +236,39 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
       col,
     );
 
-    // Apply column min-width on the <th>. With table-layout: fixed,
+    // Apply column width on the <th>. With table-layout: fixed,
     // header cell sizing controls column widths.
-    // Proportional columns (or columns without explicit width) get a default minWidth.
     const colWidth = col.width;
-    const minW =
-      !colWidth || colWidth.type === 'proportional'
-        ? (colWidth?.minWidth ?? DEFAULT_MIN_COLUMN_WIDTH)
-        : undefined;
-    const minWidthStyle = minW != null ? {minWidth: `${minW}px`} : undefined;
+    const widthStyle: React.CSSProperties = {};
+
+    if (colWidth?.type === 'pixel') {
+      // Fixed pixel width — set both width and minWidth to prevent shrinking
+      widthStyle.width = `${colWidth.value}px`;
+      widthStyle.minWidth = `${colWidth.value}px`;
+    } else {
+      // Proportional width — compute percentage from total proportional units.
+      const totalProportion = resolvedColumns.reduce((sum, c) => {
+        const w = c.width;
+        if (!w || w.type === 'proportional') {
+          return sum + (w?.value ?? 1);
+        }
+        return sum;
+      }, 0);
+      const proportion = colWidth?.value ?? 1;
+      if (totalProportion > 0) {
+        widthStyle.width = `${(proportion / totalProportion) * 100}%`;
+      }
+      const minW = colWidth?.minWidth ?? DEFAULT_MIN_COLUMN_WIDTH;
+      widthStyle.minWidth = `${minW}px`;
+    }
+
     const existingStyle = cellRenderProps.htmlProps.style as
       | React.CSSProperties
       | undefined;
-    const mergedHtmlProps = minWidthStyle
-      ? {
-          ...cellRenderProps.htmlProps,
-          style: existingStyle
-            ? {...existingStyle, ...minWidthStyle}
-            : minWidthStyle,
-        }
-      : cellRenderProps.htmlProps;
+    const mergedHtmlProps = {
+      ...cellRenderProps.htmlProps,
+      style: existingStyle ? {...existingStyle, ...widthStyle} : widthStyle,
+    };
 
     // Resolve header content from slots — plugins write to named slots
     // to avoid conflicts (e.g. sort writes `after`, resize writes `overlay`)

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -451,14 +451,14 @@ describe('XDSBaseTable', () => {
       });
     });
 
-    it('does not set minWidth on pixel columns', () => {
+    it('sets minWidth on pixel columns to prevent shrinking', () => {
       const cols: XDSTableColumn<User>[] = [
         {key: 'name', header: 'Name', width: pixel(80)},
         {key: 'age', header: 'Age', width: proportional(1)},
       ];
       render(<XDSBaseTable data={users} columns={cols} />);
       const headers = screen.getAllByRole('columnheader');
-      expect(headers[0].style.minWidth).toBe('');
+      expect(headers[0]).toHaveStyle({width: '80px', minWidth: '80px'});
       expect(headers[1]).toHaveStyle({
         minWidth: `${DEFAULT_MIN_COLUMN_WIDTH}px`,
       });


### PR DESCRIPTION
## Summary

- **Bug**: All table columns rendered at equal width regardless of `pixel()` or `proportional()` configuration
- **Root cause**: `XDSBaseTable` uses `table-layout: fixed`, which distributes columns equally when no explicit `width` is set on header cells. The previous code only applied `minWidth` to proportional columns and set nothing on pixel columns.
- **Fix**: 
  - `pixel(N)` columns now get `width: Npx` and `minWidth: Npx` (prevents shrinking below stated width)
  - `proportional(N)` columns get a percentage `width` based on their share of total proportional units, plus `minWidth` to prevent over-shrinking

## Test plan

- [x] Updated existing test (`does not set minWidth on pixel columns` → `sets minWidth on pixel columns to prevent shrinking`)
- [x] All 142 Table tests pass (unit, perf, plugin tests)
- [ ] Visual check: columns with `pixel(80)` render narrower than `proportional(2)` columns