### PR TITLE
fix(tokens): replace hardcoded borderRadius with radius token

### DIFF
--- a/packages/core/src/Avatar/XDSAvatar.tsx
+++ b/packages/core/src/Avatar/XDSAvatar.tsx
@@ -20,6 +20,7 @@ import {
   colorVars,
   typographyVars,
   fontWeightVars,
+  radiusVars,
 } from '../theme/tokens.stylex';
 import {XDSAvatarSizeContext} from './XDSAvatarSizeContext';
 import {xdsClassName, mergeProps} from '../utils';
@@ -113,7 +114,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: '50%',
+    borderRadius: radiusVars['--radius-full'],
     overflow: 'hidden',
     userSelect: 'none',
   },

--- a/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/XDSAvatarStatusDot.tsx
@@ -15,7 +15,7 @@
 import {useContext, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars} from '../theme/tokens.stylex';
+import {colorVars, radiusVars} from '../theme/tokens.stylex';
 import {XDSAvatarSizeContext} from './XDSAvatarSizeContext';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -106,7 +106,7 @@ export interface XDSAvatarStatusDotProps extends XDSBaseProps<HTMLSpanElement> {
 
 const styles = stylex.create({
   dot: {
-    borderRadius: '50%',
+    borderRadius: radiusVars['--radius-full'],
     borderStyle: 'solid',
     borderColor: colorVars['--color-background-surface'],
     boxSizing: 'border-box',

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -49,7 +49,7 @@ const styles = stylex.create({
     height: spacingVars['--spacing-2'],
     paddingInline: 0,
     paddingBlock: 0,
-    borderRadius: '50%',
+    borderRadius: radiusVars['--radius-full'],
   },
   visuallyHidden: {
     position: 'absolute',


### PR DESCRIPTION
## Component Audit — 2026-04-02

Nightly audit of 5 components: **AppShell**, **AspectRatio**, **Avatar**, **Badge**, **Banner**.

### Findings

Three instances of hardcoded `borderRadius: '50%'` replaced with `radiusVars['--radius-full']`:

| Component | File | Issue |
|-----------|------|-------|
| Avatar | `XDSAvatar.tsx` | `styles.content.borderRadius` was `'50%'` |
| AvatarStatusDot | `XDSAvatarStatusDot.tsx` | `styles.dot.borderRadius` was `'50%'` |
| Badge | `XDSBadge.tsx` | `styles.dot.borderRadius` was `'50%'` |

This ensures themes can control circular element radii through the token system.

### Clean Components

- **AppShell** — all tokens, xdsClassName with `{height, variant}`, skip-to-content a11y, exports ✓
- **AspectRatio** — structural only, no visual tokens needed, xdsClassName applied, exports ✓
- **Banner** — all tokens, xdsClassName with `{container, status}`, ARIA role mapping, XDSButton/XDSIcon reuse ✓

### Needs Review

None — all fixes are mechanical token replacements.

---
