### PR TITLE
fix(storybook): set initial color-scheme to match default light mode

### DIFF
--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -79,6 +79,11 @@ const config: StorybookConfig = {
                   '@layer reset, priority1, priority2, priority3, priority4, priority5, priority6, priority7, priority8, priority9;',
                 injectTo: 'head-prepend',
               },
+              {
+                tag: 'style',
+                children: ':root { color-scheme: light; }',
+                injectTo: 'head-prepend',
+              },
             ];
           },
         },


### PR DESCRIPTION
## Problem

On initial page load, Storybook renders with the OS color scheme preference (e.g. dark mode) regardless of the toolbar setting, which defaults to `light`. This happens because the `useEffect` in the `withXDSTheme` decorator runs **after** the first paint — by then the browser has already applied the OS preference via the unset `color-scheme` property.

## Fix

Inject a `<style>` tag via the existing `xds-css-layer-order` Vite plugin's `transformIndexHtml` hook that sets `color-scheme: light` on `:root`. This lands in the HTML `<head>` before any React hydrates, so the initial paint matches the `initialGlobals` default (`colorMode: 'light'`). The existing `useEffect` in the decorator continues to handle subsequent toolbar toggles.

Closes #716