### PR TITLE
fix(docs): remove invalid 'name' from OverflowList TranslationDoc

### DIFF
--- a/packages/core/src/OverflowList/OverflowList.doc.mjs
+++ b/packages/core/src/OverflowList/OverflowList.doc.mjs
@@ -117,7 +117,7 @@ export const docs = {
   ],
 };
 
-/** @type {import('../docs-types').TranslationDoc} */
+/** @type {import('../docs-types').ComponentDoc} */
 export const docsZh = {
   name: 'OverflowList',
   description:


### PR DESCRIPTION
TranslationDoc doesn't have a `name` property — introduced in 4e4c9e6a, breaks doc typecheck in CI.