### PR TITLE
hardening: Collapsible export/BaseProps/type rename; Divider border token

### DIFF
--- a/packages/core/src/Collapsible/XDSCollapsible.tsx
+++ b/packages/core/src/Collapsible/XDSCollapsible.tsx
@@ -32,6 +32,7 @@ import {
 import {useXDSCollapsible} from './useXDSCollapsible';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 const styles = stylex.create({
   // Trigger button — full width, flex row, no browser button styling
@@ -76,7 +77,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSCollapsibleProps {
+export interface XDSCollapsibleProps extends Omit<XDSBaseProps, 'children'> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
@@ -163,6 +164,9 @@ export function XDSCollapsible({
   onOpenChange,
   value,
   ref,
+  xstyle,
+  className,
+  style,
   ...props
 }: XDSCollapsibleProps) {
   // Build the config for the hook
@@ -179,7 +183,15 @@ export function XDSCollapsible({
   const chevronIcon = getIcon('chevronDown');
 
   return (
-    <div ref={ref} className={xdsClassName('collapsible')} {...props}>
+    <div
+      ref={ref}
+      {...mergeProps(
+        xdsClassName('collapsible'),
+        stylex.props(xstyle),
+        className,
+        style,
+      )}
+      {...props}>
       <button
         type="button"
         onClick={toggle}

--- a/packages/core/src/Collapsible/index.ts
+++ b/packages/core/src/Collapsible/index.ts
@@ -17,7 +17,7 @@ export type {XDSCollapsibleGroupProps} from './XDSCollapsibleGroup';
 
 export {useXDSCollapsible} from './useXDSCollapsible';
 export type {
-  CollapsibleConfig,
+  XDSCollapsibleConfig,
   UseXDSCollapsibleOptions,
   UseXDSCollapsibleReturn,
 } from './useXDSCollapsible';

--- a/packages/core/src/Collapsible/useXDSCollapsible.ts
+++ b/packages/core/src/Collapsible/useXDSCollapsible.ts
@@ -3,7 +3,7 @@
 /**
  * @file useXDSCollapsible.ts
  * @input Uses React useState/useContext, CollapsibleGroupContext
- * @output Exports useXDSCollapsible hook, CollapsibleConfig, UseXDSCollapsibleOptions, UseXDSCollapsibleReturn types
+ * @output Exports useXDSCollapsible hook, XDSCollapsibleConfig (formerly CollapsibleConfig), UseXDSCollapsibleOptions, UseXDSCollapsibleReturn types
  * @position Reusable hook for collapsible behavior — used by XDSCard, XDSSection, etc.
  *
  * Encapsulates the full collapsible state machine:
@@ -19,14 +19,13 @@
  * NOTE: Public hooks use the `useXDS` prefix per XDS naming conventions.
  */
 
-
 import {useState, useContext} from 'react';
 import {CollapsibleGroupContext} from './XDSCollapsibleGroupContext';
 
 /**
  * Configuration for collapsible behavior.
  */
-export type CollapsibleConfig = {
+export type XDSCollapsibleConfig = {
   /** Default open state for uncontrolled usage. @default true */
   defaultIsOpen?: boolean;
   /** Controlled open state. */
@@ -42,7 +41,7 @@ export interface UseXDSCollapsibleOptions {
    * - `{ defaultIsOpen: false }` — self-managed, starts collapsed
    * - `{ isOpen, onOpenChange }` — controlled externally
    */
-  isCollapsible?: boolean | CollapsibleConfig;
+  isCollapsible?: boolean | XDSCollapsibleConfig;
   /**
    * Unique identifier within an XDSCollapsibleGroup.
    * When present and inside a group, defers state to the group.
@@ -85,7 +84,7 @@ export function useXDSCollapsible(
   const isControlledByGroup = group != null && value != null;
 
   // Parse config: true → empty config, object → as-is, false/undefined → null
-  const config: CollapsibleConfig | null =
+  const config: XDSCollapsibleConfig | null =
     isCollapsible === true ? {} : isCollapsible ? isCollapsible : null;
   const isEnabled = config != null;
 

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -16,7 +16,12 @@ import {type HTMLAttributes, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  spacingVars,
+  typeScaleVars,
+  borderVars,
+} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
@@ -114,12 +119,12 @@ const baseStyles = stylex.create({
 
 const lineStyles = stylex.create({
   horizontalLine: {
-    height: '1px',
+    height: borderVars['--border-width'],
     flexGrow: 1,
     flexShrink: 1,
   },
   verticalLine: {
-    width: '1px',
+    width: borderVars['--border-width'],
     flexGrow: 1,
     flexShrink: 1,
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,7 @@ export * from './Card';
 export * from './Calendar';
 export * from './Center';
 export * from './CheckboxInput';
+export * from './Collapsible';
 export * from './RadioList';
 export * from './Divider';
 export * from './EmptyState';


### PR DESCRIPTION
## Summary

Component audit for 2026-04-04. Audited: CheckboxInput ✓, Collapsible (4 fixes), DateInput ✓, Dialog ✓, Divider (1 fix).

### Fixes

**Collapsible — export-gap (critical)**

`XDSCollapsible`, `XDSCollapsibleGroup`, `useXDSCollapsible`, and all their types were missing from `src/index.ts`. The components existed in `src/Collapsible/index.ts` but were never re-exported from the main package entry point, making them inaccessible via `@xds/core`.

**Collapsible — structure-issue: missing XDSBaseProps**

`XDSCollapsibleProps` did not extend `XDSBaseProps`, so the component had no `xstyle`, `className`, or `style` escape hatches. Updated to `extends Omit<XDSBaseProps, 'children'>` and the root div now uses `mergeProps()` for correct style merging.

**Collapsible — missing-type-prefix: CollapsibleConfig → XDSCollapsibleConfig**

`CollapsibleConfig` was a public exported type from `@xds/core/Collapsible` without the required `XDS` prefix. Renamed to `XDSCollapsibleConfig`. No usages outside the module (storybook + tests checked).

**Divider — hardcoded-value: '1px' → borderVars['--border-width']**

The divider line used hardcoded `height: '1px'` and `width: '1px'` instead of `borderVars['--border-width']`. Themes can now control the divider thickness via the border token.

---

## Needs Review

**Collapsible — XDSCollapsibleGroup onChange callback naming**

`XDSCollapsibleGroup` uses `onChange` (returns `string | string[]` representing which items are open). The auditor rule says visibility state changes should use `onOpenChange`, but `onOpenChange` canonically takes a `boolean`. For a group that tracks which *values* are open, `onChange` may be the correct name (it's more like a selection callback than a single visibility toggle). Flagging for human judgment.

**Collapsible — CollapsibleGroupContext / CollapsibleGroupContextValue naming**

These are internal-only (not exported from `Collapsible/index.ts`). The convention for public contexts requires the `XDS` prefix, but since these are internal implementation details, the current names may be intentional. Flagging for clarity.

---
