### PR TITLE
fix(Table): enforce minWidth on proportional columns

### DIFF
--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -215,6 +215,45 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
   const resolvedColumns: XDSTableColumn<T>[] =
     columnsProp ?? (data ? generateColumns(data) : []);
 
+  // Compute table min-width from column constraints.
+  // With table-layout: fixed, minWidth on cells is ignored — the table itself
+  // must be wide enough that no proportional column shrinks below its minWidth.
+  // Since proportional ratios are always maintained, we find the column that
+  // constrains the table the most: tableWidth >= minWidth * totalProportion / proportion.
+  // Table min-width = max of those values + sum of pixel column widths.
+  const tableMinWidth = (() => {
+    let totalProportion = 0;
+    let pixelTotal = 0;
+    const proportionalCols: Array<{proportion: number; minWidth: number}> = [];
+
+    for (const col of resolvedColumns) {
+      const w = col.width;
+      if (w?.type === 'pixel') {
+        pixelTotal += w.value;
+      } else {
+        const proportion = w?.value ?? 1;
+        // Only count minWidth for columns that explicitly used proportional().
+        // Columns with no width set (w === undefined) have no minimum.
+        const minW = w != null ? (w.minWidth ?? DEFAULT_MIN_COLUMN_WIDTH) : 0;
+        totalProportion += proportion;
+        proportionalCols.push({proportion, minWidth: minW});
+      }
+    }
+
+    if (totalProportion === 0) return pixelTotal;
+
+    // Find the proportional column that requires the most total space
+    let maxProportionalSpace = 0;
+    for (const col of proportionalCols) {
+      const required = (col.minWidth * totalProportion) / col.proportion;
+      if (required > maxProportionalSpace) {
+        maxProportionalSpace = required;
+      }
+    }
+
+    return pixelTotal + maxProportionalSpace;
+  })();
+
   // --- Plugin pipeline: table ---
   const tableRenderProps = applyPlugins(plugins, p => p.transformTable, {
     htmlProps: {...userTableProps},
@@ -258,8 +297,12 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
       if (totalProportion > 0) {
         widthStyle.width = `${(proportion / totalProportion) * 100}%`;
       }
-      const minW = colWidth?.minWidth ?? DEFAULT_MIN_COLUMN_WIDTH;
-      widthStyle.minWidth = `${minW}px`;
+      // Only apply minWidth if the column explicitly used proportional().
+      // Columns with no width set (colWidth === undefined) have no minimum.
+      if (colWidth != null) {
+        const minW = colWidth.minWidth ?? DEFAULT_MIN_COLUMN_WIDTH;
+        widthStyle.minWidth = `${minW}px`;
+      }
     }
 
     const existingStyle = cellRenderProps.htmlProps.style as
@@ -315,6 +358,11 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
   const hasData = data != null && data.length > 0;
   const hasColumns = resolvedColumns.length > 0;
 
+  const tableStyle: React.CSSProperties = {
+    ...(tableRenderProps.htmlProps.style as React.CSSProperties | undefined),
+    minWidth: tableMinWidth > 0 ? `${tableMinWidth}px` : undefined,
+  };
+
   let tableElement: ReactNode = (
     <table
       ref={ref}
@@ -322,7 +370,8 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
       {...mergeProps(
         xdsClassName('base-table'),
         stylex.props(...tableRenderProps.styles),
-      )}>
+      )}
+      style={tableStyle}>
       {/* thead */}
       {hasColumns && (
         <thead>

--- a/packages/core/src/Table/XDSTable.test.tsx
+++ b/packages/core/src/Table/XDSTable.test.tsx
@@ -472,18 +472,57 @@ describe('XDSBaseTable', () => {
       }
     });
 
-    it('applies default minWidth on columns with no explicit width', () => {
+    it('does not apply minWidth on columns with no explicit width', () => {
       const cols: XDSTableColumn<User>[] = [
         {key: 'name', header: 'Name'},
         {key: 'age', header: 'Age'},
       ];
       render(<XDSBaseTable data={users} columns={cols} />);
       const headers = screen.getAllByRole('columnheader');
-      expect(headers[0]).toHaveStyle({
+      expect(headers[0]).not.toHaveStyle({
         minWidth: `${DEFAULT_MIN_COLUMN_WIDTH}px`,
       });
-      expect(headers[1]).toHaveStyle({
+      expect(headers[1]).not.toHaveStyle({
         minWidth: `${DEFAULT_MIN_COLUMN_WIDTH}px`,
+      });
+    });
+
+    it('sets table min-width to enforce proportional column minimums', () => {
+      const cols: XDSTableColumn<User>[] = [
+        {key: 'name', header: 'Name', width: proportional(1)},
+        {key: 'age', header: 'Age', width: proportional(1)},
+      ];
+      render(<XDSBaseTable data={users} columns={cols} />);
+      const table = screen.getByRole('table');
+      // 2 equal columns: 120 * 2 / 1 = 240px
+      expect(table).toHaveStyle({
+        minWidth: `${DEFAULT_MIN_COLUMN_WIDTH * 2}px`,
+      });
+    });
+
+    it('sets table min-width based on most constrained proportional column', () => {
+      const cols: XDSTableColumn<User>[] = [
+        {key: 'name', header: 'Name', width: proportional(1, {minWidth: 200})},
+        {key: 'age', header: 'Age', width: proportional(1)},
+      ];
+      render(<XDSBaseTable data={users} columns={cols} />);
+      const table = screen.getByRole('table');
+      // name requires: 200 * 2 / 1 = 400px (most constrained)
+      // age requires:  120 * 2 / 1 = 240px
+      expect(table).toHaveStyle({minWidth: '400px'});
+    });
+
+    it('sets table min-width accounting for pixel and proportional columns', () => {
+      const cols: XDSTableColumn<User>[] = [
+        {key: 'name', header: 'Name', width: pixel(80)},
+        {key: 'age', header: 'Age', width: proportional(1)},
+      ];
+      render(<XDSBaseTable data={users} columns={cols} />);
+      const table = screen.getByRole('table');
+      // pixel: 80px + proportional requires 120 * 1 / 1 = 120px
+      // Table min-width = 80 + 120 = 200px
+      expect(table).toHaveStyle({
+        minWidth: `${80 + DEFAULT_MIN_COLUMN_WIDTH}px`,
       });
     });
   });


### PR DESCRIPTION
## Summary

Fixes a bug where `minWidth` on proportional columns had no effect — columns could shrink below their configured minimum.

**Root cause:** The table uses `table-layout: fixed`, which ignores the CSS `minWidth` property on table cells. Column widths are always distributed proportionally from the table's total width, so setting `minWidth` on a `<th>` does nothing.

**Fix:** Compute a `min-width` on the `<table>` element itself, preventing the table from shrinking to a size where any proportional column would violate its `minWidth`. The calculation:

1. For each proportional column, compute the table width required so that `(proportion / totalProportion) × tableWidth ≥ minWidth`
2. Take the max (the most constrained column drives the floor)
3. Add the sum of all pixel column widths

**Additionally fixes:** Columns with no explicit `width` prop were implicitly assigned `DEFAULT_MIN_COLUMN_WIDTH` (120px), which over-constrained the table. For example, a table with `{key: 'name'}` (no width) and `{key: 'email', width: proportional(2, {minWidth: 120})}` would force the table to 560px because Name inherited a 120px minimum. Now, only columns that explicitly use `proportional()` contribute a minimum constraint.

## Test plan

- [x] Verify proportional columns with `minWidth` cannot shrink below their minimum when resizing the browser
- [x] Verify columns with no explicit `width` do not add unnecessary minimum constraints
- [x] `yarn vitest packages/core/src/Table` — 76 tests pass (3 new tests for table min-width)