### PR TITLE
fix(Dialog): auto-capture trigger element, remove triggerRef prop

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/theme-editor/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/theme-editor/page.tsx
@@ -1669,7 +1669,6 @@ function MotionPreview() {
   >(null);
   const [modalOpen, setModalOpen] = React.useState(false);
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const modalTriggerRef = React.useRef<HTMLButtonElement>(null);
   const [containerWidth, setContainerWidth] = React.useState(1200);
 
   React.useEffect(() => {
@@ -1849,7 +1848,6 @@ function MotionPreview() {
               </div>
               <XDSHStack gap={1}>
                 <XDSButton
-                  ref={modalTriggerRef}
                   label="Modal"
                   variant="secondary"
                   onClick={() => setModalOpen(true)}
@@ -2008,10 +2006,7 @@ function MotionPreview() {
           </div>
         </div>
       </XDSAppShell>
-      <XDSDialog
-        isOpen={modalOpen}
-        onOpenChange={setModalOpen}
-        triggerRef={modalTriggerRef}>
+      <XDSDialog isOpen={modalOpen} onOpenChange={setModalOpen}>
         <div style={{padding: 'var(--spacing-3)', flex: 1}}>
           <XDSText type="body" color="secondary">
             This modal uses XDSDialog with directional entry animation from the
@@ -2095,7 +2090,6 @@ function NavigationOverlaysPreview({
   setOverlayOpen: (v: boolean) => void;
 }) {
   const [modalOpen, setModalOpen] = React.useState(false);
-  const modalTriggerRef = React.useRef<HTMLButtonElement>(null);
 
   return (
     <>
@@ -2110,7 +2104,6 @@ function NavigationOverlaysPreview({
             </XDSText>
             <div style={{marginTop: 8}}>
               <XDSButton
-                ref={modalTriggerRef}
                 label="Open Modal"
                 onClick={() => setModalOpen(true)}
               />
@@ -2139,10 +2132,7 @@ function NavigationOverlaysPreview({
           </div>
         </XDSVStack>
       </XDSCard>
-      <XDSDialog
-        isOpen={modalOpen}
-        onOpenChange={setModalOpen}
-        triggerRef={modalTriggerRef}>
+      <XDSDialog isOpen={modalOpen} onOpenChange={setModalOpen}>
         <div style={{padding: 'var(--spacing-3)'}}>
           <XDSText type="body" color="secondary">
             This modal uses the XDSDialog component with directional entry

--- a/packages/core/src/Dialog/Dialog.doc.mjs
+++ b/packages/core/src/Dialog/Dialog.doc.mjs
@@ -148,12 +148,6 @@ function Example() {
           required: true,
         },
         {
-          name: 'triggerRef',
-          type: 'RefObject<HTMLElement | null>',
-          description:
-            'Ref to the trigger element that opened the dialog. When provided, the entry animation slides from the direction of the trigger and focus returns to the trigger on close.',
-        },
-        {
           name: 'width',
           type: 'number | string',
           description: 'Width of the dialog in pixels or any CSS value.',
@@ -411,12 +405,6 @@ function Example() {
           type: 'ReactNode',
           description: '对话框内容。',
           required: true,
-        },
-        {
-          name: 'triggerRef',
-          type: 'RefObject<HTMLElement | null>',
-          description:
-            '打开对话框的触发元素的引用。提供时，进入动画从触发方向滑入，关闭时焦点返回到触发元素。',
         },
         {
           name: 'width',

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -13,7 +13,7 @@
  * - /apps/storybook/stories/Dialog.stories.tsx (storybook stories)
  */
 
-import {useEffect, useRef, type ReactNode, type RefObject} from 'react';
+import {useEffect, useRef, type ReactNode} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {useScrollLock} from '../hooks/useScrollLock';
@@ -216,14 +216,6 @@ export interface XDSDialogProps extends XDSBaseProps<HTMLDialogElement> {
   onOpenChange: (isOpen: boolean) => unknown;
 
   /**
-   * Ref to the trigger element that opens the dialog.
-   * When provided, the dialog entry animation slides from the direction
-   * of the trigger toward the viewport center. Focus is returned to
-   * the trigger when the dialog closes.
-   */
-  triggerRef?: RefObject<HTMLElement | null>;
-
-  /**
    * The width of the dialog.
    * Numbers are treated as pixels, strings are used as-is.
    * Ignored when variant is 'fullscreen'.
@@ -292,7 +284,6 @@ export interface XDSDialogProps extends XDSBaseProps<HTMLDialogElement> {
 export function XDSDialog({
   isOpen,
   onOpenChange,
-  triggerRef,
   width = 400,
   maxHeight = '75vh',
   position,
@@ -306,6 +297,10 @@ export function XDSDialog({
   ...props
 }: XDSDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+
+  // Capture the element that was focused when the dialog opened,
+  // for directional animation origin and focus restoration on close.
+  const triggerElementRef = useRef<HTMLElement | null>(null);
 
   // Derive dismissal behavior from purpose
   const allowEscape = purpose !== 'required';
@@ -328,9 +323,13 @@ export function XDSDialog({
     if (!dialog) return;
 
     if (isOpen) {
+      // Capture the currently focused element as the trigger — used for
+      // directional animation origin and focus restoration on close.
+      triggerElementRef.current = document.activeElement as HTMLElement | null;
+
       // Set directional CSS custom properties before opening
-      const trigger = triggerRef?.current;
-      if (trigger) {
+      const trigger = triggerElementRef.current;
+      if (trigger && trigger !== document.body) {
         const dir = getDialogDirection(trigger);
         dialog.style.setProperty('--dialog-dir-x', `${dir.x}px`);
         dialog.style.setProperty('--dialog-dir-y', `${dir.y}px`);
@@ -354,10 +353,11 @@ export function XDSDialog({
       if (dialog.open) {
         dialog.close();
       }
-      // Return focus to trigger
-      triggerRef?.current?.focus();
+      // Return focus to the element that opened the dialog
+      triggerElementRef.current?.focus();
+      triggerElementRef.current = null;
     }
-  }, [isOpen, triggerRef]);
+  }, [isOpen]);
 
   // Lock body scroll when dialog is open (iOS Safari workaround)
   useScrollLock(isOpen);


### PR DESCRIPTION
## Summary

Instead of requiring consumers to pass a `triggerRef`, the Dialog now captures `document.activeElement` at the moment `isOpen` flips to `true`. That element is the trigger — no prop needed.

This ref is used for two things:
1. *Directional animation* — slides from the trigger toward the viewport center
2. *Focus restoration* — returns focus when the dialog closes

## Why this is better

The `triggerRef` prop was added in #1102 alongside the directional animation, but it's redundant: the dialog already knows when it opens (via `isOpen`), and whatever had focus at that moment is the trigger by definition. Auto-capturing it eliminates a prop consumers had to remember to wire up.

```diff
- const triggerRef = useRef(null);
- <button ref={triggerRef} onClick={() => setOpen(true)}>Open</button>
- <XDSDialog isOpen={open} onOpenChange={setOpen} triggerRef={triggerRef}>

+ <button onClick={() => setOpen(true)}>Open</button>
+ <XDSDialog isOpen={open} onOpenChange={setOpen}>
```

## Changes

- `XDSDialog.tsx` — replace `triggerRef` prop with internal `triggerElementRef` that captures `document.activeElement` on open; null-guard for body focus
- `Dialog.doc.mjs` — remove `triggerRef` from props table (EN + ZH)
- `theme-editor/page.tsx` — remove `modalTriggerRef` wiring (two instances)

## No codemod needed

`triggerRef` was introduced in #1102 with no external consumers yet.

## Verification
- ✅ Build passes
- ✅ 2,612 tests pass (143 test files)
