### PR TITLE
feat(sandbox): settings dialog template + file explorer + settings-02 improvements

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/file-explorer/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/file-explorer/page.tsx
@@ -863,7 +863,7 @@ export default function FileExplorerPage() {
       <XDSToolbar
         label="File Explorer"
         padding={0}
-        style={inlineStyles.toolbar}
+        style={{...inlineStyles.toolbar, paddingTop: 8, paddingBottom: 8}}
         startContent={
           <XDSHStack gap={1} vAlign="center">
             <XDSButton
@@ -892,8 +892,7 @@ export default function FileExplorerPage() {
           <XDSSegmentedControl
             value="column"
             onChange={() => {}}
-            label="View mode"
-            size="sm">
+            label="View mode">
             <XDSSegmentedControlItem
               value="grid"
               label="Grid"

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
@@ -2,7 +2,8 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSCard} from '@xds/core/Card';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
@@ -146,141 +147,131 @@ export default function LoginTwoColumn() {
         overflow: 'auto',
         gap: 16,
       }}>
-      {/* Card — inline styles to prevent StyleX cascade issues */}
-      <div
-        {...stylex.props(styles.cardBg)}
-        style={{
-          display: 'flex',
-          maxWidth: 900,
-          width: '100%',
-          overflow: 'hidden',
-          borderRadius: 12,
-          boxShadow: '0 1px 3px rgba(0,0,0,0.08)',
-        }}>
-        {/* Left — Form */}
-        <div
-          style={{
-            flex: 1,
-            padding: 32,
-            display: 'flex',
-            flexDirection: 'column',
-            justifyContent: 'center',
-          }}>
-          <XDSVStack gap={5}>
-            <div {...stylex.props(styles.centered)}>
-              <XDSVStack gap={1}>
-                <XDSHeading level={2}>Welcome back</XDSHeading>
-                <XDSText type="body" color="secondary" size="sm">
-                  Login to your Product Inc. account
+      {/* Card */}
+      <XDSCard padding={0} maxWidth={900} width="100%">
+        <XDSHStack>
+          {/* Left — Form */}
+          <div
+            style={{
+              width: 400,
+              minWidth: 400,
+              padding: 32,
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+            }}>
+            <XDSVStack gap={4}>
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSVStack gap={1}>
+                  <XDSHeading level={2}>Welcome back</XDSHeading>
+                  <XDSText type="body" color="secondary" size="sm">
+                    Login to your Product Inc. account
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
+
+              <XDSVStack gap={2}>
+                <XDSTextInput
+                  label="Email"
+                  isLabelHidden
+                  type="email"
+                  placeholder="name@company.com"
+                  value={email}
+                  onChange={setEmail}
+                />
+                <XDSVStack gap={1}>
+                  <XDSTextInput
+                    label="Password"
+                    isLabelHidden
+                    placeholder="Enter your password"
+                    type="password"
+                    value={password}
+                    onChange={setPassword}
+                  />
+                  <div style={{textAlign: 'right'}}>
+                    <XDSLink
+                      label="Forgot your password?"
+                      href="#"
+                      size="sm"
+                      color="secondary"
+                      type="supporting">
+                      Forgot your password?
+                    </XDSLink>
+                  </div>
+                </XDSVStack>
+              </XDSVStack>
+
+              <XDSButton
+                label="Login"
+                variant="primary"
+                xstyle={styles.fullWidth}
+              />
+
+              <XDSHStack gap={4} vAlign="center">
+                <div style={{flex: 1}}>
+                  <XDSDivider />
+                </div>
+                <XDSText type="supporting" color="secondary">
+                  Or continue with
+                </XDSText>
+                <div style={{flex: 1}}>
+                  <XDSDivider />
+                </div>
+              </XDSHStack>
+
+              <div {...stylex.props(styles.socialRow)}>
+                <XDSButton
+                  label="Apple"
+                  variant="secondary"
+                  icon={<AppleIcon />}
+                  xstyle={styles.socialButton}>
+                  Apple
+                </XDSButton>
+                <XDSButton
+                  label="Google"
+                  variant="secondary"
+                  icon={<GoogleIcon />}
+                  xstyle={styles.socialButton}>
+                  Google
+                </XDSButton>
+              </div>
+
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSText type="supporting" color="secondary">
+                  Don&apos;t have an account?{' '}
+                  <XDSLink label="Sign up" href="#" type="supporting">
+                    Sign up
+                  </XDSLink>
                 </XDSText>
               </XDSVStack>
-            </div>
-
-            <XDSVStack gap={4}>
-              <XDSTextInput
-                label="Email"
-                type="email"
-                placeholder="name@company.com"
-                value={email}
-                onChange={setEmail}
-              />
-              <XDSVStack gap={0}>
-                <div {...stylex.props(styles.passwordRow)}>
-                  <XDSText type="label">Password</XDSText>
-                  <XDSLink
-                    label="Forgot your password?"
-                    href="#"
-                    size="sm"
-                    color="secondary">
-                    Forgot your password?
-                  </XDSLink>
-                </div>
-                <XDSTextInput
-                  label="Password"
-                  isLabelHidden
-                  type="password"
-                  value={password}
-                  onChange={setPassword}
-                />
-              </XDSVStack>
             </XDSVStack>
+          </div>
 
-            <XDSButton
-              label="Login"
-              variant="primary"
-              xstyle={styles.fullWidth}
-            />
-
-            <div {...stylex.props(styles.dividerRow)}>
-              <div {...stylex.props(styles.dividerLine)}>
-                <XDSDivider />
-              </div>
-              <XDSText type="supporting" color="secondary">
-                Or continue with
-              </XDSText>
-              <div {...stylex.props(styles.dividerLine)}>
-                <XDSDivider />
-              </div>
-            </div>
-
-            <div {...stylex.props(styles.socialRow)}>
-              <XDSButton
-                label="Apple"
-                variant="secondary"
-                icon={<AppleIcon />}
-                xstyle={styles.socialButton}>
-                Apple
-              </XDSButton>
-              <XDSButton
-                label="Google"
-                variant="secondary"
-                icon={<GoogleIcon />}
-                xstyle={styles.socialButton}>
-                Google
-              </XDSButton>
-              <XDSButton
-                label="Meta"
-                variant="secondary"
-                icon={<MetaIcon />}
-                xstyle={styles.socialButton}>
-                Meta
-              </XDSButton>
-            </div>
-
-            <div {...stylex.props(styles.centered)}>
-              <XDSText type="supporting" color="secondary">
-                Don&apos;t have an account?{' '}
-                <XDSLink label="Sign up" href="#" type="supporting">
-                  Sign up
-                </XDSLink>
-              </XDSText>
-            </div>
-          </XDSVStack>
-        </div>
-
-        {/* Right — Image placeholder */}
-        <div
-          {...stylex.props(styles.imageBg)}
-          style={{
-            flex: 1,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            minHeight: 400,
-          }}>
-          <ImageIcon
+          {/* Right — Image placeholder */}
+          <div
+            {...stylex.props(styles.imageBg)}
             style={{
-              width: 64,
-              height: 64,
-              opacity: 0.3,
-              color: 'var(--color-text-disabled)',
-            }}
-          />
-        </div>
-      </div>
+              flex: 1,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              minHeight: 400,
+              borderRadius: '0 12px 12px 0',
+            }}>
+            <ImageIcon
+              style={{
+                width: 64,
+                height: 64,
+                opacity: 0.3,
+                color: 'var(--color-text-disabled)',
+              }}
+            />
+          </div>
+        </XDSHStack>
+      </XDSCard>
 
       {/* Terms — outside card */}
-      <div {...stylex.props(styles.centered)}>
+      <XDSVStack hAlign="center" xstyle={styles.centered}>
         <XDSText type="supporting" color="secondary">
           By clicking continue, you agree to our{' '}
           <XDSLink label="Terms of Service" href="#" type="supporting">
