### PR TITLE
hardening: component audit 2026-04-05 (EmptyState xdsClassName + use-client directive fixes)

### DIFF
--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -1,3 +1,4 @@
+'use client';
 /**
  * @file XDSCodeBlock.tsx
  * @input Uses React, StyleX, theme tokens, CSS Custom Highlight API
@@ -9,8 +10,6 @@
  * - /packages/core/src/CodeBlock/tokenizer.ts (shared tokenizer)
  * - /packages/core/src/CodeBlock/highlightStyles.ts (::highlight rules)
  */
-
-'use client';
 
 import {
   useLayoutEffect,
@@ -410,7 +409,8 @@ export function XDSCodeBlock({
 
   const sizeStyle = size === 'sm' ? styles.sizeSm : styles.sizeMd;
   const gutterSizeStyle = size === 'sm' ? styles.gutterSm : styles.gutterMd;
-  const languageLabel = hasLanguageLabel && language !== 'plaintext' ? language : null;
+  const languageLabel =
+    hasLanguageLabel && language !== 'plaintext' ? language : null;
   const showHeader = title != null || languageLabel != null;
 
   const scrollStyle: React.CSSProperties | undefined = maxHeight
@@ -418,9 +418,30 @@ export function XDSCodeBlock({
     : undefined;
 
   const copyIcon = copied ? (
-    <svg width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><path d="M5 13l4 4L19 7" /></svg>
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round">
+      <path d="M5 13l4 4L19 7" />
+    </svg>
   ) : (
-    <svg width="1em" height="1em" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} strokeLinecap="round" strokeLinejoin="round"><path d="M8 4v12a2 2 0 002 2h8a2 2 0 002-2V7.242a2 2 0 00-.602-1.43L16.083 2.57A2 2 0 0014.685 2H10a2 2 0 00-2 2z" /><path d="M16 18v2a2 2 0 01-2 2H6a2 2 0 01-2-2V9a2 2 0 012-2h2" /></svg>
+    <svg
+      width="1em"
+      height="1em"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round">
+      <path d="M8 4v12a2 2 0 002 2h8a2 2 0 002-2V7.242a2 2 0 00-.602-1.43L16.083 2.57A2 2 0 0014.685 2H10a2 2 0 00-2 2z" />
+      <path d="M16 18v2a2 2 0 01-2 2H6a2 2 0 01-2-2V9a2 2 0 012-2h2" />
+    </svg>
   );
 
   const copyButtonEl = hasCopyButton ? (

--- a/packages/core/src/CommandPalette/CommandPaletteContext.ts
+++ b/packages/core/src/CommandPalette/CommandPaletteContext.ts
@@ -1,3 +1,4 @@
+'use client';
 /**
  * @file CommandPaletteContext.ts
  * @input Uses React createContext

--- a/packages/core/src/CommandPalette/XDSCommandPalette.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPalette.tsx
@@ -1,3 +1,4 @@
+'use client';
 /**
  * @file XDSCommandPalette.tsx
  * @input Uses React, XDSDialog, XDSLayout, CommandPaletteContext, XDSSearchSource, useCombobox
@@ -8,8 +9,6 @@
  * - /packages/lab/src/CommandPalette/README.md
  * - /apps/storybook/stories/CommandPalette.stories.tsx
  */
-
-'use client';
 
 import {
   useCallback,

--- a/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteInput.tsx
@@ -1,3 +1,4 @@
+'use client';
 /**
  * @file XDSCommandPaletteInput.tsx
  * @input Uses React, StyleX, XDSIcon, CommandPaletteContext
@@ -8,8 +9,6 @@
  * - /packages/lab/src/CommandPalette/README.md
  * - /apps/storybook/stories/CommandPalette.stories.tsx
  */
-
-'use client';
 
 import {
   useCallback,

--- a/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
+++ b/packages/core/src/CommandPalette/XDSCommandPaletteItem.tsx
@@ -1,3 +1,4 @@
+'use client';
 /**
  * @file XDSCommandPaletteItem.tsx
  * @input Uses React, StyleX, CommandPaletteContext
@@ -7,8 +8,6 @@
  * SYNC: When modified, update:
  * - /packages/lab/src/CommandPalette/README.md
  */
-
-'use client';
 
 import {useCallback, useEffect, useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';

--- a/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/XDSDropdownMenu.tsx
@@ -45,6 +45,9 @@ import {xdsClassName, mergeProps} from '../utils';
  * Size-aware item padding.
  * sm triggers → tighter vertical padding (4px block, 8px inline)
  * md/lg triggers → standard padding (8px all around, inherited from base item style)
+ *
+ * Note: menuSize is passed to xdsClassName on the item wrapper so themes
+ * can target `.xds-dropdown-menu-item[data-size="sm"]` etc.
  */
 const itemSizeStyles = stylex.create({
   sm: {
@@ -536,11 +539,14 @@ export function XDSDropdownMenu({
           aria-disabled={item.isDisabled}
           onClick={() => handleItemClick(item)}
           onMouseEnter={() => handleItemMouseEnter(item, flatIndex)}
-          {...stylex.props(
-            styles.item,
-            itemSizeStyles[menuSize],
-            isHighlighted && styles.itemHighlighted,
-            item.isDisabled && styles.itemDisabled,
+          {...mergeProps(
+            xdsClassName('dropdown-menu-item', {size: menuSize}),
+            stylex.props(
+              styles.item,
+              itemSizeStyles[menuSize],
+              isHighlighted && styles.itemHighlighted,
+              item.isDisabled && styles.itemDisabled,
+            ),
           )}>
           {children ? children(item) : <DefaultItem item={item} />}
         </div>

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -13,13 +13,13 @@
 
 import {type ReactNode, createElement} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
   fontWeightVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 const styles = stylex.create({
@@ -78,7 +78,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSEmptyStateProps {
+export interface XDSEmptyStateProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
@@ -110,31 +110,6 @@ export interface XDSEmptyStateProps {
    * @default false
    */
   isCompact?: boolean;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
-  /**
-   * Test ID for the container element.
-   */
-  'data-testid'?: string;
 }
 
 /**

--- a/packages/core/src/EmptyState/XDSEmptyState.tsx
+++ b/packages/core/src/EmptyState/XDSEmptyState.tsx
@@ -177,7 +177,7 @@ export function XDSEmptyState({
       ref={ref}
       role="status"
       {...mergeProps(
-        xdsClassName('emptystate'),
+        xdsClassName('emptystate', {variant: isCompact ? 'compact' : null}),
         stylex.props(
           styles.container,
           isCompact && styles.containerCompact,

--- a/packages/core/src/Table/XDSBaseTable.tsx
+++ b/packages/core/src/Table/XDSBaseTable.tsx
@@ -1,3 +1,4 @@
+'use client';
 /**
  * @file XDSBaseTable.tsx
  * @input React, types.ts, columnUtils.ts

--- a/packages/core/src/hooks/useEntryAnimation.ts
+++ b/packages/core/src/hooks/useEntryAnimation.ts
@@ -1,3 +1,4 @@
+'use client';
 /**
  * @file useEntryAnimation.ts
  * @input Uses React, StyleX, theme tokens
@@ -8,8 +9,6 @@
  * Only animates when the element is dynamically mounted after the initial
  * page paint — statically rendered elements on page load are not animated.
  */
-
-'use client';
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';


### PR DESCRIPTION
## Component Audit — 2026-04-05

Audited: **DropdownMenu, EmptyState, Field, FormLayout, Grid**

---

## Fixes

### EmptyState — `xdsClassName` missing visual prop

**File:** `packages/core/src/EmptyState/XDSEmptyState.tsx`
**Category:** `classname-missing-prop`

`isCompact` drives three distinct style objects but was absent from the `xdsClassName` call. Theme packages targeting `.xds-emptystate` need the `compact` variant class to scope their overrides.

### `use client` directive placement — 7 files

**Category:** `structure-issue`

7 files where the `use client` directive was either missing or not on line 1 (required by tsup for correct RSC boundary splitting). All fixed. Verified: `check-use-client.mjs` reports 130/130.

### DropdownMenu items — added `xdsClassName` for theme targeting

**Category:** `missing-classname`

Menu item wrapper divs (`div[role="menuitem"]`) had no `xdsClassName`. Added `xdsClassName("dropdown-menu-item", {size: menuSize})` so theme packages can target item-level styles via `@scope`.

### EmptyState — extends `XDSBaseProps`

**Category:** `structure-issue`

`XDSEmptyStateProps` declared `xstyle`, `className`, `style`, and `data-testid` manually instead of extending `XDSBaseProps<HTMLDivElement>`. Now extends the standard base interface.

---

## Resolved — No Change Needed

| Item | Resolution |
|------|-----------|
| DropdownMenu escape hatches | ✅ Correct — compound component contract, escape hatches live on the button via `XDSButtonProps` |
| DropdownMenu `maxHeight: 300px` | ✅ Acceptable — large layout constraints are design decisions, not tokens ([wiki updated](https://github.com/facebookexperimental/xds/wiki/Night-Watch-Component-Auditor)) |
| EmptyState `maxWidth: 360px` | ✅ Acceptable — same reasoning |

---

## Clean Components

| Component | Result |
|-----------|--------|
| Field | ✅ Clean — all checks pass |
| FormLayout | ✅ Clean — all checks pass |
| Grid | ✅ Clean — all checks pass |

---
