### PR TITLE
feat(CommandPalette): renderItem, default slots, empty states

### DIFF
--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -1,9 +1,9 @@
 /**
- * CommandPalette with searchSource API — story sketches
+ * CommandPalette stories
  *
  * Progressive disclosure:
- * 1. No children -> default rendering (label text, auto-groups by auxiliaryData.group)
- * 2. children render function -> full control over item layout and grouping
+ * 1. No props beyond searchSource — default input, footer, rendering
+ * 2. renderItem — custom item content, grouping still automatic
  */
 import {useState, useMemo} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
@@ -28,53 +28,69 @@ const meta: Meta<typeof XDSCommandPalette> = {
 export default meta;
 type Story = StoryObj<typeof XDSCommandPalette>;
 
-// --- Simplest case ---
+// ─── Default ─────────────────────────────────────────────────────────────────
 
-/** No children -- default rendering. Each item renders its label. */
+/** Simplest case — no input/footer/renderItem needed. */
 export const Default: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
-    const source = useMemo(() => createStaticSource([
-      {id: 'home', label: 'Home'},
-      {id: 'settings', label: 'Settings'},
-      {id: 'profile', label: 'Profile'},
-      {id: 'dashboard', label: 'Dashboard'},
-      {id: 'help', label: 'Help'},
-    ]), []);
-
+    const source = useMemo(
+      () =>
+        createStaticSource([
+          {id: 'home', label: 'Home'},
+          {id: 'settings', label: 'Settings'},
+          {id: 'profile', label: 'Profile'},
+          {id: 'dashboard', label: 'Dashboard'},
+          {id: 'help', label: 'Help'},
+        ]),
+      [],
+    );
     return (
       <>
-        <XDSButton label="Open Command Palette" onClick={() => setIsOpen(true)} />
+        <XDSButton
+          label="Open Command Palette"
+          onClick={() => setIsOpen(true)}
+        />
         <XDSCommandPalette
           isOpen={isOpen}
           onOpenChange={setIsOpen}
           searchSource={source}
-          input={<XDSCommandPaletteInput placeholder="Type a command..." />}
-          footer={<XDSCommandPaletteFooter />}
         />
       </>
     );
   },
 };
 
-// --- Auto-grouping ---
+// ─── Auto-grouping ────────────────────────────────────────────────────────────
 
-/**
- * Groups detected automatically from auxiliaryData.group.
- * Still no children -- the default renderer handles grouping.
- */
+/** Groups detected automatically from auxiliaryData.group. No custom rendering needed. */
 export const AutoGrouped: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
-    const source = useMemo(() => createStaticSource([
-      {id: 'home', label: 'Home', auxiliaryData: {group: 'Navigation'}},
-      {id: 'settings', label: 'Settings', auxiliaryData: {group: 'Navigation'}},
-      {id: 'profile', label: 'Profile', auxiliaryData: {group: 'Navigation'}},
-      {id: 'new-file', label: 'New File', auxiliaryData: {group: 'Actions'}},
-      {id: 'save', label: 'Save', auxiliaryData: {group: 'Actions'}},
-      {id: 'export', label: 'Export', auxiliaryData: {group: 'Actions'}},
-    ]), []);
-
+    const source = useMemo(
+      () =>
+        createStaticSource([
+          {id: 'home', label: 'Home', auxiliaryData: {group: 'Navigation'}},
+          {
+            id: 'settings',
+            label: 'Settings',
+            auxiliaryData: {group: 'Navigation'},
+          },
+          {
+            id: 'profile',
+            label: 'Profile',
+            auxiliaryData: {group: 'Navigation'},
+          },
+          {
+            id: 'new-file',
+            label: 'New File',
+            auxiliaryData: {group: 'Actions'},
+          },
+          {id: 'save', label: 'Save', auxiliaryData: {group: 'Actions'}},
+          {id: 'export', label: 'Export', auxiliaryData: {group: 'Actions'}},
+        ]),
+      [],
+    );
     return (
       <>
         <XDSButton label="Open Grouped" onClick={() => setIsOpen(true)} />
@@ -82,79 +98,67 @@ export const AutoGrouped: Story = {
           isOpen={isOpen}
           onOpenChange={setIsOpen}
           searchSource={source}
-          input={<XDSCommandPaletteInput placeholder="Search commands..." />}
-          footer={<XDSCommandPaletteFooter />}
         />
       </>
     );
   },
 };
 
-// --- Keywords ---
+// ─── Custom rendering via renderItem ─────────────────────────────────────────
 
