### PR TITLE
fix(Link): support type="emphasized" for semibold link styling

### DIFF
--- a/apps/storybook/stories/Link.stories.tsx
+++ b/apps/storybook/stories/Link.stories.tsx
@@ -241,6 +241,48 @@ export const ExternalLinks: Story = {
   ),
 };
 
+export const EmphasizedVariants: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '8px',
+      }}>
+      <XDSLink
+        label="Emphasized"
+        href="/emphasized"
+        type="emphasized"
+        isStandalone>
+        Emphasized
+      </XDSLink>
+      <XDSLink
+        label="Emphasized with underline"
+        href="/emphasized"
+        type="emphasized"
+        hasUnderline
+        isStandalone>
+        Emphasized with underline
+      </XDSLink>
+      <XDSLink
+        label="Emphasized external"
+        href="https://example.com"
+        type="emphasized"
+        isExternalLink
+        isStandalone>
+        Emphasized external
+      </XDSLink>
+      <XDSText type="body">
+        Inline text with an{' '}
+        <XDSLink label="emphasized link" href="/emphasized" type="emphasized">
+          emphasized link
+        </XDSLink>{' '}
+        inside it.
+      </XDSText>
+    </div>
+  ),
+};
+
 export const LinksWithTooltips: Story = {
   render: () => (
     <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>

--- a/packages/core/src/Link/XDSLink.test.tsx
+++ b/packages/core/src/Link/XDSLink.test.tsx
@@ -220,6 +220,37 @@ describe('XDSLink', () => {
     expect(link).not.toHaveAttribute('data-another-link');
   });
 
+  it('renders emphasized type with semibold weight', () => {
+    render(
+      <XDSLink label="Emphasized" href="/test" type="emphasized">
+        Emphasized Link
+      </XDSLink>,
+    );
+    const link = screen.getByRole('link', {name: 'Emphasized'});
+    expect(link).toBeInTheDocument();
+    // The inner XDSText span should have semibold weight
+    const textSpan = link.querySelector('span');
+    expect(textSpan).toBeInTheDocument();
+  });
+
+  it('renders emphasized type with isExternalLink', () => {
+    render(
+      <XDSLink
+        label="Emphasized External"
+        href="https://example.com"
+        type="emphasized"
+        isExternalLink>
+        Emphasized External
+      </XDSLink>,
+    );
+    const link = screen.getByRole('link', {name: 'Emphasized External'});
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link.querySelector('svg')).toBeInTheDocument();
+    // The inner XDSText span should still be present with semibold weight
+    const textSpan = link.querySelector('span');
+    expect(textSpan).toBeInTheDocument();
+  });
+
   it('renders xds-* class names for theme targeting', () => {
     render(
       <XDSLink label="Themed" href="/test" color="secondary">

--- a/packages/core/src/Link/XDSLink.tsx
+++ b/packages/core/src/Link/XDSLink.tsx
@@ -34,6 +34,12 @@ import type {
   XDSTextWeight,
   XDSTextDisplay,
 } from '../theme/types';
+
+/**
+ * Link-specific type that extends XDSTextType with link variants.
+ * - 'emphasized': Renders as body text with semibold weight for visual prominence.
+ */
+export type XDSLinkType = XDSTextType | 'emphasized';
 import {useXDSLinkComponent} from './useXDSLinkComponent';
 import type {XDSLinkComponentType} from './types';
 import {xdsClassName, mergeProps} from '../utils';
@@ -177,10 +183,11 @@ export interface XDSLinkProps extends XDSBaseProps<HTMLAnchorElement> {
    */
   isStandalone?: boolean;
   /**
-   * Semantic text type for XDSText. Determines base typography.
+   * Semantic text type. Determines base typography.
+   * Accepts all XDSTextType values plus 'emphasized' (body with semibold weight).
    * @default 'body'
    */
-  type?: XDSTextType;
+  type?: XDSLinkType;
   /**
    * Explicit font size override. Forwarded to XDSText.
    */
@@ -250,6 +257,12 @@ export function XDSLink({
   ...props
 }: XDSLinkProps) {
   const LinkComponent = useXDSLinkComponent(as);
+
+  // Resolve link-specific types to XDSText props
+  const resolvedTextType: XDSTextType = type === 'emphasized' ? 'body' : type;
+  const resolvedWeight: XDSTextWeight | undefined =
+    weight ?? (type === 'emphasized' ? 'semibold' : undefined);
+
   // Determine target and rel based on isExternalLink
   const computedTarget = isExternalLink ? '_blank' : target;
   const computedRel = isExternalLink
@@ -283,9 +296,9 @@ export function XDSLink({
       )}
       {...props}>
       <XDSText
-        type={type}
+        type={resolvedTextType}
         size={size}
-        weight={weight}
+        weight={resolvedWeight}
         color={color}
         display={display}
         maxLines={maxLines}>

--- a/packages/core/src/Link/index.ts
+++ b/packages/core/src/Link/index.ts
@@ -10,7 +10,7 @@
  */
 
 export {XDSLink} from './XDSLink';
-export type {XDSLinkProps} from './XDSLink';
+export type {XDSLinkProps, XDSLinkType} from './XDSLink';
 
 export {XDSLinkProvider} from './XDSLinkProvider';
 export type {XDSLinkProviderProps} from './XDSLinkProvider';


### PR DESCRIPTION
## Summary

- `XDSLink` passed `type` directly to `XDSText`, but `"emphasized"` is not a valid `XDSTextType` so it was silently ignored — no semibold styling was applied regardless of `isExternalLink`
- Added `XDSLinkType = XDSTextType | 'emphasized'` which resolves to body text with `weight="semibold"`, while still allowing explicit `weight` overrides
- Added `EmphasizedVariants` storybook story covering standalone, underline, external link, and inline usage

Q: is there a reason we have different styling for XDSLink vs. XDSText? It seems like maybe they should just take the same options?

## Test plan

- [x] Existing 17 Link tests pass
- [x] Added 2 new tests: emphasized type rendering, and emphasized + isExternalLink combination
- [x] Verify in Storybook that `EmphasizedVariants` story renders semibold text for all variants including the external link case