@@ -292,7 +283,7 @@ export default function LoginTwoColumn() {
           </XDSLink>
           .
         </XDSText>
-      </div>
+      </XDSVStack>
     </div>
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login-02/page.tsx
@@ -144,7 +144,7 @@ export default function LoginTwoColumn() {
         position: 'fixed',
         inset: 0,
         overflow: 'auto',
-        gap: 24,
+        gap: 16,
       }}>
       {/* Card — inline styles to prevent StyleX cascade issues */}
       <div

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login-sso/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login-sso/page.tsx
@@ -1,0 +1,395 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSButton} from '@xds/core/Button';
+import {XDSCard} from '@xds/core/Card';
+import {XDSSection} from '@xds/core/Section';
+import {XDSLink} from '@xds/core/Link';
+import {XDSDivider} from '@xds/core/Divider';
+import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
+
+// ---------------------------------------------------------------------------
+// Icons
+// ---------------------------------------------------------------------------
+
+const LogoIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="currentColor"
+    width={24}
+    height={24}
+    {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="4" fill="currentColor" />
+    <rect x="7" y="7" width="10" height="3" rx="1" fill="white" />
+    <rect x="7" y="12" width="6" height="3" rx="1" fill="white" />
+  </svg>
+);
+
+const BuildingIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" width={20} height={20}>
+    <rect
+      x="3"
+      y="6"
+      width="18"
+      height="15"
+      rx="2"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+    <path
+      d="M8 21V10M16 21V10M3 10h18"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+    />
+    <rect
+      x="10"
+      y="14"
+      width="4"
+      height="7"
+      rx="1"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    />
+  </svg>
+);
+
+const ShieldIcon = () => (
+  <svg viewBox="0 0 24 24" fill="none" width={24} height={24}>
+    <path
+      d="M12 3L4 7v6c0 4.4 3.4 8.5 8 9.5 4.6-1 8-5.1 8-9.5V7L12 3z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9 12l2 2 4-4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const ArrowRightIcon = () => (
+  <svg viewBox="0 0 16 16" fill="none" width={24} height={24}>
+    <path
+      d="M3 8h10M9 4l4 4-4 4"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = stylex.create({
+  pageBg: {
+    backgroundColor: colorVars['--color-background-body'],
+  },
+  fullWidth: {
+    width: '100%',
+  },
+  dividerRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-4'],
+    width: '100%',
+  },
+  dividerLine: {flexGrow: 1},
+  centered: {textAlign: 'center'},
+});
+
+// Mock SSO providers keyed by email domain
+const SSO_PROVIDERS: Record<
+  string,
+  {name: string; color: string; abbr: string; logo?: React.ReactNode}
+> = {
+  'google.com': {name: 'Google Workspace', color: '#4285F4', abbr: 'G'},
+  'microsoft.com': {name: 'Microsoft Entra ID', color: '#00A4EF', abbr: 'M'},
+  'okta.com': {name: 'Okta', color: '#007DC1', abbr: 'O'},
+  'meta.com': {
+    name: 'Meta SSO',
+    color: '#ffffff',
+    abbr: 'M',
+    logo: (
+      <img
+        src="https://static.xx.fbcdn.net/rsrc.php/y9/r/tL_v571NdZ0.svg"
+        height={16}
+        alt="Meta"
+        style={{display: 'block'}}
+      />
+    ),
+  },
+  'apple.com': {name: 'Apple Business', color: '#000000', abbr: 'A'},
+};
+
+function getProvider(email: string) {
+  const domain = email.split('@')[1]?.toLowerCase();
+  return domain ? (SSO_PROVIDERS[domain] ?? null) : null;
+}
+
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+type Step = 'email' | 'sso-confirm' | 'password-fallback';
+
+export default function LoginSSO() {
+  const [step, setStep] = useState<Step>('email');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const provider = getProvider(email);
+  const emailValid = isValidEmail(email);
+
+  const handleContinue = () => {
+    if (!emailValid) return;
+    if (provider) {
+      setStep('sso-confirm');
+    } else {
+      setStep('password-fallback');
+    }
+  };
+
+  const handleBack = () => setStep('email');
+
+  return (
+    <div
+      {...stylex.props(styles.pageBg)}
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'fixed',
+        inset: 0,
+        overflow: 'auto',
+        padding: 24,
+        gap: 16,
+      }}>
+      {/* Logo */}
+      <XDSVStack gap={2} hAlign="center">
+        <LogoIcon />
+        <XDSText type="body" weight="bold" size="lg">
+          Product Inc.
+        </XDSText>
+      </XDSVStack>
+
+      {/* Card */}
+      <XDSCard padding={8} width={400}>
+        <XDSVStack gap={4}>
+          {/* ── Step 1: Email entry ── */}
+          {step === 'email' && (
+            <>
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSVStack gap={1}>
+                  <XDSHeading level={2}>Welcome back</XDSHeading>
+                  <XDSText type="body" color="secondary" size="sm">
+                    Enter your work email to continue
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
+
+              <XDSVStack gap={4}>
+                <XDSTextInput
+                  label="Work email"
+                  isLabelHidden
+                  type="email"
+                  placeholder="you@company.com"
+                  value={email}
+                  onChange={setEmail}
+                  onKeyDown={(e: React.KeyboardEvent) => {
+                    if (e.key === 'Enter') handleContinue();
+                  }}
+                />
+                <XDSButton
+                  label="Continue"
+                  variant="primary"
+                  xstyle={styles.fullWidth}
+                  onClick={handleContinue}
+                  isDisabled={!emailValid}
+                />
+              </XDSVStack>
+
+              <XDSHStack gap={4} vAlign="center">
+                <div style={{flex: 1}}>
+                  <XDSDivider />
+                </div>
+                <XDSText type="supporting" color="secondary">
+                  or
+                </XDSText>
+                <div style={{flex: 1}}>
+                  <XDSDivider />
+                </div>
+              </XDSHStack>
+
+              <XDSVStack gap={2}>
+                <XDSButton
+                  label="Continue with SSO"
+                  variant="secondary"
+                  xstyle={styles.fullWidth}>
+                  Continue with SSO
+                </XDSButton>
+              </XDSVStack>
+
+              <XDSVStack hAlign="center">
+                <XDSText type="supporting" color="secondary">
+                  Don&apos;t have an account?{' '}
+                  <XDSLink label="Sign up" href="#" type="supporting">
+                    Sign up
+                  </XDSLink>
+                </XDSText>
+              </XDSVStack>
+            </>
+          )}
+
+          {/* ── Step 2a: SSO provider detected ── */}
+          {step === 'sso-confirm' && provider && (
+            <>
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSVStack gap={1}>
+                  <XDSHStack hAlign="center" style={{marginBottom: 8}}>
+                    {provider.logo ?? (
+                      <div
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 12,
+                          background: provider.color,
+                          color: '#fff',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          fontSize: 20,
+                          fontWeight: 700,
+                        }}>
+                        {provider.abbr}
+                      </div>
+                    )}
+                  </XDSHStack>
+                  <XDSHeading level={2}>
+                    Sign in with {provider.name}
+                  </XDSHeading>
+                  <XDSText type="body" color="secondary" size="sm">
+                    You will be redirected back after signing in.
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
+
+              {/* SSO info card */}
+              <XDSCard padding={0}>
+                <XDSSection variant="wash" style={{padding: 16}}>
+                  <XDSHStack gap={2} vAlign="center">
+                    <XDSText type="body" color="secondary">
+                      <ShieldIcon />
+                    </XDSText>
+                    <XDSVStack gap={0}>
+                      <XDSText type="label">{provider.name}</XDSText>
+                      <XDSText type="supporting" color="secondary">
+                        {email}
+                      </XDSText>
+                    </XDSVStack>
+                  </XDSHStack>
+                </XDSSection>
+              </XDSCard>
+
+              <XDSVStack gap={3}>
+                <XDSButton
+                  label={`Continue with ${provider.name}`}
+                  variant="primary"
+                  xstyle={styles.fullWidth}>
+                  Continue with {provider.name}
+                </XDSButton>
+                <XDSButton
+                  label="Use a different email"
+                  variant="ghost"
+                  xstyle={styles.fullWidth}
+                  onClick={handleBack}>
+                  Use a different email
+                </XDSButton>
+              </XDSVStack>
+            </>
+          )}
+
+          {/* ── Step 2b: No SSO — password fallback ── */}
+          {step === 'password-fallback' && (
+            <>
+              <XDSVStack hAlign="center" xstyle={styles.centered}>
+                <XDSVStack gap={1}>
+                  <XDSHeading level={2}>Welcome back</XDSHeading>
+                  <XDSText type="body" color="secondary" size="sm">
+                    {email}
+                  </XDSText>
+                </XDSVStack>
+              </XDSVStack>
+
+              <XDSVStack gap={4}>
+                <XDSVStack gap={0}>
+                  <XDSHStack style={{marginBottom: 4}}>
+                    <XDSText type="label">Password</XDSText>
+                    <XDSLink
+                      label="Forgot password?"
+                      href="#"
+                      size="sm"
+                      color="secondary">
+                      Forgot password?
+                    </XDSLink>
+                  </XDSHStack>
+                  <XDSTextInput
+                    label="Password"
+                    isLabelHidden
+                    type="password"
+                    value={password}
+                    onChange={setPassword}
+                  />
+                </XDSVStack>
+
+                <XDSButton
+                  label="Sign in"
+                  variant="primary"
+                  xstyle={styles.fullWidth}
+                />
+                <XDSButton
+                  label="Use a different email"
+                  variant="ghost"
+                  xstyle={styles.fullWidth}
+                  onClick={handleBack}>
+                  Use a different email
+                </XDSButton>
+              </XDSVStack>
+            </>
+          )}
+        </XDSVStack>
+      </XDSCard>
+
+      {/* Terms */}
+      <div {...stylex.props(styles.centered)} style={{maxWidth: 400}}>
+        <XDSText type="supporting" color="secondary">
+          By continuing, you agree to our{' '}
+          <XDSLink label="Terms of Service" href="#" type="supporting">
+            Terms of Service
+          </XDSLink>{' '}
+          and{' '}
+          <XDSLink label="Privacy Policy" href="#" type="supporting">
+            Privacy Policy
+          </XDSLink>
+          .
+        </XDSText>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -90,6 +90,7 @@ const styles = stylex.create({
 export default function LoginSimple() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [loginFailed, setLoginFailed] = useState(false);
 
   return (
     <div
@@ -124,10 +125,73 @@ export default function LoginSimple() {
             <XDSVStack gap={1}>
               <XDSHeading level={2}>Welcome back</XDSHeading>
               <XDSText type="body" color="secondary" size="sm">
-                Login with your Apple or Google account
+                Sign in to your account
               </XDSText>
             </XDSVStack>
           </XDSVStack>
+
+          {/* Form fields */}
+          <XDSVStack gap={2}>
+            <XDSTextInput
+              label="Email"
+              isLabelHidden
+              type="email"
+              placeholder="name@company.com"
+              value={email}
+              onChange={setEmail}
+            />
+            <XDSVStack gap={1}>
+              <XDSTextInput
+                label="Password"
+                isLabelHidden
+                placeholder="Enter your password"
+                type="password"
+                value={password}
+                onChange={(v: string) => {
+                  setPassword(v);
+                  setLoginFailed(false);
+                }}
+                status={
+                  loginFailed
+                    ? {type: 'error', message: 'Incorrect password. Try again.'}
+                    : undefined
+                }
+              />
+              {loginFailed && (
+                <div style={{textAlign: 'right'}}>
+                  <XDSLink
+                    label="Forgot your password?"
+                    href="#"
+                    size="sm"
+                    color="secondary"
+                    type="supporting">
+                    Forgot password?
+                  </XDSLink>
+                </div>
+              )}
+            </XDSVStack>
+          </XDSVStack>
+
+          {/* Login button */}
+          <XDSButton
+            label="Login"
+            variant="primary"
+            xstyle={styles.fullWidth}
+            onClick={() => setLoginFailed(true)}
+          />
+
+          {/* Divider */}
+          <XDSHStack gap={4} vAlign="center">
+            <div style={{flex: 1}}>
+              <XDSDivider />
+            </div>
+            <XDSText type="supporting" color="secondary">
+              Or continue with
+            </XDSText>
+            <div style={{flex: 1}}>
+              <XDSDivider />
+            </div>
+          </XDSHStack>
 
           {/* Social buttons */}
           <XDSVStack gap={3}>
@@ -146,57 +210,6 @@ export default function LoginSimple() {
               Login with Google
             </XDSButton>
           </XDSVStack>
-
-          {/* Divider */}
-          <XDSHStack gap={4} vAlign="center">
-            <div style={{flex: 1}}>
-              <XDSDivider />
-            </div>
-            <XDSText type="supporting" color="secondary">
-              Or continue with
-            </XDSText>
-            <div style={{flex: 1}}>
-              <XDSDivider />
-            </div>
-          </XDSHStack>
-
-          {/* Form fields */}
-          <XDSVStack gap={4}>
-            <XDSTextInput
-              label="Email"
-              isLabelHidden
-              type="email"
-              placeholder="name@company.com"
-              value={email}
-              onChange={setEmail}
-            />
-            <XDSVStack gap={0}>
-              <div {...stylex.props(styles.passwordRow)}>
-                <XDSText type="label">Password</XDSText>
-                <XDSLink
-                  label="Forgot your password?"
-                  href="#"
-                  size="sm"
-                  color="secondary">
-                  Forgot password?
-                </XDSLink>
-              </div>
-              <XDSTextInput
-                label="Password"
-                isLabelHidden
-                type="password"
-                value={password}
-                onChange={setPassword}
-              />
-            </XDSVStack>
-          </XDSVStack>
-
-          {/* Login button */}
-          <XDSButton
-            label="Login"
-            variant="primary"
-            xstyle={styles.fullWidth}
-          />
 
           {/* Sign up link */}
           <XDSVStack hAlign="center" xstyle={styles.centered}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-login/page.tsx
@@ -2,7 +2,7 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSButton} from '@xds/core/Button';
@@ -106,7 +106,7 @@ export default function LoginSimple() {
         position: 'fixed',
         inset: 0,
         overflow: 'auto',
-        gap: 24,
+        gap: 16,
       }}>
       {/* Logo — outside card */}
       <XDSVStack gap={2} hAlign="center">
@@ -117,17 +117,17 @@ export default function LoginSimple() {
       </XDSVStack>
 
       {/* Card */}
-      <XDSCard padding={6} width={400}>
-        <XDSVStack gap={5}>
+      <XDSCard padding={8} width={400}>
+        <XDSVStack gap={4}>
           {/* Header */}
-          <div {...stylex.props(styles.centered)}>
+          <XDSVStack hAlign="center" xstyle={styles.centered}>
             <XDSVStack gap={1}>
               <XDSHeading level={2}>Welcome back</XDSHeading>
               <XDSText type="body" color="secondary" size="sm">
                 Login with your Apple or Google account
               </XDSText>
             </XDSVStack>
-          </div>
+          </XDSVStack>
 
           {/* Social buttons */}
           <XDSVStack gap={3}>
@@ -148,22 +148,23 @@ export default function LoginSimple() {
           </XDSVStack>
 
           {/* Divider */}
-          <div {...stylex.props(styles.dividerRow)}>
-            <div {...stylex.props(styles.dividerLine)}>
+          <XDSHStack gap={4} vAlign="center">
+            <div style={{flex: 1}}>
               <XDSDivider />
             </div>
             <XDSText type="supporting" color="secondary">
               Or continue with
             </XDSText>
-            <div {...stylex.props(styles.dividerLine)}>
+            <div style={{flex: 1}}>
               <XDSDivider />
             </div>
-          </div>
+          </XDSHStack>
 
           {/* Form fields */}
           <XDSVStack gap={4}>
             <XDSTextInput
               label="Email"
+              isLabelHidden
               type="email"
               placeholder="name@company.com"
               value={email}
@@ -198,14 +199,14 @@ export default function LoginSimple() {
           />
 
           {/* Sign up link */}
-          <div {...stylex.props(styles.centered)}>
+          <XDSVStack hAlign="center" xstyle={styles.centered}>
             <XDSText type="supporting" color="secondary">
               Don&apos;t have an account?{' '}
               <XDSLink label="Sign up" href="#" type="supporting">
                 Sign up
               </XDSLink>
             </XDSText>
-          </div>
+          </XDSVStack>
         </XDSVStack>
       </XDSCard>
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings-02/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings-02/page.tsx
@@ -2,11 +2,15 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack} from '@xds/core/Layout';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
 import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSLink} from '@xds/core/Link';
+import {XDSButton} from '@xds/core/Button';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSCard} from '@xds/core/Card';
+import {XDSSection} from '@xds/core/Section';
 import {XDSSwitch} from '@xds/core/Switch';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
@@ -31,6 +35,9 @@ const styles = stylex.create({
   },
   flatCard: {
     backgroundColor: colorVars['--color-background-body'],
+    borderWidth: 0,
+  },
+  noBorder: {
     borderWidth: 0,
   },
 });
@@ -107,6 +114,102 @@ function InfoRowItem({label, value, action}: InfoRow) {
   );
 }
 
+// ---------------------------------------------------------------------------
+// Expandable settings row (Airbnb-style inline edit)
+// ---------------------------------------------------------------------------
+
+interface ExpandableRowProps {
+  label: string;
+  value: string;
+  children: React.ReactNode;
+  isExpanded: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+function ExpandableRow({
+  label,
+  value,
+  children,
+  isExpanded,
+  onEdit,
+  onCancel,
+  onSave,
+}: ExpandableRowProps) {
+  return (
+    <>
+      {isExpanded ? (
+        <div style={{padding: '16px 0'}}>
+          <div style={{marginBottom: 16}}>
+            <XDSText type="body" weight="semibold" display="block">
+              {label}
+            </XDSText>
+          </div>
+          <div style={{marginBottom: 16}}>{children}</div>
+          <XDSHStack gap={2}>
+            <XDSButton label="Save" variant="primary" onClick={onSave} />
+            <XDSButton label="Cancel" variant="ghost" onClick={onCancel} />
+          </XDSHStack>
+        </div>
+      ) : (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            padding: '16px 0',
+          }}>
+          <div>
+            <XDSText type="body" weight="semibold" display="block">
+              {label}
+            </XDSText>
+            <XDSText type="supporting" color="secondary" display="block">
+              {value}
+            </XDSText>
+          </div>
+          <XDSLink
+            label="Edit"
+            href="#"
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              onEdit();
+            }}>
+            Edit
+          </XDSLink>
+        </div>
+      )}
+      <XDSDivider />
+    </>
+  );
+}
+
+const LANGUAGES = [
+  {label: 'English (Canada)', value: 'en-CA'},
+  {label: 'English (US)', value: 'en-US'},
+  {label: 'French', value: 'fr'},
+  {label: 'Spanish', value: 'es'},
+  {label: 'German', value: 'de'},
+  {label: 'Japanese', value: 'ja'},
+];
+
+const CURRENCIES = [
+  {label: 'Canadian dollar (CAD)', value: 'CAD'},
+  {label: 'US dollar (USD)', value: 'USD'},
+  {label: 'Euro (EUR)', value: 'EUR'},
+  {label: 'British pound (GBP)', value: 'GBP'},
+  {label: 'Japanese yen (JPY)', value: 'JPY'},
+];
+
+const TIMEZONES = [
+  {label: '(GMT-05:00) Eastern Time (US & Canada)', value: 'ET'},
+  {label: '(GMT-06:00) Central Time (US & Canada)', value: 'CT'},
+  {label: '(GMT-07:00) Mountain Time (US & Canada)', value: 'MT'},
+  {label: '(GMT-08:00) Pacific Time (US & Canada)', value: 'PT'},
+  {label: '(GMT+00:00) UTC', value: 'UTC'},
+  {label: '(GMT+01:00) London', value: 'GMT+1'},
+];
+
 export default function SettingsSecurityTemplate() {
   const [activeNav, setActiveNav] = useState('Login & security');
   const [activeTab, setActiveTab] = useState('login');
@@ -117,6 +220,16 @@ export default function SettingsSecurityTemplate() {
   const [showStayLength, setShowStayLength] = useState(true);
   const [showServices, setShowServices] = useState(true);
   const [aiFeatures, setAiFeatures] = useState(true);
+
+  // Languages & currency state
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
+  const [language, setLanguage] = useState('en-CA');
+  const [currency, setCurrency] = useState('CAD');
+  const [timezone, setTimezone] = useState('ET');
+  const [firstName, setFirstName] = useState('Alex');
+  const [lastName, setLastName] = useState('Johnson');
+  const [email, setEmail] = useState('alex.johnson@email.com');
+  const [phone, setPhone] = useState('+1 (416) 555-0123');
 
   return (
     <div
@@ -141,6 +254,10 @@ export default function SettingsSecurityTemplate() {
             paddingBottom: 16,
             borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)',
             flexShrink: 0,
+            position: 'sticky' as const,
+            top: 0,
+            alignSelf: 'flex-start' as const,
+            maxHeight: '100vh',
             overflowY: 'auto',
           }}>
           <XDSVStack gap={4}>
@@ -322,40 +439,41 @@ export default function SettingsSecurityTemplate() {
                     </div>
                   </XDSVStack>
 
-                  <XDSCard
-                    padding={4}
-                    xstyle={styles.flatCard}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        gap: 16,
-                        alignItems: 'flex-start',
-                      }}>
+                  <XDSCard padding={0} xstyle={styles.noBorder}>
+                    <XDSSection variant="wash" style={{padding: 16}}>
                       <div
                         style={{
-                          width: 48,
-                          height: 48,
-                          borderRadius: 12,
-                          backgroundColor:
-                            'var(--xds-color-background-surface, #fff)',
                           display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          flexShrink: 0,
+                          gap: 16,
+                          alignItems: 'flex-start',
                         }}>
