### PR TITLE
hardening: component audit — Breadcrumbs, Button, Calendar, Card, Center

### DIFF
--- a/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/XDSBreadcrumbItem.tsx
@@ -15,6 +15,7 @@
 
 import {useContext, type ReactNode, type MouseEvent} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {BreadcrumbCtx} from './XDSBreadcrumbs';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
@@ -58,6 +59,27 @@ export interface XDSBreadcrumbItemProps {
    * Test ID for the list item.
    */
   'data-testid'?: string;
+  /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) appended to the root element.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 }
 
 // =============================================================================
@@ -141,6 +163,9 @@ export function XDSBreadcrumbItem({
   isCurrent: isCurrentProp,
   startIcon,
   'data-testid': testId,
+  xstyle,
+  className,
+  style,
 }: XDSBreadcrumbItemProps) {
   const ctx = useContext(BreadcrumbCtx);
   const isCurrent = isCurrentProp ?? ctx.isAutoLast;
@@ -162,7 +187,10 @@ export function XDSBreadcrumbItem({
           stylex.props(
             itemStyles.root,
             isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
+            xstyle,
           ),
+          className,
+          style,
         )}
         data-testid={testId}>
         <span
@@ -187,7 +215,10 @@ export function XDSBreadcrumbItem({
         stylex.props(
           itemStyles.root,
           isSupporting ? itemStyles.supportingSize : itemStyles.defaultSize,
+          xstyle,
         ),
+        className,
+        style,
       )}
       data-testid={testId}>
       <LinkComponent

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -24,7 +24,7 @@ import {
 } from '../Layout/padding.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
-import {XDSBaseProps} from '../XDSBaseProps';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   // Outer wrapper: visual styling with clip for border-radius
@@ -66,7 +66,7 @@ const dynamicStyles = stylex.create({
 
 export type {SizeValue} from '../utils/types';
 
-export interface XDSCardProps extends XDSBaseProps {
+export interface XDSCardProps extends XDSBaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
   /**
    * CSS class name(s) appended to the root element.

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSLayoutFooter.tsx
  * @input Uses React StyleX

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 /**
  * @file XDSLayoutHeader.tsx
  * @input Uses React StyleX


### PR DESCRIPTION
## Component Audit — 2026-04-03

Nightly component audit pass. Audited: Breadcrumbs, Button, Calendar, Card, Center.

---

### Changes

#### `XDSBreadcrumbItem` — missing escape hatches (`struct-issue`)
`XDSBreadcrumbItem` had no `xstyle`, `className`, or `style` props, making it impossible to customize from consuming code. Added all three escape hatches following the same pattern as the parent `XDSBreadcrumbs` and other XDS components. The props are passed through `mergeProps()` on the root `<li>` element in both the current-page and link render paths.

#### `XDSCard` — non-generic `XDSBaseProps` + non-type import (`struct-issue`)
`XDSCardProps` was extending `XDSBaseProps` without the `<HTMLDivElement>` type parameter, causing it to default to `HTMLElement`. Fixed to `XDSBaseProps<HTMLDivElement>`. Also changed to a `type` import to be consistent with the rest of the codebase.

#### `XDSLayoutHeader` + `XDSLayoutFooter` — missing `'use client'` (`struct-issue`)
Both files call `useContext()` (a client-only API) but were missing the `'use client'` directive. The `check-use-client.mjs` script caught these. Added the directive as line 1 in both files.

---

### No Issues Found In

- **Button** — theming, xdsClassName, props, types, a11y, exports all clean
- **Calendar** — theming, xdsClassName, types, a11y, exports all clean
- **Center** — theming, xdsClassName, props, types, exports all clean
- **Breadcrumbs (parent)** — clean; only the item sub-component had missing escape hatches

---

### Needs Review

**Calendar `boxShadow` today indicator** (`hardcoded-value` / design token question)
`dayCellTheme.dayToday` and `dayCellTheme.dayTodayInRange` in `packages/core/src/Calendar/styles.ts` use:
```ts
boxShadow: `inset 0 0 0 1px ${colorVars['--color-border-emphasized']}`
```
The color is tokenized but the shadow geometry (`0 0 0 1px`) is a hardcoded string. This is a "partially-tokenized shadow string" per the auditor rules. However, `shadowVars` has no `1px inset ring` token — the available inset tokens are `2px` focus rings for input states. Two options:
1. Add a new shadow token `--shadow-inset-ring-sm: inset 0 0 0 1px <color>` (would need color as a separate var)
2. Accept the pattern as intentional for a thin indicator ring distinct from input-state shadows

**Button icon sizes** (`hardcoded-value` / token gap)
`iconSizeStyles` in `XDSButton.tsx` uses hardcoded `{width: 16, height: 16, fontSize: 16}` for sm/md and `{width: 20, height: 20, fontSize: 20}` for lg. No icon-size token exists in `sizeVars`. Either add `--size-icon-sm: 16px` / `--size-icon-lg: 20px` tokens, or document this as intentional (icon sizes track element sizes via fixed ratios).

---
