### PR TITLE
fix(Dialog): auto-focus first input element when dialog opens

### DIFF
--- a/apps/storybook/stories/Dialog.stories.tsx
+++ b/apps/storybook/stories/Dialog.stories.tsx
@@ -9,6 +9,7 @@ import {
 } from '@xds/core/Layout';
 import {XDSButton} from '@xds/core/Button';
 import {XDSText} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
 import * as stylex from '@stylexjs/stylex';
 
 const styles = stylex.create({
@@ -653,4 +654,46 @@ export const AllPurposes: Story = {
       <InfoModalExample />
     </div>
   ),
+};
+
+/**
+ * Dialog with auto-focused input
+ */
+function AutoFocusInputExample() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [value, setValue] = useState('');
+  return (
+    <>
+      <XDSButton
+        label="Open Dialog"
+        variant="secondary"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSDialog isOpen={isOpen} onOpenChange={open => setIsOpen(open)}>
+        <XDSLayout
+          header={
+            <XDSDialogHeader
+              title="Auto-focused Input"
+              onOpenChange={open => setIsOpen(open)}
+            />
+          }
+          content={
+            <XDSLayoutContent>
+              <XDSTextInput
+                label="Name"
+                placeholder="This input is focused on mount"
+                value={value}
+                onChange={setValue}
+                hasAutoFocus
+              />
+            </XDSLayoutContent>
+          }
+        />
+      </XDSDialog>
+    </>
+  );
+}
+
+export const AutoFocusInput: Story = {
+  render: () => <AutoFocusInputExample />,
 };

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -307,6 +307,15 @@ export function XDSDialog({
     if (isOpen) {
       if (!dialog.open) {
         dialog.showModal();
+        // React's autoFocus calls .focus() during commit, before showModal()
+        // makes the dialog visible, so the focus silently fails.
+        // Focus the first input element inside the dialog.
+        const firstInput = dialog.querySelector<HTMLElement>(
+          'input, textarea, select',
+        );
+        if (firstInput) {
+          firstInput.focus();
+        }
       }
     } else {
       if (dialog.open) {

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -309,12 +309,11 @@ export function XDSDialog({
         dialog.showModal();
         // React's autoFocus calls .focus() during commit, before showModal()
         // makes the dialog visible, so the focus silently fails.
-        // Focus the first input element inside the dialog.
-        const firstInput = dialog.querySelector<HTMLElement>(
-          'input, textarea, select',
-        );
-        if (firstInput) {
-          firstInput.focus();
+        // Focus the first element with data-autofocus inside the dialog.
+        const autofocusTarget =
+          dialog.querySelector<HTMLElement>('[data-autofocus]');
+        if (autofocusTarget) {
+          autofocusTarget.focus();
         }
       }
     } else {

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -299,6 +299,7 @@ export function XDSTextInput({
           placeholder={placeholder}
           disabled={isDisabled}
           autoFocus={hasAutoFocus}
+          data-autofocus={hasAutoFocus || undefined}
           aria-describedby={ariaDescribedBy}
           aria-required={isRequired === true ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}


### PR DESCRIPTION
## Summary

- **Fix:** When a dialog opens via `showModal()`, React's `autoFocus` has already fired (and silently failed) because the dialog was still `display: none` at commit time. This means it's not easy to have a dialog that focuses the first input. I thought it would be nice to just do this automatically since it's probably desirable all the time. So now after `showModal()`, the dialog now explicitly focuses the first `input`, `textarea`, or `select` element inside it.
- **Story:** Adds an `AutoFocusInput` storybook example to Dialog stories demonstrating a dialog with an auto-focused text input.

I think it's reasonable to make this the default behavior but we could make it an option.

## Test plan

- [x] Open the `AutoFocusInput` story in Storybook and verify the text input is focused when the dialog opens
- [x] Verify existing dialog stories still work correctly (no unexpected focus changes in dialogs without inputs)
- [x] Run `yarn vitest packages/core/src/Dialog`