### PR TITLE
fix(Field): remove extra 4px height when isLabelHidden is true

### DIFF
--- a/packages/core/src/Field/XDSField.tsx
+++ b/packages/core/src/Field/XDSField.tsx
@@ -32,6 +32,8 @@ const styles = stylex.create({
   container: {
     display: 'flex',
     flexDirection: 'column',
+  },
+  containerGap: {
     gap: spacingVars['--spacing-1'],
   },
   labelHidden: {
@@ -221,7 +223,11 @@ export function XDSField({
       ref={ref}
       {...mergeProps(
         xdsClassName('field'),
-        stylex.props(styles.container, xstyle),
+        stylex.props(
+          styles.container,
+          !isLabelHidden && styles.containerGap,
+          xstyle,
+        ),
         className,
         style,
       )}


### PR DESCRIPTION
## Summary

- `XDSField` with `isLabelHidden={true}` was 4px taller than the input alone (e.g. 36px instead of 32px for `XDSTextInput`)
- The flex container's `gap: --spacing-1` (4px) was applied between the visually-hidden label group and the input, even though the label group has no visible height
- Fix: suppress the gap by applying `gap: 0` when `isLabelHidden` is true

## Test plan

- [x] All 30 existing `XDSField` tests pass
- [x] Verify in Storybook that `XDSTextInput` with `isLabelHidden={true}` renders at 32px height (matching the input's intrinsic height)
- [x] Verify fields with visible labels are unaffected