### PR TITLE
ci: allow design owners to merge CLI template changes

### DIFF
--- a/.github/DESIGNOWNERS
+++ b/.github/DESIGNOWNERS
@@ -1,10 +1,10 @@
 # Design owners for the XDS repository
 #
-# Design owners can merge changes to sandbox and storybook apps
-# without code owner approval. This lets designers iterate freely
-# on stories, demos, and visual explorations.
+# Design owners can merge changes to sandbox apps, storybook stories,
+# and CLI templates without code owner approval. This lets designers
+# iterate freely on stories, demos, visual explorations, and templates.
 #
-# Code owners still review everything else (core, CLI, infra, CI).
+# Code owners still review everything else (core, CLI logic, infra, CI).
 #
 # Format: one GitHub username per line (same as CODEOWNERS convention)
 

--- a/.github/workflows/codeowner-gate.yml
+++ b/.github/workflows/codeowner-gate.yml
@@ -1,8 +1,9 @@
 # Code owner gate: blocks merge unless a code owner has approved
 # Code owners themselves can merge freely (auto-pass)
 #
-# Design owners (.github/DESIGNOWNERS) can merge sandbox/storybook
-# changes without code owner approval. Everyone else needs it.
+# Design owners (.github/DESIGNOWNERS) can merge sandbox, storybook,
+# and CLI template changes without code owner approval. Everyone else
+# needs it.
 #
 # Uses the Checks API to write a single "Code Owner Gate" status per
 # commit SHA, so re-runs from pull_request_review events UPDATE the
@@ -58,6 +59,7 @@ jobs:
             const DESIGN_PATHS = [
               'apps/sandbox/',
               'apps/storybook/',
+              'packages/cli/templates/',
             ];
 
             // --- Resolve PR context ---
@@ -94,7 +96,7 @@ jobs:
               summary = `@${prAuthor} is a code owner — approved automatically.`;
             } else if (onlyDesignPaths && DESIGNOWNERS.includes(prAuthor)) {
               conclusion = 'success';
-              summary = `@${prAuthor} is a design owner and only sandbox/storybook files changed — approved automatically.\nFiles: ${changedFiles.join(', ')}`;
+              summary = `@${prAuthor} is a design owner and only design-owned paths changed — approved automatically.\nFiles: ${changedFiles.join(', ')}`;
             } else {
               // Check for code owner approval
               const { data: reviews } = await github.rest.pulls.listReviews({
@@ -118,7 +120,7 @@ jobs:
               } else {
                 // Tailor the message based on context
                 if (onlyDesignPaths && !DESIGNOWNERS.includes(prAuthor)) {
-                  summary = `@${prAuthor} is not a design owner. Sandbox/storybook changes require code owner approval (${CODE_OWNERS.map(u => '@' + u).join(', ')}) or being listed in .github/DESIGNOWNERS.`;
+                  summary = `@${prAuthor} is not a design owner. These paths require code owner approval (${CODE_OWNERS.map(u => '@' + u).join(', ')}) or being listed in .github/DESIGNOWNERS.`;
                 } else {
                   summary = `Requires approval from a code owner (${CODE_OWNERS.map(u => '@' + u).join(', ')}).`;
                 }


### PR DESCRIPTION
Adds `packages/cli/templates/` to the design-owned paths in the codeowner gate workflow.

Design owners listed in `.github/DESIGNOWNERS` can now merge PRs that only touch sandbox, storybook, **or CLI template** files without code owner approval — letting them contribute and iterate on templates freely.

### Changes
- **`codeowner-gate.yml`**: Added `packages/cli/templates/` to `DESIGN_PATHS`
- **`DESIGNOWNERS`**: Updated comments to reflect the expanded scope
- Generalized status messages (no longer hardcoded to "sandbox/storybook")

---
