### PR TITLE
fix(ci): reliable PR preview deploys with retry-based push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,12 +184,14 @@ jobs:
         run: |
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
           MAX_ATTEMPTS=5
+          WORK_DIR="$PWD"
 
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
+            cd "$WORK_DIR"
 
             rm -rf /tmp/gh-pages
             git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" /tmp/gh-pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,17 +153,17 @@ jobs:
           path: analysis.json
           retention-days: 1
 
-  # Deploy PR preview to GitHub Pages in its own job with a concurrency group
-  # that matches deploy.yml ("pages-deploy"). This prevents race conditions
-  # where a main branch deploy (keep_files:false) overwrites a PR preview
-  # that was just deployed, or vice versa.
+  # Deploy PR preview to GitHub Pages.
+  # Uses a per-PR concurrency group so multiple PRs deploy in parallel.
+  # Instead of peaceiris/actions-gh-pages (which can conflict with main's
+  # force-push), we do a manual git push with retry-on-conflict.
   deploy-preview:
     if: github.event_name == 'pull_request'
     needs: [build]
     runs-on: ubuntu-latest
     concurrency:
-      group: "pages-deploy"
-      cancel-in-progress: false
+      group: "pr-preview-${{ needs.build.outputs.pr_number }}"
+      cancel-in-progress: true
     steps:
       - name: Download Storybook artifact
         uses: actions/download-artifact@v4
@@ -177,25 +177,46 @@ jobs:
           name: sandbox-${{ needs.build.outputs.short_hash }}
           path: sandbox-dist
 
-      - name: Prepare PR preview
-        run: |
-          PR_NUMBER="${{ needs.build.outputs.pr_number }}"
-
-          mkdir -p deploy/pr/${PR_NUMBER}
-          cp -r storybook-dist/* deploy/pr/${PR_NUMBER}/
-
-          mkdir -p deploy/pr/${PR_NUMBER}/sandbox
-          cp -r sandbox-dist/* deploy/pr/${PR_NUMBER}/sandbox/
-
-          touch deploy/.nojekyll
-
       - name: Deploy PR preview to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./deploy
-          keep_files: true
-          destination_dir: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.build.outputs.pr_number }}
+        run: |
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          MAX_ATTEMPTS=5
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
+
+            rm -rf /tmp/gh-pages
+            git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" /tmp/gh-pages
+
+            rm -rf /tmp/gh-pages/pr/${PR_NUMBER}
+            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
+            cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
+            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
+            cp -r sandbox-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
+
+            cd /tmp/gh-pages
+            git add -A
+            git commit -m "Deploy PR #${PR_NUMBER} preview" || { echo "Nothing to commit"; echo "::endgroup::"; exit 0; }
+
+            if git push origin gh-pages; then
+              echo "Deployed successfully on attempt $attempt"
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "Push failed (likely concurrent update), retrying in $((attempt * 2))s..."
+            echo "::endgroup::"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to deploy PR preview after $MAX_ATTEMPTS attempts"
+          exit 1
 
   # Post PR comment with preview links + analysis as soon as build finishes
   # Does NOT wait for test or a11y — those update the comment later

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -72,12 +72,14 @@ jobs:
         run: |
           REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
           MAX_ATTEMPTS=5
+          WORK_DIR="$PWD"
 
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
           for attempt in $(seq 1 $MAX_ATTEMPTS); do
             echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
+            cd "$WORK_DIR"
 
             rm -rf /tmp/gh-pages
             git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" /tmp/gh-pages

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -1,8 +1,8 @@
 # Re-deploy Preview
 #
 # Manually re-deploys a PR's preview build (Storybook + Sandbox) to GitHub Pages.
-# Use this when a PR's deploy-preview job was cancelled due to concurrency contention
-# in the pages-deploy group. Enter the PR number and click "Run workflow".
+# Uses a retry-based git push instead of peaceiris/actions-gh-pages to avoid
+# concurrency conflicts with the main deploy workflow.
 
 name: Re-deploy Preview
 
@@ -22,8 +22,8 @@ permissions:
   actions: read
 
 concurrency:
-  group: "pages-deploy"
-  cancel-in-progress: false
+  group: "pr-preview-${{ github.event.inputs.pr_number }}"
+  cancel-in-progress: true
 
 jobs:
   redeploy-preview:
@@ -66,18 +66,42 @@ jobs:
           SANDBOX_BASE_PATH: /pr/${{ github.event.inputs.pr_number }}/sandbox
         run: yarn workspace @xds/sandbox build
 
-      - name: Prepare deployment directory
-        run: |
-          mkdir -p deploy/pr/${PR_NUMBER}
-          cp -r apps/storybook/dist/* deploy/pr/${PR_NUMBER}/
-          mkdir -p deploy/pr/${PR_NUMBER}/sandbox
-          cp -r apps/sandbox/out/* deploy/pr/${PR_NUMBER}/sandbox/
-          touch deploy/.nojekyll
-
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./deploy
-          keep_files: true
-          destination_dir: .
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          MAX_ATTEMPTS=5
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
+
+            rm -rf /tmp/gh-pages
+            git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" /tmp/gh-pages
+
+            rm -rf /tmp/gh-pages/pr/${PR_NUMBER}
+            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
+            cp -r apps/storybook/dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
+            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
+            cp -r apps/sandbox/out/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
+
+            cd /tmp/gh-pages
+            git add -A
+            git commit -m "Deploy PR #${PR_NUMBER} preview" || { echo "Nothing to commit"; echo "::endgroup::"; exit 0; }
+
+            if git push origin gh-pages; then
+              echo "Deployed successfully on attempt $attempt"
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "Push failed (likely concurrent update), retrying in $((attempt * 2))s..."
+            echo "::endgroup::"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to deploy PR preview after $MAX_ATTEMPTS attempts"
+          exit 1


### PR DESCRIPTION
## Summary
- PR preview deploys were getting cancelled because they shared a `concurrency: group: "pages-deploy"` with main deploys. GitHub Actions only allows 1 running + 1 pending per group — additional runs cancel the pending one.
- Replaced `peaceiris/actions-gh-pages` with a manual git push that retries on conflict (up to 5 attempts with backoff). Each retry re-clones `gh-pages` fresh, so it handles force-pushes from main deploys gracefully.
- Changed to per-PR concurrency groups (`pr-preview-<number>`) so different PRs deploy in parallel without blocking each other.

Supersedes #1073 (which added a "Re-deploy preview" manual trigger as a workaround).

## What changed
| Before | After |
|--------|-------|
| All preview deploys queue behind main deploys | Preview deploys run independently |
| Multiple PR previews cancel each other | Each PR has its own concurrency group |
| Uses `peaceiris/actions-gh-pages` (clone → modify → force push) | Manual git push with retry on conflict |

## Files
- `.github/workflows/ci.yml` — `deploy-preview` job
- `.github/workflows/redeploy-preview.yml` — manual re-deploy workflow

## Test plan
- [ ] Push to two PRs simultaneously — both should deploy without cancellation
- [ ] Push to main while a PR preview is deploying — both should succeed
- [ ] Verify preview URLs work after deploy (`/pr/<number>/` and `/pr/<number>/sandbox/`)