### PR TITLE
ci: typecheck template.doc.mjs files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Typecheck component docs
         run: yarn workspace @xds/core typecheck:docs
 
+      - name: Typecheck template docs
+        run: yarn workspace @xds/cli typecheck:template-docs
+
   # Build storybook + analyze components (parallel with test)
   # Uploads storybook preview and analysis artifacts for downstream jobs
   build:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,8 @@
     "docs"
   ],
   "scripts": {
-    "xds": "node bin/xds.mjs"
+    "xds": "node bin/xds.mjs",
+    "typecheck:template-docs": "tsc --project tsconfig.template-docs.json"
   },
   "dependencies": {
     "@clack/prompts": "^0.9.1",

--- a/packages/cli/templates/demo-dashboard/template.doc.mjs
+++ b/packages/cli/templates/demo-dashboard/template.doc.mjs
@@ -1,4 +1,4 @@
-/** @type {import('@xds/core').TemplateDoc} */
+/** @type {import('../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
   name: 'Dashboard',
   description: 'Analytics dashboard with KPI cards and a data table.',

--- a/packages/cli/tsconfig.template-docs.json
+++ b/packages/cli/tsconfig.template-docs.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": [
+    "templates/**/template.doc.mjs",
+    "../core/src/docs-types.ts"
+  ]
+}


### PR DESCRIPTION
Adds typechecking for template doc files, matching the existing pattern for component docs.

- `packages/cli/tsconfig.template-docs.json` with `checkJs: true`
- `typecheck:template-docs` script in `@xds/cli`
- Wired into CI test job alongside component doc typecheck
- Template doc uses relative import to `docs-types.ts` (same pattern as component docs)

Follow-up to #1101.