### PR TITLE
fix(ci): treat sandbox and storybook builds symmetrically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
           retention-days: 30
 
       - name: Upload Sandbox artifact
-        if: github.event_name == 'pull_request' && hashFiles('apps/sandbox/out/**') != ''
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: sandbox-${{ steps.urls.outputs.short_hash }}
@@ -176,7 +176,6 @@ jobs:
         with:
           name: sandbox-${{ needs.build.outputs.short_hash }}
           path: sandbox-dist
-        continue-on-error: true
 
       - name: Prepare PR preview
         run: |
@@ -185,10 +184,8 @@ jobs:
           mkdir -p deploy/pr/${PR_NUMBER}
           cp -r storybook-dist/* deploy/pr/${PR_NUMBER}/
 
-          if [ -d "sandbox-dist" ]; then
-            mkdir -p deploy/pr/${PR_NUMBER}/sandbox
-            cp -r sandbox-dist/* deploy/pr/${PR_NUMBER}/sandbox/
-          fi
+          mkdir -p deploy/pr/${PR_NUMBER}/sandbox
+          cp -r sandbox-dist/* deploy/pr/${PR_NUMBER}/sandbox/
 
           touch deploy/.nojekyll
 


### PR DESCRIPTION
## Summary
Follow-up from [#1049 review](https://github.com/facebookexperimental/xds/pull/1049#pullrequestreview-4047162350) — treats sandbox and storybook builds symmetrically so both are required to succeed on every PR CI run.

## Changes
- **Remove `hashFiles` guard from sandbox artifact upload** — matches storybook, which uploads unconditionally
- **Remove `continue-on-error` from sandbox artifact download** in `deploy-preview` — both artifacts are now required
- **Remove conditional directory check** in deploy prep — sandbox output is guaranteed since the build and upload are required

## Context
@cixzhang noted in the #1049 review:
> we should treat sandbox and storybook builds symmetrically — both should be required to succeed on every PR CI run. The `hashFiles` guard on the sandbox upload + `continue-on-error` on download is a slight asymmetry

This PR addresses that asymmetry.