### PR TITLE
refactor(container): replace --container-padding with directional vars

### DIFF
--- a/apps/storybook/stories/Divider.stories.tsx
+++ b/apps/storybook/stories/Divider.stories.tsx
@@ -184,3 +184,17 @@ export const InCard: Story = {
     </XDSSection>
   ),
 };
+
+export const FullBleedVertical: Story = {
+  render: () => (
+    <XDSSection variant="wash">
+      <XDSCard height={200}>
+        <XDSHStack gap={4} xstyle={styles.fullHeight}>
+          <XDSText type="body">Left content</XDSText>
+          <XDSDivider orientation="vertical" isFullBleed />
+          <XDSText type="body">Right content</XDSText>
+        </XDSHStack>
+      </XDSCard>
+    </XDSSection>
+  ),
+};

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -242,6 +242,9 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-4'],
+    // Publish inline padding for edge compensation (ghost buttons at edges).
+    // Banner has different block padding (spacing-3) vs inline padding (spacing-4).
+    '--container-padding-inline': spacingVars['--spacing-4'],
   },
   // When there's only a title (no description) and actions, center everything vertically
   headerCentered: {

--- a/packages/core/src/Card/XDSCard.tsx
+++ b/packages/core/src/Card/XDSCard.tsx
@@ -20,6 +20,8 @@ import type {SpacingToken} from '../Layout/container.stylex';
 import {
   paddingStyles,
   containerPaddingInlineVarStyles,
+  containerPaddingBlockStartVarStyles,
+  containerPaddingBlockEndVarStyles,
   spacingStepToToken,
 } from '../Layout/padding.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
@@ -194,6 +196,12 @@ export function XDSCard({
           !useThemeDefault &&
             effectivePadding !== 4 &&
             containerPaddingInlineVarStyles[effectivePadding],
+          !useThemeDefault &&
+            effectivePadding !== 4 &&
+            containerPaddingBlockStartVarStyles[effectivePadding],
+          !useThemeDefault &&
+            effectivePadding !== 4 &&
+            containerPaddingBlockEndVarStyles[effectivePadding],
         )}>
         {children}
       </div>

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -422,14 +422,6 @@ export function XDSDialog({
       {...mergeProps(
         xdsClassName('dialog', {variant}),
         stylex.props(
-          ...container({
-            padding: 'spacing0',
-            maxHeight: isFullscreen
-              ? undefined
-              : typeof maxHeight === 'number'
-                ? `${maxHeight}px`
-                : maxHeight,
-          }),
           styles.dialog,
           styles.backdrop,
           !isFullscreen && dynamicStyles.sizing(width, maxHeight),
@@ -447,7 +439,20 @@ export function XDSDialog({
         style,
       )}
       {...safeProps}>
-      <div {...stylex.props(styles.inner)}>{children}</div>
+      <div
+        {...stylex.props(
+          styles.inner,
+          ...container({
+            useThemeDefault: 'dialog',
+            maxHeight: isFullscreen
+              ? undefined
+              : typeof maxHeight === 'number'
+                ? `${maxHeight}px`
+                : maxHeight,
+          }),
+        )}>
+        {children}
+      </div>
     </dialog>
   );
 }

--- a/packages/core/src/Divider/XDSDivider.tsx
+++ b/packages/core/src/Divider/XDSDivider.tsx
@@ -154,10 +154,15 @@ const labelStyles = stylex.create({
 
 const fullBleedStyles = stylex.create({
   horizontal: {
-    marginInline: 'calc(-1 * var(--container-padding, 0px))',
+    marginInlineStart: 'calc(-1 * var(--container-padding-inline, 0px))',
+    marginInlineEnd: 'calc(-1 * var(--container-padding-inline, 0px))',
+    width: 'calc(100% + 2 * var(--container-padding-inline, 0px))',
   },
   vertical: {
-    marginBlock: 'calc(-1 * var(--container-padding, 0px))',
+    marginBlockStart: 'calc(-1 * var(--container-padding-block-start, 0px))',
+    marginBlockEnd: 'calc(-1 * var(--container-padding-block-end, 0px))',
+    height:
+      'calc(100% + var(--container-padding-block-start, 0px) + var(--container-padding-block-end, 0px))',
   },
 });
 

--- a/packages/core/src/Layout/XDSLayout.tsx
+++ b/packages/core/src/Layout/XDSLayout.tsx
@@ -40,15 +40,20 @@ export type XDSLayoutHeight = 'fill' | 'auto';
 const styles = stylex.create({
   // Outer wrapper uses negative margin to escape container padding
   layoutOuter: {
-    margin: 'calc(-1 * var(--container-padding, 0px))',
+    marginInline: 'calc(-1 * var(--container-padding-inline, 0px))',
+    marginBlockStart: 'calc(-1 * var(--container-padding-block-start, 0px))',
+    marginBlockEnd: 'calc(-1 * var(--container-padding-block-end, 0px))',
   },
-  // Inner wrapper resets --container-padding for descendants
+  // Inner wrapper resets container padding vars for descendants
   layoutInner: {
-    '--container-padding': '0px',
+    '--container-padding-inline': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
   },
   fill: {
-    // Add 2x container padding to compensate for negative margins on top/bottom
-    height: 'calc(100% + 2 * var(--container-padding, 0px))',
+    // Add 2x container block padding to compensate for negative block margins
+    height:
+      'calc(100% + var(--container-padding-block-start, 0px) + var(--container-padding-block-end, 0px))',
     maxHeight: 'var(--container-max-height, none)',
   },
   auto: {

--- a/packages/core/src/Layout/XDSLayoutContent.tsx
+++ b/packages/core/src/Layout/XDSLayoutContent.tsx
@@ -20,7 +20,12 @@ import {spacingVars} from '../theme/tokens.stylex';
 import {XDSLayoutSlotsContext} from './XDSLayoutSlotsContext';
 import {xdsClassName, mergeProps} from '../utils';
 import type {SpacingStep} from '../utils/types';
-import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
+import {
+  paddingStyles,
+  containerPaddingInlineVarStyles,
+  containerPaddingBlockStartVarStyles,
+  containerPaddingBlockEndVarStyles,
+} from './padding.stylex';
 
 const styles = stylex.create({
   content: {
@@ -44,10 +49,15 @@ const styles = stylex.create({
       [stylex.when.ancestor(':has(> .xds-layout-footer:not([data-divider]))')]:
         0,
     },
+    // Publish container padding vars for bleed children (Table, Divider, etc.)
+    '--container-padding-inline': `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-start': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-end': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
   },
   // When no start panel: outer-x on left edge
   noStart: {
     paddingInlineStart: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    '--container-padding-inline': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
   },
   // When no end panel: outer-x on right edge
   noEnd: {
@@ -56,10 +66,12 @@ const styles = stylex.create({
   // When no header: outer-y on top
   noHeader: {
     paddingBlockStart: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-start': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
   // When no footer: outer-y on bottom
   noFooter: {
     paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-end': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
   scrollable: {
     overflow: 'auto',
@@ -69,6 +81,9 @@ const styles = stylex.create({
     paddingInlineEnd: 0,
     paddingBlockStart: 0,
     paddingBlockEnd: 0,
+    '--container-padding-inline': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
   },
 });
 
@@ -178,6 +193,8 @@ export function XDSLayoutContent({
           isZeroPadding && styles.fullBleed,
           padding != null && paddingStyles[padding],
           padding != null && containerPaddingInlineVarStyles[padding],
+          padding != null && containerPaddingBlockStartVarStyles[padding],
+          padding != null && containerPaddingBlockEndVarStyles[padding],
           xstyle,
         ),
         className,

--- a/packages/core/src/Layout/XDSLayoutFooter.tsx
+++ b/packages/core/src/Layout/XDSLayoutFooter.tsx
@@ -20,7 +20,12 @@ import {XDSLayoutDividerContext} from './XDSLayoutDividerContext';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import type {SpacingStep} from '../utils/types';
-import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
+import {
+  paddingStyles,
+  containerPaddingInlineVarStyles,
+  containerPaddingBlockStartVarStyles,
+  containerPaddingBlockEndVarStyles,
+} from './padding.stylex';
 
 const styles = stylex.create({
   // Outer shell: owns border/divider and sizing. No padding — that lives on inner.
@@ -38,12 +43,18 @@ const styles = stylex.create({
     paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
     paddingBlockStart: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
     paddingBlockEnd: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-inline': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-start': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-end': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
   },
   fullBleed: {
     paddingInlineStart: 0,
     paddingInlineEnd: 0,
     paddingBlockStart: 0,
     paddingBlockEnd: 0,
+    '--container-padding-inline': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
   },
   divider: {
     borderBlockStartWidth: 1,
@@ -146,6 +157,7 @@ export function XDSLayoutFooter({
         stylex.props(
           styles.footer,
           dynamicStyles.sizing(height ?? null),
+
           resolvedHasDivider && styles.divider,
           xstyle,
         ),
@@ -159,6 +171,8 @@ export function XDSLayoutFooter({
           isZeroPadding && styles.fullBleed,
           padding != null && paddingStyles[padding],
           padding != null && containerPaddingInlineVarStyles[padding],
+          padding != null && containerPaddingBlockStartVarStyles[padding],
+          padding != null && containerPaddingBlockEndVarStyles[padding],
         )}>
         {children}
       </div>

--- a/packages/core/src/Layout/XDSLayoutHeader.tsx
+++ b/packages/core/src/Layout/XDSLayoutHeader.tsx
@@ -20,7 +20,12 @@ import {XDSLayoutDividerContext} from './XDSLayoutDividerContext';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import type {SpacingStep} from '../utils/types';
-import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
+import {
+  paddingStyles,
+  containerPaddingInlineVarStyles,
+  containerPaddingBlockStartVarStyles,
+  containerPaddingBlockEndVarStyles,
+} from './padding.stylex';
 
 const styles = stylex.create({
   // Outer shell: owns border/divider and sizing. No padding — that lives on inner.
@@ -38,12 +43,18 @@ const styles = stylex.create({
     paddingInlineEnd: `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
     paddingBlockStart: `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
     paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-inline': `var(--layout-padding-outer-x, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-start': `var(--layout-padding-outer-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-end': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
   },
   fullBleed: {
     paddingInlineStart: 0,
     paddingInlineEnd: 0,
     paddingBlockStart: 0,
     paddingBlockEnd: 0,
+    '--container-padding-inline': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
   },
   divider: {
     borderBlockEndWidth: 1,
@@ -146,6 +157,7 @@ export function XDSLayoutHeader({
         stylex.props(
           styles.header,
           dynamicStyles.sizing(height ?? null),
+
           resolvedHasDivider && styles.divider,
           xstyle,
         ),
@@ -159,6 +171,8 @@ export function XDSLayoutHeader({
           isZeroPadding && styles.fullBleed,
           padding != null && paddingStyles[padding],
           padding != null && containerPaddingInlineVarStyles[padding],
+          padding != null && containerPaddingBlockStartVarStyles[padding],
+          padding != null && containerPaddingBlockEndVarStyles[padding],
         )}>
         {children}
       </div>

--- a/packages/core/src/Layout/XDSLayoutPanel.tsx
+++ b/packages/core/src/Layout/XDSLayoutPanel.tsx
@@ -12,7 +12,6 @@
  * - /apps/storybook/stories/Layout.stories.tsx
  */
 
-
 import type {AriaRole, ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import {useContext} from 'react';
@@ -22,7 +21,12 @@ import {XDSLayoutAreaContext} from './XDSLayoutAreaContext';
 import {XDSLayoutSlotsContext} from './XDSLayoutSlotsContext';
 import {xdsClassName, mergeProps} from '../utils';
 import type {SpacingStep} from '../utils/types';
-import {paddingStyles, containerPaddingInlineVarStyles} from './padding.stylex';
+import {
+  paddingStyles,
+  containerPaddingInlineVarStyles,
+  containerPaddingBlockStartVarStyles,
+  containerPaddingBlockEndVarStyles,
+} from './padding.stylex';
 
 const styles = stylex.create({
   panel: {
@@ -34,6 +38,9 @@ const styles = stylex.create({
     paddingInlineEnd: `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
     paddingBlockStart: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
     paddingBlockEnd: `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-inline': `var(--layout-padding-inner-x, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-start': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
+    '--container-padding-block-end': `var(--layout-padding-inner-y, ${spacingVars['--spacing-4']})`,
   },
   // Start panel: outer-x on left edge
   startPanel: {
@@ -56,6 +63,9 @@ const styles = stylex.create({
     paddingInlineEnd: 0,
     paddingBlockStart: 0,
     paddingBlockEnd: 0,
+    '--container-padding-inline': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
   },
   scrollable: {
     overflow: 'auto',
@@ -231,6 +241,8 @@ export function XDSLayoutPanel({
           isZeroPadding && styles.fullBleed,
           padding != null && paddingStyles[padding],
           padding != null && containerPaddingInlineVarStyles[padding],
+          padding != null && containerPaddingBlockStartVarStyles[padding],
+          padding != null && containerPaddingBlockEndVarStyles[padding],
           hasDivider && dividerStyle,
           shouldCollapseSpacing && collapseStyle,
           xstyle,

--- a/packages/core/src/Layout/container.stylex.ts
+++ b/packages/core/src/Layout/container.stylex.ts
@@ -13,6 +13,7 @@
  * components: {
  *   card: { base: { '--xds-card-padding': 'var(--spacing-3)' } },
  *   section: { base: { '--xds-section-padding': 'var(--spacing-3)' } },
+ *   dialog: { base: { '--xds-dialog-padding': 'var(--spacing-3)' } },
  * }
  * ```
  *
@@ -49,7 +50,9 @@ export type SpacingToken =
 const baseStyles = stylex.create({
   container: {
     boxSizing: 'border-box',
-    padding: 'var(--container-padding)',
+    paddingInline: 'var(--container-padding-inline)',
+    paddingBlockStart: 'var(--container-padding-block-start)',
+    paddingBlockEnd: 'var(--container-padding-block-end)',
   },
 });
 
@@ -61,11 +64,14 @@ const baseStyles = stylex.create({
  * with a fallback to --spacing-4 (the default).
  */
 const cardDefaultPaddingStyles = stylex.create({
-  containerPadding: {
-    '--container-padding': `var(--xds-card-padding, ${spacingVars['--spacing-4']})`,
-  },
   containerPaddingInline: {
     '--container-padding-inline': `var(--xds-card-padding, ${spacingVars['--spacing-4']})`,
+  },
+  containerPaddingBlockStart: {
+    '--container-padding-block-start': `var(--xds-card-padding, ${spacingVars['--spacing-4']})`,
+  },
+  containerPaddingBlockEnd: {
+    '--container-padding-block-end': `var(--xds-card-padding, ${spacingVars['--spacing-4']})`,
   },
   layoutPaddingOuterX: {
     '--layout-padding-outer-x': `var(--xds-card-padding, ${spacingVars['--spacing-4']})`,
@@ -89,11 +95,14 @@ const cardDefaultPaddingStyles = stylex.create({
  * with a fallback to --spacing-4 (the default).
  */
 const sectionDefaultPaddingStyles = stylex.create({
-  containerPadding: {
-    '--container-padding': `var(--xds-section-padding, ${spacingVars['--spacing-4']})`,
-  },
   containerPaddingInline: {
     '--container-padding-inline': `var(--xds-section-padding, ${spacingVars['--spacing-4']})`,
+  },
+  containerPaddingBlockStart: {
+    '--container-padding-block-start': `var(--xds-section-padding, ${spacingVars['--spacing-4']})`,
+  },
+  containerPaddingBlockEnd: {
+    '--container-padding-block-end': `var(--xds-section-padding, ${spacingVars['--spacing-4']})`,
   },
   layoutPaddingOuterX: {
     '--layout-padding-outer-x': `var(--xds-section-padding, ${spacingVars['--spacing-4']})`,
@@ -110,45 +119,52 @@ const sectionDefaultPaddingStyles = stylex.create({
 });
 
 /**
+ * Dialog default padding styles that cascade from --xds-dialog-padding.
+ *
+ * When no explicit padding prop is set on Dialog, the internal
+ * layout padding variables read from --xds-dialog-padding (set by theme)
+ * with a fallback to --spacing-4 (the default).
+ */
+const dialogDefaultPaddingStyles = stylex.create({
+  containerPaddingInline: {
+    '--container-padding-inline': `var(--xds-dialog-padding, ${spacingVars['--spacing-4']})`,
+  },
+  containerPaddingBlockStart: {
+    '--container-padding-block-start': `var(--xds-dialog-padding, ${spacingVars['--spacing-4']})`,
+  },
+  containerPaddingBlockEnd: {
+    '--container-padding-block-end': `var(--xds-dialog-padding, ${spacingVars['--spacing-4']})`,
+  },
+  layoutPaddingOuterX: {
+    '--layout-padding-outer-x': `var(--xds-dialog-padding, ${spacingVars['--spacing-4']})`,
+  },
+  layoutPaddingOuterY: {
+    '--layout-padding-outer-y': `var(--xds-dialog-padding, ${spacingVars['--spacing-4']})`,
+  },
+  layoutPaddingInnerX: {
+    '--layout-padding-inner-x': `var(--xds-dialog-padding, ${spacingVars['--spacing-4']})`,
+  },
+  layoutPaddingInnerY: {
+    '--layout-padding-inner-y': `var(--xds-dialog-padding, ${spacingVars['--spacing-4']})`,
+  },
+});
+
+/**
  * Map from component name to its theme default padding styles.
  * Each component reads from its own public CSS custom property.
  */
 const themeDefaultStyles = {
   card: cardDefaultPaddingStyles,
   section: sectionDefaultPaddingStyles,
+  dialog: dialogDefaultPaddingStyles,
 };
 
 export type ContainerComponent = keyof typeof themeDefaultStyles;
 
 /**
- * Container padding styles.
- * Sets --container-padding CSS variable for simple content padding.
- * XDSLayout will override this to 0 and handle its own padding.
- */
-const containerPaddingStyles = stylex.create({
-  spacing0: {'--container-padding': spacingVars['--spacing-0']},
-  spacing0_5: {'--container-padding': spacingVars['--spacing-0-5']},
-  spacing1: {'--container-padding': spacingVars['--spacing-1']},
-  spacing1_5: {'--container-padding': spacingVars['--spacing-1-5']},
-  spacing2: {'--container-padding': spacingVars['--spacing-2']},
-  spacing3: {'--container-padding': spacingVars['--spacing-3']},
-  spacing4: {'--container-padding': spacingVars['--spacing-4']},
-  spacing5: {'--container-padding': spacingVars['--spacing-5']},
-  spacing6: {'--container-padding': spacingVars['--spacing-6']},
-  spacing7: {'--container-padding': spacingVars['--spacing-7']},
-  spacing8: {'--container-padding': spacingVars['--spacing-8']},
-  spacing9: {'--container-padding': spacingVars['--spacing-9']},
-  spacing10: {'--container-padding': spacingVars['--spacing-10']},
-  spacing11: {'--container-padding': spacingVars['--spacing-11']},
-  spacing12: {'--container-padding': spacingVars['--spacing-12']},
-});
-
-/**
  * Container inline padding styles for edge compensation.
  * Sets --container-padding-inline so edge-compensating children (ghost buttons, etc.)
- * know the inline padding to compensate against. Defaults to the same value as
- * --container-padding for isotropic containers; containers with asymmetric padding
- * (e.g., TopNav, Banner) set this directly.
+ * know the inline padding to compensate against.
  */
 const containerPaddingInlineStyles = stylex.create({
   spacing0: {'--container-padding-inline': spacingVars['--spacing-0']},
@@ -166,6 +182,47 @@ const containerPaddingInlineStyles = stylex.create({
   spacing10: {'--container-padding-inline': spacingVars['--spacing-10']},
   spacing11: {'--container-padding-inline': spacingVars['--spacing-11']},
   spacing12: {'--container-padding-inline': spacingVars['--spacing-12']},
+});
+
+/**
+ * Container block-start/block-end padding styles for vertical bleed.
+ * Split into start and end because Layout areas have asymmetric block padding
+ * (e.g., Header: block-start=outer-y, block-end=inner-y).
+ */
+const containerPaddingBlockStartStyles = stylex.create({
+  spacing0: {'--container-padding-block-start': spacingVars['--spacing-0']},
+  spacing0_5: {'--container-padding-block-start': spacingVars['--spacing-0-5']},
+  spacing1: {'--container-padding-block-start': spacingVars['--spacing-1']},
+  spacing1_5: {'--container-padding-block-start': spacingVars['--spacing-1-5']},
+  spacing2: {'--container-padding-block-start': spacingVars['--spacing-2']},
+  spacing3: {'--container-padding-block-start': spacingVars['--spacing-3']},
+  spacing4: {'--container-padding-block-start': spacingVars['--spacing-4']},
+  spacing5: {'--container-padding-block-start': spacingVars['--spacing-5']},
+  spacing6: {'--container-padding-block-start': spacingVars['--spacing-6']},
+  spacing7: {'--container-padding-block-start': spacingVars['--spacing-7']},
+  spacing8: {'--container-padding-block-start': spacingVars['--spacing-8']},
+  spacing9: {'--container-padding-block-start': spacingVars['--spacing-9']},
+  spacing10: {'--container-padding-block-start': spacingVars['--spacing-10']},
+  spacing11: {'--container-padding-block-start': spacingVars['--spacing-11']},
+  spacing12: {'--container-padding-block-start': spacingVars['--spacing-12']},
+});
+
+const containerPaddingBlockEndStyles = stylex.create({
+  spacing0: {'--container-padding-block-end': spacingVars['--spacing-0']},
+  spacing0_5: {'--container-padding-block-end': spacingVars['--spacing-0-5']},
+  spacing1: {'--container-padding-block-end': spacingVars['--spacing-1']},
+  spacing1_5: {'--container-padding-block-end': spacingVars['--spacing-1-5']},
+  spacing2: {'--container-padding-block-end': spacingVars['--spacing-2']},
+  spacing3: {'--container-padding-block-end': spacingVars['--spacing-3']},
+  spacing4: {'--container-padding-block-end': spacingVars['--spacing-4']},
+  spacing5: {'--container-padding-block-end': spacingVars['--spacing-5']},
+  spacing6: {'--container-padding-block-end': spacingVars['--spacing-6']},
+  spacing7: {'--container-padding-block-end': spacingVars['--spacing-7']},
+  spacing8: {'--container-padding-block-end': spacingVars['--spacing-8']},
+  spacing9: {'--container-padding-block-end': spacingVars['--spacing-9']},
+  spacing10: {'--container-padding-block-end': spacingVars['--spacing-10']},
+  spacing11: {'--container-padding-block-end': spacingVars['--spacing-11']},
+  spacing12: {'--container-padding-block-end': spacingVars['--spacing-12']},
 });
 
 const paddingOuterXStyles = stylex.create({
@@ -248,38 +305,38 @@ const maxHeightStyles = stylex.create({
 
 export interface ContainerOptions {
   /**
-   * Default container padding for simple content.
-   * Sets --container-padding CSS variable.
-   * XDSLayout overrides this to 0 and manages its own padding.
+   * Shortcut to set all padding values at once.
+   * Sets paddingOuterX, paddingOuterY, paddingInnerX, and paddingInnerY
+   * to the same value. Individual properties override this when set.
    * @default 'spacing4'
    */
   padding?: SpacingToken;
 
   /**
    * Outer horizontal padding (left/right).
-   * Sets --layout-padding-outer-x CSS variable.
-   * @default 'spacing4'
+   * Sets --container-padding-inline and --layout-padding-outer-x CSS variables.
+   * Overrides `padding` for the horizontal outer axis.
    */
   paddingOuterX?: SpacingToken;
 
   /**
    * Outer vertical padding (top/bottom).
-   * Sets --layout-padding-outer-y CSS variable.
-   * @default 'spacing4'
+   * Sets --container-padding-block-start, --container-padding-block-end, and --layout-padding-outer-y CSS variables.
+   * Overrides `padding` for the vertical outer axis.
    */
   paddingOuterY?: SpacingToken;
 
   /**
    * Inner horizontal padding for content areas.
    * Sets --layout-padding-inner-x CSS variable.
-   * @default 'spacing4'
+   * Overrides `padding` for the horizontal inner axis.
    */
   paddingInnerX?: SpacingToken;
 
   /**
    * Inner vertical padding for content areas.
    * Sets --layout-padding-inner-y CSS variable.
-   * @default 'spacing4'
+   * Overrides `padding` for the vertical inner axis.
    */
   paddingInnerY?: SpacingToken;
 
@@ -310,8 +367,8 @@ export interface ContainerOptions {
  * StyleX utility to add layout container styles to any element.
  *
  * Sets CSS variables for padding that child layout components read:
- * - `--container-padding` — Default padding for simple content
- * - `--container-padding-inline` — Inline padding for edge compensation
+ * - `--container-padding-inline` — Inline padding for edge compensation and bleed
+ * - `--container-padding-block-start` / `--container-padding-block-end` — Block padding for vertical bleed
  * - `--layout-padding-outer-x`, `--layout-padding-outer-y` (internal)
  * - `--layout-padding-inner-x`, `--layout-padding-inner-y` (internal)
  *
@@ -329,9 +386,14 @@ export interface ContainerOptions {
  *   <XDSLayout ... />
  * </div>
  *
- * // Explicit padding values (not theme-overridable)
+ * // Uniform padding
+ * <div {...stylex.props(...container({ padding: 'spacing3' }))}>
+ *   <XDSLayout ... />
+ * </div>
+ *
+ * // Asymmetric — padding as base, paddingOuterY overrides vertical
  * <div {...stylex.props(
- *   ...container({ padding: 'spacing3', paddingOuterY: 'spacing2', paddingInnerX: 'spacing3' }),
+ *   ...container({ padding: 'spacing3', paddingOuterY: 'spacing2' }),
  *   customStyles.card
  * )}>
  *   <XDSLayout ... />
@@ -340,13 +402,18 @@ export interface ContainerOptions {
  */
 export function container({
   padding = 'spacing4',
-  paddingOuterX = 'spacing4',
-  paddingOuterY = 'spacing4',
-  paddingInnerX = 'spacing4',
-  paddingInnerY = 'spacing4',
+  paddingOuterX,
+  paddingOuterY,
+  paddingInnerX,
+  paddingInnerY,
   useThemeDefault,
   maxHeight,
 }: ContainerOptions) {
+  const outerX = paddingOuterX ?? padding;
+  const outerY = paddingOuterY ?? padding;
+  const innerX = paddingInnerX ?? padding;
+  const innerY = paddingInnerY ?? padding;
+
   const maxHeightStyle = maxHeight
     ? maxHeightStyles.containerMaxHeight(maxHeight)
     : null;
@@ -358,8 +425,9 @@ export function container({
     const defaults = themeDefaultStyles[useThemeDefault];
     return [
       baseStyles.container,
-      defaults.containerPadding,
       defaults.containerPaddingInline,
+      defaults.containerPaddingBlockStart,
+      defaults.containerPaddingBlockEnd,
       defaults.layoutPaddingOuterX,
       defaults.layoutPaddingOuterY,
       defaults.layoutPaddingInnerX,
@@ -370,15 +438,13 @@ export function container({
 
   return [
     baseStyles.container,
-    containerPaddingStyles[padding],
-    // Set --container-padding-inline for edge compensation. When paddingOuterX
-    // differs from the base padding, use paddingOuterX since that's the actual
-    // inline padding at the container edges.
-    containerPaddingInlineStyles[paddingOuterX],
-    paddingOuterXStyles[paddingOuterX],
-    paddingOuterYStyles[paddingOuterY],
-    paddingInnerXStyles[paddingInnerX],
-    paddingInnerYStyles[paddingInnerY],
+    containerPaddingInlineStyles[outerX],
+    containerPaddingBlockStartStyles[outerY],
+    containerPaddingBlockEndStyles[outerY],
+    paddingOuterXStyles[outerX],
+    paddingOuterYStyles[outerY],
+    paddingInnerXStyles[innerX],
+    paddingInnerYStyles[innerY],
     maxHeightStyle,
   ] as const;
 }

--- a/packages/core/src/Layout/edgeCompensation.stylex.ts
+++ b/packages/core/src/Layout/edgeCompensation.stylex.ts
@@ -30,16 +30,14 @@
  * - When at an edge: margin pulls the component toward the edge by the smaller
  *   of its own padding or the container's inline padding
  *
- * ### Why --container-padding-inline instead of --container-padding?
+ * ### Why --container-padding-inline?
  *
  * Edge compensation is always an inline (horizontal) adjustment. Many containers
  * have different inline vs block padding (e.g., Banner: paddingInline=spacing-4,
  * paddingBlock=spacing-3; TopNav: paddingInline=spacing-4, no block padding).
- * Using the isotropic `--container-padding` would be semantically misleading and
- * could cause incorrect vertical compensation if a future component reads it for
- * block-direction adjustments. The existing `--container-padding` variable is used
- * by Divider and Section for edge-to-edge bleeds in both directions — we don't
- * want to overload it with a value that only represents one axis.
+ * The container system uses two directional vars: --container-padding-inline for
+ * horizontal padding and --container-padding-block-start/end for vertical. Edge compensation
+ * only reads the inline var since it only adjusts horizontal margins.
  *
  * SYNC: When modified, update /packages/core/src/Layout/Layout.doc.mjs
  */

--- a/packages/core/src/Layout/padding.stylex.ts
+++ b/packages/core/src/Layout/padding.stylex.ts
@@ -119,6 +119,39 @@ export const containerPaddingInlineVarStyles = stylex.create({
 });
 
 /**
+ * Container padding block-start/block-end CSS variable styles for vertical bleed.
+ * Sets --container-padding-block-start and --container-padding-block-end so bleed children (Table, Divider, Section)
+ * know the block padding to compensate against when first/last child.
+ */
+export const containerPaddingBlockStartVarStyles = stylex.create({
+  0: {'--container-padding-block-start': spacingVars['--spacing-0']},
+  0.5: {'--container-padding-block-start': spacingVars['--spacing-0-5']},
+  1: {'--container-padding-block-start': spacingVars['--spacing-1']},
+  1.5: {'--container-padding-block-start': spacingVars['--spacing-1-5']},
+  2: {'--container-padding-block-start': spacingVars['--spacing-2']},
+  3: {'--container-padding-block-start': spacingVars['--spacing-3']},
+  4: {'--container-padding-block-start': spacingVars['--spacing-4']},
+  5: {'--container-padding-block-start': spacingVars['--spacing-5']},
+  6: {'--container-padding-block-start': spacingVars['--spacing-6']},
+  8: {'--container-padding-block-start': spacingVars['--spacing-8']},
+  10: {'--container-padding-block-start': spacingVars['--spacing-10']},
+});
+
+export const containerPaddingBlockEndVarStyles = stylex.create({
+  0: {'--container-padding-block-end': spacingVars['--spacing-0']},
+  0.5: {'--container-padding-block-end': spacingVars['--spacing-0-5']},
+  1: {'--container-padding-block-end': spacingVars['--spacing-1']},
+  1.5: {'--container-padding-block-end': spacingVars['--spacing-1-5']},
+  2: {'--container-padding-block-end': spacingVars['--spacing-2']},
+  3: {'--container-padding-block-end': spacingVars['--spacing-3']},
+  4: {'--container-padding-block-end': spacingVars['--spacing-4']},
+  5: {'--container-padding-block-end': spacingVars['--spacing-5']},
+  6: {'--container-padding-block-end': spacingVars['--spacing-6']},
+  8: {'--container-padding-block-end': spacingVars['--spacing-8']},
+  10: {'--container-padding-block-end': spacingVars['--spacing-10']},
+});
+
+/**
  * Layout outer X padding CSS variable styles.
  */
 export const layoutPaddingOuterXVarStyles = stylex.create({

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -21,6 +21,8 @@ import type {SpacingToken} from '../Layout/container.stylex';
 import {
   paddingStyles,
   containerPaddingInlineVarStyles,
+  containerPaddingBlockStartVarStyles,
+  containerPaddingBlockEndVarStyles,
   spacingStepToToken,
 } from '../Layout/padding.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
@@ -68,21 +70,23 @@ const nestedStyles = stylex.create({
   // Outer wrapper escapes parent's container padding
   outer: {
     // Always escape horizontal padding
-    marginInline: 'calc(-1 * var(--container-padding, 0px))',
+    marginInline: 'calc(-1 * var(--container-padding-inline, 0px))',
     // Escape top padding only if first child
     marginTop: {
       default: null,
-      ':first-child': 'calc(-1 * var(--container-padding, 0px))',
+      ':first-child': 'calc(-1 * var(--container-padding-block-start, 0px))',
     },
     // Escape bottom padding only if last child
     marginBottom: {
       default: null,
-      ':last-child': 'calc(-1 * var(--container-padding, 0px))',
+      ':last-child': 'calc(-1 * var(--container-padding-block-end, 0px))',
     },
   },
   // Inner wrapper resets container padding for descendants
   inner: {
-    '--container-padding': '0px',
+    '--container-padding-inline': '0px',
+    '--container-padding-block-start': '0px',
+    '--container-padding-block-end': '0px',
     height: '100%',
   },
 });
@@ -286,6 +290,12 @@ export function XDSSection({
             !useThemeDefault &&
               effectivePadding !== 4 &&
               containerPaddingInlineVarStyles[effectivePadding],
+            !useThemeDefault &&
+              effectivePadding !== 4 &&
+              containerPaddingBlockStartVarStyles[effectivePadding],
+            !useThemeDefault &&
+              effectivePadding !== 4 &&
+              containerPaddingBlockEndVarStyles[effectivePadding],
             variantStyles[variant],
             dividers?.includes('top') && dividerStyles.top,
             dividers?.includes('bottom') && dividerStyles.bottom,

--- a/packages/core/src/Table/XDSTable.tsx
+++ b/packages/core/src/Table/XDSTable.tsx
@@ -76,12 +76,12 @@ const tableStyles = stylex.create({
     color: colorVars['--color-text-primary'],
   },
   /**
-   * Container bleed: table escapes parent container padding horizontally
+   * Container bleed: table escapes parent container padding
    * so rows span edge-to-edge inside Cards and Layout areas.
-   * Uses --container-padding-inline set by Card/Section/Layout containers.
    *
-   * Vertical bleed uses :first-child / :last-child to escape container
-   * block padding at the edges — same pattern as XDSSection.
+   * Inline bleed uses --container-padding-inline set by containers.
+   * Block bleed uses --container-padding-block-start/end for :first-child / :last-child
+   * margins, Block bleed uses --container-padding-block-start / --container-padding-block-end for :first-child / :last-child.
    */
   containerBleed: {
     marginInlineStart: 'calc(-1 * var(--container-padding-inline, 0px))',
@@ -89,11 +89,11 @@ const tableStyles = stylex.create({
     width: 'calc(100% + 2 * var(--container-padding-inline, 0px))',
     marginTop: {
       default: null,
-      ':first-child': 'calc(-1 * var(--container-padding, 0px))',
+      ':first-child': 'calc(-1 * var(--container-padding-block-start, 0px))',
     },
     marginBottom: {
       default: null,
-      ':last-child': 'calc(-1 * var(--container-padding, 0px))',
+      ':last-child': 'calc(-1 * var(--container-padding-block-end, 0px))',
     },
   },
 });


### PR DESCRIPTION
## Summary

Removes the isotropic `--container-padding` CSS variable. Container padding is now tracked by three directional variables:

| Variable | Direction | Purpose |
|---|---|---|
| `--container-padding-inline` | Horizontal | Inline bleed, edge compensation |
| `--container-padding-block-start` | Top | `:first-child` block bleed |
| `--container-padding-block-end` | Bottom | `:last-child` block bleed |

### Why split block into start/end?

Layout areas have asymmetric block padding. Header uses `outer-y` for block-start but `inner-y` for block-end. Footer is the reverse. A single `--container-padding-block` would give the wrong value for one edge. The split lets bleed children (`:first-child` reads `block-start`, `:last-child` reads `block-end`) apply the correct negative margin per edge.

### What this fixes

- **Tables overflowing in `padding={0}` containers** — the old `--container-padding` defaulted to `spacing-4` even when actual CSS padding was 0
- **Tables not bleeding inside Layout Content** — Layout inner wrapper reset the old vars but Content never re-published them for its children

### Changes

**Setters** — containers that publish the vars:
- `container()` utility: emits `--inline`, `--block-start`, `--block-end` from `paddingOuterX`/`paddingOuterY`
- Card/Section theme defaults: `--xds-card-padding` cascades to all three
- Card/Section explicit padding: sets all three
- Layout areas (Header, Content, Footer, Panel): publish vars matching their actual CSS padding per edge
- Layout inner wrapper: resets all three to `0px`

**Consumers** — components that read the vars for bleed:
- Table `containerBleed`: `marginInline` reads `--inline`, `marginTop` reads `--block-start`, `marginBottom` reads `--block-end`
- Section nested outer: same pattern
- Divider `fullBleed`: horizontal reads `--inline`, vertical reads `--block-start`
- Layout outer: `marginInline`/`marginBlockStart`/`marginBlockEnd` read respective vars
- Layout fill height: compensates with `block-start + block-end`

### Docs

Wiki page: [Container Padding System](https://github.com/facebookexperimental/xds/wiki/Container-Padding-System)

---
