### PR TITLE
feat(sandbox): Add full-page application templates

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/template-dashboard/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-dashboard/page.tsx
@@ -1,0 +1,618 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSSideNav,
+  XDSSideNavItem,
+  XDSSideNavSection,
+  XDSSideNavCollapseButton,
+} from '@xds/core/SideNav';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSProgressBar} from '@xds/core/ProgressBar';
+import {XDSButton} from '@xds/core/Button';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+import {XDSTable, proportional, pixel} from '@xds/core/Table';
+import type {XDSTableColumn} from '@xds/core/Table';
+
+// =============================================================================
+// Icons
+// =============================================================================
+
+const DashboardIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <rect x="3" y="3" width="7" height="7" rx="1" />
+    <rect x="14" y="3" width="7" height="7" rx="1" />
+    <rect x="3" y="14" width="7" height="7" rx="1" />
+    <rect x="14" y="14" width="7" height="7" rx="1" />
+  </svg>
+);
+const AnalyticsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M18 20V10M12 20V4M6 20v-6" />
+  </svg>
+);
+const UsersIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+  </svg>
+);
+const OrdersIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4zM3 6h18M16 10a4 4 0 0 1-8 0" />
+  </svg>
+);
+const SettingsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+  </svg>
+);
+
+// =============================================================================
+// Mock data
+// =============================================================================
+
+const stats = [
+  {
+    label: 'Total Revenue',
+    value: '$45,231.89',
+    change: '+20.1%',
+    positive: true,
+  },
+  {label: 'Subscriptions', value: '2,350', change: '+180.1%', positive: true},
+  {label: 'Active Users', value: '12,234', change: '+19%', positive: true},
+  {label: 'Bounce Rate', value: '21.3%', change: '-4.5%', positive: true},
+];
+
+interface OrderRow extends Record<string, unknown> {
+  id: string;
+  customer: string;
+  avatar: string;
+  email: string;
+  amount: string;
+  status: 'completed' | 'processing' | 'failed';
+  date: string;
+}
+
+const recentOrders: OrderRow[] = [
+  {
+    id: '1',
+    customer: 'Olivia Martin',
+    avatar: 'https://i.pravatar.cc/36?img=1',
+    email: 'olivia@example.com',
+    amount: '$1,999.00',
+    status: 'completed',
+    date: 'Mar 28',
+  },
+  {
+    id: '2',
+    customer: 'Jackson Lee',
+    avatar: 'https://i.pravatar.cc/36?img=2',
+    email: 'jackson@example.com',
+    amount: '$39.00',
+    status: 'processing',
+    date: 'Mar 27',
+  },
+  {
+    id: '3',
+    customer: 'Isabella Nguyen',
+    avatar: 'https://i.pravatar.cc/36?img=3',
+    email: 'isabella@example.com',
+    amount: '$299.00',
+    status: 'completed',
+    date: 'Mar 27',
+  },
+  {
+    id: '4',
+    customer: 'William Kim',
+    avatar: 'https://i.pravatar.cc/36?img=4',
+    email: 'will@example.com',
+    amount: '$99.00',
+    status: 'failed',
+    date: 'Mar 26',
+  },
+  {
+    id: '5',
+    customer: 'Sofia Davis',
+    avatar: 'https://i.pravatar.cc/36?img=5',
+    email: 'sofia@example.com',
+    amount: '$599.00',
+    status: 'completed',
+    date: 'Mar 26',
+  },
+];
+
+const teamMembers = [
+  {
+    name: 'Sofia Davis',
+    role: 'Engineering Lead',
+    avatar: 'https://i.pravatar.cc/36?img=5',
+  },
+  {
+    name: 'Jackson Lee',
+    role: 'Product Designer',
+    avatar: 'https://i.pravatar.cc/36?img=2',
+  },
+  {
+    name: 'Isabella Nguyen',
+    role: 'Frontend Engineer',
+    avatar: 'https://i.pravatar.cc/36?img=3',
+  },
+];
+
+// =============================================================================
+// Table columns
+// =============================================================================
+
+const orderColumns: XDSTableColumn<OrderRow>[] = [
+  {
+    key: 'customer',
+    header: 'Customer',
+    width: proportional(4),
+    renderCell: (item: OrderRow) => (
+      <XDSHStack gap={3} vAlign="center">
+        <XDSAvatar src={item.avatar} name={item.customer} size="small" />
+        <XDSVStack gap={0}>
+          <XDSText type="body" weight="bold">
+            {item.customer}
+          </XDSText>
+          <XDSText type="supporting" color="secondary">
+            {item.email}
+          </XDSText>
+        </XDSVStack>
+      </XDSHStack>
+    ),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    width: pixel(130),
+    renderCell: (item: OrderRow) => (
+      <XDSBadge
+        variant={
+          item.status === 'completed'
+            ? 'success'
+            : item.status === 'processing'
+              ? 'info'
+              : 'error'
+        }
+        label={item.status.charAt(0).toUpperCase() + item.status.slice(1)}
+      />
+    ),
+  },
+  {
+    key: 'date',
+    header: 'Date',
+    width: pixel(100),
+    renderCell: (item: OrderRow) => (
+      <XDSText type="supporting" color="secondary">
+        {item.date}
+      </XDSText>
+    ),
+  },
+  {
+    key: 'amount',
+    header: 'Amount',
+    width: pixel(120),
+    renderCell: (item: OrderRow) => (
+      <XDSText type="body" weight="bold">
+        {item.amount}
+      </XDSText>
+    ),
+  },
+];
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  statsGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(4, 1fr)',
+    gap: 16,
+  },
+  statCard: {
+    padding: '20px 24px',
+  },
+  changePositive: {
+    color: '#16a34a',
+  },
+  changeNegative: {
+    color: '#dc2626',
+  },
+  contentGrid: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 320px',
+    gap: 24,
+  },
+  chartPlaceholder: {
+    height: 240,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 8,
+    backgroundColor: 'var(--color-surface-wash, #f5f5f5)',
+  },
+  barChart: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    gap: 8,
+    height: 180,
+    padding: '0 24px',
+  },
+  bar: {
+    flex: 1,
+    borderRadius: '4px 4px 0 0',
+    backgroundColor: 'var(--color-action-primary, #0066ff)',
+    opacity: 0.8,
+    minWidth: 20,
+  },
+  barLabel: {
+    textAlign: 'center' as const,
+    marginTop: 8,
+  },
+  teamCard: {
+    padding: 16,
+  },
+  progress: {
+    padding: '0 24px 24px',
+  },
+});
+
+// =============================================================================
+// Components
+// =============================================================================
+
+function StatCard({label, value, change, positive}: (typeof stats)[0]) {
+  return (
+    <XDSCard>
+      <div {...stylex.props(styles.statCard)}>
+        <XDSVStack gap={1}>
+          <XDSText type="supporting" color="secondary">
+            {label}
+          </XDSText>
+          <XDSText type="large" weight="bold">
+            {value}
+          </XDSText>
+          <XDSText type="supporting" color={positive ? undefined : 'secondary'}>
+            <span
+              {...stylex.props(
+                positive ? styles.changePositive : styles.changeNegative,
+              )}>
+              {change}
+            </span>{' '}
+            from last month
+          </XDSText>
+        </XDSVStack>
+      </div>
+    </XDSCard>
+  );
+}
+
+const monthlyData = [
+  {month: 'Jan', value: 65},
+  {month: 'Feb', value: 45},
+  {month: 'Mar', value: 80},
+  {month: 'Apr', value: 55},
+  {month: 'May', value: 70},
+  {month: 'Jun', value: 90},
+  {month: 'Jul', value: 60},
+  {month: 'Aug', value: 85},
+  {month: 'Sep', value: 75},
+  {month: 'Oct', value: 95},
+  {month: 'Nov', value: 88},
+  {month: 'Dec', value: 72},
+];
+
+function MiniBarChart() {
+  const max = Math.max(...monthlyData.map(d => d.value));
+  return (
+    <XDSVStack gap={2}>
+      <div {...stylex.props(styles.barChart)}>
+        {monthlyData.map(d => (
+          <div
+            key={d.month}
+            style={{
+              flex: 1,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}>
+            <div
+              {...stylex.props(styles.bar)}
+              style={{height: `${(d.value / max) * 100}%`}}
+            />
+            <div {...stylex.props(styles.barLabel)}>
+              <XDSText type="supporting" color="secondary">
+                {d.month}
+              </XDSText>
+            </div>
+          </div>
+        ))}
+      </div>
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// Sidebar
+// =============================================================================
+
+function DashboardSideNav() {
+  const [active, setActive] = useState('dashboard');
+  return (
+    <XDSSideNav
+      header={
+        <div
+          style={{
+            padding: '12px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}>
+          <XDSNavIcon
+            icon={<AnalyticsIcon style={{width: 16, height: 16}} />}
+          />
+          <XDSText type="body" weight="bold">
+            Acme Inc
+          </XDSText>
+        </div>
+      }
+      footer={<XDSSideNavCollapseButton />}>
+      <XDSSideNavSection title="Overview">
+        <XDSSideNavItem
+          label="Dashboard"
+          icon={DashboardIcon}
+          isSelected={active === 'dashboard'}
+          onClick={() => setActive('dashboard')}
+        />
+        <XDSSideNavItem
+          label="Analytics"
+          icon={AnalyticsIcon}
+          isSelected={active === 'analytics'}
+          onClick={() => setActive('analytics')}
+        />
+      </XDSSideNavSection>
+      <XDSSideNavSection title="Management">
+        <XDSSideNavItem
+          label="Customers"
+          icon={UsersIcon}
+          isSelected={active === 'customers'}
+          onClick={() => setActive('customers')}
+        />
+        <XDSSideNavItem
+          label="Orders"
+          icon={OrdersIcon}
+          isSelected={active === 'orders'}
+          onClick={() => setActive('orders')}
+        />
+        <XDSSideNavItem
+          label="Settings"
+          icon={SettingsIcon}
+          isSelected={active === 'settings'}
+          onClick={() => setActive('settings')}
+        />
+      </XDSSideNavSection>
+    </XDSSideNav>
+  );
+}
+
+// =============================================================================
+// TopNav
+// =============================================================================
+
+function DashboardTopNav() {
+  return (
+    <XDSTopNav
+      startContent={
+        <>
+          <XDSTopNavItem label="Overview" isSelected />
+          <XDSTopNavItem label="Analytics" />
+          <XDSTopNavItem label="Reports" />
+        </>
+      }
+      endContent={
+        <XDSAvatar
+          src="https://i.pravatar.cc/36?img=12"
+          name="Admin User"
+          size="xsmall"
+        />
+      }>
+      <XDSTopNavHeading>Dashboard</XDSTopNavHeading>
+    </XDSTopNav>
+  );
+}
+
+// =============================================================================
+// Page
+// =============================================================================
+
+export default function DashboardTemplate() {
+  return (
+    <XDSAppShell
+      sideNav={<DashboardSideNav />}
+      topNav={<DashboardTopNav />}
+      variant="elevated"
+      contentPadding={6}>
+      <XDSVStack gap={6}>
+        <XDSVStack gap={1}>
+          <XDSHeading level={1}>Dashboard</XDSHeading>
+          <XDSText type="body" color="secondary">
+            Welcome back! Here&apos;s what&apos;s happening with your business
+            today.
+          </XDSText>
+        </XDSVStack>
+
+        {/* Stats Grid */}
+        <div {...stylex.props(styles.statsGrid)}>
+          {stats.map(stat => (
+            <StatCard key={stat.label} {...stat} />
+          ))}
+        </div>
+
+        {/* Main Content */}
+        <div {...stylex.props(styles.contentGrid)}>
+          {/* Chart + Table column */}
+          <XDSVStack gap={6}>
+            <XDSCard>
+              <div style={{padding: '24px 24px 0'}}>
+                <XDSVStack gap={1}>
+                  <XDSText type="body" weight="bold">
+                    Revenue Overview
+                  </XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    Monthly revenue for the current year
+                  </XDSText>
+                </XDSVStack>
+              </div>
+              <MiniBarChart />
+            </XDSCard>
+
+            <XDSCard>
+              <div style={{padding: '20px 24px 8px'}}>
+                <XDSHStack gap={3} vAlign="center">
+                  <div style={{flex: 1}}>
+                    <XDSText type="body" weight="bold">
+                      Recent Orders
+                    </XDSText>
+                  </div>
+                  <XDSButton label="View all" variant="ghost" size="sm" />
+                </XDSHStack>
+              </div>
+              <XDSTable<OrderRow>
+                data={recentOrders}
+                columns={orderColumns}
+                idKey="id"
+                density="balanced"
+                dividers="rows"
+                hasHover
+              />
+            </XDSCard>
+          </XDSVStack>
+
+          {/* Sidebar column */}
+          <XDSVStack gap={6}>
+            <XDSCard>
+              <div style={{padding: '20px 24px'}}>
+                <XDSVStack gap={4}>
+                  <XDSText type="body" weight="bold">
+                    Team Members
+                  </XDSText>
+                  {teamMembers.map(member => (
+                    <XDSHStack key={member.name} gap={3} vAlign="center">
+                      <XDSAvatar
+                        src={member.avatar}
+                        name={member.name}
+                        size="small"
+                      />
+                      <XDSVStack gap={0}>
+                        <XDSText type="body" weight="bold">
+                          {member.name}
+                        </XDSText>
+                        <XDSText type="supporting" color="secondary">
+                          {member.role}
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSHStack>
+                  ))}
+                </XDSVStack>
+              </div>
+            </XDSCard>
+
+            <XDSCard>
+              <div style={{padding: '20px 24px'}}>
+                <XDSVStack gap={4}>
+                  <XDSText type="body" weight="bold">
+                    Goals
+                  </XDSText>
+                  <XDSVStack gap={3}>
+                    <XDSVStack gap={1}>
+                      <XDSHStack gap={2} vAlign="center">
+                        <div style={{flex: 1}}>
+                          <XDSText type="supporting">Revenue target</XDSText>
+                        </div>
+                        <XDSText type="supporting" weight="bold">
+                          72%
+                        </XDSText>
+                      </XDSHStack>
+                      <XDSProgressBar
+                        value={72}
+                        label="Progress"
+                        isLabelHidden
+                      />
+                    </XDSVStack>
+                    <XDSVStack gap={1}>
+                      <XDSHStack gap={2} vAlign="center">
+                        <div style={{flex: 1}}>
+                          <XDSText type="supporting">New users</XDSText>
+                        </div>
+                        <XDSText type="supporting" weight="bold">
+                          48%
+                        </XDSText>
+                      </XDSHStack>
+                      <XDSProgressBar
+                        value={48}
+                        label="Progress"
+                        isLabelHidden
+                      />
+                    </XDSVStack>
+                    <XDSVStack gap={1}>
+                      <XDSHStack gap={2} vAlign="center">
+                        <div style={{flex: 1}}>
+                          <XDSText type="supporting">Retention</XDSText>
+                        </div>
+                        <XDSText type="supporting" weight="bold">
+                          89%
+                        </XDSText>
+                      </XDSHStack>
+                      <XDSProgressBar
+                        value={89}
+                        label="Progress"
+                        isLabelHidden
+                      />
+                    </XDSVStack>
+                  </XDSVStack>
+                </XDSVStack>
+              </div>
+            </XDSCard>
+          </XDSVStack>
+        </div>
+      </XDSVStack>
+    </XDSAppShell>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-dashboard/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-dashboard/page.tsx
@@ -7,238 +7,175 @@ import {
   XDSSideNav,
   XDSSideNavItem,
   XDSSideNavSection,
-  XDSSideNavCollapseButton,
 } from '@xds/core/SideNav';
-import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSTopNav, XDSTopNavHeading} from '@xds/core/TopNav';
 import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSCard} from '@xds/core/Card';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSAvatar} from '@xds/core/Avatar';
-import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {XDSButton} from '@xds/core/Button';
 import {XDSNavIcon} from '@xds/core/NavIcon';
 import {XDSTable, proportional, pixel} from '@xds/core/Table';
 import type {XDSTableColumn} from '@xds/core/Table';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSLink} from '@xds/core/Link';
+import {
+  XDSSegmentedControl,
+  XDSSegmentedControlItem,
+} from '@xds/core/SegmentedControl';
 
-// =============================================================================
+
 // Icons
-// =============================================================================
-
 const DashboardIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
     <rect x="3" y="3" width="7" height="7" rx="1" />
     <rect x="14" y="3" width="7" height="7" rx="1" />
     <rect x="3" y="14" width="7" height="7" rx="1" />
     <rect x="14" y="14" width="7" height="7" rx="1" />
   </svg>
 );
+const LifecycleIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="9" />
+    <path d="M12 7v5l3 3" />
+  </svg>
+);
 const AnalyticsIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
     <path d="M18 20V10M12 20V4M6 20v-6" />
   </svg>
 );
