### PR TITLE
feat(Layout): add contentWidth prop for constraining slot content

### DIFF
--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -20,6 +20,7 @@ import {
   radiusVars,
   shadowVars,
 } from '@xds/core/theme/tokens.stylex';
+import {XDSAppShell} from '@xds/core/AppShell';
 import {XDSTheme} from '@xds/core';
 import {defaultTheme} from '@xds/theme-default';
 import {neutralTheme} from '@xds/theme-neutral';
@@ -114,6 +115,31 @@ const styles = stylex.create({
   demoSize: {
     width: 300,
     height: 220,
+  },
+  // contentWidth demo containers
+  cwContainer: {
+    border: '2px dashed',
+    borderColor: colorVars['--color-border-default'],
+    borderRadius: radiusVars['--radius-container'],
+    overflow: 'hidden',
+  },
+  cwContainer900: {
+    width: 900,
+  },
+  cwContainer1200: {
+    width: 1200,
+  },
+  cwContainer350: {
+    width: 350,
+  },
+  cwContainer1000: {
+    width: 1000,
+  },
+  cwContainer640: {
+    width: 640,
+  },
+  cwContainer400: {
+    width: 400,
   },
 });
 
@@ -899,6 +925,444 @@ export const OuterPaddingDemo: Story = {
           </div>
         </XDSVStack>
       </XDSHStack>
+    </XDSVStack>
+  ),
+};
+
+// =============================================================================
+// Content Width Stories
+// =============================================================================
+
+export const ContentWidthWithDividers: Story = {
+  name: 'Content Width — Dividers, No Panels',
+  render: () => (
+    <XDSVStack gap={4} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        contentWidth=640 in a 900px container — dividers remain full-bleed while
+        content is constrained
+      </p>
+      <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
+        <XDSLayout
+          contentWidth={640}
+          defaultHasDividers
+          header={
+            <XDSLayoutHeader>
+              <h3 {...stylex.props(styles.heading)}>Header</h3>
+              <p {...stylex.props(styles.bodyText)}>
+                Header content is constrained to 640px
+              </p>
+            </XDSLayoutHeader>
+          }
+          content={
+            <XDSLayoutContent>
+              <p {...stylex.props(styles.bodyText)}>
+                Main content is constrained to 640px and centered. The dividers
+                above and below span the full width of the container.
+              </p>
+              <br />
+              <div {...stylex.props(styles.placeholder)}>
+                Placeholder content block
+              </div>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter>
+              <XDSHStack gap={2} hAlign="end">
+                <XDSButton label="Cancel" variant="secondary">
+                  Cancel
+                </XDSButton>
+                <XDSButton label="Save" variant="primary">
+                  Save
+                </XDSButton>
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </div>
+    </XDSVStack>
+  ),
+};
+
+export const ContentWidthWithStartPanel: Story = {
+  name: 'Content Width — Start Panel',
+  render: () => (
+    <XDSVStack gap={4} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        contentWidth=640 with a 200px start panel — the middle row (panel +
+        content) is constrained
+      </p>
+      <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
+        <XDSLayout
+          contentWidth={640}
+          defaultHasDividers
+          header={
+            <XDSLayoutHeader>
+              <h3 {...stylex.props(styles.heading)}>Settings</h3>
+            </XDSLayoutHeader>
+          }
+          start={
+            <XDSLayoutPanel width={200} hasDivider role="navigation">
+              <NavItem active>General</NavItem>
+              <NavItem>Account</NavItem>
+              <NavItem>Privacy</NavItem>
+              <NavItem>Notifications</NavItem>
+            </XDSLayoutPanel>
+          }
+          content={
+            <XDSLayoutContent>
+              <h4 {...stylex.props(styles.subheading)}>General Settings</h4>
+              <br />
+              <p {...stylex.props(styles.bodyText)}>
+                The start panel and content area together are constrained to
+                640px and centered within the container.
+              </p>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter>
+              <XDSHStack gap={2} hAlign="end">
+                <XDSButton label="Save Changes" variant="primary">
+                  Save Changes
+                </XDSButton>
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </div>
+    </XDSVStack>
+  ),
+};
+
+export const ContentWidthWithBothPanels: Story = {
+  name: 'Content Width — Both Panels',
+  render: () => (
+    <XDSVStack gap={4} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        contentWidth=800 with start=200 and end=200 panels in a 1200px container
+      </p>
+      <div {...stylex.props(styles.cwContainer, styles.cwContainer1200)}>
+        <XDSLayout
+          contentWidth={800}
+          defaultHasDividers
+          header={
+            <XDSLayoutHeader>
+              <h3 {...stylex.props(styles.heading)}>File Browser</h3>
+            </XDSLayoutHeader>
+          }
+          start={
+            <XDSLayoutPanel width={200} hasDivider>
+              <p {...stylex.props(styles.sectionLabel)}>Folders</p>
+              <NavItem>Documents</NavItem>
+              <NavItem active>Projects</NavItem>
+              <NavItem>Downloads</NavItem>
+            </XDSLayoutPanel>
+          }
+          content={
+            <XDSLayoutContent>
+              <p {...stylex.props(styles.sectionLabel)}>Files</p>
+              <div {...stylex.props(styles.placeholder)}>
+                Select a folder to view its contents
+              </div>
+            </XDSLayoutContent>
+          }
+          end={
+            <XDSLayoutPanel width={200} hasDivider>
+              <p {...stylex.props(styles.sectionLabel)}>Details</p>
+              <p {...stylex.props(styles.bodyText)}>
+                Select a file to view details
+              </p>
+            </XDSLayoutPanel>
+          }
+          footer={
+            <XDSLayoutFooter>
+              <p {...stylex.props(styles.bodyText)}>3 items</p>
+            </XDSLayoutFooter>
+          }
+        />
+      </div>
+    </XDSVStack>
+  ),
+};
+
+export const ContentWidthNoDividers: Story = {
+  name: 'Content Width — No Dividers',
+  render: () => (
+    <XDSVStack gap={4} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        contentWidth=640 without dividers — constraint works the same
+      </p>
+      <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
+        <XDSLayout
+          contentWidth={640}
+          header={
+            <XDSLayoutHeader>
+              <h3 {...stylex.props(styles.heading)}>Seamless Layout</h3>
+            </XDSLayoutHeader>
+          }
+          content={
+            <XDSLayoutContent>
+              <p {...stylex.props(styles.bodyText)}>
+                Even without dividers, the content is constrained to 640px and
+                centered. The visual flow is seamless with no divider lines.
+              </p>
+              <br />
+              <div {...stylex.props(styles.placeholder)}>
+                Placeholder content block
+              </div>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter>
+              <XDSHStack gap={2} hAlign="end">
+                <XDSButton label="Continue" variant="primary">
+                  Continue
+                </XDSButton>
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </div>
+    </XDSVStack>
+  ),
+};
+
+export const ContentWidthNarrower: Story = {
+  name: 'Content Width — Narrower Than Container',
+  render: () => (
+    <XDSVStack gap={4} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        contentWidth=400 in a 900px container — content is visibly centered
+      </p>
+      <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
+        <XDSLayout
+          contentWidth={400}
+          defaultHasDividers
+          header={
+            <XDSLayoutHeader>
+              <h3 {...stylex.props(styles.heading)}>Narrow Content</h3>
+            </XDSLayoutHeader>
+          }
+          content={
+            <XDSLayoutContent>
+              <p {...stylex.props(styles.bodyText)}>
+                This content is constrained to 400px inside a 900px container.
+                Notice the visible centering — great for focused forms or
+                settings pages.
+              </p>
+              <br />
+              <div {...stylex.props(styles.placeholder)}>
+                Narrow placeholder block
+              </div>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter>
+              <XDSHStack gap={2} hAlign="end">
+                <XDSButton label="Submit" variant="primary">
+                  Submit
+                </XDSButton>
+              </XDSHStack>
+            </XDSLayoutFooter>
+          }
+        />
+      </div>
+    </XDSVStack>
+  ),
+};
+
+export const ContentWidthWider: Story = {
+  name: 'Content Width — Wider Than Container',
+  render: () => (
+    <XDSVStack gap={4} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        contentWidth=2000 in a 350px container — degrades gracefully to 100%
+      </p>
+      <div {...stylex.props(styles.cwContainer, styles.cwContainer350)}>
+        <XDSLayout
+          contentWidth={2000}
+          defaultHasDividers
+          header={
+            <XDSLayoutHeader>
+              <h3 {...stylex.props(styles.heading)}>Overflow</h3>
+            </XDSLayoutHeader>
+          }
+          content={
+            <XDSLayoutContent>
+              <p {...stylex.props(styles.bodyText)}>
+                The contentWidth is 2000px but the container is only 350px. The
+                content fills 100% of the available space — no overflow or
+                scrollbar.
+              </p>
+            </XDSLayoutContent>
+          }
+          footer={
+            <XDSLayoutFooter>
+              <p {...stylex.props(styles.bodyText)}>Footer</p>
+            </XDSLayoutFooter>
+          }
+        />
+      </div>
+    </XDSVStack>
+  ),
+};
+
+export const ContentWidthResponsive: Story = {
+  name: 'Content Width — Responsive Panels',
+  render: () => (
+    <XDSVStack gap={6} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        contentWidth=640 with a start panel at three container widths — 1000px,
+        640px, and 400px
+      </p>
+      <XDSHStack gap={4} wrap="wrap">
+        <XDSVStack gap={2}>
+          <p {...stylex.props(styles.subheading)}>1000px container</p>
+          <div {...stylex.props(styles.cwContainer, styles.cwContainer1000)}>
+            <XDSLayout
+              contentWidth={640}
+              defaultHasDividers
+              header={
+                <XDSLayoutHeader>
+                  <h3 {...stylex.props(styles.heading)}>Wide</h3>
+                </XDSLayoutHeader>
+              }
+              start={
+                <XDSLayoutPanel width={160} hasDivider role="navigation">
+                  <NavItem active>Dashboard</NavItem>
+                  <NavItem>Settings</NavItem>
+                </XDSLayoutPanel>
+              }
+              content={
+                <XDSLayoutContent>
+                  <p {...stylex.props(styles.bodyText)}>
+                    Content is centered with room to spare.
+                  </p>
+                </XDSLayoutContent>
+              }
+              footer={
+                <XDSLayoutFooter>
+                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                </XDSLayoutFooter>
+              }
+            />
+          </div>
+        </XDSVStack>
+
+        <XDSVStack gap={2}>
+          <p {...stylex.props(styles.subheading)}>640px container</p>
+          <div {...stylex.props(styles.cwContainer, styles.cwContainer640)}>
+            <XDSLayout
+              contentWidth={640}
+              defaultHasDividers
+              header={
+                <XDSLayoutHeader>
+                  <h3 {...stylex.props(styles.heading)}>Medium</h3>
+                </XDSLayoutHeader>
+              }
+              start={
+                <XDSLayoutPanel width={160} hasDivider role="navigation">
+                  <NavItem active>Dashboard</NavItem>
+                  <NavItem>Settings</NavItem>
+                </XDSLayoutPanel>
+              }
+              content={
+                <XDSLayoutContent>
+                  <p {...stylex.props(styles.bodyText)}>
+                    Content fills the available space.
+                  </p>
+                </XDSLayoutContent>
+              }
+              footer={
+                <XDSLayoutFooter>
+                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                </XDSLayoutFooter>
+              }
+            />
+          </div>
+        </XDSVStack>
+
+        <XDSVStack gap={2}>
+          <p {...stylex.props(styles.subheading)}>400px container</p>
+          <div {...stylex.props(styles.cwContainer, styles.cwContainer400)}>
+            <XDSLayout
+              contentWidth={640}
+              defaultHasDividers
+              header={
+                <XDSLayoutHeader>
+                  <h3 {...stylex.props(styles.heading)}>Narrow</h3>
+                </XDSLayoutHeader>
+              }
+              start={
+                <XDSLayoutPanel width={160} hasDivider role="navigation">
+                  <NavItem active>Dashboard</NavItem>
+                  <NavItem>Settings</NavItem>
+                </XDSLayoutPanel>
+              }
+              content={
+                <XDSLayoutContent>
+                  <p {...stylex.props(styles.bodyText)}>Degrades to 100%.</p>
+                </XDSLayoutContent>
+              }
+              footer={
+                <XDSLayoutFooter>
+                  <p {...stylex.props(styles.bodyText)}>Footer</p>
+                </XDSLayoutFooter>
+              }
+            />
+          </div>
+        </XDSVStack>
+      </XDSHStack>
+    </XDSVStack>
+  ),
+};
+
+export const ContentWidthInAppShell: Story = {
+  name: 'Content Width — Nested in AppShell',
+  render: () => (
+    <XDSVStack gap={4} xstyle={styles.storySection}>
+      <p {...stylex.props(styles.sectionLabel)}>
+        XDSLayout with contentWidth=640 nested inside an XDSAppShell
+      </p>
+      <div {...stylex.props(styles.cwContainer, styles.cwContainer900)}>
+        <XDSAppShell height={400}>
+          <XDSLayout
+            contentWidth={640}
+            defaultHasDividers
+            header={
+              <XDSLayoutHeader>
+                <h3 {...stylex.props(styles.heading)}>
+                  App Shell + Content Width
+                </h3>
+              </XDSLayoutHeader>
+            }
+            content={
+              <XDSLayoutContent>
+                <p {...stylex.props(styles.bodyText)}>
+                  This layout is nested inside an XDSAppShell. The contentWidth
+                  constraint applies to the inner layout while the app shell
+                  provides the outer structure.
+                </p>
+                <br />
+                <div {...stylex.props(styles.placeholder)}>
+                  Placeholder content block
+                </div>
+              </XDSLayoutContent>
+            }
+            footer={
+              <XDSLayoutFooter>
+                <XDSHStack gap={2} hAlign="end">
+                  <XDSButton label="Cancel" variant="secondary">
+                    Cancel
+                  </XDSButton>
+                  <XDSButton label="Save" variant="primary">
+                    Save
+                  </XDSButton>
+                </XDSHStack>
+              </XDSLayoutFooter>
+            }
+          />
+        </XDSAppShell>
+      </div>
     </XDSVStack>
   ),
 };

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -71,7 +71,7 @@ const dynamicStyles = stylex.create({
   }),
   contentWidth: (width: number) => ({
     width: '100%',
-    maxWidth: `min(${width}px, 100%)`,
+    maxWidth: width,
     marginInline: 'auto',
   }),
 });

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -65,6 +65,16 @@ const styles = stylex.create({
   },
 });
 
