### PR TITLE
feat(animation): direction-aware entry animations + motion preview

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/theme-editor/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/theme-editor/page.tsx
@@ -1772,8 +1772,6 @@ function MotionPreview() {
         style={{height: '100%'}}
         variant="section"
         contentPadding={0}
-        isSideNavCollapsed={sidebarCollapsed}
-        onSideNavCollapsedChange={setSidebarCollapsed}
         sideNav={
           <XDSSideNav
             collapsible={{
@@ -1939,7 +1937,7 @@ function MotionPreview() {
                   label="Close"
                   icon={<XMarkIcon style={{width: 16, height: 16}} />}
                   variant="ghost"
-                  size="small"
+                  size="sm"
                   onClick={() => setOverlayOpen(false)}
                 />
               </div>
@@ -1975,7 +1973,7 @@ function MotionPreview() {
                   label="Close"
                   icon={<XMarkIcon style={{width: 16, height: 16}} />}
                   variant="ghost"
-                  size="small"
+                  size="sm"
                   onClick={() => setPushOpen(false)}
                 />
               </div>
@@ -2015,7 +2013,7 @@ function MotionPreview() {
         onOpenChange={setModalOpen}
         triggerRef={modalTriggerRef}>
         <div style={{padding: 'var(--spacing-3)', flex: 1}}>
-          <XDSText color="secondary">
+          <XDSText type="body" color="secondary">
             This modal uses XDSDialog with directional entry animation from the
             trigger element.
           </XDSText>
@@ -2146,7 +2144,7 @@ function NavigationOverlaysPreview({
         onOpenChange={setModalOpen}
         triggerRef={modalTriggerRef}>
         <div style={{padding: 'var(--spacing-3)'}}>
-          <XDSText color="secondary">
+          <XDSText type="body" color="secondary">
             This modal uses the XDSDialog component with directional entry
             animation from the trigger element. Try adjusting the duration and
             easing tokens.
@@ -3359,7 +3357,7 @@ function ThemeEditorComponent() {
                     label="Close"
                     icon={<XMarkIcon style={{width: 16, height: 16}} />}
                     variant="ghost"
-                    size="small"
+                    size="sm"
                     onClick={() => setOverlayPanelOpen(false)}
                   />
                 </div>
@@ -3400,7 +3398,7 @@ function ThemeEditorComponent() {
                     label="Close"
                     icon={<XMarkIcon style={{width: 16, height: 16}} />}
                     variant="ghost"
-                    size="small"
+                    size="sm"
                     onClick={() => setPushPanelOpen(false)}
                   />
                 </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/theme-editor/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/theme-editor/page.tsx
@@ -5,7 +5,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSBadge} from '@xds/core/Badge';
 import {XDSCard} from '@xds/core/Card';
-import {XDSStack} from '@xds/core/Stack';
+import {XDSHStack, XDSVStack, XDSStack} from '@xds/core/Stack';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSSwitch} from '@xds/core/Switch';
 import {XDSAvatar} from '@xds/core/Avatar';
@@ -19,9 +19,28 @@ import {XDSNumberInput} from '@xds/core/NumberInput';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {XDSCheckboxInput} from '@xds/core/CheckboxInput';
 import {XDSRadioList, XDSRadioListItem} from '@xds/core/RadioList';
-import {XDSTable} from '@xds/core/Table';
+import {XDSTable, proportional, pixel} from '@xds/core/Table';
 import type {XDSTableColumn} from '@xds/core/Table';
 import {XDSDivider} from '@xds/core/Divider';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {XDSPopover} from '@xds/core/Popover';
+import {XDSHoverCard} from '@xds/core/HoverCard';
+import {XDSTooltip} from '@xds/core/Tooltip';
+import {XDSSpinner} from '@xds/core/Spinner';
+import {XDSSkeleton} from '@xds/core/Skeleton';
+import {XDSStatusDot} from '@xds/core/StatusDot';
+import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSSideNav,
+  XDSSideNavItem,
+  XDSSideNavSection,
+  XDSSideNavCollapseButton,
+  XDSSideNavHeading,
+} from '@xds/core/SideNav';
+import {XDSNavIcon} from '@xds/core/NavIcon';
+import {XDSPowerSearch, usePowerSearchConfig} from '@xds/core/PowerSearch';
+import type {PowerSearchFilter} from '@xds/core/PowerSearch';
 import {XDSTheme, defineTheme, expandTypeScale} from '@xds/core/theme';
 import {
   colorDefaults,
@@ -38,6 +57,19 @@ import {
   transitionDefaults,
 } from '@xds/core/theme';
 import {defaultIconRegistry} from '@xds/theme-default';
+import {
+  HomeIcon,
+  FolderIcon,
+  CubeIcon,
+  XMarkIcon,
+  ChartBarIcon,
+  UserGroupIcon,
+  DocumentTextIcon,
+} from '@heroicons/react/24/outline';
+import {
+  HomeIcon as HomeIconSolid,
+  FolderIcon as FolderIconSolid,
+} from '@heroicons/react/24/solid';
 
 // =============================================================================
 // Token Groups for the Editor
@@ -1561,25 +1593,930 @@ function DashboardPreview() {
 }
 
 // =============================================================================
-// Preview Tabs (wraps all three preview modes)
+// Preview Tabs (wraps all preview modes)
 // =============================================================================
 
-function PreviewTabs() {
+function PreviewTabs({
+  isMotionGroup,
+  pushOpen,
+  setPushOpen,
+  overlayOpen,
+  setOverlayOpen,
+}: {
+  isMotionGroup: boolean;
+  pushOpen: boolean;
+  setPushOpen: (v: boolean) => void;
+  overlayOpen: boolean;
+  setOverlayOpen: (v: boolean) => void;
+}) {
   const [activePreview, setActivePreview] = React.useState('preview');
+
+  React.useEffect(() => {
+    if (!isMotionGroup && activePreview === 'table') {
+      setActivePreview('preview');
+    }
+    if (
+      isMotionGroup &&
+      (activePreview === 'landing' || activePreview === 'dashboard')
+    ) {
+      setActivePreview('preview');
+    }
+  }, [isMotionGroup, activePreview]);
 
   return (
     <div>
       <XDSTabList value={activePreview} onChange={setActivePreview}>
         <XDSTab value="preview" label="Preview" />
-        <XDSTab value="landing" label="Landing Page" />
-        <XDSTab value="dashboard" label="Dashboard" />
+        {!isMotionGroup && <XDSTab value="landing" label="Landing Page" />}
+        {!isMotionGroup && <XDSTab value="dashboard" label="Dashboard" />}
+        {isMotionGroup && <XDSTab value="table" label="Table Page" />}
       </XDSTabList>
       <div style={{marginTop: '24px'}}>
-        {activePreview === 'preview' && <ComponentPreview />}
+        {activePreview === 'preview' &&
+          (isMotionGroup ? (
+            <XDSVStack gap={4}>
+              <NavigationOverlaysPreview
+                pushOpen={pushOpen}
+                setPushOpen={setPushOpen}
+                overlayOpen={overlayOpen}
+                setOverlayOpen={setOverlayOpen}
+              />
+              <MicroInteractionsPreview />
+              <LoadingStatusPreview />
+              <SurfaceInteractionsPreview />
+            </XDSVStack>
+          ) : (
+            <ComponentPreview />
+          ))}
         {activePreview === 'landing' && <LandingPagePreview />}
         {activePreview === 'dashboard' && <DashboardPreview />}
+        {activePreview === 'table' && <MotionPreview />}
       </div>
     </div>
+  );
+}
+
+// =============================================================================
+// Motion Preview (Table Page)
+// =============================================================================
+
+function MotionPreview() {
+  const [sidebarCollapsed, setSidebarCollapsed] = React.useState(false);
+  const [overlayOpen, setOverlayOpen] = React.useState(false);
+  const [pushOpen, setPushOpen] = React.useState(false);
+  const [selectedUser, setSelectedUser] = React.useState<
+    (typeof allUsers)[0] | null
+  >(null);
+  const [modalOpen, setModalOpen] = React.useState(false);
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const modalTriggerRef = React.useRef<HTMLButtonElement>(null);
+  const [containerWidth, setContainerWidth] = React.useState(1200);
+
+  React.useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        setContainerWidth(entry.contentRect.width);
+      }
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  const [filters, setFilters] = React.useState<PowerSearchFilter[]>([]);
+
+  const fieldDefs = [
+    {key: 'name', type: 'string', label: 'Name'},
+    {key: 'email', type: 'string', label: 'Email'},
+    {
+      key: 'role',
+      type: 'enum',
+      label: 'Role',
+      enumValues: [
+        {value: 'engineer', label: 'Engineer'},
+        {value: 'designer', label: 'Designer'},
+        {value: 'pm', label: 'PM'},
+      ],
+    },
+  ] as const;
+
+  const {config, applyFilters} = usePowerSearchConfig(fieldDefs, 'Users');
+
+  const allUsers = [
+    {
+      id: '1',
+      name: 'Alice Johnson',
+      email: 'alice@example.com',
+      role: 'engineer',
+    },
+    {id: '2', name: 'Bob Smith', email: 'bob@example.com', role: 'designer'},
+    {id: '3', name: 'Charlie Brown', email: 'charlie@example.com', role: 'pm'},
+    {
+      id: '4',
+      name: 'Diana Prince',
+      email: 'diana@example.com',
+      role: 'engineer',
+    },
+    {id: '5', name: 'Eve Davis', email: 'eve@example.com', role: 'designer'},
+  ];
+
+  const filteredUsers = applyFilters(filters, allUsers);
+
+  const roleLabels: Record<string, string> = {
+    Engineer: 'Engineer',
+    Designer: 'Designer',
+    PM: 'PM',
+    engineer: 'Engineer',
+    designer: 'Designer',
+    pm: 'PM',
+  };
+
+  const tableColumns: XDSTableColumn<(typeof allUsers)[0]>[] = [
+    {key: 'name', header: 'Name', width: proportional(2)},
+    ...(containerWidth > 975
+      ? [{key: 'email' as const, header: 'Email', width: proportional(2)}]
+      : []),
+    {
+      key: 'role',
+      header: 'Role',
+      width: pixel(120),
+      renderCell: (user: (typeof allUsers)[0]) =>
+        roleLabels[user.role] ?? user.role,
+    },
+  ];
+
+  const dur = {
+    medMin: 'var(--duration-medium-min)',
+    med: 'var(--duration-medium)',
+  };
+  const ease = 'var(--ease-standard)';
+  const motionSlideIn = `${dur.med} ${ease}`;
+  const motionSlideOut = `${dur.medMin} ${ease}`;
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        border: '1px solid var(--color-border)',
+        borderRadius: '12px',
+        overflow: 'hidden',
+        height: '630px',
+        position: 'relative',
+        fontFamily: 'var(--font-family-body)',
+        fontSize: 'var(--font-size-base)',
+        lineHeight: 'var(--leading-base)',
+        color: 'var(--color-text-primary)',
+      }}>
+      <XDSAppShell
+        height="fill"
+        style={{height: '100%'}}
+        variant="section"
+        contentPadding={0}
+        isSideNavCollapsed={sidebarCollapsed}
+        onSideNavCollapsedChange={setSidebarCollapsed}
+        sideNav={
+          <XDSSideNav
+            collapsible={{
+              isCollapsed: sidebarCollapsed,
+              onCollapsedChange: setSidebarCollapsed,
+              hasButton: false,
+            }}
+            header={
+              <XDSSideNavHeading
+                icon={
+                  <XDSNavIcon
+                    icon={<CubeIcon style={{width: 16, height: 16}} />}
+                  />
+                }
+                heading="My App"
+                headingHref="/"
+              />
+            }
+            footerIcons={<XDSSideNavCollapseButton />}>
+            <XDSSideNavSection title="Main">
+              <XDSSideNavItem
+                label="Dashboard"
+                icon={HomeIcon}
+                selectedIcon={HomeIconSolid}
+                isSelected
+                onClick={() => {}}
+              />
+              <XDSSideNavItem
+                label="Projects"
+                icon={FolderIcon}
+                selectedIcon={FolderIconSolid}
+                onClick={() => {}}
+                endContent={<XDSBadge label="3" />}
+              />
+              <XDSSideNavItem
+                label="Analytics"
+                icon={ChartBarIcon}
+                onClick={() => {}}
+              />
+              <XDSSideNavItem
+                label="Team"
+                icon={UserGroupIcon}
+                onClick={() => {}}
+              />
+            </XDSSideNavSection>
+            <XDSSideNavSection title="Documents">
+              <XDSSideNavItem
+                label="All Documents"
+                icon={DocumentTextIcon}
+                onClick={() => {}}
+              />
+            </XDSSideNavSection>
+          </XDSSideNav>
+        }>
+        <div style={{display: 'flex', flexDirection: 'column', height: '100%'}}>
+          <div
+            style={{
+              padding: '12px var(--spacing-3)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '12px',
+              borderBottom: '1px solid var(--color-border)',
+            }}>
+            <XDSHeading level={2}>Users</XDSHeading>
+            <div style={{display: 'flex', alignItems: 'center', gap: '8px'}}>
+              <div style={{flex: 1}}>
+                <XDSPowerSearch
+                  config={config}
+                  filters={filters}
+                  onChange={newFilters => setFilters([...newFilters])}
+                  placeholder="Search..."
+                  label="Filter users"
+                  resultCount={filteredUsers.length}
+                />
+              </div>
+              <XDSHStack gap={1}>
+                <XDSButton
+                  ref={modalTriggerRef}
+                  label="Modal"
+                  variant="secondary"
+                  onClick={() => setModalOpen(true)}
+                />
+                <XDSButton
+                  label="Overlay"
+                  variant={overlayOpen ? 'primary' : 'secondary'}
+                  onClick={() => setOverlayOpen(!overlayOpen)}
+                />
+                <XDSButton
+                  label="Push"
+                  variant="secondary"
+                  onClick={() => setPushOpen(!pushOpen)}
+                />
+              </XDSHStack>
+            </div>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flex: 1,
+              overflow: 'hidden',
+              position: 'relative',
+            }}>
+            <div
+              style={{
+                flex: 1,
+                overflow: 'auto',
+                minWidth: 0,
+                cursor: 'pointer',
+              }}
+              onClick={e => {
+                const row = (e.target as HTMLElement).closest('tr');
+                if (
+                  !row ||
+                  !row.parentElement ||
+                  row.parentElement.tagName === 'THEAD'
+                )
+                  return;
+                const index = Array.from(row.parentElement.children).indexOf(
+                  row,
+                );
+                const user = filteredUsers[index];
+                if (user) {
+                  setSelectedUser(user);
+                  setPushOpen(true);
+                }
+              }}>
+              <XDSTable
+                data={filteredUsers}
+                columns={tableColumns}
+                hasHover
+                idKey="id"
+              />
+            </div>
+            <div
+              style={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                bottom: 0,
+                width: '40%',
+                maxWidth: '480px',
+                borderLeft: '1px solid var(--color-border)',
+                backgroundColor: 'var(--color-background-surface)',
+                transform: overlayOpen ? 'translateX(0)' : 'translateX(100%)',
+                opacity: overlayOpen ? 1 : 0,
+                transition: overlayOpen
+                  ? `transform ${motionSlideIn}, opacity ${motionSlideIn}`
+                  : `transform ${motionSlideOut}, opacity ${motionSlideOut}`,
+                display: 'flex',
+                flexDirection: 'column',
+                zIndex: 5,
+              }}>
+              <div
+                style={{
+                  padding: 'var(--spacing-2) var(--spacing-3)',
+                  borderBottom: '1px solid var(--color-border)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                }}>
+                <XDSText type="label">Details</XDSText>
+                <XDSButton
+                  label="Close"
+                  icon={<XMarkIcon style={{width: 16, height: 16}} />}
+                  variant="ghost"
+                  size="small"
+                  onClick={() => setOverlayOpen(false)}
+                />
+              </div>
+            </div>
+            <div
+              style={{
+                flexShrink: 0,
+                width: pushOpen ? '40%' : '0px',
+                maxWidth: pushOpen ? '480px' : '0px',
+                overflow: 'hidden',
+                borderLeft: pushOpen ? '1px solid var(--color-border)' : 'none',
+                backgroundColor: 'var(--color-background-surface)',
+                opacity: pushOpen ? 1 : 0,
+                transition: pushOpen
+                  ? `width ${motionSlideIn}, max-width ${motionSlideIn}, opacity ${motionSlideIn}`
+                  : `width ${motionSlideOut}, max-width ${motionSlideOut}, opacity ${motionSlideOut}`,
+                display: 'flex',
+                flexDirection: 'column',
+              }}>
+              <div
+                style={{
+                  padding: 'var(--spacing-2) var(--spacing-3)',
+                  borderBottom: '1px solid var(--color-border)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  whiteSpace: 'nowrap',
+                }}>
+                <XDSText type="label">
+                  {selectedUser?.name ?? 'Details'}
+                </XDSText>
+                <XDSButton
+                  label="Close"
+                  icon={<XMarkIcon style={{width: 16, height: 16}} />}
+                  variant="ghost"
+                  size="small"
+                  onClick={() => setPushOpen(false)}
+                />
+              </div>
+              {selectedUser && (
+                <div
+                  style={{padding: 'var(--spacing-3)', whiteSpace: 'nowrap'}}>
+                  <XDSVStack gap={2}>
+                    <div>
+                      <XDSText
+                        type="supporting"
+                        color="secondary"
+                        display="block">
+                        Email
+                      </XDSText>
+                      <XDSText type="body">{selectedUser.email}</XDSText>
+                    </div>
+                    <div>
+                      <XDSText
+                        type="supporting"
+                        color="secondary"
+                        display="block">
+                        Role
+                      </XDSText>
+                      <XDSText type="body">
+                        {roleLabels[selectedUser.role] ?? selectedUser.role}
+                      </XDSText>
+                    </div>
+                  </XDSVStack>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </XDSAppShell>
+      <XDSDialog
+        isOpen={modalOpen}
+        onOpenChange={setModalOpen}
+        triggerRef={modalTriggerRef}>
+        <div style={{padding: 'var(--spacing-3)', flex: 1}}>
+          <XDSText color="secondary">
+            This modal uses XDSDialog with directional entry animation from the
+            trigger element.
+          </XDSText>
+        </div>
+        <div
+          style={{
+            padding: 'var(--spacing-2) var(--spacing-3)',
+            borderTop: '1px solid var(--color-border)',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 'var(--spacing-2)',
+          }}>
+          <XDSButton
+            label="Cancel"
+            variant="secondary"
+            onClick={() => setModalOpen(false)}
+          />
+          <XDSButton
+            label="Confirm"
+            variant="primary"
+            onClick={() => setModalOpen(false)}
+          />
+        </div>
+      </XDSDialog>
+    </div>
+  );
+}
+
+// =============================================================================
+// Popover Settings Content
+// =============================================================================
+
+function PopoverSettingsContent() {
+  const [notifications, setNotifications] = React.useState(true);
+  const [darkMode, setDarkMode] = React.useState(false);
+  const [sounds, setSounds] = React.useState(true);
+
+  return (
+    <XDSVStack gap={3} style={{width: 240}}>
+      <XDSText type="label" display="block">
+        Settings
+      </XDSText>
+      <XDSDivider />
+      <XDSSwitch
+        label="Notifications"
+        description="Receive push notifications"
+        value={notifications}
+        onChange={setNotifications}
+      />
+      <XDSSwitch
+        label="Dark mode"
+        description="Use dark color theme"
+        value={darkMode}
+        onChange={setDarkMode}
+      />
+      <XDSSwitch
+        label="Sounds"
+        description="Play sounds for actions"
+        value={sounds}
+        onChange={setSounds}
+      />
+    </XDSVStack>
+  );
+}
+
+// =============================================================================
+// Navigation & Overlays Preview
+// =============================================================================
+
+function NavigationOverlaysPreview({
+  pushOpen,
+  setPushOpen,
+  overlayOpen,
+  setOverlayOpen,
+}: {
+  pushOpen: boolean;
+  setPushOpen: (v: boolean) => void;
+  overlayOpen: boolean;
+  setOverlayOpen: (v: boolean) => void;
+}) {
+  const [modalOpen, setModalOpen] = React.useState(false);
+  const modalTriggerRef = React.useRef<HTMLButtonElement>(null);
+
+  return (
+    <>
+      <XDSCard>
+        <XDSVStack gap={4}>
+          <XDSText type="label" display="block">
+            Navigation & Overlays
+          </XDSText>
+          <div>
+            <XDSText type="supporting" color="secondary" display="block">
+              Modal — directional entry from trigger · duration-medium-max
+            </XDSText>
+            <div style={{marginTop: 8}}>
+              <XDSButton
+                ref={modalTriggerRef}
+                label="Open Modal"
+                onClick={() => setModalOpen(true)}
+              />
+            </div>
+          </div>
+          <XDSDivider />
+          <div>
+            <XDSText type="supporting" color="secondary" display="block">
+              Panels — overlay (slide over content) vs push (resizes content) ·
+              duration-medium (enter) / duration-medium-min (exit)
+            </XDSText>
+            <div style={{marginTop: 8, display: 'flex', gap: 8}}>
+              <XDSButton
+                label="Overlay Panel"
+                variant={overlayOpen ? 'primary' : 'secondary'}
+                size="sm"
+                onClick={() => setOverlayOpen(!overlayOpen)}
+              />
+              <XDSButton
+                label="Push Panel"
+                variant={pushOpen ? 'primary' : 'secondary'}
+                size="sm"
+                onClick={() => setPushOpen(!pushOpen)}
+              />
+            </div>
+          </div>
+        </XDSVStack>
+      </XDSCard>
+      <XDSDialog
+        isOpen={modalOpen}
+        onOpenChange={setModalOpen}
+        triggerRef={modalTriggerRef}>
+        <div style={{padding: 'var(--spacing-3)'}}>
+          <XDSText color="secondary">
+            This modal uses the XDSDialog component with directional entry
+            animation from the trigger element. Try adjusting the duration and
+            easing tokens.
+          </XDSText>
+        </div>
+        <div
+          style={{
+            padding: 'var(--spacing-2) var(--spacing-3)',
+            borderTop: '1px solid var(--color-border)',
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: 'var(--spacing-2)',
+          }}>
+          <XDSButton
+            label="Cancel"
+            variant="secondary"
+            onClick={() => setModalOpen(false)}
+          />
+          <XDSButton
+            label="Confirm"
+            variant="primary"
+            onClick={() => setModalOpen(false)}
+          />
+        </div>
+      </XDSDialog>
+    </>
+  );
+}
+
+// =============================================================================
+// Micro-Interactions Preview
+// =============================================================================
+
+function MicroInteractionsPreview() {
+  const [switch1, setSwitch1] = React.useState(false);
+  const [switch2, setSwitch2] = React.useState(true);
+  const [switch3, setSwitch3] = React.useState(false);
+  const [check1, setCheck1] = React.useState(false);
+  const [check2, setCheck2] = React.useState(true);
+  const [check3, setCheck3] = React.useState(false);
+  const [sliderValue, setSliderValue] = React.useState(50);
+  const [selectorValue, setSelectorValue] = React.useState('Apple');
+  const [statusInputValue, setStatusInputValue] =
+    React.useState('ted@example.com');
+  const [showStatus, setShowStatus] = React.useState(false);
+
+  return (
+    <XDSCard>
+      <XDSVStack gap={4}>
+        <XDSText type="label" display="block">
+          Micro-Interactions
+        </XDSText>
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Buttons — hover, press, focus · duration-fast · Dropdown ·
+            duration-fast-max
+          </XDSText>
+          <XDSHStack gap={2} style={{marginTop: 8}}>
+            <XDSButton label="Primary" variant="primary" onClick={() => {}} />
+            <XDSButton
+              label="Secondary"
+              variant="secondary"
+              onClick={() => {}}
+            />
+            <XDSButton label="Ghost" variant="ghost" onClick={() => {}} />
+            <XDSButton
+              label="Destructive"
+              variant="destructive"
+              onClick={() => {}}
+            />
+            <XDSDropdownMenu
+              button={{label: 'Dropdown', variant: 'secondary'}}
+              items={[
+                {label: 'Edit', onClick: () => {}},
+                {label: 'Duplicate', onClick: () => {}},
+                {type: 'divider' as const},
+                {label: 'Delete', onClick: () => {}},
+              ]}
+            />
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Popover · duration-fast-max · HoverCard · duration-fast-max ·
+            Tooltip · duration-fast-max — fade + translateY/X + scale ·
+            direction-aware
+          </XDSText>
+          <XDSHStack
+            gap={2}
+            vAlign="center"
+            style={{marginTop: 8, flexWrap: 'wrap'}}>
+            <XDSPopover content={<PopoverSettingsContent />} placement="below">
+              <XDSButton label="Below" variant="secondary" size="sm" />
+            </XDSPopover>
+            <XDSPopover content={<PopoverSettingsContent />} placement="above">
+              <XDSButton label="Above" variant="secondary" size="sm" />
+            </XDSPopover>
+            <XDSPopover content={<PopoverSettingsContent />} placement="end">
+              <XDSButton label="End" variant="secondary" size="sm" />
+            </XDSPopover>
+            <XDSPopover content={<PopoverSettingsContent />} placement="start">
+              <XDSButton label="Start" variant="secondary" size="sm" />
+            </XDSPopover>
+            <XDSHoverCard
+              content={
+                <div style={{padding: 12, maxWidth: 240}}>
+                  <XDSText
+                    type="label"
+                    display="block"
+                    style={{marginBottom: 4}}>
+                    HoverCard
+                  </XDSText>
+                  <XDSText type="supporting" color="secondary">
+                    Uses duration-fast-max. Hover to trigger.
+                  </XDSText>
+                </div>
+              }
+              placement="below">
+              <XDSButton
+                label="HoverCard"
+                variant="secondary"
+                size="sm"
+                onClick={() => {}}
+              />
+            </XDSHoverCard>
+            <XDSTooltip content="Tooltip — uses duration-fast-max">
+              <XDSButton
+                label="Tooltip"
+                variant="secondary"
+                size="sm"
+                onClick={() => {}}
+              />
+            </XDSTooltip>
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Switches — thumb slide, track color · duration-fast
+          </XDSText>
+          <XDSHStack gap={4} style={{marginTop: 8}}>
+            <XDSSwitch label="Switch 1" value={switch1} onChange={setSwitch1} />
+            <XDSSwitch label="Switch 2" value={switch2} onChange={setSwitch2} />
+            <XDSSwitch label="Switch 3" value={switch3} onChange={setSwitch3} />
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Checkbox — check transitions · duration-fast
+          </XDSText>
+          <XDSHStack gap={6} style={{marginTop: 8}}>
+            <XDSCheckboxInput
+              label="Option A"
+              value={check1}
+              onChange={setCheck1}
+            />
+            <XDSCheckboxInput
+              label="Option B"
+              value={check2}
+              onChange={setCheck2}
+            />
+            <XDSCheckboxInput
+              label="Option C"
+              value={check3}
+              onChange={setCheck3}
+            />
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Slider — thumb: duration-fast · tooltip: duration-fast-min
+          </XDSText>
+          <div style={{marginTop: 8, maxWidth: 300}}>
+            <XDSSlider
+              label="Volume"
+              value={sliderValue}
+              onChange={setSliderValue}
+              min={0}
+              max={100}
+            />
+          </div>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Input validation — status transition · duration-fast-max
+          </XDSText>
+          <XDSHStack gap={3} vAlign="end" style={{marginTop: 8}}>
+            <div style={{flex: 1, maxWidth: 300}}>
+              <XDSTextInput
+                label="Email"
+                value={statusInputValue}
+                onChange={setStatusInputValue}
+                placeholder="Enter email..."
+                status={
+                  showStatus
+                    ? {type: 'success', message: 'Email verified'}
+                    : undefined
+                }
+              />
+            </div>
+            <XDSButton
+              label={showStatus ? 'Clear status' : 'Validate'}
+              variant={showStatus ? 'ghost' : 'secondary'}
+              onClick={() => setShowStatus(!showStatus)}
+            />
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Selector — open/close, chevron rotation · duration-fast-max
+          </XDSText>
+          <div style={{marginTop: 8, maxWidth: 200}}>
+            <XDSSelector
+              label="Fruit"
+              options={['Apple', 'Banana', 'Orange', 'Mango']}
+              value={selectorValue}
+              onChange={setSelectorValue}
+            />
+          </div>
+        </div>
+      </XDSVStack>
+    </XDSCard>
+  );
+}
+
+// =============================================================================
+// Loading & Status Preview
+// =============================================================================
+
+function LoadingStatusPreview() {
+  const [progressValue, setProgressValue] = React.useState(65);
+
+  return (
+    <XDSCard>
+      <XDSVStack gap={4}>
+        <XDSText type="label" display="block">
+          Loading & Status
+        </XDSText>
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Spinners — continuous rotation · duration-medium-max
+          </XDSText>
+          <XDSHStack gap={4} vAlign="center" style={{marginTop: 8}}>
+            <XDSSpinner size="sm" />
+            <XDSSpinner size="md" />
+            <XDSSpinner size="lg" />
+          </XDSHStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Skeletons — pulsing opacity with stagger · duration-medium-max
+          </XDSText>
+          <XDSVStack gap={2} style={{marginTop: 8}}>
+            <XDSHStack gap={3} vAlign="center">
+              <XDSSkeleton width={40} height={40} radius="rounded" index={0} />
+              <XDSVStack gap={1} style={{flex: 1}}>
+                <XDSSkeleton width={160} height={14} index={1} />
+                <XDSSkeleton width={100} height={10} index={2} />
+              </XDSVStack>
+            </XDSHStack>
+            <XDSSkeleton width="100%" height={12} index={3} />
+            <XDSSkeleton width="80%" height={12} index={4} />
+            <XDSSkeleton width="60%" height={12} index={5} />
+          </XDSVStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Progress — determinate: duration-medium · indeterminate: hardcoded
+            1.5s
+          </XDSText>
+          <XDSVStack gap={3} style={{marginTop: 8}}>
+            <XDSProgressBar value={progressValue} label={`${progressValue}%`} />
+            <XDSHStack gap={2}>
+              {[0, 25, 50, 75, 100].map(v => (
+                <XDSButton
+                  key={v}
+                  label={`${v}%`}
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setProgressValue(v)}
+                />
+              ))}
+            </XDSHStack>
+          </XDSVStack>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Status dots — pulse animation · hardcoded 2s (continuous loop)
+          </XDSText>
+          <XDSHStack gap={4} vAlign="center" style={{marginTop: 8}}>
+            <XDSHStack gap={2} vAlign="center">
+              <XDSStatusDot variant="positive" label="Online" isPulsing />
+              <XDSText type="body">Online</XDSText>
+            </XDSHStack>
+            <XDSHStack gap={2} vAlign="center">
+              <XDSStatusDot variant="warning" label="Away" isPulsing />
+              <XDSText type="body">Away</XDSText>
+            </XDSHStack>
+            <XDSHStack gap={2} vAlign="center">
+              <XDSStatusDot variant="negative" label="Busy" isPulsing />
+              <XDSText type="body">Busy</XDSText>
+            </XDSHStack>
+          </XDSHStack>
+        </div>
+      </XDSVStack>
+    </XDSCard>
+  );
+}
+
+// =============================================================================
+// Surface Interactions Preview
+// =============================================================================
+
+function SurfaceInteractionsPreview() {
+  const [activeTab, setActiveTab] = React.useState('overview');
+
+  return (
+    <XDSCard>
+      <XDSVStack gap={4}>
+        <XDSText type="label" display="block">
+          Surface Interactions
+        </XDSText>
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            Tabs — color, active indicator · duration-fast
+          </XDSText>
+          <div style={{marginTop: 8}}>
+            <XDSTabList value={activeTab} onChange={setActiveTab}>
+              <XDSTab value="overview" label="Overview" />
+              <XDSTab value="analytics" label="Analytics" />
+              <XDSTab value="reports" label="Reports" />
+              <XDSTab value="settings" label="Settings" />
+            </XDSTabList>
+          </div>
+        </div>
+        <XDSDivider />
+        <div>
+          <XDSText type="supporting" color="secondary" display="block">
+            List items — background hover · duration-fast-min
+          </XDSText>
+          <div style={{marginTop: 8}}>
+            <XDSList density="balanced" hasDividers>
+              <XDSListItem
+                label="Dashboard"
+                description="View your metrics"
+                onClick={() => {}}
+              />
+              <XDSListItem
+                label="Projects"
+                description="Manage active projects"
+                onClick={() => {}}
+              />
+              <XDSListItem
+                label="Settings"
+                description="Configure preferences"
+                onClick={() => {}}
+              />
+            </XDSList>
+          </div>
+        </div>
+      </XDSVStack>
+    </XDSCard>
   );
 }
 
@@ -1669,6 +2606,8 @@ function ThemeEditorComponent() {
 
   const [mode, setMode] = React.useState<'light' | 'dark'>('light');
   const [showCode, setShowCode] = React.useState(false);
+  const [pushPanelOpen, setPushPanelOpen] = React.useState(false);
+  const [overlayPanelOpen, setOverlayPanelOpen] = React.useState(false);
 
   // Collect all defaults
   const allDefaults: Record<string, string> = React.useMemo(
@@ -2356,15 +3295,122 @@ function ThemeEditorComponent() {
         <div
           style={{
             flex: 1,
-            overflow: 'auto',
+            display: 'flex',
+            flexDirection: 'column',
+            overflow: 'hidden',
           }}>
           <XDSTheme theme={currentTheme} mode={mode}>
             <div
               style={{
-                backgroundColor: 'var(--color-background-surface)',
-                padding: '24px',
+                flex: 1,
+                display: 'flex',
+                overflow: 'hidden',
+                position: 'relative',
               }}>
-              <PreviewTabs />
+              <div style={{flex: 1, overflow: 'auto', minWidth: 0}}>
+                <div
+                  style={{
+                    backgroundColor: 'var(--color-background-surface)',
+                    padding: '24px',
+                  }}>
+                  <PreviewTabs
+                    isMotionGroup={
+                      activeGroup === 'duration' || activeGroup === 'easing'
+                    }
+                    pushOpen={pushPanelOpen}
+                    setPushOpen={setPushPanelOpen}
+                    overlayOpen={overlayPanelOpen}
+                    setOverlayOpen={setOverlayPanelOpen}
+                  />
+                </div>
+              </div>
+
+              {/* Overlay panel — absolute, slides over content */}
+              <div
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  right: 0,
+                  bottom: 0,
+                  width: '40%',
+                  maxWidth: 480,
+                  borderLeft: '1px solid var(--color-border)',
+                  backgroundColor: mode === 'dark' ? '#1F1F22' : '#FFFFFF',
+                  transform: overlayPanelOpen
+                    ? 'translateX(0)'
+                    : 'translateX(100%)',
+                  opacity: overlayPanelOpen ? 1 : 0,
+                  transition: `transform var(--duration-medium) var(--ease-standard), opacity var(--duration-medium) var(--ease-standard)`,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  zIndex: 10,
+                  boxShadow: overlayPanelOpen ? 'var(--shadow-high)' : 'none',
+                }}>
+                <div
+                  style={{
+                    padding: 'var(--spacing-2) var(--spacing-3)',
+                    borderBottom: '1px solid var(--color-border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}>
+                  <XDSText type="label">Overlay Panel</XDSText>
+                  <XDSButton
+                    label="Close"
+                    icon={<XMarkIcon style={{width: 16, height: 16}} />}
+                    variant="ghost"
+                    size="small"
+                    onClick={() => setOverlayPanelOpen(false)}
+                  />
+                </div>
+                <div style={{padding: 'var(--spacing-3)'}}>
+                  <XDSText type="supporting" color="secondary">
+                    Slides over content without resizing it.
+                  </XDSText>
+                </div>
+              </div>
+
+              {/* Push panel — in flow, pushes content */}
+              <div
+                style={{
+                  flexShrink: 0,
+                  width: pushPanelOpen ? '40%' : '0px',
+                  maxWidth: pushPanelOpen ? 480 : 0,
+                  overflow: 'hidden',
+                  borderLeft: pushPanelOpen
+                    ? '1px solid var(--color-border)'
+                    : 'none',
+                  backgroundColor: mode === 'dark' ? '#1F1F22' : '#FFFFFF',
+                  opacity: pushPanelOpen ? 1 : 0,
+                  transition: `width var(--duration-medium) var(--ease-standard), max-width var(--duration-medium) var(--ease-standard), opacity var(--duration-medium) var(--ease-standard)`,
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}>
+                <div
+                  style={{
+                    padding: 'var(--spacing-2) var(--spacing-3)',
+                    borderBottom: '1px solid var(--color-border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    whiteSpace: 'nowrap',
+                  }}>
+                  <XDSText type="label">Push Panel</XDSText>
+                  <XDSButton
+                    label="Close"
+                    icon={<XMarkIcon style={{width: 16, height: 16}} />}
+                    variant="ghost"
+                    size="small"
+                    onClick={() => setPushPanelOpen(false)}
+                  />
+                </div>
+                <div
+                  style={{padding: 'var(--spacing-3)', whiteSpace: 'nowrap'}}>
+                  <XDSText type="supporting" color="secondary">
+                    Pushes content to make room.
+                  </XDSText>
+                </div>
+              </div>
             </div>
           </XDSTheme>
         </div>

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -13,7 +13,7 @@
  * - /apps/storybook/stories/Dialog.stories.tsx (storybook stories)
  */
 
-import {useEffect, useRef, type ReactNode} from 'react';
+import {useEffect, useRef, type ReactNode, type RefObject} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {useScrollLock} from '../hooks/useScrollLock';
@@ -26,6 +26,25 @@ import {
 } from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+
+/**
+ * Calculate a directional translate offset for dialog entry animation.
+ * Returns a normalized vector from the trigger element toward the viewport
+ * center, scaled to the given distance.
+ */
+function getDialogDirection(
+  triggerEl: HTMLElement,
+  distance = 16,
+): {x: number; y: number} {
+  const rect = triggerEl.getBoundingClientRect();
+  const dx = rect.left + rect.width / 2 - window.innerWidth / 2;
+  const dy = rect.top + rect.height / 2 - window.innerHeight / 2;
+  const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+  return {
+    x: Math.round((dx / dist) * distance),
+    y: Math.round((dy / dist) * distance),
+  };
+}
 
 /**
  * Extensible variant map for XDSDialog.
@@ -72,6 +91,15 @@ export interface XDSDialogPosition {
   top?: number | string;
 }
 
+const enterDirectional = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform:
+      'translate(var(--dialog-dir-x, 0px), var(--dialog-dir-y, 16px)) scale(0.95)',
+  },
+  to: {opacity: 1, transform: 'translate(0, 0) scale(1)'},
+});
+
 /**
  * Dialog styles using native <dialog> element
  * Uses ::backdrop pseudo-element for overlay
@@ -93,31 +121,17 @@ const styles = stylex.create({
     flexDirection: 'column',
     height: 'fit-content',
     overscrollBehavior: 'contain',
-    // Entry/exit animation. Requires @starting-style + allow-discrete
-    // for transitioning from display:none. Browsers without support
-    // get instant show/hide (opacity defaults to 1 in base, animation
-    // layer only applies when @starting-style is supported).
     opacity: {
-      default: 1,
-      ':where(:not([open]))': 0,
+      default: 0,
+      ':where([open])': 1,
     },
-    transform: {
-      default: 'scale(1) translateY(0)',
-      ':where(:not([open]))': 'scale(0.95) translateY(8px)',
+    animationName: {
+      default: 'none',
+      ':where([open])': enterDirectional,
     },
-    '@supports (transition-behavior: allow-discrete)': {
-      transitionProperty: 'opacity, transform, display, overlay',
-      transitionDuration: durationVars['--duration-medium'],
-      transitionTimingFunction: easeVars['--ease-standard'],
-      transitionBehavior: 'allow-discrete',
-      '@starting-style': {
-        opacity: 0,
-        transform: 'scale(0.95) translateY(8px)',
-      },
-    },
-    '@media (prefers-reduced-motion: reduce)': {
-      transitionDuration: '0s',
-    },
+    animationDuration: durationVars['--duration-medium-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards' as const,
     outline: {
       default: null,
       ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
@@ -202,6 +216,14 @@ export interface XDSDialogProps extends XDSBaseProps<HTMLDialogElement> {
   onOpenChange: (isOpen: boolean) => unknown;
 
   /**
+   * Ref to the trigger element that opens the dialog.
+   * When provided, the dialog entry animation slides from the direction
+   * of the trigger toward the viewport center. Focus is returned to
+   * the trigger when the dialog closes.
+   */
+  triggerRef?: RefObject<HTMLElement | null>;
+
+  /**
    * The width of the dialog.
    * Numbers are treated as pixels, strings are used as-is.
    * Ignored when variant is 'fullscreen'.
@@ -270,6 +292,7 @@ export interface XDSDialogProps extends XDSBaseProps<HTMLDialogElement> {
 export function XDSDialog({
   isOpen,
   onOpenChange,
+  triggerRef,
   width = 400,
   maxHeight = '75vh',
   position,
@@ -305,6 +328,17 @@ export function XDSDialog({
     if (!dialog) return;
 
     if (isOpen) {
+      // Set directional CSS custom properties before opening
+      const trigger = triggerRef?.current;
+      if (trigger) {
+        const dir = getDialogDirection(trigger);
+        dialog.style.setProperty('--dialog-dir-x', `${dir.x}px`);
+        dialog.style.setProperty('--dialog-dir-y', `${dir.y}px`);
+      } else {
+        dialog.style.setProperty('--dialog-dir-x', '0px');
+        dialog.style.setProperty('--dialog-dir-y', '16px');
+      }
+
       if (!dialog.open) {
         dialog.showModal();
         // React's autoFocus calls .focus() during commit, before showModal()
@@ -320,8 +354,10 @@ export function XDSDialog({
       if (dialog.open) {
         dialog.close();
       }
+      // Return focus to trigger
+      triggerRef?.current?.focus();
     }
-  }, [isOpen]);
+  }, [isOpen, triggerRef]);
 
   // Lock body scroll when dialog is open (iOS Safari workaround)
   useScrollLock(isOpen);

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -29,6 +29,7 @@ import type {XDSIconType} from '../Icon';
 
 import {XDSDivider} from '../Divider';
 import {XDSDropdownMenuItem} from './XDSDropdownMenuItem';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {
   colorVars,
   spacingVars,
@@ -649,7 +650,7 @@ export function XDSDropdownMenu({
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: [popoverXstyle, styles.popoverGap],
+          xstyle: [popoverXstyle, styles.popoverGap, layerAnimations.below],
         },
       )}
     </>

--- a/packages/core/src/Field/XDSFieldStatus.tsx
+++ b/packages/core/src/Field/XDSFieldStatus.tsx
@@ -9,6 +9,8 @@
  * - /packages/core/src/Field/index.ts (exports if types change)
  */
 
+'use client';
+
 import * as stylex from '@stylexjs/stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {
@@ -19,6 +21,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {XDSInputStatusType} from './types';
+import {useEntryAnimation} from '../hooks/useEntryAnimation';
 
 const styles = stylex.create({
   base: {
@@ -124,6 +127,8 @@ export function XDSFieldStatus({
   id,
   variant = 'attached',
 }: XDSFieldStatusProps) {
+  const entryStyle = useEntryAnimation('slideDown');
+
   return (
     <div
       id={id}
@@ -133,6 +138,7 @@ export function XDSFieldStatus({
         xdsClassName('field-status', {type, variant}),
         stylex.props(
           styles.base,
+          entryStyle,
           variant === 'attached' ? styles.attached : styles.detached,
           colorStyles[type],
         ),

--- a/packages/core/src/Field/inputStyles.stylex.ts
+++ b/packages/core/src/Field/inputStyles.stylex.ts
@@ -31,6 +31,7 @@ export const inputWrapperStyles = stylex.create({
   base: {
     boxSizing: 'border-box',
     position: 'relative',
+    zIndex: 1,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],

--- a/packages/core/src/HoverCard/useXDSHoverCard.tsx
+++ b/packages/core/src/HoverCard/useXDSHoverCard.tsx
@@ -24,10 +24,9 @@ import {
   type LayerAlignment,
   type LayerPlacement,
 } from '../Layer/useXDSLayer';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {
   colorVars,
-  durationVars,
-  easeVars,
   shadowVars,
   radiusVars,
   spacingVars,
@@ -35,31 +34,12 @@ import {
 import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
-  // Base container styles passed to useXDSLayer (includes animations)
+  // Base container styles passed to useXDSLayer
   container: {
     backgroundColor: colorVars['--color-background-surface'],
     '--hovercard-radius': radiusVars['--radius-container'],
     borderRadius: 'var(--hovercard-radius)',
     boxShadow: shadowVars['--shadow-med'],
-    // Animation: closed state (default) and open state
-    opacity: {
-      default: 0,
-      ':popover-open': 1,
-    },
-    transform: {
-      default: 'scale(0.95)',
-      ':popover-open': 'scale(1)',
-    },
-    // Transitions with allow-discrete for display/overlay
-    transitionProperty: 'opacity, transform, overlay, display',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    transitionBehavior: 'allow-discrete',
-    // Entry animation starting state
-    '@starting-style': {
-      opacity: 0,
-      transform: 'scale(0.95)',
-    },
   },
   // Position-based margin styles
   marginBlock: {
@@ -418,10 +398,11 @@ export function useXDSHoverCard(
   // Render function that wraps layer.render with hover card behavior
   const renderHoverCard = useCallback(
     (children: ReactNode, props?: ContextRenderProps) => {
+      const renderPlacement = props?.placement ?? placement;
       const renderProps = {
-        placement: props?.placement ?? placement,
+        placement: renderPlacement,
         alignment: props?.alignment ?? alignment,
-        xstyle: popoverXstyle,
+        xstyle: [popoverXstyle, layerAnimations[renderPlacement]],
       };
 
       return layer.render(

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -27,6 +27,9 @@ export type {
   FixedLayerReturn,
 } from './useXDSLayer';
 
+// Shared entry animation styles for layer-based components
+export {layerAnimations} from './layerAnimations.stylex';
+
 // Re-export Popover from new location (backward compat)
 export {useXDSPopover, XDSPopover} from '../Popover';
 export type {

--- a/packages/core/src/Layer/layerAnimations.stylex.ts
+++ b/packages/core/src/Layer/layerAnimations.stylex.ts
@@ -1,0 +1,91 @@
+/**
+ * @file layerAnimations.stylex.ts
+ * @input Uses StyleX, theme duration/easing tokens
+ * @output Exports shared entry animation styles for layer-based components
+ * @position Shared animation primitives; consumed by DropdownMenu, Popover,
+ *   HoverCard, Tooltip, Selector, and any component using useXDSLayer
+ *
+ * Provides opt-in entry animations for popover/layer components.
+ * Components apply these via the `xstyle` prop on `layer.render()`.
+ *
+ * @example
+ * ```
+ * import {layerAnimations} from '../Layer/layerAnimations.stylex';
+ *
+ * // Direction-aware (for components that know placement):
+ * layer.render(<Content />, {
+ *   xstyle: layerAnimations[placement],
+ * });
+ *
+ * // Fixed direction:
+ * layer.render(<Content />, {
+ *   xstyle: layerAnimations.below,
+ * });
+ * ```
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
+
+const enterBelow = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: `translateY(calc(-1 * ${spacingVars['--spacing-2']})) scale(0.95)`,
+  },
+  to: {opacity: 1, transform: 'translateY(0) scale(1)'},
+});
+
+const enterAbove = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: `translateY(${spacingVars['--spacing-2']}) scale(0.95)`,
+  },
+  to: {opacity: 1, transform: 'translateY(0) scale(1)'},
+});
+
+const enterEnd = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: `translateX(calc(-1 * ${spacingVars['--spacing-2']})) scale(0.95)`,
+  },
+  to: {opacity: 1, transform: 'translateX(0) scale(1)'},
+});
+
+const enterStart = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: `translateX(${spacingVars['--spacing-2']}) scale(0.95)`,
+  },
+  to: {opacity: 1, transform: 'translateX(0) scale(1)'},
+});
+
+const animationBase = {
+  animationDuration: durationVars['--duration-fast-max'],
+  animationTimingFunction: easeVars['--ease-standard'],
+  animationFillMode: 'backwards' as const,
+};
+
+/**
+ * Shared entry animation styles for layer-based components.
+ *
+ * Keyed by LayerPlacement ('above' | 'below' | 'start' | 'end')
+ * for easy lookup: `layerAnimations[placement]`.
+ */
+export const layerAnimations = stylex.create({
+  below: {
+    animationName: enterBelow,
+    ...animationBase,
+  },
+  above: {
+    animationName: enterAbove,
+    ...animationBase,
+  },
+  end: {
+    animationName: enterEnd,
+    ...animationBase,
+  },
+  start: {
+    animationName: enterStart,
+    ...animationBase,
+  },
+});

--- a/packages/core/src/Layer/useXDSLayer.tsx
+++ b/packages/core/src/Layer/useXDSLayer.tsx
@@ -11,7 +11,6 @@
  * - /packages/core/src/Layer/index.ts
  */
 
-
 import React, {
   useCallback,
   useId,

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -152,15 +152,15 @@ const styles = stylex.create({
   },
   interactive: {
     cursor: 'pointer',
-    transitionProperty: 'background-image',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionProperty: 'background-color',
+    transitionDuration: durationVars['--duration-fast-min'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    backgroundImage: {
-      default: null,
+    backgroundColor: {
+      default: 'transparent',
       ':hover': {
-        '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
+        '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
-      ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
+      ':active': colorVars['--color-overlay-pressed'],
     },
   },
   focusWithinOutline: {

--- a/packages/core/src/Popover/XDSPopover.tsx
+++ b/packages/core/src/Popover/XDSPopover.tsx
@@ -26,7 +26,8 @@ import {xdsClassName, mergeProps} from '../utils';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {useXDSPopover} from './useXDSPopover';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useXDSLayer';
-import {durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
+import {spacingVars} from '../theme/tokens.stylex';
 
 // =============================================================================
 // Helpers
@@ -174,27 +175,6 @@ const styles = stylex.create({
   // don't shift the anchor position and cause popover jitter.
   anchorWrapper: {
     display: 'inline-flex',
-  },
-  // Animation styles for the popover element (the one with [popover] attribute).
-  // :popover-open only matches the element with the popover attribute,
-  // so these MUST be applied via xstyle to useXDSLayer's render wrapper.
-  popoverAnimation: {
-    opacity: {
-      default: 0,
-      ':popover-open': 1,
-    },
-    transform: {
-      default: 'scale(0.95)',
-      ':popover-open': 'scale(1)',
-    },
-    transitionProperty: 'opacity, transform, overlay, display',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    transitionBehavior: 'allow-discrete',
-    '@starting-style': {
-      opacity: 0,
-      transform: 'scale(0.95)',
-    },
   },
   // Visual styles for the inner content container
   contentPadding: {
@@ -450,7 +430,7 @@ export function XDSPopover({
           {
             placement,
             alignment,
-            xstyle: [popoverXstyle, styles.gap, styles.popoverAnimation],
+            xstyle: [popoverXstyle, styles.gap, layerAnimations[placement]],
           },
         )}
       </>
@@ -476,7 +456,7 @@ export function XDSPopover({
         {
           placement,
           alignment,
-          xstyle: [popoverXstyle, styles.gap, styles.popoverAnimation],
+          xstyle: [popoverXstyle, styles.gap, layerAnimations[placement]],
         },
       )}
     </>

--- a/packages/core/src/PowerSearch/XDSPowerSearch.tsx
+++ b/packages/core/src/PowerSearch/XDSPowerSearch.tsx
@@ -27,6 +27,7 @@ import {
 } from '../Tokenizer';
 import {XDSTypeaheadItem} from '../Typeahead/XDSTypeaheadItem';
 import {XDSToken} from '../Token';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {XDSIcon} from '../Icon';
 import type {XDSIconType} from '../Icon';
 import type {XDSIconName} from '../Icon/globalIconRegistry';
@@ -856,7 +857,7 @@ export function XDSPowerSearch({
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: popoverLayerStyles.layer,
+          xstyle: [popoverLayerStyles.layer, layerAnimations.below],
         },
       )}
     </>

--- a/packages/core/src/Selector/XDSSelector.tsx
+++ b/packages/core/src/Selector/XDSSelector.tsx
@@ -30,6 +30,7 @@ import {
   inputStatusHoverShadowStyles,
 } from '../Field';
 import {XDSDivider} from '../Divider';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {XDSSpinner} from '../Spinner';
 import {
   colorVars,
@@ -662,7 +663,7 @@ export function XDSSelector<T extends XDSSelectorOptionType>({
         {
           placement: 'below',
           alignment: 'start',
-          xstyle: styles.popover,
+          xstyle: [styles.popover, layerAnimations.below],
         },
       )}
     </XDSField>

--- a/packages/core/src/Skeleton/XDSSkeleton.tsx
+++ b/packages/core/src/Skeleton/XDSSkeleton.tsx
@@ -14,7 +14,7 @@
 
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, radiusVars} from '../theme/tokens.stylex';
+import {colorVars, radiusVars, durationVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -62,7 +62,7 @@ const styles = stylex.create({
   },
   animate: {
     animationDirection: 'alternate',
-    animationDuration: `${FADE_TIME}ms`,
+    animationDuration: durationVars['--duration-medium-max'],
     animationIterationCount: 'infinite',
     animationName: skeletonFade,
     animationTimingFunction: 'steps(10, end)',

--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -16,7 +16,7 @@
 import {useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {colorVars, durationVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSText} from '../Text/XDSText';
 import {xdsClassName, mergeProps} from '../utils';
 
@@ -64,7 +64,7 @@ const styles = stylex.create({
   canvas: {
     backfaceVisibility: 'hidden',
     display: 'block',
-    animationDuration: '750ms',
+    animationDuration: durationVars['--duration-medium-max'],
     animationIterationCount: 'infinite',
     animationName: rotation,
     animationTimingFunction: 'linear',

--- a/packages/core/src/Tooltip/useXDSTooltip.tsx
+++ b/packages/core/src/Tooltip/useXDSTooltip.tsx
@@ -24,10 +24,9 @@ import {
   type LayerAlignment,
   type LayerPlacement,
 } from '../Layer/useXDSLayer';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import {
   colorVars,
-  durationVars,
-  easeVars,
   radiusVars,
   spacingVars,
   typographyVars,
@@ -46,25 +45,6 @@ const styles = stylex.create({
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
-    // Animation: closed state (default) and open state
-    opacity: {
-      default: 0,
-      ':popover-open': 1,
-    },
-    transform: {
-      default: 'scale(0.95)',
-      ':popover-open': 'scale(1)',
-    },
-    // Transitions with allow-discrete for display/overlay
-    transitionProperty: 'opacity, transform, overlay, display',
-    transitionDuration: durationVars['--duration-fast-min'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    transitionBehavior: 'allow-discrete',
-    // Entry animation starting state
-    '@starting-style': {
-      opacity: 0,
-      transform: 'scale(0.95)',
-    },
   },
   // Position-based margin styles
   marginBlock: {
@@ -393,10 +373,11 @@ export function useXDSTooltip(
   // Render function that wraps layer.render with tooltip styling
   const renderTooltip = useCallback(
     (children: ReactNode, props?: ContextRenderProps) => {
+      const renderPlacement = props?.placement ?? placement;
       const renderProps = {
-        placement: props?.placement ?? placement,
+        placement: renderPlacement,
         alignment: props?.alignment ?? alignment,
-        xstyle: popoverXstyle,
+        xstyle: [popoverXstyle, layerAnimations[renderPlacement]],
         className: xdsClassName('tooltip'),
       };
 

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -24,3 +24,6 @@ export {useOverflow} from './useOverflow';
 export type {UseOverflowOptions, UseOverflowReturn} from './useOverflow';
 
 export {useScrollLock} from './useScrollLock';
+
+export {useEntryAnimation} from './useEntryAnimation';
+export type {EntryAnimationPreset} from './useEntryAnimation';

--- a/packages/core/src/hooks/useEntryAnimation.ts
+++ b/packages/core/src/hooks/useEntryAnimation.ts
@@ -1,0 +1,111 @@
+/**
+ * @file useEntryAnimation.ts
+ * @input Uses React, StyleX, theme tokens
+ * @output Exports useEntryAnimation hook for mount-only entry animations
+ * @position Hook utility; consumed by XDSFieldStatus and available to consumers
+ *
+ * Provides entry animations for conditionally rendered elements.
+ * Only animates when the element is dynamically mounted after the initial
+ * page paint — statically rendered elements on page load are not animated.
+ */
+
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {durationVars, easeVars, spacingVars} from '../theme/tokens.stylex';
+
+// Track whether the initial page paint has completed.
+// Elements rendered on page load should not animate;
+// only dynamically inserted ones should.
+//
+// NOTE: This module is marked 'use client' so it never runs on the server.
+// If the directive is removed, this flag will always be false during SSR,
+// and useState(() => initialPaintComplete) will capture false — meaning
+// animations won't run after hydration. Keep 'use client' or add an
+// effect-based fallback if SSR support is needed.
+let initialPaintComplete = false;
+if (typeof window !== 'undefined') {
+  requestAnimationFrame(() => {
+    initialPaintComplete = true;
+  });
+}
+
+const slideDown = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: `translateY(calc(-1 * ${spacingVars['--spacing-2']}))`,
+  },
+  to: {opacity: 1, transform: 'translateY(0)'},
+});
+
+const slideUp = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: `translateY(${spacingVars['--spacing-2']})`,
+  },
+  to: {opacity: 1, transform: 'translateY(0)'},
+});
+
+const fadeIn = stylex.keyframes({
+  from: {opacity: 0},
+  to: {opacity: 1},
+});
+
+const scaleIn = stylex.keyframes({
+  from: {opacity: 0, transform: 'scale(0.95)'},
+  to: {opacity: 1, transform: 'scale(1)'},
+});
+
+const styles = stylex.create({
+  slideDown: {
+    animationName: slideDown,
+    animationDuration: durationVars['--duration-fast-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
+  },
+  slideUp: {
+    animationName: slideUp,
+    animationDuration: durationVars['--duration-fast-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
+  },
+  fadeIn: {
+    animationName: fadeIn,
+    animationDuration: durationVars['--duration-fast-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
+  },
+  scaleIn: {
+    animationName: scaleIn,
+    animationDuration: durationVars['--duration-fast-max'],
+    animationTimingFunction: easeVars['--ease-standard'],
+    animationFillMode: 'backwards',
+  },
+});
+
+export type EntryAnimationPreset =
+  | 'slideDown'
+  | 'slideUp'
+  | 'fadeIn'
+  | 'scaleIn';
+
+/**
+ * Returns a StyleX style for animating an element on mount.
+ *
+ * Only animates when the element is dynamically inserted after the initial
+ * page paint. Elements rendered on page load are not animated.
+ *
+ * @example
+ * ```
+ * const entryStyle = useEntryAnimation('slideDown');
+ * <div {...stylex.props(entryStyle)}>Animated content</div>
+ * ```
+ */
+export function useEntryAnimation(
+  preset: EntryAnimationPreset = 'slideDown',
+): StyleXStyles | null {
+  const [animate] = useState(() => initialPaintComplete);
+  return animate ? styles[preset] : null;
+}


### PR DESCRIPTION
## Summary

Consolidates Ted's motion PRs (#919 + #920) into a single PR, rebased on current main.

### Core Animation System (from #919)

| File | Change |
|---|---|
| `layerAnimations.stylex.ts` | **New** — shared direction-aware keyframes (below/above/start/end) using spacing tokens |
| `useEntryAnimation.ts` | **New** — composable hook for mount-only animations with initialPaintComplete guard |
| `XDSPopover.tsx` | Removed component-level `@starting-style` transitions → opt-in `layerAnimations[placement]` |
| `useXDSHoverCard.tsx` | Same — removed animation overrides, uses layerAnimations |
| `useXDSTooltip.tsx` | Same — removed animation overrides, uses layerAnimations |
| `XDSDropdownMenu.tsx` | Added `layerAnimations.below` to layer render |
| `XDSSelector.tsx` | Added `layerAnimations.below` to layer render |
| `XDSPowerSearch.tsx` | Added `layerAnimations.below` to layer render |
| `XDSDialog.tsx` | CSS keyframe animation with `triggerRef` for directional entry (preserves autofocus fix from main) |
| `XDSFieldStatus.tsx` | Uses `useEntryAnimation('slideDown')` for status message entry |
| `XDSListItem.tsx` | `background-image` → `background-color` for animatable hover transition |
| `XDSSpinner.tsx` | Hardcoded `750ms` → `--duration-medium-max` token |
| `XDSSkeleton.tsx` | Hardcoded `1000ms` → `--duration-medium-max` token |
| `inputStyles.stylex.ts` | `zIndex: 1` on input wrapper (fixes status bar overlap) |
| `hooks/index.ts` | Exports `useEntryAnimation` |
| `Layer/index.ts` | Exports `layerAnimations` |

### Sandbox Motion Preview (from #920)

Theme editor moved to fullscreen layout with motion-specific preview sections:
- Navigation & Overlays — modal, overlay panel, push panel
- Micro-Interactions — buttons, dropdown, popover (4 directions), hovercard, tooltip, switches, checkboxes, slider, input validation
- Loading & Status — spinners, skeletons, progress bar, status dots
- Surface Interactions — tabs, list items
- Table Page — full app shell with PowerSearch, table with row-click → push panel

### Architecture

Animations are **opt-in via xstyle**, not baked into `useXDSLayer`. Components apply `layerAnimations[placement]` through the existing `xstyle` prop on `layer.render()`. This keeps the layer primitive clean and lets each component control its own animation behavior.

### Verification
- ✅ Build passes
- ✅ All 2,388 tests pass (133 test files)

Supersedes #919 and #920.
Based on work by @tedmcdo.