-                        <LockClosedIcon style={{width: 24, height: 24}} />
+                        <div
+                          style={{
+                            width: 48,
+                            height: 48,
+                            borderRadius: 12,
+                            backgroundColor:
+                              'var(--xds-color-background-surface, #fff)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            flexShrink: 0,
+                          }}>
+                          <LockClosedIcon style={{width: 24, height: 24}} />
+                        </div>
+                        <XDSVStack gap={1}>
+                          <XDSText type="body" weight="bold">
+                            Adding devices from people you trust
+                          </XDSText>
+                          <XDSText type="body" color="secondary">
+                            When you approve a request, you grant someone full
+                            access to your account. They&apos;ll be able to
+                            change reservations and send messages on your
+                            behalf.
+                          </XDSText>
+                        </XDSVStack>
                       </div>
-                      <XDSVStack gap={1}>
-                        <XDSText type="body" weight="bold">
-                          Adding devices from people you trust
-                        </XDSText>
-                        <XDSText type="body" color="secondary">
-                          When you approve a request, you grant someone full
-                          access to your account. They&apos;ll be able to change
-                          reservations and send messages on your behalf.
-                        </XDSText>
-                      </XDSVStack>
-                    </div>
+                    </XDSSection>
                   </XDSCard>
                 </XDSVStack>
               )}
