### PR TITLE
fix(Table): center pagination, add margin, hide on single page

### DIFF
--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination.test.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination.test.tsx
@@ -50,6 +50,8 @@ function PaginatedTable({
   size,
   label,
   pageSizeOptions,
+  totalPagesProp,
+  hasMore,
 }: {
   data: TestItem[];
   pageSize?: number;
@@ -58,6 +60,8 @@ function PaginatedTable({
   size?: 'sm' | 'md';
   label?: string;
   pageSizeOptions?: number[];
+  totalPagesProp?: number;
+  hasMore?: boolean;
 }) {
   const [page, setPage] = useState(1);
   const [currentPageSize, setCurrentPageSize] = useState(pageSize);
@@ -65,7 +69,11 @@ function PaginatedTable({
   const pagination = useXDSTablePagination<TestItem>({
     page,
     onPageChange: setPage,
-    totalItems: data.length,
+    // Allow overriding with totalPages/hasMore for specific test scenarios
+    totalItems:
+      totalPagesProp == null && hasMore == null ? data.length : undefined,
+    totalPages: totalPagesProp,
+    hasMore,
     pageSize: currentPageSize,
     position,
     variant,
@@ -390,6 +398,36 @@ describe('useXDSTablePagination', () => {
       ).not.toBeInTheDocument();
     });
 
+    it('does not render pagination when there is only one page', () => {
+      // 5 items with pageSize 10 → 1 page total
+      render(<PaginatedTable data={generateItems(5)} pageSize={10} />);
+      expect(
+        screen.queryByRole('navigation', {name: 'Table pagination'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not render pagination when totalPages is explicitly 1', () => {
+      render(
+        <PaginatedTable
+          data={generateItems(5)}
+          pageSize={10}
+          totalPagesProp={1}
+        />,
+      );
+      expect(
+        screen.queryByRole('navigation', {name: 'Table pagination'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders pagination when hasMore is true even with one page of data', () => {
+      render(
+        <PaginatedTable data={generateItems(5)} pageSize={10} hasMore={true} />,
+      );
+      expect(
+        screen.getByRole('navigation', {name: 'Table pagination'}),
+      ).toBeInTheDocument();
+    });
+
     it('paginationProps include pageSizeOptions when provided', () => {
       render(
         <PaginatedTable
@@ -476,8 +514,7 @@ describe('useXDSTablePagination', () => {
           getIsAllSelected: () => {
             const pageData = pagination.paginatedData(data);
             return (
-              pageData.length > 0 &&
-              pageData.every(d => selectedIds.has(d.id))
+              pageData.length > 0 && pageData.every(d => selectedIds.has(d.id))
             );
           },
         });
@@ -573,11 +610,7 @@ describe('useXDSTablePagination', () => {
 
     it('passes size prop', () => {
       render(
-        <PaginatedTable
-          data={generateItems(30)}
-          pageSize={10}
-          size="sm"
-        />,
+        <PaginatedTable data={generateItems(30)} pageSize={10} size="sm" />,
       );
       const nav = screen.getByRole('navigation', {name: 'Table pagination'});
       expect(nav).toBeInTheDocument();
@@ -654,16 +687,12 @@ describe('useXDSTablePagination', () => {
       expect(result.current.totalPages).toBe(0);
     });
 
-    it('handles totalPages=1', () => {
+    it('handles totalPages=1 — pagination is hidden', () => {
+      // When there is only one page, the plugin should not render pagination at all.
       render(<PaginatedTable data={generateItems(5)} pageSize={10} />);
-      const prevButton = screen.getByRole('button', {
-        name: 'Go to previous page',
-      });
-      const nextButton = screen.getByRole('button', {
-        name: 'Go to next page',
-      });
-      expect(prevButton).toBeDisabled();
-      expect(nextButton).toBeDisabled();
+      expect(
+        screen.queryByRole('navigation', {name: 'Table pagination'}),
+      ).not.toBeInTheDocument();
     });
 
     it('handles page=1 with no totalItems or totalPages (cursor mode)', () => {
@@ -738,7 +767,8 @@ describe('useXDSTablePagination', () => {
     });
 
     it('disabled prev/next buttons have aria-disabled', () => {
-      render(<PaginatedTable data={generateItems(5)} pageSize={10} />);
+      // Use multi-page data so pagination is rendered; on page 1, prev is disabled.
+      render(<PaginatedTable data={generateItems(30)} pageSize={10} />);
       const prevButton = screen.getByRole('button', {
         name: 'Go to previous page',
       });

--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination.tsx
@@ -12,9 +12,24 @@
  */
 
 import {useCallback, useMemo, useRef, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {spacingVars} from '../../../theme/tokens.stylex';
 import {XDSPagination} from '../../../Pagination';
 import type {XDSPaginationProps} from '../../../Pagination';
 import type {TablePlugin} from '../../types';
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  wrapper: {
+    display: 'flex',
+    justifyContent: 'center',
+    marginTop: spacingVars['--spacing-4'],
+    marginBottom: spacingVars['--spacing-4'],
+  },
+});
 
 // =============================================================================
 // Config Type
@@ -136,9 +151,9 @@ export interface UseXDSTablePaginationConfig {
   /**
    * Available page size options. Shows a page size selector when provided.
    * @example
- * ```
- * [10, 25, 50, 100]
- * ```
+   * ```
+   * [10, 25, 50, 100]
+   * ```
    */
   pageSizeOptions?: number[];
 
@@ -292,7 +307,21 @@ export function useXDSTablePagination<T extends Record<string, unknown>>(
         const {position: pos, paginationProps: props} = configRef.current;
         if (pos === 'none') return children;
 
-        const paginationElement = <XDSPagination {...props} />;
+        // Don't render pagination when there's only one page and no more data.
+        // This can happen when filters reduce the result set to a single page.
+        const resolvedTotalPages =
+          props.totalPages ??
+          (props.totalItems != null && props.pageSize != null
+            ? Math.ceil(props.totalItems / props.pageSize)
+            : undefined);
+        const isSinglePage = resolvedTotalPages === 1 && props.hasMore !== true;
+        if (isSinglePage) return children;
+
+        const paginationElement = (
+          <div {...stylex.props(styles.wrapper)}>
+            <XDSPagination {...props} />
+          </div>
+        );
 
         return (
           <>


### PR DESCRIPTION
Addresses feedback from @czarandy on #1011.

## Changes

**Spacing** — adds `marginTop` and `marginBottom` (16px) between the table and its pagination controls.

**Alignment** — wraps `XDSPagination` in a centered flex container. Centered looks better than left-aligned, especially at narrower table widths.

**Single-page hiding** — skips rendering pagination entirely when `totalPages === 1` and `hasMore` is not `true`. This prevents the awkward lone prev/next buttons that appear when filters reduce results to a single page.

## Tests

- Added 3 new tests covering: single-page hide, explicit `totalPages={1}` hide, and `hasMore=true` override (still shows pagination)
- Updated 2 existing tests whose setup (5 items / pageSize 10) now correctly triggers the hide behavior

All 46 tests pass. ✅

---
