### PR TITLE
refactor(sandbox): use XDS layout components in templates

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/file-explorer/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/file-explorer/page.tsx
@@ -3,10 +3,15 @@
 import {useState, useMemo} from 'react';
 import {XDSButton} from '@xds/core/Button';
 import {XDSList, XDSListItem} from '@xds/core/List';
-import {XDSHStack, XDSVStack} from '@xds/core/Layout';
+import {
+  XDSHStack,
+  XDSVStack,
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSToolbar} from '@xds/core/Toolbar';
-import {XDSDivider} from '@xds/core';
 import {
   XDSSegmentedControl,
   XDSSegmentedControlItem,
@@ -610,16 +615,9 @@ const FONT =
 
 const inlineStyles = {
   page: {
-    display: 'flex',
-    flexDirection: 'column' as const,
-    height: '100vh',
-    width: '100vw',
-    overflow: 'hidden',
     userSelect: 'none' as const,
     fontFamily: FONT,
     backgroundColor: 'var(--xds-color-background-surface, #FFFFFF)',
-    position: 'fixed' as const,
-    inset: 0,
   },
   toolbar: {
     flexShrink: 0,
@@ -858,12 +856,15 @@ export default function FileExplorerPage() {
   }
 
   return (
-    <div style={inlineStyles.page}>
-      {/* Toolbar */}
-      <XDSToolbar
-        label="File Explorer"
-        padding={0}
-        style={inlineStyles.toolbar}
+    <XDSLayout
+      height="fill"
+      style={inlineStyles.page}
+      header={
+        <XDSLayoutHeader hasDivider padding={0}>
+          <XDSToolbar
+            label="File Explorer"
+            padding={0}
+            style={inlineStyles.toolbar}
         startContent={
           <XDSHStack gap={1} vAlign="center">
             <XDSButton
@@ -959,12 +960,13 @@ export default function FileExplorerPage() {
             />
           </XDSHStack>
         }
-      />
-
-      <XDSDivider />
-
-      {/* Columns */}
-      <XDSHStack style={inlineStyles.body}>
+          />
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent padding={0}>
+          {/* Columns */}
+          <XDSHStack style={inlineStyles.body}>
         {columns.map((col, colIndex) => {
           const isLast = colIndex === columns.length - 1;
           return (
@@ -1052,7 +1054,9 @@ export default function FileExplorerPage() {
             </XDSVStack>
           </div>
         )}
-      </XDSHStack>
-    </div>
+          </XDSHStack>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
@@ -2,12 +2,13 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
 import {XDSLink} from '@xds/core/Link';
 import {XDSDivider} from '@xds/core/Divider';
+import {XDSCenter} from '@xds/core/Center';
 import {
   colorVars,
   spacingVars,
@@ -73,30 +74,6 @@ const styles = stylex.create({
   imageBg: {
     backgroundColor: colorVars['--color-background-muted'],
   },
-  card: {
-    display: 'flex',
-    maxWidth: 900,
-    width: '100%',
-    backgroundColor: colorVars['--color-background-card'],
-    borderRadius: radiusVars['--radius-container'],
-    overflow: 'hidden',
-    boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-  },
-  formSide: {
-    flex: 1,
-    padding: spacingVars['--spacing-8'],
-    display: 'flex',
-    flexDirection: 'column',
-    justifyContent: 'center',
-  },
-  imageSide: {
-    flex: 1,
-    backgroundColor: colorVars['--color-background-muted'],
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    minHeight: 400,
-  },
   fullWidth: {
     width: '100%',
   },
@@ -131,168 +108,164 @@ export default function LoginTwoColumn() {
   const [password, setPassword] = useState('');
 
   return (
-    <div
-      {...stylex.props(styles.pageBg)}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: '100svh',
-        height: '100%',
-        padding: 24,
-        position: 'fixed',
-        inset: 0,
-        overflow: 'auto',
-        gap: 24,
-      }}>
-      {/* Card — inline styles to prevent StyleX cascade issues */}
-      <div
-        {...stylex.props(styles.cardBg)}
-        style={{
-          display: 'flex',
-          maxWidth: 900,
-          width: '100%',
-          overflow: 'hidden',
-          borderRadius: 12,
-          boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-        }}>
-        {/* Left — Form */}
-        <div
-          style={{
-            flex: 1,
-            padding: 32,
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
-          }}>
-          <XDSVStack gap={5}>
-            <div {...stylex.props(styles.centered)}>
-              <XDSVStack gap={1}>
-                <XDSHeading level={2}>Welcome back</XDSHeading>
-                <XDSText type="body" color="secondary" size="sm">
-                  Login to your Product Inc. account
-                </XDSText>
-              </XDSVStack>
-            </div>
+    <XDSLayout
+      height="fill"
+      xstyle={styles.pageBg}
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSCenter width="100%" height="100%">
+            <XDSVStack gap={5} hAlign="center" style={{padding: 24}}>
+              {/* Card — inline styles to prevent StyleX cascade issues */}
+              <div
+                {...stylex.props(styles.cardBg)}
+                style={{
+                  display: 'flex',
+                  maxWidth: 900,
+                  width: '100%',
+                  overflow: 'hidden',
+                  borderRadius: 12,
+                  boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
+                }}>
+                {/* Left — Form */}
+                <div
+                  style={{
+                    flex: 1,
+                    padding: 32,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    justifyContent: 'center',
+                  }}>
+                  <XDSVStack gap={5}>
+                    <div {...stylex.props(styles.centered)}>
+                      <XDSVStack gap={1}>
+                        <XDSHeading level={2}>Welcome back</XDSHeading>
+                        <XDSText type="body" color="secondary" size="sm">
+                          Login to your Product Inc. account
+                        </XDSText>
+                      </XDSVStack>
+                    </div>
 
-            <XDSVStack gap={4}>
-              <XDSTextInput
-                label="Email"
-                type="email"
-                placeholder="name@company.com"
-                value={email}
-                onChange={setEmail}
-              />
-              <XDSVStack gap={0}>
-                <div {...stylex.props(styles.passwordRow)}>
-                  <XDSText type="label">Password</XDSText>
-                  <XDSLink
-                    label="Forgot your password?"
-                    href="#"
-                    size="sm"
-                    color="secondary">
-                    Forgot your password?
-                  </XDSLink>
+                    <XDSVStack gap={4}>
+                      <XDSTextInput
+                        label="Email"
+                        type="email"
+                        placeholder="name@company.com"
+                        value={email}
+                        onChange={setEmail}
+                      />
+                      <XDSVStack gap={0}>
+                        <div {...stylex.props(styles.passwordRow)}>
+                          <XDSText type="label">Password</XDSText>
+                          <XDSLink
+                            label="Forgot your password?"
+                            href="#"
+                            size="sm"
+                            color="secondary">
+                            Forgot your password?
+                          </XDSLink>
+                        </div>
+                        <XDSTextInput
+                          label="Password"
+                          isLabelHidden
+                          type="password"
+                          value={password}
+                          onChange={setPassword}
+                        />
+                      </XDSVStack>
+                    </XDSVStack>
+
+                    <XDSButton
+                      label="Login"
+                      variant="primary"
+                      xstyle={styles.fullWidth}
+                    />
+
+                    <div {...stylex.props(styles.dividerRow)}>
+                      <div {...stylex.props(styles.dividerLine)}>
+                        <XDSDivider />
+                      </div>
+                      <XDSText type="supporting" color="secondary">
+                        Or continue with
+                      </XDSText>
+                      <div {...stylex.props(styles.dividerLine)}>
+                        <XDSDivider />
+                      </div>
+                    </div>
+
+                    <div {...stylex.props(styles.socialRow)}>
+                      <XDSButton
+                        label="Apple"
+                        variant="secondary"
+                        icon={<AppleIcon />}
+                        xstyle={styles.socialButton}>
+                        Apple
+                      </XDSButton>
+                      <XDSButton
+                        label="Google"
+                        variant="secondary"
+                        icon={<GoogleIcon />}
+                        xstyle={styles.socialButton}>
+                        Google
+                      </XDSButton>
+                      <XDSButton
+                        label="Meta"
+                        variant="secondary"
+                        icon={<MetaIcon />}
+                        xstyle={styles.socialButton}>
+                        Meta
+                      </XDSButton>
+                    </div>
+
+                    <div {...stylex.props(styles.centered)}>
+                      <XDSText type="supporting" color="secondary">
+                        Don&apos;t have an account?{' '}
+                        <XDSLink label="Sign up" href="#" type="supporting">
+                          Sign up
+                        </XDSLink>
+                      </XDSText>
+                    </div>
+                  </XDSVStack>
                 </div>
-                <XDSTextInput
-                  label="Password"
-                  isLabelHidden
-                  type="password"
-                  value={password}
-                  onChange={setPassword}
-                />
-              </XDSVStack>
+
+                {/* Right — Image placeholder */}
+                <div
+                  {...stylex.props(styles.imageBg)}
+                  style={{
+                    flex: 1,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    minHeight: 400,
+                  }}>
+                  <ImageIcon
+                    style={{
+                      width: 64,
+                      height: 64,
+                      opacity: 0.3,
+                      color: 'var(--color-text-disabled)',
+                    }}
+                  />
+                </div>
+              </div>
+
+              {/* Terms — outside card */}
+              <div {...stylex.props(styles.centered)}>
+                <XDSText type="supporting" color="secondary">
+                  By clicking continue, you agree to our{' '}
+                  <XDSLink label="Terms of Service" href="#" type="supporting">
+                    Terms of Service
+                  </XDSLink>{' '}
+                  and{' '}
+                  <XDSLink label="Privacy Policy" href="#" type="supporting">
+                    Privacy Policy
+                  </XDSLink>
+                  .
+                </XDSText>
+              </div>
             </XDSVStack>
-
-            <XDSButton
-              label="Login"
-              variant="primary"
-              xstyle={styles.fullWidth}
-            />
-
-            <div {...stylex.props(styles.dividerRow)}>
-              <div {...stylex.props(styles.dividerLine)}>
-                <XDSDivider />
-              </div>
-              <XDSText type="supporting" color="secondary">
-                Or continue with
-              </XDSText>
-              <div {...stylex.props(styles.dividerLine)}>
-                <XDSDivider />
-              </div>
-            </div>
-
-            <div {...stylex.props(styles.socialRow)}>
-              <XDSButton
-                label="Apple"
-                variant="secondary"
-                icon={<AppleIcon />}
-                xstyle={styles.socialButton}>
-                Apple
-              </XDSButton>
-              <XDSButton
-                label="Google"
-                variant="secondary"
-                icon={<GoogleIcon />}
-                xstyle={styles.socialButton}>
-                Google
-              </XDSButton>
-              <XDSButton
-                label="Meta"
-                variant="secondary"
-                icon={<MetaIcon />}
-                xstyle={styles.socialButton}>
-                Meta
-              </XDSButton>
-            </div>
-
-            <div {...stylex.props(styles.centered)}>
-              <XDSText type="supporting" color="secondary">
-                Don&apos;t have an account?{' '}
-                <XDSLink label="Sign up" href="#" type="supporting">
-                  Sign up
-                </XDSLink>
-              </XDSText>
-            </div>
-          </XDSVStack>
-        </div>
-
-        {/* Right — Image placeholder */}
-        <div
-          {...stylex.props(styles.imageBg)}
-          style={{
-            flex: 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            minHeight: 400,
-          }}>
-          <ImageIcon
-            style={{
-              width: 64,
-              height: 64,
-              opacity: 0.3,
-              color: 'var(--color-text-disabled)',
-            }}
-          />
-        </div>
-      </div>
-
-      {/* Terms — outside card */}
-      <div {...stylex.props(styles.centered)}>
-        <XDSText type="supporting" color="secondary">
-          By clicking continue, you agree to our{' '}
-          <XDSLink label="Terms of Service" href="#" type="supporting">
-            Terms of Service
-          </XDSLink>{' '}
-          and{' '}
-          <XDSLink label="Privacy Policy" href="#" type="supporting">
-            Privacy Policy
-          </XDSLink>
-          .
-        </XDSText>
-      </div>
-    </div>
+          </XDSCenter>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -2,13 +2,14 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSLayout, XDSLayoutContent} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCard} from '@xds/core/Card';
 import {XDSLink} from '@xds/core/Link';
 import {XDSDivider} from '@xds/core/Divider';
+import {XDSCenter} from '@xds/core/Center';
 import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 
 const LogoIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -92,137 +93,132 @@ export default function LoginSimple() {
   const [password, setPassword] = useState('');
 
   return (
-    <div
-      {...stylex.props(styles.pageBg)}
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: '100svh',
-        height: '100%',
+    <XDSLayout
+      height="fill"
+      xstyle={styles.pageBg}
+      content={
+        <XDSLayoutContent padding={0}>
+          <XDSCenter width="100%" height="100%">
+            <XDSVStack gap={5} hAlign="center" style={{padding: 24}}>
+              {/* Logo — outside card */}
+              <XDSVStack gap={2} hAlign="center">
+                <LogoIcon />
+                <XDSText type="body" weight="bold" size="lg">
+                  Product Inc.
+                </XDSText>
+              </XDSVStack>
 
-        padding: 24,
-        position: 'fixed',
-        inset: 0,
-        overflow: 'auto',
-        gap: 24,
-      }}>
-      {/* Logo — outside card */}
-      <XDSVStack gap={2} hAlign="center">
-        <LogoIcon />
-        <XDSText type="body" weight="bold" size="lg">
-          Product Inc.
-        </XDSText>
-      </XDSVStack>
+              {/* Card */}
+              <XDSCard padding={6} width={400}>
+                <XDSVStack gap={5}>
+                  {/* Header */}
+                  <div {...stylex.props(styles.centered)}>
+                    <XDSVStack gap={1}>
+                      <XDSHeading level={2}>Welcome back</XDSHeading>
+                      <XDSText type="body" color="secondary" size="sm">
+                        Login with your Apple or Google account
+                      </XDSText>
+                    </XDSVStack>
+                  </div>
 
-      {/* Card */}
-      <XDSCard padding={6} width={400}>
-        <XDSVStack gap={5}>
-          {/* Header */}
-          <div {...stylex.props(styles.centered)}>
-            <XDSVStack gap={1}>
-              <XDSHeading level={2}>Welcome back</XDSHeading>
-              <XDSText type="body" color="secondary" size="sm">
-                Login with your Apple or Google account
-              </XDSText>
-            </XDSVStack>
-          </div>
+                  {/* Social buttons */}
+                  <XDSVStack gap={3}>
+                    <XDSButton
+                      label="Login with Apple"
+                      variant="secondary"
+                      icon={<AppleIcon />}
+                      xstyle={styles.fullWidth}>
+                      Login with Apple
+                    </XDSButton>
+                    <XDSButton
+                      label="Login with Google"
+                      variant="secondary"
+                      icon={<GoogleIcon />}
+                      xstyle={styles.fullWidth}>
+                      Login with Google
+                    </XDSButton>
+                  </XDSVStack>
 
-          {/* Social buttons */}
-          <XDSVStack gap={3}>
-            <XDSButton
-              label="Login with Apple"
-              variant="secondary"
-              icon={<AppleIcon />}
-              xstyle={styles.fullWidth}>
-              Login with Apple
-            </XDSButton>
-            <XDSButton
-              label="Login with Google"
-              variant="secondary"
-              icon={<GoogleIcon />}
-              xstyle={styles.fullWidth}>
-              Login with Google
-            </XDSButton>
-          </XDSVStack>
+                  {/* Divider */}
+                  <div {...stylex.props(styles.dividerRow)}>
+                    <div {...stylex.props(styles.dividerLine)}>
+                      <XDSDivider />
+                    </div>
+                    <XDSText type="supporting" color="secondary">
+                      Or continue with
+                    </XDSText>
+                    <div {...stylex.props(styles.dividerLine)}>
+                      <XDSDivider />
+                    </div>
+                  </div>
 
-          {/* Divider */}
-          <div {...stylex.props(styles.dividerRow)}>
-            <div {...stylex.props(styles.dividerLine)}>
-              <XDSDivider />
-            </div>
-            <XDSText type="supporting" color="secondary">
-              Or continue with
-            </XDSText>
-            <div {...stylex.props(styles.dividerLine)}>
-              <XDSDivider />
-            </div>
-          </div>
+                  {/* Form fields */}
+                  <XDSVStack gap={4}>
+                    <XDSTextInput
+                      label="Email"
+                      type="email"
+                      placeholder="name@company.com"
+                      value={email}
+                      onChange={setEmail}
+                    />
+                    <XDSVStack gap={0}>
+                      <div {...stylex.props(styles.passwordRow)}>
+                        <XDSText type="label">Password</XDSText>
+                        <XDSLink
+                          label="Forgot your password?"
+                          href="#"
+                          size="sm"
+                          color="secondary">
+                          Forgot password?
+                        </XDSLink>
+                      </div>
+                      <XDSTextInput
+                        label="Password"
+                        isLabelHidden
+                        type="password"
+                        value={password}
+                        onChange={setPassword}
+                      />
+                    </XDSVStack>
+                  </XDSVStack>
 
-          {/* Form fields */}
-          <XDSVStack gap={4}>
-            <XDSTextInput
-              label="Email"
-              type="email"
-              placeholder="name@company.com"
-              value={email}
-              onChange={setEmail}
-            />
-            <XDSVStack gap={0}>
-              <div {...stylex.props(styles.passwordRow)}>
-                <XDSText type="label">Password</XDSText>
-                <XDSLink
-                  label="Forgot your password?"
-                  href="#"
-                  size="sm"
-                  color="secondary">
-                  Forgot password?
-                </XDSLink>
+                  {/* Login button */}
+                  <XDSButton
+                    label="Login"
+                    variant="primary"
+                    xstyle={styles.fullWidth}
+                  />
+
+                  {/* Sign up link */}
+                  <div {...stylex.props(styles.centered)}>
+                    <XDSText type="supporting" color="secondary">
+                      Don&apos;t have an account?{' '}
+                      <XDSLink label="Sign up" href="#" type="supporting">
+                        Sign up
+                      </XDSLink>
+                    </XDSText>
+                  </div>
+                </XDSVStack>
+              </XDSCard>
+
+              {/* Terms — outside card */}
+              <div style={{textAlign: 'center', maxWidth: 400}}>
+                <XDSText type="supporting" color="secondary">
+                  By clicking continue, you agree to our{' '}
+                  <XDSLink label="Terms of Service" href="#" type="supporting">
+                    Terms of Service
+                  </XDSLink>{' '}
+                  and{' '}
+                  <XDSLink label="Privacy Policy" href="#" type="supporting">
+                    Privacy Policy
+                  </XDSLink>
+                  .
+                </XDSText>
               </div>
-              <XDSTextInput
-                label="Password"
-                isLabelHidden
-                type="password"
-                value={password}
-                onChange={setPassword}
-              />
             </XDSVStack>
-          </XDSVStack>
-
-          {/* Login button */}
-          <XDSButton
-            label="Login"
-            variant="primary"
-            xstyle={styles.fullWidth}
-          />
-
-          {/* Sign up link */}
-          <div {...stylex.props(styles.centered)}>
-            <XDSText type="supporting" color="secondary">
-              Don&apos;t have an account?{' '}
-              <XDSLink label="Sign up" href="#" type="supporting">
-                Sign up
-              </XDSLink>
-            </XDSText>
-          </div>
-        </XDSVStack>
-      </XDSCard>
-
-      {/* Terms — outside card */}
-      <div style={{textAlign: 'center', maxWidth: 400}}>
-        <XDSText type="supporting" color="secondary">
-          By clicking continue, you agree to our{' '}
-          <XDSLink label="Terms of Service" href="#" type="supporting">
-            Terms of Service
-          </XDSLink>{' '}
-          and{' '}
-          <XDSLink label="Privacy Policy" href="#" type="supporting">
-            Privacy Policy
-          </XDSLink>
-          .
-        </XDSText>
-      </div>
-    </div>
+          </XDSCenter>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings-02/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings-02/page.tsx
@@ -2,7 +2,12 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSLayout,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+} from '@xds/core/Layout';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
@@ -119,30 +124,11 @@ export default function SettingsSecurityTemplate() {
   const [aiFeatures, setAiFeatures] = useState(true);
 
   return (
-    <div
-      {...stylex.props(styles.pageBg)}
-      style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
-      {/* Body — constrained */}
-      <div
-        style={{
-          display: 'flex',
-          flex: 1,
-          maxWidth: 1000,
-          margin: '0 auto',
-          width: '100%',
-        }}>
-        {/* Sidebar */}
-        <nav
-          style={{
-            width: 280,
-            paddingTop: 16,
-            paddingLeft: 12,
-            paddingRight: 12,
-            paddingBottom: 16,
-            borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)',
-            flexShrink: 0,
-            overflowY: 'auto',
-          }}>
+    <XDSLayout
+      height="fill"
+      xstyle={styles.pageBg}
+      start={
+        <XDSLayoutPanel width={280} hasDivider padding={3}>
           <XDSVStack gap={4}>
             <div style={{paddingLeft: 16, paddingRight: 16}}>
               <XDSHeading level={2}>Account settings</XDSHeading>
@@ -169,18 +155,10 @@ export default function SettingsSecurityTemplate() {
               />
             </XDSList>
           </XDSVStack>
-        </nav>
-
-        {/* Content */}
-        <div
-          style={{
-            flex: 1,
-            paddingTop: 16,
-            paddingLeft: 32,
-            paddingRight: 32,
-            paddingBottom: 16,
-            overflowY: 'auto',
-          }}>
+        </XDSLayoutPanel>
+      }
+      content={
+        <XDSLayoutContent padding={6}>
           {activeNav === 'Login & security' && (
             <XDSVStack gap={6}>
               <XDSHeading level={2}>Login &amp; security</XDSHeading>
@@ -549,8 +527,8 @@ export default function SettingsSecurityTemplate() {
               </XDSVStack>
             </XDSVStack>
           )}
-        </div>
-      </div>
-    </div>
+        </XDSLayoutContent>
+      }
+    />
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings/page.tsx
@@ -2,7 +2,13 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+} from '@xds/core/Layout';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
@@ -70,61 +76,38 @@ export default function SettingsTemplate() {
   );
 
   return (
-    <div
-      style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
-      {/* Header — full width with edge-to-edge divider */}
-      <div
-        style={{
-          borderBottom: '1px solid var(--xds-color-border-primary, #e5e5e5)',
-          flexShrink: 0,
-        }}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            padding: '16px 16px',
-            maxWidth: 1000,
-            margin: '0 auto',
-          }}>
-          <XDSHeading level={1}>Settings</XDSHeading>
-          <div style={{width: 344}}>
-            <XDSTypeahead
-              label="Search"
-              isLabelHidden
-              placeholder="Search settings..."
-              searchSource={settingsSearchSource}
-              value={searchValue}
-              onChange={setSearchValue}
-              hasEntriesOnFocus
-              startIcon={MagnifyingGlassIcon}
-            />
+    <XDSLayout
+      height="fill"
+      header={
+        <XDSLayoutHeader hasDivider padding={0}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: '16px 16px',
+              maxWidth: 1000,
+              margin: '0 auto',
+              width: '100%',
+            }}>
+            <XDSHeading level={1}>Settings</XDSHeading>
+            <div style={{width: 344}}>
+              <XDSTypeahead
+                label="Search"
+                isLabelHidden
+                placeholder="Search settings..."
+                searchSource={settingsSearchSource}
+                value={searchValue}
+                onChange={setSearchValue}
+                hasEntriesOnFocus
+                startIcon={MagnifyingGlassIcon}
+              />
+            </div>
           </div>
-        </div>
-      </div>
-
-      {/* Body — constrained */}
-      <div
-        style={{
-          display: 'flex',
-          flex: 1,
-          overflow: 'hidden',
-          maxWidth: 1000,
-          margin: '0 auto',
-          width: '100%',
-        }}>
-        {/* Sidebar */}
-        <nav
-          style={{
-            width: 240,
-            paddingTop: 16,
-            paddingLeft: 12,
-            paddingRight: 12,
-            paddingBottom: 8,
-            borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)',
-            flexShrink: 0,
-            overflowY: 'auto',
-          }}>
+        </XDSLayoutHeader>
+      }
+      start={
+        <XDSLayoutPanel width={240} hasDivider padding={3}>
           <XDSList density="compact">
             {NAV_ITEMS.map(item => (
               <XDSListItem
@@ -135,10 +118,10 @@ export default function SettingsTemplate() {
               />
             ))}
           </XDSList>
-        </nav>
-
-        {/* Content */}
-        <div style={{flex: 1, padding: 16, maxWidth: 960, overflowY: 'auto'}}>
+        </XDSLayoutPanel>
+      }
+      content={
+        <XDSLayoutContent padding={4}>
           <XDSVStack gap={4}>
             {/* Basic information */}
             <div
@@ -273,8 +256,8 @@ export default function SettingsTemplate() {
               </div>
             </div>
           </XDSVStack>
-        </div>
-      </div>
-    </div>
+        </XDSLayoutContent>
+      }
+    />
   );
 }


### PR DESCRIPTION
Refactors the 5 sandbox template pages (settings ×2, login ×2, file explorer) to use proper XDS layout components instead of hardcoded inline styles.

## What changed

### Anti-patterns removed
- `maxWidth + margin: '0 auto'` → `XDSLayout` with proper slots
- `position: fixed; inset: 0` → `XDSLayout` + `XDSCenter`
- Inline flex/grid for page structure → `XDSLayout` header/start/content slots
- Hardcoded border dividers → `hasDivider` prop on layout slots

### Components now used
- `XDSLayout` — page shell with header, start, content slots
- `XDSLayoutHeader` — top bar with `hasDivider`
- `XDSLayoutContent` — scrollable main content
- `XDSLayoutPanel` — side panel in start slot
- `XDSCenter` — centering for login templates

### Why
Ernest noticed the templates use hardcoded inline styles instead of XDS layout components — this is an anti-pattern when the XDS CLI template system exists for exactly this purpose. These templates should be reference implementations that demonstrate proper XDS usage.

### Visual behavior
All templates should look and behave identically. This is purely a structural refactor.