@@ -504,48 +622,177 @@ export default function SettingsSecurityTemplate() {
                       </XDSLink>
                     </div>
                   </XDSCard>
-                  <XDSCard
-                    padding={4}
-                    xstyle={styles.flatCard}>
-                    <div
-                      style={{
-                        display: 'flex',
-                        gap: 16,
-                        alignItems: 'flex-start',
-                      }}>
+                  <XDSCard padding={0} xstyle={styles.noBorder}>
+                    <XDSSection variant="wash" style={{padding: 16}}>
                       <div
                         style={{
-                          width: 48,
-                          height: 48,
-                          borderRadius: 12,
-                          backgroundColor:
-                            'var(--xds-color-background-surface, #fff)',
                           display: 'flex',
-                          alignItems: 'center',
-                          justifyContent: 'center',
-                          flexShrink: 0,
+                          gap: 16,
+                          alignItems: 'flex-start',
                         }}>
-                        <ShieldCheckIcon style={{width: 24, height: 24}} />
+                        <div
+                          style={{
+                            width: 48,
+                            height: 48,
+                            borderRadius: 12,
+                            backgroundColor:
+                              'var(--xds-color-background-surface, #fff)',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            flexShrink: 0,
+                          }}>
+                          <ShieldCheckIcon style={{width: 24, height: 24}} />
+                        </div>
+                        <XDSVStack gap={1}>
+                          <XDSText type="body" weight="bold">
+                            Committed to privacy
+                          </XDSText>
+                          <XDSText type="supporting" color="secondary">
+                            We&apos;re committed to keeping your data protected.
+                            See details in our{' '}
+                            <XDSLink
+                              label="Privacy Policy"
+                              href="#"
+                              type="supporting">
+                              Privacy Policy
+                            </XDSLink>
+                            .
+                          </XDSText>
+                        </XDSVStack>
                       </div>
-                      <XDSVStack gap={1}>
-                        <XDSText type="body" weight="bold">
-                          Committed to privacy
-                        </XDSText>
-                        <XDSText type="supporting" color="secondary">
-                          We&apos;re committed to keeping your data protected.
-                          See details in our{' '}
-                          <XDSLink
-                            label="Privacy Policy"
-                            href="#"
-                            type="supporting">
-                            Privacy Policy
-                          </XDSLink>
-                          .
-                        </XDSText>
-                      </XDSVStack>
-                    </div>
+                    </XDSSection>
                   </XDSCard>
                 </XDSVStack>
+              </XDSVStack>
+            </XDSVStack>
+          )}
+
+          {activeNav === 'Languages & currency' && (
+            <XDSVStack gap={6}>
+              <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
+              <XDSVStack gap={0}>
+                <div style={{marginBottom: 8}}>
+                  <XDSDivider />
+                </div>
+                <ExpandableRow
+                  label="Preferred language"
+                  value={
+                    LANGUAGES.find(l => l.value === language)?.label ?? language
+                  }
+                  isExpanded={expandedRow === 'language'}
+                  onEdit={() => setExpandedRow('language')}
+                  onCancel={() => setExpandedRow(null)}
+                  onSave={() => setExpandedRow(null)}>
+                  <XDSSelector
+                    label="Language"
+                    isLabelHidden
+                    size="lg"
+                    value={language}
+                    onChange={setLanguage}
+                    options={LANGUAGES}
+                  />
+                </ExpandableRow>
+                <ExpandableRow
+                  label="Preferred currency"
+                  value={
+                    CURRENCIES.find(c => c.value === currency)?.label ??
+                    currency
+                  }
+                  isExpanded={expandedRow === 'currency'}
+                  onEdit={() => setExpandedRow('currency')}
+                  onCancel={() => setExpandedRow(null)}
+                  onSave={() => setExpandedRow(null)}>
+                  <XDSSelector
+                    label="Currency"
+                    isLabelHidden
+                    size="lg"
+                    value={currency}
+                    onChange={setCurrency}
+                    options={CURRENCIES}
+                  />
+                </ExpandableRow>
+                <ExpandableRow
+                  label="Time zone"
+                  value={
+                    TIMEZONES.find(t => t.value === timezone)?.label ?? timezone
+                  }
+                  isExpanded={expandedRow === 'timezone'}
+                  onEdit={() => setExpandedRow('timezone')}
+                  onCancel={() => setExpandedRow(null)}
+                  onSave={() => setExpandedRow(null)}>
+                  <XDSSelector
+                    label="Time zone"
+                    isLabelHidden
+                    size="lg"
+                    value={timezone}
+                    onChange={setTimezone}
+                    options={TIMEZONES}
+                  />
+                </ExpandableRow>
+              </XDSVStack>
+            </XDSVStack>
+          )}
+
+          {activeNav === 'Personal info' && (
+            <XDSVStack gap={6}>
+              <XDSHeading level={2}>Personal info</XDSHeading>
+              <XDSVStack gap={0}>
+                <div style={{marginBottom: 8}}>
+                  <XDSDivider />
+                </div>
+                <ExpandableRow
+                  label="Legal name"
+                  value={firstName + ' ' + lastName}
+                  isExpanded={expandedRow === 'name'}
+                  onEdit={() => setExpandedRow('name')}
+                  onCancel={() => setExpandedRow(null)}
+                  onSave={() => setExpandedRow(null)}>
+                  <XDSVStack gap={3}>
+                    <XDSTextInput
+                      label="First name"
+                      size="lg"
+                      value={firstName}
+                      onChange={setFirstName}
+                    />
+                    <XDSTextInput
+                      label="Last name"
+                      size="lg"
+                      value={lastName}
+                      onChange={setLastName}
+                    />
+                  </XDSVStack>
+                </ExpandableRow>
+                <ExpandableRow
+                  label="Email address"
+                  value={email}
+                  isExpanded={expandedRow === 'email'}
+                  onEdit={() => setExpandedRow('email')}
+                  onCancel={() => setExpandedRow(null)}
+                  onSave={() => setExpandedRow(null)}>
+                  <XDSTextInput
+                    label="Email"
+                    size="lg"
+                    type="email"
+                    value={email}
+                    onChange={setEmail}
+                  />
+                </ExpandableRow>
+                <ExpandableRow
+                  label="Phone number"
+                  value={phone}
+                  isExpanded={expandedRow === 'phone'}
+                  onEdit={() => setExpandedRow('phone')}
+                  onCancel={() => setExpandedRow(null)}
+                  onSave={() => setExpandedRow(null)}>
+                  <XDSTextInput
+                    label="Phone number"
+                    size="lg"
+                    type="text"
+                    value={phone}
+                    onChange={setPhone}
+                  />
+                </ExpandableRow>
               </XDSVStack>
             </XDSVStack>
           )}

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings-02/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings-02/page.tsx
@@ -27,6 +27,8 @@ import {
   BriefcaseIcon,
   WrenchScrewdriverIcon,
   ComputerDesktopIcon,
+  PencilSquareIcon,
+  ShareIcon,
 } from '@heroicons/react/24/outline';
 
 const styles = stylex.create({
@@ -105,9 +107,11 @@ function InfoRowItem({label, value, action}: InfoRow) {
             {value}
           </XDSText>
         </div>
-        <XDSLink label={action} href="#">
-          {action}
-        </XDSLink>
+        {action && (
+          <XDSLink label={action} href="#">
+            {action}
+          </XDSLink>
+        )}
       </div>
       <XDSDivider />
     </>
@@ -211,7 +215,7 @@ const TIMEZONES = [
 ];
 
 export default function SettingsSecurityTemplate() {
-  const [activeNav, setActiveNav] = useState('Login & security');
+  const [activeNav, setActiveNav] = useState('Personal information');
   const [activeTab, setActiveTab] = useState('login');
   const [readReceipts, setReadReceipts] = useState(true);
   const [searchEngines, setSearchEngines] = useState(true);
@@ -234,70 +238,62 @@ export default function SettingsSecurityTemplate() {
   return (
     <div
       {...stylex.props(styles.pageBg)}
-      style={{minHeight: '100svh', display: 'flex', flexDirection: 'column'}}>
-      {/* Body — constrained */}
+      style={{
+        position: 'fixed' as const,
+        inset: 0,
+        display: 'flex',
+        flexDirection: 'row',
+        overflow: 'hidden',
+      }}>
+      {/* Sidebar */}
+      <nav
+        style={{
+          width: 280,
+          paddingTop: 16,
+          paddingLeft: 12,
+          paddingRight: 12,
+          paddingBottom: 16,
+          borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)',
+          flexShrink: 0,
+          height: '100%',
+          overflowY: 'auto' as const,
+        }}>
+        <XDSVStack gap={4}>
+          <div style={{paddingLeft: 16, paddingRight: 16}}>
+            <XDSHeading level={2}>Account settings</XDSHeading>
+          </div>
+          <XDSList density="spacious">
+            {NAV_ITEMS.map(item => (
+              <XDSListItem
+                key={item.label}
+                label={item.label}
+                startContent={<item.icon style={{width: 20, height: 20}} />}
+                isSelected={activeNav === item.label}
+                onClick={() => setActiveNav(item.label)}
+              />
+            ))}
+          </XDSList>
+          <XDSDivider />
+          <XDSList density="spacious">
+            <XDSListItem
+              label="Professional hosting tools"
+              startContent={
+                <WrenchScrewdriverIcon style={{width: 20, height: 20}} />
+              }
+              onClick={() => {}}
+            />
+          </XDSList>
+        </XDSVStack>
+      </nav>
+
+      {/* Content */}
       <div
         style={{
-          display: 'flex',
           flex: 1,
-          maxWidth: 1000,
-          margin: '0 auto',
-          width: '100%',
+          overflowY: 'auto' as const,
+          height: '100%',
         }}>
-        {/* Sidebar */}
-        <nav
-          style={{
-            width: 280,
-            paddingTop: 16,
-            paddingLeft: 12,
-            paddingRight: 12,
-            paddingBottom: 16,
-            borderRight: '1px solid var(--xds-color-border-primary, #e5e5e5)',
-            flexShrink: 0,
-            position: 'sticky' as const,
-            top: 0,
-            alignSelf: 'flex-start' as const,
-            maxHeight: '100vh',
-            overflowY: 'auto',
-          }}>
-          <XDSVStack gap={4}>
-            <div style={{paddingLeft: 16, paddingRight: 16}}>
-              <XDSHeading level={2}>Account settings</XDSHeading>
-            </div>
-            <XDSList density="spacious">
-              {NAV_ITEMS.map(item => (
-                <XDSListItem
-                  key={item.label}
-                  label={item.label}
-                  startContent={<item.icon style={{width: 20, height: 20}} />}
-                  isSelected={activeNav === item.label}
-                  onClick={() => setActiveNav(item.label)}
-                />
-              ))}
-            </XDSList>
-            <XDSDivider />
-            <XDSList density="spacious">
-              <XDSListItem
-                label="Professional hosting tools"
-                startContent={
-                  <WrenchScrewdriverIcon style={{width: 20, height: 20}} />
-                }
-                onClick={() => {}}
-              />
-            </XDSList>
-          </XDSVStack>
-        </nav>
-
-        {/* Content */}
-        <div
-          style={{
-            flex: 1,
-            paddingTop: 16,
-            paddingLeft: 32,
-            paddingRight: 32,
-            paddingBottom: 16,
-            overflowY: 'auto',
-          }}>
+        <div style={{maxWidth: 700, padding: '16px 48px', margin: '0 auto'}}>
           {activeNav === 'Login & security' && (
             <XDSVStack gap={6}>
               <XDSHeading level={2}>Login &amp; security</XDSHeading>
@@ -672,9 +668,6 @@ export default function SettingsSecurityTemplate() {
             <XDSVStack gap={6}>
               <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
               <XDSVStack gap={0}>
-                <div style={{marginBottom: 8}}>
-                  <XDSDivider />
-                </div>
                 <ExpandableRow
                   label="Preferred language"
                   value={
@@ -734,66 +727,150 @@ export default function SettingsSecurityTemplate() {
             </XDSVStack>
           )}
 
-          {activeNav === 'Personal info' && (
+          {activeNav === 'Personal information' && (
             <XDSVStack gap={6}>
               <XDSHeading level={2}>Personal info</XDSHeading>
               <XDSVStack gap={0}>
-                <div style={{marginBottom: 8}}>
-                  <XDSDivider />
-                </div>
-                <ExpandableRow
+                <InfoRowItem
                   label="Legal name"
-                  value={firstName + ' ' + lastName}
-                  isExpanded={expandedRow === 'name'}
-                  onEdit={() => setExpandedRow('name')}
-                  onCancel={() => setExpandedRow(null)}
-                  onSave={() => setExpandedRow(null)}>
-                  <XDSVStack gap={3}>
-                    <XDSTextInput
-                      label="First name"
-                      size="lg"
-                      value={firstName}
-                      onChange={setFirstName}
-                    />
-                    <XDSTextInput
-                      label="Last name"
-                      size="lg"
-                      value={lastName}
-                      onChange={setLastName}
-                    />
-                  </XDSVStack>
-                </ExpandableRow>
-                <ExpandableRow
+                  value="Alex Johnson"
+                  action="Edit"
+                />
+                <InfoRowItem
+                  label="Preferred first name"
+                  value="Not provided"
+                  action="Add"
+                />
+                <InfoRowItem
                   label="Email address"
-                  value={email}
-                  isExpanded={expandedRow === 'email'}
-                  onEdit={() => setExpandedRow('email')}
-                  onCancel={() => setExpandedRow(null)}
-                  onSave={() => setExpandedRow(null)}>
-                  <XDSTextInput
-                    label="Email"
-                    size="lg"
-                    type="email"
-                    value={email}
-                    onChange={setEmail}
-                  />
-                </ExpandableRow>
-                <ExpandableRow
+                  value="a***n@example.com"
+                  action="Edit"
+                />
+                <InfoRowItem
                   label="Phone number"
-                  value={phone}
-                  isExpanded={expandedRow === 'phone'}
-                  onEdit={() => setExpandedRow('phone')}
-                  onCancel={() => setExpandedRow(null)}
-                  onSave={() => setExpandedRow(null)}>
-                  <XDSTextInput
-                    label="Phone number"
-                    size="lg"
-                    type="text"
-                    value={phone}
-                    onChange={setPhone}
-                  />
-                </ExpandableRow>
+                  value="+1 ***-***-0123"
+                  action="Edit"
+                />
+                <InfoRowItem
+                  label="Identity verification"
+                  value="Verified"
+                  action=""
+                />
+                <InfoRowItem
+                  label="Residential address"
+                  value="Not provided"
+                  action="Add"
+                />
+                <InfoRowItem
+                  label="Mailing address"
+                  value="Not provided"
+                  action="Add"
+                />
+                <InfoRowItem
+                  label="Emergency contact"
+                  value="Provided"
+                  action="Edit"
+                />
               </XDSVStack>
+
+              <XDSCard padding={4} style={{marginTop: 16}}>
+                <XDSVStack gap={0}>
+                  <div style={{paddingTop: 0, paddingBottom: 16}}>
+                    <XDSHStack gap={3} vAlign="start">
+                      <div
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 12,
+                          backgroundColor:
+                            'var(--xds-color-background-muted, #f5f5f5)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          flexShrink: 0,
+                        }}>
+                        <LockClosedIcon style={{width: 24, height: 24}} />
+                      </div>
+                      <XDSVStack gap={0}>
+                        <XDSText type="body" weight="semibold" display="block">
+                          Why isn&apos;t my info shown here?
+                        </XDSText>
+                        <XDSText
+                          type="supporting"
+                          color="secondary"
+                          display="block">
+                          We&apos;re hiding some account details to protect your
+                          identity.
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSHStack>
+                  </div>
+                  <XDSDivider />
+                  <div style={{padding: '16px 0'}}>
+                    <XDSHStack gap={3} vAlign="start">
+                      <div
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 12,
+                          backgroundColor:
+                            'var(--xds-color-background-muted, #f5f5f5)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          flexShrink: 0,
+                        }}>
+                        <PencilSquareIcon style={{width: 24, height: 24}} />
+                      </div>
+                      <XDSVStack gap={0}>
+                        <XDSText type="body" weight="semibold" display="block">
+                          Which details can be edited?
+                        </XDSText>
+                        <XDSText
+                          type="supporting"
+                          color="secondary"
+                          display="block">
+                          Contact info and personal details can be edited. If
+                          this info was used to verify your identity,
+                          you&apos;ll need to get verified again the next time
+                          you book—or to continue hosting.
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSHStack>
+                  </div>
+                  <XDSDivider />
+                  <div style={{paddingTop: 16, paddingBottom: 0}}>
+                    <XDSHStack gap={3} vAlign="start">
+                      <div
+                        style={{
+                          width: 48,
+                          height: 48,
+                          borderRadius: 12,
+                          backgroundColor:
+                            'var(--xds-color-background-muted, #f5f5f5)',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          flexShrink: 0,
+                        }}>
+                        <ShareIcon style={{width: 24, height: 24}} />
+                      </div>
+                      <XDSVStack gap={0}>
+                        <XDSText type="body" weight="semibold" display="block">
+                          What info is shared with others?
+                        </XDSText>
+                        <XDSText
+                          type="supporting"
+                          color="secondary"
+                          display="block">
+                          We only release contact information after a
+                          reservation is confirmed.
+                        </XDSText>
+                      </XDSVStack>
+                    </XDSHStack>
+                  </div>
+                </XDSVStack>
+              </XDSCard>
             </XDSVStack>
           )}
         </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings-03/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings-03/page.tsx
@@ -29,6 +29,8 @@ import {
   DocumentTextIcon,
   CreditCardIcon,
   BriefcaseIcon,
+  PencilSquareIcon,
+  ShareIcon,
 } from '@heroicons/react/24/outline';
 
 // ---------------------------------------------------------------------------
@@ -195,9 +197,11 @@ function InfoRowItem({
             {value}
           </XDSText>
         </div>
-        <XDSLink label={action} href="#">
-          {action}
-        </XDSLink>
+        {action && (
+          <XDSLink label={action} href="#">
+            {action}
+          </XDSLink>
+        )}
       </div>
       <XDSDivider />
     </>
@@ -339,63 +343,159 @@ export default function SettingsDialogTemplate() {
                 padding: '16px 32px',
                 maxWidth: 680,
               }}>
-              {activeNav === 'Personal info' && (
+              {activeNav === 'Personal information' && (
                 <XDSVStack gap={6}>
-                  <XDSHeading level={2}>Personal information</XDSHeading>
+                  <XDSHeading level={2}>Personal info</XDSHeading>
                   <XDSVStack gap={0}>
-                    <XDSDivider />
-                    <ExpandableRow
+                    <InfoRowItem
                       label="Legal name"
-                      value={firstName + ' ' + lastName}
-                      isExpanded={expandedRow === 'name'}
-                      onEdit={() => handleEdit('name')}
-                      onCancel={handleCancel}
-                      onSave={handleSave}>
-                      <XDSVStack gap={3}>
-                        <XDSTextInput
-                          label="First name"
-                          size="lg"
-                          value={firstName}
-                          onChange={setFirstName}
-                        />
-                        <XDSTextInput
-                          label="Last name"
-                          size="lg"
-                          value={lastName}
-                          onChange={setLastName}
-                        />
-                      </XDSVStack>
-                    </ExpandableRow>
-                    <ExpandableRow
+                      value="Alex Johnson"
+                      action="Edit"
+                    />
+                    <InfoRowItem
+                      label="Preferred first name"
+                      value="Not provided"
+                      action="Add"
+                    />
+                    <InfoRowItem
                       label="Email address"
-                      value={email}
-                      isExpanded={expandedRow === 'email'}
-                      onEdit={() => handleEdit('email')}
-                      onCancel={handleCancel}
-                      onSave={handleSave}>
-                      <XDSTextInput
-                        label="Email"
-                        size="lg"
-                        type="email"
-                        value={email}
-                        onChange={setEmail}
-                      />
-                    </ExpandableRow>
-                    <ExpandableRow
+                      value="a***n@example.com"
+                      action="Edit"
+                    />
+                    <InfoRowItem
                       label="Phone number"
-                      value={phone}
-                      isExpanded={expandedRow === 'phone'}
-                      onEdit={() => handleEdit('phone')}
-                      onCancel={handleCancel}
-                      onSave={handleSave}>
-                      <XDSTextInput
-                        label="Phone number"
-                        size="lg"
-                        value={phone}
-                        onChange={setPhone}
-                      />
-                    </ExpandableRow>
+                      value="+1 ***-***-0123"
+                      action="Edit"
+                    />
+                    <InfoRowItem
+                      label="Identity verification"
+                      value="Verified"
+                      action=""
+                    />
+                    <InfoRowItem
+                      label="Residential address"
+                      value="Not provided"
+                      action="Add"
+                    />
+                    <InfoRowItem
+                      label="Mailing address"
+                      value="Not provided"
+                      action="Add"
+                    />
+                    <InfoRowItem
+                      label="Emergency contact"
+                      value="Provided"
+                      action="Edit"
+                    />
                   </XDSVStack>
+
+                  <XDSCard padding={4} style={{marginTop: 16}}>
+                    <XDSVStack gap={0}>
+                      <div style={{paddingTop: 0, paddingBottom: 16}}>
+                        <XDSHStack gap={3} vAlign="start">
+                          <div
+                            style={{
+                              width: 48,
+                              height: 48,
+                              borderRadius: 12,
+                              backgroundColor:
+                                'var(--xds-color-background-muted, #f5f5f5)',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              flexShrink: 0,
+                            }}>
+                            <LockClosedIcon width={24} height={24} />
+                          </div>
+                          <XDSVStack gap={0}>
+                            <XDSText
+                              type="body"
+                              weight="semibold"
+                              display="block">
+                              Why isn&apos;t my info shown here?
+                            </XDSText>
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              display="block">
+                              We&apos;re hiding some account details to protect
+                              your identity.
+                            </XDSText>
+                          </XDSVStack>
+                        </XDSHStack>
+                      </div>
+                      <XDSDivider />
+                      <div style={{padding: '16px 0'}}>
+                        <XDSHStack gap={3} vAlign="start">
+                          <div
+                            style={{
+                              width: 48,
+                              height: 48,
+                              borderRadius: 12,
+                              backgroundColor:
+                                'var(--xds-color-background-muted, #f5f5f5)',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              flexShrink: 0,
+                            }}>
+                            <PencilSquareIcon width={24} height={24} />
+                          </div>
+                          <XDSVStack gap={0}>
+                            <XDSText
+                              type="body"
+                              weight="semibold"
+                              display="block">
+                              Which details can be edited?
+                            </XDSText>
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              display="block">
+                              Contact info and personal details can be edited.
+                              If this info was used to verify your identity,
+                              you&apos;ll need to get verified again the next
+                              time you book—or to continue hosting.
+                            </XDSText>
+                          </XDSVStack>
+                        </XDSHStack>
+                      </div>
+                      <XDSDivider />
+                      <div style={{paddingTop: 16, paddingBottom: 0}}>
+                        <XDSHStack gap={3} vAlign="start">
+                          <div
+                            style={{
+                              width: 48,
+                              height: 48,
+                              borderRadius: 12,
+                              backgroundColor:
+                                'var(--xds-color-background-muted, #f5f5f5)',
+                              display: 'flex',
+                              alignItems: 'center',
+                              justifyContent: 'center',
+                              flexShrink: 0,
+                            }}>
+                            <ShareIcon width={24} height={24} />
+                          </div>
+                          <XDSVStack gap={0}>
+                            <XDSText
+                              type="body"
+                              weight="semibold"
+                              display="block">
+                              What info is shared with others?
+                            </XDSText>
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              display="block">
+                              We only release contact information after a
+                              reservation is confirmed.
+                            </XDSText>
+                          </XDSVStack>
+                        </XDSHStack>
+                      </div>
+                    </XDSVStack>
+                  </XDSCard>
                 </XDSVStack>
               )}
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/template-settings-03/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/template-settings-03/page.tsx
@@ -1,0 +1,851 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {XDSDialog} from '@xds/core/Dialog';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSSelector} from '@xds/core/Selector';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSSection} from '@xds/core/Section';
+import {XDSCard} from '@xds/core/Card';
+import {XDSSwitch} from '@xds/core/Switch';
+import {XDSLink} from '@xds/core/Link';
+import {XDSTabList, XDSTab} from '@xds/core/TabList';
+import {XDSBadge} from '@xds/core/Badge';
+import {colorVars} from '@xds/core/theme/tokens.stylex';
+import {
+  UserIcon,
+  LockClosedIcon,
+  GlobeAltIcon,
+  ShieldCheckIcon,
+  ComputerDesktopIcon,
+  WrenchScrewdriverIcon,
+  XMarkIcon,
+  BellIcon,
+  DocumentTextIcon,
+  CreditCardIcon,
+  BriefcaseIcon,
+} from '@heroicons/react/24/outline';
+
+// ---------------------------------------------------------------------------
+// Data
+// ---------------------------------------------------------------------------
+
+const NAV_ITEMS = [
+  {label: 'Personal information', icon: UserIcon},
+  {label: 'Login & security', icon: LockClosedIcon},
+  {label: 'Privacy', icon: ShieldCheckIcon},
+  {label: 'Notifications', icon: BellIcon},
+  {label: 'Taxes', icon: DocumentTextIcon},
+  {label: 'Payments', icon: CreditCardIcon},
+  {label: 'Languages & currency', icon: GlobeAltIcon},
+  {label: 'Travel for work', icon: BriefcaseIcon},
+];
+
+const LOGIN_ROWS: {label: string; value: string; action: string}[] = [
+  {label: 'Password', value: 'Not created', action: 'Create'},
+];
+
+const SOCIAL_ROWS: {label: string; value: string; action: string}[] = [
+  {label: 'Google', value: 'Connected', action: 'Disconnect'},
+];
+
+const DEVICE_ROWS: {
+  label: string;
+  badge?: string;
+  location: string;
+  action?: string;
+}[] = [
+  {
+    label: 'OS X 10.15.7 · Chrome',
+    badge: 'CURRENT SESSION',
+    location: 'McKinney, Texas · March 30, 2026 at 19:31',
+  },
+  {label: 'Session', location: 'August 9, 2023 at 04:19', action: 'Log out'},
+  {
+    label: 'OS X 10.15.7 · unknown',
+    location: 'Sunnyvale, California · April 14, 2023 at 17:47',
+    action: 'Log out',
+  },
+];
+
+const LANGUAGES = [
+  {label: 'English (Canada)', value: 'en-CA'},
+  {label: 'English (US)', value: 'en-US'},
+  {label: 'French', value: 'fr'},
+  {label: 'Spanish', value: 'es'},
+  {label: 'German', value: 'de'},
+  {label: 'Japanese', value: 'ja'},
+];
+
+const CURRENCIES = [
+  {label: 'Canadian dollar (CAD)', value: 'CAD'},
+  {label: 'US dollar (USD)', value: 'USD'},
+  {label: 'Euro (EUR)', value: 'EUR'},
+  {label: 'British pound (GBP)', value: 'GBP'},
+  {label: 'Japanese yen (JPY)', value: 'JPY'},
+];
+
+const TIMEZONES = [
+  {label: '(GMT-05:00) Eastern Time (US & Canada)', value: 'ET'},
+  {label: '(GMT-06:00) Central Time (US & Canada)', value: 'CT'},
+  {label: '(GMT-07:00) Mountain Time (US & Canada)', value: 'MT'},
+  {label: '(GMT-08:00) Pacific Time (US & Canada)', value: 'PT'},
+  {label: '(GMT+00:00) UTC', value: 'UTC'},
+  {label: '(GMT+01:00) London', value: 'GMT+1'},
+];
+
+// ---------------------------------------------------------------------------
+// Expandable row
+// ---------------------------------------------------------------------------
+
+interface ExpandableRowProps {
+  label: string;
+  value: string;
+  children: React.ReactNode;
+  isExpanded: boolean;
+  onEdit: () => void;
+  onCancel: () => void;
+  onSave: () => void;
+}
+
+function ExpandableRow({
+  label,
+  value,
+  children,
+  isExpanded,
+  onEdit,
+  onCancel,
+  onSave,
+}: ExpandableRowProps) {
+  return (
+    <>
+      {isExpanded ? (
+        <div style={{padding: '16px 0'}}>
+          <div style={{marginBottom: 12}}>
+            <XDSText type="body" weight="semibold" display="block">
+              {label}
+            </XDSText>
+          </div>
+          <div style={{marginBottom: 16}}>{children}</div>
+          <XDSHStack gap={2}>
+            <XDSButton label="Save" variant="primary" onClick={onSave} />
+            <XDSButton label="Cancel" variant="ghost" onClick={onCancel} />
+          </XDSHStack>
+        </div>
+      ) : (
+        <div
+          style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            padding: '16px 0',
+          }}>
+          <div>
+            <XDSText type="body" weight="semibold" display="block">
+              {label}
+            </XDSText>
+            <XDSText type="supporting" color="secondary" display="block">
+              {value}
+            </XDSText>
+          </div>
+          <XDSLink
+            label="Edit"
+            href="#"
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              onEdit();
+            }}>
+            Edit
+          </XDSLink>
+        </div>
+      )}
+      <XDSDivider />
+    </>
+  );
+}
+
+function InfoRowItem({
+  label,
+  value,
+  action,
+}: {
+  label: string;
+  value: string;
+  action: string;
+}) {
+  return (
+    <>
+      <div
+        style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+          padding: '16px 0',
+        }}>
+        <div>
+          <XDSText type="body" weight="semibold" display="block">
+            {label}
+          </XDSText>
+          <XDSText type="supporting" color="secondary" display="block">
+            {value}
+          </XDSText>
+        </div>
+        <XDSLink label={action} href="#">
+          {action}
+        </XDSLink>
+      </div>
+      <XDSDivider />
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const styles = stylex.create({
+  pageBg: {backgroundColor: colorVars['--color-background-body']},
+  cardBg: {backgroundColor: colorVars['--color-background-card']},
+  noBorder: {borderWidth: 0},
+});
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function SettingsDialogTemplate() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [activeNav, setActiveNav] = useState('Login & security');
+  const [expandedRow, setExpandedRow] = useState<string | null>(null);
+
+  const [firstName, setFirstName] = useState('Alex');
+  const [lastName, setLastName] = useState('Johnson');
+  const [email, setEmail] = useState('alex.johnson@email.com');
+  const [phone, setPhone] = useState('+1 (416) 555-0123');
+  const [language, setLanguage] = useState('en-CA');
+  const [currency, setCurrency] = useState('CAD');
+  const [timezone, setTimezone] = useState('ET');
+  const [activeTab, setActiveTab] = useState('login');
+  const [readReceipts, setReadReceipts] = useState(true);
+  const [searchEngines, setSearchEngines] = useState(true);
+  const [showCity, setShowCity] = useState(true);
+  const [showTripType, setShowTripType] = useState(true);
+  const [showStayLength, setShowStayLength] = useState(true);
+  const [showServices, setShowServices] = useState(true);
+  const [aiFeatures, setAiFeatures] = useState(true);
+
+  const handleEdit = (row: string) => setExpandedRow(row);
+  const handleCancel = () => setExpandedRow(null);
+  const handleSave = () => setExpandedRow(null);
+
+  return (
+    <div
+      {...stylex.props(styles.pageBg)}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        position: 'fixed',
+        inset: 0,
+      }}>
+      <XDSButton
+        label="Open settings"
+        variant="primary"
+        onClick={() => setIsOpen(true)}
+      />
+
+      <XDSDialog
+        isOpen={isOpen}
+        onOpenChange={open => setIsOpen(open)}
+        width={900}
+        maxHeight="85vh"
+        purpose="form">
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            height: '100%',
+            minHeight: 'calc(85vh - 2px)',
+            maxHeight: 'calc(85vh - 2px)',
+            position: 'relative',
+          }}>
+          {/* Close button — top right, no header bar */}
+          <div style={{position: 'absolute', top: 12, right: 12, zIndex: 1}}>
+            <XDSButton
+              label="Close"
+              icon={<XMarkIcon width={20} height={20} />}
+              variant="ghost"
+              onClick={() => setIsOpen(false)}
+            />
+          </div>
+
+          {/* Body: sidebar + content */}
+          <div style={{display: 'flex', flex: 1, overflow: 'hidden'}}>
+            {/* Sidebar */}
+            <nav
+              {...stylex.props(styles.cardBg)}
+              style={{
+                width: 280,
+                paddingTop: 16,
+                paddingLeft: 12,
+                paddingRight: 12,
+                paddingBottom: 16,
+                borderRight:
+                  '1px solid var(--xds-color-border-primary, #e5e5e5)',
+                flexShrink: 0,
+                overflowY: 'auto',
+              }}>
+              <XDSVStack gap={4}>
+                <div style={{paddingLeft: 16, paddingRight: 16}}>
+                  <XDSHeading level={2}>Account settings</XDSHeading>
+                </div>
+                <XDSList density="spacious">
+                  {NAV_ITEMS.map(item => (
+                    <XDSListItem
+                      key={item.label}
+                      label={item.label}
+                      startContent={<item.icon width={20} height={20} />}
+                      isSelected={activeNav === item.label}
+                      onClick={() => {
+                        setActiveNav(item.label);
+                        setExpandedRow(null);
+                      }}
+                    />
+                  ))}
+                </XDSList>
+                <XDSDivider />
+                <XDSList density="spacious">
+                  <XDSListItem
+                    label="Professional hosting tools"
+                    startContent={
+                      <WrenchScrewdriverIcon width={20} height={20} />
+                    }
+                    onClick={() => {}}
+                  />
+                </XDSList>
+              </XDSVStack>
+            </nav>
+
+            {/* Content */}
+            <div
+              style={{
+                flex: 1,
+                overflowY: 'auto',
+                padding: '16px 32px',
+                maxWidth: 680,
+              }}>
+              {activeNav === 'Personal info' && (
+                <XDSVStack gap={6}>
+                  <XDSHeading level={2}>Personal information</XDSHeading>
+                  <XDSVStack gap={0}>
+                    <XDSDivider />
+                    <ExpandableRow
+                      label="Legal name"
+                      value={firstName + ' ' + lastName}
+                      isExpanded={expandedRow === 'name'}
+                      onEdit={() => handleEdit('name')}
+                      onCancel={handleCancel}
+                      onSave={handleSave}>
+                      <XDSVStack gap={3}>
+                        <XDSTextInput
+                          label="First name"
+                          size="lg"
+                          value={firstName}
+                          onChange={setFirstName}
+                        />
+                        <XDSTextInput
+                          label="Last name"
+                          size="lg"
+                          value={lastName}
+                          onChange={setLastName}
+                        />
+                      </XDSVStack>
+                    </ExpandableRow>
+                    <ExpandableRow
+                      label="Email address"
+                      value={email}
+                      isExpanded={expandedRow === 'email'}
+                      onEdit={() => handleEdit('email')}
+                      onCancel={handleCancel}
+                      onSave={handleSave}>
+                      <XDSTextInput
+                        label="Email"
+                        size="lg"
+                        type="email"
+                        value={email}
+                        onChange={setEmail}
+                      />
+                    </ExpandableRow>
+                    <ExpandableRow
+                      label="Phone number"
+                      value={phone}
+                      isExpanded={expandedRow === 'phone'}
+                      onEdit={() => handleEdit('phone')}
+                      onCancel={handleCancel}
+                      onSave={handleSave}>
+                      <XDSTextInput
+                        label="Phone number"
+                        size="lg"
+                        value={phone}
+                        onChange={setPhone}
+                      />
+                    </ExpandableRow>
+                  </XDSVStack>
+                </XDSVStack>
+              )}
+
+              {activeNav === 'Login & security' && (
+                <XDSVStack gap={6}>
+                  <XDSHeading level={2}>Login &amp; security</XDSHeading>
+
+                  <div style={{marginLeft: -12, overflow: 'hidden'}}>
+                    <XDSTabList
+                      value={activeTab}
+                      onChange={setActiveTab}
+                      hasDivider>
+                      <XDSTab value="login" label="Login" />
+                      <XDSTab value="shared" label="Shared access" />
+                    </XDSTabList>
+                  </div>
+
+                  {activeTab === 'login' && (
+                    <XDSVStack gap={8}>
+                      {/* Login */}
+                      <XDSVStack gap={0}>
+                        <XDSHeading level={3}>Login</XDSHeading>
+                        <div style={{marginTop: 8}}>
+                          <XDSDivider />
+                        </div>
+                        {LOGIN_ROWS.map(row => (
+                          <InfoRowItem key={row.label} {...row} />
+                        ))}
+                      </XDSVStack>
+
+                      {/* Social accounts */}
+                      <XDSVStack gap={0}>
+                        <XDSHeading level={3}>Social accounts</XDSHeading>
+                        <div style={{marginTop: 8}}>
+                          <XDSDivider />
+                        </div>
+                        {SOCIAL_ROWS.map(row => (
+                          <InfoRowItem key={row.label} {...row} />
+                        ))}
+                      </XDSVStack>
+
+                      {/* Device history */}
+                      <XDSVStack gap={0}>
+                        <XDSHeading level={3}>Device history</XDSHeading>
+                        <div style={{marginTop: 8}}>
+                          <XDSDivider />
+                        </div>
+                        {DEVICE_ROWS.map((device, i) => (
+                          <div key={i}>
+                            <div
+                              style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                alignItems: 'flex-start',
+                                padding: '16px 0',
+                                gap: 12,
+                              }}>
+                              <ComputerDesktopIcon
+                                width={32}
+                                height={32}
+                                style={{
+                                  flexShrink: 0,
+                                  marginTop: 2,
+                                }}
+                              />
+                              <div style={{flex: 1}}>
+                                <div
+                                  style={{
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    gap: 8,
+                                  }}>
+                                  <XDSText type="body" weight="semibold">
+                                    {device.label}
+                                  </XDSText>
+                                  {device.badge && (
+                                    <XDSBadge label={device.badge} />
+                                  )}
+                                </div>
+                                <XDSText type="supporting" color="secondary">
+                                  {device.location}
+                                </XDSText>
+                              </div>
+                              {device.action && (
+                                <XDSLink label={device.action} href="#">
+                                  {device.action}
+                                </XDSLink>
+                              )}
+                            </div>
+                            <XDSDivider />
+                          </div>
+                        ))}
+                      </XDSVStack>
+
+                      {/* Account */}
+                      <XDSVStack gap={0}>
+                        <XDSHeading level={3}>Account</XDSHeading>
+                        <div style={{marginTop: 8}}>
+                          <XDSDivider />
+                        </div>
+                        <div
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'flex-start',
+                            padding: '16px 0',
+                          }}>
+                          <div>
+                            <XDSText
+                              type="body"
+                              weight="semibold"
+                              display="block">
+                              Deactivate your account
+                            </XDSText>
+                            <XDSText
+                              type="supporting"
+                              color="secondary"
+                              display="block">
+                              This action cannot be undone
+                            </XDSText>
+                          </div>
+                          <XDSLink label="Deactivate" href="#">
+                            Deactivate
+                          </XDSLink>
+                        </div>
+                        <XDSDivider />
+                      </XDSVStack>
+                    </XDSVStack>
+                  )}
+
+                  {activeTab === 'shared' && (
+                    <XDSVStack gap={8}>
+                      <XDSVStack gap={0}>
+                        <XDSHeading level={3}>Shared access</XDSHeading>
+                        <div style={{marginTop: 8}}>
+                          <XDSDivider />
+                        </div>
+                        <div style={{paddingTop: 16}}>
+                          <XDSText type="body" color="secondary">
+                            Review each request carefully before approving
+                            access. We&apos;ll email your employee or co-worker
+                            a 4-digit code that lets them log into your account
+                            with their trusted device.
+                          </XDSText>
+                        </div>
+                      </XDSVStack>
+
+                      <XDSCard padding={0} xstyle={styles.noBorder}>
+                        <XDSSection variant="wash" style={{padding: 16}}>
+                          <div
+                            style={{
+                              display: 'flex',
+                              gap: 16,
+                              alignItems: 'flex-start',
+                            }}>
+                            <div
+                              style={{
+                                width: 48,
+                                height: 48,
+                                borderRadius: 12,
+                                backgroundColor:
+                                  'var(--xds-color-background-surface, #fff)',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                flexShrink: 0,
+                              }}>
+                              <LockClosedIcon width={24} height={24} />
+                            </div>
+                            <XDSVStack gap={1}>
+                              <XDSText type="body" weight="bold">
+                                Adding devices from people you trust
+                              </XDSText>
+                              <XDSText type="body" color="secondary">
+                                When you approve a request, you grant someone
+                                full access to your account. They&apos;ll be
+                                able to change reservations and send messages on
+                                your behalf.
+                              </XDSText>
+                            </XDSVStack>
+                          </div>
+                        </XDSSection>
+                      </XDSCard>
+                    </XDSVStack>
+                  )}
+                </XDSVStack>
+              )}
+
+              {activeNav === 'Languages & currency' && (
+                <XDSVStack gap={6}>
+                  <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
+                  <XDSVStack gap={0}>
+                    <XDSDivider />
+                    <ExpandableRow
+                      label="Preferred language"
+                      value={
+                        LANGUAGES.find(l => l.value === language)?.label ??
+                        language
+                      }
+                      isExpanded={expandedRow === 'language'}
+                      onEdit={() => handleEdit('language')}
+                      onCancel={handleCancel}
+                      onSave={handleSave}>
+                      <XDSSelector
+                        label="Language"
+                        isLabelHidden
+                        size="lg"
+                        value={language}
+                        onChange={setLanguage}
+                        options={LANGUAGES}
+                      />
+                    </ExpandableRow>
+                    <ExpandableRow
+                      label="Preferred currency"
+                      value={
+                        CURRENCIES.find(c => c.value === currency)?.label ??
+                        currency
+                      }
+                      isExpanded={expandedRow === 'currency'}
+                      onEdit={() => handleEdit('currency')}
+                      onCancel={handleCancel}
+                      onSave={handleSave}>
+                      <XDSSelector
+                        label="Currency"
+                        isLabelHidden
+                        size="lg"
+                        value={currency}
+                        onChange={setCurrency}
+                        options={CURRENCIES}
+                      />
+                    </ExpandableRow>
+                    <ExpandableRow
+                      label="Time zone"
+                      value={
+                        TIMEZONES.find(t => t.value === timezone)?.label ??
+                        timezone
+                      }
+                      isExpanded={expandedRow === 'timezone'}
+                      onEdit={() => handleEdit('timezone')}
+                      onCancel={handleCancel}
+                      onSave={handleSave}>
+                      <XDSSelector
+                        label="Time zone"
+                        isLabelHidden
+                        size="lg"
+                        value={timezone}
+                        onChange={setTimezone}
+                        options={TIMEZONES}
+                      />
+                    </ExpandableRow>
+                  </XDSVStack>
+                </XDSVStack>
+              )}
+
+              {activeNav === 'Privacy' && (
+                <XDSVStack gap={6}>
+                  <XDSHeading level={2}>Privacy</XDSHeading>
+
+                  <XDSVStack gap={8}>
+                    {/* Messages */}
+                    <XDSVStack gap={0}>
+                      <XDSHeading level={3}>Messages</XDSHeading>
+                      <div style={{marginTop: 16}}>
+                        <XDSSwitch
+                          label="Show people when I've read their messages."
+                          value={readReceipts}
+                          onChange={setReadReceipts}
+                          labelPosition="start"
+                          labelSpacing="spread"
+                        />
+                      </div>
+                      <div style={{padding: '16px 0'}}>
+                        <div
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                          }}>
+                          <XDSText type="body" weight="semibold">
+                            Blocked people
+                          </XDSText>
+                          <XDSLink label="View" href="#">
+                            View
+                          </XDSLink>
+                        </div>
+                      </div>
+                      <XDSDivider />
+                    </XDSVStack>
+
+                    {/* Listings */}
+                    <XDSVStack gap={0}>
+                      <XDSHeading level={3}>Listings</XDSHeading>
+                      <div style={{marginTop: 16}}>
+                        <XDSSwitch
+                          label="Include my listing(s) in search engines"
+                          description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
+                          value={searchEngines}
+                          onChange={setSearchEngines}
+                          labelPosition="start"
+                          labelSpacing="spread"
+                        />
+                      </div>
+                      <div style={{marginTop: 8}}>
+                        <XDSDivider />
+                      </div>
+                    </XDSVStack>
+
+                    {/* Reviews */}
+                    <XDSVStack gap={0}>
+                      <XDSHeading level={3}>Reviews</XDSHeading>
+                      <div>
+                        <XDSText type="supporting" color="secondary">
+                          Choose what&apos;s shared when you write a review.{' '}
+                          <XDSLink
+                            label="Learn more"
+                            href="#"
+                            type="supporting">
+                            Learn more
+                          </XDSLink>
+                        </XDSText>
+                      </div>
+                      <div style={{marginTop: 16}}>
+                        <XDSVStack gap={4}>
+                          <XDSSwitch
+                            label="Show my home city and country"
+                            description="Ex: City and country"
+                            value={showCity}
+                            onChange={setShowCity}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSSwitch
+                            label="Show my trip type"
+                            description="Ex: Stayed with kids or pets"
+                            value={showTripType}
+                            onChange={setShowTripType}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSSwitch
+                            label="Show my length of stay"
+                            description="Ex: A few nights, about a week, etc."
+                            value={showStayLength}
+                            onChange={setShowStayLength}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSSwitch
+                            label="Show my booked services"
+                            description="Ex: Gourmet brunch or tasting menu"
+                            value={showServices}
+                            onChange={setShowServices}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                        </XDSVStack>
+                      </div>
+                      <div style={{marginTop: 16}}>
+                        <XDSDivider />
+                      </div>
+                    </XDSVStack>
+
+                    {/* Data privacy */}
+                    <XDSVStack gap={4}>
+                      <XDSHeading level={3}>Data privacy</XDSHeading>
+                      <XDSCard padding={4}>
+                        <div
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                          }}>
+                          <XDSText type="body">
+                            Request my personal data
+                          </XDSText>
+                          <XDSLink label="Request" href="#">
+                            Request
+                          </XDSLink>
+                        </div>
+                      </XDSCard>
+                      <XDSSwitch
+                        label="Help improve AI-powered features"
+                        description="When this is on, we use your data to develop and improve AI models."
+                        value={aiFeatures}
+                        onChange={setAiFeatures}
+                        labelPosition="start"
+                        labelSpacing="spread"
+                      />
+                      <XDSCard padding={4}>
+                        <div
+                          style={{
+                            display: 'flex',
+                            justifyContent: 'space-between',
+                            alignItems: 'center',
+                          }}>
+                          <XDSText type="body">Delete my account</XDSText>
+                          <XDSLink label="Delete" href="#">
+                            Delete
+                          </XDSLink>
+                        </div>
+                      </XDSCard>
+                      <XDSCard padding={0} xstyle={styles.noBorder}>
+                        <XDSSection variant="wash" style={{padding: 16}}>
+                          <div
+                            style={{
+                              display: 'flex',
+                              gap: 16,
+                              alignItems: 'flex-start',
+                            }}>
+                            <div
+                              style={{
+                                width: 48,
+                                height: 48,
+                                borderRadius: 12,
+                                backgroundColor:
+                                  'var(--xds-color-background-surface, #fff)',
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                flexShrink: 0,
+                              }}>
+                              <ShieldCheckIcon width={24} height={24} />
+                            </div>
+                            <XDSVStack gap={1}>
+                              <XDSText type="body" weight="bold">
+                                Committed to privacy
+                              </XDSText>
+                              <XDSText type="supporting" color="secondary">
+                                We&apos;re committed to keeping your data
+                                protected. See details in our{' '}
+                                <XDSLink
+                                  label="Privacy Policy"
+                                  href="#"
+                                  type="supporting">
+                                  Privacy Policy
+                                </XDSLink>
+                                .
+                              </XDSText>
+                            </XDSVStack>
+                          </div>
+                        </XDSSection>
+                      </XDSCard>
+                    </XDSVStack>
+                  </XDSVStack>
+                </XDSVStack>
+              )}
+            </div>
+          </div>
+        </div>
+      </XDSDialog>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

### New: Settings Dialog template (`/pages/template-settings-03/`)
- Airbnb-style settings in a fixed-height dialog (85vh)
- Split layout: 280px sidebar + scrollable content panel
- Heroicons throughout, consistent with template-settings-02
- Fixed height regardless of tab content
- Sections: Login & security (tabs + device history), Privacy, Languages & currency
- XDSCard + XDSSection wash for info cards
- Floating X close button, no dialog header bar

### template-settings-02 improvements
- Expandable inline edit rows (Airbnb-style) with Save/Cancel buttons
- XDSSection variant='wash' for info cards (no border)
- Fixed sticky sidebar
- Languages & currency + Personal info expandable sections

### file-explorer improvements
- Segmented control upgraded to md size (8px radius)
- 8px top/bottom padding on toolbar