### PR TITLE
chore: remove stale typography.css references

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,11 +99,9 @@ xds/
 │
 ├── packages/
 │   ├── core/           # Core components (Button, Input, etc.)
-│   ├── foundations/    # Design tokens, typography, colors
-│   ├── patterns/       # Composed patterns (TablePage, FormWizard)
-│   ├── icons/          # Icon library
-│   ├── themes/         # Theme presets
-│   └── utils/          # Shared utilities
+│   ├── cli/            # CLI tooling (npx xds)
+│   ├── lab/            # Experimental components (not yet stable)
+│   └── themes/         # Theme presets (default, neutral, brutalist)
 │
 ├── internal/           # Internal tooling (not published)
 │   └── test-utils/     # Shared test helpers

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -67,7 +67,7 @@ const config: StorybookConfig = {
         // In Vite dev mode the StyleX unplugin's transformIndexHtml injects
         // a <link> for /virtual:stylex.css before preview.tsx CSS imports
         // are processed, which would otherwise cause priority1-9 layers to
-        // be declared first (lowest priority) and reset/typography last
+        // be declared first (lowest priority) and the reset layer last
         // (highest priority) — the reverse of what we need.
         {
           name: 'xds-css-layer-order',

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -5,7 +5,7 @@ import {defaultTheme} from '@xds/theme-default';
 import {neutralTheme} from '@xds/theme-neutral';
 import {brutalistTheme} from '@xds/theme-brutalist';
 
-// Import the base reset and typography stylesheets
+// Import the base reset stylesheet
 import '@xds/core/reset.css';
 
 /**
@@ -42,7 +42,6 @@ const withXDSTheme: Decorator = (Story, context) => {
   if (themeKey === 'none') {
     return (
       <div
-        className="xds-typography"
         style={{
           colorScheme: mode,
           padding: 16,
@@ -57,7 +56,6 @@ const withXDSTheme: Decorator = (Story, context) => {
   return (
     <XDSTheme theme={theme} mode={mode}>
       <div
-        className="xds-typography"
         style={{
           backgroundColor: 'var(--color-background-surface)',
           padding: 16,

--- a/packages/core/src/README.md
+++ b/packages/core/src/README.md
@@ -4,9 +4,8 @@ Source code for core UI components.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
-| File/Directory   | Role      | Purpose                                              |
-| ---------------- | --------- | ---------------------------------------------------- |
-| `index.ts`       | Entry     | Package entry point; re-exports all components       |
-| `reset.css`      | Styles    | Base CSS reset for consistent cross-browser defaults |
-| `typography.css` | Styles    | Prose typography styles for native HTML elements     |
-| `Button/`        | Component | Button component with variants and loading states    |
+| File/Directory | Role      | Purpose                                              |
+| -------------- | --------- | ---------------------------------------------------- |
+| `index.ts`     | Entry     | Package entry point; re-exports all components       |
+| `reset.css`    | Styles    | Base CSS reset for consistent cross-browser defaults |
+| `Button/`      | Component | Button component with variants and loading states    |

--- a/scripts/package-source.js
+++ b/scripts/package-source.js
@@ -68,7 +68,7 @@ function deriveSourceExports() {
   const sourceExports = {};
 
   for (const [key, value] of Object.entries(PKG.exports)) {
-    // Handle string exports (e.g., "./typography.css": "./src/typography.css")
+    // Handle string exports (e.g., "./reset.css": "./src/reset.css")
     if (typeof value === 'string') {
       if (value.startsWith('./src/')) {
         sourceExports[key] = value.replace('./src/', './');


### PR DESCRIPTION
## Summary

Removes all stale references to `typography.css` and fixes the CSS setup instructions across the codebase.

## Changes

| File | Fix |
|------|-----|
| `packages/core/src/README.md` | Remove `typography.css` row from file manifest |
| `scripts/package-source.js` | Update comment example from `typography.css` → `reset.css` |
| `apps/storybook/.storybook/preview.tsx` | Fix comment; remove dead `xds-typography` className (class was never defined in any CSS) |
| `apps/storybook/.storybook/main.ts` | Fix comment about CSS layer ordering |
| `CONTRIBUTING.md` | Update project structure to match actual packages (`cli/`, `lab/`, `themes/`) |
| `packages/core/README.md` | Fix Quick Start to include `xds.css` (pre-compiled component styles); add source-path callout |
| `packages/core/src/reset.css` | Fix comment: 'theme and typography' → 'base styles and theme' |

## CSS Setup (corrected)

**Standard (dist) path** — most consumers:
```tsx
import '@xds/core/reset.css';           // CSS reset
import '@xds/core/xds.css';             // Pre-compiled component styles
import '@xds/theme-default/theme.css';  // Theme tokens
```

**Source path** (with StyleX plugin) — skip `xds.css`, the plugin compiles styles at build time:
```tsx
import '@xds/core/reset.css';
import '@xds/theme-default/theme.css';
```

---
