### PR TITLE
XDSPowerSearch: fix contentSearchFieldKey behavior & operator matching

### DIFF
--- a/apps/storybook/stories/PowerSearch.stories.tsx
+++ b/apps/storybook/stories/PowerSearch.stories.tsx
@@ -896,6 +896,88 @@ export const WithNestedFilters: Story = {
   name: 'Nested Filters',
 };
 
+const contentSearchConfig: PowerSearchConfig = {
+  name: 'ContentSearch',
+  contentSearchFieldKey: 'title',
+  fields: [
+    {
+      key: 'title',
+      label: 'Title',
+      defaultOperator: 'contains',
+      operators: [
+        {key: 'contains', label: 'contains', value: {type: 'string'}},
+        {
+          key: 'not_contains',
+          label: 'does not contain',
+          value: {type: 'string'},
+        },
+      ],
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      defaultOperator: 'is',
+      operators: [
+        {
+          key: 'is',
+          label: 'is',
+          value: {type: 'enum', values: statusValues},
+        },
+        {
+          key: 'is_not',
+          label: 'is not',
+          value: {type: 'enum', values: statusValues},
+        },
+      ],
+    },
+    {
+      key: 'priority',
+      label: 'Priority',
+      defaultOperator: 'is',
+      operators: [
+        {
+          key: 'is',
+          label: 'is',
+          value: {type: 'enum', values: priorityValues},
+        },
+      ],
+    },
+  ],
+};
+
+export const WithContentSearchFieldKey: Story = {
+  render: args => {
+    const [filters, setFilters] = useState<PowerSearchFilter[]>([]);
+    return (
+      <div>
+        <XDSPowerSearch
+          {...args}
+          config={contentSearchConfig}
+          filters={filters}
+          onChange={newFilters => setFilters([...newFilters])}
+        />
+        {filters.length > 0 && (
+          <pre
+            style={{
+              marginTop: 16,
+              padding: 12,
+              backgroundColor: '#f5f5f5',
+              borderRadius: 8,
+              fontSize: 12,
+              overflow: 'auto',
+            }}>
+            {JSON.stringify(filters, null, 2)}
+          </pre>
+        )}
+      </div>
+    );
+  },
+  args: {
+    placeholder: 'Type to search by title, or pick a field...',
+  },
+  name: 'Content Search Field Key',
+};
+
 export const WithStartIcon: Story = {
   render: args => {
     const [filters, setFilters] = useState<PowerSearchFilter[]>([]);

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -176,6 +176,48 @@ const [filters, setFilters] = useState([]);
   placeholder="Add filters..."
 />`,
     },
+    {
+      label: 'With contentSearchFieldKey for free-text search',
+      code: `const config = {
+  name: 'IssueSearch',
+  contentSearchFieldKey: 'title',
+  fields: [
+    {
+      key: 'title',
+      label: 'Title',
+      operators: [
+        { key: 'contains', label: 'contains', value: { type: 'string' } },
+        { key: 'is', label: 'is', value: { type: 'string' } },
+      ],
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      operators: [
+        {
+          key: 'is',
+          label: 'is',
+          value: {
+            type: 'enum',
+            values: [
+              { value: 'open', label: 'Open' },
+              { value: 'closed', label: 'Closed' },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const [filters, setFilters] = useState([]);
+<XDSPowerSearch
+  config={config}
+  filters={filters}
+  onChange={(newFilters) => setFilters(newFilters)}
+  placeholder="Search issues..."
+/>`,
+    },
   ],
   features: [
     'Typeahead field selection with search and aliases',
@@ -370,6 +412,48 @@ const [filters, setFilters] = useState([]);
     console.log(changeType, 'at index', index);
   }}
   placeholder="Add filters..."
+/>`,
+    },
+    {
+      label: '使用 contentSearchFieldKey 进行自由文本搜索',
+      code: `const config = {
+  name: 'IssueSearch',
+  contentSearchFieldKey: 'title',
+  fields: [
+    {
+      key: 'title',
+      label: 'Title',
+      operators: [
+        { key: 'contains', label: 'contains', value: { type: 'string' } },
+        { key: 'is', label: 'is', value: { type: 'string' } },
+      ],
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      operators: [
+        {
+          key: 'is',
+          label: 'is',
+          value: {
+            type: 'enum',
+            values: [
+              { value: 'open', label: 'Open' },
+              { value: 'closed', label: 'Closed' },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const [filters, setFilters] = useState([]);
+<XDSPowerSearch
+  config={config}
+  filters={filters}
+  onChange={(newFilters) => setFilters(newFilters)}
+  placeholder="Search issues..."
 />`,
     },
   ],

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -442,6 +442,32 @@ type PopoverState =
  *   onChange={(newFilters) => setFilters(newFilters)}
  * />
  * ```
+ *
+ * @example
+ * ```
+ * // Use contentSearchFieldKey to designate a field for free-text search.
+ * // When set, unstructured text input is routed to this field.
+ * const config = {
+ *   name: 'IssueSearch',
+ *   contentSearchFieldKey: 'title',
+ *   fields: [
+ *     {
+ *       key: 'title',
+ *       label: 'Title',
+ *       operators: [
+ *         { key: 'contains', label: 'contains', value: { type: 'string' } },
+ *       ],
+ *     },
+ *     {
+ *       key: 'status',
+ *       label: 'Status',
+ *       operators: [
+ *         { key: 'is', label: 'is', value: { type: 'enum', values: [...] } },
+ *       ],
+ *     },
+ *   ],
+ * };
+ * ```
  */
 export function XDSPowerSearch({
   config: configProp,
@@ -568,6 +594,17 @@ export function XDSPowerSearch({
         const operator = auxData.operatorKey
           ? config.getOperator(auxData.fieldKey, auxData.operatorKey)
           : config.getDefaultOperator(auxData.fieldKey);
+
+        // If the item already has a filter value (e.g. content search), add immediately
+        if (auxData.filterValue && operator) {
+          const newFilter: PowerSearchFilter = {
+            field: auxData.fieldKey,
+            operator: operator.key,
+            value: auxData.filterValue,
+          };
+          onChange([...filters, newFilter], 'add', filters.length);
+          return;
+        }
 
         // For "empty" type operators, add the filter immediately
         if (operator?.value.type === 'empty') {

--- a/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
@@ -1,0 +1,150 @@
+/**
+ * @file usePowerSearchSource.test.ts
+ * @input usePowerSearchSource, useInternalConfig
+ * @output Tests for field typeahead search source, including contentSearchFieldKey
+ * @position Testing; validates usePowerSearchSource.ts
+ */
+
+import {describe, it, expect} from 'vitest';
+import {renderHook} from '@testing-library/react';
+import {usePowerSearchSource} from './usePowerSearchSource';
+import {useInternalConfig} from './useInternalConfig';
+import type {PowerSearchConfig, PowerSearchAuxData} from './types';
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function createSource(config: PowerSearchConfig) {
+  const {result} = renderHook(() => {
+    const internal = useInternalConfig(config);
+    return usePowerSearchSource(internal);
+  });
+  return result.current;
+}
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const baseConfig: PowerSearchConfig = {
+  name: 'TestSearch',
+  fields: [
+    {
+      key: 'title',
+      label: 'Title',
+      defaultOperator: 'contains',
+      operators: [
+        {key: 'contains', label: 'contains', value: {type: 'string'}},
+        {key: 'is', label: 'is', value: {type: 'string'}},
+      ],
+    },
+    {
+      key: 'status',
+      label: 'Status',
+      defaultOperator: 'is',
+      operators: [
+        {
+          key: 'is',
+          label: 'is',
+          value: {
+            type: 'enum',
+            values: [
+              {value: 'open', label: 'Open'},
+              {value: 'closed', label: 'Closed'},
+            ],
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const configWithContentSearch: PowerSearchConfig = {
+  ...baseConfig,
+  contentSearchFieldKey: 'title',
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('usePowerSearchSource', () => {
+  describe('contentSearchFieldKey', () => {
+    it('shows content search item for non-matching query', () => {
+      const source = createSource(configWithContentSearch);
+      const results = source.search('foobar');
+
+      expect(results[0].label).toBe('"foobar"');
+      const aux = results[0].auxiliaryData as PowerSearchAuxData;
+      expect(aux.fieldKey).toBe('title');
+      expect(aux.operatorKey).toBe('contains');
+      expect(aux.filterValue).toEqual({type: 'string', value: 'foobar'});
+    });
+
+    it('does not show content search item when query exactly matches a field name', () => {
+      const source = createSource(configWithContentSearch);
+      const results = source.search('title');
+
+      const contentItem = results.find(r => r.label.startsWith('"'));
+      expect(contentItem).toBeUndefined();
+    });
+
+    it('does not show content search item when query exactly matches field + operator', () => {
+      const source = createSource(configWithContentSearch);
+      const results = source.search('Title contains');
+
+      const contentItem = results.find(r => r.label.startsWith('"'));
+      expect(contentItem).toBeUndefined();
+    });
+
+    it('exact match check is case-insensitive', () => {
+      const source = createSource(configWithContentSearch);
+      const results = source.search('TITLE');
+
+      const contentItem = results.find(r => r.label.startsWith('"'));
+      expect(contentItem).toBeUndefined();
+    });
+
+    it('shows content search item for partial field match', () => {
+      const source = createSource(configWithContentSearch);
+      const results = source.search('tit');
+
+      expect(results[0].label).toBe('"tit"');
+      // Field results should still appear after
+      expect(results.some(r => r.label === 'Title contains')).toBe(true);
+    });
+
+    it('does not show content search item when contentSearchFieldKey is not set', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('foobar');
+
+      const contentItem = results.find(r => r.label.startsWith('"'));
+      expect(contentItem).toBeUndefined();
+    });
+
+    it('content search item is first in results', () => {
+      const source = createSource(configWithContentSearch);
+      const results = source.search('sta');
+
+      expect(results[0].label).toBe('"sta"');
+      expect(results.length).toBeGreaterThan(1);
+    });
+  });
+
+  describe('field + operator matching', () => {
+    it('matches query against combined field and operator label', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title contains');
+
+      expect(results.some(r => r.label === 'Title contains')).toBe(true);
+    });
+
+    it('matches partial field + operator query', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title con');
+
+      expect(results.some(r => r.label === 'Title contains')).toBe(true);
+    });
+  });
+});

--- a/packages/core/src/PowerSearch/usePowerSearchSource.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.ts
@@ -31,8 +31,9 @@ export function usePowerSearchSource(
 
         for (const field of config.getVisibleFields()) {
           // Check if query matches field name or aliases
+          const fieldLabel = field.label.toLowerCase();
           const fieldMatches =
-            field.label.toLowerCase().includes(lower) ||
+            fieldLabel.includes(lower) ||
             field.typeaheadAliases?.some(alias =>
               alias.toLowerCase().includes(lower),
             );
@@ -66,7 +67,8 @@ export function usePowerSearchSource(
 
           // Also check if query matches operator labels
           for (const op of field.operators) {
-            if (op.label.toLowerCase().includes(lower)) {
+            const combinedLabel = `${field.label} ${op.label}`.toLowerCase();
+            if (combinedLabel.includes(lower)) {
               const id = `${field.key}:${op.key}`;
               if (!seen.has(id)) {
                 seen.add(id);
@@ -80,6 +82,34 @@ export function usePowerSearchSource(
                 });
               }
             }
+          }
+        }
+
+        // If contentSearchFieldKey is set and no field or field+operator
+        // exactly matches the query, prepend a content search item
+        const contentFieldKey = config.config.contentSearchFieldKey;
+        const hasExactMatch = config
+          .getVisibleFields()
+          .some(
+            f =>
+              f.label.toLowerCase() === lower ||
+              f.operators.some(
+                op => `${f.label} ${op.label}`.toLowerCase() === lower,
+              ),
+          );
+        if (contentFieldKey && !hasExactMatch) {
+          const contentField = config.getField(contentFieldKey);
+          const contentOp = config.getDefaultOperator(contentFieldKey);
+          if (contentField && contentOp) {
+            results.unshift({
+              id: `__content_search__:${query}`,
+              label: `"${query}"`,
+              auxiliaryData: {
+                fieldKey: contentFieldKey,
+                operatorKey: contentOp.key,
+                filterValue: {type: 'string', value: query},
+              },
+            });
           }
         }
 


### PR DESCRIPTION
1. contentSearchFieldKey implementation was missing, setting this option didn't actually do anything in the results. I have added the proper implementation for this.
2. We didn't properly match field+operator searches such as "title c" didn't match "Title contains", that is also fixed now.

Adding tests to cover both of these