### PR TITLE
fix(SideNav): constrain heading overflow to sidebar bounds

### DIFF
--- a/packages/core/src/SideNav/XDSSideNav.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.tsx
@@ -59,6 +59,8 @@ const styles = stylex.create({
     paddingBlockEnd: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
     gap: spacingVars['--spacing-2'],
+    overflow: 'hidden',
+    minWidth: 0,
   },
   topContent: {},
   scrollable: {

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -52,6 +52,8 @@ const styles = stylex.create({
     textDecoration: 'none',
     color: 'inherit',
     cursor: 'default',
+    overflow: 'hidden',
+    minWidth: 0,
   },
   rootCollapsed: {
     justifyContent: 'center',


### PR DESCRIPTION
The `stickyTop` zone in `XDSSideNav` and the `root` style in `XDSSideNavHeading` lacked overflow constraints, allowing the heading area to grow wider than the sidebar itself. Text elements had `overflow: hidden` + `textOverflow: ellipsis`, but the parent containers never enforced the boundary, so ellipsis never triggered.

**Fix:** Add `overflow: 'hidden'` and `minWidth: 0` to both the `stickyTop` style in `XDSSideNav.tsx` and the `root` style in `XDSSideNavHeading.tsx`.

Closes #1069