### PR TITLE
fix: migrate legacy string spacing tokens to numeric scale

### DIFF
--- a/apps/storybook/stories/Grid.stories.tsx
+++ b/apps/storybook/stories/Grid.stories.tsx
@@ -263,7 +263,7 @@ export const DifferentGaps: Story = {
     <div {...stylex.props(styles.storyWrapper)}>
       <div {...stylex.props(styles.container)}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
-          Same gap for rows and columns (space4)
+          Same gap for rows and columns (gap=4)
         </XDSText>
         <XDSGrid columns={3} gap={4}>
           <GridItem>Item 1</GridItem>
@@ -276,7 +276,7 @@ export const DifferentGaps: Story = {
       </div>
       <div {...stylex.props(styles.container)}>
         <XDSText type="supporting" xstyle={styles.sectionLabel}>
-          Different gaps: rowGap=space2, columnGap=space6
+          Different gaps: rowGap=2, columnGap=6
         </XDSText>
         <XDSGrid columns={3} rowGap={2} columnGap={6}>
           <GridItem>Item 1</GridItem>

--- a/internal/vibe-tests/app/src/report/CodeModal.tsx
+++ b/internal/vibe-tests/app/src/report/CodeModal.tsx
@@ -33,7 +33,7 @@ export function CodeModal({
       width={800}
       aria-label={`${targetLabel} code for ${promptId}`}>
       <div className="report-codeModal-header">
-        <XDSVStack gap="space1">
+        <XDSVStack gap={1}>
           <XDSHeading level={3}>
             {promptId} — {targetLabel}
           </XDSHeading>

--- a/internal/vibe-tests/app/src/report/CompareView.tsx
+++ b/internal/vibe-tests/app/src/report/CompareView.tsx
@@ -408,7 +408,7 @@ export function CompareView({comparison}: CompareViewProps) {
   ];
 
   return (
-    <XDSVStack gap="space4">
+    <XDSVStack gap={4}>
       <div
         className={
           isThreeWay
@@ -417,7 +417,7 @@ export function CompareView({comparison}: CompareViewProps) {
         }>
         <XDSCard>
           <div className="report-compare-winCard">
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <XDSText type="label">XDS Wins</XDSText>
               <XDSHeading level={2}>
                 <span className="report-color-positive">{xdsWins}</span>
@@ -427,7 +427,7 @@ export function CompareView({comparison}: CompareViewProps) {
         </XDSCard>
         <XDSCard>
           <div className="report-compare-winCard">
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <XDSText type="label">Baseline Wins</XDSText>
               <XDSHeading level={2}>
                 <span className="report-color-negative">{baselineWins}</span>
@@ -438,7 +438,7 @@ export function CompareView({comparison}: CompareViewProps) {
         {isThreeWay && (
           <XDSCard>
             <div className="report-compare-winCard">
-              <XDSVStack gap="space2">
+              <XDSVStack gap={2}>
                 <XDSText type="label">HTML Wins</XDSText>
                 <XDSHeading level={2}>
                   <span className="report-color-warning">{htmlWins}</span>
@@ -449,7 +449,7 @@ export function CompareView({comparison}: CompareViewProps) {
         )}
         <XDSCard>
           <div className="report-compare-winCard">
-            <XDSVStack gap="space2">
+            <XDSVStack gap={2}>
               <XDSText type="label">Ties</XDSText>
               <XDSHeading level={2}>
                 <span className="report-color-neutral">{ties}</span>
@@ -459,7 +459,7 @@ export function CompareView({comparison}: CompareViewProps) {
         </XDSCard>
       </div>
 
-      <XDSVStack gap="space3">
+      <XDSVStack gap={3}>
         <XDSHeading level={3}>Dimension Comparison</XDSHeading>
         <XDSTable<DimRow>
           data={dimData}
@@ -471,7 +471,7 @@ export function CompareView({comparison}: CompareViewProps) {
       </XDSVStack>
 
       {catData.length > 0 && (
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={3}>Category Breakdown</XDSHeading>
           <XDSTable<CatRow>
             data={catData}
@@ -484,7 +484,7 @@ export function CompareView({comparison}: CompareViewProps) {
       )}
 
       {xds.cost && baseline.cost && (
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           <XDSHeading level={3}>Cost Comparison</XDSHeading>
           <CostComparisonSection
             xdsCost={xds.cost}

--- a/internal/vibe-tests/app/src/report/DimensionTable.tsx
+++ b/internal/vibe-tests/app/src/report/DimensionTable.tsx
@@ -29,7 +29,7 @@ interface RowData extends Record<string, unknown> {
 
 function ScoreCell({score}: {score: number}) {
   return (
-    <XDSHStack gap="space1" hAlign="center">
+    <XDSHStack gap={1} hAlign="center">
       <XDSStatusDot
         variant={scoreToStatusVariant(score)}
         label={`Score: ${formatScore(score)}`}

--- a/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
+++ b/internal/vibe-tests/app/src/report/PromptDetailCard.tsx
@@ -33,7 +33,7 @@ function ScoreItem({label, score}: {label: string; score: number}) {
 function ScoreSummary({label, score}: {label: string; score: UniversalScore}) {
   return (
     <div className="report-promptDetail-scoreBlock">
-      <XDSVStack gap="space2">
+      <XDSVStack gap={2}>
         <XDSText type="label">{label}</XDSText>
         <div className="report-promptDetail-scoreGrid">
           {ALL_DIMENSIONS.map(dim => (
@@ -128,7 +128,7 @@ export function PromptDetailCard({
   return (
     <XDSCard>
       <div className="report-promptDetail-card">
-        <XDSVStack gap="space3">
+        <XDSVStack gap={3}>
           {/* Header: prompt ID, prompt text, and buttons */}
           <div className="report-promptDetail-header">
             <XDSHeading level={4}>{promptId}</XDSHeading>

--- a/internal/vibe-tests/app/src/report/Report.tsx
+++ b/internal/vibe-tests/app/src/report/Report.tsx
@@ -22,7 +22,7 @@ import './report.css';
 function MetricValue({label, value}: {label: string; value: string}) {
   return (
     <div className="report-metricItem">
-      <XDSVStack gap="space1">
+      <XDSVStack gap={1}>
         <XDSText type="label">{label}</XDSText>
         <XDSHeading level={3}>{value}</XDSHeading>
       </XDSVStack>
@@ -55,7 +55,7 @@ function EfficiencyMetricsCard({
   return (
     <XDSCard>
       <div className="report-metricsCard">
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <XDSHeading level={4}>Efficiency Metrics</XDSHeading>
           <div className="report-metricsGrid">
             <MetricValue
@@ -100,7 +100,7 @@ function MaintainabilityMetricsCard({
   return (
     <XDSCard>
       <div className="report-metricsCard">
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <XDSHeading level={4}>Maintainability Metrics</XDSHeading>
           <div className="report-metricsGrid">
             <MetricValue
@@ -125,7 +125,7 @@ function CostMetricsCard({cost}: {cost: ReportData['universal']['cost']}) {
   return (
     <XDSCard>
       <div className="report-metricsCard">
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <XDSHeading level={4}>Cost</XDSHeading>
           <div className="report-metricsGrid">
             {cost.avgDurationMs > 0 && (
@@ -173,7 +173,7 @@ export function Report() {
         <div className="report-root">
           <div className="report-container">
             <div className="report-emptyState">
-              <XDSVStack gap="space4">
+              <XDSVStack gap={4}>
                 <XDSHeading level={2}>No Report Data</XDSHeading>
                 <XDSText type="body">
                   No report data found. Run the vibe test harness to generate a
@@ -193,11 +193,11 @@ export function Report() {
     <XDSTheme theme={defaultTheme} mode={themeMode}>
       <div className="report-root">
         <div className="report-container">
-          <XDSVStack gap="space5">
+          <XDSVStack gap={5}>
             {/* Header */}
             <div className="report-header">
-              <XDSHStack gap="space4" hAlign="between" vAlign="center">
-                <XDSVStack gap="space1">
+              <XDSHStack gap={4} hAlign="between" vAlign="center">
+                <XDSVStack gap={1}>
                   <XDSHeading level={1}>Vibe Test Report</XDSHeading>
                   {data.target && (
                     <XDSText type="supporting">Target: {data.target}</XDSText>
@@ -230,7 +230,7 @@ export function Report() {
             {/* Tab Content */}
             <div className="report-tabContent">
               {activeTab === 'overview' && (
-                <XDSVStack gap="space4">
+                <XDSVStack gap={4}>
                   {/* Overall score */}
                   <ScoreCard
                     label="Overall Score"
@@ -248,7 +248,7 @@ export function Report() {
                   )}
 
                   {/* Dimension scores grid */}
-                  <XDSVStack gap="space3">
+                  <XDSVStack gap={3}>
                     <XDSHeading level={3}>Dimensions</XDSHeading>
                     <div className="report-scoreGrid">
                       {ALL_DIMENSIONS.map(dim => (
@@ -270,7 +270,7 @@ export function Report() {
 
                   {/* Comparison view */}
                   {comparison && (
-                    <XDSVStack gap="space3">
+                    <XDSVStack gap={3}>
                       <XDSHeading level={3}>
                         {comparison.html
                           ? 'XDS vs Baseline vs HTML Comparison'
@@ -283,11 +283,11 @@ export function Report() {
               )}
 
               {activeTab === 'byPrompt' && (
-                <XDSVStack gap="space4">
+                <XDSVStack gap={4}>
                   <DimensionTable byPrompt={universal.byPrompt} />
 
                   {/* Per-prompt detail cards */}
-                  <XDSVStack gap="space3">
+                  <XDSVStack gap={3}>
                     <XDSHeading level={3}>Prompt Details</XDSHeading>
                     {Object.keys(universal.byPrompt).map(promptId => (
                       <PromptDetailCard

--- a/internal/vibe-tests/app/src/report/ScoreCard.tsx
+++ b/internal/vibe-tests/app/src/report/ScoreCard.tsx
@@ -31,9 +31,9 @@ export function ScoreCard({
   return (
     <XDSCard>
       <div className="report-scoreCard-card">
-        <XDSVStack gap="space2">
+        <XDSVStack gap={2}>
           <XDSText type="label">{label}</XDSText>
-          <XDSHStack gap="space2" hAlign="center">
+          <XDSHStack gap={2} hAlign="center">
             <XDSHeading level={2}>{formatScore(score)}</XDSHeading>
             {delta != null && (
               <XDSText type="supporting" className={deltaClassName(delta)}>

--- a/internal/vibe-tests/app/src/report/ScreenshotGallery.tsx
+++ b/internal/vibe-tests/app/src/report/ScreenshotGallery.tsx
@@ -50,7 +50,7 @@ export function ScreenshotGallery({screenshots}: ScreenshotGalleryProps) {
       <div className="report-gallery-grid">
         {items.map(item => (
           <XDSCard key={item.filename}>
-            <XDSVStack gap="space0">
+            <XDSVStack gap={0}>
               <img
                 className="report-gallery-image"
                 src={item.src}
@@ -58,7 +58,7 @@ export function ScreenshotGallery({screenshots}: ScreenshotGalleryProps) {
                 onClick={() => setEnlarged(item.src)}
               />
               <div className="report-gallery-cardContent">
-                <XDSVStack gap="space1">
+                <XDSVStack gap={1}>
                   <XDSText type="label">{item.promptId}</XDSText>
                   <div className="report-gallery-meta">
                     <XDSText type="supporting">{item.viewport}</XDSText>

--- a/packages/cli/docs/tokens.md
+++ b/packages/cli/docs/tokens.md
@@ -21,7 +21,7 @@ All design tokens are defined in `packages/core/src/theme/tokens.stylex.ts`.
 | --spacing-11  | 44px  | Ultra spacious   |
 | --spacing-12  | 48px  | Maximum spacing  |
 
-Component gap props use `space0`-`space12` which map to these tokens.
+Component `gap` props use numeric scale values (e.g. `gap={4}` for 16px). The scale maps to these tokens: 0=0px, 0.5=2px, 1=4px, 2=8px, 3=12px, 4=16px, 5=20px, 6=24px, 8=32px, 10=40px.
 
 ## Size Tokens
 


### PR DESCRIPTION
Migrates all remaining gap string tokens to numeric API. The string token API was deprecated in v0.0.2 but vibe-test reports (27 instances), Grid story labels, and CLI docs still referenced the old pattern — causing LLMs to generate deprecated code.