### PR TITLE
fix(sandbox): add settings-03 dialog template to sandbox registry

### DIFF
--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -115,6 +115,11 @@ export const categories: SandboxCategory[] = [
           'Account settings with sidebar nav, info rows, and device history',
       },
       {
+        name: 'Settings (Dialog)',
+        href: '/pages/template-settings-03/',
+        description: 'Airbnb-style account settings in a dialog',
+      },
+      {
         name: 'Data Table (WIP)',
         href: '/pages/template-data-table/',
         description:
@@ -140,8 +145,7 @@ export const categories: SandboxCategory[] = [
       {
         name: 'Editor',
         href: '/pages/editor/',
-        description:
-          'Page builder with config panel and live preview',
+        description: 'Page builder with config panel and live preview',
       },
     ],
   },


### PR DESCRIPTION
Adds the Settings (Dialog) template to sandboxPages.ts so it shows up in the sandbox navigation. The page file was already merged in #1090 but the registry entry was missed.