### PR TITLE
feat(vega): add @xds/vega subpackage — Vega-Lite chart wrapper

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -12,7 +12,10 @@
     "@xds/theme-neutral": "*",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
-    "unplugin": "^2.3.11"
+    "unplugin": "^2.3.11",
+    "@xds/vega": "*",
+    "vega": "^6.2.0",
+    "vega-lite": "^6.4.2"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.6.17",

--- a/apps/storybook/stories/VegaChart.stories.tsx
+++ b/apps/storybook/stories/VegaChart.stories.tsx
@@ -98,10 +98,4 @@ export const RadialPlot: Story = {
   },
 };
 
-export const CanvasRenderer: Story = {
-  name: 'Radial Plot (Canvas)',
-  args: {
-    spec: radialPlotSpec,
-    renderer: 'canvas',
-  },
-};
+

--- a/apps/storybook/stories/VegaChart.stories.tsx
+++ b/apps/storybook/stories/VegaChart.stories.tsx
@@ -1,0 +1,107 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {VegaChart} from '@xds/vega';
+import type {AnySpec} from '@xds/vega';
+
+/**
+ * Radial plot from the official Vega example gallery.
+ * Encodes two values as the angle and radius of an arc.
+ *
+ * @see https://github.com/vega/vega/blob/main/docs/examples/radial-plot.vg.json
+ */
+const radialPlotSpec: AnySpec = {
+  $schema: 'https://vega.github.io/schema/vega/v6.json',
+  description:
+    'A basic radial plot that encodes two values as the angle and radius of an arc.',
+  width: 200,
+  height: 200,
+  data: [
+    {
+      name: 'table',
+      values: [12, 23, 47, 6, 52, 19],
+      transform: [{type: 'pie', field: 'data'}],
+    },
+  ],
+  scales: [
+    {
+      name: 'r',
+      type: 'sqrt',
+      domain: {data: 'table', field: 'data'},
+      zero: true,
+      range: [20, 100],
+    },
+  ],
+  marks: [
+    {
+      type: 'arc',
+      from: {data: 'table'},
+      encode: {
+        enter: {
+          x: {field: {group: 'width'}, mult: 0.5},
+          y: {field: {group: 'height'}, mult: 0.5},
+          startAngle: {field: 'startAngle'},
+          endAngle: {field: 'endAngle'},
+          innerRadius: {value: 20},
+          outerRadius: {scale: 'r', field: 'data'},
+          stroke: {value: '#fff'},
+        },
+        update: {
+          fill: {value: '#ccc'},
+        },
+        hover: {
+          fill: {value: 'pink'},
+        },
+      },
+    },
+    {
+      type: 'text',
+      from: {data: 'table'},
+      encode: {
+        enter: {
+          x: {field: {group: 'width'}, mult: 0.5},
+          y: {field: {group: 'height'}, mult: 0.5},
+          radius: {scale: 'r', field: 'data', offset: 8},
+          theta: {signal: '(datum.startAngle + datum.endAngle)/2'},
+          fill: {value: '#000'},
+          align: {value: 'center'},
+          baseline: {value: 'middle'},
+          text: {field: 'data'},
+        },
+      },
+    },
+  ],
+};
+
+const meta: Meta<typeof VegaChart> = {
+  title: 'Vega/VegaChart',
+  component: VegaChart,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    renderer: {
+      control: 'radio',
+      options: ['svg', 'canvas'],
+      description: 'Vega rendering backend',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof VegaChart>;
+
+export const RadialPlot: Story = {
+  name: 'Radial Plot',
+  args: {
+    spec: radialPlotSpec,
+    renderer: 'svg',
+  },
+};
+
+export const CanvasRenderer: Story = {
+  name: 'Radial Plot (Canvas)',
+  args: {
+    spec: radialPlotSpec,
+    renderer: 'canvas',
+  },
+};

--- a/apps/storybook/stories/VegaChart.stories.tsx
+++ b/apps/storybook/stories/VegaChart.stories.tsx
@@ -1,5 +1,5 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {VegaChart} from '@xds/vega';
+import {XDSVegaChart} from '@xds/vega';
 import type {AnySpec} from '@xds/vega';
 
 /**
@@ -71,9 +71,9 @@ const radialPlotSpec: AnySpec = {
   ],
 };
 
-const meta: Meta<typeof VegaChart> = {
-  title: 'Vega/VegaChart',
-  component: VegaChart,
+const meta: Meta<typeof XDSVegaChart> = {
+  title: 'Vega/XDSVegaChart',
+  component: XDSVegaChart,
   tags: ['autodocs'],
   parameters: {
     layout: 'centered',
@@ -88,14 +88,11 @@ const meta: Meta<typeof VegaChart> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof VegaChart>;
+type Story = StoryObj<typeof XDSVegaChart>;
 
 export const RadialPlot: Story = {
   name: 'Radial Plot',
   args: {
     spec: radialPlotSpec,
-    renderer: 'svg',
   },
 };
-
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "internal/*"
   ],
   "scripts": {
-    "build": "yarn workspace @xds/core build && yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build && yarn workspace @xds/theme-brutalist build && yarn workspace @xds/theme-daily build && yarn workspace @xds/theme-whatsapp build && yarn workspace @xds/theme-meta build",
+    "build": "yarn workspace @xds/core build && yarn workspace @xds/vega build && yarn workspace @xds/theme-default build && yarn workspace @xds/theme-neutral build && yarn workspace @xds/theme-brutalist build && yarn workspace @xds/theme-daily build && yarn workspace @xds/theme-whatsapp build && yarn workspace @xds/theme-meta build",
     "dev": "yarn workspace @xds/storybook dev",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/README.md
+++ b/packages/README.md
@@ -4,6 +4,7 @@ Published npm packages for the XDS design system.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
-| Directory | Role    | Purpose                                  |
-| --------- | ------- | ---------------------------------------- |
-| `core/`   | Primary | Core UI components library (`@xds/core`) |
+| Directory | Role    | Purpose                                           |
+| --------- | ------- | ------------------------------------------------- |
+| `core/`   | Primary | Core UI components library (`@xds/core`)          |
+| `vega/`   | Add-on  | Vega-Lite chart wrapper components (`@xds/vega`)  |

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -1,0 +1,60 @@
+# @xds/vega
+
+XDS Vega wrapper — chart and data visualization components.
+
+Wraps [`vega-embed`](https://github.com/vega/vega-embed) in a React component that integrates cleanly with the XDS design system.
+
+<!-- SYNC: When files in this directory change, update this document. -->
+
+## File Manifest
+
+| File | Role | Purpose |
+|------|------|---------|
+| `package.json` | Config | Package metadata, deps, build scripts |
+| `tsconfig.json` | Config | TypeScript compiler config (extends root) |
+| `tsup.config.ts` | Config | Build config — CJS + ESM + `.d.ts` outputs |
+| `src/index.ts` | Barrel | Public API surface |
+| `src/VegaChart.tsx` | Component | React wrapper around `vega-embed` |
+| `src/types.ts` | Types | Shared TypeScript types for this package |
+
+## Installation
+
+```bash
+yarn add @xds/vega vega-lite vega-embed
+```
+
+## Usage
+
+```tsx
+import {VegaChart} from '@xds/vega';
+
+const spec = {
+  mark: 'bar',
+  data: {values: [{a: 'A', b: 28}, {a: 'B', b: 55}]},
+  encoding: {
+    x: {field: 'a', type: 'ordinal'},
+    y: {field: 'b', type: 'quantitative'},
+  },
+};
+
+<VegaChart spec={spec} />
+```
+
+## API
+
+### `<VegaChart>`
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `spec` | `TopLevelSpec` | — | Vega-Lite specification (required) |
+| `options` | `EmbedOptions` | `{}` | vega-embed options (renderer, actions, tooltip…) |
+| `className` | `string` | — | CSS class on the container div |
+| `style` | `CSSProperties` | — | Inline styles on the container div |
+| `onReady` | `() => void` | — | Called when the chart is fully rendered |
+| `onError` | `(err: Error) => void` | — | Called on render failure |
+
+## Build
+
+```bash
+yarn workspace @xds/vega build
+```

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -124,18 +124,21 @@ import {VegaChart} from '@xds/vega';
 
 ### Data loading
 
-`data` maps dataset names to tuple arrays and is applied via `view.data(name, tuples)` after the View is created. Changing `data` reloads the datasets and re-runs the view *without* a full re-embed — the View is preserved. This makes it efficient for streaming or live-updating scenarios.
+`data` maps dataset names to tuple arrays and is applied via `view.data(name, tuples)` during View initialization, before the first render. It is *not reactive* — changes after mount are ignored.
+
+To update data dynamically after render, use `onReady` to get the live View and drive it yourself:
 
 ```tsx
 <VegaChart
   spec={spec}
-  data={{
-    table: [{category: 'A', value: 28}, {category: 'B', value: 55}],
+  data={{table: [{category: 'A', value: 28}, {category: 'B', value: 55}]}}
+  onReady={view => {
+    // Later, update data dynamically:
+    view.data('table', newRows);
+    view.runAsync();
   }}
 />
 ```
-
-Each key must match a dataset name defined in the spec's `data` array.
 
 ### `parseSchema(schema)` (exported utility)
 

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -85,6 +85,7 @@ import {VegaChart} from '@xds/vega';
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `spec` | `AnySpec` | -- | Vega or Vega-Lite spec with `$schema` (required) |
+| `data` | `ViewData` | -- | Initial dataset values — `{datasetName: tuples[]}` |
 | `compileOptions` | `CompileOptions` | -- | Options passed to `compile(spec, options)` — Vega-Lite only |
 | `parseConfig` | `Config` | -- | Vega config passed to `parse(spec, config)` |
 | `parseOptions` | `ParseOptions` | -- | Options passed to `parse(spec, config, options)` |
@@ -120,6 +121,21 @@ import {VegaChart} from '@xds/vega';
 | `parseOptions` field | Type | Description |
 |---|---|---|
 | `ast` | `boolean` | Retain expression AST in the runtime (useful for tooling) |
+
+### Data loading
+
+`data` maps dataset names to tuple arrays and is applied via `view.data(name, tuples)` after the View is created. Changing `data` reloads the datasets and re-runs the view *without* a full re-embed — the View is preserved. This makes it efficient for streaming or live-updating scenarios.
+
+```tsx
+<VegaChart
+  spec={spec}
+  data={{
+    table: [{category: 'A', value: 28}, {category: 'B', value: 55}],
+  }}
+/>
+```
+
+Each key must match a dataset name defined in the spec's `data` array.
 
 ### `parseSchema(schema)` (exported utility)
 

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -2,7 +2,7 @@
 
 XDS Vega wrapper -- chart and data visualization components.
 
-Renders [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github.io/vega-lite/) specifications via the Vega runtime. The component inspects `$schema` to decide whether to compile (Vega-Lite) or render directly (Vega), and validates the schema URL before doing either.
+Renders [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github.io/vega-lite/) specifications via the Vega runtime. The component inspects `$schema` to decide whether to compile (Vega-Lite) or render directly (Vega), validates the schema URL before doing either, and exposes the full Vega `parse()` and `View` construction APIs as props.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
@@ -55,11 +55,20 @@ import {VegaChart} from '@xds/vega';
 />
 ```
 
-### Accessing the live View
+### Full configuration
 
 ```tsx
 <VegaChart
   spec={spec}
+  parseConfig={{background: '#1a1a1a'}}
+  parseOptions={{ast: true}}
+  viewOptions={{
+    renderer: 'canvas',
+    logLevel: 1,
+    tooltip: myTooltipHandler,
+    locale: myLocale,
+    loader: myLoader,
+  }}
   onReady={view => {
     view.addSignalListener('highlight', (name, value) => {
       console.log('signal:', name, value);
@@ -75,13 +84,33 @@ import {VegaChart} from '@xds/vega';
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `spec` | `AnySpec` | -- | Vega or Vega-Lite spec. Must include `$schema` (required) |
-| `viewConfig` | `Config` | -- | Vega runtime config (renderer defaults, logging, etc.) |
-| `renderer` | `'svg' | 'canvas'` | `'svg'` | Rendering backend |
+| `spec` | `AnySpec` | -- | Vega or Vega-Lite spec with `$schema` (required) |
+| `parseConfig` | `Config` | -- | Vega config passed to `parse(spec, config)` |
+| `parseOptions` | `ParseOptions` | -- | Options passed to `parse(spec, config, options)` |
+| `viewOptions` | `Omit<ViewOptions, 'container'>` | -- | Options passed to `new View(runtime, options)` |
 | `className` | `string` | -- | CSS class on the container div |
 | `style` | `CSSProperties` | -- | Inline styles on the container div |
 | `onReady` | `(view: View) => void` | -- | Called with the live Vega View when ready |
 | `onError` | `(err: Error) => void` | -- | Called on schema error, compile failure, or render failure |
+
+`viewOptions` maps directly to [`ViewOptions`](https://vega.github.io/vega/docs/api/view/) with `container` omitted (always set by the component). Notable fields:
+
+| `viewOptions` field | Type | Description |
+|---|---|---|
+| `renderer` | `'svg' \| 'canvas'` | Rendering backend (default: `'svg'`) |
+| `hover` | `boolean` | Enable hover encoding (default: `true`) |
+| `logLevel` | `number` | Vega log verbosity |
+| `logger` | `LoggerInterface` | Custom logger |
+| `tooltip` | `TooltipHandler` | Custom tooltip handler |
+| `locale` | `LocaleFormatters` | Number and time format locale |
+| `loader` | `Loader` | Custom data loader |
+| `background` | `Color` | Chart background color |
+
+`parseOptions` fields:
+
+| `parseOptions` field | Type | Description |
+|---|---|---|
+| `ast` | `boolean` | Retain expression AST in the runtime (useful for tooling) |
 
 ### `parseSchema(schema)` (exported utility)
 

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -85,6 +85,7 @@ import {VegaChart} from '@xds/vega';
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `spec` | `AnySpec` | -- | Vega or Vega-Lite spec with `$schema` (required) |
+| `compileOptions` | `CompileOptions` | -- | Options passed to `compile(spec, options)` — Vega-Lite only |
 | `parseConfig` | `Config` | -- | Vega config passed to `parse(spec, config)` |
 | `parseOptions` | `ParseOptions` | -- | Options passed to `parse(spec, config, options)` |
 | `viewOptions` | `Omit<ViewOptions, 'container'>` | -- | Options passed to `new View(runtime, options)` |
@@ -105,6 +106,14 @@ import {VegaChart} from '@xds/vega';
 | `locale` | `LocaleFormatters` | Number and time format locale |
 | `loader` | `Loader` | Custom data loader |
 | `background` | `Color` | Chart background color |
+
+`compileOptions` fields (Vega-Lite specs only, ignored otherwise):
+
+| `compileOptions` field | Type | Description |
+|---|---|---|
+| `config` | `VegaLiteConfig` | Vega-Lite config merged on top of the spec's config |
+| `logger` | `LoggerInterface` | Custom logger used during compilation |
+| `fieldTitle` | `(fieldDef, config) => string` | Custom field title formatter |
 
 `parseOptions` fields:
 

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -2,7 +2,7 @@
 
 XDS Vega wrapper — chart and data visualization components.
 
-Wraps [`vega-embed`](https://github.com/vega/vega-embed) in a React component that integrates cleanly with the XDS design system.
+Compiles [Vega-Lite](https://vega.github.io/vega-lite/) specs and renders them via the [Vega](https://vega.github.io/vega/) runtime directly, giving you full access to the live `View` object for signals, data streaming, and event listeners.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
@@ -14,13 +14,13 @@ Wraps [`vega-embed`](https://github.com/vega/vega-embed) in a React component th
 | `tsconfig.json` | Config | TypeScript compiler config (extends root) |
 | `tsup.config.ts` | Config | Build config — CJS + ESM + `.d.ts` outputs |
 | `src/index.ts` | Barrel | Public API surface |
-| `src/VegaChart.tsx` | Component | React wrapper around `vega-embed` |
+| `src/VegaChart.tsx` | Component | Compiles Vega-Lite → Vega and owns the View lifecycle |
 | `src/types.ts` | Types | Shared TypeScript types for this package |
 
 ## Installation
 
 ```bash
-yarn add @xds/vega vega-lite vega-embed
+yarn add @xds/vega vega vega-lite
 ```
 
 ## Usage
@@ -40,6 +40,19 @@ const spec = {
 <VegaChart spec={spec} />
 ```
 
+Access the live Vega `View` via `onReady` for signals, streaming data, or event listeners:
+
+```tsx
+<VegaChart
+  spec={spec}
+  onReady={view => {
+    view.addSignalListener('highlight', (name, value) => {
+      console.log('signal:', name, value);
+    });
+  }}
+/>
+```
+
 ## API
 
 ### `<VegaChart>`
@@ -47,11 +60,12 @@ const spec = {
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `spec` | `TopLevelSpec` | — | Vega-Lite specification (required) |
-| `options` | `EmbedOptions` | `{}` | vega-embed options (renderer, actions, tooltip…) |
+| `viewConfig` | `Config` | — | Vega runtime config (renderer defaults, logging, etc.) |
+| `renderer` | `'svg' \| 'canvas'` | `'svg'` | Rendering backend |
 | `className` | `string` | — | CSS class on the container div |
 | `style` | `CSSProperties` | — | Inline styles on the container div |
-| `onReady` | `() => void` | — | Called when the chart is fully rendered |
-| `onError` | `(err: Error) => void` | — | Called on render failure |
+| `onReady` | `(view: View) => void` | — | Called with the live Vega View when ready |
+| `onError` | `(err: Error) => void` | — | Called on compile or render failure |
 
 ## Build
 

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -14,7 +14,7 @@ Renders [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github
 | `tsconfig.json` | Config | TypeScript compiler config (extends root) |
 | `tsup.config.ts` | Config | Build config -- CJS + ESM + `.d.ts` outputs |
 | `src/index.ts` | Barrel | Public API surface |
-| `src/VegaChart.tsx` | Component | Inspects `$schema`, compiles or renders, owns View lifecycle |
+| `src/XDSVegaChart.tsx` | Component | Inspects `$schema`, compiles or renders, owns View lifecycle |
 | `src/schema.ts` | Utility | Parses and validates Vega/Vega-Lite `$schema` URLs |
 | `src/types.ts` | Types | Shared TypeScript types for this package |
 
@@ -29,9 +29,9 @@ yarn add @xds/vega vega vega-lite
 ### Vega-Lite spec (compiled automatically)
 
 ```tsx
-import {VegaChart} from '@xds/vega';
+import {XDSVegaChart} from '@xds/vega';
 
-<VegaChart
+<XDSVegaChart
   spec={{
     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
     mark: 'bar',
@@ -47,7 +47,7 @@ import {VegaChart} from '@xds/vega';
 ### Vega spec (rendered directly, no compilation)
 
 ```tsx
-<VegaChart
+<XDSVegaChart
   spec={{
     $schema: 'https://vega.github.io/schema/vega/v5.json',
     marks: [...],
@@ -58,7 +58,7 @@ import {VegaChart} from '@xds/vega';
 ### Full configuration
 
 ```tsx
-<VegaChart
+<XDSVegaChart
   spec={spec}
   parseConfig={{background: '#1a1a1a'}}
   parseOptions={{ast: true}}
@@ -80,7 +80,7 @@ import {VegaChart} from '@xds/vega';
 
 ## API
 
-### `<VegaChart>`
+### `<XDSVegaChart>`
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
@@ -129,7 +129,7 @@ import {VegaChart} from '@xds/vega';
 To update data dynamically after render, use `onReady` to get the live View and drive it yourself:
 
 ```tsx
-<VegaChart
+<XDSVegaChart
   spec={spec}
   data={{table: [{category: 'A', value: 28}, {category: 'B', value: 55}]}}
   onReady={view => {
@@ -148,7 +148,7 @@ Parses and validates a Vega `$schema` URL. Returns:
 
 ## Schema validation
 
-`VegaChart` validates `spec.$schema` before doing any work. It will call `onError` (and render nothing) if:
+`XDSVegaChart` validates `spec.$schema` before doing any work. It will call `onError` (and render nothing) if:
 
 - `$schema` is missing or not a string
 - The URL doesn't match the expected format (`schema/{library}/{version}.json`)

--- a/packages/vega/README.md
+++ b/packages/vega/README.md
@@ -1,8 +1,8 @@
 # @xds/vega
 
-XDS Vega wrapper — chart and data visualization components.
+XDS Vega wrapper -- chart and data visualization components.
 
-Compiles [Vega-Lite](https://vega.github.io/vega-lite/) specs and renders them via the [Vega](https://vega.github.io/vega/) runtime directly, giving you full access to the live `View` object for signals, data streaming, and event listeners.
+Renders [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github.io/vega-lite/) specifications via the Vega runtime. The component inspects `$schema` to decide whether to compile (Vega-Lite) or render directly (Vega), and validates the schema URL before doing either.
 
 <!-- SYNC: When files in this directory change, update this document. -->
 
@@ -12,9 +12,10 @@ Compiles [Vega-Lite](https://vega.github.io/vega-lite/) specs and renders them v
 |------|------|---------|
 | `package.json` | Config | Package metadata, deps, build scripts |
 | `tsconfig.json` | Config | TypeScript compiler config (extends root) |
-| `tsup.config.ts` | Config | Build config — CJS + ESM + `.d.ts` outputs |
+| `tsup.config.ts` | Config | Build config -- CJS + ESM + `.d.ts` outputs |
 | `src/index.ts` | Barrel | Public API surface |
-| `src/VegaChart.tsx` | Component | Compiles Vega-Lite → Vega and owns the View lifecycle |
+| `src/VegaChart.tsx` | Component | Inspects `$schema`, compiles or renders, owns View lifecycle |
+| `src/schema.ts` | Utility | Parses and validates Vega/Vega-Lite `$schema` URLs |
 | `src/types.ts` | Types | Shared TypeScript types for this package |
 
 ## Installation
@@ -25,22 +26,36 @@ yarn add @xds/vega vega vega-lite
 
 ## Usage
 
+### Vega-Lite spec (compiled automatically)
+
 ```tsx
 import {VegaChart} from '@xds/vega';
 
-const spec = {
-  mark: 'bar',
-  data: {values: [{a: 'A', b: 28}, {a: 'B', b: 55}]},
-  encoding: {
-    x: {field: 'a', type: 'ordinal'},
-    y: {field: 'b', type: 'quantitative'},
-  },
-};
-
-<VegaChart spec={spec} />
+<VegaChart
+  spec={{
+    $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+    mark: 'bar',
+    data: {values: [{a: 'A', b: 28}, {a: 'B', b: 55}]},
+    encoding: {
+      x: {field: 'a', type: 'ordinal'},
+      y: {field: 'b', type: 'quantitative'},
+    },
+  }}
+/>
 ```
 
-Access the live Vega `View` via `onReady` for signals, streaming data, or event listeners:
+### Vega spec (rendered directly, no compilation)
+
+```tsx
+<VegaChart
+  spec={{
+    $schema: 'https://vega.github.io/schema/vega/v5.json',
+    marks: [...],
+  }}
+/>
+```
+
+### Accessing the live View
 
 ```tsx
 <VegaChart
@@ -50,6 +65,7 @@ Access the live Vega `View` via `onReady` for signals, streaming data, or event 
       console.log('signal:', name, value);
     });
   }}
+  onError={err => console.error('Chart error:', err.message)}
 />
 ```
 
@@ -59,13 +75,27 @@ Access the live Vega `View` via `onReady` for signals, streaming data, or event 
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `spec` | `TopLevelSpec` | — | Vega-Lite specification (required) |
-| `viewConfig` | `Config` | — | Vega runtime config (renderer defaults, logging, etc.) |
-| `renderer` | `'svg' \| 'canvas'` | `'svg'` | Rendering backend |
-| `className` | `string` | — | CSS class on the container div |
-| `style` | `CSSProperties` | — | Inline styles on the container div |
-| `onReady` | `(view: View) => void` | — | Called with the live Vega View when ready |
-| `onError` | `(err: Error) => void` | — | Called on compile or render failure |
+| `spec` | `AnySpec` | -- | Vega or Vega-Lite spec. Must include `$schema` (required) |
+| `viewConfig` | `Config` | -- | Vega runtime config (renderer defaults, logging, etc.) |
+| `renderer` | `'svg' | 'canvas'` | `'svg'` | Rendering backend |
+| `className` | `string` | -- | CSS class on the container div |
+| `style` | `CSSProperties` | -- | Inline styles on the container div |
+| `onReady` | `(view: View) => void` | -- | Called with the live Vega View when ready |
+| `onError` | `(err: Error) => void` | -- | Called on schema error, compile failure, or render failure |
+
+### `parseSchema(schema)` (exported utility)
+
+Parses and validates a Vega `$schema` URL. Returns:
+- `{ok: true, library: 'vega' | 'vega-lite', version: string}` on success
+- `{ok: false, error: string}` if the URL is missing, malformed, or names an unknown library
+
+## Schema validation
+
+`VegaChart` validates `spec.$schema` before doing any work. It will call `onError` (and render nothing) if:
+
+- `$schema` is missing or not a string
+- The URL doesn't match the expected format (`schema/{library}/{version}.json`)
+- The library name is not `vega` or `vega-lite`
 
 ## Build
 

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -25,8 +25,8 @@
   "peerDependencies": {
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
-    "vega-lite": ">=5.0.0",
-    "vega-embed": ">=6.0.0"
+    "vega": ">=5.0.0",
+    "vega-lite": ">=5.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -22,13 +22,11 @@
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit"
   },
-  "dependencies": {
-    "vega-lite": "^5.0.0",
-    "vega-embed": "^6.0.0"
-  },
   "peerDependencies": {
-    "react": ">=18.0.0",
-    "react-dom": ">=18.0.0"
+    "react": ">=19.0.0",
+    "react-dom": ">=19.0.0",
+    "vega-lite": ">=5.0.0",
+    "vega-embed": ">=6.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xds/vega",
-  "version": "0.0.1",
-  "description": "XDS Vega wrapper — chart and data visualization components",
+  "version": "0.0.10",
+  "description": "XDS Vega wrapper \u2014 chart and data visualization components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
@@ -26,7 +26,8 @@
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
     "vega": ">=6.0.0",
-    "vega-lite": ">=6.0.0"
+    "vega-lite": ">=6.0.0",
+    "@xds/core": "*"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
@@ -34,6 +35,7 @@
     "typescript": "^5.7.0",
     "vega": "^6.2.0",
     "vega-lite": "^6.4.2",
-    "vega-util": "^1.17.2"
+    "vega-util": "^1.17.2",
+    "@xds/core": "*"
   }
 }

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -33,6 +33,7 @@
     "tsup": "^8.3.0",
     "typescript": "^5.7.0",
     "vega": "^6.2.0",
-    "vega-lite": "^6.4.2"
+    "vega-lite": "^6.4.2",
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -25,12 +25,14 @@
   "peerDependencies": {
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
-    "vega": ">=5.0.0",
-    "vega-lite": ">=5.0.0"
+    "vega": ">=6.0.0",
+    "vega-lite": ">=6.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
     "tsup": "^8.3.0",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "vega": "^6.2.0",
+    "vega-lite": "^6.4.2"
   }
 }

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -26,8 +26,7 @@
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
     "vega": ">=6.0.0",
-    "vega-lite": ">=6.0.0",
-    "@xds/core": "*"
+    "vega-lite": ">=6.0.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
@@ -35,7 +34,6 @@
     "typescript": "^5.7.0",
     "vega": "^6.2.0",
     "vega-lite": "^6.4.2",
-    "vega-util": "^1.17.2",
-    "@xds/core": "*"
+    "vega-util": "^1.17.2"
   }
 }

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@xds/vega",
+  "version": "0.0.1",
+  "description": "XDS Vega wrapper — chart and data visualization components",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "vega-lite": "^5.0.0",
+    "vega-embed": "^6.0.0"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "tsup": "^8.3.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/vega",
-  "version": "0.0.10",
+  "version": "0.0.12",
   "description": "XDS Vega wrapper \u2014 chart and data visualization components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -1,0 +1,79 @@
+/**
+ * @file VegaChart.tsx
+ * @input A Vega-Lite spec + optional embed options
+ * @output A React component that renders a Vega-Lite chart via vega-embed
+ * @position Primary component in @xds/vega; wraps vega-embed in a React lifecycle
+ *
+ * SYNC: When modified, update /packages/vega/README.md
+ */
+
+import React, {useEffect, useRef} from 'react';
+import embed from 'vega-embed';
+import type {VegaChartProps} from './types';
+
+/**
+ * `VegaChart` renders a Vega-Lite specification as an interactive chart.
+ *
+ * It wraps `vega-embed` in a React component, managing the embed lifecycle
+ * (mount, spec update, unmount) automatically.
+ *
+ * @example
+ * ```
+ * import {VegaChart} from '@xds/vega';
+ *
+ * const spec = {
+ *   mark: 'bar',
+ *   data: {values: [{a: 'A', b: 28}, {a: 'B', b: 55}]},
+ *   encoding: {
+ *     x: {field: 'a', type: 'ordinal'},
+ *     y: {field: 'b', type: 'quantitative'},
+ *   },
+ * };
+ *
+ * <VegaChart spec={spec} />
+ * ```
+ */
+export function VegaChart({
+  spec,
+  options,
+  className,
+  style,
+  onReady,
+  onError,
+}: VegaChartProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let cancelled = false;
+
+    embed(container, spec, {
+      actions: false,
+      renderer: 'svg',
+      ...options,
+    })
+      .then(result => {
+        if (!cancelled) {
+          onReady?.();
+          return result;
+        }
+        result.finalize();
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          onError?.(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      // vega-embed cleans up its own DOM when re-embedding, but we clear
+      // the container on unmount to avoid stale SVG nodes.
+      container.innerHTML = '';
+    };
+  }, [spec, options, onReady, onError]);
+
+  return <div ref={containerRef} className={className} style={style} />;
+}

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -137,7 +137,6 @@ export function VegaChart({
     };
   // Object props are intentionally in the dep array. Callers should memoize
   // them to avoid unnecessary re-renders.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [spec, compileOptions, parseConfig, parseOptions, viewOptions]);
 
   return <div ref={containerRef} className={className} style={style} />;

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -27,8 +27,11 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec, ViewData} from './types';
  *   vega.parse(spec, parseConfig, parseOptions)
  *   new vega.View(runtime, { ...viewOptions, container })
  *
- * Initial dataset values can be provided via `data` and updated independently
- * without triggering a full re-embed -- only the data is reloaded.
+ * Initial dataset values can be provided via `data` and are loaded once
+ * during View initialization, before the first render. `data` is not
+ * reactive — changes after mount are ignored. Use `onReady` to get the
+ * live `View` and call `view.data(name, tuples)` + `view.runAsync()`
+ * yourself if you need to update data after render.
  *
  * It owns the full `View` lifecycle: creates the view on mount, re-creates
  * it when `spec`, `parseConfig`, `parseOptions`, or `viewOptions` changes,
@@ -78,7 +81,6 @@ export function VegaChart({
   onError,
 }: VegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const viewRef = useRef<View | null>(null);
 
   // Keep callbacks in refs so they don't need to be in the dep array.
   const onReadyRef = useRef(onReady);
@@ -92,6 +94,7 @@ export function VegaChart({
     if (!container) return;
 
     let cancelled = false;
+    let view: View | null = null;
 
     const fail = (err: unknown) => {
       if (!cancelled) {
@@ -117,23 +120,27 @@ export function VegaChart({
       const runtime = parse(vegaSpec, parseConfig, parseOptions);
 
       // new View(runtime, viewOptions) -- container is always injected by us.
-      const view = new View(runtime, {
+      view = new View(runtime, {
         hover: true,
         ...viewOptions,
         container,
       });
 
-      viewRef.current = view;
+      // Load initial data into named datasets before the first render.
+      if (data) {
+        for (const [name, tuples] of Object.entries(data)) {
+          view.data(name, tuples);
+        }
+      }
 
       view
         .runAsync()
         .then(() => {
           if (cancelled) {
-            view.finalize();
-            viewRef.current = null;
+            view?.finalize();
             return;
           }
-          onReadyRef.current?.(view);
+          onReadyRef.current?.(view!);
         })
         .catch(fail);
     } catch (err) {
@@ -142,25 +149,9 @@ export function VegaChart({
 
     return () => {
       cancelled = true;
-      viewRef.current?.finalize();
-      viewRef.current = null;
+      view?.finalize();
     };
-  }, [spec, compileOptions, parseConfig, parseOptions, viewOptions]); // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Effect 2: load data into named datasets when `data` changes, without
-  // re-creating the View. Runs after the View effect so viewRef is populated.
-  useEffect(() => {
-    if (!data || !viewRef.current) return;
-    const view = viewRef.current;
-
-    for (const [name, tuples] of Object.entries(data)) {
-      view.data(name, tuples);
-    }
-
-    view.runAsync().catch((err: unknown) => {
-      onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
-    });
-  }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [spec, data, compileOptions, parseConfig, parseOptions, viewOptions]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return <div ref={containerRef} className={className} style={style} />;
 }

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, {useEffect, useRef} from 'react';
-import embed from 'vega-embed';
+import embed, {type Result} from 'vega-embed';
 import type {VegaChartProps} from './types';
 
 /**
@@ -16,6 +16,10 @@ import type {VegaChartProps} from './types';
  *
  * It wraps `vega-embed` in a React component, managing the embed lifecycle
  * (mount, spec update, unmount) automatically.
+ *
+ * Callbacks (`onReady`, `onError`) are stable across renders via refs — you
+ * don't need to memoize them. `options` is a dep-array member: pass a stable
+ * reference (or `useMemo`) if you want to avoid re-embedding on every render.
  *
  * @example
  * ```
@@ -43,6 +47,17 @@ export function VegaChart({
 }: VegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Keep callbacks in refs so they never stale-close over old values and
+  // don't need to be in the effect dependency array (avoids spurious re-embeds).
+  const onReadyRef = useRef(onReady);
+  const onErrorRef = useRef(onError);
+  onReadyRef.current = onReady;
+  onErrorRef.current = onError;
+
+  // Track the active vega-embed result so we can finalize() it on cleanup,
+  // releasing timers, event listeners, and WebGL resources held by the Vega runtime.
+  const resultRef = useRef<Result | null>(null);
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -55,25 +70,29 @@ export function VegaChart({
       ...options,
     })
       .then(result => {
-        if (!cancelled) {
-          onReady?.();
-          return result;
+        if (cancelled) {
+          // Effect was cleaned up before the promise resolved — finalize immediately.
+          result.finalize();
+          return;
         }
-        result.finalize();
+        resultRef.current = result;
+        onReadyRef.current?.();
       })
       .catch((err: unknown) => {
         if (!cancelled) {
-          onError?.(err instanceof Error ? err : new Error(String(err)));
+          onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
         }
       });
 
     return () => {
       cancelled = true;
-      // vega-embed cleans up its own DOM when re-embedding, but we clear
-      // the container on unmount to avoid stale SVG nodes.
-      container.innerHTML = '';
+      resultRef.current?.finalize();
+      resultRef.current = null;
     };
-  }, [spec, options, onReady, onError]);
+  // `options` is intentionally in the dep array — a changed options object
+  // re-embeds the chart. Callers should memoize options to avoid this.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [spec, options]);
 
   return <div ref={containerRef} className={className} style={style} />;
 }

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -1,7 +1,7 @@
 /**
  * @file VegaChart.tsx
- * @input A Vega-Lite spec + optional Vega view config
- * @output A React component that compiles and renders a Vega-Lite spec via the Vega runtime
+ * @input A Vega or Vega-Lite spec (distinguished by $schema) + optional view config
+ * @output A React component that renders the spec via the Vega runtime
  * @position Primary component in @xds/vega; owns the Vega View lifecycle
  *
  * SYNC: When modified, update /packages/vega/README.md
@@ -10,35 +10,49 @@
 import React, {useEffect, useRef} from 'react';
 import {parse, View} from 'vega';
 import {compile} from 'vega-lite';
-import type {VegaChartProps} from './types';
+import {parseSchema} from './schema';
+import type {VegaChartProps, VegaSpec} from './types';
 
 /**
- * `VegaChart` compiles a Vega-Lite specification and renders it using the
- * Vega runtime directly — no vega-embed intermediary.
+ * `VegaChart` renders a Vega or Vega-Lite specification using the Vega runtime.
  *
- * The component owns the full `View` lifecycle: it creates the view on mount,
- * re-creates it when `spec` or `renderer` changes, exposes the live `View`
- * via `onReady`, and calls `view.finalize()` on cleanup to release all
- * runtime resources (timers, event listeners, WebGL contexts).
+ * The component inspects `spec.$schema` to determine how to handle the spec:
+ * - `vega-lite` schema -> compiled to Vega via `vega-lite`'s `compile()`, then rendered
+ * - `vega` schema -> rendered directly without compilation
+ * - Invalid / missing `$schema` -> calls `onError` and renders nothing
  *
- * Callbacks (`onReady`, `onError`) are stable across renders via refs —
+ * It owns the full `View` lifecycle: creates the view on mount, re-creates it
+ * when `spec`, `renderer`, or `viewConfig` changes, and calls `view.finalize()`
+ * on cleanup to release all runtime resources.
+ *
+ * Callbacks (`onReady`, `onError`) are stable across renders via refs --
  * you don't need to memoize them. Pass a stable `viewConfig` reference
- * (or `useMemo`) to avoid unnecessary re-renders.
+ * (or `useMemo`) to avoid unnecessary re-embeds.
  *
  * @example
  * ```
  * import {VegaChart} from '@xds/vega';
  *
- * const spec = {
- *   mark: 'bar',
- *   data: {values: [{a: 'A', b: 28}, {a: 'B', b: 55}]},
- *   encoding: {
- *     x: {field: 'a', type: 'ordinal'},
- *     y: {field: 'b', type: 'quantitative'},
- *   },
- * };
+ * // Vega-Lite spec -- compiled automatically
+ * <VegaChart
+ *   spec={{
+ *     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
+ *     mark: 'bar',
+ *     data: {values: [{a: 'A', b: 28}, {a: 'B', b: 55}]},
+ *     encoding: {
+ *       x: {field: 'a', type: 'ordinal'},
+ *       y: {field: 'b', type: 'quantitative'},
+ *     },
+ *   }}
+ * />
  *
- * <VegaChart spec={spec} onReady={view => console.log('view ready', view)} />
+ * // Vega spec -- rendered directly
+ * <VegaChart
+ *   spec={{
+ *     $schema: 'https://vega.github.io/schema/vega/v5.json',
+ *     marks: [],
+ *   }}
+ * />
  * ```
  */
 export function VegaChart({
@@ -52,7 +66,7 @@ export function VegaChart({
 }: VegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Keep callbacks in refs so they never need to be in the dep array.
+  // Keep callbacks in refs so they don't need to be in the dep array.
   const onReadyRef = useRef(onReady);
   const onErrorRef = useRef(onError);
   onReadyRef.current = onReady;
@@ -65,9 +79,26 @@ export function VegaChart({
     let view: View | null = null;
     let cancelled = false;
 
+    const fail = (err: unknown) => {
+      if (!cancelled) {
+        onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
+      }
+    };
+
     try {
-      // Compile Vega-Lite → Vega spec, then parse → Vega runtime.
-      const vegaSpec = compile(spec).spec;
+      // Validate $schema and resolve the library kind.
+      const schemaResult = parseSchema(spec.$schema);
+      if (!schemaResult.ok) {
+        fail(new Error(schemaResult.error));
+        return;
+      }
+
+      // Compile Vega-Lite -> Vega if needed; otherwise use the spec directly.
+      const vegaSpec: VegaSpec =
+        schemaResult.library === 'vega-lite'
+          ? compile(spec).spec
+          : (spec as VegaSpec);
+
       const runtime = parse(vegaSpec, viewConfig);
 
       view = new View(runtime, {
@@ -85,23 +116,15 @@ export function VegaChart({
           }
           onReadyRef.current?.(view!);
         })
-        .catch((err: unknown) => {
-          if (!cancelled) {
-            onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
-          }
-        });
-    } catch (err: unknown) {
-      if (!cancelled) {
-        onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
-      }
+        .catch(fail);
+    } catch (err) {
+      fail(err);
     }
 
     return () => {
       cancelled = true;
       view?.finalize();
     };
-  // viewConfig is intentionally in the dep array. Callers should memoize it
-  // if they want to avoid re-rendering on every parent render.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [spec, renderer, viewConfig]);
 

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -1,6 +1,6 @@
 /**
  * @file VegaChart.tsx
- * @input A Vega or Vega-Lite spec (distinguished by $schema) + optional view config
+ * @input A Vega or Vega-Lite spec (distinguished by $schema), parse config/options, and view options
  * @output A React component that renders the spec via the Vega runtime
  * @position Primary component in @xds/vega; owns the Vega View lifecycle
  *
@@ -21,13 +21,19 @@ import type {VegaChartProps, VegaSpec} from './types';
  * - `vega` schema -> rendered directly without compilation
  * - Invalid / missing `$schema` -> calls `onError` and renders nothing
  *
- * It owns the full `View` lifecycle: creates the view on mount, re-creates it
- * when `spec`, `renderer`, or `viewConfig` changes, and calls `view.finalize()`
- * on cleanup to release all runtime resources.
+ * Parse and view construction are fully configurable via `parseConfig`,
+ * `parseOptions`, and `viewOptions`, which map directly to the Vega API:
+ *
+ *   vega.parse(spec, parseConfig, parseOptions)
+ *   new vega.View(runtime, { ...viewOptions, container })
+ *
+ * It owns the full `View` lifecycle: creates the view on mount, re-creates
+ * it when `spec`, `parseConfig`, `parseOptions`, or `viewOptions` changes,
+ * and calls `view.finalize()` on cleanup to release all runtime resources.
  *
  * Callbacks (`onReady`, `onError`) are stable across renders via refs --
- * you don't need to memoize them. Pass a stable `viewConfig` reference
- * (or `useMemo`) to avoid unnecessary re-embeds.
+ * you don't need to memoize them. Pass stable references (or `useMemo`)
+ * for `parseConfig`, `parseOptions`, and `viewOptions` to avoid re-renders.
  *
  * @example
  * ```
@@ -44,21 +50,22 @@ import type {VegaChartProps, VegaSpec} from './types';
  *       y: {field: 'b', type: 'quantitative'},
  *     },
  *   }}
+ *   viewOptions={{renderer: 'canvas', hover: true}}
  * />
  *
  * // Vega spec -- rendered directly
  * <VegaChart
- *   spec={{
- *     $schema: 'https://vega.github.io/schema/vega/v5.json',
- *     marks: [],
- *   }}
+ *   spec={{$schema: 'https://vega.github.io/schema/vega/v5.json', marks: []}}
+ *   parseConfig={{background: '#1a1a1a'}}
+ *   viewOptions={{logLevel: 1, tooltip: myTooltipHandler}}
  * />
  * ```
  */
 export function VegaChart({
   spec,
-  viewConfig,
-  renderer = 'svg',
+  parseConfig,
+  parseOptions,
+  viewOptions,
   className,
   style,
   onReady,
@@ -99,12 +106,14 @@ export function VegaChart({
           ? compile(spec).spec
           : (spec as VegaSpec);
 
-      const runtime = parse(vegaSpec, viewConfig);
+      // parse(spec, config?, options?) -> Runtime
+      const runtime = parse(vegaSpec, parseConfig, parseOptions);
 
+      // new View(runtime, viewOptions) -- container is always injected by us.
       view = new View(runtime, {
-        renderer,
-        container,
         hover: true,
+        ...viewOptions,
+        container,
       });
 
       view
@@ -125,8 +134,10 @@ export function VegaChart({
       cancelled = true;
       view?.finalize();
     };
+  // parseConfig, parseOptions, and viewOptions are intentionally in the dep
+  // array. Callers should memoize them to avoid unnecessary re-renders.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [spec, renderer, viewConfig]);
+  }, [spec, parseConfig, parseOptions, viewOptions]);
 
   return <div ref={containerRef} className={className} style={style} />;
 }

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -63,6 +63,7 @@ import type {VegaChartProps, VegaSpec} from './types';
  */
 export function VegaChart({
   spec,
+  compileOptions,
   parseConfig,
   parseOptions,
   viewOptions,
@@ -103,7 +104,7 @@ export function VegaChart({
       // Compile Vega-Lite -> Vega if needed; otherwise use the spec directly.
       const vegaSpec: VegaSpec =
         schemaResult.library === 'vega-lite'
-          ? compile(spec).spec
+          ? compile(spec, compileOptions).spec
           : (spec as VegaSpec);
 
       // parse(spec, config?, options?) -> Runtime
@@ -134,10 +135,10 @@ export function VegaChart({
       cancelled = true;
       view?.finalize();
     };
-  // parseConfig, parseOptions, and viewOptions are intentionally in the dep
-  // array. Callers should memoize them to avoid unnecessary re-renders.
+  // Object props are intentionally in the dep array. Callers should memoize
+  // them to avoid unnecessary re-renders.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [spec, parseConfig, parseOptions, viewOptions]);
+  }, [spec, compileOptions, parseConfig, parseOptions, viewOptions]);
 
   return <div ref={containerRef} className={className} style={style} />;
 }

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -1,25 +1,29 @@
 /**
  * @file VegaChart.tsx
- * @input A Vega-Lite spec + optional embed options
- * @output A React component that renders a Vega-Lite chart via vega-embed
- * @position Primary component in @xds/vega; wraps vega-embed in a React lifecycle
+ * @input A Vega-Lite spec + optional Vega view config
+ * @output A React component that compiles and renders a Vega-Lite spec via the Vega runtime
+ * @position Primary component in @xds/vega; owns the Vega View lifecycle
  *
  * SYNC: When modified, update /packages/vega/README.md
  */
 
 import React, {useEffect, useRef} from 'react';
-import embed, {type Result} from 'vega-embed';
+import {parse, View} from 'vega';
+import {compile} from 'vega-lite';
 import type {VegaChartProps} from './types';
 
 /**
- * `VegaChart` renders a Vega-Lite specification as an interactive chart.
+ * `VegaChart` compiles a Vega-Lite specification and renders it using the
+ * Vega runtime directly — no vega-embed intermediary.
  *
- * It wraps `vega-embed` in a React component, managing the embed lifecycle
- * (mount, spec update, unmount) automatically.
+ * The component owns the full `View` lifecycle: it creates the view on mount,
+ * re-creates it when `spec` or `renderer` changes, exposes the live `View`
+ * via `onReady`, and calls `view.finalize()` on cleanup to release all
+ * runtime resources (timers, event listeners, WebGL contexts).
  *
- * Callbacks (`onReady`, `onError`) are stable across renders via refs — you
- * don't need to memoize them. `options` is a dep-array member: pass a stable
- * reference (or `useMemo`) if you want to avoid re-embedding on every render.
+ * Callbacks (`onReady`, `onError`) are stable across renders via refs —
+ * you don't need to memoize them. Pass a stable `viewConfig` reference
+ * (or `useMemo`) to avoid unnecessary re-renders.
  *
  * @example
  * ```
@@ -34,12 +38,13 @@ import type {VegaChartProps} from './types';
  *   },
  * };
  *
- * <VegaChart spec={spec} />
+ * <VegaChart spec={spec} onReady={view => console.log('view ready', view)} />
  * ```
  */
 export function VegaChart({
   spec,
-  options,
+  viewConfig,
+  renderer = 'svg',
   className,
   style,
   onReady,
@@ -47,52 +52,58 @@ export function VegaChart({
 }: VegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Keep callbacks in refs so they never stale-close over old values and
-  // don't need to be in the effect dependency array (avoids spurious re-embeds).
+  // Keep callbacks in refs so they never need to be in the dep array.
   const onReadyRef = useRef(onReady);
   const onErrorRef = useRef(onError);
   onReadyRef.current = onReady;
   onErrorRef.current = onError;
 
-  // Track the active vega-embed result so we can finalize() it on cleanup,
-  // releasing timers, event listeners, and WebGL resources held by the Vega runtime.
-  const resultRef = useRef<Result | null>(null);
-
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
+    let view: View | null = null;
     let cancelled = false;
 
-    embed(container, spec, {
-      actions: false,
-      renderer: 'svg',
-      ...options,
-    })
-      .then(result => {
-        if (cancelled) {
-          // Effect was cleaned up before the promise resolved — finalize immediately.
-          result.finalize();
-          return;
-        }
-        resultRef.current = result;
-        onReadyRef.current?.();
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
-        }
+    try {
+      // Compile Vega-Lite → Vega spec, then parse → Vega runtime.
+      const vegaSpec = compile(spec).spec;
+      const runtime = parse(vegaSpec, viewConfig);
+
+      view = new View(runtime, {
+        renderer,
+        container,
+        hover: true,
       });
+
+      view
+        .runAsync()
+        .then(() => {
+          if (cancelled) {
+            view?.finalize();
+            return;
+          }
+          onReadyRef.current?.(view!);
+        })
+        .catch((err: unknown) => {
+          if (!cancelled) {
+            onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
+          }
+        });
+    } catch (err: unknown) {
+      if (!cancelled) {
+        onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
+      }
+    }
 
     return () => {
       cancelled = true;
-      resultRef.current?.finalize();
-      resultRef.current = null;
+      view?.finalize();
     };
-  // `options` is intentionally in the dep array — a changed options object
-  // re-embeds the chart. Callers should memoize options to avoid this.
+  // viewConfig is intentionally in the dep array. Callers should memoize it
+  // if they want to avoid re-rendering on every parent render.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [spec, options]);
+  }, [spec, renderer, viewConfig]);
 
   return <div ref={containerRef} className={className} style={style} />;
 }

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -11,7 +11,7 @@ import React, {useEffect, useRef} from 'react';
 import {parse, View} from 'vega';
 import {compile} from 'vega-lite';
 import {parseSchema} from './schema';
-import type {VegaChartProps, VegaSpec} from './types';
+import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
 
 /**
  * `VegaChart` renders a Vega or Vega-Lite specification using the Vega runtime.
@@ -104,7 +104,7 @@ export function VegaChart({
       // Compile Vega-Lite -> Vega if needed; otherwise use the spec directly.
       const vegaSpec: VegaSpec =
         schemaResult.library === 'vega-lite'
-          ? compile(spec, compileOptions).spec
+          ? compile(spec as VegaLiteSpec, compileOptions).spec
           : (spec as VegaSpec);
 
       // parse(spec, config?, options?) -> Runtime

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -1,6 +1,6 @@
 /**
  * @file VegaChart.tsx
- * @input A Vega or Vega-Lite spec (distinguished by $schema), parse config/options, and view options
+ * @input A Vega or Vega-Lite spec (distinguished by $schema), parse config/options, view options, and data
  * @output A React component that renders the spec via the Vega runtime
  * @position Primary component in @xds/vega; owns the Vega View lifecycle
  *
@@ -11,7 +11,7 @@ import React, {useEffect, useRef} from 'react';
 import {parse, View} from 'vega';
 import {compile} from 'vega-lite';
 import {parseSchema} from './schema';
-import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
+import type {VegaChartProps, VegaSpec, VegaLiteSpec, ViewData} from './types';
 
 /**
  * `VegaChart` renders a Vega or Vega-Lite specification using the Vega runtime.
@@ -27,13 +27,17 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
  *   vega.parse(spec, parseConfig, parseOptions)
  *   new vega.View(runtime, { ...viewOptions, container })
  *
+ * Initial dataset values can be provided via `data` and updated independently
+ * without triggering a full re-embed -- only the data is reloaded.
+ *
  * It owns the full `View` lifecycle: creates the view on mount, re-creates
  * it when `spec`, `parseConfig`, `parseOptions`, or `viewOptions` changes,
  * and calls `view.finalize()` on cleanup to release all runtime resources.
  *
  * Callbacks (`onReady`, `onError`) are stable across renders via refs --
  * you don't need to memoize them. Pass stable references (or `useMemo`)
- * for `parseConfig`, `parseOptions`, and `viewOptions` to avoid re-renders.
+ * for `parseConfig`, `parseOptions`, `viewOptions`, and `data` to avoid
+ * unnecessary re-renders.
  *
  * @example
  * ```
@@ -44,13 +48,13 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
  *   spec={{
  *     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
  *     mark: 'bar',
- *     data: {values: [{a: 'A', b: 28}, {a: 'B', b: 55}]},
+ *     data: {name: 'table'},
  *     encoding: {
  *       x: {field: 'a', type: 'ordinal'},
  *       y: {field: 'b', type: 'quantitative'},
  *     },
  *   }}
- *   viewOptions={{renderer: 'canvas', hover: true}}
+ *   data={{table: [{a: 'A', b: 28}, {a: 'B', b: 55}]}}
  * />
  *
  * // Vega spec -- rendered directly
@@ -63,6 +67,7 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
  */
 export function VegaChart({
   spec,
+  data,
   compileOptions,
   parseConfig,
   parseOptions,
@@ -73,6 +78,7 @@ export function VegaChart({
   onError,
 }: VegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<View | null>(null);
 
   // Keep callbacks in refs so they don't need to be in the dep array.
   const onReadyRef = useRef(onReady);
@@ -80,11 +86,11 @@ export function VegaChart({
   onReadyRef.current = onReady;
   onErrorRef.current = onError;
 
+  // Effect 1: create/destroy the View when spec or construction options change.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
 
-    let view: View | null = null;
     let cancelled = false;
 
     const fail = (err: unknown) => {
@@ -111,20 +117,23 @@ export function VegaChart({
       const runtime = parse(vegaSpec, parseConfig, parseOptions);
 
       // new View(runtime, viewOptions) -- container is always injected by us.
-      view = new View(runtime, {
+      const view = new View(runtime, {
         hover: true,
         ...viewOptions,
         container,
       });
 
+      viewRef.current = view;
+
       view
         .runAsync()
         .then(() => {
           if (cancelled) {
-            view?.finalize();
+            view.finalize();
+            viewRef.current = null;
             return;
           }
-          onReadyRef.current?.(view!);
+          onReadyRef.current?.(view);
         })
         .catch(fail);
     } catch (err) {
@@ -133,11 +142,25 @@ export function VegaChart({
 
     return () => {
       cancelled = true;
-      view?.finalize();
+      viewRef.current?.finalize();
+      viewRef.current = null;
     };
-  // Object props are intentionally in the dep array. Callers should memoize
-  // them to avoid unnecessary re-renders.
-  }, [spec, compileOptions, parseConfig, parseOptions, viewOptions]);
+  }, [spec, compileOptions, parseConfig, parseOptions, viewOptions]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Effect 2: load data into named datasets when `data` changes, without
+  // re-creating the View. Runs after the View effect so viewRef is populated.
+  useEffect(() => {
+    if (!data || !viewRef.current) return;
+    const view = viewRef.current;
+
+    for (const [name, tuples] of Object.entries(data)) {
+      view.data(name, tuples);
+    }
+
+    view.runAsync().catch((err: unknown) => {
+      onErrorRef.current?.(err instanceof Error ? err : new Error(String(err)));
+    });
+  }, [data]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return <div ref={containerRef} className={className} style={style} />;
 }

--- a/packages/vega/src/XDSVegaChart.tsx
+++ b/packages/vega/src/XDSVegaChart.tsx
@@ -153,7 +153,7 @@ export function XDSVegaChart({
       cancelled = true;
       view?.finalize();
     };
-  }, [spec, data, compileOptions, parseConfig, parseOptions, viewOptions]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [spec, data, compileOptions, parseConfig, parseOptions, viewOptions]);
 
   return (
     <div

--- a/packages/vega/src/XDSVegaChart.tsx
+++ b/packages/vega/src/XDSVegaChart.tsx
@@ -1,5 +1,5 @@
 /**
- * @file VegaChart.tsx
+ * @file XDSVegaChart.tsx
  * @input A Vega or Vega-Lite spec (distinguished by $schema), parse config/options, view options, and data
  * @output A React component that renders the spec via the Vega runtime
  * @position Primary component in @xds/vega; owns the Vega View lifecycle
@@ -11,10 +11,10 @@ import React, {useEffect, useRef} from 'react';
 import {parse, View} from 'vega';
 import {compile} from 'vega-lite';
 import {parseSchema} from './schema';
-import type {VegaChartProps, VegaSpec, VegaLiteSpec, ViewData} from './types';
+import type {XDSVegaChartProps, VegaSpec, VegaLiteSpec} from './types';
 
 /**
- * `VegaChart` renders a Vega or Vega-Lite specification using the Vega runtime.
+ * `XDSVegaChart` renders a Vega or Vega-Lite specification using the Vega runtime.
  *
  * The component inspects `spec.$schema` to determine how to handle the spec:
  * - `vega-lite` schema -> compiled to Vega via `vega-lite`'s `compile()`, then rendered
@@ -27,11 +27,8 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec, ViewData} from './types';
  *   vega.parse(spec, parseConfig, parseOptions)
  *   new vega.View(runtime, { ...viewOptions, container })
  *
- * Initial dataset values can be provided via `data` and are loaded once
- * during View initialization, before the first render. `data` is not
- * reactive — changes after mount are ignored. Use `onReady` to get the
- * live `View` and call `view.data(name, tuples)` + `view.runAsync()`
- * yourself if you need to update data after render.
+ * Initial dataset values can be provided via `data`. They are loaded once
+ * during View initialization, before the first render, and are not reactive.
  *
  * It owns the full `View` lifecycle: creates the view on mount, re-creates
  * it when `spec`, `parseConfig`, `parseOptions`, or `viewOptions` changes,
@@ -42,12 +39,15 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec, ViewData} from './types';
  * for `parseConfig`, `parseOptions`, `viewOptions`, and `data` to avoid
  * unnecessary re-renders.
  *
+ * Note: this component does not accept `xstyle` because `@xds/vega` does not
+ * depend on StyleX. Use `className` or `style` for layout overrides.
+ *
  * @example
  * ```
- * import {VegaChart} from '@xds/vega';
+ * import {XDSVegaChart} from '@xds/vega';
  *
  * // Vega-Lite spec -- compiled automatically
- * <VegaChart
+ * <XDSVegaChart
  *   spec={{
  *     $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
  *     mark: 'bar',
@@ -61,14 +61,14 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec, ViewData} from './types';
  * />
  *
  * // Vega spec -- rendered directly
- * <VegaChart
+ * <XDSVegaChart
  *   spec={{$schema: 'https://vega.github.io/schema/vega/v5.json', marks: []}}
  *   parseConfig={{background: '#1a1a1a'}}
  *   viewOptions={{logLevel: 1, tooltip: myTooltipHandler}}
  * />
  * ```
  */
-export function VegaChart({
+export function XDSVegaChart({
   spec,
   data,
   compileOptions,
@@ -77,9 +77,11 @@ export function VegaChart({
   viewOptions,
   className,
   style,
+  ref,
   onReady,
   onError,
-}: VegaChartProps) {
+  ...props
+}: XDSVegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Keep callbacks in refs so they don't need to be in the dep array.
@@ -88,7 +90,6 @@ export function VegaChart({
   onReadyRef.current = onReady;
   onErrorRef.current = onError;
 
-  // Effect 1: create/destroy the View when spec or construction options change.
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -127,6 +128,7 @@ export function VegaChart({
       });
 
       // Load initial data into named datasets before the first render.
+      // data is not reactive -- changes after mount are ignored.
       if (data) {
         for (const [name, tuples] of Object.entries(data)) {
           view.data(name, tuples);
@@ -153,5 +155,18 @@ export function VegaChart({
     };
   }, [spec, data, compileOptions, parseConfig, parseOptions, viewOptions]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  return <div ref={containerRef} className={className} style={style} />;
+  return (
+    <div
+      ref={node => {
+        containerRef.current = node;
+        if (typeof ref === 'function') ref(node);
+        else if (ref) (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      }}
+      className={className}
+      style={style}
+      {...props}
+    />
+  );
 }
+
+XDSVegaChart.displayName = 'XDSVegaChart';

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -9,5 +9,5 @@
 
 export {VegaChart} from './VegaChart';
 export {parseSchema} from './schema';
-export type {VegaChartProps, AnySpec, VegaSpec, VegaLiteSpec, ParseOptions, Config, ViewOptions} from './types';
+export type {VegaChartProps, AnySpec, VegaSpec, VegaLiteSpec, CompileOptions, ParseOptions, Config, ViewOptions} from './types';
 export type {SchemaLibrary, SchemaResult} from './schema';

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -8,4 +8,6 @@
  */
 
 export {VegaChart} from './VegaChart';
-export type {VegaChartProps, TopLevelSpec} from './types';
+export {parseSchema} from './schema';
+export type {VegaChartProps, AnySpec, VegaSpec, VegaLiteSpec} from './types';
+export type {SchemaLibrary, SchemaResult} from './schema';

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @file index.ts
+ * @input All public exports for @xds/vega
+ * @output Public API surface for the XDS Vega wrapper package
+ * @position Barrel export; entry point for consumers of @xds/vega
+ *
+ * SYNC: When modified, update /packages/vega/README.md
+ */
+
+export {VegaChart} from './VegaChart';
+export type {VegaChartProps, TopLevelSpec} from './types';

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -7,7 +7,17 @@
  * SYNC: When modified, update /packages/vega/README.md
  */
 
-export {VegaChart} from './VegaChart';
+/**
+ * @file index.ts
+ * @input All public exports for @xds/vega
+ * @output Public API surface for the XDS Vega wrapper package
+ * @position Barrel export; entry point for consumers of @xds/vega
+ *
+ * SYNC: When modified, update /packages/vega/README.md
+ */
+
+export {XDSVegaChart} from './XDSVegaChart';
 export {parseSchema} from './schema';
-export type {VegaChartProps, AnySpec, ViewData, VegaSpec, VegaLiteSpec, CompileOptions, ParseOptions, Config, ViewOptions, LoggerInterface} from './types';
+export type {XDSVegaChartProps, AnySpec, ViewData, VegaSpec, VegaLiteSpec, CompileOptions, ParseOptions, Config, ViewOptions, LoggerInterface} from './types';
 export type {SchemaLibrary, SchemaResult} from './schema';
+

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -9,5 +9,5 @@
 
 export {VegaChart} from './VegaChart';
 export {parseSchema} from './schema';
-export type {VegaChartProps, AnySpec, VegaSpec, VegaLiteSpec, CompileOptions, ParseOptions, Config, ViewOptions} from './types';
+export type {VegaChartProps, AnySpec, ViewData, VegaSpec, VegaLiteSpec, CompileOptions, ParseOptions, Config, ViewOptions, LoggerInterface} from './types';
 export type {SchemaLibrary, SchemaResult} from './schema';

--- a/packages/vega/src/index.ts
+++ b/packages/vega/src/index.ts
@@ -9,5 +9,5 @@
 
 export {VegaChart} from './VegaChart';
 export {parseSchema} from './schema';
-export type {VegaChartProps, AnySpec, VegaSpec, VegaLiteSpec} from './types';
+export type {VegaChartProps, AnySpec, VegaSpec, VegaLiteSpec, ParseOptions, Config, ViewOptions} from './types';
 export type {SchemaLibrary, SchemaResult} from './schema';

--- a/packages/vega/src/schema.ts
+++ b/packages/vega/src/schema.ts
@@ -2,7 +2,7 @@
  * @file schema.ts
  * @input A spec object (Vega or Vega-Lite)
  * @output The resolved schema kind: 'vega', 'vega-lite', or an error
- * @position Utility; consumed by VegaChart to decide whether to compile
+ * @position Utility; consumed by XDSVegaChart to decide whether to compile
  *
  * SYNC: When modified, update /packages/vega/README.md
  */

--- a/packages/vega/src/schema.ts
+++ b/packages/vega/src/schema.ts
@@ -1,0 +1,61 @@
+/**
+ * @file schema.ts
+ * @input A spec object (Vega or Vega-Lite)
+ * @output The resolved schema kind: 'vega', 'vega-lite', or an error
+ * @position Utility; consumed by VegaChart to decide whether to compile
+ *
+ * SYNC: When modified, update /packages/vega/README.md
+ */
+
+/** Known libraries in the Vega schema URL namespace. */
+export type SchemaLibrary = 'vega' | 'vega-lite';
+
+/** Result of parsing a $schema URL. */
+export type SchemaResult =
+  | {ok: true; library: SchemaLibrary; version: string}
+  | {ok: false; error: string};
+
+/**
+ * Pattern matching the official Vega schema URL format:
+ *   https://vega.github.io/schema/{library}/{version}.json
+ * Also tolerates proxy-prefixed URLs (anything before "schema/").
+ *
+ * @see https://github.com/vega/schema
+ */
+const SCHEMA_RE = /schema\/([\w-]+)\/([\w.\-]+)\.json$/;
+
+/**
+ * Parse a Vega or Vega-Lite `$schema` URL.
+ *
+ * Returns `{ ok: true, library, version }` on success, or
+ * `{ ok: false, error }` if the URL is missing, not a string,
+ * doesn't match the expected format, or names an unknown library.
+ */
+export function parseSchema(schema: unknown): SchemaResult {
+  if (schema === undefined || schema === null) {
+    return {ok: false, error: 'Spec is missing a $schema field. Add "$schema": "https://vega.github.io/schema/vega/v5.json" or the vega-lite equivalent.'};
+  }
+
+  if (typeof schema !== 'string') {
+    return {ok: false, error: `$schema must be a string, got ${typeof schema}.`};
+  }
+
+  const match = SCHEMA_RE.exec(schema);
+  if (!match) {
+    return {
+      ok: false,
+      error: `Unrecognized $schema URL: "${schema}". Expected format: https://vega.github.io/schema/{vega|vega-lite}/{version}.json`,
+    };
+  }
+
+  const [, library, version] = match;
+
+  if (library !== 'vega' && library !== 'vega-lite') {
+    return {
+      ok: false,
+      error: `Unknown schema library "${library}". Must be "vega" or "vega-lite".`,
+    };
+  }
+
+  return {ok: true, library, version};
+}

--- a/packages/vega/src/schema.ts
+++ b/packages/vega/src/schema.ts
@@ -22,7 +22,7 @@ export type SchemaResult =
  *
  * @see https://github.com/vega/schema
  */
-const SCHEMA_RE = /schema\/([\w-]+)\/([\w.\-]+)\.json$/;
+const SCHEMA_RE = /schema\/([\w-]+)\/([\w.-]+)\.json$/;
 
 /**
  * Parse a Vega or Vega-Lite `$schema` URL.

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -1,34 +1,49 @@
 /**
  * @file types.ts
- * @input Vega-Lite spec types and XDS Vega wrapper API surface
+ * @input Vega and Vega-Lite spec types, and the XDS Vega wrapper API surface
  * @output Shared TypeScript types for @xds/vega
  * @position Type definitions; imported by all components in this package
  *
  * SYNC: When modified, update /packages/vega/README.md
  */
 
-import type {Config} from 'vega';
+import type {Spec as VegaSpec, Config, View} from 'vega';
+import type {TopLevelSpec as VegaLiteSpec} from 'vega-lite';
 
-/** A Vega-Lite top-level specification. Re-exported for consumer convenience. */
-export type {TopLevelSpec} from 'vega-lite';
+export type {VegaSpec, VegaLiteSpec, Config, View};
+
+/**
+ * A spec accepted by `<VegaChart>`. Must include a `$schema` field —
+ * the component uses it to decide whether to compile (Vega-Lite) or
+ * render directly (Vega).
+ */
+export type AnySpec = (VegaSpec | VegaLiteSpec) & {$schema: string};
 
 /**
  * Props for the `<VegaChart>` component.
  */
 export interface VegaChartProps {
   /**
-   * A Vega-Lite specification object.
+   * A Vega or Vega-Lite specification object.
+   *
+   * Must include a `$schema` field matching the official Vega schema URL
+   * format: `https://vega.github.io/schema/{vega|vega-lite}/{version}.json`
+   *
+   * The component inspects `$schema` to determine how to handle the spec:
+   * - `vega-lite` → compiled to Vega via `vega-lite`'s `compile()`, then rendered
+   * - `vega` → rendered directly without compilation
+   *
+   * @see https://vega.github.io/vega/docs/specification/
    * @see https://vega.github.io/vega-lite/docs/spec.html
    */
-  spec: import('vega-lite').TopLevelSpec;
+  spec: AnySpec;
   /**
-   * Optional Vega runtime config passed to `new View(runtime, { config })`.
-   * Use this to override renderer defaults, logging, or signal bindings.
-   * @see https://vega.github.io/vega/docs/api/view/
+   * Optional Vega runtime config passed when constructing the `View`.
+   * @see https://vega.github.io/vega/docs/config/
    */
   viewConfig?: Config;
   /**
-   * Renderer to use. Defaults to `'svg'`.
+   * Renderer backend. Defaults to `'svg'`.
    */
   renderer?: 'svg' | 'canvas';
   /**
@@ -40,11 +55,13 @@ export interface VegaChartProps {
    */
   style?: React.CSSProperties;
   /**
-   * Called when the Vega View has been fully initialized and rendered.
+   * Called with the live Vega `View` once the chart has rendered.
+   * Use this to attach signal listeners, stream data, or drive animations.
    */
-  onReady?: (view: import('vega').View) => void;
+  onReady?: (view: View) => void;
   /**
-   * Called when an error occurs during compilation or rendering.
+   * Called when the `$schema` is invalid, compilation fails, or the
+   * Vega runtime throws during rendering.
    */
   onError?: (error: Error) => void;
 }

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -8,9 +8,42 @@
  */
 
 import type {Spec as VegaSpec, Config, View, ViewOptions} from 'vega';
-import type {TopLevelSpec as VegaLiteSpec} from 'vega-lite';
+import type {TopLevelSpec as VegaLiteSpec, Config as VegaLiteConfig} from 'vega-lite';
 
 export type {VegaSpec, VegaLiteSpec, Config, View, ViewOptions};
+
+/**
+ * Options for the Vega-Lite `compile()` function.
+ *
+ * Mirrors `CompileOptions` from `vega-lite/src/compile/compile.ts`, which is
+ * not part of the public vega-lite export surface, so we redeclare it here.
+ *
+ * @see https://github.com/vega/vega-lite/blob/main/src/compile/compile.ts
+ */
+export interface CompileOptions {
+  /**
+   * Vega-Lite config merged on top of the spec's own config before compilation.
+   */
+  config?: VegaLiteConfig;
+  /**
+   * Custom logger used during compilation.
+   * Accepts any object matching the `LoggerInterface` shape from `vega-util`.
+   */
+  logger?: {
+    level: (lvl?: number) => number | void;
+    warn: (...args: unknown[]) => void;
+    info: (...args: unknown[]) => void;
+    debug: (...args: unknown[]) => void;
+    error: (...args: unknown[]) => Error | void;
+  };
+  /**
+   * Custom field title formatter. Overrides the global singleton used by
+   * vega-lite to produce axis/legend/header titles from field definitions.
+   *
+   * Signature: `(fieldDef: FieldDefBase<string>, config: Config) => string`
+   */
+  fieldTitle?: (fieldDef: Record<string, unknown>, config: VegaLiteConfig) => string;
+}
 
 /**
  * A spec accepted by `<VegaChart>`. Must include a `$schema` field --
@@ -50,6 +83,13 @@ export interface VegaChartProps {
    * @see https://vega.github.io/vega-lite/docs/spec.html
    */
   spec: AnySpec;
+  /**
+   * Options passed to `vega-lite`'s `compile()` function.
+   * Only applied when `spec.$schema` identifies a `vega-lite` spec.
+   * Ignored for native Vega specs.
+   * @see https://github.com/vega/vega-lite/blob/main/src/compile/compile.ts
+   */
+  compileOptions?: CompileOptions;
   /**
    * Vega config object passed as the second argument to `vega.parse()`.
    * Overrides config values embedded in the spec.

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -7,17 +7,30 @@
  * SYNC: When modified, update /packages/vega/README.md
  */
 
-import type {Spec as VegaSpec, Config, View} from 'vega';
+import type {Spec as VegaSpec, Config, View, ViewOptions} from 'vega';
 import type {TopLevelSpec as VegaLiteSpec} from 'vega-lite';
 
-export type {VegaSpec, VegaLiteSpec, Config, View};
+export type {VegaSpec, VegaLiteSpec, Config, View, ViewOptions};
 
 /**
- * A spec accepted by `<VegaChart>`. Must include a `$schema` field —
+ * A spec accepted by `<VegaChart>`. Must include a `$schema` field --
  * the component uses it to decide whether to compile (Vega-Lite) or
  * render directly (Vega).
  */
 export type AnySpec = (VegaSpec | VegaLiteSpec) & {$schema: string};
+
+/**
+ * Options forwarded to `vega.parse(spec, config, parseOptions)`.
+ * @see https://vega.github.io/vega/docs/api/view/#view_parse
+ */
+export interface ParseOptions {
+  /**
+   * When `true`, the parser retains the abstract syntax tree (AST) of
+   * Vega expressions in the runtime. Useful for introspection and tooling.
+   * Defaults to `false`.
+   */
+  ast?: boolean;
+}
 
 /**
  * Props for the `<VegaChart>` component.
@@ -30,22 +43,35 @@ export interface VegaChartProps {
    * format: `https://vega.github.io/schema/{vega|vega-lite}/{version}.json`
    *
    * The component inspects `$schema` to determine how to handle the spec:
-   * - `vega-lite` → compiled to Vega via `vega-lite`'s `compile()`, then rendered
-   * - `vega` → rendered directly without compilation
+   * - `vega-lite` -> compiled to Vega via `vega-lite`'s `compile()`, then rendered
+   * - `vega` -> rendered directly without compilation
    *
    * @see https://vega.github.io/vega/docs/specification/
    * @see https://vega.github.io/vega-lite/docs/spec.html
    */
   spec: AnySpec;
   /**
-   * Optional Vega runtime config passed when constructing the `View`.
+   * Vega config object passed as the second argument to `vega.parse()`.
+   * Overrides config values embedded in the spec.
    * @see https://vega.github.io/vega/docs/config/
    */
-  viewConfig?: Config;
+  parseConfig?: Config;
   /**
-   * Renderer backend. Defaults to `'svg'`.
+   * Options passed as the third argument to `vega.parse()`.
+   * Currently only supports `{ ast: boolean }`.
+   * @see https://vega.github.io/vega/docs/api/view/#view_parse
    */
-  renderer?: 'svg' | 'canvas';
+  parseOptions?: ParseOptions;
+  /**
+   * Options passed directly to `new vega.View(runtime, viewOptions)`.
+   * Controls renderer backend, logger, tooltip handler, locale, loader,
+   * background color, hover behavior, and more.
+   *
+   * Note: `container` is always set by the component and will be overridden.
+   *
+   * @see https://vega.github.io/vega/docs/api/view/
+   */
+  viewOptions?: Omit<ViewOptions, 'container'>;
   /**
    * Additional CSS class name applied to the container element.
    */

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -8,9 +8,10 @@
  */
 
 import type {Spec as VegaSpec, Config, View, ViewOptions} from 'vega';
+import type {LoggerInterface} from 'vega-util';
 import type {TopLevelSpec as VegaLiteSpec, Config as VegaLiteConfig} from 'vega-lite';
 
-export type {VegaSpec, VegaLiteSpec, Config, View, ViewOptions};
+export type {VegaSpec, VegaLiteSpec, Config, View, ViewOptions, LoggerInterface};
 
 /**
  * Options for the Vega-Lite `compile()` function.
@@ -27,15 +28,9 @@ export interface CompileOptions {
   config?: VegaLiteConfig;
   /**
    * Custom logger used during compilation.
-   * Accepts any object matching the `LoggerInterface` shape from `vega-util`.
+   * @see https://github.com/vega/vega/blob/main/packages/vega-util/src/logger.ts
    */
-  logger?: {
-    level: (lvl?: number) => number | void;
-    warn: (...args: unknown[]) => void;
-    info: (...args: unknown[]) => void;
-    debug: (...args: unknown[]) => void;
-    error: (...args: unknown[]) => Error | void;
-  };
+  logger?: LoggerInterface;
   /**
    * Custom field title formatter. Overrides the global singleton used by
    * vega-lite to produce axis/legend/header titles from field definitions.
@@ -66,6 +61,27 @@ export interface ParseOptions {
 }
 
 /**
+ * Initial data to load into named Vega datasets after the View is created,
+ * before the first render.
+ *
+ * Each key is a dataset name matching a `data` entry in the Vega spec.
+ * Each value is the array of tuples passed to `view.data(name, tuples)`.
+ *
+ * This mirrors the setter overload of the View data API:
+ *   `view.data(name: string, tuples: any[]): this`
+ *
+ * @see https://vega.github.io/vega/docs/api/view/#view_data
+ *
+ * @example
+ * ```
+ * data={{
+ *   table: [{category: 'A', value: 28}, {category: 'B', value: 55}],
+ * }}
+ * ```
+ */
+export type ViewData = Record<string, any[]>;
+
+/**
  * Props for the `<VegaChart>` component.
  */
 export interface VegaChartProps {
@@ -83,6 +99,18 @@ export interface VegaChartProps {
    * @see https://vega.github.io/vega-lite/docs/spec.html
    */
   spec: AnySpec;
+  /**
+   * Initial data for named Vega datasets, applied via `view.data(name, tuples)`
+   * after the View is created and before the first render.
+   *
+   * Changing this prop re-loads the data and re-runs the view without
+   * re-creating it (no full re-embed).
+   *
+   * Each key must match a dataset name defined in the spec's `data` array.
+   *
+   * @see https://vega.github.io/vega/docs/api/view/#view_data
+   */
+  data?: ViewData;
   /**
    * Options passed to `vega-lite`'s `compile()` function.
    * Only applied when `spec.$schema` identifies a `vega-lite` spec.

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -1,0 +1,46 @@
+/**
+ * @file types.ts
+ * @input Vega-Lite spec types and XDS Vega wrapper API surface
+ * @output Shared TypeScript types for @xds/vega
+ * @position Type definitions; imported by all components in this package
+ *
+ * SYNC: When modified, update /packages/vega/README.md
+ */
+
+import type {TopLevelSpec} from 'vega-lite';
+import type {EmbedOptions} from 'vega-embed';
+
+/** A Vega-Lite top-level specification. Re-exported for consumer convenience. */
+export type {TopLevelSpec} from 'vega-lite';
+
+/**
+ * Props for the `<VegaChart>` component.
+ */
+export interface VegaChartProps {
+  /**
+   * A Vega-Lite specification object.
+   * @see https://vega.github.io/vega-lite/docs/spec.html
+   */
+  spec: TopLevelSpec;
+  /**
+   * Optional vega-embed options (renderer, actions menu, tooltip, etc.).
+   * @see https://github.com/vega/vega-embed#options
+   */
+  options?: EmbedOptions;
+  /**
+   * Additional CSS class name applied to the container element.
+   */
+  className?: string;
+  /**
+   * Inline styles applied to the container element.
+   */
+  style?: React.CSSProperties;
+  /**
+   * Called when the Vega view has been fully initialized.
+   */
+  onReady?: () => void;
+  /**
+   * Called when an error occurs during rendering.
+   */
+  onError?: (error: Error) => void;
+}

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -7,8 +7,7 @@
  * SYNC: When modified, update /packages/vega/README.md
  */
 
-import type {TopLevelSpec} from 'vega-lite';
-import type {EmbedOptions} from 'vega-embed';
+import type {Config} from 'vega';
 
 /** A Vega-Lite top-level specification. Re-exported for consumer convenience. */
 export type {TopLevelSpec} from 'vega-lite';
@@ -21,12 +20,17 @@ export interface VegaChartProps {
    * A Vega-Lite specification object.
    * @see https://vega.github.io/vega-lite/docs/spec.html
    */
-  spec: TopLevelSpec;
+  spec: import('vega-lite').TopLevelSpec;
   /**
-   * Optional vega-embed options (renderer, actions menu, tooltip, etc.).
-   * @see https://github.com/vega/vega-embed#options
+   * Optional Vega runtime config passed to `new View(runtime, { config })`.
+   * Use this to override renderer defaults, logging, or signal bindings.
+   * @see https://vega.github.io/vega/docs/api/view/
    */
-  options?: EmbedOptions;
+  viewConfig?: Config;
+  /**
+   * Renderer to use. Defaults to `'svg'`.
+   */
+  renderer?: 'svg' | 'canvas';
   /**
    * Additional CSS class name applied to the container element.
    */
@@ -36,11 +40,11 @@ export interface VegaChartProps {
    */
   style?: React.CSSProperties;
   /**
-   * Called when the Vega view has been fully initialized.
+   * Called when the Vega View has been fully initialized and rendered.
    */
-  onReady?: () => void;
+  onReady?: (view: import('vega').View) => void;
   /**
-   * Called when an error occurs during rendering.
+   * Called when an error occurs during compilation or rendering.
    */
   onError?: (error: Error) => void;
 }

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -96,7 +96,11 @@ export type ViewData = Record<string, unknown[]>;
  */
 export interface XDSVegaChartProps extends Omit<
   React.HTMLAttributes<HTMLDivElement>,
-  'contentEditable' | 'dangerouslySetInnerHTML' | 'suppressContentEditableWarning' | 'suppressHydrationWarning'
+  | 'contentEditable'
+  | 'dangerouslySetInnerHTML'
+  | 'suppressContentEditableWarning'
+  | 'suppressHydrationWarning'
+  | 'onError'
 > {
   /**
    * Ref forwarded to the root container div.

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -106,8 +106,10 @@ export interface VegaChartProps {
    * Initial data for named Vega datasets, applied via `view.data(name, tuples)`
    * after the View is created and before the first render.
    *
-   * Changing this prop re-loads the data and re-runs the view without
-   * re-creating it (no full re-embed).
+   * This prop is *not reactive* — it is only read during View initialization.
+   * Changes after mount are ignored. To update data dynamically, use `onReady`
+   * to access the live View and call `view.data(name, tuples)` + `view.runAsync()`
+   * directly.
    *
    * Each key must match a dataset name defined in the spec's `data` array.
    *

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -11,7 +11,6 @@ import type React from 'react';
 import type {Spec as VegaSpec, Config, View, ViewOptions} from 'vega';
 import type {LoggerInterface} from 'vega-util';
 import type {TopLevelSpec as VegaLiteSpec, Config as VegaLiteConfig} from 'vega-lite';
-import type {XDSBaseProps} from '@xds/core/XDSBaseProps';
 
 export type {VegaSpec, VegaLiteSpec, Config, View, ViewOptions, LoggerInterface};
 
@@ -39,8 +38,8 @@ export interface CompileOptions {
    *
    * Typed loosely to avoid coupling to vega-lite's unexported internal types.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fieldTitle?: (...args: any[]) => string;
+  // Typed loosely to avoid coupling to vega-lite's unexported internal types.
+  fieldTitle?: (...args: unknown[]) => string;
 }
 
 /**
@@ -82,19 +81,23 @@ export interface ParseOptions {
  * }}
  * ```
  */
-export type ViewData = Record<string, any[]>;
+export type ViewData = Record<string, unknown[]>;
 
 /**
  * Props for the `<XDSVegaChart>` component.
  *
- * Extends `XDSBaseProps<HTMLDivElement>` for full DOM event passthrough
- * (drag, pointer, keyboard, clipboard, etc.) and `data-testid` support.
+ * Extends `React.HTMLAttributes<HTMLDivElement>` (minus `contentEditable`,
+ * `dangerouslySetInnerHTML`) for full DOM event passthrough — drag, pointer,
+ * keyboard, clipboard, `data-testid`, etc.
  *
- * Note: `xstyle` is inherited from `XDSBaseProps` but has no effect —
- * `@xds/vega` does not depend on StyleX. Use `className` or `style` for
- * layout overrides instead.
+ * Note: unlike other XDS components, this component does not accept `xstyle`
+ * because `@xds/vega` does not depend on StyleX. Use `className` or `style`
+ * for layout overrides instead.
  */
-export interface XDSVegaChartProps extends XDSBaseProps<HTMLDivElement> {
+export interface XDSVegaChartProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  'contentEditable' | 'dangerouslySetInnerHTML' | 'suppressContentEditableWarning' | 'suppressHydrationWarning'
+> {
   /**
    * Ref forwarded to the root container div.
    */

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -7,9 +7,11 @@
  * SYNC: When modified, update /packages/vega/README.md
  */
 
+import type React from 'react';
 import type {Spec as VegaSpec, Config, View, ViewOptions} from 'vega';
 import type {LoggerInterface} from 'vega-util';
 import type {TopLevelSpec as VegaLiteSpec, Config as VegaLiteConfig} from 'vega-lite';
+import type {XDSBaseProps} from '@xds/core/XDSBaseProps';
 
 export type {VegaSpec, VegaLiteSpec, Config, View, ViewOptions, LoggerInterface};
 
@@ -35,8 +37,6 @@ export interface CompileOptions {
    * Custom field title formatter. Overrides the global singleton used by
    * vega-lite to produce axis/legend/header titles from field definitions.
    *
-   * Signature: `(fieldDef: FieldDefBase<string>, config: Config) => string`
-   *
    * Typed loosely to avoid coupling to vega-lite's unexported internal types.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -44,7 +44,7 @@ export interface CompileOptions {
 }
 
 /**
- * A spec accepted by `<VegaChart>`. Must include a `$schema` field --
+ * A spec accepted by `<XDSVegaChart>`. Must include a `$schema` field --
  * the component uses it to decide whether to compile (Vega-Lite) or
  * render directly (Vega).
  */
@@ -85,9 +85,20 @@ export interface ParseOptions {
 export type ViewData = Record<string, any[]>;
 
 /**
- * Props for the `<VegaChart>` component.
+ * Props for the `<XDSVegaChart>` component.
+ *
+ * Extends `XDSBaseProps<HTMLDivElement>` for full DOM event passthrough
+ * (drag, pointer, keyboard, clipboard, etc.) and `data-testid` support.
+ *
+ * Note: `xstyle` is inherited from `XDSBaseProps` but has no effect —
+ * `@xds/vega` does not depend on StyleX. Use `className` or `style` for
+ * layout overrides instead.
  */
-export interface VegaChartProps {
+export interface XDSVegaChartProps extends XDSBaseProps<HTMLDivElement> {
+  /**
+   * Ref forwarded to the root container div.
+   */
+  ref?: React.Ref<HTMLDivElement>;
   /**
    * A Vega or Vega-Lite specification object.
    *
@@ -145,14 +156,6 @@ export interface VegaChartProps {
    * @see https://vega.github.io/vega/docs/api/view/
    */
   viewOptions?: Omit<ViewOptions, 'container'>;
-  /**
-   * Additional CSS class name applied to the container element.
-   */
-  className?: string;
-  /**
-   * Inline styles applied to the container element.
-   */
-  style?: React.CSSProperties;
   /**
    * Called with the live Vega `View` once the chart has rendered.
    * Use this to attach signal listeners, stream data, or drive animations.

--- a/packages/vega/src/types.ts
+++ b/packages/vega/src/types.ts
@@ -36,8 +36,11 @@ export interface CompileOptions {
    * vega-lite to produce axis/legend/header titles from field definitions.
    *
    * Signature: `(fieldDef: FieldDefBase<string>, config: Config) => string`
+   *
+   * Typed loosely to avoid coupling to vega-lite's unexported internal types.
    */
-  fieldTitle?: (fieldDef: Record<string, unknown>, config: VegaLiteConfig) => string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  fieldTitle?: (...args: any[]) => string;
 }
 
 /**

--- a/packages/vega/tsconfig.json
+++ b/packages/vega/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/packages/vega/tsup.config.ts
+++ b/packages/vega/tsup.config.ts
@@ -1,0 +1,19 @@
+/**
+ * @file tsup.config.ts
+ * @input Uses tsup
+ * @output Bundle configuration for CJS/ESM outputs with TypeScript declarations
+ * @position Build config; defines entry points and output formats for @xds/vega
+ *
+ * SYNC: When modified, update this header and /packages/vega/README.md
+ */
+
+import {defineConfig} from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  dts: true,
+  splitting: true,
+  clean: true,
+  external: ['react', 'react-dom', 'vega-lite', 'vega-embed'],
+});

--- a/packages/vega/tsup.config.ts
+++ b/packages/vega/tsup.config.ts
@@ -15,5 +15,5 @@ export default defineConfig({
   dts: true,
   splitting: true,
   clean: true,
-  external: ['react', 'react-dom', 'vega-lite', 'vega-embed'],
+  external: ['react', 'react-dom', 'vega', 'vega-lite'],
 });


### PR DESCRIPTION
## Summary

Adds a new `packages/vega` workspace package (`@xds/vega`) — a React component that compiles Vega-Lite specs and renders them via the *Vega runtime directly* (no `vega-embed` intermediary), giving consumers full access to the live `View` object.

## What's included

### `packages/vega/`
- `src/VegaChart.tsx` — Compiles Vega-Lite → Vega via `compile()` + `parse()`, creates a `View`, calls `view.runAsync()`, and finalizes on cleanup
- `src/types.ts` — `VegaChartProps` interface + re-exported `TopLevelSpec` from `vega-lite`
- `src/index.ts` — Barrel export
- `tsup.config.ts` — CJS + ESM + `.d.ts` build; externalises React, vega, vega-lite
- `tsconfig.json` — Extends root config, scoped to `src/`
- `README.md` — Fractal docs with file manifest, install, usage, and API table

### Cross-cutting changes
- `packages/README.md` — Added `vega/` row
- Root `package.json` build script — includes `@xds/vega`

## Usage

```tsx
import {VegaChart} from '@xds/vega';

<VegaChart
  spec={{
    mark: 'bar',
    data: {values: [{a: 'A', b: 28}, {a: 'B', b: 55}]},
    encoding: {
      x: {field: 'a', type: 'ordinal'},
      y: {field: 'b', type: 'quantitative'},
    },
  }}
  onReady={view => {
    // Full access to the live Vega View — signals, data streaming, event listeners
    view.addSignalListener('highlight', (name, value) => console.log(name, value));
  }}
/>
```

## API

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| `spec` | `TopLevelSpec` | — | Vega-Lite specification (required) |
| `viewConfig` | `Config` | — | Vega runtime config |
| `renderer` | `'svg' \| 'canvas'` | `'svg'` | Rendering backend |
| `className` | `string` | — | CSS class on the container div |
| `style` | `CSSProperties` | — | Inline styles on the container div |
| `onReady` | `(view: View) => void` | — | Called with the live Vega View when ready |
| `onError` | `(err: Error) => void` | — | Called on compile or render failure |

## Implementation notes

- `onReady`/`onError` are stored in refs — no need to memoize them
- `spec`, `renderer`, `viewConfig` are dep-array members — changing them re-creates the View
- Cleanup calls `view.finalize()` to release Vega runtime resources (timers, event listeners, WebGL)
- Race condition handled: if cleanup fires before `runAsync()` resolves, the View is finalized immediately in the `.then()`