### PR TITLE
XDSPowerSearch: fix typeahead behavior to only return fields with empty string

### DIFF
--- a/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
@@ -70,6 +70,84 @@ const configWithContentSearch: PowerSearchConfig = {
 // =============================================================================
 
 describe('usePowerSearchSource', () => {
+  describe('bootstrap (no query)', () => {
+    it('returns only field names without operator labels', () => {
+      const source = createSource(baseConfig);
+      const items = source.bootstrap();
+
+      expect(items.map(i => i.label)).toEqual(['Title', 'Status']);
+    });
+
+    it('sets defaultOperator on bootstrap items', () => {
+      const source = createSource(baseConfig);
+      const items = source.bootstrap();
+
+      const titleAux = items[0].auxiliaryData as PowerSearchAuxData;
+      expect(titleAux.fieldKey).toBe('title');
+      expect(titleAux.operatorKey).toBe('contains');
+
+      const statusAux = items[1].auxiliaryData as PowerSearchAuxData;
+      expect(statusAux.fieldKey).toBe('status');
+      expect(statusAux.operatorKey).toBe('is');
+    });
+
+    it('empty search returns same as bootstrap', () => {
+      const source = createSource(baseConfig);
+      expect(source.search('')).toEqual(source.bootstrap());
+    });
+  });
+
+  describe('search (with query)', () => {
+    it('shows field name for partial match', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('tit');
+
+      expect(results.some(r => r.label === 'Title')).toBe(true);
+    });
+
+    it('shows all field+operator combos for partial match', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('tit');
+      const labels = results.map(r => r.label);
+
+      expect(labels).toContain('Title');
+      expect(labels).toContain('Title contains');
+      expect(labels).toContain('Title is');
+    });
+
+    it('matches query against combined field and operator label', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title contains');
+
+      expect(results.some(r => r.label === 'Title contains')).toBe(true);
+    });
+
+    it('matches partial field + operator query', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title con');
+
+      expect(results.some(r => r.label === 'Title contains')).toBe(true);
+    });
+
+    it('field name item uses defaultOperator', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('tit');
+
+      const titleItem = results.find(r => r.label === 'Title');
+      const aux = titleItem?.auxiliaryData as PowerSearchAuxData;
+      expect(aux.operatorKey).toBe('contains');
+    });
+
+    it('field+operator items use specific operator', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('tit');
+
+      const isItem = results.find(r => r.label === 'Title is');
+      const aux = isItem?.auxiliaryData as PowerSearchAuxData;
+      expect(aux.operatorKey).toBe('is');
+    });
+  });
+
   describe('contentSearchFieldKey', () => {
     it('shows content search item for non-matching query', () => {
       const source = createSource(configWithContentSearch);
@@ -111,7 +189,8 @@ describe('usePowerSearchSource', () => {
       const results = source.search('tit');
 
       expect(results[0].label).toBe('"tit"');
-      // Field results should still appear after
+      // Field and field+operator results should still appear after
+      expect(results.some(r => r.label === 'Title')).toBe(true);
       expect(results.some(r => r.label === 'Title contains')).toBe(true);
     });
 
@@ -129,22 +208,6 @@ describe('usePowerSearchSource', () => {
 
       expect(results[0].label).toBe('"sta"');
       expect(results.length).toBeGreaterThan(1);
-    });
-  });
-
-  describe('field + operator matching', () => {
-    it('matches query against combined field and operator label', () => {
-      const source = createSource(baseConfig);
-      const results = source.search('title contains');
-
-      expect(results.some(r => r.label === 'Title contains')).toBe(true);
-    });
-
-    it('matches partial field + operator query', () => {
-      const source = createSource(baseConfig);
-      const results = source.search('title con');
-
-      expect(results.some(r => r.label === 'Title contains')).toBe(true);
     });
   });
 });

--- a/packages/core/src/PowerSearch/usePowerSearchSource.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.ts
@@ -30,14 +30,6 @@ export function usePowerSearchSource(
         const seen = new Set<string>();
 
         for (const field of config.getVisibleFields()) {
-          // Check if query matches field name or aliases
-          const fieldLabel = field.label.toLowerCase();
-          const fieldMatches =
-            fieldLabel.includes(lower) ||
-            field.typeaheadAliases?.some(alias =>
-              alias.toLowerCase().includes(lower),
-            );
-
           // Respect typeaheadMinQueryLength
           if (
             field.typeaheadMinQueryLength != null &&
@@ -46,17 +38,22 @@ export function usePowerSearchSource(
             continue;
           }
 
+          // Check if query matches field name or aliases
+          const fieldMatches =
+            field.label.toLowerCase().includes(lower) ||
+            field.typeaheadAliases?.some(alias =>
+              alias.toLowerCase().includes(lower),
+            );
+
           if (fieldMatches) {
-            // Add the field with its default operator
+            // Add the field name entry (opens with defaultOperator)
             const defaultOp = config.getDefaultOperator(field.key);
-            const id = defaultOp ? `${field.key}:${defaultOp.key}` : field.key;
-            if (!seen.has(id)) {
-              seen.add(id);
+            const fieldId = field.key;
+            if (!seen.has(fieldId)) {
+              seen.add(fieldId);
               results.push({
-                id,
-                label: defaultOp
-                  ? `${field.label} ${defaultOp.label}`
-                  : field.label,
+                id: fieldId,
+                label: field.label,
                 auxiliaryData: {
                   fieldKey: field.key,
                   operatorKey: defaultOp?.key,
@@ -65,7 +62,7 @@ export function usePowerSearchSource(
             }
           }
 
-          // Also check if query matches operator labels
+          // Check each field+operator combo against the query
           for (const op of field.operators) {
             const combinedLabel = `${field.label} ${op.label}`.toLowerCase();
             if (combinedLabel.includes(lower)) {
@@ -128,26 +125,14 @@ function buildFieldItems(config: InternalConfig): PowerSearchItem[] {
 
   for (const field of config.getVisibleFields()) {
     const defaultOp = config.getDefaultOperator(field.key);
-    if (defaultOp) {
-      items.push({
-        id: `${field.key}:${defaultOp.key}`,
-        label: defaultOp.label
-          ? `${field.label} ${defaultOp.label}`
-          : field.label,
-        auxiliaryData: {
-          fieldKey: field.key,
-          operatorKey: defaultOp.key,
-        },
-      });
-    } else {
-      items.push({
-        id: field.key,
-        label: field.label,
-        auxiliaryData: {
-          fieldKey: field.key,
-        },
-      });
-    }
+    items.push({
+      id: field.key,
+      label: field.label,
+      auxiliaryData: {
+        fieldKey: field.key,
+        operatorKey: defaultOp?.key,
+      },
+    });
   }
 
   return items;


### PR DESCRIPTION
Query string is empty -> only return the list of fields
Typing in query -> shows matching fields or field+operator combos

Updated tests to cover these cases.

Note: I want to add the field+operator+value match as well although I kind of don't like how it works in the _other_ version because it pollutes the list with tons of items. So still thinking about this.