### PR TITLE
feat(sandbox): add Details Page (Order details) template

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
@@ -377,7 +377,9 @@ function ShopSideNav() {
       header={
         <XDSHStack gap={2} vAlign="center" style={{padding: '8px 12px'}}>
           <XDSNavIcon icon={<ShopIcon style={{width: 16, height: 16}} />} />
-          <XDSLink href="#">Acme</XDSLink>
+          <XDSLink href="#" label="Acme">
+            Acme
+          </XDSLink>
         </XDSHStack>
       }
       footer={

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
@@ -398,7 +398,7 @@ function ShopSideNav() {
           />
         </XDSVStack>
       }>
-      <XDSSideNavSection>
+      <XDSSideNavSection title="Main" isHeaderHidden>
         <XDSSideNavItem
           label="Home"
           icon={HomeIcon}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
@@ -23,7 +23,6 @@ import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSLink} from '@xds/core/Link';
 import {XDSList, XDSListItem} from '@xds/core/List';
-import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSMetadataList, XDSMetadataListItem} from '@xds/core/MetadataList';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {XDSCollapsible} from '@xds/core/Collapsible';
@@ -117,16 +116,6 @@ const HelpIcon = (props: React.SVGProps<SVGSVGElement>) => (
     {...props}>
     <circle cx="12" cy="12" r="10" />
     <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01" />
-  </svg>
-);
-const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
-  <svg
-    viewBox="0 0 24 24"
-    fill="none"
-    stroke="currentColor"
-    strokeWidth={1.5}
-    {...props}>
-    <path d="M19 12H5M12 19l-7-7 7-7" />
   </svg>
 );
 const CalendarIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -388,7 +377,7 @@ function ShopSideNav() {
       header={
         <XDSHStack gap={2} vAlign="center" style={{padding: '8px 12px'}}>
           <XDSNavIcon icon={<ShopIcon style={{width: 16, height: 16}} />} />
-          <XDSLink href="#" label="Acme" />
+          <XDSLink href="#">Acme</XDSLink>
         </XDSHStack>
       }
       footer={

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
@@ -460,7 +460,7 @@ function PageHeader({
       <XDSCenter axis="horizontal">
         <XDSVStack xstyle={pageStyles.maxWidth} gap={0}>
           {/* Back link */}
-          <XDSLink href="#" label="← All orders" />
+          <XDSLink href="#" label="← All orders">← All orders</XDSLink>
           {/* Title + metadata */}
           <XDSVStack gap={0}>
             {/* Title row */}
@@ -499,7 +499,7 @@ function PageHeader({
                 <XDSText type="body">Needs attention</XDSText>
               </XDSHStack>
               <Bullet />
-              <XDSLink href="#" label="See all" />
+              <XDSLink href="#" label="See all">See all</XDSLink>
             </XDSHStack>
           </XDSVStack>
 
@@ -743,7 +743,7 @@ function RightPanel() {
               Customer is a repeat buyer — 3rd order this quarter. Prefers brown
               leather goods and grid-format notebooks. Requested gift wrapping
               for this order. Ships to a residential address in CA.{' '}
-              <XDSLink href="#" label="Show more" />
+              <XDSLink href="#" label="Show more">Show more</XDSLink>
             </XDSText>
           </XDSCollapsible>
         </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
@@ -192,6 +192,17 @@ const ShopIcon = (props: React.SVGProps<SVGSVGElement>) => (
     <polyline points="9 22 9 12 15 12 15 22" />
   </svg>
 );
+const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 19.5 3 12m0 0 7.5-7.5M3 12h18" />
+  </svg>
+);
+
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 const pageStyles = stylex.create({
@@ -377,9 +388,9 @@ function ShopSideNav() {
       header={
         <XDSHStack gap={2} vAlign="center" style={{padding: '8px 12px'}}>
           <XDSNavIcon icon={<ShopIcon style={{width: 16, height: 16}} />} />
-          <XDSLink href="#" label="Acme">
+          <XDSHeading level={4}>
             Acme
-          </XDSLink>
+          </XDSHeading>
         </XDSHStack>
       }
       footer={
@@ -460,7 +471,12 @@ function PageHeader({
       <XDSCenter axis="horizontal">
         <XDSVStack xstyle={pageStyles.maxWidth} gap={0}>
           {/* Back link */}
-          <XDSLink href="#" label="← All orders">← All orders</XDSLink>
+          <XDSLink href="#" label="All orders" color="secondary">
+            <XDSHStack gap={1} vAlign="center">
+              <ArrowLeftIcon style={{width: 16, height: 16}} />
+              All orders
+            </XDSHStack>
+          </XDSLink>
           {/* Title + metadata */}
           <XDSVStack gap={0}>
             {/* Title row */}
@@ -499,7 +515,7 @@ function PageHeader({
                 <XDSText type="body">Needs attention</XDSText>
               </XDSHStack>
               <Bullet />
-              <XDSLink href="#" label="See all">See all</XDSLink>
+              <XDSLink href="#" label="See all" color="secondary">See all</XDSLink>
             </XDSHStack>
           </XDSVStack>
 
@@ -743,7 +759,7 @@ function RightPanel() {
               Customer is a repeat buyer — 3rd order this quarter. Prefers brown
               leather goods and grid-format notebooks. Requested gift wrapping
               for this order. Ships to a residential address in CA.{' '}
-              <XDSLink href="#" label="Show more">Show more</XDSLink>
+              <XDSLink href="#" label="Show more" color="secondary">Show more</XDSLink>
             </XDSText>
           </XDSCollapsible>
         </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
@@ -487,10 +487,10 @@ function PageHeader({
               <XDSHStack gap={2} vAlign="center">
                 <XDSHeading level={1}>#1001</XDSHeading>
               </XDSHStack>
-              <XDSHStack gap={2} vAlign="center">
-                <XDSButton label="← 2/9 →" variant="ghost" size="sm" />
-                <XDSButton label="Restock" variant="secondary" size="sm" />
-                <XDSButton label="Edit" variant="secondary" size="sm" />
+              <XDSHStack gap={2} vAlign="start">
+                <XDSButton label="← 2/9 →" variant="ghost" />
+                <XDSButton label="Restock" variant="secondary" />
+                <XDSButton label="Edit" variant="secondary" />
               </XDSHStack>
             </XDSHStack>
 
@@ -554,11 +554,10 @@ function ItemsCard() {
             <XDSBadge variant="warning" label="Unfulfilled" />
           </XDSHStack>
           <XDSHStack gap={2}>
-            <XDSButton label="Fulfill item" variant="ghost" size="sm" />
+            <XDSButton label="Fulfill item" variant="ghost" />
             <XDSButton
               label="Create shipping label"
               variant="secondary"
-              size="sm"
             />
           </XDSHStack>
         </XDSHStack>
@@ -617,8 +616,8 @@ function InvoiceCard() {
             <XDSBadge variant="success" label="Paid" />
           </XDSHStack>
           <XDSHStack gap={2}>
-            <XDSButton label="Refund" variant="ghost" size="sm" />
-            <XDSButton label="Send Invoice" variant="secondary" size="sm" />
+            <XDSButton label="Refund" variant="ghost" />
+            <XDSButton label="Send Invoice" variant="secondary" />
           </XDSHStack>
         </XDSHStack>
 
@@ -681,7 +680,6 @@ function TimelineSection() {
           <XDSButton
             label="Filters"
             variant="ghost"
-            size="sm"
             icon={<FilterIcon style={{width: 14, height: 14}} />}
           />
         </XDSHStack>
@@ -805,7 +803,7 @@ function RightPanel() {
                     There is a low chance that you will receive a chargeback on
                     this order.
                   </XDSText>
-                  <XDSButton label="Learn more" variant="secondary" size="sm" />
+                  <XDSButton label="Learn more" variant="secondary" />
                 </XDSVStack>
               </XDSSection>
             </XDSCard>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-detail-2/page.tsx
@@ -1,0 +1,842 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSSideNav, XDSSideNavItem, XDSSideNavSection} from '@xds/core/SideNav';
+import {
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+  XDSVStack,
+  XDSHStack,
+  XDSCard,
+  XDSSection,
+} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSButton} from '@xds/core/Button';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSLink} from '@xds/core/Link';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSAspectRatio} from '@xds/core/AspectRatio';
+import {XDSMetadataList, XDSMetadataListItem} from '@xds/core/MetadataList';
+import {XDSProgressBar} from '@xds/core/ProgressBar';
+import {XDSCollapsible} from '@xds/core/Collapsible';
+import {XDSCenter} from '@xds/core/Center';
+
+// ─── Icons ──────────────────────────────────────────────────────────────────
+const HomeIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    <polyline points="9 22 9 12 15 12 15 22" />
+  </svg>
+);
+const OrdersIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <rect x="2" y="3" width="20" height="18" rx="2" />
+    <path d="M8 7h8M8 11h5M8 15h3" />
+  </svg>
+);
+const ProductsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+    <polyline points="3.27 6.96 12 12.01 20.73 6.96" />
+    <line x1="12" y1="22.08" x2="12" y2="12" />
+  </svg>
+);
+const CustomersIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
+  </svg>
+);
+const ContentIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" />
+  </svg>
+);
+const AnalyticsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M18 20V10M12 20V4M6 20v-6" />
+  </svg>
+);
+const SettingsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <circle cx="12" cy="12" r="3" />
+    <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+  </svg>
+);
+const HelpIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <circle cx="12" cy="12" r="10" />
+    <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3M12 17h.01" />
+  </svg>
+);
+const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M19 12H5M12 19l-7-7 7-7" />
+  </svg>
+);
+const CalendarIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <line x1="16" y1="2" x2="16" y2="6" />
+    <line x1="8" y1="2" x2="8" y2="6" />
+    <line x1="3" y1="10" x2="21" y2="10" />
+  </svg>
+);
+const FlagIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1zM4 22v-7" />
+  </svg>
+);
+const FilterIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <polygon points="22 3 2 3 10 12.46 10 19 14 21 14 12.46 22 3" />
+  </svg>
+);
+const ThumbUpIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
+  </svg>
+);
+const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+  </svg>
+);
+const EditIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M12 20h9M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+  </svg>
+);
+const ShopIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
+    <polyline points="9 22 9 12 15 12 15 22" />
+  </svg>
+);
+
+// ─── Styles ─────────────────────────────────────────────────────────────────
+const pageStyles = stylex.create({
+  maxWidth: {
+    maxWidth: 1000,
+    width: '100%',
+  },
+  centeredContent: {
+    maxWidth: 1000,
+    width: '100%',
+    marginInline: 'auto',
+  },
+  sectionGap: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+  },
+  bulletSeparator: {
+    fontSize: 12,
+    lineHeight: '16px',
+    color: 'var(--color-text-secondary, #666)',
+    userSelect: 'none',
+  },
+  metaIcon: {
+    width: 14,
+    height: 14,
+    color: 'var(--color-text-secondary, #666)',
+    flexShrink: 0,
+  },
+  productImage: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    borderRadius: 'var(--radius-content, 4px)',
+  },
+  productPlaceholder: {
+    position: 'absolute',
+    inset: 0,
+    backgroundColor: 'var(--color-background-deemphasized, #e5e5e5)',
+    borderRadius: 'var(--radius-content, 4px)',
+  },
+  productImageWrap: {
+    width: 80,
+    height: 80,
+    flexShrink: 0,
+  },
+  activityDot: {
+    width: 32,
+    height: 32,
+    flexShrink: 0,
+  },
+  reactionBar: {
+    display: 'flex',
+    gap: 12,
+    alignItems: 'center',
+    fontSize: 12,
+    color: 'var(--color-text-secondary, #666)',
+  },
+  commentBubble: {
+    backgroundColor: 'var(--color-bg-wash, #f5f5f5)',
+    borderRadius: 'var(--radius-container, 12px)',
+    padding: 12,
+  },
+  panelSection: {
+    paddingBlock: 4,
+  },
+  calloutCard: {
+    backgroundColor: 'var(--color-bg-wash, rgba(5,54,89,0.06))',
+    borderRadius: 'var(--radius-container, 12px)',
+    padding: 16,
+  },
+  meterBar: {
+    height: 8,
+    flex: 1,
+    backgroundColor: 'var(--color-bg-deemphasized, #e5e5e5)',
+    borderRadius: 4,
+    overflow: 'hidden',
+  },
+  meterFill: {
+    height: '100%',
+    width: '35%',
+    backgroundColor: 'var(--color-accent, #0866ff)',
+    borderRadius: 4,
+  },
+  learnMoreBtn: {
+    backgroundColor: 'rgba(255,255,255,0.5)',
+    borderRadius: 'var(--radius-element, 8px)',
+    padding: '8px 12px',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: 14,
+    textAlign: 'center',
+    width: '100%',
+  },
+  selectorLabel: {
+    padding: '4px 0',
+  },
+});
+
+// ─── Product data ───────────────────────────────────────────────────────────
+const PRODUCTS = [
+  {
+    name: 'Custom Notebook',
+    details: 'Color: Brown\nSize: B5',
+    price: 20.0,
+    qty: 1,
+  },
+  {
+    name: 'Custom Notebook',
+    details: 'Color: Brown\nSize: B5',
+    price: 20.0,
+    qty: 1,
+  },
+  {
+    name: 'Leather Pen Case',
+    details: 'Color: Black\nMaterial: Full-grain leather',
+    price: 35.0,
+    qty: 2,
+  },
+  {
+    name: 'Fountain Pen',
+    details: 'Nib: Fine\nInk: Blue-black',
+    price: 45.0,
+    qty: 1,
+  },
+  {
+    name: 'Washi Tape Set',
+    details: 'Pack: 6 rolls\nPattern: Floral',
+    price: 12.0,
+    qty: 3,
+  },
+];
+
+const SUBTOTAL = PRODUCTS.reduce((sum, p) => sum + p.price * p.qty, 0);
+const DISCOUNT = 15.0;
+const SHIPPING = 0;
+const TAX_RATE = 0.0825;
+const TAX = Math.round((SUBTOTAL - DISCOUNT) * TAX_RATE * 100) / 100;
+const TOTAL = SUBTOTAL - DISCOUNT + SHIPPING + TAX;
+const fmt = (n: number) => `$${n.toFixed(2)}`;
+
+// ─── Activity data ──────────────────────────────────────────────────────────
+const ACTIVITY = [
+  {
+    type: 'event' as const,
+    user: 'Jane Doe',
+    text: 'placed order #1001',
+    reactions: 2,
+    time: 'Feb 23 at 9:12 AM',
+  },
+  {
+    type: 'comment' as const,
+    user: 'Alex Rivera',
+    text: "Customer requested gift wrapping for the notebooks. I've added a note to the packing slip — warehouse team should see it before fulfillment.",
+    reactions: 3,
+    time: 'Feb 23 at 10:45 AM',
+  },
+  {
+    type: 'update' as const,
+    user: 'System',
+    text: 'has several information changes',
+    time: 'Feb 23 at 11:30 AM',
+    changes: [
+      'Payment verified via Visa ...7482',
+      'Fraud check passed — low risk',
+    ],
+  },
+  {
+    type: 'event' as const,
+    user: 'Alex Rivera',
+    text: 'marked order as ready for fulfillment',
+    reactions: 1,
+    time: 'Feb 23 at 2:15 PM',
+  },
+];
+
+// ─── Side Nav ───────────────────────────────────────────────────────────────
+function ShopSideNav() {
+  const [active, setActive] = useState('orders');
+  return (
+    <XDSSideNav
+      collapsible
+      header={
+        <XDSHStack gap={2} vAlign="center" style={{padding: '8px 12px'}}>
+          <XDSNavIcon icon={<ShopIcon style={{width: 16, height: 16}} />} />
+          <XDSLink href="#" label="Acme" />
+        </XDSHStack>
+      }
+      footer={
+        <XDSVStack gap={0} style={{padding: '8px 0'}}>
+          <XDSSideNavItem
+            label="Settings"
+            icon={SettingsIcon}
+            isSelected={active === 'settings'}
+            onClick={() => setActive('settings')}
+          />
+          <XDSSideNavItem
+            label="Help Center"
+            icon={HelpIcon}
+            isSelected={active === 'help'}
+            onClick={() => setActive('help')}
+          />
+        </XDSVStack>
+      }>
+      <XDSSideNavSection>
+        <XDSSideNavItem
+          label="Home"
+          icon={HomeIcon}
+          isSelected={active === 'home'}
+          onClick={() => setActive('home')}
+        />
+        <XDSSideNavItem
+          label="Orders"
+          icon={OrdersIcon}
+          isSelected={active === 'orders'}
+          onClick={() => setActive('orders')}
+        />
+        <XDSSideNavItem
+          label="Products"
+          icon={ProductsIcon}
+          isSelected={active === 'products'}
+          onClick={() => setActive('products')}
+        />
+      </XDSSideNavSection>
+      <XDSSideNavSection title="Sales channels">
+        <XDSSideNavItem
+          label="Customers"
+          icon={CustomersIcon}
+          isSelected={active === 'customers'}
+          onClick={() => setActive('customers')}
+        />
+        <XDSSideNavItem
+          label="Content"
+          icon={ContentIcon}
+          isSelected={active === 'content'}
+          onClick={() => setActive('content')}
+        />
+        <XDSSideNavItem
+          label="Analytics"
+          icon={AnalyticsIcon}
+          isSelected={active === 'analytics'}
+          onClick={() => setActive('analytics')}
+        />
+      </XDSSideNavSection>
+    </XDSSideNav>
+  );
+}
+
+// ─── Bullet separator ───────────────────────────────────────────────────────
+function Bullet() {
+  return <span {...stylex.props(pageStyles.bulletSeparator)}>{'・'}</span>;
+}
+
+// ─── Page Header ────────────────────────────────────────────────────────────
+function PageHeader({
+  activeTab,
+  onTabChange,
+}: {
+  activeTab: string;
+  onTabChange: (v: string) => void;
+}) {
+  return (
+    <XDSLayoutHeader hasDivider padding={4}>
+      <XDSCenter axis="horizontal">
+        <XDSVStack xstyle={pageStyles.maxWidth} gap={0}>
+          {/* Back link */}
+          <XDSLink href="#" label="← All orders" />
+          {/* Title + metadata */}
+          <XDSVStack gap={0}>
+            {/* Title row */}
+            <XDSHStack
+              gap={2}
+              vAlign="center"
+              style={{justifyContent: 'space-between'}}>
+              <XDSHStack gap={2} vAlign="center">
+                <XDSHeading level={1}>#1001</XDSHeading>
+              </XDSHStack>
+              <XDSHStack gap={2} vAlign="center">
+                <XDSButton label="← 2/9 →" variant="ghost" size="sm" />
+                <XDSButton label="Restock" variant="secondary" size="sm" />
+                <XDSButton label="Edit" variant="secondary" size="sm" />
+              </XDSHStack>
+            </XDSHStack>
+
+            {/* Metadata row */}
+            <XDSHStack gap={1} vAlign="center" style={{flexWrap: 'wrap'}}>
+              <XDSText type="body">{PRODUCTS.length} ordered items</XDSText>
+              <Bullet />
+              <XDSHStack gap={1} vAlign="center">
+                <XDSAvatar name="Jane Doe" size="xsmall" />
+                <XDSText type="body">Jane Doe</XDSText>
+              </XDSHStack>
+              <Bullet />
+              <XDSBadge variant="warning" label="Unfulfilled" />
+              <Bullet />
+              <XDSHStack gap={1} vAlign="center">
+                <CalendarIcon {...stylex.props(pageStyles.metaIcon)} />
+                <XDSText type="body">02/23/2026</XDSText>
+              </XDSHStack>
+              <Bullet />
+              <XDSHStack gap={1} vAlign="center">
+                <FlagIcon {...stylex.props(pageStyles.metaIcon)} />
+                <XDSText type="body">Needs attention</XDSText>
+              </XDSHStack>
+              <Bullet />
+              <XDSLink href="#" label="See all" />
+            </XDSHStack>
+          </XDSVStack>
+
+          {/* Tabs */}
+          <XDSHStack
+            vAlign="center"
+            style={{
+              justifyContent: 'space-between',
+              marginInline: -12,
+              marginBottom: -16,
+              marginTop: 12,
+            }}>
+            <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
+              <XDSTab value="details" label="Details" />
+              <XDSTab value="invoices" label="Invoices" />
+              <XDSTab value="timeline" label="Timeline" />
+              <XDSTab value="customer" label="Customer" />
+              <XDSTab value="analysis" label="Analysis" />
+            </XDSTabList>
+            <XDSButton label="View options" variant="ghost" size="md" />
+          </XDSHStack>
+        </XDSVStack>
+      </XDSCenter>
+    </XDSLayoutHeader>
+  );
+}
+
+// ─── Items Card ─────────────────────────────────────────────────────────────
+function ItemsCard() {
+  return (
+    <XDSSection>
+      <XDSVStack gap={4}>
+        <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSHeading level={2}>Items</XDSHeading>
+            <XDSBadge variant="warning" label="Unfulfilled" />
+          </XDSHStack>
+          <XDSHStack gap={2}>
+            <XDSButton label="Fulfill item" variant="ghost" size="sm" />
+            <XDSButton
+              label="Create shipping label"
+              variant="secondary"
+              size="sm"
+            />
+          </XDSHStack>
+        </XDSHStack>
+
+        <XDSList density="spacious" style={{marginInline: -12}}>
+          {PRODUCTS.map((product, i) => (
+            <XDSListItem
+              key={i}
+              label={product.name}
+              description={
+                <XDSVStack gap={0}>
+                  {product.details.split('\n').map((line, j) => (
+                    <XDSText key={j} type="supporting" color="secondary">
+                      {line}
+                    </XDSText>
+                  ))}
+                </XDSVStack>
+              }
+              onClick={() => {}}
+              startContent={
+                <div style={{width: 100, height: 66, flexShrink: 0}}>
+                  <div
+                    style={{
+                      width: '100%',
+                      height: '100%',
+                      backgroundColor:
+                        'var(--color-background-deemphasized, #e5e5e5)',
+                      borderRadius: 'var(--radius-element, 8px)',
+                    }}
+                  />
+                </div>
+              }
+              endContent={
+                <XDSText type="body" color="secondary">
+                  {fmt(product.price)} {'×'} {product.qty}
+                  {'      '}
+                  {fmt(product.price * product.qty)}
+                </XDSText>
+              }
+            />
+          ))}
+        </XDSList>
+      </XDSVStack>
+    </XDSSection>
+  );
+}
+
+// ─── Invoice Card ───────────────────────────────────────────────────────────
+function InvoiceCard() {
+  return (
+    <XDSSection>
+      <XDSVStack gap={4}>
+        <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSHeading level={2}>Invoice</XDSHeading>
+            <XDSBadge variant="success" label="Paid" />
+          </XDSHStack>
+          <XDSHStack gap={2}>
+            <XDSButton label="Refund" variant="ghost" size="sm" />
+            <XDSButton label="Send Invoice" variant="secondary" size="sm" />
+          </XDSHStack>
+        </XDSHStack>
+
+        <XDSMetadataList>
+          <XDSMetadataListItem label="Subtotal">
+            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
+              <span>{PRODUCTS.length} items</span>
+              <span>{fmt(SUBTOTAL)}</span>
+            </XDSHStack>
+          </XDSMetadataListItem>
+          <XDSMetadataListItem label="Discount">
+            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
+              <span>New customer code: NEW15</span>
+              <span>– {fmt(DISCOUNT)}</span>
+            </XDSHStack>
+          </XDSMetadataListItem>
+          <XDSMetadataListItem label="Shipping">
+            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
+              <span>Free shipping (0.0lbs) USPS</span>
+              <span>{fmt(SHIPPING)}</span>
+            </XDSHStack>
+          </XDSMetadataListItem>
+          <XDSMetadataListItem label="Tax">
+            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
+              <span>Sales tax (8.25%)</span>
+              <span>{fmt(TAX)}</span>
+            </XDSHStack>
+          </XDSMetadataListItem>
+          <XDSMetadataListItem label="Total">
+            <XDSHStack style={{justifyContent: 'flex-end', width: '100%'}}>
+              <XDSText type="body" weight="bold">
+                {fmt(TOTAL)}
+              </XDSText>
+            </XDSHStack>
+          </XDSMetadataListItem>
+        </XDSMetadataList>
+
+        <XDSDivider />
+
+        <XDSMetadataList>
+          <XDSMetadataListItem label="Paid by customer">
+            <XDSHStack style={{justifyContent: 'space-between', width: '100%'}}>
+              <span>Visa ...7482</span>
+              <span>{fmt(TOTAL)}</span>
+            </XDSHStack>
+          </XDSMetadataListItem>
+        </XDSMetadataList>
+      </XDSVStack>
+    </XDSSection>
+  );
+}
+
+// ─── Timeline ───────────────────────────────────────────────────────────────
+function TimelineSection() {
+  return (
+    <XDSSection>
+      <XDSVStack gap={4}>
+        <XDSHStack vAlign="center" style={{justifyContent: 'space-between'}}>
+          <XDSHeading level={2}>Timeline</XDSHeading>
+          <XDSButton
+            label="Filters"
+            variant="ghost"
+            size="sm"
+            icon={<FilterIcon style={{width: 14, height: 14}} />}
+          />
+        </XDSHStack>
+
+        <XDSVStack gap={4}>
+          {ACTIVITY.map((item, i) => (
+            <div key={i}>
+              <XDSVStack gap={2}>
+                <XDSHStack gap={3} vAlign="start">
+                  <XDSAvatar name={item.user} size="small" />
+                  <XDSVStack gap={2} style={{flex: 1}}>
+                    <div {...stylex.props(pageStyles.commentBubble)}>
+                      <XDSVStack gap={1}>
+                        <XDSText type="body" weight="bold">
+                          {item.user}
+                        </XDSText>
+                        <XDSText type="body">{item.text}</XDSText>
+                        {item.changes && (
+                          <XDSVStack gap={1} style={{marginTop: 4}}>
+                            {item.changes.map((change, j) => (
+                              <XDSHStack key={j} gap={2} vAlign="center">
+                                <EditIcon
+                                  style={{
+                                    width: 14,
+                                    height: 14,
+                                    color: 'var(--color-text-secondary, #888)',
+                                  }}
+                                />
+                                <XDSText type="supporting" color="secondary">
+                                  {change}
+                                </XDSText>
+                              </XDSHStack>
+                            ))}
+                          </XDSVStack>
+                        )}
+                      </XDSVStack>
+                    </div>
+                    <div {...stylex.props(pageStyles.reactionBar)}>
+                      <XDSHStack gap={1} vAlign="center">
+                        <ThumbUpIcon style={{width: 12, height: 12}} />
+                        <HeartIcon style={{width: 12, height: 12}} />
+                        <span>{item.reactions}</span>
+                      </XDSHStack>
+                      <span>Like</span>
+                      <Bullet />
+                      <span>Reply</span>
+                      <Bullet />
+                      <span>{item.time}</span>
+                    </div>
+                  </XDSVStack>
+                </XDSHStack>
+              </XDSVStack>
+              {i < ACTIVITY.length - 1 && (
+                <XDSDivider style={{marginTop: 12}} />
+              )}
+            </div>
+          ))}
+        </XDSVStack>
+      </XDSVStack>
+    </XDSSection>
+  );
+}
+
+// ─── Right Panel ────────────────────────────────────────────────────────────
+function RightPanel() {
+  return (
+    <XDSLayoutPanel hasDivider width={320} padding={0} role="complementary">
+      <XDSVStack gap={4}>
+        {/* Notes */}
+        <div
+          {...stylex.props(pageStyles.panelSection)}
+          style={{padding: '8px 16px'}}>
+          <XDSCollapsible trigger={<XDSHeading level={4}>Notes</XDSHeading>}>
+            <XDSText type="body">
+              Customer is a repeat buyer — 3rd order this quarter. Prefers brown
+              leather goods and grid-format notebooks. Requested gift wrapping
+              for this order. Ships to a residential address in CA.{' '}
+              <XDSLink href="#" label="Show more" />
+            </XDSText>
+          </XDSCollapsible>
+        </div>
+
+        {/* Customer */}
+        <div
+          {...stylex.props(pageStyles.panelSection)}
+          style={{padding: '8px 16px'}}>
+          <XDSCollapsible trigger={<XDSHeading level={4}>Customer</XDSHeading>}>
+            <XDSMetadataList>
+              <XDSMetadataListItem label="Name">Jane Doe</XDSMetadataListItem>
+              <XDSMetadataListItem label="Address">
+                321 Smith Road, CA 38238
+              </XDSMetadataListItem>
+              <XDSMetadataListItem label="Phone">234-</XDSMetadataListItem>
+              <XDSMetadataListItem label="Email">
+                janedoe@email.com
+              </XDSMetadataListItem>
+              <XDSMetadataListItem label="Billing Address">
+                Same as shipping address
+              </XDSMetadataListItem>
+            </XDSMetadataList>
+          </XDSCollapsible>
+        </div>
+
+        {/* Fraud Analysis */}
+        <div
+          {...stylex.props(pageStyles.panelSection)}
+          style={{padding: '8px 16px'}}>
+          <XDSCollapsible
+            trigger={<XDSHeading level={4}>Fraud Analysis</XDSHeading>}>
+            <XDSCard>
+              <XDSSection variant="wash">
+                <XDSVStack gap={3}>
+                  <XDSText type="body">Recommendation: Fulfill order</XDSText>
+                  <XDSProgressBar
+                    label="Risk level"
+                    value={15}
+                    variant="positive"
+                    isLabelHidden
+                  />
+                  <XDSText type="body">
+                    There is a low chance that you will receive a chargeback on
+                    this order.
+                  </XDSText>
+                  <XDSButton label="Learn more" variant="secondary" size="sm" />
+                </XDSVStack>
+              </XDSSection>
+            </XDSCard>
+          </XDSCollapsible>
+        </div>
+      </XDSVStack>
+    </XDSLayoutPanel>
+  );
+}
+
+// ─── Main Page ──────────────────────────────────────────────────────────────
+export default function DetailPage2Template() {
+  const [activeTab, setActiveTab] = useState('details');
+
+  return (
+    <XDSAppShell
+      sideNav={<ShopSideNav />}
+      variant="elevated"
+      contentPadding={0}>
+      <XDSLayout
+        height="fill"
+        defaultHasDividers
+        header={<PageHeader activeTab={activeTab} onTabChange={setActiveTab} />}
+        content={
+          <XDSLayoutContent role="main" padding={0}>
+            <div
+              {...stylex.props(
+                pageStyles.centeredContent,
+                pageStyles.sectionGap,
+              )}>
+              <ItemsCard />
+              <InvoiceCard />
+              <TimelineSection />
+            </div>
+          </XDSLayoutContent>
+        }
+        end={<RightPanel />}
+      />
+    </XDSAppShell>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
@@ -12,6 +12,7 @@ import {
   XDSSegmentedControl,
   XDSSegmentedControlItem,
 } from '@xds/core/SegmentedControl';
+import {XDSBadge} from '@xds/core/Badge';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSCollapsible, XDSCollapsibleGroup} from '@xds/core/Collapsible';
 import {XDSNavIcon} from '@xds/core/NavIcon';
@@ -62,6 +63,65 @@ const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
     <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z" />
   </svg>
 );
