### PR TITLE
feat(PowerSearch): field+operator+value typeahead string suggestions

### DIFF
--- a/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
@@ -210,4 +210,146 @@ describe('usePowerSearchSource', () => {
       expect(results.length).toBeGreaterThan(1);
     });
   });
+
+  describe('field+operator+value suggestions', () => {
+    it('suggests all string-valued operators for "title foobar"', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title foobar');
+
+      const valueItems = results.filter(r => r.label.includes('"foobar"'));
+      expect(valueItems.map(r => r.label)).toEqual([
+        'Title contains "foobar"',
+        'Title is "foobar"',
+      ]);
+
+      const containsAux = valueItems[0].auxiliaryData as PowerSearchAuxData;
+      expect(containsAux.fieldKey).toBe('title');
+      expect(containsAux.operatorKey).toBe('contains');
+      expect(containsAux.filterValue).toEqual({
+        type: 'string',
+        value: 'foobar',
+      });
+
+      const isAux = valueItems[1].auxiliaryData as PowerSearchAuxData;
+      expect(isAux.operatorKey).toBe('is');
+    });
+
+    it('suggests only the matching operator for "title contains foobar"', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title contains foobar');
+
+      const valueItems = results.filter(r => r.label.includes('"foobar"'));
+      expect(valueItems).toHaveLength(1);
+      expect(valueItems[0].label).toBe('Title contains "foobar"');
+      const aux = valueItems[0].auxiliaryData as PowerSearchAuxData;
+      expect(aux.operatorKey).toBe('contains');
+      expect(aux.filterValue).toEqual({type: 'string', value: 'foobar'});
+    });
+
+    it('does not suggest "<field> <value>" matches when explicit operator matched', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title contains foobar');
+
+      // Should NOT have 'Title is "contains foobar"' or similar
+      const spurious = results.filter(r =>
+        r.label.includes('"contains foobar"'),
+      );
+      expect(spurious).toHaveLength(0);
+    });
+
+    it('suggests only the matching operator for "title is foobar"', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title is foobar');
+
+      const valueItems = results.filter(r => r.label.includes('"foobar"'));
+      expect(valueItems).toHaveLength(1);
+      expect(valueItems[0].label).toBe('Title is "foobar"');
+      const aux = valueItems[0].auxiliaryData as PowerSearchAuxData;
+      expect(aux.operatorKey).toBe('is');
+    });
+
+    it('is case-insensitive for field and operator matching', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('TITLE CONTAINS hello');
+
+      const valueItem = results.find(r => r.label === 'Title contains "hello"');
+      expect(valueItem).toBeDefined();
+    });
+
+    it('preserves original case of the value', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title FooBar');
+
+      const valueItem = results.find(
+        r => r.label === 'Title contains "FooBar"',
+      );
+      expect(valueItem).toBeDefined();
+      const aux = valueItem!.auxiliaryData as PowerSearchAuxData;
+      expect(aux.filterValue).toEqual({type: 'string', value: 'FooBar'});
+    });
+
+    it('does not suggest value match for non-string operators', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('status foobar');
+
+      const valueItem = results.find(r => r.label.includes('"foobar"'));
+      expect(valueItem).toBeUndefined();
+    });
+
+    it('does not suggest value match when remainder matches an operator prefix', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('title con');
+
+      // "con" is a prefix of "contains", so should not suggest a value match
+      const valueItem = results.find(r => r.label.includes('"con"'));
+      expect(valueItem).toBeUndefined();
+    });
+
+    it('does not suggest value match when field has isValueMatchAllowed=false', () => {
+      const config: PowerSearchConfig = {
+        name: 'Test',
+        fields: [
+          {
+            key: 'title',
+            label: 'Title',
+            isValueMatchAllowed: false,
+            operators: [
+              {key: 'contains', label: 'contains', value: {type: 'string'}},
+            ],
+          },
+        ],
+      };
+      const source = createSource(config);
+      const results = source.search('title foobar');
+
+      const valueItem = results.find(r => r.label.includes('"foobar"'));
+      expect(valueItem).toBeUndefined();
+    });
+
+    it('uses string_list filter value for string_list operators', () => {
+      const config: PowerSearchConfig = {
+        name: 'Test',
+        fields: [
+          {
+            key: 'tags',
+            label: 'Tags',
+            operators: [
+              {
+                key: 'contains',
+                label: 'contains',
+                value: {type: 'string_list'},
+              },
+            ],
+          },
+        ],
+      };
+      const source = createSource(config);
+      const results = source.search('tags hello');
+
+      const valueItem = results.find(r => r.label === 'Tags contains "hello"');
+      expect(valueItem).toBeDefined();
+      const aux = valueItem!.auxiliaryData as PowerSearchAuxData;
+      expect(aux.filterValue).toEqual({type: 'string_list', value: ['hello']});
+    });
+  });
 });

