### PR TITLE
fix(pagination): use nav-item selected style for active page button

### DIFF
--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -22,6 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
+  fontWeightVars,
   sizeVars,
   spacingVars,
   durationVars,
@@ -236,6 +237,10 @@ const styles = stylex.create({
   dotDisabled: {
     cursor: 'not-allowed',
     opacity: 0.5,
+  },
+  activePage: {
+    backgroundColor: colorVars['--color-neutral'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
   },
   pageSizeSelector: {
     display: 'flex',
@@ -453,11 +458,12 @@ export function XDSPagination({
                   key={item}
                   label={`Go to page ${item}`}
                   aria-label={`Go to page ${item}`}
-                  variant={isActive ? 'primary' : 'ghost'}
+                  variant="ghost"
                   size={buttonSize}
                   onClick={() => handlePageChange(item)}
                   isDisabled={isDisabled}
-                  aria-current={isActive ? 'page' : undefined}>
+                  aria-current={isActive ? 'page' : undefined}
+                  xstyle={isActive && styles.activePage}>
                   {item}
                 </XDSButton>
               );


### PR DESCRIPTION
Active page buttons in Pagination used `variant="primary"` (accent-colored fill), which felt visually heavy compared to the rest of the component.

This switches the active page to use the same visual treatment as a selected nav item (`navItemStyles.selected`):
- `variant="ghost"` base with a custom `xstyle` override
- `--color-neutral` background (subtle neutral fill)
- `--font-weight-medium` text weight

This aligns pagination with the established selected-state language used by SideNavItem and other navigation components — subtler and more consistent.