### PR TITLE
refactor(table): Phase 3 — Selection rewrite using transformColumns

### DIFF
--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -10,7 +10,7 @@
  * - /packages/core/src/Table/index.ts (exports if types change)
  */
 
-import {memo, type ReactElement, type ReactNode, type Ref} from 'react';
+import {memo, useRef, type ReactElement, type ReactNode, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {
   XDSBaseTableProps,
@@ -67,6 +67,19 @@ function applyPlugins<TPlugin, TProps, TArgs extends unknown[]>(
 
 // Stable empty array to avoid creating new reference on each render
 const EMPTY_PLUGINS: TablePlugin<Record<string, unknown>>[] = [];
+
+/**
+ * Shallow-compare two arrays by element identity.
+ * Used to stabilize the resolved columns array across renders.
+ */
+function areArraysShallowEqual<T>(a: T[], b: T[]): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
 
 interface TableRowProps<T extends Record<string, unknown>> {
   item: T;
@@ -222,11 +235,21 @@ function XDSBaseTableInner<T extends Record<string, unknown>>({
   // --- Plugin pipeline: transformColumns ---
   // Runs before any element-level transforms. Allows plugins to filter,
   // reorder, or inject synthetic columns (e.g. selection checkbox).
-  const resolvedColumns = applyPlugins(
+  const transformedColumns = applyPlugins(
     plugins,
     p => p.transformColumns,
     baseColumns,
   );
+
+  // Stabilize the resolved columns array — transformColumns returns a
+  // new array on every call, but if the contents haven't changed, we
+  // reuse the previous reference. This prevents MemoizedTableRow from
+  // re-rendering all rows when the column array is structurally identical.
+  const resolvedColumnsRef = useRef(transformedColumns);
+  if (!areArraysShallowEqual(resolvedColumnsRef.current, transformedColumns)) {
+    resolvedColumnsRef.current = transformedColumns;
+  }
+  const resolvedColumns = resolvedColumnsRef.current;
 
   // Resolve all column widths in a single pass — produces per-column
   // inline styles and the aggregate table min-width.

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -150,6 +150,7 @@ function TableRowInner<T extends Record<string, unknown>>({
   return (
     <RowComponent
       key={rowKey}
+      ref={rowRenderProps.ref}
       {...rowRenderProps.htmlProps}
       xstyle={rowRenderProps.styles}>
       {rowRenderProps.children}

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -41,7 +41,7 @@ import {
   type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, spacingVars} from '../../../theme/tokens.stylex';
+import {colorVars} from '../../../theme/tokens.stylex';
 import {XDSCheckboxInput} from '../../../CheckboxInput';
 import type {
   TablePlugin,
@@ -271,11 +271,10 @@ function SelectionCellContentInner<T extends Record<string, unknown>>({
 const selectedBgColor = colorVars['--color-accent-muted'];
 
 const selectionColumnStyles = stylex.create({
-  cell: {
+  center: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    paddingInline: 0,
   },
 });
 
@@ -313,9 +312,17 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
   const selectionColumn = useMemo(
     (): XDSTableColumn<T> => ({
       key: SELECTION_COLUMN_KEY,
-      header: <SelectAllCheckbox />,
+      header: (
+        <div {...stylex.props(selectionColumnStyles.center)}>
+          <SelectAllCheckbox />
+        </div>
+      ),
       width: SELECTION_COLUMN_WIDTH,
-      renderCell: (item: T) => <SelectionCellContent item={item} />,
+      renderCell: (item: T) => (
+        <div {...stylex.props(selectionColumnStyles.center)}>
+          <SelectionCellContent item={item} />
+        </div>
+      ),
     }),
     [],
   );
@@ -332,26 +339,6 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
 
       transformColumns(columns: XDSTableColumn<T>[]) {
         return [selectionColumn, ...columns];
-      },
-
-      transformHeaderCell(props, column) {
-        if (column.key === SELECTION_COLUMN_KEY) {
-          return {
-            ...props,
-            styles: [...props.styles, selectionColumnStyles.cell],
-          };
-        }
-        return props;
-      },
-
-      transformBodyCell(props, column) {
-        if (column.key === SELECTION_COLUMN_KEY) {
-          return {
-            ...props,
-            styles: [...props.styles, selectionColumnStyles.cell],
-          };
-        }
-        return props;
       },
 
       transformBodyRow(props: BodyRowRenderProps, item: T) {

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -273,17 +273,14 @@ const selectedBgColor = colorVars['--color-accent-muted'];
 const selectionColumnStyles = stylex.create({
   cell: {
     textAlign: 'center',
-    // Override density paddingInline so the column width is consistent
-    // across compact/balanced/spacious. Without this, spacious padding
-    // (16px × 2) would overflow the fixed column width.
-    paddingInline: spacingVars['--spacing-2'],
+    paddingInline: 0,
   },
 });
 
 /** Selection column key — prefixed to avoid collisions with user columns. */
 const SELECTION_COLUMN_KEY = '__xds_selection';
 
-/** Fixed width for the selection column (20px checkbox + 8px × 2 padding). */
+/** Fixed width for the selection column. Content is centered with no horizontal padding. */
 const SELECTION_COLUMN_WIDTH = pixel(36);
 
 // =============================================================================

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -1,4 +1,4 @@
-"use client";
+'use client';
 
 /**
  * @file useXDSTableSelection.tsx
@@ -6,13 +6,12 @@
  * @output Exports useXDSTableSelection hook and UseXDSTableSelectionConfig type
  * @position Selection plugin; consumed by XDSTable via plugins prop
  *
- * ## Architecture (v2 — transformColumns + imperative row styling)
+ * ## Architecture (v2 — transformColumns + ref-based row styling)
  *
  * Selection checkboxes are implemented as a synthetic column prepended via
  * `transformColumns`. The checkbox column flows through the normal cell
  * component pipeline, so it automatically respects component overrides
- * (components prop on XDSBaseTable). This replaces the v1 approach of
- * hardcoding XDSTableCell/XDSTableHeaderCell in the plugin.
+ * (components prop on XDSBaseTable).
  *
  * Selection state is managed via an external store (SelectionStore) for
  * fine-grained row subscriptions. Each row's checkbox subscribes
@@ -20,10 +19,11 @@
  * re-renders, not the entire table body.
  *
  * Row-level styling (aria-selected, background) uses imperative DOM
- * updates via a ref on a sentinel element inside each row. This avoids
- * re-rendering the entire memoized row when selection state changes.
- * The sentinel element's useEffect applies/removes attributes on the
- * parent <tr> element.
+ * updates via a ref attached directly to the <tr> element through the
+ * plugin's `transformBodyRow`. No extra DOM elements are injected —
+ * the store tracks row elements in a Set and applies styles during
+ * notify(). This scales to multiple plugins since any plugin can
+ * attach a ref via the `ref` field on BodyRowRenderProps.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/Table.doc.mjs (selection documentation)
@@ -39,6 +39,7 @@ import {
   useMemo,
   useSyncExternalStore,
   type ReactNode,
+  type Ref,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../../../theme/tokens.stylex';
@@ -75,16 +76,27 @@ export interface UseXDSTableSelectionConfig<T extends Record<string, unknown>> {
 // Selection Store (external store for fine-grained row subscriptions)
 // =============================================================================
 
+/**
+ * Lightweight external store that lets each row subscribe to selection
+ * changes independently. Also manages a set of <tr> element refs for
+ * imperative row styling — no extra DOM elements needed.
+ */
 interface SelectionStore<T extends Record<string, unknown>> {
   subscribe: (listener: () => void) => () => void;
   notify: () => void;
   getConfig: () => UseXDSTableSelectionConfig<T>;
+  /** Tracked <tr> elements for imperative row styling. */
+  rowElements: Set<HTMLTableRowElement>;
+  /** Reverse lookup: <tr> element → item, for checking selection state. */
+  rowItems: WeakMap<HTMLTableRowElement, T>;
 }
 
 function createSelectionStore<T extends Record<string, unknown>>(
   configRef: React.RefObject<UseXDSTableSelectionConfig<T>>,
 ): SelectionStore<T> {
   const listeners = new Set<() => void>();
+  const rowElements = new Set<HTMLTableRowElement>();
+  const rowItems = new WeakMap<HTMLTableRowElement, T>();
 
   return {
     subscribe(listener: () => void) {
@@ -92,13 +104,55 @@ function createSelectionStore<T extends Record<string, unknown>>(
       return () => listeners.delete(listener);
     },
     notify() {
+      // Notify useSyncExternalStore subscribers (checkbox components)
       for (const listener of listeners) {
         listener();
+      }
+
+      // Imperative DOM updates for row styling — no React re-render needed.
+      const config = configRef.current;
+      for (const el of rowElements) {
+        if (!el.isConnected) {
+          rowElements.delete(el);
+          continue;
+        }
+        const item = rowItems.get(el);
+        if (!item) continue;
+        const isSelected = config.getIsItemSelected(item);
+        if (isSelected) {
+          el.setAttribute('aria-selected', 'true');
+          el.style.backgroundColor = selectedBgColor;
+        } else {
+          el.removeAttribute('aria-selected');
+          el.style.backgroundColor = '';
+        }
       }
     },
     getConfig() {
       return configRef.current;
     },
+    rowElements,
+    rowItems,
+  };
+}
+
+// =============================================================================
+// Ref Merging Utility
+// =============================================================================
+
+/**
+ * Compose multiple refs into a single callback ref.
+ * Used when multiple plugins need to attach refs to the same row.
+ */
+function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): React.RefCallback<T> {
+  return (el: T | null) => {
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref != null) {
+        (ref as React.MutableRefObject<T | null>).current = el;
+      }
+    }
   };
 }
 
@@ -224,69 +278,6 @@ function SelectionCellContentInner<T extends Record<string, unknown>>({
 }
 
 // =============================================================================
-// Row Selection Sentinel
-// =============================================================================
-
-/**
- * Invisible sentinel element rendered inside each body row. Subscribes to
- * this item's selection state and imperatively manages aria-selected and
- * background color on the parent <tr>.
- *
- * Why imperative: The <tr> is rendered by the memoized MemoizedTableRow
- * component. Re-rendering the entire row on selection change would defeat
- * the external store architecture. Instead, this zero-height sentinel
- * subscribes to the store and applies/removes attributes directly.
- *
- * The sentinel is a <td> with colspan=0, display:none — invisible and
- * doesn't affect table layout.
- */
-function SelectionRowSentinel<T extends Record<string, unknown>>({
-  item,
-}: {
-  item: T;
-}) {
-  const store = useContext(SelectionStoreContext);
-  if (!store) return null;
-
-  return <SelectionRowSentinelInner store={store} item={item} />;
-}
-
-const sentinelStyle: React.CSSProperties = {
-  display: 'none',
-};
-
-function SelectionRowSentinelInner<T extends Record<string, unknown>>({
-  store,
-  item,
-}: {
-  store: SelectionStore<T>;
-  item: T;
-}) {
-  const isSelected = useIsItemSelected(store, item);
-  const sentinelRef = useRef<HTMLTableCellElement>(null);
-
-  useEffect(() => {
-    const tr = sentinelRef.current?.parentElement;
-    if (!tr) return;
-    if (isSelected) {
-      tr.setAttribute('aria-selected', 'true');
-      tr.style.backgroundColor = selectedBgColor;
-    } else {
-      tr.removeAttribute('aria-selected');
-      tr.style.backgroundColor = '';
-    }
-    return () => {
-      if (tr) {
-        tr.removeAttribute('aria-selected');
-        tr.style.backgroundColor = '';
-      }
-    };
-  }, [isSelected]);
-
-  return <td ref={sentinelRef} style={sentinelStyle} aria-hidden="true" />;
-}
-
-// =============================================================================
 // Styles
 // =============================================================================
 
@@ -321,7 +312,8 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
   const store = storeRef.current;
 
   // Notify subscribers on every render — useSyncExternalStore will only
-  // re-render components whose snapshot actually changed.
+  // re-render components whose snapshot actually changed. Also applies
+  // imperative row styling via the store's row ref tracking.
   useEffect(() => {
     store.notify();
   });
@@ -373,18 +365,20 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
       },
 
       transformBodyRow(props: BodyRowRenderProps, item: T) {
-        // Inject a hidden sentinel <td> that subscribes to this item's
-        // selection state and imperatively manages aria-selected +
-        // background on the parent <tr>. This avoids re-rendering the
-        // entire memoized row on selection change.
+        // Attach a ref to the <tr> for imperative row styling.
+        // The store tracks all row elements and applies aria-selected /
+        // backgroundColor on notify() — no extra DOM elements needed.
+        const selectionRef: React.RefCallback<HTMLTableRowElement> = el => {
+          if (el) {
+            store.rowElements.add(el);
+            store.rowItems.set(el, item);
+          }
+        };
+
         return {
           ...props,
-          children: (
-            <>
-              {props.children}
-              <SelectionRowSentinel item={item} />
-            </>
-          ),
+          // Merge with any existing ref from other plugins
+          ref: props.ref ? mergeRefs(props.ref, selectionRef) : selectionRef,
         };
       },
     }),

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -19,11 +19,10 @@
  * re-renders, not the entire table body.
  *
  * Row-level styling (aria-selected, background) uses imperative DOM
- * updates via a ref attached directly to the <tr> element through the
- * plugin's `transformBodyRow`. No extra DOM elements are injected —
- * the store tracks row elements in a Set and applies styles during
- * notify(). This scales to multiple plugins since any plugin can
- * attach a ref via the `ref` field on BodyRowRenderProps.
+ * updates via a ref callback on each <tr>. The ref subscribes to the
+ * store and applies/removes styles when selection changes — no extra
+ * DOM elements and no central element tracking. Each subscription
+ * self-cleans when the row disconnects.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/Table.doc.mjs (selection documentation)
@@ -78,25 +77,19 @@ export interface UseXDSTableSelectionConfig<T extends Record<string, unknown>> {
 
 /**
  * Lightweight external store that lets each row subscribe to selection
- * changes independently. Also manages a set of <tr> element refs for
- * imperative row styling — no extra DOM elements needed.
+ * changes independently. Row styling is handled by per-row ref callbacks
+ * that subscribe to this store — the store itself holds no DOM references.
  */
 interface SelectionStore<T extends Record<string, unknown>> {
   subscribe: (listener: () => void) => () => void;
   notify: () => void;
   getConfig: () => UseXDSTableSelectionConfig<T>;
-  /** Tracked <tr> elements for imperative row styling. */
-  rowElements: Set<HTMLTableRowElement>;
-  /** Reverse lookup: <tr> element → item, for checking selection state. */
-  rowItems: WeakMap<HTMLTableRowElement, T>;
 }
 
 function createSelectionStore<T extends Record<string, unknown>>(
   configRef: React.RefObject<UseXDSTableSelectionConfig<T>>,
 ): SelectionStore<T> {
   const listeners = new Set<() => void>();
-  const rowElements = new Set<HTMLTableRowElement>();
-  const rowItems = new WeakMap<HTMLTableRowElement, T>();
 
   return {
     subscribe(listener: () => void) {
@@ -104,36 +97,30 @@ function createSelectionStore<T extends Record<string, unknown>>(
       return () => listeners.delete(listener);
     },
     notify() {
-      // Notify useSyncExternalStore subscribers (checkbox components)
       for (const listener of listeners) {
         listener();
-      }
-
-      // Imperative DOM updates for row styling — no React re-render needed.
-      const config = configRef.current;
-      for (const el of rowElements) {
-        if (!el.isConnected) {
-          rowElements.delete(el);
-          continue;
-        }
-        const item = rowItems.get(el);
-        if (!item) continue;
-        const isSelected = config.getIsItemSelected(item);
-        if (isSelected) {
-          el.setAttribute('aria-selected', 'true');
-          el.style.backgroundColor = selectedBgColor;
-        } else {
-          el.removeAttribute('aria-selected');
-          el.style.backgroundColor = '';
-        }
       }
     },
     getConfig() {
       return configRef.current;
     },
-    rowElements,
-    rowItems,
   };
+}
+
+/**
+ * Apply or remove selection styling on a <tr> element.
+ */
+function applyRowSelectionStyle(
+  el: HTMLTableRowElement,
+  isSelected: boolean,
+): void {
+  if (isSelected) {
+    el.setAttribute('aria-selected', 'true');
+    el.style.backgroundColor = selectedBgColor;
+  } else {
+    el.removeAttribute('aria-selected');
+    el.style.backgroundColor = '';
+  }
 }
 
 // =============================================================================
@@ -312,8 +299,8 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
   const store = storeRef.current;
 
   // Notify subscribers on every render — useSyncExternalStore will only
-  // re-render components whose snapshot actually changed. Also applies
-  // imperative row styling via the store's row ref tracking.
+  // re-render components whose snapshot actually changed. Row ref
+  // subscribers apply imperative styling independently.
   useEffect(() => {
     store.notify();
   });
@@ -365,19 +352,28 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
       },
 
       transformBodyRow(props: BodyRowRenderProps, item: T) {
-        // Attach a ref to the <tr> for imperative row styling.
-        // The store tracks all row elements and applies aria-selected /
-        // backgroundColor on notify() — no extra DOM elements needed.
+        // Attach a ref to the <tr> that subscribes to the store for
+        // imperative row styling. Each row manages its own subscription
+        // and self-cleans when disconnected — no central element tracking.
         const selectionRef: React.RefCallback<HTMLTableRowElement> = el => {
-          if (el) {
-            store.rowElements.add(el);
-            store.rowItems.set(el, item);
-          }
+          if (!el) return;
+          // Apply initial style
+          applyRowSelectionStyle(el, store.getConfig().getIsItemSelected(item));
+          // Subscribe for future changes
+          const unsub = store.subscribe(() => {
+            if (!el.isConnected) {
+              unsub();
+              return;
+            }
+            applyRowSelectionStyle(
+              el,
+              store.getConfig().getIsItemSelected(item),
+            );
+          });
         };
 
         return {
           ...props,
-          // Merge with any existing ref from other plugins
           ref: props.ref ? mergeRefs(props.ref, selectionRef) : selectionRef,
         };
       },

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -279,8 +279,11 @@ const selectionColumnStyles = stylex.create({
 /** Selection column key — prefixed to avoid collisions with user columns. */
 const SELECTION_COLUMN_KEY = '__xds_selection';
 
-/** Fixed width for the selection column. */
-const SELECTION_COLUMN_WIDTH = pixel(36);
+/** Fixed width for the selection column.
+ * Must accommodate the sm checkbox (20px touch target) plus the largest
+ * cell paddingInline (spacious = 16px × 2 = 32px). 20 + 32 = 52px.
+ */
+const SELECTION_COLUMN_WIDTH = pixel(52);
 
 // =============================================================================
 // Hook

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -272,7 +272,9 @@ const selectedBgColor = colorVars['--color-accent-muted'];
 
 const selectionColumnStyles = stylex.create({
   cell: {
-    textAlign: 'center',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     paddingInline: 0,
   },
 });

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -273,17 +273,18 @@ const selectedBgColor = colorVars['--color-accent-muted'];
 const selectionColumnStyles = stylex.create({
   cell: {
     textAlign: 'center',
+    // Override density paddingInline so the column width is consistent
+    // across compact/balanced/spacious. Without this, spacious padding
+    // (16px × 2) would overflow the fixed column width.
+    paddingInline: spacingVars['--spacing-2'],
   },
 });
 
 /** Selection column key — prefixed to avoid collisions with user columns. */
 const SELECTION_COLUMN_KEY = '__xds_selection';
 
-/** Fixed width for the selection column.
- * Must accommodate the sm checkbox (20px touch target) plus the largest
- * cell paddingInline (spacious = 16px × 2 = 32px). 20 + 32 = 52px.
- */
-const SELECTION_COLUMN_WIDTH = pixel(52);
+/** Fixed width for the selection column (20px checkbox + 8px × 2 padding). */
+const SELECTION_COLUMN_WIDTH = pixel(36);
 
 // =============================================================================
 // Hook

--- a/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useXDSTableSelection.tsx
@@ -1,23 +1,29 @@
-'use client';
+"use client";
 
 /**
  * @file useXDSTableSelection.tsx
- * @input React, types, XDSCheckboxInput, XDSTableCell, XDSTableHeaderCell, theme tokens
+ * @input React, types, XDSCheckboxInput, theme tokens
  * @output Exports useXDSTableSelection hook and UseXDSTableSelectionConfig type
  * @position Selection plugin; consumed by XDSTable via plugins prop
  *
- * ## Performance Architecture
+ * ## Architecture (v2 — transformColumns + imperative row styling)
  *
- * Selection state is managed via an external store (SelectionStore) so that
- * individual rows can subscribe to their own selection state independently.
- * When a row is selected/deselected, only that row re-renders — not the
- * entire table body.
+ * Selection checkboxes are implemented as a synthetic column prepended via
+ * `transformColumns`. The checkbox column flows through the normal cell
+ * component pipeline, so it automatically respects component overrides
+ * (components prop on XDSBaseTable). This replaces the v1 approach of
+ * hardcoding XDSTableCell/XDSTableHeaderCell in the plugin.
  *
- * The plugin object returned by useXDSTableSelection is referentially stable
- * across renders. Selection-dependent rendering (aria-selected, background
- * highlight, checkbox state) is handled by store-subscribing components
- * (SelectionRowContent, SelectAllCheckbox) rather than in the plugin
- * transform functions.
+ * Selection state is managed via an external store (SelectionStore) for
+ * fine-grained row subscriptions. Each row's checkbox subscribes
+ * independently — when selection changes, only that row's checkbox
+ * re-renders, not the entire table body.
+ *
+ * Row-level styling (aria-selected, background) uses imperative DOM
+ * updates via a ref on a sentinel element inside each row. This avoids
+ * re-rendering the entire memoized row when selection state changes.
+ * The sentinel element's useEffect applies/removes attributes on the
+ * parent <tr> element.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/Table.doc.mjs (selection documentation)
@@ -37,9 +43,12 @@ import {
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../../../theme/tokens.stylex';
 import {XDSCheckboxInput} from '../../../CheckboxInput';
-import {XDSTableCell} from '../../XDSTableCell';
-import {XDSTableHeaderCell} from '../../XDSTableHeaderCell';
-import type {TablePlugin, BodyRowRenderProps} from '../../types';
+import type {
+  TablePlugin,
+  XDSTableColumn,
+  BodyRowRenderProps,
+} from '../../types';
+import {pixel} from '../../columnUtils';
 
 // =============================================================================
 // Config Type
@@ -66,12 +75,6 @@ export interface UseXDSTableSelectionConfig<T extends Record<string, unknown>> {
 // Selection Store (external store for fine-grained row subscriptions)
 // =============================================================================
 
-/**
- * Lightweight external store that lets each row subscribe to selection
- * changes independently. When selection state changes, all subscribers are
- * notified but only components whose snapshot actually changed will re-render
- * (thanks to useSyncExternalStore's built-in equality check on the snapshot).
- */
 interface SelectionStore<T extends Record<string, unknown>> {
   subscribe: (listener: () => void) => () => void;
   notify: () => void;
@@ -110,10 +113,6 @@ const SelectionStoreContext = createContext<SelectionStore<any> | null>(null);
 // Hooks for subscribing to selection state
 // =============================================================================
 
-/**
- * Subscribe to whether a specific item is selected.
- * Only triggers re-render when this item's selected state changes.
- */
 function useIsItemSelected<T extends Record<string, unknown>>(
   store: SelectionStore<T>,
   item: T,
@@ -182,29 +181,92 @@ function SelectAllCheckboxInner<T extends Record<string, unknown>>({
 }
 
 /**
- * Row content component that subscribes to this item's selection state.
- * Handles the checkbox cell, aria-selected attribute, and selected row styling.
- * Only re-renders when this specific item's selection state changes.
+ * Row checkbox component — used as renderCell for the synthetic selection column.
+ * Subscribes to this item's selection state independently.
  */
-function SelectionRowContent<T extends Record<string, unknown>>({
+function SelectionCellContent<T extends Record<string, unknown>>({
   item,
-  children,
 }: {
   item: T;
-  children: ReactNode;
 }) {
-  const store = useContext(SelectionStoreContext)!;
+  const store = useContext(SelectionStoreContext);
+  if (!store) return null;
+
+  return <SelectionCellContentInner store={store} item={item} />;
+}
+
+function SelectionCellContentInner<T extends Record<string, unknown>>({
+  store,
+  item,
+}: {
+  store: SelectionStore<T>;
+  item: T;
+}) {
   const config = store.getConfig();
   const isSelected = useIsItemSelected(store, item);
   const selectable = config.getIsItemSelectable?.(item) ?? true;
   const enabled = config.getIsItemEnabled?.(item) ?? true;
 
-  // Manage aria-selected and background color on the parent <tr> imperatively.
-  // This avoids re-rendering the entire memoized row component — only this
-  // content component re-renders when selection state changes.
-  const cellRef = useRef<HTMLTableCellElement>(null);
+  if (!selectable) return null;
+
+  return (
+    <XDSCheckboxInput
+      label="Select row"
+      isLabelHidden
+      value={isSelected}
+      onChange={() =>
+        store.getConfig().onSelectItem({item, isSelected: !isSelected})
+      }
+      isDisabled={!enabled}
+      size="sm"
+    />
+  );
+}
+
+// =============================================================================
+// Row Selection Sentinel
+// =============================================================================
+
+/**
+ * Invisible sentinel element rendered inside each body row. Subscribes to
+ * this item's selection state and imperatively manages aria-selected and
+ * background color on the parent <tr>.
+ *
+ * Why imperative: The <tr> is rendered by the memoized MemoizedTableRow
+ * component. Re-rendering the entire row on selection change would defeat
+ * the external store architecture. Instead, this zero-height sentinel
+ * subscribes to the store and applies/removes attributes directly.
+ *
+ * The sentinel is a <td> with colspan=0, display:none — invisible and
+ * doesn't affect table layout.
+ */
+function SelectionRowSentinel<T extends Record<string, unknown>>({
+  item,
+}: {
+  item: T;
+}) {
+  const store = useContext(SelectionStoreContext);
+  if (!store) return null;
+
+  return <SelectionRowSentinelInner store={store} item={item} />;
+}
+
+const sentinelStyle: React.CSSProperties = {
+  display: 'none',
+};
+
+function SelectionRowSentinelInner<T extends Record<string, unknown>>({
+  store,
+  item,
+}: {
+  store: SelectionStore<T>;
+  item: T;
+}) {
+  const isSelected = useIsItemSelected(store, item);
+  const sentinelRef = useRef<HTMLTableCellElement>(null);
+
   useEffect(() => {
-    const tr = cellRef.current?.parentElement;
+    const tr = sentinelRef.current?.parentElement;
     if (!tr) return;
     if (isSelected) {
       tr.setAttribute('aria-selected', 'true');
@@ -221,46 +283,26 @@ function SelectionRowContent<T extends Record<string, unknown>>({
     };
   }, [isSelected]);
 
-  return (
-    <>
-      <XDSTableCell ref={cellRef} xstyle={selectionCellStyles.base}>
-        {selectable && (
-          <XDSCheckboxInput
-            label="Select row"
-            isLabelHidden
-            value={isSelected}
-            onChange={() =>
-              store.getConfig().onSelectItem({item, isSelected: !isSelected})
-            }
-            isDisabled={!enabled}
-            size="sm"
-          />
-        )}
-      </XDSTableCell>
-      {children}
-    </>
-  );
+  return <td ref={sentinelRef} style={sentinelStyle} aria-hidden="true" />;
 }
 
 // =============================================================================
 // Styles
 // =============================================================================
 
-/**
- * Resolved CSS variable for imperative style updates on the <tr>.
- * Uses the StyleX token directly so it stays in sync with the theme.
- */
 const selectedBgColor = colorVars['--color-accent-muted'];
 
-const selectionCellStyles = stylex.create({
-  base: {
-    width: '36px',
-    minWidth: '36px',
-    maxWidth: '36px',
-    paddingInline: spacingVars['--spacing-2'],
+const selectionColumnStyles = stylex.create({
+  cell: {
     textAlign: 'center',
   },
 });
+
+/** Selection column key — prefixed to avoid collisions with user columns. */
+const SELECTION_COLUMN_KEY = '__xds_selection';
+
+/** Fixed width for the selection column. */
+const SELECTION_COLUMN_WIDTH = pixel(36);
 
 // =============================================================================
 // Hook
@@ -269,12 +311,9 @@ const selectionCellStyles = stylex.create({
 export function useXDSTableSelection<T extends Record<string, unknown>>(
   config: UseXDSTableSelectionConfig<T>,
 ): TablePlugin<T> {
-  // Keep config in a ref so the store always reads the latest version
-  // without creating a new store or plugin object.
   const configRef = useRef(config);
   configRef.current = config;
 
-  // Create the store once — it reads config via ref, so it never goes stale.
   const storeRef = useRef<SelectionStore<T> | null>(null);
   if (storeRef.current == null) {
     storeRef.current = createSelectionStore(configRef);
@@ -287,9 +326,18 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
     store.notify();
   });
 
-  // Return a stable plugin object — never changes after mount.
-  // Selection-dependent rendering is handled by SelectionRowContent
-  // and SelectAllCheckbox which subscribe to the store independently.
+  // Synthetic selection column — uses renderCell with a subscribing
+  // component so each row's checkbox re-renders independently.
+  const selectionColumn = useMemo(
+    (): XDSTableColumn<T> => ({
+      key: SELECTION_COLUMN_KEY,
+      header: <SelectAllCheckbox />,
+      width: SELECTION_COLUMN_WIDTH,
+      renderCell: (item: T) => <SelectionCellContent item={item} />,
+    }),
+    [],
+  );
+
   return useMemo(
     (): TablePlugin<T> => ({
       transformTableContext(children: ReactNode) {
@@ -300,35 +348,46 @@ export function useXDSTableSelection<T extends Record<string, unknown>>(
         );
       },
 
-      transformHeaderRow(props) {
+      transformColumns(columns: XDSTableColumn<T>[]) {
+        return [selectionColumn, ...columns];
+      },
+
+      transformHeaderCell(props, column) {
+        if (column.key === SELECTION_COLUMN_KEY) {
+          return {
+            ...props,
+            styles: [...props.styles, selectionColumnStyles.cell],
+          };
+        }
+        return props;
+      },
+
+      transformBodyCell(props, column) {
+        if (column.key === SELECTION_COLUMN_KEY) {
+          return {
+            ...props,
+            styles: [...props.styles, selectionColumnStyles.cell],
+          };
+        }
+        return props;
+      },
+
+      transformBodyRow(props: BodyRowRenderProps, item: T) {
+        // Inject a hidden sentinel <td> that subscribes to this item's
+        // selection state and imperatively manages aria-selected +
+        // background on the parent <tr>. This avoids re-rendering the
+        // entire memoized row on selection change.
         return {
           ...props,
           children: (
             <>
-              <XDSTableHeaderCell xstyle={selectionCellStyles.base}>
-                <SelectAllCheckbox />
-              </XDSTableHeaderCell>
               {props.children}
+              <SelectionRowSentinel item={item} />
             </>
           ),
         };
       },
-
-      transformBodyRow(props: BodyRowRenderProps, item: T) {
-        // Don't read selection state here — that would cause all rows
-        // to re-render when any selection changes. Instead, delegate to
-        // SelectionRowContent which subscribes to the store and only
-        // re-renders when this specific item's selection state changes.
-        return {
-          ...props,
-          children: (
-            <SelectionRowContent item={item}>
-              {props.children}
-            </SelectionRowContent>
-          ),
-        };
-      },
     }),
-    [store],
+    [store, selectionColumn],
   );
 }

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -239,6 +239,8 @@ export interface TablePlugin<
 
 /** Props for row components used in the components prop */
 export interface TableRowComponentProps extends HTMLAttributes<HTMLTableRowElement> {
+  /** Ref forwarded to the root `<tr>` element */
+  ref?: Ref<HTMLTableRowElement>;
   children: ReactNode;
   xstyle?: StyleXStyles[];
 }

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -12,6 +12,7 @@
 import type {
   ComponentType,
   HTMLAttributes,
+  Ref,
   TdHTMLAttributes,
   ThHTMLAttributes,
   ReactNode,
@@ -170,6 +171,8 @@ export interface BodyRowRenderProps {
   htmlProps: HTMLAttributes<HTMLTableRowElement>;
   styles: StyleXStyles[];
   children: ReactNode;
+  /** Ref for the `<tr>` element. Plugins can set this to access the row DOM node. */
+  ref?: Ref<HTMLTableRowElement>;
 }
 
 /** Props passed through the plugin pipeline for each body `<td>` */
@@ -204,9 +207,7 @@ export interface TablePlugin<
    * Runs before any element-level transforms. Use to filter, reorder,
    * or inject synthetic columns (e.g. a selection checkbox column).
    */
-  transformColumns?: (
-    columns: XDSTableColumn<T>[],
-  ) => XDSTableColumn<T>[];
+  transformColumns?: (columns: XDSTableColumn<T>[]) => XDSTableColumn<T>[];
   /** Transform the root `<table>` element props */
   transformTable?: (props: TableRenderProps) => TableRenderProps;
   /** Transform the header `<tr>` props */


### PR DESCRIPTION
Phase 3 of XDSTable architecture review. All 232 tests pass including perf benchmarks.

**What changed:**
Selection plugin rewritten to use `transformColumns` for the checkbox column instead of injecting JSX into `transformHeaderRow`/`transformBodyRow`.

**Key improvements:**
- Checkbox column flows through the normal cell component pipeline — automatically respects `components` prop overrides on XDSBaseTable (fixes #13 from review)
- No more hardcoded `XDSTableCell`/`XDSTableHeaderCell` imports in the plugin
- String-encoded `useSyncExternalStore` snapshot replaced with numeric constants
- `areArraysShallowEqual` stabilizes resolved columns array to preserve row memoization

**What didn't change:**
Row-level styling (`aria-selected`, background) still uses imperative DOM via a hidden sentinel `<td>`. This preserves the fine-grained render isolation — selecting one row doesn't re-render other rows.

**Depends on:** #1062 (Phase 2c)