### PR TITLE
feat(table): Phase 2b — transformColumns plugin interface

### DIFF
--- a/apps/storybook/stories/TableColumnSettings.stories.tsx
+++ b/apps/storybook/stories/TableColumnSettings.stories.tsx
@@ -134,7 +134,7 @@ export const BasicColumnToggle: Story = {
         />
         <XDSTable
           data={users}
-          columns={columnSettings.activeColumns(allColumns)}
+          columns={allColumns}
           idKey="id"
           plugins={{columnSettings: columnSettings.plugin}}
         />
@@ -177,7 +177,7 @@ export const DisabledColumns: Story = {
         />
         <XDSTable
           data={users}
-          columns={columnSettings.activeColumns(allColumns)}
+          columns={allColumns}
           idKey="id"
           plugins={{columnSettings: columnSettings.plugin}}
         />
@@ -228,7 +228,7 @@ export const ResetToDefault: Story = {
         />
         <XDSTable
           data={users}
-          columns={columnSettings.activeColumns(allColumns)}
+          columns={allColumns}
           idKey="id"
           plugins={{columnSettings: columnSettings.plugin}}
         />
@@ -278,7 +278,7 @@ export const WithSelection: Story = {
         />
         <XDSTable
           data={users}
-          columns={columnSettings.activeColumns(allColumns)}
+          columns={allColumns}
           idKey="id"
           plugins={{
             columnSettings: columnSettings.plugin,

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -216,8 +216,17 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
     XDSTableHeaderCell) as React.ComponentType<TableHeaderCellComponentProps>;
 
   // Resolve columns: explicit > auto-generated from data.
-  const resolvedColumns: XDSTableColumn<T>[] =
+  const baseColumns: XDSTableColumn<T>[] =
     columnsProp ?? (data ? generateColumns(data) : []);
+
+  // --- Plugin pipeline: transformColumns ---
+  // Runs before any element-level transforms. Allows plugins to filter,
+  // reorder, or inject synthetic columns (e.g. selection checkbox).
+  const resolvedColumns = applyPlugins(
+    plugins,
+    p => p.transformColumns,
+    baseColumns,
+  );
 
   // Resolve all column widths in a single pass — produces per-column
   // inline styles and the aggregate table min-width.

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
@@ -90,12 +90,27 @@ function renderColumnSettingsHook(
 
 describe('useXDSTableColumnSettings', () => {
   describe('return value', () => {
-    it('returns plugin object with transformTableContext', () => {
+    it('returns plugin object with transformColumns', () => {
       const {result} = renderColumnSettingsHook();
       expect(result.current.plugin).toBeDefined();
-      expect(result.current.plugin.transformTableContext).toBeInstanceOf(
+      expect(result.current.plugin.transformColumns).toBeInstanceOf(
         Function,
       );
+    });
+
+    it('transformColumns filters and reorders columns by activeColumnKeys', () => {
+      const {result} = renderColumnSettingsHook({
+        activeColumnKeys: ['role', 'name'], // reversed order, missing 'email'
+      });
+
+      const allColumns: XDSTableColumn<User>[] = [
+        {key: 'name', header: 'Name'},
+        {key: 'email', header: 'Email'},
+        {key: 'role', header: 'Role'},
+      ];
+
+      const filtered = result.current.plugin.transformColumns!(allColumns);
+      expect(filtered.map(c => c.key)).toEqual(['role', 'name']);
     });
 
     it('returns activeColumns function', () => {

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.tsx
@@ -14,7 +14,7 @@
  * - /packages/core/src/Table/index.ts (exports)
  */
 
-import {useCallback, useMemo, useRef, type ReactNode} from 'react';
+import {useCallback, useMemo, useRef} from 'react';
 import type {TablePlugin, XDSTableColumn} from '../../types';
 import type {XDSMultiSelectorOptionType} from '../../../MultiSelector/types';
 
@@ -145,9 +145,19 @@ export interface UseXDSTableColumnSettingsReturn<
    * Filters and reorders the full columns array based on activeColumnKeys.
    * Returns only active columns, in the order specified by activeColumnKeys.
    *
+   * **Note:** When using the plugin with XDSTable, you typically don't need
+   * this — the plugin's `transformColumns` handles filtering automatically.
+   * Pass all columns to XDSTable and let the plugin do the work.
+   * Use `activeColumns()` when you need the filtered array for non-table
+   * purposes (e.g., rendering column headers in a toolbar or export).
+   *
    * @example
    * ```
-   * <XDSTable columns={columnSettings.activeColumns(allColumns)} />
+   * // Preferred: let the plugin filter via transformColumns
+   * <XDSTable columns={allColumns} plugins={{ columnSettings: cs.plugin }} />
+   *
+   * // Manual: for non-table usage
+   * const visibleCols = cs.activeColumns(allColumns);
    * ```
    */
   activeColumns: (columns: XDSTableColumn<T>[]) => XDSTableColumn<T>[];
@@ -389,12 +399,24 @@ export function useXDSTableColumnSettings<
     [],
   );
 
-  // --- Plugin (stable ref via configRef) ---
+  // --- Plugin (uses transformColumns to filter/reorder) ---
 
   const plugin = useMemo(
     (): TablePlugin<T> => ({
-      transformTableContext(children: ReactNode) {
-        return children;
+      transformColumns(columns: XDSTableColumn<T>[]): XDSTableColumn<T>[] {
+        const cfg = configRef.current;
+        const activeSet = new Set(cfg.activeColumnKeys);
+        // Build a map for ordering by activeColumnKeys position
+        const orderMap = new Map(
+          cfg.activeColumnKeys.map((key, index) => [key, index]),
+        );
+        return columns
+          .filter((col) => activeSet.has(col.key as TColumnKey))
+          .sort((a, b) => {
+            const orderA = orderMap.get(a.key as TColumnKey) ?? Infinity;
+            const orderB = orderMap.get(b.key as TColumnKey) ?? Infinity;
+            return orderA - orderB;
+          });
       },
     }),
     [],

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -185,10 +185,28 @@ export interface BodyCellRenderProps {
 /**
  * Table plugin — transforms render props at each structural level.
  * Plugins compose by sequential application (first plugin's output feeds next).
+ *
+ * ## Pipeline order
+ *
+ * 1. `transformColumns` — filter, reorder, or inject columns before rendering
+ * 2. `transformTable` — transform the root `<table>` element props
+ * 3. `transformHeaderRow` — transform the header `<tr>` props
+ * 4. `transformHeaderCell` — transform each `<th>` props
+ * 5. `transformBodyRow` — transform each body `<tr>` props
+ * 6. `transformBodyCell` — transform each body `<td>` props
+ * 7. `transformTableContext` — wrap the table output in context providers
  */
 export interface TablePlugin<
   T extends Record<string, unknown> = Record<string, unknown>,
 > {
+  /**
+   * Transform the column definitions before rendering.
+   * Runs before any element-level transforms. Use to filter, reorder,
+   * or inject synthetic columns (e.g. a selection checkbox column).
+   */
+  transformColumns?: (
+    columns: XDSTableColumn<T>[],
+  ) => XDSTableColumn<T>[];
   /** Transform the root `<table>` element props */
   transformTable?: (props: TableRenderProps) => TableRenderProps;
   /** Transform the header `<tr>` props */


### PR DESCRIPTION
Phase 2b of XDSTable architecture review. All 233 tests pass (1 new).

**Changes:**
- Add `transformColumns` to `TablePlugin` interface — runs before element-level transforms, enabling plugins to filter, reorder, or inject synthetic columns
- Migrate columnSettings plugin from no-op `transformTableContext` to `transformColumns` — column filtering now runs inside the pipeline
- New test validating transformColumns filtering and reordering

This is the key enabler for Phase 3 (selection rewrite), where selection will prepend a checkbox column through transformColumns instead of injecting JSX into transformHeaderRow/transformBodyRow.

**Depends on:** #1060 (Phase 2a)