### PR TITLE
feat(agent-docs): include template compositions as layout reference

### DIFF
--- a/internal/vibe-tests/AGENTS.md
+++ b/internal/vibe-tests/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS
+
+Project-specific guidance for AI coding agents.
+
+<!-- XDS:START -->
+
+XDS v0.0.10|Always run yarn xds component <Name> before writing XDS component code.
+yarn xds component <Name> props, usage, examples for any component
+yarn xds component --list 106 components by category
+yarn xds docs principles Design principles, rules, and anti-patterns for XDS.
+yarn xds docs theme XDSTheme provider, custom themes, light/dark mode, and component style overrides.
+yarn xds docs tokens Spacing, color, radius, typography, and shadow token reference.
+yarn xds template <name> [path] scaffold page from template
+TEMPLATES (use as layout reference — check before building a page):
+blank Layout
+contact-form CheckboxInput + Divider + RadioList + Selector + TextArea + TextInput + Token
+dashboard AppShell + Avatar + Badge + Card + NavIcon + SegmentedControl + SideNav + Tab + TabList + Table + TopNav
+data-table AppShell + Avatar + Badge + Card + Dialog + NavIcon + Pagination + Selector + SideNav + Tab + TabList + Table + TextInput
+detail-page AppShell + Avatar + Badge + Card + Center + Collapsible + Divider + Layout + List + MetadataList + NavIcon + ProgressBar + SideNav + Tab + TabList
+editor Card + Divider + List + SegmentedControl + Selector + Tab + TabList + TextArea + TextInput + Toolbar
+file-explorer Divider + List + SegmentedControl + Toolbar
+login Card + Center + FormLayout + Layout + TextInput
+login-card Card + Divider + TextInput
+login-split Card + Divider + TextInput
+login-sso Card + Divider + TextInput
+product-detail AppShell + Badge + Center + Collapsible + Divider + NavIcon + NumberInput + SegmentedControl + TopNav
+settings CheckboxInput + Divider + List + Search + Searchable + TextInput + Typeahead
+settings-dialog Badge + Card + Dialog + Divider + List + Selector + Switch + Tab + TabList + TextInput
+settings-sidebar Badge + Card + Divider + List + Selector + Switch + Tab + TabList + TextInput
+table Badge + Layout + Table
+RULE: before building a page layout, check if a template matches your intent
+yarn xds swizzle <Name> eject component source (use --gap to report why)
+yarn xds upgrade --apply [--from <v> --to 0.0.10] run version migration codemods
+--detail compact|brief less output | --lang dense|zh translation
+RULE: after @xds/core bump, always run yarn xds upgrade --apply
+RULE: when swizzling, always use --gap to report missing capabilities
+
+<!-- XDS:END -->

--- a/internal/vibe-tests/experiments/template-ref/FINDINGS.md
+++ b/internal/vibe-tests/experiments/template-ref/FINDINGS.md
@@ -1,0 +1,75 @@
+# Template Reference Vibe Test — Findings
+
+**Date:** 2026-04-04
+**Question:** Does giving LLMs template composition info improve layout quality?
+
+## Configs
+
+| Config                       | What it adds                                             | Token cost   |
+| ---------------------------- | -------------------------------------------------------- | ------------ |
+| A: Control                   | Stale CLAUDE.md (3 templates: blank, login, table)       | ~680 chars   |
+| B: Template list             | All 16 templates with component compositions             | ~1,730 chars |
+| C: Skeletons + spatial rules | B + JSX structure skeletons with padding/gap annotations | ~3,960 chars |
+
+## Results (9/18 completed — 4 A, 2 B, 3 C)
+
+### Layout Component Adoption
+
+| Signal            | A (control) | B (templates) | C (skeletons) |
+| ----------------- | :---------: | :-----------: | :-----------: |
+| Used XDSLayout    |  1/4 (25%)  |  2/2 (100%)   |  3/3 (100%)   |
+| Used hasDivider   |  1/4 (25%)  |  2/2 (100%)   |  3/3 (100%)   |
+| Used XDSGrid      |  0/4 (0%)   |   1/2 (50%)   |  0/3 (0%)\*   |
+| Used XDSSection   |  0/4 (0%)   |   0/2 (0%)    |   1/3 (33%)   |
+| Used LayoutFooter |  0/4 (0%)   |   0/2 (0%)    |   1/3 (33%)   |
+
+### Key Head-to-Head Comparisons
+
+**dd-1 (table with search) — A vs C:**
+
+- A: No Layout. Raw VStack + stylex maxWidth:1200. 8 distinct gap values.
+- C: Layout → LayoutHeader(hasDivider) → LayoutContent → Table. 1 gap value. Clean.
+
+**dd-5 (email inbox) — A vs B vs C:**
+
+- A: No Layout. Toolbar for bulk actions. maxWidth:960 in stylex.
+- B: Layout+LayoutHeader+LayoutContent. TabList for filters. hasDivider.
+- C: Layout+LayoutHeader+LayoutContent+LayoutFooter for bulk actions. hasDivider×2.
+
+**dd-3 (product grid) — A vs B:**
+
+- A: Raw CSS grid (auto-fill minmax). No XDS layout structure.
+- B: XDSGrid (columns=4, minChildWidth=240) + Layout+LayoutHeader+LayoutContent.
+
+### Spatial Decision Quality
+
+| Metric                    |     A (control)     | B (templates)  | C (skeletons) |
+| ------------------------- | :-----------------: | :------------: | :-----------: |
+| Gap value diversity       | High (4-8 per file) | Moderate (2-3) |   Low (0-2)   |
+| Ad-hoc maxWidth in stylex |        100%         |       0%       |      0%       |
+| hasDivider adoption       |         25%         |      100%      |     100%      |
+
+## Interpretation
+
+1. **Config B is surprisingly effective.** Just listing "table: Layout + LayoutHeader + LayoutContent + Table" drove Layout adoption from 25% → 100%. Cost: ~1KB.
+
+2. **Config C adds spatial precision.** Skeleton annotations teach where padding lives. C agents produce fewer, more intentional gap values and use LayoutFooter/Section — components A never discovered.
+
+3. **The biggest win is structural.** Going from "no page shell" to "Layout + LayoutHeader + LayoutContent" is the dominant effect. This alone would improve design judge layout fidelity scores.
+
+4. **hasDivider = 100% in B/C vs 25% in A.** Template references teach composition patterns, not just component names.
+
+5. **Ad-hoc maxWidth disappears.** A configs all invent their own page width constraints (1200, 960, 640). B/C let Layout/AppShell handle it — zero ad-hoc widths.
+
+## Recommendation
+
+**Ship Config B now.** ~1KB addition to agent-docs, zero new infrastructure, drives Layout adoption 25% → 100%.
+
+**Build Config C next.** Skeleton extractor + spatial rules add real value for padding/gap precision. Worth a follow-up PR.
+
+### Concrete steps:
+
+1. Update `agent-docs.mjs` `generateCompressedIndex()` to include template compositions
+2. Add `keywords` and `components` fields to `TemplateDoc` type in `docs-types.ts`
+3. Run `xds agent-docs` to refresh CLAUDE.md
+4. Future: `xds template --skeleton <name>` CLI command for Config C

--- a/internal/vibe-tests/experiments/template-ref/config-a-control.md
+++ b/internal/vibe-tests/experiments/template-ref/config-a-control.md
@@ -1,0 +1,13 @@
+<!-- XDS-CLI:START -->
+
+XDS v0.0.10|Always run npx xds component <Name> before writing XDS component code.
+npx xds component <Name> props, usage, examples for any component
+npx xds component --list 95 components by category
+npx xds template <name> [path] scaffold page (blank, login, table)
+npx xds swizzle <Name> eject component source (use --gap to report why)
+npx xds upgrade --apply run version migration codemods
+--detail compact|brief less output | --lang dense|zh translation
+RULE: after @xds/core bump, always run npx xds upgrade --apply
+RULE: when swizzling, always use --gap to report missing capabilities
+
+<!-- XDS-CLI:END -->

--- a/internal/vibe-tests/experiments/template-ref/config-b-templates.md
+++ b/internal/vibe-tests/experiments/template-ref/config-b-templates.md
@@ -1,0 +1,26 @@
+<!-- XDS-CLI:START -->
+
+XDS v0.0.10|Always run npx xds component <Name> before writing XDS component code.
+npx xds component <Name> props, usage, examples for any component
+npx xds component --list 95 components by category
+npx xds docs <topic> principles, tokens, theme reference
+npx xds template <name> [path] scaffold page from template
+npx xds swizzle <Name> eject component source (use --gap to report why)
+npx xds upgrade --apply run version migration codemods
+--detail compact|brief less output | --lang dense|zh translation
+TEMPLATES (use as layout reference — check these before building a page):
+dashboard: AppShell + SideNav + TopNav + Card + Table + TabList + SegmentedControl
+data-table: AppShell + SideNav + Table + Pagination + Dialog + TextInput
+settings-sidebar: List + TabList + Switch + Card + Section + Selector + Divider
+settings-dialog: Dialog + List + TabList + Switch + Card + Section
+detail-page: AppShell + Layout + LayoutPanel + MetadataList + Collapsible + ProgressBar
+editor: TabList + Toolbar + List + Card + TextArea + Selector
+product-detail: AppShell + TopNav + Collapsible + NumberInput + SegmentedControl
+table: Layout + LayoutHeader + LayoutContent + Table
+login-card: Card + VStack + TextInput + Button + Divider
+contact-form: VStack + TextInput + Selector + RadioList + CheckboxInput + TextArea
+RULE: before building a page layout, check if a template matches — use it as a composition reference
+RULE: after @xds/core bump, always run npx xds upgrade --apply
+RULE: when swizzling, always use --gap to report missing capabilities
+
+<!-- XDS-CLI:END -->

--- a/internal/vibe-tests/experiments/template-ref/config-c-skeletons.md
+++ b/internal/vibe-tests/experiments/template-ref/config-c-skeletons.md
@@ -1,0 +1,89 @@
+<!-- XDS-CLI:START -->
+
+XDS v0.0.10|Always run npx xds component <Name> before writing XDS component code.
+npx xds component <Name> props, usage, examples for any component
+npx xds component --list 95 components by category
+npx xds docs <topic> principles, tokens, theme reference
+npx xds template <name> [path] scaffold page from template
+npx xds swizzle <Name> eject component source (use --gap to report why)
+npx xds upgrade --apply run version migration codemods
+--detail compact|brief less output | --lang dense|zh translation
+TEMPLATES (use as layout reference — study the skeleton before building a page):
+dashboard: AppShell + SideNav + TopNav + Card + Table + TabList + SegmentedControl
+data-table: AppShell + SideNav + Table + Pagination + Dialog + TextInput
+settings-sidebar: List + TabList + Switch + Card + Section + Selector + Divider
+detail-page: AppShell + Layout + LayoutPanel + MetadataList + Collapsible + ProgressBar
+table: Layout + LayoutHeader + LayoutContent + Table
+product-detail: AppShell + TopNav + Collapsible + NumberInput + SegmentedControl
+LAYOUT SKELETONS (spatial reference — note where padding and gap live):
+[table]
+<Layout>
+<LayoutHeader hasDivider>
+<HStack hAlign="between"> title + action </HStack>
+</LayoutHeader>
+<LayoutContent> ← LayoutContent provides scroll + padding
+<Table />
+</LayoutContent>
+</Layout>
+[dashboard]
+<AppShell contentPadding={6} sideNav={<SideNav/>} topNav={<TopNav/>}>
+<VStack gap={6}> ← page sections: gap 6
+<Card> ← stat cards (use Grid columns={4} for card grid)
+<VStack gap={4}> ← inside card: gap 4
+<VStack gap={1}> ← label+value: gap 1
+<Card padding={0}> ← table card: padding 0 so table bleeds to edges
+<Table />
+</VStack>
+</AppShell>
+[settings-sidebar]
+
+  <div style="padding: 0">         ← sidebar: no extra padding, List handles it
+    <VStack gap={4}>
+      <Heading />
+      <List density="spacious" />   ← nav items
+    </VStack>
+  </div>
+  <div maxWidth={700} padding="16px 48px" margin="0 auto">  ← content area
+    <VStack gap={6}>                ← sections: gap 6
+      <Heading />
+      <TabList hasDivider />
+      <VStack gap={8}>              ← setting groups: gap 8
+        <VStack gap={0}>            ← individual rows: gap 0, Divider between
+          <Heading />
+          <Divider />
+          {rows}
+        </VStack>
+      </VStack>
+    </VStack>
+  </div>
+[detail-page]
+  <AppShell sideNav={<SideNav/>}>
+    <Layout height="fill">
+      <LayoutHeader hasDivider>     ← page header with breadcrumbs
+      </LayoutHeader>
+      <LayoutContent role="main" padding={0}>  ← padding 0 when using inner sections
+        <VStack gap={6}>
+          <Section>                  ← overview section
+            <MetadataList />         ← key-value pairs
+          </Section>
+          <TabList />
+          <Section>
+            <Collapsible />          ← expandable detail sections
+          </Section>
+        </VStack>
+      </LayoutContent>
+      <LayoutPanel hasDivider width={360}>  ← right panel for summary
+        <Card /> <ProgressBar />
+      </LayoutPanel>
+    </Layout>
+  </AppShell>
+SPATIAL RULES:
+  - AppShell/Layout handle page padding — don't add extra padding inside LayoutContent
+  - Card padding={0} when child is Table or List (they have their own row padding)
+  - VStack gap={6-8} for page sections, gap={3-4} inside cards, gap={1-2} for label+value
+  - Divider between list rows, not gap — use VStack gap={0} + Divider
+  - maxWidth + margin auto for constrained content areas
+RULE: before building a page layout, find the closest template skeleton and use it as spatial reference
+RULE: after @xds/core bump, always run npx xds upgrade --apply
+RULE: when swizzling, always use --gap to report missing capabilities
+<!-- XDS-CLI:END -->

--- a/internal/vibe-tests/experiments/template-ref/prompts.json
+++ b/internal/vibe-tests/experiments/template-ref/prompts.json
@@ -1,0 +1,8 @@
+{
+  "ps-1": "Create a new page for a settings dashboard. It should have a header with the app title, a sidebar for navigation, and a main content area. Use the XDS theme system.",
+  "ps-3": "Create an admin panel page layout with a fixed header, collapsible left sidebar, main content area, and a right panel for details. Wrap everything in the XDS theme.",
+  "ps-4": "Create a product detail page with breadcrumb navigation showing Home > Category > Subcategory > Product Name. The page should have a header, product info section, and a back button.",
+  "dd-1": "A table of users with sortable columns and search",
+  "dd-3": "Show a grid of product cards with image, title, price, and add to cart button",
+  "dd-5": "Build an email inbox view with a table showing sender, subject, date, and a preview snippet. Add row selection with checkboxes and a bulk actions bar that appears when items are selected."
+}

--- a/internal/vibe-tests/results/441ddbe0/manifest.json
+++ b/internal/vibe-tests/results/441ddbe0/manifest.json
@@ -1,0 +1,83 @@
+{
+  "iterationId": "441ddbe0",
+  "createdAt": "2026-04-04T18:34:13.709Z",
+  "config": {
+    "holdout": false,
+    "persona": "naive",
+    "degradation": false,
+    "target": "xds"
+  },
+  "label": "template-compositions-1120",
+  "prompts": [
+    {
+      "id": "dd-1",
+      "category": "data-display",
+      "prompt": "A table of users with sortable columns and search",
+      "expectedComponents": [
+        "XDSTextInput"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "dd-3",
+      "category": "data-display",
+      "prompt": "Show a grid of product cards with image, title, price, and add to cart button",
+      "expectedComponents": [
+        "XDSCard",
+        "XDSButton"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "ps-1",
+      "category": "page-setup",
+      "prompt": "Create a new page for a settings dashboard. It should have a header with the app title, a sidebar for navigation, and a main content area. Use the XDS theme system.",
+      "expectedComponents": [
+        "Theme",
+        "XDSLayout",
+        "XDSLayoutHeader",
+        "XDSLayoutContent",
+        "XDSLayoutPanel"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "ps-3",
+      "category": "page-setup",
+      "prompt": "Create an admin panel page layout with a fixed header, collapsible left sidebar, main content area, and a right panel for details. Wrap everything in the XDS theme.",
+      "expectedComponents": [
+        "Theme",
+        "XDSLayout",
+        "XDSLayoutHeader",
+        "XDSLayoutContent",
+        "XDSLayoutPanel"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "ps-4",
+      "category": "page-setup",
+      "prompt": "Create a product detail page with breadcrumb navigation showing Home > Category > Subcategory > Product Name. The page should have a header, product info section, and a back button.",
+      "expectedComponents": [
+        "XDSBreadcrumbs",
+        "XDSCard",
+        "XDSButton"
+      ],
+      "status": "pending"
+    },
+    {
+      "id": "dd-5",
+      "category": "data-display",
+      "prompt": "Build an email inbox view with a table showing sender, subject, date, and a preview snippet. Add row selection with checkboxes and a bulk actions bar that appears when items are selected.",
+      "expectedComponents": [
+        "XDSTable",
+        "XDSCheckboxInput",
+        "XDSDropdownMenu",
+        "XDSButton"
+      ],
+      "status": "pending"
+    }
+  ],
+  "totalPrompts": 6,
+  "completedPrompts": 0
+}

--- a/internal/vibe-tests/results/441ddbe0/previews/dd-1/xds.html
+++ b/internal/vibe-tests/results/441ddbe0/previews/dd-1/xds.html
@@ -1,0 +1,2494 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>dd-1 — xds</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; }
+    #root { min-height: 100%; }
+  </style>
+  <script type="module" crossorigin>(function(){const l=document.createElement("link").relList;if(l&&l.supports&&l.supports("modulepreload"))return;for(const n of document.querySelectorAll('link[rel="modulepreload"]'))a(n);new MutationObserver(n=>{for(const u of n)if(u.type==="childList")for(const c of u.addedNodes)c.tagName==="LINK"&&c.rel==="modulepreload"&&a(c)}).observe(document,{childList:!0,subtree:!0});function e(n){const u={};return n.integrity&&(u.integrity=n.integrity),n.referrerPolicy&&(u.referrerPolicy=n.referrerPolicy),n.crossOrigin==="use-credentials"?u.credentials="include":n.crossOrigin==="anonymous"?u.credentials="omit":u.credentials="same-origin",u}function a(n){if(n.ep)return;n.ep=!0;const u=e(n);fetch(n.href,u)}})();function r1(t){return t&&t.__esModule&&Object.prototype.hasOwnProperty.call(t,"default")?t.default:t}var Zo={exports:{}},Cu={};/**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var d1=Symbol.for("react.transitional.element"),m1=Symbol.for("react.fragment");function Vo(t,l,e){var a=null;if(e!==void 0&&(a=""+e),l.key!==void 0&&(a=""+l.key),"key"in l){e={};for(var n in l)n!=="key"&&(e[n]=l[n])}else e=l;return l=e.ref,{$$typeof:d1,type:t,key:a,ref:l!==void 0?l:null,props:e}}Cu.Fragment=m1;Cu.jsx=Vo;Cu.jsxs=Vo;Zo.exports=Cu;var g=Zo.exports,Qo={exports:{}},Ru={},Ko={exports:{}},Jo={};/**
+ * @license React
+ * scheduler.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */(function(t){function l(D,N){var _=D.length;D.push(N);t:for(;0<_;){var et=_-1>>>1,ut=D[et];if(0<n(ut,N))D[et]=N,D[_]=ut,_=et;else break t}}function e(D){return D.length===0?null:D[0]}function a(D){if(D.length===0)return null;var N=D[0],_=D.pop();if(_!==N){D[0]=_;t:for(var et=0,ut=D.length,je=ut>>>1;et<je;){var pn=2*(et+1)-1,Pu=D[pn],ce=pn+1,zn=D[ce];if(0>n(Pu,_))ce<ut&&0>n(zn,Pu)?(D[et]=zn,D[ce]=_,et=ce):(D[et]=Pu,D[pn]=_,et=pn);else if(ce<ut&&0>n(zn,_))D[et]=zn,D[ce]=_,et=ce;else break t}}return N}function n(D,N){var _=D.sortIndex-N.sortIndex;return _!==0?_:D.id-N.id}if(t.unstable_now=void 0,typeof performance=="object"&&typeof performance.now=="function"){var u=performance;t.unstable_now=function(){return u.now()}}else{var c=Date,i=c.now();t.unstable_now=function(){return c.now()-i}}var f=[],s=[],d=1,v=null,m=3,h=!1,S=!1,p=!1,z=!1,r=typeof setTimeout=="function"?setTimeout:null,o=typeof clearTimeout=="function"?clearTimeout:null,y=typeof setImmediate<"u"?setImmediate:null;function x(D){for(var N=e(s);N!==null;){if(N.callback===null)a(s);else if(N.startTime<=D)a(s),N.sortIndex=N.expirationTime,l(f,N);else break;N=e(s)}}function M(D){if(p=!1,x(D),!S)if(e(f)!==null)S=!0,O||(O=!0,J());else{var N=e(s);N!==null&&ue(M,N.startTime-D)}}var O=!1,E=-1,A=5,j=-1;function k(){return z?!0:!(t.unstable_now()-j<A)}function V(){if(z=!1,O){var D=t.unstable_now();j=D;var N=!0;try{t:{S=!1,p&&(p=!1,o(E),E=-1),h=!0;var _=m;try{l:{for(x(D),v=e(f);v!==null&&!(v.expirationTime>D&&k());){var et=v.callback;if(typeof et=="function"){v.callback=null,m=v.priorityLevel;var ut=et(v.expirationTime<=D);if(D=t.unstable_now(),typeof ut=="function"){v.callback=ut,x(D),N=!0;break l}v===e(f)&&a(f),x(D)}else a(f);v=e(f)}if(v!==null)N=!0;else{var je=e(s);je!==null&&ue(M,je.startTime-D),N=!1}}break t}finally{v=null,m=_,h=!1}N=void 0}}finally{N?J():O=!1}}}var J;if(typeof y=="function")J=function(){y(V)};else if(typeof MessageChannel<"u"){var wl=new MessageChannel,rl=wl.port2;wl.port1.onmessage=V,J=function(){rl.postMessage(null)}}else J=function(){r(V,0)};function ue(D,N){E=r(function(){D(t.unstable_now())},N)}t.unstable_IdlePriority=5,t.unstable_ImmediatePriority=1,t.unstable_LowPriority=4,t.unstable_NormalPriority=3,t.unstable_Profiling=null,t.unstable_UserBlockingPriority=2,t.unstable_cancelCallback=function(D){D.callback=null},t.unstable_forceFrameRate=function(D){0>D||125<D?console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"):A=0<D?Math.floor(1e3/D):5},t.unstable_getCurrentPriorityLevel=function(){return m},t.unstable_next=function(D){switch(m){case 1:case 2:case 3:var N=3;break;default:N=m}var _=m;m=N;try{return D()}finally{m=_}},t.unstable_requestPaint=function(){z=!0},t.unstable_runWithPriority=function(D,N){switch(D){case 1:case 2:case 3:case 4:case 5:break;default:D=3}var _=m;m=D;try{return N()}finally{m=_}},t.unstable_scheduleCallback=function(D,N,_){var et=t.unstable_now();switch(typeof _=="object"&&_!==null?(_=_.delay,_=typeof _=="number"&&0<_?et+_:et):_=et,D){case 1:var ut=-1;break;case 2:ut=250;break;case 5:ut=1073741823;break;case 4:ut=1e4;break;default:ut=5e3}return ut=_+ut,D={id:d++,callback:N,priorityLevel:D,startTime:_,expirationTime:ut,sortIndex:-1},_>et?(D.sortIndex=_,l(s,D),e(f)===null&&D===e(s)&&(p?(o(E),E=-1):p=!0,ue(M,_-et))):(D.sortIndex=ut,l(f,D),S||h||(S=!0,O||(O=!0,J()))),D},t.unstable_shouldYield=k,t.unstable_wrapCallback=function(D){var N=m;return function(){var _=m;m=N;try{return D.apply(this,arguments)}finally{m=_}}}})(Jo);Ko.exports=Jo;var y1=Ko.exports,Wo={exports:{}},C={};/**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var Vi=Symbol.for("react.transitional.element"),h1=Symbol.for("react.portal"),v1=Symbol.for("react.fragment"),g1=Symbol.for("react.strict_mode"),x1=Symbol.for("react.profiler"),b1=Symbol.for("react.consumer"),S1=Symbol.for("react.context"),p1=Symbol.for("react.forward_ref"),z1=Symbol.for("react.suspense"),T1=Symbol.for("react.memo"),Fo=Symbol.for("react.lazy"),E1=Symbol.for("react.activity"),ts=Symbol.iterator;function M1(t){return t===null||typeof t!="object"?null:(t=ts&&t[ts]||t["@@iterator"],typeof t=="function"?t:null)}var Io={isMounted:function(){return!1},enqueueForceUpdate:function(){},enqueueReplaceState:function(){},enqueueSetState:function(){}},Po=Object.assign,tr={};function ma(t,l,e){this.props=t,this.context=l,this.refs=tr,this.updater=e||Io}ma.prototype.isReactComponent={};ma.prototype.setState=function(t,l){if(typeof t!="object"&&typeof t!="function"&&t!=null)throw Error("takes an object of state variables to update or a function which returns an object of state variables.");this.updater.enqueueSetState(this,t,l,"setState")};ma.prototype.forceUpdate=function(t){this.updater.enqueueForceUpdate(this,t,"forceUpdate")};function lr(){}lr.prototype=ma.prototype;function Qi(t,l,e){this.props=t,this.context=l,this.refs=tr,this.updater=e||Io}var Ki=Qi.prototype=new lr;Ki.constructor=Qi;Po(Ki,ma.prototype);Ki.isPureReactComponent=!0;var ls=Array.isArray;function Vc(){}var I={H:null,A:null,T:null,S:null},er=Object.prototype.hasOwnProperty;function Ji(t,l,e){var a=e.ref;return{$$typeof:Vi,type:t,key:l,ref:a!==void 0?a:null,props:e}}function A1(t,l){return Ji(t.type,l,t.props)}function Wi(t){return typeof t=="object"&&t!==null&&t.$$typeof===Vi}function j1(t){var l={"=":"=0",":":"=2"};return"$"+t.replace(/[=:]/g,function(e){return l[e]})}var es=/\/+/g;function tc(t,l){return typeof t=="object"&&t!==null&&t.key!=null?j1(""+t.key):l.toString(36)}function k1(t){switch(t.status){case"fulfilled":return t.value;case"rejected":throw t.reason;default:switch(typeof t.status=="string"?t.then(Vc,Vc):(t.status="pending",t.then(function(l){t.status==="pending"&&(t.status="fulfilled",t.value=l)},function(l){t.status==="pending"&&(t.status="rejected",t.reason=l)})),t.status){case"fulfilled":return t.value;case"rejected":throw t.reason}}throw t}function we(t,l,e,a,n){var u=typeof t;(u==="undefined"||u==="boolean")&&(t=null);var c=!1;if(t===null)c=!0;else switch(u){case"bigint":case"string":case"number":c=!0;break;case"object":switch(t.$$typeof){case Vi:case h1:c=!0;break;case Fo:return c=t._init,we(c(t._payload),l,e,a,n)}}if(c)return n=n(t),c=a===""?"."+tc(t,0):a,ls(n)?(e="",c!=null&&(e=c.replace(es,"$&/")+"/"),we(n,l,e,"",function(s){return s})):n!=null&&(Wi(n)&&(n=A1(n,e+(n.key==null||t&&t.key===n.key?"":(""+n.key).replace(es,"$&/")+"/")+c)),l.push(n)),1;c=0;var i=a===""?".":a+":";if(ls(t))for(var f=0;f<t.length;f++)a=t[f],u=i+tc(a,f),c+=we(a,l,e,u,n);else if(f=M1(t),typeof f=="function")for(t=f.call(t),f=0;!(a=t.next()).done;)a=a.value,u=i+tc(a,f++),c+=we(a,l,e,u,n);else if(u==="object"){if(typeof t.then=="function")return we(k1(t),l,e,a,n);throw l=String(t),Error("Objects are not valid as a React child (found: "+(l==="[object Object]"?"object with keys {"+Object.keys(t).join(", ")+"}":l)+"). If you meant to render a collection of children, use an array instead.")}return c}function Tn(t,l,e){if(t==null)return t;var a=[],n=0;return we(t,a,"","",function(u){return l.call(e,u,n++)}),a}function O1(t){if(t._status===-1){var l=t._result;l=l(),l.then(function(e){(t._status===0||t._status===-1)&&(t._status=1,t._result=e)},function(e){(t._status===0||t._status===-1)&&(t._status=2,t._result=e)}),t._status===-1&&(t._status=0,t._result=l)}if(t._status===1)return t._result.default;throw t._result}var as=typeof reportError=="function"?reportError:function(t){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var l=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof t=="object"&&t!==null&&typeof t.message=="string"?String(t.message):String(t),error:t});if(!window.dispatchEvent(l))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",t);return}console.error(t)},D1={map:Tn,forEach:function(t,l,e){Tn(t,function(){l.apply(this,arguments)},e)},count:function(t){var l=0;return Tn(t,function(){l++}),l},toArray:function(t){return Tn(t,function(l){return l})||[]},only:function(t){if(!Wi(t))throw Error("React.Children.only expected to receive a single React element child.");return t}};C.Activity=E1;C.Children=D1;C.Component=ma;C.Fragment=v1;C.Profiler=x1;C.PureComponent=Qi;C.StrictMode=g1;C.Suspense=z1;C.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=I;C.__COMPILER_RUNTIME={__proto__:null,c:function(t){return I.H.useMemoCache(t)}};C.cache=function(t){return function(){return t.apply(null,arguments)}};C.cacheSignal=function(){return null};C.cloneElement=function(t,l,e){if(t==null)throw Error("The argument must be a React element, but you passed "+t+".");var a=Po({},t.props),n=t.key;if(l!=null)for(u in l.key!==void 0&&(n=""+l.key),l)!er.call(l,u)||u==="key"||u==="__self"||u==="__source"||u==="ref"&&l.ref===void 0||(a[u]=l[u]);var u=arguments.length-2;if(u===1)a.children=e;else if(1<u){for(var c=Array(u),i=0;i<u;i++)c[i]=arguments[i+2];a.children=c}return Ji(t.type,n,a)};C.createContext=function(t){return t={$$typeof:S1,_currentValue:t,_currentValue2:t,_threadCount:0,Provider:null,Consumer:null},t.Provider=t,t.Consumer={$$typeof:b1,_context:t},t};C.createElement=function(t,l,e){var a,n={},u=null;if(l!=null)for(a in l.key!==void 0&&(u=""+l.key),l)er.call(l,a)&&a!=="key"&&a!=="__self"&&a!=="__source"&&(n[a]=l[a]);var c=arguments.length-2;if(c===1)n.children=e;else if(1<c){for(var i=Array(c),f=0;f<c;f++)i[f]=arguments[f+2];n.children=i}if(t&&t.defaultProps)for(a in c=t.defaultProps,c)n[a]===void 0&&(n[a]=c[a]);return Ji(t,u,n)};C.createRef=function(){return{current:null}};C.forwardRef=function(t){return{$$typeof:p1,render:t}};C.isValidElement=Wi;C.lazy=function(t){return{$$typeof:Fo,_payload:{_status:-1,_result:t},_init:O1}};C.memo=function(t,l){return{$$typeof:T1,type:t,compare:l===void 0?null:l}};C.startTransition=function(t){var l=I.T,e={};I.T=e;try{var a=t(),n=I.S;n!==null&&n(e,a),typeof a=="object"&&a!==null&&typeof a.then=="function"&&a.then(Vc,as)}catch(u){as(u)}finally{l!==null&&e.types!==null&&(l.types=e.types),I.T=l}};C.unstable_useCacheRefresh=function(){return I.H.useCacheRefresh()};C.use=function(t){return I.H.use(t)};C.useActionState=function(t,l,e){return I.H.useActionState(t,l,e)};C.useCallback=function(t,l){return I.H.useCallback(t,l)};C.useContext=function(t){return I.H.useContext(t)};C.useDebugValue=function(){};C.useDeferredValue=function(t,l){return I.H.useDeferredValue(t,l)};C.useEffect=function(t,l){return I.H.useEffect(t,l)};C.useEffectEvent=function(t){return I.H.useEffectEvent(t)};C.useId=function(){return I.H.useId()};C.useImperativeHandle=function(t,l,e){return I.H.useImperativeHandle(t,l,e)};C.useInsertionEffect=function(t,l){return I.H.useInsertionEffect(t,l)};C.useLayoutEffect=function(t,l){return I.H.useLayoutEffect(t,l)};C.useMemo=function(t,l){return I.H.useMemo(t,l)};C.useOptimistic=function(t,l){return I.H.useOptimistic(t,l)};C.useReducer=function(t,l,e){return I.H.useReducer(t,l,e)};C.useRef=function(t){return I.H.useRef(t)};C.useState=function(t){return I.H.useState(t)};C.useSyncExternalStore=function(t,l,e){return I.H.useSyncExternalStore(t,l,e)};C.useTransition=function(){return I.H.useTransition()};C.version="19.2.4";Wo.exports=C;var b=Wo.exports;const ns=r1(b);var ar={exports:{}},kt={};/**
+ * @license React
+ * react-dom.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var w1=b;function nr(t){var l="https://react.dev/errors/"+t;if(1<arguments.length){l+="?args[]="+encodeURIComponent(arguments[1]);for(var e=2;e<arguments.length;e++)l+="&args[]="+encodeURIComponent(arguments[e])}return"Minified React error #"+t+"; visit "+l+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function Nl(){}var jt={d:{f:Nl,r:function(){throw Error(nr(522))},D:Nl,C:Nl,L:Nl,m:Nl,X:Nl,S:Nl,M:Nl},p:0,findDOMNode:null},N1=Symbol.for("react.portal");function _1(t,l,e){var a=3<arguments.length&&arguments[3]!==void 0?arguments[3]:null;return{$$typeof:N1,key:a==null?null:""+a,children:t,containerInfo:l,implementation:e}}var Ca=w1.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;function $u(t,l){if(t==="font")return"";if(typeof l=="string")return l==="use-credentials"?l:""}kt.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=jt;kt.createPortal=function(t,l){var e=2<arguments.length&&arguments[2]!==void 0?arguments[2]:null;if(!l||l.nodeType!==1&&l.nodeType!==9&&l.nodeType!==11)throw Error(nr(299));return _1(t,l,null,e)};kt.flushSync=function(t){var l=Ca.T,e=jt.p;try{if(Ca.T=null,jt.p=2,t)return t()}finally{Ca.T=l,jt.p=e,jt.d.f()}};kt.preconnect=function(t,l){typeof t=="string"&&(l?(l=l.crossOrigin,l=typeof l=="string"?l==="use-credentials"?l:"":void 0):l=null,jt.d.C(t,l))};kt.prefetchDNS=function(t){typeof t=="string"&&jt.d.D(t)};kt.preinit=function(t,l){if(typeof t=="string"&&l&&typeof l.as=="string"){var e=l.as,a=$u(e,l.crossOrigin),n=typeof l.integrity=="string"?l.integrity:void 0,u=typeof l.fetchPriority=="string"?l.fetchPriority:void 0;e==="style"?jt.d.S(t,typeof l.precedence=="string"?l.precedence:void 0,{crossOrigin:a,integrity:n,fetchPriority:u}):e==="script"&&jt.d.X(t,{crossOrigin:a,integrity:n,fetchPriority:u,nonce:typeof l.nonce=="string"?l.nonce:void 0})}};kt.preinitModule=function(t,l){if(typeof t=="string")if(typeof l=="object"&&l!==null){if(l.as==null||l.as==="script"){var e=$u(l.as,l.crossOrigin);jt.d.M(t,{crossOrigin:e,integrity:typeof l.integrity=="string"?l.integrity:void 0,nonce:typeof l.nonce=="string"?l.nonce:void 0})}}else l==null&&jt.d.M(t)};kt.preload=function(t,l){if(typeof t=="string"&&typeof l=="object"&&l!==null&&typeof l.as=="string"){var e=l.as,a=$u(e,l.crossOrigin);jt.d.L(t,e,{crossOrigin:a,integrity:typeof l.integrity=="string"?l.integrity:void 0,nonce:typeof l.nonce=="string"?l.nonce:void 0,type:typeof l.type=="string"?l.type:void 0,fetchPriority:typeof l.fetchPriority=="string"?l.fetchPriority:void 0,referrerPolicy:typeof l.referrerPolicy=="string"?l.referrerPolicy:void 0,imageSrcSet:typeof l.imageSrcSet=="string"?l.imageSrcSet:void 0,imageSizes:typeof l.imageSizes=="string"?l.imageSizes:void 0,media:typeof l.media=="string"?l.media:void 0})}};kt.preloadModule=function(t,l){if(typeof t=="string")if(l){var e=$u(l.as,l.crossOrigin);jt.d.m(t,{as:typeof l.as=="string"&&l.as!=="script"?l.as:void 0,crossOrigin:e,integrity:typeof l.integrity=="string"?l.integrity:void 0})}else jt.d.m(t)};kt.requestFormReset=function(t){jt.d.r(t)};kt.unstable_batchedUpdates=function(t,l){return t(l)};kt.useFormState=function(t,l,e){return Ca.H.useFormState(t,l,e)};kt.useFormStatus=function(){return Ca.H.useHostTransitionStatus()};kt.version="19.2.4";function ur(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(ur)}catch(t){console.error(t)}}ur(),ar.exports=kt;var C1=ar.exports;/**
+ * @license React
+ * react-dom-client.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var ht=y1,cr=b,R1=C1;function T(t){var l="https://react.dev/errors/"+t;if(1<arguments.length){l+="?args[]="+encodeURIComponent(arguments[1]);for(var e=2;e<arguments.length;e++)l+="&args[]="+encodeURIComponent(arguments[e])}return"Minified React error #"+t+"; visit "+l+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function ir(t){return!(!t||t.nodeType!==1&&t.nodeType!==9&&t.nodeType!==11)}function sn(t){var l=t,e=t;if(t.alternate)for(;l.return;)l=l.return;else{t=l;do l=t,l.flags&4098&&(e=l.return),t=l.return;while(t)}return l.tag===3?e:null}function fr(t){if(t.tag===13){var l=t.memoizedState;if(l===null&&(t=t.alternate,t!==null&&(l=t.memoizedState)),l!==null)return l.dehydrated}return null}function sr(t){if(t.tag===31){var l=t.memoizedState;if(l===null&&(t=t.alternate,t!==null&&(l=t.memoizedState)),l!==null)return l.dehydrated}return null}function us(t){if(sn(t)!==t)throw Error(T(188))}function $1(t){var l=t.alternate;if(!l){if(l=sn(t),l===null)throw Error(T(188));return l!==t?null:t}for(var e=t,a=l;;){var n=e.return;if(n===null)break;var u=n.alternate;if(u===null){if(a=n.return,a!==null){e=a;continue}break}if(n.child===u.child){for(u=n.child;u;){if(u===e)return us(n),t;if(u===a)return us(n),l;u=u.sibling}throw Error(T(188))}if(e.return!==a.return)e=n,a=u;else{for(var c=!1,i=n.child;i;){if(i===e){c=!0,e=n,a=u;break}if(i===a){c=!0,a=n,e=u;break}i=i.sibling}if(!c){for(i=u.child;i;){if(i===e){c=!0,e=u,a=n;break}if(i===a){c=!0,a=u,e=n;break}i=i.sibling}if(!c)throw Error(T(189))}}if(e.alternate!==a)throw Error(T(190))}if(e.tag!==3)throw Error(T(188));return e.stateNode.current===e?t:l}function or(t){var l=t.tag;if(l===5||l===26||l===27||l===6)return t;for(t=t.child;t!==null;){if(l=or(t),l!==null)return l;t=t.sibling}return null}var tt=Object.assign,U1=Symbol.for("react.element"),En=Symbol.for("react.transitional.element"),Oa=Symbol.for("react.portal"),Ce=Symbol.for("react.fragment"),rr=Symbol.for("react.strict_mode"),Qc=Symbol.for("react.profiler"),dr=Symbol.for("react.consumer"),bl=Symbol.for("react.context"),Fi=Symbol.for("react.forward_ref"),Kc=Symbol.for("react.suspense"),Jc=Symbol.for("react.suspense_list"),Ii=Symbol.for("react.memo"),_l=Symbol.for("react.lazy"),Wc=Symbol.for("react.activity"),H1=Symbol.for("react.memo_cache_sentinel"),cs=Symbol.iterator;function pa(t){return t===null||typeof t!="object"?null:(t=cs&&t[cs]||t["@@iterator"],typeof t=="function"?t:null)}var q1=Symbol.for("react.client.reference");function Fc(t){if(t==null)return null;if(typeof t=="function")return t.$$typeof===q1?null:t.displayName||t.name||null;if(typeof t=="string")return t;switch(t){case Ce:return"Fragment";case Qc:return"Profiler";case rr:return"StrictMode";case Kc:return"Suspense";case Jc:return"SuspenseList";case Wc:return"Activity"}if(typeof t=="object")switch(t.$$typeof){case Oa:return"Portal";case bl:return t.displayName||"Context";case dr:return(t._context.displayName||"Context")+".Consumer";case Fi:var l=t.render;return t=t.displayName,t||(t=l.displayName||l.name||"",t=t!==""?"ForwardRef("+t+")":"ForwardRef"),t;case Ii:return l=t.displayName||null,l!==null?l:Fc(t.type)||"Memo";case _l:l=t._payload,t=t._init;try{return Fc(t(l))}catch{}}return null}var Da=Array.isArray,w=cr.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,X=R1.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,de={pending:!1,data:null,method:null,action:null},Ic=[],Re=-1;function sl(t){return{current:t}}function bt(t){0>Re||(t.current=Ic[Re],Ic[Re]=null,Re--)}function K(t,l){Re++,Ic[Re]=t.current,t.current=l}var fl=sl(null),Ka=sl(null),Gl=sl(null),uu=sl(null);function cu(t,l){switch(K(Gl,l),K(Ka,t),K(fl,null),l.nodeType){case 9:case 11:t=(t=l.documentElement)&&(t=t.namespaceURI)?mo(t):0;break;default:if(t=l.tagName,l=l.namespaceURI)l=mo(l),t=N0(l,t);else switch(t){case"svg":t=1;break;case"math":t=2;break;default:t=0}}bt(fl),K(fl,t)}function la(){bt(fl),bt(Ka),bt(Gl)}function Pc(t){t.memoizedState!==null&&K(uu,t);var l=fl.current,e=N0(l,t.type);l!==e&&(K(Ka,t),K(fl,e))}function iu(t){Ka.current===t&&(bt(fl),bt(Ka)),uu.current===t&&(bt(uu),un._currentValue=de)}var lc,is;function fe(t){if(lc===void 0)try{throw Error()}catch(e){var l=e.stack.trim().match(/\n( *(at )?)/);lc=l&&l[1]||"",is=-1<e.stack.indexOf(`
+    at`)?" (<anonymous>)":-1<e.stack.indexOf("@")?"@unknown:0:0":""}return`
+`+lc+t+is}var ec=!1;function ac(t,l){if(!t||ec)return"";ec=!0;var e=Error.prepareStackTrace;Error.prepareStackTrace=void 0;try{var a={DetermineComponentFrameRoot:function(){try{if(l){var v=function(){throw Error()};if(Object.defineProperty(v.prototype,"props",{set:function(){throw Error()}}),typeof Reflect=="object"&&Reflect.construct){try{Reflect.construct(v,[])}catch(h){var m=h}Reflect.construct(t,[],v)}else{try{v.call()}catch(h){m=h}t.call(v.prototype)}}else{try{throw Error()}catch(h){m=h}(v=t())&&typeof v.catch=="function"&&v.catch(function(){})}}catch(h){if(h&&m&&typeof h.stack=="string")return[h.stack,m.stack]}return[null,null]}};a.DetermineComponentFrameRoot.displayName="DetermineComponentFrameRoot";var n=Object.getOwnPropertyDescriptor(a.DetermineComponentFrameRoot,"name");n&&n.configurable&&Object.defineProperty(a.DetermineComponentFrameRoot,"name",{value:"DetermineComponentFrameRoot"});var u=a.DetermineComponentFrameRoot(),c=u[0],i=u[1];if(c&&i){var f=c.split(`
+`),s=i.split(`
+`);for(n=a=0;a<f.length&&!f[a].includes("DetermineComponentFrameRoot");)a++;for(;n<s.length&&!s[n].includes("DetermineComponentFrameRoot");)n++;if(a===f.length||n===s.length)for(a=f.length-1,n=s.length-1;1<=a&&0<=n&&f[a]!==s[n];)n--;for(;1<=a&&0<=n;a--,n--)if(f[a]!==s[n]){if(a!==1||n!==1)do if(a--,n--,0>n||f[a]!==s[n]){var d=`
+`+f[a].replace(" at new "," at ");return t.displayName&&d.includes("<anonymous>")&&(d=d.replace("<anonymous>",t.displayName)),d}while(1<=a&&0<=n);break}}}finally{ec=!1,Error.prepareStackTrace=e}return(e=t?t.displayName||t.name:"")?fe(e):""}function B1(t,l){switch(t.tag){case 26:case 27:case 5:return fe(t.type);case 16:return fe("Lazy");case 13:return t.child!==l&&l!==null?fe("Suspense Fallback"):fe("Suspense");case 19:return fe("SuspenseList");case 0:case 15:return ac(t.type,!1);case 11:return ac(t.type.render,!1);case 1:return ac(t.type,!0);case 31:return fe("Activity");default:return""}}function fs(t){try{var l="",e=null;do l+=B1(t,e),e=t,t=t.return;while(t);return l}catch(a){return`
+Error generating stack: `+a.message+`
+`+a.stack}}var ti=Object.prototype.hasOwnProperty,Pi=ht.unstable_scheduleCallback,nc=ht.unstable_cancelCallback,X1=ht.unstable_shouldYield,L1=ht.unstable_requestPaint,Bt=ht.unstable_now,Y1=ht.unstable_getCurrentPriorityLevel,mr=ht.unstable_ImmediatePriority,yr=ht.unstable_UserBlockingPriority,fu=ht.unstable_NormalPriority,G1=ht.unstable_LowPriority,hr=ht.unstable_IdlePriority,Z1=ht.log,V1=ht.unstable_setDisableYieldValue,on=null,Xt=null;function ql(t){if(typeof Z1=="function"&&V1(t),Xt&&typeof Xt.setStrictMode=="function")try{Xt.setStrictMode(on,t)}catch{}}var Lt=Math.clz32?Math.clz32:J1,Q1=Math.log,K1=Math.LN2;function J1(t){return t>>>=0,t===0?32:31-(Q1(t)/K1|0)|0}var Mn=256,An=262144,jn=4194304;function se(t){var l=t&42;if(l!==0)return l;switch(t&-t){case 1:return 1;case 2:return 2;case 4:return 4;case 8:return 8;case 16:return 16;case 32:return 32;case 64:return 64;case 128:return 128;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:return t&261888;case 262144:case 524288:case 1048576:case 2097152:return t&3932160;case 4194304:case 8388608:case 16777216:case 33554432:return t&62914560;case 67108864:return 67108864;case 134217728:return 134217728;case 268435456:return 268435456;case 536870912:return 536870912;case 1073741824:return 0;default:return t}}function Uu(t,l,e){var a=t.pendingLanes;if(a===0)return 0;var n=0,u=t.suspendedLanes,c=t.pingedLanes;t=t.warmLanes;var i=a&134217727;return i!==0?(a=i&~u,a!==0?n=se(a):(c&=i,c!==0?n=se(c):e||(e=i&~t,e!==0&&(n=se(e))))):(i=a&~u,i!==0?n=se(i):c!==0?n=se(c):e||(e=a&~t,e!==0&&(n=se(e)))),n===0?0:l!==0&&l!==n&&!(l&u)&&(u=n&-n,e=l&-l,u>=e||u===32&&(e&4194048)!==0)?l:n}function rn(t,l){return(t.pendingLanes&~(t.suspendedLanes&~t.pingedLanes)&l)===0}function W1(t,l){switch(t){case 1:case 2:case 4:case 8:case 64:return l+250;case 16:case 32:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:return l+5e3;case 4194304:case 8388608:case 16777216:case 33554432:return-1;case 67108864:case 134217728:case 268435456:case 536870912:case 1073741824:return-1;default:return-1}}function vr(){var t=jn;return jn<<=1,!(jn&62914560)&&(jn=4194304),t}function uc(t){for(var l=[],e=0;31>e;e++)l.push(t);return l}function dn(t,l){t.pendingLanes|=l,l!==268435456&&(t.suspendedLanes=0,t.pingedLanes=0,t.warmLanes=0)}function F1(t,l,e,a,n,u){var c=t.pendingLanes;t.pendingLanes=e,t.suspendedLanes=0,t.pingedLanes=0,t.warmLanes=0,t.expiredLanes&=e,t.entangledLanes&=e,t.errorRecoveryDisabledLanes&=e,t.shellSuspendCounter=0;var i=t.entanglements,f=t.expirationTimes,s=t.hiddenUpdates;for(e=c&~e;0<e;){var d=31-Lt(e),v=1<<d;i[d]=0,f[d]=-1;var m=s[d];if(m!==null)for(s[d]=null,d=0;d<m.length;d++){var h=m[d];h!==null&&(h.lane&=-536870913)}e&=~v}a!==0&&gr(t,a,0),u!==0&&n===0&&t.tag!==0&&(t.suspendedLanes|=u&~(c&~l))}function gr(t,l,e){t.pendingLanes|=l,t.suspendedLanes&=~l;var a=31-Lt(l);t.entangledLanes|=l,t.entanglements[a]=t.entanglements[a]|1073741824|e&261930}function xr(t,l){var e=t.entangledLanes|=l;for(t=t.entanglements;e;){var a=31-Lt(e),n=1<<a;n&l|t[a]&l&&(t[a]|=l),e&=~n}}function br(t,l){var e=l&-l;return e=e&42?1:tf(e),e&(t.suspendedLanes|l)?0:e}function tf(t){switch(t){case 2:t=1;break;case 8:t=4;break;case 32:t=16;break;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:case 4194304:case 8388608:case 16777216:case 33554432:t=128;break;case 268435456:t=134217728;break;default:t=0}return t}function lf(t){return t&=-t,2<t?8<t?t&134217727?32:268435456:8:2}function Sr(){var t=X.p;return t!==0?t:(t=window.event,t===void 0?32:Y0(t.type))}function ss(t,l){var e=X.p;try{return X.p=t,l()}finally{X.p=e}}var ae=Math.random().toString(36).slice(2),zt="__reactFiber$"+ae,Ct="__reactProps$"+ae,ya="__reactContainer$"+ae,li="__reactEvents$"+ae,I1="__reactListeners$"+ae,P1="__reactHandles$"+ae,os="__reactResources$"+ae,mn="__reactMarker$"+ae;function ef(t){delete t[zt],delete t[Ct],delete t[li],delete t[I1],delete t[P1]}function $e(t){var l=t[zt];if(l)return l;for(var e=t.parentNode;e;){if(l=e[ya]||e[zt]){if(e=l.alternate,l.child!==null||e!==null&&e.child!==null)for(t=xo(t);t!==null;){if(e=t[zt])return e;t=xo(t)}return l}t=e,e=t.parentNode}return null}function ha(t){if(t=t[zt]||t[ya]){var l=t.tag;if(l===5||l===6||l===13||l===31||l===26||l===27||l===3)return t}return null}function wa(t){var l=t.tag;if(l===5||l===26||l===27||l===6)return t.stateNode;throw Error(T(33))}function Ke(t){var l=t[os];return l||(l=t[os]={hoistableStyles:new Map,hoistableScripts:new Map}),l}function xt(t){t[mn]=!0}var pr=new Set,zr={};function ze(t,l){ea(t,l),ea(t+"Capture",l)}function ea(t,l){for(zr[t]=l,t=0;t<l.length;t++)pr.add(l[t])}var tm=RegExp("^[:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD][:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$"),rs={},ds={};function lm(t){return ti.call(ds,t)?!0:ti.call(rs,t)?!1:tm.test(t)?ds[t]=!0:(rs[t]=!0,!1)}function Gn(t,l,e){if(lm(l))if(e===null)t.removeAttribute(l);else{switch(typeof e){case"undefined":case"function":case"symbol":t.removeAttribute(l);return;case"boolean":var a=l.toLowerCase().slice(0,5);if(a!=="data-"&&a!=="aria-"){t.removeAttribute(l);return}}t.setAttribute(l,""+e)}}function kn(t,l,e){if(e===null)t.removeAttribute(l);else{switch(typeof e){case"undefined":case"function":case"symbol":case"boolean":t.removeAttribute(l);return}t.setAttribute(l,""+e)}}function dl(t,l,e,a){if(a===null)t.removeAttribute(e);else{switch(typeof a){case"undefined":case"function":case"symbol":case"boolean":t.removeAttribute(e);return}t.setAttributeNS(l,e,""+a)}}function Qt(t){switch(typeof t){case"bigint":case"boolean":case"number":case"string":case"undefined":return t;case"object":return t;default:return""}}function Tr(t){var l=t.type;return(t=t.nodeName)&&t.toLowerCase()==="input"&&(l==="checkbox"||l==="radio")}function em(t,l,e){var a=Object.getOwnPropertyDescriptor(t.constructor.prototype,l);if(!t.hasOwnProperty(l)&&typeof a<"u"&&typeof a.get=="function"&&typeof a.set=="function"){var n=a.get,u=a.set;return Object.defineProperty(t,l,{configurable:!0,get:function(){return n.call(this)},set:function(c){e=""+c,u.call(this,c)}}),Object.defineProperty(t,l,{enumerable:a.enumerable}),{getValue:function(){return e},setValue:function(c){e=""+c},stopTracking:function(){t._valueTracker=null,delete t[l]}}}}function ei(t){if(!t._valueTracker){var l=Tr(t)?"checked":"value";t._valueTracker=em(t,l,""+t[l])}}function Er(t){if(!t)return!1;var l=t._valueTracker;if(!l)return!0;var e=l.getValue(),a="";return t&&(a=Tr(t)?t.checked?"true":"false":t.value),t=a,t!==e?(l.setValue(t),!0):!1}function su(t){if(t=t||(typeof document<"u"?document:void 0),typeof t>"u")return null;try{return t.activeElement||t.body}catch{return t.body}}var am=/[\n"\\]/g;function Wt(t){return t.replace(am,function(l){return"\\"+l.charCodeAt(0).toString(16)+" "})}function ai(t,l,e,a,n,u,c,i){t.name="",c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"?t.type=c:t.removeAttribute("type"),l!=null?c==="number"?(l===0&&t.value===""||t.value!=l)&&(t.value=""+Qt(l)):t.value!==""+Qt(l)&&(t.value=""+Qt(l)):c!=="submit"&&c!=="reset"||t.removeAttribute("value"),l!=null?ni(t,c,Qt(l)):e!=null?ni(t,c,Qt(e)):a!=null&&t.removeAttribute("value"),n==null&&u!=null&&(t.defaultChecked=!!u),n!=null&&(t.checked=n&&typeof n!="function"&&typeof n!="symbol"),i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"?t.name=""+Qt(i):t.removeAttribute("name")}function Mr(t,l,e,a,n,u,c,i){if(u!=null&&typeof u!="function"&&typeof u!="symbol"&&typeof u!="boolean"&&(t.type=u),l!=null||e!=null){if(!(u!=="submit"&&u!=="reset"||l!=null)){ei(t);return}e=e!=null?""+Qt(e):"",l=l!=null?""+Qt(l):e,i||l===t.value||(t.value=l),t.defaultValue=l}a=a??n,a=typeof a!="function"&&typeof a!="symbol"&&!!a,t.checked=i?t.checked:!!a,t.defaultChecked=!!a,c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"&&(t.name=c),ei(t)}function ni(t,l,e){l==="number"&&su(t.ownerDocument)===t||t.defaultValue===""+e||(t.defaultValue=""+e)}function Je(t,l,e,a){if(t=t.options,l){l={};for(var n=0;n<e.length;n++)l["$"+e[n]]=!0;for(e=0;e<t.length;e++)n=l.hasOwnProperty("$"+t[e].value),t[e].selected!==n&&(t[e].selected=n),n&&a&&(t[e].defaultSelected=!0)}else{for(e=""+Qt(e),l=null,n=0;n<t.length;n++){if(t[n].value===e){t[n].selected=!0,a&&(t[n].defaultSelected=!0);return}l!==null||t[n].disabled||(l=t[n])}l!==null&&(l.selected=!0)}}function Ar(t,l,e){if(l!=null&&(l=""+Qt(l),l!==t.value&&(t.value=l),e==null)){t.defaultValue!==l&&(t.defaultValue=l);return}t.defaultValue=e!=null?""+Qt(e):""}function jr(t,l,e,a){if(l==null){if(a!=null){if(e!=null)throw Error(T(92));if(Da(a)){if(1<a.length)throw Error(T(93));a=a[0]}e=a}e==null&&(e=""),l=e}e=Qt(l),t.defaultValue=e,a=t.textContent,a===e&&a!==""&&a!==null&&(t.value=a),ei(t)}function aa(t,l){if(l){var e=t.firstChild;if(e&&e===t.lastChild&&e.nodeType===3){e.nodeValue=l;return}}t.textContent=l}var nm=new Set("animationIterationCount aspectRatio borderImageOutset borderImageSlice borderImageWidth boxFlex boxFlexGroup boxOrdinalGroup columnCount columns flex flexGrow flexPositive flexShrink flexNegative flexOrder gridArea gridRow gridRowEnd gridRowSpan gridRowStart gridColumn gridColumnEnd gridColumnSpan gridColumnStart fontWeight lineClamp lineHeight opacity order orphans scale tabSize widows zIndex zoom fillOpacity floodOpacity stopOpacity strokeDasharray strokeDashoffset strokeMiterlimit strokeOpacity strokeWidth MozAnimationIterationCount MozBoxFlex MozBoxFlexGroup MozLineClamp msAnimationIterationCount msFlex msZoom msFlexGrow msFlexNegative msFlexOrder msFlexPositive msFlexShrink msGridColumn msGridColumnSpan msGridRow msGridRowSpan WebkitAnimationIterationCount WebkitBoxFlex WebKitBoxFlexGroup WebkitBoxOrdinalGroup WebkitColumnCount WebkitColumns WebkitFlex WebkitFlexGrow WebkitFlexPositive WebkitFlexShrink WebkitLineClamp".split(" "));function ms(t,l,e){var a=l.indexOf("--")===0;e==null||typeof e=="boolean"||e===""?a?t.setProperty(l,""):l==="float"?t.cssFloat="":t[l]="":a?t.setProperty(l,e):typeof e!="number"||e===0||nm.has(l)?l==="float"?t.cssFloat=e:t[l]=(""+e).trim():t[l]=e+"px"}function kr(t,l,e){if(l!=null&&typeof l!="object")throw Error(T(62));if(t=t.style,e!=null){for(var a in e)!e.hasOwnProperty(a)||l!=null&&l.hasOwnProperty(a)||(a.indexOf("--")===0?t.setProperty(a,""):a==="float"?t.cssFloat="":t[a]="");for(var n in l)a=l[n],l.hasOwnProperty(n)&&e[n]!==a&&ms(t,n,a)}else for(var u in l)l.hasOwnProperty(u)&&ms(t,u,l[u])}function af(t){if(t.indexOf("-")===-1)return!1;switch(t){case"annotation-xml":case"color-profile":case"font-face":case"font-face-src":case"font-face-uri":case"font-face-format":case"font-face-name":case"missing-glyph":return!1;default:return!0}}var um=new Map([["acceptCharset","accept-charset"],["htmlFor","for"],["httpEquiv","http-equiv"],["crossOrigin","crossorigin"],["accentHeight","accent-height"],["alignmentBaseline","alignment-baseline"],["arabicForm","arabic-form"],["baselineShift","baseline-shift"],["capHeight","cap-height"],["clipPath","clip-path"],["clipRule","clip-rule"],["colorInterpolation","color-interpolation"],["colorInterpolationFilters","color-interpolation-filters"],["colorProfile","color-profile"],["colorRendering","color-rendering"],["dominantBaseline","dominant-baseline"],["enableBackground","enable-background"],["fillOpacity","fill-opacity"],["fillRule","fill-rule"],["floodColor","flood-color"],["floodOpacity","flood-opacity"],["fontFamily","font-family"],["fontSize","font-size"],["fontSizeAdjust","font-size-adjust"],["fontStretch","font-stretch"],["fontStyle","font-style"],["fontVariant","font-variant"],["fontWeight","font-weight"],["glyphName","glyph-name"],["glyphOrientationHorizontal","glyph-orientation-horizontal"],["glyphOrientationVertical","glyph-orientation-vertical"],["horizAdvX","horiz-adv-x"],["horizOriginX","horiz-origin-x"],["imageRendering","image-rendering"],["letterSpacing","letter-spacing"],["lightingColor","lighting-color"],["markerEnd","marker-end"],["markerMid","marker-mid"],["markerStart","marker-start"],["overlinePosition","overline-position"],["overlineThickness","overline-thickness"],["paintOrder","paint-order"],["panose-1","panose-1"],["pointerEvents","pointer-events"],["renderingIntent","rendering-intent"],["shapeRendering","shape-rendering"],["stopColor","stop-color"],["stopOpacity","stop-opacity"],["strikethroughPosition","strikethrough-position"],["strikethroughThickness","strikethrough-thickness"],["strokeDasharray","stroke-dasharray"],["strokeDashoffset","stroke-dashoffset"],["strokeLinecap","stroke-linecap"],["strokeLinejoin","stroke-linejoin"],["strokeMiterlimit","stroke-miterlimit"],["strokeOpacity","stroke-opacity"],["strokeWidth","stroke-width"],["textAnchor","text-anchor"],["textDecoration","text-decoration"],["textRendering","text-rendering"],["transformOrigin","transform-origin"],["underlinePosition","underline-position"],["underlineThickness","underline-thickness"],["unicodeBidi","unicode-bidi"],["unicodeRange","unicode-range"],["unitsPerEm","units-per-em"],["vAlphabetic","v-alphabetic"],["vHanging","v-hanging"],["vIdeographic","v-ideographic"],["vMathematical","v-mathematical"],["vectorEffect","vector-effect"],["vertAdvY","vert-adv-y"],["vertOriginX","vert-origin-x"],["vertOriginY","vert-origin-y"],["wordSpacing","word-spacing"],["writingMode","writing-mode"],["xmlnsXlink","xmlns:xlink"],["xHeight","x-height"]]),cm=/^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i;function Zn(t){return cm.test(""+t)?"javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')":t}function Sl(){}var ui=null;function nf(t){return t=t.target||t.srcElement||window,t.correspondingUseElement&&(t=t.correspondingUseElement),t.nodeType===3?t.parentNode:t}var Ue=null,We=null;function ys(t){var l=ha(t);if(l&&(t=l.stateNode)){var e=t[Ct]||null;t:switch(t=l.stateNode,l.type){case"input":if(ai(t,e.value,e.defaultValue,e.defaultValue,e.checked,e.defaultChecked,e.type,e.name),l=e.name,e.type==="radio"&&l!=null){for(e=t;e.parentNode;)e=e.parentNode;for(e=e.querySelectorAll('input[name="'+Wt(""+l)+'"][type="radio"]'),l=0;l<e.length;l++){var a=e[l];if(a!==t&&a.form===t.form){var n=a[Ct]||null;if(!n)throw Error(T(90));ai(a,n.value,n.defaultValue,n.defaultValue,n.checked,n.defaultChecked,n.type,n.name)}}for(l=0;l<e.length;l++)a=e[l],a.form===t.form&&Er(a)}break t;case"textarea":Ar(t,e.value,e.defaultValue);break t;case"select":l=e.value,l!=null&&Je(t,!!e.multiple,l,!1)}}}var cc=!1;function Or(t,l,e){if(cc)return t(l,e);cc=!0;try{var a=t(l);return a}finally{if(cc=!1,(Ue!==null||We!==null)&&(Ju(),Ue&&(l=Ue,t=We,We=Ue=null,ys(l),t)))for(l=0;l<t.length;l++)ys(t[l])}}function Ja(t,l){var e=t.stateNode;if(e===null)return null;var a=e[Ct]||null;if(a===null)return null;e=a[l];t:switch(l){case"onClick":case"onClickCapture":case"onDoubleClick":case"onDoubleClickCapture":case"onMouseDown":case"onMouseDownCapture":case"onMouseMove":case"onMouseMoveCapture":case"onMouseUp":case"onMouseUpCapture":case"onMouseEnter":(a=!a.disabled)||(t=t.type,a=!(t==="button"||t==="input"||t==="select"||t==="textarea")),t=!a;break t;default:t=!1}if(t)return null;if(e&&typeof e!="function")throw Error(T(231,l,typeof e));return e}var Ml=!(typeof window>"u"||typeof window.document>"u"||typeof window.document.createElement>"u"),ci=!1;if(Ml)try{var za={};Object.defineProperty(za,"passive",{get:function(){ci=!0}}),window.addEventListener("test",za,za),window.removeEventListener("test",za,za)}catch{ci=!1}var Bl=null,uf=null,Vn=null;function Dr(){if(Vn)return Vn;var t,l=uf,e=l.length,a,n="value"in Bl?Bl.value:Bl.textContent,u=n.length;for(t=0;t<e&&l[t]===n[t];t++);var c=e-t;for(a=1;a<=c&&l[e-a]===n[u-a];a++);return Vn=n.slice(t,1<a?1-a:void 0)}function Qn(t){var l=t.keyCode;return"charCode"in t?(t=t.charCode,t===0&&l===13&&(t=13)):t=l,t===10&&(t=13),32<=t||t===13?t:0}function On(){return!0}function hs(){return!1}function Rt(t){function l(e,a,n,u,c){this._reactName=e,this._targetInst=n,this.type=a,this.nativeEvent=u,this.target=c,this.currentTarget=null;for(var i in t)t.hasOwnProperty(i)&&(e=t[i],this[i]=e?e(u):u[i]);return this.isDefaultPrevented=(u.defaultPrevented!=null?u.defaultPrevented:u.returnValue===!1)?On:hs,this.isPropagationStopped=hs,this}return tt(l.prototype,{preventDefault:function(){this.defaultPrevented=!0;var e=this.nativeEvent;e&&(e.preventDefault?e.preventDefault():typeof e.returnValue!="unknown"&&(e.returnValue=!1),this.isDefaultPrevented=On)},stopPropagation:function(){var e=this.nativeEvent;e&&(e.stopPropagation?e.stopPropagation():typeof e.cancelBubble!="unknown"&&(e.cancelBubble=!0),this.isPropagationStopped=On)},persist:function(){},isPersistent:On}),l}var Te={eventPhase:0,bubbles:0,cancelable:0,timeStamp:function(t){return t.timeStamp||Date.now()},defaultPrevented:0,isTrusted:0},Hu=Rt(Te),yn=tt({},Te,{view:0,detail:0}),im=Rt(yn),ic,fc,Ta,qu=tt({},yn,{screenX:0,screenY:0,clientX:0,clientY:0,pageX:0,pageY:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,getModifierState:cf,button:0,buttons:0,relatedTarget:function(t){return t.relatedTarget===void 0?t.fromElement===t.srcElement?t.toElement:t.fromElement:t.relatedTarget},movementX:function(t){return"movementX"in t?t.movementX:(t!==Ta&&(Ta&&t.type==="mousemove"?(ic=t.screenX-Ta.screenX,fc=t.screenY-Ta.screenY):fc=ic=0,Ta=t),ic)},movementY:function(t){return"movementY"in t?t.movementY:fc}}),vs=Rt(qu),fm=tt({},qu,{dataTransfer:0}),sm=Rt(fm),om=tt({},yn,{relatedTarget:0}),sc=Rt(om),rm=tt({},Te,{animationName:0,elapsedTime:0,pseudoElement:0}),dm=Rt(rm),mm=tt({},Te,{clipboardData:function(t){return"clipboardData"in t?t.clipboardData:window.clipboardData}}),ym=Rt(mm),hm=tt({},Te,{data:0}),gs=Rt(hm),vm={Esc:"Escape",Spacebar:" ",Left:"ArrowLeft",Up:"ArrowUp",Right:"ArrowRight",Down:"ArrowDown",Del:"Delete",Win:"OS",Menu:"ContextMenu",Apps:"ContextMenu",Scroll:"ScrollLock",MozPrintableKey:"Unidentified"},gm={8:"Backspace",9:"Tab",12:"Clear",13:"Enter",16:"Shift",17:"Control",18:"Alt",19:"Pause",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",45:"Insert",46:"Delete",112:"F1",113:"F2",114:"F3",115:"F4",116:"F5",117:"F6",118:"F7",119:"F8",120:"F9",121:"F10",122:"F11",123:"F12",144:"NumLock",145:"ScrollLock",224:"Meta"},xm={Alt:"altKey",Control:"ctrlKey",Meta:"metaKey",Shift:"shiftKey"};function bm(t){var l=this.nativeEvent;return l.getModifierState?l.getModifierState(t):(t=xm[t])?!!l[t]:!1}function cf(){return bm}var Sm=tt({},yn,{key:function(t){if(t.key){var l=vm[t.key]||t.key;if(l!=="Unidentified")return l}return t.type==="keypress"?(t=Qn(t),t===13?"Enter":String.fromCharCode(t)):t.type==="keydown"||t.type==="keyup"?gm[t.keyCode]||"Unidentified":""},code:0,location:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,repeat:0,locale:0,getModifierState:cf,charCode:function(t){return t.type==="keypress"?Qn(t):0},keyCode:function(t){return t.type==="keydown"||t.type==="keyup"?t.keyCode:0},which:function(t){return t.type==="keypress"?Qn(t):t.type==="keydown"||t.type==="keyup"?t.keyCode:0}}),pm=Rt(Sm),zm=tt({},qu,{pointerId:0,width:0,height:0,pressure:0,tangentialPressure:0,tiltX:0,tiltY:0,twist:0,pointerType:0,isPrimary:0}),xs=Rt(zm),Tm=tt({},yn,{touches:0,targetTouches:0,changedTouches:0,altKey:0,metaKey:0,ctrlKey:0,shiftKey:0,getModifierState:cf}),Em=Rt(Tm),Mm=tt({},Te,{propertyName:0,elapsedTime:0,pseudoElement:0}),Am=Rt(Mm),jm=tt({},qu,{deltaX:function(t){return"deltaX"in t?t.deltaX:"wheelDeltaX"in t?-t.wheelDeltaX:0},deltaY:function(t){return"deltaY"in t?t.deltaY:"wheelDeltaY"in t?-t.wheelDeltaY:"wheelDelta"in t?-t.wheelDelta:0},deltaZ:0,deltaMode:0}),km=Rt(jm),Om=tt({},Te,{newState:0,oldState:0}),Dm=Rt(Om),wm=[9,13,27,32],ff=Ml&&"CompositionEvent"in window,Ra=null;Ml&&"documentMode"in document&&(Ra=document.documentMode);var Nm=Ml&&"TextEvent"in window&&!Ra,wr=Ml&&(!ff||Ra&&8<Ra&&11>=Ra),bs=" ",Ss=!1;function Nr(t,l){switch(t){case"keyup":return wm.indexOf(l.keyCode)!==-1;case"keydown":return l.keyCode!==229;case"keypress":case"mousedown":case"focusout":return!0;default:return!1}}function _r(t){return t=t.detail,typeof t=="object"&&"data"in t?t.data:null}var He=!1;function _m(t,l){switch(t){case"compositionend":return _r(l);case"keypress":return l.which!==32?null:(Ss=!0,bs);case"textInput":return t=l.data,t===bs&&Ss?null:t;default:return null}}function Cm(t,l){if(He)return t==="compositionend"||!ff&&Nr(t,l)?(t=Dr(),Vn=uf=Bl=null,He=!1,t):null;switch(t){case"paste":return null;case"keypress":if(!(l.ctrlKey||l.altKey||l.metaKey)||l.ctrlKey&&l.altKey){if(l.char&&1<l.char.length)return l.char;if(l.which)return String.fromCharCode(l.which)}return null;case"compositionend":return wr&&l.locale!=="ko"?null:l.data;default:return null}}var Rm={color:!0,date:!0,datetime:!0,"datetime-local":!0,email:!0,month:!0,number:!0,password:!0,range:!0,search:!0,tel:!0,text:!0,time:!0,url:!0,week:!0};function ps(t){var l=t&&t.nodeName&&t.nodeName.toLowerCase();return l==="input"?!!Rm[t.type]:l==="textarea"}function Cr(t,l,e,a){Ue?We?We.push(a):We=[a]:Ue=a,l=ju(l,"onChange"),0<l.length&&(e=new Hu("onChange","change",null,e,a),t.push({event:e,listeners:l}))}var $a=null,Wa=null;function $m(t){O0(t,0)}function Bu(t){var l=wa(t);if(Er(l))return t}function zs(t,l){if(t==="change")return l}var Rr=!1;if(Ml){var oc;if(Ml){var rc="oninput"in document;if(!rc){var Ts=document.createElement("div");Ts.setAttribute("oninput","return;"),rc=typeof Ts.oninput=="function"}oc=rc}else oc=!1;Rr=oc&&(!document.documentMode||9<document.documentMode)}function Es(){$a&&($a.detachEvent("onpropertychange",$r),Wa=$a=null)}function $r(t){if(t.propertyName==="value"&&Bu(Wa)){var l=[];Cr(l,Wa,t,nf(t)),Or($m,l)}}function Um(t,l,e){t==="focusin"?(Es(),$a=l,Wa=e,$a.attachEvent("onpropertychange",$r)):t==="focusout"&&Es()}function Hm(t){if(t==="selectionchange"||t==="keyup"||t==="keydown")return Bu(Wa)}function qm(t,l){if(t==="click")return Bu(l)}function Bm(t,l){if(t==="input"||t==="change")return Bu(l)}function Xm(t,l){return t===l&&(t!==0||1/t===1/l)||t!==t&&l!==l}var Gt=typeof Object.is=="function"?Object.is:Xm;function Fa(t,l){if(Gt(t,l))return!0;if(typeof t!="object"||t===null||typeof l!="object"||l===null)return!1;var e=Object.keys(t),a=Object.keys(l);if(e.length!==a.length)return!1;for(a=0;a<e.length;a++){var n=e[a];if(!ti.call(l,n)||!Gt(t[n],l[n]))return!1}return!0}function Ms(t){for(;t&&t.firstChild;)t=t.firstChild;return t}function As(t,l){var e=Ms(t);t=0;for(var a;e;){if(e.nodeType===3){if(a=t+e.textContent.length,t<=l&&a>=l)return{node:e,offset:l-t};t=a}t:{for(;e;){if(e.nextSibling){e=e.nextSibling;break t}e=e.parentNode}e=void 0}e=Ms(e)}}function Ur(t,l){return t&&l?t===l?!0:t&&t.nodeType===3?!1:l&&l.nodeType===3?Ur(t,l.parentNode):"contains"in t?t.contains(l):t.compareDocumentPosition?!!(t.compareDocumentPosition(l)&16):!1:!1}function Hr(t){t=t!=null&&t.ownerDocument!=null&&t.ownerDocument.defaultView!=null?t.ownerDocument.defaultView:window;for(var l=su(t.document);l instanceof t.HTMLIFrameElement;){try{var e=typeof l.contentWindow.location.href=="string"}catch{e=!1}if(e)t=l.contentWindow;else break;l=su(t.document)}return l}function sf(t){var l=t&&t.nodeName&&t.nodeName.toLowerCase();return l&&(l==="input"&&(t.type==="text"||t.type==="search"||t.type==="tel"||t.type==="url"||t.type==="password")||l==="textarea"||t.contentEditable==="true")}var Lm=Ml&&"documentMode"in document&&11>=document.documentMode,qe=null,ii=null,Ua=null,fi=!1;function js(t,l,e){var a=e.window===e?e.document:e.nodeType===9?e:e.ownerDocument;fi||qe==null||qe!==su(a)||(a=qe,"selectionStart"in a&&sf(a)?a={start:a.selectionStart,end:a.selectionEnd}:(a=(a.ownerDocument&&a.ownerDocument.defaultView||window).getSelection(),a={anchorNode:a.anchorNode,anchorOffset:a.anchorOffset,focusNode:a.focusNode,focusOffset:a.focusOffset}),Ua&&Fa(Ua,a)||(Ua=a,a=ju(ii,"onSelect"),0<a.length&&(l=new Hu("onSelect","select",null,l,e),t.push({event:l,listeners:a}),l.target=qe)))}function ie(t,l){var e={};return e[t.toLowerCase()]=l.toLowerCase(),e["Webkit"+t]="webkit"+l,e["Moz"+t]="moz"+l,e}var Be={animationend:ie("Animation","AnimationEnd"),animationiteration:ie("Animation","AnimationIteration"),animationstart:ie("Animation","AnimationStart"),transitionrun:ie("Transition","TransitionRun"),transitionstart:ie("Transition","TransitionStart"),transitioncancel:ie("Transition","TransitionCancel"),transitionend:ie("Transition","TransitionEnd")},dc={},qr={};Ml&&(qr=document.createElement("div").style,"AnimationEvent"in window||(delete Be.animationend.animation,delete Be.animationiteration.animation,delete Be.animationstart.animation),"TransitionEvent"in window||delete Be.transitionend.transition);function Ee(t){if(dc[t])return dc[t];if(!Be[t])return t;var l=Be[t],e;for(e in l)if(l.hasOwnProperty(e)&&e in qr)return dc[t]=l[e];return t}var Br=Ee("animationend"),Xr=Ee("animationiteration"),Lr=Ee("animationstart"),Ym=Ee("transitionrun"),Gm=Ee("transitionstart"),Zm=Ee("transitioncancel"),Yr=Ee("transitionend"),Gr=new Map,si="abort auxClick beforeToggle cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel".split(" ");si.push("scrollEnd");function nl(t,l){Gr.set(t,l),ze(l,[t])}var ou=typeof reportError=="function"?reportError:function(t){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var l=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof t=="object"&&t!==null&&typeof t.message=="string"?String(t.message):String(t),error:t});if(!window.dispatchEvent(l))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",t);return}console.error(t)},Vt=[],Xe=0,of=0;function Xu(){for(var t=Xe,l=of=Xe=0;l<t;){var e=Vt[l];Vt[l++]=null;var a=Vt[l];Vt[l++]=null;var n=Vt[l];Vt[l++]=null;var u=Vt[l];if(Vt[l++]=null,a!==null&&n!==null){var c=a.pending;c===null?n.next=n:(n.next=c.next,c.next=n),a.pending=n}u!==0&&Zr(e,n,u)}}function Lu(t,l,e,a){Vt[Xe++]=t,Vt[Xe++]=l,Vt[Xe++]=e,Vt[Xe++]=a,of|=a,t.lanes|=a,t=t.alternate,t!==null&&(t.lanes|=a)}function rf(t,l,e,a){return Lu(t,l,e,a),ru(t)}function Me(t,l){return Lu(t,null,null,l),ru(t)}function Zr(t,l,e){t.lanes|=e;var a=t.alternate;a!==null&&(a.lanes|=e);for(var n=!1,u=t.return;u!==null;)u.childLanes|=e,a=u.alternate,a!==null&&(a.childLanes|=e),u.tag===22&&(t=u.stateNode,t===null||t._visibility&1||(n=!0)),t=u,u=u.return;return t.tag===3?(u=t.stateNode,n&&l!==null&&(n=31-Lt(e),t=u.hiddenUpdates,a=t[n],a===null?t[n]=[l]:a.push(l),l.lane=e|536870912),u):null}function ru(t){if(50<Va)throw Va=0,Di=null,Error(T(185));for(var l=t.return;l!==null;)t=l,l=t.return;return t.tag===3?t.stateNode:null}var Le={};function Vm(t,l,e,a){this.tag=t,this.key=e,this.sibling=this.child=this.return=this.stateNode=this.type=this.elementType=null,this.index=0,this.refCleanup=this.ref=null,this.pendingProps=l,this.dependencies=this.memoizedState=this.updateQueue=this.memoizedProps=null,this.mode=a,this.subtreeFlags=this.flags=0,this.deletions=null,this.childLanes=this.lanes=0,this.alternate=null}function Ht(t,l,e,a){return new Vm(t,l,e,a)}function df(t){return t=t.prototype,!(!t||!t.isReactComponent)}function zl(t,l){var e=t.alternate;return e===null?(e=Ht(t.tag,l,t.key,t.mode),e.elementType=t.elementType,e.type=t.type,e.stateNode=t.stateNode,e.alternate=t,t.alternate=e):(e.pendingProps=l,e.type=t.type,e.flags=0,e.subtreeFlags=0,e.deletions=null),e.flags=t.flags&65011712,e.childLanes=t.childLanes,e.lanes=t.lanes,e.child=t.child,e.memoizedProps=t.memoizedProps,e.memoizedState=t.memoizedState,e.updateQueue=t.updateQueue,l=t.dependencies,e.dependencies=l===null?null:{lanes:l.lanes,firstContext:l.firstContext},e.sibling=t.sibling,e.index=t.index,e.ref=t.ref,e.refCleanup=t.refCleanup,e}function Vr(t,l){t.flags&=65011714;var e=t.alternate;return e===null?(t.childLanes=0,t.lanes=l,t.child=null,t.subtreeFlags=0,t.memoizedProps=null,t.memoizedState=null,t.updateQueue=null,t.dependencies=null,t.stateNode=null):(t.childLanes=e.childLanes,t.lanes=e.lanes,t.child=e.child,t.subtreeFlags=0,t.deletions=null,t.memoizedProps=e.memoizedProps,t.memoizedState=e.memoizedState,t.updateQueue=e.updateQueue,t.type=e.type,l=e.dependencies,t.dependencies=l===null?null:{lanes:l.lanes,firstContext:l.firstContext}),t}function Kn(t,l,e,a,n,u){var c=0;if(a=t,typeof t=="function")df(t)&&(c=1);else if(typeof t=="string")c=Fy(t,e,fl.current)?26:t==="html"||t==="head"||t==="body"?27:5;else t:switch(t){case Wc:return t=Ht(31,e,l,n),t.elementType=Wc,t.lanes=u,t;case Ce:return me(e.children,n,u,l);case rr:c=8,n|=24;break;case Qc:return t=Ht(12,e,l,n|2),t.elementType=Qc,t.lanes=u,t;case Kc:return t=Ht(13,e,l,n),t.elementType=Kc,t.lanes=u,t;case Jc:return t=Ht(19,e,l,n),t.elementType=Jc,t.lanes=u,t;default:if(typeof t=="object"&&t!==null)switch(t.$$typeof){case bl:c=10;break t;case dr:c=9;break t;case Fi:c=11;break t;case Ii:c=14;break t;case _l:c=16,a=null;break t}c=29,e=Error(T(130,t===null?"null":typeof t,"")),a=null}return l=Ht(c,e,l,n),l.elementType=t,l.type=a,l.lanes=u,l}function me(t,l,e,a){return t=Ht(7,t,a,l),t.lanes=e,t}function mc(t,l,e){return t=Ht(6,t,null,l),t.lanes=e,t}function Qr(t){var l=Ht(18,null,null,0);return l.stateNode=t,l}function yc(t,l,e){return l=Ht(4,t.children!==null?t.children:[],t.key,l),l.lanes=e,l.stateNode={containerInfo:t.containerInfo,pendingChildren:null,implementation:t.implementation},l}var ks=new WeakMap;function Ft(t,l){if(typeof t=="object"&&t!==null){var e=ks.get(t);return e!==void 0?e:(l={value:t,source:l,stack:fs(l)},ks.set(t,l),l)}return{value:t,source:l,stack:fs(l)}}var Ye=[],Ge=0,du=null,Ia=0,Kt=[],Jt=0,Pl=null,ul=1,cl="";function gl(t,l){Ye[Ge++]=Ia,Ye[Ge++]=du,du=t,Ia=l}function Kr(t,l,e){Kt[Jt++]=ul,Kt[Jt++]=cl,Kt[Jt++]=Pl,Pl=t;var a=ul;t=cl;var n=32-Lt(a)-1;a&=~(1<<n),e+=1;var u=32-Lt(l)+n;if(30<u){var c=n-n%5;u=(a&(1<<c)-1).toString(32),a>>=c,n-=c,ul=1<<32-Lt(l)+n|e<<n|a,cl=u+t}else ul=1<<u|e<<n|a,cl=t}function mf(t){t.return!==null&&(gl(t,1),Kr(t,1,0))}function yf(t){for(;t===du;)du=Ye[--Ge],Ye[Ge]=null,Ia=Ye[--Ge],Ye[Ge]=null;for(;t===Pl;)Pl=Kt[--Jt],Kt[Jt]=null,cl=Kt[--Jt],Kt[Jt]=null,ul=Kt[--Jt],Kt[Jt]=null}function Jr(t,l){Kt[Jt++]=ul,Kt[Jt++]=cl,Kt[Jt++]=Pl,ul=l.id,cl=l.overflow,Pl=t}var Tt=null,F=null,q=!1,Zl=null,It=!1,oi=Error(T(519));function te(t){var l=Error(T(418,1<arguments.length&&arguments[1]!==void 0&&arguments[1]?"text":"HTML",""));throw Pa(Ft(l,t)),oi}function Os(t){var l=t.stateNode,e=t.type,a=t.memoizedProps;switch(l[zt]=t,l[Ct]=a,e){case"dialog":$("cancel",l),$("close",l);break;case"iframe":case"object":case"embed":$("load",l);break;case"video":case"audio":for(e=0;e<an.length;e++)$(an[e],l);break;case"source":$("error",l);break;case"img":case"image":case"link":$("error",l),$("load",l);break;case"details":$("toggle",l);break;case"input":$("invalid",l),Mr(l,a.value,a.defaultValue,a.checked,a.defaultChecked,a.type,a.name,!0);break;case"select":$("invalid",l);break;case"textarea":$("invalid",l),jr(l,a.value,a.defaultValue,a.children)}e=a.children,typeof e!="string"&&typeof e!="number"&&typeof e!="bigint"||l.textContent===""+e||a.suppressHydrationWarning===!0||w0(l.textContent,e)?(a.popover!=null&&($("beforetoggle",l),$("toggle",l)),a.onScroll!=null&&$("scroll",l),a.onScrollEnd!=null&&$("scrollend",l),a.onClick!=null&&(l.onclick=Sl),l=!0):l=!1,l||te(t,!0)}function Ds(t){for(Tt=t.return;Tt;)switch(Tt.tag){case 5:case 31:case 13:It=!1;return;case 27:case 3:It=!0;return;default:Tt=Tt.return}}function ke(t){if(t!==Tt)return!1;if(!q)return Ds(t),q=!0,!1;var l=t.tag,e;if((e=l!==3&&l!==27)&&((e=l===5)&&(e=t.type,e=!(e!=="form"&&e!=="button")||Ri(t.type,t.memoizedProps)),e=!e),e&&F&&te(t),Ds(t),l===13){if(t=t.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(T(317));F=go(t)}else if(l===31){if(t=t.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(T(317));F=go(t)}else l===27?(l=F,ne(t.type)?(t=qi,qi=null,F=t):F=l):F=Tt?tl(t.stateNode.nextSibling):null;return!0}function ge(){F=Tt=null,q=!1}function hc(){var t=Zl;return t!==null&&(Nt===null?Nt=t:Nt.push.apply(Nt,t),Zl=null),t}function Pa(t){Zl===null?Zl=[t]:Zl.push(t)}var ri=sl(null),Ae=null,pl=null;function Rl(t,l,e){K(ri,l._currentValue),l._currentValue=e}function Tl(t){t._currentValue=ri.current,bt(ri)}function di(t,l,e){for(;t!==null;){var a=t.alternate;if((t.childLanes&l)!==l?(t.childLanes|=l,a!==null&&(a.childLanes|=l)):a!==null&&(a.childLanes&l)!==l&&(a.childLanes|=l),t===e)break;t=t.return}}function mi(t,l,e,a){var n=t.child;for(n!==null&&(n.return=t);n!==null;){var u=n.dependencies;if(u!==null){var c=n.child;u=u.firstContext;t:for(;u!==null;){var i=u;u=n;for(var f=0;f<l.length;f++)if(i.context===l[f]){u.lanes|=e,i=u.alternate,i!==null&&(i.lanes|=e),di(u.return,e,t),a||(c=null);break t}u=i.next}}else if(n.tag===18){if(c=n.return,c===null)throw Error(T(341));c.lanes|=e,u=c.alternate,u!==null&&(u.lanes|=e),di(c,e,t),c=null}else c=n.child;if(c!==null)c.return=n;else for(c=n;c!==null;){if(c===t){c=null;break}if(n=c.sibling,n!==null){n.return=c.return,c=n;break}c=c.return}n=c}}function va(t,l,e,a){t=null;for(var n=l,u=!1;n!==null;){if(!u){if(n.flags&524288)u=!0;else if(n.flags&262144)break}if(n.tag===10){var c=n.alternate;if(c===null)throw Error(T(387));if(c=c.memoizedProps,c!==null){var i=n.type;Gt(n.pendingProps.value,c.value)||(t!==null?t.push(i):t=[i])}}else if(n===uu.current){if(c=n.alternate,c===null)throw Error(T(387));c.memoizedState.memoizedState!==n.memoizedState.memoizedState&&(t!==null?t.push(un):t=[un])}n=n.return}t!==null&&mi(l,t,e,a),l.flags|=262144}function mu(t){for(t=t.firstContext;t!==null;){if(!Gt(t.context._currentValue,t.memoizedValue))return!0;t=t.next}return!1}function xe(t){Ae=t,pl=null,t=t.dependencies,t!==null&&(t.firstContext=null)}function Et(t){return Wr(Ae,t)}function Dn(t,l){return Ae===null&&xe(t),Wr(t,l)}function Wr(t,l){var e=l._currentValue;if(l={context:l,memoizedValue:e,next:null},pl===null){if(t===null)throw Error(T(308));pl=l,t.dependencies={lanes:0,firstContext:l},t.flags|=524288}else pl=pl.next=l;return e}var Qm=typeof AbortController<"u"?AbortController:function(){var t=[],l=this.signal={aborted:!1,addEventListener:function(e,a){t.push(a)}};this.abort=function(){l.aborted=!0,t.forEach(function(e){return e()})}},Km=ht.unstable_scheduleCallback,Jm=ht.unstable_NormalPriority,rt={$$typeof:bl,Consumer:null,Provider:null,_currentValue:null,_currentValue2:null,_threadCount:0};function hf(){return{controller:new Qm,data:new Map,refCount:0}}function hn(t){t.refCount--,t.refCount===0&&Km(Jm,function(){t.controller.abort()})}var Ha=null,yi=0,na=0,Fe=null;function Wm(t,l){if(Ha===null){var e=Ha=[];yi=0,na=Bf(),Fe={status:"pending",value:void 0,then:function(a){e.push(a)}}}return yi++,l.then(ws,ws),l}function ws(){if(--yi===0&&Ha!==null){Fe!==null&&(Fe.status="fulfilled");var t=Ha;Ha=null,na=0,Fe=null;for(var l=0;l<t.length;l++)(0,t[l])()}}function Fm(t,l){var e=[],a={status:"pending",value:null,reason:null,then:function(n){e.push(n)}};return t.then(function(){a.status="fulfilled",a.value=l;for(var n=0;n<e.length;n++)(0,e[n])(l)},function(n){for(a.status="rejected",a.reason=n,n=0;n<e.length;n++)(0,e[n])(void 0)}),a}var Ns=w.S;w.S=function(t,l){o0=Bt(),typeof l=="object"&&l!==null&&typeof l.then=="function"&&Wm(t,l),Ns!==null&&Ns(t,l)};var ye=sl(null);function vf(){var t=ye.current;return t!==null?t:Q.pooledCache}function Jn(t,l){l===null?K(ye,ye.current):K(ye,l.pool)}function Fr(){var t=vf();return t===null?null:{parent:rt._currentValue,pool:t}}var ga=Error(T(460)),gf=Error(T(474)),Yu=Error(T(542)),yu={then:function(){}};function _s(t){return t=t.status,t==="fulfilled"||t==="rejected"}function Ir(t,l,e){switch(e=t[e],e===void 0?t.push(l):e!==l&&(l.then(Sl,Sl),l=e),l.status){case"fulfilled":return l.value;case"rejected":throw t=l.reason,Rs(t),t;default:if(typeof l.status=="string")l.then(Sl,Sl);else{if(t=Q,t!==null&&100<t.shellSuspendCounter)throw Error(T(482));t=l,t.status="pending",t.then(function(a){if(l.status==="pending"){var n=l;n.status="fulfilled",n.value=a}},function(a){if(l.status==="pending"){var n=l;n.status="rejected",n.reason=a}})}switch(l.status){case"fulfilled":return l.value;case"rejected":throw t=l.reason,Rs(t),t}throw he=l,ga}}function oe(t){try{var l=t._init;return l(t._payload)}catch(e){throw e!==null&&typeof e=="object"&&typeof e.then=="function"?(he=e,ga):e}}var he=null;function Cs(){if(he===null)throw Error(T(459));var t=he;return he=null,t}function Rs(t){if(t===ga||t===Yu)throw Error(T(483))}var Ie=null,tn=0;function wn(t){var l=tn;return tn+=1,Ie===null&&(Ie=[]),Ir(Ie,t,l)}function Ea(t,l){l=l.props.ref,t.ref=l!==void 0?l:null}function Nn(t,l){throw l.$$typeof===U1?Error(T(525)):(t=Object.prototype.toString.call(l),Error(T(31,t==="[object Object]"?"object with keys {"+Object.keys(l).join(", ")+"}":t)))}function Pr(t){function l(r,o){if(t){var y=r.deletions;y===null?(r.deletions=[o],r.flags|=16):y.push(o)}}function e(r,o){if(!t)return null;for(;o!==null;)l(r,o),o=o.sibling;return null}function a(r){for(var o=new Map;r!==null;)r.key!==null?o.set(r.key,r):o.set(r.index,r),r=r.sibling;return o}function n(r,o){return r=zl(r,o),r.index=0,r.sibling=null,r}function u(r,o,y){return r.index=y,t?(y=r.alternate,y!==null?(y=y.index,y<o?(r.flags|=67108866,o):y):(r.flags|=67108866,o)):(r.flags|=1048576,o)}function c(r){return t&&r.alternate===null&&(r.flags|=67108866),r}function i(r,o,y,x){return o===null||o.tag!==6?(o=mc(y,r.mode,x),o.return=r,o):(o=n(o,y),o.return=r,o)}function f(r,o,y,x){var M=y.type;return M===Ce?d(r,o,y.props.children,x,y.key):o!==null&&(o.elementType===M||typeof M=="object"&&M!==null&&M.$$typeof===_l&&oe(M)===o.type)?(o=n(o,y.props),Ea(o,y),o.return=r,o):(o=Kn(y.type,y.key,y.props,null,r.mode,x),Ea(o,y),o.return=r,o)}function s(r,o,y,x){return o===null||o.tag!==4||o.stateNode.containerInfo!==y.containerInfo||o.stateNode.implementation!==y.implementation?(o=yc(y,r.mode,x),o.return=r,o):(o=n(o,y.children||[]),o.return=r,o)}function d(r,o,y,x,M){return o===null||o.tag!==7?(o=me(y,r.mode,x,M),o.return=r,o):(o=n(o,y),o.return=r,o)}function v(r,o,y){if(typeof o=="string"&&o!==""||typeof o=="number"||typeof o=="bigint")return o=mc(""+o,r.mode,y),o.return=r,o;if(typeof o=="object"&&o!==null){switch(o.$$typeof){case En:return y=Kn(o.type,o.key,o.props,null,r.mode,y),Ea(y,o),y.return=r,y;case Oa:return o=yc(o,r.mode,y),o.return=r,o;case _l:return o=oe(o),v(r,o,y)}if(Da(o)||pa(o))return o=me(o,r.mode,y,null),o.return=r,o;if(typeof o.then=="function")return v(r,wn(o),y);if(o.$$typeof===bl)return v(r,Dn(r,o),y);Nn(r,o)}return null}function m(r,o,y,x){var M=o!==null?o.key:null;if(typeof y=="string"&&y!==""||typeof y=="number"||typeof y=="bigint")return M!==null?null:i(r,o,""+y,x);if(typeof y=="object"&&y!==null){switch(y.$$typeof){case En:return y.key===M?f(r,o,y,x):null;case Oa:return y.key===M?s(r,o,y,x):null;case _l:return y=oe(y),m(r,o,y,x)}if(Da(y)||pa(y))return M!==null?null:d(r,o,y,x,null);if(typeof y.then=="function")return m(r,o,wn(y),x);if(y.$$typeof===bl)return m(r,o,Dn(r,y),x);Nn(r,y)}return null}function h(r,o,y,x,M){if(typeof x=="string"&&x!==""||typeof x=="number"||typeof x=="bigint")return r=r.get(y)||null,i(o,r,""+x,M);if(typeof x=="object"&&x!==null){switch(x.$$typeof){case En:return r=r.get(x.key===null?y:x.key)||null,f(o,r,x,M);case Oa:return r=r.get(x.key===null?y:x.key)||null,s(o,r,x,M);case _l:return x=oe(x),h(r,o,y,x,M)}if(Da(x)||pa(x))return r=r.get(y)||null,d(o,r,x,M,null);if(typeof x.then=="function")return h(r,o,y,wn(x),M);if(x.$$typeof===bl)return h(r,o,y,Dn(o,x),M);Nn(o,x)}return null}function S(r,o,y,x){for(var M=null,O=null,E=o,A=o=0,j=null;E!==null&&A<y.length;A++){E.index>A?(j=E,E=null):j=E.sibling;var k=m(r,E,y[A],x);if(k===null){E===null&&(E=j);break}t&&E&&k.alternate===null&&l(r,E),o=u(k,o,A),O===null?M=k:O.sibling=k,O=k,E=j}if(A===y.length)return e(r,E),q&&gl(r,A),M;if(E===null){for(;A<y.length;A++)E=v(r,y[A],x),E!==null&&(o=u(E,o,A),O===null?M=E:O.sibling=E,O=E);return q&&gl(r,A),M}for(E=a(E);A<y.length;A++)j=h(E,r,A,y[A],x),j!==null&&(t&&j.alternate!==null&&E.delete(j.key===null?A:j.key),o=u(j,o,A),O===null?M=j:O.sibling=j,O=j);return t&&E.forEach(function(V){return l(r,V)}),q&&gl(r,A),M}function p(r,o,y,x){if(y==null)throw Error(T(151));for(var M=null,O=null,E=o,A=o=0,j=null,k=y.next();E!==null&&!k.done;A++,k=y.next()){E.index>A?(j=E,E=null):j=E.sibling;var V=m(r,E,k.value,x);if(V===null){E===null&&(E=j);break}t&&E&&V.alternate===null&&l(r,E),o=u(V,o,A),O===null?M=V:O.sibling=V,O=V,E=j}if(k.done)return e(r,E),q&&gl(r,A),M;if(E===null){for(;!k.done;A++,k=y.next())k=v(r,k.value,x),k!==null&&(o=u(k,o,A),O===null?M=k:O.sibling=k,O=k);return q&&gl(r,A),M}for(E=a(E);!k.done;A++,k=y.next())k=h(E,r,A,k.value,x),k!==null&&(t&&k.alternate!==null&&E.delete(k.key===null?A:k.key),o=u(k,o,A),O===null?M=k:O.sibling=k,O=k);return t&&E.forEach(function(J){return l(r,J)}),q&&gl(r,A),M}function z(r,o,y,x){if(typeof y=="object"&&y!==null&&y.type===Ce&&y.key===null&&(y=y.props.children),typeof y=="object"&&y!==null){switch(y.$$typeof){case En:t:{for(var M=y.key;o!==null;){if(o.key===M){if(M=y.type,M===Ce){if(o.tag===7){e(r,o.sibling),x=n(o,y.props.children),x.return=r,r=x;break t}}else if(o.elementType===M||typeof M=="object"&&M!==null&&M.$$typeof===_l&&oe(M)===o.type){e(r,o.sibling),x=n(o,y.props),Ea(x,y),x.return=r,r=x;break t}e(r,o);break}else l(r,o);o=o.sibling}y.type===Ce?(x=me(y.props.children,r.mode,x,y.key),x.return=r,r=x):(x=Kn(y.type,y.key,y.props,null,r.mode,x),Ea(x,y),x.return=r,r=x)}return c(r);case Oa:t:{for(M=y.key;o!==null;){if(o.key===M)if(o.tag===4&&o.stateNode.containerInfo===y.containerInfo&&o.stateNode.implementation===y.implementation){e(r,o.sibling),x=n(o,y.children||[]),x.return=r,r=x;break t}else{e(r,o);break}else l(r,o);o=o.sibling}x=yc(y,r.mode,x),x.return=r,r=x}return c(r);case _l:return y=oe(y),z(r,o,y,x)}if(Da(y))return S(r,o,y,x);if(pa(y)){if(M=pa(y),typeof M!="function")throw Error(T(150));return y=M.call(y),p(r,o,y,x)}if(typeof y.then=="function")return z(r,o,wn(y),x);if(y.$$typeof===bl)return z(r,o,Dn(r,y),x);Nn(r,y)}return typeof y=="string"&&y!==""||typeof y=="number"||typeof y=="bigint"?(y=""+y,o!==null&&o.tag===6?(e(r,o.sibling),x=n(o,y),x.return=r,r=x):(e(r,o),x=mc(y,r.mode,x),x.return=r,r=x),c(r)):e(r,o)}return function(r,o,y,x){try{tn=0;var M=z(r,o,y,x);return Ie=null,M}catch(E){if(E===ga||E===Yu)throw E;var O=Ht(29,E,null,r.mode);return O.lanes=x,O.return=r,O}finally{}}}var be=Pr(!0),td=Pr(!1),Cl=!1;function xf(t){t.updateQueue={baseState:t.memoizedState,firstBaseUpdate:null,lastBaseUpdate:null,shared:{pending:null,lanes:0,hiddenCallbacks:null},callbacks:null}}function hi(t,l){t=t.updateQueue,l.updateQueue===t&&(l.updateQueue={baseState:t.baseState,firstBaseUpdate:t.firstBaseUpdate,lastBaseUpdate:t.lastBaseUpdate,shared:t.shared,callbacks:null})}function Vl(t){return{lane:t,tag:0,payload:null,callback:null,next:null}}function Ql(t,l,e){var a=t.updateQueue;if(a===null)return null;if(a=a.shared,B&2){var n=a.pending;return n===null?l.next=l:(l.next=n.next,n.next=l),a.pending=l,l=ru(t),Zr(t,null,e),l}return Lu(t,a,l,e),ru(t)}function qa(t,l,e){if(l=l.updateQueue,l!==null&&(l=l.shared,(e&4194048)!==0)){var a=l.lanes;a&=t.pendingLanes,e|=a,l.lanes=e,xr(t,e)}}function vc(t,l){var e=t.updateQueue,a=t.alternate;if(a!==null&&(a=a.updateQueue,e===a)){var n=null,u=null;if(e=e.firstBaseUpdate,e!==null){do{var c={lane:e.lane,tag:e.tag,payload:e.payload,callback:null,next:null};u===null?n=u=c:u=u.next=c,e=e.next}while(e!==null);u===null?n=u=l:u=u.next=l}else n=u=l;e={baseState:a.baseState,firstBaseUpdate:n,lastBaseUpdate:u,shared:a.shared,callbacks:a.callbacks},t.updateQueue=e;return}t=e.lastBaseUpdate,t===null?e.firstBaseUpdate=l:t.next=l,e.lastBaseUpdate=l}var vi=!1;function Ba(){if(vi){var t=Fe;if(t!==null)throw t}}function Xa(t,l,e,a){vi=!1;var n=t.updateQueue;Cl=!1;var u=n.firstBaseUpdate,c=n.lastBaseUpdate,i=n.shared.pending;if(i!==null){n.shared.pending=null;var f=i,s=f.next;f.next=null,c===null?u=s:c.next=s,c=f;var d=t.alternate;d!==null&&(d=d.updateQueue,i=d.lastBaseUpdate,i!==c&&(i===null?d.firstBaseUpdate=s:i.next=s,d.lastBaseUpdate=f))}if(u!==null){var v=n.baseState;c=0,d=s=f=null,i=u;do{var m=i.lane&-536870913,h=m!==i.lane;if(h?(H&m)===m:(a&m)===m){m!==0&&m===na&&(vi=!0),d!==null&&(d=d.next={lane:0,tag:i.tag,payload:i.payload,callback:null,next:null});t:{var S=t,p=i;m=l;var z=e;switch(p.tag){case 1:if(S=p.payload,typeof S=="function"){v=S.call(z,v,m);break t}v=S;break t;case 3:S.flags=S.flags&-65537|128;case 0:if(S=p.payload,m=typeof S=="function"?S.call(z,v,m):S,m==null)break t;v=tt({},v,m);break t;case 2:Cl=!0}}m=i.callback,m!==null&&(t.flags|=64,h&&(t.flags|=8192),h=n.callbacks,h===null?n.callbacks=[m]:h.push(m))}else h={lane:m,tag:i.tag,payload:i.payload,callback:i.callback,next:null},d===null?(s=d=h,f=v):d=d.next=h,c|=m;if(i=i.next,i===null){if(i=n.shared.pending,i===null)break;h=i,i=h.next,h.next=null,n.lastBaseUpdate=h,n.shared.pending=null}}while(!0);d===null&&(f=v),n.baseState=f,n.firstBaseUpdate=s,n.lastBaseUpdate=d,u===null&&(n.shared.lanes=0),ee|=c,t.lanes=c,t.memoizedState=v}}function ld(t,l){if(typeof t!="function")throw Error(T(191,t));t.call(l)}function ed(t,l){var e=t.callbacks;if(e!==null)for(t.callbacks=null,t=0;t<e.length;t++)ld(e[t],l)}var ua=sl(null),hu=sl(0);function $s(t,l){t=Ol,K(hu,t),K(ua,l),Ol=t|l.baseLanes}function gi(){K(hu,Ol),K(ua,ua.current)}function bf(){Ol=hu.current,bt(ua),bt(hu)}var Zt=sl(null),Pt=null;function $l(t){var l=t.alternate;K(it,it.current&1),K(Zt,t),Pt===null&&(l===null||ua.current!==null||l.memoizedState!==null)&&(Pt=t)}function xi(t){K(it,it.current),K(Zt,t),Pt===null&&(Pt=t)}function ad(t){t.tag===22?(K(it,it.current),K(Zt,t),Pt===null&&(Pt=t)):Ul()}function Ul(){K(it,it.current),K(Zt,Zt.current)}function Ut(t){bt(Zt),Pt===t&&(Pt=null),bt(it)}var it=sl(0);function vu(t){for(var l=t;l!==null;){if(l.tag===13){var e=l.memoizedState;if(e!==null&&(e=e.dehydrated,e===null||Ui(e)||Hi(e)))return l}else if(l.tag===19&&(l.memoizedProps.revealOrder==="forwards"||l.memoizedProps.revealOrder==="backwards"||l.memoizedProps.revealOrder==="unstable_legacy-backwards"||l.memoizedProps.revealOrder==="together")){if(l.flags&128)return l}else if(l.child!==null){l.child.return=l,l=l.child;continue}if(l===t)break;for(;l.sibling===null;){if(l.return===null||l.return===t)return null;l=l.return}l.sibling.return=l.return,l=l.sibling}return null}var Al=0,R=null,Z=null,st=null,gu=!1,Pe=!1,Se=!1,xu=0,ln=0,ta=null,Im=0;function at(){throw Error(T(321))}function Sf(t,l){if(l===null)return!1;for(var e=0;e<l.length&&e<t.length;e++)if(!Gt(t[e],l[e]))return!1;return!0}function pf(t,l,e,a,n,u){return Al=u,R=l,l.memoizedState=null,l.updateQueue=null,l.lanes=0,w.H=t===null||t.memoizedState===null?Cd:Nf,Se=!1,u=e(a,n),Se=!1,Pe&&(u=ud(l,e,a,n)),nd(t),u}function nd(t){w.H=en;var l=Z!==null&&Z.next!==null;if(Al=0,st=Z=R=null,gu=!1,ln=0,ta=null,l)throw Error(T(300));t===null||dt||(t=t.dependencies,t!==null&&mu(t)&&(dt=!0))}function ud(t,l,e,a){R=t;var n=0;do{if(Pe&&(ta=null),ln=0,Pe=!1,25<=n)throw Error(T(301));if(n+=1,st=Z=null,t.updateQueue!=null){var u=t.updateQueue;u.lastEffect=null,u.events=null,u.stores=null,u.memoCache!=null&&(u.memoCache.index=0)}w.H=Rd,u=l(e,a)}while(Pe);return u}function Pm(){var t=w.H,l=t.useState()[0];return l=typeof l.then=="function"?vn(l):l,t=t.useState()[0],(Z!==null?Z.memoizedState:null)!==t&&(R.flags|=1024),l}function zf(){var t=xu!==0;return xu=0,t}function Tf(t,l,e){l.updateQueue=t.updateQueue,l.flags&=-2053,t.lanes&=~e}function Ef(t){if(gu){for(t=t.memoizedState;t!==null;){var l=t.queue;l!==null&&(l.pending=null),t=t.next}gu=!1}Al=0,st=Z=R=null,Pe=!1,ln=xu=0,ta=null}function At(){var t={memoizedState:null,baseState:null,baseQueue:null,queue:null,next:null};return st===null?R.memoizedState=st=t:st=st.next=t,st}function ft(){if(Z===null){var t=R.alternate;t=t!==null?t.memoizedState:null}else t=Z.next;var l=st===null?R.memoizedState:st.next;if(l!==null)st=l,Z=t;else{if(t===null)throw R.alternate===null?Error(T(467)):Error(T(310));Z=t,t={memoizedState:Z.memoizedState,baseState:Z.baseState,baseQueue:Z.baseQueue,queue:Z.queue,next:null},st===null?R.memoizedState=st=t:st=st.next=t}return st}function Gu(){return{lastEffect:null,events:null,stores:null,memoCache:null}}function vn(t){var l=ln;return ln+=1,ta===null&&(ta=[]),t=Ir(ta,t,l),l=R,(st===null?l.memoizedState:st.next)===null&&(l=l.alternate,w.H=l===null||l.memoizedState===null?Cd:Nf),t}function Zu(t){if(t!==null&&typeof t=="object"){if(typeof t.then=="function")return vn(t);if(t.$$typeof===bl)return Et(t)}throw Error(T(438,String(t)))}function Mf(t){var l=null,e=R.updateQueue;if(e!==null&&(l=e.memoCache),l==null){var a=R.alternate;a!==null&&(a=a.updateQueue,a!==null&&(a=a.memoCache,a!=null&&(l={data:a.data.map(function(n){return n.slice()}),index:0})))}if(l==null&&(l={data:[],index:0}),e===null&&(e=Gu(),R.updateQueue=e),e.memoCache=l,e=l.data[l.index],e===void 0)for(e=l.data[l.index]=Array(t),a=0;a<t;a++)e[a]=H1;return l.index++,e}function jl(t,l){return typeof l=="function"?l(t):l}function Wn(t){var l=ft();return Af(l,Z,t)}function Af(t,l,e){var a=t.queue;if(a===null)throw Error(T(311));a.lastRenderedReducer=e;var n=t.baseQueue,u=a.pending;if(u!==null){if(n!==null){var c=n.next;n.next=u.next,u.next=c}l.baseQueue=n=u,a.pending=null}if(u=t.baseState,n===null)t.memoizedState=u;else{l=n.next;var i=c=null,f=null,s=l,d=!1;do{var v=s.lane&-536870913;if(v!==s.lane?(H&v)===v:(Al&v)===v){var m=s.revertLane;if(m===0)f!==null&&(f=f.next={lane:0,revertLane:0,gesture:null,action:s.action,hasEagerState:s.hasEagerState,eagerState:s.eagerState,next:null}),v===na&&(d=!0);else if((Al&m)===m){s=s.next,m===na&&(d=!0);continue}else v={lane:0,revertLane:s.revertLane,gesture:null,action:s.action,hasEagerState:s.hasEagerState,eagerState:s.eagerState,next:null},f===null?(i=f=v,c=u):f=f.next=v,R.lanes|=m,ee|=m;v=s.action,Se&&e(u,v),u=s.hasEagerState?s.eagerState:e(u,v)}else m={lane:v,revertLane:s.revertLane,gesture:s.gesture,action:s.action,hasEagerState:s.hasEagerState,eagerState:s.eagerState,next:null},f===null?(i=f=m,c=u):f=f.next=m,R.lanes|=v,ee|=v;s=s.next}while(s!==null&&s!==l);if(f===null?c=u:f.next=i,!Gt(u,t.memoizedState)&&(dt=!0,d&&(e=Fe,e!==null)))throw e;t.memoizedState=u,t.baseState=c,t.baseQueue=f,a.lastRenderedState=u}return n===null&&(a.lanes=0),[t.memoizedState,a.dispatch]}function gc(t){var l=ft(),e=l.queue;if(e===null)throw Error(T(311));e.lastRenderedReducer=t;var a=e.dispatch,n=e.pending,u=l.memoizedState;if(n!==null){e.pending=null;var c=n=n.next;do u=t(u,c.action),c=c.next;while(c!==n);Gt(u,l.memoizedState)||(dt=!0),l.memoizedState=u,l.baseQueue===null&&(l.baseState=u),e.lastRenderedState=u}return[u,a]}function cd(t,l,e){var a=R,n=ft(),u=q;if(u){if(e===void 0)throw Error(T(407));e=e()}else e=l();var c=!Gt((Z||n).memoizedState,e);if(c&&(n.memoizedState=e,dt=!0),n=n.queue,jf(sd.bind(null,a,n,t),[t]),n.getSnapshot!==l||c||st!==null&&st.memoizedState.tag&1){if(a.flags|=2048,ca(9,{destroy:void 0},fd.bind(null,a,n,e,l),null),Q===null)throw Error(T(349));u||Al&127||id(a,l,e)}return e}function id(t,l,e){t.flags|=16384,t={getSnapshot:l,value:e},l=R.updateQueue,l===null?(l=Gu(),R.updateQueue=l,l.stores=[t]):(e=l.stores,e===null?l.stores=[t]:e.push(t))}function fd(t,l,e,a){l.value=e,l.getSnapshot=a,od(l)&&rd(t)}function sd(t,l,e){return e(function(){od(l)&&rd(t)})}function od(t){var l=t.getSnapshot;t=t.value;try{var e=l();return!Gt(t,e)}catch{return!0}}function rd(t){var l=Me(t,2);l!==null&&_t(l,t,2)}function bi(t){var l=At();if(typeof t=="function"){var e=t;if(t=e(),Se){ql(!0);try{e()}finally{ql(!1)}}}return l.memoizedState=l.baseState=t,l.queue={pending:null,lanes:0,dispatch:null,lastRenderedReducer:jl,lastRenderedState:t},l}function dd(t,l,e,a){return t.baseState=e,Af(t,Z,typeof a=="function"?a:jl)}function ty(t,l,e,a,n){if(Qu(t))throw Error(T(485));if(t=l.action,t!==null){var u={payload:n,action:t,next:null,isTransition:!0,status:"pending",value:null,reason:null,listeners:[],then:function(c){u.listeners.push(c)}};w.T!==null?e(!0):u.isTransition=!1,a(u),e=l.pending,e===null?(u.next=l.pending=u,md(l,u)):(u.next=e.next,l.pending=e.next=u)}}function md(t,l){var e=l.action,a=l.payload,n=t.state;if(l.isTransition){var u=w.T,c={};w.T=c;try{var i=e(n,a),f=w.S;f!==null&&f(c,i),Us(t,l,i)}catch(s){Si(t,l,s)}finally{u!==null&&c.types!==null&&(u.types=c.types),w.T=u}}else try{u=e(n,a),Us(t,l,u)}catch(s){Si(t,l,s)}}function Us(t,l,e){e!==null&&typeof e=="object"&&typeof e.then=="function"?e.then(function(a){Hs(t,l,a)},function(a){return Si(t,l,a)}):Hs(t,l,e)}function Hs(t,l,e){l.status="fulfilled",l.value=e,yd(l),t.state=e,l=t.pending,l!==null&&(e=l.next,e===l?t.pending=null:(e=e.next,l.next=e,md(t,e)))}function Si(t,l,e){var a=t.pending;if(t.pending=null,a!==null){a=a.next;do l.status="rejected",l.reason=e,yd(l),l=l.next;while(l!==a)}t.action=null}function yd(t){t=t.listeners;for(var l=0;l<t.length;l++)(0,t[l])()}function hd(t,l){return l}function qs(t,l){if(q){var e=Q.formState;if(e!==null){t:{var a=R;if(q){if(F){l:{for(var n=F,u=It;n.nodeType!==8;){if(!u){n=null;break l}if(n=tl(n.nextSibling),n===null){n=null;break l}}u=n.data,n=u==="F!"||u==="F"?n:null}if(n){F=tl(n.nextSibling),a=n.data==="F!";break t}}te(a)}a=!1}a&&(l=e[0])}}return e=At(),e.memoizedState=e.baseState=l,a={pending:null,lanes:0,dispatch:null,lastRenderedReducer:hd,lastRenderedState:l},e.queue=a,e=wd.bind(null,R,a),a.dispatch=e,a=bi(!1),u=wf.bind(null,R,!1,a.queue),a=At(),n={state:l,dispatch:null,action:t,pending:null},a.queue=n,e=ty.bind(null,R,n,u,e),n.dispatch=e,a.memoizedState=t,[l,e,!1]}function Bs(t){var l=ft();return vd(l,Z,t)}function vd(t,l,e){if(l=Af(t,l,hd)[0],t=Wn(jl)[0],typeof l=="object"&&l!==null&&typeof l.then=="function")try{var a=vn(l)}catch(c){throw c===ga?Yu:c}else a=l;l=ft();var n=l.queue,u=n.dispatch;return e!==l.memoizedState&&(R.flags|=2048,ca(9,{destroy:void 0},ly.bind(null,n,e),null)),[a,u,t]}function ly(t,l){t.action=l}function Xs(t){var l=ft(),e=Z;if(e!==null)return vd(l,e,t);ft(),l=l.memoizedState,e=ft();var a=e.queue.dispatch;return e.memoizedState=t,[l,a,!1]}function ca(t,l,e,a){return t={tag:t,create:e,deps:a,inst:l,next:null},l=R.updateQueue,l===null&&(l=Gu(),R.updateQueue=l),e=l.lastEffect,e===null?l.lastEffect=t.next=t:(a=e.next,e.next=t,t.next=a,l.lastEffect=t),t}function gd(){return ft().memoizedState}function Fn(t,l,e,a){var n=At();R.flags|=t,n.memoizedState=ca(1|l,{destroy:void 0},e,a===void 0?null:a)}function Vu(t,l,e,a){var n=ft();a=a===void 0?null:a;var u=n.memoizedState.inst;Z!==null&&a!==null&&Sf(a,Z.memoizedState.deps)?n.memoizedState=ca(l,u,e,a):(R.flags|=t,n.memoizedState=ca(1|l,u,e,a))}function Ls(t,l){Fn(8390656,8,t,l)}function jf(t,l){Vu(2048,8,t,l)}function ey(t){R.flags|=4;var l=R.updateQueue;if(l===null)l=Gu(),R.updateQueue=l,l.events=[t];else{var e=l.events;e===null?l.events=[t]:e.push(t)}}function xd(t){var l=ft().memoizedState;return ey({ref:l,nextImpl:t}),function(){if(B&2)throw Error(T(440));return l.impl.apply(void 0,arguments)}}function bd(t,l){return Vu(4,2,t,l)}function Sd(t,l){return Vu(4,4,t,l)}function pd(t,l){if(typeof l=="function"){t=t();var e=l(t);return function(){typeof e=="function"?e():l(null)}}if(l!=null)return t=t(),l.current=t,function(){l.current=null}}function zd(t,l,e){e=e!=null?e.concat([t]):null,Vu(4,4,pd.bind(null,l,t),e)}function kf(){}function Td(t,l){var e=ft();l=l===void 0?null:l;var a=e.memoizedState;return l!==null&&Sf(l,a[1])?a[0]:(e.memoizedState=[t,l],t)}function Ed(t,l){var e=ft();l=l===void 0?null:l;var a=e.memoizedState;if(l!==null&&Sf(l,a[1]))return a[0];if(a=t(),Se){ql(!0);try{t()}finally{ql(!1)}}return e.memoizedState=[a,l],a}function Of(t,l,e){return e===void 0||Al&1073741824&&!(H&261930)?t.memoizedState=l:(t.memoizedState=e,t=d0(),R.lanes|=t,ee|=t,e)}function Md(t,l,e,a){return Gt(e,l)?e:ua.current!==null?(t=Of(t,e,a),Gt(t,l)||(dt=!0),t):!(Al&42)||Al&1073741824&&!(H&261930)?(dt=!0,t.memoizedState=e):(t=d0(),R.lanes|=t,ee|=t,l)}function Ad(t,l,e,a,n){var u=X.p;X.p=u!==0&&8>u?u:8;var c=w.T,i={};w.T=i,wf(t,!1,l,e);try{var f=n(),s=w.S;if(s!==null&&s(i,f),f!==null&&typeof f=="object"&&typeof f.then=="function"){var d=Fm(f,a);La(t,l,d,Yt(t))}else La(t,l,a,Yt(t))}catch(v){La(t,l,{then:function(){},status:"rejected",reason:v},Yt())}finally{X.p=u,c!==null&&i.types!==null&&(c.types=i.types),w.T=c}}function ay(){}function pi(t,l,e,a){if(t.tag!==5)throw Error(T(476));var n=jd(t).queue;Ad(t,n,l,de,e===null?ay:function(){return kd(t),e(a)})}function jd(t){var l=t.memoizedState;if(l!==null)return l;l={memoizedState:de,baseState:de,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:jl,lastRenderedState:de},next:null};var e={};return l.next={memoizedState:e,baseState:e,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:jl,lastRenderedState:e},next:null},t.memoizedState=l,t=t.alternate,t!==null&&(t.memoizedState=l),l}function kd(t){var l=jd(t);l.next===null&&(l=t.alternate.memoizedState),La(t,l.next.queue,{},Yt())}function Df(){return Et(un)}function Od(){return ft().memoizedState}function Dd(){return ft().memoizedState}function ny(t){for(var l=t.return;l!==null;){switch(l.tag){case 24:case 3:var e=Yt();t=Vl(e);var a=Ql(l,t,e);a!==null&&(_t(a,l,e),qa(a,l,e)),l={cache:hf()},t.payload=l;return}l=l.return}}function uy(t,l,e){var a=Yt();e={lane:a,revertLane:0,gesture:null,action:e,hasEagerState:!1,eagerState:null,next:null},Qu(t)?Nd(l,e):(e=rf(t,l,e,a),e!==null&&(_t(e,t,a),_d(e,l,a)))}function wd(t,l,e){var a=Yt();La(t,l,e,a)}function La(t,l,e,a){var n={lane:a,revertLane:0,gesture:null,action:e,hasEagerState:!1,eagerState:null,next:null};if(Qu(t))Nd(l,n);else{var u=t.alternate;if(t.lanes===0&&(u===null||u.lanes===0)&&(u=l.lastRenderedReducer,u!==null))try{var c=l.lastRenderedState,i=u(c,e);if(n.hasEagerState=!0,n.eagerState=i,Gt(i,c))return Lu(t,l,n,0),Q===null&&Xu(),!1}catch{}finally{}if(e=rf(t,l,n,a),e!==null)return _t(e,t,a),_d(e,l,a),!0}return!1}function wf(t,l,e,a){if(a={lane:2,revertLane:Bf(),gesture:null,action:a,hasEagerState:!1,eagerState:null,next:null},Qu(t)){if(l)throw Error(T(479))}else l=rf(t,e,a,2),l!==null&&_t(l,t,2)}function Qu(t){var l=t.alternate;return t===R||l!==null&&l===R}function Nd(t,l){Pe=gu=!0;var e=t.pending;e===null?l.next=l:(l.next=e.next,e.next=l),t.pending=l}function _d(t,l,e){if(e&4194048){var a=l.lanes;a&=t.pendingLanes,e|=a,l.lanes=e,xr(t,e)}}var en={readContext:Et,use:Zu,useCallback:at,useContext:at,useEffect:at,useImperativeHandle:at,useLayoutEffect:at,useInsertionEffect:at,useMemo:at,useReducer:at,useRef:at,useState:at,useDebugValue:at,useDeferredValue:at,useTransition:at,useSyncExternalStore:at,useId:at,useHostTransitionStatus:at,useFormState:at,useActionState:at,useOptimistic:at,useMemoCache:at,useCacheRefresh:at};en.useEffectEvent=at;var Cd={readContext:Et,use:Zu,useCallback:function(t,l){return At().memoizedState=[t,l===void 0?null:l],t},useContext:Et,useEffect:Ls,useImperativeHandle:function(t,l,e){e=e!=null?e.concat([t]):null,Fn(4194308,4,pd.bind(null,l,t),e)},useLayoutEffect:function(t,l){return Fn(4194308,4,t,l)},useInsertionEffect:function(t,l){Fn(4,2,t,l)},useMemo:function(t,l){var e=At();l=l===void 0?null:l;var a=t();if(Se){ql(!0);try{t()}finally{ql(!1)}}return e.memoizedState=[a,l],a},useReducer:function(t,l,e){var a=At();if(e!==void 0){var n=e(l);if(Se){ql(!0);try{e(l)}finally{ql(!1)}}}else n=l;return a.memoizedState=a.baseState=n,t={pending:null,lanes:0,dispatch:null,lastRenderedReducer:t,lastRenderedState:n},a.queue=t,t=t.dispatch=uy.bind(null,R,t),[a.memoizedState,t]},useRef:function(t){var l=At();return t={current:t},l.memoizedState=t},useState:function(t){t=bi(t);var l=t.queue,e=wd.bind(null,R,l);return l.dispatch=e,[t.memoizedState,e]},useDebugValue:kf,useDeferredValue:function(t,l){var e=At();return Of(e,t,l)},useTransition:function(){var t=bi(!1);return t=Ad.bind(null,R,t.queue,!0,!1),At().memoizedState=t,[!1,t]},useSyncExternalStore:function(t,l,e){var a=R,n=At();if(q){if(e===void 0)throw Error(T(407));e=e()}else{if(e=l(),Q===null)throw Error(T(349));H&127||id(a,l,e)}n.memoizedState=e;var u={value:e,getSnapshot:l};return n.queue=u,Ls(sd.bind(null,a,u,t),[t]),a.flags|=2048,ca(9,{destroy:void 0},fd.bind(null,a,u,e,l),null),e},useId:function(){var t=At(),l=Q.identifierPrefix;if(q){var e=cl,a=ul;e=(a&~(1<<32-Lt(a)-1)).toString(32)+e,l="_"+l+"R_"+e,e=xu++,0<e&&(l+="H"+e.toString(32)),l+="_"}else e=Im++,l="_"+l+"r_"+e.toString(32)+"_";return t.memoizedState=l},useHostTransitionStatus:Df,useFormState:qs,useActionState:qs,useOptimistic:function(t){var l=At();l.memoizedState=l.baseState=t;var e={pending:null,lanes:0,dispatch:null,lastRenderedReducer:null,lastRenderedState:null};return l.queue=e,l=wf.bind(null,R,!0,e),e.dispatch=l,[t,l]},useMemoCache:Mf,useCacheRefresh:function(){return At().memoizedState=ny.bind(null,R)},useEffectEvent:function(t){var l=At(),e={impl:t};return l.memoizedState=e,function(){if(B&2)throw Error(T(440));return e.impl.apply(void 0,arguments)}}},Nf={readContext:Et,use:Zu,useCallback:Td,useContext:Et,useEffect:jf,useImperativeHandle:zd,useInsertionEffect:bd,useLayoutEffect:Sd,useMemo:Ed,useReducer:Wn,useRef:gd,useState:function(){return Wn(jl)},useDebugValue:kf,useDeferredValue:function(t,l){var e=ft();return Md(e,Z.memoizedState,t,l)},useTransition:function(){var t=Wn(jl)[0],l=ft().memoizedState;return[typeof t=="boolean"?t:vn(t),l]},useSyncExternalStore:cd,useId:Od,useHostTransitionStatus:Df,useFormState:Bs,useActionState:Bs,useOptimistic:function(t,l){var e=ft();return dd(e,Z,t,l)},useMemoCache:Mf,useCacheRefresh:Dd};Nf.useEffectEvent=xd;var Rd={readContext:Et,use:Zu,useCallback:Td,useContext:Et,useEffect:jf,useImperativeHandle:zd,useInsertionEffect:bd,useLayoutEffect:Sd,useMemo:Ed,useReducer:gc,useRef:gd,useState:function(){return gc(jl)},useDebugValue:kf,useDeferredValue:function(t,l){var e=ft();return Z===null?Of(e,t,l):Md(e,Z.memoizedState,t,l)},useTransition:function(){var t=gc(jl)[0],l=ft().memoizedState;return[typeof t=="boolean"?t:vn(t),l]},useSyncExternalStore:cd,useId:Od,useHostTransitionStatus:Df,useFormState:Xs,useActionState:Xs,useOptimistic:function(t,l){var e=ft();return Z!==null?dd(e,Z,t,l):(e.baseState=t,[t,e.queue.dispatch])},useMemoCache:Mf,useCacheRefresh:Dd};Rd.useEffectEvent=xd;function xc(t,l,e,a){l=t.memoizedState,e=e(a,l),e=e==null?l:tt({},l,e),t.memoizedState=e,t.lanes===0&&(t.updateQueue.baseState=e)}var zi={enqueueSetState:function(t,l,e){t=t._reactInternals;var a=Yt(),n=Vl(a);n.payload=l,e!=null&&(n.callback=e),l=Ql(t,n,a),l!==null&&(_t(l,t,a),qa(l,t,a))},enqueueReplaceState:function(t,l,e){t=t._reactInternals;var a=Yt(),n=Vl(a);n.tag=1,n.payload=l,e!=null&&(n.callback=e),l=Ql(t,n,a),l!==null&&(_t(l,t,a),qa(l,t,a))},enqueueForceUpdate:function(t,l){t=t._reactInternals;var e=Yt(),a=Vl(e);a.tag=2,l!=null&&(a.callback=l),l=Ql(t,a,e),l!==null&&(_t(l,t,e),qa(l,t,e))}};function Ys(t,l,e,a,n,u,c){return t=t.stateNode,typeof t.shouldComponentUpdate=="function"?t.shouldComponentUpdate(a,u,c):l.prototype&&l.prototype.isPureReactComponent?!Fa(e,a)||!Fa(n,u):!0}function Gs(t,l,e,a){t=l.state,typeof l.componentWillReceiveProps=="function"&&l.componentWillReceiveProps(e,a),typeof l.UNSAFE_componentWillReceiveProps=="function"&&l.UNSAFE_componentWillReceiveProps(e,a),l.state!==t&&zi.enqueueReplaceState(l,l.state,null)}function pe(t,l){var e=l;if("ref"in l){e={};for(var a in l)a!=="ref"&&(e[a]=l[a])}if(t=t.defaultProps){e===l&&(e=tt({},e));for(var n in t)e[n]===void 0&&(e[n]=t[n])}return e}function $d(t){ou(t)}function Ud(t){console.error(t)}function Hd(t){ou(t)}function bu(t,l){try{var e=t.onUncaughtError;e(l.value,{componentStack:l.stack})}catch(a){setTimeout(function(){throw a})}}function Zs(t,l,e){try{var a=t.onCaughtError;a(e.value,{componentStack:e.stack,errorBoundary:l.tag===1?l.stateNode:null})}catch(n){setTimeout(function(){throw n})}}function Ti(t,l,e){return e=Vl(e),e.tag=3,e.payload={element:null},e.callback=function(){bu(t,l)},e}function qd(t){return t=Vl(t),t.tag=3,t}function Bd(t,l,e,a){var n=e.type.getDerivedStateFromError;if(typeof n=="function"){var u=a.value;t.payload=function(){return n(u)},t.callback=function(){Zs(l,e,a)}}var c=e.stateNode;c!==null&&typeof c.componentDidCatch=="function"&&(t.callback=function(){Zs(l,e,a),typeof n!="function"&&(Kl===null?Kl=new Set([this]):Kl.add(this));var i=a.stack;this.componentDidCatch(a.value,{componentStack:i!==null?i:""})})}function cy(t,l,e,a,n){if(e.flags|=32768,a!==null&&typeof a=="object"&&typeof a.then=="function"){if(l=e.alternate,l!==null&&va(l,e,n,!0),e=Zt.current,e!==null){switch(e.tag){case 31:case 13:return Pt===null?Eu():e.alternate===null&&nt===0&&(nt=3),e.flags&=-257,e.flags|=65536,e.lanes=n,a===yu?e.flags|=16384:(l=e.updateQueue,l===null?e.updateQueue=new Set([a]):l.add(a),Oc(t,a,n)),!1;case 22:return e.flags|=65536,a===yu?e.flags|=16384:(l=e.updateQueue,l===null?(l={transitions:null,markerInstances:null,retryQueue:new Set([a])},e.updateQueue=l):(e=l.retryQueue,e===null?l.retryQueue=new Set([a]):e.add(a)),Oc(t,a,n)),!1}throw Error(T(435,e.tag))}return Oc(t,a,n),Eu(),!1}if(q)return l=Zt.current,l!==null?(!(l.flags&65536)&&(l.flags|=256),l.flags|=65536,l.lanes=n,a!==oi&&(t=Error(T(422),{cause:a}),Pa(Ft(t,e)))):(a!==oi&&(l=Error(T(423),{cause:a}),Pa(Ft(l,e))),t=t.current.alternate,t.flags|=65536,n&=-n,t.lanes|=n,a=Ft(a,e),n=Ti(t.stateNode,a,n),vc(t,n),nt!==4&&(nt=2)),!1;var u=Error(T(520),{cause:a});if(u=Ft(u,e),Za===null?Za=[u]:Za.push(u),nt!==4&&(nt=2),l===null)return!0;a=Ft(a,e),e=l;do{switch(e.tag){case 3:return e.flags|=65536,t=n&-n,e.lanes|=t,t=Ti(e.stateNode,a,t),vc(e,t),!1;case 1:if(l=e.type,u=e.stateNode,(e.flags&128)===0&&(typeof l.getDerivedStateFromError=="function"||u!==null&&typeof u.componentDidCatch=="function"&&(Kl===null||!Kl.has(u))))return e.flags|=65536,n&=-n,e.lanes|=n,n=qd(n),Bd(n,t,e,a),vc(e,n),!1}e=e.return}while(e!==null);return!1}var _f=Error(T(461)),dt=!1;function pt(t,l,e,a){l.child=t===null?td(l,null,e,a):be(l,t.child,e,a)}function Vs(t,l,e,a,n){e=e.render;var u=l.ref;if("ref"in a){var c={};for(var i in a)i!=="ref"&&(c[i]=a[i])}else c=a;return xe(l),a=pf(t,l,e,c,u,n),i=zf(),t!==null&&!dt?(Tf(t,l,n),kl(t,l,n)):(q&&i&&mf(l),l.flags|=1,pt(t,l,a,n),l.child)}function Qs(t,l,e,a,n){if(t===null){var u=e.type;return typeof u=="function"&&!df(u)&&u.defaultProps===void 0&&e.compare===null?(l.tag=15,l.type=u,Xd(t,l,u,a,n)):(t=Kn(e.type,null,a,l,l.mode,n),t.ref=l.ref,t.return=l,l.child=t)}if(u=t.child,!Cf(t,n)){var c=u.memoizedProps;if(e=e.compare,e=e!==null?e:Fa,e(c,a)&&t.ref===l.ref)return kl(t,l,n)}return l.flags|=1,t=zl(u,a),t.ref=l.ref,t.return=l,l.child=t}function Xd(t,l,e,a,n){if(t!==null){var u=t.memoizedProps;if(Fa(u,a)&&t.ref===l.ref)if(dt=!1,l.pendingProps=a=u,Cf(t,n))t.flags&131072&&(dt=!0);else return l.lanes=t.lanes,kl(t,l,n)}return Ei(t,l,e,a,n)}function Ld(t,l,e,a){var n=a.children,u=t!==null?t.memoizedState:null;if(t===null&&l.stateNode===null&&(l.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),a.mode==="hidden"){if(l.flags&128){if(u=u!==null?u.baseLanes|e:e,t!==null){for(a=l.child=t.child,n=0;a!==null;)n=n|a.lanes|a.childLanes,a=a.sibling;a=n&~u}else a=0,l.child=null;return Ks(t,l,u,e,a)}if(e&536870912)l.memoizedState={baseLanes:0,cachePool:null},t!==null&&Jn(l,u!==null?u.cachePool:null),u!==null?$s(l,u):gi(),ad(l);else return a=l.lanes=536870912,Ks(t,l,u!==null?u.baseLanes|e:e,e,a)}else u!==null?(Jn(l,u.cachePool),$s(l,u),Ul(),l.memoizedState=null):(t!==null&&Jn(l,null),gi(),Ul());return pt(t,l,n,e),l.child}function Na(t,l){return t!==null&&t.tag===22||l.stateNode!==null||(l.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),l.sibling}function Ks(t,l,e,a,n){var u=vf();return u=u===null?null:{parent:rt._currentValue,pool:u},l.memoizedState={baseLanes:e,cachePool:u},t!==null&&Jn(l,null),gi(),ad(l),t!==null&&va(t,l,a,!0),l.childLanes=n,null}function In(t,l){return l=Su({mode:l.mode,children:l.children},t.mode),l.ref=t.ref,t.child=l,l.return=t,l}function Js(t,l,e){return be(l,t.child,null,e),t=In(l,l.pendingProps),t.flags|=2,Ut(l),l.memoizedState=null,t}function iy(t,l,e){var a=l.pendingProps,n=(l.flags&128)!==0;if(l.flags&=-129,t===null){if(q){if(a.mode==="hidden")return t=In(l,a),l.lanes=536870912,Na(null,t);if(xi(l),(t=F)?(t=C0(t,It),t=t!==null&&t.data==="&"?t:null,t!==null&&(l.memoizedState={dehydrated:t,treeContext:Pl!==null?{id:ul,overflow:cl}:null,retryLane:536870912,hydrationErrors:null},e=Qr(t),e.return=l,l.child=e,Tt=l,F=null)):t=null,t===null)throw te(l);return l.lanes=536870912,null}return In(l,a)}var u=t.memoizedState;if(u!==null){var c=u.dehydrated;if(xi(l),n)if(l.flags&256)l.flags&=-257,l=Js(t,l,e);else if(l.memoizedState!==null)l.child=t.child,l.flags|=128,l=null;else throw Error(T(558));else if(dt||va(t,l,e,!1),n=(e&t.childLanes)!==0,dt||n){if(a=Q,a!==null&&(c=br(a,e),c!==0&&c!==u.retryLane))throw u.retryLane=c,Me(t,c),_t(a,t,c),_f;Eu(),l=Js(t,l,e)}else t=u.treeContext,F=tl(c.nextSibling),Tt=l,q=!0,Zl=null,It=!1,t!==null&&Jr(l,t),l=In(l,a),l.flags|=4096;return l}return t=zl(t.child,{mode:a.mode,children:a.children}),t.ref=l.ref,l.child=t,t.return=l,t}function Pn(t,l){var e=l.ref;if(e===null)t!==null&&t.ref!==null&&(l.flags|=4194816);else{if(typeof e!="function"&&typeof e!="object")throw Error(T(284));(t===null||t.ref!==e)&&(l.flags|=4194816)}}function Ei(t,l,e,a,n){return xe(l),e=pf(t,l,e,a,void 0,n),a=zf(),t!==null&&!dt?(Tf(t,l,n),kl(t,l,n)):(q&&a&&mf(l),l.flags|=1,pt(t,l,e,n),l.child)}function Ws(t,l,e,a,n,u){return xe(l),l.updateQueue=null,e=ud(l,a,e,n),nd(t),a=zf(),t!==null&&!dt?(Tf(t,l,u),kl(t,l,u)):(q&&a&&mf(l),l.flags|=1,pt(t,l,e,u),l.child)}function Fs(t,l,e,a,n){if(xe(l),l.stateNode===null){var u=Le,c=e.contextType;typeof c=="object"&&c!==null&&(u=Et(c)),u=new e(a,u),l.memoizedState=u.state!==null&&u.state!==void 0?u.state:null,u.updater=zi,l.stateNode=u,u._reactInternals=l,u=l.stateNode,u.props=a,u.state=l.memoizedState,u.refs={},xf(l),c=e.contextType,u.context=typeof c=="object"&&c!==null?Et(c):Le,u.state=l.memoizedState,c=e.getDerivedStateFromProps,typeof c=="function"&&(xc(l,e,c,a),u.state=l.memoizedState),typeof e.getDerivedStateFromProps=="function"||typeof u.getSnapshotBeforeUpdate=="function"||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(c=u.state,typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount(),c!==u.state&&zi.enqueueReplaceState(u,u.state,null),Xa(l,a,u,n),Ba(),u.state=l.memoizedState),typeof u.componentDidMount=="function"&&(l.flags|=4194308),a=!0}else if(t===null){u=l.stateNode;var i=l.memoizedProps,f=pe(e,i);u.props=f;var s=u.context,d=e.contextType;c=Le,typeof d=="object"&&d!==null&&(c=Et(d));var v=e.getDerivedStateFromProps;d=typeof v=="function"||typeof u.getSnapshotBeforeUpdate=="function",i=l.pendingProps!==i,d||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(i||s!==c)&&Gs(l,u,a,c),Cl=!1;var m=l.memoizedState;u.state=m,Xa(l,a,u,n),Ba(),s=l.memoizedState,i||m!==s||Cl?(typeof v=="function"&&(xc(l,e,v,a),s=l.memoizedState),(f=Cl||Ys(l,e,f,a,m,s,c))?(d||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount()),typeof u.componentDidMount=="function"&&(l.flags|=4194308)):(typeof u.componentDidMount=="function"&&(l.flags|=4194308),l.memoizedProps=a,l.memoizedState=s),u.props=a,u.state=s,u.context=c,a=f):(typeof u.componentDidMount=="function"&&(l.flags|=4194308),a=!1)}else{u=l.stateNode,hi(t,l),c=l.memoizedProps,d=pe(e,c),u.props=d,v=l.pendingProps,m=u.context,s=e.contextType,f=Le,typeof s=="object"&&s!==null&&(f=Et(s)),i=e.getDerivedStateFromProps,(s=typeof i=="function"||typeof u.getSnapshotBeforeUpdate=="function")||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(c!==v||m!==f)&&Gs(l,u,a,f),Cl=!1,m=l.memoizedState,u.state=m,Xa(l,a,u,n),Ba();var h=l.memoizedState;c!==v||m!==h||Cl||t!==null&&t.dependencies!==null&&mu(t.dependencies)?(typeof i=="function"&&(xc(l,e,i,a),h=l.memoizedState),(d=Cl||Ys(l,e,d,a,m,h,f)||t!==null&&t.dependencies!==null&&mu(t.dependencies))?(s||typeof u.UNSAFE_componentWillUpdate!="function"&&typeof u.componentWillUpdate!="function"||(typeof u.componentWillUpdate=="function"&&u.componentWillUpdate(a,h,f),typeof u.UNSAFE_componentWillUpdate=="function"&&u.UNSAFE_componentWillUpdate(a,h,f)),typeof u.componentDidUpdate=="function"&&(l.flags|=4),typeof u.getSnapshotBeforeUpdate=="function"&&(l.flags|=1024)):(typeof u.componentDidUpdate!="function"||c===t.memoizedProps&&m===t.memoizedState||(l.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||c===t.memoizedProps&&m===t.memoizedState||(l.flags|=1024),l.memoizedProps=a,l.memoizedState=h),u.props=a,u.state=h,u.context=f,a=d):(typeof u.componentDidUpdate!="function"||c===t.memoizedProps&&m===t.memoizedState||(l.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||c===t.memoizedProps&&m===t.memoizedState||(l.flags|=1024),a=!1)}return u=a,Pn(t,l),a=(l.flags&128)!==0,u||a?(u=l.stateNode,e=a&&typeof e.getDerivedStateFromError!="function"?null:u.render(),l.flags|=1,t!==null&&a?(l.child=be(l,t.child,null,n),l.child=be(l,null,e,n)):pt(t,l,e,n),l.memoizedState=u.state,t=l.child):t=kl(t,l,n),t}function Is(t,l,e,a){return ge(),l.flags|=256,pt(t,l,e,a),l.child}var bc={dehydrated:null,treeContext:null,retryLane:0,hydrationErrors:null};function Sc(t){return{baseLanes:t,cachePool:Fr()}}function pc(t,l,e){return t=t!==null?t.childLanes&~e:0,l&&(t|=qt),t}function Yd(t,l,e){var a=l.pendingProps,n=!1,u=(l.flags&128)!==0,c;if((c=u)||(c=t!==null&&t.memoizedState===null?!1:(it.current&2)!==0),c&&(n=!0,l.flags&=-129),c=(l.flags&32)!==0,l.flags&=-33,t===null){if(q){if(n?$l(l):Ul(),(t=F)?(t=C0(t,It),t=t!==null&&t.data!=="&"?t:null,t!==null&&(l.memoizedState={dehydrated:t,treeContext:Pl!==null?{id:ul,overflow:cl}:null,retryLane:536870912,hydrationErrors:null},e=Qr(t),e.return=l,l.child=e,Tt=l,F=null)):t=null,t===null)throw te(l);return Hi(t)?l.lanes=32:l.lanes=536870912,null}var i=a.children;return a=a.fallback,n?(Ul(),n=l.mode,i=Su({mode:"hidden",children:i},n),a=me(a,n,e,null),i.return=l,a.return=l,i.sibling=a,l.child=i,a=l.child,a.memoizedState=Sc(e),a.childLanes=pc(t,c,e),l.memoizedState=bc,Na(null,a)):($l(l),Mi(l,i))}var f=t.memoizedState;if(f!==null&&(i=f.dehydrated,i!==null)){if(u)l.flags&256?($l(l),l.flags&=-257,l=zc(t,l,e)):l.memoizedState!==null?(Ul(),l.child=t.child,l.flags|=128,l=null):(Ul(),i=a.fallback,n=l.mode,a=Su({mode:"visible",children:a.children},n),i=me(i,n,e,null),i.flags|=2,a.return=l,i.return=l,a.sibling=i,l.child=a,be(l,t.child,null,e),a=l.child,a.memoizedState=Sc(e),a.childLanes=pc(t,c,e),l.memoizedState=bc,l=Na(null,a));else if($l(l),Hi(i)){if(c=i.nextSibling&&i.nextSibling.dataset,c)var s=c.dgst;c=s,a=Error(T(419)),a.stack="",a.digest=c,Pa({value:a,source:null,stack:null}),l=zc(t,l,e)}else if(dt||va(t,l,e,!1),c=(e&t.childLanes)!==0,dt||c){if(c=Q,c!==null&&(a=br(c,e),a!==0&&a!==f.retryLane))throw f.retryLane=a,Me(t,a),_t(c,t,a),_f;Ui(i)||Eu(),l=zc(t,l,e)}else Ui(i)?(l.flags|=192,l.child=t.child,l=null):(t=f.treeContext,F=tl(i.nextSibling),Tt=l,q=!0,Zl=null,It=!1,t!==null&&Jr(l,t),l=Mi(l,a.children),l.flags|=4096);return l}return n?(Ul(),i=a.fallback,n=l.mode,f=t.child,s=f.sibling,a=zl(f,{mode:"hidden",children:a.children}),a.subtreeFlags=f.subtreeFlags&65011712,s!==null?i=zl(s,i):(i=me(i,n,e,null),i.flags|=2),i.return=l,a.return=l,a.sibling=i,l.child=a,Na(null,a),a=l.child,i=t.child.memoizedState,i===null?i=Sc(e):(n=i.cachePool,n!==null?(f=rt._currentValue,n=n.parent!==f?{parent:f,pool:f}:n):n=Fr(),i={baseLanes:i.baseLanes|e,cachePool:n}),a.memoizedState=i,a.childLanes=pc(t,c,e),l.memoizedState=bc,Na(t.child,a)):($l(l),e=t.child,t=e.sibling,e=zl(e,{mode:"visible",children:a.children}),e.return=l,e.sibling=null,t!==null&&(c=l.deletions,c===null?(l.deletions=[t],l.flags|=16):c.push(t)),l.child=e,l.memoizedState=null,e)}function Mi(t,l){return l=Su({mode:"visible",children:l},t.mode),l.return=t,t.child=l}function Su(t,l){return t=Ht(22,t,null,l),t.lanes=0,t}function zc(t,l,e){return be(l,t.child,null,e),t=Mi(l,l.pendingProps.children),t.flags|=2,l.memoizedState=null,t}function Ps(t,l,e){t.lanes|=l;var a=t.alternate;a!==null&&(a.lanes|=l),di(t.return,l,e)}function Tc(t,l,e,a,n,u){var c=t.memoizedState;c===null?t.memoizedState={isBackwards:l,rendering:null,renderingStartTime:0,last:a,tail:e,tailMode:n,treeForkCount:u}:(c.isBackwards=l,c.rendering=null,c.renderingStartTime=0,c.last=a,c.tail=e,c.tailMode=n,c.treeForkCount=u)}function Gd(t,l,e){var a=l.pendingProps,n=a.revealOrder,u=a.tail;a=a.children;var c=it.current,i=(c&2)!==0;if(i?(c=c&1|2,l.flags|=128):c&=1,K(it,c),pt(t,l,a,e),a=q?Ia:0,!i&&t!==null&&t.flags&128)t:for(t=l.child;t!==null;){if(t.tag===13)t.memoizedState!==null&&Ps(t,e,l);else if(t.tag===19)Ps(t,e,l);else if(t.child!==null){t.child.return=t,t=t.child;continue}if(t===l)break t;for(;t.sibling===null;){if(t.return===null||t.return===l)break t;t=t.return}t.sibling.return=t.return,t=t.sibling}switch(n){case"forwards":for(e=l.child,n=null;e!==null;)t=e.alternate,t!==null&&vu(t)===null&&(n=e),e=e.sibling;e=n,e===null?(n=l.child,l.child=null):(n=e.sibling,e.sibling=null),Tc(l,!1,n,e,u,a);break;case"backwards":case"unstable_legacy-backwards":for(e=null,n=l.child,l.child=null;n!==null;){if(t=n.alternate,t!==null&&vu(t)===null){l.child=n;break}t=n.sibling,n.sibling=e,e=n,n=t}Tc(l,!0,e,null,u,a);break;case"together":Tc(l,!1,null,null,void 0,a);break;default:l.memoizedState=null}return l.child}function kl(t,l,e){if(t!==null&&(l.dependencies=t.dependencies),ee|=l.lanes,!(e&l.childLanes))if(t!==null){if(va(t,l,e,!1),(e&l.childLanes)===0)return null}else return null;if(t!==null&&l.child!==t.child)throw Error(T(153));if(l.child!==null){for(t=l.child,e=zl(t,t.pendingProps),l.child=e,e.return=l;t.sibling!==null;)t=t.sibling,e=e.sibling=zl(t,t.pendingProps),e.return=l;e.sibling=null}return l.child}function Cf(t,l){return t.lanes&l?!0:(t=t.dependencies,!!(t!==null&&mu(t)))}function fy(t,l,e){switch(l.tag){case 3:cu(l,l.stateNode.containerInfo),Rl(l,rt,t.memoizedState.cache),ge();break;case 27:case 5:Pc(l);break;case 4:cu(l,l.stateNode.containerInfo);break;case 10:Rl(l,l.type,l.memoizedProps.value);break;case 31:if(l.memoizedState!==null)return l.flags|=128,xi(l),null;break;case 13:var a=l.memoizedState;if(a!==null)return a.dehydrated!==null?($l(l),l.flags|=128,null):e&l.child.childLanes?Yd(t,l,e):($l(l),t=kl(t,l,e),t!==null?t.sibling:null);$l(l);break;case 19:var n=(t.flags&128)!==0;if(a=(e&l.childLanes)!==0,a||(va(t,l,e,!1),a=(e&l.childLanes)!==0),n){if(a)return Gd(t,l,e);l.flags|=128}if(n=l.memoizedState,n!==null&&(n.rendering=null,n.tail=null,n.lastEffect=null),K(it,it.current),a)break;return null;case 22:return l.lanes=0,Ld(t,l,e,l.pendingProps);case 24:Rl(l,rt,t.memoizedState.cache)}return kl(t,l,e)}function Zd(t,l,e){if(t!==null)if(t.memoizedProps!==l.pendingProps)dt=!0;else{if(!Cf(t,e)&&!(l.flags&128))return dt=!1,fy(t,l,e);dt=!!(t.flags&131072)}else dt=!1,q&&l.flags&1048576&&Kr(l,Ia,l.index);switch(l.lanes=0,l.tag){case 16:t:{var a=l.pendingProps;if(t=oe(l.elementType),l.type=t,typeof t=="function")df(t)?(a=pe(t,a),l.tag=1,l=Fs(null,l,t,a,e)):(l.tag=0,l=Ei(null,l,t,a,e));else{if(t!=null){var n=t.$$typeof;if(n===Fi){l.tag=11,l=Vs(null,l,t,a,e);break t}else if(n===Ii){l.tag=14,l=Qs(null,l,t,a,e);break t}}throw l=Fc(t)||t,Error(T(306,l,""))}}return l;case 0:return Ei(t,l,l.type,l.pendingProps,e);case 1:return a=l.type,n=pe(a,l.pendingProps),Fs(t,l,a,n,e);case 3:t:{if(cu(l,l.stateNode.containerInfo),t===null)throw Error(T(387));a=l.pendingProps;var u=l.memoizedState;n=u.element,hi(t,l),Xa(l,a,null,e);var c=l.memoizedState;if(a=c.cache,Rl(l,rt,a),a!==u.cache&&mi(l,[rt],e,!0),Ba(),a=c.element,u.isDehydrated)if(u={element:a,isDehydrated:!1,cache:c.cache},l.updateQueue.baseState=u,l.memoizedState=u,l.flags&256){l=Is(t,l,a,e);break t}else if(a!==n){n=Ft(Error(T(424)),l),Pa(n),l=Is(t,l,a,e);break t}else{switch(t=l.stateNode.containerInfo,t.nodeType){case 9:t=t.body;break;default:t=t.nodeName==="HTML"?t.ownerDocument.body:t}for(F=tl(t.firstChild),Tt=l,q=!0,Zl=null,It=!0,e=td(l,null,a,e),l.child=e;e;)e.flags=e.flags&-3|4096,e=e.sibling}else{if(ge(),a===n){l=kl(t,l,e);break t}pt(t,l,a,e)}l=l.child}return l;case 26:return Pn(t,l),t===null?(e=So(l.type,null,l.pendingProps,null))?l.memoizedState=e:q||(e=l.type,t=l.pendingProps,a=ku(Gl.current).createElement(e),a[zt]=l,a[Ct]=t,Mt(a,e,t),xt(a),l.stateNode=a):l.memoizedState=So(l.type,t.memoizedProps,l.pendingProps,t.memoizedState),null;case 27:return Pc(l),t===null&&q&&(a=l.stateNode=R0(l.type,l.pendingProps,Gl.current),Tt=l,It=!0,n=F,ne(l.type)?(qi=n,F=tl(a.firstChild)):F=n),pt(t,l,l.pendingProps.children,e),Pn(t,l),t===null&&(l.flags|=4194304),l.child;case 5:return t===null&&q&&((n=a=F)&&(a=Hy(a,l.type,l.pendingProps,It),a!==null?(l.stateNode=a,Tt=l,F=tl(a.firstChild),It=!1,n=!0):n=!1),n||te(l)),Pc(l),n=l.type,u=l.pendingProps,c=t!==null?t.memoizedProps:null,a=u.children,Ri(n,u)?a=null:c!==null&&Ri(n,c)&&(l.flags|=32),l.memoizedState!==null&&(n=pf(t,l,Pm,null,null,e),un._currentValue=n),Pn(t,l),pt(t,l,a,e),l.child;case 6:return t===null&&q&&((t=e=F)&&(e=qy(e,l.pendingProps,It),e!==null?(l.stateNode=e,Tt=l,F=null,t=!0):t=!1),t||te(l)),null;case 13:return Yd(t,l,e);case 4:return cu(l,l.stateNode.containerInfo),a=l.pendingProps,t===null?l.child=be(l,null,a,e):pt(t,l,a,e),l.child;case 11:return Vs(t,l,l.type,l.pendingProps,e);case 7:return pt(t,l,l.pendingProps,e),l.child;case 8:return pt(t,l,l.pendingProps.children,e),l.child;case 12:return pt(t,l,l.pendingProps.children,e),l.child;case 10:return a=l.pendingProps,Rl(l,l.type,a.value),pt(t,l,a.children,e),l.child;case 9:return n=l.type._context,a=l.pendingProps.children,xe(l),n=Et(n),a=a(n),l.flags|=1,pt(t,l,a,e),l.child;case 14:return Qs(t,l,l.type,l.pendingProps,e);case 15:return Xd(t,l,l.type,l.pendingProps,e);case 19:return Gd(t,l,e);case 31:return iy(t,l,e);case 22:return Ld(t,l,e,l.pendingProps);case 24:return xe(l),a=Et(rt),t===null?(n=vf(),n===null&&(n=Q,u=hf(),n.pooledCache=u,u.refCount++,u!==null&&(n.pooledCacheLanes|=e),n=u),l.memoizedState={parent:a,cache:n},xf(l),Rl(l,rt,n)):(t.lanes&e&&(hi(t,l),Xa(l,null,null,e),Ba()),n=t.memoizedState,u=l.memoizedState,n.parent!==a?(n={parent:a,cache:a},l.memoizedState=n,l.lanes===0&&(l.memoizedState=l.updateQueue.baseState=n),Rl(l,rt,a)):(a=u.cache,Rl(l,rt,a),a!==n.cache&&mi(l,[rt],e,!0))),pt(t,l,l.pendingProps.children,e),l.child;case 29:throw l.pendingProps}throw Error(T(156,l.tag))}function ml(t){t.flags|=4}function Ec(t,l,e,a,n){if((l=(t.mode&32)!==0)&&(l=!1),l){if(t.flags|=16777216,(n&335544128)===n)if(t.stateNode.complete)t.flags|=8192;else if(h0())t.flags|=8192;else throw he=yu,gf}else t.flags&=-16777217}function to(t,l){if(l.type!=="stylesheet"||l.state.loading&4)t.flags&=-16777217;else if(t.flags|=16777216,!H0(l))if(h0())t.flags|=8192;else throw he=yu,gf}function _n(t,l){l!==null&&(t.flags|=4),t.flags&16384&&(l=t.tag!==22?vr():536870912,t.lanes|=l,ia|=l)}function Ma(t,l){if(!q)switch(t.tailMode){case"hidden":l=t.tail;for(var e=null;l!==null;)l.alternate!==null&&(e=l),l=l.sibling;e===null?t.tail=null:e.sibling=null;break;case"collapsed":e=t.tail;for(var a=null;e!==null;)e.alternate!==null&&(a=e),e=e.sibling;a===null?l||t.tail===null?t.tail=null:t.tail.sibling=null:a.sibling=null}}function W(t){var l=t.alternate!==null&&t.alternate.child===t.child,e=0,a=0;if(l)for(var n=t.child;n!==null;)e|=n.lanes|n.childLanes,a|=n.subtreeFlags&65011712,a|=n.flags&65011712,n.return=t,n=n.sibling;else for(n=t.child;n!==null;)e|=n.lanes|n.childLanes,a|=n.subtreeFlags,a|=n.flags,n.return=t,n=n.sibling;return t.subtreeFlags|=a,t.childLanes=e,l}function sy(t,l,e){var a=l.pendingProps;switch(yf(l),l.tag){case 16:case 15:case 0:case 11:case 7:case 8:case 12:case 9:case 14:return W(l),null;case 1:return W(l),null;case 3:return e=l.stateNode,a=null,t!==null&&(a=t.memoizedState.cache),l.memoizedState.cache!==a&&(l.flags|=2048),Tl(rt),la(),e.pendingContext&&(e.context=e.pendingContext,e.pendingContext=null),(t===null||t.child===null)&&(ke(l)?ml(l):t===null||t.memoizedState.isDehydrated&&!(l.flags&256)||(l.flags|=1024,hc())),W(l),null;case 26:var n=l.type,u=l.memoizedState;return t===null?(ml(l),u!==null?(W(l),to(l,u)):(W(l),Ec(l,n,null,a,e))):u?u!==t.memoizedState?(ml(l),W(l),to(l,u)):(W(l),l.flags&=-16777217):(t=t.memoizedProps,t!==a&&ml(l),W(l),Ec(l,n,t,a,e)),null;case 27:if(iu(l),e=Gl.current,n=l.type,t!==null&&l.stateNode!=null)t.memoizedProps!==a&&ml(l);else{if(!a){if(l.stateNode===null)throw Error(T(166));return W(l),null}t=fl.current,ke(l)?Os(l):(t=R0(n,a,e),l.stateNode=t,ml(l))}return W(l),null;case 5:if(iu(l),n=l.type,t!==null&&l.stateNode!=null)t.memoizedProps!==a&&ml(l);else{if(!a){if(l.stateNode===null)throw Error(T(166));return W(l),null}if(u=fl.current,ke(l))Os(l);else{var c=ku(Gl.current);switch(u){case 1:u=c.createElementNS("http://www.w3.org/2000/svg",n);break;case 2:u=c.createElementNS("http://www.w3.org/1998/Math/MathML",n);break;default:switch(n){case"svg":u=c.createElementNS("http://www.w3.org/2000/svg",n);break;case"math":u=c.createElementNS("http://www.w3.org/1998/Math/MathML",n);break;case"script":u=c.createElement("div"),u.innerHTML="<script><\/script>",u=u.removeChild(u.firstChild);break;case"select":u=typeof a.is=="string"?c.createElement("select",{is:a.is}):c.createElement("select"),a.multiple?u.multiple=!0:a.size&&(u.size=a.size);break;default:u=typeof a.is=="string"?c.createElement(n,{is:a.is}):c.createElement(n)}}u[zt]=l,u[Ct]=a;t:for(c=l.child;c!==null;){if(c.tag===5||c.tag===6)u.appendChild(c.stateNode);else if(c.tag!==4&&c.tag!==27&&c.child!==null){c.child.return=c,c=c.child;continue}if(c===l)break t;for(;c.sibling===null;){if(c.return===null||c.return===l)break t;c=c.return}c.sibling.return=c.return,c=c.sibling}l.stateNode=u;t:switch(Mt(u,n,a),n){case"button":case"input":case"select":case"textarea":a=!!a.autoFocus;break t;case"img":a=!0;break t;default:a=!1}a&&ml(l)}}return W(l),Ec(l,l.type,t===null?null:t.memoizedProps,l.pendingProps,e),null;case 6:if(t&&l.stateNode!=null)t.memoizedProps!==a&&ml(l);else{if(typeof a!="string"&&l.stateNode===null)throw Error(T(166));if(t=Gl.current,ke(l)){if(t=l.stateNode,e=l.memoizedProps,a=null,n=Tt,n!==null)switch(n.tag){case 27:case 5:a=n.memoizedProps}t[zt]=l,t=!!(t.nodeValue===e||a!==null&&a.suppressHydrationWarning===!0||w0(t.nodeValue,e)),t||te(l,!0)}else t=ku(t).createTextNode(a),t[zt]=l,l.stateNode=t}return W(l),null;case 31:if(e=l.memoizedState,t===null||t.memoizedState!==null){if(a=ke(l),e!==null){if(t===null){if(!a)throw Error(T(318));if(t=l.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(T(557));t[zt]=l}else ge(),!(l.flags&128)&&(l.memoizedState=null),l.flags|=4;W(l),t=!1}else e=hc(),t!==null&&t.memoizedState!==null&&(t.memoizedState.hydrationErrors=e),t=!0;if(!t)return l.flags&256?(Ut(l),l):(Ut(l),null);if(l.flags&128)throw Error(T(558))}return W(l),null;case 13:if(a=l.memoizedState,t===null||t.memoizedState!==null&&t.memoizedState.dehydrated!==null){if(n=ke(l),a!==null&&a.dehydrated!==null){if(t===null){if(!n)throw Error(T(318));if(n=l.memoizedState,n=n!==null?n.dehydrated:null,!n)throw Error(T(317));n[zt]=l}else ge(),!(l.flags&128)&&(l.memoizedState=null),l.flags|=4;W(l),n=!1}else n=hc(),t!==null&&t.memoizedState!==null&&(t.memoizedState.hydrationErrors=n),n=!0;if(!n)return l.flags&256?(Ut(l),l):(Ut(l),null)}return Ut(l),l.flags&128?(l.lanes=e,l):(e=a!==null,t=t!==null&&t.memoizedState!==null,e&&(a=l.child,n=null,a.alternate!==null&&a.alternate.memoizedState!==null&&a.alternate.memoizedState.cachePool!==null&&(n=a.alternate.memoizedState.cachePool.pool),u=null,a.memoizedState!==null&&a.memoizedState.cachePool!==null&&(u=a.memoizedState.cachePool.pool),u!==n&&(a.flags|=2048)),e!==t&&e&&(l.child.flags|=8192),_n(l,l.updateQueue),W(l),null);case 4:return la(),t===null&&Xf(l.stateNode.containerInfo),W(l),null;case 10:return Tl(l.type),W(l),null;case 19:if(bt(it),a=l.memoizedState,a===null)return W(l),null;if(n=(l.flags&128)!==0,u=a.rendering,u===null)if(n)Ma(a,!1);else{if(nt!==0||t!==null&&t.flags&128)for(t=l.child;t!==null;){if(u=vu(t),u!==null){for(l.flags|=128,Ma(a,!1),t=u.updateQueue,l.updateQueue=t,_n(l,t),l.subtreeFlags=0,t=e,e=l.child;e!==null;)Vr(e,t),e=e.sibling;return K(it,it.current&1|2),q&&gl(l,a.treeForkCount),l.child}t=t.sibling}a.tail!==null&&Bt()>zu&&(l.flags|=128,n=!0,Ma(a,!1),l.lanes=4194304)}else{if(!n)if(t=vu(u),t!==null){if(l.flags|=128,n=!0,t=t.updateQueue,l.updateQueue=t,_n(l,t),Ma(a,!0),a.tail===null&&a.tailMode==="hidden"&&!u.alternate&&!q)return W(l),null}else 2*Bt()-a.renderingStartTime>zu&&e!==536870912&&(l.flags|=128,n=!0,Ma(a,!1),l.lanes=4194304);a.isBackwards?(u.sibling=l.child,l.child=u):(t=a.last,t!==null?t.sibling=u:l.child=u,a.last=u)}return a.tail!==null?(t=a.tail,a.rendering=t,a.tail=t.sibling,a.renderingStartTime=Bt(),t.sibling=null,e=it.current,K(it,n?e&1|2:e&1),q&&gl(l,a.treeForkCount),t):(W(l),null);case 22:case 23:return Ut(l),bf(),a=l.memoizedState!==null,t!==null?t.memoizedState!==null!==a&&(l.flags|=8192):a&&(l.flags|=8192),a?e&536870912&&!(l.flags&128)&&(W(l),l.subtreeFlags&6&&(l.flags|=8192)):W(l),e=l.updateQueue,e!==null&&_n(l,e.retryQueue),e=null,t!==null&&t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(e=t.memoizedState.cachePool.pool),a=null,l.memoizedState!==null&&l.memoizedState.cachePool!==null&&(a=l.memoizedState.cachePool.pool),a!==e&&(l.flags|=2048),t!==null&&bt(ye),null;case 24:return e=null,t!==null&&(e=t.memoizedState.cache),l.memoizedState.cache!==e&&(l.flags|=2048),Tl(rt),W(l),null;case 25:return null;case 30:return null}throw Error(T(156,l.tag))}function oy(t,l){switch(yf(l),l.tag){case 1:return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 3:return Tl(rt),la(),t=l.flags,t&65536&&!(t&128)?(l.flags=t&-65537|128,l):null;case 26:case 27:case 5:return iu(l),null;case 31:if(l.memoizedState!==null){if(Ut(l),l.alternate===null)throw Error(T(340));ge()}return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 13:if(Ut(l),t=l.memoizedState,t!==null&&t.dehydrated!==null){if(l.alternate===null)throw Error(T(340));ge()}return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 19:return bt(it),null;case 4:return la(),null;case 10:return Tl(l.type),null;case 22:case 23:return Ut(l),bf(),t!==null&&bt(ye),t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 24:return Tl(rt),null;case 25:return null;default:return null}}function Vd(t,l){switch(yf(l),l.tag){case 3:Tl(rt),la();break;case 26:case 27:case 5:iu(l);break;case 4:la();break;case 31:l.memoizedState!==null&&Ut(l);break;case 13:Ut(l);break;case 19:bt(it);break;case 10:Tl(l.type);break;case 22:case 23:Ut(l),bf(),t!==null&&bt(ye);break;case 24:Tl(rt)}}function gn(t,l){try{var e=l.updateQueue,a=e!==null?e.lastEffect:null;if(a!==null){var n=a.next;e=n;do{if((e.tag&t)===t){a=void 0;var u=e.create,c=e.inst;a=u(),c.destroy=a}e=e.next}while(e!==n)}}catch(i){Y(l,l.return,i)}}function le(t,l,e){try{var a=l.updateQueue,n=a!==null?a.lastEffect:null;if(n!==null){var u=n.next;a=u;do{if((a.tag&t)===t){var c=a.inst,i=c.destroy;if(i!==void 0){c.destroy=void 0,n=l;var f=e,s=i;try{s()}catch(d){Y(n,f,d)}}}a=a.next}while(a!==u)}}catch(d){Y(l,l.return,d)}}function Qd(t){var l=t.updateQueue;if(l!==null){var e=t.stateNode;try{ed(l,e)}catch(a){Y(t,t.return,a)}}}function Kd(t,l,e){e.props=pe(t.type,t.memoizedProps),e.state=t.memoizedState;try{e.componentWillUnmount()}catch(a){Y(t,l,a)}}function Ya(t,l){try{var e=t.ref;if(e!==null){switch(t.tag){case 26:case 27:case 5:var a=t.stateNode;break;case 30:a=t.stateNode;break;default:a=t.stateNode}typeof e=="function"?t.refCleanup=e(a):e.current=a}}catch(n){Y(t,l,n)}}function il(t,l){var e=t.ref,a=t.refCleanup;if(e!==null)if(typeof a=="function")try{a()}catch(n){Y(t,l,n)}finally{t.refCleanup=null,t=t.alternate,t!=null&&(t.refCleanup=null)}else if(typeof e=="function")try{e(null)}catch(n){Y(t,l,n)}else e.current=null}function Jd(t){var l=t.type,e=t.memoizedProps,a=t.stateNode;try{t:switch(l){case"button":case"input":case"select":case"textarea":e.autoFocus&&a.focus();break t;case"img":e.src?a.src=e.src:e.srcSet&&(a.srcset=e.srcSet)}}catch(n){Y(t,t.return,n)}}function Mc(t,l,e){try{var a=t.stateNode;Ny(a,t.type,e,l),a[Ct]=l}catch(n){Y(t,t.return,n)}}function Wd(t){return t.tag===5||t.tag===3||t.tag===26||t.tag===27&&ne(t.type)||t.tag===4}function Ac(t){t:for(;;){for(;t.sibling===null;){if(t.return===null||Wd(t.return))return null;t=t.return}for(t.sibling.return=t.return,t=t.sibling;t.tag!==5&&t.tag!==6&&t.tag!==18;){if(t.tag===27&&ne(t.type)||t.flags&2||t.child===null||t.tag===4)continue t;t.child.return=t,t=t.child}if(!(t.flags&2))return t.stateNode}}function Ai(t,l,e){var a=t.tag;if(a===5||a===6)t=t.stateNode,l?(e.nodeType===9?e.body:e.nodeName==="HTML"?e.ownerDocument.body:e).insertBefore(t,l):(l=e.nodeType===9?e.body:e.nodeName==="HTML"?e.ownerDocument.body:e,l.appendChild(t),e=e._reactRootContainer,e!=null||l.onclick!==null||(l.onclick=Sl));else if(a!==4&&(a===27&&ne(t.type)&&(e=t.stateNode,l=null),t=t.child,t!==null))for(Ai(t,l,e),t=t.sibling;t!==null;)Ai(t,l,e),t=t.sibling}function pu(t,l,e){var a=t.tag;if(a===5||a===6)t=t.stateNode,l?e.insertBefore(t,l):e.appendChild(t);else if(a!==4&&(a===27&&ne(t.type)&&(e=t.stateNode),t=t.child,t!==null))for(pu(t,l,e),t=t.sibling;t!==null;)pu(t,l,e),t=t.sibling}function Fd(t){var l=t.stateNode,e=t.memoizedProps;try{for(var a=t.type,n=l.attributes;n.length;)l.removeAttributeNode(n[0]);Mt(l,a,e),l[zt]=t,l[Ct]=e}catch(u){Y(t,t.return,u)}}var xl=!1,ot=!1,jc=!1,lo=typeof WeakSet=="function"?WeakSet:Set,gt=null;function ry(t,l){if(t=t.containerInfo,_i=Nu,t=Hr(t),sf(t)){if("selectionStart"in t)var e={start:t.selectionStart,end:t.selectionEnd};else t:{e=(e=t.ownerDocument)&&e.defaultView||window;var a=e.getSelection&&e.getSelection();if(a&&a.rangeCount!==0){e=a.anchorNode;var n=a.anchorOffset,u=a.focusNode;a=a.focusOffset;try{e.nodeType,u.nodeType}catch{e=null;break t}var c=0,i=-1,f=-1,s=0,d=0,v=t,m=null;l:for(;;){for(var h;v!==e||n!==0&&v.nodeType!==3||(i=c+n),v!==u||a!==0&&v.nodeType!==3||(f=c+a),v.nodeType===3&&(c+=v.nodeValue.length),(h=v.firstChild)!==null;)m=v,v=h;for(;;){if(v===t)break l;if(m===e&&++s===n&&(i=c),m===u&&++d===a&&(f=c),(h=v.nextSibling)!==null)break;v=m,m=v.parentNode}v=h}e=i===-1||f===-1?null:{start:i,end:f}}else e=null}e=e||{start:0,end:0}}else e=null;for(Ci={focusedElem:t,selectionRange:e},Nu=!1,gt=l;gt!==null;)if(l=gt,t=l.child,(l.subtreeFlags&1028)!==0&&t!==null)t.return=l,gt=t;else for(;gt!==null;){switch(l=gt,u=l.alternate,t=l.flags,l.tag){case 0:if(t&4&&(t=l.updateQueue,t=t!==null?t.events:null,t!==null))for(e=0;e<t.length;e++)n=t[e],n.ref.impl=n.nextImpl;break;case 11:case 15:break;case 1:if(t&1024&&u!==null){t=void 0,e=l,n=u.memoizedProps,u=u.memoizedState,a=e.stateNode;try{var S=pe(e.type,n);t=a.getSnapshotBeforeUpdate(S,u),a.__reactInternalSnapshotBeforeUpdate=t}catch(p){Y(e,e.return,p)}}break;case 3:if(t&1024){if(t=l.stateNode.containerInfo,e=t.nodeType,e===9)$i(t);else if(e===1)switch(t.nodeName){case"HEAD":case"HTML":case"BODY":$i(t);break;default:t.textContent=""}}break;case 5:case 26:case 27:case 6:case 4:case 17:break;default:if(t&1024)throw Error(T(163))}if(t=l.sibling,t!==null){t.return=l.return,gt=t;break}gt=l.return}}function Id(t,l,e){var a=e.flags;switch(e.tag){case 0:case 11:case 15:hl(t,e),a&4&&gn(5,e);break;case 1:if(hl(t,e),a&4)if(t=e.stateNode,l===null)try{t.componentDidMount()}catch(c){Y(e,e.return,c)}else{var n=pe(e.type,l.memoizedProps);l=l.memoizedState;try{t.componentDidUpdate(n,l,t.__reactInternalSnapshotBeforeUpdate)}catch(c){Y(e,e.return,c)}}a&64&&Qd(e),a&512&&Ya(e,e.return);break;case 3:if(hl(t,e),a&64&&(t=e.updateQueue,t!==null)){if(l=null,e.child!==null)switch(e.child.tag){case 27:case 5:l=e.child.stateNode;break;case 1:l=e.child.stateNode}try{ed(t,l)}catch(c){Y(e,e.return,c)}}break;case 27:l===null&&a&4&&Fd(e);case 26:case 5:hl(t,e),l===null&&a&4&&Jd(e),a&512&&Ya(e,e.return);break;case 12:hl(t,e);break;case 31:hl(t,e),a&4&&l0(t,e);break;case 13:hl(t,e),a&4&&e0(t,e),a&64&&(t=e.memoizedState,t!==null&&(t=t.dehydrated,t!==null&&(e=Sy.bind(null,e),By(t,e))));break;case 22:if(a=e.memoizedState!==null||xl,!a){l=l!==null&&l.memoizedState!==null||ot,n=xl;var u=ot;xl=a,(ot=l)&&!u?vl(t,e,(e.subtreeFlags&8772)!==0):hl(t,e),xl=n,ot=u}break;case 30:break;default:hl(t,e)}}function Pd(t){var l=t.alternate;l!==null&&(t.alternate=null,Pd(l)),t.child=null,t.deletions=null,t.sibling=null,t.tag===5&&(l=t.stateNode,l!==null&&ef(l)),t.stateNode=null,t.return=null,t.dependencies=null,t.memoizedProps=null,t.memoizedState=null,t.pendingProps=null,t.stateNode=null,t.updateQueue=null}var lt=null,wt=!1;function yl(t,l,e){for(e=e.child;e!==null;)t0(t,l,e),e=e.sibling}function t0(t,l,e){if(Xt&&typeof Xt.onCommitFiberUnmount=="function")try{Xt.onCommitFiberUnmount(on,e)}catch{}switch(e.tag){case 26:ot||il(e,l),yl(t,l,e),e.memoizedState?e.memoizedState.count--:e.stateNode&&(e=e.stateNode,e.parentNode.removeChild(e));break;case 27:ot||il(e,l);var a=lt,n=wt;ne(e.type)&&(lt=e.stateNode,wt=!1),yl(t,l,e),Qa(e.stateNode),lt=a,wt=n;break;case 5:ot||il(e,l);case 6:if(a=lt,n=wt,lt=null,yl(t,l,e),lt=a,wt=n,lt!==null)if(wt)try{(lt.nodeType===9?lt.body:lt.nodeName==="HTML"?lt.ownerDocument.body:lt).removeChild(e.stateNode)}catch(u){Y(e,l,u)}else try{lt.removeChild(e.stateNode)}catch(u){Y(e,l,u)}break;case 18:lt!==null&&(wt?(t=lt,ho(t.nodeType===9?t.body:t.nodeName==="HTML"?t.ownerDocument.body:t,e.stateNode),ra(t)):ho(lt,e.stateNode));break;case 4:a=lt,n=wt,lt=e.stateNode.containerInfo,wt=!0,yl(t,l,e),lt=a,wt=n;break;case 0:case 11:case 14:case 15:le(2,e,l),ot||le(4,e,l),yl(t,l,e);break;case 1:ot||(il(e,l),a=e.stateNode,typeof a.componentWillUnmount=="function"&&Kd(e,l,a)),yl(t,l,e);break;case 21:yl(t,l,e);break;case 22:ot=(a=ot)||e.memoizedState!==null,yl(t,l,e),ot=a;break;default:yl(t,l,e)}}function l0(t,l){if(l.memoizedState===null&&(t=l.alternate,t!==null&&(t=t.memoizedState,t!==null))){t=t.dehydrated;try{ra(t)}catch(e){Y(l,l.return,e)}}}function e0(t,l){if(l.memoizedState===null&&(t=l.alternate,t!==null&&(t=t.memoizedState,t!==null&&(t=t.dehydrated,t!==null))))try{ra(t)}catch(e){Y(l,l.return,e)}}function dy(t){switch(t.tag){case 31:case 13:case 19:var l=t.stateNode;return l===null&&(l=t.stateNode=new lo),l;case 22:return t=t.stateNode,l=t._retryCache,l===null&&(l=t._retryCache=new lo),l;default:throw Error(T(435,t.tag))}}function Cn(t,l){var e=dy(t);l.forEach(function(a){if(!e.has(a)){e.add(a);var n=py.bind(null,t,a);a.then(n,n)}})}function Ot(t,l){var e=l.deletions;if(e!==null)for(var a=0;a<e.length;a++){var n=e[a],u=t,c=l,i=c;t:for(;i!==null;){switch(i.tag){case 27:if(ne(i.type)){lt=i.stateNode,wt=!1;break t}break;case 5:lt=i.stateNode,wt=!1;break t;case 3:case 4:lt=i.stateNode.containerInfo,wt=!0;break t}i=i.return}if(lt===null)throw Error(T(160));t0(u,c,n),lt=null,wt=!1,u=n.alternate,u!==null&&(u.return=null),n.return=null}if(l.subtreeFlags&13886)for(l=l.child;l!==null;)a0(l,t),l=l.sibling}var al=null;function a0(t,l){var e=t.alternate,a=t.flags;switch(t.tag){case 0:case 11:case 14:case 15:Ot(l,t),Dt(t),a&4&&(le(3,t,t.return),gn(3,t),le(5,t,t.return));break;case 1:Ot(l,t),Dt(t),a&512&&(ot||e===null||il(e,e.return)),a&64&&xl&&(t=t.updateQueue,t!==null&&(a=t.callbacks,a!==null&&(e=t.shared.hiddenCallbacks,t.shared.hiddenCallbacks=e===null?a:e.concat(a))));break;case 26:var n=al;if(Ot(l,t),Dt(t),a&512&&(ot||e===null||il(e,e.return)),a&4){var u=e!==null?e.memoizedState:null;if(a=t.memoizedState,e===null)if(a===null)if(t.stateNode===null){t:{a=t.type,e=t.memoizedProps,n=n.ownerDocument||n;l:switch(a){case"title":u=n.getElementsByTagName("title")[0],(!u||u[mn]||u[zt]||u.namespaceURI==="http://www.w3.org/2000/svg"||u.hasAttribute("itemprop"))&&(u=n.createElement(a),n.head.insertBefore(u,n.querySelector("head > title"))),Mt(u,a,e),u[zt]=t,xt(u),a=u;break t;case"link":var c=zo("link","href",n).get(a+(e.href||""));if(c){for(var i=0;i<c.length;i++)if(u=c[i],u.getAttribute("href")===(e.href==null||e.href===""?null:e.href)&&u.getAttribute("rel")===(e.rel==null?null:e.rel)&&u.getAttribute("title")===(e.title==null?null:e.title)&&u.getAttribute("crossorigin")===(e.crossOrigin==null?null:e.crossOrigin)){c.splice(i,1);break l}}u=n.createElement(a),Mt(u,a,e),n.head.appendChild(u);break;case"meta":if(c=zo("meta","content",n).get(a+(e.content||""))){for(i=0;i<c.length;i++)if(u=c[i],u.getAttribute("content")===(e.content==null?null:""+e.content)&&u.getAttribute("name")===(e.name==null?null:e.name)&&u.getAttribute("property")===(e.property==null?null:e.property)&&u.getAttribute("http-equiv")===(e.httpEquiv==null?null:e.httpEquiv)&&u.getAttribute("charset")===(e.charSet==null?null:e.charSet)){c.splice(i,1);break l}}u=n.createElement(a),Mt(u,a,e),n.head.appendChild(u);break;default:throw Error(T(468,a))}u[zt]=t,xt(u),a=u}t.stateNode=a}else To(n,t.type,t.stateNode);else t.stateNode=po(n,a,t.memoizedProps);else u!==a?(u===null?e.stateNode!==null&&(e=e.stateNode,e.parentNode.removeChild(e)):u.count--,a===null?To(n,t.type,t.stateNode):po(n,a,t.memoizedProps)):a===null&&t.stateNode!==null&&Mc(t,t.memoizedProps,e.memoizedProps)}break;case 27:Ot(l,t),Dt(t),a&512&&(ot||e===null||il(e,e.return)),e!==null&&a&4&&Mc(t,t.memoizedProps,e.memoizedProps);break;case 5:if(Ot(l,t),Dt(t),a&512&&(ot||e===null||il(e,e.return)),t.flags&32){n=t.stateNode;try{aa(n,"")}catch(S){Y(t,t.return,S)}}a&4&&t.stateNode!=null&&(n=t.memoizedProps,Mc(t,n,e!==null?e.memoizedProps:n)),a&1024&&(jc=!0);break;case 6:if(Ot(l,t),Dt(t),a&4){if(t.stateNode===null)throw Error(T(162));a=t.memoizedProps,e=t.stateNode;try{e.nodeValue=a}catch(S){Y(t,t.return,S)}}break;case 3:if(eu=null,n=al,al=Ou(l.containerInfo),Ot(l,t),al=n,Dt(t),a&4&&e!==null&&e.memoizedState.isDehydrated)try{ra(l.containerInfo)}catch(S){Y(t,t.return,S)}jc&&(jc=!1,n0(t));break;case 4:a=al,al=Ou(t.stateNode.containerInfo),Ot(l,t),Dt(t),al=a;break;case 12:Ot(l,t),Dt(t);break;case 31:Ot(l,t),Dt(t),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,Cn(t,a)));break;case 13:Ot(l,t),Dt(t),t.child.flags&8192&&t.memoizedState!==null!=(e!==null&&e.memoizedState!==null)&&(Ku=Bt()),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,Cn(t,a)));break;case 22:n=t.memoizedState!==null;var f=e!==null&&e.memoizedState!==null,s=xl,d=ot;if(xl=s||n,ot=d||f,Ot(l,t),ot=d,xl=s,Dt(t),a&8192)t:for(l=t.stateNode,l._visibility=n?l._visibility&-2:l._visibility|1,n&&(e===null||f||xl||ot||re(t)),e=null,l=t;;){if(l.tag===5||l.tag===26){if(e===null){f=e=l;try{if(u=f.stateNode,n)c=u.style,typeof c.setProperty=="function"?c.setProperty("display","none","important"):c.display="none";else{i=f.stateNode;var v=f.memoizedProps.style,m=v!=null&&v.hasOwnProperty("display")?v.display:null;i.style.display=m==null||typeof m=="boolean"?"":(""+m).trim()}}catch(S){Y(f,f.return,S)}}}else if(l.tag===6){if(e===null){f=l;try{f.stateNode.nodeValue=n?"":f.memoizedProps}catch(S){Y(f,f.return,S)}}}else if(l.tag===18){if(e===null){f=l;try{var h=f.stateNode;n?vo(h,!0):vo(f.stateNode,!1)}catch(S){Y(f,f.return,S)}}}else if((l.tag!==22&&l.tag!==23||l.memoizedState===null||l===t)&&l.child!==null){l.child.return=l,l=l.child;continue}if(l===t)break t;for(;l.sibling===null;){if(l.return===null||l.return===t)break t;e===l&&(e=null),l=l.return}e===l&&(e=null),l.sibling.return=l.return,l=l.sibling}a&4&&(a=t.updateQueue,a!==null&&(e=a.retryQueue,e!==null&&(a.retryQueue=null,Cn(t,e))));break;case 19:Ot(l,t),Dt(t),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,Cn(t,a)));break;case 30:break;case 21:break;default:Ot(l,t),Dt(t)}}function Dt(t){var l=t.flags;if(l&2){try{for(var e,a=t.return;a!==null;){if(Wd(a)){e=a;break}a=a.return}if(e==null)throw Error(T(160));switch(e.tag){case 27:var n=e.stateNode,u=Ac(t);pu(t,u,n);break;case 5:var c=e.stateNode;e.flags&32&&(aa(c,""),e.flags&=-33);var i=Ac(t);pu(t,i,c);break;case 3:case 4:var f=e.stateNode.containerInfo,s=Ac(t);Ai(t,s,f);break;default:throw Error(T(161))}}catch(d){Y(t,t.return,d)}t.flags&=-3}l&4096&&(t.flags&=-4097)}function n0(t){if(t.subtreeFlags&1024)for(t=t.child;t!==null;){var l=t;n0(l),l.tag===5&&l.flags&1024&&l.stateNode.reset(),t=t.sibling}}function hl(t,l){if(l.subtreeFlags&8772)for(l=l.child;l!==null;)Id(t,l.alternate,l),l=l.sibling}function re(t){for(t=t.child;t!==null;){var l=t;switch(l.tag){case 0:case 11:case 14:case 15:le(4,l,l.return),re(l);break;case 1:il(l,l.return);var e=l.stateNode;typeof e.componentWillUnmount=="function"&&Kd(l,l.return,e),re(l);break;case 27:Qa(l.stateNode);case 26:case 5:il(l,l.return),re(l);break;case 22:l.memoizedState===null&&re(l);break;case 30:re(l);break;default:re(l)}t=t.sibling}}function vl(t,l,e){for(e=e&&(l.subtreeFlags&8772)!==0,l=l.child;l!==null;){var a=l.alternate,n=t,u=l,c=u.flags;switch(u.tag){case 0:case 11:case 15:vl(n,u,e),gn(4,u);break;case 1:if(vl(n,u,e),a=u,n=a.stateNode,typeof n.componentDidMount=="function")try{n.componentDidMount()}catch(s){Y(a,a.return,s)}if(a=u,n=a.updateQueue,n!==null){var i=a.stateNode;try{var f=n.shared.hiddenCallbacks;if(f!==null)for(n.shared.hiddenCallbacks=null,n=0;n<f.length;n++)ld(f[n],i)}catch(s){Y(a,a.return,s)}}e&&c&64&&Qd(u),Ya(u,u.return);break;case 27:Fd(u);case 26:case 5:vl(n,u,e),e&&a===null&&c&4&&Jd(u),Ya(u,u.return);break;case 12:vl(n,u,e);break;case 31:vl(n,u,e),e&&c&4&&l0(n,u);break;case 13:vl(n,u,e),e&&c&4&&e0(n,u);break;case 22:u.memoizedState===null&&vl(n,u,e),Ya(u,u.return);break;case 30:break;default:vl(n,u,e)}l=l.sibling}}function Rf(t,l){var e=null;t!==null&&t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(e=t.memoizedState.cachePool.pool),t=null,l.memoizedState!==null&&l.memoizedState.cachePool!==null&&(t=l.memoizedState.cachePool.pool),t!==e&&(t!=null&&t.refCount++,e!=null&&hn(e))}function $f(t,l){t=null,l.alternate!==null&&(t=l.alternate.memoizedState.cache),l=l.memoizedState.cache,l!==t&&(l.refCount++,t!=null&&hn(t))}function el(t,l,e,a){if(l.subtreeFlags&10256)for(l=l.child;l!==null;)u0(t,l,e,a),l=l.sibling}function u0(t,l,e,a){var n=l.flags;switch(l.tag){case 0:case 11:case 15:el(t,l,e,a),n&2048&&gn(9,l);break;case 1:el(t,l,e,a);break;case 3:el(t,l,e,a),n&2048&&(t=null,l.alternate!==null&&(t=l.alternate.memoizedState.cache),l=l.memoizedState.cache,l!==t&&(l.refCount++,t!=null&&hn(t)));break;case 12:if(n&2048){el(t,l,e,a),t=l.stateNode;try{var u=l.memoizedProps,c=u.id,i=u.onPostCommit;typeof i=="function"&&i(c,l.alternate===null?"mount":"update",t.passiveEffectDuration,-0)}catch(f){Y(l,l.return,f)}}else el(t,l,e,a);break;case 31:el(t,l,e,a);break;case 13:el(t,l,e,a);break;case 23:break;case 22:u=l.stateNode,c=l.alternate,l.memoizedState!==null?u._visibility&2?el(t,l,e,a):Ga(t,l):u._visibility&2?el(t,l,e,a):(u._visibility|=2,Ne(t,l,e,a,(l.subtreeFlags&10256)!==0||!1)),n&2048&&Rf(c,l);break;case 24:el(t,l,e,a),n&2048&&$f(l.alternate,l);break;default:el(t,l,e,a)}}function Ne(t,l,e,a,n){for(n=n&&((l.subtreeFlags&10256)!==0||!1),l=l.child;l!==null;){var u=t,c=l,i=e,f=a,s=c.flags;switch(c.tag){case 0:case 11:case 15:Ne(u,c,i,f,n),gn(8,c);break;case 23:break;case 22:var d=c.stateNode;c.memoizedState!==null?d._visibility&2?Ne(u,c,i,f,n):Ga(u,c):(d._visibility|=2,Ne(u,c,i,f,n)),n&&s&2048&&Rf(c.alternate,c);break;case 24:Ne(u,c,i,f,n),n&&s&2048&&$f(c.alternate,c);break;default:Ne(u,c,i,f,n)}l=l.sibling}}function Ga(t,l){if(l.subtreeFlags&10256)for(l=l.child;l!==null;){var e=t,a=l,n=a.flags;switch(a.tag){case 22:Ga(e,a),n&2048&&Rf(a.alternate,a);break;case 24:Ga(e,a),n&2048&&$f(a.alternate,a);break;default:Ga(e,a)}l=l.sibling}}var _a=8192;function Oe(t,l,e){if(t.subtreeFlags&_a)for(t=t.child;t!==null;)c0(t,l,e),t=t.sibling}function c0(t,l,e){switch(t.tag){case 26:Oe(t,l,e),t.flags&_a&&t.memoizedState!==null&&Iy(e,al,t.memoizedState,t.memoizedProps);break;case 5:Oe(t,l,e);break;case 3:case 4:var a=al;al=Ou(t.stateNode.containerInfo),Oe(t,l,e),al=a;break;case 22:t.memoizedState===null&&(a=t.alternate,a!==null&&a.memoizedState!==null?(a=_a,_a=16777216,Oe(t,l,e),_a=a):Oe(t,l,e));break;default:Oe(t,l,e)}}function i0(t){var l=t.alternate;if(l!==null&&(t=l.child,t!==null)){l.child=null;do l=t.sibling,t.sibling=null,t=l;while(t!==null)}}function Aa(t){var l=t.deletions;if(t.flags&16){if(l!==null)for(var e=0;e<l.length;e++){var a=l[e];gt=a,s0(a,t)}i0(t)}if(t.subtreeFlags&10256)for(t=t.child;t!==null;)f0(t),t=t.sibling}function f0(t){switch(t.tag){case 0:case 11:case 15:Aa(t),t.flags&2048&&le(9,t,t.return);break;case 3:Aa(t);break;case 12:Aa(t);break;case 22:var l=t.stateNode;t.memoizedState!==null&&l._visibility&2&&(t.return===null||t.return.tag!==13)?(l._visibility&=-3,tu(t)):Aa(t);break;default:Aa(t)}}function tu(t){var l=t.deletions;if(t.flags&16){if(l!==null)for(var e=0;e<l.length;e++){var a=l[e];gt=a,s0(a,t)}i0(t)}for(t=t.child;t!==null;){switch(l=t,l.tag){case 0:case 11:case 15:le(8,l,l.return),tu(l);break;case 22:e=l.stateNode,e._visibility&2&&(e._visibility&=-3,tu(l));break;default:tu(l)}t=t.sibling}}function s0(t,l){for(;gt!==null;){var e=gt;switch(e.tag){case 0:case 11:case 15:le(8,e,l);break;case 23:case 22:if(e.memoizedState!==null&&e.memoizedState.cachePool!==null){var a=e.memoizedState.cachePool.pool;a!=null&&a.refCount++}break;case 24:hn(e.memoizedState.cache)}if(a=e.child,a!==null)a.return=e,gt=a;else t:for(e=t;gt!==null;){a=gt;var n=a.sibling,u=a.return;if(Pd(a),a===e){gt=null;break t}if(n!==null){n.return=u,gt=n;break t}gt=u}}}var my={getCacheForType:function(t){var l=Et(rt),e=l.data.get(t);return e===void 0&&(e=t(),l.data.set(t,e)),e},cacheSignal:function(){return Et(rt).controller.signal}},yy=typeof WeakMap=="function"?WeakMap:Map,B=0,Q=null,U=null,H=0,L=0,$t=null,Xl=!1,xa=!1,Uf=!1,Ol=0,nt=0,ee=0,ve=0,Hf=0,qt=0,ia=0,Za=null,Nt=null,ji=!1,Ku=0,o0=0,zu=1/0,Tu=null,Kl=null,yt=0,Jl=null,fa=null,El=0,ki=0,Oi=null,r0=null,Va=0,Di=null;function Yt(){return B&2&&H!==0?H&-H:w.T!==null?Bf():Sr()}function d0(){if(qt===0)if(!(H&536870912)||q){var t=An;An<<=1,!(An&3932160)&&(An=262144),qt=t}else qt=536870912;return t=Zt.current,t!==null&&(t.flags|=32),qt}function _t(t,l,e){(t===Q&&(L===2||L===9)||t.cancelPendingCommit!==null)&&(sa(t,0),Ll(t,H,qt,!1)),dn(t,e),(!(B&2)||t!==Q)&&(t===Q&&(!(B&2)&&(ve|=e),nt===4&&Ll(t,H,qt,!1)),ol(t))}function m0(t,l,e){if(B&6)throw Error(T(327));var a=!e&&(l&127)===0&&(l&t.expiredLanes)===0||rn(t,l),n=a?gy(t,l):kc(t,l,!0),u=a;do{if(n===0){xa&&!a&&Ll(t,l,0,!1);break}else{if(e=t.current.alternate,u&&!hy(e)){n=kc(t,l,!1),u=!1;continue}if(n===2){if(u=l,t.errorRecoveryDisabledLanes&u)var c=0;else c=t.pendingLanes&-536870913,c=c!==0?c:c&536870912?536870912:0;if(c!==0){l=c;t:{var i=t;n=Za;var f=i.current.memoizedState.isDehydrated;if(f&&(sa(i,c).flags|=256),c=kc(i,c,!1),c!==2){if(Uf&&!f){i.errorRecoveryDisabledLanes|=u,ve|=u,n=4;break t}u=Nt,Nt=n,u!==null&&(Nt===null?Nt=u:Nt.push.apply(Nt,u))}n=c}if(u=!1,n!==2)continue}}if(n===1){sa(t,0),Ll(t,l,0,!0);break}t:{switch(a=t,u=n,u){case 0:case 1:throw Error(T(345));case 4:if((l&4194048)!==l)break;case 6:Ll(a,l,qt,!Xl);break t;case 2:Nt=null;break;case 3:case 5:break;default:throw Error(T(329))}if((l&62914560)===l&&(n=Ku+300-Bt(),10<n)){if(Ll(a,l,qt,!Xl),Uu(a,0,!0)!==0)break t;El=l,a.timeoutHandle=_0(eo.bind(null,a,e,Nt,Tu,ji,l,qt,ve,ia,Xl,u,"Throttled",-0,0),n);break t}eo(a,e,Nt,Tu,ji,l,qt,ve,ia,Xl,u,null,-0,0)}}break}while(!0);ol(t)}function eo(t,l,e,a,n,u,c,i,f,s,d,v,m,h){if(t.timeoutHandle=-1,v=l.subtreeFlags,v&8192||(v&16785408)===16785408){v={stylesheets:null,count:0,imgCount:0,imgBytes:0,suspenseyImages:[],waitingForImages:!0,waitingForViewTransition:!1,unsuspend:Sl},c0(l,u,v);var S=(u&62914560)===u?Ku-Bt():(u&4194048)===u?o0-Bt():0;if(S=Py(v,S),S!==null){El=u,t.cancelPendingCommit=S(no.bind(null,t,l,u,e,a,n,c,i,f,d,v,null,m,h)),Ll(t,u,c,!s);return}}no(t,l,u,e,a,n,c,i,f)}function hy(t){for(var l=t;;){var e=l.tag;if((e===0||e===11||e===15)&&l.flags&16384&&(e=l.updateQueue,e!==null&&(e=e.stores,e!==null)))for(var a=0;a<e.length;a++){var n=e[a],u=n.getSnapshot;n=n.value;try{if(!Gt(u(),n))return!1}catch{return!1}}if(e=l.child,l.subtreeFlags&16384&&e!==null)e.return=l,l=e;else{if(l===t)break;for(;l.sibling===null;){if(l.return===null||l.return===t)return!0;l=l.return}l.sibling.return=l.return,l=l.sibling}}return!0}function Ll(t,l,e,a){l&=~Hf,l&=~ve,t.suspendedLanes|=l,t.pingedLanes&=~l,a&&(t.warmLanes|=l),a=t.expirationTimes;for(var n=l;0<n;){var u=31-Lt(n),c=1<<u;a[u]=-1,n&=~c}e!==0&&gr(t,e,l)}function Ju(){return B&6?!0:(xn(0),!1)}function qf(){if(U!==null){if(L===0)var t=U.return;else t=U,pl=Ae=null,Ef(t),Ie=null,tn=0,t=U;for(;t!==null;)Vd(t.alternate,t),t=t.return;U=null}}function sa(t,l){var e=t.timeoutHandle;e!==-1&&(t.timeoutHandle=-1,Ry(e)),e=t.cancelPendingCommit,e!==null&&(t.cancelPendingCommit=null,e()),El=0,qf(),Q=t,U=e=zl(t.current,null),H=l,L=0,$t=null,Xl=!1,xa=rn(t,l),Uf=!1,ia=qt=Hf=ve=ee=nt=0,Nt=Za=null,ji=!1,l&8&&(l|=l&32);var a=t.entangledLanes;if(a!==0)for(t=t.entanglements,a&=l;0<a;){var n=31-Lt(a),u=1<<n;l|=t[n],a&=~u}return Ol=l,Xu(),e}function y0(t,l){R=null,w.H=en,l===ga||l===Yu?(l=Cs(),L=3):l===gf?(l=Cs(),L=4):L=l===_f?8:l!==null&&typeof l=="object"&&typeof l.then=="function"?6:1,$t=l,U===null&&(nt=1,bu(t,Ft(l,t.current)))}function h0(){var t=Zt.current;return t===null?!0:(H&4194048)===H?Pt===null:(H&62914560)===H||H&536870912?t===Pt:!1}function v0(){var t=w.H;return w.H=en,t===null?en:t}function g0(){var t=w.A;return w.A=my,t}function Eu(){nt=4,Xl||(H&4194048)!==H&&Zt.current!==null||(xa=!0),!(ee&134217727)&&!(ve&134217727)||Q===null||Ll(Q,H,qt,!1)}function kc(t,l,e){var a=B;B|=2;var n=v0(),u=g0();(Q!==t||H!==l)&&(Tu=null,sa(t,l)),l=!1;var c=nt;t:do try{if(L!==0&&U!==null){var i=U,f=$t;switch(L){case 8:qf(),c=6;break t;case 3:case 2:case 9:case 6:Zt.current===null&&(l=!0);var s=L;if(L=0,$t=null,Ze(t,i,f,s),e&&xa){c=0;break t}break;default:s=L,L=0,$t=null,Ze(t,i,f,s)}}vy(),c=nt;break}catch(d){y0(t,d)}while(!0);return l&&t.shellSuspendCounter++,pl=Ae=null,B=a,w.H=n,w.A=u,U===null&&(Q=null,H=0,Xu()),c}function vy(){for(;U!==null;)x0(U)}function gy(t,l){var e=B;B|=2;var a=v0(),n=g0();Q!==t||H!==l?(Tu=null,zu=Bt()+500,sa(t,l)):xa=rn(t,l);t:do try{if(L!==0&&U!==null){l=U;var u=$t;l:switch(L){case 1:L=0,$t=null,Ze(t,l,u,1);break;case 2:case 9:if(_s(u)){L=0,$t=null,ao(l);break}l=function(){L!==2&&L!==9||Q!==t||(L=7),ol(t)},u.then(l,l);break t;case 3:L=7;break t;case 4:L=5;break t;case 7:_s(u)?(L=0,$t=null,ao(l)):(L=0,$t=null,Ze(t,l,u,7));break;case 5:var c=null;switch(U.tag){case 26:c=U.memoizedState;case 5:case 27:var i=U;if(c?H0(c):i.stateNode.complete){L=0,$t=null;var f=i.sibling;if(f!==null)U=f;else{var s=i.return;s!==null?(U=s,Wu(s)):U=null}break l}}L=0,$t=null,Ze(t,l,u,5);break;case 6:L=0,$t=null,Ze(t,l,u,6);break;case 8:qf(),nt=6;break t;default:throw Error(T(462))}}xy();break}catch(d){y0(t,d)}while(!0);return pl=Ae=null,w.H=a,w.A=n,B=e,U!==null?0:(Q=null,H=0,Xu(),nt)}function xy(){for(;U!==null&&!X1();)x0(U)}function x0(t){var l=Zd(t.alternate,t,Ol);t.memoizedProps=t.pendingProps,l===null?Wu(t):U=l}function ao(t){var l=t,e=l.alternate;switch(l.tag){case 15:case 0:l=Ws(e,l,l.pendingProps,l.type,void 0,H);break;case 11:l=Ws(e,l,l.pendingProps,l.type.render,l.ref,H);break;case 5:Ef(l);default:Vd(e,l),l=U=Vr(l,Ol),l=Zd(e,l,Ol)}t.memoizedProps=t.pendingProps,l===null?Wu(t):U=l}function Ze(t,l,e,a){pl=Ae=null,Ef(l),Ie=null,tn=0;var n=l.return;try{if(cy(t,n,l,e,H)){nt=1,bu(t,Ft(e,t.current)),U=null;return}}catch(u){if(n!==null)throw U=n,u;nt=1,bu(t,Ft(e,t.current)),U=null;return}l.flags&32768?(q||a===1?t=!0:xa||H&536870912?t=!1:(Xl=t=!0,(a===2||a===9||a===3||a===6)&&(a=Zt.current,a!==null&&a.tag===13&&(a.flags|=16384))),b0(l,t)):Wu(l)}function Wu(t){var l=t;do{if(l.flags&32768){b0(l,Xl);return}t=l.return;var e=sy(l.alternate,l,Ol);if(e!==null){U=e;return}if(l=l.sibling,l!==null){U=l;return}U=l=t}while(l!==null);nt===0&&(nt=5)}function b0(t,l){do{var e=oy(t.alternate,t);if(e!==null){e.flags&=32767,U=e;return}if(e=t.return,e!==null&&(e.flags|=32768,e.subtreeFlags=0,e.deletions=null),!l&&(t=t.sibling,t!==null)){U=t;return}U=t=e}while(t!==null);nt=6,U=null}function no(t,l,e,a,n,u,c,i,f){t.cancelPendingCommit=null;do Fu();while(yt!==0);if(B&6)throw Error(T(327));if(l!==null){if(l===t.current)throw Error(T(177));if(u=l.lanes|l.childLanes,u|=of,F1(t,e,u,c,i,f),t===Q&&(U=Q=null,H=0),fa=l,Jl=t,El=e,ki=u,Oi=n,r0=a,l.subtreeFlags&10256||l.flags&10256?(t.callbackNode=null,t.callbackPriority=0,zy(fu,function(){return E0(),null})):(t.callbackNode=null,t.callbackPriority=0),a=(l.flags&13878)!==0,l.subtreeFlags&13878||a){a=w.T,w.T=null,n=X.p,X.p=2,c=B,B|=4;try{ry(t,l,e)}finally{B=c,X.p=n,w.T=a}}yt=1,S0(),p0(),z0()}}function S0(){if(yt===1){yt=0;var t=Jl,l=fa,e=(l.flags&13878)!==0;if(l.subtreeFlags&13878||e){e=w.T,w.T=null;var a=X.p;X.p=2;var n=B;B|=4;try{a0(l,t);var u=Ci,c=Hr(t.containerInfo),i=u.focusedElem,f=u.selectionRange;if(c!==i&&i&&i.ownerDocument&&Ur(i.ownerDocument.documentElement,i)){if(f!==null&&sf(i)){var s=f.start,d=f.end;if(d===void 0&&(d=s),"selectionStart"in i)i.selectionStart=s,i.selectionEnd=Math.min(d,i.value.length);else{var v=i.ownerDocument||document,m=v&&v.defaultView||window;if(m.getSelection){var h=m.getSelection(),S=i.textContent.length,p=Math.min(f.start,S),z=f.end===void 0?p:Math.min(f.end,S);!h.extend&&p>z&&(c=z,z=p,p=c);var r=As(i,p),o=As(i,z);if(r&&o&&(h.rangeCount!==1||h.anchorNode!==r.node||h.anchorOffset!==r.offset||h.focusNode!==o.node||h.focusOffset!==o.offset)){var y=v.createRange();y.setStart(r.node,r.offset),h.removeAllRanges(),p>z?(h.addRange(y),h.extend(o.node,o.offset)):(y.setEnd(o.node,o.offset),h.addRange(y))}}}}for(v=[],h=i;h=h.parentNode;)h.nodeType===1&&v.push({element:h,left:h.scrollLeft,top:h.scrollTop});for(typeof i.focus=="function"&&i.focus(),i=0;i<v.length;i++){var x=v[i];x.element.scrollLeft=x.left,x.element.scrollTop=x.top}}Nu=!!_i,Ci=_i=null}finally{B=n,X.p=a,w.T=e}}t.current=l,yt=2}}function p0(){if(yt===2){yt=0;var t=Jl,l=fa,e=(l.flags&8772)!==0;if(l.subtreeFlags&8772||e){e=w.T,w.T=null;var a=X.p;X.p=2;var n=B;B|=4;try{Id(t,l.alternate,l)}finally{B=n,X.p=a,w.T=e}}yt=3}}function z0(){if(yt===4||yt===3){yt=0,L1();var t=Jl,l=fa,e=El,a=r0;l.subtreeFlags&10256||l.flags&10256?yt=5:(yt=0,fa=Jl=null,T0(t,t.pendingLanes));var n=t.pendingLanes;if(n===0&&(Kl=null),lf(e),l=l.stateNode,Xt&&typeof Xt.onCommitFiberRoot=="function")try{Xt.onCommitFiberRoot(on,l,void 0,(l.current.flags&128)===128)}catch{}if(a!==null){l=w.T,n=X.p,X.p=2,w.T=null;try{for(var u=t.onRecoverableError,c=0;c<a.length;c++){var i=a[c];u(i.value,{componentStack:i.stack})}}finally{w.T=l,X.p=n}}El&3&&Fu(),ol(t),n=t.pendingLanes,e&261930&&n&42?t===Di?Va++:(Va=0,Di=t):Va=0,xn(0)}}function T0(t,l){(t.pooledCacheLanes&=l)===0&&(l=t.pooledCache,l!=null&&(t.pooledCache=null,hn(l)))}function Fu(){return S0(),p0(),z0(),E0()}function E0(){if(yt!==5)return!1;var t=Jl,l=ki;ki=0;var e=lf(El),a=w.T,n=X.p;try{X.p=32>e?32:e,w.T=null,e=Oi,Oi=null;var u=Jl,c=El;if(yt=0,fa=Jl=null,El=0,B&6)throw Error(T(331));var i=B;if(B|=4,f0(u.current),u0(u,u.current,c,e),B=i,xn(0,!1),Xt&&typeof Xt.onPostCommitFiberRoot=="function")try{Xt.onPostCommitFiberRoot(on,u)}catch{}return!0}finally{X.p=n,w.T=a,T0(t,l)}}function uo(t,l,e){l=Ft(e,l),l=Ti(t.stateNode,l,2),t=Ql(t,l,2),t!==null&&(dn(t,2),ol(t))}function Y(t,l,e){if(t.tag===3)uo(t,t,e);else for(;l!==null;){if(l.tag===3){uo(l,t,e);break}else if(l.tag===1){var a=l.stateNode;if(typeof l.type.getDerivedStateFromError=="function"||typeof a.componentDidCatch=="function"&&(Kl===null||!Kl.has(a))){t=Ft(e,t),e=qd(2),a=Ql(l,e,2),a!==null&&(Bd(e,a,l,t),dn(a,2),ol(a));break}}l=l.return}}function Oc(t,l,e){var a=t.pingCache;if(a===null){a=t.pingCache=new yy;var n=new Set;a.set(l,n)}else n=a.get(l),n===void 0&&(n=new Set,a.set(l,n));n.has(e)||(Uf=!0,n.add(e),t=by.bind(null,t,l,e),l.then(t,t))}function by(t,l,e){var a=t.pingCache;a!==null&&a.delete(l),t.pingedLanes|=t.suspendedLanes&e,t.warmLanes&=~e,Q===t&&(H&e)===e&&(nt===4||nt===3&&(H&62914560)===H&&300>Bt()-Ku?!(B&2)&&sa(t,0):Hf|=e,ia===H&&(ia=0)),ol(t)}function M0(t,l){l===0&&(l=vr()),t=Me(t,l),t!==null&&(dn(t,l),ol(t))}function Sy(t){var l=t.memoizedState,e=0;l!==null&&(e=l.retryLane),M0(t,e)}function py(t,l){var e=0;switch(t.tag){case 31:case 13:var a=t.stateNode,n=t.memoizedState;n!==null&&(e=n.retryLane);break;case 19:a=t.stateNode;break;case 22:a=t.stateNode._retryCache;break;default:throw Error(T(314))}a!==null&&a.delete(l),M0(t,e)}function zy(t,l){return Pi(t,l)}var Mu=null,_e=null,wi=!1,Au=!1,Dc=!1,Yl=0;function ol(t){t!==_e&&t.next===null&&(_e===null?Mu=_e=t:_e=_e.next=t),Au=!0,wi||(wi=!0,Ey())}function xn(t,l){if(!Dc&&Au){Dc=!0;do for(var e=!1,a=Mu;a!==null;){if(t!==0){var n=a.pendingLanes;if(n===0)var u=0;else{var c=a.suspendedLanes,i=a.pingedLanes;u=(1<<31-Lt(42|t)+1)-1,u&=n&~(c&~i),u=u&201326741?u&201326741|1:u?u|2:0}u!==0&&(e=!0,co(a,u))}else u=H,u=Uu(a,a===Q?u:0,a.cancelPendingCommit!==null||a.timeoutHandle!==-1),!(u&3)||rn(a,u)||(e=!0,co(a,u));a=a.next}while(e);Dc=!1}}function Ty(){A0()}function A0(){Au=wi=!1;var t=0;Yl!==0&&Cy()&&(t=Yl);for(var l=Bt(),e=null,a=Mu;a!==null;){var n=a.next,u=j0(a,l);u===0?(a.next=null,e===null?Mu=n:e.next=n,n===null&&(_e=e)):(e=a,(t!==0||u&3)&&(Au=!0)),a=n}yt!==0&&yt!==5||xn(t),Yl!==0&&(Yl=0)}function j0(t,l){for(var e=t.suspendedLanes,a=t.pingedLanes,n=t.expirationTimes,u=t.pendingLanes&-62914561;0<u;){var c=31-Lt(u),i=1<<c,f=n[c];f===-1?(!(i&e)||i&a)&&(n[c]=W1(i,l)):f<=l&&(t.expiredLanes|=i),u&=~i}if(l=Q,e=H,e=Uu(t,t===l?e:0,t.cancelPendingCommit!==null||t.timeoutHandle!==-1),a=t.callbackNode,e===0||t===l&&(L===2||L===9)||t.cancelPendingCommit!==null)return a!==null&&a!==null&&nc(a),t.callbackNode=null,t.callbackPriority=0;if(!(e&3)||rn(t,e)){if(l=e&-e,l===t.callbackPriority)return l;switch(a!==null&&nc(a),lf(e)){case 2:case 8:e=yr;break;case 32:e=fu;break;case 268435456:e=hr;break;default:e=fu}return a=k0.bind(null,t),e=Pi(e,a),t.callbackPriority=l,t.callbackNode=e,l}return a!==null&&a!==null&&nc(a),t.callbackPriority=2,t.callbackNode=null,2}function k0(t,l){if(yt!==0&&yt!==5)return t.callbackNode=null,t.callbackPriority=0,null;var e=t.callbackNode;if(Fu()&&t.callbackNode!==e)return null;var a=H;return a=Uu(t,t===Q?a:0,t.cancelPendingCommit!==null||t.timeoutHandle!==-1),a===0?null:(m0(t,a,l),j0(t,Bt()),t.callbackNode!=null&&t.callbackNode===e?k0.bind(null,t):null)}function co(t,l){if(Fu())return null;m0(t,l,!0)}function Ey(){$y(function(){B&6?Pi(mr,Ty):A0()})}function Bf(){if(Yl===0){var t=na;t===0&&(t=Mn,Mn<<=1,!(Mn&261888)&&(Mn=256)),Yl=t}return Yl}function io(t){return t==null||typeof t=="symbol"||typeof t=="boolean"?null:typeof t=="function"?t:Zn(""+t)}function fo(t,l){var e=l.ownerDocument.createElement("input");return e.name=l.name,e.value=l.value,t.id&&e.setAttribute("form",t.id),l.parentNode.insertBefore(e,l),t=new FormData(t),e.parentNode.removeChild(e),t}function My(t,l,e,a,n){if(l==="submit"&&e&&e.stateNode===n){var u=io((n[Ct]||null).action),c=a.submitter;c&&(l=(l=c[Ct]||null)?io(l.formAction):c.getAttribute("formAction"),l!==null&&(u=l,c=null));var i=new Hu("action","action",null,a,n);t.push({event:i,listeners:[{instance:null,listener:function(){if(a.defaultPrevented){if(Yl!==0){var f=c?fo(n,c):new FormData(n);pi(e,{pending:!0,data:f,method:n.method,action:u},null,f)}}else typeof u=="function"&&(i.preventDefault(),f=c?fo(n,c):new FormData(n),pi(e,{pending:!0,data:f,method:n.method,action:u},u,f))},currentTarget:n}]})}}for(var wc=0;wc<si.length;wc++){var Nc=si[wc],Ay=Nc.toLowerCase(),jy=Nc[0].toUpperCase()+Nc.slice(1);nl(Ay,"on"+jy)}nl(Br,"onAnimationEnd");nl(Xr,"onAnimationIteration");nl(Lr,"onAnimationStart");nl("dblclick","onDoubleClick");nl("focusin","onFocus");nl("focusout","onBlur");nl(Ym,"onTransitionRun");nl(Gm,"onTransitionStart");nl(Zm,"onTransitionCancel");nl(Yr,"onTransitionEnd");ea("onMouseEnter",["mouseout","mouseover"]);ea("onMouseLeave",["mouseout","mouseover"]);ea("onPointerEnter",["pointerout","pointerover"]);ea("onPointerLeave",["pointerout","pointerover"]);ze("onChange","change click focusin focusout input keydown keyup selectionchange".split(" "));ze("onSelect","focusout contextmenu dragend focusin keydown keyup mousedown mouseup selectionchange".split(" "));ze("onBeforeInput",["compositionend","keypress","textInput","paste"]);ze("onCompositionEnd","compositionend focusout keydown keypress keyup mousedown".split(" "));ze("onCompositionStart","compositionstart focusout keydown keypress keyup mousedown".split(" "));ze("onCompositionUpdate","compositionupdate focusout keydown keypress keyup mousedown".split(" "));var an="abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting".split(" "),ky=new Set("beforetoggle cancel close invalid load scroll scrollend toggle".split(" ").concat(an));function O0(t,l){l=(l&4)!==0;for(var e=0;e<t.length;e++){var a=t[e],n=a.event;a=a.listeners;t:{var u=void 0;if(l)for(var c=a.length-1;0<=c;c--){var i=a[c],f=i.instance,s=i.currentTarget;if(i=i.listener,f!==u&&n.isPropagationStopped())break t;u=i,n.currentTarget=s;try{u(n)}catch(d){ou(d)}n.currentTarget=null,u=f}else for(c=0;c<a.length;c++){if(i=a[c],f=i.instance,s=i.currentTarget,i=i.listener,f!==u&&n.isPropagationStopped())break t;u=i,n.currentTarget=s;try{u(n)}catch(d){ou(d)}n.currentTarget=null,u=f}}}}function $(t,l){var e=l[li];e===void 0&&(e=l[li]=new Set);var a=t+"__bubble";e.has(a)||(D0(l,t,2,!1),e.add(a))}function _c(t,l,e){var a=0;l&&(a|=4),D0(e,t,a,l)}var Rn="_reactListening"+Math.random().toString(36).slice(2);function Xf(t){if(!t[Rn]){t[Rn]=!0,pr.forEach(function(e){e!=="selectionchange"&&(ky.has(e)||_c(e,!1,t),_c(e,!0,t))});var l=t.nodeType===9?t:t.ownerDocument;l===null||l[Rn]||(l[Rn]=!0,_c("selectionchange",!1,l))}}function D0(t,l,e,a){switch(Y0(l)){case 2:var n=eh;break;case 8:n=ah;break;default:n=Zf}e=n.bind(null,l,e,t),n=void 0,!ci||l!=="touchstart"&&l!=="touchmove"&&l!=="wheel"||(n=!0),a?n!==void 0?t.addEventListener(l,e,{capture:!0,passive:n}):t.addEventListener(l,e,!0):n!==void 0?t.addEventListener(l,e,{passive:n}):t.addEventListener(l,e,!1)}function Cc(t,l,e,a,n){var u=a;if(!(l&1)&&!(l&2)&&a!==null)t:for(;;){if(a===null)return;var c=a.tag;if(c===3||c===4){var i=a.stateNode.containerInfo;if(i===n)break;if(c===4)for(c=a.return;c!==null;){var f=c.tag;if((f===3||f===4)&&c.stateNode.containerInfo===n)return;c=c.return}for(;i!==null;){if(c=$e(i),c===null)return;if(f=c.tag,f===5||f===6||f===26||f===27){a=u=c;continue t}i=i.parentNode}}a=a.return}Or(function(){var s=u,d=nf(e),v=[];t:{var m=Gr.get(t);if(m!==void 0){var h=Hu,S=t;switch(t){case"keypress":if(Qn(e)===0)break t;case"keydown":case"keyup":h=pm;break;case"focusin":S="focus",h=sc;break;case"focusout":S="blur",h=sc;break;case"beforeblur":case"afterblur":h=sc;break;case"click":if(e.button===2)break t;case"auxclick":case"dblclick":case"mousedown":case"mousemove":case"mouseup":case"mouseout":case"mouseover":case"contextmenu":h=vs;break;case"drag":case"dragend":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"dragstart":case"drop":h=sm;break;case"touchcancel":case"touchend":case"touchmove":case"touchstart":h=Em;break;case Br:case Xr:case Lr:h=dm;break;case Yr:h=Am;break;case"scroll":case"scrollend":h=im;break;case"wheel":h=km;break;case"copy":case"cut":case"paste":h=ym;break;case"gotpointercapture":case"lostpointercapture":case"pointercancel":case"pointerdown":case"pointermove":case"pointerout":case"pointerover":case"pointerup":h=xs;break;case"toggle":case"beforetoggle":h=Dm}var p=(l&4)!==0,z=!p&&(t==="scroll"||t==="scrollend"),r=p?m!==null?m+"Capture":null:m;p=[];for(var o=s,y;o!==null;){var x=o;if(y=x.stateNode,x=x.tag,x!==5&&x!==26&&x!==27||y===null||r===null||(x=Ja(o,r),x!=null&&p.push(nn(o,x,y))),z)break;o=o.return}0<p.length&&(m=new h(m,S,null,e,d),v.push({event:m,listeners:p}))}}if(!(l&7)){t:{if(m=t==="mouseover"||t==="pointerover",h=t==="mouseout"||t==="pointerout",m&&e!==ui&&(S=e.relatedTarget||e.fromElement)&&($e(S)||S[ya]))break t;if((h||m)&&(m=d.window===d?d:(m=d.ownerDocument)?m.defaultView||m.parentWindow:window,h?(S=e.relatedTarget||e.toElement,h=s,S=S?$e(S):null,S!==null&&(z=sn(S),p=S.tag,S!==z||p!==5&&p!==27&&p!==6)&&(S=null)):(h=null,S=s),h!==S)){if(p=vs,x="onMouseLeave",r="onMouseEnter",o="mouse",(t==="pointerout"||t==="pointerover")&&(p=xs,x="onPointerLeave",r="onPointerEnter",o="pointer"),z=h==null?m:wa(h),y=S==null?m:wa(S),m=new p(x,o+"leave",h,e,d),m.target=z,m.relatedTarget=y,x=null,$e(d)===s&&(p=new p(r,o+"enter",S,e,d),p.target=y,p.relatedTarget=z,x=p),z=x,h&&S)l:{for(p=Oy,r=h,o=S,y=0,x=r;x;x=p(x))y++;x=0;for(var M=o;M;M=p(M))x++;for(;0<y-x;)r=p(r),y--;for(;0<x-y;)o=p(o),x--;for(;y--;){if(r===o||o!==null&&r===o.alternate){p=r;break l}r=p(r),o=p(o)}p=null}else p=null;h!==null&&so(v,m,h,p,!1),S!==null&&z!==null&&so(v,z,S,p,!0)}}t:{if(m=s?wa(s):window,h=m.nodeName&&m.nodeName.toLowerCase(),h==="select"||h==="input"&&m.type==="file")var O=zs;else if(ps(m))if(Rr)O=Bm;else{O=Hm;var E=Um}else h=m.nodeName,!h||h.toLowerCase()!=="input"||m.type!=="checkbox"&&m.type!=="radio"?s&&af(s.elementType)&&(O=zs):O=qm;if(O&&(O=O(t,s))){Cr(v,O,e,d);break t}E&&E(t,m,s),t==="focusout"&&s&&m.type==="number"&&s.memoizedProps.value!=null&&ni(m,"number",m.value)}switch(E=s?wa(s):window,t){case"focusin":(ps(E)||E.contentEditable==="true")&&(qe=E,ii=s,Ua=null);break;case"focusout":Ua=ii=qe=null;break;case"mousedown":fi=!0;break;case"contextmenu":case"mouseup":case"dragend":fi=!1,js(v,e,d);break;case"selectionchange":if(Lm)break;case"keydown":case"keyup":js(v,e,d)}var A;if(ff)t:{switch(t){case"compositionstart":var j="onCompositionStart";break t;case"compositionend":j="onCompositionEnd";break t;case"compositionupdate":j="onCompositionUpdate";break t}j=void 0}else He?Nr(t,e)&&(j="onCompositionEnd"):t==="keydown"&&e.keyCode===229&&(j="onCompositionStart");j&&(wr&&e.locale!=="ko"&&(He||j!=="onCompositionStart"?j==="onCompositionEnd"&&He&&(A=Dr()):(Bl=d,uf="value"in Bl?Bl.value:Bl.textContent,He=!0)),E=ju(s,j),0<E.length&&(j=new gs(j,t,null,e,d),v.push({event:j,listeners:E}),A?j.data=A:(A=_r(e),A!==null&&(j.data=A)))),(A=Nm?_m(t,e):Cm(t,e))&&(j=ju(s,"onBeforeInput"),0<j.length&&(E=new gs("onBeforeInput","beforeinput",null,e,d),v.push({event:E,listeners:j}),E.data=A)),My(v,t,s,e,d)}O0(v,l)})}function nn(t,l,e){return{instance:t,listener:l,currentTarget:e}}function ju(t,l){for(var e=l+"Capture",a=[];t!==null;){var n=t,u=n.stateNode;if(n=n.tag,n!==5&&n!==26&&n!==27||u===null||(n=Ja(t,e),n!=null&&a.unshift(nn(t,n,u)),n=Ja(t,l),n!=null&&a.push(nn(t,n,u))),t.tag===3)return a;t=t.return}return[]}function Oy(t){if(t===null)return null;do t=t.return;while(t&&t.tag!==5&&t.tag!==27);return t||null}function so(t,l,e,a,n){for(var u=l._reactName,c=[];e!==null&&e!==a;){var i=e,f=i.alternate,s=i.stateNode;if(i=i.tag,f!==null&&f===a)break;i!==5&&i!==26&&i!==27||s===null||(f=s,n?(s=Ja(e,u),s!=null&&c.unshift(nn(e,s,f))):n||(s=Ja(e,u),s!=null&&c.push(nn(e,s,f)))),e=e.return}c.length!==0&&t.push({event:l,listeners:c})}var Dy=/\r\n?/g,wy=/\u0000|\uFFFD/g;function oo(t){return(typeof t=="string"?t:""+t).replace(Dy,`
+`).replace(wy,"")}function w0(t,l){return l=oo(l),oo(t)===l}function G(t,l,e,a,n,u){switch(e){case"children":typeof a=="string"?l==="body"||l==="textarea"&&a===""||aa(t,a):(typeof a=="number"||typeof a=="bigint")&&l!=="body"&&aa(t,""+a);break;case"className":kn(t,"class",a);break;case"tabIndex":kn(t,"tabindex",a);break;case"dir":case"role":case"viewBox":case"width":case"height":kn(t,e,a);break;case"style":kr(t,a,u);break;case"data":if(l!=="object"){kn(t,"data",a);break}case"src":case"href":if(a===""&&(l!=="a"||e!=="href")){t.removeAttribute(e);break}if(a==null||typeof a=="function"||typeof a=="symbol"||typeof a=="boolean"){t.removeAttribute(e);break}a=Zn(""+a),t.setAttribute(e,a);break;case"action":case"formAction":if(typeof a=="function"){t.setAttribute(e,"javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')");break}else typeof u=="function"&&(e==="formAction"?(l!=="input"&&G(t,l,"name",n.name,n,null),G(t,l,"formEncType",n.formEncType,n,null),G(t,l,"formMethod",n.formMethod,n,null),G(t,l,"formTarget",n.formTarget,n,null)):(G(t,l,"encType",n.encType,n,null),G(t,l,"method",n.method,n,null),G(t,l,"target",n.target,n,null)));if(a==null||typeof a=="symbol"||typeof a=="boolean"){t.removeAttribute(e);break}a=Zn(""+a),t.setAttribute(e,a);break;case"onClick":a!=null&&(t.onclick=Sl);break;case"onScroll":a!=null&&$("scroll",t);break;case"onScrollEnd":a!=null&&$("scrollend",t);break;case"dangerouslySetInnerHTML":if(a!=null){if(typeof a!="object"||!("__html"in a))throw Error(T(61));if(e=a.__html,e!=null){if(n.children!=null)throw Error(T(60));t.innerHTML=e}}break;case"multiple":t.multiple=a&&typeof a!="function"&&typeof a!="symbol";break;case"muted":t.muted=a&&typeof a!="function"&&typeof a!="symbol";break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"defaultValue":case"defaultChecked":case"innerHTML":case"ref":break;case"autoFocus":break;case"xlinkHref":if(a==null||typeof a=="function"||typeof a=="boolean"||typeof a=="symbol"){t.removeAttribute("xlink:href");break}e=Zn(""+a),t.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",e);break;case"contentEditable":case"spellCheck":case"draggable":case"value":case"autoReverse":case"externalResourcesRequired":case"focusable":case"preserveAlpha":a!=null&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,""+a):t.removeAttribute(e);break;case"inert":case"allowFullScreen":case"async":case"autoPlay":case"controls":case"default":case"defer":case"disabled":case"disablePictureInPicture":case"disableRemotePlayback":case"formNoValidate":case"hidden":case"loop":case"noModule":case"noValidate":case"open":case"playsInline":case"readOnly":case"required":case"reversed":case"scoped":case"seamless":case"itemScope":a&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,""):t.removeAttribute(e);break;case"capture":case"download":a===!0?t.setAttribute(e,""):a!==!1&&a!=null&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,a):t.removeAttribute(e);break;case"cols":case"rows":case"size":case"span":a!=null&&typeof a!="function"&&typeof a!="symbol"&&!isNaN(a)&&1<=a?t.setAttribute(e,a):t.removeAttribute(e);break;case"rowSpan":case"start":a==null||typeof a=="function"||typeof a=="symbol"||isNaN(a)?t.removeAttribute(e):t.setAttribute(e,a);break;case"popover":$("beforetoggle",t),$("toggle",t),Gn(t,"popover",a);break;case"xlinkActuate":dl(t,"http://www.w3.org/1999/xlink","xlink:actuate",a);break;case"xlinkArcrole":dl(t,"http://www.w3.org/1999/xlink","xlink:arcrole",a);break;case"xlinkRole":dl(t,"http://www.w3.org/1999/xlink","xlink:role",a);break;case"xlinkShow":dl(t,"http://www.w3.org/1999/xlink","xlink:show",a);break;case"xlinkTitle":dl(t,"http://www.w3.org/1999/xlink","xlink:title",a);break;case"xlinkType":dl(t,"http://www.w3.org/1999/xlink","xlink:type",a);break;case"xmlBase":dl(t,"http://www.w3.org/XML/1998/namespace","xml:base",a);break;case"xmlLang":dl(t,"http://www.w3.org/XML/1998/namespace","xml:lang",a);break;case"xmlSpace":dl(t,"http://www.w3.org/XML/1998/namespace","xml:space",a);break;case"is":Gn(t,"is",a);break;case"innerText":case"textContent":break;default:(!(2<e.length)||e[0]!=="o"&&e[0]!=="O"||e[1]!=="n"&&e[1]!=="N")&&(e=um.get(e)||e,Gn(t,e,a))}}function Ni(t,l,e,a,n,u){switch(e){case"style":kr(t,a,u);break;case"dangerouslySetInnerHTML":if(a!=null){if(typeof a!="object"||!("__html"in a))throw Error(T(61));if(e=a.__html,e!=null){if(n.children!=null)throw Error(T(60));t.innerHTML=e}}break;case"children":typeof a=="string"?aa(t,a):(typeof a=="number"||typeof a=="bigint")&&aa(t,""+a);break;case"onScroll":a!=null&&$("scroll",t);break;case"onScrollEnd":a!=null&&$("scrollend",t);break;case"onClick":a!=null&&(t.onclick=Sl);break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"innerHTML":case"ref":break;case"innerText":case"textContent":break;default:if(!zr.hasOwnProperty(e))t:{if(e[0]==="o"&&e[1]==="n"&&(n=e.endsWith("Capture"),l=e.slice(2,n?e.length-7:void 0),u=t[Ct]||null,u=u!=null?u[e]:null,typeof u=="function"&&t.removeEventListener(l,u,n),typeof a=="function")){typeof u!="function"&&u!==null&&(e in t?t[e]=null:t.hasAttribute(e)&&t.removeAttribute(e)),t.addEventListener(l,a,n);break t}e in t?t[e]=a:a===!0?t.setAttribute(e,""):Gn(t,e,a)}}}function Mt(t,l,e){switch(l){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"img":$("error",t),$("load",t);var a=!1,n=!1,u;for(u in e)if(e.hasOwnProperty(u)){var c=e[u];if(c!=null)switch(u){case"src":a=!0;break;case"srcSet":n=!0;break;case"children":case"dangerouslySetInnerHTML":throw Error(T(137,l));default:G(t,l,u,c,e,null)}}n&&G(t,l,"srcSet",e.srcSet,e,null),a&&G(t,l,"src",e.src,e,null);return;case"input":$("invalid",t);var i=u=c=n=null,f=null,s=null;for(a in e)if(e.hasOwnProperty(a)){var d=e[a];if(d!=null)switch(a){case"name":n=d;break;case"type":c=d;break;case"checked":f=d;break;case"defaultChecked":s=d;break;case"value":u=d;break;case"defaultValue":i=d;break;case"children":case"dangerouslySetInnerHTML":if(d!=null)throw Error(T(137,l));break;default:G(t,l,a,d,e,null)}}Mr(t,u,i,f,s,c,n,!1);return;case"select":$("invalid",t),a=c=u=null;for(n in e)if(e.hasOwnProperty(n)&&(i=e[n],i!=null))switch(n){case"value":u=i;break;case"defaultValue":c=i;break;case"multiple":a=i;default:G(t,l,n,i,e,null)}l=u,e=c,t.multiple=!!a,l!=null?Je(t,!!a,l,!1):e!=null&&Je(t,!!a,e,!0);return;case"textarea":$("invalid",t),u=n=a=null;for(c in e)if(e.hasOwnProperty(c)&&(i=e[c],i!=null))switch(c){case"value":a=i;break;case"defaultValue":n=i;break;case"children":u=i;break;case"dangerouslySetInnerHTML":if(i!=null)throw Error(T(91));break;default:G(t,l,c,i,e,null)}jr(t,a,n,u);return;case"option":for(f in e)if(e.hasOwnProperty(f)&&(a=e[f],a!=null))switch(f){case"selected":t.selected=a&&typeof a!="function"&&typeof a!="symbol";break;default:G(t,l,f,a,e,null)}return;case"dialog":$("beforetoggle",t),$("toggle",t),$("cancel",t),$("close",t);break;case"iframe":case"object":$("load",t);break;case"video":case"audio":for(a=0;a<an.length;a++)$(an[a],t);break;case"image":$("error",t),$("load",t);break;case"details":$("toggle",t);break;case"embed":case"source":case"link":$("error",t),$("load",t);case"area":case"base":case"br":case"col":case"hr":case"keygen":case"meta":case"param":case"track":case"wbr":case"menuitem":for(s in e)if(e.hasOwnProperty(s)&&(a=e[s],a!=null))switch(s){case"children":case"dangerouslySetInnerHTML":throw Error(T(137,l));default:G(t,l,s,a,e,null)}return;default:if(af(l)){for(d in e)e.hasOwnProperty(d)&&(a=e[d],a!==void 0&&Ni(t,l,d,a,e,void 0));return}}for(i in e)e.hasOwnProperty(i)&&(a=e[i],a!=null&&G(t,l,i,a,e,null))}function Ny(t,l,e,a){switch(l){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"input":var n=null,u=null,c=null,i=null,f=null,s=null,d=null;for(h in e){var v=e[h];if(e.hasOwnProperty(h)&&v!=null)switch(h){case"checked":break;case"value":break;case"defaultValue":f=v;default:a.hasOwnProperty(h)||G(t,l,h,null,a,v)}}for(var m in a){var h=a[m];if(v=e[m],a.hasOwnProperty(m)&&(h!=null||v!=null))switch(m){case"type":u=h;break;case"name":n=h;break;case"checked":s=h;break;case"defaultChecked":d=h;break;case"value":c=h;break;case"defaultValue":i=h;break;case"children":case"dangerouslySetInnerHTML":if(h!=null)throw Error(T(137,l));break;default:h!==v&&G(t,l,m,h,a,v)}}ai(t,c,i,f,s,d,u,n);return;case"select":h=c=i=m=null;for(u in e)if(f=e[u],e.hasOwnProperty(u)&&f!=null)switch(u){case"value":break;case"multiple":h=f;default:a.hasOwnProperty(u)||G(t,l,u,null,a,f)}for(n in a)if(u=a[n],f=e[n],a.hasOwnProperty(n)&&(u!=null||f!=null))switch(n){case"value":m=u;break;case"defaultValue":i=u;break;case"multiple":c=u;default:u!==f&&G(t,l,n,u,a,f)}l=i,e=c,a=h,m!=null?Je(t,!!e,m,!1):!!a!=!!e&&(l!=null?Je(t,!!e,l,!0):Je(t,!!e,e?[]:"",!1));return;case"textarea":h=m=null;for(i in e)if(n=e[i],e.hasOwnProperty(i)&&n!=null&&!a.hasOwnProperty(i))switch(i){case"value":break;case"children":break;default:G(t,l,i,null,a,n)}for(c in a)if(n=a[c],u=e[c],a.hasOwnProperty(c)&&(n!=null||u!=null))switch(c){case"value":m=n;break;case"defaultValue":h=n;break;case"children":break;case"dangerouslySetInnerHTML":if(n!=null)throw Error(T(91));break;default:n!==u&&G(t,l,c,n,a,u)}Ar(t,m,h);return;case"option":for(var S in e)if(m=e[S],e.hasOwnProperty(S)&&m!=null&&!a.hasOwnProperty(S))switch(S){case"selected":t.selected=!1;break;default:G(t,l,S,null,a,m)}for(f in a)if(m=a[f],h=e[f],a.hasOwnProperty(f)&&m!==h&&(m!=null||h!=null))switch(f){case"selected":t.selected=m&&typeof m!="function"&&typeof m!="symbol";break;default:G(t,l,f,m,a,h)}return;case"img":case"link":case"area":case"base":case"br":case"col":case"embed":case"hr":case"keygen":case"meta":case"param":case"source":case"track":case"wbr":case"menuitem":for(var p in e)m=e[p],e.hasOwnProperty(p)&&m!=null&&!a.hasOwnProperty(p)&&G(t,l,p,null,a,m);for(s in a)if(m=a[s],h=e[s],a.hasOwnProperty(s)&&m!==h&&(m!=null||h!=null))switch(s){case"children":case"dangerouslySetInnerHTML":if(m!=null)throw Error(T(137,l));break;default:G(t,l,s,m,a,h)}return;default:if(af(l)){for(var z in e)m=e[z],e.hasOwnProperty(z)&&m!==void 0&&!a.hasOwnProperty(z)&&Ni(t,l,z,void 0,a,m);for(d in a)m=a[d],h=e[d],!a.hasOwnProperty(d)||m===h||m===void 0&&h===void 0||Ni(t,l,d,m,a,h);return}}for(var r in e)m=e[r],e.hasOwnProperty(r)&&m!=null&&!a.hasOwnProperty(r)&&G(t,l,r,null,a,m);for(v in a)m=a[v],h=e[v],!a.hasOwnProperty(v)||m===h||m==null&&h==null||G(t,l,v,m,a,h)}function ro(t){switch(t){case"css":case"script":case"font":case"img":case"image":case"input":case"link":return!0;default:return!1}}function _y(){if(typeof performance.getEntriesByType=="function"){for(var t=0,l=0,e=performance.getEntriesByType("resource"),a=0;a<e.length;a++){var n=e[a],u=n.transferSize,c=n.initiatorType,i=n.duration;if(u&&i&&ro(c)){for(c=0,i=n.responseEnd,a+=1;a<e.length;a++){var f=e[a],s=f.startTime;if(s>i)break;var d=f.transferSize,v=f.initiatorType;d&&ro(v)&&(f=f.responseEnd,c+=d*(f<i?1:(i-s)/(f-s)))}if(--a,l+=8*(u+c)/(n.duration/1e3),t++,10<t)break}}if(0<t)return l/t/1e6}return navigator.connection&&(t=navigator.connection.downlink,typeof t=="number")?t:5}var _i=null,Ci=null;function ku(t){return t.nodeType===9?t:t.ownerDocument}function mo(t){switch(t){case"http://www.w3.org/2000/svg":return 1;case"http://www.w3.org/1998/Math/MathML":return 2;default:return 0}}function N0(t,l){if(t===0)switch(l){case"svg":return 1;case"math":return 2;default:return 0}return t===1&&l==="foreignObject"?0:t}function Ri(t,l){return t==="textarea"||t==="noscript"||typeof l.children=="string"||typeof l.children=="number"||typeof l.children=="bigint"||typeof l.dangerouslySetInnerHTML=="object"&&l.dangerouslySetInnerHTML!==null&&l.dangerouslySetInnerHTML.__html!=null}var Rc=null;function Cy(){var t=window.event;return t&&t.type==="popstate"?t===Rc?!1:(Rc=t,!0):(Rc=null,!1)}var _0=typeof setTimeout=="function"?setTimeout:void 0,Ry=typeof clearTimeout=="function"?clearTimeout:void 0,yo=typeof Promise=="function"?Promise:void 0,$y=typeof queueMicrotask=="function"?queueMicrotask:typeof yo<"u"?function(t){return yo.resolve(null).then(t).catch(Uy)}:_0;function Uy(t){setTimeout(function(){throw t})}function ne(t){return t==="head"}function ho(t,l){var e=l,a=0;do{var n=e.nextSibling;if(t.removeChild(e),n&&n.nodeType===8)if(e=n.data,e==="/$"||e==="/&"){if(a===0){t.removeChild(n),ra(l);return}a--}else if(e==="$"||e==="$?"||e==="$~"||e==="$!"||e==="&")a++;else if(e==="html")Qa(t.ownerDocument.documentElement);else if(e==="head"){e=t.ownerDocument.head,Qa(e);for(var u=e.firstChild;u;){var c=u.nextSibling,i=u.nodeName;u[mn]||i==="SCRIPT"||i==="STYLE"||i==="LINK"&&u.rel.toLowerCase()==="stylesheet"||e.removeChild(u),u=c}}else e==="body"&&Qa(t.ownerDocument.body);e=n}while(e);ra(l)}function vo(t,l){var e=t;t=0;do{var a=e.nextSibling;if(e.nodeType===1?l?(e._stashedDisplay=e.style.display,e.style.display="none"):(e.style.display=e._stashedDisplay||"",e.getAttribute("style")===""&&e.removeAttribute("style")):e.nodeType===3&&(l?(e._stashedText=e.nodeValue,e.nodeValue=""):e.nodeValue=e._stashedText||""),a&&a.nodeType===8)if(e=a.data,e==="/$"){if(t===0)break;t--}else e!=="$"&&e!=="$?"&&e!=="$~"&&e!=="$!"||t++;e=a}while(e)}function $i(t){var l=t.firstChild;for(l&&l.nodeType===10&&(l=l.nextSibling);l;){var e=l;switch(l=l.nextSibling,e.nodeName){case"HTML":case"HEAD":case"BODY":$i(e),ef(e);continue;case"SCRIPT":case"STYLE":continue;case"LINK":if(e.rel.toLowerCase()==="stylesheet")continue}t.removeChild(e)}}function Hy(t,l,e,a){for(;t.nodeType===1;){var n=e;if(t.nodeName.toLowerCase()!==l.toLowerCase()){if(!a&&(t.nodeName!=="INPUT"||t.type!=="hidden"))break}else if(a){if(!t[mn])switch(l){case"meta":if(!t.hasAttribute("itemprop"))break;return t;case"link":if(u=t.getAttribute("rel"),u==="stylesheet"&&t.hasAttribute("data-precedence"))break;if(u!==n.rel||t.getAttribute("href")!==(n.href==null||n.href===""?null:n.href)||t.getAttribute("crossorigin")!==(n.crossOrigin==null?null:n.crossOrigin)||t.getAttribute("title")!==(n.title==null?null:n.title))break;return t;case"style":if(t.hasAttribute("data-precedence"))break;return t;case"script":if(u=t.getAttribute("src"),(u!==(n.src==null?null:n.src)||t.getAttribute("type")!==(n.type==null?null:n.type)||t.getAttribute("crossorigin")!==(n.crossOrigin==null?null:n.crossOrigin))&&u&&t.hasAttribute("async")&&!t.hasAttribute("itemprop"))break;return t;default:return t}}else if(l==="input"&&t.type==="hidden"){var u=n.name==null?null:""+n.name;if(n.type==="hidden"&&t.getAttribute("name")===u)return t}else return t;if(t=tl(t.nextSibling),t===null)break}return null}function qy(t,l,e){if(l==="")return null;for(;t.nodeType!==3;)if((t.nodeType!==1||t.nodeName!=="INPUT"||t.type!=="hidden")&&!e||(t=tl(t.nextSibling),t===null))return null;return t}function C0(t,l){for(;t.nodeType!==8;)if((t.nodeType!==1||t.nodeName!=="INPUT"||t.type!=="hidden")&&!l||(t=tl(t.nextSibling),t===null))return null;return t}function Ui(t){return t.data==="$?"||t.data==="$~"}function Hi(t){return t.data==="$!"||t.data==="$?"&&t.ownerDocument.readyState!=="loading"}function By(t,l){var e=t.ownerDocument;if(t.data==="$~")t._reactRetry=l;else if(t.data!=="$?"||e.readyState!=="loading")l();else{var a=function(){l(),e.removeEventListener("DOMContentLoaded",a)};e.addEventListener("DOMContentLoaded",a),t._reactRetry=a}}function tl(t){for(;t!=null;t=t.nextSibling){var l=t.nodeType;if(l===1||l===3)break;if(l===8){if(l=t.data,l==="$"||l==="$!"||l==="$?"||l==="$~"||l==="&"||l==="F!"||l==="F")break;if(l==="/$"||l==="/&")return null}}return t}var qi=null;function go(t){t=t.nextSibling;for(var l=0;t;){if(t.nodeType===8){var e=t.data;if(e==="/$"||e==="/&"){if(l===0)return tl(t.nextSibling);l--}else e!=="$"&&e!=="$!"&&e!=="$?"&&e!=="$~"&&e!=="&"||l++}t=t.nextSibling}return null}function xo(t){t=t.previousSibling;for(var l=0;t;){if(t.nodeType===8){var e=t.data;if(e==="$"||e==="$!"||e==="$?"||e==="$~"||e==="&"){if(l===0)return t;l--}else e!=="/$"&&e!=="/&"||l++}t=t.previousSibling}return null}function R0(t,l,e){switch(l=ku(e),t){case"html":if(t=l.documentElement,!t)throw Error(T(452));return t;case"head":if(t=l.head,!t)throw Error(T(453));return t;case"body":if(t=l.body,!t)throw Error(T(454));return t;default:throw Error(T(451))}}function Qa(t){for(var l=t.attributes;l.length;)t.removeAttributeNode(l[0]);ef(t)}var ll=new Map,bo=new Set;function Ou(t){return typeof t.getRootNode=="function"?t.getRootNode():t.nodeType===9?t:t.ownerDocument}var Dl=X.d;X.d={f:Xy,r:Ly,D:Yy,C:Gy,L:Zy,m:Vy,X:Ky,S:Qy,M:Jy};function Xy(){var t=Dl.f(),l=Ju();return t||l}function Ly(t){var l=ha(t);l!==null&&l.tag===5&&l.type==="form"?kd(l):Dl.r(t)}var ba=typeof document>"u"?null:document;function $0(t,l,e){var a=ba;if(a&&typeof l=="string"&&l){var n=Wt(l);n='link[rel="'+t+'"][href="'+n+'"]',typeof e=="string"&&(n+='[crossorigin="'+e+'"]'),bo.has(n)||(bo.add(n),t={rel:t,crossOrigin:e,href:l},a.querySelector(n)===null&&(l=a.createElement("link"),Mt(l,"link",t),xt(l),a.head.appendChild(l)))}}function Yy(t){Dl.D(t),$0("dns-prefetch",t,null)}function Gy(t,l){Dl.C(t,l),$0("preconnect",t,l)}function Zy(t,l,e){Dl.L(t,l,e);var a=ba;if(a&&t&&l){var n='link[rel="preload"][as="'+Wt(l)+'"]';l==="image"&&e&&e.imageSrcSet?(n+='[imagesrcset="'+Wt(e.imageSrcSet)+'"]',typeof e.imageSizes=="string"&&(n+='[imagesizes="'+Wt(e.imageSizes)+'"]')):n+='[href="'+Wt(t)+'"]';var u=n;switch(l){case"style":u=oa(t);break;case"script":u=Sa(t)}ll.has(u)||(t=tt({rel:"preload",href:l==="image"&&e&&e.imageSrcSet?void 0:t,as:l},e),ll.set(u,t),a.querySelector(n)!==null||l==="style"&&a.querySelector(bn(u))||l==="script"&&a.querySelector(Sn(u))||(l=a.createElement("link"),Mt(l,"link",t),xt(l),a.head.appendChild(l)))}}function Vy(t,l){Dl.m(t,l);var e=ba;if(e&&t){var a=l&&typeof l.as=="string"?l.as:"script",n='link[rel="modulepreload"][as="'+Wt(a)+'"][href="'+Wt(t)+'"]',u=n;switch(a){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":u=Sa(t)}if(!ll.has(u)&&(t=tt({rel:"modulepreload",href:t},l),ll.set(u,t),e.querySelector(n)===null)){switch(a){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":if(e.querySelector(Sn(u)))return}a=e.createElement("link"),Mt(a,"link",t),xt(a),e.head.appendChild(a)}}}function Qy(t,l,e){Dl.S(t,l,e);var a=ba;if(a&&t){var n=Ke(a).hoistableStyles,u=oa(t);l=l||"default";var c=n.get(u);if(!c){var i={loading:0,preload:null};if(c=a.querySelector(bn(u)))i.loading=5;else{t=tt({rel:"stylesheet",href:t,"data-precedence":l},e),(e=ll.get(u))&&Lf(t,e);var f=c=a.createElement("link");xt(f),Mt(f,"link",t),f._p=new Promise(function(s,d){f.onload=s,f.onerror=d}),f.addEventListener("load",function(){i.loading|=1}),f.addEventListener("error",function(){i.loading|=2}),i.loading|=4,lu(c,l,a)}c={type:"stylesheet",instance:c,count:1,state:i},n.set(u,c)}}}function Ky(t,l){Dl.X(t,l);var e=ba;if(e&&t){var a=Ke(e).hoistableScripts,n=Sa(t),u=a.get(n);u||(u=e.querySelector(Sn(n)),u||(t=tt({src:t,async:!0},l),(l=ll.get(n))&&Yf(t,l),u=e.createElement("script"),xt(u),Mt(u,"link",t),e.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},a.set(n,u))}}function Jy(t,l){Dl.M(t,l);var e=ba;if(e&&t){var a=Ke(e).hoistableScripts,n=Sa(t),u=a.get(n);u||(u=e.querySelector(Sn(n)),u||(t=tt({src:t,async:!0,type:"module"},l),(l=ll.get(n))&&Yf(t,l),u=e.createElement("script"),xt(u),Mt(u,"link",t),e.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},a.set(n,u))}}function So(t,l,e,a){var n=(n=Gl.current)?Ou(n):null;if(!n)throw Error(T(446));switch(t){case"meta":case"title":return null;case"style":return typeof e.precedence=="string"&&typeof e.href=="string"?(l=oa(e.href),e=Ke(n).hoistableStyles,a=e.get(l),a||(a={type:"style",instance:null,count:0,state:null},e.set(l,a)),a):{type:"void",instance:null,count:0,state:null};case"link":if(e.rel==="stylesheet"&&typeof e.href=="string"&&typeof e.precedence=="string"){t=oa(e.href);var u=Ke(n).hoistableStyles,c=u.get(t);if(c||(n=n.ownerDocument||n,c={type:"stylesheet",instance:null,count:0,state:{loading:0,preload:null}},u.set(t,c),(u=n.querySelector(bn(t)))&&!u._p&&(c.instance=u,c.state.loading=5),ll.has(t)||(e={rel:"preload",as:"style",href:e.href,crossOrigin:e.crossOrigin,integrity:e.integrity,media:e.media,hrefLang:e.hrefLang,referrerPolicy:e.referrerPolicy},ll.set(t,e),u||Wy(n,t,e,c.state))),l&&a===null)throw Error(T(528,""));return c}if(l&&a!==null)throw Error(T(529,""));return null;case"script":return l=e.async,e=e.src,typeof e=="string"&&l&&typeof l!="function"&&typeof l!="symbol"?(l=Sa(e),e=Ke(n).hoistableScripts,a=e.get(l),a||(a={type:"script",instance:null,count:0,state:null},e.set(l,a)),a):{type:"void",instance:null,count:0,state:null};default:throw Error(T(444,t))}}function oa(t){return'href="'+Wt(t)+'"'}function bn(t){return'link[rel="stylesheet"]['+t+"]"}function U0(t){return tt({},t,{"data-precedence":t.precedence,precedence:null})}function Wy(t,l,e,a){t.querySelector('link[rel="preload"][as="style"]['+l+"]")?a.loading=1:(l=t.createElement("link"),a.preload=l,l.addEventListener("load",function(){return a.loading|=1}),l.addEventListener("error",function(){return a.loading|=2}),Mt(l,"link",e),xt(l),t.head.appendChild(l))}function Sa(t){return'[src="'+Wt(t)+'"]'}function Sn(t){return"script[async]"+t}function po(t,l,e){if(l.count++,l.instance===null)switch(l.type){case"style":var a=t.querySelector('style[data-href~="'+Wt(e.href)+'"]');if(a)return l.instance=a,xt(a),a;var n=tt({},e,{"data-href":e.href,"data-precedence":e.precedence,href:null,precedence:null});return a=(t.ownerDocument||t).createElement("style"),xt(a),Mt(a,"style",n),lu(a,e.precedence,t),l.instance=a;case"stylesheet":n=oa(e.href);var u=t.querySelector(bn(n));if(u)return l.state.loading|=4,l.instance=u,xt(u),u;a=U0(e),(n=ll.get(n))&&Lf(a,n),u=(t.ownerDocument||t).createElement("link"),xt(u);var c=u;return c._p=new Promise(function(i,f){c.onload=i,c.onerror=f}),Mt(u,"link",a),l.state.loading|=4,lu(u,e.precedence,t),l.instance=u;case"script":return u=Sa(e.src),(n=t.querySelector(Sn(u)))?(l.instance=n,xt(n),n):(a=e,(n=ll.get(u))&&(a=tt({},e),Yf(a,n)),t=t.ownerDocument||t,n=t.createElement("script"),xt(n),Mt(n,"link",a),t.head.appendChild(n),l.instance=n);case"void":return null;default:throw Error(T(443,l.type))}else l.type==="stylesheet"&&!(l.state.loading&4)&&(a=l.instance,l.state.loading|=4,lu(a,e.precedence,t));return l.instance}function lu(t,l,e){for(var a=e.querySelectorAll('link[rel="stylesheet"][data-precedence],style[data-precedence]'),n=a.length?a[a.length-1]:null,u=n,c=0;c<a.length;c++){var i=a[c];if(i.dataset.precedence===l)u=i;else if(u!==n)break}u?u.parentNode.insertBefore(t,u.nextSibling):(l=e.nodeType===9?e.head:e,l.insertBefore(t,l.firstChild))}function Lf(t,l){t.crossOrigin==null&&(t.crossOrigin=l.crossOrigin),t.referrerPolicy==null&&(t.referrerPolicy=l.referrerPolicy),t.title==null&&(t.title=l.title)}function Yf(t,l){t.crossOrigin==null&&(t.crossOrigin=l.crossOrigin),t.referrerPolicy==null&&(t.referrerPolicy=l.referrerPolicy),t.integrity==null&&(t.integrity=l.integrity)}var eu=null;function zo(t,l,e){if(eu===null){var a=new Map,n=eu=new Map;n.set(e,a)}else n=eu,a=n.get(e),a||(a=new Map,n.set(e,a));if(a.has(t))return a;for(a.set(t,null),e=e.getElementsByTagName(t),n=0;n<e.length;n++){var u=e[n];if(!(u[mn]||u[zt]||t==="link"&&u.getAttribute("rel")==="stylesheet")&&u.namespaceURI!=="http://www.w3.org/2000/svg"){var c=u.getAttribute(l)||"";c=t+c;var i=a.get(c);i?i.push(u):a.set(c,[u])}}return a}function To(t,l,e){t=t.ownerDocument||t,t.head.insertBefore(e,l==="title"?t.querySelector("head > title"):null)}function Fy(t,l,e){if(e===1||l.itemProp!=null)return!1;switch(t){case"meta":case"title":return!0;case"style":if(typeof l.precedence!="string"||typeof l.href!="string"||l.href==="")break;return!0;case"link":if(typeof l.rel!="string"||typeof l.href!="string"||l.href===""||l.onLoad||l.onError)break;switch(l.rel){case"stylesheet":return t=l.disabled,typeof l.precedence=="string"&&t==null;default:return!0}case"script":if(l.async&&typeof l.async!="function"&&typeof l.async!="symbol"&&!l.onLoad&&!l.onError&&l.src&&typeof l.src=="string")return!0}return!1}function H0(t){return!(t.type==="stylesheet"&&!(t.state.loading&3))}function Iy(t,l,e,a){if(e.type==="stylesheet"&&(typeof a.media!="string"||matchMedia(a.media).matches!==!1)&&!(e.state.loading&4)){if(e.instance===null){var n=oa(a.href),u=l.querySelector(bn(n));if(u){l=u._p,l!==null&&typeof l=="object"&&typeof l.then=="function"&&(t.count++,t=Du.bind(t),l.then(t,t)),e.state.loading|=4,e.instance=u,xt(u);return}u=l.ownerDocument||l,a=U0(a),(n=ll.get(n))&&Lf(a,n),u=u.createElement("link"),xt(u);var c=u;c._p=new Promise(function(i,f){c.onload=i,c.onerror=f}),Mt(u,"link",a),e.instance=u}t.stylesheets===null&&(t.stylesheets=new Map),t.stylesheets.set(e,l),(l=e.state.preload)&&!(e.state.loading&3)&&(t.count++,e=Du.bind(t),l.addEventListener("load",e),l.addEventListener("error",e))}}var $c=0;function Py(t,l){return t.stylesheets&&t.count===0&&au(t,t.stylesheets),0<t.count||0<t.imgCount?function(e){var a=setTimeout(function(){if(t.stylesheets&&au(t,t.stylesheets),t.unsuspend){var u=t.unsuspend;t.unsuspend=null,u()}},6e4+l);0<t.imgBytes&&$c===0&&($c=62500*_y());var n=setTimeout(function(){if(t.waitingForImages=!1,t.count===0&&(t.stylesheets&&au(t,t.stylesheets),t.unsuspend)){var u=t.unsuspend;t.unsuspend=null,u()}},(t.imgBytes>$c?50:800)+l);return t.unsuspend=e,function(){t.unsuspend=null,clearTimeout(a),clearTimeout(n)}}:null}function Du(){if(this.count--,this.count===0&&(this.imgCount===0||!this.waitingForImages)){if(this.stylesheets)au(this,this.stylesheets);else if(this.unsuspend){var t=this.unsuspend;this.unsuspend=null,t()}}}var wu=null;function au(t,l){t.stylesheets=null,t.unsuspend!==null&&(t.count++,wu=new Map,l.forEach(th,t),wu=null,Du.call(t))}function th(t,l){if(!(l.state.loading&4)){var e=wu.get(t);if(e)var a=e.get(null);else{e=new Map,wu.set(t,e);for(var n=t.querySelectorAll("link[data-precedence],style[data-precedence]"),u=0;u<n.length;u++){var c=n[u];(c.nodeName==="LINK"||c.getAttribute("media")!=="not all")&&(e.set(c.dataset.precedence,c),a=c)}a&&e.set(null,a)}n=l.instance,c=n.getAttribute("data-precedence"),u=e.get(c)||a,u===a&&e.set(null,n),e.set(c,n),this.count++,a=Du.bind(this),n.addEventListener("load",a),n.addEventListener("error",a),u?u.parentNode.insertBefore(n,u.nextSibling):(t=t.nodeType===9?t.head:t,t.insertBefore(n,t.firstChild)),l.state.loading|=4}}var un={$$typeof:bl,Provider:null,Consumer:null,_currentValue:de,_currentValue2:de,_threadCount:0};function lh(t,l,e,a,n,u,c,i,f){this.tag=1,this.containerInfo=t,this.pingCache=this.current=this.pendingChildren=null,this.timeoutHandle=-1,this.callbackNode=this.next=this.pendingContext=this.context=this.cancelPendingCommit=null,this.callbackPriority=0,this.expirationTimes=uc(-1),this.entangledLanes=this.shellSuspendCounter=this.errorRecoveryDisabledLanes=this.expiredLanes=this.warmLanes=this.pingedLanes=this.suspendedLanes=this.pendingLanes=0,this.entanglements=uc(0),this.hiddenUpdates=uc(null),this.identifierPrefix=a,this.onUncaughtError=n,this.onCaughtError=u,this.onRecoverableError=c,this.pooledCache=null,this.pooledCacheLanes=0,this.formState=f,this.incompleteTransitions=new Map}function q0(t,l,e,a,n,u,c,i,f,s,d,v){return t=new lh(t,l,e,c,f,s,d,v,i),l=1,u===!0&&(l|=24),u=Ht(3,null,null,l),t.current=u,u.stateNode=t,l=hf(),l.refCount++,t.pooledCache=l,l.refCount++,u.memoizedState={element:a,isDehydrated:e,cache:l},xf(u),t}function B0(t){return t?(t=Le,t):Le}function X0(t,l,e,a,n,u){n=B0(n),a.context===null?a.context=n:a.pendingContext=n,a=Vl(l),a.payload={element:e},u=u===void 0?null:u,u!==null&&(a.callback=u),e=Ql(t,a,l),e!==null&&(_t(e,t,l),qa(e,t,l))}function Eo(t,l){if(t=t.memoizedState,t!==null&&t.dehydrated!==null){var e=t.retryLane;t.retryLane=e!==0&&e<l?e:l}}function Gf(t,l){Eo(t,l),(t=t.alternate)&&Eo(t,l)}function L0(t){if(t.tag===13||t.tag===31){var l=Me(t,67108864);l!==null&&_t(l,t,67108864),Gf(t,67108864)}}function Mo(t){if(t.tag===13||t.tag===31){var l=Yt();l=tf(l);var e=Me(t,l);e!==null&&_t(e,t,l),Gf(t,l)}}var Nu=!0;function eh(t,l,e,a){var n=w.T;w.T=null;var u=X.p;try{X.p=2,Zf(t,l,e,a)}finally{X.p=u,w.T=n}}function ah(t,l,e,a){var n=w.T;w.T=null;var u=X.p;try{X.p=8,Zf(t,l,e,a)}finally{X.p=u,w.T=n}}function Zf(t,l,e,a){if(Nu){var n=Bi(a);if(n===null)Cc(t,l,a,_u,e),Ao(t,a);else if(uh(n,t,l,e,a))a.stopPropagation();else if(Ao(t,a),l&4&&-1<nh.indexOf(t)){for(;n!==null;){var u=ha(n);if(u!==null)switch(u.tag){case 3:if(u=u.stateNode,u.current.memoizedState.isDehydrated){var c=se(u.pendingLanes);if(c!==0){var i=u;for(i.pendingLanes|=2,i.entangledLanes|=2;c;){var f=1<<31-Lt(c);i.entanglements[1]|=f,c&=~f}ol(u),!(B&6)&&(zu=Bt()+500,xn(0))}}break;case 31:case 13:i=Me(u,2),i!==null&&_t(i,u,2),Ju(),Gf(u,2)}if(u=Bi(a),u===null&&Cc(t,l,a,_u,e),u===n)break;n=u}n!==null&&a.stopPropagation()}else Cc(t,l,a,null,e)}}function Bi(t){return t=nf(t),Vf(t)}var _u=null;function Vf(t){if(_u=null,t=$e(t),t!==null){var l=sn(t);if(l===null)t=null;else{var e=l.tag;if(e===13){if(t=fr(l),t!==null)return t;t=null}else if(e===31){if(t=sr(l),t!==null)return t;t=null}else if(e===3){if(l.stateNode.current.memoizedState.isDehydrated)return l.tag===3?l.stateNode.containerInfo:null;t=null}else l!==t&&(t=null)}}return _u=t,null}function Y0(t){switch(t){case"beforetoggle":case"cancel":case"click":case"close":case"contextmenu":case"copy":case"cut":case"auxclick":case"dblclick":case"dragend":case"dragstart":case"drop":case"focusin":case"focusout":case"input":case"invalid":case"keydown":case"keypress":case"keyup":case"mousedown":case"mouseup":case"paste":case"pause":case"play":case"pointercancel":case"pointerdown":case"pointerup":case"ratechange":case"reset":case"resize":case"seeked":case"submit":case"toggle":case"touchcancel":case"touchend":case"touchstart":case"volumechange":case"change":case"selectionchange":case"textInput":case"compositionstart":case"compositionend":case"compositionupdate":case"beforeblur":case"afterblur":case"beforeinput":case"blur":case"fullscreenchange":case"focus":case"hashchange":case"popstate":case"select":case"selectstart":return 2;case"drag":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"mousemove":case"mouseout":case"mouseover":case"pointermove":case"pointerout":case"pointerover":case"scroll":case"touchmove":case"wheel":case"mouseenter":case"mouseleave":case"pointerenter":case"pointerleave":return 8;case"message":switch(Y1()){case mr:return 2;case yr:return 8;case fu:case G1:return 32;case hr:return 268435456;default:return 32}default:return 32}}var Xi=!1,Wl=null,Fl=null,Il=null,cn=new Map,fn=new Map,Hl=[],nh="mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset".split(" ");function Ao(t,l){switch(t){case"focusin":case"focusout":Wl=null;break;case"dragenter":case"dragleave":Fl=null;break;case"mouseover":case"mouseout":Il=null;break;case"pointerover":case"pointerout":cn.delete(l.pointerId);break;case"gotpointercapture":case"lostpointercapture":fn.delete(l.pointerId)}}function ja(t,l,e,a,n,u){return t===null||t.nativeEvent!==u?(t={blockedOn:l,domEventName:e,eventSystemFlags:a,nativeEvent:u,targetContainers:[n]},l!==null&&(l=ha(l),l!==null&&L0(l)),t):(t.eventSystemFlags|=a,l=t.targetContainers,n!==null&&l.indexOf(n)===-1&&l.push(n),t)}function uh(t,l,e,a,n){switch(l){case"focusin":return Wl=ja(Wl,t,l,e,a,n),!0;case"dragenter":return Fl=ja(Fl,t,l,e,a,n),!0;case"mouseover":return Il=ja(Il,t,l,e,a,n),!0;case"pointerover":var u=n.pointerId;return cn.set(u,ja(cn.get(u)||null,t,l,e,a,n)),!0;case"gotpointercapture":return u=n.pointerId,fn.set(u,ja(fn.get(u)||null,t,l,e,a,n)),!0}return!1}function G0(t){var l=$e(t.target);if(l!==null){var e=sn(l);if(e!==null){if(l=e.tag,l===13){if(l=fr(e),l!==null){t.blockedOn=l,ss(t.priority,function(){Mo(e)});return}}else if(l===31){if(l=sr(e),l!==null){t.blockedOn=l,ss(t.priority,function(){Mo(e)});return}}else if(l===3&&e.stateNode.current.memoizedState.isDehydrated){t.blockedOn=e.tag===3?e.stateNode.containerInfo:null;return}}}t.blockedOn=null}function nu(t){if(t.blockedOn!==null)return!1;for(var l=t.targetContainers;0<l.length;){var e=Bi(t.nativeEvent);if(e===null){e=t.nativeEvent;var a=new e.constructor(e.type,e);ui=a,e.target.dispatchEvent(a),ui=null}else return l=ha(e),l!==null&&L0(l),t.blockedOn=e,!1;l.shift()}return!0}function jo(t,l,e){nu(t)&&e.delete(l)}function ch(){Xi=!1,Wl!==null&&nu(Wl)&&(Wl=null),Fl!==null&&nu(Fl)&&(Fl=null),Il!==null&&nu(Il)&&(Il=null),cn.forEach(jo),fn.forEach(jo)}function $n(t,l){t.blockedOn===l&&(t.blockedOn=null,Xi||(Xi=!0,ht.unstable_scheduleCallback(ht.unstable_NormalPriority,ch)))}var Un=null;function ko(t){Un!==t&&(Un=t,ht.unstable_scheduleCallback(ht.unstable_NormalPriority,function(){Un===t&&(Un=null);for(var l=0;l<t.length;l+=3){var e=t[l],a=t[l+1],n=t[l+2];if(typeof a!="function"){if(Vf(a||e)===null)continue;break}var u=ha(e);u!==null&&(t.splice(l,3),l-=3,pi(u,{pending:!0,data:n,method:e.method,action:a},a,n))}}))}function ra(t){function l(f){return $n(f,t)}Wl!==null&&$n(Wl,t),Fl!==null&&$n(Fl,t),Il!==null&&$n(Il,t),cn.forEach(l),fn.forEach(l);for(var e=0;e<Hl.length;e++){var a=Hl[e];a.blockedOn===t&&(a.blockedOn=null)}for(;0<Hl.length&&(e=Hl[0],e.blockedOn===null);)G0(e),e.blockedOn===null&&Hl.shift();if(e=(t.ownerDocument||t).$$reactFormReplay,e!=null)for(a=0;a<e.length;a+=3){var n=e[a],u=e[a+1],c=n[Ct]||null;if(typeof u=="function")c||ko(e);else if(c){var i=null;if(u&&u.hasAttribute("formAction")){if(n=u,c=u[Ct]||null)i=c.formAction;else if(Vf(n)!==null)continue}else i=c.action;typeof i=="function"?e[a+1]=i:(e.splice(a,3),a-=3),ko(e)}}}function Z0(){function t(u){u.canIntercept&&u.info==="react-transition"&&u.intercept({handler:function(){return new Promise(function(c){return n=c})},focusReset:"manual",scroll:"manual"})}function l(){n!==null&&(n(),n=null),a||setTimeout(e,20)}function e(){if(!a&&!navigation.transition){var u=navigation.currentEntry;u&&u.url!=null&&navigation.navigate(u.url,{state:u.getState(),info:"react-transition",history:"replace"})}}if(typeof navigation=="object"){var a=!1,n=null;return navigation.addEventListener("navigate",t),navigation.addEventListener("navigatesuccess",l),navigation.addEventListener("navigateerror",l),setTimeout(e,100),function(){a=!0,navigation.removeEventListener("navigate",t),navigation.removeEventListener("navigatesuccess",l),navigation.removeEventListener("navigateerror",l),n!==null&&(n(),n=null)}}}function Qf(t){this._internalRoot=t}Iu.prototype.render=Qf.prototype.render=function(t){var l=this._internalRoot;if(l===null)throw Error(T(409));var e=l.current,a=Yt();X0(e,a,t,l,null,null)};Iu.prototype.unmount=Qf.prototype.unmount=function(){var t=this._internalRoot;if(t!==null){this._internalRoot=null;var l=t.containerInfo;X0(t.current,2,null,t,null,null),Ju(),l[ya]=null}};function Iu(t){this._internalRoot=t}Iu.prototype.unstable_scheduleHydration=function(t){if(t){var l=Sr();t={blockedOn:null,target:t,priority:l};for(var e=0;e<Hl.length&&l!==0&&l<Hl[e].priority;e++);Hl.splice(e,0,t),e===0&&G0(t)}};var Oo=cr.version;if(Oo!=="19.2.4")throw Error(T(527,Oo,"19.2.4"));X.findDOMNode=function(t){var l=t._reactInternals;if(l===void 0)throw typeof t.render=="function"?Error(T(188)):(t=Object.keys(t).join(","),Error(T(268,t)));return t=$1(l),t=t!==null?or(t):null,t=t===null?null:t.stateNode,t};var ih={bundleType:0,version:"19.2.4",rendererPackageName:"react-dom",currentDispatcherRef:w,reconcilerVersion:"19.2.4"};if(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__<"u"){var Hn=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(!Hn.isDisabled&&Hn.supportsFiber)try{on=Hn.inject(ih),Xt=Hn}catch{}}Ru.createRoot=function(t,l){if(!ir(t))throw Error(T(299));var e=!1,a="",n=$d,u=Ud,c=Hd;return l!=null&&(l.unstable_strictMode===!0&&(e=!0),l.identifierPrefix!==void 0&&(a=l.identifierPrefix),l.onUncaughtError!==void 0&&(n=l.onUncaughtError),l.onCaughtError!==void 0&&(u=l.onCaughtError),l.onRecoverableError!==void 0&&(c=l.onRecoverableError)),l=q0(t,1,!1,null,null,e,a,null,n,u,c,Z0),t[ya]=l.current,Xf(t),new Qf(l)};Ru.hydrateRoot=function(t,l,e){if(!ir(t))throw Error(T(299));var a=!1,n="",u=$d,c=Ud,i=Hd,f=null;return e!=null&&(e.unstable_strictMode===!0&&(a=!0),e.identifierPrefix!==void 0&&(n=e.identifierPrefix),e.onUncaughtError!==void 0&&(u=e.onUncaughtError),e.onCaughtError!==void 0&&(c=e.onCaughtError),e.onRecoverableError!==void 0&&(i=e.onRecoverableError),e.formState!==void 0&&(f=e.formState)),l=q0(t,1,!0,l,e??null,a,n,f,u,c,i,Z0),l.context=B0(null),e=l.current,a=Yt(),a=tf(a),n=Vl(a),n.callback=null,Ql(e,n,a),e=a,l.current.lanes=e,dn(l,e),ol(l),t[ya]=l.current,Xf(t),new Iu(l)};Ru.version="19.2.4";function V0(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(V0)}catch(t){console.error(t)}}V0(),Qo.exports=Ru;var fh=Qo.exports,ka={},Do;function sh(){if(Do)return ka;Do=1,Object.defineProperty(ka,"__esModule",{value:!0}),ka.styleq=void 0;var t=new WeakMap,l="$$css";function e(n){var u,c,i;return n!=null&&(u=n.disableCache===!0,c=n.disableMix===!0,i=n.transform),function(){for(var s=[],d="",v=null,m="",h=u?null:t,S=new Array(arguments.length),p=0;p<arguments.length;p++)S[p]=arguments[p];for(;S.length>0;){var z=S.pop();if(!(z==null||z===!1)){if(Array.isArray(z)){for(var r=0;r<z.length;r++)S.push(z[r]);continue}var o=i!=null?i(z):z;if(o.$$css!=null){var y="";if(h!=null&&h.has(o)){var x=h.get(o);x!=null&&(y=x[0],m=x[2],s.push.apply(s,x[1]),h=x[3])}else{var M=[];for(var O in o){var E=o[O];if(O===l){var A=o[O];A!==!0&&(m=m?A+"; "+m:A);continue}typeof E=="string"||E===null?s.includes(O)||(s.push(O),h!=null&&M.push(O),typeof E=="string"&&(y+=y?" "+E:E)):console.error("styleq: ".concat(O," typeof ").concat(String(E),' is not "string" or "null".'))}if(h!=null){var j=new WeakMap;h.set(o,[y,M,m,j]),h=j}}y&&(d=d?y+" "+d:y)}else if(c)v==null&&(v={}),v=Object.assign({},o,v);else{var k=null;for(var V in o){var J=o[V];J!==void 0&&(s.includes(V)||(J!=null&&(v==null&&(v={}),k==null&&(k={}),k[V]=J),s.push(V),h=null))}k!=null&&(v=Object.assign(k,v))}}}var wl=[d,v,m];return wl}}var a=ka.styleq=e();return a.factory=e,ka}var oh=sh();function P(...t){const[l,e,a]=oh.styleq(t),n={};return l!=null&&l!==""&&(n.className=l),e!=null&&Object.keys(e).length>0&&(n.style=e),a!=null&&a!==""&&(n["data-style-src"]=a),n}const wo={"--color-accent":"var(--color-accent)","--color-on-dark":"var(--color-on-dark)"},St={xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:1.5,strokeLinecap:"round",strokeLinejoin:"round",width:"1em",height:"1em","aria-hidden":!0},qn={xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor",width:"1em",height:"1em","aria-hidden":!0},rh={close:g.jsx("svg",{...St,children:g.jsx("path",{d:"M6 6l12 12M6 18L18 6"})}),chevronDown:g.jsx("svg",{...St,children:g.jsx("path",{d:"M6 9l6 6 6-6"})}),chevronLeft:g.jsx("svg",{...St,children:g.jsx("path",{d:"M15 6l-6 6 6 6"})}),chevronRight:g.jsx("svg",{...St,children:g.jsx("path",{d:"M9 6l6 6-6 6"})}),check:g.jsx("svg",{...St,children:g.jsx("path",{d:"M5 13l4 4L19 7"})}),checkCircle:g.jsx("svg",{...qn,children:g.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M12 3a9 9 0 100 18 9 9 0 000-18zm4.06 6.56a.75.75 0 00-1.12-1l-3.94 4.4-1.94-1.94a.75.75 0 00-1.06 1.06l2.5 2.5a.75.75 0 001.09-.03l4.47-5z"})}),xCircle:g.jsx("svg",{...qn,children:g.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M12 3a9 9 0 100 18 9 9 0 000-18zm-2.47 5.47a.75.75 0 00-1.06 1.06L10.94 12l-2.47 2.47a.75.75 0 101.06 1.06L12 13.06l2.47 2.47a.75.75 0 101.06-1.06L13.06 12l2.47-2.47a.75.75 0 00-1.06-1.06L12 10.94l-2.47-2.47z"})}),warning:g.jsx("svg",{...qn,children:g.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M10.29 3.86L2.07 19.05A2 2 0 003.78 22h16.44a2 2 0 001.71-2.95L13.71 3.86a2 2 0 00-3.42 0zM12 9a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0112 9zm0 9a1 1 0 100-2 1 1 0 000 2z"})}),info:g.jsxs("svg",{...St,children:[g.jsx("circle",{cx:"12",cy:"12",r:"9"}),g.jsx("path",{d:"M12 11v5"}),g.jsx("circle",{cx:"12",cy:"8",r:"0.5",fill:"currentColor",stroke:"none"})]}),calendar:g.jsxs("svg",{...St,children:[g.jsx("rect",{x:"3",y:"4",width:"18",height:"18",rx:"2"}),g.jsx("path",{d:"M16 2v4M8 2v4M3 10h18"})]}),clock:g.jsxs("svg",{...St,children:[g.jsx("circle",{cx:"12",cy:"12",r:"9"}),g.jsx("path",{d:"M12 7v5l3 3"})]}),externalLink:g.jsxs("svg",{...St,children:[g.jsx("path",{d:"M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"}),g.jsx("path",{d:"M15 3h6v6"}),g.jsx("path",{d:"M10 14L21 3"})]}),menu:g.jsx("svg",{...St,strokeWidth:2,children:g.jsx("path",{d:"M4 6h16M4 12h16M4 18h16"})}),moreHorizontal:g.jsxs("svg",{...qn,children:[g.jsx("circle",{cx:"5",cy:"12",r:"1.5"}),g.jsx("circle",{cx:"12",cy:"12",r:"1.5"}),g.jsx("circle",{cx:"19",cy:"12",r:"1.5"})]}),search:g.jsxs("svg",{...St,children:[g.jsx("circle",{cx:"11",cy:"11",r:"8"}),g.jsx("path",{d:"M21 21l-4.35-4.35"})]}),arrowUp:g.jsx("svg",{...St,children:g.jsx("path",{d:"M12 19V5m0 0l-7 7m7-7l7 7"})}),arrowDown:g.jsx("svg",{...St,children:g.jsx("path",{d:"M12 5v14m0 0l7-7m-7 7l-7-7"})}),arrowsUpDown:g.jsx("svg",{...St,children:g.jsx("path",{d:"M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"})}),funnel:g.jsx("svg",{...St,children:g.jsx("path",{d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z"})}),eyeSlash:g.jsx("svg",{...St,children:g.jsx("path",{d:"M3.98 8.223A10.477 10.477 0 001.934 12c1.292 4.338 5.31 7.5 10.066 7.5.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"})}),viewColumns:g.jsx("svg",{...St,children:g.jsx("path",{d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125z"})})};let Li={};function dh(t){Li={...Li,...t}}function mh(t){return Li[t]??rh[t]}function yh(t){return t==="base"?"":t.split("+").map(l=>{const[e,a]=l.split(":");return/^\d/.test(a)?`.${e}-${a}`:`.${a}`}).join("")}const Uc={[-5]:"--font-size-4xs",[-4]:"--font-size-3xs",[-3]:"--font-size-2xs",[-2]:"--font-size-xs",[-1]:"--font-size-sm",0:"--font-size-base",1:"--font-size-lg",2:"--font-size-xl",3:"--font-size-2xl",4:"--font-size-3xl",5:"--font-size-4xl",6:"--font-size-5xl"},hh={1:3,2:2,3:1,4:0,5:-1,6:-2},vh={body:0,large:1,label:0,code:0,supporting:-1,"display-1":6,"display-2":5,"display-3":4},gh={1:"var(--font-weight-semibold)",2:"var(--font-weight-semibold)",3:"var(--font-weight-semibold)",4:"var(--font-weight-semibold)",5:"var(--font-weight-semibold)",6:"var(--font-weight-semibold)"},xh={body:"var(--font-weight-normal)",large:"var(--font-weight-semibold)",label:"var(--font-weight-medium)",code:"var(--font-weight-normal)",supporting:"var(--font-weight-normal)","display-1":"var(--font-weight-normal)","display-2":"var(--font-weight-normal)","display-3":"var(--font-weight-normal)"};function Hc(t,l,e){return Math.round(t*Math.pow(l,e))}function bh(t){return`${Math.round(t/16*1e4)/1e4}rem`}function Sh(t){return t<20?1.5:t<32?1.4:1.25}function No(t){const l=Sh(t),e=t*l,a=Math.max(Math.round(e/4)*4,Math.ceil((t+4)/4)*4);return Math.round(a/t*1e4)/1e4}function ph(t){const{base:l,ratio:e,weights:a}=t,n={},u={...gh,...a==null?void 0:a.heading},c={...xh,...a==null?void 0:a.text};for(let i=-5;i<=6;i++){const f=Hc(l,e,i);n[Uc[i]]=bh(f)}for(const[i,f]of Object.entries(hh)){const s=Number(i),d=Hc(l,e,f),v=No(d);n[`--text-heading-${s}-size`]=`var(${Uc[f]})`,n[`--text-heading-${s}-weight`]=u[s],n[`--text-heading-${s}-leading`]=`${v}`}for(const[i,f]of Object.entries(vh)){const s=Hc(l,e,f),d=No(s);n[`--text-${i}-size`]=`var(${Uc[f]})`,n[`--text-${i}-weight`]=c[i],n[`--text-${i}-leading`]=`${d}`}return n}const zh={body:"var(--font-family-body)",large:"var(--font-family-body)",label:"var(--font-family-body)",code:"var(--font-family-code)",supporting:"var(--font-family-body)","display-1":"var(--font-family-heading)","display-2":"var(--font-family-heading)","display-3":"var(--font-family-heading)"};function Th(t){const l={},e={};for(const n of[1,2,3,4,5,6])e[`level:${n}`]={fontFamily:"var(--font-family-heading)",fontSize:`var(--text-heading-${n}-size)`,fontWeight:`var(--text-heading-${n}-weight)`,lineHeight:`var(--text-heading-${n}-leading)`};l.heading=e;const a={};for(const n of["body","large","label","code","supporting","display-1","display-2","display-3"])a[`type:${n}`]={fontFamily:zh[n],fontSize:`var(--text-${n}-size)`,lineHeight:`var(--text-${n}-leading)`};return l.text=a,l}function De(t){return Math.round(t/5)*5}function Eh(t){const{fast:l,medium:e,ratio:a,easing:n}=t,u={"--duration-fast-min":`${De(l*a)}ms`,"--duration-fast":`${De(l)}ms`,"--duration-fast-max":`${De(l/a)}ms`,"--duration-medium-min":`${De(e*a)}ms`,"--duration-medium":`${De(e)}ms`,"--duration-medium-max":`${De(e/a)}ms`};return n&&(u["--ease-standard"]=n),u}function Mh(t){const{base:l,multiplier:e}=t;return{"--radius-none":"0px","--radius-inner":`${Math.round(l*1*e)}px`,"--radius-element":`${Math.round(l*2*e)}px`,"--radius-container":`${Math.round(l*3*e)}px`,"--radius-page":`${Math.round(l*7*e)}px`,"--radius-full":"9999px"}}function Ah(t){return Array.isArray(t)?`light-dark(${t[0]}, ${t[1]})`:t}function jh(t,l){if(!t&&!l)return;if(!t)return l;if(!l)return t;const e={};for(const[a,n]of Object.entries(t))e[a]={...n};for(const[a,n]of Object.entries(l))if(!e[a])e[a]={...n};else for(const[u,c]of Object.entries(n))e[a][u]={...e[a][u],...c};return e}function Bn(t){return{normal:"var(--font-weight-normal)",medium:"var(--font-weight-medium)",semibold:"var(--font-weight-semibold)",bold:"var(--font-weight-bold)"}[t]??t}function qc(t,l){if(!t)return;const e=t.includes(" ")?`"${t}"`:t;return l?`${e}, ${l}`:e}function kh(t){var c,i,f,s,d,v,m,h;const l={},e=t.typography;let a;if(e!=null&&e.scale){const S={},p=e.heading;if(p!=null&&p.weights)for(const[o,y]of Object.entries(p.weights))y&&(S[Number(o)]=Bn(y));const z=p!=null&&p.weight?Bn(p.weight):void 0;if(z)for(let o=1;o<=6;o++)o in S||(S[o]=z);const r={};(c=e.body)!=null&&c.weight&&(r.body=Bn(e.body.weight)),(i=e.code)!=null&&i.weight&&(r.code=Bn(e.code.weight)),a={base:e.scale.base,ratio:e.scale.ratio,weights:{...Object.keys(S).length>0?{heading:S}:{},...Object.keys(r).length>0?{text:r}:{}}}}if(a){const S=ph(a);for(const[p,z]of Object.entries(S))l[p]=z}if(t.radius){const S=Mh(t.radius);for(const[p,z]of Object.entries(S))l[p]=z}if(t.motion){const S=Eh(t.motion);for(const[p,z]of Object.entries(S))l[p]=z}if(e){const S=qc((f=e.body)==null?void 0:f.family,(s=e.body)==null?void 0:s.fallbacks),p=qc((d=e.heading)==null?void 0:d.family,(v=e.heading)==null?void 0:v.fallbacks)??S,z=qc((m=e.code)==null?void 0:m.family,(h=e.code)==null?void 0:h.fallbacks);S&&(l["--font-family-body"]=S),p&&(l["--font-family-heading"]=p),z&&(l["--font-family-code"]=z)}if(t.tokens)for(const[S,p]of Object.entries(t.tokens))p!==void 0&&(l[S]=Ah(p));let n=t.components;if(a){const S=Th();n=jh(S,t.components)}let u;if(e){const S=new Set,p=[];for(const z of[e.body,e.heading,e.code])z!=null&&z.family&&z.url&&!S.has(z.family)&&(S.add(z.family),p.push({family:z.family,url:z.url}));p.length>0&&(u=p)}return{name:t.name,tokens:l,components:n,icons:t.icons,fonts:u,__inputTokens:t.tokens}}function _o(t){return t.replace(/[A-Z]/g,l=>`-${l.toLowerCase()}`)}function Oh(t){const l=[],e=t.tokens,a=d=>e[d]||`var(${d})`,n=Object.entries(e);if(n.length>0){const d=n.map(([v,m])=>`    ${v}: ${m};`).join(`
+`);l.push(`  :scope {
+${d}
+  }`)}if(t.components)for(const[d,v]of Object.entries(t.components))for(const[m,h]of Object.entries(v)){const S=Object.entries(h);if(S.length>0){const p=yh(m),z=`.xds-${d}${p}`,r=[],o=[];for(const[y,x]of S)y.startsWith(":")&&typeof x=="object"?o.push([y,x]):r.push([y,x]);if(r.length>0){const y=r.map(([x,M])=>`    ${_o(x)}: ${M};`).join(`
+`);l.push(`  ${z} {
+${y}
+  }`)}for(const[y,x]of o){const M=Object.entries(x);if(M.length>0){const O=M.map(([E,A])=>`    ${_o(E)}: ${A};`).join(`
+`);l.push(`  ${z}${y} {
+${O}
+  }`)}}}}l.push(`  :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-family-heading);
+    color: var(--color-text-primary);
+  }`);for(let d=1;d<=6;d++)l.push(`  h${d} {
+    font-size: ${a(`--text-heading-${d}-size`)};
+    font-weight: ${a(`--text-heading-${d}-weight`)};
+    line-height: ${a(`--text-heading-${d}-leading`)};
+  }`);l.push(`  p {
+    font-family: var(--font-family-heading);
+    font-size: ${a("--text-body-size")};
+    font-weight: ${a("--text-body-weight")};
+    line-height: ${a("--text-body-leading")};
+    color: var(--color-text-primary);
+  }`),l.push(`  small {
+    font-size: ${a("--text-supporting-size")};
+    font-weight: ${a("--text-supporting-weight")};
+    line-height: ${a("--text-supporting-leading")};
+    color: var(--color-text-secondary);
+  }`),l.push(`  code, pre {
+    font-family: var(--font-family-code);
+    font-size: ${a("--text-code-size")};
+    line-height: ${a("--text-code-leading")};
+  }`),l.push(`  hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+  }`);const u={primary:"var(--color-text-primary)",secondary:"var(--color-text-secondary)",disabled:"var(--color-text-disabled)",placeholder:"var(--color-text-secondary)",active:"var(--color-accent)"},c=t.components||{},i="text"in c,f="heading"in c,s="link"in c;if(i||f||s)for(const[d,v]of Object.entries(u))i&&l.push(`  .xds-text.${d} { color: ${v}; }`),f&&l.push(`  .xds-heading.${d} { color: ${v}; }`),s&&l.push(`  .xds-link.${d} { color: ${v}; }`);return l}function Dh(t){const l=Oh(t);if(l.length===0)return"";const e=`[data-xds-theme="${t.name}"]`,a=l.join(`
+
+`);return`@scope (${e}) to ([data-xds-theme]) {
+${a}
+}`}const wh=b.createContext(null),Xn={base:{k1xSpc:"xjp7ctv",kMwMTN:"x1tgivj0",kMv6JI:"x9ynric",$$css:!0},light:{kQNsl9:"x19aimcq",$$css:!0},dark:{kQNsl9:"xntwwlm",$$css:!0},system:{kQNsl9:"x108lcm5",$$css:!0}},Bc=new Set;function Nh(t){const l=b.useId();b.useInsertionEffect(()=>{if(t.__built)return;const e=`xds-theme-${t.name}`;if(Bc.has(e))return;const a=Dh(t);if(!a)return;const n=document.createElement("style");return n.setAttribute("data-xds-theme",t.name),n.setAttribute("data-xds-id",l),n.textContent=`@layer xds-theme {
+${a}
+}`,document.head.appendChild(n),Bc.add(e),()=>{const u=document.querySelector(`style[data-xds-theme="${t.name}"][data-xds-id="${l}"]`);u&&(u.remove(),Bc.delete(e))}},[t,l])}function _h(t){const l=b.useRef([]);b.useLayoutEffect(()=>{if(typeof document>"u"||!t.fonts||t.fonts.length===0)return;const e=[];for(const a of t.fonts){if(document.fonts.check(`16px "${a.family}"`)||document.head.querySelector(`link[rel="stylesheet"][href="${a.url}"]`))continue;const c=document.createElement("link");c.rel="stylesheet",c.href=a.url,document.head.appendChild(c),e.push(c),console.warn(`[XDS] Theme "${t.name}" loaded font "${a.family}" at runtime. For better performance, add to your document <head>:
+  <link rel="stylesheet" href="${a.url}" />`)}return l.current=e,()=>{for(const a of l.current)a.parentNode&&a.parentNode.removeChild(a);l.current=[]}},[t.fonts,t.name])}function Q0({theme:t,mode:l="system",children:e}){Nh(t),_h(t);const a=l==="dark"?Xn.dark:l==="light"?Xn.light:Xn.system,n=t.icons;n!=null&&dh(n);const u=b.useMemo(()=>({theme:t,mode:l}),[t,l]);return g.jsx(wh.Provider,{value:u,children:g.jsx("div",{...P(Xn.base,a),"data-xds-theme":t.name,"data-theme":l==="system"?void 0:l,children:e})})}Q0.displayName="XDSTheme";function Ch({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3"}))}const Rh=b.forwardRef(Ch);function $h({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18"}))}const Uh=b.forwardRef($h);function Hh({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"}))}const qh=b.forwardRef(Hh);function Bh({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"}))}const Xh=b.forwardRef(Bh);function Lh({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"}))}const Yh=b.forwardRef(Lh);function Gh({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m4.5 12.75 6 6 9-13.5"}))}const Zh=b.forwardRef(Gh);function Vh({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m19.5 8.25-7.5 7.5-7.5-7.5"}))}const Qh=b.forwardRef(Vh);function Kh({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M15.75 19.5 8.25 12l7.5-7.5"}))}const Jh=b.forwardRef(Kh);function Wh({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m8.25 4.5 7.5 7.5-7.5 7.5"}))}const Fh=b.forwardRef(Wh);function Ih({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"}))}const Ph=b.forwardRef(Ih);function tv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"}))}const lv=b.forwardRef(tv);function ev({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"}))}const av=b.forwardRef(ev);function nv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"}))}const uv=b.forwardRef(nv);function cv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"}))}const iv=b.forwardRef(cv);function fv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"}))}const sv=b.forwardRef(fv);function ov({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z"}))}const rv=b.forwardRef(ov);function dv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6 18 18 6M6 6l12 12"}))}const mv=b.forwardRef(dv);function yv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{fillRule:"evenodd",d:"M15.75 2.25H21a.75.75 0 0 1 .75.75v5.25a.75.75 0 0 1-1.5 0V4.81L8.03 17.03a.75.75 0 0 1-1.06-1.06L19.19 3.75h-3.44a.75.75 0 0 1 0-1.5Zm-10.5 4.5a1.5 1.5 0 0 0-1.5 1.5v10.5a1.5 1.5 0 0 0 1.5 1.5h10.5a1.5 1.5 0 0 0 1.5-1.5V10.5a.75.75 0 0 1 1.5 0v8.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V8.25a3 3 0 0 1 3-3h8.25a.75.75 0 0 1 0 1.5H5.25Z",clipRule:"evenodd"}))}const hv=b.forwardRef(yv);function vv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{fillRule:"evenodd",d:"M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z",clipRule:"evenodd"}))}const gv=b.forwardRef(vv);function xv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{fillRule:"evenodd",d:"M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z",clipRule:"evenodd"}))}const bv=b.forwardRef(xv);function Sv({title:t,titleId:l,...e},a){return b.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?b.createElement("title",{id:l},t):null,b.createElement("path",{fillRule:"evenodd",d:"M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-1.72 6.97a.75.75 0 1 0-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06L12 13.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L13.06 12l1.72-1.72a.75.75 0 1 0-1.06-1.06L12 10.94l-1.72-1.72Z",clipRule:"evenodd"}))}const pv=b.forwardRef(Sv),ct={width:"1em",height:"1em","aria-hidden":!0},zv={close:g.jsx(mv,{...ct}),chevronDown:g.jsx(Qh,{...ct}),chevronLeft:g.jsx(Jh,{...ct}),chevronRight:g.jsx(Fh,{...ct}),check:g.jsx(Zh,{...ct}),checkCircle:g.jsx(gv,{...ct}),xCircle:g.jsx(pv,{...ct}),warning:g.jsx(bv,{...ct}),info:g.jsx(iv,{...ct}),calendar:g.jsx(Yh,{...ct}),clock:g.jsx(Ph,{...ct}),externalLink:g.jsx(hv,{...ct}),menu:g.jsx(Xh,{...ct}),moreHorizontal:g.jsx(lv,{...ct}),search:g.jsx(sv,{...ct}),arrowUp:g.jsx(Uh,{...ct}),arrowDown:g.jsx(Rh,{...ct}),arrowsUpDown:g.jsx(qh,{...ct}),funnel:g.jsx(uv,{...ct}),eyeSlash:g.jsx(av,{...ct}),viewColumns:g.jsx(rv,{...ct})},Tv=kh({name:"default",typography:{scale:{base:14,ratio:1.2}},motion:{fast:175,medium:410,ratio:.75},tokens:{},components:{button:{"variant:secondary":{backgroundColor:"light-dark(rgba(5, 54, 89, 0.1), rgba(223, 226, 229, 0.2))"}}},icons:zv}),Yi=120;function Ev(t){let l=0,e=0;const a=[];for(const i of t){const f=i.width;if((f==null?void 0:f.type)==="pixel")e+=f.value;else{const s=(f==null?void 0:f.value)??1,d=f!=null?f.minWidth??Yi:0;l+=s,a.push({key:i.key,proportion:s,minWidth:d})}}let n=0;if(l>0)for(const i of a){const f=i.minWidth*l/i.proportion;f>n&&(n=f)}const u=e+n,c=new Map;for(const i of t){const f=i.width,s={};if((f==null?void 0:f.type)==="pixel")s.width=`${f.value}px`,s.minWidth=`${f.value}px`;else{const d=(f==null?void 0:f.value)??1;if(l>0&&(s.width=`${d/l*100}%`),f!=null){const v=f.minWidth??Yi;s.minWidth=`${v}px`}}c.set(i.key,{style:s})}return{columns:c,tableMinWidth:u}}function Mv(t=1,l){return{type:"proportional",value:t,minWidth:(l==null?void 0:l.minWidth)??Yi}}function Xc(t){return{type:"pixel",value:t}}function Av(t){return t.length===0?t:t.charAt(0).toUpperCase()+t.slice(1)}function jv(t,l){const e=t[l];return e==null?"":String(e)}function kv(t){if(t.length===0)return[];const l=t[0];return Object.keys(l).map(e=>({key:e,header:Av(e),width:Mv(1)}))}const Kf=b.createContext(null);function mt(t,l){const e=[`xds-${t}`];if(l)for(const[a,n]of Object.entries(l)){if(n==null)continue;const u=String(n);/^\d/.test(u)?e.push(`${a}-${u}`):e.push(u)}return e.join(" ")}function vt(t,l,e,a){let n=l.className?`${t} ${l.className}`:t;e&&(n=`${n} ${e}`);const u=a&&l.style?{...l.style,...a}:a||l.style;return{className:n,style:u}}const Ov={row:{kWkggS:"x1dnou9g",$$css:!0}},Dv={row:{kWkggS:"xe9uy6x",k1ekBW:"x15406qy",kIyJzY:"xuedmi6",kAMwcw:"xlr8y92",$$css:!0}},wv={row:{kWkggS:"x1dnou9g xe9uy6x",k1ekBW:"x15406qy",kIyJzY:"xuedmi6",kAMwcw:"xlr8y92",$$css:!0}};function Jf({children:t,xstyle:l,ref:e,...a}){const n=b.useContext(Kf);if(!n)return g.jsx("tr",{ref:e,...a,...vt(mt("table-row"),P(l)),children:t});const u=[];return n.isStriped&&n.hasHover?u.push(wv.row):n.isStriped?u.push(Ov.row):n.hasHover&&u.push(Dv.row),n.dividers==="rows"||n.dividers,l&&u.push(...l),g.jsx("tr",{ref:e,...a,...vt(mt("table-row"),P(...u)),children:t})}Jf.displayName="XDSTableRow";const K0={cell:{kVQacm:"xb3r6kr",kg5iWk:"xlyipyv",khDVqt:"xuxw1ft",ks0D6T:"x1m189uc",$$css:!0}};function Nv(t,l,e){const a=[];return(t.dividers==="rows"||t.dividers==="grid")&&a.push(l),(t.dividers==="columns"||t.dividers==="grid")&&a.push(e),a}function J0(t,l){return l?Array.isArray(l)?[...t,...l]:[...t,l]:t}function W0(){return b.useContext(Kf)}const _v={compact:{k8WAf4:"xu0wf1k",kg3NbH:"xf314gf",kGuDYH:"xjm74w1",kB7OPa:"x9f619",$$css:!0},balanced:{k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kGuDYH:"xjm74w1",kB7OPa:"x9f619",$$css:!0},spacious:{k8WAf4:"x8o8v82",kg3NbH:"x1pzlopt",kGuDYH:"xjm74w1",kB7OPa:"x9f619",$$css:!0}},Cv={cell:{kt9PQ7:"x92x3c3",kfdmCh:"x1q0q8m5",kL6WhQ:"xw8gpjh",$$css:!0}},Rv={cell:{kWqL5O:"x1pcaw5z x1lpyac",kSWEuD:"x32b0ac",k26BEO:"xtgwc6q",$$css:!0}};function Wf({children:t,xstyle:l,ref:e,...a}){const n=W0();if(!n)return g.jsx("td",{ref:e,...a,...vt(mt("table-cell"),P(l)),children:t});const u=[_v[n.density],K0.cell,...Nv(n,Cv.cell,Rv.cell)];return g.jsx("td",{ref:e,...a,...vt(mt("table-cell"),P(...J0(u,l))),children:t})}Wf.displayName="XDSTableCell";const $v={compact:{k8WAf4:"xu0wf1k",kg3NbH:"xf314gf",kGuDYH:"xcr08ib",kB7OPa:"x9f619",$$css:!0},balanced:{k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kGuDYH:"xcr08ib",kB7OPa:"x9f619",$$css:!0},spacious:{k8WAf4:"x8o8v82",kg3NbH:"x1pzlopt",kGuDYH:"xcr08ib",kB7OPa:"x9f619",$$css:!0}},Uv={cell:{k63SB2:"x2mo6ok",kMwMTN:"xv1l7n4",k9WMMc:"x1yc453h",$$css:!0}},Hv={cell:{kt9PQ7:"x92x3c3",kfdmCh:"x1q0q8m5",kL6WhQ:"xw8gpjh",$$css:!0}},qv={cell:{kWqL5O:"x1pcaw5z x1lpyac",kSWEuD:"x32b0ac",k26BEO:"xtgwc6q",$$css:!0}};function Ff({children:t,xstyle:l,ref:e,className:a,style:n,...u}){const c=W0();if(!c)return g.jsx("th",{ref:e,...u,...vt(mt("table-header-cell"),P(l),a,n),children:t});const i=[Uv.cell,$v[c.density],Hv.cell,K0.cell];return(c.dividers==="columns"||c.dividers==="grid")&&i.push(qv.cell),g.jsx("th",{ref:e,...u,...vt(mt("table-header-cell"),P(...J0(i,l)),a,n),children:t})}Ff.displayName="XDSTableHeaderCell";const Bv={table:{kzqmXN:"xh8yej3",kLvRdT:"x1mwwwfo",kheTzg:"x1gukg7c",kPzzVL:"x140o2bo",$$css:!0}};function Ve(t,l,e,...a){return t.reduce((n,u,c)=>{const i=l(u);if(!i)return n;try{return i(n,...a)}catch(f){return console.error(`[XDSTable] Plugin at index ${c} threw in transform:`,f),n}},e)}const Xv=[];function Lv(t,l){if(t===l)return!0;if(t.length!==l.length)return!1;for(let e=0;e<t.length;e++)if(t[e]!==l[e])return!1;return!0}function Yv({item:t,rowIndex:l,rowKey:e,columns:a,plugins:n,RowComponent:u,CellComponent:c}){const i=a.map(s=>{const d=Ve(n,h=>h.transformBodyCell,{htmlProps:{},styles:[]},s,t),v=s.renderCell?s.renderCell(t):jv(t,s.key),m=!s.renderCell&&typeof v=="string"&&v.length>0?{title:v}:{};return g.jsx(c,{...d.htmlProps,...m,xstyle:d.styles,children:v},s.key)}),f=Ve(n,s=>s.transformBodyRow,{htmlProps:{},styles:[],children:g.jsx(g.Fragment,{children:i})},t,l);return g.jsx(u,{ref:f.ref,...f.htmlProps,xstyle:f.styles,children:f.children},e)}function Gv(t,l){if(t.rowKey!==l.rowKey||t.rowIndex!==l.rowIndex||t.columns!==l.columns||t.plugins!==l.plugins||t.RowComponent!==l.RowComponent||t.CellComponent!==l.CellComponent)return!1;if(t.item===l.item)return!0;const e=t.item,a=l.item,n=Object.keys(a);for(const u of n)if(e[u]!==a[u])return!1;return!0}const Zv=b.memo(Yv,Gv);function Vv({data:t,columns:l,idKey:e,plugins:a,components:n,children:u,tableProps:c,ref:i}){const f=a??Xv,s=(n==null?void 0:n.Row)??Jf,d=(n==null?void 0:n.Cell)??Wf,v=(n==null?void 0:n.HeaderCell)??Ff,m=l??(t?kv(t):[]),h=Ve(f,A=>A.transformColumns,m),S=b.useRef(h);Lv(S.current,h)||(S.current=h);const p=S.current,z=Ev(p),r=Ve(f,A=>A.transformTable,{htmlProps:{...c},styles:[Bv.table]}),o=p.map(A=>{var ut;const j=A.header??A.key,k=Ve(f,je=>je.transformHeaderCell,{htmlProps:{"data-column-key":A.key},styles:[],content:j},A),V=((ut=z.columns.get(A.key))==null?void 0:ut.style)??{},J=k.htmlProps.style,wl={...k.htmlProps,style:J?{...V,...J}:V},rl=k.content??j,ue=typeof rl=="string"&&rl.length>0?{title:rl}:{},{before:D,after:N,overlay:_}=k,et=D!=null||N!=null||_!=null;return g.jsx(v,{...wl,...ue,xstyle:k.styles,children:et?g.jsxs(g.Fragment,{children:[D,rl,N,_]}):rl},A.key)}),y=Ve(f,A=>A.transformHeaderRow,{htmlProps:{},styles:[],children:g.jsx(g.Fragment,{children:o})}),x=t!=null&&t.length>0,M=p.length>0,O={...r.htmlProps.style,minWidth:z.tableMinWidth>0?`${z.tableMinWidth}px`:void 0};let E=g.jsxs("table",{ref:i,...r.htmlProps,...vt(mt("base-table"),P(...r.styles)),style:O,children:[M&&g.jsx("thead",{children:g.jsx(s,{...y.htmlProps,xstyle:y.styles,children:y.children})}),g.jsx("tbody",{children:u||x&&t.map((A,j)=>{const k=e==null?j:typeof e=="function"?e(A):String(A[e]);return g.jsx(Zv,{item:A,rowIndex:j,rowKey:k,columns:p,plugins:f,RowComponent:s,CellComponent:d},k)})})]});for(let A=f.length-1;A>=0;A--){const j=f[A];if(j.transformTableContext)try{E=j.transformTableContext(E)}catch(k){console.error("[XDSTable] Plugin threw in transformTableContext:",k)}}return E}const F0=Vv;F0.displayName="XDSBaseTable";const I0=["columnSettings","sort","selection","pagination"],Co=new Map(I0.map((t,l)=>[t,l]));function Qv(t){const l=I0.length;return t.sort(([e],[a])=>{const n=Co.get(e)??l,u=Co.get(a)??l;return n-u})}const Ln=new Set(["transformColumns","transformTable","transformHeaderRow","transformHeaderCell","transformBodyRow","transformBodyCell","transformTableContext"]);function Kv(t,l){const e=Object.keys(l);for(const n of e)Ln.has(n)||console.warn(`[XDSTable] Plugin "${t}" has unknown key "${n}". Valid keys: ${[...Ln].join(", ")}. This key will be ignored.`);for(const n of e)if(Ln.has(n)){const u=l[n];u!=null&&typeof u!="function"&&console.warn(`[XDSTable] Plugin "${t}" has non-function value for "${n}" (got ${typeof u}). Transform will be skipped.`)}e.some(n=>Ln.has(n)&&typeof l[n]=="function")||console.warn(`[XDSTable] Plugin "${t}" has no transform methods. It will be included in the pipeline but won't do anything.`)}function Jv(t,l){const e=b.useRef(null);if(e.current!=null){const u=e.current;if(u.basePlugins===t&&u.userPlugins===l)return u.result;if(u.basePlugins===t&&Wv(u.userPlugins,l))return u.userPlugins=l,u.result}const a=l?Qv(Object.entries(l)).map(([,u])=>u):[],n=[...t,...a];if(l)for(const[u,c]of Object.entries(l))Kv(u,c);return e.current={basePlugins:t,userPlugins:l,result:n},n}function Wv(t,l){if(t===l)return!0;if(t==null||l==null)return!1;const e=Object.keys(t),a=Object.keys(l);if(e.length!==a.length)return!1;for(const n of e)if(t[n]!==l[n])return!1;return!0}const Fv={base:{kMv6JI:"xjb2p0i",kMwMTN:"x1tgivj0",$$css:!0}};function Iv(){return{transformTable(t){return{...t,styles:[...t.styles,Fv.base]}}}}const Pv={Row:Jf,Cell:Wf,HeaderCell:Ff};function t2({density:t="balanced",dividers:l="rows",isStriped:e=!1,hasHover:a=!1,plugins:n,columns:u,data:c,ref:i,...f}){const s=b.useMemo(()=>Iv(),[]),d=b.useMemo(()=>[s],[s]),v=Jv(d,n),m=b.useMemo(()=>({density:t,dividers:l,isStriped:e,hasHover:a}),[t,l,e,a]);return g.jsx(Kf.Provider,{value:m,children:g.jsx(F0,{ref:i,data:c,columns:u,plugins:v,components:Pv,...f})})}const P0=t2;P0.displayName="XDSTable";const t1={root:{kmuXW:"x2lah0s",$$css:!0},span:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0}},l1={primary:{kMwMTN:"xtbr613",$$css:!0},secondary:{kMwMTN:"xv9yike",$$css:!0},tertiary:{kMwMTN:"xv9yike",$$css:!0},disabled:{kMwMTN:"xqa6c3m",$$css:!0},accent:{kMwMTN:"xqwr325",$$css:!0},positive:{kMwMTN:"xtjic6",$$css:!0},negative:{kMwMTN:"xjt36v0",$$css:!0},warning:{kMwMTN:"xs3pv69",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0},blue:{kMwMTN:"x1fns2mt",$$css:!0},red:{kMwMTN:"xeffzf7",$$css:!0},green:{kMwMTN:"xmxeech",$$css:!0},gray:{kMwMTN:"x1eyinzz",$$css:!0},cyan:{kMwMTN:"x157w0xa",$$css:!0},teal:{kMwMTN:"x1f3zxcb",$$css:!0},yellow:{kMwMTN:"x1g6zdft",$$css:!0},orange:{kMwMTN:"xxu74a4",$$css:!0},pink:{kMwMTN:"x1kxxfg5",$$css:!0},purple:{kMwMTN:"xzdw94u",$$css:!0}},l2={xsm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",$$css:!0},sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",$$css:!0},md:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",$$css:!0},lg:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",$$css:!0}},e2={xsm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",kGuDYH:"xfifm61",$$css:!0},sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0},lg:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",kGuDYH:"x1pvqxga",$$css:!0}};function da({icon:t,color:l="primary",size:e="md",ref:a,...n}){if(typeof t=="string")return g.jsx(a2,{name:t,color:l,size:e});const u=t;return g.jsx(u,{ref:a,"aria-hidden":"true",...vt(mt("icon",{size:e,color:l}),P(t1.root,l1[l],l2[e])),...n})}da.displayName="XDSIcon";function a2({name:t,color:l,size:e}){const a=mh(t);return a==null?null:g.jsx("span",{...vt(mt("icon",{size:e,color:l}),P(t1.span,l1[l],e2[e])),"aria-hidden":"true",children:a})}const Lc={base:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x1lziwak",k71WvV:"x14z9mp",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kMzoRj:"xc342km",ksu8eU:"xng3xce",kVQacm:"x1rea2x4",kWkggS:"xjbqb8w",$$css:!0},fixed:{kVAEAm:"xixxii4",$$css:!0}};function n2(t="above",l="center"){const a={above:"top",below:"bottom",start:"left",end:"right"}[t];return t==="above"||t==="below"?l==="start"?`${a} span-right`:l==="end"?`${a} span-left`:a:l==="start"?`${a} span-bottom`:l==="end"?`${a} span-top`:`${a} center`}function u2(t){const{mode:l,onShow:e,onHide:a,lightDismiss:n=!1}=t,u=b.useId(),c=`--xds-layer-${u.replace(/:/g,"")}`,[i,f]=b.useState(!1),s=b.useRef(null),d=b.useRef(null),v=b.useCallback(()=>{s.current&&!s.current.matches(":popover-open")&&(s.current.showPopover(),f(!0),e==null||e())},[e]),m=b.useCallback(()=>{var r;(r=s.current)!=null&&r.matches(":popover-open")&&(s.current.hidePopover(),f(!1),a==null||a())},[a]),h=l==="context"?r=>{d.current&&(d.current.style.anchorName=""),r&&(r.style.anchorName=c),d.current=r}:void 0,S=b.useCallback(r=>{const o=r;o.newState==="closed"?(f(!1),a==null||a()):o.newState==="open"&&(f(!0),e==null||e())},[e,a]),p=b.useCallback(r=>{s.current=r,r&&r.addEventListener("toggle",S)},[S]),z=b.useCallback((r,o)=>{const{placement:y="above",alignment:x="center",xstyle:M,className:O,style:E}=o||{},A={positionAnchor:c,positionArea:n2(y,x),positionTryFallbacks:"flip-block, flip-inline, flip-block flip-inline"},j=P(Lc.base,M),k=O?`${O} ${j.className??""}`:j.className;return g.jsx("div",{ref:p,id:u,popover:n?"auto":"manual",className:k,style:{...j.style,...A,...E},children:r})},[c,u,n,p]);return b.useCallback((r,o)=>{const{x:y,y:x,xstyle:M,className:O,style:E}=o,A={top:x,left:y},j=P(Lc.base,Lc.fixed,M),k=O?`${O} ${j.className??""}`:j.className;return g.jsx("div",{ref:p,id:u,popover:n?"auto":"manual",className:k,style:{...j.style,...A,...E},children:r})},[p,u,n]),{ref:h,anchorId:c,show:v,hide:m,isOpen:i,id:u,render:z}}const c2={below:{kKVMdj:"xl1vlw0",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},above:{kKVMdj:"x3psbcj",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},end:{kKVMdj:"x1i331go",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},start:{kKVMdj:"xck01x9",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}},Yc={container:{kWkggS:"x19aspcf",kMwMTN:"xrkvqaz",kaIpWk:"x1hviunn",kMv6JI:"x9ynric",kGuDYH:"xjm74w1",kLWn49:"xw6l6zx",$$css:!0},marginBlock:{keoZOQ:"xcsaf9d",k1K539:"x14cgwvg",keTefX:"x1lziwak",k71WvV:"x14z9mp",$$css:!0},marginInline:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x11g1kdw",k71WvV:"xnur1sd",$$css:!0}};function i2(t){return t.hasAttribute("tabindex")?t.tabIndex>=0:["A","BUTTON","INPUT","SELECT","TEXTAREA"].includes(t.tagName)?!t.disabled:!!t.isContentEditable}function f2(t={}){const{placement:l="above",alignment:e="center",delay:a=200,hideDelay:n=0,focusTrigger:u="auto",isEnabled:c=!0,onShow:i,onHide:f}=t,s=l==="above"||l==="below"?Yc.marginBlock:Yc.marginInline,d=u2({mode:"context",onShow:i,onHide:f}),v=[Yc.container,s],m=b.useRef(null),h=b.useRef(null),S=b.useRef(null),p=b.useCallback(()=>{m.current&&(clearTimeout(m.current),m.current=null),h.current&&(clearTimeout(h.current),h.current=null)},[]),z=b.useCallback(()=>{c&&(p(),m.current=setTimeout(()=>{d.show()},a))},[c,p,d,a]),r=b.useCallback(()=>{p(),n>0?h.current=setTimeout(()=>{d.hide()},n):d.hide()},[p,d,n]),o=b.useCallback(()=>{typeof window<"u"&&typeof window.matchMedia=="function"&&window.matchMedia("(hover: none)").matches||z()},[z]),y=b.useCallback(()=>{r()},[r]),x=b.useCallback(j=>{!c||!j.target.matches(":focus-visible")||(p(),d.show())},[c,p,d]),M=b.useCallback(()=>{r()},[r]),O=b.useCallback(j=>{S.current&&(S.current.removeEventListener("mouseenter",o),S.current.removeEventListener("mouseleave",y),S.current.removeEventListener("focusin",x),S.current.removeEventListener("focusout",M)),j&&(j.addEventListener("mouseenter",o),j.addEventListener("mouseleave",y),(u==="always"||u==="auto"&&i2(j))&&(j.addEventListener("focusin",x),j.addEventListener("focusout",M))),S.current=j},[u,o,y,x,M]),E=b.useCallback(j=>{d.ref(j),O(j)},[d.ref,O]);b.useEffect(()=>()=>{p()},[p]);const A=b.useCallback((j,k)=>{const V=(k==null?void 0:k.placement)??l,J={placement:V,alignment:(k==null?void 0:k.alignment)??e,xstyle:[v,c2[V]],className:mt("tooltip")};return d.render(g.jsx("div",{className:"xfsso4q xy143xn x12gdq22 x1djylfy xw5ewwj x13faqbe",children:j}),J)},[d,l,e,v]);return{ref:E,positionRef:d.ref,interactionRef:O,anchorId:d.anchorId,describedBy:d.id,renderTooltip:A}}function s2(t){let l=!1;return ns.Children.forEach(t,e=>{ns.isValidElement(e)&&(l=!0)}),!l}function Ro(...t){const l=t.filter(Boolean);return l.length>0?l.join(" "):void 0}function If({children:t,anchorRef:l,content:e,placement:a="above",alignment:n="center",delay:u=200,hideDelay:c=0,focusTrigger:i="auto",isEnabled:f=!0,onOpenChange:s,hasHoverIndication:d="auto"}){const v=b.useRef(null),m=t!=null?s2(t):!1,h=d===!0||d==="auto"&&m,S=b.useCallback(()=>{s==null||s(!0)},[s]),p=b.useCallback(()=>{s==null||s(!1)},[s]),z=f2({placement:a,alignment:n,delay:u,hideDelay:c,focusTrigger:i,isEnabled:f,onShow:S,onHide:p});return b.useLayoutEffect(()=>{if(!l)return;const r=l.current;if(!r)return;z.ref(r);const o=r.getAttribute("aria-describedby");return r.setAttribute("aria-describedby",Ro(o,z.describedBy)??""),()=>{z.ref(null),o?r.setAttribute("aria-describedby",o):r.removeAttribute("aria-describedby")}},[l,z.ref,z.describedBy]),b.useLayoutEffect(()=>{if(l||m)return;const r=v.current;if(!r)return;const o=r.firstElementChild;if(!o)return;z.ref(o);const y=o.getAttribute("aria-describedby");return o.setAttribute("aria-describedby",Ro(y,z.describedBy)??""),()=>{z.ref(null),y?o.setAttribute("aria-describedby",y):o.removeAttribute("aria-describedby")}},[l,m,z.ref,z.describedBy]),l&&t==null?g.jsx(g.Fragment,{children:z.renderTooltip(e)}):m?g.jsxs(g.Fragment,{children:[g.jsx("span",{ref:z.ref,tabIndex:0,"aria-describedby":z.describedBy,...{0:{className:"xt0psk2"},1:{className:"xt0psk2 xujl8zx xev0dqp xycaml9 xrys4gj"}}[!!h<<0],children:t}),z.renderTooltip(e)]}):g.jsxs(g.Fragment,{children:[g.jsx("div",{ref:v,className:"xjp7ctv",children:t}),z.renderTooltip(e)]})}If.displayName="XDSTooltip";const o2=Object.freeze(Object.defineProperty({__proto__:null,XDSTooltip:If},Symbol.toStringTag,{value:"Module"}));function e1({label:t,inputID:l,isLabelHidden:e=!1,isDisabled:a=!1,isOptional:n=!1,isRequired:u=!1,labelIcon:c,labelTooltip:i,ref:f}){const s=n?"Optional":u?"Required":null;return g.jsxs("label",{ref:f,htmlFor:l,...vt(mt("field-label"),{0:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip x1tgivj0 x1ypdohk"},2:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip xnbbluu x1h6gzvc"},1:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip x1tgivj0 x1ypdohk xng3xce xzpqnlu xjm9jq1 xu96u03 xkdpibf xb3r6kr x1717udv x47corl x10l6tqk x13vifvy x87ps6o xuxw1ft x1i1rx1s"},3:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip xnbbluu x1h6gzvc xng3xce xzpqnlu xjm9jq1 xu96u03 xkdpibf xb3r6kr x1717udv x47corl x10l6tqk x13vifvy x87ps6o xuxw1ft x1i1rx1s"}}[!!a<<1|!!e<<0]),children:[c&&g.jsx(da,{icon:c,size:"sm",color:"inherit"}),t,s&&g.jsxs("span",{className:"x1sodnla x141an7d xv1l7n4",children:[g.jsx("span",{"aria-hidden":"true",children:" ∙ "}),s]}),i&&g.jsx(If,{content:i,placement:"above",children:g.jsx(da,{icon:"info",size:"sm",color:"inherit"})})]})}e1.displayName="XDSFieldLabel";let a1=!1;typeof window<"u"&&requestAnimationFrame(()=>{a1=!0});const r2={slideDown:{kKVMdj:"x1srr2gu",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},slideUp:{kKVMdj:"x1dvww92",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},fadeIn:{kKVMdj:"xqcmdr3",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},scaleIn:{kKVMdj:"x97zbip",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}};function d2(t="slideDown"){const[l]=b.useState(()=>a1);return l?r2[t]:null}const Gc={base:{kMv6JI:"x9ynric",kGuDYH:"x141an7d",kLWn49:"x1ltkj2j",$$css:!0},attached:{keoZOQ:"x1c40v9y",kLKAdn:"x1ak3mig",kGO01o:"x1wesfrj",kg3NbH:"xf314gf",kqGeR4:"x14lggfu",kYm2EN:"xtufxuj",$$css:!0},detached:{keoZOQ:"xcsaf9d",k8WAf4:"xce4md1",kg3NbH:"xf314gf",kaIpWk:"xh6dtrn",$$css:!0}},m2={warning:{kWkggS:"x24i8r5",kMwMTN:"xdhq94a",$$css:!0},error:{kWkggS:"x1pritpl",kMwMTN:"x1joocv1",$$css:!0},success:{kWkggS:"xu13z74",kMwMTN:"xltfdvo",$$css:!0}};function Gi({type:t,message:l,id:e,variant:a="attached"}){const n=d2("slideDown");return g.jsx("div",{id:e,role:t==="error"?"alert":"status","aria-live":t==="error"?"assertive":"polite",...vt(mt("field-status",{type:t,variant:a}),P(Gc.base,n,a==="attached"?Gc.attached:Gc.detached,m2[t])),children:l})}Gi.displayName="XDSFieldStatus";const y2="modulepreload",h2=function(t,l){return new URL(t,l).href},$o={},v2=function(l,e,a){let n=Promise.resolve();if(e&&e.length>0){const c=document.getElementsByTagName("link"),i=document.querySelector("meta[property=csp-nonce]"),f=(i==null?void 0:i.nonce)||(i==null?void 0:i.getAttribute("nonce"));n=Promise.allSettled(e.map(s=>{if(s=h2(s,a),s in $o)return;$o[s]=!0;const d=s.endsWith(".css"),v=d?'[rel="stylesheet"]':"";if(!!a)for(let S=c.length-1;S>=0;S--){const p=c[S];if(p.href===s&&(!d||p.rel==="stylesheet"))return}else if(document.querySelector(`link[href="${s}"]${v}`))return;const h=document.createElement("link");if(h.rel=d?"stylesheet":y2,d||(h.as="script"),h.crossOrigin="",h.href=s,f&&h.setAttribute("nonce",f),document.head.appendChild(h),d)return new Promise((S,p)=>{h.addEventListener("load",S),h.addEventListener("error",()=>p(new Error(`Unable to preload CSS for ${s}`)))})}))}function u(c){const i=new Event("vite:preloadError",{cancelable:!0});if(i.payload=c,window.dispatchEvent(i),!i.defaultPrevented)throw c}return n.then(c=>{for(const i of c||[])i.status==="rejected"&&u(i.reason);return l().catch(u)})},g2={primary:{kMwMTN:"x1tgivj0",$$css:!0},secondary:{kMwMTN:"xv1l7n4",$$css:!0},disabled:{kMwMTN:"xnbbluu",$$css:!0},placeholder:{kMwMTN:"xv1l7n4",$$css:!0},active:{kMwMTN:"xqwr325",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0}},x2={normal:{k63SB2:"x1sodnla",$$css:!0},medium:{k63SB2:"x1e4wzip",$$css:!0},semibold:{k63SB2:"x2mo6ok",$$css:!0},bold:{k63SB2:"x1lvx875",$$css:!0}},b2={body:{k63SB2:"xxovm9e",$$css:!0},large:{k63SB2:"x149oux8",$$css:!0},label:{k63SB2:"xmhvcl5",$$css:!0},code:{k63SB2:"xx3eeay",$$css:!0},supporting:{k63SB2:"xv8on6e",$$css:!0},"display-1":{k63SB2:"x1txul5o",$$css:!0},"display-2":{k63SB2:"x1y36c3f",$$css:!0},"display-3":{k63SB2:"x1on40hk",$$css:!0}},S2={inline:{k1xSpc:"xt0psk2",$$css:!0},block:{k1xSpc:"x1lliihq",$$css:!0}},Uo={singleLine:{kVQacm:"xb3r6kr",kg5iWk:"xlyipyv",khDVqt:"xuxw1ft",k1xSpc:"x1lliihq",$$css:!0},multiLine:{kVQacm:"xb3r6kr",k1xSpc:"x104kibb",kgKLqz:"x1ua5tub",$$css:!0}},p2={"break-word":{kTgw9:"x1lldw8n",kHjlTd:"x1mzt3pk",$$css:!0},"break-all":{kTgw9:"x1yn0g08",$$css:!0}},z2={wrap:{kN2L0X:"xk4td0m",$$css:!0},nowrap:{kN2L0X:"xebhuq6",$$css:!0},balance:{kN2L0X:"x1w2vvpw",$$css:!0},pretty:{kN2L0X:"x1fzhlzt",$$css:!0}},T2={enabled:{kxwWH2:"x1b2iylo",kzeHkT:"xwgcxoh",k1xSpc:"x1lliihq",$$css:!0}},E2={strikethrough:{kybGjl:"xmqliwb",$$css:!0}},M2={enabled:{kcqcaj:"xss6m8b",$$css:!0}},A2={content:{ks0D6T:"xw5ewwj",kTgw9:"x13faqbe",$$css:!0}};function j2(t){const{maxLines:l}=t,[e,a]=b.useState(!1),[n,u]=b.useState(""),c=b.useRef(null),i=b.useRef(null),f=b.useCallback(d=>{if(l===0){a(!1);return}u(d.textContent??""),a(l===1?d.scrollWidth>d.offsetWidth:d.scrollHeight>d.offsetHeight)},[l]);return{ref:b.useCallback(d=>{i.current&&(i.current.disconnect(),i.current=null),c.current=d,d&&l>0?(f(d),typeof ResizeObserver<"u"&&(i.current=new ResizeObserver(()=>{f(d)}),i.current.observe(d))):(a(!1),u(""))},[l,f]),isTruncated:e,fullText:n}}const k2=b.lazy(()=>v2(()=>Promise.resolve().then(()=>o2),void 0,import.meta.url).then(t=>({default:t.XDSTooltip}))),O2={body:"primary",large:"primary",label:"primary",supporting:"secondary",code:"primary","display-1":"primary","display-2":"primary","display-3":"primary"};function Qe({type:t,size:l,color:e,weight:a,display:n="inline",maxLines:u=0,hasTruncateTooltip:c=!0,wordBreak:i,textWrap:f,hasCapsize:s=!1,hasStrikethrough:d=!1,hasTabularNumbers:v=!1,xstyle:m,className:h,style:S,as:p="span",children:z,ref:r,...o}){const y=e??O2[t],x=i??(u===1?"break-all":"break-word"),M=u>0||s?"block":n,O=j2({maxLines:u}),E=typeof c=="string"?c:"above",A=u>0&&c!==!1&&O.isTruncated,j=b.useRef(null),k=b.useCallback(J=>{typeof r=="function"?r(J):r&&(r.current=J),O.ref(J),j.current=J},[r,O.ref]),V=u>1?{WebkitLineClamp:u}:void 0;return g.jsxs(g.Fragment,{children:[g.jsx(p,{ref:k,...vt(mt("text",{type:t,color:y}),P(g2[y],b2[t],a&&x2[a],u===1?Uo.singleLine:u>1?Uo.multiLine:S2[M],u>0&&p2[x],f&&z2[f],s&&T2.enabled,d&&E2.strikethrough,v&&M2.enabled,m),h,{...S,...V}),title:A?O.fullText:void 0,...o,children:z}),A&&g.jsx(b.Suspense,{fallback:null,children:g.jsx(k2,{anchorRef:j,content:g.jsx("span",{...P(A2.content),children:O.fullText}),placement:E})})]})}Qe.displayName="XDSText";const D2=.75,Ho=1.5,qo={sm:{diameter:10,border:3},md:{diameter:14,border:3},lg:{diameter:18,border:3},xl:{diameter:28,border:4}},Bo={wrapper:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",$$css:!0},spinner:{k1xSpc:"x1rg5ohu",kVQacm:"xb3r6kr",kXLuUW:"xxymvpz",$$css:!0}};function n1({size:t="md",shade:l="default",label:e,xstyle:a,className:n,"aria-label":u,"data-testid":c,ref:i}){const f=b.useRef(null);b.useEffect(()=>{const p=f.current;if(p==null)return;const z=p.getContext("2d");if(!z)return;const{border:r,diameter:o}=qo[t],y=window.devicePixelRatio||1,x=getComputedStyle(p),M=l==="onMedia"?x.getPropertyValue(wo["--color-on-dark"])||"#FFFFFF":x.getPropertyValue(wo["--color-accent"])||"#0064E0",O=l==="onMedia"?"rgba(255, 255, 255, 0.3)":"rgba(0, 0, 0, 0.1)",E=o/2*y,A=r*y,j=(E+A)*2;p.height=p.width=j,p.style.width=p.style.height=j/y+"px",z.lineCap="round",z.lineWidth=A;const k=j/2;z.beginPath(),z.arc(k,k,E,0,2*Math.PI),z.strokeStyle=O,z.stroke(),z.beginPath(),z.arc(k,k,E,Ho*Math.PI,(Ho+D2)%2*Math.PI),z.strokeStyle=M,z.stroke()},[l,t]);const{border:s,diameter:d}=qo[t],v=d+s*2,m=e!=null,h=u??(typeof e=="string"?e:void 0)??"Loading",S=g.jsx("span",{ref:m?void 0:i,role:"status","aria-label":h,"data-testid":m?void 0:c,...vt(m?"":mt("spinner",{size:t,shade:l}),P(Bo.spinner,!m&&a),m?void 0:n),style:{width:v,height:v},children:g.jsx("canvas",{ref:f,className:"xlp1x4z x1lliihq xqgcaz xa4qsjk x1ka1v4i x1esw782"})});return m?g.jsxs("div",{ref:i,"data-testid":c,...vt(mt("spinner",{size:t,shade:l}),P(Bo.wrapper,a),n),children:[S,typeof e=="string"?g.jsx(Qe,{type:"body",weight:"bold",children:e}):e]}):S}n1.displayName="XDSSpinner";function u1(t){const{sortable:l}=t;return l?l===!0?t.key:l.sortKey??t.key:null}function w2(t){const{header:l}=t;return typeof l=="string"?l:t.key}function N2(t,l,e,a){const n=w2(t);if(l==null)return`Sort by ${n}`;let u=`Sort by ${n}, sorted ${l}`;return e!=null&&a>1&&(u+=`, priority ${e} of ${a}`),u}function Xo(t,l){return t==null?"ascending":t==="ascending"?"descending":l?null:"ascending"}function _2({column:t,children:l,configRef:e}){const a=e.current,n=u1(t),u=a.sort.findIndex(h=>h.sortKey===n),c=u>=0?a.sort[u]:null,i=(c==null?void 0:c.direction)??null,s=a.isMultiSortEnabled===!0&&a.sort.length>1&&u>=0?u+1:null,d=i==="ascending"?"arrowUp":i==="descending"?"arrowDown":"arrowsUpDown",v=N2(t,i,s,a.sort.length),m=h=>{const S=e.current,p=h.shiftKey&&S.isMultiSortEnabled,z=S.allowUnsortedState??!1;if(p){const r=S.sort.findIndex(o=>o.sortKey===n);if(r>=0){const o=Xo(S.sort[r].direction,z);if(o==null){const y=[...S.sort];y.splice(r,1),S.onSortChange(y)}else{const y=[...S.sort];y[r]={...y[r],direction:o},S.onSortChange(y)}}else S.onSortChange([...S.sort,{sortKey:n,direction:"ascending"}])}else{const r=S.sort.find(y=>y.sortKey===n),o=Xo((r==null?void 0:r.direction)??null,z);o==null?S.onSortChange([]):S.onSortChange([{sortKey:n,direction:o}])}};return g.jsxs("button",{type:"button",className:"x78zum5 x6s0dn4 xzye2dw x1717udv x1ghz6dp x1ypdohk xln7xf2 x1heor9g xh8yej3 x5yr21d x16tdsg8 x1a2a7pz x17nn4n9 x1hl8ikr xx3sua9","aria-label":v,onClick:m,children:[g.jsx("span",{children:l}),g.jsx("span",{...{0:{className:"x3nfvp2 xg01cxk x5b7970 x8w4yw4"},1:{className:"x3nfvp2"}}[(i!=null)<<0],children:g.jsx(da,{icon:d,size:"xsm",color:i!=null?"accent":"secondary"})}),s!=null&&g.jsx("span",{className:"x1k6wstc xo5v014 xqwr325","aria-hidden":"true",children:s})]})}function C2(t){const l=b.useRef(t);return l.current=t,b.useMemo(()=>({transformHeaderCell(e,a){const n=u1(a);if(n==null)return e;const c=l.current.sort.find(i=>i.sortKey===n);return{...e,htmlProps:{...e.htmlProps,...c!=null?{"aria-sort":c.direction}:{}},content:g.jsx(_2,{column:a,configRef:l,children:e.content})}}}),[])}const Lo={container:{k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",$$css:!0},containerGap:{kOIVth:"xzye2dw",$$css:!0}};function c1({label:t,isLabelHidden:l=!1,description:e,inputID:a,descriptionID:n,isOptional:u=!1,isRequired:c=!1,isDisabled:i=!1,labelIcon:f,status:s,labelTooltip:d,statusVariant:v="attached",xstyle:m,children:h,className:S,style:p,ref:z,...r}){const o=n??(e?`${a}-desc`:void 0),y=(s==null?void 0:s.messageID)??(s!=null&&s.message?`${a}-status`:void 0);return u&&c&&console.warn("XDSField: isOptional and isRequired are mutually exclusive. isOptional takes precedence."),g.jsxs("div",{ref:z,...vt(mt("field"),P(Lo.container,!l&&Lo.containerGap,m),S,p),...r,children:[g.jsxs("div",{className:"x78zum5 xdt5ytf",children:[g.jsx(e1,{label:t,inputID:a,isLabelHidden:l,isDisabled:i,isOptional:u,isRequired:c,labelIcon:f,labelTooltip:d}),e&&g.jsx("span",{id:o,...{0:{className:"x9ynric x141an7d x1ltkj2j x1sodnla xv1l7n4"},1:{className:"x9ynric x141an7d x1ltkj2j x1sodnla xv1l7n4 xng3xce xzpqnlu xjm9jq1 xu96u03 xkdpibf xb3r6kr x1717udv x47corl x10l6tqk x13vifvy x87ps6o xuxw1ft x1i1rx1s"}}[!!l<<0],children:e})]}),v==="attached"?g.jsxs("div",{className:"x78zum5 xdt5ytf",children:[h,(s==null?void 0:s.message)&&g.jsx(Gi,{type:s.type,message:s.message,id:y,variant:"attached"})]}):g.jsxs(g.Fragment,{children:[h,(s==null?void 0:s.message)&&g.jsx(Gi,{type:s.type,message:s.message,id:y,variant:"detached"})]})]})}c1.displayName="XDSField";const Yo={base:{kB7OPa:"x9f619",kVAEAm:"x1n2onr6",kY2c9j:"x1vjfegm",k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",k8WAf4:"xu0wf1k",kg3NbH:"xf314gf",kMzoRj:"x1litavf",ksu8eU:"x1y0btm7",kVAM5u:"xvy26l8 x1ww4t2b","--input-radius":"xrhxz6v",kaIpWk:"x11spqq5",kWkggS:"x10xzikg",k1ekBW:"xpo9ue8",kIyJzY:"xuedmi6 x12w9bfk",kAMwcw:"xlr8y92",kGVxlE:"x1gnnqk1 x1j9d0uj",kI3sdo:"x1a2a7pz x1bb4jes",kInvED:"x1wfwxd8",$$css:!0},disabled:{kkrTdU:"x1h6gzvc",kSiTet:"xbyyjgo",kVAM5u:"xvy26l8",$$css:!0}},R2={warning:{kVAM5u:"x8wg1ba",$$css:!0},error:{kVAM5u:"x1ofxpqo",$$css:!0},success:{kVAM5u:"x16m2moy",$$css:!0}},$2={warning:{kGVxlE:"x1gnnqk1 xo1e01f",$$css:!0},error:{kGVxlE:"x1gnnqk1 x1ymn3ht",$$css:!0},success:{kGVxlE:"x1gnnqk1 x1th0bn1",$$css:!0}},U2={warning:{kI3sdo:"x1a2a7pz x1i2lkmv",$$css:!0},error:{kI3sdo:"x1a2a7pz xvr22io",$$css:!0},success:{kI3sdo:"x1a2a7pz xgqqtmo",$$css:!0}},H2={wrapper:{kY2c9j:"x1vjfegm",$$css:!0}},q2={sm:{kZKoxP:"x6k0iem",$$css:!0},md:{kZKoxP:"x1ueg155",$$css:!0},lg:{kZKoxP:"xssyfek",$$css:!0}};function i1({type:t="text",label:l,isLabelHidden:e=!1,description:a,isOptional:n=!1,isRequired:u=!1,isDisabled:c=!1,startIcon:i,status:f,size:s="md",onChange:d,onChangeAction:v,isLoading:m=!1,value:h,placeholder:S,labelTooltip:p,hasAutoFocus:z=!1,htmlName:r,xstyle:o,className:y,style:x,ref:M}){const O=b.useId(),E=b.useId(),A=b.useId(),[,j]=b.useTransition(),[k,V]=b.useOptimistic(h),J=m||k!==h,wl={warning:"warning",error:"xCircle",success:"checkCircle"},rl={warning:"warning",error:"negative",success:"positive"},ue=[a?E:null,f!=null&&f.message?A:null].filter(Boolean).join(" ")||void 0,D=N=>{const _=N.target.value;d==null||d(_,N),v&&!N.defaultPrevented&&j(async()=>{V(_),await v(_,N)})};return g.jsx(c1,{label:l,isLabelHidden:e,description:a,inputID:O,descriptionID:a?E:void 0,isOptional:n,isRequired:u,isDisabled:c,status:f?{type:f.type,message:f.message,messageID:f.message?A:void 0}:void 0,labelTooltip:p,children:g.jsxs("div",{...vt(mt("text-input",{size:s}),P(Yo.base,H2.wrapper,q2[s],c&&Yo.disabled,f&&R2[f.type],f&&$2[f.type],f&&U2[f.type],o),y,x),children:[i&&g.jsx(da,{icon:i,size:"sm",color:"primary"}),g.jsx("input",{ref:M,id:O,name:r,type:t,value:String(k),onChange:D,placeholder:S,disabled:c,autoFocus:z,"data-autofocus":z||void 0,"aria-describedby":ue,"aria-required":u===!0?"true":void 0,"aria-invalid":(f==null?void 0:f.type)==="error"?"true":void 0,"aria-busy":J||void 0,...{0:{className:"x1lliihq x98rzlu xeuugli xc342km xng3xce x1717udv x9ynric xjm74w1 xw6l6zx x1tgivj0 xjbqb8w x1a2a7pz xeyghm5"},1:{className:"x1lliihq x98rzlu xeuugli xc342km xng3xce x1717udv x9ynric xjm74w1 xw6l6zx x1tgivj0 xjbqb8w x1a2a7pz xeyghm5 x1h6gzvc"}}[!!c<<0]}),J&&g.jsx(n1,{size:"sm"}),f&&g.jsx(da,{icon:wl[f.type],size:"md",color:rl[f.type]})]})})}i1.displayName="XDSTextInput";const B2=b.createContext(36),Go=(1-1/Math.SQRT2)/2,X2=.4;function L2(t){if(typeof t=="number")return t;switch(t){case"tiny":return 20;case"xsmall":return 24;case"small":return 36;case"medium":return 48;case"large":return 128}}const Yn={wrapper:{kVAEAm:"x1n2onr6",k1xSpc:"x3nfvp2",kmuXW:"x2lah0s",$$css:!0},content:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kaIpWk:"xjspbzw",kVQacm:"xb3r6kr",kfSwDN:"x87ps6o",$$css:!0},fallback:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kzqmXN:"xh8yej3",kZKoxP:"x5yr21d",kWkggS:"x17x4s8c",kMwMTN:"xv1l7n4",kMv6JI:"x9ynric",k63SB2:"x1e4wzip",kP9fke:"xtvhhri",$$css:!0},status:{kVAEAm:"x10l6tqk",$$css:!0}},Y2={kGuDYH:"xdmh292",$$css:!0},G2={krVfgx:"x1nqzi6q",kCIrl2:"x7ok3n0",k3aq6I:"x4v1no5",$$css:!0},Zc={size:t=>[{kzqmXN:t!=null?"x5lhr3w":t,kZKoxP:t!=null?"x16ye13r":t,$$css:!0},{"--x-width":(l=>typeof l=="number"?l+"px":l??void 0)(t),"--x-height":(l=>typeof l=="number"?l+"px":l??void 0)(t)}],fontSize:t=>[Y2,{"--x-fontSize":(l=>typeof l=="number"?l+"px":l??void 0)(t*X2)}],statusPosition:t=>[G2,{"--x-bottom":(l=>typeof l=="number"?l+"px":l??void 0)(t*Go),"--x-right":(l=>typeof l=="number"?l+"px":l??void 0)(t*Go)}]};function Z2(t){const l=t.trim().split(/\s+/);return l.length===0?"":l.length===1?l[0].charAt(0).toUpperCase():(l[0].charAt(0)+l[l.length-1].charAt(0)).toUpperCase()}function V2({size:t}){return g.jsx("svg",{width:t*.6,height:t*.6,viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true",children:g.jsx("path",{d:"M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"})})}function f1({alt:t,"data-testid":l,fallbackSrc:e,name:a,size:n="small",src:u,status:c,xstyle:i,className:f,style:s,ref:d,...v}){const[m,h]=b.useState(!1),[S,p]=b.useState(!1),z=u&&!m,r=!z&&e&&!S,o=!z&&!r&&a,y=!z&&!r&&!a,x=t||a||"Avatar",M=L2(n);return g.jsx(B2.Provider,{value:M,children:g.jsxs("div",{ref:d,role:"img","aria-label":x,"data-testid":l,...vt(mt("avatar",{size:n}),P(Yn.wrapper,i),f,s),...v,children:[g.jsxs("div",{...P(Yn.content,Zc.size(M)),children:[z&&g.jsx("img",{src:u,alt:x,onError:()=>h(!0),className:"xh8yej3 x5yr21d xl1xv1r"}),r&&g.jsx("img",{src:e,alt:x,onError:()=>p(!0),className:"xh8yej3 x5yr21d xl1xv1r"}),o&&g.jsx("div",{...P(Yn.fallback,Zc.fontSize(M)),children:Z2(a)}),y&&g.jsx("div",{className:"x78zum5 x6s0dn4 xl56j7k xh8yej3 x5yr21d x17x4s8c xv1l7n4 x9ynric x1e4wzip xtvhhri",children:g.jsx(V2,{size:M})})]}),c&&g.jsx("div",{...P(Yn.status,Zc.statusPosition(M)),children:c})]})})}f1.displayName="XDSAvatar";const Q2={base:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kOIVth:"xzye2dw",kZKoxP:"x1grt7ep",k8WAf4:"xt970qd",kg3NbH:"xf314gf",kaIpWk:"xjspbzw",kMv6JI:"xjb2p0i",kGuDYH:"x141an7d",kLWn49:"x1ltkj2j",k63SB2:"x1e4wzip",khDVqt:"xuxw1ft",$$css:!0}},K2={neutral:{kWkggS:"x17x4s8c",kMwMTN:"x1tgivj0",$$css:!0},info:{kWkggS:"x1ewilqj",kMwMTN:"x17wrial",$$css:!0},success:{kWkggS:"xdsz4j9",kMwMTN:"xri61p4",$$css:!0},warning:{kWkggS:"x1q8g9m5",kMwMTN:"xrebv38",$$css:!0},error:{kWkggS:"x1pjz0fi",kMwMTN:"x1m024r3",$$css:!0},blue:{kWkggS:"x1o0wnni",kMwMTN:"x1vvqiwl",$$css:!0},cyan:{kWkggS:"x1rgj867",kMwMTN:"x1txnczv",$$css:!0},green:{kWkggS:"x1sqjeoo",kMwMTN:"xltfdvo",$$css:!0},orange:{kWkggS:"x1e9xt6e",kMwMTN:"xm47u9q",$$css:!0},pink:{kWkggS:"xnpoty2",kMwMTN:"xiuofww",$$css:!0},purple:{kWkggS:"x16i6n6f",kMwMTN:"x1m9wyeb",$$css:!0},red:{kWkggS:"x1cibrc5",kMwMTN:"x1joocv1",$$css:!0},teal:{kWkggS:"x1jtji5o",kMwMTN:"x9x0lbs",$$css:!0},yellow:{kWkggS:"x1bo7t0x",kMwMTN:"xdhq94a",$$css:!0}};function s1({variant:t="neutral",label:l,icon:e,xstyle:a,className:n,style:u,ref:c,...i}){return g.jsxs("span",{ref:c,...vt(mt("badge",{variant:t}),P(Q2.base,K2[t],a),n,u),...i,children:[e,l]})}s1.displayName="XDSBadge";const J2={center:{kGNEyG:"x6s0dn4",$$css:!0},end:{kGNEyG:"xuk3077",$$css:!0},start:{kGNEyG:"x1cy8zhl",$$css:!0},stretch:{kGNEyG:"x1qjc9v5",$$css:!0}},W2={start:{kjj79g:"x1nhvcw1",$$css:!0},center:{kjj79g:"xl56j7k",$$css:!0},end:{kjj79g:"x13a6bvl",$$css:!0},between:{kjj79g:"x1qughib",$$css:!0},around:{kjj79g:"x1l1ennw",$$css:!0},evenly:{kjj79g:"xaw8158",$$css:!0}},F2={horizontal:{kXwgrk:"x1q0g3np",$$css:!0},vertical:{kXwgrk:"xdt5ytf",$$css:!0}},I2={nowrap:{kwnvtZ:"xozqiw3",$$css:!0},wrap:{kwnvtZ:"x1a02dak",$$css:!0},"wrap-reverse":{kwnvtZ:"x8hhl5t",$$css:!0}},P2={stack:{k1xSpc:"x78zum5",$$css:!0}},tg={0:{k1C7PZ:"x1o57wo1",khm7nJ:"x6yxi7o",$$css:!0},1:{k1C7PZ:"x1lfs0n9",khm7nJ:"x1ngg2t4",$$css:!0},2:{k1C7PZ:"xak3so",khm7nJ:"x1x7z4sm",$$css:!0},3:{k1C7PZ:"xewh9hi",khm7nJ:"x4olc9o",$$css:!0},4:{k1C7PZ:"xty4p9g",khm7nJ:"xtx9w7w",$$css:!0},5:{k1C7PZ:"x1eqhezk",khm7nJ:"x1iu6piu",$$css:!0},6:{k1C7PZ:"x3qlgwd",khm7nJ:"xczp1bk",$$css:!0},8:{k1C7PZ:"xicv188",khm7nJ:"xgx0vcf",$$css:!0},10:{k1C7PZ:"x1p37tyl",khm7nJ:"x1xpicb7",$$css:!0},"0.5":{k1C7PZ:"x1kihgfc",khm7nJ:"x1tw44j4",$$css:!0},"1.5":{k1C7PZ:"x1thn6ci",khm7nJ:"xhq53yo",$$css:!0}};function lg({crossAlign:t,direction:l,gap:e,mainAlign:a,wrap:n}){return[P2.stack,F2[l],e!=null&&tg[e],t!=null&&J2[t],a!=null&&W2[a],n!=null&&I2[n]]}function Pf({direction:t,hAlign:l,vAlign:e,gap:a,wrap:n,element:u="div",xstyle:c,className:i,style:f,children:s,ref:d,...v}){const S=P(...lg({direction:t,crossAlign:t==="horizontal"?e:l,mainAlign:t==="horizontal"?l:e,gap:a,wrap:n}),c);return b.createElement(u,{ref:d,...vt(mt("stack",{direction:t,gap:a,wrap:n}),S,i,f),...v},s)}Pf.displayName="XDSStack";function o1({ref:t,...l}){return g.jsx(Pf,{...l,direction:"horizontal",ref:t})}o1.displayName="XDSHStack";function Zi({ref:t,...l}){return g.jsx(Pf,{...l,direction:"vertical",ref:t})}Zi.displayName="XDSVStack";const eg=t=>g.jsx("svg",{viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:1.5,...t,children:g.jsx("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"})}),ag=[{id:"1",name:"Alice Johnson",email:"alice@example.com",role:"Admin",status:"Active",department:"Engineering"},{id:"2",name:"Bob Smith",email:"bob@example.com",role:"Editor",status:"Active",department:"Marketing"},{id:"3",name:"Carol Williams",email:"carol@example.com",role:"Viewer",status:"Inactive",department:"Design"},{id:"4",name:"David Brown",email:"david@example.com",role:"Admin",status:"Active",department:"Engineering"},{id:"5",name:"Eve Davis",email:"eve@example.com",role:"Editor",status:"Inactive",department:"Marketing"},{id:"6",name:"Frank Miller",email:"frank@example.com",role:"Viewer",status:"Active",department:"Design"},{id:"7",name:"Grace Wilson",email:"grace@example.com",role:"Admin",status:"Active",department:"Engineering"},{id:"8",name:"Hank Moore",email:"hank@example.com",role:"Editor",status:"Active",department:"Marketing"}];function ng(t,l,e){const a=t[e],n=l[e];return a.localeCompare(n)}function ug(){const[t,l]=b.useState(""),[e,a]=b.useState([{sortKey:"name",direction:"ascending"}]),n=b.useMemo(()=>{const i=t.toLowerCase();let f=ag.filter(s=>s.name.toLowerCase().includes(i)||s.email.toLowerCase().includes(i)||s.role.toLowerCase().includes(i)||s.department.toLowerCase().includes(i));return e.length>0&&(f=[...f].sort((s,d)=>{for(const{sortKey:v,direction:m}of e){const h=ng(s,d,v);if(h!==0)return m==="ascending"?h:-h}return 0})),f},[t,e]),u=C2({sort:e,onSortChange:a}),c=b.useMemo(()=>[{key:"name",header:"Name",sortKey:"name",renderCell:i=>g.jsxs(o1,{gap:2,align:"center",children:[g.jsx(f1,{name:i.name,size:"small"}),g.jsxs(Zi,{gap:1,children:[g.jsx(Qe,{type:"body",weight:"semibold",children:i.name}),g.jsx(Qe,{type:"supporting",color:"secondary",children:i.email})]})]})},{key:"role",header:"Role",sortKey:"role",width:Xc(140),renderCell:i=>g.jsx(Qe,{type:"label",color:"secondary",children:i.role})},{key:"department",header:"Department",sortKey:"department",width:Xc(160),renderCell:i=>g.jsx(Qe,{type:"body",children:i.department})},{key:"status",header:"Status",sortKey:"status",width:Xc(120),renderCell:i=>g.jsx(s1,{variant:i.status==="Active"?"success":"error",label:i.status})}],[]);return g.jsxs(Zi,{gap:4,children:[g.jsx(i1,{label:"Search users",isLabelHidden:!0,value:t,onChange:l,placeholder:"Search by name, email, role, or department...",startIcon:eg}),g.jsx(P0,{data:n,columns:c,idKey:"id",density:"balanced",dividers:"rows",hasHover:!0,plugins:{sort:u}})]})}function cg(){return g.jsx(Q0,{theme:Tv,mode:"light",children:g.jsx(ug,{})})}fh.createRoot(document.getElementById("root")).render(g.jsx(cg,{}));</script>
+  <style rel="stylesheet" crossorigin>/**
+ * XDS Reset Stylesheet
+ *
+ * An opinionated CSS reset that provides a clean, predictable base for
+ * XDS applications. Built on the same principles as Tailwind Preflight
+ * and modern-normalize, adapted for the XDS design system.
+ *
+ * This reset:
+ * - Normalizes cross-browser inconsistencies
+ * - Sets box-sizing: border-box universally
+ * - Removes default margins, padding, and list styles
+ * - Makes images block-level and responsive
+ * - Resets form elements to inherit font styles
+ * - Uses :where() for zero specificity (easy to override)
+ *
+ * Usage:
+ *
+ * 1. Import directly (global reset):
+ *    import '@xds/core/reset.css';
+ *
+ * 2. Combine with base styles and theme:
+ *    import '@xds/core/reset.css';        // @layer reset  — clean slate
+ *    import '@xds/core/xds.css';           // @layer xds-base — component styles
+ *    import '@xds/theme-default/theme.css'; // @layer xds-theme — theme overrides
+ *
+ * Layer order: reset → xds-base → xds-theme
+ * Consumer styles (unlayered) always override all XDS layers.
+ * The reset has the lowest priority and can be overridden by any other layer.
+ *
+ * Similar to:
+ * - Tailwind CSS Preflight
+ * - Chakra UI's preflight (v3)
+ * - Bootstrap Reboot
+ * - modern-normalize
+ */
+
+@layer reset {
+
+  /* ===========================================================================
+     Box Model
+     =========================================================================== */
+
+  /*
+   * Use border-box globally. Prevents padding/border from affecting
+   * element dimensions — the single most impactful reset.
+   */
+  :where(*, *::before, *::after) {
+    box-sizing: border-box;
+  }
+
+  /*
+   * Reset borders to 0-width solid. This lets you add a border by just
+   * setting border-width — no need to also specify border-style.
+   */
+  :where(*, *::before, *::after) {
+    border-width: 0;
+    border-style: solid;
+    border-color: currentColor;
+  }
+
+  /* ===========================================================================
+     Document
+     =========================================================================== */
+
+  /*
+   * Consistent line-height, prevent text size adjustment on orientation
+   * change in iOS, and set a readable tab size.
+   *
+   * color-scheme: light dark — declares that this page supports both modes,
+   * enabling CSS light-dark() to resolve correctly. Also ensures that CSS
+   * tools (e.g. LightningCSS) which polyfill light-dark() for older browsers
+   * inject their toggle-variable initialization in the same CSS bundle.
+   * XDSTheme overrides color-scheme per-wrapper as needed.
+   */
+  :where(html) {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    color-scheme: light dark;
+  }
+
+  /*
+   * Remove default body margin and set font smoothing for sharper text
+   * rendering on macOS/iOS.
+   */
+  :where(body) {
+    margin: 0;
+    line-height: inherit;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* ===========================================================================
+     Typography
+     =========================================================================== */
+
+  /*
+   * Reset headings to inherit size and weight. Headings should be styled
+   * intentionally — not rely on browser defaults that vary across browsers.
+   */
+  :where(h1, h2, h3, h4, h5, h6) {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /*
+   * Remove default margins on all block-level text elements.
+   */
+  :where(h1, h2, h3, h4, h5, h6, p, blockquote, figure, pre, dl, dd) {
+    margin: 0;
+  }
+
+  /*
+   * Links inherit color and text-decoration. Style them intentionally
+   * rather than relying on browser-default blue/purple.
+   */
+  :where(a) {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  /*
+   * Correct font-weight rendering in Chrome and Safari.
+   */
+  :where(b, strong) {
+    font-weight: bolder;
+  }
+
+  /*
+   * Use the configured monospace font stack and fix the odd em sizing
+   * that browsers apply to code elements.
+   */
+  :where(code, kbd, samp, pre) {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      'Liberation Mono', 'Courier New', monospace;
+    font-size: 1em;
+  }
+
+  /*
+   * Correct font-size for small elements.
+   */
+  :where(small) {
+    font-size: 80%;
+  }
+
+  /*
+   * Prevent sub and sup from affecting line-height.
+   */
+  :where(sub, sup) {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  :where(sub) {
+    bottom: -0.25em;
+  }
+
+  :where(sup) {
+    top: -0.5em;
+  }
+
+  /* ===========================================================================
+     Lists
+     =========================================================================== */
+
+  /*
+   * Remove default list styles, margin, and padding. Lists used for
+   * navigation or layout shouldn't carry prose styling by default.
+   * Use explicit styles for prose lists.
+   */
+  :where(ol, ul, menu) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Media
+     =========================================================================== */
+
+  /*
+   * Make replaced elements block-level. Eliminates the "mystery gap"
+   * below inline images and aligns with how these elements are
+   * actually used in modern layouts.
+   */
+  :where(img, svg, video, canvas, audio, iframe, embed, object) {
+    display: block;
+    vertical-align: middle;
+  }
+
+  /*
+   * Constrain images and video to their container. Responsive by default.
+   */
+  :where(img, video) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* ===========================================================================
+     Forms
+     =========================================================================== */
+
+  /*
+   * Form elements should inherit font styles from their parent rather
+   * than using the browser's default font stack.
+   */
+  :where(button, input, optgroup, select, textarea) {
+    font: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  /*
+   * Remove default button styling. Buttons should be styled intentionally.
+   */
+  :where(button, [type='button'], [type='reset'], [type='submit']) {
+    -webkit-appearance: button;
+    appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
+
+  /*
+   * Pointer cursor for interactive elements.
+   */
+  :where(button, [role='button']) {
+    cursor: pointer;
+  }
+
+  /*
+   * Default cursor for disabled elements.
+   */
+  :where(:disabled) {
+    cursor: default;
+  }
+
+  /*
+   * Only allow vertical resizing of textareas to prevent layout breakage.
+   */
+  :where(textarea) {
+    resize: vertical;
+  }
+
+  /*
+   * Normalize placeholder opacity (Firefox renders at reduced opacity)
+   * and set a sensible default color using the XDS text-placeholder token.
+   */
+  :where(input::placeholder, textarea::placeholder) {
+    opacity: 1;
+    color: var(--color-text-secondary, #9ca3af);
+  }
+
+  /*
+   * Remove the inner padding and cancel buttons in search inputs
+   * for Chrome and Safari.
+   */
+  :where([type='search']::-webkit-search-decoration,
+         [type='search']::-webkit-search-cancel-button) {
+    -webkit-appearance: none;
+  }
+
+  /*
+   * Remove default fieldset styles.
+   */
+  :where(fieldset) {
+    margin: 0;
+    padding: 0;
+  }
+
+  :where(legend) {
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Tables
+     =========================================================================== */
+
+  /*
+   * Collapse table borders and fix text-indent/border-color inheritance.
+   */
+  :where(table) {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  /* ===========================================================================
+     Misc
+     =========================================================================== */
+
+  /*
+   * Simplify hr to a single border-top line.
+   */
+  :where(hr) {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  /*
+   * Correct display for summary elements.
+   */
+  :where(summary) {
+    display: list-item;
+  }
+
+  /*
+   * Reset dialog padding and outline.
+   */
+  :where(dialog) {
+    padding: 0;
+    outline: none;
+  }
+
+  /*
+   * Ensure hidden elements are actually hidden.
+   */
+  :where([hidden]) {
+    display: none;
+  }
+
+  /*
+   * Remove tap highlight on iOS.
+   */
+  :where(html) {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* ===========================================================================
+     Touch Devices
+     =========================================================================== */
+
+  /*
+   * Suppress focus-visible outlines on touch-only devices.
+   *
+   * Focus rings exist to show keyboard users where focus is. On devices
+   * with no hover capability and a coarse pointer (phones, tablets),
+   * there's no keyboard navigation — focus rings are visual noise that
+   * can flash on tap, on dialog open (showModal auto-focus), or on
+   * programmatic focus.
+   *
+   * This targets touch-only devices specifically:
+   * - (hover: none) — no hover capability (not a mouse)
+   * - (pointer: coarse) — imprecise pointer (finger, not stylus)
+   *
+   * Hybrid devices (laptop with touchscreen) are NOT affected because
+   * their primary pointer is fine (trackpad/mouse) and hover is available.
+   */
+  @media (hover: none) and (pointer: coarse) {
+    :where(:focus-visible) {
+      outline: none;
+    }
+  }
+}</style>
+<style>@property --x-width {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-height {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-fontSize {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-bottom {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-right {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-borderWidth {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-marginTop {
+  syntax: "*";
+  inherits: false
+}
+
+@keyframes x18re5ia-B {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes x1k48ry3-B {
+  from {
+    opacity: 0;
+    transform: scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes xwmkjkf-B {
+  from {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xu7jd1z-B {
+  from {
+    opacity: 0;
+    transform: translateX(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xv1hr86-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes x1ahk7ht-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes xiylxmw-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2)));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes x1b6yrix-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes xqng64z-B {
+  0% {
+    transform: rotate(0);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+:root, .xyc456f {
+  --border-width: 1px;
+}
+
+:root, .xrphr3l {
+  --color-accent: light-dark(#0064e0, #2694fe);
+  --color-accent-muted: light-dark(#0082fb33, #0082fb3f);
+  --color-on-accent: light-dark(#fff, #fff);
+  --color-neutral: light-dark(#0536591a, #dfe2e533);
+  --color-background-surface: light-dark(#fff, #1f1f22);
+  --color-background-body: light-dark(#f1f4f7, #111112);
+  --color-overlay: light-dark(#01122866, #11111299);
+  --color-overlay-hover: light-dark(#0536590c, #ffffff0c);
+  --color-overlay-pressed: light-dark(#05365919, #ffffff19);
+  --color-background-muted: light-dark(#0536590c, #1111127f);
+  --color-text-primary: light-dark(#0a1317, #dfe2e5);
+  --color-text-secondary: light-dark(#4e606f, #aaafb5);
+  --color-text-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-text-accent: light-dark(#0064e0, #3e9efb);
+  --color-on-dark: light-dark(#fff, #fff);
+  --color-on-light: light-dark(#000, #000);
+  --color-icon-accent: light-dark(#0064e0, #2694fe);
+  --color-icon-primary: light-dark(#0a1317, #dfe2e5);
+  --color-icon-secondary: light-dark(#4e606f, #aaafb5);
+  --color-icon-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-background-card: light-dark(#fff, #1f1f22);
+  --color-background-popover: light-dark(#fff, #28292c);
+  --color-success: light-dark(#0d8626, #0d8626);
+  --color-success-muted: light-dark(#0b991f33, #0b991f3f);
+  --color-on-success: light-dark(#fff, #fff);
+  --color-error: light-dark(#e3193b, #f5394f);
+  --color-error-muted: light-dark(#e3193b33, #f5394f3f);
+  --color-on-error: light-dark(#fff, #fff);
+  --color-warning: light-dark(#e9af08, #f2c00b);
+  --color-warning-muted: light-dark(#e2a40033, #e2a4003f);
+  --color-on-warning: light-dark(#0a1317, #0a1317);
+  --color-border: light-dark(#05365919, #f2f4f619);
+  --color-border-emphasized: light-dark(#ccd3db, #494d53);
+  --color-skeleton: light-dark(#ccd3db, #5a5e66);
+  --color-shadow: light-dark(#0536591a, #0000004d);
+  --color-tint-hover: light-dark(#000, #fff);
+  --color-background-blue: light-dark(#0171e333, #0171e333);
+  --color-border-blue: light-dark(#0171e3, #4ba9fe);
+  --color-icon-blue: light-dark(#0064e0, #2694fe);
+  --color-text-blue: light-dark(#042f97, #afd7ff);
+  --color-background-cyan: light-dark(#03a7d733, #03a7d733);
+  --color-border-cyan: light-dark(#00bcd4, #4dd0e1);
+  --color-icon-cyan: light-dark(#00acc1, #26c6da);
+  --color-text-cyan: light-dark(#014975, #a1eef9);
+  --color-background-gray: light-dark(#0a131733, #666a724c);
+  --color-border-gray: light-dark(#647685, #8c939b);
+  --color-icon-gray: light-dark(#4e606f, #aaafb5);
+  --color-text-gray: light-dark(#0a1317, #e7eaed);
+  --color-background-green: light-dark(#24bb5e33, #24bb5e33);
+  --color-border-green: light-dark(#24bb5e, #4cd964);
+  --color-icon-green: light-dark(#0d8626, #26a756);
+  --color-text-green: light-dark(#09441f, #a5f690);
+  --color-background-orange: light-dark(#f2790233, #f2790233);
+  --color-border-orange: light-dark(#f27902, #ffa040);
+  --color-icon-orange: light-dark(#e9690b, #fb8c00);
+  --color-text-orange: light-dark(#6b2203, #fdb876);
+  --color-background-pink: light-dark(#e638b333, #e638b333);
+  --color-border-pink: light-dark(#e91e63, #f48fb1);
+  --color-icon-pink: light-dark(#c2185b, #ec407a);
+  --color-text-pink: light-dark(#650053, #feade3);
+  --color-background-purple: light-dark(#7952ff33, #7952ff33);
+  --color-border-purple: light-dark(#7952ff, #9575cd);
+  --color-icon-purple: light-dark(#5b08d8, #7952ff);
+  --color-text-purple: light-dark(#3e0697, #b3b0fe);
+  --color-background-red: light-dark(#e3193b33, #e3193b33);
+  --color-border-red: light-dark(#e3193b, #f5394f);
+  --color-icon-red: light-dark(#d31130, #e3193b);
+  --color-text-red: light-dark(#7b0210, #ffb2b8);
+  --color-background-teal: light-dark(#0db7af33, #0db7af33);
+  --color-border-teal: light-dark(#0db7af, #4db6ac);
+  --color-icon-teal: light-dark(#009688, #26a69a);
+  --color-text-teal: light-dark(#083943, #40dccd);
+  --color-background-yellow: light-dark(#e2a40033, #e2a40033);
+  --color-border-yellow: light-dark(#ffeb3b, #fff176);
+  --color-icon-yellow: light-dark(#fbc02d, #ffee58);
+  --color-text-yellow: light-dark(#753f07, #fbce03);
+}
+
+:root, .xdxxp96 {
+  --duration-fast-min: .13s;
+  --duration-fast: .175s;
+  --duration-fast-max: .23s;
+  --duration-medium-min: .31s;
+  --duration-medium: .41s;
+  --duration-medium-max: .55s;
+}
+
+:root, .x1u6r7cv {
+  --ease-standard: cubic-bezier(.24, 1, .4, 1);
+}
+
+:root, .x6xvlns {
+  --font-family-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-family-code: "SF Mono", Monaco, Consolas, monospace;
+  --font-family-heading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+:root, .x48sopm {
+  --font-size-4xs: .375rem;
+  --font-size-3xs: .4375rem;
+  --font-size-2xs: .5rem;
+  --font-size-xs: .625rem;
+  --font-size-sm: .75rem;
+  --font-size-base: .875rem;
+  --font-size-lg: 1.0625rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.8125rem;
+  --font-size-4xl: 2.1875rem;
+  --font-size-5xl: 2.625rem;
+}
+
+:root, .x1anzp68 {
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+}
+
+:root, .xy6n0i {
+  --radius-none: 0px;
+  --radius-inner: 4px;
+  --radius-element: 8px;
+  --radius-container: 12px;
+  --radius-page: 28px;
+  --radius-full: 9999px;
+}
+
+:root, .x99zpk1 {
+  --shadow-low: 0px 1px 1px light-dark(#0000001a, #0003), 0px 2px 8px light-dark(#0000001a, #0003);
+  --shadow-med: 0px 1px 2px light-dark(#0000001a, #0003), 0px 2px 12px light-dark(#0000001a, #0003);
+  --shadow-high: 0px 2px 2px light-dark(#0000001a, #0003), 0px 8px 24px light-dark(#0000001a, #0000004d);
+  --shadow-inset-hover: inset 0px 0px 0px 2px #0171e34d;
+  --shadow-inset-selected: inset 0px 0px 0px 2px #0171e380;
+  --shadow-inset-success: inset 0px 0px 0px 2px #26a7564d;
+  --shadow-inset-warning: inset 0px 0px 0px 2px #e2a4004d;
+  --shadow-inset-error: inset 0px 0px 0px 2px #e3193b4d;
+}
+
+:root, .x10aelx4 {
+  --size-element-sm: 28px;
+  --size-element-md: 32px;
+  --size-element-lg: 36px;
+}
+
+:root, .x1auoh0n {
+  --spacing-0: 0px;
+  --spacing-0-5: 2px;
+  --spacing-1: 4px;
+  --spacing-1-5: 6px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-11: 44px;
+  --spacing-12: 48px;
+}
+
+:root, .xmde5od {
+  --text-heading-1-size: var(--font-size-2xl);
+  --text-heading-1-weight: var(--font-weight-semibold);
+  --text-heading-1-leading: 1.3333;
+  --text-heading-2-size: var(--font-size-xl);
+  --text-heading-2-weight: var(--font-weight-semibold);
+  --text-heading-2-leading: 1.4;
+  --text-heading-3-size: var(--font-size-lg);
+  --text-heading-3-weight: var(--font-weight-semibold);
+  --text-heading-3-leading: 1.4118;
+  --text-heading-4-size: var(--font-size-base);
+  --text-heading-4-weight: var(--font-weight-semibold);
+  --text-heading-4-leading: 1.4286;
+  --text-heading-5-size: var(--font-size-sm);
+  --text-heading-5-weight: var(--font-weight-semibold);
+  --text-heading-5-leading: 1.6667;
+  --text-heading-6-size: var(--font-size-xs);
+  --text-heading-6-weight: var(--font-weight-semibold);
+  --text-heading-6-leading: 1.6;
+  --text-body-size: var(--font-size-base);
+  --text-body-weight: var(--font-weight-normal);
+  --text-body-leading: 1.4286;
+  --text-large-size: var(--font-size-lg);
+  --text-large-weight: var(--font-weight-semibold);
+  --text-large-leading: 1.4118;
+  --text-label-size: var(--font-size-base);
+  --text-label-weight: var(--font-weight-medium);
+  --text-label-leading: 1.4286;
+  --text-code-size: var(--font-size-base);
+  --text-code-weight: var(--font-weight-normal);
+  --text-code-leading: 1.4286;
+  --text-supporting-size: var(--font-size-sm);
+  --text-supporting-weight: var(--font-weight-normal);
+  --text-supporting-leading: 1.6667;
+  --text-display-1-size: var(--font-size-5xl);
+  --text-display-1-weight: var(--font-weight-normal);
+  --text-display-1-leading: 1.2381;
+  --text-display-2-size: var(--font-size-4xl);
+  --text-display-2-weight: var(--font-weight-normal);
+  --text-display-2-leading: 1.2571;
+  --text-display-3-size: var(--font-size-3xl);
+  --text-display-3-weight: var(--font-weight-normal);
+  --text-display-3-leading: 1.2414;
+}
+
+:root, .xs77cmt {
+  --transition-fast: .15s ease;
+  --transition-normal: .2s ease;
+}
+
+.xkzo27j {
+  --button-focus-offset: 3px;
+}
+
+.x1v15ycx {
+  --button-icon-only-aspect: 1 / 1;
+}
+
+.x1mkq5kp {
+  --button-radius: var(--radius-element);
+}
+
+.x30uzy1 {
+  --component-padding-inline: var(--spacing-2);
+}
+
+.x1ojg8sz {
+  --component-padding-inline: var(--spacing-3);
+}
+
+.xwfoc2r {
+  --edge-end: 1;
+}
+
+.x1tfgai2 {
+  --edge-start: 1;
+}
+
+.xrhxz6v {
+  --input-radius: var(--radius-element);
+}
+
+.xln7xf2:not(#\#) {
+  font: inherit;
+}
+
+.xkdpibf:not(#\#) {
+  margin: -1px;
+}
+
+.x1ghz6dp:not(#\#) {
+  margin: 0;
+}
+
+.x1717udv:not(#\#) {
+  padding: 0;
+}
+
+.x9epnlk:not(#\#) {
+  padding: var(--spacing-1);
+}
+
+.xlsj2fj:not(#\#) {
+  padding: var(--spacing-2);
+}
+
+.xad5do:not(#\#):not(#\#) {
+  border-color: var(--color-accent);
+}
+
+.x1touxvs:not(#\#):not(#\#) {
+  border-color: var(--color-background-surface);
+}
+
+.xvy26l8:not(#\#):not(#\#) {
+  border-color: var(--color-border-emphasized);
+}
+
+.x14i3s5s:not(#\#):not(#\#) {
+  border-color: var(--color-border);
+}
+
+.x1ofxpqo:not(#\#):not(#\#) {
+  border-color: var(--color-error);
+}
+
+.x16m2moy:not(#\#):not(#\#) {
+  border-color: var(--color-success);
+}
+
+.x8wg1ba:not(#\#):not(#\#) {
+  border-color: var(--color-warning);
+}
+
+.x1nj7uno:not(#\#):not(#\#) {
+  border-radius: 1px;
+}
+
+.x16rqkct:not(#\#):not(#\#) {
+  border-radius: 50%;
+}
+
+.x1q11iln:not(#\#):not(#\#) {
+  border-radius: var(--button-radius);
+}
+
+.x11spqq5:not(#\#):not(#\#) {
+  border-radius: var(--input-radius);
+}
+
+.x1hviunn:not(#\#):not(#\#) {
+  border-radius: var(--radius-container);
+}
+
+.xh6dtrn:not(#\#):not(#\#) {
+  border-radius: var(--radius-element);
+}
+
+.xjspbzw:not(#\#):not(#\#) {
+  border-radius: var(--radius-full);
+}
+
+.xx3sua9:not(#\#):not(#\#) {
+  border-radius: var(--radius-inner);
+}
+
+.xng3xce:not(#\#):not(#\#) {
+  border-style: none;
+}
+
+.x1y0btm7:not(#\#):not(#\#) {
+  border-style: solid;
+}
+
+.xc342km:not(#\#):not(#\#) {
+  border-width: 0;
+}
+
+.x1litavf:not(#\#):not(#\#) {
+  border-width: var(--border-width);
+}
+
+.x1mw0n95:not(#\#):not(#\#) {
+  border-width: var(--x-borderWidth);
+}
+
+.x98rzlu:not(#\#):not(#\#) {
+  flex: 1;
+}
+
+.xxhr3t:not(#\#):not(#\#) {
+  gap: 0;
+}
+
+.x1lsbc85:not(#\#):not(#\#) {
+  gap: var(--spacing-0-5);
+}
+
+.xzye2dw:not(#\#):not(#\#) {
+  gap: var(--spacing-1);
+}
+
+.x1txdalj:not(#\#):not(#\#) {
+  gap: var(--spacing-2);
+}
+
+.x18g69wz:not(#\#):not(#\#) {
+  gap: var(--spacing-4);
+}
+
+.xcxpkta:not(#\#):not(#\#) {
+  margin-block: calc(-1 * var(--container-padding, 0px));
+}
+
+.xsq74q5:not(#\#):not(#\#) {
+  margin-block: var(--spacing-1);
+}
+
+.xzyy9it:not(#\#):not(#\#) {
+  margin-inline: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1a2a7pz:not(#\#):not(#\#) {
+  outline: none;
+}
+
+.xb3r6kr:not(#\#):not(#\#) {
+  overflow: hidden;
+}
+
+.x1rea2x4:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xt970qd:not(#\#):not(#\#) {
+  padding-block: 0;
+}
+
+.xu0wf1k:not(#\#):not(#\#) {
+  padding-block: var(--spacing-1);
+}
+
+.xce4md1:not(#\#):not(#\#) {
+  padding-block: var(--spacing-2);
+}
+
+.x8o8v82:not(#\#):not(#\#) {
+  padding-block: var(--spacing-3);
+}
+
+.xnjsko4:not(#\#):not(#\#) {
+  padding-inline: 0;
+}
+
+.xf314gf:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-2);
+}
+
+.xrrkdod:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-3);
+}
+
+.x1pzlopt:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-4);
+}
+
+.xmqliwb:not(#\#):not(#\#) {
+  text-decoration: line-through;
+}
+
+.x1hl2dhg:not(#\#):not(#\#) {
+  text-decoration: none;
+}
+
+.x1aq93mo:not(#\#):not(#\#) {
+  transition: border-color .15s;
+}
+
+.xq2gx43:not(#\#):not(#\#) {
+  transition: none;
+}
+
+.x1ey1afo:not(#\#):not(#\#) {
+  transition: opacity var(--duration-fast);
+}
+
+.x1dg3z2k.x1dg3z2k:where(.x-default-marker:focus-within *):not(#\#):not(#\#), .x17nn4n9:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-accent);
+}
+
+.x1p73he7:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-error);
+}
+
+.x1bb4jes:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-accent);
+}
+
+.xvr22io:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-error);
+}
+
+.xgqqtmo:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-success);
+}
+
+.x1i2lkmv:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-warning);
+}
+
+.x1dordxg:focus-within:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xzeu18z:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-accent);
+}
+
+.xescob6:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-error);
+}
+
+.x1erxr0s:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-success);
+}
+
+.xhmquqt:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-warning);
+}
+
+@media (hover: hover) {
+  .xvrpfll.xvrpfll.xvrpfll:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: color-mix(in srgb,var(--color-accent),var(--color-tint-hover) 15%);
+  }
+
+  .xvyyb7d.xvyyb7d.xvyyb7d:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: color-mix(in srgb,var(--color-border-emphasized),var(--color-tint-hover) 20%);
+  }
+
+  .xrzr44y.xrzr44y.xrzr44y:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: var(--color-border);
+  }
+
+  .x1ww4t2b.x1ww4t2b:hover:not(#\#):not(#\#) {
+    border-color: var(--color-border-emphasized);
+  }
+}
+
+.x1ua5tub:not(#\#):not(#\#):not(#\#) {
+  -webkit-box-orient: vertical;
+}
+
+.x6s0dn4:not(#\#):not(#\#):not(#\#) {
+  align-items: center;
+}
+
+.xuk3077:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-end;
+}
+
+.x1cy8zhl:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-start;
+}
+
+.x1qjc9v5:not(#\#):not(#\#):not(#\#) {
+  align-items: stretch;
+}
+
+.xamitd3:not(#\#):not(#\#):not(#\#) {
+  align-self: center;
+}
+
+.xpvyfi4:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-end;
+}
+
+.xqcrz7y:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-start;
+}
+
+.xkh2ocl:not(#\#):not(#\#):not(#\#) {
+  align-self: stretch;
+}
+
+.x9uej1z:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-fast-max);
+}
+
+.xqgcaz:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-medium-max);
+}
+
+.xskzprw:not(#\#):not(#\#):not(#\#) {
+  animation-fill-mode: backwards;
+}
+
+.xa4qsjk:not(#\#):not(#\#):not(#\#) {
+  animation-iteration-count: infinite;
+}
+
+.xqcmdr3:not(#\#):not(#\#):not(#\#) {
+  animation-name: x18re5ia-B;
+}
+
+.x3psbcj:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1ahk7ht-B;
+}
+
+.x1dvww92:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1b6yrix-B;
+}
+
+.x97zbip:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1k48ry3-B;
+}
+
+.x1srr2gu:not(#\#):not(#\#):not(#\#) {
+  animation-name: xiylxmw-B;
+}
+
+.x1ka1v4i:not(#\#):not(#\#):not(#\#) {
+  animation-name: xqng64z-B;
+}
+
+.xck01x9:not(#\#):not(#\#):not(#\#) {
+  animation-name: xu7jd1z-B;
+}
+
+.xl1vlw0:not(#\#):not(#\#):not(#\#) {
+  animation-name: xv1hr86-B;
+}
+
+.x1i331go:not(#\#):not(#\#):not(#\#) {
+  animation-name: xwmkjkf-B;
+}
+
+.x1esw782:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: linear;
+}
+
+.x128ha8g:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: var(--ease-standard);
+}
+
+.xioom0i:not(#\#):not(#\#):not(#\#) {
+  aspect-ratio: var(--button-icon-only-aspect);
+}
+
+.xlp1x4z:not(#\#):not(#\#):not(#\#) {
+  backface-visibility: hidden;
+}
+
+.xjbqb8w:not(#\#):not(#\#):not(#\#) {
+  background-color: #0000;
+}
+
+.x9dqhi0:not(#\#):not(#\#):not(#\#) {
+  background-color: unset;
+}
+
+.x1ewilqj:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-accent);
+}
+
+.x1o0wnni:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-blue);
+}
+
+.x1rgj867:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-cyan);
+}
+
+.x1sqjeoo:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-green);
+}
+
+.xwmxj5m:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.x1e9xt6e:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-orange);
+}
+
+.xnpoty2:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-pink);
+}
+
+.x1prclbq:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-popover);
+}
+
+.x16i6n6f:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-purple);
+}
+
+.x1cibrc5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-red);
+}
+
+.x10xzikg:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-surface);
+}
+
+.x1jtji5o:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-teal);
+}
+
+.x1bo7t0x:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-yellow);
+}
+
+.x7njt3n:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border-emphasized);
+}
+
+.x1m4xfpy:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border);
+}
+
+.x1pritpl:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error-muted);
+}
+
+.x1pjz0fi:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error);
+}
+
+.x17x4s8c:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-neutral);
+}
+
+.x1azo05:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-on-accent);
+}
+
+.x1lmrjuc:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-overlay-hover);
+}
+
+.xu13z74:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-success-muted);
+}
+
+.xdsz4j9:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-success);
+}
+
+.x19aspcf:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-text-primary);
+}
+
+.xdomwnj:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-text-secondary);
+}
+
+.x24i8r5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-warning-muted);
+}
+
+.x1q8g9m5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-warning);
+}
+
+.x18o3ruo:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1mwwwfo:not(#\#):not(#\#):not(#\#) {
+  border-collapse: collapse;
+}
+
+.x1o3jo1z:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: #0000;
+}
+
+.x18b5jzi:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-style: solid;
+}
+
+.x1lun4ml:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-width: 1px;
+}
+
+.x1gukg7c:not(#\#):not(#\#):not(#\#) {
+  border-spacing: 0;
+}
+
+.x1gnnqk1:not(#\#):not(#\#):not(#\#) {
+  box-shadow: none;
+}
+
+.x1i5ehqx:not(#\#):not(#\#):not(#\#) {
+  box-shadow: var(--shadow-low);
+}
+
+.x9f619:not(#\#):not(#\#):not(#\#) {
+  box-sizing: border-box;
+}
+
+.x1hyvwdk:not(#\#):not(#\#):not(#\#) {
+  clip-path: inset(50%);
+}
+
+.xzpqnlu:not(#\#):not(#\#):not(#\#) {
+  clip: rect(0,0,0,0);
+}
+
+.xntwwlm:not(#\#):not(#\#):not(#\#) {
+  color-scheme: dark;
+}
+
+.x108lcm5:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light dark;
+}
+
+.x19aimcq:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light;
+}
+
+.x1heor9g:not(#\#):not(#\#):not(#\#) {
+  color: inherit;
+}
+
+.x19co3pv:not(#\#):not(#\#):not(#\#) {
+  color: #0000;
+}
+
+.xqwr325:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-accent);
+}
+
+.xrkvqaz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-background-surface);
+}
+
+.xjt36v0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-error);
+}
+
+.x1fns2mt:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-blue);
+}
+
+.x157w0xa:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-cyan);
+}
+
+.xqa6c3m:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-disabled);
+}
+
+.x1eyinzz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-gray);
+}
+
+.xmxeech:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-green);
+}
+
+.xxu74a4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-orange);
+}
+
+.x1kxxfg5:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-pink);
+}
+
+.xtbr613:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-primary);
+}
+
+.xzdw94u:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-purple);
+}
+
+.xeffzf7:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-red);
+}
+
+.xv9yike:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-secondary);
+}
+
+.x1f3zxcb:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-teal);
+}
+
+.x1g6zdft:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-yellow);
+}
+
+.x17wrial:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-accent);
+}
+
+.x1m024r3:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-error);
+}
+
+.xri61p4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-success);
+}
+
+.xrebv38:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-warning);
+}
+
+.xtjic6:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-success);
+}
+
+.x1vvqiwl:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-blue);
+}
+
+.x1txnczv:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-cyan);
+}
+
+.xnbbluu:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-disabled);
+}
+
+.xltfdvo:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-green);
+}
+
+.xm47u9q:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-orange);
+}
+
+.xiuofww:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-pink);
+}
+
+.x1tgivj0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-primary);
+}
+
+.x1m9wyeb:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-purple);
+}
+
+.x1joocv1:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-red);
+}
+
+.xv1l7n4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-secondary);
+}
+
+.x9x0lbs:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-teal);
+}
+
+.xdhq94a:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-yellow);
+}
+
+.xs3pv69:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-warning);
+}
+
+.x1kihgfc:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0-5);
+}
+
+.x1o57wo1:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0);
+}
+
+.x1thn6ci:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1-5);
+}
+
+.x1lfs0n9:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1);
+}
+
+.x1p37tyl:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-10);
+}
+
+.xak3so:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-2);
+}
+
+.xewh9hi:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-3);
+}
+
+.xty4p9g:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-4);
+}
+
+.x1eqhezk:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-5);
+}
+
+.x3qlgwd:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-6);
+}
+
+.xicv188:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-8);
+}
+
+.x7eptgl:not(#\#):not(#\#):not(#\#) {
+  cursor: ew-resize;
+}
+
+.x1h6gzvc:not(#\#):not(#\#):not(#\#) {
+  cursor: not-allowed;
+}
+
+.x1ypdohk:not(#\#):not(#\#):not(#\#) {
+  cursor: pointer;
+}
+
+.x104kibb:not(#\#):not(#\#):not(#\#) {
+  display: -webkit-box;
+}
+
+.x1lliihq:not(#\#):not(#\#):not(#\#) {
+  display: block;
+}
+
+.xjp7ctv:not(#\#):not(#\#):not(#\#) {
+  display: contents;
+}
+
+.x78zum5:not(#\#):not(#\#):not(#\#) {
+  display: flex;
+}
+
+.x1rg5ohu:not(#\#):not(#\#):not(#\#) {
+  display: inline-block;
+}
+
+.x3nfvp2:not(#\#):not(#\#):not(#\#) {
+  display: inline-flex;
+}
+
+.xt0psk2:not(#\#):not(#\#):not(#\#) {
+  display: inline;
+}
+
+.x1s85apg:not(#\#):not(#\#):not(#\#) {
+  display: none;
+}
+
+.xdt5ytf:not(#\#):not(#\#):not(#\#) {
+  flex-direction: column;
+}
+
+.x1q0g3np:not(#\#):not(#\#):not(#\#) {
+  flex-direction: row;
+}
+
+.x1c4vz4f:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 0;
+}
+
+.x1iyjqo2:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 1;
+}
+
+.x2lah0s:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 0;
+}
+
+.xs83m0k:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 1;
+}
+
+.xozqiw3:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: nowrap;
+}
+
+.x8hhl5t:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap-reverse;
+}
+
+.x1a02dak:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap;
+}
+
+.xjb2p0i:not(#\#):not(#\#):not(#\#) {
+  font-family: inherit;
+}
+
+.x9ynric:not(#\#):not(#\#):not(#\#) {
+  font-family: var(--font-family-body);
+}
+
+.x1k6wstc:not(#\#):not(#\#):not(#\#) {
+  font-size: 10px;
+}
+
+.xfifm61:not(#\#):not(#\#):not(#\#) {
+  font-size: 12px;
+}
+
+.x1j61zf2:not(#\#):not(#\#):not(#\#) {
+  font-size: 16px;
+}
+
+.xwsyq91:not(#\#):not(#\#):not(#\#) {
+  font-size: 20px;
+}
+
+.x1pvqxga:not(#\#):not(#\#):not(#\#) {
+  font-size: 24px;
+}
+
+.xjm74w1:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-body-size);
+}
+
+.xcr08ib:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-label-size);
+}
+
+.x141an7d:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-supporting-size);
+}
+
+.xdmh292:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--x-fontSize);
+}
+
+.xss6m8b:not(#\#):not(#\#):not(#\#) {
+  font-variant-numeric: tabular-nums;
+}
+
+.x1lvx875:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-bold);
+}
+
+.x1e4wzip:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-medium);
+}
+
+.x1sodnla:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-normal);
+}
+
+.x2mo6ok:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-semibold);
+}
+
+.xxovm9e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-body-weight);
+}
+
+.xx3eeay:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-code-weight);
+}
+
+.x1txul5o:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-1-weight);
+}
+
+.x1y36c3f:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-2-weight);
+}
+
+.x1on40hk:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-3-weight);
+}
+
+.xmhvcl5:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-label-weight);
+}
+
+.x149oux8:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-large-weight);
+}
+
+.xv8on6e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-supporting-weight);
+}
+
+.xtijo5x:not(#\#):not(#\#):not(#\#) {
+  inset-inline-end: 0;
+}
+
+.xl56j7k:not(#\#):not(#\#):not(#\#) {
+  justify-content: center;
+}
+
+.x13a6bvl:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-end;
+}
+
+.x1nhvcw1:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-start;
+}
+
+.x1l1ennw:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-around;
+}
+
+.x1qughib:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-between;
+}
+
+.xaw8158:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-evenly;
+}
+
+.x14ju556:not(#\#):not(#\#):not(#\#) {
+  line-height: 0;
+}
+
+.xo5v014:not(#\#):not(#\#):not(#\#) {
+  line-height: 1;
+}
+
+.xw6l6zx:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-body-leading);
+}
+
+.x1kq96og:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-label-leading);
+}
+
+.x1ltkj2j:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-supporting-leading);
+}
+
+.x14z9mp:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: 0;
+}
+
+.xofqkxr:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(var(--edge-end, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.xnur1sd:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: var(--spacing-1);
+}
+
+.x1lziwak:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: 0;
+}
+
+.xg82z56:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(var(--edge-start, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.x11g1kdw:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: var(--spacing-1);
+}
+
+.xl1xv1r:not(#\#):not(#\#):not(#\#) {
+  object-fit: cover;
+}
+
+.xbyyjgo:not(#\#):not(#\#):not(#\#) {
+  opacity: .5;
+}
+
+.xg01cxk:not(#\#):not(#\#):not(#\#) {
+  opacity: 0;
+}
+
+.x1hc1fzr:not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.x1wfwxd8:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 0;
+}
+
+.x1hl8ikr:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x1mzt3pk:not(#\#):not(#\#):not(#\#) {
+  overflow-wrap: break-word;
+}
+
+.xyri2b:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: 0;
+}
+
+.x1djylfy:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-2);
+}
+
+.x1c1uobl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: 0;
+}
+
+.x12gdq22:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-2);
+}
+
+.x47corl:not(#\#):not(#\#):not(#\#) {
+  pointer-events: none;
+}
+
+.x10l6tqk:not(#\#):not(#\#):not(#\#) {
+  position: absolute;
+}
+
+.xixxii4:not(#\#):not(#\#):not(#\#) {
+  position: fixed;
+}
+
+.x1n2onr6:not(#\#):not(#\#):not(#\#) {
+  position: relative;
+}
+
+.x1tw44j4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0-5);
+}
+
+.x6yxi7o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0);
+}
+
+.xhq53yo:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1-5);
+}
+
+.x1ngg2t4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1);
+}
+
+.x1xpicb7:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-10);
+}
+
+.x1x7z4sm:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-2);
+}
+
+.x4olc9o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-3);
+}
+
+.xtx9w7w:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-4);
+}
+
+.x1iu6piu:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-5);
+}
+
+.xczp1bk:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-6);
+}
+
+.xgx0vcf:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-8);
+}
+
+.x140o2bo:not(#\#):not(#\#):not(#\#) {
+  table-layout: fixed;
+}
+
+.x16tdsg8:not(#\#):not(#\#):not(#\#) {
+  text-align: inherit;
+}
+
+.xdpxx8g:not(#\#):not(#\#):not(#\#) {
+  text-align: left;
+}
+
+.x1yc453h:not(#\#):not(#\#):not(#\#) {
+  text-align: start;
+}
+
+.x1b2iylo:not(#\#):not(#\#):not(#\#) {
+  text-box-edge: cap alphabetic;
+}
+
+.xwgcxoh:not(#\#):not(#\#):not(#\#) {
+  text-box-trim: trim-both;
+}
+
+.xycaml9:not(#\#):not(#\#):not(#\#) {
+  -webkit-text-decoration-color: var(--color-border-emphasized);
+  text-decoration-color: var(--color-border-emphasized);
+}
+
+.xujl8zx:not(#\#):not(#\#):not(#\#) {
+  text-decoration-line: underline;
+}
+
+.xev0dqp:not(#\#):not(#\#):not(#\#) {
+  text-decoration-style: dashed;
+}
+
+.xlyipyv:not(#\#):not(#\#):not(#\#) {
+  text-overflow: ellipsis;
+}
+
+.xtvhhri:not(#\#):not(#\#):not(#\#) {
+  text-transform: uppercase;
+}
+
+.xrys4gj:not(#\#):not(#\#):not(#\#) {
+  text-underline-offset: 2px;
+}
+
+.x1w2vvpw:not(#\#):not(#\#):not(#\#) {
+  text-wrap: balance;
+}
+
+.xebhuq6:not(#\#):not(#\#):not(#\#) {
+  text-wrap: nowrap;
+}
+
+.x1fzhlzt:not(#\#):not(#\#):not(#\#) {
+  text-wrap: pretty;
+}
+
+.xk4td0m:not(#\#):not(#\#):not(#\#) {
+  text-wrap: wrap;
+}
+
+.x5ve5x3:not(#\#):not(#\#):not(#\#) {
+  touch-action: none;
+}
+
+.x1g0ag68:not(#\#):not(#\#):not(#\#) {
+  transform-origin: center;
+}
+
+.x1c071of:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.x19jd1h0:not(#\#):not(#\#):not(#\#) {
+  transform: rotate(180deg);
+}
+
+.x3oybdh:not(#\#):not(#\#):not(#\#) {
+  transform: scale(1);
+}
+
+.x31h1t8:not(#\#):not(#\#):not(#\#) {
+  transform: translate(-50%, 100%);
+}
+
+.x4v1no5:not(#\#):not(#\#):not(#\#) {
+  transform: translate(50%, 50%);
+}
+
+.xuedmi6:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-fast);
+}
+
+.xts7igz:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color, border-color;
+}
+
+.x15406qy:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color;
+}
+
+.xqc8rvf:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-image, transform;
+}
+
+.xpo9ue8:not(#\#):not(#\#):not(#\#) {
+  transition-property: border-color, outline, box-shadow;
+}
+
+.x11xpdln:not(#\#):not(#\#):not(#\#) {
+  transition-property: transform;
+}
+
+.xlr8y92:not(#\#):not(#\#):not(#\#) {
+  transition-timing-function: var(--ease-standard);
+}
+
+.x87ps6o:not(#\#):not(#\#):not(#\#) {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.xxymvpz:not(#\#):not(#\#):not(#\#) {
+  vertical-align: middle;
+}
+
+.xuxw1ft:not(#\#):not(#\#):not(#\#) {
+  white-space: nowrap;
+}
+
+.x1yn0g08:not(#\#):not(#\#):not(#\#) {
+  word-break: break-all;
+}
+
+.x13faqbe:not(#\#):not(#\#):not(#\#) {
+  word-break: break-word;
+}
+
+.x1lldw8n:not(#\#):not(#\#):not(#\#) {
+  word-break: normal;
+}
+
+.x1vjfegm:not(#\#):not(#\#):not(#\#) {
+  z-index: 1;
+}
+
+.x8w4yw4.x8w4yw4:where(.x-default-marker:focus-within *):not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.xcn42n2.xcn42n2:where(.x-default-marker:focus-within *):not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x5b7970.x5b7970:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.x25ezvp:focus-visible:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-accent);
+}
+
+.x10wafsz:focus-within:not(#\#):not(#\#):not(#\#) {
+  clip-path: none;
+}
+
+.x7s97pk:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x13aywxo:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: var(--button-focus-offset);
+}
+
+.xbt4iw:focus-within:not(#\#):not(#\#):not(#\#) {
+  pointer-events: auto;
+}
+
+.x1dnou9g:nth-child(2n):not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.xyg1mtj:hover:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-accent);
+}
+
+.xq8i9tn:active:not(#\#):not(#\#):not(#\#) {
+  background-image: linear-gradient(var(--color-overlay-pressed),var(--color-overlay-pressed));
+}
+
+.xuqm82a:active:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1pdlv7q:active:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.xk4oym4:active:not(#\#):not(#\#):not(#\#) {
+  transform: scale(.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .x12w9bfk.x12w9bfk:not(#\#):not(#\#):not(#\#) {
+    transition-duration: 0s;
+  }
+}
+
+@media (hover: hover) {
+  .x3h3317.x3h3317.x3h3317:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-accent),var(--color-tint-hover) 15%);
+  }
+
+  .xxuakwu.xxuakwu.xxuakwu:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-background-surface),var(--color-tint-hover) 5%);
+  }
+
+  .xaemn39.xaemn39.xaemn39:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: unset;
+  }
+
+  .xe9uy6x.xe9uy6x:hover:not(#\#):not(#\#):not(#\#) {
+    background-color: var(--color-overlay-hover);
+  }
+
+  .x1ilzqfv.x1ilzqfv:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: linear-gradient(var(--color-overlay-hover),var(--color-overlay-hover));
+  }
+
+  .x8o3jvd.x8o3jvd:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: none;
+  }
+
+  .x1ymn3ht.x1ymn3ht:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-error);
+  }
+
+  .x1j9d0uj.x1j9d0uj:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-hover);
+  }
+
+  .x1th0bn1.x1th0bn1:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-success);
+  }
+
+  .xo1e01f.xo1e01f:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-warning);
+  }
+}
+
+.xw8gpjh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-color: var(--color-border);
+}
+
+.x14lggfu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-left-radius: var(--radius-element);
+}
+
+.xtufxuj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-right-radius: var(--radius-element);
+}
+
+.x1q0q8m5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-style: solid;
+}
+
+.x92x3c3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-width: var(--border-width);
+}
+
+.xtgwc6q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-color: var(--color-border);
+}
+
+.x32b0ac:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-style: solid;
+}
+
+.x1pcaw5z:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-width: var(--border-width);
+}
+
+.x1ey2m1c:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: 0;
+}
+
+.x1nqzi6q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: var(--x-bottom);
+}
+
+.x5yr21d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 100%;
+}
+
+.x1kpxq89:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 12px;
+}
+
+.x1v9usgg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 14px;
+}
+
+.xlup9mm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 16px;
+}
+
+.xmix8c7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 18px;
+}
+
+.xjm9jq1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 1px;
+}
+
+.x1qx5ct2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 20px;
+}
+
+.x17rw0jw:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 22px;
+}
+
+.xxk0z11:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 24px;
+}
+
+.x36qwtl:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 2px;
+}
+
+.xols6we:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 6px;
+}
+
+.xdk7pt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 8px;
+}
+
+.xsyqizj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--border-width);
+}
+
+.xssyfek:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-lg);
+}
+
+.x1ueg155:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-md);
+}
+
+.x6k0iem:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-sm);
+}
+
+.x1grt7ep:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-5);
+}
+
+.x16ye13r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--x-height);
+}
+
+.xu96u03:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 0;
+}
+
+.x1nrll8i:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 50%;
+}
+
+.xat24cr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: 0;
+}
+
+.x14cgwvg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-1);
+}
+
+.x1p37lm5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-2);
+}
+
+.xdj266r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: 0;
+}
+
+.x1c40v9y:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: calc(-1 * var(--spacing-1-5));
+}
+
+.xcsaf9d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-1);
+}
+
+.xtbrsbv:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-2);
+}
+
+.x1gkbulp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--x-marginTop);
+}
+
+.xuyqlj2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: 300px;
+}
+
+.x1m189uc:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 0;
+}
+
+.xw5ewwj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 300px;
+}
+
+.x2lwn1j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 0;
+}
+
+.xeuugli:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 0;
+}
+
+.xrzjruh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: anchor-size(width);
+}
+
+.x17ydmr0:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--size-element-md);
+}
+
+.x1nkkqge:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--size-element-sm);
+}
+
+.x1odjw0f:not(#\#):not(#\#):not(#\#):not(#\#) {
+  overflow-y: auto;
+}
+
+.x18d9i69:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.xy143xn:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1);
+}
+
+.x1wesfrj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-2);
+}
+
+.xexx8yu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.x1ak3mig:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: calc(var(--spacing-1-5) + var(--spacing-2));
+}
+
+.xfsso4q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.x3m8u43:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: 0;
+}
+
+.x7ok3n0:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: var(--x-right);
+}
+
+.x13vifvy:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 0;
+}
+
+.xh8yej3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 100%;
+}
+
+.x1fsd2vl:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 10px;
+}
+
+.xsmyaan:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 12px;
+}
+
+.x6jxa94:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 14px;
+}
+
+.x1kky2od:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 16px;
+}
+
+.x1xp8n7a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 18px;
+}
+
+.x1i1rx1s:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 1px;
+}
+
+.xw4jnvo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 20px;
+}
+
+.x17z2i9w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 22px;
+}
+
+.xvy4d1p:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 24px;
+}
+
+.x1v4s8kt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 6px;
+}
+
+.x1dmp6jm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 80px;
+}
+
+.x1xc55vz:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 8px;
+}
+
+.xjk4fl7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--border-width);
+}
+
+.x5lhr3w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--x-width);
+}
+
+.x132qfvm:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: auto;
+}
+
+.x1kw28su:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.x10okhzq:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: auto;
+}
+
+.x1lpyac:last-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-width: 0;
+}
+
+@media (pointer: coarse) {
+  .x1kkwbli.x1kkwbli:not(#\#):not(#\#):not(#\#):not(#\#) {
+    width: 20px;
+  }
+}
+
+.xeyghm5:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::placeholder {
+  color: var(--color-text-secondary);
+}
+</style>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/internal/vibe-tests/results/441ddbe0/previews/dd-3/xds.html
+++ b/internal/vibe-tests/results/441ddbe0/previews/dd-3/xds.html
@@ -1,0 +1,2413 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>dd-3 — xds</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; }
+    #root { min-height: 100%; }
+  </style>
+  <script type="module" crossorigin>(function(){const l=document.createElement("link").relList;if(l&&l.supports&&l.supports("modulepreload"))return;for(const n of document.querySelectorAll('link[rel="modulepreload"]'))a(n);new MutationObserver(n=>{for(const u of n)if(u.type==="childList")for(const i of u.addedNodes)i.tagName==="LINK"&&i.rel==="modulepreload"&&a(i)}).observe(document,{childList:!0,subtree:!0});function e(n){const u={};return n.integrity&&(u.integrity=n.integrity),n.referrerPolicy&&(u.referrerPolicy=n.referrerPolicy),n.crossOrigin==="use-credentials"?u.credentials="include":n.crossOrigin==="anonymous"?u.credentials="omit":u.credentials="same-origin",u}function a(n){if(n.ep)return;n.ep=!0;const u=e(n);fetch(n.href,u)}})();function K0(t){return t&&t.__esModule&&Object.prototype.hasOwnProperty.call(t,"default")?t.default:t}var jo={exports:{}},_u={};/**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var J0=Symbol.for("react.transitional.element"),W0=Symbol.for("react.fragment");function _o(t,l,e){var a=null;if(e!==void 0&&(a=""+e),l.key!==void 0&&(a=""+l.key),"key"in l){e={};for(var n in l)n!=="key"&&(e[n]=l[n])}else e=l;return l=e.ref,{$$typeof:J0,type:t,key:a,ref:l!==void 0?l:null,props:e}}_u.Fragment=W0;_u.jsx=_o;_u.jsxs=_o;jo.exports=_u;var A=jo.exports,Do={exports:{}},Du={},ko={exports:{}},Co={};/**
+ * @license React
+ * scheduler.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */(function(t){function l(_,U){var N=_.length;_.push(U);t:for(;0<N;){var tt=N-1>>>1,nt=_[tt];if(0<n(nt,U))_[tt]=U,_[N]=nt,N=tt;else break t}}function e(_){return _.length===0?null:_[0]}function a(_){if(_.length===0)return null;var U=_[0],N=_.pop();if(N!==U){_[0]=N;t:for(var tt=0,nt=_.length,ie=nt>>>1;tt<ie;){var ce=2*(tt+1)-1,Dl=_[ce],ht=ce+1,al=_[ht];if(0>n(Dl,N))ht<nt&&0>n(al,Dl)?(_[tt]=al,_[ht]=N,tt=ht):(_[tt]=Dl,_[ce]=N,tt=ce);else if(ht<nt&&0>n(al,N))_[tt]=al,_[ht]=N,tt=ht;else break t}}return U}function n(_,U){var N=_.sortIndex-U.sortIndex;return N!==0?N:_.id-U.id}if(t.unstable_now=void 0,typeof performance=="object"&&typeof performance.now=="function"){var u=performance;t.unstable_now=function(){return u.now()}}else{var i=Date,c=i.now();t.unstable_now=function(){return i.now()-c}}var f=[],r=[],y=1,v=null,d=3,g=!1,p=!1,b=!1,z=!1,o=typeof setTimeout=="function"?setTimeout:null,s=typeof clearTimeout=="function"?clearTimeout:null,m=typeof setImmediate<"u"?setImmediate:null;function h(_){for(var U=e(r);U!==null;){if(U.callback===null)a(r);else if(U.startTime<=_)a(r),U.sortIndex=U.expirationTime,l(f,U);else break;U=e(r)}}function T(_){if(b=!1,h(_),!p)if(e(f)!==null)p=!0,M||(M=!0,lt());else{var U=e(r);U!==null&&Oe(T,U.startTime-_)}}var M=!1,E=-1,j=5,$=-1;function O(){return z?!0:!(t.unstable_now()-$<j)}function I(){if(z=!1,M){var _=t.unstable_now();$=_;var U=!0;try{t:{p=!1,b&&(b=!1,s(E),E=-1),g=!0;var N=d;try{l:{for(h(_),v=e(f);v!==null&&!(v.expirationTime>_&&O());){var tt=v.callback;if(typeof tt=="function"){v.callback=null,d=v.priorityLevel;var nt=tt(v.expirationTime<=_);if(_=t.unstable_now(),typeof nt=="function"){v.callback=nt,h(_),U=!0;break l}v===e(f)&&a(f),h(_)}else a(f);v=e(f)}if(v!==null)U=!0;else{var ie=e(r);ie!==null&&Oe(T,ie.startTime-_),U=!1}}break t}finally{v=null,d=N,g=!1}U=void 0}}finally{U?lt():M=!1}}}var lt;if(typeof m=="function")lt=function(){m(I)};else if(typeof MessageChannel<"u"){var ol=new MessageChannel,bn=ol.port2;ol.port1.onmessage=I,lt=function(){bn.postMessage(null)}}else lt=function(){o(I,0)};function Oe(_,U){E=o(function(){_(t.unstable_now())},U)}t.unstable_IdlePriority=5,t.unstable_ImmediatePriority=1,t.unstable_LowPriority=4,t.unstable_NormalPriority=3,t.unstable_Profiling=null,t.unstable_UserBlockingPriority=2,t.unstable_cancelCallback=function(_){_.callback=null},t.unstable_forceFrameRate=function(_){0>_||125<_?console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"):j=0<_?Math.floor(1e3/_):5},t.unstable_getCurrentPriorityLevel=function(){return d},t.unstable_next=function(_){switch(d){case 1:case 2:case 3:var U=3;break;default:U=d}var N=d;d=U;try{return _()}finally{d=N}},t.unstable_requestPaint=function(){z=!0},t.unstable_runWithPriority=function(_,U){switch(_){case 1:case 2:case 3:case 4:case 5:break;default:_=3}var N=d;d=_;try{return U()}finally{d=N}},t.unstable_scheduleCallback=function(_,U,N){var tt=t.unstable_now();switch(typeof N=="object"&&N!==null?(N=N.delay,N=typeof N=="number"&&0<N?tt+N:tt):N=tt,_){case 1:var nt=-1;break;case 2:nt=250;break;case 5:nt=1073741823;break;case 4:nt=1e4;break;default:nt=5e3}return nt=N+nt,_={id:y++,callback:U,priorityLevel:_,startTime:N,expirationTime:nt,sortIndex:-1},N>tt?(_.sortIndex=N,l(r,_),e(f)===null&&_===e(r)&&(b?(s(E),E=-1):b=!0,Oe(T,N-tt))):(_.sortIndex=nt,l(f,_),p||g||(p=!0,M||(M=!0,lt()))),_},t.unstable_shouldYield=O,t.unstable_wrapCallback=function(_){var U=d;return function(){var N=d;d=U;try{return _.apply(this,arguments)}finally{d=N}}}})(Co);ko.exports=Co;var F0=ko.exports,No={exports:{}},k={};/**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var Rc=Symbol.for("react.transitional.element"),I0=Symbol.for("react.portal"),P0=Symbol.for("react.fragment"),t1=Symbol.for("react.strict_mode"),l1=Symbol.for("react.profiler"),e1=Symbol.for("react.consumer"),a1=Symbol.for("react.context"),n1=Symbol.for("react.forward_ref"),u1=Symbol.for("react.suspense"),i1=Symbol.for("react.memo"),Uo=Symbol.for("react.lazy"),c1=Symbol.for("react.activity"),wf=Symbol.iterator;function f1(t){return t===null||typeof t!="object"?null:(t=wf&&t[wf]||t["@@iterator"],typeof t=="function"?t:null)}var Ro={isMounted:function(){return!1},enqueueForceUpdate:function(){},enqueueReplaceState:function(){},enqueueSetState:function(){}},qo=Object.assign,Ho={};function da(t,l,e){this.props=t,this.context=l,this.refs=Ho,this.updater=e||Ro}da.prototype.isReactComponent={};da.prototype.setState=function(t,l){if(typeof t!="object"&&typeof t!="function"&&t!=null)throw Error("takes an object of state variables to update or a function which returns an object of state variables.");this.updater.enqueueSetState(this,t,l,"setState")};da.prototype.forceUpdate=function(t){this.updater.enqueueForceUpdate(this,t,"forceUpdate")};function Bo(){}Bo.prototype=da.prototype;function qc(t,l,e){this.props=t,this.context=l,this.refs=Ho,this.updater=e||Ro}var Hc=qc.prototype=new Bo;Hc.constructor=qc;qo(Hc,da.prototype);Hc.isPureReactComponent=!0;var Xf=Array.isArray;function Bi(){}var W={H:null,A:null,T:null,S:null},wo=Object.prototype.hasOwnProperty;function Bc(t,l,e){var a=e.ref;return{$$typeof:Rc,type:t,key:l,ref:a!==void 0?a:null,props:e}}function s1(t,l){return Bc(t.type,l,t.props)}function wc(t){return typeof t=="object"&&t!==null&&t.$$typeof===Rc}function o1(t){var l={"=":"=0",":":"=2"};return"$"+t.replace(/[=:]/g,function(e){return l[e]})}var Zf=/\/+/g;function Ju(t,l){return typeof t=="object"&&t!==null&&t.key!=null?o1(""+t.key):l.toString(36)}function r1(t){switch(t.status){case"fulfilled":return t.value;case"rejected":throw t.reason;default:switch(typeof t.status=="string"?t.then(Bi,Bi):(t.status="pending",t.then(function(l){t.status==="pending"&&(t.status="fulfilled",t.value=l)},function(l){t.status==="pending"&&(t.status="rejected",t.reason=l)})),t.status){case"fulfilled":return t.value;case"rejected":throw t.reason}}throw t}function Ce(t,l,e,a,n){var u=typeof t;(u==="undefined"||u==="boolean")&&(t=null);var i=!1;if(t===null)i=!0;else switch(u){case"bigint":case"string":case"number":i=!0;break;case"object":switch(t.$$typeof){case Rc:case I0:i=!0;break;case Uo:return i=t._init,Ce(i(t._payload),l,e,a,n)}}if(i)return n=n(t),i=a===""?"."+Ju(t,0):a,Xf(n)?(e="",i!=null&&(e=i.replace(Zf,"$&/")+"/"),Ce(n,l,e,"",function(r){return r})):n!=null&&(wc(n)&&(n=s1(n,e+(n.key==null||t&&t.key===n.key?"":(""+n.key).replace(Zf,"$&/")+"/")+i)),l.push(n)),1;i=0;var c=a===""?".":a+":";if(Xf(t))for(var f=0;f<t.length;f++)a=t[f],u=c+Ju(a,f),i+=Ce(a,l,e,u,n);else if(f=f1(t),typeof f=="function")for(t=f.call(t),f=0;!(a=t.next()).done;)a=a.value,u=c+Ju(a,f++),i+=Ce(a,l,e,u,n);else if(u==="object"){if(typeof t.then=="function")return Ce(r1(t),l,e,a,n);throw l=String(t),Error("Objects are not valid as a React child (found: "+(l==="[object Object]"?"object with keys {"+Object.keys(t).join(", ")+"}":l)+"). If you meant to render a collection of children, use an array instead.")}return i}function Sn(t,l,e){if(t==null)return t;var a=[],n=0;return Ce(t,a,"","",function(u){return l.call(e,u,n++)}),a}function d1(t){if(t._status===-1){var l=t._result;l=l(),l.then(function(e){(t._status===0||t._status===-1)&&(t._status=1,t._result=e)},function(e){(t._status===0||t._status===-1)&&(t._status=2,t._result=e)}),t._status===-1&&(t._status=0,t._result=l)}if(t._status===1)return t._result.default;throw t._result}var Yf=typeof reportError=="function"?reportError:function(t){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var l=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof t=="object"&&t!==null&&typeof t.message=="string"?String(t.message):String(t),error:t});if(!window.dispatchEvent(l))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",t);return}console.error(t)},y1={map:Sn,forEach:function(t,l,e){Sn(t,function(){l.apply(this,arguments)},e)},count:function(t){var l=0;return Sn(t,function(){l++}),l},toArray:function(t){return Sn(t,function(l){return l})||[]},only:function(t){if(!wc(t))throw Error("React.Children.only expected to receive a single React element child.");return t}};k.Activity=c1;k.Children=y1;k.Component=da;k.Fragment=P0;k.Profiler=l1;k.PureComponent=qc;k.StrictMode=t1;k.Suspense=u1;k.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=W;k.__COMPILER_RUNTIME={__proto__:null,c:function(t){return W.H.useMemoCache(t)}};k.cache=function(t){return function(){return t.apply(null,arguments)}};k.cacheSignal=function(){return null};k.cloneElement=function(t,l,e){if(t==null)throw Error("The argument must be a React element, but you passed "+t+".");var a=qo({},t.props),n=t.key;if(l!=null)for(u in l.key!==void 0&&(n=""+l.key),l)!wo.call(l,u)||u==="key"||u==="__self"||u==="__source"||u==="ref"&&l.ref===void 0||(a[u]=l[u]);var u=arguments.length-2;if(u===1)a.children=e;else if(1<u){for(var i=Array(u),c=0;c<u;c++)i[c]=arguments[c+2];a.children=i}return Bc(t.type,n,a)};k.createContext=function(t){return t={$$typeof:a1,_currentValue:t,_currentValue2:t,_threadCount:0,Provider:null,Consumer:null},t.Provider=t,t.Consumer={$$typeof:e1,_context:t},t};k.createElement=function(t,l,e){var a,n={},u=null;if(l!=null)for(a in l.key!==void 0&&(u=""+l.key),l)wo.call(l,a)&&a!=="key"&&a!=="__self"&&a!=="__source"&&(n[a]=l[a]);var i=arguments.length-2;if(i===1)n.children=e;else if(1<i){for(var c=Array(i),f=0;f<i;f++)c[f]=arguments[f+2];n.children=c}if(t&&t.defaultProps)for(a in i=t.defaultProps,i)n[a]===void 0&&(n[a]=i[a]);return Bc(t,u,n)};k.createRef=function(){return{current:null}};k.forwardRef=function(t){return{$$typeof:n1,render:t}};k.isValidElement=wc;k.lazy=function(t){return{$$typeof:Uo,_payload:{_status:-1,_result:t},_init:d1}};k.memo=function(t,l){return{$$typeof:i1,type:t,compare:l===void 0?null:l}};k.startTransition=function(t){var l=W.T,e={};W.T=e;try{var a=t(),n=W.S;n!==null&&n(e,a),typeof a=="object"&&a!==null&&typeof a.then=="function"&&a.then(Bi,Yf)}catch(u){Yf(u)}finally{l!==null&&e.types!==null&&(l.types=e.types),W.T=l}};k.unstable_useCacheRefresh=function(){return W.H.useCacheRefresh()};k.use=function(t){return W.H.use(t)};k.useActionState=function(t,l,e){return W.H.useActionState(t,l,e)};k.useCallback=function(t,l){return W.H.useCallback(t,l)};k.useContext=function(t){return W.H.useContext(t)};k.useDebugValue=function(){};k.useDeferredValue=function(t,l){return W.H.useDeferredValue(t,l)};k.useEffect=function(t,l){return W.H.useEffect(t,l)};k.useEffectEvent=function(t){return W.H.useEffectEvent(t)};k.useId=function(){return W.H.useId()};k.useImperativeHandle=function(t,l,e){return W.H.useImperativeHandle(t,l,e)};k.useInsertionEffect=function(t,l){return W.H.useInsertionEffect(t,l)};k.useLayoutEffect=function(t,l){return W.H.useLayoutEffect(t,l)};k.useMemo=function(t,l){return W.H.useMemo(t,l)};k.useOptimistic=function(t,l){return W.H.useOptimistic(t,l)};k.useReducer=function(t,l,e){return W.H.useReducer(t,l,e)};k.useRef=function(t){return W.H.useRef(t)};k.useState=function(t){return W.H.useState(t)};k.useSyncExternalStore=function(t,l,e){return W.H.useSyncExternalStore(t,l,e)};k.useTransition=function(){return W.H.useTransition()};k.version="19.2.4";No.exports=k;var x=No.exports;const Gf=K0(x);var Xo={exports:{}},$t={};/**
+ * @license React
+ * react-dom.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var m1=x;function Zo(t){var l="https://react.dev/errors/"+t;if(1<arguments.length){l+="?args[]="+encodeURIComponent(arguments[1]);for(var e=2;e<arguments.length;e++)l+="&args[]="+encodeURIComponent(arguments[e])}return"Minified React error #"+t+"; visit "+l+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function kl(){}var Tt={d:{f:kl,r:function(){throw Error(Zo(522))},D:kl,C:kl,L:kl,m:kl,X:kl,S:kl,M:kl},p:0,findDOMNode:null},g1=Symbol.for("react.portal");function v1(t,l,e){var a=3<arguments.length&&arguments[3]!==void 0?arguments[3]:null;return{$$typeof:g1,key:a==null?null:""+a,children:t,containerInfo:l,implementation:e}}var Ca=m1.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;function ku(t,l){if(t==="font")return"";if(typeof l=="string")return l==="use-credentials"?l:""}$t.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=Tt;$t.createPortal=function(t,l){var e=2<arguments.length&&arguments[2]!==void 0?arguments[2]:null;if(!l||l.nodeType!==1&&l.nodeType!==9&&l.nodeType!==11)throw Error(Zo(299));return v1(t,l,null,e)};$t.flushSync=function(t){var l=Ca.T,e=Tt.p;try{if(Ca.T=null,Tt.p=2,t)return t()}finally{Ca.T=l,Tt.p=e,Tt.d.f()}};$t.preconnect=function(t,l){typeof t=="string"&&(l?(l=l.crossOrigin,l=typeof l=="string"?l==="use-credentials"?l:"":void 0):l=null,Tt.d.C(t,l))};$t.prefetchDNS=function(t){typeof t=="string"&&Tt.d.D(t)};$t.preinit=function(t,l){if(typeof t=="string"&&l&&typeof l.as=="string"){var e=l.as,a=ku(e,l.crossOrigin),n=typeof l.integrity=="string"?l.integrity:void 0,u=typeof l.fetchPriority=="string"?l.fetchPriority:void 0;e==="style"?Tt.d.S(t,typeof l.precedence=="string"?l.precedence:void 0,{crossOrigin:a,integrity:n,fetchPriority:u}):e==="script"&&Tt.d.X(t,{crossOrigin:a,integrity:n,fetchPriority:u,nonce:typeof l.nonce=="string"?l.nonce:void 0})}};$t.preinitModule=function(t,l){if(typeof t=="string")if(typeof l=="object"&&l!==null){if(l.as==null||l.as==="script"){var e=ku(l.as,l.crossOrigin);Tt.d.M(t,{crossOrigin:e,integrity:typeof l.integrity=="string"?l.integrity:void 0,nonce:typeof l.nonce=="string"?l.nonce:void 0})}}else l==null&&Tt.d.M(t)};$t.preload=function(t,l){if(typeof t=="string"&&typeof l=="object"&&l!==null&&typeof l.as=="string"){var e=l.as,a=ku(e,l.crossOrigin);Tt.d.L(t,e,{crossOrigin:a,integrity:typeof l.integrity=="string"?l.integrity:void 0,nonce:typeof l.nonce=="string"?l.nonce:void 0,type:typeof l.type=="string"?l.type:void 0,fetchPriority:typeof l.fetchPriority=="string"?l.fetchPriority:void 0,referrerPolicy:typeof l.referrerPolicy=="string"?l.referrerPolicy:void 0,imageSrcSet:typeof l.imageSrcSet=="string"?l.imageSrcSet:void 0,imageSizes:typeof l.imageSizes=="string"?l.imageSizes:void 0,media:typeof l.media=="string"?l.media:void 0})}};$t.preloadModule=function(t,l){if(typeof t=="string")if(l){var e=ku(l.as,l.crossOrigin);Tt.d.m(t,{as:typeof l.as=="string"&&l.as!=="script"?l.as:void 0,crossOrigin:e,integrity:typeof l.integrity=="string"?l.integrity:void 0})}else Tt.d.m(t)};$t.requestFormReset=function(t){Tt.d.r(t)};$t.unstable_batchedUpdates=function(t,l){return t(l)};$t.useFormState=function(t,l,e){return Ca.H.useFormState(t,l,e)};$t.useFormStatus=function(){return Ca.H.useHostTransitionStatus()};$t.version="19.2.4";function Yo(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(Yo)}catch(t){console.error(t)}}Yo(),Xo.exports=$t;var h1=Xo.exports;/**
+ * @license React
+ * react-dom-client.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var yt=F0,Go=x,x1=h1;function S(t){var l="https://react.dev/errors/"+t;if(1<arguments.length){l+="?args[]="+encodeURIComponent(arguments[1]);for(var e=2;e<arguments.length;e++)l+="&args[]="+encodeURIComponent(arguments[e])}return"Minified React error #"+t+"; visit "+l+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function Lo(t){return!(!t||t.nodeType!==1&&t.nodeType!==9&&t.nodeType!==11)}function fn(t){var l=t,e=t;if(t.alternate)for(;l.return;)l=l.return;else{t=l;do l=t,l.flags&4098&&(e=l.return),t=l.return;while(t)}return l.tag===3?e:null}function Qo(t){if(t.tag===13){var l=t.memoizedState;if(l===null&&(t=t.alternate,t!==null&&(l=t.memoizedState)),l!==null)return l.dehydrated}return null}function Vo(t){if(t.tag===31){var l=t.memoizedState;if(l===null&&(t=t.alternate,t!==null&&(l=t.memoizedState)),l!==null)return l.dehydrated}return null}function Lf(t){if(fn(t)!==t)throw Error(S(188))}function p1(t){var l=t.alternate;if(!l){if(l=fn(t),l===null)throw Error(S(188));return l!==t?null:t}for(var e=t,a=l;;){var n=e.return;if(n===null)break;var u=n.alternate;if(u===null){if(a=n.return,a!==null){e=a;continue}break}if(n.child===u.child){for(u=n.child;u;){if(u===e)return Lf(n),t;if(u===a)return Lf(n),l;u=u.sibling}throw Error(S(188))}if(e.return!==a.return)e=n,a=u;else{for(var i=!1,c=n.child;c;){if(c===e){i=!0,e=n,a=u;break}if(c===a){i=!0,a=n,e=u;break}c=c.sibling}if(!i){for(c=u.child;c;){if(c===e){i=!0,e=u,a=n;break}if(c===a){i=!0,a=u,e=n;break}c=c.sibling}if(!i)throw Error(S(189))}}if(e.alternate!==a)throw Error(S(190))}if(e.tag!==3)throw Error(S(188));return e.stateNode.current===e?t:l}function Ko(t){var l=t.tag;if(l===5||l===26||l===27||l===6)return t;for(t=t.child;t!==null;){if(l=Ko(t),l!==null)return l;t=t.sibling}return null}var F=Object.assign,b1=Symbol.for("react.element"),zn=Symbol.for("react.transitional.element"),Oa=Symbol.for("react.portal"),Re=Symbol.for("react.fragment"),Jo=Symbol.for("react.strict_mode"),wi=Symbol.for("react.profiler"),Wo=Symbol.for("react.consumer"),xl=Symbol.for("react.context"),Xc=Symbol.for("react.forward_ref"),Xi=Symbol.for("react.suspense"),Zi=Symbol.for("react.suspense_list"),Zc=Symbol.for("react.memo"),Cl=Symbol.for("react.lazy"),Yi=Symbol.for("react.activity"),S1=Symbol.for("react.memo_cache_sentinel"),Qf=Symbol.iterator;function ba(t){return t===null||typeof t!="object"?null:(t=Qf&&t[Qf]||t["@@iterator"],typeof t=="function"?t:null)}var z1=Symbol.for("react.client.reference");function Gi(t){if(t==null)return null;if(typeof t=="function")return t.$$typeof===z1?null:t.displayName||t.name||null;if(typeof t=="string")return t;switch(t){case Re:return"Fragment";case wi:return"Profiler";case Jo:return"StrictMode";case Xi:return"Suspense";case Zi:return"SuspenseList";case Yi:return"Activity"}if(typeof t=="object")switch(t.$$typeof){case Oa:return"Portal";case xl:return t.displayName||"Context";case Wo:return(t._context.displayName||"Context")+".Consumer";case Xc:var l=t.render;return t=t.displayName,t||(t=l.displayName||l.name||"",t=t!==""?"ForwardRef("+t+")":"ForwardRef"),t;case Zc:return l=t.displayName||null,l!==null?l:Gi(t.type)||"Memo";case Cl:l=t._payload,t=t._init;try{return Gi(t(l))}catch{}}return null}var ja=Array.isArray,D=Go.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,X=x1.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,ye={pending:!1,data:null,method:null,action:null},Li=[],qe=-1;function fl(t){return{current:t}}function vt(t){0>qe||(t.current=Li[qe],Li[qe]=null,qe--)}function V(t,l){qe++,Li[qe]=t.current,t.current=l}var cl=fl(null),Va=fl(null),Gl=fl(null),tu=fl(null);function lu(t,l){switch(V(Gl,l),V(Va,t),V(cl,null),l.nodeType){case 9:case 11:t=(t=l.documentElement)&&(t=t.namespaceURI)?Is(t):0;break;default:if(t=l.tagName,l=l.namespaceURI)l=Is(l),t=v0(l,t);else switch(t){case"svg":t=1;break;case"math":t=2;break;default:t=0}}vt(cl),V(cl,t)}function la(){vt(cl),vt(Va),vt(Gl)}function Qi(t){t.memoizedState!==null&&V(tu,t);var l=cl.current,e=v0(l,t.type);l!==e&&(V(Va,t),V(cl,e))}function eu(t){Va.current===t&&(vt(cl),vt(Va)),tu.current===t&&(vt(tu),nn._currentValue=ye)}var Wu,Vf;function se(t){if(Wu===void 0)try{throw Error()}catch(e){var l=e.stack.trim().match(/\n( *(at )?)/);Wu=l&&l[1]||"",Vf=-1<e.stack.indexOf(`
+    at`)?" (<anonymous>)":-1<e.stack.indexOf("@")?"@unknown:0:0":""}return`
+`+Wu+t+Vf}var Fu=!1;function Iu(t,l){if(!t||Fu)return"";Fu=!0;var e=Error.prepareStackTrace;Error.prepareStackTrace=void 0;try{var a={DetermineComponentFrameRoot:function(){try{if(l){var v=function(){throw Error()};if(Object.defineProperty(v.prototype,"props",{set:function(){throw Error()}}),typeof Reflect=="object"&&Reflect.construct){try{Reflect.construct(v,[])}catch(g){var d=g}Reflect.construct(t,[],v)}else{try{v.call()}catch(g){d=g}t.call(v.prototype)}}else{try{throw Error()}catch(g){d=g}(v=t())&&typeof v.catch=="function"&&v.catch(function(){})}}catch(g){if(g&&d&&typeof g.stack=="string")return[g.stack,d.stack]}return[null,null]}};a.DetermineComponentFrameRoot.displayName="DetermineComponentFrameRoot";var n=Object.getOwnPropertyDescriptor(a.DetermineComponentFrameRoot,"name");n&&n.configurable&&Object.defineProperty(a.DetermineComponentFrameRoot,"name",{value:"DetermineComponentFrameRoot"});var u=a.DetermineComponentFrameRoot(),i=u[0],c=u[1];if(i&&c){var f=i.split(`
+`),r=c.split(`
+`);for(n=a=0;a<f.length&&!f[a].includes("DetermineComponentFrameRoot");)a++;for(;n<r.length&&!r[n].includes("DetermineComponentFrameRoot");)n++;if(a===f.length||n===r.length)for(a=f.length-1,n=r.length-1;1<=a&&0<=n&&f[a]!==r[n];)n--;for(;1<=a&&0<=n;a--,n--)if(f[a]!==r[n]){if(a!==1||n!==1)do if(a--,n--,0>n||f[a]!==r[n]){var y=`
+`+f[a].replace(" at new "," at ");return t.displayName&&y.includes("<anonymous>")&&(y=y.replace("<anonymous>",t.displayName)),y}while(1<=a&&0<=n);break}}}finally{Fu=!1,Error.prepareStackTrace=e}return(e=t?t.displayName||t.name:"")?se(e):""}function E1(t,l){switch(t.tag){case 26:case 27:case 5:return se(t.type);case 16:return se("Lazy");case 13:return t.child!==l&&l!==null?se("Suspense Fallback"):se("Suspense");case 19:return se("SuspenseList");case 0:case 15:return Iu(t.type,!1);case 11:return Iu(t.type.render,!1);case 1:return Iu(t.type,!0);case 31:return se("Activity");default:return""}}function Kf(t){try{var l="",e=null;do l+=E1(t,e),e=t,t=t.return;while(t);return l}catch(a){return`
+Error generating stack: `+a.message+`
+`+a.stack}}var Vi=Object.prototype.hasOwnProperty,Yc=yt.unstable_scheduleCallback,Pu=yt.unstable_cancelCallback,T1=yt.unstable_shouldYield,A1=yt.unstable_requestPaint,Ht=yt.unstable_now,$1=yt.unstable_getCurrentPriorityLevel,Fo=yt.unstable_ImmediatePriority,Io=yt.unstable_UserBlockingPriority,au=yt.unstable_NormalPriority,M1=yt.unstable_LowPriority,Po=yt.unstable_IdlePriority,O1=yt.log,j1=yt.unstable_setDisableYieldValue,sn=null,Bt=null;function Bl(t){if(typeof O1=="function"&&j1(t),Bt&&typeof Bt.setStrictMode=="function")try{Bt.setStrictMode(sn,t)}catch{}}var wt=Math.clz32?Math.clz32:k1,_1=Math.log,D1=Math.LN2;function k1(t){return t>>>=0,t===0?32:31-(_1(t)/D1|0)|0}var En=256,Tn=262144,An=4194304;function oe(t){var l=t&42;if(l!==0)return l;switch(t&-t){case 1:return 1;case 2:return 2;case 4:return 4;case 8:return 8;case 16:return 16;case 32:return 32;case 64:return 64;case 128:return 128;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:return t&261888;case 262144:case 524288:case 1048576:case 2097152:return t&3932160;case 4194304:case 8388608:case 16777216:case 33554432:return t&62914560;case 67108864:return 67108864;case 134217728:return 134217728;case 268435456:return 268435456;case 536870912:return 536870912;case 1073741824:return 0;default:return t}}function Cu(t,l,e){var a=t.pendingLanes;if(a===0)return 0;var n=0,u=t.suspendedLanes,i=t.pingedLanes;t=t.warmLanes;var c=a&134217727;return c!==0?(a=c&~u,a!==0?n=oe(a):(i&=c,i!==0?n=oe(i):e||(e=c&~t,e!==0&&(n=oe(e))))):(c=a&~u,c!==0?n=oe(c):i!==0?n=oe(i):e||(e=a&~t,e!==0&&(n=oe(e)))),n===0?0:l!==0&&l!==n&&!(l&u)&&(u=n&-n,e=l&-l,u>=e||u===32&&(e&4194048)!==0)?l:n}function on(t,l){return(t.pendingLanes&~(t.suspendedLanes&~t.pingedLanes)&l)===0}function C1(t,l){switch(t){case 1:case 2:case 4:case 8:case 64:return l+250;case 16:case 32:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:return l+5e3;case 4194304:case 8388608:case 16777216:case 33554432:return-1;case 67108864:case 134217728:case 268435456:case 536870912:case 1073741824:return-1;default:return-1}}function tr(){var t=An;return An<<=1,!(An&62914560)&&(An=4194304),t}function ti(t){for(var l=[],e=0;31>e;e++)l.push(t);return l}function rn(t,l){t.pendingLanes|=l,l!==268435456&&(t.suspendedLanes=0,t.pingedLanes=0,t.warmLanes=0)}function N1(t,l,e,a,n,u){var i=t.pendingLanes;t.pendingLanes=e,t.suspendedLanes=0,t.pingedLanes=0,t.warmLanes=0,t.expiredLanes&=e,t.entangledLanes&=e,t.errorRecoveryDisabledLanes&=e,t.shellSuspendCounter=0;var c=t.entanglements,f=t.expirationTimes,r=t.hiddenUpdates;for(e=i&~e;0<e;){var y=31-wt(e),v=1<<y;c[y]=0,f[y]=-1;var d=r[y];if(d!==null)for(r[y]=null,y=0;y<d.length;y++){var g=d[y];g!==null&&(g.lane&=-536870913)}e&=~v}a!==0&&lr(t,a,0),u!==0&&n===0&&t.tag!==0&&(t.suspendedLanes|=u&~(i&~l))}function lr(t,l,e){t.pendingLanes|=l,t.suspendedLanes&=~l;var a=31-wt(l);t.entangledLanes|=l,t.entanglements[a]=t.entanglements[a]|1073741824|e&261930}function er(t,l){var e=t.entangledLanes|=l;for(t=t.entanglements;e;){var a=31-wt(e),n=1<<a;n&l|t[a]&l&&(t[a]|=l),e&=~n}}function ar(t,l){var e=l&-l;return e=e&42?1:Gc(e),e&(t.suspendedLanes|l)?0:e}function Gc(t){switch(t){case 2:t=1;break;case 8:t=4;break;case 32:t=16;break;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:case 4194304:case 8388608:case 16777216:case 33554432:t=128;break;case 268435456:t=134217728;break;default:t=0}return t}function Lc(t){return t&=-t,2<t?8<t?t&134217727?32:268435456:8:2}function nr(){var t=X.p;return t!==0?t:(t=window.event,t===void 0?32:M0(t.type))}function Jf(t,l){var e=X.p;try{return X.p=t,l()}finally{X.p=e}}var ne=Math.random().toString(36).slice(2),pt="__reactFiber$"+ne,kt="__reactProps$"+ne,ya="__reactContainer$"+ne,Ki="__reactEvents$"+ne,U1="__reactListeners$"+ne,R1="__reactHandles$"+ne,Wf="__reactResources$"+ne,dn="__reactMarker$"+ne;function Qc(t){delete t[pt],delete t[kt],delete t[Ki],delete t[U1],delete t[R1]}function He(t){var l=t[pt];if(l)return l;for(var e=t.parentNode;e;){if(l=e[ya]||e[pt]){if(e=l.alternate,l.child!==null||e!==null&&e.child!==null)for(t=ao(t);t!==null;){if(e=t[pt])return e;t=ao(t)}return l}t=e,e=t.parentNode}return null}function ma(t){if(t=t[pt]||t[ya]){var l=t.tag;if(l===5||l===6||l===13||l===31||l===26||l===27||l===3)return t}return null}function _a(t){var l=t.tag;if(l===5||l===26||l===27||l===6)return t.stateNode;throw Error(S(33))}function Ke(t){var l=t[Wf];return l||(l=t[Wf]={hoistableStyles:new Map,hoistableScripts:new Map}),l}function gt(t){t[dn]=!0}var ur=new Set,ir={};function Ee(t,l){ea(t,l),ea(t+"Capture",l)}function ea(t,l){for(ir[t]=l,t=0;t<l.length;t++)ur.add(l[t])}var q1=RegExp("^[:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD][:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$"),Ff={},If={};function H1(t){return Vi.call(If,t)?!0:Vi.call(Ff,t)?!1:q1.test(t)?If[t]=!0:(Ff[t]=!0,!1)}function Bn(t,l,e){if(H1(l))if(e===null)t.removeAttribute(l);else{switch(typeof e){case"undefined":case"function":case"symbol":t.removeAttribute(l);return;case"boolean":var a=l.toLowerCase().slice(0,5);if(a!=="data-"&&a!=="aria-"){t.removeAttribute(l);return}}t.setAttribute(l,""+e)}}function $n(t,l,e){if(e===null)t.removeAttribute(l);else{switch(typeof e){case"undefined":case"function":case"symbol":case"boolean":t.removeAttribute(l);return}t.setAttribute(l,""+e)}}function rl(t,l,e,a){if(a===null)t.removeAttribute(e);else{switch(typeof a){case"undefined":case"function":case"symbol":case"boolean":t.removeAttribute(e);return}t.setAttributeNS(l,e,""+a)}}function Lt(t){switch(typeof t){case"bigint":case"boolean":case"number":case"string":case"undefined":return t;case"object":return t;default:return""}}function cr(t){var l=t.type;return(t=t.nodeName)&&t.toLowerCase()==="input"&&(l==="checkbox"||l==="radio")}function B1(t,l,e){var a=Object.getOwnPropertyDescriptor(t.constructor.prototype,l);if(!t.hasOwnProperty(l)&&typeof a<"u"&&typeof a.get=="function"&&typeof a.set=="function"){var n=a.get,u=a.set;return Object.defineProperty(t,l,{configurable:!0,get:function(){return n.call(this)},set:function(i){e=""+i,u.call(this,i)}}),Object.defineProperty(t,l,{enumerable:a.enumerable}),{getValue:function(){return e},setValue:function(i){e=""+i},stopTracking:function(){t._valueTracker=null,delete t[l]}}}}function Ji(t){if(!t._valueTracker){var l=cr(t)?"checked":"value";t._valueTracker=B1(t,l,""+t[l])}}function fr(t){if(!t)return!1;var l=t._valueTracker;if(!l)return!0;var e=l.getValue(),a="";return t&&(a=cr(t)?t.checked?"true":"false":t.value),t=a,t!==e?(l.setValue(t),!0):!1}function nu(t){if(t=t||(typeof document<"u"?document:void 0),typeof t>"u")return null;try{return t.activeElement||t.body}catch{return t.body}}var w1=/[\n"\\]/g;function Kt(t){return t.replace(w1,function(l){return"\\"+l.charCodeAt(0).toString(16)+" "})}function Wi(t,l,e,a,n,u,i,c){t.name="",i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"?t.type=i:t.removeAttribute("type"),l!=null?i==="number"?(l===0&&t.value===""||t.value!=l)&&(t.value=""+Lt(l)):t.value!==""+Lt(l)&&(t.value=""+Lt(l)):i!=="submit"&&i!=="reset"||t.removeAttribute("value"),l!=null?Fi(t,i,Lt(l)):e!=null?Fi(t,i,Lt(e)):a!=null&&t.removeAttribute("value"),n==null&&u!=null&&(t.defaultChecked=!!u),n!=null&&(t.checked=n&&typeof n!="function"&&typeof n!="symbol"),c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"?t.name=""+Lt(c):t.removeAttribute("name")}function sr(t,l,e,a,n,u,i,c){if(u!=null&&typeof u!="function"&&typeof u!="symbol"&&typeof u!="boolean"&&(t.type=u),l!=null||e!=null){if(!(u!=="submit"&&u!=="reset"||l!=null)){Ji(t);return}e=e!=null?""+Lt(e):"",l=l!=null?""+Lt(l):e,c||l===t.value||(t.value=l),t.defaultValue=l}a=a??n,a=typeof a!="function"&&typeof a!="symbol"&&!!a,t.checked=c?t.checked:!!a,t.defaultChecked=!!a,i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"&&(t.name=i),Ji(t)}function Fi(t,l,e){l==="number"&&nu(t.ownerDocument)===t||t.defaultValue===""+e||(t.defaultValue=""+e)}function Je(t,l,e,a){if(t=t.options,l){l={};for(var n=0;n<e.length;n++)l["$"+e[n]]=!0;for(e=0;e<t.length;e++)n=l.hasOwnProperty("$"+t[e].value),t[e].selected!==n&&(t[e].selected=n),n&&a&&(t[e].defaultSelected=!0)}else{for(e=""+Lt(e),l=null,n=0;n<t.length;n++){if(t[n].value===e){t[n].selected=!0,a&&(t[n].defaultSelected=!0);return}l!==null||t[n].disabled||(l=t[n])}l!==null&&(l.selected=!0)}}function or(t,l,e){if(l!=null&&(l=""+Lt(l),l!==t.value&&(t.value=l),e==null)){t.defaultValue!==l&&(t.defaultValue=l);return}t.defaultValue=e!=null?""+Lt(e):""}function rr(t,l,e,a){if(l==null){if(a!=null){if(e!=null)throw Error(S(92));if(ja(a)){if(1<a.length)throw Error(S(93));a=a[0]}e=a}e==null&&(e=""),l=e}e=Lt(l),t.defaultValue=e,a=t.textContent,a===e&&a!==""&&a!==null&&(t.value=a),Ji(t)}function aa(t,l){if(l){var e=t.firstChild;if(e&&e===t.lastChild&&e.nodeType===3){e.nodeValue=l;return}}t.textContent=l}var X1=new Set("animationIterationCount aspectRatio borderImageOutset borderImageSlice borderImageWidth boxFlex boxFlexGroup boxOrdinalGroup columnCount columns flex flexGrow flexPositive flexShrink flexNegative flexOrder gridArea gridRow gridRowEnd gridRowSpan gridRowStart gridColumn gridColumnEnd gridColumnSpan gridColumnStart fontWeight lineClamp lineHeight opacity order orphans scale tabSize widows zIndex zoom fillOpacity floodOpacity stopOpacity strokeDasharray strokeDashoffset strokeMiterlimit strokeOpacity strokeWidth MozAnimationIterationCount MozBoxFlex MozBoxFlexGroup MozLineClamp msAnimationIterationCount msFlex msZoom msFlexGrow msFlexNegative msFlexOrder msFlexPositive msFlexShrink msGridColumn msGridColumnSpan msGridRow msGridRowSpan WebkitAnimationIterationCount WebkitBoxFlex WebKitBoxFlexGroup WebkitBoxOrdinalGroup WebkitColumnCount WebkitColumns WebkitFlex WebkitFlexGrow WebkitFlexPositive WebkitFlexShrink WebkitLineClamp".split(" "));function Pf(t,l,e){var a=l.indexOf("--")===0;e==null||typeof e=="boolean"||e===""?a?t.setProperty(l,""):l==="float"?t.cssFloat="":t[l]="":a?t.setProperty(l,e):typeof e!="number"||e===0||X1.has(l)?l==="float"?t.cssFloat=e:t[l]=(""+e).trim():t[l]=e+"px"}function dr(t,l,e){if(l!=null&&typeof l!="object")throw Error(S(62));if(t=t.style,e!=null){for(var a in e)!e.hasOwnProperty(a)||l!=null&&l.hasOwnProperty(a)||(a.indexOf("--")===0?t.setProperty(a,""):a==="float"?t.cssFloat="":t[a]="");for(var n in l)a=l[n],l.hasOwnProperty(n)&&e[n]!==a&&Pf(t,n,a)}else for(var u in l)l.hasOwnProperty(u)&&Pf(t,u,l[u])}function Vc(t){if(t.indexOf("-")===-1)return!1;switch(t){case"annotation-xml":case"color-profile":case"font-face":case"font-face-src":case"font-face-uri":case"font-face-format":case"font-face-name":case"missing-glyph":return!1;default:return!0}}var Z1=new Map([["acceptCharset","accept-charset"],["htmlFor","for"],["httpEquiv","http-equiv"],["crossOrigin","crossorigin"],["accentHeight","accent-height"],["alignmentBaseline","alignment-baseline"],["arabicForm","arabic-form"],["baselineShift","baseline-shift"],["capHeight","cap-height"],["clipPath","clip-path"],["clipRule","clip-rule"],["colorInterpolation","color-interpolation"],["colorInterpolationFilters","color-interpolation-filters"],["colorProfile","color-profile"],["colorRendering","color-rendering"],["dominantBaseline","dominant-baseline"],["enableBackground","enable-background"],["fillOpacity","fill-opacity"],["fillRule","fill-rule"],["floodColor","flood-color"],["floodOpacity","flood-opacity"],["fontFamily","font-family"],["fontSize","font-size"],["fontSizeAdjust","font-size-adjust"],["fontStretch","font-stretch"],["fontStyle","font-style"],["fontVariant","font-variant"],["fontWeight","font-weight"],["glyphName","glyph-name"],["glyphOrientationHorizontal","glyph-orientation-horizontal"],["glyphOrientationVertical","glyph-orientation-vertical"],["horizAdvX","horiz-adv-x"],["horizOriginX","horiz-origin-x"],["imageRendering","image-rendering"],["letterSpacing","letter-spacing"],["lightingColor","lighting-color"],["markerEnd","marker-end"],["markerMid","marker-mid"],["markerStart","marker-start"],["overlinePosition","overline-position"],["overlineThickness","overline-thickness"],["paintOrder","paint-order"],["panose-1","panose-1"],["pointerEvents","pointer-events"],["renderingIntent","rendering-intent"],["shapeRendering","shape-rendering"],["stopColor","stop-color"],["stopOpacity","stop-opacity"],["strikethroughPosition","strikethrough-position"],["strikethroughThickness","strikethrough-thickness"],["strokeDasharray","stroke-dasharray"],["strokeDashoffset","stroke-dashoffset"],["strokeLinecap","stroke-linecap"],["strokeLinejoin","stroke-linejoin"],["strokeMiterlimit","stroke-miterlimit"],["strokeOpacity","stroke-opacity"],["strokeWidth","stroke-width"],["textAnchor","text-anchor"],["textDecoration","text-decoration"],["textRendering","text-rendering"],["transformOrigin","transform-origin"],["underlinePosition","underline-position"],["underlineThickness","underline-thickness"],["unicodeBidi","unicode-bidi"],["unicodeRange","unicode-range"],["unitsPerEm","units-per-em"],["vAlphabetic","v-alphabetic"],["vHanging","v-hanging"],["vIdeographic","v-ideographic"],["vMathematical","v-mathematical"],["vectorEffect","vector-effect"],["vertAdvY","vert-adv-y"],["vertOriginX","vert-origin-x"],["vertOriginY","vert-origin-y"],["wordSpacing","word-spacing"],["writingMode","writing-mode"],["xmlnsXlink","xmlns:xlink"],["xHeight","x-height"]]),Y1=/^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i;function wn(t){return Y1.test(""+t)?"javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')":t}function pl(){}var Ii=null;function Kc(t){return t=t.target||t.srcElement||window,t.correspondingUseElement&&(t=t.correspondingUseElement),t.nodeType===3?t.parentNode:t}var Be=null,We=null;function ts(t){var l=ma(t);if(l&&(t=l.stateNode)){var e=t[kt]||null;t:switch(t=l.stateNode,l.type){case"input":if(Wi(t,e.value,e.defaultValue,e.defaultValue,e.checked,e.defaultChecked,e.type,e.name),l=e.name,e.type==="radio"&&l!=null){for(e=t;e.parentNode;)e=e.parentNode;for(e=e.querySelectorAll('input[name="'+Kt(""+l)+'"][type="radio"]'),l=0;l<e.length;l++){var a=e[l];if(a!==t&&a.form===t.form){var n=a[kt]||null;if(!n)throw Error(S(90));Wi(a,n.value,n.defaultValue,n.defaultValue,n.checked,n.defaultChecked,n.type,n.name)}}for(l=0;l<e.length;l++)a=e[l],a.form===t.form&&fr(a)}break t;case"textarea":or(t,e.value,e.defaultValue);break t;case"select":l=e.value,l!=null&&Je(t,!!e.multiple,l,!1)}}}var li=!1;function yr(t,l,e){if(li)return t(l,e);li=!0;try{var a=t(l);return a}finally{if(li=!1,(Be!==null||We!==null)&&(Lu(),Be&&(l=Be,t=We,We=Be=null,ts(l),t)))for(l=0;l<t.length;l++)ts(t[l])}}function Ka(t,l){var e=t.stateNode;if(e===null)return null;var a=e[kt]||null;if(a===null)return null;e=a[l];t:switch(l){case"onClick":case"onClickCapture":case"onDoubleClick":case"onDoubleClickCapture":case"onMouseDown":case"onMouseDownCapture":case"onMouseMove":case"onMouseMoveCapture":case"onMouseUp":case"onMouseUpCapture":case"onMouseEnter":(a=!a.disabled)||(t=t.type,a=!(t==="button"||t==="input"||t==="select"||t==="textarea")),t=!a;break t;default:t=!1}if(t)return null;if(e&&typeof e!="function")throw Error(S(231,l,typeof e));return e}var Tl=!(typeof window>"u"||typeof window.document>"u"||typeof window.document.createElement>"u"),Pi=!1;if(Tl)try{var Sa={};Object.defineProperty(Sa,"passive",{get:function(){Pi=!0}}),window.addEventListener("test",Sa,Sa),window.removeEventListener("test",Sa,Sa)}catch{Pi=!1}var wl=null,Jc=null,Xn=null;function mr(){if(Xn)return Xn;var t,l=Jc,e=l.length,a,n="value"in wl?wl.value:wl.textContent,u=n.length;for(t=0;t<e&&l[t]===n[t];t++);var i=e-t;for(a=1;a<=i&&l[e-a]===n[u-a];a++);return Xn=n.slice(t,1<a?1-a:void 0)}function Zn(t){var l=t.keyCode;return"charCode"in t?(t=t.charCode,t===0&&l===13&&(t=13)):t=l,t===10&&(t=13),32<=t||t===13?t:0}function Mn(){return!0}function ls(){return!1}function Ct(t){function l(e,a,n,u,i){this._reactName=e,this._targetInst=n,this.type=a,this.nativeEvent=u,this.target=i,this.currentTarget=null;for(var c in t)t.hasOwnProperty(c)&&(e=t[c],this[c]=e?e(u):u[c]);return this.isDefaultPrevented=(u.defaultPrevented!=null?u.defaultPrevented:u.returnValue===!1)?Mn:ls,this.isPropagationStopped=ls,this}return F(l.prototype,{preventDefault:function(){this.defaultPrevented=!0;var e=this.nativeEvent;e&&(e.preventDefault?e.preventDefault():typeof e.returnValue!="unknown"&&(e.returnValue=!1),this.isDefaultPrevented=Mn)},stopPropagation:function(){var e=this.nativeEvent;e&&(e.stopPropagation?e.stopPropagation():typeof e.cancelBubble!="unknown"&&(e.cancelBubble=!0),this.isPropagationStopped=Mn)},persist:function(){},isPersistent:Mn}),l}var Te={eventPhase:0,bubbles:0,cancelable:0,timeStamp:function(t){return t.timeStamp||Date.now()},defaultPrevented:0,isTrusted:0},Nu=Ct(Te),yn=F({},Te,{view:0,detail:0}),G1=Ct(yn),ei,ai,za,Uu=F({},yn,{screenX:0,screenY:0,clientX:0,clientY:0,pageX:0,pageY:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,getModifierState:Wc,button:0,buttons:0,relatedTarget:function(t){return t.relatedTarget===void 0?t.fromElement===t.srcElement?t.toElement:t.fromElement:t.relatedTarget},movementX:function(t){return"movementX"in t?t.movementX:(t!==za&&(za&&t.type==="mousemove"?(ei=t.screenX-za.screenX,ai=t.screenY-za.screenY):ai=ei=0,za=t),ei)},movementY:function(t){return"movementY"in t?t.movementY:ai}}),es=Ct(Uu),L1=F({},Uu,{dataTransfer:0}),Q1=Ct(L1),V1=F({},yn,{relatedTarget:0}),ni=Ct(V1),K1=F({},Te,{animationName:0,elapsedTime:0,pseudoElement:0}),J1=Ct(K1),W1=F({},Te,{clipboardData:function(t){return"clipboardData"in t?t.clipboardData:window.clipboardData}}),F1=Ct(W1),I1=F({},Te,{data:0}),as=Ct(I1),P1={Esc:"Escape",Spacebar:" ",Left:"ArrowLeft",Up:"ArrowUp",Right:"ArrowRight",Down:"ArrowDown",Del:"Delete",Win:"OS",Menu:"ContextMenu",Apps:"ContextMenu",Scroll:"ScrollLock",MozPrintableKey:"Unidentified"},ty={8:"Backspace",9:"Tab",12:"Clear",13:"Enter",16:"Shift",17:"Control",18:"Alt",19:"Pause",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",45:"Insert",46:"Delete",112:"F1",113:"F2",114:"F3",115:"F4",116:"F5",117:"F6",118:"F7",119:"F8",120:"F9",121:"F10",122:"F11",123:"F12",144:"NumLock",145:"ScrollLock",224:"Meta"},ly={Alt:"altKey",Control:"ctrlKey",Meta:"metaKey",Shift:"shiftKey"};function ey(t){var l=this.nativeEvent;return l.getModifierState?l.getModifierState(t):(t=ly[t])?!!l[t]:!1}function Wc(){return ey}var ay=F({},yn,{key:function(t){if(t.key){var l=P1[t.key]||t.key;if(l!=="Unidentified")return l}return t.type==="keypress"?(t=Zn(t),t===13?"Enter":String.fromCharCode(t)):t.type==="keydown"||t.type==="keyup"?ty[t.keyCode]||"Unidentified":""},code:0,location:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,repeat:0,locale:0,getModifierState:Wc,charCode:function(t){return t.type==="keypress"?Zn(t):0},keyCode:function(t){return t.type==="keydown"||t.type==="keyup"?t.keyCode:0},which:function(t){return t.type==="keypress"?Zn(t):t.type==="keydown"||t.type==="keyup"?t.keyCode:0}}),ny=Ct(ay),uy=F({},Uu,{pointerId:0,width:0,height:0,pressure:0,tangentialPressure:0,tiltX:0,tiltY:0,twist:0,pointerType:0,isPrimary:0}),ns=Ct(uy),iy=F({},yn,{touches:0,targetTouches:0,changedTouches:0,altKey:0,metaKey:0,ctrlKey:0,shiftKey:0,getModifierState:Wc}),cy=Ct(iy),fy=F({},Te,{propertyName:0,elapsedTime:0,pseudoElement:0}),sy=Ct(fy),oy=F({},Uu,{deltaX:function(t){return"deltaX"in t?t.deltaX:"wheelDeltaX"in t?-t.wheelDeltaX:0},deltaY:function(t){return"deltaY"in t?t.deltaY:"wheelDeltaY"in t?-t.wheelDeltaY:"wheelDelta"in t?-t.wheelDelta:0},deltaZ:0,deltaMode:0}),ry=Ct(oy),dy=F({},Te,{newState:0,oldState:0}),yy=Ct(dy),my=[9,13,27,32],Fc=Tl&&"CompositionEvent"in window,Na=null;Tl&&"documentMode"in document&&(Na=document.documentMode);var gy=Tl&&"TextEvent"in window&&!Na,gr=Tl&&(!Fc||Na&&8<Na&&11>=Na),us=" ",is=!1;function vr(t,l){switch(t){case"keyup":return my.indexOf(l.keyCode)!==-1;case"keydown":return l.keyCode!==229;case"keypress":case"mousedown":case"focusout":return!0;default:return!1}}function hr(t){return t=t.detail,typeof t=="object"&&"data"in t?t.data:null}var we=!1;function vy(t,l){switch(t){case"compositionend":return hr(l);case"keypress":return l.which!==32?null:(is=!0,us);case"textInput":return t=l.data,t===us&&is?null:t;default:return null}}function hy(t,l){if(we)return t==="compositionend"||!Fc&&vr(t,l)?(t=mr(),Xn=Jc=wl=null,we=!1,t):null;switch(t){case"paste":return null;case"keypress":if(!(l.ctrlKey||l.altKey||l.metaKey)||l.ctrlKey&&l.altKey){if(l.char&&1<l.char.length)return l.char;if(l.which)return String.fromCharCode(l.which)}return null;case"compositionend":return gr&&l.locale!=="ko"?null:l.data;default:return null}}var xy={color:!0,date:!0,datetime:!0,"datetime-local":!0,email:!0,month:!0,number:!0,password:!0,range:!0,search:!0,tel:!0,text:!0,time:!0,url:!0,week:!0};function cs(t){var l=t&&t.nodeName&&t.nodeName.toLowerCase();return l==="input"?!!xy[t.type]:l==="textarea"}function xr(t,l,e,a){Be?We?We.push(a):We=[a]:Be=a,l=zu(l,"onChange"),0<l.length&&(e=new Nu("onChange","change",null,e,a),t.push({event:e,listeners:l}))}var Ua=null,Ja=null;function py(t){y0(t,0)}function Ru(t){var l=_a(t);if(fr(l))return t}function fs(t,l){if(t==="change")return l}var pr=!1;if(Tl){var ui;if(Tl){var ii="oninput"in document;if(!ii){var ss=document.createElement("div");ss.setAttribute("oninput","return;"),ii=typeof ss.oninput=="function"}ui=ii}else ui=!1;pr=ui&&(!document.documentMode||9<document.documentMode)}function os(){Ua&&(Ua.detachEvent("onpropertychange",br),Ja=Ua=null)}function br(t){if(t.propertyName==="value"&&Ru(Ja)){var l=[];xr(l,Ja,t,Kc(t)),yr(py,l)}}function by(t,l,e){t==="focusin"?(os(),Ua=l,Ja=e,Ua.attachEvent("onpropertychange",br)):t==="focusout"&&os()}function Sy(t){if(t==="selectionchange"||t==="keyup"||t==="keydown")return Ru(Ja)}function zy(t,l){if(t==="click")return Ru(l)}function Ey(t,l){if(t==="input"||t==="change")return Ru(l)}function Ty(t,l){return t===l&&(t!==0||1/t===1/l)||t!==t&&l!==l}var Zt=typeof Object.is=="function"?Object.is:Ty;function Wa(t,l){if(Zt(t,l))return!0;if(typeof t!="object"||t===null||typeof l!="object"||l===null)return!1;var e=Object.keys(t),a=Object.keys(l);if(e.length!==a.length)return!1;for(a=0;a<e.length;a++){var n=e[a];if(!Vi.call(l,n)||!Zt(t[n],l[n]))return!1}return!0}function rs(t){for(;t&&t.firstChild;)t=t.firstChild;return t}function ds(t,l){var e=rs(t);t=0;for(var a;e;){if(e.nodeType===3){if(a=t+e.textContent.length,t<=l&&a>=l)return{node:e,offset:l-t};t=a}t:{for(;e;){if(e.nextSibling){e=e.nextSibling;break t}e=e.parentNode}e=void 0}e=rs(e)}}function Sr(t,l){return t&&l?t===l?!0:t&&t.nodeType===3?!1:l&&l.nodeType===3?Sr(t,l.parentNode):"contains"in t?t.contains(l):t.compareDocumentPosition?!!(t.compareDocumentPosition(l)&16):!1:!1}function zr(t){t=t!=null&&t.ownerDocument!=null&&t.ownerDocument.defaultView!=null?t.ownerDocument.defaultView:window;for(var l=nu(t.document);l instanceof t.HTMLIFrameElement;){try{var e=typeof l.contentWindow.location.href=="string"}catch{e=!1}if(e)t=l.contentWindow;else break;l=nu(t.document)}return l}function Ic(t){var l=t&&t.nodeName&&t.nodeName.toLowerCase();return l&&(l==="input"&&(t.type==="text"||t.type==="search"||t.type==="tel"||t.type==="url"||t.type==="password")||l==="textarea"||t.contentEditable==="true")}var Ay=Tl&&"documentMode"in document&&11>=document.documentMode,Xe=null,tc=null,Ra=null,lc=!1;function ys(t,l,e){var a=e.window===e?e.document:e.nodeType===9?e:e.ownerDocument;lc||Xe==null||Xe!==nu(a)||(a=Xe,"selectionStart"in a&&Ic(a)?a={start:a.selectionStart,end:a.selectionEnd}:(a=(a.ownerDocument&&a.ownerDocument.defaultView||window).getSelection(),a={anchorNode:a.anchorNode,anchorOffset:a.anchorOffset,focusNode:a.focusNode,focusOffset:a.focusOffset}),Ra&&Wa(Ra,a)||(Ra=a,a=zu(tc,"onSelect"),0<a.length&&(l=new Nu("onSelect","select",null,l,e),t.push({event:l,listeners:a}),l.target=Xe)))}function fe(t,l){var e={};return e[t.toLowerCase()]=l.toLowerCase(),e["Webkit"+t]="webkit"+l,e["Moz"+t]="moz"+l,e}var Ze={animationend:fe("Animation","AnimationEnd"),animationiteration:fe("Animation","AnimationIteration"),animationstart:fe("Animation","AnimationStart"),transitionrun:fe("Transition","TransitionRun"),transitionstart:fe("Transition","TransitionStart"),transitioncancel:fe("Transition","TransitionCancel"),transitionend:fe("Transition","TransitionEnd")},ci={},Er={};Tl&&(Er=document.createElement("div").style,"AnimationEvent"in window||(delete Ze.animationend.animation,delete Ze.animationiteration.animation,delete Ze.animationstart.animation),"TransitionEvent"in window||delete Ze.transitionend.transition);function Ae(t){if(ci[t])return ci[t];if(!Ze[t])return t;var l=Ze[t],e;for(e in l)if(l.hasOwnProperty(e)&&e in Er)return ci[t]=l[e];return t}var Tr=Ae("animationend"),Ar=Ae("animationiteration"),$r=Ae("animationstart"),$y=Ae("transitionrun"),My=Ae("transitionstart"),Oy=Ae("transitioncancel"),Mr=Ae("transitionend"),Or=new Map,ec="abort auxClick beforeToggle cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel".split(" ");ec.push("scrollEnd");function el(t,l){Or.set(t,l),Ee(l,[t])}var uu=typeof reportError=="function"?reportError:function(t){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var l=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof t=="object"&&t!==null&&typeof t.message=="string"?String(t.message):String(t),error:t});if(!window.dispatchEvent(l))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",t);return}console.error(t)},Gt=[],Ye=0,Pc=0;function qu(){for(var t=Ye,l=Pc=Ye=0;l<t;){var e=Gt[l];Gt[l++]=null;var a=Gt[l];Gt[l++]=null;var n=Gt[l];Gt[l++]=null;var u=Gt[l];if(Gt[l++]=null,a!==null&&n!==null){var i=a.pending;i===null?n.next=n:(n.next=i.next,i.next=n),a.pending=n}u!==0&&jr(e,n,u)}}function Hu(t,l,e,a){Gt[Ye++]=t,Gt[Ye++]=l,Gt[Ye++]=e,Gt[Ye++]=a,Pc|=a,t.lanes|=a,t=t.alternate,t!==null&&(t.lanes|=a)}function tf(t,l,e,a){return Hu(t,l,e,a),iu(t)}function $e(t,l){return Hu(t,null,null,l),iu(t)}function jr(t,l,e){t.lanes|=e;var a=t.alternate;a!==null&&(a.lanes|=e);for(var n=!1,u=t.return;u!==null;)u.childLanes|=e,a=u.alternate,a!==null&&(a.childLanes|=e),u.tag===22&&(t=u.stateNode,t===null||t._visibility&1||(n=!0)),t=u,u=u.return;return t.tag===3?(u=t.stateNode,n&&l!==null&&(n=31-wt(e),t=u.hiddenUpdates,a=t[n],a===null?t[n]=[l]:a.push(l),l.lane=e|536870912),u):null}function iu(t){if(50<La)throw La=0,Ec=null,Error(S(185));for(var l=t.return;l!==null;)t=l,l=t.return;return t.tag===3?t.stateNode:null}var Ge={};function jy(t,l,e,a){this.tag=t,this.key=e,this.sibling=this.child=this.return=this.stateNode=this.type=this.elementType=null,this.index=0,this.refCleanup=this.ref=null,this.pendingProps=l,this.dependencies=this.memoizedState=this.updateQueue=this.memoizedProps=null,this.mode=a,this.subtreeFlags=this.flags=0,this.deletions=null,this.childLanes=this.lanes=0,this.alternate=null}function Rt(t,l,e,a){return new jy(t,l,e,a)}function lf(t){return t=t.prototype,!(!t||!t.isReactComponent)}function Sl(t,l){var e=t.alternate;return e===null?(e=Rt(t.tag,l,t.key,t.mode),e.elementType=t.elementType,e.type=t.type,e.stateNode=t.stateNode,e.alternate=t,t.alternate=e):(e.pendingProps=l,e.type=t.type,e.flags=0,e.subtreeFlags=0,e.deletions=null),e.flags=t.flags&65011712,e.childLanes=t.childLanes,e.lanes=t.lanes,e.child=t.child,e.memoizedProps=t.memoizedProps,e.memoizedState=t.memoizedState,e.updateQueue=t.updateQueue,l=t.dependencies,e.dependencies=l===null?null:{lanes:l.lanes,firstContext:l.firstContext},e.sibling=t.sibling,e.index=t.index,e.ref=t.ref,e.refCleanup=t.refCleanup,e}function _r(t,l){t.flags&=65011714;var e=t.alternate;return e===null?(t.childLanes=0,t.lanes=l,t.child=null,t.subtreeFlags=0,t.memoizedProps=null,t.memoizedState=null,t.updateQueue=null,t.dependencies=null,t.stateNode=null):(t.childLanes=e.childLanes,t.lanes=e.lanes,t.child=e.child,t.subtreeFlags=0,t.deletions=null,t.memoizedProps=e.memoizedProps,t.memoizedState=e.memoizedState,t.updateQueue=e.updateQueue,t.type=e.type,l=e.dependencies,t.dependencies=l===null?null:{lanes:l.lanes,firstContext:l.firstContext}),t}function Yn(t,l,e,a,n,u){var i=0;if(a=t,typeof t=="function")lf(t)&&(i=1);else if(typeof t=="string")i=Nm(t,e,cl.current)?26:t==="html"||t==="head"||t==="body"?27:5;else t:switch(t){case Yi:return t=Rt(31,e,l,n),t.elementType=Yi,t.lanes=u,t;case Re:return me(e.children,n,u,l);case Jo:i=8,n|=24;break;case wi:return t=Rt(12,e,l,n|2),t.elementType=wi,t.lanes=u,t;case Xi:return t=Rt(13,e,l,n),t.elementType=Xi,t.lanes=u,t;case Zi:return t=Rt(19,e,l,n),t.elementType=Zi,t.lanes=u,t;default:if(typeof t=="object"&&t!==null)switch(t.$$typeof){case xl:i=10;break t;case Wo:i=9;break t;case Xc:i=11;break t;case Zc:i=14;break t;case Cl:i=16,a=null;break t}i=29,e=Error(S(130,t===null?"null":typeof t,"")),a=null}return l=Rt(i,e,l,n),l.elementType=t,l.type=a,l.lanes=u,l}function me(t,l,e,a){return t=Rt(7,t,a,l),t.lanes=e,t}function fi(t,l,e){return t=Rt(6,t,null,l),t.lanes=e,t}function Dr(t){var l=Rt(18,null,null,0);return l.stateNode=t,l}function si(t,l,e){return l=Rt(4,t.children!==null?t.children:[],t.key,l),l.lanes=e,l.stateNode={containerInfo:t.containerInfo,pendingChildren:null,implementation:t.implementation},l}var ms=new WeakMap;function Jt(t,l){if(typeof t=="object"&&t!==null){var e=ms.get(t);return e!==void 0?e:(l={value:t,source:l,stack:Kf(l)},ms.set(t,l),l)}return{value:t,source:l,stack:Kf(l)}}var Le=[],Qe=0,cu=null,Fa=0,Qt=[],Vt=0,Pl=null,nl=1,ul="";function vl(t,l){Le[Qe++]=Fa,Le[Qe++]=cu,cu=t,Fa=l}function kr(t,l,e){Qt[Vt++]=nl,Qt[Vt++]=ul,Qt[Vt++]=Pl,Pl=t;var a=nl;t=ul;var n=32-wt(a)-1;a&=~(1<<n),e+=1;var u=32-wt(l)+n;if(30<u){var i=n-n%5;u=(a&(1<<i)-1).toString(32),a>>=i,n-=i,nl=1<<32-wt(l)+n|e<<n|a,ul=u+t}else nl=1<<u|e<<n|a,ul=t}function ef(t){t.return!==null&&(vl(t,1),kr(t,1,0))}function af(t){for(;t===cu;)cu=Le[--Qe],Le[Qe]=null,Fa=Le[--Qe],Le[Qe]=null;for(;t===Pl;)Pl=Qt[--Vt],Qt[Vt]=null,ul=Qt[--Vt],Qt[Vt]=null,nl=Qt[--Vt],Qt[Vt]=null}function Cr(t,l){Qt[Vt++]=nl,Qt[Vt++]=ul,Qt[Vt++]=Pl,nl=l.id,ul=l.overflow,Pl=t}var bt=null,J=null,B=!1,Ll=null,Wt=!1,ac=Error(S(519));function te(t){var l=Error(S(418,1<arguments.length&&arguments[1]!==void 0&&arguments[1]?"text":"HTML",""));throw Ia(Jt(l,t)),ac}function gs(t){var l=t.stateNode,e=t.type,a=t.memoizedProps;switch(l[pt]=t,l[kt]=a,e){case"dialog":R("cancel",l),R("close",l);break;case"iframe":case"object":case"embed":R("load",l);break;case"video":case"audio":for(e=0;e<en.length;e++)R(en[e],l);break;case"source":R("error",l);break;case"img":case"image":case"link":R("error",l),R("load",l);break;case"details":R("toggle",l);break;case"input":R("invalid",l),sr(l,a.value,a.defaultValue,a.checked,a.defaultChecked,a.type,a.name,!0);break;case"select":R("invalid",l);break;case"textarea":R("invalid",l),rr(l,a.value,a.defaultValue,a.children)}e=a.children,typeof e!="string"&&typeof e!="number"&&typeof e!="bigint"||l.textContent===""+e||a.suppressHydrationWarning===!0||g0(l.textContent,e)?(a.popover!=null&&(R("beforetoggle",l),R("toggle",l)),a.onScroll!=null&&R("scroll",l),a.onScrollEnd!=null&&R("scrollend",l),a.onClick!=null&&(l.onclick=pl),l=!0):l=!1,l||te(t,!0)}function vs(t){for(bt=t.return;bt;)switch(bt.tag){case 5:case 31:case 13:Wt=!1;return;case 27:case 3:Wt=!0;return;default:bt=bt.return}}function je(t){if(t!==bt)return!1;if(!B)return vs(t),B=!0,!1;var l=t.tag,e;if((e=l!==3&&l!==27)&&((e=l===5)&&(e=t.type,e=!(e!=="form"&&e!=="button")||Oc(t.type,t.memoizedProps)),e=!e),e&&J&&te(t),vs(t),l===13){if(t=t.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(S(317));J=eo(t)}else if(l===31){if(t=t.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(S(317));J=eo(t)}else l===27?(l=J,ue(t.type)?(t=kc,kc=null,J=t):J=l):J=bt?It(t.stateNode.nextSibling):null;return!0}function xe(){J=bt=null,B=!1}function oi(){var t=Ll;return t!==null&&(_t===null?_t=t:_t.push.apply(_t,t),Ll=null),t}function Ia(t){Ll===null?Ll=[t]:Ll.push(t)}var nc=fl(null),Me=null,bl=null;function Ul(t,l,e){V(nc,l._currentValue),l._currentValue=e}function zl(t){t._currentValue=nc.current,vt(nc)}function uc(t,l,e){for(;t!==null;){var a=t.alternate;if((t.childLanes&l)!==l?(t.childLanes|=l,a!==null&&(a.childLanes|=l)):a!==null&&(a.childLanes&l)!==l&&(a.childLanes|=l),t===e)break;t=t.return}}function ic(t,l,e,a){var n=t.child;for(n!==null&&(n.return=t);n!==null;){var u=n.dependencies;if(u!==null){var i=n.child;u=u.firstContext;t:for(;u!==null;){var c=u;u=n;for(var f=0;f<l.length;f++)if(c.context===l[f]){u.lanes|=e,c=u.alternate,c!==null&&(c.lanes|=e),uc(u.return,e,t),a||(i=null);break t}u=c.next}}else if(n.tag===18){if(i=n.return,i===null)throw Error(S(341));i.lanes|=e,u=i.alternate,u!==null&&(u.lanes|=e),uc(i,e,t),i=null}else i=n.child;if(i!==null)i.return=n;else for(i=n;i!==null;){if(i===t){i=null;break}if(n=i.sibling,n!==null){n.return=i.return,i=n;break}i=i.return}n=i}}function ga(t,l,e,a){t=null;for(var n=l,u=!1;n!==null;){if(!u){if(n.flags&524288)u=!0;else if(n.flags&262144)break}if(n.tag===10){var i=n.alternate;if(i===null)throw Error(S(387));if(i=i.memoizedProps,i!==null){var c=n.type;Zt(n.pendingProps.value,i.value)||(t!==null?t.push(c):t=[c])}}else if(n===tu.current){if(i=n.alternate,i===null)throw Error(S(387));i.memoizedState.memoizedState!==n.memoizedState.memoizedState&&(t!==null?t.push(nn):t=[nn])}n=n.return}t!==null&&ic(l,t,e,a),l.flags|=262144}function fu(t){for(t=t.firstContext;t!==null;){if(!Zt(t.context._currentValue,t.memoizedValue))return!0;t=t.next}return!1}function pe(t){Me=t,bl=null,t=t.dependencies,t!==null&&(t.firstContext=null)}function St(t){return Nr(Me,t)}function On(t,l){return Me===null&&pe(t),Nr(t,l)}function Nr(t,l){var e=l._currentValue;if(l={context:l,memoizedValue:e,next:null},bl===null){if(t===null)throw Error(S(308));bl=l,t.dependencies={lanes:0,firstContext:l},t.flags|=524288}else bl=bl.next=l;return e}var _y=typeof AbortController<"u"?AbortController:function(){var t=[],l=this.signal={aborted:!1,addEventListener:function(e,a){t.push(a)}};this.abort=function(){l.aborted=!0,t.forEach(function(e){return e()})}},Dy=yt.unstable_scheduleCallback,ky=yt.unstable_NormalPriority,ot={$$typeof:xl,Consumer:null,Provider:null,_currentValue:null,_currentValue2:null,_threadCount:0};function nf(){return{controller:new _y,data:new Map,refCount:0}}function mn(t){t.refCount--,t.refCount===0&&Dy(ky,function(){t.controller.abort()})}var qa=null,cc=0,na=0,Fe=null;function Cy(t,l){if(qa===null){var e=qa=[];cc=0,na=_f(),Fe={status:"pending",value:void 0,then:function(a){e.push(a)}}}return cc++,l.then(hs,hs),l}function hs(){if(--cc===0&&qa!==null){Fe!==null&&(Fe.status="fulfilled");var t=qa;qa=null,na=0,Fe=null;for(var l=0;l<t.length;l++)(0,t[l])()}}function Ny(t,l){var e=[],a={status:"pending",value:null,reason:null,then:function(n){e.push(n)}};return t.then(function(){a.status="fulfilled",a.value=l;for(var n=0;n<e.length;n++)(0,e[n])(l)},function(n){for(a.status="rejected",a.reason=n,n=0;n<e.length;n++)(0,e[n])(void 0)}),a}var xs=D.S;D.S=function(t,l){Kd=Ht(),typeof l=="object"&&l!==null&&typeof l.then=="function"&&Cy(t,l),xs!==null&&xs(t,l)};var ge=fl(null);function uf(){var t=ge.current;return t!==null?t:Q.pooledCache}function Gn(t,l){l===null?V(ge,ge.current):V(ge,l.pool)}function Ur(){var t=uf();return t===null?null:{parent:ot._currentValue,pool:t}}var va=Error(S(460)),cf=Error(S(474)),Bu=Error(S(542)),su={then:function(){}};function ps(t){return t=t.status,t==="fulfilled"||t==="rejected"}function Rr(t,l,e){switch(e=t[e],e===void 0?t.push(l):e!==l&&(l.then(pl,pl),l=e),l.status){case"fulfilled":return l.value;case"rejected":throw t=l.reason,Ss(t),t;default:if(typeof l.status=="string")l.then(pl,pl);else{if(t=Q,t!==null&&100<t.shellSuspendCounter)throw Error(S(482));t=l,t.status="pending",t.then(function(a){if(l.status==="pending"){var n=l;n.status="fulfilled",n.value=a}},function(a){if(l.status==="pending"){var n=l;n.status="rejected",n.reason=a}})}switch(l.status){case"fulfilled":return l.value;case"rejected":throw t=l.reason,Ss(t),t}throw ve=l,va}}function re(t){try{var l=t._init;return l(t._payload)}catch(e){throw e!==null&&typeof e=="object"&&typeof e.then=="function"?(ve=e,va):e}}var ve=null;function bs(){if(ve===null)throw Error(S(459));var t=ve;return ve=null,t}function Ss(t){if(t===va||t===Bu)throw Error(S(483))}var Ie=null,Pa=0;function jn(t){var l=Pa;return Pa+=1,Ie===null&&(Ie=[]),Rr(Ie,t,l)}function Ea(t,l){l=l.props.ref,t.ref=l!==void 0?l:null}function _n(t,l){throw l.$$typeof===b1?Error(S(525)):(t=Object.prototype.toString.call(l),Error(S(31,t==="[object Object]"?"object with keys {"+Object.keys(l).join(", ")+"}":t)))}function qr(t){function l(o,s){if(t){var m=o.deletions;m===null?(o.deletions=[s],o.flags|=16):m.push(s)}}function e(o,s){if(!t)return null;for(;s!==null;)l(o,s),s=s.sibling;return null}function a(o){for(var s=new Map;o!==null;)o.key!==null?s.set(o.key,o):s.set(o.index,o),o=o.sibling;return s}function n(o,s){return o=Sl(o,s),o.index=0,o.sibling=null,o}function u(o,s,m){return o.index=m,t?(m=o.alternate,m!==null?(m=m.index,m<s?(o.flags|=67108866,s):m):(o.flags|=67108866,s)):(o.flags|=1048576,s)}function i(o){return t&&o.alternate===null&&(o.flags|=67108866),o}function c(o,s,m,h){return s===null||s.tag!==6?(s=fi(m,o.mode,h),s.return=o,s):(s=n(s,m),s.return=o,s)}function f(o,s,m,h){var T=m.type;return T===Re?y(o,s,m.props.children,h,m.key):s!==null&&(s.elementType===T||typeof T=="object"&&T!==null&&T.$$typeof===Cl&&re(T)===s.type)?(s=n(s,m.props),Ea(s,m),s.return=o,s):(s=Yn(m.type,m.key,m.props,null,o.mode,h),Ea(s,m),s.return=o,s)}function r(o,s,m,h){return s===null||s.tag!==4||s.stateNode.containerInfo!==m.containerInfo||s.stateNode.implementation!==m.implementation?(s=si(m,o.mode,h),s.return=o,s):(s=n(s,m.children||[]),s.return=o,s)}function y(o,s,m,h,T){return s===null||s.tag!==7?(s=me(m,o.mode,h,T),s.return=o,s):(s=n(s,m),s.return=o,s)}function v(o,s,m){if(typeof s=="string"&&s!==""||typeof s=="number"||typeof s=="bigint")return s=fi(""+s,o.mode,m),s.return=o,s;if(typeof s=="object"&&s!==null){switch(s.$$typeof){case zn:return m=Yn(s.type,s.key,s.props,null,o.mode,m),Ea(m,s),m.return=o,m;case Oa:return s=si(s,o.mode,m),s.return=o,s;case Cl:return s=re(s),v(o,s,m)}if(ja(s)||ba(s))return s=me(s,o.mode,m,null),s.return=o,s;if(typeof s.then=="function")return v(o,jn(s),m);if(s.$$typeof===xl)return v(o,On(o,s),m);_n(o,s)}return null}function d(o,s,m,h){var T=s!==null?s.key:null;if(typeof m=="string"&&m!==""||typeof m=="number"||typeof m=="bigint")return T!==null?null:c(o,s,""+m,h);if(typeof m=="object"&&m!==null){switch(m.$$typeof){case zn:return m.key===T?f(o,s,m,h):null;case Oa:return m.key===T?r(o,s,m,h):null;case Cl:return m=re(m),d(o,s,m,h)}if(ja(m)||ba(m))return T!==null?null:y(o,s,m,h,null);if(typeof m.then=="function")return d(o,s,jn(m),h);if(m.$$typeof===xl)return d(o,s,On(o,m),h);_n(o,m)}return null}function g(o,s,m,h,T){if(typeof h=="string"&&h!==""||typeof h=="number"||typeof h=="bigint")return o=o.get(m)||null,c(s,o,""+h,T);if(typeof h=="object"&&h!==null){switch(h.$$typeof){case zn:return o=o.get(h.key===null?m:h.key)||null,f(s,o,h,T);case Oa:return o=o.get(h.key===null?m:h.key)||null,r(s,o,h,T);case Cl:return h=re(h),g(o,s,m,h,T)}if(ja(h)||ba(h))return o=o.get(m)||null,y(s,o,h,T,null);if(typeof h.then=="function")return g(o,s,m,jn(h),T);if(h.$$typeof===xl)return g(o,s,m,On(s,h),T);_n(s,h)}return null}function p(o,s,m,h){for(var T=null,M=null,E=s,j=s=0,$=null;E!==null&&j<m.length;j++){E.index>j?($=E,E=null):$=E.sibling;var O=d(o,E,m[j],h);if(O===null){E===null&&(E=$);break}t&&E&&O.alternate===null&&l(o,E),s=u(O,s,j),M===null?T=O:M.sibling=O,M=O,E=$}if(j===m.length)return e(o,E),B&&vl(o,j),T;if(E===null){for(;j<m.length;j++)E=v(o,m[j],h),E!==null&&(s=u(E,s,j),M===null?T=E:M.sibling=E,M=E);return B&&vl(o,j),T}for(E=a(E);j<m.length;j++)$=g(E,o,j,m[j],h),$!==null&&(t&&$.alternate!==null&&E.delete($.key===null?j:$.key),s=u($,s,j),M===null?T=$:M.sibling=$,M=$);return t&&E.forEach(function(I){return l(o,I)}),B&&vl(o,j),T}function b(o,s,m,h){if(m==null)throw Error(S(151));for(var T=null,M=null,E=s,j=s=0,$=null,O=m.next();E!==null&&!O.done;j++,O=m.next()){E.index>j?($=E,E=null):$=E.sibling;var I=d(o,E,O.value,h);if(I===null){E===null&&(E=$);break}t&&E&&I.alternate===null&&l(o,E),s=u(I,s,j),M===null?T=I:M.sibling=I,M=I,E=$}if(O.done)return e(o,E),B&&vl(o,j),T;if(E===null){for(;!O.done;j++,O=m.next())O=v(o,O.value,h),O!==null&&(s=u(O,s,j),M===null?T=O:M.sibling=O,M=O);return B&&vl(o,j),T}for(E=a(E);!O.done;j++,O=m.next())O=g(E,o,j,O.value,h),O!==null&&(t&&O.alternate!==null&&E.delete(O.key===null?j:O.key),s=u(O,s,j),M===null?T=O:M.sibling=O,M=O);return t&&E.forEach(function(lt){return l(o,lt)}),B&&vl(o,j),T}function z(o,s,m,h){if(typeof m=="object"&&m!==null&&m.type===Re&&m.key===null&&(m=m.props.children),typeof m=="object"&&m!==null){switch(m.$$typeof){case zn:t:{for(var T=m.key;s!==null;){if(s.key===T){if(T=m.type,T===Re){if(s.tag===7){e(o,s.sibling),h=n(s,m.props.children),h.return=o,o=h;break t}}else if(s.elementType===T||typeof T=="object"&&T!==null&&T.$$typeof===Cl&&re(T)===s.type){e(o,s.sibling),h=n(s,m.props),Ea(h,m),h.return=o,o=h;break t}e(o,s);break}else l(o,s);s=s.sibling}m.type===Re?(h=me(m.props.children,o.mode,h,m.key),h.return=o,o=h):(h=Yn(m.type,m.key,m.props,null,o.mode,h),Ea(h,m),h.return=o,o=h)}return i(o);case Oa:t:{for(T=m.key;s!==null;){if(s.key===T)if(s.tag===4&&s.stateNode.containerInfo===m.containerInfo&&s.stateNode.implementation===m.implementation){e(o,s.sibling),h=n(s,m.children||[]),h.return=o,o=h;break t}else{e(o,s);break}else l(o,s);s=s.sibling}h=si(m,o.mode,h),h.return=o,o=h}return i(o);case Cl:return m=re(m),z(o,s,m,h)}if(ja(m))return p(o,s,m,h);if(ba(m)){if(T=ba(m),typeof T!="function")throw Error(S(150));return m=T.call(m),b(o,s,m,h)}if(typeof m.then=="function")return z(o,s,jn(m),h);if(m.$$typeof===xl)return z(o,s,On(o,m),h);_n(o,m)}return typeof m=="string"&&m!==""||typeof m=="number"||typeof m=="bigint"?(m=""+m,s!==null&&s.tag===6?(e(o,s.sibling),h=n(s,m),h.return=o,o=h):(e(o,s),h=fi(m,o.mode,h),h.return=o,o=h),i(o)):e(o,s)}return function(o,s,m,h){try{Pa=0;var T=z(o,s,m,h);return Ie=null,T}catch(E){if(E===va||E===Bu)throw E;var M=Rt(29,E,null,o.mode);return M.lanes=h,M.return=o,M}finally{}}}var be=qr(!0),Hr=qr(!1),Nl=!1;function ff(t){t.updateQueue={baseState:t.memoizedState,firstBaseUpdate:null,lastBaseUpdate:null,shared:{pending:null,lanes:0,hiddenCallbacks:null},callbacks:null}}function fc(t,l){t=t.updateQueue,l.updateQueue===t&&(l.updateQueue={baseState:t.baseState,firstBaseUpdate:t.firstBaseUpdate,lastBaseUpdate:t.lastBaseUpdate,shared:t.shared,callbacks:null})}function Ql(t){return{lane:t,tag:0,payload:null,callback:null,next:null}}function Vl(t,l,e){var a=t.updateQueue;if(a===null)return null;if(a=a.shared,w&2){var n=a.pending;return n===null?l.next=l:(l.next=n.next,n.next=l),a.pending=l,l=iu(t),jr(t,null,e),l}return Hu(t,a,l,e),iu(t)}function Ha(t,l,e){if(l=l.updateQueue,l!==null&&(l=l.shared,(e&4194048)!==0)){var a=l.lanes;a&=t.pendingLanes,e|=a,l.lanes=e,er(t,e)}}function ri(t,l){var e=t.updateQueue,a=t.alternate;if(a!==null&&(a=a.updateQueue,e===a)){var n=null,u=null;if(e=e.firstBaseUpdate,e!==null){do{var i={lane:e.lane,tag:e.tag,payload:e.payload,callback:null,next:null};u===null?n=u=i:u=u.next=i,e=e.next}while(e!==null);u===null?n=u=l:u=u.next=l}else n=u=l;e={baseState:a.baseState,firstBaseUpdate:n,lastBaseUpdate:u,shared:a.shared,callbacks:a.callbacks},t.updateQueue=e;return}t=e.lastBaseUpdate,t===null?e.firstBaseUpdate=l:t.next=l,e.lastBaseUpdate=l}var sc=!1;function Ba(){if(sc){var t=Fe;if(t!==null)throw t}}function wa(t,l,e,a){sc=!1;var n=t.updateQueue;Nl=!1;var u=n.firstBaseUpdate,i=n.lastBaseUpdate,c=n.shared.pending;if(c!==null){n.shared.pending=null;var f=c,r=f.next;f.next=null,i===null?u=r:i.next=r,i=f;var y=t.alternate;y!==null&&(y=y.updateQueue,c=y.lastBaseUpdate,c!==i&&(c===null?y.firstBaseUpdate=r:c.next=r,y.lastBaseUpdate=f))}if(u!==null){var v=n.baseState;i=0,y=r=f=null,c=u;do{var d=c.lane&-536870913,g=d!==c.lane;if(g?(H&d)===d:(a&d)===d){d!==0&&d===na&&(sc=!0),y!==null&&(y=y.next={lane:0,tag:c.tag,payload:c.payload,callback:null,next:null});t:{var p=t,b=c;d=l;var z=e;switch(b.tag){case 1:if(p=b.payload,typeof p=="function"){v=p.call(z,v,d);break t}v=p;break t;case 3:p.flags=p.flags&-65537|128;case 0:if(p=b.payload,d=typeof p=="function"?p.call(z,v,d):p,d==null)break t;v=F({},v,d);break t;case 2:Nl=!0}}d=c.callback,d!==null&&(t.flags|=64,g&&(t.flags|=8192),g=n.callbacks,g===null?n.callbacks=[d]:g.push(d))}else g={lane:d,tag:c.tag,payload:c.payload,callback:c.callback,next:null},y===null?(r=y=g,f=v):y=y.next=g,i|=d;if(c=c.next,c===null){if(c=n.shared.pending,c===null)break;g=c,c=g.next,g.next=null,n.lastBaseUpdate=g,n.shared.pending=null}}while(!0);y===null&&(f=v),n.baseState=f,n.firstBaseUpdate=r,n.lastBaseUpdate=y,u===null&&(n.shared.lanes=0),ee|=i,t.lanes=i,t.memoizedState=v}}function Br(t,l){if(typeof t!="function")throw Error(S(191,t));t.call(l)}function wr(t,l){var e=t.callbacks;if(e!==null)for(t.callbacks=null,t=0;t<e.length;t++)Br(e[t],l)}var ua=fl(null),ou=fl(0);function zs(t,l){t=Ol,V(ou,t),V(ua,l),Ol=t|l.baseLanes}function oc(){V(ou,Ol),V(ua,ua.current)}function sf(){Ol=ou.current,vt(ua),vt(ou)}var Yt=fl(null),Ft=null;function Rl(t){var l=t.alternate;V(it,it.current&1),V(Yt,t),Ft===null&&(l===null||ua.current!==null||l.memoizedState!==null)&&(Ft=t)}function rc(t){V(it,it.current),V(Yt,t),Ft===null&&(Ft=t)}function Xr(t){t.tag===22?(V(it,it.current),V(Yt,t),Ft===null&&(Ft=t)):ql()}function ql(){V(it,it.current),V(Yt,Yt.current)}function Ut(t){vt(Yt),Ft===t&&(Ft=null),vt(it)}var it=fl(0);function ru(t){for(var l=t;l!==null;){if(l.tag===13){var e=l.memoizedState;if(e!==null&&(e=e.dehydrated,e===null||_c(e)||Dc(e)))return l}else if(l.tag===19&&(l.memoizedProps.revealOrder==="forwards"||l.memoizedProps.revealOrder==="backwards"||l.memoizedProps.revealOrder==="unstable_legacy-backwards"||l.memoizedProps.revealOrder==="together")){if(l.flags&128)return l}else if(l.child!==null){l.child.return=l,l=l.child;continue}if(l===t)break;for(;l.sibling===null;){if(l.return===null||l.return===t)return null;l=l.return}l.sibling.return=l.return,l=l.sibling}return null}var Al=0,C=null,L=null,ft=null,du=!1,Pe=!1,Se=!1,yu=0,tn=0,ta=null,Uy=0;function et(){throw Error(S(321))}function of(t,l){if(l===null)return!1;for(var e=0;e<l.length&&e<t.length;e++)if(!Zt(t[e],l[e]))return!1;return!0}function rf(t,l,e,a,n,u){return Al=u,C=l,l.memoizedState=null,l.updateQueue=null,l.lanes=0,D.H=t===null||t.memoizedState===null?xd:zf,Se=!1,u=e(a,n),Se=!1,Pe&&(u=Yr(l,e,a,n)),Zr(t),u}function Zr(t){D.H=ln;var l=L!==null&&L.next!==null;if(Al=0,ft=L=C=null,du=!1,tn=0,ta=null,l)throw Error(S(300));t===null||rt||(t=t.dependencies,t!==null&&fu(t)&&(rt=!0))}function Yr(t,l,e,a){C=t;var n=0;do{if(Pe&&(ta=null),tn=0,Pe=!1,25<=n)throw Error(S(301));if(n+=1,ft=L=null,t.updateQueue!=null){var u=t.updateQueue;u.lastEffect=null,u.events=null,u.stores=null,u.memoCache!=null&&(u.memoCache.index=0)}D.H=pd,u=l(e,a)}while(Pe);return u}function Ry(){var t=D.H,l=t.useState()[0];return l=typeof l.then=="function"?gn(l):l,t=t.useState()[0],(L!==null?L.memoizedState:null)!==t&&(C.flags|=1024),l}function df(){var t=yu!==0;return yu=0,t}function yf(t,l,e){l.updateQueue=t.updateQueue,l.flags&=-2053,t.lanes&=~e}function mf(t){if(du){for(t=t.memoizedState;t!==null;){var l=t.queue;l!==null&&(l.pending=null),t=t.next}du=!1}Al=0,ft=L=C=null,Pe=!1,tn=yu=0,ta=null}function Et(){var t={memoizedState:null,baseState:null,baseQueue:null,queue:null,next:null};return ft===null?C.memoizedState=ft=t:ft=ft.next=t,ft}function ct(){if(L===null){var t=C.alternate;t=t!==null?t.memoizedState:null}else t=L.next;var l=ft===null?C.memoizedState:ft.next;if(l!==null)ft=l,L=t;else{if(t===null)throw C.alternate===null?Error(S(467)):Error(S(310));L=t,t={memoizedState:L.memoizedState,baseState:L.baseState,baseQueue:L.baseQueue,queue:L.queue,next:null},ft===null?C.memoizedState=ft=t:ft=ft.next=t}return ft}function wu(){return{lastEffect:null,events:null,stores:null,memoCache:null}}function gn(t){var l=tn;return tn+=1,ta===null&&(ta=[]),t=Rr(ta,t,l),l=C,(ft===null?l.memoizedState:ft.next)===null&&(l=l.alternate,D.H=l===null||l.memoizedState===null?xd:zf),t}function Xu(t){if(t!==null&&typeof t=="object"){if(typeof t.then=="function")return gn(t);if(t.$$typeof===xl)return St(t)}throw Error(S(438,String(t)))}function gf(t){var l=null,e=C.updateQueue;if(e!==null&&(l=e.memoCache),l==null){var a=C.alternate;a!==null&&(a=a.updateQueue,a!==null&&(a=a.memoCache,a!=null&&(l={data:a.data.map(function(n){return n.slice()}),index:0})))}if(l==null&&(l={data:[],index:0}),e===null&&(e=wu(),C.updateQueue=e),e.memoCache=l,e=l.data[l.index],e===void 0)for(e=l.data[l.index]=Array(t),a=0;a<t;a++)e[a]=S1;return l.index++,e}function $l(t,l){return typeof l=="function"?l(t):l}function Ln(t){var l=ct();return vf(l,L,t)}function vf(t,l,e){var a=t.queue;if(a===null)throw Error(S(311));a.lastRenderedReducer=e;var n=t.baseQueue,u=a.pending;if(u!==null){if(n!==null){var i=n.next;n.next=u.next,u.next=i}l.baseQueue=n=u,a.pending=null}if(u=t.baseState,n===null)t.memoizedState=u;else{l=n.next;var c=i=null,f=null,r=l,y=!1;do{var v=r.lane&-536870913;if(v!==r.lane?(H&v)===v:(Al&v)===v){var d=r.revertLane;if(d===0)f!==null&&(f=f.next={lane:0,revertLane:0,gesture:null,action:r.action,hasEagerState:r.hasEagerState,eagerState:r.eagerState,next:null}),v===na&&(y=!0);else if((Al&d)===d){r=r.next,d===na&&(y=!0);continue}else v={lane:0,revertLane:r.revertLane,gesture:null,action:r.action,hasEagerState:r.hasEagerState,eagerState:r.eagerState,next:null},f===null?(c=f=v,i=u):f=f.next=v,C.lanes|=d,ee|=d;v=r.action,Se&&e(u,v),u=r.hasEagerState?r.eagerState:e(u,v)}else d={lane:v,revertLane:r.revertLane,gesture:r.gesture,action:r.action,hasEagerState:r.hasEagerState,eagerState:r.eagerState,next:null},f===null?(c=f=d,i=u):f=f.next=d,C.lanes|=v,ee|=v;r=r.next}while(r!==null&&r!==l);if(f===null?i=u:f.next=c,!Zt(u,t.memoizedState)&&(rt=!0,y&&(e=Fe,e!==null)))throw e;t.memoizedState=u,t.baseState=i,t.baseQueue=f,a.lastRenderedState=u}return n===null&&(a.lanes=0),[t.memoizedState,a.dispatch]}function di(t){var l=ct(),e=l.queue;if(e===null)throw Error(S(311));e.lastRenderedReducer=t;var a=e.dispatch,n=e.pending,u=l.memoizedState;if(n!==null){e.pending=null;var i=n=n.next;do u=t(u,i.action),i=i.next;while(i!==n);Zt(u,l.memoizedState)||(rt=!0),l.memoizedState=u,l.baseQueue===null&&(l.baseState=u),e.lastRenderedState=u}return[u,a]}function Gr(t,l,e){var a=C,n=ct(),u=B;if(u){if(e===void 0)throw Error(S(407));e=e()}else e=l();var i=!Zt((L||n).memoizedState,e);if(i&&(n.memoizedState=e,rt=!0),n=n.queue,hf(Vr.bind(null,a,n,t),[t]),n.getSnapshot!==l||i||ft!==null&&ft.memoizedState.tag&1){if(a.flags|=2048,ia(9,{destroy:void 0},Qr.bind(null,a,n,e,l),null),Q===null)throw Error(S(349));u||Al&127||Lr(a,l,e)}return e}function Lr(t,l,e){t.flags|=16384,t={getSnapshot:l,value:e},l=C.updateQueue,l===null?(l=wu(),C.updateQueue=l,l.stores=[t]):(e=l.stores,e===null?l.stores=[t]:e.push(t))}function Qr(t,l,e,a){l.value=e,l.getSnapshot=a,Kr(l)&&Jr(t)}function Vr(t,l,e){return e(function(){Kr(l)&&Jr(t)})}function Kr(t){var l=t.getSnapshot;t=t.value;try{var e=l();return!Zt(t,e)}catch{return!0}}function Jr(t){var l=$e(t,2);l!==null&&Dt(l,t,2)}function dc(t){var l=Et();if(typeof t=="function"){var e=t;if(t=e(),Se){Bl(!0);try{e()}finally{Bl(!1)}}}return l.memoizedState=l.baseState=t,l.queue={pending:null,lanes:0,dispatch:null,lastRenderedReducer:$l,lastRenderedState:t},l}function Wr(t,l,e,a){return t.baseState=e,vf(t,L,typeof a=="function"?a:$l)}function qy(t,l,e,a,n){if(Yu(t))throw Error(S(485));if(t=l.action,t!==null){var u={payload:n,action:t,next:null,isTransition:!0,status:"pending",value:null,reason:null,listeners:[],then:function(i){u.listeners.push(i)}};D.T!==null?e(!0):u.isTransition=!1,a(u),e=l.pending,e===null?(u.next=l.pending=u,Fr(l,u)):(u.next=e.next,l.pending=e.next=u)}}function Fr(t,l){var e=l.action,a=l.payload,n=t.state;if(l.isTransition){var u=D.T,i={};D.T=i;try{var c=e(n,a),f=D.S;f!==null&&f(i,c),Es(t,l,c)}catch(r){yc(t,l,r)}finally{u!==null&&i.types!==null&&(u.types=i.types),D.T=u}}else try{u=e(n,a),Es(t,l,u)}catch(r){yc(t,l,r)}}function Es(t,l,e){e!==null&&typeof e=="object"&&typeof e.then=="function"?e.then(function(a){Ts(t,l,a)},function(a){return yc(t,l,a)}):Ts(t,l,e)}function Ts(t,l,e){l.status="fulfilled",l.value=e,Ir(l),t.state=e,l=t.pending,l!==null&&(e=l.next,e===l?t.pending=null:(e=e.next,l.next=e,Fr(t,e)))}function yc(t,l,e){var a=t.pending;if(t.pending=null,a!==null){a=a.next;do l.status="rejected",l.reason=e,Ir(l),l=l.next;while(l!==a)}t.action=null}function Ir(t){t=t.listeners;for(var l=0;l<t.length;l++)(0,t[l])()}function Pr(t,l){return l}function As(t,l){if(B){var e=Q.formState;if(e!==null){t:{var a=C;if(B){if(J){l:{for(var n=J,u=Wt;n.nodeType!==8;){if(!u){n=null;break l}if(n=It(n.nextSibling),n===null){n=null;break l}}u=n.data,n=u==="F!"||u==="F"?n:null}if(n){J=It(n.nextSibling),a=n.data==="F!";break t}}te(a)}a=!1}a&&(l=e[0])}}return e=Et(),e.memoizedState=e.baseState=l,a={pending:null,lanes:0,dispatch:null,lastRenderedReducer:Pr,lastRenderedState:l},e.queue=a,e=gd.bind(null,C,a),a.dispatch=e,a=dc(!1),u=Sf.bind(null,C,!1,a.queue),a=Et(),n={state:l,dispatch:null,action:t,pending:null},a.queue=n,e=qy.bind(null,C,n,u,e),n.dispatch=e,a.memoizedState=t,[l,e,!1]}function $s(t){var l=ct();return td(l,L,t)}function td(t,l,e){if(l=vf(t,l,Pr)[0],t=Ln($l)[0],typeof l=="object"&&l!==null&&typeof l.then=="function")try{var a=gn(l)}catch(i){throw i===va?Bu:i}else a=l;l=ct();var n=l.queue,u=n.dispatch;return e!==l.memoizedState&&(C.flags|=2048,ia(9,{destroy:void 0},Hy.bind(null,n,e),null)),[a,u,t]}function Hy(t,l){t.action=l}function Ms(t){var l=ct(),e=L;if(e!==null)return td(l,e,t);ct(),l=l.memoizedState,e=ct();var a=e.queue.dispatch;return e.memoizedState=t,[l,a,!1]}function ia(t,l,e,a){return t={tag:t,create:e,deps:a,inst:l,next:null},l=C.updateQueue,l===null&&(l=wu(),C.updateQueue=l),e=l.lastEffect,e===null?l.lastEffect=t.next=t:(a=e.next,e.next=t,t.next=a,l.lastEffect=t),t}function ld(){return ct().memoizedState}function Qn(t,l,e,a){var n=Et();C.flags|=t,n.memoizedState=ia(1|l,{destroy:void 0},e,a===void 0?null:a)}function Zu(t,l,e,a){var n=ct();a=a===void 0?null:a;var u=n.memoizedState.inst;L!==null&&a!==null&&of(a,L.memoizedState.deps)?n.memoizedState=ia(l,u,e,a):(C.flags|=t,n.memoizedState=ia(1|l,u,e,a))}function Os(t,l){Qn(8390656,8,t,l)}function hf(t,l){Zu(2048,8,t,l)}function By(t){C.flags|=4;var l=C.updateQueue;if(l===null)l=wu(),C.updateQueue=l,l.events=[t];else{var e=l.events;e===null?l.events=[t]:e.push(t)}}function ed(t){var l=ct().memoizedState;return By({ref:l,nextImpl:t}),function(){if(w&2)throw Error(S(440));return l.impl.apply(void 0,arguments)}}function ad(t,l){return Zu(4,2,t,l)}function nd(t,l){return Zu(4,4,t,l)}function ud(t,l){if(typeof l=="function"){t=t();var e=l(t);return function(){typeof e=="function"?e():l(null)}}if(l!=null)return t=t(),l.current=t,function(){l.current=null}}function id(t,l,e){e=e!=null?e.concat([t]):null,Zu(4,4,ud.bind(null,l,t),e)}function xf(){}function cd(t,l){var e=ct();l=l===void 0?null:l;var a=e.memoizedState;return l!==null&&of(l,a[1])?a[0]:(e.memoizedState=[t,l],t)}function fd(t,l){var e=ct();l=l===void 0?null:l;var a=e.memoizedState;if(l!==null&&of(l,a[1]))return a[0];if(a=t(),Se){Bl(!0);try{t()}finally{Bl(!1)}}return e.memoizedState=[a,l],a}function pf(t,l,e){return e===void 0||Al&1073741824&&!(H&261930)?t.memoizedState=l:(t.memoizedState=e,t=Wd(),C.lanes|=t,ee|=t,e)}function sd(t,l,e,a){return Zt(e,l)?e:ua.current!==null?(t=pf(t,e,a),Zt(t,l)||(rt=!0),t):!(Al&42)||Al&1073741824&&!(H&261930)?(rt=!0,t.memoizedState=e):(t=Wd(),C.lanes|=t,ee|=t,l)}function od(t,l,e,a,n){var u=X.p;X.p=u!==0&&8>u?u:8;var i=D.T,c={};D.T=c,Sf(t,!1,l,e);try{var f=n(),r=D.S;if(r!==null&&r(c,f),f!==null&&typeof f=="object"&&typeof f.then=="function"){var y=Ny(f,a);Xa(t,l,y,Xt(t))}else Xa(t,l,a,Xt(t))}catch(v){Xa(t,l,{then:function(){},status:"rejected",reason:v},Xt())}finally{X.p=u,i!==null&&c.types!==null&&(i.types=c.types),D.T=i}}function wy(){}function mc(t,l,e,a){if(t.tag!==5)throw Error(S(476));var n=rd(t).queue;od(t,n,l,ye,e===null?wy:function(){return dd(t),e(a)})}function rd(t){var l=t.memoizedState;if(l!==null)return l;l={memoizedState:ye,baseState:ye,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:$l,lastRenderedState:ye},next:null};var e={};return l.next={memoizedState:e,baseState:e,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:$l,lastRenderedState:e},next:null},t.memoizedState=l,t=t.alternate,t!==null&&(t.memoizedState=l),l}function dd(t){var l=rd(t);l.next===null&&(l=t.alternate.memoizedState),Xa(t,l.next.queue,{},Xt())}function bf(){return St(nn)}function yd(){return ct().memoizedState}function md(){return ct().memoizedState}function Xy(t){for(var l=t.return;l!==null;){switch(l.tag){case 24:case 3:var e=Xt();t=Ql(e);var a=Vl(l,t,e);a!==null&&(Dt(a,l,e),Ha(a,l,e)),l={cache:nf()},t.payload=l;return}l=l.return}}function Zy(t,l,e){var a=Xt();e={lane:a,revertLane:0,gesture:null,action:e,hasEagerState:!1,eagerState:null,next:null},Yu(t)?vd(l,e):(e=tf(t,l,e,a),e!==null&&(Dt(e,t,a),hd(e,l,a)))}function gd(t,l,e){var a=Xt();Xa(t,l,e,a)}function Xa(t,l,e,a){var n={lane:a,revertLane:0,gesture:null,action:e,hasEagerState:!1,eagerState:null,next:null};if(Yu(t))vd(l,n);else{var u=t.alternate;if(t.lanes===0&&(u===null||u.lanes===0)&&(u=l.lastRenderedReducer,u!==null))try{var i=l.lastRenderedState,c=u(i,e);if(n.hasEagerState=!0,n.eagerState=c,Zt(c,i))return Hu(t,l,n,0),Q===null&&qu(),!1}catch{}finally{}if(e=tf(t,l,n,a),e!==null)return Dt(e,t,a),hd(e,l,a),!0}return!1}function Sf(t,l,e,a){if(a={lane:2,revertLane:_f(),gesture:null,action:a,hasEagerState:!1,eagerState:null,next:null},Yu(t)){if(l)throw Error(S(479))}else l=tf(t,e,a,2),l!==null&&Dt(l,t,2)}function Yu(t){var l=t.alternate;return t===C||l!==null&&l===C}function vd(t,l){Pe=du=!0;var e=t.pending;e===null?l.next=l:(l.next=e.next,e.next=l),t.pending=l}function hd(t,l,e){if(e&4194048){var a=l.lanes;a&=t.pendingLanes,e|=a,l.lanes=e,er(t,e)}}var ln={readContext:St,use:Xu,useCallback:et,useContext:et,useEffect:et,useImperativeHandle:et,useLayoutEffect:et,useInsertionEffect:et,useMemo:et,useReducer:et,useRef:et,useState:et,useDebugValue:et,useDeferredValue:et,useTransition:et,useSyncExternalStore:et,useId:et,useHostTransitionStatus:et,useFormState:et,useActionState:et,useOptimistic:et,useMemoCache:et,useCacheRefresh:et};ln.useEffectEvent=et;var xd={readContext:St,use:Xu,useCallback:function(t,l){return Et().memoizedState=[t,l===void 0?null:l],t},useContext:St,useEffect:Os,useImperativeHandle:function(t,l,e){e=e!=null?e.concat([t]):null,Qn(4194308,4,ud.bind(null,l,t),e)},useLayoutEffect:function(t,l){return Qn(4194308,4,t,l)},useInsertionEffect:function(t,l){Qn(4,2,t,l)},useMemo:function(t,l){var e=Et();l=l===void 0?null:l;var a=t();if(Se){Bl(!0);try{t()}finally{Bl(!1)}}return e.memoizedState=[a,l],a},useReducer:function(t,l,e){var a=Et();if(e!==void 0){var n=e(l);if(Se){Bl(!0);try{e(l)}finally{Bl(!1)}}}else n=l;return a.memoizedState=a.baseState=n,t={pending:null,lanes:0,dispatch:null,lastRenderedReducer:t,lastRenderedState:n},a.queue=t,t=t.dispatch=Zy.bind(null,C,t),[a.memoizedState,t]},useRef:function(t){var l=Et();return t={current:t},l.memoizedState=t},useState:function(t){t=dc(t);var l=t.queue,e=gd.bind(null,C,l);return l.dispatch=e,[t.memoizedState,e]},useDebugValue:xf,useDeferredValue:function(t,l){var e=Et();return pf(e,t,l)},useTransition:function(){var t=dc(!1);return t=od.bind(null,C,t.queue,!0,!1),Et().memoizedState=t,[!1,t]},useSyncExternalStore:function(t,l,e){var a=C,n=Et();if(B){if(e===void 0)throw Error(S(407));e=e()}else{if(e=l(),Q===null)throw Error(S(349));H&127||Lr(a,l,e)}n.memoizedState=e;var u={value:e,getSnapshot:l};return n.queue=u,Os(Vr.bind(null,a,u,t),[t]),a.flags|=2048,ia(9,{destroy:void 0},Qr.bind(null,a,u,e,l),null),e},useId:function(){var t=Et(),l=Q.identifierPrefix;if(B){var e=ul,a=nl;e=(a&~(1<<32-wt(a)-1)).toString(32)+e,l="_"+l+"R_"+e,e=yu++,0<e&&(l+="H"+e.toString(32)),l+="_"}else e=Uy++,l="_"+l+"r_"+e.toString(32)+"_";return t.memoizedState=l},useHostTransitionStatus:bf,useFormState:As,useActionState:As,useOptimistic:function(t){var l=Et();l.memoizedState=l.baseState=t;var e={pending:null,lanes:0,dispatch:null,lastRenderedReducer:null,lastRenderedState:null};return l.queue=e,l=Sf.bind(null,C,!0,e),e.dispatch=l,[t,l]},useMemoCache:gf,useCacheRefresh:function(){return Et().memoizedState=Xy.bind(null,C)},useEffectEvent:function(t){var l=Et(),e={impl:t};return l.memoizedState=e,function(){if(w&2)throw Error(S(440));return e.impl.apply(void 0,arguments)}}},zf={readContext:St,use:Xu,useCallback:cd,useContext:St,useEffect:hf,useImperativeHandle:id,useInsertionEffect:ad,useLayoutEffect:nd,useMemo:fd,useReducer:Ln,useRef:ld,useState:function(){return Ln($l)},useDebugValue:xf,useDeferredValue:function(t,l){var e=ct();return sd(e,L.memoizedState,t,l)},useTransition:function(){var t=Ln($l)[0],l=ct().memoizedState;return[typeof t=="boolean"?t:gn(t),l]},useSyncExternalStore:Gr,useId:yd,useHostTransitionStatus:bf,useFormState:$s,useActionState:$s,useOptimistic:function(t,l){var e=ct();return Wr(e,L,t,l)},useMemoCache:gf,useCacheRefresh:md};zf.useEffectEvent=ed;var pd={readContext:St,use:Xu,useCallback:cd,useContext:St,useEffect:hf,useImperativeHandle:id,useInsertionEffect:ad,useLayoutEffect:nd,useMemo:fd,useReducer:di,useRef:ld,useState:function(){return di($l)},useDebugValue:xf,useDeferredValue:function(t,l){var e=ct();return L===null?pf(e,t,l):sd(e,L.memoizedState,t,l)},useTransition:function(){var t=di($l)[0],l=ct().memoizedState;return[typeof t=="boolean"?t:gn(t),l]},useSyncExternalStore:Gr,useId:yd,useHostTransitionStatus:bf,useFormState:Ms,useActionState:Ms,useOptimistic:function(t,l){var e=ct();return L!==null?Wr(e,L,t,l):(e.baseState=t,[t,e.queue.dispatch])},useMemoCache:gf,useCacheRefresh:md};pd.useEffectEvent=ed;function yi(t,l,e,a){l=t.memoizedState,e=e(a,l),e=e==null?l:F({},l,e),t.memoizedState=e,t.lanes===0&&(t.updateQueue.baseState=e)}var gc={enqueueSetState:function(t,l,e){t=t._reactInternals;var a=Xt(),n=Ql(a);n.payload=l,e!=null&&(n.callback=e),l=Vl(t,n,a),l!==null&&(Dt(l,t,a),Ha(l,t,a))},enqueueReplaceState:function(t,l,e){t=t._reactInternals;var a=Xt(),n=Ql(a);n.tag=1,n.payload=l,e!=null&&(n.callback=e),l=Vl(t,n,a),l!==null&&(Dt(l,t,a),Ha(l,t,a))},enqueueForceUpdate:function(t,l){t=t._reactInternals;var e=Xt(),a=Ql(e);a.tag=2,l!=null&&(a.callback=l),l=Vl(t,a,e),l!==null&&(Dt(l,t,e),Ha(l,t,e))}};function js(t,l,e,a,n,u,i){return t=t.stateNode,typeof t.shouldComponentUpdate=="function"?t.shouldComponentUpdate(a,u,i):l.prototype&&l.prototype.isPureReactComponent?!Wa(e,a)||!Wa(n,u):!0}function _s(t,l,e,a){t=l.state,typeof l.componentWillReceiveProps=="function"&&l.componentWillReceiveProps(e,a),typeof l.UNSAFE_componentWillReceiveProps=="function"&&l.UNSAFE_componentWillReceiveProps(e,a),l.state!==t&&gc.enqueueReplaceState(l,l.state,null)}function ze(t,l){var e=l;if("ref"in l){e={};for(var a in l)a!=="ref"&&(e[a]=l[a])}if(t=t.defaultProps){e===l&&(e=F({},e));for(var n in t)e[n]===void 0&&(e[n]=t[n])}return e}function bd(t){uu(t)}function Sd(t){console.error(t)}function zd(t){uu(t)}function mu(t,l){try{var e=t.onUncaughtError;e(l.value,{componentStack:l.stack})}catch(a){setTimeout(function(){throw a})}}function Ds(t,l,e){try{var a=t.onCaughtError;a(e.value,{componentStack:e.stack,errorBoundary:l.tag===1?l.stateNode:null})}catch(n){setTimeout(function(){throw n})}}function vc(t,l,e){return e=Ql(e),e.tag=3,e.payload={element:null},e.callback=function(){mu(t,l)},e}function Ed(t){return t=Ql(t),t.tag=3,t}function Td(t,l,e,a){var n=e.type.getDerivedStateFromError;if(typeof n=="function"){var u=a.value;t.payload=function(){return n(u)},t.callback=function(){Ds(l,e,a)}}var i=e.stateNode;i!==null&&typeof i.componentDidCatch=="function"&&(t.callback=function(){Ds(l,e,a),typeof n!="function"&&(Kl===null?Kl=new Set([this]):Kl.add(this));var c=a.stack;this.componentDidCatch(a.value,{componentStack:c!==null?c:""})})}function Yy(t,l,e,a,n){if(e.flags|=32768,a!==null&&typeof a=="object"&&typeof a.then=="function"){if(l=e.alternate,l!==null&&ga(l,e,n,!0),e=Yt.current,e!==null){switch(e.tag){case 31:case 13:return Ft===null?pu():e.alternate===null&&at===0&&(at=3),e.flags&=-257,e.flags|=65536,e.lanes=n,a===su?e.flags|=16384:(l=e.updateQueue,l===null?e.updateQueue=new Set([a]):l.add(a),Ti(t,a,n)),!1;case 22:return e.flags|=65536,a===su?e.flags|=16384:(l=e.updateQueue,l===null?(l={transitions:null,markerInstances:null,retryQueue:new Set([a])},e.updateQueue=l):(e=l.retryQueue,e===null?l.retryQueue=new Set([a]):e.add(a)),Ti(t,a,n)),!1}throw Error(S(435,e.tag))}return Ti(t,a,n),pu(),!1}if(B)return l=Yt.current,l!==null?(!(l.flags&65536)&&(l.flags|=256),l.flags|=65536,l.lanes=n,a!==ac&&(t=Error(S(422),{cause:a}),Ia(Jt(t,e)))):(a!==ac&&(l=Error(S(423),{cause:a}),Ia(Jt(l,e))),t=t.current.alternate,t.flags|=65536,n&=-n,t.lanes|=n,a=Jt(a,e),n=vc(t.stateNode,a,n),ri(t,n),at!==4&&(at=2)),!1;var u=Error(S(520),{cause:a});if(u=Jt(u,e),Ga===null?Ga=[u]:Ga.push(u),at!==4&&(at=2),l===null)return!0;a=Jt(a,e),e=l;do{switch(e.tag){case 3:return e.flags|=65536,t=n&-n,e.lanes|=t,t=vc(e.stateNode,a,t),ri(e,t),!1;case 1:if(l=e.type,u=e.stateNode,(e.flags&128)===0&&(typeof l.getDerivedStateFromError=="function"||u!==null&&typeof u.componentDidCatch=="function"&&(Kl===null||!Kl.has(u))))return e.flags|=65536,n&=-n,e.lanes|=n,n=Ed(n),Td(n,t,e,a),ri(e,n),!1}e=e.return}while(e!==null);return!1}var Ef=Error(S(461)),rt=!1;function xt(t,l,e,a){l.child=t===null?Hr(l,null,e,a):be(l,t.child,e,a)}function ks(t,l,e,a,n){e=e.render;var u=l.ref;if("ref"in a){var i={};for(var c in a)c!=="ref"&&(i[c]=a[c])}else i=a;return pe(l),a=rf(t,l,e,i,u,n),c=df(),t!==null&&!rt?(yf(t,l,n),Ml(t,l,n)):(B&&c&&ef(l),l.flags|=1,xt(t,l,a,n),l.child)}function Cs(t,l,e,a,n){if(t===null){var u=e.type;return typeof u=="function"&&!lf(u)&&u.defaultProps===void 0&&e.compare===null?(l.tag=15,l.type=u,Ad(t,l,u,a,n)):(t=Yn(e.type,null,a,l,l.mode,n),t.ref=l.ref,t.return=l,l.child=t)}if(u=t.child,!Tf(t,n)){var i=u.memoizedProps;if(e=e.compare,e=e!==null?e:Wa,e(i,a)&&t.ref===l.ref)return Ml(t,l,n)}return l.flags|=1,t=Sl(u,a),t.ref=l.ref,t.return=l,l.child=t}function Ad(t,l,e,a,n){if(t!==null){var u=t.memoizedProps;if(Wa(u,a)&&t.ref===l.ref)if(rt=!1,l.pendingProps=a=u,Tf(t,n))t.flags&131072&&(rt=!0);else return l.lanes=t.lanes,Ml(t,l,n)}return hc(t,l,e,a,n)}function $d(t,l,e,a){var n=a.children,u=t!==null?t.memoizedState:null;if(t===null&&l.stateNode===null&&(l.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),a.mode==="hidden"){if(l.flags&128){if(u=u!==null?u.baseLanes|e:e,t!==null){for(a=l.child=t.child,n=0;a!==null;)n=n|a.lanes|a.childLanes,a=a.sibling;a=n&~u}else a=0,l.child=null;return Ns(t,l,u,e,a)}if(e&536870912)l.memoizedState={baseLanes:0,cachePool:null},t!==null&&Gn(l,u!==null?u.cachePool:null),u!==null?zs(l,u):oc(),Xr(l);else return a=l.lanes=536870912,Ns(t,l,u!==null?u.baseLanes|e:e,e,a)}else u!==null?(Gn(l,u.cachePool),zs(l,u),ql(),l.memoizedState=null):(t!==null&&Gn(l,null),oc(),ql());return xt(t,l,n,e),l.child}function Da(t,l){return t!==null&&t.tag===22||l.stateNode!==null||(l.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),l.sibling}function Ns(t,l,e,a,n){var u=uf();return u=u===null?null:{parent:ot._currentValue,pool:u},l.memoizedState={baseLanes:e,cachePool:u},t!==null&&Gn(l,null),oc(),Xr(l),t!==null&&ga(t,l,a,!0),l.childLanes=n,null}function Vn(t,l){return l=gu({mode:l.mode,children:l.children},t.mode),l.ref=t.ref,t.child=l,l.return=t,l}function Us(t,l,e){return be(l,t.child,null,e),t=Vn(l,l.pendingProps),t.flags|=2,Ut(l),l.memoizedState=null,t}function Gy(t,l,e){var a=l.pendingProps,n=(l.flags&128)!==0;if(l.flags&=-129,t===null){if(B){if(a.mode==="hidden")return t=Vn(l,a),l.lanes=536870912,Da(null,t);if(rc(l),(t=J)?(t=x0(t,Wt),t=t!==null&&t.data==="&"?t:null,t!==null&&(l.memoizedState={dehydrated:t,treeContext:Pl!==null?{id:nl,overflow:ul}:null,retryLane:536870912,hydrationErrors:null},e=Dr(t),e.return=l,l.child=e,bt=l,J=null)):t=null,t===null)throw te(l);return l.lanes=536870912,null}return Vn(l,a)}var u=t.memoizedState;if(u!==null){var i=u.dehydrated;if(rc(l),n)if(l.flags&256)l.flags&=-257,l=Us(t,l,e);else if(l.memoizedState!==null)l.child=t.child,l.flags|=128,l=null;else throw Error(S(558));else if(rt||ga(t,l,e,!1),n=(e&t.childLanes)!==0,rt||n){if(a=Q,a!==null&&(i=ar(a,e),i!==0&&i!==u.retryLane))throw u.retryLane=i,$e(t,i),Dt(a,t,i),Ef;pu(),l=Us(t,l,e)}else t=u.treeContext,J=It(i.nextSibling),bt=l,B=!0,Ll=null,Wt=!1,t!==null&&Cr(l,t),l=Vn(l,a),l.flags|=4096;return l}return t=Sl(t.child,{mode:a.mode,children:a.children}),t.ref=l.ref,l.child=t,t.return=l,t}function Kn(t,l){var e=l.ref;if(e===null)t!==null&&t.ref!==null&&(l.flags|=4194816);else{if(typeof e!="function"&&typeof e!="object")throw Error(S(284));(t===null||t.ref!==e)&&(l.flags|=4194816)}}function hc(t,l,e,a,n){return pe(l),e=rf(t,l,e,a,void 0,n),a=df(),t!==null&&!rt?(yf(t,l,n),Ml(t,l,n)):(B&&a&&ef(l),l.flags|=1,xt(t,l,e,n),l.child)}function Rs(t,l,e,a,n,u){return pe(l),l.updateQueue=null,e=Yr(l,a,e,n),Zr(t),a=df(),t!==null&&!rt?(yf(t,l,u),Ml(t,l,u)):(B&&a&&ef(l),l.flags|=1,xt(t,l,e,u),l.child)}function qs(t,l,e,a,n){if(pe(l),l.stateNode===null){var u=Ge,i=e.contextType;typeof i=="object"&&i!==null&&(u=St(i)),u=new e(a,u),l.memoizedState=u.state!==null&&u.state!==void 0?u.state:null,u.updater=gc,l.stateNode=u,u._reactInternals=l,u=l.stateNode,u.props=a,u.state=l.memoizedState,u.refs={},ff(l),i=e.contextType,u.context=typeof i=="object"&&i!==null?St(i):Ge,u.state=l.memoizedState,i=e.getDerivedStateFromProps,typeof i=="function"&&(yi(l,e,i,a),u.state=l.memoizedState),typeof e.getDerivedStateFromProps=="function"||typeof u.getSnapshotBeforeUpdate=="function"||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(i=u.state,typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount(),i!==u.state&&gc.enqueueReplaceState(u,u.state,null),wa(l,a,u,n),Ba(),u.state=l.memoizedState),typeof u.componentDidMount=="function"&&(l.flags|=4194308),a=!0}else if(t===null){u=l.stateNode;var c=l.memoizedProps,f=ze(e,c);u.props=f;var r=u.context,y=e.contextType;i=Ge,typeof y=="object"&&y!==null&&(i=St(y));var v=e.getDerivedStateFromProps;y=typeof v=="function"||typeof u.getSnapshotBeforeUpdate=="function",c=l.pendingProps!==c,y||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(c||r!==i)&&_s(l,u,a,i),Nl=!1;var d=l.memoizedState;u.state=d,wa(l,a,u,n),Ba(),r=l.memoizedState,c||d!==r||Nl?(typeof v=="function"&&(yi(l,e,v,a),r=l.memoizedState),(f=Nl||js(l,e,f,a,d,r,i))?(y||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount()),typeof u.componentDidMount=="function"&&(l.flags|=4194308)):(typeof u.componentDidMount=="function"&&(l.flags|=4194308),l.memoizedProps=a,l.memoizedState=r),u.props=a,u.state=r,u.context=i,a=f):(typeof u.componentDidMount=="function"&&(l.flags|=4194308),a=!1)}else{u=l.stateNode,fc(t,l),i=l.memoizedProps,y=ze(e,i),u.props=y,v=l.pendingProps,d=u.context,r=e.contextType,f=Ge,typeof r=="object"&&r!==null&&(f=St(r)),c=e.getDerivedStateFromProps,(r=typeof c=="function"||typeof u.getSnapshotBeforeUpdate=="function")||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(i!==v||d!==f)&&_s(l,u,a,f),Nl=!1,d=l.memoizedState,u.state=d,wa(l,a,u,n),Ba();var g=l.memoizedState;i!==v||d!==g||Nl||t!==null&&t.dependencies!==null&&fu(t.dependencies)?(typeof c=="function"&&(yi(l,e,c,a),g=l.memoizedState),(y=Nl||js(l,e,y,a,d,g,f)||t!==null&&t.dependencies!==null&&fu(t.dependencies))?(r||typeof u.UNSAFE_componentWillUpdate!="function"&&typeof u.componentWillUpdate!="function"||(typeof u.componentWillUpdate=="function"&&u.componentWillUpdate(a,g,f),typeof u.UNSAFE_componentWillUpdate=="function"&&u.UNSAFE_componentWillUpdate(a,g,f)),typeof u.componentDidUpdate=="function"&&(l.flags|=4),typeof u.getSnapshotBeforeUpdate=="function"&&(l.flags|=1024)):(typeof u.componentDidUpdate!="function"||i===t.memoizedProps&&d===t.memoizedState||(l.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||i===t.memoizedProps&&d===t.memoizedState||(l.flags|=1024),l.memoizedProps=a,l.memoizedState=g),u.props=a,u.state=g,u.context=f,a=y):(typeof u.componentDidUpdate!="function"||i===t.memoizedProps&&d===t.memoizedState||(l.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||i===t.memoizedProps&&d===t.memoizedState||(l.flags|=1024),a=!1)}return u=a,Kn(t,l),a=(l.flags&128)!==0,u||a?(u=l.stateNode,e=a&&typeof e.getDerivedStateFromError!="function"?null:u.render(),l.flags|=1,t!==null&&a?(l.child=be(l,t.child,null,n),l.child=be(l,null,e,n)):xt(t,l,e,n),l.memoizedState=u.state,t=l.child):t=Ml(t,l,n),t}function Hs(t,l,e,a){return xe(),l.flags|=256,xt(t,l,e,a),l.child}var mi={dehydrated:null,treeContext:null,retryLane:0,hydrationErrors:null};function gi(t){return{baseLanes:t,cachePool:Ur()}}function vi(t,l,e){return t=t!==null?t.childLanes&~e:0,l&&(t|=qt),t}function Md(t,l,e){var a=l.pendingProps,n=!1,u=(l.flags&128)!==0,i;if((i=u)||(i=t!==null&&t.memoizedState===null?!1:(it.current&2)!==0),i&&(n=!0,l.flags&=-129),i=(l.flags&32)!==0,l.flags&=-33,t===null){if(B){if(n?Rl(l):ql(),(t=J)?(t=x0(t,Wt),t=t!==null&&t.data!=="&"?t:null,t!==null&&(l.memoizedState={dehydrated:t,treeContext:Pl!==null?{id:nl,overflow:ul}:null,retryLane:536870912,hydrationErrors:null},e=Dr(t),e.return=l,l.child=e,bt=l,J=null)):t=null,t===null)throw te(l);return Dc(t)?l.lanes=32:l.lanes=536870912,null}var c=a.children;return a=a.fallback,n?(ql(),n=l.mode,c=gu({mode:"hidden",children:c},n),a=me(a,n,e,null),c.return=l,a.return=l,c.sibling=a,l.child=c,a=l.child,a.memoizedState=gi(e),a.childLanes=vi(t,i,e),l.memoizedState=mi,Da(null,a)):(Rl(l),xc(l,c))}var f=t.memoizedState;if(f!==null&&(c=f.dehydrated,c!==null)){if(u)l.flags&256?(Rl(l),l.flags&=-257,l=hi(t,l,e)):l.memoizedState!==null?(ql(),l.child=t.child,l.flags|=128,l=null):(ql(),c=a.fallback,n=l.mode,a=gu({mode:"visible",children:a.children},n),c=me(c,n,e,null),c.flags|=2,a.return=l,c.return=l,a.sibling=c,l.child=a,be(l,t.child,null,e),a=l.child,a.memoizedState=gi(e),a.childLanes=vi(t,i,e),l.memoizedState=mi,l=Da(null,a));else if(Rl(l),Dc(c)){if(i=c.nextSibling&&c.nextSibling.dataset,i)var r=i.dgst;i=r,a=Error(S(419)),a.stack="",a.digest=i,Ia({value:a,source:null,stack:null}),l=hi(t,l,e)}else if(rt||ga(t,l,e,!1),i=(e&t.childLanes)!==0,rt||i){if(i=Q,i!==null&&(a=ar(i,e),a!==0&&a!==f.retryLane))throw f.retryLane=a,$e(t,a),Dt(i,t,a),Ef;_c(c)||pu(),l=hi(t,l,e)}else _c(c)?(l.flags|=192,l.child=t.child,l=null):(t=f.treeContext,J=It(c.nextSibling),bt=l,B=!0,Ll=null,Wt=!1,t!==null&&Cr(l,t),l=xc(l,a.children),l.flags|=4096);return l}return n?(ql(),c=a.fallback,n=l.mode,f=t.child,r=f.sibling,a=Sl(f,{mode:"hidden",children:a.children}),a.subtreeFlags=f.subtreeFlags&65011712,r!==null?c=Sl(r,c):(c=me(c,n,e,null),c.flags|=2),c.return=l,a.return=l,a.sibling=c,l.child=a,Da(null,a),a=l.child,c=t.child.memoizedState,c===null?c=gi(e):(n=c.cachePool,n!==null?(f=ot._currentValue,n=n.parent!==f?{parent:f,pool:f}:n):n=Ur(),c={baseLanes:c.baseLanes|e,cachePool:n}),a.memoizedState=c,a.childLanes=vi(t,i,e),l.memoizedState=mi,Da(t.child,a)):(Rl(l),e=t.child,t=e.sibling,e=Sl(e,{mode:"visible",children:a.children}),e.return=l,e.sibling=null,t!==null&&(i=l.deletions,i===null?(l.deletions=[t],l.flags|=16):i.push(t)),l.child=e,l.memoizedState=null,e)}function xc(t,l){return l=gu({mode:"visible",children:l},t.mode),l.return=t,t.child=l}function gu(t,l){return t=Rt(22,t,null,l),t.lanes=0,t}function hi(t,l,e){return be(l,t.child,null,e),t=xc(l,l.pendingProps.children),t.flags|=2,l.memoizedState=null,t}function Bs(t,l,e){t.lanes|=l;var a=t.alternate;a!==null&&(a.lanes|=l),uc(t.return,l,e)}function xi(t,l,e,a,n,u){var i=t.memoizedState;i===null?t.memoizedState={isBackwards:l,rendering:null,renderingStartTime:0,last:a,tail:e,tailMode:n,treeForkCount:u}:(i.isBackwards=l,i.rendering=null,i.renderingStartTime=0,i.last=a,i.tail=e,i.tailMode=n,i.treeForkCount=u)}function Od(t,l,e){var a=l.pendingProps,n=a.revealOrder,u=a.tail;a=a.children;var i=it.current,c=(i&2)!==0;if(c?(i=i&1|2,l.flags|=128):i&=1,V(it,i),xt(t,l,a,e),a=B?Fa:0,!c&&t!==null&&t.flags&128)t:for(t=l.child;t!==null;){if(t.tag===13)t.memoizedState!==null&&Bs(t,e,l);else if(t.tag===19)Bs(t,e,l);else if(t.child!==null){t.child.return=t,t=t.child;continue}if(t===l)break t;for(;t.sibling===null;){if(t.return===null||t.return===l)break t;t=t.return}t.sibling.return=t.return,t=t.sibling}switch(n){case"forwards":for(e=l.child,n=null;e!==null;)t=e.alternate,t!==null&&ru(t)===null&&(n=e),e=e.sibling;e=n,e===null?(n=l.child,l.child=null):(n=e.sibling,e.sibling=null),xi(l,!1,n,e,u,a);break;case"backwards":case"unstable_legacy-backwards":for(e=null,n=l.child,l.child=null;n!==null;){if(t=n.alternate,t!==null&&ru(t)===null){l.child=n;break}t=n.sibling,n.sibling=e,e=n,n=t}xi(l,!0,e,null,u,a);break;case"together":xi(l,!1,null,null,void 0,a);break;default:l.memoizedState=null}return l.child}function Ml(t,l,e){if(t!==null&&(l.dependencies=t.dependencies),ee|=l.lanes,!(e&l.childLanes))if(t!==null){if(ga(t,l,e,!1),(e&l.childLanes)===0)return null}else return null;if(t!==null&&l.child!==t.child)throw Error(S(153));if(l.child!==null){for(t=l.child,e=Sl(t,t.pendingProps),l.child=e,e.return=l;t.sibling!==null;)t=t.sibling,e=e.sibling=Sl(t,t.pendingProps),e.return=l;e.sibling=null}return l.child}function Tf(t,l){return t.lanes&l?!0:(t=t.dependencies,!!(t!==null&&fu(t)))}function Ly(t,l,e){switch(l.tag){case 3:lu(l,l.stateNode.containerInfo),Ul(l,ot,t.memoizedState.cache),xe();break;case 27:case 5:Qi(l);break;case 4:lu(l,l.stateNode.containerInfo);break;case 10:Ul(l,l.type,l.memoizedProps.value);break;case 31:if(l.memoizedState!==null)return l.flags|=128,rc(l),null;break;case 13:var a=l.memoizedState;if(a!==null)return a.dehydrated!==null?(Rl(l),l.flags|=128,null):e&l.child.childLanes?Md(t,l,e):(Rl(l),t=Ml(t,l,e),t!==null?t.sibling:null);Rl(l);break;case 19:var n=(t.flags&128)!==0;if(a=(e&l.childLanes)!==0,a||(ga(t,l,e,!1),a=(e&l.childLanes)!==0),n){if(a)return Od(t,l,e);l.flags|=128}if(n=l.memoizedState,n!==null&&(n.rendering=null,n.tail=null,n.lastEffect=null),V(it,it.current),a)break;return null;case 22:return l.lanes=0,$d(t,l,e,l.pendingProps);case 24:Ul(l,ot,t.memoizedState.cache)}return Ml(t,l,e)}function jd(t,l,e){if(t!==null)if(t.memoizedProps!==l.pendingProps)rt=!0;else{if(!Tf(t,e)&&!(l.flags&128))return rt=!1,Ly(t,l,e);rt=!!(t.flags&131072)}else rt=!1,B&&l.flags&1048576&&kr(l,Fa,l.index);switch(l.lanes=0,l.tag){case 16:t:{var a=l.pendingProps;if(t=re(l.elementType),l.type=t,typeof t=="function")lf(t)?(a=ze(t,a),l.tag=1,l=qs(null,l,t,a,e)):(l.tag=0,l=hc(null,l,t,a,e));else{if(t!=null){var n=t.$$typeof;if(n===Xc){l.tag=11,l=ks(null,l,t,a,e);break t}else if(n===Zc){l.tag=14,l=Cs(null,l,t,a,e);break t}}throw l=Gi(t)||t,Error(S(306,l,""))}}return l;case 0:return hc(t,l,l.type,l.pendingProps,e);case 1:return a=l.type,n=ze(a,l.pendingProps),qs(t,l,a,n,e);case 3:t:{if(lu(l,l.stateNode.containerInfo),t===null)throw Error(S(387));a=l.pendingProps;var u=l.memoizedState;n=u.element,fc(t,l),wa(l,a,null,e);var i=l.memoizedState;if(a=i.cache,Ul(l,ot,a),a!==u.cache&&ic(l,[ot],e,!0),Ba(),a=i.element,u.isDehydrated)if(u={element:a,isDehydrated:!1,cache:i.cache},l.updateQueue.baseState=u,l.memoizedState=u,l.flags&256){l=Hs(t,l,a,e);break t}else if(a!==n){n=Jt(Error(S(424)),l),Ia(n),l=Hs(t,l,a,e);break t}else{switch(t=l.stateNode.containerInfo,t.nodeType){case 9:t=t.body;break;default:t=t.nodeName==="HTML"?t.ownerDocument.body:t}for(J=It(t.firstChild),bt=l,B=!0,Ll=null,Wt=!0,e=Hr(l,null,a,e),l.child=e;e;)e.flags=e.flags&-3|4096,e=e.sibling}else{if(xe(),a===n){l=Ml(t,l,e);break t}xt(t,l,a,e)}l=l.child}return l;case 26:return Kn(t,l),t===null?(e=uo(l.type,null,l.pendingProps,null))?l.memoizedState=e:B||(e=l.type,t=l.pendingProps,a=Eu(Gl.current).createElement(e),a[pt]=l,a[kt]=t,zt(a,e,t),gt(a),l.stateNode=a):l.memoizedState=uo(l.type,t.memoizedProps,l.pendingProps,t.memoizedState),null;case 27:return Qi(l),t===null&&B&&(a=l.stateNode=p0(l.type,l.pendingProps,Gl.current),bt=l,Wt=!0,n=J,ue(l.type)?(kc=n,J=It(a.firstChild)):J=n),xt(t,l,l.pendingProps.children,e),Kn(t,l),t===null&&(l.flags|=4194304),l.child;case 5:return t===null&&B&&((n=a=J)&&(a=Sm(a,l.type,l.pendingProps,Wt),a!==null?(l.stateNode=a,bt=l,J=It(a.firstChild),Wt=!1,n=!0):n=!1),n||te(l)),Qi(l),n=l.type,u=l.pendingProps,i=t!==null?t.memoizedProps:null,a=u.children,Oc(n,u)?a=null:i!==null&&Oc(n,i)&&(l.flags|=32),l.memoizedState!==null&&(n=rf(t,l,Ry,null,null,e),nn._currentValue=n),Kn(t,l),xt(t,l,a,e),l.child;case 6:return t===null&&B&&((t=e=J)&&(e=zm(e,l.pendingProps,Wt),e!==null?(l.stateNode=e,bt=l,J=null,t=!0):t=!1),t||te(l)),null;case 13:return Md(t,l,e);case 4:return lu(l,l.stateNode.containerInfo),a=l.pendingProps,t===null?l.child=be(l,null,a,e):xt(t,l,a,e),l.child;case 11:return ks(t,l,l.type,l.pendingProps,e);case 7:return xt(t,l,l.pendingProps,e),l.child;case 8:return xt(t,l,l.pendingProps.children,e),l.child;case 12:return xt(t,l,l.pendingProps.children,e),l.child;case 10:return a=l.pendingProps,Ul(l,l.type,a.value),xt(t,l,a.children,e),l.child;case 9:return n=l.type._context,a=l.pendingProps.children,pe(l),n=St(n),a=a(n),l.flags|=1,xt(t,l,a,e),l.child;case 14:return Cs(t,l,l.type,l.pendingProps,e);case 15:return Ad(t,l,l.type,l.pendingProps,e);case 19:return Od(t,l,e);case 31:return Gy(t,l,e);case 22:return $d(t,l,e,l.pendingProps);case 24:return pe(l),a=St(ot),t===null?(n=uf(),n===null&&(n=Q,u=nf(),n.pooledCache=u,u.refCount++,u!==null&&(n.pooledCacheLanes|=e),n=u),l.memoizedState={parent:a,cache:n},ff(l),Ul(l,ot,n)):(t.lanes&e&&(fc(t,l),wa(l,null,null,e),Ba()),n=t.memoizedState,u=l.memoizedState,n.parent!==a?(n={parent:a,cache:a},l.memoizedState=n,l.lanes===0&&(l.memoizedState=l.updateQueue.baseState=n),Ul(l,ot,a)):(a=u.cache,Ul(l,ot,a),a!==n.cache&&ic(l,[ot],e,!0))),xt(t,l,l.pendingProps.children,e),l.child;case 29:throw l.pendingProps}throw Error(S(156,l.tag))}function dl(t){t.flags|=4}function pi(t,l,e,a,n){if((l=(t.mode&32)!==0)&&(l=!1),l){if(t.flags|=16777216,(n&335544128)===n)if(t.stateNode.complete)t.flags|=8192;else if(Pd())t.flags|=8192;else throw ve=su,cf}else t.flags&=-16777217}function ws(t,l){if(l.type!=="stylesheet"||l.state.loading&4)t.flags&=-16777217;else if(t.flags|=16777216,!z0(l))if(Pd())t.flags|=8192;else throw ve=su,cf}function Dn(t,l){l!==null&&(t.flags|=4),t.flags&16384&&(l=t.tag!==22?tr():536870912,t.lanes|=l,ca|=l)}function Ta(t,l){if(!B)switch(t.tailMode){case"hidden":l=t.tail;for(var e=null;l!==null;)l.alternate!==null&&(e=l),l=l.sibling;e===null?t.tail=null:e.sibling=null;break;case"collapsed":e=t.tail;for(var a=null;e!==null;)e.alternate!==null&&(a=e),e=e.sibling;a===null?l||t.tail===null?t.tail=null:t.tail.sibling=null:a.sibling=null}}function K(t){var l=t.alternate!==null&&t.alternate.child===t.child,e=0,a=0;if(l)for(var n=t.child;n!==null;)e|=n.lanes|n.childLanes,a|=n.subtreeFlags&65011712,a|=n.flags&65011712,n.return=t,n=n.sibling;else for(n=t.child;n!==null;)e|=n.lanes|n.childLanes,a|=n.subtreeFlags,a|=n.flags,n.return=t,n=n.sibling;return t.subtreeFlags|=a,t.childLanes=e,l}function Qy(t,l,e){var a=l.pendingProps;switch(af(l),l.tag){case 16:case 15:case 0:case 11:case 7:case 8:case 12:case 9:case 14:return K(l),null;case 1:return K(l),null;case 3:return e=l.stateNode,a=null,t!==null&&(a=t.memoizedState.cache),l.memoizedState.cache!==a&&(l.flags|=2048),zl(ot),la(),e.pendingContext&&(e.context=e.pendingContext,e.pendingContext=null),(t===null||t.child===null)&&(je(l)?dl(l):t===null||t.memoizedState.isDehydrated&&!(l.flags&256)||(l.flags|=1024,oi())),K(l),null;case 26:var n=l.type,u=l.memoizedState;return t===null?(dl(l),u!==null?(K(l),ws(l,u)):(K(l),pi(l,n,null,a,e))):u?u!==t.memoizedState?(dl(l),K(l),ws(l,u)):(K(l),l.flags&=-16777217):(t=t.memoizedProps,t!==a&&dl(l),K(l),pi(l,n,t,a,e)),null;case 27:if(eu(l),e=Gl.current,n=l.type,t!==null&&l.stateNode!=null)t.memoizedProps!==a&&dl(l);else{if(!a){if(l.stateNode===null)throw Error(S(166));return K(l),null}t=cl.current,je(l)?gs(l):(t=p0(n,a,e),l.stateNode=t,dl(l))}return K(l),null;case 5:if(eu(l),n=l.type,t!==null&&l.stateNode!=null)t.memoizedProps!==a&&dl(l);else{if(!a){if(l.stateNode===null)throw Error(S(166));return K(l),null}if(u=cl.current,je(l))gs(l);else{var i=Eu(Gl.current);switch(u){case 1:u=i.createElementNS("http://www.w3.org/2000/svg",n);break;case 2:u=i.createElementNS("http://www.w3.org/1998/Math/MathML",n);break;default:switch(n){case"svg":u=i.createElementNS("http://www.w3.org/2000/svg",n);break;case"math":u=i.createElementNS("http://www.w3.org/1998/Math/MathML",n);break;case"script":u=i.createElement("div"),u.innerHTML="<script><\/script>",u=u.removeChild(u.firstChild);break;case"select":u=typeof a.is=="string"?i.createElement("select",{is:a.is}):i.createElement("select"),a.multiple?u.multiple=!0:a.size&&(u.size=a.size);break;default:u=typeof a.is=="string"?i.createElement(n,{is:a.is}):i.createElement(n)}}u[pt]=l,u[kt]=a;t:for(i=l.child;i!==null;){if(i.tag===5||i.tag===6)u.appendChild(i.stateNode);else if(i.tag!==4&&i.tag!==27&&i.child!==null){i.child.return=i,i=i.child;continue}if(i===l)break t;for(;i.sibling===null;){if(i.return===null||i.return===l)break t;i=i.return}i.sibling.return=i.return,i=i.sibling}l.stateNode=u;t:switch(zt(u,n,a),n){case"button":case"input":case"select":case"textarea":a=!!a.autoFocus;break t;case"img":a=!0;break t;default:a=!1}a&&dl(l)}}return K(l),pi(l,l.type,t===null?null:t.memoizedProps,l.pendingProps,e),null;case 6:if(t&&l.stateNode!=null)t.memoizedProps!==a&&dl(l);else{if(typeof a!="string"&&l.stateNode===null)throw Error(S(166));if(t=Gl.current,je(l)){if(t=l.stateNode,e=l.memoizedProps,a=null,n=bt,n!==null)switch(n.tag){case 27:case 5:a=n.memoizedProps}t[pt]=l,t=!!(t.nodeValue===e||a!==null&&a.suppressHydrationWarning===!0||g0(t.nodeValue,e)),t||te(l,!0)}else t=Eu(t).createTextNode(a),t[pt]=l,l.stateNode=t}return K(l),null;case 31:if(e=l.memoizedState,t===null||t.memoizedState!==null){if(a=je(l),e!==null){if(t===null){if(!a)throw Error(S(318));if(t=l.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(S(557));t[pt]=l}else xe(),!(l.flags&128)&&(l.memoizedState=null),l.flags|=4;K(l),t=!1}else e=oi(),t!==null&&t.memoizedState!==null&&(t.memoizedState.hydrationErrors=e),t=!0;if(!t)return l.flags&256?(Ut(l),l):(Ut(l),null);if(l.flags&128)throw Error(S(558))}return K(l),null;case 13:if(a=l.memoizedState,t===null||t.memoizedState!==null&&t.memoizedState.dehydrated!==null){if(n=je(l),a!==null&&a.dehydrated!==null){if(t===null){if(!n)throw Error(S(318));if(n=l.memoizedState,n=n!==null?n.dehydrated:null,!n)throw Error(S(317));n[pt]=l}else xe(),!(l.flags&128)&&(l.memoizedState=null),l.flags|=4;K(l),n=!1}else n=oi(),t!==null&&t.memoizedState!==null&&(t.memoizedState.hydrationErrors=n),n=!0;if(!n)return l.flags&256?(Ut(l),l):(Ut(l),null)}return Ut(l),l.flags&128?(l.lanes=e,l):(e=a!==null,t=t!==null&&t.memoizedState!==null,e&&(a=l.child,n=null,a.alternate!==null&&a.alternate.memoizedState!==null&&a.alternate.memoizedState.cachePool!==null&&(n=a.alternate.memoizedState.cachePool.pool),u=null,a.memoizedState!==null&&a.memoizedState.cachePool!==null&&(u=a.memoizedState.cachePool.pool),u!==n&&(a.flags|=2048)),e!==t&&e&&(l.child.flags|=8192),Dn(l,l.updateQueue),K(l),null);case 4:return la(),t===null&&Df(l.stateNode.containerInfo),K(l),null;case 10:return zl(l.type),K(l),null;case 19:if(vt(it),a=l.memoizedState,a===null)return K(l),null;if(n=(l.flags&128)!==0,u=a.rendering,u===null)if(n)Ta(a,!1);else{if(at!==0||t!==null&&t.flags&128)for(t=l.child;t!==null;){if(u=ru(t),u!==null){for(l.flags|=128,Ta(a,!1),t=u.updateQueue,l.updateQueue=t,Dn(l,t),l.subtreeFlags=0,t=e,e=l.child;e!==null;)_r(e,t),e=e.sibling;return V(it,it.current&1|2),B&&vl(l,a.treeForkCount),l.child}t=t.sibling}a.tail!==null&&Ht()>hu&&(l.flags|=128,n=!0,Ta(a,!1),l.lanes=4194304)}else{if(!n)if(t=ru(u),t!==null){if(l.flags|=128,n=!0,t=t.updateQueue,l.updateQueue=t,Dn(l,t),Ta(a,!0),a.tail===null&&a.tailMode==="hidden"&&!u.alternate&&!B)return K(l),null}else 2*Ht()-a.renderingStartTime>hu&&e!==536870912&&(l.flags|=128,n=!0,Ta(a,!1),l.lanes=4194304);a.isBackwards?(u.sibling=l.child,l.child=u):(t=a.last,t!==null?t.sibling=u:l.child=u,a.last=u)}return a.tail!==null?(t=a.tail,a.rendering=t,a.tail=t.sibling,a.renderingStartTime=Ht(),t.sibling=null,e=it.current,V(it,n?e&1|2:e&1),B&&vl(l,a.treeForkCount),t):(K(l),null);case 22:case 23:return Ut(l),sf(),a=l.memoizedState!==null,t!==null?t.memoizedState!==null!==a&&(l.flags|=8192):a&&(l.flags|=8192),a?e&536870912&&!(l.flags&128)&&(K(l),l.subtreeFlags&6&&(l.flags|=8192)):K(l),e=l.updateQueue,e!==null&&Dn(l,e.retryQueue),e=null,t!==null&&t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(e=t.memoizedState.cachePool.pool),a=null,l.memoizedState!==null&&l.memoizedState.cachePool!==null&&(a=l.memoizedState.cachePool.pool),a!==e&&(l.flags|=2048),t!==null&&vt(ge),null;case 24:return e=null,t!==null&&(e=t.memoizedState.cache),l.memoizedState.cache!==e&&(l.flags|=2048),zl(ot),K(l),null;case 25:return null;case 30:return null}throw Error(S(156,l.tag))}function Vy(t,l){switch(af(l),l.tag){case 1:return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 3:return zl(ot),la(),t=l.flags,t&65536&&!(t&128)?(l.flags=t&-65537|128,l):null;case 26:case 27:case 5:return eu(l),null;case 31:if(l.memoizedState!==null){if(Ut(l),l.alternate===null)throw Error(S(340));xe()}return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 13:if(Ut(l),t=l.memoizedState,t!==null&&t.dehydrated!==null){if(l.alternate===null)throw Error(S(340));xe()}return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 19:return vt(it),null;case 4:return la(),null;case 10:return zl(l.type),null;case 22:case 23:return Ut(l),sf(),t!==null&&vt(ge),t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 24:return zl(ot),null;case 25:return null;default:return null}}function _d(t,l){switch(af(l),l.tag){case 3:zl(ot),la();break;case 26:case 27:case 5:eu(l);break;case 4:la();break;case 31:l.memoizedState!==null&&Ut(l);break;case 13:Ut(l);break;case 19:vt(it);break;case 10:zl(l.type);break;case 22:case 23:Ut(l),sf(),t!==null&&vt(ge);break;case 24:zl(ot)}}function vn(t,l){try{var e=l.updateQueue,a=e!==null?e.lastEffect:null;if(a!==null){var n=a.next;e=n;do{if((e.tag&t)===t){a=void 0;var u=e.create,i=e.inst;a=u(),i.destroy=a}e=e.next}while(e!==n)}}catch(c){Y(l,l.return,c)}}function le(t,l,e){try{var a=l.updateQueue,n=a!==null?a.lastEffect:null;if(n!==null){var u=n.next;a=u;do{if((a.tag&t)===t){var i=a.inst,c=i.destroy;if(c!==void 0){i.destroy=void 0,n=l;var f=e,r=c;try{r()}catch(y){Y(n,f,y)}}}a=a.next}while(a!==u)}}catch(y){Y(l,l.return,y)}}function Dd(t){var l=t.updateQueue;if(l!==null){var e=t.stateNode;try{wr(l,e)}catch(a){Y(t,t.return,a)}}}function kd(t,l,e){e.props=ze(t.type,t.memoizedProps),e.state=t.memoizedState;try{e.componentWillUnmount()}catch(a){Y(t,l,a)}}function Za(t,l){try{var e=t.ref;if(e!==null){switch(t.tag){case 26:case 27:case 5:var a=t.stateNode;break;case 30:a=t.stateNode;break;default:a=t.stateNode}typeof e=="function"?t.refCleanup=e(a):e.current=a}}catch(n){Y(t,l,n)}}function il(t,l){var e=t.ref,a=t.refCleanup;if(e!==null)if(typeof a=="function")try{a()}catch(n){Y(t,l,n)}finally{t.refCleanup=null,t=t.alternate,t!=null&&(t.refCleanup=null)}else if(typeof e=="function")try{e(null)}catch(n){Y(t,l,n)}else e.current=null}function Cd(t){var l=t.type,e=t.memoizedProps,a=t.stateNode;try{t:switch(l){case"button":case"input":case"select":case"textarea":e.autoFocus&&a.focus();break t;case"img":e.src?a.src=e.src:e.srcSet&&(a.srcset=e.srcSet)}}catch(n){Y(t,t.return,n)}}function bi(t,l,e){try{var a=t.stateNode;gm(a,t.type,e,l),a[kt]=l}catch(n){Y(t,t.return,n)}}function Nd(t){return t.tag===5||t.tag===3||t.tag===26||t.tag===27&&ue(t.type)||t.tag===4}function Si(t){t:for(;;){for(;t.sibling===null;){if(t.return===null||Nd(t.return))return null;t=t.return}for(t.sibling.return=t.return,t=t.sibling;t.tag!==5&&t.tag!==6&&t.tag!==18;){if(t.tag===27&&ue(t.type)||t.flags&2||t.child===null||t.tag===4)continue t;t.child.return=t,t=t.child}if(!(t.flags&2))return t.stateNode}}function pc(t,l,e){var a=t.tag;if(a===5||a===6)t=t.stateNode,l?(e.nodeType===9?e.body:e.nodeName==="HTML"?e.ownerDocument.body:e).insertBefore(t,l):(l=e.nodeType===9?e.body:e.nodeName==="HTML"?e.ownerDocument.body:e,l.appendChild(t),e=e._reactRootContainer,e!=null||l.onclick!==null||(l.onclick=pl));else if(a!==4&&(a===27&&ue(t.type)&&(e=t.stateNode,l=null),t=t.child,t!==null))for(pc(t,l,e),t=t.sibling;t!==null;)pc(t,l,e),t=t.sibling}function vu(t,l,e){var a=t.tag;if(a===5||a===6)t=t.stateNode,l?e.insertBefore(t,l):e.appendChild(t);else if(a!==4&&(a===27&&ue(t.type)&&(e=t.stateNode),t=t.child,t!==null))for(vu(t,l,e),t=t.sibling;t!==null;)vu(t,l,e),t=t.sibling}function Ud(t){var l=t.stateNode,e=t.memoizedProps;try{for(var a=t.type,n=l.attributes;n.length;)l.removeAttributeNode(n[0]);zt(l,a,e),l[pt]=t,l[kt]=e}catch(u){Y(t,t.return,u)}}var hl=!1,st=!1,zi=!1,Xs=typeof WeakSet=="function"?WeakSet:Set,mt=null;function Ky(t,l){if(t=t.containerInfo,$c=Mu,t=zr(t),Ic(t)){if("selectionStart"in t)var e={start:t.selectionStart,end:t.selectionEnd};else t:{e=(e=t.ownerDocument)&&e.defaultView||window;var a=e.getSelection&&e.getSelection();if(a&&a.rangeCount!==0){e=a.anchorNode;var n=a.anchorOffset,u=a.focusNode;a=a.focusOffset;try{e.nodeType,u.nodeType}catch{e=null;break t}var i=0,c=-1,f=-1,r=0,y=0,v=t,d=null;l:for(;;){for(var g;v!==e||n!==0&&v.nodeType!==3||(c=i+n),v!==u||a!==0&&v.nodeType!==3||(f=i+a),v.nodeType===3&&(i+=v.nodeValue.length),(g=v.firstChild)!==null;)d=v,v=g;for(;;){if(v===t)break l;if(d===e&&++r===n&&(c=i),d===u&&++y===a&&(f=i),(g=v.nextSibling)!==null)break;v=d,d=v.parentNode}v=g}e=c===-1||f===-1?null:{start:c,end:f}}else e=null}e=e||{start:0,end:0}}else e=null;for(Mc={focusedElem:t,selectionRange:e},Mu=!1,mt=l;mt!==null;)if(l=mt,t=l.child,(l.subtreeFlags&1028)!==0&&t!==null)t.return=l,mt=t;else for(;mt!==null;){switch(l=mt,u=l.alternate,t=l.flags,l.tag){case 0:if(t&4&&(t=l.updateQueue,t=t!==null?t.events:null,t!==null))for(e=0;e<t.length;e++)n=t[e],n.ref.impl=n.nextImpl;break;case 11:case 15:break;case 1:if(t&1024&&u!==null){t=void 0,e=l,n=u.memoizedProps,u=u.memoizedState,a=e.stateNode;try{var p=ze(e.type,n);t=a.getSnapshotBeforeUpdate(p,u),a.__reactInternalSnapshotBeforeUpdate=t}catch(b){Y(e,e.return,b)}}break;case 3:if(t&1024){if(t=l.stateNode.containerInfo,e=t.nodeType,e===9)jc(t);else if(e===1)switch(t.nodeName){case"HEAD":case"HTML":case"BODY":jc(t);break;default:t.textContent=""}}break;case 5:case 26:case 27:case 6:case 4:case 17:break;default:if(t&1024)throw Error(S(163))}if(t=l.sibling,t!==null){t.return=l.return,mt=t;break}mt=l.return}}function Rd(t,l,e){var a=e.flags;switch(e.tag){case 0:case 11:case 15:ml(t,e),a&4&&vn(5,e);break;case 1:if(ml(t,e),a&4)if(t=e.stateNode,l===null)try{t.componentDidMount()}catch(i){Y(e,e.return,i)}else{var n=ze(e.type,l.memoizedProps);l=l.memoizedState;try{t.componentDidUpdate(n,l,t.__reactInternalSnapshotBeforeUpdate)}catch(i){Y(e,e.return,i)}}a&64&&Dd(e),a&512&&Za(e,e.return);break;case 3:if(ml(t,e),a&64&&(t=e.updateQueue,t!==null)){if(l=null,e.child!==null)switch(e.child.tag){case 27:case 5:l=e.child.stateNode;break;case 1:l=e.child.stateNode}try{wr(t,l)}catch(i){Y(e,e.return,i)}}break;case 27:l===null&&a&4&&Ud(e);case 26:case 5:ml(t,e),l===null&&a&4&&Cd(e),a&512&&Za(e,e.return);break;case 12:ml(t,e);break;case 31:ml(t,e),a&4&&Bd(t,e);break;case 13:ml(t,e),a&4&&wd(t,e),a&64&&(t=e.memoizedState,t!==null&&(t=t.dehydrated,t!==null&&(e=am.bind(null,e),Em(t,e))));break;case 22:if(a=e.memoizedState!==null||hl,!a){l=l!==null&&l.memoizedState!==null||st,n=hl;var u=st;hl=a,(st=l)&&!u?gl(t,e,(e.subtreeFlags&8772)!==0):ml(t,e),hl=n,st=u}break;case 30:break;default:ml(t,e)}}function qd(t){var l=t.alternate;l!==null&&(t.alternate=null,qd(l)),t.child=null,t.deletions=null,t.sibling=null,t.tag===5&&(l=t.stateNode,l!==null&&Qc(l)),t.stateNode=null,t.return=null,t.dependencies=null,t.memoizedProps=null,t.memoizedState=null,t.pendingProps=null,t.stateNode=null,t.updateQueue=null}var P=null,jt=!1;function yl(t,l,e){for(e=e.child;e!==null;)Hd(t,l,e),e=e.sibling}function Hd(t,l,e){if(Bt&&typeof Bt.onCommitFiberUnmount=="function")try{Bt.onCommitFiberUnmount(sn,e)}catch{}switch(e.tag){case 26:st||il(e,l),yl(t,l,e),e.memoizedState?e.memoizedState.count--:e.stateNode&&(e=e.stateNode,e.parentNode.removeChild(e));break;case 27:st||il(e,l);var a=P,n=jt;ue(e.type)&&(P=e.stateNode,jt=!1),yl(t,l,e),Qa(e.stateNode),P=a,jt=n;break;case 5:st||il(e,l);case 6:if(a=P,n=jt,P=null,yl(t,l,e),P=a,jt=n,P!==null)if(jt)try{(P.nodeType===9?P.body:P.nodeName==="HTML"?P.ownerDocument.body:P).removeChild(e.stateNode)}catch(u){Y(e,l,u)}else try{P.removeChild(e.stateNode)}catch(u){Y(e,l,u)}break;case 18:P!==null&&(jt?(t=P,to(t.nodeType===9?t.body:t.nodeName==="HTML"?t.ownerDocument.body:t,e.stateNode),ra(t)):to(P,e.stateNode));break;case 4:a=P,n=jt,P=e.stateNode.containerInfo,jt=!0,yl(t,l,e),P=a,jt=n;break;case 0:case 11:case 14:case 15:le(2,e,l),st||le(4,e,l),yl(t,l,e);break;case 1:st||(il(e,l),a=e.stateNode,typeof a.componentWillUnmount=="function"&&kd(e,l,a)),yl(t,l,e);break;case 21:yl(t,l,e);break;case 22:st=(a=st)||e.memoizedState!==null,yl(t,l,e),st=a;break;default:yl(t,l,e)}}function Bd(t,l){if(l.memoizedState===null&&(t=l.alternate,t!==null&&(t=t.memoizedState,t!==null))){t=t.dehydrated;try{ra(t)}catch(e){Y(l,l.return,e)}}}function wd(t,l){if(l.memoizedState===null&&(t=l.alternate,t!==null&&(t=t.memoizedState,t!==null&&(t=t.dehydrated,t!==null))))try{ra(t)}catch(e){Y(l,l.return,e)}}function Jy(t){switch(t.tag){case 31:case 13:case 19:var l=t.stateNode;return l===null&&(l=t.stateNode=new Xs),l;case 22:return t=t.stateNode,l=t._retryCache,l===null&&(l=t._retryCache=new Xs),l;default:throw Error(S(435,t.tag))}}function kn(t,l){var e=Jy(t);l.forEach(function(a){if(!e.has(a)){e.add(a);var n=nm.bind(null,t,a);a.then(n,n)}})}function Mt(t,l){var e=l.deletions;if(e!==null)for(var a=0;a<e.length;a++){var n=e[a],u=t,i=l,c=i;t:for(;c!==null;){switch(c.tag){case 27:if(ue(c.type)){P=c.stateNode,jt=!1;break t}break;case 5:P=c.stateNode,jt=!1;break t;case 3:case 4:P=c.stateNode.containerInfo,jt=!0;break t}c=c.return}if(P===null)throw Error(S(160));Hd(u,i,n),P=null,jt=!1,u=n.alternate,u!==null&&(u.return=null),n.return=null}if(l.subtreeFlags&13886)for(l=l.child;l!==null;)Xd(l,t),l=l.sibling}var ll=null;function Xd(t,l){var e=t.alternate,a=t.flags;switch(t.tag){case 0:case 11:case 14:case 15:Mt(l,t),Ot(t),a&4&&(le(3,t,t.return),vn(3,t),le(5,t,t.return));break;case 1:Mt(l,t),Ot(t),a&512&&(st||e===null||il(e,e.return)),a&64&&hl&&(t=t.updateQueue,t!==null&&(a=t.callbacks,a!==null&&(e=t.shared.hiddenCallbacks,t.shared.hiddenCallbacks=e===null?a:e.concat(a))));break;case 26:var n=ll;if(Mt(l,t),Ot(t),a&512&&(st||e===null||il(e,e.return)),a&4){var u=e!==null?e.memoizedState:null;if(a=t.memoizedState,e===null)if(a===null)if(t.stateNode===null){t:{a=t.type,e=t.memoizedProps,n=n.ownerDocument||n;l:switch(a){case"title":u=n.getElementsByTagName("title")[0],(!u||u[dn]||u[pt]||u.namespaceURI==="http://www.w3.org/2000/svg"||u.hasAttribute("itemprop"))&&(u=n.createElement(a),n.head.insertBefore(u,n.querySelector("head > title"))),zt(u,a,e),u[pt]=t,gt(u),a=u;break t;case"link":var i=co("link","href",n).get(a+(e.href||""));if(i){for(var c=0;c<i.length;c++)if(u=i[c],u.getAttribute("href")===(e.href==null||e.href===""?null:e.href)&&u.getAttribute("rel")===(e.rel==null?null:e.rel)&&u.getAttribute("title")===(e.title==null?null:e.title)&&u.getAttribute("crossorigin")===(e.crossOrigin==null?null:e.crossOrigin)){i.splice(c,1);break l}}u=n.createElement(a),zt(u,a,e),n.head.appendChild(u);break;case"meta":if(i=co("meta","content",n).get(a+(e.content||""))){for(c=0;c<i.length;c++)if(u=i[c],u.getAttribute("content")===(e.content==null?null:""+e.content)&&u.getAttribute("name")===(e.name==null?null:e.name)&&u.getAttribute("property")===(e.property==null?null:e.property)&&u.getAttribute("http-equiv")===(e.httpEquiv==null?null:e.httpEquiv)&&u.getAttribute("charset")===(e.charSet==null?null:e.charSet)){i.splice(c,1);break l}}u=n.createElement(a),zt(u,a,e),n.head.appendChild(u);break;default:throw Error(S(468,a))}u[pt]=t,gt(u),a=u}t.stateNode=a}else fo(n,t.type,t.stateNode);else t.stateNode=io(n,a,t.memoizedProps);else u!==a?(u===null?e.stateNode!==null&&(e=e.stateNode,e.parentNode.removeChild(e)):u.count--,a===null?fo(n,t.type,t.stateNode):io(n,a,t.memoizedProps)):a===null&&t.stateNode!==null&&bi(t,t.memoizedProps,e.memoizedProps)}break;case 27:Mt(l,t),Ot(t),a&512&&(st||e===null||il(e,e.return)),e!==null&&a&4&&bi(t,t.memoizedProps,e.memoizedProps);break;case 5:if(Mt(l,t),Ot(t),a&512&&(st||e===null||il(e,e.return)),t.flags&32){n=t.stateNode;try{aa(n,"")}catch(p){Y(t,t.return,p)}}a&4&&t.stateNode!=null&&(n=t.memoizedProps,bi(t,n,e!==null?e.memoizedProps:n)),a&1024&&(zi=!0);break;case 6:if(Mt(l,t),Ot(t),a&4){if(t.stateNode===null)throw Error(S(162));a=t.memoizedProps,e=t.stateNode;try{e.nodeValue=a}catch(p){Y(t,t.return,p)}}break;case 3:if(Fn=null,n=ll,ll=Tu(l.containerInfo),Mt(l,t),ll=n,Ot(t),a&4&&e!==null&&e.memoizedState.isDehydrated)try{ra(l.containerInfo)}catch(p){Y(t,t.return,p)}zi&&(zi=!1,Zd(t));break;case 4:a=ll,ll=Tu(t.stateNode.containerInfo),Mt(l,t),Ot(t),ll=a;break;case 12:Mt(l,t),Ot(t);break;case 31:Mt(l,t),Ot(t),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,kn(t,a)));break;case 13:Mt(l,t),Ot(t),t.child.flags&8192&&t.memoizedState!==null!=(e!==null&&e.memoizedState!==null)&&(Gu=Ht()),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,kn(t,a)));break;case 22:n=t.memoizedState!==null;var f=e!==null&&e.memoizedState!==null,r=hl,y=st;if(hl=r||n,st=y||f,Mt(l,t),st=y,hl=r,Ot(t),a&8192)t:for(l=t.stateNode,l._visibility=n?l._visibility&-2:l._visibility|1,n&&(e===null||f||hl||st||de(t)),e=null,l=t;;){if(l.tag===5||l.tag===26){if(e===null){f=e=l;try{if(u=f.stateNode,n)i=u.style,typeof i.setProperty=="function"?i.setProperty("display","none","important"):i.display="none";else{c=f.stateNode;var v=f.memoizedProps.style,d=v!=null&&v.hasOwnProperty("display")?v.display:null;c.style.display=d==null||typeof d=="boolean"?"":(""+d).trim()}}catch(p){Y(f,f.return,p)}}}else if(l.tag===6){if(e===null){f=l;try{f.stateNode.nodeValue=n?"":f.memoizedProps}catch(p){Y(f,f.return,p)}}}else if(l.tag===18){if(e===null){f=l;try{var g=f.stateNode;n?lo(g,!0):lo(f.stateNode,!1)}catch(p){Y(f,f.return,p)}}}else if((l.tag!==22&&l.tag!==23||l.memoizedState===null||l===t)&&l.child!==null){l.child.return=l,l=l.child;continue}if(l===t)break t;for(;l.sibling===null;){if(l.return===null||l.return===t)break t;e===l&&(e=null),l=l.return}e===l&&(e=null),l.sibling.return=l.return,l=l.sibling}a&4&&(a=t.updateQueue,a!==null&&(e=a.retryQueue,e!==null&&(a.retryQueue=null,kn(t,e))));break;case 19:Mt(l,t),Ot(t),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,kn(t,a)));break;case 30:break;case 21:break;default:Mt(l,t),Ot(t)}}function Ot(t){var l=t.flags;if(l&2){try{for(var e,a=t.return;a!==null;){if(Nd(a)){e=a;break}a=a.return}if(e==null)throw Error(S(160));switch(e.tag){case 27:var n=e.stateNode,u=Si(t);vu(t,u,n);break;case 5:var i=e.stateNode;e.flags&32&&(aa(i,""),e.flags&=-33);var c=Si(t);vu(t,c,i);break;case 3:case 4:var f=e.stateNode.containerInfo,r=Si(t);pc(t,r,f);break;default:throw Error(S(161))}}catch(y){Y(t,t.return,y)}t.flags&=-3}l&4096&&(t.flags&=-4097)}function Zd(t){if(t.subtreeFlags&1024)for(t=t.child;t!==null;){var l=t;Zd(l),l.tag===5&&l.flags&1024&&l.stateNode.reset(),t=t.sibling}}function ml(t,l){if(l.subtreeFlags&8772)for(l=l.child;l!==null;)Rd(t,l.alternate,l),l=l.sibling}function de(t){for(t=t.child;t!==null;){var l=t;switch(l.tag){case 0:case 11:case 14:case 15:le(4,l,l.return),de(l);break;case 1:il(l,l.return);var e=l.stateNode;typeof e.componentWillUnmount=="function"&&kd(l,l.return,e),de(l);break;case 27:Qa(l.stateNode);case 26:case 5:il(l,l.return),de(l);break;case 22:l.memoizedState===null&&de(l);break;case 30:de(l);break;default:de(l)}t=t.sibling}}function gl(t,l,e){for(e=e&&(l.subtreeFlags&8772)!==0,l=l.child;l!==null;){var a=l.alternate,n=t,u=l,i=u.flags;switch(u.tag){case 0:case 11:case 15:gl(n,u,e),vn(4,u);break;case 1:if(gl(n,u,e),a=u,n=a.stateNode,typeof n.componentDidMount=="function")try{n.componentDidMount()}catch(r){Y(a,a.return,r)}if(a=u,n=a.updateQueue,n!==null){var c=a.stateNode;try{var f=n.shared.hiddenCallbacks;if(f!==null)for(n.shared.hiddenCallbacks=null,n=0;n<f.length;n++)Br(f[n],c)}catch(r){Y(a,a.return,r)}}e&&i&64&&Dd(u),Za(u,u.return);break;case 27:Ud(u);case 26:case 5:gl(n,u,e),e&&a===null&&i&4&&Cd(u),Za(u,u.return);break;case 12:gl(n,u,e);break;case 31:gl(n,u,e),e&&i&4&&Bd(n,u);break;case 13:gl(n,u,e),e&&i&4&&wd(n,u);break;case 22:u.memoizedState===null&&gl(n,u,e),Za(u,u.return);break;case 30:break;default:gl(n,u,e)}l=l.sibling}}function Af(t,l){var e=null;t!==null&&t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(e=t.memoizedState.cachePool.pool),t=null,l.memoizedState!==null&&l.memoizedState.cachePool!==null&&(t=l.memoizedState.cachePool.pool),t!==e&&(t!=null&&t.refCount++,e!=null&&mn(e))}function $f(t,l){t=null,l.alternate!==null&&(t=l.alternate.memoizedState.cache),l=l.memoizedState.cache,l!==t&&(l.refCount++,t!=null&&mn(t))}function tl(t,l,e,a){if(l.subtreeFlags&10256)for(l=l.child;l!==null;)Yd(t,l,e,a),l=l.sibling}function Yd(t,l,e,a){var n=l.flags;switch(l.tag){case 0:case 11:case 15:tl(t,l,e,a),n&2048&&vn(9,l);break;case 1:tl(t,l,e,a);break;case 3:tl(t,l,e,a),n&2048&&(t=null,l.alternate!==null&&(t=l.alternate.memoizedState.cache),l=l.memoizedState.cache,l!==t&&(l.refCount++,t!=null&&mn(t)));break;case 12:if(n&2048){tl(t,l,e,a),t=l.stateNode;try{var u=l.memoizedProps,i=u.id,c=u.onPostCommit;typeof c=="function"&&c(i,l.alternate===null?"mount":"update",t.passiveEffectDuration,-0)}catch(f){Y(l,l.return,f)}}else tl(t,l,e,a);break;case 31:tl(t,l,e,a);break;case 13:tl(t,l,e,a);break;case 23:break;case 22:u=l.stateNode,i=l.alternate,l.memoizedState!==null?u._visibility&2?tl(t,l,e,a):Ya(t,l):u._visibility&2?tl(t,l,e,a):(u._visibility|=2,Ne(t,l,e,a,(l.subtreeFlags&10256)!==0||!1)),n&2048&&Af(i,l);break;case 24:tl(t,l,e,a),n&2048&&$f(l.alternate,l);break;default:tl(t,l,e,a)}}function Ne(t,l,e,a,n){for(n=n&&((l.subtreeFlags&10256)!==0||!1),l=l.child;l!==null;){var u=t,i=l,c=e,f=a,r=i.flags;switch(i.tag){case 0:case 11:case 15:Ne(u,i,c,f,n),vn(8,i);break;case 23:break;case 22:var y=i.stateNode;i.memoizedState!==null?y._visibility&2?Ne(u,i,c,f,n):Ya(u,i):(y._visibility|=2,Ne(u,i,c,f,n)),n&&r&2048&&Af(i.alternate,i);break;case 24:Ne(u,i,c,f,n),n&&r&2048&&$f(i.alternate,i);break;default:Ne(u,i,c,f,n)}l=l.sibling}}function Ya(t,l){if(l.subtreeFlags&10256)for(l=l.child;l!==null;){var e=t,a=l,n=a.flags;switch(a.tag){case 22:Ya(e,a),n&2048&&Af(a.alternate,a);break;case 24:Ya(e,a),n&2048&&$f(a.alternate,a);break;default:Ya(e,a)}l=l.sibling}}var ka=8192;function _e(t,l,e){if(t.subtreeFlags&ka)for(t=t.child;t!==null;)Gd(t,l,e),t=t.sibling}function Gd(t,l,e){switch(t.tag){case 26:_e(t,l,e),t.flags&ka&&t.memoizedState!==null&&Um(e,ll,t.memoizedState,t.memoizedProps);break;case 5:_e(t,l,e);break;case 3:case 4:var a=ll;ll=Tu(t.stateNode.containerInfo),_e(t,l,e),ll=a;break;case 22:t.memoizedState===null&&(a=t.alternate,a!==null&&a.memoizedState!==null?(a=ka,ka=16777216,_e(t,l,e),ka=a):_e(t,l,e));break;default:_e(t,l,e)}}function Ld(t){var l=t.alternate;if(l!==null&&(t=l.child,t!==null)){l.child=null;do l=t.sibling,t.sibling=null,t=l;while(t!==null)}}function Aa(t){var l=t.deletions;if(t.flags&16){if(l!==null)for(var e=0;e<l.length;e++){var a=l[e];mt=a,Vd(a,t)}Ld(t)}if(t.subtreeFlags&10256)for(t=t.child;t!==null;)Qd(t),t=t.sibling}function Qd(t){switch(t.tag){case 0:case 11:case 15:Aa(t),t.flags&2048&&le(9,t,t.return);break;case 3:Aa(t);break;case 12:Aa(t);break;case 22:var l=t.stateNode;t.memoizedState!==null&&l._visibility&2&&(t.return===null||t.return.tag!==13)?(l._visibility&=-3,Jn(t)):Aa(t);break;default:Aa(t)}}function Jn(t){var l=t.deletions;if(t.flags&16){if(l!==null)for(var e=0;e<l.length;e++){var a=l[e];mt=a,Vd(a,t)}Ld(t)}for(t=t.child;t!==null;){switch(l=t,l.tag){case 0:case 11:case 15:le(8,l,l.return),Jn(l);break;case 22:e=l.stateNode,e._visibility&2&&(e._visibility&=-3,Jn(l));break;default:Jn(l)}t=t.sibling}}function Vd(t,l){for(;mt!==null;){var e=mt;switch(e.tag){case 0:case 11:case 15:le(8,e,l);break;case 23:case 22:if(e.memoizedState!==null&&e.memoizedState.cachePool!==null){var a=e.memoizedState.cachePool.pool;a!=null&&a.refCount++}break;case 24:mn(e.memoizedState.cache)}if(a=e.child,a!==null)a.return=e,mt=a;else t:for(e=t;mt!==null;){a=mt;var n=a.sibling,u=a.return;if(qd(a),a===e){mt=null;break t}if(n!==null){n.return=u,mt=n;break t}mt=u}}}var Wy={getCacheForType:function(t){var l=St(ot),e=l.data.get(t);return e===void 0&&(e=t(),l.data.set(t,e)),e},cacheSignal:function(){return St(ot).controller.signal}},Fy=typeof WeakMap=="function"?WeakMap:Map,w=0,Q=null,q=null,H=0,Z=0,Nt=null,Xl=!1,ha=!1,Mf=!1,Ol=0,at=0,ee=0,he=0,Of=0,qt=0,ca=0,Ga=null,_t=null,bc=!1,Gu=0,Kd=0,hu=1/0,xu=null,Kl=null,dt=0,Jl=null,fa=null,El=0,Sc=0,zc=null,Jd=null,La=0,Ec=null;function Xt(){return w&2&&H!==0?H&-H:D.T!==null?_f():nr()}function Wd(){if(qt===0)if(!(H&536870912)||B){var t=Tn;Tn<<=1,!(Tn&3932160)&&(Tn=262144),qt=t}else qt=536870912;return t=Yt.current,t!==null&&(t.flags|=32),qt}function Dt(t,l,e){(t===Q&&(Z===2||Z===9)||t.cancelPendingCommit!==null)&&(sa(t,0),Zl(t,H,qt,!1)),rn(t,e),(!(w&2)||t!==Q)&&(t===Q&&(!(w&2)&&(he|=e),at===4&&Zl(t,H,qt,!1)),sl(t))}function Fd(t,l,e){if(w&6)throw Error(S(327));var a=!e&&(l&127)===0&&(l&t.expiredLanes)===0||on(t,l),n=a?tm(t,l):Ei(t,l,!0),u=a;do{if(n===0){ha&&!a&&Zl(t,l,0,!1);break}else{if(e=t.current.alternate,u&&!Iy(e)){n=Ei(t,l,!1),u=!1;continue}if(n===2){if(u=l,t.errorRecoveryDisabledLanes&u)var i=0;else i=t.pendingLanes&-536870913,i=i!==0?i:i&536870912?536870912:0;if(i!==0){l=i;t:{var c=t;n=Ga;var f=c.current.memoizedState.isDehydrated;if(f&&(sa(c,i).flags|=256),i=Ei(c,i,!1),i!==2){if(Mf&&!f){c.errorRecoveryDisabledLanes|=u,he|=u,n=4;break t}u=_t,_t=n,u!==null&&(_t===null?_t=u:_t.push.apply(_t,u))}n=i}if(u=!1,n!==2)continue}}if(n===1){sa(t,0),Zl(t,l,0,!0);break}t:{switch(a=t,u=n,u){case 0:case 1:throw Error(S(345));case 4:if((l&4194048)!==l)break;case 6:Zl(a,l,qt,!Xl);break t;case 2:_t=null;break;case 3:case 5:break;default:throw Error(S(329))}if((l&62914560)===l&&(n=Gu+300-Ht(),10<n)){if(Zl(a,l,qt,!Xl),Cu(a,0,!0)!==0)break t;El=l,a.timeoutHandle=h0(Zs.bind(null,a,e,_t,xu,bc,l,qt,he,ca,Xl,u,"Throttled",-0,0),n);break t}Zs(a,e,_t,xu,bc,l,qt,he,ca,Xl,u,null,-0,0)}}break}while(!0);sl(t)}function Zs(t,l,e,a,n,u,i,c,f,r,y,v,d,g){if(t.timeoutHandle=-1,v=l.subtreeFlags,v&8192||(v&16785408)===16785408){v={stylesheets:null,count:0,imgCount:0,imgBytes:0,suspenseyImages:[],waitingForImages:!0,waitingForViewTransition:!1,unsuspend:pl},Gd(l,u,v);var p=(u&62914560)===u?Gu-Ht():(u&4194048)===u?Kd-Ht():0;if(p=Rm(v,p),p!==null){El=u,t.cancelPendingCommit=p(Gs.bind(null,t,l,u,e,a,n,i,c,f,y,v,null,d,g)),Zl(t,u,i,!r);return}}Gs(t,l,u,e,a,n,i,c,f)}function Iy(t){for(var l=t;;){var e=l.tag;if((e===0||e===11||e===15)&&l.flags&16384&&(e=l.updateQueue,e!==null&&(e=e.stores,e!==null)))for(var a=0;a<e.length;a++){var n=e[a],u=n.getSnapshot;n=n.value;try{if(!Zt(u(),n))return!1}catch{return!1}}if(e=l.child,l.subtreeFlags&16384&&e!==null)e.return=l,l=e;else{if(l===t)break;for(;l.sibling===null;){if(l.return===null||l.return===t)return!0;l=l.return}l.sibling.return=l.return,l=l.sibling}}return!0}function Zl(t,l,e,a){l&=~Of,l&=~he,t.suspendedLanes|=l,t.pingedLanes&=~l,a&&(t.warmLanes|=l),a=t.expirationTimes;for(var n=l;0<n;){var u=31-wt(n),i=1<<u;a[u]=-1,n&=~i}e!==0&&lr(t,e,l)}function Lu(){return w&6?!0:(hn(0),!1)}function jf(){if(q!==null){if(Z===0)var t=q.return;else t=q,bl=Me=null,mf(t),Ie=null,Pa=0,t=q;for(;t!==null;)_d(t.alternate,t),t=t.return;q=null}}function sa(t,l){var e=t.timeoutHandle;e!==-1&&(t.timeoutHandle=-1,xm(e)),e=t.cancelPendingCommit,e!==null&&(t.cancelPendingCommit=null,e()),El=0,jf(),Q=t,q=e=Sl(t.current,null),H=l,Z=0,Nt=null,Xl=!1,ha=on(t,l),Mf=!1,ca=qt=Of=he=ee=at=0,_t=Ga=null,bc=!1,l&8&&(l|=l&32);var a=t.entangledLanes;if(a!==0)for(t=t.entanglements,a&=l;0<a;){var n=31-wt(a),u=1<<n;l|=t[n],a&=~u}return Ol=l,qu(),e}function Id(t,l){C=null,D.H=ln,l===va||l===Bu?(l=bs(),Z=3):l===cf?(l=bs(),Z=4):Z=l===Ef?8:l!==null&&typeof l=="object"&&typeof l.then=="function"?6:1,Nt=l,q===null&&(at=1,mu(t,Jt(l,t.current)))}function Pd(){var t=Yt.current;return t===null?!0:(H&4194048)===H?Ft===null:(H&62914560)===H||H&536870912?t===Ft:!1}function t0(){var t=D.H;return D.H=ln,t===null?ln:t}function l0(){var t=D.A;return D.A=Wy,t}function pu(){at=4,Xl||(H&4194048)!==H&&Yt.current!==null||(ha=!0),!(ee&134217727)&&!(he&134217727)||Q===null||Zl(Q,H,qt,!1)}function Ei(t,l,e){var a=w;w|=2;var n=t0(),u=l0();(Q!==t||H!==l)&&(xu=null,sa(t,l)),l=!1;var i=at;t:do try{if(Z!==0&&q!==null){var c=q,f=Nt;switch(Z){case 8:jf(),i=6;break t;case 3:case 2:case 9:case 6:Yt.current===null&&(l=!0);var r=Z;if(Z=0,Nt=null,Ve(t,c,f,r),e&&ha){i=0;break t}break;default:r=Z,Z=0,Nt=null,Ve(t,c,f,r)}}Py(),i=at;break}catch(y){Id(t,y)}while(!0);return l&&t.shellSuspendCounter++,bl=Me=null,w=a,D.H=n,D.A=u,q===null&&(Q=null,H=0,qu()),i}function Py(){for(;q!==null;)e0(q)}function tm(t,l){var e=w;w|=2;var a=t0(),n=l0();Q!==t||H!==l?(xu=null,hu=Ht()+500,sa(t,l)):ha=on(t,l);t:do try{if(Z!==0&&q!==null){l=q;var u=Nt;l:switch(Z){case 1:Z=0,Nt=null,Ve(t,l,u,1);break;case 2:case 9:if(ps(u)){Z=0,Nt=null,Ys(l);break}l=function(){Z!==2&&Z!==9||Q!==t||(Z=7),sl(t)},u.then(l,l);break t;case 3:Z=7;break t;case 4:Z=5;break t;case 7:ps(u)?(Z=0,Nt=null,Ys(l)):(Z=0,Nt=null,Ve(t,l,u,7));break;case 5:var i=null;switch(q.tag){case 26:i=q.memoizedState;case 5:case 27:var c=q;if(i?z0(i):c.stateNode.complete){Z=0,Nt=null;var f=c.sibling;if(f!==null)q=f;else{var r=c.return;r!==null?(q=r,Qu(r)):q=null}break l}}Z=0,Nt=null,Ve(t,l,u,5);break;case 6:Z=0,Nt=null,Ve(t,l,u,6);break;case 8:jf(),at=6;break t;default:throw Error(S(462))}}lm();break}catch(y){Id(t,y)}while(!0);return bl=Me=null,D.H=a,D.A=n,w=e,q!==null?0:(Q=null,H=0,qu(),at)}function lm(){for(;q!==null&&!T1();)e0(q)}function e0(t){var l=jd(t.alternate,t,Ol);t.memoizedProps=t.pendingProps,l===null?Qu(t):q=l}function Ys(t){var l=t,e=l.alternate;switch(l.tag){case 15:case 0:l=Rs(e,l,l.pendingProps,l.type,void 0,H);break;case 11:l=Rs(e,l,l.pendingProps,l.type.render,l.ref,H);break;case 5:mf(l);default:_d(e,l),l=q=_r(l,Ol),l=jd(e,l,Ol)}t.memoizedProps=t.pendingProps,l===null?Qu(t):q=l}function Ve(t,l,e,a){bl=Me=null,mf(l),Ie=null,Pa=0;var n=l.return;try{if(Yy(t,n,l,e,H)){at=1,mu(t,Jt(e,t.current)),q=null;return}}catch(u){if(n!==null)throw q=n,u;at=1,mu(t,Jt(e,t.current)),q=null;return}l.flags&32768?(B||a===1?t=!0:ha||H&536870912?t=!1:(Xl=t=!0,(a===2||a===9||a===3||a===6)&&(a=Yt.current,a!==null&&a.tag===13&&(a.flags|=16384))),a0(l,t)):Qu(l)}function Qu(t){var l=t;do{if(l.flags&32768){a0(l,Xl);return}t=l.return;var e=Qy(l.alternate,l,Ol);if(e!==null){q=e;return}if(l=l.sibling,l!==null){q=l;return}q=l=t}while(l!==null);at===0&&(at=5)}function a0(t,l){do{var e=Vy(t.alternate,t);if(e!==null){e.flags&=32767,q=e;return}if(e=t.return,e!==null&&(e.flags|=32768,e.subtreeFlags=0,e.deletions=null),!l&&(t=t.sibling,t!==null)){q=t;return}q=t=e}while(t!==null);at=6,q=null}function Gs(t,l,e,a,n,u,i,c,f){t.cancelPendingCommit=null;do Vu();while(dt!==0);if(w&6)throw Error(S(327));if(l!==null){if(l===t.current)throw Error(S(177));if(u=l.lanes|l.childLanes,u|=Pc,N1(t,e,u,i,c,f),t===Q&&(q=Q=null,H=0),fa=l,Jl=t,El=e,Sc=u,zc=n,Jd=a,l.subtreeFlags&10256||l.flags&10256?(t.callbackNode=null,t.callbackPriority=0,um(au,function(){return f0(),null})):(t.callbackNode=null,t.callbackPriority=0),a=(l.flags&13878)!==0,l.subtreeFlags&13878||a){a=D.T,D.T=null,n=X.p,X.p=2,i=w,w|=4;try{Ky(t,l,e)}finally{w=i,X.p=n,D.T=a}}dt=1,n0(),u0(),i0()}}function n0(){if(dt===1){dt=0;var t=Jl,l=fa,e=(l.flags&13878)!==0;if(l.subtreeFlags&13878||e){e=D.T,D.T=null;var a=X.p;X.p=2;var n=w;w|=4;try{Xd(l,t);var u=Mc,i=zr(t.containerInfo),c=u.focusedElem,f=u.selectionRange;if(i!==c&&c&&c.ownerDocument&&Sr(c.ownerDocument.documentElement,c)){if(f!==null&&Ic(c)){var r=f.start,y=f.end;if(y===void 0&&(y=r),"selectionStart"in c)c.selectionStart=r,c.selectionEnd=Math.min(y,c.value.length);else{var v=c.ownerDocument||document,d=v&&v.defaultView||window;if(d.getSelection){var g=d.getSelection(),p=c.textContent.length,b=Math.min(f.start,p),z=f.end===void 0?b:Math.min(f.end,p);!g.extend&&b>z&&(i=z,z=b,b=i);var o=ds(c,b),s=ds(c,z);if(o&&s&&(g.rangeCount!==1||g.anchorNode!==o.node||g.anchorOffset!==o.offset||g.focusNode!==s.node||g.focusOffset!==s.offset)){var m=v.createRange();m.setStart(o.node,o.offset),g.removeAllRanges(),b>z?(g.addRange(m),g.extend(s.node,s.offset)):(m.setEnd(s.node,s.offset),g.addRange(m))}}}}for(v=[],g=c;g=g.parentNode;)g.nodeType===1&&v.push({element:g,left:g.scrollLeft,top:g.scrollTop});for(typeof c.focus=="function"&&c.focus(),c=0;c<v.length;c++){var h=v[c];h.element.scrollLeft=h.left,h.element.scrollTop=h.top}}Mu=!!$c,Mc=$c=null}finally{w=n,X.p=a,D.T=e}}t.current=l,dt=2}}function u0(){if(dt===2){dt=0;var t=Jl,l=fa,e=(l.flags&8772)!==0;if(l.subtreeFlags&8772||e){e=D.T,D.T=null;var a=X.p;X.p=2;var n=w;w|=4;try{Rd(t,l.alternate,l)}finally{w=n,X.p=a,D.T=e}}dt=3}}function i0(){if(dt===4||dt===3){dt=0,A1();var t=Jl,l=fa,e=El,a=Jd;l.subtreeFlags&10256||l.flags&10256?dt=5:(dt=0,fa=Jl=null,c0(t,t.pendingLanes));var n=t.pendingLanes;if(n===0&&(Kl=null),Lc(e),l=l.stateNode,Bt&&typeof Bt.onCommitFiberRoot=="function")try{Bt.onCommitFiberRoot(sn,l,void 0,(l.current.flags&128)===128)}catch{}if(a!==null){l=D.T,n=X.p,X.p=2,D.T=null;try{for(var u=t.onRecoverableError,i=0;i<a.length;i++){var c=a[i];u(c.value,{componentStack:c.stack})}}finally{D.T=l,X.p=n}}El&3&&Vu(),sl(t),n=t.pendingLanes,e&261930&&n&42?t===Ec?La++:(La=0,Ec=t):La=0,hn(0)}}function c0(t,l){(t.pooledCacheLanes&=l)===0&&(l=t.pooledCache,l!=null&&(t.pooledCache=null,mn(l)))}function Vu(){return n0(),u0(),i0(),f0()}function f0(){if(dt!==5)return!1;var t=Jl,l=Sc;Sc=0;var e=Lc(El),a=D.T,n=X.p;try{X.p=32>e?32:e,D.T=null,e=zc,zc=null;var u=Jl,i=El;if(dt=0,fa=Jl=null,El=0,w&6)throw Error(S(331));var c=w;if(w|=4,Qd(u.current),Yd(u,u.current,i,e),w=c,hn(0,!1),Bt&&typeof Bt.onPostCommitFiberRoot=="function")try{Bt.onPostCommitFiberRoot(sn,u)}catch{}return!0}finally{X.p=n,D.T=a,c0(t,l)}}function Ls(t,l,e){l=Jt(e,l),l=vc(t.stateNode,l,2),t=Vl(t,l,2),t!==null&&(rn(t,2),sl(t))}function Y(t,l,e){if(t.tag===3)Ls(t,t,e);else for(;l!==null;){if(l.tag===3){Ls(l,t,e);break}else if(l.tag===1){var a=l.stateNode;if(typeof l.type.getDerivedStateFromError=="function"||typeof a.componentDidCatch=="function"&&(Kl===null||!Kl.has(a))){t=Jt(e,t),e=Ed(2),a=Vl(l,e,2),a!==null&&(Td(e,a,l,t),rn(a,2),sl(a));break}}l=l.return}}function Ti(t,l,e){var a=t.pingCache;if(a===null){a=t.pingCache=new Fy;var n=new Set;a.set(l,n)}else n=a.get(l),n===void 0&&(n=new Set,a.set(l,n));n.has(e)||(Mf=!0,n.add(e),t=em.bind(null,t,l,e),l.then(t,t))}function em(t,l,e){var a=t.pingCache;a!==null&&a.delete(l),t.pingedLanes|=t.suspendedLanes&e,t.warmLanes&=~e,Q===t&&(H&e)===e&&(at===4||at===3&&(H&62914560)===H&&300>Ht()-Gu?!(w&2)&&sa(t,0):Of|=e,ca===H&&(ca=0)),sl(t)}function s0(t,l){l===0&&(l=tr()),t=$e(t,l),t!==null&&(rn(t,l),sl(t))}function am(t){var l=t.memoizedState,e=0;l!==null&&(e=l.retryLane),s0(t,e)}function nm(t,l){var e=0;switch(t.tag){case 31:case 13:var a=t.stateNode,n=t.memoizedState;n!==null&&(e=n.retryLane);break;case 19:a=t.stateNode;break;case 22:a=t.stateNode._retryCache;break;default:throw Error(S(314))}a!==null&&a.delete(l),s0(t,e)}function um(t,l){return Yc(t,l)}var bu=null,Ue=null,Tc=!1,Su=!1,Ai=!1,Yl=0;function sl(t){t!==Ue&&t.next===null&&(Ue===null?bu=Ue=t:Ue=Ue.next=t),Su=!0,Tc||(Tc=!0,cm())}function hn(t,l){if(!Ai&&Su){Ai=!0;do for(var e=!1,a=bu;a!==null;){if(t!==0){var n=a.pendingLanes;if(n===0)var u=0;else{var i=a.suspendedLanes,c=a.pingedLanes;u=(1<<31-wt(42|t)+1)-1,u&=n&~(i&~c),u=u&201326741?u&201326741|1:u?u|2:0}u!==0&&(e=!0,Qs(a,u))}else u=H,u=Cu(a,a===Q?u:0,a.cancelPendingCommit!==null||a.timeoutHandle!==-1),!(u&3)||on(a,u)||(e=!0,Qs(a,u));a=a.next}while(e);Ai=!1}}function im(){o0()}function o0(){Su=Tc=!1;var t=0;Yl!==0&&hm()&&(t=Yl);for(var l=Ht(),e=null,a=bu;a!==null;){var n=a.next,u=r0(a,l);u===0?(a.next=null,e===null?bu=n:e.next=n,n===null&&(Ue=e)):(e=a,(t!==0||u&3)&&(Su=!0)),a=n}dt!==0&&dt!==5||hn(t),Yl!==0&&(Yl=0)}function r0(t,l){for(var e=t.suspendedLanes,a=t.pingedLanes,n=t.expirationTimes,u=t.pendingLanes&-62914561;0<u;){var i=31-wt(u),c=1<<i,f=n[i];f===-1?(!(c&e)||c&a)&&(n[i]=C1(c,l)):f<=l&&(t.expiredLanes|=c),u&=~c}if(l=Q,e=H,e=Cu(t,t===l?e:0,t.cancelPendingCommit!==null||t.timeoutHandle!==-1),a=t.callbackNode,e===0||t===l&&(Z===2||Z===9)||t.cancelPendingCommit!==null)return a!==null&&a!==null&&Pu(a),t.callbackNode=null,t.callbackPriority=0;if(!(e&3)||on(t,e)){if(l=e&-e,l===t.callbackPriority)return l;switch(a!==null&&Pu(a),Lc(e)){case 2:case 8:e=Io;break;case 32:e=au;break;case 268435456:e=Po;break;default:e=au}return a=d0.bind(null,t),e=Yc(e,a),t.callbackPriority=l,t.callbackNode=e,l}return a!==null&&a!==null&&Pu(a),t.callbackPriority=2,t.callbackNode=null,2}function d0(t,l){if(dt!==0&&dt!==5)return t.callbackNode=null,t.callbackPriority=0,null;var e=t.callbackNode;if(Vu()&&t.callbackNode!==e)return null;var a=H;return a=Cu(t,t===Q?a:0,t.cancelPendingCommit!==null||t.timeoutHandle!==-1),a===0?null:(Fd(t,a,l),r0(t,Ht()),t.callbackNode!=null&&t.callbackNode===e?d0.bind(null,t):null)}function Qs(t,l){if(Vu())return null;Fd(t,l,!0)}function cm(){pm(function(){w&6?Yc(Fo,im):o0()})}function _f(){if(Yl===0){var t=na;t===0&&(t=En,En<<=1,!(En&261888)&&(En=256)),Yl=t}return Yl}function Vs(t){return t==null||typeof t=="symbol"||typeof t=="boolean"?null:typeof t=="function"?t:wn(""+t)}function Ks(t,l){var e=l.ownerDocument.createElement("input");return e.name=l.name,e.value=l.value,t.id&&e.setAttribute("form",t.id),l.parentNode.insertBefore(e,l),t=new FormData(t),e.parentNode.removeChild(e),t}function fm(t,l,e,a,n){if(l==="submit"&&e&&e.stateNode===n){var u=Vs((n[kt]||null).action),i=a.submitter;i&&(l=(l=i[kt]||null)?Vs(l.formAction):i.getAttribute("formAction"),l!==null&&(u=l,i=null));var c=new Nu("action","action",null,a,n);t.push({event:c,listeners:[{instance:null,listener:function(){if(a.defaultPrevented){if(Yl!==0){var f=i?Ks(n,i):new FormData(n);mc(e,{pending:!0,data:f,method:n.method,action:u},null,f)}}else typeof u=="function"&&(c.preventDefault(),f=i?Ks(n,i):new FormData(n),mc(e,{pending:!0,data:f,method:n.method,action:u},u,f))},currentTarget:n}]})}}for(var $i=0;$i<ec.length;$i++){var Mi=ec[$i],sm=Mi.toLowerCase(),om=Mi[0].toUpperCase()+Mi.slice(1);el(sm,"on"+om)}el(Tr,"onAnimationEnd");el(Ar,"onAnimationIteration");el($r,"onAnimationStart");el("dblclick","onDoubleClick");el("focusin","onFocus");el("focusout","onBlur");el($y,"onTransitionRun");el(My,"onTransitionStart");el(Oy,"onTransitionCancel");el(Mr,"onTransitionEnd");ea("onMouseEnter",["mouseout","mouseover"]);ea("onMouseLeave",["mouseout","mouseover"]);ea("onPointerEnter",["pointerout","pointerover"]);ea("onPointerLeave",["pointerout","pointerover"]);Ee("onChange","change click focusin focusout input keydown keyup selectionchange".split(" "));Ee("onSelect","focusout contextmenu dragend focusin keydown keyup mousedown mouseup selectionchange".split(" "));Ee("onBeforeInput",["compositionend","keypress","textInput","paste"]);Ee("onCompositionEnd","compositionend focusout keydown keypress keyup mousedown".split(" "));Ee("onCompositionStart","compositionstart focusout keydown keypress keyup mousedown".split(" "));Ee("onCompositionUpdate","compositionupdate focusout keydown keypress keyup mousedown".split(" "));var en="abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting".split(" "),rm=new Set("beforetoggle cancel close invalid load scroll scrollend toggle".split(" ").concat(en));function y0(t,l){l=(l&4)!==0;for(var e=0;e<t.length;e++){var a=t[e],n=a.event;a=a.listeners;t:{var u=void 0;if(l)for(var i=a.length-1;0<=i;i--){var c=a[i],f=c.instance,r=c.currentTarget;if(c=c.listener,f!==u&&n.isPropagationStopped())break t;u=c,n.currentTarget=r;try{u(n)}catch(y){uu(y)}n.currentTarget=null,u=f}else for(i=0;i<a.length;i++){if(c=a[i],f=c.instance,r=c.currentTarget,c=c.listener,f!==u&&n.isPropagationStopped())break t;u=c,n.currentTarget=r;try{u(n)}catch(y){uu(y)}n.currentTarget=null,u=f}}}}function R(t,l){var e=l[Ki];e===void 0&&(e=l[Ki]=new Set);var a=t+"__bubble";e.has(a)||(m0(l,t,2,!1),e.add(a))}function Oi(t,l,e){var a=0;l&&(a|=4),m0(e,t,a,l)}var Cn="_reactListening"+Math.random().toString(36).slice(2);function Df(t){if(!t[Cn]){t[Cn]=!0,ur.forEach(function(e){e!=="selectionchange"&&(rm.has(e)||Oi(e,!1,t),Oi(e,!0,t))});var l=t.nodeType===9?t:t.ownerDocument;l===null||l[Cn]||(l[Cn]=!0,Oi("selectionchange",!1,l))}}function m0(t,l,e,a){switch(M0(l)){case 2:var n=Bm;break;case 8:n=wm;break;default:n=Uf}e=n.bind(null,l,e,t),n=void 0,!Pi||l!=="touchstart"&&l!=="touchmove"&&l!=="wheel"||(n=!0),a?n!==void 0?t.addEventListener(l,e,{capture:!0,passive:n}):t.addEventListener(l,e,!0):n!==void 0?t.addEventListener(l,e,{passive:n}):t.addEventListener(l,e,!1)}function ji(t,l,e,a,n){var u=a;if(!(l&1)&&!(l&2)&&a!==null)t:for(;;){if(a===null)return;var i=a.tag;if(i===3||i===4){var c=a.stateNode.containerInfo;if(c===n)break;if(i===4)for(i=a.return;i!==null;){var f=i.tag;if((f===3||f===4)&&i.stateNode.containerInfo===n)return;i=i.return}for(;c!==null;){if(i=He(c),i===null)return;if(f=i.tag,f===5||f===6||f===26||f===27){a=u=i;continue t}c=c.parentNode}}a=a.return}yr(function(){var r=u,y=Kc(e),v=[];t:{var d=Or.get(t);if(d!==void 0){var g=Nu,p=t;switch(t){case"keypress":if(Zn(e)===0)break t;case"keydown":case"keyup":g=ny;break;case"focusin":p="focus",g=ni;break;case"focusout":p="blur",g=ni;break;case"beforeblur":case"afterblur":g=ni;break;case"click":if(e.button===2)break t;case"auxclick":case"dblclick":case"mousedown":case"mousemove":case"mouseup":case"mouseout":case"mouseover":case"contextmenu":g=es;break;case"drag":case"dragend":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"dragstart":case"drop":g=Q1;break;case"touchcancel":case"touchend":case"touchmove":case"touchstart":g=cy;break;case Tr:case Ar:case $r:g=J1;break;case Mr:g=sy;break;case"scroll":case"scrollend":g=G1;break;case"wheel":g=ry;break;case"copy":case"cut":case"paste":g=F1;break;case"gotpointercapture":case"lostpointercapture":case"pointercancel":case"pointerdown":case"pointermove":case"pointerout":case"pointerover":case"pointerup":g=ns;break;case"toggle":case"beforetoggle":g=yy}var b=(l&4)!==0,z=!b&&(t==="scroll"||t==="scrollend"),o=b?d!==null?d+"Capture":null:d;b=[];for(var s=r,m;s!==null;){var h=s;if(m=h.stateNode,h=h.tag,h!==5&&h!==26&&h!==27||m===null||o===null||(h=Ka(s,o),h!=null&&b.push(an(s,h,m))),z)break;s=s.return}0<b.length&&(d=new g(d,p,null,e,y),v.push({event:d,listeners:b}))}}if(!(l&7)){t:{if(d=t==="mouseover"||t==="pointerover",g=t==="mouseout"||t==="pointerout",d&&e!==Ii&&(p=e.relatedTarget||e.fromElement)&&(He(p)||p[ya]))break t;if((g||d)&&(d=y.window===y?y:(d=y.ownerDocument)?d.defaultView||d.parentWindow:window,g?(p=e.relatedTarget||e.toElement,g=r,p=p?He(p):null,p!==null&&(z=fn(p),b=p.tag,p!==z||b!==5&&b!==27&&b!==6)&&(p=null)):(g=null,p=r),g!==p)){if(b=es,h="onMouseLeave",o="onMouseEnter",s="mouse",(t==="pointerout"||t==="pointerover")&&(b=ns,h="onPointerLeave",o="onPointerEnter",s="pointer"),z=g==null?d:_a(g),m=p==null?d:_a(p),d=new b(h,s+"leave",g,e,y),d.target=z,d.relatedTarget=m,h=null,He(y)===r&&(b=new b(o,s+"enter",p,e,y),b.target=m,b.relatedTarget=z,h=b),z=h,g&&p)l:{for(b=dm,o=g,s=p,m=0,h=o;h;h=b(h))m++;h=0;for(var T=s;T;T=b(T))h++;for(;0<m-h;)o=b(o),m--;for(;0<h-m;)s=b(s),h--;for(;m--;){if(o===s||s!==null&&o===s.alternate){b=o;break l}o=b(o),s=b(s)}b=null}else b=null;g!==null&&Js(v,d,g,b,!1),p!==null&&z!==null&&Js(v,z,p,b,!0)}}t:{if(d=r?_a(r):window,g=d.nodeName&&d.nodeName.toLowerCase(),g==="select"||g==="input"&&d.type==="file")var M=fs;else if(cs(d))if(pr)M=Ey;else{M=Sy;var E=by}else g=d.nodeName,!g||g.toLowerCase()!=="input"||d.type!=="checkbox"&&d.type!=="radio"?r&&Vc(r.elementType)&&(M=fs):M=zy;if(M&&(M=M(t,r))){xr(v,M,e,y);break t}E&&E(t,d,r),t==="focusout"&&r&&d.type==="number"&&r.memoizedProps.value!=null&&Fi(d,"number",d.value)}switch(E=r?_a(r):window,t){case"focusin":(cs(E)||E.contentEditable==="true")&&(Xe=E,tc=r,Ra=null);break;case"focusout":Ra=tc=Xe=null;break;case"mousedown":lc=!0;break;case"contextmenu":case"mouseup":case"dragend":lc=!1,ys(v,e,y);break;case"selectionchange":if(Ay)break;case"keydown":case"keyup":ys(v,e,y)}var j;if(Fc)t:{switch(t){case"compositionstart":var $="onCompositionStart";break t;case"compositionend":$="onCompositionEnd";break t;case"compositionupdate":$="onCompositionUpdate";break t}$=void 0}else we?vr(t,e)&&($="onCompositionEnd"):t==="keydown"&&e.keyCode===229&&($="onCompositionStart");$&&(gr&&e.locale!=="ko"&&(we||$!=="onCompositionStart"?$==="onCompositionEnd"&&we&&(j=mr()):(wl=y,Jc="value"in wl?wl.value:wl.textContent,we=!0)),E=zu(r,$),0<E.length&&($=new as($,t,null,e,y),v.push({event:$,listeners:E}),j?$.data=j:(j=hr(e),j!==null&&($.data=j)))),(j=gy?vy(t,e):hy(t,e))&&($=zu(r,"onBeforeInput"),0<$.length&&(E=new as("onBeforeInput","beforeinput",null,e,y),v.push({event:E,listeners:$}),E.data=j)),fm(v,t,r,e,y)}y0(v,l)})}function an(t,l,e){return{instance:t,listener:l,currentTarget:e}}function zu(t,l){for(var e=l+"Capture",a=[];t!==null;){var n=t,u=n.stateNode;if(n=n.tag,n!==5&&n!==26&&n!==27||u===null||(n=Ka(t,e),n!=null&&a.unshift(an(t,n,u)),n=Ka(t,l),n!=null&&a.push(an(t,n,u))),t.tag===3)return a;t=t.return}return[]}function dm(t){if(t===null)return null;do t=t.return;while(t&&t.tag!==5&&t.tag!==27);return t||null}function Js(t,l,e,a,n){for(var u=l._reactName,i=[];e!==null&&e!==a;){var c=e,f=c.alternate,r=c.stateNode;if(c=c.tag,f!==null&&f===a)break;c!==5&&c!==26&&c!==27||r===null||(f=r,n?(r=Ka(e,u),r!=null&&i.unshift(an(e,r,f))):n||(r=Ka(e,u),r!=null&&i.push(an(e,r,f)))),e=e.return}i.length!==0&&t.push({event:l,listeners:i})}var ym=/\r\n?/g,mm=/\u0000|\uFFFD/g;function Ws(t){return(typeof t=="string"?t:""+t).replace(ym,`
+`).replace(mm,"")}function g0(t,l){return l=Ws(l),Ws(t)===l}function G(t,l,e,a,n,u){switch(e){case"children":typeof a=="string"?l==="body"||l==="textarea"&&a===""||aa(t,a):(typeof a=="number"||typeof a=="bigint")&&l!=="body"&&aa(t,""+a);break;case"className":$n(t,"class",a);break;case"tabIndex":$n(t,"tabindex",a);break;case"dir":case"role":case"viewBox":case"width":case"height":$n(t,e,a);break;case"style":dr(t,a,u);break;case"data":if(l!=="object"){$n(t,"data",a);break}case"src":case"href":if(a===""&&(l!=="a"||e!=="href")){t.removeAttribute(e);break}if(a==null||typeof a=="function"||typeof a=="symbol"||typeof a=="boolean"){t.removeAttribute(e);break}a=wn(""+a),t.setAttribute(e,a);break;case"action":case"formAction":if(typeof a=="function"){t.setAttribute(e,"javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')");break}else typeof u=="function"&&(e==="formAction"?(l!=="input"&&G(t,l,"name",n.name,n,null),G(t,l,"formEncType",n.formEncType,n,null),G(t,l,"formMethod",n.formMethod,n,null),G(t,l,"formTarget",n.formTarget,n,null)):(G(t,l,"encType",n.encType,n,null),G(t,l,"method",n.method,n,null),G(t,l,"target",n.target,n,null)));if(a==null||typeof a=="symbol"||typeof a=="boolean"){t.removeAttribute(e);break}a=wn(""+a),t.setAttribute(e,a);break;case"onClick":a!=null&&(t.onclick=pl);break;case"onScroll":a!=null&&R("scroll",t);break;case"onScrollEnd":a!=null&&R("scrollend",t);break;case"dangerouslySetInnerHTML":if(a!=null){if(typeof a!="object"||!("__html"in a))throw Error(S(61));if(e=a.__html,e!=null){if(n.children!=null)throw Error(S(60));t.innerHTML=e}}break;case"multiple":t.multiple=a&&typeof a!="function"&&typeof a!="symbol";break;case"muted":t.muted=a&&typeof a!="function"&&typeof a!="symbol";break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"defaultValue":case"defaultChecked":case"innerHTML":case"ref":break;case"autoFocus":break;case"xlinkHref":if(a==null||typeof a=="function"||typeof a=="boolean"||typeof a=="symbol"){t.removeAttribute("xlink:href");break}e=wn(""+a),t.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",e);break;case"contentEditable":case"spellCheck":case"draggable":case"value":case"autoReverse":case"externalResourcesRequired":case"focusable":case"preserveAlpha":a!=null&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,""+a):t.removeAttribute(e);break;case"inert":case"allowFullScreen":case"async":case"autoPlay":case"controls":case"default":case"defer":case"disabled":case"disablePictureInPicture":case"disableRemotePlayback":case"formNoValidate":case"hidden":case"loop":case"noModule":case"noValidate":case"open":case"playsInline":case"readOnly":case"required":case"reversed":case"scoped":case"seamless":case"itemScope":a&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,""):t.removeAttribute(e);break;case"capture":case"download":a===!0?t.setAttribute(e,""):a!==!1&&a!=null&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,a):t.removeAttribute(e);break;case"cols":case"rows":case"size":case"span":a!=null&&typeof a!="function"&&typeof a!="symbol"&&!isNaN(a)&&1<=a?t.setAttribute(e,a):t.removeAttribute(e);break;case"rowSpan":case"start":a==null||typeof a=="function"||typeof a=="symbol"||isNaN(a)?t.removeAttribute(e):t.setAttribute(e,a);break;case"popover":R("beforetoggle",t),R("toggle",t),Bn(t,"popover",a);break;case"xlinkActuate":rl(t,"http://www.w3.org/1999/xlink","xlink:actuate",a);break;case"xlinkArcrole":rl(t,"http://www.w3.org/1999/xlink","xlink:arcrole",a);break;case"xlinkRole":rl(t,"http://www.w3.org/1999/xlink","xlink:role",a);break;case"xlinkShow":rl(t,"http://www.w3.org/1999/xlink","xlink:show",a);break;case"xlinkTitle":rl(t,"http://www.w3.org/1999/xlink","xlink:title",a);break;case"xlinkType":rl(t,"http://www.w3.org/1999/xlink","xlink:type",a);break;case"xmlBase":rl(t,"http://www.w3.org/XML/1998/namespace","xml:base",a);break;case"xmlLang":rl(t,"http://www.w3.org/XML/1998/namespace","xml:lang",a);break;case"xmlSpace":rl(t,"http://www.w3.org/XML/1998/namespace","xml:space",a);break;case"is":Bn(t,"is",a);break;case"innerText":case"textContent":break;default:(!(2<e.length)||e[0]!=="o"&&e[0]!=="O"||e[1]!=="n"&&e[1]!=="N")&&(e=Z1.get(e)||e,Bn(t,e,a))}}function Ac(t,l,e,a,n,u){switch(e){case"style":dr(t,a,u);break;case"dangerouslySetInnerHTML":if(a!=null){if(typeof a!="object"||!("__html"in a))throw Error(S(61));if(e=a.__html,e!=null){if(n.children!=null)throw Error(S(60));t.innerHTML=e}}break;case"children":typeof a=="string"?aa(t,a):(typeof a=="number"||typeof a=="bigint")&&aa(t,""+a);break;case"onScroll":a!=null&&R("scroll",t);break;case"onScrollEnd":a!=null&&R("scrollend",t);break;case"onClick":a!=null&&(t.onclick=pl);break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"innerHTML":case"ref":break;case"innerText":case"textContent":break;default:if(!ir.hasOwnProperty(e))t:{if(e[0]==="o"&&e[1]==="n"&&(n=e.endsWith("Capture"),l=e.slice(2,n?e.length-7:void 0),u=t[kt]||null,u=u!=null?u[e]:null,typeof u=="function"&&t.removeEventListener(l,u,n),typeof a=="function")){typeof u!="function"&&u!==null&&(e in t?t[e]=null:t.hasAttribute(e)&&t.removeAttribute(e)),t.addEventListener(l,a,n);break t}e in t?t[e]=a:a===!0?t.setAttribute(e,""):Bn(t,e,a)}}}function zt(t,l,e){switch(l){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"img":R("error",t),R("load",t);var a=!1,n=!1,u;for(u in e)if(e.hasOwnProperty(u)){var i=e[u];if(i!=null)switch(u){case"src":a=!0;break;case"srcSet":n=!0;break;case"children":case"dangerouslySetInnerHTML":throw Error(S(137,l));default:G(t,l,u,i,e,null)}}n&&G(t,l,"srcSet",e.srcSet,e,null),a&&G(t,l,"src",e.src,e,null);return;case"input":R("invalid",t);var c=u=i=n=null,f=null,r=null;for(a in e)if(e.hasOwnProperty(a)){var y=e[a];if(y!=null)switch(a){case"name":n=y;break;case"type":i=y;break;case"checked":f=y;break;case"defaultChecked":r=y;break;case"value":u=y;break;case"defaultValue":c=y;break;case"children":case"dangerouslySetInnerHTML":if(y!=null)throw Error(S(137,l));break;default:G(t,l,a,y,e,null)}}sr(t,u,c,f,r,i,n,!1);return;case"select":R("invalid",t),a=i=u=null;for(n in e)if(e.hasOwnProperty(n)&&(c=e[n],c!=null))switch(n){case"value":u=c;break;case"defaultValue":i=c;break;case"multiple":a=c;default:G(t,l,n,c,e,null)}l=u,e=i,t.multiple=!!a,l!=null?Je(t,!!a,l,!1):e!=null&&Je(t,!!a,e,!0);return;case"textarea":R("invalid",t),u=n=a=null;for(i in e)if(e.hasOwnProperty(i)&&(c=e[i],c!=null))switch(i){case"value":a=c;break;case"defaultValue":n=c;break;case"children":u=c;break;case"dangerouslySetInnerHTML":if(c!=null)throw Error(S(91));break;default:G(t,l,i,c,e,null)}rr(t,a,n,u);return;case"option":for(f in e)if(e.hasOwnProperty(f)&&(a=e[f],a!=null))switch(f){case"selected":t.selected=a&&typeof a!="function"&&typeof a!="symbol";break;default:G(t,l,f,a,e,null)}return;case"dialog":R("beforetoggle",t),R("toggle",t),R("cancel",t),R("close",t);break;case"iframe":case"object":R("load",t);break;case"video":case"audio":for(a=0;a<en.length;a++)R(en[a],t);break;case"image":R("error",t),R("load",t);break;case"details":R("toggle",t);break;case"embed":case"source":case"link":R("error",t),R("load",t);case"area":case"base":case"br":case"col":case"hr":case"keygen":case"meta":case"param":case"track":case"wbr":case"menuitem":for(r in e)if(e.hasOwnProperty(r)&&(a=e[r],a!=null))switch(r){case"children":case"dangerouslySetInnerHTML":throw Error(S(137,l));default:G(t,l,r,a,e,null)}return;default:if(Vc(l)){for(y in e)e.hasOwnProperty(y)&&(a=e[y],a!==void 0&&Ac(t,l,y,a,e,void 0));return}}for(c in e)e.hasOwnProperty(c)&&(a=e[c],a!=null&&G(t,l,c,a,e,null))}function gm(t,l,e,a){switch(l){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"input":var n=null,u=null,i=null,c=null,f=null,r=null,y=null;for(g in e){var v=e[g];if(e.hasOwnProperty(g)&&v!=null)switch(g){case"checked":break;case"value":break;case"defaultValue":f=v;default:a.hasOwnProperty(g)||G(t,l,g,null,a,v)}}for(var d in a){var g=a[d];if(v=e[d],a.hasOwnProperty(d)&&(g!=null||v!=null))switch(d){case"type":u=g;break;case"name":n=g;break;case"checked":r=g;break;case"defaultChecked":y=g;break;case"value":i=g;break;case"defaultValue":c=g;break;case"children":case"dangerouslySetInnerHTML":if(g!=null)throw Error(S(137,l));break;default:g!==v&&G(t,l,d,g,a,v)}}Wi(t,i,c,f,r,y,u,n);return;case"select":g=i=c=d=null;for(u in e)if(f=e[u],e.hasOwnProperty(u)&&f!=null)switch(u){case"value":break;case"multiple":g=f;default:a.hasOwnProperty(u)||G(t,l,u,null,a,f)}for(n in a)if(u=a[n],f=e[n],a.hasOwnProperty(n)&&(u!=null||f!=null))switch(n){case"value":d=u;break;case"defaultValue":c=u;break;case"multiple":i=u;default:u!==f&&G(t,l,n,u,a,f)}l=c,e=i,a=g,d!=null?Je(t,!!e,d,!1):!!a!=!!e&&(l!=null?Je(t,!!e,l,!0):Je(t,!!e,e?[]:"",!1));return;case"textarea":g=d=null;for(c in e)if(n=e[c],e.hasOwnProperty(c)&&n!=null&&!a.hasOwnProperty(c))switch(c){case"value":break;case"children":break;default:G(t,l,c,null,a,n)}for(i in a)if(n=a[i],u=e[i],a.hasOwnProperty(i)&&(n!=null||u!=null))switch(i){case"value":d=n;break;case"defaultValue":g=n;break;case"children":break;case"dangerouslySetInnerHTML":if(n!=null)throw Error(S(91));break;default:n!==u&&G(t,l,i,n,a,u)}or(t,d,g);return;case"option":for(var p in e)if(d=e[p],e.hasOwnProperty(p)&&d!=null&&!a.hasOwnProperty(p))switch(p){case"selected":t.selected=!1;break;default:G(t,l,p,null,a,d)}for(f in a)if(d=a[f],g=e[f],a.hasOwnProperty(f)&&d!==g&&(d!=null||g!=null))switch(f){case"selected":t.selected=d&&typeof d!="function"&&typeof d!="symbol";break;default:G(t,l,f,d,a,g)}return;case"img":case"link":case"area":case"base":case"br":case"col":case"embed":case"hr":case"keygen":case"meta":case"param":case"source":case"track":case"wbr":case"menuitem":for(var b in e)d=e[b],e.hasOwnProperty(b)&&d!=null&&!a.hasOwnProperty(b)&&G(t,l,b,null,a,d);for(r in a)if(d=a[r],g=e[r],a.hasOwnProperty(r)&&d!==g&&(d!=null||g!=null))switch(r){case"children":case"dangerouslySetInnerHTML":if(d!=null)throw Error(S(137,l));break;default:G(t,l,r,d,a,g)}return;default:if(Vc(l)){for(var z in e)d=e[z],e.hasOwnProperty(z)&&d!==void 0&&!a.hasOwnProperty(z)&&Ac(t,l,z,void 0,a,d);for(y in a)d=a[y],g=e[y],!a.hasOwnProperty(y)||d===g||d===void 0&&g===void 0||Ac(t,l,y,d,a,g);return}}for(var o in e)d=e[o],e.hasOwnProperty(o)&&d!=null&&!a.hasOwnProperty(o)&&G(t,l,o,null,a,d);for(v in a)d=a[v],g=e[v],!a.hasOwnProperty(v)||d===g||d==null&&g==null||G(t,l,v,d,a,g)}function Fs(t){switch(t){case"css":case"script":case"font":case"img":case"image":case"input":case"link":return!0;default:return!1}}function vm(){if(typeof performance.getEntriesByType=="function"){for(var t=0,l=0,e=performance.getEntriesByType("resource"),a=0;a<e.length;a++){var n=e[a],u=n.transferSize,i=n.initiatorType,c=n.duration;if(u&&c&&Fs(i)){for(i=0,c=n.responseEnd,a+=1;a<e.length;a++){var f=e[a],r=f.startTime;if(r>c)break;var y=f.transferSize,v=f.initiatorType;y&&Fs(v)&&(f=f.responseEnd,i+=y*(f<c?1:(c-r)/(f-r)))}if(--a,l+=8*(u+i)/(n.duration/1e3),t++,10<t)break}}if(0<t)return l/t/1e6}return navigator.connection&&(t=navigator.connection.downlink,typeof t=="number")?t:5}var $c=null,Mc=null;function Eu(t){return t.nodeType===9?t:t.ownerDocument}function Is(t){switch(t){case"http://www.w3.org/2000/svg":return 1;case"http://www.w3.org/1998/Math/MathML":return 2;default:return 0}}function v0(t,l){if(t===0)switch(l){case"svg":return 1;case"math":return 2;default:return 0}return t===1&&l==="foreignObject"?0:t}function Oc(t,l){return t==="textarea"||t==="noscript"||typeof l.children=="string"||typeof l.children=="number"||typeof l.children=="bigint"||typeof l.dangerouslySetInnerHTML=="object"&&l.dangerouslySetInnerHTML!==null&&l.dangerouslySetInnerHTML.__html!=null}var _i=null;function hm(){var t=window.event;return t&&t.type==="popstate"?t===_i?!1:(_i=t,!0):(_i=null,!1)}var h0=typeof setTimeout=="function"?setTimeout:void 0,xm=typeof clearTimeout=="function"?clearTimeout:void 0,Ps=typeof Promise=="function"?Promise:void 0,pm=typeof queueMicrotask=="function"?queueMicrotask:typeof Ps<"u"?function(t){return Ps.resolve(null).then(t).catch(bm)}:h0;function bm(t){setTimeout(function(){throw t})}function ue(t){return t==="head"}function to(t,l){var e=l,a=0;do{var n=e.nextSibling;if(t.removeChild(e),n&&n.nodeType===8)if(e=n.data,e==="/$"||e==="/&"){if(a===0){t.removeChild(n),ra(l);return}a--}else if(e==="$"||e==="$?"||e==="$~"||e==="$!"||e==="&")a++;else if(e==="html")Qa(t.ownerDocument.documentElement);else if(e==="head"){e=t.ownerDocument.head,Qa(e);for(var u=e.firstChild;u;){var i=u.nextSibling,c=u.nodeName;u[dn]||c==="SCRIPT"||c==="STYLE"||c==="LINK"&&u.rel.toLowerCase()==="stylesheet"||e.removeChild(u),u=i}}else e==="body"&&Qa(t.ownerDocument.body);e=n}while(e);ra(l)}function lo(t,l){var e=t;t=0;do{var a=e.nextSibling;if(e.nodeType===1?l?(e._stashedDisplay=e.style.display,e.style.display="none"):(e.style.display=e._stashedDisplay||"",e.getAttribute("style")===""&&e.removeAttribute("style")):e.nodeType===3&&(l?(e._stashedText=e.nodeValue,e.nodeValue=""):e.nodeValue=e._stashedText||""),a&&a.nodeType===8)if(e=a.data,e==="/$"){if(t===0)break;t--}else e!=="$"&&e!=="$?"&&e!=="$~"&&e!=="$!"||t++;e=a}while(e)}function jc(t){var l=t.firstChild;for(l&&l.nodeType===10&&(l=l.nextSibling);l;){var e=l;switch(l=l.nextSibling,e.nodeName){case"HTML":case"HEAD":case"BODY":jc(e),Qc(e);continue;case"SCRIPT":case"STYLE":continue;case"LINK":if(e.rel.toLowerCase()==="stylesheet")continue}t.removeChild(e)}}function Sm(t,l,e,a){for(;t.nodeType===1;){var n=e;if(t.nodeName.toLowerCase()!==l.toLowerCase()){if(!a&&(t.nodeName!=="INPUT"||t.type!=="hidden"))break}else if(a){if(!t[dn])switch(l){case"meta":if(!t.hasAttribute("itemprop"))break;return t;case"link":if(u=t.getAttribute("rel"),u==="stylesheet"&&t.hasAttribute("data-precedence"))break;if(u!==n.rel||t.getAttribute("href")!==(n.href==null||n.href===""?null:n.href)||t.getAttribute("crossorigin")!==(n.crossOrigin==null?null:n.crossOrigin)||t.getAttribute("title")!==(n.title==null?null:n.title))break;return t;case"style":if(t.hasAttribute("data-precedence"))break;return t;case"script":if(u=t.getAttribute("src"),(u!==(n.src==null?null:n.src)||t.getAttribute("type")!==(n.type==null?null:n.type)||t.getAttribute("crossorigin")!==(n.crossOrigin==null?null:n.crossOrigin))&&u&&t.hasAttribute("async")&&!t.hasAttribute("itemprop"))break;return t;default:return t}}else if(l==="input"&&t.type==="hidden"){var u=n.name==null?null:""+n.name;if(n.type==="hidden"&&t.getAttribute("name")===u)return t}else return t;if(t=It(t.nextSibling),t===null)break}return null}function zm(t,l,e){if(l==="")return null;for(;t.nodeType!==3;)if((t.nodeType!==1||t.nodeName!=="INPUT"||t.type!=="hidden")&&!e||(t=It(t.nextSibling),t===null))return null;return t}function x0(t,l){for(;t.nodeType!==8;)if((t.nodeType!==1||t.nodeName!=="INPUT"||t.type!=="hidden")&&!l||(t=It(t.nextSibling),t===null))return null;return t}function _c(t){return t.data==="$?"||t.data==="$~"}function Dc(t){return t.data==="$!"||t.data==="$?"&&t.ownerDocument.readyState!=="loading"}function Em(t,l){var e=t.ownerDocument;if(t.data==="$~")t._reactRetry=l;else if(t.data!=="$?"||e.readyState!=="loading")l();else{var a=function(){l(),e.removeEventListener("DOMContentLoaded",a)};e.addEventListener("DOMContentLoaded",a),t._reactRetry=a}}function It(t){for(;t!=null;t=t.nextSibling){var l=t.nodeType;if(l===1||l===3)break;if(l===8){if(l=t.data,l==="$"||l==="$!"||l==="$?"||l==="$~"||l==="&"||l==="F!"||l==="F")break;if(l==="/$"||l==="/&")return null}}return t}var kc=null;function eo(t){t=t.nextSibling;for(var l=0;t;){if(t.nodeType===8){var e=t.data;if(e==="/$"||e==="/&"){if(l===0)return It(t.nextSibling);l--}else e!=="$"&&e!=="$!"&&e!=="$?"&&e!=="$~"&&e!=="&"||l++}t=t.nextSibling}return null}function ao(t){t=t.previousSibling;for(var l=0;t;){if(t.nodeType===8){var e=t.data;if(e==="$"||e==="$!"||e==="$?"||e==="$~"||e==="&"){if(l===0)return t;l--}else e!=="/$"&&e!=="/&"||l++}t=t.previousSibling}return null}function p0(t,l,e){switch(l=Eu(e),t){case"html":if(t=l.documentElement,!t)throw Error(S(452));return t;case"head":if(t=l.head,!t)throw Error(S(453));return t;case"body":if(t=l.body,!t)throw Error(S(454));return t;default:throw Error(S(451))}}function Qa(t){for(var l=t.attributes;l.length;)t.removeAttributeNode(l[0]);Qc(t)}var Pt=new Map,no=new Set;function Tu(t){return typeof t.getRootNode=="function"?t.getRootNode():t.nodeType===9?t:t.ownerDocument}var _l=X.d;X.d={f:Tm,r:Am,D:$m,C:Mm,L:Om,m:jm,X:Dm,S:_m,M:km};function Tm(){var t=_l.f(),l=Lu();return t||l}function Am(t){var l=ma(t);l!==null&&l.tag===5&&l.type==="form"?dd(l):_l.r(t)}var xa=typeof document>"u"?null:document;function b0(t,l,e){var a=xa;if(a&&typeof l=="string"&&l){var n=Kt(l);n='link[rel="'+t+'"][href="'+n+'"]',typeof e=="string"&&(n+='[crossorigin="'+e+'"]'),no.has(n)||(no.add(n),t={rel:t,crossOrigin:e,href:l},a.querySelector(n)===null&&(l=a.createElement("link"),zt(l,"link",t),gt(l),a.head.appendChild(l)))}}function $m(t){_l.D(t),b0("dns-prefetch",t,null)}function Mm(t,l){_l.C(t,l),b0("preconnect",t,l)}function Om(t,l,e){_l.L(t,l,e);var a=xa;if(a&&t&&l){var n='link[rel="preload"][as="'+Kt(l)+'"]';l==="image"&&e&&e.imageSrcSet?(n+='[imagesrcset="'+Kt(e.imageSrcSet)+'"]',typeof e.imageSizes=="string"&&(n+='[imagesizes="'+Kt(e.imageSizes)+'"]')):n+='[href="'+Kt(t)+'"]';var u=n;switch(l){case"style":u=oa(t);break;case"script":u=pa(t)}Pt.has(u)||(t=F({rel:"preload",href:l==="image"&&e&&e.imageSrcSet?void 0:t,as:l},e),Pt.set(u,t),a.querySelector(n)!==null||l==="style"&&a.querySelector(xn(u))||l==="script"&&a.querySelector(pn(u))||(l=a.createElement("link"),zt(l,"link",t),gt(l),a.head.appendChild(l)))}}function jm(t,l){_l.m(t,l);var e=xa;if(e&&t){var a=l&&typeof l.as=="string"?l.as:"script",n='link[rel="modulepreload"][as="'+Kt(a)+'"][href="'+Kt(t)+'"]',u=n;switch(a){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":u=pa(t)}if(!Pt.has(u)&&(t=F({rel:"modulepreload",href:t},l),Pt.set(u,t),e.querySelector(n)===null)){switch(a){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":if(e.querySelector(pn(u)))return}a=e.createElement("link"),zt(a,"link",t),gt(a),e.head.appendChild(a)}}}function _m(t,l,e){_l.S(t,l,e);var a=xa;if(a&&t){var n=Ke(a).hoistableStyles,u=oa(t);l=l||"default";var i=n.get(u);if(!i){var c={loading:0,preload:null};if(i=a.querySelector(xn(u)))c.loading=5;else{t=F({rel:"stylesheet",href:t,"data-precedence":l},e),(e=Pt.get(u))&&kf(t,e);var f=i=a.createElement("link");gt(f),zt(f,"link",t),f._p=new Promise(function(r,y){f.onload=r,f.onerror=y}),f.addEventListener("load",function(){c.loading|=1}),f.addEventListener("error",function(){c.loading|=2}),c.loading|=4,Wn(i,l,a)}i={type:"stylesheet",instance:i,count:1,state:c},n.set(u,i)}}}function Dm(t,l){_l.X(t,l);var e=xa;if(e&&t){var a=Ke(e).hoistableScripts,n=pa(t),u=a.get(n);u||(u=e.querySelector(pn(n)),u||(t=F({src:t,async:!0},l),(l=Pt.get(n))&&Cf(t,l),u=e.createElement("script"),gt(u),zt(u,"link",t),e.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},a.set(n,u))}}function km(t,l){_l.M(t,l);var e=xa;if(e&&t){var a=Ke(e).hoistableScripts,n=pa(t),u=a.get(n);u||(u=e.querySelector(pn(n)),u||(t=F({src:t,async:!0,type:"module"},l),(l=Pt.get(n))&&Cf(t,l),u=e.createElement("script"),gt(u),zt(u,"link",t),e.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},a.set(n,u))}}function uo(t,l,e,a){var n=(n=Gl.current)?Tu(n):null;if(!n)throw Error(S(446));switch(t){case"meta":case"title":return null;case"style":return typeof e.precedence=="string"&&typeof e.href=="string"?(l=oa(e.href),e=Ke(n).hoistableStyles,a=e.get(l),a||(a={type:"style",instance:null,count:0,state:null},e.set(l,a)),a):{type:"void",instance:null,count:0,state:null};case"link":if(e.rel==="stylesheet"&&typeof e.href=="string"&&typeof e.precedence=="string"){t=oa(e.href);var u=Ke(n).hoistableStyles,i=u.get(t);if(i||(n=n.ownerDocument||n,i={type:"stylesheet",instance:null,count:0,state:{loading:0,preload:null}},u.set(t,i),(u=n.querySelector(xn(t)))&&!u._p&&(i.instance=u,i.state.loading=5),Pt.has(t)||(e={rel:"preload",as:"style",href:e.href,crossOrigin:e.crossOrigin,integrity:e.integrity,media:e.media,hrefLang:e.hrefLang,referrerPolicy:e.referrerPolicy},Pt.set(t,e),u||Cm(n,t,e,i.state))),l&&a===null)throw Error(S(528,""));return i}if(l&&a!==null)throw Error(S(529,""));return null;case"script":return l=e.async,e=e.src,typeof e=="string"&&l&&typeof l!="function"&&typeof l!="symbol"?(l=pa(e),e=Ke(n).hoistableScripts,a=e.get(l),a||(a={type:"script",instance:null,count:0,state:null},e.set(l,a)),a):{type:"void",instance:null,count:0,state:null};default:throw Error(S(444,t))}}function oa(t){return'href="'+Kt(t)+'"'}function xn(t){return'link[rel="stylesheet"]['+t+"]"}function S0(t){return F({},t,{"data-precedence":t.precedence,precedence:null})}function Cm(t,l,e,a){t.querySelector('link[rel="preload"][as="style"]['+l+"]")?a.loading=1:(l=t.createElement("link"),a.preload=l,l.addEventListener("load",function(){return a.loading|=1}),l.addEventListener("error",function(){return a.loading|=2}),zt(l,"link",e),gt(l),t.head.appendChild(l))}function pa(t){return'[src="'+Kt(t)+'"]'}function pn(t){return"script[async]"+t}function io(t,l,e){if(l.count++,l.instance===null)switch(l.type){case"style":var a=t.querySelector('style[data-href~="'+Kt(e.href)+'"]');if(a)return l.instance=a,gt(a),a;var n=F({},e,{"data-href":e.href,"data-precedence":e.precedence,href:null,precedence:null});return a=(t.ownerDocument||t).createElement("style"),gt(a),zt(a,"style",n),Wn(a,e.precedence,t),l.instance=a;case"stylesheet":n=oa(e.href);var u=t.querySelector(xn(n));if(u)return l.state.loading|=4,l.instance=u,gt(u),u;a=S0(e),(n=Pt.get(n))&&kf(a,n),u=(t.ownerDocument||t).createElement("link"),gt(u);var i=u;return i._p=new Promise(function(c,f){i.onload=c,i.onerror=f}),zt(u,"link",a),l.state.loading|=4,Wn(u,e.precedence,t),l.instance=u;case"script":return u=pa(e.src),(n=t.querySelector(pn(u)))?(l.instance=n,gt(n),n):(a=e,(n=Pt.get(u))&&(a=F({},e),Cf(a,n)),t=t.ownerDocument||t,n=t.createElement("script"),gt(n),zt(n,"link",a),t.head.appendChild(n),l.instance=n);case"void":return null;default:throw Error(S(443,l.type))}else l.type==="stylesheet"&&!(l.state.loading&4)&&(a=l.instance,l.state.loading|=4,Wn(a,e.precedence,t));return l.instance}function Wn(t,l,e){for(var a=e.querySelectorAll('link[rel="stylesheet"][data-precedence],style[data-precedence]'),n=a.length?a[a.length-1]:null,u=n,i=0;i<a.length;i++){var c=a[i];if(c.dataset.precedence===l)u=c;else if(u!==n)break}u?u.parentNode.insertBefore(t,u.nextSibling):(l=e.nodeType===9?e.head:e,l.insertBefore(t,l.firstChild))}function kf(t,l){t.crossOrigin==null&&(t.crossOrigin=l.crossOrigin),t.referrerPolicy==null&&(t.referrerPolicy=l.referrerPolicy),t.title==null&&(t.title=l.title)}function Cf(t,l){t.crossOrigin==null&&(t.crossOrigin=l.crossOrigin),t.referrerPolicy==null&&(t.referrerPolicy=l.referrerPolicy),t.integrity==null&&(t.integrity=l.integrity)}var Fn=null;function co(t,l,e){if(Fn===null){var a=new Map,n=Fn=new Map;n.set(e,a)}else n=Fn,a=n.get(e),a||(a=new Map,n.set(e,a));if(a.has(t))return a;for(a.set(t,null),e=e.getElementsByTagName(t),n=0;n<e.length;n++){var u=e[n];if(!(u[dn]||u[pt]||t==="link"&&u.getAttribute("rel")==="stylesheet")&&u.namespaceURI!=="http://www.w3.org/2000/svg"){var i=u.getAttribute(l)||"";i=t+i;var c=a.get(i);c?c.push(u):a.set(i,[u])}}return a}function fo(t,l,e){t=t.ownerDocument||t,t.head.insertBefore(e,l==="title"?t.querySelector("head > title"):null)}function Nm(t,l,e){if(e===1||l.itemProp!=null)return!1;switch(t){case"meta":case"title":return!0;case"style":if(typeof l.precedence!="string"||typeof l.href!="string"||l.href==="")break;return!0;case"link":if(typeof l.rel!="string"||typeof l.href!="string"||l.href===""||l.onLoad||l.onError)break;switch(l.rel){case"stylesheet":return t=l.disabled,typeof l.precedence=="string"&&t==null;default:return!0}case"script":if(l.async&&typeof l.async!="function"&&typeof l.async!="symbol"&&!l.onLoad&&!l.onError&&l.src&&typeof l.src=="string")return!0}return!1}function z0(t){return!(t.type==="stylesheet"&&!(t.state.loading&3))}function Um(t,l,e,a){if(e.type==="stylesheet"&&(typeof a.media!="string"||matchMedia(a.media).matches!==!1)&&!(e.state.loading&4)){if(e.instance===null){var n=oa(a.href),u=l.querySelector(xn(n));if(u){l=u._p,l!==null&&typeof l=="object"&&typeof l.then=="function"&&(t.count++,t=Au.bind(t),l.then(t,t)),e.state.loading|=4,e.instance=u,gt(u);return}u=l.ownerDocument||l,a=S0(a),(n=Pt.get(n))&&kf(a,n),u=u.createElement("link"),gt(u);var i=u;i._p=new Promise(function(c,f){i.onload=c,i.onerror=f}),zt(u,"link",a),e.instance=u}t.stylesheets===null&&(t.stylesheets=new Map),t.stylesheets.set(e,l),(l=e.state.preload)&&!(e.state.loading&3)&&(t.count++,e=Au.bind(t),l.addEventListener("load",e),l.addEventListener("error",e))}}var Di=0;function Rm(t,l){return t.stylesheets&&t.count===0&&In(t,t.stylesheets),0<t.count||0<t.imgCount?function(e){var a=setTimeout(function(){if(t.stylesheets&&In(t,t.stylesheets),t.unsuspend){var u=t.unsuspend;t.unsuspend=null,u()}},6e4+l);0<t.imgBytes&&Di===0&&(Di=62500*vm());var n=setTimeout(function(){if(t.waitingForImages=!1,t.count===0&&(t.stylesheets&&In(t,t.stylesheets),t.unsuspend)){var u=t.unsuspend;t.unsuspend=null,u()}},(t.imgBytes>Di?50:800)+l);return t.unsuspend=e,function(){t.unsuspend=null,clearTimeout(a),clearTimeout(n)}}:null}function Au(){if(this.count--,this.count===0&&(this.imgCount===0||!this.waitingForImages)){if(this.stylesheets)In(this,this.stylesheets);else if(this.unsuspend){var t=this.unsuspend;this.unsuspend=null,t()}}}var $u=null;function In(t,l){t.stylesheets=null,t.unsuspend!==null&&(t.count++,$u=new Map,l.forEach(qm,t),$u=null,Au.call(t))}function qm(t,l){if(!(l.state.loading&4)){var e=$u.get(t);if(e)var a=e.get(null);else{e=new Map,$u.set(t,e);for(var n=t.querySelectorAll("link[data-precedence],style[data-precedence]"),u=0;u<n.length;u++){var i=n[u];(i.nodeName==="LINK"||i.getAttribute("media")!=="not all")&&(e.set(i.dataset.precedence,i),a=i)}a&&e.set(null,a)}n=l.instance,i=n.getAttribute("data-precedence"),u=e.get(i)||a,u===a&&e.set(null,n),e.set(i,n),this.count++,a=Au.bind(this),n.addEventListener("load",a),n.addEventListener("error",a),u?u.parentNode.insertBefore(n,u.nextSibling):(t=t.nodeType===9?t.head:t,t.insertBefore(n,t.firstChild)),l.state.loading|=4}}var nn={$$typeof:xl,Provider:null,Consumer:null,_currentValue:ye,_currentValue2:ye,_threadCount:0};function Hm(t,l,e,a,n,u,i,c,f){this.tag=1,this.containerInfo=t,this.pingCache=this.current=this.pendingChildren=null,this.timeoutHandle=-1,this.callbackNode=this.next=this.pendingContext=this.context=this.cancelPendingCommit=null,this.callbackPriority=0,this.expirationTimes=ti(-1),this.entangledLanes=this.shellSuspendCounter=this.errorRecoveryDisabledLanes=this.expiredLanes=this.warmLanes=this.pingedLanes=this.suspendedLanes=this.pendingLanes=0,this.entanglements=ti(0),this.hiddenUpdates=ti(null),this.identifierPrefix=a,this.onUncaughtError=n,this.onCaughtError=u,this.onRecoverableError=i,this.pooledCache=null,this.pooledCacheLanes=0,this.formState=f,this.incompleteTransitions=new Map}function E0(t,l,e,a,n,u,i,c,f,r,y,v){return t=new Hm(t,l,e,i,f,r,y,v,c),l=1,u===!0&&(l|=24),u=Rt(3,null,null,l),t.current=u,u.stateNode=t,l=nf(),l.refCount++,t.pooledCache=l,l.refCount++,u.memoizedState={element:a,isDehydrated:e,cache:l},ff(u),t}function T0(t){return t?(t=Ge,t):Ge}function A0(t,l,e,a,n,u){n=T0(n),a.context===null?a.context=n:a.pendingContext=n,a=Ql(l),a.payload={element:e},u=u===void 0?null:u,u!==null&&(a.callback=u),e=Vl(t,a,l),e!==null&&(Dt(e,t,l),Ha(e,t,l))}function so(t,l){if(t=t.memoizedState,t!==null&&t.dehydrated!==null){var e=t.retryLane;t.retryLane=e!==0&&e<l?e:l}}function Nf(t,l){so(t,l),(t=t.alternate)&&so(t,l)}function $0(t){if(t.tag===13||t.tag===31){var l=$e(t,67108864);l!==null&&Dt(l,t,67108864),Nf(t,67108864)}}function oo(t){if(t.tag===13||t.tag===31){var l=Xt();l=Gc(l);var e=$e(t,l);e!==null&&Dt(e,t,l),Nf(t,l)}}var Mu=!0;function Bm(t,l,e,a){var n=D.T;D.T=null;var u=X.p;try{X.p=2,Uf(t,l,e,a)}finally{X.p=u,D.T=n}}function wm(t,l,e,a){var n=D.T;D.T=null;var u=X.p;try{X.p=8,Uf(t,l,e,a)}finally{X.p=u,D.T=n}}function Uf(t,l,e,a){if(Mu){var n=Cc(a);if(n===null)ji(t,l,a,Ou,e),ro(t,a);else if(Zm(n,t,l,e,a))a.stopPropagation();else if(ro(t,a),l&4&&-1<Xm.indexOf(t)){for(;n!==null;){var u=ma(n);if(u!==null)switch(u.tag){case 3:if(u=u.stateNode,u.current.memoizedState.isDehydrated){var i=oe(u.pendingLanes);if(i!==0){var c=u;for(c.pendingLanes|=2,c.entangledLanes|=2;i;){var f=1<<31-wt(i);c.entanglements[1]|=f,i&=~f}sl(u),!(w&6)&&(hu=Ht()+500,hn(0))}}break;case 31:case 13:c=$e(u,2),c!==null&&Dt(c,u,2),Lu(),Nf(u,2)}if(u=Cc(a),u===null&&ji(t,l,a,Ou,e),u===n)break;n=u}n!==null&&a.stopPropagation()}else ji(t,l,a,null,e)}}function Cc(t){return t=Kc(t),Rf(t)}var Ou=null;function Rf(t){if(Ou=null,t=He(t),t!==null){var l=fn(t);if(l===null)t=null;else{var e=l.tag;if(e===13){if(t=Qo(l),t!==null)return t;t=null}else if(e===31){if(t=Vo(l),t!==null)return t;t=null}else if(e===3){if(l.stateNode.current.memoizedState.isDehydrated)return l.tag===3?l.stateNode.containerInfo:null;t=null}else l!==t&&(t=null)}}return Ou=t,null}function M0(t){switch(t){case"beforetoggle":case"cancel":case"click":case"close":case"contextmenu":case"copy":case"cut":case"auxclick":case"dblclick":case"dragend":case"dragstart":case"drop":case"focusin":case"focusout":case"input":case"invalid":case"keydown":case"keypress":case"keyup":case"mousedown":case"mouseup":case"paste":case"pause":case"play":case"pointercancel":case"pointerdown":case"pointerup":case"ratechange":case"reset":case"resize":case"seeked":case"submit":case"toggle":case"touchcancel":case"touchend":case"touchstart":case"volumechange":case"change":case"selectionchange":case"textInput":case"compositionstart":case"compositionend":case"compositionupdate":case"beforeblur":case"afterblur":case"beforeinput":case"blur":case"fullscreenchange":case"focus":case"hashchange":case"popstate":case"select":case"selectstart":return 2;case"drag":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"mousemove":case"mouseout":case"mouseover":case"pointermove":case"pointerout":case"pointerover":case"scroll":case"touchmove":case"wheel":case"mouseenter":case"mouseleave":case"pointerenter":case"pointerleave":return 8;case"message":switch($1()){case Fo:return 2;case Io:return 8;case au:case M1:return 32;case Po:return 268435456;default:return 32}default:return 32}}var Nc=!1,Wl=null,Fl=null,Il=null,un=new Map,cn=new Map,Hl=[],Xm="mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset".split(" ");function ro(t,l){switch(t){case"focusin":case"focusout":Wl=null;break;case"dragenter":case"dragleave":Fl=null;break;case"mouseover":case"mouseout":Il=null;break;case"pointerover":case"pointerout":un.delete(l.pointerId);break;case"gotpointercapture":case"lostpointercapture":cn.delete(l.pointerId)}}function $a(t,l,e,a,n,u){return t===null||t.nativeEvent!==u?(t={blockedOn:l,domEventName:e,eventSystemFlags:a,nativeEvent:u,targetContainers:[n]},l!==null&&(l=ma(l),l!==null&&$0(l)),t):(t.eventSystemFlags|=a,l=t.targetContainers,n!==null&&l.indexOf(n)===-1&&l.push(n),t)}function Zm(t,l,e,a,n){switch(l){case"focusin":return Wl=$a(Wl,t,l,e,a,n),!0;case"dragenter":return Fl=$a(Fl,t,l,e,a,n),!0;case"mouseover":return Il=$a(Il,t,l,e,a,n),!0;case"pointerover":var u=n.pointerId;return un.set(u,$a(un.get(u)||null,t,l,e,a,n)),!0;case"gotpointercapture":return u=n.pointerId,cn.set(u,$a(cn.get(u)||null,t,l,e,a,n)),!0}return!1}function O0(t){var l=He(t.target);if(l!==null){var e=fn(l);if(e!==null){if(l=e.tag,l===13){if(l=Qo(e),l!==null){t.blockedOn=l,Jf(t.priority,function(){oo(e)});return}}else if(l===31){if(l=Vo(e),l!==null){t.blockedOn=l,Jf(t.priority,function(){oo(e)});return}}else if(l===3&&e.stateNode.current.memoizedState.isDehydrated){t.blockedOn=e.tag===3?e.stateNode.containerInfo:null;return}}}t.blockedOn=null}function Pn(t){if(t.blockedOn!==null)return!1;for(var l=t.targetContainers;0<l.length;){var e=Cc(t.nativeEvent);if(e===null){e=t.nativeEvent;var a=new e.constructor(e.type,e);Ii=a,e.target.dispatchEvent(a),Ii=null}else return l=ma(e),l!==null&&$0(l),t.blockedOn=e,!1;l.shift()}return!0}function yo(t,l,e){Pn(t)&&e.delete(l)}function Ym(){Nc=!1,Wl!==null&&Pn(Wl)&&(Wl=null),Fl!==null&&Pn(Fl)&&(Fl=null),Il!==null&&Pn(Il)&&(Il=null),un.forEach(yo),cn.forEach(yo)}function Nn(t,l){t.blockedOn===l&&(t.blockedOn=null,Nc||(Nc=!0,yt.unstable_scheduleCallback(yt.unstable_NormalPriority,Ym)))}var Un=null;function mo(t){Un!==t&&(Un=t,yt.unstable_scheduleCallback(yt.unstable_NormalPriority,function(){Un===t&&(Un=null);for(var l=0;l<t.length;l+=3){var e=t[l],a=t[l+1],n=t[l+2];if(typeof a!="function"){if(Rf(a||e)===null)continue;break}var u=ma(e);u!==null&&(t.splice(l,3),l-=3,mc(u,{pending:!0,data:n,method:e.method,action:a},a,n))}}))}function ra(t){function l(f){return Nn(f,t)}Wl!==null&&Nn(Wl,t),Fl!==null&&Nn(Fl,t),Il!==null&&Nn(Il,t),un.forEach(l),cn.forEach(l);for(var e=0;e<Hl.length;e++){var a=Hl[e];a.blockedOn===t&&(a.blockedOn=null)}for(;0<Hl.length&&(e=Hl[0],e.blockedOn===null);)O0(e),e.blockedOn===null&&Hl.shift();if(e=(t.ownerDocument||t).$$reactFormReplay,e!=null)for(a=0;a<e.length;a+=3){var n=e[a],u=e[a+1],i=n[kt]||null;if(typeof u=="function")i||mo(e);else if(i){var c=null;if(u&&u.hasAttribute("formAction")){if(n=u,i=u[kt]||null)c=i.formAction;else if(Rf(n)!==null)continue}else c=i.action;typeof c=="function"?e[a+1]=c:(e.splice(a,3),a-=3),mo(e)}}}function j0(){function t(u){u.canIntercept&&u.info==="react-transition"&&u.intercept({handler:function(){return new Promise(function(i){return n=i})},focusReset:"manual",scroll:"manual"})}function l(){n!==null&&(n(),n=null),a||setTimeout(e,20)}function e(){if(!a&&!navigation.transition){var u=navigation.currentEntry;u&&u.url!=null&&navigation.navigate(u.url,{state:u.getState(),info:"react-transition",history:"replace"})}}if(typeof navigation=="object"){var a=!1,n=null;return navigation.addEventListener("navigate",t),navigation.addEventListener("navigatesuccess",l),navigation.addEventListener("navigateerror",l),setTimeout(e,100),function(){a=!0,navigation.removeEventListener("navigate",t),navigation.removeEventListener("navigatesuccess",l),navigation.removeEventListener("navigateerror",l),n!==null&&(n(),n=null)}}}function qf(t){this._internalRoot=t}Ku.prototype.render=qf.prototype.render=function(t){var l=this._internalRoot;if(l===null)throw Error(S(409));var e=l.current,a=Xt();A0(e,a,t,l,null,null)};Ku.prototype.unmount=qf.prototype.unmount=function(){var t=this._internalRoot;if(t!==null){this._internalRoot=null;var l=t.containerInfo;A0(t.current,2,null,t,null,null),Lu(),l[ya]=null}};function Ku(t){this._internalRoot=t}Ku.prototype.unstable_scheduleHydration=function(t){if(t){var l=nr();t={blockedOn:null,target:t,priority:l};for(var e=0;e<Hl.length&&l!==0&&l<Hl[e].priority;e++);Hl.splice(e,0,t),e===0&&O0(t)}};var go=Go.version;if(go!=="19.2.4")throw Error(S(527,go,"19.2.4"));X.findDOMNode=function(t){var l=t._reactInternals;if(l===void 0)throw typeof t.render=="function"?Error(S(188)):(t=Object.keys(t).join(","),Error(S(268,t)));return t=p1(l),t=t!==null?Ko(t):null,t=t===null?null:t.stateNode,t};var Gm={bundleType:0,version:"19.2.4",rendererPackageName:"react-dom",currentDispatcherRef:D,reconcilerVersion:"19.2.4"};if(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__<"u"){var Rn=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(!Rn.isDisabled&&Rn.supportsFiber)try{sn=Rn.inject(Gm),Bt=Rn}catch{}}Du.createRoot=function(t,l){if(!Lo(t))throw Error(S(299));var e=!1,a="",n=bd,u=Sd,i=zd;return l!=null&&(l.unstable_strictMode===!0&&(e=!0),l.identifierPrefix!==void 0&&(a=l.identifierPrefix),l.onUncaughtError!==void 0&&(n=l.onUncaughtError),l.onCaughtError!==void 0&&(u=l.onCaughtError),l.onRecoverableError!==void 0&&(i=l.onRecoverableError)),l=E0(t,1,!1,null,null,e,a,null,n,u,i,j0),t[ya]=l.current,Df(t),new qf(l)};Du.hydrateRoot=function(t,l,e){if(!Lo(t))throw Error(S(299));var a=!1,n="",u=bd,i=Sd,c=zd,f=null;return e!=null&&(e.unstable_strictMode===!0&&(a=!0),e.identifierPrefix!==void 0&&(n=e.identifierPrefix),e.onUncaughtError!==void 0&&(u=e.onUncaughtError),e.onCaughtError!==void 0&&(i=e.onCaughtError),e.onRecoverableError!==void 0&&(c=e.onRecoverableError),e.formState!==void 0&&(f=e.formState)),l=E0(t,1,!0,l,e??null,a,n,f,u,i,c,j0),l.context=T0(null),e=l.current,a=Xt(),a=Gc(a),n=Ql(a),n.callback=null,Vl(e,n,a),e=a,l.current.lanes=e,rn(l,e),sl(l),t[ya]=l.current,Df(t),new Ku(l)};Du.version="19.2.4";function _0(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(_0)}catch(t){console.error(t)}}_0(),Do.exports=Du;var Lm=Do.exports,Ma={},vo;function Qm(){if(vo)return Ma;vo=1,Object.defineProperty(Ma,"__esModule",{value:!0}),Ma.styleq=void 0;var t=new WeakMap,l="$$css";function e(n){var u,i,c;return n!=null&&(u=n.disableCache===!0,i=n.disableMix===!0,c=n.transform),function(){for(var r=[],y="",v=null,d="",g=u?null:t,p=new Array(arguments.length),b=0;b<arguments.length;b++)p[b]=arguments[b];for(;p.length>0;){var z=p.pop();if(!(z==null||z===!1)){if(Array.isArray(z)){for(var o=0;o<z.length;o++)p.push(z[o]);continue}var s=c!=null?c(z):z;if(s.$$css!=null){var m="";if(g!=null&&g.has(s)){var h=g.get(s);h!=null&&(m=h[0],d=h[2],r.push.apply(r,h[1]),g=h[3])}else{var T=[];for(var M in s){var E=s[M];if(M===l){var j=s[M];j!==!0&&(d=d?j+"; "+d:j);continue}typeof E=="string"||E===null?r.includes(M)||(r.push(M),g!=null&&T.push(M),typeof E=="string"&&(m+=m?" "+E:E)):console.error("styleq: ".concat(M," typeof ").concat(String(E),' is not "string" or "null".'))}if(g!=null){var $=new WeakMap;g.set(s,[m,T,d,$]),g=$}}m&&(y=y?m+" "+y:m)}else if(i)v==null&&(v={}),v=Object.assign({},s,v);else{var O=null;for(var I in s){var lt=s[I];lt!==void 0&&(r.includes(I)||(lt!=null&&(v==null&&(v={}),O==null&&(O={}),O[I]=lt),r.push(I),g=null))}O!=null&&(v=Object.assign(O,v))}}}var ol=[y,v,d];return ol}}var a=Ma.styleq=e();return a.factory=e,Ma}var Vm=Qm();function At(...t){const[l,e,a]=Vm.styleq(t),n={};return l!=null&&l!==""&&(n.className=l),e!=null&&Object.keys(e).length>0&&(n.style=e),a!=null&&a!==""&&(n["data-style-src"]=a),n}const ho={"--color-accent":"var(--color-accent)","--color-on-dark":"var(--color-on-dark)"};let xo={};function Km(t){xo={...xo,...t}}function Jm(t){return t==="base"?"":t.split("+").map(l=>{const[e,a]=l.split(":");return/^\d/.test(a)?`.${e}-${a}`:`.${a}`}).join("")}const ki={[-5]:"--font-size-4xs",[-4]:"--font-size-3xs",[-3]:"--font-size-2xs",[-2]:"--font-size-xs",[-1]:"--font-size-sm",0:"--font-size-base",1:"--font-size-lg",2:"--font-size-xl",3:"--font-size-2xl",4:"--font-size-3xl",5:"--font-size-4xl",6:"--font-size-5xl"},Wm={1:3,2:2,3:1,4:0,5:-1,6:-2},Fm={body:0,large:1,label:0,code:0,supporting:-1,"display-1":6,"display-2":5,"display-3":4},Im={1:"var(--font-weight-semibold)",2:"var(--font-weight-semibold)",3:"var(--font-weight-semibold)",4:"var(--font-weight-semibold)",5:"var(--font-weight-semibold)",6:"var(--font-weight-semibold)"},Pm={body:"var(--font-weight-normal)",large:"var(--font-weight-semibold)",label:"var(--font-weight-medium)",code:"var(--font-weight-normal)",supporting:"var(--font-weight-normal)","display-1":"var(--font-weight-normal)","display-2":"var(--font-weight-normal)","display-3":"var(--font-weight-normal)"};function Ci(t,l,e){return Math.round(t*Math.pow(l,e))}function tg(t){return`${Math.round(t/16*1e4)/1e4}rem`}function lg(t){return t<20?1.5:t<32?1.4:1.25}function po(t){const l=lg(t),e=t*l,a=Math.max(Math.round(e/4)*4,Math.ceil((t+4)/4)*4);return Math.round(a/t*1e4)/1e4}function eg(t){const{base:l,ratio:e,weights:a}=t,n={},u={...Im,...a==null?void 0:a.heading},i={...Pm,...a==null?void 0:a.text};for(let c=-5;c<=6;c++){const f=Ci(l,e,c);n[ki[c]]=tg(f)}for(const[c,f]of Object.entries(Wm)){const r=Number(c),y=Ci(l,e,f),v=po(y);n[`--text-heading-${r}-size`]=`var(${ki[f]})`,n[`--text-heading-${r}-weight`]=u[r],n[`--text-heading-${r}-leading`]=`${v}`}for(const[c,f]of Object.entries(Fm)){const r=Ci(l,e,f),y=po(r);n[`--text-${c}-size`]=`var(${ki[f]})`,n[`--text-${c}-weight`]=i[c],n[`--text-${c}-leading`]=`${y}`}return n}const ag={body:"var(--font-family-body)",large:"var(--font-family-body)",label:"var(--font-family-body)",code:"var(--font-family-code)",supporting:"var(--font-family-body)","display-1":"var(--font-family-heading)","display-2":"var(--font-family-heading)","display-3":"var(--font-family-heading)"};function ng(t){const l={},e={};for(const n of[1,2,3,4,5,6])e[`level:${n}`]={fontFamily:"var(--font-family-heading)",fontSize:`var(--text-heading-${n}-size)`,fontWeight:`var(--text-heading-${n}-weight)`,lineHeight:`var(--text-heading-${n}-leading)`};l.heading=e;const a={};for(const n of["body","large","label","code","supporting","display-1","display-2","display-3"])a[`type:${n}`]={fontFamily:ag[n],fontSize:`var(--text-${n}-size)`,lineHeight:`var(--text-${n}-leading)`};return l.text=a,l}function De(t){return Math.round(t/5)*5}function ug(t){const{fast:l,medium:e,ratio:a,easing:n}=t,u={"--duration-fast-min":`${De(l*a)}ms`,"--duration-fast":`${De(l)}ms`,"--duration-fast-max":`${De(l/a)}ms`,"--duration-medium-min":`${De(e*a)}ms`,"--duration-medium":`${De(e)}ms`,"--duration-medium-max":`${De(e/a)}ms`};return n&&(u["--ease-standard"]=n),u}function ig(t){const{base:l,multiplier:e}=t;return{"--radius-none":"0px","--radius-inner":`${Math.round(l*1*e)}px`,"--radius-element":`${Math.round(l*2*e)}px`,"--radius-container":`${Math.round(l*3*e)}px`,"--radius-page":`${Math.round(l*7*e)}px`,"--radius-full":"9999px"}}function cg(t){return Array.isArray(t)?`light-dark(${t[0]}, ${t[1]})`:t}function fg(t,l){if(!t&&!l)return;if(!t)return l;if(!l)return t;const e={};for(const[a,n]of Object.entries(t))e[a]={...n};for(const[a,n]of Object.entries(l))if(!e[a])e[a]={...n};else for(const[u,i]of Object.entries(n))e[a][u]={...e[a][u],...i};return e}function qn(t){return{normal:"var(--font-weight-normal)",medium:"var(--font-weight-medium)",semibold:"var(--font-weight-semibold)",bold:"var(--font-weight-bold)"}[t]??t}function Ni(t,l){if(!t)return;const e=t.includes(" ")?`"${t}"`:t;return l?`${e}, ${l}`:e}function sg(t){var i,c,f,r,y,v,d,g;const l={},e=t.typography;let a;if(e!=null&&e.scale){const p={},b=e.heading;if(b!=null&&b.weights)for(const[s,m]of Object.entries(b.weights))m&&(p[Number(s)]=qn(m));const z=b!=null&&b.weight?qn(b.weight):void 0;if(z)for(let s=1;s<=6;s++)s in p||(p[s]=z);const o={};(i=e.body)!=null&&i.weight&&(o.body=qn(e.body.weight)),(c=e.code)!=null&&c.weight&&(o.code=qn(e.code.weight)),a={base:e.scale.base,ratio:e.scale.ratio,weights:{...Object.keys(p).length>0?{heading:p}:{},...Object.keys(o).length>0?{text:o}:{}}}}if(a){const p=eg(a);for(const[b,z]of Object.entries(p))l[b]=z}if(t.radius){const p=ig(t.radius);for(const[b,z]of Object.entries(p))l[b]=z}if(t.motion){const p=ug(t.motion);for(const[b,z]of Object.entries(p))l[b]=z}if(e){const p=Ni((f=e.body)==null?void 0:f.family,(r=e.body)==null?void 0:r.fallbacks),b=Ni((y=e.heading)==null?void 0:y.family,(v=e.heading)==null?void 0:v.fallbacks)??p,z=Ni((d=e.code)==null?void 0:d.family,(g=e.code)==null?void 0:g.fallbacks);p&&(l["--font-family-body"]=p),b&&(l["--font-family-heading"]=b),z&&(l["--font-family-code"]=z)}if(t.tokens)for(const[p,b]of Object.entries(t.tokens))b!==void 0&&(l[p]=cg(b));let n=t.components;if(a){const p=ng();n=fg(p,t.components)}let u;if(e){const p=new Set,b=[];for(const z of[e.body,e.heading,e.code])z!=null&&z.family&&z.url&&!p.has(z.family)&&(p.add(z.family),b.push({family:z.family,url:z.url}));b.length>0&&(u=b)}return{name:t.name,tokens:l,components:n,icons:t.icons,fonts:u,__inputTokens:t.tokens}}function bo(t){return t.replace(/[A-Z]/g,l=>`-${l.toLowerCase()}`)}function og(t){const l=[],e=t.tokens,a=y=>e[y]||`var(${y})`,n=Object.entries(e);if(n.length>0){const y=n.map(([v,d])=>`    ${v}: ${d};`).join(`
+`);l.push(`  :scope {
+${y}
+  }`)}if(t.components)for(const[y,v]of Object.entries(t.components))for(const[d,g]of Object.entries(v)){const p=Object.entries(g);if(p.length>0){const b=Jm(d),z=`.xds-${y}${b}`,o=[],s=[];for(const[m,h]of p)m.startsWith(":")&&typeof h=="object"?s.push([m,h]):o.push([m,h]);if(o.length>0){const m=o.map(([h,T])=>`    ${bo(h)}: ${T};`).join(`
+`);l.push(`  ${z} {
+${m}
+  }`)}for(const[m,h]of s){const T=Object.entries(h);if(T.length>0){const M=T.map(([E,j])=>`    ${bo(E)}: ${j};`).join(`
+`);l.push(`  ${z}${m} {
+${M}
+  }`)}}}}l.push(`  :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-family-heading);
+    color: var(--color-text-primary);
+  }`);for(let y=1;y<=6;y++)l.push(`  h${y} {
+    font-size: ${a(`--text-heading-${y}-size`)};
+    font-weight: ${a(`--text-heading-${y}-weight`)};
+    line-height: ${a(`--text-heading-${y}-leading`)};
+  }`);l.push(`  p {
+    font-family: var(--font-family-heading);
+    font-size: ${a("--text-body-size")};
+    font-weight: ${a("--text-body-weight")};
+    line-height: ${a("--text-body-leading")};
+    color: var(--color-text-primary);
+  }`),l.push(`  small {
+    font-size: ${a("--text-supporting-size")};
+    font-weight: ${a("--text-supporting-weight")};
+    line-height: ${a("--text-supporting-leading")};
+    color: var(--color-text-secondary);
+  }`),l.push(`  code, pre {
+    font-family: var(--font-family-code);
+    font-size: ${a("--text-code-size")};
+    line-height: ${a("--text-code-leading")};
+  }`),l.push(`  hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+  }`);const u={primary:"var(--color-text-primary)",secondary:"var(--color-text-secondary)",disabled:"var(--color-text-disabled)",placeholder:"var(--color-text-secondary)",active:"var(--color-accent)"},i=t.components||{},c="text"in i,f="heading"in i,r="link"in i;if(c||f||r)for(const[y,v]of Object.entries(u))c&&l.push(`  .xds-text.${y} { color: ${v}; }`),f&&l.push(`  .xds-heading.${y} { color: ${v}; }`),r&&l.push(`  .xds-link.${y} { color: ${v}; }`);return l}function rg(t){const l=og(t);if(l.length===0)return"";const e=`[data-xds-theme="${t.name}"]`,a=l.join(`
+
+`);return`@scope (${e}) to ([data-xds-theme]) {
+${a}
+}`}const dg=x.createContext(null),Hn={base:{k1xSpc:"xjp7ctv",kMwMTN:"x1tgivj0",kMv6JI:"x9ynric",$$css:!0},light:{kQNsl9:"x19aimcq",$$css:!0},dark:{kQNsl9:"xntwwlm",$$css:!0},system:{kQNsl9:"x108lcm5",$$css:!0}},Ui=new Set;function yg(t){const l=x.useId();x.useInsertionEffect(()=>{if(t.__built)return;const e=`xds-theme-${t.name}`;if(Ui.has(e))return;const a=rg(t);if(!a)return;const n=document.createElement("style");return n.setAttribute("data-xds-theme",t.name),n.setAttribute("data-xds-id",l),n.textContent=`@layer xds-theme {
+${a}
+}`,document.head.appendChild(n),Ui.add(e),()=>{const u=document.querySelector(`style[data-xds-theme="${t.name}"][data-xds-id="${l}"]`);u&&(u.remove(),Ui.delete(e))}},[t,l])}function mg(t){const l=x.useRef([]);x.useLayoutEffect(()=>{if(typeof document>"u"||!t.fonts||t.fonts.length===0)return;const e=[];for(const a of t.fonts){if(document.fonts.check(`16px "${a.family}"`)||document.head.querySelector(`link[rel="stylesheet"][href="${a.url}"]`))continue;const i=document.createElement("link");i.rel="stylesheet",i.href=a.url,document.head.appendChild(i),e.push(i),console.warn(`[XDS] Theme "${t.name}" loaded font "${a.family}" at runtime. For better performance, add to your document <head>:
+  <link rel="stylesheet" href="${a.url}" />`)}return l.current=e,()=>{for(const a of l.current)a.parentNode&&a.parentNode.removeChild(a);l.current=[]}},[t.fonts,t.name])}function D0({theme:t,mode:l="system",children:e}){yg(t),mg(t);const a=l==="dark"?Hn.dark:l==="light"?Hn.light:Hn.system,n=t.icons;n!=null&&Km(n);const u=x.useMemo(()=>({theme:t,mode:l}),[t,l]);return A.jsx(dg.Provider,{value:u,children:A.jsx("div",{...At(Hn.base,a),"data-xds-theme":t.name,"data-theme":l==="system"?void 0:l,children:e})})}D0.displayName="XDSTheme";function gg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3"}))}const vg=x.forwardRef(gg);function hg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18"}))}const xg=x.forwardRef(hg);function pg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"}))}const bg=x.forwardRef(pg);function Sg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"}))}const zg=x.forwardRef(Sg);function Eg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"}))}const Tg=x.forwardRef(Eg);function Ag({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m4.5 12.75 6 6 9-13.5"}))}const $g=x.forwardRef(Ag);function Mg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m19.5 8.25-7.5 7.5-7.5-7.5"}))}const Og=x.forwardRef(Mg);function jg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M15.75 19.5 8.25 12l7.5-7.5"}))}const _g=x.forwardRef(jg);function Dg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m8.25 4.5 7.5 7.5-7.5 7.5"}))}const kg=x.forwardRef(Dg);function Cg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"}))}const Ng=x.forwardRef(Cg);function Ug({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"}))}const Rg=x.forwardRef(Ug);function qg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"}))}const Hg=x.forwardRef(qg);function Bg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"}))}const wg=x.forwardRef(Bg);function Xg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"}))}const Zg=x.forwardRef(Xg);function Yg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"}))}const Gg=x.forwardRef(Yg);function Lg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z"}))}const Qg=x.forwardRef(Lg);function Vg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6 18 18 6M6 6l12 12"}))}const Kg=x.forwardRef(Vg);function Jg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{fillRule:"evenodd",d:"M15.75 2.25H21a.75.75 0 0 1 .75.75v5.25a.75.75 0 0 1-1.5 0V4.81L8.03 17.03a.75.75 0 0 1-1.06-1.06L19.19 3.75h-3.44a.75.75 0 0 1 0-1.5Zm-10.5 4.5a1.5 1.5 0 0 0-1.5 1.5v10.5a1.5 1.5 0 0 0 1.5 1.5h10.5a1.5 1.5 0 0 0 1.5-1.5V10.5a.75.75 0 0 1 1.5 0v8.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V8.25a3 3 0 0 1 3-3h8.25a.75.75 0 0 1 0 1.5H5.25Z",clipRule:"evenodd"}))}const Wg=x.forwardRef(Jg);function Fg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{fillRule:"evenodd",d:"M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z",clipRule:"evenodd"}))}const Ig=x.forwardRef(Fg);function Pg({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{fillRule:"evenodd",d:"M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z",clipRule:"evenodd"}))}const tv=x.forwardRef(Pg);function lv({title:t,titleId:l,...e},a){return x.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?x.createElement("title",{id:l},t):null,x.createElement("path",{fillRule:"evenodd",d:"M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-1.72 6.97a.75.75 0 1 0-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06L12 13.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L13.06 12l1.72-1.72a.75.75 0 1 0-1.06-1.06L12 10.94l-1.72-1.72Z",clipRule:"evenodd"}))}const ev=x.forwardRef(lv),ut={width:"1em",height:"1em","aria-hidden":!0},av={close:A.jsx(Kg,{...ut}),chevronDown:A.jsx(Og,{...ut}),chevronLeft:A.jsx(_g,{...ut}),chevronRight:A.jsx(kg,{...ut}),check:A.jsx($g,{...ut}),checkCircle:A.jsx(Ig,{...ut}),xCircle:A.jsx(ev,{...ut}),warning:A.jsx(tv,{...ut}),info:A.jsx(Zg,{...ut}),calendar:A.jsx(Tg,{...ut}),clock:A.jsx(Ng,{...ut}),externalLink:A.jsx(Wg,{...ut}),menu:A.jsx(zg,{...ut}),moreHorizontal:A.jsx(Rg,{...ut}),search:A.jsx(Gg,{...ut}),arrowUp:A.jsx(xg,{...ut}),arrowDown:A.jsx(vg,{...ut}),arrowsUpDown:A.jsx(bg,{...ut}),funnel:A.jsx(wg,{...ut}),eyeSlash:A.jsx(Hg,{...ut}),viewColumns:A.jsx(Qg,{...ut})},nv=sg({name:"default",typography:{scale:{base:14,ratio:1.2}},motion:{fast:175,medium:410,ratio:.75},tokens:{},components:{button:{"variant:secondary":{backgroundColor:"light-dark(rgba(5, 54, 89, 0.1), rgba(223, 226, 229, 0.2))"}}},icons:av}),So={container:{kB7OPa:"x9f619",kmVPX3:"x1kp5lmi",$$css:!0}},uv={containerPadding:{"--container-padding":"x8q8htr",$$css:!0},containerPaddingInline:{"--container-padding-inline":"x118jium",$$css:!0},layoutPaddingOuterX:{"--layout-padding-outer-x":"x1r0u152",$$css:!0},layoutPaddingOuterY:{"--layout-padding-outer-y":"xzqheer",$$css:!0},layoutPaddingInnerX:{"--layout-padding-inner-x":"x1gox8qf",$$css:!0},layoutPaddingInnerY:{"--layout-padding-inner-y":"x1eounod",$$css:!0}},iv={containerPadding:{"--container-padding":"xms56fs",$$css:!0},containerPaddingInline:{"--container-padding-inline":"x1x4tb0e",$$css:!0},layoutPaddingOuterX:{"--layout-padding-outer-x":"x1h0nqri",$$css:!0},layoutPaddingOuterY:{"--layout-padding-outer-y":"xlfd3nr",$$css:!0},layoutPaddingInnerX:{"--layout-padding-inner-x":"xn3f0pw",$$css:!0},layoutPaddingInnerY:{"--layout-padding-inner-y":"xihc2cu",$$css:!0}},cv={card:uv,section:iv},fv={spacing0:{"--container-padding":"x1i337hy",$$css:!0},spacing0_5:{"--container-padding":"x1b322fk",$$css:!0},spacing1:{"--container-padding":"x11x0u8a",$$css:!0},spacing1_5:{"--container-padding":"x1tqehje",$$css:!0},spacing2:{"--container-padding":"xyawmno",$$css:!0},spacing3:{"--container-padding":"xiq2vfk",$$css:!0},spacing4:{"--container-padding":"x18iqpsj",$$css:!0},spacing5:{"--container-padding":"x305b4h",$$css:!0},spacing6:{"--container-padding":"x1suvfq4",$$css:!0},spacing7:{"--container-padding":"xe04trj",$$css:!0},spacing8:{"--container-padding":"xv6sa6u",$$css:!0},spacing9:{"--container-padding":"xswgb5g",$$css:!0},spacing10:{"--container-padding":"xl4lgz8",$$css:!0},spacing11:{"--container-padding":"xfk8qm2",$$css:!0},spacing12:{"--container-padding":"xtcn5oa",$$css:!0}},sv={spacing0:{"--container-padding-inline":"x11nj8ps",$$css:!0},spacing0_5:{"--container-padding-inline":"x1qmdwou",$$css:!0},spacing1:{"--container-padding-inline":"xmqp8mn",$$css:!0},spacing1_5:{"--container-padding-inline":"x11c4xrl",$$css:!0},spacing2:{"--container-padding-inline":"xvkq9sf",$$css:!0},spacing3:{"--container-padding-inline":"x17rklng",$$css:!0},spacing4:{"--container-padding-inline":"x1qtkjpi",$$css:!0},spacing5:{"--container-padding-inline":"xcek0mv",$$css:!0},spacing6:{"--container-padding-inline":"xzryng3",$$css:!0},spacing7:{"--container-padding-inline":"x1jrgra8",$$css:!0},spacing8:{"--container-padding-inline":"x1t3jwqk",$$css:!0},spacing9:{"--container-padding-inline":"x1ikhtwg",$$css:!0},spacing10:{"--container-padding-inline":"x1mh38z9",$$css:!0},spacing11:{"--container-padding-inline":"xarkblc",$$css:!0},spacing12:{"--container-padding-inline":"x15nzvup",$$css:!0}},ov={spacing0:{"--layout-padding-outer-x":"xswhm3q",$$css:!0},spacing0_5:{"--layout-padding-outer-x":"xihiwg7",$$css:!0},spacing1:{"--layout-padding-outer-x":"xc96xmq",$$css:!0},spacing1_5:{"--layout-padding-outer-x":"x1u93lgd",$$css:!0},spacing2:{"--layout-padding-outer-x":"x15dxnc0",$$css:!0},spacing3:{"--layout-padding-outer-x":"xadgj3j",$$css:!0},spacing4:{"--layout-padding-outer-x":"x1v56qcf",$$css:!0},spacing5:{"--layout-padding-outer-x":"x1nzs0gl",$$css:!0},spacing6:{"--layout-padding-outer-x":"x1c3n52a",$$css:!0},spacing7:{"--layout-padding-outer-x":"x1gfiokx",$$css:!0},spacing8:{"--layout-padding-outer-x":"x1t3kfz",$$css:!0},spacing9:{"--layout-padding-outer-x":"xzr4qsh",$$css:!0},spacing10:{"--layout-padding-outer-x":"x1jdf5a4",$$css:!0},spacing11:{"--layout-padding-outer-x":"x1hct0t0",$$css:!0},spacing12:{"--layout-padding-outer-x":"x11cyqoe",$$css:!0}},rv={spacing0:{"--layout-padding-outer-y":"x1mzf5mb",$$css:!0},spacing0_5:{"--layout-padding-outer-y":"x1vj96e0",$$css:!0},spacing1:{"--layout-padding-outer-y":"x1gpfxoh",$$css:!0},spacing1_5:{"--layout-padding-outer-y":"xd3dqby",$$css:!0},spacing2:{"--layout-padding-outer-y":"x10pz7y9",$$css:!0},spacing3:{"--layout-padding-outer-y":"x1p6yq3h",$$css:!0},spacing4:{"--layout-padding-outer-y":"xx738ci",$$css:!0},spacing5:{"--layout-padding-outer-y":"x6yxws5",$$css:!0},spacing6:{"--layout-padding-outer-y":"x180vrwl",$$css:!0},spacing7:{"--layout-padding-outer-y":"x1q6rme1",$$css:!0},spacing8:{"--layout-padding-outer-y":"xid7e43",$$css:!0},spacing9:{"--layout-padding-outer-y":"x1t5kicu",$$css:!0},spacing10:{"--layout-padding-outer-y":"x26l4wa",$$css:!0},spacing11:{"--layout-padding-outer-y":"x10zktp0",$$css:!0},spacing12:{"--layout-padding-outer-y":"x1yz3n6a",$$css:!0}},dv={spacing0:{"--layout-padding-inner-x":"xj1bl4l",$$css:!0},spacing0_5:{"--layout-padding-inner-x":"xlriy2h",$$css:!0},spacing1:{"--layout-padding-inner-x":"x6uuyak",$$css:!0},spacing1_5:{"--layout-padding-inner-x":"xd38f90",$$css:!0},spacing2:{"--layout-padding-inner-x":"xxqksqd",$$css:!0},spacing3:{"--layout-padding-inner-x":"x1fyui2f",$$css:!0},spacing4:{"--layout-padding-inner-x":"x1i2ajwi",$$css:!0},spacing5:{"--layout-padding-inner-x":"x1tac27u",$$css:!0},spacing6:{"--layout-padding-inner-x":"x1ntgf3t",$$css:!0},spacing7:{"--layout-padding-inner-x":"xhjd9tl",$$css:!0},spacing8:{"--layout-padding-inner-x":"xn7c84u",$$css:!0},spacing9:{"--layout-padding-inner-x":"xeqkbsz",$$css:!0},spacing10:{"--layout-padding-inner-x":"x1vf4qco",$$css:!0},spacing11:{"--layout-padding-inner-x":"xsmamsf",$$css:!0},spacing12:{"--layout-padding-inner-x":"x2xk2xj",$$css:!0}},yv={spacing0:{"--layout-padding-inner-y":"xwuefyo",$$css:!0},spacing0_5:{"--layout-padding-inner-y":"x180h0y5",$$css:!0},spacing1:{"--layout-padding-inner-y":"xmpug6m",$$css:!0},spacing1_5:{"--layout-padding-inner-y":"x1g8jpzm",$$css:!0},spacing2:{"--layout-padding-inner-y":"x1lksgje",$$css:!0},spacing3:{"--layout-padding-inner-y":"x4j7gld",$$css:!0},spacing4:{"--layout-padding-inner-y":"x1s3ehtl",$$css:!0},spacing5:{"--layout-padding-inner-y":"x1rj5eim",$$css:!0},spacing6:{"--layout-padding-inner-y":"x1ftgg6u",$$css:!0},spacing7:{"--layout-padding-inner-y":"x1ho74vh",$$css:!0},spacing8:{"--layout-padding-inner-y":"xm2cs6f",$$css:!0},spacing9:{"--layout-padding-inner-y":"x1vsq92b",$$css:!0},spacing10:{"--layout-padding-inner-y":"x18gbwmk",$$css:!0},spacing11:{"--layout-padding-inner-y":"x14zymzj",$$css:!0},spacing12:{"--layout-padding-inner-y":"xzfpkx9",$$css:!0}},mv={containerMaxHeight:t=>[{"--container-max-height":t!=null?"x18nyedi":t,$$css:!0},{"--x---container-max-height":t??void 0}]};function gv({padding:t="spacing4",paddingOuterX:l="spacing4",paddingOuterY:e="spacing4",paddingInnerX:a="spacing4",paddingInnerY:n="spacing4",useThemeDefault:u,maxHeight:i}){const c=i?mv.containerMaxHeight(i):null;if(u){const f=cv[u];return[So.container,f.containerPadding,f.containerPaddingInline,f.layoutPaddingOuterX,f.layoutPaddingOuterY,f.layoutPaddingInnerX,f.layoutPaddingInnerY,c]}return[So.container,fv[t],sv[l],ov[l],rv[e],dv[a],yv[n],c]}const vv={0:"spacing0",.5:"spacing0_5",1:"spacing1",1.5:"spacing1_5",2:"spacing2",3:"spacing3",4:"spacing4",5:"spacing5",6:"spacing6",8:"spacing8",10:"spacing10"},hv={0:{kZCmMZ:"x18gyask",kwRFfy:"x1s0aq8i",kLKAdn:"x1ydh6w3",kGO01o:"x1l20ajd",$$css:!0},1:{kZCmMZ:"x1vsv5vr",kwRFfy:"x1nryj5t",kLKAdn:"xfsso4q",kGO01o:"xy143xn",$$css:!0},2:{kZCmMZ:"x12gdq22",kwRFfy:"x1djylfy",kLKAdn:"x1xye8es",kGO01o:"x1wesfrj",$$css:!0},3:{kZCmMZ:"x126nfab",kwRFfy:"x1t818jl",kLKAdn:"x1vlblms",kGO01o:"xvmdzux",$$css:!0},4:{kZCmMZ:"x1rey3nv",kwRFfy:"xnjyzlh",kLKAdn:"x1oa1p4a",kGO01o:"x1awphl8",$$css:!0},5:{kZCmMZ:"x1blguxw",kwRFfy:"xdbrk9v",kLKAdn:"xx7rijo",kGO01o:"x1hk98q",$$css:!0},6:{kZCmMZ:"x31w388",kwRFfy:"x1we12cn",kLKAdn:"x1adxfkp",kGO01o:"xjpqqx5",$$css:!0},8:{kZCmMZ:"x1j3hnjz",kwRFfy:"x1q91b2g",kLKAdn:"xoxd1wu",kGO01o:"x2oz4g1",$$css:!0},10:{kZCmMZ:"xqp078j",kwRFfy:"x160ivqr",kLKAdn:"xk6660b",kGO01o:"x2izi54",$$css:!0},"0.5":{kZCmMZ:"x138rykx",kwRFfy:"x1le3yxw",kLKAdn:"xbx876j",kGO01o:"xij103a",$$css:!0},"1.5":{kZCmMZ:"xfti1ec",kwRFfy:"x17hk9do",kLKAdn:"x1kwdpsa",kGO01o:"x1opdxmq",$$css:!0}},xv={0:{"--container-padding-inline":"x11nj8ps",$$css:!0},1:{"--container-padding-inline":"xmqp8mn",$$css:!0},2:{"--container-padding-inline":"xvkq9sf",$$css:!0},3:{"--container-padding-inline":"x17rklng",$$css:!0},4:{"--container-padding-inline":"x1qtkjpi",$$css:!0},5:{"--container-padding-inline":"xcek0mv",$$css:!0},6:{"--container-padding-inline":"xzryng3",$$css:!0},8:{"--container-padding-inline":"x1t3jwqk",$$css:!0},10:{"--container-padding-inline":"x1mh38z9",$$css:!0},"0.5":{"--container-padding-inline":"x1qmdwou",$$css:!0},"1.5":{"--container-padding-inline":"x11c4xrl",$$css:!0}};function jl(t,l){const e=[`xds-${t}`];if(l)for(const[a,n]of Object.entries(l)){if(n==null)continue;const u=String(n);/^\d/.test(u)?e.push(`${a}-${u}`):e.push(u)}return e.join(" ")}function ae(t,l,e,a){let n=l.className?`${t} ${l.className}`:t;e&&(n=`${n} ${e}`);const u=a&&l.style?{...l.style,...a}:a||l.style;return{className:n,style:u}}const Ri={cardOuter:{"--card-radius":"xb26y6u",kWkggS:"x1de1mus",kaIpWk:"x8j4bds",kVQacm:"x7giv3",kMzoRj:"x1litavf",ksu8eU:"x1y0btm7",kVAM5u:"xvy26l8",$$css:!0},cardInner:{kZKoxP:"x5yr21d",$$css:!0},scrollable:{kVQacm:"xysyzu8",$$css:!0}},pv={sizing:(t,l,e,a)=>[{kzqmXN:t!=null?"x5lhr3w":t,kZKoxP:l!=null?"x16ye13r":l,ks0D6T:e!=null?"xf68679":e,kAzted:a!=null?"x82snj4":a,$$css:!0},{"--x-width":(n=>typeof n=="number"?n+"px":n??void 0)(t),"--x-height":(n=>typeof n=="number"?n+"px":n??void 0)(l),"--x-maxWidth":(n=>typeof n=="number"?n+"px":n??void 0)(e),"--x-minHeight":(n=>typeof n=="number"?n+"px":n??void 0)(a)}]};function k0({width:t,height:l,maxWidth:e,minHeight:a,children:n,padding:u,xstyle:i,className:c,style:f,ref:r,...y}){const v=l!=null&&l!=="auto",d=u==null,g=u??4,p=vv[g];return A.jsx("div",{ref:r,...ae(jl("card"),At(Ri.cardOuter,pv.sizing(t??null,l??null,e??null,a??null),i),c,f),...y,children:A.jsx("div",{...At(Ri.cardInner,v&&Ri.scrollable,...gv(d?{useThemeDefault:"card"}:{paddingInnerX:p,paddingInnerY:p,paddingOuterX:p,paddingOuterY:p}),!d&&g!==4&&hv[g],!d&&g!==4&&xv[g]),children:n})})}k0.displayName="XDSCard";const qi={base:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x1lziwak",k71WvV:"x14z9mp",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kMzoRj:"xc342km",ksu8eU:"xng3xce",kVQacm:"x1rea2x4",kWkggS:"xjbqb8w",$$css:!0},fixed:{kVAEAm:"xixxii4",$$css:!0}};function bv(t="above",l="center"){const a={above:"top",below:"bottom",start:"left",end:"right"}[t];return t==="above"||t==="below"?l==="start"?`${a} span-right`:l==="end"?`${a} span-left`:a:l==="start"?`${a} span-bottom`:l==="end"?`${a} span-top`:`${a} center`}function Sv(t){const{mode:l,onShow:e,onHide:a,lightDismiss:n=!1}=t,u=x.useId(),i=`--xds-layer-${u.replace(/:/g,"")}`,[c,f]=x.useState(!1),r=x.useRef(null),y=x.useRef(null),v=x.useCallback(()=>{r.current&&!r.current.matches(":popover-open")&&(r.current.showPopover(),f(!0),e==null||e())},[e]),d=x.useCallback(()=>{var o;(o=r.current)!=null&&o.matches(":popover-open")&&(r.current.hidePopover(),f(!1),a==null||a())},[a]),g=l==="context"?o=>{y.current&&(y.current.style.anchorName=""),o&&(o.style.anchorName=i),y.current=o}:void 0,p=x.useCallback(o=>{const s=o;s.newState==="closed"?(f(!1),a==null||a()):s.newState==="open"&&(f(!0),e==null||e())},[e,a]),b=x.useCallback(o=>{r.current=o,o&&o.addEventListener("toggle",p)},[p]),z=x.useCallback((o,s)=>{const{placement:m="above",alignment:h="center",xstyle:T,className:M,style:E}=s||{},j={positionAnchor:i,positionArea:bv(m,h),positionTryFallbacks:"flip-block, flip-inline, flip-block flip-inline"},$=At(qi.base,T),O=M?`${M} ${$.className??""}`:$.className;return A.jsx("div",{ref:b,id:u,popover:n?"auto":"manual",className:O,style:{...$.style,...j,...E},children:o})},[i,u,n,b]);return x.useCallback((o,s)=>{const{x:m,y:h,xstyle:T,className:M,style:E}=s,j={top:h,left:m},$=At(qi.base,qi.fixed,T),O=M?`${M} ${$.className??""}`:$.className;return A.jsx("div",{ref:b,id:u,popover:n?"auto":"manual",className:O,style:{...$.style,...j,...E},children:o})},[b,u,n]),{ref:g,anchorId:i,show:v,hide:d,isOpen:c,id:u,render:z}}const zv={below:{kKVMdj:"xl1vlw0",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},above:{kKVMdj:"x3psbcj",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},end:{kKVMdj:"x1i331go",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},start:{kKVMdj:"xck01x9",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}},Hi={container:{kWkggS:"x19aspcf",kMwMTN:"xrkvqaz",kaIpWk:"x1hviunn",kMv6JI:"x9ynric",kGuDYH:"xjm74w1",kLWn49:"xw6l6zx",$$css:!0},marginBlock:{keoZOQ:"xcsaf9d",k1K539:"x14cgwvg",keTefX:"x1lziwak",k71WvV:"x14z9mp",$$css:!0},marginInline:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x11g1kdw",k71WvV:"xnur1sd",$$css:!0}};function Ev(t){return t.hasAttribute("tabindex")?t.tabIndex>=0:["A","BUTTON","INPUT","SELECT","TEXTAREA"].includes(t.tagName)?!t.disabled:!!t.isContentEditable}function Tv(t={}){const{placement:l="above",alignment:e="center",delay:a=200,hideDelay:n=0,focusTrigger:u="auto",isEnabled:i=!0,onShow:c,onHide:f}=t,r=l==="above"||l==="below"?Hi.marginBlock:Hi.marginInline,y=Sv({mode:"context",onShow:c,onHide:f}),v=[Hi.container,r],d=x.useRef(null),g=x.useRef(null),p=x.useRef(null),b=x.useCallback(()=>{d.current&&(clearTimeout(d.current),d.current=null),g.current&&(clearTimeout(g.current),g.current=null)},[]),z=x.useCallback(()=>{i&&(b(),d.current=setTimeout(()=>{y.show()},a))},[i,b,y,a]),o=x.useCallback(()=>{b(),n>0?g.current=setTimeout(()=>{y.hide()},n):y.hide()},[b,y,n]),s=x.useCallback(()=>{typeof window<"u"&&typeof window.matchMedia=="function"&&window.matchMedia("(hover: none)").matches||z()},[z]),m=x.useCallback(()=>{o()},[o]),h=x.useCallback($=>{!i||!$.target.matches(":focus-visible")||(b(),y.show())},[i,b,y]),T=x.useCallback(()=>{o()},[o]),M=x.useCallback($=>{p.current&&(p.current.removeEventListener("mouseenter",s),p.current.removeEventListener("mouseleave",m),p.current.removeEventListener("focusin",h),p.current.removeEventListener("focusout",T)),$&&($.addEventListener("mouseenter",s),$.addEventListener("mouseleave",m),(u==="always"||u==="auto"&&Ev($))&&($.addEventListener("focusin",h),$.addEventListener("focusout",T))),p.current=$},[u,s,m,h,T]),E=x.useCallback($=>{y.ref($),M($)},[y.ref,M]);x.useEffect(()=>()=>{b()},[b]);const j=x.useCallback(($,O)=>{const I=(O==null?void 0:O.placement)??l,lt={placement:I,alignment:(O==null?void 0:O.alignment)??e,xstyle:[v,zv[I]],className:jl("tooltip")};return y.render(A.jsx("div",{className:"xfsso4q xy143xn x12gdq22 x1djylfy xw5ewwj x13faqbe",children:$}),lt)},[y,l,e,v]);return{ref:E,positionRef:y.ref,interactionRef:M,anchorId:y.anchorId,describedBy:y.id,renderTooltip:j}}function Av(t){let l=!1;return Gf.Children.forEach(t,e=>{Gf.isValidElement(e)&&(l=!0)}),!l}function zo(...t){const l=t.filter(Boolean);return l.length>0?l.join(" "):void 0}function Hf({children:t,anchorRef:l,content:e,placement:a="above",alignment:n="center",delay:u=200,hideDelay:i=0,focusTrigger:c="auto",isEnabled:f=!0,onOpenChange:r,hasHoverIndication:y="auto"}){const v=x.useRef(null),d=t!=null?Av(t):!1,g=y===!0||y==="auto"&&d,p=x.useCallback(()=>{r==null||r(!0)},[r]),b=x.useCallback(()=>{r==null||r(!1)},[r]),z=Tv({placement:a,alignment:n,delay:u,hideDelay:i,focusTrigger:c,isEnabled:f,onShow:p,onHide:b});return x.useLayoutEffect(()=>{if(!l)return;const o=l.current;if(!o)return;z.ref(o);const s=o.getAttribute("aria-describedby");return o.setAttribute("aria-describedby",zo(s,z.describedBy)??""),()=>{z.ref(null),s?o.setAttribute("aria-describedby",s):o.removeAttribute("aria-describedby")}},[l,z.ref,z.describedBy]),x.useLayoutEffect(()=>{if(l||d)return;const o=v.current;if(!o)return;const s=o.firstElementChild;if(!s)return;z.ref(s);const m=s.getAttribute("aria-describedby");return s.setAttribute("aria-describedby",zo(m,z.describedBy)??""),()=>{z.ref(null),m?s.setAttribute("aria-describedby",m):s.removeAttribute("aria-describedby")}},[l,d,z.ref,z.describedBy]),l&&t==null?A.jsx(A.Fragment,{children:z.renderTooltip(e)}):d?A.jsxs(A.Fragment,{children:[A.jsx("span",{ref:z.ref,tabIndex:0,"aria-describedby":z.describedBy,...{0:{className:"xt0psk2"},1:{className:"xt0psk2 xujl8zx xev0dqp xycaml9 xrys4gj"}}[!!g<<0],children:t}),z.renderTooltip(e)]}):A.jsxs(A.Fragment,{children:[A.jsx("div",{ref:v,className:"xjp7ctv",children:t}),z.renderTooltip(e)]})}Hf.displayName="XDSTooltip";const C0=Object.freeze(Object.defineProperty({__proto__:null,XDSTooltip:Hf},Symbol.toStringTag,{value:"Module"})),$v="modulepreload",Mv=function(t,l){return new URL(t,l).href},Eo={},N0=function(l,e,a){let n=Promise.resolve();if(e&&e.length>0){const i=document.getElementsByTagName("link"),c=document.querySelector("meta[property=csp-nonce]"),f=(c==null?void 0:c.nonce)||(c==null?void 0:c.getAttribute("nonce"));n=Promise.allSettled(e.map(r=>{if(r=Mv(r,a),r in Eo)return;Eo[r]=!0;const y=r.endsWith(".css"),v=y?'[rel="stylesheet"]':"";if(!!a)for(let p=i.length-1;p>=0;p--){const b=i[p];if(b.href===r&&(!y||b.rel==="stylesheet"))return}else if(document.querySelector(`link[href="${r}"]${v}`))return;const g=document.createElement("link");if(g.rel=y?"stylesheet":$v,y||(g.as="script"),g.crossOrigin="",g.href=r,f&&g.setAttribute("nonce",f),document.head.appendChild(g),y)return new Promise((p,b)=>{g.addEventListener("load",p),g.addEventListener("error",()=>b(new Error(`Unable to preload CSS for ${r}`)))})}))}function u(i){const c=new Event("vite:preloadError",{cancelable:!0});if(c.payload=i,window.dispatchEvent(c),!c.defaultPrevented)throw i}return n.then(i=>{for(const c of i||[])c.status==="rejected"&&u(c.reason);return l().catch(u)})},U0={primary:{kMwMTN:"x1tgivj0",$$css:!0},secondary:{kMwMTN:"xv1l7n4",$$css:!0},disabled:{kMwMTN:"xnbbluu",$$css:!0},placeholder:{kMwMTN:"xv1l7n4",$$css:!0},active:{kMwMTN:"xqwr325",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0}},Ov={normal:{k63SB2:"x1sodnla",$$css:!0},medium:{k63SB2:"x1e4wzip",$$css:!0},semibold:{k63SB2:"x2mo6ok",$$css:!0},bold:{k63SB2:"x1lvx875",$$css:!0}},jv={body:{k63SB2:"xxovm9e",$$css:!0},large:{k63SB2:"x149oux8",$$css:!0},label:{k63SB2:"xmhvcl5",$$css:!0},code:{k63SB2:"xx3eeay",$$css:!0},supporting:{k63SB2:"xv8on6e",$$css:!0},"display-1":{k63SB2:"x1txul5o",$$css:!0},"display-2":{k63SB2:"x1y36c3f",$$css:!0},"display-3":{k63SB2:"x1on40hk",$$css:!0}},R0={inline:{k1xSpc:"xt0psk2",$$css:!0},block:{k1xSpc:"x1lliihq",$$css:!0}},ju={singleLine:{kVQacm:"xb3r6kr",kg5iWk:"xlyipyv",khDVqt:"xuxw1ft",k1xSpc:"x1lliihq",$$css:!0},multiLine:{kVQacm:"xb3r6kr",k1xSpc:"x104kibb",kgKLqz:"x1ua5tub",$$css:!0}},q0={"break-word":{kTgw9:"x1lldw8n",kHjlTd:"x1mzt3pk",$$css:!0},"break-all":{kTgw9:"x1yn0g08",$$css:!0}},H0={wrap:{kN2L0X:"xk4td0m",$$css:!0},nowrap:{kN2L0X:"xebhuq6",$$css:!0},balance:{kN2L0X:"x1w2vvpw",$$css:!0},pretty:{kN2L0X:"x1fzhlzt",$$css:!0}},B0={enabled:{kxwWH2:"x1b2iylo",kzeHkT:"xwgcxoh",k1xSpc:"x1lliihq",$$css:!0}},w0={strikethrough:{kybGjl:"xmqliwb",$$css:!0}},_v={enabled:{kcqcaj:"xss6m8b",$$css:!0}},X0={content:{ks0D6T:"xw5ewwj",kTgw9:"x13faqbe",$$css:!0}};function Z0(t){const{maxLines:l}=t,[e,a]=x.useState(!1),[n,u]=x.useState(""),i=x.useRef(null),c=x.useRef(null),f=x.useCallback(y=>{if(l===0){a(!1);return}u(y.textContent??""),a(l===1?y.scrollWidth>y.offsetWidth:y.scrollHeight>y.offsetHeight)},[l]);return{ref:x.useCallback(y=>{c.current&&(c.current.disconnect(),c.current=null),i.current=y,y&&l>0?(f(y),typeof ResizeObserver<"u"&&(c.current=new ResizeObserver(()=>{f(y)}),c.current.observe(y))):(a(!1),u(""))},[l,f]),isTruncated:e,fullText:n}}const Dv=x.lazy(()=>N0(()=>Promise.resolve().then(()=>C0),void 0,import.meta.url).then(t=>({default:t.XDSTooltip}))),kv={body:"primary",large:"primary",label:"primary",supporting:"secondary",code:"primary","display-1":"primary","display-2":"primary","display-3":"primary"};function Bf({type:t,size:l,color:e,weight:a,display:n="inline",maxLines:u=0,hasTruncateTooltip:i=!0,wordBreak:c,textWrap:f,hasCapsize:r=!1,hasStrikethrough:y=!1,hasTabularNumbers:v=!1,xstyle:d,className:g,style:p,as:b="span",children:z,ref:o,...s}){const m=e??kv[t],h=c??(u===1?"break-all":"break-word"),T=u>0||r?"block":n,M=Z0({maxLines:u}),E=typeof i=="string"?i:"above",j=u>0&&i!==!1&&M.isTruncated,$=x.useRef(null),O=x.useCallback(lt=>{typeof o=="function"?o(lt):o&&(o.current=lt),M.ref(lt),$.current=lt},[o,M.ref]),I=u>1?{WebkitLineClamp:u}:void 0;return A.jsxs(A.Fragment,{children:[A.jsx(b,{ref:O,...ae(jl("text",{type:t,color:m}),At(U0[m],jv[t],a&&Ov[a],u===1?ju.singleLine:u>1?ju.multiLine:R0[T],u>0&&q0[h],f&&H0[f],r&&B0.enabled,y&&w0.strikethrough,v&&_v.enabled,d),g,{...p,...I}),title:j?M.fullText:void 0,...s,children:z}),j&&A.jsx(x.Suspense,{fallback:null,children:A.jsx(Dv,{anchorRef:$,content:A.jsx("span",{...At(X0.content),children:M.fullText}),placement:E})})]})}Bf.displayName="XDSText";const Cv=.75,To=1.5,Ao={sm:{diameter:10,border:3},md:{diameter:14,border:3},lg:{diameter:18,border:3},xl:{diameter:28,border:4}},$o={wrapper:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",$$css:!0},spinner:{k1xSpc:"x1rg5ohu",kVQacm:"xb3r6kr",kXLuUW:"xxymvpz",$$css:!0}};function Y0({size:t="md",shade:l="default",label:e,xstyle:a,className:n,"aria-label":u,"data-testid":i,ref:c}){const f=x.useRef(null);x.useEffect(()=>{const b=f.current;if(b==null)return;const z=b.getContext("2d");if(!z)return;const{border:o,diameter:s}=Ao[t],m=window.devicePixelRatio||1,h=getComputedStyle(b),T=l==="onMedia"?h.getPropertyValue(ho["--color-on-dark"])||"#FFFFFF":h.getPropertyValue(ho["--color-accent"])||"#0064E0",M=l==="onMedia"?"rgba(255, 255, 255, 0.3)":"rgba(0, 0, 0, 0.1)",E=s/2*m,j=o*m,$=(E+j)*2;b.height=b.width=$,b.style.width=b.style.height=$/m+"px",z.lineCap="round",z.lineWidth=j;const O=$/2;z.beginPath(),z.arc(O,O,E,0,2*Math.PI),z.strokeStyle=M,z.stroke(),z.beginPath(),z.arc(O,O,E,To*Math.PI,(To+Cv)%2*Math.PI),z.strokeStyle=T,z.stroke()},[l,t]);const{border:r,diameter:y}=Ao[t],v=y+r*2,d=e!=null,g=u??(typeof e=="string"?e:void 0)??"Loading",p=A.jsx("span",{ref:d?void 0:c,role:"status","aria-label":g,"data-testid":d?void 0:i,...ae(d?"":jl("spinner",{size:t,shade:l}),At($o.spinner,!d&&a),d?void 0:n),style:{width:v,height:v},children:A.jsx("canvas",{ref:f,className:"xlp1x4z x1lliihq xqgcaz xa4qsjk x1ka1v4i x1esw782"})});return d?A.jsxs("div",{ref:c,"data-testid":i,...ae(jl("spinner",{size:t,shade:l}),At($o.wrapper,a),n),children:[p,typeof e=="string"?A.jsx(Bf,{type:"body",weight:"bold",children:e}):e]}):p}Y0.displayName="XDSSpinner";const Nv={self:{keTefX:"xg82z56",k71WvV:"xofqkxr",$$css:!0}},Uv=x.createContext(null);function Rv(t){const l=x.useContext(Uv);return t??(l==null?void 0:l.component)??"a"}const ke={base:{kVAEAm:"x1n2onr6",k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kOIVth:"x1txdalj",k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kMzoRj:"xc342km",ksu8eU:"xng3xce","--button-radius":"x1mkq5kp",kaIpWk:"x1q11iln",kMv6JI:"xjb2p0i",kGuDYH:"xcr08ib",kLWn49:"x1kq96og",k63SB2:"x1e4wzip",khDVqt:"xuxw1ft",kkrTdU:"x1ypdohk",k1ekBW:"xqc8rvf",kIyJzY:"xuedmi6 x12w9bfk",kAMwcw:"xlr8y92",k3aq6I:"x3oybdh xk4oym4",$$css:!0},disabled:{kkrTdU:"x1h6gzvc",kSiTet:"xbyyjgo",kKwaWg:"x18o3ruo",k3aq6I:"x1c071of x1pdlv7q",$$css:!0},ariaDisabled:{kKwaWg:"x18o3ruo x8o3jvd xuqm82a",$$css:!0},iconOnly:{"--button-icon-only-aspect":"x1v15ycx",kOBAk4:"xioom0i",kg3NbH:"xf314gf",$$css:!0},iconWrapper:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0},link:{kybGjl:"x1hl2dhg",$$css:!0}},qv={sm:{kZKoxP:"x6k0iem",$$css:!0},md:{kZKoxP:"x1ueg155",$$css:!0},lg:{kZKoxP:"xssyfek",$$css:!0}},Hv={sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},lg:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0}},Bv={primary:{kWkggS:"x1ewilqj",kMwMTN:"x17wrial",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},secondary:{kWkggS:"x17x4s8c",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},ghost:{kWkggS:"xjbqb8w",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},destructive:{kWkggS:"x1pjz0fi",kMwMTN:"x1m024r3",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x1p73he7","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0}},wv={loading:{kVAEAm:"x1n2onr6",kMwMTN:"x19co3pv",$$css:!0}},Mo={paddingInline2:{"--component-padding-inline":"x30uzy1",$$css:!0},paddingInline3:{"--component-padding-inline":"x1ojg8sz",$$css:!0}};function G0({label:t,variant:l="secondary",size:e="md",type:a="button",isDisabled:n=!1,isLoading:u=!1,onClickAction:i,icon:c,children:f,endContent:r,tooltip:y,href:v,as:d,target:g,rel:p,xstyle:b,className:z,style:o,ref:s,...m}){const[h,T]=x.useTransition(),M=x.useRef(!1),E=u||h,j=n||E,$=l==="primary"||l==="destructive",O=c!=null&&f==null,I=Rv(d),lt=v!=null&&!j,ol=y!=null&&j,bn=ht=>{var al;if(j||M.current){ht.preventDefault();return}(al=m.onClick)==null||al.call(m,ht),i&&!ht.defaultPrevented&&(M.current=!0,T(async()=>{try{await i(ht)}finally{M.current=!1}}))},Oe=ol?ht=>{var al;ht.key==="Enter"||ht.key===" "?ht.preventDefault():(al=m.onKeyDown)==null||al.call(m,ht)}:void 0,_=l==="ghost",U=_?Nv.self:null,N=_?O?Mo.paddingInline2:Mo.paddingInline3:null,tt=At(ke.base,qv[e],Bv[l],O&&ke.iconOnly,j&&ke.disabled,ol&&ke.ariaDisabled,E&&wv.loading,N,U,lt&&ke.link,b),nt=ae(jl("button",{variant:l,size:e}),tt,z,o),ie=A.jsxs(A.Fragment,{children:[E&&A.jsx("span",{className:"x10l6tqk x13vifvy xu96u03 x3m8u43 x1ey2m1c x78zum5 x6s0dn4 xl56j7k","aria-hidden":"true",children:A.jsx(Y0,{size:"sm",shade:$?"onMedia":"default"})}),A.jsxs("span",{className:"xjp7ctv","aria-hidden":E||void 0,children:[c&&A.jsx("span",{...At(ke.iconWrapper,Hv[e]),children:c}),O?null:A.jsx("span",{className:"xb3r6kr xlyipyv xeuugli",children:f??t}),!O&&r&&A.jsx("span",{className:"x3nfvp2 x6s0dn4 x1heor9g",children:r})]}),A.jsx("span",{className:"x10l6tqk x1i1rx1s xjm9jq1 x1717udv xkdpibf xb3r6kr xzpqnlu xuxw1ft xc342km",role:"status","aria-live":"polite",children:E?"Loading":""})]}),ce=O&&t!==""||E&&!O?{"aria-label":t}:null;let Dl;return lt?Dl=A.jsx(I,{ref:s,href:v,target:g,rel:p,...nt,...m,...ce,onClick:bn,children:ie}):Dl=A.jsx("button",{ref:s,type:a,disabled:ol?void 0:j,...nt,...m,...ce,"aria-busy":E||void 0,"aria-disabled":ol||void 0,onClick:bn,...Oe?{onKeyDown:Oe}:null,children:ie}),y?A.jsx(Hf,{content:y,placement:"above",children:Dl}):Dl}G0.displayName="XDSButton";const Xv={grid:{k1xSpc:"xrvj5dj",$$css:!0}},Zv={start:{kGNEyG:"x7a106z",$$css:!0},center:{kGNEyG:"x6s0dn4",$$css:!0},end:{kGNEyG:"xpqajaz",$$css:!0},stretch:{kGNEyG:"x1qjc9v5",$$css:!0}},Yv={start:{kAPf3g:"x619ttb",$$css:!0},center:{kAPf3g:"x1o2pa38",$$css:!0},end:{kAPf3g:"x4xo5sw",$$css:!0},stretch:{kAPf3g:"xl4xnwh",$$css:!0}},Gv={0:{kOIVth:"xsn7fz1",$$css:!0},1:{kOIVth:"xzye2dw",$$css:!0},2:{kOIVth:"x1txdalj",$$css:!0},3:{kOIVth:"xjcht0a",$$css:!0},4:{kOIVth:"x18g69wz",$$css:!0},5:{kOIVth:"x9mgr7n",$$css:!0},6:{kOIVth:"x1qh66ti",$$css:!0},8:{kOIVth:"x4t41sb",$$css:!0},10:{kOIVth:"x3hoi3v",$$css:!0},"0.5":{kOIVth:"x1lsbc85",$$css:!0},"1.5":{kOIVth:"x1s4dlld",$$css:!0}},Lv={0:{khm7nJ:"x6yxi7o",$$css:!0},1:{khm7nJ:"x1ngg2t4",$$css:!0},2:{khm7nJ:"x1x7z4sm",$$css:!0},3:{khm7nJ:"x4olc9o",$$css:!0},4:{khm7nJ:"xtx9w7w",$$css:!0},5:{khm7nJ:"x1iu6piu",$$css:!0},6:{khm7nJ:"xczp1bk",$$css:!0},8:{khm7nJ:"xgx0vcf",$$css:!0},10:{khm7nJ:"x1xpicb7",$$css:!0},"0.5":{khm7nJ:"x1tw44j4",$$css:!0},"1.5":{khm7nJ:"xhq53yo",$$css:!0}},Qv={0:{k1C7PZ:"x1o57wo1",$$css:!0},1:{k1C7PZ:"x1lfs0n9",$$css:!0},2:{k1C7PZ:"xak3so",$$css:!0},3:{k1C7PZ:"xewh9hi",$$css:!0},4:{k1C7PZ:"xty4p9g",$$css:!0},5:{k1C7PZ:"x1eqhezk",$$css:!0},6:{k1C7PZ:"x3qlgwd",$$css:!0},8:{k1C7PZ:"xicv188",$$css:!0},10:{k1C7PZ:"x1p37tyl",$$css:!0},"0.5":{k1C7PZ:"x1kihgfc",$$css:!0},"1.5":{k1C7PZ:"x1thn6ci",$$css:!0}},Oo={0:0,.5:2,1:4,1.5:6,2:8,3:12,4:16,5:20,6:24,8:32,10:40};function Vv(t,l,e,a){const n=a!=null?Oo[a]:e!=null?Oo[e]:0;return t*l+(t-1)*n}function L0({columns:t,minChildWidth:l=0,width:e,height:a,gap:n,rowGap:u,columnGap:i,align:c,justify:f,xstyle:r,className:y,style:v,children:d,ref:g,...p}){let b,z;l>0?(b=`repeat(auto-fit, minmax(${l}px, 1fr))`,t!=null&&t>0&&(z=Vv(t,l,n,i))):t!=null&&t>0?b=`repeat(${t}, 1fr)`:b="1fr";const o={gridTemplateColumns:b,...z!=null&&{maxWidth:`${z}px`},...e!=null&&{width:typeof e=="number"?`${e}px`:e},...a!=null&&{height:typeof a=="number"?`${a}px`:a}};return A.jsx("div",{ref:g,...ae(jl("grid",{columns:t,gap:n,align:c,justify:f}),At(Xv.grid,n!=null&&Gv[n],u!=null&&Lv[u],i!=null&&Qv[i],c!=null&&Zv[c],f!=null&&Yv[f],r),y,{...v,...o}),...p,children:d})}L0.displayName="XDSGrid";const Kv=x.lazy(()=>N0(()=>Promise.resolve().then(()=>C0),void 0,import.meta.url).then(t=>({default:t.XDSTooltip}))),Jv={1:"h1",2:"h2",3:"h3",4:"h4",5:"h5",6:"h6"};function Q0({level:t,accessibilityLevel:l,color:e="primary",display:a="block",maxLines:n=0,hasTruncateTooltip:u=!0,wordBreak:i,textWrap:c,hasCapsize:f=!1,hasStrikethrough:r=!1,xstyle:y,className:v,style:d,children:g,ref:p,...b}){const z=Jv[t],o=l&&l!==t?{"aria-level":l}:{},s=i??(n===1?"break-all":"break-word"),m=n>0||f?"block":a,h=Z0({maxLines:n}),T=typeof u=="string"?u:"above",M=n>0&&u!==!1&&h.isTruncated,E=x.useRef(null),j=x.useCallback(O=>{typeof p=="function"?p(O):p&&(p.current=O),h.ref(O),E.current=O},[p,h.ref]),$=n>1?{WebkitLineClamp:n}:void 0;return A.jsxs(A.Fragment,{children:[A.jsx(z,{ref:j,...ae(jl("heading",{level:t,color:e}),At(U0[e],n===1?ju.singleLine:n>1?ju.multiLine:R0[m],n>0&&q0[s],c&&H0[c],f&&B0.enabled,r&&w0.strikethrough,y),v,{...d,...$}),title:M?h.fullText:void 0,...o,...b,children:g}),M&&A.jsx(x.Suspense,{fallback:null,children:A.jsx(Kv,{anchorRef:E,content:A.jsx("span",{...At(X0.content),children:h.fullText}),placement:T})})]})}Q0.displayName="XDSHeading";const Wv={center:{kGNEyG:"x6s0dn4",$$css:!0},end:{kGNEyG:"xuk3077",$$css:!0},start:{kGNEyG:"x1cy8zhl",$$css:!0},stretch:{kGNEyG:"x1qjc9v5",$$css:!0}},Fv={start:{kjj79g:"x1nhvcw1",$$css:!0},center:{kjj79g:"xl56j7k",$$css:!0},end:{kjj79g:"x13a6bvl",$$css:!0},between:{kjj79g:"x1qughib",$$css:!0},around:{kjj79g:"x1l1ennw",$$css:!0},evenly:{kjj79g:"xaw8158",$$css:!0}},Iv={horizontal:{kXwgrk:"x1q0g3np",$$css:!0},vertical:{kXwgrk:"xdt5ytf",$$css:!0}},Pv={nowrap:{kwnvtZ:"xozqiw3",$$css:!0},wrap:{kwnvtZ:"x1a02dak",$$css:!0},"wrap-reverse":{kwnvtZ:"x8hhl5t",$$css:!0}},th={stack:{k1xSpc:"x78zum5",$$css:!0}},lh={0:{k1C7PZ:"x1o57wo1",khm7nJ:"x6yxi7o",$$css:!0},1:{k1C7PZ:"x1lfs0n9",khm7nJ:"x1ngg2t4",$$css:!0},2:{k1C7PZ:"xak3so",khm7nJ:"x1x7z4sm",$$css:!0},3:{k1C7PZ:"xewh9hi",khm7nJ:"x4olc9o",$$css:!0},4:{k1C7PZ:"xty4p9g",khm7nJ:"xtx9w7w",$$css:!0},5:{k1C7PZ:"x1eqhezk",khm7nJ:"x1iu6piu",$$css:!0},6:{k1C7PZ:"x3qlgwd",khm7nJ:"xczp1bk",$$css:!0},8:{k1C7PZ:"xicv188",khm7nJ:"xgx0vcf",$$css:!0},10:{k1C7PZ:"x1p37tyl",khm7nJ:"x1xpicb7",$$css:!0},"0.5":{k1C7PZ:"x1kihgfc",khm7nJ:"x1tw44j4",$$css:!0},"1.5":{k1C7PZ:"x1thn6ci",khm7nJ:"xhq53yo",$$css:!0}};function eh({crossAlign:t,direction:l,gap:e,mainAlign:a,wrap:n}){return[th.stack,Iv[l],e!=null&&lh[e],t!=null&&Wv[t],a!=null&&Fv[a],n!=null&&Pv[n]]}function V0({direction:t,hAlign:l,vAlign:e,gap:a,wrap:n,element:u="div",xstyle:i,className:c,style:f,children:r,ref:y,...v}){const p=At(...eh({direction:t,crossAlign:t==="horizontal"?e:l,mainAlign:t==="horizontal"?l:e,gap:a,wrap:n}),i);return x.createElement(u,{ref:y,...ae(jl("stack",{direction:t,gap:a,wrap:n}),p,c,f),...v},r)}V0.displayName="XDSStack";function Uc({ref:t,...l}){return A.jsx(V0,{...l,direction:"vertical",ref:t})}Uc.displayName="XDSVStack";const ah=[{id:1,title:"Wireless Headphones",price:79.99,image:"https://picsum.photos/seed/headphones/400/300"},{id:2,title:"Mechanical Keyboard",price:129.99,image:"https://picsum.photos/seed/keyboard/400/300"},{id:3,title:"Ergonomic Mouse",price:49.99,image:"https://picsum.photos/seed/mouse/400/300"},{id:4,title:"USB-C Monitor",price:349.99,image:"https://picsum.photos/seed/monitor/400/300"},{id:5,title:"Webcam HD",price:59.99,image:"https://picsum.photos/seed/webcam/400/300"},{id:6,title:"Desk Lamp",price:39.99,image:"https://picsum.photos/seed/lamp/400/300"}];function nh(){return A.jsx(L0,{minChildWidth:260,gap:4,children:ah.map(t=>A.jsx(k0,{padding:0,children:A.jsxs(Uc,{gap:3,children:[A.jsx("img",{src:t.image,alt:t.title,style:{width:"100%",aspectRatio:"4 / 3",objectFit:"cover",borderRadius:"var(--radius-container) var(--radius-container) 0 0",display:"block"}}),A.jsxs(Uc,{gap:2,xstyle:{paddingInline:"var(--spacing-4)",paddingBlockEnd:"var(--spacing-4)"},children:[A.jsx(Q0,{level:4,children:t.title}),A.jsxs(Bf,{type:"large",weight:"semibold",children:["$",t.price.toFixed(2)]}),A.jsx(G0,{label:"Add to cart",variant:"primary",children:"Add to Cart"})]})]})},t.id))})}function uh(){return A.jsx(D0,{theme:nv,mode:"light",children:A.jsx(nh,{})})}Lm.createRoot(document.getElementById("root")).render(A.jsx(uh,{}));</script>
+  <style rel="stylesheet" crossorigin>/**
+ * XDS Reset Stylesheet
+ *
+ * An opinionated CSS reset that provides a clean, predictable base for
+ * XDS applications. Built on the same principles as Tailwind Preflight
+ * and modern-normalize, adapted for the XDS design system.
+ *
+ * This reset:
+ * - Normalizes cross-browser inconsistencies
+ * - Sets box-sizing: border-box universally
+ * - Removes default margins, padding, and list styles
+ * - Makes images block-level and responsive
+ * - Resets form elements to inherit font styles
+ * - Uses :where() for zero specificity (easy to override)
+ *
+ * Usage:
+ *
+ * 1. Import directly (global reset):
+ *    import '@xds/core/reset.css';
+ *
+ * 2. Combine with base styles and theme:
+ *    import '@xds/core/reset.css';        // @layer reset  — clean slate
+ *    import '@xds/core/xds.css';           // @layer xds-base — component styles
+ *    import '@xds/theme-default/theme.css'; // @layer xds-theme — theme overrides
+ *
+ * Layer order: reset → xds-base → xds-theme
+ * Consumer styles (unlayered) always override all XDS layers.
+ * The reset has the lowest priority and can be overridden by any other layer.
+ *
+ * Similar to:
+ * - Tailwind CSS Preflight
+ * - Chakra UI's preflight (v3)
+ * - Bootstrap Reboot
+ * - modern-normalize
+ */
+
+@layer reset {
+
+  /* ===========================================================================
+     Box Model
+     =========================================================================== */
+
+  /*
+   * Use border-box globally. Prevents padding/border from affecting
+   * element dimensions — the single most impactful reset.
+   */
+  :where(*, *::before, *::after) {
+    box-sizing: border-box;
+  }
+
+  /*
+   * Reset borders to 0-width solid. This lets you add a border by just
+   * setting border-width — no need to also specify border-style.
+   */
+  :where(*, *::before, *::after) {
+    border-width: 0;
+    border-style: solid;
+    border-color: currentColor;
+  }
+
+  /* ===========================================================================
+     Document
+     =========================================================================== */
+
+  /*
+   * Consistent line-height, prevent text size adjustment on orientation
+   * change in iOS, and set a readable tab size.
+   *
+   * color-scheme: light dark — declares that this page supports both modes,
+   * enabling CSS light-dark() to resolve correctly. Also ensures that CSS
+   * tools (e.g. LightningCSS) which polyfill light-dark() for older browsers
+   * inject their toggle-variable initialization in the same CSS bundle.
+   * XDSTheme overrides color-scheme per-wrapper as needed.
+   */
+  :where(html) {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    color-scheme: light dark;
+  }
+
+  /*
+   * Remove default body margin and set font smoothing for sharper text
+   * rendering on macOS/iOS.
+   */
+  :where(body) {
+    margin: 0;
+    line-height: inherit;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* ===========================================================================
+     Typography
+     =========================================================================== */
+
+  /*
+   * Reset headings to inherit size and weight. Headings should be styled
+   * intentionally — not rely on browser defaults that vary across browsers.
+   */
+  :where(h1, h2, h3, h4, h5, h6) {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /*
+   * Remove default margins on all block-level text elements.
+   */
+  :where(h1, h2, h3, h4, h5, h6, p, blockquote, figure, pre, dl, dd) {
+    margin: 0;
+  }
+
+  /*
+   * Links inherit color and text-decoration. Style them intentionally
+   * rather than relying on browser-default blue/purple.
+   */
+  :where(a) {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  /*
+   * Correct font-weight rendering in Chrome and Safari.
+   */
+  :where(b, strong) {
+    font-weight: bolder;
+  }
+
+  /*
+   * Use the configured monospace font stack and fix the odd em sizing
+   * that browsers apply to code elements.
+   */
+  :where(code, kbd, samp, pre) {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      'Liberation Mono', 'Courier New', monospace;
+    font-size: 1em;
+  }
+
+  /*
+   * Correct font-size for small elements.
+   */
+  :where(small) {
+    font-size: 80%;
+  }
+
+  /*
+   * Prevent sub and sup from affecting line-height.
+   */
+  :where(sub, sup) {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  :where(sub) {
+    bottom: -0.25em;
+  }
+
+  :where(sup) {
+    top: -0.5em;
+  }
+
+  /* ===========================================================================
+     Lists
+     =========================================================================== */
+
+  /*
+   * Remove default list styles, margin, and padding. Lists used for
+   * navigation or layout shouldn't carry prose styling by default.
+   * Use explicit styles for prose lists.
+   */
+  :where(ol, ul, menu) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Media
+     =========================================================================== */
+
+  /*
+   * Make replaced elements block-level. Eliminates the "mystery gap"
+   * below inline images and aligns with how these elements are
+   * actually used in modern layouts.
+   */
+  :where(img, svg, video, canvas, audio, iframe, embed, object) {
+    display: block;
+    vertical-align: middle;
+  }
+
+  /*
+   * Constrain images and video to their container. Responsive by default.
+   */
+  :where(img, video) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* ===========================================================================
+     Forms
+     =========================================================================== */
+
+  /*
+   * Form elements should inherit font styles from their parent rather
+   * than using the browser's default font stack.
+   */
+  :where(button, input, optgroup, select, textarea) {
+    font: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  /*
+   * Remove default button styling. Buttons should be styled intentionally.
+   */
+  :where(button, [type='button'], [type='reset'], [type='submit']) {
+    -webkit-appearance: button;
+    appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
+
+  /*
+   * Pointer cursor for interactive elements.
+   */
+  :where(button, [role='button']) {
+    cursor: pointer;
+  }
+
+  /*
+   * Default cursor for disabled elements.
+   */
+  :where(:disabled) {
+    cursor: default;
+  }
+
+  /*
+   * Only allow vertical resizing of textareas to prevent layout breakage.
+   */
+  :where(textarea) {
+    resize: vertical;
+  }
+
+  /*
+   * Normalize placeholder opacity (Firefox renders at reduced opacity)
+   * and set a sensible default color using the XDS text-placeholder token.
+   */
+  :where(input::placeholder, textarea::placeholder) {
+    opacity: 1;
+    color: var(--color-text-secondary, #9ca3af);
+  }
+
+  /*
+   * Remove the inner padding and cancel buttons in search inputs
+   * for Chrome and Safari.
+   */
+  :where([type='search']::-webkit-search-decoration,
+         [type='search']::-webkit-search-cancel-button) {
+    -webkit-appearance: none;
+  }
+
+  /*
+   * Remove default fieldset styles.
+   */
+  :where(fieldset) {
+    margin: 0;
+    padding: 0;
+  }
+
+  :where(legend) {
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Tables
+     =========================================================================== */
+
+  /*
+   * Collapse table borders and fix text-indent/border-color inheritance.
+   */
+  :where(table) {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  /* ===========================================================================
+     Misc
+     =========================================================================== */
+
+  /*
+   * Simplify hr to a single border-top line.
+   */
+  :where(hr) {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  /*
+   * Correct display for summary elements.
+   */
+  :where(summary) {
+    display: list-item;
+  }
+
+  /*
+   * Reset dialog padding and outline.
+   */
+  :where(dialog) {
+    padding: 0;
+    outline: none;
+  }
+
+  /*
+   * Ensure hidden elements are actually hidden.
+   */
+  :where([hidden]) {
+    display: none;
+  }
+
+  /*
+   * Remove tap highlight on iOS.
+   */
+  :where(html) {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* ===========================================================================
+     Touch Devices
+     =========================================================================== */
+
+  /*
+   * Suppress focus-visible outlines on touch-only devices.
+   *
+   * Focus rings exist to show keyboard users where focus is. On devices
+   * with no hover capability and a coarse pointer (phones, tablets),
+   * there's no keyboard navigation — focus rings are visual noise that
+   * can flash on tap, on dialog open (showModal auto-focus), or on
+   * programmatic focus.
+   *
+   * This targets touch-only devices specifically:
+   * - (hover: none) — no hover capability (not a mouse)
+   * - (pointer: coarse) — imprecise pointer (finger, not stylus)
+   *
+   * Hybrid devices (laptop with touchscreen) are NOT affected because
+   * their primary pointer is fine (trackpad/mouse) and hover is available.
+   */
+  @media (hover: none) and (pointer: coarse) {
+    :where(:focus-visible) {
+      outline: none;
+    }
+  }
+}</style>
+<style>@property --x-width {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-height {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-maxWidth {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-minHeight {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x---container-max-height {
+  syntax: "*";
+  inherits: false
+}
+
+@keyframes xwmkjkf-B {
+  from {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xu7jd1z-B {
+  from {
+    opacity: 0;
+    transform: translateX(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xv1hr86-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes x1ahk7ht-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes xqng64z-B {
+  0% {
+    transform: rotate(0);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+:root, .xyc456f {
+  --border-width: 1px;
+}
+
+:root, .xrphr3l {
+  --color-accent: light-dark(#0064e0, #2694fe);
+  --color-accent-muted: light-dark(#0082fb33, #0082fb3f);
+  --color-on-accent: light-dark(#fff, #fff);
+  --color-neutral: light-dark(#0536591a, #dfe2e533);
+  --color-background-surface: light-dark(#fff, #1f1f22);
+  --color-background-body: light-dark(#f1f4f7, #111112);
+  --color-overlay: light-dark(#01122866, #11111299);
+  --color-overlay-hover: light-dark(#0536590c, #ffffff0c);
+  --color-overlay-pressed: light-dark(#05365919, #ffffff19);
+  --color-background-muted: light-dark(#0536590c, #1111127f);
+  --color-text-primary: light-dark(#0a1317, #dfe2e5);
+  --color-text-secondary: light-dark(#4e606f, #aaafb5);
+  --color-text-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-text-accent: light-dark(#0064e0, #3e9efb);
+  --color-on-dark: light-dark(#fff, #fff);
+  --color-on-light: light-dark(#000, #000);
+  --color-icon-accent: light-dark(#0064e0, #2694fe);
+  --color-icon-primary: light-dark(#0a1317, #dfe2e5);
+  --color-icon-secondary: light-dark(#4e606f, #aaafb5);
+  --color-icon-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-background-card: light-dark(#fff, #1f1f22);
+  --color-background-popover: light-dark(#fff, #28292c);
+  --color-success: light-dark(#0d8626, #0d8626);
+  --color-success-muted: light-dark(#0b991f33, #0b991f3f);
+  --color-on-success: light-dark(#fff, #fff);
+  --color-error: light-dark(#e3193b, #f5394f);
+  --color-error-muted: light-dark(#e3193b33, #f5394f3f);
+  --color-on-error: light-dark(#fff, #fff);
+  --color-warning: light-dark(#e9af08, #f2c00b);
+  --color-warning-muted: light-dark(#e2a40033, #e2a4003f);
+  --color-on-warning: light-dark(#0a1317, #0a1317);
+  --color-border: light-dark(#05365919, #f2f4f619);
+  --color-border-emphasized: light-dark(#ccd3db, #494d53);
+  --color-skeleton: light-dark(#ccd3db, #5a5e66);
+  --color-shadow: light-dark(#0536591a, #0000004d);
+  --color-tint-hover: light-dark(#000, #fff);
+  --color-background-blue: light-dark(#0171e333, #0171e333);
+  --color-border-blue: light-dark(#0171e3, #4ba9fe);
+  --color-icon-blue: light-dark(#0064e0, #2694fe);
+  --color-text-blue: light-dark(#042f97, #afd7ff);
+  --color-background-cyan: light-dark(#03a7d733, #03a7d733);
+  --color-border-cyan: light-dark(#00bcd4, #4dd0e1);
+  --color-icon-cyan: light-dark(#00acc1, #26c6da);
+  --color-text-cyan: light-dark(#014975, #a1eef9);
+  --color-background-gray: light-dark(#0a131733, #666a724c);
+  --color-border-gray: light-dark(#647685, #8c939b);
+  --color-icon-gray: light-dark(#4e606f, #aaafb5);
+  --color-text-gray: light-dark(#0a1317, #e7eaed);
+  --color-background-green: light-dark(#24bb5e33, #24bb5e33);
+  --color-border-green: light-dark(#24bb5e, #4cd964);
+  --color-icon-green: light-dark(#0d8626, #26a756);
+  --color-text-green: light-dark(#09441f, #a5f690);
+  --color-background-orange: light-dark(#f2790233, #f2790233);
+  --color-border-orange: light-dark(#f27902, #ffa040);
+  --color-icon-orange: light-dark(#e9690b, #fb8c00);
+  --color-text-orange: light-dark(#6b2203, #fdb876);
+  --color-background-pink: light-dark(#e638b333, #e638b333);
+  --color-border-pink: light-dark(#e91e63, #f48fb1);
+  --color-icon-pink: light-dark(#c2185b, #ec407a);
+  --color-text-pink: light-dark(#650053, #feade3);
+  --color-background-purple: light-dark(#7952ff33, #7952ff33);
+  --color-border-purple: light-dark(#7952ff, #9575cd);
+  --color-icon-purple: light-dark(#5b08d8, #7952ff);
+  --color-text-purple: light-dark(#3e0697, #b3b0fe);
+  --color-background-red: light-dark(#e3193b33, #e3193b33);
+  --color-border-red: light-dark(#e3193b, #f5394f);
+  --color-icon-red: light-dark(#d31130, #e3193b);
+  --color-text-red: light-dark(#7b0210, #ffb2b8);
+  --color-background-teal: light-dark(#0db7af33, #0db7af33);
+  --color-border-teal: light-dark(#0db7af, #4db6ac);
+  --color-icon-teal: light-dark(#009688, #26a69a);
+  --color-text-teal: light-dark(#083943, #40dccd);
+  --color-background-yellow: light-dark(#e2a40033, #e2a40033);
+  --color-border-yellow: light-dark(#ffeb3b, #fff176);
+  --color-icon-yellow: light-dark(#fbc02d, #ffee58);
+  --color-text-yellow: light-dark(#753f07, #fbce03);
+}
+
+:root, .xdxxp96 {
+  --duration-fast-min: .13s;
+  --duration-fast: .175s;
+  --duration-fast-max: .23s;
+  --duration-medium-min: .31s;
+  --duration-medium: .41s;
+  --duration-medium-max: .55s;
+}
+
+:root, .x1u6r7cv {
+  --ease-standard: cubic-bezier(.24, 1, .4, 1);
+}
+
+:root, .x6xvlns {
+  --font-family-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-family-code: "SF Mono", Monaco, Consolas, monospace;
+  --font-family-heading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+:root, .x48sopm {
+  --font-size-4xs: .375rem;
+  --font-size-3xs: .4375rem;
+  --font-size-2xs: .5rem;
+  --font-size-xs: .625rem;
+  --font-size-sm: .75rem;
+  --font-size-base: .875rem;
+  --font-size-lg: 1.0625rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.8125rem;
+  --font-size-4xl: 2.1875rem;
+  --font-size-5xl: 2.625rem;
+}
+
+:root, .x1anzp68 {
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+}
+
+:root, .xy6n0i {
+  --radius-none: 0px;
+  --radius-inner: 4px;
+  --radius-element: 8px;
+  --radius-container: 12px;
+  --radius-page: 28px;
+  --radius-full: 9999px;
+}
+
+:root, .x99zpk1 {
+  --shadow-low: 0px 1px 1px light-dark(#0000001a, #0003), 0px 2px 8px light-dark(#0000001a, #0003);
+  --shadow-med: 0px 1px 2px light-dark(#0000001a, #0003), 0px 2px 12px light-dark(#0000001a, #0003);
+  --shadow-high: 0px 2px 2px light-dark(#0000001a, #0003), 0px 8px 24px light-dark(#0000001a, #0000004d);
+  --shadow-inset-hover: inset 0px 0px 0px 2px #0171e34d;
+  --shadow-inset-selected: inset 0px 0px 0px 2px #0171e380;
+  --shadow-inset-success: inset 0px 0px 0px 2px #26a7564d;
+  --shadow-inset-warning: inset 0px 0px 0px 2px #e2a4004d;
+  --shadow-inset-error: inset 0px 0px 0px 2px #e3193b4d;
+}
+
+:root, .x10aelx4 {
+  --size-element-sm: 28px;
+  --size-element-md: 32px;
+  --size-element-lg: 36px;
+}
+
+:root, .x1auoh0n {
+  --spacing-0: 0px;
+  --spacing-0-5: 2px;
+  --spacing-1: 4px;
+  --spacing-1-5: 6px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-11: 44px;
+  --spacing-12: 48px;
+}
+
+:root, .xmde5od {
+  --text-heading-1-size: var(--font-size-2xl);
+  --text-heading-1-weight: var(--font-weight-semibold);
+  --text-heading-1-leading: 1.3333;
+  --text-heading-2-size: var(--font-size-xl);
+  --text-heading-2-weight: var(--font-weight-semibold);
+  --text-heading-2-leading: 1.4;
+  --text-heading-3-size: var(--font-size-lg);
+  --text-heading-3-weight: var(--font-weight-semibold);
+  --text-heading-3-leading: 1.4118;
+  --text-heading-4-size: var(--font-size-base);
+  --text-heading-4-weight: var(--font-weight-semibold);
+  --text-heading-4-leading: 1.4286;
+  --text-heading-5-size: var(--font-size-sm);
+  --text-heading-5-weight: var(--font-weight-semibold);
+  --text-heading-5-leading: 1.6667;
+  --text-heading-6-size: var(--font-size-xs);
+  --text-heading-6-weight: var(--font-weight-semibold);
+  --text-heading-6-leading: 1.6;
+  --text-body-size: var(--font-size-base);
+  --text-body-weight: var(--font-weight-normal);
+  --text-body-leading: 1.4286;
+  --text-large-size: var(--font-size-lg);
+  --text-large-weight: var(--font-weight-semibold);
+  --text-large-leading: 1.4118;
+  --text-label-size: var(--font-size-base);
+  --text-label-weight: var(--font-weight-medium);
+  --text-label-leading: 1.4286;
+  --text-code-size: var(--font-size-base);
+  --text-code-weight: var(--font-weight-normal);
+  --text-code-leading: 1.4286;
+  --text-supporting-size: var(--font-size-sm);
+  --text-supporting-weight: var(--font-weight-normal);
+  --text-supporting-leading: 1.6667;
+  --text-display-1-size: var(--font-size-5xl);
+  --text-display-1-weight: var(--font-weight-normal);
+  --text-display-1-leading: 1.2381;
+  --text-display-2-size: var(--font-size-4xl);
+  --text-display-2-weight: var(--font-weight-normal);
+  --text-display-2-leading: 1.2571;
+  --text-display-3-size: var(--font-size-3xl);
+  --text-display-3-weight: var(--font-weight-normal);
+  --text-display-3-leading: 1.2414;
+}
+
+:root, .xs77cmt {
+  --transition-fast: .15s ease;
+  --transition-normal: .2s ease;
+}
+
+.xkzo27j {
+  --button-focus-offset: 3px;
+}
+
+.x1v15ycx {
+  --button-icon-only-aspect: 1 / 1;
+}
+
+.x1mkq5kp {
+  --button-radius: var(--radius-element);
+}
+
+.xb26y6u {
+  --card-radius: var(--radius-container);
+}
+
+.x30uzy1 {
+  --component-padding-inline: var(--spacing-2);
+}
+
+.x1ojg8sz {
+  --component-padding-inline: var(--spacing-3);
+}
+
+.x18nyedi {
+  --container-max-height: var(--x---container-max-height);
+}
+
+.x1qmdwou {
+  --container-padding-inline: var(--spacing-0-5);
+}
+
+.x11nj8ps {
+  --container-padding-inline: var(--spacing-0);
+}
+
+.x11c4xrl {
+  --container-padding-inline: var(--spacing-1-5);
+}
+
+.xmqp8mn {
+  --container-padding-inline: var(--spacing-1);
+}
+
+.x1mh38z9 {
+  --container-padding-inline: var(--spacing-10);
+}
+
+.xarkblc {
+  --container-padding-inline: var(--spacing-11);
+}
+
+.x15nzvup {
+  --container-padding-inline: var(--spacing-12);
+}
+
+.xvkq9sf {
+  --container-padding-inline: var(--spacing-2);
+}
+
+.x17rklng {
+  --container-padding-inline: var(--spacing-3);
+}
+
+.x1qtkjpi {
+  --container-padding-inline: var(--spacing-4);
+}
+
+.xcek0mv {
+  --container-padding-inline: var(--spacing-5);
+}
+
+.xzryng3 {
+  --container-padding-inline: var(--spacing-6);
+}
+
+.x1jrgra8 {
+  --container-padding-inline: var(--spacing-7);
+}
+
+.x1t3jwqk {
+  --container-padding-inline: var(--spacing-8);
+}
+
+.x1ikhtwg {
+  --container-padding-inline: var(--spacing-9);
+}
+
+.x118jium {
+  --container-padding-inline: var(--xds-card-padding, var(--spacing-4));
+}
+
+.x1x4tb0e {
+  --container-padding-inline: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xbuvapz {
+  --container-padding: 0px;
+}
+
+.x1b322fk {
+  --container-padding: var(--spacing-0-5);
+}
+
+.x1i337hy {
+  --container-padding: var(--spacing-0);
+}
+
+.x1tqehje {
+  --container-padding: var(--spacing-1-5);
+}
+
+.x11x0u8a {
+  --container-padding: var(--spacing-1);
+}
+
+.xl4lgz8 {
+  --container-padding: var(--spacing-10);
+}
+
+.xfk8qm2 {
+  --container-padding: var(--spacing-11);
+}
+
+.xtcn5oa {
+  --container-padding: var(--spacing-12);
+}
+
+.xyawmno {
+  --container-padding: var(--spacing-2);
+}
+
+.xiq2vfk {
+  --container-padding: var(--spacing-3);
+}
+
+.x18iqpsj {
+  --container-padding: var(--spacing-4);
+}
+
+.x305b4h {
+  --container-padding: var(--spacing-5);
+}
+
+.x1suvfq4 {
+  --container-padding: var(--spacing-6);
+}
+
+.xe04trj {
+  --container-padding: var(--spacing-7);
+}
+
+.xv6sa6u {
+  --container-padding: var(--spacing-8);
+}
+
+.xswgb5g {
+  --container-padding: var(--spacing-9);
+}
+
+.x8q8htr {
+  --container-padding: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xms56fs {
+  --container-padding: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xwfoc2r {
+  --edge-end: 1;
+}
+
+.x1tfgai2 {
+  --edge-start: 1;
+}
+
+.xlriy2h {
+  --layout-padding-inner-x: var(--spacing-0-5);
+}
+
+.xj1bl4l {
+  --layout-padding-inner-x: var(--spacing-0);
+}
+
+.xd38f90 {
+  --layout-padding-inner-x: var(--spacing-1-5);
+}
+
+.x6uuyak {
+  --layout-padding-inner-x: var(--spacing-1);
+}
+
+.x1vf4qco {
+  --layout-padding-inner-x: var(--spacing-10);
+}
+
+.xsmamsf {
+  --layout-padding-inner-x: var(--spacing-11);
+}
+
+.x2xk2xj {
+  --layout-padding-inner-x: var(--spacing-12);
+}
+
+.xxqksqd {
+  --layout-padding-inner-x: var(--spacing-2);
+}
+
+.x1fyui2f {
+  --layout-padding-inner-x: var(--spacing-3);
+}
+
+.x1i2ajwi {
+  --layout-padding-inner-x: var(--spacing-4);
+}
+
+.x1tac27u {
+  --layout-padding-inner-x: var(--spacing-5);
+}
+
+.x1ntgf3t {
+  --layout-padding-inner-x: var(--spacing-6);
+}
+
+.xhjd9tl {
+  --layout-padding-inner-x: var(--spacing-7);
+}
+
+.xn7c84u {
+  --layout-padding-inner-x: var(--spacing-8);
+}
+
+.xeqkbsz {
+  --layout-padding-inner-x: var(--spacing-9);
+}
+
+.x1gox8qf {
+  --layout-padding-inner-x: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xn3f0pw {
+  --layout-padding-inner-x: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x180h0y5 {
+  --layout-padding-inner-y: var(--spacing-0-5);
+}
+
+.xwuefyo {
+  --layout-padding-inner-y: var(--spacing-0);
+}
+
+.x1g8jpzm {
+  --layout-padding-inner-y: var(--spacing-1-5);
+}
+
+.xmpug6m {
+  --layout-padding-inner-y: var(--spacing-1);
+}
+
+.x18gbwmk {
+  --layout-padding-inner-y: var(--spacing-10);
+}
+
+.x14zymzj {
+  --layout-padding-inner-y: var(--spacing-11);
+}
+
+.xzfpkx9 {
+  --layout-padding-inner-y: var(--spacing-12);
+}
+
+.x1lksgje {
+  --layout-padding-inner-y: var(--spacing-2);
+}
+
+.x4j7gld {
+  --layout-padding-inner-y: var(--spacing-3);
+}
+
+.x1s3ehtl {
+  --layout-padding-inner-y: var(--spacing-4);
+}
+
+.x1rj5eim {
+  --layout-padding-inner-y: var(--spacing-5);
+}
+
+.x1ftgg6u {
+  --layout-padding-inner-y: var(--spacing-6);
+}
+
+.x1ho74vh {
+  --layout-padding-inner-y: var(--spacing-7);
+}
+
+.xm2cs6f {
+  --layout-padding-inner-y: var(--spacing-8);
+}
+
+.x1vsq92b {
+  --layout-padding-inner-y: var(--spacing-9);
+}
+
+.x1eounod {
+  --layout-padding-inner-y: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xihc2cu {
+  --layout-padding-inner-y: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x1wbjvqu {
+  --layout-padding-outer-x: 0px;
+}
+
+.xihiwg7 {
+  --layout-padding-outer-x: var(--spacing-0-5);
+}
+
+.xswhm3q {
+  --layout-padding-outer-x: var(--spacing-0);
+}
+
+.x1u93lgd {
+  --layout-padding-outer-x: var(--spacing-1-5);
+}
+
+.xc96xmq {
+  --layout-padding-outer-x: var(--spacing-1);
+}
+
+.x1jdf5a4 {
+  --layout-padding-outer-x: var(--spacing-10);
+}
+
+.x1hct0t0 {
+  --layout-padding-outer-x: var(--spacing-11);
+}
+
+.x11cyqoe {
+  --layout-padding-outer-x: var(--spacing-12);
+}
+
+.x15dxnc0 {
+  --layout-padding-outer-x: var(--spacing-2);
+}
+
+.xadgj3j {
+  --layout-padding-outer-x: var(--spacing-3);
+}
+
+.x1v56qcf {
+  --layout-padding-outer-x: var(--spacing-4);
+}
+
+.x1nzs0gl {
+  --layout-padding-outer-x: var(--spacing-5);
+}
+
+.x1c3n52a {
+  --layout-padding-outer-x: var(--spacing-6);
+}
+
+.x1gfiokx {
+  --layout-padding-outer-x: var(--spacing-7);
+}
+
+.x1t3kfz {
+  --layout-padding-outer-x: var(--spacing-8);
+}
+
+.xzr4qsh {
+  --layout-padding-outer-x: var(--spacing-9);
+}
+
+.x1r0u152 {
+  --layout-padding-outer-x: var(--xds-card-padding, var(--spacing-4));
+}
+
+.x1h0nqri {
+  --layout-padding-outer-x: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xzxxx64 {
+  --layout-padding-outer-y: 0px;
+}
+
+.x1vj96e0 {
+  --layout-padding-outer-y: var(--spacing-0-5);
+}
+
+.x1mzf5mb {
+  --layout-padding-outer-y: var(--spacing-0);
+}
+
+.xd3dqby {
+  --layout-padding-outer-y: var(--spacing-1-5);
+}
+
+.x1gpfxoh {
+  --layout-padding-outer-y: var(--spacing-1);
+}
+
+.x26l4wa {
+  --layout-padding-outer-y: var(--spacing-10);
+}
+
+.x10zktp0 {
+  --layout-padding-outer-y: var(--spacing-11);
+}
+
+.x1yz3n6a {
+  --layout-padding-outer-y: var(--spacing-12);
+}
+
+.x10pz7y9 {
+  --layout-padding-outer-y: var(--spacing-2);
+}
+
+.x1p6yq3h {
+  --layout-padding-outer-y: var(--spacing-3);
+}
+
+.xx738ci {
+  --layout-padding-outer-y: var(--spacing-4);
+}
+
+.x6yxws5 {
+  --layout-padding-outer-y: var(--spacing-5);
+}
+
+.x180vrwl {
+  --layout-padding-outer-y: var(--spacing-6);
+}
+
+.x1q6rme1 {
+  --layout-padding-outer-y: var(--spacing-7);
+}
+
+.xid7e43 {
+  --layout-padding-outer-y: var(--spacing-8);
+}
+
+.x1t5kicu {
+  --layout-padding-outer-y: var(--spacing-9);
+}
+
+.xzqheer {
+  --layout-padding-outer-y: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xlfd3nr {
+  --layout-padding-outer-y: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xkdpibf:not(#\#) {
+  margin: -1px;
+}
+
+.x1ak00ur:not(#\#) {
+  margin: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1717udv:not(#\#) {
+  padding: 0;
+}
+
+.x1kp5lmi:not(#\#) {
+  padding: var(--container-padding);
+}
+
+.xvy26l8:not(#\#):not(#\#) {
+  border-color: var(--color-border-emphasized);
+}
+
+.x1q11iln:not(#\#):not(#\#) {
+  border-radius: var(--button-radius);
+}
+
+.x8j4bds:not(#\#):not(#\#) {
+  border-radius: var(--card-radius);
+}
+
+.x1hviunn:not(#\#):not(#\#) {
+  border-radius: var(--radius-container);
+}
+
+.xng3xce:not(#\#):not(#\#) {
+  border-style: none;
+}
+
+.x1y0btm7:not(#\#):not(#\#) {
+  border-style: solid;
+}
+
+.xc342km:not(#\#):not(#\#) {
+  border-width: 0;
+}
+
+.x1litavf:not(#\#):not(#\#) {
+  border-width: var(--border-width);
+}
+
+.x98rzlu:not(#\#):not(#\#) {
+  flex: 1;
+}
+
+.x1lsbc85:not(#\#):not(#\#) {
+  gap: var(--spacing-0-5);
+}
+
+.xsn7fz1:not(#\#):not(#\#) {
+  gap: var(--spacing-0);
+}
+
+.x1s4dlld:not(#\#):not(#\#) {
+  gap: var(--spacing-1-5);
+}
+
+.xzye2dw:not(#\#):not(#\#) {
+  gap: var(--spacing-1);
+}
+
+.x3hoi3v:not(#\#):not(#\#) {
+  gap: var(--spacing-10);
+}
+
+.x1txdalj:not(#\#):not(#\#) {
+  gap: var(--spacing-2);
+}
+
+.xjcht0a:not(#\#):not(#\#) {
+  gap: var(--spacing-3);
+}
+
+.x18g69wz:not(#\#):not(#\#) {
+  gap: var(--spacing-4);
+}
+
+.x9mgr7n:not(#\#):not(#\#) {
+  gap: var(--spacing-5);
+}
+
+.x1qh66ti:not(#\#):not(#\#) {
+  gap: var(--spacing-6);
+}
+
+.x4t41sb:not(#\#):not(#\#) {
+  gap: var(--spacing-8);
+}
+
+.xzyy9it:not(#\#):not(#\#) {
+  margin-inline: calc(-1 * var(--container-padding, 0px));
+}
+
+.xysyzu8:not(#\#):not(#\#) {
+  overflow: auto;
+}
+
+.x7giv3:not(#\#):not(#\#) {
+  overflow: clip;
+}
+
+.xb3r6kr:not(#\#):not(#\#) {
+  overflow: hidden;
+}
+
+.x1rea2x4:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xce4md1:not(#\#):not(#\#) {
+  padding-block: var(--spacing-2);
+}
+
+.xf314gf:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-2);
+}
+
+.xrrkdod:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-3);
+}
+
+.xmqliwb:not(#\#):not(#\#) {
+  text-decoration: line-through;
+}
+
+.x1hl2dhg:not(#\#):not(#\#) {
+  text-decoration: none;
+}
+
+.x17nn4n9:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-accent);
+}
+
+.x1p73he7:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-error);
+}
+
+.x1ua5tub:not(#\#):not(#\#):not(#\#) {
+  -webkit-box-orient: vertical;
+}
+
+.x6s0dn4:not(#\#):not(#\#):not(#\#) {
+  align-items: center;
+}
+
+.xpqajaz:not(#\#):not(#\#):not(#\#) {
+  align-items: end;
+}
+
+.xuk3077:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-end;
+}
+
+.x1cy8zhl:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-start;
+}
+
+.x7a106z:not(#\#):not(#\#):not(#\#) {
+  align-items: start;
+}
+
+.x1qjc9v5:not(#\#):not(#\#):not(#\#) {
+  align-items: stretch;
+}
+
+.xamitd3:not(#\#):not(#\#):not(#\#) {
+  align-self: center;
+}
+
+.xpvyfi4:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-end;
+}
+
+.xqcrz7y:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-start;
+}
+
+.xkh2ocl:not(#\#):not(#\#):not(#\#) {
+  align-self: stretch;
+}
+
+.x9uej1z:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-fast-max);
+}
+
+.xqgcaz:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-medium-max);
+}
+
+.xskzprw:not(#\#):not(#\#):not(#\#) {
+  animation-fill-mode: backwards;
+}
+
+.xa4qsjk:not(#\#):not(#\#):not(#\#) {
+  animation-iteration-count: infinite;
+}
+
+.x3psbcj:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1ahk7ht-B;
+}
+
+.x1ka1v4i:not(#\#):not(#\#):not(#\#) {
+  animation-name: xqng64z-B;
+}
+
+.xck01x9:not(#\#):not(#\#):not(#\#) {
+  animation-name: xu7jd1z-B;
+}
+
+.xl1vlw0:not(#\#):not(#\#):not(#\#) {
+  animation-name: xv1hr86-B;
+}
+
+.x1i331go:not(#\#):not(#\#):not(#\#) {
+  animation-name: xwmkjkf-B;
+}
+
+.x1esw782:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: linear;
+}
+
+.x128ha8g:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: var(--ease-standard);
+}
+
+.xioom0i:not(#\#):not(#\#):not(#\#) {
+  aspect-ratio: var(--button-icon-only-aspect);
+}
+
+.xlp1x4z:not(#\#):not(#\#):not(#\#) {
+  backface-visibility: hidden;
+}
+
+.xjbqb8w:not(#\#):not(#\#):not(#\#) {
+  background-color: #0000;
+}
+
+.x1ewilqj:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-accent);
+}
+
+.x1de1mus:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-card);
+}
+
+.xwmxj5m:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.x10xzikg:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-surface);
+}
+
+.x1pjz0fi:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error);
+}
+
+.x17x4s8c:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-neutral);
+}
+
+.x19aspcf:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-text-primary);
+}
+
+.x18o3ruo:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1gejf6u:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-border);
+}
+
+.x18b5jzi:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-style: solid;
+}
+
+.x1lun4ml:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-width: 1px;
+}
+
+.x1j92z86:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-color: var(--color-border);
+}
+
+.x1t7ytsu:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-style: solid;
+}
+
+.xpilrb4:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-width: 1px;
+}
+
+.x9f619:not(#\#):not(#\#):not(#\#) {
+  box-sizing: border-box;
+}
+
+.xzpqnlu:not(#\#):not(#\#):not(#\#) {
+  clip: rect(0,0,0,0);
+}
+
+.xntwwlm:not(#\#):not(#\#):not(#\#) {
+  color-scheme: dark;
+}
+
+.x108lcm5:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light dark;
+}
+
+.x19aimcq:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light;
+}
+
+.x1heor9g:not(#\#):not(#\#):not(#\#) {
+  color: inherit;
+}
+
+.x19co3pv:not(#\#):not(#\#):not(#\#) {
+  color: #0000;
+}
+
+.xqwr325:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-accent);
+}
+
+.xrkvqaz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-background-surface);
+}
+
+.x17wrial:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-accent);
+}
+
+.x1m024r3:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-error);
+}
+
+.xnbbluu:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-disabled);
+}
+
+.x1tgivj0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-primary);
+}
+
+.xv1l7n4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-secondary);
+}
+
+.x1kihgfc:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0-5);
+}
+
+.x1o57wo1:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0);
+}
+
+.x1thn6ci:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1-5);
+}
+
+.x1lfs0n9:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1);
+}
+
+.x1p37tyl:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-10);
+}
+
+.xak3so:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-2);
+}
+
+.xewh9hi:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-3);
+}
+
+.xty4p9g:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-4);
+}
+
+.x1eqhezk:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-5);
+}
+
+.x3qlgwd:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-6);
+}
+
+.xicv188:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-8);
+}
+
+.x1h6gzvc:not(#\#):not(#\#):not(#\#) {
+  cursor: not-allowed;
+}
+
+.x1ypdohk:not(#\#):not(#\#):not(#\#) {
+  cursor: pointer;
+}
+
+.x104kibb:not(#\#):not(#\#):not(#\#) {
+  display: -webkit-box;
+}
+
+.x1lliihq:not(#\#):not(#\#):not(#\#) {
+  display: block;
+}
+
+.xjp7ctv:not(#\#):not(#\#):not(#\#) {
+  display: contents;
+}
+
+.x78zum5:not(#\#):not(#\#):not(#\#) {
+  display: flex;
+}
+
+.xrvj5dj:not(#\#):not(#\#):not(#\#) {
+  display: grid;
+}
+
+.x1rg5ohu:not(#\#):not(#\#):not(#\#) {
+  display: inline-block;
+}
+
+.x3nfvp2:not(#\#):not(#\#):not(#\#) {
+  display: inline-flex;
+}
+
+.xt0psk2:not(#\#):not(#\#):not(#\#) {
+  display: inline;
+}
+
+.xdt5ytf:not(#\#):not(#\#):not(#\#) {
+  flex-direction: column;
+}
+
+.x1q0g3np:not(#\#):not(#\#):not(#\#) {
+  flex-direction: row;
+}
+
+.x1c4vz4f:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 0;
+}
+
+.x1iyjqo2:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 1;
+}
+
+.x2lah0s:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 0;
+}
+
+.xozqiw3:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: nowrap;
+}
+
+.x8hhl5t:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap-reverse;
+}
+
+.x1a02dak:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap;
+}
+
+.xjb2p0i:not(#\#):not(#\#):not(#\#) {
+  font-family: inherit;
+}
+
+.x9ynric:not(#\#):not(#\#):not(#\#) {
+  font-family: var(--font-family-body);
+}
+
+.x1j61zf2:not(#\#):not(#\#):not(#\#) {
+  font-size: 16px;
+}
+
+.xwsyq91:not(#\#):not(#\#):not(#\#) {
+  font-size: 20px;
+}
+
+.xjm74w1:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-body-size);
+}
+
+.xcr08ib:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-label-size);
+}
+
+.xss6m8b:not(#\#):not(#\#):not(#\#) {
+  font-variant-numeric: tabular-nums;
+}
+
+.x1lvx875:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-bold);
+}
+
+.x1e4wzip:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-medium);
+}
+
+.x1sodnla:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-normal);
+}
+
+.x2mo6ok:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-semibold);
+}
+
+.xxovm9e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-body-weight);
+}
+
+.xx3eeay:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-code-weight);
+}
+
+.x1txul5o:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-1-weight);
+}
+
+.x1y36c3f:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-2-weight);
+}
+
+.x1on40hk:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-3-weight);
+}
+
+.xmhvcl5:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-label-weight);
+}
+
+.x149oux8:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-large-weight);
+}
+
+.xv8on6e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-supporting-weight);
+}
+
+.xl56j7k:not(#\#):not(#\#):not(#\#) {
+  justify-content: center;
+}
+
+.x13a6bvl:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-end;
+}
+
+.x1nhvcw1:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-start;
+}
+
+.x1l1ennw:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-around;
+}
+
+.x1qughib:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-between;
+}
+
+.xaw8158:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-evenly;
+}
+
+.x1o2pa38:not(#\#):not(#\#):not(#\#) {
+  justify-items: center;
+}
+
+.x4xo5sw:not(#\#):not(#\#):not(#\#) {
+  justify-items: end;
+}
+
+.x619ttb:not(#\#):not(#\#):not(#\#) {
+  justify-items: start;
+}
+
+.xl4xnwh:not(#\#):not(#\#):not(#\#) {
+  justify-items: stretch;
+}
+
+.xw6l6zx:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-body-leading);
+}
+
+.x1kq96og:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-label-leading);
+}
+
+.x14z9mp:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: 0;
+}
+
+.x1kpg4um:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(-1 * var(--layout-padding-inner-x, var(--spacing-4)));
+}
+
+.xofqkxr:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(var(--edge-end, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.xnur1sd:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: var(--spacing-1);
+}
+
+.x1lziwak:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: 0;
+}
+
+.x1wim8z0:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(-1 * var(--layout-padding-inner-x, var(--spacing-4)));
+}
+
+.xg82z56:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(var(--edge-start, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.x11g1kdw:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: var(--spacing-1);
+}
+
+.xbyyjgo:not(#\#):not(#\#):not(#\#) {
+  opacity: .5;
+}
+
+.x1wfwxd8:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 0;
+}
+
+.x1mzt3pk:not(#\#):not(#\#):not(#\#) {
+  overflow-wrap: break-word;
+}
+
+.xyri2b:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: 0;
+}
+
+.x1peupej:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--layout-padding-inner-x, var(--spacing-4));
+}
+
+.xpc6k2p:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--layout-padding-outer-x, var(--spacing-4));
+}
+
+.x1le3yxw:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-0-5);
+}
+
+.x1s0aq8i:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-0);
+}
+
+.x17hk9do:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-1-5);
+}
+
+.x1nryj5t:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-1);
+}
+
+.x160ivqr:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-10);
+}
+
+.x1djylfy:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-2);
+}
+
+.x1t818jl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-3);
+}
+
+.xnjyzlh:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-4);
+}
+
+.xdbrk9v:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-5);
+}
+
+.x1we12cn:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-6);
+}
+
+.x1q91b2g:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-8);
+}
+
+.x1c1uobl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: 0;
+}
+
+.xwjyata:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--layout-padding-inner-x, var(--spacing-4));
+}
+
+.x139j0dd:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--layout-padding-outer-x, var(--spacing-4));
+}
+
+.x138rykx:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-0-5);
+}
+
+.x18gyask:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-0);
+}
+
+.xfti1ec:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-1-5);
+}
+
+.x1vsv5vr:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-1);
+}
+
+.xqp078j:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-10);
+}
+
+.x12gdq22:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-2);
+}
+
+.x126nfab:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-3);
+}
+
+.x1rey3nv:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-4);
+}
+
+.x1blguxw:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-5);
+}
+
+.x31w388:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-6);
+}
+
+.x1j3hnjz:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-8);
+}
+
+.x10l6tqk:not(#\#):not(#\#):not(#\#) {
+  position: absolute;
+}
+
+.xixxii4:not(#\#):not(#\#):not(#\#) {
+  position: fixed;
+}
+
+.x1n2onr6:not(#\#):not(#\#):not(#\#) {
+  position: relative;
+}
+
+.x1tw44j4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0-5);
+}
+
+.x6yxi7o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0);
+}
+
+.xhq53yo:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1-5);
+}
+
+.x1ngg2t4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1);
+}
+
+.x1xpicb7:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-10);
+}
+
+.x1x7z4sm:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-2);
+}
+
+.x4olc9o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-3);
+}
+
+.xtx9w7w:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-4);
+}
+
+.x1iu6piu:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-5);
+}
+
+.xczp1bk:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-6);
+}
+
+.xgx0vcf:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-8);
+}
+
+.x1b2iylo:not(#\#):not(#\#):not(#\#) {
+  text-box-edge: cap alphabetic;
+}
+
+.xwgcxoh:not(#\#):not(#\#):not(#\#) {
+  text-box-trim: trim-both;
+}
+
+.xycaml9:not(#\#):not(#\#):not(#\#) {
+  -webkit-text-decoration-color: var(--color-border-emphasized);
+  text-decoration-color: var(--color-border-emphasized);
+}
+
+.xujl8zx:not(#\#):not(#\#):not(#\#) {
+  text-decoration-line: underline;
+}
+
+.xev0dqp:not(#\#):not(#\#):not(#\#) {
+  text-decoration-style: dashed;
+}
+
+.xlyipyv:not(#\#):not(#\#):not(#\#) {
+  text-overflow: ellipsis;
+}
+
+.xrys4gj:not(#\#):not(#\#):not(#\#) {
+  text-underline-offset: 2px;
+}
+
+.x1w2vvpw:not(#\#):not(#\#):not(#\#) {
+  text-wrap: balance;
+}
+
+.xebhuq6:not(#\#):not(#\#):not(#\#) {
+  text-wrap: nowrap;
+}
+
+.x1fzhlzt:not(#\#):not(#\#):not(#\#) {
+  text-wrap: pretty;
+}
+
+.xk4td0m:not(#\#):not(#\#):not(#\#) {
+  text-wrap: wrap;
+}
+
+.x1c071of:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.x3oybdh:not(#\#):not(#\#):not(#\#) {
+  transform: scale(1);
+}
+
+.xuedmi6:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-fast);
+}
+
+.xqc8rvf:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-image, transform;
+}
+
+.xlr8y92:not(#\#):not(#\#):not(#\#) {
+  transition-timing-function: var(--ease-standard);
+}
+
+.xxymvpz:not(#\#):not(#\#):not(#\#) {
+  vertical-align: middle;
+}
+
+.xuxw1ft:not(#\#):not(#\#):not(#\#) {
+  white-space: nowrap;
+}
+
+.x1yn0g08:not(#\#):not(#\#):not(#\#) {
+  word-break: break-all;
+}
+
+.x13faqbe:not(#\#):not(#\#):not(#\#) {
+  word-break: break-word;
+}
+
+.x1lldw8n:not(#\#):not(#\#):not(#\#) {
+  word-break: normal;
+}
+
+.x13aywxo:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: var(--button-focus-offset);
+}
+
+.xq8i9tn:active:not(#\#):not(#\#):not(#\#) {
+  background-image: linear-gradient(var(--color-overlay-pressed),var(--color-overlay-pressed));
+}
+
+.xuqm82a:active:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1pdlv7q:active:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.xk4oym4:active:not(#\#):not(#\#):not(#\#) {
+  transform: scale(.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .x12w9bfk.x12w9bfk:not(#\#):not(#\#):not(#\#) {
+    transition-duration: 0s;
+  }
+}
+
+@media (hover: hover) {
+  .x1ilzqfv.x1ilzqfv:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: linear-gradient(var(--color-overlay-hover),var(--color-overlay-hover));
+  }
+
+  .x8o3jvd.x8o3jvd:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: none;
+  }
+}
+
+.xw8gpjh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-color: var(--color-border);
+}
+
+.x1q0q8m5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-style: solid;
+}
+
+.xso031l:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-width: 1px;
+}
+
+.x1pc3f07:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-color: var(--color-border);
+}
+
+.x13fuv20:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-style: solid;
+}
+
+.x178xt8z:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-width: 1px;
+}
+
+.x1ey2m1c:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: 0;
+}
+
+.x5yr21d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 100%;
+}
+
+.xlup9mm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 16px;
+}
+
+.xjm9jq1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 1px;
+}
+
+.x1qx5ct2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 20px;
+}
+
+.x1x2thlr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(100% + 2 * var(--container-padding, 0px));
+}
+
+.xssyfek:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-lg);
+}
+
+.x1ueg155:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-md);
+}
+
+.x6k0iem:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-sm);
+}
+
+.x16ye13r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--x-height);
+}
+
+.xu96u03:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 0;
+}
+
+.xat24cr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: 0;
+}
+
+.x14cgwvg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-1);
+}
+
+.xdj266r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: 0;
+}
+
+.xcsaf9d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-1);
+}
+
+.xenllk4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: var(--container-max-height, none);
+}
+
+.xw5ewwj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 300px;
+}
+
+.xf68679:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: var(--x-maxWidth);
+}
+
+.x2lwn1j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 0;
+}
+
+.x1us19tq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 100%;
+}
+
+.x82snj4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--x-minHeight);
+}
+
+.xeuugli:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 0;
+}
+
+.x18d9i69:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.xg476vw:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--layout-padding-inner-y, var(--spacing-4));
+}
+
+.xon7vh3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--layout-padding-outer-y, var(--spacing-4));
+}
+
+.xij103a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-0-5);
+}
+
+.x1l20ajd:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-0);
+}
+
+.x1opdxmq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1-5);
+}
+
+.xy143xn:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1);
+}
+
+.x2izi54:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-10);
+}
+
+.x1wesfrj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-2);
+}
+
+.xvmdzux:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-3);
+}
+
+.x1awphl8:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-4);
+}
+
+.x1hk98q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-5);
+}
+
+.xjpqqx5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-6);
+}
+
+.x2oz4g1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-8);
+}
+
+.xexx8yu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.xqty4a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--layout-padding-inner-y, var(--spacing-4));
+}
+
+.x81pis9:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--layout-padding-outer-y, var(--spacing-4));
+}
+
+.xbx876j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-0-5);
+}
+
+.x1ydh6w3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-0);
+}
+
+.x1kwdpsa:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1-5);
+}
+
+.xfsso4q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.xk6660b:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-10);
+}
+
+.x1xye8es:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-2);
+}
+
+.x1vlblms:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-3);
+}
+
+.x1oa1p4a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-4);
+}
+
+.xx7rijo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-5);
+}
+
+.x1adxfkp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-6);
+}
+
+.xoxd1wu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-8);
+}
+
+.x3m8u43:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: 0;
+}
+
+.x13vifvy:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 0;
+}
+
+.x1kky2od:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 16px;
+}
+
+.x1i1rx1s:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 1px;
+}
+
+.xw4jnvo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 20px;
+}
+
+.x5lhr3w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--x-width);
+}
+
+.x1o6z09h.x1o6z09h:where(.x-default-marker:has( > .xds-layout-footer:not([data-divider])) *):not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.x1c51l3k.x1c51l3k:where(.x-default-marker:has( > .xds-layout-header:not([data-divider])) *):not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.x8achem:first-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1a5yysu:last-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: calc(-1 * var(--container-padding, 0px));
+}
+</style>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/internal/vibe-tests/results/441ddbe0/previews/dd-5/xds.html
+++ b/internal/vibe-tests/results/441ddbe0/previews/dd-5/xds.html
@@ -1,0 +1,2441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>dd-5 — xds</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; }
+    #root { min-height: 100%; }
+  </style>
+  <script type="module" crossorigin>(function(){const t=document.createElement("link").relList;if(t&&t.supports&&t.supports("modulepreload"))return;for(const a of document.querySelectorAll('link[rel="modulepreload"]'))n(a);new MutationObserver(a=>{for(const u of a)if(u.type==="childList")for(const c of u.addedNodes)c.tagName==="LINK"&&c.rel==="modulepreload"&&n(c)}).observe(document,{childList:!0,subtree:!0});function l(a){const u={};return a.integrity&&(u.integrity=a.integrity),a.referrerPolicy&&(u.referrerPolicy=a.referrerPolicy),a.crossOrigin==="use-credentials"?u.credentials="include":a.crossOrigin==="anonymous"?u.credentials="omit":u.credentials="same-origin",u}function n(a){if(a.ep)return;a.ep=!0;const u=l(a);fetch(a.href,u)}})();function A0(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var nr={exports:{}},Bu={};/**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var D0=Symbol.for("react.transitional.element"),w0=Symbol.for("react.fragment");function ar(e,t,l){var n=null;if(l!==void 0&&(n=""+l),t.key!==void 0&&(n=""+t.key),"key"in t){l={};for(var a in t)a!=="key"&&(l[a]=t[a])}else l=t;return t=l.ref,{$$typeof:D0,type:e,key:n,ref:t!==void 0?t:null,props:l}}Bu.Fragment=w0;Bu.jsx=ar;Bu.jsxs=ar;nr.exports=Bu;var v=nr.exports,ur={exports:{}},Xu={},cr={exports:{}},ir={};/**
+ * @license React
+ * scheduler.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */(function(e){function t(w,D){var O=w.length;w.push(D);e:for(;0<O;){var $=O-1>>>1,Y=w[$];if(0<a(Y,D))w[$]=D,w[O]=Y,O=$;else break e}}function l(w){return w.length===0?null:w[0]}function n(w){if(w.length===0)return null;var D=w[0],O=w.pop();if(O!==D){w[0]=O;e:for(var $=0,Y=w.length,Fe=Y>>>1;$<Fe;){var bt=2*($+1)-1,Ht=w[bt],pe=bt+1,rt=w[pe];if(0>a(Ht,O))pe<Y&&0>a(rt,Ht)?(w[$]=rt,w[pe]=O,$=pe):(w[$]=Ht,w[bt]=O,$=bt);else if(pe<Y&&0>a(rt,O))w[$]=rt,w[pe]=O,$=pe;else break e}}return D}function a(w,D){var O=w.sortIndex-D.sortIndex;return O!==0?O:w.id-D.id}if(e.unstable_now=void 0,typeof performance=="object"&&typeof performance.now=="function"){var u=performance;e.unstable_now=function(){return u.now()}}else{var c=Date,i=c.now();e.unstable_now=function(){return c.now()-i}}var f=[],s=[],d=1,g=null,r=3,x=!1,S=!1,p=!1,k=!1,h=typeof setTimeout=="function"?setTimeout:null,o=typeof clearTimeout=="function"?clearTimeout:null,m=typeof setImmediate<"u"?setImmediate:null;function b(w){for(var D=l(s);D!==null;){if(D.callback===null)n(s);else if(D.startTime<=w)n(s),D.sortIndex=D.expirationTime,t(f,D);else break;D=l(s)}}function T(w){if(p=!1,b(w),!S)if(l(f)!==null)S=!0,N||(N=!0,G());else{var D=l(s);D!==null&&We(T,D.startTime-w)}}var N=!1,E=-1,j=5,A=-1;function M(){return k?!0:!(e.unstable_now()-A<j)}function q(){if(k=!1,N){var w=e.unstable_now();A=w;var D=!0;try{e:{S=!1,p&&(p=!1,o(E),E=-1),x=!0;var O=r;try{t:{for(b(w),g=l(f);g!==null&&!(g.expirationTime>w&&M());){var $=g.callback;if(typeof $=="function"){g.callback=null,r=g.priorityLevel;var Y=$(g.expirationTime<=w);if(w=e.unstable_now(),typeof Y=="function"){g.callback=Y,b(w),D=!0;break t}g===l(f)&&n(f),b(w)}else n(f);g=l(f)}if(g!==null)D=!0;else{var Fe=l(s);Fe!==null&&We(T,Fe.startTime-w),D=!1}}break e}finally{g=null,r=O,x=!1}D=void 0}}finally{D?G():N=!1}}}var G;if(typeof m=="function")G=function(){m(q)};else if(typeof MessageChannel<"u"){var Ae=new MessageChannel,Se=Ae.port2;Ae.port1.onmessage=q,G=function(){Se.postMessage(null)}}else G=function(){h(q,0)};function We(w,D){E=h(function(){w(e.unstable_now())},D)}e.unstable_IdlePriority=5,e.unstable_ImmediatePriority=1,e.unstable_LowPriority=4,e.unstable_NormalPriority=3,e.unstable_Profiling=null,e.unstable_UserBlockingPriority=2,e.unstable_cancelCallback=function(w){w.callback=null},e.unstable_forceFrameRate=function(w){0>w||125<w?console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"):j=0<w?Math.floor(1e3/w):5},e.unstable_getCurrentPriorityLevel=function(){return r},e.unstable_next=function(w){switch(r){case 1:case 2:case 3:var D=3;break;default:D=r}var O=r;r=D;try{return w()}finally{r=O}},e.unstable_requestPaint=function(){k=!0},e.unstable_runWithPriority=function(w,D){switch(w){case 1:case 2:case 3:case 4:case 5:break;default:w=3}var O=r;r=w;try{return D()}finally{r=O}},e.unstable_scheduleCallback=function(w,D,O){var $=e.unstable_now();switch(typeof O=="object"&&O!==null?(O=O.delay,O=typeof O=="number"&&0<O?$+O:$):O=$,w){case 1:var Y=-1;break;case 2:Y=250;break;case 5:Y=1073741823;break;case 4:Y=1e4;break;default:Y=5e3}return Y=O+Y,w={id:d++,callback:D,priorityLevel:w,startTime:O,expirationTime:Y,sortIndex:-1},O>$?(w.sortIndex=O,t(s,w),l(f)===null&&w===l(s)&&(p?(o(E),E=-1):p=!0,We(T,O-$))):(w.sortIndex=Y,t(f,w),S||x||(S=!0,N||(N=!0,G()))),w},e.unstable_shouldYield=M,e.unstable_wrapCallback=function(w){var D=r;return function(){var O=r;r=D;try{return w.apply(this,arguments)}finally{r=O}}}})(ir);cr.exports=ir;var N0=cr.exports,fr={exports:{}},_={};/**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var Wi=Symbol.for("react.transitional.element"),O0=Symbol.for("react.portal"),C0=Symbol.for("react.fragment"),$0=Symbol.for("react.strict_mode"),_0=Symbol.for("react.profiler"),R0=Symbol.for("react.consumer"),q0=Symbol.for("react.context"),U0=Symbol.for("react.forward_ref"),H0=Symbol.for("react.suspense"),B0=Symbol.for("react.memo"),sr=Symbol.for("react.lazy"),X0=Symbol.for("react.activity"),is=Symbol.iterator;function L0(e){return e===null||typeof e!="object"?null:(e=is&&e[is]||e["@@iterator"],typeof e=="function"?e:null)}var or={isMounted:function(){return!1},enqueueForceUpdate:function(){},enqueueReplaceState:function(){},enqueueSetState:function(){}},rr=Object.assign,dr={};function Sn(e,t,l){this.props=e,this.context=t,this.refs=dr,this.updater=l||or}Sn.prototype.isReactComponent={};Sn.prototype.setState=function(e,t){if(typeof e!="object"&&typeof e!="function"&&e!=null)throw Error("takes an object of state variables to update or a function which returns an object of state variables.");this.updater.enqueueSetState(this,e,t,"setState")};Sn.prototype.forceUpdate=function(e){this.updater.enqueueForceUpdate(this,e,"forceUpdate")};function mr(){}mr.prototype=Sn.prototype;function Fi(e,t,l){this.props=e,this.context=t,this.refs=dr,this.updater=l||or}var Ii=Fi.prototype=new mr;Ii.constructor=Fi;rr(Ii,Sn.prototype);Ii.isPureReactComponent=!0;var fs=Array.isArray;function Wc(){}var te={H:null,A:null,T:null,S:null},hr=Object.prototype.hasOwnProperty;function Pi(e,t,l){var n=l.ref;return{$$typeof:Wi,type:e,key:t,ref:n!==void 0?n:null,props:l}}function G0(e,t){return Pi(e.type,t,e.props)}function ef(e){return typeof e=="object"&&e!==null&&e.$$typeof===Wi}function Y0(e){var t={"=":"=0",":":"=2"};return"$"+e.replace(/[=:]/g,function(l){return t[l]})}var ss=/\/+/g;function cc(e,t){return typeof e=="object"&&e!==null&&e.key!=null?Y0(""+e.key):t.toString(36)}function Z0(e){switch(e.status){case"fulfilled":return e.value;case"rejected":throw e.reason;default:switch(typeof e.status=="string"?e.then(Wc,Wc):(e.status="pending",e.then(function(t){e.status==="pending"&&(e.status="fulfilled",e.value=t)},function(t){e.status==="pending"&&(e.status="rejected",e.reason=t)})),e.status){case"fulfilled":return e.value;case"rejected":throw e.reason}}throw e}function Hl(e,t,l,n,a){var u=typeof e;(u==="undefined"||u==="boolean")&&(e=null);var c=!1;if(e===null)c=!0;else switch(u){case"bigint":case"string":case"number":c=!0;break;case"object":switch(e.$$typeof){case Wi:case O0:c=!0;break;case sr:return c=e._init,Hl(c(e._payload),t,l,n,a)}}if(c)return a=a(e),c=n===""?"."+cc(e,0):n,fs(a)?(l="",c!=null&&(l=c.replace(ss,"$&/")+"/"),Hl(a,t,l,"",function(s){return s})):a!=null&&(ef(a)&&(a=G0(a,l+(a.key==null||e&&e.key===a.key?"":(""+a.key).replace(ss,"$&/")+"/")+c)),t.push(a)),1;c=0;var i=n===""?".":n+":";if(fs(e))for(var f=0;f<e.length;f++)n=e[f],u=i+cc(n,f),c+=Hl(n,t,l,u,a);else if(f=L0(e),typeof f=="function")for(e=f.call(e),f=0;!(n=e.next()).done;)n=n.value,u=i+cc(n,f++),c+=Hl(n,t,l,u,a);else if(u==="object"){if(typeof e.then=="function")return Hl(Z0(e),t,l,n,a);throw t=String(e),Error("Objects are not valid as a React child (found: "+(t==="[object Object]"?"object with keys {"+Object.keys(e).join(", ")+"}":t)+"). If you meant to render a collection of children, use an array instead.")}return c}function Da(e,t,l){if(e==null)return e;var n=[],a=0;return Hl(e,n,"","",function(u){return t.call(l,u,a++)}),n}function V0(e){if(e._status===-1){var t=e._result;t=t(),t.then(function(l){(e._status===0||e._status===-1)&&(e._status=1,e._result=l)},function(l){(e._status===0||e._status===-1)&&(e._status=2,e._result=l)}),e._status===-1&&(e._status=0,e._result=t)}if(e._status===1)return e._result.default;throw e._result}var os=typeof reportError=="function"?reportError:function(e){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var t=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof e=="object"&&e!==null&&typeof e.message=="string"?String(e.message):String(e),error:e});if(!window.dispatchEvent(t))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",e);return}console.error(e)},Q0={map:Da,forEach:function(e,t,l){Da(e,function(){t.apply(this,arguments)},l)},count:function(e){var t=0;return Da(e,function(){t++}),t},toArray:function(e){return Da(e,function(t){return t})||[]},only:function(e){if(!ef(e))throw Error("React.Children.only expected to receive a single React element child.");return e}};_.Activity=X0;_.Children=Q0;_.Component=Sn;_.Fragment=C0;_.Profiler=_0;_.PureComponent=Fi;_.StrictMode=$0;_.Suspense=H0;_.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=te;_.__COMPILER_RUNTIME={__proto__:null,c:function(e){return te.H.useMemoCache(e)}};_.cache=function(e){return function(){return e.apply(null,arguments)}};_.cacheSignal=function(){return null};_.cloneElement=function(e,t,l){if(e==null)throw Error("The argument must be a React element, but you passed "+e+".");var n=rr({},e.props),a=e.key;if(t!=null)for(u in t.key!==void 0&&(a=""+t.key),t)!hr.call(t,u)||u==="key"||u==="__self"||u==="__source"||u==="ref"&&t.ref===void 0||(n[u]=t[u]);var u=arguments.length-2;if(u===1)n.children=l;else if(1<u){for(var c=Array(u),i=0;i<u;i++)c[i]=arguments[i+2];n.children=c}return Pi(e.type,a,n)};_.createContext=function(e){return e={$$typeof:q0,_currentValue:e,_currentValue2:e,_threadCount:0,Provider:null,Consumer:null},e.Provider=e,e.Consumer={$$typeof:R0,_context:e},e};_.createElement=function(e,t,l){var n,a={},u=null;if(t!=null)for(n in t.key!==void 0&&(u=""+t.key),t)hr.call(t,n)&&n!=="key"&&n!=="__self"&&n!=="__source"&&(a[n]=t[n]);var c=arguments.length-2;if(c===1)a.children=l;else if(1<c){for(var i=Array(c),f=0;f<c;f++)i[f]=arguments[f+2];a.children=i}if(e&&e.defaultProps)for(n in c=e.defaultProps,c)a[n]===void 0&&(a[n]=c[n]);return Pi(e,u,a)};_.createRef=function(){return{current:null}};_.forwardRef=function(e){return{$$typeof:U0,render:e}};_.isValidElement=ef;_.lazy=function(e){return{$$typeof:sr,_payload:{_status:-1,_result:e},_init:V0}};_.memo=function(e,t){return{$$typeof:B0,type:e,compare:t===void 0?null:t}};_.startTransition=function(e){var t=te.T,l={};te.T=l;try{var n=e(),a=te.S;a!==null&&a(l,n),typeof n=="object"&&n!==null&&typeof n.then=="function"&&n.then(Wc,os)}catch(u){os(u)}finally{t!==null&&l.types!==null&&(t.types=l.types),te.T=t}};_.unstable_useCacheRefresh=function(){return te.H.useCacheRefresh()};_.use=function(e){return te.H.use(e)};_.useActionState=function(e,t,l){return te.H.useActionState(e,t,l)};_.useCallback=function(e,t){return te.H.useCallback(e,t)};_.useContext=function(e){return te.H.useContext(e)};_.useDebugValue=function(){};_.useDeferredValue=function(e,t){return te.H.useDeferredValue(e,t)};_.useEffect=function(e,t){return te.H.useEffect(e,t)};_.useEffectEvent=function(e){return te.H.useEffectEvent(e)};_.useId=function(){return te.H.useId()};_.useImperativeHandle=function(e,t,l){return te.H.useImperativeHandle(e,t,l)};_.useInsertionEffect=function(e,t){return te.H.useInsertionEffect(e,t)};_.useLayoutEffect=function(e,t){return te.H.useLayoutEffect(e,t)};_.useMemo=function(e,t){return te.H.useMemo(e,t)};_.useOptimistic=function(e,t){return te.H.useOptimistic(e,t)};_.useReducer=function(e,t,l){return te.H.useReducer(e,t,l)};_.useRef=function(e){return te.H.useRef(e)};_.useState=function(e){return te.H.useState(e)};_.useSyncExternalStore=function(e,t,l){return te.H.useSyncExternalStore(e,t,l)};_.useTransition=function(){return te.H.useTransition()};_.version="19.2.4";fr.exports=_;var y=fr.exports;const Fc=A0(y);var yr={exports:{}},Ne={};/**
+ * @license React
+ * react-dom.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var K0=y;function vr(e){var t="https://react.dev/errors/"+e;if(1<arguments.length){t+="?args[]="+encodeURIComponent(arguments[1]);for(var l=2;l<arguments.length;l++)t+="&args[]="+encodeURIComponent(arguments[l])}return"Minified React error #"+e+"; visit "+t+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function Bt(){}var we={d:{f:Bt,r:function(){throw Error(vr(522))},D:Bt,C:Bt,L:Bt,m:Bt,X:Bt,S:Bt,M:Bt},p:0,findDOMNode:null},J0=Symbol.for("react.portal");function W0(e,t,l){var n=3<arguments.length&&arguments[3]!==void 0?arguments[3]:null;return{$$typeof:J0,key:n==null?null:""+n,children:e,containerInfo:t,implementation:l}}var Xn=K0.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;function Lu(e,t){if(e==="font")return"";if(typeof t=="string")return t==="use-credentials"?t:""}Ne.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=we;Ne.createPortal=function(e,t){var l=2<arguments.length&&arguments[2]!==void 0?arguments[2]:null;if(!t||t.nodeType!==1&&t.nodeType!==9&&t.nodeType!==11)throw Error(vr(299));return W0(e,t,null,l)};Ne.flushSync=function(e){var t=Xn.T,l=we.p;try{if(Xn.T=null,we.p=2,e)return e()}finally{Xn.T=t,we.p=l,we.d.f()}};Ne.preconnect=function(e,t){typeof e=="string"&&(t?(t=t.crossOrigin,t=typeof t=="string"?t==="use-credentials"?t:"":void 0):t=null,we.d.C(e,t))};Ne.prefetchDNS=function(e){typeof e=="string"&&we.d.D(e)};Ne.preinit=function(e,t){if(typeof e=="string"&&t&&typeof t.as=="string"){var l=t.as,n=Lu(l,t.crossOrigin),a=typeof t.integrity=="string"?t.integrity:void 0,u=typeof t.fetchPriority=="string"?t.fetchPriority:void 0;l==="style"?we.d.S(e,typeof t.precedence=="string"?t.precedence:void 0,{crossOrigin:n,integrity:a,fetchPriority:u}):l==="script"&&we.d.X(e,{crossOrigin:n,integrity:a,fetchPriority:u,nonce:typeof t.nonce=="string"?t.nonce:void 0})}};Ne.preinitModule=function(e,t){if(typeof e=="string")if(typeof t=="object"&&t!==null){if(t.as==null||t.as==="script"){var l=Lu(t.as,t.crossOrigin);we.d.M(e,{crossOrigin:l,integrity:typeof t.integrity=="string"?t.integrity:void 0,nonce:typeof t.nonce=="string"?t.nonce:void 0})}}else t==null&&we.d.M(e)};Ne.preload=function(e,t){if(typeof e=="string"&&typeof t=="object"&&t!==null&&typeof t.as=="string"){var l=t.as,n=Lu(l,t.crossOrigin);we.d.L(e,l,{crossOrigin:n,integrity:typeof t.integrity=="string"?t.integrity:void 0,nonce:typeof t.nonce=="string"?t.nonce:void 0,type:typeof t.type=="string"?t.type:void 0,fetchPriority:typeof t.fetchPriority=="string"?t.fetchPriority:void 0,referrerPolicy:typeof t.referrerPolicy=="string"?t.referrerPolicy:void 0,imageSrcSet:typeof t.imageSrcSet=="string"?t.imageSrcSet:void 0,imageSizes:typeof t.imageSizes=="string"?t.imageSizes:void 0,media:typeof t.media=="string"?t.media:void 0})}};Ne.preloadModule=function(e,t){if(typeof e=="string")if(t){var l=Lu(t.as,t.crossOrigin);we.d.m(e,{as:typeof t.as=="string"&&t.as!=="script"?t.as:void 0,crossOrigin:l,integrity:typeof t.integrity=="string"?t.integrity:void 0})}else we.d.m(e)};Ne.requestFormReset=function(e){we.d.r(e)};Ne.unstable_batchedUpdates=function(e,t){return e(t)};Ne.useFormState=function(e,t,l){return Xn.H.useFormState(e,t,l)};Ne.useFormStatus=function(){return Xn.H.useHostTransitionStatus()};Ne.version="19.2.4";function xr(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(xr)}catch(e){console.error(e)}}xr(),yr.exports=Ne;var F0=yr.exports;/**
+ * @license React
+ * react-dom-client.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var ve=N0,gr=y,I0=F0;function z(e){var t="https://react.dev/errors/"+e;if(1<arguments.length){t+="?args[]="+encodeURIComponent(arguments[1]);for(var l=2;l<arguments.length;l++)t+="&args[]="+encodeURIComponent(arguments[l])}return"Minified React error #"+e+"; visit "+t+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function br(e){return!(!e||e.nodeType!==1&&e.nodeType!==9&&e.nodeType!==11)}function xa(e){var t=e,l=e;if(e.alternate)for(;t.return;)t=t.return;else{e=t;do t=e,t.flags&4098&&(l=t.return),e=t.return;while(e)}return t.tag===3?l:null}function Sr(e){if(e.tag===13){var t=e.memoizedState;if(t===null&&(e=e.alternate,e!==null&&(t=e.memoizedState)),t!==null)return t.dehydrated}return null}function pr(e){if(e.tag===31){var t=e.memoizedState;if(t===null&&(e=e.alternate,e!==null&&(t=e.memoizedState)),t!==null)return t.dehydrated}return null}function rs(e){if(xa(e)!==e)throw Error(z(188))}function P0(e){var t=e.alternate;if(!t){if(t=xa(e),t===null)throw Error(z(188));return t!==e?null:e}for(var l=e,n=t;;){var a=l.return;if(a===null)break;var u=a.alternate;if(u===null){if(n=a.return,n!==null){l=n;continue}break}if(a.child===u.child){for(u=a.child;u;){if(u===l)return rs(a),e;if(u===n)return rs(a),t;u=u.sibling}throw Error(z(188))}if(l.return!==n.return)l=a,n=u;else{for(var c=!1,i=a.child;i;){if(i===l){c=!0,l=a,n=u;break}if(i===n){c=!0,n=a,l=u;break}i=i.sibling}if(!c){for(i=u.child;i;){if(i===l){c=!0,l=u,n=a;break}if(i===n){c=!0,n=u,l=a;break}i=i.sibling}if(!c)throw Error(z(189))}}if(l.alternate!==n)throw Error(z(190))}if(l.tag!==3)throw Error(z(188));return l.stateNode.current===l?e:t}function kr(e){var t=e.tag;if(t===5||t===26||t===27||t===6)return e;for(e=e.child;e!==null;){if(t=kr(e),t!==null)return t;e=e.sibling}return null}var le=Object.assign,em=Symbol.for("react.element"),wa=Symbol.for("react.transitional.element"),Rn=Symbol.for("react.portal"),Ll=Symbol.for("react.fragment"),zr=Symbol.for("react.strict_mode"),Ic=Symbol.for("react.profiler"),Er=Symbol.for("react.consumer"),Mt=Symbol.for("react.context"),tf=Symbol.for("react.forward_ref"),Pc=Symbol.for("react.suspense"),ei=Symbol.for("react.suspense_list"),lf=Symbol.for("react.memo"),Xt=Symbol.for("react.lazy"),ti=Symbol.for("react.activity"),tm=Symbol.for("react.memo_cache_sentinel"),ds=Symbol.iterator;function An(e){return e===null||typeof e!="object"?null:(e=ds&&e[ds]||e["@@iterator"],typeof e=="function"?e:null)}var lm=Symbol.for("react.client.reference");function li(e){if(e==null)return null;if(typeof e=="function")return e.$$typeof===lm?null:e.displayName||e.name||null;if(typeof e=="string")return e;switch(e){case Ll:return"Fragment";case Ic:return"Profiler";case zr:return"StrictMode";case Pc:return"Suspense";case ei:return"SuspenseList";case ti:return"Activity"}if(typeof e=="object")switch(e.$$typeof){case Rn:return"Portal";case Mt:return e.displayName||"Context";case Er:return(e._context.displayName||"Context")+".Consumer";case tf:var t=e.render;return e=e.displayName,e||(e=t.displayName||t.name||"",e=e!==""?"ForwardRef("+e+")":"ForwardRef"),e;case lf:return t=e.displayName||null,t!==null?t:li(e.type)||"Memo";case Xt:t=e._payload,e=e._init;try{return li(e(t))}catch{}}return null}var qn=Array.isArray,C=gr.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,V=I0.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,bl={pending:!1,data:null,method:null,action:null},ni=[],Gl=-1;function xt(e){return{current:e}}function be(e){0>Gl||(e.current=ni[Gl],ni[Gl]=null,Gl--)}function I(e,t){Gl++,ni[Gl]=e.current,e.current=t}var vt=xt(null),ta=xt(null),It=xt(null),ru=xt(null);function du(e,t){switch(I(It,t),I(ta,e),I(vt,null),t.nodeType){case 9:case 11:e=(e=t.documentElement)&&(e=e.namespaceURI)?bo(e):0;break;default:if(e=t.tagName,t=t.namespaceURI)t=bo(t),e=Y1(t,e);else switch(e){case"svg":e=1;break;case"math":e=2;break;default:e=0}}be(vt),I(vt,e)}function sn(){be(vt),be(ta),be(It)}function ai(e){e.memoizedState!==null&&I(ru,e);var t=vt.current,l=Y1(t,e.type);t!==l&&(I(ta,e),I(vt,l))}function mu(e){ta.current===e&&(be(vt),be(ta)),ru.current===e&&(be(ru),da._currentValue=bl)}var ic,ms;function yl(e){if(ic===void 0)try{throw Error()}catch(l){var t=l.stack.trim().match(/\n( *(at )?)/);ic=t&&t[1]||"",ms=-1<l.stack.indexOf(`
+    at`)?" (<anonymous>)":-1<l.stack.indexOf("@")?"@unknown:0:0":""}return`
+`+ic+e+ms}var fc=!1;function sc(e,t){if(!e||fc)return"";fc=!0;var l=Error.prepareStackTrace;Error.prepareStackTrace=void 0;try{var n={DetermineComponentFrameRoot:function(){try{if(t){var g=function(){throw Error()};if(Object.defineProperty(g.prototype,"props",{set:function(){throw Error()}}),typeof Reflect=="object"&&Reflect.construct){try{Reflect.construct(g,[])}catch(x){var r=x}Reflect.construct(e,[],g)}else{try{g.call()}catch(x){r=x}e.call(g.prototype)}}else{try{throw Error()}catch(x){r=x}(g=e())&&typeof g.catch=="function"&&g.catch(function(){})}}catch(x){if(x&&r&&typeof x.stack=="string")return[x.stack,r.stack]}return[null,null]}};n.DetermineComponentFrameRoot.displayName="DetermineComponentFrameRoot";var a=Object.getOwnPropertyDescriptor(n.DetermineComponentFrameRoot,"name");a&&a.configurable&&Object.defineProperty(n.DetermineComponentFrameRoot,"name",{value:"DetermineComponentFrameRoot"});var u=n.DetermineComponentFrameRoot(),c=u[0],i=u[1];if(c&&i){var f=c.split(`
+`),s=i.split(`
+`);for(a=n=0;n<f.length&&!f[n].includes("DetermineComponentFrameRoot");)n++;for(;a<s.length&&!s[a].includes("DetermineComponentFrameRoot");)a++;if(n===f.length||a===s.length)for(n=f.length-1,a=s.length-1;1<=n&&0<=a&&f[n]!==s[a];)a--;for(;1<=n&&0<=a;n--,a--)if(f[n]!==s[a]){if(n!==1||a!==1)do if(n--,a--,0>a||f[n]!==s[a]){var d=`
+`+f[n].replace(" at new "," at ");return e.displayName&&d.includes("<anonymous>")&&(d=d.replace("<anonymous>",e.displayName)),d}while(1<=n&&0<=a);break}}}finally{fc=!1,Error.prepareStackTrace=l}return(l=e?e.displayName||e.name:"")?yl(l):""}function nm(e,t){switch(e.tag){case 26:case 27:case 5:return yl(e.type);case 16:return yl("Lazy");case 13:return e.child!==t&&t!==null?yl("Suspense Fallback"):yl("Suspense");case 19:return yl("SuspenseList");case 0:case 15:return sc(e.type,!1);case 11:return sc(e.type.render,!1);case 1:return sc(e.type,!0);case 31:return yl("Activity");default:return""}}function hs(e){try{var t="",l=null;do t+=nm(e,l),l=e,e=e.return;while(e);return t}catch(n){return`
+Error generating stack: `+n.message+`
+`+n.stack}}var ui=Object.prototype.hasOwnProperty,nf=ve.unstable_scheduleCallback,oc=ve.unstable_cancelCallback,am=ve.unstable_shouldYield,um=ve.unstable_requestPaint,Ye=ve.unstable_now,cm=ve.unstable_getCurrentPriorityLevel,Tr=ve.unstable_ImmediatePriority,jr=ve.unstable_UserBlockingPriority,hu=ve.unstable_NormalPriority,im=ve.unstable_LowPriority,Mr=ve.unstable_IdlePriority,fm=ve.log,sm=ve.unstable_setDisableYieldValue,ga=null,Ze=null;function Qt(e){if(typeof fm=="function"&&sm(e),Ze&&typeof Ze.setStrictMode=="function")try{Ze.setStrictMode(ga,e)}catch{}}var Ve=Math.clz32?Math.clz32:dm,om=Math.log,rm=Math.LN2;function dm(e){return e>>>=0,e===0?32:31-(om(e)/rm|0)|0}var Na=256,Oa=262144,Ca=4194304;function vl(e){var t=e&42;if(t!==0)return t;switch(e&-e){case 1:return 1;case 2:return 2;case 4:return 4;case 8:return 8;case 16:return 16;case 32:return 32;case 64:return 64;case 128:return 128;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:return e&261888;case 262144:case 524288:case 1048576:case 2097152:return e&3932160;case 4194304:case 8388608:case 16777216:case 33554432:return e&62914560;case 67108864:return 67108864;case 134217728:return 134217728;case 268435456:return 268435456;case 536870912:return 536870912;case 1073741824:return 0;default:return e}}function Gu(e,t,l){var n=e.pendingLanes;if(n===0)return 0;var a=0,u=e.suspendedLanes,c=e.pingedLanes;e=e.warmLanes;var i=n&134217727;return i!==0?(n=i&~u,n!==0?a=vl(n):(c&=i,c!==0?a=vl(c):l||(l=i&~e,l!==0&&(a=vl(l))))):(i=n&~u,i!==0?a=vl(i):c!==0?a=vl(c):l||(l=n&~e,l!==0&&(a=vl(l)))),a===0?0:t!==0&&t!==a&&!(t&u)&&(u=a&-a,l=t&-t,u>=l||u===32&&(l&4194048)!==0)?t:a}function ba(e,t){return(e.pendingLanes&~(e.suspendedLanes&~e.pingedLanes)&t)===0}function mm(e,t){switch(e){case 1:case 2:case 4:case 8:case 64:return t+250;case 16:case 32:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:return t+5e3;case 4194304:case 8388608:case 16777216:case 33554432:return-1;case 67108864:case 134217728:case 268435456:case 536870912:case 1073741824:return-1;default:return-1}}function Ar(){var e=Ca;return Ca<<=1,!(Ca&62914560)&&(Ca=4194304),e}function rc(e){for(var t=[],l=0;31>l;l++)t.push(e);return t}function Sa(e,t){e.pendingLanes|=t,t!==268435456&&(e.suspendedLanes=0,e.pingedLanes=0,e.warmLanes=0)}function hm(e,t,l,n,a,u){var c=e.pendingLanes;e.pendingLanes=l,e.suspendedLanes=0,e.pingedLanes=0,e.warmLanes=0,e.expiredLanes&=l,e.entangledLanes&=l,e.errorRecoveryDisabledLanes&=l,e.shellSuspendCounter=0;var i=e.entanglements,f=e.expirationTimes,s=e.hiddenUpdates;for(l=c&~l;0<l;){var d=31-Ve(l),g=1<<d;i[d]=0,f[d]=-1;var r=s[d];if(r!==null)for(s[d]=null,d=0;d<r.length;d++){var x=r[d];x!==null&&(x.lane&=-536870913)}l&=~g}n!==0&&Dr(e,n,0),u!==0&&a===0&&e.tag!==0&&(e.suspendedLanes|=u&~(c&~t))}function Dr(e,t,l){e.pendingLanes|=t,e.suspendedLanes&=~t;var n=31-Ve(t);e.entangledLanes|=t,e.entanglements[n]=e.entanglements[n]|1073741824|l&261930}function wr(e,t){var l=e.entangledLanes|=t;for(e=e.entanglements;l;){var n=31-Ve(l),a=1<<n;a&t|e[n]&t&&(e[n]|=t),l&=~a}}function Nr(e,t){var l=t&-t;return l=l&42?1:af(l),l&(e.suspendedLanes|t)?0:l}function af(e){switch(e){case 2:e=1;break;case 8:e=4;break;case 32:e=16;break;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:case 4194304:case 8388608:case 16777216:case 33554432:e=128;break;case 268435456:e=134217728;break;default:e=0}return e}function uf(e){return e&=-e,2<e?8<e?e&134217727?32:268435456:8:2}function Or(){var e=V.p;return e!==0?e:(e=window.event,e===void 0?32:t0(e.type))}function ys(e,t){var l=V.p;try{return V.p=e,t()}finally{V.p=l}}var rl=Math.random().toString(36).slice(2),Ee="__reactFiber$"+rl,qe="__reactProps$"+rl,pn="__reactContainer$"+rl,ci="__reactEvents$"+rl,ym="__reactListeners$"+rl,vm="__reactHandles$"+rl,vs="__reactResources$"+rl,pa="__reactMarker$"+rl;function cf(e){delete e[Ee],delete e[qe],delete e[ci],delete e[ym],delete e[vm]}function Yl(e){var t=e[Ee];if(t)return t;for(var l=e.parentNode;l;){if(t=l[pn]||l[Ee]){if(l=t.alternate,t.child!==null||l!==null&&l.child!==null)for(e=Eo(e);e!==null;){if(l=e[Ee])return l;e=Eo(e)}return t}e=l,l=e.parentNode}return null}function kn(e){if(e=e[Ee]||e[pn]){var t=e.tag;if(t===5||t===6||t===13||t===31||t===26||t===27||t===3)return e}return null}function Un(e){var t=e.tag;if(t===5||t===26||t===27||t===6)return e.stateNode;throw Error(z(33))}function tn(e){var t=e[vs];return t||(t=e[vs]={hoistableStyles:new Map,hoistableScripts:new Map}),t}function ge(e){e[pa]=!0}var Cr=new Set,$r={};function Dl(e,t){on(e,t),on(e+"Capture",t)}function on(e,t){for($r[e]=t,e=0;e<t.length;e++)Cr.add(t[e])}var xm=RegExp("^[:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD][:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$"),xs={},gs={};function gm(e){return ui.call(gs,e)?!0:ui.call(xs,e)?!1:xm.test(e)?gs[e]=!0:(xs[e]=!0,!1)}function Ja(e,t,l){if(gm(t))if(l===null)e.removeAttribute(t);else{switch(typeof l){case"undefined":case"function":case"symbol":e.removeAttribute(t);return;case"boolean":var n=t.toLowerCase().slice(0,5);if(n!=="data-"&&n!=="aria-"){e.removeAttribute(t);return}}e.setAttribute(t,""+l)}}function $a(e,t,l){if(l===null)e.removeAttribute(t);else{switch(typeof l){case"undefined":case"function":case"symbol":case"boolean":e.removeAttribute(t);return}e.setAttribute(t,""+l)}}function St(e,t,l,n){if(n===null)e.removeAttribute(l);else{switch(typeof n){case"undefined":case"function":case"symbol":case"boolean":e.removeAttribute(l);return}e.setAttributeNS(t,l,""+n)}}function Pe(e){switch(typeof e){case"bigint":case"boolean":case"number":case"string":case"undefined":return e;case"object":return e;default:return""}}function _r(e){var t=e.type;return(e=e.nodeName)&&e.toLowerCase()==="input"&&(t==="checkbox"||t==="radio")}function bm(e,t,l){var n=Object.getOwnPropertyDescriptor(e.constructor.prototype,t);if(!e.hasOwnProperty(t)&&typeof n<"u"&&typeof n.get=="function"&&typeof n.set=="function"){var a=n.get,u=n.set;return Object.defineProperty(e,t,{configurable:!0,get:function(){return a.call(this)},set:function(c){l=""+c,u.call(this,c)}}),Object.defineProperty(e,t,{enumerable:n.enumerable}),{getValue:function(){return l},setValue:function(c){l=""+c},stopTracking:function(){e._valueTracker=null,delete e[t]}}}}function ii(e){if(!e._valueTracker){var t=_r(e)?"checked":"value";e._valueTracker=bm(e,t,""+e[t])}}function Rr(e){if(!e)return!1;var t=e._valueTracker;if(!t)return!0;var l=t.getValue(),n="";return e&&(n=_r(e)?e.checked?"true":"false":e.value),e=n,e!==l?(t.setValue(e),!0):!1}function yu(e){if(e=e||(typeof document<"u"?document:void 0),typeof e>"u")return null;try{return e.activeElement||e.body}catch{return e.body}}var Sm=/[\n"\\]/g;function lt(e){return e.replace(Sm,function(t){return"\\"+t.charCodeAt(0).toString(16)+" "})}function fi(e,t,l,n,a,u,c,i){e.name="",c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"?e.type=c:e.removeAttribute("type"),t!=null?c==="number"?(t===0&&e.value===""||e.value!=t)&&(e.value=""+Pe(t)):e.value!==""+Pe(t)&&(e.value=""+Pe(t)):c!=="submit"&&c!=="reset"||e.removeAttribute("value"),t!=null?si(e,c,Pe(t)):l!=null?si(e,c,Pe(l)):n!=null&&e.removeAttribute("value"),a==null&&u!=null&&(e.defaultChecked=!!u),a!=null&&(e.checked=a&&typeof a!="function"&&typeof a!="symbol"),i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"?e.name=""+Pe(i):e.removeAttribute("name")}function qr(e,t,l,n,a,u,c,i){if(u!=null&&typeof u!="function"&&typeof u!="symbol"&&typeof u!="boolean"&&(e.type=u),t!=null||l!=null){if(!(u!=="submit"&&u!=="reset"||t!=null)){ii(e);return}l=l!=null?""+Pe(l):"",t=t!=null?""+Pe(t):l,i||t===e.value||(e.value=t),e.defaultValue=t}n=n??a,n=typeof n!="function"&&typeof n!="symbol"&&!!n,e.checked=i?e.checked:!!n,e.defaultChecked=!!n,c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"&&(e.name=c),ii(e)}function si(e,t,l){t==="number"&&yu(e.ownerDocument)===e||e.defaultValue===""+l||(e.defaultValue=""+l)}function ln(e,t,l,n){if(e=e.options,t){t={};for(var a=0;a<l.length;a++)t["$"+l[a]]=!0;for(l=0;l<e.length;l++)a=t.hasOwnProperty("$"+e[l].value),e[l].selected!==a&&(e[l].selected=a),a&&n&&(e[l].defaultSelected=!0)}else{for(l=""+Pe(l),t=null,a=0;a<e.length;a++){if(e[a].value===l){e[a].selected=!0,n&&(e[a].defaultSelected=!0);return}t!==null||e[a].disabled||(t=e[a])}t!==null&&(t.selected=!0)}}function Ur(e,t,l){if(t!=null&&(t=""+Pe(t),t!==e.value&&(e.value=t),l==null)){e.defaultValue!==t&&(e.defaultValue=t);return}e.defaultValue=l!=null?""+Pe(l):""}function Hr(e,t,l,n){if(t==null){if(n!=null){if(l!=null)throw Error(z(92));if(qn(n)){if(1<n.length)throw Error(z(93));n=n[0]}l=n}l==null&&(l=""),t=l}l=Pe(t),e.defaultValue=l,n=e.textContent,n===l&&n!==""&&n!==null&&(e.value=n),ii(e)}function rn(e,t){if(t){var l=e.firstChild;if(l&&l===e.lastChild&&l.nodeType===3){l.nodeValue=t;return}}e.textContent=t}var pm=new Set("animationIterationCount aspectRatio borderImageOutset borderImageSlice borderImageWidth boxFlex boxFlexGroup boxOrdinalGroup columnCount columns flex flexGrow flexPositive flexShrink flexNegative flexOrder gridArea gridRow gridRowEnd gridRowSpan gridRowStart gridColumn gridColumnEnd gridColumnSpan gridColumnStart fontWeight lineClamp lineHeight opacity order orphans scale tabSize widows zIndex zoom fillOpacity floodOpacity stopOpacity strokeDasharray strokeDashoffset strokeMiterlimit strokeOpacity strokeWidth MozAnimationIterationCount MozBoxFlex MozBoxFlexGroup MozLineClamp msAnimationIterationCount msFlex msZoom msFlexGrow msFlexNegative msFlexOrder msFlexPositive msFlexShrink msGridColumn msGridColumnSpan msGridRow msGridRowSpan WebkitAnimationIterationCount WebkitBoxFlex WebKitBoxFlexGroup WebkitBoxOrdinalGroup WebkitColumnCount WebkitColumns WebkitFlex WebkitFlexGrow WebkitFlexPositive WebkitFlexShrink WebkitLineClamp".split(" "));function bs(e,t,l){var n=t.indexOf("--")===0;l==null||typeof l=="boolean"||l===""?n?e.setProperty(t,""):t==="float"?e.cssFloat="":e[t]="":n?e.setProperty(t,l):typeof l!="number"||l===0||pm.has(t)?t==="float"?e.cssFloat=l:e[t]=(""+l).trim():e[t]=l+"px"}function Br(e,t,l){if(t!=null&&typeof t!="object")throw Error(z(62));if(e=e.style,l!=null){for(var n in l)!l.hasOwnProperty(n)||t!=null&&t.hasOwnProperty(n)||(n.indexOf("--")===0?e.setProperty(n,""):n==="float"?e.cssFloat="":e[n]="");for(var a in t)n=t[a],t.hasOwnProperty(a)&&l[a]!==n&&bs(e,a,n)}else for(var u in t)t.hasOwnProperty(u)&&bs(e,u,t[u])}function ff(e){if(e.indexOf("-")===-1)return!1;switch(e){case"annotation-xml":case"color-profile":case"font-face":case"font-face-src":case"font-face-uri":case"font-face-format":case"font-face-name":case"missing-glyph":return!1;default:return!0}}var km=new Map([["acceptCharset","accept-charset"],["htmlFor","for"],["httpEquiv","http-equiv"],["crossOrigin","crossorigin"],["accentHeight","accent-height"],["alignmentBaseline","alignment-baseline"],["arabicForm","arabic-form"],["baselineShift","baseline-shift"],["capHeight","cap-height"],["clipPath","clip-path"],["clipRule","clip-rule"],["colorInterpolation","color-interpolation"],["colorInterpolationFilters","color-interpolation-filters"],["colorProfile","color-profile"],["colorRendering","color-rendering"],["dominantBaseline","dominant-baseline"],["enableBackground","enable-background"],["fillOpacity","fill-opacity"],["fillRule","fill-rule"],["floodColor","flood-color"],["floodOpacity","flood-opacity"],["fontFamily","font-family"],["fontSize","font-size"],["fontSizeAdjust","font-size-adjust"],["fontStretch","font-stretch"],["fontStyle","font-style"],["fontVariant","font-variant"],["fontWeight","font-weight"],["glyphName","glyph-name"],["glyphOrientationHorizontal","glyph-orientation-horizontal"],["glyphOrientationVertical","glyph-orientation-vertical"],["horizAdvX","horiz-adv-x"],["horizOriginX","horiz-origin-x"],["imageRendering","image-rendering"],["letterSpacing","letter-spacing"],["lightingColor","lighting-color"],["markerEnd","marker-end"],["markerMid","marker-mid"],["markerStart","marker-start"],["overlinePosition","overline-position"],["overlineThickness","overline-thickness"],["paintOrder","paint-order"],["panose-1","panose-1"],["pointerEvents","pointer-events"],["renderingIntent","rendering-intent"],["shapeRendering","shape-rendering"],["stopColor","stop-color"],["stopOpacity","stop-opacity"],["strikethroughPosition","strikethrough-position"],["strikethroughThickness","strikethrough-thickness"],["strokeDasharray","stroke-dasharray"],["strokeDashoffset","stroke-dashoffset"],["strokeLinecap","stroke-linecap"],["strokeLinejoin","stroke-linejoin"],["strokeMiterlimit","stroke-miterlimit"],["strokeOpacity","stroke-opacity"],["strokeWidth","stroke-width"],["textAnchor","text-anchor"],["textDecoration","text-decoration"],["textRendering","text-rendering"],["transformOrigin","transform-origin"],["underlinePosition","underline-position"],["underlineThickness","underline-thickness"],["unicodeBidi","unicode-bidi"],["unicodeRange","unicode-range"],["unitsPerEm","units-per-em"],["vAlphabetic","v-alphabetic"],["vHanging","v-hanging"],["vIdeographic","v-ideographic"],["vMathematical","v-mathematical"],["vectorEffect","vector-effect"],["vertAdvY","vert-adv-y"],["vertOriginX","vert-origin-x"],["vertOriginY","vert-origin-y"],["wordSpacing","word-spacing"],["writingMode","writing-mode"],["xmlnsXlink","xmlns:xlink"],["xHeight","x-height"]]),zm=/^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i;function Wa(e){return zm.test(""+e)?"javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')":e}function At(){}var oi=null;function sf(e){return e=e.target||e.srcElement||window,e.correspondingUseElement&&(e=e.correspondingUseElement),e.nodeType===3?e.parentNode:e}var Zl=null,nn=null;function Ss(e){var t=kn(e);if(t&&(e=t.stateNode)){var l=e[qe]||null;e:switch(e=t.stateNode,t.type){case"input":if(fi(e,l.value,l.defaultValue,l.defaultValue,l.checked,l.defaultChecked,l.type,l.name),t=l.name,l.type==="radio"&&t!=null){for(l=e;l.parentNode;)l=l.parentNode;for(l=l.querySelectorAll('input[name="'+lt(""+t)+'"][type="radio"]'),t=0;t<l.length;t++){var n=l[t];if(n!==e&&n.form===e.form){var a=n[qe]||null;if(!a)throw Error(z(90));fi(n,a.value,a.defaultValue,a.defaultValue,a.checked,a.defaultChecked,a.type,a.name)}}for(t=0;t<l.length;t++)n=l[t],n.form===e.form&&Rr(n)}break e;case"textarea":Ur(e,l.value,l.defaultValue);break e;case"select":t=l.value,t!=null&&ln(e,!!l.multiple,t,!1)}}}var dc=!1;function Xr(e,t,l){if(dc)return e(t,l);dc=!0;try{var n=e(t);return n}finally{if(dc=!1,(Zl!==null||nn!==null)&&(tc(),Zl&&(t=Zl,e=nn,nn=Zl=null,Ss(t),e)))for(t=0;t<e.length;t++)Ss(e[t])}}function la(e,t){var l=e.stateNode;if(l===null)return null;var n=l[qe]||null;if(n===null)return null;l=n[t];e:switch(t){case"onClick":case"onClickCapture":case"onDoubleClick":case"onDoubleClickCapture":case"onMouseDown":case"onMouseDownCapture":case"onMouseMove":case"onMouseMoveCapture":case"onMouseUp":case"onMouseUpCapture":case"onMouseEnter":(n=!n.disabled)||(e=e.type,n=!(e==="button"||e==="input"||e==="select"||e==="textarea")),e=!n;break e;default:e=!1}if(e)return null;if(l&&typeof l!="function")throw Error(z(231,t,typeof l));return l}var Ct=!(typeof window>"u"||typeof window.document>"u"||typeof window.document.createElement>"u"),ri=!1;if(Ct)try{var Dn={};Object.defineProperty(Dn,"passive",{get:function(){ri=!0}}),window.addEventListener("test",Dn,Dn),window.removeEventListener("test",Dn,Dn)}catch{ri=!1}var Kt=null,of=null,Fa=null;function Lr(){if(Fa)return Fa;var e,t=of,l=t.length,n,a="value"in Kt?Kt.value:Kt.textContent,u=a.length;for(e=0;e<l&&t[e]===a[e];e++);var c=l-e;for(n=1;n<=c&&t[l-n]===a[u-n];n++);return Fa=a.slice(e,1<n?1-n:void 0)}function Ia(e){var t=e.keyCode;return"charCode"in e?(e=e.charCode,e===0&&t===13&&(e=13)):e=t,e===10&&(e=13),32<=e||e===13?e:0}function _a(){return!0}function ps(){return!1}function Ue(e){function t(l,n,a,u,c){this._reactName=l,this._targetInst=a,this.type=n,this.nativeEvent=u,this.target=c,this.currentTarget=null;for(var i in e)e.hasOwnProperty(i)&&(l=e[i],this[i]=l?l(u):u[i]);return this.isDefaultPrevented=(u.defaultPrevented!=null?u.defaultPrevented:u.returnValue===!1)?_a:ps,this.isPropagationStopped=ps,this}return le(t.prototype,{preventDefault:function(){this.defaultPrevented=!0;var l=this.nativeEvent;l&&(l.preventDefault?l.preventDefault():typeof l.returnValue!="unknown"&&(l.returnValue=!1),this.isDefaultPrevented=_a)},stopPropagation:function(){var l=this.nativeEvent;l&&(l.stopPropagation?l.stopPropagation():typeof l.cancelBubble!="unknown"&&(l.cancelBubble=!0),this.isPropagationStopped=_a)},persist:function(){},isPersistent:_a}),t}var wl={eventPhase:0,bubbles:0,cancelable:0,timeStamp:function(e){return e.timeStamp||Date.now()},defaultPrevented:0,isTrusted:0},Yu=Ue(wl),ka=le({},wl,{view:0,detail:0}),Em=Ue(ka),mc,hc,wn,Zu=le({},ka,{screenX:0,screenY:0,clientX:0,clientY:0,pageX:0,pageY:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,getModifierState:rf,button:0,buttons:0,relatedTarget:function(e){return e.relatedTarget===void 0?e.fromElement===e.srcElement?e.toElement:e.fromElement:e.relatedTarget},movementX:function(e){return"movementX"in e?e.movementX:(e!==wn&&(wn&&e.type==="mousemove"?(mc=e.screenX-wn.screenX,hc=e.screenY-wn.screenY):hc=mc=0,wn=e),mc)},movementY:function(e){return"movementY"in e?e.movementY:hc}}),ks=Ue(Zu),Tm=le({},Zu,{dataTransfer:0}),jm=Ue(Tm),Mm=le({},ka,{relatedTarget:0}),yc=Ue(Mm),Am=le({},wl,{animationName:0,elapsedTime:0,pseudoElement:0}),Dm=Ue(Am),wm=le({},wl,{clipboardData:function(e){return"clipboardData"in e?e.clipboardData:window.clipboardData}}),Nm=Ue(wm),Om=le({},wl,{data:0}),zs=Ue(Om),Cm={Esc:"Escape",Spacebar:" ",Left:"ArrowLeft",Up:"ArrowUp",Right:"ArrowRight",Down:"ArrowDown",Del:"Delete",Win:"OS",Menu:"ContextMenu",Apps:"ContextMenu",Scroll:"ScrollLock",MozPrintableKey:"Unidentified"},$m={8:"Backspace",9:"Tab",12:"Clear",13:"Enter",16:"Shift",17:"Control",18:"Alt",19:"Pause",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",45:"Insert",46:"Delete",112:"F1",113:"F2",114:"F3",115:"F4",116:"F5",117:"F6",118:"F7",119:"F8",120:"F9",121:"F10",122:"F11",123:"F12",144:"NumLock",145:"ScrollLock",224:"Meta"},_m={Alt:"altKey",Control:"ctrlKey",Meta:"metaKey",Shift:"shiftKey"};function Rm(e){var t=this.nativeEvent;return t.getModifierState?t.getModifierState(e):(e=_m[e])?!!t[e]:!1}function rf(){return Rm}var qm=le({},ka,{key:function(e){if(e.key){var t=Cm[e.key]||e.key;if(t!=="Unidentified")return t}return e.type==="keypress"?(e=Ia(e),e===13?"Enter":String.fromCharCode(e)):e.type==="keydown"||e.type==="keyup"?$m[e.keyCode]||"Unidentified":""},code:0,location:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,repeat:0,locale:0,getModifierState:rf,charCode:function(e){return e.type==="keypress"?Ia(e):0},keyCode:function(e){return e.type==="keydown"||e.type==="keyup"?e.keyCode:0},which:function(e){return e.type==="keypress"?Ia(e):e.type==="keydown"||e.type==="keyup"?e.keyCode:0}}),Um=Ue(qm),Hm=le({},Zu,{pointerId:0,width:0,height:0,pressure:0,tangentialPressure:0,tiltX:0,tiltY:0,twist:0,pointerType:0,isPrimary:0}),Es=Ue(Hm),Bm=le({},ka,{touches:0,targetTouches:0,changedTouches:0,altKey:0,metaKey:0,ctrlKey:0,shiftKey:0,getModifierState:rf}),Xm=Ue(Bm),Lm=le({},wl,{propertyName:0,elapsedTime:0,pseudoElement:0}),Gm=Ue(Lm),Ym=le({},Zu,{deltaX:function(e){return"deltaX"in e?e.deltaX:"wheelDeltaX"in e?-e.wheelDeltaX:0},deltaY:function(e){return"deltaY"in e?e.deltaY:"wheelDeltaY"in e?-e.wheelDeltaY:"wheelDelta"in e?-e.wheelDelta:0},deltaZ:0,deltaMode:0}),Zm=Ue(Ym),Vm=le({},wl,{newState:0,oldState:0}),Qm=Ue(Vm),Km=[9,13,27,32],df=Ct&&"CompositionEvent"in window,Ln=null;Ct&&"documentMode"in document&&(Ln=document.documentMode);var Jm=Ct&&"TextEvent"in window&&!Ln,Gr=Ct&&(!df||Ln&&8<Ln&&11>=Ln),Ts=" ",js=!1;function Yr(e,t){switch(e){case"keyup":return Km.indexOf(t.keyCode)!==-1;case"keydown":return t.keyCode!==229;case"keypress":case"mousedown":case"focusout":return!0;default:return!1}}function Zr(e){return e=e.detail,typeof e=="object"&&"data"in e?e.data:null}var Vl=!1;function Wm(e,t){switch(e){case"compositionend":return Zr(t);case"keypress":return t.which!==32?null:(js=!0,Ts);case"textInput":return e=t.data,e===Ts&&js?null:e;default:return null}}function Fm(e,t){if(Vl)return e==="compositionend"||!df&&Yr(e,t)?(e=Lr(),Fa=of=Kt=null,Vl=!1,e):null;switch(e){case"paste":return null;case"keypress":if(!(t.ctrlKey||t.altKey||t.metaKey)||t.ctrlKey&&t.altKey){if(t.char&&1<t.char.length)return t.char;if(t.which)return String.fromCharCode(t.which)}return null;case"compositionend":return Gr&&t.locale!=="ko"?null:t.data;default:return null}}var Im={color:!0,date:!0,datetime:!0,"datetime-local":!0,email:!0,month:!0,number:!0,password:!0,range:!0,search:!0,tel:!0,text:!0,time:!0,url:!0,week:!0};function Ms(e){var t=e&&e.nodeName&&e.nodeName.toLowerCase();return t==="input"?!!Im[e.type]:t==="textarea"}function Vr(e,t,l,n){Zl?nn?nn.push(n):nn=[n]:Zl=n,t=Cu(t,"onChange"),0<t.length&&(l=new Yu("onChange","change",null,l,n),e.push({event:l,listeners:t}))}var Gn=null,na=null;function Pm(e){X1(e,0)}function Vu(e){var t=Un(e);if(Rr(t))return e}function As(e,t){if(e==="change")return t}var Qr=!1;if(Ct){var vc;if(Ct){var xc="oninput"in document;if(!xc){var Ds=document.createElement("div");Ds.setAttribute("oninput","return;"),xc=typeof Ds.oninput=="function"}vc=xc}else vc=!1;Qr=vc&&(!document.documentMode||9<document.documentMode)}function ws(){Gn&&(Gn.detachEvent("onpropertychange",Kr),na=Gn=null)}function Kr(e){if(e.propertyName==="value"&&Vu(na)){var t=[];Vr(t,na,e,sf(e)),Xr(Pm,t)}}function eh(e,t,l){e==="focusin"?(ws(),Gn=t,na=l,Gn.attachEvent("onpropertychange",Kr)):e==="focusout"&&ws()}function th(e){if(e==="selectionchange"||e==="keyup"||e==="keydown")return Vu(na)}function lh(e,t){if(e==="click")return Vu(t)}function nh(e,t){if(e==="input"||e==="change")return Vu(t)}function ah(e,t){return e===t&&(e!==0||1/e===1/t)||e!==e&&t!==t}var Ke=typeof Object.is=="function"?Object.is:ah;function aa(e,t){if(Ke(e,t))return!0;if(typeof e!="object"||e===null||typeof t!="object"||t===null)return!1;var l=Object.keys(e),n=Object.keys(t);if(l.length!==n.length)return!1;for(n=0;n<l.length;n++){var a=l[n];if(!ui.call(t,a)||!Ke(e[a],t[a]))return!1}return!0}function Ns(e){for(;e&&e.firstChild;)e=e.firstChild;return e}function Os(e,t){var l=Ns(e);e=0;for(var n;l;){if(l.nodeType===3){if(n=e+l.textContent.length,e<=t&&n>=t)return{node:l,offset:t-e};e=n}e:{for(;l;){if(l.nextSibling){l=l.nextSibling;break e}l=l.parentNode}l=void 0}l=Ns(l)}}function Jr(e,t){return e&&t?e===t?!0:e&&e.nodeType===3?!1:t&&t.nodeType===3?Jr(e,t.parentNode):"contains"in e?e.contains(t):e.compareDocumentPosition?!!(e.compareDocumentPosition(t)&16):!1:!1}function Wr(e){e=e!=null&&e.ownerDocument!=null&&e.ownerDocument.defaultView!=null?e.ownerDocument.defaultView:window;for(var t=yu(e.document);t instanceof e.HTMLIFrameElement;){try{var l=typeof t.contentWindow.location.href=="string"}catch{l=!1}if(l)e=t.contentWindow;else break;t=yu(e.document)}return t}function mf(e){var t=e&&e.nodeName&&e.nodeName.toLowerCase();return t&&(t==="input"&&(e.type==="text"||e.type==="search"||e.type==="tel"||e.type==="url"||e.type==="password")||t==="textarea"||e.contentEditable==="true")}var uh=Ct&&"documentMode"in document&&11>=document.documentMode,Ql=null,di=null,Yn=null,mi=!1;function Cs(e,t,l){var n=l.window===l?l.document:l.nodeType===9?l:l.ownerDocument;mi||Ql==null||Ql!==yu(n)||(n=Ql,"selectionStart"in n&&mf(n)?n={start:n.selectionStart,end:n.selectionEnd}:(n=(n.ownerDocument&&n.ownerDocument.defaultView||window).getSelection(),n={anchorNode:n.anchorNode,anchorOffset:n.anchorOffset,focusNode:n.focusNode,focusOffset:n.focusOffset}),Yn&&aa(Yn,n)||(Yn=n,n=Cu(di,"onSelect"),0<n.length&&(t=new Yu("onSelect","select",null,t,l),e.push({event:t,listeners:n}),t.target=Ql)))}function ml(e,t){var l={};return l[e.toLowerCase()]=t.toLowerCase(),l["Webkit"+e]="webkit"+t,l["Moz"+e]="moz"+t,l}var Kl={animationend:ml("Animation","AnimationEnd"),animationiteration:ml("Animation","AnimationIteration"),animationstart:ml("Animation","AnimationStart"),transitionrun:ml("Transition","TransitionRun"),transitionstart:ml("Transition","TransitionStart"),transitioncancel:ml("Transition","TransitionCancel"),transitionend:ml("Transition","TransitionEnd")},gc={},Fr={};Ct&&(Fr=document.createElement("div").style,"AnimationEvent"in window||(delete Kl.animationend.animation,delete Kl.animationiteration.animation,delete Kl.animationstart.animation),"TransitionEvent"in window||delete Kl.transitionend.transition);function Nl(e){if(gc[e])return gc[e];if(!Kl[e])return e;var t=Kl[e],l;for(l in t)if(t.hasOwnProperty(l)&&l in Fr)return gc[e]=t[l];return e}var Ir=Nl("animationend"),Pr=Nl("animationiteration"),ed=Nl("animationstart"),ch=Nl("transitionrun"),ih=Nl("transitionstart"),fh=Nl("transitioncancel"),td=Nl("transitionend"),ld=new Map,hi="abort auxClick beforeToggle cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel".split(" ");hi.push("scrollEnd");function ot(e,t){ld.set(e,t),Dl(t,[e])}var vu=typeof reportError=="function"?reportError:function(e){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var t=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof e=="object"&&e!==null&&typeof e.message=="string"?String(e.message):String(e),error:e});if(!window.dispatchEvent(t))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",e);return}console.error(e)},Ie=[],Jl=0,hf=0;function Qu(){for(var e=Jl,t=hf=Jl=0;t<e;){var l=Ie[t];Ie[t++]=null;var n=Ie[t];Ie[t++]=null;var a=Ie[t];Ie[t++]=null;var u=Ie[t];if(Ie[t++]=null,n!==null&&a!==null){var c=n.pending;c===null?a.next=a:(a.next=c.next,c.next=a),n.pending=a}u!==0&&nd(l,a,u)}}function Ku(e,t,l,n){Ie[Jl++]=e,Ie[Jl++]=t,Ie[Jl++]=l,Ie[Jl++]=n,hf|=n,e.lanes|=n,e=e.alternate,e!==null&&(e.lanes|=n)}function yf(e,t,l,n){return Ku(e,t,l,n),xu(e)}function Ol(e,t){return Ku(e,null,null,t),xu(e)}function nd(e,t,l){e.lanes|=l;var n=e.alternate;n!==null&&(n.lanes|=l);for(var a=!1,u=e.return;u!==null;)u.childLanes|=l,n=u.alternate,n!==null&&(n.childLanes|=l),u.tag===22&&(e=u.stateNode,e===null||e._visibility&1||(a=!0)),e=u,u=u.return;return e.tag===3?(u=e.stateNode,a&&t!==null&&(a=31-Ve(l),e=u.hiddenUpdates,n=e[a],n===null?e[a]=[t]:n.push(t),t.lane=l|536870912),u):null}function xu(e){if(50<Pn)throw Pn=0,_i=null,Error(z(185));for(var t=e.return;t!==null;)e=t,t=e.return;return e.tag===3?e.stateNode:null}var Wl={};function sh(e,t,l,n){this.tag=e,this.key=l,this.sibling=this.child=this.return=this.stateNode=this.type=this.elementType=null,this.index=0,this.refCleanup=this.ref=null,this.pendingProps=t,this.dependencies=this.memoizedState=this.updateQueue=this.memoizedProps=null,this.mode=n,this.subtreeFlags=this.flags=0,this.deletions=null,this.childLanes=this.lanes=0,this.alternate=null}function Le(e,t,l,n){return new sh(e,t,l,n)}function vf(e){return e=e.prototype,!(!e||!e.isReactComponent)}function wt(e,t){var l=e.alternate;return l===null?(l=Le(e.tag,t,e.key,e.mode),l.elementType=e.elementType,l.type=e.type,l.stateNode=e.stateNode,l.alternate=e,e.alternate=l):(l.pendingProps=t,l.type=e.type,l.flags=0,l.subtreeFlags=0,l.deletions=null),l.flags=e.flags&65011712,l.childLanes=e.childLanes,l.lanes=e.lanes,l.child=e.child,l.memoizedProps=e.memoizedProps,l.memoizedState=e.memoizedState,l.updateQueue=e.updateQueue,t=e.dependencies,l.dependencies=t===null?null:{lanes:t.lanes,firstContext:t.firstContext},l.sibling=e.sibling,l.index=e.index,l.ref=e.ref,l.refCleanup=e.refCleanup,l}function ad(e,t){e.flags&=65011714;var l=e.alternate;return l===null?(e.childLanes=0,e.lanes=t,e.child=null,e.subtreeFlags=0,e.memoizedProps=null,e.memoizedState=null,e.updateQueue=null,e.dependencies=null,e.stateNode=null):(e.childLanes=l.childLanes,e.lanes=l.lanes,e.child=l.child,e.subtreeFlags=0,e.deletions=null,e.memoizedProps=l.memoizedProps,e.memoizedState=l.memoizedState,e.updateQueue=l.updateQueue,e.type=l.type,t=l.dependencies,e.dependencies=t===null?null:{lanes:t.lanes,firstContext:t.firstContext}),e}function Pa(e,t,l,n,a,u){var c=0;if(n=e,typeof e=="function")vf(e)&&(c=1);else if(typeof e=="string")c=hy(e,l,vt.current)?26:e==="html"||e==="head"||e==="body"?27:5;else e:switch(e){case ti:return e=Le(31,l,t,a),e.elementType=ti,e.lanes=u,e;case Ll:return Sl(l.children,a,u,t);case zr:c=8,a|=24;break;case Ic:return e=Le(12,l,t,a|2),e.elementType=Ic,e.lanes=u,e;case Pc:return e=Le(13,l,t,a),e.elementType=Pc,e.lanes=u,e;case ei:return e=Le(19,l,t,a),e.elementType=ei,e.lanes=u,e;default:if(typeof e=="object"&&e!==null)switch(e.$$typeof){case Mt:c=10;break e;case Er:c=9;break e;case tf:c=11;break e;case lf:c=14;break e;case Xt:c=16,n=null;break e}c=29,l=Error(z(130,e===null?"null":typeof e,"")),n=null}return t=Le(c,l,t,a),t.elementType=e,t.type=n,t.lanes=u,t}function Sl(e,t,l,n){return e=Le(7,e,n,t),e.lanes=l,e}function bc(e,t,l){return e=Le(6,e,null,t),e.lanes=l,e}function ud(e){var t=Le(18,null,null,0);return t.stateNode=e,t}function Sc(e,t,l){return t=Le(4,e.children!==null?e.children:[],e.key,t),t.lanes=l,t.stateNode={containerInfo:e.containerInfo,pendingChildren:null,implementation:e.implementation},t}var $s=new WeakMap;function nt(e,t){if(typeof e=="object"&&e!==null){var l=$s.get(e);return l!==void 0?l:(t={value:e,source:t,stack:hs(t)},$s.set(e,t),t)}return{value:e,source:t,stack:hs(t)}}var Fl=[],Il=0,gu=null,ua=0,et=[],tt=0,il=null,mt=1,ht="";function Tt(e,t){Fl[Il++]=ua,Fl[Il++]=gu,gu=e,ua=t}function cd(e,t,l){et[tt++]=mt,et[tt++]=ht,et[tt++]=il,il=e;var n=mt;e=ht;var a=32-Ve(n)-1;n&=~(1<<a),l+=1;var u=32-Ve(t)+a;if(30<u){var c=a-a%5;u=(n&(1<<c)-1).toString(32),n>>=c,a-=c,mt=1<<32-Ve(t)+a|l<<a|n,ht=u+e}else mt=1<<u|l<<a|n,ht=e}function xf(e){e.return!==null&&(Tt(e,1),cd(e,1,0))}function gf(e){for(;e===gu;)gu=Fl[--Il],Fl[Il]=null,ua=Fl[--Il],Fl[Il]=null;for(;e===il;)il=et[--tt],et[tt]=null,ht=et[--tt],et[tt]=null,mt=et[--tt],et[tt]=null}function id(e,t){et[tt++]=mt,et[tt++]=ht,et[tt++]=il,mt=t.id,ht=t.overflow,il=e}var Te=null,ee=null,X=!1,Pt=null,at=!1,yi=Error(z(519));function fl(e){var t=Error(z(418,1<arguments.length&&arguments[1]!==void 0&&arguments[1]?"text":"HTML",""));throw ca(nt(t,e)),yi}function _s(e){var t=e.stateNode,l=e.type,n=e.memoizedProps;switch(t[Ee]=e,t[qe]=n,l){case"dialog":U("cancel",t),U("close",t);break;case"iframe":case"object":case"embed":U("load",t);break;case"video":case"audio":for(l=0;l<oa.length;l++)U(oa[l],t);break;case"source":U("error",t);break;case"img":case"image":case"link":U("error",t),U("load",t);break;case"details":U("toggle",t);break;case"input":U("invalid",t),qr(t,n.value,n.defaultValue,n.checked,n.defaultChecked,n.type,n.name,!0);break;case"select":U("invalid",t);break;case"textarea":U("invalid",t),Hr(t,n.value,n.defaultValue,n.children)}l=n.children,typeof l!="string"&&typeof l!="number"&&typeof l!="bigint"||t.textContent===""+l||n.suppressHydrationWarning===!0||G1(t.textContent,l)?(n.popover!=null&&(U("beforetoggle",t),U("toggle",t)),n.onScroll!=null&&U("scroll",t),n.onScrollEnd!=null&&U("scrollend",t),n.onClick!=null&&(t.onclick=At),t=!0):t=!1,t||fl(e,!0)}function Rs(e){for(Te=e.return;Te;)switch(Te.tag){case 5:case 31:case 13:at=!1;return;case 27:case 3:at=!0;return;default:Te=Te.return}}function $l(e){if(e!==Te)return!1;if(!X)return Rs(e),X=!0,!1;var t=e.tag,l;if((l=t!==3&&t!==27)&&((l=t===5)&&(l=e.type,l=!(l!=="form"&&l!=="button")||Bi(e.type,e.memoizedProps)),l=!l),l&&ee&&fl(e),Rs(e),t===13){if(e=e.memoizedState,e=e!==null?e.dehydrated:null,!e)throw Error(z(317));ee=zo(e)}else if(t===31){if(e=e.memoizedState,e=e!==null?e.dehydrated:null,!e)throw Error(z(317));ee=zo(e)}else t===27?(t=ee,dl(e.type)?(e=Yi,Yi=null,ee=e):ee=t):ee=Te?ct(e.stateNode.nextSibling):null;return!0}function El(){ee=Te=null,X=!1}function pc(){var e=Pt;return e!==null&&(_e===null?_e=e:_e.push.apply(_e,e),Pt=null),e}function ca(e){Pt===null?Pt=[e]:Pt.push(e)}var vi=xt(null),Cl=null,Dt=null;function Gt(e,t,l){I(vi,t._currentValue),t._currentValue=l}function Nt(e){e._currentValue=vi.current,be(vi)}function xi(e,t,l){for(;e!==null;){var n=e.alternate;if((e.childLanes&t)!==t?(e.childLanes|=t,n!==null&&(n.childLanes|=t)):n!==null&&(n.childLanes&t)!==t&&(n.childLanes|=t),e===l)break;e=e.return}}function gi(e,t,l,n){var a=e.child;for(a!==null&&(a.return=e);a!==null;){var u=a.dependencies;if(u!==null){var c=a.child;u=u.firstContext;e:for(;u!==null;){var i=u;u=a;for(var f=0;f<t.length;f++)if(i.context===t[f]){u.lanes|=l,i=u.alternate,i!==null&&(i.lanes|=l),xi(u.return,l,e),n||(c=null);break e}u=i.next}}else if(a.tag===18){if(c=a.return,c===null)throw Error(z(341));c.lanes|=l,u=c.alternate,u!==null&&(u.lanes|=l),xi(c,l,e),c=null}else c=a.child;if(c!==null)c.return=a;else for(c=a;c!==null;){if(c===e){c=null;break}if(a=c.sibling,a!==null){a.return=c.return,c=a;break}c=c.return}a=c}}function zn(e,t,l,n){e=null;for(var a=t,u=!1;a!==null;){if(!u){if(a.flags&524288)u=!0;else if(a.flags&262144)break}if(a.tag===10){var c=a.alternate;if(c===null)throw Error(z(387));if(c=c.memoizedProps,c!==null){var i=a.type;Ke(a.pendingProps.value,c.value)||(e!==null?e.push(i):e=[i])}}else if(a===ru.current){if(c=a.alternate,c===null)throw Error(z(387));c.memoizedState.memoizedState!==a.memoizedState.memoizedState&&(e!==null?e.push(da):e=[da])}a=a.return}e!==null&&gi(t,e,l,n),t.flags|=262144}function bu(e){for(e=e.firstContext;e!==null;){if(!Ke(e.context._currentValue,e.memoizedValue))return!0;e=e.next}return!1}function Tl(e){Cl=e,Dt=null,e=e.dependencies,e!==null&&(e.firstContext=null)}function je(e){return fd(Cl,e)}function Ra(e,t){return Cl===null&&Tl(e),fd(e,t)}function fd(e,t){var l=t._currentValue;if(t={context:t,memoizedValue:l,next:null},Dt===null){if(e===null)throw Error(z(308));Dt=t,e.dependencies={lanes:0,firstContext:t},e.flags|=524288}else Dt=Dt.next=t;return l}var oh=typeof AbortController<"u"?AbortController:function(){var e=[],t=this.signal={aborted:!1,addEventListener:function(l,n){e.push(n)}};this.abort=function(){t.aborted=!0,e.forEach(function(l){return l()})}},rh=ve.unstable_scheduleCallback,dh=ve.unstable_NormalPriority,me={$$typeof:Mt,Consumer:null,Provider:null,_currentValue:null,_currentValue2:null,_threadCount:0};function bf(){return{controller:new oh,data:new Map,refCount:0}}function za(e){e.refCount--,e.refCount===0&&rh(dh,function(){e.controller.abort()})}var Zn=null,bi=0,dn=0,an=null;function mh(e,t){if(Zn===null){var l=Zn=[];bi=0,dn=Yf(),an={status:"pending",value:void 0,then:function(n){l.push(n)}}}return bi++,t.then(qs,qs),t}function qs(){if(--bi===0&&Zn!==null){an!==null&&(an.status="fulfilled");var e=Zn;Zn=null,dn=0,an=null;for(var t=0;t<e.length;t++)(0,e[t])()}}function hh(e,t){var l=[],n={status:"pending",value:null,reason:null,then:function(a){l.push(a)}};return e.then(function(){n.status="fulfilled",n.value=t;for(var a=0;a<l.length;a++)(0,l[a])(t)},function(a){for(n.status="rejected",n.reason=a,a=0;a<l.length;a++)(0,l[a])(void 0)}),n}var Us=C.S;C.S=function(e,t){k1=Ye(),typeof t=="object"&&t!==null&&typeof t.then=="function"&&mh(e,t),Us!==null&&Us(e,t)};var pl=xt(null);function Sf(){var e=pl.current;return e!==null?e:F.pooledCache}function eu(e,t){t===null?I(pl,pl.current):I(pl,t.pool)}function sd(){var e=Sf();return e===null?null:{parent:me._currentValue,pool:e}}var En=Error(z(460)),pf=Error(z(474)),Ju=Error(z(542)),Su={then:function(){}};function Hs(e){return e=e.status,e==="fulfilled"||e==="rejected"}function od(e,t,l){switch(l=e[l],l===void 0?e.push(t):l!==t&&(t.then(At,At),t=l),t.status){case"fulfilled":return t.value;case"rejected":throw e=t.reason,Xs(e),e;default:if(typeof t.status=="string")t.then(At,At);else{if(e=F,e!==null&&100<e.shellSuspendCounter)throw Error(z(482));e=t,e.status="pending",e.then(function(n){if(t.status==="pending"){var a=t;a.status="fulfilled",a.value=n}},function(n){if(t.status==="pending"){var a=t;a.status="rejected",a.reason=n}})}switch(t.status){case"fulfilled":return t.value;case"rejected":throw e=t.reason,Xs(e),e}throw kl=t,En}}function xl(e){try{var t=e._init;return t(e._payload)}catch(l){throw l!==null&&typeof l=="object"&&typeof l.then=="function"?(kl=l,En):l}}var kl=null;function Bs(){if(kl===null)throw Error(z(459));var e=kl;return kl=null,e}function Xs(e){if(e===En||e===Ju)throw Error(z(483))}var un=null,ia=0;function qa(e){var t=ia;return ia+=1,un===null&&(un=[]),od(un,e,t)}function Nn(e,t){t=t.props.ref,e.ref=t!==void 0?t:null}function Ua(e,t){throw t.$$typeof===em?Error(z(525)):(e=Object.prototype.toString.call(t),Error(z(31,e==="[object Object]"?"object with keys {"+Object.keys(t).join(", ")+"}":e)))}function rd(e){function t(h,o){if(e){var m=h.deletions;m===null?(h.deletions=[o],h.flags|=16):m.push(o)}}function l(h,o){if(!e)return null;for(;o!==null;)t(h,o),o=o.sibling;return null}function n(h){for(var o=new Map;h!==null;)h.key!==null?o.set(h.key,h):o.set(h.index,h),h=h.sibling;return o}function a(h,o){return h=wt(h,o),h.index=0,h.sibling=null,h}function u(h,o,m){return h.index=m,e?(m=h.alternate,m!==null?(m=m.index,m<o?(h.flags|=67108866,o):m):(h.flags|=67108866,o)):(h.flags|=1048576,o)}function c(h){return e&&h.alternate===null&&(h.flags|=67108866),h}function i(h,o,m,b){return o===null||o.tag!==6?(o=bc(m,h.mode,b),o.return=h,o):(o=a(o,m),o.return=h,o)}function f(h,o,m,b){var T=m.type;return T===Ll?d(h,o,m.props.children,b,m.key):o!==null&&(o.elementType===T||typeof T=="object"&&T!==null&&T.$$typeof===Xt&&xl(T)===o.type)?(o=a(o,m.props),Nn(o,m),o.return=h,o):(o=Pa(m.type,m.key,m.props,null,h.mode,b),Nn(o,m),o.return=h,o)}function s(h,o,m,b){return o===null||o.tag!==4||o.stateNode.containerInfo!==m.containerInfo||o.stateNode.implementation!==m.implementation?(o=Sc(m,h.mode,b),o.return=h,o):(o=a(o,m.children||[]),o.return=h,o)}function d(h,o,m,b,T){return o===null||o.tag!==7?(o=Sl(m,h.mode,b,T),o.return=h,o):(o=a(o,m),o.return=h,o)}function g(h,o,m){if(typeof o=="string"&&o!==""||typeof o=="number"||typeof o=="bigint")return o=bc(""+o,h.mode,m),o.return=h,o;if(typeof o=="object"&&o!==null){switch(o.$$typeof){case wa:return m=Pa(o.type,o.key,o.props,null,h.mode,m),Nn(m,o),m.return=h,m;case Rn:return o=Sc(o,h.mode,m),o.return=h,o;case Xt:return o=xl(o),g(h,o,m)}if(qn(o)||An(o))return o=Sl(o,h.mode,m,null),o.return=h,o;if(typeof o.then=="function")return g(h,qa(o),m);if(o.$$typeof===Mt)return g(h,Ra(h,o),m);Ua(h,o)}return null}function r(h,o,m,b){var T=o!==null?o.key:null;if(typeof m=="string"&&m!==""||typeof m=="number"||typeof m=="bigint")return T!==null?null:i(h,o,""+m,b);if(typeof m=="object"&&m!==null){switch(m.$$typeof){case wa:return m.key===T?f(h,o,m,b):null;case Rn:return m.key===T?s(h,o,m,b):null;case Xt:return m=xl(m),r(h,o,m,b)}if(qn(m)||An(m))return T!==null?null:d(h,o,m,b,null);if(typeof m.then=="function")return r(h,o,qa(m),b);if(m.$$typeof===Mt)return r(h,o,Ra(h,m),b);Ua(h,m)}return null}function x(h,o,m,b,T){if(typeof b=="string"&&b!==""||typeof b=="number"||typeof b=="bigint")return h=h.get(m)||null,i(o,h,""+b,T);if(typeof b=="object"&&b!==null){switch(b.$$typeof){case wa:return h=h.get(b.key===null?m:b.key)||null,f(o,h,b,T);case Rn:return h=h.get(b.key===null?m:b.key)||null,s(o,h,b,T);case Xt:return b=xl(b),x(h,o,m,b,T)}if(qn(b)||An(b))return h=h.get(m)||null,d(o,h,b,T,null);if(typeof b.then=="function")return x(h,o,m,qa(b),T);if(b.$$typeof===Mt)return x(h,o,m,Ra(o,b),T);Ua(o,b)}return null}function S(h,o,m,b){for(var T=null,N=null,E=o,j=o=0,A=null;E!==null&&j<m.length;j++){E.index>j?(A=E,E=null):A=E.sibling;var M=r(h,E,m[j],b);if(M===null){E===null&&(E=A);break}e&&E&&M.alternate===null&&t(h,E),o=u(M,o,j),N===null?T=M:N.sibling=M,N=M,E=A}if(j===m.length)return l(h,E),X&&Tt(h,j),T;if(E===null){for(;j<m.length;j++)E=g(h,m[j],b),E!==null&&(o=u(E,o,j),N===null?T=E:N.sibling=E,N=E);return X&&Tt(h,j),T}for(E=n(E);j<m.length;j++)A=x(E,h,j,m[j],b),A!==null&&(e&&A.alternate!==null&&E.delete(A.key===null?j:A.key),o=u(A,o,j),N===null?T=A:N.sibling=A,N=A);return e&&E.forEach(function(q){return t(h,q)}),X&&Tt(h,j),T}function p(h,o,m,b){if(m==null)throw Error(z(151));for(var T=null,N=null,E=o,j=o=0,A=null,M=m.next();E!==null&&!M.done;j++,M=m.next()){E.index>j?(A=E,E=null):A=E.sibling;var q=r(h,E,M.value,b);if(q===null){E===null&&(E=A);break}e&&E&&q.alternate===null&&t(h,E),o=u(q,o,j),N===null?T=q:N.sibling=q,N=q,E=A}if(M.done)return l(h,E),X&&Tt(h,j),T;if(E===null){for(;!M.done;j++,M=m.next())M=g(h,M.value,b),M!==null&&(o=u(M,o,j),N===null?T=M:N.sibling=M,N=M);return X&&Tt(h,j),T}for(E=n(E);!M.done;j++,M=m.next())M=x(E,h,j,M.value,b),M!==null&&(e&&M.alternate!==null&&E.delete(M.key===null?j:M.key),o=u(M,o,j),N===null?T=M:N.sibling=M,N=M);return e&&E.forEach(function(G){return t(h,G)}),X&&Tt(h,j),T}function k(h,o,m,b){if(typeof m=="object"&&m!==null&&m.type===Ll&&m.key===null&&(m=m.props.children),typeof m=="object"&&m!==null){switch(m.$$typeof){case wa:e:{for(var T=m.key;o!==null;){if(o.key===T){if(T=m.type,T===Ll){if(o.tag===7){l(h,o.sibling),b=a(o,m.props.children),b.return=h,h=b;break e}}else if(o.elementType===T||typeof T=="object"&&T!==null&&T.$$typeof===Xt&&xl(T)===o.type){l(h,o.sibling),b=a(o,m.props),Nn(b,m),b.return=h,h=b;break e}l(h,o);break}else t(h,o);o=o.sibling}m.type===Ll?(b=Sl(m.props.children,h.mode,b,m.key),b.return=h,h=b):(b=Pa(m.type,m.key,m.props,null,h.mode,b),Nn(b,m),b.return=h,h=b)}return c(h);case Rn:e:{for(T=m.key;o!==null;){if(o.key===T)if(o.tag===4&&o.stateNode.containerInfo===m.containerInfo&&o.stateNode.implementation===m.implementation){l(h,o.sibling),b=a(o,m.children||[]),b.return=h,h=b;break e}else{l(h,o);break}else t(h,o);o=o.sibling}b=Sc(m,h.mode,b),b.return=h,h=b}return c(h);case Xt:return m=xl(m),k(h,o,m,b)}if(qn(m))return S(h,o,m,b);if(An(m)){if(T=An(m),typeof T!="function")throw Error(z(150));return m=T.call(m),p(h,o,m,b)}if(typeof m.then=="function")return k(h,o,qa(m),b);if(m.$$typeof===Mt)return k(h,o,Ra(h,m),b);Ua(h,m)}return typeof m=="string"&&m!==""||typeof m=="number"||typeof m=="bigint"?(m=""+m,o!==null&&o.tag===6?(l(h,o.sibling),b=a(o,m),b.return=h,h=b):(l(h,o),b=bc(m,h.mode,b),b.return=h,h=b),c(h)):l(h,o)}return function(h,o,m,b){try{ia=0;var T=k(h,o,m,b);return un=null,T}catch(E){if(E===En||E===Ju)throw E;var N=Le(29,E,null,h.mode);return N.lanes=b,N.return=h,N}finally{}}}var jl=rd(!0),dd=rd(!1),Lt=!1;function kf(e){e.updateQueue={baseState:e.memoizedState,firstBaseUpdate:null,lastBaseUpdate:null,shared:{pending:null,lanes:0,hiddenCallbacks:null},callbacks:null}}function Si(e,t){e=e.updateQueue,t.updateQueue===e&&(t.updateQueue={baseState:e.baseState,firstBaseUpdate:e.firstBaseUpdate,lastBaseUpdate:e.lastBaseUpdate,shared:e.shared,callbacks:null})}function el(e){return{lane:e,tag:0,payload:null,callback:null,next:null}}function tl(e,t,l){var n=e.updateQueue;if(n===null)return null;if(n=n.shared,Z&2){var a=n.pending;return a===null?t.next=t:(t.next=a.next,a.next=t),n.pending=t,t=xu(e),nd(e,null,l),t}return Ku(e,n,t,l),xu(e)}function Vn(e,t,l){if(t=t.updateQueue,t!==null&&(t=t.shared,(l&4194048)!==0)){var n=t.lanes;n&=e.pendingLanes,l|=n,t.lanes=l,wr(e,l)}}function kc(e,t){var l=e.updateQueue,n=e.alternate;if(n!==null&&(n=n.updateQueue,l===n)){var a=null,u=null;if(l=l.firstBaseUpdate,l!==null){do{var c={lane:l.lane,tag:l.tag,payload:l.payload,callback:null,next:null};u===null?a=u=c:u=u.next=c,l=l.next}while(l!==null);u===null?a=u=t:u=u.next=t}else a=u=t;l={baseState:n.baseState,firstBaseUpdate:a,lastBaseUpdate:u,shared:n.shared,callbacks:n.callbacks},e.updateQueue=l;return}e=l.lastBaseUpdate,e===null?l.firstBaseUpdate=t:e.next=t,l.lastBaseUpdate=t}var pi=!1;function Qn(){if(pi){var e=an;if(e!==null)throw e}}function Kn(e,t,l,n){pi=!1;var a=e.updateQueue;Lt=!1;var u=a.firstBaseUpdate,c=a.lastBaseUpdate,i=a.shared.pending;if(i!==null){a.shared.pending=null;var f=i,s=f.next;f.next=null,c===null?u=s:c.next=s,c=f;var d=e.alternate;d!==null&&(d=d.updateQueue,i=d.lastBaseUpdate,i!==c&&(i===null?d.firstBaseUpdate=s:i.next=s,d.lastBaseUpdate=f))}if(u!==null){var g=a.baseState;c=0,d=s=f=null,i=u;do{var r=i.lane&-536870913,x=r!==i.lane;if(x?(B&r)===r:(n&r)===r){r!==0&&r===dn&&(pi=!0),d!==null&&(d=d.next={lane:0,tag:i.tag,payload:i.payload,callback:null,next:null});e:{var S=e,p=i;r=t;var k=l;switch(p.tag){case 1:if(S=p.payload,typeof S=="function"){g=S.call(k,g,r);break e}g=S;break e;case 3:S.flags=S.flags&-65537|128;case 0:if(S=p.payload,r=typeof S=="function"?S.call(k,g,r):S,r==null)break e;g=le({},g,r);break e;case 2:Lt=!0}}r=i.callback,r!==null&&(e.flags|=64,x&&(e.flags|=8192),x=a.callbacks,x===null?a.callbacks=[r]:x.push(r))}else x={lane:r,tag:i.tag,payload:i.payload,callback:i.callback,next:null},d===null?(s=d=x,f=g):d=d.next=x,c|=r;if(i=i.next,i===null){if(i=a.shared.pending,i===null)break;x=i,i=x.next,x.next=null,a.lastBaseUpdate=x,a.shared.pending=null}}while(!0);d===null&&(f=g),a.baseState=f,a.firstBaseUpdate=s,a.lastBaseUpdate=d,u===null&&(a.shared.lanes=0),ol|=c,e.lanes=c,e.memoizedState=g}}function md(e,t){if(typeof e!="function")throw Error(z(191,e));e.call(t)}function hd(e,t){var l=e.callbacks;if(l!==null)for(e.callbacks=null,e=0;e<l.length;e++)md(l[e],t)}var mn=xt(null),pu=xt(0);function Ls(e,t){e=qt,I(pu,e),I(mn,t),qt=e|t.baseLanes}function ki(){I(pu,qt),I(mn,mn.current)}function zf(){qt=pu.current,be(mn),be(pu)}var Je=xt(null),ut=null;function Yt(e){var t=e.alternate;I(se,se.current&1),I(Je,e),ut===null&&(t===null||mn.current!==null||t.memoizedState!==null)&&(ut=e)}function zi(e){I(se,se.current),I(Je,e),ut===null&&(ut=e)}function yd(e){e.tag===22?(I(se,se.current),I(Je,e),ut===null&&(ut=e)):Zt()}function Zt(){I(se,se.current),I(Je,Je.current)}function Xe(e){be(Je),ut===e&&(ut=null),be(se)}var se=xt(0);function ku(e){for(var t=e;t!==null;){if(t.tag===13){var l=t.memoizedState;if(l!==null&&(l=l.dehydrated,l===null||Li(l)||Gi(l)))return t}else if(t.tag===19&&(t.memoizedProps.revealOrder==="forwards"||t.memoizedProps.revealOrder==="backwards"||t.memoizedProps.revealOrder==="unstable_legacy-backwards"||t.memoizedProps.revealOrder==="together")){if(t.flags&128)return t}else if(t.child!==null){t.child.return=t,t=t.child;continue}if(t===e)break;for(;t.sibling===null;){if(t.return===null||t.return===e)return null;t=t.return}t.sibling.return=t.return,t=t.sibling}return null}var $t=0,R=null,W=null,re=null,zu=!1,cn=!1,Ml=!1,Eu=0,fa=0,fn=null,yh=0;function ce(){throw Error(z(321))}function Ef(e,t){if(t===null)return!1;for(var l=0;l<t.length&&l<e.length;l++)if(!Ke(e[l],t[l]))return!1;return!0}function Tf(e,t,l,n,a,u){return $t=u,R=t,t.memoizedState=null,t.updateQueue=null,t.lanes=0,C.H=e===null||e.memoizedState===null?Vd:Rf,Ml=!1,u=l(n,a),Ml=!1,cn&&(u=xd(t,l,n,a)),vd(e),u}function vd(e){C.H=sa;var t=W!==null&&W.next!==null;if($t=0,re=W=R=null,zu=!1,fa=0,fn=null,t)throw Error(z(300));e===null||he||(e=e.dependencies,e!==null&&bu(e)&&(he=!0))}function xd(e,t,l,n){R=e;var a=0;do{if(cn&&(fn=null),fa=0,cn=!1,25<=a)throw Error(z(301));if(a+=1,re=W=null,e.updateQueue!=null){var u=e.updateQueue;u.lastEffect=null,u.events=null,u.stores=null,u.memoCache!=null&&(u.memoCache.index=0)}C.H=Qd,u=t(l,n)}while(cn);return u}function vh(){var e=C.H,t=e.useState()[0];return t=typeof t.then=="function"?Ea(t):t,e=e.useState()[0],(W!==null?W.memoizedState:null)!==e&&(R.flags|=1024),t}function jf(){var e=Eu!==0;return Eu=0,e}function Mf(e,t,l){t.updateQueue=e.updateQueue,t.flags&=-2053,e.lanes&=~l}function Af(e){if(zu){for(e=e.memoizedState;e!==null;){var t=e.queue;t!==null&&(t.pending=null),e=e.next}zu=!1}$t=0,re=W=R=null,cn=!1,fa=Eu=0,fn=null}function De(){var e={memoizedState:null,baseState:null,baseQueue:null,queue:null,next:null};return re===null?R.memoizedState=re=e:re=re.next=e,re}function oe(){if(W===null){var e=R.alternate;e=e!==null?e.memoizedState:null}else e=W.next;var t=re===null?R.memoizedState:re.next;if(t!==null)re=t,W=e;else{if(e===null)throw R.alternate===null?Error(z(467)):Error(z(310));W=e,e={memoizedState:W.memoizedState,baseState:W.baseState,baseQueue:W.baseQueue,queue:W.queue,next:null},re===null?R.memoizedState=re=e:re=re.next=e}return re}function Wu(){return{lastEffect:null,events:null,stores:null,memoCache:null}}function Ea(e){var t=fa;return fa+=1,fn===null&&(fn=[]),e=od(fn,e,t),t=R,(re===null?t.memoizedState:re.next)===null&&(t=t.alternate,C.H=t===null||t.memoizedState===null?Vd:Rf),e}function Fu(e){if(e!==null&&typeof e=="object"){if(typeof e.then=="function")return Ea(e);if(e.$$typeof===Mt)return je(e)}throw Error(z(438,String(e)))}function Df(e){var t=null,l=R.updateQueue;if(l!==null&&(t=l.memoCache),t==null){var n=R.alternate;n!==null&&(n=n.updateQueue,n!==null&&(n=n.memoCache,n!=null&&(t={data:n.data.map(function(a){return a.slice()}),index:0})))}if(t==null&&(t={data:[],index:0}),l===null&&(l=Wu(),R.updateQueue=l),l.memoCache=t,l=t.data[t.index],l===void 0)for(l=t.data[t.index]=Array(e),n=0;n<e;n++)l[n]=tm;return t.index++,l}function _t(e,t){return typeof t=="function"?t(e):t}function tu(e){var t=oe();return wf(t,W,e)}function wf(e,t,l){var n=e.queue;if(n===null)throw Error(z(311));n.lastRenderedReducer=l;var a=e.baseQueue,u=n.pending;if(u!==null){if(a!==null){var c=a.next;a.next=u.next,u.next=c}t.baseQueue=a=u,n.pending=null}if(u=e.baseState,a===null)e.memoizedState=u;else{t=a.next;var i=c=null,f=null,s=t,d=!1;do{var g=s.lane&-536870913;if(g!==s.lane?(B&g)===g:($t&g)===g){var r=s.revertLane;if(r===0)f!==null&&(f=f.next={lane:0,revertLane:0,gesture:null,action:s.action,hasEagerState:s.hasEagerState,eagerState:s.eagerState,next:null}),g===dn&&(d=!0);else if(($t&r)===r){s=s.next,r===dn&&(d=!0);continue}else g={lane:0,revertLane:s.revertLane,gesture:null,action:s.action,hasEagerState:s.hasEagerState,eagerState:s.eagerState,next:null},f===null?(i=f=g,c=u):f=f.next=g,R.lanes|=r,ol|=r;g=s.action,Ml&&l(u,g),u=s.hasEagerState?s.eagerState:l(u,g)}else r={lane:g,revertLane:s.revertLane,gesture:s.gesture,action:s.action,hasEagerState:s.hasEagerState,eagerState:s.eagerState,next:null},f===null?(i=f=r,c=u):f=f.next=r,R.lanes|=g,ol|=g;s=s.next}while(s!==null&&s!==t);if(f===null?c=u:f.next=i,!Ke(u,e.memoizedState)&&(he=!0,d&&(l=an,l!==null)))throw l;e.memoizedState=u,e.baseState=c,e.baseQueue=f,n.lastRenderedState=u}return a===null&&(n.lanes=0),[e.memoizedState,n.dispatch]}function zc(e){var t=oe(),l=t.queue;if(l===null)throw Error(z(311));l.lastRenderedReducer=e;var n=l.dispatch,a=l.pending,u=t.memoizedState;if(a!==null){l.pending=null;var c=a=a.next;do u=e(u,c.action),c=c.next;while(c!==a);Ke(u,t.memoizedState)||(he=!0),t.memoizedState=u,t.baseQueue===null&&(t.baseState=u),l.lastRenderedState=u}return[u,n]}function gd(e,t,l){var n=R,a=oe(),u=X;if(u){if(l===void 0)throw Error(z(407));l=l()}else l=t();var c=!Ke((W||a).memoizedState,l);if(c&&(a.memoizedState=l,he=!0),a=a.queue,Nf(pd.bind(null,n,a,e),[e]),a.getSnapshot!==t||c||re!==null&&re.memoizedState.tag&1){if(n.flags|=2048,hn(9,{destroy:void 0},Sd.bind(null,n,a,l,t),null),F===null)throw Error(z(349));u||$t&127||bd(n,t,l)}return l}function bd(e,t,l){e.flags|=16384,e={getSnapshot:t,value:l},t=R.updateQueue,t===null?(t=Wu(),R.updateQueue=t,t.stores=[e]):(l=t.stores,l===null?t.stores=[e]:l.push(e))}function Sd(e,t,l,n){t.value=l,t.getSnapshot=n,kd(t)&&zd(e)}function pd(e,t,l){return l(function(){kd(t)&&zd(e)})}function kd(e){var t=e.getSnapshot;e=e.value;try{var l=t();return!Ke(e,l)}catch{return!0}}function zd(e){var t=Ol(e,2);t!==null&&Re(t,e,2)}function Ei(e){var t=De();if(typeof e=="function"){var l=e;if(e=l(),Ml){Qt(!0);try{l()}finally{Qt(!1)}}}return t.memoizedState=t.baseState=e,t.queue={pending:null,lanes:0,dispatch:null,lastRenderedReducer:_t,lastRenderedState:e},t}function Ed(e,t,l,n){return e.baseState=l,wf(e,W,typeof n=="function"?n:_t)}function xh(e,t,l,n,a){if(Pu(e))throw Error(z(485));if(e=t.action,e!==null){var u={payload:a,action:e,next:null,isTransition:!0,status:"pending",value:null,reason:null,listeners:[],then:function(c){u.listeners.push(c)}};C.T!==null?l(!0):u.isTransition=!1,n(u),l=t.pending,l===null?(u.next=t.pending=u,Td(t,u)):(u.next=l.next,t.pending=l.next=u)}}function Td(e,t){var l=t.action,n=t.payload,a=e.state;if(t.isTransition){var u=C.T,c={};C.T=c;try{var i=l(a,n),f=C.S;f!==null&&f(c,i),Gs(e,t,i)}catch(s){Ti(e,t,s)}finally{u!==null&&c.types!==null&&(u.types=c.types),C.T=u}}else try{u=l(a,n),Gs(e,t,u)}catch(s){Ti(e,t,s)}}function Gs(e,t,l){l!==null&&typeof l=="object"&&typeof l.then=="function"?l.then(function(n){Ys(e,t,n)},function(n){return Ti(e,t,n)}):Ys(e,t,l)}function Ys(e,t,l){t.status="fulfilled",t.value=l,jd(t),e.state=l,t=e.pending,t!==null&&(l=t.next,l===t?e.pending=null:(l=l.next,t.next=l,Td(e,l)))}function Ti(e,t,l){var n=e.pending;if(e.pending=null,n!==null){n=n.next;do t.status="rejected",t.reason=l,jd(t),t=t.next;while(t!==n)}e.action=null}function jd(e){e=e.listeners;for(var t=0;t<e.length;t++)(0,e[t])()}function Md(e,t){return t}function Zs(e,t){if(X){var l=F.formState;if(l!==null){e:{var n=R;if(X){if(ee){t:{for(var a=ee,u=at;a.nodeType!==8;){if(!u){a=null;break t}if(a=ct(a.nextSibling),a===null){a=null;break t}}u=a.data,a=u==="F!"||u==="F"?a:null}if(a){ee=ct(a.nextSibling),n=a.data==="F!";break e}}fl(n)}n=!1}n&&(t=l[0])}}return l=De(),l.memoizedState=l.baseState=t,n={pending:null,lanes:0,dispatch:null,lastRenderedReducer:Md,lastRenderedState:t},l.queue=n,l=Gd.bind(null,R,n),n.dispatch=l,n=Ei(!1),u=_f.bind(null,R,!1,n.queue),n=De(),a={state:t,dispatch:null,action:e,pending:null},n.queue=a,l=xh.bind(null,R,a,u,l),a.dispatch=l,n.memoizedState=e,[t,l,!1]}function Vs(e){var t=oe();return Ad(t,W,e)}function Ad(e,t,l){if(t=wf(e,t,Md)[0],e=tu(_t)[0],typeof t=="object"&&t!==null&&typeof t.then=="function")try{var n=Ea(t)}catch(c){throw c===En?Ju:c}else n=t;t=oe();var a=t.queue,u=a.dispatch;return l!==t.memoizedState&&(R.flags|=2048,hn(9,{destroy:void 0},gh.bind(null,a,l),null)),[n,u,e]}function gh(e,t){e.action=t}function Qs(e){var t=oe(),l=W;if(l!==null)return Ad(t,l,e);oe(),t=t.memoizedState,l=oe();var n=l.queue.dispatch;return l.memoizedState=e,[t,n,!1]}function hn(e,t,l,n){return e={tag:e,create:l,deps:n,inst:t,next:null},t=R.updateQueue,t===null&&(t=Wu(),R.updateQueue=t),l=t.lastEffect,l===null?t.lastEffect=e.next=e:(n=l.next,l.next=e,e.next=n,t.lastEffect=e),e}function Dd(){return oe().memoizedState}function lu(e,t,l,n){var a=De();R.flags|=e,a.memoizedState=hn(1|t,{destroy:void 0},l,n===void 0?null:n)}function Iu(e,t,l,n){var a=oe();n=n===void 0?null:n;var u=a.memoizedState.inst;W!==null&&n!==null&&Ef(n,W.memoizedState.deps)?a.memoizedState=hn(t,u,l,n):(R.flags|=e,a.memoizedState=hn(1|t,u,l,n))}function Ks(e,t){lu(8390656,8,e,t)}function Nf(e,t){Iu(2048,8,e,t)}function bh(e){R.flags|=4;var t=R.updateQueue;if(t===null)t=Wu(),R.updateQueue=t,t.events=[e];else{var l=t.events;l===null?t.events=[e]:l.push(e)}}function wd(e){var t=oe().memoizedState;return bh({ref:t,nextImpl:e}),function(){if(Z&2)throw Error(z(440));return t.impl.apply(void 0,arguments)}}function Nd(e,t){return Iu(4,2,e,t)}function Od(e,t){return Iu(4,4,e,t)}function Cd(e,t){if(typeof t=="function"){e=e();var l=t(e);return function(){typeof l=="function"?l():t(null)}}if(t!=null)return e=e(),t.current=e,function(){t.current=null}}function $d(e,t,l){l=l!=null?l.concat([e]):null,Iu(4,4,Cd.bind(null,t,e),l)}function Of(){}function _d(e,t){var l=oe();t=t===void 0?null:t;var n=l.memoizedState;return t!==null&&Ef(t,n[1])?n[0]:(l.memoizedState=[e,t],e)}function Rd(e,t){var l=oe();t=t===void 0?null:t;var n=l.memoizedState;if(t!==null&&Ef(t,n[1]))return n[0];if(n=e(),Ml){Qt(!0);try{e()}finally{Qt(!1)}}return l.memoizedState=[n,t],n}function Cf(e,t,l){return l===void 0||$t&1073741824&&!(B&261930)?e.memoizedState=t:(e.memoizedState=l,e=E1(),R.lanes|=e,ol|=e,l)}function qd(e,t,l,n){return Ke(l,t)?l:mn.current!==null?(e=Cf(e,l,n),Ke(e,t)||(he=!0),e):!($t&42)||$t&1073741824&&!(B&261930)?(he=!0,e.memoizedState=l):(e=E1(),R.lanes|=e,ol|=e,t)}function Ud(e,t,l,n,a){var u=V.p;V.p=u!==0&&8>u?u:8;var c=C.T,i={};C.T=i,_f(e,!1,t,l);try{var f=a(),s=C.S;if(s!==null&&s(i,f),f!==null&&typeof f=="object"&&typeof f.then=="function"){var d=hh(f,n);Jn(e,t,d,Qe(e))}else Jn(e,t,n,Qe(e))}catch(g){Jn(e,t,{then:function(){},status:"rejected",reason:g},Qe())}finally{V.p=u,c!==null&&i.types!==null&&(c.types=i.types),C.T=c}}function Sh(){}function ji(e,t,l,n){if(e.tag!==5)throw Error(z(476));var a=Hd(e).queue;Ud(e,a,t,bl,l===null?Sh:function(){return Bd(e),l(n)})}function Hd(e){var t=e.memoizedState;if(t!==null)return t;t={memoizedState:bl,baseState:bl,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:_t,lastRenderedState:bl},next:null};var l={};return t.next={memoizedState:l,baseState:l,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:_t,lastRenderedState:l},next:null},e.memoizedState=t,e=e.alternate,e!==null&&(e.memoizedState=t),t}function Bd(e){var t=Hd(e);t.next===null&&(t=e.alternate.memoizedState),Jn(e,t.next.queue,{},Qe())}function $f(){return je(da)}function Xd(){return oe().memoizedState}function Ld(){return oe().memoizedState}function ph(e){for(var t=e.return;t!==null;){switch(t.tag){case 24:case 3:var l=Qe();e=el(l);var n=tl(t,e,l);n!==null&&(Re(n,t,l),Vn(n,t,l)),t={cache:bf()},e.payload=t;return}t=t.return}}function kh(e,t,l){var n=Qe();l={lane:n,revertLane:0,gesture:null,action:l,hasEagerState:!1,eagerState:null,next:null},Pu(e)?Yd(t,l):(l=yf(e,t,l,n),l!==null&&(Re(l,e,n),Zd(l,t,n)))}function Gd(e,t,l){var n=Qe();Jn(e,t,l,n)}function Jn(e,t,l,n){var a={lane:n,revertLane:0,gesture:null,action:l,hasEagerState:!1,eagerState:null,next:null};if(Pu(e))Yd(t,a);else{var u=e.alternate;if(e.lanes===0&&(u===null||u.lanes===0)&&(u=t.lastRenderedReducer,u!==null))try{var c=t.lastRenderedState,i=u(c,l);if(a.hasEagerState=!0,a.eagerState=i,Ke(i,c))return Ku(e,t,a,0),F===null&&Qu(),!1}catch{}finally{}if(l=yf(e,t,a,n),l!==null)return Re(l,e,n),Zd(l,t,n),!0}return!1}function _f(e,t,l,n){if(n={lane:2,revertLane:Yf(),gesture:null,action:n,hasEagerState:!1,eagerState:null,next:null},Pu(e)){if(t)throw Error(z(479))}else t=yf(e,l,n,2),t!==null&&Re(t,e,2)}function Pu(e){var t=e.alternate;return e===R||t!==null&&t===R}function Yd(e,t){cn=zu=!0;var l=e.pending;l===null?t.next=t:(t.next=l.next,l.next=t),e.pending=t}function Zd(e,t,l){if(l&4194048){var n=t.lanes;n&=e.pendingLanes,l|=n,t.lanes=l,wr(e,l)}}var sa={readContext:je,use:Fu,useCallback:ce,useContext:ce,useEffect:ce,useImperativeHandle:ce,useLayoutEffect:ce,useInsertionEffect:ce,useMemo:ce,useReducer:ce,useRef:ce,useState:ce,useDebugValue:ce,useDeferredValue:ce,useTransition:ce,useSyncExternalStore:ce,useId:ce,useHostTransitionStatus:ce,useFormState:ce,useActionState:ce,useOptimistic:ce,useMemoCache:ce,useCacheRefresh:ce};sa.useEffectEvent=ce;var Vd={readContext:je,use:Fu,useCallback:function(e,t){return De().memoizedState=[e,t===void 0?null:t],e},useContext:je,useEffect:Ks,useImperativeHandle:function(e,t,l){l=l!=null?l.concat([e]):null,lu(4194308,4,Cd.bind(null,t,e),l)},useLayoutEffect:function(e,t){return lu(4194308,4,e,t)},useInsertionEffect:function(e,t){lu(4,2,e,t)},useMemo:function(e,t){var l=De();t=t===void 0?null:t;var n=e();if(Ml){Qt(!0);try{e()}finally{Qt(!1)}}return l.memoizedState=[n,t],n},useReducer:function(e,t,l){var n=De();if(l!==void 0){var a=l(t);if(Ml){Qt(!0);try{l(t)}finally{Qt(!1)}}}else a=t;return n.memoizedState=n.baseState=a,e={pending:null,lanes:0,dispatch:null,lastRenderedReducer:e,lastRenderedState:a},n.queue=e,e=e.dispatch=kh.bind(null,R,e),[n.memoizedState,e]},useRef:function(e){var t=De();return e={current:e},t.memoizedState=e},useState:function(e){e=Ei(e);var t=e.queue,l=Gd.bind(null,R,t);return t.dispatch=l,[e.memoizedState,l]},useDebugValue:Of,useDeferredValue:function(e,t){var l=De();return Cf(l,e,t)},useTransition:function(){var e=Ei(!1);return e=Ud.bind(null,R,e.queue,!0,!1),De().memoizedState=e,[!1,e]},useSyncExternalStore:function(e,t,l){var n=R,a=De();if(X){if(l===void 0)throw Error(z(407));l=l()}else{if(l=t(),F===null)throw Error(z(349));B&127||bd(n,t,l)}a.memoizedState=l;var u={value:l,getSnapshot:t};return a.queue=u,Ks(pd.bind(null,n,u,e),[e]),n.flags|=2048,hn(9,{destroy:void 0},Sd.bind(null,n,u,l,t),null),l},useId:function(){var e=De(),t=F.identifierPrefix;if(X){var l=ht,n=mt;l=(n&~(1<<32-Ve(n)-1)).toString(32)+l,t="_"+t+"R_"+l,l=Eu++,0<l&&(t+="H"+l.toString(32)),t+="_"}else l=yh++,t="_"+t+"r_"+l.toString(32)+"_";return e.memoizedState=t},useHostTransitionStatus:$f,useFormState:Zs,useActionState:Zs,useOptimistic:function(e){var t=De();t.memoizedState=t.baseState=e;var l={pending:null,lanes:0,dispatch:null,lastRenderedReducer:null,lastRenderedState:null};return t.queue=l,t=_f.bind(null,R,!0,l),l.dispatch=t,[e,t]},useMemoCache:Df,useCacheRefresh:function(){return De().memoizedState=ph.bind(null,R)},useEffectEvent:function(e){var t=De(),l={impl:e};return t.memoizedState=l,function(){if(Z&2)throw Error(z(440));return l.impl.apply(void 0,arguments)}}},Rf={readContext:je,use:Fu,useCallback:_d,useContext:je,useEffect:Nf,useImperativeHandle:$d,useInsertionEffect:Nd,useLayoutEffect:Od,useMemo:Rd,useReducer:tu,useRef:Dd,useState:function(){return tu(_t)},useDebugValue:Of,useDeferredValue:function(e,t){var l=oe();return qd(l,W.memoizedState,e,t)},useTransition:function(){var e=tu(_t)[0],t=oe().memoizedState;return[typeof e=="boolean"?e:Ea(e),t]},useSyncExternalStore:gd,useId:Xd,useHostTransitionStatus:$f,useFormState:Vs,useActionState:Vs,useOptimistic:function(e,t){var l=oe();return Ed(l,W,e,t)},useMemoCache:Df,useCacheRefresh:Ld};Rf.useEffectEvent=wd;var Qd={readContext:je,use:Fu,useCallback:_d,useContext:je,useEffect:Nf,useImperativeHandle:$d,useInsertionEffect:Nd,useLayoutEffect:Od,useMemo:Rd,useReducer:zc,useRef:Dd,useState:function(){return zc(_t)},useDebugValue:Of,useDeferredValue:function(e,t){var l=oe();return W===null?Cf(l,e,t):qd(l,W.memoizedState,e,t)},useTransition:function(){var e=zc(_t)[0],t=oe().memoizedState;return[typeof e=="boolean"?e:Ea(e),t]},useSyncExternalStore:gd,useId:Xd,useHostTransitionStatus:$f,useFormState:Qs,useActionState:Qs,useOptimistic:function(e,t){var l=oe();return W!==null?Ed(l,W,e,t):(l.baseState=e,[e,l.queue.dispatch])},useMemoCache:Df,useCacheRefresh:Ld};Qd.useEffectEvent=wd;function Ec(e,t,l,n){t=e.memoizedState,l=l(n,t),l=l==null?t:le({},t,l),e.memoizedState=l,e.lanes===0&&(e.updateQueue.baseState=l)}var Mi={enqueueSetState:function(e,t,l){e=e._reactInternals;var n=Qe(),a=el(n);a.payload=t,l!=null&&(a.callback=l),t=tl(e,a,n),t!==null&&(Re(t,e,n),Vn(t,e,n))},enqueueReplaceState:function(e,t,l){e=e._reactInternals;var n=Qe(),a=el(n);a.tag=1,a.payload=t,l!=null&&(a.callback=l),t=tl(e,a,n),t!==null&&(Re(t,e,n),Vn(t,e,n))},enqueueForceUpdate:function(e,t){e=e._reactInternals;var l=Qe(),n=el(l);n.tag=2,t!=null&&(n.callback=t),t=tl(e,n,l),t!==null&&(Re(t,e,l),Vn(t,e,l))}};function Js(e,t,l,n,a,u,c){return e=e.stateNode,typeof e.shouldComponentUpdate=="function"?e.shouldComponentUpdate(n,u,c):t.prototype&&t.prototype.isPureReactComponent?!aa(l,n)||!aa(a,u):!0}function Ws(e,t,l,n){e=t.state,typeof t.componentWillReceiveProps=="function"&&t.componentWillReceiveProps(l,n),typeof t.UNSAFE_componentWillReceiveProps=="function"&&t.UNSAFE_componentWillReceiveProps(l,n),t.state!==e&&Mi.enqueueReplaceState(t,t.state,null)}function Al(e,t){var l=t;if("ref"in t){l={};for(var n in t)n!=="ref"&&(l[n]=t[n])}if(e=e.defaultProps){l===t&&(l=le({},l));for(var a in e)l[a]===void 0&&(l[a]=e[a])}return l}function Kd(e){vu(e)}function Jd(e){console.error(e)}function Wd(e){vu(e)}function Tu(e,t){try{var l=e.onUncaughtError;l(t.value,{componentStack:t.stack})}catch(n){setTimeout(function(){throw n})}}function Fs(e,t,l){try{var n=e.onCaughtError;n(l.value,{componentStack:l.stack,errorBoundary:t.tag===1?t.stateNode:null})}catch(a){setTimeout(function(){throw a})}}function Ai(e,t,l){return l=el(l),l.tag=3,l.payload={element:null},l.callback=function(){Tu(e,t)},l}function Fd(e){return e=el(e),e.tag=3,e}function Id(e,t,l,n){var a=l.type.getDerivedStateFromError;if(typeof a=="function"){var u=n.value;e.payload=function(){return a(u)},e.callback=function(){Fs(t,l,n)}}var c=l.stateNode;c!==null&&typeof c.componentDidCatch=="function"&&(e.callback=function(){Fs(t,l,n),typeof a!="function"&&(ll===null?ll=new Set([this]):ll.add(this));var i=n.stack;this.componentDidCatch(n.value,{componentStack:i!==null?i:""})})}function zh(e,t,l,n,a){if(l.flags|=32768,n!==null&&typeof n=="object"&&typeof n.then=="function"){if(t=l.alternate,t!==null&&zn(t,l,a,!0),l=Je.current,l!==null){switch(l.tag){case 31:case 13:return ut===null?wu():l.alternate===null&&ie===0&&(ie=3),l.flags&=-257,l.flags|=65536,l.lanes=a,n===Su?l.flags|=16384:(t=l.updateQueue,t===null?l.updateQueue=new Set([n]):t.add(n),_c(e,n,a)),!1;case 22:return l.flags|=65536,n===Su?l.flags|=16384:(t=l.updateQueue,t===null?(t={transitions:null,markerInstances:null,retryQueue:new Set([n])},l.updateQueue=t):(l=t.retryQueue,l===null?t.retryQueue=new Set([n]):l.add(n)),_c(e,n,a)),!1}throw Error(z(435,l.tag))}return _c(e,n,a),wu(),!1}if(X)return t=Je.current,t!==null?(!(t.flags&65536)&&(t.flags|=256),t.flags|=65536,t.lanes=a,n!==yi&&(e=Error(z(422),{cause:n}),ca(nt(e,l)))):(n!==yi&&(t=Error(z(423),{cause:n}),ca(nt(t,l))),e=e.current.alternate,e.flags|=65536,a&=-a,e.lanes|=a,n=nt(n,l),a=Ai(e.stateNode,n,a),kc(e,a),ie!==4&&(ie=2)),!1;var u=Error(z(520),{cause:n});if(u=nt(u,l),In===null?In=[u]:In.push(u),ie!==4&&(ie=2),t===null)return!0;n=nt(n,l),l=t;do{switch(l.tag){case 3:return l.flags|=65536,e=a&-a,l.lanes|=e,e=Ai(l.stateNode,n,e),kc(l,e),!1;case 1:if(t=l.type,u=l.stateNode,(l.flags&128)===0&&(typeof t.getDerivedStateFromError=="function"||u!==null&&typeof u.componentDidCatch=="function"&&(ll===null||!ll.has(u))))return l.flags|=65536,a&=-a,l.lanes|=a,a=Fd(a),Id(a,e,l,n),kc(l,a),!1}l=l.return}while(l!==null);return!1}var qf=Error(z(461)),he=!1;function ze(e,t,l,n){t.child=e===null?dd(t,null,l,n):jl(t,e.child,l,n)}function Is(e,t,l,n,a){l=l.render;var u=t.ref;if("ref"in n){var c={};for(var i in n)i!=="ref"&&(c[i]=n[i])}else c=n;return Tl(t),n=Tf(e,t,l,c,u,a),i=jf(),e!==null&&!he?(Mf(e,t,a),Rt(e,t,a)):(X&&i&&xf(t),t.flags|=1,ze(e,t,n,a),t.child)}function Ps(e,t,l,n,a){if(e===null){var u=l.type;return typeof u=="function"&&!vf(u)&&u.defaultProps===void 0&&l.compare===null?(t.tag=15,t.type=u,Pd(e,t,u,n,a)):(e=Pa(l.type,null,n,t,t.mode,a),e.ref=t.ref,e.return=t,t.child=e)}if(u=e.child,!Uf(e,a)){var c=u.memoizedProps;if(l=l.compare,l=l!==null?l:aa,l(c,n)&&e.ref===t.ref)return Rt(e,t,a)}return t.flags|=1,e=wt(u,n),e.ref=t.ref,e.return=t,t.child=e}function Pd(e,t,l,n,a){if(e!==null){var u=e.memoizedProps;if(aa(u,n)&&e.ref===t.ref)if(he=!1,t.pendingProps=n=u,Uf(e,a))e.flags&131072&&(he=!0);else return t.lanes=e.lanes,Rt(e,t,a)}return Di(e,t,l,n,a)}function e1(e,t,l,n){var a=n.children,u=e!==null?e.memoizedState:null;if(e===null&&t.stateNode===null&&(t.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),n.mode==="hidden"){if(t.flags&128){if(u=u!==null?u.baseLanes|l:l,e!==null){for(n=t.child=e.child,a=0;n!==null;)a=a|n.lanes|n.childLanes,n=n.sibling;n=a&~u}else n=0,t.child=null;return eo(e,t,u,l,n)}if(l&536870912)t.memoizedState={baseLanes:0,cachePool:null},e!==null&&eu(t,u!==null?u.cachePool:null),u!==null?Ls(t,u):ki(),yd(t);else return n=t.lanes=536870912,eo(e,t,u!==null?u.baseLanes|l:l,l,n)}else u!==null?(eu(t,u.cachePool),Ls(t,u),Zt(),t.memoizedState=null):(e!==null&&eu(t,null),ki(),Zt());return ze(e,t,a,l),t.child}function Hn(e,t){return e!==null&&e.tag===22||t.stateNode!==null||(t.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),t.sibling}function eo(e,t,l,n,a){var u=Sf();return u=u===null?null:{parent:me._currentValue,pool:u},t.memoizedState={baseLanes:l,cachePool:u},e!==null&&eu(t,null),ki(),yd(t),e!==null&&zn(e,t,n,!0),t.childLanes=a,null}function nu(e,t){return t=ju({mode:t.mode,children:t.children},e.mode),t.ref=e.ref,e.child=t,t.return=e,t}function to(e,t,l){return jl(t,e.child,null,l),e=nu(t,t.pendingProps),e.flags|=2,Xe(t),t.memoizedState=null,e}function Eh(e,t,l){var n=t.pendingProps,a=(t.flags&128)!==0;if(t.flags&=-129,e===null){if(X){if(n.mode==="hidden")return e=nu(t,n),t.lanes=536870912,Hn(null,e);if(zi(t),(e=ee)?(e=V1(e,at),e=e!==null&&e.data==="&"?e:null,e!==null&&(t.memoizedState={dehydrated:e,treeContext:il!==null?{id:mt,overflow:ht}:null,retryLane:536870912,hydrationErrors:null},l=ud(e),l.return=t,t.child=l,Te=t,ee=null)):e=null,e===null)throw fl(t);return t.lanes=536870912,null}return nu(t,n)}var u=e.memoizedState;if(u!==null){var c=u.dehydrated;if(zi(t),a)if(t.flags&256)t.flags&=-257,t=to(e,t,l);else if(t.memoizedState!==null)t.child=e.child,t.flags|=128,t=null;else throw Error(z(558));else if(he||zn(e,t,l,!1),a=(l&e.childLanes)!==0,he||a){if(n=F,n!==null&&(c=Nr(n,l),c!==0&&c!==u.retryLane))throw u.retryLane=c,Ol(e,c),Re(n,e,c),qf;wu(),t=to(e,t,l)}else e=u.treeContext,ee=ct(c.nextSibling),Te=t,X=!0,Pt=null,at=!1,e!==null&&id(t,e),t=nu(t,n),t.flags|=4096;return t}return e=wt(e.child,{mode:n.mode,children:n.children}),e.ref=t.ref,t.child=e,e.return=t,e}function au(e,t){var l=t.ref;if(l===null)e!==null&&e.ref!==null&&(t.flags|=4194816);else{if(typeof l!="function"&&typeof l!="object")throw Error(z(284));(e===null||e.ref!==l)&&(t.flags|=4194816)}}function Di(e,t,l,n,a){return Tl(t),l=Tf(e,t,l,n,void 0,a),n=jf(),e!==null&&!he?(Mf(e,t,a),Rt(e,t,a)):(X&&n&&xf(t),t.flags|=1,ze(e,t,l,a),t.child)}function lo(e,t,l,n,a,u){return Tl(t),t.updateQueue=null,l=xd(t,n,l,a),vd(e),n=jf(),e!==null&&!he?(Mf(e,t,u),Rt(e,t,u)):(X&&n&&xf(t),t.flags|=1,ze(e,t,l,u),t.child)}function no(e,t,l,n,a){if(Tl(t),t.stateNode===null){var u=Wl,c=l.contextType;typeof c=="object"&&c!==null&&(u=je(c)),u=new l(n,u),t.memoizedState=u.state!==null&&u.state!==void 0?u.state:null,u.updater=Mi,t.stateNode=u,u._reactInternals=t,u=t.stateNode,u.props=n,u.state=t.memoizedState,u.refs={},kf(t),c=l.contextType,u.context=typeof c=="object"&&c!==null?je(c):Wl,u.state=t.memoizedState,c=l.getDerivedStateFromProps,typeof c=="function"&&(Ec(t,l,c,n),u.state=t.memoizedState),typeof l.getDerivedStateFromProps=="function"||typeof u.getSnapshotBeforeUpdate=="function"||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(c=u.state,typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount(),c!==u.state&&Mi.enqueueReplaceState(u,u.state,null),Kn(t,n,u,a),Qn(),u.state=t.memoizedState),typeof u.componentDidMount=="function"&&(t.flags|=4194308),n=!0}else if(e===null){u=t.stateNode;var i=t.memoizedProps,f=Al(l,i);u.props=f;var s=u.context,d=l.contextType;c=Wl,typeof d=="object"&&d!==null&&(c=je(d));var g=l.getDerivedStateFromProps;d=typeof g=="function"||typeof u.getSnapshotBeforeUpdate=="function",i=t.pendingProps!==i,d||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(i||s!==c)&&Ws(t,u,n,c),Lt=!1;var r=t.memoizedState;u.state=r,Kn(t,n,u,a),Qn(),s=t.memoizedState,i||r!==s||Lt?(typeof g=="function"&&(Ec(t,l,g,n),s=t.memoizedState),(f=Lt||Js(t,l,f,n,r,s,c))?(d||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount()),typeof u.componentDidMount=="function"&&(t.flags|=4194308)):(typeof u.componentDidMount=="function"&&(t.flags|=4194308),t.memoizedProps=n,t.memoizedState=s),u.props=n,u.state=s,u.context=c,n=f):(typeof u.componentDidMount=="function"&&(t.flags|=4194308),n=!1)}else{u=t.stateNode,Si(e,t),c=t.memoizedProps,d=Al(l,c),u.props=d,g=t.pendingProps,r=u.context,s=l.contextType,f=Wl,typeof s=="object"&&s!==null&&(f=je(s)),i=l.getDerivedStateFromProps,(s=typeof i=="function"||typeof u.getSnapshotBeforeUpdate=="function")||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(c!==g||r!==f)&&Ws(t,u,n,f),Lt=!1,r=t.memoizedState,u.state=r,Kn(t,n,u,a),Qn();var x=t.memoizedState;c!==g||r!==x||Lt||e!==null&&e.dependencies!==null&&bu(e.dependencies)?(typeof i=="function"&&(Ec(t,l,i,n),x=t.memoizedState),(d=Lt||Js(t,l,d,n,r,x,f)||e!==null&&e.dependencies!==null&&bu(e.dependencies))?(s||typeof u.UNSAFE_componentWillUpdate!="function"&&typeof u.componentWillUpdate!="function"||(typeof u.componentWillUpdate=="function"&&u.componentWillUpdate(n,x,f),typeof u.UNSAFE_componentWillUpdate=="function"&&u.UNSAFE_componentWillUpdate(n,x,f)),typeof u.componentDidUpdate=="function"&&(t.flags|=4),typeof u.getSnapshotBeforeUpdate=="function"&&(t.flags|=1024)):(typeof u.componentDidUpdate!="function"||c===e.memoizedProps&&r===e.memoizedState||(t.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||c===e.memoizedProps&&r===e.memoizedState||(t.flags|=1024),t.memoizedProps=n,t.memoizedState=x),u.props=n,u.state=x,u.context=f,n=d):(typeof u.componentDidUpdate!="function"||c===e.memoizedProps&&r===e.memoizedState||(t.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||c===e.memoizedProps&&r===e.memoizedState||(t.flags|=1024),n=!1)}return u=n,au(e,t),n=(t.flags&128)!==0,u||n?(u=t.stateNode,l=n&&typeof l.getDerivedStateFromError!="function"?null:u.render(),t.flags|=1,e!==null&&n?(t.child=jl(t,e.child,null,a),t.child=jl(t,null,l,a)):ze(e,t,l,a),t.memoizedState=u.state,e=t.child):e=Rt(e,t,a),e}function ao(e,t,l,n){return El(),t.flags|=256,ze(e,t,l,n),t.child}var Tc={dehydrated:null,treeContext:null,retryLane:0,hydrationErrors:null};function jc(e){return{baseLanes:e,cachePool:sd()}}function Mc(e,t,l){return e=e!==null?e.childLanes&~l:0,t&&(e|=Ge),e}function t1(e,t,l){var n=t.pendingProps,a=!1,u=(t.flags&128)!==0,c;if((c=u)||(c=e!==null&&e.memoizedState===null?!1:(se.current&2)!==0),c&&(a=!0,t.flags&=-129),c=(t.flags&32)!==0,t.flags&=-33,e===null){if(X){if(a?Yt(t):Zt(),(e=ee)?(e=V1(e,at),e=e!==null&&e.data!=="&"?e:null,e!==null&&(t.memoizedState={dehydrated:e,treeContext:il!==null?{id:mt,overflow:ht}:null,retryLane:536870912,hydrationErrors:null},l=ud(e),l.return=t,t.child=l,Te=t,ee=null)):e=null,e===null)throw fl(t);return Gi(e)?t.lanes=32:t.lanes=536870912,null}var i=n.children;return n=n.fallback,a?(Zt(),a=t.mode,i=ju({mode:"hidden",children:i},a),n=Sl(n,a,l,null),i.return=t,n.return=t,i.sibling=n,t.child=i,n=t.child,n.memoizedState=jc(l),n.childLanes=Mc(e,c,l),t.memoizedState=Tc,Hn(null,n)):(Yt(t),wi(t,i))}var f=e.memoizedState;if(f!==null&&(i=f.dehydrated,i!==null)){if(u)t.flags&256?(Yt(t),t.flags&=-257,t=Ac(e,t,l)):t.memoizedState!==null?(Zt(),t.child=e.child,t.flags|=128,t=null):(Zt(),i=n.fallback,a=t.mode,n=ju({mode:"visible",children:n.children},a),i=Sl(i,a,l,null),i.flags|=2,n.return=t,i.return=t,n.sibling=i,t.child=n,jl(t,e.child,null,l),n=t.child,n.memoizedState=jc(l),n.childLanes=Mc(e,c,l),t.memoizedState=Tc,t=Hn(null,n));else if(Yt(t),Gi(i)){if(c=i.nextSibling&&i.nextSibling.dataset,c)var s=c.dgst;c=s,n=Error(z(419)),n.stack="",n.digest=c,ca({value:n,source:null,stack:null}),t=Ac(e,t,l)}else if(he||zn(e,t,l,!1),c=(l&e.childLanes)!==0,he||c){if(c=F,c!==null&&(n=Nr(c,l),n!==0&&n!==f.retryLane))throw f.retryLane=n,Ol(e,n),Re(c,e,n),qf;Li(i)||wu(),t=Ac(e,t,l)}else Li(i)?(t.flags|=192,t.child=e.child,t=null):(e=f.treeContext,ee=ct(i.nextSibling),Te=t,X=!0,Pt=null,at=!1,e!==null&&id(t,e),t=wi(t,n.children),t.flags|=4096);return t}return a?(Zt(),i=n.fallback,a=t.mode,f=e.child,s=f.sibling,n=wt(f,{mode:"hidden",children:n.children}),n.subtreeFlags=f.subtreeFlags&65011712,s!==null?i=wt(s,i):(i=Sl(i,a,l,null),i.flags|=2),i.return=t,n.return=t,n.sibling=i,t.child=n,Hn(null,n),n=t.child,i=e.child.memoizedState,i===null?i=jc(l):(a=i.cachePool,a!==null?(f=me._currentValue,a=a.parent!==f?{parent:f,pool:f}:a):a=sd(),i={baseLanes:i.baseLanes|l,cachePool:a}),n.memoizedState=i,n.childLanes=Mc(e,c,l),t.memoizedState=Tc,Hn(e.child,n)):(Yt(t),l=e.child,e=l.sibling,l=wt(l,{mode:"visible",children:n.children}),l.return=t,l.sibling=null,e!==null&&(c=t.deletions,c===null?(t.deletions=[e],t.flags|=16):c.push(e)),t.child=l,t.memoizedState=null,l)}function wi(e,t){return t=ju({mode:"visible",children:t},e.mode),t.return=e,e.child=t}function ju(e,t){return e=Le(22,e,null,t),e.lanes=0,e}function Ac(e,t,l){return jl(t,e.child,null,l),e=wi(t,t.pendingProps.children),e.flags|=2,t.memoizedState=null,e}function uo(e,t,l){e.lanes|=t;var n=e.alternate;n!==null&&(n.lanes|=t),xi(e.return,t,l)}function Dc(e,t,l,n,a,u){var c=e.memoizedState;c===null?e.memoizedState={isBackwards:t,rendering:null,renderingStartTime:0,last:n,tail:l,tailMode:a,treeForkCount:u}:(c.isBackwards=t,c.rendering=null,c.renderingStartTime=0,c.last=n,c.tail=l,c.tailMode=a,c.treeForkCount=u)}function l1(e,t,l){var n=t.pendingProps,a=n.revealOrder,u=n.tail;n=n.children;var c=se.current,i=(c&2)!==0;if(i?(c=c&1|2,t.flags|=128):c&=1,I(se,c),ze(e,t,n,l),n=X?ua:0,!i&&e!==null&&e.flags&128)e:for(e=t.child;e!==null;){if(e.tag===13)e.memoizedState!==null&&uo(e,l,t);else if(e.tag===19)uo(e,l,t);else if(e.child!==null){e.child.return=e,e=e.child;continue}if(e===t)break e;for(;e.sibling===null;){if(e.return===null||e.return===t)break e;e=e.return}e.sibling.return=e.return,e=e.sibling}switch(a){case"forwards":for(l=t.child,a=null;l!==null;)e=l.alternate,e!==null&&ku(e)===null&&(a=l),l=l.sibling;l=a,l===null?(a=t.child,t.child=null):(a=l.sibling,l.sibling=null),Dc(t,!1,a,l,u,n);break;case"backwards":case"unstable_legacy-backwards":for(l=null,a=t.child,t.child=null;a!==null;){if(e=a.alternate,e!==null&&ku(e)===null){t.child=a;break}e=a.sibling,a.sibling=l,l=a,a=e}Dc(t,!0,l,null,u,n);break;case"together":Dc(t,!1,null,null,void 0,n);break;default:t.memoizedState=null}return t.child}function Rt(e,t,l){if(e!==null&&(t.dependencies=e.dependencies),ol|=t.lanes,!(l&t.childLanes))if(e!==null){if(zn(e,t,l,!1),(l&t.childLanes)===0)return null}else return null;if(e!==null&&t.child!==e.child)throw Error(z(153));if(t.child!==null){for(e=t.child,l=wt(e,e.pendingProps),t.child=l,l.return=t;e.sibling!==null;)e=e.sibling,l=l.sibling=wt(e,e.pendingProps),l.return=t;l.sibling=null}return t.child}function Uf(e,t){return e.lanes&t?!0:(e=e.dependencies,!!(e!==null&&bu(e)))}function Th(e,t,l){switch(t.tag){case 3:du(t,t.stateNode.containerInfo),Gt(t,me,e.memoizedState.cache),El();break;case 27:case 5:ai(t);break;case 4:du(t,t.stateNode.containerInfo);break;case 10:Gt(t,t.type,t.memoizedProps.value);break;case 31:if(t.memoizedState!==null)return t.flags|=128,zi(t),null;break;case 13:var n=t.memoizedState;if(n!==null)return n.dehydrated!==null?(Yt(t),t.flags|=128,null):l&t.child.childLanes?t1(e,t,l):(Yt(t),e=Rt(e,t,l),e!==null?e.sibling:null);Yt(t);break;case 19:var a=(e.flags&128)!==0;if(n=(l&t.childLanes)!==0,n||(zn(e,t,l,!1),n=(l&t.childLanes)!==0),a){if(n)return l1(e,t,l);t.flags|=128}if(a=t.memoizedState,a!==null&&(a.rendering=null,a.tail=null,a.lastEffect=null),I(se,se.current),n)break;return null;case 22:return t.lanes=0,e1(e,t,l,t.pendingProps);case 24:Gt(t,me,e.memoizedState.cache)}return Rt(e,t,l)}function n1(e,t,l){if(e!==null)if(e.memoizedProps!==t.pendingProps)he=!0;else{if(!Uf(e,l)&&!(t.flags&128))return he=!1,Th(e,t,l);he=!!(e.flags&131072)}else he=!1,X&&t.flags&1048576&&cd(t,ua,t.index);switch(t.lanes=0,t.tag){case 16:e:{var n=t.pendingProps;if(e=xl(t.elementType),t.type=e,typeof e=="function")vf(e)?(n=Al(e,n),t.tag=1,t=no(null,t,e,n,l)):(t.tag=0,t=Di(null,t,e,n,l));else{if(e!=null){var a=e.$$typeof;if(a===tf){t.tag=11,t=Is(null,t,e,n,l);break e}else if(a===lf){t.tag=14,t=Ps(null,t,e,n,l);break e}}throw t=li(e)||e,Error(z(306,t,""))}}return t;case 0:return Di(e,t,t.type,t.pendingProps,l);case 1:return n=t.type,a=Al(n,t.pendingProps),no(e,t,n,a,l);case 3:e:{if(du(t,t.stateNode.containerInfo),e===null)throw Error(z(387));n=t.pendingProps;var u=t.memoizedState;a=u.element,Si(e,t),Kn(t,n,null,l);var c=t.memoizedState;if(n=c.cache,Gt(t,me,n),n!==u.cache&&gi(t,[me],l,!0),Qn(),n=c.element,u.isDehydrated)if(u={element:n,isDehydrated:!1,cache:c.cache},t.updateQueue.baseState=u,t.memoizedState=u,t.flags&256){t=ao(e,t,n,l);break e}else if(n!==a){a=nt(Error(z(424)),t),ca(a),t=ao(e,t,n,l);break e}else{switch(e=t.stateNode.containerInfo,e.nodeType){case 9:e=e.body;break;default:e=e.nodeName==="HTML"?e.ownerDocument.body:e}for(ee=ct(e.firstChild),Te=t,X=!0,Pt=null,at=!0,l=dd(t,null,n,l),t.child=l;l;)l.flags=l.flags&-3|4096,l=l.sibling}else{if(El(),n===a){t=Rt(e,t,l);break e}ze(e,t,n,l)}t=t.child}return t;case 26:return au(e,t),e===null?(l=jo(t.type,null,t.pendingProps,null))?t.memoizedState=l:X||(l=t.type,e=t.pendingProps,n=$u(It.current).createElement(l),n[Ee]=t,n[qe]=e,Me(n,l,e),ge(n),t.stateNode=n):t.memoizedState=jo(t.type,e.memoizedProps,t.pendingProps,e.memoizedState),null;case 27:return ai(t),e===null&&X&&(n=t.stateNode=Q1(t.type,t.pendingProps,It.current),Te=t,at=!0,a=ee,dl(t.type)?(Yi=a,ee=ct(n.firstChild)):ee=a),ze(e,t,t.pendingProps.children,l),au(e,t),e===null&&(t.flags|=4194304),t.child;case 5:return e===null&&X&&((a=n=ee)&&(n=ty(n,t.type,t.pendingProps,at),n!==null?(t.stateNode=n,Te=t,ee=ct(n.firstChild),at=!1,a=!0):a=!1),a||fl(t)),ai(t),a=t.type,u=t.pendingProps,c=e!==null?e.memoizedProps:null,n=u.children,Bi(a,u)?n=null:c!==null&&Bi(a,c)&&(t.flags|=32),t.memoizedState!==null&&(a=Tf(e,t,vh,null,null,l),da._currentValue=a),au(e,t),ze(e,t,n,l),t.child;case 6:return e===null&&X&&((e=l=ee)&&(l=ly(l,t.pendingProps,at),l!==null?(t.stateNode=l,Te=t,ee=null,e=!0):e=!1),e||fl(t)),null;case 13:return t1(e,t,l);case 4:return du(t,t.stateNode.containerInfo),n=t.pendingProps,e===null?t.child=jl(t,null,n,l):ze(e,t,n,l),t.child;case 11:return Is(e,t,t.type,t.pendingProps,l);case 7:return ze(e,t,t.pendingProps,l),t.child;case 8:return ze(e,t,t.pendingProps.children,l),t.child;case 12:return ze(e,t,t.pendingProps.children,l),t.child;case 10:return n=t.pendingProps,Gt(t,t.type,n.value),ze(e,t,n.children,l),t.child;case 9:return a=t.type._context,n=t.pendingProps.children,Tl(t),a=je(a),n=n(a),t.flags|=1,ze(e,t,n,l),t.child;case 14:return Ps(e,t,t.type,t.pendingProps,l);case 15:return Pd(e,t,t.type,t.pendingProps,l);case 19:return l1(e,t,l);case 31:return Eh(e,t,l);case 22:return e1(e,t,l,t.pendingProps);case 24:return Tl(t),n=je(me),e===null?(a=Sf(),a===null&&(a=F,u=bf(),a.pooledCache=u,u.refCount++,u!==null&&(a.pooledCacheLanes|=l),a=u),t.memoizedState={parent:n,cache:a},kf(t),Gt(t,me,a)):(e.lanes&l&&(Si(e,t),Kn(t,null,null,l),Qn()),a=e.memoizedState,u=t.memoizedState,a.parent!==n?(a={parent:n,cache:n},t.memoizedState=a,t.lanes===0&&(t.memoizedState=t.updateQueue.baseState=a),Gt(t,me,n)):(n=u.cache,Gt(t,me,n),n!==a.cache&&gi(t,[me],l,!0))),ze(e,t,t.pendingProps.children,l),t.child;case 29:throw t.pendingProps}throw Error(z(156,t.tag))}function pt(e){e.flags|=4}function wc(e,t,l,n,a){if((t=(e.mode&32)!==0)&&(t=!1),t){if(e.flags|=16777216,(a&335544128)===a)if(e.stateNode.complete)e.flags|=8192;else if(M1())e.flags|=8192;else throw kl=Su,pf}else e.flags&=-16777217}function co(e,t){if(t.type!=="stylesheet"||t.state.loading&4)e.flags&=-16777217;else if(e.flags|=16777216,!W1(t))if(M1())e.flags|=8192;else throw kl=Su,pf}function Ha(e,t){t!==null&&(e.flags|=4),e.flags&16384&&(t=e.tag!==22?Ar():536870912,e.lanes|=t,yn|=t)}function On(e,t){if(!X)switch(e.tailMode){case"hidden":t=e.tail;for(var l=null;t!==null;)t.alternate!==null&&(l=t),t=t.sibling;l===null?e.tail=null:l.sibling=null;break;case"collapsed":l=e.tail;for(var n=null;l!==null;)l.alternate!==null&&(n=l),l=l.sibling;n===null?t||e.tail===null?e.tail=null:e.tail.sibling=null:n.sibling=null}}function P(e){var t=e.alternate!==null&&e.alternate.child===e.child,l=0,n=0;if(t)for(var a=e.child;a!==null;)l|=a.lanes|a.childLanes,n|=a.subtreeFlags&65011712,n|=a.flags&65011712,a.return=e,a=a.sibling;else for(a=e.child;a!==null;)l|=a.lanes|a.childLanes,n|=a.subtreeFlags,n|=a.flags,a.return=e,a=a.sibling;return e.subtreeFlags|=n,e.childLanes=l,t}function jh(e,t,l){var n=t.pendingProps;switch(gf(t),t.tag){case 16:case 15:case 0:case 11:case 7:case 8:case 12:case 9:case 14:return P(t),null;case 1:return P(t),null;case 3:return l=t.stateNode,n=null,e!==null&&(n=e.memoizedState.cache),t.memoizedState.cache!==n&&(t.flags|=2048),Nt(me),sn(),l.pendingContext&&(l.context=l.pendingContext,l.pendingContext=null),(e===null||e.child===null)&&($l(t)?pt(t):e===null||e.memoizedState.isDehydrated&&!(t.flags&256)||(t.flags|=1024,pc())),P(t),null;case 26:var a=t.type,u=t.memoizedState;return e===null?(pt(t),u!==null?(P(t),co(t,u)):(P(t),wc(t,a,null,n,l))):u?u!==e.memoizedState?(pt(t),P(t),co(t,u)):(P(t),t.flags&=-16777217):(e=e.memoizedProps,e!==n&&pt(t),P(t),wc(t,a,e,n,l)),null;case 27:if(mu(t),l=It.current,a=t.type,e!==null&&t.stateNode!=null)e.memoizedProps!==n&&pt(t);else{if(!n){if(t.stateNode===null)throw Error(z(166));return P(t),null}e=vt.current,$l(t)?_s(t):(e=Q1(a,n,l),t.stateNode=e,pt(t))}return P(t),null;case 5:if(mu(t),a=t.type,e!==null&&t.stateNode!=null)e.memoizedProps!==n&&pt(t);else{if(!n){if(t.stateNode===null)throw Error(z(166));return P(t),null}if(u=vt.current,$l(t))_s(t);else{var c=$u(It.current);switch(u){case 1:u=c.createElementNS("http://www.w3.org/2000/svg",a);break;case 2:u=c.createElementNS("http://www.w3.org/1998/Math/MathML",a);break;default:switch(a){case"svg":u=c.createElementNS("http://www.w3.org/2000/svg",a);break;case"math":u=c.createElementNS("http://www.w3.org/1998/Math/MathML",a);break;case"script":u=c.createElement("div"),u.innerHTML="<script><\/script>",u=u.removeChild(u.firstChild);break;case"select":u=typeof n.is=="string"?c.createElement("select",{is:n.is}):c.createElement("select"),n.multiple?u.multiple=!0:n.size&&(u.size=n.size);break;default:u=typeof n.is=="string"?c.createElement(a,{is:n.is}):c.createElement(a)}}u[Ee]=t,u[qe]=n;e:for(c=t.child;c!==null;){if(c.tag===5||c.tag===6)u.appendChild(c.stateNode);else if(c.tag!==4&&c.tag!==27&&c.child!==null){c.child.return=c,c=c.child;continue}if(c===t)break e;for(;c.sibling===null;){if(c.return===null||c.return===t)break e;c=c.return}c.sibling.return=c.return,c=c.sibling}t.stateNode=u;e:switch(Me(u,a,n),a){case"button":case"input":case"select":case"textarea":n=!!n.autoFocus;break e;case"img":n=!0;break e;default:n=!1}n&&pt(t)}}return P(t),wc(t,t.type,e===null?null:e.memoizedProps,t.pendingProps,l),null;case 6:if(e&&t.stateNode!=null)e.memoizedProps!==n&&pt(t);else{if(typeof n!="string"&&t.stateNode===null)throw Error(z(166));if(e=It.current,$l(t)){if(e=t.stateNode,l=t.memoizedProps,n=null,a=Te,a!==null)switch(a.tag){case 27:case 5:n=a.memoizedProps}e[Ee]=t,e=!!(e.nodeValue===l||n!==null&&n.suppressHydrationWarning===!0||G1(e.nodeValue,l)),e||fl(t,!0)}else e=$u(e).createTextNode(n),e[Ee]=t,t.stateNode=e}return P(t),null;case 31:if(l=t.memoizedState,e===null||e.memoizedState!==null){if(n=$l(t),l!==null){if(e===null){if(!n)throw Error(z(318));if(e=t.memoizedState,e=e!==null?e.dehydrated:null,!e)throw Error(z(557));e[Ee]=t}else El(),!(t.flags&128)&&(t.memoizedState=null),t.flags|=4;P(t),e=!1}else l=pc(),e!==null&&e.memoizedState!==null&&(e.memoizedState.hydrationErrors=l),e=!0;if(!e)return t.flags&256?(Xe(t),t):(Xe(t),null);if(t.flags&128)throw Error(z(558))}return P(t),null;case 13:if(n=t.memoizedState,e===null||e.memoizedState!==null&&e.memoizedState.dehydrated!==null){if(a=$l(t),n!==null&&n.dehydrated!==null){if(e===null){if(!a)throw Error(z(318));if(a=t.memoizedState,a=a!==null?a.dehydrated:null,!a)throw Error(z(317));a[Ee]=t}else El(),!(t.flags&128)&&(t.memoizedState=null),t.flags|=4;P(t),a=!1}else a=pc(),e!==null&&e.memoizedState!==null&&(e.memoizedState.hydrationErrors=a),a=!0;if(!a)return t.flags&256?(Xe(t),t):(Xe(t),null)}return Xe(t),t.flags&128?(t.lanes=l,t):(l=n!==null,e=e!==null&&e.memoizedState!==null,l&&(n=t.child,a=null,n.alternate!==null&&n.alternate.memoizedState!==null&&n.alternate.memoizedState.cachePool!==null&&(a=n.alternate.memoizedState.cachePool.pool),u=null,n.memoizedState!==null&&n.memoizedState.cachePool!==null&&(u=n.memoizedState.cachePool.pool),u!==a&&(n.flags|=2048)),l!==e&&l&&(t.child.flags|=8192),Ha(t,t.updateQueue),P(t),null);case 4:return sn(),e===null&&Zf(t.stateNode.containerInfo),P(t),null;case 10:return Nt(t.type),P(t),null;case 19:if(be(se),n=t.memoizedState,n===null)return P(t),null;if(a=(t.flags&128)!==0,u=n.rendering,u===null)if(a)On(n,!1);else{if(ie!==0||e!==null&&e.flags&128)for(e=t.child;e!==null;){if(u=ku(e),u!==null){for(t.flags|=128,On(n,!1),e=u.updateQueue,t.updateQueue=e,Ha(t,e),t.subtreeFlags=0,e=l,l=t.child;l!==null;)ad(l,e),l=l.sibling;return I(se,se.current&1|2),X&&Tt(t,n.treeForkCount),t.child}e=e.sibling}n.tail!==null&&Ye()>Au&&(t.flags|=128,a=!0,On(n,!1),t.lanes=4194304)}else{if(!a)if(e=ku(u),e!==null){if(t.flags|=128,a=!0,e=e.updateQueue,t.updateQueue=e,Ha(t,e),On(n,!0),n.tail===null&&n.tailMode==="hidden"&&!u.alternate&&!X)return P(t),null}else 2*Ye()-n.renderingStartTime>Au&&l!==536870912&&(t.flags|=128,a=!0,On(n,!1),t.lanes=4194304);n.isBackwards?(u.sibling=t.child,t.child=u):(e=n.last,e!==null?e.sibling=u:t.child=u,n.last=u)}return n.tail!==null?(e=n.tail,n.rendering=e,n.tail=e.sibling,n.renderingStartTime=Ye(),e.sibling=null,l=se.current,I(se,a?l&1|2:l&1),X&&Tt(t,n.treeForkCount),e):(P(t),null);case 22:case 23:return Xe(t),zf(),n=t.memoizedState!==null,e!==null?e.memoizedState!==null!==n&&(t.flags|=8192):n&&(t.flags|=8192),n?l&536870912&&!(t.flags&128)&&(P(t),t.subtreeFlags&6&&(t.flags|=8192)):P(t),l=t.updateQueue,l!==null&&Ha(t,l.retryQueue),l=null,e!==null&&e.memoizedState!==null&&e.memoizedState.cachePool!==null&&(l=e.memoizedState.cachePool.pool),n=null,t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(n=t.memoizedState.cachePool.pool),n!==l&&(t.flags|=2048),e!==null&&be(pl),null;case 24:return l=null,e!==null&&(l=e.memoizedState.cache),t.memoizedState.cache!==l&&(t.flags|=2048),Nt(me),P(t),null;case 25:return null;case 30:return null}throw Error(z(156,t.tag))}function Mh(e,t){switch(gf(t),t.tag){case 1:return e=t.flags,e&65536?(t.flags=e&-65537|128,t):null;case 3:return Nt(me),sn(),e=t.flags,e&65536&&!(e&128)?(t.flags=e&-65537|128,t):null;case 26:case 27:case 5:return mu(t),null;case 31:if(t.memoizedState!==null){if(Xe(t),t.alternate===null)throw Error(z(340));El()}return e=t.flags,e&65536?(t.flags=e&-65537|128,t):null;case 13:if(Xe(t),e=t.memoizedState,e!==null&&e.dehydrated!==null){if(t.alternate===null)throw Error(z(340));El()}return e=t.flags,e&65536?(t.flags=e&-65537|128,t):null;case 19:return be(se),null;case 4:return sn(),null;case 10:return Nt(t.type),null;case 22:case 23:return Xe(t),zf(),e!==null&&be(pl),e=t.flags,e&65536?(t.flags=e&-65537|128,t):null;case 24:return Nt(me),null;case 25:return null;default:return null}}function a1(e,t){switch(gf(t),t.tag){case 3:Nt(me),sn();break;case 26:case 27:case 5:mu(t);break;case 4:sn();break;case 31:t.memoizedState!==null&&Xe(t);break;case 13:Xe(t);break;case 19:be(se);break;case 10:Nt(t.type);break;case 22:case 23:Xe(t),zf(),e!==null&&be(pl);break;case 24:Nt(me)}}function Ta(e,t){try{var l=t.updateQueue,n=l!==null?l.lastEffect:null;if(n!==null){var a=n.next;l=a;do{if((l.tag&e)===e){n=void 0;var u=l.create,c=l.inst;n=u(),c.destroy=n}l=l.next}while(l!==a)}}catch(i){K(t,t.return,i)}}function sl(e,t,l){try{var n=t.updateQueue,a=n!==null?n.lastEffect:null;if(a!==null){var u=a.next;n=u;do{if((n.tag&e)===e){var c=n.inst,i=c.destroy;if(i!==void 0){c.destroy=void 0,a=t;var f=l,s=i;try{s()}catch(d){K(a,f,d)}}}n=n.next}while(n!==u)}}catch(d){K(t,t.return,d)}}function u1(e){var t=e.updateQueue;if(t!==null){var l=e.stateNode;try{hd(t,l)}catch(n){K(e,e.return,n)}}}function c1(e,t,l){l.props=Al(e.type,e.memoizedProps),l.state=e.memoizedState;try{l.componentWillUnmount()}catch(n){K(e,t,n)}}function Wn(e,t){try{var l=e.ref;if(l!==null){switch(e.tag){case 26:case 27:case 5:var n=e.stateNode;break;case 30:n=e.stateNode;break;default:n=e.stateNode}typeof l=="function"?e.refCleanup=l(n):l.current=n}}catch(a){K(e,t,a)}}function yt(e,t){var l=e.ref,n=e.refCleanup;if(l!==null)if(typeof n=="function")try{n()}catch(a){K(e,t,a)}finally{e.refCleanup=null,e=e.alternate,e!=null&&(e.refCleanup=null)}else if(typeof l=="function")try{l(null)}catch(a){K(e,t,a)}else l.current=null}function i1(e){var t=e.type,l=e.memoizedProps,n=e.stateNode;try{e:switch(t){case"button":case"input":case"select":case"textarea":l.autoFocus&&n.focus();break e;case"img":l.src?n.src=l.src:l.srcSet&&(n.srcset=l.srcSet)}}catch(a){K(e,e.return,a)}}function Nc(e,t,l){try{var n=e.stateNode;Jh(n,e.type,l,t),n[qe]=t}catch(a){K(e,e.return,a)}}function f1(e){return e.tag===5||e.tag===3||e.tag===26||e.tag===27&&dl(e.type)||e.tag===4}function Oc(e){e:for(;;){for(;e.sibling===null;){if(e.return===null||f1(e.return))return null;e=e.return}for(e.sibling.return=e.return,e=e.sibling;e.tag!==5&&e.tag!==6&&e.tag!==18;){if(e.tag===27&&dl(e.type)||e.flags&2||e.child===null||e.tag===4)continue e;e.child.return=e,e=e.child}if(!(e.flags&2))return e.stateNode}}function Ni(e,t,l){var n=e.tag;if(n===5||n===6)e=e.stateNode,t?(l.nodeType===9?l.body:l.nodeName==="HTML"?l.ownerDocument.body:l).insertBefore(e,t):(t=l.nodeType===9?l.body:l.nodeName==="HTML"?l.ownerDocument.body:l,t.appendChild(e),l=l._reactRootContainer,l!=null||t.onclick!==null||(t.onclick=At));else if(n!==4&&(n===27&&dl(e.type)&&(l=e.stateNode,t=null),e=e.child,e!==null))for(Ni(e,t,l),e=e.sibling;e!==null;)Ni(e,t,l),e=e.sibling}function Mu(e,t,l){var n=e.tag;if(n===5||n===6)e=e.stateNode,t?l.insertBefore(e,t):l.appendChild(e);else if(n!==4&&(n===27&&dl(e.type)&&(l=e.stateNode),e=e.child,e!==null))for(Mu(e,t,l),e=e.sibling;e!==null;)Mu(e,t,l),e=e.sibling}function s1(e){var t=e.stateNode,l=e.memoizedProps;try{for(var n=e.type,a=t.attributes;a.length;)t.removeAttributeNode(a[0]);Me(t,n,l),t[Ee]=e,t[qe]=l}catch(u){K(e,e.return,u)}}var jt=!1,de=!1,Cc=!1,io=typeof WeakSet=="function"?WeakSet:Set,xe=null;function Ah(e,t){if(e=e.containerInfo,Ui=Uu,e=Wr(e),mf(e)){if("selectionStart"in e)var l={start:e.selectionStart,end:e.selectionEnd};else e:{l=(l=e.ownerDocument)&&l.defaultView||window;var n=l.getSelection&&l.getSelection();if(n&&n.rangeCount!==0){l=n.anchorNode;var a=n.anchorOffset,u=n.focusNode;n=n.focusOffset;try{l.nodeType,u.nodeType}catch{l=null;break e}var c=0,i=-1,f=-1,s=0,d=0,g=e,r=null;t:for(;;){for(var x;g!==l||a!==0&&g.nodeType!==3||(i=c+a),g!==u||n!==0&&g.nodeType!==3||(f=c+n),g.nodeType===3&&(c+=g.nodeValue.length),(x=g.firstChild)!==null;)r=g,g=x;for(;;){if(g===e)break t;if(r===l&&++s===a&&(i=c),r===u&&++d===n&&(f=c),(x=g.nextSibling)!==null)break;g=r,r=g.parentNode}g=x}l=i===-1||f===-1?null:{start:i,end:f}}else l=null}l=l||{start:0,end:0}}else l=null;for(Hi={focusedElem:e,selectionRange:l},Uu=!1,xe=t;xe!==null;)if(t=xe,e=t.child,(t.subtreeFlags&1028)!==0&&e!==null)e.return=t,xe=e;else for(;xe!==null;){switch(t=xe,u=t.alternate,e=t.flags,t.tag){case 0:if(e&4&&(e=t.updateQueue,e=e!==null?e.events:null,e!==null))for(l=0;l<e.length;l++)a=e[l],a.ref.impl=a.nextImpl;break;case 11:case 15:break;case 1:if(e&1024&&u!==null){e=void 0,l=t,a=u.memoizedProps,u=u.memoizedState,n=l.stateNode;try{var S=Al(l.type,a);e=n.getSnapshotBeforeUpdate(S,u),n.__reactInternalSnapshotBeforeUpdate=e}catch(p){K(l,l.return,p)}}break;case 3:if(e&1024){if(e=t.stateNode.containerInfo,l=e.nodeType,l===9)Xi(e);else if(l===1)switch(e.nodeName){case"HEAD":case"HTML":case"BODY":Xi(e);break;default:e.textContent=""}}break;case 5:case 26:case 27:case 6:case 4:case 17:break;default:if(e&1024)throw Error(z(163))}if(e=t.sibling,e!==null){e.return=t.return,xe=e;break}xe=t.return}}function o1(e,t,l){var n=l.flags;switch(l.tag){case 0:case 11:case 15:zt(e,l),n&4&&Ta(5,l);break;case 1:if(zt(e,l),n&4)if(e=l.stateNode,t===null)try{e.componentDidMount()}catch(c){K(l,l.return,c)}else{var a=Al(l.type,t.memoizedProps);t=t.memoizedState;try{e.componentDidUpdate(a,t,e.__reactInternalSnapshotBeforeUpdate)}catch(c){K(l,l.return,c)}}n&64&&u1(l),n&512&&Wn(l,l.return);break;case 3:if(zt(e,l),n&64&&(e=l.updateQueue,e!==null)){if(t=null,l.child!==null)switch(l.child.tag){case 27:case 5:t=l.child.stateNode;break;case 1:t=l.child.stateNode}try{hd(e,t)}catch(c){K(l,l.return,c)}}break;case 27:t===null&&n&4&&s1(l);case 26:case 5:zt(e,l),t===null&&n&4&&i1(l),n&512&&Wn(l,l.return);break;case 12:zt(e,l);break;case 31:zt(e,l),n&4&&m1(e,l);break;case 13:zt(e,l),n&4&&h1(e,l),n&64&&(e=l.memoizedState,e!==null&&(e=e.dehydrated,e!==null&&(l=qh.bind(null,l),ny(e,l))));break;case 22:if(n=l.memoizedState!==null||jt,!n){t=t!==null&&t.memoizedState!==null||de,a=jt;var u=de;jt=n,(de=t)&&!u?Et(e,l,(l.subtreeFlags&8772)!==0):zt(e,l),jt=a,de=u}break;case 30:break;default:zt(e,l)}}function r1(e){var t=e.alternate;t!==null&&(e.alternate=null,r1(t)),e.child=null,e.deletions=null,e.sibling=null,e.tag===5&&(t=e.stateNode,t!==null&&cf(t)),e.stateNode=null,e.return=null,e.dependencies=null,e.memoizedProps=null,e.memoizedState=null,e.pendingProps=null,e.stateNode=null,e.updateQueue=null}var ne=null,$e=!1;function kt(e,t,l){for(l=l.child;l!==null;)d1(e,t,l),l=l.sibling}function d1(e,t,l){if(Ze&&typeof Ze.onCommitFiberUnmount=="function")try{Ze.onCommitFiberUnmount(ga,l)}catch{}switch(l.tag){case 26:de||yt(l,t),kt(e,t,l),l.memoizedState?l.memoizedState.count--:l.stateNode&&(l=l.stateNode,l.parentNode.removeChild(l));break;case 27:de||yt(l,t);var n=ne,a=$e;dl(l.type)&&(ne=l.stateNode,$e=!1),kt(e,t,l),ea(l.stateNode),ne=n,$e=a;break;case 5:de||yt(l,t);case 6:if(n=ne,a=$e,ne=null,kt(e,t,l),ne=n,$e=a,ne!==null)if($e)try{(ne.nodeType===9?ne.body:ne.nodeName==="HTML"?ne.ownerDocument.body:ne).removeChild(l.stateNode)}catch(u){K(l,t,u)}else try{ne.removeChild(l.stateNode)}catch(u){K(l,t,u)}break;case 18:ne!==null&&($e?(e=ne,po(e.nodeType===9?e.body:e.nodeName==="HTML"?e.ownerDocument.body:e,l.stateNode),bn(e)):po(ne,l.stateNode));break;case 4:n=ne,a=$e,ne=l.stateNode.containerInfo,$e=!0,kt(e,t,l),ne=n,$e=a;break;case 0:case 11:case 14:case 15:sl(2,l,t),de||sl(4,l,t),kt(e,t,l);break;case 1:de||(yt(l,t),n=l.stateNode,typeof n.componentWillUnmount=="function"&&c1(l,t,n)),kt(e,t,l);break;case 21:kt(e,t,l);break;case 22:de=(n=de)||l.memoizedState!==null,kt(e,t,l),de=n;break;default:kt(e,t,l)}}function m1(e,t){if(t.memoizedState===null&&(e=t.alternate,e!==null&&(e=e.memoizedState,e!==null))){e=e.dehydrated;try{bn(e)}catch(l){K(t,t.return,l)}}}function h1(e,t){if(t.memoizedState===null&&(e=t.alternate,e!==null&&(e=e.memoizedState,e!==null&&(e=e.dehydrated,e!==null))))try{bn(e)}catch(l){K(t,t.return,l)}}function Dh(e){switch(e.tag){case 31:case 13:case 19:var t=e.stateNode;return t===null&&(t=e.stateNode=new io),t;case 22:return e=e.stateNode,t=e._retryCache,t===null&&(t=e._retryCache=new io),t;default:throw Error(z(435,e.tag))}}function Ba(e,t){var l=Dh(e);t.forEach(function(n){if(!l.has(n)){l.add(n);var a=Uh.bind(null,e,n);n.then(a,a)}})}function Oe(e,t){var l=t.deletions;if(l!==null)for(var n=0;n<l.length;n++){var a=l[n],u=e,c=t,i=c;e:for(;i!==null;){switch(i.tag){case 27:if(dl(i.type)){ne=i.stateNode,$e=!1;break e}break;case 5:ne=i.stateNode,$e=!1;break e;case 3:case 4:ne=i.stateNode.containerInfo,$e=!0;break e}i=i.return}if(ne===null)throw Error(z(160));d1(u,c,a),ne=null,$e=!1,u=a.alternate,u!==null&&(u.return=null),a.return=null}if(t.subtreeFlags&13886)for(t=t.child;t!==null;)y1(t,e),t=t.sibling}var st=null;function y1(e,t){var l=e.alternate,n=e.flags;switch(e.tag){case 0:case 11:case 14:case 15:Oe(t,e),Ce(e),n&4&&(sl(3,e,e.return),Ta(3,e),sl(5,e,e.return));break;case 1:Oe(t,e),Ce(e),n&512&&(de||l===null||yt(l,l.return)),n&64&&jt&&(e=e.updateQueue,e!==null&&(n=e.callbacks,n!==null&&(l=e.shared.hiddenCallbacks,e.shared.hiddenCallbacks=l===null?n:l.concat(n))));break;case 26:var a=st;if(Oe(t,e),Ce(e),n&512&&(de||l===null||yt(l,l.return)),n&4){var u=l!==null?l.memoizedState:null;if(n=e.memoizedState,l===null)if(n===null)if(e.stateNode===null){e:{n=e.type,l=e.memoizedProps,a=a.ownerDocument||a;t:switch(n){case"title":u=a.getElementsByTagName("title")[0],(!u||u[pa]||u[Ee]||u.namespaceURI==="http://www.w3.org/2000/svg"||u.hasAttribute("itemprop"))&&(u=a.createElement(n),a.head.insertBefore(u,a.querySelector("head > title"))),Me(u,n,l),u[Ee]=e,ge(u),n=u;break e;case"link":var c=Ao("link","href",a).get(n+(l.href||""));if(c){for(var i=0;i<c.length;i++)if(u=c[i],u.getAttribute("href")===(l.href==null||l.href===""?null:l.href)&&u.getAttribute("rel")===(l.rel==null?null:l.rel)&&u.getAttribute("title")===(l.title==null?null:l.title)&&u.getAttribute("crossorigin")===(l.crossOrigin==null?null:l.crossOrigin)){c.splice(i,1);break t}}u=a.createElement(n),Me(u,n,l),a.head.appendChild(u);break;case"meta":if(c=Ao("meta","content",a).get(n+(l.content||""))){for(i=0;i<c.length;i++)if(u=c[i],u.getAttribute("content")===(l.content==null?null:""+l.content)&&u.getAttribute("name")===(l.name==null?null:l.name)&&u.getAttribute("property")===(l.property==null?null:l.property)&&u.getAttribute("http-equiv")===(l.httpEquiv==null?null:l.httpEquiv)&&u.getAttribute("charset")===(l.charSet==null?null:l.charSet)){c.splice(i,1);break t}}u=a.createElement(n),Me(u,n,l),a.head.appendChild(u);break;default:throw Error(z(468,n))}u[Ee]=e,ge(u),n=u}e.stateNode=n}else Do(a,e.type,e.stateNode);else e.stateNode=Mo(a,n,e.memoizedProps);else u!==n?(u===null?l.stateNode!==null&&(l=l.stateNode,l.parentNode.removeChild(l)):u.count--,n===null?Do(a,e.type,e.stateNode):Mo(a,n,e.memoizedProps)):n===null&&e.stateNode!==null&&Nc(e,e.memoizedProps,l.memoizedProps)}break;case 27:Oe(t,e),Ce(e),n&512&&(de||l===null||yt(l,l.return)),l!==null&&n&4&&Nc(e,e.memoizedProps,l.memoizedProps);break;case 5:if(Oe(t,e),Ce(e),n&512&&(de||l===null||yt(l,l.return)),e.flags&32){a=e.stateNode;try{rn(a,"")}catch(S){K(e,e.return,S)}}n&4&&e.stateNode!=null&&(a=e.memoizedProps,Nc(e,a,l!==null?l.memoizedProps:a)),n&1024&&(Cc=!0);break;case 6:if(Oe(t,e),Ce(e),n&4){if(e.stateNode===null)throw Error(z(162));n=e.memoizedProps,l=e.stateNode;try{l.nodeValue=n}catch(S){K(e,e.return,S)}}break;case 3:if(iu=null,a=st,st=_u(t.containerInfo),Oe(t,e),st=a,Ce(e),n&4&&l!==null&&l.memoizedState.isDehydrated)try{bn(t.containerInfo)}catch(S){K(e,e.return,S)}Cc&&(Cc=!1,v1(e));break;case 4:n=st,st=_u(e.stateNode.containerInfo),Oe(t,e),Ce(e),st=n;break;case 12:Oe(t,e),Ce(e);break;case 31:Oe(t,e),Ce(e),n&4&&(n=e.updateQueue,n!==null&&(e.updateQueue=null,Ba(e,n)));break;case 13:Oe(t,e),Ce(e),e.child.flags&8192&&e.memoizedState!==null!=(l!==null&&l.memoizedState!==null)&&(ec=Ye()),n&4&&(n=e.updateQueue,n!==null&&(e.updateQueue=null,Ba(e,n)));break;case 22:a=e.memoizedState!==null;var f=l!==null&&l.memoizedState!==null,s=jt,d=de;if(jt=s||a,de=d||f,Oe(t,e),de=d,jt=s,Ce(e),n&8192)e:for(t=e.stateNode,t._visibility=a?t._visibility&-2:t._visibility|1,a&&(l===null||f||jt||de||gl(e)),l=null,t=e;;){if(t.tag===5||t.tag===26){if(l===null){f=l=t;try{if(u=f.stateNode,a)c=u.style,typeof c.setProperty=="function"?c.setProperty("display","none","important"):c.display="none";else{i=f.stateNode;var g=f.memoizedProps.style,r=g!=null&&g.hasOwnProperty("display")?g.display:null;i.style.display=r==null||typeof r=="boolean"?"":(""+r).trim()}}catch(S){K(f,f.return,S)}}}else if(t.tag===6){if(l===null){f=t;try{f.stateNode.nodeValue=a?"":f.memoizedProps}catch(S){K(f,f.return,S)}}}else if(t.tag===18){if(l===null){f=t;try{var x=f.stateNode;a?ko(x,!0):ko(f.stateNode,!1)}catch(S){K(f,f.return,S)}}}else if((t.tag!==22&&t.tag!==23||t.memoizedState===null||t===e)&&t.child!==null){t.child.return=t,t=t.child;continue}if(t===e)break e;for(;t.sibling===null;){if(t.return===null||t.return===e)break e;l===t&&(l=null),t=t.return}l===t&&(l=null),t.sibling.return=t.return,t=t.sibling}n&4&&(n=e.updateQueue,n!==null&&(l=n.retryQueue,l!==null&&(n.retryQueue=null,Ba(e,l))));break;case 19:Oe(t,e),Ce(e),n&4&&(n=e.updateQueue,n!==null&&(e.updateQueue=null,Ba(e,n)));break;case 30:break;case 21:break;default:Oe(t,e),Ce(e)}}function Ce(e){var t=e.flags;if(t&2){try{for(var l,n=e.return;n!==null;){if(f1(n)){l=n;break}n=n.return}if(l==null)throw Error(z(160));switch(l.tag){case 27:var a=l.stateNode,u=Oc(e);Mu(e,u,a);break;case 5:var c=l.stateNode;l.flags&32&&(rn(c,""),l.flags&=-33);var i=Oc(e);Mu(e,i,c);break;case 3:case 4:var f=l.stateNode.containerInfo,s=Oc(e);Ni(e,s,f);break;default:throw Error(z(161))}}catch(d){K(e,e.return,d)}e.flags&=-3}t&4096&&(e.flags&=-4097)}function v1(e){if(e.subtreeFlags&1024)for(e=e.child;e!==null;){var t=e;v1(t),t.tag===5&&t.flags&1024&&t.stateNode.reset(),e=e.sibling}}function zt(e,t){if(t.subtreeFlags&8772)for(t=t.child;t!==null;)o1(e,t.alternate,t),t=t.sibling}function gl(e){for(e=e.child;e!==null;){var t=e;switch(t.tag){case 0:case 11:case 14:case 15:sl(4,t,t.return),gl(t);break;case 1:yt(t,t.return);var l=t.stateNode;typeof l.componentWillUnmount=="function"&&c1(t,t.return,l),gl(t);break;case 27:ea(t.stateNode);case 26:case 5:yt(t,t.return),gl(t);break;case 22:t.memoizedState===null&&gl(t);break;case 30:gl(t);break;default:gl(t)}e=e.sibling}}function Et(e,t,l){for(l=l&&(t.subtreeFlags&8772)!==0,t=t.child;t!==null;){var n=t.alternate,a=e,u=t,c=u.flags;switch(u.tag){case 0:case 11:case 15:Et(a,u,l),Ta(4,u);break;case 1:if(Et(a,u,l),n=u,a=n.stateNode,typeof a.componentDidMount=="function")try{a.componentDidMount()}catch(s){K(n,n.return,s)}if(n=u,a=n.updateQueue,a!==null){var i=n.stateNode;try{var f=a.shared.hiddenCallbacks;if(f!==null)for(a.shared.hiddenCallbacks=null,a=0;a<f.length;a++)md(f[a],i)}catch(s){K(n,n.return,s)}}l&&c&64&&u1(u),Wn(u,u.return);break;case 27:s1(u);case 26:case 5:Et(a,u,l),l&&n===null&&c&4&&i1(u),Wn(u,u.return);break;case 12:Et(a,u,l);break;case 31:Et(a,u,l),l&&c&4&&m1(a,u);break;case 13:Et(a,u,l),l&&c&4&&h1(a,u);break;case 22:u.memoizedState===null&&Et(a,u,l),Wn(u,u.return);break;case 30:break;default:Et(a,u,l)}t=t.sibling}}function Hf(e,t){var l=null;e!==null&&e.memoizedState!==null&&e.memoizedState.cachePool!==null&&(l=e.memoizedState.cachePool.pool),e=null,t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(e=t.memoizedState.cachePool.pool),e!==l&&(e!=null&&e.refCount++,l!=null&&za(l))}function Bf(e,t){e=null,t.alternate!==null&&(e=t.alternate.memoizedState.cache),t=t.memoizedState.cache,t!==e&&(t.refCount++,e!=null&&za(e))}function ft(e,t,l,n){if(t.subtreeFlags&10256)for(t=t.child;t!==null;)x1(e,t,l,n),t=t.sibling}function x1(e,t,l,n){var a=t.flags;switch(t.tag){case 0:case 11:case 15:ft(e,t,l,n),a&2048&&Ta(9,t);break;case 1:ft(e,t,l,n);break;case 3:ft(e,t,l,n),a&2048&&(e=null,t.alternate!==null&&(e=t.alternate.memoizedState.cache),t=t.memoizedState.cache,t!==e&&(t.refCount++,e!=null&&za(e)));break;case 12:if(a&2048){ft(e,t,l,n),e=t.stateNode;try{var u=t.memoizedProps,c=u.id,i=u.onPostCommit;typeof i=="function"&&i(c,t.alternate===null?"mount":"update",e.passiveEffectDuration,-0)}catch(f){K(t,t.return,f)}}else ft(e,t,l,n);break;case 31:ft(e,t,l,n);break;case 13:ft(e,t,l,n);break;case 23:break;case 22:u=t.stateNode,c=t.alternate,t.memoizedState!==null?u._visibility&2?ft(e,t,l,n):Fn(e,t):u._visibility&2?ft(e,t,l,n):(u._visibility|=2,Bl(e,t,l,n,(t.subtreeFlags&10256)!==0||!1)),a&2048&&Hf(c,t);break;case 24:ft(e,t,l,n),a&2048&&Bf(t.alternate,t);break;default:ft(e,t,l,n)}}function Bl(e,t,l,n,a){for(a=a&&((t.subtreeFlags&10256)!==0||!1),t=t.child;t!==null;){var u=e,c=t,i=l,f=n,s=c.flags;switch(c.tag){case 0:case 11:case 15:Bl(u,c,i,f,a),Ta(8,c);break;case 23:break;case 22:var d=c.stateNode;c.memoizedState!==null?d._visibility&2?Bl(u,c,i,f,a):Fn(u,c):(d._visibility|=2,Bl(u,c,i,f,a)),a&&s&2048&&Hf(c.alternate,c);break;case 24:Bl(u,c,i,f,a),a&&s&2048&&Bf(c.alternate,c);break;default:Bl(u,c,i,f,a)}t=t.sibling}}function Fn(e,t){if(t.subtreeFlags&10256)for(t=t.child;t!==null;){var l=e,n=t,a=n.flags;switch(n.tag){case 22:Fn(l,n),a&2048&&Hf(n.alternate,n);break;case 24:Fn(l,n),a&2048&&Bf(n.alternate,n);break;default:Fn(l,n)}t=t.sibling}}var Bn=8192;function _l(e,t,l){if(e.subtreeFlags&Bn)for(e=e.child;e!==null;)g1(e,t,l),e=e.sibling}function g1(e,t,l){switch(e.tag){case 26:_l(e,t,l),e.flags&Bn&&e.memoizedState!==null&&yy(l,st,e.memoizedState,e.memoizedProps);break;case 5:_l(e,t,l);break;case 3:case 4:var n=st;st=_u(e.stateNode.containerInfo),_l(e,t,l),st=n;break;case 22:e.memoizedState===null&&(n=e.alternate,n!==null&&n.memoizedState!==null?(n=Bn,Bn=16777216,_l(e,t,l),Bn=n):_l(e,t,l));break;default:_l(e,t,l)}}function b1(e){var t=e.alternate;if(t!==null&&(e=t.child,e!==null)){t.child=null;do t=e.sibling,e.sibling=null,e=t;while(e!==null)}}function Cn(e){var t=e.deletions;if(e.flags&16){if(t!==null)for(var l=0;l<t.length;l++){var n=t[l];xe=n,p1(n,e)}b1(e)}if(e.subtreeFlags&10256)for(e=e.child;e!==null;)S1(e),e=e.sibling}function S1(e){switch(e.tag){case 0:case 11:case 15:Cn(e),e.flags&2048&&sl(9,e,e.return);break;case 3:Cn(e);break;case 12:Cn(e);break;case 22:var t=e.stateNode;e.memoizedState!==null&&t._visibility&2&&(e.return===null||e.return.tag!==13)?(t._visibility&=-3,uu(e)):Cn(e);break;default:Cn(e)}}function uu(e){var t=e.deletions;if(e.flags&16){if(t!==null)for(var l=0;l<t.length;l++){var n=t[l];xe=n,p1(n,e)}b1(e)}for(e=e.child;e!==null;){switch(t=e,t.tag){case 0:case 11:case 15:sl(8,t,t.return),uu(t);break;case 22:l=t.stateNode,l._visibility&2&&(l._visibility&=-3,uu(t));break;default:uu(t)}e=e.sibling}}function p1(e,t){for(;xe!==null;){var l=xe;switch(l.tag){case 0:case 11:case 15:sl(8,l,t);break;case 23:case 22:if(l.memoizedState!==null&&l.memoizedState.cachePool!==null){var n=l.memoizedState.cachePool.pool;n!=null&&n.refCount++}break;case 24:za(l.memoizedState.cache)}if(n=l.child,n!==null)n.return=l,xe=n;else e:for(l=e;xe!==null;){n=xe;var a=n.sibling,u=n.return;if(r1(n),n===l){xe=null;break e}if(a!==null){a.return=u,xe=a;break e}xe=u}}}var wh={getCacheForType:function(e){var t=je(me),l=t.data.get(e);return l===void 0&&(l=e(),t.data.set(e,l)),l},cacheSignal:function(){return je(me).controller.signal}},Nh=typeof WeakMap=="function"?WeakMap:Map,Z=0,F=null,H=null,B=0,Q=0,Be=null,Jt=!1,Tn=!1,Xf=!1,qt=0,ie=0,ol=0,zl=0,Lf=0,Ge=0,yn=0,In=null,_e=null,Oi=!1,ec=0,k1=0,Au=1/0,Du=null,ll=null,ye=0,nl=null,vn=null,Ot=0,Ci=0,$i=null,z1=null,Pn=0,_i=null;function Qe(){return Z&2&&B!==0?B&-B:C.T!==null?Yf():Or()}function E1(){if(Ge===0)if(!(B&536870912)||X){var e=Oa;Oa<<=1,!(Oa&3932160)&&(Oa=262144),Ge=e}else Ge=536870912;return e=Je.current,e!==null&&(e.flags|=32),Ge}function Re(e,t,l){(e===F&&(Q===2||Q===9)||e.cancelPendingCommit!==null)&&(xn(e,0),Wt(e,B,Ge,!1)),Sa(e,l),(!(Z&2)||e!==F)&&(e===F&&(!(Z&2)&&(zl|=l),ie===4&&Wt(e,B,Ge,!1)),gt(e))}function T1(e,t,l){if(Z&6)throw Error(z(327));var n=!l&&(t&127)===0&&(t&e.expiredLanes)===0||ba(e,t),a=n?$h(e,t):$c(e,t,!0),u=n;do{if(a===0){Tn&&!n&&Wt(e,t,0,!1);break}else{if(l=e.current.alternate,u&&!Oh(l)){a=$c(e,t,!1),u=!1;continue}if(a===2){if(u=t,e.errorRecoveryDisabledLanes&u)var c=0;else c=e.pendingLanes&-536870913,c=c!==0?c:c&536870912?536870912:0;if(c!==0){t=c;e:{var i=e;a=In;var f=i.current.memoizedState.isDehydrated;if(f&&(xn(i,c).flags|=256),c=$c(i,c,!1),c!==2){if(Xf&&!f){i.errorRecoveryDisabledLanes|=u,zl|=u,a=4;break e}u=_e,_e=a,u!==null&&(_e===null?_e=u:_e.push.apply(_e,u))}a=c}if(u=!1,a!==2)continue}}if(a===1){xn(e,0),Wt(e,t,0,!0);break}e:{switch(n=e,u=a,u){case 0:case 1:throw Error(z(345));case 4:if((t&4194048)!==t)break;case 6:Wt(n,t,Ge,!Jt);break e;case 2:_e=null;break;case 3:case 5:break;default:throw Error(z(329))}if((t&62914560)===t&&(a=ec+300-Ye(),10<a)){if(Wt(n,t,Ge,!Jt),Gu(n,0,!0)!==0)break e;Ot=t,n.timeoutHandle=Z1(fo.bind(null,n,l,_e,Du,Oi,t,Ge,zl,yn,Jt,u,"Throttled",-0,0),a);break e}fo(n,l,_e,Du,Oi,t,Ge,zl,yn,Jt,u,null,-0,0)}}break}while(!0);gt(e)}function fo(e,t,l,n,a,u,c,i,f,s,d,g,r,x){if(e.timeoutHandle=-1,g=t.subtreeFlags,g&8192||(g&16785408)===16785408){g={stylesheets:null,count:0,imgCount:0,imgBytes:0,suspenseyImages:[],waitingForImages:!0,waitingForViewTransition:!1,unsuspend:At},g1(t,u,g);var S=(u&62914560)===u?ec-Ye():(u&4194048)===u?k1-Ye():0;if(S=vy(g,S),S!==null){Ot=u,e.cancelPendingCommit=S(oo.bind(null,e,t,u,l,n,a,c,i,f,d,g,null,r,x)),Wt(e,u,c,!s);return}}oo(e,t,u,l,n,a,c,i,f)}function Oh(e){for(var t=e;;){var l=t.tag;if((l===0||l===11||l===15)&&t.flags&16384&&(l=t.updateQueue,l!==null&&(l=l.stores,l!==null)))for(var n=0;n<l.length;n++){var a=l[n],u=a.getSnapshot;a=a.value;try{if(!Ke(u(),a))return!1}catch{return!1}}if(l=t.child,t.subtreeFlags&16384&&l!==null)l.return=t,t=l;else{if(t===e)break;for(;t.sibling===null;){if(t.return===null||t.return===e)return!0;t=t.return}t.sibling.return=t.return,t=t.sibling}}return!0}function Wt(e,t,l,n){t&=~Lf,t&=~zl,e.suspendedLanes|=t,e.pingedLanes&=~t,n&&(e.warmLanes|=t),n=e.expirationTimes;for(var a=t;0<a;){var u=31-Ve(a),c=1<<u;n[u]=-1,a&=~c}l!==0&&Dr(e,l,t)}function tc(){return Z&6?!0:(ja(0),!1)}function Gf(){if(H!==null){if(Q===0)var e=H.return;else e=H,Dt=Cl=null,Af(e),un=null,ia=0,e=H;for(;e!==null;)a1(e.alternate,e),e=e.return;H=null}}function xn(e,t){var l=e.timeoutHandle;l!==-1&&(e.timeoutHandle=-1,Ih(l)),l=e.cancelPendingCommit,l!==null&&(e.cancelPendingCommit=null,l()),Ot=0,Gf(),F=e,H=l=wt(e.current,null),B=t,Q=0,Be=null,Jt=!1,Tn=ba(e,t),Xf=!1,yn=Ge=Lf=zl=ol=ie=0,_e=In=null,Oi=!1,t&8&&(t|=t&32);var n=e.entangledLanes;if(n!==0)for(e=e.entanglements,n&=t;0<n;){var a=31-Ve(n),u=1<<a;t|=e[a],n&=~u}return qt=t,Qu(),l}function j1(e,t){R=null,C.H=sa,t===En||t===Ju?(t=Bs(),Q=3):t===pf?(t=Bs(),Q=4):Q=t===qf?8:t!==null&&typeof t=="object"&&typeof t.then=="function"?6:1,Be=t,H===null&&(ie=1,Tu(e,nt(t,e.current)))}function M1(){var e=Je.current;return e===null?!0:(B&4194048)===B?ut===null:(B&62914560)===B||B&536870912?e===ut:!1}function A1(){var e=C.H;return C.H=sa,e===null?sa:e}function D1(){var e=C.A;return C.A=wh,e}function wu(){ie=4,Jt||(B&4194048)!==B&&Je.current!==null||(Tn=!0),!(ol&134217727)&&!(zl&134217727)||F===null||Wt(F,B,Ge,!1)}function $c(e,t,l){var n=Z;Z|=2;var a=A1(),u=D1();(F!==e||B!==t)&&(Du=null,xn(e,t)),t=!1;var c=ie;e:do try{if(Q!==0&&H!==null){var i=H,f=Be;switch(Q){case 8:Gf(),c=6;break e;case 3:case 2:case 9:case 6:Je.current===null&&(t=!0);var s=Q;if(Q=0,Be=null,Pl(e,i,f,s),l&&Tn){c=0;break e}break;default:s=Q,Q=0,Be=null,Pl(e,i,f,s)}}Ch(),c=ie;break}catch(d){j1(e,d)}while(!0);return t&&e.shellSuspendCounter++,Dt=Cl=null,Z=n,C.H=a,C.A=u,H===null&&(F=null,B=0,Qu()),c}function Ch(){for(;H!==null;)w1(H)}function $h(e,t){var l=Z;Z|=2;var n=A1(),a=D1();F!==e||B!==t?(Du=null,Au=Ye()+500,xn(e,t)):Tn=ba(e,t);e:do try{if(Q!==0&&H!==null){t=H;var u=Be;t:switch(Q){case 1:Q=0,Be=null,Pl(e,t,u,1);break;case 2:case 9:if(Hs(u)){Q=0,Be=null,so(t);break}t=function(){Q!==2&&Q!==9||F!==e||(Q=7),gt(e)},u.then(t,t);break e;case 3:Q=7;break e;case 4:Q=5;break e;case 7:Hs(u)?(Q=0,Be=null,so(t)):(Q=0,Be=null,Pl(e,t,u,7));break;case 5:var c=null;switch(H.tag){case 26:c=H.memoizedState;case 5:case 27:var i=H;if(c?W1(c):i.stateNode.complete){Q=0,Be=null;var f=i.sibling;if(f!==null)H=f;else{var s=i.return;s!==null?(H=s,lc(s)):H=null}break t}}Q=0,Be=null,Pl(e,t,u,5);break;case 6:Q=0,Be=null,Pl(e,t,u,6);break;case 8:Gf(),ie=6;break e;default:throw Error(z(462))}}_h();break}catch(d){j1(e,d)}while(!0);return Dt=Cl=null,C.H=n,C.A=a,Z=l,H!==null?0:(F=null,B=0,Qu(),ie)}function _h(){for(;H!==null&&!am();)w1(H)}function w1(e){var t=n1(e.alternate,e,qt);e.memoizedProps=e.pendingProps,t===null?lc(e):H=t}function so(e){var t=e,l=t.alternate;switch(t.tag){case 15:case 0:t=lo(l,t,t.pendingProps,t.type,void 0,B);break;case 11:t=lo(l,t,t.pendingProps,t.type.render,t.ref,B);break;case 5:Af(t);default:a1(l,t),t=H=ad(t,qt),t=n1(l,t,qt)}e.memoizedProps=e.pendingProps,t===null?lc(e):H=t}function Pl(e,t,l,n){Dt=Cl=null,Af(t),un=null,ia=0;var a=t.return;try{if(zh(e,a,t,l,B)){ie=1,Tu(e,nt(l,e.current)),H=null;return}}catch(u){if(a!==null)throw H=a,u;ie=1,Tu(e,nt(l,e.current)),H=null;return}t.flags&32768?(X||n===1?e=!0:Tn||B&536870912?e=!1:(Jt=e=!0,(n===2||n===9||n===3||n===6)&&(n=Je.current,n!==null&&n.tag===13&&(n.flags|=16384))),N1(t,e)):lc(t)}function lc(e){var t=e;do{if(t.flags&32768){N1(t,Jt);return}e=t.return;var l=jh(t.alternate,t,qt);if(l!==null){H=l;return}if(t=t.sibling,t!==null){H=t;return}H=t=e}while(t!==null);ie===0&&(ie=5)}function N1(e,t){do{var l=Mh(e.alternate,e);if(l!==null){l.flags&=32767,H=l;return}if(l=e.return,l!==null&&(l.flags|=32768,l.subtreeFlags=0,l.deletions=null),!t&&(e=e.sibling,e!==null)){H=e;return}H=e=l}while(e!==null);ie=6,H=null}function oo(e,t,l,n,a,u,c,i,f){e.cancelPendingCommit=null;do nc();while(ye!==0);if(Z&6)throw Error(z(327));if(t!==null){if(t===e.current)throw Error(z(177));if(u=t.lanes|t.childLanes,u|=hf,hm(e,l,u,c,i,f),e===F&&(H=F=null,B=0),vn=t,nl=e,Ot=l,Ci=u,$i=a,z1=n,t.subtreeFlags&10256||t.flags&10256?(e.callbackNode=null,e.callbackPriority=0,Hh(hu,function(){return R1(),null})):(e.callbackNode=null,e.callbackPriority=0),n=(t.flags&13878)!==0,t.subtreeFlags&13878||n){n=C.T,C.T=null,a=V.p,V.p=2,c=Z,Z|=4;try{Ah(e,t,l)}finally{Z=c,V.p=a,C.T=n}}ye=1,O1(),C1(),$1()}}function O1(){if(ye===1){ye=0;var e=nl,t=vn,l=(t.flags&13878)!==0;if(t.subtreeFlags&13878||l){l=C.T,C.T=null;var n=V.p;V.p=2;var a=Z;Z|=4;try{y1(t,e);var u=Hi,c=Wr(e.containerInfo),i=u.focusedElem,f=u.selectionRange;if(c!==i&&i&&i.ownerDocument&&Jr(i.ownerDocument.documentElement,i)){if(f!==null&&mf(i)){var s=f.start,d=f.end;if(d===void 0&&(d=s),"selectionStart"in i)i.selectionStart=s,i.selectionEnd=Math.min(d,i.value.length);else{var g=i.ownerDocument||document,r=g&&g.defaultView||window;if(r.getSelection){var x=r.getSelection(),S=i.textContent.length,p=Math.min(f.start,S),k=f.end===void 0?p:Math.min(f.end,S);!x.extend&&p>k&&(c=k,k=p,p=c);var h=Os(i,p),o=Os(i,k);if(h&&o&&(x.rangeCount!==1||x.anchorNode!==h.node||x.anchorOffset!==h.offset||x.focusNode!==o.node||x.focusOffset!==o.offset)){var m=g.createRange();m.setStart(h.node,h.offset),x.removeAllRanges(),p>k?(x.addRange(m),x.extend(o.node,o.offset)):(m.setEnd(o.node,o.offset),x.addRange(m))}}}}for(g=[],x=i;x=x.parentNode;)x.nodeType===1&&g.push({element:x,left:x.scrollLeft,top:x.scrollTop});for(typeof i.focus=="function"&&i.focus(),i=0;i<g.length;i++){var b=g[i];b.element.scrollLeft=b.left,b.element.scrollTop=b.top}}Uu=!!Ui,Hi=Ui=null}finally{Z=a,V.p=n,C.T=l}}e.current=t,ye=2}}function C1(){if(ye===2){ye=0;var e=nl,t=vn,l=(t.flags&8772)!==0;if(t.subtreeFlags&8772||l){l=C.T,C.T=null;var n=V.p;V.p=2;var a=Z;Z|=4;try{o1(e,t.alternate,t)}finally{Z=a,V.p=n,C.T=l}}ye=3}}function $1(){if(ye===4||ye===3){ye=0,um();var e=nl,t=vn,l=Ot,n=z1;t.subtreeFlags&10256||t.flags&10256?ye=5:(ye=0,vn=nl=null,_1(e,e.pendingLanes));var a=e.pendingLanes;if(a===0&&(ll=null),uf(l),t=t.stateNode,Ze&&typeof Ze.onCommitFiberRoot=="function")try{Ze.onCommitFiberRoot(ga,t,void 0,(t.current.flags&128)===128)}catch{}if(n!==null){t=C.T,a=V.p,V.p=2,C.T=null;try{for(var u=e.onRecoverableError,c=0;c<n.length;c++){var i=n[c];u(i.value,{componentStack:i.stack})}}finally{C.T=t,V.p=a}}Ot&3&&nc(),gt(e),a=e.pendingLanes,l&261930&&a&42?e===_i?Pn++:(Pn=0,_i=e):Pn=0,ja(0)}}function _1(e,t){(e.pooledCacheLanes&=t)===0&&(t=e.pooledCache,t!=null&&(e.pooledCache=null,za(t)))}function nc(){return O1(),C1(),$1(),R1()}function R1(){if(ye!==5)return!1;var e=nl,t=Ci;Ci=0;var l=uf(Ot),n=C.T,a=V.p;try{V.p=32>l?32:l,C.T=null,l=$i,$i=null;var u=nl,c=Ot;if(ye=0,vn=nl=null,Ot=0,Z&6)throw Error(z(331));var i=Z;if(Z|=4,S1(u.current),x1(u,u.current,c,l),Z=i,ja(0,!1),Ze&&typeof Ze.onPostCommitFiberRoot=="function")try{Ze.onPostCommitFiberRoot(ga,u)}catch{}return!0}finally{V.p=a,C.T=n,_1(e,t)}}function ro(e,t,l){t=nt(l,t),t=Ai(e.stateNode,t,2),e=tl(e,t,2),e!==null&&(Sa(e,2),gt(e))}function K(e,t,l){if(e.tag===3)ro(e,e,l);else for(;t!==null;){if(t.tag===3){ro(t,e,l);break}else if(t.tag===1){var n=t.stateNode;if(typeof t.type.getDerivedStateFromError=="function"||typeof n.componentDidCatch=="function"&&(ll===null||!ll.has(n))){e=nt(l,e),l=Fd(2),n=tl(t,l,2),n!==null&&(Id(l,n,t,e),Sa(n,2),gt(n));break}}t=t.return}}function _c(e,t,l){var n=e.pingCache;if(n===null){n=e.pingCache=new Nh;var a=new Set;n.set(t,a)}else a=n.get(t),a===void 0&&(a=new Set,n.set(t,a));a.has(l)||(Xf=!0,a.add(l),e=Rh.bind(null,e,t,l),t.then(e,e))}function Rh(e,t,l){var n=e.pingCache;n!==null&&n.delete(t),e.pingedLanes|=e.suspendedLanes&l,e.warmLanes&=~l,F===e&&(B&l)===l&&(ie===4||ie===3&&(B&62914560)===B&&300>Ye()-ec?!(Z&2)&&xn(e,0):Lf|=l,yn===B&&(yn=0)),gt(e)}function q1(e,t){t===0&&(t=Ar()),e=Ol(e,t),e!==null&&(Sa(e,t),gt(e))}function qh(e){var t=e.memoizedState,l=0;t!==null&&(l=t.retryLane),q1(e,l)}function Uh(e,t){var l=0;switch(e.tag){case 31:case 13:var n=e.stateNode,a=e.memoizedState;a!==null&&(l=a.retryLane);break;case 19:n=e.stateNode;break;case 22:n=e.stateNode._retryCache;break;default:throw Error(z(314))}n!==null&&n.delete(t),q1(e,l)}function Hh(e,t){return nf(e,t)}var Nu=null,Xl=null,Ri=!1,Ou=!1,Rc=!1,Ft=0;function gt(e){e!==Xl&&e.next===null&&(Xl===null?Nu=Xl=e:Xl=Xl.next=e),Ou=!0,Ri||(Ri=!0,Xh())}function ja(e,t){if(!Rc&&Ou){Rc=!0;do for(var l=!1,n=Nu;n!==null;){if(e!==0){var a=n.pendingLanes;if(a===0)var u=0;else{var c=n.suspendedLanes,i=n.pingedLanes;u=(1<<31-Ve(42|e)+1)-1,u&=a&~(c&~i),u=u&201326741?u&201326741|1:u?u|2:0}u!==0&&(l=!0,mo(n,u))}else u=B,u=Gu(n,n===F?u:0,n.cancelPendingCommit!==null||n.timeoutHandle!==-1),!(u&3)||ba(n,u)||(l=!0,mo(n,u));n=n.next}while(l);Rc=!1}}function Bh(){U1()}function U1(){Ou=Ri=!1;var e=0;Ft!==0&&Fh()&&(e=Ft);for(var t=Ye(),l=null,n=Nu;n!==null;){var a=n.next,u=H1(n,t);u===0?(n.next=null,l===null?Nu=a:l.next=a,a===null&&(Xl=l)):(l=n,(e!==0||u&3)&&(Ou=!0)),n=a}ye!==0&&ye!==5||ja(e),Ft!==0&&(Ft=0)}function H1(e,t){for(var l=e.suspendedLanes,n=e.pingedLanes,a=e.expirationTimes,u=e.pendingLanes&-62914561;0<u;){var c=31-Ve(u),i=1<<c,f=a[c];f===-1?(!(i&l)||i&n)&&(a[c]=mm(i,t)):f<=t&&(e.expiredLanes|=i),u&=~i}if(t=F,l=B,l=Gu(e,e===t?l:0,e.cancelPendingCommit!==null||e.timeoutHandle!==-1),n=e.callbackNode,l===0||e===t&&(Q===2||Q===9)||e.cancelPendingCommit!==null)return n!==null&&n!==null&&oc(n),e.callbackNode=null,e.callbackPriority=0;if(!(l&3)||ba(e,l)){if(t=l&-l,t===e.callbackPriority)return t;switch(n!==null&&oc(n),uf(l)){case 2:case 8:l=jr;break;case 32:l=hu;break;case 268435456:l=Mr;break;default:l=hu}return n=B1.bind(null,e),l=nf(l,n),e.callbackPriority=t,e.callbackNode=l,t}return n!==null&&n!==null&&oc(n),e.callbackPriority=2,e.callbackNode=null,2}function B1(e,t){if(ye!==0&&ye!==5)return e.callbackNode=null,e.callbackPriority=0,null;var l=e.callbackNode;if(nc()&&e.callbackNode!==l)return null;var n=B;return n=Gu(e,e===F?n:0,e.cancelPendingCommit!==null||e.timeoutHandle!==-1),n===0?null:(T1(e,n,t),H1(e,Ye()),e.callbackNode!=null&&e.callbackNode===l?B1.bind(null,e):null)}function mo(e,t){if(nc())return null;T1(e,t,!0)}function Xh(){Ph(function(){Z&6?nf(Tr,Bh):U1()})}function Yf(){if(Ft===0){var e=dn;e===0&&(e=Na,Na<<=1,!(Na&261888)&&(Na=256)),Ft=e}return Ft}function ho(e){return e==null||typeof e=="symbol"||typeof e=="boolean"?null:typeof e=="function"?e:Wa(""+e)}function yo(e,t){var l=t.ownerDocument.createElement("input");return l.name=t.name,l.value=t.value,e.id&&l.setAttribute("form",e.id),t.parentNode.insertBefore(l,t),e=new FormData(e),l.parentNode.removeChild(l),e}function Lh(e,t,l,n,a){if(t==="submit"&&l&&l.stateNode===a){var u=ho((a[qe]||null).action),c=n.submitter;c&&(t=(t=c[qe]||null)?ho(t.formAction):c.getAttribute("formAction"),t!==null&&(u=t,c=null));var i=new Yu("action","action",null,n,a);e.push({event:i,listeners:[{instance:null,listener:function(){if(n.defaultPrevented){if(Ft!==0){var f=c?yo(a,c):new FormData(a);ji(l,{pending:!0,data:f,method:a.method,action:u},null,f)}}else typeof u=="function"&&(i.preventDefault(),f=c?yo(a,c):new FormData(a),ji(l,{pending:!0,data:f,method:a.method,action:u},u,f))},currentTarget:a}]})}}for(var qc=0;qc<hi.length;qc++){var Uc=hi[qc],Gh=Uc.toLowerCase(),Yh=Uc[0].toUpperCase()+Uc.slice(1);ot(Gh,"on"+Yh)}ot(Ir,"onAnimationEnd");ot(Pr,"onAnimationIteration");ot(ed,"onAnimationStart");ot("dblclick","onDoubleClick");ot("focusin","onFocus");ot("focusout","onBlur");ot(ch,"onTransitionRun");ot(ih,"onTransitionStart");ot(fh,"onTransitionCancel");ot(td,"onTransitionEnd");on("onMouseEnter",["mouseout","mouseover"]);on("onMouseLeave",["mouseout","mouseover"]);on("onPointerEnter",["pointerout","pointerover"]);on("onPointerLeave",["pointerout","pointerover"]);Dl("onChange","change click focusin focusout input keydown keyup selectionchange".split(" "));Dl("onSelect","focusout contextmenu dragend focusin keydown keyup mousedown mouseup selectionchange".split(" "));Dl("onBeforeInput",["compositionend","keypress","textInput","paste"]);Dl("onCompositionEnd","compositionend focusout keydown keypress keyup mousedown".split(" "));Dl("onCompositionStart","compositionstart focusout keydown keypress keyup mousedown".split(" "));Dl("onCompositionUpdate","compositionupdate focusout keydown keypress keyup mousedown".split(" "));var oa="abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting".split(" "),Zh=new Set("beforetoggle cancel close invalid load scroll scrollend toggle".split(" ").concat(oa));function X1(e,t){t=(t&4)!==0;for(var l=0;l<e.length;l++){var n=e[l],a=n.event;n=n.listeners;e:{var u=void 0;if(t)for(var c=n.length-1;0<=c;c--){var i=n[c],f=i.instance,s=i.currentTarget;if(i=i.listener,f!==u&&a.isPropagationStopped())break e;u=i,a.currentTarget=s;try{u(a)}catch(d){vu(d)}a.currentTarget=null,u=f}else for(c=0;c<n.length;c++){if(i=n[c],f=i.instance,s=i.currentTarget,i=i.listener,f!==u&&a.isPropagationStopped())break e;u=i,a.currentTarget=s;try{u(a)}catch(d){vu(d)}a.currentTarget=null,u=f}}}}function U(e,t){var l=t[ci];l===void 0&&(l=t[ci]=new Set);var n=e+"__bubble";l.has(n)||(L1(t,e,2,!1),l.add(n))}function Hc(e,t,l){var n=0;t&&(n|=4),L1(l,e,n,t)}var Xa="_reactListening"+Math.random().toString(36).slice(2);function Zf(e){if(!e[Xa]){e[Xa]=!0,Cr.forEach(function(l){l!=="selectionchange"&&(Zh.has(l)||Hc(l,!1,e),Hc(l,!0,e))});var t=e.nodeType===9?e:e.ownerDocument;t===null||t[Xa]||(t[Xa]=!0,Hc("selectionchange",!1,t))}}function L1(e,t,l,n){switch(t0(t)){case 2:var a=by;break;case 8:a=Sy;break;default:a=Jf}l=a.bind(null,t,l,e),a=void 0,!ri||t!=="touchstart"&&t!=="touchmove"&&t!=="wheel"||(a=!0),n?a!==void 0?e.addEventListener(t,l,{capture:!0,passive:a}):e.addEventListener(t,l,!0):a!==void 0?e.addEventListener(t,l,{passive:a}):e.addEventListener(t,l,!1)}function Bc(e,t,l,n,a){var u=n;if(!(t&1)&&!(t&2)&&n!==null)e:for(;;){if(n===null)return;var c=n.tag;if(c===3||c===4){var i=n.stateNode.containerInfo;if(i===a)break;if(c===4)for(c=n.return;c!==null;){var f=c.tag;if((f===3||f===4)&&c.stateNode.containerInfo===a)return;c=c.return}for(;i!==null;){if(c=Yl(i),c===null)return;if(f=c.tag,f===5||f===6||f===26||f===27){n=u=c;continue e}i=i.parentNode}}n=n.return}Xr(function(){var s=u,d=sf(l),g=[];e:{var r=ld.get(e);if(r!==void 0){var x=Yu,S=e;switch(e){case"keypress":if(Ia(l)===0)break e;case"keydown":case"keyup":x=Um;break;case"focusin":S="focus",x=yc;break;case"focusout":S="blur",x=yc;break;case"beforeblur":case"afterblur":x=yc;break;case"click":if(l.button===2)break e;case"auxclick":case"dblclick":case"mousedown":case"mousemove":case"mouseup":case"mouseout":case"mouseover":case"contextmenu":x=ks;break;case"drag":case"dragend":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"dragstart":case"drop":x=jm;break;case"touchcancel":case"touchend":case"touchmove":case"touchstart":x=Xm;break;case Ir:case Pr:case ed:x=Dm;break;case td:x=Gm;break;case"scroll":case"scrollend":x=Em;break;case"wheel":x=Zm;break;case"copy":case"cut":case"paste":x=Nm;break;case"gotpointercapture":case"lostpointercapture":case"pointercancel":case"pointerdown":case"pointermove":case"pointerout":case"pointerover":case"pointerup":x=Es;break;case"toggle":case"beforetoggle":x=Qm}var p=(t&4)!==0,k=!p&&(e==="scroll"||e==="scrollend"),h=p?r!==null?r+"Capture":null:r;p=[];for(var o=s,m;o!==null;){var b=o;if(m=b.stateNode,b=b.tag,b!==5&&b!==26&&b!==27||m===null||h===null||(b=la(o,h),b!=null&&p.push(ra(o,b,m))),k)break;o=o.return}0<p.length&&(r=new x(r,S,null,l,d),g.push({event:r,listeners:p}))}}if(!(t&7)){e:{if(r=e==="mouseover"||e==="pointerover",x=e==="mouseout"||e==="pointerout",r&&l!==oi&&(S=l.relatedTarget||l.fromElement)&&(Yl(S)||S[pn]))break e;if((x||r)&&(r=d.window===d?d:(r=d.ownerDocument)?r.defaultView||r.parentWindow:window,x?(S=l.relatedTarget||l.toElement,x=s,S=S?Yl(S):null,S!==null&&(k=xa(S),p=S.tag,S!==k||p!==5&&p!==27&&p!==6)&&(S=null)):(x=null,S=s),x!==S)){if(p=ks,b="onMouseLeave",h="onMouseEnter",o="mouse",(e==="pointerout"||e==="pointerover")&&(p=Es,b="onPointerLeave",h="onPointerEnter",o="pointer"),k=x==null?r:Un(x),m=S==null?r:Un(S),r=new p(b,o+"leave",x,l,d),r.target=k,r.relatedTarget=m,b=null,Yl(d)===s&&(p=new p(h,o+"enter",S,l,d),p.target=m,p.relatedTarget=k,b=p),k=b,x&&S)t:{for(p=Vh,h=x,o=S,m=0,b=h;b;b=p(b))m++;b=0;for(var T=o;T;T=p(T))b++;for(;0<m-b;)h=p(h),m--;for(;0<b-m;)o=p(o),b--;for(;m--;){if(h===o||o!==null&&h===o.alternate){p=h;break t}h=p(h),o=p(o)}p=null}else p=null;x!==null&&vo(g,r,x,p,!1),S!==null&&k!==null&&vo(g,k,S,p,!0)}}e:{if(r=s?Un(s):window,x=r.nodeName&&r.nodeName.toLowerCase(),x==="select"||x==="input"&&r.type==="file")var N=As;else if(Ms(r))if(Qr)N=nh;else{N=th;var E=eh}else x=r.nodeName,!x||x.toLowerCase()!=="input"||r.type!=="checkbox"&&r.type!=="radio"?s&&ff(s.elementType)&&(N=As):N=lh;if(N&&(N=N(e,s))){Vr(g,N,l,d);break e}E&&E(e,r,s),e==="focusout"&&s&&r.type==="number"&&s.memoizedProps.value!=null&&si(r,"number",r.value)}switch(E=s?Un(s):window,e){case"focusin":(Ms(E)||E.contentEditable==="true")&&(Ql=E,di=s,Yn=null);break;case"focusout":Yn=di=Ql=null;break;case"mousedown":mi=!0;break;case"contextmenu":case"mouseup":case"dragend":mi=!1,Cs(g,l,d);break;case"selectionchange":if(uh)break;case"keydown":case"keyup":Cs(g,l,d)}var j;if(df)e:{switch(e){case"compositionstart":var A="onCompositionStart";break e;case"compositionend":A="onCompositionEnd";break e;case"compositionupdate":A="onCompositionUpdate";break e}A=void 0}else Vl?Yr(e,l)&&(A="onCompositionEnd"):e==="keydown"&&l.keyCode===229&&(A="onCompositionStart");A&&(Gr&&l.locale!=="ko"&&(Vl||A!=="onCompositionStart"?A==="onCompositionEnd"&&Vl&&(j=Lr()):(Kt=d,of="value"in Kt?Kt.value:Kt.textContent,Vl=!0)),E=Cu(s,A),0<E.length&&(A=new zs(A,e,null,l,d),g.push({event:A,listeners:E}),j?A.data=j:(j=Zr(l),j!==null&&(A.data=j)))),(j=Jm?Wm(e,l):Fm(e,l))&&(A=Cu(s,"onBeforeInput"),0<A.length&&(E=new zs("onBeforeInput","beforeinput",null,l,d),g.push({event:E,listeners:A}),E.data=j)),Lh(g,e,s,l,d)}X1(g,t)})}function ra(e,t,l){return{instance:e,listener:t,currentTarget:l}}function Cu(e,t){for(var l=t+"Capture",n=[];e!==null;){var a=e,u=a.stateNode;if(a=a.tag,a!==5&&a!==26&&a!==27||u===null||(a=la(e,l),a!=null&&n.unshift(ra(e,a,u)),a=la(e,t),a!=null&&n.push(ra(e,a,u))),e.tag===3)return n;e=e.return}return[]}function Vh(e){if(e===null)return null;do e=e.return;while(e&&e.tag!==5&&e.tag!==27);return e||null}function vo(e,t,l,n,a){for(var u=t._reactName,c=[];l!==null&&l!==n;){var i=l,f=i.alternate,s=i.stateNode;if(i=i.tag,f!==null&&f===n)break;i!==5&&i!==26&&i!==27||s===null||(f=s,a?(s=la(l,u),s!=null&&c.unshift(ra(l,s,f))):a||(s=la(l,u),s!=null&&c.push(ra(l,s,f)))),l=l.return}c.length!==0&&e.push({event:t,listeners:c})}var Qh=/\r\n?/g,Kh=/\u0000|\uFFFD/g;function xo(e){return(typeof e=="string"?e:""+e).replace(Qh,`
+`).replace(Kh,"")}function G1(e,t){return t=xo(t),xo(e)===t}function J(e,t,l,n,a,u){switch(l){case"children":typeof n=="string"?t==="body"||t==="textarea"&&n===""||rn(e,n):(typeof n=="number"||typeof n=="bigint")&&t!=="body"&&rn(e,""+n);break;case"className":$a(e,"class",n);break;case"tabIndex":$a(e,"tabindex",n);break;case"dir":case"role":case"viewBox":case"width":case"height":$a(e,l,n);break;case"style":Br(e,n,u);break;case"data":if(t!=="object"){$a(e,"data",n);break}case"src":case"href":if(n===""&&(t!=="a"||l!=="href")){e.removeAttribute(l);break}if(n==null||typeof n=="function"||typeof n=="symbol"||typeof n=="boolean"){e.removeAttribute(l);break}n=Wa(""+n),e.setAttribute(l,n);break;case"action":case"formAction":if(typeof n=="function"){e.setAttribute(l,"javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')");break}else typeof u=="function"&&(l==="formAction"?(t!=="input"&&J(e,t,"name",a.name,a,null),J(e,t,"formEncType",a.formEncType,a,null),J(e,t,"formMethod",a.formMethod,a,null),J(e,t,"formTarget",a.formTarget,a,null)):(J(e,t,"encType",a.encType,a,null),J(e,t,"method",a.method,a,null),J(e,t,"target",a.target,a,null)));if(n==null||typeof n=="symbol"||typeof n=="boolean"){e.removeAttribute(l);break}n=Wa(""+n),e.setAttribute(l,n);break;case"onClick":n!=null&&(e.onclick=At);break;case"onScroll":n!=null&&U("scroll",e);break;case"onScrollEnd":n!=null&&U("scrollend",e);break;case"dangerouslySetInnerHTML":if(n!=null){if(typeof n!="object"||!("__html"in n))throw Error(z(61));if(l=n.__html,l!=null){if(a.children!=null)throw Error(z(60));e.innerHTML=l}}break;case"multiple":e.multiple=n&&typeof n!="function"&&typeof n!="symbol";break;case"muted":e.muted=n&&typeof n!="function"&&typeof n!="symbol";break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"defaultValue":case"defaultChecked":case"innerHTML":case"ref":break;case"autoFocus":break;case"xlinkHref":if(n==null||typeof n=="function"||typeof n=="boolean"||typeof n=="symbol"){e.removeAttribute("xlink:href");break}l=Wa(""+n),e.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",l);break;case"contentEditable":case"spellCheck":case"draggable":case"value":case"autoReverse":case"externalResourcesRequired":case"focusable":case"preserveAlpha":n!=null&&typeof n!="function"&&typeof n!="symbol"?e.setAttribute(l,""+n):e.removeAttribute(l);break;case"inert":case"allowFullScreen":case"async":case"autoPlay":case"controls":case"default":case"defer":case"disabled":case"disablePictureInPicture":case"disableRemotePlayback":case"formNoValidate":case"hidden":case"loop":case"noModule":case"noValidate":case"open":case"playsInline":case"readOnly":case"required":case"reversed":case"scoped":case"seamless":case"itemScope":n&&typeof n!="function"&&typeof n!="symbol"?e.setAttribute(l,""):e.removeAttribute(l);break;case"capture":case"download":n===!0?e.setAttribute(l,""):n!==!1&&n!=null&&typeof n!="function"&&typeof n!="symbol"?e.setAttribute(l,n):e.removeAttribute(l);break;case"cols":case"rows":case"size":case"span":n!=null&&typeof n!="function"&&typeof n!="symbol"&&!isNaN(n)&&1<=n?e.setAttribute(l,n):e.removeAttribute(l);break;case"rowSpan":case"start":n==null||typeof n=="function"||typeof n=="symbol"||isNaN(n)?e.removeAttribute(l):e.setAttribute(l,n);break;case"popover":U("beforetoggle",e),U("toggle",e),Ja(e,"popover",n);break;case"xlinkActuate":St(e,"http://www.w3.org/1999/xlink","xlink:actuate",n);break;case"xlinkArcrole":St(e,"http://www.w3.org/1999/xlink","xlink:arcrole",n);break;case"xlinkRole":St(e,"http://www.w3.org/1999/xlink","xlink:role",n);break;case"xlinkShow":St(e,"http://www.w3.org/1999/xlink","xlink:show",n);break;case"xlinkTitle":St(e,"http://www.w3.org/1999/xlink","xlink:title",n);break;case"xlinkType":St(e,"http://www.w3.org/1999/xlink","xlink:type",n);break;case"xmlBase":St(e,"http://www.w3.org/XML/1998/namespace","xml:base",n);break;case"xmlLang":St(e,"http://www.w3.org/XML/1998/namespace","xml:lang",n);break;case"xmlSpace":St(e,"http://www.w3.org/XML/1998/namespace","xml:space",n);break;case"is":Ja(e,"is",n);break;case"innerText":case"textContent":break;default:(!(2<l.length)||l[0]!=="o"&&l[0]!=="O"||l[1]!=="n"&&l[1]!=="N")&&(l=km.get(l)||l,Ja(e,l,n))}}function qi(e,t,l,n,a,u){switch(l){case"style":Br(e,n,u);break;case"dangerouslySetInnerHTML":if(n!=null){if(typeof n!="object"||!("__html"in n))throw Error(z(61));if(l=n.__html,l!=null){if(a.children!=null)throw Error(z(60));e.innerHTML=l}}break;case"children":typeof n=="string"?rn(e,n):(typeof n=="number"||typeof n=="bigint")&&rn(e,""+n);break;case"onScroll":n!=null&&U("scroll",e);break;case"onScrollEnd":n!=null&&U("scrollend",e);break;case"onClick":n!=null&&(e.onclick=At);break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"innerHTML":case"ref":break;case"innerText":case"textContent":break;default:if(!$r.hasOwnProperty(l))e:{if(l[0]==="o"&&l[1]==="n"&&(a=l.endsWith("Capture"),t=l.slice(2,a?l.length-7:void 0),u=e[qe]||null,u=u!=null?u[l]:null,typeof u=="function"&&e.removeEventListener(t,u,a),typeof n=="function")){typeof u!="function"&&u!==null&&(l in e?e[l]=null:e.hasAttribute(l)&&e.removeAttribute(l)),e.addEventListener(t,n,a);break e}l in e?e[l]=n:n===!0?e.setAttribute(l,""):Ja(e,l,n)}}}function Me(e,t,l){switch(t){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"img":U("error",e),U("load",e);var n=!1,a=!1,u;for(u in l)if(l.hasOwnProperty(u)){var c=l[u];if(c!=null)switch(u){case"src":n=!0;break;case"srcSet":a=!0;break;case"children":case"dangerouslySetInnerHTML":throw Error(z(137,t));default:J(e,t,u,c,l,null)}}a&&J(e,t,"srcSet",l.srcSet,l,null),n&&J(e,t,"src",l.src,l,null);return;case"input":U("invalid",e);var i=u=c=a=null,f=null,s=null;for(n in l)if(l.hasOwnProperty(n)){var d=l[n];if(d!=null)switch(n){case"name":a=d;break;case"type":c=d;break;case"checked":f=d;break;case"defaultChecked":s=d;break;case"value":u=d;break;case"defaultValue":i=d;break;case"children":case"dangerouslySetInnerHTML":if(d!=null)throw Error(z(137,t));break;default:J(e,t,n,d,l,null)}}qr(e,u,i,f,s,c,a,!1);return;case"select":U("invalid",e),n=c=u=null;for(a in l)if(l.hasOwnProperty(a)&&(i=l[a],i!=null))switch(a){case"value":u=i;break;case"defaultValue":c=i;break;case"multiple":n=i;default:J(e,t,a,i,l,null)}t=u,l=c,e.multiple=!!n,t!=null?ln(e,!!n,t,!1):l!=null&&ln(e,!!n,l,!0);return;case"textarea":U("invalid",e),u=a=n=null;for(c in l)if(l.hasOwnProperty(c)&&(i=l[c],i!=null))switch(c){case"value":n=i;break;case"defaultValue":a=i;break;case"children":u=i;break;case"dangerouslySetInnerHTML":if(i!=null)throw Error(z(91));break;default:J(e,t,c,i,l,null)}Hr(e,n,a,u);return;case"option":for(f in l)if(l.hasOwnProperty(f)&&(n=l[f],n!=null))switch(f){case"selected":e.selected=n&&typeof n!="function"&&typeof n!="symbol";break;default:J(e,t,f,n,l,null)}return;case"dialog":U("beforetoggle",e),U("toggle",e),U("cancel",e),U("close",e);break;case"iframe":case"object":U("load",e);break;case"video":case"audio":for(n=0;n<oa.length;n++)U(oa[n],e);break;case"image":U("error",e),U("load",e);break;case"details":U("toggle",e);break;case"embed":case"source":case"link":U("error",e),U("load",e);case"area":case"base":case"br":case"col":case"hr":case"keygen":case"meta":case"param":case"track":case"wbr":case"menuitem":for(s in l)if(l.hasOwnProperty(s)&&(n=l[s],n!=null))switch(s){case"children":case"dangerouslySetInnerHTML":throw Error(z(137,t));default:J(e,t,s,n,l,null)}return;default:if(ff(t)){for(d in l)l.hasOwnProperty(d)&&(n=l[d],n!==void 0&&qi(e,t,d,n,l,void 0));return}}for(i in l)l.hasOwnProperty(i)&&(n=l[i],n!=null&&J(e,t,i,n,l,null))}function Jh(e,t,l,n){switch(t){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"input":var a=null,u=null,c=null,i=null,f=null,s=null,d=null;for(x in l){var g=l[x];if(l.hasOwnProperty(x)&&g!=null)switch(x){case"checked":break;case"value":break;case"defaultValue":f=g;default:n.hasOwnProperty(x)||J(e,t,x,null,n,g)}}for(var r in n){var x=n[r];if(g=l[r],n.hasOwnProperty(r)&&(x!=null||g!=null))switch(r){case"type":u=x;break;case"name":a=x;break;case"checked":s=x;break;case"defaultChecked":d=x;break;case"value":c=x;break;case"defaultValue":i=x;break;case"children":case"dangerouslySetInnerHTML":if(x!=null)throw Error(z(137,t));break;default:x!==g&&J(e,t,r,x,n,g)}}fi(e,c,i,f,s,d,u,a);return;case"select":x=c=i=r=null;for(u in l)if(f=l[u],l.hasOwnProperty(u)&&f!=null)switch(u){case"value":break;case"multiple":x=f;default:n.hasOwnProperty(u)||J(e,t,u,null,n,f)}for(a in n)if(u=n[a],f=l[a],n.hasOwnProperty(a)&&(u!=null||f!=null))switch(a){case"value":r=u;break;case"defaultValue":i=u;break;case"multiple":c=u;default:u!==f&&J(e,t,a,u,n,f)}t=i,l=c,n=x,r!=null?ln(e,!!l,r,!1):!!n!=!!l&&(t!=null?ln(e,!!l,t,!0):ln(e,!!l,l?[]:"",!1));return;case"textarea":x=r=null;for(i in l)if(a=l[i],l.hasOwnProperty(i)&&a!=null&&!n.hasOwnProperty(i))switch(i){case"value":break;case"children":break;default:J(e,t,i,null,n,a)}for(c in n)if(a=n[c],u=l[c],n.hasOwnProperty(c)&&(a!=null||u!=null))switch(c){case"value":r=a;break;case"defaultValue":x=a;break;case"children":break;case"dangerouslySetInnerHTML":if(a!=null)throw Error(z(91));break;default:a!==u&&J(e,t,c,a,n,u)}Ur(e,r,x);return;case"option":for(var S in l)if(r=l[S],l.hasOwnProperty(S)&&r!=null&&!n.hasOwnProperty(S))switch(S){case"selected":e.selected=!1;break;default:J(e,t,S,null,n,r)}for(f in n)if(r=n[f],x=l[f],n.hasOwnProperty(f)&&r!==x&&(r!=null||x!=null))switch(f){case"selected":e.selected=r&&typeof r!="function"&&typeof r!="symbol";break;default:J(e,t,f,r,n,x)}return;case"img":case"link":case"area":case"base":case"br":case"col":case"embed":case"hr":case"keygen":case"meta":case"param":case"source":case"track":case"wbr":case"menuitem":for(var p in l)r=l[p],l.hasOwnProperty(p)&&r!=null&&!n.hasOwnProperty(p)&&J(e,t,p,null,n,r);for(s in n)if(r=n[s],x=l[s],n.hasOwnProperty(s)&&r!==x&&(r!=null||x!=null))switch(s){case"children":case"dangerouslySetInnerHTML":if(r!=null)throw Error(z(137,t));break;default:J(e,t,s,r,n,x)}return;default:if(ff(t)){for(var k in l)r=l[k],l.hasOwnProperty(k)&&r!==void 0&&!n.hasOwnProperty(k)&&qi(e,t,k,void 0,n,r);for(d in n)r=n[d],x=l[d],!n.hasOwnProperty(d)||r===x||r===void 0&&x===void 0||qi(e,t,d,r,n,x);return}}for(var h in l)r=l[h],l.hasOwnProperty(h)&&r!=null&&!n.hasOwnProperty(h)&&J(e,t,h,null,n,r);for(g in n)r=n[g],x=l[g],!n.hasOwnProperty(g)||r===x||r==null&&x==null||J(e,t,g,r,n,x)}function go(e){switch(e){case"css":case"script":case"font":case"img":case"image":case"input":case"link":return!0;default:return!1}}function Wh(){if(typeof performance.getEntriesByType=="function"){for(var e=0,t=0,l=performance.getEntriesByType("resource"),n=0;n<l.length;n++){var a=l[n],u=a.transferSize,c=a.initiatorType,i=a.duration;if(u&&i&&go(c)){for(c=0,i=a.responseEnd,n+=1;n<l.length;n++){var f=l[n],s=f.startTime;if(s>i)break;var d=f.transferSize,g=f.initiatorType;d&&go(g)&&(f=f.responseEnd,c+=d*(f<i?1:(i-s)/(f-s)))}if(--n,t+=8*(u+c)/(a.duration/1e3),e++,10<e)break}}if(0<e)return t/e/1e6}return navigator.connection&&(e=navigator.connection.downlink,typeof e=="number")?e:5}var Ui=null,Hi=null;function $u(e){return e.nodeType===9?e:e.ownerDocument}function bo(e){switch(e){case"http://www.w3.org/2000/svg":return 1;case"http://www.w3.org/1998/Math/MathML":return 2;default:return 0}}function Y1(e,t){if(e===0)switch(t){case"svg":return 1;case"math":return 2;default:return 0}return e===1&&t==="foreignObject"?0:e}function Bi(e,t){return e==="textarea"||e==="noscript"||typeof t.children=="string"||typeof t.children=="number"||typeof t.children=="bigint"||typeof t.dangerouslySetInnerHTML=="object"&&t.dangerouslySetInnerHTML!==null&&t.dangerouslySetInnerHTML.__html!=null}var Xc=null;function Fh(){var e=window.event;return e&&e.type==="popstate"?e===Xc?!1:(Xc=e,!0):(Xc=null,!1)}var Z1=typeof setTimeout=="function"?setTimeout:void 0,Ih=typeof clearTimeout=="function"?clearTimeout:void 0,So=typeof Promise=="function"?Promise:void 0,Ph=typeof queueMicrotask=="function"?queueMicrotask:typeof So<"u"?function(e){return So.resolve(null).then(e).catch(ey)}:Z1;function ey(e){setTimeout(function(){throw e})}function dl(e){return e==="head"}function po(e,t){var l=t,n=0;do{var a=l.nextSibling;if(e.removeChild(l),a&&a.nodeType===8)if(l=a.data,l==="/$"||l==="/&"){if(n===0){e.removeChild(a),bn(t);return}n--}else if(l==="$"||l==="$?"||l==="$~"||l==="$!"||l==="&")n++;else if(l==="html")ea(e.ownerDocument.documentElement);else if(l==="head"){l=e.ownerDocument.head,ea(l);for(var u=l.firstChild;u;){var c=u.nextSibling,i=u.nodeName;u[pa]||i==="SCRIPT"||i==="STYLE"||i==="LINK"&&u.rel.toLowerCase()==="stylesheet"||l.removeChild(u),u=c}}else l==="body"&&ea(e.ownerDocument.body);l=a}while(l);bn(t)}function ko(e,t){var l=e;e=0;do{var n=l.nextSibling;if(l.nodeType===1?t?(l._stashedDisplay=l.style.display,l.style.display="none"):(l.style.display=l._stashedDisplay||"",l.getAttribute("style")===""&&l.removeAttribute("style")):l.nodeType===3&&(t?(l._stashedText=l.nodeValue,l.nodeValue=""):l.nodeValue=l._stashedText||""),n&&n.nodeType===8)if(l=n.data,l==="/$"){if(e===0)break;e--}else l!=="$"&&l!=="$?"&&l!=="$~"&&l!=="$!"||e++;l=n}while(l)}function Xi(e){var t=e.firstChild;for(t&&t.nodeType===10&&(t=t.nextSibling);t;){var l=t;switch(t=t.nextSibling,l.nodeName){case"HTML":case"HEAD":case"BODY":Xi(l),cf(l);continue;case"SCRIPT":case"STYLE":continue;case"LINK":if(l.rel.toLowerCase()==="stylesheet")continue}e.removeChild(l)}}function ty(e,t,l,n){for(;e.nodeType===1;){var a=l;if(e.nodeName.toLowerCase()!==t.toLowerCase()){if(!n&&(e.nodeName!=="INPUT"||e.type!=="hidden"))break}else if(n){if(!e[pa])switch(t){case"meta":if(!e.hasAttribute("itemprop"))break;return e;case"link":if(u=e.getAttribute("rel"),u==="stylesheet"&&e.hasAttribute("data-precedence"))break;if(u!==a.rel||e.getAttribute("href")!==(a.href==null||a.href===""?null:a.href)||e.getAttribute("crossorigin")!==(a.crossOrigin==null?null:a.crossOrigin)||e.getAttribute("title")!==(a.title==null?null:a.title))break;return e;case"style":if(e.hasAttribute("data-precedence"))break;return e;case"script":if(u=e.getAttribute("src"),(u!==(a.src==null?null:a.src)||e.getAttribute("type")!==(a.type==null?null:a.type)||e.getAttribute("crossorigin")!==(a.crossOrigin==null?null:a.crossOrigin))&&u&&e.hasAttribute("async")&&!e.hasAttribute("itemprop"))break;return e;default:return e}}else if(t==="input"&&e.type==="hidden"){var u=a.name==null?null:""+a.name;if(a.type==="hidden"&&e.getAttribute("name")===u)return e}else return e;if(e=ct(e.nextSibling),e===null)break}return null}function ly(e,t,l){if(t==="")return null;for(;e.nodeType!==3;)if((e.nodeType!==1||e.nodeName!=="INPUT"||e.type!=="hidden")&&!l||(e=ct(e.nextSibling),e===null))return null;return e}function V1(e,t){for(;e.nodeType!==8;)if((e.nodeType!==1||e.nodeName!=="INPUT"||e.type!=="hidden")&&!t||(e=ct(e.nextSibling),e===null))return null;return e}function Li(e){return e.data==="$?"||e.data==="$~"}function Gi(e){return e.data==="$!"||e.data==="$?"&&e.ownerDocument.readyState!=="loading"}function ny(e,t){var l=e.ownerDocument;if(e.data==="$~")e._reactRetry=t;else if(e.data!=="$?"||l.readyState!=="loading")t();else{var n=function(){t(),l.removeEventListener("DOMContentLoaded",n)};l.addEventListener("DOMContentLoaded",n),e._reactRetry=n}}function ct(e){for(;e!=null;e=e.nextSibling){var t=e.nodeType;if(t===1||t===3)break;if(t===8){if(t=e.data,t==="$"||t==="$!"||t==="$?"||t==="$~"||t==="&"||t==="F!"||t==="F")break;if(t==="/$"||t==="/&")return null}}return e}var Yi=null;function zo(e){e=e.nextSibling;for(var t=0;e;){if(e.nodeType===8){var l=e.data;if(l==="/$"||l==="/&"){if(t===0)return ct(e.nextSibling);t--}else l!=="$"&&l!=="$!"&&l!=="$?"&&l!=="$~"&&l!=="&"||t++}e=e.nextSibling}return null}function Eo(e){e=e.previousSibling;for(var t=0;e;){if(e.nodeType===8){var l=e.data;if(l==="$"||l==="$!"||l==="$?"||l==="$~"||l==="&"){if(t===0)return e;t--}else l!=="/$"&&l!=="/&"||t++}e=e.previousSibling}return null}function Q1(e,t,l){switch(t=$u(l),e){case"html":if(e=t.documentElement,!e)throw Error(z(452));return e;case"head":if(e=t.head,!e)throw Error(z(453));return e;case"body":if(e=t.body,!e)throw Error(z(454));return e;default:throw Error(z(451))}}function ea(e){for(var t=e.attributes;t.length;)e.removeAttributeNode(t[0]);cf(e)}var it=new Map,To=new Set;function _u(e){return typeof e.getRootNode=="function"?e.getRootNode():e.nodeType===9?e:e.ownerDocument}var Ut=V.d;V.d={f:ay,r:uy,D:cy,C:iy,L:fy,m:sy,X:ry,S:oy,M:dy};function ay(){var e=Ut.f(),t=tc();return e||t}function uy(e){var t=kn(e);t!==null&&t.tag===5&&t.type==="form"?Bd(t):Ut.r(e)}var jn=typeof document>"u"?null:document;function K1(e,t,l){var n=jn;if(n&&typeof t=="string"&&t){var a=lt(t);a='link[rel="'+e+'"][href="'+a+'"]',typeof l=="string"&&(a+='[crossorigin="'+l+'"]'),To.has(a)||(To.add(a),e={rel:e,crossOrigin:l,href:t},n.querySelector(a)===null&&(t=n.createElement("link"),Me(t,"link",e),ge(t),n.head.appendChild(t)))}}function cy(e){Ut.D(e),K1("dns-prefetch",e,null)}function iy(e,t){Ut.C(e,t),K1("preconnect",e,t)}function fy(e,t,l){Ut.L(e,t,l);var n=jn;if(n&&e&&t){var a='link[rel="preload"][as="'+lt(t)+'"]';t==="image"&&l&&l.imageSrcSet?(a+='[imagesrcset="'+lt(l.imageSrcSet)+'"]',typeof l.imageSizes=="string"&&(a+='[imagesizes="'+lt(l.imageSizes)+'"]')):a+='[href="'+lt(e)+'"]';var u=a;switch(t){case"style":u=gn(e);break;case"script":u=Mn(e)}it.has(u)||(e=le({rel:"preload",href:t==="image"&&l&&l.imageSrcSet?void 0:e,as:t},l),it.set(u,e),n.querySelector(a)!==null||t==="style"&&n.querySelector(Ma(u))||t==="script"&&n.querySelector(Aa(u))||(t=n.createElement("link"),Me(t,"link",e),ge(t),n.head.appendChild(t)))}}function sy(e,t){Ut.m(e,t);var l=jn;if(l&&e){var n=t&&typeof t.as=="string"?t.as:"script",a='link[rel="modulepreload"][as="'+lt(n)+'"][href="'+lt(e)+'"]',u=a;switch(n){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":u=Mn(e)}if(!it.has(u)&&(e=le({rel:"modulepreload",href:e},t),it.set(u,e),l.querySelector(a)===null)){switch(n){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":if(l.querySelector(Aa(u)))return}n=l.createElement("link"),Me(n,"link",e),ge(n),l.head.appendChild(n)}}}function oy(e,t,l){Ut.S(e,t,l);var n=jn;if(n&&e){var a=tn(n).hoistableStyles,u=gn(e);t=t||"default";var c=a.get(u);if(!c){var i={loading:0,preload:null};if(c=n.querySelector(Ma(u)))i.loading=5;else{e=le({rel:"stylesheet",href:e,"data-precedence":t},l),(l=it.get(u))&&Vf(e,l);var f=c=n.createElement("link");ge(f),Me(f,"link",e),f._p=new Promise(function(s,d){f.onload=s,f.onerror=d}),f.addEventListener("load",function(){i.loading|=1}),f.addEventListener("error",function(){i.loading|=2}),i.loading|=4,cu(c,t,n)}c={type:"stylesheet",instance:c,count:1,state:i},a.set(u,c)}}}function ry(e,t){Ut.X(e,t);var l=jn;if(l&&e){var n=tn(l).hoistableScripts,a=Mn(e),u=n.get(a);u||(u=l.querySelector(Aa(a)),u||(e=le({src:e,async:!0},t),(t=it.get(a))&&Qf(e,t),u=l.createElement("script"),ge(u),Me(u,"link",e),l.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},n.set(a,u))}}function dy(e,t){Ut.M(e,t);var l=jn;if(l&&e){var n=tn(l).hoistableScripts,a=Mn(e),u=n.get(a);u||(u=l.querySelector(Aa(a)),u||(e=le({src:e,async:!0,type:"module"},t),(t=it.get(a))&&Qf(e,t),u=l.createElement("script"),ge(u),Me(u,"link",e),l.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},n.set(a,u))}}function jo(e,t,l,n){var a=(a=It.current)?_u(a):null;if(!a)throw Error(z(446));switch(e){case"meta":case"title":return null;case"style":return typeof l.precedence=="string"&&typeof l.href=="string"?(t=gn(l.href),l=tn(a).hoistableStyles,n=l.get(t),n||(n={type:"style",instance:null,count:0,state:null},l.set(t,n)),n):{type:"void",instance:null,count:0,state:null};case"link":if(l.rel==="stylesheet"&&typeof l.href=="string"&&typeof l.precedence=="string"){e=gn(l.href);var u=tn(a).hoistableStyles,c=u.get(e);if(c||(a=a.ownerDocument||a,c={type:"stylesheet",instance:null,count:0,state:{loading:0,preload:null}},u.set(e,c),(u=a.querySelector(Ma(e)))&&!u._p&&(c.instance=u,c.state.loading=5),it.has(e)||(l={rel:"preload",as:"style",href:l.href,crossOrigin:l.crossOrigin,integrity:l.integrity,media:l.media,hrefLang:l.hrefLang,referrerPolicy:l.referrerPolicy},it.set(e,l),u||my(a,e,l,c.state))),t&&n===null)throw Error(z(528,""));return c}if(t&&n!==null)throw Error(z(529,""));return null;case"script":return t=l.async,l=l.src,typeof l=="string"&&t&&typeof t!="function"&&typeof t!="symbol"?(t=Mn(l),l=tn(a).hoistableScripts,n=l.get(t),n||(n={type:"script",instance:null,count:0,state:null},l.set(t,n)),n):{type:"void",instance:null,count:0,state:null};default:throw Error(z(444,e))}}function gn(e){return'href="'+lt(e)+'"'}function Ma(e){return'link[rel="stylesheet"]['+e+"]"}function J1(e){return le({},e,{"data-precedence":e.precedence,precedence:null})}function my(e,t,l,n){e.querySelector('link[rel="preload"][as="style"]['+t+"]")?n.loading=1:(t=e.createElement("link"),n.preload=t,t.addEventListener("load",function(){return n.loading|=1}),t.addEventListener("error",function(){return n.loading|=2}),Me(t,"link",l),ge(t),e.head.appendChild(t))}function Mn(e){return'[src="'+lt(e)+'"]'}function Aa(e){return"script[async]"+e}function Mo(e,t,l){if(t.count++,t.instance===null)switch(t.type){case"style":var n=e.querySelector('style[data-href~="'+lt(l.href)+'"]');if(n)return t.instance=n,ge(n),n;var a=le({},l,{"data-href":l.href,"data-precedence":l.precedence,href:null,precedence:null});return n=(e.ownerDocument||e).createElement("style"),ge(n),Me(n,"style",a),cu(n,l.precedence,e),t.instance=n;case"stylesheet":a=gn(l.href);var u=e.querySelector(Ma(a));if(u)return t.state.loading|=4,t.instance=u,ge(u),u;n=J1(l),(a=it.get(a))&&Vf(n,a),u=(e.ownerDocument||e).createElement("link"),ge(u);var c=u;return c._p=new Promise(function(i,f){c.onload=i,c.onerror=f}),Me(u,"link",n),t.state.loading|=4,cu(u,l.precedence,e),t.instance=u;case"script":return u=Mn(l.src),(a=e.querySelector(Aa(u)))?(t.instance=a,ge(a),a):(n=l,(a=it.get(u))&&(n=le({},l),Qf(n,a)),e=e.ownerDocument||e,a=e.createElement("script"),ge(a),Me(a,"link",n),e.head.appendChild(a),t.instance=a);case"void":return null;default:throw Error(z(443,t.type))}else t.type==="stylesheet"&&!(t.state.loading&4)&&(n=t.instance,t.state.loading|=4,cu(n,l.precedence,e));return t.instance}function cu(e,t,l){for(var n=l.querySelectorAll('link[rel="stylesheet"][data-precedence],style[data-precedence]'),a=n.length?n[n.length-1]:null,u=a,c=0;c<n.length;c++){var i=n[c];if(i.dataset.precedence===t)u=i;else if(u!==a)break}u?u.parentNode.insertBefore(e,u.nextSibling):(t=l.nodeType===9?l.head:l,t.insertBefore(e,t.firstChild))}function Vf(e,t){e.crossOrigin==null&&(e.crossOrigin=t.crossOrigin),e.referrerPolicy==null&&(e.referrerPolicy=t.referrerPolicy),e.title==null&&(e.title=t.title)}function Qf(e,t){e.crossOrigin==null&&(e.crossOrigin=t.crossOrigin),e.referrerPolicy==null&&(e.referrerPolicy=t.referrerPolicy),e.integrity==null&&(e.integrity=t.integrity)}var iu=null;function Ao(e,t,l){if(iu===null){var n=new Map,a=iu=new Map;a.set(l,n)}else a=iu,n=a.get(l),n||(n=new Map,a.set(l,n));if(n.has(e))return n;for(n.set(e,null),l=l.getElementsByTagName(e),a=0;a<l.length;a++){var u=l[a];if(!(u[pa]||u[Ee]||e==="link"&&u.getAttribute("rel")==="stylesheet")&&u.namespaceURI!=="http://www.w3.org/2000/svg"){var c=u.getAttribute(t)||"";c=e+c;var i=n.get(c);i?i.push(u):n.set(c,[u])}}return n}function Do(e,t,l){e=e.ownerDocument||e,e.head.insertBefore(l,t==="title"?e.querySelector("head > title"):null)}function hy(e,t,l){if(l===1||t.itemProp!=null)return!1;switch(e){case"meta":case"title":return!0;case"style":if(typeof t.precedence!="string"||typeof t.href!="string"||t.href==="")break;return!0;case"link":if(typeof t.rel!="string"||typeof t.href!="string"||t.href===""||t.onLoad||t.onError)break;switch(t.rel){case"stylesheet":return e=t.disabled,typeof t.precedence=="string"&&e==null;default:return!0}case"script":if(t.async&&typeof t.async!="function"&&typeof t.async!="symbol"&&!t.onLoad&&!t.onError&&t.src&&typeof t.src=="string")return!0}return!1}function W1(e){return!(e.type==="stylesheet"&&!(e.state.loading&3))}function yy(e,t,l,n){if(l.type==="stylesheet"&&(typeof n.media!="string"||matchMedia(n.media).matches!==!1)&&!(l.state.loading&4)){if(l.instance===null){var a=gn(n.href),u=t.querySelector(Ma(a));if(u){t=u._p,t!==null&&typeof t=="object"&&typeof t.then=="function"&&(e.count++,e=Ru.bind(e),t.then(e,e)),l.state.loading|=4,l.instance=u,ge(u);return}u=t.ownerDocument||t,n=J1(n),(a=it.get(a))&&Vf(n,a),u=u.createElement("link"),ge(u);var c=u;c._p=new Promise(function(i,f){c.onload=i,c.onerror=f}),Me(u,"link",n),l.instance=u}e.stylesheets===null&&(e.stylesheets=new Map),e.stylesheets.set(l,t),(t=l.state.preload)&&!(l.state.loading&3)&&(e.count++,l=Ru.bind(e),t.addEventListener("load",l),t.addEventListener("error",l))}}var Lc=0;function vy(e,t){return e.stylesheets&&e.count===0&&fu(e,e.stylesheets),0<e.count||0<e.imgCount?function(l){var n=setTimeout(function(){if(e.stylesheets&&fu(e,e.stylesheets),e.unsuspend){var u=e.unsuspend;e.unsuspend=null,u()}},6e4+t);0<e.imgBytes&&Lc===0&&(Lc=62500*Wh());var a=setTimeout(function(){if(e.waitingForImages=!1,e.count===0&&(e.stylesheets&&fu(e,e.stylesheets),e.unsuspend)){var u=e.unsuspend;e.unsuspend=null,u()}},(e.imgBytes>Lc?50:800)+t);return e.unsuspend=l,function(){e.unsuspend=null,clearTimeout(n),clearTimeout(a)}}:null}function Ru(){if(this.count--,this.count===0&&(this.imgCount===0||!this.waitingForImages)){if(this.stylesheets)fu(this,this.stylesheets);else if(this.unsuspend){var e=this.unsuspend;this.unsuspend=null,e()}}}var qu=null;function fu(e,t){e.stylesheets=null,e.unsuspend!==null&&(e.count++,qu=new Map,t.forEach(xy,e),qu=null,Ru.call(e))}function xy(e,t){if(!(t.state.loading&4)){var l=qu.get(e);if(l)var n=l.get(null);else{l=new Map,qu.set(e,l);for(var a=e.querySelectorAll("link[data-precedence],style[data-precedence]"),u=0;u<a.length;u++){var c=a[u];(c.nodeName==="LINK"||c.getAttribute("media")!=="not all")&&(l.set(c.dataset.precedence,c),n=c)}n&&l.set(null,n)}a=t.instance,c=a.getAttribute("data-precedence"),u=l.get(c)||n,u===n&&l.set(null,a),l.set(c,a),this.count++,n=Ru.bind(this),a.addEventListener("load",n),a.addEventListener("error",n),u?u.parentNode.insertBefore(a,u.nextSibling):(e=e.nodeType===9?e.head:e,e.insertBefore(a,e.firstChild)),t.state.loading|=4}}var da={$$typeof:Mt,Provider:null,Consumer:null,_currentValue:bl,_currentValue2:bl,_threadCount:0};function gy(e,t,l,n,a,u,c,i,f){this.tag=1,this.containerInfo=e,this.pingCache=this.current=this.pendingChildren=null,this.timeoutHandle=-1,this.callbackNode=this.next=this.pendingContext=this.context=this.cancelPendingCommit=null,this.callbackPriority=0,this.expirationTimes=rc(-1),this.entangledLanes=this.shellSuspendCounter=this.errorRecoveryDisabledLanes=this.expiredLanes=this.warmLanes=this.pingedLanes=this.suspendedLanes=this.pendingLanes=0,this.entanglements=rc(0),this.hiddenUpdates=rc(null),this.identifierPrefix=n,this.onUncaughtError=a,this.onCaughtError=u,this.onRecoverableError=c,this.pooledCache=null,this.pooledCacheLanes=0,this.formState=f,this.incompleteTransitions=new Map}function F1(e,t,l,n,a,u,c,i,f,s,d,g){return e=new gy(e,t,l,c,f,s,d,g,i),t=1,u===!0&&(t|=24),u=Le(3,null,null,t),e.current=u,u.stateNode=e,t=bf(),t.refCount++,e.pooledCache=t,t.refCount++,u.memoizedState={element:n,isDehydrated:l,cache:t},kf(u),e}function I1(e){return e?(e=Wl,e):Wl}function P1(e,t,l,n,a,u){a=I1(a),n.context===null?n.context=a:n.pendingContext=a,n=el(t),n.payload={element:l},u=u===void 0?null:u,u!==null&&(n.callback=u),l=tl(e,n,t),l!==null&&(Re(l,e,t),Vn(l,e,t))}function wo(e,t){if(e=e.memoizedState,e!==null&&e.dehydrated!==null){var l=e.retryLane;e.retryLane=l!==0&&l<t?l:t}}function Kf(e,t){wo(e,t),(e=e.alternate)&&wo(e,t)}function e0(e){if(e.tag===13||e.tag===31){var t=Ol(e,67108864);t!==null&&Re(t,e,67108864),Kf(e,67108864)}}function No(e){if(e.tag===13||e.tag===31){var t=Qe();t=af(t);var l=Ol(e,t);l!==null&&Re(l,e,t),Kf(e,t)}}var Uu=!0;function by(e,t,l,n){var a=C.T;C.T=null;var u=V.p;try{V.p=2,Jf(e,t,l,n)}finally{V.p=u,C.T=a}}function Sy(e,t,l,n){var a=C.T;C.T=null;var u=V.p;try{V.p=8,Jf(e,t,l,n)}finally{V.p=u,C.T=a}}function Jf(e,t,l,n){if(Uu){var a=Zi(n);if(a===null)Bc(e,t,n,Hu,l),Oo(e,n);else if(ky(a,e,t,l,n))n.stopPropagation();else if(Oo(e,n),t&4&&-1<py.indexOf(e)){for(;a!==null;){var u=kn(a);if(u!==null)switch(u.tag){case 3:if(u=u.stateNode,u.current.memoizedState.isDehydrated){var c=vl(u.pendingLanes);if(c!==0){var i=u;for(i.pendingLanes|=2,i.entangledLanes|=2;c;){var f=1<<31-Ve(c);i.entanglements[1]|=f,c&=~f}gt(u),!(Z&6)&&(Au=Ye()+500,ja(0))}}break;case 31:case 13:i=Ol(u,2),i!==null&&Re(i,u,2),tc(),Kf(u,2)}if(u=Zi(n),u===null&&Bc(e,t,n,Hu,l),u===a)break;a=u}a!==null&&n.stopPropagation()}else Bc(e,t,n,null,l)}}function Zi(e){return e=sf(e),Wf(e)}var Hu=null;function Wf(e){if(Hu=null,e=Yl(e),e!==null){var t=xa(e);if(t===null)e=null;else{var l=t.tag;if(l===13){if(e=Sr(t),e!==null)return e;e=null}else if(l===31){if(e=pr(t),e!==null)return e;e=null}else if(l===3){if(t.stateNode.current.memoizedState.isDehydrated)return t.tag===3?t.stateNode.containerInfo:null;e=null}else t!==e&&(e=null)}}return Hu=e,null}function t0(e){switch(e){case"beforetoggle":case"cancel":case"click":case"close":case"contextmenu":case"copy":case"cut":case"auxclick":case"dblclick":case"dragend":case"dragstart":case"drop":case"focusin":case"focusout":case"input":case"invalid":case"keydown":case"keypress":case"keyup":case"mousedown":case"mouseup":case"paste":case"pause":case"play":case"pointercancel":case"pointerdown":case"pointerup":case"ratechange":case"reset":case"resize":case"seeked":case"submit":case"toggle":case"touchcancel":case"touchend":case"touchstart":case"volumechange":case"change":case"selectionchange":case"textInput":case"compositionstart":case"compositionend":case"compositionupdate":case"beforeblur":case"afterblur":case"beforeinput":case"blur":case"fullscreenchange":case"focus":case"hashchange":case"popstate":case"select":case"selectstart":return 2;case"drag":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"mousemove":case"mouseout":case"mouseover":case"pointermove":case"pointerout":case"pointerover":case"scroll":case"touchmove":case"wheel":case"mouseenter":case"mouseleave":case"pointerenter":case"pointerleave":return 8;case"message":switch(cm()){case Tr:return 2;case jr:return 8;case hu:case im:return 32;case Mr:return 268435456;default:return 32}default:return 32}}var Vi=!1,al=null,ul=null,cl=null,ma=new Map,ha=new Map,Vt=[],py="mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset".split(" ");function Oo(e,t){switch(e){case"focusin":case"focusout":al=null;break;case"dragenter":case"dragleave":ul=null;break;case"mouseover":case"mouseout":cl=null;break;case"pointerover":case"pointerout":ma.delete(t.pointerId);break;case"gotpointercapture":case"lostpointercapture":ha.delete(t.pointerId)}}function $n(e,t,l,n,a,u){return e===null||e.nativeEvent!==u?(e={blockedOn:t,domEventName:l,eventSystemFlags:n,nativeEvent:u,targetContainers:[a]},t!==null&&(t=kn(t),t!==null&&e0(t)),e):(e.eventSystemFlags|=n,t=e.targetContainers,a!==null&&t.indexOf(a)===-1&&t.push(a),e)}function ky(e,t,l,n,a){switch(t){case"focusin":return al=$n(al,e,t,l,n,a),!0;case"dragenter":return ul=$n(ul,e,t,l,n,a),!0;case"mouseover":return cl=$n(cl,e,t,l,n,a),!0;case"pointerover":var u=a.pointerId;return ma.set(u,$n(ma.get(u)||null,e,t,l,n,a)),!0;case"gotpointercapture":return u=a.pointerId,ha.set(u,$n(ha.get(u)||null,e,t,l,n,a)),!0}return!1}function l0(e){var t=Yl(e.target);if(t!==null){var l=xa(t);if(l!==null){if(t=l.tag,t===13){if(t=Sr(l),t!==null){e.blockedOn=t,ys(e.priority,function(){No(l)});return}}else if(t===31){if(t=pr(l),t!==null){e.blockedOn=t,ys(e.priority,function(){No(l)});return}}else if(t===3&&l.stateNode.current.memoizedState.isDehydrated){e.blockedOn=l.tag===3?l.stateNode.containerInfo:null;return}}}e.blockedOn=null}function su(e){if(e.blockedOn!==null)return!1;for(var t=e.targetContainers;0<t.length;){var l=Zi(e.nativeEvent);if(l===null){l=e.nativeEvent;var n=new l.constructor(l.type,l);oi=n,l.target.dispatchEvent(n),oi=null}else return t=kn(l),t!==null&&e0(t),e.blockedOn=l,!1;t.shift()}return!0}function Co(e,t,l){su(e)&&l.delete(t)}function zy(){Vi=!1,al!==null&&su(al)&&(al=null),ul!==null&&su(ul)&&(ul=null),cl!==null&&su(cl)&&(cl=null),ma.forEach(Co),ha.forEach(Co)}function La(e,t){e.blockedOn===t&&(e.blockedOn=null,Vi||(Vi=!0,ve.unstable_scheduleCallback(ve.unstable_NormalPriority,zy)))}var Ga=null;function $o(e){Ga!==e&&(Ga=e,ve.unstable_scheduleCallback(ve.unstable_NormalPriority,function(){Ga===e&&(Ga=null);for(var t=0;t<e.length;t+=3){var l=e[t],n=e[t+1],a=e[t+2];if(typeof n!="function"){if(Wf(n||l)===null)continue;break}var u=kn(l);u!==null&&(e.splice(t,3),t-=3,ji(u,{pending:!0,data:a,method:l.method,action:n},n,a))}}))}function bn(e){function t(f){return La(f,e)}al!==null&&La(al,e),ul!==null&&La(ul,e),cl!==null&&La(cl,e),ma.forEach(t),ha.forEach(t);for(var l=0;l<Vt.length;l++){var n=Vt[l];n.blockedOn===e&&(n.blockedOn=null)}for(;0<Vt.length&&(l=Vt[0],l.blockedOn===null);)l0(l),l.blockedOn===null&&Vt.shift();if(l=(e.ownerDocument||e).$$reactFormReplay,l!=null)for(n=0;n<l.length;n+=3){var a=l[n],u=l[n+1],c=a[qe]||null;if(typeof u=="function")c||$o(l);else if(c){var i=null;if(u&&u.hasAttribute("formAction")){if(a=u,c=u[qe]||null)i=c.formAction;else if(Wf(a)!==null)continue}else i=c.action;typeof i=="function"?l[n+1]=i:(l.splice(n,3),n-=3),$o(l)}}}function n0(){function e(u){u.canIntercept&&u.info==="react-transition"&&u.intercept({handler:function(){return new Promise(function(c){return a=c})},focusReset:"manual",scroll:"manual"})}function t(){a!==null&&(a(),a=null),n||setTimeout(l,20)}function l(){if(!n&&!navigation.transition){var u=navigation.currentEntry;u&&u.url!=null&&navigation.navigate(u.url,{state:u.getState(),info:"react-transition",history:"replace"})}}if(typeof navigation=="object"){var n=!1,a=null;return navigation.addEventListener("navigate",e),navigation.addEventListener("navigatesuccess",t),navigation.addEventListener("navigateerror",t),setTimeout(l,100),function(){n=!0,navigation.removeEventListener("navigate",e),navigation.removeEventListener("navigatesuccess",t),navigation.removeEventListener("navigateerror",t),a!==null&&(a(),a=null)}}}function Ff(e){this._internalRoot=e}ac.prototype.render=Ff.prototype.render=function(e){var t=this._internalRoot;if(t===null)throw Error(z(409));var l=t.current,n=Qe();P1(l,n,e,t,null,null)};ac.prototype.unmount=Ff.prototype.unmount=function(){var e=this._internalRoot;if(e!==null){this._internalRoot=null;var t=e.containerInfo;P1(e.current,2,null,e,null,null),tc(),t[pn]=null}};function ac(e){this._internalRoot=e}ac.prototype.unstable_scheduleHydration=function(e){if(e){var t=Or();e={blockedOn:null,target:e,priority:t};for(var l=0;l<Vt.length&&t!==0&&t<Vt[l].priority;l++);Vt.splice(l,0,e),l===0&&l0(e)}};var _o=gr.version;if(_o!=="19.2.4")throw Error(z(527,_o,"19.2.4"));V.findDOMNode=function(e){var t=e._reactInternals;if(t===void 0)throw typeof e.render=="function"?Error(z(188)):(e=Object.keys(e).join(","),Error(z(268,e)));return e=P0(t),e=e!==null?kr(e):null,e=e===null?null:e.stateNode,e};var Ey={bundleType:0,version:"19.2.4",rendererPackageName:"react-dom",currentDispatcherRef:C,reconcilerVersion:"19.2.4"};if(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__<"u"){var Ya=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(!Ya.isDisabled&&Ya.supportsFiber)try{ga=Ya.inject(Ey),Ze=Ya}catch{}}Xu.createRoot=function(e,t){if(!br(e))throw Error(z(299));var l=!1,n="",a=Kd,u=Jd,c=Wd;return t!=null&&(t.unstable_strictMode===!0&&(l=!0),t.identifierPrefix!==void 0&&(n=t.identifierPrefix),t.onUncaughtError!==void 0&&(a=t.onUncaughtError),t.onCaughtError!==void 0&&(u=t.onCaughtError),t.onRecoverableError!==void 0&&(c=t.onRecoverableError)),t=F1(e,1,!1,null,null,l,n,null,a,u,c,n0),e[pn]=t.current,Zf(e),new Ff(t)};Xu.hydrateRoot=function(e,t,l){if(!br(e))throw Error(z(299));var n=!1,a="",u=Kd,c=Jd,i=Wd,f=null;return l!=null&&(l.unstable_strictMode===!0&&(n=!0),l.identifierPrefix!==void 0&&(a=l.identifierPrefix),l.onUncaughtError!==void 0&&(u=l.onUncaughtError),l.onCaughtError!==void 0&&(c=l.onCaughtError),l.onRecoverableError!==void 0&&(i=l.onRecoverableError),l.formState!==void 0&&(f=l.formState)),t=F1(e,1,!0,t,l??null,n,a,f,u,c,i,n0),t.context=I1(null),l=t.current,n=Qe(),n=af(n),a=el(n),a.callback=null,tl(l,a,n),l=n,t.current.lanes=l,Sa(t,l),gt(t),e[pn]=t.current,Zf(e),new ac(t)};Xu.version="19.2.4";function a0(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(a0)}catch(e){console.error(e)}}a0(),ur.exports=Xu;var Ty=ur.exports,_n={},Ro;function jy(){if(Ro)return _n;Ro=1,Object.defineProperty(_n,"__esModule",{value:!0}),_n.styleq=void 0;var e=new WeakMap,t="$$css";function l(a){var u,c,i;return a!=null&&(u=a.disableCache===!0,c=a.disableMix===!0,i=a.transform),function(){for(var s=[],d="",g=null,r="",x=u?null:e,S=new Array(arguments.length),p=0;p<arguments.length;p++)S[p]=arguments[p];for(;S.length>0;){var k=S.pop();if(!(k==null||k===!1)){if(Array.isArray(k)){for(var h=0;h<k.length;h++)S.push(k[h]);continue}var o=i!=null?i(k):k;if(o.$$css!=null){var m="";if(x!=null&&x.has(o)){var b=x.get(o);b!=null&&(m=b[0],r=b[2],s.push.apply(s,b[1]),x=b[3])}else{var T=[];for(var N in o){var E=o[N];if(N===t){var j=o[N];j!==!0&&(r=r?j+"; "+r:j);continue}typeof E=="string"||E===null?s.includes(N)||(s.push(N),x!=null&&T.push(N),typeof E=="string"&&(m+=m?" "+E:E)):console.error("styleq: ".concat(N," typeof ").concat(String(E),' is not "string" or "null".'))}if(x!=null){var A=new WeakMap;x.set(o,[m,T,r,A]),x=A}}m&&(d=d?m+" "+d:m)}else if(c)g==null&&(g={}),g=Object.assign({},o,g);else{var M=null;for(var q in o){var G=o[q];G!==void 0&&(s.includes(q)||(G!=null&&(g==null&&(g={}),M==null&&(M={}),M[q]=G),s.push(q),x=null))}M!=null&&(g=Object.assign(M,g))}}}var Ae=[d,g,r];return Ae}}var n=_n.styleq=l();return n.factory=l,_n}var My=jy();function L(...e){const[t,l,n]=My.styleq(e),a={};return t!=null&&t!==""&&(a.className=t),l!=null&&Object.keys(l).length>0&&(a.style=l),n!=null&&n!==""&&(a["data-style-src"]=n),a}const Qi={"--color-accent":"var(--color-accent)","--color-accent-muted":"var(--color-accent-muted)","--color-on-dark":"var(--color-on-dark)"},ke={xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:1.5,strokeLinecap:"round",strokeLinejoin:"round",width:"1em",height:"1em","aria-hidden":!0},Za={xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor",width:"1em",height:"1em","aria-hidden":!0},Ay={close:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M6 6l12 12M6 18L18 6"})}),chevronDown:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M6 9l6 6 6-6"})}),chevronLeft:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M15 6l-6 6 6 6"})}),chevronRight:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M9 6l6 6-6 6"})}),check:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M5 13l4 4L19 7"})}),checkCircle:v.jsx("svg",{...Za,children:v.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M12 3a9 9 0 100 18 9 9 0 000-18zm4.06 6.56a.75.75 0 00-1.12-1l-3.94 4.4-1.94-1.94a.75.75 0 00-1.06 1.06l2.5 2.5a.75.75 0 001.09-.03l4.47-5z"})}),xCircle:v.jsx("svg",{...Za,children:v.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M12 3a9 9 0 100 18 9 9 0 000-18zm-2.47 5.47a.75.75 0 00-1.06 1.06L10.94 12l-2.47 2.47a.75.75 0 101.06 1.06L12 13.06l2.47 2.47a.75.75 0 101.06-1.06L13.06 12l2.47-2.47a.75.75 0 00-1.06-1.06L12 10.94l-2.47-2.47z"})}),warning:v.jsx("svg",{...Za,children:v.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M10.29 3.86L2.07 19.05A2 2 0 003.78 22h16.44a2 2 0 001.71-2.95L13.71 3.86a2 2 0 00-3.42 0zM12 9a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0112 9zm0 9a1 1 0 100-2 1 1 0 000 2z"})}),info:v.jsxs("svg",{...ke,children:[v.jsx("circle",{cx:"12",cy:"12",r:"9"}),v.jsx("path",{d:"M12 11v5"}),v.jsx("circle",{cx:"12",cy:"8",r:"0.5",fill:"currentColor",stroke:"none"})]}),calendar:v.jsxs("svg",{...ke,children:[v.jsx("rect",{x:"3",y:"4",width:"18",height:"18",rx:"2"}),v.jsx("path",{d:"M16 2v4M8 2v4M3 10h18"})]}),clock:v.jsxs("svg",{...ke,children:[v.jsx("circle",{cx:"12",cy:"12",r:"9"}),v.jsx("path",{d:"M12 7v5l3 3"})]}),externalLink:v.jsxs("svg",{...ke,children:[v.jsx("path",{d:"M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"}),v.jsx("path",{d:"M15 3h6v6"}),v.jsx("path",{d:"M10 14L21 3"})]}),menu:v.jsx("svg",{...ke,strokeWidth:2,children:v.jsx("path",{d:"M4 6h16M4 12h16M4 18h16"})}),moreHorizontal:v.jsxs("svg",{...Za,children:[v.jsx("circle",{cx:"5",cy:"12",r:"1.5"}),v.jsx("circle",{cx:"12",cy:"12",r:"1.5"}),v.jsx("circle",{cx:"19",cy:"12",r:"1.5"})]}),search:v.jsxs("svg",{...ke,children:[v.jsx("circle",{cx:"11",cy:"11",r:"8"}),v.jsx("path",{d:"M21 21l-4.35-4.35"})]}),arrowUp:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M12 19V5m0 0l-7 7m7-7l7 7"})}),arrowDown:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M12 5v14m0 0l7-7m-7 7l-7-7"})}),arrowsUpDown:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"})}),funnel:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z"})}),eyeSlash:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M3.98 8.223A10.477 10.477 0 001.934 12c1.292 4.338 5.31 7.5 10.066 7.5.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"})}),viewColumns:v.jsx("svg",{...ke,children:v.jsx("path",{d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125z"})})};let Ki={};function Dy(e){Ki={...Ki,...e}}function wy(e){return Ki[e]??Ay[e]}function Ny(e){return e==="base"?"":e.split("+").map(t=>{const[l,n]=t.split(":");return/^\d/.test(n)?`.${l}-${n}`:`.${n}`}).join("")}const Gc={[-5]:"--font-size-4xs",[-4]:"--font-size-3xs",[-3]:"--font-size-2xs",[-2]:"--font-size-xs",[-1]:"--font-size-sm",0:"--font-size-base",1:"--font-size-lg",2:"--font-size-xl",3:"--font-size-2xl",4:"--font-size-3xl",5:"--font-size-4xl",6:"--font-size-5xl"},Oy={1:3,2:2,3:1,4:0,5:-1,6:-2},Cy={body:0,large:1,label:0,code:0,supporting:-1,"display-1":6,"display-2":5,"display-3":4},$y={1:"var(--font-weight-semibold)",2:"var(--font-weight-semibold)",3:"var(--font-weight-semibold)",4:"var(--font-weight-semibold)",5:"var(--font-weight-semibold)",6:"var(--font-weight-semibold)"},_y={body:"var(--font-weight-normal)",large:"var(--font-weight-semibold)",label:"var(--font-weight-medium)",code:"var(--font-weight-normal)",supporting:"var(--font-weight-normal)","display-1":"var(--font-weight-normal)","display-2":"var(--font-weight-normal)","display-3":"var(--font-weight-normal)"};function Yc(e,t,l){return Math.round(e*Math.pow(t,l))}function Ry(e){return`${Math.round(e/16*1e4)/1e4}rem`}function qy(e){return e<20?1.5:e<32?1.4:1.25}function qo(e){const t=qy(e),l=e*t,n=Math.max(Math.round(l/4)*4,Math.ceil((e+4)/4)*4);return Math.round(n/e*1e4)/1e4}function Uy(e){const{base:t,ratio:l,weights:n}=e,a={},u={...$y,...n==null?void 0:n.heading},c={..._y,...n==null?void 0:n.text};for(let i=-5;i<=6;i++){const f=Yc(t,l,i);a[Gc[i]]=Ry(f)}for(const[i,f]of Object.entries(Oy)){const s=Number(i),d=Yc(t,l,f),g=qo(d);a[`--text-heading-${s}-size`]=`var(${Gc[f]})`,a[`--text-heading-${s}-weight`]=u[s],a[`--text-heading-${s}-leading`]=`${g}`}for(const[i,f]of Object.entries(Cy)){const s=Yc(t,l,f),d=qo(s);a[`--text-${i}-size`]=`var(${Gc[f]})`,a[`--text-${i}-weight`]=c[i],a[`--text-${i}-leading`]=`${d}`}return a}const Hy={body:"var(--font-family-body)",large:"var(--font-family-body)",label:"var(--font-family-body)",code:"var(--font-family-code)",supporting:"var(--font-family-body)","display-1":"var(--font-family-heading)","display-2":"var(--font-family-heading)","display-3":"var(--font-family-heading)"};function By(e){const t={},l={};for(const a of[1,2,3,4,5,6])l[`level:${a}`]={fontFamily:"var(--font-family-heading)",fontSize:`var(--text-heading-${a}-size)`,fontWeight:`var(--text-heading-${a}-weight)`,lineHeight:`var(--text-heading-${a}-leading)`};t.heading=l;const n={};for(const a of["body","large","label","code","supporting","display-1","display-2","display-3"])n[`type:${a}`]={fontFamily:Hy[a],fontSize:`var(--text-${a}-size)`,lineHeight:`var(--text-${a}-leading)`};return t.text=n,t}function Rl(e){return Math.round(e/5)*5}function Xy(e){const{fast:t,medium:l,ratio:n,easing:a}=e,u={"--duration-fast-min":`${Rl(t*n)}ms`,"--duration-fast":`${Rl(t)}ms`,"--duration-fast-max":`${Rl(t/n)}ms`,"--duration-medium-min":`${Rl(l*n)}ms`,"--duration-medium":`${Rl(l)}ms`,"--duration-medium-max":`${Rl(l/n)}ms`};return a&&(u["--ease-standard"]=a),u}function Ly(e){const{base:t,multiplier:l}=e;return{"--radius-none":"0px","--radius-inner":`${Math.round(t*1*l)}px`,"--radius-element":`${Math.round(t*2*l)}px`,"--radius-container":`${Math.round(t*3*l)}px`,"--radius-page":`${Math.round(t*7*l)}px`,"--radius-full":"9999px"}}function Gy(e){return Array.isArray(e)?`light-dark(${e[0]}, ${e[1]})`:e}function Yy(e,t){if(!e&&!t)return;if(!e)return t;if(!t)return e;const l={};for(const[n,a]of Object.entries(e))l[n]={...a};for(const[n,a]of Object.entries(t))if(!l[n])l[n]={...a};else for(const[u,c]of Object.entries(a))l[n][u]={...l[n][u],...c};return l}function Va(e){return{normal:"var(--font-weight-normal)",medium:"var(--font-weight-medium)",semibold:"var(--font-weight-semibold)",bold:"var(--font-weight-bold)"}[e]??e}function Zc(e,t){if(!e)return;const l=e.includes(" ")?`"${e}"`:e;return t?`${l}, ${t}`:l}function Zy(e){var c,i,f,s,d,g,r,x;const t={},l=e.typography;let n;if(l!=null&&l.scale){const S={},p=l.heading;if(p!=null&&p.weights)for(const[o,m]of Object.entries(p.weights))m&&(S[Number(o)]=Va(m));const k=p!=null&&p.weight?Va(p.weight):void 0;if(k)for(let o=1;o<=6;o++)o in S||(S[o]=k);const h={};(c=l.body)!=null&&c.weight&&(h.body=Va(l.body.weight)),(i=l.code)!=null&&i.weight&&(h.code=Va(l.code.weight)),n={base:l.scale.base,ratio:l.scale.ratio,weights:{...Object.keys(S).length>0?{heading:S}:{},...Object.keys(h).length>0?{text:h}:{}}}}if(n){const S=Uy(n);for(const[p,k]of Object.entries(S))t[p]=k}if(e.radius){const S=Ly(e.radius);for(const[p,k]of Object.entries(S))t[p]=k}if(e.motion){const S=Xy(e.motion);for(const[p,k]of Object.entries(S))t[p]=k}if(l){const S=Zc((f=l.body)==null?void 0:f.family,(s=l.body)==null?void 0:s.fallbacks),p=Zc((d=l.heading)==null?void 0:d.family,(g=l.heading)==null?void 0:g.fallbacks)??S,k=Zc((r=l.code)==null?void 0:r.family,(x=l.code)==null?void 0:x.fallbacks);S&&(t["--font-family-body"]=S),p&&(t["--font-family-heading"]=p),k&&(t["--font-family-code"]=k)}if(e.tokens)for(const[S,p]of Object.entries(e.tokens))p!==void 0&&(t[S]=Gy(p));let a=e.components;if(n){const S=By();a=Yy(S,e.components)}let u;if(l){const S=new Set,p=[];for(const k of[l.body,l.heading,l.code])k!=null&&k.family&&k.url&&!S.has(k.family)&&(S.add(k.family),p.push({family:k.family,url:k.url}));p.length>0&&(u=p)}return{name:e.name,tokens:t,components:a,icons:e.icons,fonts:u,__inputTokens:e.tokens}}function Uo(e){return e.replace(/[A-Z]/g,t=>`-${t.toLowerCase()}`)}function Vy(e){const t=[],l=e.tokens,n=d=>l[d]||`var(${d})`,a=Object.entries(l);if(a.length>0){const d=a.map(([g,r])=>`    ${g}: ${r};`).join(`
+`);t.push(`  :scope {
+${d}
+  }`)}if(e.components)for(const[d,g]of Object.entries(e.components))for(const[r,x]of Object.entries(g)){const S=Object.entries(x);if(S.length>0){const p=Ny(r),k=`.xds-${d}${p}`,h=[],o=[];for(const[m,b]of S)m.startsWith(":")&&typeof b=="object"?o.push([m,b]):h.push([m,b]);if(h.length>0){const m=h.map(([b,T])=>`    ${Uo(b)}: ${T};`).join(`
+`);t.push(`  ${k} {
+${m}
+  }`)}for(const[m,b]of o){const T=Object.entries(b);if(T.length>0){const N=T.map(([E,j])=>`    ${Uo(E)}: ${j};`).join(`
+`);t.push(`  ${k}${m} {
+${N}
+  }`)}}}}t.push(`  :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-family-heading);
+    color: var(--color-text-primary);
+  }`);for(let d=1;d<=6;d++)t.push(`  h${d} {
+    font-size: ${n(`--text-heading-${d}-size`)};
+    font-weight: ${n(`--text-heading-${d}-weight`)};
+    line-height: ${n(`--text-heading-${d}-leading`)};
+  }`);t.push(`  p {
+    font-family: var(--font-family-heading);
+    font-size: ${n("--text-body-size")};
+    font-weight: ${n("--text-body-weight")};
+    line-height: ${n("--text-body-leading")};
+    color: var(--color-text-primary);
+  }`),t.push(`  small {
+    font-size: ${n("--text-supporting-size")};
+    font-weight: ${n("--text-supporting-weight")};
+    line-height: ${n("--text-supporting-leading")};
+    color: var(--color-text-secondary);
+  }`),t.push(`  code, pre {
+    font-family: var(--font-family-code);
+    font-size: ${n("--text-code-size")};
+    line-height: ${n("--text-code-leading")};
+  }`),t.push(`  hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+  }`);const u={primary:"var(--color-text-primary)",secondary:"var(--color-text-secondary)",disabled:"var(--color-text-disabled)",placeholder:"var(--color-text-secondary)",active:"var(--color-accent)"},c=e.components||{},i="text"in c,f="heading"in c,s="link"in c;if(i||f||s)for(const[d,g]of Object.entries(u))i&&t.push(`  .xds-text.${d} { color: ${g}; }`),f&&t.push(`  .xds-heading.${d} { color: ${g}; }`),s&&t.push(`  .xds-link.${d} { color: ${g}; }`);return t}function Qy(e){const t=Vy(e);if(t.length===0)return"";const l=`[data-xds-theme="${e.name}"]`,n=t.join(`
+
+`);return`@scope (${l}) to ([data-xds-theme]) {
+${n}
+}`}const Ky=y.createContext(null),Qa={base:{k1xSpc:"xjp7ctv",kMwMTN:"x1tgivj0",kMv6JI:"x9ynric",$$css:!0},light:{kQNsl9:"x19aimcq",$$css:!0},dark:{kQNsl9:"xntwwlm",$$css:!0},system:{kQNsl9:"x108lcm5",$$css:!0}},Vc=new Set;function Jy(e){const t=y.useId();y.useInsertionEffect(()=>{if(e.__built)return;const l=`xds-theme-${e.name}`;if(Vc.has(l))return;const n=Qy(e);if(!n)return;const a=document.createElement("style");return a.setAttribute("data-xds-theme",e.name),a.setAttribute("data-xds-id",t),a.textContent=`@layer xds-theme {
+${n}
+}`,document.head.appendChild(a),Vc.add(l),()=>{const u=document.querySelector(`style[data-xds-theme="${e.name}"][data-xds-id="${t}"]`);u&&(u.remove(),Vc.delete(l))}},[e,t])}function Wy(e){const t=y.useRef([]);y.useLayoutEffect(()=>{if(typeof document>"u"||!e.fonts||e.fonts.length===0)return;const l=[];for(const n of e.fonts){if(document.fonts.check(`16px "${n.family}"`)||document.head.querySelector(`link[rel="stylesheet"][href="${n.url}"]`))continue;const c=document.createElement("link");c.rel="stylesheet",c.href=n.url,document.head.appendChild(c),l.push(c),console.warn(`[XDS] Theme "${e.name}" loaded font "${n.family}" at runtime. For better performance, add to your document <head>:
+  <link rel="stylesheet" href="${n.url}" />`)}return t.current=l,()=>{for(const n of t.current)n.parentNode&&n.parentNode.removeChild(n);t.current=[]}},[e.fonts,e.name])}function u0({theme:e,mode:t="system",children:l}){Jy(e),Wy(e);const n=t==="dark"?Qa.dark:t==="light"?Qa.light:Qa.system,a=e.icons;a!=null&&Dy(a);const u=y.useMemo(()=>({theme:e,mode:t}),[e,t]);return v.jsx(Ky.Provider,{value:u,children:v.jsx("div",{...L(Qa.base,n),"data-xds-theme":e.name,"data-theme":t==="system"?void 0:t,children:l})})}u0.displayName="XDSTheme";function Fy({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3"}))}const Iy=y.forwardRef(Fy);function Py({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18"}))}const ev=y.forwardRef(Py);function tv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"}))}const lv=y.forwardRef(tv);function nv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"}))}const av=y.forwardRef(nv);function uv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"}))}const cv=y.forwardRef(uv);function iv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m4.5 12.75 6 6 9-13.5"}))}const fv=y.forwardRef(iv);function sv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m19.5 8.25-7.5 7.5-7.5-7.5"}))}const ov=y.forwardRef(sv);function rv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M15.75 19.5 8.25 12l7.5-7.5"}))}const dv=y.forwardRef(rv);function mv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m8.25 4.5 7.5 7.5-7.5 7.5"}))}const hv=y.forwardRef(mv);function yv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"}))}const vv=y.forwardRef(yv);function xv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"}))}const gv=y.forwardRef(xv);function bv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"}))}const Sv=y.forwardRef(bv);function pv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"}))}const kv=y.forwardRef(pv);function zv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"}))}const Ev=y.forwardRef(zv);function Tv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"}))}const jv=y.forwardRef(Tv);function Mv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z"}))}const Av=y.forwardRef(Mv);function Dv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6 18 18 6M6 6l12 12"}))}const wv=y.forwardRef(Dv);function Nv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{fillRule:"evenodd",d:"M15.75 2.25H21a.75.75 0 0 1 .75.75v5.25a.75.75 0 0 1-1.5 0V4.81L8.03 17.03a.75.75 0 0 1-1.06-1.06L19.19 3.75h-3.44a.75.75 0 0 1 0-1.5Zm-10.5 4.5a1.5 1.5 0 0 0-1.5 1.5v10.5a1.5 1.5 0 0 0 1.5 1.5h10.5a1.5 1.5 0 0 0 1.5-1.5V10.5a.75.75 0 0 1 1.5 0v8.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V8.25a3 3 0 0 1 3-3h8.25a.75.75 0 0 1 0 1.5H5.25Z",clipRule:"evenodd"}))}const Ov=y.forwardRef(Nv);function Cv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{fillRule:"evenodd",d:"M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z",clipRule:"evenodd"}))}const $v=y.forwardRef(Cv);function _v({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{fillRule:"evenodd",d:"M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z",clipRule:"evenodd"}))}const Rv=y.forwardRef(_v);function qv({title:e,titleId:t,...l},n){return y.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?y.createElement("title",{id:t},e):null,y.createElement("path",{fillRule:"evenodd",d:"M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-1.72 6.97a.75.75 0 1 0-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06L12 13.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L13.06 12l1.72-1.72a.75.75 0 1 0-1.06-1.06L12 10.94l-1.72-1.72Z",clipRule:"evenodd"}))}const Uv=y.forwardRef(qv),fe={width:"1em",height:"1em","aria-hidden":!0},Hv={close:v.jsx(wv,{...fe}),chevronDown:v.jsx(ov,{...fe}),chevronLeft:v.jsx(dv,{...fe}),chevronRight:v.jsx(hv,{...fe}),check:v.jsx(fv,{...fe}),checkCircle:v.jsx($v,{...fe}),xCircle:v.jsx(Uv,{...fe}),warning:v.jsx(Rv,{...fe}),info:v.jsx(Ev,{...fe}),calendar:v.jsx(cv,{...fe}),clock:v.jsx(vv,{...fe}),externalLink:v.jsx(Ov,{...fe}),menu:v.jsx(av,{...fe}),moreHorizontal:v.jsx(gv,{...fe}),search:v.jsx(jv,{...fe}),arrowUp:v.jsx(ev,{...fe}),arrowDown:v.jsx(Iy,{...fe}),arrowsUpDown:v.jsx(lv,{...fe}),funnel:v.jsx(kv,{...fe}),eyeSlash:v.jsx(Sv,{...fe}),viewColumns:v.jsx(Av,{...fe})},Bv=Zy({name:"default",typography:{scale:{base:14,ratio:1.2}},motion:{fast:175,medium:410,ratio:.75},tokens:{},components:{button:{"variant:secondary":{backgroundColor:"light-dark(rgba(5, 54, 89, 0.1), rgba(223, 226, 229, 0.2))"}}},icons:Hv}),Ji=120;function Xv(e){let t=0,l=0;const n=[];for(const i of e){const f=i.width;if((f==null?void 0:f.type)==="pixel")l+=f.value;else{const s=(f==null?void 0:f.value)??1,d=f!=null?f.minWidth??Ji:0;t+=s,n.push({key:i.key,proportion:s,minWidth:d})}}let a=0;if(t>0)for(const i of n){const f=i.minWidth*t/i.proportion;f>a&&(a=f)}const u=l+a,c=new Map;for(const i of e){const f=i.width,s={};if((f==null?void 0:f.type)==="pixel")s.width=`${f.value}px`,s.minWidth=`${f.value}px`;else{const d=(f==null?void 0:f.value)??1;if(t>0&&(s.width=`${d/t*100}%`),f!=null){const g=f.minWidth??Ji;s.minWidth=`${g}px`}}c.set(i.key,{style:s})}return{columns:c,tableMinWidth:u}}function Lv(e=1,t){return{type:"proportional",value:e,minWidth:(t==null?void 0:t.minWidth)??Ji}}function Gv(e){return{type:"pixel",value:e}}function Yv(e){return e.length===0?e:e.charAt(0).toUpperCase()+e.slice(1)}function Zv(e,t){const l=e[t];return l==null?"":String(l)}function Vv(e){if(e.length===0)return[];const t=e[0];return Object.keys(t).map(l=>({key:l,header:Yv(l),width:Lv(1)}))}const If=y.createContext(null);function ae(e,t){const l=[`xds-${e}`];if(t)for(const[n,a]of Object.entries(t)){if(a==null)continue;const u=String(a);/^\d/.test(u)?l.push(`${n}-${u}`):l.push(u)}return l.join(" ")}function ue(e,t,l,n){let a=t.className?`${e} ${t.className}`:e;l&&(a=`${a} ${l}`);const u=n&&t.style?{...t.style,...n}:n||t.style;return{className:a,style:u}}const Qv={row:{kWkggS:"x1dnou9g",$$css:!0}},Kv={row:{kWkggS:"xe9uy6x",k1ekBW:"x15406qy",kIyJzY:"xuedmi6",kAMwcw:"xlr8y92",$$css:!0}},Jv={row:{kWkggS:"x1dnou9g xe9uy6x",k1ekBW:"x15406qy",kIyJzY:"xuedmi6",kAMwcw:"xlr8y92",$$css:!0}};function Pf({children:e,xstyle:t,ref:l,...n}){const a=y.useContext(If);if(!a)return v.jsx("tr",{ref:l,...n,...ue(ae("table-row"),L(t)),children:e});const u=[];return a.isStriped&&a.hasHover?u.push(Jv.row):a.isStriped?u.push(Qv.row):a.hasHover&&u.push(Kv.row),a.dividers==="rows"||a.dividers,t&&u.push(...t),v.jsx("tr",{ref:l,...n,...ue(ae("table-row"),L(...u)),children:e})}Pf.displayName="XDSTableRow";const c0={cell:{kVQacm:"xb3r6kr",kg5iWk:"xlyipyv",khDVqt:"xuxw1ft",ks0D6T:"x1m189uc",$$css:!0}};function Wv(e,t,l){const n=[];return(e.dividers==="rows"||e.dividers==="grid")&&n.push(t),(e.dividers==="columns"||e.dividers==="grid")&&n.push(l),n}function i0(e,t){return t?Array.isArray(t)?[...e,...t]:[...e,t]:e}function f0(){return y.useContext(If)}const Fv={compact:{k8WAf4:"xu0wf1k",kg3NbH:"xf314gf",kGuDYH:"xjm74w1",kB7OPa:"x9f619",$$css:!0},balanced:{k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kGuDYH:"xjm74w1",kB7OPa:"x9f619",$$css:!0},spacious:{k8WAf4:"x8o8v82",kg3NbH:"x1pzlopt",kGuDYH:"xjm74w1",kB7OPa:"x9f619",$$css:!0}},Iv={cell:{kt9PQ7:"x92x3c3",kfdmCh:"x1q0q8m5",kL6WhQ:"xw8gpjh",$$css:!0}},Pv={cell:{kWqL5O:"x1pcaw5z x1lpyac",kSWEuD:"x32b0ac",k26BEO:"xtgwc6q",$$css:!0}};function es({children:e,xstyle:t,ref:l,...n}){const a=f0();if(!a)return v.jsx("td",{ref:l,...n,...ue(ae("table-cell"),L(t)),children:e});const u=[Fv[a.density],c0.cell,...Wv(a,Iv.cell,Pv.cell)];return v.jsx("td",{ref:l,...n,...ue(ae("table-cell"),L(...i0(u,t))),children:e})}es.displayName="XDSTableCell";const ex={compact:{k8WAf4:"xu0wf1k",kg3NbH:"xf314gf",kGuDYH:"xcr08ib",kB7OPa:"x9f619",$$css:!0},balanced:{k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kGuDYH:"xcr08ib",kB7OPa:"x9f619",$$css:!0},spacious:{k8WAf4:"x8o8v82",kg3NbH:"x1pzlopt",kGuDYH:"xcr08ib",kB7OPa:"x9f619",$$css:!0}},tx={cell:{k63SB2:"x2mo6ok",kMwMTN:"xv1l7n4",k9WMMc:"x1yc453h",$$css:!0}},lx={cell:{kt9PQ7:"x92x3c3",kfdmCh:"x1q0q8m5",kL6WhQ:"xw8gpjh",$$css:!0}},nx={cell:{kWqL5O:"x1pcaw5z x1lpyac",kSWEuD:"x32b0ac",k26BEO:"xtgwc6q",$$css:!0}};function ts({children:e,xstyle:t,ref:l,className:n,style:a,...u}){const c=f0();if(!c)return v.jsx("th",{ref:l,...u,...ue(ae("table-header-cell"),L(t),n,a),children:e});const i=[tx.cell,ex[c.density],lx.cell,c0.cell];return(c.dividers==="columns"||c.dividers==="grid")&&i.push(nx.cell),v.jsx("th",{ref:l,...u,...ue(ae("table-header-cell"),L(...i0(i,t)),n,a),children:e})}ts.displayName="XDSTableHeaderCell";const ax={table:{kzqmXN:"xh8yej3",kLvRdT:"x1mwwwfo",kheTzg:"x1gukg7c",kPzzVL:"x140o2bo",$$css:!0}};function en(e,t,l,...n){return e.reduce((a,u,c)=>{const i=t(u);if(!i)return a;try{return i(a,...n)}catch(f){return console.error(`[XDSTable] Plugin at index ${c} threw in transform:`,f),a}},l)}const ux=[];function cx(e,t){if(e===t)return!0;if(e.length!==t.length)return!1;for(let l=0;l<e.length;l++)if(e[l]!==t[l])return!1;return!0}function ix({item:e,rowIndex:t,rowKey:l,columns:n,plugins:a,RowComponent:u,CellComponent:c}){const i=n.map(s=>{const d=en(a,x=>x.transformBodyCell,{htmlProps:{},styles:[]},s,e),g=s.renderCell?s.renderCell(e):Zv(e,s.key),r=!s.renderCell&&typeof g=="string"&&g.length>0?{title:g}:{};return v.jsx(c,{...d.htmlProps,...r,xstyle:d.styles,children:g},s.key)}),f=en(a,s=>s.transformBodyRow,{htmlProps:{},styles:[],children:v.jsx(v.Fragment,{children:i})},e,t);return v.jsx(u,{ref:f.ref,...f.htmlProps,xstyle:f.styles,children:f.children},l)}function fx(e,t){if(e.rowKey!==t.rowKey||e.rowIndex!==t.rowIndex||e.columns!==t.columns||e.plugins!==t.plugins||e.RowComponent!==t.RowComponent||e.CellComponent!==t.CellComponent)return!1;if(e.item===t.item)return!0;const l=e.item,n=t.item,a=Object.keys(n);for(const u of a)if(l[u]!==n[u])return!1;return!0}const sx=y.memo(ix,fx);function ox({data:e,columns:t,idKey:l,plugins:n,components:a,children:u,tableProps:c,ref:i}){const f=n??ux,s=(a==null?void 0:a.Row)??Pf,d=(a==null?void 0:a.Cell)??es,g=(a==null?void 0:a.HeaderCell)??ts,r=t??(e?Vv(e):[]),x=en(f,j=>j.transformColumns,r),S=y.useRef(x);cx(S.current,x)||(S.current=x);const p=S.current,k=Xv(p),h=en(f,j=>j.transformTable,{htmlProps:{...c},styles:[ax.table]}),o=p.map(j=>{var Y;const A=j.header??j.key,M=en(f,Fe=>Fe.transformHeaderCell,{htmlProps:{"data-column-key":j.key},styles:[],content:A},j),q=((Y=k.columns.get(j.key))==null?void 0:Y.style)??{},G=M.htmlProps.style,Ae={...M.htmlProps,style:G?{...q,...G}:q},Se=M.content??A,We=typeof Se=="string"&&Se.length>0?{title:Se}:{},{before:w,after:D,overlay:O}=M,$=w!=null||D!=null||O!=null;return v.jsx(g,{...Ae,...We,xstyle:M.styles,children:$?v.jsxs(v.Fragment,{children:[w,Se,D,O]}):Se},j.key)}),m=en(f,j=>j.transformHeaderRow,{htmlProps:{},styles:[],children:v.jsx(v.Fragment,{children:o})}),b=e!=null&&e.length>0,T=p.length>0,N={...h.htmlProps.style,minWidth:k.tableMinWidth>0?`${k.tableMinWidth}px`:void 0};let E=v.jsxs("table",{ref:i,...h.htmlProps,...ue(ae("base-table"),L(...h.styles)),style:N,children:[T&&v.jsx("thead",{children:v.jsx(s,{...m.htmlProps,xstyle:m.styles,children:m.children})}),v.jsx("tbody",{children:u||b&&e.map((j,A)=>{const M=l==null?A:typeof l=="function"?l(j):String(j[l]);return v.jsx(sx,{item:j,rowIndex:A,rowKey:M,columns:p,plugins:f,RowComponent:s,CellComponent:d},M)})})]});for(let j=f.length-1;j>=0;j--){const A=f[j];if(A.transformTableContext)try{E=A.transformTableContext(E)}catch(M){console.error("[XDSTable] Plugin threw in transformTableContext:",M)}}return E}const s0=ox;s0.displayName="XDSBaseTable";const o0=["columnSettings","sort","selection","pagination"],Ho=new Map(o0.map((e,t)=>[e,t]));function rx(e){const t=o0.length;return e.sort(([l],[n])=>{const a=Ho.get(l)??t,u=Ho.get(n)??t;return a-u})}const Ka=new Set(["transformColumns","transformTable","transformHeaderRow","transformHeaderCell","transformBodyRow","transformBodyCell","transformTableContext"]);function dx(e,t){const l=Object.keys(t);for(const a of l)Ka.has(a)||console.warn(`[XDSTable] Plugin "${e}" has unknown key "${a}". Valid keys: ${[...Ka].join(", ")}. This key will be ignored.`);for(const a of l)if(Ka.has(a)){const u=t[a];u!=null&&typeof u!="function"&&console.warn(`[XDSTable] Plugin "${e}" has non-function value for "${a}" (got ${typeof u}). Transform will be skipped.`)}l.some(a=>Ka.has(a)&&typeof t[a]=="function")||console.warn(`[XDSTable] Plugin "${e}" has no transform methods. It will be included in the pipeline but won't do anything.`)}function mx(e,t){const l=y.useRef(null);if(l.current!=null){const u=l.current;if(u.basePlugins===e&&u.userPlugins===t)return u.result;if(u.basePlugins===e&&hx(u.userPlugins,t))return u.userPlugins=t,u.result}const n=t?rx(Object.entries(t)).map(([,u])=>u):[],a=[...e,...n];if(t)for(const[u,c]of Object.entries(t))dx(u,c);return l.current={basePlugins:e,userPlugins:t,result:a},a}function hx(e,t){if(e===t)return!0;if(e==null||t==null)return!1;const l=Object.keys(e),n=Object.keys(t);if(l.length!==n.length)return!1;for(const a of l)if(e[a]!==t[a])return!1;return!0}const yx={base:{kMv6JI:"xjb2p0i",kMwMTN:"x1tgivj0",$$css:!0}};function vx(){return{transformTable(e){return{...e,styles:[...e.styles,yx.base]}}}}const xx={Row:Pf,Cell:es,HeaderCell:ts};function gx({density:e="balanced",dividers:t="rows",isStriped:l=!1,hasHover:n=!1,plugins:a,columns:u,data:c,ref:i,...f}){const s=y.useMemo(()=>vx(),[]),d=y.useMemo(()=>[s],[s]),g=mx(d,a),r=y.useMemo(()=>({density:e,dividers:t,isStriped:l,hasHover:n}),[e,t,l,n]);return v.jsx(If.Provider,{value:r,children:v.jsx(s0,{ref:i,data:c,columns:u,plugins:g,components:xx,...f})})}const r0=gx;r0.displayName="XDSTable";const d0={root:{kmuXW:"x2lah0s",$$css:!0},span:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0}},m0={primary:{kMwMTN:"xtbr613",$$css:!0},secondary:{kMwMTN:"xv9yike",$$css:!0},tertiary:{kMwMTN:"xv9yike",$$css:!0},disabled:{kMwMTN:"xqa6c3m",$$css:!0},accent:{kMwMTN:"xqwr325",$$css:!0},positive:{kMwMTN:"xtjic6",$$css:!0},negative:{kMwMTN:"xjt36v0",$$css:!0},warning:{kMwMTN:"xs3pv69",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0},blue:{kMwMTN:"x1fns2mt",$$css:!0},red:{kMwMTN:"xeffzf7",$$css:!0},green:{kMwMTN:"xmxeech",$$css:!0},gray:{kMwMTN:"x1eyinzz",$$css:!0},cyan:{kMwMTN:"x157w0xa",$$css:!0},teal:{kMwMTN:"x1f3zxcb",$$css:!0},yellow:{kMwMTN:"x1g6zdft",$$css:!0},orange:{kMwMTN:"xxu74a4",$$css:!0},pink:{kMwMTN:"x1kxxfg5",$$css:!0},purple:{kMwMTN:"xzdw94u",$$css:!0}},bx={xsm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",$$css:!0},sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",$$css:!0},md:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",$$css:!0},lg:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",$$css:!0}},Sx={xsm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",kGuDYH:"xfifm61",$$css:!0},sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0},lg:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",kGuDYH:"x1pvqxga",$$css:!0}};function ya({icon:e,color:t="primary",size:l="md",ref:n,...a}){if(typeof e=="string")return v.jsx(px,{name:e,color:t,size:l});const u=e;return v.jsx(u,{ref:n,"aria-hidden":"true",...ue(ae("icon",{size:l,color:t}),L(d0.root,m0[t],bx[l])),...a})}ya.displayName="XDSIcon";function px({name:e,color:t,size:l}){const n=wy(e);return n==null?null:v.jsx("span",{...ue(ae("icon",{size:l,color:t}),L(d0.span,m0[t],Sx[l])),"aria-hidden":"true",children:n})}const Qc={base:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x1lziwak",k71WvV:"x14z9mp",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kMzoRj:"xc342km",ksu8eU:"xng3xce",kVQacm:"x1rea2x4",kWkggS:"xjbqb8w",$$css:!0},fixed:{kVAEAm:"xixxii4",$$css:!0}};function kx(e="above",t="center"){const n={above:"top",below:"bottom",start:"left",end:"right"}[e];return e==="above"||e==="below"?t==="start"?`${n} span-right`:t==="end"?`${n} span-left`:n:t==="start"?`${n} span-bottom`:t==="end"?`${n} span-top`:`${n} center`}function h0(e){const{mode:t,onShow:l,onHide:n,lightDismiss:a=!1}=e,u=y.useId(),c=`--xds-layer-${u.replace(/:/g,"")}`,[i,f]=y.useState(!1),s=y.useRef(null),d=y.useRef(null),g=y.useCallback(()=>{s.current&&!s.current.matches(":popover-open")&&(s.current.showPopover(),f(!0),l==null||l())},[l]),r=y.useCallback(()=>{var o;(o=s.current)!=null&&o.matches(":popover-open")&&(s.current.hidePopover(),f(!1),n==null||n())},[n]),x=t==="context"?o=>{d.current&&(d.current.style.anchorName=""),o&&(o.style.anchorName=c),d.current=o}:void 0,S=y.useCallback(o=>{const m=o;m.newState==="closed"?(f(!1),n==null||n()):m.newState==="open"&&(f(!0),l==null||l())},[l,n]),p=y.useCallback(o=>{s.current=o,o&&o.addEventListener("toggle",S)},[S]),k=y.useCallback((o,m)=>{const{placement:b="above",alignment:T="center",xstyle:N,className:E,style:j}=m||{},A={positionAnchor:c,positionArea:kx(b,T),positionTryFallbacks:"flip-block, flip-inline, flip-block flip-inline"},M=L(Qc.base,N),q=E?`${E} ${M.className??""}`:M.className;return v.jsx("div",{ref:p,id:u,popover:a?"auto":"manual",className:q,style:{...M.style,...A,...j},children:o})},[c,u,a,p]),h=y.useCallback((o,m)=>{const{x:b,y:T,xstyle:N,className:E,style:j}=m,A={top:T,left:b},M=L(Qc.base,Qc.fixed,N),q=E?`${E} ${M.className??""}`:M.className;return v.jsx("div",{ref:p,id:u,popover:a?"auto":"manual",className:q,style:{...M.style,...A,...j},children:o})},[p,u,a]);return t==="context"?{ref:x,anchorId:c,show:g,hide:r,isOpen:i,id:u,render:k}:{ref:void 0,show:g,hide:r,isOpen:i,id:u,render:h}}const y0={below:{kKVMdj:"xl1vlw0",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},above:{kKVMdj:"x3psbcj",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},end:{kKVMdj:"x1i331go",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},start:{kKVMdj:"xck01x9",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}},Kc={container:{kWkggS:"x19aspcf",kMwMTN:"xrkvqaz",kaIpWk:"x1hviunn",kMv6JI:"x9ynric",kGuDYH:"xjm74w1",kLWn49:"xw6l6zx",$$css:!0},marginBlock:{keoZOQ:"xcsaf9d",k1K539:"x14cgwvg",keTefX:"x1lziwak",k71WvV:"x14z9mp",$$css:!0},marginInline:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x11g1kdw",k71WvV:"xnur1sd",$$css:!0}};function zx(e){return e.hasAttribute("tabindex")?e.tabIndex>=0:["A","BUTTON","INPUT","SELECT","TEXTAREA"].includes(e.tagName)?!e.disabled:!!e.isContentEditable}function Ex(e={}){const{placement:t="above",alignment:l="center",delay:n=200,hideDelay:a=0,focusTrigger:u="auto",isEnabled:c=!0,onShow:i,onHide:f}=e,s=t==="above"||t==="below"?Kc.marginBlock:Kc.marginInline,d=h0({mode:"context",onShow:i,onHide:f}),g=[Kc.container,s],r=y.useRef(null),x=y.useRef(null),S=y.useRef(null),p=y.useCallback(()=>{r.current&&(clearTimeout(r.current),r.current=null),x.current&&(clearTimeout(x.current),x.current=null)},[]),k=y.useCallback(()=>{c&&(p(),r.current=setTimeout(()=>{d.show()},n))},[c,p,d,n]),h=y.useCallback(()=>{p(),a>0?x.current=setTimeout(()=>{d.hide()},a):d.hide()},[p,d,a]),o=y.useCallback(()=>{typeof window<"u"&&typeof window.matchMedia=="function"&&window.matchMedia("(hover: none)").matches||k()},[k]),m=y.useCallback(()=>{h()},[h]),b=y.useCallback(A=>{!c||!A.target.matches(":focus-visible")||(p(),d.show())},[c,p,d]),T=y.useCallback(()=>{h()},[h]),N=y.useCallback(A=>{S.current&&(S.current.removeEventListener("mouseenter",o),S.current.removeEventListener("mouseleave",m),S.current.removeEventListener("focusin",b),S.current.removeEventListener("focusout",T)),A&&(A.addEventListener("mouseenter",o),A.addEventListener("mouseleave",m),(u==="always"||u==="auto"&&zx(A))&&(A.addEventListener("focusin",b),A.addEventListener("focusout",T))),S.current=A},[u,o,m,b,T]),E=y.useCallback(A=>{d.ref(A),N(A)},[d.ref,N]);y.useEffect(()=>()=>{p()},[p]);const j=y.useCallback((A,M)=>{const q=(M==null?void 0:M.placement)??t,G={placement:q,alignment:(M==null?void 0:M.alignment)??l,xstyle:[g,y0[q]],className:ae("tooltip")};return d.render(v.jsx("div",{className:"xfsso4q xy143xn x12gdq22 x1djylfy xw5ewwj x13faqbe",children:A}),G)},[d,t,l,g]);return{ref:E,positionRef:d.ref,interactionRef:N,anchorId:d.anchorId,describedBy:d.id,renderTooltip:j}}function Tx(e){let t=!1;return Fc.Children.forEach(e,l=>{Fc.isValidElement(l)&&(t=!0)}),!t}function Bo(...e){const t=e.filter(Boolean);return t.length>0?t.join(" "):void 0}function uc({children:e,anchorRef:t,content:l,placement:n="above",alignment:a="center",delay:u=200,hideDelay:c=0,focusTrigger:i="auto",isEnabled:f=!0,onOpenChange:s,hasHoverIndication:d="auto"}){const g=y.useRef(null),r=e!=null?Tx(e):!1,x=d===!0||d==="auto"&&r,S=y.useCallback(()=>{s==null||s(!0)},[s]),p=y.useCallback(()=>{s==null||s(!1)},[s]),k=Ex({placement:n,alignment:a,delay:u,hideDelay:c,focusTrigger:i,isEnabled:f,onShow:S,onHide:p});return y.useLayoutEffect(()=>{if(!t)return;const h=t.current;if(!h)return;k.ref(h);const o=h.getAttribute("aria-describedby");return h.setAttribute("aria-describedby",Bo(o,k.describedBy)??""),()=>{k.ref(null),o?h.setAttribute("aria-describedby",o):h.removeAttribute("aria-describedby")}},[t,k.ref,k.describedBy]),y.useLayoutEffect(()=>{if(t||r)return;const h=g.current;if(!h)return;const o=h.firstElementChild;if(!o)return;k.ref(o);const m=o.getAttribute("aria-describedby");return o.setAttribute("aria-describedby",Bo(m,k.describedBy)??""),()=>{k.ref(null),m?o.setAttribute("aria-describedby",m):o.removeAttribute("aria-describedby")}},[t,r,k.ref,k.describedBy]),t&&e==null?v.jsx(v.Fragment,{children:k.renderTooltip(l)}):r?v.jsxs(v.Fragment,{children:[v.jsx("span",{ref:k.ref,tabIndex:0,"aria-describedby":k.describedBy,...{0:{className:"xt0psk2"},1:{className:"xt0psk2 xujl8zx xev0dqp xycaml9 xrys4gj"}}[!!x<<0],children:e}),k.renderTooltip(l)]}):v.jsxs(v.Fragment,{children:[v.jsx("div",{ref:g,className:"xjp7ctv",children:e}),k.renderTooltip(l)]})}uc.displayName="XDSTooltip";const jx=Object.freeze(Object.defineProperty({__proto__:null,XDSTooltip:uc},Symbol.toStringTag,{value:"Module"}));function v0({label:e,inputID:t,isLabelHidden:l=!1,isDisabled:n=!1,isOptional:a=!1,isRequired:u=!1,labelIcon:c,labelTooltip:i,ref:f}){const s=a?"Optional":u?"Required":null;return v.jsxs("label",{ref:f,htmlFor:t,...ue(ae("field-label"),{0:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip x1tgivj0 x1ypdohk"},2:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip xnbbluu x1h6gzvc"},1:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip x1tgivj0 x1ypdohk xng3xce xzpqnlu xjm9jq1 xu96u03 xkdpibf xb3r6kr x1717udv x47corl x10l6tqk x13vifvy x87ps6o xuxw1ft x1i1rx1s"},3:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip xnbbluu x1h6gzvc xng3xce xzpqnlu xjm9jq1 xu96u03 xkdpibf xb3r6kr x1717udv x47corl x10l6tqk x13vifvy x87ps6o xuxw1ft x1i1rx1s"}}[!!n<<1|!!l<<0]),children:[c&&v.jsx(ya,{icon:c,size:"sm",color:"inherit"}),e,s&&v.jsxs("span",{className:"x1sodnla x141an7d xv1l7n4",children:[v.jsx("span",{"aria-hidden":"true",children:" ∙ "}),s]}),i&&v.jsx(uc,{content:i,placement:"above",children:v.jsx(ya,{icon:"info",size:"sm",color:"inherit"})})]})}v0.displayName="XDSFieldLabel";let x0=!1;typeof window<"u"&&requestAnimationFrame(()=>{x0=!0});const Mx={slideDown:{kKVMdj:"x1srr2gu",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},slideUp:{kKVMdj:"x1dvww92",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},fadeIn:{kKVMdj:"xqcmdr3",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},scaleIn:{kKVMdj:"x97zbip",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}};function Ax(e="slideDown"){const[t]=y.useState(()=>x0);return t?Mx[e]:null}const Jc={base:{kMv6JI:"x9ynric",kGuDYH:"x141an7d",kLWn49:"x1ltkj2j",$$css:!0},attached:{keoZOQ:"x1c40v9y",kLKAdn:"x1ak3mig",kGO01o:"x1wesfrj",kg3NbH:"xf314gf",kqGeR4:"x14lggfu",kYm2EN:"xtufxuj",$$css:!0},detached:{keoZOQ:"xcsaf9d",k8WAf4:"xce4md1",kg3NbH:"xf314gf",kaIpWk:"xh6dtrn",$$css:!0}},Dx={warning:{kWkggS:"x24i8r5",kMwMTN:"xdhq94a",$$css:!0},error:{kWkggS:"x1pritpl",kMwMTN:"x1joocv1",$$css:!0},success:{kWkggS:"xu13z74",kMwMTN:"xltfdvo",$$css:!0}};function g0({type:e,message:t,id:l,variant:n="attached"}){const a=Ax("slideDown");return v.jsx("div",{id:l,role:e==="error"?"alert":"status","aria-live":e==="error"?"assertive":"polite",...ue(ae("field-status",{type:e,variant:n}),L(Jc.base,a,n==="attached"?Jc.attached:Jc.detached,Dx[e])),children:t})}g0.displayName="XDSFieldStatus";const wx="modulepreload",Nx=function(e,t){return new URL(e,t).href},Xo={},Ox=function(t,l,n){let a=Promise.resolve();if(l&&l.length>0){const c=document.getElementsByTagName("link"),i=document.querySelector("meta[property=csp-nonce]"),f=(i==null?void 0:i.nonce)||(i==null?void 0:i.getAttribute("nonce"));a=Promise.allSettled(l.map(s=>{if(s=Nx(s,n),s in Xo)return;Xo[s]=!0;const d=s.endsWith(".css"),g=d?'[rel="stylesheet"]':"";if(!!n)for(let S=c.length-1;S>=0;S--){const p=c[S];if(p.href===s&&(!d||p.rel==="stylesheet"))return}else if(document.querySelector(`link[href="${s}"]${g}`))return;const x=document.createElement("link");if(x.rel=d?"stylesheet":wx,d||(x.as="script"),x.crossOrigin="",x.href=s,f&&x.setAttribute("nonce",f),document.head.appendChild(x),d)return new Promise((S,p)=>{x.addEventListener("load",S),x.addEventListener("error",()=>p(new Error(`Unable to preload CSS for ${s}`)))})}))}function u(c){const i=new Event("vite:preloadError",{cancelable:!0});if(i.payload=c,window.dispatchEvent(i),!i.defaultPrevented)throw c}return a.then(c=>{for(const i of c||[])i.status==="rejected"&&u(i.reason);return t().catch(u)})},Cx={primary:{kMwMTN:"x1tgivj0",$$css:!0},secondary:{kMwMTN:"xv1l7n4",$$css:!0},disabled:{kMwMTN:"xnbbluu",$$css:!0},placeholder:{kMwMTN:"xv1l7n4",$$css:!0},active:{kMwMTN:"xqwr325",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0}},$x={normal:{k63SB2:"x1sodnla",$$css:!0},medium:{k63SB2:"x1e4wzip",$$css:!0},semibold:{k63SB2:"x2mo6ok",$$css:!0},bold:{k63SB2:"x1lvx875",$$css:!0}},_x={body:{k63SB2:"xxovm9e",$$css:!0},large:{k63SB2:"x149oux8",$$css:!0},label:{k63SB2:"xmhvcl5",$$css:!0},code:{k63SB2:"xx3eeay",$$css:!0},supporting:{k63SB2:"xv8on6e",$$css:!0},"display-1":{k63SB2:"x1txul5o",$$css:!0},"display-2":{k63SB2:"x1y36c3f",$$css:!0},"display-3":{k63SB2:"x1on40hk",$$css:!0}},Rx={inline:{k1xSpc:"xt0psk2",$$css:!0},block:{k1xSpc:"x1lliihq",$$css:!0}},Lo={singleLine:{kVQacm:"xb3r6kr",kg5iWk:"xlyipyv",khDVqt:"xuxw1ft",k1xSpc:"x1lliihq",$$css:!0},multiLine:{kVQacm:"xb3r6kr",k1xSpc:"x104kibb",kgKLqz:"x1ua5tub",$$css:!0}},qx={"break-word":{kTgw9:"x1lldw8n",kHjlTd:"x1mzt3pk",$$css:!0},"break-all":{kTgw9:"x1yn0g08",$$css:!0}},Ux={wrap:{kN2L0X:"xk4td0m",$$css:!0},nowrap:{kN2L0X:"xebhuq6",$$css:!0},balance:{kN2L0X:"x1w2vvpw",$$css:!0},pretty:{kN2L0X:"x1fzhlzt",$$css:!0}},Hx={enabled:{kxwWH2:"x1b2iylo",kzeHkT:"xwgcxoh",k1xSpc:"x1lliihq",$$css:!0}},Bx={strikethrough:{kybGjl:"xmqliwb",$$css:!0}},Xx={enabled:{kcqcaj:"xss6m8b",$$css:!0}},Lx={content:{ks0D6T:"xw5ewwj",kTgw9:"x13faqbe",$$css:!0}};function Gx(e){const{maxLines:t}=e,[l,n]=y.useState(!1),[a,u]=y.useState(""),c=y.useRef(null),i=y.useRef(null),f=y.useCallback(d=>{if(t===0){n(!1);return}u(d.textContent??""),n(t===1?d.scrollWidth>d.offsetWidth:d.scrollHeight>d.offsetHeight)},[t]);return{ref:y.useCallback(d=>{i.current&&(i.current.disconnect(),i.current=null),c.current=d,d&&t>0?(f(d),typeof ResizeObserver<"u"&&(i.current=new ResizeObserver(()=>{f(d)}),i.current.observe(d))):(n(!1),u(""))},[t,f]),isTruncated:l,fullText:a}}const Yx=y.lazy(()=>Ox(()=>Promise.resolve().then(()=>jx),void 0,import.meta.url).then(e=>({default:e.XDSTooltip}))),Zx={body:"primary",large:"primary",label:"primary",supporting:"secondary",code:"primary","display-1":"primary","display-2":"primary","display-3":"primary"};function dt({type:e,size:t,color:l,weight:n,display:a="inline",maxLines:u=0,hasTruncateTooltip:c=!0,wordBreak:i,textWrap:f,hasCapsize:s=!1,hasStrikethrough:d=!1,hasTabularNumbers:g=!1,xstyle:r,className:x,style:S,as:p="span",children:k,ref:h,...o}){const m=l??Zx[e],b=i??(u===1?"break-all":"break-word"),T=u>0||s?"block":a,N=Gx({maxLines:u}),E=typeof c=="string"?c:"above",j=u>0&&c!==!1&&N.isTruncated,A=y.useRef(null),M=y.useCallback(G=>{typeof h=="function"?h(G):h&&(h.current=G),N.ref(G),A.current=G},[h,N.ref]),q=u>1?{WebkitLineClamp:u}:void 0;return v.jsxs(v.Fragment,{children:[v.jsx(p,{ref:M,...ue(ae("text",{type:e,color:m}),L(Cx[m],_x[e],n&&$x[n],u===1?Lo.singleLine:u>1?Lo.multiLine:Rx[T],u>0&&qx[b],f&&Ux[f],s&&Hx.enabled,d&&Bx.strikethrough,g&&Xx.enabled,r),x,{...S,...q}),title:j?N.fullText:void 0,...o,children:k}),j&&v.jsx(y.Suspense,{fallback:null,children:v.jsx(Yx,{anchorRef:A,content:v.jsx("span",{...L(Lx.content),children:N.fullText}),placement:E})})]})}dt.displayName="XDSText";const Vx=.75,Go=1.5,Yo={sm:{diameter:10,border:3},md:{diameter:14,border:3},lg:{diameter:18,border:3},xl:{diameter:28,border:4}},Zo={wrapper:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",$$css:!0},spinner:{k1xSpc:"x1rg5ohu",kVQacm:"xb3r6kr",kXLuUW:"xxymvpz",$$css:!0}};function ls({size:e="md",shade:t="default",label:l,xstyle:n,className:a,"aria-label":u,"data-testid":c,ref:i}){const f=y.useRef(null);y.useEffect(()=>{const p=f.current;if(p==null)return;const k=p.getContext("2d");if(!k)return;const{border:h,diameter:o}=Yo[e],m=window.devicePixelRatio||1,b=getComputedStyle(p),T=t==="onMedia"?b.getPropertyValue(Qi["--color-on-dark"])||"#FFFFFF":b.getPropertyValue(Qi["--color-accent"])||"#0064E0",N=t==="onMedia"?"rgba(255, 255, 255, 0.3)":"rgba(0, 0, 0, 0.1)",E=o/2*m,j=h*m,A=(E+j)*2;p.height=p.width=A,p.style.width=p.style.height=A/m+"px",k.lineCap="round",k.lineWidth=j;const M=A/2;k.beginPath(),k.arc(M,M,E,0,2*Math.PI),k.strokeStyle=N,k.stroke(),k.beginPath(),k.arc(M,M,E,Go*Math.PI,(Go+Vx)%2*Math.PI),k.strokeStyle=T,k.stroke()},[t,e]);const{border:s,diameter:d}=Yo[e],g=d+s*2,r=l!=null,x=u??(typeof l=="string"?l:void 0)??"Loading",S=v.jsx("span",{ref:r?void 0:i,role:"status","aria-label":x,"data-testid":r?void 0:c,...ue(r?"":ae("spinner",{size:e,shade:t}),L(Zo.spinner,!r&&n),r?void 0:a),style:{width:g,height:g},children:v.jsx("canvas",{ref:f,className:"xlp1x4z x1lliihq xqgcaz xa4qsjk x1ka1v4i x1esw782"})});return r?v.jsxs("div",{ref:i,"data-testid":c,...ue(ae("spinner",{size:e,shade:t}),L(Zo.wrapper,n),a),children:[S,typeof l=="string"?v.jsx(dt,{type:"body",weight:"bold",children:l}):l]}):S}ls.displayName="XDSSpinner";const He={checkboxWrapper:{kVAEAm:"x1n2onr6",k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0},input:{kVAEAm:"x10l6tqk",kogj98:"x1ghz6dp",kmVPX3:"x1717udv",kSiTet:"xg01cxk",kkrTdU:"x1ypdohk",kY2c9j:"x1vjfegm",$$css:!0},inputDisabled:{kkrTdU:"x1h6gzvc",$$css:!0},checkbox:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kMzoRj:"x1litavf",ksu8eU:"x1y0btm7",kaIpWk:"xx3sua9",k1ekBW:"xts7igz",kIyJzY:"xuedmi6 x12w9bfk",kAMwcw:"xlr8y92",$$css:!0},checkboxFocus:{kI3sdo:"x1a2a7pz x1dg3z2k",kInvED:"xcn42n2",$$css:!0},checkboxUnchecked:{kVAM5u:"xvy26l8 xvyyb7d",kWkggS:"x10xzikg xxuakwu",$$css:!0},checkboxChecked:{kVAM5u:"xad5do xvrpfll",kWkggS:"x1ewilqj x3h3317",$$css:!0},checkboxDisabled:{kSiTet:"xbyyjgo",kVAM5u:"x14i3s5s xrzr44y",kWkggS:"x9dqhi0 xaemn39",$$css:!0},checkboxDisabledUnchecked:{kWkggS:"xwmxj5m",$$css:!0},checkmark:{k1xSpc:"x1s85apg",kMwMTN:"x17wrial",$$css:!0},checkmarkVisible:{k1xSpc:"x1lliihq",$$css:!0},indeterminateMark:{k1xSpc:"x1s85apg",kWkggS:"x1azo05",kaIpWk:"x1nj7uno",$$css:!0},indeterminateMarkVisible:{k1xSpc:"x1lliihq",$$css:!0}},Vo={sm:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",$$css:!0},md:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",$$css:!0}},Qx={sm:{kzqmXN:"x1xp8n7a",kZKoxP:"xmix8c7",$$css:!0},md:{kzqmXN:"x17z2i9w",kZKoxP:"x17rw0jw",$$css:!0}},Kx={sm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",$$css:!0},md:{kzqmXN:"x6jxa94",kZKoxP:"x1v9usgg",$$css:!0}},Jx={sm:{kzqmXN:"x1fsd2vl",kZKoxP:"x36qwtl",$$css:!0},md:{kzqmXN:"xsmyaan",kZKoxP:"x36qwtl",$$css:!0}};function ns({label:e,isLabelHidden:t=!1,description:l,onChange:n,onChangeAction:a,isLoading:u=!1,value:c,isDisabled:i=!1,isOptional:f=!1,isRequired:s=!1,size:d="md",onFocus:g,onBlur:r,labelIcon:x,status:S,xstyle:p,className:k,style:h,ref:o}){const m=y.useId(),b=y.useId(),T=y.useId(),[,N]=y.useTransition(),[E,j]=y.useOptimistic(c),A=u||E!==c,M=E==="indeterminate",q=E===!0,G=q||M,Ae=y.useCallback(w=>{w&&(w.indeterminate=M),typeof o=="function"?o(w):o&&(o.current=w)},[M,o]),Se=[];l&&!t&&Se.push(b),S!=null&&S.message&&Se.push(T);const We=Se.length>0?Se.join(" "):void 0;return v.jsxs("div",{...ue(ae("checkbox-input",{size:d}),L(p),k,h),children:[v.jsxs("div",{...{0:{className:"x78zum5 x6s0dn4 x1txdalj"},2:{className:"x78zum5 x6s0dn4 xxhr3t"},1:{className:"x78zum5 x6s0dn4 x1txdalj x-default-marker"},3:{className:"x78zum5 x6s0dn4 xxhr3t x-default-marker"}}[!!t<<1|!i<<0],children:[v.jsxs("div",{...L(He.checkboxWrapper,Vo[d]),children:[v.jsx("input",{ref:Ae,id:m,type:"checkbox",checked:q,disabled:i,required:s,onChange:w=>{if(A)return;const D=w.target.checked;n==null||n(D,w),a&&!w.defaultPrevented&&N(async()=>{j(D),await a(D,w)})},onFocus:g,onBlur:r,"aria-checked":M?"mixed":void 0,"aria-describedby":We,"aria-invalid":(S==null?void 0:S.type)==="error"?!0:void 0,"aria-busy":A||void 0,...L(He.input,Vo[d],i&&He.inputDisabled)}),v.jsx("div",{"aria-hidden":"true",...ue(ae("checkbox"),L(He.checkbox,Qx[d],!i&&He.checkboxFocus,G?He.checkboxChecked:He.checkboxUnchecked,i&&He.checkboxDisabled,i&&!G&&He.checkboxDisabledUnchecked)),children:A?v.jsx(ls,{size:"sm",shade:G?"onMedia":"default"}):v.jsxs(v.Fragment,{children:[v.jsx("svg",{viewBox:"0 0 10 10",...L(He.checkmark,Kx[d],q&&He.checkmarkVisible),children:v.jsx("path",{d:"M8.5 2.5L4 7.5L1.5 5",stroke:"currentColor",strokeWidth:"1.5",fill:"none",strokeLinecap:"round",strokeLinejoin:"round"})}),v.jsx("div",{...L(He.indeterminateMark,Jx[d],M&&He.indeterminateMarkVisible)})]})})]}),v.jsxs("div",{className:"x78zum5 xdt5ytf x1lsbc85",children:[v.jsx(v0,{label:e,inputID:m,isLabelHidden:t,isDisabled:i,isOptional:f,isRequired:s,labelIcon:x}),l&&!t&&v.jsx("span",{id:b,className:"x9ynric x141an7d x1ltkj2j x1sodnla xv1l7n4",children:l})]})]}),(S==null?void 0:S.message)&&v.jsx(g0,{type:S.type,message:S.message,id:T,variant:"detached"})]})}ns.displayName="XDSCheckboxInput";function Wx(e){const t=new Set;return{subscribe(l){return t.add(l),()=>t.delete(l)},notify(){for(const l of t)l()},getConfig(){return e.current}}}function Qo(e,t){t?(e.setAttribute("aria-selected","true"),e.style.backgroundColor=a2):(e.removeAttribute("aria-selected"),e.style.backgroundColor="")}function Fx(...e){return t=>{for(const l of e)typeof l=="function"?l(t):l!=null&&(l.current=t)}}const as=y.createContext(null);function Ix(e,t){const l=y.useCallback(()=>e.getConfig().getIsItemSelected(t),[e,t]);return y.useSyncExternalStore(e.subscribe,l,l)}function Px(){const e=y.useContext(as);return e?v.jsx(t2,{store:e}):null}const e2=0,Ko=1,Jo=2;function t2({store:e}){const t=y.useCallback(()=>{var f;const u=e.getConfig();return u.getIsAllSelected()?Jo:((f=u.getIsIndeterminate)==null?void 0:f.call(u))??!1?Ko:e2},[e]),l=y.useSyncExternalStore(e.subscribe,t,t),n=l===Jo,a=l===Ko;return v.jsx(ns,{label:"Select all rows",isLabelHidden:!0,value:n?!0:a?"indeterminate":!1,onChange:()=>e.getConfig().onSelectAll({isAllSelected:!n}),size:"sm"})}function l2({item:e}){const t=y.useContext(as);return t?v.jsx(n2,{store:t,item:e}):null}function n2({store:e,item:t}){var c,i;const l=e.getConfig(),n=Ix(e,t),a=((c=l.getIsItemSelectable)==null?void 0:c.call(l,t))??!0,u=((i=l.getIsItemEnabled)==null?void 0:i.call(l,t))??!0;return a?v.jsx(ns,{label:"Select row",isLabelHidden:!0,value:n,onChange:()=>e.getConfig().onSelectItem({item:t,isSelected:!n}),isDisabled:!u,size:"sm"}):null}const a2=Qi["--color-accent-muted"],u2="__xds_selection",c2=Gv(36);function i2(e){const t=y.useRef(e);t.current=e;const l=y.useRef(null);l.current==null&&(l.current=Wx(t));const n=l.current;y.useEffect(()=>{n.notify()});const a=y.useMemo(()=>({key:u2,header:v.jsx("div",{className:"x78zum5 x6s0dn4 xl56j7k",children:v.jsx(Px,{})}),width:c2,resizable:!1,renderCell:u=>v.jsx("div",{className:"x78zum5 x6s0dn4 xl56j7k",children:v.jsx(l2,{item:u})})}),[]);return y.useMemo(()=>({transformTableContext(u){return v.jsx(as.Provider,{value:n,children:u})},transformColumns(u){return[a,...u]},transformBodyRow(u,c){const i=f=>{if(!f)return;Qo(f,n.getConfig().getIsItemSelected(c));const s=n.subscribe(()=>{if(!f.isConnected){s();return}Qo(f,n.getConfig().getIsItemSelected(c))})};return{...u,ref:u.ref?Fx(u.ref,i):i}}}),[n,a])}const Wo=()=>!0;function f2(e){const{data:t,idKey:l,getIsItemSelectable:n=Wo,getIsItemEnabled:a=Wo,selectedKeys:u,setSelectedKeys:c}=e,i=y.useCallback(m=>typeof l=="function"?l(m):String(m[l]),[l]),f=y.useCallback(m=>n(m)&&a(m),[n,a]),s=y.useMemo(()=>new Set(t.filter(f).map(i)),[t,f,i]),d=y.useMemo(()=>{const m=new Set;for(const b of u)s.has(b)||m.add(b);return m},[u,s]),g=y.useMemo(()=>new Set([...u,...s]),[u,s]),r=y.useCallback(()=>g.size===u.size&&g.size!==0,[g,u]),x=y.useRef(d);x.current=d;const S=y.useRef(g);S.current=g;const p=y.useCallback(({isAllSelected:m})=>{c(m?S.current:x.current)},[c]),k=y.useCallback(({item:m,isSelected:b})=>{c(T=>{const N=new Set(T),E=i(m);return b?N.add(E):N.delete(E),N})},[i,c]),h=y.useCallback(()=>{const m=t.filter(b=>f(b)&&u.has(i(b))).length;return m>0&&m<s.size},[t,f,u,i,s]);return{selectionConfig:y.useMemo(()=>({getIsItemSelected:m=>u.has(i(m)),onSelectItem:k,onSelectAll:p,getIsAllSelected:r,getIsIndeterminate:h,getIsItemSelectable:n,getIsItemEnabled:a}),[u,i,k,p,r,h,n,a])}}const s2={self:{keTefX:"xg82z56",k71WvV:"xofqkxr",$$css:!0}},o2=y.createContext(null);function r2(e){const t=y.useContext(o2);return e??(t==null?void 0:t.component)??"a"}const ql={base:{kVAEAm:"x1n2onr6",k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kOIVth:"x1txdalj",k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kMzoRj:"xc342km",ksu8eU:"xng3xce","--button-radius":"x1mkq5kp",kaIpWk:"x1q11iln",kMv6JI:"xjb2p0i",kGuDYH:"xcr08ib",kLWn49:"x1kq96og",k63SB2:"x1e4wzip",khDVqt:"xuxw1ft",kkrTdU:"x1ypdohk",k1ekBW:"xqc8rvf",kIyJzY:"xuedmi6 x12w9bfk",kAMwcw:"xlr8y92",k3aq6I:"x3oybdh xk4oym4",$$css:!0},disabled:{kkrTdU:"x1h6gzvc",kSiTet:"xbyyjgo",kKwaWg:"x18o3ruo",k3aq6I:"x1c071of x1pdlv7q",$$css:!0},ariaDisabled:{kKwaWg:"x18o3ruo x8o3jvd xuqm82a",$$css:!0},iconOnly:{"--button-icon-only-aspect":"x1v15ycx",kOBAk4:"xioom0i",kg3NbH:"xf314gf",$$css:!0},iconWrapper:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0},link:{kybGjl:"x1hl2dhg",$$css:!0}},d2={sm:{kZKoxP:"x6k0iem",$$css:!0},md:{kZKoxP:"x1ueg155",$$css:!0},lg:{kZKoxP:"xssyfek",$$css:!0}},m2={sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},lg:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0}},h2={primary:{kWkggS:"x1ewilqj",kMwMTN:"x17wrial",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},secondary:{kWkggS:"x17x4s8c",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},ghost:{kWkggS:"xjbqb8w",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},destructive:{kWkggS:"x1pjz0fi",kMwMTN:"x1m024r3",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x1p73he7","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0}},y2={loading:{kVAEAm:"x1n2onr6",kMwMTN:"x19co3pv",$$css:!0}},Fo={paddingInline2:{"--component-padding-inline":"x30uzy1",$$css:!0},paddingInline3:{"--component-padding-inline":"x1ojg8sz",$$css:!0}};function va({label:e,variant:t="secondary",size:l="md",type:n="button",isDisabled:a=!1,isLoading:u=!1,onClickAction:c,icon:i,children:f,endContent:s,tooltip:d,href:g,as:r,target:x,rel:S,xstyle:p,className:k,style:h,ref:o,...m}){const[b,T]=y.useTransition(),N=y.useRef(!1),E=u||b,j=a||E,A=t==="primary"||t==="destructive",M=i!=null&&f==null,q=r2(r),G=g!=null&&!j,Ae=d!=null&&j,Se=pe=>{var rt;if(j||N.current){pe.preventDefault();return}(rt=m.onClick)==null||rt.call(m,pe),c&&!pe.defaultPrevented&&(N.current=!0,T(async()=>{try{await c(pe)}finally{N.current=!1}}))},We=Ae?pe=>{var rt;pe.key==="Enter"||pe.key===" "?pe.preventDefault():(rt=m.onKeyDown)==null||rt.call(m,pe)}:void 0,w=t==="ghost",D=w?s2.self:null,O=w?M?Fo.paddingInline2:Fo.paddingInline3:null,$=L(ql.base,d2[l],h2[t],M&&ql.iconOnly,j&&ql.disabled,Ae&&ql.ariaDisabled,E&&y2.loading,O,D,G&&ql.link,p),Y=ue(ae("button",{variant:t,size:l}),$,k,h),Fe=v.jsxs(v.Fragment,{children:[E&&v.jsx("span",{className:"x10l6tqk x13vifvy xu96u03 x3m8u43 x1ey2m1c x78zum5 x6s0dn4 xl56j7k","aria-hidden":"true",children:v.jsx(ls,{size:"sm",shade:A?"onMedia":"default"})}),v.jsxs("span",{className:"xjp7ctv","aria-hidden":E||void 0,children:[i&&v.jsx("span",{...L(ql.iconWrapper,m2[l]),children:i}),M?null:v.jsx("span",{className:"xb3r6kr xlyipyv xeuugli",children:f??e}),!M&&s&&v.jsx("span",{className:"x3nfvp2 x6s0dn4 x1heor9g",children:s})]}),v.jsx("span",{className:"x10l6tqk x1i1rx1s xjm9jq1 x1717udv xkdpibf xb3r6kr xzpqnlu xuxw1ft xc342km",role:"status","aria-live":"polite",children:E?"Loading":""})]}),bt=M&&e!==""||E&&!M?{"aria-label":e}:null;let Ht;return G?Ht=v.jsx(q,{ref:o,href:g,target:x,rel:S,...Y,...m,...bt,onClick:Se,children:Fe}):Ht=v.jsx("button",{ref:o,type:n,disabled:Ae?void 0:j,...Y,...m,...bt,"aria-busy":E||void 0,"aria-disabled":Ae||void 0,onClick:Se,...We?{onKeyDown:We}:null,children:Fe}),d?v.jsx(uc,{content:d,placement:"above",children:Ht}):Ht}va.displayName="XDSButton";const v2='button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])';function us(e){return Array.from(e.querySelectorAll(v2))}function b0(e){try{e.focus()}catch{}return document.activeElement===e}function Io(e){const t=us(e);for(const l of t)if(b0(l))return!0;return!1}function x2(e){const t=us(e);for(let l=t.length-1;l>=0;l--)if(b0(t[l]))return!0;return!1}function g2(e){const{isActive:t,onEscape:l}=e,n=y.useRef(null),a=y.useRef(null),u=y.useRef(!1),c=y.useCallback(()=>{n.current&&Io(n.current)},[]);return y.useEffect(()=>{if(!t)return;const i=f=>{const s=n.current;if(!s)return;const d=f.target;s.contains(d)?a.current=d:u.current&&(Io(s),a.current===document.activeElement&&x2(s),a.current=document.activeElement),u.current=!1};return document.addEventListener("focus",i,!0),()=>{document.removeEventListener("focus",i,!0)}},[t]),y.useEffect(()=>{if(!t)return;const i=f=>{const s=n.current;if(s){if(f.key==="Escape"&&l){f.preventDefault(),l();return}if(f.key==="Tab"){u.current=!0;const d=us(s);if(d.length===0)return;const g=d[0],r=d[d.length-1];f.shiftKey?document.activeElement===g&&(f.preventDefault(),r.focus()):document.activeElement===r&&(f.preventDefault(),g.focus())}}};return document.addEventListener("keydown",i),()=>{document.removeEventListener("keydown",i)}},[t,l]),{containerRef:n,focusFirst:c}}const Po={surface:{kWkggS:"x1prclbq",kaIpWk:"x1hviunn",kGVxlE:"x1i5ehqx",$$css:!0},contentWrapper:{kVAEAm:"x1n2onr6",$$css:!0}};function b2(e={}){const{onShow:t,onHide:l,xstyle:n,hasLightDismiss:a=!0,hasAutoFocus:u=!0,hasSurface:c=!0,hasCloseButton:i=!0,closeButtonLabel:f="Close popover",dialogLabel:s}=e,d=y.useRef(null),g=y.useRef(!1),r=h0({mode:"context",lightDismiss:a,onShow:t,onHide:l}),{containerRef:x,focusFirst:S}=g2({isActive:r.isOpen,onEscape:r.hide});y.useEffect(()=>{r.isOpen&&u&&!g.current&&requestAnimationFrame(()=>{S()}),r.isOpen||(g.current=!1)},[r.isOpen,u,S]);const p=y.useCallback(b=>{d.current=b,r.ref(b)},[r]),k=y.useCallback(b=>{g.current=(b==null?void 0:b.skipAutoFocus)??!1,r.show()},[r]),h=y.useCallback(()=>{r.isOpen?r.hide():k()},[r,k]),o={"aria-haspopup":"dialog","aria-expanded":r.isOpen,"aria-controls":r.id},m=y.useCallback((b,T)=>r.render(v.jsxs("div",{ref:x,role:"dialog","aria-modal":"true","aria-label":s,...L(Po.contentWrapper,c&&Po.surface,n),children:[b,i&&v.jsx("div",{className:"x10l6tqk x1ey2m1c x1nrll8i x31h1t8 x1vjfegm x1i1rx1s x10okhzq xjm9jq1 x132qfvm xb3r6kr x1dordxg x1hyvwdk x10wafsz x47corl xbt4iw xexx8yu x1kw28su",children:v.jsx(va,{variant:"secondary",label:f,onClick:r.hide})})]}),{...T,xstyle:T==null?void 0:T.xstyle}),[r,i,c,f,x,s,n]);return{triggerRef:p,contentRef:x,anchorId:r.anchorId,show:k,hide:r.hide,toggle:h,isOpen:r.isOpen,id:r.id,render:m,triggerProps:o}}const er={horizontal:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kzqmXN:"xh8yej3",$$css:!0},vertical:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kZKoxP:"x5yr21d",$$css:!0}},Ul={horizontalLine:{kZKoxP:"xsyqizj",kzQI83:"x1iyjqo2",kmuXW:"xs83m0k",$$css:!0},verticalLine:{kzqmXN:"xjk4fl7",kzQI83:"x1iyjqo2",kmuXW:"xs83m0k",$$css:!0},subtle:{kWkggS:"x1m4xfpy",$$css:!0},strong:{kWkggS:"x7njt3n",$$css:!0}},tr={horizontal:{kUOVxO:"xzyy9it",$$css:!0},vertical:{kqGvvJ:"xcxpkta",$$css:!0}};function S0({orientation:e="horizontal",label:t,variant:l="subtle",isFullBleed:n=!1,xstyle:a,className:u,style:c,ref:i,...f}){const s=e==="horizontal";return v.jsxs("div",{ref:i,role:"separator","aria-orientation":e,...ue(ae("divider",{variant:l,orientation:e}),L(s?er.horizontal:er.vertical,n&&(s?tr.horizontal:tr.vertical),a),u,c),...f,children:[v.jsx("div",{...L(s?Ul.horizontalLine:Ul.verticalLine,Ul[l])}),t&&v.jsx("div",{...{0:{className:"x2lah0s xrrkdod x10xzikg x141an7d x1ltkj2j xv1l7n4"},1:{className:"x2lah0s x10xzikg x141an7d x1ltkj2j xv1l7n4 xnjsko4 x8o8v82"}}[!s<<0],children:t}),t&&v.jsx("div",{...L(s?Ul.horizontalLine:Ul.verticalLine,Ul[l])})]})}S0.displayName="XDSDivider";const S2={center:{kGNEyG:"x6s0dn4",$$css:!0},end:{kGNEyG:"xuk3077",$$css:!0},start:{kGNEyG:"x1cy8zhl",$$css:!0},stretch:{kGNEyG:"x1qjc9v5",$$css:!0}},p2={start:{kjj79g:"x1nhvcw1",$$css:!0},center:{kjj79g:"xl56j7k",$$css:!0},end:{kjj79g:"x13a6bvl",$$css:!0},between:{kjj79g:"x1qughib",$$css:!0},around:{kjj79g:"x1l1ennw",$$css:!0},evenly:{kjj79g:"xaw8158",$$css:!0}},k2={horizontal:{kXwgrk:"x1q0g3np",$$css:!0},vertical:{kXwgrk:"xdt5ytf",$$css:!0}},z2={nowrap:{kwnvtZ:"xozqiw3",$$css:!0},wrap:{kwnvtZ:"x1a02dak",$$css:!0},"wrap-reverse":{kwnvtZ:"x8hhl5t",$$css:!0}},E2={stack:{k1xSpc:"x78zum5",$$css:!0}},T2={0:{k1C7PZ:"x1o57wo1",khm7nJ:"x6yxi7o",$$css:!0},1:{k1C7PZ:"x1lfs0n9",khm7nJ:"x1ngg2t4",$$css:!0},2:{k1C7PZ:"xak3so",khm7nJ:"x1x7z4sm",$$css:!0},3:{k1C7PZ:"xewh9hi",khm7nJ:"x4olc9o",$$css:!0},4:{k1C7PZ:"xty4p9g",khm7nJ:"xtx9w7w",$$css:!0},5:{k1C7PZ:"x1eqhezk",khm7nJ:"x1iu6piu",$$css:!0},6:{k1C7PZ:"x3qlgwd",khm7nJ:"xczp1bk",$$css:!0},8:{k1C7PZ:"xicv188",khm7nJ:"xgx0vcf",$$css:!0},10:{k1C7PZ:"x1p37tyl",khm7nJ:"x1xpicb7",$$css:!0},"0.5":{k1C7PZ:"x1kihgfc",khm7nJ:"x1tw44j4",$$css:!0},"1.5":{k1C7PZ:"x1thn6ci",khm7nJ:"xhq53yo",$$css:!0}};function j2({crossAlign:e,direction:t,gap:l,mainAlign:n,wrap:a}){return[E2.stack,k2[t],l!=null&&T2[l],e!=null&&S2[e],n!=null&&p2[n],a!=null&&z2[a]]}function cs({direction:e,hAlign:t,vAlign:l,gap:n,wrap:a,element:u="div",xstyle:c,className:i,style:f,children:s,ref:d,...g}){const S=L(...j2({direction:e,crossAlign:e==="horizontal"?l:t,mainAlign:e==="horizontal"?t:l,gap:n,wrap:a}),c);return y.createElement(u,{ref:d,...ue(ae("stack",{direction:e,gap:n,wrap:a}),S,i,f),...g},s)}cs.displayName="XDSStack";function ou({ref:e,...t}){return v.jsx(cs,{...t,direction:"horizontal",ref:e})}ou.displayName="XDSHStack";function p0({ref:e,...t}){return v.jsx(cs,{...t,direction:"vertical",ref:e})}p0.displayName="XDSVStack";const M2={reset:{kAzted:"x2lwn1j",k7Eaqz:"xeuugli",$$css:!0}},A2={center:{kSGwAc:"xamitd3",$$css:!0},end:{kSGwAc:"xpvyfi4",$$css:!0},start:{kSGwAc:"xqcrz7y",$$css:!0},stretch:{kSGwAc:"xkh2ocl",$$css:!0}},D2={fill:{kzQI83:"x1iyjqo2",$$css:!0},static:{kzQI83:"x1c4vz4f",kmuXW:"x2lah0s",$$css:!0}};function w2({crossAlignSelf:e,size:t}={}){return[M2.reset,D2[t??"static"],e!=null&&A2[e]]}function k0({crossAlignSelf:e,size:t,element:l="div",xstyle:n,className:a,style:u,children:c,ref:i,...f}){const s=L(...w2({crossAlignSelf:e,size:t}),n);return y.createElement(l,{ref:i,...ue(ae("stack-item",{size:t}),s,a,u),...f},c)}k0.displayName="XDSStackItem";const N2={root:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",kUk6DE:"x98rzlu",k7Eaqz:"xeuugli",$$css:!0}};function z0({icon:e,label:t,description:l,children:n,xstyle:a,className:u,style:c}){return v.jsxs("span",{...ue(ae("dropdown-menu-item"),L(N2.root,a),u,c),children:[e&&v.jsx(ya,{icon:e,size:"sm",color:"secondary"}),v.jsxs("span",{className:"x78zum5 xdt5ytf x98rzlu xeuugli",children:[typeof t=="string"?v.jsx(dt,{type:"body",maxLines:1,children:t}):t,l&&v.jsx(dt,{type:"supporting",maxLines:1,children:l})]}),n]})}z0.displayName="XDSDropdownMenuItem";const O2={sm:{k8WAf4:"xu0wf1k",kg3NbH:"xf314gf",$$css:!0},md:{$$css:!0},lg:{$$css:!0}},hl={popover:{k7Eaqz:"xrzjruh",$$css:!0},popoverGap:{keoZOQ:"xcsaf9d",k1K539:"x14cgwvg",$$css:!0},popoverCustomWidth:e=>[{k7Eaqz:(typeof e=="number"?`${e}px`:e)!=null?"xkj4a21":typeof e=="number"?`${e}px`:e,$$css:!0},{"--x-minWidth":(t=>typeof t=="number"?t+"px":t??void 0)(typeof e=="number"?`${e}px`:e)}],divider:{kqGvvJ:"xsq74q5",$$css:!0},item:{kB7OPa:"x9f619",k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",kzqmXN:"xh8yej3",kmVPX3:"xlsj2fj",kaIpWk:"x1hsanxr",kMv6JI:"x9ynric",kGuDYH:"xcr08ib",kMwMTN:"x1tgivj0",kWkggS:"xjbqb8w",kkrTdU:"x1ypdohk",k9WMMc:"xdpxx8g",kI3sdo:"x1a2a7pz",$$css:!0},itemHighlighted:{kWkggS:"x1lmrjuc",$$css:!0},itemDisabled:{kSiTet:"xbyyjgo",kkrTdU:"x1h6gzvc",$$css:!0}};function E0(e){return!("type"in e)}function C2(e){return"type"in e&&e.type==="divider"}function T0(e){return"type"in e&&e.type==="section"}function $2(e){const t=[];for(const l of e)if(E0(l))t.push(l);else if(T0(l))for(const n of l.items)t.push(n);return t}function _2({item:e}){return v.jsx(z0,{icon:e.icon,label:e.label})}function j0({button:e={label:"Menu"},items:t,isMenuOpen:l,onOpenChange:n,menuWidth:a,onClick:u,hasChevron:c=!0,children:i,"data-testid":f}){const s=y.useId(),d=(e==null?void 0:e.size)??"md",g=y.useRef(null),[r,x]=y.useState(!1),S=l!==void 0,p=S?l:r,[k,h]=y.useState(-1),o=y.useMemo(()=>$2(t),[t]),m=y.useCallback(()=>{var D;S?n==null||n(!1):x(!1),h(-1),(D=g.current)==null||D.focus()},[S,n]),b=y.useCallback(()=>{S?n==null||n(!0):x(!0)},[S,n]),T=b2({onHide:m,onShow:b,hasLightDismiss:!0,hasCloseButton:!1,hasAutoFocus:!1});Fc.useEffect(()=>{S&&(l&&!T.isOpen?T.show():!l&&T.isOpen&&T.hide())},[l,S,T]);const N=y.useCallback(()=>{u==null||u(),S?n==null||n(!l):T.isOpen?T.hide():T.show()},[u,S,n,l,T]),E=y.useCallback(()=>{T.hide()},[T]),j=y.useCallback(D=>`${s}-item-${D}`,[s]),A=y.useCallback(D=>{var O;D.isDisabled||((O=D.onClick)==null||O.call(D),E())},[E]),M=y.useCallback((D,O)=>{D.isDisabled||h(O)},[]),q=y.useCallback(D=>{if(!T.isOpen){(D.key==="ArrowDown"||D.key==="Enter"||D.key===" ")&&(D.preventDefault(),T.show(),h(0));return}switch(D.key){case"ArrowDown":D.preventDefault(),h(O=>{let $=O+1;for(;$<o.length&&o[$].isDisabled;)$++;return $<o.length?$:O});break;case"ArrowUp":D.preventDefault(),h(O=>{let $=O-1;for(;$>=0&&o[$].isDisabled;)$--;return $>=0?$:O});break;case"Home":D.preventDefault();{let O=0;for(;O<o.length&&o[O].isDisabled;)O++;h(O<o.length?O:-1)}break;case"End":D.preventDefault();{let O=o.length-1;for(;O>=0&&o[O].isDisabled;)O--;h(O>=0?O:-1)}break;case"Escape":D.preventDefault(),E();break;case"Enter":case" ":D.preventDefault(),k>=0&&k<o.length&&A(o[k]);break}},[T,o,k,E,A]),G=y.useCallback((D,O)=>{const $=O===k;return v.jsx("div",{id:j(O),role:"menuitem",tabIndex:-1,"aria-disabled":D.isDisabled,onClick:()=>A(D),onMouseEnter:()=>M(D,O),...L(hl.item,O2[d],$&&hl.itemHighlighted,D.isDisabled&&hl.itemDisabled),children:i?i(D):v.jsx(_2,{item:D})},`${D.label}-${O}`)},[i,d,k,j,A,M]),Ae=y.useCallback(()=>{let D=0;const O=[];for(let $=0;$<t.length;$++){const Y=t[$];if(C2(Y))O.push(v.jsx(S0,{xstyle:hl.divider},`divider-${$}`));else if(T0(Y)){const Fe=[];for(const bt of Y.items)Fe.push(G(bt,D)),D++;O.push(v.jsxs("div",{role:"group","aria-label":Y.title,children:[Y.title&&v.jsx("div",{className:"xu0wf1k xf314gf x9ynric x141an7d x1ltkj2j xv1l7n4 x87ps6o","aria-hidden":"true",children:Y.title},`section-heading-${$}`),Fe]},`section-${$}`))}else E0(Y)&&(O.push(G(Y,D)),D++)}return O},[t,G]),Se=e.icon!=null&&e.children==null,We=e.endContent??(c&&!Se?v.jsx(ya,{icon:"chevronDown",size:"sm",color:"inherit"}):void 0),w=a?hl.popoverCustomWidth(a):hl.popover;return v.jsxs(v.Fragment,{children:[v.jsx(va,{ref:D=>{g.current=D,T.triggerRef(D)},...e,endContent:We,onClick:N,onKeyDown:q,"aria-haspopup":"menu","aria-expanded":p,"aria-controls":s,"aria-activedescendant":p&&k>=0?j(k):void 0,"data-testid":f}),T.render(v.jsx("div",{id:s,role:"menu",...ue(ae("dropdown-menu"),{className:"x9f619 xuyqlj2 x1odjw0f x1u41t63 x1r315hb x9epnlk xzg3hwr x1hc1fzr x19991ni xuedmi6 xlr8y92"}),children:Ae()}),{placement:"below",alignment:"start",xstyle:[w,hl.popoverGap,y0.below]})]})}j0.displayName="XDSDropdownMenu";const R2={base:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kOIVth:"xzye2dw",kZKoxP:"x1grt7ep",k8WAf4:"xt970qd",kg3NbH:"xf314gf",kaIpWk:"xjspbzw",kMv6JI:"xjb2p0i",kGuDYH:"x141an7d",kLWn49:"x1ltkj2j",k63SB2:"x1e4wzip",khDVqt:"xuxw1ft",$$css:!0}},q2={neutral:{kWkggS:"x17x4s8c",kMwMTN:"x1tgivj0",$$css:!0},info:{kWkggS:"x1ewilqj",kMwMTN:"x17wrial",$$css:!0},success:{kWkggS:"xdsz4j9",kMwMTN:"xri61p4",$$css:!0},warning:{kWkggS:"x1q8g9m5",kMwMTN:"xrebv38",$$css:!0},error:{kWkggS:"x1pjz0fi",kMwMTN:"x1m024r3",$$css:!0},blue:{kWkggS:"x1o0wnni",kMwMTN:"x1vvqiwl",$$css:!0},cyan:{kWkggS:"x1rgj867",kMwMTN:"x1txnczv",$$css:!0},green:{kWkggS:"x1sqjeoo",kMwMTN:"xltfdvo",$$css:!0},orange:{kWkggS:"x1e9xt6e",kMwMTN:"xm47u9q",$$css:!0},pink:{kWkggS:"xnpoty2",kMwMTN:"xiuofww",$$css:!0},purple:{kWkggS:"x16i6n6f",kMwMTN:"x1m9wyeb",$$css:!0},red:{kWkggS:"x1cibrc5",kMwMTN:"x1joocv1",$$css:!0},teal:{kWkggS:"x1jtji5o",kMwMTN:"x9x0lbs",$$css:!0},yellow:{kWkggS:"x1bo7t0x",kMwMTN:"xdhq94a",$$css:!0}};function M0({variant:e="neutral",label:t,icon:l,xstyle:n,className:a,style:u,ref:c,...i}){return v.jsxs("span",{ref:c,...ue(ae("badge",{variant:e}),L(R2.base,q2[e],n),a,u),...i,children:[l,t]})}M0.displayName="XDSBadge";const lr=[{id:"1",sender:"Alice Johnson",subject:"Q2 Planning Meeting Notes",preview:"Hey team, here are the notes from our planning session yesterday. Please review the action items...",date:"2026-04-04",isRead:!1},{id:"2",sender:"Bob Smith",subject:"Re: Design System Update",preview:"Looks great! I left some comments on the PR. The new token structure is much cleaner...",date:"2026-04-03",isRead:!0},{id:"3",sender:"Carol Williams",subject:"Urgent: Production Incident",preview:"We're seeing elevated error rates on the checkout flow. The SEV has been filed and oncall is...",date:"2026-04-03",isRead:!1},{id:"4",sender:"David Chen",subject:"Weekly Standup Recap",preview:"Here's a summary of what everyone shared in standup this week. Key highlights include the...",date:"2026-04-02",isRead:!0},{id:"5",sender:"Eva Martinez",subject:"New Component Proposal: DataGrid",preview:"I've drafted a proposal for a new DataGrid component. It builds on XDSTable but adds inline...",date:"2026-04-02",isRead:!0},{id:"6",sender:"Frank Lee",subject:"Offsite Logistics",preview:"Please fill out the travel form by Friday. Hotel blocks have been reserved at the Marriott...",date:"2026-04-01",isRead:!1},{id:"7",sender:"Grace Kim",subject:"Re: API Review Feedback",preview:"Thanks for the thorough review! I addressed all the comments and pushed a new revision...",date:"2026-04-01",isRead:!0},{id:"8",sender:"Henry Park",subject:"Accessibility Audit Results",preview:"The audit found 3 critical issues and 12 minor ones. I've created tasks for each and assigned...",date:"2026-03-31",isRead:!0}];function U2(){const[e,t]=y.useState(new Set),{selectionConfig:l}=f2({data:lr,idKey:"id",selectedKeys:e,setSelectedKeys:t}),n=i2(l),a=e.size,u=()=>{t(new Set)},c=()=>{t(new Set)},i=()=>{t(new Set)},f=[{key:"sender",header:"Sender",renderCell:s=>v.jsx(dt,{type:"body",weight:s.isRead?"normal":"semibold",children:s.sender})},{key:"subject",header:"Subject",renderCell:s=>v.jsxs(ou,{gap:2,vAlign:"center",children:[v.jsx(dt,{type:"body",weight:s.isRead?"normal":"semibold",children:s.subject}),!s.isRead&&v.jsx(M0,{variant:"info",label:"New"})]})},{key:"preview",header:"Preview",renderCell:s=>v.jsx(dt,{type:"supporting",color:"secondary",maxLines:1,children:s.preview})},{key:"date",header:"Date",renderCell:s=>v.jsx(dt,{type:"supporting",color:"secondary",children:s.date})}];return v.jsxs(p0,{gap:4,children:[v.jsx(ou,{gap:3,vAlign:"center",children:v.jsx(k0,{size:"fill",children:v.jsx(dt,{type:"large",weight:"bold",children:"Inbox"})})}),a>0&&v.jsxs(ou,{gap:2,vAlign:"center",children:[v.jsxs(dt,{type:"body",weight:"semibold",children:[a," selected"]}),v.jsx(va,{label:"Archive",variant:"secondary",size:"sm",onClick:u}),v.jsx(va,{label:"Mark as read",variant:"secondary",size:"sm",onClick:c}),v.jsx(j0,{button:{label:"More actions",variant:"ghost",size:"sm"},items:[{label:"Mark as unread",onClick:c},{label:"Move to folder",onClick:()=>{}},{type:"divider"},{label:"Delete",onClick:i}]})]}),v.jsx(r0,{data:lr,columns:f,idKey:"id",density:"balanced",dividers:"rows",hasHover:!0,plugins:{selection:n}})]})}function H2(){return v.jsx(u0,{theme:Bv,mode:"light",children:v.jsx(U2,{})})}Ty.createRoot(document.getElementById("root")).render(v.jsx(H2,{}));</script>
+  <style rel="stylesheet" crossorigin>/**
+ * XDS Reset Stylesheet
+ *
+ * An opinionated CSS reset that provides a clean, predictable base for
+ * XDS applications. Built on the same principles as Tailwind Preflight
+ * and modern-normalize, adapted for the XDS design system.
+ *
+ * This reset:
+ * - Normalizes cross-browser inconsistencies
+ * - Sets box-sizing: border-box universally
+ * - Removes default margins, padding, and list styles
+ * - Makes images block-level and responsive
+ * - Resets form elements to inherit font styles
+ * - Uses :where() for zero specificity (easy to override)
+ *
+ * Usage:
+ *
+ * 1. Import directly (global reset):
+ *    import '@xds/core/reset.css';
+ *
+ * 2. Combine with base styles and theme:
+ *    import '@xds/core/reset.css';        // @layer reset  — clean slate
+ *    import '@xds/core/xds.css';           // @layer xds-base — component styles
+ *    import '@xds/theme-default/theme.css'; // @layer xds-theme — theme overrides
+ *
+ * Layer order: reset → xds-base → xds-theme
+ * Consumer styles (unlayered) always override all XDS layers.
+ * The reset has the lowest priority and can be overridden by any other layer.
+ *
+ * Similar to:
+ * - Tailwind CSS Preflight
+ * - Chakra UI's preflight (v3)
+ * - Bootstrap Reboot
+ * - modern-normalize
+ */
+
+@layer reset {
+
+  /* ===========================================================================
+     Box Model
+     =========================================================================== */
+
+  /*
+   * Use border-box globally. Prevents padding/border from affecting
+   * element dimensions — the single most impactful reset.
+   */
+  :where(*, *::before, *::after) {
+    box-sizing: border-box;
+  }
+
+  /*
+   * Reset borders to 0-width solid. This lets you add a border by just
+   * setting border-width — no need to also specify border-style.
+   */
+  :where(*, *::before, *::after) {
+    border-width: 0;
+    border-style: solid;
+    border-color: currentColor;
+  }
+
+  /* ===========================================================================
+     Document
+     =========================================================================== */
+
+  /*
+   * Consistent line-height, prevent text size adjustment on orientation
+   * change in iOS, and set a readable tab size.
+   *
+   * color-scheme: light dark — declares that this page supports both modes,
+   * enabling CSS light-dark() to resolve correctly. Also ensures that CSS
+   * tools (e.g. LightningCSS) which polyfill light-dark() for older browsers
+   * inject their toggle-variable initialization in the same CSS bundle.
+   * XDSTheme overrides color-scheme per-wrapper as needed.
+   */
+  :where(html) {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    color-scheme: light dark;
+  }
+
+  /*
+   * Remove default body margin and set font smoothing for sharper text
+   * rendering on macOS/iOS.
+   */
+  :where(body) {
+    margin: 0;
+    line-height: inherit;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* ===========================================================================
+     Typography
+     =========================================================================== */
+
+  /*
+   * Reset headings to inherit size and weight. Headings should be styled
+   * intentionally — not rely on browser defaults that vary across browsers.
+   */
+  :where(h1, h2, h3, h4, h5, h6) {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /*
+   * Remove default margins on all block-level text elements.
+   */
+  :where(h1, h2, h3, h4, h5, h6, p, blockquote, figure, pre, dl, dd) {
+    margin: 0;
+  }
+
+  /*
+   * Links inherit color and text-decoration. Style them intentionally
+   * rather than relying on browser-default blue/purple.
+   */
+  :where(a) {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  /*
+   * Correct font-weight rendering in Chrome and Safari.
+   */
+  :where(b, strong) {
+    font-weight: bolder;
+  }
+
+  /*
+   * Use the configured monospace font stack and fix the odd em sizing
+   * that browsers apply to code elements.
+   */
+  :where(code, kbd, samp, pre) {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      'Liberation Mono', 'Courier New', monospace;
+    font-size: 1em;
+  }
+
+  /*
+   * Correct font-size for small elements.
+   */
+  :where(small) {
+    font-size: 80%;
+  }
+
+  /*
+   * Prevent sub and sup from affecting line-height.
+   */
+  :where(sub, sup) {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  :where(sub) {
+    bottom: -0.25em;
+  }
+
+  :where(sup) {
+    top: -0.5em;
+  }
+
+  /* ===========================================================================
+     Lists
+     =========================================================================== */
+
+  /*
+   * Remove default list styles, margin, and padding. Lists used for
+   * navigation or layout shouldn't carry prose styling by default.
+   * Use explicit styles for prose lists.
+   */
+  :where(ol, ul, menu) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Media
+     =========================================================================== */
+
+  /*
+   * Make replaced elements block-level. Eliminates the "mystery gap"
+   * below inline images and aligns with how these elements are
+   * actually used in modern layouts.
+   */
+  :where(img, svg, video, canvas, audio, iframe, embed, object) {
+    display: block;
+    vertical-align: middle;
+  }
+
+  /*
+   * Constrain images and video to their container. Responsive by default.
+   */
+  :where(img, video) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* ===========================================================================
+     Forms
+     =========================================================================== */
+
+  /*
+   * Form elements should inherit font styles from their parent rather
+   * than using the browser's default font stack.
+   */
+  :where(button, input, optgroup, select, textarea) {
+    font: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  /*
+   * Remove default button styling. Buttons should be styled intentionally.
+   */
+  :where(button, [type='button'], [type='reset'], [type='submit']) {
+    -webkit-appearance: button;
+    appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
+
+  /*
+   * Pointer cursor for interactive elements.
+   */
+  :where(button, [role='button']) {
+    cursor: pointer;
+  }
+
+  /*
+   * Default cursor for disabled elements.
+   */
+  :where(:disabled) {
+    cursor: default;
+  }
+
+  /*
+   * Only allow vertical resizing of textareas to prevent layout breakage.
+   */
+  :where(textarea) {
+    resize: vertical;
+  }
+
+  /*
+   * Normalize placeholder opacity (Firefox renders at reduced opacity)
+   * and set a sensible default color using the XDS text-placeholder token.
+   */
+  :where(input::placeholder, textarea::placeholder) {
+    opacity: 1;
+    color: var(--color-text-secondary, #9ca3af);
+  }
+
+  /*
+   * Remove the inner padding and cancel buttons in search inputs
+   * for Chrome and Safari.
+   */
+  :where([type='search']::-webkit-search-decoration,
+         [type='search']::-webkit-search-cancel-button) {
+    -webkit-appearance: none;
+  }
+
+  /*
+   * Remove default fieldset styles.
+   */
+  :where(fieldset) {
+    margin: 0;
+    padding: 0;
+  }
+
+  :where(legend) {
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Tables
+     =========================================================================== */
+
+  /*
+   * Collapse table borders and fix text-indent/border-color inheritance.
+   */
+  :where(table) {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  /* ===========================================================================
+     Misc
+     =========================================================================== */
+
+  /*
+   * Simplify hr to a single border-top line.
+   */
+  :where(hr) {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  /*
+   * Correct display for summary elements.
+   */
+  :where(summary) {
+    display: list-item;
+  }
+
+  /*
+   * Reset dialog padding and outline.
+   */
+  :where(dialog) {
+    padding: 0;
+    outline: none;
+  }
+
+  /*
+   * Ensure hidden elements are actually hidden.
+   */
+  :where([hidden]) {
+    display: none;
+  }
+
+  /*
+   * Remove tap highlight on iOS.
+   */
+  :where(html) {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* ===========================================================================
+     Touch Devices
+     =========================================================================== */
+
+  /*
+   * Suppress focus-visible outlines on touch-only devices.
+   *
+   * Focus rings exist to show keyboard users where focus is. On devices
+   * with no hover capability and a coarse pointer (phones, tablets),
+   * there's no keyboard navigation — focus rings are visual noise that
+   * can flash on tap, on dialog open (showModal auto-focus), or on
+   * programmatic focus.
+   *
+   * This targets touch-only devices specifically:
+   * - (hover: none) — no hover capability (not a mouse)
+   * - (pointer: coarse) — imprecise pointer (finger, not stylus)
+   *
+   * Hybrid devices (laptop with touchscreen) are NOT affected because
+   * their primary pointer is fine (trackpad/mouse) and hover is available.
+   */
+  @media (hover: none) and (pointer: coarse) {
+    :where(:focus-visible) {
+      outline: none;
+    }
+  }
+}</style>
+<style>@property --x-minWidth {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-marginTop {
+  syntax: "*";
+  inherits: false
+}
+
+@keyframes x18re5ia-B {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes x1k48ry3-B {
+  from {
+    opacity: 0;
+    transform: scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes xwmkjkf-B {
+  from {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xu7jd1z-B {
+  from {
+    opacity: 0;
+    transform: translateX(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xv1hr86-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes x1ahk7ht-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes xiylxmw-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2)));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes x1b6yrix-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes xqng64z-B {
+  0% {
+    transform: rotate(0);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+:root, .xyc456f {
+  --border-width: 1px;
+}
+
+:root, .xrphr3l {
+  --color-accent: light-dark(#0064e0, #2694fe);
+  --color-accent-muted: light-dark(#0082fb33, #0082fb3f);
+  --color-on-accent: light-dark(#fff, #fff);
+  --color-neutral: light-dark(#0536591a, #dfe2e533);
+  --color-background-surface: light-dark(#fff, #1f1f22);
+  --color-background-body: light-dark(#f1f4f7, #111112);
+  --color-overlay: light-dark(#01122866, #11111299);
+  --color-overlay-hover: light-dark(#0536590c, #ffffff0c);
+  --color-overlay-pressed: light-dark(#05365919, #ffffff19);
+  --color-background-muted: light-dark(#0536590c, #1111127f);
+  --color-text-primary: light-dark(#0a1317, #dfe2e5);
+  --color-text-secondary: light-dark(#4e606f, #aaafb5);
+  --color-text-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-text-accent: light-dark(#0064e0, #3e9efb);
+  --color-on-dark: light-dark(#fff, #fff);
+  --color-on-light: light-dark(#000, #000);
+  --color-icon-accent: light-dark(#0064e0, #2694fe);
+  --color-icon-primary: light-dark(#0a1317, #dfe2e5);
+  --color-icon-secondary: light-dark(#4e606f, #aaafb5);
+  --color-icon-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-background-card: light-dark(#fff, #1f1f22);
+  --color-background-popover: light-dark(#fff, #28292c);
+  --color-success: light-dark(#0d8626, #0d8626);
+  --color-success-muted: light-dark(#0b991f33, #0b991f3f);
+  --color-on-success: light-dark(#fff, #fff);
+  --color-error: light-dark(#e3193b, #f5394f);
+  --color-error-muted: light-dark(#e3193b33, #f5394f3f);
+  --color-on-error: light-dark(#fff, #fff);
+  --color-warning: light-dark(#e9af08, #f2c00b);
+  --color-warning-muted: light-dark(#e2a40033, #e2a4003f);
+  --color-on-warning: light-dark(#0a1317, #0a1317);
+  --color-border: light-dark(#05365919, #f2f4f619);
+  --color-border-emphasized: light-dark(#ccd3db, #494d53);
+  --color-skeleton: light-dark(#ccd3db, #5a5e66);
+  --color-shadow: light-dark(#0536591a, #0000004d);
+  --color-tint-hover: light-dark(#000, #fff);
+  --color-background-blue: light-dark(#0171e333, #0171e333);
+  --color-border-blue: light-dark(#0171e3, #4ba9fe);
+  --color-icon-blue: light-dark(#0064e0, #2694fe);
+  --color-text-blue: light-dark(#042f97, #afd7ff);
+  --color-background-cyan: light-dark(#03a7d733, #03a7d733);
+  --color-border-cyan: light-dark(#00bcd4, #4dd0e1);
+  --color-icon-cyan: light-dark(#00acc1, #26c6da);
+  --color-text-cyan: light-dark(#014975, #a1eef9);
+  --color-background-gray: light-dark(#0a131733, #666a724c);
+  --color-border-gray: light-dark(#647685, #8c939b);
+  --color-icon-gray: light-dark(#4e606f, #aaafb5);
+  --color-text-gray: light-dark(#0a1317, #e7eaed);
+  --color-background-green: light-dark(#24bb5e33, #24bb5e33);
+  --color-border-green: light-dark(#24bb5e, #4cd964);
+  --color-icon-green: light-dark(#0d8626, #26a756);
+  --color-text-green: light-dark(#09441f, #a5f690);
+  --color-background-orange: light-dark(#f2790233, #f2790233);
+  --color-border-orange: light-dark(#f27902, #ffa040);
+  --color-icon-orange: light-dark(#e9690b, #fb8c00);
+  --color-text-orange: light-dark(#6b2203, #fdb876);
+  --color-background-pink: light-dark(#e638b333, #e638b333);
+  --color-border-pink: light-dark(#e91e63, #f48fb1);
+  --color-icon-pink: light-dark(#c2185b, #ec407a);
+  --color-text-pink: light-dark(#650053, #feade3);
+  --color-background-purple: light-dark(#7952ff33, #7952ff33);
+  --color-border-purple: light-dark(#7952ff, #9575cd);
+  --color-icon-purple: light-dark(#5b08d8, #7952ff);
+  --color-text-purple: light-dark(#3e0697, #b3b0fe);
+  --color-background-red: light-dark(#e3193b33, #e3193b33);
+  --color-border-red: light-dark(#e3193b, #f5394f);
+  --color-icon-red: light-dark(#d31130, #e3193b);
+  --color-text-red: light-dark(#7b0210, #ffb2b8);
+  --color-background-teal: light-dark(#0db7af33, #0db7af33);
+  --color-border-teal: light-dark(#0db7af, #4db6ac);
+  --color-icon-teal: light-dark(#009688, #26a69a);
+  --color-text-teal: light-dark(#083943, #40dccd);
+  --color-background-yellow: light-dark(#e2a40033, #e2a40033);
+  --color-border-yellow: light-dark(#ffeb3b, #fff176);
+  --color-icon-yellow: light-dark(#fbc02d, #ffee58);
+  --color-text-yellow: light-dark(#753f07, #fbce03);
+}
+
+:root, .xdxxp96 {
+  --duration-fast-min: .13s;
+  --duration-fast: .175s;
+  --duration-fast-max: .23s;
+  --duration-medium-min: .31s;
+  --duration-medium: .41s;
+  --duration-medium-max: .55s;
+}
+
+:root, .x1u6r7cv {
+  --ease-standard: cubic-bezier(.24, 1, .4, 1);
+}
+
+:root, .x6xvlns {
+  --font-family-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-family-code: "SF Mono", Monaco, Consolas, monospace;
+  --font-family-heading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+:root, .x48sopm {
+  --font-size-4xs: .375rem;
+  --font-size-3xs: .4375rem;
+  --font-size-2xs: .5rem;
+  --font-size-xs: .625rem;
+  --font-size-sm: .75rem;
+  --font-size-base: .875rem;
+  --font-size-lg: 1.0625rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.8125rem;
+  --font-size-4xl: 2.1875rem;
+  --font-size-5xl: 2.625rem;
+}
+
+:root, .x1anzp68 {
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+}
+
+:root, .xy6n0i {
+  --radius-none: 0px;
+  --radius-inner: 4px;
+  --radius-element: 8px;
+  --radius-container: 12px;
+  --radius-page: 28px;
+  --radius-full: 9999px;
+}
+
+:root, .x99zpk1 {
+  --shadow-low: 0px 1px 1px light-dark(#0000001a, #0003), 0px 2px 8px light-dark(#0000001a, #0003);
+  --shadow-med: 0px 1px 2px light-dark(#0000001a, #0003), 0px 2px 12px light-dark(#0000001a, #0003);
+  --shadow-high: 0px 2px 2px light-dark(#0000001a, #0003), 0px 8px 24px light-dark(#0000001a, #0000004d);
+  --shadow-inset-hover: inset 0px 0px 0px 2px #0171e34d;
+  --shadow-inset-selected: inset 0px 0px 0px 2px #0171e380;
+  --shadow-inset-success: inset 0px 0px 0px 2px #26a7564d;
+  --shadow-inset-warning: inset 0px 0px 0px 2px #e2a4004d;
+  --shadow-inset-error: inset 0px 0px 0px 2px #e3193b4d;
+}
+
+:root, .x10aelx4 {
+  --size-element-sm: 28px;
+  --size-element-md: 32px;
+  --size-element-lg: 36px;
+}
+
+:root, .x1auoh0n {
+  --spacing-0: 0px;
+  --spacing-0-5: 2px;
+  --spacing-1: 4px;
+  --spacing-1-5: 6px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-11: 44px;
+  --spacing-12: 48px;
+}
+
+:root, .xmde5od {
+  --text-heading-1-size: var(--font-size-2xl);
+  --text-heading-1-weight: var(--font-weight-semibold);
+  --text-heading-1-leading: 1.3333;
+  --text-heading-2-size: var(--font-size-xl);
+  --text-heading-2-weight: var(--font-weight-semibold);
+  --text-heading-2-leading: 1.4;
+  --text-heading-3-size: var(--font-size-lg);
+  --text-heading-3-weight: var(--font-weight-semibold);
+  --text-heading-3-leading: 1.4118;
+  --text-heading-4-size: var(--font-size-base);
+  --text-heading-4-weight: var(--font-weight-semibold);
+  --text-heading-4-leading: 1.4286;
+  --text-heading-5-size: var(--font-size-sm);
+  --text-heading-5-weight: var(--font-weight-semibold);
+  --text-heading-5-leading: 1.6667;
+  --text-heading-6-size: var(--font-size-xs);
+  --text-heading-6-weight: var(--font-weight-semibold);
+  --text-heading-6-leading: 1.6;
+  --text-body-size: var(--font-size-base);
+  --text-body-weight: var(--font-weight-normal);
+  --text-body-leading: 1.4286;
+  --text-large-size: var(--font-size-lg);
+  --text-large-weight: var(--font-weight-semibold);
+  --text-large-leading: 1.4118;
+  --text-label-size: var(--font-size-base);
+  --text-label-weight: var(--font-weight-medium);
+  --text-label-leading: 1.4286;
+  --text-code-size: var(--font-size-base);
+  --text-code-weight: var(--font-weight-normal);
+  --text-code-leading: 1.4286;
+  --text-supporting-size: var(--font-size-sm);
+  --text-supporting-weight: var(--font-weight-normal);
+  --text-supporting-leading: 1.6667;
+  --text-display-1-size: var(--font-size-5xl);
+  --text-display-1-weight: var(--font-weight-normal);
+  --text-display-1-leading: 1.2381;
+  --text-display-2-size: var(--font-size-4xl);
+  --text-display-2-weight: var(--font-weight-normal);
+  --text-display-2-leading: 1.2571;
+  --text-display-3-size: var(--font-size-3xl);
+  --text-display-3-weight: var(--font-weight-normal);
+  --text-display-3-leading: 1.2414;
+}
+
+:root, .xs77cmt {
+  --transition-fast: .15s ease;
+  --transition-normal: .2s ease;
+}
+
+.xkzo27j {
+  --button-focus-offset: 3px;
+}
+
+.x1v15ycx {
+  --button-icon-only-aspect: 1 / 1;
+}
+
+.x1mkq5kp {
+  --button-radius: var(--radius-element);
+}
+
+.x30uzy1 {
+  --component-padding-inline: var(--spacing-2);
+}
+
+.x1ojg8sz {
+  --component-padding-inline: var(--spacing-3);
+}
+
+.x1r315hb {
+  --dropdown-padding: var(--spacing-1);
+}
+
+.x1u41t63 {
+  --dropdown-radius: var(--radius-container);
+}
+
+.xwfoc2r {
+  --edge-end: 1;
+}
+
+.x1tfgai2 {
+  --edge-start: 1;
+}
+
+.xrhxz6v {
+  --input-radius: var(--radius-element);
+}
+
+.xln7xf2:not(#\#) {
+  font: inherit;
+}
+
+.xkdpibf:not(#\#) {
+  margin: -1px;
+}
+
+.x1ghz6dp:not(#\#) {
+  margin: 0;
+}
+
+.x1717udv:not(#\#) {
+  padding: 0;
+}
+
+.x9epnlk:not(#\#) {
+  padding: var(--spacing-1);
+}
+
+.xlsj2fj:not(#\#) {
+  padding: var(--spacing-2);
+}
+
+.xad5do:not(#\#):not(#\#) {
+  border-color: var(--color-accent);
+}
+
+.xvy26l8:not(#\#):not(#\#) {
+  border-color: var(--color-border-emphasized);
+}
+
+.x14i3s5s:not(#\#):not(#\#) {
+  border-color: var(--color-border);
+}
+
+.x1ofxpqo:not(#\#):not(#\#) {
+  border-color: var(--color-error);
+}
+
+.x16m2moy:not(#\#):not(#\#) {
+  border-color: var(--color-success);
+}
+
+.x8wg1ba:not(#\#):not(#\#) {
+  border-color: var(--color-warning);
+}
+
+.x1nj7uno:not(#\#):not(#\#) {
+  border-radius: 1px;
+}
+
+.x16rqkct:not(#\#):not(#\#) {
+  border-radius: 50%;
+}
+
+.x1hsanxr:not(#\#):not(#\#) {
+  border-radius: max(0px,calc(var(--dropdown-radius) - var(--dropdown-padding)));
+}
+
+.x1q11iln:not(#\#):not(#\#) {
+  border-radius: var(--button-radius);
+}
+
+.xzg3hwr:not(#\#):not(#\#) {
+  border-radius: var(--dropdown-radius);
+}
+
+.x11spqq5:not(#\#):not(#\#) {
+  border-radius: var(--input-radius);
+}
+
+.x1hviunn:not(#\#):not(#\#) {
+  border-radius: var(--radius-container);
+}
+
+.xh6dtrn:not(#\#):not(#\#) {
+  border-radius: var(--radius-element);
+}
+
+.xjspbzw:not(#\#):not(#\#) {
+  border-radius: var(--radius-full);
+}
+
+.xx3sua9:not(#\#):not(#\#) {
+  border-radius: var(--radius-inner);
+}
+
+.xng3xce:not(#\#):not(#\#) {
+  border-style: none;
+}
+
+.x1y0btm7:not(#\#):not(#\#) {
+  border-style: solid;
+}
+
+.xc342km:not(#\#):not(#\#) {
+  border-width: 0;
+}
+
+.x1litavf:not(#\#):not(#\#) {
+  border-width: var(--border-width);
+}
+
+.x98rzlu:not(#\#):not(#\#) {
+  flex: 1;
+}
+
+.xxhr3t:not(#\#):not(#\#) {
+  gap: 0;
+}
+
+.x1lsbc85:not(#\#):not(#\#) {
+  gap: var(--spacing-0-5);
+}
+
+.xzye2dw:not(#\#):not(#\#) {
+  gap: var(--spacing-1);
+}
+
+.x1txdalj:not(#\#):not(#\#) {
+  gap: var(--spacing-2);
+}
+
+.x18g69wz:not(#\#):not(#\#) {
+  gap: var(--spacing-4);
+}
+
+.xcxpkta:not(#\#):not(#\#) {
+  margin-block: calc(-1 * var(--container-padding, 0px));
+}
+
+.xsq74q5:not(#\#):not(#\#) {
+  margin-block: var(--spacing-1);
+}
+
+.xzyy9it:not(#\#):not(#\#) {
+  margin-inline: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1a2a7pz:not(#\#):not(#\#) {
+  outline: none;
+}
+
+.xb3r6kr:not(#\#):not(#\#) {
+  overflow: hidden;
+}
+
+.x1rea2x4:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xt970qd:not(#\#):not(#\#) {
+  padding-block: 0;
+}
+
+.xu0wf1k:not(#\#):not(#\#) {
+  padding-block: var(--spacing-1);
+}
+
+.xce4md1:not(#\#):not(#\#) {
+  padding-block: var(--spacing-2);
+}
+
+.x8o8v82:not(#\#):not(#\#) {
+  padding-block: var(--spacing-3);
+}
+
+.xnjsko4:not(#\#):not(#\#) {
+  padding-inline: 0;
+}
+
+.xf314gf:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-2);
+}
+
+.xrrkdod:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-3);
+}
+
+.x1pzlopt:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-4);
+}
+
+.xmqliwb:not(#\#):not(#\#) {
+  text-decoration: line-through;
+}
+
+.x1hl2dhg:not(#\#):not(#\#) {
+  text-decoration: none;
+}
+
+.x1aq93mo:not(#\#):not(#\#) {
+  transition: border-color .15s;
+}
+
+.xq2gx43:not(#\#):not(#\#) {
+  transition: none;
+}
+
+.x1ey1afo:not(#\#):not(#\#) {
+  transition: opacity var(--duration-fast);
+}
+
+.x1dg3z2k.x1dg3z2k:where(.x-default-marker:focus-within *):not(#\#):not(#\#), .x17nn4n9:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-accent);
+}
+
+.x1p73he7:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-error);
+}
+
+.x1bb4jes:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-accent);
+}
+
+.xvr22io:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-error);
+}
+
+.xgqqtmo:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-success);
+}
+
+.x1i2lkmv:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-warning);
+}
+
+.x1dordxg:focus-within:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xzeu18z:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-accent);
+}
+
+.xescob6:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-error);
+}
+
+.x1erxr0s:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-success);
+}
+
+.xhmquqt:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-warning);
+}
+
+@media (hover: hover) {
+  .xvrpfll.xvrpfll.xvrpfll:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: color-mix(in srgb,var(--color-accent),var(--color-tint-hover) 15%);
+  }
+
+  .xvyyb7d.xvyyb7d.xvyyb7d:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: color-mix(in srgb,var(--color-border-emphasized),var(--color-tint-hover) 20%);
+  }
+
+  .xrzr44y.xrzr44y.xrzr44y:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: var(--color-border);
+  }
+
+  .x1ww4t2b.x1ww4t2b:hover:not(#\#):not(#\#) {
+    border-color: var(--color-border-emphasized);
+  }
+}
+
+.x1ua5tub:not(#\#):not(#\#):not(#\#) {
+  -webkit-box-orient: vertical;
+}
+
+.x6s0dn4:not(#\#):not(#\#):not(#\#) {
+  align-items: center;
+}
+
+.xuk3077:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-end;
+}
+
+.x1cy8zhl:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-start;
+}
+
+.x1qjc9v5:not(#\#):not(#\#):not(#\#) {
+  align-items: stretch;
+}
+
+.xamitd3:not(#\#):not(#\#):not(#\#) {
+  align-self: center;
+}
+
+.xpvyfi4:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-end;
+}
+
+.xqcrz7y:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-start;
+}
+
+.xkh2ocl:not(#\#):not(#\#):not(#\#) {
+  align-self: stretch;
+}
+
+.x9uej1z:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-fast-max);
+}
+
+.xqgcaz:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-medium-max);
+}
+
+.xskzprw:not(#\#):not(#\#):not(#\#) {
+  animation-fill-mode: backwards;
+}
+
+.xa4qsjk:not(#\#):not(#\#):not(#\#) {
+  animation-iteration-count: infinite;
+}
+
+.xqcmdr3:not(#\#):not(#\#):not(#\#) {
+  animation-name: x18re5ia-B;
+}
+
+.x3psbcj:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1ahk7ht-B;
+}
+
+.x1dvww92:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1b6yrix-B;
+}
+
+.x97zbip:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1k48ry3-B;
+}
+
+.x1srr2gu:not(#\#):not(#\#):not(#\#) {
+  animation-name: xiylxmw-B;
+}
+
+.x1ka1v4i:not(#\#):not(#\#):not(#\#) {
+  animation-name: xqng64z-B;
+}
+
+.xck01x9:not(#\#):not(#\#):not(#\#) {
+  animation-name: xu7jd1z-B;
+}
+
+.xl1vlw0:not(#\#):not(#\#):not(#\#) {
+  animation-name: xv1hr86-B;
+}
+
+.x1i331go:not(#\#):not(#\#):not(#\#) {
+  animation-name: xwmkjkf-B;
+}
+
+.x1esw782:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: linear;
+}
+
+.x128ha8g:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: var(--ease-standard);
+}
+
+.xioom0i:not(#\#):not(#\#):not(#\#) {
+  aspect-ratio: var(--button-icon-only-aspect);
+}
+
+.xlp1x4z:not(#\#):not(#\#):not(#\#) {
+  backface-visibility: hidden;
+}
+
+.xjbqb8w:not(#\#):not(#\#):not(#\#) {
+  background-color: #0000;
+}
+
+.x9dqhi0:not(#\#):not(#\#):not(#\#) {
+  background-color: unset;
+}
+
+.x1ewilqj:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-accent);
+}
+
+.x1o0wnni:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-blue);
+}
+
+.x1rgj867:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-cyan);
+}
+
+.x1sqjeoo:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-green);
+}
+
+.xwmxj5m:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.x1e9xt6e:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-orange);
+}
+
+.xnpoty2:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-pink);
+}
+
+.x1prclbq:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-popover);
+}
+
+.x16i6n6f:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-purple);
+}
+
+.x1cibrc5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-red);
+}
+
+.x10xzikg:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-surface);
+}
+
+.x1jtji5o:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-teal);
+}
+
+.x1bo7t0x:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-yellow);
+}
+
+.x7njt3n:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border-emphasized);
+}
+
+.x1m4xfpy:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border);
+}
+
+.x1pritpl:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error-muted);
+}
+
+.x1pjz0fi:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error);
+}
+
+.x17x4s8c:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-neutral);
+}
+
+.x1azo05:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-on-accent);
+}
+
+.x1lmrjuc:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-overlay-hover);
+}
+
+.xu13z74:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-success-muted);
+}
+
+.xdsz4j9:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-success);
+}
+
+.x19aspcf:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-text-primary);
+}
+
+.x24i8r5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-warning-muted);
+}
+
+.x1q8g9m5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-warning);
+}
+
+.x18o3ruo:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1mwwwfo:not(#\#):not(#\#):not(#\#) {
+  border-collapse: collapse;
+}
+
+.x1o3jo1z:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: #0000;
+}
+
+.x18b5jzi:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-style: solid;
+}
+
+.x1lun4ml:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-width: 1px;
+}
+
+.x1gukg7c:not(#\#):not(#\#):not(#\#) {
+  border-spacing: 0;
+}
+
+.x1gnnqk1:not(#\#):not(#\#):not(#\#) {
+  box-shadow: none;
+}
+
+.x1i5ehqx:not(#\#):not(#\#):not(#\#) {
+  box-shadow: var(--shadow-low);
+}
+
+.x9f619:not(#\#):not(#\#):not(#\#) {
+  box-sizing: border-box;
+}
+
+.x1hyvwdk:not(#\#):not(#\#):not(#\#) {
+  clip-path: inset(50%);
+}
+
+.xzpqnlu:not(#\#):not(#\#):not(#\#) {
+  clip: rect(0,0,0,0);
+}
+
+.xntwwlm:not(#\#):not(#\#):not(#\#) {
+  color-scheme: dark;
+}
+
+.x108lcm5:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light dark;
+}
+
+.x19aimcq:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light;
+}
+
+.x1heor9g:not(#\#):not(#\#):not(#\#) {
+  color: inherit;
+}
+
+.x19co3pv:not(#\#):not(#\#):not(#\#) {
+  color: #0000;
+}
+
+.xqwr325:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-accent);
+}
+
+.xrkvqaz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-background-surface);
+}
+
+.xjt36v0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-error);
+}
+
+.x1fns2mt:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-blue);
+}
+
+.x157w0xa:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-cyan);
+}
+
+.xqa6c3m:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-disabled);
+}
+
+.x1eyinzz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-gray);
+}
+
+.xmxeech:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-green);
+}
+
+.xxu74a4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-orange);
+}
+
+.x1kxxfg5:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-pink);
+}
+
+.xtbr613:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-primary);
+}
+
+.xzdw94u:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-purple);
+}
+
+.xeffzf7:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-red);
+}
+
+.xv9yike:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-secondary);
+}
+
+.x1f3zxcb:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-teal);
+}
+
+.x1g6zdft:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-yellow);
+}
+
+.x17wrial:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-accent);
+}
+
+.x1m024r3:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-error);
+}
+
+.xri61p4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-success);
+}
+
+.xrebv38:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-warning);
+}
+
+.xtjic6:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-success);
+}
+
+.x1vvqiwl:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-blue);
+}
+
+.x1txnczv:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-cyan);
+}
+
+.xnbbluu:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-disabled);
+}
+
+.xltfdvo:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-green);
+}
+
+.xm47u9q:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-orange);
+}
+
+.xiuofww:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-pink);
+}
+
+.x1tgivj0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-primary);
+}
+
+.x1m9wyeb:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-purple);
+}
+
+.x1joocv1:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-red);
+}
+
+.xv1l7n4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-secondary);
+}
+
+.x9x0lbs:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-teal);
+}
+
+.xdhq94a:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-yellow);
+}
+
+.xs3pv69:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-warning);
+}
+
+.x1kihgfc:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0-5);
+}
+
+.x1o57wo1:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0);
+}
+
+.x1thn6ci:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1-5);
+}
+
+.x1lfs0n9:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1);
+}
+
+.x1p37tyl:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-10);
+}
+
+.xak3so:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-2);
+}
+
+.xewh9hi:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-3);
+}
+
+.xty4p9g:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-4);
+}
+
+.x1eqhezk:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-5);
+}
+
+.x3qlgwd:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-6);
+}
+
+.xicv188:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-8);
+}
+
+.x7eptgl:not(#\#):not(#\#):not(#\#) {
+  cursor: ew-resize;
+}
+
+.x1h6gzvc:not(#\#):not(#\#):not(#\#) {
+  cursor: not-allowed;
+}
+
+.x1ypdohk:not(#\#):not(#\#):not(#\#) {
+  cursor: pointer;
+}
+
+.x104kibb:not(#\#):not(#\#):not(#\#) {
+  display: -webkit-box;
+}
+
+.x1lliihq:not(#\#):not(#\#):not(#\#) {
+  display: block;
+}
+
+.xjp7ctv:not(#\#):not(#\#):not(#\#) {
+  display: contents;
+}
+
+.x78zum5:not(#\#):not(#\#):not(#\#) {
+  display: flex;
+}
+
+.x1rg5ohu:not(#\#):not(#\#):not(#\#) {
+  display: inline-block;
+}
+
+.x3nfvp2:not(#\#):not(#\#):not(#\#) {
+  display: inline-flex;
+}
+
+.xt0psk2:not(#\#):not(#\#):not(#\#) {
+  display: inline;
+}
+
+.x1s85apg:not(#\#):not(#\#):not(#\#) {
+  display: none;
+}
+
+.xdt5ytf:not(#\#):not(#\#):not(#\#) {
+  flex-direction: column;
+}
+
+.x1q0g3np:not(#\#):not(#\#):not(#\#) {
+  flex-direction: row;
+}
+
+.x1c4vz4f:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 0;
+}
+
+.x1iyjqo2:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 1;
+}
+
+.x2lah0s:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 0;
+}
+
+.xs83m0k:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 1;
+}
+
+.xozqiw3:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: nowrap;
+}
+
+.x8hhl5t:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap-reverse;
+}
+
+.x1a02dak:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap;
+}
+
+.xjb2p0i:not(#\#):not(#\#):not(#\#) {
+  font-family: inherit;
+}
+
+.x9ynric:not(#\#):not(#\#):not(#\#) {
+  font-family: var(--font-family-body);
+}
+
+.x1k6wstc:not(#\#):not(#\#):not(#\#) {
+  font-size: 10px;
+}
+
+.xfifm61:not(#\#):not(#\#):not(#\#) {
+  font-size: 12px;
+}
+
+.x1j61zf2:not(#\#):not(#\#):not(#\#) {
+  font-size: 16px;
+}
+
+.xwsyq91:not(#\#):not(#\#):not(#\#) {
+  font-size: 20px;
+}
+
+.x1pvqxga:not(#\#):not(#\#):not(#\#) {
+  font-size: 24px;
+}
+
+.xjm74w1:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-body-size);
+}
+
+.xcr08ib:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-label-size);
+}
+
+.x141an7d:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-supporting-size);
+}
+
+.xss6m8b:not(#\#):not(#\#):not(#\#) {
+  font-variant-numeric: tabular-nums;
+}
+
+.x1lvx875:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-bold);
+}
+
+.x1e4wzip:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-medium);
+}
+
+.x1sodnla:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-normal);
+}
+
+.x2mo6ok:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-semibold);
+}
+
+.xxovm9e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-body-weight);
+}
+
+.xx3eeay:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-code-weight);
+}
+
+.x1txul5o:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-1-weight);
+}
+
+.x1y36c3f:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-2-weight);
+}
+
+.x1on40hk:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-3-weight);
+}
+
+.xmhvcl5:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-label-weight);
+}
+
+.x149oux8:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-large-weight);
+}
+
+.xv8on6e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-supporting-weight);
+}
+
+.xtijo5x:not(#\#):not(#\#):not(#\#) {
+  inset-inline-end: 0;
+}
+
+.xl56j7k:not(#\#):not(#\#):not(#\#) {
+  justify-content: center;
+}
+
+.x13a6bvl:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-end;
+}
+
+.x1nhvcw1:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-start;
+}
+
+.x1l1ennw:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-around;
+}
+
+.x1qughib:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-between;
+}
+
+.xaw8158:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-evenly;
+}
+
+.xo5v014:not(#\#):not(#\#):not(#\#) {
+  line-height: 1;
+}
+
+.xw6l6zx:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-body-leading);
+}
+
+.x1kq96og:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-label-leading);
+}
+
+.x1ltkj2j:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-supporting-leading);
+}
+
+.x14z9mp:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: 0;
+}
+
+.xofqkxr:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(var(--edge-end, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.xnur1sd:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: var(--spacing-1);
+}
+
+.x1lziwak:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: 0;
+}
+
+.xg82z56:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(var(--edge-start, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.x11g1kdw:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: var(--spacing-1);
+}
+
+.xbyyjgo:not(#\#):not(#\#):not(#\#) {
+  opacity: .5;
+}
+
+.xg01cxk:not(#\#):not(#\#):not(#\#) {
+  opacity: 0;
+}
+
+.x1hc1fzr:not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.x1wfwxd8:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 0;
+}
+
+.x1hl8ikr:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x1mzt3pk:not(#\#):not(#\#):not(#\#) {
+  overflow-wrap: break-word;
+}
+
+.xyri2b:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: 0;
+}
+
+.x1djylfy:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-2);
+}
+
+.x1c1uobl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: 0;
+}
+
+.x12gdq22:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-2);
+}
+
+.x47corl:not(#\#):not(#\#):not(#\#) {
+  pointer-events: none;
+}
+
+.x10l6tqk:not(#\#):not(#\#):not(#\#) {
+  position: absolute;
+}
+
+.xixxii4:not(#\#):not(#\#):not(#\#) {
+  position: fixed;
+}
+
+.x1n2onr6:not(#\#):not(#\#):not(#\#) {
+  position: relative;
+}
+
+.x1tw44j4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0-5);
+}
+
+.x6yxi7o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0);
+}
+
+.xhq53yo:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1-5);
+}
+
+.x1ngg2t4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1);
+}
+
+.x1xpicb7:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-10);
+}
+
+.x1x7z4sm:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-2);
+}
+
+.x4olc9o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-3);
+}
+
+.xtx9w7w:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-4);
+}
+
+.x1iu6piu:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-5);
+}
+
+.xczp1bk:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-6);
+}
+
+.xgx0vcf:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-8);
+}
+
+.x140o2bo:not(#\#):not(#\#):not(#\#) {
+  table-layout: fixed;
+}
+
+.x16tdsg8:not(#\#):not(#\#):not(#\#) {
+  text-align: inherit;
+}
+
+.xdpxx8g:not(#\#):not(#\#):not(#\#) {
+  text-align: left;
+}
+
+.x1yc453h:not(#\#):not(#\#):not(#\#) {
+  text-align: start;
+}
+
+.x1b2iylo:not(#\#):not(#\#):not(#\#) {
+  text-box-edge: cap alphabetic;
+}
+
+.xwgcxoh:not(#\#):not(#\#):not(#\#) {
+  text-box-trim: trim-both;
+}
+
+.xycaml9:not(#\#):not(#\#):not(#\#) {
+  -webkit-text-decoration-color: var(--color-border-emphasized);
+  text-decoration-color: var(--color-border-emphasized);
+}
+
+.xujl8zx:not(#\#):not(#\#):not(#\#) {
+  text-decoration-line: underline;
+}
+
+.xev0dqp:not(#\#):not(#\#):not(#\#) {
+  text-decoration-style: dashed;
+}
+
+.xlyipyv:not(#\#):not(#\#):not(#\#) {
+  text-overflow: ellipsis;
+}
+
+.xrys4gj:not(#\#):not(#\#):not(#\#) {
+  text-underline-offset: 2px;
+}
+
+.x1w2vvpw:not(#\#):not(#\#):not(#\#) {
+  text-wrap: balance;
+}
+
+.xebhuq6:not(#\#):not(#\#):not(#\#) {
+  text-wrap: nowrap;
+}
+
+.x1fzhlzt:not(#\#):not(#\#):not(#\#) {
+  text-wrap: pretty;
+}
+
+.xk4td0m:not(#\#):not(#\#):not(#\#) {
+  text-wrap: wrap;
+}
+
+.x5ve5x3:not(#\#):not(#\#):not(#\#) {
+  touch-action: none;
+}
+
+.x1g0ag68:not(#\#):not(#\#):not(#\#) {
+  transform-origin: center;
+}
+
+.x1c071of:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.x19jd1h0:not(#\#):not(#\#):not(#\#) {
+  transform: rotate(180deg);
+}
+
+.x3oybdh:not(#\#):not(#\#):not(#\#) {
+  transform: scale(1);
+}
+
+.x31h1t8:not(#\#):not(#\#):not(#\#) {
+  transform: translate(-50%, 100%);
+}
+
+.xuedmi6:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-fast);
+}
+
+.xts7igz:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color, border-color;
+}
+
+.x15406qy:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color;
+}
+
+.xqc8rvf:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-image, transform;
+}
+
+.xpo9ue8:not(#\#):not(#\#):not(#\#) {
+  transition-property: border-color, outline, box-shadow;
+}
+
+.x19991ni:not(#\#):not(#\#):not(#\#) {
+  transition-property: opacity;
+}
+
+.x11xpdln:not(#\#):not(#\#):not(#\#) {
+  transition-property: transform;
+}
+
+.xlr8y92:not(#\#):not(#\#):not(#\#) {
+  transition-timing-function: var(--ease-standard);
+}
+
+.x87ps6o:not(#\#):not(#\#):not(#\#) {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.xxymvpz:not(#\#):not(#\#):not(#\#) {
+  vertical-align: middle;
+}
+
+.xuxw1ft:not(#\#):not(#\#):not(#\#) {
+  white-space: nowrap;
+}
+
+.x1yn0g08:not(#\#):not(#\#):not(#\#) {
+  word-break: break-all;
+}
+
+.x13faqbe:not(#\#):not(#\#):not(#\#) {
+  word-break: break-word;
+}
+
+.x1lldw8n:not(#\#):not(#\#):not(#\#) {
+  word-break: normal;
+}
+
+.x1vjfegm:not(#\#):not(#\#):not(#\#) {
+  z-index: 1;
+}
+
+.x8w4yw4.x8w4yw4:where(.x-default-marker:focus-within *):not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.xcn42n2.xcn42n2:where(.x-default-marker:focus-within *):not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x5b7970.x5b7970:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.x25ezvp:focus-visible:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-accent);
+}
+
+.x10wafsz:focus-within:not(#\#):not(#\#):not(#\#) {
+  clip-path: none;
+}
+
+.x7s97pk:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x13aywxo:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: var(--button-focus-offset);
+}
+
+.xbt4iw:focus-within:not(#\#):not(#\#):not(#\#) {
+  pointer-events: auto;
+}
+
+.x1dnou9g:nth-child(2n):not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.xyg1mtj:hover:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-accent);
+}
+
+.xq8i9tn:active:not(#\#):not(#\#):not(#\#) {
+  background-image: linear-gradient(var(--color-overlay-pressed),var(--color-overlay-pressed));
+}
+
+.xuqm82a:active:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1pdlv7q:active:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.xk4oym4:active:not(#\#):not(#\#):not(#\#) {
+  transform: scale(.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .x12w9bfk.x12w9bfk:not(#\#):not(#\#):not(#\#) {
+    transition-duration: 0s;
+  }
+}
+
+@media (hover: hover) {
+  .x3h3317.x3h3317.x3h3317:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-accent),var(--color-tint-hover) 15%);
+  }
+
+  .xxuakwu.xxuakwu.xxuakwu:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-background-surface),var(--color-tint-hover) 5%);
+  }
+
+  .xaemn39.xaemn39.xaemn39:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: unset;
+  }
+
+  .xe9uy6x.xe9uy6x:hover:not(#\#):not(#\#):not(#\#) {
+    background-color: var(--color-overlay-hover);
+  }
+
+  .x1ilzqfv.x1ilzqfv:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: linear-gradient(var(--color-overlay-hover),var(--color-overlay-hover));
+  }
+
+  .x8o3jvd.x8o3jvd:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: none;
+  }
+
+  .x1ymn3ht.x1ymn3ht:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-error);
+  }
+
+  .x1j9d0uj.x1j9d0uj:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-hover);
+  }
+
+  .x1th0bn1.x1th0bn1:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-success);
+  }
+
+  .xo1e01f.xo1e01f:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-warning);
+  }
+}
+
+.xw8gpjh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-color: var(--color-border);
+}
+
+.x14lggfu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-left-radius: var(--radius-element);
+}
+
+.xtufxuj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-right-radius: var(--radius-element);
+}
+
+.x1q0q8m5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-style: solid;
+}
+
+.x92x3c3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-width: var(--border-width);
+}
+
+.xtgwc6q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-color: var(--color-border);
+}
+
+.x32b0ac:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-style: solid;
+}
+
+.x1pcaw5z:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-width: var(--border-width);
+}
+
+.x1ey2m1c:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: 0;
+}
+
+.x5yr21d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 100%;
+}
+
+.x1kpxq89:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 12px;
+}
+
+.x1v9usgg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 14px;
+}
+
+.xlup9mm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 16px;
+}
+
+.xmix8c7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 18px;
+}
+
+.xjm9jq1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 1px;
+}
+
+.x1qx5ct2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 20px;
+}
+
+.x17rw0jw:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 22px;
+}
+
+.xxk0z11:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 24px;
+}
+
+.x36qwtl:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 2px;
+}
+
+.xols6we:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 6px;
+}
+
+.xdk7pt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 8px;
+}
+
+.xsyqizj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--border-width);
+}
+
+.xssyfek:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-lg);
+}
+
+.x1ueg155:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-md);
+}
+
+.x6k0iem:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-sm);
+}
+
+.x1grt7ep:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-5);
+}
+
+.xu96u03:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 0;
+}
+
+.x1nrll8i:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 50%;
+}
+
+.xat24cr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: 0;
+}
+
+.x14cgwvg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-1);
+}
+
+.x1p37lm5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-2);
+}
+
+.xdj266r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: 0;
+}
+
+.x1c40v9y:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: calc(-1 * var(--spacing-1-5));
+}
+
+.xcsaf9d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-1);
+}
+
+.xtbrsbv:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-2);
+}
+
+.x1gkbulp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--x-marginTop);
+}
+
+.xuyqlj2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: 300px;
+}
+
+.x1m189uc:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 0;
+}
+
+.xw5ewwj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 300px;
+}
+
+.x2lwn1j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 0;
+}
+
+.xeuugli:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 0;
+}
+
+.xrzjruh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: anchor-size(width);
+}
+
+.x17ydmr0:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--size-element-md);
+}
+
+.x1nkkqge:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--size-element-sm);
+}
+
+.xkj4a21:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--x-minWidth);
+}
+
+.x1odjw0f:not(#\#):not(#\#):not(#\#):not(#\#) {
+  overflow-y: auto;
+}
+
+.x18d9i69:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.xy143xn:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1);
+}
+
+.x1wesfrj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-2);
+}
+
+.xexx8yu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.x1ak3mig:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: calc(var(--spacing-1-5) + var(--spacing-2));
+}
+
+.xfsso4q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.x3m8u43:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: 0;
+}
+
+.x13vifvy:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 0;
+}
+
+.xh8yej3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 100%;
+}
+
+.x1fsd2vl:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 10px;
+}
+
+.xsmyaan:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 12px;
+}
+
+.x6jxa94:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 14px;
+}
+
+.x1kky2od:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 16px;
+}
+
+.x1xp8n7a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 18px;
+}
+
+.x1i1rx1s:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 1px;
+}
+
+.xw4jnvo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 20px;
+}
+
+.x17z2i9w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 22px;
+}
+
+.xvy4d1p:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 24px;
+}
+
+.x1v4s8kt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 6px;
+}
+
+.x1dmp6jm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 80px;
+}
+
+.x1xc55vz:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 8px;
+}
+
+.xjk4fl7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--border-width);
+}
+
+.x132qfvm:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: auto;
+}
+
+.x1kw28su:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.x10okhzq:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: auto;
+}
+
+.x1lpyac:last-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-width: 0;
+}
+
+@media (pointer: coarse) {
+  .x1kkwbli.x1kkwbli:not(#\#):not(#\#):not(#\#):not(#\#) {
+    width: 20px;
+  }
+}
+</style>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/internal/vibe-tests/results/441ddbe0/previews/manifest.json
+++ b/internal/vibe-tests/results/441ddbe0/previews/manifest.json
@@ -1,0 +1,20 @@
+{
+  "dd-1": {
+    "xds": "previews/dd-1/xds.html"
+  },
+  "dd-3": {
+    "xds": "previews/dd-3/xds.html"
+  },
+  "dd-5": {
+    "xds": "previews/dd-5/xds.html"
+  },
+  "ps-1": {
+    "xds": "previews/ps-1/xds.html"
+  },
+  "ps-3": {
+    "xds": "previews/ps-3/xds.html"
+  },
+  "ps-4": {
+    "xds": "previews/ps-4/xds.html"
+  }
+}

--- a/internal/vibe-tests/results/441ddbe0/previews/ps-1/xds.html
+++ b/internal/vibe-tests/results/441ddbe0/previews/ps-1/xds.html
@@ -1,0 +1,4636 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ps-1 — xds</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; }
+    #root { min-height: 100%; }
+  </style>
+  <script type="module" crossorigin>(function(){const t=document.createElement("link").relList;if(t&&t.supports&&t.supports("modulepreload"))return;for(const a of document.querySelectorAll('link[rel="modulepreload"]'))n(a);new MutationObserver(a=>{for(const u of a)if(u.type==="childList")for(const i of u.addedNodes)i.tagName==="LINK"&&i.rel==="modulepreload"&&n(i)}).observe(document,{childList:!0,subtree:!0});function l(a){const u={};return a.integrity&&(u.integrity=a.integrity),a.referrerPolicy&&(u.referrerPolicy=a.referrerPolicy),a.crossOrigin==="use-credentials"?u.credentials="include":a.crossOrigin==="anonymous"?u.credentials="omit":u.credentials="same-origin",u}function n(a){if(a.ep)return;a.ep=!0;const u=l(a);fetch(a.href,u)}})();function A0(e){return e&&e.__esModule&&Object.prototype.hasOwnProperty.call(e,"default")?e.default:e}var Lr={exports:{}},ui={};/**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var N0=Symbol.for("react.transitional.element"),O0=Symbol.for("react.fragment");function Gr(e,t,l){var n=null;if(l!==void 0&&(n=""+l),t.key!==void 0&&(n=""+t.key),"key"in t){l={};for(var a in t)a!=="key"&&(l[a]=t[a])}else l=t;return t=l.ref,{$$typeof:N0,type:e,key:n,ref:t!==void 0?t:null,props:l}}ui.Fragment=O0;ui.jsx=Gr;ui.jsxs=Gr;Lr.exports=ui;var f=Lr.exports,Zr={exports:{}},ii={},Yr={exports:{}},Vr={};/**
+ * @license React
+ * scheduler.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */(function(e){function t(A,N){var O=A.length;A.push(N);e:for(;0<O;){var Y=O-1>>>1,I=A[Y];if(0<a(I,N))A[Y]=N,A[O]=I,O=Y;else break e}}function l(A){return A.length===0?null:A[0]}function n(A){if(A.length===0)return null;var N=A[0],O=A.pop();if(O!==N){A[0]=O;e:for(var Y=0,I=A.length,$e=I>>>1;Y<$e;){var De=2*(Y+1)-1,qe=A[De],J=De+1,me=A[J];if(0>a(qe,O))J<I&&0>a(me,qe)?(A[Y]=me,A[J]=O,Y=J):(A[Y]=qe,A[De]=O,Y=De);else if(J<I&&0>a(me,O))A[Y]=me,A[J]=O,Y=J;else break e}}return N}function a(A,N){var O=A.sortIndex-N.sortIndex;return O!==0?O:A.id-N.id}if(e.unstable_now=void 0,typeof performance=="object"&&typeof performance.now=="function"){var u=performance;e.unstable_now=function(){return u.now()}}else{var i=Date,c=i.now();e.unstable_now=function(){return i.now()-c}}var s=[],o=[],x=1,h=null,d=3,m=!1,p=!1,k=!1,S=!1,y=typeof setTimeout=="function"?setTimeout:null,r=typeof clearTimeout=="function"?clearTimeout:null,v=typeof setImmediate<"u"?setImmediate:null;function b(A){for(var N=l(o);N!==null;){if(N.callback===null)n(o);else if(N.startTime<=A)n(o),N.sortIndex=N.expirationTime,t(s,N);else break;N=l(o)}}function z(A){if(k=!1,b(A),!p)if(l(s)!==null)p=!0,w||(w=!0,R());else{var N=l(o);N!==null&&fe(z,N.startTime-A)}}var w=!1,$=-1,T=5,E=-1;function M(){return S?!0:!(e.unstable_now()-E<T)}function D(){if(S=!1,w){var A=e.unstable_now();E=A;var N=!0;try{e:{p=!1,k&&(k=!1,r($),$=-1),m=!0;var O=d;try{t:{for(b(A),h=l(s);h!==null&&!(h.expirationTime>A&&M());){var Y=h.callback;if(typeof Y=="function"){h.callback=null,d=h.priorityLevel;var I=Y(h.expirationTime<=A);if(A=e.unstable_now(),typeof I=="function"){h.callback=I,b(A),N=!0;break t}h===l(s)&&n(s),b(A)}else n(s);h=l(s)}if(h!==null)N=!0;else{var $e=l(o);$e!==null&&fe(z,$e.startTime-A),N=!1}}break e}finally{h=null,d=O,m=!1}N=void 0}}finally{N?R():w=!1}}}var R;if(typeof v=="function")R=function(){v(D)};else if(typeof MessageChannel<"u"){var Z=new MessageChannel,ce=Z.port2;Z.port1.onmessage=D,R=function(){ce.postMessage(null)}}else R=function(){y(D,0)};function fe(A,N){$=y(function(){A(e.unstable_now())},N)}e.unstable_IdlePriority=5,e.unstable_ImmediatePriority=1,e.unstable_LowPriority=4,e.unstable_NormalPriority=3,e.unstable_Profiling=null,e.unstable_UserBlockingPriority=2,e.unstable_cancelCallback=function(A){A.callback=null},e.unstable_forceFrameRate=function(A){0>A||125<A?console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"):T=0<A?Math.floor(1e3/A):5},e.unstable_getCurrentPriorityLevel=function(){return d},e.unstable_next=function(A){switch(d){case 1:case 2:case 3:var N=3;break;default:N=d}var O=d;d=N;try{return A()}finally{d=O}},e.unstable_requestPaint=function(){S=!0},e.unstable_runWithPriority=function(A,N){switch(A){case 1:case 2:case 3:case 4:case 5:break;default:A=3}var O=d;d=A;try{return N()}finally{d=O}},e.unstable_scheduleCallback=function(A,N,O){var Y=e.unstable_now();switch(typeof O=="object"&&O!==null?(O=O.delay,O=typeof O=="number"&&0<O?Y+O:Y):O=Y,A){case 1:var I=-1;break;case 2:I=250;break;case 5:I=1073741823;break;case 4:I=1e4;break;default:I=5e3}return I=O+I,A={id:x++,callback:N,priorityLevel:A,startTime:O,expirationTime:I,sortIndex:-1},O>Y?(A.sortIndex=O,t(o,A),l(s)===null&&A===l(o)&&(k?(r($),$=-1):k=!0,fe(z,O-Y))):(A.sortIndex=I,t(s,A),p||m||(p=!0,w||(w=!0,R()))),A},e.unstable_shouldYield=M,e.unstable_wrapCallback=function(A){var N=d;return function(){var O=d;d=N;try{return A.apply(this,arguments)}finally{d=O}}}})(Vr);Yr.exports=Vr;var D0=Yr.exports,Qr={exports:{}},_={};/**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var Ns=Symbol.for("react.transitional.element"),q0=Symbol.for("react.portal"),C0=Symbol.for("react.fragment"),_0=Symbol.for("react.strict_mode"),R0=Symbol.for("react.profiler"),H0=Symbol.for("react.consumer"),U0=Symbol.for("react.context"),X0=Symbol.for("react.forward_ref"),B0=Symbol.for("react.suspense"),L0=Symbol.for("react.memo"),Kr=Symbol.for("react.lazy"),G0=Symbol.for("react.activity"),Qf=Symbol.iterator;function Z0(e){return e===null||typeof e!="object"?null:(e=Qf&&e[Qf]||e["@@iterator"],typeof e=="function"?e:null)}var Jr={isMounted:function(){return!1},enqueueForceUpdate:function(){},enqueueReplaceState:function(){},enqueueSetState:function(){}},Wr=Object.assign,Fr={};function Nn(e,t,l){this.props=e,this.context=t,this.refs=Fr,this.updater=l||Jr}Nn.prototype.isReactComponent={};Nn.prototype.setState=function(e,t){if(typeof e!="object"&&typeof e!="function"&&e!=null)throw Error("takes an object of state variables to update or a function which returns an object of state variables.");this.updater.enqueueSetState(this,e,t,"setState")};Nn.prototype.forceUpdate=function(e){this.updater.enqueueForceUpdate(this,e,"forceUpdate")};function Ir(){}Ir.prototype=Nn.prototype;function Os(e,t,l){this.props=e,this.context=t,this.refs=Fr,this.updater=l||Jr}var Ds=Os.prototype=new Ir;Ds.constructor=Os;Wr(Ds,Nn.prototype);Ds.isPureReactComponent=!0;var Kf=Array.isArray;function Tc(){}var ue={H:null,A:null,T:null,S:null},Pr=Object.prototype.hasOwnProperty;function qs(e,t,l){var n=l.ref;return{$$typeof:Ns,type:e,key:t,ref:n!==void 0?n:null,props:l}}function Y0(e,t){return qs(e.type,t,e.props)}function Cs(e){return typeof e=="object"&&e!==null&&e.$$typeof===Ns}function V0(e){var t={"=":"=0",":":"=2"};return"$"+e.replace(/[=:]/g,function(l){return t[l]})}var Jf=/\/+/g;function Ni(e,t){return typeof e=="object"&&e!==null&&e.key!=null?V0(""+e.key):t.toString(36)}function Q0(e){switch(e.status){case"fulfilled":return e.value;case"rejected":throw e.reason;default:switch(typeof e.status=="string"?e.then(Tc,Tc):(e.status="pending",e.then(function(t){e.status==="pending"&&(e.status="fulfilled",e.value=t)},function(t){e.status==="pending"&&(e.status="rejected",e.reason=t)})),e.status){case"fulfilled":return e.value;case"rejected":throw e.reason}}throw e}function Jl(e,t,l,n,a){var u=typeof e;(u==="undefined"||u==="boolean")&&(e=null);var i=!1;if(e===null)i=!0;else switch(u){case"bigint":case"string":case"number":i=!0;break;case"object":switch(e.$$typeof){case Ns:case q0:i=!0;break;case Kr:return i=e._init,Jl(i(e._payload),t,l,n,a)}}if(i)return a=a(e),i=n===""?"."+Ni(e,0):n,Kf(a)?(l="",i!=null&&(l=i.replace(Jf,"$&/")+"/"),Jl(a,t,l,"",function(o){return o})):a!=null&&(Cs(a)&&(a=Y0(a,l+(a.key==null||e&&e.key===a.key?"":(""+a.key).replace(Jf,"$&/")+"/")+i)),t.push(a)),1;i=0;var c=n===""?".":n+":";if(Kf(e))for(var s=0;s<e.length;s++)n=e[s],u=c+Ni(n,s),i+=Jl(n,t,l,u,a);else if(s=Z0(e),typeof s=="function")for(e=s.call(e),s=0;!(n=e.next()).done;)n=n.value,u=c+Ni(n,s++),i+=Jl(n,t,l,u,a);else if(u==="object"){if(typeof e.then=="function")return Jl(Q0(e),t,l,n,a);throw t=String(e),Error("Objects are not valid as a React child (found: "+(t==="[object Object]"?"object with keys {"+Object.keys(e).join(", ")+"}":t)+"). If you meant to render a collection of children, use an array instead.")}return i}function Za(e,t,l){if(e==null)return e;var n=[],a=0;return Jl(e,n,"","",function(u){return t.call(l,u,a++)}),n}function K0(e){if(e._status===-1){var t=e._result;t=t(),t.then(function(l){(e._status===0||e._status===-1)&&(e._status=1,e._result=l)},function(l){(e._status===0||e._status===-1)&&(e._status=2,e._result=l)}),e._status===-1&&(e._status=0,e._result=t)}if(e._status===1)return e._result.default;throw e._result}var Wf=typeof reportError=="function"?reportError:function(e){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var t=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof e=="object"&&e!==null&&typeof e.message=="string"?String(e.message):String(e),error:e});if(!window.dispatchEvent(t))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",e);return}console.error(e)},J0={map:Za,forEach:function(e,t,l){Za(e,function(){t.apply(this,arguments)},l)},count:function(e){var t=0;return Za(e,function(){t++}),t},toArray:function(e){return Za(e,function(t){return t})||[]},only:function(e){if(!Cs(e))throw Error("React.Children.only expected to receive a single React element child.");return e}};_.Activity=G0;_.Children=J0;_.Component=Nn;_.Fragment=C0;_.Profiler=R0;_.PureComponent=Os;_.StrictMode=_0;_.Suspense=B0;_.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=ue;_.__COMPILER_RUNTIME={__proto__:null,c:function(e){return ue.H.useMemoCache(e)}};_.cache=function(e){return function(){return e.apply(null,arguments)}};_.cacheSignal=function(){return null};_.cloneElement=function(e,t,l){if(e==null)throw Error("The argument must be a React element, but you passed "+e+".");var n=Wr({},e.props),a=e.key;if(t!=null)for(u in t.key!==void 0&&(a=""+t.key),t)!Pr.call(t,u)||u==="key"||u==="__self"||u==="__source"||u==="ref"&&t.ref===void 0||(n[u]=t[u]);var u=arguments.length-2;if(u===1)n.children=l;else if(1<u){for(var i=Array(u),c=0;c<u;c++)i[c]=arguments[c+2];n.children=i}return qs(e.type,a,n)};_.createContext=function(e){return e={$$typeof:U0,_currentValue:e,_currentValue2:e,_threadCount:0,Provider:null,Consumer:null},e.Provider=e,e.Consumer={$$typeof:H0,_context:e},e};_.createElement=function(e,t,l){var n,a={},u=null;if(t!=null)for(n in t.key!==void 0&&(u=""+t.key),t)Pr.call(t,n)&&n!=="key"&&n!=="__self"&&n!=="__source"&&(a[n]=t[n]);var i=arguments.length-2;if(i===1)a.children=l;else if(1<i){for(var c=Array(i),s=0;s<i;s++)c[s]=arguments[s+2];a.children=c}if(e&&e.defaultProps)for(n in i=e.defaultProps,i)a[n]===void 0&&(a[n]=i[n]);return qs(e,u,a)};_.createRef=function(){return{current:null}};_.forwardRef=function(e){return{$$typeof:X0,render:e}};_.isValidElement=Cs;_.lazy=function(e){return{$$typeof:Kr,_payload:{_status:-1,_result:e},_init:K0}};_.memo=function(e,t){return{$$typeof:L0,type:e,compare:t===void 0?null:t}};_.startTransition=function(e){var t=ue.T,l={};ue.T=l;try{var n=e(),a=ue.S;a!==null&&a(l,n),typeof n=="object"&&n!==null&&typeof n.then=="function"&&n.then(Tc,Wf)}catch(u){Wf(u)}finally{t!==null&&l.types!==null&&(t.types=l.types),ue.T=t}};_.unstable_useCacheRefresh=function(){return ue.H.useCacheRefresh()};_.use=function(e){return ue.H.use(e)};_.useActionState=function(e,t,l){return ue.H.useActionState(e,t,l)};_.useCallback=function(e,t){return ue.H.useCallback(e,t)};_.useContext=function(e){return ue.H.useContext(e)};_.useDebugValue=function(){};_.useDeferredValue=function(e,t){return ue.H.useDeferredValue(e,t)};_.useEffect=function(e,t){return ue.H.useEffect(e,t)};_.useEffectEvent=function(e){return ue.H.useEffectEvent(e)};_.useId=function(){return ue.H.useId()};_.useImperativeHandle=function(e,t,l){return ue.H.useImperativeHandle(e,t,l)};_.useInsertionEffect=function(e,t){return ue.H.useInsertionEffect(e,t)};_.useLayoutEffect=function(e,t){return ue.H.useLayoutEffect(e,t)};_.useMemo=function(e,t){return ue.H.useMemo(e,t)};_.useOptimistic=function(e,t){return ue.H.useOptimistic(e,t)};_.useReducer=function(e,t,l){return ue.H.useReducer(e,t,l)};_.useRef=function(e){return ue.H.useRef(e)};_.useState=function(e){return ue.H.useState(e)};_.useSyncExternalStore=function(e,t,l){return ue.H.useSyncExternalStore(e,t,l)};_.useTransition=function(){return ue.H.useTransition()};_.version="19.2.4";Qr.exports=_;var g=Qr.exports;const Ff=A0(g);var ed={exports:{}},Re={};/**
+ * @license React
+ * react-dom.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var W0=g;function td(e){var t="https://react.dev/errors/"+e;if(1<arguments.length){t+="?args[]="+encodeURIComponent(arguments[1]);for(var l=2;l<arguments.length;l++)t+="&args[]="+encodeURIComponent(arguments[l])}return"Minified React error #"+e+"; visit "+t+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function Yt(){}var _e={d:{f:Yt,r:function(){throw Error(td(522))},D:Yt,C:Yt,L:Yt,m:Yt,X:Yt,S:Yt,M:Yt},p:0,findDOMNode:null},F0=Symbol.for("react.portal");function I0(e,t,l){var n=3<arguments.length&&arguments[3]!==void 0?arguments[3]:null;return{$$typeof:F0,key:n==null?null:""+n,children:e,containerInfo:t,implementation:l}}var ta=W0.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;function ci(e,t){if(e==="font")return"";if(typeof t=="string")return t==="use-credentials"?t:""}Re.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=_e;Re.createPortal=function(e,t){var l=2<arguments.length&&arguments[2]!==void 0?arguments[2]:null;if(!t||t.nodeType!==1&&t.nodeType!==9&&t.nodeType!==11)throw Error(td(299));return I0(e,t,null,l)};Re.flushSync=function(e){var t=ta.T,l=_e.p;try{if(ta.T=null,_e.p=2,e)return e()}finally{ta.T=t,_e.p=l,_e.d.f()}};Re.preconnect=function(e,t){typeof e=="string"&&(t?(t=t.crossOrigin,t=typeof t=="string"?t==="use-credentials"?t:"":void 0):t=null,_e.d.C(e,t))};Re.prefetchDNS=function(e){typeof e=="string"&&_e.d.D(e)};Re.preinit=function(e,t){if(typeof e=="string"&&t&&typeof t.as=="string"){var l=t.as,n=ci(l,t.crossOrigin),a=typeof t.integrity=="string"?t.integrity:void 0,u=typeof t.fetchPriority=="string"?t.fetchPriority:void 0;l==="style"?_e.d.S(e,typeof t.precedence=="string"?t.precedence:void 0,{crossOrigin:n,integrity:a,fetchPriority:u}):l==="script"&&_e.d.X(e,{crossOrigin:n,integrity:a,fetchPriority:u,nonce:typeof t.nonce=="string"?t.nonce:void 0})}};Re.preinitModule=function(e,t){if(typeof e=="string")if(typeof t=="object"&&t!==null){if(t.as==null||t.as==="script"){var l=ci(t.as,t.crossOrigin);_e.d.M(e,{crossOrigin:l,integrity:typeof t.integrity=="string"?t.integrity:void 0,nonce:typeof t.nonce=="string"?t.nonce:void 0})}}else t==null&&_e.d.M(e)};Re.preload=function(e,t){if(typeof e=="string"&&typeof t=="object"&&t!==null&&typeof t.as=="string"){var l=t.as,n=ci(l,t.crossOrigin);_e.d.L(e,l,{crossOrigin:n,integrity:typeof t.integrity=="string"?t.integrity:void 0,nonce:typeof t.nonce=="string"?t.nonce:void 0,type:typeof t.type=="string"?t.type:void 0,fetchPriority:typeof t.fetchPriority=="string"?t.fetchPriority:void 0,referrerPolicy:typeof t.referrerPolicy=="string"?t.referrerPolicy:void 0,imageSrcSet:typeof t.imageSrcSet=="string"?t.imageSrcSet:void 0,imageSizes:typeof t.imageSizes=="string"?t.imageSizes:void 0,media:typeof t.media=="string"?t.media:void 0})}};Re.preloadModule=function(e,t){if(typeof e=="string")if(t){var l=ci(t.as,t.crossOrigin);_e.d.m(e,{as:typeof t.as=="string"&&t.as!=="script"?t.as:void 0,crossOrigin:l,integrity:typeof t.integrity=="string"?t.integrity:void 0})}else _e.d.m(e)};Re.requestFormReset=function(e){_e.d.r(e)};Re.unstable_batchedUpdates=function(e,t){return e(t)};Re.useFormState=function(e,t,l){return ta.H.useFormState(e,t,l)};Re.useFormStatus=function(){return ta.H.useHostTransitionStatus()};Re.version="19.2.4";function ld(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(ld)}catch(e){console.error(e)}}ld(),ed.exports=Re;var P0=ed.exports;/**
+ * @license React
+ * react-dom-client.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var ke=D0,nd=g,ey=P0;function j(e){var t="https://react.dev/errors/"+e;if(1<arguments.length){t+="?args[]="+encodeURIComponent(arguments[1]);for(var l=2;l<arguments.length;l++)t+="&args[]="+encodeURIComponent(arguments[l])}return"Minified React error #"+e+"; visit "+t+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function ad(e){return!(!e||e.nodeType!==1&&e.nodeType!==9&&e.nodeType!==11)}function wa(e){var t=e,l=e;if(e.alternate)for(;t.return;)t=t.return;else{e=t;do t=e,t.flags&4098&&(l=t.return),e=t.return;while(e)}return t.tag===3?l:null}function ud(e){if(e.tag===13){var t=e.memoizedState;if(t===null&&(e=e.alternate,e!==null&&(t=e.memoizedState)),t!==null)return t.dehydrated}return null}function id(e){if(e.tag===31){var t=e.memoizedState;if(t===null&&(e=e.alternate,e!==null&&(t=e.memoizedState)),t!==null)return t.dehydrated}return null}function If(e){if(wa(e)!==e)throw Error(j(188))}function ty(e){var t=e.alternate;if(!t){if(t=wa(e),t===null)throw Error(j(188));return t!==e?null:e}for(var l=e,n=t;;){var a=l.return;if(a===null)break;var u=a.alternate;if(u===null){if(n=a.return,n!==null){l=n;continue}break}if(a.child===u.child){for(u=a.child;u;){if(u===l)return If(a),e;if(u===n)return If(a),t;u=u.sibling}throw Error(j(188))}if(l.return!==n.return)l=a,n=u;else{for(var i=!1,c=a.child;c;){if(c===l){i=!0,l=a,n=u;break}if(c===n){i=!0,n=a,l=u;break}c=c.sibling}if(!i){for(c=u.child;c;){if(c===l){i=!0,l=u,n=a;break}if(c===n){i=!0,n=u,l=a;break}c=c.sibling}if(!i)throw Error(j(189))}}if(l.alternate!==n)throw Error(j(190))}if(l.tag!==3)throw Error(j(188));return l.stateNode.current===l?e:t}function cd(e){var t=e.tag;if(t===5||t===26||t===27||t===6)return e;for(e=e.child;e!==null;){if(t=cd(e),t!==null)return t;e=e.sibling}return null}var ie=Object.assign,ly=Symbol.for("react.element"),Ya=Symbol.for("react.transitional.element"),Jn=Symbol.for("react.portal"),Pl=Symbol.for("react.fragment"),sd=Symbol.for("react.strict_mode"),Mc=Symbol.for("react.profiler"),fd=Symbol.for("react.consumer"),Nt=Symbol.for("react.context"),_s=Symbol.for("react.forward_ref"),wc=Symbol.for("react.suspense"),Ac=Symbol.for("react.suspense_list"),Rs=Symbol.for("react.memo"),Kt=Symbol.for("react.lazy"),Nc=Symbol.for("react.activity"),ny=Symbol.for("react.memo_cache_sentinel"),Pf=Symbol.iterator;function Xn(e){return e===null||typeof e!="object"?null:(e=Pf&&e[Pf]||e["@@iterator"],typeof e=="function"?e:null)}var ay=Symbol.for("react.client.reference");function Oc(e){if(e==null)return null;if(typeof e=="function")return e.$$typeof===ay?null:e.displayName||e.name||null;if(typeof e=="string")return e;switch(e){case Pl:return"Fragment";case Mc:return"Profiler";case sd:return"StrictMode";case wc:return"Suspense";case Ac:return"SuspenseList";case Nc:return"Activity"}if(typeof e=="object")switch(e.$$typeof){case Jn:return"Portal";case Nt:return e.displayName||"Context";case fd:return(e._context.displayName||"Context")+".Consumer";case _s:var t=e.render;return e=e.displayName,e||(e=t.displayName||t.name||"",e=e!==""?"ForwardRef("+e+")":"ForwardRef"),e;case Rs:return t=e.displayName||null,t!==null?t:Oc(e.type)||"Memo";case Kt:t=e._payload,e=e._init;try{return Oc(e(t))}catch{}}return null}var Wn=Array.isArray,C=nd.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,K=ey.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,Ml={pending:!1,data:null,method:null,action:null},Dc=[],en=-1;function kt(e){return{current:e}}function je(e){0>en||(e.current=Dc[en],Dc[en]=null,en--)}function le(e,t){en++,Dc[en]=e.current,e.current=t}var bt=kt(null),ma=kt(null),ul=kt(null),Mu=kt(null);function wu(e,t){switch(le(ul,t),le(ma,e),le(bt,null),t.nodeType){case 9:case 11:e=(e=t.documentElement)&&(e=e.namespaceURI)?ir(e):0;break;default:if(e=t.tagName,t=t.namespaceURI)t=ir(t),e=w1(t,e);else switch(e){case"svg":e=1;break;case"math":e=2;break;default:e=0}}je(bt),le(bt,e)}function bn(){je(bt),je(ma),je(ul)}function qc(e){e.memoizedState!==null&&le(Mu,e);var t=bt.current,l=w1(t,e.type);t!==l&&(le(ma,e),le(bt,l))}function Au(e){ma.current===e&&(je(bt),je(ma)),Mu.current===e&&(je(Mu),Ea._currentValue=Ml)}var Oi,eo;function jl(e){if(Oi===void 0)try{throw Error()}catch(l){var t=l.stack.trim().match(/\n( *(at )?)/);Oi=t&&t[1]||"",eo=-1<l.stack.indexOf(`
+    at`)?" (<anonymous>)":-1<l.stack.indexOf("@")?"@unknown:0:0":""}return`
+`+Oi+e+eo}var Di=!1;function qi(e,t){if(!e||Di)return"";Di=!0;var l=Error.prepareStackTrace;Error.prepareStackTrace=void 0;try{var n={DetermineComponentFrameRoot:function(){try{if(t){var h=function(){throw Error()};if(Object.defineProperty(h.prototype,"props",{set:function(){throw Error()}}),typeof Reflect=="object"&&Reflect.construct){try{Reflect.construct(h,[])}catch(m){var d=m}Reflect.construct(e,[],h)}else{try{h.call()}catch(m){d=m}e.call(h.prototype)}}else{try{throw Error()}catch(m){d=m}(h=e())&&typeof h.catch=="function"&&h.catch(function(){})}}catch(m){if(m&&d&&typeof m.stack=="string")return[m.stack,d.stack]}return[null,null]}};n.DetermineComponentFrameRoot.displayName="DetermineComponentFrameRoot";var a=Object.getOwnPropertyDescriptor(n.DetermineComponentFrameRoot,"name");a&&a.configurable&&Object.defineProperty(n.DetermineComponentFrameRoot,"name",{value:"DetermineComponentFrameRoot"});var u=n.DetermineComponentFrameRoot(),i=u[0],c=u[1];if(i&&c){var s=i.split(`
+`),o=c.split(`
+`);for(a=n=0;n<s.length&&!s[n].includes("DetermineComponentFrameRoot");)n++;for(;a<o.length&&!o[a].includes("DetermineComponentFrameRoot");)a++;if(n===s.length||a===o.length)for(n=s.length-1,a=o.length-1;1<=n&&0<=a&&s[n]!==o[a];)a--;for(;1<=n&&0<=a;n--,a--)if(s[n]!==o[a]){if(n!==1||a!==1)do if(n--,a--,0>a||s[n]!==o[a]){var x=`
+`+s[n].replace(" at new "," at ");return e.displayName&&x.includes("<anonymous>")&&(x=x.replace("<anonymous>",e.displayName)),x}while(1<=n&&0<=a);break}}}finally{Di=!1,Error.prepareStackTrace=l}return(l=e?e.displayName||e.name:"")?jl(l):""}function uy(e,t){switch(e.tag){case 26:case 27:case 5:return jl(e.type);case 16:return jl("Lazy");case 13:return e.child!==t&&t!==null?jl("Suspense Fallback"):jl("Suspense");case 19:return jl("SuspenseList");case 0:case 15:return qi(e.type,!1);case 11:return qi(e.type.render,!1);case 1:return qi(e.type,!0);case 31:return jl("Activity");default:return""}}function to(e){try{var t="",l=null;do t+=uy(e,l),l=e,e=e.return;while(e);return t}catch(n){return`
+Error generating stack: `+n.message+`
+`+n.stack}}var Cc=Object.prototype.hasOwnProperty,Hs=ke.unstable_scheduleCallback,Ci=ke.unstable_cancelCallback,iy=ke.unstable_shouldYield,cy=ke.unstable_requestPaint,We=ke.unstable_now,sy=ke.unstable_getCurrentPriorityLevel,od=ke.unstable_ImmediatePriority,rd=ke.unstable_UserBlockingPriority,Nu=ke.unstable_NormalPriority,fy=ke.unstable_LowPriority,dd=ke.unstable_IdlePriority,oy=ke.log,ry=ke.unstable_setDisableYieldValue,Aa=null,Fe=null;function el(e){if(typeof oy=="function"&&ry(e),Fe&&typeof Fe.setStrictMode=="function")try{Fe.setStrictMode(Aa,e)}catch{}}var Ie=Math.clz32?Math.clz32:yy,dy=Math.log,xy=Math.LN2;function yy(e){return e>>>=0,e===0?32:31-(dy(e)/xy|0)|0}var Va=256,Qa=262144,Ka=4194304;function $l(e){var t=e&42;if(t!==0)return t;switch(e&-e){case 1:return 1;case 2:return 2;case 4:return 4;case 8:return 8;case 16:return 16;case 32:return 32;case 64:return 64;case 128:return 128;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:return e&261888;case 262144:case 524288:case 1048576:case 2097152:return e&3932160;case 4194304:case 8388608:case 16777216:case 33554432:return e&62914560;case 67108864:return 67108864;case 134217728:return 134217728;case 268435456:return 268435456;case 536870912:return 536870912;case 1073741824:return 0;default:return e}}function si(e,t,l){var n=e.pendingLanes;if(n===0)return 0;var a=0,u=e.suspendedLanes,i=e.pingedLanes;e=e.warmLanes;var c=n&134217727;return c!==0?(n=c&~u,n!==0?a=$l(n):(i&=c,i!==0?a=$l(i):l||(l=c&~e,l!==0&&(a=$l(l))))):(c=n&~u,c!==0?a=$l(c):i!==0?a=$l(i):l||(l=n&~e,l!==0&&(a=$l(l)))),a===0?0:t!==0&&t!==a&&!(t&u)&&(u=a&-a,l=t&-t,u>=l||u===32&&(l&4194048)!==0)?t:a}function Na(e,t){return(e.pendingLanes&~(e.suspendedLanes&~e.pingedLanes)&t)===0}function my(e,t){switch(e){case 1:case 2:case 4:case 8:case 64:return t+250;case 16:case 32:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:return t+5e3;case 4194304:case 8388608:case 16777216:case 33554432:return-1;case 67108864:case 134217728:case 268435456:case 536870912:case 1073741824:return-1;default:return-1}}function xd(){var e=Ka;return Ka<<=1,!(Ka&62914560)&&(Ka=4194304),e}function _i(e){for(var t=[],l=0;31>l;l++)t.push(e);return t}function Oa(e,t){e.pendingLanes|=t,t!==268435456&&(e.suspendedLanes=0,e.pingedLanes=0,e.warmLanes=0)}function vy(e,t,l,n,a,u){var i=e.pendingLanes;e.pendingLanes=l,e.suspendedLanes=0,e.pingedLanes=0,e.warmLanes=0,e.expiredLanes&=l,e.entangledLanes&=l,e.errorRecoveryDisabledLanes&=l,e.shellSuspendCounter=0;var c=e.entanglements,s=e.expirationTimes,o=e.hiddenUpdates;for(l=i&~l;0<l;){var x=31-Ie(l),h=1<<x;c[x]=0,s[x]=-1;var d=o[x];if(d!==null)for(o[x]=null,x=0;x<d.length;x++){var m=d[x];m!==null&&(m.lane&=-536870913)}l&=~h}n!==0&&yd(e,n,0),u!==0&&a===0&&e.tag!==0&&(e.suspendedLanes|=u&~(i&~t))}function yd(e,t,l){e.pendingLanes|=t,e.suspendedLanes&=~t;var n=31-Ie(t);e.entangledLanes|=t,e.entanglements[n]=e.entanglements[n]|1073741824|l&261930}function md(e,t){var l=e.entangledLanes|=t;for(e=e.entanglements;l;){var n=31-Ie(l),a=1<<n;a&t|e[n]&t&&(e[n]|=t),l&=~a}}function vd(e,t){var l=t&-t;return l=l&42?1:Us(l),l&(e.suspendedLanes|t)?0:l}function Us(e){switch(e){case 2:e=1;break;case 8:e=4;break;case 32:e=16;break;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:case 4194304:case 8388608:case 16777216:case 33554432:e=128;break;case 268435456:e=134217728;break;default:e=0}return e}function Xs(e){return e&=-e,2<e?8<e?e&134217727?32:268435456:8:2}function hd(){var e=K.p;return e!==0?e:(e=window.event,e===void 0?32:X1(e.type))}function lo(e,t){var l=K.p;try{return K.p=e,t()}finally{K.p=l}}var gl=Math.random().toString(36).slice(2),we="__reactFiber$"+gl,Ge="__reactProps$"+gl,On="__reactContainer$"+gl,_c="__reactEvents$"+gl,hy="__reactListeners$"+gl,gy="__reactHandles$"+gl,no="__reactResources$"+gl,Da="__reactMarker$"+gl;function Bs(e){delete e[we],delete e[Ge],delete e[_c],delete e[hy],delete e[gy]}function tn(e){var t=e[we];if(t)return t;for(var l=e.parentNode;l;){if(t=l[On]||l[we]){if(l=t.alternate,t.child!==null||l!==null&&l.child!==null)for(e=rr(e);e!==null;){if(l=e[we])return l;e=rr(e)}return t}e=l,l=e.parentNode}return null}function Dn(e){if(e=e[we]||e[On]){var t=e.tag;if(t===5||t===6||t===13||t===31||t===26||t===27||t===3)return e}return null}function Fn(e){var t=e.tag;if(t===5||t===26||t===27||t===6)return e.stateNode;throw Error(j(33))}function xn(e){var t=e[no];return t||(t=e[no]={hoistableStyles:new Map,hoistableScripts:new Map}),t}function ze(e){e[Da]=!0}var gd=new Set,pd={};function Hl(e,t){kn(e,t),kn(e+"Capture",t)}function kn(e,t){for(pd[e]=t,e=0;e<t.length;e++)gd.add(t[e])}var py=RegExp("^[:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD][:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$"),ao={},uo={};function by(e){return Cc.call(uo,e)?!0:Cc.call(ao,e)?!1:py.test(e)?uo[e]=!0:(ao[e]=!0,!1)}function ru(e,t,l){if(by(t))if(l===null)e.removeAttribute(t);else{switch(typeof l){case"undefined":case"function":case"symbol":e.removeAttribute(t);return;case"boolean":var n=t.toLowerCase().slice(0,5);if(n!=="data-"&&n!=="aria-"){e.removeAttribute(t);return}}e.setAttribute(t,""+l)}}function Ja(e,t,l){if(l===null)e.removeAttribute(t);else{switch(typeof l){case"undefined":case"function":case"symbol":case"boolean":e.removeAttribute(t);return}e.setAttribute(t,""+l)}}function zt(e,t,l,n){if(n===null)e.removeAttribute(l);else{switch(typeof n){case"undefined":case"function":case"symbol":case"boolean":e.removeAttribute(l);return}e.setAttributeNS(t,l,""+n)}}function nt(e){switch(typeof e){case"bigint":case"boolean":case"number":case"string":case"undefined":return e;case"object":return e;default:return""}}function bd(e){var t=e.type;return(e=e.nodeName)&&e.toLowerCase()==="input"&&(t==="checkbox"||t==="radio")}function ky(e,t,l){var n=Object.getOwnPropertyDescriptor(e.constructor.prototype,t);if(!e.hasOwnProperty(t)&&typeof n<"u"&&typeof n.get=="function"&&typeof n.set=="function"){var a=n.get,u=n.set;return Object.defineProperty(e,t,{configurable:!0,get:function(){return a.call(this)},set:function(i){l=""+i,u.call(this,i)}}),Object.defineProperty(e,t,{enumerable:n.enumerable}),{getValue:function(){return l},setValue:function(i){l=""+i},stopTracking:function(){e._valueTracker=null,delete e[t]}}}}function Rc(e){if(!e._valueTracker){var t=bd(e)?"checked":"value";e._valueTracker=ky(e,t,""+e[t])}}function kd(e){if(!e)return!1;var t=e._valueTracker;if(!t)return!0;var l=t.getValue(),n="";return e&&(n=bd(e)?e.checked?"true":"false":e.value),e=n,e!==l?(t.setValue(e),!0):!1}function Ou(e){if(e=e||(typeof document<"u"?document:void 0),typeof e>"u")return null;try{return e.activeElement||e.body}catch{return e.body}}var Sy=/[\n"\\]/g;function it(e){return e.replace(Sy,function(t){return"\\"+t.charCodeAt(0).toString(16)+" "})}function Hc(e,t,l,n,a,u,i,c){e.name="",i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"?e.type=i:e.removeAttribute("type"),t!=null?i==="number"?(t===0&&e.value===""||e.value!=t)&&(e.value=""+nt(t)):e.value!==""+nt(t)&&(e.value=""+nt(t)):i!=="submit"&&i!=="reset"||e.removeAttribute("value"),t!=null?Uc(e,i,nt(t)):l!=null?Uc(e,i,nt(l)):n!=null&&e.removeAttribute("value"),a==null&&u!=null&&(e.defaultChecked=!!u),a!=null&&(e.checked=a&&typeof a!="function"&&typeof a!="symbol"),c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"?e.name=""+nt(c):e.removeAttribute("name")}function Sd(e,t,l,n,a,u,i,c){if(u!=null&&typeof u!="function"&&typeof u!="symbol"&&typeof u!="boolean"&&(e.type=u),t!=null||l!=null){if(!(u!=="submit"&&u!=="reset"||t!=null)){Rc(e);return}l=l!=null?""+nt(l):"",t=t!=null?""+nt(t):l,c||t===e.value||(e.value=t),e.defaultValue=t}n=n??a,n=typeof n!="function"&&typeof n!="symbol"&&!!n,e.checked=c?e.checked:!!n,e.defaultChecked=!!n,i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"&&(e.name=i),Rc(e)}function Uc(e,t,l){t==="number"&&Ou(e.ownerDocument)===e||e.defaultValue===""+l||(e.defaultValue=""+l)}function yn(e,t,l,n){if(e=e.options,t){t={};for(var a=0;a<l.length;a++)t["$"+l[a]]=!0;for(l=0;l<e.length;l++)a=t.hasOwnProperty("$"+e[l].value),e[l].selected!==a&&(e[l].selected=a),a&&n&&(e[l].defaultSelected=!0)}else{for(l=""+nt(l),t=null,a=0;a<e.length;a++){if(e[a].value===l){e[a].selected=!0,n&&(e[a].defaultSelected=!0);return}t!==null||e[a].disabled||(t=e[a])}t!==null&&(t.selected=!0)}}function zd(e,t,l){if(t!=null&&(t=""+nt(t),t!==e.value&&(e.value=t),l==null)){e.defaultValue!==t&&(e.defaultValue=t);return}e.defaultValue=l!=null?""+nt(l):""}function jd(e,t,l,n){if(t==null){if(n!=null){if(l!=null)throw Error(j(92));if(Wn(n)){if(1<n.length)throw Error(j(93));n=n[0]}l=n}l==null&&(l=""),t=l}l=nt(t),e.defaultValue=l,n=e.textContent,n===l&&n!==""&&n!==null&&(e.value=n),Rc(e)}function Sn(e,t){if(t){var l=e.firstChild;if(l&&l===e.lastChild&&l.nodeType===3){l.nodeValue=t;return}}e.textContent=t}var zy=new Set("animationIterationCount aspectRatio borderImageOutset borderImageSlice borderImageWidth boxFlex boxFlexGroup boxOrdinalGroup columnCount columns flex flexGrow flexPositive flexShrink flexNegative flexOrder gridArea gridRow gridRowEnd gridRowSpan gridRowStart gridColumn gridColumnEnd gridColumnSpan gridColumnStart fontWeight lineClamp lineHeight opacity order orphans scale tabSize widows zIndex zoom fillOpacity floodOpacity stopOpacity strokeDasharray strokeDashoffset strokeMiterlimit strokeOpacity strokeWidth MozAnimationIterationCount MozBoxFlex MozBoxFlexGroup MozLineClamp msAnimationIterationCount msFlex msZoom msFlexGrow msFlexNegative msFlexOrder msFlexPositive msFlexShrink msGridColumn msGridColumnSpan msGridRow msGridRowSpan WebkitAnimationIterationCount WebkitBoxFlex WebKitBoxFlexGroup WebkitBoxOrdinalGroup WebkitColumnCount WebkitColumns WebkitFlex WebkitFlexGrow WebkitFlexPositive WebkitFlexShrink WebkitLineClamp".split(" "));function io(e,t,l){var n=t.indexOf("--")===0;l==null||typeof l=="boolean"||l===""?n?e.setProperty(t,""):t==="float"?e.cssFloat="":e[t]="":n?e.setProperty(t,l):typeof l!="number"||l===0||zy.has(t)?t==="float"?e.cssFloat=l:e[t]=(""+l).trim():e[t]=l+"px"}function $d(e,t,l){if(t!=null&&typeof t!="object")throw Error(j(62));if(e=e.style,l!=null){for(var n in l)!l.hasOwnProperty(n)||t!=null&&t.hasOwnProperty(n)||(n.indexOf("--")===0?e.setProperty(n,""):n==="float"?e.cssFloat="":e[n]="");for(var a in t)n=t[a],t.hasOwnProperty(a)&&l[a]!==n&&io(e,a,n)}else for(var u in t)t.hasOwnProperty(u)&&io(e,u,t[u])}function Ls(e){if(e.indexOf("-")===-1)return!1;switch(e){case"annotation-xml":case"color-profile":case"font-face":case"font-face-src":case"font-face-uri":case"font-face-format":case"font-face-name":case"missing-glyph":return!1;default:return!0}}var jy=new Map([["acceptCharset","accept-charset"],["htmlFor","for"],["httpEquiv","http-equiv"],["crossOrigin","crossorigin"],["accentHeight","accent-height"],["alignmentBaseline","alignment-baseline"],["arabicForm","arabic-form"],["baselineShift","baseline-shift"],["capHeight","cap-height"],["clipPath","clip-path"],["clipRule","clip-rule"],["colorInterpolation","color-interpolation"],["colorInterpolationFilters","color-interpolation-filters"],["colorProfile","color-profile"],["colorRendering","color-rendering"],["dominantBaseline","dominant-baseline"],["enableBackground","enable-background"],["fillOpacity","fill-opacity"],["fillRule","fill-rule"],["floodColor","flood-color"],["floodOpacity","flood-opacity"],["fontFamily","font-family"],["fontSize","font-size"],["fontSizeAdjust","font-size-adjust"],["fontStretch","font-stretch"],["fontStyle","font-style"],["fontVariant","font-variant"],["fontWeight","font-weight"],["glyphName","glyph-name"],["glyphOrientationHorizontal","glyph-orientation-horizontal"],["glyphOrientationVertical","glyph-orientation-vertical"],["horizAdvX","horiz-adv-x"],["horizOriginX","horiz-origin-x"],["imageRendering","image-rendering"],["letterSpacing","letter-spacing"],["lightingColor","lighting-color"],["markerEnd","marker-end"],["markerMid","marker-mid"],["markerStart","marker-start"],["overlinePosition","overline-position"],["overlineThickness","overline-thickness"],["paintOrder","paint-order"],["panose-1","panose-1"],["pointerEvents","pointer-events"],["renderingIntent","rendering-intent"],["shapeRendering","shape-rendering"],["stopColor","stop-color"],["stopOpacity","stop-opacity"],["strikethroughPosition","strikethrough-position"],["strikethroughThickness","strikethrough-thickness"],["strokeDasharray","stroke-dasharray"],["strokeDashoffset","stroke-dashoffset"],["strokeLinecap","stroke-linecap"],["strokeLinejoin","stroke-linejoin"],["strokeMiterlimit","stroke-miterlimit"],["strokeOpacity","stroke-opacity"],["strokeWidth","stroke-width"],["textAnchor","text-anchor"],["textDecoration","text-decoration"],["textRendering","text-rendering"],["transformOrigin","transform-origin"],["underlinePosition","underline-position"],["underlineThickness","underline-thickness"],["unicodeBidi","unicode-bidi"],["unicodeRange","unicode-range"],["unitsPerEm","units-per-em"],["vAlphabetic","v-alphabetic"],["vHanging","v-hanging"],["vIdeographic","v-ideographic"],["vMathematical","v-mathematical"],["vectorEffect","vector-effect"],["vertAdvY","vert-adv-y"],["vertOriginX","vert-origin-x"],["vertOriginY","vert-origin-y"],["wordSpacing","word-spacing"],["writingMode","writing-mode"],["xmlnsXlink","xmlns:xlink"],["xHeight","x-height"]]),$y=/^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i;function du(e){return $y.test(""+e)?"javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')":e}function Ot(){}var Xc=null;function Gs(e){return e=e.target||e.srcElement||window,e.correspondingUseElement&&(e=e.correspondingUseElement),e.nodeType===3?e.parentNode:e}var ln=null,mn=null;function co(e){var t=Dn(e);if(t&&(e=t.stateNode)){var l=e[Ge]||null;e:switch(e=t.stateNode,t.type){case"input":if(Hc(e,l.value,l.defaultValue,l.defaultValue,l.checked,l.defaultChecked,l.type,l.name),t=l.name,l.type==="radio"&&t!=null){for(l=e;l.parentNode;)l=l.parentNode;for(l=l.querySelectorAll('input[name="'+it(""+t)+'"][type="radio"]'),t=0;t<l.length;t++){var n=l[t];if(n!==e&&n.form===e.form){var a=n[Ge]||null;if(!a)throw Error(j(90));Hc(n,a.value,a.defaultValue,a.defaultValue,a.checked,a.defaultChecked,a.type,a.name)}}for(t=0;t<l.length;t++)n=l[t],n.form===e.form&&kd(n)}break e;case"textarea":zd(e,l.value,l.defaultValue);break e;case"select":t=l.value,t!=null&&yn(e,!!l.multiple,t,!1)}}}var Ri=!1;function Ed(e,t,l){if(Ri)return e(t,l);Ri=!0;try{var n=e(t);return n}finally{if(Ri=!1,(ln!==null||mn!==null)&&(bi(),ln&&(t=ln,e=mn,mn=ln=null,co(t),e)))for(t=0;t<e.length;t++)co(e[t])}}function va(e,t){var l=e.stateNode;if(l===null)return null;var n=l[Ge]||null;if(n===null)return null;l=n[t];e:switch(t){case"onClick":case"onClickCapture":case"onDoubleClick":case"onDoubleClickCapture":case"onMouseDown":case"onMouseDownCapture":case"onMouseMove":case"onMouseMoveCapture":case"onMouseUp":case"onMouseUpCapture":case"onMouseEnter":(n=!n.disabled)||(e=e.type,n=!(e==="button"||e==="input"||e==="select"||e==="textarea")),e=!n;break e;default:e=!1}if(e)return null;if(l&&typeof l!="function")throw Error(j(231,t,typeof l));return l}var Rt=!(typeof window>"u"||typeof window.document>"u"||typeof window.document.createElement>"u"),Bc=!1;if(Rt)try{var Bn={};Object.defineProperty(Bn,"passive",{get:function(){Bc=!0}}),window.addEventListener("test",Bn,Bn),window.removeEventListener("test",Bn,Bn)}catch{Bc=!1}var tl=null,Zs=null,xu=null;function Td(){if(xu)return xu;var e,t=Zs,l=t.length,n,a="value"in tl?tl.value:tl.textContent,u=a.length;for(e=0;e<l&&t[e]===a[e];e++);var i=l-e;for(n=1;n<=i&&t[l-n]===a[u-n];n++);return xu=a.slice(e,1<n?1-n:void 0)}function yu(e){var t=e.keyCode;return"charCode"in e?(e=e.charCode,e===0&&t===13&&(e=13)):e=t,e===10&&(e=13),32<=e||e===13?e:0}function Wa(){return!0}function so(){return!1}function Ze(e){function t(l,n,a,u,i){this._reactName=l,this._targetInst=a,this.type=n,this.nativeEvent=u,this.target=i,this.currentTarget=null;for(var c in e)e.hasOwnProperty(c)&&(l=e[c],this[c]=l?l(u):u[c]);return this.isDefaultPrevented=(u.defaultPrevented!=null?u.defaultPrevented:u.returnValue===!1)?Wa:so,this.isPropagationStopped=so,this}return ie(t.prototype,{preventDefault:function(){this.defaultPrevented=!0;var l=this.nativeEvent;l&&(l.preventDefault?l.preventDefault():typeof l.returnValue!="unknown"&&(l.returnValue=!1),this.isDefaultPrevented=Wa)},stopPropagation:function(){var l=this.nativeEvent;l&&(l.stopPropagation?l.stopPropagation():typeof l.cancelBubble!="unknown"&&(l.cancelBubble=!0),this.isPropagationStopped=Wa)},persist:function(){},isPersistent:Wa}),t}var Ul={eventPhase:0,bubbles:0,cancelable:0,timeStamp:function(e){return e.timeStamp||Date.now()},defaultPrevented:0,isTrusted:0},fi=Ze(Ul),qa=ie({},Ul,{view:0,detail:0}),Ey=Ze(qa),Hi,Ui,Ln,oi=ie({},qa,{screenX:0,screenY:0,clientX:0,clientY:0,pageX:0,pageY:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,getModifierState:Ys,button:0,buttons:0,relatedTarget:function(e){return e.relatedTarget===void 0?e.fromElement===e.srcElement?e.toElement:e.fromElement:e.relatedTarget},movementX:function(e){return"movementX"in e?e.movementX:(e!==Ln&&(Ln&&e.type==="mousemove"?(Hi=e.screenX-Ln.screenX,Ui=e.screenY-Ln.screenY):Ui=Hi=0,Ln=e),Hi)},movementY:function(e){return"movementY"in e?e.movementY:Ui}}),fo=Ze(oi),Ty=ie({},oi,{dataTransfer:0}),My=Ze(Ty),wy=ie({},qa,{relatedTarget:0}),Xi=Ze(wy),Ay=ie({},Ul,{animationName:0,elapsedTime:0,pseudoElement:0}),Ny=Ze(Ay),Oy=ie({},Ul,{clipboardData:function(e){return"clipboardData"in e?e.clipboardData:window.clipboardData}}),Dy=Ze(Oy),qy=ie({},Ul,{data:0}),oo=Ze(qy),Cy={Esc:"Escape",Spacebar:" ",Left:"ArrowLeft",Up:"ArrowUp",Right:"ArrowRight",Down:"ArrowDown",Del:"Delete",Win:"OS",Menu:"ContextMenu",Apps:"ContextMenu",Scroll:"ScrollLock",MozPrintableKey:"Unidentified"},_y={8:"Backspace",9:"Tab",12:"Clear",13:"Enter",16:"Shift",17:"Control",18:"Alt",19:"Pause",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",45:"Insert",46:"Delete",112:"F1",113:"F2",114:"F3",115:"F4",116:"F5",117:"F6",118:"F7",119:"F8",120:"F9",121:"F10",122:"F11",123:"F12",144:"NumLock",145:"ScrollLock",224:"Meta"},Ry={Alt:"altKey",Control:"ctrlKey",Meta:"metaKey",Shift:"shiftKey"};function Hy(e){var t=this.nativeEvent;return t.getModifierState?t.getModifierState(e):(e=Ry[e])?!!t[e]:!1}function Ys(){return Hy}var Uy=ie({},qa,{key:function(e){if(e.key){var t=Cy[e.key]||e.key;if(t!=="Unidentified")return t}return e.type==="keypress"?(e=yu(e),e===13?"Enter":String.fromCharCode(e)):e.type==="keydown"||e.type==="keyup"?_y[e.keyCode]||"Unidentified":""},code:0,location:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,repeat:0,locale:0,getModifierState:Ys,charCode:function(e){return e.type==="keypress"?yu(e):0},keyCode:function(e){return e.type==="keydown"||e.type==="keyup"?e.keyCode:0},which:function(e){return e.type==="keypress"?yu(e):e.type==="keydown"||e.type==="keyup"?e.keyCode:0}}),Xy=Ze(Uy),By=ie({},oi,{pointerId:0,width:0,height:0,pressure:0,tangentialPressure:0,tiltX:0,tiltY:0,twist:0,pointerType:0,isPrimary:0}),ro=Ze(By),Ly=ie({},qa,{touches:0,targetTouches:0,changedTouches:0,altKey:0,metaKey:0,ctrlKey:0,shiftKey:0,getModifierState:Ys}),Gy=Ze(Ly),Zy=ie({},Ul,{propertyName:0,elapsedTime:0,pseudoElement:0}),Yy=Ze(Zy),Vy=ie({},oi,{deltaX:function(e){return"deltaX"in e?e.deltaX:"wheelDeltaX"in e?-e.wheelDeltaX:0},deltaY:function(e){return"deltaY"in e?e.deltaY:"wheelDeltaY"in e?-e.wheelDeltaY:"wheelDelta"in e?-e.wheelDelta:0},deltaZ:0,deltaMode:0}),Qy=Ze(Vy),Ky=ie({},Ul,{newState:0,oldState:0}),Jy=Ze(Ky),Wy=[9,13,27,32],Vs=Rt&&"CompositionEvent"in window,la=null;Rt&&"documentMode"in document&&(la=document.documentMode);var Fy=Rt&&"TextEvent"in window&&!la,Md=Rt&&(!Vs||la&&8<la&&11>=la),xo=" ",yo=!1;function wd(e,t){switch(e){case"keyup":return Wy.indexOf(t.keyCode)!==-1;case"keydown":return t.keyCode!==229;case"keypress":case"mousedown":case"focusout":return!0;default:return!1}}function Ad(e){return e=e.detail,typeof e=="object"&&"data"in e?e.data:null}var nn=!1;function Iy(e,t){switch(e){case"compositionend":return Ad(t);case"keypress":return t.which!==32?null:(yo=!0,xo);case"textInput":return e=t.data,e===xo&&yo?null:e;default:return null}}function Py(e,t){if(nn)return e==="compositionend"||!Vs&&wd(e,t)?(e=Td(),xu=Zs=tl=null,nn=!1,e):null;switch(e){case"paste":return null;case"keypress":if(!(t.ctrlKey||t.altKey||t.metaKey)||t.ctrlKey&&t.altKey){if(t.char&&1<t.char.length)return t.char;if(t.which)return String.fromCharCode(t.which)}return null;case"compositionend":return Md&&t.locale!=="ko"?null:t.data;default:return null}}var em={color:!0,date:!0,datetime:!0,"datetime-local":!0,email:!0,month:!0,number:!0,password:!0,range:!0,search:!0,tel:!0,text:!0,time:!0,url:!0,week:!0};function mo(e){var t=e&&e.nodeName&&e.nodeName.toLowerCase();return t==="input"?!!em[e.type]:t==="textarea"}function Nd(e,t,l,n){ln?mn?mn.push(n):mn=[n]:ln=n,t=Wu(t,"onChange"),0<t.length&&(l=new fi("onChange","change",null,l,n),e.push({event:l,listeners:t}))}var na=null,ha=null;function tm(e){E1(e,0)}function ri(e){var t=Fn(e);if(kd(t))return e}function vo(e,t){if(e==="change")return t}var Od=!1;if(Rt){var Bi;if(Rt){var Li="oninput"in document;if(!Li){var ho=document.createElement("div");ho.setAttribute("oninput","return;"),Li=typeof ho.oninput=="function"}Bi=Li}else Bi=!1;Od=Bi&&(!document.documentMode||9<document.documentMode)}function go(){na&&(na.detachEvent("onpropertychange",Dd),ha=na=null)}function Dd(e){if(e.propertyName==="value"&&ri(ha)){var t=[];Nd(t,ha,e,Gs(e)),Ed(tm,t)}}function lm(e,t,l){e==="focusin"?(go(),na=t,ha=l,na.attachEvent("onpropertychange",Dd)):e==="focusout"&&go()}function nm(e){if(e==="selectionchange"||e==="keyup"||e==="keydown")return ri(ha)}function am(e,t){if(e==="click")return ri(t)}function um(e,t){if(e==="input"||e==="change")return ri(t)}function im(e,t){return e===t&&(e!==0||1/e===1/t)||e!==e&&t!==t}var et=typeof Object.is=="function"?Object.is:im;function ga(e,t){if(et(e,t))return!0;if(typeof e!="object"||e===null||typeof t!="object"||t===null)return!1;var l=Object.keys(e),n=Object.keys(t);if(l.length!==n.length)return!1;for(n=0;n<l.length;n++){var a=l[n];if(!Cc.call(t,a)||!et(e[a],t[a]))return!1}return!0}function po(e){for(;e&&e.firstChild;)e=e.firstChild;return e}function bo(e,t){var l=po(e);e=0;for(var n;l;){if(l.nodeType===3){if(n=e+l.textContent.length,e<=t&&n>=t)return{node:l,offset:t-e};e=n}e:{for(;l;){if(l.nextSibling){l=l.nextSibling;break e}l=l.parentNode}l=void 0}l=po(l)}}function qd(e,t){return e&&t?e===t?!0:e&&e.nodeType===3?!1:t&&t.nodeType===3?qd(e,t.parentNode):"contains"in e?e.contains(t):e.compareDocumentPosition?!!(e.compareDocumentPosition(t)&16):!1:!1}function Cd(e){e=e!=null&&e.ownerDocument!=null&&e.ownerDocument.defaultView!=null?e.ownerDocument.defaultView:window;for(var t=Ou(e.document);t instanceof e.HTMLIFrameElement;){try{var l=typeof t.contentWindow.location.href=="string"}catch{l=!1}if(l)e=t.contentWindow;else break;t=Ou(e.document)}return t}function Qs(e){var t=e&&e.nodeName&&e.nodeName.toLowerCase();return t&&(t==="input"&&(e.type==="text"||e.type==="search"||e.type==="tel"||e.type==="url"||e.type==="password")||t==="textarea"||e.contentEditable==="true")}var cm=Rt&&"documentMode"in document&&11>=document.documentMode,an=null,Lc=null,aa=null,Gc=!1;function ko(e,t,l){var n=l.window===l?l.document:l.nodeType===9?l:l.ownerDocument;Gc||an==null||an!==Ou(n)||(n=an,"selectionStart"in n&&Qs(n)?n={start:n.selectionStart,end:n.selectionEnd}:(n=(n.ownerDocument&&n.ownerDocument.defaultView||window).getSelection(),n={anchorNode:n.anchorNode,anchorOffset:n.anchorOffset,focusNode:n.focusNode,focusOffset:n.focusOffset}),aa&&ga(aa,n)||(aa=n,n=Wu(Lc,"onSelect"),0<n.length&&(t=new fi("onSelect","select",null,t,l),e.push({event:t,listeners:n}),t.target=an)))}function kl(e,t){var l={};return l[e.toLowerCase()]=t.toLowerCase(),l["Webkit"+e]="webkit"+t,l["Moz"+e]="moz"+t,l}var un={animationend:kl("Animation","AnimationEnd"),animationiteration:kl("Animation","AnimationIteration"),animationstart:kl("Animation","AnimationStart"),transitionrun:kl("Transition","TransitionRun"),transitionstart:kl("Transition","TransitionStart"),transitioncancel:kl("Transition","TransitionCancel"),transitionend:kl("Transition","TransitionEnd")},Gi={},_d={};Rt&&(_d=document.createElement("div").style,"AnimationEvent"in window||(delete un.animationend.animation,delete un.animationiteration.animation,delete un.animationstart.animation),"TransitionEvent"in window||delete un.transitionend.transition);function Xl(e){if(Gi[e])return Gi[e];if(!un[e])return e;var t=un[e],l;for(l in t)if(t.hasOwnProperty(l)&&l in _d)return Gi[e]=t[l];return e}var Rd=Xl("animationend"),Hd=Xl("animationiteration"),Ud=Xl("animationstart"),sm=Xl("transitionrun"),fm=Xl("transitionstart"),om=Xl("transitioncancel"),Xd=Xl("transitionend"),Bd=new Map,Zc="abort auxClick beforeToggle cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel".split(" ");Zc.push("scrollEnd");function vt(e,t){Bd.set(e,t),Hl(t,[e])}var Du=typeof reportError=="function"?reportError:function(e){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var t=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof e=="object"&&e!==null&&typeof e.message=="string"?String(e.message):String(e),error:e});if(!window.dispatchEvent(t))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",e);return}console.error(e)},lt=[],cn=0,Ks=0;function di(){for(var e=cn,t=Ks=cn=0;t<e;){var l=lt[t];lt[t++]=null;var n=lt[t];lt[t++]=null;var a=lt[t];lt[t++]=null;var u=lt[t];if(lt[t++]=null,n!==null&&a!==null){var i=n.pending;i===null?a.next=a:(a.next=i.next,i.next=a),n.pending=a}u!==0&&Ld(l,a,u)}}function xi(e,t,l,n){lt[cn++]=e,lt[cn++]=t,lt[cn++]=l,lt[cn++]=n,Ks|=n,e.lanes|=n,e=e.alternate,e!==null&&(e.lanes|=n)}function Js(e,t,l,n){return xi(e,t,l,n),qu(e)}function Bl(e,t){return xi(e,null,null,t),qu(e)}function Ld(e,t,l){e.lanes|=l;var n=e.alternate;n!==null&&(n.lanes|=l);for(var a=!1,u=e.return;u!==null;)u.childLanes|=l,n=u.alternate,n!==null&&(n.childLanes|=l),u.tag===22&&(e=u.stateNode,e===null||e._visibility&1||(a=!0)),e=u,u=u.return;return e.tag===3?(u=e.stateNode,a&&t!==null&&(a=31-Ie(l),e=u.hiddenUpdates,n=e[a],n===null?e[a]=[t]:n.push(t),t.lane=l|536870912),u):null}function qu(e){if(50<xa)throw xa=0,rs=null,Error(j(185));for(var t=e.return;t!==null;)e=t,t=e.return;return e.tag===3?e.stateNode:null}var sn={};function rm(e,t,l,n){this.tag=e,this.key=l,this.sibling=this.child=this.return=this.stateNode=this.type=this.elementType=null,this.index=0,this.refCleanup=this.ref=null,this.pendingProps=t,this.dependencies=this.memoizedState=this.updateQueue=this.memoizedProps=null,this.mode=n,this.subtreeFlags=this.flags=0,this.deletions=null,this.childLanes=this.lanes=0,this.alternate=null}function Ke(e,t,l,n){return new rm(e,t,l,n)}function Ws(e){return e=e.prototype,!(!e||!e.isReactComponent)}function qt(e,t){var l=e.alternate;return l===null?(l=Ke(e.tag,t,e.key,e.mode),l.elementType=e.elementType,l.type=e.type,l.stateNode=e.stateNode,l.alternate=e,e.alternate=l):(l.pendingProps=t,l.type=e.type,l.flags=0,l.subtreeFlags=0,l.deletions=null),l.flags=e.flags&65011712,l.childLanes=e.childLanes,l.lanes=e.lanes,l.child=e.child,l.memoizedProps=e.memoizedProps,l.memoizedState=e.memoizedState,l.updateQueue=e.updateQueue,t=e.dependencies,l.dependencies=t===null?null:{lanes:t.lanes,firstContext:t.firstContext},l.sibling=e.sibling,l.index=e.index,l.ref=e.ref,l.refCleanup=e.refCleanup,l}function Gd(e,t){e.flags&=65011714;var l=e.alternate;return l===null?(e.childLanes=0,e.lanes=t,e.child=null,e.subtreeFlags=0,e.memoizedProps=null,e.memoizedState=null,e.updateQueue=null,e.dependencies=null,e.stateNode=null):(e.childLanes=l.childLanes,e.lanes=l.lanes,e.child=l.child,e.subtreeFlags=0,e.deletions=null,e.memoizedProps=l.memoizedProps,e.memoizedState=l.memoizedState,e.updateQueue=l.updateQueue,e.type=l.type,t=l.dependencies,e.dependencies=t===null?null:{lanes:t.lanes,firstContext:t.firstContext}),e}function mu(e,t,l,n,a,u){var i=0;if(n=e,typeof e=="function")Ws(e)&&(i=1);else if(typeof e=="string")i=vv(e,l,bt.current)?26:e==="html"||e==="head"||e==="body"?27:5;else e:switch(e){case Nc:return e=Ke(31,l,t,a),e.elementType=Nc,e.lanes=u,e;case Pl:return wl(l.children,a,u,t);case sd:i=8,a|=24;break;case Mc:return e=Ke(12,l,t,a|2),e.elementType=Mc,e.lanes=u,e;case wc:return e=Ke(13,l,t,a),e.elementType=wc,e.lanes=u,e;case Ac:return e=Ke(19,l,t,a),e.elementType=Ac,e.lanes=u,e;default:if(typeof e=="object"&&e!==null)switch(e.$$typeof){case Nt:i=10;break e;case fd:i=9;break e;case _s:i=11;break e;case Rs:i=14;break e;case Kt:i=16,n=null;break e}i=29,l=Error(j(130,e===null?"null":typeof e,"")),n=null}return t=Ke(i,l,t,a),t.elementType=e,t.type=n,t.lanes=u,t}function wl(e,t,l,n){return e=Ke(7,e,n,t),e.lanes=l,e}function Zi(e,t,l){return e=Ke(6,e,null,t),e.lanes=l,e}function Zd(e){var t=Ke(18,null,null,0);return t.stateNode=e,t}function Yi(e,t,l){return t=Ke(4,e.children!==null?e.children:[],e.key,t),t.lanes=l,t.stateNode={containerInfo:e.containerInfo,pendingChildren:null,implementation:e.implementation},t}var So=new WeakMap;function ct(e,t){if(typeof e=="object"&&e!==null){var l=So.get(e);return l!==void 0?l:(t={value:e,source:t,stack:to(t)},So.set(e,t),t)}return{value:e,source:t,stack:to(t)}}var fn=[],on=0,Cu=null,pa=0,at=[],ut=0,yl=null,ht=1,gt="";function wt(e,t){fn[on++]=pa,fn[on++]=Cu,Cu=e,pa=t}function Yd(e,t,l){at[ut++]=ht,at[ut++]=gt,at[ut++]=yl,yl=e;var n=ht;e=gt;var a=32-Ie(n)-1;n&=~(1<<a),l+=1;var u=32-Ie(t)+a;if(30<u){var i=a-a%5;u=(n&(1<<i)-1).toString(32),n>>=i,a-=i,ht=1<<32-Ie(t)+a|l<<a|n,gt=u+e}else ht=1<<u|l<<a|n,gt=e}function Fs(e){e.return!==null&&(wt(e,1),Yd(e,1,0))}function Is(e){for(;e===Cu;)Cu=fn[--on],fn[on]=null,pa=fn[--on],fn[on]=null;for(;e===yl;)yl=at[--ut],at[ut]=null,gt=at[--ut],at[ut]=null,ht=at[--ut],at[ut]=null}function Vd(e,t){at[ut++]=ht,at[ut++]=gt,at[ut++]=yl,ht=t.id,gt=t.overflow,yl=e}var Ae=null,ae=null,L=!1,il=null,st=!1,Yc=Error(j(519));function ml(e){var t=Error(j(418,1<arguments.length&&arguments[1]!==void 0&&arguments[1]?"text":"HTML",""));throw ba(ct(t,e)),Yc}function zo(e){var t=e.stateNode,l=e.type,n=e.memoizedProps;switch(t[we]=e,t[Ge]=n,l){case"dialog":U("cancel",t),U("close",t);break;case"iframe":case"object":case"embed":U("load",t);break;case"video":case"audio":for(l=0;l<ja.length;l++)U(ja[l],t);break;case"source":U("error",t);break;case"img":case"image":case"link":U("error",t),U("load",t);break;case"details":U("toggle",t);break;case"input":U("invalid",t),Sd(t,n.value,n.defaultValue,n.checked,n.defaultChecked,n.type,n.name,!0);break;case"select":U("invalid",t);break;case"textarea":U("invalid",t),jd(t,n.value,n.defaultValue,n.children)}l=n.children,typeof l!="string"&&typeof l!="number"&&typeof l!="bigint"||t.textContent===""+l||n.suppressHydrationWarning===!0||M1(t.textContent,l)?(n.popover!=null&&(U("beforetoggle",t),U("toggle",t)),n.onScroll!=null&&U("scroll",t),n.onScrollEnd!=null&&U("scrollend",t),n.onClick!=null&&(t.onclick=Ot),t=!0):t=!1,t||ml(e,!0)}function jo(e){for(Ae=e.return;Ae;)switch(Ae.tag){case 5:case 31:case 13:st=!1;return;case 27:case 3:st=!0;return;default:Ae=Ae.return}}function Zl(e){if(e!==Ae)return!1;if(!L)return jo(e),L=!0,!1;var t=e.tag,l;if((l=t!==3&&t!==27)&&((l=t===5)&&(l=e.type,l=!(l!=="form"&&l!=="button")||vs(e.type,e.memoizedProps)),l=!l),l&&ae&&ml(e),jo(e),t===13){if(e=e.memoizedState,e=e!==null?e.dehydrated:null,!e)throw Error(j(317));ae=or(e)}else if(t===31){if(e=e.memoizedState,e=e!==null?e.dehydrated:null,!e)throw Error(j(317));ae=or(e)}else t===27?(t=ae,pl(e.type)?(e=bs,bs=null,ae=e):ae=t):ae=Ae?ot(e.stateNode.nextSibling):null;return!0}function Dl(){ae=Ae=null,L=!1}function Vi(){var e=il;return e!==null&&(Be===null?Be=e:Be.push.apply(Be,e),il=null),e}function ba(e){il===null?il=[e]:il.push(e)}var Vc=kt(null),Ll=null,Dt=null;function Wt(e,t,l){le(Vc,t._currentValue),t._currentValue=l}function Ct(e){e._currentValue=Vc.current,je(Vc)}function Qc(e,t,l){for(;e!==null;){var n=e.alternate;if((e.childLanes&t)!==t?(e.childLanes|=t,n!==null&&(n.childLanes|=t)):n!==null&&(n.childLanes&t)!==t&&(n.childLanes|=t),e===l)break;e=e.return}}function Kc(e,t,l,n){var a=e.child;for(a!==null&&(a.return=e);a!==null;){var u=a.dependencies;if(u!==null){var i=a.child;u=u.firstContext;e:for(;u!==null;){var c=u;u=a;for(var s=0;s<t.length;s++)if(c.context===t[s]){u.lanes|=l,c=u.alternate,c!==null&&(c.lanes|=l),Qc(u.return,l,e),n||(i=null);break e}u=c.next}}else if(a.tag===18){if(i=a.return,i===null)throw Error(j(341));i.lanes|=l,u=i.alternate,u!==null&&(u.lanes|=l),Qc(i,l,e),i=null}else i=a.child;if(i!==null)i.return=a;else for(i=a;i!==null;){if(i===e){i=null;break}if(a=i.sibling,a!==null){a.return=i.return,i=a;break}i=i.return}a=i}}function qn(e,t,l,n){e=null;for(var a=t,u=!1;a!==null;){if(!u){if(a.flags&524288)u=!0;else if(a.flags&262144)break}if(a.tag===10){var i=a.alternate;if(i===null)throw Error(j(387));if(i=i.memoizedProps,i!==null){var c=a.type;et(a.pendingProps.value,i.value)||(e!==null?e.push(c):e=[c])}}else if(a===Mu.current){if(i=a.alternate,i===null)throw Error(j(387));i.memoizedState.memoizedState!==a.memoizedState.memoizedState&&(e!==null?e.push(Ea):e=[Ea])}a=a.return}e!==null&&Kc(t,e,l,n),t.flags|=262144}function _u(e){for(e=e.firstContext;e!==null;){if(!et(e.context._currentValue,e.memoizedValue))return!0;e=e.next}return!1}function ql(e){Ll=e,Dt=null,e=e.dependencies,e!==null&&(e.firstContext=null)}function Ne(e){return Qd(Ll,e)}function Fa(e,t){return Ll===null&&ql(e),Qd(e,t)}function Qd(e,t){var l=t._currentValue;if(t={context:t,memoizedValue:l,next:null},Dt===null){if(e===null)throw Error(j(308));Dt=t,e.dependencies={lanes:0,firstContext:t},e.flags|=524288}else Dt=Dt.next=t;return l}var dm=typeof AbortController<"u"?AbortController:function(){var e=[],t=this.signal={aborted:!1,addEventListener:function(l,n){e.push(n)}};this.abort=function(){t.aborted=!0,e.forEach(function(l){return l()})}},xm=ke.unstable_scheduleCallback,ym=ke.unstable_NormalPriority,ge={$$typeof:Nt,Consumer:null,Provider:null,_currentValue:null,_currentValue2:null,_threadCount:0};function Ps(){return{controller:new dm,data:new Map,refCount:0}}function Ca(e){e.refCount--,e.refCount===0&&xm(ym,function(){e.controller.abort()})}var ua=null,Jc=0,zn=0,vn=null;function mm(e,t){if(ua===null){var l=ua=[];Jc=0,zn=$f(),vn={status:"pending",value:void 0,then:function(n){l.push(n)}}}return Jc++,t.then($o,$o),t}function $o(){if(--Jc===0&&ua!==null){vn!==null&&(vn.status="fulfilled");var e=ua;ua=null,zn=0,vn=null;for(var t=0;t<e.length;t++)(0,e[t])()}}function vm(e,t){var l=[],n={status:"pending",value:null,reason:null,then:function(a){l.push(a)}};return e.then(function(){n.status="fulfilled",n.value=t;for(var a=0;a<l.length;a++)(0,l[a])(t)},function(a){for(n.status="rejected",n.reason=a,a=0;a<l.length;a++)(0,l[a])(void 0)}),n}var Eo=C.S;C.S=function(e,t){c1=We(),typeof t=="object"&&t!==null&&typeof t.then=="function"&&mm(e,t),Eo!==null&&Eo(e,t)};var Al=kt(null);function ef(){var e=Al.current;return e!==null?e:te.pooledCache}function vu(e,t){t===null?le(Al,Al.current):le(Al,t.pool)}function Kd(){var e=ef();return e===null?null:{parent:ge._currentValue,pool:e}}var Cn=Error(j(460)),tf=Error(j(474)),yi=Error(j(542)),Ru={then:function(){}};function To(e){return e=e.status,e==="fulfilled"||e==="rejected"}function Jd(e,t,l){switch(l=e[l],l===void 0?e.push(t):l!==t&&(t.then(Ot,Ot),t=l),t.status){case"fulfilled":return t.value;case"rejected":throw e=t.reason,wo(e),e;default:if(typeof t.status=="string")t.then(Ot,Ot);else{if(e=te,e!==null&&100<e.shellSuspendCounter)throw Error(j(482));e=t,e.status="pending",e.then(function(n){if(t.status==="pending"){var a=t;a.status="fulfilled",a.value=n}},function(n){if(t.status==="pending"){var a=t;a.status="rejected",a.reason=n}})}switch(t.status){case"fulfilled":return t.value;case"rejected":throw e=t.reason,wo(e),e}throw Nl=t,Cn}}function El(e){try{var t=e._init;return t(e._payload)}catch(l){throw l!==null&&typeof l=="object"&&typeof l.then=="function"?(Nl=l,Cn):l}}var Nl=null;function Mo(){if(Nl===null)throw Error(j(459));var e=Nl;return Nl=null,e}function wo(e){if(e===Cn||e===yi)throw Error(j(483))}var hn=null,ka=0;function Ia(e){var t=ka;return ka+=1,hn===null&&(hn=[]),Jd(hn,e,t)}function Gn(e,t){t=t.props.ref,e.ref=t!==void 0?t:null}function Pa(e,t){throw t.$$typeof===ly?Error(j(525)):(e=Object.prototype.toString.call(t),Error(j(31,e==="[object Object]"?"object with keys {"+Object.keys(t).join(", ")+"}":e)))}function Wd(e){function t(y,r){if(e){var v=y.deletions;v===null?(y.deletions=[r],y.flags|=16):v.push(r)}}function l(y,r){if(!e)return null;for(;r!==null;)t(y,r),r=r.sibling;return null}function n(y){for(var r=new Map;y!==null;)y.key!==null?r.set(y.key,y):r.set(y.index,y),y=y.sibling;return r}function a(y,r){return y=qt(y,r),y.index=0,y.sibling=null,y}function u(y,r,v){return y.index=v,e?(v=y.alternate,v!==null?(v=v.index,v<r?(y.flags|=67108866,r):v):(y.flags|=67108866,r)):(y.flags|=1048576,r)}function i(y){return e&&y.alternate===null&&(y.flags|=67108866),y}function c(y,r,v,b){return r===null||r.tag!==6?(r=Zi(v,y.mode,b),r.return=y,r):(r=a(r,v),r.return=y,r)}function s(y,r,v,b){var z=v.type;return z===Pl?x(y,r,v.props.children,b,v.key):r!==null&&(r.elementType===z||typeof z=="object"&&z!==null&&z.$$typeof===Kt&&El(z)===r.type)?(r=a(r,v.props),Gn(r,v),r.return=y,r):(r=mu(v.type,v.key,v.props,null,y.mode,b),Gn(r,v),r.return=y,r)}function o(y,r,v,b){return r===null||r.tag!==4||r.stateNode.containerInfo!==v.containerInfo||r.stateNode.implementation!==v.implementation?(r=Yi(v,y.mode,b),r.return=y,r):(r=a(r,v.children||[]),r.return=y,r)}function x(y,r,v,b,z){return r===null||r.tag!==7?(r=wl(v,y.mode,b,z),r.return=y,r):(r=a(r,v),r.return=y,r)}function h(y,r,v){if(typeof r=="string"&&r!==""||typeof r=="number"||typeof r=="bigint")return r=Zi(""+r,y.mode,v),r.return=y,r;if(typeof r=="object"&&r!==null){switch(r.$$typeof){case Ya:return v=mu(r.type,r.key,r.props,null,y.mode,v),Gn(v,r),v.return=y,v;case Jn:return r=Yi(r,y.mode,v),r.return=y,r;case Kt:return r=El(r),h(y,r,v)}if(Wn(r)||Xn(r))return r=wl(r,y.mode,v,null),r.return=y,r;if(typeof r.then=="function")return h(y,Ia(r),v);if(r.$$typeof===Nt)return h(y,Fa(y,r),v);Pa(y,r)}return null}function d(y,r,v,b){var z=r!==null?r.key:null;if(typeof v=="string"&&v!==""||typeof v=="number"||typeof v=="bigint")return z!==null?null:c(y,r,""+v,b);if(typeof v=="object"&&v!==null){switch(v.$$typeof){case Ya:return v.key===z?s(y,r,v,b):null;case Jn:return v.key===z?o(y,r,v,b):null;case Kt:return v=El(v),d(y,r,v,b)}if(Wn(v)||Xn(v))return z!==null?null:x(y,r,v,b,null);if(typeof v.then=="function")return d(y,r,Ia(v),b);if(v.$$typeof===Nt)return d(y,r,Fa(y,v),b);Pa(y,v)}return null}function m(y,r,v,b,z){if(typeof b=="string"&&b!==""||typeof b=="number"||typeof b=="bigint")return y=y.get(v)||null,c(r,y,""+b,z);if(typeof b=="object"&&b!==null){switch(b.$$typeof){case Ya:return y=y.get(b.key===null?v:b.key)||null,s(r,y,b,z);case Jn:return y=y.get(b.key===null?v:b.key)||null,o(r,y,b,z);case Kt:return b=El(b),m(y,r,v,b,z)}if(Wn(b)||Xn(b))return y=y.get(v)||null,x(r,y,b,z,null);if(typeof b.then=="function")return m(y,r,v,Ia(b),z);if(b.$$typeof===Nt)return m(y,r,v,Fa(r,b),z);Pa(r,b)}return null}function p(y,r,v,b){for(var z=null,w=null,$=r,T=r=0,E=null;$!==null&&T<v.length;T++){$.index>T?(E=$,$=null):E=$.sibling;var M=d(y,$,v[T],b);if(M===null){$===null&&($=E);break}e&&$&&M.alternate===null&&t(y,$),r=u(M,r,T),w===null?z=M:w.sibling=M,w=M,$=E}if(T===v.length)return l(y,$),L&&wt(y,T),z;if($===null){for(;T<v.length;T++)$=h(y,v[T],b),$!==null&&(r=u($,r,T),w===null?z=$:w.sibling=$,w=$);return L&&wt(y,T),z}for($=n($);T<v.length;T++)E=m($,y,T,v[T],b),E!==null&&(e&&E.alternate!==null&&$.delete(E.key===null?T:E.key),r=u(E,r,T),w===null?z=E:w.sibling=E,w=E);return e&&$.forEach(function(D){return t(y,D)}),L&&wt(y,T),z}function k(y,r,v,b){if(v==null)throw Error(j(151));for(var z=null,w=null,$=r,T=r=0,E=null,M=v.next();$!==null&&!M.done;T++,M=v.next()){$.index>T?(E=$,$=null):E=$.sibling;var D=d(y,$,M.value,b);if(D===null){$===null&&($=E);break}e&&$&&D.alternate===null&&t(y,$),r=u(D,r,T),w===null?z=D:w.sibling=D,w=D,$=E}if(M.done)return l(y,$),L&&wt(y,T),z;if($===null){for(;!M.done;T++,M=v.next())M=h(y,M.value,b),M!==null&&(r=u(M,r,T),w===null?z=M:w.sibling=M,w=M);return L&&wt(y,T),z}for($=n($);!M.done;T++,M=v.next())M=m($,y,T,M.value,b),M!==null&&(e&&M.alternate!==null&&$.delete(M.key===null?T:M.key),r=u(M,r,T),w===null?z=M:w.sibling=M,w=M);return e&&$.forEach(function(R){return t(y,R)}),L&&wt(y,T),z}function S(y,r,v,b){if(typeof v=="object"&&v!==null&&v.type===Pl&&v.key===null&&(v=v.props.children),typeof v=="object"&&v!==null){switch(v.$$typeof){case Ya:e:{for(var z=v.key;r!==null;){if(r.key===z){if(z=v.type,z===Pl){if(r.tag===7){l(y,r.sibling),b=a(r,v.props.children),b.return=y,y=b;break e}}else if(r.elementType===z||typeof z=="object"&&z!==null&&z.$$typeof===Kt&&El(z)===r.type){l(y,r.sibling),b=a(r,v.props),Gn(b,v),b.return=y,y=b;break e}l(y,r);break}else t(y,r);r=r.sibling}v.type===Pl?(b=wl(v.props.children,y.mode,b,v.key),b.return=y,y=b):(b=mu(v.type,v.key,v.props,null,y.mode,b),Gn(b,v),b.return=y,y=b)}return i(y);case Jn:e:{for(z=v.key;r!==null;){if(r.key===z)if(r.tag===4&&r.stateNode.containerInfo===v.containerInfo&&r.stateNode.implementation===v.implementation){l(y,r.sibling),b=a(r,v.children||[]),b.return=y,y=b;break e}else{l(y,r);break}else t(y,r);r=r.sibling}b=Yi(v,y.mode,b),b.return=y,y=b}return i(y);case Kt:return v=El(v),S(y,r,v,b)}if(Wn(v))return p(y,r,v,b);if(Xn(v)){if(z=Xn(v),typeof z!="function")throw Error(j(150));return v=z.call(v),k(y,r,v,b)}if(typeof v.then=="function")return S(y,r,Ia(v),b);if(v.$$typeof===Nt)return S(y,r,Fa(y,v),b);Pa(y,v)}return typeof v=="string"&&v!==""||typeof v=="number"||typeof v=="bigint"?(v=""+v,r!==null&&r.tag===6?(l(y,r.sibling),b=a(r,v),b.return=y,y=b):(l(y,r),b=Zi(v,y.mode,b),b.return=y,y=b),i(y)):l(y,r)}return function(y,r,v,b){try{ka=0;var z=S(y,r,v,b);return hn=null,z}catch($){if($===Cn||$===yi)throw $;var w=Ke(29,$,null,y.mode);return w.lanes=b,w.return=y,w}finally{}}}var Cl=Wd(!0),Fd=Wd(!1),Jt=!1;function lf(e){e.updateQueue={baseState:e.memoizedState,firstBaseUpdate:null,lastBaseUpdate:null,shared:{pending:null,lanes:0,hiddenCallbacks:null},callbacks:null}}function Wc(e,t){e=e.updateQueue,t.updateQueue===e&&(t.updateQueue={baseState:e.baseState,firstBaseUpdate:e.firstBaseUpdate,lastBaseUpdate:e.lastBaseUpdate,shared:e.shared,callbacks:null})}function cl(e){return{lane:e,tag:0,payload:null,callback:null,next:null}}function sl(e,t,l){var n=e.updateQueue;if(n===null)return null;if(n=n.shared,Q&2){var a=n.pending;return a===null?t.next=t:(t.next=a.next,a.next=t),n.pending=t,t=qu(e),Ld(e,null,l),t}return xi(e,n,t,l),qu(e)}function ia(e,t,l){if(t=t.updateQueue,t!==null&&(t=t.shared,(l&4194048)!==0)){var n=t.lanes;n&=e.pendingLanes,l|=n,t.lanes=l,md(e,l)}}function Qi(e,t){var l=e.updateQueue,n=e.alternate;if(n!==null&&(n=n.updateQueue,l===n)){var a=null,u=null;if(l=l.firstBaseUpdate,l!==null){do{var i={lane:l.lane,tag:l.tag,payload:l.payload,callback:null,next:null};u===null?a=u=i:u=u.next=i,l=l.next}while(l!==null);u===null?a=u=t:u=u.next=t}else a=u=t;l={baseState:n.baseState,firstBaseUpdate:a,lastBaseUpdate:u,shared:n.shared,callbacks:n.callbacks},e.updateQueue=l;return}e=l.lastBaseUpdate,e===null?l.firstBaseUpdate=t:e.next=t,l.lastBaseUpdate=t}var Fc=!1;function ca(){if(Fc){var e=vn;if(e!==null)throw e}}function sa(e,t,l,n){Fc=!1;var a=e.updateQueue;Jt=!1;var u=a.firstBaseUpdate,i=a.lastBaseUpdate,c=a.shared.pending;if(c!==null){a.shared.pending=null;var s=c,o=s.next;s.next=null,i===null?u=o:i.next=o,i=s;var x=e.alternate;x!==null&&(x=x.updateQueue,c=x.lastBaseUpdate,c!==i&&(c===null?x.firstBaseUpdate=o:c.next=o,x.lastBaseUpdate=s))}if(u!==null){var h=a.baseState;i=0,x=o=s=null,c=u;do{var d=c.lane&-536870913,m=d!==c.lane;if(m?(B&d)===d:(n&d)===d){d!==0&&d===zn&&(Fc=!0),x!==null&&(x=x.next={lane:0,tag:c.tag,payload:c.payload,callback:null,next:null});e:{var p=e,k=c;d=t;var S=l;switch(k.tag){case 1:if(p=k.payload,typeof p=="function"){h=p.call(S,h,d);break e}h=p;break e;case 3:p.flags=p.flags&-65537|128;case 0:if(p=k.payload,d=typeof p=="function"?p.call(S,h,d):p,d==null)break e;h=ie({},h,d);break e;case 2:Jt=!0}}d=c.callback,d!==null&&(e.flags|=64,m&&(e.flags|=8192),m=a.callbacks,m===null?a.callbacks=[d]:m.push(d))}else m={lane:d,tag:c.tag,payload:c.payload,callback:c.callback,next:null},x===null?(o=x=m,s=h):x=x.next=m,i|=d;if(c=c.next,c===null){if(c=a.shared.pending,c===null)break;m=c,c=m.next,m.next=null,a.lastBaseUpdate=m,a.shared.pending=null}}while(!0);x===null&&(s=h),a.baseState=s,a.firstBaseUpdate=o,a.lastBaseUpdate=x,u===null&&(a.shared.lanes=0),hl|=i,e.lanes=i,e.memoizedState=h}}function Id(e,t){if(typeof e!="function")throw Error(j(191,e));e.call(t)}function Pd(e,t){var l=e.callbacks;if(l!==null)for(e.callbacks=null,e=0;e<l.length;e++)Id(l[e],t)}var jn=kt(null),Hu=kt(0);function Ao(e,t){e=Bt,le(Hu,e),le(jn,t),Bt=e|t.baseLanes}function Ic(){le(Hu,Bt),le(jn,jn.current)}function nf(){Bt=Hu.current,je(jn),je(Hu)}var tt=kt(null),ft=null;function Ft(e){var t=e.alternate;le(xe,xe.current&1),le(tt,e),ft===null&&(t===null||jn.current!==null||t.memoizedState!==null)&&(ft=e)}function Pc(e){le(xe,xe.current),le(tt,e),ft===null&&(ft=e)}function ex(e){e.tag===22?(le(xe,xe.current),le(tt,e),ft===null&&(ft=e)):It()}function It(){le(xe,xe.current),le(tt,tt.current)}function Qe(e){je(tt),ft===e&&(ft=null),je(xe)}var xe=kt(0);function Uu(e){for(var t=e;t!==null;){if(t.tag===13){var l=t.memoizedState;if(l!==null&&(l=l.dehydrated,l===null||gs(l)||ps(l)))return t}else if(t.tag===19&&(t.memoizedProps.revealOrder==="forwards"||t.memoizedProps.revealOrder==="backwards"||t.memoizedProps.revealOrder==="unstable_legacy-backwards"||t.memoizedProps.revealOrder==="together")){if(t.flags&128)return t}else if(t.child!==null){t.child.return=t,t=t.child;continue}if(t===e)break;for(;t.sibling===null;){if(t.return===null||t.return===e)return null;t=t.return}t.sibling.return=t.return,t=t.sibling}return null}var Ht=0,H=null,ee=null,ve=null,Xu=!1,gn=!1,_l=!1,Bu=0,Sa=0,pn=null,hm=0;function oe(){throw Error(j(321))}function af(e,t){if(t===null)return!1;for(var l=0;l<t.length&&l<e.length;l++)if(!et(e[l],t[l]))return!1;return!0}function uf(e,t,l,n,a,u){return Ht=u,H=t,t.memoizedState=null,t.updateQueue=null,t.lanes=0,C.H=e===null||e.memoizedState===null?Nx:hf,_l=!1,u=l(n,a),_l=!1,gn&&(u=lx(t,l,n,a)),tx(e),u}function tx(e){C.H=za;var t=ee!==null&&ee.next!==null;if(Ht=0,ve=ee=H=null,Xu=!1,Sa=0,pn=null,t)throw Error(j(300));e===null||pe||(e=e.dependencies,e!==null&&_u(e)&&(pe=!0))}function lx(e,t,l,n){H=e;var a=0;do{if(gn&&(pn=null),Sa=0,gn=!1,25<=a)throw Error(j(301));if(a+=1,ve=ee=null,e.updateQueue!=null){var u=e.updateQueue;u.lastEffect=null,u.events=null,u.stores=null,u.memoCache!=null&&(u.memoCache.index=0)}C.H=Ox,u=t(l,n)}while(gn);return u}function gm(){var e=C.H,t=e.useState()[0];return t=typeof t.then=="function"?_a(t):t,e=e.useState()[0],(ee!==null?ee.memoizedState:null)!==e&&(H.flags|=1024),t}function cf(){var e=Bu!==0;return Bu=0,e}function sf(e,t,l){t.updateQueue=e.updateQueue,t.flags&=-2053,e.lanes&=~l}function ff(e){if(Xu){for(e=e.memoizedState;e!==null;){var t=e.queue;t!==null&&(t.pending=null),e=e.next}Xu=!1}Ht=0,ve=ee=H=null,gn=!1,Sa=Bu=0,pn=null}function Ce(){var e={memoizedState:null,baseState:null,baseQueue:null,queue:null,next:null};return ve===null?H.memoizedState=ve=e:ve=ve.next=e,ve}function ye(){if(ee===null){var e=H.alternate;e=e!==null?e.memoizedState:null}else e=ee.next;var t=ve===null?H.memoizedState:ve.next;if(t!==null)ve=t,ee=e;else{if(e===null)throw H.alternate===null?Error(j(467)):Error(j(310));ee=e,e={memoizedState:ee.memoizedState,baseState:ee.baseState,baseQueue:ee.baseQueue,queue:ee.queue,next:null},ve===null?H.memoizedState=ve=e:ve=ve.next=e}return ve}function mi(){return{lastEffect:null,events:null,stores:null,memoCache:null}}function _a(e){var t=Sa;return Sa+=1,pn===null&&(pn=[]),e=Jd(pn,e,t),t=H,(ve===null?t.memoizedState:ve.next)===null&&(t=t.alternate,C.H=t===null||t.memoizedState===null?Nx:hf),e}function vi(e){if(e!==null&&typeof e=="object"){if(typeof e.then=="function")return _a(e);if(e.$$typeof===Nt)return Ne(e)}throw Error(j(438,String(e)))}function of(e){var t=null,l=H.updateQueue;if(l!==null&&(t=l.memoCache),t==null){var n=H.alternate;n!==null&&(n=n.updateQueue,n!==null&&(n=n.memoCache,n!=null&&(t={data:n.data.map(function(a){return a.slice()}),index:0})))}if(t==null&&(t={data:[],index:0}),l===null&&(l=mi(),H.updateQueue=l),l.memoCache=t,l=t.data[t.index],l===void 0)for(l=t.data[t.index]=Array(e),n=0;n<e;n++)l[n]=ny;return t.index++,l}function Ut(e,t){return typeof t=="function"?t(e):t}function hu(e){var t=ye();return rf(t,ee,e)}function rf(e,t,l){var n=e.queue;if(n===null)throw Error(j(311));n.lastRenderedReducer=l;var a=e.baseQueue,u=n.pending;if(u!==null){if(a!==null){var i=a.next;a.next=u.next,u.next=i}t.baseQueue=a=u,n.pending=null}if(u=e.baseState,a===null)e.memoizedState=u;else{t=a.next;var c=i=null,s=null,o=t,x=!1;do{var h=o.lane&-536870913;if(h!==o.lane?(B&h)===h:(Ht&h)===h){var d=o.revertLane;if(d===0)s!==null&&(s=s.next={lane:0,revertLane:0,gesture:null,action:o.action,hasEagerState:o.hasEagerState,eagerState:o.eagerState,next:null}),h===zn&&(x=!0);else if((Ht&d)===d){o=o.next,d===zn&&(x=!0);continue}else h={lane:0,revertLane:o.revertLane,gesture:null,action:o.action,hasEagerState:o.hasEagerState,eagerState:o.eagerState,next:null},s===null?(c=s=h,i=u):s=s.next=h,H.lanes|=d,hl|=d;h=o.action,_l&&l(u,h),u=o.hasEagerState?o.eagerState:l(u,h)}else d={lane:h,revertLane:o.revertLane,gesture:o.gesture,action:o.action,hasEagerState:o.hasEagerState,eagerState:o.eagerState,next:null},s===null?(c=s=d,i=u):s=s.next=d,H.lanes|=h,hl|=h;o=o.next}while(o!==null&&o!==t);if(s===null?i=u:s.next=c,!et(u,e.memoizedState)&&(pe=!0,x&&(l=vn,l!==null)))throw l;e.memoizedState=u,e.baseState=i,e.baseQueue=s,n.lastRenderedState=u}return a===null&&(n.lanes=0),[e.memoizedState,n.dispatch]}function Ki(e){var t=ye(),l=t.queue;if(l===null)throw Error(j(311));l.lastRenderedReducer=e;var n=l.dispatch,a=l.pending,u=t.memoizedState;if(a!==null){l.pending=null;var i=a=a.next;do u=e(u,i.action),i=i.next;while(i!==a);et(u,t.memoizedState)||(pe=!0),t.memoizedState=u,t.baseQueue===null&&(t.baseState=u),l.lastRenderedState=u}return[u,n]}function nx(e,t,l){var n=H,a=ye(),u=L;if(u){if(l===void 0)throw Error(j(407));l=l()}else l=t();var i=!et((ee||a).memoizedState,l);if(i&&(a.memoizedState=l,pe=!0),a=a.queue,df(ix.bind(null,n,a,e),[e]),a.getSnapshot!==t||i||ve!==null&&ve.memoizedState.tag&1){if(n.flags|=2048,$n(9,{destroy:void 0},ux.bind(null,n,a,l,t),null),te===null)throw Error(j(349));u||Ht&127||ax(n,t,l)}return l}function ax(e,t,l){e.flags|=16384,e={getSnapshot:t,value:l},t=H.updateQueue,t===null?(t=mi(),H.updateQueue=t,t.stores=[e]):(l=t.stores,l===null?t.stores=[e]:l.push(e))}function ux(e,t,l,n){t.value=l,t.getSnapshot=n,cx(t)&&sx(e)}function ix(e,t,l){return l(function(){cx(t)&&sx(e)})}function cx(e){var t=e.getSnapshot;e=e.value;try{var l=t();return!et(e,l)}catch{return!0}}function sx(e){var t=Bl(e,2);t!==null&&Le(t,e,2)}function es(e){var t=Ce();if(typeof e=="function"){var l=e;if(e=l(),_l){el(!0);try{l()}finally{el(!1)}}}return t.memoizedState=t.baseState=e,t.queue={pending:null,lanes:0,dispatch:null,lastRenderedReducer:Ut,lastRenderedState:e},t}function fx(e,t,l,n){return e.baseState=l,rf(e,ee,typeof n=="function"?n:Ut)}function pm(e,t,l,n,a){if(gi(e))throw Error(j(485));if(e=t.action,e!==null){var u={payload:a,action:e,next:null,isTransition:!0,status:"pending",value:null,reason:null,listeners:[],then:function(i){u.listeners.push(i)}};C.T!==null?l(!0):u.isTransition=!1,n(u),l=t.pending,l===null?(u.next=t.pending=u,ox(t,u)):(u.next=l.next,t.pending=l.next=u)}}function ox(e,t){var l=t.action,n=t.payload,a=e.state;if(t.isTransition){var u=C.T,i={};C.T=i;try{var c=l(a,n),s=C.S;s!==null&&s(i,c),No(e,t,c)}catch(o){ts(e,t,o)}finally{u!==null&&i.types!==null&&(u.types=i.types),C.T=u}}else try{u=l(a,n),No(e,t,u)}catch(o){ts(e,t,o)}}function No(e,t,l){l!==null&&typeof l=="object"&&typeof l.then=="function"?l.then(function(n){Oo(e,t,n)},function(n){return ts(e,t,n)}):Oo(e,t,l)}function Oo(e,t,l){t.status="fulfilled",t.value=l,rx(t),e.state=l,t=e.pending,t!==null&&(l=t.next,l===t?e.pending=null:(l=l.next,t.next=l,ox(e,l)))}function ts(e,t,l){var n=e.pending;if(e.pending=null,n!==null){n=n.next;do t.status="rejected",t.reason=l,rx(t),t=t.next;while(t!==n)}e.action=null}function rx(e){e=e.listeners;for(var t=0;t<e.length;t++)(0,e[t])()}function dx(e,t){return t}function Do(e,t){if(L){var l=te.formState;if(l!==null){e:{var n=H;if(L){if(ae){t:{for(var a=ae,u=st;a.nodeType!==8;){if(!u){a=null;break t}if(a=ot(a.nextSibling),a===null){a=null;break t}}u=a.data,a=u==="F!"||u==="F"?a:null}if(a){ae=ot(a.nextSibling),n=a.data==="F!";break e}}ml(n)}n=!1}n&&(t=l[0])}}return l=Ce(),l.memoizedState=l.baseState=t,n={pending:null,lanes:0,dispatch:null,lastRenderedReducer:dx,lastRenderedState:t},l.queue=n,l=Mx.bind(null,H,n),n.dispatch=l,n=es(!1),u=vf.bind(null,H,!1,n.queue),n=Ce(),a={state:t,dispatch:null,action:e,pending:null},n.queue=a,l=pm.bind(null,H,a,u,l),a.dispatch=l,n.memoizedState=e,[t,l,!1]}function qo(e){var t=ye();return xx(t,ee,e)}function xx(e,t,l){if(t=rf(e,t,dx)[0],e=hu(Ut)[0],typeof t=="object"&&t!==null&&typeof t.then=="function")try{var n=_a(t)}catch(i){throw i===Cn?yi:i}else n=t;t=ye();var a=t.queue,u=a.dispatch;return l!==t.memoizedState&&(H.flags|=2048,$n(9,{destroy:void 0},bm.bind(null,a,l),null)),[n,u,e]}function bm(e,t){e.action=t}function Co(e){var t=ye(),l=ee;if(l!==null)return xx(t,l,e);ye(),t=t.memoizedState,l=ye();var n=l.queue.dispatch;return l.memoizedState=e,[t,n,!1]}function $n(e,t,l,n){return e={tag:e,create:l,deps:n,inst:t,next:null},t=H.updateQueue,t===null&&(t=mi(),H.updateQueue=t),l=t.lastEffect,l===null?t.lastEffect=e.next=e:(n=l.next,l.next=e,e.next=n,t.lastEffect=e),e}function yx(){return ye().memoizedState}function gu(e,t,l,n){var a=Ce();H.flags|=e,a.memoizedState=$n(1|t,{destroy:void 0},l,n===void 0?null:n)}function hi(e,t,l,n){var a=ye();n=n===void 0?null:n;var u=a.memoizedState.inst;ee!==null&&n!==null&&af(n,ee.memoizedState.deps)?a.memoizedState=$n(t,u,l,n):(H.flags|=e,a.memoizedState=$n(1|t,u,l,n))}function _o(e,t){gu(8390656,8,e,t)}function df(e,t){hi(2048,8,e,t)}function km(e){H.flags|=4;var t=H.updateQueue;if(t===null)t=mi(),H.updateQueue=t,t.events=[e];else{var l=t.events;l===null?t.events=[e]:l.push(e)}}function mx(e){var t=ye().memoizedState;return km({ref:t,nextImpl:e}),function(){if(Q&2)throw Error(j(440));return t.impl.apply(void 0,arguments)}}function vx(e,t){return hi(4,2,e,t)}function hx(e,t){return hi(4,4,e,t)}function gx(e,t){if(typeof t=="function"){e=e();var l=t(e);return function(){typeof l=="function"?l():t(null)}}if(t!=null)return e=e(),t.current=e,function(){t.current=null}}function px(e,t,l){l=l!=null?l.concat([e]):null,hi(4,4,gx.bind(null,t,e),l)}function xf(){}function bx(e,t){var l=ye();t=t===void 0?null:t;var n=l.memoizedState;return t!==null&&af(t,n[1])?n[0]:(l.memoizedState=[e,t],e)}function kx(e,t){var l=ye();t=t===void 0?null:t;var n=l.memoizedState;if(t!==null&&af(t,n[1]))return n[0];if(n=e(),_l){el(!0);try{e()}finally{el(!1)}}return l.memoizedState=[n,t],n}function yf(e,t,l){return l===void 0||Ht&1073741824&&!(B&261930)?e.memoizedState=t:(e.memoizedState=l,e=f1(),H.lanes|=e,hl|=e,l)}function Sx(e,t,l,n){return et(l,t)?l:jn.current!==null?(e=yf(e,l,n),et(e,t)||(pe=!0),e):!(Ht&42)||Ht&1073741824&&!(B&261930)?(pe=!0,e.memoizedState=l):(e=f1(),H.lanes|=e,hl|=e,t)}function zx(e,t,l,n,a){var u=K.p;K.p=u!==0&&8>u?u:8;var i=C.T,c={};C.T=c,vf(e,!1,t,l);try{var s=a(),o=C.S;if(o!==null&&o(c,s),s!==null&&typeof s=="object"&&typeof s.then=="function"){var x=vm(s,n);fa(e,t,x,Pe(e))}else fa(e,t,n,Pe(e))}catch(h){fa(e,t,{then:function(){},status:"rejected",reason:h},Pe())}finally{K.p=u,i!==null&&c.types!==null&&(i.types=c.types),C.T=i}}function Sm(){}function ls(e,t,l,n){if(e.tag!==5)throw Error(j(476));var a=jx(e).queue;zx(e,a,t,Ml,l===null?Sm:function(){return $x(e),l(n)})}function jx(e){var t=e.memoizedState;if(t!==null)return t;t={memoizedState:Ml,baseState:Ml,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:Ut,lastRenderedState:Ml},next:null};var l={};return t.next={memoizedState:l,baseState:l,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:Ut,lastRenderedState:l},next:null},e.memoizedState=t,e=e.alternate,e!==null&&(e.memoizedState=t),t}function $x(e){var t=jx(e);t.next===null&&(t=e.alternate.memoizedState),fa(e,t.next.queue,{},Pe())}function mf(){return Ne(Ea)}function Ex(){return ye().memoizedState}function Tx(){return ye().memoizedState}function zm(e){for(var t=e.return;t!==null;){switch(t.tag){case 24:case 3:var l=Pe();e=cl(l);var n=sl(t,e,l);n!==null&&(Le(n,t,l),ia(n,t,l)),t={cache:Ps()},e.payload=t;return}t=t.return}}function jm(e,t,l){var n=Pe();l={lane:n,revertLane:0,gesture:null,action:l,hasEagerState:!1,eagerState:null,next:null},gi(e)?wx(t,l):(l=Js(e,t,l,n),l!==null&&(Le(l,e,n),Ax(l,t,n)))}function Mx(e,t,l){var n=Pe();fa(e,t,l,n)}function fa(e,t,l,n){var a={lane:n,revertLane:0,gesture:null,action:l,hasEagerState:!1,eagerState:null,next:null};if(gi(e))wx(t,a);else{var u=e.alternate;if(e.lanes===0&&(u===null||u.lanes===0)&&(u=t.lastRenderedReducer,u!==null))try{var i=t.lastRenderedState,c=u(i,l);if(a.hasEagerState=!0,a.eagerState=c,et(c,i))return xi(e,t,a,0),te===null&&di(),!1}catch{}finally{}if(l=Js(e,t,a,n),l!==null)return Le(l,e,n),Ax(l,t,n),!0}return!1}function vf(e,t,l,n){if(n={lane:2,revertLane:$f(),gesture:null,action:n,hasEagerState:!1,eagerState:null,next:null},gi(e)){if(t)throw Error(j(479))}else t=Js(e,l,n,2),t!==null&&Le(t,e,2)}function gi(e){var t=e.alternate;return e===H||t!==null&&t===H}function wx(e,t){gn=Xu=!0;var l=e.pending;l===null?t.next=t:(t.next=l.next,l.next=t),e.pending=t}function Ax(e,t,l){if(l&4194048){var n=t.lanes;n&=e.pendingLanes,l|=n,t.lanes=l,md(e,l)}}var za={readContext:Ne,use:vi,useCallback:oe,useContext:oe,useEffect:oe,useImperativeHandle:oe,useLayoutEffect:oe,useInsertionEffect:oe,useMemo:oe,useReducer:oe,useRef:oe,useState:oe,useDebugValue:oe,useDeferredValue:oe,useTransition:oe,useSyncExternalStore:oe,useId:oe,useHostTransitionStatus:oe,useFormState:oe,useActionState:oe,useOptimistic:oe,useMemoCache:oe,useCacheRefresh:oe};za.useEffectEvent=oe;var Nx={readContext:Ne,use:vi,useCallback:function(e,t){return Ce().memoizedState=[e,t===void 0?null:t],e},useContext:Ne,useEffect:_o,useImperativeHandle:function(e,t,l){l=l!=null?l.concat([e]):null,gu(4194308,4,gx.bind(null,t,e),l)},useLayoutEffect:function(e,t){return gu(4194308,4,e,t)},useInsertionEffect:function(e,t){gu(4,2,e,t)},useMemo:function(e,t){var l=Ce();t=t===void 0?null:t;var n=e();if(_l){el(!0);try{e()}finally{el(!1)}}return l.memoizedState=[n,t],n},useReducer:function(e,t,l){var n=Ce();if(l!==void 0){var a=l(t);if(_l){el(!0);try{l(t)}finally{el(!1)}}}else a=t;return n.memoizedState=n.baseState=a,e={pending:null,lanes:0,dispatch:null,lastRenderedReducer:e,lastRenderedState:a},n.queue=e,e=e.dispatch=jm.bind(null,H,e),[n.memoizedState,e]},useRef:function(e){var t=Ce();return e={current:e},t.memoizedState=e},useState:function(e){e=es(e);var t=e.queue,l=Mx.bind(null,H,t);return t.dispatch=l,[e.memoizedState,l]},useDebugValue:xf,useDeferredValue:function(e,t){var l=Ce();return yf(l,e,t)},useTransition:function(){var e=es(!1);return e=zx.bind(null,H,e.queue,!0,!1),Ce().memoizedState=e,[!1,e]},useSyncExternalStore:function(e,t,l){var n=H,a=Ce();if(L){if(l===void 0)throw Error(j(407));l=l()}else{if(l=t(),te===null)throw Error(j(349));B&127||ax(n,t,l)}a.memoizedState=l;var u={value:l,getSnapshot:t};return a.queue=u,_o(ix.bind(null,n,u,e),[e]),n.flags|=2048,$n(9,{destroy:void 0},ux.bind(null,n,u,l,t),null),l},useId:function(){var e=Ce(),t=te.identifierPrefix;if(L){var l=gt,n=ht;l=(n&~(1<<32-Ie(n)-1)).toString(32)+l,t="_"+t+"R_"+l,l=Bu++,0<l&&(t+="H"+l.toString(32)),t+="_"}else l=hm++,t="_"+t+"r_"+l.toString(32)+"_";return e.memoizedState=t},useHostTransitionStatus:mf,useFormState:Do,useActionState:Do,useOptimistic:function(e){var t=Ce();t.memoizedState=t.baseState=e;var l={pending:null,lanes:0,dispatch:null,lastRenderedReducer:null,lastRenderedState:null};return t.queue=l,t=vf.bind(null,H,!0,l),l.dispatch=t,[e,t]},useMemoCache:of,useCacheRefresh:function(){return Ce().memoizedState=zm.bind(null,H)},useEffectEvent:function(e){var t=Ce(),l={impl:e};return t.memoizedState=l,function(){if(Q&2)throw Error(j(440));return l.impl.apply(void 0,arguments)}}},hf={readContext:Ne,use:vi,useCallback:bx,useContext:Ne,useEffect:df,useImperativeHandle:px,useInsertionEffect:vx,useLayoutEffect:hx,useMemo:kx,useReducer:hu,useRef:yx,useState:function(){return hu(Ut)},useDebugValue:xf,useDeferredValue:function(e,t){var l=ye();return Sx(l,ee.memoizedState,e,t)},useTransition:function(){var e=hu(Ut)[0],t=ye().memoizedState;return[typeof e=="boolean"?e:_a(e),t]},useSyncExternalStore:nx,useId:Ex,useHostTransitionStatus:mf,useFormState:qo,useActionState:qo,useOptimistic:function(e,t){var l=ye();return fx(l,ee,e,t)},useMemoCache:of,useCacheRefresh:Tx};hf.useEffectEvent=mx;var Ox={readContext:Ne,use:vi,useCallback:bx,useContext:Ne,useEffect:df,useImperativeHandle:px,useInsertionEffect:vx,useLayoutEffect:hx,useMemo:kx,useReducer:Ki,useRef:yx,useState:function(){return Ki(Ut)},useDebugValue:xf,useDeferredValue:function(e,t){var l=ye();return ee===null?yf(l,e,t):Sx(l,ee.memoizedState,e,t)},useTransition:function(){var e=Ki(Ut)[0],t=ye().memoizedState;return[typeof e=="boolean"?e:_a(e),t]},useSyncExternalStore:nx,useId:Ex,useHostTransitionStatus:mf,useFormState:Co,useActionState:Co,useOptimistic:function(e,t){var l=ye();return ee!==null?fx(l,ee,e,t):(l.baseState=e,[e,l.queue.dispatch])},useMemoCache:of,useCacheRefresh:Tx};Ox.useEffectEvent=mx;function Ji(e,t,l,n){t=e.memoizedState,l=l(n,t),l=l==null?t:ie({},t,l),e.memoizedState=l,e.lanes===0&&(e.updateQueue.baseState=l)}var ns={enqueueSetState:function(e,t,l){e=e._reactInternals;var n=Pe(),a=cl(n);a.payload=t,l!=null&&(a.callback=l),t=sl(e,a,n),t!==null&&(Le(t,e,n),ia(t,e,n))},enqueueReplaceState:function(e,t,l){e=e._reactInternals;var n=Pe(),a=cl(n);a.tag=1,a.payload=t,l!=null&&(a.callback=l),t=sl(e,a,n),t!==null&&(Le(t,e,n),ia(t,e,n))},enqueueForceUpdate:function(e,t){e=e._reactInternals;var l=Pe(),n=cl(l);n.tag=2,t!=null&&(n.callback=t),t=sl(e,n,l),t!==null&&(Le(t,e,l),ia(t,e,l))}};function Ro(e,t,l,n,a,u,i){return e=e.stateNode,typeof e.shouldComponentUpdate=="function"?e.shouldComponentUpdate(n,u,i):t.prototype&&t.prototype.isPureReactComponent?!ga(l,n)||!ga(a,u):!0}function Ho(e,t,l,n){e=t.state,typeof t.componentWillReceiveProps=="function"&&t.componentWillReceiveProps(l,n),typeof t.UNSAFE_componentWillReceiveProps=="function"&&t.UNSAFE_componentWillReceiveProps(l,n),t.state!==e&&ns.enqueueReplaceState(t,t.state,null)}function Rl(e,t){var l=t;if("ref"in t){l={};for(var n in t)n!=="ref"&&(l[n]=t[n])}if(e=e.defaultProps){l===t&&(l=ie({},l));for(var a in e)l[a]===void 0&&(l[a]=e[a])}return l}function Dx(e){Du(e)}function qx(e){console.error(e)}function Cx(e){Du(e)}function Lu(e,t){try{var l=e.onUncaughtError;l(t.value,{componentStack:t.stack})}catch(n){setTimeout(function(){throw n})}}function Uo(e,t,l){try{var n=e.onCaughtError;n(l.value,{componentStack:l.stack,errorBoundary:t.tag===1?t.stateNode:null})}catch(a){setTimeout(function(){throw a})}}function as(e,t,l){return l=cl(l),l.tag=3,l.payload={element:null},l.callback=function(){Lu(e,t)},l}function _x(e){return e=cl(e),e.tag=3,e}function Rx(e,t,l,n){var a=l.type.getDerivedStateFromError;if(typeof a=="function"){var u=n.value;e.payload=function(){return a(u)},e.callback=function(){Uo(t,l,n)}}var i=l.stateNode;i!==null&&typeof i.componentDidCatch=="function"&&(e.callback=function(){Uo(t,l,n),typeof a!="function"&&(fl===null?fl=new Set([this]):fl.add(this));var c=n.stack;this.componentDidCatch(n.value,{componentStack:c!==null?c:""})})}function $m(e,t,l,n,a){if(l.flags|=32768,n!==null&&typeof n=="object"&&typeof n.then=="function"){if(t=l.alternate,t!==null&&qn(t,l,a,!0),l=tt.current,l!==null){switch(l.tag){case 31:case 13:return ft===null?Qu():l.alternate===null&&re===0&&(re=3),l.flags&=-257,l.flags|=65536,l.lanes=a,n===Ru?l.flags|=16384:(t=l.updateQueue,t===null?l.updateQueue=new Set([n]):t.add(n),ic(e,n,a)),!1;case 22:return l.flags|=65536,n===Ru?l.flags|=16384:(t=l.updateQueue,t===null?(t={transitions:null,markerInstances:null,retryQueue:new Set([n])},l.updateQueue=t):(l=t.retryQueue,l===null?t.retryQueue=new Set([n]):l.add(n)),ic(e,n,a)),!1}throw Error(j(435,l.tag))}return ic(e,n,a),Qu(),!1}if(L)return t=tt.current,t!==null?(!(t.flags&65536)&&(t.flags|=256),t.flags|=65536,t.lanes=a,n!==Yc&&(e=Error(j(422),{cause:n}),ba(ct(e,l)))):(n!==Yc&&(t=Error(j(423),{cause:n}),ba(ct(t,l))),e=e.current.alternate,e.flags|=65536,a&=-a,e.lanes|=a,n=ct(n,l),a=as(e.stateNode,n,a),Qi(e,a),re!==4&&(re=2)),!1;var u=Error(j(520),{cause:n});if(u=ct(u,l),da===null?da=[u]:da.push(u),re!==4&&(re=2),t===null)return!0;n=ct(n,l),l=t;do{switch(l.tag){case 3:return l.flags|=65536,e=a&-a,l.lanes|=e,e=as(l.stateNode,n,e),Qi(l,e),!1;case 1:if(t=l.type,u=l.stateNode,(l.flags&128)===0&&(typeof t.getDerivedStateFromError=="function"||u!==null&&typeof u.componentDidCatch=="function"&&(fl===null||!fl.has(u))))return l.flags|=65536,a&=-a,l.lanes|=a,a=_x(a),Rx(a,e,l,n),Qi(l,a),!1}l=l.return}while(l!==null);return!1}var gf=Error(j(461)),pe=!1;function Me(e,t,l,n){t.child=e===null?Fd(t,null,l,n):Cl(t,e.child,l,n)}function Xo(e,t,l,n,a){l=l.render;var u=t.ref;if("ref"in n){var i={};for(var c in n)c!=="ref"&&(i[c]=n[c])}else i=n;return ql(t),n=uf(e,t,l,i,u,a),c=cf(),e!==null&&!pe?(sf(e,t,a),Xt(e,t,a)):(L&&c&&Fs(t),t.flags|=1,Me(e,t,n,a),t.child)}function Bo(e,t,l,n,a){if(e===null){var u=l.type;return typeof u=="function"&&!Ws(u)&&u.defaultProps===void 0&&l.compare===null?(t.tag=15,t.type=u,Hx(e,t,u,n,a)):(e=mu(l.type,null,n,t,t.mode,a),e.ref=t.ref,e.return=t,t.child=e)}if(u=e.child,!pf(e,a)){var i=u.memoizedProps;if(l=l.compare,l=l!==null?l:ga,l(i,n)&&e.ref===t.ref)return Xt(e,t,a)}return t.flags|=1,e=qt(u,n),e.ref=t.ref,e.return=t,t.child=e}function Hx(e,t,l,n,a){if(e!==null){var u=e.memoizedProps;if(ga(u,n)&&e.ref===t.ref)if(pe=!1,t.pendingProps=n=u,pf(e,a))e.flags&131072&&(pe=!0);else return t.lanes=e.lanes,Xt(e,t,a)}return us(e,t,l,n,a)}function Ux(e,t,l,n){var a=n.children,u=e!==null?e.memoizedState:null;if(e===null&&t.stateNode===null&&(t.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),n.mode==="hidden"){if(t.flags&128){if(u=u!==null?u.baseLanes|l:l,e!==null){for(n=t.child=e.child,a=0;n!==null;)a=a|n.lanes|n.childLanes,n=n.sibling;n=a&~u}else n=0,t.child=null;return Lo(e,t,u,l,n)}if(l&536870912)t.memoizedState={baseLanes:0,cachePool:null},e!==null&&vu(t,u!==null?u.cachePool:null),u!==null?Ao(t,u):Ic(),ex(t);else return n=t.lanes=536870912,Lo(e,t,u!==null?u.baseLanes|l:l,l,n)}else u!==null?(vu(t,u.cachePool),Ao(t,u),It(),t.memoizedState=null):(e!==null&&vu(t,null),Ic(),It());return Me(e,t,a,l),t.child}function In(e,t){return e!==null&&e.tag===22||t.stateNode!==null||(t.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),t.sibling}function Lo(e,t,l,n,a){var u=ef();return u=u===null?null:{parent:ge._currentValue,pool:u},t.memoizedState={baseLanes:l,cachePool:u},e!==null&&vu(t,null),Ic(),ex(t),e!==null&&qn(e,t,n,!0),t.childLanes=a,null}function pu(e,t){return t=Gu({mode:t.mode,children:t.children},e.mode),t.ref=e.ref,e.child=t,t.return=e,t}function Go(e,t,l){return Cl(t,e.child,null,l),e=pu(t,t.pendingProps),e.flags|=2,Qe(t),t.memoizedState=null,e}function Em(e,t,l){var n=t.pendingProps,a=(t.flags&128)!==0;if(t.flags&=-129,e===null){if(L){if(n.mode==="hidden")return e=pu(t,n),t.lanes=536870912,In(null,e);if(Pc(t),(e=ae)?(e=N1(e,st),e=e!==null&&e.data==="&"?e:null,e!==null&&(t.memoizedState={dehydrated:e,treeContext:yl!==null?{id:ht,overflow:gt}:null,retryLane:536870912,hydrationErrors:null},l=Zd(e),l.return=t,t.child=l,Ae=t,ae=null)):e=null,e===null)throw ml(t);return t.lanes=536870912,null}return pu(t,n)}var u=e.memoizedState;if(u!==null){var i=u.dehydrated;if(Pc(t),a)if(t.flags&256)t.flags&=-257,t=Go(e,t,l);else if(t.memoizedState!==null)t.child=e.child,t.flags|=128,t=null;else throw Error(j(558));else if(pe||qn(e,t,l,!1),a=(l&e.childLanes)!==0,pe||a){if(n=te,n!==null&&(i=vd(n,l),i!==0&&i!==u.retryLane))throw u.retryLane=i,Bl(e,i),Le(n,e,i),gf;Qu(),t=Go(e,t,l)}else e=u.treeContext,ae=ot(i.nextSibling),Ae=t,L=!0,il=null,st=!1,e!==null&&Vd(t,e),t=pu(t,n),t.flags|=4096;return t}return e=qt(e.child,{mode:n.mode,children:n.children}),e.ref=t.ref,t.child=e,e.return=t,e}function bu(e,t){var l=t.ref;if(l===null)e!==null&&e.ref!==null&&(t.flags|=4194816);else{if(typeof l!="function"&&typeof l!="object")throw Error(j(284));(e===null||e.ref!==l)&&(t.flags|=4194816)}}function us(e,t,l,n,a){return ql(t),l=uf(e,t,l,n,void 0,a),n=cf(),e!==null&&!pe?(sf(e,t,a),Xt(e,t,a)):(L&&n&&Fs(t),t.flags|=1,Me(e,t,l,a),t.child)}function Zo(e,t,l,n,a,u){return ql(t),t.updateQueue=null,l=lx(t,n,l,a),tx(e),n=cf(),e!==null&&!pe?(sf(e,t,u),Xt(e,t,u)):(L&&n&&Fs(t),t.flags|=1,Me(e,t,l,u),t.child)}function Yo(e,t,l,n,a){if(ql(t),t.stateNode===null){var u=sn,i=l.contextType;typeof i=="object"&&i!==null&&(u=Ne(i)),u=new l(n,u),t.memoizedState=u.state!==null&&u.state!==void 0?u.state:null,u.updater=ns,t.stateNode=u,u._reactInternals=t,u=t.stateNode,u.props=n,u.state=t.memoizedState,u.refs={},lf(t),i=l.contextType,u.context=typeof i=="object"&&i!==null?Ne(i):sn,u.state=t.memoizedState,i=l.getDerivedStateFromProps,typeof i=="function"&&(Ji(t,l,i,n),u.state=t.memoizedState),typeof l.getDerivedStateFromProps=="function"||typeof u.getSnapshotBeforeUpdate=="function"||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(i=u.state,typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount(),i!==u.state&&ns.enqueueReplaceState(u,u.state,null),sa(t,n,u,a),ca(),u.state=t.memoizedState),typeof u.componentDidMount=="function"&&(t.flags|=4194308),n=!0}else if(e===null){u=t.stateNode;var c=t.memoizedProps,s=Rl(l,c);u.props=s;var o=u.context,x=l.contextType;i=sn,typeof x=="object"&&x!==null&&(i=Ne(x));var h=l.getDerivedStateFromProps;x=typeof h=="function"||typeof u.getSnapshotBeforeUpdate=="function",c=t.pendingProps!==c,x||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(c||o!==i)&&Ho(t,u,n,i),Jt=!1;var d=t.memoizedState;u.state=d,sa(t,n,u,a),ca(),o=t.memoizedState,c||d!==o||Jt?(typeof h=="function"&&(Ji(t,l,h,n),o=t.memoizedState),(s=Jt||Ro(t,l,s,n,d,o,i))?(x||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount()),typeof u.componentDidMount=="function"&&(t.flags|=4194308)):(typeof u.componentDidMount=="function"&&(t.flags|=4194308),t.memoizedProps=n,t.memoizedState=o),u.props=n,u.state=o,u.context=i,n=s):(typeof u.componentDidMount=="function"&&(t.flags|=4194308),n=!1)}else{u=t.stateNode,Wc(e,t),i=t.memoizedProps,x=Rl(l,i),u.props=x,h=t.pendingProps,d=u.context,o=l.contextType,s=sn,typeof o=="object"&&o!==null&&(s=Ne(o)),c=l.getDerivedStateFromProps,(o=typeof c=="function"||typeof u.getSnapshotBeforeUpdate=="function")||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(i!==h||d!==s)&&Ho(t,u,n,s),Jt=!1,d=t.memoizedState,u.state=d,sa(t,n,u,a),ca();var m=t.memoizedState;i!==h||d!==m||Jt||e!==null&&e.dependencies!==null&&_u(e.dependencies)?(typeof c=="function"&&(Ji(t,l,c,n),m=t.memoizedState),(x=Jt||Ro(t,l,x,n,d,m,s)||e!==null&&e.dependencies!==null&&_u(e.dependencies))?(o||typeof u.UNSAFE_componentWillUpdate!="function"&&typeof u.componentWillUpdate!="function"||(typeof u.componentWillUpdate=="function"&&u.componentWillUpdate(n,m,s),typeof u.UNSAFE_componentWillUpdate=="function"&&u.UNSAFE_componentWillUpdate(n,m,s)),typeof u.componentDidUpdate=="function"&&(t.flags|=4),typeof u.getSnapshotBeforeUpdate=="function"&&(t.flags|=1024)):(typeof u.componentDidUpdate!="function"||i===e.memoizedProps&&d===e.memoizedState||(t.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||i===e.memoizedProps&&d===e.memoizedState||(t.flags|=1024),t.memoizedProps=n,t.memoizedState=m),u.props=n,u.state=m,u.context=s,n=x):(typeof u.componentDidUpdate!="function"||i===e.memoizedProps&&d===e.memoizedState||(t.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||i===e.memoizedProps&&d===e.memoizedState||(t.flags|=1024),n=!1)}return u=n,bu(e,t),n=(t.flags&128)!==0,u||n?(u=t.stateNode,l=n&&typeof l.getDerivedStateFromError!="function"?null:u.render(),t.flags|=1,e!==null&&n?(t.child=Cl(t,e.child,null,a),t.child=Cl(t,null,l,a)):Me(e,t,l,a),t.memoizedState=u.state,e=t.child):e=Xt(e,t,a),e}function Vo(e,t,l,n){return Dl(),t.flags|=256,Me(e,t,l,n),t.child}var Wi={dehydrated:null,treeContext:null,retryLane:0,hydrationErrors:null};function Fi(e){return{baseLanes:e,cachePool:Kd()}}function Ii(e,t,l){return e=e!==null?e.childLanes&~l:0,t&&(e|=Je),e}function Xx(e,t,l){var n=t.pendingProps,a=!1,u=(t.flags&128)!==0,i;if((i=u)||(i=e!==null&&e.memoizedState===null?!1:(xe.current&2)!==0),i&&(a=!0,t.flags&=-129),i=(t.flags&32)!==0,t.flags&=-33,e===null){if(L){if(a?Ft(t):It(),(e=ae)?(e=N1(e,st),e=e!==null&&e.data!=="&"?e:null,e!==null&&(t.memoizedState={dehydrated:e,treeContext:yl!==null?{id:ht,overflow:gt}:null,retryLane:536870912,hydrationErrors:null},l=Zd(e),l.return=t,t.child=l,Ae=t,ae=null)):e=null,e===null)throw ml(t);return ps(e)?t.lanes=32:t.lanes=536870912,null}var c=n.children;return n=n.fallback,a?(It(),a=t.mode,c=Gu({mode:"hidden",children:c},a),n=wl(n,a,l,null),c.return=t,n.return=t,c.sibling=n,t.child=c,n=t.child,n.memoizedState=Fi(l),n.childLanes=Ii(e,i,l),t.memoizedState=Wi,In(null,n)):(Ft(t),is(t,c))}var s=e.memoizedState;if(s!==null&&(c=s.dehydrated,c!==null)){if(u)t.flags&256?(Ft(t),t.flags&=-257,t=Pi(e,t,l)):t.memoizedState!==null?(It(),t.child=e.child,t.flags|=128,t=null):(It(),c=n.fallback,a=t.mode,n=Gu({mode:"visible",children:n.children},a),c=wl(c,a,l,null),c.flags|=2,n.return=t,c.return=t,n.sibling=c,t.child=n,Cl(t,e.child,null,l),n=t.child,n.memoizedState=Fi(l),n.childLanes=Ii(e,i,l),t.memoizedState=Wi,t=In(null,n));else if(Ft(t),ps(c)){if(i=c.nextSibling&&c.nextSibling.dataset,i)var o=i.dgst;i=o,n=Error(j(419)),n.stack="",n.digest=i,ba({value:n,source:null,stack:null}),t=Pi(e,t,l)}else if(pe||qn(e,t,l,!1),i=(l&e.childLanes)!==0,pe||i){if(i=te,i!==null&&(n=vd(i,l),n!==0&&n!==s.retryLane))throw s.retryLane=n,Bl(e,n),Le(i,e,n),gf;gs(c)||Qu(),t=Pi(e,t,l)}else gs(c)?(t.flags|=192,t.child=e.child,t=null):(e=s.treeContext,ae=ot(c.nextSibling),Ae=t,L=!0,il=null,st=!1,e!==null&&Vd(t,e),t=is(t,n.children),t.flags|=4096);return t}return a?(It(),c=n.fallback,a=t.mode,s=e.child,o=s.sibling,n=qt(s,{mode:"hidden",children:n.children}),n.subtreeFlags=s.subtreeFlags&65011712,o!==null?c=qt(o,c):(c=wl(c,a,l,null),c.flags|=2),c.return=t,n.return=t,n.sibling=c,t.child=n,In(null,n),n=t.child,c=e.child.memoizedState,c===null?c=Fi(l):(a=c.cachePool,a!==null?(s=ge._currentValue,a=a.parent!==s?{parent:s,pool:s}:a):a=Kd(),c={baseLanes:c.baseLanes|l,cachePool:a}),n.memoizedState=c,n.childLanes=Ii(e,i,l),t.memoizedState=Wi,In(e.child,n)):(Ft(t),l=e.child,e=l.sibling,l=qt(l,{mode:"visible",children:n.children}),l.return=t,l.sibling=null,e!==null&&(i=t.deletions,i===null?(t.deletions=[e],t.flags|=16):i.push(e)),t.child=l,t.memoizedState=null,l)}function is(e,t){return t=Gu({mode:"visible",children:t},e.mode),t.return=e,e.child=t}function Gu(e,t){return e=Ke(22,e,null,t),e.lanes=0,e}function Pi(e,t,l){return Cl(t,e.child,null,l),e=is(t,t.pendingProps.children),e.flags|=2,t.memoizedState=null,e}function Qo(e,t,l){e.lanes|=t;var n=e.alternate;n!==null&&(n.lanes|=t),Qc(e.return,t,l)}function ec(e,t,l,n,a,u){var i=e.memoizedState;i===null?e.memoizedState={isBackwards:t,rendering:null,renderingStartTime:0,last:n,tail:l,tailMode:a,treeForkCount:u}:(i.isBackwards=t,i.rendering=null,i.renderingStartTime=0,i.last=n,i.tail=l,i.tailMode=a,i.treeForkCount=u)}function Bx(e,t,l){var n=t.pendingProps,a=n.revealOrder,u=n.tail;n=n.children;var i=xe.current,c=(i&2)!==0;if(c?(i=i&1|2,t.flags|=128):i&=1,le(xe,i),Me(e,t,n,l),n=L?pa:0,!c&&e!==null&&e.flags&128)e:for(e=t.child;e!==null;){if(e.tag===13)e.memoizedState!==null&&Qo(e,l,t);else if(e.tag===19)Qo(e,l,t);else if(e.child!==null){e.child.return=e,e=e.child;continue}if(e===t)break e;for(;e.sibling===null;){if(e.return===null||e.return===t)break e;e=e.return}e.sibling.return=e.return,e=e.sibling}switch(a){case"forwards":for(l=t.child,a=null;l!==null;)e=l.alternate,e!==null&&Uu(e)===null&&(a=l),l=l.sibling;l=a,l===null?(a=t.child,t.child=null):(a=l.sibling,l.sibling=null),ec(t,!1,a,l,u,n);break;case"backwards":case"unstable_legacy-backwards":for(l=null,a=t.child,t.child=null;a!==null;){if(e=a.alternate,e!==null&&Uu(e)===null){t.child=a;break}e=a.sibling,a.sibling=l,l=a,a=e}ec(t,!0,l,null,u,n);break;case"together":ec(t,!1,null,null,void 0,n);break;default:t.memoizedState=null}return t.child}function Xt(e,t,l){if(e!==null&&(t.dependencies=e.dependencies),hl|=t.lanes,!(l&t.childLanes))if(e!==null){if(qn(e,t,l,!1),(l&t.childLanes)===0)return null}else return null;if(e!==null&&t.child!==e.child)throw Error(j(153));if(t.child!==null){for(e=t.child,l=qt(e,e.pendingProps),t.child=l,l.return=t;e.sibling!==null;)e=e.sibling,l=l.sibling=qt(e,e.pendingProps),l.return=t;l.sibling=null}return t.child}function pf(e,t){return e.lanes&t?!0:(e=e.dependencies,!!(e!==null&&_u(e)))}function Tm(e,t,l){switch(t.tag){case 3:wu(t,t.stateNode.containerInfo),Wt(t,ge,e.memoizedState.cache),Dl();break;case 27:case 5:qc(t);break;case 4:wu(t,t.stateNode.containerInfo);break;case 10:Wt(t,t.type,t.memoizedProps.value);break;case 31:if(t.memoizedState!==null)return t.flags|=128,Pc(t),null;break;case 13:var n=t.memoizedState;if(n!==null)return n.dehydrated!==null?(Ft(t),t.flags|=128,null):l&t.child.childLanes?Xx(e,t,l):(Ft(t),e=Xt(e,t,l),e!==null?e.sibling:null);Ft(t);break;case 19:var a=(e.flags&128)!==0;if(n=(l&t.childLanes)!==0,n||(qn(e,t,l,!1),n=(l&t.childLanes)!==0),a){if(n)return Bx(e,t,l);t.flags|=128}if(a=t.memoizedState,a!==null&&(a.rendering=null,a.tail=null,a.lastEffect=null),le(xe,xe.current),n)break;return null;case 22:return t.lanes=0,Ux(e,t,l,t.pendingProps);case 24:Wt(t,ge,e.memoizedState.cache)}return Xt(e,t,l)}function Lx(e,t,l){if(e!==null)if(e.memoizedProps!==t.pendingProps)pe=!0;else{if(!pf(e,l)&&!(t.flags&128))return pe=!1,Tm(e,t,l);pe=!!(e.flags&131072)}else pe=!1,L&&t.flags&1048576&&Yd(t,pa,t.index);switch(t.lanes=0,t.tag){case 16:e:{var n=t.pendingProps;if(e=El(t.elementType),t.type=e,typeof e=="function")Ws(e)?(n=Rl(e,n),t.tag=1,t=Yo(null,t,e,n,l)):(t.tag=0,t=us(null,t,e,n,l));else{if(e!=null){var a=e.$$typeof;if(a===_s){t.tag=11,t=Xo(null,t,e,n,l);break e}else if(a===Rs){t.tag=14,t=Bo(null,t,e,n,l);break e}}throw t=Oc(e)||e,Error(j(306,t,""))}}return t;case 0:return us(e,t,t.type,t.pendingProps,l);case 1:return n=t.type,a=Rl(n,t.pendingProps),Yo(e,t,n,a,l);case 3:e:{if(wu(t,t.stateNode.containerInfo),e===null)throw Error(j(387));n=t.pendingProps;var u=t.memoizedState;a=u.element,Wc(e,t),sa(t,n,null,l);var i=t.memoizedState;if(n=i.cache,Wt(t,ge,n),n!==u.cache&&Kc(t,[ge],l,!0),ca(),n=i.element,u.isDehydrated)if(u={element:n,isDehydrated:!1,cache:i.cache},t.updateQueue.baseState=u,t.memoizedState=u,t.flags&256){t=Vo(e,t,n,l);break e}else if(n!==a){a=ct(Error(j(424)),t),ba(a),t=Vo(e,t,n,l);break e}else{switch(e=t.stateNode.containerInfo,e.nodeType){case 9:e=e.body;break;default:e=e.nodeName==="HTML"?e.ownerDocument.body:e}for(ae=ot(e.firstChild),Ae=t,L=!0,il=null,st=!0,l=Fd(t,null,n,l),t.child=l;l;)l.flags=l.flags&-3|4096,l=l.sibling}else{if(Dl(),n===a){t=Xt(e,t,l);break e}Me(e,t,n,l)}t=t.child}return t;case 26:return bu(e,t),e===null?(l=xr(t.type,null,t.pendingProps,null))?t.memoizedState=l:L||(l=t.type,e=t.pendingProps,n=Fu(ul.current).createElement(l),n[we]=t,n[Ge]=e,Oe(n,l,e),ze(n),t.stateNode=n):t.memoizedState=xr(t.type,e.memoizedProps,t.pendingProps,e.memoizedState),null;case 27:return qc(t),e===null&&L&&(n=t.stateNode=O1(t.type,t.pendingProps,ul.current),Ae=t,st=!0,a=ae,pl(t.type)?(bs=a,ae=ot(n.firstChild)):ae=a),Me(e,t,t.pendingProps.children,l),bu(e,t),e===null&&(t.flags|=4194304),t.child;case 5:return e===null&&L&&((a=n=ae)&&(n=nv(n,t.type,t.pendingProps,st),n!==null?(t.stateNode=n,Ae=t,ae=ot(n.firstChild),st=!1,a=!0):a=!1),a||ml(t)),qc(t),a=t.type,u=t.pendingProps,i=e!==null?e.memoizedProps:null,n=u.children,vs(a,u)?n=null:i!==null&&vs(a,i)&&(t.flags|=32),t.memoizedState!==null&&(a=uf(e,t,gm,null,null,l),Ea._currentValue=a),bu(e,t),Me(e,t,n,l),t.child;case 6:return e===null&&L&&((e=l=ae)&&(l=av(l,t.pendingProps,st),l!==null?(t.stateNode=l,Ae=t,ae=null,e=!0):e=!1),e||ml(t)),null;case 13:return Xx(e,t,l);case 4:return wu(t,t.stateNode.containerInfo),n=t.pendingProps,e===null?t.child=Cl(t,null,n,l):Me(e,t,n,l),t.child;case 11:return Xo(e,t,t.type,t.pendingProps,l);case 7:return Me(e,t,t.pendingProps,l),t.child;case 8:return Me(e,t,t.pendingProps.children,l),t.child;case 12:return Me(e,t,t.pendingProps.children,l),t.child;case 10:return n=t.pendingProps,Wt(t,t.type,n.value),Me(e,t,n.children,l),t.child;case 9:return a=t.type._context,n=t.pendingProps.children,ql(t),a=Ne(a),n=n(a),t.flags|=1,Me(e,t,n,l),t.child;case 14:return Bo(e,t,t.type,t.pendingProps,l);case 15:return Hx(e,t,t.type,t.pendingProps,l);case 19:return Bx(e,t,l);case 31:return Em(e,t,l);case 22:return Ux(e,t,l,t.pendingProps);case 24:return ql(t),n=Ne(ge),e===null?(a=ef(),a===null&&(a=te,u=Ps(),a.pooledCache=u,u.refCount++,u!==null&&(a.pooledCacheLanes|=l),a=u),t.memoizedState={parent:n,cache:a},lf(t),Wt(t,ge,a)):(e.lanes&l&&(Wc(e,t),sa(t,null,null,l),ca()),a=e.memoizedState,u=t.memoizedState,a.parent!==n?(a={parent:n,cache:n},t.memoizedState=a,t.lanes===0&&(t.memoizedState=t.updateQueue.baseState=a),Wt(t,ge,n)):(n=u.cache,Wt(t,ge,n),n!==a.cache&&Kc(t,[ge],l,!0))),Me(e,t,t.pendingProps.children,l),t.child;case 29:throw t.pendingProps}throw Error(j(156,t.tag))}function jt(e){e.flags|=4}function tc(e,t,l,n,a){if((t=(e.mode&32)!==0)&&(t=!1),t){if(e.flags|=16777216,(a&335544128)===a)if(e.stateNode.complete)e.flags|=8192;else if(d1())e.flags|=8192;else throw Nl=Ru,tf}else e.flags&=-16777217}function Ko(e,t){if(t.type!=="stylesheet"||t.state.loading&4)e.flags&=-16777217;else if(e.flags|=16777216,!C1(t))if(d1())e.flags|=8192;else throw Nl=Ru,tf}function eu(e,t){t!==null&&(e.flags|=4),e.flags&16384&&(t=e.tag!==22?xd():536870912,e.lanes|=t,En|=t)}function Zn(e,t){if(!L)switch(e.tailMode){case"hidden":t=e.tail;for(var l=null;t!==null;)t.alternate!==null&&(l=t),t=t.sibling;l===null?e.tail=null:l.sibling=null;break;case"collapsed":l=e.tail;for(var n=null;l!==null;)l.alternate!==null&&(n=l),l=l.sibling;n===null?t||e.tail===null?e.tail=null:e.tail.sibling=null:n.sibling=null}}function ne(e){var t=e.alternate!==null&&e.alternate.child===e.child,l=0,n=0;if(t)for(var a=e.child;a!==null;)l|=a.lanes|a.childLanes,n|=a.subtreeFlags&65011712,n|=a.flags&65011712,a.return=e,a=a.sibling;else for(a=e.child;a!==null;)l|=a.lanes|a.childLanes,n|=a.subtreeFlags,n|=a.flags,a.return=e,a=a.sibling;return e.subtreeFlags|=n,e.childLanes=l,t}function Mm(e,t,l){var n=t.pendingProps;switch(Is(t),t.tag){case 16:case 15:case 0:case 11:case 7:case 8:case 12:case 9:case 14:return ne(t),null;case 1:return ne(t),null;case 3:return l=t.stateNode,n=null,e!==null&&(n=e.memoizedState.cache),t.memoizedState.cache!==n&&(t.flags|=2048),Ct(ge),bn(),l.pendingContext&&(l.context=l.pendingContext,l.pendingContext=null),(e===null||e.child===null)&&(Zl(t)?jt(t):e===null||e.memoizedState.isDehydrated&&!(t.flags&256)||(t.flags|=1024,Vi())),ne(t),null;case 26:var a=t.type,u=t.memoizedState;return e===null?(jt(t),u!==null?(ne(t),Ko(t,u)):(ne(t),tc(t,a,null,n,l))):u?u!==e.memoizedState?(jt(t),ne(t),Ko(t,u)):(ne(t),t.flags&=-16777217):(e=e.memoizedProps,e!==n&&jt(t),ne(t),tc(t,a,e,n,l)),null;case 27:if(Au(t),l=ul.current,a=t.type,e!==null&&t.stateNode!=null)e.memoizedProps!==n&&jt(t);else{if(!n){if(t.stateNode===null)throw Error(j(166));return ne(t),null}e=bt.current,Zl(t)?zo(t):(e=O1(a,n,l),t.stateNode=e,jt(t))}return ne(t),null;case 5:if(Au(t),a=t.type,e!==null&&t.stateNode!=null)e.memoizedProps!==n&&jt(t);else{if(!n){if(t.stateNode===null)throw Error(j(166));return ne(t),null}if(u=bt.current,Zl(t))zo(t);else{var i=Fu(ul.current);switch(u){case 1:u=i.createElementNS("http://www.w3.org/2000/svg",a);break;case 2:u=i.createElementNS("http://www.w3.org/1998/Math/MathML",a);break;default:switch(a){case"svg":u=i.createElementNS("http://www.w3.org/2000/svg",a);break;case"math":u=i.createElementNS("http://www.w3.org/1998/Math/MathML",a);break;case"script":u=i.createElement("div"),u.innerHTML="<script><\/script>",u=u.removeChild(u.firstChild);break;case"select":u=typeof n.is=="string"?i.createElement("select",{is:n.is}):i.createElement("select"),n.multiple?u.multiple=!0:n.size&&(u.size=n.size);break;default:u=typeof n.is=="string"?i.createElement(a,{is:n.is}):i.createElement(a)}}u[we]=t,u[Ge]=n;e:for(i=t.child;i!==null;){if(i.tag===5||i.tag===6)u.appendChild(i.stateNode);else if(i.tag!==4&&i.tag!==27&&i.child!==null){i.child.return=i,i=i.child;continue}if(i===t)break e;for(;i.sibling===null;){if(i.return===null||i.return===t)break e;i=i.return}i.sibling.return=i.return,i=i.sibling}t.stateNode=u;e:switch(Oe(u,a,n),a){case"button":case"input":case"select":case"textarea":n=!!n.autoFocus;break e;case"img":n=!0;break e;default:n=!1}n&&jt(t)}}return ne(t),tc(t,t.type,e===null?null:e.memoizedProps,t.pendingProps,l),null;case 6:if(e&&t.stateNode!=null)e.memoizedProps!==n&&jt(t);else{if(typeof n!="string"&&t.stateNode===null)throw Error(j(166));if(e=ul.current,Zl(t)){if(e=t.stateNode,l=t.memoizedProps,n=null,a=Ae,a!==null)switch(a.tag){case 27:case 5:n=a.memoizedProps}e[we]=t,e=!!(e.nodeValue===l||n!==null&&n.suppressHydrationWarning===!0||M1(e.nodeValue,l)),e||ml(t,!0)}else e=Fu(e).createTextNode(n),e[we]=t,t.stateNode=e}return ne(t),null;case 31:if(l=t.memoizedState,e===null||e.memoizedState!==null){if(n=Zl(t),l!==null){if(e===null){if(!n)throw Error(j(318));if(e=t.memoizedState,e=e!==null?e.dehydrated:null,!e)throw Error(j(557));e[we]=t}else Dl(),!(t.flags&128)&&(t.memoizedState=null),t.flags|=4;ne(t),e=!1}else l=Vi(),e!==null&&e.memoizedState!==null&&(e.memoizedState.hydrationErrors=l),e=!0;if(!e)return t.flags&256?(Qe(t),t):(Qe(t),null);if(t.flags&128)throw Error(j(558))}return ne(t),null;case 13:if(n=t.memoizedState,e===null||e.memoizedState!==null&&e.memoizedState.dehydrated!==null){if(a=Zl(t),n!==null&&n.dehydrated!==null){if(e===null){if(!a)throw Error(j(318));if(a=t.memoizedState,a=a!==null?a.dehydrated:null,!a)throw Error(j(317));a[we]=t}else Dl(),!(t.flags&128)&&(t.memoizedState=null),t.flags|=4;ne(t),a=!1}else a=Vi(),e!==null&&e.memoizedState!==null&&(e.memoizedState.hydrationErrors=a),a=!0;if(!a)return t.flags&256?(Qe(t),t):(Qe(t),null)}return Qe(t),t.flags&128?(t.lanes=l,t):(l=n!==null,e=e!==null&&e.memoizedState!==null,l&&(n=t.child,a=null,n.alternate!==null&&n.alternate.memoizedState!==null&&n.alternate.memoizedState.cachePool!==null&&(a=n.alternate.memoizedState.cachePool.pool),u=null,n.memoizedState!==null&&n.memoizedState.cachePool!==null&&(u=n.memoizedState.cachePool.pool),u!==a&&(n.flags|=2048)),l!==e&&l&&(t.child.flags|=8192),eu(t,t.updateQueue),ne(t),null);case 4:return bn(),e===null&&Ef(t.stateNode.containerInfo),ne(t),null;case 10:return Ct(t.type),ne(t),null;case 19:if(je(xe),n=t.memoizedState,n===null)return ne(t),null;if(a=(t.flags&128)!==0,u=n.rendering,u===null)if(a)Zn(n,!1);else{if(re!==0||e!==null&&e.flags&128)for(e=t.child;e!==null;){if(u=Uu(e),u!==null){for(t.flags|=128,Zn(n,!1),e=u.updateQueue,t.updateQueue=e,eu(t,e),t.subtreeFlags=0,e=l,l=t.child;l!==null;)Gd(l,e),l=l.sibling;return le(xe,xe.current&1|2),L&&wt(t,n.treeForkCount),t.child}e=e.sibling}n.tail!==null&&We()>Yu&&(t.flags|=128,a=!0,Zn(n,!1),t.lanes=4194304)}else{if(!a)if(e=Uu(u),e!==null){if(t.flags|=128,a=!0,e=e.updateQueue,t.updateQueue=e,eu(t,e),Zn(n,!0),n.tail===null&&n.tailMode==="hidden"&&!u.alternate&&!L)return ne(t),null}else 2*We()-n.renderingStartTime>Yu&&l!==536870912&&(t.flags|=128,a=!0,Zn(n,!1),t.lanes=4194304);n.isBackwards?(u.sibling=t.child,t.child=u):(e=n.last,e!==null?e.sibling=u:t.child=u,n.last=u)}return n.tail!==null?(e=n.tail,n.rendering=e,n.tail=e.sibling,n.renderingStartTime=We(),e.sibling=null,l=xe.current,le(xe,a?l&1|2:l&1),L&&wt(t,n.treeForkCount),e):(ne(t),null);case 22:case 23:return Qe(t),nf(),n=t.memoizedState!==null,e!==null?e.memoizedState!==null!==n&&(t.flags|=8192):n&&(t.flags|=8192),n?l&536870912&&!(t.flags&128)&&(ne(t),t.subtreeFlags&6&&(t.flags|=8192)):ne(t),l=t.updateQueue,l!==null&&eu(t,l.retryQueue),l=null,e!==null&&e.memoizedState!==null&&e.memoizedState.cachePool!==null&&(l=e.memoizedState.cachePool.pool),n=null,t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(n=t.memoizedState.cachePool.pool),n!==l&&(t.flags|=2048),e!==null&&je(Al),null;case 24:return l=null,e!==null&&(l=e.memoizedState.cache),t.memoizedState.cache!==l&&(t.flags|=2048),Ct(ge),ne(t),null;case 25:return null;case 30:return null}throw Error(j(156,t.tag))}function wm(e,t){switch(Is(t),t.tag){case 1:return e=t.flags,e&65536?(t.flags=e&-65537|128,t):null;case 3:return Ct(ge),bn(),e=t.flags,e&65536&&!(e&128)?(t.flags=e&-65537|128,t):null;case 26:case 27:case 5:return Au(t),null;case 31:if(t.memoizedState!==null){if(Qe(t),t.alternate===null)throw Error(j(340));Dl()}return e=t.flags,e&65536?(t.flags=e&-65537|128,t):null;case 13:if(Qe(t),e=t.memoizedState,e!==null&&e.dehydrated!==null){if(t.alternate===null)throw Error(j(340));Dl()}return e=t.flags,e&65536?(t.flags=e&-65537|128,t):null;case 19:return je(xe),null;case 4:return bn(),null;case 10:return Ct(t.type),null;case 22:case 23:return Qe(t),nf(),e!==null&&je(Al),e=t.flags,e&65536?(t.flags=e&-65537|128,t):null;case 24:return Ct(ge),null;case 25:return null;default:return null}}function Gx(e,t){switch(Is(t),t.tag){case 3:Ct(ge),bn();break;case 26:case 27:case 5:Au(t);break;case 4:bn();break;case 31:t.memoizedState!==null&&Qe(t);break;case 13:Qe(t);break;case 19:je(xe);break;case 10:Ct(t.type);break;case 22:case 23:Qe(t),nf(),e!==null&&je(Al);break;case 24:Ct(ge)}}function Ra(e,t){try{var l=t.updateQueue,n=l!==null?l.lastEffect:null;if(n!==null){var a=n.next;l=a;do{if((l.tag&e)===e){n=void 0;var u=l.create,i=l.inst;n=u(),i.destroy=n}l=l.next}while(l!==a)}}catch(c){F(t,t.return,c)}}function vl(e,t,l){try{var n=t.updateQueue,a=n!==null?n.lastEffect:null;if(a!==null){var u=a.next;n=u;do{if((n.tag&e)===e){var i=n.inst,c=i.destroy;if(c!==void 0){i.destroy=void 0,a=t;var s=l,o=c;try{o()}catch(x){F(a,s,x)}}}n=n.next}while(n!==u)}}catch(x){F(t,t.return,x)}}function Zx(e){var t=e.updateQueue;if(t!==null){var l=e.stateNode;try{Pd(t,l)}catch(n){F(e,e.return,n)}}}function Yx(e,t,l){l.props=Rl(e.type,e.memoizedProps),l.state=e.memoizedState;try{l.componentWillUnmount()}catch(n){F(e,t,n)}}function oa(e,t){try{var l=e.ref;if(l!==null){switch(e.tag){case 26:case 27:case 5:var n=e.stateNode;break;case 30:n=e.stateNode;break;default:n=e.stateNode}typeof l=="function"?e.refCleanup=l(n):l.current=n}}catch(a){F(e,t,a)}}function pt(e,t){var l=e.ref,n=e.refCleanup;if(l!==null)if(typeof n=="function")try{n()}catch(a){F(e,t,a)}finally{e.refCleanup=null,e=e.alternate,e!=null&&(e.refCleanup=null)}else if(typeof l=="function")try{l(null)}catch(a){F(e,t,a)}else l.current=null}function Vx(e){var t=e.type,l=e.memoizedProps,n=e.stateNode;try{e:switch(t){case"button":case"input":case"select":case"textarea":l.autoFocus&&n.focus();break e;case"img":l.src?n.src=l.src:l.srcSet&&(n.srcset=l.srcSet)}}catch(a){F(e,e.return,a)}}function lc(e,t,l){try{var n=e.stateNode;Fm(n,e.type,l,t),n[Ge]=t}catch(a){F(e,e.return,a)}}function Qx(e){return e.tag===5||e.tag===3||e.tag===26||e.tag===27&&pl(e.type)||e.tag===4}function nc(e){e:for(;;){for(;e.sibling===null;){if(e.return===null||Qx(e.return))return null;e=e.return}for(e.sibling.return=e.return,e=e.sibling;e.tag!==5&&e.tag!==6&&e.tag!==18;){if(e.tag===27&&pl(e.type)||e.flags&2||e.child===null||e.tag===4)continue e;e.child.return=e,e=e.child}if(!(e.flags&2))return e.stateNode}}function cs(e,t,l){var n=e.tag;if(n===5||n===6)e=e.stateNode,t?(l.nodeType===9?l.body:l.nodeName==="HTML"?l.ownerDocument.body:l).insertBefore(e,t):(t=l.nodeType===9?l.body:l.nodeName==="HTML"?l.ownerDocument.body:l,t.appendChild(e),l=l._reactRootContainer,l!=null||t.onclick!==null||(t.onclick=Ot));else if(n!==4&&(n===27&&pl(e.type)&&(l=e.stateNode,t=null),e=e.child,e!==null))for(cs(e,t,l),e=e.sibling;e!==null;)cs(e,t,l),e=e.sibling}function Zu(e,t,l){var n=e.tag;if(n===5||n===6)e=e.stateNode,t?l.insertBefore(e,t):l.appendChild(e);else if(n!==4&&(n===27&&pl(e.type)&&(l=e.stateNode),e=e.child,e!==null))for(Zu(e,t,l),e=e.sibling;e!==null;)Zu(e,t,l),e=e.sibling}function Kx(e){var t=e.stateNode,l=e.memoizedProps;try{for(var n=e.type,a=t.attributes;a.length;)t.removeAttributeNode(a[0]);Oe(t,n,l),t[we]=e,t[Ge]=l}catch(u){F(e,e.return,u)}}var At=!1,he=!1,ac=!1,Jo=typeof WeakSet=="function"?WeakSet:Set,Se=null;function Am(e,t){if(e=e.containerInfo,ys=ti,e=Cd(e),Qs(e)){if("selectionStart"in e)var l={start:e.selectionStart,end:e.selectionEnd};else e:{l=(l=e.ownerDocument)&&l.defaultView||window;var n=l.getSelection&&l.getSelection();if(n&&n.rangeCount!==0){l=n.anchorNode;var a=n.anchorOffset,u=n.focusNode;n=n.focusOffset;try{l.nodeType,u.nodeType}catch{l=null;break e}var i=0,c=-1,s=-1,o=0,x=0,h=e,d=null;t:for(;;){for(var m;h!==l||a!==0&&h.nodeType!==3||(c=i+a),h!==u||n!==0&&h.nodeType!==3||(s=i+n),h.nodeType===3&&(i+=h.nodeValue.length),(m=h.firstChild)!==null;)d=h,h=m;for(;;){if(h===e)break t;if(d===l&&++o===a&&(c=i),d===u&&++x===n&&(s=i),(m=h.nextSibling)!==null)break;h=d,d=h.parentNode}h=m}l=c===-1||s===-1?null:{start:c,end:s}}else l=null}l=l||{start:0,end:0}}else l=null;for(ms={focusedElem:e,selectionRange:l},ti=!1,Se=t;Se!==null;)if(t=Se,e=t.child,(t.subtreeFlags&1028)!==0&&e!==null)e.return=t,Se=e;else for(;Se!==null;){switch(t=Se,u=t.alternate,e=t.flags,t.tag){case 0:if(e&4&&(e=t.updateQueue,e=e!==null?e.events:null,e!==null))for(l=0;l<e.length;l++)a=e[l],a.ref.impl=a.nextImpl;break;case 11:case 15:break;case 1:if(e&1024&&u!==null){e=void 0,l=t,a=u.memoizedProps,u=u.memoizedState,n=l.stateNode;try{var p=Rl(l.type,a);e=n.getSnapshotBeforeUpdate(p,u),n.__reactInternalSnapshotBeforeUpdate=e}catch(k){F(l,l.return,k)}}break;case 3:if(e&1024){if(e=t.stateNode.containerInfo,l=e.nodeType,l===9)hs(e);else if(l===1)switch(e.nodeName){case"HEAD":case"HTML":case"BODY":hs(e);break;default:e.textContent=""}}break;case 5:case 26:case 27:case 6:case 4:case 17:break;default:if(e&1024)throw Error(j(163))}if(e=t.sibling,e!==null){e.return=t.return,Se=e;break}Se=t.return}}function Jx(e,t,l){var n=l.flags;switch(l.tag){case 0:case 11:case 15:Et(e,l),n&4&&Ra(5,l);break;case 1:if(Et(e,l),n&4)if(e=l.stateNode,t===null)try{e.componentDidMount()}catch(i){F(l,l.return,i)}else{var a=Rl(l.type,t.memoizedProps);t=t.memoizedState;try{e.componentDidUpdate(a,t,e.__reactInternalSnapshotBeforeUpdate)}catch(i){F(l,l.return,i)}}n&64&&Zx(l),n&512&&oa(l,l.return);break;case 3:if(Et(e,l),n&64&&(e=l.updateQueue,e!==null)){if(t=null,l.child!==null)switch(l.child.tag){case 27:case 5:t=l.child.stateNode;break;case 1:t=l.child.stateNode}try{Pd(e,t)}catch(i){F(l,l.return,i)}}break;case 27:t===null&&n&4&&Kx(l);case 26:case 5:Et(e,l),t===null&&n&4&&Vx(l),n&512&&oa(l,l.return);break;case 12:Et(e,l);break;case 31:Et(e,l),n&4&&Ix(e,l);break;case 13:Et(e,l),n&4&&Px(e,l),n&64&&(e=l.memoizedState,e!==null&&(e=e.dehydrated,e!==null&&(l=Um.bind(null,l),uv(e,l))));break;case 22:if(n=l.memoizedState!==null||At,!n){t=t!==null&&t.memoizedState!==null||he,a=At;var u=he;At=n,(he=t)&&!u?Tt(e,l,(l.subtreeFlags&8772)!==0):Et(e,l),At=a,he=u}break;case 30:break;default:Et(e,l)}}function Wx(e){var t=e.alternate;t!==null&&(e.alternate=null,Wx(t)),e.child=null,e.deletions=null,e.sibling=null,e.tag===5&&(t=e.stateNode,t!==null&&Bs(t)),e.stateNode=null,e.return=null,e.dependencies=null,e.memoizedProps=null,e.memoizedState=null,e.pendingProps=null,e.stateNode=null,e.updateQueue=null}var se=null,Xe=!1;function $t(e,t,l){for(l=l.child;l!==null;)Fx(e,t,l),l=l.sibling}function Fx(e,t,l){if(Fe&&typeof Fe.onCommitFiberUnmount=="function")try{Fe.onCommitFiberUnmount(Aa,l)}catch{}switch(l.tag){case 26:he||pt(l,t),$t(e,t,l),l.memoizedState?l.memoizedState.count--:l.stateNode&&(l=l.stateNode,l.parentNode.removeChild(l));break;case 27:he||pt(l,t);var n=se,a=Xe;pl(l.type)&&(se=l.stateNode,Xe=!1),$t(e,t,l),ya(l.stateNode),se=n,Xe=a;break;case 5:he||pt(l,t);case 6:if(n=se,a=Xe,se=null,$t(e,t,l),se=n,Xe=a,se!==null)if(Xe)try{(se.nodeType===9?se.body:se.nodeName==="HTML"?se.ownerDocument.body:se).removeChild(l.stateNode)}catch(u){F(l,t,u)}else try{se.removeChild(l.stateNode)}catch(u){F(l,t,u)}break;case 18:se!==null&&(Xe?(e=se,sr(e.nodeType===9?e.body:e.nodeName==="HTML"?e.ownerDocument.body:e,l.stateNode),An(e)):sr(se,l.stateNode));break;case 4:n=se,a=Xe,se=l.stateNode.containerInfo,Xe=!0,$t(e,t,l),se=n,Xe=a;break;case 0:case 11:case 14:case 15:vl(2,l,t),he||vl(4,l,t),$t(e,t,l);break;case 1:he||(pt(l,t),n=l.stateNode,typeof n.componentWillUnmount=="function"&&Yx(l,t,n)),$t(e,t,l);break;case 21:$t(e,t,l);break;case 22:he=(n=he)||l.memoizedState!==null,$t(e,t,l),he=n;break;default:$t(e,t,l)}}function Ix(e,t){if(t.memoizedState===null&&(e=t.alternate,e!==null&&(e=e.memoizedState,e!==null))){e=e.dehydrated;try{An(e)}catch(l){F(t,t.return,l)}}}function Px(e,t){if(t.memoizedState===null&&(e=t.alternate,e!==null&&(e=e.memoizedState,e!==null&&(e=e.dehydrated,e!==null))))try{An(e)}catch(l){F(t,t.return,l)}}function Nm(e){switch(e.tag){case 31:case 13:case 19:var t=e.stateNode;return t===null&&(t=e.stateNode=new Jo),t;case 22:return e=e.stateNode,t=e._retryCache,t===null&&(t=e._retryCache=new Jo),t;default:throw Error(j(435,e.tag))}}function tu(e,t){var l=Nm(e);t.forEach(function(n){if(!l.has(n)){l.add(n);var a=Xm.bind(null,e,n);n.then(a,a)}})}function He(e,t){var l=t.deletions;if(l!==null)for(var n=0;n<l.length;n++){var a=l[n],u=e,i=t,c=i;e:for(;c!==null;){switch(c.tag){case 27:if(pl(c.type)){se=c.stateNode,Xe=!1;break e}break;case 5:se=c.stateNode,Xe=!1;break e;case 3:case 4:se=c.stateNode.containerInfo,Xe=!0;break e}c=c.return}if(se===null)throw Error(j(160));Fx(u,i,a),se=null,Xe=!1,u=a.alternate,u!==null&&(u.return=null),a.return=null}if(t.subtreeFlags&13886)for(t=t.child;t!==null;)e1(t,e),t=t.sibling}var mt=null;function e1(e,t){var l=e.alternate,n=e.flags;switch(e.tag){case 0:case 11:case 14:case 15:He(t,e),Ue(e),n&4&&(vl(3,e,e.return),Ra(3,e),vl(5,e,e.return));break;case 1:He(t,e),Ue(e),n&512&&(he||l===null||pt(l,l.return)),n&64&&At&&(e=e.updateQueue,e!==null&&(n=e.callbacks,n!==null&&(l=e.shared.hiddenCallbacks,e.shared.hiddenCallbacks=l===null?n:l.concat(n))));break;case 26:var a=mt;if(He(t,e),Ue(e),n&512&&(he||l===null||pt(l,l.return)),n&4){var u=l!==null?l.memoizedState:null;if(n=e.memoizedState,l===null)if(n===null)if(e.stateNode===null){e:{n=e.type,l=e.memoizedProps,a=a.ownerDocument||a;t:switch(n){case"title":u=a.getElementsByTagName("title")[0],(!u||u[Da]||u[we]||u.namespaceURI==="http://www.w3.org/2000/svg"||u.hasAttribute("itemprop"))&&(u=a.createElement(n),a.head.insertBefore(u,a.querySelector("head > title"))),Oe(u,n,l),u[we]=e,ze(u),n=u;break e;case"link":var i=mr("link","href",a).get(n+(l.href||""));if(i){for(var c=0;c<i.length;c++)if(u=i[c],u.getAttribute("href")===(l.href==null||l.href===""?null:l.href)&&u.getAttribute("rel")===(l.rel==null?null:l.rel)&&u.getAttribute("title")===(l.title==null?null:l.title)&&u.getAttribute("crossorigin")===(l.crossOrigin==null?null:l.crossOrigin)){i.splice(c,1);break t}}u=a.createElement(n),Oe(u,n,l),a.head.appendChild(u);break;case"meta":if(i=mr("meta","content",a).get(n+(l.content||""))){for(c=0;c<i.length;c++)if(u=i[c],u.getAttribute("content")===(l.content==null?null:""+l.content)&&u.getAttribute("name")===(l.name==null?null:l.name)&&u.getAttribute("property")===(l.property==null?null:l.property)&&u.getAttribute("http-equiv")===(l.httpEquiv==null?null:l.httpEquiv)&&u.getAttribute("charset")===(l.charSet==null?null:l.charSet)){i.splice(c,1);break t}}u=a.createElement(n),Oe(u,n,l),a.head.appendChild(u);break;default:throw Error(j(468,n))}u[we]=e,ze(u),n=u}e.stateNode=n}else vr(a,e.type,e.stateNode);else e.stateNode=yr(a,n,e.memoizedProps);else u!==n?(u===null?l.stateNode!==null&&(l=l.stateNode,l.parentNode.removeChild(l)):u.count--,n===null?vr(a,e.type,e.stateNode):yr(a,n,e.memoizedProps)):n===null&&e.stateNode!==null&&lc(e,e.memoizedProps,l.memoizedProps)}break;case 27:He(t,e),Ue(e),n&512&&(he||l===null||pt(l,l.return)),l!==null&&n&4&&lc(e,e.memoizedProps,l.memoizedProps);break;case 5:if(He(t,e),Ue(e),n&512&&(he||l===null||pt(l,l.return)),e.flags&32){a=e.stateNode;try{Sn(a,"")}catch(p){F(e,e.return,p)}}n&4&&e.stateNode!=null&&(a=e.memoizedProps,lc(e,a,l!==null?l.memoizedProps:a)),n&1024&&(ac=!0);break;case 6:if(He(t,e),Ue(e),n&4){if(e.stateNode===null)throw Error(j(162));n=e.memoizedProps,l=e.stateNode;try{l.nodeValue=n}catch(p){F(e,e.return,p)}}break;case 3:if(zu=null,a=mt,mt=Iu(t.containerInfo),He(t,e),mt=a,Ue(e),n&4&&l!==null&&l.memoizedState.isDehydrated)try{An(t.containerInfo)}catch(p){F(e,e.return,p)}ac&&(ac=!1,t1(e));break;case 4:n=mt,mt=Iu(e.stateNode.containerInfo),He(t,e),Ue(e),mt=n;break;case 12:He(t,e),Ue(e);break;case 31:He(t,e),Ue(e),n&4&&(n=e.updateQueue,n!==null&&(e.updateQueue=null,tu(e,n)));break;case 13:He(t,e),Ue(e),e.child.flags&8192&&e.memoizedState!==null!=(l!==null&&l.memoizedState!==null)&&(pi=We()),n&4&&(n=e.updateQueue,n!==null&&(e.updateQueue=null,tu(e,n)));break;case 22:a=e.memoizedState!==null;var s=l!==null&&l.memoizedState!==null,o=At,x=he;if(At=o||a,he=x||s,He(t,e),he=x,At=o,Ue(e),n&8192)e:for(t=e.stateNode,t._visibility=a?t._visibility&-2:t._visibility|1,a&&(l===null||s||At||he||Tl(e)),l=null,t=e;;){if(t.tag===5||t.tag===26){if(l===null){s=l=t;try{if(u=s.stateNode,a)i=u.style,typeof i.setProperty=="function"?i.setProperty("display","none","important"):i.display="none";else{c=s.stateNode;var h=s.memoizedProps.style,d=h!=null&&h.hasOwnProperty("display")?h.display:null;c.style.display=d==null||typeof d=="boolean"?"":(""+d).trim()}}catch(p){F(s,s.return,p)}}}else if(t.tag===6){if(l===null){s=t;try{s.stateNode.nodeValue=a?"":s.memoizedProps}catch(p){F(s,s.return,p)}}}else if(t.tag===18){if(l===null){s=t;try{var m=s.stateNode;a?fr(m,!0):fr(s.stateNode,!1)}catch(p){F(s,s.return,p)}}}else if((t.tag!==22&&t.tag!==23||t.memoizedState===null||t===e)&&t.child!==null){t.child.return=t,t=t.child;continue}if(t===e)break e;for(;t.sibling===null;){if(t.return===null||t.return===e)break e;l===t&&(l=null),t=t.return}l===t&&(l=null),t.sibling.return=t.return,t=t.sibling}n&4&&(n=e.updateQueue,n!==null&&(l=n.retryQueue,l!==null&&(n.retryQueue=null,tu(e,l))));break;case 19:He(t,e),Ue(e),n&4&&(n=e.updateQueue,n!==null&&(e.updateQueue=null,tu(e,n)));break;case 30:break;case 21:break;default:He(t,e),Ue(e)}}function Ue(e){var t=e.flags;if(t&2){try{for(var l,n=e.return;n!==null;){if(Qx(n)){l=n;break}n=n.return}if(l==null)throw Error(j(160));switch(l.tag){case 27:var a=l.stateNode,u=nc(e);Zu(e,u,a);break;case 5:var i=l.stateNode;l.flags&32&&(Sn(i,""),l.flags&=-33);var c=nc(e);Zu(e,c,i);break;case 3:case 4:var s=l.stateNode.containerInfo,o=nc(e);cs(e,o,s);break;default:throw Error(j(161))}}catch(x){F(e,e.return,x)}e.flags&=-3}t&4096&&(e.flags&=-4097)}function t1(e){if(e.subtreeFlags&1024)for(e=e.child;e!==null;){var t=e;t1(t),t.tag===5&&t.flags&1024&&t.stateNode.reset(),e=e.sibling}}function Et(e,t){if(t.subtreeFlags&8772)for(t=t.child;t!==null;)Jx(e,t.alternate,t),t=t.sibling}function Tl(e){for(e=e.child;e!==null;){var t=e;switch(t.tag){case 0:case 11:case 14:case 15:vl(4,t,t.return),Tl(t);break;case 1:pt(t,t.return);var l=t.stateNode;typeof l.componentWillUnmount=="function"&&Yx(t,t.return,l),Tl(t);break;case 27:ya(t.stateNode);case 26:case 5:pt(t,t.return),Tl(t);break;case 22:t.memoizedState===null&&Tl(t);break;case 30:Tl(t);break;default:Tl(t)}e=e.sibling}}function Tt(e,t,l){for(l=l&&(t.subtreeFlags&8772)!==0,t=t.child;t!==null;){var n=t.alternate,a=e,u=t,i=u.flags;switch(u.tag){case 0:case 11:case 15:Tt(a,u,l),Ra(4,u);break;case 1:if(Tt(a,u,l),n=u,a=n.stateNode,typeof a.componentDidMount=="function")try{a.componentDidMount()}catch(o){F(n,n.return,o)}if(n=u,a=n.updateQueue,a!==null){var c=n.stateNode;try{var s=a.shared.hiddenCallbacks;if(s!==null)for(a.shared.hiddenCallbacks=null,a=0;a<s.length;a++)Id(s[a],c)}catch(o){F(n,n.return,o)}}l&&i&64&&Zx(u),oa(u,u.return);break;case 27:Kx(u);case 26:case 5:Tt(a,u,l),l&&n===null&&i&4&&Vx(u),oa(u,u.return);break;case 12:Tt(a,u,l);break;case 31:Tt(a,u,l),l&&i&4&&Ix(a,u);break;case 13:Tt(a,u,l),l&&i&4&&Px(a,u);break;case 22:u.memoizedState===null&&Tt(a,u,l),oa(u,u.return);break;case 30:break;default:Tt(a,u,l)}t=t.sibling}}function bf(e,t){var l=null;e!==null&&e.memoizedState!==null&&e.memoizedState.cachePool!==null&&(l=e.memoizedState.cachePool.pool),e=null,t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(e=t.memoizedState.cachePool.pool),e!==l&&(e!=null&&e.refCount++,l!=null&&Ca(l))}function kf(e,t){e=null,t.alternate!==null&&(e=t.alternate.memoizedState.cache),t=t.memoizedState.cache,t!==e&&(t.refCount++,e!=null&&Ca(e))}function xt(e,t,l,n){if(t.subtreeFlags&10256)for(t=t.child;t!==null;)l1(e,t,l,n),t=t.sibling}function l1(e,t,l,n){var a=t.flags;switch(t.tag){case 0:case 11:case 15:xt(e,t,l,n),a&2048&&Ra(9,t);break;case 1:xt(e,t,l,n);break;case 3:xt(e,t,l,n),a&2048&&(e=null,t.alternate!==null&&(e=t.alternate.memoizedState.cache),t=t.memoizedState.cache,t!==e&&(t.refCount++,e!=null&&Ca(e)));break;case 12:if(a&2048){xt(e,t,l,n),e=t.stateNode;try{var u=t.memoizedProps,i=u.id,c=u.onPostCommit;typeof c=="function"&&c(i,t.alternate===null?"mount":"update",e.passiveEffectDuration,-0)}catch(s){F(t,t.return,s)}}else xt(e,t,l,n);break;case 31:xt(e,t,l,n);break;case 13:xt(e,t,l,n);break;case 23:break;case 22:u=t.stateNode,i=t.alternate,t.memoizedState!==null?u._visibility&2?xt(e,t,l,n):ra(e,t):u._visibility&2?xt(e,t,l,n):(u._visibility|=2,Wl(e,t,l,n,(t.subtreeFlags&10256)!==0||!1)),a&2048&&bf(i,t);break;case 24:xt(e,t,l,n),a&2048&&kf(t.alternate,t);break;default:xt(e,t,l,n)}}function Wl(e,t,l,n,a){for(a=a&&((t.subtreeFlags&10256)!==0||!1),t=t.child;t!==null;){var u=e,i=t,c=l,s=n,o=i.flags;switch(i.tag){case 0:case 11:case 15:Wl(u,i,c,s,a),Ra(8,i);break;case 23:break;case 22:var x=i.stateNode;i.memoizedState!==null?x._visibility&2?Wl(u,i,c,s,a):ra(u,i):(x._visibility|=2,Wl(u,i,c,s,a)),a&&o&2048&&bf(i.alternate,i);break;case 24:Wl(u,i,c,s,a),a&&o&2048&&kf(i.alternate,i);break;default:Wl(u,i,c,s,a)}t=t.sibling}}function ra(e,t){if(t.subtreeFlags&10256)for(t=t.child;t!==null;){var l=e,n=t,a=n.flags;switch(n.tag){case 22:ra(l,n),a&2048&&bf(n.alternate,n);break;case 24:ra(l,n),a&2048&&kf(n.alternate,n);break;default:ra(l,n)}t=t.sibling}}var Pn=8192;function Yl(e,t,l){if(e.subtreeFlags&Pn)for(e=e.child;e!==null;)n1(e,t,l),e=e.sibling}function n1(e,t,l){switch(e.tag){case 26:Yl(e,t,l),e.flags&Pn&&e.memoizedState!==null&&hv(l,mt,e.memoizedState,e.memoizedProps);break;case 5:Yl(e,t,l);break;case 3:case 4:var n=mt;mt=Iu(e.stateNode.containerInfo),Yl(e,t,l),mt=n;break;case 22:e.memoizedState===null&&(n=e.alternate,n!==null&&n.memoizedState!==null?(n=Pn,Pn=16777216,Yl(e,t,l),Pn=n):Yl(e,t,l));break;default:Yl(e,t,l)}}function a1(e){var t=e.alternate;if(t!==null&&(e=t.child,e!==null)){t.child=null;do t=e.sibling,e.sibling=null,e=t;while(e!==null)}}function Yn(e){var t=e.deletions;if(e.flags&16){if(t!==null)for(var l=0;l<t.length;l++){var n=t[l];Se=n,i1(n,e)}a1(e)}if(e.subtreeFlags&10256)for(e=e.child;e!==null;)u1(e),e=e.sibling}function u1(e){switch(e.tag){case 0:case 11:case 15:Yn(e),e.flags&2048&&vl(9,e,e.return);break;case 3:Yn(e);break;case 12:Yn(e);break;case 22:var t=e.stateNode;e.memoizedState!==null&&t._visibility&2&&(e.return===null||e.return.tag!==13)?(t._visibility&=-3,ku(e)):Yn(e);break;default:Yn(e)}}function ku(e){var t=e.deletions;if(e.flags&16){if(t!==null)for(var l=0;l<t.length;l++){var n=t[l];Se=n,i1(n,e)}a1(e)}for(e=e.child;e!==null;){switch(t=e,t.tag){case 0:case 11:case 15:vl(8,t,t.return),ku(t);break;case 22:l=t.stateNode,l._visibility&2&&(l._visibility&=-3,ku(t));break;default:ku(t)}e=e.sibling}}function i1(e,t){for(;Se!==null;){var l=Se;switch(l.tag){case 0:case 11:case 15:vl(8,l,t);break;case 23:case 22:if(l.memoizedState!==null&&l.memoizedState.cachePool!==null){var n=l.memoizedState.cachePool.pool;n!=null&&n.refCount++}break;case 24:Ca(l.memoizedState.cache)}if(n=l.child,n!==null)n.return=l,Se=n;else e:for(l=e;Se!==null;){n=Se;var a=n.sibling,u=n.return;if(Wx(n),n===l){Se=null;break e}if(a!==null){a.return=u,Se=a;break e}Se=u}}}var Om={getCacheForType:function(e){var t=Ne(ge),l=t.data.get(e);return l===void 0&&(l=e(),t.data.set(e,l)),l},cacheSignal:function(){return Ne(ge).controller.signal}},Dm=typeof WeakMap=="function"?WeakMap:Map,Q=0,te=null,X=null,B=0,W=0,Ve=null,ll=!1,_n=!1,Sf=!1,Bt=0,re=0,hl=0,Ol=0,zf=0,Je=0,En=0,da=null,Be=null,ss=!1,pi=0,c1=0,Yu=1/0,Vu=null,fl=null,be=0,ol=null,Tn=null,_t=0,fs=0,os=null,s1=null,xa=0,rs=null;function Pe(){return Q&2&&B!==0?B&-B:C.T!==null?$f():hd()}function f1(){if(Je===0)if(!(B&536870912)||L){var e=Qa;Qa<<=1,!(Qa&3932160)&&(Qa=262144),Je=e}else Je=536870912;return e=tt.current,e!==null&&(e.flags|=32),Je}function Le(e,t,l){(e===te&&(W===2||W===9)||e.cancelPendingCommit!==null)&&(Mn(e,0),nl(e,B,Je,!1)),Oa(e,l),(!(Q&2)||e!==te)&&(e===te&&(!(Q&2)&&(Ol|=l),re===4&&nl(e,B,Je,!1)),St(e))}function o1(e,t,l){if(Q&6)throw Error(j(327));var n=!l&&(t&127)===0&&(t&e.expiredLanes)===0||Na(e,t),a=n?_m(e,t):uc(e,t,!0),u=n;do{if(a===0){_n&&!n&&nl(e,t,0,!1);break}else{if(l=e.current.alternate,u&&!qm(l)){a=uc(e,t,!1),u=!1;continue}if(a===2){if(u=t,e.errorRecoveryDisabledLanes&u)var i=0;else i=e.pendingLanes&-536870913,i=i!==0?i:i&536870912?536870912:0;if(i!==0){t=i;e:{var c=e;a=da;var s=c.current.memoizedState.isDehydrated;if(s&&(Mn(c,i).flags|=256),i=uc(c,i,!1),i!==2){if(Sf&&!s){c.errorRecoveryDisabledLanes|=u,Ol|=u,a=4;break e}u=Be,Be=a,u!==null&&(Be===null?Be=u:Be.push.apply(Be,u))}a=i}if(u=!1,a!==2)continue}}if(a===1){Mn(e,0),nl(e,t,0,!0);break}e:{switch(n=e,u=a,u){case 0:case 1:throw Error(j(345));case 4:if((t&4194048)!==t)break;case 6:nl(n,t,Je,!ll);break e;case 2:Be=null;break;case 3:case 5:break;default:throw Error(j(329))}if((t&62914560)===t&&(a=pi+300-We(),10<a)){if(nl(n,t,Je,!ll),si(n,0,!0)!==0)break e;_t=t,n.timeoutHandle=A1(Wo.bind(null,n,l,Be,Vu,ss,t,Je,Ol,En,ll,u,"Throttled",-0,0),a);break e}Wo(n,l,Be,Vu,ss,t,Je,Ol,En,ll,u,null,-0,0)}}break}while(!0);St(e)}function Wo(e,t,l,n,a,u,i,c,s,o,x,h,d,m){if(e.timeoutHandle=-1,h=t.subtreeFlags,h&8192||(h&16785408)===16785408){h={stylesheets:null,count:0,imgCount:0,imgBytes:0,suspenseyImages:[],waitingForImages:!0,waitingForViewTransition:!1,unsuspend:Ot},n1(t,u,h);var p=(u&62914560)===u?pi-We():(u&4194048)===u?c1-We():0;if(p=gv(h,p),p!==null){_t=u,e.cancelPendingCommit=p(Io.bind(null,e,t,u,l,n,a,i,c,s,x,h,null,d,m)),nl(e,u,i,!o);return}}Io(e,t,u,l,n,a,i,c,s)}function qm(e){for(var t=e;;){var l=t.tag;if((l===0||l===11||l===15)&&t.flags&16384&&(l=t.updateQueue,l!==null&&(l=l.stores,l!==null)))for(var n=0;n<l.length;n++){var a=l[n],u=a.getSnapshot;a=a.value;try{if(!et(u(),a))return!1}catch{return!1}}if(l=t.child,t.subtreeFlags&16384&&l!==null)l.return=t,t=l;else{if(t===e)break;for(;t.sibling===null;){if(t.return===null||t.return===e)return!0;t=t.return}t.sibling.return=t.return,t=t.sibling}}return!0}function nl(e,t,l,n){t&=~zf,t&=~Ol,e.suspendedLanes|=t,e.pingedLanes&=~t,n&&(e.warmLanes|=t),n=e.expirationTimes;for(var a=t;0<a;){var u=31-Ie(a),i=1<<u;n[u]=-1,a&=~i}l!==0&&yd(e,l,t)}function bi(){return Q&6?!0:(Ha(0),!1)}function jf(){if(X!==null){if(W===0)var e=X.return;else e=X,Dt=Ll=null,ff(e),hn=null,ka=0,e=X;for(;e!==null;)Gx(e.alternate,e),e=e.return;X=null}}function Mn(e,t){var l=e.timeoutHandle;l!==-1&&(e.timeoutHandle=-1,ev(l)),l=e.cancelPendingCommit,l!==null&&(e.cancelPendingCommit=null,l()),_t=0,jf(),te=e,X=l=qt(e.current,null),B=t,W=0,Ve=null,ll=!1,_n=Na(e,t),Sf=!1,En=Je=zf=Ol=hl=re=0,Be=da=null,ss=!1,t&8&&(t|=t&32);var n=e.entangledLanes;if(n!==0)for(e=e.entanglements,n&=t;0<n;){var a=31-Ie(n),u=1<<a;t|=e[a],n&=~u}return Bt=t,di(),l}function r1(e,t){H=null,C.H=za,t===Cn||t===yi?(t=Mo(),W=3):t===tf?(t=Mo(),W=4):W=t===gf?8:t!==null&&typeof t=="object"&&typeof t.then=="function"?6:1,Ve=t,X===null&&(re=1,Lu(e,ct(t,e.current)))}function d1(){var e=tt.current;return e===null?!0:(B&4194048)===B?ft===null:(B&62914560)===B||B&536870912?e===ft:!1}function x1(){var e=C.H;return C.H=za,e===null?za:e}function y1(){var e=C.A;return C.A=Om,e}function Qu(){re=4,ll||(B&4194048)!==B&&tt.current!==null||(_n=!0),!(hl&134217727)&&!(Ol&134217727)||te===null||nl(te,B,Je,!1)}function uc(e,t,l){var n=Q;Q|=2;var a=x1(),u=y1();(te!==e||B!==t)&&(Vu=null,Mn(e,t)),t=!1;var i=re;e:do try{if(W!==0&&X!==null){var c=X,s=Ve;switch(W){case 8:jf(),i=6;break e;case 3:case 2:case 9:case 6:tt.current===null&&(t=!0);var o=W;if(W=0,Ve=null,rn(e,c,s,o),l&&_n){i=0;break e}break;default:o=W,W=0,Ve=null,rn(e,c,s,o)}}Cm(),i=re;break}catch(x){r1(e,x)}while(!0);return t&&e.shellSuspendCounter++,Dt=Ll=null,Q=n,C.H=a,C.A=u,X===null&&(te=null,B=0,di()),i}function Cm(){for(;X!==null;)m1(X)}function _m(e,t){var l=Q;Q|=2;var n=x1(),a=y1();te!==e||B!==t?(Vu=null,Yu=We()+500,Mn(e,t)):_n=Na(e,t);e:do try{if(W!==0&&X!==null){t=X;var u=Ve;t:switch(W){case 1:W=0,Ve=null,rn(e,t,u,1);break;case 2:case 9:if(To(u)){W=0,Ve=null,Fo(t);break}t=function(){W!==2&&W!==9||te!==e||(W=7),St(e)},u.then(t,t);break e;case 3:W=7;break e;case 4:W=5;break e;case 7:To(u)?(W=0,Ve=null,Fo(t)):(W=0,Ve=null,rn(e,t,u,7));break;case 5:var i=null;switch(X.tag){case 26:i=X.memoizedState;case 5:case 27:var c=X;if(i?C1(i):c.stateNode.complete){W=0,Ve=null;var s=c.sibling;if(s!==null)X=s;else{var o=c.return;o!==null?(X=o,ki(o)):X=null}break t}}W=0,Ve=null,rn(e,t,u,5);break;case 6:W=0,Ve=null,rn(e,t,u,6);break;case 8:jf(),re=6;break e;default:throw Error(j(462))}}Rm();break}catch(x){r1(e,x)}while(!0);return Dt=Ll=null,C.H=n,C.A=a,Q=l,X!==null?0:(te=null,B=0,di(),re)}function Rm(){for(;X!==null&&!iy();)m1(X)}function m1(e){var t=Lx(e.alternate,e,Bt);e.memoizedProps=e.pendingProps,t===null?ki(e):X=t}function Fo(e){var t=e,l=t.alternate;switch(t.tag){case 15:case 0:t=Zo(l,t,t.pendingProps,t.type,void 0,B);break;case 11:t=Zo(l,t,t.pendingProps,t.type.render,t.ref,B);break;case 5:ff(t);default:Gx(l,t),t=X=Gd(t,Bt),t=Lx(l,t,Bt)}e.memoizedProps=e.pendingProps,t===null?ki(e):X=t}function rn(e,t,l,n){Dt=Ll=null,ff(t),hn=null,ka=0;var a=t.return;try{if($m(e,a,t,l,B)){re=1,Lu(e,ct(l,e.current)),X=null;return}}catch(u){if(a!==null)throw X=a,u;re=1,Lu(e,ct(l,e.current)),X=null;return}t.flags&32768?(L||n===1?e=!0:_n||B&536870912?e=!1:(ll=e=!0,(n===2||n===9||n===3||n===6)&&(n=tt.current,n!==null&&n.tag===13&&(n.flags|=16384))),v1(t,e)):ki(t)}function ki(e){var t=e;do{if(t.flags&32768){v1(t,ll);return}e=t.return;var l=Mm(t.alternate,t,Bt);if(l!==null){X=l;return}if(t=t.sibling,t!==null){X=t;return}X=t=e}while(t!==null);re===0&&(re=5)}function v1(e,t){do{var l=wm(e.alternate,e);if(l!==null){l.flags&=32767,X=l;return}if(l=e.return,l!==null&&(l.flags|=32768,l.subtreeFlags=0,l.deletions=null),!t&&(e=e.sibling,e!==null)){X=e;return}X=e=l}while(e!==null);re=6,X=null}function Io(e,t,l,n,a,u,i,c,s){e.cancelPendingCommit=null;do Si();while(be!==0);if(Q&6)throw Error(j(327));if(t!==null){if(t===e.current)throw Error(j(177));if(u=t.lanes|t.childLanes,u|=Ks,vy(e,l,u,i,c,s),e===te&&(X=te=null,B=0),Tn=t,ol=e,_t=l,fs=u,os=a,s1=n,t.subtreeFlags&10256||t.flags&10256?(e.callbackNode=null,e.callbackPriority=0,Bm(Nu,function(){return k1(),null})):(e.callbackNode=null,e.callbackPriority=0),n=(t.flags&13878)!==0,t.subtreeFlags&13878||n){n=C.T,C.T=null,a=K.p,K.p=2,i=Q,Q|=4;try{Am(e,t,l)}finally{Q=i,K.p=a,C.T=n}}be=1,h1(),g1(),p1()}}function h1(){if(be===1){be=0;var e=ol,t=Tn,l=(t.flags&13878)!==0;if(t.subtreeFlags&13878||l){l=C.T,C.T=null;var n=K.p;K.p=2;var a=Q;Q|=4;try{e1(t,e);var u=ms,i=Cd(e.containerInfo),c=u.focusedElem,s=u.selectionRange;if(i!==c&&c&&c.ownerDocument&&qd(c.ownerDocument.documentElement,c)){if(s!==null&&Qs(c)){var o=s.start,x=s.end;if(x===void 0&&(x=o),"selectionStart"in c)c.selectionStart=o,c.selectionEnd=Math.min(x,c.value.length);else{var h=c.ownerDocument||document,d=h&&h.defaultView||window;if(d.getSelection){var m=d.getSelection(),p=c.textContent.length,k=Math.min(s.start,p),S=s.end===void 0?k:Math.min(s.end,p);!m.extend&&k>S&&(i=S,S=k,k=i);var y=bo(c,k),r=bo(c,S);if(y&&r&&(m.rangeCount!==1||m.anchorNode!==y.node||m.anchorOffset!==y.offset||m.focusNode!==r.node||m.focusOffset!==r.offset)){var v=h.createRange();v.setStart(y.node,y.offset),m.removeAllRanges(),k>S?(m.addRange(v),m.extend(r.node,r.offset)):(v.setEnd(r.node,r.offset),m.addRange(v))}}}}for(h=[],m=c;m=m.parentNode;)m.nodeType===1&&h.push({element:m,left:m.scrollLeft,top:m.scrollTop});for(typeof c.focus=="function"&&c.focus(),c=0;c<h.length;c++){var b=h[c];b.element.scrollLeft=b.left,b.element.scrollTop=b.top}}ti=!!ys,ms=ys=null}finally{Q=a,K.p=n,C.T=l}}e.current=t,be=2}}function g1(){if(be===2){be=0;var e=ol,t=Tn,l=(t.flags&8772)!==0;if(t.subtreeFlags&8772||l){l=C.T,C.T=null;var n=K.p;K.p=2;var a=Q;Q|=4;try{Jx(e,t.alternate,t)}finally{Q=a,K.p=n,C.T=l}}be=3}}function p1(){if(be===4||be===3){be=0,cy();var e=ol,t=Tn,l=_t,n=s1;t.subtreeFlags&10256||t.flags&10256?be=5:(be=0,Tn=ol=null,b1(e,e.pendingLanes));var a=e.pendingLanes;if(a===0&&(fl=null),Xs(l),t=t.stateNode,Fe&&typeof Fe.onCommitFiberRoot=="function")try{Fe.onCommitFiberRoot(Aa,t,void 0,(t.current.flags&128)===128)}catch{}if(n!==null){t=C.T,a=K.p,K.p=2,C.T=null;try{for(var u=e.onRecoverableError,i=0;i<n.length;i++){var c=n[i];u(c.value,{componentStack:c.stack})}}finally{C.T=t,K.p=a}}_t&3&&Si(),St(e),a=e.pendingLanes,l&261930&&a&42?e===rs?xa++:(xa=0,rs=e):xa=0,Ha(0)}}function b1(e,t){(e.pooledCacheLanes&=t)===0&&(t=e.pooledCache,t!=null&&(e.pooledCache=null,Ca(t)))}function Si(){return h1(),g1(),p1(),k1()}function k1(){if(be!==5)return!1;var e=ol,t=fs;fs=0;var l=Xs(_t),n=C.T,a=K.p;try{K.p=32>l?32:l,C.T=null,l=os,os=null;var u=ol,i=_t;if(be=0,Tn=ol=null,_t=0,Q&6)throw Error(j(331));var c=Q;if(Q|=4,u1(u.current),l1(u,u.current,i,l),Q=c,Ha(0,!1),Fe&&typeof Fe.onPostCommitFiberRoot=="function")try{Fe.onPostCommitFiberRoot(Aa,u)}catch{}return!0}finally{K.p=a,C.T=n,b1(e,t)}}function Po(e,t,l){t=ct(l,t),t=as(e.stateNode,t,2),e=sl(e,t,2),e!==null&&(Oa(e,2),St(e))}function F(e,t,l){if(e.tag===3)Po(e,e,l);else for(;t!==null;){if(t.tag===3){Po(t,e,l);break}else if(t.tag===1){var n=t.stateNode;if(typeof t.type.getDerivedStateFromError=="function"||typeof n.componentDidCatch=="function"&&(fl===null||!fl.has(n))){e=ct(l,e),l=_x(2),n=sl(t,l,2),n!==null&&(Rx(l,n,t,e),Oa(n,2),St(n));break}}t=t.return}}function ic(e,t,l){var n=e.pingCache;if(n===null){n=e.pingCache=new Dm;var a=new Set;n.set(t,a)}else a=n.get(t),a===void 0&&(a=new Set,n.set(t,a));a.has(l)||(Sf=!0,a.add(l),e=Hm.bind(null,e,t,l),t.then(e,e))}function Hm(e,t,l){var n=e.pingCache;n!==null&&n.delete(t),e.pingedLanes|=e.suspendedLanes&l,e.warmLanes&=~l,te===e&&(B&l)===l&&(re===4||re===3&&(B&62914560)===B&&300>We()-pi?!(Q&2)&&Mn(e,0):zf|=l,En===B&&(En=0)),St(e)}function S1(e,t){t===0&&(t=xd()),e=Bl(e,t),e!==null&&(Oa(e,t),St(e))}function Um(e){var t=e.memoizedState,l=0;t!==null&&(l=t.retryLane),S1(e,l)}function Xm(e,t){var l=0;switch(e.tag){case 31:case 13:var n=e.stateNode,a=e.memoizedState;a!==null&&(l=a.retryLane);break;case 19:n=e.stateNode;break;case 22:n=e.stateNode._retryCache;break;default:throw Error(j(314))}n!==null&&n.delete(t),S1(e,l)}function Bm(e,t){return Hs(e,t)}var Ku=null,Fl=null,ds=!1,Ju=!1,cc=!1,al=0;function St(e){e!==Fl&&e.next===null&&(Fl===null?Ku=Fl=e:Fl=Fl.next=e),Ju=!0,ds||(ds=!0,Gm())}function Ha(e,t){if(!cc&&Ju){cc=!0;do for(var l=!1,n=Ku;n!==null;){if(e!==0){var a=n.pendingLanes;if(a===0)var u=0;else{var i=n.suspendedLanes,c=n.pingedLanes;u=(1<<31-Ie(42|e)+1)-1,u&=a&~(i&~c),u=u&201326741?u&201326741|1:u?u|2:0}u!==0&&(l=!0,er(n,u))}else u=B,u=si(n,n===te?u:0,n.cancelPendingCommit!==null||n.timeoutHandle!==-1),!(u&3)||Na(n,u)||(l=!0,er(n,u));n=n.next}while(l);cc=!1}}function Lm(){z1()}function z1(){Ju=ds=!1;var e=0;al!==0&&Pm()&&(e=al);for(var t=We(),l=null,n=Ku;n!==null;){var a=n.next,u=j1(n,t);u===0?(n.next=null,l===null?Ku=a:l.next=a,a===null&&(Fl=l)):(l=n,(e!==0||u&3)&&(Ju=!0)),n=a}be!==0&&be!==5||Ha(e),al!==0&&(al=0)}function j1(e,t){for(var l=e.suspendedLanes,n=e.pingedLanes,a=e.expirationTimes,u=e.pendingLanes&-62914561;0<u;){var i=31-Ie(u),c=1<<i,s=a[i];s===-1?(!(c&l)||c&n)&&(a[i]=my(c,t)):s<=t&&(e.expiredLanes|=c),u&=~c}if(t=te,l=B,l=si(e,e===t?l:0,e.cancelPendingCommit!==null||e.timeoutHandle!==-1),n=e.callbackNode,l===0||e===t&&(W===2||W===9)||e.cancelPendingCommit!==null)return n!==null&&n!==null&&Ci(n),e.callbackNode=null,e.callbackPriority=0;if(!(l&3)||Na(e,l)){if(t=l&-l,t===e.callbackPriority)return t;switch(n!==null&&Ci(n),Xs(l)){case 2:case 8:l=rd;break;case 32:l=Nu;break;case 268435456:l=dd;break;default:l=Nu}return n=$1.bind(null,e),l=Hs(l,n),e.callbackPriority=t,e.callbackNode=l,t}return n!==null&&n!==null&&Ci(n),e.callbackPriority=2,e.callbackNode=null,2}function $1(e,t){if(be!==0&&be!==5)return e.callbackNode=null,e.callbackPriority=0,null;var l=e.callbackNode;if(Si()&&e.callbackNode!==l)return null;var n=B;return n=si(e,e===te?n:0,e.cancelPendingCommit!==null||e.timeoutHandle!==-1),n===0?null:(o1(e,n,t),j1(e,We()),e.callbackNode!=null&&e.callbackNode===l?$1.bind(null,e):null)}function er(e,t){if(Si())return null;o1(e,t,!0)}function Gm(){tv(function(){Q&6?Hs(od,Lm):z1()})}function $f(){if(al===0){var e=zn;e===0&&(e=Va,Va<<=1,!(Va&261888)&&(Va=256)),al=e}return al}function tr(e){return e==null||typeof e=="symbol"||typeof e=="boolean"?null:typeof e=="function"?e:du(""+e)}function lr(e,t){var l=t.ownerDocument.createElement("input");return l.name=t.name,l.value=t.value,e.id&&l.setAttribute("form",e.id),t.parentNode.insertBefore(l,t),e=new FormData(e),l.parentNode.removeChild(l),e}function Zm(e,t,l,n,a){if(t==="submit"&&l&&l.stateNode===a){var u=tr((a[Ge]||null).action),i=n.submitter;i&&(t=(t=i[Ge]||null)?tr(t.formAction):i.getAttribute("formAction"),t!==null&&(u=t,i=null));var c=new fi("action","action",null,n,a);e.push({event:c,listeners:[{instance:null,listener:function(){if(n.defaultPrevented){if(al!==0){var s=i?lr(a,i):new FormData(a);ls(l,{pending:!0,data:s,method:a.method,action:u},null,s)}}else typeof u=="function"&&(c.preventDefault(),s=i?lr(a,i):new FormData(a),ls(l,{pending:!0,data:s,method:a.method,action:u},u,s))},currentTarget:a}]})}}for(var sc=0;sc<Zc.length;sc++){var fc=Zc[sc],Ym=fc.toLowerCase(),Vm=fc[0].toUpperCase()+fc.slice(1);vt(Ym,"on"+Vm)}vt(Rd,"onAnimationEnd");vt(Hd,"onAnimationIteration");vt(Ud,"onAnimationStart");vt("dblclick","onDoubleClick");vt("focusin","onFocus");vt("focusout","onBlur");vt(sm,"onTransitionRun");vt(fm,"onTransitionStart");vt(om,"onTransitionCancel");vt(Xd,"onTransitionEnd");kn("onMouseEnter",["mouseout","mouseover"]);kn("onMouseLeave",["mouseout","mouseover"]);kn("onPointerEnter",["pointerout","pointerover"]);kn("onPointerLeave",["pointerout","pointerover"]);Hl("onChange","change click focusin focusout input keydown keyup selectionchange".split(" "));Hl("onSelect","focusout contextmenu dragend focusin keydown keyup mousedown mouseup selectionchange".split(" "));Hl("onBeforeInput",["compositionend","keypress","textInput","paste"]);Hl("onCompositionEnd","compositionend focusout keydown keypress keyup mousedown".split(" "));Hl("onCompositionStart","compositionstart focusout keydown keypress keyup mousedown".split(" "));Hl("onCompositionUpdate","compositionupdate focusout keydown keypress keyup mousedown".split(" "));var ja="abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting".split(" "),Qm=new Set("beforetoggle cancel close invalid load scroll scrollend toggle".split(" ").concat(ja));function E1(e,t){t=(t&4)!==0;for(var l=0;l<e.length;l++){var n=e[l],a=n.event;n=n.listeners;e:{var u=void 0;if(t)for(var i=n.length-1;0<=i;i--){var c=n[i],s=c.instance,o=c.currentTarget;if(c=c.listener,s!==u&&a.isPropagationStopped())break e;u=c,a.currentTarget=o;try{u(a)}catch(x){Du(x)}a.currentTarget=null,u=s}else for(i=0;i<n.length;i++){if(c=n[i],s=c.instance,o=c.currentTarget,c=c.listener,s!==u&&a.isPropagationStopped())break e;u=c,a.currentTarget=o;try{u(a)}catch(x){Du(x)}a.currentTarget=null,u=s}}}}function U(e,t){var l=t[_c];l===void 0&&(l=t[_c]=new Set);var n=e+"__bubble";l.has(n)||(T1(t,e,2,!1),l.add(n))}function oc(e,t,l){var n=0;t&&(n|=4),T1(l,e,n,t)}var lu="_reactListening"+Math.random().toString(36).slice(2);function Ef(e){if(!e[lu]){e[lu]=!0,gd.forEach(function(l){l!=="selectionchange"&&(Qm.has(l)||oc(l,!1,e),oc(l,!0,e))});var t=e.nodeType===9?e:e.ownerDocument;t===null||t[lu]||(t[lu]=!0,oc("selectionchange",!1,t))}}function T1(e,t,l,n){switch(X1(t)){case 2:var a=kv;break;case 8:a=Sv;break;default:a=Af}l=a.bind(null,t,l,e),a=void 0,!Bc||t!=="touchstart"&&t!=="touchmove"&&t!=="wheel"||(a=!0),n?a!==void 0?e.addEventListener(t,l,{capture:!0,passive:a}):e.addEventListener(t,l,!0):a!==void 0?e.addEventListener(t,l,{passive:a}):e.addEventListener(t,l,!1)}function rc(e,t,l,n,a){var u=n;if(!(t&1)&&!(t&2)&&n!==null)e:for(;;){if(n===null)return;var i=n.tag;if(i===3||i===4){var c=n.stateNode.containerInfo;if(c===a)break;if(i===4)for(i=n.return;i!==null;){var s=i.tag;if((s===3||s===4)&&i.stateNode.containerInfo===a)return;i=i.return}for(;c!==null;){if(i=tn(c),i===null)return;if(s=i.tag,s===5||s===6||s===26||s===27){n=u=i;continue e}c=c.parentNode}}n=n.return}Ed(function(){var o=u,x=Gs(l),h=[];e:{var d=Bd.get(e);if(d!==void 0){var m=fi,p=e;switch(e){case"keypress":if(yu(l)===0)break e;case"keydown":case"keyup":m=Xy;break;case"focusin":p="focus",m=Xi;break;case"focusout":p="blur",m=Xi;break;case"beforeblur":case"afterblur":m=Xi;break;case"click":if(l.button===2)break e;case"auxclick":case"dblclick":case"mousedown":case"mousemove":case"mouseup":case"mouseout":case"mouseover":case"contextmenu":m=fo;break;case"drag":case"dragend":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"dragstart":case"drop":m=My;break;case"touchcancel":case"touchend":case"touchmove":case"touchstart":m=Gy;break;case Rd:case Hd:case Ud:m=Ny;break;case Xd:m=Yy;break;case"scroll":case"scrollend":m=Ey;break;case"wheel":m=Qy;break;case"copy":case"cut":case"paste":m=Dy;break;case"gotpointercapture":case"lostpointercapture":case"pointercancel":case"pointerdown":case"pointermove":case"pointerout":case"pointerover":case"pointerup":m=ro;break;case"toggle":case"beforetoggle":m=Jy}var k=(t&4)!==0,S=!k&&(e==="scroll"||e==="scrollend"),y=k?d!==null?d+"Capture":null:d;k=[];for(var r=o,v;r!==null;){var b=r;if(v=b.stateNode,b=b.tag,b!==5&&b!==26&&b!==27||v===null||y===null||(b=va(r,y),b!=null&&k.push($a(r,b,v))),S)break;r=r.return}0<k.length&&(d=new m(d,p,null,l,x),h.push({event:d,listeners:k}))}}if(!(t&7)){e:{if(d=e==="mouseover"||e==="pointerover",m=e==="mouseout"||e==="pointerout",d&&l!==Xc&&(p=l.relatedTarget||l.fromElement)&&(tn(p)||p[On]))break e;if((m||d)&&(d=x.window===x?x:(d=x.ownerDocument)?d.defaultView||d.parentWindow:window,m?(p=l.relatedTarget||l.toElement,m=o,p=p?tn(p):null,p!==null&&(S=wa(p),k=p.tag,p!==S||k!==5&&k!==27&&k!==6)&&(p=null)):(m=null,p=o),m!==p)){if(k=fo,b="onMouseLeave",y="onMouseEnter",r="mouse",(e==="pointerout"||e==="pointerover")&&(k=ro,b="onPointerLeave",y="onPointerEnter",r="pointer"),S=m==null?d:Fn(m),v=p==null?d:Fn(p),d=new k(b,r+"leave",m,l,x),d.target=S,d.relatedTarget=v,b=null,tn(x)===o&&(k=new k(y,r+"enter",p,l,x),k.target=v,k.relatedTarget=S,b=k),S=b,m&&p)t:{for(k=Km,y=m,r=p,v=0,b=y;b;b=k(b))v++;b=0;for(var z=r;z;z=k(z))b++;for(;0<v-b;)y=k(y),v--;for(;0<b-v;)r=k(r),b--;for(;v--;){if(y===r||r!==null&&y===r.alternate){k=y;break t}y=k(y),r=k(r)}k=null}else k=null;m!==null&&nr(h,d,m,k,!1),p!==null&&S!==null&&nr(h,S,p,k,!0)}}e:{if(d=o?Fn(o):window,m=d.nodeName&&d.nodeName.toLowerCase(),m==="select"||m==="input"&&d.type==="file")var w=vo;else if(mo(d))if(Od)w=um;else{w=nm;var $=lm}else m=d.nodeName,!m||m.toLowerCase()!=="input"||d.type!=="checkbox"&&d.type!=="radio"?o&&Ls(o.elementType)&&(w=vo):w=am;if(w&&(w=w(e,o))){Nd(h,w,l,x);break e}$&&$(e,d,o),e==="focusout"&&o&&d.type==="number"&&o.memoizedProps.value!=null&&Uc(d,"number",d.value)}switch($=o?Fn(o):window,e){case"focusin":(mo($)||$.contentEditable==="true")&&(an=$,Lc=o,aa=null);break;case"focusout":aa=Lc=an=null;break;case"mousedown":Gc=!0;break;case"contextmenu":case"mouseup":case"dragend":Gc=!1,ko(h,l,x);break;case"selectionchange":if(cm)break;case"keydown":case"keyup":ko(h,l,x)}var T;if(Vs)e:{switch(e){case"compositionstart":var E="onCompositionStart";break e;case"compositionend":E="onCompositionEnd";break e;case"compositionupdate":E="onCompositionUpdate";break e}E=void 0}else nn?wd(e,l)&&(E="onCompositionEnd"):e==="keydown"&&l.keyCode===229&&(E="onCompositionStart");E&&(Md&&l.locale!=="ko"&&(nn||E!=="onCompositionStart"?E==="onCompositionEnd"&&nn&&(T=Td()):(tl=x,Zs="value"in tl?tl.value:tl.textContent,nn=!0)),$=Wu(o,E),0<$.length&&(E=new oo(E,e,null,l,x),h.push({event:E,listeners:$}),T?E.data=T:(T=Ad(l),T!==null&&(E.data=T)))),(T=Fy?Iy(e,l):Py(e,l))&&(E=Wu(o,"onBeforeInput"),0<E.length&&($=new oo("onBeforeInput","beforeinput",null,l,x),h.push({event:$,listeners:E}),$.data=T)),Zm(h,e,o,l,x)}E1(h,t)})}function $a(e,t,l){return{instance:e,listener:t,currentTarget:l}}function Wu(e,t){for(var l=t+"Capture",n=[];e!==null;){var a=e,u=a.stateNode;if(a=a.tag,a!==5&&a!==26&&a!==27||u===null||(a=va(e,l),a!=null&&n.unshift($a(e,a,u)),a=va(e,t),a!=null&&n.push($a(e,a,u))),e.tag===3)return n;e=e.return}return[]}function Km(e){if(e===null)return null;do e=e.return;while(e&&e.tag!==5&&e.tag!==27);return e||null}function nr(e,t,l,n,a){for(var u=t._reactName,i=[];l!==null&&l!==n;){var c=l,s=c.alternate,o=c.stateNode;if(c=c.tag,s!==null&&s===n)break;c!==5&&c!==26&&c!==27||o===null||(s=o,a?(o=va(l,u),o!=null&&i.unshift($a(l,o,s))):a||(o=va(l,u),o!=null&&i.push($a(l,o,s)))),l=l.return}i.length!==0&&e.push({event:t,listeners:i})}var Jm=/\r\n?/g,Wm=/\u0000|\uFFFD/g;function ar(e){return(typeof e=="string"?e:""+e).replace(Jm,`
+`).replace(Wm,"")}function M1(e,t){return t=ar(t),ar(e)===t}function P(e,t,l,n,a,u){switch(l){case"children":typeof n=="string"?t==="body"||t==="textarea"&&n===""||Sn(e,n):(typeof n=="number"||typeof n=="bigint")&&t!=="body"&&Sn(e,""+n);break;case"className":Ja(e,"class",n);break;case"tabIndex":Ja(e,"tabindex",n);break;case"dir":case"role":case"viewBox":case"width":case"height":Ja(e,l,n);break;case"style":$d(e,n,u);break;case"data":if(t!=="object"){Ja(e,"data",n);break}case"src":case"href":if(n===""&&(t!=="a"||l!=="href")){e.removeAttribute(l);break}if(n==null||typeof n=="function"||typeof n=="symbol"||typeof n=="boolean"){e.removeAttribute(l);break}n=du(""+n),e.setAttribute(l,n);break;case"action":case"formAction":if(typeof n=="function"){e.setAttribute(l,"javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')");break}else typeof u=="function"&&(l==="formAction"?(t!=="input"&&P(e,t,"name",a.name,a,null),P(e,t,"formEncType",a.formEncType,a,null),P(e,t,"formMethod",a.formMethod,a,null),P(e,t,"formTarget",a.formTarget,a,null)):(P(e,t,"encType",a.encType,a,null),P(e,t,"method",a.method,a,null),P(e,t,"target",a.target,a,null)));if(n==null||typeof n=="symbol"||typeof n=="boolean"){e.removeAttribute(l);break}n=du(""+n),e.setAttribute(l,n);break;case"onClick":n!=null&&(e.onclick=Ot);break;case"onScroll":n!=null&&U("scroll",e);break;case"onScrollEnd":n!=null&&U("scrollend",e);break;case"dangerouslySetInnerHTML":if(n!=null){if(typeof n!="object"||!("__html"in n))throw Error(j(61));if(l=n.__html,l!=null){if(a.children!=null)throw Error(j(60));e.innerHTML=l}}break;case"multiple":e.multiple=n&&typeof n!="function"&&typeof n!="symbol";break;case"muted":e.muted=n&&typeof n!="function"&&typeof n!="symbol";break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"defaultValue":case"defaultChecked":case"innerHTML":case"ref":break;case"autoFocus":break;case"xlinkHref":if(n==null||typeof n=="function"||typeof n=="boolean"||typeof n=="symbol"){e.removeAttribute("xlink:href");break}l=du(""+n),e.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",l);break;case"contentEditable":case"spellCheck":case"draggable":case"value":case"autoReverse":case"externalResourcesRequired":case"focusable":case"preserveAlpha":n!=null&&typeof n!="function"&&typeof n!="symbol"?e.setAttribute(l,""+n):e.removeAttribute(l);break;case"inert":case"allowFullScreen":case"async":case"autoPlay":case"controls":case"default":case"defer":case"disabled":case"disablePictureInPicture":case"disableRemotePlayback":case"formNoValidate":case"hidden":case"loop":case"noModule":case"noValidate":case"open":case"playsInline":case"readOnly":case"required":case"reversed":case"scoped":case"seamless":case"itemScope":n&&typeof n!="function"&&typeof n!="symbol"?e.setAttribute(l,""):e.removeAttribute(l);break;case"capture":case"download":n===!0?e.setAttribute(l,""):n!==!1&&n!=null&&typeof n!="function"&&typeof n!="symbol"?e.setAttribute(l,n):e.removeAttribute(l);break;case"cols":case"rows":case"size":case"span":n!=null&&typeof n!="function"&&typeof n!="symbol"&&!isNaN(n)&&1<=n?e.setAttribute(l,n):e.removeAttribute(l);break;case"rowSpan":case"start":n==null||typeof n=="function"||typeof n=="symbol"||isNaN(n)?e.removeAttribute(l):e.setAttribute(l,n);break;case"popover":U("beforetoggle",e),U("toggle",e),ru(e,"popover",n);break;case"xlinkActuate":zt(e,"http://www.w3.org/1999/xlink","xlink:actuate",n);break;case"xlinkArcrole":zt(e,"http://www.w3.org/1999/xlink","xlink:arcrole",n);break;case"xlinkRole":zt(e,"http://www.w3.org/1999/xlink","xlink:role",n);break;case"xlinkShow":zt(e,"http://www.w3.org/1999/xlink","xlink:show",n);break;case"xlinkTitle":zt(e,"http://www.w3.org/1999/xlink","xlink:title",n);break;case"xlinkType":zt(e,"http://www.w3.org/1999/xlink","xlink:type",n);break;case"xmlBase":zt(e,"http://www.w3.org/XML/1998/namespace","xml:base",n);break;case"xmlLang":zt(e,"http://www.w3.org/XML/1998/namespace","xml:lang",n);break;case"xmlSpace":zt(e,"http://www.w3.org/XML/1998/namespace","xml:space",n);break;case"is":ru(e,"is",n);break;case"innerText":case"textContent":break;default:(!(2<l.length)||l[0]!=="o"&&l[0]!=="O"||l[1]!=="n"&&l[1]!=="N")&&(l=jy.get(l)||l,ru(e,l,n))}}function xs(e,t,l,n,a,u){switch(l){case"style":$d(e,n,u);break;case"dangerouslySetInnerHTML":if(n!=null){if(typeof n!="object"||!("__html"in n))throw Error(j(61));if(l=n.__html,l!=null){if(a.children!=null)throw Error(j(60));e.innerHTML=l}}break;case"children":typeof n=="string"?Sn(e,n):(typeof n=="number"||typeof n=="bigint")&&Sn(e,""+n);break;case"onScroll":n!=null&&U("scroll",e);break;case"onScrollEnd":n!=null&&U("scrollend",e);break;case"onClick":n!=null&&(e.onclick=Ot);break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"innerHTML":case"ref":break;case"innerText":case"textContent":break;default:if(!pd.hasOwnProperty(l))e:{if(l[0]==="o"&&l[1]==="n"&&(a=l.endsWith("Capture"),t=l.slice(2,a?l.length-7:void 0),u=e[Ge]||null,u=u!=null?u[l]:null,typeof u=="function"&&e.removeEventListener(t,u,a),typeof n=="function")){typeof u!="function"&&u!==null&&(l in e?e[l]=null:e.hasAttribute(l)&&e.removeAttribute(l)),e.addEventListener(t,n,a);break e}l in e?e[l]=n:n===!0?e.setAttribute(l,""):ru(e,l,n)}}}function Oe(e,t,l){switch(t){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"img":U("error",e),U("load",e);var n=!1,a=!1,u;for(u in l)if(l.hasOwnProperty(u)){var i=l[u];if(i!=null)switch(u){case"src":n=!0;break;case"srcSet":a=!0;break;case"children":case"dangerouslySetInnerHTML":throw Error(j(137,t));default:P(e,t,u,i,l,null)}}a&&P(e,t,"srcSet",l.srcSet,l,null),n&&P(e,t,"src",l.src,l,null);return;case"input":U("invalid",e);var c=u=i=a=null,s=null,o=null;for(n in l)if(l.hasOwnProperty(n)){var x=l[n];if(x!=null)switch(n){case"name":a=x;break;case"type":i=x;break;case"checked":s=x;break;case"defaultChecked":o=x;break;case"value":u=x;break;case"defaultValue":c=x;break;case"children":case"dangerouslySetInnerHTML":if(x!=null)throw Error(j(137,t));break;default:P(e,t,n,x,l,null)}}Sd(e,u,c,s,o,i,a,!1);return;case"select":U("invalid",e),n=i=u=null;for(a in l)if(l.hasOwnProperty(a)&&(c=l[a],c!=null))switch(a){case"value":u=c;break;case"defaultValue":i=c;break;case"multiple":n=c;default:P(e,t,a,c,l,null)}t=u,l=i,e.multiple=!!n,t!=null?yn(e,!!n,t,!1):l!=null&&yn(e,!!n,l,!0);return;case"textarea":U("invalid",e),u=a=n=null;for(i in l)if(l.hasOwnProperty(i)&&(c=l[i],c!=null))switch(i){case"value":n=c;break;case"defaultValue":a=c;break;case"children":u=c;break;case"dangerouslySetInnerHTML":if(c!=null)throw Error(j(91));break;default:P(e,t,i,c,l,null)}jd(e,n,a,u);return;case"option":for(s in l)if(l.hasOwnProperty(s)&&(n=l[s],n!=null))switch(s){case"selected":e.selected=n&&typeof n!="function"&&typeof n!="symbol";break;default:P(e,t,s,n,l,null)}return;case"dialog":U("beforetoggle",e),U("toggle",e),U("cancel",e),U("close",e);break;case"iframe":case"object":U("load",e);break;case"video":case"audio":for(n=0;n<ja.length;n++)U(ja[n],e);break;case"image":U("error",e),U("load",e);break;case"details":U("toggle",e);break;case"embed":case"source":case"link":U("error",e),U("load",e);case"area":case"base":case"br":case"col":case"hr":case"keygen":case"meta":case"param":case"track":case"wbr":case"menuitem":for(o in l)if(l.hasOwnProperty(o)&&(n=l[o],n!=null))switch(o){case"children":case"dangerouslySetInnerHTML":throw Error(j(137,t));default:P(e,t,o,n,l,null)}return;default:if(Ls(t)){for(x in l)l.hasOwnProperty(x)&&(n=l[x],n!==void 0&&xs(e,t,x,n,l,void 0));return}}for(c in l)l.hasOwnProperty(c)&&(n=l[c],n!=null&&P(e,t,c,n,l,null))}function Fm(e,t,l,n){switch(t){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"input":var a=null,u=null,i=null,c=null,s=null,o=null,x=null;for(m in l){var h=l[m];if(l.hasOwnProperty(m)&&h!=null)switch(m){case"checked":break;case"value":break;case"defaultValue":s=h;default:n.hasOwnProperty(m)||P(e,t,m,null,n,h)}}for(var d in n){var m=n[d];if(h=l[d],n.hasOwnProperty(d)&&(m!=null||h!=null))switch(d){case"type":u=m;break;case"name":a=m;break;case"checked":o=m;break;case"defaultChecked":x=m;break;case"value":i=m;break;case"defaultValue":c=m;break;case"children":case"dangerouslySetInnerHTML":if(m!=null)throw Error(j(137,t));break;default:m!==h&&P(e,t,d,m,n,h)}}Hc(e,i,c,s,o,x,u,a);return;case"select":m=i=c=d=null;for(u in l)if(s=l[u],l.hasOwnProperty(u)&&s!=null)switch(u){case"value":break;case"multiple":m=s;default:n.hasOwnProperty(u)||P(e,t,u,null,n,s)}for(a in n)if(u=n[a],s=l[a],n.hasOwnProperty(a)&&(u!=null||s!=null))switch(a){case"value":d=u;break;case"defaultValue":c=u;break;case"multiple":i=u;default:u!==s&&P(e,t,a,u,n,s)}t=c,l=i,n=m,d!=null?yn(e,!!l,d,!1):!!n!=!!l&&(t!=null?yn(e,!!l,t,!0):yn(e,!!l,l?[]:"",!1));return;case"textarea":m=d=null;for(c in l)if(a=l[c],l.hasOwnProperty(c)&&a!=null&&!n.hasOwnProperty(c))switch(c){case"value":break;case"children":break;default:P(e,t,c,null,n,a)}for(i in n)if(a=n[i],u=l[i],n.hasOwnProperty(i)&&(a!=null||u!=null))switch(i){case"value":d=a;break;case"defaultValue":m=a;break;case"children":break;case"dangerouslySetInnerHTML":if(a!=null)throw Error(j(91));break;default:a!==u&&P(e,t,i,a,n,u)}zd(e,d,m);return;case"option":for(var p in l)if(d=l[p],l.hasOwnProperty(p)&&d!=null&&!n.hasOwnProperty(p))switch(p){case"selected":e.selected=!1;break;default:P(e,t,p,null,n,d)}for(s in n)if(d=n[s],m=l[s],n.hasOwnProperty(s)&&d!==m&&(d!=null||m!=null))switch(s){case"selected":e.selected=d&&typeof d!="function"&&typeof d!="symbol";break;default:P(e,t,s,d,n,m)}return;case"img":case"link":case"area":case"base":case"br":case"col":case"embed":case"hr":case"keygen":case"meta":case"param":case"source":case"track":case"wbr":case"menuitem":for(var k in l)d=l[k],l.hasOwnProperty(k)&&d!=null&&!n.hasOwnProperty(k)&&P(e,t,k,null,n,d);for(o in n)if(d=n[o],m=l[o],n.hasOwnProperty(o)&&d!==m&&(d!=null||m!=null))switch(o){case"children":case"dangerouslySetInnerHTML":if(d!=null)throw Error(j(137,t));break;default:P(e,t,o,d,n,m)}return;default:if(Ls(t)){for(var S in l)d=l[S],l.hasOwnProperty(S)&&d!==void 0&&!n.hasOwnProperty(S)&&xs(e,t,S,void 0,n,d);for(x in n)d=n[x],m=l[x],!n.hasOwnProperty(x)||d===m||d===void 0&&m===void 0||xs(e,t,x,d,n,m);return}}for(var y in l)d=l[y],l.hasOwnProperty(y)&&d!=null&&!n.hasOwnProperty(y)&&P(e,t,y,null,n,d);for(h in n)d=n[h],m=l[h],!n.hasOwnProperty(h)||d===m||d==null&&m==null||P(e,t,h,d,n,m)}function ur(e){switch(e){case"css":case"script":case"font":case"img":case"image":case"input":case"link":return!0;default:return!1}}function Im(){if(typeof performance.getEntriesByType=="function"){for(var e=0,t=0,l=performance.getEntriesByType("resource"),n=0;n<l.length;n++){var a=l[n],u=a.transferSize,i=a.initiatorType,c=a.duration;if(u&&c&&ur(i)){for(i=0,c=a.responseEnd,n+=1;n<l.length;n++){var s=l[n],o=s.startTime;if(o>c)break;var x=s.transferSize,h=s.initiatorType;x&&ur(h)&&(s=s.responseEnd,i+=x*(s<c?1:(c-o)/(s-o)))}if(--n,t+=8*(u+i)/(a.duration/1e3),e++,10<e)break}}if(0<e)return t/e/1e6}return navigator.connection&&(e=navigator.connection.downlink,typeof e=="number")?e:5}var ys=null,ms=null;function Fu(e){return e.nodeType===9?e:e.ownerDocument}function ir(e){switch(e){case"http://www.w3.org/2000/svg":return 1;case"http://www.w3.org/1998/Math/MathML":return 2;default:return 0}}function w1(e,t){if(e===0)switch(t){case"svg":return 1;case"math":return 2;default:return 0}return e===1&&t==="foreignObject"?0:e}function vs(e,t){return e==="textarea"||e==="noscript"||typeof t.children=="string"||typeof t.children=="number"||typeof t.children=="bigint"||typeof t.dangerouslySetInnerHTML=="object"&&t.dangerouslySetInnerHTML!==null&&t.dangerouslySetInnerHTML.__html!=null}var dc=null;function Pm(){var e=window.event;return e&&e.type==="popstate"?e===dc?!1:(dc=e,!0):(dc=null,!1)}var A1=typeof setTimeout=="function"?setTimeout:void 0,ev=typeof clearTimeout=="function"?clearTimeout:void 0,cr=typeof Promise=="function"?Promise:void 0,tv=typeof queueMicrotask=="function"?queueMicrotask:typeof cr<"u"?function(e){return cr.resolve(null).then(e).catch(lv)}:A1;function lv(e){setTimeout(function(){throw e})}function pl(e){return e==="head"}function sr(e,t){var l=t,n=0;do{var a=l.nextSibling;if(e.removeChild(l),a&&a.nodeType===8)if(l=a.data,l==="/$"||l==="/&"){if(n===0){e.removeChild(a),An(t);return}n--}else if(l==="$"||l==="$?"||l==="$~"||l==="$!"||l==="&")n++;else if(l==="html")ya(e.ownerDocument.documentElement);else if(l==="head"){l=e.ownerDocument.head,ya(l);for(var u=l.firstChild;u;){var i=u.nextSibling,c=u.nodeName;u[Da]||c==="SCRIPT"||c==="STYLE"||c==="LINK"&&u.rel.toLowerCase()==="stylesheet"||l.removeChild(u),u=i}}else l==="body"&&ya(e.ownerDocument.body);l=a}while(l);An(t)}function fr(e,t){var l=e;e=0;do{var n=l.nextSibling;if(l.nodeType===1?t?(l._stashedDisplay=l.style.display,l.style.display="none"):(l.style.display=l._stashedDisplay||"",l.getAttribute("style")===""&&l.removeAttribute("style")):l.nodeType===3&&(t?(l._stashedText=l.nodeValue,l.nodeValue=""):l.nodeValue=l._stashedText||""),n&&n.nodeType===8)if(l=n.data,l==="/$"){if(e===0)break;e--}else l!=="$"&&l!=="$?"&&l!=="$~"&&l!=="$!"||e++;l=n}while(l)}function hs(e){var t=e.firstChild;for(t&&t.nodeType===10&&(t=t.nextSibling);t;){var l=t;switch(t=t.nextSibling,l.nodeName){case"HTML":case"HEAD":case"BODY":hs(l),Bs(l);continue;case"SCRIPT":case"STYLE":continue;case"LINK":if(l.rel.toLowerCase()==="stylesheet")continue}e.removeChild(l)}}function nv(e,t,l,n){for(;e.nodeType===1;){var a=l;if(e.nodeName.toLowerCase()!==t.toLowerCase()){if(!n&&(e.nodeName!=="INPUT"||e.type!=="hidden"))break}else if(n){if(!e[Da])switch(t){case"meta":if(!e.hasAttribute("itemprop"))break;return e;case"link":if(u=e.getAttribute("rel"),u==="stylesheet"&&e.hasAttribute("data-precedence"))break;if(u!==a.rel||e.getAttribute("href")!==(a.href==null||a.href===""?null:a.href)||e.getAttribute("crossorigin")!==(a.crossOrigin==null?null:a.crossOrigin)||e.getAttribute("title")!==(a.title==null?null:a.title))break;return e;case"style":if(e.hasAttribute("data-precedence"))break;return e;case"script":if(u=e.getAttribute("src"),(u!==(a.src==null?null:a.src)||e.getAttribute("type")!==(a.type==null?null:a.type)||e.getAttribute("crossorigin")!==(a.crossOrigin==null?null:a.crossOrigin))&&u&&e.hasAttribute("async")&&!e.hasAttribute("itemprop"))break;return e;default:return e}}else if(t==="input"&&e.type==="hidden"){var u=a.name==null?null:""+a.name;if(a.type==="hidden"&&e.getAttribute("name")===u)return e}else return e;if(e=ot(e.nextSibling),e===null)break}return null}function av(e,t,l){if(t==="")return null;for(;e.nodeType!==3;)if((e.nodeType!==1||e.nodeName!=="INPUT"||e.type!=="hidden")&&!l||(e=ot(e.nextSibling),e===null))return null;return e}function N1(e,t){for(;e.nodeType!==8;)if((e.nodeType!==1||e.nodeName!=="INPUT"||e.type!=="hidden")&&!t||(e=ot(e.nextSibling),e===null))return null;return e}function gs(e){return e.data==="$?"||e.data==="$~"}function ps(e){return e.data==="$!"||e.data==="$?"&&e.ownerDocument.readyState!=="loading"}function uv(e,t){var l=e.ownerDocument;if(e.data==="$~")e._reactRetry=t;else if(e.data!=="$?"||l.readyState!=="loading")t();else{var n=function(){t(),l.removeEventListener("DOMContentLoaded",n)};l.addEventListener("DOMContentLoaded",n),e._reactRetry=n}}function ot(e){for(;e!=null;e=e.nextSibling){var t=e.nodeType;if(t===1||t===3)break;if(t===8){if(t=e.data,t==="$"||t==="$!"||t==="$?"||t==="$~"||t==="&"||t==="F!"||t==="F")break;if(t==="/$"||t==="/&")return null}}return e}var bs=null;function or(e){e=e.nextSibling;for(var t=0;e;){if(e.nodeType===8){var l=e.data;if(l==="/$"||l==="/&"){if(t===0)return ot(e.nextSibling);t--}else l!=="$"&&l!=="$!"&&l!=="$?"&&l!=="$~"&&l!=="&"||t++}e=e.nextSibling}return null}function rr(e){e=e.previousSibling;for(var t=0;e;){if(e.nodeType===8){var l=e.data;if(l==="$"||l==="$!"||l==="$?"||l==="$~"||l==="&"){if(t===0)return e;t--}else l!=="/$"&&l!=="/&"||t++}e=e.previousSibling}return null}function O1(e,t,l){switch(t=Fu(l),e){case"html":if(e=t.documentElement,!e)throw Error(j(452));return e;case"head":if(e=t.head,!e)throw Error(j(453));return e;case"body":if(e=t.body,!e)throw Error(j(454));return e;default:throw Error(j(451))}}function ya(e){for(var t=e.attributes;t.length;)e.removeAttributeNode(t[0]);Bs(e)}var rt=new Map,dr=new Set;function Iu(e){return typeof e.getRootNode=="function"?e.getRootNode():e.nodeType===9?e:e.ownerDocument}var Gt=K.d;K.d={f:iv,r:cv,D:sv,C:fv,L:ov,m:rv,X:xv,S:dv,M:yv};function iv(){var e=Gt.f(),t=bi();return e||t}function cv(e){var t=Dn(e);t!==null&&t.tag===5&&t.type==="form"?$x(t):Gt.r(e)}var Rn=typeof document>"u"?null:document;function D1(e,t,l){var n=Rn;if(n&&typeof t=="string"&&t){var a=it(t);a='link[rel="'+e+'"][href="'+a+'"]',typeof l=="string"&&(a+='[crossorigin="'+l+'"]'),dr.has(a)||(dr.add(a),e={rel:e,crossOrigin:l,href:t},n.querySelector(a)===null&&(t=n.createElement("link"),Oe(t,"link",e),ze(t),n.head.appendChild(t)))}}function sv(e){Gt.D(e),D1("dns-prefetch",e,null)}function fv(e,t){Gt.C(e,t),D1("preconnect",e,t)}function ov(e,t,l){Gt.L(e,t,l);var n=Rn;if(n&&e&&t){var a='link[rel="preload"][as="'+it(t)+'"]';t==="image"&&l&&l.imageSrcSet?(a+='[imagesrcset="'+it(l.imageSrcSet)+'"]',typeof l.imageSizes=="string"&&(a+='[imagesizes="'+it(l.imageSizes)+'"]')):a+='[href="'+it(e)+'"]';var u=a;switch(t){case"style":u=wn(e);break;case"script":u=Hn(e)}rt.has(u)||(e=ie({rel:"preload",href:t==="image"&&l&&l.imageSrcSet?void 0:e,as:t},l),rt.set(u,e),n.querySelector(a)!==null||t==="style"&&n.querySelector(Ua(u))||t==="script"&&n.querySelector(Xa(u))||(t=n.createElement("link"),Oe(t,"link",e),ze(t),n.head.appendChild(t)))}}function rv(e,t){Gt.m(e,t);var l=Rn;if(l&&e){var n=t&&typeof t.as=="string"?t.as:"script",a='link[rel="modulepreload"][as="'+it(n)+'"][href="'+it(e)+'"]',u=a;switch(n){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":u=Hn(e)}if(!rt.has(u)&&(e=ie({rel:"modulepreload",href:e},t),rt.set(u,e),l.querySelector(a)===null)){switch(n){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":if(l.querySelector(Xa(u)))return}n=l.createElement("link"),Oe(n,"link",e),ze(n),l.head.appendChild(n)}}}function dv(e,t,l){Gt.S(e,t,l);var n=Rn;if(n&&e){var a=xn(n).hoistableStyles,u=wn(e);t=t||"default";var i=a.get(u);if(!i){var c={loading:0,preload:null};if(i=n.querySelector(Ua(u)))c.loading=5;else{e=ie({rel:"stylesheet",href:e,"data-precedence":t},l),(l=rt.get(u))&&Tf(e,l);var s=i=n.createElement("link");ze(s),Oe(s,"link",e),s._p=new Promise(function(o,x){s.onload=o,s.onerror=x}),s.addEventListener("load",function(){c.loading|=1}),s.addEventListener("error",function(){c.loading|=2}),c.loading|=4,Su(i,t,n)}i={type:"stylesheet",instance:i,count:1,state:c},a.set(u,i)}}}function xv(e,t){Gt.X(e,t);var l=Rn;if(l&&e){var n=xn(l).hoistableScripts,a=Hn(e),u=n.get(a);u||(u=l.querySelector(Xa(a)),u||(e=ie({src:e,async:!0},t),(t=rt.get(a))&&Mf(e,t),u=l.createElement("script"),ze(u),Oe(u,"link",e),l.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},n.set(a,u))}}function yv(e,t){Gt.M(e,t);var l=Rn;if(l&&e){var n=xn(l).hoistableScripts,a=Hn(e),u=n.get(a);u||(u=l.querySelector(Xa(a)),u||(e=ie({src:e,async:!0,type:"module"},t),(t=rt.get(a))&&Mf(e,t),u=l.createElement("script"),ze(u),Oe(u,"link",e),l.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},n.set(a,u))}}function xr(e,t,l,n){var a=(a=ul.current)?Iu(a):null;if(!a)throw Error(j(446));switch(e){case"meta":case"title":return null;case"style":return typeof l.precedence=="string"&&typeof l.href=="string"?(t=wn(l.href),l=xn(a).hoistableStyles,n=l.get(t),n||(n={type:"style",instance:null,count:0,state:null},l.set(t,n)),n):{type:"void",instance:null,count:0,state:null};case"link":if(l.rel==="stylesheet"&&typeof l.href=="string"&&typeof l.precedence=="string"){e=wn(l.href);var u=xn(a).hoistableStyles,i=u.get(e);if(i||(a=a.ownerDocument||a,i={type:"stylesheet",instance:null,count:0,state:{loading:0,preload:null}},u.set(e,i),(u=a.querySelector(Ua(e)))&&!u._p&&(i.instance=u,i.state.loading=5),rt.has(e)||(l={rel:"preload",as:"style",href:l.href,crossOrigin:l.crossOrigin,integrity:l.integrity,media:l.media,hrefLang:l.hrefLang,referrerPolicy:l.referrerPolicy},rt.set(e,l),u||mv(a,e,l,i.state))),t&&n===null)throw Error(j(528,""));return i}if(t&&n!==null)throw Error(j(529,""));return null;case"script":return t=l.async,l=l.src,typeof l=="string"&&t&&typeof t!="function"&&typeof t!="symbol"?(t=Hn(l),l=xn(a).hoistableScripts,n=l.get(t),n||(n={type:"script",instance:null,count:0,state:null},l.set(t,n)),n):{type:"void",instance:null,count:0,state:null};default:throw Error(j(444,e))}}function wn(e){return'href="'+it(e)+'"'}function Ua(e){return'link[rel="stylesheet"]['+e+"]"}function q1(e){return ie({},e,{"data-precedence":e.precedence,precedence:null})}function mv(e,t,l,n){e.querySelector('link[rel="preload"][as="style"]['+t+"]")?n.loading=1:(t=e.createElement("link"),n.preload=t,t.addEventListener("load",function(){return n.loading|=1}),t.addEventListener("error",function(){return n.loading|=2}),Oe(t,"link",l),ze(t),e.head.appendChild(t))}function Hn(e){return'[src="'+it(e)+'"]'}function Xa(e){return"script[async]"+e}function yr(e,t,l){if(t.count++,t.instance===null)switch(t.type){case"style":var n=e.querySelector('style[data-href~="'+it(l.href)+'"]');if(n)return t.instance=n,ze(n),n;var a=ie({},l,{"data-href":l.href,"data-precedence":l.precedence,href:null,precedence:null});return n=(e.ownerDocument||e).createElement("style"),ze(n),Oe(n,"style",a),Su(n,l.precedence,e),t.instance=n;case"stylesheet":a=wn(l.href);var u=e.querySelector(Ua(a));if(u)return t.state.loading|=4,t.instance=u,ze(u),u;n=q1(l),(a=rt.get(a))&&Tf(n,a),u=(e.ownerDocument||e).createElement("link"),ze(u);var i=u;return i._p=new Promise(function(c,s){i.onload=c,i.onerror=s}),Oe(u,"link",n),t.state.loading|=4,Su(u,l.precedence,e),t.instance=u;case"script":return u=Hn(l.src),(a=e.querySelector(Xa(u)))?(t.instance=a,ze(a),a):(n=l,(a=rt.get(u))&&(n=ie({},l),Mf(n,a)),e=e.ownerDocument||e,a=e.createElement("script"),ze(a),Oe(a,"link",n),e.head.appendChild(a),t.instance=a);case"void":return null;default:throw Error(j(443,t.type))}else t.type==="stylesheet"&&!(t.state.loading&4)&&(n=t.instance,t.state.loading|=4,Su(n,l.precedence,e));return t.instance}function Su(e,t,l){for(var n=l.querySelectorAll('link[rel="stylesheet"][data-precedence],style[data-precedence]'),a=n.length?n[n.length-1]:null,u=a,i=0;i<n.length;i++){var c=n[i];if(c.dataset.precedence===t)u=c;else if(u!==a)break}u?u.parentNode.insertBefore(e,u.nextSibling):(t=l.nodeType===9?l.head:l,t.insertBefore(e,t.firstChild))}function Tf(e,t){e.crossOrigin==null&&(e.crossOrigin=t.crossOrigin),e.referrerPolicy==null&&(e.referrerPolicy=t.referrerPolicy),e.title==null&&(e.title=t.title)}function Mf(e,t){e.crossOrigin==null&&(e.crossOrigin=t.crossOrigin),e.referrerPolicy==null&&(e.referrerPolicy=t.referrerPolicy),e.integrity==null&&(e.integrity=t.integrity)}var zu=null;function mr(e,t,l){if(zu===null){var n=new Map,a=zu=new Map;a.set(l,n)}else a=zu,n=a.get(l),n||(n=new Map,a.set(l,n));if(n.has(e))return n;for(n.set(e,null),l=l.getElementsByTagName(e),a=0;a<l.length;a++){var u=l[a];if(!(u[Da]||u[we]||e==="link"&&u.getAttribute("rel")==="stylesheet")&&u.namespaceURI!=="http://www.w3.org/2000/svg"){var i=u.getAttribute(t)||"";i=e+i;var c=n.get(i);c?c.push(u):n.set(i,[u])}}return n}function vr(e,t,l){e=e.ownerDocument||e,e.head.insertBefore(l,t==="title"?e.querySelector("head > title"):null)}function vv(e,t,l){if(l===1||t.itemProp!=null)return!1;switch(e){case"meta":case"title":return!0;case"style":if(typeof t.precedence!="string"||typeof t.href!="string"||t.href==="")break;return!0;case"link":if(typeof t.rel!="string"||typeof t.href!="string"||t.href===""||t.onLoad||t.onError)break;switch(t.rel){case"stylesheet":return e=t.disabled,typeof t.precedence=="string"&&e==null;default:return!0}case"script":if(t.async&&typeof t.async!="function"&&typeof t.async!="symbol"&&!t.onLoad&&!t.onError&&t.src&&typeof t.src=="string")return!0}return!1}function C1(e){return!(e.type==="stylesheet"&&!(e.state.loading&3))}function hv(e,t,l,n){if(l.type==="stylesheet"&&(typeof n.media!="string"||matchMedia(n.media).matches!==!1)&&!(l.state.loading&4)){if(l.instance===null){var a=wn(n.href),u=t.querySelector(Ua(a));if(u){t=u._p,t!==null&&typeof t=="object"&&typeof t.then=="function"&&(e.count++,e=Pu.bind(e),t.then(e,e)),l.state.loading|=4,l.instance=u,ze(u);return}u=t.ownerDocument||t,n=q1(n),(a=rt.get(a))&&Tf(n,a),u=u.createElement("link"),ze(u);var i=u;i._p=new Promise(function(c,s){i.onload=c,i.onerror=s}),Oe(u,"link",n),l.instance=u}e.stylesheets===null&&(e.stylesheets=new Map),e.stylesheets.set(l,t),(t=l.state.preload)&&!(l.state.loading&3)&&(e.count++,l=Pu.bind(e),t.addEventListener("load",l),t.addEventListener("error",l))}}var xc=0;function gv(e,t){return e.stylesheets&&e.count===0&&ju(e,e.stylesheets),0<e.count||0<e.imgCount?function(l){var n=setTimeout(function(){if(e.stylesheets&&ju(e,e.stylesheets),e.unsuspend){var u=e.unsuspend;e.unsuspend=null,u()}},6e4+t);0<e.imgBytes&&xc===0&&(xc=62500*Im());var a=setTimeout(function(){if(e.waitingForImages=!1,e.count===0&&(e.stylesheets&&ju(e,e.stylesheets),e.unsuspend)){var u=e.unsuspend;e.unsuspend=null,u()}},(e.imgBytes>xc?50:800)+t);return e.unsuspend=l,function(){e.unsuspend=null,clearTimeout(n),clearTimeout(a)}}:null}function Pu(){if(this.count--,this.count===0&&(this.imgCount===0||!this.waitingForImages)){if(this.stylesheets)ju(this,this.stylesheets);else if(this.unsuspend){var e=this.unsuspend;this.unsuspend=null,e()}}}var ei=null;function ju(e,t){e.stylesheets=null,e.unsuspend!==null&&(e.count++,ei=new Map,t.forEach(pv,e),ei=null,Pu.call(e))}function pv(e,t){if(!(t.state.loading&4)){var l=ei.get(e);if(l)var n=l.get(null);else{l=new Map,ei.set(e,l);for(var a=e.querySelectorAll("link[data-precedence],style[data-precedence]"),u=0;u<a.length;u++){var i=a[u];(i.nodeName==="LINK"||i.getAttribute("media")!=="not all")&&(l.set(i.dataset.precedence,i),n=i)}n&&l.set(null,n)}a=t.instance,i=a.getAttribute("data-precedence"),u=l.get(i)||n,u===n&&l.set(null,a),l.set(i,a),this.count++,n=Pu.bind(this),a.addEventListener("load",n),a.addEventListener("error",n),u?u.parentNode.insertBefore(a,u.nextSibling):(e=e.nodeType===9?e.head:e,e.insertBefore(a,e.firstChild)),t.state.loading|=4}}var Ea={$$typeof:Nt,Provider:null,Consumer:null,_currentValue:Ml,_currentValue2:Ml,_threadCount:0};function bv(e,t,l,n,a,u,i,c,s){this.tag=1,this.containerInfo=e,this.pingCache=this.current=this.pendingChildren=null,this.timeoutHandle=-1,this.callbackNode=this.next=this.pendingContext=this.context=this.cancelPendingCommit=null,this.callbackPriority=0,this.expirationTimes=_i(-1),this.entangledLanes=this.shellSuspendCounter=this.errorRecoveryDisabledLanes=this.expiredLanes=this.warmLanes=this.pingedLanes=this.suspendedLanes=this.pendingLanes=0,this.entanglements=_i(0),this.hiddenUpdates=_i(null),this.identifierPrefix=n,this.onUncaughtError=a,this.onCaughtError=u,this.onRecoverableError=i,this.pooledCache=null,this.pooledCacheLanes=0,this.formState=s,this.incompleteTransitions=new Map}function _1(e,t,l,n,a,u,i,c,s,o,x,h){return e=new bv(e,t,l,i,s,o,x,h,c),t=1,u===!0&&(t|=24),u=Ke(3,null,null,t),e.current=u,u.stateNode=e,t=Ps(),t.refCount++,e.pooledCache=t,t.refCount++,u.memoizedState={element:n,isDehydrated:l,cache:t},lf(u),e}function R1(e){return e?(e=sn,e):sn}function H1(e,t,l,n,a,u){a=R1(a),n.context===null?n.context=a:n.pendingContext=a,n=cl(t),n.payload={element:l},u=u===void 0?null:u,u!==null&&(n.callback=u),l=sl(e,n,t),l!==null&&(Le(l,e,t),ia(l,e,t))}function hr(e,t){if(e=e.memoizedState,e!==null&&e.dehydrated!==null){var l=e.retryLane;e.retryLane=l!==0&&l<t?l:t}}function wf(e,t){hr(e,t),(e=e.alternate)&&hr(e,t)}function U1(e){if(e.tag===13||e.tag===31){var t=Bl(e,67108864);t!==null&&Le(t,e,67108864),wf(e,67108864)}}function gr(e){if(e.tag===13||e.tag===31){var t=Pe();t=Us(t);var l=Bl(e,t);l!==null&&Le(l,e,t),wf(e,t)}}var ti=!0;function kv(e,t,l,n){var a=C.T;C.T=null;var u=K.p;try{K.p=2,Af(e,t,l,n)}finally{K.p=u,C.T=a}}function Sv(e,t,l,n){var a=C.T;C.T=null;var u=K.p;try{K.p=8,Af(e,t,l,n)}finally{K.p=u,C.T=a}}function Af(e,t,l,n){if(ti){var a=ks(n);if(a===null)rc(e,t,n,li,l),pr(e,n);else if(jv(a,e,t,l,n))n.stopPropagation();else if(pr(e,n),t&4&&-1<zv.indexOf(e)){for(;a!==null;){var u=Dn(a);if(u!==null)switch(u.tag){case 3:if(u=u.stateNode,u.current.memoizedState.isDehydrated){var i=$l(u.pendingLanes);if(i!==0){var c=u;for(c.pendingLanes|=2,c.entangledLanes|=2;i;){var s=1<<31-Ie(i);c.entanglements[1]|=s,i&=~s}St(u),!(Q&6)&&(Yu=We()+500,Ha(0))}}break;case 31:case 13:c=Bl(u,2),c!==null&&Le(c,u,2),bi(),wf(u,2)}if(u=ks(n),u===null&&rc(e,t,n,li,l),u===a)break;a=u}a!==null&&n.stopPropagation()}else rc(e,t,n,null,l)}}function ks(e){return e=Gs(e),Nf(e)}var li=null;function Nf(e){if(li=null,e=tn(e),e!==null){var t=wa(e);if(t===null)e=null;else{var l=t.tag;if(l===13){if(e=ud(t),e!==null)return e;e=null}else if(l===31){if(e=id(t),e!==null)return e;e=null}else if(l===3){if(t.stateNode.current.memoizedState.isDehydrated)return t.tag===3?t.stateNode.containerInfo:null;e=null}else t!==e&&(e=null)}}return li=e,null}function X1(e){switch(e){case"beforetoggle":case"cancel":case"click":case"close":case"contextmenu":case"copy":case"cut":case"auxclick":case"dblclick":case"dragend":case"dragstart":case"drop":case"focusin":case"focusout":case"input":case"invalid":case"keydown":case"keypress":case"keyup":case"mousedown":case"mouseup":case"paste":case"pause":case"play":case"pointercancel":case"pointerdown":case"pointerup":case"ratechange":case"reset":case"resize":case"seeked":case"submit":case"toggle":case"touchcancel":case"touchend":case"touchstart":case"volumechange":case"change":case"selectionchange":case"textInput":case"compositionstart":case"compositionend":case"compositionupdate":case"beforeblur":case"afterblur":case"beforeinput":case"blur":case"fullscreenchange":case"focus":case"hashchange":case"popstate":case"select":case"selectstart":return 2;case"drag":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"mousemove":case"mouseout":case"mouseover":case"pointermove":case"pointerout":case"pointerover":case"scroll":case"touchmove":case"wheel":case"mouseenter":case"mouseleave":case"pointerenter":case"pointerleave":return 8;case"message":switch(sy()){case od:return 2;case rd:return 8;case Nu:case fy:return 32;case dd:return 268435456;default:return 32}default:return 32}}var Ss=!1,rl=null,dl=null,xl=null,Ta=new Map,Ma=new Map,Pt=[],zv="mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset".split(" ");function pr(e,t){switch(e){case"focusin":case"focusout":rl=null;break;case"dragenter":case"dragleave":dl=null;break;case"mouseover":case"mouseout":xl=null;break;case"pointerover":case"pointerout":Ta.delete(t.pointerId);break;case"gotpointercapture":case"lostpointercapture":Ma.delete(t.pointerId)}}function Vn(e,t,l,n,a,u){return e===null||e.nativeEvent!==u?(e={blockedOn:t,domEventName:l,eventSystemFlags:n,nativeEvent:u,targetContainers:[a]},t!==null&&(t=Dn(t),t!==null&&U1(t)),e):(e.eventSystemFlags|=n,t=e.targetContainers,a!==null&&t.indexOf(a)===-1&&t.push(a),e)}function jv(e,t,l,n,a){switch(t){case"focusin":return rl=Vn(rl,e,t,l,n,a),!0;case"dragenter":return dl=Vn(dl,e,t,l,n,a),!0;case"mouseover":return xl=Vn(xl,e,t,l,n,a),!0;case"pointerover":var u=a.pointerId;return Ta.set(u,Vn(Ta.get(u)||null,e,t,l,n,a)),!0;case"gotpointercapture":return u=a.pointerId,Ma.set(u,Vn(Ma.get(u)||null,e,t,l,n,a)),!0}return!1}function B1(e){var t=tn(e.target);if(t!==null){var l=wa(t);if(l!==null){if(t=l.tag,t===13){if(t=ud(l),t!==null){e.blockedOn=t,lo(e.priority,function(){gr(l)});return}}else if(t===31){if(t=id(l),t!==null){e.blockedOn=t,lo(e.priority,function(){gr(l)});return}}else if(t===3&&l.stateNode.current.memoizedState.isDehydrated){e.blockedOn=l.tag===3?l.stateNode.containerInfo:null;return}}}e.blockedOn=null}function $u(e){if(e.blockedOn!==null)return!1;for(var t=e.targetContainers;0<t.length;){var l=ks(e.nativeEvent);if(l===null){l=e.nativeEvent;var n=new l.constructor(l.type,l);Xc=n,l.target.dispatchEvent(n),Xc=null}else return t=Dn(l),t!==null&&U1(t),e.blockedOn=l,!1;t.shift()}return!0}function br(e,t,l){$u(e)&&l.delete(t)}function $v(){Ss=!1,rl!==null&&$u(rl)&&(rl=null),dl!==null&&$u(dl)&&(dl=null),xl!==null&&$u(xl)&&(xl=null),Ta.forEach(br),Ma.forEach(br)}function nu(e,t){e.blockedOn===t&&(e.blockedOn=null,Ss||(Ss=!0,ke.unstable_scheduleCallback(ke.unstable_NormalPriority,$v)))}var au=null;function kr(e){au!==e&&(au=e,ke.unstable_scheduleCallback(ke.unstable_NormalPriority,function(){au===e&&(au=null);for(var t=0;t<e.length;t+=3){var l=e[t],n=e[t+1],a=e[t+2];if(typeof n!="function"){if(Nf(n||l)===null)continue;break}var u=Dn(l);u!==null&&(e.splice(t,3),t-=3,ls(u,{pending:!0,data:a,method:l.method,action:n},n,a))}}))}function An(e){function t(s){return nu(s,e)}rl!==null&&nu(rl,e),dl!==null&&nu(dl,e),xl!==null&&nu(xl,e),Ta.forEach(t),Ma.forEach(t);for(var l=0;l<Pt.length;l++){var n=Pt[l];n.blockedOn===e&&(n.blockedOn=null)}for(;0<Pt.length&&(l=Pt[0],l.blockedOn===null);)B1(l),l.blockedOn===null&&Pt.shift();if(l=(e.ownerDocument||e).$$reactFormReplay,l!=null)for(n=0;n<l.length;n+=3){var a=l[n],u=l[n+1],i=a[Ge]||null;if(typeof u=="function")i||kr(l);else if(i){var c=null;if(u&&u.hasAttribute("formAction")){if(a=u,i=u[Ge]||null)c=i.formAction;else if(Nf(a)!==null)continue}else c=i.action;typeof c=="function"?l[n+1]=c:(l.splice(n,3),n-=3),kr(l)}}}function L1(){function e(u){u.canIntercept&&u.info==="react-transition"&&u.intercept({handler:function(){return new Promise(function(i){return a=i})},focusReset:"manual",scroll:"manual"})}function t(){a!==null&&(a(),a=null),n||setTimeout(l,20)}function l(){if(!n&&!navigation.transition){var u=navigation.currentEntry;u&&u.url!=null&&navigation.navigate(u.url,{state:u.getState(),info:"react-transition",history:"replace"})}}if(typeof navigation=="object"){var n=!1,a=null;return navigation.addEventListener("navigate",e),navigation.addEventListener("navigatesuccess",t),navigation.addEventListener("navigateerror",t),setTimeout(l,100),function(){n=!0,navigation.removeEventListener("navigate",e),navigation.removeEventListener("navigatesuccess",t),navigation.removeEventListener("navigateerror",t),a!==null&&(a(),a=null)}}}function Of(e){this._internalRoot=e}zi.prototype.render=Of.prototype.render=function(e){var t=this._internalRoot;if(t===null)throw Error(j(409));var l=t.current,n=Pe();H1(l,n,e,t,null,null)};zi.prototype.unmount=Of.prototype.unmount=function(){var e=this._internalRoot;if(e!==null){this._internalRoot=null;var t=e.containerInfo;H1(e.current,2,null,e,null,null),bi(),t[On]=null}};function zi(e){this._internalRoot=e}zi.prototype.unstable_scheduleHydration=function(e){if(e){var t=hd();e={blockedOn:null,target:e,priority:t};for(var l=0;l<Pt.length&&t!==0&&t<Pt[l].priority;l++);Pt.splice(l,0,e),l===0&&B1(e)}};var Sr=nd.version;if(Sr!=="19.2.4")throw Error(j(527,Sr,"19.2.4"));K.findDOMNode=function(e){var t=e._reactInternals;if(t===void 0)throw typeof e.render=="function"?Error(j(188)):(e=Object.keys(e).join(","),Error(j(268,e)));return e=ty(t),e=e!==null?cd(e):null,e=e===null?null:e.stateNode,e};var Ev={bundleType:0,version:"19.2.4",rendererPackageName:"react-dom",currentDispatcherRef:C,reconcilerVersion:"19.2.4"};if(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__<"u"){var uu=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(!uu.isDisabled&&uu.supportsFiber)try{Aa=uu.inject(Ev),Fe=uu}catch{}}ii.createRoot=function(e,t){if(!ad(e))throw Error(j(299));var l=!1,n="",a=Dx,u=qx,i=Cx;return t!=null&&(t.unstable_strictMode===!0&&(l=!0),t.identifierPrefix!==void 0&&(n=t.identifierPrefix),t.onUncaughtError!==void 0&&(a=t.onUncaughtError),t.onCaughtError!==void 0&&(u=t.onCaughtError),t.onRecoverableError!==void 0&&(i=t.onRecoverableError)),t=_1(e,1,!1,null,null,l,n,null,a,u,i,L1),e[On]=t.current,Ef(e),new Of(t)};ii.hydrateRoot=function(e,t,l){if(!ad(e))throw Error(j(299));var n=!1,a="",u=Dx,i=qx,c=Cx,s=null;return l!=null&&(l.unstable_strictMode===!0&&(n=!0),l.identifierPrefix!==void 0&&(a=l.identifierPrefix),l.onUncaughtError!==void 0&&(u=l.onUncaughtError),l.onCaughtError!==void 0&&(i=l.onCaughtError),l.onRecoverableError!==void 0&&(c=l.onRecoverableError),l.formState!==void 0&&(s=l.formState)),t=_1(e,1,!0,t,l??null,n,a,s,u,i,c,L1),t.context=R1(null),l=t.current,n=Pe(),n=Us(n),a=cl(n),a.callback=null,sl(l,a,n),l=n,t.current.lanes=l,Oa(t,l),St(t),e[On]=t.current,Ef(e),new zi(t)};ii.version="19.2.4";function G1(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(G1)}catch(e){console.error(e)}}G1(),Zr.exports=ii;var Tv=Zr.exports,Qn={},zr;function Mv(){if(zr)return Qn;zr=1,Object.defineProperty(Qn,"__esModule",{value:!0}),Qn.styleq=void 0;var e=new WeakMap,t="$$css";function l(a){var u,i,c;return a!=null&&(u=a.disableCache===!0,i=a.disableMix===!0,c=a.transform),function(){for(var o=[],x="",h=null,d="",m=u?null:e,p=new Array(arguments.length),k=0;k<arguments.length;k++)p[k]=arguments[k];for(;p.length>0;){var S=p.pop();if(!(S==null||S===!1)){if(Array.isArray(S)){for(var y=0;y<S.length;y++)p.push(S[y]);continue}var r=c!=null?c(S):S;if(r.$$css!=null){var v="";if(m!=null&&m.has(r)){var b=m.get(r);b!=null&&(v=b[0],d=b[2],o.push.apply(o,b[1]),m=b[3])}else{var z=[];for(var w in r){var $=r[w];if(w===t){var T=r[w];T!==!0&&(d=d?T+"; "+d:T);continue}typeof $=="string"||$===null?o.includes(w)||(o.push(w),m!=null&&z.push(w),typeof $=="string"&&(v+=v?" "+$:$)):console.error("styleq: ".concat(w," typeof ").concat(String($),' is not "string" or "null".'))}if(m!=null){var E=new WeakMap;m.set(r,[v,z,d,E]),m=E}}v&&(x=x?v+" "+x:v)}else if(i)h==null&&(h={}),h=Object.assign({},r,h);else{var M=null;for(var D in r){var R=r[D];R!==void 0&&(o.includes(D)||(R!=null&&(h==null&&(h={}),M==null&&(M={}),M[D]=R),o.push(D),m=null))}M!=null&&(h=Object.assign(M,h))}}}var Z=[x,h,d];return Z}}var n=Qn.styleq=l();return n.factory=l,Qn}var wv=Mv();function q(...e){const[t,l,n]=wv.styleq(e),a={};return t!=null&&t!==""&&(a.className=t),l!=null&&Object.keys(l).length>0&&(a.style=l),n!=null&&n!==""&&(a["data-style-src"]=n),a}const jr={"--color-accent":"var(--color-accent)","--color-on-dark":"var(--color-on-dark)"},Ee={xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:1.5,strokeLinecap:"round",strokeLinejoin:"round",width:"1em",height:"1em","aria-hidden":!0},iu={xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor",width:"1em",height:"1em","aria-hidden":!0},Av={close:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M6 6l12 12M6 18L18 6"})}),chevronDown:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M6 9l6 6 6-6"})}),chevronLeft:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M15 6l-6 6 6 6"})}),chevronRight:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M9 6l6 6-6 6"})}),check:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M5 13l4 4L19 7"})}),checkCircle:f.jsx("svg",{...iu,children:f.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M12 3a9 9 0 100 18 9 9 0 000-18zm4.06 6.56a.75.75 0 00-1.12-1l-3.94 4.4-1.94-1.94a.75.75 0 00-1.06 1.06l2.5 2.5a.75.75 0 001.09-.03l4.47-5z"})}),xCircle:f.jsx("svg",{...iu,children:f.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M12 3a9 9 0 100 18 9 9 0 000-18zm-2.47 5.47a.75.75 0 00-1.06 1.06L10.94 12l-2.47 2.47a.75.75 0 101.06 1.06L12 13.06l2.47 2.47a.75.75 0 101.06-1.06L13.06 12l2.47-2.47a.75.75 0 00-1.06-1.06L12 10.94l-2.47-2.47z"})}),warning:f.jsx("svg",{...iu,children:f.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M10.29 3.86L2.07 19.05A2 2 0 003.78 22h16.44a2 2 0 001.71-2.95L13.71 3.86a2 2 0 00-3.42 0zM12 9a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0112 9zm0 9a1 1 0 100-2 1 1 0 000 2z"})}),info:f.jsxs("svg",{...Ee,children:[f.jsx("circle",{cx:"12",cy:"12",r:"9"}),f.jsx("path",{d:"M12 11v5"}),f.jsx("circle",{cx:"12",cy:"8",r:"0.5",fill:"currentColor",stroke:"none"})]}),calendar:f.jsxs("svg",{...Ee,children:[f.jsx("rect",{x:"3",y:"4",width:"18",height:"18",rx:"2"}),f.jsx("path",{d:"M16 2v4M8 2v4M3 10h18"})]}),clock:f.jsxs("svg",{...Ee,children:[f.jsx("circle",{cx:"12",cy:"12",r:"9"}),f.jsx("path",{d:"M12 7v5l3 3"})]}),externalLink:f.jsxs("svg",{...Ee,children:[f.jsx("path",{d:"M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"}),f.jsx("path",{d:"M15 3h6v6"}),f.jsx("path",{d:"M10 14L21 3"})]}),menu:f.jsx("svg",{...Ee,strokeWidth:2,children:f.jsx("path",{d:"M4 6h16M4 12h16M4 18h16"})}),moreHorizontal:f.jsxs("svg",{...iu,children:[f.jsx("circle",{cx:"5",cy:"12",r:"1.5"}),f.jsx("circle",{cx:"12",cy:"12",r:"1.5"}),f.jsx("circle",{cx:"19",cy:"12",r:"1.5"})]}),search:f.jsxs("svg",{...Ee,children:[f.jsx("circle",{cx:"11",cy:"11",r:"8"}),f.jsx("path",{d:"M21 21l-4.35-4.35"})]}),arrowUp:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M12 19V5m0 0l-7 7m7-7l7 7"})}),arrowDown:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M12 5v14m0 0l7-7m-7 7l-7-7"})}),arrowsUpDown:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"})}),funnel:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z"})}),eyeSlash:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M3.98 8.223A10.477 10.477 0 001.934 12c1.292 4.338 5.31 7.5 10.066 7.5.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"})}),viewColumns:f.jsx("svg",{...Ee,children:f.jsx("path",{d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125z"})})};let zs={};function Nv(e){zs={...zs,...e}}function Df(e){return zs[e]??Av[e]}function Ov(e){return e==="base"?"":e.split("+").map(t=>{const[l,n]=t.split(":");return/^\d/.test(n)?`.${l}-${n}`:`.${n}`}).join("")}const yc={[-5]:"--font-size-4xs",[-4]:"--font-size-3xs",[-3]:"--font-size-2xs",[-2]:"--font-size-xs",[-1]:"--font-size-sm",0:"--font-size-base",1:"--font-size-lg",2:"--font-size-xl",3:"--font-size-2xl",4:"--font-size-3xl",5:"--font-size-4xl",6:"--font-size-5xl"},Dv={1:3,2:2,3:1,4:0,5:-1,6:-2},qv={body:0,large:1,label:0,code:0,supporting:-1,"display-1":6,"display-2":5,"display-3":4},Cv={1:"var(--font-weight-semibold)",2:"var(--font-weight-semibold)",3:"var(--font-weight-semibold)",4:"var(--font-weight-semibold)",5:"var(--font-weight-semibold)",6:"var(--font-weight-semibold)"},_v={body:"var(--font-weight-normal)",large:"var(--font-weight-semibold)",label:"var(--font-weight-medium)",code:"var(--font-weight-normal)",supporting:"var(--font-weight-normal)","display-1":"var(--font-weight-normal)","display-2":"var(--font-weight-normal)","display-3":"var(--font-weight-normal)"};function mc(e,t,l){return Math.round(e*Math.pow(t,l))}function Rv(e){return`${Math.round(e/16*1e4)/1e4}rem`}function Hv(e){return e<20?1.5:e<32?1.4:1.25}function $r(e){const t=Hv(e),l=e*t,n=Math.max(Math.round(l/4)*4,Math.ceil((e+4)/4)*4);return Math.round(n/e*1e4)/1e4}function Uv(e){const{base:t,ratio:l,weights:n}=e,a={},u={...Cv,...n==null?void 0:n.heading},i={..._v,...n==null?void 0:n.text};for(let c=-5;c<=6;c++){const s=mc(t,l,c);a[yc[c]]=Rv(s)}for(const[c,s]of Object.entries(Dv)){const o=Number(c),x=mc(t,l,s),h=$r(x);a[`--text-heading-${o}-size`]=`var(${yc[s]})`,a[`--text-heading-${o}-weight`]=u[o],a[`--text-heading-${o}-leading`]=`${h}`}for(const[c,s]of Object.entries(qv)){const o=mc(t,l,s),x=$r(o);a[`--text-${c}-size`]=`var(${yc[s]})`,a[`--text-${c}-weight`]=i[c],a[`--text-${c}-leading`]=`${x}`}return a}const Xv={body:"var(--font-family-body)",large:"var(--font-family-body)",label:"var(--font-family-body)",code:"var(--font-family-code)",supporting:"var(--font-family-body)","display-1":"var(--font-family-heading)","display-2":"var(--font-family-heading)","display-3":"var(--font-family-heading)"};function Bv(e){const t={},l={};for(const a of[1,2,3,4,5,6])l[`level:${a}`]={fontFamily:"var(--font-family-heading)",fontSize:`var(--text-heading-${a}-size)`,fontWeight:`var(--text-heading-${a}-weight)`,lineHeight:`var(--text-heading-${a}-leading)`};t.heading=l;const n={};for(const a of["body","large","label","code","supporting","display-1","display-2","display-3"])n[`type:${a}`]={fontFamily:Xv[a],fontSize:`var(--text-${a}-size)`,lineHeight:`var(--text-${a}-leading)`};return t.text=n,t}function Vl(e){return Math.round(e/5)*5}function Lv(e){const{fast:t,medium:l,ratio:n,easing:a}=e,u={"--duration-fast-min":`${Vl(t*n)}ms`,"--duration-fast":`${Vl(t)}ms`,"--duration-fast-max":`${Vl(t/n)}ms`,"--duration-medium-min":`${Vl(l*n)}ms`,"--duration-medium":`${Vl(l)}ms`,"--duration-medium-max":`${Vl(l/n)}ms`};return a&&(u["--ease-standard"]=a),u}function Gv(e){const{base:t,multiplier:l}=e;return{"--radius-none":"0px","--radius-inner":`${Math.round(t*1*l)}px`,"--radius-element":`${Math.round(t*2*l)}px`,"--radius-container":`${Math.round(t*3*l)}px`,"--radius-page":`${Math.round(t*7*l)}px`,"--radius-full":"9999px"}}function Zv(e){return Array.isArray(e)?`light-dark(${e[0]}, ${e[1]})`:e}function Yv(e,t){if(!e&&!t)return;if(!e)return t;if(!t)return e;const l={};for(const[n,a]of Object.entries(e))l[n]={...a};for(const[n,a]of Object.entries(t))if(!l[n])l[n]={...a};else for(const[u,i]of Object.entries(a))l[n][u]={...l[n][u],...i};return l}function cu(e){return{normal:"var(--font-weight-normal)",medium:"var(--font-weight-medium)",semibold:"var(--font-weight-semibold)",bold:"var(--font-weight-bold)"}[e]??e}function vc(e,t){if(!e)return;const l=e.includes(" ")?`"${e}"`:e;return t?`${l}, ${t}`:l}function Vv(e){var i,c,s,o,x,h,d,m;const t={},l=e.typography;let n;if(l!=null&&l.scale){const p={},k=l.heading;if(k!=null&&k.weights)for(const[r,v]of Object.entries(k.weights))v&&(p[Number(r)]=cu(v));const S=k!=null&&k.weight?cu(k.weight):void 0;if(S)for(let r=1;r<=6;r++)r in p||(p[r]=S);const y={};(i=l.body)!=null&&i.weight&&(y.body=cu(l.body.weight)),(c=l.code)!=null&&c.weight&&(y.code=cu(l.code.weight)),n={base:l.scale.base,ratio:l.scale.ratio,weights:{...Object.keys(p).length>0?{heading:p}:{},...Object.keys(y).length>0?{text:y}:{}}}}if(n){const p=Uv(n);for(const[k,S]of Object.entries(p))t[k]=S}if(e.radius){const p=Gv(e.radius);for(const[k,S]of Object.entries(p))t[k]=S}if(e.motion){const p=Lv(e.motion);for(const[k,S]of Object.entries(p))t[k]=S}if(l){const p=vc((s=l.body)==null?void 0:s.family,(o=l.body)==null?void 0:o.fallbacks),k=vc((x=l.heading)==null?void 0:x.family,(h=l.heading)==null?void 0:h.fallbacks)??p,S=vc((d=l.code)==null?void 0:d.family,(m=l.code)==null?void 0:m.fallbacks);p&&(t["--font-family-body"]=p),k&&(t["--font-family-heading"]=k),S&&(t["--font-family-code"]=S)}if(e.tokens)for(const[p,k]of Object.entries(e.tokens))k!==void 0&&(t[p]=Zv(k));let a=e.components;if(n){const p=Bv();a=Yv(p,e.components)}let u;if(l){const p=new Set,k=[];for(const S of[l.body,l.heading,l.code])S!=null&&S.family&&S.url&&!p.has(S.family)&&(p.add(S.family),k.push({family:S.family,url:S.url}));k.length>0&&(u=k)}return{name:e.name,tokens:t,components:a,icons:e.icons,fonts:u,__inputTokens:e.tokens}}function Er(e){return e.replace(/[A-Z]/g,t=>`-${t.toLowerCase()}`)}function Qv(e){const t=[],l=e.tokens,n=x=>l[x]||`var(${x})`,a=Object.entries(l);if(a.length>0){const x=a.map(([h,d])=>`    ${h}: ${d};`).join(`
+`);t.push(`  :scope {
+${x}
+  }`)}if(e.components)for(const[x,h]of Object.entries(e.components))for(const[d,m]of Object.entries(h)){const p=Object.entries(m);if(p.length>0){const k=Ov(d),S=`.xds-${x}${k}`,y=[],r=[];for(const[v,b]of p)v.startsWith(":")&&typeof b=="object"?r.push([v,b]):y.push([v,b]);if(y.length>0){const v=y.map(([b,z])=>`    ${Er(b)}: ${z};`).join(`
+`);t.push(`  ${S} {
+${v}
+  }`)}for(const[v,b]of r){const z=Object.entries(b);if(z.length>0){const w=z.map(([$,T])=>`    ${Er($)}: ${T};`).join(`
+`);t.push(`  ${S}${v} {
+${w}
+  }`)}}}}t.push(`  :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-family-heading);
+    color: var(--color-text-primary);
+  }`);for(let x=1;x<=6;x++)t.push(`  h${x} {
+    font-size: ${n(`--text-heading-${x}-size`)};
+    font-weight: ${n(`--text-heading-${x}-weight`)};
+    line-height: ${n(`--text-heading-${x}-leading`)};
+  }`);t.push(`  p {
+    font-family: var(--font-family-heading);
+    font-size: ${n("--text-body-size")};
+    font-weight: ${n("--text-body-weight")};
+    line-height: ${n("--text-body-leading")};
+    color: var(--color-text-primary);
+  }`),t.push(`  small {
+    font-size: ${n("--text-supporting-size")};
+    font-weight: ${n("--text-supporting-weight")};
+    line-height: ${n("--text-supporting-leading")};
+    color: var(--color-text-secondary);
+  }`),t.push(`  code, pre {
+    font-family: var(--font-family-code);
+    font-size: ${n("--text-code-size")};
+    line-height: ${n("--text-code-leading")};
+  }`),t.push(`  hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+  }`);const u={primary:"var(--color-text-primary)",secondary:"var(--color-text-secondary)",disabled:"var(--color-text-disabled)",placeholder:"var(--color-text-secondary)",active:"var(--color-accent)"},i=e.components||{},c="text"in i,s="heading"in i,o="link"in i;if(c||s||o)for(const[x,h]of Object.entries(u))c&&t.push(`  .xds-text.${x} { color: ${h}; }`),s&&t.push(`  .xds-heading.${x} { color: ${h}; }`),o&&t.push(`  .xds-link.${x} { color: ${h}; }`);return t}function Kv(e){const t=Qv(e);if(t.length===0)return"";const l=`[data-xds-theme="${e.name}"]`,n=t.join(`
+
+`);return`@scope (${l}) to ([data-xds-theme]) {
+${n}
+}`}const Jv=g.createContext(null),su={base:{k1xSpc:"xjp7ctv",kMwMTN:"x1tgivj0",kMv6JI:"x9ynric",$$css:!0},light:{kQNsl9:"x19aimcq",$$css:!0},dark:{kQNsl9:"xntwwlm",$$css:!0},system:{kQNsl9:"x108lcm5",$$css:!0}},hc=new Set;function Wv(e){const t=g.useId();g.useInsertionEffect(()=>{if(e.__built)return;const l=`xds-theme-${e.name}`;if(hc.has(l))return;const n=Kv(e);if(!n)return;const a=document.createElement("style");return a.setAttribute("data-xds-theme",e.name),a.setAttribute("data-xds-id",t),a.textContent=`@layer xds-theme {
+${n}
+}`,document.head.appendChild(a),hc.add(l),()=>{const u=document.querySelector(`style[data-xds-theme="${e.name}"][data-xds-id="${t}"]`);u&&(u.remove(),hc.delete(l))}},[e,t])}function Fv(e){const t=g.useRef([]);g.useLayoutEffect(()=>{if(typeof document>"u"||!e.fonts||e.fonts.length===0)return;const l=[];for(const n of e.fonts){if(document.fonts.check(`16px "${n.family}"`)||document.head.querySelector(`link[rel="stylesheet"][href="${n.url}"]`))continue;const i=document.createElement("link");i.rel="stylesheet",i.href=n.url,document.head.appendChild(i),l.push(i),console.warn(`[XDS] Theme "${e.name}" loaded font "${n.family}" at runtime. For better performance, add to your document <head>:
+  <link rel="stylesheet" href="${n.url}" />`)}return t.current=l,()=>{for(const n of t.current)n.parentNode&&n.parentNode.removeChild(n);t.current=[]}},[e.fonts,e.name])}function qf({theme:e,mode:t="system",children:l}){Wv(e),Fv(e);const n=t==="dark"?su.dark:t==="light"?su.light:su.system,a=e.icons;a!=null&&Nv(a);const u=g.useMemo(()=>({theme:e,mode:t}),[e,t]);return f.jsx(Jv.Provider,{value:u,children:f.jsx("div",{...q(su.base,n),"data-xds-theme":e.name,"data-theme":t==="system"?void 0:t,children:l})})}qf.displayName="XDSTheme";function Iv({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3"}))}const Pv=g.forwardRef(Iv);function eh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18"}))}const th=g.forwardRef(eh);function lh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"}))}const nh=g.forwardRef(lh);function ah({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"}))}const uh=g.forwardRef(ah);function ih({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"}))}const ch=g.forwardRef(ih);function sh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m4.5 12.75 6 6 9-13.5"}))}const fh=g.forwardRef(sh);function oh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m19.5 8.25-7.5 7.5-7.5-7.5"}))}const rh=g.forwardRef(oh);function dh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M15.75 19.5 8.25 12l7.5-7.5"}))}const xh=g.forwardRef(dh);function yh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m8.25 4.5 7.5 7.5-7.5 7.5"}))}const mh=g.forwardRef(yh);function vh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"}))}const hh=g.forwardRef(vh);function gh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"}))}const ph=g.forwardRef(gh);function bh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"}))}const kh=g.forwardRef(bh);function Sh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"}))}const zh=g.forwardRef(Sh);function jh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"}))}const $h=g.forwardRef(jh);function Eh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"}))}const Th=g.forwardRef(Eh);function Mh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z"}))}const wh=g.forwardRef(Mh);function Ah({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6 18 18 6M6 6l12 12"}))}const Nh=g.forwardRef(Ah);function Oh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{fillRule:"evenodd",d:"M15.75 2.25H21a.75.75 0 0 1 .75.75v5.25a.75.75 0 0 1-1.5 0V4.81L8.03 17.03a.75.75 0 0 1-1.06-1.06L19.19 3.75h-3.44a.75.75 0 0 1 0-1.5Zm-10.5 4.5a1.5 1.5 0 0 0-1.5 1.5v10.5a1.5 1.5 0 0 0 1.5 1.5h10.5a1.5 1.5 0 0 0 1.5-1.5V10.5a.75.75 0 0 1 1.5 0v8.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V8.25a3 3 0 0 1 3-3h8.25a.75.75 0 0 1 0 1.5H5.25Z",clipRule:"evenodd"}))}const Dh=g.forwardRef(Oh);function qh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{fillRule:"evenodd",d:"M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z",clipRule:"evenodd"}))}const Ch=g.forwardRef(qh);function _h({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{fillRule:"evenodd",d:"M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z",clipRule:"evenodd"}))}const Rh=g.forwardRef(_h);function Hh({title:e,titleId:t,...l},n){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:n,"aria-labelledby":t},l),e?g.createElement("title",{id:t},e):null,g.createElement("path",{fillRule:"evenodd",d:"M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-1.72 6.97a.75.75 0 1 0-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06L12 13.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L13.06 12l1.72-1.72a.75.75 0 1 0-1.06-1.06L12 10.94l-1.72-1.72Z",clipRule:"evenodd"}))}const Uh=g.forwardRef(Hh),de={width:"1em",height:"1em","aria-hidden":!0},Xh={close:f.jsx(Nh,{...de}),chevronDown:f.jsx(rh,{...de}),chevronLeft:f.jsx(xh,{...de}),chevronRight:f.jsx(mh,{...de}),check:f.jsx(fh,{...de}),checkCircle:f.jsx(Ch,{...de}),xCircle:f.jsx(Uh,{...de}),warning:f.jsx(Rh,{...de}),info:f.jsx($h,{...de}),calendar:f.jsx(ch,{...de}),clock:f.jsx(hh,{...de}),externalLink:f.jsx(Dh,{...de}),menu:f.jsx(uh,{...de}),moreHorizontal:f.jsx(ph,{...de}),search:f.jsx(Th,{...de}),arrowUp:f.jsx(th,{...de}),arrowDown:f.jsx(Pv,{...de}),arrowsUpDown:f.jsx(nh,{...de}),funnel:f.jsx(zh,{...de}),eyeSlash:f.jsx(kh,{...de}),viewColumns:f.jsx(wh,{...de})},Z1=Vv({name:"default",typography:{scale:{base:14,ratio:1.2}},motion:{fast:175,medium:410,ratio:.75},tokens:{},components:{button:{"variant:secondary":{backgroundColor:"light-dark(rgba(5, 54, 89, 0.1), rgba(223, 226, 229, 0.2))"}}},icons:Xh}),Y1=g.createContext(null),Bh={hasHeader:!1,hasFooter:!1,hasStart:!1,hasEnd:!1},Cf=g.createContext(Bh),V1=g.createContext(null),Lh={center:{kGNEyG:"x6s0dn4",$$css:!0},end:{kGNEyG:"xuk3077",$$css:!0},start:{kGNEyG:"x1cy8zhl",$$css:!0},stretch:{kGNEyG:"x1qjc9v5",$$css:!0}},Gh={start:{kjj79g:"x1nhvcw1",$$css:!0},center:{kjj79g:"xl56j7k",$$css:!0},end:{kjj79g:"x13a6bvl",$$css:!0},between:{kjj79g:"x1qughib",$$css:!0},around:{kjj79g:"x1l1ennw",$$css:!0},evenly:{kjj79g:"xaw8158",$$css:!0}},Zh={horizontal:{kXwgrk:"x1q0g3np",$$css:!0},vertical:{kXwgrk:"xdt5ytf",$$css:!0}},Yh={nowrap:{kwnvtZ:"xozqiw3",$$css:!0},wrap:{kwnvtZ:"x1a02dak",$$css:!0},"wrap-reverse":{kwnvtZ:"x8hhl5t",$$css:!0}},Vh={stack:{k1xSpc:"x78zum5",$$css:!0}},Qh={0:{k1C7PZ:"x1o57wo1",khm7nJ:"x6yxi7o",$$css:!0},1:{k1C7PZ:"x1lfs0n9",khm7nJ:"x1ngg2t4",$$css:!0},2:{k1C7PZ:"xak3so",khm7nJ:"x1x7z4sm",$$css:!0},3:{k1C7PZ:"xewh9hi",khm7nJ:"x4olc9o",$$css:!0},4:{k1C7PZ:"xty4p9g",khm7nJ:"xtx9w7w",$$css:!0},5:{k1C7PZ:"x1eqhezk",khm7nJ:"x1iu6piu",$$css:!0},6:{k1C7PZ:"x3qlgwd",khm7nJ:"xczp1bk",$$css:!0},8:{k1C7PZ:"xicv188",khm7nJ:"xgx0vcf",$$css:!0},10:{k1C7PZ:"x1p37tyl",khm7nJ:"x1xpicb7",$$css:!0},"0.5":{k1C7PZ:"x1kihgfc",khm7nJ:"x1tw44j4",$$css:!0},"1.5":{k1C7PZ:"x1thn6ci",khm7nJ:"xhq53yo",$$css:!0}};function js({crossAlign:e,direction:t,gap:l,mainAlign:n,wrap:a}){return[Vh.stack,Zh[t],l!=null&&Qh[l],e!=null&&Lh[e],n!=null&&Gh[n],a!=null&&Yh[a]]}const Kh={reset:{kAzted:"x2lwn1j",k7Eaqz:"xeuugli",$$css:!0}},Jh={center:{kSGwAc:"xamitd3",$$css:!0},end:{kSGwAc:"xpvyfi4",$$css:!0},start:{kSGwAc:"xqcrz7y",$$css:!0},stretch:{kSGwAc:"xkh2ocl",$$css:!0}},Wh={fill:{kzQI83:"x1iyjqo2",$$css:!0},static:{kzQI83:"x1c4vz4f",kmuXW:"x2lah0s",$$css:!0}};function Fh({crossAlignSelf:e,size:t}={}){return[Kh.reset,Wh[t??"static"],e!=null&&Jh[e]]}function G(e,t){const l=[`xds-${e}`];if(t)for(const[n,a]of Object.entries(t)){if(a==null)continue;const u=String(a);/^\d/.test(u)?l.push(`${n}-${u}`):l.push(u)}return l.join(" ")}function V(e,t,l,n){let a=t.className?`${e} ${t.className}`:e;l&&(a=`${a} ${l}`);const u=n&&t.style?{...t.style,...n}:n||t.style;return{className:a,style:u}}const Ih={0:"spacing0",.5:"spacing0_5",1:"spacing1",1.5:"spacing1_5",2:"spacing2",3:"spacing3",4:"spacing4",5:"spacing5",6:"spacing6",8:"spacing8",10:"spacing10"},ji={0:{kZCmMZ:"x18gyask",kwRFfy:"x1s0aq8i",kLKAdn:"x1ydh6w3",kGO01o:"x1l20ajd",$$css:!0},1:{kZCmMZ:"x1vsv5vr",kwRFfy:"x1nryj5t",kLKAdn:"xfsso4q",kGO01o:"xy143xn",$$css:!0},2:{kZCmMZ:"x12gdq22",kwRFfy:"x1djylfy",kLKAdn:"x1xye8es",kGO01o:"x1wesfrj",$$css:!0},3:{kZCmMZ:"x126nfab",kwRFfy:"x1t818jl",kLKAdn:"x1vlblms",kGO01o:"xvmdzux",$$css:!0},4:{kZCmMZ:"x1rey3nv",kwRFfy:"xnjyzlh",kLKAdn:"x1oa1p4a",kGO01o:"x1awphl8",$$css:!0},5:{kZCmMZ:"x1blguxw",kwRFfy:"xdbrk9v",kLKAdn:"xx7rijo",kGO01o:"x1hk98q",$$css:!0},6:{kZCmMZ:"x31w388",kwRFfy:"x1we12cn",kLKAdn:"x1adxfkp",kGO01o:"xjpqqx5",$$css:!0},8:{kZCmMZ:"x1j3hnjz",kwRFfy:"x1q91b2g",kLKAdn:"xoxd1wu",kGO01o:"x2oz4g1",$$css:!0},10:{kZCmMZ:"xqp078j",kwRFfy:"x160ivqr",kLKAdn:"xk6660b",kGO01o:"x2izi54",$$css:!0},"0.5":{kZCmMZ:"x138rykx",kwRFfy:"x1le3yxw",kLKAdn:"xbx876j",kGO01o:"xij103a",$$css:!0},"1.5":{kZCmMZ:"xfti1ec",kwRFfy:"x17hk9do",kLKAdn:"x1kwdpsa",kGO01o:"x1opdxmq",$$css:!0}},$i={0:{"--container-padding-inline":"x11nj8ps",$$css:!0},1:{"--container-padding-inline":"xmqp8mn",$$css:!0},2:{"--container-padding-inline":"xvkq9sf",$$css:!0},3:{"--container-padding-inline":"x17rklng",$$css:!0},4:{"--container-padding-inline":"x1qtkjpi",$$css:!0},5:{"--container-padding-inline":"xcek0mv",$$css:!0},6:{"--container-padding-inline":"xzryng3",$$css:!0},8:{"--container-padding-inline":"x1t3jwqk",$$css:!0},10:{"--container-padding-inline":"x1mh38z9",$$css:!0},"0.5":{"--container-padding-inline":"x1qmdwou",$$css:!0},"1.5":{"--container-padding-inline":"x11c4xrl",$$css:!0}},Ph={0:{"--layout-padding-outer-x":"xswhm3q",$$css:!0},1:{"--layout-padding-outer-x":"xc96xmq",$$css:!0},2:{"--layout-padding-outer-x":"x15dxnc0",$$css:!0},3:{"--layout-padding-outer-x":"xadgj3j",$$css:!0},4:{"--layout-padding-outer-x":"x1v56qcf",$$css:!0},5:{"--layout-padding-outer-x":"x1nzs0gl",$$css:!0},6:{"--layout-padding-outer-x":"x1c3n52a",$$css:!0},8:{"--layout-padding-outer-x":"x1t3kfz",$$css:!0},10:{"--layout-padding-outer-x":"x1jdf5a4",$$css:!0},"0.5":{"--layout-padding-outer-x":"xihiwg7",$$css:!0},"1.5":{"--layout-padding-outer-x":"x1u93lgd",$$css:!0}},eg={0:{"--layout-padding-outer-y":"x1mzf5mb",$$css:!0},1:{"--layout-padding-outer-y":"x1gpfxoh",$$css:!0},2:{"--layout-padding-outer-y":"x10pz7y9",$$css:!0},3:{"--layout-padding-outer-y":"x1p6yq3h",$$css:!0},4:{"--layout-padding-outer-y":"xx738ci",$$css:!0},5:{"--layout-padding-outer-y":"x6yxws5",$$css:!0},6:{"--layout-padding-outer-y":"x180vrwl",$$css:!0},8:{"--layout-padding-outer-y":"xid7e43",$$css:!0},10:{"--layout-padding-outer-y":"x26l4wa",$$css:!0},"0.5":{"--layout-padding-outer-y":"x1vj96e0",$$css:!0},"1.5":{"--layout-padding-outer-y":"xd3dqby",$$css:!0}},Vt={layoutOuter:{kogj98:"x1ak00ur",$$css:!0},layoutInner:{"--container-padding":"xbuvapz",$$css:!0},fill:{kZKoxP:"x1x2thlr",kskxy:"xenllk4",$$css:!0},auto:{kAzted:"x1us19tq",$$css:!0},middle:{kUk6DE:"x98rzlu",kAzted:"x2lwn1j",$$css:!0},fullBleed:{"--layout-padding-outer-x":"x1wbjvqu","--layout-padding-outer-y":"xzxxx64",$$css:!0}};function Kn({area:e,children:t}){return t==null?null:f.jsx(Y1.Provider,{value:e,children:t})}function Q1({content:e,defaultHasDividers:t,end:l,footer:n,header:a,height:u="fill",padding:i,ref:c,start:s,xstyle:o,className:x,style:h}){const d=u==="fill",m=g.useMemo(()=>t!=null?{defaultHasDividers:t}:null,[t]),p=g.useMemo(()=>({hasHeader:a!=null,hasFooter:n!=null,hasStart:s!=null,hasEnd:l!=null}),[a!=null,n!=null,s!=null,l!=null]),k=f.jsx(Cf.Provider,{value:p,children:f.jsx("div",{ref:c,...V(G("layout",{height:u}),q(Vt.layoutOuter,d?Vt.fill:Vt.auto,o),x,h),children:f.jsxs("div",{...q({"x-default-marker":"x-default-marker",$$css:!0},Vt.layoutInner,...js({direction:"vertical"}),d?Vt.fill:Vt.auto,i===0&&Vt.fullBleed,i!=null&&Ph[i],i!=null&&eg[i]),children:[f.jsx(Kn,{area:"header",children:a}),f.jsxs("div",{...q(...js({direction:"horizontal"}),Vt.middle),children:[f.jsx(Kn,{area:"start",children:s}),f.jsx("div",{...q(...Fh({size:"fill"})),children:f.jsx(Kn,{area:"content",children:e})}),f.jsx(Kn,{area:"end",children:l})]}),f.jsx(Kn,{area:"footer",children:n})]})})});return m!=null?f.jsx(V1.Provider,{value:m,children:k}):k}Q1.displayName="XDSLayout";const gc={header:{kB7OPa:"x9f619",kmuXW:"x2lah0s",kZCmMZ:"x139j0dd",kwRFfy:"xpc6k2p",kLKAdn:"x81pis9",kGO01o:"xg476vw",$$css:!0},fullBleed:{kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",$$css:!0},divider:{kt9PQ7:"xso031l",kfdmCh:"x1q0q8m5",kL6WhQ:"xw8gpjh",$$css:!0}},tg={sizing:e=>[{kZKoxP:e!=null?"x16ye13r":e,$$css:!0},{"--x-height":(t=>typeof t=="number"?t+"px":t??void 0)(e)}]};function $s({children:e,hasDivider:t,height:l,label:n,padding:a,role:u,xstyle:i,className:c,style:s,ref:o,...x}){const h=g.useContext(V1),d=t??(h==null?void 0:h.defaultHasDividers)??!1,m=a===0;return f.jsx("div",{ref:o,role:u,"aria-label":n,"data-divider":d||void 0,...V(G("layout-header"),q(gc.header,tg.sizing(l??null),m&&gc.fullBleed,a!=null&&ji[a],a!=null&&$i[a],d&&gc.divider,i),c,s),...x,children:e})}$s.displayName="XDSLayoutHeader";const yt={panel:{kB7OPa:"x9f619",kmuXW:"x2lah0s",kVQacm:"x7giv3",kZCmMZ:"xwjyata",kwRFfy:"x1peupej",kLKAdn:"xqty4a",kGO01o:"xg476vw",$$css:!0},startPanel:{kZCmMZ:"x139j0dd",$$css:!0},endPanel:{kwRFfy:"xpc6k2p",$$css:!0},noHeader:{kLKAdn:"x81pis9",$$css:!0},noFooter:{kGO01o:"xon7vh3",$$css:!0},fullBleed:{kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",$$css:!0},scrollable:{kVQacm:"xysyzu8",$$css:!0},dividerEnd:{ke9TFa:"x1lun4ml",k8ry5P:"x18b5jzi",kBCPoo:"x1gejf6u",$$css:!0},dividerStart:{k2ei4v:"xpilrb4",kVhnKS:"x1t7ytsu",kGJrpR:"x1j92z86",$$css:!0},collapseStart:{keTefX:"x1wim8z0",$$css:!0},collapseEnd:{k71WvV:"x1kpg4um",$$css:!0}},lg={sizing:e=>[{kzqmXN:e!=null?"x5lhr3w":e,$$css:!0},{"--x-width":(t=>typeof t=="number"?t+"px":t??void 0)(e)}]};function K1({children:e,hasDivider:t=!1,isScrollable:l=!0,label:n,padding:a,role:u,width:i,xstyle:c,className:s,style:o,ref:x,...h}){const d=g.useContext(Y1),{hasHeader:m,hasFooter:p}=g.useContext(Cf),k=d==="start",S=d==="end",y=a===0,r=!t&&!y&&a==null,v=k?yt.dividerEnd:S?yt.dividerStart:null,b=k?yt.collapseEnd:S?yt.collapseStart:null;return f.jsx("div",{ref:x,role:u,"aria-label":n,...V(G("layout-panel"),q(yt.panel,lg.sizing(i??null),k&&!y&&a==null&&yt.startPanel,S&&!y&&a==null&&yt.endPanel,!m&&!y&&a==null&&yt.noHeader,!p&&!y&&a==null&&yt.noFooter,l&&yt.scrollable,y&&yt.fullBleed,a!=null&&ji[a],a!=null&&$i[a],t&&v,r&&b,c),s,o),...h,children:e})}K1.displayName="XDSLayoutPanel";const Sl={content:{kB7OPa:"x9f619",kZKoxP:"x5yr21d",kUk6DE:"x98rzlu",kAzted:"x2lwn1j",kVQacm:"x7giv3",kZCmMZ:"xwjyata",kwRFfy:"x1peupej",kLKAdn:"xqty4a x1c51l3k",kGO01o:"xg476vw x1o6z09h",$$css:!0},noStart:{kZCmMZ:"x139j0dd",$$css:!0},noEnd:{kwRFfy:"xpc6k2p",$$css:!0},noHeader:{kLKAdn:"x81pis9",$$css:!0},noFooter:{kGO01o:"xon7vh3",$$css:!0},scrollable:{kVQacm:"xysyzu8",$$css:!0},fullBleed:{kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",$$css:!0}};function J1({children:e,isScrollable:t=!0,padding:l,label:n,role:a,xstyle:u,className:i,style:c,ref:s,...o}){const{hasHeader:x,hasFooter:h,hasStart:d,hasEnd:m}=g.useContext(Cf),p=l===0;return f.jsx("div",{ref:s,role:a,"aria-label":n,...V(G("layout-content"),q(Sl.content,!d&&!p&&l==null&&Sl.noStart,!m&&!p&&l==null&&Sl.noEnd,!x&&!p&&l==null&&Sl.noHeader,!h&&!p&&l==null&&Sl.noFooter,t&&Sl.scrollable,p&&Sl.fullBleed,l!=null&&ji[l],l!=null&&$i[l],u),i,c),...o,children:e})}J1.displayName="XDSLayoutContent";const pc={base:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x1lziwak",k71WvV:"x14z9mp",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kMzoRj:"xc342km",ksu8eU:"xng3xce",kVQacm:"x1rea2x4",kWkggS:"xjbqb8w",$$css:!0},fixed:{kVAEAm:"xixxii4",$$css:!0}};function ng(e="above",t="center"){const n={above:"top",below:"bottom",start:"left",end:"right"}[e];return e==="above"||e==="below"?t==="start"?`${n} span-right`:t==="end"?`${n} span-left`:n:t==="start"?`${n} span-bottom`:t==="end"?`${n} span-top`:`${n} center`}function W1(e){const{mode:t,onShow:l,onHide:n,lightDismiss:a=!1}=e,u=g.useId(),i=`--xds-layer-${u.replace(/:/g,"")}`,[c,s]=g.useState(!1),o=g.useRef(null),x=g.useRef(null),h=g.useCallback(()=>{o.current&&!o.current.matches(":popover-open")&&(o.current.showPopover(),s(!0),l==null||l())},[l]),d=g.useCallback(()=>{var r;(r=o.current)!=null&&r.matches(":popover-open")&&(o.current.hidePopover(),s(!1),n==null||n())},[n]),m=t==="context"?r=>{x.current&&(x.current.style.anchorName=""),r&&(r.style.anchorName=i),x.current=r}:void 0,p=g.useCallback(r=>{const v=r;v.newState==="closed"?(s(!1),n==null||n()):v.newState==="open"&&(s(!0),l==null||l())},[l,n]),k=g.useCallback(r=>{o.current=r,r&&r.addEventListener("toggle",p)},[p]),S=g.useCallback((r,v)=>{const{placement:b="above",alignment:z="center",xstyle:w,className:$,style:T}=v||{},E={positionAnchor:i,positionArea:ng(b,z),positionTryFallbacks:"flip-block, flip-inline, flip-block flip-inline"},M=q(pc.base,w),D=$?`${$} ${M.className??""}`:M.className;return f.jsx("div",{ref:k,id:u,popover:a?"auto":"manual",className:D,style:{...M.style,...E,...T},children:r})},[i,u,a,k]),y=g.useCallback((r,v)=>{const{x:b,y:z,xstyle:w,className:$,style:T}=v,E={top:z,left:b},M=q(pc.base,pc.fixed,w),D=$?`${$} ${M.className??""}`:M.className;return f.jsx("div",{ref:k,id:u,popover:a?"auto":"manual",className:D,style:{...M.style,...E,...T},children:r})},[k,u,a]);return t==="context"?{ref:m,anchorId:i,show:h,hide:d,isOpen:c,id:u,render:S}:{ref:void 0,show:h,hide:d,isOpen:c,id:u,render:y}}const ag={below:{kKVMdj:"xl1vlw0",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},above:{kKVMdj:"x3psbcj",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},end:{kKVMdj:"x1i331go",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},start:{kKVMdj:"xck01x9",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}},bc={container:{kWkggS:"x19aspcf",kMwMTN:"xrkvqaz",kaIpWk:"x1hviunn",kMv6JI:"x9ynric",kGuDYH:"xjm74w1",kLWn49:"xw6l6zx",$$css:!0},marginBlock:{keoZOQ:"xcsaf9d",k1K539:"x14cgwvg",keTefX:"x1lziwak",k71WvV:"x14z9mp",$$css:!0},marginInline:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x11g1kdw",k71WvV:"xnur1sd",$$css:!0}};function ug(e){return e.hasAttribute("tabindex")?e.tabIndex>=0:["A","BUTTON","INPUT","SELECT","TEXTAREA"].includes(e.tagName)?!e.disabled:!!e.isContentEditable}function ig(e={}){const{placement:t="above",alignment:l="center",delay:n=200,hideDelay:a=0,focusTrigger:u="auto",isEnabled:i=!0,onShow:c,onHide:s}=e,o=t==="above"||t==="below"?bc.marginBlock:bc.marginInline,x=W1({mode:"context",onShow:c,onHide:s}),h=[bc.container,o],d=g.useRef(null),m=g.useRef(null),p=g.useRef(null),k=g.useCallback(()=>{d.current&&(clearTimeout(d.current),d.current=null),m.current&&(clearTimeout(m.current),m.current=null)},[]),S=g.useCallback(()=>{i&&(k(),d.current=setTimeout(()=>{x.show()},n))},[i,k,x,n]),y=g.useCallback(()=>{k(),a>0?m.current=setTimeout(()=>{x.hide()},a):x.hide()},[k,x,a]),r=g.useCallback(()=>{typeof window<"u"&&typeof window.matchMedia=="function"&&window.matchMedia("(hover: none)").matches||S()},[S]),v=g.useCallback(()=>{y()},[y]),b=g.useCallback(E=>{!i||!E.target.matches(":focus-visible")||(k(),x.show())},[i,k,x]),z=g.useCallback(()=>{y()},[y]),w=g.useCallback(E=>{p.current&&(p.current.removeEventListener("mouseenter",r),p.current.removeEventListener("mouseleave",v),p.current.removeEventListener("focusin",b),p.current.removeEventListener("focusout",z)),E&&(E.addEventListener("mouseenter",r),E.addEventListener("mouseleave",v),(u==="always"||u==="auto"&&ug(E))&&(E.addEventListener("focusin",b),E.addEventListener("focusout",z))),p.current=E},[u,r,v,b,z]),$=g.useCallback(E=>{x.ref(E),w(E)},[x.ref,w]);g.useEffect(()=>()=>{k()},[k]);const T=g.useCallback((E,M)=>{const D=(M==null?void 0:M.placement)??t,R={placement:D,alignment:(M==null?void 0:M.alignment)??l,xstyle:[h,ag[D]],className:G("tooltip")};return x.render(f.jsx("div",{className:"xfsso4q xy143xn x12gdq22 x1djylfy xw5ewwj x13faqbe",children:E}),R)},[x,t,l,h]);return{ref:$,positionRef:x.ref,interactionRef:w,anchorId:x.anchorId,describedBy:x.id,renderTooltip:T}}function cg(e){let t=!1;return Ff.Children.forEach(e,l=>{Ff.isValidElement(l)&&(t=!0)}),!t}function Tr(...e){const t=e.filter(Boolean);return t.length>0?t.join(" "):void 0}function Ba({children:e,anchorRef:t,content:l,placement:n="above",alignment:a="center",delay:u=200,hideDelay:i=0,focusTrigger:c="auto",isEnabled:s=!0,onOpenChange:o,hasHoverIndication:x="auto"}){const h=g.useRef(null),d=e!=null?cg(e):!1,m=x===!0||x==="auto"&&d,p=g.useCallback(()=>{o==null||o(!0)},[o]),k=g.useCallback(()=>{o==null||o(!1)},[o]),S=ig({placement:n,alignment:a,delay:u,hideDelay:i,focusTrigger:c,isEnabled:s,onShow:p,onHide:k});return g.useLayoutEffect(()=>{if(!t)return;const y=t.current;if(!y)return;S.ref(y);const r=y.getAttribute("aria-describedby");return y.setAttribute("aria-describedby",Tr(r,S.describedBy)??""),()=>{S.ref(null),r?y.setAttribute("aria-describedby",r):y.removeAttribute("aria-describedby")}},[t,S.ref,S.describedBy]),g.useLayoutEffect(()=>{if(t||d)return;const y=h.current;if(!y)return;const r=y.firstElementChild;if(!r)return;S.ref(r);const v=r.getAttribute("aria-describedby");return r.setAttribute("aria-describedby",Tr(v,S.describedBy)??""),()=>{S.ref(null),v?r.setAttribute("aria-describedby",v):r.removeAttribute("aria-describedby")}},[t,d,S.ref,S.describedBy]),t&&e==null?f.jsx(f.Fragment,{children:S.renderTooltip(l)}):d?f.jsxs(f.Fragment,{children:[f.jsx("span",{ref:S.ref,tabIndex:0,"aria-describedby":S.describedBy,...{0:{className:"xt0psk2"},1:{className:"xt0psk2 xujl8zx xev0dqp xycaml9 xrys4gj"}}[!!m<<0],children:e}),S.renderTooltip(l)]}):f.jsxs(f.Fragment,{children:[f.jsx("div",{ref:h,className:"xjp7ctv",children:e}),S.renderTooltip(l)]})}Ba.displayName="XDSTooltip";const F1=Object.freeze(Object.defineProperty({__proto__:null,XDSTooltip:Ba},Symbol.toStringTag,{value:"Module"})),sg="modulepreload",fg=function(e,t){return new URL(e,t).href},Mr={},I1=function(t,l,n){let a=Promise.resolve();if(l&&l.length>0){const i=document.getElementsByTagName("link"),c=document.querySelector("meta[property=csp-nonce]"),s=(c==null?void 0:c.nonce)||(c==null?void 0:c.getAttribute("nonce"));a=Promise.allSettled(l.map(o=>{if(o=fg(o,n),o in Mr)return;Mr[o]=!0;const x=o.endsWith(".css"),h=x?'[rel="stylesheet"]':"";if(!!n)for(let p=i.length-1;p>=0;p--){const k=i[p];if(k.href===o&&(!x||k.rel==="stylesheet"))return}else if(document.querySelector(`link[href="${o}"]${h}`))return;const m=document.createElement("link");if(m.rel=x?"stylesheet":sg,x||(m.as="script"),m.crossOrigin="",m.href=o,s&&m.setAttribute("nonce",s),document.head.appendChild(m),x)return new Promise((p,k)=>{m.addEventListener("load",p),m.addEventListener("error",()=>k(new Error(`Unable to preload CSS for ${o}`)))})}))}function u(i){const c=new Event("vite:preloadError",{cancelable:!0});if(c.payload=i,window.dispatchEvent(c),!c.defaultPrevented)throw i}return a.then(i=>{for(const c of i||[])c.status==="rejected"&&u(c.reason);return t().catch(u)})},P1={primary:{kMwMTN:"x1tgivj0",$$css:!0},secondary:{kMwMTN:"xv1l7n4",$$css:!0},disabled:{kMwMTN:"xnbbluu",$$css:!0},placeholder:{kMwMTN:"xv1l7n4",$$css:!0},active:{kMwMTN:"xqwr325",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0}},og={normal:{k63SB2:"x1sodnla",$$css:!0},medium:{k63SB2:"x1e4wzip",$$css:!0},semibold:{k63SB2:"x2mo6ok",$$css:!0},bold:{k63SB2:"x1lvx875",$$css:!0}},rg={body:{k63SB2:"xxovm9e",$$css:!0},large:{k63SB2:"x149oux8",$$css:!0},label:{k63SB2:"xmhvcl5",$$css:!0},code:{k63SB2:"xx3eeay",$$css:!0},supporting:{k63SB2:"xv8on6e",$$css:!0},"display-1":{k63SB2:"x1txul5o",$$css:!0},"display-2":{k63SB2:"x1y36c3f",$$css:!0},"display-3":{k63SB2:"x1on40hk",$$css:!0}},e0={inline:{k1xSpc:"xt0psk2",$$css:!0},block:{k1xSpc:"x1lliihq",$$css:!0}},ni={singleLine:{kVQacm:"xb3r6kr",kg5iWk:"xlyipyv",khDVqt:"xuxw1ft",k1xSpc:"x1lliihq",$$css:!0},multiLine:{kVQacm:"xb3r6kr",k1xSpc:"x104kibb",kgKLqz:"x1ua5tub",$$css:!0}},t0={"break-word":{kTgw9:"x1lldw8n",kHjlTd:"x1mzt3pk",$$css:!0},"break-all":{kTgw9:"x1yn0g08",$$css:!0}},l0={wrap:{kN2L0X:"xk4td0m",$$css:!0},nowrap:{kN2L0X:"xebhuq6",$$css:!0},balance:{kN2L0X:"x1w2vvpw",$$css:!0},pretty:{kN2L0X:"x1fzhlzt",$$css:!0}},n0={enabled:{kxwWH2:"x1b2iylo",kzeHkT:"xwgcxoh",k1xSpc:"x1lliihq",$$css:!0}},a0={strikethrough:{kybGjl:"xmqliwb",$$css:!0}},dg={enabled:{kcqcaj:"xss6m8b",$$css:!0}},u0={content:{ks0D6T:"xw5ewwj",kTgw9:"x13faqbe",$$css:!0}};function i0(e){const{maxLines:t}=e,[l,n]=g.useState(!1),[a,u]=g.useState(""),i=g.useRef(null),c=g.useRef(null),s=g.useCallback(x=>{if(t===0){n(!1);return}u(x.textContent??""),n(t===1?x.scrollWidth>x.offsetWidth:x.scrollHeight>x.offsetHeight)},[t]);return{ref:g.useCallback(x=>{c.current&&(c.current.disconnect(),c.current=null),i.current=x,x&&t>0?(s(x),typeof ResizeObserver<"u"&&(c.current=new ResizeObserver(()=>{s(x)}),c.current.observe(x))):(n(!1),u(""))},[t,s]),isTruncated:l,fullText:a}}const xg=g.lazy(()=>I1(()=>Promise.resolve().then(()=>F1),void 0,import.meta.url).then(e=>({default:e.XDSTooltip}))),yg={body:"primary",large:"primary",label:"primary",supporting:"secondary",code:"primary","display-1":"primary","display-2":"primary","display-3":"primary"};function _f({type:e,size:t,color:l,weight:n,display:a="inline",maxLines:u=0,hasTruncateTooltip:i=!0,wordBreak:c,textWrap:s,hasCapsize:o=!1,hasStrikethrough:x=!1,hasTabularNumbers:h=!1,xstyle:d,className:m,style:p,as:k="span",children:S,ref:y,...r}){const v=l??yg[e],b=c??(u===1?"break-all":"break-word"),z=u>0||o?"block":a,w=i0({maxLines:u}),$=typeof i=="string"?i:"above",T=u>0&&i!==!1&&w.isTruncated,E=g.useRef(null),M=g.useCallback(R=>{typeof y=="function"?y(R):y&&(y.current=R),w.ref(R),E.current=R},[y,w.ref]),D=u>1?{WebkitLineClamp:u}:void 0;return f.jsxs(f.Fragment,{children:[f.jsx(k,{ref:M,...V(G("text",{type:e,color:v}),q(P1[v],rg[e],n&&og[n],u===1?ni.singleLine:u>1?ni.multiLine:e0[z],u>0&&t0[b],s&&l0[s],o&&n0.enabled,x&&a0.strikethrough,h&&dg.enabled,d),m,{...p,...D}),title:T?w.fullText:void 0,...r,children:S}),T&&f.jsx(g.Suspense,{fallback:null,children:f.jsx(xg,{anchorRef:E,content:f.jsx("span",{...q(u0.content),children:w.fullText}),placement:$})})]})}_f.displayName="XDSText";const mg=.75,wr=1.5,Ar={sm:{diameter:10,border:3},md:{diameter:14,border:3},lg:{diameter:18,border:3},xl:{diameter:28,border:4}},Nr={wrapper:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",$$css:!0},spinner:{k1xSpc:"x1rg5ohu",kVQacm:"xb3r6kr",kXLuUW:"xxymvpz",$$css:!0}};function Ei({size:e="md",shade:t="default",label:l,xstyle:n,className:a,"aria-label":u,"data-testid":i,ref:c}){const s=g.useRef(null);g.useEffect(()=>{const k=s.current;if(k==null)return;const S=k.getContext("2d");if(!S)return;const{border:y,diameter:r}=Ar[e],v=window.devicePixelRatio||1,b=getComputedStyle(k),z=t==="onMedia"?b.getPropertyValue(jr["--color-on-dark"])||"#FFFFFF":b.getPropertyValue(jr["--color-accent"])||"#0064E0",w=t==="onMedia"?"rgba(255, 255, 255, 0.3)":"rgba(0, 0, 0, 0.1)",$=r/2*v,T=y*v,E=($+T)*2;k.height=k.width=E,k.style.width=k.style.height=E/v+"px",S.lineCap="round",S.lineWidth=T;const M=E/2;S.beginPath(),S.arc(M,M,$,0,2*Math.PI),S.strokeStyle=w,S.stroke(),S.beginPath(),S.arc(M,M,$,wr*Math.PI,(wr+mg)%2*Math.PI),S.strokeStyle=z,S.stroke()},[t,e]);const{border:o,diameter:x}=Ar[e],h=x+o*2,d=l!=null,m=u??(typeof l=="string"?l:void 0)??"Loading",p=f.jsx("span",{ref:d?void 0:c,role:"status","aria-label":m,"data-testid":d?void 0:i,...V(d?"":G("spinner",{size:e,shade:t}),q(Nr.spinner,!d&&n),d?void 0:a),style:{width:h,height:h},children:f.jsx("canvas",{ref:s,className:"xlp1x4z x1lliihq xqgcaz xa4qsjk x1ka1v4i x1esw782"})});return d?f.jsxs("div",{ref:c,"data-testid":i,...V(G("spinner",{size:e,shade:t}),q(Nr.wrapper,n),a),children:[p,typeof l=="string"?f.jsx(_f,{type:"body",weight:"bold",children:l}):l]}):p}Ei.displayName="XDSSpinner";const kc={start:{"--edge-start":"x1tfgai2",$$css:!0},end:{"--edge-end":"xwfoc2r",$$css:!0}},vg={self:{keTefX:"xg82z56",k71WvV:"xofqkxr",$$css:!0}},hg=g.createContext(null);function Ti(e){const t=g.useContext(hg);return e??(t==null?void 0:t.component)??"a"}const Ql={base:{kVAEAm:"x1n2onr6",k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kOIVth:"x1txdalj",k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kMzoRj:"xc342km",ksu8eU:"xng3xce","--button-radius":"x1mkq5kp",kaIpWk:"x1q11iln",kMv6JI:"xjb2p0i",kGuDYH:"xcr08ib",kLWn49:"x1kq96og",k63SB2:"x1e4wzip",khDVqt:"xuxw1ft",kkrTdU:"x1ypdohk",k1ekBW:"xqc8rvf",kIyJzY:"xuedmi6 x12w9bfk",kAMwcw:"xlr8y92",k3aq6I:"x3oybdh xk4oym4",$$css:!0},disabled:{kkrTdU:"x1h6gzvc",kSiTet:"xbyyjgo",kKwaWg:"x18o3ruo",k3aq6I:"x1c071of x1pdlv7q",$$css:!0},ariaDisabled:{kKwaWg:"x18o3ruo x8o3jvd xuqm82a",$$css:!0},iconOnly:{"--button-icon-only-aspect":"x1v15ycx",kOBAk4:"xioom0i",kg3NbH:"xf314gf",$$css:!0},iconWrapper:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0},link:{kybGjl:"x1hl2dhg",$$css:!0}},gg={sm:{kZKoxP:"x6k0iem",$$css:!0},md:{kZKoxP:"x1ueg155",$$css:!0},lg:{kZKoxP:"xssyfek",$$css:!0}},pg={sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},lg:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0}},bg={primary:{kWkggS:"x1ewilqj",kMwMTN:"x17wrial",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},secondary:{kWkggS:"x17x4s8c",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},ghost:{kWkggS:"xjbqb8w",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},destructive:{kWkggS:"x1pjz0fi",kMwMTN:"x1m024r3",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x1p73he7","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0}},kg={loading:{kVAEAm:"x1n2onr6",kMwMTN:"x19co3pv",$$css:!0}},Or={paddingInline2:{"--component-padding-inline":"x30uzy1",$$css:!0},paddingInline3:{"--component-padding-inline":"x1ojg8sz",$$css:!0}};function La({label:e,variant:t="secondary",size:l="md",type:n="button",isDisabled:a=!1,isLoading:u=!1,onClickAction:i,icon:c,children:s,endContent:o,tooltip:x,href:h,as:d,target:m,rel:p,xstyle:k,className:S,style:y,ref:r,...v}){const[b,z]=g.useTransition(),w=g.useRef(!1),$=u||b,T=a||$,E=t==="primary"||t==="destructive",M=c!=null&&s==null,D=Ti(d),R=h!=null&&!T,Z=x!=null&&T,ce=J=>{var me;if(T||w.current){J.preventDefault();return}(me=v.onClick)==null||me.call(v,J),i&&!J.defaultPrevented&&(w.current=!0,z(async()=>{try{await i(J)}finally{w.current=!1}}))},fe=Z?J=>{var me;J.key==="Enter"||J.key===" "?J.preventDefault():(me=v.onKeyDown)==null||me.call(v,J)}:void 0,A=t==="ghost",N=A?vg.self:null,O=A?M?Or.paddingInline2:Or.paddingInline3:null,Y=q(Ql.base,gg[l],bg[t],M&&Ql.iconOnly,T&&Ql.disabled,Z&&Ql.ariaDisabled,$&&kg.loading,O,N,R&&Ql.link,k),I=V(G("button",{variant:t,size:l}),Y,S,y),$e=f.jsxs(f.Fragment,{children:[$&&f.jsx("span",{className:"x10l6tqk x13vifvy xu96u03 x3m8u43 x1ey2m1c x78zum5 x6s0dn4 xl56j7k","aria-hidden":"true",children:f.jsx(Ei,{size:"sm",shade:E?"onMedia":"default"})}),f.jsxs("span",{className:"xjp7ctv","aria-hidden":$||void 0,children:[c&&f.jsx("span",{...q(Ql.iconWrapper,pg[l]),children:c}),M?null:f.jsx("span",{className:"xb3r6kr xlyipyv xeuugli",children:s??e}),!M&&o&&f.jsx("span",{className:"x3nfvp2 x6s0dn4 x1heor9g",children:o})]}),f.jsx("span",{className:"x10l6tqk x1i1rx1s xjm9jq1 x1717udv xkdpibf xb3r6kr xzpqnlu xuxw1ft xc342km",role:"status","aria-live":"polite",children:$?"Loading":""})]}),De=M&&e!==""||$&&!M?{"aria-label":e}:null;let qe;return R?qe=f.jsx(D,{ref:r,href:h,target:m,rel:p,...I,...v,...De,onClick:ce,children:$e}):qe=f.jsx("button",{ref:r,type:n,disabled:Z?void 0:T,...I,...v,...De,"aria-busy":$||void 0,"aria-disabled":Z||void 0,onClick:ce,...fe?{onKeyDown:fe}:null,children:$e}),x?f.jsx(Ba,{content:x,placement:"above",children:qe}):qe}La.displayName="XDSButton";const c0={root:{kmuXW:"x2lah0s",$$css:!0},span:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0}},s0={primary:{kMwMTN:"xtbr613",$$css:!0},secondary:{kMwMTN:"xv9yike",$$css:!0},tertiary:{kMwMTN:"xv9yike",$$css:!0},disabled:{kMwMTN:"xqa6c3m",$$css:!0},accent:{kMwMTN:"xqwr325",$$css:!0},positive:{kMwMTN:"xtjic6",$$css:!0},negative:{kMwMTN:"xjt36v0",$$css:!0},warning:{kMwMTN:"xs3pv69",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0},blue:{kMwMTN:"x1fns2mt",$$css:!0},red:{kMwMTN:"xeffzf7",$$css:!0},green:{kMwMTN:"xmxeech",$$css:!0},gray:{kMwMTN:"x1eyinzz",$$css:!0},cyan:{kMwMTN:"x157w0xa",$$css:!0},teal:{kMwMTN:"x1f3zxcb",$$css:!0},yellow:{kMwMTN:"x1g6zdft",$$css:!0},orange:{kMwMTN:"xxu74a4",$$css:!0},pink:{kMwMTN:"x1kxxfg5",$$css:!0},purple:{kMwMTN:"xzdw94u",$$css:!0}},Sg={xsm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",$$css:!0},sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",$$css:!0},md:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",$$css:!0},lg:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",$$css:!0}},zg={xsm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",kGuDYH:"xfifm61",$$css:!0},sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0},lg:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",kGuDYH:"x1pvqxga",$$css:!0}};function Lt({icon:e,color:t="primary",size:l="md",ref:n,...a}){if(typeof e=="string")return f.jsx(jg,{name:e,color:t,size:l});const u=e;return f.jsx(u,{ref:n,"aria-hidden":"true",...V(G("icon",{size:l,color:t}),q(c0.root,s0[t],Sg[l])),...a})}Lt.displayName="XDSIcon";function jg({name:e,color:t,size:l}){const n=Df(e);return n==null?null:f.jsx("span",{...V(G("icon",{size:l,color:t}),q(c0.span,s0[t],zg[l])),"aria-hidden":"true",children:n})}const $g={isMobile:!1,isMobileNavOpen:!1,toggleMobileNav:()=>{},openMobileNav:()=>{},closeMobileNav:()=>{},isMobileNavEnabled:!1},f0=g.createContext($g);function Rf(){return g.useContext(f0)}function Hf({children:e,label:t="Open navigation","data-testid":l,xstyle:n,className:a,style:u}){const{isMobile:i,isMobileNavEnabled:c,toggleMobileNav:s}=Rf();return!i||!c?null:f.jsx(La,{variant:"ghost",label:t,icon:e??f.jsx(Lt,{icon:"menu",color:"inherit"}),onClick:s,"data-testid":l??"mobile-nav-toggle",xstyle:n,className:a,style:u})}Hf.displayName="XDSMobileNavToggle";const ea=g.createContext("default");function Eg(){return g.useContext(ea)}const Eu=g.createContext("default");function o0(){return g.useContext(Eu)}const Es=g.createContext(null);function Tg(){return g.useContext(Es)}const Mg={sm:640,md:768,lg:1024,none:0},Dr="xds-app-shell-main",Te={root:{k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",kVAEAm:"x1n2onr6",$$css:!0},variantWash:{kWkggS:"x1eiddq6",$$css:!0},variantSurface:{kWkggS:"x10xzikg",$$css:!0},variantSection:{kWkggS:"x10xzikg",$$css:!0},variantElevated:{kWkggS:"x1eiddq6",$$css:!0},rootFill:{kZKoxP:"xtdtrs8",$$css:!0},rootAuto:{kAzted:"x1ov3xa9",$$css:!0},contentBgSurface:{kWkggS:"x10xzikg",$$css:!0},contentBgWash:{kWkggS:"x1eiddq6",$$css:!0},contentBgTransparent:{kWkggS:"xjbqb8w",kHBbk8:"xc8icb0",$$css:!0},navAreaWash:{kWkggS:"x1eiddq6",$$css:!0},navAreaSurface:{kWkggS:"x10xzikg",$$css:!0},headerSticky:{kVAEAm:"x7wzq59",k87sOh:"x13vifvy",kY2c9j:"x1vjfegm",$$css:!0},panelAutoFill:{kUk6DE:"x98rzlu",$$css:!0},sideNavSticky:{kVAEAm:"x7wzq59",k87sOh:"xepuwc7",kZKoxP:"x16zugyo",kVQacm:"xysyzu8",k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",$$css:!0}};function r0({variant:e="elevated",banner:t,children:l,contentPadding:n,"data-testid":a,height:u="fill",mobileNav:i,sideNav:c,topNav:s,xstyle:o,className:x,style:h,ref:d}){const m=i===!1,p=i!=null&&i!==!1&&typeof i=="object"&&!g.isValidElement(i)?i:null,k=(p==null?void 0:p.breakpoint)??"md",S=i!=null&&i!==!1&&(g.isValidElement(i)||typeof i=="string")?i:null,y=(p==null?void 0:p.content)??null,r=(p==null?void 0:p.hasToggle)!==!1,v=(p==null?void 0:p.isOpen)!==void 0,[b,z]=g.useState(!1),[w,$]=g.useState(!1),T=v?p.isOpen:w,E=g.useCallback(dt=>{var Zt;v||$(dt),(Zt=p==null?void 0:p.onOpenChange)==null||Zt.call(p,dt)},[v,p]),M=u==="fill",D=u==="auto",R=t!=null,Z=s!=null,ce=c!=null,fe=ce||Z,A=!m&&fe&&S==null,N=e==="section",O=e==="elevated",Y=e==="wash"||e==="elevated"?Te.navAreaWash:e==="surface"?Te.navAreaSurface:void 0,I=e==="wash"?Te.contentBgWash:e==="elevated"&&Z&&ce&&!b?Te.contentBgTransparent:e==="surface"||e==="elevated"?Te.contentBgSurface:void 0,$e=Y??Te.navAreaSurface,De=g.useRef(null),qe=g.useRef(null),J=g.useCallback(dt=>{qe.current=dt,typeof d=="function"?d(dt):d&&(d.current=dt)},[d]);g.useEffect(()=>{if(!D||!De.current||!qe.current)return;const dt=De.current,Zt=qe.current,Gl=()=>{const Ai=dt.getBoundingClientRect().height;Zt.style.setProperty("--appshell-header-height",`${Ai}px`)};Gl();const Un=new ResizeObserver(Gl);return Un.observe(dt),()=>Un.disconnect()},[D]),g.useEffect(()=>{if(k==="none"||!fe)return;const dt=Mg[k],Zt=window.matchMedia(`(max-width: ${dt}px)`),Gl=Un=>{const Ai="matches"in Un?Un.matches:!1;z(Ai)};return Gl(Zt),Zt.addEventListener("change",Gl),()=>Zt.removeEventListener("change",Gl)},[k,fe]);const me=ce&&!b,Ga=S!=null,Mi=A&&y!=null&&b,bl=A&&!S&&!y&&b&&fe,b0=bl&&Z&&!ce,k0=bl&&Z&&ce,S0=bl&&!Z&&ce,z0=g.useMemo(()=>({isMobile:b,isMobileNavOpen:T,toggleMobileNav:()=>E(!T),openMobileNav:()=>E(!0),closeMobileNav:()=>E(!1),isMobileNavEnabled:A}),[b,T,E,A]),j0=Z?b&&A?f.jsx(Es,{value:ce?f.jsx(ea,{value:"drawer-content",children:c}):null,children:f.jsx(Eu,{value:"mobile-bar",children:s})}):s:null,Yf=Z||R?f.jsxs($s,{padding:0,hasDivider:N&&Z,xstyle:Y,children:[R&&f.jsx("div",{className:"x2lah0s",children:t}),j0]}):void 0,$0=Yf!=null?f.jsx("div",{ref:De,...q(D&&Te.headerSticky,D&&$e),children:Yf}):void 0,wi=me?f.jsx(K1,{padding:0,hasDivider:N,isScrollable:M,xstyle:[Y,D&&Te.panelAutoFill],children:c}):void 0,E0=wi!=null&&D?f.jsx("div",{className:"xkh2ocl",children:f.jsx("div",{...q(Te.sideNavSticky,$e),children:wi})}):wi,T0=O&&Z&&me,Vf=f.jsx(J1,{padding:n??0,role:"main",id:Dr,isScrollable:M,xstyle:I,children:l}),M0=T0?f.jsxs("div",{className:"x1n2onr6 x78zum5 x98rzlu x2lwn1j x5yr21d",children:[f.jsx("div",{className:"x10l6tqk x10a8y8t x10xzikg x183tx6i x47corl"}),Vf]}):Vf,w0=A&&r&&b&&!Z&&ce?f.jsx("div",{...q(D&&Te.headerSticky,D&&$e),children:f.jsx($s,{padding:0,hasDivider:N,xstyle:Y,children:f.jsxs("div",{className:"x78zum5 x6s0dn4 x1k15mir xf314gf",role:"navigation","aria-label":"Mobile navigation",children:[f.jsx(ea,{value:"topbar",children:c}),f.jsx(Hf,{})]})})}):void 0;return f.jsx(f0.Provider,{value:z0,children:f.jsxs("div",{ref:J,"data-testid":a,...V(G("app-shell",{height:u,variant:e}),q(Te.root,e==="wash"?Te.variantWash:e==="surface"?Te.variantSurface:e==="section"?Te.variantSection:Te.variantElevated,M?Te.rootFill:Te.rootAuto,o),x,h),children:[f.jsx("a",{href:`#${Dr}`,className:"x10l6tqk x1xrnuwo x1i1rx1s x1jqxupm xjm9jq1 x15cytp8 xt970qd xh2mrf5 xnjsko4 x1cf3d6k xkdpibf x1y5lnwp xb3r6kr xomzh7y x1hyvwdk x1rsz1da xuxw1ft x1hbpcn8 xc342km x13vifvy x1rw3289 x1o0tod xodanix x10xzikg xjse4m1 x1q2oy4v x1hl2dhg x2mo6ok xjm74w1","data-testid":"skip-to-content",children:"Skip to content"}),f.jsx(Q1,{height:u,padding:0,header:f.jsxs(f.Fragment,{children:[$0,w0]}),start:E0,content:M0}),Ga&&S,Mi&&y,b0&&f.jsx(Eu,{value:"drawer",children:s}),k0&&f.jsx(Es,{value:f.jsx(ea,{value:"drawer-content",children:c}),children:f.jsx(Eu,{value:"drawer",children:s})}),S0&&f.jsx(ea,{value:"drawer",children:c})]})})}r0.displayName="XDSAppShell";const qr={container:{kB7OPa:"x9f619",kmVPX3:"x1kp5lmi",$$css:!0}},wg={containerPadding:{"--container-padding":"x8q8htr",$$css:!0},containerPaddingInline:{"--container-padding-inline":"x118jium",$$css:!0},layoutPaddingOuterX:{"--layout-padding-outer-x":"x1r0u152",$$css:!0},layoutPaddingOuterY:{"--layout-padding-outer-y":"xzqheer",$$css:!0},layoutPaddingInnerX:{"--layout-padding-inner-x":"x1gox8qf",$$css:!0},layoutPaddingInnerY:{"--layout-padding-inner-y":"x1eounod",$$css:!0}},Ag={containerPadding:{"--container-padding":"xms56fs",$$css:!0},containerPaddingInline:{"--container-padding-inline":"x1x4tb0e",$$css:!0},layoutPaddingOuterX:{"--layout-padding-outer-x":"x1h0nqri",$$css:!0},layoutPaddingOuterY:{"--layout-padding-outer-y":"xlfd3nr",$$css:!0},layoutPaddingInnerX:{"--layout-padding-inner-x":"xn3f0pw",$$css:!0},layoutPaddingInnerY:{"--layout-padding-inner-y":"xihc2cu",$$css:!0}},Ng={card:wg,section:Ag},Og={spacing0:{"--container-padding":"x1i337hy",$$css:!0},spacing0_5:{"--container-padding":"x1b322fk",$$css:!0},spacing1:{"--container-padding":"x11x0u8a",$$css:!0},spacing1_5:{"--container-padding":"x1tqehje",$$css:!0},spacing2:{"--container-padding":"xyawmno",$$css:!0},spacing3:{"--container-padding":"xiq2vfk",$$css:!0},spacing4:{"--container-padding":"x18iqpsj",$$css:!0},spacing5:{"--container-padding":"x305b4h",$$css:!0},spacing6:{"--container-padding":"x1suvfq4",$$css:!0},spacing7:{"--container-padding":"xe04trj",$$css:!0},spacing8:{"--container-padding":"xv6sa6u",$$css:!0},spacing9:{"--container-padding":"xswgb5g",$$css:!0},spacing10:{"--container-padding":"xl4lgz8",$$css:!0},spacing11:{"--container-padding":"xfk8qm2",$$css:!0},spacing12:{"--container-padding":"xtcn5oa",$$css:!0}},Dg={spacing0:{"--container-padding-inline":"x11nj8ps",$$css:!0},spacing0_5:{"--container-padding-inline":"x1qmdwou",$$css:!0},spacing1:{"--container-padding-inline":"xmqp8mn",$$css:!0},spacing1_5:{"--container-padding-inline":"x11c4xrl",$$css:!0},spacing2:{"--container-padding-inline":"xvkq9sf",$$css:!0},spacing3:{"--container-padding-inline":"x17rklng",$$css:!0},spacing4:{"--container-padding-inline":"x1qtkjpi",$$css:!0},spacing5:{"--container-padding-inline":"xcek0mv",$$css:!0},spacing6:{"--container-padding-inline":"xzryng3",$$css:!0},spacing7:{"--container-padding-inline":"x1jrgra8",$$css:!0},spacing8:{"--container-padding-inline":"x1t3jwqk",$$css:!0},spacing9:{"--container-padding-inline":"x1ikhtwg",$$css:!0},spacing10:{"--container-padding-inline":"x1mh38z9",$$css:!0},spacing11:{"--container-padding-inline":"xarkblc",$$css:!0},spacing12:{"--container-padding-inline":"x15nzvup",$$css:!0}},qg={spacing0:{"--layout-padding-outer-x":"xswhm3q",$$css:!0},spacing0_5:{"--layout-padding-outer-x":"xihiwg7",$$css:!0},spacing1:{"--layout-padding-outer-x":"xc96xmq",$$css:!0},spacing1_5:{"--layout-padding-outer-x":"x1u93lgd",$$css:!0},spacing2:{"--layout-padding-outer-x":"x15dxnc0",$$css:!0},spacing3:{"--layout-padding-outer-x":"xadgj3j",$$css:!0},spacing4:{"--layout-padding-outer-x":"x1v56qcf",$$css:!0},spacing5:{"--layout-padding-outer-x":"x1nzs0gl",$$css:!0},spacing6:{"--layout-padding-outer-x":"x1c3n52a",$$css:!0},spacing7:{"--layout-padding-outer-x":"x1gfiokx",$$css:!0},spacing8:{"--layout-padding-outer-x":"x1t3kfz",$$css:!0},spacing9:{"--layout-padding-outer-x":"xzr4qsh",$$css:!0},spacing10:{"--layout-padding-outer-x":"x1jdf5a4",$$css:!0},spacing11:{"--layout-padding-outer-x":"x1hct0t0",$$css:!0},spacing12:{"--layout-padding-outer-x":"x11cyqoe",$$css:!0}},Cg={spacing0:{"--layout-padding-outer-y":"x1mzf5mb",$$css:!0},spacing0_5:{"--layout-padding-outer-y":"x1vj96e0",$$css:!0},spacing1:{"--layout-padding-outer-y":"x1gpfxoh",$$css:!0},spacing1_5:{"--layout-padding-outer-y":"xd3dqby",$$css:!0},spacing2:{"--layout-padding-outer-y":"x10pz7y9",$$css:!0},spacing3:{"--layout-padding-outer-y":"x1p6yq3h",$$css:!0},spacing4:{"--layout-padding-outer-y":"xx738ci",$$css:!0},spacing5:{"--layout-padding-outer-y":"x6yxws5",$$css:!0},spacing6:{"--layout-padding-outer-y":"x180vrwl",$$css:!0},spacing7:{"--layout-padding-outer-y":"x1q6rme1",$$css:!0},spacing8:{"--layout-padding-outer-y":"xid7e43",$$css:!0},spacing9:{"--layout-padding-outer-y":"x1t5kicu",$$css:!0},spacing10:{"--layout-padding-outer-y":"x26l4wa",$$css:!0},spacing11:{"--layout-padding-outer-y":"x10zktp0",$$css:!0},spacing12:{"--layout-padding-outer-y":"x1yz3n6a",$$css:!0}},_g={spacing0:{"--layout-padding-inner-x":"xj1bl4l",$$css:!0},spacing0_5:{"--layout-padding-inner-x":"xlriy2h",$$css:!0},spacing1:{"--layout-padding-inner-x":"x6uuyak",$$css:!0},spacing1_5:{"--layout-padding-inner-x":"xd38f90",$$css:!0},spacing2:{"--layout-padding-inner-x":"xxqksqd",$$css:!0},spacing3:{"--layout-padding-inner-x":"x1fyui2f",$$css:!0},spacing4:{"--layout-padding-inner-x":"x1i2ajwi",$$css:!0},spacing5:{"--layout-padding-inner-x":"x1tac27u",$$css:!0},spacing6:{"--layout-padding-inner-x":"x1ntgf3t",$$css:!0},spacing7:{"--layout-padding-inner-x":"xhjd9tl",$$css:!0},spacing8:{"--layout-padding-inner-x":"xn7c84u",$$css:!0},spacing9:{"--layout-padding-inner-x":"xeqkbsz",$$css:!0},spacing10:{"--layout-padding-inner-x":"x1vf4qco",$$css:!0},spacing11:{"--layout-padding-inner-x":"xsmamsf",$$css:!0},spacing12:{"--layout-padding-inner-x":"x2xk2xj",$$css:!0}},Rg={spacing0:{"--layout-padding-inner-y":"xwuefyo",$$css:!0},spacing0_5:{"--layout-padding-inner-y":"x180h0y5",$$css:!0},spacing1:{"--layout-padding-inner-y":"xmpug6m",$$css:!0},spacing1_5:{"--layout-padding-inner-y":"x1g8jpzm",$$css:!0},spacing2:{"--layout-padding-inner-y":"x1lksgje",$$css:!0},spacing3:{"--layout-padding-inner-y":"x4j7gld",$$css:!0},spacing4:{"--layout-padding-inner-y":"x1s3ehtl",$$css:!0},spacing5:{"--layout-padding-inner-y":"x1rj5eim",$$css:!0},spacing6:{"--layout-padding-inner-y":"x1ftgg6u",$$css:!0},spacing7:{"--layout-padding-inner-y":"x1ho74vh",$$css:!0},spacing8:{"--layout-padding-inner-y":"xm2cs6f",$$css:!0},spacing9:{"--layout-padding-inner-y":"x1vsq92b",$$css:!0},spacing10:{"--layout-padding-inner-y":"x18gbwmk",$$css:!0},spacing11:{"--layout-padding-inner-y":"x14zymzj",$$css:!0},spacing12:{"--layout-padding-inner-y":"xzfpkx9",$$css:!0}},Hg={containerMaxHeight:e=>[{"--container-max-height":e!=null?"x18nyedi":e,$$css:!0},{"--x---container-max-height":e??void 0}]};function Ug({padding:e="spacing4",paddingOuterX:t="spacing4",paddingOuterY:l="spacing4",paddingInnerX:n="spacing4",paddingInnerY:a="spacing4",useThemeDefault:u,maxHeight:i}){const c=i?Hg.containerMaxHeight(i):null;if(u){const s=Ng[u];return[qr.container,s.containerPadding,s.containerPaddingInline,s.layoutPaddingOuterX,s.layoutPaddingOuterY,s.layoutPaddingInnerX,s.layoutPaddingInnerY,c]}return[qr.container,Og[e],Dg[t],qg[t],Cg[l],_g[n],Rg[a],c]}const Sc={cardOuter:{"--card-radius":"xb26y6u",kWkggS:"x1de1mus",kaIpWk:"x8j4bds",kVQacm:"x7giv3",kMzoRj:"x1litavf",ksu8eU:"x1y0btm7",kVAM5u:"xvy26l8",$$css:!0},cardInner:{kZKoxP:"x5yr21d",$$css:!0},scrollable:{kVQacm:"xysyzu8",$$css:!0}},Xg={sizing:(e,t,l,n)=>[{kzqmXN:e!=null?"x5lhr3w":e,kZKoxP:t!=null?"x16ye13r":t,ks0D6T:l!=null?"xf68679":l,kAzted:n!=null?"x82snj4":n,$$css:!0},{"--x-width":(a=>typeof a=="number"?a+"px":a??void 0)(e),"--x-height":(a=>typeof a=="number"?a+"px":a??void 0)(t),"--x-maxWidth":(a=>typeof a=="number"?a+"px":a??void 0)(l),"--x-minHeight":(a=>typeof a=="number"?a+"px":a??void 0)(n)}]};function Ts({width:e,height:t,maxWidth:l,minHeight:n,children:a,padding:u,xstyle:i,className:c,style:s,ref:o,...x}){const h=t!=null&&t!=="auto",d=u==null,m=u??4,p=Ih[m];return f.jsx("div",{ref:o,...V(G("card"),q(Sc.cardOuter,Xg.sizing(e??null,t??null,l??null,n??null),i),c,s),...x,children:f.jsx("div",{...q(Sc.cardInner,h&&Sc.scrollable,...Ug(d?{useThemeDefault:"card"}:{paddingInnerX:p,paddingInnerY:p,paddingOuterX:p,paddingOuterY:p}),!d&&m!==4&&ji[m],!d&&m!==4&&$i[m]),children:a})})}Ts.displayName="XDSCard";const Bg='button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])';function Uf(e){return Array.from(e.querySelectorAll(Bg))}function d0(e){try{e.focus()}catch{}return document.activeElement===e}function Cr(e){const t=Uf(e);for(const l of t)if(d0(l))return!0;return!1}function Lg(e){const t=Uf(e);for(let l=t.length-1;l>=0;l--)if(d0(t[l]))return!0;return!1}function Gg(e){const{isActive:t,onEscape:l}=e,n=g.useRef(null),a=g.useRef(null),u=g.useRef(!1),i=g.useCallback(()=>{n.current&&Cr(n.current)},[]);return g.useEffect(()=>{if(!t)return;const c=s=>{const o=n.current;if(!o)return;const x=s.target;o.contains(x)?a.current=x:u.current&&(Cr(o),a.current===document.activeElement&&Lg(o),a.current=document.activeElement),u.current=!1};return document.addEventListener("focus",c,!0),()=>{document.removeEventListener("focus",c,!0)}},[t]),g.useEffect(()=>{if(!t)return;const c=s=>{const o=n.current;if(o){if(s.key==="Escape"&&l){s.preventDefault(),l();return}if(s.key==="Tab"){u.current=!0;const x=Uf(o);if(x.length===0)return;const h=x[0],d=x[x.length-1];s.shiftKey?document.activeElement===h&&(s.preventDefault(),d.focus()):document.activeElement===d&&(s.preventDefault(),h.focus())}}};return document.addEventListener("keydown",c),()=>{document.removeEventListener("keydown",c)}},[t,l]),{containerRef:n,focusFirst:i}}let x0=!1;typeof window<"u"&&requestAnimationFrame(()=>{x0=!0});const Zg={slideDown:{kKVMdj:"x1srr2gu",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},slideUp:{kKVMdj:"x1dvww92",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},fadeIn:{kKVMdj:"xqcmdr3",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},scaleIn:{kKVMdj:"x97zbip",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}};function Yg(e="slideDown"){const[t]=g.useState(()=>x0);return t?Zg[e]:null}function Xf({label:e,inputID:t,isLabelHidden:l=!1,isDisabled:n=!1,isOptional:a=!1,isRequired:u=!1,labelIcon:i,labelTooltip:c,ref:s}){const o=a?"Optional":u?"Required":null;return f.jsxs("label",{ref:s,htmlFor:t,...V(G("field-label"),{0:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip x1tgivj0 x1ypdohk"},2:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip xnbbluu x1h6gzvc"},1:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip x1tgivj0 x1ypdohk xng3xce xzpqnlu xjm9jq1 xu96u03 xkdpibf xb3r6kr x1717udv x47corl x10l6tqk x13vifvy x87ps6o xuxw1ft x1i1rx1s"},3:{className:"x78zum5 x6s0dn4 xzye2dw x9ynric xcr08ib x1e4wzip xnbbluu x1h6gzvc xng3xce xzpqnlu xjm9jq1 xu96u03 xkdpibf xb3r6kr x1717udv x47corl x10l6tqk x13vifvy x87ps6o xuxw1ft x1i1rx1s"}}[!!n<<1|!!l<<0]),children:[i&&f.jsx(Lt,{icon:i,size:"sm",color:"inherit"}),e,o&&f.jsxs("span",{className:"x1sodnla x141an7d xv1l7n4",children:[f.jsx("span",{"aria-hidden":"true",children:" ∙ "}),o]}),c&&f.jsx(Ba,{content:c,placement:"above",children:f.jsx(Lt,{icon:"info",size:"sm",color:"inherit"})})]})}Xf.displayName="XDSFieldLabel";const zc={base:{kMv6JI:"x9ynric",kGuDYH:"x141an7d",kLWn49:"x1ltkj2j",$$css:!0},attached:{keoZOQ:"x1c40v9y",kLKAdn:"x1ak3mig",kGO01o:"x1wesfrj",kg3NbH:"xf314gf",kqGeR4:"x14lggfu",kYm2EN:"xtufxuj",$$css:!0},detached:{keoZOQ:"xcsaf9d",k8WAf4:"xce4md1",kg3NbH:"xf314gf",kaIpWk:"xh6dtrn",$$css:!0}},Vg={warning:{kWkggS:"x24i8r5",kMwMTN:"xdhq94a",$$css:!0},error:{kWkggS:"x1pritpl",kMwMTN:"x1joocv1",$$css:!0},success:{kWkggS:"xu13z74",kMwMTN:"xltfdvo",$$css:!0}};function ai({type:e,message:t,id:l,variant:n="attached"}){const a=Yg("slideDown");return f.jsx("div",{id:l,role:e==="error"?"alert":"status","aria-live":e==="error"?"assertive":"polite",...V(G("field-status",{type:e,variant:n}),q(zc.base,a,n==="attached"?zc.attached:zc.detached,Vg[e])),children:t})}ai.displayName="XDSFieldStatus";const _r={container:{k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",$$css:!0},containerGap:{kOIVth:"xzye2dw",$$css:!0}};function y0({label:e,isLabelHidden:t=!1,description:l,inputID:n,descriptionID:a,isOptional:u=!1,isRequired:i=!1,isDisabled:c=!1,labelIcon:s,status:o,labelTooltip:x,statusVariant:h="attached",xstyle:d,children:m,className:p,style:k,ref:S,...y}){const r=a??(l?`${n}-desc`:void 0),v=(o==null?void 0:o.messageID)??(o!=null&&o.message?`${n}-status`:void 0);return u&&i&&console.warn("XDSField: isOptional and isRequired are mutually exclusive. isOptional takes precedence."),f.jsxs("div",{ref:S,...V(G("field"),q(_r.container,!t&&_r.containerGap,d),p,k),...y,children:[f.jsxs("div",{className:"x78zum5 xdt5ytf",children:[f.jsx(Xf,{label:e,inputID:n,isLabelHidden:t,isDisabled:c,isOptional:u,isRequired:i,labelIcon:s,labelTooltip:x}),l&&f.jsx("span",{id:r,...{0:{className:"x9ynric x141an7d x1ltkj2j x1sodnla xv1l7n4"},1:{className:"x9ynric x141an7d x1ltkj2j x1sodnla xv1l7n4 xng3xce xzpqnlu xjm9jq1 xu96u03 xkdpibf xb3r6kr x1717udv x47corl x10l6tqk x13vifvy x87ps6o xuxw1ft x1i1rx1s"}}[!!t<<0],children:l})]}),h==="attached"?f.jsxs("div",{className:"x78zum5 xdt5ytf",children:[m,(o==null?void 0:o.message)&&f.jsx(ai,{type:o.type,message:o.message,id:v,variant:"attached"})]}):f.jsxs(f.Fragment,{children:[m,(o==null?void 0:o.message)&&f.jsx(ai,{type:o.type,message:o.message,id:v,variant:"detached"})]})]})}y0.displayName="XDSField";const Rr={horizontal:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kzqmXN:"xh8yej3",$$css:!0},vertical:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kZKoxP:"x5yr21d",$$css:!0}},Kl={horizontalLine:{kZKoxP:"xsyqizj",kzQI83:"x1iyjqo2",kmuXW:"xs83m0k",$$css:!0},verticalLine:{kzqmXN:"xjk4fl7",kzQI83:"x1iyjqo2",kmuXW:"xs83m0k",$$css:!0},subtle:{kWkggS:"x1m4xfpy",$$css:!0},strong:{kWkggS:"x7njt3n",$$css:!0}},Hr={horizontal:{kUOVxO:"xzyy9it",$$css:!0},vertical:{kqGvvJ:"xcxpkta",$$css:!0}};function Bf({orientation:e="horizontal",label:t,variant:l="subtle",isFullBleed:n=!1,xstyle:a,className:u,style:i,ref:c,...s}){const o=e==="horizontal";return f.jsxs("div",{ref:c,role:"separator","aria-orientation":e,...V(G("divider",{variant:l,orientation:e}),q(o?Rr.horizontal:Rr.vertical,n&&(o?Hr.horizontal:Hr.vertical),a),u,i),...s,children:[f.jsx("div",{...q(o?Kl.horizontalLine:Kl.verticalLine,Kl[l])}),t&&f.jsx("div",{...{0:{className:"x2lah0s xrrkdod x10xzikg x141an7d x1ltkj2j xv1l7n4"},1:{className:"x2lah0s x10xzikg x141an7d x1ltkj2j xv1l7n4 xnjsko4 x8o8v82"}}[!o<<0],children:t}),t&&f.jsx("div",{...q(o?Kl.horizontalLine:Kl.verticalLine,Kl[l])})]})}Bf.displayName="XDSDivider";const Qg=g.lazy(()=>I1(()=>Promise.resolve().then(()=>F1),void 0,import.meta.url).then(e=>({default:e.XDSTooltip}))),Kg={1:"h1",2:"h2",3:"h3",4:"h4",5:"h5",6:"h6"};function dn({level:e,accessibilityLevel:t,color:l="primary",display:n="block",maxLines:a=0,hasTruncateTooltip:u=!0,wordBreak:i,textWrap:c,hasCapsize:s=!1,hasStrikethrough:o=!1,xstyle:x,className:h,style:d,children:m,ref:p,...k}){const S=Kg[e],y=t&&t!==e?{"aria-level":t}:{},r=i??(a===1?"break-all":"break-word"),v=a>0||s?"block":n,b=i0({maxLines:a}),z=typeof u=="string"?u:"above",w=a>0&&u!==!1&&b.isTruncated,$=g.useRef(null),T=g.useCallback(M=>{typeof p=="function"?p(M):p&&(p.current=M),b.ref(M),$.current=M},[p,b.ref]),E=a>1?{WebkitLineClamp:a}:void 0;return f.jsxs(f.Fragment,{children:[f.jsx(S,{ref:T,...V(G("heading",{level:e,color:l}),q(P1[l],a===1?ni.singleLine:a>1?ni.multiLine:e0[v],a>0&&t0[r],c&&l0[c],s&&n0.enabled,o&&a0.strikethrough,x),h,{...d,...E}),title:w?b.fullText:void 0,...y,...k,children:m}),w&&f.jsx(g.Suspense,{fallback:null,children:f.jsx(Qg,{anchorRef:$,content:f.jsx("span",{...q(u0.content),children:b.fullText}),placement:z})})]})}dn.displayName="XDSHeading";const Ye={item:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",kzqmXN:"xh8yej3",kg3NbH:"xf314gf",k8WAf4:"xce4md1",kaIpWk:"xh6dtrn",kMzoRj:"xc342km",ksu8eU:"xng3xce",kWkggS:"xjbqb8w",kMwMTN:"x1tgivj0",kybGjl:"x1hl2dhg",kkrTdU:"x1ypdohk",kMv6JI:"xjb2p0i",kGuDYH:"xcr08ib",k63SB2:"x1sodnla",kLWn49:"x1kq96og",k9WMMc:"x1yc453h",kB7OPa:"x9f619",kHE3J0:"xe9uy6x",kSReZ0:"xyxi2l3",$$css:!0},selected:{kWkggS:"x17x4s8c",k63SB2:"x1e4wzip",kHE3J0:"x1sua13m",kSReZ0:"xjtnuge",$$css:!0},disabled:{kMwMTN:"xnbbluu",kkrTdU:"x1h6gzvc",kfzvcC:"x47corl",$$css:!0}};function m0({direction:e,hAlign:t,vAlign:l,gap:n,wrap:a,element:u="div",xstyle:i,className:c,style:s,children:o,ref:x,...h}){const p=q(...js({direction:e,crossAlign:e==="horizontal"?l:t,mainAlign:e==="horizontal"?t:l,gap:n,wrap:a}),i);return g.createElement(u,{ref:x,...V(G("stack",{direction:e,gap:n,wrap:a}),p,c,s),...h},o)}m0.displayName="XDSStack";function Tu({ref:e,...t}){return f.jsx(m0,{...t,direction:"vertical",ref:e})}Tu.displayName="XDSVStack";function Il({label:e,isLabelHidden:t=!1,description:l,onChange:n,onChangeAction:a,isLoading:u=!1,value:i,isDisabled:c=!1,isOptional:s=!1,isRequired:o=!1,onFocus:x,onBlur:h,labelIcon:d,labelTooltip:m,labelPosition:p="end",labelSpacing:k="default",status:S,xstyle:y,className:r,style:v,ref:b}){const z=g.useId(),w=g.useId(),$=g.useId(),[,T]=g.useTransition(),[E,M]=g.useOptimistic(i),D=u||E!==i,R=E===!0,Z=[];l&&!t&&Z.push(w),S!=null&&S.message&&Z.push($);const ce=Z.length>0?Z.join(" "):void 0,fe=f.jsxs("div",{className:"x1n2onr6 x78zum5 x6s0dn4 x2lah0s x100vrsf xxk0z11",children:[f.jsx("input",{ref:b,id:z,type:"checkbox",role:"switch",checked:R,disabled:c,required:o,onChange:N=>{if(D)return;const O=N.target.checked;n==null||n(O,N),a&&!N.defaultPrevented&&T(async()=>{M(O),await a(O,N)})},onFocus:x,onBlur:h,"aria-describedby":ce,"aria-invalid":(S==null?void 0:S.type)==="error"?!0:void 0,"aria-busy":D||void 0,...{0:{className:"x10l6tqk x1ghz6dp x1717udv xg01cxk x1ypdohk x1vjfegm x100vrsf xxk0z11"},2:{className:"x10l6tqk x1ghz6dp x1717udv xg01cxk x1vjfegm x100vrsf xxk0z11 x1h6gzvc"},1:{className:"x10l6tqk x1ghz6dp x1717udv xg01cxk x1ypdohk x1vjfegm x100vrsf xxk0z11 x47corl"},3:{className:"x10l6tqk x1ghz6dp x1717udv xg01cxk x1vjfegm x100vrsf xxk0z11 x1h6gzvc x47corl"}}[!!c<<1|!!D<<0]}),f.jsx("div",{"aria-hidden":"true",...V(G("switch",{checked:R?"checked":null,disabled:c?"disabled":null}),{0:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 xspzpui x2xxuwy"},8:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 x1ewilqj x3h3317"},4:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 xspzpui x2xxuwy x1a2a7pz x1dg3z2k xcn42n2"},12:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 x1ewilqj x3h3317 x1a2a7pz x1dg3z2k xcn42n2"},2:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 xspzpui x2xxuwy xbyyjgo"},10:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 x1ewilqj x3h3317 xbyyjgo"},6:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 xspzpui x2xxuwy x1a2a7pz x1dg3z2k xcn42n2 xbyyjgo"},14:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 x1ewilqj x3h3317 x1a2a7pz x1dg3z2k xcn42n2 xbyyjgo"},1:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 xspzpui"},9:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 xspzpui"},5:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 x1a2a7pz x1dg3z2k xcn42n2 xspzpui"},13:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 x1a2a7pz x1dg3z2k xcn42n2 xspzpui"},3:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 xbyyjgo xspzpui"},11:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 xbyyjgo xspzpui"},7:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 x1a2a7pz x1dg3z2k xcn42n2 xbyyjgo xspzpui"},15:{className:"x78zum5 x6s0dn4 x100vrsf xxk0z11 xfawy5m xjspbzw x15406qy xuedmi6 x12w9bfk xlr8y92 x9f619 x1a2a7pz x1dg3z2k xcn42n2 xbyyjgo xspzpui"}}[!!R<<3|!c<<2|!!c<<1|!!(c&&!R)<<0]),children:f.jsx("div",{...V(G("switch-thumb",{checked:R?"checked":null}),{0:{className:"x78zum5 x6s0dn4 xl56j7k xjspbzw x10xzikg xh3q6i0 xuedmi6 x12w9bfk xlr8y92 x1kky2od xlup9mm xbryuvx"},1:{className:"x78zum5 x6s0dn4 xl56j7k xjspbzw x10xzikg xh3q6i0 xuedmi6 x12w9bfk xlr8y92 xw4jnvo x1qx5ct2 x15481yp"}}[!!R<<0]),children:D&&f.jsx(Ei,{size:"sm"})})}),D&&f.jsx("span",{className:"x10l6tqk x1i1rx1s xjm9jq1 x1717udv xkdpibf xb3r6kr xzpqnlu xuxw1ft xc342km",role:"status",children:"Loading"})]}),A=f.jsxs("div",{className:"x78zum5 xdt5ytf x1lsbc85 xl56j7k xjwf9q1",children:[f.jsx(Xf,{label:e,inputID:z,isLabelHidden:t,isDisabled:c,isOptional:s,isRequired:o,labelIcon:d,labelTooltip:m}),l&&!t&&f.jsx("span",{id:w,className:"x9ynric x141an7d xv1l7n4",children:l})]});return f.jsxs("div",{...V(G("switch-field",{labelPosition:p!=="end"?p:void 0,labelSpacing:k!=="default"?k:void 0}),q(y),r,v),children:[f.jsx("div",{...{0:{className:"x78zum5 x6s0dn4 x1txdalj"},2:{className:"x78zum5 x6s0dn4 x1txdalj x1qughib xh8yej3"},1:{className:"x78zum5 x6s0dn4 x1txdalj x-default-marker"},3:{className:"x78zum5 x6s0dn4 x1txdalj x1qughib xh8yej3 x-default-marker"}}[(k==="spread")<<1|!c<<0],children:p==="start"?f.jsxs(f.Fragment,{children:[A,fe]}):f.jsxs(f.Fragment,{children:[fe,A]})}),(S==null?void 0:S.message)&&f.jsx("div",{className:"xtbrsbv",children:f.jsx(ai,{type:S.type,message:S.message,id:$,variant:"detached"})})]})}Il.displayName="XDSSwitch";const Ur={base:{kB7OPa:"x9f619",kVAEAm:"x1n2onr6",kY2c9j:"x1vjfegm",k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",k8WAf4:"xu0wf1k",kg3NbH:"xf314gf",kMzoRj:"x1litavf",ksu8eU:"x1y0btm7",kVAM5u:"xvy26l8 x1ww4t2b","--input-radius":"xrhxz6v",kaIpWk:"x11spqq5",kWkggS:"x10xzikg",k1ekBW:"xpo9ue8",kIyJzY:"xuedmi6 x12w9bfk",kAMwcw:"xlr8y92",kGVxlE:"x1gnnqk1 x1j9d0uj",kI3sdo:"x1a2a7pz x1bb4jes",kInvED:"x1wfwxd8",$$css:!0},disabled:{kkrTdU:"x1h6gzvc",kSiTet:"xbyyjgo",kVAM5u:"xvy26l8",$$css:!0}},Jg={warning:{kVAM5u:"x8wg1ba",$$css:!0},error:{kVAM5u:"x1ofxpqo",$$css:!0},success:{kVAM5u:"x16m2moy",$$css:!0}},Wg={warning:{kGVxlE:"x1gnnqk1 xo1e01f",$$css:!0},error:{kGVxlE:"x1gnnqk1 x1ymn3ht",$$css:!0},success:{kGVxlE:"x1gnnqk1 x1th0bn1",$$css:!0}},Fg={warning:{kI3sdo:"x1a2a7pz x1i2lkmv",$$css:!0},error:{kI3sdo:"x1a2a7pz xvr22io",$$css:!0},success:{kI3sdo:"x1a2a7pz xgqqtmo",$$css:!0}},Xr={surface:{kWkggS:"x1prclbq",kaIpWk:"x1hviunn",kGVxlE:"x1i5ehqx",$$css:!0},contentWrapper:{kVAEAm:"x1n2onr6",$$css:!0}};function Ig(e={}){const{onShow:t,onHide:l,xstyle:n,hasLightDismiss:a=!0,hasAutoFocus:u=!0,hasSurface:i=!0,hasCloseButton:c=!0,closeButtonLabel:s="Close popover",dialogLabel:o}=e,x=g.useRef(null),h=g.useRef(!1),d=W1({mode:"context",lightDismiss:a,onShow:t,onHide:l}),{containerRef:m,focusFirst:p}=Gg({isActive:d.isOpen,onEscape:d.hide});g.useEffect(()=>{d.isOpen&&u&&!h.current&&requestAnimationFrame(()=>{p()}),d.isOpen||(h.current=!1)},[d.isOpen,u,p]);const k=g.useCallback(b=>{x.current=b,d.ref(b)},[d]),S=g.useCallback(b=>{h.current=(b==null?void 0:b.skipAutoFocus)??!1,d.show()},[d]),y=g.useCallback(()=>{d.isOpen?d.hide():S()},[d,S]),r={"aria-haspopup":"dialog","aria-expanded":d.isOpen,"aria-controls":d.id},v=g.useCallback((b,z)=>d.render(f.jsxs("div",{ref:m,role:"dialog","aria-modal":"true","aria-label":o,...q(Xr.contentWrapper,i&&Xr.surface,n),children:[b,c&&f.jsx("div",{className:"x10l6tqk x1ey2m1c x1nrll8i x31h1t8 x1vjfegm x1i1rx1s x10okhzq xjm9jq1 x132qfvm xb3r6kr x1dordxg x1hyvwdk x10wafsz x47corl xbt4iw xexx8yu x1kw28su",children:f.jsx(La,{variant:"secondary",label:s,onClick:d.hide})})]}),{...z,xstyle:z==null?void 0:z.xstyle}),[d,c,i,s,m,o,n]);return{triggerRef:k,contentRef:m,anchorId:d.anchorId,show:S,hide:d.hide,toggle:y,isOpen:d.isOpen,id:d.id,render:v,triggerProps:r}}const Pg={wrapper:{kY2c9j:"x1vjfegm",$$css:!0}},e2={sm:{kZKoxP:"x6k0iem",$$css:!0},md:{kZKoxP:"x1ueg155",$$css:!0},lg:{kZKoxP:"xssyfek",$$css:!0}};function Ms({type:e="text",label:t,isLabelHidden:l=!1,description:n,isOptional:a=!1,isRequired:u=!1,isDisabled:i=!1,startIcon:c,status:s,size:o="md",onChange:x,onChangeAction:h,isLoading:d=!1,value:m,placeholder:p,labelTooltip:k,hasAutoFocus:S=!1,htmlName:y,xstyle:r,className:v,style:b,ref:z}){const w=g.useId(),$=g.useId(),T=g.useId(),[,E]=g.useTransition(),[M,D]=g.useOptimistic(m),R=d||M!==m,Z={warning:"warning",error:"xCircle",success:"checkCircle"},ce={warning:"warning",error:"negative",success:"positive"},fe=[n?$:null,s!=null&&s.message?T:null].filter(Boolean).join(" ")||void 0,A=N=>{const O=N.target.value;x==null||x(O,N),h&&!N.defaultPrevented&&E(async()=>{D(O),await h(O,N)})};return f.jsx(y0,{label:t,isLabelHidden:l,description:n,inputID:w,descriptionID:n?$:void 0,isOptional:a,isRequired:u,isDisabled:i,status:s?{type:s.type,message:s.message,messageID:s.message?T:void 0}:void 0,labelTooltip:k,children:f.jsxs("div",{...V(G("text-input",{size:o}),q(Ur.base,Pg.wrapper,e2[o],i&&Ur.disabled,s&&Jg[s.type],s&&Wg[s.type],s&&Fg[s.type],r),v,b),children:[c&&f.jsx(Lt,{icon:c,size:"sm",color:"primary"}),f.jsx("input",{ref:z,id:w,name:y,type:e,value:String(M),onChange:A,placeholder:p,disabled:i,autoFocus:S,"data-autofocus":S||void 0,"aria-describedby":fe,"aria-required":u===!0?"true":void 0,"aria-invalid":(s==null?void 0:s.type)==="error"?"true":void 0,"aria-busy":R||void 0,...{0:{className:"x1lliihq x98rzlu xeuugli xc342km xng3xce x1717udv x9ynric xjm74w1 xw6l6zx x1tgivj0 xjbqb8w x1a2a7pz xeyghm5"},1:{className:"x1lliihq x98rzlu xeuugli xc342km xng3xce x1717udv x9ynric xjm74w1 xw6l6zx x1tgivj0 xjbqb8w x1a2a7pz xeyghm5 x1h6gzvc"}}[!!i<<0]}),R&&f.jsx(Ei,{size:"sm"}),s&&f.jsx(Lt,{icon:Z[s.type],size:"md",color:ce[s.type]})]})})}Ms.displayName="XDSTextInput";const fu=g.createContext("start"),Qt={dialog:{kVAEAm:"xixxii4",kogj98:"x1ghz6dp",kmVPX3:"x1717udv",ks0D6T:"x1x1rfll",kskxy:"x7ab17h",kpwlN0:"x10a8y8t",kzqmXN:"xn9wirt",kZKoxP:"xtdtrs8",kWkggS:"xjbqb8w",kVQacm:"xb3r6kr",kZeWKH:"xish69e",kFalU9:"x5ve5x3",kI3sdo:"x1a2a7pz",k1xSpc:"x1s85apg xf1xu1x",$$css:!0},backdrop:{kGyWv1:"xnixb3f",kba3nw:"x1abwkk1",k5sjJv:"xph5o2a",kND0Po:"x167zut7",k9an0g:"xft5bk6",kb4ib:"x15h3t91",kA5Tbj:"x1viac0w",$$css:!0},backdropOpen:{k5sjJv:"xb3n6bw",$$css:!0},drawer:{kVAEAm:"x10l6tqk",k87sOh:"x13vifvy",krVfgx:"x1ey2m1c",k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",kWkggS:"x10xzikg",kB7OPa:"x9f619",kVQacm:"xb3r6kr",k1ekBW:"x11xpdln",kIyJzY:"x80gvsz",kAMwcw:"xlr8y92",kI3sdo:"x1a2a7pz",k6CgDc:"xzg1mie",$$css:!0},drawerStart:{kLqNvP:"x1o0tod",ke9TFa:"x1lun4ml",k8ry5P:"x18b5jzi",kBCPoo:"x1gejf6u",k3aq6I:"x5i6ehr xttggg",$$css:!0},drawerStartOpen:{k3aq6I:"xbryuvx",$$css:!0},drawerEnd:{kt4wiu:"xtijo5x",k2ei4v:"xpilrb4",kVhnKS:"x1t7ytsu",kGJrpR:"x1j92z86",k3aq6I:"xumwmo6 x1df3fe5",$$css:!0},drawerEndOpen:{k3aq6I:"xbryuvx",$$css:!0}},t2={kzqmXN:"xn9wirt",ks0D6T:"xf68679",$$css:!0},l2={width:e=>[t2,{"--x-maxWidth":(t=>typeof t=="number"?t+"px":t??void 0)(`${e}px`)}]};function Lf({isOpen:e,onOpenChange:t,children:l,header:n,width:a=320,side:u="end",label:i,"data-testid":c,xstyle:s,className:o,style:x,ref:h}){const d=Rf(),m=e??d.isMobileNavOpen,p=t??(z=>{z?d.openMobileNav():d.closeMobileNav()}),k=g.useRef(null),S=g.useRef(null),y=g.useCallback(z=>{k.current=z,typeof h=="function"?h(z):h&&(h.current=z)},[h]);g.useEffect(()=>{const z=k.current;if(z){if(S.current&&(clearTimeout(S.current),S.current=null),m)z.open||z.showModal(),document.documentElement.style.overflow="clip";else if(z.open){document.documentElement.style.overflow="";const w=window.matchMedia("(prefers-reduced-motion: reduce)").matches?10:250;S.current=setTimeout(()=>{z.close()},w)}return()=>{S.current&&clearTimeout(S.current),document.documentElement.style.overflow=""}}},[m]);const r=g.useCallback(z=>{z.preventDefault(),p(!1)},[p]),v=g.useCallback(z=>{z.target===z.currentTarget&&p(!1)},[p]),b=u==="start";return f.jsx("dialog",{ref:y,"data-testid":c,"aria-label":i??(typeof n=="string"?n:"Navigation"),onClick:v,onCancel:r,...V(G("mobile-nav",{side:u}),q(Qt.dialog,Qt.backdrop,m&&Qt.backdropOpen,s)),children:f.jsxs("div",{tabIndex:-1,...q(Qt.drawer,l2.width(a),b&&Qt.drawerStart,b&&m&&Qt.drawerStartOpen,!b&&Qt.drawerEnd,!b&&m&&Qt.drawerEndOpen),children:[f.jsxs("div",{...{0:{className:"x78zum5 x6s0dn4 x1qughib x1k15mir xf314gf x2lah0s xso031l x1q0q8m5 xw8gpjh"},1:{className:"x78zum5 x6s0dn4 x1k15mir xf314gf x2lah0s xso031l x1q0q8m5 xw8gpjh x13a6bvl"}}[!n<<0],children:[typeof n=="string"?f.jsx("span",{className:"x11g1kdw",children:f.jsx(dn,{level:2,children:n})}):n??null,f.jsx(La,{variant:"ghost",label:"Close navigation",icon:f.jsx(Lt,{icon:"close",color:"inherit"}),onClick:()=>p(!1)})]}),f.jsx("div",{className:"x98rzlu x1odjw0f x6ikm8r xish69e xx69xxh xf314gf xce4md1",children:l})]})})}Lf.displayName="XDSMobileNav";const zl={base:{kGNEyG:"x6s0dn4",kzqmXN:"xh8yej3",kZKoxP:"x1k15mir",kg3NbH:"x1pzlopt",kB7OPa:"x9f619","--container-padding-inline":"x1qtkjpi",$$css:!0},baseFlex:{k1xSpc:"x78zum5",$$css:!0},baseGrid:{k1xSpc:"xrvj5dj",kumcoG:"x134kloy",$$css:!0},leftSection:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x18g69wz",kUk6DE:"x845mor",k7Eaqz:"xeuugli",$$css:!0},rightSection:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kjj79g:"x13a6bvl",kOIVth:"xzye2dw",$$css:!0},endContent:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"xzye2dw",kmuXW:"x2lah0s",keTefX:"xvc5jky",$$css:!0},mobileBar:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kzqmXN:"xh8yej3",kZKoxP:"x1k15mir",kg3NbH:"x1pzlopt",kB7OPa:"x9f619",$$css:!0}};function v0({heading:e,startContent:t,centerContent:l,endContent:n,label:a,xstyle:u,className:i,style:c,ref:s,...o}){const x=o0(),h=Tg(),d=l!=null,m=t!=null||l!=null,p=m||h!=null;return x==="mobile-bar"?f.jsxs("nav",{ref:s,role:"navigation","aria-label":a,...V(G("top-nav",{mode:"mobile-bar"}),q(zl.mobileBar,u),i,c),...o,children:[e&&f.jsx("div",{className:"x78zum5 x6s0dn4 x2lah0s",children:e}),f.jsxs("div",{className:"x78zum5 x6s0dn4 xzye2dw xvc5jky",children:[n,p&&f.jsx(Hf,{})]})]}):x==="drawer"?!m&&!h?null:f.jsxs(Lf,{header:e,children:[m&&f.jsxs("div",{className:"x78zum5 xdt5ytf x1lsbc85",children:[t,l]}),m&&h&&f.jsx("div",{className:"x1g06x3t",children:f.jsx(Bf,{})}),h&&f.jsx("div",{children:h})]}):f.jsxs("nav",{ref:s,role:"navigation","aria-label":a,...V(G("top-nav"),q(zl.base,d?zl.baseGrid:zl.baseFlex,u),i,c),...o,children:[f.jsxs("div",{...q(zl.leftSection,kc.start),children:[e&&f.jsx("div",{className:"x78zum5 x6s0dn4 x2lah0s",children:e}),t&&f.jsx(fu,{value:"start",children:f.jsx("div",{className:"x78zum5 x6s0dn4 xzye2dw",children:t})})]}),d&&f.jsx(fu,{value:"center",children:f.jsx("div",{className:"x78zum5 x6s0dn4 xl56j7k xzye2dw",children:l})}),d?f.jsx("div",{...q(zl.rightSection,kc.end),children:f.jsx(fu,{value:"end",children:n})}):n&&f.jsx("div",{...q(zl.endContent,kc.end),children:f.jsx(fu,{value:"end",children:n})})]})}v0.displayName="XDSTopNav";const Br={base:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",kybGjl:"x1hl2dhg",kMwMTN:"x1tgivj0",$$css:!0},clickable:{kkrTdU:"x1ypdohk",$$css:!0}};function h0({as:e,heading:t,logo:l,href:n,xstyle:a,className:u,style:i,ref:c,...s}){const o=Ti(e),x=n!=null,h=x?o:"div";return f.jsxs(h,{ref:c,href:n,...V(G("top-nav-heading"),q(Br.base,x&&Br.clickable,a),u,i),...s,children:[l&&f.jsx("span",{className:"x78zum5 x6s0dn4 xl56j7k x2lah0s",children:l}),t&&f.jsx("span",{className:"x18juvz8 x2mo6ok xf74fhv xuxw1ft",children:t})]})}h0.displayName="XDSTopNavHeading";const ou={base:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kaIpWk:"xh6dtrn",kGuDYH:"xcr08ib",kLWn49:"x1kq96og",k63SB2:"x1e4wzip",kMwMTN:"xv1l7n4",kybGjl:"x1hl2dhg",kkrTdU:"x1ypdohk",k1ekBW:"xs2xxs2",kIyJzY:"xuedmi6",kAMwcw:"xlr8y92",kWkggS:"xjbqb8w xe9uy6x xyxi2l3",kI3sdo:"x17nn4n9",kInvED:"x1wfwxd8 x7s97pk",$$css:!0},selected:{kMwMTN:"x1tgivj0",k63SB2:"x2mo6ok",kWkggS:"x17x4s8c x1sua13m xjtnuge",$$css:!0},iconOnly:{kg3NbH:"xf314gf",$$css:!0},drawerFocus:{kI3sdo:"x17nn4n9",kInvED:"x1wfwxd8 x7s97pk",$$css:!0}};function ws({as:e,label:t,isSelected:l=!1,isDisabled:n=!1,icon:a,children:u,xstyle:i,className:c,style:s,ref:o,...x}){const h=Ti(e),d=o0(),m=a!=null&&u==null&&!t,p=!m;return d==="drawer"?f.jsxs(h,{ref:o,"aria-current":l?"page":void 0,"aria-disabled":n||void 0,tabIndex:n?-1:void 0,...V(G("top-nav-item",{mode:"drawer"}),q(Ye.item,ou.drawerFocus,l&&Ye.selected,n&&Ye.disabled,i),c,s),...x,children:[a,u??t]}):f.jsxs(h,{ref:o,"aria-label":m?t:void 0,"aria-current":l?"page":void 0,"aria-disabled":n||void 0,tabIndex:n?-1:void 0,...V(G("top-nav-item"),q(ou.base,l&&ou.selected,n&&Ye.disabled,m&&ou.iconOnly,i),c,s),...x,children:[a,p&&(u??t)]})}ws.displayName="XDSTopNavItem";const Gf=g.createContext({isCollapsed:!1,toggle:()=>{},isCollapsible:!1});function Zf(){return g.useContext(Gf)}function g0({sideNavRef:e,label:t,children:l}){const{isCollapsed:n,toggle:a,isCollapsible:u}=Zf(),{isMobile:i}=Rf(),c=g.useCallback(()=>{a()},[a]);return!u||i?null:f.jsx(La,{label:t??(n?"Expand sidebar":"Collapse sidebar"),variant:"ghost",onClick:c,icon:l??f.jsx("span",{...{0:{className:"x3nfvp2 x6s0dn4 x11xpdln xuedmi6 xlr8y92"},1:{className:"x3nfvp2 x6s0dn4 x11xpdln xuedmi6 xlr8y92 x19jd1h0"}}[!!n<<0],children:Df("chevronLeft")})})}g0.displayName="XDSSideNavCollapseButton";const jc=180,$c=480,n2=260;function a2({enabled:e,config:t,collapsed:l}){const{defaultWidth:n=n2,onWidthChange:a}=t,[u,i]=g.useState(Math.min($c,Math.max(jc,n))),c=g.useRef(null),s=g.useRef(!1),o=g.useRef(0),x=g.useRef(0),[h,d]=g.useState(!1),m=g.useCallback(S=>{if(!e)return;S.preventDefault(),s.current=!0,o.current=S.clientX,x.current=u,document.body.style.cursor="col-resize";const y=v=>{if(!s.current)return;const b=v.clientX-o.current,z=Math.min($c,Math.max(jc,x.current+b));c.current&&(c.current.style.width=`${z}px`)},r=v=>{s.current=!1,document.body.style.cursor="",document.removeEventListener("pointermove",y),document.removeEventListener("pointerup",r);const b=v.clientX-o.current,z=Math.min($c,Math.max(jc,x.current+b));i(z),a==null||a(z)};document.addEventListener("pointermove",y),document.addEventListener("pointerup",r)},[e,u,a]);return g.useEffect(()=>()=>{s.current&&(document.body.style.cursor="")},[]),{width:u,containerRef:c,showHandle:e&&!l,handleProps:{onPointerDown:m,onPointerEnter:()=>d(!0),onPointerLeave:()=>{s.current||d(!1)}},isHandleHovered:h}}const Ec={root:{k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",kZKoxP:"x5yr21d",kzqmXN:"x1hfn5x7",kWkggS:"xgcd1z6",kB7OPa:"x9f619",kVQacm:"xb3r6kr",$$css:!0},rootCollapsed:{kzqmXN:"xvni27",$$css:!0},topbar:{k1xSpc:"x78zum5",kXwgrk:"x1q0g3np",kGNEyG:"x6s0dn4",kjj79g:"x1qughib",kZKoxP:"xsdox4t",kzqmXN:"xh8yej3",kWkggS:"xgcd1z6",kB7OPa:"x9f619",kVQacm:"xb3r6kr",$$css:!0}};function p0({header:e,topContent:t,children:l,footer:n,footerIcons:a,collapsible:u=!1,resizable:i=!1,xstyle:c,className:s,style:o,"data-testid":x,ref:h,...d}){const m=typeof u=="object"?u:{},p=!!u,k=m.hasButton??!0,S=m.defaultIsCollapsed??!1,y=m.isCollapsed,r=m.onCollapsedChange,v=typeof i=="object"?i:{},b=!!i,z=y!==void 0,[w,$]=g.useState(S),T=z?y:w,E=g.useCallback(()=>{const qe=!T;z||$(qe),r==null||r(qe)},[T,z,r]),M={isCollapsed:T,toggle:E,isCollapsible:p},{width:D,containerRef:R,showHandle:Z,handleProps:ce,isHandleHovered:fe}=a2({enabled:b,config:v,collapsed:T}),A=Eg();if(A==="topbar")return f.jsxs("div",{"data-testid":x,...V(G("side-nav",{mode:"topbar"}),q(Ec.topbar,c),s,o),children:[e,f.jsx("div",{className:"x78zum5 x6s0dn4 xzye2dw xvc5jky",children:a})]});const N=!!(n||a);if(A==="drawer")return f.jsxs(Lf,{header:e,"data-testid":x,children:[t,l,N&&f.jsxs("div",{className:"x78zum5 xdt5ytf xr1yuqi x1txdalj x1xye8es",children:[n,a&&f.jsx("div",{className:"x78zum5 x6s0dn4 xzye2dw",children:a})]})]});if(A==="drawer-content")return f.jsxs(f.Fragment,{children:[t,l,N&&f.jsxs("div",{className:"x78zum5 xdt5ytf xr1yuqi x1txdalj x1xye8es",children:[n,a&&f.jsx("div",{className:"x78zum5 x6s0dn4 xzye2dw",children:a})]})]});const O=!!(e||t),Y=!!(n||a),I=b?{...o??{},width:T?void 0:D}:o,$e=f.jsxs("nav",{ref:h,role:"navigation","aria-label":"Side navigation","data-testid":x,...V(G("side-nav"),q(Ec.root,T&&Ec.rootCollapsed,c),s,I),...d,children:[O&&f.jsxs("div",{className:"x78zum5 xdt5ytf x2lah0s x7wzq59 x13vifvy x1vjfegm xgcd1z6 x1xye8es xy143xn xf314gf x1txdalj xb3r6kr xeuugli",children:[e,t&&f.jsx("div",{children:t})]}),f.jsx("div",{...{0:{className:"x98rzlu x1odjw0f x6ikm8r xf314gf x1xye8es x1wesfrj"},2:{className:"x98rzlu x1odjw0f x6ikm8r xf314gf xfsso4q x1wesfrj"},1:{className:"x98rzlu x1odjw0f x6ikm8r xf314gf x1xye8es xy143xn"},3:{className:"x98rzlu x1odjw0f x6ikm8r xf314gf xfsso4q xy143xn"}}[!!O<<1|!!Y<<0],children:l}),(Y||p)&&f.jsxs("div",{...{0:{className:"x78zum5 xdt5ytf x2lah0s xr1yuqi x7wzq59 x1ey2m1c xgcd1z6 x1txdalj xf314gf xfsso4q x1wesfrj"},1:{className:"x78zum5 xdt5ytf x2lah0s xr1yuqi x7wzq59 x1ey2m1c xgcd1z6 x1txdalj xf314gf x1wesfrj xexx8yu"}}[!!T<<0],children:[n,f.jsxs("div",{...{0:{className:"x78zum5 x6s0dn4 xzye2dw"},1:{className:"x78zum5 x6s0dn4 xzye2dw x3ieub6"}}[!!T<<0],children:[p&&k&&f.jsx(g0,{}),a]})]})]}),De=Z?f.jsxs("div",{ref:R,className:"x1n2onr6 x78zum5 x2lah0s x5yr21d",style:{width:D},children:[$e,f.jsx("div",{"data-testid":"xds-sidenav-resize-handle",role:"separator","aria-orientation":"vertical","aria-label":"Resize sidebar",...{0:{className:"x10l6tqk xtijo5x x13vifvy x1ey2m1c x1v4s8kt xicojor xhtitgo xjbqb8w x111pd7f x5ve5x3"},1:{className:"x10l6tqk xtijo5x x13vifvy x1ey2m1c x1v4s8kt xicojor xhtitgo x111pd7f x5ve5x3 x1m4xfpy"}}[!!fe<<0],...ce})]}):$e;return p?f.jsx(Gf,{value:M,children:De}):De}p0.displayName="XDSSideNav";const u2={itemCollapsed:{kjj79g:"xl56j7k",kg3NbH:"x7a5moj",$$css:!0}},i2={isCollapsed:!1,toggle:()=>{},isCollapsible:!1};function Mt({as:e,label:t,icon:l,selectedIcon:n,isSelected:a=!1,isDisabled:u=!1,href:i,onClick:c,endContent:s,children:o,collapsible:x,"data-testid":h,ref:d}){const{isCollapsed:m}=Zf(),p=g.useId(),k=!!o,S=Ti(e),y=g.useRef(null),r=Ig({hasLightDismiss:!0,hasAutoFocus:!0,hasCloseButton:!1,dialogLabel:`${t} submenu`}),v=typeof x=="object"?x:{},b=k&&x!==!1,z=v.isCollapsed,w=z!==void 0,[$,T]=g.useState(v.defaultIsCollapsed??!1),E=w?z:$,M=g.useCallback(()=>{var me;const J=!E;w||T(J),(me=v.onCollapsedChange)==null||me.call(v,J)},[E,w,v]),D=a&&n?n:l,R=J=>{if(u){J.preventDefault();return}if(b&&!m){J.preventDefault(),M();return}c==null||c(J)},Z=g.useRef(null),ce=g.useRef(null),fe=g.useCallback(()=>{Z.current&&(clearTimeout(Z.current),Z.current=null),ce.current&&(clearTimeout(ce.current),ce.current=null)},[]),A=g.useCallback(()=>{fe(),Z.current=setTimeout(()=>{r.show({skipAutoFocus:!0})},150)},[fe,r]),N=g.useCallback(()=>{fe(),ce.current=setTimeout(()=>{r.hide()},200)},[fe,r]),O=g.useCallback(()=>{A()},[A]),Y=g.useCallback(()=>{N()},[N]);if(m&&!l)return null;if(m){const J=D&&f.jsx(Lt,{icon:D,size:"sm",color:a?"primary":u?"disabled":"secondary"}),me=V(G("side-nav-item"),q(Ye.item,u2.itemCollapsed,a&&Ye.selected,u&&Ye.disabled));if(k)return f.jsxs("div",{className:"x78zum5 xdt5ytf xh8yej3",children:[f.jsx("button",{ref:bl=>{r.triggerRef(bl),typeof d=="function"?d(bl):d&&(d.current=bl)},type:"button",onClick:r.toggle,onMouseEnter:O,onMouseLeave:Y,"aria-label":t,"data-testid":h,...r.triggerProps,...me,children:J}),r.render(f.jsxs("div",{className:"x1litavf x1y0btm7 x14i3s5s xu0wf1k x7a5moj x11g1kdw xfb3i0g",onMouseEnter:O,onMouseLeave:Y,onClick:()=>r.hide(),children:[f.jsx("div",{className:"xf314gf xu0wf1k x141an7d x2mo6ok xv1l7n4 x1ltkj2j",children:t}),f.jsx(Gf,{value:i2,children:o})]}),{placement:"end",alignment:"start"})]});const Ga={"aria-current":a?"page":void 0,"aria-disabled":u||void 0,"aria-label":t,"data-testid":h},Mi=i&&!u?f.jsx(S,{ref:d,href:i,onClick:R,...Ga,...me,children:J}):f.jsx("button",{ref:d,type:"button",onClick:R,disabled:u,...Ga,...me,children:J});return f.jsxs("div",{ref:y,className:"x78zum5 xdt5ytf xh8yej3",children:[Mi,f.jsx(Ba,{content:t,placement:"end",anchorRef:y})]})}const I=f.jsxs(f.Fragment,{children:[D&&f.jsx(Lt,{icon:D,size:"sm",color:a?"primary":u?"disabled":"secondary"}),!m&&f.jsx("span",{className:"x98rzlu xeuugli xb3r6kr xlyipyv xuxw1ft",children:t}),!m&&s&&f.jsx("span",{className:"x2lah0s x78zum5 x6s0dn4",children:s}),!m&&b&&f.jsx("span",{...{0:{className:"x3nfvp2 x6s0dn4 x11xpdln xuedmi6 xlr8y92 x2lah0s"},1:{className:"x3nfvp2 x6s0dn4 x11xpdln xuedmi6 xlr8y92 x2lah0s x19jd1h0"}}[!!E<<0],children:Df("chevronDown")})]}),$e={"aria-current":a?"page":void 0,"aria-disabled":u||void 0,"aria-expanded":b?!E:void 0,"aria-controls":b?`${p}-children`:void 0,"data-testid":h},De=i&&!u?f.jsx(S,{ref:d,href:i,onClick:R,...$e,...V(G("side-nav-item"),q(Ye.item,a&&Ye.selected,u&&Ye.disabled)),children:I}):f.jsx("button",{ref:d,type:"button",onClick:R,disabled:u,...$e,...V(G("side-nav-item"),q(Ye.item,a&&Ye.selected,u&&Ye.disabled)),children:I});return f.jsxs("div",{ref:y,className:"x78zum5 xdt5ytf xh8yej3",children:[De,k&&!m&&f.jsx("div",{id:`${p}-children`,role:"group","aria-labelledby":`${p}-label`,"aria-hidden":E,...{0:{className:"xrvj5dj x1tu4anv x1qn9uv2 x80gvsz xlr8y92"},1:{className:"xrvj5dj x1qn9uv2 x80gvsz xlr8y92 xihq33y"}}[!!E<<0],children:f.jsxs("div",{className:"xb3r6kr x2lwn1j x31w388",children:[f.jsx("span",{id:`${p}-label`,hidden:!0,children:t}),o]})})]})}Mt.displayName="XDSSideNavItem";function As({title:e,subtitle:t,children:l,endContent:n,isHeaderHidden:a=!1,"data-testid":u}){const{isCollapsed:i}=Zf(),s=`${g.useId()}-title`,o=f.jsxs(f.Fragment,{children:[f.jsxs("span",{className:"x78zum5 xdt5ytf x98rzlu xeuugli",children:[f.jsx("span",{id:s,className:"x141an7d x2mo6ok x1ltkj2j xv1l7n4 xb3r6kr xlyipyv xuxw1ft",children:e}),t&&f.jsx("span",{className:"x141an7d x1ltkj2j xv1l7n4 xb3r6kr xlyipyv xuxw1ft",children:t})]}),n&&f.jsx("span",{className:"x2lah0s x78zum5 x6s0dn4",children:n})]}),x=a||i,h=x?{position:"absolute",width:1,height:1,padding:0,margin:-1,overflow:"hidden",clip:"rect(0, 0, 0, 0)",whiteSpace:"nowrap",borderWidth:0}:{};return f.jsxs("div",{role:"group","aria-labelledby":s,"data-testid":u,...V(G("side-nav-section"),{className:"x78zum5 xdt5ytf xu0wf1k"}),children:[f.jsx("div",{style:x?h:void 0,className:"x78zum5 x6s0dn4 x1txdalj xf314gf xu0wf1k xt0e3qv x87ps6o",children:o}),f.jsx("div",{className:"x78zum5 xdt5ytf x1lsbc85",children:l})]})}As.displayName="XDSSideNavSection";function c2(){return f.jsxs(Tu,{gap:6,children:[f.jsx(dn,{level:1,children:"General Settings"}),f.jsx(Ts,{children:f.jsxs(Tu,{gap:4,children:[f.jsx(dn,{level:3,children:"Profile"}),f.jsx(Ms,{label:"Display Name"}),f.jsx(Ms,{label:"Email Address"}),f.jsx(Bf,{}),f.jsx(dn,{level:3,children:"Preferences"}),f.jsx(Il,{label:"Enable email notifications"}),f.jsx(Il,{label:"Dark mode"}),f.jsx(Il,{label:"Show online status"})]})}),f.jsx(Ts,{children:f.jsxs(Tu,{gap:4,children:[f.jsx(dn,{level:3,children:"Privacy"}),f.jsx(Il,{label:"Make profile public"}),f.jsx(Il,{label:"Allow search engines to index profile"}),f.jsx(_f,{type:"supporting",children:"These settings control how others can find and view your profile."})]})})]})}function s2(){return f.jsx(qf,{theme:Z1,children:f.jsx(r0,{contentPadding:4,topNav:f.jsx(v0,{label:"Main navigation",heading:f.jsx(h0,{heading:"Settings Dashboard"}),startContent:f.jsxs(f.Fragment,{children:[f.jsx(ws,{label:"Home",href:"/"}),f.jsx(ws,{label:"Settings",href:"/settings",isSelected:!0})]})}),sideNav:f.jsxs(p0,{children:[f.jsxs(As,{title:"Settings",isHeaderHidden:!0,children:[f.jsx(Mt,{label:"General",isSelected:!0,href:"/settings/general"}),f.jsx(Mt,{label:"Account",href:"/settings/account"}),f.jsx(Mt,{label:"Notifications",href:"/settings/notifications"}),f.jsx(Mt,{label:"Privacy",href:"/settings/privacy"}),f.jsx(Mt,{label:"Security",href:"/settings/security"})]}),f.jsxs(As,{title:"Advanced",children:[f.jsx(Mt,{label:"API Keys",href:"/settings/api-keys"}),f.jsx(Mt,{label:"Integrations",href:"/settings/integrations"}),f.jsx(Mt,{label:"Danger Zone",href:"/settings/danger"})]})]}),children:f.jsx(c2,{})})})}function f2(){return f.jsx(qf,{theme:Z1,mode:"light",children:f.jsx(s2,{})})}Tv.createRoot(document.getElementById("root")).render(f.jsx(f2,{}));</script>
+  <style rel="stylesheet" crossorigin>/**
+ * XDS Reset Stylesheet
+ *
+ * An opinionated CSS reset that provides a clean, predictable base for
+ * XDS applications. Built on the same principles as Tailwind Preflight
+ * and modern-normalize, adapted for the XDS design system.
+ *
+ * This reset:
+ * - Normalizes cross-browser inconsistencies
+ * - Sets box-sizing: border-box universally
+ * - Removes default margins, padding, and list styles
+ * - Makes images block-level and responsive
+ * - Resets form elements to inherit font styles
+ * - Uses :where() for zero specificity (easy to override)
+ *
+ * Usage:
+ *
+ * 1. Import directly (global reset):
+ *    import '@xds/core/reset.css';
+ *
+ * 2. Combine with base styles and theme:
+ *    import '@xds/core/reset.css';        // @layer reset  — clean slate
+ *    import '@xds/core/xds.css';           // @layer xds-base — component styles
+ *    import '@xds/theme-default/theme.css'; // @layer xds-theme — theme overrides
+ *
+ * Layer order: reset → xds-base → xds-theme
+ * Consumer styles (unlayered) always override all XDS layers.
+ * The reset has the lowest priority and can be overridden by any other layer.
+ *
+ * Similar to:
+ * - Tailwind CSS Preflight
+ * - Chakra UI's preflight (v3)
+ * - Bootstrap Reboot
+ * - modern-normalize
+ */
+
+@layer reset {
+
+  /* ===========================================================================
+     Box Model
+     =========================================================================== */
+
+  /*
+   * Use border-box globally. Prevents padding/border from affecting
+   * element dimensions — the single most impactful reset.
+   */
+  :where(*, *::before, *::after) {
+    box-sizing: border-box;
+  }
+
+  /*
+   * Reset borders to 0-width solid. This lets you add a border by just
+   * setting border-width — no need to also specify border-style.
+   */
+  :where(*, *::before, *::after) {
+    border-width: 0;
+    border-style: solid;
+    border-color: currentColor;
+  }
+
+  /* ===========================================================================
+     Document
+     =========================================================================== */
+
+  /*
+   * Consistent line-height, prevent text size adjustment on orientation
+   * change in iOS, and set a readable tab size.
+   *
+   * color-scheme: light dark — declares that this page supports both modes,
+   * enabling CSS light-dark() to resolve correctly. Also ensures that CSS
+   * tools (e.g. LightningCSS) which polyfill light-dark() for older browsers
+   * inject their toggle-variable initialization in the same CSS bundle.
+   * XDSTheme overrides color-scheme per-wrapper as needed.
+   */
+  :where(html) {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    color-scheme: light dark;
+  }
+
+  /*
+   * Remove default body margin and set font smoothing for sharper text
+   * rendering on macOS/iOS.
+   */
+  :where(body) {
+    margin: 0;
+    line-height: inherit;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* ===========================================================================
+     Typography
+     =========================================================================== */
+
+  /*
+   * Reset headings to inherit size and weight. Headings should be styled
+   * intentionally — not rely on browser defaults that vary across browsers.
+   */
+  :where(h1, h2, h3, h4, h5, h6) {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /*
+   * Remove default margins on all block-level text elements.
+   */
+  :where(h1, h2, h3, h4, h5, h6, p, blockquote, figure, pre, dl, dd) {
+    margin: 0;
+  }
+
+  /*
+   * Links inherit color and text-decoration. Style them intentionally
+   * rather than relying on browser-default blue/purple.
+   */
+  :where(a) {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  /*
+   * Correct font-weight rendering in Chrome and Safari.
+   */
+  :where(b, strong) {
+    font-weight: bolder;
+  }
+
+  /*
+   * Use the configured monospace font stack and fix the odd em sizing
+   * that browsers apply to code elements.
+   */
+  :where(code, kbd, samp, pre) {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      'Liberation Mono', 'Courier New', monospace;
+    font-size: 1em;
+  }
+
+  /*
+   * Correct font-size for small elements.
+   */
+  :where(small) {
+    font-size: 80%;
+  }
+
+  /*
+   * Prevent sub and sup from affecting line-height.
+   */
+  :where(sub, sup) {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  :where(sub) {
+    bottom: -0.25em;
+  }
+
+  :where(sup) {
+    top: -0.5em;
+  }
+
+  /* ===========================================================================
+     Lists
+     =========================================================================== */
+
+  /*
+   * Remove default list styles, margin, and padding. Lists used for
+   * navigation or layout shouldn't carry prose styling by default.
+   * Use explicit styles for prose lists.
+   */
+  :where(ol, ul, menu) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Media
+     =========================================================================== */
+
+  /*
+   * Make replaced elements block-level. Eliminates the "mystery gap"
+   * below inline images and aligns with how these elements are
+   * actually used in modern layouts.
+   */
+  :where(img, svg, video, canvas, audio, iframe, embed, object) {
+    display: block;
+    vertical-align: middle;
+  }
+
+  /*
+   * Constrain images and video to their container. Responsive by default.
+   */
+  :where(img, video) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* ===========================================================================
+     Forms
+     =========================================================================== */
+
+  /*
+   * Form elements should inherit font styles from their parent rather
+   * than using the browser's default font stack.
+   */
+  :where(button, input, optgroup, select, textarea) {
+    font: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  /*
+   * Remove default button styling. Buttons should be styled intentionally.
+   */
+  :where(button, [type='button'], [type='reset'], [type='submit']) {
+    -webkit-appearance: button;
+    appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
+
+  /*
+   * Pointer cursor for interactive elements.
+   */
+  :where(button, [role='button']) {
+    cursor: pointer;
+  }
+
+  /*
+   * Default cursor for disabled elements.
+   */
+  :where(:disabled) {
+    cursor: default;
+  }
+
+  /*
+   * Only allow vertical resizing of textareas to prevent layout breakage.
+   */
+  :where(textarea) {
+    resize: vertical;
+  }
+
+  /*
+   * Normalize placeholder opacity (Firefox renders at reduced opacity)
+   * and set a sensible default color using the XDS text-placeholder token.
+   */
+  :where(input::placeholder, textarea::placeholder) {
+    opacity: 1;
+    color: var(--color-text-secondary, #9ca3af);
+  }
+
+  /*
+   * Remove the inner padding and cancel buttons in search inputs
+   * for Chrome and Safari.
+   */
+  :where([type='search']::-webkit-search-decoration,
+         [type='search']::-webkit-search-cancel-button) {
+    -webkit-appearance: none;
+  }
+
+  /*
+   * Remove default fieldset styles.
+   */
+  :where(fieldset) {
+    margin: 0;
+    padding: 0;
+  }
+
+  :where(legend) {
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Tables
+     =========================================================================== */
+
+  /*
+   * Collapse table borders and fix text-indent/border-color inheritance.
+   */
+  :where(table) {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  /* ===========================================================================
+     Misc
+     =========================================================================== */
+
+  /*
+   * Simplify hr to a single border-top line.
+   */
+  :where(hr) {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  /*
+   * Correct display for summary elements.
+   */
+  :where(summary) {
+    display: list-item;
+  }
+
+  /*
+   * Reset dialog padding and outline.
+   */
+  :where(dialog) {
+    padding: 0;
+    outline: none;
+  }
+
+  /*
+   * Ensure hidden elements are actually hidden.
+   */
+  :where([hidden]) {
+    display: none;
+  }
+
+  /*
+   * Remove tap highlight on iOS.
+   */
+  :where(html) {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* ===========================================================================
+     Touch Devices
+     =========================================================================== */
+
+  /*
+   * Suppress focus-visible outlines on touch-only devices.
+   *
+   * Focus rings exist to show keyboard users where focus is. On devices
+   * with no hover capability and a coarse pointer (phones, tablets),
+   * there's no keyboard navigation — focus rings are visual noise that
+   * can flash on tap, on dialog open (showModal auto-focus), or on
+   * programmatic focus.
+   *
+   * This targets touch-only devices specifically:
+   * - (hover: none) — no hover capability (not a mouse)
+   * - (pointer: coarse) — imprecise pointer (finger, not stylus)
+   *
+   * Hybrid devices (laptop with touchscreen) are NOT affected because
+   * their primary pointer is fine (trackpad/mouse) and hover is available.
+   */
+  @media (hover: none) and (pointer: coarse) {
+    :where(:focus-visible) {
+      outline: none;
+    }
+  }
+}</style>
+<style>@property --x-width {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-height {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-maxWidth {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-minHeight {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x---container-max-height {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-fontSize {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-bottom {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-right {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-borderWidth {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-gap {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-marginTop {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-animationDelay {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-minWidth {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-maxHeight {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-top {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-left {
+  syntax: "*";
+  inherits: false
+}
+
+@keyframes xtut5q7-B {
+  0% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: .5;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes xgnty7z-B {
+  0% {
+    opacity: .25;
+  }
+
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes x18re5ia-B {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes x1k48ry3-B {
+  from {
+    opacity: 0;
+    transform: scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+@keyframes x11lauxq-B {
+  from {
+    opacity: 0;
+    transform: translate(var(--dialog-dir-x, 0px),var(--dialog-dir-y, 16px)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translate(0)scale(1);
+  }
+}
+
+@keyframes xwmkjkf-B {
+  from {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xu7jd1z-B {
+  from {
+    opacity: 0;
+    transform: translateX(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xv1hr86-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes x1ahk7ht-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes xiylxmw-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2)));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes x1b6yrix-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes xqng64z-B {
+  0% {
+    transform: rotate(0);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes xr3m334-B {
+  0% {
+    transform: translateX(-100%);
+  }
+
+  100% {
+    transform: translateX(250%);
+  }
+}
+
+:root, .xyc456f {
+  --border-width: 1px;
+}
+
+:root, .xrphr3l {
+  --color-accent: light-dark(#0064e0, #2694fe);
+  --color-accent-muted: light-dark(#0082fb33, #0082fb3f);
+  --color-on-accent: light-dark(#fff, #fff);
+  --color-neutral: light-dark(#0536591a, #dfe2e533);
+  --color-background-surface: light-dark(#fff, #1f1f22);
+  --color-background-body: light-dark(#f1f4f7, #111112);
+  --color-overlay: light-dark(#01122866, #11111299);
+  --color-overlay-hover: light-dark(#0536590c, #ffffff0c);
+  --color-overlay-pressed: light-dark(#05365919, #ffffff19);
+  --color-background-muted: light-dark(#0536590c, #1111127f);
+  --color-text-primary: light-dark(#0a1317, #dfe2e5);
+  --color-text-secondary: light-dark(#4e606f, #aaafb5);
+  --color-text-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-text-accent: light-dark(#0064e0, #3e9efb);
+  --color-on-dark: light-dark(#fff, #fff);
+  --color-on-light: light-dark(#000, #000);
+  --color-icon-accent: light-dark(#0064e0, #2694fe);
+  --color-icon-primary: light-dark(#0a1317, #dfe2e5);
+  --color-icon-secondary: light-dark(#4e606f, #aaafb5);
+  --color-icon-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-background-card: light-dark(#fff, #1f1f22);
+  --color-background-popover: light-dark(#fff, #28292c);
+  --color-success: light-dark(#0d8626, #0d8626);
+  --color-success-muted: light-dark(#0b991f33, #0b991f3f);
+  --color-on-success: light-dark(#fff, #fff);
+  --color-error: light-dark(#e3193b, #f5394f);
+  --color-error-muted: light-dark(#e3193b33, #f5394f3f);
+  --color-on-error: light-dark(#fff, #fff);
+  --color-warning: light-dark(#e9af08, #f2c00b);
+  --color-warning-muted: light-dark(#e2a40033, #e2a4003f);
+  --color-on-warning: light-dark(#0a1317, #0a1317);
+  --color-border: light-dark(#05365919, #f2f4f619);
+  --color-border-emphasized: light-dark(#ccd3db, #494d53);
+  --color-skeleton: light-dark(#ccd3db, #5a5e66);
+  --color-shadow: light-dark(#0536591a, #0000004d);
+  --color-tint-hover: light-dark(#000, #fff);
+  --color-background-blue: light-dark(#0171e333, #0171e333);
+  --color-border-blue: light-dark(#0171e3, #4ba9fe);
+  --color-icon-blue: light-dark(#0064e0, #2694fe);
+  --color-text-blue: light-dark(#042f97, #afd7ff);
+  --color-background-cyan: light-dark(#03a7d733, #03a7d733);
+  --color-border-cyan: light-dark(#00bcd4, #4dd0e1);
+  --color-icon-cyan: light-dark(#00acc1, #26c6da);
+  --color-text-cyan: light-dark(#014975, #a1eef9);
+  --color-background-gray: light-dark(#0a131733, #666a724c);
+  --color-border-gray: light-dark(#647685, #8c939b);
+  --color-icon-gray: light-dark(#4e606f, #aaafb5);
+  --color-text-gray: light-dark(#0a1317, #e7eaed);
+  --color-background-green: light-dark(#24bb5e33, #24bb5e33);
+  --color-border-green: light-dark(#24bb5e, #4cd964);
+  --color-icon-green: light-dark(#0d8626, #26a756);
+  --color-text-green: light-dark(#09441f, #a5f690);
+  --color-background-orange: light-dark(#f2790233, #f2790233);
+  --color-border-orange: light-dark(#f27902, #ffa040);
+  --color-icon-orange: light-dark(#e9690b, #fb8c00);
+  --color-text-orange: light-dark(#6b2203, #fdb876);
+  --color-background-pink: light-dark(#e638b333, #e638b333);
+  --color-border-pink: light-dark(#e91e63, #f48fb1);
+  --color-icon-pink: light-dark(#c2185b, #ec407a);
+  --color-text-pink: light-dark(#650053, #feade3);
+  --color-background-purple: light-dark(#7952ff33, #7952ff33);
+  --color-border-purple: light-dark(#7952ff, #9575cd);
+  --color-icon-purple: light-dark(#5b08d8, #7952ff);
+  --color-text-purple: light-dark(#3e0697, #b3b0fe);
+  --color-background-red: light-dark(#e3193b33, #e3193b33);
+  --color-border-red: light-dark(#e3193b, #f5394f);
+  --color-icon-red: light-dark(#d31130, #e3193b);
+  --color-text-red: light-dark(#7b0210, #ffb2b8);
+  --color-background-teal: light-dark(#0db7af33, #0db7af33);
+  --color-border-teal: light-dark(#0db7af, #4db6ac);
+  --color-icon-teal: light-dark(#009688, #26a69a);
+  --color-text-teal: light-dark(#083943, #40dccd);
+  --color-background-yellow: light-dark(#e2a40033, #e2a40033);
+  --color-border-yellow: light-dark(#ffeb3b, #fff176);
+  --color-icon-yellow: light-dark(#fbc02d, #ffee58);
+  --color-text-yellow: light-dark(#753f07, #fbce03);
+}
+
+:root, .xdxxp96 {
+  --duration-fast-min: .13s;
+  --duration-fast: .175s;
+  --duration-fast-max: .23s;
+  --duration-medium-min: .31s;
+  --duration-medium: .41s;
+  --duration-medium-max: .55s;
+}
+
+:root, .x1u6r7cv {
+  --ease-standard: cubic-bezier(.24, 1, .4, 1);
+}
+
+:root, .x6xvlns {
+  --font-family-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-family-code: "SF Mono", Monaco, Consolas, monospace;
+  --font-family-heading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+:root, .x48sopm {
+  --font-size-4xs: .375rem;
+  --font-size-3xs: .4375rem;
+  --font-size-2xs: .5rem;
+  --font-size-xs: .625rem;
+  --font-size-sm: .75rem;
+  --font-size-base: .875rem;
+  --font-size-lg: 1.0625rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.8125rem;
+  --font-size-4xl: 2.1875rem;
+  --font-size-5xl: 2.625rem;
+}
+
+:root, .x1anzp68 {
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+}
+
+:root, .xy6n0i {
+  --radius-none: 0px;
+  --radius-inner: 4px;
+  --radius-element: 8px;
+  --radius-container: 12px;
+  --radius-page: 28px;
+  --radius-full: 9999px;
+}
+
+:root, .x99zpk1 {
+  --shadow-low: 0px 1px 1px light-dark(#0000001a, #0003), 0px 2px 8px light-dark(#0000001a, #0003);
+  --shadow-med: 0px 1px 2px light-dark(#0000001a, #0003), 0px 2px 12px light-dark(#0000001a, #0003);
+  --shadow-high: 0px 2px 2px light-dark(#0000001a, #0003), 0px 8px 24px light-dark(#0000001a, #0000004d);
+  --shadow-inset-hover: inset 0px 0px 0px 2px #0171e34d;
+  --shadow-inset-selected: inset 0px 0px 0px 2px #0171e380;
+  --shadow-inset-success: inset 0px 0px 0px 2px #26a7564d;
+  --shadow-inset-warning: inset 0px 0px 0px 2px #e2a4004d;
+  --shadow-inset-error: inset 0px 0px 0px 2px #e3193b4d;
+}
+
+:root, .x10aelx4 {
+  --size-element-sm: 28px;
+  --size-element-md: 32px;
+  --size-element-lg: 36px;
+}
+
+:root, .x1auoh0n {
+  --spacing-0: 0px;
+  --spacing-0-5: 2px;
+  --spacing-1: 4px;
+  --spacing-1-5: 6px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-11: 44px;
+  --spacing-12: 48px;
+}
+
+:root, .xmde5od {
+  --text-heading-1-size: var(--font-size-2xl);
+  --text-heading-1-weight: var(--font-weight-semibold);
+  --text-heading-1-leading: 1.3333;
+  --text-heading-2-size: var(--font-size-xl);
+  --text-heading-2-weight: var(--font-weight-semibold);
+  --text-heading-2-leading: 1.4;
+  --text-heading-3-size: var(--font-size-lg);
+  --text-heading-3-weight: var(--font-weight-semibold);
+  --text-heading-3-leading: 1.4118;
+  --text-heading-4-size: var(--font-size-base);
+  --text-heading-4-weight: var(--font-weight-semibold);
+  --text-heading-4-leading: 1.4286;
+  --text-heading-5-size: var(--font-size-sm);
+  --text-heading-5-weight: var(--font-weight-semibold);
+  --text-heading-5-leading: 1.6667;
+  --text-heading-6-size: var(--font-size-xs);
+  --text-heading-6-weight: var(--font-weight-semibold);
+  --text-heading-6-leading: 1.6;
+  --text-body-size: var(--font-size-base);
+  --text-body-weight: var(--font-weight-normal);
+  --text-body-leading: 1.4286;
+  --text-large-size: var(--font-size-lg);
+  --text-large-weight: var(--font-weight-semibold);
+  --text-large-leading: 1.4118;
+  --text-label-size: var(--font-size-base);
+  --text-label-weight: var(--font-weight-medium);
+  --text-label-leading: 1.4286;
+  --text-code-size: var(--font-size-base);
+  --text-code-weight: var(--font-weight-normal);
+  --text-code-leading: 1.4286;
+  --text-supporting-size: var(--font-size-sm);
+  --text-supporting-weight: var(--font-weight-normal);
+  --text-supporting-leading: 1.6667;
+  --text-display-1-size: var(--font-size-5xl);
+  --text-display-1-weight: var(--font-weight-normal);
+  --text-display-1-leading: 1.2381;
+  --text-display-2-size: var(--font-size-4xl);
+  --text-display-2-weight: var(--font-weight-normal);
+  --text-display-2-leading: 1.2571;
+  --text-display-3-size: var(--font-size-3xl);
+  --text-display-3-weight: var(--font-weight-normal);
+  --text-display-3-leading: 1.2414;
+}
+
+:root, .xs77cmt {
+  --transition-fast: .15s ease;
+  --transition-normal: .2s ease;
+}
+
+.xmj1mr2 {
+  --banner-radius: var(--radius-container);
+}
+
+.xkzo27j {
+  --button-focus-offset: 3px;
+}
+
+.x1v15ycx {
+  --button-icon-only-aspect: 1 / 1;
+}
+
+.x1mkq5kp {
+  --button-radius: var(--radius-element);
+}
+
+.xb26y6u {
+  --card-radius: var(--radius-container);
+}
+
+.x30uzy1 {
+  --component-padding-inline: var(--spacing-2);
+}
+
+.x1ojg8sz {
+  --component-padding-inline: var(--spacing-3);
+}
+
+.x18nyedi {
+  --container-max-height: var(--x---container-max-height);
+}
+
+.x1qmdwou {
+  --container-padding-inline: var(--spacing-0-5);
+}
+
+.x11nj8ps {
+  --container-padding-inline: var(--spacing-0);
+}
+
+.x11c4xrl {
+  --container-padding-inline: var(--spacing-1-5);
+}
+
+.xmqp8mn {
+  --container-padding-inline: var(--spacing-1);
+}
+
+.x1mh38z9 {
+  --container-padding-inline: var(--spacing-10);
+}
+
+.xarkblc {
+  --container-padding-inline: var(--spacing-11);
+}
+
+.x15nzvup {
+  --container-padding-inline: var(--spacing-12);
+}
+
+.xvkq9sf {
+  --container-padding-inline: var(--spacing-2);
+}
+
+.x17rklng {
+  --container-padding-inline: var(--spacing-3);
+}
+
+.x1qtkjpi {
+  --container-padding-inline: var(--spacing-4);
+}
+
+.xcek0mv {
+  --container-padding-inline: var(--spacing-5);
+}
+
+.xzryng3 {
+  --container-padding-inline: var(--spacing-6);
+}
+
+.x1jrgra8 {
+  --container-padding-inline: var(--spacing-7);
+}
+
+.x1t3jwqk {
+  --container-padding-inline: var(--spacing-8);
+}
+
+.x1ikhtwg {
+  --container-padding-inline: var(--spacing-9);
+}
+
+.x118jium {
+  --container-padding-inline: var(--xds-card-padding, var(--spacing-4));
+}
+
+.x1x4tb0e {
+  --container-padding-inline: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xbuvapz {
+  --container-padding: 0px;
+}
+
+.x1b322fk {
+  --container-padding: var(--spacing-0-5);
+}
+
+.x1i337hy {
+  --container-padding: var(--spacing-0);
+}
+
+.x1tqehje {
+  --container-padding: var(--spacing-1-5);
+}
+
+.x11x0u8a {
+  --container-padding: var(--spacing-1);
+}
+
+.xl4lgz8 {
+  --container-padding: var(--spacing-10);
+}
+
+.xfk8qm2 {
+  --container-padding: var(--spacing-11);
+}
+
+.xtcn5oa {
+  --container-padding: var(--spacing-12);
+}
+
+.xyawmno {
+  --container-padding: var(--spacing-2);
+}
+
+.xiq2vfk {
+  --container-padding: var(--spacing-3);
+}
+
+.x18iqpsj {
+  --container-padding: var(--spacing-4);
+}
+
+.x305b4h {
+  --container-padding: var(--spacing-5);
+}
+
+.x1suvfq4 {
+  --container-padding: var(--spacing-6);
+}
+
+.xe04trj {
+  --container-padding: var(--spacing-7);
+}
+
+.xv6sa6u {
+  --container-padding: var(--spacing-8);
+}
+
+.xswgb5g {
+  --container-padding: var(--spacing-9);
+}
+
+.x8q8htr {
+  --container-padding: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xms56fs {
+  --container-padding: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xuli5px {
+  --dialog-radius: var(--radius-container);
+}
+
+.x1r315hb {
+  --dropdown-padding: var(--spacing-1);
+}
+
+.x1u41t63 {
+  --dropdown-radius: var(--radius-container);
+}
+
+.xwfoc2r {
+  --edge-end: 1;
+}
+
+.x1tfgai2 {
+  --edge-start: 1;
+}
+
+.x19f4gzr {
+  --hovercard-radius: var(--radius-container);
+}
+
+.xrhxz6v {
+  --input-radius: var(--radius-element);
+}
+
+.xlriy2h {
+  --layout-padding-inner-x: var(--spacing-0-5);
+}
+
+.xj1bl4l {
+  --layout-padding-inner-x: var(--spacing-0);
+}
+
+.xd38f90 {
+  --layout-padding-inner-x: var(--spacing-1-5);
+}
+
+.x6uuyak {
+  --layout-padding-inner-x: var(--spacing-1);
+}
+
+.x1vf4qco {
+  --layout-padding-inner-x: var(--spacing-10);
+}
+
+.xsmamsf {
+  --layout-padding-inner-x: var(--spacing-11);
+}
+
+.x2xk2xj {
+  --layout-padding-inner-x: var(--spacing-12);
+}
+
+.xxqksqd {
+  --layout-padding-inner-x: var(--spacing-2);
+}
+
+.x1fyui2f {
+  --layout-padding-inner-x: var(--spacing-3);
+}
+
+.x1i2ajwi {
+  --layout-padding-inner-x: var(--spacing-4);
+}
+
+.x1tac27u {
+  --layout-padding-inner-x: var(--spacing-5);
+}
+
+.x1ntgf3t {
+  --layout-padding-inner-x: var(--spacing-6);
+}
+
+.xhjd9tl {
+  --layout-padding-inner-x: var(--spacing-7);
+}
+
+.xn7c84u {
+  --layout-padding-inner-x: var(--spacing-8);
+}
+
+.xeqkbsz {
+  --layout-padding-inner-x: var(--spacing-9);
+}
+
+.x1gox8qf {
+  --layout-padding-inner-x: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xn3f0pw {
+  --layout-padding-inner-x: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x180h0y5 {
+  --layout-padding-inner-y: var(--spacing-0-5);
+}
+
+.xwuefyo {
+  --layout-padding-inner-y: var(--spacing-0);
+}
+
+.x1g8jpzm {
+  --layout-padding-inner-y: var(--spacing-1-5);
+}
+
+.xmpug6m {
+  --layout-padding-inner-y: var(--spacing-1);
+}
+
+.x18gbwmk {
+  --layout-padding-inner-y: var(--spacing-10);
+}
+
+.x14zymzj {
+  --layout-padding-inner-y: var(--spacing-11);
+}
+
+.xzfpkx9 {
+  --layout-padding-inner-y: var(--spacing-12);
+}
+
+.x1lksgje {
+  --layout-padding-inner-y: var(--spacing-2);
+}
+
+.x4j7gld {
+  --layout-padding-inner-y: var(--spacing-3);
+}
+
+.x1s3ehtl {
+  --layout-padding-inner-y: var(--spacing-4);
+}
+
+.x1rj5eim {
+  --layout-padding-inner-y: var(--spacing-5);
+}
+
+.x1ftgg6u {
+  --layout-padding-inner-y: var(--spacing-6);
+}
+
+.x1ho74vh {
+  --layout-padding-inner-y: var(--spacing-7);
+}
+
+.xm2cs6f {
+  --layout-padding-inner-y: var(--spacing-8);
+}
+
+.x1vsq92b {
+  --layout-padding-inner-y: var(--spacing-9);
+}
+
+.x1eounod {
+  --layout-padding-inner-y: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xihc2cu {
+  --layout-padding-inner-y: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x1wbjvqu {
+  --layout-padding-outer-x: 0px;
+}
+
+.xihiwg7 {
+  --layout-padding-outer-x: var(--spacing-0-5);
+}
+
+.xswhm3q {
+  --layout-padding-outer-x: var(--spacing-0);
+}
+
+.x1u93lgd {
+  --layout-padding-outer-x: var(--spacing-1-5);
+}
+
+.xc96xmq {
+  --layout-padding-outer-x: var(--spacing-1);
+}
+
+.x1jdf5a4 {
+  --layout-padding-outer-x: var(--spacing-10);
+}
+
+.x1hct0t0 {
+  --layout-padding-outer-x: var(--spacing-11);
+}
+
+.x11cyqoe {
+  --layout-padding-outer-x: var(--spacing-12);
+}
+
+.x15dxnc0 {
+  --layout-padding-outer-x: var(--spacing-2);
+}
+
+.xadgj3j {
+  --layout-padding-outer-x: var(--spacing-3);
+}
+
+.x1v56qcf {
+  --layout-padding-outer-x: var(--spacing-4);
+}
+
+.x1nzs0gl {
+  --layout-padding-outer-x: var(--spacing-5);
+}
+
+.x1c3n52a {
+  --layout-padding-outer-x: var(--spacing-6);
+}
+
+.x1gfiokx {
+  --layout-padding-outer-x: var(--spacing-7);
+}
+
+.x1t3kfz {
+  --layout-padding-outer-x: var(--spacing-8);
+}
+
+.xzr4qsh {
+  --layout-padding-outer-x: var(--spacing-9);
+}
+
+.x1r0u152 {
+  --layout-padding-outer-x: var(--xds-card-padding, var(--spacing-4));
+}
+
+.x1h0nqri {
+  --layout-padding-outer-x: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xzxxx64 {
+  --layout-padding-outer-y: 0px;
+}
+
+.x1vj96e0 {
+  --layout-padding-outer-y: var(--spacing-0-5);
+}
+
+.x1mzf5mb {
+  --layout-padding-outer-y: var(--spacing-0);
+}
+
+.xd3dqby {
+  --layout-padding-outer-y: var(--spacing-1-5);
+}
+
+.x1gpfxoh {
+  --layout-padding-outer-y: var(--spacing-1);
+}
+
+.x26l4wa {
+  --layout-padding-outer-y: var(--spacing-10);
+}
+
+.x10zktp0 {
+  --layout-padding-outer-y: var(--spacing-11);
+}
+
+.x1yz3n6a {
+  --layout-padding-outer-y: var(--spacing-12);
+}
+
+.x10pz7y9 {
+  --layout-padding-outer-y: var(--spacing-2);
+}
+
+.x1p6yq3h {
+  --layout-padding-outer-y: var(--spacing-3);
+}
+
+.xx738ci {
+  --layout-padding-outer-y: var(--spacing-4);
+}
+
+.x6yxws5 {
+  --layout-padding-outer-y: var(--spacing-5);
+}
+
+.x180vrwl {
+  --layout-padding-outer-y: var(--spacing-6);
+}
+
+.x1q6rme1 {
+  --layout-padding-outer-y: var(--spacing-7);
+}
+
+.xid7e43 {
+  --layout-padding-outer-y: var(--spacing-8);
+}
+
+.x1t5kicu {
+  --layout-padding-outer-y: var(--spacing-9);
+}
+
+.xzqheer {
+  --layout-padding-outer-y: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xlfd3nr {
+  --layout-padding-outer-y: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x18trcj8 {
+  --segmented-padding: var(--spacing-0-5);
+}
+
+.x1yrec62 {
+  --segmented-radius: var(--radius-element);
+}
+
+.x1vnzsc9 {
+  --segmented-radius: var(--radius-inner);
+}
+
+.xln7xf2:not(#\#) {
+  font: inherit;
+}
+
+.x10a8y8t:not(#\#) {
+  inset: 0;
+}
+
+.xkdpibf:not(#\#) {
+  margin: -1px;
+}
+
+.x1ghz6dp:not(#\#) {
+  margin: 0;
+}
+
+.x1bpp3o7:not(#\#) {
+  margin: auto;
+}
+
+.x1n5sqmh:not(#\#) {
+  margin: calc(-1 * (var(--spacing-2) - var(--spacing-1) + 1px));
+}
+
+.x1ak00ur:not(#\#) {
+  margin: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1717udv:not(#\#) {
+  padding: 0;
+}
+
+.xfawy5m:not(#\#) {
+  padding: 4px;
+}
+
+.x1kp5lmi:not(#\#) {
+  padding: var(--container-padding);
+}
+
+.x1b391p0:not(#\#) {
+  padding: var(--segmented-padding);
+}
+
+.x9epnlk:not(#\#) {
+  padding: var(--spacing-1);
+}
+
+.x15nmkw0:not(#\#) {
+  padding: var(--spacing-2) 0;
+}
+
+.xlsj2fj:not(#\#) {
+  padding: var(--spacing-2);
+}
+
+.x1b2ylru:not(#\#) {
+  padding: var(--spacing-3);
+}
+
+.x1shk3sm:not(#\#) {
+  padding: var(--spacing-4);
+}
+
+.x1y5lnwp:focus:not(#\#) {
+  margin: 0;
+}
+
+.xad5do:not(#\#):not(#\#) {
+  border-color: var(--color-accent);
+}
+
+.x1touxvs:not(#\#):not(#\#) {
+  border-color: var(--color-background-surface);
+}
+
+.xvy26l8:not(#\#):not(#\#) {
+  border-color: var(--color-border-emphasized);
+}
+
+.x14i3s5s:not(#\#):not(#\#) {
+  border-color: var(--color-border);
+}
+
+.x1ofxpqo:not(#\#):not(#\#) {
+  border-color: var(--color-error);
+}
+
+.x16m2moy:not(#\#):not(#\#) {
+  border-color: var(--color-success);
+}
+
+.xqcx1ss:not(#\#):not(#\#) {
+  border-color: var(--color-text-primary);
+}
+
+.x8wg1ba:not(#\#):not(#\#) {
+  border-color: var(--color-warning);
+}
+
+.x2u8bby:not(#\#):not(#\#) {
+  border-radius: 0;
+}
+
+.x1nj7uno:not(#\#):not(#\#) {
+  border-radius: 1px;
+}
+
+.x16rqkct:not(#\#):not(#\#) {
+  border-radius: 50%;
+}
+
+.x1pjcqnp:not(#\#):not(#\#) {
+  border-radius: inherit;
+}
+
+.x1hsanxr:not(#\#):not(#\#) {
+  border-radius: max(0px,calc(var(--dropdown-radius) - var(--dropdown-padding)));
+}
+
+.x1s2h61r:not(#\#):not(#\#) {
+  border-radius: max(0px,calc(var(--segmented-radius) - var(--segmented-padding)));
+}
+
+.xsjjj52:not(#\#):not(#\#) {
+  border-radius: var(--banner-radius);
+}
+
+.x1q11iln:not(#\#):not(#\#) {
+  border-radius: var(--button-radius);
+}
+
+.x8j4bds:not(#\#):not(#\#) {
+  border-radius: var(--card-radius);
+}
+
+.x5kj0t4:not(#\#):not(#\#) {
+  border-radius: var(--dialog-radius);
+}
+
+.xzg3hwr:not(#\#):not(#\#) {
+  border-radius: var(--dropdown-radius);
+}
+
+.x1opg4e7:not(#\#):not(#\#) {
+  border-radius: var(--hovercard-radius);
+}
+
+.x11spqq5:not(#\#):not(#\#) {
+  border-radius: var(--input-radius);
+}
+
+.x1hviunn:not(#\#):not(#\#) {
+  border-radius: var(--radius-container);
+}
+
+.xh6dtrn:not(#\#):not(#\#) {
+  border-radius: var(--radius-element);
+}
+
+.xjspbzw:not(#\#):not(#\#) {
+  border-radius: var(--radius-full);
+}
+
+.xx3sua9:not(#\#):not(#\#) {
+  border-radius: var(--radius-inner);
+}
+
+.xwksslw:not(#\#):not(#\#) {
+  border-radius: var(--radius-none);
+}
+
+.x8i8e1q:not(#\#):not(#\#) {
+  border-radius: var(--segmented-radius);
+}
+
+.xng3xce:not(#\#):not(#\#) {
+  border-style: none;
+}
+
+.x1y0btm7:not(#\#):not(#\#) {
+  border-style: solid;
+}
+
+.xc342km:not(#\#):not(#\#) {
+  border-width: 0;
+}
+
+.xmkeg23:not(#\#):not(#\#) {
+  border-width: 1px;
+}
+
+.x1litavf:not(#\#):not(#\#) {
+  border-width: var(--border-width);
+}
+
+.x1mw0n95:not(#\#):not(#\#) {
+  border-width: var(--x-borderWidth);
+}
+
+.x1somy94:not(#\#):not(#\#) {
+  flex: 0 0 0;
+}
+
+.x1cqoux5:not(#\#):not(#\#) {
+  flex: 1 1 0;
+}
+
+.x845mor:not(#\#):not(#\#) {
+  flex: 1;
+}
+
+.xfoc8du:not(#\#):not(#\#) {
+  flex: 40px;
+}
+
+.x12lumcd:not(#\#):not(#\#) {
+  flex: auto;
+}
+
+.x98rzlu:not(#\#):not(#\#) {
+  flex: 1;
+}
+
+.xxhr3t:not(#\#):not(#\#) {
+  gap: 0;
+}
+
+.x14kbac9:not(#\#):not(#\#) {
+  gap: inherit;
+}
+
+.x1lsbc85:not(#\#):not(#\#) {
+  gap: var(--spacing-0-5);
+}
+
+.xsn7fz1:not(#\#):not(#\#) {
+  gap: var(--spacing-0);
+}
+
+.x1s4dlld:not(#\#):not(#\#) {
+  gap: var(--spacing-1-5);
+}
+
+.xzye2dw:not(#\#):not(#\#) {
+  gap: var(--spacing-1);
+}
+
+.x3hoi3v:not(#\#):not(#\#) {
+  gap: var(--spacing-10);
+}
+
+.xpec5dj:not(#\#):not(#\#) {
+  gap: var(--spacing-2) var(--spacing-4);
+}
+
+.x1txdalj:not(#\#):not(#\#) {
+  gap: var(--spacing-2);
+}
+
+.xlaq8a2:not(#\#):not(#\#) {
+  gap: var(--spacing-3) var(--spacing-4);
+}
+
+.xjcht0a:not(#\#):not(#\#) {
+  gap: var(--spacing-3);
+}
+
+.x18g69wz:not(#\#):not(#\#) {
+  gap: var(--spacing-4);
+}
+
+.x9mgr7n:not(#\#):not(#\#) {
+  gap: var(--spacing-5);
+}
+
+.x1qh66ti:not(#\#):not(#\#) {
+  gap: var(--spacing-6);
+}
+
+.x4t41sb:not(#\#):not(#\#) {
+  gap: var(--spacing-8);
+}
+
+.x1pidvrl:not(#\#):not(#\#) {
+  gap: var(--x-gap);
+}
+
+.xe8uvvx:not(#\#):not(#\#) {
+  list-style: none;
+}
+
+.xcxpkta:not(#\#):not(#\#) {
+  margin-block: calc(-1 * var(--container-padding, 0px));
+}
+
+.xhzvc8f:not(#\#):not(#\#) {
+  margin-block: calc(-1 * var(--spacing-2));
+}
+
+.xqixskq:not(#\#):not(#\#) {
+  margin-block: calc(var(--size-element-md) / 2 - var(--spacing-2) - var(--text-heading-2-size) * var(--text-heading-2-leading) / 2);
+}
+
+.xsq74q5:not(#\#):not(#\#) {
+  margin-block: var(--spacing-1);
+}
+
+.x1g06x3t:not(#\#):not(#\#) {
+  margin-block: var(--spacing-2);
+}
+
+.xzyy9it:not(#\#):not(#\#) {
+  margin-inline: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1a2a7pz:not(#\#):not(#\#) {
+  outline: none;
+}
+
+.xysyzu8:not(#\#):not(#\#) {
+  overflow: auto;
+}
+
+.x7giv3:not(#\#):not(#\#) {
+  overflow: clip;
+}
+
+.xb3r6kr:not(#\#):not(#\#) {
+  overflow: hidden;
+}
+
+.x1rea2x4:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xish69e:not(#\#):not(#\#) {
+  overscroll-behavior: contain;
+}
+
+.xt970qd:not(#\#):not(#\#) {
+  padding-block: 0;
+}
+
+.x1x7cmac:not(#\#):not(#\#) {
+  padding-block: calc(var(--spacing-1) - 1px);
+}
+
+.x13f7esw:not(#\#):not(#\#) {
+  padding-block: var(--spacing-0-5);
+}
+
+.xu0wf1k:not(#\#):not(#\#) {
+  padding-block: var(--spacing-1);
+}
+
+.xce4md1:not(#\#):not(#\#) {
+  padding-block: var(--spacing-2);
+}
+
+.x8o8v82:not(#\#):not(#\#) {
+  padding-block: var(--spacing-3);
+}
+
+.x1na6nto:not(#\#):not(#\#) {
+  padding-block: var(--spacing-4);
+}
+
+.xmfvnks:not(#\#):not(#\#) {
+  padding-block: var(--spacing-8);
+}
+
+.xnjsko4:not(#\#):not(#\#) {
+  padding-inline: 0;
+}
+
+.xx2oswg:not(#\#):not(#\#) {
+  padding-inline: calc(var(--spacing-1) - 1px);
+}
+
+.xkjnx3w:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-0-5);
+}
+
+.x7a5moj:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-1);
+}
+
+.xf314gf:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-2);
+}
+
+.xrrkdod:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-3);
+}
+
+.x1pzlopt:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-4);
+}
+
+.xm7rs69:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-6);
+}
+
+.xmqliwb:not(#\#):not(#\#) {
+  text-decoration: line-through;
+}
+
+.x1hl2dhg:not(#\#):not(#\#) {
+  text-decoration: none;
+}
+
+.x1bvjpef:not(#\#):not(#\#) {
+  text-decoration: underline;
+}
+
+.x111pd7f:not(#\#):not(#\#) {
+  transition: background-color .15s;
+}
+
+.x1aq93mo:not(#\#):not(#\#) {
+  transition: border-color .15s;
+}
+
+.xq2gx43:not(#\#):not(#\#) {
+  transition: none;
+}
+
+.x1ey1afo:not(#\#):not(#\#) {
+  transition: opacity var(--duration-fast);
+}
+
+.x1dg3z2k.x1dg3z2k:where(.x-default-marker:focus-within *):not(#\#):not(#\#), .x17nn4n9:focus-visible:not(#\#):not(#\#), .x1oqel4m:focus-within:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-accent);
+}
+
+.x1p73he7:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-error);
+}
+
+.x1p25gnr:focus-visible:not(#\#):not(#\#), .x1bb4jes:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-accent);
+}
+
+.xvr22io:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-error);
+}
+
+.xgqqtmo:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-success);
+}
+
+.x1i2lkmv:focus-within:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-warning);
+}
+
+.x1dordxg:focus-within:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xzeu18z:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-accent);
+}
+
+.xescob6:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-error);
+}
+
+.x1erxr0s:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-success);
+}
+
+.xhmquqt:focus:not(#\#):not(#\#) {
+  outline: var(--border-width) solid var(--color-warning);
+}
+
+.xomzh7y:focus:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xh2mrf5:focus:not(#\#):not(#\#) {
+  padding-block: var(--spacing-2);
+}
+
+.x1cf3d6k:focus:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-4);
+}
+
+@media (width <= 480px) {
+  .x1a1jff.x1a1jff:not(#\#):not(#\#) {
+    gap: var(--spacing-4);
+  }
+}
+
+@media (hover: hover) {
+  .xvrpfll.xvrpfll.xvrpfll:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: color-mix(in srgb,var(--color-accent),var(--color-tint-hover) 15%);
+  }
+
+  .xvyyb7d.xvyyb7d.xvyyb7d:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: color-mix(in srgb,var(--color-border-emphasized),var(--color-tint-hover) 20%);
+  }
+
+  .xrzr44y.xrzr44y.xrzr44y:where(.x-default-marker:hover *):not(#\#):not(#\#) {
+    border-color: var(--color-border);
+  }
+
+  .x1ww4t2b.x1ww4t2b:hover:not(#\#):not(#\#) {
+    border-color: var(--color-border-emphasized);
+  }
+
+  .x4ohgrr.x4ohgrr:hover:not(#\#):not(#\#) {
+    text-decoration: underline;
+  }
+}
+
+.x1ua5tub:not(#\#):not(#\#):not(#\#) {
+  -webkit-box-orient: vertical;
+}
+
+.x1pha0wt:not(#\#):not(#\#):not(#\#) {
+  align-items: baseline;
+}
+
+.x6s0dn4:not(#\#):not(#\#):not(#\#) {
+  align-items: center;
+}
+
+.xpqajaz:not(#\#):not(#\#):not(#\#) {
+  align-items: end;
+}
+
+.xuk3077:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-end;
+}
+
+.x1cy8zhl:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-start;
+}
+
+.x7a106z:not(#\#):not(#\#):not(#\#) {
+  align-items: start;
+}
+
+.x1qjc9v5:not(#\#):not(#\#):not(#\#) {
+  align-items: stretch;
+}
+
+.xoi2r2e:not(#\#):not(#\#):not(#\#) {
+  align-self: baseline;
+}
+
+.xamitd3:not(#\#):not(#\#):not(#\#) {
+  align-self: center;
+}
+
+.xpvyfi4:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-end;
+}
+
+.xqcrz7y:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-start;
+}
+
+.xkh2ocl:not(#\#):not(#\#):not(#\#) {
+  align-self: stretch;
+}
+
+.xvo38ju:not(#\#):not(#\#):not(#\#) {
+  animation-delay: var(--x-animationDelay);
+}
+
+.xpz12be:not(#\#):not(#\#):not(#\#) {
+  animation-direction: alternate;
+}
+
+.xmg6eyc:not(#\#):not(#\#):not(#\#) {
+  animation-duration: 1.5s;
+}
+
+.x1c74tu6:not(#\#):not(#\#):not(#\#) {
+  animation-duration: 2s;
+}
+
+.x9uej1z:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-fast-max);
+}
+
+.xqgcaz:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-medium-max);
+}
+
+.xskzprw:not(#\#):not(#\#):not(#\#) {
+  animation-fill-mode: backwards;
+}
+
+.xa4qsjk:not(#\#):not(#\#):not(#\#) {
+  animation-iteration-count: infinite;
+}
+
+.x1a5igra:not(#\#):not(#\#):not(#\#) {
+  animation-name: none;
+}
+
+.xqcmdr3:not(#\#):not(#\#):not(#\#) {
+  animation-name: x18re5ia-B;
+}
+
+.x3psbcj:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1ahk7ht-B;
+}
+
+.x1dvww92:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1b6yrix-B;
+}
+
+.x97zbip:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1k48ry3-B;
+}
+
+.xeuoslp:not(#\#):not(#\#):not(#\#) {
+  animation-name: xgnty7z-B;
+}
+
+.x1srr2gu:not(#\#):not(#\#):not(#\#) {
+  animation-name: xiylxmw-B;
+}
+
+.x1ka1v4i:not(#\#):not(#\#):not(#\#) {
+  animation-name: xqng64z-B;
+}
+
+.xozk8ic:not(#\#):not(#\#):not(#\#) {
+  animation-name: xr3m334-B;
+}
+
+.x1mta51n:not(#\#):not(#\#):not(#\#) {
+  animation-name: xtut5q7-B;
+}
+
+.xck01x9:not(#\#):not(#\#):not(#\#) {
+  animation-name: xu7jd1z-B;
+}
+
+.xl1vlw0:not(#\#):not(#\#):not(#\#) {
+  animation-name: xv1hr86-B;
+}
+
+.x1i331go:not(#\#):not(#\#):not(#\#) {
+  animation-name: xwmkjkf-B;
+}
+
+.x4hg4is:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: ease-in-out;
+}
+
+.x1esw782:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: linear;
+}
+
+.x193epu2:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: steps(10, end);
+}
+
+.x128ha8g:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: var(--ease-standard);
+}
+
+.xjyslct:not(#\#):not(#\#):not(#\#) {
+  appearance: none;
+}
+
+.xioom0i:not(#\#):not(#\#):not(#\#) {
+  aspect-ratio: var(--button-icon-only-aspect);
+}
+
+.xlp1x4z:not(#\#):not(#\#):not(#\#) {
+  backface-visibility: hidden;
+}
+
+.xgcd1z6:not(#\#):not(#\#):not(#\#) {
+  background-color: inherit;
+}
+
+.xjbqb8w:not(#\#):not(#\#):not(#\#) {
+  background-color: #0000;
+}
+
+.x9dqhi0:not(#\#):not(#\#):not(#\#) {
+  background-color: unset;
+}
+
+.xgcxg3y:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-accent-muted);
+}
+
+.x1ewilqj:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-accent);
+}
+
+.x1o0wnni:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-blue);
+}
+
+.x1eiddq6:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-body);
+}
+
+.x1de1mus:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-card);
+}
+
+.x1rgj867:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-cyan);
+}
+
+.xspzpui:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-gray);
+}
+
+.x1sqjeoo:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-green);
+}
+
+.xwmxj5m:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.x1e9xt6e:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-orange);
+}
+
+.xnpoty2:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-pink);
+}
+
+.x1prclbq:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-popover);
+}
+
+.x16i6n6f:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-purple);
+}
+
+.x1cibrc5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-red);
+}
+
+.x10xzikg:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-surface);
+}
+
+.x1jtji5o:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-teal);
+}
+
+.x1bo7t0x:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-yellow);
+}
+
+.x7njt3n:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border-emphasized);
+}
+
+.x1m4xfpy:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border);
+}
+
+.x1pritpl:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error-muted);
+}
+
+.x1pjz0fi:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error);
+}
+
+.x17x4s8c:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-neutral);
+}
+
+.x1azo05:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-on-accent);
+}
+
+.x1lmrjuc:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-overlay-hover);
+}
+
+.xprdx6m:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-skeleton);
+}
+
+.xu13z74:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-success-muted);
+}
+
+.xdsz4j9:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-success);
+}
+
+.x19aspcf:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-text-primary);
+}
+
+.xdomwnj:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-text-secondary);
+}
+
+.x24i8r5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-warning-muted);
+}
+
+.x1q8g9m5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-warning);
+}
+
+.x18o3ruo:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1mwwwfo:not(#\#):not(#\#):not(#\#) {
+  border-collapse: collapse;
+}
+
+.x1o3jo1z:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: #0000;
+}
+
+.x1gejf6u:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-border);
+}
+
+.x18b5jzi:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-style: solid;
+}
+
+.x1lun4ml:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-width: 1px;
+}
+
+.x1j92z86:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-color: var(--color-border);
+}
+
+.x1t7ytsu:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-style: solid;
+}
+
+.xpilrb4:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-width: 1px;
+}
+
+.x1gukg7c:not(#\#):not(#\#):not(#\#) {
+  border-spacing: 0;
+}
+
+.x183tx6i:not(#\#):not(#\#):not(#\#) {
+  border-start-start-radius: var(--radius-page);
+}
+
+.x1lp15jv:not(#\#):not(#\#):not(#\#) {
+  box-shadow: inset 0 0 0 1px var(--color-border-emphasized);
+}
+
+.x1iobdd1:not(#\#):not(#\#):not(#\#) {
+  box-shadow: inset 0 0 0 1px var(--color-text-primary);
+}
+
+.x1gnnqk1:not(#\#):not(#\#):not(#\#) {
+  box-shadow: none;
+}
+
+.x1kcpxr7:not(#\#):not(#\#):not(#\#) {
+  box-shadow: var(--shadow-high);
+}
+
+.x1i5ehqx:not(#\#):not(#\#):not(#\#) {
+  box-shadow: var(--shadow-low);
+}
+
+.x14hfi27:not(#\#):not(#\#):not(#\#) {
+  box-shadow: var(--shadow-med);
+}
+
+.x9f619:not(#\#):not(#\#):not(#\#) {
+  box-sizing: border-box;
+}
+
+.x1hyvwdk:not(#\#):not(#\#):not(#\#) {
+  clip-path: inset(50%);
+}
+
+.xzpqnlu:not(#\#):not(#\#):not(#\#) {
+  clip: rect(0,0,0,0);
+}
+
+.xntwwlm:not(#\#):not(#\#):not(#\#) {
+  color-scheme: dark;
+}
+
+.x108lcm5:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light dark;
+}
+
+.x19aimcq:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light;
+}
+
+.x1heor9g:not(#\#):not(#\#):not(#\#) {
+  color: inherit;
+}
+
+.x19co3pv:not(#\#):not(#\#):not(#\#) {
+  color: #0000;
+}
+
+.xqwr325:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-accent);
+}
+
+.xrkvqaz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-background-surface);
+}
+
+.xjt36v0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-error);
+}
+
+.x1fns2mt:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-blue);
+}
+
+.x157w0xa:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-cyan);
+}
+
+.xqa6c3m:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-disabled);
+}
+
+.x1eyinzz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-gray);
+}
+
+.xmxeech:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-green);
+}
+
+.xxu74a4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-orange);
+}
+
+.x1kxxfg5:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-pink);
+}
+
+.xtbr613:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-primary);
+}
+
+.xzdw94u:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-purple);
+}
+
+.xeffzf7:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-red);
+}
+
+.xv9yike:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-secondary);
+}
+
+.x1f3zxcb:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-teal);
+}
+
+.x1g6zdft:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-yellow);
+}
+
+.x17wrial:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-accent);
+}
+
+.x1m024r3:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-error);
+}
+
+.xri61p4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-success);
+}
+
+.xrebv38:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-warning);
+}
+
+.xtjic6:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-success);
+}
+
+.xjse4m1:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-accent);
+}
+
+.x1vvqiwl:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-blue);
+}
+
+.x1txnczv:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-cyan);
+}
+
+.xnbbluu:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-disabled);
+}
+
+.xru1t7f:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-gray);
+}
+
+.xltfdvo:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-green);
+}
+
+.xm47u9q:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-orange);
+}
+
+.xiuofww:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-pink);
+}
+
+.x1tgivj0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-primary);
+}
+
+.x1m9wyeb:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-purple);
+}
+
+.x1joocv1:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-red);
+}
+
+.xv1l7n4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-secondary);
+}
+
+.x9x0lbs:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-teal);
+}
+
+.xdhq94a:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-yellow);
+}
+
+.xs3pv69:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-warning);
+}
+
+.x1kihgfc:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0-5);
+}
+
+.x1o57wo1:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0);
+}
+
+.x1thn6ci:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1-5);
+}
+
+.x1lfs0n9:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1);
+}
+
+.x1p37tyl:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-10);
+}
+
+.xak3so:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-2);
+}
+
+.xewh9hi:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-3);
+}
+
+.xty4p9g:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-4);
+}
+
+.x1eqhezk:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-5);
+}
+
+.x3qlgwd:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-6);
+}
+
+.xicv188:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-8);
+}
+
+.x1qwvq9q:not(#\#):not(#\#):not(#\#) {
+  counter-increment: xds-list;
+}
+
+.x1vtlanm:not(#\#):not(#\#):not(#\#) {
+  counter-reset: xds-list;
+}
+
+.xicojor:not(#\#):not(#\#):not(#\#) {
+  cursor: col-resize;
+}
+
+.xt0e3qv:not(#\#):not(#\#):not(#\#) {
+  cursor: default;
+}
+
+.x7eptgl:not(#\#):not(#\#):not(#\#) {
+  cursor: ew-resize;
+}
+
+.x1jm3nie:not(#\#):not(#\#):not(#\#) {
+  cursor: grab;
+}
+
+.xmper1u:not(#\#):not(#\#):not(#\#) {
+  cursor: inherit;
+}
+
+.x1h6gzvc:not(#\#):not(#\#):not(#\#) {
+  cursor: not-allowed;
+}
+
+.x1ypdohk:not(#\#):not(#\#):not(#\#) {
+  cursor: pointer;
+}
+
+.x1ed109x:not(#\#):not(#\#):not(#\#) {
+  cursor: text;
+}
+
+.x104kibb:not(#\#):not(#\#):not(#\#) {
+  display: -webkit-box;
+}
+
+.x1lliihq:not(#\#):not(#\#):not(#\#) {
+  display: block;
+}
+
+.xjp7ctv:not(#\#):not(#\#):not(#\#) {
+  display: contents;
+}
+
+.x78zum5:not(#\#):not(#\#):not(#\#) {
+  display: flex;
+}
+
+.xrvj5dj:not(#\#):not(#\#):not(#\#) {
+  display: grid;
+}
+
+.x1rg5ohu:not(#\#):not(#\#):not(#\#) {
+  display: inline-block;
+}
+
+.x3nfvp2:not(#\#):not(#\#):not(#\#) {
+  display: inline-flex;
+}
+
+.xwz0xwf:not(#\#):not(#\#):not(#\#) {
+  display: inline-grid;
+}
+
+.xt0psk2:not(#\#):not(#\#):not(#\#) {
+  display: inline;
+}
+
+.x1s85apg:not(#\#):not(#\#):not(#\#) {
+  display: none;
+}
+
+.x1r8uery:not(#\#):not(#\#):not(#\#) {
+  flex-basis: 0;
+}
+
+.xjpgo6f:not(#\#):not(#\#):not(#\#) {
+  flex-basis: 200px;
+}
+
+.xchdapg:not(#\#):not(#\#):not(#\#) {
+  flex-basis: 300px;
+}
+
+.x3ieub6:not(#\#):not(#\#):not(#\#) {
+  flex-direction: column-reverse;
+}
+
+.xdt5ytf:not(#\#):not(#\#):not(#\#) {
+  flex-direction: column;
+}
+
+.x1q0g3np:not(#\#):not(#\#):not(#\#) {
+  flex-direction: row;
+}
+
+.x1c4vz4f:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 0;
+}
+
+.x1iyjqo2:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 1;
+}
+
+.xgyuaek:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 2;
+}
+
+.x2lah0s:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 0;
+}
+
+.xs83m0k:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 1;
+}
+
+.xozqiw3:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: nowrap;
+}
+
+.x8hhl5t:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap-reverse;
+}
+
+.x1a02dak:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap;
+}
+
+.xjb2p0i:not(#\#):not(#\#):not(#\#) {
+  font-family: inherit;
+}
+
+.x9ynric:not(#\#):not(#\#):not(#\#) {
+  font-family: var(--font-family-body);
+}
+
+.x1k6wstc:not(#\#):not(#\#):not(#\#) {
+  font-size: 10px;
+}
+
+.xfifm61:not(#\#):not(#\#):not(#\#) {
+  font-size: 12px;
+}
+
+.x1j61zf2:not(#\#):not(#\#):not(#\#) {
+  font-size: 16px;
+}
+
+.xwsyq91:not(#\#):not(#\#):not(#\#) {
+  font-size: 20px;
+}
+
+.x1pvqxga:not(#\#):not(#\#):not(#\#) {
+  font-size: 24px;
+}
+
+.x1qlqyl8:not(#\#):not(#\#):not(#\#) {
+  font-size: inherit;
+}
+
+.xho7bvi:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--spacing-4);
+}
+
+.xjm74w1:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-body-size);
+}
+
+.xcr08ib:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-label-size);
+}
+
+.x18juvz8:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-large-size);
+}
+
+.x141an7d:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-supporting-size);
+}
+
+.xdmh292:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--x-fontSize);
+}
+
+.x1j61x8r:not(#\#):not(#\#):not(#\#) {
+  font-style: normal;
+}
+
+.xss6m8b:not(#\#):not(#\#):not(#\#) {
+  font-variant-numeric: tabular-nums;
+}
+
+.x117nqv4:not(#\#):not(#\#):not(#\#) {
+  font-weight: bold;
+}
+
+.x1pd3egz:not(#\#):not(#\#):not(#\#) {
+  font-weight: inherit;
+}
+
+.x1lvx875:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-bold);
+}
+
+.x1e4wzip:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-medium);
+}
+
+.x1sodnla:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-normal);
+}
+
+.x2mo6ok:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-semibold);
+}
+
+.xxovm9e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-body-weight);
+}
+
+.xx3eeay:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-code-weight);
+}
+
+.x1txul5o:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-1-weight);
+}
+
+.x1y36c3f:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-2-weight);
+}
+
+.x1on40hk:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-3-weight);
+}
+
+.xmhvcl5:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-label-weight);
+}
+
+.x149oux8:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-large-weight);
+}
+
+.xv8on6e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-supporting-weight);
+}
+
+.xcrlgei:not(#\#):not(#\#):not(#\#) {
+  grid-column-start: 1;
+}
+
+.x1agbcgv:not(#\#):not(#\#):not(#\#) {
+  grid-row-start: 1;
+}
+
+.x134kloy:not(#\#):not(#\#):not(#\#) {
+  grid-template-columns: 1fr auto 1fr;
+}
+
+.x1y6fwsi:not(#\#):not(#\#):not(#\#) {
+  grid-template-columns: 1fr;
+}
+
+.x1pmbctz:not(#\#):not(#\#):not(#\#) {
+  grid-template-columns: auto 1fr;
+}
+
+.x1wthsqz:not(#\#):not(#\#):not(#\#) {
+  grid-template-columns: auto repeat(7, 1fr);
+}
+
+.x1mzazjb:not(#\#):not(#\#):not(#\#) {
+  grid-template-columns: repeat(7, 1fr);
+}
+
+.x189bvgu:not(#\#):not(#\#):not(#\#) {
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+}
+
+.xihq33y:not(#\#):not(#\#):not(#\#) {
+  grid-template-rows: 0fr;
+}
+
+.x1tu4anv:not(#\#):not(#\#):not(#\#) {
+  grid-template-rows: 1fr;
+}
+
+.xtijo5x:not(#\#):not(#\#):not(#\#) {
+  inset-inline-end: 0;
+}
+
+.x72tfeb:not(#\#):not(#\#):not(#\#) {
+  inset-inline-end: var(--spacing-2);
+}
+
+.x1o0tod:not(#\#):not(#\#):not(#\#) {
+  inset-inline-start: 0;
+}
+
+.xc8icb0:not(#\#):not(#\#):not(#\#) {
+  isolation: isolate;
+}
+
+.xl56j7k:not(#\#):not(#\#):not(#\#) {
+  justify-content: center;
+}
+
+.x13a6bvl:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-end;
+}
+
+.x1nhvcw1:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-start;
+}
+
+.x1l1ennw:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-around;
+}
+
+.x1qughib:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-between;
+}
+
+.xaw8158:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-evenly;
+}
+
+.x1o2pa38:not(#\#):not(#\#):not(#\#) {
+  justify-items: center;
+}
+
+.x4xo5sw:not(#\#):not(#\#):not(#\#) {
+  justify-items: end;
+}
+
+.x619ttb:not(#\#):not(#\#):not(#\#) {
+  justify-items: start;
+}
+
+.xl4xnwh:not(#\#):not(#\#):not(#\#) {
+  justify-items: stretch;
+}
+
+.x14ju556:not(#\#):not(#\#):not(#\#) {
+  line-height: 0;
+}
+
+.xo5v014:not(#\#):not(#\#):not(#\#) {
+  line-height: 1;
+}
+
+.x15bjb6t:not(#\#):not(#\#):not(#\#) {
+  line-height: inherit;
+}
+
+.xw6l6zx:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-body-leading);
+}
+
+.x1kq96og:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-label-leading);
+}
+
+.xf74fhv:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-large-leading);
+}
+
+.x1ltkj2j:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-supporting-leading);
+}
+
+.x3ct3a4:not(#\#):not(#\#):not(#\#) {
+  list-style-type: none;
+}
+
+.x14z9mp:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: 0;
+}
+
+.x1kpg4um:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(-1 * var(--layout-padding-inner-x, var(--spacing-4)));
+}
+
+.xkd40ry:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(-1 * var(--spacing-1));
+}
+
+.x3kzqx6:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(-1 * var(--spacing-2));
+}
+
+.xofqkxr:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(var(--edge-end, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.xmequkd:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(var(--spacing-1) * -1);
+}
+
+.xnur1sd:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: var(--spacing-1);
+}
+
+.x1lziwak:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: 0;
+}
+
+.xvc5jky:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: auto;
+}
+
+.x1wim8z0:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(-1 * var(--layout-padding-inner-x, var(--spacing-4)));
+}
+
+.xg82z56:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(var(--edge-start, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.x11g1kdw:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: var(--spacing-1);
+}
+
+.x1l10yog:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: var(--spacing-6);
+}
+
+.xl1xv1r:not(#\#):not(#\#):not(#\#) {
+  object-fit: cover;
+}
+
+.xvpkmg4:not(#\#):not(#\#):not(#\#) {
+  opacity: .25;
+}
+
+.xuzhngd:not(#\#):not(#\#):not(#\#) {
+  opacity: .3;
+}
+
+.xbyyjgo:not(#\#):not(#\#):not(#\#) {
+  opacity: .5;
+}
+
+.x1ks1olk:not(#\#):not(#\#):not(#\#) {
+  opacity: .7;
+}
+
+.xg01cxk:not(#\#):not(#\#):not(#\#) {
+  opacity: 0;
+}
+
+.x1hc1fzr:not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.x1wfwxd8:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 0;
+}
+
+.x1y3gkto:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 1px;
+}
+
+.x1hl8ikr:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x1mzt3pk:not(#\#):not(#\#):not(#\#) {
+  overflow-wrap: break-word;
+}
+
+.xyri2b:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: 0;
+}
+
+.x1peupej:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--layout-padding-inner-x, var(--spacing-4));
+}
+
+.xpc6k2p:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--layout-padding-outer-x, var(--spacing-4));
+}
+
+.x1le3yxw:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-0-5);
+}
+
+.x1s0aq8i:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-0);
+}
+
+.x17hk9do:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-1-5);
+}
+
+.x1nryj5t:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-1);
+}
+
+.x160ivqr:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-10);
+}
+
+.x1djylfy:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-2);
+}
+
+.x1t818jl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-3);
+}
+
+.xnjyzlh:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-4);
+}
+
+.xdbrk9v:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-5);
+}
+
+.x1we12cn:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-6);
+}
+
+.x1q91b2g:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-8);
+}
+
+.x1c1uobl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: 0;
+}
+
+.x2a0j69:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: calc(var(--spacing-2) - var(--spacing-1) + 1px);
+}
+
+.xter8d0:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: calc(var(--spacing-2) + var(--spacing-0-5));
+}
+
+.xwjyata:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--layout-padding-inner-x, var(--spacing-4));
+}
+
+.x139j0dd:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--layout-padding-outer-x, var(--spacing-4));
+}
+
+.x138rykx:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-0-5);
+}
+
+.x18gyask:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-0);
+}
+
+.xfti1ec:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-1-5);
+}
+
+.x1vsv5vr:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-1);
+}
+
+.xqp078j:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-10);
+}
+
+.x12gdq22:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-2);
+}
+
+.x126nfab:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-3);
+}
+
+.x1rey3nv:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-4);
+}
+
+.x1blguxw:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-5);
+}
+
+.x31w388:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-6);
+}
+
+.x1j3hnjz:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-8);
+}
+
+.x47corl:not(#\#):not(#\#):not(#\#) {
+  pointer-events: none;
+}
+
+.x10l6tqk:not(#\#):not(#\#):not(#\#) {
+  position: absolute;
+}
+
+.xixxii4:not(#\#):not(#\#):not(#\#) {
+  position: fixed;
+}
+
+.x1n2onr6:not(#\#):not(#\#):not(#\#) {
+  position: relative;
+}
+
+.x7wzq59:not(#\#):not(#\#):not(#\#) {
+  position: sticky;
+}
+
+.x288g5:not(#\#):not(#\#):not(#\#) {
+  resize: vertical;
+}
+
+.x1tw44j4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0-5);
+}
+
+.x6yxi7o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0);
+}
+
+.xhq53yo:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1-5);
+}
+
+.x1ngg2t4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1);
+}
+
+.x1xpicb7:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-10);
+}
+
+.x1x7z4sm:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-2);
+}
+
+.x4olc9o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-3);
+}
+
+.xtx9w7w:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-4);
+}
+
+.x1iu6piu:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-5);
+}
+
+.xczp1bk:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-6);
+}
+
+.xgx0vcf:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-8);
+}
+
+.x140o2bo:not(#\#):not(#\#):not(#\#) {
+  table-layout: fixed;
+}
+
+.x2b8uid:not(#\#):not(#\#):not(#\#) {
+  text-align: center;
+}
+
+.x16tdsg8:not(#\#):not(#\#):not(#\#) {
+  text-align: inherit;
+}
+
+.xdpxx8g:not(#\#):not(#\#):not(#\#) {
+  text-align: left;
+}
+
+.x1yc453h:not(#\#):not(#\#):not(#\#) {
+  text-align: start;
+}
+
+.x1b2iylo:not(#\#):not(#\#):not(#\#) {
+  text-box-edge: cap alphabetic;
+}
+
+.xwgcxoh:not(#\#):not(#\#):not(#\#) {
+  text-box-trim: trim-both;
+}
+
+.xycaml9:not(#\#):not(#\#):not(#\#) {
+  -webkit-text-decoration-color: var(--color-border-emphasized);
+  text-decoration-color: var(--color-border-emphasized);
+}
+
+.xujl8zx:not(#\#):not(#\#):not(#\#) {
+  text-decoration-line: underline;
+}
+
+.xev0dqp:not(#\#):not(#\#):not(#\#) {
+  text-decoration-style: dashed;
+}
+
+.xlyipyv:not(#\#):not(#\#):not(#\#) {
+  text-overflow: ellipsis;
+}
+
+.xtvhhri:not(#\#):not(#\#):not(#\#) {
+  text-transform: uppercase;
+}
+
+.xrys4gj:not(#\#):not(#\#):not(#\#) {
+  text-underline-offset: 2px;
+}
+
+.x1w2vvpw:not(#\#):not(#\#):not(#\#) {
+  text-wrap: balance;
+}
+
+.xebhuq6:not(#\#):not(#\#):not(#\#) {
+  text-wrap: nowrap;
+}
+
+.x1fzhlzt:not(#\#):not(#\#):not(#\#) {
+  text-wrap: pretty;
+}
+
+.xk4td0m:not(#\#):not(#\#):not(#\#) {
+  text-wrap: wrap;
+}
+
+.x5ve5x3:not(#\#):not(#\#):not(#\#) {
+  touch-action: none;
+}
+
+.xx69xxh:not(#\#):not(#\#):not(#\#) {
+  touch-action: pan-y;
+}
+
+.x1g0ag68:not(#\#):not(#\#):not(#\#) {
+  transform-origin: center;
+}
+
+.x1c071of:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.x7p49u4:not(#\#):not(#\#):not(#\#) {
+  transform: rotate(0);
+}
+
+.x19jd1h0:not(#\#):not(#\#):not(#\#) {
+  transform: rotate(180deg);
+}
+
+.x1iffjtl:not(#\#):not(#\#):not(#\#) {
+  transform: rotate(90deg);
+}
+
+.x3oybdh:not(#\#):not(#\#):not(#\#) {
+  transform: scale(1);
+}
+
+.x11lhmoz:not(#\#):not(#\#):not(#\#) {
+  transform: translate(-50%, -50%);
+}
+
+.x31h1t8:not(#\#):not(#\#):not(#\#) {
+  transform: translate(-50%, 100%);
+}
+
+.x1m9mm8y:not(#\#):not(#\#):not(#\#) {
+  transform: translate(-50%, 50%);
+}
+
+.x4v1no5:not(#\#):not(#\#):not(#\#) {
+  transform: translate(50%, 50%);
+}
+
+.x5i6ehr:not(#\#):not(#\#):not(#\#) {
+  transform: translateX(-100%);
+}
+
+.xuuh30:not(#\#):not(#\#):not(#\#) {
+  transform: translateX(-50%);
+}
+
+.xbryuvx:not(#\#):not(#\#):not(#\#) {
+  transform: translateX(0);
+}
+
+.xumwmo6:not(#\#):not(#\#):not(#\#) {
+  transform: translateX(100%);
+}
+
+.x15481yp:not(#\#):not(#\#):not(#\#) {
+  transform: translateX(14px);
+}
+
+.x1bvilyr:not(#\#):not(#\#):not(#\#) {
+  transform: translateY(-4px);
+}
+
+.x1cb1t30:not(#\#):not(#\#):not(#\#) {
+  transform: translateY(-50%);
+}
+
+.x131p8rn:not(#\#):not(#\#):not(#\#) {
+  transform: translateY(50%);
+}
+
+.xd00j3c:not(#\#):not(#\#):not(#\#) {
+  transition-behavior: allow-discrete;
+}
+
+.xkvfbh3:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-fast-min);
+}
+
+.xuedmi6:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-fast);
+}
+
+.xgneliz:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-medium-min);
+}
+
+.x80gvsz:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-medium);
+}
+
+.xts7igz:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color, border-color;
+}
+
+.x106061f:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color, box-shadow;
+}
+
+.xs2xxs2:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color, color;
+}
+
+.x15406qy:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color;
+}
+
+.xqc8rvf:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-image, transform;
+}
+
+.x12qzo2w:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-image;
+}
+
+.xpo9ue8:not(#\#):not(#\#):not(#\#) {
+  transition-property: border-color, outline, box-shadow;
+}
+
+.x1vix5yk:not(#\#):not(#\#):not(#\#) {
+  transition-property: color, background-color, box-shadow;
+}
+
+.x1mpt4pi:not(#\#):not(#\#):not(#\#) {
+  transition-property: color, -webkit-text-decoration, text-decoration;
+}
+
+.xt3l3uh:not(#\#):not(#\#):not(#\#) {
+  transition-property: color;
+}
+
+.x1qn9uv2:not(#\#):not(#\#):not(#\#) {
+  transition-property: grid-template-rows;
+}
+
+.x4bbghf:not(#\#):not(#\#):not(#\#) {
+  transition-property: opacity, transform, overlay, display;
+}
+
+.x19991ni:not(#\#):not(#\#):not(#\#) {
+  transition-property: opacity;
+}
+
+.xh3q6i0:not(#\#):not(#\#):not(#\#) {
+  transition-property: transform, width, height;
+}
+
+.x11xpdln:not(#\#):not(#\#):not(#\#) {
+  transition-property: transform;
+}
+
+.xxrbq2n:not(#\#):not(#\#):not(#\#) {
+  transition-property: width;
+}
+
+.xlr8y92:not(#\#):not(#\#):not(#\#) {
+  transition-timing-function: var(--ease-standard);
+}
+
+.x87ps6o:not(#\#):not(#\#):not(#\#) {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.xxymvpz:not(#\#):not(#\#):not(#\#) {
+  vertical-align: middle;
+}
+
+.xlshs6z:not(#\#):not(#\#):not(#\#) {
+  visibility: hidden;
+}
+
+.xuxw1ft:not(#\#):not(#\#):not(#\#) {
+  white-space: nowrap;
+}
+
+.x1yn0g08:not(#\#):not(#\#):not(#\#) {
+  word-break: break-all;
+}
+
+.x13faqbe:not(#\#):not(#\#):not(#\#) {
+  word-break: break-word;
+}
+
+.x1lldw8n:not(#\#):not(#\#):not(#\#) {
+  word-break: normal;
+}
+
+.x1vjfegm:not(#\#):not(#\#):not(#\#) {
+  z-index: 1;
+}
+
+.xhtitgo:not(#\#):not(#\#):not(#\#) {
+  z-index: 2;
+}
+
+.x1q2oy4v:not(#\#):not(#\#):not(#\#) {
+  z-index: 9999;
+}
+
+.x8w4yw4.x8w4yw4:where(.x-default-marker:focus-within *):not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.xcn42n2.xcn42n2:where(.x-default-marker:focus-within *):not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x5b7970.x5b7970:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.xvg0fhp.xvg0fhp:where([open]):not(#\#):not(#\#):not(#\#) {
+  animation-name: x11lauxq-B;
+}
+
+.x25ezvp:focus-visible:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-accent);
+}
+
+.x10wafsz:focus-within:not(#\#):not(#\#):not(#\#) {
+  clip-path: none;
+}
+
+.xf1xu1x.xf1xu1x:where([open]):not(#\#):not(#\#):not(#\#) {
+  display: flex;
+}
+
+.xofkqq2:popover-open:not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.x13ph25t.x13ph25t:where([open]):not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.x7s97pk:focus-visible:not(#\#):not(#\#):not(#\#), .x1fanpfn:focus-within:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x13aywxo:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: var(--button-focus-offset);
+}
+
+.xbt4iw:focus-within:not(#\#):not(#\#):not(#\#) {
+  pointer-events: auto;
+}
+
+.x1df3fe5:is([dir="rtl"] *):not(#\#):not(#\#):not(#\#) {
+  transform: translateX(-100%);
+}
+
+.xttggg:is([dir="rtl"] *):not(#\#):not(#\#):not(#\#) {
+  transform: translateX(100%);
+}
+
+.x9cjr8z:popover-open:not(#\#):not(#\#):not(#\#) {
+  transform: translateY(0);
+}
+
+.x1dnou9g:nth-child(2n):not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.xyg1mtj:hover:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-accent);
+}
+
+.x1rsz1da:focus:not(#\#):not(#\#):not(#\#) {
+  clip-path: none;
+}
+
+.xodanix:focus:not(#\#):not(#\#):not(#\#) {
+  inset-inline-start: var(--spacing-2);
+}
+
+.x1xrnuwo:focus:not(#\#):not(#\#):not(#\#) {
+  position: fixed;
+}
+
+.x1hbpcn8:focus:not(#\#):not(#\#):not(#\#) {
+  white-space: normal;
+}
+
+.xjtnuge:active:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-neutral);
+}
+
+.xyxi2l3:active:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-overlay-pressed);
+}
+
+.xq8i9tn:active:not(#\#):not(#\#):not(#\#) {
+  background-image: linear-gradient(var(--color-overlay-pressed),var(--color-overlay-pressed));
+}
+
+.xuqm82a:active:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1pdlv7q:active:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.xk4oym4:active:not(#\#):not(#\#):not(#\#) {
+  transform: scale(.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .xnh0sag.xnh0sag:not(#\#):not(#\#):not(#\#) {
+    animation-duration: 3s;
+  }
+
+  .x1aquc0h.x1aquc0h:not(#\#):not(#\#):not(#\#) {
+    animation-name: none;
+  }
+}
+
+@media (prefers-contrast: more) {
+  .x1r1p5j5.x1r1p5j5:not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-skeleton),var(--color-text-primary) 30%);
+  }
+}
+
+@media (width <= 480px) {
+  .xedohl4.xedohl4:not(#\#):not(#\#):not(#\#) {
+    display: flex;
+  }
+
+  .x1rpgqan.x1rpgqan:not(#\#):not(#\#):not(#\#) {
+    flex-direction: column;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .xzg1mie.xzg1mie:not(#\#):not(#\#):not(#\#) {
+    transition-duration: 10ms;
+  }
+
+  .x12w9bfk.x12w9bfk:not(#\#):not(#\#):not(#\#) {
+    transition-duration: 0s;
+  }
+
+  .x4wkmsb.x4wkmsb:not(#\#):not(#\#):not(#\#) {
+    transition-property: none;
+  }
+}
+
+@media (hover: hover) {
+  .x3h3317.x3h3317.x3h3317:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-accent),var(--color-tint-hover) 15%);
+  }
+
+  .x2xxuwy.x2xxuwy.x2xxuwy:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-background-gray),var(--color-tint-hover) 5%);
+  }
+
+  .xxuakwu.xxuakwu.xxuakwu:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-background-surface),var(--color-tint-hover) 5%);
+  }
+
+  .xaemn39.xaemn39.xaemn39:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    background-color: unset;
+  }
+
+  .x18qi2qe.x18qi2qe.x18qi2qe:where(.x-default-marker:hover *):not(#\#):not(#\#):not(#\#) {
+    opacity: 1;
+  }
+
+  .xyxu9wt.xyxu9wt:hover:not(#\#):not(#\#):not(#\#) {
+    background-color: color-mix(in srgb,var(--color-accent),var(--color-tint-hover) 15%);
+  }
+
+  .x1sua13m.x1sua13m:hover:not(#\#):not(#\#):not(#\#) {
+    background-color: var(--color-neutral);
+  }
+
+  .xe9uy6x.xe9uy6x:hover:not(#\#):not(#\#):not(#\#) {
+    background-color: var(--color-overlay-hover);
+  }
+
+  .x1ilzqfv.x1ilzqfv:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: linear-gradient(var(--color-overlay-hover),var(--color-overlay-hover));
+  }
+
+  .x8o3jvd.x8o3jvd:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: none;
+  }
+
+  .x1ymn3ht.x1ymn3ht:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-error);
+  }
+
+  .x1j9d0uj.x1j9d0uj:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-hover);
+  }
+
+  .x1th0bn1.x1th0bn1:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-success);
+  }
+
+  .xo1e01f.xo1e01f:hover:not(#\#):not(#\#):not(#\#) {
+    box-shadow: var(--shadow-inset-warning);
+  }
+
+  .x1j9pxtw.x1j9pxtw:hover:not(#\#):not(#\#):not(#\#) {
+    opacity: 1;
+  }
+}
+
+.xw8gpjh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-color: var(--color-border);
+}
+
+.x1p00y4n:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-left-radius: var(--banner-radius);
+}
+
+.x14lggfu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-left-radius: var(--radius-element);
+}
+
+.xi9l6n1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-left-radius: var(--radius-full);
+}
+
+.x1nhu2vm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-right-radius: 4px;
+}
+
+.x1tmeely:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-right-radius: var(--banner-radius);
+}
+
+.xtufxuj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-right-radius: var(--radius-element);
+}
+
+.x1gu3054:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-right-radius: var(--radius-full);
+}
+
+.x1q0q8m5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-style: solid;
+}
+
+.xso031l:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-width: 1px;
+}
+
+.xlxy82:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-width: 2px;
+}
+
+.x92x3c3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-width: var(--border-width);
+}
+
+.x1utcnwd:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-left-color: var(--color-border);
+}
+
+.x19ypqd9:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-left-style: solid;
+}
+
+.xe0pwq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-left-width: 1px;
+}
+
+.xtgwc6q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-color: var(--color-border);
+}
+
+.x32b0ac:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-style: solid;
+}
+
+.xs1s249:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-width: 1px;
+}
+
+.x1pcaw5z:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-width: var(--border-width);
+}
+
+.x1pc3f07:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-color: var(--color-border);
+}
+
+.x99wiku:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-left-radius: var(--radius-full);
+}
+
+.x11ly021:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-right-radius: var(--radius-full);
+}
+
+.x13fuv20:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-style: solid;
+}
+
+.x178xt8z:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-width: 1px;
+}
+
+.x1ey2m1c:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: 0;
+}
+
+.x1c7jfne:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: 2px;
+}
+
+.x1nqzi6q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: var(--x-bottom);
+}
+
+.xqtp20y:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 0;
+}
+
+.x5yr21d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 100%;
+}
+
+.xtdtrs8:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 100dvh;
+}
+
+.x170jfvy:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 10px;
+}
+
+.x1kpxq89:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 12px;
+}
+
+.xhjk10j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 140px;
+}
+
+.x1v9usgg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 14px;
+}
+
+.x1ymw6g:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 160px;
+}
+
+.xlup9mm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 16px;
+}
+
+.xmix8c7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 18px;
+}
+
+.xjm9jq1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 1px;
+}
+
+.x1qx5ct2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 20px;
+}
+
+.x17rw0jw:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 22px;
+}
+
+.xxk0z11:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 24px;
+}
+
+.x36qwtl:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 2px;
+}
+
+.x10w6t97:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 32px;
+}
+
+.x1vqgdyp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 40px;
+}
+
+.xsdox4t:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 48px;
+}
+
+.xqu0tyb:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 4px;
+}
+
+.xlxyqfn:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 50%;
+}
+
+.xols6we:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 6px;
+}
+
+.xdk7pt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 8px;
+}
+
+.xt7dq6l:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: auto;
+}
+
+.xs02d24:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(100% + 1px);
+}
+
+.x1x2thlr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(100% + 2 * var(--container-padding, 0px));
+}
+
+.x16zugyo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(100dvh - var(--appshell-header-height, 0px));
+}
+
+.x1uiybsj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(var(--size-element-lg) - 4px);
+}
+
+.x184gfjb:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(var(--size-element-md) - 4px);
+}
+
+.xrmxcn7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(var(--size-element-md) - 8px);
+}
+
+.xzj98nu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(var(--size-element-sm) - 4px);
+}
+
+.xzydfjl:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(var(--size-element-sm) - 8px);
+}
+
+.xg7h5cd:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: fit-content;
+}
+
+.xsyqizj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--border-width);
+}
+
+.xssyfek:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-lg);
+}
+
+.x1ueg155:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-md);
+}
+
+.x6k0iem:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-sm);
+}
+
+.x1k15mir:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-12);
+}
+
+.x6b6gus:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-4);
+}
+
+.x1grt7ep:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-5);
+}
+
+.x18to7ep:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-8);
+}
+
+.x16ye13r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--x-height);
+}
+
+.xu96u03:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 0;
+}
+
+.x1trqr8e:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 14px;
+}
+
+.x54rlcq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 2px;
+}
+
+.x1nrll8i:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 50%;
+}
+
+.xnp31yv:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: var(--spacing-3);
+}
+
+.xgq9j65:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: var(--x-left);
+}
+
+.xat24cr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: 0;
+}
+
+.x14cgwvg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-1);
+}
+
+.x1p37lm5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-2);
+}
+
+.xep27e5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-3);
+}
+
+.xdj266r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: 0;
+}
+
+.xr1yuqi:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: auto;
+}
+
+.x1c40v9y:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: calc(-1 * var(--spacing-1-5));
+}
+
+.x1233pnv:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: calc((1em * var(--text-body-leading) - 6px) / 2);
+}
+
+.xjc2qm6:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-0-5);
+}
+
+.xcsaf9d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-1);
+}
+
+.xtbrsbv:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-2);
+}
+
+.x1gkbulp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--x-marginTop);
+}
+
+.x1wj9ous:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: 100dvh;
+}
+
+.xuyqlj2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: 300px;
+}
+
+.x7ab17h:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: none;
+}
+
+.xenllk4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: var(--container-max-height, none);
+}
+
+.x1jols5v:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: var(--x-maxHeight);
+}
+
+.x1m189uc:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 0;
+}
+
+.x193iq5w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 100%;
+}
+
+.xlbgzzq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 100dvw;
+}
+
+.xw5ewwj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 300px;
+}
+
+.xxc7z9f:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 360px;
+}
+
+.x95b5qq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 90vw;
+}
+
+.xyzno7u:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 960px;
+}
+
+.x1x1rfll:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: none;
+}
+
+.xf68679:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: var(--x-maxWidth);
+}
+
+.x2lwn1j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 0;
+}
+
+.x1us19tq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 100%;
+}
+
+.x1ov3xa9:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 100dvh;
+}
+
+.xjwf9q1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 24px;
+}
+
+.xseoqlg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 80px;
+}
+
+.x1uogy3y:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--size-element-md);
+}
+
+.x1gdqauq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--size-element-sm);
+}
+
+.x1jehcu4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--spacing-10);
+}
+
+.ximsjs8:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--spacing-7);
+}
+
+.xkoleio:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--spacing-8);
+}
+
+.x82snj4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--x-minHeight);
+}
+
+.xeuugli:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 0;
+}
+
+.x5w4yej:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 160px;
+}
+
+.xfb3i0g:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 180px;
+}
+
+.xt4ypqs:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 20px;
+}
+
+.x12rczxh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 220px;
+}
+
+.x1u2d2a2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 280px;
+}
+
+.x13o0s5z:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 400px;
+}
+
+.x1fns5xo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 40px;
+}
+
+.xfvyar9:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 60px;
+}
+
+.xrzjruh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: anchor-size(width);
+}
+
+.x17ydmr0:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--size-element-md);
+}
+
+.x1nkkqge:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--size-element-sm);
+}
+
+.xy8csz5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--spacing-7);
+}
+
+.xkj4a21:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--x-minWidth);
+}
+
+.x6ikm8r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  overflow-x: hidden;
+}
+
+.x1odjw0f:not(#\#):not(#\#):not(#\#):not(#\#) {
+  overflow-y: auto;
+}
+
+.x18d9i69:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.xg476vw:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--layout-padding-inner-y, var(--spacing-4));
+}
+
+.xon7vh3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--layout-padding-outer-y, var(--spacing-4));
+}
+
+.xij103a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-0-5);
+}
+
+.x1l20ajd:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-0);
+}
+
+.x1opdxmq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1-5);
+}
+
+.xy143xn:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1);
+}
+
+.x2izi54:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-10);
+}
+
+.x1wesfrj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-2);
+}
+
+.xvmdzux:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-3);
+}
+
+.x1awphl8:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-4);
+}
+
+.x1hk98q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-5);
+}
+
+.xjpqqx5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-6);
+}
+
+.x2oz4g1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-8);
+}
+
+.xexx8yu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.x1ak3mig:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: calc(var(--spacing-1-5) + var(--spacing-2));
+}
+
+.xqty4a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--layout-padding-inner-y, var(--spacing-4));
+}
+
+.x81pis9:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--layout-padding-outer-y, var(--spacing-4));
+}
+
+.xbx876j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-0-5);
+}
+
+.x1ydh6w3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-0);
+}
+
+.x1kwdpsa:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1-5);
+}
+
+.xfsso4q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.xk6660b:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-10);
+}
+
+.x1xye8es:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-2);
+}
+
+.x1vlblms:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-3);
+}
+
+.x1oa1p4a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-4);
+}
+
+.xx7rijo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-5);
+}
+
+.x1adxfkp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-6);
+}
+
+.xoxd1wu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-8);
+}
+
+.x3m8u43:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: 0;
+}
+
+.x3lmqil:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: 2px;
+}
+
+.xmz3bnw:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: var(--spacing-3);
+}
+
+.x7ok3n0:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: var(--x-right);
+}
+
+.x13vifvy:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 0;
+}
+
+.xuivejd:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 14px;
+}
+
+.xs7f9wi:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 2px;
+}
+
+.xwa60dl:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 50%;
+}
+
+.xepuwc7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: var(--appshell-header-height, 0px);
+}
+
+.xctzyg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: var(--spacing-2);
+}
+
+.xjbys53:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: var(--x-top);
+}
+
+.xnalus7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 0;
+}
+
+.xh8yej3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 100%;
+}
+
+.x1o6l61p:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 100dvw;
+}
+
+.xn9wirt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 100vw;
+}
+
+.x1fsd2vl:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 10px;
+}
+
+.xsmyaan:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 12px;
+}
+
+.x6jxa94:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 14px;
+}
+
+.x1kky2od:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 16px;
+}
+
+.xzjbwwf:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 180px;
+}
+
+.x1xp8n7a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 18px;
+}
+
+.x1i1rx1s:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 1px;
+}
+
+.x1oysuqx:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 200px;
+}
+
+.xw4jnvo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 20px;
+}
+
+.x17z2i9w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 22px;
+}
+
+.xvy4d1p:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 24px;
+}
+
+.x1hfn5x7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 260px;
+}
+
+.xfo62xy:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 2px;
+}
+
+.x1td3qas:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 32px;
+}
+
+.xz84dc7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 40%;
+}
+
+.x100vrsf:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 40px;
+}
+
+.x51ohtg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 4px;
+}
+
+.x3hqpx7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 50%;
+}
+
+.xvni27:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 52px;
+}
+
+.x1v4s8kt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 6px;
+}
+
+.x1dmp6jm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 80px;
+}
+
+.x1xc55vz:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 8px;
+}
+
+.x1xgy17j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: anchor-size(width);
+}
+
+.xjk4fl7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--border-width);
+}
+
+.x805d0l:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--size-element-md);
+}
+
+.x1fvqzum:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--size-element-sm);
+}
+
+.x1ad1g3v:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--spacing-3);
+}
+
+.x12xnipv:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--spacing-4);
+}
+
+.xfyiiit:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--spacing-5);
+}
+
+.xgc8j7m:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--spacing-8);
+}
+
+.x5lhr3w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--x-width);
+}
+
+.x132qfvm:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: auto;
+}
+
+.x1o6z09h.x1o6z09h:where(.x-default-marker:has( > .xds-layout-footer:not([data-divider])) *):not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.x1c51l3k.x1c51l3k:where(.x-default-marker:has( > .xds-layout-header:not([data-divider])) *):not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.x1kw28su:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.x10okhzq:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: auto;
+}
+
+.x8achem:first-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1lpyac:last-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-right-width: 0;
+}
+
+.x1a5yysu:last-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: calc(-1 * var(--container-padding, 0px));
+}
+
+.x15cytp8:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: auto;
+}
+
+.x1rw3289:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: var(--spacing-2);
+}
+
+.x1jqxupm:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: auto;
+}
+
+@media (pointer: coarse) {
+  .x1kkwbli.x1kkwbli:not(#\#):not(#\#):not(#\#):not(#\#) {
+    width: 20px;
+  }
+}
+
+.x1xsm0q9:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  inset: -14px;
+}
+
+@starting-style {
+  .x4itv7f.x4itv7f:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+    opacity: 0;
+  }
+}
+
+@starting-style {
+  .x12p7p72.x12p7p72:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+    transform: translateY(-4px);
+  }
+}
+
+.xq94oqs:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  border-radius: var(--radius-full);
+}
+
+.x1abwkk1:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+}
+
+.xs88s87:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  background-color: var(--color-accent);
+}
+
+.xnixb3f:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  background-color: var(--color-overlay);
+}
+
+.xeyghm5:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::placeholder {
+  color: var(--color-text-secondary);
+}
+
+.x1cpjm7i:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):before, .x1s928wv:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  content: "";
+}
+
+.x83grso:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):before {
+  content: counter(xds-list) ".";
+}
+
+.xph5o2a:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  opacity: 0;
+}
+
+.xb3n6bw:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  opacity: 1;
+}
+
+.x1hmns74:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):before, .x1j6awrg:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  position: absolute;
+}
+
+.xft5bk6:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  transition-duration: var(--duration-medium);
+}
+
+.x167zut7:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  transition-property: opacity;
+}
+
+.x15h3t91:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  transition-timing-function: var(--ease-standard);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .x1viac0w.x1viac0w:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+    transition-duration: 10ms;
+  }
+}
+
+.xe80sof:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):before {
+  bottom: -2px;
+}
+
+.x1xrz1ek:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  bottom: 0;
+}
+
+.x3cntg4:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  height: 2px;
+}
+
+.xabwq6t:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):before {
+  left: -2px;
+}
+
+.x17cx49:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  left: 0;
+}
+
+.xkbfwm6:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  left: var(--spacing-3);
+}
+
+.x1ydowbf:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):before {
+  right: -2px;
+}
+
+.xnbfe2x:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  right: 0;
+}
+
+.xk1u3ur:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):after {
+  right: var(--spacing-3);
+}
+
+.x51xajf:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):before {
+  top: -2px;
+}
+</style>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/internal/vibe-tests/results/441ddbe0/previews/ps-3/xds.html
+++ b/internal/vibe-tests/results/441ddbe0/previews/ps-3/xds.html
@@ -1,0 +1,3115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ps-3 — xds</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; }
+    #root { min-height: 100%; }
+  </style>
+  <script type="module" crossorigin>(function(){const e=document.createElement("link").relList;if(e&&e.supports&&e.supports("modulepreload"))return;for(const n of document.querySelectorAll('link[rel="modulepreload"]'))a(n);new MutationObserver(n=>{for(const u of n)if(u.type==="childList")for(const c of u.addedNodes)c.tagName==="LINK"&&c.rel==="modulepreload"&&a(c)}).observe(document,{childList:!0,subtree:!0});function l(n){const u={};return n.integrity&&(u.integrity=n.integrity),n.referrerPolicy&&(u.referrerPolicy=n.referrerPolicy),n.crossOrigin==="use-credentials"?u.credentials="include":n.crossOrigin==="anonymous"?u.credentials="omit":u.credentials="same-origin",u}function a(n){if(n.ep)return;n.ep=!0;const u=l(n);fetch(n.href,u)}})();function yx(t){return t&&t.__esModule&&Object.prototype.hasOwnProperty.call(t,"default")?t.default:t}var Or={exports:{}},ec={};/**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var hx=Symbol.for("react.transitional.element"),gx=Symbol.for("react.fragment");function Dr(t,e,l){var a=null;if(l!==void 0&&(a=""+l),e.key!==void 0&&(a=""+e.key),"key"in e){l={};for(var n in e)n!=="key"&&(l[n]=e[n])}else l=e;return e=l.ref,{$$typeof:hx,type:t,key:a,ref:e!==void 0?e:null,props:l}}ec.Fragment=gx;ec.jsx=Dr;ec.jsxs=Dr;Or.exports=ec;var o=Or.exports,wr={exports:{}},lc={},Cr={exports:{}},_r={};/**
+ * @license React
+ * scheduler.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */(function(t){function e($,O){var D=$.length;$.push(O);t:for(;0<D;){var L=D-1>>>1,J=$[L];if(0<n(J,O))$[L]=O,$[D]=J,D=L;else break t}}function l($){return $.length===0?null:$[0]}function a($){if($.length===0)return null;var O=$[0],D=$.pop();if(D!==O){$[0]=D;t:for(var L=0,J=$.length,Et=J>>>1;L<Et;){var wt=2*(L+1)-1,Ct=$[wt],V=wt+1,mt=$[V];if(0>n(Ct,D))V<J&&0>n(mt,Ct)?($[L]=mt,$[V]=D,L=V):($[L]=Ct,$[wt]=D,L=wt);else if(V<J&&0>n(mt,D))$[L]=mt,$[V]=D,L=V;else break t}}return O}function n($,O){var D=$.sortIndex-O.sortIndex;return D!==0?D:$.id-O.id}if(t.unstable_now=void 0,typeof performance=="object"&&typeof performance.now=="function"){var u=performance;t.unstable_now=function(){return u.now()}}else{var c=Date,i=c.now();t.unstable_now=function(){return c.now()-i}}var s=[],r=[],x=1,h=null,d=3,y=!1,p=!1,S=!1,k=!1,m=typeof setTimeout=="function"?setTimeout:null,f=typeof clearTimeout=="function"?clearTimeout:null,v=typeof setImmediate<"u"?setImmediate:null;function b($){for(var O=l(r);O!==null;){if(O.callback===null)a(r);else if(O.startTime<=$)a(r),O.sortIndex=O.expirationTime,e(s,O);else break;O=l(r)}}function z($){if(S=!1,b($),!p)if(l(s)!==null)p=!0,N||(N=!0,Z());else{var O=l(r);O!==null&&St(z,O.startTime-$)}}var N=!1,E=-1,M=5,T=-1;function A(){return k?!0:!(t.unstable_now()-T<M)}function C(){if(k=!1,N){var $=t.unstable_now();T=$;var O=!0;try{t:{p=!1,S&&(S=!1,f(E),E=-1),y=!0;var D=d;try{e:{for(b($),h=l(s);h!==null&&!(h.expirationTime>$&&A());){var L=h.callback;if(typeof L=="function"){h.callback=null,d=h.priorityLevel;var J=L(h.expirationTime<=$);if($=t.unstable_now(),typeof J=="function"){h.callback=J,b($),O=!0;break e}h===l(s)&&a(s),b($)}else a(s);h=l(s)}if(h!==null)O=!0;else{var Et=l(r);Et!==null&&St(z,Et.startTime-$),O=!1}}break t}finally{h=null,d=D,y=!1}O=void 0}}finally{O?Z():N=!1}}}var Z;if(typeof v=="function")Z=function(){v(C)};else if(typeof MessageChannel<"u"){var I=new MessageChannel,xt=I.port2;I.port1.onmessage=C,Z=function(){xt.postMessage(null)}}else Z=function(){m(C,0)};function St($,O){E=m(function(){$(t.unstable_now())},O)}t.unstable_IdlePriority=5,t.unstable_ImmediatePriority=1,t.unstable_LowPriority=4,t.unstable_NormalPriority=3,t.unstable_Profiling=null,t.unstable_UserBlockingPriority=2,t.unstable_cancelCallback=function($){$.callback=null},t.unstable_forceFrameRate=function($){0>$||125<$?console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"):M=0<$?Math.floor(1e3/$):5},t.unstable_getCurrentPriorityLevel=function(){return d},t.unstable_next=function($){switch(d){case 1:case 2:case 3:var O=3;break;default:O=d}var D=d;d=O;try{return $()}finally{d=D}},t.unstable_requestPaint=function(){k=!0},t.unstable_runWithPriority=function($,O){switch($){case 1:case 2:case 3:case 4:case 5:break;default:$=3}var D=d;d=$;try{return O()}finally{d=D}},t.unstable_scheduleCallback=function($,O,D){var L=t.unstable_now();switch(typeof D=="object"&&D!==null?(D=D.delay,D=typeof D=="number"&&0<D?L+D:L):D=L,$){case 1:var J=-1;break;case 2:J=250;break;case 5:J=1073741823;break;case 4:J=1e4;break;default:J=5e3}return J=D+J,$={id:x++,callback:O,priorityLevel:$,startTime:D,expirationTime:J,sortIndex:-1},D>L?($.sortIndex=D,e(r,$),l(s)===null&&$===l(r)&&(S?(f(E),E=-1):S=!0,St(z,D-L))):($.sortIndex=J,e(s,$),p||y||(p=!0,N||(N=!0,Z()))),$},t.unstable_shouldYield=A,t.unstable_wrapCallback=function($){var O=d;return function(){var D=d;d=O;try{return $.apply(this,arguments)}finally{d=D}}}})(_r);Cr.exports=_r;var bx=Cr.exports,Rr={exports:{}},R={};/**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var bs=Symbol.for("react.transitional.element"),px=Symbol.for("react.portal"),Sx=Symbol.for("react.fragment"),kx=Symbol.for("react.strict_mode"),zx=Symbol.for("react.profiler"),jx=Symbol.for("react.consumer"),Ex=Symbol.for("react.context"),Tx=Symbol.for("react.forward_ref"),Mx=Symbol.for("react.suspense"),Ax=Symbol.for("react.memo"),qr=Symbol.for("react.lazy"),$x=Symbol.for("react.activity"),Hf=Symbol.iterator;function Nx(t){return t===null||typeof t!="object"?null:(t=Hf&&t[Hf]||t["@@iterator"],typeof t=="function"?t:null)}var Hr={isMounted:function(){return!1},enqueueForceUpdate:function(){},enqueueReplaceState:function(){},enqueueSetState:function(){}},Ur=Object.assign,Br={};function Ma(t,e,l){this.props=t,this.context=e,this.refs=Br,this.updater=l||Hr}Ma.prototype.isReactComponent={};Ma.prototype.setState=function(t,e){if(typeof t!="object"&&typeof t!="function"&&t!=null)throw Error("takes an object of state variables to update or a function which returns an object of state variables.");this.updater.enqueueSetState(this,t,e,"setState")};Ma.prototype.forceUpdate=function(t){this.updater.enqueueForceUpdate(this,t,"forceUpdate")};function Xr(){}Xr.prototype=Ma.prototype;function ps(t,e,l){this.props=t,this.context=e,this.refs=Br,this.updater=l||Hr}var Ss=ps.prototype=new Xr;Ss.constructor=ps;Ur(Ss,Ma.prototype);Ss.isPureReactComponent=!0;var Uf=Array.isArray;function bi(){}var nt={H:null,A:null,T:null,S:null},Lr=Object.prototype.hasOwnProperty;function ks(t,e,l){var a=l.ref;return{$$typeof:bs,type:t,key:e,ref:a!==void 0?a:null,props:l}}function Ox(t,e){return ks(t.type,e,t.props)}function zs(t){return typeof t=="object"&&t!==null&&t.$$typeof===bs}function Dx(t){var e={"=":"=0",":":"=2"};return"$"+t.replace(/[=:]/g,function(l){return e[l]})}var Bf=/\/+/g;function Ec(t,e){return typeof t=="object"&&t!==null&&t.key!=null?Dx(""+t.key):e.toString(36)}function wx(t){switch(t.status){case"fulfilled":return t.value;case"rejected":throw t.reason;default:switch(typeof t.status=="string"?t.then(bi,bi):(t.status="pending",t.then(function(e){t.status==="pending"&&(t.status="fulfilled",t.value=e)},function(e){t.status==="pending"&&(t.status="rejected",t.reason=e)})),t.status){case"fulfilled":return t.value;case"rejected":throw t.reason}}throw t}function Ql(t,e,l,a,n){var u=typeof t;(u==="undefined"||u==="boolean")&&(t=null);var c=!1;if(t===null)c=!0;else switch(u){case"bigint":case"string":case"number":c=!0;break;case"object":switch(t.$$typeof){case bs:case px:c=!0;break;case qr:return c=t._init,Ql(c(t._payload),e,l,a,n)}}if(c)return n=n(t),c=a===""?"."+Ec(t,0):a,Uf(n)?(l="",c!=null&&(l=c.replace(Bf,"$&/")+"/"),Ql(n,e,l,"",function(r){return r})):n!=null&&(zs(n)&&(n=Ox(n,l+(n.key==null||t&&t.key===n.key?"":(""+n.key).replace(Bf,"$&/")+"/")+c)),e.push(n)),1;c=0;var i=a===""?".":a+":";if(Uf(t))for(var s=0;s<t.length;s++)a=t[s],u=i+Ec(a,s),c+=Ql(a,e,l,u,n);else if(s=Nx(t),typeof s=="function")for(t=s.call(t),s=0;!(a=t.next()).done;)a=a.value,u=i+Ec(a,s++),c+=Ql(a,e,l,u,n);else if(u==="object"){if(typeof t.then=="function")return Ql(wx(t),e,l,a,n);throw e=String(t),Error("Objects are not valid as a React child (found: "+(e==="[object Object]"?"object with keys {"+Object.keys(t).join(", ")+"}":e)+"). If you meant to render a collection of children, use an array instead.")}return c}function Xn(t,e,l){if(t==null)return t;var a=[],n=0;return Ql(t,a,"","",function(u){return e.call(l,u,n++)}),a}function Cx(t){if(t._status===-1){var e=t._result;e=e(),e.then(function(l){(t._status===0||t._status===-1)&&(t._status=1,t._result=l)},function(l){(t._status===0||t._status===-1)&&(t._status=2,t._result=l)}),t._status===-1&&(t._status=0,t._result=e)}if(t._status===1)return t._result.default;throw t._result}var Xf=typeof reportError=="function"?reportError:function(t){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var e=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof t=="object"&&t!==null&&typeof t.message=="string"?String(t.message):String(t),error:t});if(!window.dispatchEvent(e))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",t);return}console.error(t)},_x={map:Xn,forEach:function(t,e,l){Xn(t,function(){e.apply(this,arguments)},l)},count:function(t){var e=0;return Xn(t,function(){e++}),e},toArray:function(t){return Xn(t,function(e){return e})||[]},only:function(t){if(!zs(t))throw Error("React.Children.only expected to receive a single React element child.");return t}};R.Activity=$x;R.Children=_x;R.Component=Ma;R.Fragment=Sx;R.Profiler=zx;R.PureComponent=ps;R.StrictMode=kx;R.Suspense=Mx;R.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=nt;R.__COMPILER_RUNTIME={__proto__:null,c:function(t){return nt.H.useMemoCache(t)}};R.cache=function(t){return function(){return t.apply(null,arguments)}};R.cacheSignal=function(){return null};R.cloneElement=function(t,e,l){if(t==null)throw Error("The argument must be a React element, but you passed "+t+".");var a=Ur({},t.props),n=t.key;if(e!=null)for(u in e.key!==void 0&&(n=""+e.key),e)!Lr.call(e,u)||u==="key"||u==="__self"||u==="__source"||u==="ref"&&e.ref===void 0||(a[u]=e[u]);var u=arguments.length-2;if(u===1)a.children=l;else if(1<u){for(var c=Array(u),i=0;i<u;i++)c[i]=arguments[i+2];a.children=c}return ks(t.type,n,a)};R.createContext=function(t){return t={$$typeof:Ex,_currentValue:t,_currentValue2:t,_threadCount:0,Provider:null,Consumer:null},t.Provider=t,t.Consumer={$$typeof:jx,_context:t},t};R.createElement=function(t,e,l){var a,n={},u=null;if(e!=null)for(a in e.key!==void 0&&(u=""+e.key),e)Lr.call(e,a)&&a!=="key"&&a!=="__self"&&a!=="__source"&&(n[a]=e[a]);var c=arguments.length-2;if(c===1)n.children=l;else if(1<c){for(var i=Array(c),s=0;s<c;s++)i[s]=arguments[s+2];n.children=i}if(t&&t.defaultProps)for(a in c=t.defaultProps,c)n[a]===void 0&&(n[a]=c[a]);return ks(t,u,n)};R.createRef=function(){return{current:null}};R.forwardRef=function(t){return{$$typeof:Tx,render:t}};R.isValidElement=zs;R.lazy=function(t){return{$$typeof:qr,_payload:{_status:-1,_result:t},_init:Cx}};R.memo=function(t,e){return{$$typeof:Ax,type:t,compare:e===void 0?null:e}};R.startTransition=function(t){var e=nt.T,l={};nt.T=l;try{var a=t(),n=nt.S;n!==null&&n(l,a),typeof a=="object"&&a!==null&&typeof a.then=="function"&&a.then(bi,Xf)}catch(u){Xf(u)}finally{e!==null&&l.types!==null&&(e.types=l.types),nt.T=e}};R.unstable_useCacheRefresh=function(){return nt.H.useCacheRefresh()};R.use=function(t){return nt.H.use(t)};R.useActionState=function(t,e,l){return nt.H.useActionState(t,e,l)};R.useCallback=function(t,e){return nt.H.useCallback(t,e)};R.useContext=function(t){return nt.H.useContext(t)};R.useDebugValue=function(){};R.useDeferredValue=function(t,e){return nt.H.useDeferredValue(t,e)};R.useEffect=function(t,e){return nt.H.useEffect(t,e)};R.useEffectEvent=function(t){return nt.H.useEffectEvent(t)};R.useId=function(){return nt.H.useId()};R.useImperativeHandle=function(t,e,l){return nt.H.useImperativeHandle(t,e,l)};R.useInsertionEffect=function(t,e){return nt.H.useInsertionEffect(t,e)};R.useLayoutEffect=function(t,e){return nt.H.useLayoutEffect(t,e)};R.useMemo=function(t,e){return nt.H.useMemo(t,e)};R.useOptimistic=function(t,e){return nt.H.useOptimistic(t,e)};R.useReducer=function(t,e,l){return nt.H.useReducer(t,e,l)};R.useRef=function(t){return nt.H.useRef(t)};R.useState=function(t){return nt.H.useState(t)};R.useSyncExternalStore=function(t,e,l){return nt.H.useSyncExternalStore(t,e,l)};R.useTransition=function(){return nt.H.useTransition()};R.version="19.2.4";Rr.exports=R;var g=Rr.exports;const Lf=yx(g);var Zr={exports:{}},qt={};/**
+ * @license React
+ * react-dom.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var Rx=g;function Gr(t){var e="https://react.dev/errors/"+t;if(1<arguments.length){e+="?args[]="+encodeURIComponent(arguments[1]);for(var l=2;l<arguments.length;l++)e+="&args[]="+encodeURIComponent(arguments[l])}return"Minified React error #"+t+"; visit "+e+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function Ze(){}var Rt={d:{f:Ze,r:function(){throw Error(Gr(522))},D:Ze,C:Ze,L:Ze,m:Ze,X:Ze,S:Ze,M:Ze},p:0,findDOMNode:null},qx=Symbol.for("react.portal");function Hx(t,e,l){var a=3<arguments.length&&arguments[3]!==void 0?arguments[3]:null;return{$$typeof:qx,key:a==null?null:""+a,children:t,containerInfo:e,implementation:l}}var Fa=Rx.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;function ac(t,e){if(t==="font")return"";if(typeof e=="string")return e==="use-credentials"?e:""}qt.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=Rt;qt.createPortal=function(t,e){var l=2<arguments.length&&arguments[2]!==void 0?arguments[2]:null;if(!e||e.nodeType!==1&&e.nodeType!==9&&e.nodeType!==11)throw Error(Gr(299));return Hx(t,e,null,l)};qt.flushSync=function(t){var e=Fa.T,l=Rt.p;try{if(Fa.T=null,Rt.p=2,t)return t()}finally{Fa.T=e,Rt.p=l,Rt.d.f()}};qt.preconnect=function(t,e){typeof t=="string"&&(e?(e=e.crossOrigin,e=typeof e=="string"?e==="use-credentials"?e:"":void 0):e=null,Rt.d.C(t,e))};qt.prefetchDNS=function(t){typeof t=="string"&&Rt.d.D(t)};qt.preinit=function(t,e){if(typeof t=="string"&&e&&typeof e.as=="string"){var l=e.as,a=ac(l,e.crossOrigin),n=typeof e.integrity=="string"?e.integrity:void 0,u=typeof e.fetchPriority=="string"?e.fetchPriority:void 0;l==="style"?Rt.d.S(t,typeof e.precedence=="string"?e.precedence:void 0,{crossOrigin:a,integrity:n,fetchPriority:u}):l==="script"&&Rt.d.X(t,{crossOrigin:a,integrity:n,fetchPriority:u,nonce:typeof e.nonce=="string"?e.nonce:void 0})}};qt.preinitModule=function(t,e){if(typeof t=="string")if(typeof e=="object"&&e!==null){if(e.as==null||e.as==="script"){var l=ac(e.as,e.crossOrigin);Rt.d.M(t,{crossOrigin:l,integrity:typeof e.integrity=="string"?e.integrity:void 0,nonce:typeof e.nonce=="string"?e.nonce:void 0})}}else e==null&&Rt.d.M(t)};qt.preload=function(t,e){if(typeof t=="string"&&typeof e=="object"&&e!==null&&typeof e.as=="string"){var l=e.as,a=ac(l,e.crossOrigin);Rt.d.L(t,l,{crossOrigin:a,integrity:typeof e.integrity=="string"?e.integrity:void 0,nonce:typeof e.nonce=="string"?e.nonce:void 0,type:typeof e.type=="string"?e.type:void 0,fetchPriority:typeof e.fetchPriority=="string"?e.fetchPriority:void 0,referrerPolicy:typeof e.referrerPolicy=="string"?e.referrerPolicy:void 0,imageSrcSet:typeof e.imageSrcSet=="string"?e.imageSrcSet:void 0,imageSizes:typeof e.imageSizes=="string"?e.imageSizes:void 0,media:typeof e.media=="string"?e.media:void 0})}};qt.preloadModule=function(t,e){if(typeof t=="string")if(e){var l=ac(e.as,e.crossOrigin);Rt.d.m(t,{as:typeof e.as=="string"&&e.as!=="script"?e.as:void 0,crossOrigin:l,integrity:typeof e.integrity=="string"?e.integrity:void 0})}else Rt.d.m(t)};qt.requestFormReset=function(t){Rt.d.r(t)};qt.unstable_batchedUpdates=function(t,e){return t(e)};qt.useFormState=function(t,e,l){return Fa.H.useFormState(t,e,l)};qt.useFormStatus=function(){return Fa.H.useHostTransitionStatus()};qt.version="19.2.4";function Yr(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(Yr)}catch(t){console.error(t)}}Yr(),Zr.exports=qt;var Ux=Zr.exports;/**
+ * @license React
+ * react-dom-client.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var pt=bx,Vr=g,Bx=Ux;function j(t){var e="https://react.dev/errors/"+t;if(1<arguments.length){e+="?args[]="+encodeURIComponent(arguments[1]);for(var l=2;l<arguments.length;l++)e+="&args[]="+encodeURIComponent(arguments[l])}return"Minified React error #"+t+"; visit "+e+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function Qr(t){return!(!t||t.nodeType!==1&&t.nodeType!==9&&t.nodeType!==11)}function Mn(t){var e=t,l=t;if(t.alternate)for(;e.return;)e=e.return;else{t=e;do e=t,e.flags&4098&&(l=e.return),t=e.return;while(t)}return e.tag===3?l:null}function Kr(t){if(t.tag===13){var e=t.memoizedState;if(e===null&&(t=t.alternate,t!==null&&(e=t.memoizedState)),e!==null)return e.dehydrated}return null}function Jr(t){if(t.tag===31){var e=t.memoizedState;if(e===null&&(t=t.alternate,t!==null&&(e=t.memoizedState)),e!==null)return e.dehydrated}return null}function Zf(t){if(Mn(t)!==t)throw Error(j(188))}function Xx(t){var e=t.alternate;if(!e){if(e=Mn(t),e===null)throw Error(j(188));return e!==t?null:t}for(var l=t,a=e;;){var n=l.return;if(n===null)break;var u=n.alternate;if(u===null){if(a=n.return,a!==null){l=a;continue}break}if(n.child===u.child){for(u=n.child;u;){if(u===l)return Zf(n),t;if(u===a)return Zf(n),e;u=u.sibling}throw Error(j(188))}if(l.return!==a.return)l=n,a=u;else{for(var c=!1,i=n.child;i;){if(i===l){c=!0,l=n,a=u;break}if(i===a){c=!0,a=n,l=u;break}i=i.sibling}if(!c){for(i=u.child;i;){if(i===l){c=!0,l=u,a=n;break}if(i===a){c=!0,a=u,l=n;break}i=i.sibling}if(!c)throw Error(j(189))}}if(l.alternate!==a)throw Error(j(190))}if(l.tag!==3)throw Error(j(188));return l.stateNode.current===l?t:e}function Wr(t){var e=t.tag;if(e===5||e===26||e===27||e===6)return t;for(t=t.child;t!==null;){if(e=Wr(t),e!==null)return e;t=t.sibling}return null}var ct=Object.assign,Lx=Symbol.for("react.element"),Ln=Symbol.for("react.transitional.element"),Ya=Symbol.for("react.portal"),Fl=Symbol.for("react.fragment"),Fr=Symbol.for("react.strict_mode"),pi=Symbol.for("react.profiler"),Ir=Symbol.for("react.consumer"),Ne=Symbol.for("react.context"),js=Symbol.for("react.forward_ref"),Si=Symbol.for("react.suspense"),ki=Symbol.for("react.suspense_list"),Es=Symbol.for("react.memo"),Ve=Symbol.for("react.lazy"),zi=Symbol.for("react.activity"),Zx=Symbol.for("react.memo_cache_sentinel"),Gf=Symbol.iterator;function Ra(t){return t===null||typeof t!="object"?null:(t=Gf&&t[Gf]||t["@@iterator"],typeof t=="function"?t:null)}var Gx=Symbol.for("react.client.reference");function ji(t){if(t==null)return null;if(typeof t=="function")return t.$$typeof===Gx?null:t.displayName||t.name||null;if(typeof t=="string")return t;switch(t){case Fl:return"Fragment";case pi:return"Profiler";case Fr:return"StrictMode";case Si:return"Suspense";case ki:return"SuspenseList";case zi:return"Activity"}if(typeof t=="object")switch(t.$$typeof){case Ya:return"Portal";case Ne:return t.displayName||"Context";case Ir:return(t._context.displayName||"Context")+".Consumer";case js:var e=t.render;return t=t.displayName,t||(t=e.displayName||e.name||"",t=t!==""?"ForwardRef("+t+")":"ForwardRef"),t;case Es:return e=t.displayName||null,e!==null?e:ji(t.type)||"Memo";case Ve:e=t._payload,t=t._init;try{return ji(t(e))}catch{}}return null}var Va=Array.isArray,w=Vr.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,Y=Bx.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,Tl={pending:!1,data:null,method:null,action:null},Ei=[],Il=-1;function Se(t){return{current:t}}function jt(t){0>Il||(t.current=Ei[Il],Ei[Il]=null,Il--)}function tt(t,e){Il++,Ei[Il]=t.current,t.current=e}var pe=Se(null),dn=Se(null),al=Se(null),Eu=Se(null);function Tu(t,e){switch(tt(al,e),tt(dn,t),tt(pe,null),e.nodeType){case 9:case 11:t=(t=e.documentElement)&&(t=t.namespaceURI)?Fo(t):0;break;default:if(t=e.tagName,e=e.namespaceURI)e=Fo(e),t=g0(e,t);else switch(t){case"svg":t=1;break;case"math":t=2;break;default:t=0}}jt(pe),tt(pe,t)}function ya(){jt(pe),jt(dn),jt(al)}function Ti(t){t.memoizedState!==null&&tt(Eu,t);var e=pe.current,l=g0(e,t.type);e!==l&&(tt(dn,t),tt(pe,l))}function Mu(t){dn.current===t&&(jt(pe),jt(dn)),Eu.current===t&&(jt(Eu),zn._currentValue=Tl)}var Tc,Yf;function kl(t){if(Tc===void 0)try{throw Error()}catch(l){var e=l.stack.trim().match(/\n( *(at )?)/);Tc=e&&e[1]||"",Yf=-1<l.stack.indexOf(`
+    at`)?" (<anonymous>)":-1<l.stack.indexOf("@")?"@unknown:0:0":""}return`
+`+Tc+t+Yf}var Mc=!1;function Ac(t,e){if(!t||Mc)return"";Mc=!0;var l=Error.prepareStackTrace;Error.prepareStackTrace=void 0;try{var a={DetermineComponentFrameRoot:function(){try{if(e){var h=function(){throw Error()};if(Object.defineProperty(h.prototype,"props",{set:function(){throw Error()}}),typeof Reflect=="object"&&Reflect.construct){try{Reflect.construct(h,[])}catch(y){var d=y}Reflect.construct(t,[],h)}else{try{h.call()}catch(y){d=y}t.call(h.prototype)}}else{try{throw Error()}catch(y){d=y}(h=t())&&typeof h.catch=="function"&&h.catch(function(){})}}catch(y){if(y&&d&&typeof y.stack=="string")return[y.stack,d.stack]}return[null,null]}};a.DetermineComponentFrameRoot.displayName="DetermineComponentFrameRoot";var n=Object.getOwnPropertyDescriptor(a.DetermineComponentFrameRoot,"name");n&&n.configurable&&Object.defineProperty(a.DetermineComponentFrameRoot,"name",{value:"DetermineComponentFrameRoot"});var u=a.DetermineComponentFrameRoot(),c=u[0],i=u[1];if(c&&i){var s=c.split(`
+`),r=i.split(`
+`);for(n=a=0;a<s.length&&!s[a].includes("DetermineComponentFrameRoot");)a++;for(;n<r.length&&!r[n].includes("DetermineComponentFrameRoot");)n++;if(a===s.length||n===r.length)for(a=s.length-1,n=r.length-1;1<=a&&0<=n&&s[a]!==r[n];)n--;for(;1<=a&&0<=n;a--,n--)if(s[a]!==r[n]){if(a!==1||n!==1)do if(a--,n--,0>n||s[a]!==r[n]){var x=`
+`+s[a].replace(" at new "," at ");return t.displayName&&x.includes("<anonymous>")&&(x=x.replace("<anonymous>",t.displayName)),x}while(1<=a&&0<=n);break}}}finally{Mc=!1,Error.prepareStackTrace=l}return(l=t?t.displayName||t.name:"")?kl(l):""}function Yx(t,e){switch(t.tag){case 26:case 27:case 5:return kl(t.type);case 16:return kl("Lazy");case 13:return t.child!==e&&e!==null?kl("Suspense Fallback"):kl("Suspense");case 19:return kl("SuspenseList");case 0:case 15:return Ac(t.type,!1);case 11:return Ac(t.type.render,!1);case 1:return Ac(t.type,!0);case 31:return kl("Activity");default:return""}}function Vf(t){try{var e="",l=null;do e+=Yx(t,l),l=t,t=t.return;while(t);return e}catch(a){return`
+Error generating stack: `+a.message+`
+`+a.stack}}var Mi=Object.prototype.hasOwnProperty,Ts=pt.unstable_scheduleCallback,$c=pt.unstable_cancelCallback,Vx=pt.unstable_shouldYield,Qx=pt.unstable_requestPaint,Wt=pt.unstable_now,Kx=pt.unstable_getCurrentPriorityLevel,Pr=pt.unstable_ImmediatePriority,td=pt.unstable_UserBlockingPriority,Au=pt.unstable_NormalPriority,Jx=pt.unstable_LowPriority,ed=pt.unstable_IdlePriority,Wx=pt.log,Fx=pt.unstable_setDisableYieldValue,An=null,Ft=null;function Ie(t){if(typeof Wx=="function"&&Fx(t),Ft&&typeof Ft.setStrictMode=="function")try{Ft.setStrictMode(An,t)}catch{}}var It=Math.clz32?Math.clz32:tm,Ix=Math.log,Px=Math.LN2;function tm(t){return t>>>=0,t===0?32:31-(Ix(t)/Px|0)|0}var Zn=256,Gn=262144,Yn=4194304;function zl(t){var e=t&42;if(e!==0)return e;switch(t&-t){case 1:return 1;case 2:return 2;case 4:return 4;case 8:return 8;case 16:return 16;case 32:return 32;case 64:return 64;case 128:return 128;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:return t&261888;case 262144:case 524288:case 1048576:case 2097152:return t&3932160;case 4194304:case 8388608:case 16777216:case 33554432:return t&62914560;case 67108864:return 67108864;case 134217728:return 134217728;case 268435456:return 268435456;case 536870912:return 536870912;case 1073741824:return 0;default:return t}}function nc(t,e,l){var a=t.pendingLanes;if(a===0)return 0;var n=0,u=t.suspendedLanes,c=t.pingedLanes;t=t.warmLanes;var i=a&134217727;return i!==0?(a=i&~u,a!==0?n=zl(a):(c&=i,c!==0?n=zl(c):l||(l=i&~t,l!==0&&(n=zl(l))))):(i=a&~u,i!==0?n=zl(i):c!==0?n=zl(c):l||(l=a&~t,l!==0&&(n=zl(l)))),n===0?0:e!==0&&e!==n&&!(e&u)&&(u=n&-n,l=e&-e,u>=l||u===32&&(l&4194048)!==0)?e:n}function $n(t,e){return(t.pendingLanes&~(t.suspendedLanes&~t.pingedLanes)&e)===0}function em(t,e){switch(t){case 1:case 2:case 4:case 8:case 64:return e+250;case 16:case 32:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:return e+5e3;case 4194304:case 8388608:case 16777216:case 33554432:return-1;case 67108864:case 134217728:case 268435456:case 536870912:case 1073741824:return-1;default:return-1}}function ld(){var t=Yn;return Yn<<=1,!(Yn&62914560)&&(Yn=4194304),t}function Nc(t){for(var e=[],l=0;31>l;l++)e.push(t);return e}function Nn(t,e){t.pendingLanes|=e,e!==268435456&&(t.suspendedLanes=0,t.pingedLanes=0,t.warmLanes=0)}function lm(t,e,l,a,n,u){var c=t.pendingLanes;t.pendingLanes=l,t.suspendedLanes=0,t.pingedLanes=0,t.warmLanes=0,t.expiredLanes&=l,t.entangledLanes&=l,t.errorRecoveryDisabledLanes&=l,t.shellSuspendCounter=0;var i=t.entanglements,s=t.expirationTimes,r=t.hiddenUpdates;for(l=c&~l;0<l;){var x=31-It(l),h=1<<x;i[x]=0,s[x]=-1;var d=r[x];if(d!==null)for(r[x]=null,x=0;x<d.length;x++){var y=d[x];y!==null&&(y.lane&=-536870913)}l&=~h}a!==0&&ad(t,a,0),u!==0&&n===0&&t.tag!==0&&(t.suspendedLanes|=u&~(c&~e))}function ad(t,e,l){t.pendingLanes|=e,t.suspendedLanes&=~e;var a=31-It(e);t.entangledLanes|=e,t.entanglements[a]=t.entanglements[a]|1073741824|l&261930}function nd(t,e){var l=t.entangledLanes|=e;for(t=t.entanglements;l;){var a=31-It(l),n=1<<a;n&e|t[a]&e&&(t[a]|=e),l&=~n}}function ud(t,e){var l=e&-e;return l=l&42?1:Ms(l),l&(t.suspendedLanes|e)?0:l}function Ms(t){switch(t){case 2:t=1;break;case 8:t=4;break;case 32:t=16;break;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:case 4194304:case 8388608:case 16777216:case 33554432:t=128;break;case 268435456:t=134217728;break;default:t=0}return t}function As(t){return t&=-t,2<t?8<t?t&134217727?32:268435456:8:2}function cd(){var t=Y.p;return t!==0?t:(t=window.event,t===void 0?32:$0(t.type))}function Qf(t,e){var l=Y.p;try{return Y.p=t,e()}finally{Y.p=l}}var yl=Math.random().toString(36).slice(2),$t="__reactFiber$"+yl,Zt="__reactProps$"+yl,Aa="__reactContainer$"+yl,Ai="__reactEvents$"+yl,am="__reactListeners$"+yl,nm="__reactHandles$"+yl,Kf="__reactResources$"+yl,On="__reactMarker$"+yl;function $s(t){delete t[$t],delete t[Zt],delete t[Ai],delete t[am],delete t[nm]}function Pl(t){var e=t[$t];if(e)return e;for(var l=t.parentNode;l;){if(e=l[Aa]||l[$t]){if(l=e.alternate,e.child!==null||l!==null&&l.child!==null)for(t=lr(t);t!==null;){if(l=t[$t])return l;t=lr(t)}return e}t=l,l=t.parentNode}return null}function $a(t){if(t=t[$t]||t[Aa]){var e=t.tag;if(e===5||e===6||e===13||e===31||e===26||e===27||e===3)return t}return null}function Qa(t){var e=t.tag;if(e===5||e===26||e===27||e===6)return t.stateNode;throw Error(j(33))}function fa(t){var e=t[Kf];return e||(e=t[Kf]={hoistableStyles:new Map,hoistableScripts:new Map}),e}function zt(t){t[On]=!0}var id=new Set,sd={};function Rl(t,e){ha(t,e),ha(t+"Capture",e)}function ha(t,e){for(sd[t]=e,t=0;t<e.length;t++)id.add(e[t])}var um=RegExp("^[:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD][:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$"),Jf={},Wf={};function cm(t){return Mi.call(Wf,t)?!0:Mi.call(Jf,t)?!1:um.test(t)?Wf[t]=!0:(Jf[t]=!0,!1)}function su(t,e,l){if(cm(e))if(l===null)t.removeAttribute(e);else{switch(typeof l){case"undefined":case"function":case"symbol":t.removeAttribute(e);return;case"boolean":var a=e.toLowerCase().slice(0,5);if(a!=="data-"&&a!=="aria-"){t.removeAttribute(e);return}}t.setAttribute(e,""+l)}}function Vn(t,e,l){if(l===null)t.removeAttribute(e);else{switch(typeof l){case"undefined":case"function":case"symbol":case"boolean":t.removeAttribute(e);return}t.setAttribute(e,""+l)}}function ze(t,e,l,a){if(a===null)t.removeAttribute(l);else{switch(typeof a){case"undefined":case"function":case"symbol":case"boolean":t.removeAttribute(l);return}t.setAttributeNS(e,l,""+a)}}function ae(t){switch(typeof t){case"bigint":case"boolean":case"number":case"string":case"undefined":return t;case"object":return t;default:return""}}function fd(t){var e=t.type;return(t=t.nodeName)&&t.toLowerCase()==="input"&&(e==="checkbox"||e==="radio")}function im(t,e,l){var a=Object.getOwnPropertyDescriptor(t.constructor.prototype,e);if(!t.hasOwnProperty(e)&&typeof a<"u"&&typeof a.get=="function"&&typeof a.set=="function"){var n=a.get,u=a.set;return Object.defineProperty(t,e,{configurable:!0,get:function(){return n.call(this)},set:function(c){l=""+c,u.call(this,c)}}),Object.defineProperty(t,e,{enumerable:a.enumerable}),{getValue:function(){return l},setValue:function(c){l=""+c},stopTracking:function(){t._valueTracker=null,delete t[e]}}}}function $i(t){if(!t._valueTracker){var e=fd(t)?"checked":"value";t._valueTracker=im(t,e,""+t[e])}}function od(t){if(!t)return!1;var e=t._valueTracker;if(!e)return!0;var l=e.getValue(),a="";return t&&(a=fd(t)?t.checked?"true":"false":t.value),t=a,t!==l?(e.setValue(t),!0):!1}function $u(t){if(t=t||(typeof document<"u"?document:void 0),typeof t>"u")return null;try{return t.activeElement||t.body}catch{return t.body}}var sm=/[\n"\\]/g;function ce(t){return t.replace(sm,function(e){return"\\"+e.charCodeAt(0).toString(16)+" "})}function Ni(t,e,l,a,n,u,c,i){t.name="",c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"?t.type=c:t.removeAttribute("type"),e!=null?c==="number"?(e===0&&t.value===""||t.value!=e)&&(t.value=""+ae(e)):t.value!==""+ae(e)&&(t.value=""+ae(e)):c!=="submit"&&c!=="reset"||t.removeAttribute("value"),e!=null?Oi(t,c,ae(e)):l!=null?Oi(t,c,ae(l)):a!=null&&t.removeAttribute("value"),n==null&&u!=null&&(t.defaultChecked=!!u),n!=null&&(t.checked=n&&typeof n!="function"&&typeof n!="symbol"),i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"?t.name=""+ae(i):t.removeAttribute("name")}function rd(t,e,l,a,n,u,c,i){if(u!=null&&typeof u!="function"&&typeof u!="symbol"&&typeof u!="boolean"&&(t.type=u),e!=null||l!=null){if(!(u!=="submit"&&u!=="reset"||e!=null)){$i(t);return}l=l!=null?""+ae(l):"",e=e!=null?""+ae(e):l,i||e===t.value||(t.value=e),t.defaultValue=e}a=a??n,a=typeof a!="function"&&typeof a!="symbol"&&!!a,t.checked=i?t.checked:!!a,t.defaultChecked=!!a,c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"&&(t.name=c),$i(t)}function Oi(t,e,l){e==="number"&&$u(t.ownerDocument)===t||t.defaultValue===""+l||(t.defaultValue=""+l)}function oa(t,e,l,a){if(t=t.options,e){e={};for(var n=0;n<l.length;n++)e["$"+l[n]]=!0;for(l=0;l<t.length;l++)n=e.hasOwnProperty("$"+t[l].value),t[l].selected!==n&&(t[l].selected=n),n&&a&&(t[l].defaultSelected=!0)}else{for(l=""+ae(l),e=null,n=0;n<t.length;n++){if(t[n].value===l){t[n].selected=!0,a&&(t[n].defaultSelected=!0);return}e!==null||t[n].disabled||(e=t[n])}e!==null&&(e.selected=!0)}}function dd(t,e,l){if(e!=null&&(e=""+ae(e),e!==t.value&&(t.value=e),l==null)){t.defaultValue!==e&&(t.defaultValue=e);return}t.defaultValue=l!=null?""+ae(l):""}function xd(t,e,l,a){if(e==null){if(a!=null){if(l!=null)throw Error(j(92));if(Va(a)){if(1<a.length)throw Error(j(93));a=a[0]}l=a}l==null&&(l=""),e=l}l=ae(e),t.defaultValue=l,a=t.textContent,a===l&&a!==""&&a!==null&&(t.value=a),$i(t)}function ga(t,e){if(e){var l=t.firstChild;if(l&&l===t.lastChild&&l.nodeType===3){l.nodeValue=e;return}}t.textContent=e}var fm=new Set("animationIterationCount aspectRatio borderImageOutset borderImageSlice borderImageWidth boxFlex boxFlexGroup boxOrdinalGroup columnCount columns flex flexGrow flexPositive flexShrink flexNegative flexOrder gridArea gridRow gridRowEnd gridRowSpan gridRowStart gridColumn gridColumnEnd gridColumnSpan gridColumnStart fontWeight lineClamp lineHeight opacity order orphans scale tabSize widows zIndex zoom fillOpacity floodOpacity stopOpacity strokeDasharray strokeDashoffset strokeMiterlimit strokeOpacity strokeWidth MozAnimationIterationCount MozBoxFlex MozBoxFlexGroup MozLineClamp msAnimationIterationCount msFlex msZoom msFlexGrow msFlexNegative msFlexOrder msFlexPositive msFlexShrink msGridColumn msGridColumnSpan msGridRow msGridRowSpan WebkitAnimationIterationCount WebkitBoxFlex WebKitBoxFlexGroup WebkitBoxOrdinalGroup WebkitColumnCount WebkitColumns WebkitFlex WebkitFlexGrow WebkitFlexPositive WebkitFlexShrink WebkitLineClamp".split(" "));function Ff(t,e,l){var a=e.indexOf("--")===0;l==null||typeof l=="boolean"||l===""?a?t.setProperty(e,""):e==="float"?t.cssFloat="":t[e]="":a?t.setProperty(e,l):typeof l!="number"||l===0||fm.has(e)?e==="float"?t.cssFloat=l:t[e]=(""+l).trim():t[e]=l+"px"}function md(t,e,l){if(e!=null&&typeof e!="object")throw Error(j(62));if(t=t.style,l!=null){for(var a in l)!l.hasOwnProperty(a)||e!=null&&e.hasOwnProperty(a)||(a.indexOf("--")===0?t.setProperty(a,""):a==="float"?t.cssFloat="":t[a]="");for(var n in e)a=e[n],e.hasOwnProperty(n)&&l[n]!==a&&Ff(t,n,a)}else for(var u in e)e.hasOwnProperty(u)&&Ff(t,u,e[u])}function Ns(t){if(t.indexOf("-")===-1)return!1;switch(t){case"annotation-xml":case"color-profile":case"font-face":case"font-face-src":case"font-face-uri":case"font-face-format":case"font-face-name":case"missing-glyph":return!1;default:return!0}}var om=new Map([["acceptCharset","accept-charset"],["htmlFor","for"],["httpEquiv","http-equiv"],["crossOrigin","crossorigin"],["accentHeight","accent-height"],["alignmentBaseline","alignment-baseline"],["arabicForm","arabic-form"],["baselineShift","baseline-shift"],["capHeight","cap-height"],["clipPath","clip-path"],["clipRule","clip-rule"],["colorInterpolation","color-interpolation"],["colorInterpolationFilters","color-interpolation-filters"],["colorProfile","color-profile"],["colorRendering","color-rendering"],["dominantBaseline","dominant-baseline"],["enableBackground","enable-background"],["fillOpacity","fill-opacity"],["fillRule","fill-rule"],["floodColor","flood-color"],["floodOpacity","flood-opacity"],["fontFamily","font-family"],["fontSize","font-size"],["fontSizeAdjust","font-size-adjust"],["fontStretch","font-stretch"],["fontStyle","font-style"],["fontVariant","font-variant"],["fontWeight","font-weight"],["glyphName","glyph-name"],["glyphOrientationHorizontal","glyph-orientation-horizontal"],["glyphOrientationVertical","glyph-orientation-vertical"],["horizAdvX","horiz-adv-x"],["horizOriginX","horiz-origin-x"],["imageRendering","image-rendering"],["letterSpacing","letter-spacing"],["lightingColor","lighting-color"],["markerEnd","marker-end"],["markerMid","marker-mid"],["markerStart","marker-start"],["overlinePosition","overline-position"],["overlineThickness","overline-thickness"],["paintOrder","paint-order"],["panose-1","panose-1"],["pointerEvents","pointer-events"],["renderingIntent","rendering-intent"],["shapeRendering","shape-rendering"],["stopColor","stop-color"],["stopOpacity","stop-opacity"],["strikethroughPosition","strikethrough-position"],["strikethroughThickness","strikethrough-thickness"],["strokeDasharray","stroke-dasharray"],["strokeDashoffset","stroke-dashoffset"],["strokeLinecap","stroke-linecap"],["strokeLinejoin","stroke-linejoin"],["strokeMiterlimit","stroke-miterlimit"],["strokeOpacity","stroke-opacity"],["strokeWidth","stroke-width"],["textAnchor","text-anchor"],["textDecoration","text-decoration"],["textRendering","text-rendering"],["transformOrigin","transform-origin"],["underlinePosition","underline-position"],["underlineThickness","underline-thickness"],["unicodeBidi","unicode-bidi"],["unicodeRange","unicode-range"],["unitsPerEm","units-per-em"],["vAlphabetic","v-alphabetic"],["vHanging","v-hanging"],["vIdeographic","v-ideographic"],["vMathematical","v-mathematical"],["vectorEffect","vector-effect"],["vertAdvY","vert-adv-y"],["vertOriginX","vert-origin-x"],["vertOriginY","vert-origin-y"],["wordSpacing","word-spacing"],["writingMode","writing-mode"],["xmlnsXlink","xmlns:xlink"],["xHeight","x-height"]]),rm=/^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i;function fu(t){return rm.test(""+t)?"javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')":t}function Oe(){}var Di=null;function Os(t){return t=t.target||t.srcElement||window,t.correspondingUseElement&&(t=t.correspondingUseElement),t.nodeType===3?t.parentNode:t}var ta=null,ra=null;function If(t){var e=$a(t);if(e&&(t=e.stateNode)){var l=t[Zt]||null;t:switch(t=e.stateNode,e.type){case"input":if(Ni(t,l.value,l.defaultValue,l.defaultValue,l.checked,l.defaultChecked,l.type,l.name),e=l.name,l.type==="radio"&&e!=null){for(l=t;l.parentNode;)l=l.parentNode;for(l=l.querySelectorAll('input[name="'+ce(""+e)+'"][type="radio"]'),e=0;e<l.length;e++){var a=l[e];if(a!==t&&a.form===t.form){var n=a[Zt]||null;if(!n)throw Error(j(90));Ni(a,n.value,n.defaultValue,n.defaultValue,n.checked,n.defaultChecked,n.type,n.name)}}for(e=0;e<l.length;e++)a=l[e],a.form===t.form&&od(a)}break t;case"textarea":dd(t,l.value,l.defaultValue);break t;case"select":e=l.value,e!=null&&oa(t,!!l.multiple,e,!1)}}}var Oc=!1;function vd(t,e,l){if(Oc)return t(e,l);Oc=!0;try{var a=t(e);return a}finally{if(Oc=!1,(ta!==null||ra!==null)&&(yc(),ta&&(e=ta,t=ra,ra=ta=null,If(e),t)))for(e=0;e<t.length;e++)If(t[e])}}function xn(t,e){var l=t.stateNode;if(l===null)return null;var a=l[Zt]||null;if(a===null)return null;l=a[e];t:switch(e){case"onClick":case"onClickCapture":case"onDoubleClick":case"onDoubleClickCapture":case"onMouseDown":case"onMouseDownCapture":case"onMouseMove":case"onMouseMoveCapture":case"onMouseUp":case"onMouseUpCapture":case"onMouseEnter":(a=!a.disabled)||(t=t.type,a=!(t==="button"||t==="input"||t==="select"||t==="textarea")),t=!a;break t;default:t=!1}if(t)return null;if(l&&typeof l!="function")throw Error(j(231,e,typeof l));return l}var Re=!(typeof window>"u"||typeof window.document>"u"||typeof window.document.createElement>"u"),wi=!1;if(Re)try{var qa={};Object.defineProperty(qa,"passive",{get:function(){wi=!0}}),window.addEventListener("test",qa,qa),window.removeEventListener("test",qa,qa)}catch{wi=!1}var Pe=null,Ds=null,ou=null;function yd(){if(ou)return ou;var t,e=Ds,l=e.length,a,n="value"in Pe?Pe.value:Pe.textContent,u=n.length;for(t=0;t<l&&e[t]===n[t];t++);var c=l-t;for(a=1;a<=c&&e[l-a]===n[u-a];a++);return ou=n.slice(t,1<a?1-a:void 0)}function ru(t){var e=t.keyCode;return"charCode"in t?(t=t.charCode,t===0&&e===13&&(t=13)):t=e,t===10&&(t=13),32<=t||t===13?t:0}function Qn(){return!0}function Pf(){return!1}function Gt(t){function e(l,a,n,u,c){this._reactName=l,this._targetInst=n,this.type=a,this.nativeEvent=u,this.target=c,this.currentTarget=null;for(var i in t)t.hasOwnProperty(i)&&(l=t[i],this[i]=l?l(u):u[i]);return this.isDefaultPrevented=(u.defaultPrevented!=null?u.defaultPrevented:u.returnValue===!1)?Qn:Pf,this.isPropagationStopped=Pf,this}return ct(e.prototype,{preventDefault:function(){this.defaultPrevented=!0;var l=this.nativeEvent;l&&(l.preventDefault?l.preventDefault():typeof l.returnValue!="unknown"&&(l.returnValue=!1),this.isDefaultPrevented=Qn)},stopPropagation:function(){var l=this.nativeEvent;l&&(l.stopPropagation?l.stopPropagation():typeof l.cancelBubble!="unknown"&&(l.cancelBubble=!0),this.isPropagationStopped=Qn)},persist:function(){},isPersistent:Qn}),e}var ql={eventPhase:0,bubbles:0,cancelable:0,timeStamp:function(t){return t.timeStamp||Date.now()},defaultPrevented:0,isTrusted:0},uc=Gt(ql),Dn=ct({},ql,{view:0,detail:0}),dm=Gt(Dn),Dc,wc,Ha,cc=ct({},Dn,{screenX:0,screenY:0,clientX:0,clientY:0,pageX:0,pageY:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,getModifierState:ws,button:0,buttons:0,relatedTarget:function(t){return t.relatedTarget===void 0?t.fromElement===t.srcElement?t.toElement:t.fromElement:t.relatedTarget},movementX:function(t){return"movementX"in t?t.movementX:(t!==Ha&&(Ha&&t.type==="mousemove"?(Dc=t.screenX-Ha.screenX,wc=t.screenY-Ha.screenY):wc=Dc=0,Ha=t),Dc)},movementY:function(t){return"movementY"in t?t.movementY:wc}}),to=Gt(cc),xm=ct({},cc,{dataTransfer:0}),mm=Gt(xm),vm=ct({},Dn,{relatedTarget:0}),Cc=Gt(vm),ym=ct({},ql,{animationName:0,elapsedTime:0,pseudoElement:0}),hm=Gt(ym),gm=ct({},ql,{clipboardData:function(t){return"clipboardData"in t?t.clipboardData:window.clipboardData}}),bm=Gt(gm),pm=ct({},ql,{data:0}),eo=Gt(pm),Sm={Esc:"Escape",Spacebar:" ",Left:"ArrowLeft",Up:"ArrowUp",Right:"ArrowRight",Down:"ArrowDown",Del:"Delete",Win:"OS",Menu:"ContextMenu",Apps:"ContextMenu",Scroll:"ScrollLock",MozPrintableKey:"Unidentified"},km={8:"Backspace",9:"Tab",12:"Clear",13:"Enter",16:"Shift",17:"Control",18:"Alt",19:"Pause",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",45:"Insert",46:"Delete",112:"F1",113:"F2",114:"F3",115:"F4",116:"F5",117:"F6",118:"F7",119:"F8",120:"F9",121:"F10",122:"F11",123:"F12",144:"NumLock",145:"ScrollLock",224:"Meta"},zm={Alt:"altKey",Control:"ctrlKey",Meta:"metaKey",Shift:"shiftKey"};function jm(t){var e=this.nativeEvent;return e.getModifierState?e.getModifierState(t):(t=zm[t])?!!e[t]:!1}function ws(){return jm}var Em=ct({},Dn,{key:function(t){if(t.key){var e=Sm[t.key]||t.key;if(e!=="Unidentified")return e}return t.type==="keypress"?(t=ru(t),t===13?"Enter":String.fromCharCode(t)):t.type==="keydown"||t.type==="keyup"?km[t.keyCode]||"Unidentified":""},code:0,location:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,repeat:0,locale:0,getModifierState:ws,charCode:function(t){return t.type==="keypress"?ru(t):0},keyCode:function(t){return t.type==="keydown"||t.type==="keyup"?t.keyCode:0},which:function(t){return t.type==="keypress"?ru(t):t.type==="keydown"||t.type==="keyup"?t.keyCode:0}}),Tm=Gt(Em),Mm=ct({},cc,{pointerId:0,width:0,height:0,pressure:0,tangentialPressure:0,tiltX:0,tiltY:0,twist:0,pointerType:0,isPrimary:0}),lo=Gt(Mm),Am=ct({},Dn,{touches:0,targetTouches:0,changedTouches:0,altKey:0,metaKey:0,ctrlKey:0,shiftKey:0,getModifierState:ws}),$m=Gt(Am),Nm=ct({},ql,{propertyName:0,elapsedTime:0,pseudoElement:0}),Om=Gt(Nm),Dm=ct({},cc,{deltaX:function(t){return"deltaX"in t?t.deltaX:"wheelDeltaX"in t?-t.wheelDeltaX:0},deltaY:function(t){return"deltaY"in t?t.deltaY:"wheelDeltaY"in t?-t.wheelDeltaY:"wheelDelta"in t?-t.wheelDelta:0},deltaZ:0,deltaMode:0}),wm=Gt(Dm),Cm=ct({},ql,{newState:0,oldState:0}),_m=Gt(Cm),Rm=[9,13,27,32],Cs=Re&&"CompositionEvent"in window,Ia=null;Re&&"documentMode"in document&&(Ia=document.documentMode);var qm=Re&&"TextEvent"in window&&!Ia,hd=Re&&(!Cs||Ia&&8<Ia&&11>=Ia),ao=" ",no=!1;function gd(t,e){switch(t){case"keyup":return Rm.indexOf(e.keyCode)!==-1;case"keydown":return e.keyCode!==229;case"keypress":case"mousedown":case"focusout":return!0;default:return!1}}function bd(t){return t=t.detail,typeof t=="object"&&"data"in t?t.data:null}var ea=!1;function Hm(t,e){switch(t){case"compositionend":return bd(e);case"keypress":return e.which!==32?null:(no=!0,ao);case"textInput":return t=e.data,t===ao&&no?null:t;default:return null}}function Um(t,e){if(ea)return t==="compositionend"||!Cs&&gd(t,e)?(t=yd(),ou=Ds=Pe=null,ea=!1,t):null;switch(t){case"paste":return null;case"keypress":if(!(e.ctrlKey||e.altKey||e.metaKey)||e.ctrlKey&&e.altKey){if(e.char&&1<e.char.length)return e.char;if(e.which)return String.fromCharCode(e.which)}return null;case"compositionend":return hd&&e.locale!=="ko"?null:e.data;default:return null}}var Bm={color:!0,date:!0,datetime:!0,"datetime-local":!0,email:!0,month:!0,number:!0,password:!0,range:!0,search:!0,tel:!0,text:!0,time:!0,url:!0,week:!0};function uo(t){var e=t&&t.nodeName&&t.nodeName.toLowerCase();return e==="input"?!!Bm[t.type]:e==="textarea"}function pd(t,e,l,a){ta?ra?ra.push(a):ra=[a]:ta=a,e=Qu(e,"onChange"),0<e.length&&(l=new uc("onChange","change",null,l,a),t.push({event:l,listeners:e}))}var Pa=null,mn=null;function Xm(t){v0(t,0)}function ic(t){var e=Qa(t);if(od(e))return t}function co(t,e){if(t==="change")return e}var Sd=!1;if(Re){var _c;if(Re){var Rc="oninput"in document;if(!Rc){var io=document.createElement("div");io.setAttribute("oninput","return;"),Rc=typeof io.oninput=="function"}_c=Rc}else _c=!1;Sd=_c&&(!document.documentMode||9<document.documentMode)}function so(){Pa&&(Pa.detachEvent("onpropertychange",kd),mn=Pa=null)}function kd(t){if(t.propertyName==="value"&&ic(mn)){var e=[];pd(e,mn,t,Os(t)),vd(Xm,e)}}function Lm(t,e,l){t==="focusin"?(so(),Pa=e,mn=l,Pa.attachEvent("onpropertychange",kd)):t==="focusout"&&so()}function Zm(t){if(t==="selectionchange"||t==="keyup"||t==="keydown")return ic(mn)}function Gm(t,e){if(t==="click")return ic(e)}function Ym(t,e){if(t==="input"||t==="change")return ic(e)}function Vm(t,e){return t===e&&(t!==0||1/t===1/e)||t!==t&&e!==e}var te=typeof Object.is=="function"?Object.is:Vm;function vn(t,e){if(te(t,e))return!0;if(typeof t!="object"||t===null||typeof e!="object"||e===null)return!1;var l=Object.keys(t),a=Object.keys(e);if(l.length!==a.length)return!1;for(a=0;a<l.length;a++){var n=l[a];if(!Mi.call(e,n)||!te(t[n],e[n]))return!1}return!0}function fo(t){for(;t&&t.firstChild;)t=t.firstChild;return t}function oo(t,e){var l=fo(t);t=0;for(var a;l;){if(l.nodeType===3){if(a=t+l.textContent.length,t<=e&&a>=e)return{node:l,offset:e-t};t=a}t:{for(;l;){if(l.nextSibling){l=l.nextSibling;break t}l=l.parentNode}l=void 0}l=fo(l)}}function zd(t,e){return t&&e?t===e?!0:t&&t.nodeType===3?!1:e&&e.nodeType===3?zd(t,e.parentNode):"contains"in t?t.contains(e):t.compareDocumentPosition?!!(t.compareDocumentPosition(e)&16):!1:!1}function jd(t){t=t!=null&&t.ownerDocument!=null&&t.ownerDocument.defaultView!=null?t.ownerDocument.defaultView:window;for(var e=$u(t.document);e instanceof t.HTMLIFrameElement;){try{var l=typeof e.contentWindow.location.href=="string"}catch{l=!1}if(l)t=e.contentWindow;else break;e=$u(t.document)}return e}function _s(t){var e=t&&t.nodeName&&t.nodeName.toLowerCase();return e&&(e==="input"&&(t.type==="text"||t.type==="search"||t.type==="tel"||t.type==="url"||t.type==="password")||e==="textarea"||t.contentEditable==="true")}var Qm=Re&&"documentMode"in document&&11>=document.documentMode,la=null,Ci=null,tn=null,_i=!1;function ro(t,e,l){var a=l.window===l?l.document:l.nodeType===9?l:l.ownerDocument;_i||la==null||la!==$u(a)||(a=la,"selectionStart"in a&&_s(a)?a={start:a.selectionStart,end:a.selectionEnd}:(a=(a.ownerDocument&&a.ownerDocument.defaultView||window).getSelection(),a={anchorNode:a.anchorNode,anchorOffset:a.anchorOffset,focusNode:a.focusNode,focusOffset:a.focusOffset}),tn&&vn(tn,a)||(tn=a,a=Qu(Ci,"onSelect"),0<a.length&&(e=new uc("onSelect","select",null,e,l),t.push({event:e,listeners:a}),e.target=la)))}function bl(t,e){var l={};return l[t.toLowerCase()]=e.toLowerCase(),l["Webkit"+t]="webkit"+e,l["Moz"+t]="moz"+e,l}var aa={animationend:bl("Animation","AnimationEnd"),animationiteration:bl("Animation","AnimationIteration"),animationstart:bl("Animation","AnimationStart"),transitionrun:bl("Transition","TransitionRun"),transitionstart:bl("Transition","TransitionStart"),transitioncancel:bl("Transition","TransitionCancel"),transitionend:bl("Transition","TransitionEnd")},qc={},Ed={};Re&&(Ed=document.createElement("div").style,"AnimationEvent"in window||(delete aa.animationend.animation,delete aa.animationiteration.animation,delete aa.animationstart.animation),"TransitionEvent"in window||delete aa.transitionend.transition);function Hl(t){if(qc[t])return qc[t];if(!aa[t])return t;var e=aa[t],l;for(l in e)if(e.hasOwnProperty(l)&&l in Ed)return qc[t]=e[l];return t}var Td=Hl("animationend"),Md=Hl("animationiteration"),Ad=Hl("animationstart"),Km=Hl("transitionrun"),Jm=Hl("transitionstart"),Wm=Hl("transitioncancel"),$d=Hl("transitionend"),Nd=new Map,Ri="abort auxClick beforeToggle cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel".split(" ");Ri.push("scrollEnd");function ye(t,e){Nd.set(t,e),Rl(e,[t])}var Nu=typeof reportError=="function"?reportError:function(t){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var e=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof t=="object"&&t!==null&&typeof t.message=="string"?String(t.message):String(t),error:t});if(!window.dispatchEvent(e))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",t);return}console.error(t)},le=[],na=0,Rs=0;function sc(){for(var t=na,e=Rs=na=0;e<t;){var l=le[e];le[e++]=null;var a=le[e];le[e++]=null;var n=le[e];le[e++]=null;var u=le[e];if(le[e++]=null,a!==null&&n!==null){var c=a.pending;c===null?n.next=n:(n.next=c.next,c.next=n),a.pending=n}u!==0&&Od(l,n,u)}}function fc(t,e,l,a){le[na++]=t,le[na++]=e,le[na++]=l,le[na++]=a,Rs|=a,t.lanes|=a,t=t.alternate,t!==null&&(t.lanes|=a)}function qs(t,e,l,a){return fc(t,e,l,a),Ou(t)}function Ul(t,e){return fc(t,null,null,e),Ou(t)}function Od(t,e,l){t.lanes|=l;var a=t.alternate;a!==null&&(a.lanes|=l);for(var n=!1,u=t.return;u!==null;)u.childLanes|=l,a=u.alternate,a!==null&&(a.childLanes|=l),u.tag===22&&(t=u.stateNode,t===null||t._visibility&1||(n=!0)),t=u,u=u.return;return t.tag===3?(u=t.stateNode,n&&e!==null&&(n=31-It(l),t=u.hiddenUpdates,a=t[n],a===null?t[n]=[e]:a.push(e),e.lane=l|536870912),u):null}function Ou(t){if(50<on)throw on=0,as=null,Error(j(185));for(var e=t.return;e!==null;)t=e,e=t.return;return t.tag===3?t.stateNode:null}var ua={};function Fm(t,e,l,a){this.tag=t,this.key=l,this.sibling=this.child=this.return=this.stateNode=this.type=this.elementType=null,this.index=0,this.refCleanup=this.ref=null,this.pendingProps=e,this.dependencies=this.memoizedState=this.updateQueue=this.memoizedProps=null,this.mode=a,this.subtreeFlags=this.flags=0,this.deletions=null,this.childLanes=this.lanes=0,this.alternate=null}function Kt(t,e,l,a){return new Fm(t,e,l,a)}function Hs(t){return t=t.prototype,!(!t||!t.isReactComponent)}function we(t,e){var l=t.alternate;return l===null?(l=Kt(t.tag,e,t.key,t.mode),l.elementType=t.elementType,l.type=t.type,l.stateNode=t.stateNode,l.alternate=t,t.alternate=l):(l.pendingProps=e,l.type=t.type,l.flags=0,l.subtreeFlags=0,l.deletions=null),l.flags=t.flags&65011712,l.childLanes=t.childLanes,l.lanes=t.lanes,l.child=t.child,l.memoizedProps=t.memoizedProps,l.memoizedState=t.memoizedState,l.updateQueue=t.updateQueue,e=t.dependencies,l.dependencies=e===null?null:{lanes:e.lanes,firstContext:e.firstContext},l.sibling=t.sibling,l.index=t.index,l.ref=t.ref,l.refCleanup=t.refCleanup,l}function Dd(t,e){t.flags&=65011714;var l=t.alternate;return l===null?(t.childLanes=0,t.lanes=e,t.child=null,t.subtreeFlags=0,t.memoizedProps=null,t.memoizedState=null,t.updateQueue=null,t.dependencies=null,t.stateNode=null):(t.childLanes=l.childLanes,t.lanes=l.lanes,t.child=l.child,t.subtreeFlags=0,t.deletions=null,t.memoizedProps=l.memoizedProps,t.memoizedState=l.memoizedState,t.updateQueue=l.updateQueue,t.type=l.type,e=l.dependencies,t.dependencies=e===null?null:{lanes:e.lanes,firstContext:e.firstContext}),t}function du(t,e,l,a,n,u){var c=0;if(a=t,typeof t=="function")Hs(t)&&(c=1);else if(typeof t=="string")c=ly(t,l,pe.current)?26:t==="html"||t==="head"||t==="body"?27:5;else t:switch(t){case zi:return t=Kt(31,l,e,n),t.elementType=zi,t.lanes=u,t;case Fl:return Ml(l.children,n,u,e);case Fr:c=8,n|=24;break;case pi:return t=Kt(12,l,e,n|2),t.elementType=pi,t.lanes=u,t;case Si:return t=Kt(13,l,e,n),t.elementType=Si,t.lanes=u,t;case ki:return t=Kt(19,l,e,n),t.elementType=ki,t.lanes=u,t;default:if(typeof t=="object"&&t!==null)switch(t.$$typeof){case Ne:c=10;break t;case Ir:c=9;break t;case js:c=11;break t;case Es:c=14;break t;case Ve:c=16,a=null;break t}c=29,l=Error(j(130,t===null?"null":typeof t,"")),a=null}return e=Kt(c,l,e,n),e.elementType=t,e.type=a,e.lanes=u,e}function Ml(t,e,l,a){return t=Kt(7,t,a,e),t.lanes=l,t}function Hc(t,e,l){return t=Kt(6,t,null,e),t.lanes=l,t}function wd(t){var e=Kt(18,null,null,0);return e.stateNode=t,e}function Uc(t,e,l){return e=Kt(4,t.children!==null?t.children:[],t.key,e),e.lanes=l,e.stateNode={containerInfo:t.containerInfo,pendingChildren:null,implementation:t.implementation},e}var xo=new WeakMap;function ie(t,e){if(typeof t=="object"&&t!==null){var l=xo.get(t);return l!==void 0?l:(e={value:t,source:e,stack:Vf(e)},xo.set(t,e),e)}return{value:t,source:e,stack:Vf(e)}}var ca=[],ia=0,Du=null,yn=0,ne=[],ue=0,dl=null,he=1,ge="";function Ae(t,e){ca[ia++]=yn,ca[ia++]=Du,Du=t,yn=e}function Cd(t,e,l){ne[ue++]=he,ne[ue++]=ge,ne[ue++]=dl,dl=t;var a=he;t=ge;var n=32-It(a)-1;a&=~(1<<n),l+=1;var u=32-It(e)+n;if(30<u){var c=n-n%5;u=(a&(1<<c)-1).toString(32),a>>=c,n-=c,he=1<<32-It(e)+n|l<<n|a,ge=u+t}else he=1<<u|l<<n|a,ge=t}function Us(t){t.return!==null&&(Ae(t,1),Cd(t,1,0))}function Bs(t){for(;t===Du;)Du=ca[--ia],ca[ia]=null,yn=ca[--ia],ca[ia]=null;for(;t===dl;)dl=ne[--ue],ne[ue]=null,ge=ne[--ue],ne[ue]=null,he=ne[--ue],ne[ue]=null}function _d(t,e){ne[ue++]=he,ne[ue++]=ge,ne[ue++]=dl,he=e.id,ge=e.overflow,dl=t}var Nt=null,at=null,X=!1,nl=null,se=!1,qi=Error(j(519));function xl(t){var e=Error(j(418,1<arguments.length&&arguments[1]!==void 0&&arguments[1]?"text":"HTML",""));throw hn(ie(e,t)),qi}function mo(t){var e=t.stateNode,l=t.type,a=t.memoizedProps;switch(e[$t]=t,e[Zt]=a,l){case"dialog":H("cancel",e),H("close",e);break;case"iframe":case"object":case"embed":H("load",e);break;case"video":case"audio":for(l=0;l<Sn.length;l++)H(Sn[l],e);break;case"source":H("error",e);break;case"img":case"image":case"link":H("error",e),H("load",e);break;case"details":H("toggle",e);break;case"input":H("invalid",e),rd(e,a.value,a.defaultValue,a.checked,a.defaultChecked,a.type,a.name,!0);break;case"select":H("invalid",e);break;case"textarea":H("invalid",e),xd(e,a.value,a.defaultValue,a.children)}l=a.children,typeof l!="string"&&typeof l!="number"&&typeof l!="bigint"||e.textContent===""+l||a.suppressHydrationWarning===!0||h0(e.textContent,l)?(a.popover!=null&&(H("beforetoggle",e),H("toggle",e)),a.onScroll!=null&&H("scroll",e),a.onScrollEnd!=null&&H("scrollend",e),a.onClick!=null&&(e.onclick=Oe),e=!0):e=!1,e||xl(t,!0)}function vo(t){for(Nt=t.return;Nt;)switch(Nt.tag){case 5:case 31:case 13:se=!1;return;case 27:case 3:se=!0;return;default:Nt=Nt.return}}function Ll(t){if(t!==Nt)return!1;if(!X)return vo(t),X=!0,!1;var e=t.tag,l;if((l=e!==3&&e!==27)&&((l=e===5)&&(l=t.type,l=!(l!=="form"&&l!=="button")||ss(t.type,t.memoizedProps)),l=!l),l&&at&&xl(t),vo(t),e===13){if(t=t.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(j(317));at=er(t)}else if(e===31){if(t=t.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(j(317));at=er(t)}else e===27?(e=at,hl(t.type)?(t=ds,ds=null,at=t):at=e):at=Nt?oe(t.stateNode.nextSibling):null;return!0}function Ol(){at=Nt=null,X=!1}function Bc(){var t=nl;return t!==null&&(Xt===null?Xt=t:Xt.push.apply(Xt,t),nl=null),t}function hn(t){nl===null?nl=[t]:nl.push(t)}var Hi=Se(null),Bl=null,De=null;function Ke(t,e,l){tt(Hi,e._currentValue),e._currentValue=l}function Ce(t){t._currentValue=Hi.current,jt(Hi)}function Ui(t,e,l){for(;t!==null;){var a=t.alternate;if((t.childLanes&e)!==e?(t.childLanes|=e,a!==null&&(a.childLanes|=e)):a!==null&&(a.childLanes&e)!==e&&(a.childLanes|=e),t===l)break;t=t.return}}function Bi(t,e,l,a){var n=t.child;for(n!==null&&(n.return=t);n!==null;){var u=n.dependencies;if(u!==null){var c=n.child;u=u.firstContext;t:for(;u!==null;){var i=u;u=n;for(var s=0;s<e.length;s++)if(i.context===e[s]){u.lanes|=l,i=u.alternate,i!==null&&(i.lanes|=l),Ui(u.return,l,t),a||(c=null);break t}u=i.next}}else if(n.tag===18){if(c=n.return,c===null)throw Error(j(341));c.lanes|=l,u=c.alternate,u!==null&&(u.lanes|=l),Ui(c,l,t),c=null}else c=n.child;if(c!==null)c.return=n;else for(c=n;c!==null;){if(c===t){c=null;break}if(n=c.sibling,n!==null){n.return=c.return,c=n;break}c=c.return}n=c}}function Na(t,e,l,a){t=null;for(var n=e,u=!1;n!==null;){if(!u){if(n.flags&524288)u=!0;else if(n.flags&262144)break}if(n.tag===10){var c=n.alternate;if(c===null)throw Error(j(387));if(c=c.memoizedProps,c!==null){var i=n.type;te(n.pendingProps.value,c.value)||(t!==null?t.push(i):t=[i])}}else if(n===Eu.current){if(c=n.alternate,c===null)throw Error(j(387));c.memoizedState.memoizedState!==n.memoizedState.memoizedState&&(t!==null?t.push(zn):t=[zn])}n=n.return}t!==null&&Bi(e,t,l,a),e.flags|=262144}function wu(t){for(t=t.firstContext;t!==null;){if(!te(t.context._currentValue,t.memoizedValue))return!0;t=t.next}return!1}function Dl(t){Bl=t,De=null,t=t.dependencies,t!==null&&(t.firstContext=null)}function Ot(t){return Rd(Bl,t)}function Kn(t,e){return Bl===null&&Dl(t),Rd(t,e)}function Rd(t,e){var l=e._currentValue;if(e={context:e,memoizedValue:l,next:null},De===null){if(t===null)throw Error(j(308));De=e,t.dependencies={lanes:0,firstContext:e},t.flags|=524288}else De=De.next=e;return l}var Im=typeof AbortController<"u"?AbortController:function(){var t=[],e=this.signal={aborted:!1,addEventListener:function(l,a){t.push(a)}};this.abort=function(){e.aborted=!0,t.forEach(function(l){return l()})}},Pm=pt.unstable_scheduleCallback,tv=pt.unstable_NormalPriority,ht={$$typeof:Ne,Consumer:null,Provider:null,_currentValue:null,_currentValue2:null,_threadCount:0};function Xs(){return{controller:new Im,data:new Map,refCount:0}}function wn(t){t.refCount--,t.refCount===0&&Pm(tv,function(){t.controller.abort()})}var en=null,Xi=0,ba=0,da=null;function ev(t,e){if(en===null){var l=en=[];Xi=0,ba=xf(),da={status:"pending",value:void 0,then:function(a){l.push(a)}}}return Xi++,e.then(yo,yo),e}function yo(){if(--Xi===0&&en!==null){da!==null&&(da.status="fulfilled");var t=en;en=null,ba=0,da=null;for(var e=0;e<t.length;e++)(0,t[e])()}}function lv(t,e){var l=[],a={status:"pending",value:null,reason:null,then:function(n){l.push(n)}};return t.then(function(){a.status="fulfilled",a.value=e;for(var n=0;n<l.length;n++)(0,l[n])(e)},function(n){for(a.status="rejected",a.reason=n,n=0;n<l.length;n++)(0,l[n])(void 0)}),a}var ho=w.S;w.S=function(t,e){W1=Wt(),typeof e=="object"&&e!==null&&typeof e.then=="function"&&ev(t,e),ho!==null&&ho(t,e)};var Al=Se(null);function Ls(){var t=Al.current;return t!==null?t:P.pooledCache}function xu(t,e){e===null?tt(Al,Al.current):tt(Al,e.pool)}function qd(){var t=Ls();return t===null?null:{parent:ht._currentValue,pool:t}}var Oa=Error(j(460)),Zs=Error(j(474)),oc=Error(j(542)),Cu={then:function(){}};function go(t){return t=t.status,t==="fulfilled"||t==="rejected"}function Hd(t,e,l){switch(l=t[l],l===void 0?t.push(e):l!==e&&(e.then(Oe,Oe),e=l),e.status){case"fulfilled":return e.value;case"rejected":throw t=e.reason,po(t),t;default:if(typeof e.status=="string")e.then(Oe,Oe);else{if(t=P,t!==null&&100<t.shellSuspendCounter)throw Error(j(482));t=e,t.status="pending",t.then(function(a){if(e.status==="pending"){var n=e;n.status="fulfilled",n.value=a}},function(a){if(e.status==="pending"){var n=e;n.status="rejected",n.reason=a}})}switch(e.status){case"fulfilled":return e.value;case"rejected":throw t=e.reason,po(t),t}throw $l=e,Oa}}function jl(t){try{var e=t._init;return e(t._payload)}catch(l){throw l!==null&&typeof l=="object"&&typeof l.then=="function"?($l=l,Oa):l}}var $l=null;function bo(){if($l===null)throw Error(j(459));var t=$l;return $l=null,t}function po(t){if(t===Oa||t===oc)throw Error(j(483))}var xa=null,gn=0;function Jn(t){var e=gn;return gn+=1,xa===null&&(xa=[]),Hd(xa,t,e)}function Ua(t,e){e=e.props.ref,t.ref=e!==void 0?e:null}function Wn(t,e){throw e.$$typeof===Lx?Error(j(525)):(t=Object.prototype.toString.call(e),Error(j(31,t==="[object Object]"?"object with keys {"+Object.keys(e).join(", ")+"}":t)))}function Ud(t){function e(m,f){if(t){var v=m.deletions;v===null?(m.deletions=[f],m.flags|=16):v.push(f)}}function l(m,f){if(!t)return null;for(;f!==null;)e(m,f),f=f.sibling;return null}function a(m){for(var f=new Map;m!==null;)m.key!==null?f.set(m.key,m):f.set(m.index,m),m=m.sibling;return f}function n(m,f){return m=we(m,f),m.index=0,m.sibling=null,m}function u(m,f,v){return m.index=v,t?(v=m.alternate,v!==null?(v=v.index,v<f?(m.flags|=67108866,f):v):(m.flags|=67108866,f)):(m.flags|=1048576,f)}function c(m){return t&&m.alternate===null&&(m.flags|=67108866),m}function i(m,f,v,b){return f===null||f.tag!==6?(f=Hc(v,m.mode,b),f.return=m,f):(f=n(f,v),f.return=m,f)}function s(m,f,v,b){var z=v.type;return z===Fl?x(m,f,v.props.children,b,v.key):f!==null&&(f.elementType===z||typeof z=="object"&&z!==null&&z.$$typeof===Ve&&jl(z)===f.type)?(f=n(f,v.props),Ua(f,v),f.return=m,f):(f=du(v.type,v.key,v.props,null,m.mode,b),Ua(f,v),f.return=m,f)}function r(m,f,v,b){return f===null||f.tag!==4||f.stateNode.containerInfo!==v.containerInfo||f.stateNode.implementation!==v.implementation?(f=Uc(v,m.mode,b),f.return=m,f):(f=n(f,v.children||[]),f.return=m,f)}function x(m,f,v,b,z){return f===null||f.tag!==7?(f=Ml(v,m.mode,b,z),f.return=m,f):(f=n(f,v),f.return=m,f)}function h(m,f,v){if(typeof f=="string"&&f!==""||typeof f=="number"||typeof f=="bigint")return f=Hc(""+f,m.mode,v),f.return=m,f;if(typeof f=="object"&&f!==null){switch(f.$$typeof){case Ln:return v=du(f.type,f.key,f.props,null,m.mode,v),Ua(v,f),v.return=m,v;case Ya:return f=Uc(f,m.mode,v),f.return=m,f;case Ve:return f=jl(f),h(m,f,v)}if(Va(f)||Ra(f))return f=Ml(f,m.mode,v,null),f.return=m,f;if(typeof f.then=="function")return h(m,Jn(f),v);if(f.$$typeof===Ne)return h(m,Kn(m,f),v);Wn(m,f)}return null}function d(m,f,v,b){var z=f!==null?f.key:null;if(typeof v=="string"&&v!==""||typeof v=="number"||typeof v=="bigint")return z!==null?null:i(m,f,""+v,b);if(typeof v=="object"&&v!==null){switch(v.$$typeof){case Ln:return v.key===z?s(m,f,v,b):null;case Ya:return v.key===z?r(m,f,v,b):null;case Ve:return v=jl(v),d(m,f,v,b)}if(Va(v)||Ra(v))return z!==null?null:x(m,f,v,b,null);if(typeof v.then=="function")return d(m,f,Jn(v),b);if(v.$$typeof===Ne)return d(m,f,Kn(m,v),b);Wn(m,v)}return null}function y(m,f,v,b,z){if(typeof b=="string"&&b!==""||typeof b=="number"||typeof b=="bigint")return m=m.get(v)||null,i(f,m,""+b,z);if(typeof b=="object"&&b!==null){switch(b.$$typeof){case Ln:return m=m.get(b.key===null?v:b.key)||null,s(f,m,b,z);case Ya:return m=m.get(b.key===null?v:b.key)||null,r(f,m,b,z);case Ve:return b=jl(b),y(m,f,v,b,z)}if(Va(b)||Ra(b))return m=m.get(v)||null,x(f,m,b,z,null);if(typeof b.then=="function")return y(m,f,v,Jn(b),z);if(b.$$typeof===Ne)return y(m,f,v,Kn(f,b),z);Wn(f,b)}return null}function p(m,f,v,b){for(var z=null,N=null,E=f,M=f=0,T=null;E!==null&&M<v.length;M++){E.index>M?(T=E,E=null):T=E.sibling;var A=d(m,E,v[M],b);if(A===null){E===null&&(E=T);break}t&&E&&A.alternate===null&&e(m,E),f=u(A,f,M),N===null?z=A:N.sibling=A,N=A,E=T}if(M===v.length)return l(m,E),X&&Ae(m,M),z;if(E===null){for(;M<v.length;M++)E=h(m,v[M],b),E!==null&&(f=u(E,f,M),N===null?z=E:N.sibling=E,N=E);return X&&Ae(m,M),z}for(E=a(E);M<v.length;M++)T=y(E,m,M,v[M],b),T!==null&&(t&&T.alternate!==null&&E.delete(T.key===null?M:T.key),f=u(T,f,M),N===null?z=T:N.sibling=T,N=T);return t&&E.forEach(function(C){return e(m,C)}),X&&Ae(m,M),z}function S(m,f,v,b){if(v==null)throw Error(j(151));for(var z=null,N=null,E=f,M=f=0,T=null,A=v.next();E!==null&&!A.done;M++,A=v.next()){E.index>M?(T=E,E=null):T=E.sibling;var C=d(m,E,A.value,b);if(C===null){E===null&&(E=T);break}t&&E&&C.alternate===null&&e(m,E),f=u(C,f,M),N===null?z=C:N.sibling=C,N=C,E=T}if(A.done)return l(m,E),X&&Ae(m,M),z;if(E===null){for(;!A.done;M++,A=v.next())A=h(m,A.value,b),A!==null&&(f=u(A,f,M),N===null?z=A:N.sibling=A,N=A);return X&&Ae(m,M),z}for(E=a(E);!A.done;M++,A=v.next())A=y(E,m,M,A.value,b),A!==null&&(t&&A.alternate!==null&&E.delete(A.key===null?M:A.key),f=u(A,f,M),N===null?z=A:N.sibling=A,N=A);return t&&E.forEach(function(Z){return e(m,Z)}),X&&Ae(m,M),z}function k(m,f,v,b){if(typeof v=="object"&&v!==null&&v.type===Fl&&v.key===null&&(v=v.props.children),typeof v=="object"&&v!==null){switch(v.$$typeof){case Ln:t:{for(var z=v.key;f!==null;){if(f.key===z){if(z=v.type,z===Fl){if(f.tag===7){l(m,f.sibling),b=n(f,v.props.children),b.return=m,m=b;break t}}else if(f.elementType===z||typeof z=="object"&&z!==null&&z.$$typeof===Ve&&jl(z)===f.type){l(m,f.sibling),b=n(f,v.props),Ua(b,v),b.return=m,m=b;break t}l(m,f);break}else e(m,f);f=f.sibling}v.type===Fl?(b=Ml(v.props.children,m.mode,b,v.key),b.return=m,m=b):(b=du(v.type,v.key,v.props,null,m.mode,b),Ua(b,v),b.return=m,m=b)}return c(m);case Ya:t:{for(z=v.key;f!==null;){if(f.key===z)if(f.tag===4&&f.stateNode.containerInfo===v.containerInfo&&f.stateNode.implementation===v.implementation){l(m,f.sibling),b=n(f,v.children||[]),b.return=m,m=b;break t}else{l(m,f);break}else e(m,f);f=f.sibling}b=Uc(v,m.mode,b),b.return=m,m=b}return c(m);case Ve:return v=jl(v),k(m,f,v,b)}if(Va(v))return p(m,f,v,b);if(Ra(v)){if(z=Ra(v),typeof z!="function")throw Error(j(150));return v=z.call(v),S(m,f,v,b)}if(typeof v.then=="function")return k(m,f,Jn(v),b);if(v.$$typeof===Ne)return k(m,f,Kn(m,v),b);Wn(m,v)}return typeof v=="string"&&v!==""||typeof v=="number"||typeof v=="bigint"?(v=""+v,f!==null&&f.tag===6?(l(m,f.sibling),b=n(f,v),b.return=m,m=b):(l(m,f),b=Hc(v,m.mode,b),b.return=m,m=b),c(m)):l(m,f)}return function(m,f,v,b){try{gn=0;var z=k(m,f,v,b);return xa=null,z}catch(E){if(E===Oa||E===oc)throw E;var N=Kt(29,E,null,m.mode);return N.lanes=b,N.return=m,N}finally{}}}var wl=Ud(!0),Bd=Ud(!1),Qe=!1;function Gs(t){t.updateQueue={baseState:t.memoizedState,firstBaseUpdate:null,lastBaseUpdate:null,shared:{pending:null,lanes:0,hiddenCallbacks:null},callbacks:null}}function Li(t,e){t=t.updateQueue,e.updateQueue===t&&(e.updateQueue={baseState:t.baseState,firstBaseUpdate:t.firstBaseUpdate,lastBaseUpdate:t.lastBaseUpdate,shared:t.shared,callbacks:null})}function ul(t){return{lane:t,tag:0,payload:null,callback:null,next:null}}function cl(t,e,l){var a=t.updateQueue;if(a===null)return null;if(a=a.shared,G&2){var n=a.pending;return n===null?e.next=e:(e.next=n.next,n.next=e),a.pending=e,e=Ou(t),Od(t,null,l),e}return fc(t,a,e,l),Ou(t)}function ln(t,e,l){if(e=e.updateQueue,e!==null&&(e=e.shared,(l&4194048)!==0)){var a=e.lanes;a&=t.pendingLanes,l|=a,e.lanes=l,nd(t,l)}}function Xc(t,e){var l=t.updateQueue,a=t.alternate;if(a!==null&&(a=a.updateQueue,l===a)){var n=null,u=null;if(l=l.firstBaseUpdate,l!==null){do{var c={lane:l.lane,tag:l.tag,payload:l.payload,callback:null,next:null};u===null?n=u=c:u=u.next=c,l=l.next}while(l!==null);u===null?n=u=e:u=u.next=e}else n=u=e;l={baseState:a.baseState,firstBaseUpdate:n,lastBaseUpdate:u,shared:a.shared,callbacks:a.callbacks},t.updateQueue=l;return}t=l.lastBaseUpdate,t===null?l.firstBaseUpdate=e:t.next=e,l.lastBaseUpdate=e}var Zi=!1;function an(){if(Zi){var t=da;if(t!==null)throw t}}function nn(t,e,l,a){Zi=!1;var n=t.updateQueue;Qe=!1;var u=n.firstBaseUpdate,c=n.lastBaseUpdate,i=n.shared.pending;if(i!==null){n.shared.pending=null;var s=i,r=s.next;s.next=null,c===null?u=r:c.next=r,c=s;var x=t.alternate;x!==null&&(x=x.updateQueue,i=x.lastBaseUpdate,i!==c&&(i===null?x.firstBaseUpdate=r:i.next=r,x.lastBaseUpdate=s))}if(u!==null){var h=n.baseState;c=0,x=r=s=null,i=u;do{var d=i.lane&-536870913,y=d!==i.lane;if(y?(B&d)===d:(a&d)===d){d!==0&&d===ba&&(Zi=!0),x!==null&&(x=x.next={lane:0,tag:i.tag,payload:i.payload,callback:null,next:null});t:{var p=t,S=i;d=e;var k=l;switch(S.tag){case 1:if(p=S.payload,typeof p=="function"){h=p.call(k,h,d);break t}h=p;break t;case 3:p.flags=p.flags&-65537|128;case 0:if(p=S.payload,d=typeof p=="function"?p.call(k,h,d):p,d==null)break t;h=ct({},h,d);break t;case 2:Qe=!0}}d=i.callback,d!==null&&(t.flags|=64,y&&(t.flags|=8192),y=n.callbacks,y===null?n.callbacks=[d]:y.push(d))}else y={lane:d,tag:i.tag,payload:i.payload,callback:i.callback,next:null},x===null?(r=x=y,s=h):x=x.next=y,c|=d;if(i=i.next,i===null){if(i=n.shared.pending,i===null)break;y=i,i=y.next,y.next=null,n.lastBaseUpdate=y,n.shared.pending=null}}while(!0);x===null&&(s=h),n.baseState=s,n.firstBaseUpdate=r,n.lastBaseUpdate=x,u===null&&(n.shared.lanes=0),vl|=c,t.lanes=c,t.memoizedState=h}}function Xd(t,e){if(typeof t!="function")throw Error(j(191,t));t.call(e)}function Ld(t,e){var l=t.callbacks;if(l!==null)for(t.callbacks=null,t=0;t<l.length;t++)Xd(l[t],e)}var pa=Se(null),_u=Se(0);function So(t,e){t=Be,tt(_u,t),tt(pa,e),Be=t|e.baseLanes}function Gi(){tt(_u,Be),tt(pa,pa.current)}function Ys(){Be=_u.current,jt(pa),jt(_u)}var ee=Se(null),fe=null;function Je(t){var e=t.alternate;tt(rt,rt.current&1),tt(ee,t),fe===null&&(e===null||pa.current!==null||e.memoizedState!==null)&&(fe=t)}function Yi(t){tt(rt,rt.current),tt(ee,t),fe===null&&(fe=t)}function Zd(t){t.tag===22?(tt(rt,rt.current),tt(ee,t),fe===null&&(fe=t)):We()}function We(){tt(rt,rt.current),tt(ee,ee.current)}function Qt(t){jt(ee),fe===t&&(fe=null),jt(rt)}var rt=Se(0);function Ru(t){for(var e=t;e!==null;){if(e.tag===13){var l=e.memoizedState;if(l!==null&&(l=l.dehydrated,l===null||os(l)||rs(l)))return e}else if(e.tag===19&&(e.memoizedProps.revealOrder==="forwards"||e.memoizedProps.revealOrder==="backwards"||e.memoizedProps.revealOrder==="unstable_legacy-backwards"||e.memoizedProps.revealOrder==="together")){if(e.flags&128)return e}else if(e.child!==null){e.child.return=e,e=e.child;continue}if(e===t)break;for(;e.sibling===null;){if(e.return===null||e.return===t)return null;e=e.return}e.sibling.return=e.return,e=e.sibling}return null}var qe=0,q=null,F=null,vt=null,qu=!1,ma=!1,Cl=!1,Hu=0,bn=0,va=null,av=0;function st(){throw Error(j(321))}function Vs(t,e){if(e===null)return!1;for(var l=0;l<e.length&&l<t.length;l++)if(!te(t[l],e[l]))return!1;return!0}function Qs(t,e,l,a,n,u){return qe=u,q=e,e.memoizedState=null,e.updateQueue=null,e.lanes=0,w.H=t===null||t.memoizedState===null?p1:nf,Cl=!1,u=l(a,n),Cl=!1,ma&&(u=Yd(e,l,a,n)),Gd(t),u}function Gd(t){w.H=pn;var e=F!==null&&F.next!==null;if(qe=0,vt=F=q=null,qu=!1,bn=0,va=null,e)throw Error(j(300));t===null||gt||(t=t.dependencies,t!==null&&wu(t)&&(gt=!0))}function Yd(t,e,l,a){q=t;var n=0;do{if(ma&&(va=null),bn=0,ma=!1,25<=n)throw Error(j(301));if(n+=1,vt=F=null,t.updateQueue!=null){var u=t.updateQueue;u.lastEffect=null,u.events=null,u.stores=null,u.memoCache!=null&&(u.memoCache.index=0)}w.H=S1,u=e(l,a)}while(ma);return u}function nv(){var t=w.H,e=t.useState()[0];return e=typeof e.then=="function"?Cn(e):e,t=t.useState()[0],(F!==null?F.memoizedState:null)!==t&&(q.flags|=1024),e}function Ks(){var t=Hu!==0;return Hu=0,t}function Js(t,e,l){e.updateQueue=t.updateQueue,e.flags&=-2053,t.lanes&=~l}function Ws(t){if(qu){for(t=t.memoizedState;t!==null;){var e=t.queue;e!==null&&(e.pending=null),t=t.next}qu=!1}qe=0,vt=F=q=null,ma=!1,bn=Hu=0,va=null}function _t(){var t={memoizedState:null,baseState:null,baseQueue:null,queue:null,next:null};return vt===null?q.memoizedState=vt=t:vt=vt.next=t,vt}function dt(){if(F===null){var t=q.alternate;t=t!==null?t.memoizedState:null}else t=F.next;var e=vt===null?q.memoizedState:vt.next;if(e!==null)vt=e,F=t;else{if(t===null)throw q.alternate===null?Error(j(467)):Error(j(310));F=t,t={memoizedState:F.memoizedState,baseState:F.baseState,baseQueue:F.baseQueue,queue:F.queue,next:null},vt===null?q.memoizedState=vt=t:vt=vt.next=t}return vt}function rc(){return{lastEffect:null,events:null,stores:null,memoCache:null}}function Cn(t){var e=bn;return bn+=1,va===null&&(va=[]),t=Hd(va,t,e),e=q,(vt===null?e.memoizedState:vt.next)===null&&(e=e.alternate,w.H=e===null||e.memoizedState===null?p1:nf),t}function dc(t){if(t!==null&&typeof t=="object"){if(typeof t.then=="function")return Cn(t);if(t.$$typeof===Ne)return Ot(t)}throw Error(j(438,String(t)))}function Fs(t){var e=null,l=q.updateQueue;if(l!==null&&(e=l.memoCache),e==null){var a=q.alternate;a!==null&&(a=a.updateQueue,a!==null&&(a=a.memoCache,a!=null&&(e={data:a.data.map(function(n){return n.slice()}),index:0})))}if(e==null&&(e={data:[],index:0}),l===null&&(l=rc(),q.updateQueue=l),l.memoCache=e,l=e.data[e.index],l===void 0)for(l=e.data[e.index]=Array(t),a=0;a<t;a++)l[a]=Zx;return e.index++,l}function He(t,e){return typeof e=="function"?e(t):e}function mu(t){var e=dt();return Is(e,F,t)}function Is(t,e,l){var a=t.queue;if(a===null)throw Error(j(311));a.lastRenderedReducer=l;var n=t.baseQueue,u=a.pending;if(u!==null){if(n!==null){var c=n.next;n.next=u.next,u.next=c}e.baseQueue=n=u,a.pending=null}if(u=t.baseState,n===null)t.memoizedState=u;else{e=n.next;var i=c=null,s=null,r=e,x=!1;do{var h=r.lane&-536870913;if(h!==r.lane?(B&h)===h:(qe&h)===h){var d=r.revertLane;if(d===0)s!==null&&(s=s.next={lane:0,revertLane:0,gesture:null,action:r.action,hasEagerState:r.hasEagerState,eagerState:r.eagerState,next:null}),h===ba&&(x=!0);else if((qe&d)===d){r=r.next,d===ba&&(x=!0);continue}else h={lane:0,revertLane:r.revertLane,gesture:null,action:r.action,hasEagerState:r.hasEagerState,eagerState:r.eagerState,next:null},s===null?(i=s=h,c=u):s=s.next=h,q.lanes|=d,vl|=d;h=r.action,Cl&&l(u,h),u=r.hasEagerState?r.eagerState:l(u,h)}else d={lane:h,revertLane:r.revertLane,gesture:r.gesture,action:r.action,hasEagerState:r.hasEagerState,eagerState:r.eagerState,next:null},s===null?(i=s=d,c=u):s=s.next=d,q.lanes|=h,vl|=h;r=r.next}while(r!==null&&r!==e);if(s===null?c=u:s.next=i,!te(u,t.memoizedState)&&(gt=!0,x&&(l=da,l!==null)))throw l;t.memoizedState=u,t.baseState=c,t.baseQueue=s,a.lastRenderedState=u}return n===null&&(a.lanes=0),[t.memoizedState,a.dispatch]}function Lc(t){var e=dt(),l=e.queue;if(l===null)throw Error(j(311));l.lastRenderedReducer=t;var a=l.dispatch,n=l.pending,u=e.memoizedState;if(n!==null){l.pending=null;var c=n=n.next;do u=t(u,c.action),c=c.next;while(c!==n);te(u,e.memoizedState)||(gt=!0),e.memoizedState=u,e.baseQueue===null&&(e.baseState=u),l.lastRenderedState=u}return[u,a]}function Vd(t,e,l){var a=q,n=dt(),u=X;if(u){if(l===void 0)throw Error(j(407));l=l()}else l=e();var c=!te((F||n).memoizedState,l);if(c&&(n.memoizedState=l,gt=!0),n=n.queue,Ps(Jd.bind(null,a,n,t),[t]),n.getSnapshot!==e||c||vt!==null&&vt.memoizedState.tag&1){if(a.flags|=2048,Sa(9,{destroy:void 0},Kd.bind(null,a,n,l,e),null),P===null)throw Error(j(349));u||qe&127||Qd(a,e,l)}return l}function Qd(t,e,l){t.flags|=16384,t={getSnapshot:e,value:l},e=q.updateQueue,e===null?(e=rc(),q.updateQueue=e,e.stores=[t]):(l=e.stores,l===null?e.stores=[t]:l.push(t))}function Kd(t,e,l,a){e.value=l,e.getSnapshot=a,Wd(e)&&Fd(t)}function Jd(t,e,l){return l(function(){Wd(e)&&Fd(t)})}function Wd(t){var e=t.getSnapshot;t=t.value;try{var l=e();return!te(t,l)}catch{return!0}}function Fd(t){var e=Ul(t,2);e!==null&&Lt(e,t,2)}function Vi(t){var e=_t();if(typeof t=="function"){var l=t;if(t=l(),Cl){Ie(!0);try{l()}finally{Ie(!1)}}}return e.memoizedState=e.baseState=t,e.queue={pending:null,lanes:0,dispatch:null,lastRenderedReducer:He,lastRenderedState:t},e}function Id(t,e,l,a){return t.baseState=l,Is(t,F,typeof a=="function"?a:He)}function uv(t,e,l,a,n){if(mc(t))throw Error(j(485));if(t=e.action,t!==null){var u={payload:n,action:t,next:null,isTransition:!0,status:"pending",value:null,reason:null,listeners:[],then:function(c){u.listeners.push(c)}};w.T!==null?l(!0):u.isTransition=!1,a(u),l=e.pending,l===null?(u.next=e.pending=u,Pd(e,u)):(u.next=l.next,e.pending=l.next=u)}}function Pd(t,e){var l=e.action,a=e.payload,n=t.state;if(e.isTransition){var u=w.T,c={};w.T=c;try{var i=l(n,a),s=w.S;s!==null&&s(c,i),ko(t,e,i)}catch(r){Qi(t,e,r)}finally{u!==null&&c.types!==null&&(u.types=c.types),w.T=u}}else try{u=l(n,a),ko(t,e,u)}catch(r){Qi(t,e,r)}}function ko(t,e,l){l!==null&&typeof l=="object"&&typeof l.then=="function"?l.then(function(a){zo(t,e,a)},function(a){return Qi(t,e,a)}):zo(t,e,l)}function zo(t,e,l){e.status="fulfilled",e.value=l,t1(e),t.state=l,e=t.pending,e!==null&&(l=e.next,l===e?t.pending=null:(l=l.next,e.next=l,Pd(t,l)))}function Qi(t,e,l){var a=t.pending;if(t.pending=null,a!==null){a=a.next;do e.status="rejected",e.reason=l,t1(e),e=e.next;while(e!==a)}t.action=null}function t1(t){t=t.listeners;for(var e=0;e<t.length;e++)(0,t[e])()}function e1(t,e){return e}function jo(t,e){if(X){var l=P.formState;if(l!==null){t:{var a=q;if(X){if(at){e:{for(var n=at,u=se;n.nodeType!==8;){if(!u){n=null;break e}if(n=oe(n.nextSibling),n===null){n=null;break e}}u=n.data,n=u==="F!"||u==="F"?n:null}if(n){at=oe(n.nextSibling),a=n.data==="F!";break t}}xl(a)}a=!1}a&&(e=l[0])}}return l=_t(),l.memoizedState=l.baseState=e,a={pending:null,lanes:0,dispatch:null,lastRenderedReducer:e1,lastRenderedState:e},l.queue=a,l=h1.bind(null,q,a),a.dispatch=l,a=Vi(!1),u=af.bind(null,q,!1,a.queue),a=_t(),n={state:e,dispatch:null,action:t,pending:null},a.queue=n,l=uv.bind(null,q,n,u,l),n.dispatch=l,a.memoizedState=t,[e,l,!1]}function Eo(t){var e=dt();return l1(e,F,t)}function l1(t,e,l){if(e=Is(t,e,e1)[0],t=mu(He)[0],typeof e=="object"&&e!==null&&typeof e.then=="function")try{var a=Cn(e)}catch(c){throw c===Oa?oc:c}else a=e;e=dt();var n=e.queue,u=n.dispatch;return l!==e.memoizedState&&(q.flags|=2048,Sa(9,{destroy:void 0},cv.bind(null,n,l),null)),[a,u,t]}function cv(t,e){t.action=e}function To(t){var e=dt(),l=F;if(l!==null)return l1(e,l,t);dt(),e=e.memoizedState,l=dt();var a=l.queue.dispatch;return l.memoizedState=t,[e,a,!1]}function Sa(t,e,l,a){return t={tag:t,create:l,deps:a,inst:e,next:null},e=q.updateQueue,e===null&&(e=rc(),q.updateQueue=e),l=e.lastEffect,l===null?e.lastEffect=t.next=t:(a=l.next,l.next=t,t.next=a,e.lastEffect=t),t}function a1(){return dt().memoizedState}function vu(t,e,l,a){var n=_t();q.flags|=t,n.memoizedState=Sa(1|e,{destroy:void 0},l,a===void 0?null:a)}function xc(t,e,l,a){var n=dt();a=a===void 0?null:a;var u=n.memoizedState.inst;F!==null&&a!==null&&Vs(a,F.memoizedState.deps)?n.memoizedState=Sa(e,u,l,a):(q.flags|=t,n.memoizedState=Sa(1|e,u,l,a))}function Mo(t,e){vu(8390656,8,t,e)}function Ps(t,e){xc(2048,8,t,e)}function iv(t){q.flags|=4;var e=q.updateQueue;if(e===null)e=rc(),q.updateQueue=e,e.events=[t];else{var l=e.events;l===null?e.events=[t]:l.push(t)}}function n1(t){var e=dt().memoizedState;return iv({ref:e,nextImpl:t}),function(){if(G&2)throw Error(j(440));return e.impl.apply(void 0,arguments)}}function u1(t,e){return xc(4,2,t,e)}function c1(t,e){return xc(4,4,t,e)}function i1(t,e){if(typeof e=="function"){t=t();var l=e(t);return function(){typeof l=="function"?l():e(null)}}if(e!=null)return t=t(),e.current=t,function(){e.current=null}}function s1(t,e,l){l=l!=null?l.concat([t]):null,xc(4,4,i1.bind(null,e,t),l)}function tf(){}function f1(t,e){var l=dt();e=e===void 0?null:e;var a=l.memoizedState;return e!==null&&Vs(e,a[1])?a[0]:(l.memoizedState=[t,e],t)}function o1(t,e){var l=dt();e=e===void 0?null:e;var a=l.memoizedState;if(e!==null&&Vs(e,a[1]))return a[0];if(a=t(),Cl){Ie(!0);try{t()}finally{Ie(!1)}}return l.memoizedState=[a,e],a}function ef(t,e,l){return l===void 0||qe&1073741824&&!(B&261930)?t.memoizedState=e:(t.memoizedState=l,t=I1(),q.lanes|=t,vl|=t,l)}function r1(t,e,l,a){return te(l,e)?l:pa.current!==null?(t=ef(t,l,a),te(t,e)||(gt=!0),t):!(qe&42)||qe&1073741824&&!(B&261930)?(gt=!0,t.memoizedState=l):(t=I1(),q.lanes|=t,vl|=t,e)}function d1(t,e,l,a,n){var u=Y.p;Y.p=u!==0&&8>u?u:8;var c=w.T,i={};w.T=i,af(t,!1,e,l);try{var s=n(),r=w.S;if(r!==null&&r(i,s),s!==null&&typeof s=="object"&&typeof s.then=="function"){var x=lv(s,a);un(t,e,x,Pt(t))}else un(t,e,a,Pt(t))}catch(h){un(t,e,{then:function(){},status:"rejected",reason:h},Pt())}finally{Y.p=u,c!==null&&i.types!==null&&(c.types=i.types),w.T=c}}function sv(){}function Ki(t,e,l,a){if(t.tag!==5)throw Error(j(476));var n=x1(t).queue;d1(t,n,e,Tl,l===null?sv:function(){return m1(t),l(a)})}function x1(t){var e=t.memoizedState;if(e!==null)return e;e={memoizedState:Tl,baseState:Tl,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:He,lastRenderedState:Tl},next:null};var l={};return e.next={memoizedState:l,baseState:l,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:He,lastRenderedState:l},next:null},t.memoizedState=e,t=t.alternate,t!==null&&(t.memoizedState=e),e}function m1(t){var e=x1(t);e.next===null&&(e=t.alternate.memoizedState),un(t,e.next.queue,{},Pt())}function lf(){return Ot(zn)}function v1(){return dt().memoizedState}function y1(){return dt().memoizedState}function fv(t){for(var e=t.return;e!==null;){switch(e.tag){case 24:case 3:var l=Pt();t=ul(l);var a=cl(e,t,l);a!==null&&(Lt(a,e,l),ln(a,e,l)),e={cache:Xs()},t.payload=e;return}e=e.return}}function ov(t,e,l){var a=Pt();l={lane:a,revertLane:0,gesture:null,action:l,hasEagerState:!1,eagerState:null,next:null},mc(t)?g1(e,l):(l=qs(t,e,l,a),l!==null&&(Lt(l,t,a),b1(l,e,a)))}function h1(t,e,l){var a=Pt();un(t,e,l,a)}function un(t,e,l,a){var n={lane:a,revertLane:0,gesture:null,action:l,hasEagerState:!1,eagerState:null,next:null};if(mc(t))g1(e,n);else{var u=t.alternate;if(t.lanes===0&&(u===null||u.lanes===0)&&(u=e.lastRenderedReducer,u!==null))try{var c=e.lastRenderedState,i=u(c,l);if(n.hasEagerState=!0,n.eagerState=i,te(i,c))return fc(t,e,n,0),P===null&&sc(),!1}catch{}finally{}if(l=qs(t,e,n,a),l!==null)return Lt(l,t,a),b1(l,e,a),!0}return!1}function af(t,e,l,a){if(a={lane:2,revertLane:xf(),gesture:null,action:a,hasEagerState:!1,eagerState:null,next:null},mc(t)){if(e)throw Error(j(479))}else e=qs(t,l,a,2),e!==null&&Lt(e,t,2)}function mc(t){var e=t.alternate;return t===q||e!==null&&e===q}function g1(t,e){ma=qu=!0;var l=t.pending;l===null?e.next=e:(e.next=l.next,l.next=e),t.pending=e}function b1(t,e,l){if(l&4194048){var a=e.lanes;a&=t.pendingLanes,l|=a,e.lanes=l,nd(t,l)}}var pn={readContext:Ot,use:dc,useCallback:st,useContext:st,useEffect:st,useImperativeHandle:st,useLayoutEffect:st,useInsertionEffect:st,useMemo:st,useReducer:st,useRef:st,useState:st,useDebugValue:st,useDeferredValue:st,useTransition:st,useSyncExternalStore:st,useId:st,useHostTransitionStatus:st,useFormState:st,useActionState:st,useOptimistic:st,useMemoCache:st,useCacheRefresh:st};pn.useEffectEvent=st;var p1={readContext:Ot,use:dc,useCallback:function(t,e){return _t().memoizedState=[t,e===void 0?null:e],t},useContext:Ot,useEffect:Mo,useImperativeHandle:function(t,e,l){l=l!=null?l.concat([t]):null,vu(4194308,4,i1.bind(null,e,t),l)},useLayoutEffect:function(t,e){return vu(4194308,4,t,e)},useInsertionEffect:function(t,e){vu(4,2,t,e)},useMemo:function(t,e){var l=_t();e=e===void 0?null:e;var a=t();if(Cl){Ie(!0);try{t()}finally{Ie(!1)}}return l.memoizedState=[a,e],a},useReducer:function(t,e,l){var a=_t();if(l!==void 0){var n=l(e);if(Cl){Ie(!0);try{l(e)}finally{Ie(!1)}}}else n=e;return a.memoizedState=a.baseState=n,t={pending:null,lanes:0,dispatch:null,lastRenderedReducer:t,lastRenderedState:n},a.queue=t,t=t.dispatch=ov.bind(null,q,t),[a.memoizedState,t]},useRef:function(t){var e=_t();return t={current:t},e.memoizedState=t},useState:function(t){t=Vi(t);var e=t.queue,l=h1.bind(null,q,e);return e.dispatch=l,[t.memoizedState,l]},useDebugValue:tf,useDeferredValue:function(t,e){var l=_t();return ef(l,t,e)},useTransition:function(){var t=Vi(!1);return t=d1.bind(null,q,t.queue,!0,!1),_t().memoizedState=t,[!1,t]},useSyncExternalStore:function(t,e,l){var a=q,n=_t();if(X){if(l===void 0)throw Error(j(407));l=l()}else{if(l=e(),P===null)throw Error(j(349));B&127||Qd(a,e,l)}n.memoizedState=l;var u={value:l,getSnapshot:e};return n.queue=u,Mo(Jd.bind(null,a,u,t),[t]),a.flags|=2048,Sa(9,{destroy:void 0},Kd.bind(null,a,u,l,e),null),l},useId:function(){var t=_t(),e=P.identifierPrefix;if(X){var l=ge,a=he;l=(a&~(1<<32-It(a)-1)).toString(32)+l,e="_"+e+"R_"+l,l=Hu++,0<l&&(e+="H"+l.toString(32)),e+="_"}else l=av++,e="_"+e+"r_"+l.toString(32)+"_";return t.memoizedState=e},useHostTransitionStatus:lf,useFormState:jo,useActionState:jo,useOptimistic:function(t){var e=_t();e.memoizedState=e.baseState=t;var l={pending:null,lanes:0,dispatch:null,lastRenderedReducer:null,lastRenderedState:null};return e.queue=l,e=af.bind(null,q,!0,l),l.dispatch=e,[t,e]},useMemoCache:Fs,useCacheRefresh:function(){return _t().memoizedState=fv.bind(null,q)},useEffectEvent:function(t){var e=_t(),l={impl:t};return e.memoizedState=l,function(){if(G&2)throw Error(j(440));return l.impl.apply(void 0,arguments)}}},nf={readContext:Ot,use:dc,useCallback:f1,useContext:Ot,useEffect:Ps,useImperativeHandle:s1,useInsertionEffect:u1,useLayoutEffect:c1,useMemo:o1,useReducer:mu,useRef:a1,useState:function(){return mu(He)},useDebugValue:tf,useDeferredValue:function(t,e){var l=dt();return r1(l,F.memoizedState,t,e)},useTransition:function(){var t=mu(He)[0],e=dt().memoizedState;return[typeof t=="boolean"?t:Cn(t),e]},useSyncExternalStore:Vd,useId:v1,useHostTransitionStatus:lf,useFormState:Eo,useActionState:Eo,useOptimistic:function(t,e){var l=dt();return Id(l,F,t,e)},useMemoCache:Fs,useCacheRefresh:y1};nf.useEffectEvent=n1;var S1={readContext:Ot,use:dc,useCallback:f1,useContext:Ot,useEffect:Ps,useImperativeHandle:s1,useInsertionEffect:u1,useLayoutEffect:c1,useMemo:o1,useReducer:Lc,useRef:a1,useState:function(){return Lc(He)},useDebugValue:tf,useDeferredValue:function(t,e){var l=dt();return F===null?ef(l,t,e):r1(l,F.memoizedState,t,e)},useTransition:function(){var t=Lc(He)[0],e=dt().memoizedState;return[typeof t=="boolean"?t:Cn(t),e]},useSyncExternalStore:Vd,useId:v1,useHostTransitionStatus:lf,useFormState:To,useActionState:To,useOptimistic:function(t,e){var l=dt();return F!==null?Id(l,F,t,e):(l.baseState=t,[t,l.queue.dispatch])},useMemoCache:Fs,useCacheRefresh:y1};S1.useEffectEvent=n1;function Zc(t,e,l,a){e=t.memoizedState,l=l(a,e),l=l==null?e:ct({},e,l),t.memoizedState=l,t.lanes===0&&(t.updateQueue.baseState=l)}var Ji={enqueueSetState:function(t,e,l){t=t._reactInternals;var a=Pt(),n=ul(a);n.payload=e,l!=null&&(n.callback=l),e=cl(t,n,a),e!==null&&(Lt(e,t,a),ln(e,t,a))},enqueueReplaceState:function(t,e,l){t=t._reactInternals;var a=Pt(),n=ul(a);n.tag=1,n.payload=e,l!=null&&(n.callback=l),e=cl(t,n,a),e!==null&&(Lt(e,t,a),ln(e,t,a))},enqueueForceUpdate:function(t,e){t=t._reactInternals;var l=Pt(),a=ul(l);a.tag=2,e!=null&&(a.callback=e),e=cl(t,a,l),e!==null&&(Lt(e,t,l),ln(e,t,l))}};function Ao(t,e,l,a,n,u,c){return t=t.stateNode,typeof t.shouldComponentUpdate=="function"?t.shouldComponentUpdate(a,u,c):e.prototype&&e.prototype.isPureReactComponent?!vn(l,a)||!vn(n,u):!0}function $o(t,e,l,a){t=e.state,typeof e.componentWillReceiveProps=="function"&&e.componentWillReceiveProps(l,a),typeof e.UNSAFE_componentWillReceiveProps=="function"&&e.UNSAFE_componentWillReceiveProps(l,a),e.state!==t&&Ji.enqueueReplaceState(e,e.state,null)}function _l(t,e){var l=e;if("ref"in e){l={};for(var a in e)a!=="ref"&&(l[a]=e[a])}if(t=t.defaultProps){l===e&&(l=ct({},l));for(var n in t)l[n]===void 0&&(l[n]=t[n])}return l}function k1(t){Nu(t)}function z1(t){console.error(t)}function j1(t){Nu(t)}function Uu(t,e){try{var l=t.onUncaughtError;l(e.value,{componentStack:e.stack})}catch(a){setTimeout(function(){throw a})}}function No(t,e,l){try{var a=t.onCaughtError;a(l.value,{componentStack:l.stack,errorBoundary:e.tag===1?e.stateNode:null})}catch(n){setTimeout(function(){throw n})}}function Wi(t,e,l){return l=ul(l),l.tag=3,l.payload={element:null},l.callback=function(){Uu(t,e)},l}function E1(t){return t=ul(t),t.tag=3,t}function T1(t,e,l,a){var n=l.type.getDerivedStateFromError;if(typeof n=="function"){var u=a.value;t.payload=function(){return n(u)},t.callback=function(){No(e,l,a)}}var c=l.stateNode;c!==null&&typeof c.componentDidCatch=="function"&&(t.callback=function(){No(e,l,a),typeof n!="function"&&(il===null?il=new Set([this]):il.add(this));var i=a.stack;this.componentDidCatch(a.value,{componentStack:i!==null?i:""})})}function rv(t,e,l,a,n){if(l.flags|=32768,a!==null&&typeof a=="object"&&typeof a.then=="function"){if(e=l.alternate,e!==null&&Na(e,l,n,!0),l=ee.current,l!==null){switch(l.tag){case 31:case 13:return fe===null?Gu():l.alternate===null&&ft===0&&(ft=3),l.flags&=-257,l.flags|=65536,l.lanes=n,a===Cu?l.flags|=16384:(e=l.updateQueue,e===null?l.updateQueue=new Set([a]):e.add(a),ti(t,a,n)),!1;case 22:return l.flags|=65536,a===Cu?l.flags|=16384:(e=l.updateQueue,e===null?(e={transitions:null,markerInstances:null,retryQueue:new Set([a])},l.updateQueue=e):(l=e.retryQueue,l===null?e.retryQueue=new Set([a]):l.add(a)),ti(t,a,n)),!1}throw Error(j(435,l.tag))}return ti(t,a,n),Gu(),!1}if(X)return e=ee.current,e!==null?(!(e.flags&65536)&&(e.flags|=256),e.flags|=65536,e.lanes=n,a!==qi&&(t=Error(j(422),{cause:a}),hn(ie(t,l)))):(a!==qi&&(e=Error(j(423),{cause:a}),hn(ie(e,l))),t=t.current.alternate,t.flags|=65536,n&=-n,t.lanes|=n,a=ie(a,l),n=Wi(t.stateNode,a,n),Xc(t,n),ft!==4&&(ft=2)),!1;var u=Error(j(520),{cause:a});if(u=ie(u,l),fn===null?fn=[u]:fn.push(u),ft!==4&&(ft=2),e===null)return!0;a=ie(a,l),l=e;do{switch(l.tag){case 3:return l.flags|=65536,t=n&-n,l.lanes|=t,t=Wi(l.stateNode,a,t),Xc(l,t),!1;case 1:if(e=l.type,u=l.stateNode,(l.flags&128)===0&&(typeof e.getDerivedStateFromError=="function"||u!==null&&typeof u.componentDidCatch=="function"&&(il===null||!il.has(u))))return l.flags|=65536,n&=-n,l.lanes|=n,n=E1(n),T1(n,t,l,a),Xc(l,n),!1}l=l.return}while(l!==null);return!1}var uf=Error(j(461)),gt=!1;function At(t,e,l,a){e.child=t===null?Bd(e,null,l,a):wl(e,t.child,l,a)}function Oo(t,e,l,a,n){l=l.render;var u=e.ref;if("ref"in a){var c={};for(var i in a)i!=="ref"&&(c[i]=a[i])}else c=a;return Dl(e),a=Qs(t,e,l,c,u,n),i=Ks(),t!==null&&!gt?(Js(t,e,n),Ue(t,e,n)):(X&&i&&Us(e),e.flags|=1,At(t,e,a,n),e.child)}function Do(t,e,l,a,n){if(t===null){var u=l.type;return typeof u=="function"&&!Hs(u)&&u.defaultProps===void 0&&l.compare===null?(e.tag=15,e.type=u,M1(t,e,u,a,n)):(t=du(l.type,null,a,e,e.mode,n),t.ref=e.ref,t.return=e,e.child=t)}if(u=t.child,!cf(t,n)){var c=u.memoizedProps;if(l=l.compare,l=l!==null?l:vn,l(c,a)&&t.ref===e.ref)return Ue(t,e,n)}return e.flags|=1,t=we(u,a),t.ref=e.ref,t.return=e,e.child=t}function M1(t,e,l,a,n){if(t!==null){var u=t.memoizedProps;if(vn(u,a)&&t.ref===e.ref)if(gt=!1,e.pendingProps=a=u,cf(t,n))t.flags&131072&&(gt=!0);else return e.lanes=t.lanes,Ue(t,e,n)}return Fi(t,e,l,a,n)}function A1(t,e,l,a){var n=a.children,u=t!==null?t.memoizedState:null;if(t===null&&e.stateNode===null&&(e.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),a.mode==="hidden"){if(e.flags&128){if(u=u!==null?u.baseLanes|l:l,t!==null){for(a=e.child=t.child,n=0;a!==null;)n=n|a.lanes|a.childLanes,a=a.sibling;a=n&~u}else a=0,e.child=null;return wo(t,e,u,l,a)}if(l&536870912)e.memoizedState={baseLanes:0,cachePool:null},t!==null&&xu(e,u!==null?u.cachePool:null),u!==null?So(e,u):Gi(),Zd(e);else return a=e.lanes=536870912,wo(t,e,u!==null?u.baseLanes|l:l,l,a)}else u!==null?(xu(e,u.cachePool),So(e,u),We(),e.memoizedState=null):(t!==null&&xu(e,null),Gi(),We());return At(t,e,n,l),e.child}function Ka(t,e){return t!==null&&t.tag===22||e.stateNode!==null||(e.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),e.sibling}function wo(t,e,l,a,n){var u=Ls();return u=u===null?null:{parent:ht._currentValue,pool:u},e.memoizedState={baseLanes:l,cachePool:u},t!==null&&xu(e,null),Gi(),Zd(e),t!==null&&Na(t,e,a,!0),e.childLanes=n,null}function yu(t,e){return e=Bu({mode:e.mode,children:e.children},t.mode),e.ref=t.ref,t.child=e,e.return=t,e}function Co(t,e,l){return wl(e,t.child,null,l),t=yu(e,e.pendingProps),t.flags|=2,Qt(e),e.memoizedState=null,t}function dv(t,e,l){var a=e.pendingProps,n=(e.flags&128)!==0;if(e.flags&=-129,t===null){if(X){if(a.mode==="hidden")return t=yu(e,a),e.lanes=536870912,Ka(null,t);if(Yi(e),(t=at)?(t=p0(t,se),t=t!==null&&t.data==="&"?t:null,t!==null&&(e.memoizedState={dehydrated:t,treeContext:dl!==null?{id:he,overflow:ge}:null,retryLane:536870912,hydrationErrors:null},l=wd(t),l.return=e,e.child=l,Nt=e,at=null)):t=null,t===null)throw xl(e);return e.lanes=536870912,null}return yu(e,a)}var u=t.memoizedState;if(u!==null){var c=u.dehydrated;if(Yi(e),n)if(e.flags&256)e.flags&=-257,e=Co(t,e,l);else if(e.memoizedState!==null)e.child=t.child,e.flags|=128,e=null;else throw Error(j(558));else if(gt||Na(t,e,l,!1),n=(l&t.childLanes)!==0,gt||n){if(a=P,a!==null&&(c=ud(a,l),c!==0&&c!==u.retryLane))throw u.retryLane=c,Ul(t,c),Lt(a,t,c),uf;Gu(),e=Co(t,e,l)}else t=u.treeContext,at=oe(c.nextSibling),Nt=e,X=!0,nl=null,se=!1,t!==null&&_d(e,t),e=yu(e,a),e.flags|=4096;return e}return t=we(t.child,{mode:a.mode,children:a.children}),t.ref=e.ref,e.child=t,t.return=e,t}function hu(t,e){var l=e.ref;if(l===null)t!==null&&t.ref!==null&&(e.flags|=4194816);else{if(typeof l!="function"&&typeof l!="object")throw Error(j(284));(t===null||t.ref!==l)&&(e.flags|=4194816)}}function Fi(t,e,l,a,n){return Dl(e),l=Qs(t,e,l,a,void 0,n),a=Ks(),t!==null&&!gt?(Js(t,e,n),Ue(t,e,n)):(X&&a&&Us(e),e.flags|=1,At(t,e,l,n),e.child)}function _o(t,e,l,a,n,u){return Dl(e),e.updateQueue=null,l=Yd(e,a,l,n),Gd(t),a=Ks(),t!==null&&!gt?(Js(t,e,u),Ue(t,e,u)):(X&&a&&Us(e),e.flags|=1,At(t,e,l,u),e.child)}function Ro(t,e,l,a,n){if(Dl(e),e.stateNode===null){var u=ua,c=l.contextType;typeof c=="object"&&c!==null&&(u=Ot(c)),u=new l(a,u),e.memoizedState=u.state!==null&&u.state!==void 0?u.state:null,u.updater=Ji,e.stateNode=u,u._reactInternals=e,u=e.stateNode,u.props=a,u.state=e.memoizedState,u.refs={},Gs(e),c=l.contextType,u.context=typeof c=="object"&&c!==null?Ot(c):ua,u.state=e.memoizedState,c=l.getDerivedStateFromProps,typeof c=="function"&&(Zc(e,l,c,a),u.state=e.memoizedState),typeof l.getDerivedStateFromProps=="function"||typeof u.getSnapshotBeforeUpdate=="function"||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(c=u.state,typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount(),c!==u.state&&Ji.enqueueReplaceState(u,u.state,null),nn(e,a,u,n),an(),u.state=e.memoizedState),typeof u.componentDidMount=="function"&&(e.flags|=4194308),a=!0}else if(t===null){u=e.stateNode;var i=e.memoizedProps,s=_l(l,i);u.props=s;var r=u.context,x=l.contextType;c=ua,typeof x=="object"&&x!==null&&(c=Ot(x));var h=l.getDerivedStateFromProps;x=typeof h=="function"||typeof u.getSnapshotBeforeUpdate=="function",i=e.pendingProps!==i,x||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(i||r!==c)&&$o(e,u,a,c),Qe=!1;var d=e.memoizedState;u.state=d,nn(e,a,u,n),an(),r=e.memoizedState,i||d!==r||Qe?(typeof h=="function"&&(Zc(e,l,h,a),r=e.memoizedState),(s=Qe||Ao(e,l,s,a,d,r,c))?(x||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount()),typeof u.componentDidMount=="function"&&(e.flags|=4194308)):(typeof u.componentDidMount=="function"&&(e.flags|=4194308),e.memoizedProps=a,e.memoizedState=r),u.props=a,u.state=r,u.context=c,a=s):(typeof u.componentDidMount=="function"&&(e.flags|=4194308),a=!1)}else{u=e.stateNode,Li(t,e),c=e.memoizedProps,x=_l(l,c),u.props=x,h=e.pendingProps,d=u.context,r=l.contextType,s=ua,typeof r=="object"&&r!==null&&(s=Ot(r)),i=l.getDerivedStateFromProps,(r=typeof i=="function"||typeof u.getSnapshotBeforeUpdate=="function")||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(c!==h||d!==s)&&$o(e,u,a,s),Qe=!1,d=e.memoizedState,u.state=d,nn(e,a,u,n),an();var y=e.memoizedState;c!==h||d!==y||Qe||t!==null&&t.dependencies!==null&&wu(t.dependencies)?(typeof i=="function"&&(Zc(e,l,i,a),y=e.memoizedState),(x=Qe||Ao(e,l,x,a,d,y,s)||t!==null&&t.dependencies!==null&&wu(t.dependencies))?(r||typeof u.UNSAFE_componentWillUpdate!="function"&&typeof u.componentWillUpdate!="function"||(typeof u.componentWillUpdate=="function"&&u.componentWillUpdate(a,y,s),typeof u.UNSAFE_componentWillUpdate=="function"&&u.UNSAFE_componentWillUpdate(a,y,s)),typeof u.componentDidUpdate=="function"&&(e.flags|=4),typeof u.getSnapshotBeforeUpdate=="function"&&(e.flags|=1024)):(typeof u.componentDidUpdate!="function"||c===t.memoizedProps&&d===t.memoizedState||(e.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||c===t.memoizedProps&&d===t.memoizedState||(e.flags|=1024),e.memoizedProps=a,e.memoizedState=y),u.props=a,u.state=y,u.context=s,a=x):(typeof u.componentDidUpdate!="function"||c===t.memoizedProps&&d===t.memoizedState||(e.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||c===t.memoizedProps&&d===t.memoizedState||(e.flags|=1024),a=!1)}return u=a,hu(t,e),a=(e.flags&128)!==0,u||a?(u=e.stateNode,l=a&&typeof l.getDerivedStateFromError!="function"?null:u.render(),e.flags|=1,t!==null&&a?(e.child=wl(e,t.child,null,n),e.child=wl(e,null,l,n)):At(t,e,l,n),e.memoizedState=u.state,t=e.child):t=Ue(t,e,n),t}function qo(t,e,l,a){return Ol(),e.flags|=256,At(t,e,l,a),e.child}var Gc={dehydrated:null,treeContext:null,retryLane:0,hydrationErrors:null};function Yc(t){return{baseLanes:t,cachePool:qd()}}function Vc(t,e,l){return t=t!==null?t.childLanes&~l:0,e&&(t|=Jt),t}function $1(t,e,l){var a=e.pendingProps,n=!1,u=(e.flags&128)!==0,c;if((c=u)||(c=t!==null&&t.memoizedState===null?!1:(rt.current&2)!==0),c&&(n=!0,e.flags&=-129),c=(e.flags&32)!==0,e.flags&=-33,t===null){if(X){if(n?Je(e):We(),(t=at)?(t=p0(t,se),t=t!==null&&t.data!=="&"?t:null,t!==null&&(e.memoizedState={dehydrated:t,treeContext:dl!==null?{id:he,overflow:ge}:null,retryLane:536870912,hydrationErrors:null},l=wd(t),l.return=e,e.child=l,Nt=e,at=null)):t=null,t===null)throw xl(e);return rs(t)?e.lanes=32:e.lanes=536870912,null}var i=a.children;return a=a.fallback,n?(We(),n=e.mode,i=Bu({mode:"hidden",children:i},n),a=Ml(a,n,l,null),i.return=e,a.return=e,i.sibling=a,e.child=i,a=e.child,a.memoizedState=Yc(l),a.childLanes=Vc(t,c,l),e.memoizedState=Gc,Ka(null,a)):(Je(e),Ii(e,i))}var s=t.memoizedState;if(s!==null&&(i=s.dehydrated,i!==null)){if(u)e.flags&256?(Je(e),e.flags&=-257,e=Qc(t,e,l)):e.memoizedState!==null?(We(),e.child=t.child,e.flags|=128,e=null):(We(),i=a.fallback,n=e.mode,a=Bu({mode:"visible",children:a.children},n),i=Ml(i,n,l,null),i.flags|=2,a.return=e,i.return=e,a.sibling=i,e.child=a,wl(e,t.child,null,l),a=e.child,a.memoizedState=Yc(l),a.childLanes=Vc(t,c,l),e.memoizedState=Gc,e=Ka(null,a));else if(Je(e),rs(i)){if(c=i.nextSibling&&i.nextSibling.dataset,c)var r=c.dgst;c=r,a=Error(j(419)),a.stack="",a.digest=c,hn({value:a,source:null,stack:null}),e=Qc(t,e,l)}else if(gt||Na(t,e,l,!1),c=(l&t.childLanes)!==0,gt||c){if(c=P,c!==null&&(a=ud(c,l),a!==0&&a!==s.retryLane))throw s.retryLane=a,Ul(t,a),Lt(c,t,a),uf;os(i)||Gu(),e=Qc(t,e,l)}else os(i)?(e.flags|=192,e.child=t.child,e=null):(t=s.treeContext,at=oe(i.nextSibling),Nt=e,X=!0,nl=null,se=!1,t!==null&&_d(e,t),e=Ii(e,a.children),e.flags|=4096);return e}return n?(We(),i=a.fallback,n=e.mode,s=t.child,r=s.sibling,a=we(s,{mode:"hidden",children:a.children}),a.subtreeFlags=s.subtreeFlags&65011712,r!==null?i=we(r,i):(i=Ml(i,n,l,null),i.flags|=2),i.return=e,a.return=e,a.sibling=i,e.child=a,Ka(null,a),a=e.child,i=t.child.memoizedState,i===null?i=Yc(l):(n=i.cachePool,n!==null?(s=ht._currentValue,n=n.parent!==s?{parent:s,pool:s}:n):n=qd(),i={baseLanes:i.baseLanes|l,cachePool:n}),a.memoizedState=i,a.childLanes=Vc(t,c,l),e.memoizedState=Gc,Ka(t.child,a)):(Je(e),l=t.child,t=l.sibling,l=we(l,{mode:"visible",children:a.children}),l.return=e,l.sibling=null,t!==null&&(c=e.deletions,c===null?(e.deletions=[t],e.flags|=16):c.push(t)),e.child=l,e.memoizedState=null,l)}function Ii(t,e){return e=Bu({mode:"visible",children:e},t.mode),e.return=t,t.child=e}function Bu(t,e){return t=Kt(22,t,null,e),t.lanes=0,t}function Qc(t,e,l){return wl(e,t.child,null,l),t=Ii(e,e.pendingProps.children),t.flags|=2,e.memoizedState=null,t}function Ho(t,e,l){t.lanes|=e;var a=t.alternate;a!==null&&(a.lanes|=e),Ui(t.return,e,l)}function Kc(t,e,l,a,n,u){var c=t.memoizedState;c===null?t.memoizedState={isBackwards:e,rendering:null,renderingStartTime:0,last:a,tail:l,tailMode:n,treeForkCount:u}:(c.isBackwards=e,c.rendering=null,c.renderingStartTime=0,c.last=a,c.tail=l,c.tailMode=n,c.treeForkCount=u)}function N1(t,e,l){var a=e.pendingProps,n=a.revealOrder,u=a.tail;a=a.children;var c=rt.current,i=(c&2)!==0;if(i?(c=c&1|2,e.flags|=128):c&=1,tt(rt,c),At(t,e,a,l),a=X?yn:0,!i&&t!==null&&t.flags&128)t:for(t=e.child;t!==null;){if(t.tag===13)t.memoizedState!==null&&Ho(t,l,e);else if(t.tag===19)Ho(t,l,e);else if(t.child!==null){t.child.return=t,t=t.child;continue}if(t===e)break t;for(;t.sibling===null;){if(t.return===null||t.return===e)break t;t=t.return}t.sibling.return=t.return,t=t.sibling}switch(n){case"forwards":for(l=e.child,n=null;l!==null;)t=l.alternate,t!==null&&Ru(t)===null&&(n=l),l=l.sibling;l=n,l===null?(n=e.child,e.child=null):(n=l.sibling,l.sibling=null),Kc(e,!1,n,l,u,a);break;case"backwards":case"unstable_legacy-backwards":for(l=null,n=e.child,e.child=null;n!==null;){if(t=n.alternate,t!==null&&Ru(t)===null){e.child=n;break}t=n.sibling,n.sibling=l,l=n,n=t}Kc(e,!0,l,null,u,a);break;case"together":Kc(e,!1,null,null,void 0,a);break;default:e.memoizedState=null}return e.child}function Ue(t,e,l){if(t!==null&&(e.dependencies=t.dependencies),vl|=e.lanes,!(l&e.childLanes))if(t!==null){if(Na(t,e,l,!1),(l&e.childLanes)===0)return null}else return null;if(t!==null&&e.child!==t.child)throw Error(j(153));if(e.child!==null){for(t=e.child,l=we(t,t.pendingProps),e.child=l,l.return=e;t.sibling!==null;)t=t.sibling,l=l.sibling=we(t,t.pendingProps),l.return=e;l.sibling=null}return e.child}function cf(t,e){return t.lanes&e?!0:(t=t.dependencies,!!(t!==null&&wu(t)))}function xv(t,e,l){switch(e.tag){case 3:Tu(e,e.stateNode.containerInfo),Ke(e,ht,t.memoizedState.cache),Ol();break;case 27:case 5:Ti(e);break;case 4:Tu(e,e.stateNode.containerInfo);break;case 10:Ke(e,e.type,e.memoizedProps.value);break;case 31:if(e.memoizedState!==null)return e.flags|=128,Yi(e),null;break;case 13:var a=e.memoizedState;if(a!==null)return a.dehydrated!==null?(Je(e),e.flags|=128,null):l&e.child.childLanes?$1(t,e,l):(Je(e),t=Ue(t,e,l),t!==null?t.sibling:null);Je(e);break;case 19:var n=(t.flags&128)!==0;if(a=(l&e.childLanes)!==0,a||(Na(t,e,l,!1),a=(l&e.childLanes)!==0),n){if(a)return N1(t,e,l);e.flags|=128}if(n=e.memoizedState,n!==null&&(n.rendering=null,n.tail=null,n.lastEffect=null),tt(rt,rt.current),a)break;return null;case 22:return e.lanes=0,A1(t,e,l,e.pendingProps);case 24:Ke(e,ht,t.memoizedState.cache)}return Ue(t,e,l)}function O1(t,e,l){if(t!==null)if(t.memoizedProps!==e.pendingProps)gt=!0;else{if(!cf(t,l)&&!(e.flags&128))return gt=!1,xv(t,e,l);gt=!!(t.flags&131072)}else gt=!1,X&&e.flags&1048576&&Cd(e,yn,e.index);switch(e.lanes=0,e.tag){case 16:t:{var a=e.pendingProps;if(t=jl(e.elementType),e.type=t,typeof t=="function")Hs(t)?(a=_l(t,a),e.tag=1,e=Ro(null,e,t,a,l)):(e.tag=0,e=Fi(null,e,t,a,l));else{if(t!=null){var n=t.$$typeof;if(n===js){e.tag=11,e=Oo(null,e,t,a,l);break t}else if(n===Es){e.tag=14,e=Do(null,e,t,a,l);break t}}throw e=ji(t)||t,Error(j(306,e,""))}}return e;case 0:return Fi(t,e,e.type,e.pendingProps,l);case 1:return a=e.type,n=_l(a,e.pendingProps),Ro(t,e,a,n,l);case 3:t:{if(Tu(e,e.stateNode.containerInfo),t===null)throw Error(j(387));a=e.pendingProps;var u=e.memoizedState;n=u.element,Li(t,e),nn(e,a,null,l);var c=e.memoizedState;if(a=c.cache,Ke(e,ht,a),a!==u.cache&&Bi(e,[ht],l,!0),an(),a=c.element,u.isDehydrated)if(u={element:a,isDehydrated:!1,cache:c.cache},e.updateQueue.baseState=u,e.memoizedState=u,e.flags&256){e=qo(t,e,a,l);break t}else if(a!==n){n=ie(Error(j(424)),e),hn(n),e=qo(t,e,a,l);break t}else{switch(t=e.stateNode.containerInfo,t.nodeType){case 9:t=t.body;break;default:t=t.nodeName==="HTML"?t.ownerDocument.body:t}for(at=oe(t.firstChild),Nt=e,X=!0,nl=null,se=!0,l=Bd(e,null,a,l),e.child=l;l;)l.flags=l.flags&-3|4096,l=l.sibling}else{if(Ol(),a===n){e=Ue(t,e,l);break t}At(t,e,a,l)}e=e.child}return e;case 26:return hu(t,e),t===null?(l=nr(e.type,null,e.pendingProps,null))?e.memoizedState=l:X||(l=e.type,t=e.pendingProps,a=Ku(al.current).createElement(l),a[$t]=e,a[Zt]=t,Dt(a,l,t),zt(a),e.stateNode=a):e.memoizedState=nr(e.type,t.memoizedProps,e.pendingProps,t.memoizedState),null;case 27:return Ti(e),t===null&&X&&(a=e.stateNode=S0(e.type,e.pendingProps,al.current),Nt=e,se=!0,n=at,hl(e.type)?(ds=n,at=oe(a.firstChild)):at=n),At(t,e,e.pendingProps.children,l),hu(t,e),t===null&&(e.flags|=4194304),e.child;case 5:return t===null&&X&&((n=a=at)&&(a=Zv(a,e.type,e.pendingProps,se),a!==null?(e.stateNode=a,Nt=e,at=oe(a.firstChild),se=!1,n=!0):n=!1),n||xl(e)),Ti(e),n=e.type,u=e.pendingProps,c=t!==null?t.memoizedProps:null,a=u.children,ss(n,u)?a=null:c!==null&&ss(n,c)&&(e.flags|=32),e.memoizedState!==null&&(n=Qs(t,e,nv,null,null,l),zn._currentValue=n),hu(t,e),At(t,e,a,l),e.child;case 6:return t===null&&X&&((t=l=at)&&(l=Gv(l,e.pendingProps,se),l!==null?(e.stateNode=l,Nt=e,at=null,t=!0):t=!1),t||xl(e)),null;case 13:return $1(t,e,l);case 4:return Tu(e,e.stateNode.containerInfo),a=e.pendingProps,t===null?e.child=wl(e,null,a,l):At(t,e,a,l),e.child;case 11:return Oo(t,e,e.type,e.pendingProps,l);case 7:return At(t,e,e.pendingProps,l),e.child;case 8:return At(t,e,e.pendingProps.children,l),e.child;case 12:return At(t,e,e.pendingProps.children,l),e.child;case 10:return a=e.pendingProps,Ke(e,e.type,a.value),At(t,e,a.children,l),e.child;case 9:return n=e.type._context,a=e.pendingProps.children,Dl(e),n=Ot(n),a=a(n),e.flags|=1,At(t,e,a,l),e.child;case 14:return Do(t,e,e.type,e.pendingProps,l);case 15:return M1(t,e,e.type,e.pendingProps,l);case 19:return N1(t,e,l);case 31:return dv(t,e,l);case 22:return A1(t,e,l,e.pendingProps);case 24:return Dl(e),a=Ot(ht),t===null?(n=Ls(),n===null&&(n=P,u=Xs(),n.pooledCache=u,u.refCount++,u!==null&&(n.pooledCacheLanes|=l),n=u),e.memoizedState={parent:a,cache:n},Gs(e),Ke(e,ht,n)):(t.lanes&l&&(Li(t,e),nn(e,null,null,l),an()),n=t.memoizedState,u=e.memoizedState,n.parent!==a?(n={parent:a,cache:a},e.memoizedState=n,e.lanes===0&&(e.memoizedState=e.updateQueue.baseState=n),Ke(e,ht,a)):(a=u.cache,Ke(e,ht,a),a!==n.cache&&Bi(e,[ht],l,!0))),At(t,e,e.pendingProps.children,l),e.child;case 29:throw e.pendingProps}throw Error(j(156,e.tag))}function je(t){t.flags|=4}function Jc(t,e,l,a,n){if((e=(t.mode&32)!==0)&&(e=!1),e){if(t.flags|=16777216,(n&335544128)===n)if(t.stateNode.complete)t.flags|=8192;else if(e0())t.flags|=8192;else throw $l=Cu,Zs}else t.flags&=-16777217}function Uo(t,e){if(e.type!=="stylesheet"||e.state.loading&4)t.flags&=-16777217;else if(t.flags|=16777216,!j0(e))if(e0())t.flags|=8192;else throw $l=Cu,Zs}function Fn(t,e){e!==null&&(t.flags|=4),t.flags&16384&&(e=t.tag!==22?ld():536870912,t.lanes|=e,ka|=e)}function Ba(t,e){if(!X)switch(t.tailMode){case"hidden":e=t.tail;for(var l=null;e!==null;)e.alternate!==null&&(l=e),e=e.sibling;l===null?t.tail=null:l.sibling=null;break;case"collapsed":l=t.tail;for(var a=null;l!==null;)l.alternate!==null&&(a=l),l=l.sibling;a===null?e||t.tail===null?t.tail=null:t.tail.sibling=null:a.sibling=null}}function lt(t){var e=t.alternate!==null&&t.alternate.child===t.child,l=0,a=0;if(e)for(var n=t.child;n!==null;)l|=n.lanes|n.childLanes,a|=n.subtreeFlags&65011712,a|=n.flags&65011712,n.return=t,n=n.sibling;else for(n=t.child;n!==null;)l|=n.lanes|n.childLanes,a|=n.subtreeFlags,a|=n.flags,n.return=t,n=n.sibling;return t.subtreeFlags|=a,t.childLanes=l,e}function mv(t,e,l){var a=e.pendingProps;switch(Bs(e),e.tag){case 16:case 15:case 0:case 11:case 7:case 8:case 12:case 9:case 14:return lt(e),null;case 1:return lt(e),null;case 3:return l=e.stateNode,a=null,t!==null&&(a=t.memoizedState.cache),e.memoizedState.cache!==a&&(e.flags|=2048),Ce(ht),ya(),l.pendingContext&&(l.context=l.pendingContext,l.pendingContext=null),(t===null||t.child===null)&&(Ll(e)?je(e):t===null||t.memoizedState.isDehydrated&&!(e.flags&256)||(e.flags|=1024,Bc())),lt(e),null;case 26:var n=e.type,u=e.memoizedState;return t===null?(je(e),u!==null?(lt(e),Uo(e,u)):(lt(e),Jc(e,n,null,a,l))):u?u!==t.memoizedState?(je(e),lt(e),Uo(e,u)):(lt(e),e.flags&=-16777217):(t=t.memoizedProps,t!==a&&je(e),lt(e),Jc(e,n,t,a,l)),null;case 27:if(Mu(e),l=al.current,n=e.type,t!==null&&e.stateNode!=null)t.memoizedProps!==a&&je(e);else{if(!a){if(e.stateNode===null)throw Error(j(166));return lt(e),null}t=pe.current,Ll(e)?mo(e):(t=S0(n,a,l),e.stateNode=t,je(e))}return lt(e),null;case 5:if(Mu(e),n=e.type,t!==null&&e.stateNode!=null)t.memoizedProps!==a&&je(e);else{if(!a){if(e.stateNode===null)throw Error(j(166));return lt(e),null}if(u=pe.current,Ll(e))mo(e);else{var c=Ku(al.current);switch(u){case 1:u=c.createElementNS("http://www.w3.org/2000/svg",n);break;case 2:u=c.createElementNS("http://www.w3.org/1998/Math/MathML",n);break;default:switch(n){case"svg":u=c.createElementNS("http://www.w3.org/2000/svg",n);break;case"math":u=c.createElementNS("http://www.w3.org/1998/Math/MathML",n);break;case"script":u=c.createElement("div"),u.innerHTML="<script><\/script>",u=u.removeChild(u.firstChild);break;case"select":u=typeof a.is=="string"?c.createElement("select",{is:a.is}):c.createElement("select"),a.multiple?u.multiple=!0:a.size&&(u.size=a.size);break;default:u=typeof a.is=="string"?c.createElement(n,{is:a.is}):c.createElement(n)}}u[$t]=e,u[Zt]=a;t:for(c=e.child;c!==null;){if(c.tag===5||c.tag===6)u.appendChild(c.stateNode);else if(c.tag!==4&&c.tag!==27&&c.child!==null){c.child.return=c,c=c.child;continue}if(c===e)break t;for(;c.sibling===null;){if(c.return===null||c.return===e)break t;c=c.return}c.sibling.return=c.return,c=c.sibling}e.stateNode=u;t:switch(Dt(u,n,a),n){case"button":case"input":case"select":case"textarea":a=!!a.autoFocus;break t;case"img":a=!0;break t;default:a=!1}a&&je(e)}}return lt(e),Jc(e,e.type,t===null?null:t.memoizedProps,e.pendingProps,l),null;case 6:if(t&&e.stateNode!=null)t.memoizedProps!==a&&je(e);else{if(typeof a!="string"&&e.stateNode===null)throw Error(j(166));if(t=al.current,Ll(e)){if(t=e.stateNode,l=e.memoizedProps,a=null,n=Nt,n!==null)switch(n.tag){case 27:case 5:a=n.memoizedProps}t[$t]=e,t=!!(t.nodeValue===l||a!==null&&a.suppressHydrationWarning===!0||h0(t.nodeValue,l)),t||xl(e,!0)}else t=Ku(t).createTextNode(a),t[$t]=e,e.stateNode=t}return lt(e),null;case 31:if(l=e.memoizedState,t===null||t.memoizedState!==null){if(a=Ll(e),l!==null){if(t===null){if(!a)throw Error(j(318));if(t=e.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(j(557));t[$t]=e}else Ol(),!(e.flags&128)&&(e.memoizedState=null),e.flags|=4;lt(e),t=!1}else l=Bc(),t!==null&&t.memoizedState!==null&&(t.memoizedState.hydrationErrors=l),t=!0;if(!t)return e.flags&256?(Qt(e),e):(Qt(e),null);if(e.flags&128)throw Error(j(558))}return lt(e),null;case 13:if(a=e.memoizedState,t===null||t.memoizedState!==null&&t.memoizedState.dehydrated!==null){if(n=Ll(e),a!==null&&a.dehydrated!==null){if(t===null){if(!n)throw Error(j(318));if(n=e.memoizedState,n=n!==null?n.dehydrated:null,!n)throw Error(j(317));n[$t]=e}else Ol(),!(e.flags&128)&&(e.memoizedState=null),e.flags|=4;lt(e),n=!1}else n=Bc(),t!==null&&t.memoizedState!==null&&(t.memoizedState.hydrationErrors=n),n=!0;if(!n)return e.flags&256?(Qt(e),e):(Qt(e),null)}return Qt(e),e.flags&128?(e.lanes=l,e):(l=a!==null,t=t!==null&&t.memoizedState!==null,l&&(a=e.child,n=null,a.alternate!==null&&a.alternate.memoizedState!==null&&a.alternate.memoizedState.cachePool!==null&&(n=a.alternate.memoizedState.cachePool.pool),u=null,a.memoizedState!==null&&a.memoizedState.cachePool!==null&&(u=a.memoizedState.cachePool.pool),u!==n&&(a.flags|=2048)),l!==t&&l&&(e.child.flags|=8192),Fn(e,e.updateQueue),lt(e),null);case 4:return ya(),t===null&&mf(e.stateNode.containerInfo),lt(e),null;case 10:return Ce(e.type),lt(e),null;case 19:if(jt(rt),a=e.memoizedState,a===null)return lt(e),null;if(n=(e.flags&128)!==0,u=a.rendering,u===null)if(n)Ba(a,!1);else{if(ft!==0||t!==null&&t.flags&128)for(t=e.child;t!==null;){if(u=Ru(t),u!==null){for(e.flags|=128,Ba(a,!1),t=u.updateQueue,e.updateQueue=t,Fn(e,t),e.subtreeFlags=0,t=l,l=e.child;l!==null;)Dd(l,t),l=l.sibling;return tt(rt,rt.current&1|2),X&&Ae(e,a.treeForkCount),e.child}t=t.sibling}a.tail!==null&&Wt()>Lu&&(e.flags|=128,n=!0,Ba(a,!1),e.lanes=4194304)}else{if(!n)if(t=Ru(u),t!==null){if(e.flags|=128,n=!0,t=t.updateQueue,e.updateQueue=t,Fn(e,t),Ba(a,!0),a.tail===null&&a.tailMode==="hidden"&&!u.alternate&&!X)return lt(e),null}else 2*Wt()-a.renderingStartTime>Lu&&l!==536870912&&(e.flags|=128,n=!0,Ba(a,!1),e.lanes=4194304);a.isBackwards?(u.sibling=e.child,e.child=u):(t=a.last,t!==null?t.sibling=u:e.child=u,a.last=u)}return a.tail!==null?(t=a.tail,a.rendering=t,a.tail=t.sibling,a.renderingStartTime=Wt(),t.sibling=null,l=rt.current,tt(rt,n?l&1|2:l&1),X&&Ae(e,a.treeForkCount),t):(lt(e),null);case 22:case 23:return Qt(e),Ys(),a=e.memoizedState!==null,t!==null?t.memoizedState!==null!==a&&(e.flags|=8192):a&&(e.flags|=8192),a?l&536870912&&!(e.flags&128)&&(lt(e),e.subtreeFlags&6&&(e.flags|=8192)):lt(e),l=e.updateQueue,l!==null&&Fn(e,l.retryQueue),l=null,t!==null&&t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(l=t.memoizedState.cachePool.pool),a=null,e.memoizedState!==null&&e.memoizedState.cachePool!==null&&(a=e.memoizedState.cachePool.pool),a!==l&&(e.flags|=2048),t!==null&&jt(Al),null;case 24:return l=null,t!==null&&(l=t.memoizedState.cache),e.memoizedState.cache!==l&&(e.flags|=2048),Ce(ht),lt(e),null;case 25:return null;case 30:return null}throw Error(j(156,e.tag))}function vv(t,e){switch(Bs(e),e.tag){case 1:return t=e.flags,t&65536?(e.flags=t&-65537|128,e):null;case 3:return Ce(ht),ya(),t=e.flags,t&65536&&!(t&128)?(e.flags=t&-65537|128,e):null;case 26:case 27:case 5:return Mu(e),null;case 31:if(e.memoizedState!==null){if(Qt(e),e.alternate===null)throw Error(j(340));Ol()}return t=e.flags,t&65536?(e.flags=t&-65537|128,e):null;case 13:if(Qt(e),t=e.memoizedState,t!==null&&t.dehydrated!==null){if(e.alternate===null)throw Error(j(340));Ol()}return t=e.flags,t&65536?(e.flags=t&-65537|128,e):null;case 19:return jt(rt),null;case 4:return ya(),null;case 10:return Ce(e.type),null;case 22:case 23:return Qt(e),Ys(),t!==null&&jt(Al),t=e.flags,t&65536?(e.flags=t&-65537|128,e):null;case 24:return Ce(ht),null;case 25:return null;default:return null}}function D1(t,e){switch(Bs(e),e.tag){case 3:Ce(ht),ya();break;case 26:case 27:case 5:Mu(e);break;case 4:ya();break;case 31:e.memoizedState!==null&&Qt(e);break;case 13:Qt(e);break;case 19:jt(rt);break;case 10:Ce(e.type);break;case 22:case 23:Qt(e),Ys(),t!==null&&jt(Al);break;case 24:Ce(ht)}}function _n(t,e){try{var l=e.updateQueue,a=l!==null?l.lastEffect:null;if(a!==null){var n=a.next;l=n;do{if((l.tag&t)===t){a=void 0;var u=l.create,c=l.inst;a=u(),c.destroy=a}l=l.next}while(l!==n)}}catch(i){K(e,e.return,i)}}function ml(t,e,l){try{var a=e.updateQueue,n=a!==null?a.lastEffect:null;if(n!==null){var u=n.next;a=u;do{if((a.tag&t)===t){var c=a.inst,i=c.destroy;if(i!==void 0){c.destroy=void 0,n=e;var s=l,r=i;try{r()}catch(x){K(n,s,x)}}}a=a.next}while(a!==u)}}catch(x){K(e,e.return,x)}}function w1(t){var e=t.updateQueue;if(e!==null){var l=t.stateNode;try{Ld(e,l)}catch(a){K(t,t.return,a)}}}function C1(t,e,l){l.props=_l(t.type,t.memoizedProps),l.state=t.memoizedState;try{l.componentWillUnmount()}catch(a){K(t,e,a)}}function cn(t,e){try{var l=t.ref;if(l!==null){switch(t.tag){case 26:case 27:case 5:var a=t.stateNode;break;case 30:a=t.stateNode;break;default:a=t.stateNode}typeof l=="function"?t.refCleanup=l(a):l.current=a}}catch(n){K(t,e,n)}}function be(t,e){var l=t.ref,a=t.refCleanup;if(l!==null)if(typeof a=="function")try{a()}catch(n){K(t,e,n)}finally{t.refCleanup=null,t=t.alternate,t!=null&&(t.refCleanup=null)}else if(typeof l=="function")try{l(null)}catch(n){K(t,e,n)}else l.current=null}function _1(t){var e=t.type,l=t.memoizedProps,a=t.stateNode;try{t:switch(e){case"button":case"input":case"select":case"textarea":l.autoFocus&&a.focus();break t;case"img":l.src?a.src=l.src:l.srcSet&&(a.srcset=l.srcSet)}}catch(n){K(t,t.return,n)}}function Wc(t,e,l){try{var a=t.stateNode;qv(a,t.type,l,e),a[Zt]=e}catch(n){K(t,t.return,n)}}function R1(t){return t.tag===5||t.tag===3||t.tag===26||t.tag===27&&hl(t.type)||t.tag===4}function Fc(t){t:for(;;){for(;t.sibling===null;){if(t.return===null||R1(t.return))return null;t=t.return}for(t.sibling.return=t.return,t=t.sibling;t.tag!==5&&t.tag!==6&&t.tag!==18;){if(t.tag===27&&hl(t.type)||t.flags&2||t.child===null||t.tag===4)continue t;t.child.return=t,t=t.child}if(!(t.flags&2))return t.stateNode}}function Pi(t,e,l){var a=t.tag;if(a===5||a===6)t=t.stateNode,e?(l.nodeType===9?l.body:l.nodeName==="HTML"?l.ownerDocument.body:l).insertBefore(t,e):(e=l.nodeType===9?l.body:l.nodeName==="HTML"?l.ownerDocument.body:l,e.appendChild(t),l=l._reactRootContainer,l!=null||e.onclick!==null||(e.onclick=Oe));else if(a!==4&&(a===27&&hl(t.type)&&(l=t.stateNode,e=null),t=t.child,t!==null))for(Pi(t,e,l),t=t.sibling;t!==null;)Pi(t,e,l),t=t.sibling}function Xu(t,e,l){var a=t.tag;if(a===5||a===6)t=t.stateNode,e?l.insertBefore(t,e):l.appendChild(t);else if(a!==4&&(a===27&&hl(t.type)&&(l=t.stateNode),t=t.child,t!==null))for(Xu(t,e,l),t=t.sibling;t!==null;)Xu(t,e,l),t=t.sibling}function q1(t){var e=t.stateNode,l=t.memoizedProps;try{for(var a=t.type,n=e.attributes;n.length;)e.removeAttributeNode(n[0]);Dt(e,a,l),e[$t]=t,e[Zt]=l}catch(u){K(t,t.return,u)}}var $e=!1,yt=!1,Ic=!1,Bo=typeof WeakSet=="function"?WeakSet:Set,kt=null;function yv(t,e){if(t=t.containerInfo,cs=Iu,t=jd(t),_s(t)){if("selectionStart"in t)var l={start:t.selectionStart,end:t.selectionEnd};else t:{l=(l=t.ownerDocument)&&l.defaultView||window;var a=l.getSelection&&l.getSelection();if(a&&a.rangeCount!==0){l=a.anchorNode;var n=a.anchorOffset,u=a.focusNode;a=a.focusOffset;try{l.nodeType,u.nodeType}catch{l=null;break t}var c=0,i=-1,s=-1,r=0,x=0,h=t,d=null;e:for(;;){for(var y;h!==l||n!==0&&h.nodeType!==3||(i=c+n),h!==u||a!==0&&h.nodeType!==3||(s=c+a),h.nodeType===3&&(c+=h.nodeValue.length),(y=h.firstChild)!==null;)d=h,h=y;for(;;){if(h===t)break e;if(d===l&&++r===n&&(i=c),d===u&&++x===a&&(s=c),(y=h.nextSibling)!==null)break;h=d,d=h.parentNode}h=y}l=i===-1||s===-1?null:{start:i,end:s}}else l=null}l=l||{start:0,end:0}}else l=null;for(is={focusedElem:t,selectionRange:l},Iu=!1,kt=e;kt!==null;)if(e=kt,t=e.child,(e.subtreeFlags&1028)!==0&&t!==null)t.return=e,kt=t;else for(;kt!==null;){switch(e=kt,u=e.alternate,t=e.flags,e.tag){case 0:if(t&4&&(t=e.updateQueue,t=t!==null?t.events:null,t!==null))for(l=0;l<t.length;l++)n=t[l],n.ref.impl=n.nextImpl;break;case 11:case 15:break;case 1:if(t&1024&&u!==null){t=void 0,l=e,n=u.memoizedProps,u=u.memoizedState,a=l.stateNode;try{var p=_l(l.type,n);t=a.getSnapshotBeforeUpdate(p,u),a.__reactInternalSnapshotBeforeUpdate=t}catch(S){K(l,l.return,S)}}break;case 3:if(t&1024){if(t=e.stateNode.containerInfo,l=t.nodeType,l===9)fs(t);else if(l===1)switch(t.nodeName){case"HEAD":case"HTML":case"BODY":fs(t);break;default:t.textContent=""}}break;case 5:case 26:case 27:case 6:case 4:case 17:break;default:if(t&1024)throw Error(j(163))}if(t=e.sibling,t!==null){t.return=e.return,kt=t;break}kt=e.return}}function H1(t,e,l){var a=l.flags;switch(l.tag){case 0:case 11:case 15:Te(t,l),a&4&&_n(5,l);break;case 1:if(Te(t,l),a&4)if(t=l.stateNode,e===null)try{t.componentDidMount()}catch(c){K(l,l.return,c)}else{var n=_l(l.type,e.memoizedProps);e=e.memoizedState;try{t.componentDidUpdate(n,e,t.__reactInternalSnapshotBeforeUpdate)}catch(c){K(l,l.return,c)}}a&64&&w1(l),a&512&&cn(l,l.return);break;case 3:if(Te(t,l),a&64&&(t=l.updateQueue,t!==null)){if(e=null,l.child!==null)switch(l.child.tag){case 27:case 5:e=l.child.stateNode;break;case 1:e=l.child.stateNode}try{Ld(t,e)}catch(c){K(l,l.return,c)}}break;case 27:e===null&&a&4&&q1(l);case 26:case 5:Te(t,l),e===null&&a&4&&_1(l),a&512&&cn(l,l.return);break;case 12:Te(t,l);break;case 31:Te(t,l),a&4&&X1(t,l);break;case 13:Te(t,l),a&4&&L1(t,l),a&64&&(t=l.memoizedState,t!==null&&(t=t.dehydrated,t!==null&&(l=Ev.bind(null,l),Yv(t,l))));break;case 22:if(a=l.memoizedState!==null||$e,!a){e=e!==null&&e.memoizedState!==null||yt,n=$e;var u=yt;$e=a,(yt=e)&&!u?Me(t,l,(l.subtreeFlags&8772)!==0):Te(t,l),$e=n,yt=u}break;case 30:break;default:Te(t,l)}}function U1(t){var e=t.alternate;e!==null&&(t.alternate=null,U1(e)),t.child=null,t.deletions=null,t.sibling=null,t.tag===5&&(e=t.stateNode,e!==null&&$s(e)),t.stateNode=null,t.return=null,t.dependencies=null,t.memoizedProps=null,t.memoizedState=null,t.pendingProps=null,t.stateNode=null,t.updateQueue=null}var it=null,Bt=!1;function Ee(t,e,l){for(l=l.child;l!==null;)B1(t,e,l),l=l.sibling}function B1(t,e,l){if(Ft&&typeof Ft.onCommitFiberUnmount=="function")try{Ft.onCommitFiberUnmount(An,l)}catch{}switch(l.tag){case 26:yt||be(l,e),Ee(t,e,l),l.memoizedState?l.memoizedState.count--:l.stateNode&&(l=l.stateNode,l.parentNode.removeChild(l));break;case 27:yt||be(l,e);var a=it,n=Bt;hl(l.type)&&(it=l.stateNode,Bt=!1),Ee(t,e,l),rn(l.stateNode),it=a,Bt=n;break;case 5:yt||be(l,e);case 6:if(a=it,n=Bt,it=null,Ee(t,e,l),it=a,Bt=n,it!==null)if(Bt)try{(it.nodeType===9?it.body:it.nodeName==="HTML"?it.ownerDocument.body:it).removeChild(l.stateNode)}catch(u){K(l,e,u)}else try{it.removeChild(l.stateNode)}catch(u){K(l,e,u)}break;case 18:it!==null&&(Bt?(t=it,Po(t.nodeType===9?t.body:t.nodeName==="HTML"?t.ownerDocument.body:t,l.stateNode),Ta(t)):Po(it,l.stateNode));break;case 4:a=it,n=Bt,it=l.stateNode.containerInfo,Bt=!0,Ee(t,e,l),it=a,Bt=n;break;case 0:case 11:case 14:case 15:ml(2,l,e),yt||ml(4,l,e),Ee(t,e,l);break;case 1:yt||(be(l,e),a=l.stateNode,typeof a.componentWillUnmount=="function"&&C1(l,e,a)),Ee(t,e,l);break;case 21:Ee(t,e,l);break;case 22:yt=(a=yt)||l.memoizedState!==null,Ee(t,e,l),yt=a;break;default:Ee(t,e,l)}}function X1(t,e){if(e.memoizedState===null&&(t=e.alternate,t!==null&&(t=t.memoizedState,t!==null))){t=t.dehydrated;try{Ta(t)}catch(l){K(e,e.return,l)}}}function L1(t,e){if(e.memoizedState===null&&(t=e.alternate,t!==null&&(t=t.memoizedState,t!==null&&(t=t.dehydrated,t!==null))))try{Ta(t)}catch(l){K(e,e.return,l)}}function hv(t){switch(t.tag){case 31:case 13:case 19:var e=t.stateNode;return e===null&&(e=t.stateNode=new Bo),e;case 22:return t=t.stateNode,e=t._retryCache,e===null&&(e=t._retryCache=new Bo),e;default:throw Error(j(435,t.tag))}}function In(t,e){var l=hv(t);e.forEach(function(a){if(!l.has(a)){l.add(a);var n=Tv.bind(null,t,a);a.then(n,n)}})}function Ht(t,e){var l=e.deletions;if(l!==null)for(var a=0;a<l.length;a++){var n=l[a],u=t,c=e,i=c;t:for(;i!==null;){switch(i.tag){case 27:if(hl(i.type)){it=i.stateNode,Bt=!1;break t}break;case 5:it=i.stateNode,Bt=!1;break t;case 3:case 4:it=i.stateNode.containerInfo,Bt=!0;break t}i=i.return}if(it===null)throw Error(j(160));B1(u,c,n),it=null,Bt=!1,u=n.alternate,u!==null&&(u.return=null),n.return=null}if(e.subtreeFlags&13886)for(e=e.child;e!==null;)Z1(e,t),e=e.sibling}var ve=null;function Z1(t,e){var l=t.alternate,a=t.flags;switch(t.tag){case 0:case 11:case 14:case 15:Ht(e,t),Ut(t),a&4&&(ml(3,t,t.return),_n(3,t),ml(5,t,t.return));break;case 1:Ht(e,t),Ut(t),a&512&&(yt||l===null||be(l,l.return)),a&64&&$e&&(t=t.updateQueue,t!==null&&(a=t.callbacks,a!==null&&(l=t.shared.hiddenCallbacks,t.shared.hiddenCallbacks=l===null?a:l.concat(a))));break;case 26:var n=ve;if(Ht(e,t),Ut(t),a&512&&(yt||l===null||be(l,l.return)),a&4){var u=l!==null?l.memoizedState:null;if(a=t.memoizedState,l===null)if(a===null)if(t.stateNode===null){t:{a=t.type,l=t.memoizedProps,n=n.ownerDocument||n;e:switch(a){case"title":u=n.getElementsByTagName("title")[0],(!u||u[On]||u[$t]||u.namespaceURI==="http://www.w3.org/2000/svg"||u.hasAttribute("itemprop"))&&(u=n.createElement(a),n.head.insertBefore(u,n.querySelector("head > title"))),Dt(u,a,l),u[$t]=t,zt(u),a=u;break t;case"link":var c=cr("link","href",n).get(a+(l.href||""));if(c){for(var i=0;i<c.length;i++)if(u=c[i],u.getAttribute("href")===(l.href==null||l.href===""?null:l.href)&&u.getAttribute("rel")===(l.rel==null?null:l.rel)&&u.getAttribute("title")===(l.title==null?null:l.title)&&u.getAttribute("crossorigin")===(l.crossOrigin==null?null:l.crossOrigin)){c.splice(i,1);break e}}u=n.createElement(a),Dt(u,a,l),n.head.appendChild(u);break;case"meta":if(c=cr("meta","content",n).get(a+(l.content||""))){for(i=0;i<c.length;i++)if(u=c[i],u.getAttribute("content")===(l.content==null?null:""+l.content)&&u.getAttribute("name")===(l.name==null?null:l.name)&&u.getAttribute("property")===(l.property==null?null:l.property)&&u.getAttribute("http-equiv")===(l.httpEquiv==null?null:l.httpEquiv)&&u.getAttribute("charset")===(l.charSet==null?null:l.charSet)){c.splice(i,1);break e}}u=n.createElement(a),Dt(u,a,l),n.head.appendChild(u);break;default:throw Error(j(468,a))}u[$t]=t,zt(u),a=u}t.stateNode=a}else ir(n,t.type,t.stateNode);else t.stateNode=ur(n,a,t.memoizedProps);else u!==a?(u===null?l.stateNode!==null&&(l=l.stateNode,l.parentNode.removeChild(l)):u.count--,a===null?ir(n,t.type,t.stateNode):ur(n,a,t.memoizedProps)):a===null&&t.stateNode!==null&&Wc(t,t.memoizedProps,l.memoizedProps)}break;case 27:Ht(e,t),Ut(t),a&512&&(yt||l===null||be(l,l.return)),l!==null&&a&4&&Wc(t,t.memoizedProps,l.memoizedProps);break;case 5:if(Ht(e,t),Ut(t),a&512&&(yt||l===null||be(l,l.return)),t.flags&32){n=t.stateNode;try{ga(n,"")}catch(p){K(t,t.return,p)}}a&4&&t.stateNode!=null&&(n=t.memoizedProps,Wc(t,n,l!==null?l.memoizedProps:n)),a&1024&&(Ic=!0);break;case 6:if(Ht(e,t),Ut(t),a&4){if(t.stateNode===null)throw Error(j(162));a=t.memoizedProps,l=t.stateNode;try{l.nodeValue=a}catch(p){K(t,t.return,p)}}break;case 3:if(pu=null,n=ve,ve=Ju(e.containerInfo),Ht(e,t),ve=n,Ut(t),a&4&&l!==null&&l.memoizedState.isDehydrated)try{Ta(e.containerInfo)}catch(p){K(t,t.return,p)}Ic&&(Ic=!1,G1(t));break;case 4:a=ve,ve=Ju(t.stateNode.containerInfo),Ht(e,t),Ut(t),ve=a;break;case 12:Ht(e,t),Ut(t);break;case 31:Ht(e,t),Ut(t),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,In(t,a)));break;case 13:Ht(e,t),Ut(t),t.child.flags&8192&&t.memoizedState!==null!=(l!==null&&l.memoizedState!==null)&&(vc=Wt()),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,In(t,a)));break;case 22:n=t.memoizedState!==null;var s=l!==null&&l.memoizedState!==null,r=$e,x=yt;if($e=r||n,yt=x||s,Ht(e,t),yt=x,$e=r,Ut(t),a&8192)t:for(e=t.stateNode,e._visibility=n?e._visibility&-2:e._visibility|1,n&&(l===null||s||$e||yt||El(t)),l=null,e=t;;){if(e.tag===5||e.tag===26){if(l===null){s=l=e;try{if(u=s.stateNode,n)c=u.style,typeof c.setProperty=="function"?c.setProperty("display","none","important"):c.display="none";else{i=s.stateNode;var h=s.memoizedProps.style,d=h!=null&&h.hasOwnProperty("display")?h.display:null;i.style.display=d==null||typeof d=="boolean"?"":(""+d).trim()}}catch(p){K(s,s.return,p)}}}else if(e.tag===6){if(l===null){s=e;try{s.stateNode.nodeValue=n?"":s.memoizedProps}catch(p){K(s,s.return,p)}}}else if(e.tag===18){if(l===null){s=e;try{var y=s.stateNode;n?tr(y,!0):tr(s.stateNode,!1)}catch(p){K(s,s.return,p)}}}else if((e.tag!==22&&e.tag!==23||e.memoizedState===null||e===t)&&e.child!==null){e.child.return=e,e=e.child;continue}if(e===t)break t;for(;e.sibling===null;){if(e.return===null||e.return===t)break t;l===e&&(l=null),e=e.return}l===e&&(l=null),e.sibling.return=e.return,e=e.sibling}a&4&&(a=t.updateQueue,a!==null&&(l=a.retryQueue,l!==null&&(a.retryQueue=null,In(t,l))));break;case 19:Ht(e,t),Ut(t),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,In(t,a)));break;case 30:break;case 21:break;default:Ht(e,t),Ut(t)}}function Ut(t){var e=t.flags;if(e&2){try{for(var l,a=t.return;a!==null;){if(R1(a)){l=a;break}a=a.return}if(l==null)throw Error(j(160));switch(l.tag){case 27:var n=l.stateNode,u=Fc(t);Xu(t,u,n);break;case 5:var c=l.stateNode;l.flags&32&&(ga(c,""),l.flags&=-33);var i=Fc(t);Xu(t,i,c);break;case 3:case 4:var s=l.stateNode.containerInfo,r=Fc(t);Pi(t,r,s);break;default:throw Error(j(161))}}catch(x){K(t,t.return,x)}t.flags&=-3}e&4096&&(t.flags&=-4097)}function G1(t){if(t.subtreeFlags&1024)for(t=t.child;t!==null;){var e=t;G1(e),e.tag===5&&e.flags&1024&&e.stateNode.reset(),t=t.sibling}}function Te(t,e){if(e.subtreeFlags&8772)for(e=e.child;e!==null;)H1(t,e.alternate,e),e=e.sibling}function El(t){for(t=t.child;t!==null;){var e=t;switch(e.tag){case 0:case 11:case 14:case 15:ml(4,e,e.return),El(e);break;case 1:be(e,e.return);var l=e.stateNode;typeof l.componentWillUnmount=="function"&&C1(e,e.return,l),El(e);break;case 27:rn(e.stateNode);case 26:case 5:be(e,e.return),El(e);break;case 22:e.memoizedState===null&&El(e);break;case 30:El(e);break;default:El(e)}t=t.sibling}}function Me(t,e,l){for(l=l&&(e.subtreeFlags&8772)!==0,e=e.child;e!==null;){var a=e.alternate,n=t,u=e,c=u.flags;switch(u.tag){case 0:case 11:case 15:Me(n,u,l),_n(4,u);break;case 1:if(Me(n,u,l),a=u,n=a.stateNode,typeof n.componentDidMount=="function")try{n.componentDidMount()}catch(r){K(a,a.return,r)}if(a=u,n=a.updateQueue,n!==null){var i=a.stateNode;try{var s=n.shared.hiddenCallbacks;if(s!==null)for(n.shared.hiddenCallbacks=null,n=0;n<s.length;n++)Xd(s[n],i)}catch(r){K(a,a.return,r)}}l&&c&64&&w1(u),cn(u,u.return);break;case 27:q1(u);case 26:case 5:Me(n,u,l),l&&a===null&&c&4&&_1(u),cn(u,u.return);break;case 12:Me(n,u,l);break;case 31:Me(n,u,l),l&&c&4&&X1(n,u);break;case 13:Me(n,u,l),l&&c&4&&L1(n,u);break;case 22:u.memoizedState===null&&Me(n,u,l),cn(u,u.return);break;case 30:break;default:Me(n,u,l)}e=e.sibling}}function sf(t,e){var l=null;t!==null&&t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(l=t.memoizedState.cachePool.pool),t=null,e.memoizedState!==null&&e.memoizedState.cachePool!==null&&(t=e.memoizedState.cachePool.pool),t!==l&&(t!=null&&t.refCount++,l!=null&&wn(l))}function ff(t,e){t=null,e.alternate!==null&&(t=e.alternate.memoizedState.cache),e=e.memoizedState.cache,e!==t&&(e.refCount++,t!=null&&wn(t))}function xe(t,e,l,a){if(e.subtreeFlags&10256)for(e=e.child;e!==null;)Y1(t,e,l,a),e=e.sibling}function Y1(t,e,l,a){var n=e.flags;switch(e.tag){case 0:case 11:case 15:xe(t,e,l,a),n&2048&&_n(9,e);break;case 1:xe(t,e,l,a);break;case 3:xe(t,e,l,a),n&2048&&(t=null,e.alternate!==null&&(t=e.alternate.memoizedState.cache),e=e.memoizedState.cache,e!==t&&(e.refCount++,t!=null&&wn(t)));break;case 12:if(n&2048){xe(t,e,l,a),t=e.stateNode;try{var u=e.memoizedProps,c=u.id,i=u.onPostCommit;typeof i=="function"&&i(c,e.alternate===null?"mount":"update",t.passiveEffectDuration,-0)}catch(s){K(e,e.return,s)}}else xe(t,e,l,a);break;case 31:xe(t,e,l,a);break;case 13:xe(t,e,l,a);break;case 23:break;case 22:u=e.stateNode,c=e.alternate,e.memoizedState!==null?u._visibility&2?xe(t,e,l,a):sn(t,e):u._visibility&2?xe(t,e,l,a):(u._visibility|=2,Kl(t,e,l,a,(e.subtreeFlags&10256)!==0||!1)),n&2048&&sf(c,e);break;case 24:xe(t,e,l,a),n&2048&&ff(e.alternate,e);break;default:xe(t,e,l,a)}}function Kl(t,e,l,a,n){for(n=n&&((e.subtreeFlags&10256)!==0||!1),e=e.child;e!==null;){var u=t,c=e,i=l,s=a,r=c.flags;switch(c.tag){case 0:case 11:case 15:Kl(u,c,i,s,n),_n(8,c);break;case 23:break;case 22:var x=c.stateNode;c.memoizedState!==null?x._visibility&2?Kl(u,c,i,s,n):sn(u,c):(x._visibility|=2,Kl(u,c,i,s,n)),n&&r&2048&&sf(c.alternate,c);break;case 24:Kl(u,c,i,s,n),n&&r&2048&&ff(c.alternate,c);break;default:Kl(u,c,i,s,n)}e=e.sibling}}function sn(t,e){if(e.subtreeFlags&10256)for(e=e.child;e!==null;){var l=t,a=e,n=a.flags;switch(a.tag){case 22:sn(l,a),n&2048&&sf(a.alternate,a);break;case 24:sn(l,a),n&2048&&ff(a.alternate,a);break;default:sn(l,a)}e=e.sibling}}var Ja=8192;function Zl(t,e,l){if(t.subtreeFlags&Ja)for(t=t.child;t!==null;)V1(t,e,l),t=t.sibling}function V1(t,e,l){switch(t.tag){case 26:Zl(t,e,l),t.flags&Ja&&t.memoizedState!==null&&ay(l,ve,t.memoizedState,t.memoizedProps);break;case 5:Zl(t,e,l);break;case 3:case 4:var a=ve;ve=Ju(t.stateNode.containerInfo),Zl(t,e,l),ve=a;break;case 22:t.memoizedState===null&&(a=t.alternate,a!==null&&a.memoizedState!==null?(a=Ja,Ja=16777216,Zl(t,e,l),Ja=a):Zl(t,e,l));break;default:Zl(t,e,l)}}function Q1(t){var e=t.alternate;if(e!==null&&(t=e.child,t!==null)){e.child=null;do e=t.sibling,t.sibling=null,t=e;while(t!==null)}}function Xa(t){var e=t.deletions;if(t.flags&16){if(e!==null)for(var l=0;l<e.length;l++){var a=e[l];kt=a,J1(a,t)}Q1(t)}if(t.subtreeFlags&10256)for(t=t.child;t!==null;)K1(t),t=t.sibling}function K1(t){switch(t.tag){case 0:case 11:case 15:Xa(t),t.flags&2048&&ml(9,t,t.return);break;case 3:Xa(t);break;case 12:Xa(t);break;case 22:var e=t.stateNode;t.memoizedState!==null&&e._visibility&2&&(t.return===null||t.return.tag!==13)?(e._visibility&=-3,gu(t)):Xa(t);break;default:Xa(t)}}function gu(t){var e=t.deletions;if(t.flags&16){if(e!==null)for(var l=0;l<e.length;l++){var a=e[l];kt=a,J1(a,t)}Q1(t)}for(t=t.child;t!==null;){switch(e=t,e.tag){case 0:case 11:case 15:ml(8,e,e.return),gu(e);break;case 22:l=e.stateNode,l._visibility&2&&(l._visibility&=-3,gu(e));break;default:gu(e)}t=t.sibling}}function J1(t,e){for(;kt!==null;){var l=kt;switch(l.tag){case 0:case 11:case 15:ml(8,l,e);break;case 23:case 22:if(l.memoizedState!==null&&l.memoizedState.cachePool!==null){var a=l.memoizedState.cachePool.pool;a!=null&&a.refCount++}break;case 24:wn(l.memoizedState.cache)}if(a=l.child,a!==null)a.return=l,kt=a;else t:for(l=t;kt!==null;){a=kt;var n=a.sibling,u=a.return;if(U1(a),a===l){kt=null;break t}if(n!==null){n.return=u,kt=n;break t}kt=u}}}var gv={getCacheForType:function(t){var e=Ot(ht),l=e.data.get(t);return l===void 0&&(l=t(),e.data.set(t,l)),l},cacheSignal:function(){return Ot(ht).controller.signal}},bv=typeof WeakMap=="function"?WeakMap:Map,G=0,P=null,U=null,B=0,Q=0,Vt=null,tl=!1,Da=!1,of=!1,Be=0,ft=0,vl=0,Nl=0,rf=0,Jt=0,ka=0,fn=null,Xt=null,ts=!1,vc=0,W1=0,Lu=1/0,Zu=null,il=null,bt=0,sl=null,za=null,_e=0,es=0,ls=null,F1=null,on=0,as=null;function Pt(){return G&2&&B!==0?B&-B:w.T!==null?xf():cd()}function I1(){if(Jt===0)if(!(B&536870912)||X){var t=Gn;Gn<<=1,!(Gn&3932160)&&(Gn=262144),Jt=t}else Jt=536870912;return t=ee.current,t!==null&&(t.flags|=32),Jt}function Lt(t,e,l){(t===P&&(Q===2||Q===9)||t.cancelPendingCommit!==null)&&(ja(t,0),el(t,B,Jt,!1)),Nn(t,l),(!(G&2)||t!==P)&&(t===P&&(!(G&2)&&(Nl|=l),ft===4&&el(t,B,Jt,!1)),ke(t))}function P1(t,e,l){if(G&6)throw Error(j(327));var a=!l&&(e&127)===0&&(e&t.expiredLanes)===0||$n(t,e),n=a?kv(t,e):Pc(t,e,!0),u=a;do{if(n===0){Da&&!a&&el(t,e,0,!1);break}else{if(l=t.current.alternate,u&&!pv(l)){n=Pc(t,e,!1),u=!1;continue}if(n===2){if(u=e,t.errorRecoveryDisabledLanes&u)var c=0;else c=t.pendingLanes&-536870913,c=c!==0?c:c&536870912?536870912:0;if(c!==0){e=c;t:{var i=t;n=fn;var s=i.current.memoizedState.isDehydrated;if(s&&(ja(i,c).flags|=256),c=Pc(i,c,!1),c!==2){if(of&&!s){i.errorRecoveryDisabledLanes|=u,Nl|=u,n=4;break t}u=Xt,Xt=n,u!==null&&(Xt===null?Xt=u:Xt.push.apply(Xt,u))}n=c}if(u=!1,n!==2)continue}}if(n===1){ja(t,0),el(t,e,0,!0);break}t:{switch(a=t,u=n,u){case 0:case 1:throw Error(j(345));case 4:if((e&4194048)!==e)break;case 6:el(a,e,Jt,!tl);break t;case 2:Xt=null;break;case 3:case 5:break;default:throw Error(j(329))}if((e&62914560)===e&&(n=vc+300-Wt(),10<n)){if(el(a,e,Jt,!tl),nc(a,0,!0)!==0)break t;_e=e,a.timeoutHandle=b0(Xo.bind(null,a,l,Xt,Zu,ts,e,Jt,Nl,ka,tl,u,"Throttled",-0,0),n);break t}Xo(a,l,Xt,Zu,ts,e,Jt,Nl,ka,tl,u,null,-0,0)}}break}while(!0);ke(t)}function Xo(t,e,l,a,n,u,c,i,s,r,x,h,d,y){if(t.timeoutHandle=-1,h=e.subtreeFlags,h&8192||(h&16785408)===16785408){h={stylesheets:null,count:0,imgCount:0,imgBytes:0,suspenseyImages:[],waitingForImages:!0,waitingForViewTransition:!1,unsuspend:Oe},V1(e,u,h);var p=(u&62914560)===u?vc-Wt():(u&4194048)===u?W1-Wt():0;if(p=ny(h,p),p!==null){_e=u,t.cancelPendingCommit=p(Zo.bind(null,t,e,u,l,a,n,c,i,s,x,h,null,d,y)),el(t,u,c,!r);return}}Zo(t,e,u,l,a,n,c,i,s)}function pv(t){for(var e=t;;){var l=e.tag;if((l===0||l===11||l===15)&&e.flags&16384&&(l=e.updateQueue,l!==null&&(l=l.stores,l!==null)))for(var a=0;a<l.length;a++){var n=l[a],u=n.getSnapshot;n=n.value;try{if(!te(u(),n))return!1}catch{return!1}}if(l=e.child,e.subtreeFlags&16384&&l!==null)l.return=e,e=l;else{if(e===t)break;for(;e.sibling===null;){if(e.return===null||e.return===t)return!0;e=e.return}e.sibling.return=e.return,e=e.sibling}}return!0}function el(t,e,l,a){e&=~rf,e&=~Nl,t.suspendedLanes|=e,t.pingedLanes&=~e,a&&(t.warmLanes|=e),a=t.expirationTimes;for(var n=e;0<n;){var u=31-It(n),c=1<<u;a[u]=-1,n&=~c}l!==0&&ad(t,l,e)}function yc(){return G&6?!0:(Rn(0),!1)}function df(){if(U!==null){if(Q===0)var t=U.return;else t=U,De=Bl=null,Ws(t),xa=null,gn=0,t=U;for(;t!==null;)D1(t.alternate,t),t=t.return;U=null}}function ja(t,e){var l=t.timeoutHandle;l!==-1&&(t.timeoutHandle=-1,Bv(l)),l=t.cancelPendingCommit,l!==null&&(t.cancelPendingCommit=null,l()),_e=0,df(),P=t,U=l=we(t.current,null),B=e,Q=0,Vt=null,tl=!1,Da=$n(t,e),of=!1,ka=Jt=rf=Nl=vl=ft=0,Xt=fn=null,ts=!1,e&8&&(e|=e&32);var a=t.entangledLanes;if(a!==0)for(t=t.entanglements,a&=e;0<a;){var n=31-It(a),u=1<<n;e|=t[n],a&=~u}return Be=e,sc(),l}function t0(t,e){q=null,w.H=pn,e===Oa||e===oc?(e=bo(),Q=3):e===Zs?(e=bo(),Q=4):Q=e===uf?8:e!==null&&typeof e=="object"&&typeof e.then=="function"?6:1,Vt=e,U===null&&(ft=1,Uu(t,ie(e,t.current)))}function e0(){var t=ee.current;return t===null?!0:(B&4194048)===B?fe===null:(B&62914560)===B||B&536870912?t===fe:!1}function l0(){var t=w.H;return w.H=pn,t===null?pn:t}function a0(){var t=w.A;return w.A=gv,t}function Gu(){ft=4,tl||(B&4194048)!==B&&ee.current!==null||(Da=!0),!(vl&134217727)&&!(Nl&134217727)||P===null||el(P,B,Jt,!1)}function Pc(t,e,l){var a=G;G|=2;var n=l0(),u=a0();(P!==t||B!==e)&&(Zu=null,ja(t,e)),e=!1;var c=ft;t:do try{if(Q!==0&&U!==null){var i=U,s=Vt;switch(Q){case 8:df(),c=6;break t;case 3:case 2:case 9:case 6:ee.current===null&&(e=!0);var r=Q;if(Q=0,Vt=null,sa(t,i,s,r),l&&Da){c=0;break t}break;default:r=Q,Q=0,Vt=null,sa(t,i,s,r)}}Sv(),c=ft;break}catch(x){t0(t,x)}while(!0);return e&&t.shellSuspendCounter++,De=Bl=null,G=a,w.H=n,w.A=u,U===null&&(P=null,B=0,sc()),c}function Sv(){for(;U!==null;)n0(U)}function kv(t,e){var l=G;G|=2;var a=l0(),n=a0();P!==t||B!==e?(Zu=null,Lu=Wt()+500,ja(t,e)):Da=$n(t,e);t:do try{if(Q!==0&&U!==null){e=U;var u=Vt;e:switch(Q){case 1:Q=0,Vt=null,sa(t,e,u,1);break;case 2:case 9:if(go(u)){Q=0,Vt=null,Lo(e);break}e=function(){Q!==2&&Q!==9||P!==t||(Q=7),ke(t)},u.then(e,e);break t;case 3:Q=7;break t;case 4:Q=5;break t;case 7:go(u)?(Q=0,Vt=null,Lo(e)):(Q=0,Vt=null,sa(t,e,u,7));break;case 5:var c=null;switch(U.tag){case 26:c=U.memoizedState;case 5:case 27:var i=U;if(c?j0(c):i.stateNode.complete){Q=0,Vt=null;var s=i.sibling;if(s!==null)U=s;else{var r=i.return;r!==null?(U=r,hc(r)):U=null}break e}}Q=0,Vt=null,sa(t,e,u,5);break;case 6:Q=0,Vt=null,sa(t,e,u,6);break;case 8:df(),ft=6;break t;default:throw Error(j(462))}}zv();break}catch(x){t0(t,x)}while(!0);return De=Bl=null,w.H=a,w.A=n,G=l,U!==null?0:(P=null,B=0,sc(),ft)}function zv(){for(;U!==null&&!Vx();)n0(U)}function n0(t){var e=O1(t.alternate,t,Be);t.memoizedProps=t.pendingProps,e===null?hc(t):U=e}function Lo(t){var e=t,l=e.alternate;switch(e.tag){case 15:case 0:e=_o(l,e,e.pendingProps,e.type,void 0,B);break;case 11:e=_o(l,e,e.pendingProps,e.type.render,e.ref,B);break;case 5:Ws(e);default:D1(l,e),e=U=Dd(e,Be),e=O1(l,e,Be)}t.memoizedProps=t.pendingProps,e===null?hc(t):U=e}function sa(t,e,l,a){De=Bl=null,Ws(e),xa=null,gn=0;var n=e.return;try{if(rv(t,n,e,l,B)){ft=1,Uu(t,ie(l,t.current)),U=null;return}}catch(u){if(n!==null)throw U=n,u;ft=1,Uu(t,ie(l,t.current)),U=null;return}e.flags&32768?(X||a===1?t=!0:Da||B&536870912?t=!1:(tl=t=!0,(a===2||a===9||a===3||a===6)&&(a=ee.current,a!==null&&a.tag===13&&(a.flags|=16384))),u0(e,t)):hc(e)}function hc(t){var e=t;do{if(e.flags&32768){u0(e,tl);return}t=e.return;var l=mv(e.alternate,e,Be);if(l!==null){U=l;return}if(e=e.sibling,e!==null){U=e;return}U=e=t}while(e!==null);ft===0&&(ft=5)}function u0(t,e){do{var l=vv(t.alternate,t);if(l!==null){l.flags&=32767,U=l;return}if(l=t.return,l!==null&&(l.flags|=32768,l.subtreeFlags=0,l.deletions=null),!e&&(t=t.sibling,t!==null)){U=t;return}U=t=l}while(t!==null);ft=6,U=null}function Zo(t,e,l,a,n,u,c,i,s){t.cancelPendingCommit=null;do gc();while(bt!==0);if(G&6)throw Error(j(327));if(e!==null){if(e===t.current)throw Error(j(177));if(u=e.lanes|e.childLanes,u|=Rs,lm(t,l,u,c,i,s),t===P&&(U=P=null,B=0),za=e,sl=t,_e=l,es=u,ls=n,F1=a,e.subtreeFlags&10256||e.flags&10256?(t.callbackNode=null,t.callbackPriority=0,Mv(Au,function(){return o0(),null})):(t.callbackNode=null,t.callbackPriority=0),a=(e.flags&13878)!==0,e.subtreeFlags&13878||a){a=w.T,w.T=null,n=Y.p,Y.p=2,c=G,G|=4;try{yv(t,e,l)}finally{G=c,Y.p=n,w.T=a}}bt=1,c0(),i0(),s0()}}function c0(){if(bt===1){bt=0;var t=sl,e=za,l=(e.flags&13878)!==0;if(e.subtreeFlags&13878||l){l=w.T,w.T=null;var a=Y.p;Y.p=2;var n=G;G|=4;try{Z1(e,t);var u=is,c=jd(t.containerInfo),i=u.focusedElem,s=u.selectionRange;if(c!==i&&i&&i.ownerDocument&&zd(i.ownerDocument.documentElement,i)){if(s!==null&&_s(i)){var r=s.start,x=s.end;if(x===void 0&&(x=r),"selectionStart"in i)i.selectionStart=r,i.selectionEnd=Math.min(x,i.value.length);else{var h=i.ownerDocument||document,d=h&&h.defaultView||window;if(d.getSelection){var y=d.getSelection(),p=i.textContent.length,S=Math.min(s.start,p),k=s.end===void 0?S:Math.min(s.end,p);!y.extend&&S>k&&(c=k,k=S,S=c);var m=oo(i,S),f=oo(i,k);if(m&&f&&(y.rangeCount!==1||y.anchorNode!==m.node||y.anchorOffset!==m.offset||y.focusNode!==f.node||y.focusOffset!==f.offset)){var v=h.createRange();v.setStart(m.node,m.offset),y.removeAllRanges(),S>k?(y.addRange(v),y.extend(f.node,f.offset)):(v.setEnd(f.node,f.offset),y.addRange(v))}}}}for(h=[],y=i;y=y.parentNode;)y.nodeType===1&&h.push({element:y,left:y.scrollLeft,top:y.scrollTop});for(typeof i.focus=="function"&&i.focus(),i=0;i<h.length;i++){var b=h[i];b.element.scrollLeft=b.left,b.element.scrollTop=b.top}}Iu=!!cs,is=cs=null}finally{G=n,Y.p=a,w.T=l}}t.current=e,bt=2}}function i0(){if(bt===2){bt=0;var t=sl,e=za,l=(e.flags&8772)!==0;if(e.subtreeFlags&8772||l){l=w.T,w.T=null;var a=Y.p;Y.p=2;var n=G;G|=4;try{H1(t,e.alternate,e)}finally{G=n,Y.p=a,w.T=l}}bt=3}}function s0(){if(bt===4||bt===3){bt=0,Qx();var t=sl,e=za,l=_e,a=F1;e.subtreeFlags&10256||e.flags&10256?bt=5:(bt=0,za=sl=null,f0(t,t.pendingLanes));var n=t.pendingLanes;if(n===0&&(il=null),As(l),e=e.stateNode,Ft&&typeof Ft.onCommitFiberRoot=="function")try{Ft.onCommitFiberRoot(An,e,void 0,(e.current.flags&128)===128)}catch{}if(a!==null){e=w.T,n=Y.p,Y.p=2,w.T=null;try{for(var u=t.onRecoverableError,c=0;c<a.length;c++){var i=a[c];u(i.value,{componentStack:i.stack})}}finally{w.T=e,Y.p=n}}_e&3&&gc(),ke(t),n=t.pendingLanes,l&261930&&n&42?t===as?on++:(on=0,as=t):on=0,Rn(0)}}function f0(t,e){(t.pooledCacheLanes&=e)===0&&(e=t.pooledCache,e!=null&&(t.pooledCache=null,wn(e)))}function gc(){return c0(),i0(),s0(),o0()}function o0(){if(bt!==5)return!1;var t=sl,e=es;es=0;var l=As(_e),a=w.T,n=Y.p;try{Y.p=32>l?32:l,w.T=null,l=ls,ls=null;var u=sl,c=_e;if(bt=0,za=sl=null,_e=0,G&6)throw Error(j(331));var i=G;if(G|=4,K1(u.current),Y1(u,u.current,c,l),G=i,Rn(0,!1),Ft&&typeof Ft.onPostCommitFiberRoot=="function")try{Ft.onPostCommitFiberRoot(An,u)}catch{}return!0}finally{Y.p=n,w.T=a,f0(t,e)}}function Go(t,e,l){e=ie(l,e),e=Wi(t.stateNode,e,2),t=cl(t,e,2),t!==null&&(Nn(t,2),ke(t))}function K(t,e,l){if(t.tag===3)Go(t,t,l);else for(;e!==null;){if(e.tag===3){Go(e,t,l);break}else if(e.tag===1){var a=e.stateNode;if(typeof e.type.getDerivedStateFromError=="function"||typeof a.componentDidCatch=="function"&&(il===null||!il.has(a))){t=ie(l,t),l=E1(2),a=cl(e,l,2),a!==null&&(T1(l,a,e,t),Nn(a,2),ke(a));break}}e=e.return}}function ti(t,e,l){var a=t.pingCache;if(a===null){a=t.pingCache=new bv;var n=new Set;a.set(e,n)}else n=a.get(e),n===void 0&&(n=new Set,a.set(e,n));n.has(l)||(of=!0,n.add(l),t=jv.bind(null,t,e,l),e.then(t,t))}function jv(t,e,l){var a=t.pingCache;a!==null&&a.delete(e),t.pingedLanes|=t.suspendedLanes&l,t.warmLanes&=~l,P===t&&(B&l)===l&&(ft===4||ft===3&&(B&62914560)===B&&300>Wt()-vc?!(G&2)&&ja(t,0):rf|=l,ka===B&&(ka=0)),ke(t)}function r0(t,e){e===0&&(e=ld()),t=Ul(t,e),t!==null&&(Nn(t,e),ke(t))}function Ev(t){var e=t.memoizedState,l=0;e!==null&&(l=e.retryLane),r0(t,l)}function Tv(t,e){var l=0;switch(t.tag){case 31:case 13:var a=t.stateNode,n=t.memoizedState;n!==null&&(l=n.retryLane);break;case 19:a=t.stateNode;break;case 22:a=t.stateNode._retryCache;break;default:throw Error(j(314))}a!==null&&a.delete(e),r0(t,l)}function Mv(t,e){return Ts(t,e)}var Yu=null,Jl=null,ns=!1,Vu=!1,ei=!1,ll=0;function ke(t){t!==Jl&&t.next===null&&(Jl===null?Yu=Jl=t:Jl=Jl.next=t),Vu=!0,ns||(ns=!0,$v())}function Rn(t,e){if(!ei&&Vu){ei=!0;do for(var l=!1,a=Yu;a!==null;){if(t!==0){var n=a.pendingLanes;if(n===0)var u=0;else{var c=a.suspendedLanes,i=a.pingedLanes;u=(1<<31-It(42|t)+1)-1,u&=n&~(c&~i),u=u&201326741?u&201326741|1:u?u|2:0}u!==0&&(l=!0,Yo(a,u))}else u=B,u=nc(a,a===P?u:0,a.cancelPendingCommit!==null||a.timeoutHandle!==-1),!(u&3)||$n(a,u)||(l=!0,Yo(a,u));a=a.next}while(l);ei=!1}}function Av(){d0()}function d0(){Vu=ns=!1;var t=0;ll!==0&&Uv()&&(t=ll);for(var e=Wt(),l=null,a=Yu;a!==null;){var n=a.next,u=x0(a,e);u===0?(a.next=null,l===null?Yu=n:l.next=n,n===null&&(Jl=l)):(l=a,(t!==0||u&3)&&(Vu=!0)),a=n}bt!==0&&bt!==5||Rn(t),ll!==0&&(ll=0)}function x0(t,e){for(var l=t.suspendedLanes,a=t.pingedLanes,n=t.expirationTimes,u=t.pendingLanes&-62914561;0<u;){var c=31-It(u),i=1<<c,s=n[c];s===-1?(!(i&l)||i&a)&&(n[c]=em(i,e)):s<=e&&(t.expiredLanes|=i),u&=~i}if(e=P,l=B,l=nc(t,t===e?l:0,t.cancelPendingCommit!==null||t.timeoutHandle!==-1),a=t.callbackNode,l===0||t===e&&(Q===2||Q===9)||t.cancelPendingCommit!==null)return a!==null&&a!==null&&$c(a),t.callbackNode=null,t.callbackPriority=0;if(!(l&3)||$n(t,l)){if(e=l&-l,e===t.callbackPriority)return e;switch(a!==null&&$c(a),As(l)){case 2:case 8:l=td;break;case 32:l=Au;break;case 268435456:l=ed;break;default:l=Au}return a=m0.bind(null,t),l=Ts(l,a),t.callbackPriority=e,t.callbackNode=l,e}return a!==null&&a!==null&&$c(a),t.callbackPriority=2,t.callbackNode=null,2}function m0(t,e){if(bt!==0&&bt!==5)return t.callbackNode=null,t.callbackPriority=0,null;var l=t.callbackNode;if(gc()&&t.callbackNode!==l)return null;var a=B;return a=nc(t,t===P?a:0,t.cancelPendingCommit!==null||t.timeoutHandle!==-1),a===0?null:(P1(t,a,e),x0(t,Wt()),t.callbackNode!=null&&t.callbackNode===l?m0.bind(null,t):null)}function Yo(t,e){if(gc())return null;P1(t,e,!0)}function $v(){Xv(function(){G&6?Ts(Pr,Av):d0()})}function xf(){if(ll===0){var t=ba;t===0&&(t=Zn,Zn<<=1,!(Zn&261888)&&(Zn=256)),ll=t}return ll}function Vo(t){return t==null||typeof t=="symbol"||typeof t=="boolean"?null:typeof t=="function"?t:fu(""+t)}function Qo(t,e){var l=e.ownerDocument.createElement("input");return l.name=e.name,l.value=e.value,t.id&&l.setAttribute("form",t.id),e.parentNode.insertBefore(l,e),t=new FormData(t),l.parentNode.removeChild(l),t}function Nv(t,e,l,a,n){if(e==="submit"&&l&&l.stateNode===n){var u=Vo((n[Zt]||null).action),c=a.submitter;c&&(e=(e=c[Zt]||null)?Vo(e.formAction):c.getAttribute("formAction"),e!==null&&(u=e,c=null));var i=new uc("action","action",null,a,n);t.push({event:i,listeners:[{instance:null,listener:function(){if(a.defaultPrevented){if(ll!==0){var s=c?Qo(n,c):new FormData(n);Ki(l,{pending:!0,data:s,method:n.method,action:u},null,s)}}else typeof u=="function"&&(i.preventDefault(),s=c?Qo(n,c):new FormData(n),Ki(l,{pending:!0,data:s,method:n.method,action:u},u,s))},currentTarget:n}]})}}for(var li=0;li<Ri.length;li++){var ai=Ri[li],Ov=ai.toLowerCase(),Dv=ai[0].toUpperCase()+ai.slice(1);ye(Ov,"on"+Dv)}ye(Td,"onAnimationEnd");ye(Md,"onAnimationIteration");ye(Ad,"onAnimationStart");ye("dblclick","onDoubleClick");ye("focusin","onFocus");ye("focusout","onBlur");ye(Km,"onTransitionRun");ye(Jm,"onTransitionStart");ye(Wm,"onTransitionCancel");ye($d,"onTransitionEnd");ha("onMouseEnter",["mouseout","mouseover"]);ha("onMouseLeave",["mouseout","mouseover"]);ha("onPointerEnter",["pointerout","pointerover"]);ha("onPointerLeave",["pointerout","pointerover"]);Rl("onChange","change click focusin focusout input keydown keyup selectionchange".split(" "));Rl("onSelect","focusout contextmenu dragend focusin keydown keyup mousedown mouseup selectionchange".split(" "));Rl("onBeforeInput",["compositionend","keypress","textInput","paste"]);Rl("onCompositionEnd","compositionend focusout keydown keypress keyup mousedown".split(" "));Rl("onCompositionStart","compositionstart focusout keydown keypress keyup mousedown".split(" "));Rl("onCompositionUpdate","compositionupdate focusout keydown keypress keyup mousedown".split(" "));var Sn="abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting".split(" "),wv=new Set("beforetoggle cancel close invalid load scroll scrollend toggle".split(" ").concat(Sn));function v0(t,e){e=(e&4)!==0;for(var l=0;l<t.length;l++){var a=t[l],n=a.event;a=a.listeners;t:{var u=void 0;if(e)for(var c=a.length-1;0<=c;c--){var i=a[c],s=i.instance,r=i.currentTarget;if(i=i.listener,s!==u&&n.isPropagationStopped())break t;u=i,n.currentTarget=r;try{u(n)}catch(x){Nu(x)}n.currentTarget=null,u=s}else for(c=0;c<a.length;c++){if(i=a[c],s=i.instance,r=i.currentTarget,i=i.listener,s!==u&&n.isPropagationStopped())break t;u=i,n.currentTarget=r;try{u(n)}catch(x){Nu(x)}n.currentTarget=null,u=s}}}}function H(t,e){var l=e[Ai];l===void 0&&(l=e[Ai]=new Set);var a=t+"__bubble";l.has(a)||(y0(e,t,2,!1),l.add(a))}function ni(t,e,l){var a=0;e&&(a|=4),y0(l,t,a,e)}var Pn="_reactListening"+Math.random().toString(36).slice(2);function mf(t){if(!t[Pn]){t[Pn]=!0,id.forEach(function(l){l!=="selectionchange"&&(wv.has(l)||ni(l,!1,t),ni(l,!0,t))});var e=t.nodeType===9?t:t.ownerDocument;e===null||e[Pn]||(e[Pn]=!0,ni("selectionchange",!1,e))}}function y0(t,e,l,a){switch($0(e)){case 2:var n=iy;break;case 8:n=sy;break;default:n=gf}l=n.bind(null,e,l,t),n=void 0,!wi||e!=="touchstart"&&e!=="touchmove"&&e!=="wheel"||(n=!0),a?n!==void 0?t.addEventListener(e,l,{capture:!0,passive:n}):t.addEventListener(e,l,!0):n!==void 0?t.addEventListener(e,l,{passive:n}):t.addEventListener(e,l,!1)}function ui(t,e,l,a,n){var u=a;if(!(e&1)&&!(e&2)&&a!==null)t:for(;;){if(a===null)return;var c=a.tag;if(c===3||c===4){var i=a.stateNode.containerInfo;if(i===n)break;if(c===4)for(c=a.return;c!==null;){var s=c.tag;if((s===3||s===4)&&c.stateNode.containerInfo===n)return;c=c.return}for(;i!==null;){if(c=Pl(i),c===null)return;if(s=c.tag,s===5||s===6||s===26||s===27){a=u=c;continue t}i=i.parentNode}}a=a.return}vd(function(){var r=u,x=Os(l),h=[];t:{var d=Nd.get(t);if(d!==void 0){var y=uc,p=t;switch(t){case"keypress":if(ru(l)===0)break t;case"keydown":case"keyup":y=Tm;break;case"focusin":p="focus",y=Cc;break;case"focusout":p="blur",y=Cc;break;case"beforeblur":case"afterblur":y=Cc;break;case"click":if(l.button===2)break t;case"auxclick":case"dblclick":case"mousedown":case"mousemove":case"mouseup":case"mouseout":case"mouseover":case"contextmenu":y=to;break;case"drag":case"dragend":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"dragstart":case"drop":y=mm;break;case"touchcancel":case"touchend":case"touchmove":case"touchstart":y=$m;break;case Td:case Md:case Ad:y=hm;break;case $d:y=Om;break;case"scroll":case"scrollend":y=dm;break;case"wheel":y=wm;break;case"copy":case"cut":case"paste":y=bm;break;case"gotpointercapture":case"lostpointercapture":case"pointercancel":case"pointerdown":case"pointermove":case"pointerout":case"pointerover":case"pointerup":y=lo;break;case"toggle":case"beforetoggle":y=_m}var S=(e&4)!==0,k=!S&&(t==="scroll"||t==="scrollend"),m=S?d!==null?d+"Capture":null:d;S=[];for(var f=r,v;f!==null;){var b=f;if(v=b.stateNode,b=b.tag,b!==5&&b!==26&&b!==27||v===null||m===null||(b=xn(f,m),b!=null&&S.push(kn(f,b,v))),k)break;f=f.return}0<S.length&&(d=new y(d,p,null,l,x),h.push({event:d,listeners:S}))}}if(!(e&7)){t:{if(d=t==="mouseover"||t==="pointerover",y=t==="mouseout"||t==="pointerout",d&&l!==Di&&(p=l.relatedTarget||l.fromElement)&&(Pl(p)||p[Aa]))break t;if((y||d)&&(d=x.window===x?x:(d=x.ownerDocument)?d.defaultView||d.parentWindow:window,y?(p=l.relatedTarget||l.toElement,y=r,p=p?Pl(p):null,p!==null&&(k=Mn(p),S=p.tag,p!==k||S!==5&&S!==27&&S!==6)&&(p=null)):(y=null,p=r),y!==p)){if(S=to,b="onMouseLeave",m="onMouseEnter",f="mouse",(t==="pointerout"||t==="pointerover")&&(S=lo,b="onPointerLeave",m="onPointerEnter",f="pointer"),k=y==null?d:Qa(y),v=p==null?d:Qa(p),d=new S(b,f+"leave",y,l,x),d.target=k,d.relatedTarget=v,b=null,Pl(x)===r&&(S=new S(m,f+"enter",p,l,x),S.target=v,S.relatedTarget=k,b=S),k=b,y&&p)e:{for(S=Cv,m=y,f=p,v=0,b=m;b;b=S(b))v++;b=0;for(var z=f;z;z=S(z))b++;for(;0<v-b;)m=S(m),v--;for(;0<b-v;)f=S(f),b--;for(;v--;){if(m===f||f!==null&&m===f.alternate){S=m;break e}m=S(m),f=S(f)}S=null}else S=null;y!==null&&Ko(h,d,y,S,!1),p!==null&&k!==null&&Ko(h,k,p,S,!0)}}t:{if(d=r?Qa(r):window,y=d.nodeName&&d.nodeName.toLowerCase(),y==="select"||y==="input"&&d.type==="file")var N=co;else if(uo(d))if(Sd)N=Ym;else{N=Zm;var E=Lm}else y=d.nodeName,!y||y.toLowerCase()!=="input"||d.type!=="checkbox"&&d.type!=="radio"?r&&Ns(r.elementType)&&(N=co):N=Gm;if(N&&(N=N(t,r))){pd(h,N,l,x);break t}E&&E(t,d,r),t==="focusout"&&r&&d.type==="number"&&r.memoizedProps.value!=null&&Oi(d,"number",d.value)}switch(E=r?Qa(r):window,t){case"focusin":(uo(E)||E.contentEditable==="true")&&(la=E,Ci=r,tn=null);break;case"focusout":tn=Ci=la=null;break;case"mousedown":_i=!0;break;case"contextmenu":case"mouseup":case"dragend":_i=!1,ro(h,l,x);break;case"selectionchange":if(Qm)break;case"keydown":case"keyup":ro(h,l,x)}var M;if(Cs)t:{switch(t){case"compositionstart":var T="onCompositionStart";break t;case"compositionend":T="onCompositionEnd";break t;case"compositionupdate":T="onCompositionUpdate";break t}T=void 0}else ea?gd(t,l)&&(T="onCompositionEnd"):t==="keydown"&&l.keyCode===229&&(T="onCompositionStart");T&&(hd&&l.locale!=="ko"&&(ea||T!=="onCompositionStart"?T==="onCompositionEnd"&&ea&&(M=yd()):(Pe=x,Ds="value"in Pe?Pe.value:Pe.textContent,ea=!0)),E=Qu(r,T),0<E.length&&(T=new eo(T,t,null,l,x),h.push({event:T,listeners:E}),M?T.data=M:(M=bd(l),M!==null&&(T.data=M)))),(M=qm?Hm(t,l):Um(t,l))&&(T=Qu(r,"onBeforeInput"),0<T.length&&(E=new eo("onBeforeInput","beforeinput",null,l,x),h.push({event:E,listeners:T}),E.data=M)),Nv(h,t,r,l,x)}v0(h,e)})}function kn(t,e,l){return{instance:t,listener:e,currentTarget:l}}function Qu(t,e){for(var l=e+"Capture",a=[];t!==null;){var n=t,u=n.stateNode;if(n=n.tag,n!==5&&n!==26&&n!==27||u===null||(n=xn(t,l),n!=null&&a.unshift(kn(t,n,u)),n=xn(t,e),n!=null&&a.push(kn(t,n,u))),t.tag===3)return a;t=t.return}return[]}function Cv(t){if(t===null)return null;do t=t.return;while(t&&t.tag!==5&&t.tag!==27);return t||null}function Ko(t,e,l,a,n){for(var u=e._reactName,c=[];l!==null&&l!==a;){var i=l,s=i.alternate,r=i.stateNode;if(i=i.tag,s!==null&&s===a)break;i!==5&&i!==26&&i!==27||r===null||(s=r,n?(r=xn(l,u),r!=null&&c.unshift(kn(l,r,s))):n||(r=xn(l,u),r!=null&&c.push(kn(l,r,s)))),l=l.return}c.length!==0&&t.push({event:e,listeners:c})}var _v=/\r\n?/g,Rv=/\u0000|\uFFFD/g;function Jo(t){return(typeof t=="string"?t:""+t).replace(_v,`
+`).replace(Rv,"")}function h0(t,e){return e=Jo(e),Jo(t)===e}function W(t,e,l,a,n,u){switch(l){case"children":typeof a=="string"?e==="body"||e==="textarea"&&a===""||ga(t,a):(typeof a=="number"||typeof a=="bigint")&&e!=="body"&&ga(t,""+a);break;case"className":Vn(t,"class",a);break;case"tabIndex":Vn(t,"tabindex",a);break;case"dir":case"role":case"viewBox":case"width":case"height":Vn(t,l,a);break;case"style":md(t,a,u);break;case"data":if(e!=="object"){Vn(t,"data",a);break}case"src":case"href":if(a===""&&(e!=="a"||l!=="href")){t.removeAttribute(l);break}if(a==null||typeof a=="function"||typeof a=="symbol"||typeof a=="boolean"){t.removeAttribute(l);break}a=fu(""+a),t.setAttribute(l,a);break;case"action":case"formAction":if(typeof a=="function"){t.setAttribute(l,"javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')");break}else typeof u=="function"&&(l==="formAction"?(e!=="input"&&W(t,e,"name",n.name,n,null),W(t,e,"formEncType",n.formEncType,n,null),W(t,e,"formMethod",n.formMethod,n,null),W(t,e,"formTarget",n.formTarget,n,null)):(W(t,e,"encType",n.encType,n,null),W(t,e,"method",n.method,n,null),W(t,e,"target",n.target,n,null)));if(a==null||typeof a=="symbol"||typeof a=="boolean"){t.removeAttribute(l);break}a=fu(""+a),t.setAttribute(l,a);break;case"onClick":a!=null&&(t.onclick=Oe);break;case"onScroll":a!=null&&H("scroll",t);break;case"onScrollEnd":a!=null&&H("scrollend",t);break;case"dangerouslySetInnerHTML":if(a!=null){if(typeof a!="object"||!("__html"in a))throw Error(j(61));if(l=a.__html,l!=null){if(n.children!=null)throw Error(j(60));t.innerHTML=l}}break;case"multiple":t.multiple=a&&typeof a!="function"&&typeof a!="symbol";break;case"muted":t.muted=a&&typeof a!="function"&&typeof a!="symbol";break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"defaultValue":case"defaultChecked":case"innerHTML":case"ref":break;case"autoFocus":break;case"xlinkHref":if(a==null||typeof a=="function"||typeof a=="boolean"||typeof a=="symbol"){t.removeAttribute("xlink:href");break}l=fu(""+a),t.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",l);break;case"contentEditable":case"spellCheck":case"draggable":case"value":case"autoReverse":case"externalResourcesRequired":case"focusable":case"preserveAlpha":a!=null&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(l,""+a):t.removeAttribute(l);break;case"inert":case"allowFullScreen":case"async":case"autoPlay":case"controls":case"default":case"defer":case"disabled":case"disablePictureInPicture":case"disableRemotePlayback":case"formNoValidate":case"hidden":case"loop":case"noModule":case"noValidate":case"open":case"playsInline":case"readOnly":case"required":case"reversed":case"scoped":case"seamless":case"itemScope":a&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(l,""):t.removeAttribute(l);break;case"capture":case"download":a===!0?t.setAttribute(l,""):a!==!1&&a!=null&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(l,a):t.removeAttribute(l);break;case"cols":case"rows":case"size":case"span":a!=null&&typeof a!="function"&&typeof a!="symbol"&&!isNaN(a)&&1<=a?t.setAttribute(l,a):t.removeAttribute(l);break;case"rowSpan":case"start":a==null||typeof a=="function"||typeof a=="symbol"||isNaN(a)?t.removeAttribute(l):t.setAttribute(l,a);break;case"popover":H("beforetoggle",t),H("toggle",t),su(t,"popover",a);break;case"xlinkActuate":ze(t,"http://www.w3.org/1999/xlink","xlink:actuate",a);break;case"xlinkArcrole":ze(t,"http://www.w3.org/1999/xlink","xlink:arcrole",a);break;case"xlinkRole":ze(t,"http://www.w3.org/1999/xlink","xlink:role",a);break;case"xlinkShow":ze(t,"http://www.w3.org/1999/xlink","xlink:show",a);break;case"xlinkTitle":ze(t,"http://www.w3.org/1999/xlink","xlink:title",a);break;case"xlinkType":ze(t,"http://www.w3.org/1999/xlink","xlink:type",a);break;case"xmlBase":ze(t,"http://www.w3.org/XML/1998/namespace","xml:base",a);break;case"xmlLang":ze(t,"http://www.w3.org/XML/1998/namespace","xml:lang",a);break;case"xmlSpace":ze(t,"http://www.w3.org/XML/1998/namespace","xml:space",a);break;case"is":su(t,"is",a);break;case"innerText":case"textContent":break;default:(!(2<l.length)||l[0]!=="o"&&l[0]!=="O"||l[1]!=="n"&&l[1]!=="N")&&(l=om.get(l)||l,su(t,l,a))}}function us(t,e,l,a,n,u){switch(l){case"style":md(t,a,u);break;case"dangerouslySetInnerHTML":if(a!=null){if(typeof a!="object"||!("__html"in a))throw Error(j(61));if(l=a.__html,l!=null){if(n.children!=null)throw Error(j(60));t.innerHTML=l}}break;case"children":typeof a=="string"?ga(t,a):(typeof a=="number"||typeof a=="bigint")&&ga(t,""+a);break;case"onScroll":a!=null&&H("scroll",t);break;case"onScrollEnd":a!=null&&H("scrollend",t);break;case"onClick":a!=null&&(t.onclick=Oe);break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"innerHTML":case"ref":break;case"innerText":case"textContent":break;default:if(!sd.hasOwnProperty(l))t:{if(l[0]==="o"&&l[1]==="n"&&(n=l.endsWith("Capture"),e=l.slice(2,n?l.length-7:void 0),u=t[Zt]||null,u=u!=null?u[l]:null,typeof u=="function"&&t.removeEventListener(e,u,n),typeof a=="function")){typeof u!="function"&&u!==null&&(l in t?t[l]=null:t.hasAttribute(l)&&t.removeAttribute(l)),t.addEventListener(e,a,n);break t}l in t?t[l]=a:a===!0?t.setAttribute(l,""):su(t,l,a)}}}function Dt(t,e,l){switch(e){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"img":H("error",t),H("load",t);var a=!1,n=!1,u;for(u in l)if(l.hasOwnProperty(u)){var c=l[u];if(c!=null)switch(u){case"src":a=!0;break;case"srcSet":n=!0;break;case"children":case"dangerouslySetInnerHTML":throw Error(j(137,e));default:W(t,e,u,c,l,null)}}n&&W(t,e,"srcSet",l.srcSet,l,null),a&&W(t,e,"src",l.src,l,null);return;case"input":H("invalid",t);var i=u=c=n=null,s=null,r=null;for(a in l)if(l.hasOwnProperty(a)){var x=l[a];if(x!=null)switch(a){case"name":n=x;break;case"type":c=x;break;case"checked":s=x;break;case"defaultChecked":r=x;break;case"value":u=x;break;case"defaultValue":i=x;break;case"children":case"dangerouslySetInnerHTML":if(x!=null)throw Error(j(137,e));break;default:W(t,e,a,x,l,null)}}rd(t,u,i,s,r,c,n,!1);return;case"select":H("invalid",t),a=c=u=null;for(n in l)if(l.hasOwnProperty(n)&&(i=l[n],i!=null))switch(n){case"value":u=i;break;case"defaultValue":c=i;break;case"multiple":a=i;default:W(t,e,n,i,l,null)}e=u,l=c,t.multiple=!!a,e!=null?oa(t,!!a,e,!1):l!=null&&oa(t,!!a,l,!0);return;case"textarea":H("invalid",t),u=n=a=null;for(c in l)if(l.hasOwnProperty(c)&&(i=l[c],i!=null))switch(c){case"value":a=i;break;case"defaultValue":n=i;break;case"children":u=i;break;case"dangerouslySetInnerHTML":if(i!=null)throw Error(j(91));break;default:W(t,e,c,i,l,null)}xd(t,a,n,u);return;case"option":for(s in l)if(l.hasOwnProperty(s)&&(a=l[s],a!=null))switch(s){case"selected":t.selected=a&&typeof a!="function"&&typeof a!="symbol";break;default:W(t,e,s,a,l,null)}return;case"dialog":H("beforetoggle",t),H("toggle",t),H("cancel",t),H("close",t);break;case"iframe":case"object":H("load",t);break;case"video":case"audio":for(a=0;a<Sn.length;a++)H(Sn[a],t);break;case"image":H("error",t),H("load",t);break;case"details":H("toggle",t);break;case"embed":case"source":case"link":H("error",t),H("load",t);case"area":case"base":case"br":case"col":case"hr":case"keygen":case"meta":case"param":case"track":case"wbr":case"menuitem":for(r in l)if(l.hasOwnProperty(r)&&(a=l[r],a!=null))switch(r){case"children":case"dangerouslySetInnerHTML":throw Error(j(137,e));default:W(t,e,r,a,l,null)}return;default:if(Ns(e)){for(x in l)l.hasOwnProperty(x)&&(a=l[x],a!==void 0&&us(t,e,x,a,l,void 0));return}}for(i in l)l.hasOwnProperty(i)&&(a=l[i],a!=null&&W(t,e,i,a,l,null))}function qv(t,e,l,a){switch(e){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"input":var n=null,u=null,c=null,i=null,s=null,r=null,x=null;for(y in l){var h=l[y];if(l.hasOwnProperty(y)&&h!=null)switch(y){case"checked":break;case"value":break;case"defaultValue":s=h;default:a.hasOwnProperty(y)||W(t,e,y,null,a,h)}}for(var d in a){var y=a[d];if(h=l[d],a.hasOwnProperty(d)&&(y!=null||h!=null))switch(d){case"type":u=y;break;case"name":n=y;break;case"checked":r=y;break;case"defaultChecked":x=y;break;case"value":c=y;break;case"defaultValue":i=y;break;case"children":case"dangerouslySetInnerHTML":if(y!=null)throw Error(j(137,e));break;default:y!==h&&W(t,e,d,y,a,h)}}Ni(t,c,i,s,r,x,u,n);return;case"select":y=c=i=d=null;for(u in l)if(s=l[u],l.hasOwnProperty(u)&&s!=null)switch(u){case"value":break;case"multiple":y=s;default:a.hasOwnProperty(u)||W(t,e,u,null,a,s)}for(n in a)if(u=a[n],s=l[n],a.hasOwnProperty(n)&&(u!=null||s!=null))switch(n){case"value":d=u;break;case"defaultValue":i=u;break;case"multiple":c=u;default:u!==s&&W(t,e,n,u,a,s)}e=i,l=c,a=y,d!=null?oa(t,!!l,d,!1):!!a!=!!l&&(e!=null?oa(t,!!l,e,!0):oa(t,!!l,l?[]:"",!1));return;case"textarea":y=d=null;for(i in l)if(n=l[i],l.hasOwnProperty(i)&&n!=null&&!a.hasOwnProperty(i))switch(i){case"value":break;case"children":break;default:W(t,e,i,null,a,n)}for(c in a)if(n=a[c],u=l[c],a.hasOwnProperty(c)&&(n!=null||u!=null))switch(c){case"value":d=n;break;case"defaultValue":y=n;break;case"children":break;case"dangerouslySetInnerHTML":if(n!=null)throw Error(j(91));break;default:n!==u&&W(t,e,c,n,a,u)}dd(t,d,y);return;case"option":for(var p in l)if(d=l[p],l.hasOwnProperty(p)&&d!=null&&!a.hasOwnProperty(p))switch(p){case"selected":t.selected=!1;break;default:W(t,e,p,null,a,d)}for(s in a)if(d=a[s],y=l[s],a.hasOwnProperty(s)&&d!==y&&(d!=null||y!=null))switch(s){case"selected":t.selected=d&&typeof d!="function"&&typeof d!="symbol";break;default:W(t,e,s,d,a,y)}return;case"img":case"link":case"area":case"base":case"br":case"col":case"embed":case"hr":case"keygen":case"meta":case"param":case"source":case"track":case"wbr":case"menuitem":for(var S in l)d=l[S],l.hasOwnProperty(S)&&d!=null&&!a.hasOwnProperty(S)&&W(t,e,S,null,a,d);for(r in a)if(d=a[r],y=l[r],a.hasOwnProperty(r)&&d!==y&&(d!=null||y!=null))switch(r){case"children":case"dangerouslySetInnerHTML":if(d!=null)throw Error(j(137,e));break;default:W(t,e,r,d,a,y)}return;default:if(Ns(e)){for(var k in l)d=l[k],l.hasOwnProperty(k)&&d!==void 0&&!a.hasOwnProperty(k)&&us(t,e,k,void 0,a,d);for(x in a)d=a[x],y=l[x],!a.hasOwnProperty(x)||d===y||d===void 0&&y===void 0||us(t,e,x,d,a,y);return}}for(var m in l)d=l[m],l.hasOwnProperty(m)&&d!=null&&!a.hasOwnProperty(m)&&W(t,e,m,null,a,d);for(h in a)d=a[h],y=l[h],!a.hasOwnProperty(h)||d===y||d==null&&y==null||W(t,e,h,d,a,y)}function Wo(t){switch(t){case"css":case"script":case"font":case"img":case"image":case"input":case"link":return!0;default:return!1}}function Hv(){if(typeof performance.getEntriesByType=="function"){for(var t=0,e=0,l=performance.getEntriesByType("resource"),a=0;a<l.length;a++){var n=l[a],u=n.transferSize,c=n.initiatorType,i=n.duration;if(u&&i&&Wo(c)){for(c=0,i=n.responseEnd,a+=1;a<l.length;a++){var s=l[a],r=s.startTime;if(r>i)break;var x=s.transferSize,h=s.initiatorType;x&&Wo(h)&&(s=s.responseEnd,c+=x*(s<i?1:(i-r)/(s-r)))}if(--a,e+=8*(u+c)/(n.duration/1e3),t++,10<t)break}}if(0<t)return e/t/1e6}return navigator.connection&&(t=navigator.connection.downlink,typeof t=="number")?t:5}var cs=null,is=null;function Ku(t){return t.nodeType===9?t:t.ownerDocument}function Fo(t){switch(t){case"http://www.w3.org/2000/svg":return 1;case"http://www.w3.org/1998/Math/MathML":return 2;default:return 0}}function g0(t,e){if(t===0)switch(e){case"svg":return 1;case"math":return 2;default:return 0}return t===1&&e==="foreignObject"?0:t}function ss(t,e){return t==="textarea"||t==="noscript"||typeof e.children=="string"||typeof e.children=="number"||typeof e.children=="bigint"||typeof e.dangerouslySetInnerHTML=="object"&&e.dangerouslySetInnerHTML!==null&&e.dangerouslySetInnerHTML.__html!=null}var ci=null;function Uv(){var t=window.event;return t&&t.type==="popstate"?t===ci?!1:(ci=t,!0):(ci=null,!1)}var b0=typeof setTimeout=="function"?setTimeout:void 0,Bv=typeof clearTimeout=="function"?clearTimeout:void 0,Io=typeof Promise=="function"?Promise:void 0,Xv=typeof queueMicrotask=="function"?queueMicrotask:typeof Io<"u"?function(t){return Io.resolve(null).then(t).catch(Lv)}:b0;function Lv(t){setTimeout(function(){throw t})}function hl(t){return t==="head"}function Po(t,e){var l=e,a=0;do{var n=l.nextSibling;if(t.removeChild(l),n&&n.nodeType===8)if(l=n.data,l==="/$"||l==="/&"){if(a===0){t.removeChild(n),Ta(e);return}a--}else if(l==="$"||l==="$?"||l==="$~"||l==="$!"||l==="&")a++;else if(l==="html")rn(t.ownerDocument.documentElement);else if(l==="head"){l=t.ownerDocument.head,rn(l);for(var u=l.firstChild;u;){var c=u.nextSibling,i=u.nodeName;u[On]||i==="SCRIPT"||i==="STYLE"||i==="LINK"&&u.rel.toLowerCase()==="stylesheet"||l.removeChild(u),u=c}}else l==="body"&&rn(t.ownerDocument.body);l=n}while(l);Ta(e)}function tr(t,e){var l=t;t=0;do{var a=l.nextSibling;if(l.nodeType===1?e?(l._stashedDisplay=l.style.display,l.style.display="none"):(l.style.display=l._stashedDisplay||"",l.getAttribute("style")===""&&l.removeAttribute("style")):l.nodeType===3&&(e?(l._stashedText=l.nodeValue,l.nodeValue=""):l.nodeValue=l._stashedText||""),a&&a.nodeType===8)if(l=a.data,l==="/$"){if(t===0)break;t--}else l!=="$"&&l!=="$?"&&l!=="$~"&&l!=="$!"||t++;l=a}while(l)}function fs(t){var e=t.firstChild;for(e&&e.nodeType===10&&(e=e.nextSibling);e;){var l=e;switch(e=e.nextSibling,l.nodeName){case"HTML":case"HEAD":case"BODY":fs(l),$s(l);continue;case"SCRIPT":case"STYLE":continue;case"LINK":if(l.rel.toLowerCase()==="stylesheet")continue}t.removeChild(l)}}function Zv(t,e,l,a){for(;t.nodeType===1;){var n=l;if(t.nodeName.toLowerCase()!==e.toLowerCase()){if(!a&&(t.nodeName!=="INPUT"||t.type!=="hidden"))break}else if(a){if(!t[On])switch(e){case"meta":if(!t.hasAttribute("itemprop"))break;return t;case"link":if(u=t.getAttribute("rel"),u==="stylesheet"&&t.hasAttribute("data-precedence"))break;if(u!==n.rel||t.getAttribute("href")!==(n.href==null||n.href===""?null:n.href)||t.getAttribute("crossorigin")!==(n.crossOrigin==null?null:n.crossOrigin)||t.getAttribute("title")!==(n.title==null?null:n.title))break;return t;case"style":if(t.hasAttribute("data-precedence"))break;return t;case"script":if(u=t.getAttribute("src"),(u!==(n.src==null?null:n.src)||t.getAttribute("type")!==(n.type==null?null:n.type)||t.getAttribute("crossorigin")!==(n.crossOrigin==null?null:n.crossOrigin))&&u&&t.hasAttribute("async")&&!t.hasAttribute("itemprop"))break;return t;default:return t}}else if(e==="input"&&t.type==="hidden"){var u=n.name==null?null:""+n.name;if(n.type==="hidden"&&t.getAttribute("name")===u)return t}else return t;if(t=oe(t.nextSibling),t===null)break}return null}function Gv(t,e,l){if(e==="")return null;for(;t.nodeType!==3;)if((t.nodeType!==1||t.nodeName!=="INPUT"||t.type!=="hidden")&&!l||(t=oe(t.nextSibling),t===null))return null;return t}function p0(t,e){for(;t.nodeType!==8;)if((t.nodeType!==1||t.nodeName!=="INPUT"||t.type!=="hidden")&&!e||(t=oe(t.nextSibling),t===null))return null;return t}function os(t){return t.data==="$?"||t.data==="$~"}function rs(t){return t.data==="$!"||t.data==="$?"&&t.ownerDocument.readyState!=="loading"}function Yv(t,e){var l=t.ownerDocument;if(t.data==="$~")t._reactRetry=e;else if(t.data!=="$?"||l.readyState!=="loading")e();else{var a=function(){e(),l.removeEventListener("DOMContentLoaded",a)};l.addEventListener("DOMContentLoaded",a),t._reactRetry=a}}function oe(t){for(;t!=null;t=t.nextSibling){var e=t.nodeType;if(e===1||e===3)break;if(e===8){if(e=t.data,e==="$"||e==="$!"||e==="$?"||e==="$~"||e==="&"||e==="F!"||e==="F")break;if(e==="/$"||e==="/&")return null}}return t}var ds=null;function er(t){t=t.nextSibling;for(var e=0;t;){if(t.nodeType===8){var l=t.data;if(l==="/$"||l==="/&"){if(e===0)return oe(t.nextSibling);e--}else l!=="$"&&l!=="$!"&&l!=="$?"&&l!=="$~"&&l!=="&"||e++}t=t.nextSibling}return null}function lr(t){t=t.previousSibling;for(var e=0;t;){if(t.nodeType===8){var l=t.data;if(l==="$"||l==="$!"||l==="$?"||l==="$~"||l==="&"){if(e===0)return t;e--}else l!=="/$"&&l!=="/&"||e++}t=t.previousSibling}return null}function S0(t,e,l){switch(e=Ku(l),t){case"html":if(t=e.documentElement,!t)throw Error(j(452));return t;case"head":if(t=e.head,!t)throw Error(j(453));return t;case"body":if(t=e.body,!t)throw Error(j(454));return t;default:throw Error(j(451))}}function rn(t){for(var e=t.attributes;e.length;)t.removeAttributeNode(e[0]);$s(t)}var re=new Map,ar=new Set;function Ju(t){return typeof t.getRootNode=="function"?t.getRootNode():t.nodeType===9?t:t.ownerDocument}var Xe=Y.d;Y.d={f:Vv,r:Qv,D:Kv,C:Jv,L:Wv,m:Fv,X:Pv,S:Iv,M:ty};function Vv(){var t=Xe.f(),e=yc();return t||e}function Qv(t){var e=$a(t);e!==null&&e.tag===5&&e.type==="form"?m1(e):Xe.r(t)}var wa=typeof document>"u"?null:document;function k0(t,e,l){var a=wa;if(a&&typeof e=="string"&&e){var n=ce(e);n='link[rel="'+t+'"][href="'+n+'"]',typeof l=="string"&&(n+='[crossorigin="'+l+'"]'),ar.has(n)||(ar.add(n),t={rel:t,crossOrigin:l,href:e},a.querySelector(n)===null&&(e=a.createElement("link"),Dt(e,"link",t),zt(e),a.head.appendChild(e)))}}function Kv(t){Xe.D(t),k0("dns-prefetch",t,null)}function Jv(t,e){Xe.C(t,e),k0("preconnect",t,e)}function Wv(t,e,l){Xe.L(t,e,l);var a=wa;if(a&&t&&e){var n='link[rel="preload"][as="'+ce(e)+'"]';e==="image"&&l&&l.imageSrcSet?(n+='[imagesrcset="'+ce(l.imageSrcSet)+'"]',typeof l.imageSizes=="string"&&(n+='[imagesizes="'+ce(l.imageSizes)+'"]')):n+='[href="'+ce(t)+'"]';var u=n;switch(e){case"style":u=Ea(t);break;case"script":u=Ca(t)}re.has(u)||(t=ct({rel:"preload",href:e==="image"&&l&&l.imageSrcSet?void 0:t,as:e},l),re.set(u,t),a.querySelector(n)!==null||e==="style"&&a.querySelector(qn(u))||e==="script"&&a.querySelector(Hn(u))||(e=a.createElement("link"),Dt(e,"link",t),zt(e),a.head.appendChild(e)))}}function Fv(t,e){Xe.m(t,e);var l=wa;if(l&&t){var a=e&&typeof e.as=="string"?e.as:"script",n='link[rel="modulepreload"][as="'+ce(a)+'"][href="'+ce(t)+'"]',u=n;switch(a){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":u=Ca(t)}if(!re.has(u)&&(t=ct({rel:"modulepreload",href:t},e),re.set(u,t),l.querySelector(n)===null)){switch(a){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":if(l.querySelector(Hn(u)))return}a=l.createElement("link"),Dt(a,"link",t),zt(a),l.head.appendChild(a)}}}function Iv(t,e,l){Xe.S(t,e,l);var a=wa;if(a&&t){var n=fa(a).hoistableStyles,u=Ea(t);e=e||"default";var c=n.get(u);if(!c){var i={loading:0,preload:null};if(c=a.querySelector(qn(u)))i.loading=5;else{t=ct({rel:"stylesheet",href:t,"data-precedence":e},l),(l=re.get(u))&&vf(t,l);var s=c=a.createElement("link");zt(s),Dt(s,"link",t),s._p=new Promise(function(r,x){s.onload=r,s.onerror=x}),s.addEventListener("load",function(){i.loading|=1}),s.addEventListener("error",function(){i.loading|=2}),i.loading|=4,bu(c,e,a)}c={type:"stylesheet",instance:c,count:1,state:i},n.set(u,c)}}}function Pv(t,e){Xe.X(t,e);var l=wa;if(l&&t){var a=fa(l).hoistableScripts,n=Ca(t),u=a.get(n);u||(u=l.querySelector(Hn(n)),u||(t=ct({src:t,async:!0},e),(e=re.get(n))&&yf(t,e),u=l.createElement("script"),zt(u),Dt(u,"link",t),l.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},a.set(n,u))}}function ty(t,e){Xe.M(t,e);var l=wa;if(l&&t){var a=fa(l).hoistableScripts,n=Ca(t),u=a.get(n);u||(u=l.querySelector(Hn(n)),u||(t=ct({src:t,async:!0,type:"module"},e),(e=re.get(n))&&yf(t,e),u=l.createElement("script"),zt(u),Dt(u,"link",t),l.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},a.set(n,u))}}function nr(t,e,l,a){var n=(n=al.current)?Ju(n):null;if(!n)throw Error(j(446));switch(t){case"meta":case"title":return null;case"style":return typeof l.precedence=="string"&&typeof l.href=="string"?(e=Ea(l.href),l=fa(n).hoistableStyles,a=l.get(e),a||(a={type:"style",instance:null,count:0,state:null},l.set(e,a)),a):{type:"void",instance:null,count:0,state:null};case"link":if(l.rel==="stylesheet"&&typeof l.href=="string"&&typeof l.precedence=="string"){t=Ea(l.href);var u=fa(n).hoistableStyles,c=u.get(t);if(c||(n=n.ownerDocument||n,c={type:"stylesheet",instance:null,count:0,state:{loading:0,preload:null}},u.set(t,c),(u=n.querySelector(qn(t)))&&!u._p&&(c.instance=u,c.state.loading=5),re.has(t)||(l={rel:"preload",as:"style",href:l.href,crossOrigin:l.crossOrigin,integrity:l.integrity,media:l.media,hrefLang:l.hrefLang,referrerPolicy:l.referrerPolicy},re.set(t,l),u||ey(n,t,l,c.state))),e&&a===null)throw Error(j(528,""));return c}if(e&&a!==null)throw Error(j(529,""));return null;case"script":return e=l.async,l=l.src,typeof l=="string"&&e&&typeof e!="function"&&typeof e!="symbol"?(e=Ca(l),l=fa(n).hoistableScripts,a=l.get(e),a||(a={type:"script",instance:null,count:0,state:null},l.set(e,a)),a):{type:"void",instance:null,count:0,state:null};default:throw Error(j(444,t))}}function Ea(t){return'href="'+ce(t)+'"'}function qn(t){return'link[rel="stylesheet"]['+t+"]"}function z0(t){return ct({},t,{"data-precedence":t.precedence,precedence:null})}function ey(t,e,l,a){t.querySelector('link[rel="preload"][as="style"]['+e+"]")?a.loading=1:(e=t.createElement("link"),a.preload=e,e.addEventListener("load",function(){return a.loading|=1}),e.addEventListener("error",function(){return a.loading|=2}),Dt(e,"link",l),zt(e),t.head.appendChild(e))}function Ca(t){return'[src="'+ce(t)+'"]'}function Hn(t){return"script[async]"+t}function ur(t,e,l){if(e.count++,e.instance===null)switch(e.type){case"style":var a=t.querySelector('style[data-href~="'+ce(l.href)+'"]');if(a)return e.instance=a,zt(a),a;var n=ct({},l,{"data-href":l.href,"data-precedence":l.precedence,href:null,precedence:null});return a=(t.ownerDocument||t).createElement("style"),zt(a),Dt(a,"style",n),bu(a,l.precedence,t),e.instance=a;case"stylesheet":n=Ea(l.href);var u=t.querySelector(qn(n));if(u)return e.state.loading|=4,e.instance=u,zt(u),u;a=z0(l),(n=re.get(n))&&vf(a,n),u=(t.ownerDocument||t).createElement("link"),zt(u);var c=u;return c._p=new Promise(function(i,s){c.onload=i,c.onerror=s}),Dt(u,"link",a),e.state.loading|=4,bu(u,l.precedence,t),e.instance=u;case"script":return u=Ca(l.src),(n=t.querySelector(Hn(u)))?(e.instance=n,zt(n),n):(a=l,(n=re.get(u))&&(a=ct({},l),yf(a,n)),t=t.ownerDocument||t,n=t.createElement("script"),zt(n),Dt(n,"link",a),t.head.appendChild(n),e.instance=n);case"void":return null;default:throw Error(j(443,e.type))}else e.type==="stylesheet"&&!(e.state.loading&4)&&(a=e.instance,e.state.loading|=4,bu(a,l.precedence,t));return e.instance}function bu(t,e,l){for(var a=l.querySelectorAll('link[rel="stylesheet"][data-precedence],style[data-precedence]'),n=a.length?a[a.length-1]:null,u=n,c=0;c<a.length;c++){var i=a[c];if(i.dataset.precedence===e)u=i;else if(u!==n)break}u?u.parentNode.insertBefore(t,u.nextSibling):(e=l.nodeType===9?l.head:l,e.insertBefore(t,e.firstChild))}function vf(t,e){t.crossOrigin==null&&(t.crossOrigin=e.crossOrigin),t.referrerPolicy==null&&(t.referrerPolicy=e.referrerPolicy),t.title==null&&(t.title=e.title)}function yf(t,e){t.crossOrigin==null&&(t.crossOrigin=e.crossOrigin),t.referrerPolicy==null&&(t.referrerPolicy=e.referrerPolicy),t.integrity==null&&(t.integrity=e.integrity)}var pu=null;function cr(t,e,l){if(pu===null){var a=new Map,n=pu=new Map;n.set(l,a)}else n=pu,a=n.get(l),a||(a=new Map,n.set(l,a));if(a.has(t))return a;for(a.set(t,null),l=l.getElementsByTagName(t),n=0;n<l.length;n++){var u=l[n];if(!(u[On]||u[$t]||t==="link"&&u.getAttribute("rel")==="stylesheet")&&u.namespaceURI!=="http://www.w3.org/2000/svg"){var c=u.getAttribute(e)||"";c=t+c;var i=a.get(c);i?i.push(u):a.set(c,[u])}}return a}function ir(t,e,l){t=t.ownerDocument||t,t.head.insertBefore(l,e==="title"?t.querySelector("head > title"):null)}function ly(t,e,l){if(l===1||e.itemProp!=null)return!1;switch(t){case"meta":case"title":return!0;case"style":if(typeof e.precedence!="string"||typeof e.href!="string"||e.href==="")break;return!0;case"link":if(typeof e.rel!="string"||typeof e.href!="string"||e.href===""||e.onLoad||e.onError)break;switch(e.rel){case"stylesheet":return t=e.disabled,typeof e.precedence=="string"&&t==null;default:return!0}case"script":if(e.async&&typeof e.async!="function"&&typeof e.async!="symbol"&&!e.onLoad&&!e.onError&&e.src&&typeof e.src=="string")return!0}return!1}function j0(t){return!(t.type==="stylesheet"&&!(t.state.loading&3))}function ay(t,e,l,a){if(l.type==="stylesheet"&&(typeof a.media!="string"||matchMedia(a.media).matches!==!1)&&!(l.state.loading&4)){if(l.instance===null){var n=Ea(a.href),u=e.querySelector(qn(n));if(u){e=u._p,e!==null&&typeof e=="object"&&typeof e.then=="function"&&(t.count++,t=Wu.bind(t),e.then(t,t)),l.state.loading|=4,l.instance=u,zt(u);return}u=e.ownerDocument||e,a=z0(a),(n=re.get(n))&&vf(a,n),u=u.createElement("link"),zt(u);var c=u;c._p=new Promise(function(i,s){c.onload=i,c.onerror=s}),Dt(u,"link",a),l.instance=u}t.stylesheets===null&&(t.stylesheets=new Map),t.stylesheets.set(l,e),(e=l.state.preload)&&!(l.state.loading&3)&&(t.count++,l=Wu.bind(t),e.addEventListener("load",l),e.addEventListener("error",l))}}var ii=0;function ny(t,e){return t.stylesheets&&t.count===0&&Su(t,t.stylesheets),0<t.count||0<t.imgCount?function(l){var a=setTimeout(function(){if(t.stylesheets&&Su(t,t.stylesheets),t.unsuspend){var u=t.unsuspend;t.unsuspend=null,u()}},6e4+e);0<t.imgBytes&&ii===0&&(ii=62500*Hv());var n=setTimeout(function(){if(t.waitingForImages=!1,t.count===0&&(t.stylesheets&&Su(t,t.stylesheets),t.unsuspend)){var u=t.unsuspend;t.unsuspend=null,u()}},(t.imgBytes>ii?50:800)+e);return t.unsuspend=l,function(){t.unsuspend=null,clearTimeout(a),clearTimeout(n)}}:null}function Wu(){if(this.count--,this.count===0&&(this.imgCount===0||!this.waitingForImages)){if(this.stylesheets)Su(this,this.stylesheets);else if(this.unsuspend){var t=this.unsuspend;this.unsuspend=null,t()}}}var Fu=null;function Su(t,e){t.stylesheets=null,t.unsuspend!==null&&(t.count++,Fu=new Map,e.forEach(uy,t),Fu=null,Wu.call(t))}function uy(t,e){if(!(e.state.loading&4)){var l=Fu.get(t);if(l)var a=l.get(null);else{l=new Map,Fu.set(t,l);for(var n=t.querySelectorAll("link[data-precedence],style[data-precedence]"),u=0;u<n.length;u++){var c=n[u];(c.nodeName==="LINK"||c.getAttribute("media")!=="not all")&&(l.set(c.dataset.precedence,c),a=c)}a&&l.set(null,a)}n=e.instance,c=n.getAttribute("data-precedence"),u=l.get(c)||a,u===a&&l.set(null,n),l.set(c,n),this.count++,a=Wu.bind(this),n.addEventListener("load",a),n.addEventListener("error",a),u?u.parentNode.insertBefore(n,u.nextSibling):(t=t.nodeType===9?t.head:t,t.insertBefore(n,t.firstChild)),e.state.loading|=4}}var zn={$$typeof:Ne,Provider:null,Consumer:null,_currentValue:Tl,_currentValue2:Tl,_threadCount:0};function cy(t,e,l,a,n,u,c,i,s){this.tag=1,this.containerInfo=t,this.pingCache=this.current=this.pendingChildren=null,this.timeoutHandle=-1,this.callbackNode=this.next=this.pendingContext=this.context=this.cancelPendingCommit=null,this.callbackPriority=0,this.expirationTimes=Nc(-1),this.entangledLanes=this.shellSuspendCounter=this.errorRecoveryDisabledLanes=this.expiredLanes=this.warmLanes=this.pingedLanes=this.suspendedLanes=this.pendingLanes=0,this.entanglements=Nc(0),this.hiddenUpdates=Nc(null),this.identifierPrefix=a,this.onUncaughtError=n,this.onCaughtError=u,this.onRecoverableError=c,this.pooledCache=null,this.pooledCacheLanes=0,this.formState=s,this.incompleteTransitions=new Map}function E0(t,e,l,a,n,u,c,i,s,r,x,h){return t=new cy(t,e,l,c,s,r,x,h,i),e=1,u===!0&&(e|=24),u=Kt(3,null,null,e),t.current=u,u.stateNode=t,e=Xs(),e.refCount++,t.pooledCache=e,e.refCount++,u.memoizedState={element:a,isDehydrated:l,cache:e},Gs(u),t}function T0(t){return t?(t=ua,t):ua}function M0(t,e,l,a,n,u){n=T0(n),a.context===null?a.context=n:a.pendingContext=n,a=ul(e),a.payload={element:l},u=u===void 0?null:u,u!==null&&(a.callback=u),l=cl(t,a,e),l!==null&&(Lt(l,t,e),ln(l,t,e))}function sr(t,e){if(t=t.memoizedState,t!==null&&t.dehydrated!==null){var l=t.retryLane;t.retryLane=l!==0&&l<e?l:e}}function hf(t,e){sr(t,e),(t=t.alternate)&&sr(t,e)}function A0(t){if(t.tag===13||t.tag===31){var e=Ul(t,67108864);e!==null&&Lt(e,t,67108864),hf(t,67108864)}}function fr(t){if(t.tag===13||t.tag===31){var e=Pt();e=Ms(e);var l=Ul(t,e);l!==null&&Lt(l,t,e),hf(t,e)}}var Iu=!0;function iy(t,e,l,a){var n=w.T;w.T=null;var u=Y.p;try{Y.p=2,gf(t,e,l,a)}finally{Y.p=u,w.T=n}}function sy(t,e,l,a){var n=w.T;w.T=null;var u=Y.p;try{Y.p=8,gf(t,e,l,a)}finally{Y.p=u,w.T=n}}function gf(t,e,l,a){if(Iu){var n=xs(a);if(n===null)ui(t,e,a,Pu,l),or(t,a);else if(oy(n,t,e,l,a))a.stopPropagation();else if(or(t,a),e&4&&-1<fy.indexOf(t)){for(;n!==null;){var u=$a(n);if(u!==null)switch(u.tag){case 3:if(u=u.stateNode,u.current.memoizedState.isDehydrated){var c=zl(u.pendingLanes);if(c!==0){var i=u;for(i.pendingLanes|=2,i.entangledLanes|=2;c;){var s=1<<31-It(c);i.entanglements[1]|=s,c&=~s}ke(u),!(G&6)&&(Lu=Wt()+500,Rn(0))}}break;case 31:case 13:i=Ul(u,2),i!==null&&Lt(i,u,2),yc(),hf(u,2)}if(u=xs(a),u===null&&ui(t,e,a,Pu,l),u===n)break;n=u}n!==null&&a.stopPropagation()}else ui(t,e,a,null,l)}}function xs(t){return t=Os(t),bf(t)}var Pu=null;function bf(t){if(Pu=null,t=Pl(t),t!==null){var e=Mn(t);if(e===null)t=null;else{var l=e.tag;if(l===13){if(t=Kr(e),t!==null)return t;t=null}else if(l===31){if(t=Jr(e),t!==null)return t;t=null}else if(l===3){if(e.stateNode.current.memoizedState.isDehydrated)return e.tag===3?e.stateNode.containerInfo:null;t=null}else e!==t&&(t=null)}}return Pu=t,null}function $0(t){switch(t){case"beforetoggle":case"cancel":case"click":case"close":case"contextmenu":case"copy":case"cut":case"auxclick":case"dblclick":case"dragend":case"dragstart":case"drop":case"focusin":case"focusout":case"input":case"invalid":case"keydown":case"keypress":case"keyup":case"mousedown":case"mouseup":case"paste":case"pause":case"play":case"pointercancel":case"pointerdown":case"pointerup":case"ratechange":case"reset":case"resize":case"seeked":case"submit":case"toggle":case"touchcancel":case"touchend":case"touchstart":case"volumechange":case"change":case"selectionchange":case"textInput":case"compositionstart":case"compositionend":case"compositionupdate":case"beforeblur":case"afterblur":case"beforeinput":case"blur":case"fullscreenchange":case"focus":case"hashchange":case"popstate":case"select":case"selectstart":return 2;case"drag":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"mousemove":case"mouseout":case"mouseover":case"pointermove":case"pointerout":case"pointerover":case"scroll":case"touchmove":case"wheel":case"mouseenter":case"mouseleave":case"pointerenter":case"pointerleave":return 8;case"message":switch(Kx()){case Pr:return 2;case td:return 8;case Au:case Jx:return 32;case ed:return 268435456;default:return 32}default:return 32}}var ms=!1,fl=null,ol=null,rl=null,jn=new Map,En=new Map,Fe=[],fy="mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset".split(" ");function or(t,e){switch(t){case"focusin":case"focusout":fl=null;break;case"dragenter":case"dragleave":ol=null;break;case"mouseover":case"mouseout":rl=null;break;case"pointerover":case"pointerout":jn.delete(e.pointerId);break;case"gotpointercapture":case"lostpointercapture":En.delete(e.pointerId)}}function La(t,e,l,a,n,u){return t===null||t.nativeEvent!==u?(t={blockedOn:e,domEventName:l,eventSystemFlags:a,nativeEvent:u,targetContainers:[n]},e!==null&&(e=$a(e),e!==null&&A0(e)),t):(t.eventSystemFlags|=a,e=t.targetContainers,n!==null&&e.indexOf(n)===-1&&e.push(n),t)}function oy(t,e,l,a,n){switch(e){case"focusin":return fl=La(fl,t,e,l,a,n),!0;case"dragenter":return ol=La(ol,t,e,l,a,n),!0;case"mouseover":return rl=La(rl,t,e,l,a,n),!0;case"pointerover":var u=n.pointerId;return jn.set(u,La(jn.get(u)||null,t,e,l,a,n)),!0;case"gotpointercapture":return u=n.pointerId,En.set(u,La(En.get(u)||null,t,e,l,a,n)),!0}return!1}function N0(t){var e=Pl(t.target);if(e!==null){var l=Mn(e);if(l!==null){if(e=l.tag,e===13){if(e=Kr(l),e!==null){t.blockedOn=e,Qf(t.priority,function(){fr(l)});return}}else if(e===31){if(e=Jr(l),e!==null){t.blockedOn=e,Qf(t.priority,function(){fr(l)});return}}else if(e===3&&l.stateNode.current.memoizedState.isDehydrated){t.blockedOn=l.tag===3?l.stateNode.containerInfo:null;return}}}t.blockedOn=null}function ku(t){if(t.blockedOn!==null)return!1;for(var e=t.targetContainers;0<e.length;){var l=xs(t.nativeEvent);if(l===null){l=t.nativeEvent;var a=new l.constructor(l.type,l);Di=a,l.target.dispatchEvent(a),Di=null}else return e=$a(l),e!==null&&A0(e),t.blockedOn=l,!1;e.shift()}return!0}function rr(t,e,l){ku(t)&&l.delete(e)}function ry(){ms=!1,fl!==null&&ku(fl)&&(fl=null),ol!==null&&ku(ol)&&(ol=null),rl!==null&&ku(rl)&&(rl=null),jn.forEach(rr),En.forEach(rr)}function tu(t,e){t.blockedOn===e&&(t.blockedOn=null,ms||(ms=!0,pt.unstable_scheduleCallback(pt.unstable_NormalPriority,ry)))}var eu=null;function dr(t){eu!==t&&(eu=t,pt.unstable_scheduleCallback(pt.unstable_NormalPriority,function(){eu===t&&(eu=null);for(var e=0;e<t.length;e+=3){var l=t[e],a=t[e+1],n=t[e+2];if(typeof a!="function"){if(bf(a||l)===null)continue;break}var u=$a(l);u!==null&&(t.splice(e,3),e-=3,Ki(u,{pending:!0,data:n,method:l.method,action:a},a,n))}}))}function Ta(t){function e(s){return tu(s,t)}fl!==null&&tu(fl,t),ol!==null&&tu(ol,t),rl!==null&&tu(rl,t),jn.forEach(e),En.forEach(e);for(var l=0;l<Fe.length;l++){var a=Fe[l];a.blockedOn===t&&(a.blockedOn=null)}for(;0<Fe.length&&(l=Fe[0],l.blockedOn===null);)N0(l),l.blockedOn===null&&Fe.shift();if(l=(t.ownerDocument||t).$$reactFormReplay,l!=null)for(a=0;a<l.length;a+=3){var n=l[a],u=l[a+1],c=n[Zt]||null;if(typeof u=="function")c||dr(l);else if(c){var i=null;if(u&&u.hasAttribute("formAction")){if(n=u,c=u[Zt]||null)i=c.formAction;else if(bf(n)!==null)continue}else i=c.action;typeof i=="function"?l[a+1]=i:(l.splice(a,3),a-=3),dr(l)}}}function O0(){function t(u){u.canIntercept&&u.info==="react-transition"&&u.intercept({handler:function(){return new Promise(function(c){return n=c})},focusReset:"manual",scroll:"manual"})}function e(){n!==null&&(n(),n=null),a||setTimeout(l,20)}function l(){if(!a&&!navigation.transition){var u=navigation.currentEntry;u&&u.url!=null&&navigation.navigate(u.url,{state:u.getState(),info:"react-transition",history:"replace"})}}if(typeof navigation=="object"){var a=!1,n=null;return navigation.addEventListener("navigate",t),navigation.addEventListener("navigatesuccess",e),navigation.addEventListener("navigateerror",e),setTimeout(l,100),function(){a=!0,navigation.removeEventListener("navigate",t),navigation.removeEventListener("navigatesuccess",e),navigation.removeEventListener("navigateerror",e),n!==null&&(n(),n=null)}}}function pf(t){this._internalRoot=t}bc.prototype.render=pf.prototype.render=function(t){var e=this._internalRoot;if(e===null)throw Error(j(409));var l=e.current,a=Pt();M0(l,a,t,e,null,null)};bc.prototype.unmount=pf.prototype.unmount=function(){var t=this._internalRoot;if(t!==null){this._internalRoot=null;var e=t.containerInfo;M0(t.current,2,null,t,null,null),yc(),e[Aa]=null}};function bc(t){this._internalRoot=t}bc.prototype.unstable_scheduleHydration=function(t){if(t){var e=cd();t={blockedOn:null,target:t,priority:e};for(var l=0;l<Fe.length&&e!==0&&e<Fe[l].priority;l++);Fe.splice(l,0,t),l===0&&N0(t)}};var xr=Vr.version;if(xr!=="19.2.4")throw Error(j(527,xr,"19.2.4"));Y.findDOMNode=function(t){var e=t._reactInternals;if(e===void 0)throw typeof t.render=="function"?Error(j(188)):(t=Object.keys(t).join(","),Error(j(268,t)));return t=Xx(e),t=t!==null?Wr(t):null,t=t===null?null:t.stateNode,t};var dy={bundleType:0,version:"19.2.4",rendererPackageName:"react-dom",currentDispatcherRef:w,reconcilerVersion:"19.2.4"};if(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__<"u"){var lu=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(!lu.isDisabled&&lu.supportsFiber)try{An=lu.inject(dy),Ft=lu}catch{}}lc.createRoot=function(t,e){if(!Qr(t))throw Error(j(299));var l=!1,a="",n=k1,u=z1,c=j1;return e!=null&&(e.unstable_strictMode===!0&&(l=!0),e.identifierPrefix!==void 0&&(a=e.identifierPrefix),e.onUncaughtError!==void 0&&(n=e.onUncaughtError),e.onCaughtError!==void 0&&(u=e.onCaughtError),e.onRecoverableError!==void 0&&(c=e.onRecoverableError)),e=E0(t,1,!1,null,null,l,a,null,n,u,c,O0),t[Aa]=e.current,mf(t),new pf(e)};lc.hydrateRoot=function(t,e,l){if(!Qr(t))throw Error(j(299));var a=!1,n="",u=k1,c=z1,i=j1,s=null;return l!=null&&(l.unstable_strictMode===!0&&(a=!0),l.identifierPrefix!==void 0&&(n=l.identifierPrefix),l.onUncaughtError!==void 0&&(u=l.onUncaughtError),l.onCaughtError!==void 0&&(c=l.onCaughtError),l.onRecoverableError!==void 0&&(i=l.onRecoverableError),l.formState!==void 0&&(s=l.formState)),e=E0(t,1,!0,e,l??null,a,n,s,u,c,i,O0),e.context=T0(null),l=e.current,a=Pt(),a=Ms(a),n=ul(a),n.callback=null,cl(l,n,a),l=a,e.current.lanes=l,Nn(e,l),ke(e),t[Aa]=e.current,mf(t),new bc(e)};lc.version="19.2.4";function D0(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(D0)}catch(t){console.error(t)}}D0(),wr.exports=lc;var xy=wr.exports,Za={},mr;function my(){if(mr)return Za;mr=1,Object.defineProperty(Za,"__esModule",{value:!0}),Za.styleq=void 0;var t=new WeakMap,e="$$css";function l(n){var u,c,i;return n!=null&&(u=n.disableCache===!0,c=n.disableMix===!0,i=n.transform),function(){for(var r=[],x="",h=null,d="",y=u?null:t,p=new Array(arguments.length),S=0;S<arguments.length;S++)p[S]=arguments[S];for(;p.length>0;){var k=p.pop();if(!(k==null||k===!1)){if(Array.isArray(k)){for(var m=0;m<k.length;m++)p.push(k[m]);continue}var f=i!=null?i(k):k;if(f.$$css!=null){var v="";if(y!=null&&y.has(f)){var b=y.get(f);b!=null&&(v=b[0],d=b[2],r.push.apply(r,b[1]),y=b[3])}else{var z=[];for(var N in f){var E=f[N];if(N===e){var M=f[N];M!==!0&&(d=d?M+"; "+d:M);continue}typeof E=="string"||E===null?r.includes(N)||(r.push(N),y!=null&&z.push(N),typeof E=="string"&&(v+=v?" "+E:E)):console.error("styleq: ".concat(N," typeof ").concat(String(E),' is not "string" or "null".'))}if(y!=null){var T=new WeakMap;y.set(f,[v,z,d,T]),y=T}}v&&(x=x?v+" "+x:v)}else if(c)h==null&&(h={}),h=Object.assign({},f,h);else{var A=null;for(var C in f){var Z=f[C];Z!==void 0&&(r.includes(C)||(Z!=null&&(h==null&&(h={}),A==null&&(A={}),A[C]=Z),r.push(C),y=null))}A!=null&&(h=Object.assign(A,h))}}}var I=[x,h,d];return I}}var a=Za.styleq=l();return a.factory=l,Za}var vy=my();function _(...t){const[e,l,a]=vy.styleq(t),n={};return e!=null&&e!==""&&(n.className=e),l!=null&&Object.keys(l).length>0&&(n.style=l),a!=null&&a!==""&&(n["data-style-src"]=a),n}const vr={"--color-accent":"var(--color-accent)","--color-on-dark":"var(--color-on-dark)"},Tt={xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:1.5,strokeLinecap:"round",strokeLinejoin:"round",width:"1em",height:"1em","aria-hidden":!0},au={xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor",width:"1em",height:"1em","aria-hidden":!0},yy={close:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M6 6l12 12M6 18L18 6"})}),chevronDown:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M6 9l6 6 6-6"})}),chevronLeft:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M15 6l-6 6 6 6"})}),chevronRight:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M9 6l6 6-6 6"})}),check:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M5 13l4 4L19 7"})}),checkCircle:o.jsx("svg",{...au,children:o.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M12 3a9 9 0 100 18 9 9 0 000-18zm4.06 6.56a.75.75 0 00-1.12-1l-3.94 4.4-1.94-1.94a.75.75 0 00-1.06 1.06l2.5 2.5a.75.75 0 001.09-.03l4.47-5z"})}),xCircle:o.jsx("svg",{...au,children:o.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M12 3a9 9 0 100 18 9 9 0 000-18zm-2.47 5.47a.75.75 0 00-1.06 1.06L10.94 12l-2.47 2.47a.75.75 0 101.06 1.06L12 13.06l2.47 2.47a.75.75 0 101.06-1.06L13.06 12l2.47-2.47a.75.75 0 00-1.06-1.06L12 10.94l-2.47-2.47z"})}),warning:o.jsx("svg",{...au,children:o.jsx("path",{fillRule:"evenodd",clipRule:"evenodd",d:"M10.29 3.86L2.07 19.05A2 2 0 003.78 22h16.44a2 2 0 001.71-2.95L13.71 3.86a2 2 0 00-3.42 0zM12 9a.75.75 0 01.75.75v4.5a.75.75 0 01-1.5 0v-4.5A.75.75 0 0112 9zm0 9a1 1 0 100-2 1 1 0 000 2z"})}),info:o.jsxs("svg",{...Tt,children:[o.jsx("circle",{cx:"12",cy:"12",r:"9"}),o.jsx("path",{d:"M12 11v5"}),o.jsx("circle",{cx:"12",cy:"8",r:"0.5",fill:"currentColor",stroke:"none"})]}),calendar:o.jsxs("svg",{...Tt,children:[o.jsx("rect",{x:"3",y:"4",width:"18",height:"18",rx:"2"}),o.jsx("path",{d:"M16 2v4M8 2v4M3 10h18"})]}),clock:o.jsxs("svg",{...Tt,children:[o.jsx("circle",{cx:"12",cy:"12",r:"9"}),o.jsx("path",{d:"M12 7v5l3 3"})]}),externalLink:o.jsxs("svg",{...Tt,children:[o.jsx("path",{d:"M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6"}),o.jsx("path",{d:"M15 3h6v6"}),o.jsx("path",{d:"M10 14L21 3"})]}),menu:o.jsx("svg",{...Tt,strokeWidth:2,children:o.jsx("path",{d:"M4 6h16M4 12h16M4 18h16"})}),moreHorizontal:o.jsxs("svg",{...au,children:[o.jsx("circle",{cx:"5",cy:"12",r:"1.5"}),o.jsx("circle",{cx:"12",cy:"12",r:"1.5"}),o.jsx("circle",{cx:"19",cy:"12",r:"1.5"})]}),search:o.jsxs("svg",{...Tt,children:[o.jsx("circle",{cx:"11",cy:"11",r:"8"}),o.jsx("path",{d:"M21 21l-4.35-4.35"})]}),arrowUp:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M12 19V5m0 0l-7 7m7-7l7 7"})}),arrowDown:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M12 5v14m0 0l7-7m-7 7l-7-7"})}),arrowsUpDown:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M3 7.5L7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"})}),funnel:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z"})}),eyeSlash:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M3.98 8.223A10.477 10.477 0 001.934 12c1.292 4.338 5.31 7.5 10.066 7.5.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88"})}),viewColumns:o.jsx("svg",{...Tt,children:o.jsx("path",{d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125z"})})};let vs={};function hy(t){vs={...vs,...t}}function Sf(t){return vs[t]??yy[t]}function gy(t){return t==="base"?"":t.split("+").map(e=>{const[l,a]=e.split(":");return/^\d/.test(a)?`.${l}-${a}`:`.${a}`}).join("")}const si={[-5]:"--font-size-4xs",[-4]:"--font-size-3xs",[-3]:"--font-size-2xs",[-2]:"--font-size-xs",[-1]:"--font-size-sm",0:"--font-size-base",1:"--font-size-lg",2:"--font-size-xl",3:"--font-size-2xl",4:"--font-size-3xl",5:"--font-size-4xl",6:"--font-size-5xl"},by={1:3,2:2,3:1,4:0,5:-1,6:-2},py={body:0,large:1,label:0,code:0,supporting:-1,"display-1":6,"display-2":5,"display-3":4},Sy={1:"var(--font-weight-semibold)",2:"var(--font-weight-semibold)",3:"var(--font-weight-semibold)",4:"var(--font-weight-semibold)",5:"var(--font-weight-semibold)",6:"var(--font-weight-semibold)"},ky={body:"var(--font-weight-normal)",large:"var(--font-weight-semibold)",label:"var(--font-weight-medium)",code:"var(--font-weight-normal)",supporting:"var(--font-weight-normal)","display-1":"var(--font-weight-normal)","display-2":"var(--font-weight-normal)","display-3":"var(--font-weight-normal)"};function fi(t,e,l){return Math.round(t*Math.pow(e,l))}function zy(t){return`${Math.round(t/16*1e4)/1e4}rem`}function jy(t){return t<20?1.5:t<32?1.4:1.25}function yr(t){const e=jy(t),l=t*e,a=Math.max(Math.round(l/4)*4,Math.ceil((t+4)/4)*4);return Math.round(a/t*1e4)/1e4}function Ey(t){const{base:e,ratio:l,weights:a}=t,n={},u={...Sy,...a==null?void 0:a.heading},c={...ky,...a==null?void 0:a.text};for(let i=-5;i<=6;i++){const s=fi(e,l,i);n[si[i]]=zy(s)}for(const[i,s]of Object.entries(by)){const r=Number(i),x=fi(e,l,s),h=yr(x);n[`--text-heading-${r}-size`]=`var(${si[s]})`,n[`--text-heading-${r}-weight`]=u[r],n[`--text-heading-${r}-leading`]=`${h}`}for(const[i,s]of Object.entries(py)){const r=fi(e,l,s),x=yr(r);n[`--text-${i}-size`]=`var(${si[s]})`,n[`--text-${i}-weight`]=c[i],n[`--text-${i}-leading`]=`${x}`}return n}const Ty={body:"var(--font-family-body)",large:"var(--font-family-body)",label:"var(--font-family-body)",code:"var(--font-family-code)",supporting:"var(--font-family-body)","display-1":"var(--font-family-heading)","display-2":"var(--font-family-heading)","display-3":"var(--font-family-heading)"};function My(t){const e={},l={};for(const n of[1,2,3,4,5,6])l[`level:${n}`]={fontFamily:"var(--font-family-heading)",fontSize:`var(--text-heading-${n}-size)`,fontWeight:`var(--text-heading-${n}-weight)`,lineHeight:`var(--text-heading-${n}-leading)`};e.heading=l;const a={};for(const n of["body","large","label","code","supporting","display-1","display-2","display-3"])a[`type:${n}`]={fontFamily:Ty[n],fontSize:`var(--text-${n}-size)`,lineHeight:`var(--text-${n}-leading)`};return e.text=a,e}function Gl(t){return Math.round(t/5)*5}function Ay(t){const{fast:e,medium:l,ratio:a,easing:n}=t,u={"--duration-fast-min":`${Gl(e*a)}ms`,"--duration-fast":`${Gl(e)}ms`,"--duration-fast-max":`${Gl(e/a)}ms`,"--duration-medium-min":`${Gl(l*a)}ms`,"--duration-medium":`${Gl(l)}ms`,"--duration-medium-max":`${Gl(l/a)}ms`};return n&&(u["--ease-standard"]=n),u}function $y(t){const{base:e,multiplier:l}=t;return{"--radius-none":"0px","--radius-inner":`${Math.round(e*1*l)}px`,"--radius-element":`${Math.round(e*2*l)}px`,"--radius-container":`${Math.round(e*3*l)}px`,"--radius-page":`${Math.round(e*7*l)}px`,"--radius-full":"9999px"}}function Ny(t){return Array.isArray(t)?`light-dark(${t[0]}, ${t[1]})`:t}function Oy(t,e){if(!t&&!e)return;if(!t)return e;if(!e)return t;const l={};for(const[a,n]of Object.entries(t))l[a]={...n};for(const[a,n]of Object.entries(e))if(!l[a])l[a]={...n};else for(const[u,c]of Object.entries(n))l[a][u]={...l[a][u],...c};return l}function nu(t){return{normal:"var(--font-weight-normal)",medium:"var(--font-weight-medium)",semibold:"var(--font-weight-semibold)",bold:"var(--font-weight-bold)"}[t]??t}function oi(t,e){if(!t)return;const l=t.includes(" ")?`"${t}"`:t;return e?`${l}, ${e}`:l}function Dy(t){var c,i,s,r,x,h,d,y;const e={},l=t.typography;let a;if(l!=null&&l.scale){const p={},S=l.heading;if(S!=null&&S.weights)for(const[f,v]of Object.entries(S.weights))v&&(p[Number(f)]=nu(v));const k=S!=null&&S.weight?nu(S.weight):void 0;if(k)for(let f=1;f<=6;f++)f in p||(p[f]=k);const m={};(c=l.body)!=null&&c.weight&&(m.body=nu(l.body.weight)),(i=l.code)!=null&&i.weight&&(m.code=nu(l.code.weight)),a={base:l.scale.base,ratio:l.scale.ratio,weights:{...Object.keys(p).length>0?{heading:p}:{},...Object.keys(m).length>0?{text:m}:{}}}}if(a){const p=Ey(a);for(const[S,k]of Object.entries(p))e[S]=k}if(t.radius){const p=$y(t.radius);for(const[S,k]of Object.entries(p))e[S]=k}if(t.motion){const p=Ay(t.motion);for(const[S,k]of Object.entries(p))e[S]=k}if(l){const p=oi((s=l.body)==null?void 0:s.family,(r=l.body)==null?void 0:r.fallbacks),S=oi((x=l.heading)==null?void 0:x.family,(h=l.heading)==null?void 0:h.fallbacks)??p,k=oi((d=l.code)==null?void 0:d.family,(y=l.code)==null?void 0:y.fallbacks);p&&(e["--font-family-body"]=p),S&&(e["--font-family-heading"]=S),k&&(e["--font-family-code"]=k)}if(t.tokens)for(const[p,S]of Object.entries(t.tokens))S!==void 0&&(e[p]=Ny(S));let n=t.components;if(a){const p=My();n=Oy(p,t.components)}let u;if(l){const p=new Set,S=[];for(const k of[l.body,l.heading,l.code])k!=null&&k.family&&k.url&&!p.has(k.family)&&(p.add(k.family),S.push({family:k.family,url:k.url}));S.length>0&&(u=S)}return{name:t.name,tokens:e,components:n,icons:t.icons,fonts:u,__inputTokens:t.tokens}}function hr(t){return t.replace(/[A-Z]/g,e=>`-${e.toLowerCase()}`)}function wy(t){const e=[],l=t.tokens,a=x=>l[x]||`var(${x})`,n=Object.entries(l);if(n.length>0){const x=n.map(([h,d])=>`    ${h}: ${d};`).join(`
+`);e.push(`  :scope {
+${x}
+  }`)}if(t.components)for(const[x,h]of Object.entries(t.components))for(const[d,y]of Object.entries(h)){const p=Object.entries(y);if(p.length>0){const S=gy(d),k=`.xds-${x}${S}`,m=[],f=[];for(const[v,b]of p)v.startsWith(":")&&typeof b=="object"?f.push([v,b]):m.push([v,b]);if(m.length>0){const v=m.map(([b,z])=>`    ${hr(b)}: ${z};`).join(`
+`);e.push(`  ${k} {
+${v}
+  }`)}for(const[v,b]of f){const z=Object.entries(b);if(z.length>0){const N=z.map(([E,M])=>`    ${hr(E)}: ${M};`).join(`
+`);e.push(`  ${k}${v} {
+${N}
+  }`)}}}}e.push(`  :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-family-heading);
+    color: var(--color-text-primary);
+  }`);for(let x=1;x<=6;x++)e.push(`  h${x} {
+    font-size: ${a(`--text-heading-${x}-size`)};
+    font-weight: ${a(`--text-heading-${x}-weight`)};
+    line-height: ${a(`--text-heading-${x}-leading`)};
+  }`);e.push(`  p {
+    font-family: var(--font-family-heading);
+    font-size: ${a("--text-body-size")};
+    font-weight: ${a("--text-body-weight")};
+    line-height: ${a("--text-body-leading")};
+    color: var(--color-text-primary);
+  }`),e.push(`  small {
+    font-size: ${a("--text-supporting-size")};
+    font-weight: ${a("--text-supporting-weight")};
+    line-height: ${a("--text-supporting-leading")};
+    color: var(--color-text-secondary);
+  }`),e.push(`  code, pre {
+    font-family: var(--font-family-code);
+    font-size: ${a("--text-code-size")};
+    line-height: ${a("--text-code-leading")};
+  }`),e.push(`  hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+  }`);const u={primary:"var(--color-text-primary)",secondary:"var(--color-text-secondary)",disabled:"var(--color-text-disabled)",placeholder:"var(--color-text-secondary)",active:"var(--color-accent)"},c=t.components||{},i="text"in c,s="heading"in c,r="link"in c;if(i||s||r)for(const[x,h]of Object.entries(u))i&&e.push(`  .xds-text.${x} { color: ${h}; }`),s&&e.push(`  .xds-heading.${x} { color: ${h}; }`),r&&e.push(`  .xds-link.${x} { color: ${h}; }`);return e}function Cy(t){const e=wy(t);if(e.length===0)return"";const l=`[data-xds-theme="${t.name}"]`,a=e.join(`
+
+`);return`@scope (${l}) to ([data-xds-theme]) {
+${a}
+}`}const _y=g.createContext(null),uu={base:{k1xSpc:"xjp7ctv",kMwMTN:"x1tgivj0",kMv6JI:"x9ynric",$$css:!0},light:{kQNsl9:"x19aimcq",$$css:!0},dark:{kQNsl9:"xntwwlm",$$css:!0},system:{kQNsl9:"x108lcm5",$$css:!0}},ri=new Set;function Ry(t){const e=g.useId();g.useInsertionEffect(()=>{if(t.__built)return;const l=`xds-theme-${t.name}`;if(ri.has(l))return;const a=Cy(t);if(!a)return;const n=document.createElement("style");return n.setAttribute("data-xds-theme",t.name),n.setAttribute("data-xds-id",e),n.textContent=`@layer xds-theme {
+${a}
+}`,document.head.appendChild(n),ri.add(l),()=>{const u=document.querySelector(`style[data-xds-theme="${t.name}"][data-xds-id="${e}"]`);u&&(u.remove(),ri.delete(l))}},[t,e])}function qy(t){const e=g.useRef([]);g.useLayoutEffect(()=>{if(typeof document>"u"||!t.fonts||t.fonts.length===0)return;const l=[];for(const a of t.fonts){if(document.fonts.check(`16px "${a.family}"`)||document.head.querySelector(`link[rel="stylesheet"][href="${a.url}"]`))continue;const c=document.createElement("link");c.rel="stylesheet",c.href=a.url,document.head.appendChild(c),l.push(c),console.warn(`[XDS] Theme "${t.name}" loaded font "${a.family}" at runtime. For better performance, add to your document <head>:
+  <link rel="stylesheet" href="${a.url}" />`)}return e.current=l,()=>{for(const a of e.current)a.parentNode&&a.parentNode.removeChild(a);e.current=[]}},[t.fonts,t.name])}function kf({theme:t,mode:e="system",children:l}){Ry(t),qy(t);const a=e==="dark"?uu.dark:e==="light"?uu.light:uu.system,n=t.icons;n!=null&&hy(n);const u=g.useMemo(()=>({theme:t,mode:e}),[t,e]);return o.jsx(_y.Provider,{value:u,children:o.jsx("div",{..._(uu.base,a),"data-xds-theme":t.name,"data-theme":e==="system"?void 0:e,children:l})})}kf.displayName="XDSTheme";function Hy({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3"}))}const Uy=g.forwardRef(Hy);function By({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18"}))}const Xy=g.forwardRef(By);function Ly({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"}))}const Zy=g.forwardRef(Ly);function Gy({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"}))}const Yy=g.forwardRef(Gy);function Vy({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"}))}const Qy=g.forwardRef(Vy);function Ky({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m4.5 12.75 6 6 9-13.5"}))}const Jy=g.forwardRef(Ky);function Wy({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m19.5 8.25-7.5 7.5-7.5-7.5"}))}const Fy=g.forwardRef(Wy);function Iy({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M15.75 19.5 8.25 12l7.5-7.5"}))}const Py=g.forwardRef(Iy);function th({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m8.25 4.5 7.5 7.5-7.5 7.5"}))}const eh=g.forwardRef(th);function lh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"}))}const ah=g.forwardRef(lh);function nh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"}))}const uh=g.forwardRef(nh);function ch({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"}))}const ih=g.forwardRef(ch);function sh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"}))}const fh=g.forwardRef(sh);function oh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"}))}const rh=g.forwardRef(oh);function dh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"}))}const xh=g.forwardRef(dh);function mh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z"}))}const vh=g.forwardRef(mh);function yh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6 18 18 6M6 6l12 12"}))}const hh=g.forwardRef(yh);function gh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{fillRule:"evenodd",d:"M15.75 2.25H21a.75.75 0 0 1 .75.75v5.25a.75.75 0 0 1-1.5 0V4.81L8.03 17.03a.75.75 0 0 1-1.06-1.06L19.19 3.75h-3.44a.75.75 0 0 1 0-1.5Zm-10.5 4.5a1.5 1.5 0 0 0-1.5 1.5v10.5a1.5 1.5 0 0 0 1.5 1.5h10.5a1.5 1.5 0 0 0 1.5-1.5V10.5a.75.75 0 0 1 1.5 0v8.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V8.25a3 3 0 0 1 3-3h8.25a.75.75 0 0 1 0 1.5H5.25Z",clipRule:"evenodd"}))}const bh=g.forwardRef(gh);function ph({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{fillRule:"evenodd",d:"M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z",clipRule:"evenodd"}))}const Sh=g.forwardRef(ph);function kh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{fillRule:"evenodd",d:"M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z",clipRule:"evenodd"}))}const zh=g.forwardRef(kh);function jh({title:t,titleId:e,...l},a){return g.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":e},l),t?g.createElement("title",{id:e},t):null,g.createElement("path",{fillRule:"evenodd",d:"M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-1.72 6.97a.75.75 0 1 0-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06L12 13.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L13.06 12l1.72-1.72a.75.75 0 1 0-1.06-1.06L12 10.94l-1.72-1.72Z",clipRule:"evenodd"}))}const Eh=g.forwardRef(jh),ot={width:"1em",height:"1em","aria-hidden":!0},Th={close:o.jsx(hh,{...ot}),chevronDown:o.jsx(Fy,{...ot}),chevronLeft:o.jsx(Py,{...ot}),chevronRight:o.jsx(eh,{...ot}),check:o.jsx(Jy,{...ot}),checkCircle:o.jsx(Sh,{...ot}),xCircle:o.jsx(Eh,{...ot}),warning:o.jsx(zh,{...ot}),info:o.jsx(rh,{...ot}),calendar:o.jsx(Qy,{...ot}),clock:o.jsx(ah,{...ot}),externalLink:o.jsx(bh,{...ot}),menu:o.jsx(Yy,{...ot}),moreHorizontal:o.jsx(uh,{...ot}),search:o.jsx(xh,{...ot}),arrowUp:o.jsx(Xy,{...ot}),arrowDown:o.jsx(Uy,{...ot}),arrowsUpDown:o.jsx(Zy,{...ot}),funnel:o.jsx(fh,{...ot}),eyeSlash:o.jsx(ih,{...ot}),viewColumns:o.jsx(vh,{...ot})},w0=Dy({name:"default",typography:{scale:{base:14,ratio:1.2}},motion:{fast:175,medium:410,ratio:.75},tokens:{},components:{button:{"variant:secondary":{backgroundColor:"light-dark(rgba(5, 54, 89, 0.1), rgba(223, 226, 229, 0.2))"}}},icons:Th}),C0=g.createContext(null),Mh={hasHeader:!1,hasFooter:!1,hasStart:!1,hasEnd:!1},zf=g.createContext(Mh),_0=g.createContext(null),Ah={center:{kGNEyG:"x6s0dn4",$$css:!0},end:{kGNEyG:"xuk3077",$$css:!0},start:{kGNEyG:"x1cy8zhl",$$css:!0},stretch:{kGNEyG:"x1qjc9v5",$$css:!0}},$h={start:{kjj79g:"x1nhvcw1",$$css:!0},center:{kjj79g:"xl56j7k",$$css:!0},end:{kjj79g:"x13a6bvl",$$css:!0},between:{kjj79g:"x1qughib",$$css:!0},around:{kjj79g:"x1l1ennw",$$css:!0},evenly:{kjj79g:"xaw8158",$$css:!0}},Nh={horizontal:{kXwgrk:"x1q0g3np",$$css:!0},vertical:{kXwgrk:"xdt5ytf",$$css:!0}},Oh={nowrap:{kwnvtZ:"xozqiw3",$$css:!0},wrap:{kwnvtZ:"x1a02dak",$$css:!0},"wrap-reverse":{kwnvtZ:"x8hhl5t",$$css:!0}},Dh={stack:{k1xSpc:"x78zum5",$$css:!0}},wh={0:{k1C7PZ:"x1o57wo1",khm7nJ:"x6yxi7o",$$css:!0},1:{k1C7PZ:"x1lfs0n9",khm7nJ:"x1ngg2t4",$$css:!0},2:{k1C7PZ:"xak3so",khm7nJ:"x1x7z4sm",$$css:!0},3:{k1C7PZ:"xewh9hi",khm7nJ:"x4olc9o",$$css:!0},4:{k1C7PZ:"xty4p9g",khm7nJ:"xtx9w7w",$$css:!0},5:{k1C7PZ:"x1eqhezk",khm7nJ:"x1iu6piu",$$css:!0},6:{k1C7PZ:"x3qlgwd",khm7nJ:"xczp1bk",$$css:!0},8:{k1C7PZ:"xicv188",khm7nJ:"xgx0vcf",$$css:!0},10:{k1C7PZ:"x1p37tyl",khm7nJ:"x1xpicb7",$$css:!0},"0.5":{k1C7PZ:"x1kihgfc",khm7nJ:"x1tw44j4",$$css:!0},"1.5":{k1C7PZ:"x1thn6ci",khm7nJ:"xhq53yo",$$css:!0}};function gr({crossAlign:t,direction:e,gap:l,mainAlign:a,wrap:n}){return[Dh.stack,Nh[e],l!=null&&wh[l],t!=null&&Ah[t],a!=null&&$h[a],n!=null&&Oh[n]]}const Ch={reset:{kAzted:"x2lwn1j",k7Eaqz:"xeuugli",$$css:!0}},_h={center:{kSGwAc:"xamitd3",$$css:!0},end:{kSGwAc:"xpvyfi4",$$css:!0},start:{kSGwAc:"xqcrz7y",$$css:!0},stretch:{kSGwAc:"xkh2ocl",$$css:!0}},Rh={fill:{kzQI83:"x1iyjqo2",$$css:!0},static:{kzQI83:"x1c4vz4f",kmuXW:"x2lah0s",$$css:!0}};function qh({crossAlignSelf:t,size:e}={}){return[Ch.reset,Rh[e??"static"],t!=null&&_h[t]]}function et(t,e){const l=[`xds-${t}`];if(e)for(const[a,n]of Object.entries(e)){if(n==null)continue;const u=String(n);/^\d/.test(u)?l.push(`${a}-${u}`):l.push(u)}return l.join(" ")}function ut(t,e,l,a){let n=e.className?`${t} ${e.className}`:t;l&&(n=`${n} ${l}`);const u=a&&e.style?{...e.style,...a}:a||e.style;return{className:n,style:u}}const jf={0:{kZCmMZ:"x18gyask",kwRFfy:"x1s0aq8i",kLKAdn:"x1ydh6w3",kGO01o:"x1l20ajd",$$css:!0},1:{kZCmMZ:"x1vsv5vr",kwRFfy:"x1nryj5t",kLKAdn:"xfsso4q",kGO01o:"xy143xn",$$css:!0},2:{kZCmMZ:"x12gdq22",kwRFfy:"x1djylfy",kLKAdn:"x1xye8es",kGO01o:"x1wesfrj",$$css:!0},3:{kZCmMZ:"x126nfab",kwRFfy:"x1t818jl",kLKAdn:"x1vlblms",kGO01o:"xvmdzux",$$css:!0},4:{kZCmMZ:"x1rey3nv",kwRFfy:"xnjyzlh",kLKAdn:"x1oa1p4a",kGO01o:"x1awphl8",$$css:!0},5:{kZCmMZ:"x1blguxw",kwRFfy:"xdbrk9v",kLKAdn:"xx7rijo",kGO01o:"x1hk98q",$$css:!0},6:{kZCmMZ:"x31w388",kwRFfy:"x1we12cn",kLKAdn:"x1adxfkp",kGO01o:"xjpqqx5",$$css:!0},8:{kZCmMZ:"x1j3hnjz",kwRFfy:"x1q91b2g",kLKAdn:"xoxd1wu",kGO01o:"x2oz4g1",$$css:!0},10:{kZCmMZ:"xqp078j",kwRFfy:"x160ivqr",kLKAdn:"xk6660b",kGO01o:"x2izi54",$$css:!0},"0.5":{kZCmMZ:"x138rykx",kwRFfy:"x1le3yxw",kLKAdn:"xbx876j",kGO01o:"xij103a",$$css:!0},"1.5":{kZCmMZ:"xfti1ec",kwRFfy:"x17hk9do",kLKAdn:"x1kwdpsa",kGO01o:"x1opdxmq",$$css:!0}},Ef={0:{"--container-padding-inline":"x11nj8ps",$$css:!0},1:{"--container-padding-inline":"xmqp8mn",$$css:!0},2:{"--container-padding-inline":"xvkq9sf",$$css:!0},3:{"--container-padding-inline":"x17rklng",$$css:!0},4:{"--container-padding-inline":"x1qtkjpi",$$css:!0},5:{"--container-padding-inline":"xcek0mv",$$css:!0},6:{"--container-padding-inline":"xzryng3",$$css:!0},8:{"--container-padding-inline":"x1t3jwqk",$$css:!0},10:{"--container-padding-inline":"x1mh38z9",$$css:!0},"0.5":{"--container-padding-inline":"x1qmdwou",$$css:!0},"1.5":{"--container-padding-inline":"x11c4xrl",$$css:!0}},Hh={0:{"--layout-padding-outer-x":"xswhm3q",$$css:!0},1:{"--layout-padding-outer-x":"xc96xmq",$$css:!0},2:{"--layout-padding-outer-x":"x15dxnc0",$$css:!0},3:{"--layout-padding-outer-x":"xadgj3j",$$css:!0},4:{"--layout-padding-outer-x":"x1v56qcf",$$css:!0},5:{"--layout-padding-outer-x":"x1nzs0gl",$$css:!0},6:{"--layout-padding-outer-x":"x1c3n52a",$$css:!0},8:{"--layout-padding-outer-x":"x1t3kfz",$$css:!0},10:{"--layout-padding-outer-x":"x1jdf5a4",$$css:!0},"0.5":{"--layout-padding-outer-x":"xihiwg7",$$css:!0},"1.5":{"--layout-padding-outer-x":"x1u93lgd",$$css:!0}},Uh={0:{"--layout-padding-outer-y":"x1mzf5mb",$$css:!0},1:{"--layout-padding-outer-y":"x1gpfxoh",$$css:!0},2:{"--layout-padding-outer-y":"x10pz7y9",$$css:!0},3:{"--layout-padding-outer-y":"x1p6yq3h",$$css:!0},4:{"--layout-padding-outer-y":"xx738ci",$$css:!0},5:{"--layout-padding-outer-y":"x6yxws5",$$css:!0},6:{"--layout-padding-outer-y":"x180vrwl",$$css:!0},8:{"--layout-padding-outer-y":"xid7e43",$$css:!0},10:{"--layout-padding-outer-y":"x26l4wa",$$css:!0},"0.5":{"--layout-padding-outer-y":"x1vj96e0",$$css:!0},"1.5":{"--layout-padding-outer-y":"xd3dqby",$$css:!0}},Ge={layoutOuter:{kogj98:"x1ak00ur",$$css:!0},layoutInner:{"--container-padding":"xbuvapz",$$css:!0},fill:{kZKoxP:"x1x2thlr",kskxy:"xenllk4",$$css:!0},auto:{kAzted:"x1us19tq",$$css:!0},middle:{kUk6DE:"x98rzlu",kAzted:"x2lwn1j",$$css:!0},fullBleed:{"--layout-padding-outer-x":"x1wbjvqu","--layout-padding-outer-y":"xzxxx64",$$css:!0}};function Ga({area:t,children:e}){return e==null?null:o.jsx(C0.Provider,{value:t,children:e})}function Tf({content:t,defaultHasDividers:e,end:l,footer:a,header:n,height:u="fill",padding:c,ref:i,start:s,xstyle:r,className:x,style:h}){const d=u==="fill",y=g.useMemo(()=>e!=null?{defaultHasDividers:e}:null,[e]),p=g.useMemo(()=>({hasHeader:n!=null,hasFooter:a!=null,hasStart:s!=null,hasEnd:l!=null}),[n!=null,a!=null,s!=null,l!=null]),S=o.jsx(zf.Provider,{value:p,children:o.jsx("div",{ref:i,...ut(et("layout",{height:u}),_(Ge.layoutOuter,d?Ge.fill:Ge.auto,r),x,h),children:o.jsxs("div",{..._({"x-default-marker":"x-default-marker",$$css:!0},Ge.layoutInner,...gr({direction:"vertical"}),d?Ge.fill:Ge.auto,c===0&&Ge.fullBleed,c!=null&&Hh[c],c!=null&&Uh[c]),children:[o.jsx(Ga,{area:"header",children:n}),o.jsxs("div",{..._(...gr({direction:"horizontal"}),Ge.middle),children:[o.jsx(Ga,{area:"start",children:s}),o.jsx("div",{..._(...qh({size:"fill"})),children:o.jsx(Ga,{area:"content",children:t})}),o.jsx(Ga,{area:"end",children:l})]}),o.jsx(Ga,{area:"footer",children:a})]})})});return y!=null?o.jsx(_0.Provider,{value:y,children:S}):S}Tf.displayName="XDSLayout";const di={header:{kB7OPa:"x9f619",kmuXW:"x2lah0s",kZCmMZ:"x139j0dd",kwRFfy:"xpc6k2p",kLKAdn:"x81pis9",kGO01o:"xg476vw",$$css:!0},fullBleed:{kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",$$css:!0},divider:{kt9PQ7:"xso031l",kfdmCh:"x1q0q8m5",kL6WhQ:"xw8gpjh",$$css:!0}},Bh={sizing:t=>[{kZKoxP:t!=null?"x16ye13r":t,$$css:!0},{"--x-height":(e=>typeof e=="number"?e+"px":e??void 0)(t)}]};function ys({children:t,hasDivider:e,height:l,label:a,padding:n,role:u,xstyle:c,className:i,style:s,ref:r,...x}){const h=g.useContext(_0),d=e??(h==null?void 0:h.defaultHasDividers)??!1,y=n===0;return o.jsx("div",{ref:r,role:u,"aria-label":a,"data-divider":d||void 0,...ut(et("layout-header"),_(di.header,Bh.sizing(l??null),y&&di.fullBleed,n!=null&&jf[n],n!=null&&Ef[n],d&&di.divider,c),i,s),...x,children:t})}ys.displayName="XDSLayoutHeader";const me={panel:{kB7OPa:"x9f619",kmuXW:"x2lah0s",kVQacm:"x7giv3",kZCmMZ:"xwjyata",kwRFfy:"x1peupej",kLKAdn:"xqty4a",kGO01o:"xg476vw",$$css:!0},startPanel:{kZCmMZ:"x139j0dd",$$css:!0},endPanel:{kwRFfy:"xpc6k2p",$$css:!0},noHeader:{kLKAdn:"x81pis9",$$css:!0},noFooter:{kGO01o:"xon7vh3",$$css:!0},fullBleed:{kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",$$css:!0},scrollable:{kVQacm:"xysyzu8",$$css:!0},dividerEnd:{ke9TFa:"x1lun4ml",k8ry5P:"x18b5jzi",kBCPoo:"x1gejf6u",$$css:!0},dividerStart:{k2ei4v:"xpilrb4",kVhnKS:"x1t7ytsu",kGJrpR:"x1j92z86",$$css:!0},collapseStart:{keTefX:"x1wim8z0",$$css:!0},collapseEnd:{k71WvV:"x1kpg4um",$$css:!0}},Xh={sizing:t=>[{kzqmXN:t!=null?"x5lhr3w":t,$$css:!0},{"--x-width":(e=>typeof e=="number"?e+"px":e??void 0)(t)}]};function Mf({children:t,hasDivider:e=!1,isScrollable:l=!0,label:a,padding:n,role:u,width:c,xstyle:i,className:s,style:r,ref:x,...h}){const d=g.useContext(C0),{hasHeader:y,hasFooter:p}=g.useContext(zf),S=d==="start",k=d==="end",m=n===0,f=!e&&!m&&n==null,v=S?me.dividerEnd:k?me.dividerStart:null,b=S?me.collapseEnd:k?me.collapseStart:null;return o.jsx("div",{ref:x,role:u,"aria-label":a,...ut(et("layout-panel"),_(me.panel,Xh.sizing(c??null),S&&!m&&n==null&&me.startPanel,k&&!m&&n==null&&me.endPanel,!y&&!m&&n==null&&me.noHeader,!p&&!m&&n==null&&me.noFooter,l&&me.scrollable,m&&me.fullBleed,n!=null&&jf[n],n!=null&&Ef[n],e&&v,f&&b,i),s,r),...h,children:t})}Mf.displayName="XDSLayoutPanel";const pl={content:{kB7OPa:"x9f619",kZKoxP:"x5yr21d",kUk6DE:"x98rzlu",kAzted:"x2lwn1j",kVQacm:"x7giv3",kZCmMZ:"xwjyata",kwRFfy:"x1peupej",kLKAdn:"xqty4a x1c51l3k",kGO01o:"xg476vw x1o6z09h",$$css:!0},noStart:{kZCmMZ:"x139j0dd",$$css:!0},noEnd:{kwRFfy:"xpc6k2p",$$css:!0},noHeader:{kLKAdn:"x81pis9",$$css:!0},noFooter:{kGO01o:"xon7vh3",$$css:!0},scrollable:{kVQacm:"xysyzu8",$$css:!0},fullBleed:{kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",$$css:!0}};function Af({children:t,isScrollable:e=!0,padding:l,label:a,role:n,xstyle:u,className:c,style:i,ref:s,...r}){const{hasHeader:x,hasFooter:h,hasStart:d,hasEnd:y}=g.useContext(zf),p=l===0;return o.jsx("div",{ref:s,role:n,"aria-label":a,...ut(et("layout-content"),_(pl.content,!d&&!p&&l==null&&pl.noStart,!y&&!p&&l==null&&pl.noEnd,!x&&!p&&l==null&&pl.noHeader,!h&&!p&&l==null&&pl.noFooter,e&&pl.scrollable,p&&pl.fullBleed,l!=null&&jf[l],l!=null&&Ef[l],u),c,i),...r,children:t})}Af.displayName="XDSLayoutContent";const xi={base:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x1lziwak",k71WvV:"x14z9mp",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kMzoRj:"xc342km",ksu8eU:"xng3xce",kVQacm:"x1rea2x4",kWkggS:"xjbqb8w",$$css:!0},fixed:{kVAEAm:"xixxii4",$$css:!0}};function Lh(t="above",e="center"){const a={above:"top",below:"bottom",start:"left",end:"right"}[t];return t==="above"||t==="below"?e==="start"?`${a} span-right`:e==="end"?`${a} span-left`:a:e==="start"?`${a} span-bottom`:e==="end"?`${a} span-top`:`${a} center`}function R0(t){const{mode:e,onShow:l,onHide:a,lightDismiss:n=!1}=t,u=g.useId(),c=`--xds-layer-${u.replace(/:/g,"")}`,[i,s]=g.useState(!1),r=g.useRef(null),x=g.useRef(null),h=g.useCallback(()=>{r.current&&!r.current.matches(":popover-open")&&(r.current.showPopover(),s(!0),l==null||l())},[l]),d=g.useCallback(()=>{var f;(f=r.current)!=null&&f.matches(":popover-open")&&(r.current.hidePopover(),s(!1),a==null||a())},[a]),y=e==="context"?f=>{x.current&&(x.current.style.anchorName=""),f&&(f.style.anchorName=c),x.current=f}:void 0,p=g.useCallback(f=>{const v=f;v.newState==="closed"?(s(!1),a==null||a()):v.newState==="open"&&(s(!0),l==null||l())},[l,a]),S=g.useCallback(f=>{r.current=f,f&&f.addEventListener("toggle",p)},[p]),k=g.useCallback((f,v)=>{const{placement:b="above",alignment:z="center",xstyle:N,className:E,style:M}=v||{},T={positionAnchor:c,positionArea:Lh(b,z),positionTryFallbacks:"flip-block, flip-inline, flip-block flip-inline"},A=_(xi.base,N),C=E?`${E} ${A.className??""}`:A.className;return o.jsx("div",{ref:S,id:u,popover:n?"auto":"manual",className:C,style:{...A.style,...T,...M},children:f})},[c,u,n,S]),m=g.useCallback((f,v)=>{const{x:b,y:z,xstyle:N,className:E,style:M}=v,T={top:z,left:b},A=_(xi.base,xi.fixed,N),C=E?`${E} ${A.className??""}`:A.className;return o.jsx("div",{ref:S,id:u,popover:n?"auto":"manual",className:C,style:{...A.style,...T,...M},children:f})},[S,u,n]);return e==="context"?{ref:y,anchorId:c,show:h,hide:d,isOpen:i,id:u,render:k}:{ref:void 0,show:h,hide:d,isOpen:i,id:u,render:m}}const Zh={below:{kKVMdj:"xl1vlw0",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},above:{kKVMdj:"x3psbcj",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},end:{kKVMdj:"x1i331go",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},start:{kKVMdj:"xck01x9",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}},mi={container:{kWkggS:"x19aspcf",kMwMTN:"xrkvqaz",kaIpWk:"x1hviunn",kMv6JI:"x9ynric",kGuDYH:"xjm74w1",kLWn49:"xw6l6zx",$$css:!0},marginBlock:{keoZOQ:"xcsaf9d",k1K539:"x14cgwvg",keTefX:"x1lziwak",k71WvV:"x14z9mp",$$css:!0},marginInline:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x11g1kdw",k71WvV:"xnur1sd",$$css:!0}};function Gh(t){return t.hasAttribute("tabindex")?t.tabIndex>=0:["A","BUTTON","INPUT","SELECT","TEXTAREA"].includes(t.tagName)?!t.disabled:!!t.isContentEditable}function Yh(t={}){const{placement:e="above",alignment:l="center",delay:a=200,hideDelay:n=0,focusTrigger:u="auto",isEnabled:c=!0,onShow:i,onHide:s}=t,r=e==="above"||e==="below"?mi.marginBlock:mi.marginInline,x=R0({mode:"context",onShow:i,onHide:s}),h=[mi.container,r],d=g.useRef(null),y=g.useRef(null),p=g.useRef(null),S=g.useCallback(()=>{d.current&&(clearTimeout(d.current),d.current=null),y.current&&(clearTimeout(y.current),y.current=null)},[]),k=g.useCallback(()=>{c&&(S(),d.current=setTimeout(()=>{x.show()},a))},[c,S,x,a]),m=g.useCallback(()=>{S(),n>0?y.current=setTimeout(()=>{x.hide()},n):x.hide()},[S,x,n]),f=g.useCallback(()=>{typeof window<"u"&&typeof window.matchMedia=="function"&&window.matchMedia("(hover: none)").matches||k()},[k]),v=g.useCallback(()=>{m()},[m]),b=g.useCallback(T=>{!c||!T.target.matches(":focus-visible")||(S(),x.show())},[c,S,x]),z=g.useCallback(()=>{m()},[m]),N=g.useCallback(T=>{p.current&&(p.current.removeEventListener("mouseenter",f),p.current.removeEventListener("mouseleave",v),p.current.removeEventListener("focusin",b),p.current.removeEventListener("focusout",z)),T&&(T.addEventListener("mouseenter",f),T.addEventListener("mouseleave",v),(u==="always"||u==="auto"&&Gh(T))&&(T.addEventListener("focusin",b),T.addEventListener("focusout",z))),p.current=T},[u,f,v,b,z]),E=g.useCallback(T=>{x.ref(T),N(T)},[x.ref,N]);g.useEffect(()=>()=>{S()},[S]);const M=g.useCallback((T,A)=>{const C=(A==null?void 0:A.placement)??e,Z={placement:C,alignment:(A==null?void 0:A.alignment)??l,xstyle:[h,Zh[C]],className:et("tooltip")};return x.render(o.jsx("div",{className:"xfsso4q xy143xn x12gdq22 x1djylfy xw5ewwj x13faqbe",children:T}),Z)},[x,e,l,h]);return{ref:E,positionRef:x.ref,interactionRef:N,anchorId:x.anchorId,describedBy:x.id,renderTooltip:M}}function Vh(t){let e=!1;return Lf.Children.forEach(t,l=>{Lf.isValidElement(l)&&(e=!0)}),!e}function br(...t){const e=t.filter(Boolean);return e.length>0?e.join(" "):void 0}function pc({children:t,anchorRef:e,content:l,placement:a="above",alignment:n="center",delay:u=200,hideDelay:c=0,focusTrigger:i="auto",isEnabled:s=!0,onOpenChange:r,hasHoverIndication:x="auto"}){const h=g.useRef(null),d=t!=null?Vh(t):!1,y=x===!0||x==="auto"&&d,p=g.useCallback(()=>{r==null||r(!0)},[r]),S=g.useCallback(()=>{r==null||r(!1)},[r]),k=Yh({placement:a,alignment:n,delay:u,hideDelay:c,focusTrigger:i,isEnabled:s,onShow:p,onHide:S});return g.useLayoutEffect(()=>{if(!e)return;const m=e.current;if(!m)return;k.ref(m);const f=m.getAttribute("aria-describedby");return m.setAttribute("aria-describedby",br(f,k.describedBy)??""),()=>{k.ref(null),f?m.setAttribute("aria-describedby",f):m.removeAttribute("aria-describedby")}},[e,k.ref,k.describedBy]),g.useLayoutEffect(()=>{if(e||d)return;const m=h.current;if(!m)return;const f=m.firstElementChild;if(!f)return;k.ref(f);const v=f.getAttribute("aria-describedby");return f.setAttribute("aria-describedby",br(v,k.describedBy)??""),()=>{k.ref(null),v?f.setAttribute("aria-describedby",v):f.removeAttribute("aria-describedby")}},[e,d,k.ref,k.describedBy]),e&&t==null?o.jsx(o.Fragment,{children:k.renderTooltip(l)}):d?o.jsxs(o.Fragment,{children:[o.jsx("span",{ref:k.ref,tabIndex:0,"aria-describedby":k.describedBy,...{0:{className:"xt0psk2"},1:{className:"xt0psk2 xujl8zx xev0dqp xycaml9 xrys4gj"}}[!!y<<0],children:t}),k.renderTooltip(l)]}):o.jsxs(o.Fragment,{children:[o.jsx("div",{ref:h,className:"xjp7ctv",children:t}),k.renderTooltip(l)]})}pc.displayName="XDSTooltip";const q0=Object.freeze(Object.defineProperty({__proto__:null,XDSTooltip:pc},Symbol.toStringTag,{value:"Module"})),Qh="modulepreload",Kh=function(t,e){return new URL(t,e).href},pr={},H0=function(e,l,a){let n=Promise.resolve();if(l&&l.length>0){const c=document.getElementsByTagName("link"),i=document.querySelector("meta[property=csp-nonce]"),s=(i==null?void 0:i.nonce)||(i==null?void 0:i.getAttribute("nonce"));n=Promise.allSettled(l.map(r=>{if(r=Kh(r,a),r in pr)return;pr[r]=!0;const x=r.endsWith(".css"),h=x?'[rel="stylesheet"]':"";if(!!a)for(let p=c.length-1;p>=0;p--){const S=c[p];if(S.href===r&&(!x||S.rel==="stylesheet"))return}else if(document.querySelector(`link[href="${r}"]${h}`))return;const y=document.createElement("link");if(y.rel=x?"stylesheet":Qh,x||(y.as="script"),y.crossOrigin="",y.href=r,s&&y.setAttribute("nonce",s),document.head.appendChild(y),x)return new Promise((p,S)=>{y.addEventListener("load",p),y.addEventListener("error",()=>S(new Error(`Unable to preload CSS for ${r}`)))})}))}function u(c){const i=new Event("vite:preloadError",{cancelable:!0});if(i.payload=c,window.dispatchEvent(i),!i.defaultPrevented)throw c}return n.then(c=>{for(const i of c||[])i.status==="rejected"&&u(i.reason);return e().catch(u)})},U0={primary:{kMwMTN:"x1tgivj0",$$css:!0},secondary:{kMwMTN:"xv1l7n4",$$css:!0},disabled:{kMwMTN:"xnbbluu",$$css:!0},placeholder:{kMwMTN:"xv1l7n4",$$css:!0},active:{kMwMTN:"xqwr325",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0}},Jh={normal:{k63SB2:"x1sodnla",$$css:!0},medium:{k63SB2:"x1e4wzip",$$css:!0},semibold:{k63SB2:"x2mo6ok",$$css:!0},bold:{k63SB2:"x1lvx875",$$css:!0}},Wh={body:{k63SB2:"xxovm9e",$$css:!0},large:{k63SB2:"x149oux8",$$css:!0},label:{k63SB2:"xmhvcl5",$$css:!0},code:{k63SB2:"xx3eeay",$$css:!0},supporting:{k63SB2:"xv8on6e",$$css:!0},"display-1":{k63SB2:"x1txul5o",$$css:!0},"display-2":{k63SB2:"x1y36c3f",$$css:!0},"display-3":{k63SB2:"x1on40hk",$$css:!0}},B0={inline:{k1xSpc:"xt0psk2",$$css:!0},block:{k1xSpc:"x1lliihq",$$css:!0}},tc={singleLine:{kVQacm:"xb3r6kr",kg5iWk:"xlyipyv",khDVqt:"xuxw1ft",k1xSpc:"x1lliihq",$$css:!0},multiLine:{kVQacm:"xb3r6kr",k1xSpc:"x104kibb",kgKLqz:"x1ua5tub",$$css:!0}},X0={"break-word":{kTgw9:"x1lldw8n",kHjlTd:"x1mzt3pk",$$css:!0},"break-all":{kTgw9:"x1yn0g08",$$css:!0}},L0={wrap:{kN2L0X:"xk4td0m",$$css:!0},nowrap:{kN2L0X:"xebhuq6",$$css:!0},balance:{kN2L0X:"x1w2vvpw",$$css:!0},pretty:{kN2L0X:"x1fzhlzt",$$css:!0}},Z0={enabled:{kxwWH2:"x1b2iylo",kzeHkT:"xwgcxoh",k1xSpc:"x1lliihq",$$css:!0}},G0={strikethrough:{kybGjl:"xmqliwb",$$css:!0}},Fh={enabled:{kcqcaj:"xss6m8b",$$css:!0}},Y0={content:{ks0D6T:"xw5ewwj",kTgw9:"x13faqbe",$$css:!0}};function V0(t){const{maxLines:e}=t,[l,a]=g.useState(!1),[n,u]=g.useState(""),c=g.useRef(null),i=g.useRef(null),s=g.useCallback(x=>{if(e===0){a(!1);return}u(x.textContent??""),a(e===1?x.scrollWidth>x.offsetWidth:x.scrollHeight>x.offsetHeight)},[e]);return{ref:g.useCallback(x=>{i.current&&(i.current.disconnect(),i.current=null),c.current=x,x&&e>0?(s(x),typeof ResizeObserver<"u"&&(i.current=new ResizeObserver(()=>{s(x)}),i.current.observe(x))):(a(!1),u(""))},[e,s]),isTruncated:l,fullText:n}}const Ih=g.lazy(()=>H0(()=>Promise.resolve().then(()=>q0),void 0,import.meta.url).then(t=>({default:t.XDSTooltip}))),Ph={body:"primary",large:"primary",label:"primary",supporting:"secondary",code:"primary","display-1":"primary","display-2":"primary","display-3":"primary"};function Q0({type:t,size:e,color:l,weight:a,display:n="inline",maxLines:u=0,hasTruncateTooltip:c=!0,wordBreak:i,textWrap:s,hasCapsize:r=!1,hasStrikethrough:x=!1,hasTabularNumbers:h=!1,xstyle:d,className:y,style:p,as:S="span",children:k,ref:m,...f}){const v=l??Ph[t],b=i??(u===1?"break-all":"break-word"),z=u>0||r?"block":n,N=V0({maxLines:u}),E=typeof c=="string"?c:"above",M=u>0&&c!==!1&&N.isTruncated,T=g.useRef(null),A=g.useCallback(Z=>{typeof m=="function"?m(Z):m&&(m.current=Z),N.ref(Z),T.current=Z},[m,N.ref]),C=u>1?{WebkitLineClamp:u}:void 0;return o.jsxs(o.Fragment,{children:[o.jsx(S,{ref:A,...ut(et("text",{type:t,color:v}),_(U0[v],Wh[t],a&&Jh[a],u===1?tc.singleLine:u>1?tc.multiLine:B0[z],u>0&&X0[b],s&&L0[s],r&&Z0.enabled,x&&G0.strikethrough,h&&Fh.enabled,d),y,{...p,...C}),title:M?N.fullText:void 0,...f,children:k}),M&&o.jsx(g.Suspense,{fallback:null,children:o.jsx(Ih,{anchorRef:T,content:o.jsx("span",{..._(Y0.content),children:N.fullText}),placement:E})})]})}Q0.displayName="XDSText";const t2=.75,Sr=1.5,kr={sm:{diameter:10,border:3},md:{diameter:14,border:3},lg:{diameter:18,border:3},xl:{diameter:28,border:4}},zr={wrapper:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",$$css:!0},spinner:{k1xSpc:"x1rg5ohu",kVQacm:"xb3r6kr",kXLuUW:"xxymvpz",$$css:!0}};function K0({size:t="md",shade:e="default",label:l,xstyle:a,className:n,"aria-label":u,"data-testid":c,ref:i}){const s=g.useRef(null);g.useEffect(()=>{const S=s.current;if(S==null)return;const k=S.getContext("2d");if(!k)return;const{border:m,diameter:f}=kr[t],v=window.devicePixelRatio||1,b=getComputedStyle(S),z=e==="onMedia"?b.getPropertyValue(vr["--color-on-dark"])||"#FFFFFF":b.getPropertyValue(vr["--color-accent"])||"#0064E0",N=e==="onMedia"?"rgba(255, 255, 255, 0.3)":"rgba(0, 0, 0, 0.1)",E=f/2*v,M=m*v,T=(E+M)*2;S.height=S.width=T,S.style.width=S.style.height=T/v+"px",k.lineCap="round",k.lineWidth=M;const A=T/2;k.beginPath(),k.arc(A,A,E,0,2*Math.PI),k.strokeStyle=N,k.stroke(),k.beginPath(),k.arc(A,A,E,Sr*Math.PI,(Sr+t2)%2*Math.PI),k.strokeStyle=z,k.stroke()},[e,t]);const{border:r,diameter:x}=kr[t],h=x+r*2,d=l!=null,y=u??(typeof l=="string"?l:void 0)??"Loading",p=o.jsx("span",{ref:d?void 0:i,role:"status","aria-label":y,"data-testid":d?void 0:c,...ut(d?"":et("spinner",{size:t,shade:e}),_(zr.spinner,!d&&a),d?void 0:n),style:{width:h,height:h},children:o.jsx("canvas",{ref:s,className:"xlp1x4z x1lliihq xqgcaz xa4qsjk x1ka1v4i x1esw782"})});return d?o.jsxs("div",{ref:i,"data-testid":c,...ut(et("spinner",{size:t,shade:e}),_(zr.wrapper,a),n),children:[p,typeof l=="string"?o.jsx(Q0,{type:"body",weight:"bold",children:l}):l]}):p}K0.displayName="XDSSpinner";const vi={start:{"--edge-start":"x1tfgai2",$$css:!0},end:{"--edge-end":"xwfoc2r",$$css:!0}},e2={self:{keTefX:"xg82z56",k71WvV:"xofqkxr",$$css:!0}},l2=g.createContext(null);function Sc(t){const e=g.useContext(l2);return t??(e==null?void 0:e.component)??"a"}const Yl={base:{kVAEAm:"x1n2onr6",k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kOIVth:"x1txdalj",k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kMzoRj:"xc342km",ksu8eU:"xng3xce","--button-radius":"x1mkq5kp",kaIpWk:"x1q11iln",kMv6JI:"xjb2p0i",kGuDYH:"xcr08ib",kLWn49:"x1kq96og",k63SB2:"x1e4wzip",khDVqt:"xuxw1ft",kkrTdU:"x1ypdohk",k1ekBW:"xqc8rvf",kIyJzY:"xuedmi6 x12w9bfk",kAMwcw:"xlr8y92",k3aq6I:"x3oybdh xk4oym4",$$css:!0},disabled:{kkrTdU:"x1h6gzvc",kSiTet:"xbyyjgo",kKwaWg:"x18o3ruo",k3aq6I:"x1c071of x1pdlv7q",$$css:!0},ariaDisabled:{kKwaWg:"x18o3ruo x8o3jvd xuqm82a",$$css:!0},iconOnly:{"--button-icon-only-aspect":"x1v15ycx",kOBAk4:"xioom0i",kg3NbH:"xf314gf",$$css:!0},iconWrapper:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0},link:{kybGjl:"x1hl2dhg",$$css:!0}},a2={sm:{kZKoxP:"x6k0iem",$$css:!0},md:{kZKoxP:"x1ueg155",$$css:!0},lg:{kZKoxP:"xssyfek",$$css:!0}},n2={sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},lg:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0}},u2={primary:{kWkggS:"x1ewilqj",kMwMTN:"x17wrial",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},secondary:{kWkggS:"x17x4s8c",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},ghost:{kWkggS:"xjbqb8w",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},destructive:{kWkggS:"x1pjz0fi",kMwMTN:"x1m024r3",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x1p73he7","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0}},c2={loading:{kVAEAm:"x1n2onr6",kMwMTN:"x19co3pv",$$css:!0}},jr={paddingInline2:{"--component-padding-inline":"x30uzy1",$$css:!0},paddingInline3:{"--component-padding-inline":"x1ojg8sz",$$css:!0}};function Un({label:t,variant:e="secondary",size:l="md",type:a="button",isDisabled:n=!1,isLoading:u=!1,onClickAction:c,icon:i,children:s,endContent:r,tooltip:x,href:h,as:d,target:y,rel:p,xstyle:S,className:k,style:m,ref:f,...v}){const[b,z]=g.useTransition(),N=g.useRef(!1),E=u||b,M=n||E,T=e==="primary"||e==="destructive",A=i!=null&&s==null,C=Sc(d),Z=h!=null&&!M,I=x!=null&&M,xt=V=>{var mt;if(M||N.current){V.preventDefault();return}(mt=v.onClick)==null||mt.call(v,V),c&&!V.defaultPrevented&&(N.current=!0,z(async()=>{try{await c(V)}finally{N.current=!1}}))},St=I?V=>{var mt;V.key==="Enter"||V.key===" "?V.preventDefault():(mt=v.onKeyDown)==null||mt.call(v,V)}:void 0,$=e==="ghost",O=$?e2.self:null,D=$?A?jr.paddingInline2:jr.paddingInline3:null,L=_(Yl.base,a2[l],u2[e],A&&Yl.iconOnly,M&&Yl.disabled,I&&Yl.ariaDisabled,E&&c2.loading,D,O,Z&&Yl.link,S),J=ut(et("button",{variant:e,size:l}),L,k,m),Et=o.jsxs(o.Fragment,{children:[E&&o.jsx("span",{className:"x10l6tqk x13vifvy xu96u03 x3m8u43 x1ey2m1c x78zum5 x6s0dn4 xl56j7k","aria-hidden":"true",children:o.jsx(K0,{size:"sm",shade:T?"onMedia":"default"})}),o.jsxs("span",{className:"xjp7ctv","aria-hidden":E||void 0,children:[i&&o.jsx("span",{..._(Yl.iconWrapper,n2[l]),children:i}),A?null:o.jsx("span",{className:"xb3r6kr xlyipyv xeuugli",children:s??t}),!A&&r&&o.jsx("span",{className:"x3nfvp2 x6s0dn4 x1heor9g",children:r})]}),o.jsx("span",{className:"x10l6tqk x1i1rx1s xjm9jq1 x1717udv xkdpibf xb3r6kr xzpqnlu xuxw1ft xc342km",role:"status","aria-live":"polite",children:E?"Loading":""})]}),wt=A&&t!==""||E&&!A?{"aria-label":t}:null;let Ct;return Z?Ct=o.jsx(C,{ref:f,href:h,target:y,rel:p,...J,...v,...wt,onClick:xt,children:Et}):Ct=o.jsx("button",{ref:f,type:a,disabled:I?void 0:M,...J,...v,...wt,"aria-busy":E||void 0,"aria-disabled":I||void 0,onClick:xt,...St?{onKeyDown:St}:null,children:Et}),x?o.jsx(pc,{content:x,placement:"above",children:Ct}):Ct}Un.displayName="XDSButton";const J0={root:{kmuXW:"x2lah0s",$$css:!0},span:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0}},W0={primary:{kMwMTN:"xtbr613",$$css:!0},secondary:{kMwMTN:"xv9yike",$$css:!0},tertiary:{kMwMTN:"xv9yike",$$css:!0},disabled:{kMwMTN:"xqa6c3m",$$css:!0},accent:{kMwMTN:"xqwr325",$$css:!0},positive:{kMwMTN:"xtjic6",$$css:!0},negative:{kMwMTN:"xjt36v0",$$css:!0},warning:{kMwMTN:"xs3pv69",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0},blue:{kMwMTN:"x1fns2mt",$$css:!0},red:{kMwMTN:"xeffzf7",$$css:!0},green:{kMwMTN:"xmxeech",$$css:!0},gray:{kMwMTN:"x1eyinzz",$$css:!0},cyan:{kMwMTN:"x157w0xa",$$css:!0},teal:{kMwMTN:"x1f3zxcb",$$css:!0},yellow:{kMwMTN:"x1g6zdft",$$css:!0},orange:{kMwMTN:"xxu74a4",$$css:!0},pink:{kMwMTN:"x1kxxfg5",$$css:!0},purple:{kMwMTN:"xzdw94u",$$css:!0}},i2={xsm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",$$css:!0},sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",$$css:!0},md:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",$$css:!0},lg:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",$$css:!0}},s2={xsm:{kzqmXN:"xsmyaan",kZKoxP:"x1kpxq89",kGuDYH:"xfifm61",$$css:!0},sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0},lg:{kzqmXN:"xvy4d1p",kZKoxP:"xxk0z11",kGuDYH:"x1pvqxga",$$css:!0}};function Tn({icon:t,color:e="primary",size:l="md",ref:a,...n}){if(typeof t=="string")return o.jsx(f2,{name:t,color:e,size:l});const u=t;return o.jsx(u,{ref:a,"aria-hidden":"true",...ut(et("icon",{size:l,color:e}),_(J0.root,W0[e],i2[l])),...n})}Tn.displayName="XDSIcon";function f2({name:t,color:e,size:l}){const a=Sf(t);return a==null?null:o.jsx("span",{...ut(et("icon",{size:l,color:e}),_(J0.span,W0[e],s2[l])),"aria-hidden":"true",children:a})}const o2={isMobile:!1,isMobileNavOpen:!1,toggleMobileNav:()=>{},openMobileNav:()=>{},closeMobileNav:()=>{},isMobileNavEnabled:!1},F0=g.createContext(o2);function $f(){return g.useContext(F0)}function Nf({children:t,label:e="Open navigation","data-testid":l,xstyle:a,className:n,style:u}){const{isMobile:c,isMobileNavEnabled:i,toggleMobileNav:s}=$f();return!c||!i?null:o.jsx(Un,{variant:"ghost",label:e,icon:t??o.jsx(Tn,{icon:"menu",color:"inherit"}),onClick:s,"data-testid":l??"mobile-nav-toggle",xstyle:a,className:n,style:u})}Nf.displayName="XDSMobileNavToggle";const Wa=g.createContext("default");function r2(){return g.useContext(Wa)}const zu=g.createContext("default");function I0(){return g.useContext(zu)}const hs=g.createContext(null);function d2(){return g.useContext(hs)}const x2={sm:640,md:768,lg:1024,none:0},Er="xds-app-shell-main",Mt={root:{k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",kVAEAm:"x1n2onr6",$$css:!0},variantWash:{kWkggS:"x1eiddq6",$$css:!0},variantSurface:{kWkggS:"x10xzikg",$$css:!0},variantSection:{kWkggS:"x10xzikg",$$css:!0},variantElevated:{kWkggS:"x1eiddq6",$$css:!0},rootFill:{kZKoxP:"xtdtrs8",$$css:!0},rootAuto:{kAzted:"x1ov3xa9",$$css:!0},contentBgSurface:{kWkggS:"x10xzikg",$$css:!0},contentBgWash:{kWkggS:"x1eiddq6",$$css:!0},contentBgTransparent:{kWkggS:"xjbqb8w",kHBbk8:"xc8icb0",$$css:!0},navAreaWash:{kWkggS:"x1eiddq6",$$css:!0},navAreaSurface:{kWkggS:"x10xzikg",$$css:!0},headerSticky:{kVAEAm:"x7wzq59",k87sOh:"x13vifvy",kY2c9j:"x1vjfegm",$$css:!0},panelAutoFill:{kUk6DE:"x98rzlu",$$css:!0},sideNavSticky:{kVAEAm:"x7wzq59",k87sOh:"xepuwc7",kZKoxP:"x16zugyo",kVQacm:"xysyzu8",k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",$$css:!0}};function P0({variant:t="elevated",banner:e,children:l,contentPadding:a,"data-testid":n,height:u="fill",mobileNav:c,sideNav:i,topNav:s,xstyle:r,className:x,style:h,ref:d}){const y=c===!1,p=c!=null&&c!==!1&&typeof c=="object"&&!g.isValidElement(c)?c:null,S=(p==null?void 0:p.breakpoint)??"md",k=c!=null&&c!==!1&&(g.isValidElement(c)||typeof c=="string")?c:null,m=(p==null?void 0:p.content)??null,f=(p==null?void 0:p.hasToggle)!==!1,v=(p==null?void 0:p.isOpen)!==void 0,[b,z]=g.useState(!1),[N,E]=g.useState(!1),M=v?p.isOpen:N,T=g.useCallback(de=>{var Le;v||E(de),(Le=p==null?void 0:p.onOpenChange)==null||Le.call(p,de)},[v,p]),A=u==="fill",C=u==="auto",Z=e!=null,I=s!=null,xt=i!=null,St=xt||I,$=!y&&St&&k==null,O=t==="section",D=t==="elevated",L=t==="wash"||t==="elevated"?Mt.navAreaWash:t==="surface"?Mt.navAreaSurface:void 0,J=t==="wash"?Mt.contentBgWash:t==="elevated"&&I&&xt&&!b?Mt.contentBgTransparent:t==="surface"||t==="elevated"?Mt.contentBgSurface:void 0,Et=L??Mt.navAreaSurface,wt=g.useRef(null),Ct=g.useRef(null),V=g.useCallback(de=>{Ct.current=de,typeof d=="function"?d(de):d&&(d.current=de)},[d]);g.useEffect(()=>{if(!C||!wt.current||!Ct.current)return;const de=wt.current,Le=Ct.current,Xl=()=>{const jc=de.getBoundingClientRect().height;Le.style.setProperty("--appshell-header-height",`${jc}px`)};Xl();const _a=new ResizeObserver(Xl);return _a.observe(de),()=>_a.disconnect()},[C]),g.useEffect(()=>{if(S==="none"||!St)return;const de=x2[S],Le=window.matchMedia(`(max-width: ${de}px)`),Xl=_a=>{const jc="matches"in _a?_a.matches:!1;z(jc)};return Xl(Le),Le.addEventListener("change",Xl),()=>Le.removeEventListener("change",Xl)},[S,St]);const mt=xt&&!b,Bn=k!=null,kc=$&&m!=null&&b,gl=$&&!k&&!m&&b&&St,cx=gl&&I&&!xt,ix=gl&&I&&xt,sx=gl&&!I&&xt,fx=g.useMemo(()=>({isMobile:b,isMobileNavOpen:M,toggleMobileNav:()=>T(!M),openMobileNav:()=>T(!0),closeMobileNav:()=>T(!1),isMobileNavEnabled:$}),[b,M,T,$]),ox=I?b&&$?o.jsx(hs,{value:xt?o.jsx(Wa,{value:"drawer-content",children:i}):null,children:o.jsx(zu,{value:"mobile-bar",children:s})}):s:null,Rf=I||Z?o.jsxs(ys,{padding:0,hasDivider:O&&I,xstyle:L,children:[Z&&o.jsx("div",{className:"x2lah0s",children:e}),ox]}):void 0,rx=Rf!=null?o.jsx("div",{ref:wt,..._(C&&Mt.headerSticky,C&&Et),children:Rf}):void 0,zc=mt?o.jsx(Mf,{padding:0,hasDivider:O,isScrollable:A,xstyle:[L,C&&Mt.panelAutoFill],children:i}):void 0,dx=zc!=null&&C?o.jsx("div",{className:"xkh2ocl",children:o.jsx("div",{..._(Mt.sideNavSticky,Et),children:zc})}):zc,xx=D&&I&&mt,qf=o.jsx(Af,{padding:a??0,role:"main",id:Er,isScrollable:A,xstyle:J,children:l}),mx=xx?o.jsxs("div",{className:"x1n2onr6 x78zum5 x98rzlu x2lwn1j x5yr21d",children:[o.jsx("div",{className:"x10l6tqk x10a8y8t x10xzikg x183tx6i x47corl"}),qf]}):qf,vx=$&&f&&b&&!I&&xt?o.jsx("div",{..._(C&&Mt.headerSticky,C&&Et),children:o.jsx(ys,{padding:0,hasDivider:O,xstyle:L,children:o.jsxs("div",{className:"x78zum5 x6s0dn4 x1k15mir xf314gf",role:"navigation","aria-label":"Mobile navigation",children:[o.jsx(Wa,{value:"topbar",children:i}),o.jsx(Nf,{})]})})}):void 0;return o.jsx(F0.Provider,{value:fx,children:o.jsxs("div",{ref:V,"data-testid":n,...ut(et("app-shell",{height:u,variant:t}),_(Mt.root,t==="wash"?Mt.variantWash:t==="surface"?Mt.variantSurface:t==="section"?Mt.variantSection:Mt.variantElevated,A?Mt.rootFill:Mt.rootAuto,r),x,h),children:[o.jsx("a",{href:`#${Er}`,className:"x10l6tqk x1xrnuwo x1i1rx1s x1jqxupm xjm9jq1 x15cytp8 xt970qd xh2mrf5 xnjsko4 x1cf3d6k xkdpibf x1y5lnwp xb3r6kr xomzh7y x1hyvwdk x1rsz1da xuxw1ft x1hbpcn8 xc342km x13vifvy x1rw3289 x1o0tod xodanix x10xzikg xjse4m1 x1q2oy4v x1hl2dhg x2mo6ok xjm74w1","data-testid":"skip-to-content",children:"Skip to content"}),o.jsx(Tf,{height:u,padding:0,header:o.jsxs(o.Fragment,{children:[rx,vx]}),start:dx,content:mx}),Bn&&k,kc&&m,cx&&o.jsx(zu,{value:"drawer",children:s}),ix&&o.jsx(hs,{value:o.jsx(Wa,{value:"drawer-content",children:i}),children:o.jsx(zu,{value:"drawer",children:s})}),sx&&o.jsx(Wa,{value:"drawer",children:i})]})})}P0.displayName="XDSAppShell";const cu=g.createContext("start"),Tr={horizontal:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kzqmXN:"xh8yej3",$$css:!0},vertical:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kZKoxP:"x5yr21d",$$css:!0}},Vl={horizontalLine:{kZKoxP:"xsyqizj",kzQI83:"x1iyjqo2",kmuXW:"xs83m0k",$$css:!0},verticalLine:{kzqmXN:"xjk4fl7",kzQI83:"x1iyjqo2",kmuXW:"xs83m0k",$$css:!0},subtle:{kWkggS:"x1m4xfpy",$$css:!0},strong:{kWkggS:"x7njt3n",$$css:!0}},Mr={horizontal:{kUOVxO:"xzyy9it",$$css:!0},vertical:{kqGvvJ:"xcxpkta",$$css:!0}};function tx({orientation:t="horizontal",label:e,variant:l="subtle",isFullBleed:a=!1,xstyle:n,className:u,style:c,ref:i,...s}){const r=t==="horizontal";return o.jsxs("div",{ref:i,role:"separator","aria-orientation":t,...ut(et("divider",{variant:l,orientation:t}),_(r?Tr.horizontal:Tr.vertical,a&&(r?Mr.horizontal:Mr.vertical),n),u,c),...s,children:[o.jsx("div",{..._(r?Vl.horizontalLine:Vl.verticalLine,Vl[l])}),e&&o.jsx("div",{...{0:{className:"x2lah0s xrrkdod x10xzikg x141an7d x1ltkj2j xv1l7n4"},1:{className:"x2lah0s x10xzikg x141an7d x1ltkj2j xv1l7n4 xnjsko4 x8o8v82"}}[!r<<0],children:e}),e&&o.jsx("div",{..._(r?Vl.horizontalLine:Vl.verticalLine,Vl[l])})]})}tx.displayName="XDSDivider";const m2=g.lazy(()=>H0(()=>Promise.resolve().then(()=>q0),void 0,import.meta.url).then(t=>({default:t.XDSTooltip}))),v2={1:"h1",2:"h2",3:"h3",4:"h4",5:"h5",6:"h6"};function ex({level:t,accessibilityLevel:e,color:l="primary",display:a="block",maxLines:n=0,hasTruncateTooltip:u=!0,wordBreak:c,textWrap:i,hasCapsize:s=!1,hasStrikethrough:r=!1,xstyle:x,className:h,style:d,children:y,ref:p,...S}){const k=v2[t],m=e&&e!==t?{"aria-level":e}:{},f=c??(n===1?"break-all":"break-word"),v=n>0||s?"block":a,b=V0({maxLines:n}),z=typeof u=="string"?u:"above",N=n>0&&u!==!1&&b.isTruncated,E=g.useRef(null),M=g.useCallback(A=>{typeof p=="function"?p(A):p&&(p.current=A),b.ref(A),E.current=A},[p,b.ref]),T=n>1?{WebkitLineClamp:n}:void 0;return o.jsxs(o.Fragment,{children:[o.jsx(k,{ref:M,...ut(et("heading",{level:t,color:l}),_(U0[l],n===1?tc.singleLine:n>1?tc.multiLine:B0[v],n>0&&X0[f],i&&L0[i],s&&Z0.enabled,r&&G0.strikethrough,x),h,{...d,...T}),title:N?b.fullText:void 0,...m,...S,children:y}),N&&o.jsx(g.Suspense,{fallback:null,children:o.jsx(m2,{anchorRef:E,content:o.jsx("span",{..._(Y0.content),children:b.fullText}),placement:z})})]})}ex.displayName="XDSHeading";const Ye={dialog:{kVAEAm:"xixxii4",kogj98:"x1ghz6dp",kmVPX3:"x1717udv",ks0D6T:"x1x1rfll",kskxy:"x7ab17h",kpwlN0:"x10a8y8t",kzqmXN:"xn9wirt",kZKoxP:"xtdtrs8",kWkggS:"xjbqb8w",kVQacm:"xb3r6kr",kZeWKH:"xish69e",kFalU9:"x5ve5x3",kI3sdo:"x1a2a7pz",k1xSpc:"x1s85apg xf1xu1x",$$css:!0},backdrop:{kGyWv1:"xnixb3f",kba3nw:"x1abwkk1",k5sjJv:"xph5o2a",kND0Po:"x167zut7",k9an0g:"xft5bk6",kb4ib:"x15h3t91",kA5Tbj:"x1viac0w",$$css:!0},backdropOpen:{k5sjJv:"xb3n6bw",$$css:!0},drawer:{kVAEAm:"x10l6tqk",k87sOh:"x13vifvy",krVfgx:"x1ey2m1c",k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",kWkggS:"x10xzikg",kB7OPa:"x9f619",kVQacm:"xb3r6kr",k1ekBW:"x11xpdln",kIyJzY:"x80gvsz",kAMwcw:"xlr8y92",kI3sdo:"x1a2a7pz",k6CgDc:"xzg1mie",$$css:!0},drawerStart:{kLqNvP:"x1o0tod",ke9TFa:"x1lun4ml",k8ry5P:"x18b5jzi",kBCPoo:"x1gejf6u",k3aq6I:"x5i6ehr xttggg",$$css:!0},drawerStartOpen:{k3aq6I:"xbryuvx",$$css:!0},drawerEnd:{kt4wiu:"xtijo5x",k2ei4v:"xpilrb4",kVhnKS:"x1t7ytsu",kGJrpR:"x1j92z86",k3aq6I:"xumwmo6 x1df3fe5",$$css:!0},drawerEndOpen:{k3aq6I:"xbryuvx",$$css:!0}},y2={kzqmXN:"xn9wirt",ks0D6T:"xf68679",$$css:!0},h2={width:t=>[y2,{"--x-maxWidth":(e=>typeof e=="number"?e+"px":e??void 0)(`${t}px`)}]};function Of({isOpen:t,onOpenChange:e,children:l,header:a,width:n=320,side:u="end",label:c,"data-testid":i,xstyle:s,className:r,style:x,ref:h}){const d=$f(),y=t??d.isMobileNavOpen,p=e??(z=>{z?d.openMobileNav():d.closeMobileNav()}),S=g.useRef(null),k=g.useRef(null),m=g.useCallback(z=>{S.current=z,typeof h=="function"?h(z):h&&(h.current=z)},[h]);g.useEffect(()=>{const z=S.current;if(z){if(k.current&&(clearTimeout(k.current),k.current=null),y)z.open||z.showModal(),document.documentElement.style.overflow="clip";else if(z.open){document.documentElement.style.overflow="";const N=window.matchMedia("(prefers-reduced-motion: reduce)").matches?10:250;k.current=setTimeout(()=>{z.close()},N)}return()=>{k.current&&clearTimeout(k.current),document.documentElement.style.overflow=""}}},[y]);const f=g.useCallback(z=>{z.preventDefault(),p(!1)},[p]),v=g.useCallback(z=>{z.target===z.currentTarget&&p(!1)},[p]),b=u==="start";return o.jsx("dialog",{ref:m,"data-testid":i,"aria-label":c??(typeof a=="string"?a:"Navigation"),onClick:v,onCancel:f,...ut(et("mobile-nav",{side:u}),_(Ye.dialog,Ye.backdrop,y&&Ye.backdropOpen,s)),children:o.jsxs("div",{tabIndex:-1,..._(Ye.drawer,h2.width(n),b&&Ye.drawerStart,b&&y&&Ye.drawerStartOpen,!b&&Ye.drawerEnd,!b&&y&&Ye.drawerEndOpen),children:[o.jsxs("div",{...{0:{className:"x78zum5 x6s0dn4 x1qughib x1k15mir xf314gf x2lah0s xso031l x1q0q8m5 xw8gpjh"},1:{className:"x78zum5 x6s0dn4 x1k15mir xf314gf x2lah0s xso031l x1q0q8m5 xw8gpjh x13a6bvl"}}[!a<<0],children:[typeof a=="string"?o.jsx("span",{className:"x11g1kdw",children:o.jsx(ex,{level:2,children:a})}):a??null,o.jsx(Un,{variant:"ghost",label:"Close navigation",icon:o.jsx(Tn,{icon:"close",color:"inherit"}),onClick:()=>p(!1)})]}),o.jsx("div",{className:"x98rzlu x1odjw0f x6ikm8r xish69e xx69xxh xf314gf xce4md1",children:l})]})})}Of.displayName="XDSMobileNav";const Sl={base:{kGNEyG:"x6s0dn4",kzqmXN:"xh8yej3",kZKoxP:"x1k15mir",kg3NbH:"x1pzlopt",kB7OPa:"x9f619","--container-padding-inline":"x1qtkjpi",$$css:!0},baseFlex:{k1xSpc:"x78zum5",$$css:!0},baseGrid:{k1xSpc:"xrvj5dj",kumcoG:"x134kloy",$$css:!0},leftSection:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x18g69wz",kUk6DE:"x845mor",k7Eaqz:"xeuugli",$$css:!0},rightSection:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kjj79g:"x13a6bvl",kOIVth:"xzye2dw",$$css:!0},endContent:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"xzye2dw",kmuXW:"x2lah0s",keTefX:"xvc5jky",$$css:!0},mobileBar:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kzqmXN:"xh8yej3",kZKoxP:"x1k15mir",kg3NbH:"x1pzlopt",kB7OPa:"x9f619",$$css:!0}};function lx({heading:t,startContent:e,centerContent:l,endContent:a,label:n,xstyle:u,className:c,style:i,ref:s,...r}){const x=I0(),h=d2(),d=l!=null,y=e!=null||l!=null,p=y||h!=null;return x==="mobile-bar"?o.jsxs("nav",{ref:s,role:"navigation","aria-label":n,...ut(et("top-nav",{mode:"mobile-bar"}),_(Sl.mobileBar,u),c,i),...r,children:[t&&o.jsx("div",{className:"x78zum5 x6s0dn4 x2lah0s",children:t}),o.jsxs("div",{className:"x78zum5 x6s0dn4 xzye2dw xvc5jky",children:[a,p&&o.jsx(Nf,{})]})]}):x==="drawer"?!y&&!h?null:o.jsxs(Of,{header:t,children:[y&&o.jsxs("div",{className:"x78zum5 xdt5ytf x1lsbc85",children:[e,l]}),y&&h&&o.jsx("div",{className:"x1g06x3t",children:o.jsx(tx,{})}),h&&o.jsx("div",{children:h})]}):o.jsxs("nav",{ref:s,role:"navigation","aria-label":n,...ut(et("top-nav"),_(Sl.base,d?Sl.baseGrid:Sl.baseFlex,u),c,i),...r,children:[o.jsxs("div",{..._(Sl.leftSection,vi.start),children:[t&&o.jsx("div",{className:"x78zum5 x6s0dn4 x2lah0s",children:t}),e&&o.jsx(cu,{value:"start",children:o.jsx("div",{className:"x78zum5 x6s0dn4 xzye2dw",children:e})})]}),d&&o.jsx(cu,{value:"center",children:o.jsx("div",{className:"x78zum5 x6s0dn4 xl56j7k xzye2dw",children:l})}),d?o.jsx("div",{..._(Sl.rightSection,vi.end),children:o.jsx(cu,{value:"end",children:a})}):a&&o.jsx("div",{..._(Sl.endContent,vi.end),children:o.jsx(cu,{value:"end",children:a})})]})}lx.displayName="XDSTopNav";const Ar={base:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",kybGjl:"x1hl2dhg",kMwMTN:"x1tgivj0",$$css:!0},clickable:{kkrTdU:"x1ypdohk",$$css:!0}};function ax({as:t,heading:e,logo:l,href:a,xstyle:n,className:u,style:c,ref:i,...s}){const r=Sc(t),x=a!=null,h=x?r:"div";return o.jsxs(h,{ref:i,href:a,...ut(et("top-nav-heading"),_(Ar.base,x&&Ar.clickable,n),u,c),...s,children:[l&&o.jsx("span",{className:"x78zum5 x6s0dn4 xl56j7k x2lah0s",children:l}),e&&o.jsx("span",{className:"x18juvz8 x2mo6ok xf74fhv xuxw1ft",children:e})]})}ax.displayName="XDSTopNavHeading";const Yt={item:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",kzqmXN:"xh8yej3",kg3NbH:"xf314gf",k8WAf4:"xce4md1",kaIpWk:"xh6dtrn",kMzoRj:"xc342km",ksu8eU:"xng3xce",kWkggS:"xjbqb8w",kMwMTN:"x1tgivj0",kybGjl:"x1hl2dhg",kkrTdU:"x1ypdohk",kMv6JI:"xjb2p0i",kGuDYH:"xcr08ib",k63SB2:"x1sodnla",kLWn49:"x1kq96og",k9WMMc:"x1yc453h",kB7OPa:"x9f619",kHE3J0:"xe9uy6x",kSReZ0:"xyxi2l3",$$css:!0},selected:{kWkggS:"x17x4s8c",k63SB2:"x1e4wzip",kHE3J0:"x1sua13m",kSReZ0:"xjtnuge",$$css:!0},disabled:{kMwMTN:"xnbbluu",kkrTdU:"x1h6gzvc",kfzvcC:"x47corl",$$css:!0}},iu={base:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kaIpWk:"xh6dtrn",kGuDYH:"xcr08ib",kLWn49:"x1kq96og",k63SB2:"x1e4wzip",kMwMTN:"xv1l7n4",kybGjl:"x1hl2dhg",kkrTdU:"x1ypdohk",k1ekBW:"xs2xxs2",kIyJzY:"xuedmi6",kAMwcw:"xlr8y92",kWkggS:"xjbqb8w xe9uy6x xyxi2l3",kI3sdo:"x17nn4n9",kInvED:"x1wfwxd8 x7s97pk",$$css:!0},selected:{kMwMTN:"x1tgivj0",k63SB2:"x2mo6ok",kWkggS:"x17x4s8c x1sua13m xjtnuge",$$css:!0},iconOnly:{kg3NbH:"xf314gf",$$css:!0},drawerFocus:{kI3sdo:"x17nn4n9",kInvED:"x1wfwxd8 x7s97pk",$$css:!0}};function ju({as:t,label:e,isSelected:l=!1,isDisabled:a=!1,icon:n,children:u,xstyle:c,className:i,style:s,ref:r,...x}){const h=Sc(t),d=I0(),y=n!=null&&u==null&&!e,p=!y;return d==="drawer"?o.jsxs(h,{ref:r,"aria-current":l?"page":void 0,"aria-disabled":a||void 0,tabIndex:a?-1:void 0,...ut(et("top-nav-item",{mode:"drawer"}),_(Yt.item,iu.drawerFocus,l&&Yt.selected,a&&Yt.disabled,c),i,s),...x,children:[n,u??e]}):o.jsxs(h,{ref:r,"aria-label":y?e:void 0,"aria-current":l?"page":void 0,"aria-disabled":a||void 0,tabIndex:a?-1:void 0,...ut(et("top-nav-item"),_(iu.base,l&&iu.selected,a&&Yt.disabled,y&&iu.iconOnly,c),i,s),...x,children:[n,p&&(u??e)]})}ju.displayName="XDSTopNavItem";const g2='button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])';function Df(t){return Array.from(t.querySelectorAll(g2))}function nx(t){try{t.focus()}catch{}return document.activeElement===t}function $r(t){const e=Df(t);for(const l of e)if(nx(l))return!0;return!1}function b2(t){const e=Df(t);for(let l=e.length-1;l>=0;l--)if(nx(e[l]))return!0;return!1}function p2(t){const{isActive:e,onEscape:l}=t,a=g.useRef(null),n=g.useRef(null),u=g.useRef(!1),c=g.useCallback(()=>{a.current&&$r(a.current)},[]);return g.useEffect(()=>{if(!e)return;const i=s=>{const r=a.current;if(!r)return;const x=s.target;r.contains(x)?n.current=x:u.current&&($r(r),n.current===document.activeElement&&b2(r),n.current=document.activeElement),u.current=!1};return document.addEventListener("focus",i,!0),()=>{document.removeEventListener("focus",i,!0)}},[e]),g.useEffect(()=>{if(!e)return;const i=s=>{const r=a.current;if(r){if(s.key==="Escape"&&l){s.preventDefault(),l();return}if(s.key==="Tab"){u.current=!0;const x=Df(r);if(x.length===0)return;const h=x[0],d=x[x.length-1];s.shiftKey?document.activeElement===h&&(s.preventDefault(),d.focus()):document.activeElement===d&&(s.preventDefault(),h.focus())}}};return document.addEventListener("keydown",i),()=>{document.removeEventListener("keydown",i)}},[e,l]),{containerRef:a,focusFirst:c}}const Nr={surface:{kWkggS:"x1prclbq",kaIpWk:"x1hviunn",kGVxlE:"x1i5ehqx",$$css:!0},contentWrapper:{kVAEAm:"x1n2onr6",$$css:!0}};function S2(t={}){const{onShow:e,onHide:l,xstyle:a,hasLightDismiss:n=!0,hasAutoFocus:u=!0,hasSurface:c=!0,hasCloseButton:i=!0,closeButtonLabel:s="Close popover",dialogLabel:r}=t,x=g.useRef(null),h=g.useRef(!1),d=R0({mode:"context",lightDismiss:n,onShow:e,onHide:l}),{containerRef:y,focusFirst:p}=p2({isActive:d.isOpen,onEscape:d.hide});g.useEffect(()=>{d.isOpen&&u&&!h.current&&requestAnimationFrame(()=>{p()}),d.isOpen||(h.current=!1)},[d.isOpen,u,p]);const S=g.useCallback(b=>{x.current=b,d.ref(b)},[d]),k=g.useCallback(b=>{h.current=(b==null?void 0:b.skipAutoFocus)??!1,d.show()},[d]),m=g.useCallback(()=>{d.isOpen?d.hide():k()},[d,k]),f={"aria-haspopup":"dialog","aria-expanded":d.isOpen,"aria-controls":d.id},v=g.useCallback((b,z)=>d.render(o.jsxs("div",{ref:y,role:"dialog","aria-modal":"true","aria-label":r,..._(Nr.contentWrapper,c&&Nr.surface,a),children:[b,i&&o.jsx("div",{className:"x10l6tqk x1ey2m1c x1nrll8i x31h1t8 x1vjfegm x1i1rx1s x10okhzq xjm9jq1 x132qfvm xb3r6kr x1dordxg x1hyvwdk x10wafsz x47corl xbt4iw xexx8yu x1kw28su",children:o.jsx(Un,{variant:"secondary",label:s,onClick:d.hide})})]}),{...z,xstyle:z==null?void 0:z.xstyle}),[d,i,c,s,y,r,a]);return{triggerRef:S,contentRef:y,anchorId:d.anchorId,show:k,hide:d.hide,toggle:m,isOpen:d.isOpen,id:d.id,render:v,triggerProps:f}}const wf=g.createContext({isCollapsed:!1,toggle:()=>{},isCollapsible:!1});function Cf(){return g.useContext(wf)}function _f({sideNavRef:t,label:e,children:l}){const{isCollapsed:a,toggle:n,isCollapsible:u}=Cf(),{isMobile:c}=$f(),i=g.useCallback(()=>{n()},[n]);return!u||c?null:o.jsx(Un,{label:e??(a?"Expand sidebar":"Collapse sidebar"),variant:"ghost",onClick:i,icon:l??o.jsx("span",{...{0:{className:"x3nfvp2 x6s0dn4 x11xpdln xuedmi6 xlr8y92"},1:{className:"x3nfvp2 x6s0dn4 x11xpdln xuedmi6 xlr8y92 x19jd1h0"}}[!!a<<0],children:Sf("chevronLeft")})})}_f.displayName="XDSSideNavCollapseButton";const yi=180,hi=480,k2=260;function z2({enabled:t,config:e,collapsed:l}){const{defaultWidth:a=k2,onWidthChange:n}=e,[u,c]=g.useState(Math.min(hi,Math.max(yi,a))),i=g.useRef(null),s=g.useRef(!1),r=g.useRef(0),x=g.useRef(0),[h,d]=g.useState(!1),y=g.useCallback(k=>{if(!t)return;k.preventDefault(),s.current=!0,r.current=k.clientX,x.current=u,document.body.style.cursor="col-resize";const m=v=>{if(!s.current)return;const b=v.clientX-r.current,z=Math.min(hi,Math.max(yi,x.current+b));i.current&&(i.current.style.width=`${z}px`)},f=v=>{s.current=!1,document.body.style.cursor="",document.removeEventListener("pointermove",m),document.removeEventListener("pointerup",f);const b=v.clientX-r.current,z=Math.min(hi,Math.max(yi,x.current+b));c(z),n==null||n(z)};document.addEventListener("pointermove",m),document.addEventListener("pointerup",f)},[t,u,n]);return g.useEffect(()=>()=>{s.current&&(document.body.style.cursor="")},[]),{width:u,containerRef:i,showHandle:t&&!l,handleProps:{onPointerDown:y,onPointerEnter:()=>d(!0),onPointerLeave:()=>{s.current||d(!1)}},isHandleHovered:h}}const gi={root:{k1xSpc:"x78zum5",kXwgrk:"xdt5ytf",kZKoxP:"x5yr21d",kzqmXN:"x1hfn5x7",kWkggS:"xgcd1z6",kB7OPa:"x9f619",kVQacm:"xb3r6kr",$$css:!0},rootCollapsed:{kzqmXN:"xvni27",$$css:!0},topbar:{k1xSpc:"x78zum5",kXwgrk:"x1q0g3np",kGNEyG:"x6s0dn4",kjj79g:"x1qughib",kZKoxP:"xsdox4t",kzqmXN:"xh8yej3",kWkggS:"xgcd1z6",kB7OPa:"x9f619",kVQacm:"xb3r6kr",$$css:!0}};function ux({header:t,topContent:e,children:l,footer:a,footerIcons:n,collapsible:u=!1,resizable:c=!1,xstyle:i,className:s,style:r,"data-testid":x,ref:h,...d}){const y=typeof u=="object"?u:{},p=!!u,S=y.hasButton??!0,k=y.defaultIsCollapsed??!1,m=y.isCollapsed,f=y.onCollapsedChange,v=typeof c=="object"?c:{},b=!!c,z=m!==void 0,[N,E]=g.useState(k),M=z?m:N,T=g.useCallback(()=>{const Ct=!M;z||E(Ct),f==null||f(Ct)},[M,z,f]),A={isCollapsed:M,toggle:T,isCollapsible:p},{width:C,containerRef:Z,showHandle:I,handleProps:xt,isHandleHovered:St}=z2({enabled:b,config:v,collapsed:M}),$=r2();if($==="topbar")return o.jsxs("div",{"data-testid":x,...ut(et("side-nav",{mode:"topbar"}),_(gi.topbar,i),s,r),children:[t,o.jsx("div",{className:"x78zum5 x6s0dn4 xzye2dw xvc5jky",children:n})]});const O=!!(a||n);if($==="drawer")return o.jsxs(Of,{header:t,"data-testid":x,children:[e,l,O&&o.jsxs("div",{className:"x78zum5 xdt5ytf xr1yuqi x1txdalj x1xye8es",children:[a,n&&o.jsx("div",{className:"x78zum5 x6s0dn4 xzye2dw",children:n})]})]});if($==="drawer-content")return o.jsxs(o.Fragment,{children:[e,l,O&&o.jsxs("div",{className:"x78zum5 xdt5ytf xr1yuqi x1txdalj x1xye8es",children:[a,n&&o.jsx("div",{className:"x78zum5 x6s0dn4 xzye2dw",children:n})]})]});const D=!!(t||e),L=!!(a||n),J=b?{...r??{},width:M?void 0:C}:r,Et=o.jsxs("nav",{ref:h,role:"navigation","aria-label":"Side navigation","data-testid":x,...ut(et("side-nav"),_(gi.root,M&&gi.rootCollapsed,i),s,J),...d,children:[D&&o.jsxs("div",{className:"x78zum5 xdt5ytf x2lah0s x7wzq59 x13vifvy x1vjfegm xgcd1z6 x1xye8es xy143xn xf314gf x1txdalj xb3r6kr xeuugli",children:[t,e&&o.jsx("div",{children:e})]}),o.jsx("div",{...{0:{className:"x98rzlu x1odjw0f x6ikm8r xf314gf x1xye8es x1wesfrj"},2:{className:"x98rzlu x1odjw0f x6ikm8r xf314gf xfsso4q x1wesfrj"},1:{className:"x98rzlu x1odjw0f x6ikm8r xf314gf x1xye8es xy143xn"},3:{className:"x98rzlu x1odjw0f x6ikm8r xf314gf xfsso4q xy143xn"}}[!!D<<1|!!L<<0],children:l}),(L||p)&&o.jsxs("div",{...{0:{className:"x78zum5 xdt5ytf x2lah0s xr1yuqi x7wzq59 x1ey2m1c xgcd1z6 x1txdalj xf314gf xfsso4q x1wesfrj"},1:{className:"x78zum5 xdt5ytf x2lah0s xr1yuqi x7wzq59 x1ey2m1c xgcd1z6 x1txdalj xf314gf x1wesfrj xexx8yu"}}[!!M<<0],children:[a,o.jsxs("div",{...{0:{className:"x78zum5 x6s0dn4 xzye2dw"},1:{className:"x78zum5 x6s0dn4 xzye2dw x3ieub6"}}[!!M<<0],children:[p&&S&&o.jsx(_f,{}),n]})]})]}),wt=I?o.jsxs("div",{ref:Z,className:"x1n2onr6 x78zum5 x2lah0s x5yr21d",style:{width:C},children:[Et,o.jsx("div",{"data-testid":"xds-sidenav-resize-handle",role:"separator","aria-orientation":"vertical","aria-label":"Resize sidebar",...{0:{className:"x10l6tqk xtijo5x x13vifvy x1ey2m1c x1v4s8kt xicojor xhtitgo xjbqb8w x111pd7f x5ve5x3"},1:{className:"x10l6tqk xtijo5x x13vifvy x1ey2m1c x1v4s8kt xicojor xhtitgo x111pd7f x5ve5x3 x1m4xfpy"}}[!!St<<0],...xt})]}):Et;return p?o.jsx(wf,{value:A,children:wt}):wt}ux.displayName="XDSSideNav";const j2={itemCollapsed:{kjj79g:"xl56j7k",kg3NbH:"x7a5moj",$$css:!0}},E2={isCollapsed:!1,toggle:()=>{},isCollapsible:!1};function Wl({as:t,label:e,icon:l,selectedIcon:a,isSelected:n=!1,isDisabled:u=!1,href:c,onClick:i,endContent:s,children:r,collapsible:x,"data-testid":h,ref:d}){const{isCollapsed:y}=Cf(),p=g.useId(),S=!!r,k=Sc(t),m=g.useRef(null),f=S2({hasLightDismiss:!0,hasAutoFocus:!0,hasCloseButton:!1,dialogLabel:`${e} submenu`}),v=typeof x=="object"?x:{},b=S&&x!==!1,z=v.isCollapsed,N=z!==void 0,[E,M]=g.useState(v.defaultIsCollapsed??!1),T=N?z:E,A=g.useCallback(()=>{var mt;const V=!T;N||M(V),(mt=v.onCollapsedChange)==null||mt.call(v,V)},[T,N,v]),C=n&&a?a:l,Z=V=>{if(u){V.preventDefault();return}if(b&&!y){V.preventDefault(),A();return}i==null||i(V)},I=g.useRef(null),xt=g.useRef(null),St=g.useCallback(()=>{I.current&&(clearTimeout(I.current),I.current=null),xt.current&&(clearTimeout(xt.current),xt.current=null)},[]),$=g.useCallback(()=>{St(),I.current=setTimeout(()=>{f.show({skipAutoFocus:!0})},150)},[St,f]),O=g.useCallback(()=>{St(),xt.current=setTimeout(()=>{f.hide()},200)},[St,f]),D=g.useCallback(()=>{$()},[$]),L=g.useCallback(()=>{O()},[O]);if(y&&!l)return null;if(y){const V=C&&o.jsx(Tn,{icon:C,size:"sm",color:n?"primary":u?"disabled":"secondary"}),mt=ut(et("side-nav-item"),_(Yt.item,j2.itemCollapsed,n&&Yt.selected,u&&Yt.disabled));if(S)return o.jsxs("div",{className:"x78zum5 xdt5ytf xh8yej3",children:[o.jsx("button",{ref:gl=>{f.triggerRef(gl),typeof d=="function"?d(gl):d&&(d.current=gl)},type:"button",onClick:f.toggle,onMouseEnter:D,onMouseLeave:L,"aria-label":e,"data-testid":h,...f.triggerProps,...mt,children:V}),f.render(o.jsxs("div",{className:"x1litavf x1y0btm7 x14i3s5s xu0wf1k x7a5moj x11g1kdw xfb3i0g",onMouseEnter:D,onMouseLeave:L,onClick:()=>f.hide(),children:[o.jsx("div",{className:"xf314gf xu0wf1k x141an7d x2mo6ok xv1l7n4 x1ltkj2j",children:e}),o.jsx(wf,{value:E2,children:r})]}),{placement:"end",alignment:"start"})]});const Bn={"aria-current":n?"page":void 0,"aria-disabled":u||void 0,"aria-label":e,"data-testid":h},kc=c&&!u?o.jsx(k,{ref:d,href:c,onClick:Z,...Bn,...mt,children:V}):o.jsx("button",{ref:d,type:"button",onClick:Z,disabled:u,...Bn,...mt,children:V});return o.jsxs("div",{ref:m,className:"x78zum5 xdt5ytf xh8yej3",children:[kc,o.jsx(pc,{content:e,placement:"end",anchorRef:m})]})}const J=o.jsxs(o.Fragment,{children:[C&&o.jsx(Tn,{icon:C,size:"sm",color:n?"primary":u?"disabled":"secondary"}),!y&&o.jsx("span",{className:"x98rzlu xeuugli xb3r6kr xlyipyv xuxw1ft",children:e}),!y&&s&&o.jsx("span",{className:"x2lah0s x78zum5 x6s0dn4",children:s}),!y&&b&&o.jsx("span",{...{0:{className:"x3nfvp2 x6s0dn4 x11xpdln xuedmi6 xlr8y92 x2lah0s"},1:{className:"x3nfvp2 x6s0dn4 x11xpdln xuedmi6 xlr8y92 x2lah0s x19jd1h0"}}[!!T<<0],children:Sf("chevronDown")})]}),Et={"aria-current":n?"page":void 0,"aria-disabled":u||void 0,"aria-expanded":b?!T:void 0,"aria-controls":b?`${p}-children`:void 0,"data-testid":h},wt=c&&!u?o.jsx(k,{ref:d,href:c,onClick:Z,...Et,...ut(et("side-nav-item"),_(Yt.item,n&&Yt.selected,u&&Yt.disabled)),children:J}):o.jsx("button",{ref:d,type:"button",onClick:Z,disabled:u,...Et,...ut(et("side-nav-item"),_(Yt.item,n&&Yt.selected,u&&Yt.disabled)),children:J});return o.jsxs("div",{ref:m,className:"x78zum5 xdt5ytf xh8yej3",children:[wt,S&&!y&&o.jsx("div",{id:`${p}-children`,role:"group","aria-labelledby":`${p}-label`,"aria-hidden":T,...{0:{className:"xrvj5dj x1tu4anv x1qn9uv2 x80gvsz xlr8y92"},1:{className:"xrvj5dj x1qn9uv2 x80gvsz xlr8y92 xihq33y"}}[!!T<<0],children:o.jsxs("div",{className:"xb3r6kr x2lwn1j x31w388",children:[o.jsx("span",{id:`${p}-label`,hidden:!0,children:e}),r]})})]})}Wl.displayName="XDSSideNavItem";function gs({title:t,subtitle:e,children:l,endContent:a,isHeaderHidden:n=!1,"data-testid":u}){const{isCollapsed:c}=Cf(),s=`${g.useId()}-title`,r=o.jsxs(o.Fragment,{children:[o.jsxs("span",{className:"x78zum5 xdt5ytf x98rzlu xeuugli",children:[o.jsx("span",{id:s,className:"x141an7d x2mo6ok x1ltkj2j xv1l7n4 xb3r6kr xlyipyv xuxw1ft",children:t}),e&&o.jsx("span",{className:"x141an7d x1ltkj2j xv1l7n4 xb3r6kr xlyipyv xuxw1ft",children:e})]}),a&&o.jsx("span",{className:"x2lah0s x78zum5 x6s0dn4",children:a})]}),x=n||c,h=x?{position:"absolute",width:1,height:1,padding:0,margin:-1,overflow:"hidden",clip:"rect(0, 0, 0, 0)",whiteSpace:"nowrap",borderWidth:0}:{};return o.jsxs("div",{role:"group","aria-labelledby":s,"data-testid":u,...ut(et("side-nav-section"),{className:"x78zum5 xdt5ytf xu0wf1k"}),children:[o.jsx("div",{style:x?h:void 0,className:"x78zum5 x6s0dn4 x1txdalj xf314gf xu0wf1k xt0e3qv x87ps6o",children:r}),o.jsx("div",{className:"x78zum5 xdt5ytf x1lsbc85",children:l})]})}gs.displayName="XDSSideNavSection";function T2(){const[t,e]=g.useState("users");return o.jsx(kf,{theme:w0,children:o.jsx(P0,{topNav:o.jsx(lx,{label:"Admin navigation",heading:o.jsx(ax,{heading:"Admin Panel",href:"/"}),startContent:o.jsxs(o.Fragment,{children:[o.jsx(ju,{label:"Dashboard",href:"/dashboard",isSelected:!0}),o.jsx(ju,{label:"Analytics",href:"/analytics"}),o.jsx(ju,{label:"Reports",href:"/reports"})]})}),sideNav:o.jsxs(ux,{collapsible:!0,footerIcons:o.jsx(_f,{}),children:[o.jsxs(gs,{title:"Management",isHeaderHidden:!0,children:[o.jsx(Wl,{label:"Users",isSelected:t==="users",onClick:()=>e("users")}),o.jsx(Wl,{label:"Roles",isSelected:t==="roles",onClick:()=>e("roles")}),o.jsx(Wl,{label:"Permissions",isSelected:t==="permissions",onClick:()=>e("permissions")})]}),o.jsxs(gs,{title:"System",children:[o.jsx(Wl,{label:"Settings",isSelected:t==="settings",onClick:()=>e("settings")}),o.jsx(Wl,{label:"Logs",isSelected:t==="logs",onClick:()=>e("logs")})]})]}),children:o.jsx(Tf,{content:o.jsxs(Af,{role:"main",label:"Main content",children:[o.jsx("h2",{children:"Content Area"}),o.jsxs("p",{children:["Main content for the ",o.jsx("strong",{children:t})," section goes here. This area scrolls independently."]})]}),end:o.jsxs(Mf,{hasDivider:!0,label:"Details panel",children:[o.jsx("h3",{children:"Details"}),o.jsx("p",{children:"Contextual information and actions for the selected item appear in this right panel."})]})})})})}function M2(){return o.jsx(kf,{theme:w0,mode:"light",children:o.jsx(T2,{})})}xy.createRoot(document.getElementById("root")).render(o.jsx(M2,{}));</script>
+  <style rel="stylesheet" crossorigin>/**
+ * XDS Reset Stylesheet
+ *
+ * An opinionated CSS reset that provides a clean, predictable base for
+ * XDS applications. Built on the same principles as Tailwind Preflight
+ * and modern-normalize, adapted for the XDS design system.
+ *
+ * This reset:
+ * - Normalizes cross-browser inconsistencies
+ * - Sets box-sizing: border-box universally
+ * - Removes default margins, padding, and list styles
+ * - Makes images block-level and responsive
+ * - Resets form elements to inherit font styles
+ * - Uses :where() for zero specificity (easy to override)
+ *
+ * Usage:
+ *
+ * 1. Import directly (global reset):
+ *    import '@xds/core/reset.css';
+ *
+ * 2. Combine with base styles and theme:
+ *    import '@xds/core/reset.css';        // @layer reset  — clean slate
+ *    import '@xds/core/xds.css';           // @layer xds-base — component styles
+ *    import '@xds/theme-default/theme.css'; // @layer xds-theme — theme overrides
+ *
+ * Layer order: reset → xds-base → xds-theme
+ * Consumer styles (unlayered) always override all XDS layers.
+ * The reset has the lowest priority and can be overridden by any other layer.
+ *
+ * Similar to:
+ * - Tailwind CSS Preflight
+ * - Chakra UI's preflight (v3)
+ * - Bootstrap Reboot
+ * - modern-normalize
+ */
+
+@layer reset {
+
+  /* ===========================================================================
+     Box Model
+     =========================================================================== */
+
+  /*
+   * Use border-box globally. Prevents padding/border from affecting
+   * element dimensions — the single most impactful reset.
+   */
+  :where(*, *::before, *::after) {
+    box-sizing: border-box;
+  }
+
+  /*
+   * Reset borders to 0-width solid. This lets you add a border by just
+   * setting border-width — no need to also specify border-style.
+   */
+  :where(*, *::before, *::after) {
+    border-width: 0;
+    border-style: solid;
+    border-color: currentColor;
+  }
+
+  /* ===========================================================================
+     Document
+     =========================================================================== */
+
+  /*
+   * Consistent line-height, prevent text size adjustment on orientation
+   * change in iOS, and set a readable tab size.
+   *
+   * color-scheme: light dark — declares that this page supports both modes,
+   * enabling CSS light-dark() to resolve correctly. Also ensures that CSS
+   * tools (e.g. LightningCSS) which polyfill light-dark() for older browsers
+   * inject their toggle-variable initialization in the same CSS bundle.
+   * XDSTheme overrides color-scheme per-wrapper as needed.
+   */
+  :where(html) {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    color-scheme: light dark;
+  }
+
+  /*
+   * Remove default body margin and set font smoothing for sharper text
+   * rendering on macOS/iOS.
+   */
+  :where(body) {
+    margin: 0;
+    line-height: inherit;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* ===========================================================================
+     Typography
+     =========================================================================== */
+
+  /*
+   * Reset headings to inherit size and weight. Headings should be styled
+   * intentionally — not rely on browser defaults that vary across browsers.
+   */
+  :where(h1, h2, h3, h4, h5, h6) {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /*
+   * Remove default margins on all block-level text elements.
+   */
+  :where(h1, h2, h3, h4, h5, h6, p, blockquote, figure, pre, dl, dd) {
+    margin: 0;
+  }
+
+  /*
+   * Links inherit color and text-decoration. Style them intentionally
+   * rather than relying on browser-default blue/purple.
+   */
+  :where(a) {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  /*
+   * Correct font-weight rendering in Chrome and Safari.
+   */
+  :where(b, strong) {
+    font-weight: bolder;
+  }
+
+  /*
+   * Use the configured monospace font stack and fix the odd em sizing
+   * that browsers apply to code elements.
+   */
+  :where(code, kbd, samp, pre) {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      'Liberation Mono', 'Courier New', monospace;
+    font-size: 1em;
+  }
+
+  /*
+   * Correct font-size for small elements.
+   */
+  :where(small) {
+    font-size: 80%;
+  }
+
+  /*
+   * Prevent sub and sup from affecting line-height.
+   */
+  :where(sub, sup) {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  :where(sub) {
+    bottom: -0.25em;
+  }
+
+  :where(sup) {
+    top: -0.5em;
+  }
+
+  /* ===========================================================================
+     Lists
+     =========================================================================== */
+
+  /*
+   * Remove default list styles, margin, and padding. Lists used for
+   * navigation or layout shouldn't carry prose styling by default.
+   * Use explicit styles for prose lists.
+   */
+  :where(ol, ul, menu) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Media
+     =========================================================================== */
+
+  /*
+   * Make replaced elements block-level. Eliminates the "mystery gap"
+   * below inline images and aligns with how these elements are
+   * actually used in modern layouts.
+   */
+  :where(img, svg, video, canvas, audio, iframe, embed, object) {
+    display: block;
+    vertical-align: middle;
+  }
+
+  /*
+   * Constrain images and video to their container. Responsive by default.
+   */
+  :where(img, video) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* ===========================================================================
+     Forms
+     =========================================================================== */
+
+  /*
+   * Form elements should inherit font styles from their parent rather
+   * than using the browser's default font stack.
+   */
+  :where(button, input, optgroup, select, textarea) {
+    font: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  /*
+   * Remove default button styling. Buttons should be styled intentionally.
+   */
+  :where(button, [type='button'], [type='reset'], [type='submit']) {
+    -webkit-appearance: button;
+    appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
+
+  /*
+   * Pointer cursor for interactive elements.
+   */
+  :where(button, [role='button']) {
+    cursor: pointer;
+  }
+
+  /*
+   * Default cursor for disabled elements.
+   */
+  :where(:disabled) {
+    cursor: default;
+  }
+
+  /*
+   * Only allow vertical resizing of textareas to prevent layout breakage.
+   */
+  :where(textarea) {
+    resize: vertical;
+  }
+
+  /*
+   * Normalize placeholder opacity (Firefox renders at reduced opacity)
+   * and set a sensible default color using the XDS text-placeholder token.
+   */
+  :where(input::placeholder, textarea::placeholder) {
+    opacity: 1;
+    color: var(--color-text-secondary, #9ca3af);
+  }
+
+  /*
+   * Remove the inner padding and cancel buttons in search inputs
+   * for Chrome and Safari.
+   */
+  :where([type='search']::-webkit-search-decoration,
+         [type='search']::-webkit-search-cancel-button) {
+    -webkit-appearance: none;
+  }
+
+  /*
+   * Remove default fieldset styles.
+   */
+  :where(fieldset) {
+    margin: 0;
+    padding: 0;
+  }
+
+  :where(legend) {
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Tables
+     =========================================================================== */
+
+  /*
+   * Collapse table borders and fix text-indent/border-color inheritance.
+   */
+  :where(table) {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  /* ===========================================================================
+     Misc
+     =========================================================================== */
+
+  /*
+   * Simplify hr to a single border-top line.
+   */
+  :where(hr) {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  /*
+   * Correct display for summary elements.
+   */
+  :where(summary) {
+    display: list-item;
+  }
+
+  /*
+   * Reset dialog padding and outline.
+   */
+  :where(dialog) {
+    padding: 0;
+    outline: none;
+  }
+
+  /*
+   * Ensure hidden elements are actually hidden.
+   */
+  :where([hidden]) {
+    display: none;
+  }
+
+  /*
+   * Remove tap highlight on iOS.
+   */
+  :where(html) {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* ===========================================================================
+     Touch Devices
+     =========================================================================== */
+
+  /*
+   * Suppress focus-visible outlines on touch-only devices.
+   *
+   * Focus rings exist to show keyboard users where focus is. On devices
+   * with no hover capability and a coarse pointer (phones, tablets),
+   * there's no keyboard navigation — focus rings are visual noise that
+   * can flash on tap, on dialog open (showModal auto-focus), or on
+   * programmatic focus.
+   *
+   * This targets touch-only devices specifically:
+   * - (hover: none) — no hover capability (not a mouse)
+   * - (pointer: coarse) — imprecise pointer (finger, not stylus)
+   *
+   * Hybrid devices (laptop with touchscreen) are NOT affected because
+   * their primary pointer is fine (trackpad/mouse) and hover is available.
+   */
+  @media (hover: none) and (pointer: coarse) {
+    :where(:focus-visible) {
+      outline: none;
+    }
+  }
+}</style>
+<style>@property --x---container-max-height {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-height {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-width {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-maxWidth {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-minHeight {
+  syntax: "*";
+  inherits: false
+}
+
+@keyframes xwmkjkf-B {
+  from {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xu7jd1z-B {
+  from {
+    opacity: 0;
+    transform: translateX(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xv1hr86-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes x1ahk7ht-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes xqng64z-B {
+  0% {
+    transform: rotate(0);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+:root, .xyc456f {
+  --border-width: 1px;
+}
+
+:root, .xrphr3l {
+  --color-accent: light-dark(#0064e0, #2694fe);
+  --color-accent-muted: light-dark(#0082fb33, #0082fb3f);
+  --color-on-accent: light-dark(#fff, #fff);
+  --color-neutral: light-dark(#0536591a, #dfe2e533);
+  --color-background-surface: light-dark(#fff, #1f1f22);
+  --color-background-body: light-dark(#f1f4f7, #111112);
+  --color-overlay: light-dark(#01122866, #11111299);
+  --color-overlay-hover: light-dark(#0536590c, #ffffff0c);
+  --color-overlay-pressed: light-dark(#05365919, #ffffff19);
+  --color-background-muted: light-dark(#0536590c, #1111127f);
+  --color-text-primary: light-dark(#0a1317, #dfe2e5);
+  --color-text-secondary: light-dark(#4e606f, #aaafb5);
+  --color-text-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-text-accent: light-dark(#0064e0, #3e9efb);
+  --color-on-dark: light-dark(#fff, #fff);
+  --color-on-light: light-dark(#000, #000);
+  --color-icon-accent: light-dark(#0064e0, #2694fe);
+  --color-icon-primary: light-dark(#0a1317, #dfe2e5);
+  --color-icon-secondary: light-dark(#4e606f, #aaafb5);
+  --color-icon-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-background-card: light-dark(#fff, #1f1f22);
+  --color-background-popover: light-dark(#fff, #28292c);
+  --color-success: light-dark(#0d8626, #0d8626);
+  --color-success-muted: light-dark(#0b991f33, #0b991f3f);
+  --color-on-success: light-dark(#fff, #fff);
+  --color-error: light-dark(#e3193b, #f5394f);
+  --color-error-muted: light-dark(#e3193b33, #f5394f3f);
+  --color-on-error: light-dark(#fff, #fff);
+  --color-warning: light-dark(#e9af08, #f2c00b);
+  --color-warning-muted: light-dark(#e2a40033, #e2a4003f);
+  --color-on-warning: light-dark(#0a1317, #0a1317);
+  --color-border: light-dark(#05365919, #f2f4f619);
+  --color-border-emphasized: light-dark(#ccd3db, #494d53);
+  --color-skeleton: light-dark(#ccd3db, #5a5e66);
+  --color-shadow: light-dark(#0536591a, #0000004d);
+  --color-tint-hover: light-dark(#000, #fff);
+  --color-background-blue: light-dark(#0171e333, #0171e333);
+  --color-border-blue: light-dark(#0171e3, #4ba9fe);
+  --color-icon-blue: light-dark(#0064e0, #2694fe);
+  --color-text-blue: light-dark(#042f97, #afd7ff);
+  --color-background-cyan: light-dark(#03a7d733, #03a7d733);
+  --color-border-cyan: light-dark(#00bcd4, #4dd0e1);
+  --color-icon-cyan: light-dark(#00acc1, #26c6da);
+  --color-text-cyan: light-dark(#014975, #a1eef9);
+  --color-background-gray: light-dark(#0a131733, #666a724c);
+  --color-border-gray: light-dark(#647685, #8c939b);
+  --color-icon-gray: light-dark(#4e606f, #aaafb5);
+  --color-text-gray: light-dark(#0a1317, #e7eaed);
+  --color-background-green: light-dark(#24bb5e33, #24bb5e33);
+  --color-border-green: light-dark(#24bb5e, #4cd964);
+  --color-icon-green: light-dark(#0d8626, #26a756);
+  --color-text-green: light-dark(#09441f, #a5f690);
+  --color-background-orange: light-dark(#f2790233, #f2790233);
+  --color-border-orange: light-dark(#f27902, #ffa040);
+  --color-icon-orange: light-dark(#e9690b, #fb8c00);
+  --color-text-orange: light-dark(#6b2203, #fdb876);
+  --color-background-pink: light-dark(#e638b333, #e638b333);
+  --color-border-pink: light-dark(#e91e63, #f48fb1);
+  --color-icon-pink: light-dark(#c2185b, #ec407a);
+  --color-text-pink: light-dark(#650053, #feade3);
+  --color-background-purple: light-dark(#7952ff33, #7952ff33);
+  --color-border-purple: light-dark(#7952ff, #9575cd);
+  --color-icon-purple: light-dark(#5b08d8, #7952ff);
+  --color-text-purple: light-dark(#3e0697, #b3b0fe);
+  --color-background-red: light-dark(#e3193b33, #e3193b33);
+  --color-border-red: light-dark(#e3193b, #f5394f);
+  --color-icon-red: light-dark(#d31130, #e3193b);
+  --color-text-red: light-dark(#7b0210, #ffb2b8);
+  --color-background-teal: light-dark(#0db7af33, #0db7af33);
+  --color-border-teal: light-dark(#0db7af, #4db6ac);
+  --color-icon-teal: light-dark(#009688, #26a69a);
+  --color-text-teal: light-dark(#083943, #40dccd);
+  --color-background-yellow: light-dark(#e2a40033, #e2a40033);
+  --color-border-yellow: light-dark(#ffeb3b, #fff176);
+  --color-icon-yellow: light-dark(#fbc02d, #ffee58);
+  --color-text-yellow: light-dark(#753f07, #fbce03);
+}
+
+:root, .xdxxp96 {
+  --duration-fast-min: .13s;
+  --duration-fast: .175s;
+  --duration-fast-max: .23s;
+  --duration-medium-min: .31s;
+  --duration-medium: .41s;
+  --duration-medium-max: .55s;
+}
+
+:root, .x1u6r7cv {
+  --ease-standard: cubic-bezier(.24, 1, .4, 1);
+}
+
+:root, .x6xvlns {
+  --font-family-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-family-code: "SF Mono", Monaco, Consolas, monospace;
+  --font-family-heading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+:root, .x48sopm {
+  --font-size-4xs: .375rem;
+  --font-size-3xs: .4375rem;
+  --font-size-2xs: .5rem;
+  --font-size-xs: .625rem;
+  --font-size-sm: .75rem;
+  --font-size-base: .875rem;
+  --font-size-lg: 1.0625rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.8125rem;
+  --font-size-4xl: 2.1875rem;
+  --font-size-5xl: 2.625rem;
+}
+
+:root, .x1anzp68 {
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+}
+
+:root, .xy6n0i {
+  --radius-none: 0px;
+  --radius-inner: 4px;
+  --radius-element: 8px;
+  --radius-container: 12px;
+  --radius-page: 28px;
+  --radius-full: 9999px;
+}
+
+:root, .x99zpk1 {
+  --shadow-low: 0px 1px 1px light-dark(#0000001a, #0003), 0px 2px 8px light-dark(#0000001a, #0003);
+  --shadow-med: 0px 1px 2px light-dark(#0000001a, #0003), 0px 2px 12px light-dark(#0000001a, #0003);
+  --shadow-high: 0px 2px 2px light-dark(#0000001a, #0003), 0px 8px 24px light-dark(#0000001a, #0000004d);
+  --shadow-inset-hover: inset 0px 0px 0px 2px #0171e34d;
+  --shadow-inset-selected: inset 0px 0px 0px 2px #0171e380;
+  --shadow-inset-success: inset 0px 0px 0px 2px #26a7564d;
+  --shadow-inset-warning: inset 0px 0px 0px 2px #e2a4004d;
+  --shadow-inset-error: inset 0px 0px 0px 2px #e3193b4d;
+}
+
+:root, .x10aelx4 {
+  --size-element-sm: 28px;
+  --size-element-md: 32px;
+  --size-element-lg: 36px;
+}
+
+:root, .x1auoh0n {
+  --spacing-0: 0px;
+  --spacing-0-5: 2px;
+  --spacing-1: 4px;
+  --spacing-1-5: 6px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-11: 44px;
+  --spacing-12: 48px;
+}
+
+:root, .xmde5od {
+  --text-heading-1-size: var(--font-size-2xl);
+  --text-heading-1-weight: var(--font-weight-semibold);
+  --text-heading-1-leading: 1.3333;
+  --text-heading-2-size: var(--font-size-xl);
+  --text-heading-2-weight: var(--font-weight-semibold);
+  --text-heading-2-leading: 1.4;
+  --text-heading-3-size: var(--font-size-lg);
+  --text-heading-3-weight: var(--font-weight-semibold);
+  --text-heading-3-leading: 1.4118;
+  --text-heading-4-size: var(--font-size-base);
+  --text-heading-4-weight: var(--font-weight-semibold);
+  --text-heading-4-leading: 1.4286;
+  --text-heading-5-size: var(--font-size-sm);
+  --text-heading-5-weight: var(--font-weight-semibold);
+  --text-heading-5-leading: 1.6667;
+  --text-heading-6-size: var(--font-size-xs);
+  --text-heading-6-weight: var(--font-weight-semibold);
+  --text-heading-6-leading: 1.6;
+  --text-body-size: var(--font-size-base);
+  --text-body-weight: var(--font-weight-normal);
+  --text-body-leading: 1.4286;
+  --text-large-size: var(--font-size-lg);
+  --text-large-weight: var(--font-weight-semibold);
+  --text-large-leading: 1.4118;
+  --text-label-size: var(--font-size-base);
+  --text-label-weight: var(--font-weight-medium);
+  --text-label-leading: 1.4286;
+  --text-code-size: var(--font-size-base);
+  --text-code-weight: var(--font-weight-normal);
+  --text-code-leading: 1.4286;
+  --text-supporting-size: var(--font-size-sm);
+  --text-supporting-weight: var(--font-weight-normal);
+  --text-supporting-leading: 1.6667;
+  --text-display-1-size: var(--font-size-5xl);
+  --text-display-1-weight: var(--font-weight-normal);
+  --text-display-1-leading: 1.2381;
+  --text-display-2-size: var(--font-size-4xl);
+  --text-display-2-weight: var(--font-weight-normal);
+  --text-display-2-leading: 1.2571;
+  --text-display-3-size: var(--font-size-3xl);
+  --text-display-3-weight: var(--font-weight-normal);
+  --text-display-3-leading: 1.2414;
+}
+
+:root, .xs77cmt {
+  --transition-fast: .15s ease;
+  --transition-normal: .2s ease;
+}
+
+.xkzo27j {
+  --button-focus-offset: 3px;
+}
+
+.x1v15ycx {
+  --button-icon-only-aspect: 1 / 1;
+}
+
+.x1mkq5kp {
+  --button-radius: var(--radius-element);
+}
+
+.xb26y6u {
+  --card-radius: var(--radius-container);
+}
+
+.x30uzy1 {
+  --component-padding-inline: var(--spacing-2);
+}
+
+.x1ojg8sz {
+  --component-padding-inline: var(--spacing-3);
+}
+
+.x18nyedi {
+  --container-max-height: var(--x---container-max-height);
+}
+
+.x1qmdwou {
+  --container-padding-inline: var(--spacing-0-5);
+}
+
+.x11nj8ps {
+  --container-padding-inline: var(--spacing-0);
+}
+
+.x11c4xrl {
+  --container-padding-inline: var(--spacing-1-5);
+}
+
+.xmqp8mn {
+  --container-padding-inline: var(--spacing-1);
+}
+
+.x1mh38z9 {
+  --container-padding-inline: var(--spacing-10);
+}
+
+.xarkblc {
+  --container-padding-inline: var(--spacing-11);
+}
+
+.x15nzvup {
+  --container-padding-inline: var(--spacing-12);
+}
+
+.xvkq9sf {
+  --container-padding-inline: var(--spacing-2);
+}
+
+.x17rklng {
+  --container-padding-inline: var(--spacing-3);
+}
+
+.x1qtkjpi {
+  --container-padding-inline: var(--spacing-4);
+}
+
+.xcek0mv {
+  --container-padding-inline: var(--spacing-5);
+}
+
+.xzryng3 {
+  --container-padding-inline: var(--spacing-6);
+}
+
+.x1jrgra8 {
+  --container-padding-inline: var(--spacing-7);
+}
+
+.x1t3jwqk {
+  --container-padding-inline: var(--spacing-8);
+}
+
+.x1ikhtwg {
+  --container-padding-inline: var(--spacing-9);
+}
+
+.x118jium {
+  --container-padding-inline: var(--xds-card-padding, var(--spacing-4));
+}
+
+.x1x4tb0e {
+  --container-padding-inline: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xbuvapz {
+  --container-padding: 0px;
+}
+
+.x1b322fk {
+  --container-padding: var(--spacing-0-5);
+}
+
+.x1i337hy {
+  --container-padding: var(--spacing-0);
+}
+
+.x1tqehje {
+  --container-padding: var(--spacing-1-5);
+}
+
+.x11x0u8a {
+  --container-padding: var(--spacing-1);
+}
+
+.xl4lgz8 {
+  --container-padding: var(--spacing-10);
+}
+
+.xfk8qm2 {
+  --container-padding: var(--spacing-11);
+}
+
+.xtcn5oa {
+  --container-padding: var(--spacing-12);
+}
+
+.xyawmno {
+  --container-padding: var(--spacing-2);
+}
+
+.xiq2vfk {
+  --container-padding: var(--spacing-3);
+}
+
+.x18iqpsj {
+  --container-padding: var(--spacing-4);
+}
+
+.x305b4h {
+  --container-padding: var(--spacing-5);
+}
+
+.x1suvfq4 {
+  --container-padding: var(--spacing-6);
+}
+
+.xe04trj {
+  --container-padding: var(--spacing-7);
+}
+
+.xv6sa6u {
+  --container-padding: var(--spacing-8);
+}
+
+.xswgb5g {
+  --container-padding: var(--spacing-9);
+}
+
+.x8q8htr {
+  --container-padding: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xms56fs {
+  --container-padding: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xwfoc2r {
+  --edge-end: 1;
+}
+
+.x1tfgai2 {
+  --edge-start: 1;
+}
+
+.xlriy2h {
+  --layout-padding-inner-x: var(--spacing-0-5);
+}
+
+.xj1bl4l {
+  --layout-padding-inner-x: var(--spacing-0);
+}
+
+.xd38f90 {
+  --layout-padding-inner-x: var(--spacing-1-5);
+}
+
+.x6uuyak {
+  --layout-padding-inner-x: var(--spacing-1);
+}
+
+.x1vf4qco {
+  --layout-padding-inner-x: var(--spacing-10);
+}
+
+.xsmamsf {
+  --layout-padding-inner-x: var(--spacing-11);
+}
+
+.x2xk2xj {
+  --layout-padding-inner-x: var(--spacing-12);
+}
+
+.xxqksqd {
+  --layout-padding-inner-x: var(--spacing-2);
+}
+
+.x1fyui2f {
+  --layout-padding-inner-x: var(--spacing-3);
+}
+
+.x1i2ajwi {
+  --layout-padding-inner-x: var(--spacing-4);
+}
+
+.x1tac27u {
+  --layout-padding-inner-x: var(--spacing-5);
+}
+
+.x1ntgf3t {
+  --layout-padding-inner-x: var(--spacing-6);
+}
+
+.xhjd9tl {
+  --layout-padding-inner-x: var(--spacing-7);
+}
+
+.xn7c84u {
+  --layout-padding-inner-x: var(--spacing-8);
+}
+
+.xeqkbsz {
+  --layout-padding-inner-x: var(--spacing-9);
+}
+
+.x1gox8qf {
+  --layout-padding-inner-x: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xn3f0pw {
+  --layout-padding-inner-x: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x180h0y5 {
+  --layout-padding-inner-y: var(--spacing-0-5);
+}
+
+.xwuefyo {
+  --layout-padding-inner-y: var(--spacing-0);
+}
+
+.x1g8jpzm {
+  --layout-padding-inner-y: var(--spacing-1-5);
+}
+
+.xmpug6m {
+  --layout-padding-inner-y: var(--spacing-1);
+}
+
+.x18gbwmk {
+  --layout-padding-inner-y: var(--spacing-10);
+}
+
+.x14zymzj {
+  --layout-padding-inner-y: var(--spacing-11);
+}
+
+.xzfpkx9 {
+  --layout-padding-inner-y: var(--spacing-12);
+}
+
+.x1lksgje {
+  --layout-padding-inner-y: var(--spacing-2);
+}
+
+.x4j7gld {
+  --layout-padding-inner-y: var(--spacing-3);
+}
+
+.x1s3ehtl {
+  --layout-padding-inner-y: var(--spacing-4);
+}
+
+.x1rj5eim {
+  --layout-padding-inner-y: var(--spacing-5);
+}
+
+.x1ftgg6u {
+  --layout-padding-inner-y: var(--spacing-6);
+}
+
+.x1ho74vh {
+  --layout-padding-inner-y: var(--spacing-7);
+}
+
+.xm2cs6f {
+  --layout-padding-inner-y: var(--spacing-8);
+}
+
+.x1vsq92b {
+  --layout-padding-inner-y: var(--spacing-9);
+}
+
+.x1eounod {
+  --layout-padding-inner-y: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xihc2cu {
+  --layout-padding-inner-y: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x1wbjvqu {
+  --layout-padding-outer-x: 0px;
+}
+
+.xihiwg7 {
+  --layout-padding-outer-x: var(--spacing-0-5);
+}
+
+.xswhm3q {
+  --layout-padding-outer-x: var(--spacing-0);
+}
+
+.x1u93lgd {
+  --layout-padding-outer-x: var(--spacing-1-5);
+}
+
+.xc96xmq {
+  --layout-padding-outer-x: var(--spacing-1);
+}
+
+.x1jdf5a4 {
+  --layout-padding-outer-x: var(--spacing-10);
+}
+
+.x1hct0t0 {
+  --layout-padding-outer-x: var(--spacing-11);
+}
+
+.x11cyqoe {
+  --layout-padding-outer-x: var(--spacing-12);
+}
+
+.x15dxnc0 {
+  --layout-padding-outer-x: var(--spacing-2);
+}
+
+.xadgj3j {
+  --layout-padding-outer-x: var(--spacing-3);
+}
+
+.x1v56qcf {
+  --layout-padding-outer-x: var(--spacing-4);
+}
+
+.x1nzs0gl {
+  --layout-padding-outer-x: var(--spacing-5);
+}
+
+.x1c3n52a {
+  --layout-padding-outer-x: var(--spacing-6);
+}
+
+.x1gfiokx {
+  --layout-padding-outer-x: var(--spacing-7);
+}
+
+.x1t3kfz {
+  --layout-padding-outer-x: var(--spacing-8);
+}
+
+.xzr4qsh {
+  --layout-padding-outer-x: var(--spacing-9);
+}
+
+.x1r0u152 {
+  --layout-padding-outer-x: var(--xds-card-padding, var(--spacing-4));
+}
+
+.x1h0nqri {
+  --layout-padding-outer-x: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xzxxx64 {
+  --layout-padding-outer-y: 0px;
+}
+
+.x1vj96e0 {
+  --layout-padding-outer-y: var(--spacing-0-5);
+}
+
+.x1mzf5mb {
+  --layout-padding-outer-y: var(--spacing-0);
+}
+
+.xd3dqby {
+  --layout-padding-outer-y: var(--spacing-1-5);
+}
+
+.x1gpfxoh {
+  --layout-padding-outer-y: var(--spacing-1);
+}
+
+.x26l4wa {
+  --layout-padding-outer-y: var(--spacing-10);
+}
+
+.x10zktp0 {
+  --layout-padding-outer-y: var(--spacing-11);
+}
+
+.x1yz3n6a {
+  --layout-padding-outer-y: var(--spacing-12);
+}
+
+.x10pz7y9 {
+  --layout-padding-outer-y: var(--spacing-2);
+}
+
+.x1p6yq3h {
+  --layout-padding-outer-y: var(--spacing-3);
+}
+
+.xx738ci {
+  --layout-padding-outer-y: var(--spacing-4);
+}
+
+.x6yxws5 {
+  --layout-padding-outer-y: var(--spacing-5);
+}
+
+.x180vrwl {
+  --layout-padding-outer-y: var(--spacing-6);
+}
+
+.x1q6rme1 {
+  --layout-padding-outer-y: var(--spacing-7);
+}
+
+.xid7e43 {
+  --layout-padding-outer-y: var(--spacing-8);
+}
+
+.x1t5kicu {
+  --layout-padding-outer-y: var(--spacing-9);
+}
+
+.xzqheer {
+  --layout-padding-outer-y: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xlfd3nr {
+  --layout-padding-outer-y: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x10a8y8t:not(#\#) {
+  inset: 0;
+}
+
+.xkdpibf:not(#\#) {
+  margin: -1px;
+}
+
+.x1ghz6dp:not(#\#) {
+  margin: 0;
+}
+
+.x1ak00ur:not(#\#) {
+  margin: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1717udv:not(#\#) {
+  padding: 0;
+}
+
+.x1kp5lmi:not(#\#) {
+  padding: var(--container-padding);
+}
+
+.x9epnlk:not(#\#) {
+  padding: var(--spacing-1);
+}
+
+.x1shk3sm:not(#\#) {
+  padding: var(--spacing-4);
+}
+
+.x1y5lnwp:focus:not(#\#) {
+  margin: 0;
+}
+
+.xvy26l8:not(#\#):not(#\#) {
+  border-color: var(--color-border-emphasized);
+}
+
+.x14i3s5s:not(#\#):not(#\#) {
+  border-color: var(--color-border);
+}
+
+.x1q11iln:not(#\#):not(#\#) {
+  border-radius: var(--button-radius);
+}
+
+.x8j4bds:not(#\#):not(#\#) {
+  border-radius: var(--card-radius);
+}
+
+.x1hviunn:not(#\#):not(#\#) {
+  border-radius: var(--radius-container);
+}
+
+.xh6dtrn:not(#\#):not(#\#) {
+  border-radius: var(--radius-element);
+}
+
+.xng3xce:not(#\#):not(#\#) {
+  border-style: none;
+}
+
+.x1y0btm7:not(#\#):not(#\#) {
+  border-style: solid;
+}
+
+.xc342km:not(#\#):not(#\#) {
+  border-width: 0;
+}
+
+.x1litavf:not(#\#):not(#\#) {
+  border-width: var(--border-width);
+}
+
+.x845mor:not(#\#):not(#\#), .x98rzlu:not(#\#):not(#\#) {
+  flex: 1;
+}
+
+.x14kbac9:not(#\#):not(#\#) {
+  gap: inherit;
+}
+
+.x1lsbc85:not(#\#):not(#\#) {
+  gap: var(--spacing-0-5);
+}
+
+.xsn7fz1:not(#\#):not(#\#) {
+  gap: var(--spacing-0);
+}
+
+.x1s4dlld:not(#\#):not(#\#) {
+  gap: var(--spacing-1-5);
+}
+
+.xzye2dw:not(#\#):not(#\#) {
+  gap: var(--spacing-1);
+}
+
+.x3hoi3v:not(#\#):not(#\#) {
+  gap: var(--spacing-10);
+}
+
+.x1txdalj:not(#\#):not(#\#) {
+  gap: var(--spacing-2);
+}
+
+.xjcht0a:not(#\#):not(#\#) {
+  gap: var(--spacing-3);
+}
+
+.x18g69wz:not(#\#):not(#\#) {
+  gap: var(--spacing-4);
+}
+
+.x9mgr7n:not(#\#):not(#\#) {
+  gap: var(--spacing-5);
+}
+
+.x1qh66ti:not(#\#):not(#\#) {
+  gap: var(--spacing-6);
+}
+
+.x4t41sb:not(#\#):not(#\#) {
+  gap: var(--spacing-8);
+}
+
+.xcxpkta:not(#\#):not(#\#) {
+  margin-block: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1g06x3t:not(#\#):not(#\#) {
+  margin-block: var(--spacing-2);
+}
+
+.xzyy9it:not(#\#):not(#\#) {
+  margin-inline: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1a2a7pz:not(#\#):not(#\#) {
+  outline: none;
+}
+
+.xysyzu8:not(#\#):not(#\#) {
+  overflow: auto;
+}
+
+.x7giv3:not(#\#):not(#\#) {
+  overflow: clip;
+}
+
+.xb3r6kr:not(#\#):not(#\#) {
+  overflow: hidden;
+}
+
+.x1rea2x4:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xish69e:not(#\#):not(#\#) {
+  overscroll-behavior: contain;
+}
+
+.xt970qd:not(#\#):not(#\#) {
+  padding-block: 0;
+}
+
+.xu0wf1k:not(#\#):not(#\#) {
+  padding-block: var(--spacing-1);
+}
+
+.xce4md1:not(#\#):not(#\#) {
+  padding-block: var(--spacing-2);
+}
+
+.x8o8v82:not(#\#):not(#\#) {
+  padding-block: var(--spacing-3);
+}
+
+.xnjsko4:not(#\#):not(#\#) {
+  padding-inline: 0;
+}
+
+.xkjnx3w:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-0-5);
+}
+
+.x7a5moj:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-1);
+}
+
+.xf314gf:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-2);
+}
+
+.xrrkdod:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-3);
+}
+
+.x1pzlopt:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-4);
+}
+
+.xmqliwb:not(#\#):not(#\#) {
+  text-decoration: line-through;
+}
+
+.x1hl2dhg:not(#\#):not(#\#) {
+  text-decoration: none;
+}
+
+.x1bvjpef:not(#\#):not(#\#) {
+  text-decoration: underline;
+}
+
+.x111pd7f:not(#\#):not(#\#) {
+  transition: background-color .15s;
+}
+
+.x17nn4n9:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-accent);
+}
+
+.x1p73he7:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-error);
+}
+
+.x1dordxg:focus-within:not(#\#):not(#\#), .xomzh7y:focus:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xh2mrf5:focus:not(#\#):not(#\#) {
+  padding-block: var(--spacing-2);
+}
+
+.x1cf3d6k:focus:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-4);
+}
+
+@media (hover: hover) {
+  .x4ohgrr.x4ohgrr:hover:not(#\#):not(#\#) {
+    text-decoration: underline;
+  }
+}
+
+.x1ua5tub:not(#\#):not(#\#):not(#\#) {
+  -webkit-box-orient: vertical;
+}
+
+.x6s0dn4:not(#\#):not(#\#):not(#\#) {
+  align-items: center;
+}
+
+.xpqajaz:not(#\#):not(#\#):not(#\#) {
+  align-items: end;
+}
+
+.xuk3077:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-end;
+}
+
+.x1cy8zhl:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-start;
+}
+
+.x7a106z:not(#\#):not(#\#):not(#\#) {
+  align-items: start;
+}
+
+.x1qjc9v5:not(#\#):not(#\#):not(#\#) {
+  align-items: stretch;
+}
+
+.xamitd3:not(#\#):not(#\#):not(#\#) {
+  align-self: center;
+}
+
+.xpvyfi4:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-end;
+}
+
+.xqcrz7y:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-start;
+}
+
+.xkh2ocl:not(#\#):not(#\#):not(#\#) {
+  align-self: stretch;
+}
+
+.x9uej1z:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-fast-max);
+}
+
+.xqgcaz:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-medium-max);
+}
+
+.xskzprw:not(#\#):not(#\#):not(#\#) {
+  animation-fill-mode: backwards;
+}
+
+.xa4qsjk:not(#\#):not(#\#):not(#\#) {
+  animation-iteration-count: infinite;
+}
+
+.x3psbcj:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1ahk7ht-B;
+}
+
+.x1ka1v4i:not(#\#):not(#\#):not(#\#) {
+  animation-name: xqng64z-B;
+}
+
+.xck01x9:not(#\#):not(#\#):not(#\#) {
+  animation-name: xu7jd1z-B;
+}
+
+.xl1vlw0:not(#\#):not(#\#):not(#\#) {
+  animation-name: xv1hr86-B;
+}
+
+.x1i331go:not(#\#):not(#\#):not(#\#) {
+  animation-name: xwmkjkf-B;
+}
+
+.x1esw782:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: linear;
+}
+
+.x128ha8g:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: var(--ease-standard);
+}
+
+.xioom0i:not(#\#):not(#\#):not(#\#) {
+  aspect-ratio: var(--button-icon-only-aspect);
+}
+
+.xlp1x4z:not(#\#):not(#\#):not(#\#) {
+  backface-visibility: hidden;
+}
+
+.xgcd1z6:not(#\#):not(#\#):not(#\#) {
+  background-color: inherit;
+}
+
+.xjbqb8w:not(#\#):not(#\#):not(#\#) {
+  background-color: #0000;
+}
+
+.x1ewilqj:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-accent);
+}
+
+.x1eiddq6:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-body);
+}
+
+.x1de1mus:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-card);
+}
+
+.xwmxj5m:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.x1prclbq:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-popover);
+}
+
+.x10xzikg:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-surface);
+}
+
+.x7njt3n:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border-emphasized);
+}
+
+.x1m4xfpy:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border);
+}
+
+.x1pjz0fi:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error);
+}
+
+.x17x4s8c:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-neutral);
+}
+
+.x1lmrjuc:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-overlay-hover);
+}
+
+.x19aspcf:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-text-primary);
+}
+
+.x18o3ruo:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1gejf6u:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-border);
+}
+
+.x18b5jzi:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-style: solid;
+}
+
+.x1lun4ml:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-width: 1px;
+}
+
+.x1j92z86:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-color: var(--color-border);
+}
+
+.x1t7ytsu:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-style: solid;
+}
+
+.xpilrb4:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-width: 1px;
+}
+
+.x183tx6i:not(#\#):not(#\#):not(#\#) {
+  border-start-start-radius: var(--radius-page);
+}
+
+.x1i5ehqx:not(#\#):not(#\#):not(#\#) {
+  box-shadow: var(--shadow-low);
+}
+
+.x9f619:not(#\#):not(#\#):not(#\#) {
+  box-sizing: border-box;
+}
+
+.x1hyvwdk:not(#\#):not(#\#):not(#\#) {
+  clip-path: inset(50%);
+}
+
+.xzpqnlu:not(#\#):not(#\#):not(#\#) {
+  clip: rect(0,0,0,0);
+}
+
+.xntwwlm:not(#\#):not(#\#):not(#\#) {
+  color-scheme: dark;
+}
+
+.x108lcm5:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light dark;
+}
+
+.x19aimcq:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light;
+}
+
+.x1heor9g:not(#\#):not(#\#):not(#\#) {
+  color: inherit;
+}
+
+.x19co3pv:not(#\#):not(#\#):not(#\#) {
+  color: #0000;
+}
+
+.xqwr325:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-accent);
+}
+
+.xrkvqaz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-background-surface);
+}
+
+.xjt36v0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-error);
+}
+
+.x1fns2mt:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-blue);
+}
+
+.x157w0xa:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-cyan);
+}
+
+.xqa6c3m:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-disabled);
+}
+
+.x1eyinzz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-gray);
+}
+
+.xmxeech:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-green);
+}
+
+.xxu74a4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-orange);
+}
+
+.x1kxxfg5:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-pink);
+}
+
+.xtbr613:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-primary);
+}
+
+.xzdw94u:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-purple);
+}
+
+.xeffzf7:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-red);
+}
+
+.xv9yike:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-secondary);
+}
+
+.x1f3zxcb:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-teal);
+}
+
+.x1g6zdft:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-icon-yellow);
+}
+
+.x17wrial:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-accent);
+}
+
+.x1m024r3:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-error);
+}
+
+.xtjic6:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-success);
+}
+
+.xjse4m1:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-accent);
+}
+
+.xnbbluu:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-disabled);
+}
+
+.x1tgivj0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-primary);
+}
+
+.xv1l7n4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-secondary);
+}
+
+.xs3pv69:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-warning);
+}
+
+.x1kihgfc:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0-5);
+}
+
+.x1o57wo1:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0);
+}
+
+.x1thn6ci:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1-5);
+}
+
+.x1lfs0n9:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1);
+}
+
+.x1p37tyl:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-10);
+}
+
+.xak3so:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-2);
+}
+
+.xewh9hi:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-3);
+}
+
+.xty4p9g:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-4);
+}
+
+.x1eqhezk:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-5);
+}
+
+.x3qlgwd:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-6);
+}
+
+.xicv188:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-8);
+}
+
+.xicojor:not(#\#):not(#\#):not(#\#) {
+  cursor: col-resize;
+}
+
+.xt0e3qv:not(#\#):not(#\#):not(#\#) {
+  cursor: default;
+}
+
+.x1h6gzvc:not(#\#):not(#\#):not(#\#) {
+  cursor: not-allowed;
+}
+
+.x1ypdohk:not(#\#):not(#\#):not(#\#) {
+  cursor: pointer;
+}
+
+.x104kibb:not(#\#):not(#\#):not(#\#) {
+  display: -webkit-box;
+}
+
+.x1lliihq:not(#\#):not(#\#):not(#\#) {
+  display: block;
+}
+
+.xjp7ctv:not(#\#):not(#\#):not(#\#) {
+  display: contents;
+}
+
+.x78zum5:not(#\#):not(#\#):not(#\#) {
+  display: flex;
+}
+
+.xrvj5dj:not(#\#):not(#\#):not(#\#) {
+  display: grid;
+}
+
+.x1rg5ohu:not(#\#):not(#\#):not(#\#) {
+  display: inline-block;
+}
+
+.x3nfvp2:not(#\#):not(#\#):not(#\#) {
+  display: inline-flex;
+}
+
+.xt0psk2:not(#\#):not(#\#):not(#\#) {
+  display: inline;
+}
+
+.x1s85apg:not(#\#):not(#\#):not(#\#) {
+  display: none;
+}
+
+.xjpgo6f:not(#\#):not(#\#):not(#\#) {
+  flex-basis: 200px;
+}
+
+.xchdapg:not(#\#):not(#\#):not(#\#) {
+  flex-basis: 300px;
+}
+
+.x3ieub6:not(#\#):not(#\#):not(#\#) {
+  flex-direction: column-reverse;
+}
+
+.xdt5ytf:not(#\#):not(#\#):not(#\#) {
+  flex-direction: column;
+}
+
+.x1q0g3np:not(#\#):not(#\#):not(#\#) {
+  flex-direction: row;
+}
+
+.x1c4vz4f:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 0;
+}
+
+.x1iyjqo2:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 1;
+}
+
+.xgyuaek:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 2;
+}
+
+.x2lah0s:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 0;
+}
+
+.xs83m0k:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 1;
+}
+
+.xozqiw3:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: nowrap;
+}
+
+.x8hhl5t:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap-reverse;
+}
+
+.x1a02dak:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap;
+}
+
+.xjb2p0i:not(#\#):not(#\#):not(#\#) {
+  font-family: inherit;
+}
+
+.x9ynric:not(#\#):not(#\#):not(#\#) {
+  font-family: var(--font-family-body);
+}
+
+.xfifm61:not(#\#):not(#\#):not(#\#) {
+  font-size: 12px;
+}
+
+.x1j61zf2:not(#\#):not(#\#):not(#\#) {
+  font-size: 16px;
+}
+
+.xwsyq91:not(#\#):not(#\#):not(#\#) {
+  font-size: 20px;
+}
+
+.x1pvqxga:not(#\#):not(#\#):not(#\#) {
+  font-size: 24px;
+}
+
+.x1qlqyl8:not(#\#):not(#\#):not(#\#) {
+  font-size: inherit;
+}
+
+.xjm74w1:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-body-size);
+}
+
+.xcr08ib:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-label-size);
+}
+
+.x18juvz8:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-large-size);
+}
+
+.x141an7d:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-supporting-size);
+}
+
+.xss6m8b:not(#\#):not(#\#):not(#\#) {
+  font-variant-numeric: tabular-nums;
+}
+
+.x1pd3egz:not(#\#):not(#\#):not(#\#) {
+  font-weight: inherit;
+}
+
+.x1lvx875:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-bold);
+}
+
+.x1e4wzip:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-medium);
+}
+
+.x1sodnla:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-normal);
+}
+
+.x2mo6ok:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-semibold);
+}
+
+.xxovm9e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-body-weight);
+}
+
+.xx3eeay:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-code-weight);
+}
+
+.x1txul5o:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-1-weight);
+}
+
+.x1y36c3f:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-2-weight);
+}
+
+.x1on40hk:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-3-weight);
+}
+
+.xmhvcl5:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-label-weight);
+}
+
+.x149oux8:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-large-weight);
+}
+
+.xv8on6e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-supporting-weight);
+}
+
+.x134kloy:not(#\#):not(#\#):not(#\#) {
+  grid-template-columns: 1fr auto 1fr;
+}
+
+.xihq33y:not(#\#):not(#\#):not(#\#) {
+  grid-template-rows: 0fr;
+}
+
+.x1tu4anv:not(#\#):not(#\#):not(#\#) {
+  grid-template-rows: 1fr;
+}
+
+.xtijo5x:not(#\#):not(#\#):not(#\#) {
+  inset-inline-end: 0;
+}
+
+.x1o0tod:not(#\#):not(#\#):not(#\#) {
+  inset-inline-start: 0;
+}
+
+.xc8icb0:not(#\#):not(#\#):not(#\#) {
+  isolation: isolate;
+}
+
+.xl56j7k:not(#\#):not(#\#):not(#\#) {
+  justify-content: center;
+}
+
+.x13a6bvl:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-end;
+}
+
+.x1nhvcw1:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-start;
+}
+
+.x1l1ennw:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-around;
+}
+
+.x1qughib:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-between;
+}
+
+.xaw8158:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-evenly;
+}
+
+.x1o2pa38:not(#\#):not(#\#):not(#\#) {
+  justify-items: center;
+}
+
+.x4xo5sw:not(#\#):not(#\#):not(#\#) {
+  justify-items: end;
+}
+
+.x619ttb:not(#\#):not(#\#):not(#\#) {
+  justify-items: start;
+}
+
+.xl4xnwh:not(#\#):not(#\#):not(#\#) {
+  justify-items: stretch;
+}
+
+.x15bjb6t:not(#\#):not(#\#):not(#\#) {
+  line-height: inherit;
+}
+
+.xw6l6zx:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-body-leading);
+}
+
+.x1kq96og:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-label-leading);
+}
+
+.xf74fhv:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-large-leading);
+}
+
+.x1ltkj2j:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-supporting-leading);
+}
+
+.x14z9mp:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: 0;
+}
+
+.x1kpg4um:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(-1 * var(--layout-padding-inner-x, var(--spacing-4)));
+}
+
+.xofqkxr:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(var(--edge-end, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.xnur1sd:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: var(--spacing-1);
+}
+
+.x1lziwak:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: 0;
+}
+
+.xvc5jky:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: auto;
+}
+
+.x1wim8z0:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(-1 * var(--layout-padding-inner-x, var(--spacing-4)));
+}
+
+.xg82z56:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(var(--edge-start, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.x11g1kdw:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: var(--spacing-1);
+}
+
+.x1l10yog:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: var(--spacing-6);
+}
+
+.xl1xv1r:not(#\#):not(#\#):not(#\#) {
+  object-fit: cover;
+}
+
+.xbyyjgo:not(#\#):not(#\#):not(#\#) {
+  opacity: .5;
+}
+
+.xg01cxk:not(#\#):not(#\#):not(#\#) {
+  opacity: 0;
+}
+
+.x1wfwxd8:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 0;
+}
+
+.x1mzt3pk:not(#\#):not(#\#):not(#\#) {
+  overflow-wrap: break-word;
+}
+
+.xyri2b:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: 0;
+}
+
+.x1peupej:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--layout-padding-inner-x, var(--spacing-4));
+}
+
+.xpc6k2p:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--layout-padding-outer-x, var(--spacing-4));
+}
+
+.x1le3yxw:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-0-5);
+}
+
+.x1s0aq8i:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-0);
+}
+
+.x17hk9do:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-1-5);
+}
+
+.x1nryj5t:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-1);
+}
+
+.x160ivqr:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-10);
+}
+
+.x1djylfy:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-2);
+}
+
+.x1t818jl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-3);
+}
+
+.xnjyzlh:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-4);
+}
+
+.xdbrk9v:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-5);
+}
+
+.x1we12cn:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-6);
+}
+
+.x1q91b2g:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-8);
+}
+
+.x1c1uobl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: 0;
+}
+
+.xwjyata:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--layout-padding-inner-x, var(--spacing-4));
+}
+
+.x139j0dd:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--layout-padding-outer-x, var(--spacing-4));
+}
+
+.x138rykx:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-0-5);
+}
+
+.x18gyask:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-0);
+}
+
+.xfti1ec:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-1-5);
+}
+
+.x1vsv5vr:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-1);
+}
+
+.xqp078j:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-10);
+}
+
+.x12gdq22:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-2);
+}
+
+.x126nfab:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-3);
+}
+
+.x1rey3nv:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-4);
+}
+
+.x1blguxw:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-5);
+}
+
+.x31w388:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-6);
+}
+
+.x1j3hnjz:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-8);
+}
+
+.x47corl:not(#\#):not(#\#):not(#\#) {
+  pointer-events: none;
+}
+
+.x10l6tqk:not(#\#):not(#\#):not(#\#) {
+  position: absolute;
+}
+
+.xixxii4:not(#\#):not(#\#):not(#\#) {
+  position: fixed;
+}
+
+.x1n2onr6:not(#\#):not(#\#):not(#\#) {
+  position: relative;
+}
+
+.x7wzq59:not(#\#):not(#\#):not(#\#) {
+  position: sticky;
+}
+
+.x1tw44j4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0-5);
+}
+
+.x6yxi7o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0);
+}
+
+.xhq53yo:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1-5);
+}
+
+.x1ngg2t4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1);
+}
+
+.x1xpicb7:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-10);
+}
+
+.x1x7z4sm:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-2);
+}
+
+.x4olc9o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-3);
+}
+
+.xtx9w7w:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-4);
+}
+
+.x1iu6piu:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-5);
+}
+
+.xczp1bk:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-6);
+}
+
+.xgx0vcf:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-8);
+}
+
+.x1yc453h:not(#\#):not(#\#):not(#\#) {
+  text-align: start;
+}
+
+.x1b2iylo:not(#\#):not(#\#):not(#\#) {
+  text-box-edge: cap alphabetic;
+}
+
+.xwgcxoh:not(#\#):not(#\#):not(#\#) {
+  text-box-trim: trim-both;
+}
+
+.xycaml9:not(#\#):not(#\#):not(#\#) {
+  -webkit-text-decoration-color: var(--color-border-emphasized);
+  text-decoration-color: var(--color-border-emphasized);
+}
+
+.xujl8zx:not(#\#):not(#\#):not(#\#) {
+  text-decoration-line: underline;
+}
+
+.xev0dqp:not(#\#):not(#\#):not(#\#) {
+  text-decoration-style: dashed;
+}
+
+.xlyipyv:not(#\#):not(#\#):not(#\#) {
+  text-overflow: ellipsis;
+}
+
+.xrys4gj:not(#\#):not(#\#):not(#\#) {
+  text-underline-offset: 2px;
+}
+
+.x1w2vvpw:not(#\#):not(#\#):not(#\#) {
+  text-wrap: balance;
+}
+
+.xebhuq6:not(#\#):not(#\#):not(#\#) {
+  text-wrap: nowrap;
+}
+
+.x1fzhlzt:not(#\#):not(#\#):not(#\#) {
+  text-wrap: pretty;
+}
+
+.xk4td0m:not(#\#):not(#\#):not(#\#) {
+  text-wrap: wrap;
+}
+
+.x5ve5x3:not(#\#):not(#\#):not(#\#) {
+  touch-action: none;
+}
+
+.xx69xxh:not(#\#):not(#\#):not(#\#) {
+  touch-action: pan-y;
+}
+
+.x1c071of:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.x19jd1h0:not(#\#):not(#\#):not(#\#) {
+  transform: rotate(180deg);
+}
+
+.x3oybdh:not(#\#):not(#\#):not(#\#) {
+  transform: scale(1);
+}
+
+.x31h1t8:not(#\#):not(#\#):not(#\#) {
+  transform: translate(-50%, 100%);
+}
+
+.x5i6ehr:not(#\#):not(#\#):not(#\#) {
+  transform: translateX(-100%);
+}
+
+.xbryuvx:not(#\#):not(#\#):not(#\#) {
+  transform: translateX(0);
+}
+
+.xumwmo6:not(#\#):not(#\#):not(#\#) {
+  transform: translateX(100%);
+}
+
+.x1bvilyr:not(#\#):not(#\#):not(#\#) {
+  transform: translateY(-4px);
+}
+
+.xd00j3c:not(#\#):not(#\#):not(#\#) {
+  transition-behavior: allow-discrete;
+}
+
+.xuedmi6:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-fast);
+}
+
+.xgneliz:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-medium-min);
+}
+
+.x80gvsz:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-medium);
+}
+
+.xs2xxs2:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color, color;
+}
+
+.x15406qy:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-color;
+}
+
+.xqc8rvf:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-image, transform;
+}
+
+.x1mpt4pi:not(#\#):not(#\#):not(#\#) {
+  transition-property: color, -webkit-text-decoration, text-decoration;
+}
+
+.x1qn9uv2:not(#\#):not(#\#):not(#\#) {
+  transition-property: grid-template-rows;
+}
+
+.x4bbghf:not(#\#):not(#\#):not(#\#) {
+  transition-property: opacity, transform, overlay, display;
+}
+
+.x11xpdln:not(#\#):not(#\#):not(#\#) {
+  transition-property: transform;
+}
+
+.xlr8y92:not(#\#):not(#\#):not(#\#) {
+  transition-timing-function: var(--ease-standard);
+}
+
+.x87ps6o:not(#\#):not(#\#):not(#\#) {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.xxymvpz:not(#\#):not(#\#):not(#\#) {
+  vertical-align: middle;
+}
+
+.xuxw1ft:not(#\#):not(#\#):not(#\#) {
+  white-space: nowrap;
+}
+
+.x1yn0g08:not(#\#):not(#\#):not(#\#) {
+  word-break: break-all;
+}
+
+.x13faqbe:not(#\#):not(#\#):not(#\#) {
+  word-break: break-word;
+}
+
+.x1lldw8n:not(#\#):not(#\#):not(#\#) {
+  word-break: normal;
+}
+
+.x1vjfegm:not(#\#):not(#\#):not(#\#) {
+  z-index: 1;
+}
+
+.xhtitgo:not(#\#):not(#\#):not(#\#) {
+  z-index: 2;
+}
+
+.x1q2oy4v:not(#\#):not(#\#):not(#\#) {
+  z-index: 9999;
+}
+
+.x10wafsz:focus-within:not(#\#):not(#\#):not(#\#) {
+  clip-path: none;
+}
+
+.xf1xu1x.xf1xu1x:where([open]):not(#\#):not(#\#):not(#\#) {
+  display: flex;
+}
+
+.xofkqq2:popover-open:not(#\#):not(#\#):not(#\#) {
+  opacity: 1;
+}
+
+.x7s97pk:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 2px;
+}
+
+.x13aywxo:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: var(--button-focus-offset);
+}
+
+.xbt4iw:focus-within:not(#\#):not(#\#):not(#\#) {
+  pointer-events: auto;
+}
+
+.x1df3fe5:is([dir="rtl"] *):not(#\#):not(#\#):not(#\#) {
+  transform: translateX(-100%);
+}
+
+.xttggg:is([dir="rtl"] *):not(#\#):not(#\#):not(#\#) {
+  transform: translateX(100%);
+}
+
+.x9cjr8z:popover-open:not(#\#):not(#\#):not(#\#) {
+  transform: translateY(0);
+}
+
+.x1rsz1da:focus:not(#\#):not(#\#):not(#\#) {
+  clip-path: none;
+}
+
+.xodanix:focus:not(#\#):not(#\#):not(#\#) {
+  inset-inline-start: var(--spacing-2);
+}
+
+.x1xrnuwo:focus:not(#\#):not(#\#):not(#\#) {
+  position: fixed;
+}
+
+.x1hbpcn8:focus:not(#\#):not(#\#):not(#\#) {
+  white-space: normal;
+}
+
+.xjtnuge:active:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-neutral);
+}
+
+.xyxi2l3:active:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-overlay-pressed);
+}
+
+.xq8i9tn:active:not(#\#):not(#\#):not(#\#) {
+  background-image: linear-gradient(var(--color-overlay-pressed),var(--color-overlay-pressed));
+}
+
+.xuqm82a:active:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1pdlv7q:active:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.xk4oym4:active:not(#\#):not(#\#):not(#\#) {
+  transform: scale(.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .xzg1mie.xzg1mie:not(#\#):not(#\#):not(#\#) {
+    transition-duration: 10ms;
+  }
+
+  .x12w9bfk.x12w9bfk:not(#\#):not(#\#):not(#\#) {
+    transition-duration: 0s;
+  }
+}
+
+@media (hover: hover) {
+  .x1sua13m.x1sua13m:hover:not(#\#):not(#\#):not(#\#) {
+    background-color: var(--color-neutral);
+  }
+
+  .xe9uy6x.xe9uy6x:hover:not(#\#):not(#\#):not(#\#) {
+    background-color: var(--color-overlay-hover);
+  }
+
+  .x1ilzqfv.x1ilzqfv:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: linear-gradient(var(--color-overlay-hover),var(--color-overlay-hover));
+  }
+
+  .x8o3jvd.x8o3jvd:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: none;
+  }
+}
+
+.xw8gpjh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-color: var(--color-border);
+}
+
+.x1q0q8m5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-style: solid;
+}
+
+.xso031l:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-width: 1px;
+}
+
+.x1pc3f07:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-color: var(--color-border);
+}
+
+.x13fuv20:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-style: solid;
+}
+
+.x178xt8z:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-width: 1px;
+}
+
+.x1ey2m1c:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: 0;
+}
+
+.x5yr21d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 100%;
+}
+
+.xtdtrs8:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 100dvh;
+}
+
+.x1kpxq89:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 12px;
+}
+
+.xhjk10j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 140px;
+}
+
+.xlup9mm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 16px;
+}
+
+.xjm9jq1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 1px;
+}
+
+.x1qx5ct2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 20px;
+}
+
+.xxk0z11:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 24px;
+}
+
+.x10w6t97:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 32px;
+}
+
+.x1vqgdyp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 40px;
+}
+
+.xsdox4t:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 48px;
+}
+
+.x1x2thlr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(100% + 2 * var(--container-padding, 0px));
+}
+
+.x16zugyo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(100dvh - var(--appshell-header-height, 0px));
+}
+
+.xsyqizj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--border-width);
+}
+
+.xssyfek:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-lg);
+}
+
+.x1ueg155:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-md);
+}
+
+.x6k0iem:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-sm);
+}
+
+.x1k15mir:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-12);
+}
+
+.x18to7ep:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-8);
+}
+
+.x16ye13r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--x-height);
+}
+
+.xu96u03:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 0;
+}
+
+.x1nrll8i:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 50%;
+}
+
+.xat24cr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: 0;
+}
+
+.x14cgwvg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-1);
+}
+
+.xdj266r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: 0;
+}
+
+.xr1yuqi:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: auto;
+}
+
+.xjc2qm6:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-0-5);
+}
+
+.xcsaf9d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-1);
+}
+
+.xtbrsbv:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-2);
+}
+
+.x7ab17h:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: none;
+}
+
+.xenllk4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: var(--container-max-height, none);
+}
+
+.xw5ewwj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 300px;
+}
+
+.xyzno7u:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 960px;
+}
+
+.x1x1rfll:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: none;
+}
+
+.xf68679:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: var(--x-maxWidth);
+}
+
+.x2lwn1j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 0;
+}
+
+.x1us19tq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 100%;
+}
+
+.x1ov3xa9:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 100dvh;
+}
+
+.ximsjs8:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--spacing-7);
+}
+
+.x82snj4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--x-minHeight);
+}
+
+.xeuugli:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 0;
+}
+
+.xfb3i0g:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 180px;
+}
+
+.x1u2d2a2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 280px;
+}
+
+.xrzjruh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: anchor-size(width);
+}
+
+.xy8csz5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: var(--spacing-7);
+}
+
+.x6ikm8r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  overflow-x: hidden;
+}
+
+.x1odjw0f:not(#\#):not(#\#):not(#\#):not(#\#) {
+  overflow-y: auto;
+}
+
+.x18d9i69:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.xg476vw:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--layout-padding-inner-y, var(--spacing-4));
+}
+
+.xon7vh3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--layout-padding-outer-y, var(--spacing-4));
+}
+
+.xij103a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-0-5);
+}
+
+.x1l20ajd:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-0);
+}
+
+.x1opdxmq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1-5);
+}
+
+.xy143xn:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1);
+}
+
+.x2izi54:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-10);
+}
+
+.x1wesfrj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-2);
+}
+
+.xvmdzux:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-3);
+}
+
+.x1awphl8:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-4);
+}
+
+.x1hk98q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-5);
+}
+
+.xjpqqx5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-6);
+}
+
+.x2oz4g1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-8);
+}
+
+.xexx8yu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.xqty4a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--layout-padding-inner-y, var(--spacing-4));
+}
+
+.x81pis9:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--layout-padding-outer-y, var(--spacing-4));
+}
+
+.xbx876j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-0-5);
+}
+
+.x1ydh6w3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-0);
+}
+
+.x1kwdpsa:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1-5);
+}
+
+.xfsso4q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.xk6660b:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-10);
+}
+
+.x1xye8es:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-2);
+}
+
+.x1vlblms:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-3);
+}
+
+.x1oa1p4a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-4);
+}
+
+.xx7rijo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-5);
+}
+
+.x1adxfkp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-6);
+}
+
+.xoxd1wu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-8);
+}
+
+.x3m8u43:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: 0;
+}
+
+.x13vifvy:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 0;
+}
+
+.xepuwc7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: var(--appshell-header-height, 0px);
+}
+
+.xh8yej3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 100%;
+}
+
+.xn9wirt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 100vw;
+}
+
+.xsmyaan:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 12px;
+}
+
+.x1kky2od:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 16px;
+}
+
+.x1i1rx1s:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 1px;
+}
+
+.xw4jnvo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 20px;
+}
+
+.xvy4d1p:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 24px;
+}
+
+.x1hfn5x7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 260px;
+}
+
+.x1td3qas:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 32px;
+}
+
+.x100vrsf:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 40px;
+}
+
+.xvni27:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 52px;
+}
+
+.x1v4s8kt:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 6px;
+}
+
+.xjk4fl7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--border-width);
+}
+
+.xgc8j7m:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--spacing-8);
+}
+
+.x5lhr3w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--x-width);
+}
+
+.x132qfvm:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: auto;
+}
+
+.x1o6z09h.x1o6z09h:where(.x-default-marker:has( > .xds-layout-footer:not([data-divider])) *):not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.x1c51l3k.x1c51l3k:where(.x-default-marker:has( > .xds-layout-header:not([data-divider])) *):not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.x1kw28su:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.x10okhzq:focus-within:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: auto;
+}
+
+.x8achem:first-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1a5yysu:last-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: calc(-1 * var(--container-padding, 0px));
+}
+
+.x15cytp8:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: auto;
+}
+
+.x1rw3289:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: var(--spacing-2);
+}
+
+.x1jqxupm:focus:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: auto;
+}
+
+@starting-style {
+  .x4itv7f.x4itv7f:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+    opacity: 0;
+  }
+}
+
+@starting-style {
+  .x12p7p72.x12p7p72:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#) {
+    transform: translateY(-4px);
+  }
+}
+
+.x1abwkk1:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  -webkit-backdrop-filter: blur(2px);
+  backdrop-filter: blur(2px);
+}
+
+.xnixb3f:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  background-color: var(--color-overlay);
+}
+
+.xph5o2a:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  opacity: 0;
+}
+
+.xb3n6bw:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  opacity: 1;
+}
+
+.xft5bk6:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  transition-duration: var(--duration-medium);
+}
+
+.x167zut7:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  transition-property: opacity;
+}
+
+.x15h3t91:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+  transition-timing-function: var(--ease-standard);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .x1viac0w.x1viac0w:not(#\#):not(#\#):not(#\#):not(#\#):not(#\#):not(#\#)::backdrop {
+    transition-duration: 10ms;
+  }
+}
+</style>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/internal/vibe-tests/results/441ddbe0/previews/ps-4/xds.html
+++ b/internal/vibe-tests/results/441ddbe0/previews/ps-4/xds.html
@@ -1,0 +1,2524 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>ps-4 — xds</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; font-family: system-ui, -apple-system, sans-serif; }
+    #root { min-height: 100%; }
+  </style>
+  <script type="module" crossorigin>(function(){const l=document.createElement("link").relList;if(l&&l.supports&&l.supports("modulepreload"))return;for(const n of document.querySelectorAll('link[rel="modulepreload"]'))a(n);new MutationObserver(n=>{for(const u of n)if(u.type==="childList")for(const i of u.addedNodes)i.tagName==="LINK"&&i.rel==="modulepreload"&&a(i)}).observe(document,{childList:!0,subtree:!0});function e(n){const u={};return n.integrity&&(u.integrity=n.integrity),n.referrerPolicy&&(u.referrerPolicy=n.referrerPolicy),n.crossOrigin==="use-credentials"?u.credentials="include":n.crossOrigin==="anonymous"?u.credentials="omit":u.credentials="same-origin",u}function a(n){if(n.ep)return;n.ep=!0;const u=e(n);fetch(n.href,u)}})();function v0(t){return t&&t.__esModule&&Object.prototype.hasOwnProperty.call(t,"default")?t.default:t}var Qo={exports:{}},Zu={};/**
+ * @license React
+ * react-jsx-runtime.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var h0=Symbol.for("react.transitional.element"),x0=Symbol.for("react.fragment");function Vo(t,l,e){var a=null;if(e!==void 0&&(a=""+e),l.key!==void 0&&(a=""+l.key),"key"in l){e={};for(var n in l)n!=="key"&&(e[n]=l[n])}else e=l;return l=e.ref,{$$typeof:h0,type:t,key:a,ref:l!==void 0?l:null,props:e}}Zu.Fragment=x0;Zu.jsx=Vo;Zu.jsxs=Vo;Qo.exports=Zu;var b=Qo.exports,Ko={exports:{}},Gu={},Jo={exports:{}},Wo={};/**
+ * @license React
+ * scheduler.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */(function(t){function l(O,q){var C=O.length;O.push(q);t:for(;0<C;){var lt=C-1>>>1,ut=O[lt];if(0<n(ut,q))O[lt]=q,O[C]=ut,C=lt;else break t}}function e(O){return O.length===0?null:O[0]}function a(O){if(O.length===0)return null;var q=O[0],C=O.pop();if(C!==q){O[0]=C;t:for(var lt=0,ut=O.length,se=ut>>>1;lt<se;){var oe=2*(lt+1)-1,Nl=O[oe],xt=oe+1,ul=O[xt];if(0>n(Nl,C))xt<ut&&0>n(ul,Nl)?(O[lt]=ul,O[xt]=C,lt=xt):(O[lt]=Nl,O[oe]=C,lt=oe);else if(xt<ut&&0>n(ul,C))O[lt]=ul,O[xt]=C,lt=xt;else break t}}return q}function n(O,q){var C=O.sortIndex-q.sortIndex;return C!==0?C:O.id-q.id}if(t.unstable_now=void 0,typeof performance=="object"&&typeof performance.now=="function"){var u=performance;t.unstable_now=function(){return u.now()}}else{var i=Date,c=i.now();t.unstable_now=function(){return i.now()-c}}var f=[],o=[],y=1,v=null,d=3,g=!1,x=!1,S=!1,E=!1,r=typeof setTimeout=="function"?setTimeout:null,s=typeof clearTimeout=="function"?clearTimeout:null,m=typeof setImmediate<"u"?setImmediate:null;function h(O){for(var q=e(o);q!==null;){if(q.callback===null)a(o);else if(q.startTime<=O)a(o),q.sortIndex=q.expirationTime,l(f,q);else break;q=e(o)}}function $(O){if(S=!1,h(O),!x)if(e(f)!==null)x=!0,A||(A=!0,et());else{var q=e(o);q!==null&&Ne($,q.startTime-O)}}var A=!1,T=-1,M=5,j=-1;function k(){return E?!0:!(t.unstable_now()-j<M)}function P(){if(E=!1,A){var O=t.unstable_now();j=O;var q=!0;try{t:{x=!1,S&&(S=!1,s(T),T=-1),g=!0;var C=d;try{l:{for(h(O),v=e(f);v!==null&&!(v.expirationTime>O&&k());){var lt=v.callback;if(typeof lt=="function"){v.callback=null,d=v.priorityLevel;var ut=lt(v.expirationTime<=O);if(O=t.unstable_now(),typeof ut=="function"){v.callback=ut,h(O),q=!0;break l}v===e(f)&&a(f),h(O)}else a(f);v=e(f)}if(v!==null)q=!0;else{var se=e(o);se!==null&&Ne($,se.startTime-O),q=!1}}break t}finally{v=null,d=C,g=!1}q=void 0}}finally{q?et():A=!1}}}var et;if(typeof m=="function")et=function(){m(P)};else if(typeof MessageChannel<"u"){var yl=new MessageChannel,Dn=yl.port2;yl.port1.onmessage=P,et=function(){Dn.postMessage(null)}}else et=function(){r(P,0)};function Ne(O,q){T=r(function(){O(t.unstable_now())},q)}t.unstable_IdlePriority=5,t.unstable_ImmediatePriority=1,t.unstable_LowPriority=4,t.unstable_NormalPriority=3,t.unstable_Profiling=null,t.unstable_UserBlockingPriority=2,t.unstable_cancelCallback=function(O){O.callback=null},t.unstable_forceFrameRate=function(O){0>O||125<O?console.error("forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"):M=0<O?Math.floor(1e3/O):5},t.unstable_getCurrentPriorityLevel=function(){return d},t.unstable_next=function(O){switch(d){case 1:case 2:case 3:var q=3;break;default:q=d}var C=d;d=q;try{return O()}finally{d=C}},t.unstable_requestPaint=function(){E=!0},t.unstable_runWithPriority=function(O,q){switch(O){case 1:case 2:case 3:case 4:case 5:break;default:O=3}var C=d;d=O;try{return q()}finally{d=C}},t.unstable_scheduleCallback=function(O,q,C){var lt=t.unstable_now();switch(typeof C=="object"&&C!==null?(C=C.delay,C=typeof C=="number"&&0<C?lt+C:lt):C=lt,O){case 1:var ut=-1;break;case 2:ut=250;break;case 5:ut=1073741823;break;case 4:ut=1e4;break;default:ut=5e3}return ut=C+ut,O={id:y++,callback:q,priorityLevel:O,startTime:C,expirationTime:ut,sortIndex:-1},C>lt?(O.sortIndex=C,l(o,O),e(f)===null&&O===e(o)&&(S?(s(T),T=-1):S=!0,Ne($,C-lt))):(O.sortIndex=ut,l(f,O),x||g||(x=!0,A||(A=!0,et()))),O},t.unstable_shouldYield=k,t.unstable_wrapCallback=function(O){var q=d;return function(){var C=d;d=q;try{return O.apply(this,arguments)}finally{d=C}}}})(Wo);Jo.exports=Wo;var p0=Jo.exports,Fo={exports:{}},_={};/**
+ * @license React
+ * react.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var Wc=Symbol.for("react.transitional.element"),b0=Symbol.for("react.portal"),S0=Symbol.for("react.fragment"),z0=Symbol.for("react.strict_mode"),E0=Symbol.for("react.profiler"),T0=Symbol.for("react.consumer"),$0=Symbol.for("react.context"),j0=Symbol.for("react.forward_ref"),A0=Symbol.for("react.suspense"),k0=Symbol.for("react.memo"),Io=Symbol.for("react.lazy"),M0=Symbol.for("react.activity"),es=Symbol.iterator;function O0(t){return t===null||typeof t!="object"?null:(t=es&&t[es]||t["@@iterator"],typeof t=="function"?t:null)}var Po={isMounted:function(){return!1},enqueueForceUpdate:function(){},enqueueReplaceState:function(){},enqueueSetState:function(){}},tr=Object.assign,lr={};function pa(t,l,e){this.props=t,this.context=l,this.refs=lr,this.updater=e||Po}pa.prototype.isReactComponent={};pa.prototype.setState=function(t,l){if(typeof t!="object"&&typeof t!="function"&&t!=null)throw Error("takes an object of state variables to update or a function which returns an object of state variables.");this.updater.enqueueSetState(this,t,l,"setState")};pa.prototype.forceUpdate=function(t){this.updater.enqueueForceUpdate(this,t,"forceUpdate")};function er(){}er.prototype=pa.prototype;function Fc(t,l,e){this.props=t,this.context=l,this.refs=lr,this.updater=e||Po}var Ic=Fc.prototype=new er;Ic.constructor=Fc;tr(Ic,pa.prototype);Ic.isPureReactComponent=!0;var as=Array.isArray;function Pi(){}var F={H:null,A:null,T:null,S:null},ar=Object.prototype.hasOwnProperty;function Pc(t,l,e){var a=e.ref;return{$$typeof:Wc,type:t,key:l,ref:a!==void 0?a:null,props:e}}function D0(t,l){return Pc(t.type,l,t.props)}function tf(t){return typeof t=="object"&&t!==null&&t.$$typeof===Wc}function _0(t){var l={"=":"=0",":":"=2"};return"$"+t.replace(/[=:]/g,function(e){return l[e]})}var ns=/\/+/g;function fi(t,l){return typeof t=="object"&&t!==null&&t.key!=null?_0(""+t.key):l.toString(36)}function N0(t){switch(t.status){case"fulfilled":return t.value;case"rejected":throw t.reason;default:switch(typeof t.status=="string"?t.then(Pi,Pi):(t.status="pending",t.then(function(l){t.status==="pending"&&(t.status="fulfilled",t.value=l)},function(l){t.status==="pending"&&(t.status="rejected",t.reason=l)})),t.status){case"fulfilled":return t.value;case"rejected":throw t.reason}}throw t}function Be(t,l,e,a,n){var u=typeof t;(u==="undefined"||u==="boolean")&&(t=null);var i=!1;if(t===null)i=!0;else switch(u){case"bigint":case"string":case"number":i=!0;break;case"object":switch(t.$$typeof){case Wc:case b0:i=!0;break;case Io:return i=t._init,Be(i(t._payload),l,e,a,n)}}if(i)return n=n(t),i=a===""?"."+fi(t,0):a,as(n)?(e="",i!=null&&(e=i.replace(ns,"$&/")+"/"),Be(n,l,e,"",function(o){return o})):n!=null&&(tf(n)&&(n=D0(n,e+(n.key==null||t&&t.key===n.key?"":(""+n.key).replace(ns,"$&/")+"/")+i)),l.push(n)),1;i=0;var c=a===""?".":a+":";if(as(t))for(var f=0;f<t.length;f++)a=t[f],u=c+fi(a,f),i+=Be(a,l,e,u,n);else if(f=O0(t),typeof f=="function")for(t=f.call(t),f=0;!(a=t.next()).done;)a=a.value,u=c+fi(a,f++),i+=Be(a,l,e,u,n);else if(u==="object"){if(typeof t.then=="function")return Be(N0(t),l,e,a,n);throw l=String(t),Error("Objects are not valid as a React child (found: "+(l==="[object Object]"?"object with keys {"+Object.keys(t).join(", ")+"}":l)+"). If you meant to render a collection of children, use an array instead.")}return i}function _n(t,l,e){if(t==null)return t;var a=[],n=0;return Be(t,a,"","",function(u){return l.call(e,u,n++)}),a}function C0(t){if(t._status===-1){var l=t._result;l=l(),l.then(function(e){(t._status===0||t._status===-1)&&(t._status=1,t._result=e)},function(e){(t._status===0||t._status===-1)&&(t._status=2,t._result=e)}),t._status===-1&&(t._status=0,t._result=l)}if(t._status===1)return t._result.default;throw t._result}var us=typeof reportError=="function"?reportError:function(t){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var l=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof t=="object"&&t!==null&&typeof t.message=="string"?String(t.message):String(t),error:t});if(!window.dispatchEvent(l))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",t);return}console.error(t)},q0={map:_n,forEach:function(t,l,e){_n(t,function(){l.apply(this,arguments)},e)},count:function(t){var l=0;return _n(t,function(){l++}),l},toArray:function(t){return _n(t,function(l){return l})||[]},only:function(t){if(!tf(t))throw Error("React.Children.only expected to receive a single React element child.");return t}};_.Activity=M0;_.Children=q0;_.Component=pa;_.Fragment=S0;_.Profiler=E0;_.PureComponent=Fc;_.StrictMode=z0;_.Suspense=A0;_.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=F;_.__COMPILER_RUNTIME={__proto__:null,c:function(t){return F.H.useMemoCache(t)}};_.cache=function(t){return function(){return t.apply(null,arguments)}};_.cacheSignal=function(){return null};_.cloneElement=function(t,l,e){if(t==null)throw Error("The argument must be a React element, but you passed "+t+".");var a=tr({},t.props),n=t.key;if(l!=null)for(u in l.key!==void 0&&(n=""+l.key),l)!ar.call(l,u)||u==="key"||u==="__self"||u==="__source"||u==="ref"&&l.ref===void 0||(a[u]=l[u]);var u=arguments.length-2;if(u===1)a.children=e;else if(1<u){for(var i=Array(u),c=0;c<u;c++)i[c]=arguments[c+2];a.children=i}return Pc(t.type,n,a)};_.createContext=function(t){return t={$$typeof:$0,_currentValue:t,_currentValue2:t,_threadCount:0,Provider:null,Consumer:null},t.Provider=t,t.Consumer={$$typeof:T0,_context:t},t};_.createElement=function(t,l,e){var a,n={},u=null;if(l!=null)for(a in l.key!==void 0&&(u=""+l.key),l)ar.call(l,a)&&a!=="key"&&a!=="__self"&&a!=="__source"&&(n[a]=l[a]);var i=arguments.length-2;if(i===1)n.children=e;else if(1<i){for(var c=Array(i),f=0;f<i;f++)c[f]=arguments[f+2];n.children=c}if(t&&t.defaultProps)for(a in i=t.defaultProps,i)n[a]===void 0&&(n[a]=i[a]);return Pc(t,u,n)};_.createRef=function(){return{current:null}};_.forwardRef=function(t){return{$$typeof:j0,render:t}};_.isValidElement=tf;_.lazy=function(t){return{$$typeof:Io,_payload:{_status:-1,_result:t},_init:C0}};_.memo=function(t,l){return{$$typeof:k0,type:t,compare:l===void 0?null:l}};_.startTransition=function(t){var l=F.T,e={};F.T=e;try{var a=t(),n=F.S;n!==null&&n(e,a),typeof a=="object"&&a!==null&&typeof a.then=="function"&&a.then(Pi,us)}catch(u){us(u)}finally{l!==null&&e.types!==null&&(l.types=e.types),F.T=l}};_.unstable_useCacheRefresh=function(){return F.H.useCacheRefresh()};_.use=function(t){return F.H.use(t)};_.useActionState=function(t,l,e){return F.H.useActionState(t,l,e)};_.useCallback=function(t,l){return F.H.useCallback(t,l)};_.useContext=function(t){return F.H.useContext(t)};_.useDebugValue=function(){};_.useDeferredValue=function(t,l){return F.H.useDeferredValue(t,l)};_.useEffect=function(t,l){return F.H.useEffect(t,l)};_.useEffectEvent=function(t){return F.H.useEffectEvent(t)};_.useId=function(){return F.H.useId()};_.useImperativeHandle=function(t,l,e){return F.H.useImperativeHandle(t,l,e)};_.useInsertionEffect=function(t,l){return F.H.useInsertionEffect(t,l)};_.useLayoutEffect=function(t,l){return F.H.useLayoutEffect(t,l)};_.useMemo=function(t,l){return F.H.useMemo(t,l)};_.useOptimistic=function(t,l){return F.H.useOptimistic(t,l)};_.useReducer=function(t,l,e){return F.H.useReducer(t,l,e)};_.useRef=function(t){return F.H.useRef(t)};_.useState=function(t){return F.H.useState(t)};_.useSyncExternalStore=function(t,l,e){return F.H.useSyncExternalStore(t,l,e)};_.useTransition=function(){return F.H.useTransition()};_.version="19.2.4";Fo.exports=_;var p=Fo.exports;const is=v0(p);var nr={exports:{}},kt={};/**
+ * @license React
+ * react-dom.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var w0=p;function ur(t){var l="https://react.dev/errors/"+t;if(1<arguments.length){l+="?args[]="+encodeURIComponent(arguments[1]);for(var e=2;e<arguments.length;e++)l+="&args[]="+encodeURIComponent(arguments[e])}return"Minified React error #"+t+"; visit "+l+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function Cl(){}var jt={d:{f:Cl,r:function(){throw Error(ur(522))},D:Cl,C:Cl,L:Cl,m:Cl,X:Cl,S:Cl,M:Cl},p:0,findDOMNode:null},R0=Symbol.for("react.portal");function U0(t,l,e){var a=3<arguments.length&&arguments[3]!==void 0?arguments[3]:null;return{$$typeof:R0,key:a==null?null:""+a,children:t,containerInfo:l,implementation:e}}var Ga=w0.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE;function Yu(t,l){if(t==="font")return"";if(typeof l=="string")return l==="use-credentials"?l:""}kt.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE=jt;kt.createPortal=function(t,l){var e=2<arguments.length&&arguments[2]!==void 0?arguments[2]:null;if(!l||l.nodeType!==1&&l.nodeType!==9&&l.nodeType!==11)throw Error(ur(299));return U0(t,l,null,e)};kt.flushSync=function(t){var l=Ga.T,e=jt.p;try{if(Ga.T=null,jt.p=2,t)return t()}finally{Ga.T=l,jt.p=e,jt.d.f()}};kt.preconnect=function(t,l){typeof t=="string"&&(l?(l=l.crossOrigin,l=typeof l=="string"?l==="use-credentials"?l:"":void 0):l=null,jt.d.C(t,l))};kt.prefetchDNS=function(t){typeof t=="string"&&jt.d.D(t)};kt.preinit=function(t,l){if(typeof t=="string"&&l&&typeof l.as=="string"){var e=l.as,a=Yu(e,l.crossOrigin),n=typeof l.integrity=="string"?l.integrity:void 0,u=typeof l.fetchPriority=="string"?l.fetchPriority:void 0;e==="style"?jt.d.S(t,typeof l.precedence=="string"?l.precedence:void 0,{crossOrigin:a,integrity:n,fetchPriority:u}):e==="script"&&jt.d.X(t,{crossOrigin:a,integrity:n,fetchPriority:u,nonce:typeof l.nonce=="string"?l.nonce:void 0})}};kt.preinitModule=function(t,l){if(typeof t=="string")if(typeof l=="object"&&l!==null){if(l.as==null||l.as==="script"){var e=Yu(l.as,l.crossOrigin);jt.d.M(t,{crossOrigin:e,integrity:typeof l.integrity=="string"?l.integrity:void 0,nonce:typeof l.nonce=="string"?l.nonce:void 0})}}else l==null&&jt.d.M(t)};kt.preload=function(t,l){if(typeof t=="string"&&typeof l=="object"&&l!==null&&typeof l.as=="string"){var e=l.as,a=Yu(e,l.crossOrigin);jt.d.L(t,e,{crossOrigin:a,integrity:typeof l.integrity=="string"?l.integrity:void 0,nonce:typeof l.nonce=="string"?l.nonce:void 0,type:typeof l.type=="string"?l.type:void 0,fetchPriority:typeof l.fetchPriority=="string"?l.fetchPriority:void 0,referrerPolicy:typeof l.referrerPolicy=="string"?l.referrerPolicy:void 0,imageSrcSet:typeof l.imageSrcSet=="string"?l.imageSrcSet:void 0,imageSizes:typeof l.imageSizes=="string"?l.imageSizes:void 0,media:typeof l.media=="string"?l.media:void 0})}};kt.preloadModule=function(t,l){if(typeof t=="string")if(l){var e=Yu(l.as,l.crossOrigin);jt.d.m(t,{as:typeof l.as=="string"&&l.as!=="script"?l.as:void 0,crossOrigin:e,integrity:typeof l.integrity=="string"?l.integrity:void 0})}else jt.d.m(t)};kt.requestFormReset=function(t){jt.d.r(t)};kt.unstable_batchedUpdates=function(t,l){return t(l)};kt.useFormState=function(t,l,e){return Ga.H.useFormState(t,l,e)};kt.useFormStatus=function(){return Ga.H.useHostTransitionStatus()};kt.version="19.2.4";function ir(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(ir)}catch(t){console.error(t)}}ir(),nr.exports=kt;var H0=nr.exports;/**
+ * @license React
+ * react-dom-client.production.js
+ *
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */var mt=p0,cr=p,B0=H0;function z(t){var l="https://react.dev/errors/"+t;if(1<arguments.length){l+="?args[]="+encodeURIComponent(arguments[1]);for(var e=2;e<arguments.length;e++)l+="&args[]="+encodeURIComponent(arguments[e])}return"Minified React error #"+t+"; visit "+l+" for the full message or use the non-minified dev environment for full errors and additional helpful warnings."}function fr(t){return!(!t||t.nodeType!==1&&t.nodeType!==9&&t.nodeType!==11)}function pn(t){var l=t,e=t;if(t.alternate)for(;l.return;)l=l.return;else{t=l;do l=t,l.flags&4098&&(e=l.return),t=l.return;while(t)}return l.tag===3?e:null}function sr(t){if(t.tag===13){var l=t.memoizedState;if(l===null&&(t=t.alternate,t!==null&&(l=t.memoizedState)),l!==null)return l.dehydrated}return null}function or(t){if(t.tag===31){var l=t.memoizedState;if(l===null&&(t=t.alternate,t!==null&&(l=t.memoizedState)),l!==null)return l.dehydrated}return null}function cs(t){if(pn(t)!==t)throw Error(z(188))}function X0(t){var l=t.alternate;if(!l){if(l=pn(t),l===null)throw Error(z(188));return l!==t?null:t}for(var e=t,a=l;;){var n=e.return;if(n===null)break;var u=n.alternate;if(u===null){if(a=n.return,a!==null){e=a;continue}break}if(n.child===u.child){for(u=n.child;u;){if(u===e)return cs(n),t;if(u===a)return cs(n),l;u=u.sibling}throw Error(z(188))}if(e.return!==a.return)e=n,a=u;else{for(var i=!1,c=n.child;c;){if(c===e){i=!0,e=n,a=u;break}if(c===a){i=!0,a=n,e=u;break}c=c.sibling}if(!i){for(c=u.child;c;){if(c===e){i=!0,e=u,a=n;break}if(c===a){i=!0,a=u,e=n;break}c=c.sibling}if(!i)throw Error(z(189))}}if(e.alternate!==a)throw Error(z(190))}if(e.tag!==3)throw Error(z(188));return e.stateNode.current===e?t:l}function rr(t){var l=t.tag;if(l===5||l===26||l===27||l===6)return t;for(t=t.child;t!==null;){if(l=rr(t),l!==null)return l;t=t.sibling}return null}var I=Object.assign,L0=Symbol.for("react.element"),Nn=Symbol.for("react.transitional.element"),wa=Symbol.for("react.portal"),Ze=Symbol.for("react.fragment"),dr=Symbol.for("react.strict_mode"),tc=Symbol.for("react.profiler"),yr=Symbol.for("react.consumer"),Sl=Symbol.for("react.context"),lf=Symbol.for("react.forward_ref"),lc=Symbol.for("react.suspense"),ec=Symbol.for("react.suspense_list"),ef=Symbol.for("react.memo"),wl=Symbol.for("react.lazy"),ac=Symbol.for("react.activity"),Z0=Symbol.for("react.memo_cache_sentinel"),fs=Symbol.iterator;function Aa(t){return t===null||typeof t!="object"?null:(t=fs&&t[fs]||t["@@iterator"],typeof t=="function"?t:null)}var G0=Symbol.for("react.client.reference");function nc(t){if(t==null)return null;if(typeof t=="function")return t.$$typeof===G0?null:t.displayName||t.name||null;if(typeof t=="string")return t;switch(t){case Ze:return"Fragment";case tc:return"Profiler";case dr:return"StrictMode";case lc:return"Suspense";case ec:return"SuspenseList";case ac:return"Activity"}if(typeof t=="object")switch(t.$$typeof){case wa:return"Portal";case Sl:return t.displayName||"Context";case yr:return(t._context.displayName||"Context")+".Consumer";case lf:var l=t.render;return t=t.displayName,t||(t=l.displayName||l.name||"",t=t!==""?"ForwardRef("+t+")":"ForwardRef"),t;case ef:return l=t.displayName||null,l!==null?l:nc(t.type)||"Memo";case wl:l=t._payload,t=t._init;try{return nc(t(l))}catch{}}return null}var Ra=Array.isArray,D=cr.__CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,X=B0.__DOM_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,xe={pending:!1,data:null,method:null,action:null},uc=[],Ge=-1;function rl(t){return{current:t}}function ht(t){0>Ge||(t.current=uc[Ge],uc[Ge]=null,Ge--)}function K(t,l){Ge++,uc[Ge]=t.current,t.current=l}var ol=rl(null),nn=rl(null),Kl=rl(null),yu=rl(null);function mu(t,l){switch(K(Kl,l),K(nn,t),K(ol,null),l.nodeType){case 9:case 11:t=(t=l.documentElement)&&(t=t.namespaceURI)?go(t):0;break;default:if(t=l.tagName,l=l.namespaceURI)l=go(l),t=N1(l,t);else switch(t){case"svg":t=1;break;case"math":t=2;break;default:t=0}}ht(ol),K(ol,t)}function fa(){ht(ol),ht(nn),ht(Kl)}function ic(t){t.memoizedState!==null&&K(yu,t);var l=ol.current,e=N1(l,t.type);l!==e&&(K(nn,t),K(ol,e))}function gu(t){nn.current===t&&(ht(ol),ht(nn)),yu.current===t&&(ht(yu),vn._currentValue=xe)}var si,ss;function ye(t){if(si===void 0)try{throw Error()}catch(e){var l=e.stack.trim().match(/\n( *(at )?)/);si=l&&l[1]||"",ss=-1<e.stack.indexOf(`
+    at`)?" (<anonymous>)":-1<e.stack.indexOf("@")?"@unknown:0:0":""}return`
+`+si+t+ss}var oi=!1;function ri(t,l){if(!t||oi)return"";oi=!0;var e=Error.prepareStackTrace;Error.prepareStackTrace=void 0;try{var a={DetermineComponentFrameRoot:function(){try{if(l){var v=function(){throw Error()};if(Object.defineProperty(v.prototype,"props",{set:function(){throw Error()}}),typeof Reflect=="object"&&Reflect.construct){try{Reflect.construct(v,[])}catch(g){var d=g}Reflect.construct(t,[],v)}else{try{v.call()}catch(g){d=g}t.call(v.prototype)}}else{try{throw Error()}catch(g){d=g}(v=t())&&typeof v.catch=="function"&&v.catch(function(){})}}catch(g){if(g&&d&&typeof g.stack=="string")return[g.stack,d.stack]}return[null,null]}};a.DetermineComponentFrameRoot.displayName="DetermineComponentFrameRoot";var n=Object.getOwnPropertyDescriptor(a.DetermineComponentFrameRoot,"name");n&&n.configurable&&Object.defineProperty(a.DetermineComponentFrameRoot,"name",{value:"DetermineComponentFrameRoot"});var u=a.DetermineComponentFrameRoot(),i=u[0],c=u[1];if(i&&c){var f=i.split(`
+`),o=c.split(`
+`);for(n=a=0;a<f.length&&!f[a].includes("DetermineComponentFrameRoot");)a++;for(;n<o.length&&!o[n].includes("DetermineComponentFrameRoot");)n++;if(a===f.length||n===o.length)for(a=f.length-1,n=o.length-1;1<=a&&0<=n&&f[a]!==o[n];)n--;for(;1<=a&&0<=n;a--,n--)if(f[a]!==o[n]){if(a!==1||n!==1)do if(a--,n--,0>n||f[a]!==o[n]){var y=`
+`+f[a].replace(" at new "," at ");return t.displayName&&y.includes("<anonymous>")&&(y=y.replace("<anonymous>",t.displayName)),y}while(1<=a&&0<=n);break}}}finally{oi=!1,Error.prepareStackTrace=e}return(e=t?t.displayName||t.name:"")?ye(e):""}function Y0(t,l){switch(t.tag){case 26:case 27:case 5:return ye(t.type);case 16:return ye("Lazy");case 13:return t.child!==l&&l!==null?ye("Suspense Fallback"):ye("Suspense");case 19:return ye("SuspenseList");case 0:case 15:return ri(t.type,!1);case 11:return ri(t.type.render,!1);case 1:return ri(t.type,!0);case 31:return ye("Activity");default:return""}}function os(t){try{var l="",e=null;do l+=Y0(t,e),e=t,t=t.return;while(t);return l}catch(a){return`
+Error generating stack: `+a.message+`
+`+a.stack}}var cc=Object.prototype.hasOwnProperty,af=mt.unstable_scheduleCallback,di=mt.unstable_cancelCallback,Q0=mt.unstable_shouldYield,V0=mt.unstable_requestPaint,Bt=mt.unstable_now,K0=mt.unstable_getCurrentPriorityLevel,mr=mt.unstable_ImmediatePriority,gr=mt.unstable_UserBlockingPriority,vu=mt.unstable_NormalPriority,J0=mt.unstable_LowPriority,vr=mt.unstable_IdlePriority,W0=mt.log,F0=mt.unstable_setDisableYieldValue,bn=null,Xt=null;function Zl(t){if(typeof W0=="function"&&F0(t),Xt&&typeof Xt.setStrictMode=="function")try{Xt.setStrictMode(bn,t)}catch{}}var Lt=Math.clz32?Math.clz32:ty,I0=Math.log,P0=Math.LN2;function ty(t){return t>>>=0,t===0?32:31-(I0(t)/P0|0)|0}var Cn=256,qn=262144,wn=4194304;function me(t){var l=t&42;if(l!==0)return l;switch(t&-t){case 1:return 1;case 2:return 2;case 4:return 4;case 8:return 8;case 16:return 16;case 32:return 32;case 64:return 64;case 128:return 128;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:return t&261888;case 262144:case 524288:case 1048576:case 2097152:return t&3932160;case 4194304:case 8388608:case 16777216:case 33554432:return t&62914560;case 67108864:return 67108864;case 134217728:return 134217728;case 268435456:return 268435456;case 536870912:return 536870912;case 1073741824:return 0;default:return t}}function Qu(t,l,e){var a=t.pendingLanes;if(a===0)return 0;var n=0,u=t.suspendedLanes,i=t.pingedLanes;t=t.warmLanes;var c=a&134217727;return c!==0?(a=c&~u,a!==0?n=me(a):(i&=c,i!==0?n=me(i):e||(e=c&~t,e!==0&&(n=me(e))))):(c=a&~u,c!==0?n=me(c):i!==0?n=me(i):e||(e=a&~t,e!==0&&(n=me(e)))),n===0?0:l!==0&&l!==n&&!(l&u)&&(u=n&-n,e=l&-l,u>=e||u===32&&(e&4194048)!==0)?l:n}function Sn(t,l){return(t.pendingLanes&~(t.suspendedLanes&~t.pingedLanes)&l)===0}function ly(t,l){switch(t){case 1:case 2:case 4:case 8:case 64:return l+250;case 16:case 32:case 128:case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:return l+5e3;case 4194304:case 8388608:case 16777216:case 33554432:return-1;case 67108864:case 134217728:case 268435456:case 536870912:case 1073741824:return-1;default:return-1}}function hr(){var t=wn;return wn<<=1,!(wn&62914560)&&(wn=4194304),t}function yi(t){for(var l=[],e=0;31>e;e++)l.push(t);return l}function zn(t,l){t.pendingLanes|=l,l!==268435456&&(t.suspendedLanes=0,t.pingedLanes=0,t.warmLanes=0)}function ey(t,l,e,a,n,u){var i=t.pendingLanes;t.pendingLanes=e,t.suspendedLanes=0,t.pingedLanes=0,t.warmLanes=0,t.expiredLanes&=e,t.entangledLanes&=e,t.errorRecoveryDisabledLanes&=e,t.shellSuspendCounter=0;var c=t.entanglements,f=t.expirationTimes,o=t.hiddenUpdates;for(e=i&~e;0<e;){var y=31-Lt(e),v=1<<y;c[y]=0,f[y]=-1;var d=o[y];if(d!==null)for(o[y]=null,y=0;y<d.length;y++){var g=d[y];g!==null&&(g.lane&=-536870913)}e&=~v}a!==0&&xr(t,a,0),u!==0&&n===0&&t.tag!==0&&(t.suspendedLanes|=u&~(i&~l))}function xr(t,l,e){t.pendingLanes|=l,t.suspendedLanes&=~l;var a=31-Lt(l);t.entangledLanes|=l,t.entanglements[a]=t.entanglements[a]|1073741824|e&261930}function pr(t,l){var e=t.entangledLanes|=l;for(t=t.entanglements;e;){var a=31-Lt(e),n=1<<a;n&l|t[a]&l&&(t[a]|=l),e&=~n}}function br(t,l){var e=l&-l;return e=e&42?1:nf(e),e&(t.suspendedLanes|l)?0:e}function nf(t){switch(t){case 2:t=1;break;case 8:t=4;break;case 32:t=16;break;case 256:case 512:case 1024:case 2048:case 4096:case 8192:case 16384:case 32768:case 65536:case 131072:case 262144:case 524288:case 1048576:case 2097152:case 4194304:case 8388608:case 16777216:case 33554432:t=128;break;case 268435456:t=134217728;break;default:t=0}return t}function uf(t){return t&=-t,2<t?8<t?t&134217727?32:268435456:8:2}function Sr(){var t=X.p;return t!==0?t:(t=window.event,t===void 0?32:G1(t.type))}function rs(t,l){var e=X.p;try{return X.p=t,l()}finally{X.p=e}}var ce=Math.random().toString(36).slice(2),bt="__reactFiber$"+ce,Ct="__reactProps$"+ce,ba="__reactContainer$"+ce,fc="__reactEvents$"+ce,ay="__reactListeners$"+ce,ny="__reactHandles$"+ce,ds="__reactResources$"+ce,En="__reactMarker$"+ce;function cf(t){delete t[bt],delete t[Ct],delete t[fc],delete t[ay],delete t[ny]}function Ye(t){var l=t[bt];if(l)return l;for(var e=t.parentNode;e;){if(l=e[ba]||e[bt]){if(e=l.alternate,l.child!==null||e!==null&&e.child!==null)for(t=bo(t);t!==null;){if(e=t[bt])return e;t=bo(t)}return l}t=e,e=t.parentNode}return null}function Sa(t){if(t=t[bt]||t[ba]){var l=t.tag;if(l===5||l===6||l===13||l===31||l===26||l===27||l===3)return t}return null}function Ua(t){var l=t.tag;if(l===5||l===26||l===27||l===6)return t.stateNode;throw Error(z(33))}function la(t){var l=t[ds];return l||(l=t[ds]={hoistableStyles:new Map,hoistableScripts:new Map}),l}function vt(t){t[En]=!0}var zr=new Set,Er={};function ke(t,l){sa(t,l),sa(t+"Capture",l)}function sa(t,l){for(Er[t]=l,t=0;t<l.length;t++)zr.add(l[t])}var uy=RegExp("^[:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD][:A-Z_a-z\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u02FF\\u0370-\\u037D\\u037F-\\u1FFF\\u200C-\\u200D\\u2070-\\u218F\\u2C00-\\u2FEF\\u3001-\\uD7FF\\uF900-\\uFDCF\\uFDF0-\\uFFFD\\-.0-9\\u00B7\\u0300-\\u036F\\u203F-\\u2040]*$"),ys={},ms={};function iy(t){return cc.call(ms,t)?!0:cc.call(ys,t)?!1:uy.test(t)?ms[t]=!0:(ys[t]=!0,!1)}function Wn(t,l,e){if(iy(l))if(e===null)t.removeAttribute(l);else{switch(typeof e){case"undefined":case"function":case"symbol":t.removeAttribute(l);return;case"boolean":var a=l.toLowerCase().slice(0,5);if(a!=="data-"&&a!=="aria-"){t.removeAttribute(l);return}}t.setAttribute(l,""+e)}}function Rn(t,l,e){if(e===null)t.removeAttribute(l);else{switch(typeof e){case"undefined":case"function":case"symbol":case"boolean":t.removeAttribute(l);return}t.setAttribute(l,""+e)}}function ml(t,l,e,a){if(a===null)t.removeAttribute(e);else{switch(typeof a){case"undefined":case"function":case"symbol":case"boolean":t.removeAttribute(e);return}t.setAttributeNS(l,e,""+a)}}function Vt(t){switch(typeof t){case"bigint":case"boolean":case"number":case"string":case"undefined":return t;case"object":return t;default:return""}}function Tr(t){var l=t.type;return(t=t.nodeName)&&t.toLowerCase()==="input"&&(l==="checkbox"||l==="radio")}function cy(t,l,e){var a=Object.getOwnPropertyDescriptor(t.constructor.prototype,l);if(!t.hasOwnProperty(l)&&typeof a<"u"&&typeof a.get=="function"&&typeof a.set=="function"){var n=a.get,u=a.set;return Object.defineProperty(t,l,{configurable:!0,get:function(){return n.call(this)},set:function(i){e=""+i,u.call(this,i)}}),Object.defineProperty(t,l,{enumerable:a.enumerable}),{getValue:function(){return e},setValue:function(i){e=""+i},stopTracking:function(){t._valueTracker=null,delete t[l]}}}}function sc(t){if(!t._valueTracker){var l=Tr(t)?"checked":"value";t._valueTracker=cy(t,l,""+t[l])}}function $r(t){if(!t)return!1;var l=t._valueTracker;if(!l)return!0;var e=l.getValue(),a="";return t&&(a=Tr(t)?t.checked?"true":"false":t.value),t=a,t!==e?(l.setValue(t),!0):!1}function hu(t){if(t=t||(typeof document<"u"?document:void 0),typeof t>"u")return null;try{return t.activeElement||t.body}catch{return t.body}}var fy=/[\n"\\]/g;function Wt(t){return t.replace(fy,function(l){return"\\"+l.charCodeAt(0).toString(16)+" "})}function oc(t,l,e,a,n,u,i,c){t.name="",i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"?t.type=i:t.removeAttribute("type"),l!=null?i==="number"?(l===0&&t.value===""||t.value!=l)&&(t.value=""+Vt(l)):t.value!==""+Vt(l)&&(t.value=""+Vt(l)):i!=="submit"&&i!=="reset"||t.removeAttribute("value"),l!=null?rc(t,i,Vt(l)):e!=null?rc(t,i,Vt(e)):a!=null&&t.removeAttribute("value"),n==null&&u!=null&&(t.defaultChecked=!!u),n!=null&&(t.checked=n&&typeof n!="function"&&typeof n!="symbol"),c!=null&&typeof c!="function"&&typeof c!="symbol"&&typeof c!="boolean"?t.name=""+Vt(c):t.removeAttribute("name")}function jr(t,l,e,a,n,u,i,c){if(u!=null&&typeof u!="function"&&typeof u!="symbol"&&typeof u!="boolean"&&(t.type=u),l!=null||e!=null){if(!(u!=="submit"&&u!=="reset"||l!=null)){sc(t);return}e=e!=null?""+Vt(e):"",l=l!=null?""+Vt(l):e,c||l===t.value||(t.value=l),t.defaultValue=l}a=a??n,a=typeof a!="function"&&typeof a!="symbol"&&!!a,t.checked=c?t.checked:!!a,t.defaultChecked=!!a,i!=null&&typeof i!="function"&&typeof i!="symbol"&&typeof i!="boolean"&&(t.name=i),sc(t)}function rc(t,l,e){l==="number"&&hu(t.ownerDocument)===t||t.defaultValue===""+e||(t.defaultValue=""+e)}function ea(t,l,e,a){if(t=t.options,l){l={};for(var n=0;n<e.length;n++)l["$"+e[n]]=!0;for(e=0;e<t.length;e++)n=l.hasOwnProperty("$"+t[e].value),t[e].selected!==n&&(t[e].selected=n),n&&a&&(t[e].defaultSelected=!0)}else{for(e=""+Vt(e),l=null,n=0;n<t.length;n++){if(t[n].value===e){t[n].selected=!0,a&&(t[n].defaultSelected=!0);return}l!==null||t[n].disabled||(l=t[n])}l!==null&&(l.selected=!0)}}function Ar(t,l,e){if(l!=null&&(l=""+Vt(l),l!==t.value&&(t.value=l),e==null)){t.defaultValue!==l&&(t.defaultValue=l);return}t.defaultValue=e!=null?""+Vt(e):""}function kr(t,l,e,a){if(l==null){if(a!=null){if(e!=null)throw Error(z(92));if(Ra(a)){if(1<a.length)throw Error(z(93));a=a[0]}e=a}e==null&&(e=""),l=e}e=Vt(l),t.defaultValue=e,a=t.textContent,a===e&&a!==""&&a!==null&&(t.value=a),sc(t)}function oa(t,l){if(l){var e=t.firstChild;if(e&&e===t.lastChild&&e.nodeType===3){e.nodeValue=l;return}}t.textContent=l}var sy=new Set("animationIterationCount aspectRatio borderImageOutset borderImageSlice borderImageWidth boxFlex boxFlexGroup boxOrdinalGroup columnCount columns flex flexGrow flexPositive flexShrink flexNegative flexOrder gridArea gridRow gridRowEnd gridRowSpan gridRowStart gridColumn gridColumnEnd gridColumnSpan gridColumnStart fontWeight lineClamp lineHeight opacity order orphans scale tabSize widows zIndex zoom fillOpacity floodOpacity stopOpacity strokeDasharray strokeDashoffset strokeMiterlimit strokeOpacity strokeWidth MozAnimationIterationCount MozBoxFlex MozBoxFlexGroup MozLineClamp msAnimationIterationCount msFlex msZoom msFlexGrow msFlexNegative msFlexOrder msFlexPositive msFlexShrink msGridColumn msGridColumnSpan msGridRow msGridRowSpan WebkitAnimationIterationCount WebkitBoxFlex WebKitBoxFlexGroup WebkitBoxOrdinalGroup WebkitColumnCount WebkitColumns WebkitFlex WebkitFlexGrow WebkitFlexPositive WebkitFlexShrink WebkitLineClamp".split(" "));function gs(t,l,e){var a=l.indexOf("--")===0;e==null||typeof e=="boolean"||e===""?a?t.setProperty(l,""):l==="float"?t.cssFloat="":t[l]="":a?t.setProperty(l,e):typeof e!="number"||e===0||sy.has(l)?l==="float"?t.cssFloat=e:t[l]=(""+e).trim():t[l]=e+"px"}function Mr(t,l,e){if(l!=null&&typeof l!="object")throw Error(z(62));if(t=t.style,e!=null){for(var a in e)!e.hasOwnProperty(a)||l!=null&&l.hasOwnProperty(a)||(a.indexOf("--")===0?t.setProperty(a,""):a==="float"?t.cssFloat="":t[a]="");for(var n in l)a=l[n],l.hasOwnProperty(n)&&e[n]!==a&&gs(t,n,a)}else for(var u in l)l.hasOwnProperty(u)&&gs(t,u,l[u])}function ff(t){if(t.indexOf("-")===-1)return!1;switch(t){case"annotation-xml":case"color-profile":case"font-face":case"font-face-src":case"font-face-uri":case"font-face-format":case"font-face-name":case"missing-glyph":return!1;default:return!0}}var oy=new Map([["acceptCharset","accept-charset"],["htmlFor","for"],["httpEquiv","http-equiv"],["crossOrigin","crossorigin"],["accentHeight","accent-height"],["alignmentBaseline","alignment-baseline"],["arabicForm","arabic-form"],["baselineShift","baseline-shift"],["capHeight","cap-height"],["clipPath","clip-path"],["clipRule","clip-rule"],["colorInterpolation","color-interpolation"],["colorInterpolationFilters","color-interpolation-filters"],["colorProfile","color-profile"],["colorRendering","color-rendering"],["dominantBaseline","dominant-baseline"],["enableBackground","enable-background"],["fillOpacity","fill-opacity"],["fillRule","fill-rule"],["floodColor","flood-color"],["floodOpacity","flood-opacity"],["fontFamily","font-family"],["fontSize","font-size"],["fontSizeAdjust","font-size-adjust"],["fontStretch","font-stretch"],["fontStyle","font-style"],["fontVariant","font-variant"],["fontWeight","font-weight"],["glyphName","glyph-name"],["glyphOrientationHorizontal","glyph-orientation-horizontal"],["glyphOrientationVertical","glyph-orientation-vertical"],["horizAdvX","horiz-adv-x"],["horizOriginX","horiz-origin-x"],["imageRendering","image-rendering"],["letterSpacing","letter-spacing"],["lightingColor","lighting-color"],["markerEnd","marker-end"],["markerMid","marker-mid"],["markerStart","marker-start"],["overlinePosition","overline-position"],["overlineThickness","overline-thickness"],["paintOrder","paint-order"],["panose-1","panose-1"],["pointerEvents","pointer-events"],["renderingIntent","rendering-intent"],["shapeRendering","shape-rendering"],["stopColor","stop-color"],["stopOpacity","stop-opacity"],["strikethroughPosition","strikethrough-position"],["strikethroughThickness","strikethrough-thickness"],["strokeDasharray","stroke-dasharray"],["strokeDashoffset","stroke-dashoffset"],["strokeLinecap","stroke-linecap"],["strokeLinejoin","stroke-linejoin"],["strokeMiterlimit","stroke-miterlimit"],["strokeOpacity","stroke-opacity"],["strokeWidth","stroke-width"],["textAnchor","text-anchor"],["textDecoration","text-decoration"],["textRendering","text-rendering"],["transformOrigin","transform-origin"],["underlinePosition","underline-position"],["underlineThickness","underline-thickness"],["unicodeBidi","unicode-bidi"],["unicodeRange","unicode-range"],["unitsPerEm","units-per-em"],["vAlphabetic","v-alphabetic"],["vHanging","v-hanging"],["vIdeographic","v-ideographic"],["vMathematical","v-mathematical"],["vectorEffect","vector-effect"],["vertAdvY","vert-adv-y"],["vertOriginX","vert-origin-x"],["vertOriginY","vert-origin-y"],["wordSpacing","word-spacing"],["writingMode","writing-mode"],["xmlnsXlink","xmlns:xlink"],["xHeight","x-height"]]),ry=/^[\u0000-\u001F ]*j[\r\n\t]*a[\r\n\t]*v[\r\n\t]*a[\r\n\t]*s[\r\n\t]*c[\r\n\t]*r[\r\n\t]*i[\r\n\t]*p[\r\n\t]*t[\r\n\t]*:/i;function Fn(t){return ry.test(""+t)?"javascript:throw new Error('React has blocked a javascript: URL as a security precaution.')":t}function zl(){}var dc=null;function sf(t){return t=t.target||t.srcElement||window,t.correspondingUseElement&&(t=t.correspondingUseElement),t.nodeType===3?t.parentNode:t}var Qe=null,aa=null;function vs(t){var l=Sa(t);if(l&&(t=l.stateNode)){var e=t[Ct]||null;t:switch(t=l.stateNode,l.type){case"input":if(oc(t,e.value,e.defaultValue,e.defaultValue,e.checked,e.defaultChecked,e.type,e.name),l=e.name,e.type==="radio"&&l!=null){for(e=t;e.parentNode;)e=e.parentNode;for(e=e.querySelectorAll('input[name="'+Wt(""+l)+'"][type="radio"]'),l=0;l<e.length;l++){var a=e[l];if(a!==t&&a.form===t.form){var n=a[Ct]||null;if(!n)throw Error(z(90));oc(a,n.value,n.defaultValue,n.defaultValue,n.checked,n.defaultChecked,n.type,n.name)}}for(l=0;l<e.length;l++)a=e[l],a.form===t.form&&$r(a)}break t;case"textarea":Ar(t,e.value,e.defaultValue);break t;case"select":l=e.value,l!=null&&ea(t,!!e.multiple,l,!1)}}}var mi=!1;function Or(t,l,e){if(mi)return t(l,e);mi=!0;try{var a=t(l);return a}finally{if(mi=!1,(Qe!==null||aa!==null)&&(ni(),Qe&&(l=Qe,t=aa,aa=Qe=null,vs(l),t)))for(l=0;l<t.length;l++)vs(t[l])}}function un(t,l){var e=t.stateNode;if(e===null)return null;var a=e[Ct]||null;if(a===null)return null;e=a[l];t:switch(l){case"onClick":case"onClickCapture":case"onDoubleClick":case"onDoubleClickCapture":case"onMouseDown":case"onMouseDownCapture":case"onMouseMove":case"onMouseMoveCapture":case"onMouseUp":case"onMouseUpCapture":case"onMouseEnter":(a=!a.disabled)||(t=t.type,a=!(t==="button"||t==="input"||t==="select"||t==="textarea")),t=!a;break t;default:t=!1}if(t)return null;if(e&&typeof e!="function")throw Error(z(231,l,typeof e));return e}var Al=!(typeof window>"u"||typeof window.document>"u"||typeof window.document.createElement>"u"),yc=!1;if(Al)try{var ka={};Object.defineProperty(ka,"passive",{get:function(){yc=!0}}),window.addEventListener("test",ka,ka),window.removeEventListener("test",ka,ka)}catch{yc=!1}var Gl=null,of=null,In=null;function Dr(){if(In)return In;var t,l=of,e=l.length,a,n="value"in Gl?Gl.value:Gl.textContent,u=n.length;for(t=0;t<e&&l[t]===n[t];t++);var i=e-t;for(a=1;a<=i&&l[e-a]===n[u-a];a++);return In=n.slice(t,1<a?1-a:void 0)}function Pn(t){var l=t.keyCode;return"charCode"in t?(t=t.charCode,t===0&&l===13&&(t=13)):t=l,t===10&&(t=13),32<=t||t===13?t:0}function Un(){return!0}function hs(){return!1}function qt(t){function l(e,a,n,u,i){this._reactName=e,this._targetInst=n,this.type=a,this.nativeEvent=u,this.target=i,this.currentTarget=null;for(var c in t)t.hasOwnProperty(c)&&(e=t[c],this[c]=e?e(u):u[c]);return this.isDefaultPrevented=(u.defaultPrevented!=null?u.defaultPrevented:u.returnValue===!1)?Un:hs,this.isPropagationStopped=hs,this}return I(l.prototype,{preventDefault:function(){this.defaultPrevented=!0;var e=this.nativeEvent;e&&(e.preventDefault?e.preventDefault():typeof e.returnValue!="unknown"&&(e.returnValue=!1),this.isDefaultPrevented=Un)},stopPropagation:function(){var e=this.nativeEvent;e&&(e.stopPropagation?e.stopPropagation():typeof e.cancelBubble!="unknown"&&(e.cancelBubble=!0),this.isPropagationStopped=Un)},persist:function(){},isPersistent:Un}),l}var Me={eventPhase:0,bubbles:0,cancelable:0,timeStamp:function(t){return t.timeStamp||Date.now()},defaultPrevented:0,isTrusted:0},Vu=qt(Me),Tn=I({},Me,{view:0,detail:0}),dy=qt(Tn),gi,vi,Ma,Ku=I({},Tn,{screenX:0,screenY:0,clientX:0,clientY:0,pageX:0,pageY:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,getModifierState:rf,button:0,buttons:0,relatedTarget:function(t){return t.relatedTarget===void 0?t.fromElement===t.srcElement?t.toElement:t.fromElement:t.relatedTarget},movementX:function(t){return"movementX"in t?t.movementX:(t!==Ma&&(Ma&&t.type==="mousemove"?(gi=t.screenX-Ma.screenX,vi=t.screenY-Ma.screenY):vi=gi=0,Ma=t),gi)},movementY:function(t){return"movementY"in t?t.movementY:vi}}),xs=qt(Ku),yy=I({},Ku,{dataTransfer:0}),my=qt(yy),gy=I({},Tn,{relatedTarget:0}),hi=qt(gy),vy=I({},Me,{animationName:0,elapsedTime:0,pseudoElement:0}),hy=qt(vy),xy=I({},Me,{clipboardData:function(t){return"clipboardData"in t?t.clipboardData:window.clipboardData}}),py=qt(xy),by=I({},Me,{data:0}),ps=qt(by),Sy={Esc:"Escape",Spacebar:" ",Left:"ArrowLeft",Up:"ArrowUp",Right:"ArrowRight",Down:"ArrowDown",Del:"Delete",Win:"OS",Menu:"ContextMenu",Apps:"ContextMenu",Scroll:"ScrollLock",MozPrintableKey:"Unidentified"},zy={8:"Backspace",9:"Tab",12:"Clear",13:"Enter",16:"Shift",17:"Control",18:"Alt",19:"Pause",20:"CapsLock",27:"Escape",32:" ",33:"PageUp",34:"PageDown",35:"End",36:"Home",37:"ArrowLeft",38:"ArrowUp",39:"ArrowRight",40:"ArrowDown",45:"Insert",46:"Delete",112:"F1",113:"F2",114:"F3",115:"F4",116:"F5",117:"F6",118:"F7",119:"F8",120:"F9",121:"F10",122:"F11",123:"F12",144:"NumLock",145:"ScrollLock",224:"Meta"},Ey={Alt:"altKey",Control:"ctrlKey",Meta:"metaKey",Shift:"shiftKey"};function Ty(t){var l=this.nativeEvent;return l.getModifierState?l.getModifierState(t):(t=Ey[t])?!!l[t]:!1}function rf(){return Ty}var $y=I({},Tn,{key:function(t){if(t.key){var l=Sy[t.key]||t.key;if(l!=="Unidentified")return l}return t.type==="keypress"?(t=Pn(t),t===13?"Enter":String.fromCharCode(t)):t.type==="keydown"||t.type==="keyup"?zy[t.keyCode]||"Unidentified":""},code:0,location:0,ctrlKey:0,shiftKey:0,altKey:0,metaKey:0,repeat:0,locale:0,getModifierState:rf,charCode:function(t){return t.type==="keypress"?Pn(t):0},keyCode:function(t){return t.type==="keydown"||t.type==="keyup"?t.keyCode:0},which:function(t){return t.type==="keypress"?Pn(t):t.type==="keydown"||t.type==="keyup"?t.keyCode:0}}),jy=qt($y),Ay=I({},Ku,{pointerId:0,width:0,height:0,pressure:0,tangentialPressure:0,tiltX:0,tiltY:0,twist:0,pointerType:0,isPrimary:0}),bs=qt(Ay),ky=I({},Tn,{touches:0,targetTouches:0,changedTouches:0,altKey:0,metaKey:0,ctrlKey:0,shiftKey:0,getModifierState:rf}),My=qt(ky),Oy=I({},Me,{propertyName:0,elapsedTime:0,pseudoElement:0}),Dy=qt(Oy),_y=I({},Ku,{deltaX:function(t){return"deltaX"in t?t.deltaX:"wheelDeltaX"in t?-t.wheelDeltaX:0},deltaY:function(t){return"deltaY"in t?t.deltaY:"wheelDeltaY"in t?-t.wheelDeltaY:"wheelDelta"in t?-t.wheelDelta:0},deltaZ:0,deltaMode:0}),Ny=qt(_y),Cy=I({},Me,{newState:0,oldState:0}),qy=qt(Cy),wy=[9,13,27,32],df=Al&&"CompositionEvent"in window,Ya=null;Al&&"documentMode"in document&&(Ya=document.documentMode);var Ry=Al&&"TextEvent"in window&&!Ya,_r=Al&&(!df||Ya&&8<Ya&&11>=Ya),Ss=" ",zs=!1;function Nr(t,l){switch(t){case"keyup":return wy.indexOf(l.keyCode)!==-1;case"keydown":return l.keyCode!==229;case"keypress":case"mousedown":case"focusout":return!0;default:return!1}}function Cr(t){return t=t.detail,typeof t=="object"&&"data"in t?t.data:null}var Ve=!1;function Uy(t,l){switch(t){case"compositionend":return Cr(l);case"keypress":return l.which!==32?null:(zs=!0,Ss);case"textInput":return t=l.data,t===Ss&&zs?null:t;default:return null}}function Hy(t,l){if(Ve)return t==="compositionend"||!df&&Nr(t,l)?(t=Dr(),In=of=Gl=null,Ve=!1,t):null;switch(t){case"paste":return null;case"keypress":if(!(l.ctrlKey||l.altKey||l.metaKey)||l.ctrlKey&&l.altKey){if(l.char&&1<l.char.length)return l.char;if(l.which)return String.fromCharCode(l.which)}return null;case"compositionend":return _r&&l.locale!=="ko"?null:l.data;default:return null}}var By={color:!0,date:!0,datetime:!0,"datetime-local":!0,email:!0,month:!0,number:!0,password:!0,range:!0,search:!0,tel:!0,text:!0,time:!0,url:!0,week:!0};function Es(t){var l=t&&t.nodeName&&t.nodeName.toLowerCase();return l==="input"?!!By[t.type]:l==="textarea"}function qr(t,l,e,a){Qe?aa?aa.push(a):aa=[a]:Qe=a,l=qu(l,"onChange"),0<l.length&&(e=new Vu("onChange","change",null,e,a),t.push({event:e,listeners:l}))}var Qa=null,cn=null;function Xy(t){O1(t,0)}function Ju(t){var l=Ua(t);if($r(l))return t}function Ts(t,l){if(t==="change")return l}var wr=!1;if(Al){var xi;if(Al){var pi="oninput"in document;if(!pi){var $s=document.createElement("div");$s.setAttribute("oninput","return;"),pi=typeof $s.oninput=="function"}xi=pi}else xi=!1;wr=xi&&(!document.documentMode||9<document.documentMode)}function js(){Qa&&(Qa.detachEvent("onpropertychange",Rr),cn=Qa=null)}function Rr(t){if(t.propertyName==="value"&&Ju(cn)){var l=[];qr(l,cn,t,sf(t)),Or(Xy,l)}}function Ly(t,l,e){t==="focusin"?(js(),Qa=l,cn=e,Qa.attachEvent("onpropertychange",Rr)):t==="focusout"&&js()}function Zy(t){if(t==="selectionchange"||t==="keyup"||t==="keydown")return Ju(cn)}function Gy(t,l){if(t==="click")return Ju(l)}function Yy(t,l){if(t==="input"||t==="change")return Ju(l)}function Qy(t,l){return t===l&&(t!==0||1/t===1/l)||t!==t&&l!==l}var Gt=typeof Object.is=="function"?Object.is:Qy;function fn(t,l){if(Gt(t,l))return!0;if(typeof t!="object"||t===null||typeof l!="object"||l===null)return!1;var e=Object.keys(t),a=Object.keys(l);if(e.length!==a.length)return!1;for(a=0;a<e.length;a++){var n=e[a];if(!cc.call(l,n)||!Gt(t[n],l[n]))return!1}return!0}function As(t){for(;t&&t.firstChild;)t=t.firstChild;return t}function ks(t,l){var e=As(t);t=0;for(var a;e;){if(e.nodeType===3){if(a=t+e.textContent.length,t<=l&&a>=l)return{node:e,offset:l-t};t=a}t:{for(;e;){if(e.nextSibling){e=e.nextSibling;break t}e=e.parentNode}e=void 0}e=As(e)}}function Ur(t,l){return t&&l?t===l?!0:t&&t.nodeType===3?!1:l&&l.nodeType===3?Ur(t,l.parentNode):"contains"in t?t.contains(l):t.compareDocumentPosition?!!(t.compareDocumentPosition(l)&16):!1:!1}function Hr(t){t=t!=null&&t.ownerDocument!=null&&t.ownerDocument.defaultView!=null?t.ownerDocument.defaultView:window;for(var l=hu(t.document);l instanceof t.HTMLIFrameElement;){try{var e=typeof l.contentWindow.location.href=="string"}catch{e=!1}if(e)t=l.contentWindow;else break;l=hu(t.document)}return l}function yf(t){var l=t&&t.nodeName&&t.nodeName.toLowerCase();return l&&(l==="input"&&(t.type==="text"||t.type==="search"||t.type==="tel"||t.type==="url"||t.type==="password")||l==="textarea"||t.contentEditable==="true")}var Vy=Al&&"documentMode"in document&&11>=document.documentMode,Ke=null,mc=null,Va=null,gc=!1;function Ms(t,l,e){var a=e.window===e?e.document:e.nodeType===9?e:e.ownerDocument;gc||Ke==null||Ke!==hu(a)||(a=Ke,"selectionStart"in a&&yf(a)?a={start:a.selectionStart,end:a.selectionEnd}:(a=(a.ownerDocument&&a.ownerDocument.defaultView||window).getSelection(),a={anchorNode:a.anchorNode,anchorOffset:a.anchorOffset,focusNode:a.focusNode,focusOffset:a.focusOffset}),Va&&fn(Va,a)||(Va=a,a=qu(mc,"onSelect"),0<a.length&&(l=new Vu("onSelect","select",null,l,e),t.push({event:l,listeners:a}),l.target=Ke)))}function re(t,l){var e={};return e[t.toLowerCase()]=l.toLowerCase(),e["Webkit"+t]="webkit"+l,e["Moz"+t]="moz"+l,e}var Je={animationend:re("Animation","AnimationEnd"),animationiteration:re("Animation","AnimationIteration"),animationstart:re("Animation","AnimationStart"),transitionrun:re("Transition","TransitionRun"),transitionstart:re("Transition","TransitionStart"),transitioncancel:re("Transition","TransitionCancel"),transitionend:re("Transition","TransitionEnd")},bi={},Br={};Al&&(Br=document.createElement("div").style,"AnimationEvent"in window||(delete Je.animationend.animation,delete Je.animationiteration.animation,delete Je.animationstart.animation),"TransitionEvent"in window||delete Je.transitionend.transition);function Oe(t){if(bi[t])return bi[t];if(!Je[t])return t;var l=Je[t],e;for(e in l)if(l.hasOwnProperty(e)&&e in Br)return bi[t]=l[e];return t}var Xr=Oe("animationend"),Lr=Oe("animationiteration"),Zr=Oe("animationstart"),Ky=Oe("transitionrun"),Jy=Oe("transitionstart"),Wy=Oe("transitioncancel"),Gr=Oe("transitionend"),Yr=new Map,vc="abort auxClick beforeToggle cancel canPlay canPlayThrough click close contextMenu copy cut drag dragEnd dragEnter dragExit dragLeave dragOver dragStart drop durationChange emptied encrypted ended error gotPointerCapture input invalid keyDown keyPress keyUp load loadedData loadedMetadata loadStart lostPointerCapture mouseDown mouseMove mouseOut mouseOver mouseUp paste pause play playing pointerCancel pointerDown pointerMove pointerOut pointerOver pointerUp progress rateChange reset resize seeked seeking stalled submit suspend timeUpdate touchCancel touchEnd touchStart volumeChange scroll toggle touchMove waiting wheel".split(" ");vc.push("scrollEnd");function nl(t,l){Yr.set(t,l),ke(l,[t])}var xu=typeof reportError=="function"?reportError:function(t){if(typeof window=="object"&&typeof window.ErrorEvent=="function"){var l=new window.ErrorEvent("error",{bubbles:!0,cancelable:!0,message:typeof t=="object"&&t!==null&&typeof t.message=="string"?String(t.message):String(t),error:t});if(!window.dispatchEvent(l))return}else if(typeof process=="object"&&typeof process.emit=="function"){process.emit("uncaughtException",t);return}console.error(t)},Qt=[],We=0,mf=0;function Wu(){for(var t=We,l=mf=We=0;l<t;){var e=Qt[l];Qt[l++]=null;var a=Qt[l];Qt[l++]=null;var n=Qt[l];Qt[l++]=null;var u=Qt[l];if(Qt[l++]=null,a!==null&&n!==null){var i=a.pending;i===null?n.next=n:(n.next=i.next,i.next=n),a.pending=n}u!==0&&Qr(e,n,u)}}function Fu(t,l,e,a){Qt[We++]=t,Qt[We++]=l,Qt[We++]=e,Qt[We++]=a,mf|=a,t.lanes|=a,t=t.alternate,t!==null&&(t.lanes|=a)}function gf(t,l,e,a){return Fu(t,l,e,a),pu(t)}function De(t,l){return Fu(t,null,null,l),pu(t)}function Qr(t,l,e){t.lanes|=e;var a=t.alternate;a!==null&&(a.lanes|=e);for(var n=!1,u=t.return;u!==null;)u.childLanes|=e,a=u.alternate,a!==null&&(a.childLanes|=e),u.tag===22&&(t=u.stateNode,t===null||t._visibility&1||(n=!0)),t=u,u=u.return;return t.tag===3?(u=t.stateNode,n&&l!==null&&(n=31-Lt(e),t=u.hiddenUpdates,a=t[n],a===null?t[n]=[l]:a.push(l),l.lane=e|536870912),u):null}function pu(t){if(50<en)throw en=0,Rc=null,Error(z(185));for(var l=t.return;l!==null;)t=l,l=t.return;return t.tag===3?t.stateNode:null}var Fe={};function Fy(t,l,e,a){this.tag=t,this.key=e,this.sibling=this.child=this.return=this.stateNode=this.type=this.elementType=null,this.index=0,this.refCleanup=this.ref=null,this.pendingProps=l,this.dependencies=this.memoizedState=this.updateQueue=this.memoizedProps=null,this.mode=a,this.subtreeFlags=this.flags=0,this.deletions=null,this.childLanes=this.lanes=0,this.alternate=null}function Ut(t,l,e,a){return new Fy(t,l,e,a)}function vf(t){return t=t.prototype,!(!t||!t.isReactComponent)}function Tl(t,l){var e=t.alternate;return e===null?(e=Ut(t.tag,l,t.key,t.mode),e.elementType=t.elementType,e.type=t.type,e.stateNode=t.stateNode,e.alternate=t,t.alternate=e):(e.pendingProps=l,e.type=t.type,e.flags=0,e.subtreeFlags=0,e.deletions=null),e.flags=t.flags&65011712,e.childLanes=t.childLanes,e.lanes=t.lanes,e.child=t.child,e.memoizedProps=t.memoizedProps,e.memoizedState=t.memoizedState,e.updateQueue=t.updateQueue,l=t.dependencies,e.dependencies=l===null?null:{lanes:l.lanes,firstContext:l.firstContext},e.sibling=t.sibling,e.index=t.index,e.ref=t.ref,e.refCleanup=t.refCleanup,e}function Vr(t,l){t.flags&=65011714;var e=t.alternate;return e===null?(t.childLanes=0,t.lanes=l,t.child=null,t.subtreeFlags=0,t.memoizedProps=null,t.memoizedState=null,t.updateQueue=null,t.dependencies=null,t.stateNode=null):(t.childLanes=e.childLanes,t.lanes=e.lanes,t.child=e.child,t.subtreeFlags=0,t.deletions=null,t.memoizedProps=e.memoizedProps,t.memoizedState=e.memoizedState,t.updateQueue=e.updateQueue,t.type=e.type,l=e.dependencies,t.dependencies=l===null?null:{lanes:l.lanes,firstContext:l.firstContext}),t}function tu(t,l,e,a,n,u){var i=0;if(a=t,typeof t=="function")vf(t)&&(i=1);else if(typeof t=="string")i=eg(t,e,ol.current)?26:t==="html"||t==="head"||t==="body"?27:5;else t:switch(t){case ac:return t=Ut(31,e,l,n),t.elementType=ac,t.lanes=u,t;case Ze:return pe(e.children,n,u,l);case dr:i=8,n|=24;break;case tc:return t=Ut(12,e,l,n|2),t.elementType=tc,t.lanes=u,t;case lc:return t=Ut(13,e,l,n),t.elementType=lc,t.lanes=u,t;case ec:return t=Ut(19,e,l,n),t.elementType=ec,t.lanes=u,t;default:if(typeof t=="object"&&t!==null)switch(t.$$typeof){case Sl:i=10;break t;case yr:i=9;break t;case lf:i=11;break t;case ef:i=14;break t;case wl:i=16,a=null;break t}i=29,e=Error(z(130,t===null?"null":typeof t,"")),a=null}return l=Ut(i,e,l,n),l.elementType=t,l.type=a,l.lanes=u,l}function pe(t,l,e,a){return t=Ut(7,t,a,l),t.lanes=e,t}function Si(t,l,e){return t=Ut(6,t,null,l),t.lanes=e,t}function Kr(t){var l=Ut(18,null,null,0);return l.stateNode=t,l}function zi(t,l,e){return l=Ut(4,t.children!==null?t.children:[],t.key,l),l.lanes=e,l.stateNode={containerInfo:t.containerInfo,pendingChildren:null,implementation:t.implementation},l}var Os=new WeakMap;function Ft(t,l){if(typeof t=="object"&&t!==null){var e=Os.get(t);return e!==void 0?e:(l={value:t,source:l,stack:os(l)},Os.set(t,l),l)}return{value:t,source:l,stack:os(l)}}var Ie=[],Pe=0,bu=null,sn=0,Kt=[],Jt=0,ae=null,cl=1,fl="";function pl(t,l){Ie[Pe++]=sn,Ie[Pe++]=bu,bu=t,sn=l}function Jr(t,l,e){Kt[Jt++]=cl,Kt[Jt++]=fl,Kt[Jt++]=ae,ae=t;var a=cl;t=fl;var n=32-Lt(a)-1;a&=~(1<<n),e+=1;var u=32-Lt(l)+n;if(30<u){var i=n-n%5;u=(a&(1<<i)-1).toString(32),a>>=i,n-=i,cl=1<<32-Lt(l)+n|e<<n|a,fl=u+t}else cl=1<<u|e<<n|a,fl=t}function hf(t){t.return!==null&&(pl(t,1),Jr(t,1,0))}function xf(t){for(;t===bu;)bu=Ie[--Pe],Ie[Pe]=null,sn=Ie[--Pe],Ie[Pe]=null;for(;t===ae;)ae=Kt[--Jt],Kt[Jt]=null,fl=Kt[--Jt],Kt[Jt]=null,cl=Kt[--Jt],Kt[Jt]=null}function Wr(t,l){Kt[Jt++]=cl,Kt[Jt++]=fl,Kt[Jt++]=ae,cl=l.id,fl=l.overflow,ae=t}var St=null,W=null,H=!1,Jl=null,It=!1,hc=Error(z(519));function ne(t){var l=Error(z(418,1<arguments.length&&arguments[1]!==void 0&&arguments[1]?"text":"HTML",""));throw on(Ft(l,t)),hc}function Ds(t){var l=t.stateNode,e=t.type,a=t.memoizedProps;switch(l[bt]=t,l[Ct]=a,e){case"dialog":w("cancel",l),w("close",l);break;case"iframe":case"object":case"embed":w("load",l);break;case"video":case"audio":for(e=0;e<mn.length;e++)w(mn[e],l);break;case"source":w("error",l);break;case"img":case"image":case"link":w("error",l),w("load",l);break;case"details":w("toggle",l);break;case"input":w("invalid",l),jr(l,a.value,a.defaultValue,a.checked,a.defaultChecked,a.type,a.name,!0);break;case"select":w("invalid",l);break;case"textarea":w("invalid",l),kr(l,a.value,a.defaultValue,a.children)}e=a.children,typeof e!="string"&&typeof e!="number"&&typeof e!="bigint"||l.textContent===""+e||a.suppressHydrationWarning===!0||_1(l.textContent,e)?(a.popover!=null&&(w("beforetoggle",l),w("toggle",l)),a.onScroll!=null&&w("scroll",l),a.onScrollEnd!=null&&w("scrollend",l),a.onClick!=null&&(l.onclick=zl),l=!0):l=!1,l||ne(t,!0)}function _s(t){for(St=t.return;St;)switch(St.tag){case 5:case 31:case 13:It=!1;return;case 27:case 3:It=!0;return;default:St=St.return}}function Ce(t){if(t!==St)return!1;if(!H)return _s(t),H=!0,!1;var l=t.tag,e;if((e=l!==3&&l!==27)&&((e=l===5)&&(e=t.type,e=!(e!=="form"&&e!=="button")||Lc(t.type,t.memoizedProps)),e=!e),e&&W&&ne(t),_s(t),l===13){if(t=t.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(z(317));W=po(t)}else if(l===31){if(t=t.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(z(317));W=po(t)}else l===27?(l=W,fe(t.type)?(t=Qc,Qc=null,W=t):W=l):W=St?tl(t.stateNode.nextSibling):null;return!0}function Ee(){W=St=null,H=!1}function Ei(){var t=Jl;return t!==null&&(_t===null?_t=t:_t.push.apply(_t,t),Jl=null),t}function on(t){Jl===null?Jl=[t]:Jl.push(t)}var xc=rl(null),_e=null,El=null;function Hl(t,l,e){K(xc,l._currentValue),l._currentValue=e}function $l(t){t._currentValue=xc.current,ht(xc)}function pc(t,l,e){for(;t!==null;){var a=t.alternate;if((t.childLanes&l)!==l?(t.childLanes|=l,a!==null&&(a.childLanes|=l)):a!==null&&(a.childLanes&l)!==l&&(a.childLanes|=l),t===e)break;t=t.return}}function bc(t,l,e,a){var n=t.child;for(n!==null&&(n.return=t);n!==null;){var u=n.dependencies;if(u!==null){var i=n.child;u=u.firstContext;t:for(;u!==null;){var c=u;u=n;for(var f=0;f<l.length;f++)if(c.context===l[f]){u.lanes|=e,c=u.alternate,c!==null&&(c.lanes|=e),pc(u.return,e,t),a||(i=null);break t}u=c.next}}else if(n.tag===18){if(i=n.return,i===null)throw Error(z(341));i.lanes|=e,u=i.alternate,u!==null&&(u.lanes|=e),pc(i,e,t),i=null}else i=n.child;if(i!==null)i.return=n;else for(i=n;i!==null;){if(i===t){i=null;break}if(n=i.sibling,n!==null){n.return=i.return,i=n;break}i=i.return}n=i}}function za(t,l,e,a){t=null;for(var n=l,u=!1;n!==null;){if(!u){if(n.flags&524288)u=!0;else if(n.flags&262144)break}if(n.tag===10){var i=n.alternate;if(i===null)throw Error(z(387));if(i=i.memoizedProps,i!==null){var c=n.type;Gt(n.pendingProps.value,i.value)||(t!==null?t.push(c):t=[c])}}else if(n===yu.current){if(i=n.alternate,i===null)throw Error(z(387));i.memoizedState.memoizedState!==n.memoizedState.memoizedState&&(t!==null?t.push(vn):t=[vn])}n=n.return}t!==null&&bc(l,t,e,a),l.flags|=262144}function Su(t){for(t=t.firstContext;t!==null;){if(!Gt(t.context._currentValue,t.memoizedValue))return!0;t=t.next}return!1}function Te(t){_e=t,El=null,t=t.dependencies,t!==null&&(t.firstContext=null)}function zt(t){return Fr(_e,t)}function Hn(t,l){return _e===null&&Te(t),Fr(t,l)}function Fr(t,l){var e=l._currentValue;if(l={context:l,memoizedValue:e,next:null},El===null){if(t===null)throw Error(z(308));El=l,t.dependencies={lanes:0,firstContext:l},t.flags|=524288}else El=El.next=l;return e}var Iy=typeof AbortController<"u"?AbortController:function(){var t=[],l=this.signal={aborted:!1,addEventListener:function(e,a){t.push(a)}};this.abort=function(){l.aborted=!0,t.forEach(function(e){return e()})}},Py=mt.unstable_scheduleCallback,tm=mt.unstable_NormalPriority,rt={$$typeof:Sl,Consumer:null,Provider:null,_currentValue:null,_currentValue2:null,_threadCount:0};function pf(){return{controller:new Iy,data:new Map,refCount:0}}function $n(t){t.refCount--,t.refCount===0&&Py(tm,function(){t.controller.abort()})}var Ka=null,Sc=0,ra=0,na=null;function lm(t,l){if(Ka===null){var e=Ka=[];Sc=0,ra=Gf(),na={status:"pending",value:void 0,then:function(a){e.push(a)}}}return Sc++,l.then(Ns,Ns),l}function Ns(){if(--Sc===0&&Ka!==null){na!==null&&(na.status="fulfilled");var t=Ka;Ka=null,ra=0,na=null;for(var l=0;l<t.length;l++)(0,t[l])()}}function em(t,l){var e=[],a={status:"pending",value:null,reason:null,then:function(n){e.push(n)}};return t.then(function(){a.status="fulfilled",a.value=l;for(var n=0;n<e.length;n++)(0,e[n])(l)},function(n){for(a.status="rejected",a.reason=n,n=0;n<e.length;n++)(0,e[n])(void 0)}),a}var Cs=D.S;D.S=function(t,l){r1=Bt(),typeof l=="object"&&l!==null&&typeof l.then=="function"&&lm(t,l),Cs!==null&&Cs(t,l)};var be=rl(null);function bf(){var t=be.current;return t!==null?t:V.pooledCache}function lu(t,l){l===null?K(be,be.current):K(be,l.pool)}function Ir(){var t=bf();return t===null?null:{parent:rt._currentValue,pool:t}}var Ea=Error(z(460)),Sf=Error(z(474)),Iu=Error(z(542)),zu={then:function(){}};function qs(t){return t=t.status,t==="fulfilled"||t==="rejected"}function Pr(t,l,e){switch(e=t[e],e===void 0?t.push(l):e!==l&&(l.then(zl,zl),l=e),l.status){case"fulfilled":return l.value;case"rejected":throw t=l.reason,Rs(t),t;default:if(typeof l.status=="string")l.then(zl,zl);else{if(t=V,t!==null&&100<t.shellSuspendCounter)throw Error(z(482));t=l,t.status="pending",t.then(function(a){if(l.status==="pending"){var n=l;n.status="fulfilled",n.value=a}},function(a){if(l.status==="pending"){var n=l;n.status="rejected",n.reason=a}})}switch(l.status){case"fulfilled":return l.value;case"rejected":throw t=l.reason,Rs(t),t}throw Se=l,Ea}}function ge(t){try{var l=t._init;return l(t._payload)}catch(e){throw e!==null&&typeof e=="object"&&typeof e.then=="function"?(Se=e,Ea):e}}var Se=null;function ws(){if(Se===null)throw Error(z(459));var t=Se;return Se=null,t}function Rs(t){if(t===Ea||t===Iu)throw Error(z(483))}var ua=null,rn=0;function Bn(t){var l=rn;return rn+=1,ua===null&&(ua=[]),Pr(ua,t,l)}function Oa(t,l){l=l.props.ref,t.ref=l!==void 0?l:null}function Xn(t,l){throw l.$$typeof===L0?Error(z(525)):(t=Object.prototype.toString.call(l),Error(z(31,t==="[object Object]"?"object with keys {"+Object.keys(l).join(", ")+"}":t)))}function td(t){function l(r,s){if(t){var m=r.deletions;m===null?(r.deletions=[s],r.flags|=16):m.push(s)}}function e(r,s){if(!t)return null;for(;s!==null;)l(r,s),s=s.sibling;return null}function a(r){for(var s=new Map;r!==null;)r.key!==null?s.set(r.key,r):s.set(r.index,r),r=r.sibling;return s}function n(r,s){return r=Tl(r,s),r.index=0,r.sibling=null,r}function u(r,s,m){return r.index=m,t?(m=r.alternate,m!==null?(m=m.index,m<s?(r.flags|=67108866,s):m):(r.flags|=67108866,s)):(r.flags|=1048576,s)}function i(r){return t&&r.alternate===null&&(r.flags|=67108866),r}function c(r,s,m,h){return s===null||s.tag!==6?(s=Si(m,r.mode,h),s.return=r,s):(s=n(s,m),s.return=r,s)}function f(r,s,m,h){var $=m.type;return $===Ze?y(r,s,m.props.children,h,m.key):s!==null&&(s.elementType===$||typeof $=="object"&&$!==null&&$.$$typeof===wl&&ge($)===s.type)?(s=n(s,m.props),Oa(s,m),s.return=r,s):(s=tu(m.type,m.key,m.props,null,r.mode,h),Oa(s,m),s.return=r,s)}function o(r,s,m,h){return s===null||s.tag!==4||s.stateNode.containerInfo!==m.containerInfo||s.stateNode.implementation!==m.implementation?(s=zi(m,r.mode,h),s.return=r,s):(s=n(s,m.children||[]),s.return=r,s)}function y(r,s,m,h,$){return s===null||s.tag!==7?(s=pe(m,r.mode,h,$),s.return=r,s):(s=n(s,m),s.return=r,s)}function v(r,s,m){if(typeof s=="string"&&s!==""||typeof s=="number"||typeof s=="bigint")return s=Si(""+s,r.mode,m),s.return=r,s;if(typeof s=="object"&&s!==null){switch(s.$$typeof){case Nn:return m=tu(s.type,s.key,s.props,null,r.mode,m),Oa(m,s),m.return=r,m;case wa:return s=zi(s,r.mode,m),s.return=r,s;case wl:return s=ge(s),v(r,s,m)}if(Ra(s)||Aa(s))return s=pe(s,r.mode,m,null),s.return=r,s;if(typeof s.then=="function")return v(r,Bn(s),m);if(s.$$typeof===Sl)return v(r,Hn(r,s),m);Xn(r,s)}return null}function d(r,s,m,h){var $=s!==null?s.key:null;if(typeof m=="string"&&m!==""||typeof m=="number"||typeof m=="bigint")return $!==null?null:c(r,s,""+m,h);if(typeof m=="object"&&m!==null){switch(m.$$typeof){case Nn:return m.key===$?f(r,s,m,h):null;case wa:return m.key===$?o(r,s,m,h):null;case wl:return m=ge(m),d(r,s,m,h)}if(Ra(m)||Aa(m))return $!==null?null:y(r,s,m,h,null);if(typeof m.then=="function")return d(r,s,Bn(m),h);if(m.$$typeof===Sl)return d(r,s,Hn(r,m),h);Xn(r,m)}return null}function g(r,s,m,h,$){if(typeof h=="string"&&h!==""||typeof h=="number"||typeof h=="bigint")return r=r.get(m)||null,c(s,r,""+h,$);if(typeof h=="object"&&h!==null){switch(h.$$typeof){case Nn:return r=r.get(h.key===null?m:h.key)||null,f(s,r,h,$);case wa:return r=r.get(h.key===null?m:h.key)||null,o(s,r,h,$);case wl:return h=ge(h),g(r,s,m,h,$)}if(Ra(h)||Aa(h))return r=r.get(m)||null,y(s,r,h,$,null);if(typeof h.then=="function")return g(r,s,m,Bn(h),$);if(h.$$typeof===Sl)return g(r,s,m,Hn(s,h),$);Xn(s,h)}return null}function x(r,s,m,h){for(var $=null,A=null,T=s,M=s=0,j=null;T!==null&&M<m.length;M++){T.index>M?(j=T,T=null):j=T.sibling;var k=d(r,T,m[M],h);if(k===null){T===null&&(T=j);break}t&&T&&k.alternate===null&&l(r,T),s=u(k,s,M),A===null?$=k:A.sibling=k,A=k,T=j}if(M===m.length)return e(r,T),H&&pl(r,M),$;if(T===null){for(;M<m.length;M++)T=v(r,m[M],h),T!==null&&(s=u(T,s,M),A===null?$=T:A.sibling=T,A=T);return H&&pl(r,M),$}for(T=a(T);M<m.length;M++)j=g(T,r,M,m[M],h),j!==null&&(t&&j.alternate!==null&&T.delete(j.key===null?M:j.key),s=u(j,s,M),A===null?$=j:A.sibling=j,A=j);return t&&T.forEach(function(P){return l(r,P)}),H&&pl(r,M),$}function S(r,s,m,h){if(m==null)throw Error(z(151));for(var $=null,A=null,T=s,M=s=0,j=null,k=m.next();T!==null&&!k.done;M++,k=m.next()){T.index>M?(j=T,T=null):j=T.sibling;var P=d(r,T,k.value,h);if(P===null){T===null&&(T=j);break}t&&T&&P.alternate===null&&l(r,T),s=u(P,s,M),A===null?$=P:A.sibling=P,A=P,T=j}if(k.done)return e(r,T),H&&pl(r,M),$;if(T===null){for(;!k.done;M++,k=m.next())k=v(r,k.value,h),k!==null&&(s=u(k,s,M),A===null?$=k:A.sibling=k,A=k);return H&&pl(r,M),$}for(T=a(T);!k.done;M++,k=m.next())k=g(T,r,M,k.value,h),k!==null&&(t&&k.alternate!==null&&T.delete(k.key===null?M:k.key),s=u(k,s,M),A===null?$=k:A.sibling=k,A=k);return t&&T.forEach(function(et){return l(r,et)}),H&&pl(r,M),$}function E(r,s,m,h){if(typeof m=="object"&&m!==null&&m.type===Ze&&m.key===null&&(m=m.props.children),typeof m=="object"&&m!==null){switch(m.$$typeof){case Nn:t:{for(var $=m.key;s!==null;){if(s.key===$){if($=m.type,$===Ze){if(s.tag===7){e(r,s.sibling),h=n(s,m.props.children),h.return=r,r=h;break t}}else if(s.elementType===$||typeof $=="object"&&$!==null&&$.$$typeof===wl&&ge($)===s.type){e(r,s.sibling),h=n(s,m.props),Oa(h,m),h.return=r,r=h;break t}e(r,s);break}else l(r,s);s=s.sibling}m.type===Ze?(h=pe(m.props.children,r.mode,h,m.key),h.return=r,r=h):(h=tu(m.type,m.key,m.props,null,r.mode,h),Oa(h,m),h.return=r,r=h)}return i(r);case wa:t:{for($=m.key;s!==null;){if(s.key===$)if(s.tag===4&&s.stateNode.containerInfo===m.containerInfo&&s.stateNode.implementation===m.implementation){e(r,s.sibling),h=n(s,m.children||[]),h.return=r,r=h;break t}else{e(r,s);break}else l(r,s);s=s.sibling}h=zi(m,r.mode,h),h.return=r,r=h}return i(r);case wl:return m=ge(m),E(r,s,m,h)}if(Ra(m))return x(r,s,m,h);if(Aa(m)){if($=Aa(m),typeof $!="function")throw Error(z(150));return m=$.call(m),S(r,s,m,h)}if(typeof m.then=="function")return E(r,s,Bn(m),h);if(m.$$typeof===Sl)return E(r,s,Hn(r,m),h);Xn(r,m)}return typeof m=="string"&&m!==""||typeof m=="number"||typeof m=="bigint"?(m=""+m,s!==null&&s.tag===6?(e(r,s.sibling),h=n(s,m),h.return=r,r=h):(e(r,s),h=Si(m,r.mode,h),h.return=r,r=h),i(r)):e(r,s)}return function(r,s,m,h){try{rn=0;var $=E(r,s,m,h);return ua=null,$}catch(T){if(T===Ea||T===Iu)throw T;var A=Ut(29,T,null,r.mode);return A.lanes=h,A.return=r,A}finally{}}}var $e=td(!0),ld=td(!1),Rl=!1;function zf(t){t.updateQueue={baseState:t.memoizedState,firstBaseUpdate:null,lastBaseUpdate:null,shared:{pending:null,lanes:0,hiddenCallbacks:null},callbacks:null}}function zc(t,l){t=t.updateQueue,l.updateQueue===t&&(l.updateQueue={baseState:t.baseState,firstBaseUpdate:t.firstBaseUpdate,lastBaseUpdate:t.lastBaseUpdate,shared:t.shared,callbacks:null})}function Wl(t){return{lane:t,tag:0,payload:null,callback:null,next:null}}function Fl(t,l,e){var a=t.updateQueue;if(a===null)return null;if(a=a.shared,B&2){var n=a.pending;return n===null?l.next=l:(l.next=n.next,n.next=l),a.pending=l,l=pu(t),Qr(t,null,e),l}return Fu(t,a,l,e),pu(t)}function Ja(t,l,e){if(l=l.updateQueue,l!==null&&(l=l.shared,(e&4194048)!==0)){var a=l.lanes;a&=t.pendingLanes,e|=a,l.lanes=e,pr(t,e)}}function Ti(t,l){var e=t.updateQueue,a=t.alternate;if(a!==null&&(a=a.updateQueue,e===a)){var n=null,u=null;if(e=e.firstBaseUpdate,e!==null){do{var i={lane:e.lane,tag:e.tag,payload:e.payload,callback:null,next:null};u===null?n=u=i:u=u.next=i,e=e.next}while(e!==null);u===null?n=u=l:u=u.next=l}else n=u=l;e={baseState:a.baseState,firstBaseUpdate:n,lastBaseUpdate:u,shared:a.shared,callbacks:a.callbacks},t.updateQueue=e;return}t=e.lastBaseUpdate,t===null?e.firstBaseUpdate=l:t.next=l,e.lastBaseUpdate=l}var Ec=!1;function Wa(){if(Ec){var t=na;if(t!==null)throw t}}function Fa(t,l,e,a){Ec=!1;var n=t.updateQueue;Rl=!1;var u=n.firstBaseUpdate,i=n.lastBaseUpdate,c=n.shared.pending;if(c!==null){n.shared.pending=null;var f=c,o=f.next;f.next=null,i===null?u=o:i.next=o,i=f;var y=t.alternate;y!==null&&(y=y.updateQueue,c=y.lastBaseUpdate,c!==i&&(c===null?y.firstBaseUpdate=o:c.next=o,y.lastBaseUpdate=f))}if(u!==null){var v=n.baseState;i=0,y=o=f=null,c=u;do{var d=c.lane&-536870913,g=d!==c.lane;if(g?(U&d)===d:(a&d)===d){d!==0&&d===ra&&(Ec=!0),y!==null&&(y=y.next={lane:0,tag:c.tag,payload:c.payload,callback:null,next:null});t:{var x=t,S=c;d=l;var E=e;switch(S.tag){case 1:if(x=S.payload,typeof x=="function"){v=x.call(E,v,d);break t}v=x;break t;case 3:x.flags=x.flags&-65537|128;case 0:if(x=S.payload,d=typeof x=="function"?x.call(E,v,d):x,d==null)break t;v=I({},v,d);break t;case 2:Rl=!0}}d=c.callback,d!==null&&(t.flags|=64,g&&(t.flags|=8192),g=n.callbacks,g===null?n.callbacks=[d]:g.push(d))}else g={lane:d,tag:c.tag,payload:c.payload,callback:c.callback,next:null},y===null?(o=y=g,f=v):y=y.next=g,i|=d;if(c=c.next,c===null){if(c=n.shared.pending,c===null)break;g=c,c=g.next,g.next=null,n.lastBaseUpdate=g,n.shared.pending=null}}while(!0);y===null&&(f=v),n.baseState=f,n.firstBaseUpdate=o,n.lastBaseUpdate=y,u===null&&(n.shared.lanes=0),ie|=i,t.lanes=i,t.memoizedState=v}}function ed(t,l){if(typeof t!="function")throw Error(z(191,t));t.call(l)}function ad(t,l){var e=t.callbacks;if(e!==null)for(t.callbacks=null,t=0;t<e.length;t++)ed(e[t],l)}var da=rl(null),Eu=rl(0);function Us(t,l){t=Dl,K(Eu,t),K(da,l),Dl=t|l.baseLanes}function Tc(){K(Eu,Dl),K(da,da.current)}function Ef(){Dl=Eu.current,ht(da),ht(Eu)}var Yt=rl(null),Pt=null;function Bl(t){var l=t.alternate;K(ct,ct.current&1),K(Yt,t),Pt===null&&(l===null||da.current!==null||l.memoizedState!==null)&&(Pt=t)}function $c(t){K(ct,ct.current),K(Yt,t),Pt===null&&(Pt=t)}function nd(t){t.tag===22?(K(ct,ct.current),K(Yt,t),Pt===null&&(Pt=t)):Xl()}function Xl(){K(ct,ct.current),K(Yt,Yt.current)}function Rt(t){ht(Yt),Pt===t&&(Pt=null),ht(ct)}var ct=rl(0);function Tu(t){for(var l=t;l!==null;){if(l.tag===13){var e=l.memoizedState;if(e!==null&&(e=e.dehydrated,e===null||Gc(e)||Yc(e)))return l}else if(l.tag===19&&(l.memoizedProps.revealOrder==="forwards"||l.memoizedProps.revealOrder==="backwards"||l.memoizedProps.revealOrder==="unstable_legacy-backwards"||l.memoizedProps.revealOrder==="together")){if(l.flags&128)return l}else if(l.child!==null){l.child.return=l,l=l.child;continue}if(l===t)break;for(;l.sibling===null;){if(l.return===null||l.return===t)return null;l=l.return}l.sibling.return=l.return,l=l.sibling}return null}var kl=0,N=null,Y=null,st=null,$u=!1,ia=!1,je=!1,ju=0,dn=0,ca=null,am=0;function at(){throw Error(z(321))}function Tf(t,l){if(l===null)return!1;for(var e=0;e<l.length&&e<t.length;e++)if(!Gt(t[e],l[e]))return!1;return!0}function $f(t,l,e,a,n,u){return kl=u,N=l,l.memoizedState=null,l.updateQueue=null,l.lanes=0,D.H=t===null||t.memoizedState===null?qd:wf,je=!1,u=e(a,n),je=!1,ia&&(u=id(l,e,a,n)),ud(t),u}function ud(t){D.H=yn;var l=Y!==null&&Y.next!==null;if(kl=0,st=Y=N=null,$u=!1,dn=0,ca=null,l)throw Error(z(300));t===null||dt||(t=t.dependencies,t!==null&&Su(t)&&(dt=!0))}function id(t,l,e,a){N=t;var n=0;do{if(ia&&(ca=null),dn=0,ia=!1,25<=n)throw Error(z(301));if(n+=1,st=Y=null,t.updateQueue!=null){var u=t.updateQueue;u.lastEffect=null,u.events=null,u.stores=null,u.memoCache!=null&&(u.memoCache.index=0)}D.H=wd,u=l(e,a)}while(ia);return u}function nm(){var t=D.H,l=t.useState()[0];return l=typeof l.then=="function"?jn(l):l,t=t.useState()[0],(Y!==null?Y.memoizedState:null)!==t&&(N.flags|=1024),l}function jf(){var t=ju!==0;return ju=0,t}function Af(t,l,e){l.updateQueue=t.updateQueue,l.flags&=-2053,t.lanes&=~e}function kf(t){if($u){for(t=t.memoizedState;t!==null;){var l=t.queue;l!==null&&(l.pending=null),t=t.next}$u=!1}kl=0,st=Y=N=null,ia=!1,dn=ju=0,ca=null}function $t(){var t={memoizedState:null,baseState:null,baseQueue:null,queue:null,next:null};return st===null?N.memoizedState=st=t:st=st.next=t,st}function ft(){if(Y===null){var t=N.alternate;t=t!==null?t.memoizedState:null}else t=Y.next;var l=st===null?N.memoizedState:st.next;if(l!==null)st=l,Y=t;else{if(t===null)throw N.alternate===null?Error(z(467)):Error(z(310));Y=t,t={memoizedState:Y.memoizedState,baseState:Y.baseState,baseQueue:Y.baseQueue,queue:Y.queue,next:null},st===null?N.memoizedState=st=t:st=st.next=t}return st}function Pu(){return{lastEffect:null,events:null,stores:null,memoCache:null}}function jn(t){var l=dn;return dn+=1,ca===null&&(ca=[]),t=Pr(ca,t,l),l=N,(st===null?l.memoizedState:st.next)===null&&(l=l.alternate,D.H=l===null||l.memoizedState===null?qd:wf),t}function ti(t){if(t!==null&&typeof t=="object"){if(typeof t.then=="function")return jn(t);if(t.$$typeof===Sl)return zt(t)}throw Error(z(438,String(t)))}function Mf(t){var l=null,e=N.updateQueue;if(e!==null&&(l=e.memoCache),l==null){var a=N.alternate;a!==null&&(a=a.updateQueue,a!==null&&(a=a.memoCache,a!=null&&(l={data:a.data.map(function(n){return n.slice()}),index:0})))}if(l==null&&(l={data:[],index:0}),e===null&&(e=Pu(),N.updateQueue=e),e.memoCache=l,e=l.data[l.index],e===void 0)for(e=l.data[l.index]=Array(t),a=0;a<t;a++)e[a]=Z0;return l.index++,e}function Ml(t,l){return typeof l=="function"?l(t):l}function eu(t){var l=ft();return Of(l,Y,t)}function Of(t,l,e){var a=t.queue;if(a===null)throw Error(z(311));a.lastRenderedReducer=e;var n=t.baseQueue,u=a.pending;if(u!==null){if(n!==null){var i=n.next;n.next=u.next,u.next=i}l.baseQueue=n=u,a.pending=null}if(u=t.baseState,n===null)t.memoizedState=u;else{l=n.next;var c=i=null,f=null,o=l,y=!1;do{var v=o.lane&-536870913;if(v!==o.lane?(U&v)===v:(kl&v)===v){var d=o.revertLane;if(d===0)f!==null&&(f=f.next={lane:0,revertLane:0,gesture:null,action:o.action,hasEagerState:o.hasEagerState,eagerState:o.eagerState,next:null}),v===ra&&(y=!0);else if((kl&d)===d){o=o.next,d===ra&&(y=!0);continue}else v={lane:0,revertLane:o.revertLane,gesture:null,action:o.action,hasEagerState:o.hasEagerState,eagerState:o.eagerState,next:null},f===null?(c=f=v,i=u):f=f.next=v,N.lanes|=d,ie|=d;v=o.action,je&&e(u,v),u=o.hasEagerState?o.eagerState:e(u,v)}else d={lane:v,revertLane:o.revertLane,gesture:o.gesture,action:o.action,hasEagerState:o.hasEagerState,eagerState:o.eagerState,next:null},f===null?(c=f=d,i=u):f=f.next=d,N.lanes|=v,ie|=v;o=o.next}while(o!==null&&o!==l);if(f===null?i=u:f.next=c,!Gt(u,t.memoizedState)&&(dt=!0,y&&(e=na,e!==null)))throw e;t.memoizedState=u,t.baseState=i,t.baseQueue=f,a.lastRenderedState=u}return n===null&&(a.lanes=0),[t.memoizedState,a.dispatch]}function $i(t){var l=ft(),e=l.queue;if(e===null)throw Error(z(311));e.lastRenderedReducer=t;var a=e.dispatch,n=e.pending,u=l.memoizedState;if(n!==null){e.pending=null;var i=n=n.next;do u=t(u,i.action),i=i.next;while(i!==n);Gt(u,l.memoizedState)||(dt=!0),l.memoizedState=u,l.baseQueue===null&&(l.baseState=u),e.lastRenderedState=u}return[u,a]}function cd(t,l,e){var a=N,n=ft(),u=H;if(u){if(e===void 0)throw Error(z(407));e=e()}else e=l();var i=!Gt((Y||n).memoizedState,e);if(i&&(n.memoizedState=e,dt=!0),n=n.queue,Df(od.bind(null,a,n,t),[t]),n.getSnapshot!==l||i||st!==null&&st.memoizedState.tag&1){if(a.flags|=2048,ya(9,{destroy:void 0},sd.bind(null,a,n,e,l),null),V===null)throw Error(z(349));u||kl&127||fd(a,l,e)}return e}function fd(t,l,e){t.flags|=16384,t={getSnapshot:l,value:e},l=N.updateQueue,l===null?(l=Pu(),N.updateQueue=l,l.stores=[t]):(e=l.stores,e===null?l.stores=[t]:e.push(t))}function sd(t,l,e,a){l.value=e,l.getSnapshot=a,rd(l)&&dd(t)}function od(t,l,e){return e(function(){rd(l)&&dd(t)})}function rd(t){var l=t.getSnapshot;t=t.value;try{var e=l();return!Gt(t,e)}catch{return!0}}function dd(t){var l=De(t,2);l!==null&&Nt(l,t,2)}function jc(t){var l=$t();if(typeof t=="function"){var e=t;if(t=e(),je){Zl(!0);try{e()}finally{Zl(!1)}}}return l.memoizedState=l.baseState=t,l.queue={pending:null,lanes:0,dispatch:null,lastRenderedReducer:Ml,lastRenderedState:t},l}function yd(t,l,e,a){return t.baseState=e,Of(t,Y,typeof a=="function"?a:Ml)}function um(t,l,e,a,n){if(ei(t))throw Error(z(485));if(t=l.action,t!==null){var u={payload:n,action:t,next:null,isTransition:!0,status:"pending",value:null,reason:null,listeners:[],then:function(i){u.listeners.push(i)}};D.T!==null?e(!0):u.isTransition=!1,a(u),e=l.pending,e===null?(u.next=l.pending=u,md(l,u)):(u.next=e.next,l.pending=e.next=u)}}function md(t,l){var e=l.action,a=l.payload,n=t.state;if(l.isTransition){var u=D.T,i={};D.T=i;try{var c=e(n,a),f=D.S;f!==null&&f(i,c),Hs(t,l,c)}catch(o){Ac(t,l,o)}finally{u!==null&&i.types!==null&&(u.types=i.types),D.T=u}}else try{u=e(n,a),Hs(t,l,u)}catch(o){Ac(t,l,o)}}function Hs(t,l,e){e!==null&&typeof e=="object"&&typeof e.then=="function"?e.then(function(a){Bs(t,l,a)},function(a){return Ac(t,l,a)}):Bs(t,l,e)}function Bs(t,l,e){l.status="fulfilled",l.value=e,gd(l),t.state=e,l=t.pending,l!==null&&(e=l.next,e===l?t.pending=null:(e=e.next,l.next=e,md(t,e)))}function Ac(t,l,e){var a=t.pending;if(t.pending=null,a!==null){a=a.next;do l.status="rejected",l.reason=e,gd(l),l=l.next;while(l!==a)}t.action=null}function gd(t){t=t.listeners;for(var l=0;l<t.length;l++)(0,t[l])()}function vd(t,l){return l}function Xs(t,l){if(H){var e=V.formState;if(e!==null){t:{var a=N;if(H){if(W){l:{for(var n=W,u=It;n.nodeType!==8;){if(!u){n=null;break l}if(n=tl(n.nextSibling),n===null){n=null;break l}}u=n.data,n=u==="F!"||u==="F"?n:null}if(n){W=tl(n.nextSibling),a=n.data==="F!";break t}}ne(a)}a=!1}a&&(l=e[0])}}return e=$t(),e.memoizedState=e.baseState=l,a={pending:null,lanes:0,dispatch:null,lastRenderedReducer:vd,lastRenderedState:l},e.queue=a,e=_d.bind(null,N,a),a.dispatch=e,a=jc(!1),u=qf.bind(null,N,!1,a.queue),a=$t(),n={state:l,dispatch:null,action:t,pending:null},a.queue=n,e=um.bind(null,N,n,u,e),n.dispatch=e,a.memoizedState=t,[l,e,!1]}function Ls(t){var l=ft();return hd(l,Y,t)}function hd(t,l,e){if(l=Of(t,l,vd)[0],t=eu(Ml)[0],typeof l=="object"&&l!==null&&typeof l.then=="function")try{var a=jn(l)}catch(i){throw i===Ea?Iu:i}else a=l;l=ft();var n=l.queue,u=n.dispatch;return e!==l.memoizedState&&(N.flags|=2048,ya(9,{destroy:void 0},im.bind(null,n,e),null)),[a,u,t]}function im(t,l){t.action=l}function Zs(t){var l=ft(),e=Y;if(e!==null)return hd(l,e,t);ft(),l=l.memoizedState,e=ft();var a=e.queue.dispatch;return e.memoizedState=t,[l,a,!1]}function ya(t,l,e,a){return t={tag:t,create:e,deps:a,inst:l,next:null},l=N.updateQueue,l===null&&(l=Pu(),N.updateQueue=l),e=l.lastEffect,e===null?l.lastEffect=t.next=t:(a=e.next,e.next=t,t.next=a,l.lastEffect=t),t}function xd(){return ft().memoizedState}function au(t,l,e,a){var n=$t();N.flags|=t,n.memoizedState=ya(1|l,{destroy:void 0},e,a===void 0?null:a)}function li(t,l,e,a){var n=ft();a=a===void 0?null:a;var u=n.memoizedState.inst;Y!==null&&a!==null&&Tf(a,Y.memoizedState.deps)?n.memoizedState=ya(l,u,e,a):(N.flags|=t,n.memoizedState=ya(1|l,u,e,a))}function Gs(t,l){au(8390656,8,t,l)}function Df(t,l){li(2048,8,t,l)}function cm(t){N.flags|=4;var l=N.updateQueue;if(l===null)l=Pu(),N.updateQueue=l,l.events=[t];else{var e=l.events;e===null?l.events=[t]:e.push(t)}}function pd(t){var l=ft().memoizedState;return cm({ref:l,nextImpl:t}),function(){if(B&2)throw Error(z(440));return l.impl.apply(void 0,arguments)}}function bd(t,l){return li(4,2,t,l)}function Sd(t,l){return li(4,4,t,l)}function zd(t,l){if(typeof l=="function"){t=t();var e=l(t);return function(){typeof e=="function"?e():l(null)}}if(l!=null)return t=t(),l.current=t,function(){l.current=null}}function Ed(t,l,e){e=e!=null?e.concat([t]):null,li(4,4,zd.bind(null,l,t),e)}function _f(){}function Td(t,l){var e=ft();l=l===void 0?null:l;var a=e.memoizedState;return l!==null&&Tf(l,a[1])?a[0]:(e.memoizedState=[t,l],t)}function $d(t,l){var e=ft();l=l===void 0?null:l;var a=e.memoizedState;if(l!==null&&Tf(l,a[1]))return a[0];if(a=t(),je){Zl(!0);try{t()}finally{Zl(!1)}}return e.memoizedState=[a,l],a}function Nf(t,l,e){return e===void 0||kl&1073741824&&!(U&261930)?t.memoizedState=l:(t.memoizedState=e,t=y1(),N.lanes|=t,ie|=t,e)}function jd(t,l,e,a){return Gt(e,l)?e:da.current!==null?(t=Nf(t,e,a),Gt(t,l)||(dt=!0),t):!(kl&42)||kl&1073741824&&!(U&261930)?(dt=!0,t.memoizedState=e):(t=y1(),N.lanes|=t,ie|=t,l)}function Ad(t,l,e,a,n){var u=X.p;X.p=u!==0&&8>u?u:8;var i=D.T,c={};D.T=c,qf(t,!1,l,e);try{var f=n(),o=D.S;if(o!==null&&o(c,f),f!==null&&typeof f=="object"&&typeof f.then=="function"){var y=em(f,a);Ia(t,l,y,Zt(t))}else Ia(t,l,a,Zt(t))}catch(v){Ia(t,l,{then:function(){},status:"rejected",reason:v},Zt())}finally{X.p=u,i!==null&&c.types!==null&&(i.types=c.types),D.T=i}}function fm(){}function kc(t,l,e,a){if(t.tag!==5)throw Error(z(476));var n=kd(t).queue;Ad(t,n,l,xe,e===null?fm:function(){return Md(t),e(a)})}function kd(t){var l=t.memoizedState;if(l!==null)return l;l={memoizedState:xe,baseState:xe,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:Ml,lastRenderedState:xe},next:null};var e={};return l.next={memoizedState:e,baseState:e,baseQueue:null,queue:{pending:null,lanes:0,dispatch:null,lastRenderedReducer:Ml,lastRenderedState:e},next:null},t.memoizedState=l,t=t.alternate,t!==null&&(t.memoizedState=l),l}function Md(t){var l=kd(t);l.next===null&&(l=t.alternate.memoizedState),Ia(t,l.next.queue,{},Zt())}function Cf(){return zt(vn)}function Od(){return ft().memoizedState}function Dd(){return ft().memoizedState}function sm(t){for(var l=t.return;l!==null;){switch(l.tag){case 24:case 3:var e=Zt();t=Wl(e);var a=Fl(l,t,e);a!==null&&(Nt(a,l,e),Ja(a,l,e)),l={cache:pf()},t.payload=l;return}l=l.return}}function om(t,l,e){var a=Zt();e={lane:a,revertLane:0,gesture:null,action:e,hasEagerState:!1,eagerState:null,next:null},ei(t)?Nd(l,e):(e=gf(t,l,e,a),e!==null&&(Nt(e,t,a),Cd(e,l,a)))}function _d(t,l,e){var a=Zt();Ia(t,l,e,a)}function Ia(t,l,e,a){var n={lane:a,revertLane:0,gesture:null,action:e,hasEagerState:!1,eagerState:null,next:null};if(ei(t))Nd(l,n);else{var u=t.alternate;if(t.lanes===0&&(u===null||u.lanes===0)&&(u=l.lastRenderedReducer,u!==null))try{var i=l.lastRenderedState,c=u(i,e);if(n.hasEagerState=!0,n.eagerState=c,Gt(c,i))return Fu(t,l,n,0),V===null&&Wu(),!1}catch{}finally{}if(e=gf(t,l,n,a),e!==null)return Nt(e,t,a),Cd(e,l,a),!0}return!1}function qf(t,l,e,a){if(a={lane:2,revertLane:Gf(),gesture:null,action:a,hasEagerState:!1,eagerState:null,next:null},ei(t)){if(l)throw Error(z(479))}else l=gf(t,e,a,2),l!==null&&Nt(l,t,2)}function ei(t){var l=t.alternate;return t===N||l!==null&&l===N}function Nd(t,l){ia=$u=!0;var e=t.pending;e===null?l.next=l:(l.next=e.next,e.next=l),t.pending=l}function Cd(t,l,e){if(e&4194048){var a=l.lanes;a&=t.pendingLanes,e|=a,l.lanes=e,pr(t,e)}}var yn={readContext:zt,use:ti,useCallback:at,useContext:at,useEffect:at,useImperativeHandle:at,useLayoutEffect:at,useInsertionEffect:at,useMemo:at,useReducer:at,useRef:at,useState:at,useDebugValue:at,useDeferredValue:at,useTransition:at,useSyncExternalStore:at,useId:at,useHostTransitionStatus:at,useFormState:at,useActionState:at,useOptimistic:at,useMemoCache:at,useCacheRefresh:at};yn.useEffectEvent=at;var qd={readContext:zt,use:ti,useCallback:function(t,l){return $t().memoizedState=[t,l===void 0?null:l],t},useContext:zt,useEffect:Gs,useImperativeHandle:function(t,l,e){e=e!=null?e.concat([t]):null,au(4194308,4,zd.bind(null,l,t),e)},useLayoutEffect:function(t,l){return au(4194308,4,t,l)},useInsertionEffect:function(t,l){au(4,2,t,l)},useMemo:function(t,l){var e=$t();l=l===void 0?null:l;var a=t();if(je){Zl(!0);try{t()}finally{Zl(!1)}}return e.memoizedState=[a,l],a},useReducer:function(t,l,e){var a=$t();if(e!==void 0){var n=e(l);if(je){Zl(!0);try{e(l)}finally{Zl(!1)}}}else n=l;return a.memoizedState=a.baseState=n,t={pending:null,lanes:0,dispatch:null,lastRenderedReducer:t,lastRenderedState:n},a.queue=t,t=t.dispatch=om.bind(null,N,t),[a.memoizedState,t]},useRef:function(t){var l=$t();return t={current:t},l.memoizedState=t},useState:function(t){t=jc(t);var l=t.queue,e=_d.bind(null,N,l);return l.dispatch=e,[t.memoizedState,e]},useDebugValue:_f,useDeferredValue:function(t,l){var e=$t();return Nf(e,t,l)},useTransition:function(){var t=jc(!1);return t=Ad.bind(null,N,t.queue,!0,!1),$t().memoizedState=t,[!1,t]},useSyncExternalStore:function(t,l,e){var a=N,n=$t();if(H){if(e===void 0)throw Error(z(407));e=e()}else{if(e=l(),V===null)throw Error(z(349));U&127||fd(a,l,e)}n.memoizedState=e;var u={value:e,getSnapshot:l};return n.queue=u,Gs(od.bind(null,a,u,t),[t]),a.flags|=2048,ya(9,{destroy:void 0},sd.bind(null,a,u,e,l),null),e},useId:function(){var t=$t(),l=V.identifierPrefix;if(H){var e=fl,a=cl;e=(a&~(1<<32-Lt(a)-1)).toString(32)+e,l="_"+l+"R_"+e,e=ju++,0<e&&(l+="H"+e.toString(32)),l+="_"}else e=am++,l="_"+l+"r_"+e.toString(32)+"_";return t.memoizedState=l},useHostTransitionStatus:Cf,useFormState:Xs,useActionState:Xs,useOptimistic:function(t){var l=$t();l.memoizedState=l.baseState=t;var e={pending:null,lanes:0,dispatch:null,lastRenderedReducer:null,lastRenderedState:null};return l.queue=e,l=qf.bind(null,N,!0,e),e.dispatch=l,[t,l]},useMemoCache:Mf,useCacheRefresh:function(){return $t().memoizedState=sm.bind(null,N)},useEffectEvent:function(t){var l=$t(),e={impl:t};return l.memoizedState=e,function(){if(B&2)throw Error(z(440));return e.impl.apply(void 0,arguments)}}},wf={readContext:zt,use:ti,useCallback:Td,useContext:zt,useEffect:Df,useImperativeHandle:Ed,useInsertionEffect:bd,useLayoutEffect:Sd,useMemo:$d,useReducer:eu,useRef:xd,useState:function(){return eu(Ml)},useDebugValue:_f,useDeferredValue:function(t,l){var e=ft();return jd(e,Y.memoizedState,t,l)},useTransition:function(){var t=eu(Ml)[0],l=ft().memoizedState;return[typeof t=="boolean"?t:jn(t),l]},useSyncExternalStore:cd,useId:Od,useHostTransitionStatus:Cf,useFormState:Ls,useActionState:Ls,useOptimistic:function(t,l){var e=ft();return yd(e,Y,t,l)},useMemoCache:Mf,useCacheRefresh:Dd};wf.useEffectEvent=pd;var wd={readContext:zt,use:ti,useCallback:Td,useContext:zt,useEffect:Df,useImperativeHandle:Ed,useInsertionEffect:bd,useLayoutEffect:Sd,useMemo:$d,useReducer:$i,useRef:xd,useState:function(){return $i(Ml)},useDebugValue:_f,useDeferredValue:function(t,l){var e=ft();return Y===null?Nf(e,t,l):jd(e,Y.memoizedState,t,l)},useTransition:function(){var t=$i(Ml)[0],l=ft().memoizedState;return[typeof t=="boolean"?t:jn(t),l]},useSyncExternalStore:cd,useId:Od,useHostTransitionStatus:Cf,useFormState:Zs,useActionState:Zs,useOptimistic:function(t,l){var e=ft();return Y!==null?yd(e,Y,t,l):(e.baseState=t,[t,e.queue.dispatch])},useMemoCache:Mf,useCacheRefresh:Dd};wd.useEffectEvent=pd;function ji(t,l,e,a){l=t.memoizedState,e=e(a,l),e=e==null?l:I({},l,e),t.memoizedState=e,t.lanes===0&&(t.updateQueue.baseState=e)}var Mc={enqueueSetState:function(t,l,e){t=t._reactInternals;var a=Zt(),n=Wl(a);n.payload=l,e!=null&&(n.callback=e),l=Fl(t,n,a),l!==null&&(Nt(l,t,a),Ja(l,t,a))},enqueueReplaceState:function(t,l,e){t=t._reactInternals;var a=Zt(),n=Wl(a);n.tag=1,n.payload=l,e!=null&&(n.callback=e),l=Fl(t,n,a),l!==null&&(Nt(l,t,a),Ja(l,t,a))},enqueueForceUpdate:function(t,l){t=t._reactInternals;var e=Zt(),a=Wl(e);a.tag=2,l!=null&&(a.callback=l),l=Fl(t,a,e),l!==null&&(Nt(l,t,e),Ja(l,t,e))}};function Ys(t,l,e,a,n,u,i){return t=t.stateNode,typeof t.shouldComponentUpdate=="function"?t.shouldComponentUpdate(a,u,i):l.prototype&&l.prototype.isPureReactComponent?!fn(e,a)||!fn(n,u):!0}function Qs(t,l,e,a){t=l.state,typeof l.componentWillReceiveProps=="function"&&l.componentWillReceiveProps(e,a),typeof l.UNSAFE_componentWillReceiveProps=="function"&&l.UNSAFE_componentWillReceiveProps(e,a),l.state!==t&&Mc.enqueueReplaceState(l,l.state,null)}function Ae(t,l){var e=l;if("ref"in l){e={};for(var a in l)a!=="ref"&&(e[a]=l[a])}if(t=t.defaultProps){e===l&&(e=I({},e));for(var n in t)e[n]===void 0&&(e[n]=t[n])}return e}function Rd(t){xu(t)}function Ud(t){console.error(t)}function Hd(t){xu(t)}function Au(t,l){try{var e=t.onUncaughtError;e(l.value,{componentStack:l.stack})}catch(a){setTimeout(function(){throw a})}}function Vs(t,l,e){try{var a=t.onCaughtError;a(e.value,{componentStack:e.stack,errorBoundary:l.tag===1?l.stateNode:null})}catch(n){setTimeout(function(){throw n})}}function Oc(t,l,e){return e=Wl(e),e.tag=3,e.payload={element:null},e.callback=function(){Au(t,l)},e}function Bd(t){return t=Wl(t),t.tag=3,t}function Xd(t,l,e,a){var n=e.type.getDerivedStateFromError;if(typeof n=="function"){var u=a.value;t.payload=function(){return n(u)},t.callback=function(){Vs(l,e,a)}}var i=e.stateNode;i!==null&&typeof i.componentDidCatch=="function"&&(t.callback=function(){Vs(l,e,a),typeof n!="function"&&(Il===null?Il=new Set([this]):Il.add(this));var c=a.stack;this.componentDidCatch(a.value,{componentStack:c!==null?c:""})})}function rm(t,l,e,a,n){if(e.flags|=32768,a!==null&&typeof a=="object"&&typeof a.then=="function"){if(l=e.alternate,l!==null&&za(l,e,n,!0),e=Yt.current,e!==null){switch(e.tag){case 31:case 13:return Pt===null?_u():e.alternate===null&&nt===0&&(nt=3),e.flags&=-257,e.flags|=65536,e.lanes=n,a===zu?e.flags|=16384:(l=e.updateQueue,l===null?e.updateQueue=new Set([a]):l.add(a),Ri(t,a,n)),!1;case 22:return e.flags|=65536,a===zu?e.flags|=16384:(l=e.updateQueue,l===null?(l={transitions:null,markerInstances:null,retryQueue:new Set([a])},e.updateQueue=l):(e=l.retryQueue,e===null?l.retryQueue=new Set([a]):e.add(a)),Ri(t,a,n)),!1}throw Error(z(435,e.tag))}return Ri(t,a,n),_u(),!1}if(H)return l=Yt.current,l!==null?(!(l.flags&65536)&&(l.flags|=256),l.flags|=65536,l.lanes=n,a!==hc&&(t=Error(z(422),{cause:a}),on(Ft(t,e)))):(a!==hc&&(l=Error(z(423),{cause:a}),on(Ft(l,e))),t=t.current.alternate,t.flags|=65536,n&=-n,t.lanes|=n,a=Ft(a,e),n=Oc(t.stateNode,a,n),Ti(t,n),nt!==4&&(nt=2)),!1;var u=Error(z(520),{cause:a});if(u=Ft(u,e),ln===null?ln=[u]:ln.push(u),nt!==4&&(nt=2),l===null)return!0;a=Ft(a,e),e=l;do{switch(e.tag){case 3:return e.flags|=65536,t=n&-n,e.lanes|=t,t=Oc(e.stateNode,a,t),Ti(e,t),!1;case 1:if(l=e.type,u=e.stateNode,(e.flags&128)===0&&(typeof l.getDerivedStateFromError=="function"||u!==null&&typeof u.componentDidCatch=="function"&&(Il===null||!Il.has(u))))return e.flags|=65536,n&=-n,e.lanes|=n,n=Bd(n),Xd(n,t,e,a),Ti(e,n),!1}e=e.return}while(e!==null);return!1}var Rf=Error(z(461)),dt=!1;function pt(t,l,e,a){l.child=t===null?ld(l,null,e,a):$e(l,t.child,e,a)}function Ks(t,l,e,a,n){e=e.render;var u=l.ref;if("ref"in a){var i={};for(var c in a)c!=="ref"&&(i[c]=a[c])}else i=a;return Te(l),a=$f(t,l,e,i,u,n),c=jf(),t!==null&&!dt?(Af(t,l,n),Ol(t,l,n)):(H&&c&&hf(l),l.flags|=1,pt(t,l,a,n),l.child)}function Js(t,l,e,a,n){if(t===null){var u=e.type;return typeof u=="function"&&!vf(u)&&u.defaultProps===void 0&&e.compare===null?(l.tag=15,l.type=u,Ld(t,l,u,a,n)):(t=tu(e.type,null,a,l,l.mode,n),t.ref=l.ref,t.return=l,l.child=t)}if(u=t.child,!Uf(t,n)){var i=u.memoizedProps;if(e=e.compare,e=e!==null?e:fn,e(i,a)&&t.ref===l.ref)return Ol(t,l,n)}return l.flags|=1,t=Tl(u,a),t.ref=l.ref,t.return=l,l.child=t}function Ld(t,l,e,a,n){if(t!==null){var u=t.memoizedProps;if(fn(u,a)&&t.ref===l.ref)if(dt=!1,l.pendingProps=a=u,Uf(t,n))t.flags&131072&&(dt=!0);else return l.lanes=t.lanes,Ol(t,l,n)}return Dc(t,l,e,a,n)}function Zd(t,l,e,a){var n=a.children,u=t!==null?t.memoizedState:null;if(t===null&&l.stateNode===null&&(l.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),a.mode==="hidden"){if(l.flags&128){if(u=u!==null?u.baseLanes|e:e,t!==null){for(a=l.child=t.child,n=0;a!==null;)n=n|a.lanes|a.childLanes,a=a.sibling;a=n&~u}else a=0,l.child=null;return Ws(t,l,u,e,a)}if(e&536870912)l.memoizedState={baseLanes:0,cachePool:null},t!==null&&lu(l,u!==null?u.cachePool:null),u!==null?Us(l,u):Tc(),nd(l);else return a=l.lanes=536870912,Ws(t,l,u!==null?u.baseLanes|e:e,e,a)}else u!==null?(lu(l,u.cachePool),Us(l,u),Xl(),l.memoizedState=null):(t!==null&&lu(l,null),Tc(),Xl());return pt(t,l,n,e),l.child}function Ha(t,l){return t!==null&&t.tag===22||l.stateNode!==null||(l.stateNode={_visibility:1,_pendingMarkers:null,_retryCache:null,_transitions:null}),l.sibling}function Ws(t,l,e,a,n){var u=bf();return u=u===null?null:{parent:rt._currentValue,pool:u},l.memoizedState={baseLanes:e,cachePool:u},t!==null&&lu(l,null),Tc(),nd(l),t!==null&&za(t,l,a,!0),l.childLanes=n,null}function nu(t,l){return l=ku({mode:l.mode,children:l.children},t.mode),l.ref=t.ref,t.child=l,l.return=t,l}function Fs(t,l,e){return $e(l,t.child,null,e),t=nu(l,l.pendingProps),t.flags|=2,Rt(l),l.memoizedState=null,t}function dm(t,l,e){var a=l.pendingProps,n=(l.flags&128)!==0;if(l.flags&=-129,t===null){if(H){if(a.mode==="hidden")return t=nu(l,a),l.lanes=536870912,Ha(null,t);if($c(l),(t=W)?(t=q1(t,It),t=t!==null&&t.data==="&"?t:null,t!==null&&(l.memoizedState={dehydrated:t,treeContext:ae!==null?{id:cl,overflow:fl}:null,retryLane:536870912,hydrationErrors:null},e=Kr(t),e.return=l,l.child=e,St=l,W=null)):t=null,t===null)throw ne(l);return l.lanes=536870912,null}return nu(l,a)}var u=t.memoizedState;if(u!==null){var i=u.dehydrated;if($c(l),n)if(l.flags&256)l.flags&=-257,l=Fs(t,l,e);else if(l.memoizedState!==null)l.child=t.child,l.flags|=128,l=null;else throw Error(z(558));else if(dt||za(t,l,e,!1),n=(e&t.childLanes)!==0,dt||n){if(a=V,a!==null&&(i=br(a,e),i!==0&&i!==u.retryLane))throw u.retryLane=i,De(t,i),Nt(a,t,i),Rf;_u(),l=Fs(t,l,e)}else t=u.treeContext,W=tl(i.nextSibling),St=l,H=!0,Jl=null,It=!1,t!==null&&Wr(l,t),l=nu(l,a),l.flags|=4096;return l}return t=Tl(t.child,{mode:a.mode,children:a.children}),t.ref=l.ref,l.child=t,t.return=l,t}function uu(t,l){var e=l.ref;if(e===null)t!==null&&t.ref!==null&&(l.flags|=4194816);else{if(typeof e!="function"&&typeof e!="object")throw Error(z(284));(t===null||t.ref!==e)&&(l.flags|=4194816)}}function Dc(t,l,e,a,n){return Te(l),e=$f(t,l,e,a,void 0,n),a=jf(),t!==null&&!dt?(Af(t,l,n),Ol(t,l,n)):(H&&a&&hf(l),l.flags|=1,pt(t,l,e,n),l.child)}function Is(t,l,e,a,n,u){return Te(l),l.updateQueue=null,e=id(l,a,e,n),ud(t),a=jf(),t!==null&&!dt?(Af(t,l,u),Ol(t,l,u)):(H&&a&&hf(l),l.flags|=1,pt(t,l,e,u),l.child)}function Ps(t,l,e,a,n){if(Te(l),l.stateNode===null){var u=Fe,i=e.contextType;typeof i=="object"&&i!==null&&(u=zt(i)),u=new e(a,u),l.memoizedState=u.state!==null&&u.state!==void 0?u.state:null,u.updater=Mc,l.stateNode=u,u._reactInternals=l,u=l.stateNode,u.props=a,u.state=l.memoizedState,u.refs={},zf(l),i=e.contextType,u.context=typeof i=="object"&&i!==null?zt(i):Fe,u.state=l.memoizedState,i=e.getDerivedStateFromProps,typeof i=="function"&&(ji(l,e,i,a),u.state=l.memoizedState),typeof e.getDerivedStateFromProps=="function"||typeof u.getSnapshotBeforeUpdate=="function"||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(i=u.state,typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount(),i!==u.state&&Mc.enqueueReplaceState(u,u.state,null),Fa(l,a,u,n),Wa(),u.state=l.memoizedState),typeof u.componentDidMount=="function"&&(l.flags|=4194308),a=!0}else if(t===null){u=l.stateNode;var c=l.memoizedProps,f=Ae(e,c);u.props=f;var o=u.context,y=e.contextType;i=Fe,typeof y=="object"&&y!==null&&(i=zt(y));var v=e.getDerivedStateFromProps;y=typeof v=="function"||typeof u.getSnapshotBeforeUpdate=="function",c=l.pendingProps!==c,y||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(c||o!==i)&&Qs(l,u,a,i),Rl=!1;var d=l.memoizedState;u.state=d,Fa(l,a,u,n),Wa(),o=l.memoizedState,c||d!==o||Rl?(typeof v=="function"&&(ji(l,e,v,a),o=l.memoizedState),(f=Rl||Ys(l,e,f,a,d,o,i))?(y||typeof u.UNSAFE_componentWillMount!="function"&&typeof u.componentWillMount!="function"||(typeof u.componentWillMount=="function"&&u.componentWillMount(),typeof u.UNSAFE_componentWillMount=="function"&&u.UNSAFE_componentWillMount()),typeof u.componentDidMount=="function"&&(l.flags|=4194308)):(typeof u.componentDidMount=="function"&&(l.flags|=4194308),l.memoizedProps=a,l.memoizedState=o),u.props=a,u.state=o,u.context=i,a=f):(typeof u.componentDidMount=="function"&&(l.flags|=4194308),a=!1)}else{u=l.stateNode,zc(t,l),i=l.memoizedProps,y=Ae(e,i),u.props=y,v=l.pendingProps,d=u.context,o=e.contextType,f=Fe,typeof o=="object"&&o!==null&&(f=zt(o)),c=e.getDerivedStateFromProps,(o=typeof c=="function"||typeof u.getSnapshotBeforeUpdate=="function")||typeof u.UNSAFE_componentWillReceiveProps!="function"&&typeof u.componentWillReceiveProps!="function"||(i!==v||d!==f)&&Qs(l,u,a,f),Rl=!1,d=l.memoizedState,u.state=d,Fa(l,a,u,n),Wa();var g=l.memoizedState;i!==v||d!==g||Rl||t!==null&&t.dependencies!==null&&Su(t.dependencies)?(typeof c=="function"&&(ji(l,e,c,a),g=l.memoizedState),(y=Rl||Ys(l,e,y,a,d,g,f)||t!==null&&t.dependencies!==null&&Su(t.dependencies))?(o||typeof u.UNSAFE_componentWillUpdate!="function"&&typeof u.componentWillUpdate!="function"||(typeof u.componentWillUpdate=="function"&&u.componentWillUpdate(a,g,f),typeof u.UNSAFE_componentWillUpdate=="function"&&u.UNSAFE_componentWillUpdate(a,g,f)),typeof u.componentDidUpdate=="function"&&(l.flags|=4),typeof u.getSnapshotBeforeUpdate=="function"&&(l.flags|=1024)):(typeof u.componentDidUpdate!="function"||i===t.memoizedProps&&d===t.memoizedState||(l.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||i===t.memoizedProps&&d===t.memoizedState||(l.flags|=1024),l.memoizedProps=a,l.memoizedState=g),u.props=a,u.state=g,u.context=f,a=y):(typeof u.componentDidUpdate!="function"||i===t.memoizedProps&&d===t.memoizedState||(l.flags|=4),typeof u.getSnapshotBeforeUpdate!="function"||i===t.memoizedProps&&d===t.memoizedState||(l.flags|=1024),a=!1)}return u=a,uu(t,l),a=(l.flags&128)!==0,u||a?(u=l.stateNode,e=a&&typeof e.getDerivedStateFromError!="function"?null:u.render(),l.flags|=1,t!==null&&a?(l.child=$e(l,t.child,null,n),l.child=$e(l,null,e,n)):pt(t,l,e,n),l.memoizedState=u.state,t=l.child):t=Ol(t,l,n),t}function to(t,l,e,a){return Ee(),l.flags|=256,pt(t,l,e,a),l.child}var Ai={dehydrated:null,treeContext:null,retryLane:0,hydrationErrors:null};function ki(t){return{baseLanes:t,cachePool:Ir()}}function Mi(t,l,e){return t=t!==null?t.childLanes&~e:0,l&&(t|=Ht),t}function Gd(t,l,e){var a=l.pendingProps,n=!1,u=(l.flags&128)!==0,i;if((i=u)||(i=t!==null&&t.memoizedState===null?!1:(ct.current&2)!==0),i&&(n=!0,l.flags&=-129),i=(l.flags&32)!==0,l.flags&=-33,t===null){if(H){if(n?Bl(l):Xl(),(t=W)?(t=q1(t,It),t=t!==null&&t.data!=="&"?t:null,t!==null&&(l.memoizedState={dehydrated:t,treeContext:ae!==null?{id:cl,overflow:fl}:null,retryLane:536870912,hydrationErrors:null},e=Kr(t),e.return=l,l.child=e,St=l,W=null)):t=null,t===null)throw ne(l);return Yc(t)?l.lanes=32:l.lanes=536870912,null}var c=a.children;return a=a.fallback,n?(Xl(),n=l.mode,c=ku({mode:"hidden",children:c},n),a=pe(a,n,e,null),c.return=l,a.return=l,c.sibling=a,l.child=c,a=l.child,a.memoizedState=ki(e),a.childLanes=Mi(t,i,e),l.memoizedState=Ai,Ha(null,a)):(Bl(l),_c(l,c))}var f=t.memoizedState;if(f!==null&&(c=f.dehydrated,c!==null)){if(u)l.flags&256?(Bl(l),l.flags&=-257,l=Oi(t,l,e)):l.memoizedState!==null?(Xl(),l.child=t.child,l.flags|=128,l=null):(Xl(),c=a.fallback,n=l.mode,a=ku({mode:"visible",children:a.children},n),c=pe(c,n,e,null),c.flags|=2,a.return=l,c.return=l,a.sibling=c,l.child=a,$e(l,t.child,null,e),a=l.child,a.memoizedState=ki(e),a.childLanes=Mi(t,i,e),l.memoizedState=Ai,l=Ha(null,a));else if(Bl(l),Yc(c)){if(i=c.nextSibling&&c.nextSibling.dataset,i)var o=i.dgst;i=o,a=Error(z(419)),a.stack="",a.digest=i,on({value:a,source:null,stack:null}),l=Oi(t,l,e)}else if(dt||za(t,l,e,!1),i=(e&t.childLanes)!==0,dt||i){if(i=V,i!==null&&(a=br(i,e),a!==0&&a!==f.retryLane))throw f.retryLane=a,De(t,a),Nt(i,t,a),Rf;Gc(c)||_u(),l=Oi(t,l,e)}else Gc(c)?(l.flags|=192,l.child=t.child,l=null):(t=f.treeContext,W=tl(c.nextSibling),St=l,H=!0,Jl=null,It=!1,t!==null&&Wr(l,t),l=_c(l,a.children),l.flags|=4096);return l}return n?(Xl(),c=a.fallback,n=l.mode,f=t.child,o=f.sibling,a=Tl(f,{mode:"hidden",children:a.children}),a.subtreeFlags=f.subtreeFlags&65011712,o!==null?c=Tl(o,c):(c=pe(c,n,e,null),c.flags|=2),c.return=l,a.return=l,a.sibling=c,l.child=a,Ha(null,a),a=l.child,c=t.child.memoizedState,c===null?c=ki(e):(n=c.cachePool,n!==null?(f=rt._currentValue,n=n.parent!==f?{parent:f,pool:f}:n):n=Ir(),c={baseLanes:c.baseLanes|e,cachePool:n}),a.memoizedState=c,a.childLanes=Mi(t,i,e),l.memoizedState=Ai,Ha(t.child,a)):(Bl(l),e=t.child,t=e.sibling,e=Tl(e,{mode:"visible",children:a.children}),e.return=l,e.sibling=null,t!==null&&(i=l.deletions,i===null?(l.deletions=[t],l.flags|=16):i.push(t)),l.child=e,l.memoizedState=null,e)}function _c(t,l){return l=ku({mode:"visible",children:l},t.mode),l.return=t,t.child=l}function ku(t,l){return t=Ut(22,t,null,l),t.lanes=0,t}function Oi(t,l,e){return $e(l,t.child,null,e),t=_c(l,l.pendingProps.children),t.flags|=2,l.memoizedState=null,t}function lo(t,l,e){t.lanes|=l;var a=t.alternate;a!==null&&(a.lanes|=l),pc(t.return,l,e)}function Di(t,l,e,a,n,u){var i=t.memoizedState;i===null?t.memoizedState={isBackwards:l,rendering:null,renderingStartTime:0,last:a,tail:e,tailMode:n,treeForkCount:u}:(i.isBackwards=l,i.rendering=null,i.renderingStartTime=0,i.last=a,i.tail=e,i.tailMode=n,i.treeForkCount=u)}function Yd(t,l,e){var a=l.pendingProps,n=a.revealOrder,u=a.tail;a=a.children;var i=ct.current,c=(i&2)!==0;if(c?(i=i&1|2,l.flags|=128):i&=1,K(ct,i),pt(t,l,a,e),a=H?sn:0,!c&&t!==null&&t.flags&128)t:for(t=l.child;t!==null;){if(t.tag===13)t.memoizedState!==null&&lo(t,e,l);else if(t.tag===19)lo(t,e,l);else if(t.child!==null){t.child.return=t,t=t.child;continue}if(t===l)break t;for(;t.sibling===null;){if(t.return===null||t.return===l)break t;t=t.return}t.sibling.return=t.return,t=t.sibling}switch(n){case"forwards":for(e=l.child,n=null;e!==null;)t=e.alternate,t!==null&&Tu(t)===null&&(n=e),e=e.sibling;e=n,e===null?(n=l.child,l.child=null):(n=e.sibling,e.sibling=null),Di(l,!1,n,e,u,a);break;case"backwards":case"unstable_legacy-backwards":for(e=null,n=l.child,l.child=null;n!==null;){if(t=n.alternate,t!==null&&Tu(t)===null){l.child=n;break}t=n.sibling,n.sibling=e,e=n,n=t}Di(l,!0,e,null,u,a);break;case"together":Di(l,!1,null,null,void 0,a);break;default:l.memoizedState=null}return l.child}function Ol(t,l,e){if(t!==null&&(l.dependencies=t.dependencies),ie|=l.lanes,!(e&l.childLanes))if(t!==null){if(za(t,l,e,!1),(e&l.childLanes)===0)return null}else return null;if(t!==null&&l.child!==t.child)throw Error(z(153));if(l.child!==null){for(t=l.child,e=Tl(t,t.pendingProps),l.child=e,e.return=l;t.sibling!==null;)t=t.sibling,e=e.sibling=Tl(t,t.pendingProps),e.return=l;e.sibling=null}return l.child}function Uf(t,l){return t.lanes&l?!0:(t=t.dependencies,!!(t!==null&&Su(t)))}function ym(t,l,e){switch(l.tag){case 3:mu(l,l.stateNode.containerInfo),Hl(l,rt,t.memoizedState.cache),Ee();break;case 27:case 5:ic(l);break;case 4:mu(l,l.stateNode.containerInfo);break;case 10:Hl(l,l.type,l.memoizedProps.value);break;case 31:if(l.memoizedState!==null)return l.flags|=128,$c(l),null;break;case 13:var a=l.memoizedState;if(a!==null)return a.dehydrated!==null?(Bl(l),l.flags|=128,null):e&l.child.childLanes?Gd(t,l,e):(Bl(l),t=Ol(t,l,e),t!==null?t.sibling:null);Bl(l);break;case 19:var n=(t.flags&128)!==0;if(a=(e&l.childLanes)!==0,a||(za(t,l,e,!1),a=(e&l.childLanes)!==0),n){if(a)return Yd(t,l,e);l.flags|=128}if(n=l.memoizedState,n!==null&&(n.rendering=null,n.tail=null,n.lastEffect=null),K(ct,ct.current),a)break;return null;case 22:return l.lanes=0,Zd(t,l,e,l.pendingProps);case 24:Hl(l,rt,t.memoizedState.cache)}return Ol(t,l,e)}function Qd(t,l,e){if(t!==null)if(t.memoizedProps!==l.pendingProps)dt=!0;else{if(!Uf(t,e)&&!(l.flags&128))return dt=!1,ym(t,l,e);dt=!!(t.flags&131072)}else dt=!1,H&&l.flags&1048576&&Jr(l,sn,l.index);switch(l.lanes=0,l.tag){case 16:t:{var a=l.pendingProps;if(t=ge(l.elementType),l.type=t,typeof t=="function")vf(t)?(a=Ae(t,a),l.tag=1,l=Ps(null,l,t,a,e)):(l.tag=0,l=Dc(null,l,t,a,e));else{if(t!=null){var n=t.$$typeof;if(n===lf){l.tag=11,l=Ks(null,l,t,a,e);break t}else if(n===ef){l.tag=14,l=Js(null,l,t,a,e);break t}}throw l=nc(t)||t,Error(z(306,l,""))}}return l;case 0:return Dc(t,l,l.type,l.pendingProps,e);case 1:return a=l.type,n=Ae(a,l.pendingProps),Ps(t,l,a,n,e);case 3:t:{if(mu(l,l.stateNode.containerInfo),t===null)throw Error(z(387));a=l.pendingProps;var u=l.memoizedState;n=u.element,zc(t,l),Fa(l,a,null,e);var i=l.memoizedState;if(a=i.cache,Hl(l,rt,a),a!==u.cache&&bc(l,[rt],e,!0),Wa(),a=i.element,u.isDehydrated)if(u={element:a,isDehydrated:!1,cache:i.cache},l.updateQueue.baseState=u,l.memoizedState=u,l.flags&256){l=to(t,l,a,e);break t}else if(a!==n){n=Ft(Error(z(424)),l),on(n),l=to(t,l,a,e);break t}else{switch(t=l.stateNode.containerInfo,t.nodeType){case 9:t=t.body;break;default:t=t.nodeName==="HTML"?t.ownerDocument.body:t}for(W=tl(t.firstChild),St=l,H=!0,Jl=null,It=!0,e=ld(l,null,a,e),l.child=e;e;)e.flags=e.flags&-3|4096,e=e.sibling}else{if(Ee(),a===n){l=Ol(t,l,e);break t}pt(t,l,a,e)}l=l.child}return l;case 26:return uu(t,l),t===null?(e=zo(l.type,null,l.pendingProps,null))?l.memoizedState=e:H||(e=l.type,t=l.pendingProps,a=wu(Kl.current).createElement(e),a[bt]=l,a[Ct]=t,Et(a,e,t),vt(a),l.stateNode=a):l.memoizedState=zo(l.type,t.memoizedProps,l.pendingProps,t.memoizedState),null;case 27:return ic(l),t===null&&H&&(a=l.stateNode=w1(l.type,l.pendingProps,Kl.current),St=l,It=!0,n=W,fe(l.type)?(Qc=n,W=tl(a.firstChild)):W=n),pt(t,l,l.pendingProps.children,e),uu(t,l),t===null&&(l.flags|=4194304),l.child;case 5:return t===null&&H&&((n=a=W)&&(a=Zm(a,l.type,l.pendingProps,It),a!==null?(l.stateNode=a,St=l,W=tl(a.firstChild),It=!1,n=!0):n=!1),n||ne(l)),ic(l),n=l.type,u=l.pendingProps,i=t!==null?t.memoizedProps:null,a=u.children,Lc(n,u)?a=null:i!==null&&Lc(n,i)&&(l.flags|=32),l.memoizedState!==null&&(n=$f(t,l,nm,null,null,e),vn._currentValue=n),uu(t,l),pt(t,l,a,e),l.child;case 6:return t===null&&H&&((t=e=W)&&(e=Gm(e,l.pendingProps,It),e!==null?(l.stateNode=e,St=l,W=null,t=!0):t=!1),t||ne(l)),null;case 13:return Gd(t,l,e);case 4:return mu(l,l.stateNode.containerInfo),a=l.pendingProps,t===null?l.child=$e(l,null,a,e):pt(t,l,a,e),l.child;case 11:return Ks(t,l,l.type,l.pendingProps,e);case 7:return pt(t,l,l.pendingProps,e),l.child;case 8:return pt(t,l,l.pendingProps.children,e),l.child;case 12:return pt(t,l,l.pendingProps.children,e),l.child;case 10:return a=l.pendingProps,Hl(l,l.type,a.value),pt(t,l,a.children,e),l.child;case 9:return n=l.type._context,a=l.pendingProps.children,Te(l),n=zt(n),a=a(n),l.flags|=1,pt(t,l,a,e),l.child;case 14:return Js(t,l,l.type,l.pendingProps,e);case 15:return Ld(t,l,l.type,l.pendingProps,e);case 19:return Yd(t,l,e);case 31:return dm(t,l,e);case 22:return Zd(t,l,e,l.pendingProps);case 24:return Te(l),a=zt(rt),t===null?(n=bf(),n===null&&(n=V,u=pf(),n.pooledCache=u,u.refCount++,u!==null&&(n.pooledCacheLanes|=e),n=u),l.memoizedState={parent:a,cache:n},zf(l),Hl(l,rt,n)):(t.lanes&e&&(zc(t,l),Fa(l,null,null,e),Wa()),n=t.memoizedState,u=l.memoizedState,n.parent!==a?(n={parent:a,cache:a},l.memoizedState=n,l.lanes===0&&(l.memoizedState=l.updateQueue.baseState=n),Hl(l,rt,a)):(a=u.cache,Hl(l,rt,a),a!==n.cache&&bc(l,[rt],e,!0))),pt(t,l,l.pendingProps.children,e),l.child;case 29:throw l.pendingProps}throw Error(z(156,l.tag))}function gl(t){t.flags|=4}function _i(t,l,e,a,n){if((l=(t.mode&32)!==0)&&(l=!1),l){if(t.flags|=16777216,(n&335544128)===n)if(t.stateNode.complete)t.flags|=8192;else if(v1())t.flags|=8192;else throw Se=zu,Sf}else t.flags&=-16777217}function eo(t,l){if(l.type!=="stylesheet"||l.state.loading&4)t.flags&=-16777217;else if(t.flags|=16777216,!H1(l))if(v1())t.flags|=8192;else throw Se=zu,Sf}function Ln(t,l){l!==null&&(t.flags|=4),t.flags&16384&&(l=t.tag!==22?hr():536870912,t.lanes|=l,ma|=l)}function Da(t,l){if(!H)switch(t.tailMode){case"hidden":l=t.tail;for(var e=null;l!==null;)l.alternate!==null&&(e=l),l=l.sibling;e===null?t.tail=null:e.sibling=null;break;case"collapsed":e=t.tail;for(var a=null;e!==null;)e.alternate!==null&&(a=e),e=e.sibling;a===null?l||t.tail===null?t.tail=null:t.tail.sibling=null:a.sibling=null}}function J(t){var l=t.alternate!==null&&t.alternate.child===t.child,e=0,a=0;if(l)for(var n=t.child;n!==null;)e|=n.lanes|n.childLanes,a|=n.subtreeFlags&65011712,a|=n.flags&65011712,n.return=t,n=n.sibling;else for(n=t.child;n!==null;)e|=n.lanes|n.childLanes,a|=n.subtreeFlags,a|=n.flags,n.return=t,n=n.sibling;return t.subtreeFlags|=a,t.childLanes=e,l}function mm(t,l,e){var a=l.pendingProps;switch(xf(l),l.tag){case 16:case 15:case 0:case 11:case 7:case 8:case 12:case 9:case 14:return J(l),null;case 1:return J(l),null;case 3:return e=l.stateNode,a=null,t!==null&&(a=t.memoizedState.cache),l.memoizedState.cache!==a&&(l.flags|=2048),$l(rt),fa(),e.pendingContext&&(e.context=e.pendingContext,e.pendingContext=null),(t===null||t.child===null)&&(Ce(l)?gl(l):t===null||t.memoizedState.isDehydrated&&!(l.flags&256)||(l.flags|=1024,Ei())),J(l),null;case 26:var n=l.type,u=l.memoizedState;return t===null?(gl(l),u!==null?(J(l),eo(l,u)):(J(l),_i(l,n,null,a,e))):u?u!==t.memoizedState?(gl(l),J(l),eo(l,u)):(J(l),l.flags&=-16777217):(t=t.memoizedProps,t!==a&&gl(l),J(l),_i(l,n,t,a,e)),null;case 27:if(gu(l),e=Kl.current,n=l.type,t!==null&&l.stateNode!=null)t.memoizedProps!==a&&gl(l);else{if(!a){if(l.stateNode===null)throw Error(z(166));return J(l),null}t=ol.current,Ce(l)?Ds(l):(t=w1(n,a,e),l.stateNode=t,gl(l))}return J(l),null;case 5:if(gu(l),n=l.type,t!==null&&l.stateNode!=null)t.memoizedProps!==a&&gl(l);else{if(!a){if(l.stateNode===null)throw Error(z(166));return J(l),null}if(u=ol.current,Ce(l))Ds(l);else{var i=wu(Kl.current);switch(u){case 1:u=i.createElementNS("http://www.w3.org/2000/svg",n);break;case 2:u=i.createElementNS("http://www.w3.org/1998/Math/MathML",n);break;default:switch(n){case"svg":u=i.createElementNS("http://www.w3.org/2000/svg",n);break;case"math":u=i.createElementNS("http://www.w3.org/1998/Math/MathML",n);break;case"script":u=i.createElement("div"),u.innerHTML="<script><\/script>",u=u.removeChild(u.firstChild);break;case"select":u=typeof a.is=="string"?i.createElement("select",{is:a.is}):i.createElement("select"),a.multiple?u.multiple=!0:a.size&&(u.size=a.size);break;default:u=typeof a.is=="string"?i.createElement(n,{is:a.is}):i.createElement(n)}}u[bt]=l,u[Ct]=a;t:for(i=l.child;i!==null;){if(i.tag===5||i.tag===6)u.appendChild(i.stateNode);else if(i.tag!==4&&i.tag!==27&&i.child!==null){i.child.return=i,i=i.child;continue}if(i===l)break t;for(;i.sibling===null;){if(i.return===null||i.return===l)break t;i=i.return}i.sibling.return=i.return,i=i.sibling}l.stateNode=u;t:switch(Et(u,n,a),n){case"button":case"input":case"select":case"textarea":a=!!a.autoFocus;break t;case"img":a=!0;break t;default:a=!1}a&&gl(l)}}return J(l),_i(l,l.type,t===null?null:t.memoizedProps,l.pendingProps,e),null;case 6:if(t&&l.stateNode!=null)t.memoizedProps!==a&&gl(l);else{if(typeof a!="string"&&l.stateNode===null)throw Error(z(166));if(t=Kl.current,Ce(l)){if(t=l.stateNode,e=l.memoizedProps,a=null,n=St,n!==null)switch(n.tag){case 27:case 5:a=n.memoizedProps}t[bt]=l,t=!!(t.nodeValue===e||a!==null&&a.suppressHydrationWarning===!0||_1(t.nodeValue,e)),t||ne(l,!0)}else t=wu(t).createTextNode(a),t[bt]=l,l.stateNode=t}return J(l),null;case 31:if(e=l.memoizedState,t===null||t.memoizedState!==null){if(a=Ce(l),e!==null){if(t===null){if(!a)throw Error(z(318));if(t=l.memoizedState,t=t!==null?t.dehydrated:null,!t)throw Error(z(557));t[bt]=l}else Ee(),!(l.flags&128)&&(l.memoizedState=null),l.flags|=4;J(l),t=!1}else e=Ei(),t!==null&&t.memoizedState!==null&&(t.memoizedState.hydrationErrors=e),t=!0;if(!t)return l.flags&256?(Rt(l),l):(Rt(l),null);if(l.flags&128)throw Error(z(558))}return J(l),null;case 13:if(a=l.memoizedState,t===null||t.memoizedState!==null&&t.memoizedState.dehydrated!==null){if(n=Ce(l),a!==null&&a.dehydrated!==null){if(t===null){if(!n)throw Error(z(318));if(n=l.memoizedState,n=n!==null?n.dehydrated:null,!n)throw Error(z(317));n[bt]=l}else Ee(),!(l.flags&128)&&(l.memoizedState=null),l.flags|=4;J(l),n=!1}else n=Ei(),t!==null&&t.memoizedState!==null&&(t.memoizedState.hydrationErrors=n),n=!0;if(!n)return l.flags&256?(Rt(l),l):(Rt(l),null)}return Rt(l),l.flags&128?(l.lanes=e,l):(e=a!==null,t=t!==null&&t.memoizedState!==null,e&&(a=l.child,n=null,a.alternate!==null&&a.alternate.memoizedState!==null&&a.alternate.memoizedState.cachePool!==null&&(n=a.alternate.memoizedState.cachePool.pool),u=null,a.memoizedState!==null&&a.memoizedState.cachePool!==null&&(u=a.memoizedState.cachePool.pool),u!==n&&(a.flags|=2048)),e!==t&&e&&(l.child.flags|=8192),Ln(l,l.updateQueue),J(l),null);case 4:return fa(),t===null&&Yf(l.stateNode.containerInfo),J(l),null;case 10:return $l(l.type),J(l),null;case 19:if(ht(ct),a=l.memoizedState,a===null)return J(l),null;if(n=(l.flags&128)!==0,u=a.rendering,u===null)if(n)Da(a,!1);else{if(nt!==0||t!==null&&t.flags&128)for(t=l.child;t!==null;){if(u=Tu(t),u!==null){for(l.flags|=128,Da(a,!1),t=u.updateQueue,l.updateQueue=t,Ln(l,t),l.subtreeFlags=0,t=e,e=l.child;e!==null;)Vr(e,t),e=e.sibling;return K(ct,ct.current&1|2),H&&pl(l,a.treeForkCount),l.child}t=t.sibling}a.tail!==null&&Bt()>Ou&&(l.flags|=128,n=!0,Da(a,!1),l.lanes=4194304)}else{if(!n)if(t=Tu(u),t!==null){if(l.flags|=128,n=!0,t=t.updateQueue,l.updateQueue=t,Ln(l,t),Da(a,!0),a.tail===null&&a.tailMode==="hidden"&&!u.alternate&&!H)return J(l),null}else 2*Bt()-a.renderingStartTime>Ou&&e!==536870912&&(l.flags|=128,n=!0,Da(a,!1),l.lanes=4194304);a.isBackwards?(u.sibling=l.child,l.child=u):(t=a.last,t!==null?t.sibling=u:l.child=u,a.last=u)}return a.tail!==null?(t=a.tail,a.rendering=t,a.tail=t.sibling,a.renderingStartTime=Bt(),t.sibling=null,e=ct.current,K(ct,n?e&1|2:e&1),H&&pl(l,a.treeForkCount),t):(J(l),null);case 22:case 23:return Rt(l),Ef(),a=l.memoizedState!==null,t!==null?t.memoizedState!==null!==a&&(l.flags|=8192):a&&(l.flags|=8192),a?e&536870912&&!(l.flags&128)&&(J(l),l.subtreeFlags&6&&(l.flags|=8192)):J(l),e=l.updateQueue,e!==null&&Ln(l,e.retryQueue),e=null,t!==null&&t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(e=t.memoizedState.cachePool.pool),a=null,l.memoizedState!==null&&l.memoizedState.cachePool!==null&&(a=l.memoizedState.cachePool.pool),a!==e&&(l.flags|=2048),t!==null&&ht(be),null;case 24:return e=null,t!==null&&(e=t.memoizedState.cache),l.memoizedState.cache!==e&&(l.flags|=2048),$l(rt),J(l),null;case 25:return null;case 30:return null}throw Error(z(156,l.tag))}function gm(t,l){switch(xf(l),l.tag){case 1:return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 3:return $l(rt),fa(),t=l.flags,t&65536&&!(t&128)?(l.flags=t&-65537|128,l):null;case 26:case 27:case 5:return gu(l),null;case 31:if(l.memoizedState!==null){if(Rt(l),l.alternate===null)throw Error(z(340));Ee()}return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 13:if(Rt(l),t=l.memoizedState,t!==null&&t.dehydrated!==null){if(l.alternate===null)throw Error(z(340));Ee()}return t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 19:return ht(ct),null;case 4:return fa(),null;case 10:return $l(l.type),null;case 22:case 23:return Rt(l),Ef(),t!==null&&ht(be),t=l.flags,t&65536?(l.flags=t&-65537|128,l):null;case 24:return $l(rt),null;case 25:return null;default:return null}}function Vd(t,l){switch(xf(l),l.tag){case 3:$l(rt),fa();break;case 26:case 27:case 5:gu(l);break;case 4:fa();break;case 31:l.memoizedState!==null&&Rt(l);break;case 13:Rt(l);break;case 19:ht(ct);break;case 10:$l(l.type);break;case 22:case 23:Rt(l),Ef(),t!==null&&ht(be);break;case 24:$l(rt)}}function An(t,l){try{var e=l.updateQueue,a=e!==null?e.lastEffect:null;if(a!==null){var n=a.next;e=n;do{if((e.tag&t)===t){a=void 0;var u=e.create,i=e.inst;a=u(),i.destroy=a}e=e.next}while(e!==n)}}catch(c){Z(l,l.return,c)}}function ue(t,l,e){try{var a=l.updateQueue,n=a!==null?a.lastEffect:null;if(n!==null){var u=n.next;a=u;do{if((a.tag&t)===t){var i=a.inst,c=i.destroy;if(c!==void 0){i.destroy=void 0,n=l;var f=e,o=c;try{o()}catch(y){Z(n,f,y)}}}a=a.next}while(a!==u)}}catch(y){Z(l,l.return,y)}}function Kd(t){var l=t.updateQueue;if(l!==null){var e=t.stateNode;try{ad(l,e)}catch(a){Z(t,t.return,a)}}}function Jd(t,l,e){e.props=Ae(t.type,t.memoizedProps),e.state=t.memoizedState;try{e.componentWillUnmount()}catch(a){Z(t,l,a)}}function Pa(t,l){try{var e=t.ref;if(e!==null){switch(t.tag){case 26:case 27:case 5:var a=t.stateNode;break;case 30:a=t.stateNode;break;default:a=t.stateNode}typeof e=="function"?t.refCleanup=e(a):e.current=a}}catch(n){Z(t,l,n)}}function sl(t,l){var e=t.ref,a=t.refCleanup;if(e!==null)if(typeof a=="function")try{a()}catch(n){Z(t,l,n)}finally{t.refCleanup=null,t=t.alternate,t!=null&&(t.refCleanup=null)}else if(typeof e=="function")try{e(null)}catch(n){Z(t,l,n)}else e.current=null}function Wd(t){var l=t.type,e=t.memoizedProps,a=t.stateNode;try{t:switch(l){case"button":case"input":case"select":case"textarea":e.autoFocus&&a.focus();break t;case"img":e.src?a.src=e.src:e.srcSet&&(a.srcset=e.srcSet)}}catch(n){Z(t,t.return,n)}}function Ni(t,l,e){try{var a=t.stateNode;Rm(a,t.type,e,l),a[Ct]=l}catch(n){Z(t,t.return,n)}}function Fd(t){return t.tag===5||t.tag===3||t.tag===26||t.tag===27&&fe(t.type)||t.tag===4}function Ci(t){t:for(;;){for(;t.sibling===null;){if(t.return===null||Fd(t.return))return null;t=t.return}for(t.sibling.return=t.return,t=t.sibling;t.tag!==5&&t.tag!==6&&t.tag!==18;){if(t.tag===27&&fe(t.type)||t.flags&2||t.child===null||t.tag===4)continue t;t.child.return=t,t=t.child}if(!(t.flags&2))return t.stateNode}}function Nc(t,l,e){var a=t.tag;if(a===5||a===6)t=t.stateNode,l?(e.nodeType===9?e.body:e.nodeName==="HTML"?e.ownerDocument.body:e).insertBefore(t,l):(l=e.nodeType===9?e.body:e.nodeName==="HTML"?e.ownerDocument.body:e,l.appendChild(t),e=e._reactRootContainer,e!=null||l.onclick!==null||(l.onclick=zl));else if(a!==4&&(a===27&&fe(t.type)&&(e=t.stateNode,l=null),t=t.child,t!==null))for(Nc(t,l,e),t=t.sibling;t!==null;)Nc(t,l,e),t=t.sibling}function Mu(t,l,e){var a=t.tag;if(a===5||a===6)t=t.stateNode,l?e.insertBefore(t,l):e.appendChild(t);else if(a!==4&&(a===27&&fe(t.type)&&(e=t.stateNode),t=t.child,t!==null))for(Mu(t,l,e),t=t.sibling;t!==null;)Mu(t,l,e),t=t.sibling}function Id(t){var l=t.stateNode,e=t.memoizedProps;try{for(var a=t.type,n=l.attributes;n.length;)l.removeAttributeNode(n[0]);Et(l,a,e),l[bt]=t,l[Ct]=e}catch(u){Z(t,t.return,u)}}var bl=!1,ot=!1,qi=!1,ao=typeof WeakSet=="function"?WeakSet:Set,gt=null;function vm(t,l){if(t=t.containerInfo,Bc=Bu,t=Hr(t),yf(t)){if("selectionStart"in t)var e={start:t.selectionStart,end:t.selectionEnd};else t:{e=(e=t.ownerDocument)&&e.defaultView||window;var a=e.getSelection&&e.getSelection();if(a&&a.rangeCount!==0){e=a.anchorNode;var n=a.anchorOffset,u=a.focusNode;a=a.focusOffset;try{e.nodeType,u.nodeType}catch{e=null;break t}var i=0,c=-1,f=-1,o=0,y=0,v=t,d=null;l:for(;;){for(var g;v!==e||n!==0&&v.nodeType!==3||(c=i+n),v!==u||a!==0&&v.nodeType!==3||(f=i+a),v.nodeType===3&&(i+=v.nodeValue.length),(g=v.firstChild)!==null;)d=v,v=g;for(;;){if(v===t)break l;if(d===e&&++o===n&&(c=i),d===u&&++y===a&&(f=i),(g=v.nextSibling)!==null)break;v=d,d=v.parentNode}v=g}e=c===-1||f===-1?null:{start:c,end:f}}else e=null}e=e||{start:0,end:0}}else e=null;for(Xc={focusedElem:t,selectionRange:e},Bu=!1,gt=l;gt!==null;)if(l=gt,t=l.child,(l.subtreeFlags&1028)!==0&&t!==null)t.return=l,gt=t;else for(;gt!==null;){switch(l=gt,u=l.alternate,t=l.flags,l.tag){case 0:if(t&4&&(t=l.updateQueue,t=t!==null?t.events:null,t!==null))for(e=0;e<t.length;e++)n=t[e],n.ref.impl=n.nextImpl;break;case 11:case 15:break;case 1:if(t&1024&&u!==null){t=void 0,e=l,n=u.memoizedProps,u=u.memoizedState,a=e.stateNode;try{var x=Ae(e.type,n);t=a.getSnapshotBeforeUpdate(x,u),a.__reactInternalSnapshotBeforeUpdate=t}catch(S){Z(e,e.return,S)}}break;case 3:if(t&1024){if(t=l.stateNode.containerInfo,e=t.nodeType,e===9)Zc(t);else if(e===1)switch(t.nodeName){case"HEAD":case"HTML":case"BODY":Zc(t);break;default:t.textContent=""}}break;case 5:case 26:case 27:case 6:case 4:case 17:break;default:if(t&1024)throw Error(z(163))}if(t=l.sibling,t!==null){t.return=l.return,gt=t;break}gt=l.return}}function Pd(t,l,e){var a=e.flags;switch(e.tag){case 0:case 11:case 15:hl(t,e),a&4&&An(5,e);break;case 1:if(hl(t,e),a&4)if(t=e.stateNode,l===null)try{t.componentDidMount()}catch(i){Z(e,e.return,i)}else{var n=Ae(e.type,l.memoizedProps);l=l.memoizedState;try{t.componentDidUpdate(n,l,t.__reactInternalSnapshotBeforeUpdate)}catch(i){Z(e,e.return,i)}}a&64&&Kd(e),a&512&&Pa(e,e.return);break;case 3:if(hl(t,e),a&64&&(t=e.updateQueue,t!==null)){if(l=null,e.child!==null)switch(e.child.tag){case 27:case 5:l=e.child.stateNode;break;case 1:l=e.child.stateNode}try{ad(t,l)}catch(i){Z(e,e.return,i)}}break;case 27:l===null&&a&4&&Id(e);case 26:case 5:hl(t,e),l===null&&a&4&&Wd(e),a&512&&Pa(e,e.return);break;case 12:hl(t,e);break;case 31:hl(t,e),a&4&&e1(t,e);break;case 13:hl(t,e),a&4&&a1(t,e),a&64&&(t=e.memoizedState,t!==null&&(t=t.dehydrated,t!==null&&(e=$m.bind(null,e),Ym(t,e))));break;case 22:if(a=e.memoizedState!==null||bl,!a){l=l!==null&&l.memoizedState!==null||ot,n=bl;var u=ot;bl=a,(ot=l)&&!u?xl(t,e,(e.subtreeFlags&8772)!==0):hl(t,e),bl=n,ot=u}break;case 30:break;default:hl(t,e)}}function t1(t){var l=t.alternate;l!==null&&(t.alternate=null,t1(l)),t.child=null,t.deletions=null,t.sibling=null,t.tag===5&&(l=t.stateNode,l!==null&&cf(l)),t.stateNode=null,t.return=null,t.dependencies=null,t.memoizedProps=null,t.memoizedState=null,t.pendingProps=null,t.stateNode=null,t.updateQueue=null}var tt=null,Dt=!1;function vl(t,l,e){for(e=e.child;e!==null;)l1(t,l,e),e=e.sibling}function l1(t,l,e){if(Xt&&typeof Xt.onCommitFiberUnmount=="function")try{Xt.onCommitFiberUnmount(bn,e)}catch{}switch(e.tag){case 26:ot||sl(e,l),vl(t,l,e),e.memoizedState?e.memoizedState.count--:e.stateNode&&(e=e.stateNode,e.parentNode.removeChild(e));break;case 27:ot||sl(e,l);var a=tt,n=Dt;fe(e.type)&&(tt=e.stateNode,Dt=!1),vl(t,l,e),an(e.stateNode),tt=a,Dt=n;break;case 5:ot||sl(e,l);case 6:if(a=tt,n=Dt,tt=null,vl(t,l,e),tt=a,Dt=n,tt!==null)if(Dt)try{(tt.nodeType===9?tt.body:tt.nodeName==="HTML"?tt.ownerDocument.body:tt).removeChild(e.stateNode)}catch(u){Z(e,l,u)}else try{tt.removeChild(e.stateNode)}catch(u){Z(e,l,u)}break;case 18:tt!==null&&(Dt?(t=tt,ho(t.nodeType===9?t.body:t.nodeName==="HTML"?t.ownerDocument.body:t,e.stateNode),xa(t)):ho(tt,e.stateNode));break;case 4:a=tt,n=Dt,tt=e.stateNode.containerInfo,Dt=!0,vl(t,l,e),tt=a,Dt=n;break;case 0:case 11:case 14:case 15:ue(2,e,l),ot||ue(4,e,l),vl(t,l,e);break;case 1:ot||(sl(e,l),a=e.stateNode,typeof a.componentWillUnmount=="function"&&Jd(e,l,a)),vl(t,l,e);break;case 21:vl(t,l,e);break;case 22:ot=(a=ot)||e.memoizedState!==null,vl(t,l,e),ot=a;break;default:vl(t,l,e)}}function e1(t,l){if(l.memoizedState===null&&(t=l.alternate,t!==null&&(t=t.memoizedState,t!==null))){t=t.dehydrated;try{xa(t)}catch(e){Z(l,l.return,e)}}}function a1(t,l){if(l.memoizedState===null&&(t=l.alternate,t!==null&&(t=t.memoizedState,t!==null&&(t=t.dehydrated,t!==null))))try{xa(t)}catch(e){Z(l,l.return,e)}}function hm(t){switch(t.tag){case 31:case 13:case 19:var l=t.stateNode;return l===null&&(l=t.stateNode=new ao),l;case 22:return t=t.stateNode,l=t._retryCache,l===null&&(l=t._retryCache=new ao),l;default:throw Error(z(435,t.tag))}}function Zn(t,l){var e=hm(t);l.forEach(function(a){if(!e.has(a)){e.add(a);var n=jm.bind(null,t,a);a.then(n,n)}})}function Mt(t,l){var e=l.deletions;if(e!==null)for(var a=0;a<e.length;a++){var n=e[a],u=t,i=l,c=i;t:for(;c!==null;){switch(c.tag){case 27:if(fe(c.type)){tt=c.stateNode,Dt=!1;break t}break;case 5:tt=c.stateNode,Dt=!1;break t;case 3:case 4:tt=c.stateNode.containerInfo,Dt=!0;break t}c=c.return}if(tt===null)throw Error(z(160));l1(u,i,n),tt=null,Dt=!1,u=n.alternate,u!==null&&(u.return=null),n.return=null}if(l.subtreeFlags&13886)for(l=l.child;l!==null;)n1(l,t),l=l.sibling}var al=null;function n1(t,l){var e=t.alternate,a=t.flags;switch(t.tag){case 0:case 11:case 14:case 15:Mt(l,t),Ot(t),a&4&&(ue(3,t,t.return),An(3,t),ue(5,t,t.return));break;case 1:Mt(l,t),Ot(t),a&512&&(ot||e===null||sl(e,e.return)),a&64&&bl&&(t=t.updateQueue,t!==null&&(a=t.callbacks,a!==null&&(e=t.shared.hiddenCallbacks,t.shared.hiddenCallbacks=e===null?a:e.concat(a))));break;case 26:var n=al;if(Mt(l,t),Ot(t),a&512&&(ot||e===null||sl(e,e.return)),a&4){var u=e!==null?e.memoizedState:null;if(a=t.memoizedState,e===null)if(a===null)if(t.stateNode===null){t:{a=t.type,e=t.memoizedProps,n=n.ownerDocument||n;l:switch(a){case"title":u=n.getElementsByTagName("title")[0],(!u||u[En]||u[bt]||u.namespaceURI==="http://www.w3.org/2000/svg"||u.hasAttribute("itemprop"))&&(u=n.createElement(a),n.head.insertBefore(u,n.querySelector("head > title"))),Et(u,a,e),u[bt]=t,vt(u),a=u;break t;case"link":var i=To("link","href",n).get(a+(e.href||""));if(i){for(var c=0;c<i.length;c++)if(u=i[c],u.getAttribute("href")===(e.href==null||e.href===""?null:e.href)&&u.getAttribute("rel")===(e.rel==null?null:e.rel)&&u.getAttribute("title")===(e.title==null?null:e.title)&&u.getAttribute("crossorigin")===(e.crossOrigin==null?null:e.crossOrigin)){i.splice(c,1);break l}}u=n.createElement(a),Et(u,a,e),n.head.appendChild(u);break;case"meta":if(i=To("meta","content",n).get(a+(e.content||""))){for(c=0;c<i.length;c++)if(u=i[c],u.getAttribute("content")===(e.content==null?null:""+e.content)&&u.getAttribute("name")===(e.name==null?null:e.name)&&u.getAttribute("property")===(e.property==null?null:e.property)&&u.getAttribute("http-equiv")===(e.httpEquiv==null?null:e.httpEquiv)&&u.getAttribute("charset")===(e.charSet==null?null:e.charSet)){i.splice(c,1);break l}}u=n.createElement(a),Et(u,a,e),n.head.appendChild(u);break;default:throw Error(z(468,a))}u[bt]=t,vt(u),a=u}t.stateNode=a}else $o(n,t.type,t.stateNode);else t.stateNode=Eo(n,a,t.memoizedProps);else u!==a?(u===null?e.stateNode!==null&&(e=e.stateNode,e.parentNode.removeChild(e)):u.count--,a===null?$o(n,t.type,t.stateNode):Eo(n,a,t.memoizedProps)):a===null&&t.stateNode!==null&&Ni(t,t.memoizedProps,e.memoizedProps)}break;case 27:Mt(l,t),Ot(t),a&512&&(ot||e===null||sl(e,e.return)),e!==null&&a&4&&Ni(t,t.memoizedProps,e.memoizedProps);break;case 5:if(Mt(l,t),Ot(t),a&512&&(ot||e===null||sl(e,e.return)),t.flags&32){n=t.stateNode;try{oa(n,"")}catch(x){Z(t,t.return,x)}}a&4&&t.stateNode!=null&&(n=t.memoizedProps,Ni(t,n,e!==null?e.memoizedProps:n)),a&1024&&(qi=!0);break;case 6:if(Mt(l,t),Ot(t),a&4){if(t.stateNode===null)throw Error(z(162));a=t.memoizedProps,e=t.stateNode;try{e.nodeValue=a}catch(x){Z(t,t.return,x)}}break;case 3:if(fu=null,n=al,al=Ru(l.containerInfo),Mt(l,t),al=n,Ot(t),a&4&&e!==null&&e.memoizedState.isDehydrated)try{xa(l.containerInfo)}catch(x){Z(t,t.return,x)}qi&&(qi=!1,u1(t));break;case 4:a=al,al=Ru(t.stateNode.containerInfo),Mt(l,t),Ot(t),al=a;break;case 12:Mt(l,t),Ot(t);break;case 31:Mt(l,t),Ot(t),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,Zn(t,a)));break;case 13:Mt(l,t),Ot(t),t.child.flags&8192&&t.memoizedState!==null!=(e!==null&&e.memoizedState!==null)&&(ai=Bt()),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,Zn(t,a)));break;case 22:n=t.memoizedState!==null;var f=e!==null&&e.memoizedState!==null,o=bl,y=ot;if(bl=o||n,ot=y||f,Mt(l,t),ot=y,bl=o,Ot(t),a&8192)t:for(l=t.stateNode,l._visibility=n?l._visibility&-2:l._visibility|1,n&&(e===null||f||bl||ot||ve(t)),e=null,l=t;;){if(l.tag===5||l.tag===26){if(e===null){f=e=l;try{if(u=f.stateNode,n)i=u.style,typeof i.setProperty=="function"?i.setProperty("display","none","important"):i.display="none";else{c=f.stateNode;var v=f.memoizedProps.style,d=v!=null&&v.hasOwnProperty("display")?v.display:null;c.style.display=d==null||typeof d=="boolean"?"":(""+d).trim()}}catch(x){Z(f,f.return,x)}}}else if(l.tag===6){if(e===null){f=l;try{f.stateNode.nodeValue=n?"":f.memoizedProps}catch(x){Z(f,f.return,x)}}}else if(l.tag===18){if(e===null){f=l;try{var g=f.stateNode;n?xo(g,!0):xo(f.stateNode,!1)}catch(x){Z(f,f.return,x)}}}else if((l.tag!==22&&l.tag!==23||l.memoizedState===null||l===t)&&l.child!==null){l.child.return=l,l=l.child;continue}if(l===t)break t;for(;l.sibling===null;){if(l.return===null||l.return===t)break t;e===l&&(e=null),l=l.return}e===l&&(e=null),l.sibling.return=l.return,l=l.sibling}a&4&&(a=t.updateQueue,a!==null&&(e=a.retryQueue,e!==null&&(a.retryQueue=null,Zn(t,e))));break;case 19:Mt(l,t),Ot(t),a&4&&(a=t.updateQueue,a!==null&&(t.updateQueue=null,Zn(t,a)));break;case 30:break;case 21:break;default:Mt(l,t),Ot(t)}}function Ot(t){var l=t.flags;if(l&2){try{for(var e,a=t.return;a!==null;){if(Fd(a)){e=a;break}a=a.return}if(e==null)throw Error(z(160));switch(e.tag){case 27:var n=e.stateNode,u=Ci(t);Mu(t,u,n);break;case 5:var i=e.stateNode;e.flags&32&&(oa(i,""),e.flags&=-33);var c=Ci(t);Mu(t,c,i);break;case 3:case 4:var f=e.stateNode.containerInfo,o=Ci(t);Nc(t,o,f);break;default:throw Error(z(161))}}catch(y){Z(t,t.return,y)}t.flags&=-3}l&4096&&(t.flags&=-4097)}function u1(t){if(t.subtreeFlags&1024)for(t=t.child;t!==null;){var l=t;u1(l),l.tag===5&&l.flags&1024&&l.stateNode.reset(),t=t.sibling}}function hl(t,l){if(l.subtreeFlags&8772)for(l=l.child;l!==null;)Pd(t,l.alternate,l),l=l.sibling}function ve(t){for(t=t.child;t!==null;){var l=t;switch(l.tag){case 0:case 11:case 14:case 15:ue(4,l,l.return),ve(l);break;case 1:sl(l,l.return);var e=l.stateNode;typeof e.componentWillUnmount=="function"&&Jd(l,l.return,e),ve(l);break;case 27:an(l.stateNode);case 26:case 5:sl(l,l.return),ve(l);break;case 22:l.memoizedState===null&&ve(l);break;case 30:ve(l);break;default:ve(l)}t=t.sibling}}function xl(t,l,e){for(e=e&&(l.subtreeFlags&8772)!==0,l=l.child;l!==null;){var a=l.alternate,n=t,u=l,i=u.flags;switch(u.tag){case 0:case 11:case 15:xl(n,u,e),An(4,u);break;case 1:if(xl(n,u,e),a=u,n=a.stateNode,typeof n.componentDidMount=="function")try{n.componentDidMount()}catch(o){Z(a,a.return,o)}if(a=u,n=a.updateQueue,n!==null){var c=a.stateNode;try{var f=n.shared.hiddenCallbacks;if(f!==null)for(n.shared.hiddenCallbacks=null,n=0;n<f.length;n++)ed(f[n],c)}catch(o){Z(a,a.return,o)}}e&&i&64&&Kd(u),Pa(u,u.return);break;case 27:Id(u);case 26:case 5:xl(n,u,e),e&&a===null&&i&4&&Wd(u),Pa(u,u.return);break;case 12:xl(n,u,e);break;case 31:xl(n,u,e),e&&i&4&&e1(n,u);break;case 13:xl(n,u,e),e&&i&4&&a1(n,u);break;case 22:u.memoizedState===null&&xl(n,u,e),Pa(u,u.return);break;case 30:break;default:xl(n,u,e)}l=l.sibling}}function Hf(t,l){var e=null;t!==null&&t.memoizedState!==null&&t.memoizedState.cachePool!==null&&(e=t.memoizedState.cachePool.pool),t=null,l.memoizedState!==null&&l.memoizedState.cachePool!==null&&(t=l.memoizedState.cachePool.pool),t!==e&&(t!=null&&t.refCount++,e!=null&&$n(e))}function Bf(t,l){t=null,l.alternate!==null&&(t=l.alternate.memoizedState.cache),l=l.memoizedState.cache,l!==t&&(l.refCount++,t!=null&&$n(t))}function el(t,l,e,a){if(l.subtreeFlags&10256)for(l=l.child;l!==null;)i1(t,l,e,a),l=l.sibling}function i1(t,l,e,a){var n=l.flags;switch(l.tag){case 0:case 11:case 15:el(t,l,e,a),n&2048&&An(9,l);break;case 1:el(t,l,e,a);break;case 3:el(t,l,e,a),n&2048&&(t=null,l.alternate!==null&&(t=l.alternate.memoizedState.cache),l=l.memoizedState.cache,l!==t&&(l.refCount++,t!=null&&$n(t)));break;case 12:if(n&2048){el(t,l,e,a),t=l.stateNode;try{var u=l.memoizedProps,i=u.id,c=u.onPostCommit;typeof c=="function"&&c(i,l.alternate===null?"mount":"update",t.passiveEffectDuration,-0)}catch(f){Z(l,l.return,f)}}else el(t,l,e,a);break;case 31:el(t,l,e,a);break;case 13:el(t,l,e,a);break;case 23:break;case 22:u=l.stateNode,i=l.alternate,l.memoizedState!==null?u._visibility&2?el(t,l,e,a):tn(t,l):u._visibility&2?el(t,l,e,a):(u._visibility|=2,Xe(t,l,e,a,(l.subtreeFlags&10256)!==0||!1)),n&2048&&Hf(i,l);break;case 24:el(t,l,e,a),n&2048&&Bf(l.alternate,l);break;default:el(t,l,e,a)}}function Xe(t,l,e,a,n){for(n=n&&((l.subtreeFlags&10256)!==0||!1),l=l.child;l!==null;){var u=t,i=l,c=e,f=a,o=i.flags;switch(i.tag){case 0:case 11:case 15:Xe(u,i,c,f,n),An(8,i);break;case 23:break;case 22:var y=i.stateNode;i.memoizedState!==null?y._visibility&2?Xe(u,i,c,f,n):tn(u,i):(y._visibility|=2,Xe(u,i,c,f,n)),n&&o&2048&&Hf(i.alternate,i);break;case 24:Xe(u,i,c,f,n),n&&o&2048&&Bf(i.alternate,i);break;default:Xe(u,i,c,f,n)}l=l.sibling}}function tn(t,l){if(l.subtreeFlags&10256)for(l=l.child;l!==null;){var e=t,a=l,n=a.flags;switch(a.tag){case 22:tn(e,a),n&2048&&Hf(a.alternate,a);break;case 24:tn(e,a),n&2048&&Bf(a.alternate,a);break;default:tn(e,a)}l=l.sibling}}var Ba=8192;function qe(t,l,e){if(t.subtreeFlags&Ba)for(t=t.child;t!==null;)c1(t,l,e),t=t.sibling}function c1(t,l,e){switch(t.tag){case 26:qe(t,l,e),t.flags&Ba&&t.memoizedState!==null&&ag(e,al,t.memoizedState,t.memoizedProps);break;case 5:qe(t,l,e);break;case 3:case 4:var a=al;al=Ru(t.stateNode.containerInfo),qe(t,l,e),al=a;break;case 22:t.memoizedState===null&&(a=t.alternate,a!==null&&a.memoizedState!==null?(a=Ba,Ba=16777216,qe(t,l,e),Ba=a):qe(t,l,e));break;default:qe(t,l,e)}}function f1(t){var l=t.alternate;if(l!==null&&(t=l.child,t!==null)){l.child=null;do l=t.sibling,t.sibling=null,t=l;while(t!==null)}}function _a(t){var l=t.deletions;if(t.flags&16){if(l!==null)for(var e=0;e<l.length;e++){var a=l[e];gt=a,o1(a,t)}f1(t)}if(t.subtreeFlags&10256)for(t=t.child;t!==null;)s1(t),t=t.sibling}function s1(t){switch(t.tag){case 0:case 11:case 15:_a(t),t.flags&2048&&ue(9,t,t.return);break;case 3:_a(t);break;case 12:_a(t);break;case 22:var l=t.stateNode;t.memoizedState!==null&&l._visibility&2&&(t.return===null||t.return.tag!==13)?(l._visibility&=-3,iu(t)):_a(t);break;default:_a(t)}}function iu(t){var l=t.deletions;if(t.flags&16){if(l!==null)for(var e=0;e<l.length;e++){var a=l[e];gt=a,o1(a,t)}f1(t)}for(t=t.child;t!==null;){switch(l=t,l.tag){case 0:case 11:case 15:ue(8,l,l.return),iu(l);break;case 22:e=l.stateNode,e._visibility&2&&(e._visibility&=-3,iu(l));break;default:iu(l)}t=t.sibling}}function o1(t,l){for(;gt!==null;){var e=gt;switch(e.tag){case 0:case 11:case 15:ue(8,e,l);break;case 23:case 22:if(e.memoizedState!==null&&e.memoizedState.cachePool!==null){var a=e.memoizedState.cachePool.pool;a!=null&&a.refCount++}break;case 24:$n(e.memoizedState.cache)}if(a=e.child,a!==null)a.return=e,gt=a;else t:for(e=t;gt!==null;){a=gt;var n=a.sibling,u=a.return;if(t1(a),a===e){gt=null;break t}if(n!==null){n.return=u,gt=n;break t}gt=u}}}var xm={getCacheForType:function(t){var l=zt(rt),e=l.data.get(t);return e===void 0&&(e=t(),l.data.set(t,e)),e},cacheSignal:function(){return zt(rt).controller.signal}},pm=typeof WeakMap=="function"?WeakMap:Map,B=0,V=null,R=null,U=0,L=0,wt=null,Yl=!1,Ta=!1,Xf=!1,Dl=0,nt=0,ie=0,ze=0,Lf=0,Ht=0,ma=0,ln=null,_t=null,Cc=!1,ai=0,r1=0,Ou=1/0,Du=null,Il=null,yt=0,Pl=null,ga=null,jl=0,qc=0,wc=null,d1=null,en=0,Rc=null;function Zt(){return B&2&&U!==0?U&-U:D.T!==null?Gf():Sr()}function y1(){if(Ht===0)if(!(U&536870912)||H){var t=qn;qn<<=1,!(qn&3932160)&&(qn=262144),Ht=t}else Ht=536870912;return t=Yt.current,t!==null&&(t.flags|=32),Ht}function Nt(t,l,e){(t===V&&(L===2||L===9)||t.cancelPendingCommit!==null)&&(va(t,0),Ql(t,U,Ht,!1)),zn(t,e),(!(B&2)||t!==V)&&(t===V&&(!(B&2)&&(ze|=e),nt===4&&Ql(t,U,Ht,!1)),dl(t))}function m1(t,l,e){if(B&6)throw Error(z(327));var a=!e&&(l&127)===0&&(l&t.expiredLanes)===0||Sn(t,l),n=a?zm(t,l):wi(t,l,!0),u=a;do{if(n===0){Ta&&!a&&Ql(t,l,0,!1);break}else{if(e=t.current.alternate,u&&!bm(e)){n=wi(t,l,!1),u=!1;continue}if(n===2){if(u=l,t.errorRecoveryDisabledLanes&u)var i=0;else i=t.pendingLanes&-536870913,i=i!==0?i:i&536870912?536870912:0;if(i!==0){l=i;t:{var c=t;n=ln;var f=c.current.memoizedState.isDehydrated;if(f&&(va(c,i).flags|=256),i=wi(c,i,!1),i!==2){if(Xf&&!f){c.errorRecoveryDisabledLanes|=u,ze|=u,n=4;break t}u=_t,_t=n,u!==null&&(_t===null?_t=u:_t.push.apply(_t,u))}n=i}if(u=!1,n!==2)continue}}if(n===1){va(t,0),Ql(t,l,0,!0);break}t:{switch(a=t,u=n,u){case 0:case 1:throw Error(z(345));case 4:if((l&4194048)!==l)break;case 6:Ql(a,l,Ht,!Yl);break t;case 2:_t=null;break;case 3:case 5:break;default:throw Error(z(329))}if((l&62914560)===l&&(n=ai+300-Bt(),10<n)){if(Ql(a,l,Ht,!Yl),Qu(a,0,!0)!==0)break t;jl=l,a.timeoutHandle=C1(no.bind(null,a,e,_t,Du,Cc,l,Ht,ze,ma,Yl,u,"Throttled",-0,0),n);break t}no(a,e,_t,Du,Cc,l,Ht,ze,ma,Yl,u,null,-0,0)}}break}while(!0);dl(t)}function no(t,l,e,a,n,u,i,c,f,o,y,v,d,g){if(t.timeoutHandle=-1,v=l.subtreeFlags,v&8192||(v&16785408)===16785408){v={stylesheets:null,count:0,imgCount:0,imgBytes:0,suspenseyImages:[],waitingForImages:!0,waitingForViewTransition:!1,unsuspend:zl},c1(l,u,v);var x=(u&62914560)===u?ai-Bt():(u&4194048)===u?r1-Bt():0;if(x=ng(v,x),x!==null){jl=u,t.cancelPendingCommit=x(io.bind(null,t,l,u,e,a,n,i,c,f,y,v,null,d,g)),Ql(t,u,i,!o);return}}io(t,l,u,e,a,n,i,c,f)}function bm(t){for(var l=t;;){var e=l.tag;if((e===0||e===11||e===15)&&l.flags&16384&&(e=l.updateQueue,e!==null&&(e=e.stores,e!==null)))for(var a=0;a<e.length;a++){var n=e[a],u=n.getSnapshot;n=n.value;try{if(!Gt(u(),n))return!1}catch{return!1}}if(e=l.child,l.subtreeFlags&16384&&e!==null)e.return=l,l=e;else{if(l===t)break;for(;l.sibling===null;){if(l.return===null||l.return===t)return!0;l=l.return}l.sibling.return=l.return,l=l.sibling}}return!0}function Ql(t,l,e,a){l&=~Lf,l&=~ze,t.suspendedLanes|=l,t.pingedLanes&=~l,a&&(t.warmLanes|=l),a=t.expirationTimes;for(var n=l;0<n;){var u=31-Lt(n),i=1<<u;a[u]=-1,n&=~i}e!==0&&xr(t,e,l)}function ni(){return B&6?!0:(kn(0),!1)}function Zf(){if(R!==null){if(L===0)var t=R.return;else t=R,El=_e=null,kf(t),ua=null,rn=0,t=R;for(;t!==null;)Vd(t.alternate,t),t=t.return;R=null}}function va(t,l){var e=t.timeoutHandle;e!==-1&&(t.timeoutHandle=-1,Bm(e)),e=t.cancelPendingCommit,e!==null&&(t.cancelPendingCommit=null,e()),jl=0,Zf(),V=t,R=e=Tl(t.current,null),U=l,L=0,wt=null,Yl=!1,Ta=Sn(t,l),Xf=!1,ma=Ht=Lf=ze=ie=nt=0,_t=ln=null,Cc=!1,l&8&&(l|=l&32);var a=t.entangledLanes;if(a!==0)for(t=t.entanglements,a&=l;0<a;){var n=31-Lt(a),u=1<<n;l|=t[n],a&=~u}return Dl=l,Wu(),e}function g1(t,l){N=null,D.H=yn,l===Ea||l===Iu?(l=ws(),L=3):l===Sf?(l=ws(),L=4):L=l===Rf?8:l!==null&&typeof l=="object"&&typeof l.then=="function"?6:1,wt=l,R===null&&(nt=1,Au(t,Ft(l,t.current)))}function v1(){var t=Yt.current;return t===null?!0:(U&4194048)===U?Pt===null:(U&62914560)===U||U&536870912?t===Pt:!1}function h1(){var t=D.H;return D.H=yn,t===null?yn:t}function x1(){var t=D.A;return D.A=xm,t}function _u(){nt=4,Yl||(U&4194048)!==U&&Yt.current!==null||(Ta=!0),!(ie&134217727)&&!(ze&134217727)||V===null||Ql(V,U,Ht,!1)}function wi(t,l,e){var a=B;B|=2;var n=h1(),u=x1();(V!==t||U!==l)&&(Du=null,va(t,l)),l=!1;var i=nt;t:do try{if(L!==0&&R!==null){var c=R,f=wt;switch(L){case 8:Zf(),i=6;break t;case 3:case 2:case 9:case 6:Yt.current===null&&(l=!0);var o=L;if(L=0,wt=null,ta(t,c,f,o),e&&Ta){i=0;break t}break;default:o=L,L=0,wt=null,ta(t,c,f,o)}}Sm(),i=nt;break}catch(y){g1(t,y)}while(!0);return l&&t.shellSuspendCounter++,El=_e=null,B=a,D.H=n,D.A=u,R===null&&(V=null,U=0,Wu()),i}function Sm(){for(;R!==null;)p1(R)}function zm(t,l){var e=B;B|=2;var a=h1(),n=x1();V!==t||U!==l?(Du=null,Ou=Bt()+500,va(t,l)):Ta=Sn(t,l);t:do try{if(L!==0&&R!==null){l=R;var u=wt;l:switch(L){case 1:L=0,wt=null,ta(t,l,u,1);break;case 2:case 9:if(qs(u)){L=0,wt=null,uo(l);break}l=function(){L!==2&&L!==9||V!==t||(L=7),dl(t)},u.then(l,l);break t;case 3:L=7;break t;case 4:L=5;break t;case 7:qs(u)?(L=0,wt=null,uo(l)):(L=0,wt=null,ta(t,l,u,7));break;case 5:var i=null;switch(R.tag){case 26:i=R.memoizedState;case 5:case 27:var c=R;if(i?H1(i):c.stateNode.complete){L=0,wt=null;var f=c.sibling;if(f!==null)R=f;else{var o=c.return;o!==null?(R=o,ui(o)):R=null}break l}}L=0,wt=null,ta(t,l,u,5);break;case 6:L=0,wt=null,ta(t,l,u,6);break;case 8:Zf(),nt=6;break t;default:throw Error(z(462))}}Em();break}catch(y){g1(t,y)}while(!0);return El=_e=null,D.H=a,D.A=n,B=e,R!==null?0:(V=null,U=0,Wu(),nt)}function Em(){for(;R!==null&&!Q0();)p1(R)}function p1(t){var l=Qd(t.alternate,t,Dl);t.memoizedProps=t.pendingProps,l===null?ui(t):R=l}function uo(t){var l=t,e=l.alternate;switch(l.tag){case 15:case 0:l=Is(e,l,l.pendingProps,l.type,void 0,U);break;case 11:l=Is(e,l,l.pendingProps,l.type.render,l.ref,U);break;case 5:kf(l);default:Vd(e,l),l=R=Vr(l,Dl),l=Qd(e,l,Dl)}t.memoizedProps=t.pendingProps,l===null?ui(t):R=l}function ta(t,l,e,a){El=_e=null,kf(l),ua=null,rn=0;var n=l.return;try{if(rm(t,n,l,e,U)){nt=1,Au(t,Ft(e,t.current)),R=null;return}}catch(u){if(n!==null)throw R=n,u;nt=1,Au(t,Ft(e,t.current)),R=null;return}l.flags&32768?(H||a===1?t=!0:Ta||U&536870912?t=!1:(Yl=t=!0,(a===2||a===9||a===3||a===6)&&(a=Yt.current,a!==null&&a.tag===13&&(a.flags|=16384))),b1(l,t)):ui(l)}function ui(t){var l=t;do{if(l.flags&32768){b1(l,Yl);return}t=l.return;var e=mm(l.alternate,l,Dl);if(e!==null){R=e;return}if(l=l.sibling,l!==null){R=l;return}R=l=t}while(l!==null);nt===0&&(nt=5)}function b1(t,l){do{var e=gm(t.alternate,t);if(e!==null){e.flags&=32767,R=e;return}if(e=t.return,e!==null&&(e.flags|=32768,e.subtreeFlags=0,e.deletions=null),!l&&(t=t.sibling,t!==null)){R=t;return}R=t=e}while(t!==null);nt=6,R=null}function io(t,l,e,a,n,u,i,c,f){t.cancelPendingCommit=null;do ii();while(yt!==0);if(B&6)throw Error(z(327));if(l!==null){if(l===t.current)throw Error(z(177));if(u=l.lanes|l.childLanes,u|=mf,ey(t,e,u,i,c,f),t===V&&(R=V=null,U=0),ga=l,Pl=t,jl=e,qc=u,wc=n,d1=a,l.subtreeFlags&10256||l.flags&10256?(t.callbackNode=null,t.callbackPriority=0,Am(vu,function(){return $1(),null})):(t.callbackNode=null,t.callbackPriority=0),a=(l.flags&13878)!==0,l.subtreeFlags&13878||a){a=D.T,D.T=null,n=X.p,X.p=2,i=B,B|=4;try{vm(t,l,e)}finally{B=i,X.p=n,D.T=a}}yt=1,S1(),z1(),E1()}}function S1(){if(yt===1){yt=0;var t=Pl,l=ga,e=(l.flags&13878)!==0;if(l.subtreeFlags&13878||e){e=D.T,D.T=null;var a=X.p;X.p=2;var n=B;B|=4;try{n1(l,t);var u=Xc,i=Hr(t.containerInfo),c=u.focusedElem,f=u.selectionRange;if(i!==c&&c&&c.ownerDocument&&Ur(c.ownerDocument.documentElement,c)){if(f!==null&&yf(c)){var o=f.start,y=f.end;if(y===void 0&&(y=o),"selectionStart"in c)c.selectionStart=o,c.selectionEnd=Math.min(y,c.value.length);else{var v=c.ownerDocument||document,d=v&&v.defaultView||window;if(d.getSelection){var g=d.getSelection(),x=c.textContent.length,S=Math.min(f.start,x),E=f.end===void 0?S:Math.min(f.end,x);!g.extend&&S>E&&(i=E,E=S,S=i);var r=ks(c,S),s=ks(c,E);if(r&&s&&(g.rangeCount!==1||g.anchorNode!==r.node||g.anchorOffset!==r.offset||g.focusNode!==s.node||g.focusOffset!==s.offset)){var m=v.createRange();m.setStart(r.node,r.offset),g.removeAllRanges(),S>E?(g.addRange(m),g.extend(s.node,s.offset)):(m.setEnd(s.node,s.offset),g.addRange(m))}}}}for(v=[],g=c;g=g.parentNode;)g.nodeType===1&&v.push({element:g,left:g.scrollLeft,top:g.scrollTop});for(typeof c.focus=="function"&&c.focus(),c=0;c<v.length;c++){var h=v[c];h.element.scrollLeft=h.left,h.element.scrollTop=h.top}}Bu=!!Bc,Xc=Bc=null}finally{B=n,X.p=a,D.T=e}}t.current=l,yt=2}}function z1(){if(yt===2){yt=0;var t=Pl,l=ga,e=(l.flags&8772)!==0;if(l.subtreeFlags&8772||e){e=D.T,D.T=null;var a=X.p;X.p=2;var n=B;B|=4;try{Pd(t,l.alternate,l)}finally{B=n,X.p=a,D.T=e}}yt=3}}function E1(){if(yt===4||yt===3){yt=0,V0();var t=Pl,l=ga,e=jl,a=d1;l.subtreeFlags&10256||l.flags&10256?yt=5:(yt=0,ga=Pl=null,T1(t,t.pendingLanes));var n=t.pendingLanes;if(n===0&&(Il=null),uf(e),l=l.stateNode,Xt&&typeof Xt.onCommitFiberRoot=="function")try{Xt.onCommitFiberRoot(bn,l,void 0,(l.current.flags&128)===128)}catch{}if(a!==null){l=D.T,n=X.p,X.p=2,D.T=null;try{for(var u=t.onRecoverableError,i=0;i<a.length;i++){var c=a[i];u(c.value,{componentStack:c.stack})}}finally{D.T=l,X.p=n}}jl&3&&ii(),dl(t),n=t.pendingLanes,e&261930&&n&42?t===Rc?en++:(en=0,Rc=t):en=0,kn(0)}}function T1(t,l){(t.pooledCacheLanes&=l)===0&&(l=t.pooledCache,l!=null&&(t.pooledCache=null,$n(l)))}function ii(){return S1(),z1(),E1(),$1()}function $1(){if(yt!==5)return!1;var t=Pl,l=qc;qc=0;var e=uf(jl),a=D.T,n=X.p;try{X.p=32>e?32:e,D.T=null,e=wc,wc=null;var u=Pl,i=jl;if(yt=0,ga=Pl=null,jl=0,B&6)throw Error(z(331));var c=B;if(B|=4,s1(u.current),i1(u,u.current,i,e),B=c,kn(0,!1),Xt&&typeof Xt.onPostCommitFiberRoot=="function")try{Xt.onPostCommitFiberRoot(bn,u)}catch{}return!0}finally{X.p=n,D.T=a,T1(t,l)}}function co(t,l,e){l=Ft(e,l),l=Oc(t.stateNode,l,2),t=Fl(t,l,2),t!==null&&(zn(t,2),dl(t))}function Z(t,l,e){if(t.tag===3)co(t,t,e);else for(;l!==null;){if(l.tag===3){co(l,t,e);break}else if(l.tag===1){var a=l.stateNode;if(typeof l.type.getDerivedStateFromError=="function"||typeof a.componentDidCatch=="function"&&(Il===null||!Il.has(a))){t=Ft(e,t),e=Bd(2),a=Fl(l,e,2),a!==null&&(Xd(e,a,l,t),zn(a,2),dl(a));break}}l=l.return}}function Ri(t,l,e){var a=t.pingCache;if(a===null){a=t.pingCache=new pm;var n=new Set;a.set(l,n)}else n=a.get(l),n===void 0&&(n=new Set,a.set(l,n));n.has(e)||(Xf=!0,n.add(e),t=Tm.bind(null,t,l,e),l.then(t,t))}function Tm(t,l,e){var a=t.pingCache;a!==null&&a.delete(l),t.pingedLanes|=t.suspendedLanes&e,t.warmLanes&=~e,V===t&&(U&e)===e&&(nt===4||nt===3&&(U&62914560)===U&&300>Bt()-ai?!(B&2)&&va(t,0):Lf|=e,ma===U&&(ma=0)),dl(t)}function j1(t,l){l===0&&(l=hr()),t=De(t,l),t!==null&&(zn(t,l),dl(t))}function $m(t){var l=t.memoizedState,e=0;l!==null&&(e=l.retryLane),j1(t,e)}function jm(t,l){var e=0;switch(t.tag){case 31:case 13:var a=t.stateNode,n=t.memoizedState;n!==null&&(e=n.retryLane);break;case 19:a=t.stateNode;break;case 22:a=t.stateNode._retryCache;break;default:throw Error(z(314))}a!==null&&a.delete(l),j1(t,e)}function Am(t,l){return af(t,l)}var Nu=null,Le=null,Uc=!1,Cu=!1,Ui=!1,Vl=0;function dl(t){t!==Le&&t.next===null&&(Le===null?Nu=Le=t:Le=Le.next=t),Cu=!0,Uc||(Uc=!0,Mm())}function kn(t,l){if(!Ui&&Cu){Ui=!0;do for(var e=!1,a=Nu;a!==null;){if(t!==0){var n=a.pendingLanes;if(n===0)var u=0;else{var i=a.suspendedLanes,c=a.pingedLanes;u=(1<<31-Lt(42|t)+1)-1,u&=n&~(i&~c),u=u&201326741?u&201326741|1:u?u|2:0}u!==0&&(e=!0,fo(a,u))}else u=U,u=Qu(a,a===V?u:0,a.cancelPendingCommit!==null||a.timeoutHandle!==-1),!(u&3)||Sn(a,u)||(e=!0,fo(a,u));a=a.next}while(e);Ui=!1}}function km(){A1()}function A1(){Cu=Uc=!1;var t=0;Vl!==0&&Hm()&&(t=Vl);for(var l=Bt(),e=null,a=Nu;a!==null;){var n=a.next,u=k1(a,l);u===0?(a.next=null,e===null?Nu=n:e.next=n,n===null&&(Le=e)):(e=a,(t!==0||u&3)&&(Cu=!0)),a=n}yt!==0&&yt!==5||kn(t),Vl!==0&&(Vl=0)}function k1(t,l){for(var e=t.suspendedLanes,a=t.pingedLanes,n=t.expirationTimes,u=t.pendingLanes&-62914561;0<u;){var i=31-Lt(u),c=1<<i,f=n[i];f===-1?(!(c&e)||c&a)&&(n[i]=ly(c,l)):f<=l&&(t.expiredLanes|=c),u&=~c}if(l=V,e=U,e=Qu(t,t===l?e:0,t.cancelPendingCommit!==null||t.timeoutHandle!==-1),a=t.callbackNode,e===0||t===l&&(L===2||L===9)||t.cancelPendingCommit!==null)return a!==null&&a!==null&&di(a),t.callbackNode=null,t.callbackPriority=0;if(!(e&3)||Sn(t,e)){if(l=e&-e,l===t.callbackPriority)return l;switch(a!==null&&di(a),uf(e)){case 2:case 8:e=gr;break;case 32:e=vu;break;case 268435456:e=vr;break;default:e=vu}return a=M1.bind(null,t),e=af(e,a),t.callbackPriority=l,t.callbackNode=e,l}return a!==null&&a!==null&&di(a),t.callbackPriority=2,t.callbackNode=null,2}function M1(t,l){if(yt!==0&&yt!==5)return t.callbackNode=null,t.callbackPriority=0,null;var e=t.callbackNode;if(ii()&&t.callbackNode!==e)return null;var a=U;return a=Qu(t,t===V?a:0,t.cancelPendingCommit!==null||t.timeoutHandle!==-1),a===0?null:(m1(t,a,l),k1(t,Bt()),t.callbackNode!=null&&t.callbackNode===e?M1.bind(null,t):null)}function fo(t,l){if(ii())return null;m1(t,l,!0)}function Mm(){Xm(function(){B&6?af(mr,km):A1()})}function Gf(){if(Vl===0){var t=ra;t===0&&(t=Cn,Cn<<=1,!(Cn&261888)&&(Cn=256)),Vl=t}return Vl}function so(t){return t==null||typeof t=="symbol"||typeof t=="boolean"?null:typeof t=="function"?t:Fn(""+t)}function oo(t,l){var e=l.ownerDocument.createElement("input");return e.name=l.name,e.value=l.value,t.id&&e.setAttribute("form",t.id),l.parentNode.insertBefore(e,l),t=new FormData(t),e.parentNode.removeChild(e),t}function Om(t,l,e,a,n){if(l==="submit"&&e&&e.stateNode===n){var u=so((n[Ct]||null).action),i=a.submitter;i&&(l=(l=i[Ct]||null)?so(l.formAction):i.getAttribute("formAction"),l!==null&&(u=l,i=null));var c=new Vu("action","action",null,a,n);t.push({event:c,listeners:[{instance:null,listener:function(){if(a.defaultPrevented){if(Vl!==0){var f=i?oo(n,i):new FormData(n);kc(e,{pending:!0,data:f,method:n.method,action:u},null,f)}}else typeof u=="function"&&(c.preventDefault(),f=i?oo(n,i):new FormData(n),kc(e,{pending:!0,data:f,method:n.method,action:u},u,f))},currentTarget:n}]})}}for(var Hi=0;Hi<vc.length;Hi++){var Bi=vc[Hi],Dm=Bi.toLowerCase(),_m=Bi[0].toUpperCase()+Bi.slice(1);nl(Dm,"on"+_m)}nl(Xr,"onAnimationEnd");nl(Lr,"onAnimationIteration");nl(Zr,"onAnimationStart");nl("dblclick","onDoubleClick");nl("focusin","onFocus");nl("focusout","onBlur");nl(Ky,"onTransitionRun");nl(Jy,"onTransitionStart");nl(Wy,"onTransitionCancel");nl(Gr,"onTransitionEnd");sa("onMouseEnter",["mouseout","mouseover"]);sa("onMouseLeave",["mouseout","mouseover"]);sa("onPointerEnter",["pointerout","pointerover"]);sa("onPointerLeave",["pointerout","pointerover"]);ke("onChange","change click focusin focusout input keydown keyup selectionchange".split(" "));ke("onSelect","focusout contextmenu dragend focusin keydown keyup mousedown mouseup selectionchange".split(" "));ke("onBeforeInput",["compositionend","keypress","textInput","paste"]);ke("onCompositionEnd","compositionend focusout keydown keypress keyup mousedown".split(" "));ke("onCompositionStart","compositionstart focusout keydown keypress keyup mousedown".split(" "));ke("onCompositionUpdate","compositionupdate focusout keydown keypress keyup mousedown".split(" "));var mn="abort canplay canplaythrough durationchange emptied encrypted ended error loadeddata loadedmetadata loadstart pause play playing progress ratechange resize seeked seeking stalled suspend timeupdate volumechange waiting".split(" "),Nm=new Set("beforetoggle cancel close invalid load scroll scrollend toggle".split(" ").concat(mn));function O1(t,l){l=(l&4)!==0;for(var e=0;e<t.length;e++){var a=t[e],n=a.event;a=a.listeners;t:{var u=void 0;if(l)for(var i=a.length-1;0<=i;i--){var c=a[i],f=c.instance,o=c.currentTarget;if(c=c.listener,f!==u&&n.isPropagationStopped())break t;u=c,n.currentTarget=o;try{u(n)}catch(y){xu(y)}n.currentTarget=null,u=f}else for(i=0;i<a.length;i++){if(c=a[i],f=c.instance,o=c.currentTarget,c=c.listener,f!==u&&n.isPropagationStopped())break t;u=c,n.currentTarget=o;try{u(n)}catch(y){xu(y)}n.currentTarget=null,u=f}}}}function w(t,l){var e=l[fc];e===void 0&&(e=l[fc]=new Set);var a=t+"__bubble";e.has(a)||(D1(l,t,2,!1),e.add(a))}function Xi(t,l,e){var a=0;l&&(a|=4),D1(e,t,a,l)}var Gn="_reactListening"+Math.random().toString(36).slice(2);function Yf(t){if(!t[Gn]){t[Gn]=!0,zr.forEach(function(e){e!=="selectionchange"&&(Nm.has(e)||Xi(e,!1,t),Xi(e,!0,t))});var l=t.nodeType===9?t:t.ownerDocument;l===null||l[Gn]||(l[Gn]=!0,Xi("selectionchange",!1,l))}}function D1(t,l,e,a){switch(G1(l)){case 2:var n=cg;break;case 8:n=fg;break;default:n=Jf}e=n.bind(null,l,e,t),n=void 0,!yc||l!=="touchstart"&&l!=="touchmove"&&l!=="wheel"||(n=!0),a?n!==void 0?t.addEventListener(l,e,{capture:!0,passive:n}):t.addEventListener(l,e,!0):n!==void 0?t.addEventListener(l,e,{passive:n}):t.addEventListener(l,e,!1)}function Li(t,l,e,a,n){var u=a;if(!(l&1)&&!(l&2)&&a!==null)t:for(;;){if(a===null)return;var i=a.tag;if(i===3||i===4){var c=a.stateNode.containerInfo;if(c===n)break;if(i===4)for(i=a.return;i!==null;){var f=i.tag;if((f===3||f===4)&&i.stateNode.containerInfo===n)return;i=i.return}for(;c!==null;){if(i=Ye(c),i===null)return;if(f=i.tag,f===5||f===6||f===26||f===27){a=u=i;continue t}c=c.parentNode}}a=a.return}Or(function(){var o=u,y=sf(e),v=[];t:{var d=Yr.get(t);if(d!==void 0){var g=Vu,x=t;switch(t){case"keypress":if(Pn(e)===0)break t;case"keydown":case"keyup":g=jy;break;case"focusin":x="focus",g=hi;break;case"focusout":x="blur",g=hi;break;case"beforeblur":case"afterblur":g=hi;break;case"click":if(e.button===2)break t;case"auxclick":case"dblclick":case"mousedown":case"mousemove":case"mouseup":case"mouseout":case"mouseover":case"contextmenu":g=xs;break;case"drag":case"dragend":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"dragstart":case"drop":g=my;break;case"touchcancel":case"touchend":case"touchmove":case"touchstart":g=My;break;case Xr:case Lr:case Zr:g=hy;break;case Gr:g=Dy;break;case"scroll":case"scrollend":g=dy;break;case"wheel":g=Ny;break;case"copy":case"cut":case"paste":g=py;break;case"gotpointercapture":case"lostpointercapture":case"pointercancel":case"pointerdown":case"pointermove":case"pointerout":case"pointerover":case"pointerup":g=bs;break;case"toggle":case"beforetoggle":g=qy}var S=(l&4)!==0,E=!S&&(t==="scroll"||t==="scrollend"),r=S?d!==null?d+"Capture":null:d;S=[];for(var s=o,m;s!==null;){var h=s;if(m=h.stateNode,h=h.tag,h!==5&&h!==26&&h!==27||m===null||r===null||(h=un(s,r),h!=null&&S.push(gn(s,h,m))),E)break;s=s.return}0<S.length&&(d=new g(d,x,null,e,y),v.push({event:d,listeners:S}))}}if(!(l&7)){t:{if(d=t==="mouseover"||t==="pointerover",g=t==="mouseout"||t==="pointerout",d&&e!==dc&&(x=e.relatedTarget||e.fromElement)&&(Ye(x)||x[ba]))break t;if((g||d)&&(d=y.window===y?y:(d=y.ownerDocument)?d.defaultView||d.parentWindow:window,g?(x=e.relatedTarget||e.toElement,g=o,x=x?Ye(x):null,x!==null&&(E=pn(x),S=x.tag,x!==E||S!==5&&S!==27&&S!==6)&&(x=null)):(g=null,x=o),g!==x)){if(S=xs,h="onMouseLeave",r="onMouseEnter",s="mouse",(t==="pointerout"||t==="pointerover")&&(S=bs,h="onPointerLeave",r="onPointerEnter",s="pointer"),E=g==null?d:Ua(g),m=x==null?d:Ua(x),d=new S(h,s+"leave",g,e,y),d.target=E,d.relatedTarget=m,h=null,Ye(y)===o&&(S=new S(r,s+"enter",x,e,y),S.target=m,S.relatedTarget=E,h=S),E=h,g&&x)l:{for(S=Cm,r=g,s=x,m=0,h=r;h;h=S(h))m++;h=0;for(var $=s;$;$=S($))h++;for(;0<m-h;)r=S(r),m--;for(;0<h-m;)s=S(s),h--;for(;m--;){if(r===s||s!==null&&r===s.alternate){S=r;break l}r=S(r),s=S(s)}S=null}else S=null;g!==null&&ro(v,d,g,S,!1),x!==null&&E!==null&&ro(v,E,x,S,!0)}}t:{if(d=o?Ua(o):window,g=d.nodeName&&d.nodeName.toLowerCase(),g==="select"||g==="input"&&d.type==="file")var A=Ts;else if(Es(d))if(wr)A=Yy;else{A=Zy;var T=Ly}else g=d.nodeName,!g||g.toLowerCase()!=="input"||d.type!=="checkbox"&&d.type!=="radio"?o&&ff(o.elementType)&&(A=Ts):A=Gy;if(A&&(A=A(t,o))){qr(v,A,e,y);break t}T&&T(t,d,o),t==="focusout"&&o&&d.type==="number"&&o.memoizedProps.value!=null&&rc(d,"number",d.value)}switch(T=o?Ua(o):window,t){case"focusin":(Es(T)||T.contentEditable==="true")&&(Ke=T,mc=o,Va=null);break;case"focusout":Va=mc=Ke=null;break;case"mousedown":gc=!0;break;case"contextmenu":case"mouseup":case"dragend":gc=!1,Ms(v,e,y);break;case"selectionchange":if(Vy)break;case"keydown":case"keyup":Ms(v,e,y)}var M;if(df)t:{switch(t){case"compositionstart":var j="onCompositionStart";break t;case"compositionend":j="onCompositionEnd";break t;case"compositionupdate":j="onCompositionUpdate";break t}j=void 0}else Ve?Nr(t,e)&&(j="onCompositionEnd"):t==="keydown"&&e.keyCode===229&&(j="onCompositionStart");j&&(_r&&e.locale!=="ko"&&(Ve||j!=="onCompositionStart"?j==="onCompositionEnd"&&Ve&&(M=Dr()):(Gl=y,of="value"in Gl?Gl.value:Gl.textContent,Ve=!0)),T=qu(o,j),0<T.length&&(j=new ps(j,t,null,e,y),v.push({event:j,listeners:T}),M?j.data=M:(M=Cr(e),M!==null&&(j.data=M)))),(M=Ry?Uy(t,e):Hy(t,e))&&(j=qu(o,"onBeforeInput"),0<j.length&&(T=new ps("onBeforeInput","beforeinput",null,e,y),v.push({event:T,listeners:j}),T.data=M)),Om(v,t,o,e,y)}O1(v,l)})}function gn(t,l,e){return{instance:t,listener:l,currentTarget:e}}function qu(t,l){for(var e=l+"Capture",a=[];t!==null;){var n=t,u=n.stateNode;if(n=n.tag,n!==5&&n!==26&&n!==27||u===null||(n=un(t,e),n!=null&&a.unshift(gn(t,n,u)),n=un(t,l),n!=null&&a.push(gn(t,n,u))),t.tag===3)return a;t=t.return}return[]}function Cm(t){if(t===null)return null;do t=t.return;while(t&&t.tag!==5&&t.tag!==27);return t||null}function ro(t,l,e,a,n){for(var u=l._reactName,i=[];e!==null&&e!==a;){var c=e,f=c.alternate,o=c.stateNode;if(c=c.tag,f!==null&&f===a)break;c!==5&&c!==26&&c!==27||o===null||(f=o,n?(o=un(e,u),o!=null&&i.unshift(gn(e,o,f))):n||(o=un(e,u),o!=null&&i.push(gn(e,o,f)))),e=e.return}i.length!==0&&t.push({event:l,listeners:i})}var qm=/\r\n?/g,wm=/\u0000|\uFFFD/g;function yo(t){return(typeof t=="string"?t:""+t).replace(qm,`
+`).replace(wm,"")}function _1(t,l){return l=yo(l),yo(t)===l}function G(t,l,e,a,n,u){switch(e){case"children":typeof a=="string"?l==="body"||l==="textarea"&&a===""||oa(t,a):(typeof a=="number"||typeof a=="bigint")&&l!=="body"&&oa(t,""+a);break;case"className":Rn(t,"class",a);break;case"tabIndex":Rn(t,"tabindex",a);break;case"dir":case"role":case"viewBox":case"width":case"height":Rn(t,e,a);break;case"style":Mr(t,a,u);break;case"data":if(l!=="object"){Rn(t,"data",a);break}case"src":case"href":if(a===""&&(l!=="a"||e!=="href")){t.removeAttribute(e);break}if(a==null||typeof a=="function"||typeof a=="symbol"||typeof a=="boolean"){t.removeAttribute(e);break}a=Fn(""+a),t.setAttribute(e,a);break;case"action":case"formAction":if(typeof a=="function"){t.setAttribute(e,"javascript:throw new Error('A React form was unexpectedly submitted. If you called form.submit() manually, consider using form.requestSubmit() instead. If you\\'re trying to use event.stopPropagation() in a submit event handler, consider also calling event.preventDefault().')");break}else typeof u=="function"&&(e==="formAction"?(l!=="input"&&G(t,l,"name",n.name,n,null),G(t,l,"formEncType",n.formEncType,n,null),G(t,l,"formMethod",n.formMethod,n,null),G(t,l,"formTarget",n.formTarget,n,null)):(G(t,l,"encType",n.encType,n,null),G(t,l,"method",n.method,n,null),G(t,l,"target",n.target,n,null)));if(a==null||typeof a=="symbol"||typeof a=="boolean"){t.removeAttribute(e);break}a=Fn(""+a),t.setAttribute(e,a);break;case"onClick":a!=null&&(t.onclick=zl);break;case"onScroll":a!=null&&w("scroll",t);break;case"onScrollEnd":a!=null&&w("scrollend",t);break;case"dangerouslySetInnerHTML":if(a!=null){if(typeof a!="object"||!("__html"in a))throw Error(z(61));if(e=a.__html,e!=null){if(n.children!=null)throw Error(z(60));t.innerHTML=e}}break;case"multiple":t.multiple=a&&typeof a!="function"&&typeof a!="symbol";break;case"muted":t.muted=a&&typeof a!="function"&&typeof a!="symbol";break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"defaultValue":case"defaultChecked":case"innerHTML":case"ref":break;case"autoFocus":break;case"xlinkHref":if(a==null||typeof a=="function"||typeof a=="boolean"||typeof a=="symbol"){t.removeAttribute("xlink:href");break}e=Fn(""+a),t.setAttributeNS("http://www.w3.org/1999/xlink","xlink:href",e);break;case"contentEditable":case"spellCheck":case"draggable":case"value":case"autoReverse":case"externalResourcesRequired":case"focusable":case"preserveAlpha":a!=null&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,""+a):t.removeAttribute(e);break;case"inert":case"allowFullScreen":case"async":case"autoPlay":case"controls":case"default":case"defer":case"disabled":case"disablePictureInPicture":case"disableRemotePlayback":case"formNoValidate":case"hidden":case"loop":case"noModule":case"noValidate":case"open":case"playsInline":case"readOnly":case"required":case"reversed":case"scoped":case"seamless":case"itemScope":a&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,""):t.removeAttribute(e);break;case"capture":case"download":a===!0?t.setAttribute(e,""):a!==!1&&a!=null&&typeof a!="function"&&typeof a!="symbol"?t.setAttribute(e,a):t.removeAttribute(e);break;case"cols":case"rows":case"size":case"span":a!=null&&typeof a!="function"&&typeof a!="symbol"&&!isNaN(a)&&1<=a?t.setAttribute(e,a):t.removeAttribute(e);break;case"rowSpan":case"start":a==null||typeof a=="function"||typeof a=="symbol"||isNaN(a)?t.removeAttribute(e):t.setAttribute(e,a);break;case"popover":w("beforetoggle",t),w("toggle",t),Wn(t,"popover",a);break;case"xlinkActuate":ml(t,"http://www.w3.org/1999/xlink","xlink:actuate",a);break;case"xlinkArcrole":ml(t,"http://www.w3.org/1999/xlink","xlink:arcrole",a);break;case"xlinkRole":ml(t,"http://www.w3.org/1999/xlink","xlink:role",a);break;case"xlinkShow":ml(t,"http://www.w3.org/1999/xlink","xlink:show",a);break;case"xlinkTitle":ml(t,"http://www.w3.org/1999/xlink","xlink:title",a);break;case"xlinkType":ml(t,"http://www.w3.org/1999/xlink","xlink:type",a);break;case"xmlBase":ml(t,"http://www.w3.org/XML/1998/namespace","xml:base",a);break;case"xmlLang":ml(t,"http://www.w3.org/XML/1998/namespace","xml:lang",a);break;case"xmlSpace":ml(t,"http://www.w3.org/XML/1998/namespace","xml:space",a);break;case"is":Wn(t,"is",a);break;case"innerText":case"textContent":break;default:(!(2<e.length)||e[0]!=="o"&&e[0]!=="O"||e[1]!=="n"&&e[1]!=="N")&&(e=oy.get(e)||e,Wn(t,e,a))}}function Hc(t,l,e,a,n,u){switch(e){case"style":Mr(t,a,u);break;case"dangerouslySetInnerHTML":if(a!=null){if(typeof a!="object"||!("__html"in a))throw Error(z(61));if(e=a.__html,e!=null){if(n.children!=null)throw Error(z(60));t.innerHTML=e}}break;case"children":typeof a=="string"?oa(t,a):(typeof a=="number"||typeof a=="bigint")&&oa(t,""+a);break;case"onScroll":a!=null&&w("scroll",t);break;case"onScrollEnd":a!=null&&w("scrollend",t);break;case"onClick":a!=null&&(t.onclick=zl);break;case"suppressContentEditableWarning":case"suppressHydrationWarning":case"innerHTML":case"ref":break;case"innerText":case"textContent":break;default:if(!Er.hasOwnProperty(e))t:{if(e[0]==="o"&&e[1]==="n"&&(n=e.endsWith("Capture"),l=e.slice(2,n?e.length-7:void 0),u=t[Ct]||null,u=u!=null?u[e]:null,typeof u=="function"&&t.removeEventListener(l,u,n),typeof a=="function")){typeof u!="function"&&u!==null&&(e in t?t[e]=null:t.hasAttribute(e)&&t.removeAttribute(e)),t.addEventListener(l,a,n);break t}e in t?t[e]=a:a===!0?t.setAttribute(e,""):Wn(t,e,a)}}}function Et(t,l,e){switch(l){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"img":w("error",t),w("load",t);var a=!1,n=!1,u;for(u in e)if(e.hasOwnProperty(u)){var i=e[u];if(i!=null)switch(u){case"src":a=!0;break;case"srcSet":n=!0;break;case"children":case"dangerouslySetInnerHTML":throw Error(z(137,l));default:G(t,l,u,i,e,null)}}n&&G(t,l,"srcSet",e.srcSet,e,null),a&&G(t,l,"src",e.src,e,null);return;case"input":w("invalid",t);var c=u=i=n=null,f=null,o=null;for(a in e)if(e.hasOwnProperty(a)){var y=e[a];if(y!=null)switch(a){case"name":n=y;break;case"type":i=y;break;case"checked":f=y;break;case"defaultChecked":o=y;break;case"value":u=y;break;case"defaultValue":c=y;break;case"children":case"dangerouslySetInnerHTML":if(y!=null)throw Error(z(137,l));break;default:G(t,l,a,y,e,null)}}jr(t,u,c,f,o,i,n,!1);return;case"select":w("invalid",t),a=i=u=null;for(n in e)if(e.hasOwnProperty(n)&&(c=e[n],c!=null))switch(n){case"value":u=c;break;case"defaultValue":i=c;break;case"multiple":a=c;default:G(t,l,n,c,e,null)}l=u,e=i,t.multiple=!!a,l!=null?ea(t,!!a,l,!1):e!=null&&ea(t,!!a,e,!0);return;case"textarea":w("invalid",t),u=n=a=null;for(i in e)if(e.hasOwnProperty(i)&&(c=e[i],c!=null))switch(i){case"value":a=c;break;case"defaultValue":n=c;break;case"children":u=c;break;case"dangerouslySetInnerHTML":if(c!=null)throw Error(z(91));break;default:G(t,l,i,c,e,null)}kr(t,a,n,u);return;case"option":for(f in e)if(e.hasOwnProperty(f)&&(a=e[f],a!=null))switch(f){case"selected":t.selected=a&&typeof a!="function"&&typeof a!="symbol";break;default:G(t,l,f,a,e,null)}return;case"dialog":w("beforetoggle",t),w("toggle",t),w("cancel",t),w("close",t);break;case"iframe":case"object":w("load",t);break;case"video":case"audio":for(a=0;a<mn.length;a++)w(mn[a],t);break;case"image":w("error",t),w("load",t);break;case"details":w("toggle",t);break;case"embed":case"source":case"link":w("error",t),w("load",t);case"area":case"base":case"br":case"col":case"hr":case"keygen":case"meta":case"param":case"track":case"wbr":case"menuitem":for(o in e)if(e.hasOwnProperty(o)&&(a=e[o],a!=null))switch(o){case"children":case"dangerouslySetInnerHTML":throw Error(z(137,l));default:G(t,l,o,a,e,null)}return;default:if(ff(l)){for(y in e)e.hasOwnProperty(y)&&(a=e[y],a!==void 0&&Hc(t,l,y,a,e,void 0));return}}for(c in e)e.hasOwnProperty(c)&&(a=e[c],a!=null&&G(t,l,c,a,e,null))}function Rm(t,l,e,a){switch(l){case"div":case"span":case"svg":case"path":case"a":case"g":case"p":case"li":break;case"input":var n=null,u=null,i=null,c=null,f=null,o=null,y=null;for(g in e){var v=e[g];if(e.hasOwnProperty(g)&&v!=null)switch(g){case"checked":break;case"value":break;case"defaultValue":f=v;default:a.hasOwnProperty(g)||G(t,l,g,null,a,v)}}for(var d in a){var g=a[d];if(v=e[d],a.hasOwnProperty(d)&&(g!=null||v!=null))switch(d){case"type":u=g;break;case"name":n=g;break;case"checked":o=g;break;case"defaultChecked":y=g;break;case"value":i=g;break;case"defaultValue":c=g;break;case"children":case"dangerouslySetInnerHTML":if(g!=null)throw Error(z(137,l));break;default:g!==v&&G(t,l,d,g,a,v)}}oc(t,i,c,f,o,y,u,n);return;case"select":g=i=c=d=null;for(u in e)if(f=e[u],e.hasOwnProperty(u)&&f!=null)switch(u){case"value":break;case"multiple":g=f;default:a.hasOwnProperty(u)||G(t,l,u,null,a,f)}for(n in a)if(u=a[n],f=e[n],a.hasOwnProperty(n)&&(u!=null||f!=null))switch(n){case"value":d=u;break;case"defaultValue":c=u;break;case"multiple":i=u;default:u!==f&&G(t,l,n,u,a,f)}l=c,e=i,a=g,d!=null?ea(t,!!e,d,!1):!!a!=!!e&&(l!=null?ea(t,!!e,l,!0):ea(t,!!e,e?[]:"",!1));return;case"textarea":g=d=null;for(c in e)if(n=e[c],e.hasOwnProperty(c)&&n!=null&&!a.hasOwnProperty(c))switch(c){case"value":break;case"children":break;default:G(t,l,c,null,a,n)}for(i in a)if(n=a[i],u=e[i],a.hasOwnProperty(i)&&(n!=null||u!=null))switch(i){case"value":d=n;break;case"defaultValue":g=n;break;case"children":break;case"dangerouslySetInnerHTML":if(n!=null)throw Error(z(91));break;default:n!==u&&G(t,l,i,n,a,u)}Ar(t,d,g);return;case"option":for(var x in e)if(d=e[x],e.hasOwnProperty(x)&&d!=null&&!a.hasOwnProperty(x))switch(x){case"selected":t.selected=!1;break;default:G(t,l,x,null,a,d)}for(f in a)if(d=a[f],g=e[f],a.hasOwnProperty(f)&&d!==g&&(d!=null||g!=null))switch(f){case"selected":t.selected=d&&typeof d!="function"&&typeof d!="symbol";break;default:G(t,l,f,d,a,g)}return;case"img":case"link":case"area":case"base":case"br":case"col":case"embed":case"hr":case"keygen":case"meta":case"param":case"source":case"track":case"wbr":case"menuitem":for(var S in e)d=e[S],e.hasOwnProperty(S)&&d!=null&&!a.hasOwnProperty(S)&&G(t,l,S,null,a,d);for(o in a)if(d=a[o],g=e[o],a.hasOwnProperty(o)&&d!==g&&(d!=null||g!=null))switch(o){case"children":case"dangerouslySetInnerHTML":if(d!=null)throw Error(z(137,l));break;default:G(t,l,o,d,a,g)}return;default:if(ff(l)){for(var E in e)d=e[E],e.hasOwnProperty(E)&&d!==void 0&&!a.hasOwnProperty(E)&&Hc(t,l,E,void 0,a,d);for(y in a)d=a[y],g=e[y],!a.hasOwnProperty(y)||d===g||d===void 0&&g===void 0||Hc(t,l,y,d,a,g);return}}for(var r in e)d=e[r],e.hasOwnProperty(r)&&d!=null&&!a.hasOwnProperty(r)&&G(t,l,r,null,a,d);for(v in a)d=a[v],g=e[v],!a.hasOwnProperty(v)||d===g||d==null&&g==null||G(t,l,v,d,a,g)}function mo(t){switch(t){case"css":case"script":case"font":case"img":case"image":case"input":case"link":return!0;default:return!1}}function Um(){if(typeof performance.getEntriesByType=="function"){for(var t=0,l=0,e=performance.getEntriesByType("resource"),a=0;a<e.length;a++){var n=e[a],u=n.transferSize,i=n.initiatorType,c=n.duration;if(u&&c&&mo(i)){for(i=0,c=n.responseEnd,a+=1;a<e.length;a++){var f=e[a],o=f.startTime;if(o>c)break;var y=f.transferSize,v=f.initiatorType;y&&mo(v)&&(f=f.responseEnd,i+=y*(f<c?1:(c-o)/(f-o)))}if(--a,l+=8*(u+i)/(n.duration/1e3),t++,10<t)break}}if(0<t)return l/t/1e6}return navigator.connection&&(t=navigator.connection.downlink,typeof t=="number")?t:5}var Bc=null,Xc=null;function wu(t){return t.nodeType===9?t:t.ownerDocument}function go(t){switch(t){case"http://www.w3.org/2000/svg":return 1;case"http://www.w3.org/1998/Math/MathML":return 2;default:return 0}}function N1(t,l){if(t===0)switch(l){case"svg":return 1;case"math":return 2;default:return 0}return t===1&&l==="foreignObject"?0:t}function Lc(t,l){return t==="textarea"||t==="noscript"||typeof l.children=="string"||typeof l.children=="number"||typeof l.children=="bigint"||typeof l.dangerouslySetInnerHTML=="object"&&l.dangerouslySetInnerHTML!==null&&l.dangerouslySetInnerHTML.__html!=null}var Zi=null;function Hm(){var t=window.event;return t&&t.type==="popstate"?t===Zi?!1:(Zi=t,!0):(Zi=null,!1)}var C1=typeof setTimeout=="function"?setTimeout:void 0,Bm=typeof clearTimeout=="function"?clearTimeout:void 0,vo=typeof Promise=="function"?Promise:void 0,Xm=typeof queueMicrotask=="function"?queueMicrotask:typeof vo<"u"?function(t){return vo.resolve(null).then(t).catch(Lm)}:C1;function Lm(t){setTimeout(function(){throw t})}function fe(t){return t==="head"}function ho(t,l){var e=l,a=0;do{var n=e.nextSibling;if(t.removeChild(e),n&&n.nodeType===8)if(e=n.data,e==="/$"||e==="/&"){if(a===0){t.removeChild(n),xa(l);return}a--}else if(e==="$"||e==="$?"||e==="$~"||e==="$!"||e==="&")a++;else if(e==="html")an(t.ownerDocument.documentElement);else if(e==="head"){e=t.ownerDocument.head,an(e);for(var u=e.firstChild;u;){var i=u.nextSibling,c=u.nodeName;u[En]||c==="SCRIPT"||c==="STYLE"||c==="LINK"&&u.rel.toLowerCase()==="stylesheet"||e.removeChild(u),u=i}}else e==="body"&&an(t.ownerDocument.body);e=n}while(e);xa(l)}function xo(t,l){var e=t;t=0;do{var a=e.nextSibling;if(e.nodeType===1?l?(e._stashedDisplay=e.style.display,e.style.display="none"):(e.style.display=e._stashedDisplay||"",e.getAttribute("style")===""&&e.removeAttribute("style")):e.nodeType===3&&(l?(e._stashedText=e.nodeValue,e.nodeValue=""):e.nodeValue=e._stashedText||""),a&&a.nodeType===8)if(e=a.data,e==="/$"){if(t===0)break;t--}else e!=="$"&&e!=="$?"&&e!=="$~"&&e!=="$!"||t++;e=a}while(e)}function Zc(t){var l=t.firstChild;for(l&&l.nodeType===10&&(l=l.nextSibling);l;){var e=l;switch(l=l.nextSibling,e.nodeName){case"HTML":case"HEAD":case"BODY":Zc(e),cf(e);continue;case"SCRIPT":case"STYLE":continue;case"LINK":if(e.rel.toLowerCase()==="stylesheet")continue}t.removeChild(e)}}function Zm(t,l,e,a){for(;t.nodeType===1;){var n=e;if(t.nodeName.toLowerCase()!==l.toLowerCase()){if(!a&&(t.nodeName!=="INPUT"||t.type!=="hidden"))break}else if(a){if(!t[En])switch(l){case"meta":if(!t.hasAttribute("itemprop"))break;return t;case"link":if(u=t.getAttribute("rel"),u==="stylesheet"&&t.hasAttribute("data-precedence"))break;if(u!==n.rel||t.getAttribute("href")!==(n.href==null||n.href===""?null:n.href)||t.getAttribute("crossorigin")!==(n.crossOrigin==null?null:n.crossOrigin)||t.getAttribute("title")!==(n.title==null?null:n.title))break;return t;case"style":if(t.hasAttribute("data-precedence"))break;return t;case"script":if(u=t.getAttribute("src"),(u!==(n.src==null?null:n.src)||t.getAttribute("type")!==(n.type==null?null:n.type)||t.getAttribute("crossorigin")!==(n.crossOrigin==null?null:n.crossOrigin))&&u&&t.hasAttribute("async")&&!t.hasAttribute("itemprop"))break;return t;default:return t}}else if(l==="input"&&t.type==="hidden"){var u=n.name==null?null:""+n.name;if(n.type==="hidden"&&t.getAttribute("name")===u)return t}else return t;if(t=tl(t.nextSibling),t===null)break}return null}function Gm(t,l,e){if(l==="")return null;for(;t.nodeType!==3;)if((t.nodeType!==1||t.nodeName!=="INPUT"||t.type!=="hidden")&&!e||(t=tl(t.nextSibling),t===null))return null;return t}function q1(t,l){for(;t.nodeType!==8;)if((t.nodeType!==1||t.nodeName!=="INPUT"||t.type!=="hidden")&&!l||(t=tl(t.nextSibling),t===null))return null;return t}function Gc(t){return t.data==="$?"||t.data==="$~"}function Yc(t){return t.data==="$!"||t.data==="$?"&&t.ownerDocument.readyState!=="loading"}function Ym(t,l){var e=t.ownerDocument;if(t.data==="$~")t._reactRetry=l;else if(t.data!=="$?"||e.readyState!=="loading")l();else{var a=function(){l(),e.removeEventListener("DOMContentLoaded",a)};e.addEventListener("DOMContentLoaded",a),t._reactRetry=a}}function tl(t){for(;t!=null;t=t.nextSibling){var l=t.nodeType;if(l===1||l===3)break;if(l===8){if(l=t.data,l==="$"||l==="$!"||l==="$?"||l==="$~"||l==="&"||l==="F!"||l==="F")break;if(l==="/$"||l==="/&")return null}}return t}var Qc=null;function po(t){t=t.nextSibling;for(var l=0;t;){if(t.nodeType===8){var e=t.data;if(e==="/$"||e==="/&"){if(l===0)return tl(t.nextSibling);l--}else e!=="$"&&e!=="$!"&&e!=="$?"&&e!=="$~"&&e!=="&"||l++}t=t.nextSibling}return null}function bo(t){t=t.previousSibling;for(var l=0;t;){if(t.nodeType===8){var e=t.data;if(e==="$"||e==="$!"||e==="$?"||e==="$~"||e==="&"){if(l===0)return t;l--}else e!=="/$"&&e!=="/&"||l++}t=t.previousSibling}return null}function w1(t,l,e){switch(l=wu(e),t){case"html":if(t=l.documentElement,!t)throw Error(z(452));return t;case"head":if(t=l.head,!t)throw Error(z(453));return t;case"body":if(t=l.body,!t)throw Error(z(454));return t;default:throw Error(z(451))}}function an(t){for(var l=t.attributes;l.length;)t.removeAttributeNode(l[0]);cf(t)}var ll=new Map,So=new Set;function Ru(t){return typeof t.getRootNode=="function"?t.getRootNode():t.nodeType===9?t:t.ownerDocument}var _l=X.d;X.d={f:Qm,r:Vm,D:Km,C:Jm,L:Wm,m:Fm,X:Pm,S:Im,M:tg};function Qm(){var t=_l.f(),l=ni();return t||l}function Vm(t){var l=Sa(t);l!==null&&l.tag===5&&l.type==="form"?Md(l):_l.r(t)}var $a=typeof document>"u"?null:document;function R1(t,l,e){var a=$a;if(a&&typeof l=="string"&&l){var n=Wt(l);n='link[rel="'+t+'"][href="'+n+'"]',typeof e=="string"&&(n+='[crossorigin="'+e+'"]'),So.has(n)||(So.add(n),t={rel:t,crossOrigin:e,href:l},a.querySelector(n)===null&&(l=a.createElement("link"),Et(l,"link",t),vt(l),a.head.appendChild(l)))}}function Km(t){_l.D(t),R1("dns-prefetch",t,null)}function Jm(t,l){_l.C(t,l),R1("preconnect",t,l)}function Wm(t,l,e){_l.L(t,l,e);var a=$a;if(a&&t&&l){var n='link[rel="preload"][as="'+Wt(l)+'"]';l==="image"&&e&&e.imageSrcSet?(n+='[imagesrcset="'+Wt(e.imageSrcSet)+'"]',typeof e.imageSizes=="string"&&(n+='[imagesizes="'+Wt(e.imageSizes)+'"]')):n+='[href="'+Wt(t)+'"]';var u=n;switch(l){case"style":u=ha(t);break;case"script":u=ja(t)}ll.has(u)||(t=I({rel:"preload",href:l==="image"&&e&&e.imageSrcSet?void 0:t,as:l},e),ll.set(u,t),a.querySelector(n)!==null||l==="style"&&a.querySelector(Mn(u))||l==="script"&&a.querySelector(On(u))||(l=a.createElement("link"),Et(l,"link",t),vt(l),a.head.appendChild(l)))}}function Fm(t,l){_l.m(t,l);var e=$a;if(e&&t){var a=l&&typeof l.as=="string"?l.as:"script",n='link[rel="modulepreload"][as="'+Wt(a)+'"][href="'+Wt(t)+'"]',u=n;switch(a){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":u=ja(t)}if(!ll.has(u)&&(t=I({rel:"modulepreload",href:t},l),ll.set(u,t),e.querySelector(n)===null)){switch(a){case"audioworklet":case"paintworklet":case"serviceworker":case"sharedworker":case"worker":case"script":if(e.querySelector(On(u)))return}a=e.createElement("link"),Et(a,"link",t),vt(a),e.head.appendChild(a)}}}function Im(t,l,e){_l.S(t,l,e);var a=$a;if(a&&t){var n=la(a).hoistableStyles,u=ha(t);l=l||"default";var i=n.get(u);if(!i){var c={loading:0,preload:null};if(i=a.querySelector(Mn(u)))c.loading=5;else{t=I({rel:"stylesheet",href:t,"data-precedence":l},e),(e=ll.get(u))&&Qf(t,e);var f=i=a.createElement("link");vt(f),Et(f,"link",t),f._p=new Promise(function(o,y){f.onload=o,f.onerror=y}),f.addEventListener("load",function(){c.loading|=1}),f.addEventListener("error",function(){c.loading|=2}),c.loading|=4,cu(i,l,a)}i={type:"stylesheet",instance:i,count:1,state:c},n.set(u,i)}}}function Pm(t,l){_l.X(t,l);var e=$a;if(e&&t){var a=la(e).hoistableScripts,n=ja(t),u=a.get(n);u||(u=e.querySelector(On(n)),u||(t=I({src:t,async:!0},l),(l=ll.get(n))&&Vf(t,l),u=e.createElement("script"),vt(u),Et(u,"link",t),e.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},a.set(n,u))}}function tg(t,l){_l.M(t,l);var e=$a;if(e&&t){var a=la(e).hoistableScripts,n=ja(t),u=a.get(n);u||(u=e.querySelector(On(n)),u||(t=I({src:t,async:!0,type:"module"},l),(l=ll.get(n))&&Vf(t,l),u=e.createElement("script"),vt(u),Et(u,"link",t),e.head.appendChild(u)),u={type:"script",instance:u,count:1,state:null},a.set(n,u))}}function zo(t,l,e,a){var n=(n=Kl.current)?Ru(n):null;if(!n)throw Error(z(446));switch(t){case"meta":case"title":return null;case"style":return typeof e.precedence=="string"&&typeof e.href=="string"?(l=ha(e.href),e=la(n).hoistableStyles,a=e.get(l),a||(a={type:"style",instance:null,count:0,state:null},e.set(l,a)),a):{type:"void",instance:null,count:0,state:null};case"link":if(e.rel==="stylesheet"&&typeof e.href=="string"&&typeof e.precedence=="string"){t=ha(e.href);var u=la(n).hoistableStyles,i=u.get(t);if(i||(n=n.ownerDocument||n,i={type:"stylesheet",instance:null,count:0,state:{loading:0,preload:null}},u.set(t,i),(u=n.querySelector(Mn(t)))&&!u._p&&(i.instance=u,i.state.loading=5),ll.has(t)||(e={rel:"preload",as:"style",href:e.href,crossOrigin:e.crossOrigin,integrity:e.integrity,media:e.media,hrefLang:e.hrefLang,referrerPolicy:e.referrerPolicy},ll.set(t,e),u||lg(n,t,e,i.state))),l&&a===null)throw Error(z(528,""));return i}if(l&&a!==null)throw Error(z(529,""));return null;case"script":return l=e.async,e=e.src,typeof e=="string"&&l&&typeof l!="function"&&typeof l!="symbol"?(l=ja(e),e=la(n).hoistableScripts,a=e.get(l),a||(a={type:"script",instance:null,count:0,state:null},e.set(l,a)),a):{type:"void",instance:null,count:0,state:null};default:throw Error(z(444,t))}}function ha(t){return'href="'+Wt(t)+'"'}function Mn(t){return'link[rel="stylesheet"]['+t+"]"}function U1(t){return I({},t,{"data-precedence":t.precedence,precedence:null})}function lg(t,l,e,a){t.querySelector('link[rel="preload"][as="style"]['+l+"]")?a.loading=1:(l=t.createElement("link"),a.preload=l,l.addEventListener("load",function(){return a.loading|=1}),l.addEventListener("error",function(){return a.loading|=2}),Et(l,"link",e),vt(l),t.head.appendChild(l))}function ja(t){return'[src="'+Wt(t)+'"]'}function On(t){return"script[async]"+t}function Eo(t,l,e){if(l.count++,l.instance===null)switch(l.type){case"style":var a=t.querySelector('style[data-href~="'+Wt(e.href)+'"]');if(a)return l.instance=a,vt(a),a;var n=I({},e,{"data-href":e.href,"data-precedence":e.precedence,href:null,precedence:null});return a=(t.ownerDocument||t).createElement("style"),vt(a),Et(a,"style",n),cu(a,e.precedence,t),l.instance=a;case"stylesheet":n=ha(e.href);var u=t.querySelector(Mn(n));if(u)return l.state.loading|=4,l.instance=u,vt(u),u;a=U1(e),(n=ll.get(n))&&Qf(a,n),u=(t.ownerDocument||t).createElement("link"),vt(u);var i=u;return i._p=new Promise(function(c,f){i.onload=c,i.onerror=f}),Et(u,"link",a),l.state.loading|=4,cu(u,e.precedence,t),l.instance=u;case"script":return u=ja(e.src),(n=t.querySelector(On(u)))?(l.instance=n,vt(n),n):(a=e,(n=ll.get(u))&&(a=I({},e),Vf(a,n)),t=t.ownerDocument||t,n=t.createElement("script"),vt(n),Et(n,"link",a),t.head.appendChild(n),l.instance=n);case"void":return null;default:throw Error(z(443,l.type))}else l.type==="stylesheet"&&!(l.state.loading&4)&&(a=l.instance,l.state.loading|=4,cu(a,e.precedence,t));return l.instance}function cu(t,l,e){for(var a=e.querySelectorAll('link[rel="stylesheet"][data-precedence],style[data-precedence]'),n=a.length?a[a.length-1]:null,u=n,i=0;i<a.length;i++){var c=a[i];if(c.dataset.precedence===l)u=c;else if(u!==n)break}u?u.parentNode.insertBefore(t,u.nextSibling):(l=e.nodeType===9?e.head:e,l.insertBefore(t,l.firstChild))}function Qf(t,l){t.crossOrigin==null&&(t.crossOrigin=l.crossOrigin),t.referrerPolicy==null&&(t.referrerPolicy=l.referrerPolicy),t.title==null&&(t.title=l.title)}function Vf(t,l){t.crossOrigin==null&&(t.crossOrigin=l.crossOrigin),t.referrerPolicy==null&&(t.referrerPolicy=l.referrerPolicy),t.integrity==null&&(t.integrity=l.integrity)}var fu=null;function To(t,l,e){if(fu===null){var a=new Map,n=fu=new Map;n.set(e,a)}else n=fu,a=n.get(e),a||(a=new Map,n.set(e,a));if(a.has(t))return a;for(a.set(t,null),e=e.getElementsByTagName(t),n=0;n<e.length;n++){var u=e[n];if(!(u[En]||u[bt]||t==="link"&&u.getAttribute("rel")==="stylesheet")&&u.namespaceURI!=="http://www.w3.org/2000/svg"){var i=u.getAttribute(l)||"";i=t+i;var c=a.get(i);c?c.push(u):a.set(i,[u])}}return a}function $o(t,l,e){t=t.ownerDocument||t,t.head.insertBefore(e,l==="title"?t.querySelector("head > title"):null)}function eg(t,l,e){if(e===1||l.itemProp!=null)return!1;switch(t){case"meta":case"title":return!0;case"style":if(typeof l.precedence!="string"||typeof l.href!="string"||l.href==="")break;return!0;case"link":if(typeof l.rel!="string"||typeof l.href!="string"||l.href===""||l.onLoad||l.onError)break;switch(l.rel){case"stylesheet":return t=l.disabled,typeof l.precedence=="string"&&t==null;default:return!0}case"script":if(l.async&&typeof l.async!="function"&&typeof l.async!="symbol"&&!l.onLoad&&!l.onError&&l.src&&typeof l.src=="string")return!0}return!1}function H1(t){return!(t.type==="stylesheet"&&!(t.state.loading&3))}function ag(t,l,e,a){if(e.type==="stylesheet"&&(typeof a.media!="string"||matchMedia(a.media).matches!==!1)&&!(e.state.loading&4)){if(e.instance===null){var n=ha(a.href),u=l.querySelector(Mn(n));if(u){l=u._p,l!==null&&typeof l=="object"&&typeof l.then=="function"&&(t.count++,t=Uu.bind(t),l.then(t,t)),e.state.loading|=4,e.instance=u,vt(u);return}u=l.ownerDocument||l,a=U1(a),(n=ll.get(n))&&Qf(a,n),u=u.createElement("link"),vt(u);var i=u;i._p=new Promise(function(c,f){i.onload=c,i.onerror=f}),Et(u,"link",a),e.instance=u}t.stylesheets===null&&(t.stylesheets=new Map),t.stylesheets.set(e,l),(l=e.state.preload)&&!(e.state.loading&3)&&(t.count++,e=Uu.bind(t),l.addEventListener("load",e),l.addEventListener("error",e))}}var Gi=0;function ng(t,l){return t.stylesheets&&t.count===0&&su(t,t.stylesheets),0<t.count||0<t.imgCount?function(e){var a=setTimeout(function(){if(t.stylesheets&&su(t,t.stylesheets),t.unsuspend){var u=t.unsuspend;t.unsuspend=null,u()}},6e4+l);0<t.imgBytes&&Gi===0&&(Gi=62500*Um());var n=setTimeout(function(){if(t.waitingForImages=!1,t.count===0&&(t.stylesheets&&su(t,t.stylesheets),t.unsuspend)){var u=t.unsuspend;t.unsuspend=null,u()}},(t.imgBytes>Gi?50:800)+l);return t.unsuspend=e,function(){t.unsuspend=null,clearTimeout(a),clearTimeout(n)}}:null}function Uu(){if(this.count--,this.count===0&&(this.imgCount===0||!this.waitingForImages)){if(this.stylesheets)su(this,this.stylesheets);else if(this.unsuspend){var t=this.unsuspend;this.unsuspend=null,t()}}}var Hu=null;function su(t,l){t.stylesheets=null,t.unsuspend!==null&&(t.count++,Hu=new Map,l.forEach(ug,t),Hu=null,Uu.call(t))}function ug(t,l){if(!(l.state.loading&4)){var e=Hu.get(t);if(e)var a=e.get(null);else{e=new Map,Hu.set(t,e);for(var n=t.querySelectorAll("link[data-precedence],style[data-precedence]"),u=0;u<n.length;u++){var i=n[u];(i.nodeName==="LINK"||i.getAttribute("media")!=="not all")&&(e.set(i.dataset.precedence,i),a=i)}a&&e.set(null,a)}n=l.instance,i=n.getAttribute("data-precedence"),u=e.get(i)||a,u===a&&e.set(null,n),e.set(i,n),this.count++,a=Uu.bind(this),n.addEventListener("load",a),n.addEventListener("error",a),u?u.parentNode.insertBefore(n,u.nextSibling):(t=t.nodeType===9?t.head:t,t.insertBefore(n,t.firstChild)),l.state.loading|=4}}var vn={$$typeof:Sl,Provider:null,Consumer:null,_currentValue:xe,_currentValue2:xe,_threadCount:0};function ig(t,l,e,a,n,u,i,c,f){this.tag=1,this.containerInfo=t,this.pingCache=this.current=this.pendingChildren=null,this.timeoutHandle=-1,this.callbackNode=this.next=this.pendingContext=this.context=this.cancelPendingCommit=null,this.callbackPriority=0,this.expirationTimes=yi(-1),this.entangledLanes=this.shellSuspendCounter=this.errorRecoveryDisabledLanes=this.expiredLanes=this.warmLanes=this.pingedLanes=this.suspendedLanes=this.pendingLanes=0,this.entanglements=yi(0),this.hiddenUpdates=yi(null),this.identifierPrefix=a,this.onUncaughtError=n,this.onCaughtError=u,this.onRecoverableError=i,this.pooledCache=null,this.pooledCacheLanes=0,this.formState=f,this.incompleteTransitions=new Map}function B1(t,l,e,a,n,u,i,c,f,o,y,v){return t=new ig(t,l,e,i,f,o,y,v,c),l=1,u===!0&&(l|=24),u=Ut(3,null,null,l),t.current=u,u.stateNode=t,l=pf(),l.refCount++,t.pooledCache=l,l.refCount++,u.memoizedState={element:a,isDehydrated:e,cache:l},zf(u),t}function X1(t){return t?(t=Fe,t):Fe}function L1(t,l,e,a,n,u){n=X1(n),a.context===null?a.context=n:a.pendingContext=n,a=Wl(l),a.payload={element:e},u=u===void 0?null:u,u!==null&&(a.callback=u),e=Fl(t,a,l),e!==null&&(Nt(e,t,l),Ja(e,t,l))}function jo(t,l){if(t=t.memoizedState,t!==null&&t.dehydrated!==null){var e=t.retryLane;t.retryLane=e!==0&&e<l?e:l}}function Kf(t,l){jo(t,l),(t=t.alternate)&&jo(t,l)}function Z1(t){if(t.tag===13||t.tag===31){var l=De(t,67108864);l!==null&&Nt(l,t,67108864),Kf(t,67108864)}}function Ao(t){if(t.tag===13||t.tag===31){var l=Zt();l=nf(l);var e=De(t,l);e!==null&&Nt(e,t,l),Kf(t,l)}}var Bu=!0;function cg(t,l,e,a){var n=D.T;D.T=null;var u=X.p;try{X.p=2,Jf(t,l,e,a)}finally{X.p=u,D.T=n}}function fg(t,l,e,a){var n=D.T;D.T=null;var u=X.p;try{X.p=8,Jf(t,l,e,a)}finally{X.p=u,D.T=n}}function Jf(t,l,e,a){if(Bu){var n=Vc(a);if(n===null)Li(t,l,a,Xu,e),ko(t,a);else if(og(n,t,l,e,a))a.stopPropagation();else if(ko(t,a),l&4&&-1<sg.indexOf(t)){for(;n!==null;){var u=Sa(n);if(u!==null)switch(u.tag){case 3:if(u=u.stateNode,u.current.memoizedState.isDehydrated){var i=me(u.pendingLanes);if(i!==0){var c=u;for(c.pendingLanes|=2,c.entangledLanes|=2;i;){var f=1<<31-Lt(i);c.entanglements[1]|=f,i&=~f}dl(u),!(B&6)&&(Ou=Bt()+500,kn(0))}}break;case 31:case 13:c=De(u,2),c!==null&&Nt(c,u,2),ni(),Kf(u,2)}if(u=Vc(a),u===null&&Li(t,l,a,Xu,e),u===n)break;n=u}n!==null&&a.stopPropagation()}else Li(t,l,a,null,e)}}function Vc(t){return t=sf(t),Wf(t)}var Xu=null;function Wf(t){if(Xu=null,t=Ye(t),t!==null){var l=pn(t);if(l===null)t=null;else{var e=l.tag;if(e===13){if(t=sr(l),t!==null)return t;t=null}else if(e===31){if(t=or(l),t!==null)return t;t=null}else if(e===3){if(l.stateNode.current.memoizedState.isDehydrated)return l.tag===3?l.stateNode.containerInfo:null;t=null}else l!==t&&(t=null)}}return Xu=t,null}function G1(t){switch(t){case"beforetoggle":case"cancel":case"click":case"close":case"contextmenu":case"copy":case"cut":case"auxclick":case"dblclick":case"dragend":case"dragstart":case"drop":case"focusin":case"focusout":case"input":case"invalid":case"keydown":case"keypress":case"keyup":case"mousedown":case"mouseup":case"paste":case"pause":case"play":case"pointercancel":case"pointerdown":case"pointerup":case"ratechange":case"reset":case"resize":case"seeked":case"submit":case"toggle":case"touchcancel":case"touchend":case"touchstart":case"volumechange":case"change":case"selectionchange":case"textInput":case"compositionstart":case"compositionend":case"compositionupdate":case"beforeblur":case"afterblur":case"beforeinput":case"blur":case"fullscreenchange":case"focus":case"hashchange":case"popstate":case"select":case"selectstart":return 2;case"drag":case"dragenter":case"dragexit":case"dragleave":case"dragover":case"mousemove":case"mouseout":case"mouseover":case"pointermove":case"pointerout":case"pointerover":case"scroll":case"touchmove":case"wheel":case"mouseenter":case"mouseleave":case"pointerenter":case"pointerleave":return 8;case"message":switch(K0()){case mr:return 2;case gr:return 8;case vu:case J0:return 32;case vr:return 268435456;default:return 32}default:return 32}}var Kc=!1,te=null,le=null,ee=null,hn=new Map,xn=new Map,Ll=[],sg="mousedown mouseup touchcancel touchend touchstart auxclick dblclick pointercancel pointerdown pointerup dragend dragstart drop compositionend compositionstart keydown keypress keyup input textInput copy cut paste click change contextmenu reset".split(" ");function ko(t,l){switch(t){case"focusin":case"focusout":te=null;break;case"dragenter":case"dragleave":le=null;break;case"mouseover":case"mouseout":ee=null;break;case"pointerover":case"pointerout":hn.delete(l.pointerId);break;case"gotpointercapture":case"lostpointercapture":xn.delete(l.pointerId)}}function Na(t,l,e,a,n,u){return t===null||t.nativeEvent!==u?(t={blockedOn:l,domEventName:e,eventSystemFlags:a,nativeEvent:u,targetContainers:[n]},l!==null&&(l=Sa(l),l!==null&&Z1(l)),t):(t.eventSystemFlags|=a,l=t.targetContainers,n!==null&&l.indexOf(n)===-1&&l.push(n),t)}function og(t,l,e,a,n){switch(l){case"focusin":return te=Na(te,t,l,e,a,n),!0;case"dragenter":return le=Na(le,t,l,e,a,n),!0;case"mouseover":return ee=Na(ee,t,l,e,a,n),!0;case"pointerover":var u=n.pointerId;return hn.set(u,Na(hn.get(u)||null,t,l,e,a,n)),!0;case"gotpointercapture":return u=n.pointerId,xn.set(u,Na(xn.get(u)||null,t,l,e,a,n)),!0}return!1}function Y1(t){var l=Ye(t.target);if(l!==null){var e=pn(l);if(e!==null){if(l=e.tag,l===13){if(l=sr(e),l!==null){t.blockedOn=l,rs(t.priority,function(){Ao(e)});return}}else if(l===31){if(l=or(e),l!==null){t.blockedOn=l,rs(t.priority,function(){Ao(e)});return}}else if(l===3&&e.stateNode.current.memoizedState.isDehydrated){t.blockedOn=e.tag===3?e.stateNode.containerInfo:null;return}}}t.blockedOn=null}function ou(t){if(t.blockedOn!==null)return!1;for(var l=t.targetContainers;0<l.length;){var e=Vc(t.nativeEvent);if(e===null){e=t.nativeEvent;var a=new e.constructor(e.type,e);dc=a,e.target.dispatchEvent(a),dc=null}else return l=Sa(e),l!==null&&Z1(l),t.blockedOn=e,!1;l.shift()}return!0}function Mo(t,l,e){ou(t)&&e.delete(l)}function rg(){Kc=!1,te!==null&&ou(te)&&(te=null),le!==null&&ou(le)&&(le=null),ee!==null&&ou(ee)&&(ee=null),hn.forEach(Mo),xn.forEach(Mo)}function Yn(t,l){t.blockedOn===l&&(t.blockedOn=null,Kc||(Kc=!0,mt.unstable_scheduleCallback(mt.unstable_NormalPriority,rg)))}var Qn=null;function Oo(t){Qn!==t&&(Qn=t,mt.unstable_scheduleCallback(mt.unstable_NormalPriority,function(){Qn===t&&(Qn=null);for(var l=0;l<t.length;l+=3){var e=t[l],a=t[l+1],n=t[l+2];if(typeof a!="function"){if(Wf(a||e)===null)continue;break}var u=Sa(e);u!==null&&(t.splice(l,3),l-=3,kc(u,{pending:!0,data:n,method:e.method,action:a},a,n))}}))}function xa(t){function l(f){return Yn(f,t)}te!==null&&Yn(te,t),le!==null&&Yn(le,t),ee!==null&&Yn(ee,t),hn.forEach(l),xn.forEach(l);for(var e=0;e<Ll.length;e++){var a=Ll[e];a.blockedOn===t&&(a.blockedOn=null)}for(;0<Ll.length&&(e=Ll[0],e.blockedOn===null);)Y1(e),e.blockedOn===null&&Ll.shift();if(e=(t.ownerDocument||t).$$reactFormReplay,e!=null)for(a=0;a<e.length;a+=3){var n=e[a],u=e[a+1],i=n[Ct]||null;if(typeof u=="function")i||Oo(e);else if(i){var c=null;if(u&&u.hasAttribute("formAction")){if(n=u,i=u[Ct]||null)c=i.formAction;else if(Wf(n)!==null)continue}else c=i.action;typeof c=="function"?e[a+1]=c:(e.splice(a,3),a-=3),Oo(e)}}}function Q1(){function t(u){u.canIntercept&&u.info==="react-transition"&&u.intercept({handler:function(){return new Promise(function(i){return n=i})},focusReset:"manual",scroll:"manual"})}function l(){n!==null&&(n(),n=null),a||setTimeout(e,20)}function e(){if(!a&&!navigation.transition){var u=navigation.currentEntry;u&&u.url!=null&&navigation.navigate(u.url,{state:u.getState(),info:"react-transition",history:"replace"})}}if(typeof navigation=="object"){var a=!1,n=null;return navigation.addEventListener("navigate",t),navigation.addEventListener("navigatesuccess",l),navigation.addEventListener("navigateerror",l),setTimeout(e,100),function(){a=!0,navigation.removeEventListener("navigate",t),navigation.removeEventListener("navigatesuccess",l),navigation.removeEventListener("navigateerror",l),n!==null&&(n(),n=null)}}}function Ff(t){this._internalRoot=t}ci.prototype.render=Ff.prototype.render=function(t){var l=this._internalRoot;if(l===null)throw Error(z(409));var e=l.current,a=Zt();L1(e,a,t,l,null,null)};ci.prototype.unmount=Ff.prototype.unmount=function(){var t=this._internalRoot;if(t!==null){this._internalRoot=null;var l=t.containerInfo;L1(t.current,2,null,t,null,null),ni(),l[ba]=null}};function ci(t){this._internalRoot=t}ci.prototype.unstable_scheduleHydration=function(t){if(t){var l=Sr();t={blockedOn:null,target:t,priority:l};for(var e=0;e<Ll.length&&l!==0&&l<Ll[e].priority;e++);Ll.splice(e,0,t),e===0&&Y1(t)}};var Do=cr.version;if(Do!=="19.2.4")throw Error(z(527,Do,"19.2.4"));X.findDOMNode=function(t){var l=t._reactInternals;if(l===void 0)throw typeof t.render=="function"?Error(z(188)):(t=Object.keys(t).join(","),Error(z(268,t)));return t=X0(l),t=t!==null?rr(t):null,t=t===null?null:t.stateNode,t};var dg={bundleType:0,version:"19.2.4",rendererPackageName:"react-dom",currentDispatcherRef:D,reconcilerVersion:"19.2.4"};if(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__<"u"){var Vn=__REACT_DEVTOOLS_GLOBAL_HOOK__;if(!Vn.isDisabled&&Vn.supportsFiber)try{bn=Vn.inject(dg),Xt=Vn}catch{}}Gu.createRoot=function(t,l){if(!fr(t))throw Error(z(299));var e=!1,a="",n=Rd,u=Ud,i=Hd;return l!=null&&(l.unstable_strictMode===!0&&(e=!0),l.identifierPrefix!==void 0&&(a=l.identifierPrefix),l.onUncaughtError!==void 0&&(n=l.onUncaughtError),l.onCaughtError!==void 0&&(u=l.onCaughtError),l.onRecoverableError!==void 0&&(i=l.onRecoverableError)),l=B1(t,1,!1,null,null,e,a,null,n,u,i,Q1),t[ba]=l.current,Yf(t),new Ff(l)};Gu.hydrateRoot=function(t,l,e){if(!fr(t))throw Error(z(299));var a=!1,n="",u=Rd,i=Ud,c=Hd,f=null;return e!=null&&(e.unstable_strictMode===!0&&(a=!0),e.identifierPrefix!==void 0&&(n=e.identifierPrefix),e.onUncaughtError!==void 0&&(u=e.onUncaughtError),e.onCaughtError!==void 0&&(i=e.onCaughtError),e.onRecoverableError!==void 0&&(c=e.onRecoverableError),e.formState!==void 0&&(f=e.formState)),l=B1(t,1,!0,l,e??null,a,n,f,u,i,c,Q1),l.context=X1(null),e=l.current,a=Zt(),a=nf(a),n=Wl(a),n.callback=null,Fl(e,n,a),e=a,l.current.lanes=e,zn(l,e),dl(l),t[ba]=l.current,Yf(t),new ci(l)};Gu.version="19.2.4";function V1(){if(!(typeof __REACT_DEVTOOLS_GLOBAL_HOOK__>"u"||typeof __REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE!="function"))try{__REACT_DEVTOOLS_GLOBAL_HOOK__.checkDCE(V1)}catch(t){console.error(t)}}V1(),Ko.exports=Gu;var yg=Ko.exports,Ca={},_o;function mg(){if(_o)return Ca;_o=1,Object.defineProperty(Ca,"__esModule",{value:!0}),Ca.styleq=void 0;var t=new WeakMap,l="$$css";function e(n){var u,i,c;return n!=null&&(u=n.disableCache===!0,i=n.disableMix===!0,c=n.transform),function(){for(var o=[],y="",v=null,d="",g=u?null:t,x=new Array(arguments.length),S=0;S<arguments.length;S++)x[S]=arguments[S];for(;x.length>0;){var E=x.pop();if(!(E==null||E===!1)){if(Array.isArray(E)){for(var r=0;r<E.length;r++)x.push(E[r]);continue}var s=c!=null?c(E):E;if(s.$$css!=null){var m="";if(g!=null&&g.has(s)){var h=g.get(s);h!=null&&(m=h[0],d=h[2],o.push.apply(o,h[1]),g=h[3])}else{var $=[];for(var A in s){var T=s[A];if(A===l){var M=s[A];M!==!0&&(d=d?M+"; "+d:M);continue}typeof T=="string"||T===null?o.includes(A)||(o.push(A),g!=null&&$.push(A),typeof T=="string"&&(m+=m?" "+T:T)):console.error("styleq: ".concat(A," typeof ").concat(String(T),' is not "string" or "null".'))}if(g!=null){var j=new WeakMap;g.set(s,[m,$,d,j]),g=j}}m&&(y=y?m+" "+y:m)}else if(i)v==null&&(v={}),v=Object.assign({},s,v);else{var k=null;for(var P in s){var et=s[P];et!==void 0&&(o.includes(P)||(et!=null&&(v==null&&(v={}),k==null&&(k={}),k[P]=et),o.push(P),g=null))}k!=null&&(v=Object.assign(k,v))}}}var yl=[y,v,d];return yl}}var a=Ca.styleq=e();return a.factory=e,Ca}var gg=mg();function Q(...t){const[l,e,a]=gg.styleq(t),n={};return l!=null&&l!==""&&(n.className=l),e!=null&&Object.keys(e).length>0&&(n.style=e),a!=null&&a!==""&&(n["data-style-src"]=a),n}const No={"--color-accent":"var(--color-accent)","--color-on-dark":"var(--color-on-dark)"};let Co={};function vg(t){Co={...Co,...t}}function hg(t){return t==="base"?"":t.split("+").map(l=>{const[e,a]=l.split(":");return/^\d/.test(a)?`.${e}-${a}`:`.${a}`}).join("")}const Yi={[-5]:"--font-size-4xs",[-4]:"--font-size-3xs",[-3]:"--font-size-2xs",[-2]:"--font-size-xs",[-1]:"--font-size-sm",0:"--font-size-base",1:"--font-size-lg",2:"--font-size-xl",3:"--font-size-2xl",4:"--font-size-3xl",5:"--font-size-4xl",6:"--font-size-5xl"},xg={1:3,2:2,3:1,4:0,5:-1,6:-2},pg={body:0,large:1,label:0,code:0,supporting:-1,"display-1":6,"display-2":5,"display-3":4},bg={1:"var(--font-weight-semibold)",2:"var(--font-weight-semibold)",3:"var(--font-weight-semibold)",4:"var(--font-weight-semibold)",5:"var(--font-weight-semibold)",6:"var(--font-weight-semibold)"},Sg={body:"var(--font-weight-normal)",large:"var(--font-weight-semibold)",label:"var(--font-weight-medium)",code:"var(--font-weight-normal)",supporting:"var(--font-weight-normal)","display-1":"var(--font-weight-normal)","display-2":"var(--font-weight-normal)","display-3":"var(--font-weight-normal)"};function Qi(t,l,e){return Math.round(t*Math.pow(l,e))}function zg(t){return`${Math.round(t/16*1e4)/1e4}rem`}function Eg(t){return t<20?1.5:t<32?1.4:1.25}function qo(t){const l=Eg(t),e=t*l,a=Math.max(Math.round(e/4)*4,Math.ceil((t+4)/4)*4);return Math.round(a/t*1e4)/1e4}function Tg(t){const{base:l,ratio:e,weights:a}=t,n={},u={...bg,...a==null?void 0:a.heading},i={...Sg,...a==null?void 0:a.text};for(let c=-5;c<=6;c++){const f=Qi(l,e,c);n[Yi[c]]=zg(f)}for(const[c,f]of Object.entries(xg)){const o=Number(c),y=Qi(l,e,f),v=qo(y);n[`--text-heading-${o}-size`]=`var(${Yi[f]})`,n[`--text-heading-${o}-weight`]=u[o],n[`--text-heading-${o}-leading`]=`${v}`}for(const[c,f]of Object.entries(pg)){const o=Qi(l,e,f),y=qo(o);n[`--text-${c}-size`]=`var(${Yi[f]})`,n[`--text-${c}-weight`]=i[c],n[`--text-${c}-leading`]=`${y}`}return n}const $g={body:"var(--font-family-body)",large:"var(--font-family-body)",label:"var(--font-family-body)",code:"var(--font-family-code)",supporting:"var(--font-family-body)","display-1":"var(--font-family-heading)","display-2":"var(--font-family-heading)","display-3":"var(--font-family-heading)"};function jg(t){const l={},e={};for(const n of[1,2,3,4,5,6])e[`level:${n}`]={fontFamily:"var(--font-family-heading)",fontSize:`var(--text-heading-${n}-size)`,fontWeight:`var(--text-heading-${n}-weight)`,lineHeight:`var(--text-heading-${n}-leading)`};l.heading=e;const a={};for(const n of["body","large","label","code","supporting","display-1","display-2","display-3"])a[`type:${n}`]={fontFamily:$g[n],fontSize:`var(--text-${n}-size)`,lineHeight:`var(--text-${n}-leading)`};return l.text=a,l}function we(t){return Math.round(t/5)*5}function Ag(t){const{fast:l,medium:e,ratio:a,easing:n}=t,u={"--duration-fast-min":`${we(l*a)}ms`,"--duration-fast":`${we(l)}ms`,"--duration-fast-max":`${we(l/a)}ms`,"--duration-medium-min":`${we(e*a)}ms`,"--duration-medium":`${we(e)}ms`,"--duration-medium-max":`${we(e/a)}ms`};return n&&(u["--ease-standard"]=n),u}function kg(t){const{base:l,multiplier:e}=t;return{"--radius-none":"0px","--radius-inner":`${Math.round(l*1*e)}px`,"--radius-element":`${Math.round(l*2*e)}px`,"--radius-container":`${Math.round(l*3*e)}px`,"--radius-page":`${Math.round(l*7*e)}px`,"--radius-full":"9999px"}}function Mg(t){return Array.isArray(t)?`light-dark(${t[0]}, ${t[1]})`:t}function Og(t,l){if(!t&&!l)return;if(!t)return l;if(!l)return t;const e={};for(const[a,n]of Object.entries(t))e[a]={...n};for(const[a,n]of Object.entries(l))if(!e[a])e[a]={...n};else for(const[u,i]of Object.entries(n))e[a][u]={...e[a][u],...i};return e}function Kn(t){return{normal:"var(--font-weight-normal)",medium:"var(--font-weight-medium)",semibold:"var(--font-weight-semibold)",bold:"var(--font-weight-bold)"}[t]??t}function Vi(t,l){if(!t)return;const e=t.includes(" ")?`"${t}"`:t;return l?`${e}, ${l}`:e}function Dg(t){var i,c,f,o,y,v,d,g;const l={},e=t.typography;let a;if(e!=null&&e.scale){const x={},S=e.heading;if(S!=null&&S.weights)for(const[s,m]of Object.entries(S.weights))m&&(x[Number(s)]=Kn(m));const E=S!=null&&S.weight?Kn(S.weight):void 0;if(E)for(let s=1;s<=6;s++)s in x||(x[s]=E);const r={};(i=e.body)!=null&&i.weight&&(r.body=Kn(e.body.weight)),(c=e.code)!=null&&c.weight&&(r.code=Kn(e.code.weight)),a={base:e.scale.base,ratio:e.scale.ratio,weights:{...Object.keys(x).length>0?{heading:x}:{},...Object.keys(r).length>0?{text:r}:{}}}}if(a){const x=Tg(a);for(const[S,E]of Object.entries(x))l[S]=E}if(t.radius){const x=kg(t.radius);for(const[S,E]of Object.entries(x))l[S]=E}if(t.motion){const x=Ag(t.motion);for(const[S,E]of Object.entries(x))l[S]=E}if(e){const x=Vi((f=e.body)==null?void 0:f.family,(o=e.body)==null?void 0:o.fallbacks),S=Vi((y=e.heading)==null?void 0:y.family,(v=e.heading)==null?void 0:v.fallbacks)??x,E=Vi((d=e.code)==null?void 0:d.family,(g=e.code)==null?void 0:g.fallbacks);x&&(l["--font-family-body"]=x),S&&(l["--font-family-heading"]=S),E&&(l["--font-family-code"]=E)}if(t.tokens)for(const[x,S]of Object.entries(t.tokens))S!==void 0&&(l[x]=Mg(S));let n=t.components;if(a){const x=jg();n=Og(x,t.components)}let u;if(e){const x=new Set,S=[];for(const E of[e.body,e.heading,e.code])E!=null&&E.family&&E.url&&!x.has(E.family)&&(x.add(E.family),S.push({family:E.family,url:E.url}));S.length>0&&(u=S)}return{name:t.name,tokens:l,components:n,icons:t.icons,fonts:u,__inputTokens:t.tokens}}function wo(t){return t.replace(/[A-Z]/g,l=>`-${l.toLowerCase()}`)}function _g(t){const l=[],e=t.tokens,a=y=>e[y]||`var(${y})`,n=Object.entries(e);if(n.length>0){const y=n.map(([v,d])=>`    ${v}: ${d};`).join(`
+`);l.push(`  :scope {
+${y}
+  }`)}if(t.components)for(const[y,v]of Object.entries(t.components))for(const[d,g]of Object.entries(v)){const x=Object.entries(g);if(x.length>0){const S=hg(d),E=`.xds-${y}${S}`,r=[],s=[];for(const[m,h]of x)m.startsWith(":")&&typeof h=="object"?s.push([m,h]):r.push([m,h]);if(r.length>0){const m=r.map(([h,$])=>`    ${wo(h)}: ${$};`).join(`
+`);l.push(`  ${E} {
+${m}
+  }`)}for(const[m,h]of s){const $=Object.entries(h);if($.length>0){const A=$.map(([T,M])=>`    ${wo(T)}: ${M};`).join(`
+`);l.push(`  ${E}${m} {
+${A}
+  }`)}}}}l.push(`  :is(h1, h2, h3, h4, h5, h6) {
+    font-family: var(--font-family-heading);
+    color: var(--color-text-primary);
+  }`);for(let y=1;y<=6;y++)l.push(`  h${y} {
+    font-size: ${a(`--text-heading-${y}-size`)};
+    font-weight: ${a(`--text-heading-${y}-weight`)};
+    line-height: ${a(`--text-heading-${y}-leading`)};
+  }`);l.push(`  p {
+    font-family: var(--font-family-heading);
+    font-size: ${a("--text-body-size")};
+    font-weight: ${a("--text-body-weight")};
+    line-height: ${a("--text-body-leading")};
+    color: var(--color-text-primary);
+  }`),l.push(`  small {
+    font-size: ${a("--text-supporting-size")};
+    font-weight: ${a("--text-supporting-weight")};
+    line-height: ${a("--text-supporting-leading")};
+    color: var(--color-text-secondary);
+  }`),l.push(`  code, pre {
+    font-family: var(--font-family-code);
+    font-size: ${a("--text-code-size")};
+    line-height: ${a("--text-code-leading")};
+  }`),l.push(`  hr {
+    border: none;
+    border-top: 1px solid var(--color-border);
+  }`);const u={primary:"var(--color-text-primary)",secondary:"var(--color-text-secondary)",disabled:"var(--color-text-disabled)",placeholder:"var(--color-text-secondary)",active:"var(--color-accent)"},i=t.components||{},c="text"in i,f="heading"in i,o="link"in i;if(c||f||o)for(const[y,v]of Object.entries(u))c&&l.push(`  .xds-text.${y} { color: ${v}; }`),f&&l.push(`  .xds-heading.${y} { color: ${v}; }`),o&&l.push(`  .xds-link.${y} { color: ${v}; }`);return l}function Ng(t){const l=_g(t);if(l.length===0)return"";const e=`[data-xds-theme="${t.name}"]`,a=l.join(`
+
+`);return`@scope (${e}) to ([data-xds-theme]) {
+${a}
+}`}const Cg=p.createContext(null),Jn={base:{k1xSpc:"xjp7ctv",kMwMTN:"x1tgivj0",kMv6JI:"x9ynric",$$css:!0},light:{kQNsl9:"x19aimcq",$$css:!0},dark:{kQNsl9:"xntwwlm",$$css:!0},system:{kQNsl9:"x108lcm5",$$css:!0}},Ki=new Set;function qg(t){const l=p.useId();p.useInsertionEffect(()=>{if(t.__built)return;const e=`xds-theme-${t.name}`;if(Ki.has(e))return;const a=Ng(t);if(!a)return;const n=document.createElement("style");return n.setAttribute("data-xds-theme",t.name),n.setAttribute("data-xds-id",l),n.textContent=`@layer xds-theme {
+${a}
+}`,document.head.appendChild(n),Ki.add(e),()=>{const u=document.querySelector(`style[data-xds-theme="${t.name}"][data-xds-id="${l}"]`);u&&(u.remove(),Ki.delete(e))}},[t,l])}function wg(t){const l=p.useRef([]);p.useLayoutEffect(()=>{if(typeof document>"u"||!t.fonts||t.fonts.length===0)return;const e=[];for(const a of t.fonts){if(document.fonts.check(`16px "${a.family}"`)||document.head.querySelector(`link[rel="stylesheet"][href="${a.url}"]`))continue;const i=document.createElement("link");i.rel="stylesheet",i.href=a.url,document.head.appendChild(i),e.push(i),console.warn(`[XDS] Theme "${t.name}" loaded font "${a.family}" at runtime. For better performance, add to your document <head>:
+  <link rel="stylesheet" href="${a.url}" />`)}return l.current=e,()=>{for(const a of l.current)a.parentNode&&a.parentNode.removeChild(a);l.current=[]}},[t.fonts,t.name])}function K1({theme:t,mode:l="system",children:e}){qg(t),wg(t);const a=l==="dark"?Jn.dark:l==="light"?Jn.light:Jn.system,n=t.icons;n!=null&&vg(n);const u=p.useMemo(()=>({theme:t,mode:l}),[t,l]);return b.jsx(Cg.Provider,{value:u,children:b.jsx("div",{...Q(Jn.base,a),"data-xds-theme":t.name,"data-theme":l==="system"?void 0:l,children:e})})}K1.displayName="XDSTheme";function Rg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3"}))}const Ug=p.forwardRef(Rg);function Hg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M4.5 10.5 12 3m0 0 7.5 7.5M12 3v18"}))}const Bg=p.forwardRef(Hg);function Xg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3 7.5 7.5 3m0 0L12 7.5M7.5 3v13.5m13.5 0L16.5 21m0 0L12 16.5m4.5 4.5V7.5"}))}const Lg=p.forwardRef(Xg);function Zg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5"}))}const Gg=p.forwardRef(Zg);function Yg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5m-9-6h.008v.008H12v-.008ZM12 15h.008v.008H12V15Zm0 2.25h.008v.008H12v-.008ZM9.75 15h.008v.008H9.75V15Zm0 2.25h.008v.008H9.75v-.008ZM7.5 15h.008v.008H7.5V15Zm0 2.25h.008v.008H7.5v-.008Zm6.75-4.5h.008v.008h-.008v-.008Zm0 2.25h.008v.008h-.008V15Zm0 2.25h.008v.008h-.008v-.008Zm2.25-4.5h.008v.008H16.5v-.008Zm0 2.25h.008v.008H16.5V15Z"}))}const Qg=p.forwardRef(Yg);function Vg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m4.5 12.75 6 6 9-13.5"}))}const Kg=p.forwardRef(Vg);function Jg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m19.5 8.25-7.5 7.5-7.5-7.5"}))}const Wg=p.forwardRef(Jg);function Fg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M15.75 19.5 8.25 12l7.5-7.5"}))}const Ig=p.forwardRef(Fg);function Pg({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m8.25 4.5 7.5 7.5-7.5 7.5"}))}const tv=p.forwardRef(Pg);function lv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"}))}const ev=p.forwardRef(lv);function av({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"}))}const nv=p.forwardRef(av);function uv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M3.98 8.223A10.477 10.477 0 0 0 1.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.451 10.451 0 0 1 12 4.5c4.756 0 8.773 3.162 10.065 7.498a10.522 10.522 0 0 1-4.293 5.774M6.228 6.228 3 3m3.228 3.228 3.65 3.65m7.894 7.894L21 21m-3.228-3.228-3.65-3.65m0 0a3 3 0 1 0-4.243-4.243m4.242 4.242L9.88 9.88"}))}const iv=p.forwardRef(uv);function cv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 0 1-.659 1.591l-5.432 5.432a2.25 2.25 0 0 0-.659 1.591v2.927a2.25 2.25 0 0 1-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 0 0-.659-1.591L3.659 7.409A2.25 2.25 0 0 1 3 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0 1 12 3Z"}))}const fv=p.forwardRef(cv);function sv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z"}))}const ov=p.forwardRef(sv);function rv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"}))}const dv=p.forwardRef(rv);function yv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z"}))}const mv=p.forwardRef(yv);function gv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",fill:"none",viewBox:"0 0 24 24",strokeWidth:1.5,stroke:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{strokeLinecap:"round",strokeLinejoin:"round",d:"M6 18 18 6M6 6l12 12"}))}const vv=p.forwardRef(gv);function hv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{fillRule:"evenodd",d:"M15.75 2.25H21a.75.75 0 0 1 .75.75v5.25a.75.75 0 0 1-1.5 0V4.81L8.03 17.03a.75.75 0 0 1-1.06-1.06L19.19 3.75h-3.44a.75.75 0 0 1 0-1.5Zm-10.5 4.5a1.5 1.5 0 0 0-1.5 1.5v10.5a1.5 1.5 0 0 0 1.5 1.5h10.5a1.5 1.5 0 0 0 1.5-1.5V10.5a.75.75 0 0 1 1.5 0v8.25a3 3 0 0 1-3 3H5.25a3 3 0 0 1-3-3V8.25a3 3 0 0 1 3-3h8.25a.75.75 0 0 1 0 1.5H5.25Z",clipRule:"evenodd"}))}const xv=p.forwardRef(hv);function pv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{fillRule:"evenodd",d:"M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12Zm13.36-1.814a.75.75 0 1 0-1.22-.872l-3.236 4.53L9.53 12.22a.75.75 0 0 0-1.06 1.06l2.25 2.25a.75.75 0 0 0 1.14-.094l3.75-5.25Z",clipRule:"evenodd"}))}const bv=p.forwardRef(pv);function Sv({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{fillRule:"evenodd",d:"M9.401 3.003c1.155-2 4.043-2 5.197 0l7.355 12.748c1.154 2-.29 4.5-2.599 4.5H4.645c-2.309 0-3.752-2.5-2.598-4.5L9.4 3.003ZM12 8.25a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V9a.75.75 0 0 1 .75-.75Zm0 8.25a.75.75 0 1 0 0-1.5.75.75 0 0 0 0 1.5Z",clipRule:"evenodd"}))}const zv=p.forwardRef(Sv);function Ev({title:t,titleId:l,...e},a){return p.createElement("svg",Object.assign({xmlns:"http://www.w3.org/2000/svg",viewBox:"0 0 24 24",fill:"currentColor","aria-hidden":"true","data-slot":"icon",ref:a,"aria-labelledby":l},e),t?p.createElement("title",{id:l},t):null,p.createElement("path",{fillRule:"evenodd",d:"M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25Zm-1.72 6.97a.75.75 0 1 0-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 1 0 1.06 1.06L12 13.06l1.72 1.72a.75.75 0 1 0 1.06-1.06L13.06 12l1.72-1.72a.75.75 0 1 0-1.06-1.06L12 10.94l-1.72-1.72Z",clipRule:"evenodd"}))}const Tv=p.forwardRef(Ev),it={width:"1em",height:"1em","aria-hidden":!0},$v={close:b.jsx(vv,{...it}),chevronDown:b.jsx(Wg,{...it}),chevronLeft:b.jsx(Ig,{...it}),chevronRight:b.jsx(tv,{...it}),check:b.jsx(Kg,{...it}),checkCircle:b.jsx(bv,{...it}),xCircle:b.jsx(Tv,{...it}),warning:b.jsx(zv,{...it}),info:b.jsx(ov,{...it}),calendar:b.jsx(Qg,{...it}),clock:b.jsx(ev,{...it}),externalLink:b.jsx(xv,{...it}),menu:b.jsx(Gg,{...it}),moreHorizontal:b.jsx(nv,{...it}),search:b.jsx(dv,{...it}),arrowUp:b.jsx(Bg,{...it}),arrowDown:b.jsx(Ug,{...it}),arrowsUpDown:b.jsx(Lg,{...it}),funnel:b.jsx(fv,{...it}),eyeSlash:b.jsx(iv,{...it}),viewColumns:b.jsx(mv,{...it})},jv=Dg({name:"default",typography:{scale:{base:14,ratio:1.2}},motion:{fast:175,medium:410,ratio:.75},tokens:{},components:{button:{"variant:secondary":{backgroundColor:"light-dark(rgba(5, 54, 89, 0.1), rgba(223, 226, 229, 0.2))"}}},icons:$v});function Tt(t,l){const e=[`xds-${t}`];if(l)for(const[a,n]of Object.entries(l)){if(n==null)continue;const u=String(n);/^\d/.test(u)?e.push(`${a}-${u}`):e.push(u)}return e.join(" ")}function At(t,l,e,a){let n=l.className?`${t} ${l.className}`:t;e&&(n=`${n} ${e}`);const u=a&&l.style?{...l.style,...a}:a||l.style;return{className:n,style:u}}const J1=p.createContext({isAutoLast:!1,variant:"default"}),Av={root:{k1xSpc:"x1lliihq",$$css:!0}};function W1({children:t,separator:l="/",variant:e="default",xstyle:a,className:n,style:u,label:i="Breadcrumb","data-testid":c,ref:f}){const o=p.Children.toArray(t),y=e==="supporting",v=o.some(g=>p.isValidElement(g)&&g.props.isCurrent===!0),d=[];return o.forEach((g,x)=>{const S=x===o.length-1,E={isAutoLast:!v&&S,variant:e};d.push(b.jsx(J1.Provider,{value:E,children:g},`item-${x}`)),S||d.push(b.jsx("li",{role:"presentation","aria-hidden":"true",...{0:{className:"x78zum5 x6s0dn4 xv1l7n4 xu0wf1k x87ps6o xjm74w1 xw6l6zx"},1:{className:"x78zum5 x6s0dn4 xv1l7n4 xu0wf1k x87ps6o x141an7d x1ltkj2j"}}[!!y<<0],children:l},`sep-${x}`))}),b.jsx("nav",{ref:f,"aria-label":i,"data-testid":c,...At(Tt("breadcrumbs",{variant:e}),Q(Av.root,a),n,u),children:b.jsx("ol",{className:"x78zum5 x6s0dn4 x1a02dak xe8uvvx x1ghz6dp x1717udv xzye2dw",children:d})})}W1.displayName="XDSBreadcrumbs";const kv=p.createContext(null);function F1(t){const l=p.useContext(kv);return t??(l==null?void 0:l.component)??"a"}const Re={root:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kOIVth:"xzye2dw",kogj98:"x1ghz6dp",$$css:!0},defaultSize:{kGuDYH:"xjm74w1",kLWn49:"xw6l6zx",$$css:!0},supportingSize:{kGuDYH:"x141an7d",kLWn49:"x1ltkj2j",$$css:!0}};function Xa({as:t,children:l,href:e,onClick:a,isCurrent:n,startIcon:u,"data-testid":i,xstyle:c,className:f,style:o}){const y=p.useContext(J1),v=n??y.isAutoLast,d=F1(t),g=y.variant==="supporting",x=b.jsxs(b.Fragment,{children:[u&&b.jsx("span",{className:"x78zum5 x6s0dn4 x2lah0s",children:u}),l]});return v?b.jsx("li",{...At(Tt("breadcrumb-item"),Q(Re.root,g?Re.supportingSize:Re.defaultSize,c),f,o),"data-testid":i,children:b.jsx("span",{...{0:{className:"x78zum5 x6s0dn4 xzye2dw x1pd3egz x1tgivj0"},1:{className:"x78zum5 x6s0dn4 xzye2dw x1pd3egz xv1l7n4"}}[!!g<<0],"aria-current":"page",children:x})}):b.jsx("li",{...At(Tt("breadcrumb-item"),Q(Re.root,g?Re.supportingSize:Re.defaultSize,c),f,o),"data-testid":i,children:b.jsx(d,{href:e,onClick:a,...{0:{className:"x78zum5 x6s0dn4 xzye2dw xu0wf1k x1hl2dhg x4ohgrr x1ypdohk xjse4m1"},1:{className:"x78zum5 x6s0dn4 xzye2dw xu0wf1k x1hl2dhg x4ohgrr x1ypdohk xv1l7n4"}}[!!g<<0],children:x})})}Xa.displayName="XDSBreadcrumbItem";const Ji={base:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x1lziwak",k71WvV:"x14z9mp",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kMzoRj:"xc342km",ksu8eU:"xng3xce",kVQacm:"x1rea2x4",kWkggS:"xjbqb8w",$$css:!0},fixed:{kVAEAm:"xixxii4",$$css:!0}};function Mv(t="above",l="center"){const a={above:"top",below:"bottom",start:"left",end:"right"}[t];return t==="above"||t==="below"?l==="start"?`${a} span-right`:l==="end"?`${a} span-left`:a:l==="start"?`${a} span-bottom`:l==="end"?`${a} span-top`:`${a} center`}function Ov(t){const{mode:l,onShow:e,onHide:a,lightDismiss:n=!1}=t,u=p.useId(),i=`--xds-layer-${u.replace(/:/g,"")}`,[c,f]=p.useState(!1),o=p.useRef(null),y=p.useRef(null),v=p.useCallback(()=>{o.current&&!o.current.matches(":popover-open")&&(o.current.showPopover(),f(!0),e==null||e())},[e]),d=p.useCallback(()=>{var r;(r=o.current)!=null&&r.matches(":popover-open")&&(o.current.hidePopover(),f(!1),a==null||a())},[a]),g=l==="context"?r=>{y.current&&(y.current.style.anchorName=""),r&&(r.style.anchorName=i),y.current=r}:void 0,x=p.useCallback(r=>{const s=r;s.newState==="closed"?(f(!1),a==null||a()):s.newState==="open"&&(f(!0),e==null||e())},[e,a]),S=p.useCallback(r=>{o.current=r,r&&r.addEventListener("toggle",x)},[x]),E=p.useCallback((r,s)=>{const{placement:m="above",alignment:h="center",xstyle:$,className:A,style:T}=s||{},M={positionAnchor:i,positionArea:Mv(m,h),positionTryFallbacks:"flip-block, flip-inline, flip-block flip-inline"},j=Q(Ji.base,$),k=A?`${A} ${j.className??""}`:j.className;return b.jsx("div",{ref:S,id:u,popover:n?"auto":"manual",className:k,style:{...j.style,...M,...T},children:r})},[i,u,n,S]);return p.useCallback((r,s)=>{const{x:m,y:h,xstyle:$,className:A,style:T}=s,M={top:h,left:m},j=Q(Ji.base,Ji.fixed,$),k=A?`${A} ${j.className??""}`:j.className;return b.jsx("div",{ref:S,id:u,popover:n?"auto":"manual",className:k,style:{...j.style,...M,...T},children:r})},[S,u,n]),{ref:g,anchorId:i,show:v,hide:d,isOpen:c,id:u,render:E}}const Dv={below:{kKVMdj:"xl1vlw0",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},above:{kKVMdj:"x3psbcj",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},end:{kKVMdj:"x1i331go",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0},start:{kKVMdj:"xck01x9",k44tkh:"x9uej1z",kyAemX:"x128ha8g",kWV6AL:"xskzprw",$$css:!0}},Wi={container:{kWkggS:"x19aspcf",kMwMTN:"xrkvqaz",kaIpWk:"x1hviunn",kMv6JI:"x9ynric",kGuDYH:"xjm74w1",kLWn49:"xw6l6zx",$$css:!0},marginBlock:{keoZOQ:"xcsaf9d",k1K539:"x14cgwvg",keTefX:"x1lziwak",k71WvV:"x14z9mp",$$css:!0},marginInline:{keoZOQ:"xdj266r",k1K539:"xat24cr",keTefX:"x11g1kdw",k71WvV:"xnur1sd",$$css:!0}};function _v(t){return t.hasAttribute("tabindex")?t.tabIndex>=0:["A","BUTTON","INPUT","SELECT","TEXTAREA"].includes(t.tagName)?!t.disabled:!!t.isContentEditable}function Nv(t={}){const{placement:l="above",alignment:e="center",delay:a=200,hideDelay:n=0,focusTrigger:u="auto",isEnabled:i=!0,onShow:c,onHide:f}=t,o=l==="above"||l==="below"?Wi.marginBlock:Wi.marginInline,y=Ov({mode:"context",onShow:c,onHide:f}),v=[Wi.container,o],d=p.useRef(null),g=p.useRef(null),x=p.useRef(null),S=p.useCallback(()=>{d.current&&(clearTimeout(d.current),d.current=null),g.current&&(clearTimeout(g.current),g.current=null)},[]),E=p.useCallback(()=>{i&&(S(),d.current=setTimeout(()=>{y.show()},a))},[i,S,y,a]),r=p.useCallback(()=>{S(),n>0?g.current=setTimeout(()=>{y.hide()},n):y.hide()},[S,y,n]),s=p.useCallback(()=>{typeof window<"u"&&typeof window.matchMedia=="function"&&window.matchMedia("(hover: none)").matches||E()},[E]),m=p.useCallback(()=>{r()},[r]),h=p.useCallback(j=>{!i||!j.target.matches(":focus-visible")||(S(),y.show())},[i,S,y]),$=p.useCallback(()=>{r()},[r]),A=p.useCallback(j=>{x.current&&(x.current.removeEventListener("mouseenter",s),x.current.removeEventListener("mouseleave",m),x.current.removeEventListener("focusin",h),x.current.removeEventListener("focusout",$)),j&&(j.addEventListener("mouseenter",s),j.addEventListener("mouseleave",m),(u==="always"||u==="auto"&&_v(j))&&(j.addEventListener("focusin",h),j.addEventListener("focusout",$))),x.current=j},[u,s,m,h,$]),T=p.useCallback(j=>{y.ref(j),A(j)},[y.ref,A]);p.useEffect(()=>()=>{S()},[S]);const M=p.useCallback((j,k)=>{const P=(k==null?void 0:k.placement)??l,et={placement:P,alignment:(k==null?void 0:k.alignment)??e,xstyle:[v,Dv[P]],className:Tt("tooltip")};return y.render(b.jsx("div",{className:"xfsso4q xy143xn x12gdq22 x1djylfy xw5ewwj x13faqbe",children:j}),et)},[y,l,e,v]);return{ref:T,positionRef:y.ref,interactionRef:A,anchorId:y.anchorId,describedBy:y.id,renderTooltip:M}}function Cv(t){let l=!1;return is.Children.forEach(t,e=>{is.isValidElement(e)&&(l=!0)}),!l}function Ro(...t){const l=t.filter(Boolean);return l.length>0?l.join(" "):void 0}function If({children:t,anchorRef:l,content:e,placement:a="above",alignment:n="center",delay:u=200,hideDelay:i=0,focusTrigger:c="auto",isEnabled:f=!0,onOpenChange:o,hasHoverIndication:y="auto"}){const v=p.useRef(null),d=t!=null?Cv(t):!1,g=y===!0||y==="auto"&&d,x=p.useCallback(()=>{o==null||o(!0)},[o]),S=p.useCallback(()=>{o==null||o(!1)},[o]),E=Nv({placement:a,alignment:n,delay:u,hideDelay:i,focusTrigger:c,isEnabled:f,onShow:x,onHide:S});return p.useLayoutEffect(()=>{if(!l)return;const r=l.current;if(!r)return;E.ref(r);const s=r.getAttribute("aria-describedby");return r.setAttribute("aria-describedby",Ro(s,E.describedBy)??""),()=>{E.ref(null),s?r.setAttribute("aria-describedby",s):r.removeAttribute("aria-describedby")}},[l,E.ref,E.describedBy]),p.useLayoutEffect(()=>{if(l||d)return;const r=v.current;if(!r)return;const s=r.firstElementChild;if(!s)return;E.ref(s);const m=s.getAttribute("aria-describedby");return s.setAttribute("aria-describedby",Ro(m,E.describedBy)??""),()=>{E.ref(null),m?s.setAttribute("aria-describedby",m):s.removeAttribute("aria-describedby")}},[l,d,E.ref,E.describedBy]),l&&t==null?b.jsx(b.Fragment,{children:E.renderTooltip(e)}):d?b.jsxs(b.Fragment,{children:[b.jsx("span",{ref:E.ref,tabIndex:0,"aria-describedby":E.describedBy,...{0:{className:"xt0psk2"},1:{className:"xt0psk2 xujl8zx xev0dqp xycaml9 xrys4gj"}}[!!g<<0],children:t}),E.renderTooltip(e)]}):b.jsxs(b.Fragment,{children:[b.jsx("div",{ref:v,className:"xjp7ctv",children:t}),E.renderTooltip(e)]})}If.displayName="XDSTooltip";const I1=Object.freeze(Object.defineProperty({__proto__:null,XDSTooltip:If},Symbol.toStringTag,{value:"Module"})),qv="modulepreload",wv=function(t,l){return new URL(t,l).href},Uo={},P1=function(l,e,a){let n=Promise.resolve();if(e&&e.length>0){const i=document.getElementsByTagName("link"),c=document.querySelector("meta[property=csp-nonce]"),f=(c==null?void 0:c.nonce)||(c==null?void 0:c.getAttribute("nonce"));n=Promise.allSettled(e.map(o=>{if(o=wv(o,a),o in Uo)return;Uo[o]=!0;const y=o.endsWith(".css"),v=y?'[rel="stylesheet"]':"";if(!!a)for(let x=i.length-1;x>=0;x--){const S=i[x];if(S.href===o&&(!y||S.rel==="stylesheet"))return}else if(document.querySelector(`link[href="${o}"]${v}`))return;const g=document.createElement("link");if(g.rel=y?"stylesheet":qv,y||(g.as="script"),g.crossOrigin="",g.href=o,f&&g.setAttribute("nonce",f),document.head.appendChild(g),y)return new Promise((x,S)=>{g.addEventListener("load",x),g.addEventListener("error",()=>S(new Error(`Unable to preload CSS for ${o}`)))})}))}function u(i){const c=new Event("vite:preloadError",{cancelable:!0});if(c.payload=i,window.dispatchEvent(c),!c.defaultPrevented)throw i}return n.then(i=>{for(const c of i||[])c.status==="rejected"&&u(c.reason);return l().catch(u)})},t0={primary:{kMwMTN:"x1tgivj0",$$css:!0},secondary:{kMwMTN:"xv1l7n4",$$css:!0},disabled:{kMwMTN:"xnbbluu",$$css:!0},placeholder:{kMwMTN:"xv1l7n4",$$css:!0},active:{kMwMTN:"xqwr325",$$css:!0},inherit:{kMwMTN:"x1heor9g",$$css:!0}},Rv={normal:{k63SB2:"x1sodnla",$$css:!0},medium:{k63SB2:"x1e4wzip",$$css:!0},semibold:{k63SB2:"x2mo6ok",$$css:!0},bold:{k63SB2:"x1lvx875",$$css:!0}},Uv={body:{k63SB2:"xxovm9e",$$css:!0},large:{k63SB2:"x149oux8",$$css:!0},label:{k63SB2:"xmhvcl5",$$css:!0},code:{k63SB2:"xx3eeay",$$css:!0},supporting:{k63SB2:"xv8on6e",$$css:!0},"display-1":{k63SB2:"x1txul5o",$$css:!0},"display-2":{k63SB2:"x1y36c3f",$$css:!0},"display-3":{k63SB2:"x1on40hk",$$css:!0}},l0={inline:{k1xSpc:"xt0psk2",$$css:!0},block:{k1xSpc:"x1lliihq",$$css:!0}},Lu={singleLine:{kVQacm:"xb3r6kr",kg5iWk:"xlyipyv",khDVqt:"xuxw1ft",k1xSpc:"x1lliihq",$$css:!0},multiLine:{kVQacm:"xb3r6kr",k1xSpc:"x104kibb",kgKLqz:"x1ua5tub",$$css:!0}},e0={"break-word":{kTgw9:"x1lldw8n",kHjlTd:"x1mzt3pk",$$css:!0},"break-all":{kTgw9:"x1yn0g08",$$css:!0}},a0={wrap:{kN2L0X:"xk4td0m",$$css:!0},nowrap:{kN2L0X:"xebhuq6",$$css:!0},balance:{kN2L0X:"x1w2vvpw",$$css:!0},pretty:{kN2L0X:"x1fzhlzt",$$css:!0}},n0={enabled:{kxwWH2:"x1b2iylo",kzeHkT:"xwgcxoh",k1xSpc:"x1lliihq",$$css:!0}},u0={strikethrough:{kybGjl:"xmqliwb",$$css:!0}},Hv={enabled:{kcqcaj:"xss6m8b",$$css:!0}},i0={content:{ks0D6T:"xw5ewwj",kTgw9:"x13faqbe",$$css:!0}};function c0(t){const{maxLines:l}=t,[e,a]=p.useState(!1),[n,u]=p.useState(""),i=p.useRef(null),c=p.useRef(null),f=p.useCallback(y=>{if(l===0){a(!1);return}u(y.textContent??""),a(l===1?y.scrollWidth>y.offsetWidth:y.scrollHeight>y.offsetHeight)},[l]);return{ref:p.useCallback(y=>{c.current&&(c.current.disconnect(),c.current=null),i.current=y,y&&l>0?(f(y),typeof ResizeObserver<"u"&&(c.current=new ResizeObserver(()=>{f(y)}),c.current.observe(y))):(a(!1),u(""))},[l,f]),isTruncated:e,fullText:n}}const Bv=p.lazy(()=>P1(()=>Promise.resolve().then(()=>I1),void 0,import.meta.url).then(t=>({default:t.XDSTooltip}))),Xv={body:"primary",large:"primary",label:"primary",supporting:"secondary",code:"primary","display-1":"primary","display-2":"primary","display-3":"primary"};function Ul({type:t,size:l,color:e,weight:a,display:n="inline",maxLines:u=0,hasTruncateTooltip:i=!0,wordBreak:c,textWrap:f,hasCapsize:o=!1,hasStrikethrough:y=!1,hasTabularNumbers:v=!1,xstyle:d,className:g,style:x,as:S="span",children:E,ref:r,...s}){const m=e??Xv[t],h=c??(u===1?"break-all":"break-word"),$=u>0||o?"block":n,A=c0({maxLines:u}),T=typeof i=="string"?i:"above",M=u>0&&i!==!1&&A.isTruncated,j=p.useRef(null),k=p.useCallback(et=>{typeof r=="function"?r(et):r&&(r.current=et),A.ref(et),j.current=et},[r,A.ref]),P=u>1?{WebkitLineClamp:u}:void 0;return b.jsxs(b.Fragment,{children:[b.jsx(S,{ref:k,...At(Tt("text",{type:t,color:m}),Q(t0[m],Uv[t],a&&Rv[a],u===1?Lu.singleLine:u>1?Lu.multiLine:l0[$],u>0&&e0[h],f&&a0[f],o&&n0.enabled,y&&u0.strikethrough,v&&Hv.enabled,d),g,{...x,...P}),title:M?A.fullText:void 0,...s,children:E}),M&&b.jsx(p.Suspense,{fallback:null,children:b.jsx(Bv,{anchorRef:j,content:b.jsx("span",{...Q(i0.content),children:A.fullText}),placement:T})})]})}Ul.displayName="XDSText";const Lv=.75,Ho=1.5,Bo={sm:{diameter:10,border:3},md:{diameter:14,border:3},lg:{diameter:18,border:3},xl:{diameter:28,border:4}},Xo={wrapper:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kOIVth:"x1txdalj",$$css:!0},spinner:{k1xSpc:"x1rg5ohu",kVQacm:"xb3r6kr",kXLuUW:"xxymvpz",$$css:!0}};function f0({size:t="md",shade:l="default",label:e,xstyle:a,className:n,"aria-label":u,"data-testid":i,ref:c}){const f=p.useRef(null);p.useEffect(()=>{const S=f.current;if(S==null)return;const E=S.getContext("2d");if(!E)return;const{border:r,diameter:s}=Bo[t],m=window.devicePixelRatio||1,h=getComputedStyle(S),$=l==="onMedia"?h.getPropertyValue(No["--color-on-dark"])||"#FFFFFF":h.getPropertyValue(No["--color-accent"])||"#0064E0",A=l==="onMedia"?"rgba(255, 255, 255, 0.3)":"rgba(0, 0, 0, 0.1)",T=s/2*m,M=r*m,j=(T+M)*2;S.height=S.width=j,S.style.width=S.style.height=j/m+"px",E.lineCap="round",E.lineWidth=M;const k=j/2;E.beginPath(),E.arc(k,k,T,0,2*Math.PI),E.strokeStyle=A,E.stroke(),E.beginPath(),E.arc(k,k,T,Ho*Math.PI,(Ho+Lv)%2*Math.PI),E.strokeStyle=$,E.stroke()},[l,t]);const{border:o,diameter:y}=Bo[t],v=y+o*2,d=e!=null,g=u??(typeof e=="string"?e:void 0)??"Loading",x=b.jsx("span",{ref:d?void 0:c,role:"status","aria-label":g,"data-testid":d?void 0:i,...At(d?"":Tt("spinner",{size:t,shade:l}),Q(Xo.spinner,!d&&a),d?void 0:n),style:{width:v,height:v},children:b.jsx("canvas",{ref:f,className:"xlp1x4z x1lliihq xqgcaz xa4qsjk x1ka1v4i x1esw782"})});return d?b.jsxs("div",{ref:c,"data-testid":i,...At(Tt("spinner",{size:t,shade:l}),Q(Xo.wrapper,a),n),children:[x,typeof e=="string"?b.jsx(Ul,{type:"body",weight:"bold",children:e}):e]}):x}f0.displayName="XDSSpinner";const Zv={self:{keTefX:"xg82z56",k71WvV:"xofqkxr",$$css:!0}},Ue={base:{kVAEAm:"x1n2onr6",k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kOIVth:"x1txdalj",k8WAf4:"xce4md1",kg3NbH:"xrrkdod",kMzoRj:"xc342km",ksu8eU:"xng3xce","--button-radius":"x1mkq5kp",kaIpWk:"x1q11iln",kMv6JI:"xjb2p0i",kGuDYH:"xcr08ib",kLWn49:"x1kq96og",k63SB2:"x1e4wzip",khDVqt:"xuxw1ft",kkrTdU:"x1ypdohk",k1ekBW:"xqc8rvf",kIyJzY:"xuedmi6 x12w9bfk",kAMwcw:"xlr8y92",k3aq6I:"x3oybdh xk4oym4",$$css:!0},disabled:{kkrTdU:"x1h6gzvc",kSiTet:"xbyyjgo",kKwaWg:"x18o3ruo",k3aq6I:"x1c071of x1pdlv7q",$$css:!0},ariaDisabled:{kKwaWg:"x18o3ruo x8o3jvd xuqm82a",$$css:!0},iconOnly:{"--button-icon-only-aspect":"x1v15ycx",kOBAk4:"xioom0i",kg3NbH:"xf314gf",$$css:!0},iconWrapper:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kmuXW:"x2lah0s",$$css:!0},link:{kybGjl:"x1hl2dhg",$$css:!0}},Gv={sm:{kZKoxP:"x6k0iem",$$css:!0},md:{kZKoxP:"x1ueg155",$$css:!0},lg:{kZKoxP:"xssyfek",$$css:!0}},Yv={sm:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},md:{kzqmXN:"x1kky2od",kZKoxP:"xlup9mm",kGuDYH:"x1j61zf2",$$css:!0},lg:{kzqmXN:"xw4jnvo",kZKoxP:"x1qx5ct2",kGuDYH:"xwsyq91",$$css:!0}},Qv={primary:{kWkggS:"x1ewilqj",kMwMTN:"x17wrial",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},secondary:{kWkggS:"x17x4s8c",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},ghost:{kWkggS:"xjbqb8w",kMwMTN:"x1tgivj0",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x17nn4n9","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0},destructive:{kWkggS:"x1pjz0fi",kMwMTN:"x1m024r3",kKwaWg:"x1ilzqfv xq8i9tn",kI3sdo:"x1p73he7","--button-focus-offset":"xkzo27j",kInvED:"x1wfwxd8 x13aywxo",$$css:!0}},Vv={loading:{kVAEAm:"x1n2onr6",kMwMTN:"x19co3pv",$$css:!0}},Lo={paddingInline2:{"--component-padding-inline":"x30uzy1",$$css:!0},paddingInline3:{"--component-padding-inline":"x1ojg8sz",$$css:!0}};function ru({label:t,variant:l="secondary",size:e="md",type:a="button",isDisabled:n=!1,isLoading:u=!1,onClickAction:i,icon:c,children:f,endContent:o,tooltip:y,href:v,as:d,target:g,rel:x,xstyle:S,className:E,style:r,ref:s,...m}){const[h,$]=p.useTransition(),A=p.useRef(!1),T=u||h,M=n||T,j=l==="primary"||l==="destructive",k=c!=null&&f==null,P=F1(d),et=v!=null&&!M,yl=y!=null&&M,Dn=xt=>{var ul;if(M||A.current){xt.preventDefault();return}(ul=m.onClick)==null||ul.call(m,xt),i&&!xt.defaultPrevented&&(A.current=!0,$(async()=>{try{await i(xt)}finally{A.current=!1}}))},Ne=yl?xt=>{var ul;xt.key==="Enter"||xt.key===" "?xt.preventDefault():(ul=m.onKeyDown)==null||ul.call(m,xt)}:void 0,O=l==="ghost",q=O?Zv.self:null,C=O?k?Lo.paddingInline2:Lo.paddingInline3:null,lt=Q(Ue.base,Gv[e],Qv[l],k&&Ue.iconOnly,M&&Ue.disabled,yl&&Ue.ariaDisabled,T&&Vv.loading,C,q,et&&Ue.link,S),ut=At(Tt("button",{variant:l,size:e}),lt,E,r),se=b.jsxs(b.Fragment,{children:[T&&b.jsx("span",{className:"x10l6tqk x13vifvy xu96u03 x3m8u43 x1ey2m1c x78zum5 x6s0dn4 xl56j7k","aria-hidden":"true",children:b.jsx(f0,{size:"sm",shade:j?"onMedia":"default"})}),b.jsxs("span",{className:"xjp7ctv","aria-hidden":T||void 0,children:[c&&b.jsx("span",{...Q(Ue.iconWrapper,Yv[e]),children:c}),k?null:b.jsx("span",{className:"xb3r6kr xlyipyv xeuugli",children:f??t}),!k&&o&&b.jsx("span",{className:"x3nfvp2 x6s0dn4 x1heor9g",children:o})]}),b.jsx("span",{className:"x10l6tqk x1i1rx1s xjm9jq1 x1717udv xkdpibf xb3r6kr xzpqnlu xuxw1ft xc342km",role:"status","aria-live":"polite",children:T?"Loading":""})]}),oe=k&&t!==""||T&&!k?{"aria-label":t}:null;let Nl;return et?Nl=b.jsx(P,{ref:s,href:v,target:g,rel:x,...ut,...m,...oe,onClick:Dn,children:se}):Nl=b.jsx("button",{ref:s,type:a,disabled:yl?void 0:M,...ut,...m,...oe,"aria-busy":T||void 0,"aria-disabled":yl||void 0,onClick:Dn,...Ne?{onKeyDown:Ne}:null,children:se}),y?b.jsx(If,{content:y,placement:"above",children:Nl}):Nl}ru.displayName="XDSButton";const Zo={container:{kB7OPa:"x9f619",kmVPX3:"x1kp5lmi",$$css:!0}},Kv={containerPadding:{"--container-padding":"x8q8htr",$$css:!0},containerPaddingInline:{"--container-padding-inline":"x118jium",$$css:!0},layoutPaddingOuterX:{"--layout-padding-outer-x":"x1r0u152",$$css:!0},layoutPaddingOuterY:{"--layout-padding-outer-y":"xzqheer",$$css:!0},layoutPaddingInnerX:{"--layout-padding-inner-x":"x1gox8qf",$$css:!0},layoutPaddingInnerY:{"--layout-padding-inner-y":"x1eounod",$$css:!0}},Jv={containerPadding:{"--container-padding":"xms56fs",$$css:!0},containerPaddingInline:{"--container-padding-inline":"x1x4tb0e",$$css:!0},layoutPaddingOuterX:{"--layout-padding-outer-x":"x1h0nqri",$$css:!0},layoutPaddingOuterY:{"--layout-padding-outer-y":"xlfd3nr",$$css:!0},layoutPaddingInnerX:{"--layout-padding-inner-x":"xn3f0pw",$$css:!0},layoutPaddingInnerY:{"--layout-padding-inner-y":"xihc2cu",$$css:!0}},Wv={card:Kv,section:Jv},Fv={spacing0:{"--container-padding":"x1i337hy",$$css:!0},spacing0_5:{"--container-padding":"x1b322fk",$$css:!0},spacing1:{"--container-padding":"x11x0u8a",$$css:!0},spacing1_5:{"--container-padding":"x1tqehje",$$css:!0},spacing2:{"--container-padding":"xyawmno",$$css:!0},spacing3:{"--container-padding":"xiq2vfk",$$css:!0},spacing4:{"--container-padding":"x18iqpsj",$$css:!0},spacing5:{"--container-padding":"x305b4h",$$css:!0},spacing6:{"--container-padding":"x1suvfq4",$$css:!0},spacing7:{"--container-padding":"xe04trj",$$css:!0},spacing8:{"--container-padding":"xv6sa6u",$$css:!0},spacing9:{"--container-padding":"xswgb5g",$$css:!0},spacing10:{"--container-padding":"xl4lgz8",$$css:!0},spacing11:{"--container-padding":"xfk8qm2",$$css:!0},spacing12:{"--container-padding":"xtcn5oa",$$css:!0}},Iv={spacing0:{"--container-padding-inline":"x11nj8ps",$$css:!0},spacing0_5:{"--container-padding-inline":"x1qmdwou",$$css:!0},spacing1:{"--container-padding-inline":"xmqp8mn",$$css:!0},spacing1_5:{"--container-padding-inline":"x11c4xrl",$$css:!0},spacing2:{"--container-padding-inline":"xvkq9sf",$$css:!0},spacing3:{"--container-padding-inline":"x17rklng",$$css:!0},spacing4:{"--container-padding-inline":"x1qtkjpi",$$css:!0},spacing5:{"--container-padding-inline":"xcek0mv",$$css:!0},spacing6:{"--container-padding-inline":"xzryng3",$$css:!0},spacing7:{"--container-padding-inline":"x1jrgra8",$$css:!0},spacing8:{"--container-padding-inline":"x1t3jwqk",$$css:!0},spacing9:{"--container-padding-inline":"x1ikhtwg",$$css:!0},spacing10:{"--container-padding-inline":"x1mh38z9",$$css:!0},spacing11:{"--container-padding-inline":"xarkblc",$$css:!0},spacing12:{"--container-padding-inline":"x15nzvup",$$css:!0}},Pv={spacing0:{"--layout-padding-outer-x":"xswhm3q",$$css:!0},spacing0_5:{"--layout-padding-outer-x":"xihiwg7",$$css:!0},spacing1:{"--layout-padding-outer-x":"xc96xmq",$$css:!0},spacing1_5:{"--layout-padding-outer-x":"x1u93lgd",$$css:!0},spacing2:{"--layout-padding-outer-x":"x15dxnc0",$$css:!0},spacing3:{"--layout-padding-outer-x":"xadgj3j",$$css:!0},spacing4:{"--layout-padding-outer-x":"x1v56qcf",$$css:!0},spacing5:{"--layout-padding-outer-x":"x1nzs0gl",$$css:!0},spacing6:{"--layout-padding-outer-x":"x1c3n52a",$$css:!0},spacing7:{"--layout-padding-outer-x":"x1gfiokx",$$css:!0},spacing8:{"--layout-padding-outer-x":"x1t3kfz",$$css:!0},spacing9:{"--layout-padding-outer-x":"xzr4qsh",$$css:!0},spacing10:{"--layout-padding-outer-x":"x1jdf5a4",$$css:!0},spacing11:{"--layout-padding-outer-x":"x1hct0t0",$$css:!0},spacing12:{"--layout-padding-outer-x":"x11cyqoe",$$css:!0}},th={spacing0:{"--layout-padding-outer-y":"x1mzf5mb",$$css:!0},spacing0_5:{"--layout-padding-outer-y":"x1vj96e0",$$css:!0},spacing1:{"--layout-padding-outer-y":"x1gpfxoh",$$css:!0},spacing1_5:{"--layout-padding-outer-y":"xd3dqby",$$css:!0},spacing2:{"--layout-padding-outer-y":"x10pz7y9",$$css:!0},spacing3:{"--layout-padding-outer-y":"x1p6yq3h",$$css:!0},spacing4:{"--layout-padding-outer-y":"xx738ci",$$css:!0},spacing5:{"--layout-padding-outer-y":"x6yxws5",$$css:!0},spacing6:{"--layout-padding-outer-y":"x180vrwl",$$css:!0},spacing7:{"--layout-padding-outer-y":"x1q6rme1",$$css:!0},spacing8:{"--layout-padding-outer-y":"xid7e43",$$css:!0},spacing9:{"--layout-padding-outer-y":"x1t5kicu",$$css:!0},spacing10:{"--layout-padding-outer-y":"x26l4wa",$$css:!0},spacing11:{"--layout-padding-outer-y":"x10zktp0",$$css:!0},spacing12:{"--layout-padding-outer-y":"x1yz3n6a",$$css:!0}},lh={spacing0:{"--layout-padding-inner-x":"xj1bl4l",$$css:!0},spacing0_5:{"--layout-padding-inner-x":"xlriy2h",$$css:!0},spacing1:{"--layout-padding-inner-x":"x6uuyak",$$css:!0},spacing1_5:{"--layout-padding-inner-x":"xd38f90",$$css:!0},spacing2:{"--layout-padding-inner-x":"xxqksqd",$$css:!0},spacing3:{"--layout-padding-inner-x":"x1fyui2f",$$css:!0},spacing4:{"--layout-padding-inner-x":"x1i2ajwi",$$css:!0},spacing5:{"--layout-padding-inner-x":"x1tac27u",$$css:!0},spacing6:{"--layout-padding-inner-x":"x1ntgf3t",$$css:!0},spacing7:{"--layout-padding-inner-x":"xhjd9tl",$$css:!0},spacing8:{"--layout-padding-inner-x":"xn7c84u",$$css:!0},spacing9:{"--layout-padding-inner-x":"xeqkbsz",$$css:!0},spacing10:{"--layout-padding-inner-x":"x1vf4qco",$$css:!0},spacing11:{"--layout-padding-inner-x":"xsmamsf",$$css:!0},spacing12:{"--layout-padding-inner-x":"x2xk2xj",$$css:!0}},eh={spacing0:{"--layout-padding-inner-y":"xwuefyo",$$css:!0},spacing0_5:{"--layout-padding-inner-y":"x180h0y5",$$css:!0},spacing1:{"--layout-padding-inner-y":"xmpug6m",$$css:!0},spacing1_5:{"--layout-padding-inner-y":"x1g8jpzm",$$css:!0},spacing2:{"--layout-padding-inner-y":"x1lksgje",$$css:!0},spacing3:{"--layout-padding-inner-y":"x4j7gld",$$css:!0},spacing4:{"--layout-padding-inner-y":"x1s3ehtl",$$css:!0},spacing5:{"--layout-padding-inner-y":"x1rj5eim",$$css:!0},spacing6:{"--layout-padding-inner-y":"x1ftgg6u",$$css:!0},spacing7:{"--layout-padding-inner-y":"x1ho74vh",$$css:!0},spacing8:{"--layout-padding-inner-y":"xm2cs6f",$$css:!0},spacing9:{"--layout-padding-inner-y":"x1vsq92b",$$css:!0},spacing10:{"--layout-padding-inner-y":"x18gbwmk",$$css:!0},spacing11:{"--layout-padding-inner-y":"x14zymzj",$$css:!0},spacing12:{"--layout-padding-inner-y":"xzfpkx9",$$css:!0}},ah={containerMaxHeight:t=>[{"--container-max-height":t!=null?"x18nyedi":t,$$css:!0},{"--x---container-max-height":t??void 0}]};function nh({padding:t="spacing4",paddingOuterX:l="spacing4",paddingOuterY:e="spacing4",paddingInnerX:a="spacing4",paddingInnerY:n="spacing4",useThemeDefault:u,maxHeight:i}){const c=i?ah.containerMaxHeight(i):null;if(u){const f=Wv[u];return[Zo.container,f.containerPadding,f.containerPaddingInline,f.layoutPaddingOuterX,f.layoutPaddingOuterY,f.layoutPaddingInnerX,f.layoutPaddingInnerY,c]}return[Zo.container,Fv[t],Iv[l],Pv[l],th[e],lh[a],eh[n],c]}const uh={0:"spacing0",.5:"spacing0_5",1:"spacing1",1.5:"spacing1_5",2:"spacing2",3:"spacing3",4:"spacing4",5:"spacing5",6:"spacing6",8:"spacing8",10:"spacing10"},Pf={0:{kZCmMZ:"x18gyask",kwRFfy:"x1s0aq8i",kLKAdn:"x1ydh6w3",kGO01o:"x1l20ajd",$$css:!0},1:{kZCmMZ:"x1vsv5vr",kwRFfy:"x1nryj5t",kLKAdn:"xfsso4q",kGO01o:"xy143xn",$$css:!0},2:{kZCmMZ:"x12gdq22",kwRFfy:"x1djylfy",kLKAdn:"x1xye8es",kGO01o:"x1wesfrj",$$css:!0},3:{kZCmMZ:"x126nfab",kwRFfy:"x1t818jl",kLKAdn:"x1vlblms",kGO01o:"xvmdzux",$$css:!0},4:{kZCmMZ:"x1rey3nv",kwRFfy:"xnjyzlh",kLKAdn:"x1oa1p4a",kGO01o:"x1awphl8",$$css:!0},5:{kZCmMZ:"x1blguxw",kwRFfy:"xdbrk9v",kLKAdn:"xx7rijo",kGO01o:"x1hk98q",$$css:!0},6:{kZCmMZ:"x31w388",kwRFfy:"x1we12cn",kLKAdn:"x1adxfkp",kGO01o:"xjpqqx5",$$css:!0},8:{kZCmMZ:"x1j3hnjz",kwRFfy:"x1q91b2g",kLKAdn:"xoxd1wu",kGO01o:"x2oz4g1",$$css:!0},10:{kZCmMZ:"xqp078j",kwRFfy:"x160ivqr",kLKAdn:"xk6660b",kGO01o:"x2izi54",$$css:!0},"0.5":{kZCmMZ:"x138rykx",kwRFfy:"x1le3yxw",kLKAdn:"xbx876j",kGO01o:"xij103a",$$css:!0},"1.5":{kZCmMZ:"xfti1ec",kwRFfy:"x17hk9do",kLKAdn:"x1kwdpsa",kGO01o:"x1opdxmq",$$css:!0}},ts={0:{"--container-padding-inline":"x11nj8ps",$$css:!0},1:{"--container-padding-inline":"xmqp8mn",$$css:!0},2:{"--container-padding-inline":"xvkq9sf",$$css:!0},3:{"--container-padding-inline":"x17rklng",$$css:!0},4:{"--container-padding-inline":"x1qtkjpi",$$css:!0},5:{"--container-padding-inline":"xcek0mv",$$css:!0},6:{"--container-padding-inline":"xzryng3",$$css:!0},8:{"--container-padding-inline":"x1t3jwqk",$$css:!0},10:{"--container-padding-inline":"x1mh38z9",$$css:!0},"0.5":{"--container-padding-inline":"x1qmdwou",$$css:!0},"1.5":{"--container-padding-inline":"x11c4xrl",$$css:!0}},ih={0:{"--layout-padding-outer-x":"xswhm3q",$$css:!0},1:{"--layout-padding-outer-x":"xc96xmq",$$css:!0},2:{"--layout-padding-outer-x":"x15dxnc0",$$css:!0},3:{"--layout-padding-outer-x":"xadgj3j",$$css:!0},4:{"--layout-padding-outer-x":"x1v56qcf",$$css:!0},5:{"--layout-padding-outer-x":"x1nzs0gl",$$css:!0},6:{"--layout-padding-outer-x":"x1c3n52a",$$css:!0},8:{"--layout-padding-outer-x":"x1t3kfz",$$css:!0},10:{"--layout-padding-outer-x":"x1jdf5a4",$$css:!0},"0.5":{"--layout-padding-outer-x":"xihiwg7",$$css:!0},"1.5":{"--layout-padding-outer-x":"x1u93lgd",$$css:!0}},ch={0:{"--layout-padding-outer-y":"x1mzf5mb",$$css:!0},1:{"--layout-padding-outer-y":"x1gpfxoh",$$css:!0},2:{"--layout-padding-outer-y":"x10pz7y9",$$css:!0},3:{"--layout-padding-outer-y":"x1p6yq3h",$$css:!0},4:{"--layout-padding-outer-y":"xx738ci",$$css:!0},5:{"--layout-padding-outer-y":"x6yxws5",$$css:!0},6:{"--layout-padding-outer-y":"x180vrwl",$$css:!0},8:{"--layout-padding-outer-y":"xid7e43",$$css:!0},10:{"--layout-padding-outer-y":"x26l4wa",$$css:!0},"0.5":{"--layout-padding-outer-y":"x1vj96e0",$$css:!0},"1.5":{"--layout-padding-outer-y":"xd3dqby",$$css:!0}},Fi={cardOuter:{"--card-radius":"xb26y6u",kWkggS:"x1de1mus",kaIpWk:"x8j4bds",kVQacm:"x7giv3",kMzoRj:"x1litavf",ksu8eU:"x1y0btm7",kVAM5u:"xvy26l8",$$css:!0},cardInner:{kZKoxP:"x5yr21d",$$css:!0},scrollable:{kVQacm:"xysyzu8",$$css:!0}},fh={sizing:(t,l,e,a)=>[{kzqmXN:t!=null?"x5lhr3w":t,kZKoxP:l!=null?"x16ye13r":l,ks0D6T:e!=null?"xf68679":e,kAzted:a!=null?"x82snj4":a,$$css:!0},{"--x-width":(n=>typeof n=="number"?n+"px":n??void 0)(t),"--x-height":(n=>typeof n=="number"?n+"px":n??void 0)(l),"--x-maxWidth":(n=>typeof n=="number"?n+"px":n??void 0)(e),"--x-minHeight":(n=>typeof n=="number"?n+"px":n??void 0)(a)}]};function s0({width:t,height:l,maxWidth:e,minHeight:a,children:n,padding:u,xstyle:i,className:c,style:f,ref:o,...y}){const v=l!=null&&l!=="auto",d=u==null,g=u??4,x=uh[g];return b.jsx("div",{ref:o,...At(Tt("card"),Q(Fi.cardOuter,fh.sizing(t??null,l??null,e??null,a??null),i),c,f),...y,children:b.jsx("div",{...Q(Fi.cardInner,v&&Fi.scrollable,...nh(d?{useThemeDefault:"card"}:{paddingInnerX:x,paddingInnerY:x,paddingOuterX:x,paddingOuterY:x}),!d&&g!==4&&Pf[g],!d&&g!==4&&ts[g]),children:n})})}s0.displayName="XDSCard";const sh={center:{kGNEyG:"x6s0dn4",$$css:!0},end:{kGNEyG:"xuk3077",$$css:!0},start:{kGNEyG:"x1cy8zhl",$$css:!0},stretch:{kGNEyG:"x1qjc9v5",$$css:!0}},oh={start:{kjj79g:"x1nhvcw1",$$css:!0},center:{kjj79g:"xl56j7k",$$css:!0},end:{kjj79g:"x13a6bvl",$$css:!0},between:{kjj79g:"x1qughib",$$css:!0},around:{kjj79g:"x1l1ennw",$$css:!0},evenly:{kjj79g:"xaw8158",$$css:!0}},rh={horizontal:{kXwgrk:"x1q0g3np",$$css:!0},vertical:{kXwgrk:"xdt5ytf",$$css:!0}},dh={nowrap:{kwnvtZ:"xozqiw3",$$css:!0},wrap:{kwnvtZ:"x1a02dak",$$css:!0},"wrap-reverse":{kwnvtZ:"x8hhl5t",$$css:!0}},yh={stack:{k1xSpc:"x78zum5",$$css:!0}},mh={0:{k1C7PZ:"x1o57wo1",khm7nJ:"x6yxi7o",$$css:!0},1:{k1C7PZ:"x1lfs0n9",khm7nJ:"x1ngg2t4",$$css:!0},2:{k1C7PZ:"xak3so",khm7nJ:"x1x7z4sm",$$css:!0},3:{k1C7PZ:"xewh9hi",khm7nJ:"x4olc9o",$$css:!0},4:{k1C7PZ:"xty4p9g",khm7nJ:"xtx9w7w",$$css:!0},5:{k1C7PZ:"x1eqhezk",khm7nJ:"x1iu6piu",$$css:!0},6:{k1C7PZ:"x3qlgwd",khm7nJ:"xczp1bk",$$css:!0},8:{k1C7PZ:"xicv188",khm7nJ:"xgx0vcf",$$css:!0},10:{k1C7PZ:"x1p37tyl",khm7nJ:"x1xpicb7",$$css:!0},"0.5":{k1C7PZ:"x1kihgfc",khm7nJ:"x1tw44j4",$$css:!0},"1.5":{k1C7PZ:"x1thn6ci",khm7nJ:"xhq53yo",$$css:!0}};function Jc({crossAlign:t,direction:l,gap:e,mainAlign:a,wrap:n}){return[yh.stack,rh[l],e!=null&&mh[e],t!=null&&sh[t],a!=null&&oh[a],n!=null&&dh[n]]}const gh={reset:{kAzted:"x2lwn1j",k7Eaqz:"xeuugli",$$css:!0}},vh={center:{kSGwAc:"xamitd3",$$css:!0},end:{kSGwAc:"xpvyfi4",$$css:!0},start:{kSGwAc:"xqcrz7y",$$css:!0},stretch:{kSGwAc:"xkh2ocl",$$css:!0}},hh={fill:{kzQI83:"x1iyjqo2",$$css:!0},static:{kzQI83:"x1c4vz4f",kmuXW:"x2lah0s",$$css:!0}};function xh({crossAlignSelf:t,size:l}={}){return[gh.reset,hh[l??"static"],t!=null&&vh[t]]}function ls({direction:t,hAlign:l,vAlign:e,gap:a,wrap:n,element:u="div",xstyle:i,className:c,style:f,children:o,ref:y,...v}){const x=Q(...Jc({direction:t,crossAlign:t==="horizontal"?e:l,mainAlign:t==="horizontal"?l:e,gap:a,wrap:n}),i);return p.createElement(u,{ref:y,...At(Tt("stack",{direction:t,gap:a,wrap:n}),x,c,f),...v},o)}ls.displayName="XDSStack";function du({ref:t,...l}){return b.jsx(ls,{...l,direction:"horizontal",ref:t})}du.displayName="XDSHStack";function he({ref:t,...l}){return b.jsx(ls,{...l,direction:"vertical",ref:t})}he.displayName="XDSVStack";const ph=p.createContext(null),bh={hasHeader:!1,hasFooter:!1,hasStart:!1,hasEnd:!1},o0=p.createContext(bh),r0=p.createContext(null),ql={layoutOuter:{kogj98:"x1ak00ur",$$css:!0},layoutInner:{"--container-padding":"xbuvapz",$$css:!0},fill:{kZKoxP:"x1x2thlr",kskxy:"xenllk4",$$css:!0},auto:{kAzted:"x1us19tq",$$css:!0},middle:{kUk6DE:"x98rzlu",kAzted:"x2lwn1j",$$css:!0},fullBleed:{"--layout-padding-outer-x":"x1wbjvqu","--layout-padding-outer-y":"xzxxx64",$$css:!0}};function qa({area:t,children:l}){return l==null?null:b.jsx(ph.Provider,{value:t,children:l})}function d0({content:t,defaultHasDividers:l,end:e,footer:a,header:n,height:u="fill",padding:i,ref:c,start:f,xstyle:o,className:y,style:v}){const d=u==="fill",g=p.useMemo(()=>l!=null?{defaultHasDividers:l}:null,[l]),x=p.useMemo(()=>({hasHeader:n!=null,hasFooter:a!=null,hasStart:f!=null,hasEnd:e!=null}),[n!=null,a!=null,f!=null,e!=null]),S=b.jsx(o0.Provider,{value:x,children:b.jsx("div",{ref:c,...At(Tt("layout",{height:u}),Q(ql.layoutOuter,d?ql.fill:ql.auto,o),y,v),children:b.jsxs("div",{...Q({"x-default-marker":"x-default-marker",$$css:!0},ql.layoutInner,...Jc({direction:"vertical"}),d?ql.fill:ql.auto,i===0&&ql.fullBleed,i!=null&&ih[i],i!=null&&ch[i]),children:[b.jsx(qa,{area:"header",children:n}),b.jsxs("div",{...Q(...Jc({direction:"horizontal"}),ql.middle),children:[b.jsx(qa,{area:"start",children:f}),b.jsx("div",{...Q(...xh({size:"fill"})),children:b.jsx(qa,{area:"content",children:t})}),b.jsx(qa,{area:"end",children:e})]}),b.jsx(qa,{area:"footer",children:a})]})})});return g!=null?b.jsx(r0.Provider,{value:g,children:S}):S}d0.displayName="XDSLayout";const Ii={header:{kB7OPa:"x9f619",kmuXW:"x2lah0s",kZCmMZ:"x139j0dd",kwRFfy:"xpc6k2p",kLKAdn:"x81pis9",kGO01o:"xg476vw",$$css:!0},fullBleed:{kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",$$css:!0},divider:{kt9PQ7:"xso031l",kfdmCh:"x1q0q8m5",kL6WhQ:"xw8gpjh",$$css:!0}},Sh={sizing:t=>[{kZKoxP:t!=null?"x16ye13r":t,$$css:!0},{"--x-height":(l=>typeof l=="number"?l+"px":l??void 0)(t)}]};function y0({children:t,hasDivider:l,height:e,label:a,padding:n,role:u,xstyle:i,className:c,style:f,ref:o,...y}){const v=p.useContext(r0),d=l??(v==null?void 0:v.defaultHasDividers)??!1,g=n===0;return b.jsx("div",{ref:o,role:u,"aria-label":a,"data-divider":d||void 0,...At(Tt("layout-header"),Q(Ii.header,Sh.sizing(e??null),g&&Ii.fullBleed,n!=null&&Pf[n],n!=null&&ts[n],d&&Ii.divider,i),c,f),...y,children:t})}y0.displayName="XDSLayoutHeader";const de={content:{kB7OPa:"x9f619",kZKoxP:"x5yr21d",kUk6DE:"x98rzlu",kAzted:"x2lwn1j",kVQacm:"x7giv3",kZCmMZ:"xwjyata",kwRFfy:"x1peupej",kLKAdn:"xqty4a x1c51l3k",kGO01o:"xg476vw x1o6z09h",$$css:!0},noStart:{kZCmMZ:"x139j0dd",$$css:!0},noEnd:{kwRFfy:"xpc6k2p",$$css:!0},noHeader:{kLKAdn:"x81pis9",$$css:!0},noFooter:{kGO01o:"xon7vh3",$$css:!0},scrollable:{kVQacm:"xysyzu8",$$css:!0},fullBleed:{kZCmMZ:"x1c1uobl",kwRFfy:"xyri2b",kLKAdn:"xexx8yu",kGO01o:"x18d9i69",$$css:!0}};function m0({children:t,isScrollable:l=!0,padding:e,label:a,role:n,xstyle:u,className:i,style:c,ref:f,...o}){const{hasHeader:y,hasFooter:v,hasStart:d,hasEnd:g}=p.useContext(o0),x=e===0;return b.jsx("div",{ref:f,role:n,"aria-label":a,...At(Tt("layout-content"),Q(de.content,!d&&!x&&e==null&&de.noStart,!g&&!x&&e==null&&de.noEnd,!y&&!x&&e==null&&de.noHeader,!v&&!x&&e==null&&de.noFooter,l&&de.scrollable,x&&de.fullBleed,e!=null&&Pf[e],e!=null&&ts[e],u),i,c),...o,children:t})}m0.displayName="XDSLayoutContent";const zh=p.lazy(()=>P1(()=>Promise.resolve().then(()=>I1),void 0,import.meta.url).then(t=>({default:t.XDSTooltip}))),Eh={1:"h1",2:"h2",3:"h3",4:"h4",5:"h5",6:"h6"};function La({level:t,accessibilityLevel:l,color:e="primary",display:a="block",maxLines:n=0,hasTruncateTooltip:u=!0,wordBreak:i,textWrap:c,hasCapsize:f=!1,hasStrikethrough:o=!1,xstyle:y,className:v,style:d,children:g,ref:x,...S}){const E=Eh[t],r=l&&l!==t?{"aria-level":l}:{},s=i??(n===1?"break-all":"break-word"),m=n>0||f?"block":a,h=c0({maxLines:n}),$=typeof u=="string"?u:"above",A=n>0&&u!==!1&&h.isTruncated,T=p.useRef(null),M=p.useCallback(k=>{typeof x=="function"?x(k):x&&(x.current=k),h.ref(k),T.current=k},[x,h.ref]),j=n>1?{WebkitLineClamp:n}:void 0;return b.jsxs(b.Fragment,{children:[b.jsx(E,{ref:M,...At(Tt("heading",{level:t,color:e}),Q(t0[e],n===1?Lu.singleLine:n>1?Lu.multiLine:l0[m],n>0&&e0[s],c&&a0[c],f&&n0.enabled,o&&u0.strikethrough,y),v,{...d,...j}),title:A?h.fullText:void 0,...r,...S,children:g}),A&&b.jsx(p.Suspense,{fallback:null,children:b.jsx(zh,{anchorRef:T,content:b.jsx("span",{...Q(i0.content),children:h.fullText}),placement:$})})]})}La.displayName="XDSHeading";const Go={horizontal:{k1xSpc:"x78zum5",kGNEyG:"x6s0dn4",kzqmXN:"xh8yej3",$$css:!0},vertical:{k1xSpc:"x3nfvp2",kXwgrk:"xdt5ytf",kGNEyG:"x6s0dn4",kZKoxP:"x5yr21d",$$css:!0}},He={horizontalLine:{kZKoxP:"xsyqizj",kzQI83:"x1iyjqo2",kmuXW:"xs83m0k",$$css:!0},verticalLine:{kzqmXN:"xjk4fl7",kzQI83:"x1iyjqo2",kmuXW:"xs83m0k",$$css:!0},subtle:{kWkggS:"x1m4xfpy",$$css:!0},strong:{kWkggS:"x7njt3n",$$css:!0}},Yo={horizontal:{kUOVxO:"xzyy9it",$$css:!0},vertical:{kqGvvJ:"xcxpkta",$$css:!0}};function Za({orientation:t="horizontal",label:l,variant:e="subtle",isFullBleed:a=!1,xstyle:n,className:u,style:i,ref:c,...f}){const o=t==="horizontal";return b.jsxs("div",{ref:c,role:"separator","aria-orientation":t,...At(Tt("divider",{variant:e,orientation:t}),Q(o?Go.horizontal:Go.vertical,a&&(o?Yo.horizontal:Yo.vertical),n),u,i),...f,children:[b.jsx("div",{...Q(o?He.horizontalLine:He.verticalLine,He[e])}),l&&b.jsx("div",{...{0:{className:"x2lah0s xrrkdod x10xzikg x141an7d x1ltkj2j xv1l7n4"},1:{className:"x2lah0s x10xzikg x141an7d x1ltkj2j xv1l7n4 xnjsko4 x8o8v82"}}[!o<<0],children:l}),l&&b.jsx("div",{...Q(o?He.horizontalLine:He.verticalLine,He[e])})]})}Za.displayName="XDSDivider";const Th={base:{k1xSpc:"x3nfvp2",kGNEyG:"x6s0dn4",kjj79g:"xl56j7k",kOIVth:"xzye2dw",kZKoxP:"x1grt7ep",k8WAf4:"xt970qd",kg3NbH:"xf314gf",kaIpWk:"xjspbzw",kMv6JI:"xjb2p0i",kGuDYH:"x141an7d",kLWn49:"x1ltkj2j",k63SB2:"x1e4wzip",khDVqt:"xuxw1ft",$$css:!0}},$h={neutral:{kWkggS:"x17x4s8c",kMwMTN:"x1tgivj0",$$css:!0},info:{kWkggS:"x1ewilqj",kMwMTN:"x17wrial",$$css:!0},success:{kWkggS:"xdsz4j9",kMwMTN:"xri61p4",$$css:!0},warning:{kWkggS:"x1q8g9m5",kMwMTN:"xrebv38",$$css:!0},error:{kWkggS:"x1pjz0fi",kMwMTN:"x1m024r3",$$css:!0},blue:{kWkggS:"x1o0wnni",kMwMTN:"x1vvqiwl",$$css:!0},cyan:{kWkggS:"x1rgj867",kMwMTN:"x1txnczv",$$css:!0},green:{kWkggS:"x1sqjeoo",kMwMTN:"xltfdvo",$$css:!0},orange:{kWkggS:"x1e9xt6e",kMwMTN:"xm47u9q",$$css:!0},pink:{kWkggS:"xnpoty2",kMwMTN:"xiuofww",$$css:!0},purple:{kWkggS:"x16i6n6f",kMwMTN:"x1m9wyeb",$$css:!0},red:{kWkggS:"x1cibrc5",kMwMTN:"x1joocv1",$$css:!0},teal:{kWkggS:"x1jtji5o",kMwMTN:"x9x0lbs",$$css:!0},yellow:{kWkggS:"x1bo7t0x",kMwMTN:"xdhq94a",$$css:!0}};function g0({variant:t="neutral",label:l,icon:e,xstyle:a,className:n,style:u,ref:i,...c}){return b.jsxs("span",{ref:i,...At(Tt("badge",{variant:t}),Q(Th.base,$h[t],a),n,u),...c,children:[e,l]})}g0.displayName="XDSBadge";const jh=t=>b.jsxs("svg",{viewBox:"0 0 24 24",fill:"none",stroke:"currentColor",strokeWidth:2,strokeLinecap:"round",strokeLinejoin:"round",...t,children:[b.jsx("line",{x1:"19",y1:"12",x2:"5",y2:"12"}),b.jsx("polyline",{points:"12 19 5 12 12 5"})]}),il={name:"Meridian Desk Lamp",category:"Lighting",subcategory:"Desk Lamps",price:189,sku:"MDL-2024-BRS",description:"A refined desk lamp with an adjustable brass arm and a linen shade. The weighted walnut base keeps it stable on any surface. Perfect for focused task lighting or a warm ambient glow in your workspace.",features:["Adjustable brass arm with 180° rotation","Natural walnut base with anti-scratch felt pad","Linen drum shade with white interior lining","Built-in touch dimmer (3 brightness levels)","Compatible with E26 LED bulbs up to 60W equivalent"],dimensions:"Height: 48 cm | Base: 15 cm diameter | Shade: 20 cm diameter",availability:"In Stock"},Ah=t=>`$${t.toFixed(2)}`;function kh(){return b.jsx(d0,{header:b.jsx(y0,{hasDivider:!0,children:b.jsxs(du,{gap:2,vAlign:"center",children:[b.jsx(ru,{label:"Back",variant:"ghost",icon:b.jsx(jh,{style:{width:16,height:16}}),onClick:()=>window.history.back(),children:"Back"}),b.jsx(Ul,{type:"label",color:"secondary",children:"Product Detail"})]})}),content:b.jsx(m0,{children:b.jsxs(he,{gap:6,children:[b.jsxs(W1,{children:[b.jsx(Xa,{href:"/",children:"Home"}),b.jsx(Xa,{href:"/category",children:il.category}),b.jsx(Xa,{href:"/category/subcategory",children:il.subcategory}),b.jsx(Xa,{isCurrent:!0,children:il.name})]}),b.jsx(s0,{children:b.jsxs(he,{gap:4,children:[b.jsxs(du,{gap:2,vAlign:"center",children:[b.jsx(La,{level:1,children:il.name}),b.jsx(g0,{variant:"success",label:il.availability})]}),b.jsx(Ul,{type:"large",weight:"bold",children:Ah(il.price)}),b.jsxs(Ul,{type:"supporting",color:"secondary",children:["SKU: ",il.sku]}),b.jsx(Za,{}),b.jsxs(he,{gap:2,children:[b.jsx(La,{level:3,children:"Description"}),b.jsx(Ul,{type:"body",children:il.description})]}),b.jsx(Za,{}),b.jsxs(he,{gap:2,children:[b.jsx(La,{level:3,children:"Features"}),b.jsx(he,{gap:1,children:il.features.map((t,l)=>b.jsxs(Ul,{type:"body",children:["• ",t]},l))})]}),b.jsx(Za,{}),b.jsxs(he,{gap:2,children:[b.jsx(La,{level:3,children:"Dimensions"}),b.jsx(Ul,{type:"body",children:il.dimensions})]}),b.jsx(Za,{}),b.jsxs(du,{gap:2,children:[b.jsx(ru,{label:"Add to Cart",variant:"primary",size:"lg",children:"Add to Cart"}),b.jsx(ru,{label:"Back to browsing",variant:"secondary",size:"lg",onClick:()=>window.history.back(),children:"Back"})]})]})})]})})})}function Mh(){return b.jsx(K1,{theme:jv,mode:"light",children:b.jsx(kh,{})})}yg.createRoot(document.getElementById("root")).render(b.jsx(Mh,{}));</script>
+  <style rel="stylesheet" crossorigin>/**
+ * XDS Reset Stylesheet
+ *
+ * An opinionated CSS reset that provides a clean, predictable base for
+ * XDS applications. Built on the same principles as Tailwind Preflight
+ * and modern-normalize, adapted for the XDS design system.
+ *
+ * This reset:
+ * - Normalizes cross-browser inconsistencies
+ * - Sets box-sizing: border-box universally
+ * - Removes default margins, padding, and list styles
+ * - Makes images block-level and responsive
+ * - Resets form elements to inherit font styles
+ * - Uses :where() for zero specificity (easy to override)
+ *
+ * Usage:
+ *
+ * 1. Import directly (global reset):
+ *    import '@xds/core/reset.css';
+ *
+ * 2. Combine with base styles and theme:
+ *    import '@xds/core/reset.css';        // @layer reset  — clean slate
+ *    import '@xds/core/xds.css';           // @layer xds-base — component styles
+ *    import '@xds/theme-default/theme.css'; // @layer xds-theme — theme overrides
+ *
+ * Layer order: reset → xds-base → xds-theme
+ * Consumer styles (unlayered) always override all XDS layers.
+ * The reset has the lowest priority and can be overridden by any other layer.
+ *
+ * Similar to:
+ * - Tailwind CSS Preflight
+ * - Chakra UI's preflight (v3)
+ * - Bootstrap Reboot
+ * - modern-normalize
+ */
+
+@layer reset {
+
+  /* ===========================================================================
+     Box Model
+     =========================================================================== */
+
+  /*
+   * Use border-box globally. Prevents padding/border from affecting
+   * element dimensions — the single most impactful reset.
+   */
+  :where(*, *::before, *::after) {
+    box-sizing: border-box;
+  }
+
+  /*
+   * Reset borders to 0-width solid. This lets you add a border by just
+   * setting border-width — no need to also specify border-style.
+   */
+  :where(*, *::before, *::after) {
+    border-width: 0;
+    border-style: solid;
+    border-color: currentColor;
+  }
+
+  /* ===========================================================================
+     Document
+     =========================================================================== */
+
+  /*
+   * Consistent line-height, prevent text size adjustment on orientation
+   * change in iOS, and set a readable tab size.
+   *
+   * color-scheme: light dark — declares that this page supports both modes,
+   * enabling CSS light-dark() to resolve correctly. Also ensures that CSS
+   * tools (e.g. LightningCSS) which polyfill light-dark() for older browsers
+   * inject their toggle-variable initialization in the same CSS bundle.
+   * XDSTheme overrides color-scheme per-wrapper as needed.
+   */
+  :where(html) {
+    line-height: 1.5;
+    -webkit-text-size-adjust: 100%;
+    tab-size: 4;
+    color-scheme: light dark;
+  }
+
+  /*
+   * Remove default body margin and set font smoothing for sharper text
+   * rendering on macOS/iOS.
+   */
+  :where(body) {
+    margin: 0;
+    line-height: inherit;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+  }
+
+  /* ===========================================================================
+     Typography
+     =========================================================================== */
+
+  /*
+   * Reset headings to inherit size and weight. Headings should be styled
+   * intentionally — not rely on browser defaults that vary across browsers.
+   */
+  :where(h1, h2, h3, h4, h5, h6) {
+    font-size: inherit;
+    font-weight: inherit;
+  }
+
+  /*
+   * Remove default margins on all block-level text elements.
+   */
+  :where(h1, h2, h3, h4, h5, h6, p, blockquote, figure, pre, dl, dd) {
+    margin: 0;
+  }
+
+  /*
+   * Links inherit color and text-decoration. Style them intentionally
+   * rather than relying on browser-default blue/purple.
+   */
+  :where(a) {
+    color: inherit;
+    text-decoration: inherit;
+  }
+
+  /*
+   * Correct font-weight rendering in Chrome and Safari.
+   */
+  :where(b, strong) {
+    font-weight: bolder;
+  }
+
+  /*
+   * Use the configured monospace font stack and fix the odd em sizing
+   * that browsers apply to code elements.
+   */
+  :where(code, kbd, samp, pre) {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+      'Liberation Mono', 'Courier New', monospace;
+    font-size: 1em;
+  }
+
+  /*
+   * Correct font-size for small elements.
+   */
+  :where(small) {
+    font-size: 80%;
+  }
+
+  /*
+   * Prevent sub and sup from affecting line-height.
+   */
+  :where(sub, sup) {
+    font-size: 75%;
+    line-height: 0;
+    position: relative;
+    vertical-align: baseline;
+  }
+
+  :where(sub) {
+    bottom: -0.25em;
+  }
+
+  :where(sup) {
+    top: -0.5em;
+  }
+
+  /* ===========================================================================
+     Lists
+     =========================================================================== */
+
+  /*
+   * Remove default list styles, margin, and padding. Lists used for
+   * navigation or layout shouldn't carry prose styling by default.
+   * Use explicit styles for prose lists.
+   */
+  :where(ol, ul, menu) {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Media
+     =========================================================================== */
+
+  /*
+   * Make replaced elements block-level. Eliminates the "mystery gap"
+   * below inline images and aligns with how these elements are
+   * actually used in modern layouts.
+   */
+  :where(img, svg, video, canvas, audio, iframe, embed, object) {
+    display: block;
+    vertical-align: middle;
+  }
+
+  /*
+   * Constrain images and video to their container. Responsive by default.
+   */
+  :where(img, video) {
+    max-width: 100%;
+    height: auto;
+  }
+
+  /* ===========================================================================
+     Forms
+     =========================================================================== */
+
+  /*
+   * Form elements should inherit font styles from their parent rather
+   * than using the browser's default font stack.
+   */
+  :where(button, input, optgroup, select, textarea) {
+    font: inherit;
+    color: inherit;
+    margin: 0;
+    padding: 0;
+  }
+
+  /*
+   * Remove default button styling. Buttons should be styled intentionally.
+   */
+  :where(button, [type='button'], [type='reset'], [type='submit']) {
+    -webkit-appearance: button;
+    appearance: button;
+    background-color: transparent;
+    background-image: none;
+  }
+
+  /*
+   * Pointer cursor for interactive elements.
+   */
+  :where(button, [role='button']) {
+    cursor: pointer;
+  }
+
+  /*
+   * Default cursor for disabled elements.
+   */
+  :where(:disabled) {
+    cursor: default;
+  }
+
+  /*
+   * Only allow vertical resizing of textareas to prevent layout breakage.
+   */
+  :where(textarea) {
+    resize: vertical;
+  }
+
+  /*
+   * Normalize placeholder opacity (Firefox renders at reduced opacity)
+   * and set a sensible default color using the XDS text-placeholder token.
+   */
+  :where(input::placeholder, textarea::placeholder) {
+    opacity: 1;
+    color: var(--color-text-secondary, #9ca3af);
+  }
+
+  /*
+   * Remove the inner padding and cancel buttons in search inputs
+   * for Chrome and Safari.
+   */
+  :where([type='search']::-webkit-search-decoration,
+         [type='search']::-webkit-search-cancel-button) {
+    -webkit-appearance: none;
+  }
+
+  /*
+   * Remove default fieldset styles.
+   */
+  :where(fieldset) {
+    margin: 0;
+    padding: 0;
+  }
+
+  :where(legend) {
+    padding: 0;
+  }
+
+  /* ===========================================================================
+     Tables
+     =========================================================================== */
+
+  /*
+   * Collapse table borders and fix text-indent/border-color inheritance.
+   */
+  :where(table) {
+    text-indent: 0;
+    border-color: inherit;
+    border-collapse: collapse;
+  }
+
+  /* ===========================================================================
+     Misc
+     =========================================================================== */
+
+  /*
+   * Simplify hr to a single border-top line.
+   */
+  :where(hr) {
+    height: 0;
+    color: inherit;
+    border-top-width: 1px;
+  }
+
+  /*
+   * Correct display for summary elements.
+   */
+  :where(summary) {
+    display: list-item;
+  }
+
+  /*
+   * Reset dialog padding and outline.
+   */
+  :where(dialog) {
+    padding: 0;
+    outline: none;
+  }
+
+  /*
+   * Ensure hidden elements are actually hidden.
+   */
+  :where([hidden]) {
+    display: none;
+  }
+
+  /*
+   * Remove tap highlight on iOS.
+   */
+  :where(html) {
+    -webkit-tap-highlight-color: transparent;
+  }
+
+  /* ===========================================================================
+     Touch Devices
+     =========================================================================== */
+
+  /*
+   * Suppress focus-visible outlines on touch-only devices.
+   *
+   * Focus rings exist to show keyboard users where focus is. On devices
+   * with no hover capability and a coarse pointer (phones, tablets),
+   * there's no keyboard navigation — focus rings are visual noise that
+   * can flash on tap, on dialog open (showModal auto-focus), or on
+   * programmatic focus.
+   *
+   * This targets touch-only devices specifically:
+   * - (hover: none) — no hover capability (not a mouse)
+   * - (pointer: coarse) — imprecise pointer (finger, not stylus)
+   *
+   * Hybrid devices (laptop with touchscreen) are NOT affected because
+   * their primary pointer is fine (trackpad/mouse) and hover is available.
+   */
+  @media (hover: none) and (pointer: coarse) {
+    :where(:focus-visible) {
+      outline: none;
+    }
+  }
+}</style>
+<style>@property --x-width {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-height {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-maxWidth {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x-minHeight {
+  syntax: "*";
+  inherits: false
+}
+
+@property --x---container-max-height {
+  syntax: "*";
+  inherits: false
+}
+
+@keyframes xwmkjkf-B {
+  from {
+    opacity: 0;
+    transform: translateX(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xu7jd1z-B {
+  from {
+    opacity: 0;
+    transform: translateX(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateX(0)scale(1);
+  }
+}
+
+@keyframes xv1hr86-B {
+  from {
+    opacity: 0;
+    transform: translateY(calc(-1 * var(--spacing-2))) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes x1ahk7ht-B {
+  from {
+    opacity: 0;
+    transform: translateY(var(--spacing-2)) scale(.95);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0)scale(1);
+  }
+}
+
+@keyframes xqng64z-B {
+  0% {
+    transform: rotate(0);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+:root, .xyc456f {
+  --border-width: 1px;
+}
+
+:root, .xrphr3l {
+  --color-accent: light-dark(#0064e0, #2694fe);
+  --color-accent-muted: light-dark(#0082fb33, #0082fb3f);
+  --color-on-accent: light-dark(#fff, #fff);
+  --color-neutral: light-dark(#0536591a, #dfe2e533);
+  --color-background-surface: light-dark(#fff, #1f1f22);
+  --color-background-body: light-dark(#f1f4f7, #111112);
+  --color-overlay: light-dark(#01122866, #11111299);
+  --color-overlay-hover: light-dark(#0536590c, #ffffff0c);
+  --color-overlay-pressed: light-dark(#05365919, #ffffff19);
+  --color-background-muted: light-dark(#0536590c, #1111127f);
+  --color-text-primary: light-dark(#0a1317, #dfe2e5);
+  --color-text-secondary: light-dark(#4e606f, #aaafb5);
+  --color-text-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-text-accent: light-dark(#0064e0, #3e9efb);
+  --color-on-dark: light-dark(#fff, #fff);
+  --color-on-light: light-dark(#000, #000);
+  --color-icon-accent: light-dark(#0064e0, #2694fe);
+  --color-icon-primary: light-dark(#0a1317, #dfe2e5);
+  --color-icon-secondary: light-dark(#4e606f, #aaafb5);
+  --color-icon-disabled: light-dark(#a4b0bc, #6f747c);
+  --color-background-card: light-dark(#fff, #1f1f22);
+  --color-background-popover: light-dark(#fff, #28292c);
+  --color-success: light-dark(#0d8626, #0d8626);
+  --color-success-muted: light-dark(#0b991f33, #0b991f3f);
+  --color-on-success: light-dark(#fff, #fff);
+  --color-error: light-dark(#e3193b, #f5394f);
+  --color-error-muted: light-dark(#e3193b33, #f5394f3f);
+  --color-on-error: light-dark(#fff, #fff);
+  --color-warning: light-dark(#e9af08, #f2c00b);
+  --color-warning-muted: light-dark(#e2a40033, #e2a4003f);
+  --color-on-warning: light-dark(#0a1317, #0a1317);
+  --color-border: light-dark(#05365919, #f2f4f619);
+  --color-border-emphasized: light-dark(#ccd3db, #494d53);
+  --color-skeleton: light-dark(#ccd3db, #5a5e66);
+  --color-shadow: light-dark(#0536591a, #0000004d);
+  --color-tint-hover: light-dark(#000, #fff);
+  --color-background-blue: light-dark(#0171e333, #0171e333);
+  --color-border-blue: light-dark(#0171e3, #4ba9fe);
+  --color-icon-blue: light-dark(#0064e0, #2694fe);
+  --color-text-blue: light-dark(#042f97, #afd7ff);
+  --color-background-cyan: light-dark(#03a7d733, #03a7d733);
+  --color-border-cyan: light-dark(#00bcd4, #4dd0e1);
+  --color-icon-cyan: light-dark(#00acc1, #26c6da);
+  --color-text-cyan: light-dark(#014975, #a1eef9);
+  --color-background-gray: light-dark(#0a131733, #666a724c);
+  --color-border-gray: light-dark(#647685, #8c939b);
+  --color-icon-gray: light-dark(#4e606f, #aaafb5);
+  --color-text-gray: light-dark(#0a1317, #e7eaed);
+  --color-background-green: light-dark(#24bb5e33, #24bb5e33);
+  --color-border-green: light-dark(#24bb5e, #4cd964);
+  --color-icon-green: light-dark(#0d8626, #26a756);
+  --color-text-green: light-dark(#09441f, #a5f690);
+  --color-background-orange: light-dark(#f2790233, #f2790233);
+  --color-border-orange: light-dark(#f27902, #ffa040);
+  --color-icon-orange: light-dark(#e9690b, #fb8c00);
+  --color-text-orange: light-dark(#6b2203, #fdb876);
+  --color-background-pink: light-dark(#e638b333, #e638b333);
+  --color-border-pink: light-dark(#e91e63, #f48fb1);
+  --color-icon-pink: light-dark(#c2185b, #ec407a);
+  --color-text-pink: light-dark(#650053, #feade3);
+  --color-background-purple: light-dark(#7952ff33, #7952ff33);
+  --color-border-purple: light-dark(#7952ff, #9575cd);
+  --color-icon-purple: light-dark(#5b08d8, #7952ff);
+  --color-text-purple: light-dark(#3e0697, #b3b0fe);
+  --color-background-red: light-dark(#e3193b33, #e3193b33);
+  --color-border-red: light-dark(#e3193b, #f5394f);
+  --color-icon-red: light-dark(#d31130, #e3193b);
+  --color-text-red: light-dark(#7b0210, #ffb2b8);
+  --color-background-teal: light-dark(#0db7af33, #0db7af33);
+  --color-border-teal: light-dark(#0db7af, #4db6ac);
+  --color-icon-teal: light-dark(#009688, #26a69a);
+  --color-text-teal: light-dark(#083943, #40dccd);
+  --color-background-yellow: light-dark(#e2a40033, #e2a40033);
+  --color-border-yellow: light-dark(#ffeb3b, #fff176);
+  --color-icon-yellow: light-dark(#fbc02d, #ffee58);
+  --color-text-yellow: light-dark(#753f07, #fbce03);
+}
+
+:root, .xdxxp96 {
+  --duration-fast-min: .13s;
+  --duration-fast: .175s;
+  --duration-fast-max: .23s;
+  --duration-medium-min: .31s;
+  --duration-medium: .41s;
+  --duration-medium-max: .55s;
+}
+
+:root, .x1u6r7cv {
+  --ease-standard: cubic-bezier(.24, 1, .4, 1);
+}
+
+:root, .x6xvlns {
+  --font-family-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-family-code: "SF Mono", Monaco, Consolas, monospace;
+  --font-family-heading: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+:root, .x48sopm {
+  --font-size-4xs: .375rem;
+  --font-size-3xs: .4375rem;
+  --font-size-2xs: .5rem;
+  --font-size-xs: .625rem;
+  --font-size-sm: .75rem;
+  --font-size-base: .875rem;
+  --font-size-lg: 1.0625rem;
+  --font-size-xl: 1.25rem;
+  --font-size-2xl: 1.5rem;
+  --font-size-3xl: 1.8125rem;
+  --font-size-4xl: 2.1875rem;
+  --font-size-5xl: 2.625rem;
+}
+
+:root, .x1anzp68 {
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+}
+
+:root, .xy6n0i {
+  --radius-none: 0px;
+  --radius-inner: 4px;
+  --radius-element: 8px;
+  --radius-container: 12px;
+  --radius-page: 28px;
+  --radius-full: 9999px;
+}
+
+:root, .x99zpk1 {
+  --shadow-low: 0px 1px 1px light-dark(#0000001a, #0003), 0px 2px 8px light-dark(#0000001a, #0003);
+  --shadow-med: 0px 1px 2px light-dark(#0000001a, #0003), 0px 2px 12px light-dark(#0000001a, #0003);
+  --shadow-high: 0px 2px 2px light-dark(#0000001a, #0003), 0px 8px 24px light-dark(#0000001a, #0000004d);
+  --shadow-inset-hover: inset 0px 0px 0px 2px #0171e34d;
+  --shadow-inset-selected: inset 0px 0px 0px 2px #0171e380;
+  --shadow-inset-success: inset 0px 0px 0px 2px #26a7564d;
+  --shadow-inset-warning: inset 0px 0px 0px 2px #e2a4004d;
+  --shadow-inset-error: inset 0px 0px 0px 2px #e3193b4d;
+}
+
+:root, .x10aelx4 {
+  --size-element-sm: 28px;
+  --size-element-md: 32px;
+  --size-element-lg: 36px;
+}
+
+:root, .x1auoh0n {
+  --spacing-0: 0px;
+  --spacing-0-5: 2px;
+  --spacing-1: 4px;
+  --spacing-1-5: 6px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-5: 20px;
+  --spacing-6: 24px;
+  --spacing-7: 28px;
+  --spacing-8: 32px;
+  --spacing-9: 36px;
+  --spacing-10: 40px;
+  --spacing-11: 44px;
+  --spacing-12: 48px;
+}
+
+:root, .xmde5od {
+  --text-heading-1-size: var(--font-size-2xl);
+  --text-heading-1-weight: var(--font-weight-semibold);
+  --text-heading-1-leading: 1.3333;
+  --text-heading-2-size: var(--font-size-xl);
+  --text-heading-2-weight: var(--font-weight-semibold);
+  --text-heading-2-leading: 1.4;
+  --text-heading-3-size: var(--font-size-lg);
+  --text-heading-3-weight: var(--font-weight-semibold);
+  --text-heading-3-leading: 1.4118;
+  --text-heading-4-size: var(--font-size-base);
+  --text-heading-4-weight: var(--font-weight-semibold);
+  --text-heading-4-leading: 1.4286;
+  --text-heading-5-size: var(--font-size-sm);
+  --text-heading-5-weight: var(--font-weight-semibold);
+  --text-heading-5-leading: 1.6667;
+  --text-heading-6-size: var(--font-size-xs);
+  --text-heading-6-weight: var(--font-weight-semibold);
+  --text-heading-6-leading: 1.6;
+  --text-body-size: var(--font-size-base);
+  --text-body-weight: var(--font-weight-normal);
+  --text-body-leading: 1.4286;
+  --text-large-size: var(--font-size-lg);
+  --text-large-weight: var(--font-weight-semibold);
+  --text-large-leading: 1.4118;
+  --text-label-size: var(--font-size-base);
+  --text-label-weight: var(--font-weight-medium);
+  --text-label-leading: 1.4286;
+  --text-code-size: var(--font-size-base);
+  --text-code-weight: var(--font-weight-normal);
+  --text-code-leading: 1.4286;
+  --text-supporting-size: var(--font-size-sm);
+  --text-supporting-weight: var(--font-weight-normal);
+  --text-supporting-leading: 1.6667;
+  --text-display-1-size: var(--font-size-5xl);
+  --text-display-1-weight: var(--font-weight-normal);
+  --text-display-1-leading: 1.2381;
+  --text-display-2-size: var(--font-size-4xl);
+  --text-display-2-weight: var(--font-weight-normal);
+  --text-display-2-leading: 1.2571;
+  --text-display-3-size: var(--font-size-3xl);
+  --text-display-3-weight: var(--font-weight-normal);
+  --text-display-3-leading: 1.2414;
+}
+
+:root, .xs77cmt {
+  --transition-fast: .15s ease;
+  --transition-normal: .2s ease;
+}
+
+.xkzo27j {
+  --button-focus-offset: 3px;
+}
+
+.x1v15ycx {
+  --button-icon-only-aspect: 1 / 1;
+}
+
+.x1mkq5kp {
+  --button-radius: var(--radius-element);
+}
+
+.xb26y6u {
+  --card-radius: var(--radius-container);
+}
+
+.x30uzy1 {
+  --component-padding-inline: var(--spacing-2);
+}
+
+.x1ojg8sz {
+  --component-padding-inline: var(--spacing-3);
+}
+
+.x18nyedi {
+  --container-max-height: var(--x---container-max-height);
+}
+
+.x1qmdwou {
+  --container-padding-inline: var(--spacing-0-5);
+}
+
+.x11nj8ps {
+  --container-padding-inline: var(--spacing-0);
+}
+
+.x11c4xrl {
+  --container-padding-inline: var(--spacing-1-5);
+}
+
+.xmqp8mn {
+  --container-padding-inline: var(--spacing-1);
+}
+
+.x1mh38z9 {
+  --container-padding-inline: var(--spacing-10);
+}
+
+.xarkblc {
+  --container-padding-inline: var(--spacing-11);
+}
+
+.x15nzvup {
+  --container-padding-inline: var(--spacing-12);
+}
+
+.xvkq9sf {
+  --container-padding-inline: var(--spacing-2);
+}
+
+.x17rklng {
+  --container-padding-inline: var(--spacing-3);
+}
+
+.x1qtkjpi {
+  --container-padding-inline: var(--spacing-4);
+}
+
+.xcek0mv {
+  --container-padding-inline: var(--spacing-5);
+}
+
+.xzryng3 {
+  --container-padding-inline: var(--spacing-6);
+}
+
+.x1jrgra8 {
+  --container-padding-inline: var(--spacing-7);
+}
+
+.x1t3jwqk {
+  --container-padding-inline: var(--spacing-8);
+}
+
+.x1ikhtwg {
+  --container-padding-inline: var(--spacing-9);
+}
+
+.x118jium {
+  --container-padding-inline: var(--xds-card-padding, var(--spacing-4));
+}
+
+.x1x4tb0e {
+  --container-padding-inline: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xbuvapz {
+  --container-padding: 0px;
+}
+
+.x1b322fk {
+  --container-padding: var(--spacing-0-5);
+}
+
+.x1i337hy {
+  --container-padding: var(--spacing-0);
+}
+
+.x1tqehje {
+  --container-padding: var(--spacing-1-5);
+}
+
+.x11x0u8a {
+  --container-padding: var(--spacing-1);
+}
+
+.xl4lgz8 {
+  --container-padding: var(--spacing-10);
+}
+
+.xfk8qm2 {
+  --container-padding: var(--spacing-11);
+}
+
+.xtcn5oa {
+  --container-padding: var(--spacing-12);
+}
+
+.xyawmno {
+  --container-padding: var(--spacing-2);
+}
+
+.xiq2vfk {
+  --container-padding: var(--spacing-3);
+}
+
+.x18iqpsj {
+  --container-padding: var(--spacing-4);
+}
+
+.x305b4h {
+  --container-padding: var(--spacing-5);
+}
+
+.x1suvfq4 {
+  --container-padding: var(--spacing-6);
+}
+
+.xe04trj {
+  --container-padding: var(--spacing-7);
+}
+
+.xv6sa6u {
+  --container-padding: var(--spacing-8);
+}
+
+.xswgb5g {
+  --container-padding: var(--spacing-9);
+}
+
+.x8q8htr {
+  --container-padding: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xms56fs {
+  --container-padding: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xwfoc2r {
+  --edge-end: 1;
+}
+
+.x1tfgai2 {
+  --edge-start: 1;
+}
+
+.xlriy2h {
+  --layout-padding-inner-x: var(--spacing-0-5);
+}
+
+.xj1bl4l {
+  --layout-padding-inner-x: var(--spacing-0);
+}
+
+.xd38f90 {
+  --layout-padding-inner-x: var(--spacing-1-5);
+}
+
+.x6uuyak {
+  --layout-padding-inner-x: var(--spacing-1);
+}
+
+.x1vf4qco {
+  --layout-padding-inner-x: var(--spacing-10);
+}
+
+.xsmamsf {
+  --layout-padding-inner-x: var(--spacing-11);
+}
+
+.x2xk2xj {
+  --layout-padding-inner-x: var(--spacing-12);
+}
+
+.xxqksqd {
+  --layout-padding-inner-x: var(--spacing-2);
+}
+
+.x1fyui2f {
+  --layout-padding-inner-x: var(--spacing-3);
+}
+
+.x1i2ajwi {
+  --layout-padding-inner-x: var(--spacing-4);
+}
+
+.x1tac27u {
+  --layout-padding-inner-x: var(--spacing-5);
+}
+
+.x1ntgf3t {
+  --layout-padding-inner-x: var(--spacing-6);
+}
+
+.xhjd9tl {
+  --layout-padding-inner-x: var(--spacing-7);
+}
+
+.xn7c84u {
+  --layout-padding-inner-x: var(--spacing-8);
+}
+
+.xeqkbsz {
+  --layout-padding-inner-x: var(--spacing-9);
+}
+
+.x1gox8qf {
+  --layout-padding-inner-x: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xn3f0pw {
+  --layout-padding-inner-x: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x180h0y5 {
+  --layout-padding-inner-y: var(--spacing-0-5);
+}
+
+.xwuefyo {
+  --layout-padding-inner-y: var(--spacing-0);
+}
+
+.x1g8jpzm {
+  --layout-padding-inner-y: var(--spacing-1-5);
+}
+
+.xmpug6m {
+  --layout-padding-inner-y: var(--spacing-1);
+}
+
+.x18gbwmk {
+  --layout-padding-inner-y: var(--spacing-10);
+}
+
+.x14zymzj {
+  --layout-padding-inner-y: var(--spacing-11);
+}
+
+.xzfpkx9 {
+  --layout-padding-inner-y: var(--spacing-12);
+}
+
+.x1lksgje {
+  --layout-padding-inner-y: var(--spacing-2);
+}
+
+.x4j7gld {
+  --layout-padding-inner-y: var(--spacing-3);
+}
+
+.x1s3ehtl {
+  --layout-padding-inner-y: var(--spacing-4);
+}
+
+.x1rj5eim {
+  --layout-padding-inner-y: var(--spacing-5);
+}
+
+.x1ftgg6u {
+  --layout-padding-inner-y: var(--spacing-6);
+}
+
+.x1ho74vh {
+  --layout-padding-inner-y: var(--spacing-7);
+}
+
+.xm2cs6f {
+  --layout-padding-inner-y: var(--spacing-8);
+}
+
+.x1vsq92b {
+  --layout-padding-inner-y: var(--spacing-9);
+}
+
+.x1eounod {
+  --layout-padding-inner-y: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xihc2cu {
+  --layout-padding-inner-y: var(--xds-section-padding, var(--spacing-4));
+}
+
+.x1wbjvqu {
+  --layout-padding-outer-x: 0px;
+}
+
+.xihiwg7 {
+  --layout-padding-outer-x: var(--spacing-0-5);
+}
+
+.xswhm3q {
+  --layout-padding-outer-x: var(--spacing-0);
+}
+
+.x1u93lgd {
+  --layout-padding-outer-x: var(--spacing-1-5);
+}
+
+.xc96xmq {
+  --layout-padding-outer-x: var(--spacing-1);
+}
+
+.x1jdf5a4 {
+  --layout-padding-outer-x: var(--spacing-10);
+}
+
+.x1hct0t0 {
+  --layout-padding-outer-x: var(--spacing-11);
+}
+
+.x11cyqoe {
+  --layout-padding-outer-x: var(--spacing-12);
+}
+
+.x15dxnc0 {
+  --layout-padding-outer-x: var(--spacing-2);
+}
+
+.xadgj3j {
+  --layout-padding-outer-x: var(--spacing-3);
+}
+
+.x1v56qcf {
+  --layout-padding-outer-x: var(--spacing-4);
+}
+
+.x1nzs0gl {
+  --layout-padding-outer-x: var(--spacing-5);
+}
+
+.x1c3n52a {
+  --layout-padding-outer-x: var(--spacing-6);
+}
+
+.x1gfiokx {
+  --layout-padding-outer-x: var(--spacing-7);
+}
+
+.x1t3kfz {
+  --layout-padding-outer-x: var(--spacing-8);
+}
+
+.xzr4qsh {
+  --layout-padding-outer-x: var(--spacing-9);
+}
+
+.x1r0u152 {
+  --layout-padding-outer-x: var(--xds-card-padding, var(--spacing-4));
+}
+
+.x1h0nqri {
+  --layout-padding-outer-x: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xzxxx64 {
+  --layout-padding-outer-y: 0px;
+}
+
+.x1vj96e0 {
+  --layout-padding-outer-y: var(--spacing-0-5);
+}
+
+.x1mzf5mb {
+  --layout-padding-outer-y: var(--spacing-0);
+}
+
+.xd3dqby {
+  --layout-padding-outer-y: var(--spacing-1-5);
+}
+
+.x1gpfxoh {
+  --layout-padding-outer-y: var(--spacing-1);
+}
+
+.x26l4wa {
+  --layout-padding-outer-y: var(--spacing-10);
+}
+
+.x10zktp0 {
+  --layout-padding-outer-y: var(--spacing-11);
+}
+
+.x1yz3n6a {
+  --layout-padding-outer-y: var(--spacing-12);
+}
+
+.x10pz7y9 {
+  --layout-padding-outer-y: var(--spacing-2);
+}
+
+.x1p6yq3h {
+  --layout-padding-outer-y: var(--spacing-3);
+}
+
+.xx738ci {
+  --layout-padding-outer-y: var(--spacing-4);
+}
+
+.x6yxws5 {
+  --layout-padding-outer-y: var(--spacing-5);
+}
+
+.x180vrwl {
+  --layout-padding-outer-y: var(--spacing-6);
+}
+
+.x1q6rme1 {
+  --layout-padding-outer-y: var(--spacing-7);
+}
+
+.xid7e43 {
+  --layout-padding-outer-y: var(--spacing-8);
+}
+
+.x1t5kicu {
+  --layout-padding-outer-y: var(--spacing-9);
+}
+
+.xzqheer {
+  --layout-padding-outer-y: var(--xds-card-padding, var(--spacing-4));
+}
+
+.xlfd3nr {
+  --layout-padding-outer-y: var(--xds-section-padding, var(--spacing-4));
+}
+
+.xkdpibf:not(#\#) {
+  margin: -1px;
+}
+
+.x1ghz6dp:not(#\#) {
+  margin: 0;
+}
+
+.x1ak00ur:not(#\#) {
+  margin: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1717udv:not(#\#) {
+  padding: 0;
+}
+
+.x1kp5lmi:not(#\#) {
+  padding: var(--container-padding);
+}
+
+.xvy26l8:not(#\#):not(#\#) {
+  border-color: var(--color-border-emphasized);
+}
+
+.x1q11iln:not(#\#):not(#\#) {
+  border-radius: var(--button-radius);
+}
+
+.x8j4bds:not(#\#):not(#\#) {
+  border-radius: var(--card-radius);
+}
+
+.x1hviunn:not(#\#):not(#\#) {
+  border-radius: var(--radius-container);
+}
+
+.xjspbzw:not(#\#):not(#\#) {
+  border-radius: var(--radius-full);
+}
+
+.xng3xce:not(#\#):not(#\#) {
+  border-style: none;
+}
+
+.x1y0btm7:not(#\#):not(#\#) {
+  border-style: solid;
+}
+
+.xc342km:not(#\#):not(#\#) {
+  border-width: 0;
+}
+
+.x1litavf:not(#\#):not(#\#) {
+  border-width: var(--border-width);
+}
+
+.x98rzlu:not(#\#):not(#\#) {
+  flex: 1;
+}
+
+.xzye2dw:not(#\#):not(#\#) {
+  gap: var(--spacing-1);
+}
+
+.x1txdalj:not(#\#):not(#\#) {
+  gap: var(--spacing-2);
+}
+
+.xe8uvvx:not(#\#):not(#\#) {
+  list-style: none;
+}
+
+.xcxpkta:not(#\#):not(#\#) {
+  margin-block: calc(-1 * var(--container-padding, 0px));
+}
+
+.xzyy9it:not(#\#):not(#\#) {
+  margin-inline: calc(-1 * var(--container-padding, 0px));
+}
+
+.xysyzu8:not(#\#):not(#\#) {
+  overflow: auto;
+}
+
+.x7giv3:not(#\#):not(#\#) {
+  overflow: clip;
+}
+
+.xb3r6kr:not(#\#):not(#\#) {
+  overflow: hidden;
+}
+
+.x1rea2x4:not(#\#):not(#\#) {
+  overflow: visible;
+}
+
+.xt970qd:not(#\#):not(#\#) {
+  padding-block: 0;
+}
+
+.xu0wf1k:not(#\#):not(#\#) {
+  padding-block: var(--spacing-1);
+}
+
+.xce4md1:not(#\#):not(#\#) {
+  padding-block: var(--spacing-2);
+}
+
+.x8o8v82:not(#\#):not(#\#) {
+  padding-block: var(--spacing-3);
+}
+
+.xnjsko4:not(#\#):not(#\#) {
+  padding-inline: 0;
+}
+
+.xf314gf:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-2);
+}
+
+.xrrkdod:not(#\#):not(#\#) {
+  padding-inline: var(--spacing-3);
+}
+
+.xmqliwb:not(#\#):not(#\#) {
+  text-decoration: line-through;
+}
+
+.x1hl2dhg:not(#\#):not(#\#) {
+  text-decoration: none;
+}
+
+.x17nn4n9:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-accent);
+}
+
+.x1p73he7:focus-visible:not(#\#):not(#\#) {
+  outline: 2px solid var(--color-error);
+}
+
+@media (hover: hover) {
+  .x4ohgrr.x4ohgrr:hover:not(#\#):not(#\#) {
+    text-decoration: underline;
+  }
+}
+
+.x1ua5tub:not(#\#):not(#\#):not(#\#) {
+  -webkit-box-orient: vertical;
+}
+
+.x6s0dn4:not(#\#):not(#\#):not(#\#) {
+  align-items: center;
+}
+
+.xuk3077:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-end;
+}
+
+.x1cy8zhl:not(#\#):not(#\#):not(#\#) {
+  align-items: flex-start;
+}
+
+.x1qjc9v5:not(#\#):not(#\#):not(#\#) {
+  align-items: stretch;
+}
+
+.xamitd3:not(#\#):not(#\#):not(#\#) {
+  align-self: center;
+}
+
+.xpvyfi4:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-end;
+}
+
+.xqcrz7y:not(#\#):not(#\#):not(#\#) {
+  align-self: flex-start;
+}
+
+.xkh2ocl:not(#\#):not(#\#):not(#\#) {
+  align-self: stretch;
+}
+
+.x9uej1z:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-fast-max);
+}
+
+.xqgcaz:not(#\#):not(#\#):not(#\#) {
+  animation-duration: var(--duration-medium-max);
+}
+
+.xskzprw:not(#\#):not(#\#):not(#\#) {
+  animation-fill-mode: backwards;
+}
+
+.xa4qsjk:not(#\#):not(#\#):not(#\#) {
+  animation-iteration-count: infinite;
+}
+
+.x3psbcj:not(#\#):not(#\#):not(#\#) {
+  animation-name: x1ahk7ht-B;
+}
+
+.x1ka1v4i:not(#\#):not(#\#):not(#\#) {
+  animation-name: xqng64z-B;
+}
+
+.xck01x9:not(#\#):not(#\#):not(#\#) {
+  animation-name: xu7jd1z-B;
+}
+
+.xl1vlw0:not(#\#):not(#\#):not(#\#) {
+  animation-name: xv1hr86-B;
+}
+
+.x1i331go:not(#\#):not(#\#):not(#\#) {
+  animation-name: xwmkjkf-B;
+}
+
+.x1esw782:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: linear;
+}
+
+.x128ha8g:not(#\#):not(#\#):not(#\#) {
+  animation-timing-function: var(--ease-standard);
+}
+
+.xioom0i:not(#\#):not(#\#):not(#\#) {
+  aspect-ratio: var(--button-icon-only-aspect);
+}
+
+.xlp1x4z:not(#\#):not(#\#):not(#\#) {
+  backface-visibility: hidden;
+}
+
+.xjbqb8w:not(#\#):not(#\#):not(#\#) {
+  background-color: #0000;
+}
+
+.x1ewilqj:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-accent);
+}
+
+.x1o0wnni:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-blue);
+}
+
+.x1de1mus:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-card);
+}
+
+.x1rgj867:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-cyan);
+}
+
+.x1sqjeoo:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-green);
+}
+
+.xwmxj5m:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-muted);
+}
+
+.x1e9xt6e:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-orange);
+}
+
+.xnpoty2:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-pink);
+}
+
+.x16i6n6f:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-purple);
+}
+
+.x1cibrc5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-red);
+}
+
+.x10xzikg:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-surface);
+}
+
+.x1jtji5o:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-teal);
+}
+
+.x1bo7t0x:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-background-yellow);
+}
+
+.x7njt3n:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border-emphasized);
+}
+
+.x1m4xfpy:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-border);
+}
+
+.x1pjz0fi:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-error);
+}
+
+.x17x4s8c:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-neutral);
+}
+
+.xdsz4j9:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-success);
+}
+
+.x19aspcf:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-text-primary);
+}
+
+.x1q8g9m5:not(#\#):not(#\#):not(#\#) {
+  background-color: var(--color-warning);
+}
+
+.x18o3ruo:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1gejf6u:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-color: var(--color-border);
+}
+
+.x18b5jzi:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-style: solid;
+}
+
+.x1lun4ml:not(#\#):not(#\#):not(#\#) {
+  border-inline-end-width: 1px;
+}
+
+.x1j92z86:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-color: var(--color-border);
+}
+
+.x1t7ytsu:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-style: solid;
+}
+
+.xpilrb4:not(#\#):not(#\#):not(#\#) {
+  border-inline-start-width: 1px;
+}
+
+.x9f619:not(#\#):not(#\#):not(#\#) {
+  box-sizing: border-box;
+}
+
+.xzpqnlu:not(#\#):not(#\#):not(#\#) {
+  clip: rect(0,0,0,0);
+}
+
+.xntwwlm:not(#\#):not(#\#):not(#\#) {
+  color-scheme: dark;
+}
+
+.x108lcm5:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light dark;
+}
+
+.x19aimcq:not(#\#):not(#\#):not(#\#) {
+  color-scheme: light;
+}
+
+.x1heor9g:not(#\#):not(#\#):not(#\#) {
+  color: inherit;
+}
+
+.x19co3pv:not(#\#):not(#\#):not(#\#) {
+  color: #0000;
+}
+
+.xqwr325:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-accent);
+}
+
+.xrkvqaz:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-background-surface);
+}
+
+.x17wrial:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-accent);
+}
+
+.x1m024r3:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-error);
+}
+
+.xri61p4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-success);
+}
+
+.xrebv38:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-on-warning);
+}
+
+.xjse4m1:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-accent);
+}
+
+.x1vvqiwl:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-blue);
+}
+
+.x1txnczv:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-cyan);
+}
+
+.xnbbluu:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-disabled);
+}
+
+.xltfdvo:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-green);
+}
+
+.xm47u9q:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-orange);
+}
+
+.xiuofww:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-pink);
+}
+
+.x1tgivj0:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-primary);
+}
+
+.x1m9wyeb:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-purple);
+}
+
+.x1joocv1:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-red);
+}
+
+.xv1l7n4:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-secondary);
+}
+
+.x9x0lbs:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-teal);
+}
+
+.xdhq94a:not(#\#):not(#\#):not(#\#) {
+  color: var(--color-text-yellow);
+}
+
+.x1kihgfc:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0-5);
+}
+
+.x1o57wo1:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-0);
+}
+
+.x1thn6ci:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1-5);
+}
+
+.x1lfs0n9:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-1);
+}
+
+.x1p37tyl:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-10);
+}
+
+.xak3so:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-2);
+}
+
+.xewh9hi:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-3);
+}
+
+.xty4p9g:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-4);
+}
+
+.x1eqhezk:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-5);
+}
+
+.x3qlgwd:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-6);
+}
+
+.xicv188:not(#\#):not(#\#):not(#\#) {
+  column-gap: var(--spacing-8);
+}
+
+.x1h6gzvc:not(#\#):not(#\#):not(#\#) {
+  cursor: not-allowed;
+}
+
+.x1ypdohk:not(#\#):not(#\#):not(#\#) {
+  cursor: pointer;
+}
+
+.x104kibb:not(#\#):not(#\#):not(#\#) {
+  display: -webkit-box;
+}
+
+.x1lliihq:not(#\#):not(#\#):not(#\#) {
+  display: block;
+}
+
+.xjp7ctv:not(#\#):not(#\#):not(#\#) {
+  display: contents;
+}
+
+.x78zum5:not(#\#):not(#\#):not(#\#) {
+  display: flex;
+}
+
+.x1rg5ohu:not(#\#):not(#\#):not(#\#) {
+  display: inline-block;
+}
+
+.x3nfvp2:not(#\#):not(#\#):not(#\#) {
+  display: inline-flex;
+}
+
+.xt0psk2:not(#\#):not(#\#):not(#\#) {
+  display: inline;
+}
+
+.xdt5ytf:not(#\#):not(#\#):not(#\#) {
+  flex-direction: column;
+}
+
+.x1q0g3np:not(#\#):not(#\#):not(#\#) {
+  flex-direction: row;
+}
+
+.x1c4vz4f:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 0;
+}
+
+.x1iyjqo2:not(#\#):not(#\#):not(#\#) {
+  flex-grow: 1;
+}
+
+.x2lah0s:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 0;
+}
+
+.xs83m0k:not(#\#):not(#\#):not(#\#) {
+  flex-shrink: 1;
+}
+
+.xozqiw3:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: nowrap;
+}
+
+.x8hhl5t:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap-reverse;
+}
+
+.x1a02dak:not(#\#):not(#\#):not(#\#) {
+  flex-wrap: wrap;
+}
+
+.xjb2p0i:not(#\#):not(#\#):not(#\#) {
+  font-family: inherit;
+}
+
+.x9ynric:not(#\#):not(#\#):not(#\#) {
+  font-family: var(--font-family-body);
+}
+
+.x1j61zf2:not(#\#):not(#\#):not(#\#) {
+  font-size: 16px;
+}
+
+.xwsyq91:not(#\#):not(#\#):not(#\#) {
+  font-size: 20px;
+}
+
+.xjm74w1:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-body-size);
+}
+
+.xcr08ib:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-label-size);
+}
+
+.x141an7d:not(#\#):not(#\#):not(#\#) {
+  font-size: var(--text-supporting-size);
+}
+
+.xss6m8b:not(#\#):not(#\#):not(#\#) {
+  font-variant-numeric: tabular-nums;
+}
+
+.x1pd3egz:not(#\#):not(#\#):not(#\#) {
+  font-weight: inherit;
+}
+
+.x1lvx875:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-bold);
+}
+
+.x1e4wzip:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-medium);
+}
+
+.x1sodnla:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-normal);
+}
+
+.x2mo6ok:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--font-weight-semibold);
+}
+
+.xxovm9e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-body-weight);
+}
+
+.xx3eeay:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-code-weight);
+}
+
+.x1txul5o:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-1-weight);
+}
+
+.x1y36c3f:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-2-weight);
+}
+
+.x1on40hk:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-display-3-weight);
+}
+
+.xmhvcl5:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-label-weight);
+}
+
+.x149oux8:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-large-weight);
+}
+
+.xv8on6e:not(#\#):not(#\#):not(#\#) {
+  font-weight: var(--text-supporting-weight);
+}
+
+.xl56j7k:not(#\#):not(#\#):not(#\#) {
+  justify-content: center;
+}
+
+.x13a6bvl:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-end;
+}
+
+.x1nhvcw1:not(#\#):not(#\#):not(#\#) {
+  justify-content: flex-start;
+}
+
+.x1l1ennw:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-around;
+}
+
+.x1qughib:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-between;
+}
+
+.xaw8158:not(#\#):not(#\#):not(#\#) {
+  justify-content: space-evenly;
+}
+
+.xw6l6zx:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-body-leading);
+}
+
+.x1kq96og:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-label-leading);
+}
+
+.x1ltkj2j:not(#\#):not(#\#):not(#\#) {
+  line-height: var(--text-supporting-leading);
+}
+
+.x14z9mp:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: 0;
+}
+
+.x1kpg4um:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(-1 * var(--layout-padding-inner-x, var(--spacing-4)));
+}
+
+.xofqkxr:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: calc(var(--edge-end, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.xnur1sd:not(#\#):not(#\#):not(#\#) {
+  margin-inline-end: var(--spacing-1);
+}
+
+.x1lziwak:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: 0;
+}
+
+.x1wim8z0:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(-1 * var(--layout-padding-inner-x, var(--spacing-4)));
+}
+
+.xg82z56:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: calc(var(--edge-start, 0) * -1 * min(var(--component-padding-inline, 0px),var(--container-padding-inline, 0px)));
+}
+
+.x11g1kdw:not(#\#):not(#\#):not(#\#) {
+  margin-inline-start: var(--spacing-1);
+}
+
+.xbyyjgo:not(#\#):not(#\#):not(#\#) {
+  opacity: .5;
+}
+
+.x1wfwxd8:not(#\#):not(#\#):not(#\#) {
+  outline-offset: 0;
+}
+
+.x1mzt3pk:not(#\#):not(#\#):not(#\#) {
+  overflow-wrap: break-word;
+}
+
+.xyri2b:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: 0;
+}
+
+.x1peupej:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--layout-padding-inner-x, var(--spacing-4));
+}
+
+.xpc6k2p:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--layout-padding-outer-x, var(--spacing-4));
+}
+
+.x1le3yxw:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-0-5);
+}
+
+.x1s0aq8i:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-0);
+}
+
+.x17hk9do:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-1-5);
+}
+
+.x1nryj5t:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-1);
+}
+
+.x160ivqr:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-10);
+}
+
+.x1djylfy:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-2);
+}
+
+.x1t818jl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-3);
+}
+
+.xnjyzlh:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-4);
+}
+
+.xdbrk9v:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-5);
+}
+
+.x1we12cn:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-6);
+}
+
+.x1q91b2g:not(#\#):not(#\#):not(#\#) {
+  padding-inline-end: var(--spacing-8);
+}
+
+.x1c1uobl:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: 0;
+}
+
+.xwjyata:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--layout-padding-inner-x, var(--spacing-4));
+}
+
+.x139j0dd:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--layout-padding-outer-x, var(--spacing-4));
+}
+
+.x138rykx:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-0-5);
+}
+
+.x18gyask:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-0);
+}
+
+.xfti1ec:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-1-5);
+}
+
+.x1vsv5vr:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-1);
+}
+
+.xqp078j:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-10);
+}
+
+.x12gdq22:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-2);
+}
+
+.x126nfab:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-3);
+}
+
+.x1rey3nv:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-4);
+}
+
+.x1blguxw:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-5);
+}
+
+.x31w388:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-6);
+}
+
+.x1j3hnjz:not(#\#):not(#\#):not(#\#) {
+  padding-inline-start: var(--spacing-8);
+}
+
+.x10l6tqk:not(#\#):not(#\#):not(#\#) {
+  position: absolute;
+}
+
+.xixxii4:not(#\#):not(#\#):not(#\#) {
+  position: fixed;
+}
+
+.x1n2onr6:not(#\#):not(#\#):not(#\#) {
+  position: relative;
+}
+
+.x1tw44j4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0-5);
+}
+
+.x6yxi7o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-0);
+}
+
+.xhq53yo:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1-5);
+}
+
+.x1ngg2t4:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-1);
+}
+
+.x1xpicb7:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-10);
+}
+
+.x1x7z4sm:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-2);
+}
+
+.x4olc9o:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-3);
+}
+
+.xtx9w7w:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-4);
+}
+
+.x1iu6piu:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-5);
+}
+
+.xczp1bk:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-6);
+}
+
+.xgx0vcf:not(#\#):not(#\#):not(#\#) {
+  row-gap: var(--spacing-8);
+}
+
+.x1b2iylo:not(#\#):not(#\#):not(#\#) {
+  text-box-edge: cap alphabetic;
+}
+
+.xwgcxoh:not(#\#):not(#\#):not(#\#) {
+  text-box-trim: trim-both;
+}
+
+.xycaml9:not(#\#):not(#\#):not(#\#) {
+  -webkit-text-decoration-color: var(--color-border-emphasized);
+  text-decoration-color: var(--color-border-emphasized);
+}
+
+.xujl8zx:not(#\#):not(#\#):not(#\#) {
+  text-decoration-line: underline;
+}
+
+.xev0dqp:not(#\#):not(#\#):not(#\#) {
+  text-decoration-style: dashed;
+}
+
+.xlyipyv:not(#\#):not(#\#):not(#\#) {
+  text-overflow: ellipsis;
+}
+
+.xrys4gj:not(#\#):not(#\#):not(#\#) {
+  text-underline-offset: 2px;
+}
+
+.x1w2vvpw:not(#\#):not(#\#):not(#\#) {
+  text-wrap: balance;
+}
+
+.xebhuq6:not(#\#):not(#\#):not(#\#) {
+  text-wrap: nowrap;
+}
+
+.x1fzhlzt:not(#\#):not(#\#):not(#\#) {
+  text-wrap: pretty;
+}
+
+.xk4td0m:not(#\#):not(#\#):not(#\#) {
+  text-wrap: wrap;
+}
+
+.x1c071of:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.x3oybdh:not(#\#):not(#\#):not(#\#) {
+  transform: scale(1);
+}
+
+.xuedmi6:not(#\#):not(#\#):not(#\#) {
+  transition-duration: var(--duration-fast);
+}
+
+.xqc8rvf:not(#\#):not(#\#):not(#\#) {
+  transition-property: background-image, transform;
+}
+
+.xlr8y92:not(#\#):not(#\#):not(#\#) {
+  transition-timing-function: var(--ease-standard);
+}
+
+.x87ps6o:not(#\#):not(#\#):not(#\#) {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.xxymvpz:not(#\#):not(#\#):not(#\#) {
+  vertical-align: middle;
+}
+
+.xuxw1ft:not(#\#):not(#\#):not(#\#) {
+  white-space: nowrap;
+}
+
+.x1yn0g08:not(#\#):not(#\#):not(#\#) {
+  word-break: break-all;
+}
+
+.x13faqbe:not(#\#):not(#\#):not(#\#) {
+  word-break: break-word;
+}
+
+.x1lldw8n:not(#\#):not(#\#):not(#\#) {
+  word-break: normal;
+}
+
+.x13aywxo:focus-visible:not(#\#):not(#\#):not(#\#) {
+  outline-offset: var(--button-focus-offset);
+}
+
+.xq8i9tn:active:not(#\#):not(#\#):not(#\#) {
+  background-image: linear-gradient(var(--color-overlay-pressed),var(--color-overlay-pressed));
+}
+
+.xuqm82a:active:not(#\#):not(#\#):not(#\#) {
+  background-image: none;
+}
+
+.x1pdlv7q:active:not(#\#):not(#\#):not(#\#) {
+  transform: none;
+}
+
+.xk4oym4:active:not(#\#):not(#\#):not(#\#) {
+  transform: scale(.98);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .x12w9bfk.x12w9bfk:not(#\#):not(#\#):not(#\#) {
+    transition-duration: 0s;
+  }
+}
+
+@media (hover: hover) {
+  .x1ilzqfv.x1ilzqfv:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: linear-gradient(var(--color-overlay-hover),var(--color-overlay-hover));
+  }
+
+  .x8o3jvd.x8o3jvd:hover:not(#\#):not(#\#):not(#\#) {
+    background-image: none;
+  }
+}
+
+.xw8gpjh:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-color: var(--color-border);
+}
+
+.x1q0q8m5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-style: solid;
+}
+
+.xso031l:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-bottom-width: 1px;
+}
+
+.x1pc3f07:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-color: var(--color-border);
+}
+
+.x13fuv20:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-style: solid;
+}
+
+.x178xt8z:not(#\#):not(#\#):not(#\#):not(#\#) {
+  border-top-width: 1px;
+}
+
+.x1ey2m1c:not(#\#):not(#\#):not(#\#):not(#\#) {
+  bottom: 0;
+}
+
+.x5yr21d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 100%;
+}
+
+.xlup9mm:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 16px;
+}
+
+.xjm9jq1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 1px;
+}
+
+.x1qx5ct2:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: 20px;
+}
+
+.x1x2thlr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: calc(100% + 2 * var(--container-padding, 0px));
+}
+
+.xsyqizj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--border-width);
+}
+
+.xssyfek:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-lg);
+}
+
+.x1ueg155:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-md);
+}
+
+.x6k0iem:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--size-element-sm);
+}
+
+.x1grt7ep:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--spacing-5);
+}
+
+.x16ye13r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  height: var(--x-height);
+}
+
+.xu96u03:not(#\#):not(#\#):not(#\#):not(#\#) {
+  left: 0;
+}
+
+.xat24cr:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: 0;
+}
+
+.x14cgwvg:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: var(--spacing-1);
+}
+
+.xdj266r:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: 0;
+}
+
+.xcsaf9d:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: var(--spacing-1);
+}
+
+.xenllk4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-height: var(--container-max-height, none);
+}
+
+.xw5ewwj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: 300px;
+}
+
+.xf68679:not(#\#):not(#\#):not(#\#):not(#\#) {
+  max-width: var(--x-maxWidth);
+}
+
+.x2lwn1j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 0;
+}
+
+.x1us19tq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: 100%;
+}
+
+.x82snj4:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-height: var(--x-minHeight);
+}
+
+.xeuugli:not(#\#):not(#\#):not(#\#):not(#\#) {
+  min-width: 0;
+}
+
+.x18d9i69:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.xg476vw:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--layout-padding-inner-y, var(--spacing-4));
+}
+
+.xon7vh3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--layout-padding-outer-y, var(--spacing-4));
+}
+
+.xij103a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-0-5);
+}
+
+.x1l20ajd:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-0);
+}
+
+.x1opdxmq:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1-5);
+}
+
+.xy143xn:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-1);
+}
+
+.x2izi54:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-10);
+}
+
+.x1wesfrj:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-2);
+}
+
+.xvmdzux:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-3);
+}
+
+.x1awphl8:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-4);
+}
+
+.x1hk98q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-5);
+}
+
+.xjpqqx5:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-6);
+}
+
+.x2oz4g1:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: var(--spacing-8);
+}
+
+.xexx8yu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.xqty4a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--layout-padding-inner-y, var(--spacing-4));
+}
+
+.x81pis9:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--layout-padding-outer-y, var(--spacing-4));
+}
+
+.xbx876j:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-0-5);
+}
+
+.x1ydh6w3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-0);
+}
+
+.x1kwdpsa:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1-5);
+}
+
+.xfsso4q:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-1);
+}
+
+.xk6660b:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-10);
+}
+
+.x1xye8es:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-2);
+}
+
+.x1vlblms:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-3);
+}
+
+.x1oa1p4a:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-4);
+}
+
+.xx7rijo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-5);
+}
+
+.x1adxfkp:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-6);
+}
+
+.xoxd1wu:not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: var(--spacing-8);
+}
+
+.x3m8u43:not(#\#):not(#\#):not(#\#):not(#\#) {
+  right: 0;
+}
+
+.x13vifvy:not(#\#):not(#\#):not(#\#):not(#\#) {
+  top: 0;
+}
+
+.xh8yej3:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 100%;
+}
+
+.x1kky2od:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 16px;
+}
+
+.x1i1rx1s:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 1px;
+}
+
+.xw4jnvo:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: 20px;
+}
+
+.xjk4fl7:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--border-width);
+}
+
+.x5lhr3w:not(#\#):not(#\#):not(#\#):not(#\#) {
+  width: var(--x-width);
+}
+
+.x1o6z09h.x1o6z09h:where(.x-default-marker:has( > .xds-layout-footer:not([data-divider])) *):not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-bottom: 0;
+}
+
+.x1c51l3k.x1c51l3k:where(.x-default-marker:has( > .xds-layout-header:not([data-divider])) *):not(#\#):not(#\#):not(#\#):not(#\#) {
+  padding-top: 0;
+}
+
+.x8achem:first-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-top: calc(-1 * var(--container-padding, 0px));
+}
+
+.x1a5yysu:last-child:not(#\#):not(#\#):not(#\#):not(#\#) {
+  margin-bottom: calc(-1 * var(--container-padding, 0px));
+}
+</style>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/internal/vibe-tests/results/441ddbe0/results/dd-1.json
+++ b/internal/vibe-tests/results/441ddbe0/results/dd-1.json
@@ -1,0 +1,36 @@
+{
+  "id": "441ddbe0-dd-1",
+  "timestamp": "2026-04-04T18:36:32.331743+00:00",
+  "model": "navi-subagent",
+  "persona": "naive",
+  "promptCategory": "data-display",
+  "trajectoryDepth": 0,
+  "prompt": "A table of users with sortable columns and search",
+  "evaluation": {
+    "success": true,
+    "componentsUsed": [
+      "XDSTable",
+      "useXDSTableSortable",
+      "XDSTextInput",
+      "XDSAvatar",
+      "XDSBadge",
+      "XDSText",
+      "XDSHStack",
+      "XDSVStack"
+    ],
+    "componentsExpected": [
+      "XDSTextInput"
+    ],
+    "escapeHatches": [],
+    "failureMode": null,
+    "confusionSignals": []
+  },
+  "docsRead": [
+    "AGENTS.md",
+    "Table",
+    "TextInput",
+    "Badge",
+    "Avatar"
+  ],
+  "completedAt": "2026-04-04T18:36:32.331743+00:00"
+}

--- a/internal/vibe-tests/results/441ddbe0/results/dd-1.tsx
+++ b/internal/vibe-tests/results/441ddbe0/results/dd-1.tsx
@@ -1,0 +1,153 @@
+import {useState, useMemo} from 'react';
+import {XDSTable, useXDSTableSortable} from '@xds/core/Table';
+import type {XDSTableSortState} from '@xds/core/Table';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSText} from '@xds/core/Text';
+import {XDSHStack, XDSVStack} from '@xds/core/Stack';
+const MagnifyingGlassIcon = (props: React.SVGProps<SVGSVGElement>) => <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} {...props}><path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" /></svg>;
+import {pixel} from '@xds/core/Table';
+
+type User = {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: 'Active' | 'Inactive';
+  department: string;
+};
+
+const users: User[] = [
+  {id: '1', name: 'Alice Johnson', email: 'alice@example.com', role: 'Admin', status: 'Active', department: 'Engineering'},
+  {id: '2', name: 'Bob Smith', email: 'bob@example.com', role: 'Editor', status: 'Active', department: 'Marketing'},
+  {id: '3', name: 'Carol Williams', email: 'carol@example.com', role: 'Viewer', status: 'Inactive', department: 'Design'},
+  {id: '4', name: 'David Brown', email: 'david@example.com', role: 'Admin', status: 'Active', department: 'Engineering'},
+  {id: '5', name: 'Eve Davis', email: 'eve@example.com', role: 'Editor', status: 'Inactive', department: 'Marketing'},
+  {id: '6', name: 'Frank Miller', email: 'frank@example.com', role: 'Viewer', status: 'Active', department: 'Design'},
+  {id: '7', name: 'Grace Wilson', email: 'grace@example.com', role: 'Admin', status: 'Active', department: 'Engineering'},
+  {id: '8', name: 'Hank Moore', email: 'hank@example.com', role: 'Editor', status: 'Active', department: 'Marketing'},
+];
+
+type SortKey = 'name' | 'email' | 'role' | 'status' | 'department';
+
+function compareSortKey(a: User, b: User, key: SortKey): number {
+  const aVal = a[key];
+  const bVal = b[key];
+  return aVal.localeCompare(bVal);
+}
+
+export default function UserTable() {
+  const [search, setSearch] = useState('');
+  const [sort, setSort] = useState<XDSTableSortState<SortKey>>([
+    {sortKey: 'name', direction: 'ascending'},
+  ]);
+
+  const filteredUsers = useMemo(() => {
+    const q = search.toLowerCase();
+    let result = users.filter(
+      user =>
+        user.name.toLowerCase().includes(q) ||
+        user.email.toLowerCase().includes(q) ||
+        user.role.toLowerCase().includes(q) ||
+        user.department.toLowerCase().includes(q),
+    );
+
+    if (sort.length > 0) {
+      result = [...result].sort((a, b) => {
+        for (const {sortKey, direction} of sort) {
+          const cmp = compareSortKey(a, b, sortKey);
+          if (cmp !== 0) {
+            return direction === 'ascending' ? cmp : -cmp;
+          }
+        }
+        return 0;
+      });
+    }
+
+    return result;
+  }, [search, sort]);
+
+  const sortPlugin = useXDSTableSortable<SortKey>({
+    sort,
+    onSortChange: setSort,
+  });
+
+  const columns = useMemo(
+    () => [
+      {
+        key: 'name' as const,
+        header: 'Name',
+        sortKey: 'name' as SortKey,
+        renderCell: (user: User) => (
+          <XDSHStack gap={2} align="center">
+            <XDSAvatar name={user.name} size="small" />
+            <XDSVStack gap={1}>
+              <XDSText type="body" weight="semibold">
+                {user.name}
+              </XDSText>
+              <XDSText type="supporting" color="secondary">
+                {user.email}
+              </XDSText>
+            </XDSVStack>
+          </XDSHStack>
+        ),
+      },
+      {
+        key: 'role' as const,
+        header: 'Role',
+        sortKey: 'role' as SortKey,
+        width: pixel(140),
+        renderCell: (user: User) => (
+          <XDSText type="label" color="secondary">
+            {user.role}
+          </XDSText>
+        ),
+      },
+      {
+        key: 'department' as const,
+        header: 'Department',
+        sortKey: 'department' as SortKey,
+        width: pixel(160),
+        renderCell: (user: User) => (
+          <XDSText type="body">{user.department}</XDSText>
+        ),
+      },
+      {
+        key: 'status' as const,
+        header: 'Status',
+        sortKey: 'status' as SortKey,
+        width: pixel(120),
+        renderCell: (user: User) => (
+          <XDSBadge
+            variant={user.status === 'Active' ? 'success' : 'error'}
+            label={user.status}
+          />
+        ),
+      },
+    ],
+    [],
+  );
+
+  return (
+    <XDSVStack gap={4}>
+      <XDSTextInput
+        label="Search users"
+        isLabelHidden
+        value={search}
+        onChange={setSearch}
+        placeholder="Search by name, email, role, or department..."
+        startIcon={MagnifyingGlassIcon}
+      />
+      <XDSTable
+        data={filteredUsers}
+        columns={columns}
+        idKey="id"
+        density="balanced"
+        dividers="rows"
+        hasHover
+        plugins={{sort: sortPlugin}}
+      />
+    </XDSVStack>
+  );
+}

--- a/internal/vibe-tests/results/441ddbe0/results/dd-3.json
+++ b/internal/vibe-tests/results/441ddbe0/results/dd-3.json
@@ -1,0 +1,36 @@
+{
+  "id": "441ddbe0-dd-3",
+  "timestamp": "2026-04-04T18:36:26.433955+00:00",
+  "model": "navi-subagent",
+  "persona": "naive",
+  "promptCategory": "data-display",
+  "trajectoryDepth": 0,
+  "prompt": "Show a grid of product cards with image, title, price, and add to cart button",
+  "evaluation": {
+    "success": true,
+    "componentsUsed": [
+      "XDSCard",
+      "XDSButton",
+      "XDSGrid",
+      "XDSText",
+      "XDSHeading",
+      "XDSVStack"
+    ],
+    "componentsExpected": [
+      "XDSCard",
+      "XDSButton"
+    ],
+    "escapeHatches": [],
+    "failureMode": null,
+    "confusionSignals": []
+  },
+  "docsRead": [
+    "AGENTS.md",
+    "XDSCard",
+    "XDSButton",
+    "XDSGrid",
+    "XDSText",
+    "XDSLayout"
+  ],
+  "completedAt": "2026-04-04T18:36:26.433955+00:00"
+}

--- a/internal/vibe-tests/results/441ddbe0/results/dd-3.tsx
+++ b/internal/vibe-tests/results/441ddbe0/results/dd-3.tsx
@@ -1,0 +1,77 @@
+import {XDSCard} from '@xds/core/Card';
+import {XDSButton} from '@xds/core/Button';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSText, XDSHeading} from '@xds/core/Text';
+import {XDSVStack} from '@xds/core/Layout';
+
+const products = [
+  {
+    id: 1,
+    title: 'Wireless Headphones',
+    price: 79.99,
+    image: 'https://picsum.photos/seed/headphones/400/300',
+  },
+  {
+    id: 2,
+    title: 'Mechanical Keyboard',
+    price: 129.99,
+    image: 'https://picsum.photos/seed/keyboard/400/300',
+  },
+  {
+    id: 3,
+    title: 'Ergonomic Mouse',
+    price: 49.99,
+    image: 'https://picsum.photos/seed/mouse/400/300',
+  },
+  {
+    id: 4,
+    title: 'USB-C Monitor',
+    price: 349.99,
+    image: 'https://picsum.photos/seed/monitor/400/300',
+  },
+  {
+    id: 5,
+    title: 'Webcam HD',
+    price: 59.99,
+    image: 'https://picsum.photos/seed/webcam/400/300',
+  },
+  {
+    id: 6,
+    title: 'Desk Lamp',
+    price: 39.99,
+    image: 'https://picsum.photos/seed/lamp/400/300',
+  },
+];
+
+export default function ProductGrid() {
+  return (
+    <XDSGrid minChildWidth={260} gap={4}>
+      {products.map((product) => (
+        <XDSCard key={product.id} padding={0}>
+          <XDSVStack gap={3}>
+            <img
+              src={product.image}
+              alt={product.title}
+              style={{
+                width: '100%',
+                aspectRatio: '4 / 3',
+                objectFit: 'cover',
+                borderRadius: 'var(--radius-container) var(--radius-container) 0 0',
+                display: 'block',
+              }}
+            />
+            <XDSVStack gap={2} xstyle={{paddingInline: 'var(--spacing-4)', paddingBlockEnd: 'var(--spacing-4)'}}>
+              <XDSHeading level={4}>{product.title}</XDSHeading>
+              <XDSText type="large" weight="semibold">
+                ${product.price.toFixed(2)}
+              </XDSText>
+              <XDSButton label="Add to cart" variant="primary">
+                Add to Cart
+              </XDSButton>
+            </XDSVStack>
+          </XDSVStack>
+        </XDSCard>
+      ))}
+    </XDSGrid>
+  );
+}

--- a/internal/vibe-tests/results/441ddbe0/results/dd-5.json
+++ b/internal/vibe-tests/results/441ddbe0/results/dd-5.json
@@ -1,0 +1,44 @@
+{
+  "id": "441ddbe0-dd-5",
+  "timestamp": "2026-04-04T18:36:44.999769+00:00",
+  "model": "navi-subagent",
+  "persona": "naive",
+  "promptCategory": "data-display",
+  "trajectoryDepth": 0,
+  "prompt": "Build an email inbox view with a table showing sender, subject, date, and a preview snippet. Add row selection with checkboxes and a bulk actions bar that appears when items are selected.",
+  "evaluation": {
+    "success": true,
+    "componentsUsed": [
+      "XDSTable",
+      "useXDSTableSelection",
+      "useXDSTableSelectionState",
+      "XDSText",
+      "XDSVStack",
+      "XDSHStack",
+      "XDSStackItem",
+      "XDSButton",
+      "XDSDropdownMenu",
+      "XDSBadge"
+    ],
+    "componentsExpected": [
+      "XDSTable",
+      "XDSCheckboxInput",
+      "XDSDropdownMenu",
+      "XDSButton"
+    ],
+    "escapeHatches": [],
+    "failureMode": null,
+    "confusionSignals": []
+  },
+  "docsRead": [
+    "AGENTS.md",
+    "Table",
+    "CheckboxInput",
+    "DropdownMenu",
+    "Button",
+    "Text",
+    "Stack",
+    "Badge"
+  ],
+  "completedAt": "2026-04-04T18:36:44.999769+00:00"
+}

--- a/internal/vibe-tests/results/441ddbe0/results/dd-5.tsx
+++ b/internal/vibe-tests/results/441ddbe0/results/dd-5.tsx
@@ -1,0 +1,203 @@
+import {useState} from 'react';
+import {XDSTable, useXDSTableSelection, useXDSTableSelectionState} from '@xds/core/Table';
+import type {XDSTableColumn} from '@xds/core/Table';
+import {XDSText} from '@xds/core/Text';
+import {XDSVStack, XDSHStack, XDSStackItem} from '@xds/core/Stack';
+import {XDSButton} from '@xds/core/Button';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
+import {XDSBadge} from '@xds/core/Badge';
+
+type Email = {
+  id: string;
+  sender: string;
+  subject: string;
+  preview: string;
+  date: string;
+  isRead: boolean;
+};
+
+const emails: Email[] = [
+  {
+    id: '1',
+    sender: 'Alice Johnson',
+    subject: 'Q2 Planning Meeting Notes',
+    preview: 'Hey team, here are the notes from our planning session yesterday. Please review the action items...',
+    date: '2026-04-04',
+    isRead: false,
+  },
+  {
+    id: '2',
+    sender: 'Bob Smith',
+    subject: 'Re: Design System Update',
+    preview: 'Looks great! I left some comments on the PR. The new token structure is much cleaner...',
+    date: '2026-04-03',
+    isRead: true,
+  },
+  {
+    id: '3',
+    sender: 'Carol Williams',
+    subject: 'Urgent: Production Incident',
+      preview: "We're seeing elevated error rates on the checkout flow. The SEV has been filed and oncall is...",
+    date: '2026-04-03',
+    isRead: false,
+  },
+  {
+    id: '4',
+    sender: 'David Chen',
+    subject: 'Weekly Standup Recap',
+      preview: "Here's a summary of what everyone shared in standup this week. Key highlights include the...",
+    date: '2026-04-02',
+    isRead: true,
+  },
+  {
+    id: '5',
+    sender: 'Eva Martinez',
+    subject: 'New Component Proposal: DataGrid',
+      preview: "I've drafted a proposal for a new DataGrid component. It builds on XDSTable but adds inline...",
+    date: '2026-04-02',
+    isRead: true,
+  },
+  {
+    id: '6',
+    sender: 'Frank Lee',
+    subject: 'Offsite Logistics',
+    preview: 'Please fill out the travel form by Friday. Hotel blocks have been reserved at the Marriott...',
+    date: '2026-04-01',
+    isRead: false,
+  },
+  {
+    id: '7',
+    sender: 'Grace Kim',
+    subject: 'Re: API Review Feedback',
+    preview: 'Thanks for the thorough review! I addressed all the comments and pushed a new revision...',
+    date: '2026-04-01',
+    isRead: true,
+  },
+  {
+    id: '8',
+    sender: 'Henry Park',
+    subject: 'Accessibility Audit Results',
+      preview: "The audit found 3 critical issues and 12 minor ones. I've created tasks for each and assigned...",
+    date: '2026-03-31',
+    isRead: true,
+  },
+];
+
+export default function EmailInbox() {
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+
+  const {selectionConfig} = useXDSTableSelectionState<Email>({
+    data: emails,
+    idKey: 'id',
+    selectedKeys,
+    setSelectedKeys,
+  });
+  const selectionPlugin = useXDSTableSelection<Email>(selectionConfig);
+
+  const selectedCount = selectedKeys.size;
+
+  const handleArchive = () => {
+    setSelectedKeys(new Set());
+  };
+
+  const handleMarkRead = () => {
+    setSelectedKeys(new Set());
+  };
+
+  const handleDelete = () => {
+    setSelectedKeys(new Set());
+  };
+
+  const columns: XDSTableColumn<Email>[] = [
+    {
+      key: 'sender',
+      header: 'Sender',
+      renderCell: (email) => (
+        <XDSText type="body" weight={email.isRead ? 'normal' : 'semibold'}>
+          {email.sender}
+        </XDSText>
+      ),
+    },
+    {
+      key: 'subject',
+      header: 'Subject',
+      renderCell: (email) => (
+        <XDSHStack gap={2} vAlign="center">
+          <XDSText type="body" weight={email.isRead ? 'normal' : 'semibold'}>
+            {email.subject}
+          </XDSText>
+          {!email.isRead && <XDSBadge variant="info" label="New" />}
+        </XDSHStack>
+      ),
+    },
+    {
+      key: 'preview',
+      header: 'Preview',
+      renderCell: (email) => (
+        <XDSText type="supporting" color="secondary" maxLines={1}>
+          {email.preview}
+        </XDSText>
+      ),
+    },
+    {
+      key: 'date',
+      header: 'Date',
+      renderCell: (email) => (
+        <XDSText type="supporting" color="secondary">
+          {email.date}
+        </XDSText>
+      ),
+    },
+  ];
+
+  return (
+    <XDSVStack gap={4}>
+      <XDSHStack gap={3} vAlign="center">
+        <XDSStackItem size="fill">
+          <XDSText type="large" weight="bold">
+            Inbox
+          </XDSText>
+        </XDSStackItem>
+      </XDSHStack>
+
+      {selectedCount > 0 && (
+        <XDSHStack gap={2} vAlign="center">
+          <XDSText type="body" weight="semibold">
+            {selectedCount} selected
+          </XDSText>
+          <XDSButton
+            label="Archive"
+            variant="secondary"
+            size="sm"
+            onClick={handleArchive}
+          />
+          <XDSButton
+            label="Mark as read"
+            variant="secondary"
+            size="sm"
+            onClick={handleMarkRead}
+          />
+          <XDSDropdownMenu
+            button={{label: 'More actions', variant: 'ghost', size: 'sm'}}
+            items={[
+              {label: 'Mark as unread', onClick: handleMarkRead},
+              {label: 'Move to folder', onClick: () => {}},
+              {type: 'divider' as const},
+              {label: 'Delete', onClick: handleDelete},
+            ]}
+          />
+        </XDSHStack>
+      )}
+
+      <XDSTable<Email>
+        data={emails}
+        columns={columns}
+        idKey="id"
+        density="balanced"
+        dividers="rows"
+        hasHover
+        plugins={{selection: selectionPlugin}}
+      />
+    </XDSVStack>
+  );
+}

--- a/internal/vibe-tests/results/441ddbe0/results/ps-1.json
+++ b/internal/vibe-tests/results/441ddbe0/results/ps-1.json
@@ -1,0 +1,52 @@
+{
+  "id": "441ddbe0-ps-1",
+  "timestamp": "2026-04-04T18:36:56.894003+00:00",
+  "model": "navi-subagent",
+  "persona": "naive",
+  "promptCategory": "page-setup",
+  "trajectoryDepth": 0,
+  "prompt": "Create a new page for a settings dashboard. It should have a header with the app title, a sidebar for navigation, and a main content area. Use the XDS theme system.",
+  "evaluation": {
+    "success": true,
+    "componentsUsed": [
+      "XDSTheme",
+      "XDSAppShell",
+      "XDSTopNav",
+      "XDSTopNavHeading",
+      "XDSTopNavItem",
+      "XDSSideNav",
+      "XDSSideNavSection",
+      "XDSSideNavItem",
+      "XDSHeading",
+      "XDSText",
+      "XDSCard",
+      "XDSVStack",
+      "XDSSwitch",
+      "XDSTextInput",
+      "XDSDivider"
+    ],
+    "componentsExpected": [
+      "Theme",
+      "XDSLayout",
+      "XDSLayoutHeader",
+      "XDSLayoutContent",
+      "XDSLayoutPanel"
+    ],
+    "escapeHatches": [],
+    "failureMode": null,
+    "confusionSignals": []
+  },
+  "docsRead": [
+    "AGENTS.md",
+    "Theme",
+    "AppShell",
+    "SideNav",
+    "TopNav",
+    "Layout",
+    "Heading",
+    "Text",
+    "Switch",
+    "Card"
+  ],
+  "completedAt": "2026-04-04T18:36:56.894003+00:00"
+}

--- a/internal/vibe-tests/results/441ddbe0/results/ps-1.tsx
+++ b/internal/vibe-tests/results/441ddbe0/results/ps-1.tsx
@@ -1,0 +1,89 @@
+import {XDSTheme} from '@xds/core';
+import {defaultTheme} from '@xds/theme/default';
+import {
+  XDSAppShell,
+  XDSTopNav,
+  XDSTopNavHeading,
+  XDSTopNavItem,
+  XDSSideNav,
+  XDSSideNavSection,
+  XDSSideNavItem,
+} from '@xds/core';
+import {XDSHeading} from '@xds/core/Text';
+import {XDSText} from '@xds/core/Text';
+import {XDSCard} from '@xds/core/Card';
+import {XDSVStack} from '@xds/core/Layout';
+import {XDSSwitch} from '@xds/core/Switch';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSDivider} from '@xds/core/Divider';
+
+function SettingsContent() {
+  return (
+    <XDSVStack gap={6}>
+      <XDSHeading level={1}>General Settings</XDSHeading>
+
+      <XDSCard>
+        <XDSVStack gap={4}>
+          <XDSHeading level={3}>Profile</XDSHeading>
+          <XDSTextInput label="Display Name" />
+          <XDSTextInput label="Email Address" />
+          <XDSDivider />
+          <XDSHeading level={3}>Preferences</XDSHeading>
+          <XDSSwitch label="Enable email notifications" />
+          <XDSSwitch label="Dark mode" />
+          <XDSSwitch label="Show online status" />
+        </XDSVStack>
+      </XDSCard>
+
+      <XDSCard>
+        <XDSVStack gap={4}>
+          <XDSHeading level={3}>Privacy</XDSHeading>
+          <XDSSwitch label="Make profile public" />
+          <XDSSwitch label="Allow search engines to index profile" />
+          <XDSText type="supporting">
+            These settings control how others can find and view your profile.
+          </XDSText>
+        </XDSVStack>
+      </XDSCard>
+    </XDSVStack>
+  );
+}
+
+export default function SettingsDashboard() {
+  return (
+    <XDSTheme theme={defaultTheme}>
+      <XDSAppShell
+        contentPadding={4}
+        topNav={
+          <XDSTopNav
+            label="Main navigation"
+            heading={<XDSTopNavHeading heading="Settings Dashboard" />}
+            startContent={
+              <>
+                <XDSTopNavItem label="Home" href="/" />
+                <XDSTopNavItem label="Settings" href="/settings" isSelected />
+              </>
+            }
+          />
+        }
+        sideNav={
+          <XDSSideNav>
+            <XDSSideNavSection title="Settings" isHeaderHidden>
+              <XDSSideNavItem label="General" isSelected href="/settings/general" />
+              <XDSSideNavItem label="Account" href="/settings/account" />
+              <XDSSideNavItem label="Notifications" href="/settings/notifications" />
+              <XDSSideNavItem label="Privacy" href="/settings/privacy" />
+              <XDSSideNavItem label="Security" href="/settings/security" />
+            </XDSSideNavSection>
+            <XDSSideNavSection title="Advanced">
+              <XDSSideNavItem label="API Keys" href="/settings/api-keys" />
+              <XDSSideNavItem label="Integrations" href="/settings/integrations" />
+              <XDSSideNavItem label="Danger Zone" href="/settings/danger" />
+            </XDSSideNavSection>
+          </XDSSideNav>
+        }>
+        <SettingsContent />
+      </XDSAppShell>
+    </XDSTheme>
+  );
+}

--- a/internal/vibe-tests/results/441ddbe0/results/ps-3.json
+++ b/internal/vibe-tests/results/441ddbe0/results/ps-3.json
@@ -1,0 +1,45 @@
+{
+  "id": "441ddbe0-ps-3",
+  "timestamp": "2026-04-04T18:36:40.437847+00:00",
+  "model": "navi-subagent",
+  "persona": "naive",
+  "promptCategory": "page-setup",
+  "trajectoryDepth": 0,
+  "prompt": "Create an admin panel page layout with a fixed header, collapsible left sidebar, main content area, and a right panel for details. Wrap everything in the XDS theme.",
+  "evaluation": {
+    "success": true,
+    "componentsUsed": [
+      "XDSTheme",
+      "XDSAppShell",
+      "XDSLayout",
+      "XDSLayoutContent",
+      "XDSLayoutPanel",
+      "XDSTopNav",
+      "XDSTopNavHeading",
+      "XDSTopNavItem",
+      "XDSSideNav",
+      "XDSSideNavItem",
+      "XDSSideNavSection",
+      "XDSSideNavCollapseButton"
+    ],
+    "componentsExpected": [
+      "Theme",
+      "XDSLayout",
+      "XDSLayoutHeader",
+      "XDSLayoutContent",
+      "XDSLayoutPanel"
+    ],
+    "escapeHatches": [],
+    "failureMode": null,
+    "confusionSignals": []
+  },
+  "docsRead": [
+    "AGENTS.md",
+    "Theme",
+    "Layout",
+    "AppShell",
+    "SideNav",
+    "TopNav"
+  ],
+  "completedAt": "2026-04-04T18:36:40.437847+00:00"
+}

--- a/internal/vibe-tests/results/441ddbe0/results/ps-3.tsx
+++ b/internal/vibe-tests/results/441ddbe0/results/ps-3.tsx
@@ -1,0 +1,100 @@
+import React, {useState} from 'react';
+import {XDSTheme} from '@xds/core/theme';
+import {defaultTheme} from '@xds/theme/default';
+import {XDSAppShell} from '@xds/core/AppShell';
+import {
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutContent,
+  XDSLayoutPanel,
+} from '@xds/core/Layout';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+import {
+  XDSSideNav,
+  XDSSideNavHeading,
+  XDSSideNavItem,
+  XDSSideNavSection,
+  XDSSideNavCollapseButton,
+} from '@xds/core/SideNav';
+
+export default function AdminPanel() {
+  const [selectedItem, setSelectedItem] = useState<string | null>('users');
+
+  return (
+    <XDSTheme theme={defaultTheme}>
+      <XDSAppShell
+        topNav={
+          <XDSTopNav
+            label="Admin navigation"
+            heading={<XDSTopNavHeading heading="Admin Panel" href="/" />}
+            startContent={
+              <>
+                <XDSTopNavItem label="Dashboard" href="/dashboard" isSelected />
+                <XDSTopNavItem label="Analytics" href="/analytics" />
+                <XDSTopNavItem label="Reports" href="/reports" />
+              </>
+            }
+          />
+        }
+        sideNav={
+          <XDSSideNav
+            collapsible
+            footerIcons={<XDSSideNavCollapseButton />}
+          >
+            <XDSSideNavSection title="Management" isHeaderHidden>
+              <XDSSideNavItem
+                label="Users"
+                isSelected={selectedItem === 'users'}
+                onClick={() => setSelectedItem('users')}
+              />
+              <XDSSideNavItem
+                label="Roles"
+                isSelected={selectedItem === 'roles'}
+                onClick={() => setSelectedItem('roles')}
+              />
+              <XDSSideNavItem
+                label="Permissions"
+                isSelected={selectedItem === 'permissions'}
+                onClick={() => setSelectedItem('permissions')}
+              />
+            </XDSSideNavSection>
+            <XDSSideNavSection title="System">
+              <XDSSideNavItem
+                label="Settings"
+                isSelected={selectedItem === 'settings'}
+                onClick={() => setSelectedItem('settings')}
+              />
+              <XDSSideNavItem
+                label="Logs"
+                isSelected={selectedItem === 'logs'}
+                onClick={() => setSelectedItem('logs')}
+              />
+            </XDSSideNavSection>
+          </XDSSideNav>
+        }
+      >
+        {/* Inner layout adds the right-side details panel */}
+        <XDSLayout
+          content={
+            <XDSLayoutContent role="main" label="Main content">
+              <h2>Content Area</h2>
+              <p>
+                Main content for the <strong>{selectedItem}</strong> section goes
+                here. This area scrolls independently.
+              </p>
+            </XDSLayoutContent>
+          }
+          end={
+            <XDSLayoutPanel hasDivider label="Details panel">
+              <h3>Details</h3>
+              <p>
+                Contextual information and actions for the selected item appear
+                in this right panel.
+              </p>
+            </XDSLayoutPanel>
+          }
+        />
+      </XDSAppShell>
+    </XDSTheme>
+  );
+}

--- a/internal/vibe-tests/results/441ddbe0/results/ps-4.json
+++ b/internal/vibe-tests/results/441ddbe0/results/ps-4.json
@@ -1,0 +1,45 @@
+{
+  "id": "441ddbe0-ps-4",
+  "timestamp": "2026-04-04T18:37:46.617971+00:00",
+  "model": "navi-subagent",
+  "persona": "naive",
+  "promptCategory": "page-setup",
+  "trajectoryDepth": 0,
+  "prompt": "Create a product detail page with breadcrumb navigation showing Home > Category > Subcategory > Product Name. The page should have a header, product info section, and a back button.",
+  "evaluation": {
+    "success": true,
+    "componentsUsed": [
+      "XDSBreadcrumbs",
+      "XDSBreadcrumbItem",
+      "XDSButton",
+      "XDSCard",
+      "XDSLayout",
+      "XDSLayoutHeader",
+      "XDSLayoutContent",
+      "XDSVStack",
+      "XDSHStack",
+      "XDSHeading",
+      "XDSText",
+      "XDSDivider",
+      "XDSBadge"
+    ],
+    "componentsExpected": [
+      "XDSBreadcrumbs",
+      "XDSCard",
+      "XDSButton"
+    ],
+    "escapeHatches": [],
+    "failureMode": null,
+    "confusionSignals": []
+  },
+  "docsRead": [
+    "AGENTS.md",
+    "Breadcrumbs",
+    "Button",
+    "Card",
+    "Layout",
+    "Text",
+    "product-detail template"
+  ],
+  "completedAt": "2026-04-04T18:37:46.617971+00:00"
+}

--- a/internal/vibe-tests/results/441ddbe0/results/ps-4.tsx
+++ b/internal/vibe-tests/results/441ddbe0/results/ps-4.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import {XDSBreadcrumbs, XDSBreadcrumbItem} from '@xds/core/Breadcrumbs';
+import {XDSButton} from '@xds/core/Button';
+import {XDSCard} from '@xds/core/Card';
+import {
+  XDSLayout,
+  XDSLayoutHeader,
+  XDSLayoutContent,
+  XDSVStack,
+  XDSHStack,
+} from '@xds/core/Layout';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSBadge} from '@xds/core/Badge';
+
+// ─── Icons ──────────────────────────────────────────────────────────────────
+const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <line x1="19" y1="12" x2="5" y2="12" />
+    <polyline points="12 19 5 12 12 5" />
+  </svg>
+);
+
+// ─── Product Data ───────────────────────────────────────────────────────────
+const PRODUCT = {
+  name: 'Meridian Desk Lamp',
+  category: 'Lighting',
+  subcategory: 'Desk Lamps',
+  price: 189.0,
+  sku: 'MDL-2024-BRS',
+  description:
+    'A refined desk lamp with an adjustable brass arm and a linen shade. The weighted walnut base keeps it stable on any surface. Perfect for focused task lighting or a warm ambient glow in your workspace.',
+  features: [
+    'Adjustable brass arm with 180° rotation',
+    'Natural walnut base with anti-scratch felt pad',
+    'Linen drum shade with white interior lining',
+    'Built-in touch dimmer (3 brightness levels)',
+    'Compatible with E26 LED bulbs up to 60W equivalent',
+  ],
+  dimensions: 'Height: 48 cm | Base: 15 cm diameter | Shade: 20 cm diameter',
+  availability: 'In Stock',
+};
+
+const fmt = (n: number) => `$${n.toFixed(2)}`;
+
+// ─── Main Page ──────────────────────────────────────────────────────────────
+export default function ProductDetailPage() {
+  return (
+    <XDSLayout
+      header={
+        <XDSLayoutHeader hasDivider>
+          <XDSHStack gap={2} vAlign="center">
+            <XDSButton
+              label="Back"
+              variant="ghost"
+              icon={<ArrowLeftIcon style={{width: 16, height: 16}} />}
+              onClick={() => window.history.back()}>
+              Back
+            </XDSButton>
+            <XDSText type="label" color="secondary">
+              Product Detail
+            </XDSText>
+          </XDSHStack>
+        </XDSLayoutHeader>
+      }
+      content={
+        <XDSLayoutContent>
+          <XDSVStack gap={6}>
+            {/* Breadcrumb Navigation */}
+            <XDSBreadcrumbs>
+              <XDSBreadcrumbItem href="/">Home</XDSBreadcrumbItem>
+              <XDSBreadcrumbItem href="/category">
+                {PRODUCT.category}
+              </XDSBreadcrumbItem>
+              <XDSBreadcrumbItem href="/category/subcategory">
+                {PRODUCT.subcategory}
+              </XDSBreadcrumbItem>
+              <XDSBreadcrumbItem isCurrent>
+                {PRODUCT.name}
+              </XDSBreadcrumbItem>
+            </XDSBreadcrumbs>
+
+            {/* Product Info Section */}
+            <XDSCard>
+              <XDSVStack gap={4}>
+                <XDSHStack gap={2} vAlign="center">
+                  <XDSHeading level={1}>{PRODUCT.name}</XDSHeading>
+                  <XDSBadge variant="success" label={PRODUCT.availability} />
+                </XDSHStack>
+
+                <XDSText type="large" weight="bold">
+                  {fmt(PRODUCT.price)}
+                </XDSText>
+
+                <XDSText type="supporting" color="secondary">
+                  SKU: {PRODUCT.sku}
+                </XDSText>
+
+                <XDSDivider />
+
+                <XDSVStack gap={2}>
+                  <XDSHeading level={3}>Description</XDSHeading>
+                  <XDSText type="body">{PRODUCT.description}</XDSText>
+                </XDSVStack>
+
+                <XDSDivider />
+
+                <XDSVStack gap={2}>
+                  <XDSHeading level={3}>Features</XDSHeading>
+                  <XDSVStack gap={1}>
+                    {PRODUCT.features.map((feature, i) => (
+                      <XDSText key={i} type="body">
+                        • {feature}
+                      </XDSText>
+                    ))}
+                  </XDSVStack>
+                </XDSVStack>
+
+                <XDSDivider />
+
+                <XDSVStack gap={2}>
+                  <XDSHeading level={3}>Dimensions</XDSHeading>
+                  <XDSText type="body">{PRODUCT.dimensions}</XDSText>
+                </XDSVStack>
+
+                <XDSDivider />
+
+                <XDSHStack gap={2}>
+                  <XDSButton label="Add to Cart" variant="primary" size="lg">
+                    Add to Cart
+                  </XDSButton>
+                  <XDSButton
+                    label="Back to browsing"
+                    variant="secondary"
+                    size="lg"
+                    onClick={() => window.history.back()}>
+                    Back
+                  </XDSButton>
+                </XDSHStack>
+              </XDSVStack>
+            </XDSCard>
+          </XDSVStack>
+        </XDSLayoutContent>
+      }
+    />
+  );
+}

--- a/internal/vibe-tests/results/441ddbe0/tasks/dd-1.json
+++ b/internal/vibe-tests/results/441ddbe0/tasks/dd-1.json
@@ -1,0 +1,17 @@
+{
+  "promptId": "dd-1",
+  "category": "data-display",
+  "prompt": "A table of users with sortable columns and search",
+  "expectedComponents": [
+    "XDSTextInput"
+  ],
+  "followUps": [
+    "Add pagination with page size selector (10, 25, 50)",
+    "Add row selection with a bulk actions dropdown"
+  ],
+  "persona": "naive",
+  "degradation": false,
+  "target": "xds",
+  "subagentPrompt": "First read AGENTS.md in this directory for component library guidance.\n\nA table of users with sortable columns and search\n\nWrite the code to: /vercel/sandbox/repos/xds-worktrees/f5a57175/internal/vibe-tests/results/441ddbe0/results/dd-1.tsx",
+  "createdAt": "2026-04-04T18:34:13.711Z"
+}

--- a/internal/vibe-tests/results/441ddbe0/tasks/dd-3.json
+++ b/internal/vibe-tests/results/441ddbe0/tasks/dd-3.json
@@ -1,0 +1,18 @@
+{
+  "promptId": "dd-3",
+  "category": "data-display",
+  "prompt": "Show a grid of product cards with image, title, price, and add to cart button",
+  "expectedComponents": [
+    "XDSCard",
+    "XDSButton"
+  ],
+  "followUps": [
+    "Add a quantity selector to each card",
+    "Add a 'Quick view' button that opens a modal with more details"
+  ],
+  "persona": "naive",
+  "degradation": false,
+  "target": "xds",
+  "subagentPrompt": "First read AGENTS.md in this directory for component library guidance.\n\nShow a grid of product cards with image, title, price, and add to cart button\n\nWrite the code to: /vercel/sandbox/repos/xds-worktrees/f5a57175/internal/vibe-tests/results/441ddbe0/results/dd-3.tsx",
+  "createdAt": "2026-04-04T18:34:13.711Z"
+}

--- a/internal/vibe-tests/results/441ddbe0/tasks/dd-5.json
+++ b/internal/vibe-tests/results/441ddbe0/tasks/dd-5.json
@@ -1,0 +1,20 @@
+{
+  "promptId": "dd-5",
+  "category": "data-display",
+  "prompt": "Build an email inbox view with a table showing sender, subject, date, and a preview snippet. Add row selection with checkboxes and a bulk actions bar that appears when items are selected.",
+  "expectedComponents": [
+    "XDSTable",
+    "XDSCheckboxInput",
+    "XDSDropdownMenu",
+    "XDSButton"
+  ],
+  "followUps": [
+    "Add a \"Select all\" checkbox in the header that selects all visible rows",
+    "Add swipe-to-archive on mobile"
+  ],
+  "persona": "naive",
+  "degradation": false,
+  "target": "xds",
+  "subagentPrompt": "First read AGENTS.md in this directory for component library guidance.\n\nBuild an email inbox view with a table showing sender, subject, date, and a preview snippet. Add row selection with checkboxes and a bulk actions bar that appears when items are selected.\n\nWrite the code to: /vercel/sandbox/repos/xds-worktrees/f5a57175/internal/vibe-tests/results/441ddbe0/results/dd-5.tsx",
+  "createdAt": "2026-04-04T18:34:13.712Z"
+}

--- a/internal/vibe-tests/results/441ddbe0/tasks/ps-1.json
+++ b/internal/vibe-tests/results/441ddbe0/tasks/ps-1.json
@@ -1,0 +1,21 @@
+{
+  "promptId": "ps-1",
+  "category": "page-setup",
+  "prompt": "Create a new page for a settings dashboard. It should have a header with the app title, a sidebar for navigation, and a main content area. Use the XDS theme system.",
+  "expectedComponents": [
+    "Theme",
+    "XDSLayout",
+    "XDSLayoutHeader",
+    "XDSLayoutContent",
+    "XDSLayoutPanel"
+  ],
+  "followUps": [
+    "Add a user avatar with dropdown menu in the header",
+    "Make the sidebar collapsible with a toggle button"
+  ],
+  "persona": "naive",
+  "degradation": false,
+  "target": "xds",
+  "subagentPrompt": "First read AGENTS.md in this directory for component library guidance.\n\nCreate a new page for a settings dashboard. It should have a header with the app title, a sidebar for navigation, and a main content area. Use the XDS theme system.\n\nWrite the code to: /vercel/sandbox/repos/xds-worktrees/f5a57175/internal/vibe-tests/results/441ddbe0/results/ps-1.tsx",
+  "createdAt": "2026-04-04T18:34:13.711Z"
+}

--- a/internal/vibe-tests/results/441ddbe0/tasks/ps-3.json
+++ b/internal/vibe-tests/results/441ddbe0/tasks/ps-3.json
@@ -1,0 +1,21 @@
+{
+  "promptId": "ps-3",
+  "category": "page-setup",
+  "prompt": "Create an admin panel page layout with a fixed header, collapsible left sidebar, main content area, and a right panel for details. Wrap everything in the XDS theme.",
+  "expectedComponents": [
+    "Theme",
+    "XDSLayout",
+    "XDSLayoutHeader",
+    "XDSLayoutContent",
+    "XDSLayoutPanel"
+  ],
+  "followUps": [
+    "Add breadcrumbs below the header",
+    "Add a footer with version info and links"
+  ],
+  "persona": "naive",
+  "degradation": false,
+  "target": "xds",
+  "subagentPrompt": "First read AGENTS.md in this directory for component library guidance.\n\nCreate an admin panel page layout with a fixed header, collapsible left sidebar, main content area, and a right panel for details. Wrap everything in the XDS theme.\n\nWrite the code to: /vercel/sandbox/repos/xds-worktrees/f5a57175/internal/vibe-tests/results/441ddbe0/results/ps-3.tsx",
+  "createdAt": "2026-04-04T18:34:13.711Z"
+}

--- a/internal/vibe-tests/results/441ddbe0/tasks/ps-4.json
+++ b/internal/vibe-tests/results/441ddbe0/tasks/ps-4.json
@@ -1,0 +1,19 @@
+{
+  "promptId": "ps-4",
+  "category": "page-setup",
+  "prompt": "Create a product detail page with breadcrumb navigation showing Home > Category > Subcategory > Product Name. The page should have a header, product info section, and a back button.",
+  "expectedComponents": [
+    "XDSBreadcrumbs",
+    "XDSCard",
+    "XDSButton"
+  ],
+  "followUps": [
+    "Make the breadcrumb items clickable links that navigate to each level",
+    "Add a \"Related Products\" section below the product details"
+  ],
+  "persona": "naive",
+  "degradation": false,
+  "target": "xds",
+  "subagentPrompt": "First read AGENTS.md in this directory for component library guidance.\n\nCreate a product detail page with breadcrumb navigation showing Home > Category > Subcategory > Product Name. The page should have a header, product info section, and a back button.\n\nWrite the code to: /vercel/sandbox/repos/xds-worktrees/f5a57175/internal/vibe-tests/results/441ddbe0/results/ps-4.tsx",
+  "createdAt": "2026-04-04T18:34:13.712Z"
+}

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -129,15 +129,42 @@ export function generateCompressedIndex(version, {coreDir, zh = false, lang, run
     }
   }
 
-  // Templates from live discovery
+  // Templates from live discovery — include component compositions
   const templatesDir = path.join(CLI_ROOT, 'templates');
   if (fs.existsSync(templatesDir)) {
-    const templates = fs.readdirSync(templatesDir, {withFileTypes: true})
+    const templateDirs = fs.readdirSync(templatesDir, {withFileTypes: true})
       .filter(e => e.isDirectory())
-      .map(e => e.name)
-      .sort();
-    if (templates.length > 0) {
-      lines.push(`${run} template <name> [path]  scaffold page (${templates.join(', ')})`);
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    if (templateDirs.length > 0) {
+      lines.push(`${run} template <name> [path]  scaffold page from template`);
+      lines.push('TEMPLATES (use as layout reference — check before building a page):');
+      for (const dir of templateDirs) {
+        const pagePath = path.join(templatesDir, dir.name, 'page.tsx');
+        if (!fs.existsSync(pagePath)) continue;
+        // Extract key structural XDS components from imports
+        // Filter out ubiquitous components (Text, Button, etc.) to show the
+        // distinguishing composition — what makes this template's layout unique.
+        const src = fs.readFileSync(pagePath, 'utf-8');
+        const UBIQUITOUS = new Set([
+          'Text', 'Heading', 'Button', 'HStack', 'VStack', 'Link',
+          'StackItem', 'Icon',
+        ]);
+        const comps = [...new Set(
+          (src.match(/XDS[A-Z]\w+/g) || [])
+            .map(n => n.replace(/^XDS/, ''))
+            .filter(n => !['Theme', 'ThemeProvider'].includes(n))
+            .filter(n => !UBIQUITOUS.has(n))
+            // Strip sub-types (SideNavItem → SideNav, TabListItem → TabList)
+            .map(n => n.replace(/(Item|Section|Header|Content|Footer|Panel|Heading|CollapseButton|Column|Sortable|Selection|Group|Source)$/, ''))
+            .filter(Boolean)
+        )].sort();
+        if (comps.length > 0) {
+          const name = dir.name.padEnd(22);
+          lines.push(`  ${name}${comps.join(' + ')}`);
+        }
+      }
+      lines.push(`RULE: before building a page layout, check if a template matches your intent`);
     }
   }
 

--- a/packages/cli/templates/dashboard/template.doc.mjs
+++ b/packages/cli/templates/dashboard/template.doc.mjs
@@ -3,4 +3,6 @@ export const doc = {
   name: 'Dashboard',
   description: 'Analytics dashboard with KPI cards, charts, and data tables',
   isReady: false,
+  keywords: ['dashboard', 'analytics', 'metrics', 'kpi', 'admin', 'stats'],
+  components: ['AppShell', 'SideNav', 'TopNav', 'Card', 'Table', 'TabList', 'SegmentedControl', 'Badge', 'Avatar'],
 };

--- a/packages/cli/templates/detail-page/template.doc.mjs
+++ b/packages/cli/templates/detail-page/template.doc.mjs
@@ -3,4 +3,6 @@ export const doc = {
   name: 'Detail Page',
   description: 'Order detail page with timeline and line items',
   isReady: true,
+  keywords: ['detail', 'order', 'invoice', 'record', 'profile', 'overview'],
+  components: ['AppShell', 'Layout', 'LayoutPanel', 'MetadataList', 'Collapsible', 'ProgressBar', 'TabList', 'Badge', 'Section'],
 };

--- a/packages/cli/templates/settings-sidebar/template.doc.mjs
+++ b/packages/cli/templates/settings-sidebar/template.doc.mjs
@@ -3,4 +3,6 @@ export const doc = {
   name: 'Settings (Sidebar)',
   description: 'Account settings with sidebar nav and inline editing',
   isReady: true,
+  keywords: ['settings', 'preferences', 'account', 'profile', 'config', 'admin'],
+  components: ['List', 'ListItem', 'TabList', 'Switch', 'Card', 'Section', 'Selector', 'Divider', 'Heading', 'Text'],
 };

--- a/packages/cli/templates/table/template.doc.mjs
+++ b/packages/cli/templates/table/template.doc.mjs
@@ -3,4 +3,6 @@ export const doc = {
   name: 'Table',
   description: 'Data table with actions',
   isReady: true,
+  keywords: ['table', 'data', 'list', 'users', 'inbox', 'sortable', 'search'],
+  components: ['Layout', 'LayoutHeader', 'LayoutContent', 'Table', 'Badge', 'Button', 'Text'],
 };

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -413,4 +413,16 @@ export interface TemplateDoc {
   /** Whether this template is ready for use. Templates with
    *  isReady: false show as "(WIP)" in the gallery and CLI. */
   isReady: boolean;
+
+  /** Search keywords for CLI discovery. Terms a developer or LLM might use
+   *  when looking for this layout pattern: intents, synonyms, related concepts.
+   *  Lowercase only. Used by `xds component <term>` cross-referencing.
+   *  e.g. `['dashboard', 'analytics', 'metrics', 'admin']` */
+  keywords?: string[];
+
+  /** XDS components used in this template (without XDS prefix).
+   *  Serves as a composition reference — LLMs use this to learn which
+   *  components go together for a given page intent.
+   *  e.g. `['AppShell', 'SideNav', 'TopNav', 'Card', 'Table']` */
+  components?: string[];
 }


### PR DESCRIPTION
## What

The `agent-docs` compressed index now extracts XDS component compositions from each template's `page.tsx` and includes them in the generated CLAUDE.md/AGENTS.md block.

Before:
```
npx xds template <name> [path]  scaffold page (blank, login, table)
```

After:
```
npx xds template <name> [path]  scaffold page from template
TEMPLATES (use as layout reference — check before building a page):
  dashboard             AppShell + Avatar + Badge + Card + NavIcon + SegmentedControl + SideNav + Tab + TabList + Table + TopNav
  detail-page           AppShell + Avatar + Badge + Card + Center + Collapsible + Divider + Layout + List + MetadataList + NavIcon + ProgressBar + SideNav + Tab + TabList
  settings-sidebar      Badge + Card + Divider + List + Selector + Switch + Tab + TabList + TextInput
  table                 Badge + Layout + Table
  ...
RULE: before building a page layout, check if a template matches your intent
```

## Why

Vibe tested 3 configs × 6 layout prompts (see `internal/vibe-tests/experiments/template-ref/FINDINGS.md`):

| Signal | A (control) | B (template list) | C (skeletons) |
|--------|:-----------:|:-------------:|:--------------:|
| Used XDSLayout | 25% | **100%** | **100%** |
| Used hasDivider | 25% | **100%** | **100%** |
| Ad-hoc maxWidth in stylex | 100% | **0%** | **0%** |

The template composition list is ~1.5KB of additional context in CLAUDE.md. It drives:
- **Layout adoption 25% → 100%** — LLMs use proper page shells instead of raw VStack
- **hasDivider pattern 100%** — composition patterns teach idioms, not just component names
- **Zero ad-hoc maxWidth** — Layout/AppShell handle page constraints
- **Richer component choices** — B/C configs used XDSGrid, MetadataList, Collapsible, Breadcrumbs where control configs didn't

## Changes

- **`agent-docs.mjs`**: `generateCompressedIndex()` now reads template `page.tsx` files, extracts XDS component names from imports, filters ubiquitous components (Text, Button, HStack, etc.), and includes the composition per template
- **`docs-types.ts`**: Extended `TemplateDoc` with optional `keywords` and `components` fields
- **4 template.doc.mjs files**: Added keywords + components to dashboard, table, settings-sidebar, detail-page
- **`internal/vibe-tests/experiments/template-ref/`**: Full experiment data — configs, prompts, and findings

## Related

- #740 — Improve XDS design fidelity via retrieval-led component notes + pattern CLI (this implements the template-as-pattern-reference approach Ernest suggested)
- #733 — Night Watch: Design dimension vision judge

---