-const UsersIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
+const ProjectsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path d="M2 17l10 5 10-5M2 12l10 5 10-5M12 2L2 7l10 5 10-5-10-5z" />
+  </svg>
+);
+const TeamIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
     <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
     <circle cx="9" cy="7" r="4" />
     <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
   </svg>
 );
-const OrdersIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M6 2L3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4zM3 6h18M16 10a4 4 0 0 1-8 0" />
+const DataIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <ellipse cx="12" cy="5" rx="9" ry="3" />
+    <path d="M21 12c0 1.66-4.03 3-9 3s-9-1.34-9-3" />
+    <path d="M3 5v14c0 1.66 4.03 3 9 3s9-1.34 9-3V5" />
+  </svg>
+);
+const ReportsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" />
+  </svg>
+);
+const WordIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
   </svg>
 );
 const SettingsIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
     <circle cx="12" cy="12" r="3" />
     <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
   </svg>
 );
+const HelpIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01" />
+  </svg>
+);
+const SearchIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="11" cy="11" r="8" />
+    <path d="M21 21l-4.35-4.35" />
+  </svg>
+);
+const MailIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <rect x="2" y="4" width="20" height="16" rx="2" />
+    <path d="M22 7l-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7" />
+  </svg>
+);
+const MoreIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}>
+    <circle cx="12" cy="12" r="1" /><circle cx="19" cy="12" r="1" /><circle cx="5" cy="12" r="1" />
+  </svg>
+);
+const TrendUpIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} width={16} height={16}>
+    <path d="M23 6l-9.5 9.5-5-5L1 18" /><path d="M17 6h6v6" />
+  </svg>
+);
+const TrendDownIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} width={16} height={16}>
+    <path d="M23 18l-9.5-9.5-5 5L1 6" /><path d="M17 18h6v-6" />
+  </svg>
+);
 
-// =============================================================================
 // Mock data
-// =============================================================================
-
 const stats = [
-  {
-    label: 'Total Revenue',
-    value: '$45,231.89',
-    change: '+20.1%',
-    positive: true,
-  },
-  {label: 'Subscriptions', value: '2,350', change: '+180.1%', positive: true},
-  {label: 'Active Users', value: '12,234', change: '+19%', positive: true},
-  {label: 'Bounce Rate', value: '21.3%', change: '-4.5%', positive: true},
+  {label: 'Total Revenue', value: '$1,250.00', change: '+12.5%', positive: true, desc: 'Trending up this month'},
+  {label: 'New Customers', value: '1,234', change: '-20%', positive: false, desc: 'Down 20% this period'},
+  {label: 'Active Accounts', value: '45,678', change: '+12.5%', positive: true, desc: 'Strong user retention'},
+  {label: 'Growth Rate', value: '4.5%', change: '+4.5%', positive: true, desc: 'Steady performance increase'},
 ];
 
