### PR TITLE
feat(sandbox): SSO login template + login UX improvements

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
@@ -2,7 +2,8 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSCard} from '@xds/core/Card';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
@@ -146,141 +147,131 @@ export default function LoginTwoColumn() {
         overflow: 'auto',
         gap: 16,
       }}>
-      {/* Card — inline styles to prevent StyleX cascade issues */}
-      <div
-        {...stylex.props(styles.cardBg)}
-        style={{
-          display: 'flex',
-          maxWidth: 900,
-          width: '100%',
-          overflow: 'hidden',
-          borderRadius: 12,
-          boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-        }}>
-        {/* Left — Form */}
-        <div
-          style={{
-            flex: 1,
-            padding: 32,
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
-          }}>
-          <XDSVStack gap={5}>
-            <div {...stylex.props(styles.centered)}>
-              <XDSVStack gap={1}>
-                <XDSHeading level={2}>Welcome back</XDSHeading>
-                <XDSText type="body" color="secondary" size="sm">
-                  Login to your Product Inc. account
+      {/* Card */}
+      <XDSCard padding={0} maxWidth={900} width="100%">
+        <XDSHStack>
+          {/* Left — Form */}
+          <div
+            style={{
+              width: 400,
+              minWidth: 400,
+              padding: 32,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+            }}>
+            <XDSVStack gap={4}>
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSVStack gap={1}>
+                  <XDSHeading level={2}>Welcome back</XDSHeading>
+                  <XDSText type="body" color="secondary" size="sm">
+                    Login to your Product Inc. account
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
+
+              <XDSVStack gap={2}>
+                <XDSTextInput
+                  label="Email"
+                  isLabelHidden
+                  type="email"
+                  placeholder="name@company.com"
+                  value={email}
+                  onChange={setEmail}
+                />
+                <XDSVStack gap={1}>
+                  <XDSTextInput
+                    label="Password"
+                    isLabelHidden
+                    placeholder="Enter your password"
+                    type="password"
+                    value={password}
+                    onChange={setPassword}
+                  />
+                  <div style={{textAlign: 'right'}}>
+                    <XDSLink
+                      label="Forgot your password?"
+                      href="#"
+                      size="sm"
+                      color="secondary"
+                      type="supporting">
+                      Forgot your password?
+                    </XDSLink>
+                  </div>
+                </XDSVStack>
+              </XDSVStack>
+
+              <XDSButton
+                label="Login"
+                variant="primary"
+                xstyle={styles.fullWidth}
+              />
+
+              <XDSHStack gap={4} vAlign="center">
+                <div style={{flex: 1}}>
+                  <XDSDivider />
+                </div>
+                <XDSText type="supporting" color="secondary">
+                  Or continue with
+                </XDSText>
+                <div style={{flex: 1}}>
+                  <XDSDivider />
+                </div>
+              </XDSHStack>
+
+              <div {...stylex.props(styles.socialRow)}>
+                <XDSButton
+                  label="Apple"
+                  variant="secondary"
+                  icon={<AppleIcon />}
+                  xstyle={styles.socialButton}>
+                  Apple
+                </XDSButton>
+                <XDSButton
+                  label="Google"
+                  variant="secondary"
+                  icon={<GoogleIcon />}
+                  xstyle={styles.socialButton}>
+                  Google
+                </XDSButton>
+              </div>
+
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSText type="supporting" color="secondary">
+                  Don&apos;t have an account?{' '}
+                  <XDSLink label="Sign up" href="#" type="supporting">
+                    Sign up
+                  </XDSLink>
                 </XDSText>
               </XDSVStack>
-            </div>
-
-            <XDSVStack gap={4}>
-              <XDSTextInput
-                label="Email"
-                type="email"
-                placeholder="name@company.com"
-                value={email}
-                onChange={setEmail}
-              />
-              <XDSVStack gap={0}>
-                <div {...stylex.props(styles.passwordRow)}>
-                  <XDSText type="label">Password</XDSText>
-                  <XDSLink
-                    label="Forgot your password?"
-                    href="#"
-                    size="sm"
-                    color="secondary">
-                    Forgot your password?
-                  </XDSLink>
-                </div>
-                <XDSTextInput
-                  label="Password"
-                  isLabelHidden
-                  type="password"
-                  value={password}
-                  onChange={setPassword}
-                />
-              </XDSVStack>
             </XDSVStack>
