### PR TITLE
fix: make multi-selector checkboxes decorative to fix label click toggle

### DIFF
--- a/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
@@ -403,6 +403,43 @@ describe('XDSMultiSelector', () => {
     expect(onChange).toHaveBeenCalledWith([]);
   });
 
+  it('select-all is a role="option" in the listbox', async () => {
+    const user = userEvent.setup();
+    render(
+      <XDSMultiSelector
+        label="Fruit"
+        options={defaultOptions}
+        value={[]}
+        onChange={() => {}}
+        hasSelectAll
+      />,
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    const options = screen.getAllByRole('option', h);
+    expect(options[0]).toHaveTextContent('Select all');
+  });
+
+  it('select-all toggles via keyboard Enter', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <XDSMultiSelector
+        label="Fruit"
+        options={defaultOptions}
+        value={[]}
+        onChange={onChange}
+        hasSelectAll
+      />,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    // highlightedIndex starts at 0 which is select-all
+    await user.keyboard('{Enter}');
+    expect(onChange).toHaveBeenCalledWith(['Apple', 'Banana', 'Orange']);
+  });
+
   it('renders search input when hasSearch', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
@@ -356,7 +356,7 @@ describe('XDSMultiSelector', () => {
     );
 
     await user.click(screen.getByRole('combobox'));
-    expect(screen.getByLabelText('Select all', h)).toBeInTheDocument();
+    expect(screen.getByText('Select all')).toBeInTheDocument();
   });
 
   it('select-all selects all enabled items', async () => {
@@ -377,7 +377,7 @@ describe('XDSMultiSelector', () => {
     );
 
     await user.click(screen.getByRole('combobox'));
-    const selectAll = screen.getByLabelText('Select all', h);
+    const selectAll = screen.getByText('Select all');
     await user.click(selectAll);
 
     expect(onChange).toHaveBeenCalledWith(['apple', 'orange']);
@@ -397,7 +397,7 @@ describe('XDSMultiSelector', () => {
     );
 
     await user.click(screen.getByRole('combobox'));
-    const selectAll = screen.getByLabelText('Select all', h);
+    const selectAll = screen.getByText('Select all');
     await user.click(selectAll);
 
     expect(onChange).toHaveBeenCalledWith([]);
@@ -539,7 +539,7 @@ describe('XDSMultiSelector', () => {
     );
 
     await user.click(screen.getByRole('combobox'));
-    expect(screen.getByLabelText('Check all', h)).toBeInTheDocument();
+    expect(screen.getByText('Check all')).toBeInTheDocument();
   });
 
   it('sorts selected items to top', async () => {

--- a/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.test.tsx
@@ -284,6 +284,28 @@ describe('XDSMultiSelector', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('closes combobox on Tab and moves focus to next element', async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <XDSMultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+        />
+        <button>Next</button>
+      </>,
+    );
+
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    await user.keyboard('{Tab}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('supports keyboard navigation with ArrowDown/ArrowUp', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -555,9 +555,9 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     );
   }, [selectableItems, searchQuery]);
 
-  // Sorted items for keyboard navigation — matches the visual render order.
-  // Selected-at-open items are placed first so the highlight index and the
-  // toggle target always refer to the same item the user sees.
+  // Single source of truth for item order. Both the hook (keyboard navigation)
+  // and renderOptions (DOM rendering) consume this list — no independent sorting.
+  // Selected-at-open items are placed first within each group/section.
   const sortedItems = useMemo(() => {
     const selectedSet = selectedAtOpenRef.current ?? new Set(optimisticValue);
     if (searchQuery) {
@@ -902,72 +902,47 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     ],
   );
 
-  // Render all options (handling sections/dividers and search filtering)
+  // Render all options. Uses sortedItems as the single source of truth for
+  // item order — no independent sorting here. Structural elements (dividers,
+  // section headers) come from the original options prop.
   const renderOptions = useCallback(() => {
-    // Use the open-time snapshot for sort partitioning (stable during interaction).
-    // Falls back to live value when dropdown isn't open yet.
-    const selectedSet = selectedAtOpenRef.current ?? new Set(optimisticValue);
-
     if (searchQuery) {
-      // Sort filtered: selected-at-open first, then unselected
-      const selected = filteredItems.filter(item =>
-        selectedSet.has(item.value),
-      );
-      const unselected = filteredItems.filter(
-        item => !selectedSet.has(item.value),
-      );
-      const sorted = [...selected, ...unselected];
-
-      if (sorted.length === 0) {
+      // In search mode, sortedItems is already filtered and sorted
+      if (sortedItems.length === 0) {
         return <div {...stylex.props(styles.emptyState)}>No results found</div>;
       }
-      return sorted.map(item => renderItem(item));
+      return sortedItems.map(item => renderItem(item));
     }
 
-    // Normal rendering with selected-first sorting (using open-time snapshot)
+    // Non-search: consume items from sortedItems in order, interleaving
+    // structural elements (dividers, section headers) from the options prop.
+    // sortedItems was built by the same iteration pattern over options, so
+    // the cursor stays in sync with the structural boundaries.
+    let cursor = 0;
     const elements: ReactNode[] = [];
-    let pendingFlatItems: Array<{
-      item: XDSMultiSelectorOptionData;
-    }> = [];
+    let pendingCount = 0;
 
-    const flushFlatItems = () => {
-      if (pendingFlatItems.length === 0) return;
-      const selected = pendingFlatItems.filter(({item}) =>
-        selectedSet.has(item.value),
-      );
-      const unselected = pendingFlatItems.filter(
-        ({item}) => !selectedSet.has(item.value),
-      );
-      const sorted = [...selected, ...unselected];
-      for (const {item} of sorted) {
-        elements.push(renderItem(item));
+    const flushPending = () => {
+      for (let j = 0; j < pendingCount; j++) {
+        elements.push(renderItem(sortedItems[cursor++]));
       }
-      pendingFlatItems = [];
+      pendingCount = 0;
     };
 
     for (let i = 0; i < options.length; i++) {
       const option = options[i];
 
       if (isDivider(option)) {
-        flushFlatItems();
+        flushPending();
         elements.push(
           <XDSDivider key={`divider-${i}`} xstyle={styles.divider} />,
         );
       } else if (isSection(option)) {
-        flushFlatItems();
-        // Sort within section: selected-at-open first
-        const sectionOptions = option.options.map(opt => normalizeOption(opt));
-        const selectedInSection = sectionOptions.filter(item =>
-          selectedSet.has(item.value),
-        );
-        const unselectedInSection = sectionOptions.filter(
-          item => !selectedSet.has(item.value),
-        );
-        const sortedSection = [...selectedInSection, ...unselectedInSection];
-
+        flushPending();
+        const count = option.options.length;
         const sectionItems: ReactNode[] = [];
-        for (const item of sortedSection) {
-          sectionItems.push(renderItem(item));
+        for (let j = 0; j < count; j++) {
+          sectionItems.push(renderItem(sortedItems[cursor++]));
         }
         if (option.title) {
           elements.push(
@@ -984,13 +959,13 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
           </div>,
         );
       } else if (isOptionData(option)) {
-        pendingFlatItems.push({item: normalizeOption(option)});
+        pendingCount++;
       }
     }
-    flushFlatItems();
+    flushPending();
 
     return elements;
-  }, [options, renderItem, filteredItems, searchQuery, optimisticValue]);
+  }, [options, renderItem, sortedItems, searchQuery]);
 
   return (
     <XDSField

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -63,6 +63,9 @@ import {useMultiCombobox} from './hooks';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSBaseProps} from '../XDSBaseProps';
 
+// Sentinel value for the select-all item in keyboard navigation
+const SELECT_ALL_VALUE = '__xds_select_all__';
+
 const styles = stylex.create({
   // Trigger button
   trigger: {
@@ -640,35 +643,6 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     ],
   );
 
-  // Multi-select combobox behavior
-  const {
-    highlightedIndex,
-    getItemId,
-    onTriggerClick,
-    onKeyDown,
-    onItemMouseEnter,
-  } = useMultiCombobox({
-    selectableItems: sortedItems,
-    isDisabled,
-    isOpen: popover.isOpen,
-    hasSearch,
-    onOpen: useCallback(() => {
-      // Snapshot which items are selected at open time — sort is stable during interaction
-      selectedAtOpenRef.current = new Set(optimisticValue);
-
-      popover.show();
-      if (hasSearch) {
-        // Focus search after popover opens
-        requestAnimationFrame(() => {
-          searchRef.current?.focus();
-        });
-      }
-    }, [popover, hasSearch, filteredItems, optimisticValue]),
-    onClose: popover.hide,
-    onToggle: handleToggle,
-    listboxId,
-  });
-
   // Select-all logic
   const enabledItems = useMemo(
     () => filteredItems.filter(item => !item.disabled),
@@ -726,6 +700,60 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     startTransition,
     setOptimisticValue,
   ]);
+
+  // Prepend a synthetic select-all item so it participates in keyboard navigation
+  const navigableItems = useMemo(() => {
+    if (!hasSelectAll) return sortedItems;
+    const selectAllItem: XDSMultiSelectorOptionData = {
+      value: SELECT_ALL_VALUE,
+      label: selectAllLabel,
+    };
+    return [selectAllItem, ...sortedItems];
+  }, [hasSelectAll, sortedItems, selectAllLabel]);
+
+  // Offset for flat indices: when select-all is present, regular items start at index 1
+  const itemIndexOffset = hasSelectAll ? 1 : 0;
+
+  // Route toggle: select-all sentinel → handleSelectAll, everything else → handleToggle
+  const handleNavigableToggle = useCallback(
+    (itemValue: string) => {
+      if (itemValue === SELECT_ALL_VALUE) {
+        handleSelectAll();
+      } else {
+        handleToggle(itemValue);
+      }
+    },
+    [handleSelectAll, handleToggle],
+  );
+
+  // Multi-select combobox behavior
+  const {
+    highlightedIndex,
+    getItemId,
+    onTriggerClick,
+    onKeyDown,
+    onItemMouseEnter,
+  } = useMultiCombobox({
+    selectableItems: navigableItems,
+    isDisabled,
+    isOpen: popover.isOpen,
+    hasSearch,
+    onOpen: useCallback(() => {
+      // Snapshot which items are selected at open time — sort is stable during interaction
+      selectedAtOpenRef.current = new Set(optimisticValue);
+
+      popover.show();
+      if (hasSearch) {
+        // Focus search after popover opens
+        requestAnimationFrame(() => {
+          searchRef.current?.focus();
+        });
+      }
+    }, [popover, hasSearch, filteredItems, optimisticValue]),
+    onClose: popover.hide,
+    onToggle: handleNavigableToggle,
+    listboxId,
+  });
 
   // Build trigger display content
   const selectedLabels = useMemo(() => {
@@ -894,11 +922,13 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
       if (sorted.length === 0) {
         return <div {...stylex.props(styles.emptyState)}>No results found</div>;
       }
-      return sorted.map((item, index) => renderItem(item, index));
+      return sorted.map((item, index) =>
+        renderItem(item, index + itemIndexOffset),
+      );
     }
 
     // Normal rendering with selected-first sorting (using open-time snapshot)
-    let flatIndex = 0;
+    let flatIndex = itemIndexOffset;
     const elements: ReactNode[] = [];
     let pendingFlatItems: Array<{
       item: XDSMultiSelectorOptionData;
@@ -966,7 +996,14 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     flushFlatItems();
 
     return elements;
-  }, [options, renderItem, filteredItems, searchQuery, optimisticValue]);
+  }, [
+    options,
+    renderItem,
+    filteredItems,
+    searchQuery,
+    optimisticValue,
+    itemIndexOffset,
+  ]);
 
   return (
     <XDSField
@@ -1053,37 +1090,48 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
       {popover.render(
         <div {...stylex.props(styles.dropdown)}>
           {renderSearch()}
-          {hasSelectAll && (
-            <>
-              <div
-                {...stylex.props(
-                  styles.selectAllWrapper,
-                  selectAllSizeStyles[size],
-                )}
-                onClick={handleSelectAll}>
-                <div
-                  aria-hidden="true"
-                  {...stylex.props(styles.checkboxDecorative)}>
-                  <XDSCheckboxInput
-                    label=""
-                    isLabelHidden
-                    value={selectAllState}
-                    onChange={() => {}}
-                    size={size === 'lg' ? 'md' : size}
-                  />
-                </div>
-                <span {...stylex.props(styles.itemLabel)}>
-                  {selectAllLabel}
-                </span>
-              </div>
-              <XDSDivider xstyle={styles.divider} />
-            </>
-          )}
           <div
             id={listboxId}
             role="listbox"
             aria-multiselectable="true"
             aria-labelledby={triggerId}>
+            {hasSelectAll && (
+              <>
+                <div
+                  id={getItemId(0)}
+                  role="option"
+                  aria-selected={allEnabledSelected}
+                  onClick={handleSelectAll}
+                  onMouseEnter={() =>
+                    onItemMouseEnter(
+                      {value: SELECT_ALL_VALUE, label: selectAllLabel},
+                      0,
+                    )
+                  }
+                  {...stylex.props(
+                    styles.item,
+                    styles.selectAllWrapper,
+                    selectAllSizeStyles[size],
+                    highlightedIndex === 0 && styles.itemHighlighted,
+                  )}>
+                  <div
+                    aria-hidden="true"
+                    {...stylex.props(styles.checkboxDecorative)}>
+                    <XDSCheckboxInput
+                      label=""
+                      isLabelHidden
+                      value={selectAllState}
+                      onChange={() => {}}
+                      size={size === 'lg' ? 'md' : size}
+                    />
+                  </div>
+                  <span {...stylex.props(styles.itemLabel)}>
+                    {selectAllLabel}
+                  </span>
+                </div>
+                <XDSDivider xstyle={styles.divider} />
+              </>
+            )}
             {renderOptions()}
           </div>
         </div>,

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -524,8 +524,11 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   const [searchQuery, setSearchQuery] = useState('');
 
   // Snapshot of which values were selected when the dropdown opened.
-  // Used for sort partitioning so items don't jump during interaction.
-  const selectedAtOpenRef = useRef<Set<string> | null>(null);
+  // Stored as state (not a ref) so sortedItems recomputes exactly once on open,
+  // then stays frozen until the menu closes.
+  const [selectedAtOpen, setSelectedAtOpen] = useState<Set<string> | null>(
+    null,
+  );
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
@@ -559,7 +562,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   // and renderOptions (DOM rendering) consume this list — no independent sorting.
   // Selected-at-open items are placed first within each group/section.
   const sortedItems = useMemo(() => {
-    const selectedSet = selectedAtOpenRef.current ?? new Set(optimisticValue);
+    const selectedSet = selectedAtOpen ?? new Set<string>();
     if (searchQuery) {
       const selected = filteredItems.filter(item =>
         selectedSet.has(item.value),
@@ -614,7 +617,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     filteredItems,
     searchQuery,
     options,
-    optimisticValue,
+    selectedAtOpen,
     hasSelectAll,
     selectAllLabel,
   ]);
@@ -622,7 +625,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   // Layer for dropdown positioning
   const handleLayerHide = useCallback(() => {
     setSearchQuery('');
-    selectedAtOpenRef.current = null;
+    setSelectedAtOpen(null);
     triggerRef.current?.focus();
   }, []);
 
@@ -742,8 +745,8 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     isOpen: popover.isOpen,
     hasSearch,
     onOpen: useCallback(() => {
-      // Snapshot which items are selected at open time — sort is stable during interaction
-      selectedAtOpenRef.current = new Set(optimisticValue);
+      // Snapshot which items are selected at open time — sort is frozen until close
+      setSelectedAtOpen(new Set(optimisticValue));
 
       popover.show();
       if (hasSearch) {

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -567,7 +567,11 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
       const unselected = filteredItems.filter(
         item => !selectedSet.has(item.value),
       );
-      return [...selected, ...unselected];
+      const items = [...selected, ...unselected];
+      if (hasSelectAll) {
+        return [{value: SELECT_ALL_VALUE, label: selectAllLabel}, ...items];
+      }
+      return items;
     }
     // For non-search mode, flatten options in the same order as renderOptions
     const result: XDSMultiSelectorOptionData[] = [];
@@ -601,8 +605,19 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
       }
     }
     flushFlat();
+
+    if (hasSelectAll) {
+      return [{value: SELECT_ALL_VALUE, label: selectAllLabel}, ...result];
+    }
     return result;
-  }, [filteredItems, searchQuery, options, optimisticValue]);
+  }, [
+    filteredItems,
+    searchQuery,
+    options,
+    optimisticValue,
+    hasSelectAll,
+    selectAllLabel,
+  ]);
 
   // Layer for dropdown positioning
   const handleLayerHide = useCallback(() => {
@@ -701,16 +716,6 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     setOptimisticValue,
   ]);
 
-  // Prepend a synthetic select-all item so it participates in keyboard navigation
-  const navigableItems = useMemo(() => {
-    if (!hasSelectAll) return sortedItems;
-    const selectAllItem: XDSMultiSelectorOptionData = {
-      value: SELECT_ALL_VALUE,
-      label: selectAllLabel,
-    };
-    return [selectAllItem, ...sortedItems];
-  }, [hasSelectAll, sortedItems, selectAllLabel]);
-
   // Route toggle: select-all sentinel → handleSelectAll, everything else → handleToggle
   const handleNavigableToggle = useCallback(
     (itemValue: string) => {
@@ -723,16 +728,16 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     [handleSelectAll, handleToggle],
   );
 
-  // Multi-select combobox behavior — uses value-based highlighting
-  // so keyboard navigation and selection are decoupled from render order.
+  // Multi-select combobox behavior — index-based, matching useCombobox pattern.
+  // sortedItems is the single source of truth for item order.
   const {
-    highlightedValue,
+    highlightedIndex,
     getItemId,
     onTriggerClick,
     onKeyDown,
     onItemMouseEnter,
   } = useMultiCombobox({
-    selectableItems: navigableItems,
+    selectableItems: sortedItems,
     isDisabled,
     isOpen: popover.isOpen,
     hasSearch,
@@ -842,28 +847,33 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     onKeyDown,
   ]);
 
-  // Render an individual item
+  // Render an individual item (index-based)
   const renderItem = useCallback(
-    (item: XDSMultiSelectorOptionData) => {
-      const isHighlighted = item.value === highlightedValue;
-      const isSelected = optimisticValue.includes(item.value);
+    (item: XDSMultiSelectorOptionData, flatIndex: number) => {
+      const isHighlighted = flatIndex === highlightedIndex;
+      const isSelectAll = item.value === SELECT_ALL_VALUE;
+      const isSelected = isSelectAll
+        ? allEnabledSelected
+        : optimisticValue.includes(item.value);
+      const checkboxValue = isSelectAll ? selectAllState : isSelected;
 
       return (
         <div
           key={item.value}
-          id={getItemId(item.value)}
+          id={getItemId(flatIndex)}
           role="option"
           aria-selected={isSelected}
           aria-disabled={item.disabled}
           onClick={() => {
             if (!item.disabled) {
-              handleToggle(item.value);
+              handleNavigableToggle(item.value);
             }
           }}
-          onMouseEnter={() => onItemMouseEnter(item)}
+          onMouseEnter={() => onItemMouseEnter(item, flatIndex)}
           {...stylex.props(
             styles.item,
-            itemSizeStyles[size],
+            isSelectAll ? selectAllSizeStyles[size] : itemSizeStyles[size],
+            isSelectAll && styles.selectAllWrapper,
             isHighlighted && styles.itemHighlighted,
             item.disabled && styles.itemDisabled,
           )}>
@@ -871,13 +881,13 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
             <XDSCheckboxInput
               label=""
               isLabelHidden
-              value={isSelected}
+              value={checkboxValue}
               onChange={() => {}}
               isDisabled={item.disabled}
               size={size === 'lg' ? 'md' : size}
             />
           </div>
-          {children ? (
+          {children && !isSelectAll ? (
             children(item)
           ) : (
             <span
@@ -893,10 +903,12 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     },
     [
       children,
-      highlightedValue,
+      highlightedIndex,
       optimisticValue,
+      allEnabledSelected,
+      selectAllState,
       getItemId,
-      handleToggle,
+      handleNavigableToggle,
       onItemMouseEnter,
       size,
     ],
@@ -906,25 +918,51 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
   // item order — no independent sorting here. Structural elements (dividers,
   // section headers) come from the original options prop.
   const renderOptions = useCallback(() => {
+    const elements: ReactNode[] = [];
+    let cursor = 0;
+
+    // Number of real items (excluding the select-all sentinel)
+    const realItemCount = hasSelectAll
+      ? sortedItems.length - 1
+      : sortedItems.length;
+
+    // Show select-all only when there are real items to select
+    if (hasSelectAll && realItemCount > 0) {
+      elements.push(renderItem(sortedItems[0], 0));
+      elements.push(
+        <XDSDivider key="select-all-divider" xstyle={styles.divider} />,
+      );
+      cursor = 1;
+    } else if (hasSelectAll) {
+      // Skip the select-all sentinel when there are no real items
+      cursor = 1;
+    }
+
+    // Empty state — no real items to show
+    if (realItemCount === 0) {
+      elements.push(
+        <div key="empty" {...stylex.props(styles.emptyState)}>
+          No results found
+        </div>,
+      );
+      return elements;
+    }
+
     if (searchQuery) {
-      // In search mode, sortedItems is already filtered and sorted
-      if (sortedItems.length === 0) {
-        return <div {...stylex.props(styles.emptyState)}>No results found</div>;
+      for (let i = cursor; i < sortedItems.length; i++) {
+        elements.push(renderItem(sortedItems[i], i));
       }
-      return sortedItems.map(item => renderItem(item));
+      return elements;
     }
 
     // Non-search: consume items from sortedItems in order, interleaving
     // structural elements (dividers, section headers) from the options prop.
-    // sortedItems was built by the same iteration pattern over options, so
-    // the cursor stays in sync with the structural boundaries.
-    let cursor = 0;
-    const elements: ReactNode[] = [];
     let pendingCount = 0;
 
     const flushPending = () => {
       for (let j = 0; j < pendingCount; j++) {
-        elements.push(renderItem(sortedItems[cursor++]));
+        elements.push(renderItem(sortedItems[cursor], cursor));
+        cursor++;
       }
       pendingCount = 0;
     };
@@ -942,7 +980,8 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
         const count = option.options.length;
         const sectionItems: ReactNode[] = [];
         for (let j = 0; j < count; j++) {
-          sectionItems.push(renderItem(sortedItems[cursor++]));
+          sectionItems.push(renderItem(sortedItems[cursor], cursor));
+          cursor++;
         }
         if (option.title) {
           elements.push(
@@ -965,7 +1004,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     flushPending();
 
     return elements;
-  }, [options, renderItem, sortedItems, searchQuery]);
+  }, [options, renderItem, sortedItems, searchQuery, hasSelectAll]);
 
   return (
     <XDSField
@@ -1001,8 +1040,8 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
         aria-expanded={popover.isOpen}
         aria-controls={listboxId}
         aria-activedescendant={
-          popover.isOpen && highlightedValue != null
-            ? getItemId(highlightedValue)
+          popover.isOpen && highlightedIndex >= 0
+            ? getItemId(highlightedIndex)
             : undefined
         }
         aria-describedby={ariaDescribedBy}
@@ -1057,42 +1096,6 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
             role="listbox"
             aria-multiselectable="true"
             aria-labelledby={triggerId}>
-            {hasSelectAll && (
-              <>
-                <div
-                  id={getItemId(SELECT_ALL_VALUE)}
-                  role="option"
-                  aria-selected={allEnabledSelected}
-                  onClick={handleSelectAll}
-                  onMouseEnter={() =>
-                    onItemMouseEnter({
-                      value: SELECT_ALL_VALUE,
-                      label: selectAllLabel,
-                    })
-                  }
-                  {...stylex.props(
-                    styles.item,
-                    styles.selectAllWrapper,
-                    selectAllSizeStyles[size],
-                    highlightedValue === SELECT_ALL_VALUE &&
-                      styles.itemHighlighted,
-                  )}>
-                  <div inert {...stylex.props(styles.checkboxDecorative)}>
-                    <XDSCheckboxInput
-                      label=""
-                      isLabelHidden
-                      value={selectAllState}
-                      onChange={() => {}}
-                      size={size === 'lg' ? 'md' : size}
-                    />
-                  </div>
-                  <span {...stylex.props(styles.itemLabel)}>
-                    {selectAllLabel}
-                  </span>
-                </div>
-                <XDSDivider xstyle={styles.divider} />
-              </>
-            )}
             {renderOptions()}
           </div>
         </div>,

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -200,6 +200,9 @@ const styles = stylex.create({
 
   // Select-all wrapper
   selectAllWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
     cursor: 'pointer',
   },
 
@@ -232,6 +235,28 @@ const styles = stylex.create({
   itemDisabled: {
     opacity: 0.5,
     cursor: 'not-allowed',
+  },
+
+  // Decorative checkbox (non-interactive, purely visual)
+  checkboxDecorative: {
+    pointerEvents: 'none',
+    display: 'flex',
+    flexShrink: 0,
+  },
+
+  // Label text for items (rendered outside checkbox for correct click behavior)
+  itemLabel: {
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-label-size'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-primary'],
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  itemLabelDisabled: {
+    color: colorVars['--color-text-disabled'],
   },
 
   // Empty state
@@ -815,15 +840,27 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
             isHighlighted && styles.itemHighlighted,
             item.disabled && styles.itemDisabled,
           )}>
-          <XDSCheckboxInput
-            label={children ? '' : (item.label ?? item.value)}
-            isLabelHidden={!!children}
-            value={isSelected}
-            onChange={() => {}}
-            isDisabled={item.disabled}
-            size={size === 'lg' ? 'md' : size}
-          />
-          {children && children(item)}
+          <div aria-hidden="true" {...stylex.props(styles.checkboxDecorative)}>
+            <XDSCheckboxInput
+              label=""
+              isLabelHidden
+              value={isSelected}
+              onChange={() => {}}
+              isDisabled={item.disabled}
+              size={size === 'lg' ? 'md' : size}
+            />
+          </div>
+          {children ? (
+            children(item)
+          ) : (
+            <span
+              {...stylex.props(
+                styles.itemLabel,
+                item.disabled && styles.itemLabelDisabled,
+              )}>
+              {item.label ?? item.value}
+            </span>
+          )}
         </div>
       );
     },
@@ -1024,12 +1061,20 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
                   selectAllSizeStyles[size],
                 )}
                 onClick={handleSelectAll}>
-                <XDSCheckboxInput
-                  label={selectAllLabel}
-                  value={selectAllState}
-                  onChange={() => {}}
-                  size={size === 'lg' ? 'md' : size}
-                />
+                <div
+                  aria-hidden="true"
+                  {...stylex.props(styles.checkboxDecorative)}>
+                  <XDSCheckboxInput
+                    label=""
+                    isLabelHidden
+                    value={selectAllState}
+                    onChange={() => {}}
+                    size={size === 'lg' ? 'md' : size}
+                  />
+                </div>
+                <span {...stylex.props(styles.itemLabel)}>
+                  {selectAllLabel}
+                </span>
               </div>
               <XDSDivider xstyle={styles.divider} />
             </>

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -711,9 +711,6 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     return [selectAllItem, ...sortedItems];
   }, [hasSelectAll, sortedItems, selectAllLabel]);
 
-  // Offset for flat indices: when select-all is present, regular items start at index 1
-  const itemIndexOffset = hasSelectAll ? 1 : 0;
-
   // Route toggle: select-all sentinel → handleSelectAll, everything else → handleToggle
   const handleNavigableToggle = useCallback(
     (itemValue: string) => {
@@ -726,9 +723,10 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     [handleSelectAll, handleToggle],
   );
 
-  // Multi-select combobox behavior
+  // Multi-select combobox behavior — uses value-based highlighting
+  // so keyboard navigation and selection are decoupled from render order.
   const {
-    highlightedIndex,
+    highlightedValue,
     getItemId,
     onTriggerClick,
     onKeyDown,
@@ -846,14 +844,14 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
 
   // Render an individual item
   const renderItem = useCallback(
-    (item: XDSMultiSelectorOptionData, flatIndex: number) => {
-      const isHighlighted = flatIndex === highlightedIndex;
+    (item: XDSMultiSelectorOptionData) => {
+      const isHighlighted = item.value === highlightedValue;
       const isSelected = optimisticValue.includes(item.value);
 
       return (
         <div
           key={item.value}
-          id={getItemId(flatIndex)}
+          id={getItemId(item.value)}
           role="option"
           aria-selected={isSelected}
           aria-disabled={item.disabled}
@@ -862,7 +860,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
               handleToggle(item.value);
             }
           }}
-          onMouseEnter={() => onItemMouseEnter(item, flatIndex)}
+          onMouseEnter={() => onItemMouseEnter(item)}
           {...stylex.props(
             styles.item,
             itemSizeStyles[size],
@@ -895,7 +893,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     },
     [
       children,
-      highlightedIndex,
+      highlightedValue,
       optimisticValue,
       getItemId,
       handleToggle,
@@ -923,13 +921,10 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
       if (sorted.length === 0) {
         return <div {...stylex.props(styles.emptyState)}>No results found</div>;
       }
-      return sorted.map((item, index) =>
-        renderItem(item, index + itemIndexOffset),
-      );
+      return sorted.map(item => renderItem(item));
     }
 
     // Normal rendering with selected-first sorting (using open-time snapshot)
-    let flatIndex = itemIndexOffset;
     const elements: ReactNode[] = [];
     let pendingFlatItems: Array<{
       item: XDSMultiSelectorOptionData;
@@ -945,8 +940,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
       );
       const sorted = [...selected, ...unselected];
       for (const {item} of sorted) {
-        elements.push(renderItem(item, flatIndex));
-        flatIndex++;
+        elements.push(renderItem(item));
       }
       pendingFlatItems = [];
     };
@@ -973,8 +967,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
 
         const sectionItems: ReactNode[] = [];
         for (const item of sortedSection) {
-          sectionItems.push(renderItem(item, flatIndex));
-          flatIndex++;
+          sectionItems.push(renderItem(item));
         }
         if (option.title) {
           elements.push(
@@ -997,14 +990,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
     flushFlatItems();
 
     return elements;
-  }, [
-    options,
-    renderItem,
-    filteredItems,
-    searchQuery,
-    optimisticValue,
-    itemIndexOffset,
-  ]);
+  }, [options, renderItem, filteredItems, searchQuery, optimisticValue]);
 
   return (
     <XDSField
@@ -1040,8 +1026,8 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
         aria-expanded={popover.isOpen}
         aria-controls={listboxId}
         aria-activedescendant={
-          popover.isOpen && highlightedIndex >= 0
-            ? getItemId(highlightedIndex)
+          popover.isOpen && highlightedValue != null
+            ? getItemId(highlightedValue)
             : undefined
         }
         aria-describedby={ariaDescribedBy}
@@ -1099,25 +1085,24 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
             {hasSelectAll && (
               <>
                 <div
-                  id={getItemId(0)}
+                  id={getItemId(SELECT_ALL_VALUE)}
                   role="option"
                   aria-selected={allEnabledSelected}
                   onClick={handleSelectAll}
                   onMouseEnter={() =>
-                    onItemMouseEnter(
-                      {value: SELECT_ALL_VALUE, label: selectAllLabel},
-                      0,
-                    )
+                    onItemMouseEnter({
+                      value: SELECT_ALL_VALUE,
+                      label: selectAllLabel,
+                    })
                   }
                   {...stylex.props(
                     styles.item,
                     styles.selectAllWrapper,
                     selectAllSizeStyles[size],
-                    highlightedIndex === 0 && styles.itemHighlighted,
+                    highlightedValue === SELECT_ALL_VALUE &&
+                      styles.itemHighlighted,
                   )}>
-                  <div
-                    aria-hidden="true"
-                    {...stylex.props(styles.checkboxDecorative)}>
+                  <div inert {...stylex.props(styles.checkboxDecorative)}>
                     <XDSCheckboxInput
                       label=""
                       isLabelHidden

--- a/packages/core/src/MultiSelector/XDSMultiSelector.tsx
+++ b/packages/core/src/MultiSelector/XDSMultiSelector.tsx
@@ -820,11 +820,12 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
           value={searchQuery}
           onChange={e => setSearchQuery(e.target.value)}
           onKeyDown={e => {
-            // Let ArrowDown/Up/Escape propagate to parent handler
+            // Let ArrowDown/Up/Escape/Tab propagate to parent handler
             if (
               e.key === 'ArrowDown' ||
               e.key === 'ArrowUp' ||
-              e.key === 'Escape'
+              e.key === 'Escape' ||
+              e.key === 'Tab'
             ) {
               onKeyDown(e);
             }
@@ -868,7 +869,7 @@ export function XDSMultiSelector<T extends XDSMultiSelectorOptionType>({
             isHighlighted && styles.itemHighlighted,
             item.disabled && styles.itemDisabled,
           )}>
-          <div aria-hidden="true" {...stylex.props(styles.checkboxDecorative)}>
+          <div inert {...stylex.props(styles.checkboxDecorative)}>
             <XDSCheckboxInput
               label=""
               isLabelHidden

--- a/packages/core/src/MultiSelector/hooks.ts
+++ b/packages/core/src/MultiSelector/hooks.ts
@@ -145,6 +145,13 @@ export function useMultiCombobox({
           }
           break;
 
+        case 'Tab':
+          // Close the combobox and let the browser move focus to the next element
+          if (isOpen) {
+            closeAndReset();
+          }
+          break;
+
         case 'Escape':
           if (isOpen) {
             e.preventDefault();

--- a/packages/core/src/MultiSelector/hooks.ts
+++ b/packages/core/src/MultiSelector/hooks.ts
@@ -25,19 +25,19 @@ interface UseMultiComboboxOptions {
 }
 
 interface UseMultiComboboxResult {
-  highlightedValue: string | null;
-  getItemId: (value: string) => string;
+  highlightedIndex: number;
+  setHighlightedIndex: (index: number) => void;
+  getItemId: (index: number) => string;
   onTriggerClick: () => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
-  onItemMouseEnter: (item: XDSMultiSelectorOptionData) => void;
+  onItemMouseEnter: (item: XDSMultiSelectorOptionData, index: number) => void;
 }
 
 /**
  * Handles keyboard navigation and toggle logic for multi-select combobox.
- * Unlike useCombobox (single-select), toggling an item does NOT close the dropdown.
+ * Works like useCombobox (index-based) but toggling does NOT close the dropdown.
  *
- * Uses value-based highlighting (not positional indices) so that keyboard
- * navigation and selection are decoupled from render order.
+ * The caller must ensure selectableItems is in the same order as the rendered DOM.
  */
 export function useMultiCombobox({
   selectableItems,
@@ -49,45 +49,27 @@ export function useMultiCombobox({
   onToggle,
   listboxId,
 }: UseMultiComboboxOptions): UseMultiComboboxResult {
-  const [highlightedValue, setHighlightedValue] = useState<string | null>(null);
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
   const [typeahead, setTypeahead] = useState('');
   const typeaheadTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
 
   const getItemId = useCallback(
-    (value: string) => `${listboxId}-item-${encodeURIComponent(value)}`,
+    (index: number) => `${listboxId}-item-${index}`,
     [listboxId],
   );
 
-  const getEnabledItems = useCallback(() => {
-    return selectableItems.filter(item => !item.disabled);
+  const getEnabledIndices = useCallback(() => {
+    return selectableItems
+      .map((item, i) => (!item.disabled ? i : -1))
+      .filter(i => i >= 0);
   }, [selectableItems]);
 
-  // Find the position of the highlighted value in the current items list
-  const getHighlightedPosition = useCallback(() => {
-    if (highlightedValue == null) return -1;
-    return selectableItems.findIndex(item => item.value === highlightedValue);
-  }, [selectableItems, highlightedValue]);
-
   const closeAndReset = useCallback(() => {
-    setHighlightedValue(null);
+    setHighlightedIndex(-1);
     onClose();
   }, [onClose]);
-
-  const highlightFirstEnabled = useCallback(() => {
-    const enabled = getEnabledItems();
-    if (enabled.length > 0) {
-      setHighlightedValue(enabled[0].value);
-    }
-  }, [getEnabledItems]);
-
-  const highlightLastEnabled = useCallback(() => {
-    const enabled = getEnabledItems();
-    if (enabled.length > 0) {
-      setHighlightedValue(enabled[enabled.length - 1].value);
-    }
-  }, [getEnabledItems]);
 
   const onTriggerClick = useCallback(() => {
     if (isDisabled) return;
@@ -95,51 +77,40 @@ export function useMultiCombobox({
       closeAndReset();
     } else {
       onOpen();
-      // If search is present, don't highlight any item (focus goes to search)
       if (!hasSearch) {
-        highlightFirstEnabled();
+        setHighlightedIndex(0);
       }
     }
-  }, [
-    isDisabled,
-    isOpen,
-    onOpen,
-    closeAndReset,
-    hasSearch,
-    highlightFirstEnabled,
-  ]);
+  }, [isDisabled, isOpen, onOpen, closeAndReset, hasSearch]);
 
-  const onItemMouseEnter = useCallback((item: XDSMultiSelectorOptionData) => {
-    if (!item.disabled) {
-      setHighlightedValue(item.value);
-    }
-  }, []);
+  const onItemMouseEnter = useCallback(
+    (item: XDSMultiSelectorOptionData, index: number) => {
+      if (!item.disabled) {
+        setHighlightedIndex(index);
+      }
+    },
+    [],
+  );
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (isDisabled) return;
 
-      const enabledItems = getEnabledItems();
-
-      // Build an ordered list of enabled values for navigation
-      const enabledValues = enabledItems.map(item => item.value);
-
-      // Find current position among enabled items
-      const currentEnabledPos =
-        highlightedValue != null ? enabledValues.indexOf(highlightedValue) : -1;
+      const enabledIndices = getEnabledIndices();
 
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
           if (!isOpen) {
             onOpen();
-            highlightFirstEnabled();
-          } else if (enabledValues.length > 0) {
+            setHighlightedIndex(0);
+          } else {
+            const currentEnabledPos = enabledIndices.indexOf(highlightedIndex);
             const nextPos = Math.min(
               currentEnabledPos + 1,
-              enabledValues.length - 1,
+              enabledIndices.length - 1,
             );
-            setHighlightedValue(enabledValues[nextPos]);
+            setHighlightedIndex(enabledIndices[nextPos] ?? highlightedIndex);
           }
           break;
 
@@ -147,10 +118,11 @@ export function useMultiCombobox({
           e.preventDefault();
           if (!isOpen) {
             onOpen();
-            highlightLastEnabled();
-          } else if (enabledValues.length > 0) {
+            setHighlightedIndex(selectableItems.length - 1);
+          } else {
+            const currentEnabledPos = enabledIndices.indexOf(highlightedIndex);
             const prevPos = Math.max(currentEnabledPos - 1, 0);
-            setHighlightedValue(enabledValues[prevPos]);
+            setHighlightedIndex(enabledIndices[prevPos] ?? highlightedIndex);
           }
           break;
 
@@ -161,23 +133,20 @@ export function useMultiCombobox({
             break;
           }
           e.preventDefault();
-          if (isOpen && highlightedValue != null) {
-            const item = selectableItems.find(
-              i => i.value === highlightedValue,
-            );
+          if (isOpen && highlightedIndex >= 0) {
+            const item = selectableItems[highlightedIndex];
             if (item && !item.disabled) {
               onToggle(item.value);
             }
           } else if (!isOpen) {
             onOpen();
             if (!hasSearch) {
-              highlightFirstEnabled();
+              setHighlightedIndex(0);
             }
           }
           break;
 
         case 'Tab':
-          // Close the combobox and let the browser move focus to the next element
           if (isOpen) {
             closeAndReset();
           }
@@ -192,15 +161,15 @@ export function useMultiCombobox({
 
         case 'Home':
           e.preventDefault();
-          if (isOpen) {
-            highlightFirstEnabled();
+          if (isOpen && enabledIndices.length > 0) {
+            setHighlightedIndex(enabledIndices[0]);
           }
           break;
 
         case 'End':
           e.preventDefault();
-          if (isOpen) {
-            highlightLastEnabled();
+          if (isOpen && enabledIndices.length > 0) {
+            setHighlightedIndex(enabledIndices[enabledIndices.length - 1]);
           }
           break;
 
@@ -217,16 +186,16 @@ export function useMultiCombobox({
               setTypeahead('');
             }, 500);
 
-            const match = selectableItems.find(
+            const matchIndex = selectableItems.findIndex(
               item =>
                 !item.disabled &&
                 item.label?.toLowerCase().startsWith(newTypeahead),
             );
-            if (match) {
+            if (matchIndex >= 0) {
               if (!isOpen) {
                 onOpen();
               }
-              setHighlightedValue(match.value);
+              setHighlightedIndex(matchIndex);
             }
           }
           break;
@@ -238,18 +207,17 @@ export function useMultiCombobox({
       onOpen,
       closeAndReset,
       selectableItems,
-      highlightedValue,
+      highlightedIndex,
       onToggle,
-      getEnabledItems,
-      highlightFirstEnabled,
-      highlightLastEnabled,
+      getEnabledIndices,
       typeahead,
       hasSearch,
     ],
   );
 
   return {
-    highlightedValue,
+    highlightedIndex,
+    setHighlightedIndex,
     getItemId,
     onTriggerClick,
     onKeyDown,

--- a/packages/core/src/MultiSelector/hooks.ts
+++ b/packages/core/src/MultiSelector/hooks.ts
@@ -25,17 +25,19 @@ interface UseMultiComboboxOptions {
 }
 
 interface UseMultiComboboxResult {
-  highlightedIndex: number;
-  setHighlightedIndex: (index: number) => void;
-  getItemId: (index: number) => string;
+  highlightedValue: string | null;
+  getItemId: (value: string) => string;
   onTriggerClick: () => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
-  onItemMouseEnter: (item: XDSMultiSelectorOptionData, index: number) => void;
+  onItemMouseEnter: (item: XDSMultiSelectorOptionData) => void;
 }
 
 /**
  * Handles keyboard navigation and toggle logic for multi-select combobox.
  * Unlike useCombobox (single-select), toggling an item does NOT close the dropdown.
+ *
+ * Uses value-based highlighting (not positional indices) so that keyboard
+ * navigation and selection are decoupled from render order.
  */
 export function useMultiCombobox({
   selectableItems,
@@ -47,27 +49,45 @@ export function useMultiCombobox({
   onToggle,
   listboxId,
 }: UseMultiComboboxOptions): UseMultiComboboxResult {
-  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
+  const [highlightedValue, setHighlightedValue] = useState<string | null>(null);
   const [typeahead, setTypeahead] = useState('');
   const typeaheadTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
 
   const getItemId = useCallback(
-    (index: number) => `${listboxId}-item-${index}`,
+    (value: string) => `${listboxId}-item-${encodeURIComponent(value)}`,
     [listboxId],
   );
 
-  const getEnabledIndices = useCallback(() => {
-    return selectableItems
-      .map((item, i) => (!item.disabled ? i : -1))
-      .filter(i => i >= 0);
+  const getEnabledItems = useCallback(() => {
+    return selectableItems.filter(item => !item.disabled);
   }, [selectableItems]);
 
+  // Find the position of the highlighted value in the current items list
+  const getHighlightedPosition = useCallback(() => {
+    if (highlightedValue == null) return -1;
+    return selectableItems.findIndex(item => item.value === highlightedValue);
+  }, [selectableItems, highlightedValue]);
+
   const closeAndReset = useCallback(() => {
-    setHighlightedIndex(-1);
+    setHighlightedValue(null);
     onClose();
   }, [onClose]);
+
+  const highlightFirstEnabled = useCallback(() => {
+    const enabled = getEnabledItems();
+    if (enabled.length > 0) {
+      setHighlightedValue(enabled[0].value);
+    }
+  }, [getEnabledItems]);
+
+  const highlightLastEnabled = useCallback(() => {
+    const enabled = getEnabledItems();
+    if (enabled.length > 0) {
+      setHighlightedValue(enabled[enabled.length - 1].value);
+    }
+  }, [getEnabledItems]);
 
   const onTriggerClick = useCallback(() => {
     if (isDisabled) return;
@@ -77,39 +97,49 @@ export function useMultiCombobox({
       onOpen();
       // If search is present, don't highlight any item (focus goes to search)
       if (!hasSearch) {
-        setHighlightedIndex(0);
+        highlightFirstEnabled();
       }
     }
-  }, [isDisabled, isOpen, onOpen, closeAndReset, hasSearch]);
+  }, [
+    isDisabled,
+    isOpen,
+    onOpen,
+    closeAndReset,
+    hasSearch,
+    highlightFirstEnabled,
+  ]);
 
-  const onItemMouseEnter = useCallback(
-    (item: XDSMultiSelectorOptionData, index: number) => {
-      if (!item.disabled) {
-        setHighlightedIndex(index);
-      }
-    },
-    [],
-  );
+  const onItemMouseEnter = useCallback((item: XDSMultiSelectorOptionData) => {
+    if (!item.disabled) {
+      setHighlightedValue(item.value);
+    }
+  }, []);
 
   const onKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (isDisabled) return;
 
-      const enabledIndices = getEnabledIndices();
+      const enabledItems = getEnabledItems();
+
+      // Build an ordered list of enabled values for navigation
+      const enabledValues = enabledItems.map(item => item.value);
+
+      // Find current position among enabled items
+      const currentEnabledPos =
+        highlightedValue != null ? enabledValues.indexOf(highlightedValue) : -1;
 
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
           if (!isOpen) {
             onOpen();
-            setHighlightedIndex(0);
-          } else {
-            const currentEnabledPos = enabledIndices.indexOf(highlightedIndex);
+            highlightFirstEnabled();
+          } else if (enabledValues.length > 0) {
             const nextPos = Math.min(
               currentEnabledPos + 1,
-              enabledIndices.length - 1,
+              enabledValues.length - 1,
             );
-            setHighlightedIndex(enabledIndices[nextPos] ?? highlightedIndex);
+            setHighlightedValue(enabledValues[nextPos]);
           }
           break;
 
@@ -117,11 +147,10 @@ export function useMultiCombobox({
           e.preventDefault();
           if (!isOpen) {
             onOpen();
-            setHighlightedIndex(selectableItems.length - 1);
-          } else {
-            const currentEnabledPos = enabledIndices.indexOf(highlightedIndex);
+            highlightLastEnabled();
+          } else if (enabledValues.length > 0) {
             const prevPos = Math.max(currentEnabledPos - 1, 0);
-            setHighlightedIndex(enabledIndices[prevPos] ?? highlightedIndex);
+            setHighlightedValue(enabledValues[prevPos]);
           }
           break;
 
@@ -132,15 +161,17 @@ export function useMultiCombobox({
             break;
           }
           e.preventDefault();
-          if (isOpen && highlightedIndex >= 0) {
-            const item = selectableItems[highlightedIndex];
+          if (isOpen && highlightedValue != null) {
+            const item = selectableItems.find(
+              i => i.value === highlightedValue,
+            );
             if (item && !item.disabled) {
               onToggle(item.value);
             }
           } else if (!isOpen) {
             onOpen();
             if (!hasSearch) {
-              setHighlightedIndex(0);
+              highlightFirstEnabled();
             }
           }
           break;
@@ -161,15 +192,15 @@ export function useMultiCombobox({
 
         case 'Home':
           e.preventDefault();
-          if (isOpen && enabledIndices.length > 0) {
-            setHighlightedIndex(enabledIndices[0]);
+          if (isOpen) {
+            highlightFirstEnabled();
           }
           break;
 
         case 'End':
           e.preventDefault();
-          if (isOpen && enabledIndices.length > 0) {
-            setHighlightedIndex(enabledIndices[enabledIndices.length - 1]);
+          if (isOpen) {
+            highlightLastEnabled();
           }
           break;
 
@@ -186,16 +217,16 @@ export function useMultiCombobox({
               setTypeahead('');
             }, 500);
 
-            const matchIndex = selectableItems.findIndex(
+            const match = selectableItems.find(
               item =>
                 !item.disabled &&
                 item.label?.toLowerCase().startsWith(newTypeahead),
             );
-            if (matchIndex >= 0) {
+            if (match) {
               if (!isOpen) {
                 onOpen();
               }
-              setHighlightedIndex(matchIndex);
+              setHighlightedValue(match.value);
             }
           }
           break;
@@ -207,17 +238,18 @@ export function useMultiCombobox({
       onOpen,
       closeAndReset,
       selectableItems,
-      highlightedIndex,
+      highlightedValue,
       onToggle,
-      getEnabledIndices,
+      getEnabledItems,
+      highlightFirstEnabled,
+      highlightLastEnabled,
       typeahead,
       hasSearch,
     ],
   );
 
   return {
-    highlightedIndex,
-    setHighlightedIndex,
+    highlightedValue,
     getItemId,
     onTriggerClick,
     onKeyDown,


### PR DESCRIPTION
## Summary

Fixes #1072

- Clicking the label text in multi-selector items caused a double-toggle (no net change) because the native `<label>`→`<input>` association fired a synthesized click that bubbled to the parent alongside the original click, calling `handleToggle` twice
- Made `XDSCheckboxInput` purely decorative inside multi-selector items by wrapping it in `aria-hidden="true"` + `pointer-events: none` containers
- Rendered item label text in a separate `<span>` outside the checkbox component
- Applied the same fix to the "select all" row
- Updated tests to query by text content instead of label association

## Test plan

- [x] All 32 existing multi-selector tests pass
- [x] Manually verify clicking anywhere on a multi-selector item row (including label text) toggles the checkbox
- [x] Verify "select all" label click works correctly
- [x] Verify keyboard navigation still works (Enter/Space to toggle)
- [x] Verify screen reader announces items as `role="option"` with `aria-selected` state