### PR TITLE
fix(Table): improve useXDSTableColumnResize constraints and a11y (#978)

### DIFF
--- a/apps/storybook/stories/TableColumnResize.stories.tsx
+++ b/apps/storybook/stories/TableColumnResize.stories.tsx
@@ -5,6 +5,8 @@ import {
   useXDSTableColumnResize,
   useXDSTableSelection,
   useXDSTableSelectionState,
+  proportional,
+  pixel,
 } from '@xds/core/Table';
 import type {XDSTableColumn} from '@xds/core/Table';
 
@@ -84,6 +86,7 @@ export const Default: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
+      columns,
       onColumnResizeEnd: ({columnKey, newWidth}) => {
         setColumnWidths(prev => ({...prev, [columnKey]: newWidth}));
       },
@@ -92,7 +95,8 @@ export const Default: Story = {
     return (
       <div style={{maxWidth: 600}}>
         <p style={{marginBottom: 8, fontSize: 14, color: '#666'}}>
-          Drag the right edge of any column header to resize.
+          Drag the right edge of any column header to resize. The last
+          proportional column has no handle — it flexes to fill remaining space.
         </p>
         <XDSTable
           data={users}
@@ -116,6 +120,7 @@ export const WithMinMaxConstraints: Story = {
       onColumnResizeEnd: ({columnKey, newWidth}) => {
         setColumnWidths(prev => ({...prev, [columnKey]: newWidth}));
       },
+      columns,
       minWidth: 80,
       maxWidth: 300,
     });
@@ -144,6 +149,7 @@ export const PersistingWidths: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
+      columns,
       onColumnResizeEnd: ({columnKey, newWidth}) => {
         setColumnWidths(prev => ({...prev, [columnKey]: newWidth}));
       },
@@ -161,8 +167,7 @@ export const PersistingWidths: Story = {
         </p>
         <button
           onClick={() => setColumnWidths({})}
-          style={{marginBottom: 8, fontSize: 14}}
-        >
+          style={{marginBottom: 8, fontSize: 14}}>
           Reset all widths
         </button>
         <XDSTable
@@ -184,6 +189,7 @@ export const KeyboardResize: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
+      columns,
       onColumnResizeEnd: ({columnKey, newWidth}) => {
         setColumnWidths(prev => ({...prev, [columnKey]: newWidth}));
       },
@@ -223,6 +229,7 @@ export const WithSelectionAndResize: Story = {
 
     const resizePlugin = useXDSTableColumnResize<User>({
       columnWidths,
+      columns,
       onColumnResizeEnd: ({columnKey, newWidth}) => {
         setColumnWidths(prev => ({...prev, [columnKey]: newWidth}));
       },
@@ -239,6 +246,44 @@ export const WithSelectionAndResize: Story = {
           columns={columns}
           idKey="id"
           plugins={{selection: selectionPlugin, columnResize: resizePlugin}}
+        />
+      </div>
+    );
+  },
+};
+
+const pixelColumns: XDSTableColumn<User>[] = [
+  {key: 'name', header: 'Name', width: pixel(200)},
+  {key: 'email', header: 'Email', width: pixel(250)},
+  {key: 'role', header: 'Role', width: pixel(150)},
+];
+
+export const AllPixelColumns: Story = {
+  render: () => {
+    const [columnWidths, setColumnWidths] = useState<Record<string, number>>(
+      {},
+    );
+
+    const resizePlugin = useXDSTableColumnResize<User>({
+      columnWidths,
+      columns: pixelColumns,
+      onColumnResizeEnd: ({columnKey, newWidth}) => {
+        setColumnWidths(prev => ({...prev, [columnKey]: newWidth}));
+      },
+    });
+
+    return (
+      <div style={{maxWidth: 600}}>
+        <p style={{marginBottom: 8, fontSize: 14, color: '#666'}}>
+          All columns are pixel-width. Every column gets a resize handle,
+          including the last one. Min width defaults to the column&apos;s
+          declared pixel value.
+        </p>
+        <XDSTable
+          data={users}
+          columns={pixelColumns}
+          idKey="id"
+          plugins={{columnResize: resizePlugin}}
         />
       </div>
     );

--- a/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.test.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.test.tsx
@@ -12,6 +12,7 @@ import userEvent from '@testing-library/user-event';
 import {XDSTable} from '../../XDSTable';
 import {useXDSTableColumnResize} from './useXDSTableColumnResize';
 import {useXDSTableSelection} from '../selection/useXDSTableSelection';
+import {proportional, pixel} from '../../columnUtils';
 import type {XDSTableColumn} from '../../types';
 
 // JSDOM doesn't implement pointer capture
@@ -41,6 +42,12 @@ const testColumns: XDSTableColumn<TestItem>[] = [
   {key: 'role', header: 'Role'},
 ];
 
+/** Pixel columns — both columns get handles and resize directly */
+const pixelColumns: XDSTableColumn<TestItem>[] = [
+  {key: 'name', header: 'Name', width: pixel(200)},
+  {key: 'role', header: 'Role', width: pixel(200)},
+];
+
 // =============================================================================
 // Test Helpers
 // =============================================================================
@@ -50,11 +57,13 @@ function ResizeTable({
   onColumnResizeEnd,
   minWidth,
   maxWidth,
+  columns: columnsProp = testColumns,
 }: {
   columnWidths?: Record<string, number>;
   onColumnResizeEnd?: (event: {columnKey: string; newWidth: number}) => void;
   minWidth?: number;
   maxWidth?: number;
+  columns?: XDSTableColumn<TestItem>[];
 }) {
   const [columnWidths, setColumnWidths] = useState(initialWidths);
 
@@ -66,12 +75,13 @@ function ResizeTable({
     },
     minWidth,
     maxWidth,
+    columns: columnsProp,
   });
 
   return (
     <XDSTable
       data={testData}
-      columns={testColumns}
+      columns={columnsProp}
       idKey="id"
       plugins={{resize: resizePlugin}}
     />
@@ -88,8 +98,8 @@ function getResizeHandles() {
 
 describe('useXDSTableColumnResize', () => {
   describe('hook behavior', () => {
-    it('renders resize handles in each header cell', () => {
-      render(<ResizeTable />);
+    it('renders resize handles in each header cell (pixel columns)', () => {
+      render(<ResizeTable columns={pixelColumns} />);
       const handles = getResizeHandles();
       expect(handles).toHaveLength(2);
     });
@@ -128,6 +138,7 @@ describe('useXDSTableColumnResize', () => {
       const onResize = vi.fn();
       render(
         <ResizeTable
+          columns={pixelColumns}
           columnWidths={{name: 200}}
           onColumnResizeEnd={onResize}
         />,
@@ -148,6 +159,7 @@ describe('useXDSTableColumnResize', () => {
       const onResize = vi.fn();
       render(
         <ResizeTable
+          columns={pixelColumns}
           columnWidths={{name: 100}}
           onColumnResizeEnd={onResize}
           minWidth={80}
@@ -170,6 +182,7 @@ describe('useXDSTableColumnResize', () => {
       const onResize = vi.fn();
       render(
         <ResizeTable
+          columns={pixelColumns}
           columnWidths={{name: 200}}
           onColumnResizeEnd={onResize}
           maxWidth={300}
@@ -190,10 +203,7 @@ describe('useXDSTableColumnResize', () => {
     it('does not call onColumnResizeEnd on Escape during drag', () => {
       const onResize = vi.fn();
       render(
-        <ResizeTable
-          columnWidths={{name: 200}}
-          onColumnResizeEnd={onResize}
-        />,
+        <ResizeTable columnWidths={{name: 200}} onColumnResizeEnd={onResize} />,
       );
       const handle = getResizeHandles()[0];
 
@@ -252,18 +262,16 @@ describe('useXDSTableColumnResize', () => {
     });
 
     it('resized column persists across re-renders', () => {
-      const {rerender} = render(
-        <ResizeTable columnWidths={{name: 250}} />,
-      );
+      const {rerender} = render(<ResizeTable columnWidths={{name: 250}} />);
       const headerRow = screen.getAllByRole('row')[0];
       const headers = within(headerRow).getAllByRole('columnheader');
       expect(headers[0].style.width).toBe('250px');
 
       // Trigger re-render
       rerender(<ResizeTable columnWidths={{name: 250}} />);
-      const headersAfter = within(
-        screen.getAllByRole('row')[0],
-      ).getAllByRole('columnheader');
+      const headersAfter = within(screen.getAllByRole('row')[0]).getAllByRole(
+        'columnheader',
+      );
       expect(headersAfter[0].style.width).toBe('250px');
     });
 
@@ -290,15 +298,15 @@ describe('useXDSTableColumnResize', () => {
       const {rerender} = render(
         <ControlledResizeTable columnWidths={{name: 250}} />,
       );
-      const headers = within(
-        screen.getAllByRole('row')[0],
-      ).getAllByRole('columnheader');
+      const headers = within(screen.getAllByRole('row')[0]).getAllByRole(
+        'columnheader',
+      );
       expect(headers[0].style.width).toBe('250px');
 
       rerender(<ControlledResizeTable columnWidths={{}} />);
-      const headersAfter = within(
-        screen.getAllByRole('row')[0],
-      ).getAllByRole('columnheader');
+      const headersAfter = within(screen.getAllByRole('row')[0]).getAllByRole(
+        'columnheader',
+      );
       expect(headersAfter[0].style.width).toBe('');
     });
   });
@@ -314,29 +322,16 @@ describe('useXDSTableColumnResize', () => {
       const handle = getResizeHandles()[0];
 
       await user.tab();
-      // Tab may land on the handle (or other focusable elements first)
       // Explicitly focus the handle
       handle.focus();
       expect(document.activeElement).toBe(handle);
     });
 
-    it('Enter activates resize mode and locks width', () => {
-      render(<ResizeTable columnWidths={{name: 200}} />);
-      const handle = getResizeHandles()[0];
-      handle.focus();
-
-      fireEvent.keyDown(handle, {key: 'Enter'});
-      // After activation, the th should have width locked as inline style
-      const headers = within(
-        screen.getAllByRole('row')[0],
-      ).getAllByRole('columnheader');
-      expect(headers[0].style.width).toBe('200px');
-    });
-
-    it('ArrowRight increases width by 10px in resize mode', () => {
+    it('ArrowRight resizes immediately on focus (no activation step)', () => {
       const onResize = vi.fn();
       render(
         <ResizeTable
+          columns={pixelColumns}
           columnWidths={{name: 200}}
           onColumnResizeEnd={onResize}
         />,
@@ -344,12 +339,8 @@ describe('useXDSTableColumnResize', () => {
       const handle = getResizeHandles()[0];
       handle.focus();
 
-      // Activate
-      fireEvent.keyDown(handle, {key: 'Enter'});
-      // Arrow right
+      // Arrow right commits immediately — no Enter activation needed
       fireEvent.keyDown(handle, {key: 'ArrowRight'});
-      // Commit
-      fireEvent.keyDown(handle, {key: 'Enter'});
 
       expect(onResize).toHaveBeenCalledWith({
         columnKey: 'name',
@@ -357,10 +348,15 @@ describe('useXDSTableColumnResize', () => {
       });
     });
 
-    it('ArrowLeft decreases width by 10px', () => {
+    it('ArrowLeft decreases width by 10px immediately', () => {
+      const smallPixelColumns: XDSTableColumn<TestItem>[] = [
+        {key: 'name', header: 'Name', width: pixel(100)},
+        {key: 'role', header: 'Role', width: pixel(100)},
+      ];
       const onResize = vi.fn();
       render(
         <ResizeTable
+          columns={smallPixelColumns}
           columnWidths={{name: 200}}
           onColumnResizeEnd={onResize}
         />,
@@ -368,9 +364,7 @@ describe('useXDSTableColumnResize', () => {
       const handle = getResizeHandles()[0];
       handle.focus();
 
-      fireEvent.keyDown(handle, {key: 'Enter'});
       fireEvent.keyDown(handle, {key: 'ArrowLeft'});
-      fireEvent.keyDown(handle, {key: 'Enter'});
 
       expect(onResize).toHaveBeenCalledWith({
         columnKey: 'name',
@@ -382,6 +376,7 @@ describe('useXDSTableColumnResize', () => {
       const onResize = vi.fn();
       render(
         <ResizeTable
+          columns={pixelColumns}
           columnWidths={{name: 200}}
           onColumnResizeEnd={onResize}
         />,
@@ -389,9 +384,7 @@ describe('useXDSTableColumnResize', () => {
       const handle = getResizeHandles()[0];
       handle.focus();
 
-      fireEvent.keyDown(handle, {key: 'Enter'});
       fireEvent.keyDown(handle, {key: 'ArrowRight', shiftKey: true});
-      fireEvent.keyDown(handle, {key: 'Enter'});
 
       expect(onResize).toHaveBeenCalledWith({
         columnKey: 'name',
@@ -399,10 +392,11 @@ describe('useXDSTableColumnResize', () => {
       });
     });
 
-    it('Escape cancels keyboard resize and reverts width', () => {
+    it('multiple arrow presses accumulate', () => {
       const onResize = vi.fn();
       render(
         <ResizeTable
+          columns={pixelColumns}
           columnWidths={{name: 200}}
           onColumnResizeEnd={onResize}
         />,
@@ -410,41 +404,74 @@ describe('useXDSTableColumnResize', () => {
       const handle = getResizeHandles()[0];
       handle.focus();
 
-      fireEvent.keyDown(handle, {key: 'Enter'});
       fireEvent.keyDown(handle, {key: 'ArrowRight'});
       fireEvent.keyDown(handle, {key: 'ArrowRight'});
-      fireEvent.keyDown(handle, {key: 'Escape'});
+      fireEvent.keyDown(handle, {key: 'ArrowRight'});
 
-      expect(onResize).not.toHaveBeenCalled();
-
-      // Width should revert — the th should have the original 200px
-      const headers = within(
-        screen.getAllByRole('row')[0],
-      ).getAllByRole('columnheader');
-      expect(headers[0].style.width).toBe('200px');
+      // Each press commits independently, building on the previous
+      expect(onResize).toHaveBeenCalledTimes(3);
+      expect(onResize).toHaveBeenLastCalledWith({
+        columnKey: 'name',
+        newWidth: 230, // 200 + 10 + 10 + 10
+      });
     });
 
-    it('Enter commits keyboard resize with accumulated changes', () => {
+    it('Home key jumps to minimum width', () => {
       const onResize = vi.fn();
       render(
         <ResizeTable
-          columnWidths={{name: 200}}
+          columns={pixelColumns}
+          columnWidths={{name: 300}}
           onColumnResizeEnd={onResize}
         />,
       );
       const handle = getResizeHandles()[0];
       handle.focus();
 
-      fireEvent.keyDown(handle, {key: 'Enter'});
-      fireEvent.keyDown(handle, {key: 'ArrowRight'});
-      fireEvent.keyDown(handle, {key: 'ArrowRight'});
-      fireEvent.keyDown(handle, {key: 'ArrowRight'});
-      fireEvent.keyDown(handle, {key: 'Enter'});
+      fireEvent.keyDown(handle, {key: 'Home'});
 
       expect(onResize).toHaveBeenCalledWith({
         columnKey: 'name',
-        newWidth: 230,
+        newWidth: 200, // pixel(200) column min
       });
+    });
+
+    it('End key jumps to maximum width when finite', () => {
+      const onResize = vi.fn();
+      render(
+        <ResizeTable
+          columns={pixelColumns}
+          columnWidths={{name: 200}}
+          onColumnResizeEnd={onResize}
+          maxWidth={500}
+        />,
+      );
+      const handle = getResizeHandles()[0];
+      handle.focus();
+
+      fireEvent.keyDown(handle, {key: 'End'});
+
+      expect(onResize).toHaveBeenCalledWith({
+        columnKey: 'name',
+        newWidth: 500,
+      });
+    });
+
+    it('End key does nothing when maxWidth is Infinity', () => {
+      const onResize = vi.fn();
+      render(
+        <ResizeTable
+          columns={pixelColumns}
+          columnWidths={{name: 200}}
+          onColumnResizeEnd={onResize}
+        />,
+      );
+      const handle = getResizeHandles()[0];
+      handle.focus();
+
+      fireEvent.keyDown(handle, {key: 'End'});
+
+      expect(onResize).not.toHaveBeenCalled();
     });
   });
 
@@ -499,11 +526,7 @@ describe('useXDSTableColumnResize', () => {
       function EmptyTable() {
         const resizePlugin = useXDSTableColumnResize<TestItem>({});
         return (
-          <XDSTable
-            data={[]}
-            columns={[]}
-            plugins={{resize: resizePlugin}}
-          />
+          <XDSTable data={[]} columns={[]} plugins={{resize: resizePlugin}} />
         );
       }
 
@@ -571,6 +594,117 @@ describe('useXDSTableColumnResize', () => {
       // After reorder, Role is first, Name is second
       expect(headers[0].style.width).toBe('150px');
       expect(headers[1].style.width).toBe('200px');
+    });
+  });
+
+  // ===========================================================================
+  // 6.7 Per-Column Min Width
+  // ===========================================================================
+
+  describe('per-column min width', () => {
+    it('uses proportional column minWidth as resize minimum', () => {
+      const columnsWithMinWidth: XDSTableColumn<TestItem>[] = [
+        {key: 'name', header: 'Name', width: proportional(1, {minWidth: 150})},
+        {key: 'role', header: 'Role', width: pixel(200)},
+      ];
+
+      render(<ResizeTable columns={columnsWithMinWidth} />);
+      const handle = getResizeHandles()[0];
+      // The handle's aria-valuemin should reflect the column's minWidth
+      expect(handle).toHaveAttribute('aria-valuemin', '150');
+    });
+
+    it('uses pixel column value as resize minimum', () => {
+      const columnsWithPixel: XDSTableColumn<TestItem>[] = [
+        {key: 'name', header: 'Name', width: pixel(180)},
+        {key: 'role', header: 'Role', width: pixel(200)},
+      ];
+
+      render(<ResizeTable columns={columnsWithPixel} />);
+      const handle = getResizeHandles()[0];
+      expect(handle).toHaveAttribute('aria-valuemin', '180');
+    });
+
+    it('global minWidth overrides per-column minimum', () => {
+      const columnsWithMinWidth: XDSTableColumn<TestItem>[] = [
+        {key: 'name', header: 'Name', width: proportional(1, {minWidth: 150})},
+        {key: 'role', header: 'Role'},
+      ];
+
+      render(<ResizeTable columns={columnsWithMinWidth} minWidth={60} />);
+      const handle = getResizeHandles()[0];
+      // Global override wins
+      expect(handle).toHaveAttribute('aria-valuemin', '60');
+    });
+
+    it('defaults to DEFAULT_MIN_COLUMN_WIDTH (120) for proportional without explicit minWidth', () => {
+      const defaultColumns: XDSTableColumn<TestItem>[] = [
+        {key: 'name', header: 'Name', width: proportional(1)},
+        {key: 'role', header: 'Role', width: pixel(200)},
+      ];
+
+      render(<ResizeTable columns={defaultColumns} />);
+      const handle = getResizeHandles()[0];
+      // proportional() helper defaults minWidth to 120
+      expect(handle).toHaveAttribute('aria-valuemin', '120');
+    });
+  });
+
+  // ===========================================================================
+  // 6.8 Proportional-Preserving Resize
+  // ===========================================================================
+
+  describe('proportional-preserving resize', () => {
+    it('does not render resize handle on last proportional column', () => {
+      // Default columns have no explicit width → proportional
+      // The last column (role) should have no handle
+      render(<ResizeTable />);
+      const handles = getResizeHandles();
+      // Only the first column should get a handle (proportional with a neighbor)
+      // The last proportional column has no handle
+      expect(handles).toHaveLength(1);
+    });
+
+    it('renders resize handle on last column if it is pixel', () => {
+      const columnsWithPixelLast: XDSTableColumn<TestItem>[] = [
+        {key: 'name', header: 'Name'},
+        {key: 'role', header: 'Role', width: pixel(200)},
+      ];
+
+      render(<ResizeTable columns={columnsWithPixelLast} />);
+      const handles = getResizeHandles();
+      // Both columns get handles — last is pixel, not proportional
+      expect(handles).toHaveLength(2);
+    });
+
+    it('all pixel columns get handles including last', () => {
+      const allPixel: XDSTableColumn<TestItem>[] = [
+        {key: 'name', header: 'Name', width: pixel(200)},
+        {key: 'role', header: 'Role', width: pixel(200)},
+      ];
+
+      render(<ResizeTable columns={allPixel} />);
+      const handles = getResizeHandles();
+      expect(handles).toHaveLength(2);
+    });
+
+    it('without columns config, all columns get handles (backward compat)', () => {
+      // Don't pass columns to the plugin — falls back to old behavior
+      function LegacyResizeTable() {
+        const resizePlugin = useXDSTableColumnResize<TestItem>({});
+        return (
+          <XDSTable
+            data={testData}
+            columns={testColumns}
+            idKey="id"
+            plugins={{resize: resizePlugin}}
+          />
+        );
+      }
+
+      render(<LegacyResizeTable />);
+      const handles = getResizeHandles();
+      expect(handles).toHaveLength(2);
     });
   });
 });

--- a/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useXDSTableColumnResize.tsx
@@ -18,7 +18,9 @@ import type {
   TablePlugin,
   HeaderCellRenderProps,
   XDSTableColumn,
+  ColumnWidth,
 } from '../../types';
+import {DEFAULT_MIN_COLUMN_WIDTH} from '../../columnUtils';
 
 // =============================================================================
 // Config Type
@@ -42,25 +44,75 @@ export interface UseXDSTableColumnResizeConfig {
   onColumnResizeEnd?: (event: {columnKey: string; newWidth: number}) => void;
 
   /**
-   * Minimum column width in pixels during resize.
-   * @default 50
+   * Global minimum column width in pixels during resize.
+   * Overrides per-column defaults when set.
+   * @default undefined (uses column-specific minimum)
    */
   minWidth?: number;
 
   /**
-   * Maximum column width in pixels during resize.
+   * Global maximum column width in pixels during resize.
    * @default Infinity (no max)
    */
   maxWidth?: number;
+
+  /**
+   * Column definitions — needed to derive per-column min widths
+   * and detect proportional vs pixel columns for last-column behavior.
+   *
+   * When proportional columns are detected, the resize handle
+   * automatically adjusts the neighboring column instead of the
+   * proportional column itself. The last proportional column has
+   * no resize handle (it flexes to fill remaining space).
+   *
+   * When not provided, all columns are treated as pixel columns
+   * and the global minWidth fallback (50px) is used.
+   */
+  columns?: XDSTableColumn<Record<string, unknown>>[];
 }
 
 // =============================================================================
 // Constants
 // =============================================================================
 
-const DEFAULT_MIN_WIDTH = 50;
+const FALLBACK_MIN_WIDTH = 50;
 const KEYBOARD_STEP = 10;
 const KEYBOARD_LARGE_STEP = 50;
+
+// =============================================================================
+// Width Helpers
+// =============================================================================
+
+/**
+ * Derive the effective minimum width for a column based on its width config.
+ * - Proportional columns: use their declared minWidth (default 120px)
+ * - Pixel columns: use their declared value (you set 200px, min is 200px)
+ * - No width / unknown: use DEFAULT_MIN_COLUMN_WIDTH
+ *
+ * A global override (from config.minWidth) takes precedence when set.
+ */
+function resolveColumnMinWidth(
+  colWidth: ColumnWidth | undefined,
+  globalOverride: number | undefined,
+): number {
+  if (globalOverride != null) return globalOverride;
+  if (!colWidth) return DEFAULT_MIN_COLUMN_WIDTH;
+  if (colWidth.type === 'proportional') {
+    return colWidth.minWidth ?? DEFAULT_MIN_COLUMN_WIDTH;
+  }
+  if (colWidth.type === 'pixel') {
+    return colWidth.value;
+  }
+  return FALLBACK_MIN_WIDTH;
+}
+
+/**
+ * Check whether a column is proportional (or has no explicit width,
+ * which defaults to proportional(1) in XDSBaseTable).
+ */
+function isProportionalColumn(colWidth: ColumnWidth | undefined): boolean {
+  return !colWidth || colWidth.type === 'proportional';
+}
 
 // =============================================================================
 // Styles
@@ -115,6 +167,10 @@ interface DragState {
   startX: number;
   initialWidth: number;
   thElement: HTMLTableCellElement;
+  /** When resizing a proportional column, we resize the next column instead */
+  neighborKey: string | null;
+  neighborTh: HTMLTableCellElement | null;
+  neighborInitialWidth: number;
 }
 
 // =============================================================================
@@ -127,6 +183,9 @@ interface ResizeHandleProps {
   currentWidth: number | undefined;
   minWidth: number;
   maxWidth: number;
+  /** For proportional-preserving: the neighbor column to resize instead */
+  neighborKey: string | null;
+  neighborMinWidth: number;
   configRef: React.RefObject<UseXDSTableColumnResizeConfig>;
   dragStateRef: React.RefObject<DragState | null>;
   isDraggingRef: React.RefObject<boolean>;
@@ -139,14 +198,13 @@ function ResizeHandle({
   currentWidth,
   minWidth,
   maxWidth,
+  neighborKey,
+  neighborMinWidth,
   configRef,
   dragStateRef,
   isDraggingRef,
   tableRef,
 }: ResizeHandleProps) {
-  const keyboardActiveRef = useRef(false);
-  const keyboardInitialWidthRef = useRef(0);
-
   const resolveCurrentWidth = useCallback(
     (handle: HTMLElement): number => {
       if (currentWidth != null) return currentWidth;
@@ -157,14 +215,20 @@ function ResizeHandle({
     [currentWidth, minWidth],
   );
 
+  /**
+   * Resolve the effective maximum width. When no explicit maxWidth is set,
+   * use the table's current width as a natural ceiling — no single column
+   * should exceed the table's bounds.
+   */
   const clamp = useCallback(
-    (value: number) => Math.max(minWidth, Math.min(maxWidth, value)),
+    (value: number, min: number = minWidth, max: number = maxWidth) =>
+      Math.max(min, Math.min(max, value)),
     [minWidth, maxWidth],
   );
 
   const applyWidth = useCallback(
-    (th: HTMLTableCellElement, width: number) => {
-      const clamped = clamp(width);
+    (th: HTMLTableCellElement, width: number, min?: number, max?: number) => {
+      const clamped = clamp(width, min, max);
       const px = `${clamped}px`;
       th.style.width = px;
       th.style.minWidth = px;
@@ -205,6 +269,19 @@ function ResizeHandle({
     return dir === 'rtl' ? -1 : 1;
   }, []);
 
+  /**
+   * Resolve the neighbor <th> element from the handle's <th>.
+   * The neighbor is the next sibling <th> in DOM order.
+   */
+  const resolveNeighborTh = useCallback(
+    (th: HTMLTableCellElement): HTMLTableCellElement | null => {
+      if (!neighborKey) return null;
+      const next = th.nextElementSibling;
+      return next instanceof HTMLTableCellElement ? next : null;
+    },
+    [neighborKey],
+  );
+
   const handlePointerDown = useCallback(
     (e: React.PointerEvent<HTMLDivElement>) => {
       e.preventDefault();
@@ -220,14 +297,38 @@ function ResizeHandle({
       const initialWidth = resolveCurrentWidth(handle);
       if (handle.setPointerCapture) handle.setPointerCapture(e.pointerId);
 
-      dragStateRef.current = {columnKey, startX: e.clientX, initialWidth, thElement: th};
+      // Resolve neighbor for proportional-preserving resize
+      const nTh = resolveNeighborTh(th);
+      const nInitialWidth = nTh ? nTh.getBoundingClientRect().width : 0;
+
+      dragStateRef.current = {
+        columnKey,
+        startX: e.clientX,
+        initialWidth,
+        thElement: th,
+        neighborKey,
+        neighborTh: nTh,
+        neighborInitialWidth: nInitialWidth,
+      };
       isDraggingRef.current = true;
       handle.setAttribute('data-resizing', 'true');
 
       applyWidth(th, initialWidth);
+      if (nTh) applyWidth(nTh, nInitialWidth, neighborMinWidth);
       setTableDragging(true);
     },
-    [columnKey, resolveCurrentWidth, dragStateRef, isDraggingRef, tableRef, applyWidth, setTableDragging],
+    [
+      columnKey,
+      neighborKey,
+      neighborMinWidth,
+      resolveCurrentWidth,
+      resolveNeighborTh,
+      dragStateRef,
+      isDraggingRef,
+      tableRef,
+      applyWidth,
+      setTableDragging,
+    ],
   );
 
   const handlePointerMove = useCallback(
@@ -235,10 +336,43 @@ function ResizeHandle({
       const drag = dragStateRef.current;
       if (!drag || !isDraggingRef.current) return;
 
-      const delta = (e.clientX - drag.startX) * getRTLMultiplier(drag.thElement);
-      applyWidth(drag.thElement, drag.initialWidth + delta);
+      const delta =
+        (e.clientX - drag.startX) * getRTLMultiplier(drag.thElement);
+
+      if (drag.neighborTh && drag.neighborKey) {
+        // Proportional-preserving: resize the neighbor column inversely.
+        // Clamp from below (neighbor can't go below neighborMinWidth), which
+        // also implicitly caps the second-to-last column from eating into
+        // the last column's minimum reserved space.
+        const newNeighborWidth = drag.neighborInitialWidth - delta;
+        const clampedNeighbor = Math.max(neighborMinWidth, newNeighborWidth);
+        applyWidth(drag.neighborTh, clampedNeighbor, neighborMinWidth);
+
+        // Also cap the second-to-last column: it can't grow beyond
+        // (tableWidth - neighborMinWidth), i.e. can't squeeze last column below min.
+        const tableWidth =
+          tableRef.current?.getBoundingClientRect().width ?? Infinity;
+        const maxSecondToLast =
+          tableWidth > 0 ? tableWidth - neighborMinWidth : Infinity;
+        applyWidth(
+          drag.thElement,
+          drag.initialWidth + delta,
+          minWidth,
+          maxSecondToLast,
+        );
+      } else {
+        applyWidth(drag.thElement, drag.initialWidth + delta);
+      }
     },
-    [dragStateRef, isDraggingRef, getRTLMultiplier, applyWidth],
+    [
+      dragStateRef,
+      isDraggingRef,
+      getRTLMultiplier,
+      neighborMinWidth,
+      minWidth,
+      tableRef,
+      applyWidth,
+    ],
   );
 
   const handlePointerUp = useCallback(
@@ -247,92 +381,150 @@ function ResizeHandle({
       if (!drag || !isDraggingRef.current) return;
 
       e.currentTarget.removeAttribute('data-resizing');
-      const delta = (e.clientX - drag.startX) * getRTLMultiplier(drag.thElement);
-      const newWidth = clamp(drag.initialWidth + delta);
+      const delta =
+        (e.clientX - drag.startX) * getRTLMultiplier(drag.thElement);
 
       isDraggingRef.current = false;
       dragStateRef.current = null;
       setTableDragging(false);
 
-      configRef.current.onColumnResizeEnd?.({columnKey, newWidth});
+      if (drag.neighborTh && drag.neighborKey) {
+        // Proportional-preserving: report the neighbor column's new width,
+        // clamped so it never goes below its minimum.
+        const newNeighborWidth = Math.max(
+          neighborMinWidth,
+          drag.neighborInitialWidth - delta,
+        );
+        configRef.current.onColumnResizeEnd?.({
+          columnKey: drag.neighborKey,
+          newWidth: newNeighborWidth,
+        });
+      } else {
+        const newWidth = clamp(drag.initialWidth + delta);
+        configRef.current.onColumnResizeEnd?.({columnKey, newWidth});
+      }
     },
-    [columnKey, dragStateRef, isDraggingRef, getRTLMultiplier, clamp, setTableDragging, configRef],
+    [
+      columnKey,
+      dragStateRef,
+      isDraggingRef,
+      getRTLMultiplier,
+      clamp,
+      neighborMinWidth,
+      setTableDragging,
+      configRef,
+    ],
   );
 
-  const handlePointerCancel = useCallback(
-    () => {
-      const drag = dragStateRef.current;
-      if (!drag || !isDraggingRef.current) return;
+  const handlePointerCancel = useCallback(() => {
+    const drag = dragStateRef.current;
+    if (!drag || !isDraggingRef.current) return;
 
-      // Revert to width before drag
-      clearWidth(drag.thElement, drag.columnKey);
+    // Revert to width before drag
+    clearWidth(drag.thElement, drag.columnKey);
+    if (drag.neighborTh && drag.neighborKey) {
+      clearWidth(drag.neighborTh, drag.neighborKey);
+    }
 
-      isDraggingRef.current = false;
-      dragStateRef.current = null;
-      setTableDragging(false);
-    },
-    [dragStateRef, isDraggingRef, clearWidth, setTableDragging],
-  );
+    isDraggingRef.current = false;
+    dragStateRef.current = null;
+    setTableDragging(false);
+  }, [dragStateRef, isDraggingRef, clearWidth, setTableDragging]);
 
+  /**
+   * Keyboard resize per WAI-ARIA Window Splitter pattern.
+   * Arrow keys resize immediately on focus — no activation step.
+   * Each keypress commits the new width directly.
+   * Home/End jump to min/max width.
+   */
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       const handle = e.currentTarget;
       const th = handle.closest('th') as HTMLTableCellElement | null;
       if (!th) return;
 
-      // Activate keyboard resize mode
-      if (!keyboardActiveRef.current) {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          keyboardActiveRef.current = true;
-          keyboardInitialWidthRef.current = resolveCurrentWidth(handle);
-          handle.setAttribute('data-resizing', 'true');
-
-          const table = th.closest('table');
-          if (table) tableRef.current = table;
-
-          applyWidth(th, keyboardInitialWidthRef.current);
-          return;
-        }
-        return;
-      }
+      const table = th.closest('table');
+      if (table) tableRef.current = table;
 
       const step = e.shiftKey ? KEYBOARD_LARGE_STEP : KEYBOARD_STEP;
       const rtl = getRTLMultiplier(th);
 
       switch (e.key) {
-        case 'ArrowRight': {
-          e.preventDefault();
-          const cur = parseFloat(th.style.width) || keyboardInitialWidthRef.current;
-          applyWidth(th, cur + step * rtl);
-          break;
-        }
+        case 'ArrowRight':
         case 'ArrowLeft': {
           e.preventDefault();
-          const cur = parseFloat(th.style.width) || keyboardInitialWidthRef.current;
-          applyWidth(th, cur - step * rtl);
+          const direction = e.key === 'ArrowRight' ? 1 : -1;
+          const delta = step * direction * rtl;
+
+          if (neighborKey) {
+            // Proportional-preserving: adjust neighbor inversely, clamped so
+            // it never drops below its min (which also prevents this column
+            // from growing into the last column's reserved minimum space).
+            const nTh = resolveNeighborTh(th);
+            if (nTh) {
+              const curNeighbor = nTh.getBoundingClientRect().width;
+              const newWidth = Math.max(neighborMinWidth, curNeighbor - delta);
+              applyWidth(nTh, newWidth, neighborMinWidth);
+              configRef.current.onColumnResizeEnd?.({
+                columnKey: neighborKey,
+                newWidth,
+              });
+            }
+          } else {
+            const curWidth = currentWidth ?? th.getBoundingClientRect().width;
+            const newWidth = clamp(curWidth + delta);
+            applyWidth(th, newWidth);
+            configRef.current.onColumnResizeEnd?.({columnKey, newWidth});
+          }
           break;
         }
-        case 'Escape':
+        case 'Home': {
           e.preventDefault();
-          clearWidth(th, columnKey);
-          keyboardActiveRef.current = false;
-          handle.removeAttribute('data-resizing');
+          if (neighborKey) {
+            const nTh = resolveNeighborTh(th);
+            if (nTh) {
+              applyWidth(nTh, neighborMinWidth, neighborMinWidth);
+              configRef.current.onColumnResizeEnd?.({
+                columnKey: neighborKey,
+                newWidth: neighborMinWidth,
+              });
+            }
+          } else {
+            applyWidth(th, minWidth);
+            configRef.current.onColumnResizeEnd?.({
+              columnKey,
+              newWidth: minWidth,
+            });
+          }
           break;
-        case 'Enter': {
+        }
+        case 'End': {
           e.preventDefault();
-          const finalWidth = parseFloat(th.style.width) || keyboardInitialWidthRef.current;
-          keyboardActiveRef.current = false;
-          handle.removeAttribute('data-resizing');
-          configRef.current.onColumnResizeEnd?.({
-            columnKey,
-            newWidth: clamp(finalWidth),
-          });
+          if (maxWidth !== Infinity) {
+            applyWidth(th, maxWidth);
+            configRef.current.onColumnResizeEnd?.({
+              columnKey,
+              newWidth: maxWidth,
+            });
+          }
           break;
         }
       }
     },
-    [columnKey, resolveCurrentWidth, getRTLMultiplier, clamp, applyWidth, clearWidth, configRef, tableRef],
+    [
+      columnKey,
+      currentWidth,
+      neighborKey,
+      neighborMinWidth,
+      resolveNeighborTh,
+      getRTLMultiplier,
+      clamp,
+      minWidth,
+      maxWidth,
+      applyWidth,
+      configRef,
+      tableRef,
+    ],
   );
 
   const ariaLabel =
@@ -363,9 +555,9 @@ function ResizeHandle({
 // Hook
 // =============================================================================
 
-export function useXDSTableColumnResize<
-  T extends Record<string, unknown>,
->(config: UseXDSTableColumnResizeConfig): TablePlugin<T> {
+export function useXDSTableColumnResize<T extends Record<string, unknown>>(
+  config: UseXDSTableColumnResizeConfig,
+): TablePlugin<T> {
   const configRef = useRef(config);
   configRef.current = config;
 
@@ -373,9 +565,10 @@ export function useXDSTableColumnResize<
   const isDraggingRef = useRef(false);
   const tableRef = useRef<HTMLTableElement | null>(null);
 
-  const minWidth = config.minWidth ?? DEFAULT_MIN_WIDTH;
+  const globalMinWidth = config.minWidth;
   const maxWidth = config.maxWidth ?? Infinity;
   const columnWidths = config.columnWidths;
+  const columns = config.columns;
 
   return useMemo(
     (): TablePlugin<T> => ({
@@ -384,6 +577,42 @@ export function useXDSTableColumnResize<
         column: XDSTableColumn<T>,
       ): HeaderCellRenderProps {
         const overrideWidth = columnWidths?.[column.key];
+
+        // Derive per-column min width from the column's own width config
+        const effectiveMinWidth = resolveColumnMinWidth(
+          column.width,
+          globalMinWidth,
+        );
+
+        // Determine if this is a proportional column that should
+        // delegate resize to its neighbor (the next column).
+        // This prevents weird behavior when the table is 100% width
+        // and the last column is proportional — it just flexes.
+        let neighborKey: string | null = null;
+        let neighborMinWidth = FALLBACK_MIN_WIDTH;
+
+        if (columns && isProportionalColumn(column.width)) {
+          const colIndex = columns.findIndex(c => c.key === column.key);
+          if (colIndex >= 0 && colIndex < columns.length - 1) {
+            const nextCol = columns[colIndex + 1];
+            neighborKey = nextCol.key;
+            neighborMinWidth = resolveColumnMinWidth(
+              nextCol.width,
+              globalMinWidth,
+            );
+          }
+        }
+
+        // If this is the last column and it's proportional, skip the handle.
+        // There's no neighbor to resize and resizing a flex column in a
+        // full-width table produces unpredictable results.
+        if (columns) {
+          const colIndex = columns.findIndex(c => c.key === column.key);
+          const isLastColumn = colIndex === columns.length - 1;
+          if (isLastColumn && isProportionalColumn(column.width)) {
+            return props;
+          }
+        }
 
         const widthStyle: React.CSSProperties | undefined =
           overrideWidth != null
@@ -409,8 +638,10 @@ export function useXDSTableColumnResize<
             columnKey={column.key}
             columnHeader={column.header ?? column.key}
             currentWidth={overrideWidth}
-            minWidth={minWidth}
+            minWidth={effectiveMinWidth}
             maxWidth={maxWidth}
+            neighborKey={neighborKey}
+            neighborMinWidth={neighborMinWidth}
             configRef={configRef}
             dragStateRef={dragStateRef}
             isDraggingRef={isDraggingRef}
@@ -433,8 +664,7 @@ export function useXDSTableColumnResize<
           styles: [...props.styles, headerCellRelative.base],
         };
       },
-
     }),
-    [columnWidths, minWidth, maxWidth],
+    [columnWidths, globalMinWidth, maxWidth, columns],
   );
 }


### PR DESCRIPTION
Follow-up improvements to #1012 based on review.

## Changes

**Per-column min width**
Derives min width from the column's own config: proportional columns use their `minWidth` (default 120px), pixel columns use their declared `value` as the floor. Global `minWidth`/`maxWidth` on the config still override when set.

**Proportional-preserving resize (default)**
When resizing a proportional column, the handle adjusts the *next* column instead — same as WWW's `preserveProportional` mode, but on by default. The last proportional column gets no resize handle; it flexes to fill remaining space. Fixes the weird behavior when a 100%-width table has a flex last column.

**Neighbor-min guard**
The second-to-last column is capped from growing into the last column's reserved minimum space (`tableWidth - neighborMinWidth`).

**Keyboard a11y**
Follows the WAI-ARIA [Window Splitter pattern](https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/) correctly: arrow keys resize immediately on focus — no Enter activation step. Home/End jump to min/max.

## API change

`columns` is now accepted on the config to enable per-column width inference and last-column detection. Backward compatible — without `columns`, all columns get handles and use the global min fallback.

```tsx
const resizePlugin = useXDSTableColumnResize<Item>({
  columnWidths,
  columns, // pass columns for smart defaults
  onColumnResizeEnd: ({columnKey, newWidth}) => { ... },
});
```