-/** Type "theme" or "appearance" to find "Toggle Dark Mode". */
-export const WithKeywords: Story = {
-  render: function Render() {
-    const [isOpen, setIsOpen] = useState(false);
-
-    const commands: XDSSearchableItem<{aliases?: string[]}>[] = [
-      {id: 'home', label: 'Home'},
-      {id: 'dark-mode', label: 'Toggle Dark Mode', auxiliaryData: {aliases: ['theme', 'appearance']}},
-      {id: 'font-size', label: 'Change Font Size', auxiliaryData: {aliases: ['text', 'zoom']}},
-    ];
-
-    const source = useMemo(
-      () => createStaticSource(commands, {
-        keywords: (item) => item.auxiliaryData?.aliases ?? [],
-      }),
-      [],
-    );
-
-    return (
-      <>
-        <XDSButton label="Open (try 'theme')" onClick={() => setIsOpen(true)} />
-        <XDSCommandPalette
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          searchSource={source}
-          input={<XDSCommandPaletteInput placeholder="Search..." />}
-          footer={<XDSCommandPaletteFooter />}
-        />
-      </>
-    );
-  },
-};
-
-// --- Custom rendering with groups ---
-
-type CommandItem = XDSSearchableItem<{
+type RichCommand = XDSSearchableItem<{
   icon?: string;
   group?: string;
   shortcut?: string;
   keywords?: string[];
 }>;
 
-/** Full control via render function. Groups, icons, shortcuts -- all explicit. */
-export const CustomRendering: Story = {
+/**
+ * Custom item content via renderItem — icons and shortcuts.
+ * Grouping remains automatic via auxiliaryData.group.
+ */
+export const WithRenderItem: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
-
-    const commands: CommandItem[] = [
-      {id: 'dashboard', label: 'Go to Dashboard', auxiliaryData: {icon: 'home', group: 'Navigation'}},
-      {id: 'settings', label: 'Open Settings', auxiliaryData: {icon: 'settings', group: 'Navigation', shortcut: '\u2318,'}},
-      {id: 'profile', label: 'View Profile', auxiliaryData: {icon: 'user', group: 'Navigation'}},
-      {id: 'dark-mode', label: 'Toggle Dark Mode', auxiliaryData: {group: 'Actions', keywords: ['theme', 'appearance']}},
-      {id: 'new-file', label: 'Create New File', auxiliaryData: {group: 'Actions', shortcut: '\u2318N'}},
-      {id: 'search', label: 'Search Files', auxiliaryData: {icon: 'search', group: 'Actions', shortcut: '\u2318P'}},
+    const commands: RichCommand[] = [
+      {
+        id: 'dashboard',
+        label: 'Go to Dashboard',
+        auxiliaryData: {icon: 'home', group: 'Navigation'},
+      },
+      {
+        id: 'settings',
+        label: 'Open Settings',
+        auxiliaryData: {icon: 'settings', group: 'Navigation', shortcut: '⌘,'},
+      },
+      {
+        id: 'profile',
+        label: 'View Profile',
+        auxiliaryData: {icon: 'user', group: 'Navigation'},
+      },
+      {
+        id: 'dark-mode',
+        label: 'Toggle Dark Mode',
+        auxiliaryData: {group: 'Actions', keywords: ['theme', 'appearance']},
+      },
+      {
+        id: 'new-file',
+        label: 'Create New File',
+        auxiliaryData: {group: 'Actions', shortcut: '⌘N'},
+      },
+      {
+        id: 'search',
+        label: 'Search Files',
+        auxiliaryData: {icon: 'search', group: 'Actions', shortcut: '⌘P'},
+      },
     ];
-
     const source = useMemo(
-      () => createStaticSource(commands, {
-        keywords: (item) => item.auxiliaryData?.keywords ?? [],
-      }),
+      () =>
+        createStaticSource(commands, {
+          keywords: item => item.auxiliaryData?.keywords ?? [],
+        }),
       [],
     );
-
     return (
       <>
         <XDSButton label="Open Rich Palette" onClick={() => setIsOpen(true)} />
@@ -162,189 +166,42 @@ export const CustomRendering: Story = {
           isOpen={isOpen}
           onOpenChange={setIsOpen}
           searchSource={source}
-          input={<XDSCommandPaletteInput placeholder="Type a command..." />}
-          footer={<XDSCommandPaletteFooter />}>
-          {(items) => {
-            const groups = new Map<string, CommandItem[]>();
-            const ungrouped: CommandItem[] = [];
-
-            for (const item of items as CommandItem[]) {
-              const group = item.auxiliaryData?.group;
-              if (group) {
-                if (!groups.has(group)) groups.set(group, []);
-                groups.get(group)!.push(item);
-              } else {
-                ungrouped.push(item);
-              }
-            }
-
-            return (
-              <>
-                {Array.from(groups.entries()).map(([heading, groupItems]) => (
-                  <XDSCommandPaletteGroup key={heading} heading={heading}>
-                    {groupItems.map(item => (
-                      <XDSCommandPaletteItem
-                        key={item.id}
-                        value={item.id}
-                        onSelect={() => console.log('Selected:', item.id)}>
-                        <div style={{display: 'flex', alignItems: 'center', gap: 8, flex: 1}}>
-                          {item.auxiliaryData?.icon && (
-                            <XDSIcon icon={item.auxiliaryData.icon} size="sm" />
-                          )}
-                          <span style={{flex: 1}}>{item.label}</span>
-                          {item.auxiliaryData?.shortcut && (
-                            <span style={{fontSize: 12, opacity: 0.5}}>
-                              {item.auxiliaryData.shortcut}
-                            </span>
-                          )}
-                        </div>
-                      </XDSCommandPaletteItem>
-                    ))}
-                  </XDSCommandPaletteGroup>
-                ))}
-                {ungrouped.map(item => (
-                  <XDSCommandPaletteItem key={item.id} value={item.id}>
-                    {item.label}
-                  </XDSCommandPaletteItem>
-                ))}
-              </>
-            );
-          }}
-        </XDSCommandPalette>
-      </>
-    );
-  },
-};
-
-// --- Async search ---
-
-/** Server-side search. Input shows spinner while pending. */
-export const AsyncSearch: Story = {
-  render: function Render() {
-    const [isOpen, setIsOpen] = useState(false);
-
-    const source = useMemo<XDSSearchSource>(() => ({
-      _controller: null as AbortController | null,
-      cancel() { this._controller?.abort(); },
-      async search(query: string) {
-        this.cancel();
-        this._controller = new AbortController();
-        await new Promise(r => setTimeout(r, 300));
-        const all = [
-          {id: 'readme', label: 'README.md'},
-          {id: 'package', label: 'package.json'},
-          {id: 'tsconfig', label: 'tsconfig.json'},
-          {id: 'index', label: 'src/index.ts'},
-          {id: 'app', label: 'src/App.tsx'},
-        ];
-        return all.filter(f => f.label.toLowerCase().includes(query.toLowerCase()));
-      },
-      bootstrap() { return []; },
-    }), []);
-
-    return (
-      <>
-        <XDSButton label="Open File Search" onClick={() => setIsOpen(true)} />
-        <XDSCommandPalette
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          searchSource={source}
-          input={<XDSCommandPaletteInput placeholder="Search files..." />}
+          renderItem={(item: RichCommand) => (
+            <span
+              style={{display: 'flex', alignItems: 'center', gap: 8, flex: 1}}>
+              {item.auxiliaryData?.icon && (
+                <XDSIcon icon={item.auxiliaryData.icon} size="sm" />
+              )}
+              <span style={{flex: 1}}>{item.label}</span>
+              {item.auxiliaryData?.shortcut && (
+                <span style={{fontSize: 12, opacity: 0.5}}>
+                  {item.auxiliaryData.shortcut}
+                </span>
+              )}
+            </span>
+          )}
         />
       </>
     );
   },
 };
 
-// --- Hybrid: static + async ---
+// ─── Picker mode ─────────────────────────────────────────────────────────────
 
-/** Recent files (static) + project files (API) in one source. */
-export const HybridSearch: Story = {
-  render: function Render() {
-    const [isOpen, setIsOpen] = useState(false);
-
-    const recentFiles: XDSSearchableItem<{recent: boolean}>[] = [
-      {id: 'recent-1', label: 'App.tsx', auxiliaryData: {recent: true}},
-      {id: 'recent-2', label: 'index.ts', auxiliaryData: {recent: true}},
-    ];
-
-    const source = useMemo<XDSSearchSource>(() => ({
-      async search(query: string) {
-        const lower = query.toLowerCase();
-        const matchingRecent = recentFiles.filter(f =>
-          f.label.toLowerCase().includes(lower),
-        );
-        await new Promise(r => setTimeout(r, 200));
-        const apiResults: XDSSearchableItem[] = [
-          {id: 'api-1', label: 'utils/helpers.ts'},
-          {id: 'api-2', label: 'components/Button.tsx'},
-          {id: 'api-3', label: 'hooks/useAuth.ts'},
-        ].filter(f => f.label.toLowerCase().includes(lower));
-        return [...matchingRecent, ...apiResults];
-      },
-      bootstrap() { return recentFiles; },
-    }), []);
-
-    return (
-      <>
-        <XDSButton label="Open File Finder" onClick={() => setIsOpen(true)} />
-        <XDSCommandPalette
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          searchSource={source}
-          input={<XDSCommandPaletteInput placeholder="Search project files..." />}>
-          {(items) => {
-            const recent = items.filter(i => {
-              const aux = i.auxiliaryData as Record<string, unknown> | undefined;
-              return aux?.recent === true;
-            });
-            const other = items.filter(i => {
-              const aux = i.auxiliaryData as Record<string, unknown> | undefined;
-              return aux?.recent !== true;
-            });
-            return (
-              <>
-                {recent.length > 0 && (
-                  <XDSCommandPaletteGroup heading="Recent">
-                    {recent.map(item => (
-                      <XDSCommandPaletteItem key={item.id} value={item.id}>
-                        {item.label}
-                      </XDSCommandPaletteItem>
-                    ))}
-                  </XDSCommandPaletteGroup>
-                )}
-                {other.length > 0 && (
-                  <XDSCommandPaletteGroup heading="Project">
-                    {other.map(item => (
-                      <XDSCommandPaletteItem key={item.id} value={item.id}>
-                        {item.label}
-                      </XDSCommandPaletteItem>
-                    ))}
-                  </XDSCommandPaletteGroup>
-                )}
-              </>
-            );
-          }}
-        </XDSCommandPalette>
-      </>
-    );
-  },
-};
-
-// --- Picker ---
-
-/** Selection persists across opens. Uses isSelected for visual state. */
+/** Selection persists across opens. isSelected passed to renderItem. */
 export const Picker: Story = {
   render: function Render() {
     const [isOpen, setIsOpen] = useState(false);
     const [theme, setTheme] = useState('light');
-
-    const source = useMemo(() => createStaticSource([
-      {id: 'light', label: 'Light'},
-      {id: 'dark', label: 'Dark'},
-      {id: 'system', label: 'System'},
-    ]), []);
-
+    const source = useMemo(
+      () =>
+        createStaticSource([
+          {id: 'light', label: 'Light'},
+          {id: 'dark', label: 'Dark'},
+          {id: 'system', label: 'System'},
+        ]),
+      [],
+    );
     return (
       <>
         <XDSButton label={`Theme: ${theme}`} onClick={() => setIsOpen(true)} />
@@ -353,17 +210,167 @@ export const Picker: Story = {
           onOpenChange={setIsOpen}
           searchSource={source}
           value={theme}
-          onValueChange={setTheme}
-          input={<XDSCommandPaletteInput placeholder="Choose theme..." />}>
-          {(items) => items.map(item => (
-            <XDSCommandPaletteItem
-              key={item.id}
-              value={item.id}
-              isSelected={item.id === theme}>
-              {item.label}
-            </XDSCommandPaletteItem>
-          ))}
-        </XDSCommandPalette>
+          onValueChange={v => {
+            setTheme(v);
+            setIsOpen(false);
+          }}
+          renderItem={(item, isSelected) => (
+            <span
+              style={{display: 'flex', alignItems: 'center', gap: 8, flex: 1}}>
+              <span style={{flex: 1}}>{item.label}</span>
+              {isSelected && <XDSIcon icon="check" size="sm" />}
+            </span>
+          )}
+        />
+      </>
+    );
+  },
+};
+
+// ─── Async search ─────────────────────────────────────────────────────────────
+
+/** Server-side search. Spinner shown while pending. Empty state on no results. */
+export const AsyncSearch: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+    const source = useMemo<XDSSearchSource>(
+      () => ({
+        _controller: null as AbortController | null,
+        cancel() {
+          this._controller?.abort();
+        },
+        async search(query: string) {
+          this.cancel();
+          this._controller = new AbortController();
+          await new Promise(r => setTimeout(r, 400));
+          const all = [
+            {id: 'readme', label: 'README.md'},
+            {id: 'package', label: 'package.json'},
+            {id: 'tsconfig', label: 'tsconfig.json'},
+            {id: 'index', label: 'src/index.ts'},
+            {id: 'app', label: 'src/App.tsx'},
+          ];
+          return all.filter(f =>
+            f.label.toLowerCase().includes(query.toLowerCase()),
+          );
+        },
+        bootstrap() {
+          return [];
+        },
+      }),
+      [],
+    );
+    return (
+      <>
+        <XDSButton label="Open File Search" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          searchSource={source}
+          input={<XDSCommandPaletteInput placeholder="Search files..." />}
+          emptyBootstrapText="Type a filename to search"
+          emptySearchText="No files found"
+        />
+      </>
+    );
+  },
+};
+
+// ─── Keywords ────────────────────────────────────────────────────────────────
+
+/** Type "theme" or "appearance" to find "Toggle Dark Mode". */
+export const WithKeywords: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+    const commands: XDSSearchableItem<{aliases?: string[]}>[] = [
+      {id: 'home', label: 'Home'},
+      {
+        id: 'dark-mode',
+        label: 'Toggle Dark Mode',
+        auxiliaryData: {aliases: ['theme', 'appearance']},
+      },
+      {
+        id: 'font-size',
+        label: 'Change Font Size',
+        auxiliaryData: {aliases: ['text', 'zoom']},
+      },
+    ];
+    const source = useMemo(
+      () =>
+        createStaticSource(commands, {
+          keywords: item => item.auxiliaryData?.aliases ?? [],
+        }),
+      [],
+    );
+    return (
+      <>
+        <XDSButton label="Open (try 'theme')" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          searchSource={source}
+        />
+      </>
+    );
+  },
+};
+
+// ─── Many items (overflow / scroll test) ─────────────────────────────────────
+
+/**
+ * 50 items across 5 groups. Verifies the list scrolls within the dialog
+ * rather than expanding it past maxHeight.
+ */
+export const ManyItems: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+    const groups = ['Files', 'Actions', 'Navigation', 'Settings', 'Recent'];
+    const items = Array.from({length: 50}, (_, i) => ({
+      id: `item-${i}`,
+      label: `Item ${i + 1}`,
+      auxiliaryData: {group: groups[i % groups.length]},
+    }));
+    const source = useMemo(() => createStaticSource(items), []);
+    return (
+      <>
+        <XDSButton label="Open (50 items)" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          searchSource={source}
+        />
+      </>
+    );
+  },
+};
+
+// ─── Custom footer ────────────────────────────────────────────────────────────
+
+/** Replacing the footer with custom content. */
+export const CustomFooter: Story = {
+  render: function Render() {
+    const [isOpen, setIsOpen] = useState(false);
+    const source = useMemo(
+      () =>
+        createStaticSource([
+          {id: 'home', label: 'Home'},
+          {id: 'settings', label: 'Settings'},
+        ]),
+      [],
+    );
+    return (
+      <>
+        <XDSButton label="Open" onClick={() => setIsOpen(true)} />
+        <XDSCommandPalette
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          searchSource={source}
+          footer={
+            <XDSCommandPaletteFooter>
+              <span>Pro tip: use ⌘K to open anywhere</span>
+            </XDSCommandPaletteFooter>
+          }
+        />
       </>
     );
   },

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.test.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.test.tsx
@@ -20,6 +20,8 @@ const groupedSource = createStaticSource([
   {id: 'save', label: 'Save', auxiliaryData: {group: 'Actions'}},
 ]);
 
+const emptySource = createStaticSource([]);
+
 // Mock showModal and close since jsdom doesn't implement them
 beforeEach(() => {
   HTMLDialogElement.prototype.showModal = vi.fn(function (
@@ -39,7 +41,6 @@ describe('XDSCommandPalette', () => {
         isOpen={true}
         onOpenChange={() => {}}
         searchSource={simpleSource}
-        input={<div>Input</div>}
       />,
     );
     expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -51,7 +52,6 @@ describe('XDSCommandPalette', () => {
         isOpen={false}
         onOpenChange={() => {}}
         searchSource={simpleSource}
-        input={<div>Input</div>}
       />,
     );
     const dialog = screen.getByRole('dialog', {hidden: true});
@@ -64,7 +64,6 @@ describe('XDSCommandPalette', () => {
         isOpen={true}
         onOpenChange={() => {}}
         searchSource={simpleSource}
-        input={<div>Input</div>}
       />,
     );
     expect(screen.getByRole('dialog')).toHaveAttribute(
@@ -80,7 +79,6 @@ describe('XDSCommandPalette', () => {
         onOpenChange={() => {}}
         searchSource={simpleSource}
         label="Quick search"
-        input={<div>Input</div>}
       />,
     );
     expect(screen.getByRole('dialog')).toHaveAttribute(
@@ -89,30 +87,30 @@ describe('XDSCommandPalette', () => {
     );
   });
 
-  it('renders input and footer slots', () => {
+  it('renders default input and footer when not provided', () => {
     render(
       <XDSCommandPalette
         isOpen={true}
         onOpenChange={() => {}}
         searchSource={simpleSource}
-        input={<div data-testid="input-slot">Input</div>}
-        footer={<div data-testid="footer-slot">Footer</div>}
+      />,
+    );
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText(/Navigate/)).toBeInTheDocument();
+  });
+
+  it('renders custom input and footer slots', () => {
+    render(
+      <XDSCommandPalette
+        isOpen={true}
+        onOpenChange={() => {}}
+        searchSource={simpleSource}
+        input={<div data-testid="input-slot">Custom Input</div>}
+        footer={<div data-testid="footer-slot">Custom Footer</div>}
       />,
     );
     expect(screen.getByTestId('input-slot')).toBeInTheDocument();
     expect(screen.getByTestId('footer-slot')).toBeInTheDocument();
-  });
-
-  it('renders without footer slot', () => {
-    render(
-      <XDSCommandPalette
-        isOpen={true}
-        onOpenChange={() => {}}
-        searchSource={simpleSource}
-        input={<div>Input</div>}
-      />,
-    );
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
   });
 
   it('default renders items from searchSource bootstrap', async () => {
@@ -121,7 +119,6 @@ describe('XDSCommandPalette', () => {
         isOpen={true}
         onOpenChange={() => {}}
         searchSource={simpleSource}
-        input={<div>Input</div>}
       />,
     );
     await waitFor(() => {
@@ -136,7 +133,6 @@ describe('XDSCommandPalette', () => {
         isOpen={true}
         onOpenChange={() => {}}
         searchSource={groupedSource}
-        input={<div>Input</div>}
       />,
     );
     await waitFor(() => {
@@ -147,26 +143,63 @@ describe('XDSCommandPalette', () => {
     });
   });
 
-  it('uses render function children when provided', async () => {
+  it('uses renderItem for custom item content', async () => {
     render(
       <XDSCommandPalette
         isOpen={true}
         onOpenChange={() => {}}
         searchSource={simpleSource}
-        input={<div>Input</div>}>
-        {(items) => (
-          <div data-testid="custom-render">
-            {items.map(item => (
-              <span key={item.id}>{item.label.toUpperCase()}</span>
-            ))}
-          </div>
-        )}
-      </XDSCommandPalette>,
+        renderItem={item => <span>{item.label.toUpperCase()}</span>}
+      />,
     );
     await waitFor(() => {
-      expect(screen.getByTestId('custom-render')).toBeInTheDocument();
       expect(screen.getByText('HOME')).toBeInTheDocument();
       expect(screen.getByText('SETTINGS')).toBeInTheDocument();
+    });
+  });
+
+  it('passes isSelected=true to renderItem for the selected value', async () => {
+    render(
+      <XDSCommandPalette
+        isOpen={true}
+        onOpenChange={() => {}}
+        searchSource={simpleSource}
+        value="home"
+        renderItem={(item, isSelected) => (
+          <span>{isSelected ? `checked-${item.label}` : item.label}</span>
+        )}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('checked-Home')).toBeInTheDocument();
+      expect(screen.getByText('Settings')).toBeInTheDocument();
+    });
+  });
+
+  it('shows emptyBootstrapText when bootstrap returns nothing', async () => {
+    render(
+      <XDSCommandPalette
+        isOpen={true}
+        onOpenChange={() => {}}
+        searchSource={emptySource}
+        emptyBootstrapText="Nothing to show"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Nothing to show')).toBeInTheDocument();
+    });
+  });
+
+  it('shows default emptyBootstrapText when not provided', async () => {
+    render(
+      <XDSCommandPalette
+        isOpen={true}
+        onOpenChange={() => {}}
+        searchSource={emptySource}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText('Type to search')).toBeInTheDocument();
     });
   });
 
@@ -177,7 +210,6 @@ describe('XDSCommandPalette', () => {
         isOpen={true}
         onOpenChange={handleOpenChange}
         searchSource={simpleSource}
-        input={<div>Input</div>}
       />,
     );
     const dialog = screen.getByRole('dialog');

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -279,29 +279,19 @@ export function XDSCommandPalette<
   maxHeight = 480,
 }: XDSCommandPaletteProps<T>) {
   const listId = useId();
-  const [search, setSearchRaw] = useState('');
+  const [search, setSearch] = useState('');
   const [internalValue, setInternalValue] = useState('');
   const [searchResults, setSearchResults] = useState<T[]>([]);
   const [isPending, startTransition] = useTransition();
-  // Results are optimistic so the previous list stays visible while the
-  // new query is in flight.
+  // optimisticResults: previous results stay visible while a new query is in flight
   const [optimisticResults, setOptimisticResults] =
     useOptimistic(searchResults);
+  // optimisticSearch: lags behind real search — only advances when the transition
+  // commits. Used for empty state logic so showEmptyBootstrap stays true while
+  // the async query is pending. The input uses real search for immediate feedback.
+  const [optimisticSearch, setOptimisticSearch] = useOptimistic(search);
   const isBusy = isPending;
   const searchVersionRef = useRef(0);
-
-  // Wrap setSearch in startTransition so the query update and the async
-  // search are part of the same transition. This keeps search and
-  // optimisticResults in the same snapshot — search only advances when
-  // the transition commits, so empty-state conditions are always coherent.
-  const setSearch = useCallback(
-    (newSearch: string) => {
-      startTransition(() => {
-        setSearchRaw(newSearch);
-      });
-    },
-    [startTransition],
-  );
 
   const value = controlledValue ?? internalValue;
 
@@ -323,7 +313,7 @@ export function XDSCommandPalette<
   );
 
   const handleClose = useCallback(() => {
-    setSearchRaw('');
+    setSearch('');
     setSearchResults([]);
     if (controlledValue === undefined) {
       setInternalValue('');
@@ -382,6 +372,10 @@ export function XDSCommandPalette<
     startTransition(async () => {
       const isBootstrap = search === '';
 
+      // Advance optimisticSearch to match the real query now that we're
+      // inside the transition. This keeps it coherent with optimisticResults.
+      setOptimisticSearch(search);
+
       // Only client-filter if there are previous results to narrow.
       if (!isBootstrap && searchResults.length > 0) {
         const lower = search.toLowerCase().trim();
@@ -437,6 +431,7 @@ export function XDSCommandPalette<
 
   const contextValue = useMemo(
     () => ({
+      // Expose real search to the input so it reflects keystrokes immediately
       search,
       setSearch,
       value,
@@ -472,11 +467,14 @@ export function XDSCommandPalette<
     ],
   );
 
-  // search is only updated inside startTransition, so it stays at '' while
-  // the transition is pending — coherent with optimisticResults.
-  const showEmptyBootstrap = search === '' && optimisticResults.length === 0;
+  // Empty state uses optimisticSearch (lags behind real search) so that
+  // showEmptyBootstrap stays true while the transition is pending — the input
+  // already shows the typed query via real search, but the list hasn't
+  // transitioned yet so we hold at the bootstrap empty state.
+  const showEmptyBootstrap =
+    optimisticSearch === '' && optimisticResults.length === 0;
   const showEmptySearch =
-    !isPending && search !== '' && optimisticResults.length === 0;
+    !isPending && optimisticSearch !== '' && optimisticResults.length === 0;
 
   let listContent: ReactNode;
   if (showEmptyBootstrap) {

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -283,11 +283,12 @@ export function XDSCommandPalette<
   const [internalValue, setInternalValue] = useState('');
   const [searchResults, setSearchResults] = useState<T[]>([]);
   const [isPending, startTransition] = useTransition();
-  // useOptimistic keeps the previous results visible while a new query is pending.
-  // This prevents the list from blanking out during async searches.
+  // Both search query and results are optimistic so they stay in the same
+  // snapshot during a transition — no mismatch between "query says non-empty"
+  // and "results still reflect the previous query".
   const [optimisticResults, setOptimisticResults] =
     useOptimistic(searchResults);
-  // isBusy: spinner in input. True while a transition is running.
+  const [optimisticSearch, setOptimisticSearch] = useOptimistic(search);
   const isBusy = isPending;
   const searchVersionRef = useRef(0);
 
@@ -370,6 +371,10 @@ export function XDSCommandPalette<
     startTransition(async () => {
       const isBootstrap = search === '';
 
+      // Set optimistic search query so it stays in sync with optimistic results.
+      // Both are updated together inside the transition — no snapshot mismatch.
+      setOptimisticSearch(search);
+
       // Only client-filter if there are previous results to narrow.
       // If the current set is empty (e.g. bootstrap returned nothing),
       // leave optimisticResults as-is so the empty state stays visible
@@ -428,7 +433,7 @@ export function XDSCommandPalette<
 
   const contextValue = useMemo(
     () => ({
-      search,
+      search: optimisticSearch,
       setSearch,
       value,
       setValue,
@@ -445,7 +450,7 @@ export function XDSCommandPalette<
       isBusy,
     }),
     [
-      search,
+      optimisticSearch,
       value,
       setValue,
       listId,
@@ -462,20 +467,19 @@ export function XDSCommandPalette<
     ],
   );
 
-  // Empty states:
-  // - Bootstrap empty: no query and nothing to show
-  // - Search empty: query returned nothing — only after the transition settles
-  //   so we don't flash "No results" while the async query is still in flight
-  // - Pending from empty: query is in flight but we have no optimistic results
-  //   to show (e.g. typed from bootstrap-empty state) — hold at bootstrap empty
-  const showEmptyBootstrap = search === '' && optimisticResults.length === 0;
+  // Both optimisticSearch and optimisticResults are updated together inside
+  // the transition, so they're always in the same snapshot.
+  // showEmptyBootstrap: no query and no results — covers pending-from-empty too,
+  // since optimisticSearch stays '' while the transition runs.
+  // showEmptySearch: only shown once settled so we don't flash "No results"
+  // while the async query is still in flight.
+  const showEmptyBootstrap =
+    optimisticSearch === '' && optimisticResults.length === 0;
   const showEmptySearch =
-    !isPending && search !== '' && optimisticResults.length === 0;
-  const showEmptyPending =
-    isPending && search !== '' && optimisticResults.length === 0;
+    !isPending && optimisticSearch !== '' && optimisticResults.length === 0;
 
   let listContent: ReactNode;
-  if (showEmptyBootstrap || showEmptyPending) {
+  if (showEmptyBootstrap) {
     listContent = (
       <XDSCommandPaletteEmpty>{emptyBootstrapText}</XDSCommandPaletteEmpty>
     );

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -34,6 +34,9 @@ import {CommandPaletteContext} from './CommandPaletteContext';
 import {XDSCommandPaletteList} from './XDSCommandPaletteList';
 import {XDSCommandPaletteItem} from './XDSCommandPaletteItem';
 import {XDSCommandPaletteGroup} from './XDSCommandPaletteGroup';
+import {XDSCommandPaletteInput} from './XDSCommandPaletteInput';
+import {XDSCommandPaletteFooter} from './XDSCommandPaletteFooter';
+import {XDSCommandPaletteEmpty} from './XDSCommandPaletteEmpty';
 
 export interface XDSCommandPaletteProps<
   T extends XDSSearchableItem = XDSSearchableItem,
@@ -52,22 +55,35 @@ export interface XDSCommandPaletteProps<
   searchSource: XDSSearchSource<T>;
 
   /**
-   * The search input slot. Pass XDSCommandPaletteInput here.
+   * The search input slot.
+   * @default <XDSCommandPaletteInput />
    */
   input?: ReactNode;
 
   /**
-   * The footer slot. Pass XDSCommandPaletteFooter here.
+   * The footer slot.
+   * @default <XDSCommandPaletteFooter />
    */
   footer?: ReactNode;
 
   /**
-   * Custom render function for items. Receives the filtered items array.
-   * When omitted, items are rendered with default rendering:
-   * - Each item shows its `label` text
-   * - Items with `auxiliaryData.group` are auto-grouped
+   * Per-item render function. Receives the item and whether it is currently selected.
+   * Auto-grouping by `auxiliaryData.group` is preserved.
+   * When omitted, renders each item's `label` text.
    */
-  children?: (items: T[]) => ReactNode;
+  renderItem?: (item: T, isSelected: boolean) => ReactNode;
+
+  /**
+   * Content shown when a search query returns no results.
+   * @default 'No results'
+   */
+  emptySearchText?: ReactNode;
+
+  /**
+   * Content shown when there is no search query and bootstrap() returns nothing.
+   * @default 'Type to search'
+   */
+  emptyBootstrapText?: ReactNode;
 
   /** Controlled selected value (for picker mode). */
   value?: string;
@@ -146,30 +162,37 @@ function buildSelectableItems(
   return result;
 }
 
+interface RendererProps<T extends XDSSearchableItem> {
+  items: T[];
+  value: string;
+  renderItem?: (item: T, isSelected: boolean) => ReactNode;
+}
+
 /**
- * Default renderer for search results.
- * Renders items as XDSCommandPaletteItem with label text.
- * Auto-groups items by auxiliaryData.group when present.
+ * Renders items with optional per-item customization.
+ * Auto-groups by auxiliaryData.group when present.
+ * Passes `isSelected` so renderItem can handle picker-mode visuals.
  */
-function DefaultRenderer({items}: {items: XDSSearchableItem[]}) {
+function ItemRenderer<T extends XDSSearchableItem>({
+  items,
+  value,
+  renderItem,
+}: RendererProps<T>) {
+  const renderOne = (item: T) => (
+    <XDSCommandPaletteItem key={item.id} value={item.id}>
+      {renderItem ? renderItem(item, item.id === value) : item.label}
+    </XDSCommandPaletteItem>
+  );
+
   const hasGroups = items.some(item => getGroup(item) != null);
 
   if (!hasGroups) {
-    return (
-      <>
-        {items.map(item => (
-          <XDSCommandPaletteItem key={item.id} value={item.id}>
-            {item.label}
-          </XDSCommandPaletteItem>
-        ))}
-      </>
-    );
+    return <>{items.map(renderOne)}</>;
   }
 
-  // Group items preserving insertion order of groups
   const groupOrder: string[] = [];
-  const groups = new Map<string, XDSSearchableItem[]>();
-  const ungrouped: XDSSearchableItem[] = [];
+  const groups = new Map<string, T[]>();
+  const ungrouped: T[] = [];
 
   for (const item of items) {
     const group = getGroup(item);
@@ -188,18 +211,10 @@ function DefaultRenderer({items}: {items: XDSSearchableItem[]}) {
     <>
       {groupOrder.map(heading => (
         <XDSCommandPaletteGroup key={heading} heading={heading}>
-          {groups.get(heading)!.map(item => (
-            <XDSCommandPaletteItem key={item.id} value={item.id}>
-              {item.label}
-            </XDSCommandPaletteItem>
-          ))}
+          {groups.get(heading)!.map(renderOne)}
         </XDSCommandPaletteGroup>
       ))}
-      {ungrouped.map(item => (
-        <XDSCommandPaletteItem key={item.id} value={item.id}>
-          {item.label}
-        </XDSCommandPaletteItem>
-      ))}
+      {ungrouped.map(renderOne)}
     </>
   );
 }
@@ -214,38 +229,34 @@ function DefaultRenderer({items}: {items: XDSSearchableItem[]}) {
  * ensuring consistent arrow key, Home/End, Enter, and Escape behavior
  * across all combobox-pattern components.
  *
- * Progressive disclosure:
- * - No children: default rendering (label text, auto-groups by auxiliaryData.group)
- * - Children render function: full control over item layout and grouping
+ * Input and footer are rendered by default — only pass them to replace the defaults.
  *
  * @compositionHint
- *   - `input` slot: XDSCommandPaletteInput
- *   - `children`: optional render function `(items) => ReactNode`
- *   - `footer` slot: XDSCommandPaletteFooter
+ *   - `input` slot: XDSCommandPaletteInput (default)
+ *   - `footer` slot: XDSCommandPaletteFooter (default)
+ *   - `renderItem(item, isSelected)`: custom per-item content (grouping preserved)
  *
  * @example
- * ```
- * // Simplest — no children, default rendering
+ * ```tsx
+ * // Simplest — zero config beyond open state and source
  * <XDSCommandPalette
  *   isOpen={isOpen}
  *   onOpenChange={setIsOpen}
  *   searchSource={createStaticSource(commands)}
- *   input={<XDSCommandPaletteInput placeholder="Search..." />}
- *   footer={<XDSCommandPaletteFooter />}
  * />
  *
- * // Custom rendering
+ * // Custom item rendering (grouping still automatic)
  * <XDSCommandPalette
  *   isOpen={isOpen}
  *   onOpenChange={setIsOpen}
  *   searchSource={source}
- *   input={<XDSCommandPaletteInput placeholder="Search..." />}>
- *   {(items) => items.map(item => (
- *     <XDSCommandPaletteItem key={item.id} value={item.id}>
+ *   renderItem={(item, isSelected) => (
+ *     <>
+ *       <XDSIcon icon={item.auxiliaryData.icon} size="sm" />
  *       {item.label}
- *     </XDSCommandPaletteItem>
- *   ))}
- * </XDSCommandPalette>
+ *     </>
+ *   )}
+ * />
  * ```
  */
 export function XDSCommandPalette<
@@ -255,8 +266,10 @@ export function XDSCommandPalette<
   onOpenChange,
   searchSource,
   input,
-  children,
   footer,
+  renderItem,
+  emptySearchText = 'No results',
+  emptyBootstrapText = 'Type to search',
   value: controlledValue,
   onValueChange,
   label = 'Command palette',
@@ -283,7 +296,7 @@ export function XDSCommandPalette<
   );
 
   // Build flat selectable items in DOM order from search results.
-  // This must match the order that DefaultRenderer (or custom children) renders.
+  // Must match the render order of ItemRenderer.
   const selectableItems = useMemo(
     () => buildSelectableItems(searchResults),
     [searchResults],
@@ -429,11 +442,30 @@ export function XDSCommandPalette<
     ],
   );
 
-  const listContent = children ? (
-    children(searchResults)
-  ) : (
-    <DefaultRenderer items={searchResults} />
-  );
+  // Determine list content — empty states take priority over item rendering
+  const showEmptyBootstrap =
+    !isBusy && search === '' && searchResults.length === 0;
+  const showEmptySearch =
+    !isBusy && search !== '' && searchResults.length === 0;
+
+  let listContent: ReactNode;
+  if (showEmptyBootstrap) {
+    listContent = (
+      <XDSCommandPaletteEmpty>{emptyBootstrapText}</XDSCommandPaletteEmpty>
+    );
+  } else if (showEmptySearch) {
+    listContent = (
+      <XDSCommandPaletteEmpty>{emptySearchText}</XDSCommandPaletteEmpty>
+    );
+  } else {
+    listContent = (
+      <ItemRenderer
+        items={searchResults}
+        value={value}
+        renderItem={renderItem}
+      />
+    );
+  }
 
   return (
     <XDSDialog
@@ -450,11 +482,9 @@ export function XDSCommandPalette<
         <XDSLayout
           defaultHasDividers
           header={
-            input != null ? (
-              <XDSLayoutHeader hasDivider padding={0}>
-                {input}
-              </XDSLayoutHeader>
-            ) : undefined
+            <XDSLayoutHeader hasDivider padding={0}>
+              {input ?? <XDSCommandPaletteInput />}
+            </XDSLayoutHeader>
           }
           content={
             <XDSLayoutContent padding={0}>
@@ -462,11 +492,9 @@ export function XDSCommandPalette<
             </XDSLayoutContent>
           }
           footer={
-            footer != null ? (
-              <XDSLayoutFooter hasDivider padding={0}>
-                {footer}
-              </XDSLayoutFooter>
-            ) : undefined
+            <XDSLayoutFooter hasDivider padding={0}>
+              {footer ?? <XDSCommandPaletteFooter />}
+            </XDSLayoutFooter>
           }
         />
       </CommandPaletteContext.Provider>

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -370,8 +370,11 @@ export function XDSCommandPalette<
     startTransition(async () => {
       const isBootstrap = search === '';
 
-      // Optimistically narrow the previous results while the real query is in flight
-      if (!isBootstrap) {
+      // Only client-filter if there are previous results to narrow.
+      // If the current set is empty (e.g. bootstrap returned nothing),
+      // leave optimisticResults as-is so the empty state stays visible
+      // rather than flashing a blank list.
+      if (!isBootstrap && searchResults.length > 0) {
         const lower = search.toLowerCase().trim();
         const optimistic = searchResults.filter(item =>
           item.label.toLowerCase().includes(lower),
@@ -459,14 +462,12 @@ export function XDSCommandPalette<
     ],
   );
 
-  // Empty states: only show after the transition settles (not while pending),
-  // and only when there are truly no results to show — not stale ones.
-  // During a pending transition, optimisticResults holds the previous results,
-  // so the list stays populated rather than flashing blank.
-  const showEmptyBootstrap =
-    !isPending && search === '' && optimisticResults.length === 0;
-  const showEmptySearch =
-    !isPending && search !== '' && optimisticResults.length === 0;
+  // Empty states: shown whenever there's nothing to render — including during
+  // a pending transition when optimisticResults is empty (e.g. typing from
+  // an empty bootstrap). The list stays at the empty state rather than
+  // flashing blank while the async query is in flight.
+  const showEmptyBootstrap = search === '' && optimisticResults.length === 0;
+  const showEmptySearch = search !== '' && optimisticResults.length === 0;
 
   let listContent: ReactNode;
   if (showEmptyBootstrap) {

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -16,8 +16,10 @@ import {
   useEffect,
   useId,
   useMemo,
+  useOptimistic,
   useRef,
   useState,
+  useTransition,
   type ReactNode,
 } from 'react';
 import {XDSDialog} from '@xds/core/Dialog';
@@ -280,7 +282,13 @@ export function XDSCommandPalette<
   const [search, setSearch] = useState('');
   const [internalValue, setInternalValue] = useState('');
   const [searchResults, setSearchResults] = useState<T[]>([]);
-  const [isBusy, setIsBusy] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  // useOptimistic keeps the previous results visible while a new query is pending.
+  // This prevents the list from blanking out during async searches.
+  const [optimisticResults, setOptimisticResults] =
+    useOptimistic(searchResults);
+  // isBusy: spinner in input. True while a transition is running.
+  const isBusy = isPending;
   const searchVersionRef = useRef(0);
 
   const value = controlledValue ?? internalValue;
@@ -298,12 +306,13 @@ export function XDSCommandPalette<
   // Build flat selectable items in DOM order from search results.
   // Must match the render order of ItemRenderer.
   const selectableItems = useMemo(
-    () => buildSelectableItems(searchResults),
-    [searchResults],
+    () => buildSelectableItems(optimisticResults),
+    [optimisticResults],
   );
 
   const handleClose = useCallback(() => {
     setSearch('');
+    setSearchResults([]);
     if (controlledValue === undefined) {
       setInternalValue('');
     }
@@ -345,34 +354,29 @@ export function XDSCommandPalette<
     }
   }, [isOpen, selectableItems, value, combobox]);
 
-  // Unified search effect: bootstrap on open or empty query, search otherwise
+  // Unified search effect: bootstrap on open or empty query, search otherwise.
+  // Wrapped in startTransition so the current optimisticResults remain visible
+  // while the new query is in flight — no blank flash between queries.
   useEffect(() => {
     if (!isOpen) return;
 
     searchSource.cancel?.();
     const version = ++searchVersionRef.current;
 
-    const result =
-      search === '' ? searchSource.bootstrap() : searchSource.search(search);
+    startTransition(async () => {
+      const isBootstrap = search === '';
+      const result = isBootstrap
+        ? searchSource.bootstrap()
+        : searchSource.search(search);
 
-    if (result instanceof Promise) {
-      setIsBusy(true);
-      result
-        .then(items => {
-          if (searchVersionRef.current === version) {
-            setSearchResults(items);
-            setIsBusy(false);
-          }
-        })
-        .catch(() => {
-          if (searchVersionRef.current === version) {
-            setIsBusy(false);
-          }
-        });
-    } else {
-      setSearchResults(result);
-      setIsBusy(false);
-    }
+      // Show stale results while waiting
+      const items = await Promise.resolve(result);
+
+      if (searchVersionRef.current === version) {
+        setOptimisticResults(items);
+        setSearchResults(items);
+      }
+    });
   }, [search, isOpen, searchSource]);
 
   // Wrap combobox's onKeyDown to intercept Escape (close palette) and
@@ -417,7 +421,7 @@ export function XDSCommandPalette<
       setHighlightedIndex: combobox.setHighlightedIndex,
       getItemId: combobox.getItemId,
       selectableItems,
-      searchResults,
+      searchResults: optimisticResults,
       selectItem,
       onKeyDown: handleKeyDown,
       onClose: handleClose,
@@ -433,7 +437,7 @@ export function XDSCommandPalette<
       combobox.setHighlightedIndex,
       combobox.getItemId,
       selectableItems,
-      searchResults,
+      optimisticResults,
       selectItem,
       handleKeyDown,
       handleClose,
@@ -442,11 +446,14 @@ export function XDSCommandPalette<
     ],
   );
 
-  // Determine list content — empty states take priority over item rendering
+  // Empty states: only show after the transition settles (not while pending),
+  // and only when there are truly no results to show — not stale ones.
+  // During a pending transition, optimisticResults holds the previous results,
+  // so the list stays populated rather than flashing blank.
   const showEmptyBootstrap =
-    !isBusy && search === '' && searchResults.length === 0;
+    !isPending && search === '' && optimisticResults.length === 0;
   const showEmptySearch =
-    !isBusy && search !== '' && searchResults.length === 0;
+    !isPending && search !== '' && optimisticResults.length === 0;
 
   let listContent: ReactNode;
   if (showEmptyBootstrap) {
@@ -460,7 +467,7 @@ export function XDSCommandPalette<
   } else {
     listContent = (
       <ItemRenderer
-        items={searchResults}
+        items={optimisticResults}
         value={value}
         renderItem={renderItem}
       />

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -357,46 +357,49 @@ export function XDSCommandPalette<
     }
   }, [isOpen, selectableItems, value, combobox]);
 
-  // Effect triggers on optimisticSearch (immediate) not search (committed).
-  // Inside the transition:
-  //   - Client-filter previous results for instant feedback while fetching
-  //   - Await the real async result
-  //   - Commit both search and searchResults together when done
-  // This means search always reflects what the current results correspond to,
-  // and optimisticSearch is always what the user sees.
+  // Run a search for the given query and commit results.
+  // Called directly when the user types — no effect needed.
+  const runSearch = useCallback(
+    (query: string) => {
+      searchSource.cancel?.();
+      const version = ++searchVersionRef.current;
+
+      startTransition(async () => {
+        const isBootstrap = query === '';
+
+        // Client-filter previous results for instant narrowing while fetch is in flight
+        if (!isBootstrap && searchResults.length > 0) {
+          const lower = query.toLowerCase().trim();
+          setOptimisticResults(
+            searchResults.filter(item =>
+              item.label.toLowerCase().includes(lower),
+            ),
+          );
+        }
+
+        const result = isBootstrap
+          ? searchSource.bootstrap()
+          : searchSource.search(query);
+
+        const items = await Promise.resolve(result);
+
+        if (searchVersionRef.current === version) {
+          // Commit query and results together
+          setSearch(query);
+          setOptimisticResults(items);
+          setSearchResults(items);
+        }
+      });
+    },
+    [searchSource, searchResults, startTransition],
+  );
+
+  // Bootstrap on open — the only remaining effect.
   useEffect(() => {
-    if (!isOpen) return;
-
-    searchSource.cancel?.();
-    const version = ++searchVersionRef.current;
-
-    startTransition(async () => {
-      const isBootstrap = optimisticSearch === '';
-
-      // Client-filter previous results for instant narrowing while fetch is in flight
-      if (!isBootstrap && searchResults.length > 0) {
-        const lower = optimisticSearch.toLowerCase().trim();
-        setOptimisticResults(
-          searchResults.filter(item =>
-            item.label.toLowerCase().includes(lower),
-          ),
-        );
-      }
-
-      const result = isBootstrap
-        ? searchSource.bootstrap()
-        : searchSource.search(optimisticSearch);
-
-      const items = await Promise.resolve(result);
-
-      if (searchVersionRef.current === version) {
-        // Commit the query and results together — search now reflects the results
-        setSearch(optimisticSearch);
-        setOptimisticResults(items);
-        setSearchResults(items);
-      }
-    });
-  }, [optimisticSearch, isOpen, searchSource]);
+    if (isOpen) {
+      runSearch('');
+    }
+  }, [isOpen]);
 
   // Wrap combobox's onKeyDown to intercept Escape (close palette) and
   // Enter on highlight (select + close), since we're not using combobox's
@@ -431,9 +434,14 @@ export function XDSCommandPalette<
 
   const contextValue = useMemo(
     () => ({
-      // Input uses optimisticSearch — reflects keystrokes immediately
+      // Input uses optimisticSearch — reflects keystrokes immediately.
+      // setSearch calls setOptimisticSearch for instant feedback then
+      // triggers the async search directly (no effect indirection).
       search: optimisticSearch,
-      setSearch: setOptimisticSearch,
+      setSearch: (query: string) => {
+        setOptimisticSearch(query);
+        runSearch(query);
+      },
       value,
       setValue,
       listId,
@@ -451,6 +459,7 @@ export function XDSCommandPalette<
     [
       optimisticSearch,
       setOptimisticSearch,
+      runSearch,
       value,
       setValue,
       listId,

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -462,15 +462,20 @@ export function XDSCommandPalette<
     ],
   );
 
-  // Empty states: shown whenever there's nothing to render — including during
-  // a pending transition when optimisticResults is empty (e.g. typing from
-  // an empty bootstrap). The list stays at the empty state rather than
-  // flashing blank while the async query is in flight.
+  // Empty states:
+  // - Bootstrap empty: no query and nothing to show
+  // - Search empty: query returned nothing — only after the transition settles
+  //   so we don't flash "No results" while the async query is still in flight
+  // - Pending from empty: query is in flight but we have no optimistic results
+  //   to show (e.g. typed from bootstrap-empty state) — hold at bootstrap empty
   const showEmptyBootstrap = search === '' && optimisticResults.length === 0;
-  const showEmptySearch = search !== '' && optimisticResults.length === 0;
+  const showEmptySearch =
+    !isPending && search !== '' && optimisticResults.length === 0;
+  const showEmptyPending =
+    isPending && search !== '' && optimisticResults.length === 0;
 
   let listContent: ReactNode;
-  if (showEmptyBootstrap) {
+  if (showEmptyBootstrap || showEmptyPending) {
     listContent = (
       <XDSCommandPaletteEmpty>{emptyBootstrapText}</XDSCommandPaletteEmpty>
     );

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -279,18 +279,29 @@ export function XDSCommandPalette<
   maxHeight = 480,
 }: XDSCommandPaletteProps<T>) {
   const listId = useId();
-  const [search, setSearch] = useState('');
+  const [search, setSearchRaw] = useState('');
   const [internalValue, setInternalValue] = useState('');
   const [searchResults, setSearchResults] = useState<T[]>([]);
   const [isPending, startTransition] = useTransition();
-  // Both search query and results are optimistic so they stay in the same
-  // snapshot during a transition — no mismatch between "query says non-empty"
-  // and "results still reflect the previous query".
+  // Results are optimistic so the previous list stays visible while the
+  // new query is in flight.
   const [optimisticResults, setOptimisticResults] =
     useOptimistic(searchResults);
-  const [optimisticSearch, setOptimisticSearch] = useOptimistic(search);
   const isBusy = isPending;
   const searchVersionRef = useRef(0);
+
+  // Wrap setSearch in startTransition so the query update and the async
+  // search are part of the same transition. This keeps search and
+  // optimisticResults in the same snapshot — search only advances when
+  // the transition commits, so empty-state conditions are always coherent.
+  const setSearch = useCallback(
+    (newSearch: string) => {
+      startTransition(() => {
+        setSearchRaw(newSearch);
+      });
+    },
+    [startTransition],
+  );
 
   const value = controlledValue ?? internalValue;
 
@@ -312,7 +323,7 @@ export function XDSCommandPalette<
   );
 
   const handleClose = useCallback(() => {
-    setSearch('');
+    setSearchRaw('');
     setSearchResults([]);
     if (controlledValue === undefined) {
       setInternalValue('');
@@ -371,14 +382,7 @@ export function XDSCommandPalette<
     startTransition(async () => {
       const isBootstrap = search === '';
 
-      // Set optimistic search query so it stays in sync with optimistic results.
-      // Both are updated together inside the transition — no snapshot mismatch.
-      setOptimisticSearch(search);
-
       // Only client-filter if there are previous results to narrow.
-      // If the current set is empty (e.g. bootstrap returned nothing),
-      // leave optimisticResults as-is so the empty state stays visible
-      // rather than flashing a blank list.
       if (!isBootstrap && searchResults.length > 0) {
         const lower = search.toLowerCase().trim();
         const optimistic = searchResults.filter(item =>
@@ -433,7 +437,7 @@ export function XDSCommandPalette<
 
   const contextValue = useMemo(
     () => ({
-      search: optimisticSearch,
+      search,
       setSearch,
       value,
       setValue,
@@ -450,7 +454,8 @@ export function XDSCommandPalette<
       isBusy,
     }),
     [
-      optimisticSearch,
+      search,
+      setSearch,
       value,
       setValue,
       listId,
@@ -467,16 +472,11 @@ export function XDSCommandPalette<
     ],
   );
 
-  // Both optimisticSearch and optimisticResults are updated together inside
-  // the transition, so they're always in the same snapshot.
-  // showEmptyBootstrap: no query and no results — covers pending-from-empty too,
-  // since optimisticSearch stays '' while the transition runs.
-  // showEmptySearch: only shown once settled so we don't flash "No results"
-  // while the async query is still in flight.
-  const showEmptyBootstrap =
-    optimisticSearch === '' && optimisticResults.length === 0;
+  // search is only updated inside startTransition, so it stays at '' while
+  // the transition is pending — coherent with optimisticResults.
+  const showEmptyBootstrap = search === '' && optimisticResults.length === 0;
   const showEmptySearch =
-    !isPending && optimisticSearch !== '' && optimisticResults.length === 0;
+    !isPending && search !== '' && optimisticResults.length === 0;
 
   let listContent: ReactNode;
   if (showEmptyBootstrap) {

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -357,6 +357,10 @@ export function XDSCommandPalette<
   // Unified search effect: bootstrap on open or empty query, search otherwise.
   // Wrapped in startTransition so the current optimisticResults remain visible
   // while the new query is in flight — no blank flash between queries.
+  //
+  // While pending, we immediately client-filter the previous result set by the
+  // current query so something relevant shows up rather than holding stale results
+  // verbatim. The async source result replaces this once it resolves.
   useEffect(() => {
     if (!isOpen) return;
 
@@ -365,11 +369,20 @@ export function XDSCommandPalette<
 
     startTransition(async () => {
       const isBootstrap = search === '';
+
+      // Optimistically narrow the previous results while the real query is in flight
+      if (!isBootstrap) {
+        const lower = search.toLowerCase().trim();
+        const optimistic = searchResults.filter(item =>
+          item.label.toLowerCase().includes(lower),
+        );
+        setOptimisticResults(optimistic);
+      }
+
       const result = isBootstrap
         ? searchSource.bootstrap()
         : searchSource.search(search);
 
-      // Show stale results while waiting
       const items = await Promise.resolve(result);
 
       if (searchVersionRef.current === version) {

--- a/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPalette.tsx
@@ -279,17 +279,17 @@ export function XDSCommandPalette<
   maxHeight = 480,
 }: XDSCommandPaletteProps<T>) {
   const listId = useId();
+  // search: the committed query — only advances when async results arrive.
+  // optimisticSearch: updates immediately on keystroke, drives input + empty state.
+  // This way optimisticSearch is always what the user sees, and search is what
+  // the current results actually correspond to.
   const [search, setSearch] = useState('');
   const [internalValue, setInternalValue] = useState('');
   const [searchResults, setSearchResults] = useState<T[]>([]);
   const [isPending, startTransition] = useTransition();
-  // optimisticResults: previous results stay visible while a new query is in flight
+  const [optimisticSearch, setOptimisticSearch] = useOptimistic(search);
   const [optimisticResults, setOptimisticResults] =
     useOptimistic(searchResults);
-  // optimisticSearch: lags behind real search — only advances when the transition
-  // commits. Used for empty state logic so showEmptyBootstrap stays true while
-  // the async query is pending. The input uses real search for immediate feedback.
-  const [optimisticSearch, setOptimisticSearch] = useOptimistic(search);
   const isBusy = isPending;
   const searchVersionRef = useRef(0);
 
@@ -313,6 +313,7 @@ export function XDSCommandPalette<
   );
 
   const handleClose = useCallback(() => {
+    // Reset both committed and optimistic search on close
     setSearch('');
     setSearchResults([]);
     if (controlledValue === undefined) {
@@ -356,13 +357,13 @@ export function XDSCommandPalette<
     }
   }, [isOpen, selectableItems, value, combobox]);
 
-  // Unified search effect: bootstrap on open or empty query, search otherwise.
-  // Wrapped in startTransition so the current optimisticResults remain visible
-  // while the new query is in flight — no blank flash between queries.
-  //
-  // While pending, we immediately client-filter the previous result set by the
-  // current query so something relevant shows up rather than holding stale results
-  // verbatim. The async source result replaces this once it resolves.
+  // Effect triggers on optimisticSearch (immediate) not search (committed).
+  // Inside the transition:
+  //   - Client-filter previous results for instant feedback while fetching
+  //   - Await the real async result
+  //   - Commit both search and searchResults together when done
+  // This means search always reflects what the current results correspond to,
+  // and optimisticSearch is always what the user sees.
   useEffect(() => {
     if (!isOpen) return;
 
@@ -370,33 +371,32 @@ export function XDSCommandPalette<
     const version = ++searchVersionRef.current;
 
     startTransition(async () => {
-      const isBootstrap = search === '';
+      const isBootstrap = optimisticSearch === '';
 
-      // Advance optimisticSearch to match the real query now that we're
-      // inside the transition. This keeps it coherent with optimisticResults.
-      setOptimisticSearch(search);
-
-      // Only client-filter if there are previous results to narrow.
+      // Client-filter previous results for instant narrowing while fetch is in flight
       if (!isBootstrap && searchResults.length > 0) {
-        const lower = search.toLowerCase().trim();
-        const optimistic = searchResults.filter(item =>
-          item.label.toLowerCase().includes(lower),
+        const lower = optimisticSearch.toLowerCase().trim();
+        setOptimisticResults(
+          searchResults.filter(item =>
+            item.label.toLowerCase().includes(lower),
+          ),
         );
-        setOptimisticResults(optimistic);
       }
 
       const result = isBootstrap
         ? searchSource.bootstrap()
-        : searchSource.search(search);
+        : searchSource.search(optimisticSearch);
 
       const items = await Promise.resolve(result);
 
       if (searchVersionRef.current === version) {
+        // Commit the query and results together — search now reflects the results
+        setSearch(optimisticSearch);
         setOptimisticResults(items);
         setSearchResults(items);
       }
     });
-  }, [search, isOpen, searchSource]);
+  }, [optimisticSearch, isOpen, searchSource]);
 
   // Wrap combobox's onKeyDown to intercept Escape (close palette) and
   // Enter on highlight (select + close), since we're not using combobox's
@@ -431,9 +431,9 @@ export function XDSCommandPalette<
 
   const contextValue = useMemo(
     () => ({
-      // Expose real search to the input so it reflects keystrokes immediately
-      search,
-      setSearch,
+      // Input uses optimisticSearch — reflects keystrokes immediately
+      search: optimisticSearch,
+      setSearch: setOptimisticSearch,
       value,
       setValue,
       listId,
@@ -449,8 +449,8 @@ export function XDSCommandPalette<
       isBusy,
     }),
     [
-      search,
-      setSearch,
+      optimisticSearch,
+      setOptimisticSearch,
       value,
       setValue,
       listId,
@@ -467,14 +467,13 @@ export function XDSCommandPalette<
     ],
   );
 
-  // Empty state uses optimisticSearch (lags behind real search) so that
-  // showEmptyBootstrap stays true while the transition is pending — the input
-  // already shows the typed query via real search, but the list hasn't
-  // transitioned yet so we hold at the bootstrap empty state.
-  const showEmptyBootstrap =
-    optimisticSearch === '' && optimisticResults.length === 0;
+  // Empty state uses committed search (= what current results correspond to),
+  // not optimisticSearch (= what the user typed).
+  // While the transition is pending, search stays at '' so showEmptyBootstrap
+  // remains true even after the user has started typing.
+  const showEmptyBootstrap = search === '' && optimisticResults.length === 0;
   const showEmptySearch =
-    !isPending && optimisticSearch !== '' && optimisticResults.length === 0;
+    !isPending && search !== '' && optimisticResults.length === 0;
 
   let listContent: ReactNode;
   if (showEmptyBootstrap) {

--- a/packages/lab/src/CommandPalette/XDSCommandPaletteEmpty.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPaletteEmpty.tsx
@@ -1,0 +1,57 @@
+/**
+ * @file XDSCommandPaletteEmpty.tsx
+ * @input Uses React, StyleX
+ * @output Exports XDSCommandPaletteEmpty component
+ * @position Sub-component; empty state shown when there are no items to display
+ *
+ * SYNC: When modified, update:
+ * - /packages/lab/src/CommandPalette/README.md
+ */
+
+'use client';
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  typeScaleVars,
+  typographyVars,
+} from '@xds/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  empty: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingBlock: spacingVars['--spacing-8'],
+    paddingInline: spacingVars['--spacing-4'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    color: colorVars['--color-text-secondary'],
+    textAlign: 'center' as const,
+  },
+});
+
+export interface XDSCommandPaletteEmptyProps {
+  /** The message or content to display. */
+  children: ReactNode;
+}
+
+/**
+ * Empty state for the command palette list area.
+ *
+ * Rendered automatically by XDSCommandPalette in two situations:
+ * - `emptyBootstrapText`: no search term and bootstrap() returns nothing
+ * - `emptySearchText`: a search query returned no results
+ *
+ * Can also be composed manually inside a custom render function.
+ */
+export function XDSCommandPaletteEmpty({
+  children,
+}: XDSCommandPaletteEmptyProps) {
+  return <div {...stylex.props(styles.empty)}>{children}</div>;
+}
+
+XDSCommandPaletteEmpty.displayName = 'XDSCommandPaletteEmpty';

--- a/packages/lab/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -11,7 +11,13 @@
 
 'use client';
 
-import {useCallback, useEffect, useRef, type InputHTMLAttributes} from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  type InputHTMLAttributes,
+  type ReactNode,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {XDSIcon} from '@xds/core/Icon';
@@ -41,6 +47,13 @@ const styles = stylex.create({
     alignItems: 'center',
     flexShrink: 0,
     color: colorVars['--color-text-secondary'],
+  },
+  // Groups spinner + endContent on the right with a consistent gap
+  end: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    flexShrink: 0,
   },
   input: {
     flex: 1,
@@ -90,6 +103,13 @@ export interface XDSCommandPaletteInputProps extends Omit<
    */
   hasAutoFocus?: boolean;
 
+  /**
+   * Content rendered at the trailing end of the input, after the spinner.
+   * Use for clear buttons, keyboard shortcuts, or other trailing actions.
+   * The spinner (when busy) appears immediately before this content with a 4px gap.
+   */
+  endContent?: ReactNode;
+
   /** StyleX styles for the wrapper element. */
   xstyle?: StyleXStyles;
 }
@@ -118,6 +138,7 @@ export function XDSCommandPaletteInput({
   onValueChange,
   placeholder = 'Search...',
   hasAutoFocus = true,
+  endContent,
   onChange,
   onKeyDown,
   ref,
@@ -194,11 +215,16 @@ export function XDSCommandPaletteInput({
         {...stylex.props(styles.input)}
         {...props}
       />
-      {ctx?.isBusy && (
-        <span {...stylex.props(styles.icon)}>
-          <XDSSpinner size="sm" />
+      {(ctx?.isBusy || endContent) && (
+        <span {...stylex.props(styles.end)}>
+          {ctx?.isBusy && (
+            <span {...stylex.props(styles.icon)}>
+              <XDSSpinner size="sm" />
+            </span>
+          )}
+          {endContent}
         </span>
-      )}
+      )}{' '}
     </div>
   );
 }

--- a/packages/lab/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -32,13 +32,6 @@ import {
 } from '@xds/core/theme/tokens.stylex';
 import {useCommandPaletteContext} from './CommandPaletteContext';
 
-// Keyframe for delayed fade-in — spinner only appears after 150ms
-// so it doesn't flicker on near-instant (synchronous) searches.
-const fadeIn = stylex.keyframes({
-  from: {opacity: 0},
-  to: {opacity: 1},
-});
-
 const styles = stylex.create({
   wrapper: {
     display: 'flex',
@@ -63,12 +56,16 @@ const styles = stylex.create({
     flexShrink: 0,
   },
   // Delay spinner appearance to avoid flickering on near-instant searches.
-  // The spinner fades in only if the search is still pending after 150ms.
+  // Uses @starting-style + transition-delay so the spinner only appears
+  // if the search is still pending after 150ms.
   spinner: {
-    animationName: fadeIn,
-    animationDuration: '1ms',
-    animationDelay: '150ms',
-    animationFillMode: 'both',
+    opacity: 1,
+    transitionProperty: 'opacity',
+    transitionDuration: '1ms',
+    transitionDelay: '150ms',
+    '@starting-style': {
+      opacity: 0,
+    },
   },
   input: {
     flex: 1,

--- a/packages/lab/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -170,11 +170,7 @@ export function XDSCommandPaletteInput({
         stylex.props(styles.wrapper, xstyle),
       )}>
       <span {...stylex.props(styles.icon)}>
-        {ctx?.isBusy ? (
-          <XDSSpinner size="sm" />
-        ) : (
-          <XDSIcon icon="search" size="sm" color="inherit" />
-        )}
+        <XDSIcon icon="search" size="sm" color="inherit" />
       </span>
       <input
         ref={setRefs}
@@ -198,6 +194,11 @@ export function XDSCommandPaletteInput({
         {...stylex.props(styles.input)}
         {...props}
       />
+      {ctx?.isBusy && (
+        <span {...stylex.props(styles.icon)}>
+          <XDSSpinner size="sm" />
+        </span>
+      )}
     </div>
   );
 }

--- a/packages/lab/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/lab/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -32,6 +32,13 @@ import {
 } from '@xds/core/theme/tokens.stylex';
 import {useCommandPaletteContext} from './CommandPaletteContext';
 
+// Keyframe for delayed fade-in — spinner only appears after 150ms
+// so it doesn't flicker on near-instant (synchronous) searches.
+const fadeIn = stylex.keyframes({
+  from: {opacity: 0},
+  to: {opacity: 1},
+});
+
 const styles = stylex.create({
   wrapper: {
     display: 'flex',
@@ -54,6 +61,14 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
     flexShrink: 0,
+  },
+  // Delay spinner appearance to avoid flickering on near-instant searches.
+  // The spinner fades in only if the search is still pending after 150ms.
+  spinner: {
+    animationName: fadeIn,
+    animationDuration: '1ms',
+    animationDelay: '150ms',
+    animationFillMode: 'both',
   },
   input: {
     flex: 1,
@@ -218,7 +233,7 @@ export function XDSCommandPaletteInput({
       {(ctx?.isBusy || endContent) && (
         <span {...stylex.props(styles.end)}>
           {ctx?.isBusy && (
-            <span {...stylex.props(styles.icon)}>
+            <span {...stylex.props(styles.icon, styles.spinner)}>
               <XDSSpinner size="sm" />
             </span>
           )}

--- a/packages/lab/src/CommandPalette/index.ts
+++ b/packages/lab/src/CommandPalette/index.ts
@@ -25,5 +25,8 @@ export type {XDSCommandPaletteGroupProps} from './XDSCommandPaletteGroup';
 export {XDSCommandPaletteFooter} from './XDSCommandPaletteFooter';
 export type {XDSCommandPaletteFooterProps} from './XDSCommandPaletteFooter';
 
+export {XDSCommandPaletteEmpty} from './XDSCommandPaletteEmpty';
+export type {XDSCommandPaletteEmptyProps} from './XDSCommandPaletteEmpty';
+
 export {useCommandPaletteContext} from './CommandPaletteContext';
 export type {CommandPaletteContextValue} from './CommandPaletteContext';


### PR DESCRIPTION
## Summary

Separate PR off main with API improvements to XDSCommandPalette.

## Changes

### `children` → `renderItem`
```tsx
// Before: had to reimplement grouping yourself
<XDSCommandPalette searchSource={source}>
  {items => items.map(item => <XDSCommandPaletteItem .../>)}
</XDSCommandPalette>

// After: per-item customization, grouping stays automatic
<XDSCommandPalette
  searchSource={source}
  renderItem={(item, isSelected) => (
    <><XDSIcon icon={item.auxiliaryData.icon} /> {item.label}</>
  )}
/>
```

### Default input and footer
```tsx
// Before: required
<XDSCommandPalette
  searchSource={source}
  input={<XDSCommandPaletteInput />}
  footer={<XDSCommandPaletteFooter />}
/>

// After: zero config
<XDSCommandPalette searchSource={source} />
```

### Empty states
- `emptyBootstrapText` — shown when bootstrap() returns nothing (default: `'Type to search'`)
- `emptySearchText` — shown when a search query returns no results (default: `'No results'`)

### New: `XDSCommandPaletteEmpty`
Internal component (also exported) for the empty state UI.

### ManyItems story
50 items across 5 groups to verify scroll behavior within the dialog's maxHeight constraint.

## API Diff

| Prop | Before | After |
|---|---|---|
| `children` | `(items: T[]) => ReactNode` | removed |
| `renderItem` | — | `(item: T, isSelected: boolean) => ReactNode` |
| `input` | required for input | defaults to `<XDSCommandPaletteInput />` |
| `footer` | required for footer | defaults to `<XDSCommandPaletteFooter />` |
| `emptySearchText` | — | `ReactNode`, default `'No results'` |
| `emptyBootstrapText` | — | `ReactNode`, default `'Type to search'` |

---