+
+// ─── Star Rating ─────────────────────────────────────────────────────────────
+function StarRating({rating, count}: {rating: number; count: number}) {
+  const full = Math.floor(rating);
+  const partial = rating - full;
+  const empty = 5 - full - (partial > 0 ? 1 : 0);
+  const starSize = 16;
+
+  return (
+    <div style={{display: 'flex', alignItems: 'center', gap: 6}}>
+      {Array.from({length: full}, (_, i) => (
+        <svg
+          key={`full-${i}`}
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          style={{width: starSize, height: starSize, color: '#f59e0b'}}>
+          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+        </svg>
+      ))}
+      {partial > 0 && (
+        <svg
+          key="partial"
+          viewBox="0 0 24 24"
+          style={{width: starSize, height: starSize}}>
+          <defs>
+            <clipPath id="star-clip">
+              <rect x="0" y="0" width={24 * partial} height="24" />
+            </clipPath>
+          </defs>
+          <path
+            d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+            fill="#f59e0b"
+            clipPath="url(#star-clip)"
+          />
+          <path
+            d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
+            fill="none"
+            stroke="#f59e0b"
+            strokeWidth={1.5}
+          />
+        </svg>
+      )}
+      {Array.from({length: empty}, (_, i) => (
+        <svg
+          key={`empty-${i}`}
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="#f59e0b"
+          strokeWidth={1.5}
+          style={{width: starSize, height: starSize}}>
+          <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
+        </svg>
+      ))}
+      <XDSText type="body" color="secondary">
+        {rating} ({count})
+      </XDSText>
+    </div>
+  );
+}
 
 // ─── Image URLs ─────────────────────────────────────────────────────────────
 const IMAGES = [
@@ -235,7 +295,7 @@ function ProductInfo() {
 
   return (
     <XDSVStack gap={5}>
-      {/* Title & Price */}
+      {/* Title & Rating */}
       <XDSVStack gap={2}>
         <p
           style={{
@@ -246,13 +306,15 @@ function ProductInfo() {
           }}>
           {PRODUCT.name}
         </p>
-        <XDSHStack gap={2} style={{alignItems: 'baseline'}}>
+        <StarRating rating={4.3} count={128} />
+        <XDSHStack gap={2} style={{alignItems: 'center'}}>
           <XDSText type="large" weight="bold">
             {fmt(PRODUCT.price)}
           </XDSText>
           <XDSText type="body" color="secondary" hasStrikethrough>
             {fmt(PRODUCT.originalPrice)}
           </XDSText>
+          <XDSBadge variant="success" label="In stock" />
         </XDSHStack>
       </XDSVStack>
 
@@ -309,6 +371,23 @@ function ProductInfo() {
         style={{display: 'flex', width: '100%'}}>
         Add to Cart
       </XDSButton>
+
+      {/* Buy it now + Wishlist */}
+      <XDSHStack gap={2}>
+        <XDSButton
+          label="Buy it now"
+          variant="secondary"
+          size="lg"
+          style={{display: 'flex', flex: 1}}>
+          Buy it now
+        </XDSButton>
+        <XDSButton
+          label="Add to wishlist"
+          variant="ghost"
+          size="lg"
+          icon={<HeartIcon style={{width: 16, height: 16}} />}
+        />
+      </XDSHStack>
 
       {/* Description */}
       <XDSText type="body">{PRODUCT.description}</XDSText>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
@@ -7,7 +7,6 @@ import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
-import {XDSNumberInput} from '@xds/core/NumberInput';
 import {
   XDSSegmentedControl,
   XDSSegmentedControlItem,
@@ -64,6 +63,31 @@ const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+const MinusIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    {...props}>
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const PlusIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    {...props}>
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
 // ─── Star Rating ─────────────────────────────────────────────────────────────
 function StarRating({rating, count}: {rating: number; count: number}) {
   const full = Math.floor(rating);
@@ -72,13 +96,17 @@ function StarRating({rating, count}: {rating: number; count: number}) {
   const starSize = 16;
 
   return (
-    <div style={{display: 'flex', alignItems: 'center', gap: 6}}>
+    <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
       {Array.from({length: full}, (_, i) => (
         <svg
           key={`full-${i}`}
           viewBox="0 0 24 24"
           fill="currentColor"
-          style={{width: starSize, height: starSize, color: '#f59e0b'}}>
+          style={{
+            width: starSize,
+            height: starSize,
+            color: 'var(--color-accent)',
+          }}>
           <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
         </svg>
       ))}
@@ -94,13 +122,13 @@ function StarRating({rating, count}: {rating: number; count: number}) {
           </defs>
           <path
             d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
-            fill="#f59e0b"
+            fill="var(--color-accent)"
             clipPath="url(#star-clip)"
           />
           <path
             d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
             fill="none"
-            stroke="#f59e0b"
+            stroke="var(--color-accent)"
             strokeWidth={1.5}
           />
         </svg>
@@ -110,7 +138,7 @@ function StarRating({rating, count}: {rating: number; count: number}) {
           key={`empty-${i}`}
           viewBox="0 0 24 24"
           fill="none"
-          stroke="#f59e0b"
+          stroke="var(--color-accent)"
           strokeWidth={1.5}
           style={{width: starSize, height: starSize}}>
           <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
@@ -124,13 +152,15 @@ function StarRating({rating, count}: {rating: number; count: number}) {
 }
 
 // ─── Image URLs ─────────────────────────────────────────────────────────────
+// Main hero: B&W living room (unsplash pqyu59ZcbLU)
+// Thumbnails: B&W interiors of similar tone
 const IMAGES = [
-  'https://images.unsplash.com/photo-1513506003901-1e6a229e2d15?w=800&q=80',
-  'https://images.unsplash.com/photo-1540574163026-643ea20ade25?w=400&q=80',
-  'https://images.unsplash.com/photo-1524484485831-a92ffc0de03f?w=400&q=80',
+  'https://images.unsplash.com/photo-1567016432779-094069958ea5?w=800&q=80',
+  'https://images.unsplash.com/photo-1555041469-a586c61ea9bc?w=400&q=80',
   'https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?w=400&q=80',
-  'https://images.unsplash.com/photo-1416339134316-0e91dc9ded92?w=400&q=80',
-  'https://images.unsplash.com/photo-1505691938895-1758d7feb511?w=400&q=80',
+  'https://images.unsplash.com/photo-1560448204-603b3fc33ddc?w=400&q=80',
+  'https://images.unsplash.com/photo-1616486338812-3dadae4b4ace?w=400&q=80',
+  'https://images.unsplash.com/photo-1586023492125-27b2c045efd7?w=400&q=80',
   'https://images.unsplash.com/photo-1489171078254-c3365d6e359f?w=400&q=80',
 ];
 
@@ -163,13 +193,6 @@ const FINISHES = [
 ];
 
 const fmt = (n: number) => `$${n.toFixed(2)}`;
-
-// ─── Placeholder image style ────────────────────────────────────────────────
-const placeholderStyle: React.CSSProperties = {
-  backgroundColor: '#e8e8e8',
-  borderRadius: 'var(--radius-element, 8px)',
-  border: '1px solid #d4d4d4',
-};
 
 // ─── TopNav ─────────────────────────────────────────────────────────────────
 function StoreTopNav() {
@@ -291,7 +314,10 @@ function ImageGallery({
 function ProductInfo() {
   const [color, setColor] = useState('matte-black');
   const [finish, setFinish] = useState('linen');
-  const [quantity, setQuantity] = useState<number | null>(1);
+  const [quantity, setQuantity] = useState(1);
+
+  const decrement = () => setQuantity(q => Math.max(1, q - 1));
+  const increment = () => setQuantity(q => Math.min(10, q + 1));
 
   return (
     <XDSVStack gap={5}>
@@ -314,7 +340,7 @@ function ProductInfo() {
           <XDSText type="body" color="secondary" hasStrikethrough>
             {fmt(PRODUCT.originalPrice)}
           </XDSText>
-          <XDSBadge variant="success" label="In stock" />
+          <XDSBadge variant="error" label="Sale" />
         </XDSHStack>
       </XDSVStack>
 
@@ -354,40 +380,73 @@ function ProductInfo() {
       </XDSVStack>
 
       {/* Quantity */}
-      <XDSNumberInput
-        label="Quantity"
-        value={quantity}
-        onChange={setQuantity}
-        min={1}
-        max={10}
-        isIntegerOnly
-      />
+      <XDSVStack gap={1}>
+        <XDSText type="label">Quantity</XDSText>
+        <XDSHStack gap={1} vAlign="center">
+          <XDSButton
+            label="Decrease quantity"
+            variant="ghost"
+            icon={<MinusIcon style={{width: 16, height: 16}} />}
+            onClickAction={decrement}
+            isDisabled={quantity <= 1}
+          />
+          <input
+            type="number"
+            value={quantity}
+            min={1}
+            max={10}
+            readOnly
+            aria-label="Quantity"
+            style={{
+              width: 100,
+              textAlign: 'center',
+              border: '1px solid var(--color-divider-emphasized)',
+              borderRadius: 'var(--radius-element, 8px)',
+              padding: '6px 8px',
+              fontSize: 'var(--text-body-size, 14px)',
+              color: 'var(--color-text-primary)',
+              backgroundColor: 'var(--color-background-surface)',
+              outline: 'none',
+              MozAppearance: 'textfield',
+            }}
+          />
+          <XDSButton
+            label="Increase quantity"
+            variant="ghost"
+            icon={<PlusIcon style={{width: 16, height: 16}} />}
+            onClickAction={increment}
+            isDisabled={quantity >= 10}
+          />
+        </XDSHStack>
+      </XDSVStack>
 
-      {/* Add to Cart */}
-      <XDSButton
-        label="Add to Cart"
-        variant="primary"
-        size="lg"
-        style={{display: 'flex', width: '100%'}}>
-        Add to Cart
-      </XDSButton>
-
-      {/* Buy it now + Wishlist */}
-      <XDSHStack gap={2}>
+      {/* Add to Cart + Buy it now (8px gap between them) */}
+      <XDSVStack gap={2}>
         <XDSButton
-          label="Buy it now"
-          variant="secondary"
+          label="Add to Cart"
+          variant="primary"
           size="lg"
-          style={{display: 'flex', flex: 1}}>
-          Buy it now
+          style={{display: 'flex', width: '100%'}}>
+          Add to Cart
         </XDSButton>
-        <XDSButton
-          label="Add to wishlist"
-          variant="ghost"
-          size="lg"
-          icon={<HeartIcon style={{width: 16, height: 16}} />}
-        />
-      </XDSHStack>
+
+        {/* Buy it now + Wishlist */}
+        <XDSHStack gap={2}>
+          <XDSButton
+            label="Buy it now"
+            variant="secondary"
+            size="lg"
+            style={{display: 'flex', flex: 1}}>
+            Buy it now
+          </XDSButton>
+          <XDSButton
+            label="Add to wishlist"
+            variant="ghost"
+            size="lg"
+            icon={<HeartIcon style={{width: 16, height: 16}} />}
+          />
+        </XDSHStack>
+      </XDSVStack>
 
       {/* Description */}
       <XDSText type="body">{PRODUCT.description}</XDSText>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
@@ -7,6 +7,7 @@ import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSCenter} from '@xds/core/Center';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
+import {XDSNumberInput} from '@xds/core/NumberInput';
 import {
   XDSSegmentedControl,
   XDSSegmentedControlItem,
@@ -105,7 +106,7 @@ function StarRating({rating, count}: {rating: number; count: number}) {
           style={{
             width: starSize,
             height: starSize,
-            color: 'var(--color-accent)',
+            color: 'var(--color-icon-primary)',
           }}>
           <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
         </svg>
@@ -122,13 +123,13 @@ function StarRating({rating, count}: {rating: number; count: number}) {
           </defs>
           <path
             d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
-            fill="var(--color-accent)"
+            fill="var(--color-icon-primary)"
             clipPath="url(#star-clip)"
           />
           <path
             d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"
             fill="none"
-            stroke="var(--color-accent)"
+            stroke="var(--color-icon-primary)"
             strokeWidth={1.5}
           />
         </svg>
@@ -138,7 +139,7 @@ function StarRating({rating, count}: {rating: number; count: number}) {
           key={`empty-${i}`}
           viewBox="0 0 24 24"
           fill="none"
-          stroke="var(--color-accent)"
+          stroke="var(--color-icon-primary)"
           strokeWidth={1.5}
           style={{width: starSize, height: starSize}}>
           <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z" />
@@ -314,10 +315,10 @@ function ImageGallery({
 function ProductInfo() {
   const [color, setColor] = useState('matte-black');
   const [finish, setFinish] = useState('linen');
-  const [quantity, setQuantity] = useState(1);
+  const [quantity, setQuantity] = useState<number | null>(1);
 
-  const decrement = () => setQuantity(q => Math.max(1, q - 1));
-  const increment = () => setQuantity(q => Math.min(10, q + 1));
+  const decrement = () => setQuantity(q => Math.max(1, (q ?? 1) - 1));
+  const increment = () => setQuantity(q => Math.min(10, (q ?? 1) + 1));
 
   return (
     <XDSVStack gap={5}>
@@ -380,45 +381,33 @@ function ProductInfo() {
       </XDSVStack>
 
       {/* Quantity */}
-      <XDSVStack gap={1}>
-        <XDSText type="label">Quantity</XDSText>
-        <XDSHStack gap={1} vAlign="center">
-          <XDSButton
-            label="Decrease quantity"
-            variant="ghost"
-            icon={<MinusIcon style={{width: 16, height: 16}} />}
-            onClickAction={decrement}
-            isDisabled={quantity <= 1}
-          />
-          <input
-            type="number"
+      <XDSHStack gap={1} vAlign="center">
+        <XDSButton
+          label="Decrease quantity"
+          variant="ghost"
+          icon={<MinusIcon style={{width: 16, height: 16}} />}
+          onClickAction={decrement}
+          isDisabled={(quantity ?? 1) <= 1}
+        />
+        <div style={{width: 100}}>
+          <XDSNumberInput
+            label="Quantity"
+            isLabelHidden
             value={quantity}
+            onChange={setQuantity}
             min={1}
             max={10}
-            readOnly
-            aria-label="Quantity"
-            style={{
-              width: 100,
-              textAlign: 'center',
-              border: '1px solid var(--color-divider-emphasized)',
-              borderRadius: 'var(--radius-element, 8px)',
-              padding: '6px 8px',
-              fontSize: 'var(--text-body-size, 14px)',
-              color: 'var(--color-text-primary)',
-              backgroundColor: 'var(--color-background-surface)',
-              outline: 'none',
-              MozAppearance: 'textfield',
-            }}
+            isIntegerOnly
           />
-          <XDSButton
-            label="Increase quantity"
-            variant="ghost"
-            icon={<PlusIcon style={{width: 16, height: 16}} />}
-            onClickAction={increment}
-            isDisabled={quantity >= 10}
-          />
-        </XDSHStack>
-      </XDSVStack>
+        </div>
+        <XDSButton
+          label="Increase quantity"
+          variant="ghost"
+          icon={<PlusIcon style={{width: 16, height: 16}} />}
+          onClickAction={increment}
+          isDisabled={(quantity ?? 1) >= 10}
+        />
+      </XDSHStack>
 
       {/* Add to Cart + Buy it now (8px gap between them) */}
       <XDSVStack gap={2}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
@@ -64,7 +64,15 @@ const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
 );
 
 // ─── Image URLs ─────────────────────────────────────────────────────────────
-// TODO: Swap placeholder gray rectangles for real product images when merging.
+const IMAGES = [
+  'https://images.unsplash.com/photo-1513506003901-1e6a229e2d15?w=800&q=80',
+  'https://images.unsplash.com/photo-1540574163026-643ea20ade25?w=400&q=80',
+  'https://images.unsplash.com/photo-1524484485831-a92ffc0de03f?w=400&q=80',
+  'https://images.unsplash.com/photo-1493663284031-b7e3aefcae8e?w=400&q=80',
+  'https://images.unsplash.com/photo-1416339134316-0e91dc9ded92?w=400&q=80',
+  'https://images.unsplash.com/photo-1505691938895-1758d7feb511?w=400&q=80',
+  'https://images.unsplash.com/photo-1489171078254-c3365d6e359f?w=400&q=80',
+];
 
 // ─── Product Data ───────────────────────────────────────────────────────────
 const PRODUCT = {
@@ -162,15 +170,21 @@ function ImageGallery({
   selected: number;
   onSelect: (i: number) => void;
 }) {
+  const heroSrc = IMAGES[selected + 1] ?? IMAGES[0];
+  const thumbnails = IMAGES.slice(1);
+
   return (
     <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
       {/* Hero image */}
-      <div
+      <img
+        src={heroSrc}
+        alt={PRODUCT.name}
         style={{
-          ...placeholderStyle,
           width: '100%',
           aspectRatio: '4 / 5',
+          objectFit: 'cover',
           borderRadius: 'var(--radius-container, 12px)',
+          backgroundColor: '#e8e8e8',
         }}
       />
       {/* Thumbnail grid */}
@@ -180,13 +194,17 @@ function ImageGallery({
           gridTemplateColumns: 'repeat(3, 1fr)',
           gap: 8,
         }}>
-        {Array.from({length: 6}, (_, i) => (
-          <div
+        {thumbnails.map((src, i) => (
+          <img
             key={i}
+            src={src}
+            alt={`Product image ${i + 1}`}
             style={{
-              ...placeholderStyle,
+              width: '100%',
               aspectRatio: '1 / 1',
+              objectFit: 'cover',
               cursor: 'pointer',
+              borderRadius: 'var(--radius-element, 8px)',
               outline:
                 selected === i
                   ? '2px solid var(--color-accent, #0866ff)'
@@ -196,7 +214,6 @@ function ImageGallery({
             onClick={() => onSelect(i)}
             role="button"
             tabIndex={0}
-            aria-label={`Product image ${i + 1}`}
             onKeyDown={e => {
               if (e.key === 'Enter' || e.key === ' ') {
                 e.preventDefault();

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-product-detail/page.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import {useState} from 'react';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSCenter} from '@xds/core/Center';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {XDSNumberInput} from '@xds/core/NumberInput';
+import {
+  XDSSegmentedControl,
+  XDSSegmentedControlItem,
+} from '@xds/core/SegmentedControl';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSCollapsible, XDSCollapsibleGroup} from '@xds/core/Collapsible';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+
+// ─── Icons ──────────────────────────────────────────────────────────────────
+const BagIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M6 2L3 6v14a2 2 0 002 2h14a2 2 0 002-2V6l-3-4zM3 6h18M16 10a4 4 0 01-8 0" />
+  </svg>
+);
+
+const UserIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M20 21v-2a4 4 0 00-4-4H8a4 4 0 00-4 4v2" />
+    <circle cx="12" cy="7" r="4" />
+  </svg>
+);
+
+const SearchIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <circle cx="11" cy="11" r="8" />
+    <path d="M21 21l-4.35-4.35" />
+  </svg>
+);
+
+const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}>
+    <path d="M20.84 4.61a5.5 5.5 0 00-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 00-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 000-7.78z" />
+  </svg>
+);
+
+// ─── Image URLs ─────────────────────────────────────────────────────────────
+// TODO: Swap placeholder gray rectangles for real product images when merging.
+
+// ─── Product Data ───────────────────────────────────────────────────────────
+const PRODUCT = {
+  name: 'Arc Floor Lamp',
+  price: 249.0,
+  originalPrice: 329.0,
+  description:
+    'A sculptural arc floor lamp that balances bold geometry with warm ambient light. The adjustable arm extends up to 72 inches, casting a wide pool of light over a reading nook, sofa, or desk. The weighted marble base keeps it stable without a bulky footprint. A built-in dimmer on the cord lets you shift from bright task lighting to a soft evening glow. Pairs beautifully with mid-century and minimalist interiors alike.',
+  composition:
+    'Powder-coated steel arm with a brushed brass finish at the joints. Natural Carrara marble base (each piece has unique veining). Linen drum shade lined in white for even light diffusion. UL-listed for dry locations. Uses one standard E26 bulb (LED recommended, up to 100W equivalent).',
+  deliveryReturns:
+    'Free white-glove delivery on all lighting orders. Professional assembly included. Returns accepted within 14 days — item must be unassembled in original packaging. Replacement shades available separately.',
+  dimensions:
+    'Overall height: 183 cm / 72 in (adjustable). Base diameter: 30 cm / 12 in. Shade diameter: 36 cm / 14 in. Shade height: 25 cm / 10 in. Arm reach: 100 cm / 39 in.',
+};
+
+const COLORS = [
+  {value: 'matte-black', label: 'Matte Black'},
+  {value: 'brass', label: 'Brass'},
+  {value: 'white', label: 'White'},
+  {value: 'walnut', label: 'Walnut'},
+];
+
+const FINISHES = [
+  {value: 'linen', label: 'Linen'},
+  {value: 'frosted', label: 'Frosted Glass'},
+  {value: 'rattan', label: 'Rattan'},
+];
+
+const fmt = (n: number) => `$${n.toFixed(2)}`;
+
+// ─── Placeholder image style ────────────────────────────────────────────────
+const placeholderStyle: React.CSSProperties = {
+  backgroundColor: '#e8e8e8',
+  borderRadius: 'var(--radius-element, 8px)',
+  border: '1px solid #d4d4d4',
+};
+
+// ─── TopNav ─────────────────────────────────────────────────────────────────
+function StoreTopNav() {
+  return (
+    <XDSTopNav
+      label="Store navigation"
+      heading={
+        <XDSTopNavHeading
+          heading="Haus Studio"
+          logo={
+            <XDSNavIcon icon={<BagIcon style={{width: 16, height: 16}} />} />
+          }
+          href="#"
+        />
+      }
+      centerContent={
+        <>
+          <XDSTopNavItem label="New Arrivals" href="#" />
+          <XDSTopNavItem label="Lighting" href="#" isSelected />
+          <XDSTopNavItem label="Furniture" href="#" />
+          <XDSTopNavItem label="Decor" href="#" />
+          <XDSTopNavItem label="About" href="#" />
+        </>
+      }
+      endContent={
+        <>
+          <XDSButton
+            label="Search"
+            variant="ghost"
+            icon={<SearchIcon style={{width: 16, height: 16}} />}
+          />
+          <XDSButton
+            label="Wishlist"
+            variant="ghost"
+            icon={<HeartIcon style={{width: 16, height: 16}} />}
+          />
+          <XDSButton
+            label="Account"
+            variant="ghost"
+            icon={<UserIcon style={{width: 16, height: 16}} />}
+          />
+          <XDSButton
+            label="Cart"
+            variant="ghost"
+            icon={<BagIcon style={{width: 16, height: 16}} />}
+          />
+        </>
+      }
+    />
+  );
+}
+
+// ─── Image Gallery ──────────────────────────────────────────────────────────
+function ImageGallery({
+  selected,
+  onSelect,
+}: {
+  selected: number;
+  onSelect: (i: number) => void;
+}) {
+  return (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
+      {/* Hero image */}
+      <div
+        style={{
+          ...placeholderStyle,
+          width: '100%',
+          aspectRatio: '4 / 5',
+          borderRadius: 'var(--radius-container, 12px)',
+        }}
+      />
+      {/* Thumbnail grid */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: 8,
+        }}>
+        {Array.from({length: 6}, (_, i) => (
+          <div
+            key={i}
+            style={{
+              ...placeholderStyle,
+              aspectRatio: '1 / 1',
+              cursor: 'pointer',
+              outline:
+                selected === i
+                  ? '2px solid var(--color-accent, #0866ff)'
+                  : 'none',
+              outlineOffset: selected === i ? 2 : 0,
+            }}
+            onClick={() => onSelect(i)}
+            role="button"
+            tabIndex={0}
+            aria-label={`Product image ${i + 1}`}
+            onKeyDown={e => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                onSelect(i);
+              }
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Product Info ───────────────────────────────────────────────────────────
+function ProductInfo() {
+  const [color, setColor] = useState('matte-black');
+  const [finish, setFinish] = useState('linen');
+  const [quantity, setQuantity] = useState<number | null>(1);
+
+  return (
+    <XDSVStack gap={5}>
+      {/* Title & Price */}
+      <XDSVStack gap={2}>
+        <p
+          style={{
+            fontSize: 'var(--font-size-4xl, 2.25rem)',
+            lineHeight: 1.1,
+            fontWeight: 700,
+            margin: 0,
+          }}>
+          {PRODUCT.name}
+        </p>
+        <XDSHStack gap={2} style={{alignItems: 'baseline'}}>
+          <XDSText type="large" weight="bold">
+            {fmt(PRODUCT.price)}
+          </XDSText>
+          <XDSText type="body" color="secondary" hasStrikethrough>
+            {fmt(PRODUCT.originalPrice)}
+          </XDSText>
+        </XDSHStack>
+      </XDSVStack>
+
+      {/* Color Selector */}
+      <XDSVStack gap={2}>
+        <XDSText type="label">Color</XDSText>
+        <div style={{width: 'fit-content'}}>
+          <XDSSegmentedControl value={color} onChange={setColor} label="Color">
+            {COLORS.map(c => (
+              <XDSSegmentedControlItem
+                key={c.value}
+                value={c.value}
+                label={c.label}
+              />
+            ))}
+          </XDSSegmentedControl>
+        </div>
+      </XDSVStack>
+
+      {/* Shade Finish Selector */}
+      <XDSVStack gap={2}>
+        <XDSText type="label">Shade Finish</XDSText>
+        <div style={{width: 'fit-content'}}>
+          <XDSSegmentedControl
+            value={finish}
+            onChange={setFinish}
+            label="Shade Finish">
+            {FINISHES.map(f => (
+              <XDSSegmentedControlItem
+                key={f.value}
+                value={f.value}
+                label={f.label}
+              />
+            ))}
+          </XDSSegmentedControl>
+        </div>
+      </XDSVStack>
+
+      {/* Quantity */}
+      <XDSNumberInput
+        label="Quantity"
+        value={quantity}
+        onChange={setQuantity}
+        min={1}
+        max={10}
+        isIntegerOnly
+      />
+
+      {/* Add to Cart */}
+      <XDSButton
+        label="Add to Cart"
+        variant="primary"
+        size="lg"
+        style={{display: 'flex', width: '100%'}}>
+        Add to Cart
+      </XDSButton>
+
+      {/* Description */}
+      <XDSText type="body">{PRODUCT.description}</XDSText>
+
+      {/* Collapsible Sections */}
+      <XDSCollapsibleGroup type="multiple" defaultValue={['composition']}>
+        <XDSDivider />
+        <XDSCollapsible
+          value="composition"
+          trigger={<XDSHeading level={3}>Composition</XDSHeading>}>
+          <XDSText type="body">{PRODUCT.composition}</XDSText>
+        </XDSCollapsible>
+        <XDSDivider />
+        <XDSCollapsible
+          value="delivery"
+          defaultIsOpen={false}
+          trigger={<XDSHeading level={3}>Delivery &amp; Returns</XDSHeading>}>
+          <XDSText type="body">{PRODUCT.deliveryReturns}</XDSText>
+        </XDSCollapsible>
+        <XDSDivider />
+        <XDSCollapsible
+          value="dimensions"
+          defaultIsOpen={false}
+          trigger={<XDSHeading level={3}>Dimensions</XDSHeading>}>
+          <XDSText type="body">{PRODUCT.dimensions}</XDSText>
+        </XDSCollapsible>
+        <XDSDivider />
+      </XDSCollapsibleGroup>
+    </XDSVStack>
+  );
+}
+
+// ─── Main Page ──────────────────────────────────────────────────────────────
+export default function ProductDetailTemplate() {
+  const [selectedThumb, setSelectedThumb] = useState(0);
+
+  return (
+    <XDSAppShell
+      topNav={<StoreTopNav />}
+      height="auto"
+      contentPadding={0}
+      variant="surface">
+      <XDSCenter axis="horizontal">
+        <div
+          style={{
+            maxWidth: 1200,
+            width: '100%',
+            padding: '32px 24px',
+          }}>
+          <div
+            style={{
+              display: 'flex',
+              gap: 40,
+              alignItems: 'flex-start',
+            }}>
+            <div style={{flex: '1 1 55%', minWidth: 0}}>
+              <ImageGallery
+                selected={selectedThumb}
+                onSelect={setSelectedThumb}
+              />
+            </div>
+            <div
+              style={{
+                flex: '1 1 45%',
+                minWidth: 0,
+                position: 'sticky',
+                top: 64,
+              }}>
+              <ProductInfo />
+            </div>
+          </div>
+        </div>
+      </XDSCenter>
+    </XDSAppShell>
+  );
+}

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -131,6 +131,12 @@ export const categories: SandboxCategory[] = [
         href: '/pages/template-detail-2/',
         description: 'Order details',
       },
+      {
+        name: 'Detail Page (Product)',
+        href: '/pages/template-product-detail/',
+        description:
+          'Product detail page with image gallery, options, and collapsible info',
+      },
     ],
   },
   {

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -126,6 +126,11 @@ export const categories: SandboxCategory[] = [
         description:
           'macOS Finder-style column view with drill-down file navigation',
       },
+      {
+        name: 'Details Page',
+        href: '/pages/template-detail-2/',
+        description: 'Order details',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Adds a new **Details Page** template to the sandbox, showcasing an e-commerce order detail view (Order #1001)
- Demonstrates XDSAppShell, XDSLayout, XDSSideNav, XDSTabList, XDSSection, XDSList, XDSMetadataList, XDSCollapsible, XDSProgressBar, and XDSCard components in a realistic composition
- Registers the page in `sandboxPages.ts` under the Templates category

## Test plan
- [ ] Visit `/pages/template-detail-2/` in the sandbox and verify the page renders correctly
- [ ] Verify sidebar navigation is collapsible
- [ ] Verify tab list, items list, invoice, and timeline sections display correctly
- [ ] Verify right panel with Notes, Customer, and Fraud Analysis sections
- [ ] Run `node scripts/capture-previews.mjs` to generate a preview screenshot