### PR TITLE
feat(PowerSearch): enum/enum_list value suggestions in typeahead

### DIFF
--- a/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.test.ts
@@ -351,5 +351,161 @@ describe('usePowerSearchSource', () => {
       const aux = valueItem!.auxiliaryData as PowerSearchAuxData;
       expect(aux.filterValue).toEqual({type: 'string_list', value: ['hello']});
     });
+
+    it('suggests matching enum values for "<field> <value>"', () => {
+      const config: PowerSearchConfig = {
+        name: 'Test',
+        fields: [
+          {
+            key: 'genre',
+            label: 'Genre',
+            operators: [
+              {
+                key: 'is',
+                label: 'is',
+                value: {
+                  type: 'enum',
+                  values: [
+                    {value: 'fiction', label: 'Fiction'},
+                    {value: 'nonfiction', label: 'Non-Fiction'},
+                    {value: 'science', label: 'Science'},
+                  ],
+                },
+              },
+              {
+                key: 'is_not',
+                label: 'is not',
+                value: {
+                  type: 'enum',
+                  values: [
+                    {value: 'fiction', label: 'Fiction'},
+                    {value: 'nonfiction', label: 'Non-Fiction'},
+                    {value: 'science', label: 'Science'},
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const source = createSource(config);
+      const results = source.search('genre fiction');
+
+      const valueItems = results.filter(
+        r => r.label.startsWith('Genre ') && r.label.includes('Fiction'),
+      );
+      // "fiction" matches both "Fiction" and "Non-Fiction"
+      expect(valueItems.map(r => r.label)).toEqual([
+        'Genre is Fiction',
+        'Genre is Non-Fiction',
+        'Genre is not Fiction',
+        'Genre is not Non-Fiction',
+      ]);
+
+      const isAux = valueItems[0].auxiliaryData as PowerSearchAuxData;
+      expect(isAux.filterValue).toEqual({type: 'enum', value: 'fiction'});
+    });
+
+    it('suggests only matching operator for "<field> <operator> <value>" with enum', () => {
+      const config: PowerSearchConfig = {
+        name: 'Test',
+        fields: [
+          {
+            key: 'genre',
+            label: 'Genre',
+            operators: [
+              {
+                key: 'is',
+                label: 'is',
+                value: {
+                  type: 'enum',
+                  values: [
+                    {value: 'fiction', label: 'Fiction'},
+                    {value: 'nonfiction', label: 'Non-Fiction'},
+                  ],
+                },
+              },
+              {
+                key: 'is_not',
+                label: 'is not',
+                value: {
+                  type: 'enum',
+                  values: [
+                    {value: 'fiction', label: 'Fiction'},
+                    {value: 'nonfiction', label: 'Non-Fiction'},
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const source = createSource(config);
+      const results = source.search('genre is fiction');
+
+      const valueItems = results.filter(r => r.label === 'Genre is Fiction');
+      expect(valueItems).toHaveLength(1);
+      // Should NOT include "is not" operator results
+      const isNotItems = results.filter(r =>
+        r.label.startsWith('Genre is not'),
+      );
+      expect(isNotItems).toHaveLength(0);
+    });
+
+    it('suggests multiple matching enum values for partial match', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('status o');
+
+      // "o" matches "Open" and "Closed"
+      const valueItems = results.filter(
+        r => r.label.startsWith('Status is ') && r.label !== 'Status is',
+      );
+      expect(valueItems.map(r => r.label)).toEqual([
+        'Status is Open',
+        'Status is Closed',
+      ]);
+    });
+
+    it('does not suggest enum values when no labels match', () => {
+      const source = createSource(baseConfig);
+      const results = source.search('status xyz');
+
+      const valueItems = results.filter(
+        r => r.label.startsWith('Status is ') && r.label !== 'Status is',
+      );
+      expect(valueItems).toHaveLength(0);
+    });
+
+    it('uses enum_list filter value for enum_list operators', () => {
+      const config: PowerSearchConfig = {
+        name: 'Test',
+        fields: [
+          {
+            key: 'tags',
+            label: 'Tags',
+            operators: [
+              {
+                key: 'includes',
+                label: 'includes',
+                value: {
+                  type: 'enum_list',
+                  values: [
+                    {value: 'bug', label: 'Bug'},
+                    {value: 'feature', label: 'Feature'},
+                  ],
+                },
+              },
+            ],
+          },
+        ],
+      };
+      const source = createSource(config);
+      const results = source.search('tags bug');
+
+      const valueItem = results.find(r => r.label === 'Tags includes Bug');
+      expect(valueItem).toBeDefined();
+      const aux = valueItem!.auxiliaryData as PowerSearchAuxData;
+      expect(aux.filterValue).toEqual({type: 'enum_list', value: ['bug']});
+    });
   });
 });

--- a/packages/core/src/PowerSearch/usePowerSearchSource.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.ts
@@ -13,7 +13,7 @@
 import {useMemo} from 'react';
 import type {XDSSearchSource} from '../Typeahead/types';
 import type {InternalConfig} from './useInternalConfig';
-import type {PowerSearchItem} from './types';
+import type {PowerSearchItem, PowerSearchOperator, FilterValue} from './types';
 
 export function usePowerSearchSource(
   config: InternalConfig,
@@ -82,9 +82,10 @@ export function usePowerSearchSource(
           }
         }
 
-        // Field+operator+value suggestions for string-valued operators.
+        // Field+operator+value suggestions for string and enum operators.
         // Matches "title foobar" → Title contains "foobar"
         // and "title contains foobar" → Title contains "foobar"
+        // and "genre fiction" → Genre is "Fiction"
         for (const field of config.getVisibleFields()) {
           if (field.isValueMatchAllowed === false) continue;
 
@@ -93,33 +94,32 @@ export function usePowerSearchSource(
           // Try "<field> <operator> <value>" first (longer match wins)
           let hasExactOperatorMatch = false;
           for (const op of field.operators) {
-            if (op.value.type !== 'string' && op.value.type !== 'string_list') {
-              continue;
-            }
             const prefix = `${fieldLabel} ${op.label.toLowerCase()} `;
             if (lower.startsWith(prefix) && lower.length > prefix.length) {
-              hasExactOperatorMatch = true;
               const rawValue = query.slice(prefix.length);
-              const id = `${field.key}:${op.key}:value:${rawValue}`;
-              if (!seen.has(id)) {
-                seen.add(id);
-                results.push({
-                  id,
-                  label: `${field.label} ${op.label} "${rawValue}"`,
-                  auxiliaryData: {
-                    fieldKey: field.key,
-                    operatorKey: op.key,
-                    filterValue:
-                      op.value.type === 'string'
-                        ? {type: 'string', value: rawValue}
-                        : {type: 'string_list', value: [rawValue]},
-                  },
-                });
+              const matches = resolveValueMatches(op, rawValue);
+              if (matches.length > 0) {
+                hasExactOperatorMatch = true;
+              }
+              for (const match of matches) {
+                const id = `${field.key}:${op.key}:value:${match.displayValue}`;
+                if (!seen.has(id)) {
+                  seen.add(id);
+                  results.push({
+                    id,
+                    label: `${field.label} ${op.label} ${match.quoted ? `"${match.displayValue}"` : match.displayValue}`,
+                    auxiliaryData: {
+                      fieldKey: field.key,
+                      operatorKey: op.key,
+                      filterValue: match.filterValue,
+                    },
+                  });
+                }
               }
             }
           }
 
-          // Try "<field> <value>" — suggests all string-valued operators.
+          // Try "<field> <value>" — suggests all matching operators.
           // Skip if an explicit "<field> <operator> <value>" already matched.
           const fieldPrefix = `${fieldLabel} `;
           if (
@@ -135,27 +135,21 @@ export function usePowerSearchSource(
             if (!isOperatorPrefix) {
               const rawValue = query.slice(fieldPrefix.length);
               for (const op of field.operators) {
-                if (
-                  op.value.type !== 'string' &&
-                  op.value.type !== 'string_list'
-                ) {
-                  continue;
-                }
-                const id = `${field.key}:${op.key}:value:${rawValue}`;
-                if (!seen.has(id)) {
-                  seen.add(id);
-                  results.push({
-                    id,
-                    label: `${field.label} ${op.label} "${rawValue}"`,
-                    auxiliaryData: {
-                      fieldKey: field.key,
-                      operatorKey: op.key,
-                      filterValue:
-                        op.value.type === 'string'
-                          ? {type: 'string', value: rawValue}
-                          : {type: 'string_list', value: [rawValue]},
-                    },
-                  });
+                const matches = resolveValueMatches(op, rawValue);
+                for (const match of matches) {
+                  const id = `${field.key}:${op.key}:value:${match.displayValue}`;
+                  if (!seen.has(id)) {
+                    seen.add(id);
+                    results.push({
+                      id,
+                      label: `${field.label} ${op.label} ${match.quoted ? `"${match.displayValue}"` : match.displayValue}`,
+                      auxiliaryData: {
+                        fieldKey: field.key,
+                        operatorKey: op.key,
+                        filterValue: match.filterValue,
+                      },
+                    });
+                  }
                 }
               }
             }
@@ -198,6 +192,69 @@ export function usePowerSearchSource(
       },
     };
   }, [config]);
+}
+
+interface ValueMatch {
+  displayValue: string;
+  filterValue: FilterValue;
+  /** Whether to wrap the display value in quotes (for arbitrary string values). */
+  quoted: boolean;
+}
+
+/**
+ * Given an operator and a raw typed value, returns matching value suggestions.
+ * - string/string_list: returns the raw value as-is
+ * - enum/enum_list: returns enum items whose labels match the typed value
+ */
+function resolveValueMatches(
+  op: PowerSearchOperator,
+  rawValue: string,
+): ValueMatch[] {
+  const opType = op.value.type;
+
+  if (opType === 'string') {
+    return [
+      {
+        displayValue: rawValue,
+        filterValue: {type: 'string', value: rawValue},
+        quoted: true,
+      },
+    ];
+  }
+
+  if (opType === 'string_list') {
+    return [
+      {
+        displayValue: rawValue,
+        filterValue: {type: 'string_list', value: [rawValue]},
+        quoted: true,
+      },
+    ];
+  }
+
+  if (opType === 'enum') {
+    const lower = rawValue.toLowerCase();
+    return op.value.values
+      .filter(item => item.label.toLowerCase().includes(lower))
+      .map(item => ({
+        displayValue: item.label,
+        filterValue: {type: 'enum' as const, value: item.value},
+        quoted: false,
+      }));
+  }
+
+  if (opType === 'enum_list') {
+    const lower = rawValue.toLowerCase();
+    return op.value.values
+      .filter(item => item.label.toLowerCase().includes(lower))
+      .map(item => ({
+        displayValue: item.label,
+        filterValue: {type: 'enum_list' as const, value: [item.value]},
+        quoted: false,
+      }));
+  }
+
+  return [];
 }
 
 function buildFieldItems(config: InternalConfig): PowerSearchItem[] {


### PR DESCRIPTION
## Summary

Extends the field+operator+value typeahead suggestions (from #1051) to also work with `enum` and `enum_list` operators. Typing a value after a field name now matches against enum item labels (case-insensitive, partial match).

**Examples:**
- `genre fiction` → `Genre is Fiction`, `Genre is not Fiction` (all enum operators)
- `genre is fiction` → `Genre is Fiction` (only the matched operator)
- `status o` → `Status is Open`, `Status is Closed` (multiple enum matches)
- `status xyz` → no value suggestions (no enum labels match)

Enum values are displayed **without quotes** since they are known values, unlike arbitrary string values which remain quoted.

**Implementation:**
- Extracts a `resolveValueMatches()` helper that handles all supported value types (`string`, `string_list`, `enum`, `enum_list`)
- For enum types, filters enum items whose labels contain the typed value (case-insensitive)
- Each matching enum item produces a separate suggestion with the correct filter value
- The `<field> <operator> <value>` vs `<field> <value>` precedence rules from #1051 still apply

## Test plan

- [x] `yarn vitest packages/core/src/PowerSearch` — 82 tests pass (5 new enum-specific tests)
- [x] Type `status open` in PowerSearch and verify `Status is Open` appears (no quotes)
- [x] Type `status is clo` and verify only `Status is Closed` appears
- [x] Verify no suggestions appear when the typed value doesn't match any enum labels