-interface OrderRow extends Record<string, unknown> {
+interface DocRow extends Record<string, unknown> {
   id: string;
-  customer: string;
-  avatar: string;
-  email: string;
-  amount: string;
-  status: 'completed' | 'processing' | 'failed';
-  date: string;
+  header: string;
+  sectionType: string;
+  status: 'In Process' | 'Done' | 'Draft';
+  target: number;
+  limit: number;
+  reviewer: string;
 }
 
-const recentOrders: OrderRow[] = [
-  {
-    id: '1',
-    customer: 'Olivia Martin',
-    avatar: 'https://i.pravatar.cc/36?img=1',
-    email: 'olivia@example.com',
-    amount: '$1,999.00',
-    status: 'completed',
-    date: 'Mar 28',
-  },
-  {
-    id: '2',
-    customer: 'Jackson Lee',
-    avatar: 'https://i.pravatar.cc/36?img=2',
-    email: 'jackson@example.com',
-    amount: '$39.00',
-    status: 'processing',
-    date: 'Mar 27',
-  },
-  {
-    id: '3',
-    customer: 'Isabella Nguyen',
-    avatar: 'https://i.pravatar.cc/36?img=3',
-    email: 'isabella@example.com',
-    amount: '$299.00',
-    status: 'completed',
-    date: 'Mar 27',
-  },
-  {
-    id: '4',
-    customer: 'William Kim',
-    avatar: 'https://i.pravatar.cc/36?img=4',
-    email: 'will@example.com',
-    amount: '$99.00',
-    status: 'failed',
-    date: 'Mar 26',
-  },
-  {
-    id: '5',
-    customer: 'Sofia Davis',
-    avatar: 'https://i.pravatar.cc/36?img=5',
-    email: 'sofia@example.com',
-    amount: '$599.00',
-    status: 'completed',
-    date: 'Mar 26',
-  },
+const docRows: DocRow[] = [
+  {id: '1', header: 'Cover page', sectionType: 'Cover page', status: 'In Process', target: 18, limit: 5, reviewer: 'Eddie Lake'},
+  {id: '2', header: 'Table of contents', sectionType: 'Table of contents', status: 'Done', target: 20, limit: 24, reviewer: 'Eddie Lake'},
+  {id: '3', header: 'Executive summary', sectionType: 'Summary', status: 'In Process', target: 12, limit: 8, reviewer: 'Eddie Lake'},
+  {id: '4', header: 'Technical approach', sectionType: 'Technical', status: 'Draft', target: 45, limit: 30, reviewer: 'Eddie Lake'},
+  {id: '5', header: 'Design methodology', sectionType: 'Design', status: 'In Process', target: 22, limit: 15, reviewer: 'Eddie Lake'},
 ];
 
-const teamMembers = [
-  {
-    name: 'Sofia Davis',
-    role: 'Engineering Lead',
-    avatar: 'https://i.pravatar.cc/36?img=5',
-  },
-  {
-    name: 'Jackson Lee',
-    role: 'Product Designer',
-    avatar: 'https://i.pravatar.cc/36?img=2',
-  },
-  {
-    name: 'Isabella Nguyen',
-    role: 'Frontend Engineer',
-    avatar: 'https://i.pravatar.cc/36?img=3',
-  },
-];
-
-// =============================================================================
-// Table columns
-// =============================================================================
-
-const orderColumns: XDSTableColumn<OrderRow>[] = [
-  {
-    key: 'customer',
-    header: 'Customer',
-    width: proportional(4),
-    renderCell: (item: OrderRow) => (
-      <XDSHStack gap={3} vAlign="center">
-        <XDSAvatar src={item.avatar} name={item.customer} size="small" />
-        <XDSVStack gap={0}>
-          <XDSText type="body" weight="bold">
-            {item.customer}
-          </XDSText>
-          <XDSText type="supporting" color="secondary">
-            {item.email}
-          </XDSText>
-        </XDSVStack>
-      </XDSHStack>
-    ),
-  },
+const docColumns: XDSTableColumn<DocRow>[] = [
+  {key: 'header', header: 'Header', width: proportional(3)},
+  {key: 'sectionType', header: 'Section Type', width: proportional(2)},
   {
     key: 'status',
     header: 'Status',
     width: pixel(130),
-    renderCell: (item: OrderRow) => (
+    renderCell: (item: DocRow) => (
       <XDSBadge
-        variant={
-          item.status === 'completed'
-            ? 'success'
-            : item.status === 'processing'
-              ? 'info'
-              : 'error'
-        }
-        label={item.status.charAt(0).toUpperCase() + item.status.slice(1)}
+        variant={item.status === 'Done' ? 'success' : item.status === 'Draft' ? undefined : 'info'}
+        label={item.status}
       />
     ),
   },
+  {key: 'target', header: 'Target', width: pixel(80)},
+  {key: 'limit', header: 'Limit', width: pixel(80)},
   {
-    key: 'date',
-    header: 'Date',
-    width: pixel(100),
-    renderCell: (item: OrderRow) => (
-      <XDSText type="supporting" color="secondary">
-        {item.date}
-      </XDSText>
-    ),
-  },
-  {
-    key: 'amount',
-    header: 'Amount',
-    width: pixel(120),
-    renderCell: (item: OrderRow) => (
-      <XDSText type="body" weight="bold">
-        {item.amount}
-      </XDSText>
+    key: 'reviewer',
+    header: 'Reviewer',
+    width: pixel(140),
+    renderCell: (item: DocRow) => (
+      <XDSText type="body">{item.reviewer}</XDSText>
     ),
   },
 ];
 
-// =============================================================================
-// Styles
-// =============================================================================
+// Chart data — approximate the area chart from the screenshot
+const chartPoints = [
+  10, 15, 12, 18, 25, 30, 28, 35, 32, 38, 42, 35, 30, 28, 32, 25, 20, 22,
+  28, 35, 30, 25, 22, 28, 32, 38, 42, 45, 40, 35, 38, 42, 48, 45, 40, 38,
+  42, 45, 50, 48, 42, 38, 35, 40, 45, 42, 38, 35, 30, 28, 32, 35, 38, 42,
+  45, 48, 52, 50, 45, 42, 38, 35, 32, 30, 28, 25, 22, 20, 18, 22, 25, 28,
+  32, 35, 38, 42, 45, 48, 42, 38, 35, 32, 35, 38, 42, 45, 48, 52, 55, 50,
+];
 
 const styles = stylex.create({
   statsGrid: {
@@ -246,238 +183,173 @@ const styles = stylex.create({
     gridTemplateColumns: 'repeat(4, 1fr)',
     gap: 16,
   },
-  statCard: {
-    padding: '20px 24px',
-  },
-  changePositive: {
-    color: '#16a34a',
-  },
-  changeNegative: {
-    color: '#dc2626',
-  },
-  contentGrid: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 320px',
-    gap: 24,
-  },
-  chartPlaceholder: {
-    height: 240,
+  statRow: {
     display: 'flex',
     alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 8,
-    backgroundColor: 'var(--color-surface-wash, #f5f5f5)',
+    justifyContent: 'space-between',
   },
-  barChart: {
+  changePositive: {color: 'var(--color-text-success, #16a34a)'},
+  changeNegative: {color: 'var(--color-text-error, #dc2626)'},
+  chartContainer: {
+    position: 'relative',
+    height: 260,
+    overflow: 'hidden',
+  },
+  chartSvg: {
+    width: '100%',
+    height: '100%',
+  },
+  tabRow: {
     display: 'flex',
-    alignItems: 'flex-end',
-    gap: 8,
-    height: 180,
-    padding: '0 24px',
-  },
-  bar: {
-    flex: 1,
-    borderRadius: '4px 4px 0 0',
-    backgroundColor: 'var(--color-action-primary, #0066ff)',
-    opacity: 0.8,
-    minWidth: 20,
-  },
-  barLabel: {
-    textAlign: 'center' as const,
-    marginTop: 8,
-  },
-  teamCard: {
-    padding: 16,
-  },
-  progress: {
-    padding: '0 24px 24px',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 16,
   },
 });
 
-// =============================================================================
-// Components
-// =============================================================================
+function AreaChart() {
+  const max = Math.max(...chartPoints);
+  const w = 900;
+  const h = 220;
+  const pad = 20;
+  const points = chartPoints.map((v, i) => ({
+    x: pad + (i / (chartPoints.length - 1)) * (w - pad * 2),
+    y: h - pad - (v / max) * (h - pad * 2),
+  }));
+  const line = points.map((p, i) => `${i === 0 ? 'M' : 'L'}${p.x},${p.y}`).join(' ');
+  const area = `${line} L${points[points.length - 1].x},${h} L${points[0].x},${h} Z`;
 
-function StatCard({label, value, change, positive}: (typeof stats)[0]) {
+  const months = ['Apr 7', 'Apr 13', 'Apr 19', 'Apr 26', 'May 2', 'May 8', 'May 14', 'May 21', 'May 28', 'Jun 3', 'Jun 9', 'Jun 15', 'Jun 22', 'Jun 30'];
+
+  return (
+    <div {...stylex.props(styles.chartContainer)}>
+      <svg viewBox={`0 0 ${w} ${h + 30}`} {...stylex.props(styles.chartSvg)} preserveAspectRatio="none">
+        <defs>
+          <linearGradient id="areaGrad" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor="var(--color-accent, #000)" stopOpacity="0.15" />
+            <stop offset="100%" stopColor="var(--color-accent, #000)" stopOpacity="0.01" />
+          </linearGradient>
+        </defs>
+        {/* Grid lines */}
+        {[0.25, 0.5, 0.75].map(pct => (
+          <line
+            key={pct}
+            x1={pad}
+            y1={h - pad - pct * (h - pad * 2)}
+            x2={w - pad}
+            y2={h - pad - pct * (h - pad * 2)}
+            stroke="var(--color-divider, #e5e5e5)"
+            strokeWidth="1"
+          />
+        ))}
+        <path d={area} fill="url(#areaGrad)" />
+        <path d={line} fill="none" stroke="var(--color-text-primary, #000)" strokeWidth="1.5" />
+        {/* X-axis labels */}
+        {months.map((label, i) => (
+          <text
+            key={label}
+            x={pad + (i / (months.length - 1)) * (w - pad * 2)}
+            y={h + 20}
+            textAnchor="middle"
+            fontSize="11"
+            fill="var(--color-text-secondary, #888)"
+          >
+            {label}
+          </text>
+        ))}
+      </svg>
+    </div>
+  );
+}
+
+function StatCard({label, value, change, positive, desc}: typeof stats[0]) {
   return (
     <XDSCard>
-      <div {...stylex.props(styles.statCard)}>
-        <XDSVStack gap={1}>
-          <XDSText type="supporting" color="secondary">
-            {label}
-          </XDSText>
-          <XDSText type="large" weight="bold">
-            {value}
-          </XDSText>
-          <XDSText type="supporting" color={positive ? undefined : 'secondary'}>
-            <span
-              {...stylex.props(
-                positive ? styles.changePositive : styles.changeNegative,
-              )}>
-              {change}
-            </span>{' '}
-            from last month
-          </XDSText>
-        </XDSVStack>
-      </div>
+      <XDSVStack gap={2}>
+        <div {...stylex.props(styles.statRow)}>
+          <XDSText type="supporting" color="secondary">{label}</XDSText>
+          <XDSHStack gap={1} vAlign="center">
+            {positive ? <TrendUpIcon /> : <TrendDownIcon />}
+            <span {...stylex.props(positive ? styles.changePositive : styles.changeNegative)}>
+              <XDSText type="supporting">{change}</XDSText>
+            </span>
+          </XDSHStack>
+        </div>
+        <XDSHeading level={2}>{value}</XDSHeading>
+        <XDSText type="supporting" color="secondary">{desc}</XDSText>
+      </XDSVStack>
     </XDSCard>
   );
 }
-
-const monthlyData = [
-  {month: 'Jan', value: 65},
-  {month: 'Feb', value: 45},
-  {month: 'Mar', value: 80},
-  {month: 'Apr', value: 55},
-  {month: 'May', value: 70},
-  {month: 'Jun', value: 90},
-  {month: 'Jul', value: 60},
-  {month: 'Aug', value: 85},
-  {month: 'Sep', value: 75},
-  {month: 'Oct', value: 95},
-  {month: 'Nov', value: 88},
-  {month: 'Dec', value: 72},
-];
-
-function MiniBarChart() {
-  const max = Math.max(...monthlyData.map(d => d.value));
-  return (
-    <XDSVStack gap={2}>
-      <div {...stylex.props(styles.barChart)}>
-        {monthlyData.map(d => (
-          <div
-            key={d.month}
-            style={{
-              flex: 1,
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-            }}>
-            <div
-              {...stylex.props(styles.bar)}
-              style={{height: `${(d.value / max) * 100}%`}}
-            />
-            <div {...stylex.props(styles.barLabel)}>
-              <XDSText type="supporting" color="secondary">
-                {d.month}
-              </XDSText>
-            </div>
-          </div>
-        ))}
-      </div>
-    </XDSVStack>
-  );
-}
-
-// =============================================================================
-// Sidebar
-// =============================================================================
 
 function DashboardSideNav() {
   const [active, setActive] = useState('dashboard');
   return (
     <XDSSideNav
       header={
-        <div
-          style={{
-            padding: '12px 16px',
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-          }}>
-          <XDSNavIcon
-            icon={<AnalyticsIcon style={{width: 16, height: 16}} />}
-          />
-          <XDSText type="body" weight="bold">
-            Acme Inc
-          </XDSText>
-        </div>
+        <XDSVStack gap={3} style={{padding: '12px 16px'}}>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSNavIcon icon={<DashboardIcon style={{width: 16, height: 16}} />} />
+            <XDSText type="body" weight="bold">Acme Inc.</XDSText>
+          </XDSHStack>
+          <XDSHStack gap={2}>
+            <XDSButton label="Quick Create" variant="primary" size="sm" xstyle={{flex: 1} as never} />
+            <XDSButton label="Mail" variant="ghost" size="sm" icon={<MailIcon style={{width: 16, height: 16}} />} />
+          </XDSHStack>
+        </XDSVStack>
       }
-      footer={<XDSSideNavCollapseButton />}>
-      <XDSSideNavSection title="Overview">
-        <XDSSideNavItem
-          label="Dashboard"
-          icon={DashboardIcon}
-          isSelected={active === 'dashboard'}
-          onClick={() => setActive('dashboard')}
-        />
-        <XDSSideNavItem
-          label="Analytics"
-          icon={AnalyticsIcon}
-          isSelected={active === 'analytics'}
-          onClick={() => setActive('analytics')}
-        />
+      footer={
+        <XDSVStack gap={0} style={{padding: '8px 0'}}>
+          <XDSSideNavItem label="Settings" icon={SettingsIcon} isSelected={active === 'settings'} onClick={() => setActive('settings')} />
+          <XDSSideNavItem label="Get Help" icon={HelpIcon} isSelected={active === 'help'} onClick={() => setActive('help')} />
+          <XDSSideNavItem label="Search" icon={SearchIcon} isSelected={active === 'search'} onClick={() => setActive('search')} />
+          <div style={{padding: '12px 16px', borderTop: '1px solid var(--color-divider)'}}>
+            <XDSHStack gap={3} vAlign="center">
+              <XDSAvatar name="shadcn" size="small" />
+              <XDSVStack gap={0} style={{flex: 1}}>
+                <XDSText type="body" weight="bold">shadcn</XDSText>
+                <XDSText type="supporting" color="secondary">m@example.com</XDSText>
+              </XDSVStack>
+              <XDSButton label="More" variant="ghost" size="sm" icon={<MoreIcon style={{width: 16, height: 16}} />} />
+            </XDSHStack>
+          </div>
+        </XDSVStack>
+      }>
+      <XDSSideNavSection title="Platform">
+        <XDSSideNavItem label="Dashboard" icon={DashboardIcon} isSelected={active === 'dashboard'} onClick={() => setActive('dashboard')} />
+        <XDSSideNavItem label="Lifecycle" icon={LifecycleIcon} isSelected={active === 'lifecycle'} onClick={() => setActive('lifecycle')} />
+        <XDSSideNavItem label="Analytics" icon={AnalyticsIcon} isSelected={active === 'analytics'} onClick={() => setActive('analytics')} />
+        <XDSSideNavItem label="Projects" icon={ProjectsIcon} isSelected={active === 'projects'} onClick={() => setActive('projects')} />
+        <XDSSideNavItem label="Team" icon={TeamIcon} isSelected={active === 'team'} onClick={() => setActive('team')} />
       </XDSSideNavSection>
-      <XDSSideNavSection title="Management">
-        <XDSSideNavItem
-          label="Customers"
-          icon={UsersIcon}
-          isSelected={active === 'customers'}
-          onClick={() => setActive('customers')}
-        />
-        <XDSSideNavItem
-          label="Orders"
-          icon={OrdersIcon}
-          isSelected={active === 'orders'}
-          onClick={() => setActive('orders')}
-        />
-        <XDSSideNavItem
-          label="Settings"
-          icon={SettingsIcon}
-          isSelected={active === 'settings'}
-          onClick={() => setActive('settings')}
-        />
+      <XDSSideNavSection title="Documents">
+        <XDSSideNavItem label="Data Library" icon={DataIcon} isSelected={active === 'data'} onClick={() => setActive('data')} />
+        <XDSSideNavItem label="Reports" icon={ReportsIcon} isSelected={active === 'reports'} onClick={() => setActive('reports')} />
+        <XDSSideNavItem label="Word Assistant" icon={WordIcon} isSelected={active === 'word'} onClick={() => setActive('word')} />
+        <XDSSideNavItem label="More" icon={MoreIcon} isSelected={active === 'more'} onClick={() => setActive('more')} />
       </XDSSideNavSection>
     </XDSSideNav>
   );
 }
 
-// =============================================================================
-// TopNav
-// =============================================================================
-
-function DashboardTopNav() {
-  return (
-    <XDSTopNav
-      startContent={
-        <>
-          <XDSTopNavItem label="Overview" isSelected />
-          <XDSTopNavItem label="Analytics" />
-          <XDSTopNavItem label="Reports" />
-        </>
-      }
-      endContent={
-        <XDSAvatar
-          src="https://i.pravatar.cc/36?img=12"
-          name="Admin User"
-          size="xsmall"
-        />
-      }>
-      <XDSTopNavHeading>Dashboard</XDSTopNavHeading>
-    </XDSTopNav>
-  );
-}
-
-// =============================================================================
-// Page
-// =============================================================================
-
 export default function DashboardTemplate() {
+  const [period, setPeriod] = useState('3m');
+  const [docTab, setDocTab] = useState('outline');
+
   return (
     <XDSAppShell
       sideNav={<DashboardSideNav />}
-      topNav={<DashboardTopNav />}
+      topNav={
+        <XDSTopNav
+          endContent={
+            <XDSLink label="GitHub" href="#">GitHub</XDSLink>
+          }>
+          <XDSTopNavHeading>Documents</XDSTopNavHeading>
+        </XDSTopNav>
+      }
       variant="elevated"
       contentPadding={6}>
       <XDSVStack gap={6}>
-        <XDSVStack gap={1}>
-          <XDSHeading level={1}>Dashboard</XDSHeading>
-          <XDSText type="body" color="secondary">
-            Welcome back! Here&apos;s what&apos;s happening with your business
-            today.
-          </XDSText>
-        </XDSVStack>
-
         {/* Stats Grid */}
         <div {...stylex.props(styles.statsGrid)}>
           {stats.map(stat => (
@@ -485,133 +357,50 @@ export default function DashboardTemplate() {
           ))}
         </div>
 
-        {/* Main Content */}
-        <div {...stylex.props(styles.contentGrid)}>
-          {/* Chart + Table column */}
-          <XDSVStack gap={6}>
-            <XDSCard>
-              <div style={{padding: '24px 24px 0'}}>
-                <XDSVStack gap={1}>
-                  <XDSText type="body" weight="bold">
-                    Revenue Overview
-                  </XDSText>
-                  <XDSText type="supporting" color="secondary">
-                    Monthly revenue for the current year
-                  </XDSText>
-                </XDSVStack>
-              </div>
-              <MiniBarChart />
-            </XDSCard>
-
-            <XDSCard>
-              <div style={{padding: '20px 24px 8px'}}>
-                <XDSHStack gap={3} vAlign="center">
-                  <div style={{flex: 1}}>
-                    <XDSText type="body" weight="bold">
-                      Recent Orders
-                    </XDSText>
-                  </div>
-                  <XDSButton label="View all" variant="ghost" size="sm" />
-                </XDSHStack>
-              </div>
-              <XDSTable<OrderRow>
-                data={recentOrders}
-                columns={orderColumns}
-                idKey="id"
-                density="balanced"
-                dividers="rows"
-                hasHover
-              />
-            </XDSCard>
+        {/* Area Chart */}
+        <XDSCard>
+          <XDSVStack gap={4}>
+            <div {...stylex.props(styles.statRow)}>
+              <XDSVStack gap={1}>
+                <XDSHeading level={3}>Total Visitors</XDSHeading>
+                <XDSText type="supporting" color="secondary">
+                  Total for the last 3 months
+                </XDSText>
+              </XDSVStack>
+              <XDSSegmentedControl label="Time period" value={period} onChange={setPeriod}>
+                <XDSSegmentedControlItem value="3m" label="Last 3 months" />
+                <XDSSegmentedControlItem value="30d" label="Last 30 days" />
+                <XDSSegmentedControlItem value="7d" label="Last 7 days" />
+              </XDSSegmentedControl>
+            </div>
+            <AreaChart />
           </XDSVStack>
+        </XDSCard>
 
-          {/* Sidebar column */}
-          <XDSVStack gap={6}>
-            <XDSCard>
-              <div style={{padding: '20px 24px'}}>
-                <XDSVStack gap={4}>
-                  <XDSText type="body" weight="bold">
-                    Team Members
-                  </XDSText>
-                  {teamMembers.map(member => (
-                    <XDSHStack key={member.name} gap={3} vAlign="center">
-                      <XDSAvatar
-                        src={member.avatar}
-                        name={member.name}
-                        size="small"
-                      />
-                      <XDSVStack gap={0}>
-                        <XDSText type="body" weight="bold">
-                          {member.name}
-                        </XDSText>
-                        <XDSText type="supporting" color="secondary">
-                          {member.role}
-                        </XDSText>
-                      </XDSVStack>
-                    </XDSHStack>
-                  ))}
-                </XDSVStack>
-              </div>
-            </XDSCard>
-
-            <XDSCard>
-              <div style={{padding: '20px 24px'}}>
-                <XDSVStack gap={4}>
-                  <XDSText type="body" weight="bold">
-                    Goals
-                  </XDSText>
-                  <XDSVStack gap={3}>
-                    <XDSVStack gap={1}>
-                      <XDSHStack gap={2} vAlign="center">
-                        <div style={{flex: 1}}>
-                          <XDSText type="supporting">Revenue target</XDSText>
-                        </div>
-                        <XDSText type="supporting" weight="bold">
-                          72%
-                        </XDSText>
-                      </XDSHStack>
-                      <XDSProgressBar
-                        value={72}
-                        label="Progress"
-                        isLabelHidden
-                      />
-                    </XDSVStack>
-                    <XDSVStack gap={1}>
-                      <XDSHStack gap={2} vAlign="center">
-                        <div style={{flex: 1}}>
-                          <XDSText type="supporting">New users</XDSText>
-                        </div>
-                        <XDSText type="supporting" weight="bold">
-                          48%
-                        </XDSText>
-                      </XDSHStack>
-                      <XDSProgressBar
-                        value={48}
-                        label="Progress"
-                        isLabelHidden
-                      />
-                    </XDSVStack>
-                    <XDSVStack gap={1}>
-                      <XDSHStack gap={2} vAlign="center">
-                        <div style={{flex: 1}}>
-                          <XDSText type="supporting">Retention</XDSText>
-                        </div>
-                        <XDSText type="supporting" weight="bold">
-                          89%
-                        </XDSText>
-                      </XDSHStack>
-                      <XDSProgressBar
-                        value={89}
-                        label="Progress"
-                        isLabelHidden
-                      />
-                    </XDSVStack>
-                  </XDSVStack>
-                </XDSVStack>
-              </div>
-            </XDSCard>
-          </XDSVStack>
+        {/* Document Tabs + Table */}
+        <div {...stylex.props(styles.tabRow)}>
+          <XDSTabList value={docTab} onChange={setDocTab}>
+            <XDSTab value="outline" label="Outline" />
+            <XDSTab value="performance" label="Past Performance" />
+            <XDSTab value="personnel" label="Key Personnel" />
+            <XDSTab value="focus" label="Focus Documents" />
+          </XDSTabList>
+          <XDSHStack gap={3}>
+            <XDSButton label="Customize Columns" variant="secondary" size="sm" />
+            <XDSButton label="+ Add Section" variant="secondary" size="sm" />
+          </XDSHStack>
         </div>
+
+        <XDSCard padding={0}>
+          <XDSTable<DocRow>
+            data={docRows}
+            columns={docColumns}
+            idKey="id"
+            density="balanced"
+            dividers="rows"
+            hasHover
+          />
+        </XDSCard>
       </XDSVStack>
     </XDSAppShell>
   );

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-data-table/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-data-table/page.tsx
@@ -1,0 +1,583 @@
+'use client';
+
+import {useState, useMemo} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSSideNav,
+  XDSSideNavItem,
+  XDSSideNavSection,
+  XDSSideNavCollapseButton,
+} from '@xds/core/SideNav';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSButton} from '@xds/core/Button';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+import {XDSPagination} from '@xds/core/Pagination';
+import {
+  XDSTable,
+  useXDSTableSelection,
+  useXDSTableSortable,
+  proportional,
+  pixel,
+} from '@xds/core/Table';
+import type {XDSTableColumn} from '@xds/core/Table';
+
+// Icons
+const UsersIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+  </svg>
+);
+const InboxIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <polyline points="22 12 16 12 14 15 10 15 8 12 2 12" />
+    <path d="M5.45 5.11L2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z" />
+  </svg>
+);
+const TagIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z" />
+    <line x1="7" y1="7" x2="7.01" y2="7" />
+  </svg>
+);
+const SettingsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+  </svg>
+);
+
+// Types
+type UserStatus = 'active' | 'inactive' | 'pending';
+type UserRole = 'admin' | 'editor' | 'viewer';
+
+interface UserRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  email: string;
+  avatar: string;
+  role: UserRole;
+  status: UserStatus;
+  lastActive: string;
+  joined: string;
+}
+
+// Mock data
+const allUsers: UserRow[] = [
+  {
+    id: '1',
+    name: 'Olivia Martin',
+    email: 'olivia@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=1',
+    role: 'admin',
+    status: 'active',
+    lastActive: '2 min ago',
+    joined: 'Jan 2024',
+  },
+  {
+    id: '2',
+    name: 'Jackson Lee',
+    email: 'jackson@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=2',
+    role: 'editor',
+    status: 'active',
+    lastActive: '5 min ago',
+    joined: 'Feb 2024',
+  },
+  {
+    id: '3',
+    name: 'Isabella Nguyen',
+    email: 'isabella@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=3',
+    role: 'viewer',
+    status: 'inactive',
+    lastActive: '2 days ago',
+    joined: 'Mar 2024',
+  },
+  {
+    id: '4',
+    name: 'William Kim',
+    email: 'william@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=4',
+    role: 'editor',
+    status: 'active',
+    lastActive: '1 hour ago',
+    joined: 'Apr 2024',
+  },
+  {
+    id: '5',
+    name: 'Sofia Davis',
+    email: 'sofia@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=5',
+    role: 'admin',
+    status: 'active',
+    lastActive: '10 min ago',
+    joined: 'May 2024',
+  },
+  {
+    id: '6',
+    name: 'Lucas Brown',
+    email: 'lucas@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=6',
+    role: 'viewer',
+    status: 'pending',
+    lastActive: 'Never',
+    joined: 'Jun 2024',
+  },
+  {
+    id: '7',
+    name: 'Mia Wilson',
+    email: 'mia@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=7',
+    role: 'editor',
+    status: 'active',
+    lastActive: '30 min ago',
+    joined: 'Jul 2024',
+  },
+  {
+    id: '8',
+    name: 'Ethan Jones',
+    email: 'ethan@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=8',
+    role: 'viewer',
+    status: 'inactive',
+    lastActive: '1 week ago',
+    joined: 'Aug 2024',
+  },
+  {
+    id: '9',
+    name: 'Ava Taylor',
+    email: 'ava@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=9',
+    role: 'editor',
+    status: 'active',
+    lastActive: '15 min ago',
+    joined: 'Sep 2024',
+  },
+  {
+    id: '10',
+    name: 'Noah Garcia',
+    email: 'noah@acme.com',
+    avatar: 'https://i.pravatar.cc/36?img=10',
+    role: 'viewer',
+    status: 'pending',
+    lastActive: 'Never',
+    joined: 'Oct 2024',
+  },
+];
+
+const BADGE_VARIANT: Record<UserStatus, 'success' | 'warning' | 'neutral'> = {
+  active: 'success',
+  inactive: 'neutral',
+  pending: 'warning',
+};
+
+const ROLE_BADGE: Record<UserRole, 'info' | 'neutral' | 'warning'> = {
+  admin: 'info',
+  editor: 'warning',
+  viewer: 'neutral',
+};
+
+const PAGE_SIZE = 5;
+
+// Columns
+const columns: XDSTableColumn<UserRow>[] = [
+  {
+    key: 'name',
+    header: 'User',
+    width: proportional(4),
+    renderCell: (item: UserRow) => (
+      <XDSHStack gap={3} vAlign="center">
+        <XDSAvatar src={item.avatar} name={item.name} size="small" />
+        <XDSVStack gap={0}>
+          <XDSText type="body" weight="bold">
+            {item.name}
+          </XDSText>
+          <XDSText type="supporting" color="secondary">
+            {item.email}
+          </XDSText>
+        </XDSVStack>
+      </XDSHStack>
+    ),
+  },
+  {
+    key: 'role',
+    header: 'Role',
+    width: pixel(110),
+    renderCell: (item: UserRow) => (
+      <XDSBadge
+        variant={ROLE_BADGE[item.role]}
+        label={item.role.charAt(0).toUpperCase() + item.role.slice(1)}
+      />
+    ),
+  },
+  {
+    key: 'status',
+    header: 'Status',
+    width: pixel(110),
+    renderCell: (item: UserRow) => (
+      <XDSBadge
+        variant={BADGE_VARIANT[item.status]}
+        label={item.status.charAt(0).toUpperCase() + item.status.slice(1)}
+      />
+    ),
+  },
+  {
+    key: 'lastActive',
+    header: 'Last Active',
+    width: pixel(130),
+    renderCell: (item: UserRow) => (
+      <XDSText type="supporting" color="secondary">
+        {item.lastActive}
+      </XDSText>
+    ),
+  },
+  {
+    key: 'joined',
+    header: 'Joined',
+    width: pixel(110),
+    renderCell: (item: UserRow) => (
+      <XDSText type="supporting" color="secondary">
+        {item.joined}
+      </XDSText>
+    ),
+  },
+];
+
+const styles = stylex.create({
+  toolbar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: 12,
+  },
+  filters: {display: 'flex', gap: 8, alignItems: 'center'},
+  bulkBar: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: '8px 16px',
+    borderRadius: 8,
+    backgroundColor: 'var(--color-surface-wash, #f5f5f5)',
+  },
+});
+
+function DataTableSideNav() {
+  const [active, setActive] = useState('users');
+  return (
+    <XDSSideNav
+      header={
+        <div
+          style={{
+            padding: '12px 16px',
+            display: 'flex',
+            alignItems: 'center',
+            gap: 8,
+          }}>
+          <XDSNavIcon icon={<UsersIcon style={{width: 16, height: 16}} />} />
+          <XDSText type="body" weight="bold">
+            Admin
+          </XDSText>
+        </div>
+      }
+      footer={<XDSSideNavCollapseButton />}>
+      <XDSSideNavSection title="Manage">
+        <XDSSideNavItem
+          label="Users"
+          icon={UsersIcon}
+          isSelected={active === 'users'}
+          onClick={() => setActive('users')}
+        />
+        <XDSSideNavItem
+          label="Invitations"
+          icon={InboxIcon}
+          isSelected={active === 'invitations'}
+          onClick={() => setActive('invitations')}
+        />
+        <XDSSideNavItem
+          label="Roles"
+          icon={TagIcon}
+          isSelected={active === 'roles'}
+          onClick={() => setActive('roles')}
+        />
+      </XDSSideNavSection>
+      <XDSSideNavSection title="System">
+        <XDSSideNavItem
+          label="Settings"
+          icon={SettingsIcon}
+          isSelected={active === 'settings'}
+          onClick={() => setActive('settings')}
+        />
+      </XDSSideNavSection>
+    </XDSSideNav>
+  );
+}
+
+export default function DataTableTemplate() {
+  const [search, setSearch] = useState('');
+  const [statusFilter, setStatusFilter] = useState('all');
+  const [roleFilter, setRoleFilter] = useState('all');
+  const [tab, setTab] = useState('all');
+  const [page, setPage] = useState(1);
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const filtered = useMemo(() => {
+    let data = allUsers;
+    if (search.trim()) {
+      const q = search.toLowerCase();
+      data = data.filter(
+        u =>
+          u.name.toLowerCase().includes(q) || u.email.toLowerCase().includes(q),
+      );
+    }
+    if (statusFilter !== 'all')
+      data = data.filter(u => u.status === statusFilter);
+    if (roleFilter !== 'all') data = data.filter(u => u.role === roleFilter);
+    if (tab !== 'all') data = data.filter(u => u.status === tab);
+    return data;
+  }, [search, statusFilter, roleFilter, tab]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  const paged = filtered.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE);
+
+  const selectionPlugin = useXDSTableSelection<UserRow>({
+    getIsItemSelected: (item: UserRow) => selectedKeys.has(item.id),
+    onSelectItem: ({
+      item,
+      isSelected,
+    }: {
+      item: UserRow;
+      isSelected: boolean;
+    }) => {
+      setSelectedKeys(prev => {
+        const next = new Set(prev);
+        if (isSelected) {
+          next.add(item.id);
+        } else {
+          next.delete(item.id);
+        }
+        return next;
+      });
+    },
+    onSelectAll: ({isAllSelected}: {isAllSelected: boolean}) => {
+      setSelectedKeys(prev => {
+        const next = new Set(prev);
+        if (isAllSelected) paged.forEach(r => next.add(r.id));
+        else paged.forEach(r => next.delete(r.id));
+        return next;
+      });
+    },
+    getIsAllSelected: () =>
+      paged.length > 0 && paged.every(r => selectedKeys.has(r.id)),
+    getIsIndeterminate: () => {
+      const c = paged.filter(r => selectedKeys.has(r.id)).length;
+      return c > 0 && c < paged.length;
+    },
+  });
+
+  const plugins = useMemo(
+    () => ({selection: selectionPlugin}),
+    [selectionPlugin],
+  );
+
+  const activeCount = allUsers.filter(u => u.status === 'active').length;
+  const pendingCount = allUsers.filter(u => u.status === 'pending').length;
+
+  return (
+    <XDSAppShell
+      sideNav={<DataTableSideNav />}
+      variant="elevated"
+      contentPadding={6}>
+      <XDSVStack gap={6}>
+        <XDSHStack gap={3} vAlign="center">
+          <div style={{flex: 1}}>
+            <XDSVStack gap={1}>
+              <XDSHeading level={1}>Users</XDSHeading>
+              <XDSText type="body" color="secondary">
+                Manage user accounts, roles, and permissions.
+              </XDSText>
+            </XDSVStack>
+          </div>
+          <XDSButton
+            label="+ Invite user"
+            variant="primary"
+            size="sm"
+            onClick={() => setDialogOpen(true)}
+          />
+        </XDSHStack>
+
+        <XDSTabList
+          value={tab}
+          onChange={id => {
+            setTab(id);
+            setPage(1);
+          }}>
+          <XDSTab value="all" label={`All users (${allUsers.length})`} />
+          <XDSTab value="active" label={`Active (${activeCount})`} />
+          <XDSTab value="pending" label={`Pending (${pendingCount})`} />
+        </XDSTabList>
+
+        <XDSCard>
+          <div style={{padding: '16px 20px'}}>
+            <XDSVStack gap={4}>
+              <div {...stylex.props(styles.toolbar)}>
+                <div {...stylex.props(styles.filters)}>
+                  <XDSTextInput
+                    label="Search"
+                    isLabelHidden
+                    placeholder="Search users..."
+                    value={search}
+                    onChange={v => {
+                      setSearch(v);
+                      setPage(1);
+                    }}
+                  />
+                  <XDSSelector
+                    label="Status"
+                    isLabelHidden
+                    value={statusFilter}
+                    options={[
+                      {value: 'all', label: 'All statuses'},
+                      {value: 'active', label: 'Active'},
+                      {value: 'inactive', label: 'Inactive'},
+                      {value: 'pending', label: 'Pending'},
+                    ]}
+                    onChange={v => {
+                      setStatusFilter(v);
+                      setPage(1);
+                    }}
+                  />
+                  <XDSSelector
+                    label="Role"
+                    isLabelHidden
+                    value={roleFilter}
+                    options={[
+                      {value: 'all', label: 'All roles'},
+                      {value: 'admin', label: 'Admin'},
+                      {value: 'editor', label: 'Editor'},
+                      {value: 'viewer', label: 'Viewer'},
+                    ]}
+                    onChange={v => {
+                      setRoleFilter(v);
+                      setPage(1);
+                    }}
+                  />
+                </div>
+                <XDSText type="supporting" color="secondary">
+                  {filtered.length} user{filtered.length !== 1 ? 's' : ''}
+                </XDSText>
+              </div>
+
+              {selectedKeys.size > 0 && (
+                <div {...stylex.props(styles.bulkBar)}>
+                  <XDSText type="supporting" weight="bold">
+                    {selectedKeys.size} selected
+                  </XDSText>
+                  <XDSHStack gap={2}>
+                    <XDSButton label="Deactivate" variant="ghost" size="sm" />
+                    <XDSButton label="Delete" variant="ghost" size="sm" />
+                  </XDSHStack>
+                </div>
+              )}
+            </XDSVStack>
+          </div>
+
+          <XDSTable<UserRow>
+            data={paged}
+            columns={columns}
+            idKey="id"
+            density="balanced"
+            dividers="rows"
+            hasHover
+            plugins={plugins}
+          />
+
+          <div
+            style={{
+              padding: '12px 20px',
+              display: 'flex',
+              justifyContent: 'center',
+            }}>
+            <XDSPagination
+              page={page}
+              totalPages={totalPages}
+              onChange={setPage}
+            />
+          </div>
+        </XDSCard>
+      </XDSVStack>
+
+      <XDSDialog isOpen={dialogOpen} onOpenChange={open => setDialogOpen(open)}>
+        <XDSDialogHeader
+          title="Invite User"
+          onOpenChange={open => setDialogOpen(open)}
+        />
+        <div style={{padding: '16px 24px'}}>
+          <XDSVStack gap={4}>
+            <XDSTextInput
+              label="Email address"
+              placeholder="colleague@acme.com"
+              value=""
+              onChange={() => {}}
+            />
+            <XDSSelector
+              label="Role"
+              value="viewer"
+              options={[
+                {value: 'admin', label: 'Admin'},
+                {value: 'editor', label: 'Editor'},
+                {value: 'viewer', label: 'Viewer'},
+              ]}
+              onChange={() => {}}
+            />
+            <XDSHStack gap={2}>
+              <XDSButton
+                label="Send Invite"
+                variant="primary"
+                size="sm"
+                onClick={() => setDialogOpen(false)}
+              />
+              <XDSButton
+                label="Cancel"
+                variant="secondary"
+                size="sm"
+                onClick={() => setDialogOpen(false)}
+              />
+            </XDSHStack>
+          </XDSVStack>
+        </div>
+      </XDSDialog>
+    </XDSAppShell>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -50,7 +50,7 @@ const styles = stylex.create({
     alignItems: 'center',
     width: '100%',
     maxWidth: 400,
-    gap: 24,
+    gap: 16,
   },
   fullWidth: {
     width: '100%',
@@ -77,7 +77,6 @@ const styles = stylex.create({
   },
   footer: {
     textAlign: 'center',
-    marginTop: 8,
   },
 });
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -6,157 +6,85 @@ import {XDSVStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
-import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+import {XDSCard} from '@xds/core/Card';
 import {XDSLink} from '@xds/core/Link';
 
 const styles = stylex.create({
   page: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    minHeight: '100vh',
-  },
-  brandPanel: {
     display: 'flex',
-    flexDirection: 'column',
+    minHeight: '100svh',
+    width: '100%',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  wrapper: {
+    width: '100%',
+    maxWidth: 384,
+  },
+  passwordRow: {
+    display: 'flex',
+    alignItems: 'center',
     justifyContent: 'space-between',
-    padding: 48,
-    backgroundColor: 'var(--color-action-primary, #0066ff)',
-    color: '#fff',
   },
-  brandLogo: {display: 'flex', alignItems: 'center', gap: 12},
-  logoMark: {
-    width: 40,
-    height: 40,
-    borderRadius: 10,
-    backgroundColor: 'rgba(255,255,255,0.2)',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    fontSize: 20,
-    fontWeight: 700,
+  signupText: {
+    textAlign: 'center',
   },
-  brandTitle: {
-    fontSize: 40,
-    fontWeight: 700,
-    lineHeight: 1.2,
-    color: '#fff',
-    marginBottom: 16,
-  },
-  brandSub: {fontSize: 18, lineHeight: 1.5, opacity: 0.85, color: '#fff'},
-  brandFooter: {opacity: 0.6, fontSize: 14, color: '#fff'},
-  formPanel: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 48,
-    backgroundColor: 'var(--color-surface-default, #fff)',
-  },
-  formContainer: {width: '100%', maxWidth: 400},
-  dividerRow: {display: 'flex', alignItems: 'center', gap: 16},
-  dividerLine: {
-    flex: 1,
-    height: 1,
-    backgroundColor: 'var(--color-border, #e0e0e0)',
-  },
-  row: {display: 'flex', justifyContent: 'space-between', alignItems: 'center'},
 });
 
 export default function LoginTemplate() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [remember, setRemember] = useState(false);
 
   return (
     <div {...stylex.props(styles.page)}>
-      <div {...stylex.props(styles.brandPanel)}>
-        <div {...stylex.props(styles.brandLogo)}>
-          <div {...stylex.props(styles.logoMark)}>A</div>
-          <span style={{fontSize: 18, fontWeight: 600, color: '#fff'}}>
-            Acme
-          </span>
-        </div>
-        <div style={{maxWidth: 480}}>
-          <div {...stylex.props(styles.brandTitle)}>
-            Build better products, faster.
-          </div>
-          <div {...stylex.props(styles.brandSub)}>
-            Streamline your workflow with our all-in-one platform. Trusted by
-            10,000+ teams worldwide.
-          </div>
-        </div>
-        <div {...stylex.props(styles.brandFooter)}>
-          &copy; 2026 Acme Inc. All rights reserved.
-        </div>
-      </div>
-
-      <div {...stylex.props(styles.formPanel)}>
-        <div {...stylex.props(styles.formContainer)}>
-          <XDSVStack gap={6}>
-            <XDSVStack gap={2}>
-              <XDSHeading level={1}>Welcome back</XDSHeading>
-              <XDSText type="body" color="secondary">
-                Enter your credentials to access your account
-              </XDSText>
+      <div {...stylex.props(styles.wrapper)}>
+        <XDSVStack gap={6}>
+          <XDSCard>
+            <XDSVStack gap={6}>
+              <XDSVStack gap={2}>
+                <XDSHeading level={2}>Login</XDSHeading>
+                <XDSText type="body" color="secondary">
+                  Enter your email below to login to your account
+                </XDSText>
+              </XDSVStack>
+              <XDSVStack gap={6}>
+                <XDSTextInput
+                  label="Email"
+                  type="email"
+                  placeholder="m@example.com"
+                  value={email}
+                  onChange={setEmail}
+                />
+                <XDSVStack gap={2}>
+                  <div {...stylex.props(styles.passwordRow)}>
+                    <XDSText type="label">Password</XDSText>
+                    <XDSLink label="Forgot your password?" href="#">
+                      Forgot your password?
+                    </XDSLink>
+                  </div>
+                  <XDSTextInput
+                    label="Password"
+                    isLabelHidden
+                    type="password"
+                    value={password}
+                    onChange={setPassword}
+                  />
+                </XDSVStack>
+                <XDSButton label="Login" variant="primary" />
+                <XDSButton label="Login with Google" variant="secondary" />
+              </XDSVStack>
+              <div {...stylex.props(styles.signupText)}>
+                <XDSText type="supporting" color="secondary">
+                  Don&apos;t have an account?{' '}
+                  <XDSLink label="Sign up" href="#">
+                    Sign up
+                  </XDSLink>
+                </XDSText>
+              </div>
             </XDSVStack>
-
-            <XDSVStack gap={3}>
-              <XDSButton
-                label="Continue with Google"
-                variant="secondary"
-                size="md"
-              />
-              <XDSButton
-                label="Continue with GitHub"
-                variant="secondary"
-                size="md"
-              />
-            </XDSVStack>
-
-            <div {...stylex.props(styles.dividerRow)}>
-              <div {...stylex.props(styles.dividerLine)} />
-              <XDSText type="supporting" color="secondary">
-                or continue with email
-              </XDSText>
-              <div {...stylex.props(styles.dividerLine)} />
-            </div>
-
-            <XDSVStack gap={4}>
-              <XDSTextInput
-                label="Email"
-                placeholder="name@company.com"
-                value={email}
-                onChange={setEmail}
-              />
-              <XDSTextInput
-                label="Password"
-                placeholder="Enter your password"
-                value={password}
-                onChange={setPassword}
-                type="password"
-              />
-            </XDSVStack>
-
-            <div {...stylex.props(styles.row)}>
-              <XDSCheckboxInput
-                label="Remember me"
-                value={remember}
-                onChange={setRemember}
-              />
-              <XDSLink label="Forgot password" href="#">
-                Forgot password?
-              </XDSLink>
-            </div>
-
-            <XDSButton label="Sign in" variant="primary" size="md" />
-
-            <XDSText type="supporting" color="secondary">
-              Don&apos;t have an account?{' '}
-              <XDSLink label="Sign up" href="#">
-                Sign up
-              </XDSLink>
-            </XDSText>
-          </XDSVStack>
-        </div>
+          </XDSCard>
+        </XDSVStack>
       </div>
     </div>
   );

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -95,7 +95,7 @@ export default function LoginTemplate() {
 
         {/* Card */}
         <XDSCard maxWidth={400}>
-          <XDSVStack gap={6}>
+          <XDSVStack gap={4}>
             {/* Header */}
             <div {...stylex.props(styles.centered)}>
               <XDSVStack gap={2}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -86,7 +86,7 @@ export default function LoginTemplate() {
   const [password, setPassword] = useState('');
 
   return (
-    <div {...stylex.props(styles.page)}>
+    <div style={{display: 'flex', flexDirection: 'column', minHeight: '100svh', width: '100%', alignItems: 'center', justifyContent: 'center', padding: 24}}>
       <div {...stylex.props(styles.wrapper)}>
         {/* Logo */}
         <XDSHStack gap={2}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -2,16 +2,42 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSLink} from '@xds/core/Link';
+import {XDSDivider} from '@xds/core/Divider';
+
+// Icons
+const LogoIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width={24} height={24} {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="4" fill="currentColor" />
+    <rect x="7" y="7" width="10" height="3" rx="1" fill="white" />
+    <rect x="7" y="12" width="6" height="3" rx="1" fill="white" />
+  </svg>
+);
+
+const AppleIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} {...props}>
+    <path d="M17.05 20.28c-.98.95-2.05.88-3.08.4-1.09-.5-2.08-.48-3.24 0-1.44.62-2.2.44-3.06-.4C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8 1.18-.24 2.31-.93 3.57-.84 1.51.12 2.65.72 3.4 1.8-3.12 1.87-2.38 5.98.48 7.13-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25.29 2.58-2.34 4.5-3.74 4.25z"/>
+  </svg>
+);
+
+const GoogleIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" width={16} height={16} {...props}>
+    <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z" fill="#4285F4"/>
+    <path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/>
+    <path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z" fill="#FBBC05"/>
+    <path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/>
+  </svg>
+);
 
 const styles = stylex.create({
   page: {
     display: 'flex',
+    flexDirection: 'column',
     minHeight: '100svh',
     width: '100%',
     alignItems: 'center',
@@ -19,8 +45,12 @@ const styles = stylex.create({
     padding: 24,
   },
   wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
     width: '100%',
-    maxWidth: 384,
+    maxWidth: 400,
+    gap: 24,
   },
   fullWidth: {
     width: '100%',
@@ -31,8 +61,23 @@ const styles = stylex.create({
     justifyContent: 'space-between',
   },
   signupText: {
-    marginTop: 16,
     textAlign: 'center',
+  },
+  dividerRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    width: '100%',
+  },
+  dividerLine: {
+    flexGrow: 1,
+  },
+  centered: {
+    textAlign: 'center',
+  },
+  footer: {
+    textAlign: 'center',
+    marginTop: 8,
   },
 });
 
@@ -43,15 +88,58 @@ export default function LoginTemplate() {
   return (
     <div {...stylex.props(styles.page)}>
       <div {...stylex.props(styles.wrapper)}>
-        <XDSCard maxWidth={384}>
+        {/* Logo */}
+        <XDSHStack gap={2}>
+          <LogoIcon />
+          <XDSText type="body" weight="bold">Acme Inc.</XDSText>
+        </XDSHStack>
+
+        {/* Card */}
+        <XDSCard maxWidth={400}>
           <XDSVStack gap={6}>
-            <XDSVStack gap={2}>
-              <XDSHeading level={2}>Login</XDSHeading>
-              <XDSText type="body" color="secondary">
-                Enter your email below to login to your account
-              </XDSText>
+            {/* Header */}
+            <div {...stylex.props(styles.centered)}>
+              <XDSVStack gap={2}>
+                <XDSHeading level={2}>Welcome back</XDSHeading>
+                <XDSText type="body" color="secondary">
+                  Login with your Apple or Google account
+                </XDSText>
+              </XDSVStack>
+            </div>
+
+            {/* Social buttons */}
+            <XDSVStack gap={3}>
+              <XDSButton
+                label="Login with Apple"
+                variant="secondary"
+                icon={<AppleIcon />}
+                xstyle={styles.fullWidth}
+              >
+                Login with Apple
+              </XDSButton>
+              <XDSButton
+                label="Login with Google"
+                variant="secondary"
+                icon={<GoogleIcon />}
+                xstyle={styles.fullWidth}
+              >
+                Login with Google
+              </XDSButton>
             </XDSVStack>
-            <XDSVStack gap={6}>
+
+            {/* Divider */}
+            <div {...stylex.props(styles.dividerRow)}>
+              <div {...stylex.props(styles.dividerLine)}>
+                <XDSDivider />
+              </div>
+              <XDSText type="supporting" color="secondary">Or continue with</XDSText>
+              <div {...stylex.props(styles.dividerLine)}>
+                <XDSDivider />
+              </div>
+            </div>
+
+            {/* Form fields */}
+            <XDSVStack gap={4}>
               <XDSTextInput
                 label="Email"
                 type="email"
@@ -74,17 +162,16 @@ export default function LoginTemplate() {
                   onChange={setPassword}
                 />
               </XDSVStack>
-              <XDSButton
-                label="Login"
-                variant="primary"
-                xstyle={styles.fullWidth}
-              />
-              <XDSButton
-                label="Login with Google"
-                variant="secondary"
-                xstyle={styles.fullWidth}
-              />
             </XDSVStack>
+
+            {/* Login button */}
+            <XDSButton
+              label="Login"
+              variant="primary"
+              xstyle={styles.fullWidth}
+            />
+
+            {/* Sign up link */}
             <div {...stylex.props(styles.signupText)}>
               <XDSText type="supporting" color="secondary">
                 Don&apos;t have an account?{' '}
@@ -95,6 +182,21 @@ export default function LoginTemplate() {
             </div>
           </XDSVStack>
         </XDSCard>
+
+        {/* Terms footer */}
+        <div {...stylex.props(styles.footer)}>
+          <XDSText type="supporting" color="secondary">
+            By clicking continue, you agree to our{' '}
+            <XDSLink label="Terms of Service" href="#">
+              Terms of Service
+            </XDSLink>{' '}
+            and{' '}
+            <XDSLink label="Privacy Policy" href="#">
+              Privacy Policy
+            </XDSLink>
+            .
+          </XDSText>
+        </div>
       </div>
     </div>
   );

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -86,7 +86,7 @@ export default function LoginTemplate() {
 
   return (
     <div style={{display: 'flex', flexDirection: 'column', minHeight: '100svh', width: '100%', alignItems: 'center', justifyContent: 'center', padding: 24}}>
-      <div {...stylex.props(styles.wrapper)}>
+      <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', maxWidth: 340, gap: 16}}>
         {/* Logo */}
         <XDSHStack gap={2}>
           <LogoIcon />

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSButton} from '@xds/core/Button';
+import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+import {XDSLink} from '@xds/core/Link';
+
+const styles = stylex.create({
+  page: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    minHeight: '100vh',
+  },
+  brandPanel: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    padding: 48,
+    backgroundColor: 'var(--color-action-primary, #0066ff)',
+    color: '#fff',
+  },
+  brandLogo: {display: 'flex', alignItems: 'center', gap: 12},
+  logoMark: {
+    width: 40,
+    height: 40,
+    borderRadius: 10,
+    backgroundColor: 'rgba(255,255,255,0.2)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: 20,
+    fontWeight: 700,
+  },
+  brandTitle: {
+    fontSize: 40,
+    fontWeight: 700,
+    lineHeight: 1.2,
+    color: '#fff',
+    marginBottom: 16,
+  },
+  brandSub: {fontSize: 18, lineHeight: 1.5, opacity: 0.85, color: '#fff'},
+  brandFooter: {opacity: 0.6, fontSize: 14, color: '#fff'},
+  formPanel: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 48,
+    backgroundColor: 'var(--color-surface-default, #fff)',
+  },
+  formContainer: {width: '100%', maxWidth: 400},
+  dividerRow: {display: 'flex', alignItems: 'center', gap: 16},
+  dividerLine: {
+    flex: 1,
+    height: 1,
+    backgroundColor: 'var(--color-border, #e0e0e0)',
+  },
+  row: {display: 'flex', justifyContent: 'space-between', alignItems: 'center'},
+});
+
+export default function LoginTemplate() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [remember, setRemember] = useState(false);
+
+  return (
+    <div {...stylex.props(styles.page)}>
+      <div {...stylex.props(styles.brandPanel)}>
+        <div {...stylex.props(styles.brandLogo)}>
+          <div {...stylex.props(styles.logoMark)}>A</div>
+          <span style={{fontSize: 18, fontWeight: 600, color: '#fff'}}>
+            Acme
+          </span>
+        </div>
+        <div style={{maxWidth: 480}}>
+          <div {...stylex.props(styles.brandTitle)}>
+            Build better products, faster.
+          </div>
+          <div {...stylex.props(styles.brandSub)}>
+            Streamline your workflow with our all-in-one platform. Trusted by
+            10,000+ teams worldwide.
+          </div>
+        </div>
+        <div {...stylex.props(styles.brandFooter)}>
+          &copy; 2026 Acme Inc. All rights reserved.
+        </div>
+      </div>
+
+      <div {...stylex.props(styles.formPanel)}>
+        <div {...stylex.props(styles.formContainer)}>
+          <XDSVStack gap={6}>
+            <XDSVStack gap={2}>
+              <XDSHeading level={1}>Welcome back</XDSHeading>
+              <XDSText type="body" color="secondary">
+                Enter your credentials to access your account
+              </XDSText>
+            </XDSVStack>
+
+            <XDSVStack gap={3}>
+              <XDSButton
+                label="Continue with Google"
+                variant="secondary"
+                size="md"
+              />
+              <XDSButton
+                label="Continue with GitHub"
+                variant="secondary"
+                size="md"
+              />
+            </XDSVStack>
+
+            <div {...stylex.props(styles.dividerRow)}>
+              <div {...stylex.props(styles.dividerLine)} />
+              <XDSText type="supporting" color="secondary">
+                or continue with email
+              </XDSText>
+              <div {...stylex.props(styles.dividerLine)} />
+            </div>
+
+            <XDSVStack gap={4}>
+              <XDSTextInput
+                label="Email"
+                placeholder="name@company.com"
+                value={email}
+                onChange={setEmail}
+              />
+              <XDSTextInput
+                label="Password"
+                placeholder="Enter your password"
+                value={password}
+                onChange={setPassword}
+                type="password"
+              />
+            </XDSVStack>
+
+            <div {...stylex.props(styles.row)}>
+              <XDSCheckboxInput
+                label="Remember me"
+                value={remember}
+                onChange={setRemember}
+              />
+              <XDSLink label="Forgot password" href="#">
+                Forgot password?
+              </XDSLink>
+            </div>
+
+            <XDSButton label="Sign in" variant="primary" size="md" />
+
+            <XDSText type="supporting" color="secondary">
+              Don&apos;t have an account?{' '}
+              <XDSLink label="Sign up" href="#">
+                Sign up
+              </XDSLink>
+            </XDSText>
+          </XDSVStack>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -22,12 +22,16 @@ const styles = stylex.create({
     width: '100%',
     maxWidth: 384,
   },
-  passwordRow: {
+  fullWidth: {
+    width: '100%',
+  },
+  passwordLabelRow: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
   },
   signupText: {
+    marginTop: 16,
     textAlign: 'center',
   },
 });
@@ -39,52 +43,58 @@ export default function LoginTemplate() {
   return (
     <div {...stylex.props(styles.page)}>
       <div {...stylex.props(styles.wrapper)}>
-        <XDSVStack gap={6}>
-          <XDSCard>
-            <XDSVStack gap={6}>
-              <XDSVStack gap={2}>
-                <XDSHeading level={2}>Login</XDSHeading>
-                <XDSText type="body" color="secondary">
-                  Enter your email below to login to your account
-                </XDSText>
-              </XDSVStack>
-              <XDSVStack gap={6}>
-                <XDSTextInput
-                  label="Email"
-                  type="email"
-                  placeholder="m@example.com"
-                  value={email}
-                  onChange={setEmail}
-                />
-                <XDSVStack gap={2}>
-                  <div {...stylex.props(styles.passwordRow)}>
-                    <XDSText type="label">Password</XDSText>
-                    <XDSLink label="Forgot your password?" href="#">
-                      Forgot your password?
-                    </XDSLink>
-                  </div>
-                  <XDSTextInput
-                    label="Password"
-                    isLabelHidden
-                    type="password"
-                    value={password}
-                    onChange={setPassword}
-                  />
-                </XDSVStack>
-                <XDSButton label="Login" variant="primary" />
-                <XDSButton label="Login with Google" variant="secondary" />
-              </XDSVStack>
-              <div {...stylex.props(styles.signupText)}>
-                <XDSText type="supporting" color="secondary">
-                  Don&apos;t have an account?{' '}
-                  <XDSLink label="Sign up" href="#">
-                    Sign up
-                  </XDSLink>
-                </XDSText>
-              </div>
+        <XDSCard>
+          <XDSVStack gap={6}>
+            <XDSVStack gap={2}>
+              <XDSHeading level={2}>Login</XDSHeading>
+              <XDSText type="body" color="secondary">
+                Enter your email below to login to your account
+              </XDSText>
             </XDSVStack>
-          </XDSCard>
-        </XDSVStack>
+            <XDSVStack gap={6}>
+              <XDSTextInput
+                label="Email"
+                type="email"
+                placeholder="m@example.com"
+                value={email}
+                onChange={setEmail}
+              />
+              <XDSVStack gap={2}>
+                <div {...stylex.props(styles.passwordLabelRow)}>
+                  <XDSText type="label">Password</XDSText>
+                  <XDSLink label="Forgot your password?" href="#">
+                    Forgot your password?
+                  </XDSLink>
+                </div>
+                <XDSTextInput
+                  label="Password"
+                  isLabelHidden
+                  type="password"
+                  value={password}
+                  onChange={setPassword}
+                />
+              </XDSVStack>
+              <XDSButton
+                label="Login"
+                variant="primary"
+                xstyle={styles.fullWidth}
+              />
+              <XDSButton
+                label="Login with Google"
+                variant="secondary"
+                xstyle={styles.fullWidth}
+              />
+            </XDSVStack>
+            <div {...stylex.props(styles.signupText)}>
+              <XDSText type="supporting" color="secondary">
+                Don&apos;t have an account?{' '}
+                <XDSLink label="Sign up" href="#">
+                  Sign up
+                </XDSLink>
+              </XDSText>
+            </div>
+          </XDSVStack>
+        </XDSCard>
       </div>
     </div>
   );

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -146,15 +146,21 @@ export default function LoginTemplate() {
                 value={email}
                 onChange={setEmail}
               />
-              <XDSTextInput
-                label="Password"
-                type="password"
-                value={password}
-                onChange={setPassword}
-              />
-              <XDSLink label="Forgot your password?" href="#">
-                <XDSText type="supporting">Forgot your password?</XDSText>
-              </XDSLink>
+              <XDSVStack gap={2}>
+                <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
+                  <XDSText type="label">Password</XDSText>
+                  <XDSLink label="Forgot your password?" href="#">
+                    <XDSText type="supporting">Forgot your password?</XDSText>
+                  </XDSLink>
+                </div>
+                <XDSTextInput
+                  label="Password"
+                  isLabelHidden
+                  type="password"
+                  value={password}
+                  onChange={setPassword}
+                />
+              </XDSVStack>
             </XDSVStack>
 
             {/* Login button */}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -146,7 +146,7 @@ export default function LoginTemplate() {
                 value={email}
                 onChange={setEmail}
               />
-              <XDSVStack gap={2}>
+              <XDSVStack gap={1}>
                 <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between'}}>
                   <XDSText type="label">Password</XDSText>
                   <XDSLink label="Forgot your password?" href="#">

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -86,7 +86,7 @@ export default function LoginTemplate() {
 
   return (
     <div style={{display: 'flex', flexDirection: 'column', minHeight: '100svh', width: '100%', alignItems: 'center', justifyContent: 'center', padding: 24}}>
-      <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', maxWidth: 400, gap: 16}}>
+      <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', maxWidth: 340, gap: 16}}>
         {/* Logo */}
         <XDSHStack gap={2}>
           <LogoIcon />
@@ -94,7 +94,7 @@ export default function LoginTemplate() {
         </XDSHStack>
 
         {/* Card */}
-        <XDSCard maxWidth={400}>
+        <XDSCard>
           <XDSVStack gap={4}>
             {/* Header */}
             <div {...stylex.props(styles.centered)}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -187,11 +187,11 @@ export default function LoginTemplate() {
           <XDSText type="supporting" color="secondary">
             By clicking continue, you agree to our{' '}
             <XDSLink label="Terms of Service" href="#">
-              Terms of Service
+              <XDSText type="supporting">Terms of Service</XDSText>
             </XDSLink>{' '}
             and{' '}
             <XDSLink label="Privacy Policy" href="#">
-              Privacy Policy
+              <XDSText type="supporting">Privacy Policy</XDSText>
             </XDSLink>
             .
           </XDSText>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -43,7 +43,7 @@ export default function LoginTemplate() {
   return (
     <div {...stylex.props(styles.page)}>
       <div {...stylex.props(styles.wrapper)}>
-        <XDSCard>
+        <XDSCard maxWidth={384}>
           <XDSVStack gap={6}>
             <XDSVStack gap={2}>
               <XDSHeading level={2}>Login</XDSHeading>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -86,7 +86,7 @@ export default function LoginTemplate() {
 
   return (
     <div style={{display: 'flex', flexDirection: 'column', minHeight: '100svh', width: '100%', alignItems: 'center', justifyContent: 'center', padding: 24}}>
-      <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', maxWidth: 340, gap: 16}}>
+      <div style={{display: 'flex', flexDirection: 'column', alignItems: 'center', width: '100%', maxWidth: 400, gap: 16}}>
         {/* Logo */}
         <XDSHStack gap={2}>
           <LogoIcon />

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -49,7 +49,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     alignItems: 'center',
     width: '100%',
-    maxWidth: 400,
+    maxWidth: 340,
     gap: 16,
   },
   fullWidth: {

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -146,21 +146,15 @@ export default function LoginTemplate() {
                 value={email}
                 onChange={setEmail}
               />
-              <XDSVStack gap={2}>
-                <div {...stylex.props(styles.passwordLabelRow)}>
-                  <XDSText type="label">Password</XDSText>
-                  <XDSLink label="Forgot your password?" href="#">
-                    Forgot your password?
-                  </XDSLink>
-                </div>
-                <XDSTextInput
-                  label="Password"
-                  isLabelHidden
-                  type="password"
-                  value={password}
-                  onChange={setPassword}
-                />
-              </XDSVStack>
+              <XDSTextInput
+                label="Password"
+                type="password"
+                value={password}
+                onChange={setPassword}
+              />
+              <XDSLink label="Forgot your password?" href="#">
+                <XDSText type="supporting">Forgot your password?</XDSText>
+              </XDSLink>
             </XDSVStack>
 
             {/* Login button */}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -38,9 +38,9 @@ export default function SettingsTemplate() {
   const [twoFactor, setTwoFactor] = useState(false);
 
   return (
-    <div style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
+    <div style={{height: '100svh', display: 'flex', flexDirection: 'column', overflow: 'hidden'}}>
       {/* Header */}
-      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: 16, borderBottom: '1px solid var(--xds-color-border-primary, #e5e5e5)'}}>
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: 16, borderBottom: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0}}>
         <XDSHeading level={1}>Settings</XDSHeading>
         <div style={{width: 240}}>
           <XDSTextInput label="Search" isLabelHidden placeholder="Search" value="" onChange={() => {}} />
@@ -48,9 +48,9 @@ export default function SettingsTemplate() {
       </div>
 
       {/* Body */}
-      <div style={{display: 'flex', flex: 1}}>
+      <div style={{display: 'flex', flex: 1, overflow: 'hidden'}}>
         {/* Sidebar */}
-        <nav style={{width: 200, padding: 8, borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0}}>
+        <nav style={{width: 200, padding: 8, borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0, overflowY: 'auto'}}>
           <XDSList density="compact">
             {NAV_ITEMS.map(item => (
               <XDSListItem
@@ -64,7 +64,7 @@ export default function SettingsTemplate() {
         </nav>
 
         {/* Content */}
-        <div style={{flex: 1, padding: 16, maxWidth: 960}}>
+        <div style={{flex: 1, padding: 16, maxWidth: 960, overflowY: 'auto'}}>
           <XDSVStack gap={8}>
             {/* Basic information */}
             <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40}}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -50,7 +50,7 @@ export default function SettingsTemplate() {
       {/* Body */}
       <div style={{display: 'flex', flex: 1}}>
         {/* Sidebar */}
-        <nav style={{width: 200, padding: 16, borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0}}>
+        <nav style={{width: 200, padding: 8, borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0}}>
           <XDSList density="compact">
             {NAV_ITEMS.map(item => (
               <XDSListItem

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -3,6 +3,7 @@
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSVStack} from '@xds/core/Layout';
+import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
@@ -50,22 +51,16 @@ export default function SettingsTemplate() {
       <div style={{display: 'flex', flex: 1}}>
         {/* Sidebar */}
         <nav style={{width: 200, padding: '24px 16px', borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0}}>
-          <XDSVStack gap={1}>
+          <XDSList density="compact">
             {NAV_ITEMS.map(item => (
-              <div
+              <XDSListItem
                 key={item}
+                label={item}
+                isSelected={activeNav === item}
                 onClick={() => setActiveNav(item)}
-                {...stylex.props(
-                  styles.sidebarItem,
-                  activeNav === item && styles.sidebarItemSelected,
-                )}
-              >
-                <XDSText type="body" weight={activeNav === item ? 'bold' : undefined}>
-                  {item}
-                </XDSText>
-              </div>
+              />
             ))}
-          </XDSVStack>
+          </XDSList>
         </nav>
 
         {/* Content */}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -40,7 +40,7 @@ export default function SettingsTemplate() {
   return (
     <div style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
       {/* Header */}
-      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '24px 32px', borderBottom: '1px solid var(--xds-color-border-primary, #e5e5e5)'}}>
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: 16, borderBottom: '1px solid var(--xds-color-border-primary, #e5e5e5)'}}>
         <XDSHeading level={1}>Settings</XDSHeading>
         <div style={{width: 240}}>
           <XDSTextInput label="Search" isLabelHidden placeholder="Search" value="" onChange={() => {}} />
@@ -50,7 +50,7 @@ export default function SettingsTemplate() {
       {/* Body */}
       <div style={{display: 'flex', flex: 1}}>
         {/* Sidebar */}
-        <nav style={{width: 200, padding: '24px 16px', borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0}}>
+        <nav style={{width: 200, padding: 16, borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0}}>
           <XDSList density="compact">
             {NAV_ITEMS.map(item => (
               <XDSListItem
@@ -64,7 +64,7 @@ export default function SettingsTemplate() {
         </nav>
 
         {/* Content */}
-        <div style={{flex: 1, padding: '32px 40px', maxWidth: 960}}>
+        <div style={{flex: 1, padding: 16, maxWidth: 960}}>
           <XDSVStack gap={8}>
             {/* Basic information */}
             <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40}}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -75,7 +75,7 @@ export default function SettingsTemplate() {
             <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40}}>
               <div>
                 <XDSVStack gap={1}>
-                  <XDSText type="body" weight="bold">Basic information</XDSText>
+                  <XDSHeading level={3}>Basic information</XDSHeading>
                   <XDSText type="supporting" color="secondary">
                     View and update your personal details and account information.
                   </XDSText>
@@ -100,7 +100,7 @@ export default function SettingsTemplate() {
             <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40}}>
               <div>
                 <XDSVStack gap={1}>
-                  <XDSText type="body" weight="bold">Change password</XDSText>
+                  <XDSHeading level={3}>Change password</XDSHeading>
                   <XDSText type="supporting" color="secondary">
                     Update your password to keep your account secure.
                   </XDSText>
@@ -124,7 +124,7 @@ export default function SettingsTemplate() {
             <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40}}>
               <div>
                 <XDSVStack gap={1}>
-                  <XDSText type="body" weight="bold">Advanced settings</XDSText>
+                  <XDSHeading level={3}>Advanced settings</XDSHeading>
                   <XDSText type="supporting" color="secondary">
                     Configure detailed account preferences and security options.
                   </XDSText>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -1,0 +1,421 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
+
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSTextArea} from '@xds/core/TextArea';
+import {XDSSwitch} from '@xds/core/Switch';
+import {XDSButton} from '@xds/core/Button';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSBadge} from '@xds/core/Badge';
+
+// Icons
+const ProfileIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+const BellIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0" />
+  </svg>
+);
+const ShieldIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+  </svg>
+);
+const PaintbrushIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M18.37 2.63L14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a2.12 2.12 0 1 0-3-3z" />
+    <path d="M9 8c-2 3-4 3.5-7 4l8 10c2-1 6-5 6-7" />
+  </svg>
+);
+const KeyIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
+  </svg>
+);
+
+const styles = stylex.create({
+  formSection: {padding: '24px'},
+  row: {display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16},
+  avatarRow: {display: 'flex', alignItems: 'center', gap: 16},
+  actions: {display: 'flex', justifyContent: 'flex-end', gap: 8},
+  notifRow: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+});
+
+// Sub-pages
+function ProfileTab() {
+  const [name, setName] = useState('Olivia Martin');
+  const [email, setEmail] = useState('olivia@acme.com');
+  const [bio, setBio] = useState('Product designer based in San Francisco.');
+  const [role, setRole] = useState('Designer');
+
+  return (
+    <XDSVStack gap={6}>
+      <XDSCard>
+        <div {...stylex.props(styles.formSection)}>
+          <XDSVStack gap={5}>
+            <XDSVStack gap={1}>
+              <XDSText type="body" weight="bold">
+                Profile
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                Manage your public profile information.
+              </XDSText>
+            </XDSVStack>
+            <XDSDivider />
+            <div {...stylex.props(styles.avatarRow)}>
+              <XDSAvatar
+                src="https://i.pravatar.cc/80?img=1"
+                name="Olivia Martin"
+                size="large"
+              />
+              <XDSVStack gap={1}>
+                <XDSButton
+                  label="Change avatar"
+                  variant="secondary"
+                  size="sm"
+                />
+                <XDSText type="supporting" color="secondary">
+                  JPG, GIF or PNG. 1MB max.
+                </XDSText>
+              </XDSVStack>
+            </div>
+            <div {...stylex.props(styles.row)}>
+              <XDSTextInput label="Full name" value={name} onChange={setName} />
+              <XDSTextInput label="Email" value={email} onChange={setEmail} />
+            </div>
+            <div {...stylex.props(styles.row)}>
+              <XDSTextInput label="Role" value={role} onChange={setRole} />
+              <XDSSelector
+                label="Timezone"
+                value="pst"
+                options={[
+                  {value: 'pst', label: 'Pacific Time (PT)'},
+                  {value: 'est', label: 'Eastern Time (ET)'},
+                  {value: 'utc', label: 'UTC'},
+                  {value: 'cet', label: 'Central European Time'},
+                ]}
+                onChange={() => {}}
+              />
+            </div>
+            <XDSTextArea label="Bio" value={bio} onChange={setBio} />
+            <div {...stylex.props(styles.actions)}>
+              <XDSButton label="Cancel" variant="secondary" size="sm" />
+              <XDSButton label="Save changes" variant="primary" size="sm" />
+            </div>
+          </XDSVStack>
+        </div>
+      </XDSCard>
+    </XDSVStack>
+  );
+}
+
+function NotificationsTab() {
+  const [emailNotifs, setEmailNotifs] = useState(true);
+  const [pushNotifs, setPushNotifs] = useState(false);
+  const [marketing, setMarketing] = useState(false);
+  const [security, setSecurity] = useState(true);
+  const [weeklyDigest, setWeeklyDigest] = useState(true);
+
+  const items = [
+    {
+      label: 'Email notifications',
+      desc: 'Receive email about account activity.',
+      value: emailNotifs,
+      onChange: setEmailNotifs,
+    },
+    {
+      label: 'Push notifications',
+      desc: 'Receive push notifications on your devices.',
+      value: pushNotifs,
+      onChange: setPushNotifs,
+    },
+    {
+      label: 'Marketing emails',
+      desc: 'Receive emails about new features and updates.',
+      value: marketing,
+      onChange: setMarketing,
+    },
+    {
+      label: 'Security alerts',
+      desc: 'Get notified about unusual account activity.',
+      value: security,
+      onChange: setSecurity,
+    },
+    {
+      label: 'Weekly digest',
+      desc: 'A weekly summary of your activity.',
+      value: weeklyDigest,
+      onChange: setWeeklyDigest,
+    },
+  ];
+
+  return (
+    <XDSCard>
+      <div {...stylex.props(styles.formSection)}>
+        <XDSVStack gap={5}>
+          <XDSVStack gap={1}>
+            <XDSText type="body" weight="bold">
+              Notifications
+            </XDSText>
+            <XDSText type="supporting" color="secondary">
+              Choose what notifications you receive.
+            </XDSText>
+          </XDSVStack>
+          <XDSDivider />
+          {items.map(item => (
+            <div key={item.label} {...stylex.props(styles.notifRow)}>
+              <XDSVStack gap={0}>
+                <XDSText type="body">{item.label}</XDSText>
+                <XDSText type="supporting" color="secondary">
+                  {item.desc}
+                </XDSText>
+              </XDSVStack>
+              <XDSSwitch
+                label={item.label}
+                isLabelHidden
+                value={item.value}
+                onChange={item.onChange}
+              />
+            </div>
+          ))}
+          <div {...stylex.props(styles.actions)}>
+            <XDSButton label="Save preferences" variant="primary" size="sm" />
+          </div>
+        </XDSVStack>
+      </div>
+    </XDSCard>
+  );
+}
+
+function SecurityTab() {
+  const [currentPw, setCurrentPw] = useState('');
+  const [newPw, setNewPw] = useState('');
+  const [confirmPw, setConfirmPw] = useState('');
+
+  const sessions = [
+    {
+      device: 'MacBook Pro',
+      location: 'San Francisco, CA',
+      time: 'Active now',
+      current: true,
+    },
+    {
+      device: 'iPhone 15',
+      location: 'San Francisco, CA',
+      time: '2 hours ago',
+      current: false,
+    },
+    {
+      device: 'Windows PC',
+      location: 'New York, NY',
+      time: '3 days ago',
+      current: false,
+    },
+  ];
+
+  return (
+    <XDSVStack gap={6}>
+      <XDSCard>
+        <div {...stylex.props(styles.formSection)}>
+          <XDSVStack gap={5}>
+            <XDSVStack gap={1}>
+              <XDSText type="body" weight="bold">
+                Change Password
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                Update your password to keep your account secure.
+              </XDSText>
+            </XDSVStack>
+            <XDSDivider />
+            <XDSTextInput
+              label="Current password"
+              value={currentPw}
+              onChange={setCurrentPw}
+              type="password"
+            />
+            <div {...stylex.props(styles.row)}>
+              <XDSTextInput
+                label="New password"
+                value={newPw}
+                onChange={setNewPw}
+                type="password"
+              />
+              <XDSTextInput
+                label="Confirm password"
+                value={confirmPw}
+                onChange={setConfirmPw}
+                type="password"
+              />
+            </div>
+            <div {...stylex.props(styles.actions)}>
+              <XDSButton label="Update password" variant="primary" size="sm" />
+            </div>
+          </XDSVStack>
+        </div>
+      </XDSCard>
+      <XDSCard>
+        <div {...stylex.props(styles.formSection)}>
+          <XDSVStack gap={4}>
+            <XDSVStack gap={1}>
+              <XDSText type="body" weight="bold">
+                Active Sessions
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                Manage your active sessions across devices.
+              </XDSText>
+            </XDSVStack>
+            <XDSDivider />
+            {sessions.map(s => (
+              <XDSHStack key={s.device} gap={3} vAlign="center">
+                <div style={{flex: 1}}>
+                  <XDSHStack gap={2} vAlign="center">
+                    <XDSText type="body" weight="bold">
+                      {s.device}
+                    </XDSText>
+                    {s.current && (
+                      <XDSBadge variant="success" label="Current" />
+                    )}
+                  </XDSHStack>
+                  <XDSText type="supporting" color="secondary">
+                    {s.location} &middot; {s.time}
+                  </XDSText>
+                </div>
+                {!s.current && (
+                  <XDSButton label="Revoke" variant="ghost" size="sm" />
+                )}
+              </XDSHStack>
+            ))}
+          </XDSVStack>
+        </div>
+      </XDSCard>
+    </XDSVStack>
+  );
+}
+
+// Sidebar
+function SettingsSideNav() {
+  const [active, setActive] = useState('profile');
+  return (
+    <XDSSideNav
+      header={
+        <div style={{padding: '12px 16px'}}>
+          <XDSText type="body" weight="bold">
+            Settings
+          </XDSText>
+        </div>
+      }>
+      <XDSSideNavSection title="Account">
+        <XDSSideNavItem
+          label="Profile"
+          icon={ProfileIcon}
+          isSelected={active === 'profile'}
+          onClick={() => setActive('profile')}
+        />
+        <XDSSideNavItem
+          label="Notifications"
+          icon={BellIcon}
+          isSelected={active === 'notifications'}
+          onClick={() => setActive('notifications')}
+        />
+        <XDSSideNavItem
+          label="Security"
+          icon={ShieldIcon}
+          isSelected={active === 'security'}
+          onClick={() => setActive('security')}
+        />
+      </XDSSideNavSection>
+      <XDSSideNavSection title="Preferences">
+        <XDSSideNavItem
+          label="Appearance"
+          icon={PaintbrushIcon}
+          isSelected={active === 'appearance'}
+          onClick={() => setActive('appearance')}
+        />
+        <XDSSideNavItem
+          label="API Keys"
+          icon={KeyIcon}
+          isSelected={active === 'api'}
+          onClick={() => setActive('api')}
+        />
+      </XDSSideNavSection>
+    </XDSSideNav>
+  );
+}
+
+export default function SettingsTemplate() {
+  const [tab, setTab] = useState('profile');
+
+  const content =
+    tab === 'notifications' ? (
+      <NotificationsTab />
+    ) : tab === 'security' ? (
+      <SecurityTab />
+    ) : (
+      <ProfileTab />
+    );
+
+  return (
+    <XDSAppShell
+      sideNav={<SettingsSideNav />}
+      variant="elevated"
+      contentPadding={6}>
+      <XDSVStack gap={6}>
+        <XDSVStack gap={1}>
+          <XDSHeading level={1}>Settings</XDSHeading>
+          <XDSText type="body" color="secondary">
+            Manage your account settings and preferences.
+          </XDSText>
+        </XDSVStack>
+        <XDSTabList value={tab} onChange={setTab}>
+          <XDSTab value="profile" label="Profile" />
+          <XDSTab value="notifications" label="Notifications" />
+          <XDSTab value="security" label="Security" />
+        </XDSTabList>
+        {content}
+      </XDSVStack>
+    </XDSAppShell>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -2,420 +2,163 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSAppShell} from '@xds/core/AppShell';
-import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
-
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSVStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
-import {XDSCard} from '@xds/core/Card';
 import {XDSTextInput} from '@xds/core/TextInput';
-import {XDSTextArea} from '@xds/core/TextArea';
-import {XDSSwitch} from '@xds/core/Switch';
 import {XDSButton} from '@xds/core/Button';
-import {XDSTabList, XDSTab} from '@xds/core/TabList';
-import {XDSAvatar} from '@xds/core/Avatar';
 import {XDSDivider} from '@xds/core/Divider';
-import {XDSSelector} from '@xds/core/Selector';
-import {XDSBadge} from '@xds/core/Badge';
-
-// Icons
-const ProfileIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-    <circle cx="12" cy="7" r="4" />
-  </svg>
-);
-const BellIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9M13.73 21a2 2 0 0 1-3.46 0" />
-  </svg>
-);
-const ShieldIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
-  </svg>
-);
-const PaintbrushIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M18.37 2.63L14 7l-1.59-1.59a2 2 0 0 0-2.82 0L8 7l9 9 1.59-1.59a2 2 0 0 0 0-2.82L17 10l4.37-4.37a2.12 2.12 0 1 0-3-3z" />
-    <path d="M9 8c-2 3-4 3.5-7 4l8 10c2-1 6-5 6-7" />
-  </svg>
-);
-const KeyIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4" />
-  </svg>
-);
+import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 
 const styles = stylex.create({
-  formSection: {padding: '24px'},
-  row: {display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16},
-  avatarRow: {display: 'flex', alignItems: 'center', gap: 16},
-  actions: {display: 'flex', justifyContent: 'flex-end', gap: 8},
-  notifRow: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
+  sidebarItem: {
+    padding: '8px 12px',
+    borderRadius: 6,
+    cursor: 'pointer',
+    fontSize: 14,
+  },
+  sidebarItemSelected: {
+    fontWeight: 600,
   },
 });
 
-// Sub-pages
-function ProfileTab() {
-  const [name, setName] = useState('Olivia Martin');
-  const [email, setEmail] = useState('olivia@acme.com');
-  const [bio, setBio] = useState('Product designer based in San Francisco.');
-  const [role, setRole] = useState('Designer');
-
-  return (
-    <XDSVStack gap={6}>
-      <XDSCard>
-        <div {...stylex.props(styles.formSection)}>
-          <XDSVStack gap={5}>
-            <XDSVStack gap={1}>
-              <XDSText type="body" weight="bold">
-                Profile
-              </XDSText>
-              <XDSText type="supporting" color="secondary">
-                Manage your public profile information.
-              </XDSText>
-            </XDSVStack>
-            <XDSDivider />
-            <div {...stylex.props(styles.avatarRow)}>
-              <XDSAvatar
-                src="https://i.pravatar.cc/80?img=1"
-                name="Olivia Martin"
-                size="large"
-              />
-              <XDSVStack gap={1}>
-                <XDSButton
-                  label="Change avatar"
-                  variant="secondary"
-                  size="sm"
-                />
-                <XDSText type="supporting" color="secondary">
-                  JPG, GIF or PNG. 1MB max.
-                </XDSText>
-              </XDSVStack>
-            </div>
-            <div {...stylex.props(styles.row)}>
-              <XDSTextInput label="Full name" value={name} onChange={setName} />
-              <XDSTextInput label="Email" value={email} onChange={setEmail} />
-            </div>
-            <div {...stylex.props(styles.row)}>
-              <XDSTextInput label="Role" value={role} onChange={setRole} />
-              <XDSSelector
-                label="Timezone"
-                value="pst"
-                options={[
-                  {value: 'pst', label: 'Pacific Time (PT)'},
-                  {value: 'est', label: 'Eastern Time (ET)'},
-                  {value: 'utc', label: 'UTC'},
-                  {value: 'cet', label: 'Central European Time'},
-                ]}
-                onChange={() => {}}
-              />
-            </div>
-            <XDSTextArea label="Bio" value={bio} onChange={setBio} />
-            <div {...stylex.props(styles.actions)}>
-              <XDSButton label="Cancel" variant="secondary" size="sm" />
-              <XDSButton label="Save changes" variant="primary" size="sm" />
-            </div>
-          </XDSVStack>
-        </div>
-      </XDSCard>
-    </XDSVStack>
-  );
-}
-
-function NotificationsTab() {
-  const [emailNotifs, setEmailNotifs] = useState(true);
-  const [pushNotifs, setPushNotifs] = useState(false);
-  const [marketing, setMarketing] = useState(false);
-  const [security, setSecurity] = useState(true);
-  const [weeklyDigest, setWeeklyDigest] = useState(true);
-
-  const items = [
-    {
-      label: 'Email notifications',
-      desc: 'Receive email about account activity.',
-      value: emailNotifs,
-      onChange: setEmailNotifs,
-    },
-    {
-      label: 'Push notifications',
-      desc: 'Receive push notifications on your devices.',
-      value: pushNotifs,
-      onChange: setPushNotifs,
-    },
-    {
-      label: 'Marketing emails',
-      desc: 'Receive emails about new features and updates.',
-      value: marketing,
-      onChange: setMarketing,
-    },
-    {
-      label: 'Security alerts',
-      desc: 'Get notified about unusual account activity.',
-      value: security,
-      onChange: setSecurity,
-    },
-    {
-      label: 'Weekly digest',
-      desc: 'A weekly summary of your activity.',
-      value: weeklyDigest,
-      onChange: setWeeklyDigest,
-    },
-  ];
-
-  return (
-    <XDSCard>
-      <div {...stylex.props(styles.formSection)}>
-        <XDSVStack gap={5}>
-          <XDSVStack gap={1}>
-            <XDSText type="body" weight="bold">
-              Notifications
-            </XDSText>
-            <XDSText type="supporting" color="secondary">
-              Choose what notifications you receive.
-            </XDSText>
-          </XDSVStack>
-          <XDSDivider />
-          {items.map(item => (
-            <div key={item.label} {...stylex.props(styles.notifRow)}>
-              <XDSVStack gap={0}>
-                <XDSText type="body">{item.label}</XDSText>
-                <XDSText type="supporting" color="secondary">
-                  {item.desc}
-                </XDSText>
-              </XDSVStack>
-              <XDSSwitch
-                label={item.label}
-                isLabelHidden
-                value={item.value}
-                onChange={item.onChange}
-              />
-            </div>
-          ))}
-          <div {...stylex.props(styles.actions)}>
-            <XDSButton label="Save preferences" variant="primary" size="sm" />
-          </div>
-        </XDSVStack>
-      </div>
-    </XDSCard>
-  );
-}
-
-function SecurityTab() {
-  const [currentPw, setCurrentPw] = useState('');
-  const [newPw, setNewPw] = useState('');
-  const [confirmPw, setConfirmPw] = useState('');
-
-  const sessions = [
-    {
-      device: 'MacBook Pro',
-      location: 'San Francisco, CA',
-      time: 'Active now',
-      current: true,
-    },
-    {
-      device: 'iPhone 15',
-      location: 'San Francisco, CA',
-      time: '2 hours ago',
-      current: false,
-    },
-    {
-      device: 'Windows PC',
-      location: 'New York, NY',
-      time: '3 days ago',
-      current: false,
-    },
-  ];
-
-  return (
-    <XDSVStack gap={6}>
-      <XDSCard>
-        <div {...stylex.props(styles.formSection)}>
-          <XDSVStack gap={5}>
-            <XDSVStack gap={1}>
-              <XDSText type="body" weight="bold">
-                Change Password
-              </XDSText>
-              <XDSText type="supporting" color="secondary">
-                Update your password to keep your account secure.
-              </XDSText>
-            </XDSVStack>
-            <XDSDivider />
-            <XDSTextInput
-              label="Current password"
-              value={currentPw}
-              onChange={setCurrentPw}
-              type="password"
-            />
-            <div {...stylex.props(styles.row)}>
-              <XDSTextInput
-                label="New password"
-                value={newPw}
-                onChange={setNewPw}
-                type="password"
-              />
-              <XDSTextInput
-                label="Confirm password"
-                value={confirmPw}
-                onChange={setConfirmPw}
-                type="password"
-              />
-            </div>
-            <div {...stylex.props(styles.actions)}>
-              <XDSButton label="Update password" variant="primary" size="sm" />
-            </div>
-          </XDSVStack>
-        </div>
-      </XDSCard>
-      <XDSCard>
-        <div {...stylex.props(styles.formSection)}>
-          <XDSVStack gap={4}>
-            <XDSVStack gap={1}>
-              <XDSText type="body" weight="bold">
-                Active Sessions
-              </XDSText>
-              <XDSText type="supporting" color="secondary">
-                Manage your active sessions across devices.
-              </XDSText>
-            </XDSVStack>
-            <XDSDivider />
-            {sessions.map(s => (
-              <XDSHStack key={s.device} gap={3} vAlign="center">
-                <div style={{flex: 1}}>
-                  <XDSHStack gap={2} vAlign="center">
-                    <XDSText type="body" weight="bold">
-                      {s.device}
-                    </XDSText>
-                    {s.current && (
-                      <XDSBadge variant="success" label="Current" />
-                    )}
-                  </XDSHStack>
-                  <XDSText type="supporting" color="secondary">
-                    {s.location} &middot; {s.time}
-                  </XDSText>
-                </div>
-                {!s.current && (
-                  <XDSButton label="Revoke" variant="ghost" size="sm" />
-                )}
-              </XDSHStack>
-            ))}
-          </XDSVStack>
-        </div>
-      </XDSCard>
-    </XDSVStack>
-  );
-}
-
-// Sidebar
-function SettingsSideNav() {
-  const [active, setActive] = useState('profile');
-  return (
-    <XDSSideNav
-      header={
-        <div style={{padding: '12px 16px'}}>
-          <XDSText type="body" weight="bold">
-            Settings
-          </XDSText>
-        </div>
-      }>
-      <XDSSideNavSection title="Account">
-        <XDSSideNavItem
-          label="Profile"
-          icon={ProfileIcon}
-          isSelected={active === 'profile'}
-          onClick={() => setActive('profile')}
-        />
-        <XDSSideNavItem
-          label="Notifications"
-          icon={BellIcon}
-          isSelected={active === 'notifications'}
-          onClick={() => setActive('notifications')}
-        />
-        <XDSSideNavItem
-          label="Security"
-          icon={ShieldIcon}
-          isSelected={active === 'security'}
-          onClick={() => setActive('security')}
-        />
-      </XDSSideNavSection>
-      <XDSSideNavSection title="Preferences">
-        <XDSSideNavItem
-          label="Appearance"
-          icon={PaintbrushIcon}
-          isSelected={active === 'appearance'}
-          onClick={() => setActive('appearance')}
-        />
-        <XDSSideNavItem
-          label="API Keys"
-          icon={KeyIcon}
-          isSelected={active === 'api'}
-          onClick={() => setActive('api')}
-        />
-      </XDSSideNavSection>
-    </XDSSideNav>
-  );
-}
+const NAV_ITEMS = ['Profile', 'Account', 'Members', 'Billing', 'Invoices', 'API'];
 
 export default function SettingsTemplate() {
-  const [tab, setTab] = useState('profile');
-
-  const content =
-    tab === 'notifications' ? (
-      <NotificationsTab />
-    ) : tab === 'security' ? (
-      <SecurityTab />
-    ) : (
-      <ProfileTab />
-    );
+  const [activeNav, setActiveNav] = useState('Profile');
+  const [username, setUsername] = useState('nicol43');
+  const [firstName, setFirstName] = useState('Stephanie');
+  const [lastName, setLastName] = useState('Nicol');
+  const [email, setEmail] = useState('stephanie_nicol@mail.com');
+  const [currentPw, setCurrentPw] = useState('password123');
+  const [newPw, setNewPw] = useState('password123');
+  const [confirmPw, setConfirmPw] = useState('password123');
+  const [dataExport, setDataExport] = useState(false);
+  const [adminMembers, setAdminMembers] = useState(false);
+  const [twoFactor, setTwoFactor] = useState(false);
 
   return (
-    <XDSAppShell
-      sideNav={<SettingsSideNav />}
-      variant="elevated"
-      contentPadding={6}>
-      <XDSVStack gap={6}>
-        <XDSVStack gap={1}>
-          <XDSHeading level={1}>Settings</XDSHeading>
-          <XDSText type="body" color="secondary">
-            Manage your account settings and preferences.
-          </XDSText>
-        </XDSVStack>
-        <XDSTabList value={tab} onChange={setTab}>
-          <XDSTab value="profile" label="Profile" />
-          <XDSTab value="notifications" label="Notifications" />
-          <XDSTab value="security" label="Security" />
-        </XDSTabList>
-        {content}
-      </XDSVStack>
-    </XDSAppShell>
+    <div style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
+      {/* Header */}
+      <div style={{display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '24px 32px', borderBottom: '1px solid var(--xds-color-border-primary, #e5e5e5)'}}>
+        <XDSHeading level={1}>Settings</XDSHeading>
+        <div style={{width: 240}}>
+          <XDSTextInput label="Search" isLabelHidden placeholder="Search" value="" onChange={() => {}} />
+        </div>
+      </div>
+
+      {/* Body */}
+      <div style={{display: 'flex', flex: 1}}>
+        {/* Sidebar */}
+        <nav style={{width: 200, padding: '24px 16px', borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)', flexShrink: 0}}>
+          <XDSVStack gap={1}>
+            {NAV_ITEMS.map(item => (
+              <div
+                key={item}
+                onClick={() => setActiveNav(item)}
+                {...stylex.props(
+                  styles.sidebarItem,
+                  activeNav === item && styles.sidebarItemSelected,
+                )}
+              >
+                <XDSText type="body" weight={activeNav === item ? 'bold' : undefined}>
+                  {item}
+                </XDSText>
+              </div>
+            ))}
+          </XDSVStack>
+        </nav>
+
+        {/* Content */}
+        <div style={{flex: 1, padding: '32px 40px', maxWidth: 960}}>
+          <XDSVStack gap={8}>
+            {/* Basic information */}
+            <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40}}>
+              <div>
+                <XDSVStack gap={1}>
+                  <XDSText type="body" weight="bold">Basic information</XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    View and update your personal details and account information.
+                  </XDSText>
+                </XDSVStack>
+              </div>
+              <div>
+                <XDSVStack gap={4}>
+                  <XDSTextInput label="Username" value={username} onChange={setUsername} />
+                  <XDSTextInput label="First name" value={firstName} onChange={setFirstName} />
+                  <XDSTextInput label="Last name" value={lastName} onChange={setLastName} />
+                  <XDSTextInput label="Email address" value={email} onChange={setEmail} />
+                  <div>
+                    <XDSButton label="Save" variant="primary" size="sm" />
+                  </div>
+                </XDSVStack>
+              </div>
+            </div>
+
+            <XDSDivider />
+
+            {/* Change password */}
+            <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40}}>
+              <div>
+                <XDSVStack gap={1}>
+                  <XDSText type="body" weight="bold">Change password</XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    Update your password to keep your account secure.
+                  </XDSText>
+                </XDSVStack>
+              </div>
+              <div>
+                <XDSVStack gap={4}>
+                  <XDSTextInput label="Verify current password" type="password" value={currentPw} onChange={setCurrentPw} />
+                  <XDSTextInput label="New password" type="password" value={newPw} onChange={setNewPw} />
+                  <XDSTextInput label="Confirm password" type="password" value={confirmPw} onChange={setConfirmPw} />
+                  <div>
+                    <XDSButton label="Save" variant="primary" size="sm" />
+                  </div>
+                </XDSVStack>
+              </div>
+            </div>
+
+            <XDSDivider />
+
+            {/* Advanced settings */}
+            <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 40}}>
+              <div>
+                <XDSVStack gap={1}>
+                  <XDSText type="body" weight="bold">Advanced settings</XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    Configure detailed account preferences and security options.
+                  </XDSText>
+                </XDSVStack>
+              </div>
+              <div>
+                <XDSVStack gap={5}>
+                  <XDSCheckboxInput
+                    label="Data Export Access"
+                    description="Allow export of personal data and backups."
+                    value={dataExport}
+                    onChange={setDataExport}
+                  />
+                  <XDSCheckboxInput
+                    label="Allow Admin to Add Members"
+                    description="Admins can invite and manage members."
+                    value={adminMembers}
+                    onChange={setAdminMembers}
+                  />
+                  <XDSCheckboxInput
+                    label="Enable Two-Factor Authentication"
+                    description="Require 2FA for added account security."
+                    value={twoFactor}
+                    onChange={setTwoFactor}
+                  />
+                  <div>
+                    <XDSButton label="Save" variant="primary" size="sm" />
+                  </div>
+                </XDSVStack>
+              </div>
+            </div>
+          </XDSVStack>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -88,7 +88,7 @@ export default function SettingsTemplate() {
                   <XDSTextInput label="Last name" value={lastName} onChange={setLastName} />
                   <XDSTextInput label="Email address" value={email} onChange={setEmail} />
                   <div>
-                    <XDSButton label="Save" variant="primary" size="sm" />
+                    <XDSButton label="Save" variant="primary" />
                   </div>
                 </XDSVStack>
               </div>
@@ -112,7 +112,7 @@ export default function SettingsTemplate() {
                   <XDSTextInput label="New password" type="password" value={newPw} onChange={setNewPw} />
                   <XDSTextInput label="Confirm password" type="password" value={confirmPw} onChange={setConfirmPw} />
                   <div>
-                    <XDSButton label="Save" variant="primary" size="sm" />
+                    <XDSButton label="Save" variant="primary" />
                   </div>
                 </XDSVStack>
               </div>
@@ -151,7 +151,7 @@ export default function SettingsTemplate() {
                     onChange={setTwoFactor}
                   />
                   <div>
-                    <XDSButton label="Save" variant="primary" size="sm" />
+                    <XDSButton label="Save" variant="primary" />
                   </div>
                 </XDSVStack>
               </div>

--- a/apps/sandbox/src/app/SandboxNav.tsx
+++ b/apps/sandbox/src/app/SandboxNav.tsx
@@ -12,10 +12,11 @@ import {categories} from './sandboxPages';
 import {
   HomeIcon,
   WrenchIcon,
-  LayoutTemplateIcon,
   PaletteIcon,
   SunIcon,
   MoonIcon,
+  BoxIcon,
+  AppWindowIcon,
 } from './icons';
 import {spacingVars, colorVars} from '@xds/core/theme/tokens.stylex';
 
@@ -24,7 +25,8 @@ const categoryIcons: Record<
   React.ComponentType<React.SVGProps<SVGSVGElement>>
 > = {
   tools: WrenchIcon,
-  templates: LayoutTemplateIcon,
+  examples: BoxIcon,
+  templates: AppWindowIcon,
 };
 
 const styles = stylex.create({
@@ -69,7 +71,13 @@ function SandboxHeader() {
         <XDSDropdownMenu
           button={{
             label: 'Theme',
-            icon: <PaletteIcon width={16} height={16} style={{color: 'var(--color-icon-secondary)'}} />,
+            icon: (
+              <PaletteIcon
+                width={16}
+                height={16}
+                style={{color: 'var(--color-icon-secondary)'}}
+              />
+            ),
             variant: 'ghost',
             size: 'sm',
           }}
@@ -81,9 +89,17 @@ function SandboxHeader() {
             label: mode === 'dark' ? 'Dark mode' : 'Light mode',
             icon:
               mode === 'dark' ? (
-                <MoonIcon width={16} height={16} style={{color: 'var(--color-icon-secondary)'}} />
+                <MoonIcon
+                  width={16}
+                  height={16}
+                  style={{color: 'var(--color-icon-secondary)'}}
+                />
               ) : (
-                <SunIcon width={16} height={16} style={{color: 'var(--color-icon-secondary)'}} />
+                <SunIcon
+                  width={16}
+                  height={16}
+                  style={{color: 'var(--color-icon-secondary)'}}
+                />
               ),
             variant: 'ghost',
             size: 'sm',

--- a/apps/sandbox/src/app/icons.tsx
+++ b/apps/sandbox/src/app/icons.tsx
@@ -125,3 +125,34 @@ export const HomeIcon = (props: IconProps) => (
     <polyline points="9 22 9 12 15 12 15 22" />
   </svg>
 );
+
+export const BoxIcon = (props: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+    <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+    <line x1="12" y1="22.08" x2="12" y2="12" />
+  </svg>
+);
+
+export const AppWindowIcon = (props: IconProps) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <rect x="2" y="4" width="20" height="16" rx="2" />
+    <path d="M10 4v4" />
+    <path d="M2 8h20" />
+    <path d="M6 4v4" />
+  </svg>
+);

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -59,9 +59,9 @@ export const categories: SandboxCategory[] = [
     ],
   },
   {
-    label: 'Templates',
-    slug: 'templates',
-    description: 'Ready-to-use page templates and composition patterns.',
+    label: 'Examples',
+    slug: 'examples',
+    description: 'Component demos and composition patterns.',
     pages: [
       {
         name: 'Navigation',
@@ -87,6 +87,36 @@ export const categories: SandboxCategory[] = [
         name: 'Example',
         href: '/pages/example/',
         description: 'General component composition examples',
+      },
+    ],
+  },
+  {
+    label: 'Templates',
+    slug: 'templates',
+    description:
+      'Full-page application templates — dashboards, forms, and data views built with XDS.',
+    pages: [
+      {
+        name: 'Dashboard',
+        href: '/pages/template-dashboard/',
+        description:
+          'Analytics dashboard with sidebar, stats, charts, and tables',
+      },
+      {
+        name: 'Login',
+        href: '/pages/template-login/',
+        description: 'Authentication page with login form and branding',
+      },
+      {
+        name: 'Settings',
+        href: '/pages/template-settings/',
+        description: 'Settings page with tabs, forms, and toggles',
+      },
+      {
+        name: 'Data Table',
+        href: '/pages/template-data-table/',
+        description:
+          'Full data management view with search, filters, and pagination',
       },
     ],
   },


### PR DESCRIPTION
## Summary

Adds four shadcn-inspired full-page application templates to the sandbox, giving us complete page layouts to evaluate XDS components in realistic application contexts.

## Templates

| Template | Components Used |
|---|---|
| **Dashboard** | AppShell, SideNav, TopNav, Card, Table, Badge, Avatar, ProgressBar, NavIcon, Button |
| **Login** | Card, TextInput, Button, CheckboxInput, Link, Text |
| **Settings** | AppShell, SideNav, TabList, TextInput, TextArea, Switch, Selector, Avatar, Badge, Dialog, Card |
| **Data Table** | AppShell, SideNav, Table (selection + sort), Pagination, TabList, Selector, TextInput, Dialog, Badge, Avatar |

## Other Changes

- Renamed existing `Templates` category → `Examples` (they're component demos, not full-page layouts)
- New `Templates` category for full-page application templates
- Added `BoxIcon` and `AppWindowIcon` sidebar icons
- All templates live in `(fullscreen)/` route group (no sandbox shell wrapper)

## Preview

Templates will be available at the PR sandbox deployment:
- `/pages/template-dashboard/`
- `/pages/template-login/`
- `/pages/template-settings/`
- `/pages/template-data-table/`
