### PR TITLE
sandbox: Form (Simple) template

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -235,13 +235,6 @@ export default function FormSimplePage() {
               status={errors.budget ? {type: 'error', message: errors.budget} : undefined}
             />
 
-            <XDSTextArea
-              label="Anything else?"
-              placeholder="Tell us whatever else is on your mind..."
-              value={message}
-              onChange={setMessage}
-            />
-
             <XDSRadioList
               label="How did you hear about us?"
               value={hearAboutUs}
@@ -253,6 +246,13 @@ export default function FormSimplePage() {
               <XDSRadioListItem label="Event or conference" value="event" />
               <XDSRadioListItem label="Other" value="other" />
             </XDSRadioList>
+
+            <XDSTextArea
+              label="Anything else?"
+              placeholder="Tell us whatever else is on your mind..."
+              value={message}
+              onChange={setMessage}
+            />
 
             <XDSCheckboxInput
               label="I'm a budget decision-maker"

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -30,6 +30,9 @@ const CAMPAIGN_GOALS = [
   'Event Promotion',
   'Retail / In-Store',
   'Trade Show',
+  'Influencer Activation',
+  'Community Building',
+  'Seasonal Campaign',
   'Other',
 ];
 
@@ -167,7 +170,9 @@ export default function FormSimplePage() {
               />
             </div>
 
-            <XDSDivider label="About your campaign" />
+            <div style={{paddingBlock: 16}}>
+              <XDSDivider label="About your campaign" />
+            </div>
 
             {/* Goals */}
             <XDSVStack gap={2}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -51,6 +51,10 @@ const styles = stylex.create({
   fullWidth: {
     width: '100%',
   },
+  errorText: {
+    color: colorVars['--color-error'],
+    fontSize: 12,
+  },
 });
 
 /**
@@ -171,7 +175,7 @@ export default function FormSimplePage() {
                 ))}
               </div>
               {errors.goals && (
-                <span style={{fontSize: 12, color: 'var(--xds-color-error)'}}>
+                <span {...stylex.props(styles.errorText)}>
                   {errors.goals}
                 </span>
               )}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -10,6 +10,7 @@ import {XDSSelector} from '@xds/core/Selector';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSLink} from '@xds/core/Link';
+import {XDSTextArea} from '@xds/core/TextArea';
 import {colorVars} from '@xds/core/theme/tokens.stylex';
 import {
   radiusVars,
@@ -90,6 +91,7 @@ export default function FormSimplePage() {
   const [goals, setGoals] = useState<string[]>([]);
   const [timeline, setTimeline] = useState('');
   const [budget, setBudget] = useState('');
+  const [message, setMessage] = useState('');
   const [isDecider, setIsDecider] = useState(false);
 
   const toggleGoal = (goal: string) =>
@@ -103,7 +105,7 @@ export default function FormSimplePage() {
       style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
       <div
         style={{
-          maxWidth: 1000,
+          maxWidth: 900,
           margin: '0 auto',
           width: '100%',
           paddingTop: 48,
@@ -201,6 +203,13 @@ export default function FormSimplePage() {
               options={BUDGET_OPTIONS}
               value={budget}
               onChange={setBudget}
+            />
+
+            <XDSTextArea
+              label="Leave us a message"
+              placeholder="Tell us anything else you'd like us to know..."
+              value={message}
+              onChange={setMessage}
             />
 
             <XDSCheckboxInput

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -10,11 +10,10 @@ import {XDSSelector} from '@xds/core/Selector';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSLink} from '@xds/core/Link';
+import {XDSToken} from '@xds/core/Token';
 import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 import {XDSTextArea} from '@xds/core/TextArea';
-import {
-  colorVars,
-} from '@xds/core/theme/tokens.stylex';
+import {colorVars} from '@xds/core/theme/tokens.stylex';
 
 const CAMPAIGN_GOALS = [
   'Brand Awareness',
@@ -163,10 +162,10 @@ export default function FormSimplePage() {
               <XDSText type="label">What are you going for?</XDSText>
               <div style={{display: 'flex', flexWrap: 'wrap', gap: 8}}>
                 {CAMPAIGN_GOALS.map(goal => (
-                  <XDSButton
+                  <XDSToken
                     key={goal}
                     label={goal}
-                    variant={goals.includes(goal) ? 'primary' : 'secondary'}
+                    color={goals.includes(goal) ? 'blue' : 'default'}
                     onClick={() => toggleGoal(goal)}
                   />
                 ))}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -51,7 +51,7 @@ const BUDGET_OPTIONS = [
 const styles = stylex.create({
   page: {
     minHeight: '100svh',
-    backgroundColor: colorVars['--color-background-body'],
+    backgroundColor: colorVars['--color-background-surface'],
     display: 'flex',
     alignItems: 'flex-start',
     justifyContent: 'center',
@@ -60,7 +60,7 @@ const styles = stylex.create({
   },
   form: {
     width: '100%',
-    maxWidth: 600,
+    maxWidth: 1000,
   },
   centered: {
     textAlign: 'center',

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -116,10 +116,10 @@ export default function FormSimplePage() {
         <XDSVStack gap={8}>
           {/* Header */}
           <div style={{textAlign: 'center'}}>
-            <XDSVStack gap={2}>
-              <XDSHeading level={1}>Get in touch</XDSHeading>
+            <XDSVStack gap={1}>
+              <XDSHeading level={1}>Let's work together</XDSHeading>
               <XDSText type="body" color="secondary">
-                Tell us about your campaign and we'll be in touch shortly.
+                Tell us a bit about what you're working on — we'd love to help.
               </XDSText>
             </XDSVStack>
           </div>
@@ -167,11 +167,11 @@ export default function FormSimplePage() {
               />
             </div>
 
-            <XDSDivider label="Campaign Details" />
+            <XDSDivider label="About your campaign" />
 
             {/* Goals */}
             <XDSVStack gap={2}>
-              <XDSText type="label">Campaign goals</XDSText>
+              <XDSText type="label">What are you going for?</XDSText>
               <div style={{display: 'flex', flexWrap: 'wrap', gap: 8}}>
                 {CAMPAIGN_GOALS.map(goal => (
                   <button
@@ -190,24 +190,24 @@ export default function FormSimplePage() {
             </XDSVStack>
 
             <XDSSelector
-              label="Launch timeline"
-              placeholder="When are you looking to launch?"
+              label="When are you thinking?"
+              placeholder="When are you thinking of launching?"
               options={LAUNCH_OPTIONS}
               value={timeline}
               onChange={setTimeline}
             />
 
             <XDSSelector
-              label="Monthly budget"
-              placeholder="What's your estimated monthly budget?"
+              label="Ballpark budget?"
+              placeholder="What's your rough monthly budget?"
               options={BUDGET_OPTIONS}
               value={budget}
               onChange={setBudget}
             />
 
             <XDSTextArea
-              label="Leave us a message"
-              placeholder="Tell us anything else you'd like us to know..."
+              label="Anything else?"
+              placeholder="Tell us whatever else is on your mind..."
               value={message}
               onChange={setMessage}
             />

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -52,14 +52,10 @@ const styles = stylex.create({
   page: {
     minHeight: '100svh',
     backgroundColor: colorVars['--color-background-surface'],
-    display: 'flex',
-    alignItems: 'flex-start',
-    justifyContent: 'center',
     paddingBlock: spacingVars['--spacing-12'],
     paddingInline: spacingVars['--spacing-4'],
   },
   form: {
-    width: '100%',
     maxWidth: 1000,
     margin: '0 auto',
   },

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -79,9 +79,6 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-accent'],
     color: colorVars['--color-on-accent'],
   },
-  pillError: {
-    borderColor: colorVars['--color-error'],
-  },
   fullWidth: {
     width: '100%',
   },
@@ -204,7 +201,6 @@ export default function FormSimplePage() {
                     {...stylex.props(
                       styles.pill,
                       goals.includes(goal) && styles.pillSelected,
-                      !!errors.goals && !goals.includes(goal) && styles.pillError,
                     )}>
                     {goal}
                   </button>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -10,9 +10,8 @@ import {XDSSelector} from '@xds/core/Selector';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSLink} from '@xds/core/Link';
+import {colorVars} from '@xds/core/theme/tokens.stylex';
 import {
-  colorVars,
-  spacingVars,
   radiusVars,
   borderVars,
   durationVars,
@@ -20,6 +19,7 @@ import {
   typographyVars,
   typeScaleVars,
   fontWeightVars,
+  spacingVars,
 } from '@xds/core/theme/tokens.stylex';
 
 const CAMPAIGN_GOALS = [
@@ -49,28 +49,8 @@ const BUDGET_OPTIONS = [
 ];
 
 const styles = stylex.create({
-  page: {
-    minHeight: '100svh',
+  pageBg: {
     backgroundColor: colorVars['--color-background-surface'],
-  },
-  form: {
-    maxWidth: 1000,
-    margin: '0 auto',
-    paddingBlock: spacingVars['--spacing-12'],
-    paddingInline: spacingVars['--spacing-4'],
-  },
-  centered: {
-    textAlign: 'center',
-  },
-  twoCol: {
-    display: 'grid',
-    gridTemplateColumns: '1fr 1fr',
-    gap: spacingVars['--spacing-4'],
-  },
-  pillGroup: {
-    display: 'flex',
-    flexWrap: 'wrap',
-    gap: spacingVars['--spacing-2'],
   },
   pill: {
     paddingBlock: spacingVars['--spacing-2'],
@@ -118,11 +98,22 @@ export default function FormSimplePage() {
     );
 
   return (
-    <div {...stylex.props(styles.page)}>
-      <div style={{maxWidth: 720, margin: '0 auto', paddingBlock: 48, paddingInline: 24}}>
+    <div
+      {...stylex.props(styles.pageBg)}
+      style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
+      <div
+        style={{
+          maxWidth: 1000,
+          margin: '0 auto',
+          width: '100%',
+          paddingTop: 48,
+          paddingBottom: 48,
+          paddingLeft: 24,
+          paddingRight: 24,
+        }}>
         <XDSVStack gap={8}>
           {/* Header */}
-          <div {...stylex.props(styles.centered)}>
+          <div style={{textAlign: 'center'}}>
             <XDSVStack gap={2}>
               <XDSHeading level={1}>Get in touch</XDSHeading>
               <XDSText type="body" color="secondary">
@@ -133,7 +124,12 @@ export default function FormSimplePage() {
 
           <XDSVStack gap={4}>
             {/* Row 1 */}
-            <div {...stylex.props(styles.twoCol)}>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: 16,
+              }}>
               <XDSTextInput
                 label="Full Name"
                 placeholder="Full Name"
@@ -149,7 +145,12 @@ export default function FormSimplePage() {
             </div>
 
             {/* Row 2 */}
-            <div {...stylex.props(styles.twoCol)}>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: 16,
+              }}>
               <XDSTextInput
                 label="Company"
                 placeholder="Company"
@@ -169,7 +170,7 @@ export default function FormSimplePage() {
             {/* Goals */}
             <XDSVStack gap={2}>
               <XDSText type="label">Campaign goals</XDSText>
-              <div {...stylex.props(styles.pillGroup)}>
+              <div style={{display: 'flex', flexWrap: 'wrap', gap: 8}}>
                 {CAMPAIGN_GOALS.map(goal => (
                   <button
                     key={goal}
@@ -186,7 +187,6 @@ export default function FormSimplePage() {
               </div>
             </XDSVStack>
 
-            {/* Timeline */}
             <XDSSelector
               label="Launch timeline"
               placeholder="When are you looking to launch?"
@@ -195,7 +195,6 @@ export default function FormSimplePage() {
               onChange={setTimeline}
             />
 
-            {/* Budget */}
             <XDSSelector
               label="Monthly budget"
               placeholder="What's your estimated monthly budget?"

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -119,7 +119,7 @@ export default function FormSimplePage() {
 
   return (
     <div {...stylex.props(styles.page)}>
-      <div {...stylex.props(styles.form)}>
+      <div style={{maxWidth: 720, margin: '0 auto', paddingBlock: 48, paddingInline: 24}}>
         <XDSVStack gap={8}>
           {/* Header */}
           <div {...stylex.props(styles.centered)}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -52,12 +52,12 @@ const styles = stylex.create({
   page: {
     minHeight: '100svh',
     backgroundColor: colorVars['--color-background-surface'],
-    paddingBlock: spacingVars['--spacing-12'],
-    paddingInline: spacingVars['--spacing-4'],
   },
   form: {
     maxWidth: 1000,
     margin: '0 auto',
+    paddingBlock: spacingVars['--spacing-12'],
+    paddingInline: spacingVars['--spacing-4'],
   },
   centered: {
     textAlign: 'center',

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -112,7 +112,7 @@ export default function FormSimplePage() {
         goals: goals.length === 0 ? 'Pick at least one' : undefined,
         timeline: !timeline ? 'Required' : undefined,
         budget: !budget ? 'Required' : undefined,
-        hearAboutUs: !hearAboutUs ? 'Required' : undefined,
+        hearAboutUs: undefined,
       }
     : {};
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSLink} from '@xds/core/Link';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  borderVars,
+  durationVars,
+  easeVars,
+  typographyVars,
+  typeScaleVars,
+  fontWeightVars,
+} from '@xds/core/theme/tokens.stylex';
+
+const CAMPAIGN_GOALS = [
+  'Brand Awareness',
+  'Product Sampling',
+  'Product Launch',
+  'Event Promotion',
+  'Retail / In-Store',
+  'Trade Show',
+  'Other',
+];
+
+const LAUNCH_OPTIONS = [
+  'Within 30 days',
+  '1\u20133 months',
+  '3\u20136 months',
+  '6\u201312 months',
+  '12+ months',
+];
+
+const BUDGET_OPTIONS = [
+  'Under $5K/mo',
+  '$5K\u2013$15K/mo',
+  '$15K\u2013$50K/mo',
+  '$50K\u2013$100K/mo',
+  '$100K+/mo',
+];
+
+const styles = stylex.create({
+  page: {
+    minHeight: '100svh',
+    backgroundColor: colorVars['--color-background-body'],
+    display: 'flex',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+    paddingBlock: spacingVars['--spacing-12'],
+    paddingInline: spacingVars['--spacing-4'],
+  },
+  form: {
+    width: '100%',
+    maxWidth: 600,
+  },
+  centered: {
+    textAlign: 'center',
+  },
+  twoCol: {
+    display: 'grid',
+    gridTemplateColumns: '1fr 1fr',
+    gap: spacingVars['--spacing-4'],
+  },
+  pillGroup: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: spacingVars['--spacing-2'],
+  },
+  pill: {
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-4'],
+    borderRadius: radiusVars['--radius-full'],
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border-emphasized'],
+    backgroundColor: colorVars['--color-background-surface'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-label-size'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-primary'],
+    cursor: 'pointer',
+    transitionProperty: 'background-color, border-color, color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  pillSelected: {
+    borderColor: colorVars['--color-accent'],
+    backgroundColor: colorVars['--color-accent'],
+    color: colorVars['--color-on-accent'],
+  },
+  fullWidth: {
+    width: '100%',
+  },
+});
+
+/**
+ * Form (Simple) — lead capture form template
+ */
+export default function FormSimplePage() {
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [company, setCompany] = useState('');
+  const [phone, setPhone] = useState('');
+  const [goals, setGoals] = useState<string[]>([]);
+  const [timeline, setTimeline] = useState('');
+  const [budget, setBudget] = useState('');
+  const [isDecider, setIsDecider] = useState(false);
+
+  const toggleGoal = (goal: string) =>
+    setGoals(prev =>
+      prev.includes(goal) ? prev.filter(g => g !== goal) : [...prev, goal],
+    );
+
+  return (
+    <div {...stylex.props(styles.page)}>
+      <div {...stylex.props(styles.form)}>
+        <XDSVStack gap={8}>
+          {/* Header */}
+          <div {...stylex.props(styles.centered)}>
+            <XDSVStack gap={2}>
+              <XDSHeading level={1}>Get in touch</XDSHeading>
+              <XDSText type="body" color="secondary">
+                Tell us about your campaign and we'll be in touch shortly.
+              </XDSText>
+            </XDSVStack>
+          </div>
+
+          <XDSVStack gap={4}>
+            {/* Row 1 */}
+            <div {...stylex.props(styles.twoCol)}>
+              <XDSTextInput
+                label="Full Name"
+                placeholder="Full Name"
+                value={fullName}
+                onChange={setFullName}
+              />
+              <XDSTextInput
+                label="Business Email"
+                placeholder="you@company.com"
+                value={email}
+                onChange={setEmail}
+              />
+            </div>
+
+            {/* Row 2 */}
+            <div {...stylex.props(styles.twoCol)}>
+              <XDSTextInput
+                label="Company"
+                placeholder="Company"
+                value={company}
+                onChange={setCompany}
+              />
+              <XDSTextInput
+                label="Phone"
+                placeholder="Phone number"
+                value={phone}
+                onChange={setPhone}
+              />
+            </div>
+
+            <XDSDivider label="Campaign Details" />
+
+            {/* Goals */}
+            <XDSVStack gap={2}>
+              <XDSText type="label">Campaign goals</XDSText>
+              <div {...stylex.props(styles.pillGroup)}>
+                {CAMPAIGN_GOALS.map(goal => (
+                  <button
+                    key={goal}
+                    type="button"
+                    aria-pressed={goals.includes(goal)}
+                    onClick={() => toggleGoal(goal)}
+                    {...stylex.props(
+                      styles.pill,
+                      goals.includes(goal) && styles.pillSelected,
+                    )}>
+                    {goal}
+                  </button>
+                ))}
+              </div>
+            </XDSVStack>
+
+            {/* Timeline */}
+            <XDSSelector
+              label="Launch timeline"
+              placeholder="When are you looking to launch?"
+              options={LAUNCH_OPTIONS}
+              value={timeline}
+              onChange={setTimeline}
+            />
+
+            {/* Budget */}
+            <XDSSelector
+              label="Monthly budget"
+              placeholder="What's your estimated monthly budget?"
+              options={BUDGET_OPTIONS}
+              value={budget}
+              onChange={setBudget}
+            />
+
+            <XDSCheckboxInput
+              label="I'm a budget decision-maker"
+              value={isDecider}
+              onChange={setIsDecider}
+            />
+
+            <XDSButton
+              label="Submit"
+              variant="primary"
+              size="lg"
+              xstyle={styles.fullWidth}
+            />
+
+            <XDSHStack gap={1} hAlign="center">
+              <XDSText type="supporting" color="secondary">
+                By submitting you agree to our{' '}
+                <XDSLink label="Privacy Policy" href="#" type="supporting">
+                  Privacy Policy
+                </XDSLink>
+                .
+              </XDSText>
+            </XDSHStack>
+          </XDSVStack>
+        </XDSVStack>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -10,9 +10,10 @@ import {XDSSelector} from '@xds/core/Selector';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSLink} from '@xds/core/Link';
+import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 import {XDSTextArea} from '@xds/core/TextArea';
-import {colorVars} from '@xds/core/theme/tokens.stylex';
 import {
+  colorVars,
   radiusVars,
   borderVars,
   durationVars,
@@ -95,6 +96,7 @@ export default function FormSimplePage() {
   const [timeline, setTimeline] = useState('');
   const [budget, setBudget] = useState('');
   const [message, setMessage] = useState('');
+  const [hearAboutUs, setHearAboutUs] = useState('');
   const [isDecider, setIsDecider] = useState(false);
 
   const toggleGoal = (goal: string) =>
@@ -216,6 +218,17 @@ export default function FormSimplePage() {
               value={message}
               onChange={setMessage}
             />
+
+            <XDSRadioList
+              label="How did you hear about us?"
+              value={hearAboutUs}
+              onChange={setHearAboutUs}>
+              <XDSRadioListItem label="Social media" value="social" />
+              <XDSRadioListItem label="Word of mouth" value="word-of-mouth" />
+              <XDSRadioListItem label="Search engine" value="search" />
+              <XDSRadioListItem label="Event or conference" value="event" />
+              <XDSRadioListItem label="Other" value="other" />
+            </XDSRadioList>
 
             <XDSCheckboxInput
               label="I'm a budget decision-maker"

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -79,6 +79,9 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-accent'],
     color: colorVars['--color-on-accent'],
   },
+  pillError: {
+    borderColor: colorVars['--color-status-error'],
+  },
   fullWidth: {
     width: '100%',
   },
@@ -98,11 +101,29 @@ export default function FormSimplePage() {
   const [message, setMessage] = useState('');
   const [hearAboutUs, setHearAboutUs] = useState('');
   const [isDecider, setIsDecider] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const errors = submitted
+    ? {
+        fullName: !fullName.trim() ? 'Required' : undefined,
+        email: !email.trim() ? 'Required' : undefined,
+        company: !company.trim() ? 'Required' : undefined,
+        phone: !phone.trim() ? 'Required' : undefined,
+        goals: goals.length === 0 ? 'Pick at least one' : undefined,
+        timeline: !timeline ? 'Required' : undefined,
+        budget: !budget ? 'Required' : undefined,
+        hearAboutUs: !hearAboutUs ? 'Required' : undefined,
+      }
+    : {};
 
   const toggleGoal = (goal: string) =>
     setGoals(prev =>
       prev.includes(goal) ? prev.filter(g => g !== goal) : [...prev, goal],
     );
+
+  const handleSubmit = () => {
+    setSubmitted(true);
+  };
 
   return (
     <div
@@ -131,44 +152,38 @@ export default function FormSimplePage() {
 
           <XDSVStack gap={4}>
             {/* Row 1 */}
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 16,
-              }}>
+            <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16}}>
               <XDSTextInput
                 label="Full Name"
                 placeholder="Full Name"
                 value={fullName}
                 onChange={setFullName}
+                status={errors.fullName ? {type: 'error', message: errors.fullName} : undefined}
               />
               <XDSTextInput
-                label="Business Email"
+                label="Email"
                 placeholder="you@company.com"
                 value={email}
                 onChange={setEmail}
+                status={errors.email ? {type: 'error', message: errors.email} : undefined}
               />
             </div>
 
             {/* Row 2 */}
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 16,
-              }}>
+            <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16}}>
               <XDSTextInput
                 label="Company"
                 placeholder="Company"
                 value={company}
                 onChange={setCompany}
+                status={errors.company ? {type: 'error', message: errors.company} : undefined}
               />
               <XDSTextInput
                 label="Phone"
                 placeholder="Phone number"
                 value={phone}
                 onChange={setPhone}
+                status={errors.phone ? {type: 'error', message: errors.phone} : undefined}
               />
             </div>
 
@@ -189,11 +204,17 @@ export default function FormSimplePage() {
                     {...stylex.props(
                       styles.pill,
                       goals.includes(goal) && styles.pillSelected,
+                      !!errors.goals && !goals.includes(goal) && styles.pillError,
                     )}>
                     {goal}
                   </button>
                 ))}
               </div>
+              {errors.goals && (
+                <XDSText type="supporting" color="negative">
+                  {errors.goals}
+                </XDSText>
+              )}
             </XDSVStack>
 
             <XDSSelector
@@ -202,6 +223,7 @@ export default function FormSimplePage() {
               options={LAUNCH_OPTIONS}
               value={timeline}
               onChange={setTimeline}
+              status={errors.timeline ? {type: 'error', message: errors.timeline} : undefined}
             />
 
             <XDSSelector
@@ -210,6 +232,7 @@ export default function FormSimplePage() {
               options={BUDGET_OPTIONS}
               value={budget}
               onChange={setBudget}
+              status={errors.budget ? {type: 'error', message: errors.budget} : undefined}
             />
 
             <XDSTextArea
@@ -222,7 +245,8 @@ export default function FormSimplePage() {
             <XDSRadioList
               label="How did you hear about us?"
               value={hearAboutUs}
-              onChange={setHearAboutUs}>
+              onChange={setHearAboutUs}
+              status={errors.hearAboutUs ? {type: 'error', message: errors.hearAboutUs} : undefined}>
               <XDSRadioListItem label="Social media" value="social" />
               <XDSRadioListItem label="Word of mouth" value="word-of-mouth" />
               <XDSRadioListItem label="Search engine" value="search" />
@@ -241,6 +265,7 @@ export default function FormSimplePage() {
               variant="primary"
               size="lg"
               xstyle={styles.fullWidth}
+              onClick={handleSubmit}
             />
 
             <XDSHStack gap={1} hAlign="center">

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -61,6 +61,7 @@ const styles = stylex.create({
   form: {
     width: '100%',
     maxWidth: 1000,
+    margin: '0 auto',
   },
   centered: {
     textAlign: 'center',

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -14,14 +14,6 @@ import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
 import {XDSTextArea} from '@xds/core/TextArea';
 import {
   colorVars,
-  radiusVars,
-  borderVars,
-  durationVars,
-  easeVars,
-  typographyVars,
-  typeScaleVars,
-  fontWeightVars,
-  spacingVars,
 } from '@xds/core/theme/tokens.stylex';
 
 const CAMPAIGN_GOALS = [
@@ -56,28 +48,6 @@ const BUDGET_OPTIONS = [
 const styles = stylex.create({
   pageBg: {
     backgroundColor: colorVars['--color-background-surface'],
-  },
-  pill: {
-    paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-4'],
-    borderRadius: radiusVars['--radius-full'],
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderColor: colorVars['--color-border-emphasized'],
-    backgroundColor: colorVars['--color-background-surface'],
-    fontFamily: typographyVars['--font-family-body'],
-    fontSize: typeScaleVars['--text-label-size'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    color: colorVars['--color-text-primary'],
-    cursor: 'pointer',
-    transitionProperty: 'background-color, border-color, color',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-  },
-  pillSelected: {
-    borderColor: colorVars['--color-accent'],
-    backgroundColor: colorVars['--color-accent'],
-    color: colorVars['--color-on-accent'],
   },
   fullWidth: {
     width: '100%',
@@ -193,17 +163,12 @@ export default function FormSimplePage() {
               <XDSText type="label">What are you going for?</XDSText>
               <div style={{display: 'flex', flexWrap: 'wrap', gap: 8}}>
                 {CAMPAIGN_GOALS.map(goal => (
-                  <button
+                  <XDSButton
                     key={goal}
-                    type="button"
-                    aria-pressed={goals.includes(goal)}
+                    label={goal}
+                    variant={goals.includes(goal) ? 'primary' : 'secondary'}
                     onClick={() => toggleGoal(goal)}
-                    {...stylex.props(
-                      styles.pill,
-                      goals.includes(goal) && styles.pillSelected,
-                    )}>
-                    {goal}
-                  </button>
+                  />
                 ))}
               </div>
               {errors.goals && (

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx
@@ -80,7 +80,7 @@ const styles = stylex.create({
     color: colorVars['--color-on-accent'],
   },
   pillError: {
-    borderColor: colorVars['--color-status-error'],
+    borderColor: colorVars['--color-error'],
   },
   fullWidth: {
     width: '100%',
@@ -211,9 +211,9 @@ export default function FormSimplePage() {
                 ))}
               </div>
               {errors.goals && (
-                <XDSText type="supporting" color="negative">
+                <span style={{fontSize: 12, color: 'var(--xds-color-error)'}}>
                   {errors.goals}
-                </XDSText>
+                </span>
               )}
             </XDSVStack>
 

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -142,6 +142,10 @@ export const categories: SandboxCategory[] = [
         href: '/pages/editor/',
         description:
           'Page builder with config panel and live preview',
+        name: 'Form (Simple)',
+        href: '/pages/template-form/',
+        description:
+          'Marketing lead-capture form with pill toggles, dropdowns, and full-width CTA',
       },
     ],
   },

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -140,8 +140,9 @@ export const categories: SandboxCategory[] = [
       {
         name: 'Editor',
         href: '/pages/editor/',
-        description:
-          'Page builder with config panel and live preview',
+        description: 'Page builder with config panel and live preview',
+      },
+      {
         name: 'Form (Simple)',
         href: '/pages/template-form/',
         description:


### PR DESCRIPTION
Adds a Form (Simple) lead-capture form template to the sandbox under the Templates category.

- New page: `apps/sandbox/src/app/(fullscreen)/pages/template-form/page.tsx`
- Registered in `sandboxPages.ts` under Templates as "Form (Simple)"

Sandbox-only change — no core package modifications.