### PR TITLE
feat(Markdown): use XDSList for lists, add isReadOnly to checkbox chain

### DIFF
--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -256,6 +256,13 @@ export interface XDSCheckboxInputProps extends Omit<XDSBaseProps, 'onChange'> {
    */
   isDisabled?: boolean;
   /**
+   * Whether the checkbox is read-only.
+   * Displays the current state at full opacity but prevents interaction.
+   * Unlike `isDisabled`, read-only checkboxes are not visually dimmed.
+   * @default false
+   */
+  isReadOnly?: boolean;
+  /**
    * Whether the field is optional. Mutually exclusive with isRequired.
    * @default false
    */
@@ -318,6 +325,7 @@ export function XDSCheckboxInput({
   isLoading = false,
   value,
   isDisabled = false,
+  isReadOnly = false,
   isOptional = false,
   isRequired = false,
   size = 'md',
@@ -381,9 +389,10 @@ export function XDSCheckboxInput({
             type="checkbox"
             checked={isChecked}
             disabled={isDisabled}
+            readOnly={isReadOnly}
             required={isRequired}
             onChange={e => {
-              if (isBusy) return;
+              if (isBusy || isReadOnly) return;
               const checked = e.target.checked;
               onChange?.(checked, e);
               if (onChangeAction && !e.defaultPrevented) {
@@ -396,6 +405,7 @@ export function XDSCheckboxInput({
             onFocus={onFocus}
             onBlur={onBlur}
             aria-checked={isIndeterminate ? 'mixed' : undefined}
+            aria-readonly={isReadOnly || undefined}
             aria-describedby={ariaDescribedBy}
             aria-invalid={status?.type === 'error' ? true : undefined}
             aria-busy={isBusy || undefined}

--- a/packages/core/src/CheckboxList/XDSCheckboxList.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxList.tsx
@@ -79,6 +79,13 @@ export interface XDSCheckboxListProps {
    */
   isDisabled?: boolean;
   /**
+   * Whether all checkbox items are read-only.
+   * Displays the current state at full opacity but prevents interaction.
+   * Unlike `isDisabled`, read-only checkboxes are not visually dimmed.
+   * @default false
+   */
+  isReadOnly?: boolean;
+  /**
    * Checkbox list items to render.
    */
   children: ReactNode;
@@ -141,6 +148,7 @@ export function XDSCheckboxList({
   density = 'balanced',
   hasDividers = false,
   isDisabled = false,
+  isReadOnly = false,
   children,
   ref,
   xstyle,
@@ -172,6 +180,7 @@ export function XDSCheckboxList({
     value: isCollectionMode ? optimisticValue : undefined,
     onChange: isCollectionMode ? handleChange : undefined,
     isDisabled,
+    isReadOnly,
     isBusy,
   };
 

--- a/packages/core/src/CheckboxList/XDSCheckboxListContext.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListContext.tsx
@@ -13,6 +13,7 @@ export interface XDSCheckboxListContextValue {
   value?: string[];
   onChange?: (values: string[]) => void;
   isDisabled: boolean;
+  isReadOnly: boolean;
   isBusy: boolean;
 }
 

--- a/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
@@ -183,7 +183,10 @@ export function XDSCheckboxListItem({
       aria-busy={isBusy || undefined}
       xstyle={
         [
-          resolvedChecked === true && !effectiveDisabled && styles.selected,
+          resolvedChecked === true &&
+            !effectiveDisabled &&
+            !effectiveReadOnly &&
+            styles.selected,
           xstyle,
         ] as StyleXStyles
       }

--- a/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/XDSCheckboxListItem.tsx
@@ -40,8 +40,12 @@ const styles = stylex.create({
 export interface XDSCheckboxListItemProps extends XDSBaseProps<HTMLLIElement> {
   /**
    * Primary text label for the item.
+   *
+   * Accepts a plain string (single-line truncation applied automatically)
+   * or a ReactNode for rich content (no truncation constraints —
+   * child components control their own text behavior).
    */
-  label: string;
+  label: ReactNode;
   /**
    * Identity key for collection mode (REQUIRED inside XDSCheckboxList).
    * Throws a runtime error if missing when used inside XDSCheckboxList.
@@ -129,6 +133,7 @@ export function XDSCheckboxListItem({
 
   // Disabled: parent-level OR item-level
   const effectiveDisabled = (ctx?.isDisabled ?? false) || isItemDisabled;
+  const effectiveReadOnly = ctx?.isReadOnly ?? false;
   const isBusy = ctx?.isBusy ?? false;
 
   // Resolve checked state:
@@ -143,10 +148,10 @@ export function XDSCheckboxListItem({
   }
 
   // Whether this item is interactive (has a toggle handler)
-  const isInteractive = ctx != null || onCheck != null;
+  const isInteractive = !effectiveReadOnly && (ctx != null || onCheck != null);
 
   const handleToggle = () => {
-    if (effectiveDisabled || isBusy) return;
+    if (effectiveDisabled || effectiveReadOnly || isBusy) return;
 
     if (ctx && ctx.value !== undefined) {
       // Collection mode
@@ -186,13 +191,14 @@ export function XDSCheckboxListItem({
       style={style}
       startContent={
         <XDSCheckboxInput
-          label={label}
+          label={typeof label === 'string' ? label : 'Checkbox'}
           isLabelHidden
           value={resolvedChecked}
           onChange={() => handleToggle()}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           isDisabled={effectiveDisabled}
+          isReadOnly={effectiveReadOnly}
           size={checkboxSize}
         />
       }

--- a/packages/core/src/List/XDSListItem.tsx
+++ b/packages/core/src/List/XDSListItem.tsx
@@ -38,8 +38,12 @@ export interface XDSListItemProps extends XDSBaseProps<HTMLLIElement> {
   ref?: React.Ref<HTMLLIElement>;
   /**
    * Primary text label for the item.
+   *
+   * Accepts a plain string (single-line truncation applied automatically)
+   * or a ReactNode for rich content (no truncation constraints —
+   * child components control their own text behavior).
    */
-  label: string;
+  label: ReactNode;
 
   /**
    * Secondary description below the label.
@@ -189,6 +193,8 @@ const styles = stylex.create({
   },
   label: {
     color: colorVars['--color-text-primary'],
+  },
+  labelTruncate: {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
@@ -338,11 +344,15 @@ export function XDSListItem({
   const hasMarkers = listStyle !== 'none';
   const isInteractive = onClick != null || href != null;
 
+  const isStringLabel = typeof label === 'string';
   const isStringDescription = typeof description === 'string';
 
   const labelAndDescription = (
     <>
-      <span {...stylex.props(styles.label)}>{label}</span>
+      <span
+        {...stylex.props(styles.label, isStringLabel && styles.labelTruncate)}>
+        {label}
+      </span>
       {description != null && (
         <span
           {...stylex.props(

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -23,6 +23,8 @@ import {
 import {XDSCodeBlock, XDSCode} from '../CodeBlock';
 import {XDSCheckboxList} from '../CheckboxList/XDSCheckboxList';
 import {XDSCheckboxListItem} from '../CheckboxList/XDSCheckboxListItem';
+import {XDSList} from '../List/XDSList';
+import {XDSListItem} from '../List/XDSListItem';
 import {xdsClassName, mergeProps} from '../utils';
 import {
   parseMarkdown,
@@ -30,11 +32,7 @@ import {
   createIncrementalState,
   trimStreamingArtifacts,
 } from './parser';
-import type {
-  BlockNode,
-  InlineNode,
-  IncrementalState,
-} from './parser';
+import type {BlockNode, InlineNode, IncrementalState} from './parser';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -53,7 +51,10 @@ export interface XDSMarkdownProps {
    */
   headingLevelStart?: 1 | 2 | 3 | 4 | 5 | 6;
   isStreaming?: boolean;
-  onLinkClick?: (href: string, event: React.MouseEvent<HTMLAnchorElement>) => void | false;
+  onLinkClick?: (
+    href: string,
+    event: React.MouseEvent<HTMLAnchorElement>,
+  ) => void | false;
   xstyle?: StyleXStyles;
   className?: string;
   style?: React.CSSProperties;
@@ -196,11 +197,6 @@ const styles = stylex.create({
     marginInlineStart: 0,
     marginInlineEnd: 0,
   },
-  // List
-  list: {
-    paddingInlineStart: spacingVars['--spacing-6'],
-  },
-
   // Table
   tableWrapper: {
     overflowX: 'auto',
@@ -312,7 +308,11 @@ function renderInline(
       const safeHref = sanitizeUrl(node.href);
       if (safeHref == null) {
         // Unsafe URL — render as plain text
-        return <span key={index}>{node.children.map((c, i) => renderInline(c, i, onLinkClick))}</span>;
+        return (
+          <span key={index}>
+            {node.children.map((c, i) => renderInline(c, i, onLinkClick))}
+          </span>
+        );
       }
       const isExternal = safeHref.startsWith('http');
       const handleClick = onLinkClick
@@ -328,9 +328,10 @@ function renderInline(
           key={index}
           href={safeHref}
           onClick={handleClick}
-          {...(isExternal ? {target: '_blank', rel: 'noopener noreferrer'} : {})}
-          {...stylex.props(styles.link)}
-        >
+          {...(isExternal
+            ? {target: '_blank', rel: 'noopener noreferrer'}
+            : {})}
+          {...stylex.props(styles.link)}>
           {node.children.map((c, i) => renderInline(c, i, onLinkClick))}
         </a>
       );
@@ -338,7 +339,14 @@ function renderInline(
     case 'image': {
       const safeSrc = sanitizeUrl(node.src);
       if (safeSrc == null) return <span key={index}>[{node.alt}]</span>;
-      return <img key={index} src={safeSrc} alt={node.alt} {...stylex.props(styles.image)} />;
+      return (
+        <img
+          key={index}
+          src={safeSrc}
+          alt={node.alt}
+          {...stylex.props(styles.image)}
+        />
+      );
     }
     case 'break':
       return <br key={index} />;
@@ -357,14 +365,24 @@ function getElementSpacing(
   switch (node.type) {
     case 'heading':
       return node.level <= 3
-        ? (compact ? styles.spacingHeadingMajorCompact : styles.spacingHeadingMajorDefault)
-        : (compact ? styles.spacingHeadingMinorCompact : styles.spacingHeadingMinorDefault);
+        ? compact
+          ? styles.spacingHeadingMajorCompact
+          : styles.spacingHeadingMajorDefault
+        : compact
+          ? styles.spacingHeadingMinorCompact
+          : styles.spacingHeadingMinorDefault;
     case 'paragraph':
-      return compact ? styles.spacingParagraphCompact : styles.spacingParagraphDefault;
+      return compact
+        ? styles.spacingParagraphCompact
+        : styles.spacingParagraphDefault;
     case 'codeblock':
-      return compact ? styles.spacingCodeblockCompact : styles.spacingCodeblockDefault;
+      return compact
+        ? styles.spacingCodeblockCompact
+        : styles.spacingCodeblockDefault;
     case 'blockquote':
-      return compact ? styles.spacingBlockquoteCompact : styles.spacingBlockquoteDefault;
+      return compact
+        ? styles.spacingBlockquoteCompact
+        : styles.spacingBlockquoteDefault;
     case 'list':
       return compact ? styles.spacingListCompact : styles.spacingListDefault;
     case 'table':
@@ -394,7 +412,13 @@ function renderBlock(
 
   switch (node.type) {
     case 'heading': {
-      const level = Math.min(node.level + headingLevelStart - 1, 6) as 1 | 2 | 3 | 4 | 5 | 6;
+      const level = Math.min(node.level + headingLevelStart - 1, 6) as
+        | 1
+        | 2
+        | 3
+        | 4
+        | 5
+        | 6;
       const Tag = `h${level}` as const;
       return (
         <Tag
@@ -405,8 +429,7 @@ function renderBlock(
             spacing,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
-          )}
-        >
+          )}>
           {node.children.map((c, i) => renderInline(c, i, onLinkClick))}
         </Tag>
       );
@@ -419,8 +442,7 @@ function renderBlock(
             spacing,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
-          )}
-        >
+          )}>
           {node.children.map((c, i) => renderInline(c, i, onLinkClick))}
         </p>
       );
@@ -432,8 +454,7 @@ function renderBlock(
             spacing,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
-          )}
-        >
+          )}>
           <XDSCodeBlock code={node.content} language={node.language} />
         </div>
       );
@@ -446,17 +467,26 @@ function renderBlock(
             spacing,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
+          )}>
+          {node.children.map((c, i) =>
+            renderBlock(
+              c,
+              i,
+              node.children.length,
+              density,
+              headingLevelStart,
+              onLinkClick,
+            ),
           )}
-        >
-          {node.children.map((c, i) => renderBlock(c, i, node.children.length, density, headingLevelStart, onLinkClick))}
         </blockquote>
       );
     case 'list': {
       // Detect task lists: all items have a checked state
-      const isTaskList = node.items.length > 0 && node.items.every(item => item.checked != null);
+      const isTaskList =
+        node.items.length > 0 && node.items.every(item => item.checked != null);
 
       if (isTaskList) {
-        // Extract labels from task items — use first paragraph's inline text
+        // Extract labels from task items — render as rich inline content
         const checkedValues = node.items
           .map((item, i) => ({item, key: `task-${i}`}))
           .filter(({item}) => item.checked)
@@ -469,33 +499,45 @@ function renderBlock(
               spacing,
               isFirst && styles.noMarginBlockStart,
               isLast && styles.noMarginBlockEnd,
-            )}
-          >
+            )}>
             <XDSCheckboxList
               label="Task list"
               isLabelHidden
               value={checkedValues}
-              isDisabled
-              density={density === 'compact' ? 'compact' : 'balanced'}
-            >
+              isReadOnly
+              density="compact">
               {node.items.map((item, i) => {
                 const firstChild = item.children[0];
-                const isInline = item.children.length === 1 && firstChild?.type === 'paragraph';
-                // Build label from first paragraph text
-                const label = isInline
-                  ? firstChild.children.map(c => c.type === 'text' ? c.content : '').join('')
-                  : `Item ${i + 1}`;
+                const isInline =
+                  item.children.length === 1 &&
+                  firstChild?.type === 'paragraph';
+
+                const label = isInline ? (
+                  <>
+                    {firstChild.children.map((c, j) =>
+                      renderInline(c, j, onLinkClick),
+                    )}
+                  </>
+                ) : (
+                  <>
+                    {item.children.map((c, j) =>
+                      renderBlock(
+                        c,
+                        j,
+                        item.children.length,
+                        density,
+                        headingLevelStart,
+                        onLinkClick,
+                      ),
+                    )}
+                  </>
+                );
 
                 return (
                   <XDSCheckboxListItem
                     key={i}
                     value={`task-${i}`}
                     label={label}
-                    description={
-                      isInline
-                        ? undefined
-                        : undefined
-                    }
                   />
                 );
               })}
@@ -504,38 +546,56 @@ function renderBlock(
         );
       }
 
-      const Tag = node.ordered ? 'ol' : 'ul';
       return (
-        <Tag
+        <div
           key={index}
-          {...(node.ordered && node.start != null ? {start: node.start} : {})}
           {...stylex.props(
-            styles.list,
             spacing,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
-          )}
-        >
-          {node.items.map((item, i) => {
-            const firstChild = item.children[0];
-            const isInline = item.children.length === 1 && firstChild?.type === 'paragraph';
+          )}>
+          <XDSList
+            listStyle={node.ordered ? 'decimal' : 'disc'}
+            density="compact">
+            {node.items.map((item, i) => {
+              const firstChild = item.children[0];
+              const isInline =
+                item.children.length === 1 && firstChild?.type === 'paragraph';
 
-            return (
-              <li key={i}>
-                {isInline ? (
-                  <span>{firstChild.children.map((c, j) => renderInline(c, j, onLinkClick))}</span>
-                ) : (
-                  item.children.map((c, j) => renderBlock(c, j, item.children.length, density, headingLevelStart, onLinkClick))
-                )}
-              </li>
-            );
-          })}
-        </Tag>
+              const label = isInline ? (
+                <>
+                  {firstChild.children.map((c, j) =>
+                    renderInline(c, j, onLinkClick),
+                  )}
+                </>
+              ) : (
+                <>
+                  {item.children.map((c, j) =>
+                    renderBlock(
+                      c,
+                      j,
+                      item.children.length,
+                      density,
+                      headingLevelStart,
+                      onLinkClick,
+                    ),
+                  )}
+                </>
+              );
+
+              return <XDSListItem key={i} label={label} />;
+            })}
+          </XDSList>
+        </div>
       );
     }
     case 'table': {
-      const alignStyle = (a: typeof node.alignments[number]) =>
-        a === 'center' ? styles.alignCenter : a === 'right' ? styles.alignRight : styles.alignLeft;
+      const alignStyle = (a: (typeof node.alignments)[number]) =>
+        a === 'center'
+          ? styles.alignCenter
+          : a === 'right'
+            ? styles.alignRight
+            : styles.alignLeft;
       return (
         <div
           key={index}
@@ -544,13 +604,17 @@ function renderBlock(
             spacing,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
-          )}
-        >
+          )}>
           <table {...stylex.props(styles.table)}>
             <thead>
               <tr>
                 {node.headers.map((h, i) => (
-                  <th key={i} {...stylex.props(styles.th, alignStyle(node.alignments[i]))}>
+                  <th
+                    key={i}
+                    {...stylex.props(
+                      styles.th,
+                      alignStyle(node.alignments[i]),
+                    )}>
                     {h.children.map((c, j) => renderInline(c, j, onLinkClick))}
                   </th>
                 ))}
@@ -560,8 +624,15 @@ function renderBlock(
               {node.rows.map((row, i) => (
                 <tr key={i}>
                   {row.map((cell, j) => (
-                    <td key={j} {...stylex.props(styles.td, alignStyle(node.alignments[j]))}>
-                      {cell.children.map((c, k) => renderInline(c, k, onLinkClick))}
+                    <td
+                      key={j}
+                      {...stylex.props(
+                        styles.td,
+                        alignStyle(node.alignments[j]),
+                      )}>
+                      {cell.children.map((c, k) =>
+                        renderInline(c, k, onLinkClick),
+                      )}
                     </td>
                   ))}
                 </tr>
@@ -593,8 +664,7 @@ function renderBlock(
               spacing,
               isFirst && styles.noMarginBlockStart,
               isLast && styles.noMarginBlockEnd,
-            )}
-          >
+            )}>
             [{node.alt}]
           </p>
         );
@@ -606,8 +676,7 @@ function renderBlock(
             spacing,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
-          )}
-        >
+          )}>
           <img src={safeSrc} alt={node.alt} {...stylex.props(styles.image)} />
         </p>
       );
@@ -655,9 +724,17 @@ export function XDSMarkdown({
         stylex.props(styles.root, xstyle),
         className,
         style,
+      )}>
+      {blocks.map((block, i) =>
+        renderBlock(
+          block,
+          i,
+          blocks.length,
+          density,
+          headingLevelStart,
+          onLinkClick,
+        ),
       )}
-    >
-      {blocks.map((block, i) => renderBlock(block, i, blocks.length, density, headingLevelStart, onLinkClick))}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Three related improvements to how XDSMarkdown renders lists:

### 1. Use XDSList/XDSListItem for regular lists
Replaces raw `<ol>`/`<ul>`/`<li>` elements with `XDSList` and `XDSListItem`. The CSS reset strips `list-style: none` globally, so markdown lists had no bullet/number markers. Now uses `listStyle='disc'`/`'decimal'` and `density='compact'`.

### 2. Add `isReadOnly` to the checkbox chain
Adds `isReadOnly` prop to `XDSCheckboxInput`, `XDSCheckboxList`, and `XDSCheckboxListItem`. Unlike `isDisabled` (which dims to 0.5 opacity), `isReadOnly` renders at full opacity but prevents interaction. Markdown task lists now use `isReadOnly` instead of `isDisabled` so checkboxes are clearly visible.

### 3. Widen label types to ReactNode
`XDSListItem.label` and `XDSCheckboxListItem.label` now accept `ReactNode` (not just `string`). String labels still get single-line truncation; ReactNode labels render freely. This lets the markdown renderer pass rich inline content (bold, links, code) directly as labels instead of extracting plain text.

## Changes
| File | What |
|------|------|
| `XDSCheckboxInput` | Add `isReadOnly` prop, `readOnly` attr, `aria-readonly` |
| `XDSCheckboxList` | Add `isReadOnly` prop, pass through context |
| `XDSCheckboxListContext` | Add `isReadOnly` to context value |
| `XDSCheckboxListItem` | Wire `isReadOnly` from context, widen `label` to ReactNode |
| `XDSListItem` | Widen `label` to ReactNode, conditional truncation |
| `XDSMarkdown` | Use XDSList/XDSListItem, `isReadOnly` for task lists, compact density |

## Test plan
- All 29 XDSMarkdown tests pass
- All 47 XDSList tests pass
- All 28 XDSCheckboxList tests pass
- All 16 XDSCheckboxInput tests pass