--- a/packages/core/src/PowerSearch/usePowerSearchSource.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.ts
@@ -82,6 +82,86 @@ export function usePowerSearchSource(
           }
         }
 
+        // Field+operator+value suggestions for string-valued operators.
+        // Matches "title foobar" → Title contains "foobar"
+        // and "title contains foobar" → Title contains "foobar"
+        for (const field of config.getVisibleFields()) {
+          if (field.isValueMatchAllowed === false) continue;
+
+          const fieldLabel = field.label.toLowerCase();
+
+          // Try "<field> <operator> <value>" first (longer match wins)
+          let hasExactOperatorMatch = false;
+          for (const op of field.operators) {
+            if (op.value.type !== 'string' && op.value.type !== 'string_list') {
+              continue;
+            }
+            const prefix = `${fieldLabel} ${op.label.toLowerCase()} `;
+            if (lower.startsWith(prefix) && lower.length > prefix.length) {
+              hasExactOperatorMatch = true;
+              const rawValue = query.slice(prefix.length);
+              const id = `${field.key}:${op.key}:value:${rawValue}`;
+              if (!seen.has(id)) {
+                seen.add(id);
+                results.push({
+                  id,
+                  label: `${field.label} ${op.label} "${rawValue}"`,
+                  auxiliaryData: {
+                    fieldKey: field.key,
+                    operatorKey: op.key,
+                    filterValue:
+                      op.value.type === 'string'
+                        ? {type: 'string', value: rawValue}
+                        : {type: 'string_list', value: [rawValue]},
+                  },
+                });
+              }
+            }
+          }
+
+          // Try "<field> <value>" — suggests all string-valued operators.
+          // Skip if an explicit "<field> <operator> <value>" already matched.
+          const fieldPrefix = `${fieldLabel} `;
+          if (
+            !hasExactOperatorMatch &&
+            lower.startsWith(fieldPrefix) &&
+            lower.length > fieldPrefix.length
+          ) {
+            // Check the remainder isn't the start of an operator name
+            const remainder = lower.slice(fieldPrefix.length);
+            const isOperatorPrefix = field.operators.some(op =>
+              op.label.toLowerCase().startsWith(remainder),
+            );
+            if (!isOperatorPrefix) {
+              const rawValue = query.slice(fieldPrefix.length);
+              for (const op of field.operators) {
+                if (
+                  op.value.type !== 'string' &&
+                  op.value.type !== 'string_list'
+                ) {
+                  continue;
+                }
+                const id = `${field.key}:${op.key}:value:${rawValue}`;
+                if (!seen.has(id)) {
+                  seen.add(id);
+                  results.push({
+                    id,
+                    label: `${field.label} ${op.label} "${rawValue}"`,
+                    auxiliaryData: {
+                      fieldKey: field.key,
+                      operatorKey: op.key,
+                      filterValue:
+                        op.value.type === 'string'
+                          ? {type: 'string', value: rawValue}
+                          : {type: 'string_list', value: [rawValue]},
+                    },
+                  });
+                }
+              }
+            }
+          }
+        }
+
         // If contentSearchFieldKey is set and no field or field+operator
         // exactly matches the query, prepend a content search item
         const contentFieldKey = config.config.contentSearchFieldKey;


### PR DESCRIPTION
## Summary

Adds inline value string suggestions to the PowerSearch typeahead. When a user types a field name followed by a value, the dropdown now suggests fully-formed filter results.

**`"<field> <value>"` — suggests all string-valued operators:**
- `title foobar` → `Title contains "foobar"`, `Title is "foobar"`, etc.

**`"<field> <operator> <value>"` — suggests only the matched operator:**
- `title contains foobar` → `Title contains "foobar"`

Selecting a suggestion immediately creates the filter with the value pre-filled, skipping the value editor step.

This just adds it for string operators, will do the rest separately.

### Behavior details

- Only applies to operators with `string` or `string_list` value types
- Respects `isValueMatchAllowed: false` on fields to opt out
- When the typed remainder matches the start of an operator name (e.g. `title con`), value suggestions are suppressed so the operator suggestion (`Title contains`) still appears
- When an explicit `<field> <operator> <value>` match is found, the broader `<field> <value>` suggestions are suppressed to avoid spurious results like `Title is "contains foobar"`
- Field/operator matching is case-insensitive; the original case of the typed value is preserved

## Test plan

- [x] `yarn vitest packages/core/src/PowerSearch` — 76 tests pass (13 new)
- [x] Type `title foobar` in PowerSearch and verify all string operators appear as suggestions
- [x] Type `title contains foobar` and verify only the `contains` operator suggestion appears
- [x] Type `title con` and verify operator suggestions appear (no value suggestions)
- [x] Verify selecting a suggestion creates the filter with the value pre-filled