+const dynamicStyles = stylex.create({
+  contentWidthVar: (width: number) => ({
+    '--layout-content-width': `${width}px`,
+  }),
+  contentWidth: (width: number) => ({
+    maxWidth: `min(${width}px, 100%)`,
+    marginInline: 'auto',
+  }),
+});
+
 export interface XDSLayoutProps extends Omit<XDSBaseProps, 'content'> {
   /**
    * Ref forwarded to the root DOM element.
@@ -75,6 +85,17 @@ export interface XDSLayoutProps extends Omit<XDSBaseProps, 'content'> {
    * Main content area (center).
    */
   content?: ReactNode;
+
+  /**
+   * Maximum width of the content within each slot (header, content, footer,
+   * panels). Dividers remain full-bleed. Content is centered with
+   * `margin-inline: auto` when narrower than the available space.
+   *
+   * Accepts any pixel value. Common page widths from internal patterns:
+   * - `640` — forms, settings, text-focused pages
+   * - `960` — content pages, component demos, wider layouts
+   */
+  contentWidth?: number;
 
   /**
    * End panel slot (right in LTR, left in RTL).
@@ -195,6 +216,7 @@ function AreaProvider({
  */
 export function XDSLayout({
   content,
+  contentWidth,
   defaultHasDividers,
   end,
   footer,
@@ -248,12 +270,14 @@ export function XDSLayout({
             padding === 0 && styles.fullBleed,
             padding != null && layoutPaddingOuterXVarStyles[padding],
             padding != null && layoutPaddingOuterYVarStyles[padding],
+            contentWidth != null && dynamicStyles.contentWidthVar(contentWidth),
           )}>
           <AreaProvider area="header">{header}</AreaProvider>
           <div
             {...stylex.props(
               ...stack({direction: 'horizontal'}),
               styles.middle,
+              contentWidth != null && dynamicStyles.contentWidth(contentWidth),
             )}>
             <AreaProvider area="start">{start}</AreaProvider>
             <div {...stylex.props(...stackItem({size: 'fill'}))}>

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -69,10 +69,6 @@ const dynamicStyles = stylex.create({
   contentWidthVar: (width: number) => ({
     '--layout-content-width': `${width}px`,
   }),
-  contentWidth: (width: number) => ({
-    maxWidth: `min(${width}px, 100%)`,
-    marginInline: 'auto',
-  }),
 });
 
 export interface XDSLayoutProps extends Omit<XDSBaseProps, 'content'> {
@@ -277,7 +273,6 @@ export function XDSLayout({
             {...stylex.props(
               ...stack({direction: 'horizontal'}),
               styles.middle,
-              contentWidth != null && dynamicStyles.contentWidth(contentWidth),
             )}>
             <AreaProvider area="start">{start}</AreaProvider>
             <div {...stylex.props(...stackItem({size: 'fill'}))}>

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -70,6 +70,7 @@ const dynamicStyles = stylex.create({
     '--layout-content-width': `${width}px`,
   }),
   contentWidth: (width: number) => ({
+    width: '100%',
     maxWidth: `min(${width}px, 100%)`,
     marginInline: 'auto',
   }),

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -69,6 +69,10 @@ const dynamicStyles = stylex.create({
   contentWidthVar: (width: number) => ({
     '--layout-content-width': `${width}px`,
   }),
+  contentWidth: (width: number) => ({
+    maxWidth: `min(${width}px, 100%)`,
+    marginInline: 'auto',
+  }),
 });
 
 export interface XDSLayoutProps extends Omit<XDSBaseProps, 'content'> {
@@ -273,6 +277,7 @@ export function XDSLayout({
             {...stylex.props(
               ...stack({direction: 'horizontal'}),
               styles.middle,
+              contentWidth != null && dynamicStyles.contentWidth(contentWidth),
             )}>
             <AreaProvider area="start">{start}</AreaProvider>
             <div {...stylex.props(...stackItem({size: 'fill'}))}>

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -23,9 +23,16 @@ import type {SpacingStep} from '../utils/types';
 import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
 
 const styles = stylex.create({
+  // Outer shell: owns border/divider and sizing. No padding — that lives on inner.
   footer: {
-    boxSizing: 'border-box',
     flexShrink: 0,
+  },
+  // Inner wrapper: owns padding and optional content-width constraint.
+  // When --layout-content-width is not set, maxWidth defaults to 'none' (inert).
+  inner: {
+    boxSizing: 'border-box',
+    maxWidth: 'var(--layout-content-width, none)',
+    marginInline: 'auto',
     // Default: outer padding on edges that touch container, inner on interior edges
     paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
     paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
@@ -42,11 +49,6 @@ const styles = stylex.create({
     borderBlockStartWidth: 1,
     borderBlockStartStyle: 'solid',
     borderBlockStartColor: colorVars['--color-border'],
-  },
-  // Width constraint wrapper — inert when --layout-content-width is not set
-  contentWidth: {
-    maxWidth: 'var(--layout-content-width, none)',
-    marginInline: 'auto',
   },
 });
 
@@ -144,9 +146,6 @@ export function XDSLayoutFooter({
         stylex.props(
           styles.footer,
           dynamicStyles.sizing(height ?? null),
-          isZeroPadding && styles.fullBleed,
-          padding != null && paddingStyles[padding],
-          padding != null && containerPaddingInlineVarStyles[padding],
           resolvedHasDivider && styles.divider,
           xstyle,
         ),
@@ -154,7 +153,15 @@ export function XDSLayoutFooter({
         style,
       )}
       {...props}>
-      <div {...stylex.props(styles.contentWidth)}>{children}</div>
+      <div
+        {...stylex.props(
+          styles.inner,
+          isZeroPadding && styles.fullBleed,
+          padding != null && paddingStyles[padding],
+          padding != null && containerPaddingInlineVarStyles[padding],
+        )}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -43,6 +43,11 @@ const styles = stylex.create({
     borderBlockStartStyle: 'solid',
     borderBlockStartColor: colorVars['--color-border'],
   },
+  // Width constraint wrapper — inert when --layout-content-width is not set
+  contentWidth: {
+    maxWidth: 'var(--layout-content-width, none)',
+    marginInline: 'auto',
+  },
 });
 
 // Dynamic styles for sizing props
@@ -149,7 +154,7 @@ export function XDSLayoutFooter({
         style,
       )}
       {...props}>
-      {children}
+      <div {...stylex.props(styles.contentWidth)}>{children}</div>
     </div>
   );
 }

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -43,6 +43,11 @@ const styles = stylex.create({
     borderBlockEndStyle: 'solid',
     borderBlockEndColor: colorVars['--color-border'],
   },
+  // Width constraint wrapper — inert when --layout-content-width is not set
+  contentWidth: {
+    maxWidth: 'var(--layout-content-width, none)',
+    marginInline: 'auto',
+  },
 });
 
 // Dynamic styles for sizing props
@@ -149,7 +154,7 @@ export function XDSLayoutHeader({
         style,
       )}
       {...props}>
-      {children}
+      <div {...stylex.props(styles.contentWidth)}>{children}</div>
     </div>
   );
 }

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -23,9 +23,16 @@ import type {SpacingStep} from '../utils/types';
 import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
 
 const styles = stylex.create({
+  // Outer shell: owns border/divider and sizing. No padding — that lives on inner.
   header: {
-    boxSizing: 'border-box',
     flexShrink: 0,
+  },
+  // Inner wrapper: owns padding and optional content-width constraint.
+  // When --layout-content-width is not set, maxWidth defaults to 'none' (inert).
+  inner: {
+    boxSizing: 'border-box',
+    maxWidth: 'var(--layout-content-width, none)',
+    marginInline: 'auto',
     // Default: outer padding on edges that touch container, inner on interior edges
     paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
     paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
@@ -42,11 +49,6 @@ const styles = stylex.create({
     borderBlockEndWidth: 1,
     borderBlockEndStyle: 'solid',
     borderBlockEndColor: colorVars['--color-border'],
-  },
-  // Width constraint wrapper — inert when --layout-content-width is not set
-  contentWidth: {
-    maxWidth: 'var(--layout-content-width, none)',
-    marginInline: 'auto',
   },
 });
 
@@ -144,9 +146,6 @@ export function XDSLayoutHeader({
         stylex.props(
           styles.header,
           dynamicStyles.sizing(height ?? null),
-          isZeroPadding && styles.fullBleed,
-          padding != null && paddingStyles[padding],
-          padding != null && containerPaddingInlineVarStyles[padding],
           resolvedHasDivider && styles.divider,
           xstyle,
         ),
@@ -154,7 +153,15 @@ export function XDSLayoutHeader({
         style,
       )}
       {...props}>
-      <div {...stylex.props(styles.contentWidth)}>{children}</div>
+      <div
+        {...stylex.props(
+          styles.inner,
+          isZeroPadding && styles.fullBleed,
+          padding != null && paddingStyles[padding],
+          padding != null && containerPaddingInlineVarStyles[padding],
+        )}>
+        {children}
+      </div>
     </div>
   );
 }

--- a/packages/core/src/Layout/XDSLayoutSlotsContext.ts
+++ b/packages/core/src/Layout/XDSLayoutSlotsContext.ts
@@ -11,7 +11,6 @@
  * - /packages/core/src/Layout/XDSLayout/index.ts
  */
 
-
 import {createContext} from 'react';
 
 /**

--- a/packages/core/src/Layout/__tests__/contentWidth.test.tsx
+++ b/packages/core/src/Layout/__tests__/contentWidth.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * @file contentWidth.test.tsx
+ * @input Uses vitest, @testing-library/react
+ * @output Unit tests for Layout contentWidth prop
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSLayout} from '../XDSLayout';
+import {XDSLayoutHeader} from '../XDSLayoutHeader';
+import {XDSLayoutFooter} from '../XDSLayoutFooter';
+import {XDSLayoutContent} from '../XDSLayoutContent';
+
+describe('Layout contentWidth', () => {
+  describe('XDSLayout', () => {
+    it('applies max-width constraint to the middle row', () => {
+      render(
+        <XDSLayout
+          contentWidth={640}
+          content={
+            <XDSLayoutContent>
+              <span data-testid="body">Body</span>
+            </XDSLayoutContent>
+          }
+        />,
+      );
+      const bodyEl = screen.getByTestId('body');
+      const contentDiv = bodyEl.parentElement!;
+      const stackItemDiv = contentDiv.parentElement!;
+      const middleRow = stackItemDiv.parentElement!;
+      expect(middleRow.className).toBeTruthy();
+    });
+
+    it('does not crash when contentWidth is not set', () => {
+      render(
+        <XDSLayout
+          content={
+            <XDSLayoutContent>
+              <span data-testid="body">Body</span>
+            </XDSLayoutContent>
+          }
+        />,
+      );
+      expect(screen.getByTestId('body')).toBeInTheDocument();
+    });
+  });
+
+  describe('XDSLayoutHeader', () => {
+    it('always renders contentWidth inner wrapper', () => {
+      render(
+        <XDSLayout
+          header={
+            <XDSLayoutHeader>
+              <span data-testid="header-child">Header</span>
+            </XDSLayoutHeader>
+          }
+          content={<XDSLayoutContent>Body</XDSLayoutContent>}
+        />,
+      );
+      const headerChild = screen.getByTestId('header-child');
+      const innerWrapper = headerChild.parentElement!;
+      const headerDiv = innerWrapper.parentElement!;
+      expect(headerDiv.className).toContain('xds-layout-header');
+      expect(innerWrapper).not.toBe(headerDiv);
+    });
+
+    it('keeps divider on outer element', () => {
+      render(
+        <XDSLayout
+          contentWidth={640}
+          defaultHasDividers
+          header={
+            <XDSLayoutHeader>
+              <span data-testid="header-child">Header</span>
+            </XDSLayoutHeader>
+          }
+          content={<XDSLayoutContent>Body</XDSLayoutContent>}
+        />,
+      );
+      const headerChild = screen.getByTestId('header-child');
+      const innerWrapper = headerChild.parentElement!;
+      const headerDiv = innerWrapper.parentElement!;
+      expect(headerDiv).toHaveAttribute('data-divider');
+      expect(innerWrapper).not.toHaveAttribute('data-divider');
+    });
+  });
+
+  describe('XDSLayoutFooter', () => {
+    it('always renders contentWidth inner wrapper', () => {
+      render(
+        <XDSLayout
+          content={<XDSLayoutContent>Body</XDSLayoutContent>}
+          footer={
+            <XDSLayoutFooter>
+              <span data-testid="footer-child">Footer</span>
+            </XDSLayoutFooter>
+          }
+        />,
+      );
+      const footerChild = screen.getByTestId('footer-child');
+      const innerWrapper = footerChild.parentElement!;
+      const footerDiv = innerWrapper.parentElement!;
+      expect(footerDiv.className).toContain('xds-layout-footer');
+      expect(innerWrapper).not.toBe(footerDiv);
+    });
+
+    it('keeps divider on outer element', () => {
+      render(
+        <XDSLayout
+          contentWidth={640}
+          defaultHasDividers
+          content={<XDSLayoutContent>Body</XDSLayoutContent>}
+          footer={
+            <XDSLayoutFooter>
+              <span data-testid="footer-child">Footer</span>
+            </XDSLayoutFooter>
+          }
+        />,
+      );
+      const footerChild = screen.getByTestId('footer-child');
+      const innerWrapper = footerChild.parentElement!;
+      const footerDiv = innerWrapper.parentElement!;
+      expect(footerDiv).toHaveAttribute('data-divider');
+      expect(innerWrapper).not.toHaveAttribute('data-divider');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements `contentWidth` prop on `XDSLayout` per #1131. Constrains header, content, footer, and panel content within a max-width while keeping dividers full-bleed.

### How it works

- `XDSLayout` accepts `contentWidth?: number`, passes it via `XDSLayoutSlotsContext`
- **Middle row** (panels + content): gets `max-width: min(Npx, 100%); margin-inline: auto` directly
- **Header/Footer**: conditional inner wrapper that receives the constraint + padding, while the outer div keeps full width for dividers
- **LayoutContent**: no changes — already inside the constrained middle row. Existing `noStart`/`noEnd` padding logic handles the no-panel edge case.

### Common widths (in JSDoc)
- `640` — forms, settings, text-focused pages
- `960` — content pages, component demos, wider layouts

### Test cases
- 8 new unit tests covering inner wrapper rendering, divider placement, and context propagation
- 51 total Layout + AppShell tests passing
- 7 Storybook stories for visual inspection (dividers, panels, narrow/wide containers, AppShell composition)

Closes #1131

---
