### PR TITLE
fix(templates): adopt Table container bleed + Layout contentWidth

### DIFF
--- a/packages/cli/templates/dashboard/page.tsx
+++ b/packages/cli/templates/dashboard/page.tsx
@@ -672,7 +672,7 @@ export default function DashboardTemplate() {
           </XDSHStack>
         </div>
 
-        <XDSCard padding={0}>
+        <XDSCard>
           <XDSTable<DocRow>
             data={docRows}
             columns={docColumns}

--- a/packages/cli/templates/detail-page/page.tsx
+++ b/packages/cli/templates/detail-page/page.tsx
@@ -209,20 +209,8 @@ const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
 
 // ─── Styles ─────────────────────────────────────────────────────────────────
 const pageStyles = stylex.create({
-  maxWidth: {
-    maxWidth: 1000,
-    width: '100%',
-  },
-  centeredContent: {
-    maxWidth: 1000,
-    width: '100%',
-    marginInline: 'auto',
-  },
-  sectionGap: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 16,
-  },
+
+
   bulletSeparator: {
     fontSize: 12,
     lineHeight: '16px',
@@ -470,7 +458,7 @@ function PageHeader({
   return (
     <XDSLayoutHeader hasDivider padding={4}>
       <XDSCenter axis="horizontal">
-        <XDSVStack xstyle={pageStyles.maxWidth} gap={0}>
+        <XDSVStack gap={0}>
           {/* Back link */}
           <XDSLink href="#" label="All orders" color="secondary">
             <XDSHStack gap={1} vAlign="center">
@@ -827,19 +815,16 @@ export default function DetailPage2Template() {
       contentPadding={0}>
       <XDSLayout
         height="fill"
+        contentWidth={1000}
         defaultHasDividers
         header={<PageHeader activeTab={activeTab} onTabChange={setActiveTab} />}
         content={
-          <XDSLayoutContent role="main" padding={0}>
-            <div
-              {...stylex.props(
-                pageStyles.centeredContent,
-                pageStyles.sectionGap,
-              )}>
+          <XDSLayoutContent role="main">
+            <XDSVStack gap={4}>
               <ItemsCard />
               <InvoiceCard />
               <TimelineSection />
-            </div>
+            </XDSVStack>
           </XDSLayoutContent>
         }
         end={<RightPanel />}


### PR DESCRIPTION
Updates dashboard and detail-page templates to use the new layout features:

**dashboard:** Remove `Card padding={0}` wrapping Table — Table now auto-bleeds to container edges via #1130.

**detail-page:** Replace manual `<div maxWidth={1000} marginInline=auto>` with `Layout contentWidth={1000}` from #1135. Remove `LayoutContent padding={0}`, unused `centeredContent`/`sectionGap` styles, and manual header `maxWidth`.

The `xds template --skeleton` output (#1132) automatically reflects these changes — skeletons now show the cleaner patterns.
