### PR TITLE
feat(ci): add re-deploy preview link to PR comments

### DIFF
--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -150,6 +150,11 @@ let footerLinks = [];
 if (storybookUrl) footerLinks.push(extLink('Storybook', storybookUrl));
 if (sandboxUrl) footerLinks.push(extLink('Sandbox', sandboxUrl));
 if (runUrl) footerLinks.push(extLink('View full report', runUrl));
+if (prNumber) {
+  const repoUrl = 'https://github.com/facebookexperimental/xds';
+  const redeployUrl = `${repoUrl}/actions/workflows/redeploy-preview.yml`;
+  footerLinks.push(extLink('Re-deploy preview', redeployUrl));
+}
 const footerLinksStr = footerLinks.length > 0 ? ` | ${footerLinks.join(' | ')}` : '';
 
 // Build the full comment


### PR DESCRIPTION
## Summary
Adds a "Re-deploy preview" link to the PR bot comment footer, pointing to the `redeploy-preview.yml` workflow dispatch page. Makes it easy for anyone to re-trigger a preview deploy when the `deploy-preview` job gets cancelled due to concurrency contention.

## Changes
- **`.github/scripts/generate-pr-comment.js`** — adds a "Re-deploy preview" link to the footer when a PR number is available

## Before
```
Generated by PR Enrichment workflow | Storybook | Sandbox | View full report
```

## After
```
Generated by PR Enrichment workflow | Storybook | Sandbox | View full report | Re-deploy preview
```

Follow-up to #1063 which added the `Re-deploy Preview` workflow.

---
