### PR TITLE
test: storybook repro for SideNav heading overflow (#1069)

### DIFF
--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -415,7 +415,7 @@ export const HeadingOverflow: Story = {
   ],
   render: () => (
     <>
-      {/* Case 1: Long heading text */}
+      {/* Case 1: Long unbroken strings */}
       <div style={{width: 280, height: 400, border: '1px solid #e5e7eb'}}>
         <XDSSideNav
           header={
@@ -425,8 +425,8 @@ export const HeadingOverflow: Story = {
                   icon={<CubeIcon style={{width: 16, height: 16}} />}
                 />
               }
-              heading="Enterprise Content Management Platform"
-              superheading="verylongusernamethatshouldtruncate"
+              heading="this_is_a_long_unbroken_application_name"
+              superheading="very_long_unbroken_username_that_should_truncate"
               headingHref="/"
             />
           }>
@@ -442,7 +442,7 @@ export const HeadingOverflow: Story = {
         </XDSSideNav>
       </div>
 
-      {/* Case 2: Long heading + subheading + menu */}
+      {/* Case 2: Unbroken heading + subheading + menu */}
       <div style={{width: 280, height: 400, border: '1px solid #e5e7eb'}}>
         <XDSSideNav
           header={
@@ -452,8 +452,8 @@ export const HeadingOverflow: Story = {
                   icon={<CubeIcon style={{width: 16, height: 16}} />}
                 />
               }
-              heading="My Super Long Application Name Here"
-              subheading="really-long-business-account-name@company.com"
+              heading="my_super_long_unbroken_app_name_here"
+              subheading="really_long_business_account_name@company.com"
               menu={
                 <XDSList density="compact">
                   <XDSListItem label="Switch account" href="#" />
@@ -483,7 +483,7 @@ export const HeadingOverflow: Story = {
                   icon={<CubeIcon style={{width: 16, height: 16}} />}
                 />
               }
-              heading="Normal App Name"
+              heading="normal_app_name"
               superheading="username"
               headingHref="/"
             />

--- a/apps/storybook/stories/SideNav.stories.tsx
+++ b/apps/storybook/stories/SideNav.stories.tsx
@@ -394,3 +394,111 @@ export const HiddenSectionHeader: Story = {
     </XDSSideNav>
   ),
 };
+
+// =============================================================================
+// Bug Repro: Heading Overflow (#1069)
+// =============================================================================
+
+export const HeadingOverflow: Story = {
+  name: 'Bug #1069: Heading Overflow',
+  decorators: [
+    Story => (
+      <div
+        style={{
+          display: 'flex',
+          gap: 24,
+          alignItems: 'flex-start',
+        }}>
+        <Story />
+      </div>
+    ),
+  ],
+  render: () => (
+    <>
+      {/* Case 1: Long heading text */}
+      <div style={{width: 280, height: 400, border: '1px solid #e5e7eb'}}>
+        <XDSSideNav
+          header={
+            <XDSSideNavHeading
+              icon={
+                <XDSNavIcon
+                  icon={<CubeIcon style={{width: 16, height: 16}} />}
+                />
+              }
+              heading="Enterprise Content Management Platform"
+              superheading="verylongusernamethatshouldtruncate"
+              headingHref="/"
+            />
+          }>
+          <XDSSideNavSection title="Main">
+            <XDSSideNavItem
+              label="Dashboard"
+              icon={HomeIcon}
+              selectedIcon={HomeIconSolid}
+              isSelected
+            />
+            <XDSSideNavItem label="Projects" icon={FolderIcon} />
+          </XDSSideNavSection>
+        </XDSSideNav>
+      </div>
+
+      {/* Case 2: Long heading + subheading + menu */}
+      <div style={{width: 280, height: 400, border: '1px solid #e5e7eb'}}>
+        <XDSSideNav
+          header={
+            <XDSSideNavHeading
+              icon={
+                <XDSNavIcon
+                  icon={<CubeIcon style={{width: 16, height: 16}} />}
+                />
+              }
+              heading="My Super Long Application Name Here"
+              subheading="really-long-business-account-name@company.com"
+              menu={
+                <XDSList density="compact">
+                  <XDSListItem label="Switch account" href="#" />
+                </XDSList>
+              }
+            />
+          }>
+          <XDSSideNavSection title="Main">
+            <XDSSideNavItem
+              label="Dashboard"
+              icon={HomeIcon}
+              selectedIcon={HomeIconSolid}
+              isSelected
+            />
+            <XDSSideNavItem label="Projects" icon={FolderIcon} />
+          </XDSSideNavSection>
+        </XDSSideNav>
+      </div>
+
+      {/* Case 3: Narrow container — simulates resized sidebar */}
+      <div style={{width: 180, height: 400, border: '1px solid #e5e7eb'}}>
+        <XDSSideNav
+          header={
+            <XDSSideNavHeading
+              icon={
+                <XDSNavIcon
+                  icon={<CubeIcon style={{width: 16, height: 16}} />}
+                />
+              }
+              heading="Normal App Name"
+              superheading="username"
+              headingHref="/"
+            />
+          }>
+          <XDSSideNavSection title="Main">
+            <XDSSideNavItem
+              label="Dashboard"
+              icon={HomeIcon}
+              selectedIcon={HomeIconSolid}
+              isSelected
+            />
+            <XDSSideNavItem label="Projects" icon={FolderIcon} />
+          </XDSSideNavSection>
+        </XDSSideNav>
+      </div>
+    </>
+  ),
+};


### PR DESCRIPTION
Adds a storybook story that reproduces [#1069](https://github.com/facebookexperimental/xds/issues/1069) — the sidebar heading area growing larger than the sidebar itself.

Three cases side by side:
1. **Long heading + superheading** — long app name + long username
2. **Long heading + subheading + menu** — button trigger mode with a long email subheading
3. **Narrow container (180px)** — simulates a resized sidebar where even normal text overflows

Navigate to **Navigation / XDSSideNav / Bug #1069: Heading Overflow** in Storybook to see it.

Fixes https://github.com/facebookexperimental/xds/issues/1069