+          </div>
 
-            <XDSButton
-              label="Login"
-              variant="primary"
-              xstyle={styles.fullWidth}
-            />
-
-            <div {...stylex.props(styles.dividerRow)}>
-              <div {...stylex.props(styles.dividerLine)}>
-                <XDSDivider />
-              </div>
-              <XDSText type="supporting" color="secondary">
-                Or continue with
-              </XDSText>
-              <div {...stylex.props(styles.dividerLine)}>
-                <XDSDivider />
-              </div>
-            </div>
-
-            <div {...stylex.props(styles.socialRow)}>
-              <XDSButton
-                label="Apple"
-                variant="secondary"
-                icon={<AppleIcon />}
-                xstyle={styles.socialButton}>
-                Apple
-              </XDSButton>
-              <XDSButton
-                label="Google"
-                variant="secondary"
-                icon={<GoogleIcon />}
-                xstyle={styles.socialButton}>
-                Google
-              </XDSButton>
-              <XDSButton
-                label="Meta"
-                variant="secondary"
-                icon={<MetaIcon />}
-                xstyle={styles.socialButton}>
-                Meta
-              </XDSButton>
-            </div>
-
-            <div {...stylex.props(styles.centered)}>
-              <XDSText type="supporting" color="secondary">
-                Don&apos;t have an account?{' '}
-                <XDSLink label="Sign up" href="#" type="supporting">
-                  Sign up
-                </XDSLink>
-              </XDSText>
-            </div>
-          </XDSVStack>
-        </div>
-
-        {/* Right — Image placeholder */}
-        <div
-          {...stylex.props(styles.imageBg)}
-          style={{
-            flex: 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            minHeight: 400,
-          }}>
-          <ImageIcon
+          {/* Right — Image placeholder */}
+          <div
+            {...stylex.props(styles.imageBg)}
             style={{
-              width: 64,
-              height: 64,
-              opacity: 0.3,
-              color: 'var(--color-text-disabled)',
-            }}
-          />
-        </div>
-      </div>
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 400,
+              borderRadius: '0 12px 12px 0',
+            }}>
+            <ImageIcon
+              style={{
+                width: 64,
+                height: 64,
+                opacity: 0.3,
+                color: 'var(--color-text-disabled)',
+              }}
+            />
+          </div>
+        </XDSHStack>
+      </XDSCard>
 
       {/* Terms — outside card */}
-      <div {...stylex.props(styles.centered)}>
+      <XDSVStack hAlign="center" xstyle={styles.centered}>
         <XDSText type="supporting" color="secondary">
           By clicking continue, you agree to our{' '}
           <XDSLink label="Terms of Service" href="#" type="supporting">
