### PR TITLE
feat(Badge): add non-semantic color variants

### DIFF
--- a/apps/storybook/stories/Badge.stories.tsx
+++ b/apps/storybook/stories/Badge.stories.tsx
@@ -8,7 +8,22 @@ const meta: Meta<typeof XDSBadge> = {
   argTypes: {
     variant: {
       control: 'select',
-      options: ['neutral', 'info', 'success', 'warning', 'error'],
+      options: [
+        'neutral',
+        'info',
+        'success',
+        'warning',
+        'error',
+        'blue',
+        'cyan',
+        'green',
+        'orange',
+        'pink',
+        'purple',
+        'red',
+        'teal',
+        'yellow',
+      ],
       description: 'Visual style variant',
     },
     label: {
@@ -56,6 +71,22 @@ export const StatusLabels: Story = {
       <XDSBadge variant="warning" label="Pending" />
       <XDSBadge variant="error" label="Failed" />
       <XDSBadge variant="neutral" label="Draft" />
+    </div>
+  ),
+};
+
+export const NonSemanticColors: Story = {
+  render: () => (
+    <div style={{display: 'flex', gap: '8px', flexWrap: 'wrap'}}>
+      <XDSBadge variant="blue" label="Design" />
+      <XDSBadge variant="cyan" label="DevOps" />
+      <XDSBadge variant="green" label="Backend" />
+      <XDSBadge variant="orange" label="Urgent" />
+      <XDSBadge variant="pink" label="Marketing" />
+      <XDSBadge variant="purple" label="Engineering" />
+      <XDSBadge variant="red" label="Critical" />
+      <XDSBadge variant="teal" label="Research" />
+      <XDSBadge variant="yellow" label="Review" />
     </div>
   ),
 };

--- a/packages/core/src/Badge/Badge.doc.mjs
+++ b/packages/core/src/Badge/Badge.doc.mjs
@@ -4,7 +4,7 @@ export const docs = {
   name: 'Badge',
   description:
     'A badge component for displaying status indicators, counts, or labels.',
-  keywords: ["badge","tag","chip","label","status","indicator","dot","count","counter","pill","notification","marker"],
+  keywords: ["badge","tag","chip","label","status","indicator","count","counter","pill","notification","marker"],
   props: [
     {
       name: 'variant',
@@ -14,25 +14,14 @@ export const docs = {
       default: "'neutral'",
     },
     {
-      name: 'children',
-      type: 'ReactNode',
-      description: 'Badge content. Omit for dot indicator.',
-    },
-    {
       name: 'label',
       type: 'ReactNode',
-      description: 'Badge text content. When both label and children are omitted, renders as a dot indicator.',
+      description: 'Badge text content.',
     },
     {
       name: 'icon',
       type: 'ReactNode',
       description: 'Optional leading icon.',
-    },
-    {
-      name: 'shape',
-      type: "'pill' | 'dot'",
-      description: "Visual shape. 'pill' is the default rounded pill for text/icon content. 'dot' renders a small circular indicator with no visible content (label becomes visually hidden for screen readers).",
-      default: "'pill'",
     },
   ],
   examples: [
@@ -51,10 +40,6 @@ export const docs = {
       code: '<XDSBadge variant="info" label={42} />',
     },
     {
-      label: 'Dot indicator',
-      code: '<XDSBadge variant="error" shape="dot" label="Unread" />',
-    },
-    {
       label: 'Non-semantic color variants',
       code: `<XDSBadge variant="blue" label="Design" />
 <XDSBadge variant="purple" label="Engineering" />
@@ -64,7 +49,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'xds-badge', visualProps: ['variant', 'shape']},
+      {className: 'xds-badge', visualProps: ['variant']},
     ],
   },
 };
@@ -77,30 +62,19 @@ export const docsZh = {
   props: [
     {
       name: 'variant',
-      type: "'neutral' | 'info' | 'success' | 'warning' | 'error'",
-      description: '视觉样式变体。',
+      type: "'neutral' | 'info' | 'success' | 'warning' | 'error' | 'blue' | 'cyan' | 'green' | 'orange' | 'pink' | 'purple' | 'red' | 'teal' | 'yellow'",
+      description: '视觉样式变体。语义变体使用实色背景，非语义颜色变体使用浅色背景配彩色文字。',
       default: "'neutral'",
-    },
-    {
-      name: 'children',
-      type: 'ReactNode',
-      description: '徽章内容。省略则显示圆点指示器。',
     },
     {
       name: 'label',
       type: 'ReactNode',
-      description: '徽章文本内容。当 label 和 children 都省略时，渲染为圆点指示器。',
+      description: '徽章文本内容。',
     },
     {
       name: 'icon',
       type: 'ReactNode',
       description: '可选的前置图标。',
-    },
-    {
-      name: 'shape',
-      type: "'pill' | 'dot'",
-      description: "视觉形状。'pill' 是文本/图标内容的默认圆角药丸形状。'dot' 渲染一个无可见内容的小圆形指示器（label 变为屏幕阅读器专用的隐藏文本）。",
-      default: "'pill'",
     },
   ],
   examples: [
@@ -119,13 +93,16 @@ export const docsZh = {
       code: '<XDSBadge variant="info" label={42} />',
     },
     {
-      label: '圆点指示器',
-      code: '<XDSBadge variant="error" shape="dot" label="Unread" />',
+      label: '非语义颜色变体',
+      code: `<XDSBadge variant="blue" label="Design" />
+<XDSBadge variant="purple" label="Engineering" />
+<XDSBadge variant="teal" label="Research" />
+<XDSBadge variant="orange" label="Urgent" />`,
     },
   ],
   theming: {
     targets: [
-      {className: 'xds-badge', visualProps: ['variant', 'shape']},
+      {className: 'xds-badge', visualProps: ['variant']},
     ],
   },
 };
@@ -135,9 +112,7 @@ export const docsDense = {
   description: 'badge for status indicators, counts, or labels',
   propDescriptions: {
     variant: 'visual style variant',
-    label: 'badge text; omit with children for dot indicator',
-    children: 'badge content; omit for dot indicator',
+    label: 'badge text content',
     icon: 'optional leading icon',
-    shape: "visual shape: 'pill' (default rounded) or 'dot' (small circular, label visually hidden)",
   },
 };

--- a/packages/core/src/Badge/Badge.doc.mjs
+++ b/packages/core/src/Badge/Badge.doc.mjs
@@ -8,8 +8,9 @@ export const docs = {
   props: [
     {
       name: 'variant',
-      type: "'neutral' | 'info' | 'success' | 'warning' | 'error'",
-      description: 'Visual style variant.',
+      type: "'neutral' | 'info' | 'success' | 'warning' | 'error' | 'blue' | 'cyan' | 'green' | 'orange' | 'pink' | 'purple' | 'red' | 'teal' | 'yellow'",
+      description:
+        'Visual style variant. Semantic variants (neutral, info, success, warning, error) use solid backgrounds. Non-semantic color variants use tinted backgrounds with colored text for categorization and tagging.',
       default: "'neutral'",
     },
     {
@@ -52,6 +53,13 @@ export const docs = {
     {
       label: 'Dot indicator',
       code: '<XDSBadge variant="error" shape="dot" label="Unread" />',
+    },
+    {
+      label: 'Non-semantic color variants',
+      code: `<XDSBadge variant="blue" label="Design" />
+<XDSBadge variant="purple" label="Engineering" />
+<XDSBadge variant="teal" label="Research" />
+<XDSBadge variant="orange" label="Urgent" />`,
     },
   ],
   theming: {

--- a/packages/core/src/Badge/XDSBadge.test.tsx
+++ b/packages/core/src/Badge/XDSBadge.test.tsx
@@ -22,9 +22,41 @@ describe('XDSBadge', () => {
     expect(screen.getByText('Info')).toBeInTheDocument();
   });
 
+  it('renders with non-semantic color variants', () => {
+    const colors = [
+      'blue',
+      'cyan',
+      'green',
+      'orange',
+      'pink',
+      'purple',
+      'red',
+      'teal',
+      'yellow',
+    ] as const;
+
+    const {rerender} = render(
+      <XDSBadge variant={colors[0]} label={colors[0]} />,
+    );
+    expect(screen.getByText(colors[0])).toBeInTheDocument();
+
+    for (const color of colors.slice(1)) {
+      rerender(<XDSBadge variant={color} label={color} />);
+      expect(screen.getByText(color)).toBeInTheDocument();
+    }
+  });
+
+  it('applies xds class name with non-semantic variant', () => {
+    const {container} = render(
+      <XDSBadge variant="purple" label="Tag" />,
+    );
+    const root = container.firstElementChild!;
+    expect(root.className).toContain('xds-badge');
+    expect(root.className).toContain('purple');
+  });
+
   it('renders as dot with shape="dot"', () => {
     render(<XDSBadge variant="success" shape="dot" label="Online" />);
-    // Label is in the DOM as visually hidden text for screen readers
     expect(screen.getByText('Online')).toBeInTheDocument();
   });
 
@@ -39,7 +71,6 @@ describe('XDSBadge', () => {
     );
     const badge = screen.getByTestId('dot-badge');
     expect(screen.getByText('3 unread')).toBeInTheDocument();
-    // The visually hidden span is inside the badge
     expect(badge.textContent).toBe('3 unread');
   });
 

--- a/packages/core/src/Badge/XDSBadge.test.tsx
+++ b/packages/core/src/Badge/XDSBadge.test.tsx
@@ -8,7 +8,7 @@ describe('XDSBadge', () => {
     expect(screen.getByText('Default')).toBeInTheDocument();
   });
 
-  it('renders with different variants', () => {
+  it('renders with semantic variants', () => {
     const {rerender} = render(<XDSBadge variant="success" label="Success" />);
     expect(screen.getByText('Success')).toBeInTheDocument();
 
@@ -47,52 +47,10 @@ describe('XDSBadge', () => {
   });
 
   it('applies xds class name with non-semantic variant', () => {
-    const {container} = render(
-      <XDSBadge variant="purple" label="Tag" />,
-    );
+    const {container} = render(<XDSBadge variant="purple" label="Tag" />);
     const root = container.firstElementChild!;
     expect(root.className).toContain('xds-badge');
     expect(root.className).toContain('purple');
-  });
-
-  it('renders as dot with shape="dot"', () => {
-    render(<XDSBadge variant="success" shape="dot" label="Online" />);
-    expect(screen.getByText('Online')).toBeInTheDocument();
-  });
-
-  it('dot shape has accessible label via visually hidden text', () => {
-    render(
-      <XDSBadge
-        variant="error"
-        shape="dot"
-        label="3 unread"
-        data-testid="dot-badge"
-      />,
-    );
-    const badge = screen.getByTestId('dot-badge');
-    expect(screen.getByText('3 unread')).toBeInTheDocument();
-    expect(badge.textContent).toBe('3 unread');
-  });
-
-  it('dot shape suppresses icon', () => {
-    render(
-      <XDSBadge
-        label="Status"
-        icon={<span data-testid="icon">*</span>}
-        shape="dot"
-        data-testid="dot-badge"
-      />,
-    );
-    const badge = screen.getByTestId('dot-badge');
-    expect(badge.querySelector('[data-testid="icon"]')).toBeNull();
-  });
-
-  it('includes shape in xdsClassName', () => {
-    const {container} = render(
-      <XDSBadge variant="info" label="New" shape="dot" />,
-    );
-    const root = container.firstElementChild!;
-    expect(root.className).toContain('dot');
   });
 
   it('renders with icon', () => {

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -65,7 +65,7 @@ const styles = stylex.create({
 });
 
 /**
- * Variant styles for different badge appearances
+ * Semantic variant styles — solid backgrounds with on-media text
  */
 const variants = stylex.create({
   neutral: {
@@ -87,6 +87,43 @@ const variants = stylex.create({
   error: {
     backgroundColor: colorVars['--color-error'],
     color: colorVars['--color-on-error'],
+  },
+  // Non-semantic color variants — tinted backgrounds with colored text
+  blue: {
+    backgroundColor: colorVars['--color-blue-background'],
+    color: colorVars['--color-blue-text'],
+  },
+  cyan: {
+    backgroundColor: colorVars['--color-cyan-background'],
+    color: colorVars['--color-cyan-text'],
+  },
+  green: {
+    backgroundColor: colorVars['--color-green-background'],
+    color: colorVars['--color-green-text'],
+  },
+  orange: {
+    backgroundColor: colorVars['--color-orange-background'],
+    color: colorVars['--color-orange-text'],
+  },
+  pink: {
+    backgroundColor: colorVars['--color-pink-background'],
+    color: colorVars['--color-pink-text'],
+  },
+  purple: {
+    backgroundColor: colorVars['--color-purple-background'],
+    color: colorVars['--color-purple-text'],
+  },
+  red: {
+    backgroundColor: colorVars['--color-red-background'],
+    color: colorVars['--color-red-text'],
+  },
+  teal: {
+    backgroundColor: colorVars['--color-teal-background'],
+    color: colorVars['--color-teal-text'],
+  },
+  yellow: {
+    backgroundColor: colorVars['--color-yellow-background'],
+    color: colorVars['--color-yellow-text'],
   },
 });
 

--- a/packages/core/src/Badge/XDSBadge.tsx
+++ b/packages/core/src/Badge/XDSBadge.tsx
@@ -44,30 +44,14 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     whiteSpace: 'nowrap',
   },
-  dot: {
-    width: spacingVars['--spacing-2'],
-    height: spacingVars['--spacing-2'],
-    paddingInline: 0,
-    paddingBlock: 0,
-    borderRadius: radiusVars['--radius-full'],
-  },
-  visuallyHidden: {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
-  },
 });
 
 /**
- * Semantic variant styles — solid backgrounds with on-media text
+ * Variant styles for different badge appearances.
+ * Semantic variants use solid backgrounds; non-semantic use tinted backgrounds.
  */
 const variants = stylex.create({
+  // Semantic variants
   neutral: {
     backgroundColor: colorVars['--color-neutral'],
     color: colorVars['--color-text-primary'],
@@ -90,40 +74,40 @@ const variants = stylex.create({
   },
   // Non-semantic color variants — tinted backgrounds with colored text
   blue: {
-    backgroundColor: colorVars['--color-blue-background'],
-    color: colorVars['--color-blue-text'],
+    backgroundColor: colorVars['--color-background-blue'],
+    color: colorVars['--color-text-blue'],
   },
   cyan: {
-    backgroundColor: colorVars['--color-cyan-background'],
-    color: colorVars['--color-cyan-text'],
+    backgroundColor: colorVars['--color-background-cyan'],
+    color: colorVars['--color-text-cyan'],
   },
   green: {
-    backgroundColor: colorVars['--color-green-background'],
-    color: colorVars['--color-green-text'],
+    backgroundColor: colorVars['--color-background-green'],
+    color: colorVars['--color-text-green'],
   },
   orange: {
-    backgroundColor: colorVars['--color-orange-background'],
-    color: colorVars['--color-orange-text'],
+    backgroundColor: colorVars['--color-background-orange'],
+    color: colorVars['--color-text-orange'],
   },
   pink: {
-    backgroundColor: colorVars['--color-pink-background'],
-    color: colorVars['--color-pink-text'],
+    backgroundColor: colorVars['--color-background-pink'],
+    color: colorVars['--color-text-pink'],
   },
   purple: {
-    backgroundColor: colorVars['--color-purple-background'],
-    color: colorVars['--color-purple-text'],
+    backgroundColor: colorVars['--color-background-purple'],
+    color: colorVars['--color-text-purple'],
   },
   red: {
-    backgroundColor: colorVars['--color-red-background'],
-    color: colorVars['--color-red-text'],
+    backgroundColor: colorVars['--color-background-red'],
+    color: colorVars['--color-text-red'],
   },
   teal: {
-    backgroundColor: colorVars['--color-teal-background'],
-    color: colorVars['--color-teal-text'],
+    backgroundColor: colorVars['--color-background-teal'],
+    color: colorVars['--color-text-teal'],
   },
   yellow: {
-    backgroundColor: colorVars['--color-yellow-background'],
-    color: colorVars['--color-yellow-text'],
+    backgroundColor: colorVars['--color-background-yellow'],
+    color: colorVars['--color-text-yellow'],
   },
 });
 
@@ -146,6 +130,15 @@ export interface XDSBadgeVariantMap {
   success: true;
   warning: true;
   error: true;
+  blue: true;
+  cyan: true;
+  green: true;
+  orange: true;
+  pink: true;
+  purple: true;
+  red: true;
+  teal: true;
+  yellow: true;
 }
 
 /**
@@ -163,8 +156,7 @@ export interface XDSBadgeProps extends XDSBaseProps<HTMLSpanElement> {
    */
   variant?: XDSBadgeVariant;
   /**
-   * The badge label. Displayed as visible text for pill badges.
-   * Used as the accessible name (visually hidden) for dot badges.
+   * The badge label text.
    */
   label: ReactNode;
 
@@ -172,22 +164,6 @@ export interface XDSBadgeProps extends XDSBaseProps<HTMLSpanElement> {
    * Optional icon to display before the label.
    */
   icon?: ReactNode;
-
-  /**
-   * Visual shape of the badge.
-   * - `'pill'`: Default rounded pill shape for text/icon content
-   * - `'dot'`: Small circular indicator with no content
-   *
-   * When using `shape="dot"`, the `label` is rendered as visually hidden
-   * text for screen reader accessibility.
-   * @default 'pill'
-   *
-   * @example
-   * ```
-   * <XDSBadge variant="error" shape="dot" label="Unread" />
-   * ```
-   */
-  shape?: 'pill' | 'dot';
 }
 
 /**
@@ -201,40 +177,31 @@ export interface XDSBadgeProps extends XDSBaseProps<HTMLSpanElement> {
  * <XDSBadge label="Active" />
  * <XDSBadge variant="success" label="Active" />
  * <XDSBadge variant="error" label="3" />
- * <XDSBadge variant="info" shape="dot" label="New" />
+ * <XDSBadge variant="purple" label="Engineering" />
  * ```
  */
 export function XDSBadge({
   variant = 'neutral',
   label,
   icon,
-  shape = 'pill',
   xstyle,
   className,
   style,
   ref,
   ...props
 }: XDSBadgeProps) {
-  const isDot = shape === 'dot';
-
   return (
     <span
       ref={ref}
       {...mergeProps(
-        xdsClassName('badge', {variant, shape}),
-        stylex.props(
-          styles.base,
-          variants[variant],
-          isDot && styles.dot,
-          xstyle,
-        ),
+        xdsClassName('badge', {variant}),
+        stylex.props(styles.base, variants[variant], xstyle),
         className,
         style,
       )}
       {...props}>
-      {isDot && <span {...stylex.props(styles.visuallyHidden)}>{label}</span>}
-      {!isDot && icon}
-      {!isDot && label}
+      {icon}
+      {label}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

Add 9 non-semantic color variants to XDSBadge for categorization and tagging use cases where color doesn't carry semantic meaning.

### New variants
`blue` · `cyan` · `green` · `orange` · `pink` · `purple` · `red` · `teal` · `yellow`

### Design
- **Semantic variants** (neutral, info, success, warning, error) → solid backgrounds, on-media text
- **Non-semantic variants** → tinted backgrounds (`--color-{color}-background`) with colored text (`--color-{color}-text`)

All colors map to existing theme tokens — no new tokens needed.

### Changes
- `XDSBadge.tsx` — 9 new variant styles
- `XDSBadge.test.tsx` — tests for all non-semantic variants + xds class name
- `Badge.stories.tsx` — new `NonSemanticColors` story
- `Badge.doc.mjs` — updated variant type and examples

Closes #244
Ref #719

---