@@ -292,7 +283,7 @@ export default function LoginTwoColumn() {
           </XDSLink>
           .
         </XDSText>
-      </div>
+      </XDSVStack>
     </div>
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
@@ -144,7 +144,7 @@ export default function LoginTwoColumn() {
         position: 'fixed',
         inset: 0,
         overflow: 'auto',
-        gap: 24,
+        gap: 16,
       }}>
       {/* Card — inline styles to prevent StyleX cascade issues */}
       <div

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login-sso/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login-sso/page.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSButton} from '@xds/core/Button';
+import {XDSCard} from '@xds/core/Card';
+import {XDSSection} from '@xds/core/Section';
+import {XDSLink} from '@xds/core/Link';
+import {XDSDivider} from '@xds/core/Divider';
+import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+const LogoIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    width={24}
+    height={24}
+    {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="4" fill="currentColor" />
+    <rect x="7" y="7" width="10" height="3" rx="1" fill="white" />
+    <rect x="7" y="12" width="6" height="3" rx="1" fill="white" />
+  </svg>
+);
+
+const BuildingIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" width={20} height={20}>
+    <rect
+      x="3"
+      y="6"
+      width="18"
+      height="15"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M8 21V10M16 21V10M3 10h18"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <rect
+      x="10"
+      y="14"
+      width="4"
+      height="7"
+      rx="1"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+const ShieldIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" width={24} height={24}>
+    <path
+      d="M12 3L4 7v6c0 4.4 3.4 8.5 8 9.5 4.6-1 8-5.1 8-9.5V7L12 3z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9 12l2 2 4-4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const ArrowRightIcon = () => (
+  <svg viewBox="0 0 16 16" fill="none" width={24} height={24}>
+    <path
+      d="M3 8h10M9 4l4 4-4 4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = stylex.create({
+  pageBg: {
+    backgroundColor: colorVars['--color-background-body'],
+  },
+  fullWidth: {
+    width: '100%',
+  },
+  dividerRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-4'],
+    width: '100%',
+  },
+  dividerLine: {flexGrow: 1},
+  centered: {textAlign: 'center'},
+});
+
+// Mock SSO providers keyed by email domain
+const SSO_PROVIDERS: Record<
+  string,
+  {name: string; color: string; abbr: string; logo?: React.ReactNode}
+> = {
+  'google.com': {name: 'Google Workspace', color: '#4285F4', abbr: 'G'},
+  'microsoft.com': {name: 'Microsoft Entra ID', color: '#00A4EF', abbr: 'M'},
+  'okta.com': {name: 'Okta', color: '#007DC1', abbr: 'O'},
+  'meta.com': {
+    name: 'Meta SSO',
+    color: '#ffffff',
+    abbr: 'M',
+    logo: (
+      <img
+        src="https://static.xx.fbcdn.net/rsrc.php/y9/r/tL_v571NdZ0.svg"
+        height={16}
+        alt="Meta"
+        style={{display: 'block'}}
+      />
+    ),
+  },
+  'apple.com': {name: 'Apple Business', color: '#000000', abbr: 'A'},
+};
+
+function getProvider(email: string) {
+  const domain = email.split('@')[1]?.toLowerCase();
+  return domain ? (SSO_PROVIDERS[domain] ?? null) : null;
+}
+
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+type Step = 'email' | 'sso-confirm' | 'password-fallback';
+
+export default function LoginSSO() {
+  const [step, setStep] = useState<Step>('email');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const provider = getProvider(email);
+  const emailValid = isValidEmail(email);
+
+  const handleContinue = () => {
+    if (!emailValid) return;
+    if (provider) {
+      setStep('sso-confirm');
+    } else {
+      setStep('password-fallback');
+    }
+  };
+
+  const handleBack = () => setStep('email');
+
+  return (
+    <div
+      {...stylex.props(styles.pageBg)}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'fixed',
+        inset: 0,
+        overflow: 'auto',
+        padding: 24,
+        gap: 16,
+      }}>
+      {/* Logo */}
+      <XDSVStack gap={2} hAlign="center">
+        <LogoIcon />
+        <XDSText type="body" weight="bold" size="lg">
+          Product Inc.
+        </XDSText>
+      </XDSVStack>
+
+      {/* Card */}
+      <XDSCard padding={8} width={400}>
+        <XDSVStack gap={4}>
+          {/* ── Step 1: Email entry ── */}
+          {step === 'email' && (
+            <>
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSVStack gap={1}>
+                  <XDSHeading level={2}>Welcome back</XDSHeading>
+                  <XDSText type="body" color="secondary" size="sm">
+                    Enter your work email to continue
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
+
+              <XDSVStack gap={4}>
+                <XDSTextInput
+                  label="Work email"
+                  isLabelHidden
+                  type="email"
+                  placeholder="you@company.com"
+                  value={email}
+                  onChange={setEmail}
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === 'Enter') handleContinue();
+                  }}
+                />
+                <XDSButton
+                  label="Continue"
+                  variant="primary"
+                  xstyle={styles.fullWidth}
+                  onClick={handleContinue}
+                  isDisabled={!emailValid}
+                />
+              </XDSVStack>
+
+              <XDSHStack gap={4} vAlign="center">
+                <div style={{flex: 1}}>
+                  <XDSDivider />
+                </div>
+                <XDSText type="supporting" color="secondary">
+                  or
+                </XDSText>
+                <div style={{flex: 1}}>
+                  <XDSDivider />
+                </div>
+              </XDSHStack>
+
+              <XDSVStack gap={2}>
+                <XDSButton
+                  label="Continue with SSO"
+                  variant="secondary"
+                  xstyle={styles.fullWidth}>
+                  Continue with SSO
+                </XDSButton>
+              </XDSVStack>
+
+              <XDSVStack hAlign="center">
+                <XDSText type="supporting" color="secondary">
+                  Don&apos;t have an account?{' '}
+                  <XDSLink label="Sign up" href="#" type="supporting">
+                    Sign up
+                  </XDSLink>
+                </XDSText>
+              </XDSVStack>
+            </>
+          )}
+
+          {/* ── Step 2a: SSO provider detected ── */}
+          {step === 'sso-confirm' && provider && (
+            <>
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSVStack gap={1}>
+                  <XDSHStack hAlign="center" style={{marginBottom: 8}}>
+                    {provider.logo ?? (
+                      <div
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 12,
+                          background: provider.color,
+                          color: '#fff',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: 20,
+                          fontWeight: 700,
+                        }}>
+                        {provider.abbr}
+                      </div>
+                    )}
+                  </XDSHStack>
+                  <XDSHeading level={2}>
+                    Sign in with {provider.name}
+                  </XDSHeading>
+                  <XDSText type="body" color="secondary" size="sm">
+                    You will be redirected back after signing in.
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
+
+              {/* SSO info card */}
+              <XDSCard padding={0}>
+                <XDSSection variant="wash" style={{padding: 16}}>
+                  <XDSHStack gap={2} vAlign="center">
+                    <XDSText type="body" color="secondary">
+                      <ShieldIcon />
+                    </XDSText>
+                    <XDSVStack gap={0}>
+                      <XDSText type="label">{provider.name}</XDSText>
+                      <XDSText type="supporting" color="secondary">
+                        {email}
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSHStack>
+                </XDSSection>
+              </XDSCard>
+
+              <XDSVStack gap={3}>
+                <XDSButton
+                  label={`Continue with ${provider.name}`}
+                  variant="primary"
+                  xstyle={styles.fullWidth}>
+                  Continue with {provider.name}
+                </XDSButton>
+                <XDSButton
+                  label="Use a different email"
+                  variant="ghost"
+                  xstyle={styles.fullWidth}
+                  onClick={handleBack}>
+                  Use a different email
+                </XDSButton>
+              </XDSVStack>
+            </>
+          )}
+
+          {/* ── Step 2b: No SSO — password fallback ── */}
+          {step === 'password-fallback' && (
+            <>
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSVStack gap={1}>
+                  <XDSHeading level={2}>Welcome back</XDSHeading>
+                  <XDSText type="body" color="secondary" size="sm">
+                    {email}
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
+
+              <XDSVStack gap={4}>
+                <XDSVStack gap={0}>
+                  <XDSHStack style={{marginBottom: 4}}>
+                    <XDSText type="label">Password</XDSText>
+                    <XDSLink
+                      label="Forgot password?"
+                      href="#"
+                      size="sm"
+                      color="secondary">
+                      Forgot password?
+                    </XDSLink>
+                  </XDSHStack>
+                  <XDSTextInput
+                    label="Password"
+                    isLabelHidden
+                    type="password"
+                    value={password}
+                    onChange={setPassword}
+                  />
+                </XDSVStack>
+
+                <XDSButton
+                  label="Sign in"
+                  variant="primary"
+                  xstyle={styles.fullWidth}
+                />
+                <XDSButton
+                  label="Use a different email"
+                  variant="ghost"
+                  xstyle={styles.fullWidth}
+                  onClick={handleBack}>
+                  Use a different email
+                </XDSButton>
+              </XDSVStack>
+            </>
+          )}
+        </XDSVStack>
+      </XDSCard>
+
+      {/* Terms */}
+      <div {...stylex.props(styles.centered)} style={{maxWidth: 400}}>
+        <XDSText type="supporting" color="secondary">
+          By continuing, you agree to our{' '}
+          <XDSLink label="Terms of Service" href="#" type="supporting">
+            Terms of Service
+          </XDSLink>{' '}
+          and{' '}
+          <XDSLink label="Privacy Policy" href="#" type="supporting">
+            Privacy Policy
+          </XDSLink>
+          .
+        </XDSText>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -90,6 +90,7 @@ const styles = stylex.create({
 export default function LoginSimple() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [loginFailed, setLoginFailed] = useState(false);
 
   return (
     <div
@@ -124,10 +125,73 @@ export default function LoginSimple() {
             <XDSVStack gap={1}>
               <XDSHeading level={2}>Welcome back</XDSHeading>
               <XDSText type="body" color="secondary" size="sm">
-                Login with your Apple or Google account
+                Sign in to your account
               </XDSText>
             </XDSVStack>
           </XDSVStack>
+
+          {/* Form fields */}
+          <XDSVStack gap={2}>
+            <XDSTextInput
+              label="Email"
+              isLabelHidden
+              type="email"
+              placeholder="name@company.com"
+              value={email}
+              onChange={setEmail}
+            />
+            <XDSVStack gap={1}>
+              <XDSTextInput
+                label="Password"
+                isLabelHidden
+                placeholder="Enter your password"
+                type="password"
+                value={password}
+                onChange={(v: string) => {
+                  setPassword(v);
+                  setLoginFailed(false);
+                }}
+                status={
+                  loginFailed
+                    ? {type: 'error', message: 'Incorrect password. Try again.'}
+                    : undefined
+                }
+              />
+              {loginFailed && (
+                <div style={{textAlign: 'right'}}>
+                  <XDSLink
+                    label="Forgot your password?"
+                    href="#"
+                    size="sm"
+                    color="secondary"
+                    type="supporting">
+                    Forgot password?
+                  </XDSLink>
+                </div>
+              )}
+            </XDSVStack>
+          </XDSVStack>
+
+          {/* Login button */}
+          <XDSButton
+            label="Login"
+            variant="primary"
+            xstyle={styles.fullWidth}
+            onClick={() => setLoginFailed(true)}
+          />
+
+          {/* Divider */}
+          <XDSHStack gap={4} vAlign="center">
+            <div style={{flex: 1}}>
+              <XDSDivider />
+            </div>
+            <XDSText type="supporting" color="secondary">
+              Or continue with
+            </XDSText>
+            <div style={{flex: 1}}>
+              <XDSDivider />
+            </div>
+          </XDSHStack>
 
           {/* Social buttons */}
           <XDSVStack gap={3}>
@@ -146,57 +210,6 @@ export default function LoginSimple() {
               Login with Google
             </XDSButton>
           </XDSVStack>
-
-          {/* Divider */}
-          <XDSHStack gap={4} vAlign="center">
-            <div style={{flex: 1}}>
-              <XDSDivider />
-            </div>
-            <XDSText type="supporting" color="secondary">
-              Or continue with
-            </XDSText>
-            <div style={{flex: 1}}>
-              <XDSDivider />
-            </div>
-          </XDSHStack>
-
-          {/* Form fields */}
-          <XDSVStack gap={4}>
-            <XDSTextInput
-              label="Email"
-              isLabelHidden
-              type="email"
-              placeholder="name@company.com"
-              value={email}
-              onChange={setEmail}
-            />
-            <XDSVStack gap={0}>
-              <div {...stylex.props(styles.passwordRow)}>
-                <XDSText type="label">Password</XDSText>
-                <XDSLink
-                  label="Forgot your password?"
-                  href="#"
-                  size="sm"
-                  color="secondary">
-                  Forgot password?
-                </XDSLink>
-              </div>
-              <XDSTextInput
-                label="Password"
-                isLabelHidden
-                type="password"
-                value={password}
-                onChange={setPassword}
-              />
-            </XDSVStack>
-          </XDSVStack>
-
-          {/* Login button */}
-          <XDSButton
-            label="Login"
-            variant="primary"
-            xstyle={styles.fullWidth}
-          />
 
           {/* Sign up link */}
           <XDSVStack hAlign="center" xstyle={styles.centered}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -2,7 +2,7 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
@@ -106,7 +106,7 @@ export default function LoginSimple() {
         position: 'fixed',
         inset: 0,
         overflow: 'auto',
-        gap: 24,
+        gap: 16,
       }}>
       {/* Logo — outside card */}
       <XDSVStack gap={2} hAlign="center">
@@ -117,17 +117,17 @@ export default function LoginSimple() {
       </XDSVStack>
 
       {/* Card */}
-      <XDSCard padding={6} width={400}>
-        <XDSVStack gap={5}>
+      <XDSCard padding={8} width={400}>
+        <XDSVStack gap={4}>
           {/* Header */}
-          <div {...stylex.props(styles.centered)}>
+          <XDSVStack hAlign="center" xstyle={styles.centered}>
             <XDSVStack gap={1}>
               <XDSHeading level={2}>Welcome back</XDSHeading>
               <XDSText type="body" color="secondary" size="sm">
                 Login with your Apple or Google account
               </XDSText>
             </XDSVStack>
-          </div>
+          </XDSVStack>
 
           {/* Social buttons */}
           <XDSVStack gap={3}>
@@ -148,22 +148,23 @@ export default function LoginSimple() {
           </XDSVStack>
 
           {/* Divider */}
-          <div {...stylex.props(styles.dividerRow)}>
-            <div {...stylex.props(styles.dividerLine)}>
+          <XDSHStack gap={4} vAlign="center">
+            <div style={{flex: 1}}>
               <XDSDivider />
             </div>
             <XDSText type="supporting" color="secondary">
               Or continue with
             </XDSText>
-            <div {...stylex.props(styles.dividerLine)}>
+            <div style={{flex: 1}}>
               <XDSDivider />
             </div>
-          </div>
+          </XDSHStack>
 
           {/* Form fields */}
           <XDSVStack gap={4}>
             <XDSTextInput
               label="Email"
+              isLabelHidden
               type="email"
               placeholder="name@company.com"
               value={email}
@@ -198,14 +199,14 @@ export default function LoginSimple() {
           />
 
           {/* Sign up link */}
-          <div {...stylex.props(styles.centered)}>
+          <XDSVStack hAlign="center" xstyle={styles.centered}>
             <XDSText type="supporting" color="secondary">
               Don&apos;t have an account?{' '}
               <XDSLink label="Sign up" href="#" type="supporting">
                 Sign up
               </XDSLink>
             </XDSText>
-          </div>
+          </XDSVStack>
         </XDSVStack>
       </XDSCard>
 


### PR DESCRIPTION
## Summary

Adds a new SSO login template and improves the existing login templates.

## New: Login SSO template (`/pages/template-login-sso/`)

- Email-based SSO provider detection — enter a work email and auto-route to the right provider
- Supported providers: Meta, Google Workspace, Microsoft Entra ID, Okta, Apple Business
- Step flow: email entry → SSO confirm (with provider logo) or password fallback
- `XDSCard` + `XDSSection variant="wash"` for the provider info card

## Login 01 improvements

- Social buttons moved to bottom (below login button)
- Password label removed, placeholder text added
- Forgot password link appears only on failed login with error state on the input
- Card padding 32px, row gap 16px

## Login 02 improvements

- Replaced custom card div with `XDSCard` + `XDSHStack` split layout (400px each side)
- Meta social button removed
- Password label removed, forgot password link moved below input (right-aligned)
- Field gap 8px

## Components used

`XDSCard`, `XDSSection`, `XDSHStack`, `XDSVStack`, `XDSTextInput`, `XDSButton`, `XDSLink`, `XDSDivider`, `XDSText`, `XDSHeading`