### PR TITLE
fix(Banner): use icon registry instead of hardcoded heroicon imports

### DIFF
--- a/packages/core/src/Banner/XDSBanner.test.tsx
+++ b/packages/core/src/Banner/XDSBanner.test.tsx
@@ -7,12 +7,17 @@
  * SYNC: When modified, update this header
  */
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {XDSBanner} from './XDSBanner';
+import {registerIcons, resetIcons} from '../Icon';
 
 describe('XDSBanner', () => {
+  afterEach(() => {
+    resetIcons();
+  });
+
   it('renders with title and status', () => {
     render(<XDSBanner status="info" title="Test Banner" />);
     expect(screen.getByText('Test Banner')).toBeInTheDocument();
@@ -277,5 +282,37 @@ describe('XDSBanner', () => {
     const ref = {current: null as HTMLDivElement | null};
     render(<XDSBanner ref={ref} status="info" title="Ref Test" />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  // =========================================================================
+  // Icon registry integration
+  // =========================================================================
+
+  it('uses icons from the global registry when registered', () => {
+    registerIcons({
+      info: (
+        <svg data-testid="custom-registry-icon">
+          <circle />
+        </svg>
+      ),
+    });
+    render(<XDSBanner status="info" title="Registry Test" />);
+    expect(screen.getByTestId('custom-registry-icon')).toBeInTheDocument();
+  });
+
+  it('uses chevronDown from the registry for expand/collapse', () => {
+    registerIcons({
+      chevronDown: (
+        <svg data-testid="custom-chevron">
+          <path d="M0 0" />
+        </svg>
+      ),
+    });
+    render(
+      <XDSBanner status="info" title="Chevron Test">
+        <div>Content</div>
+      </XDSBanner>,
+    );
+    expect(screen.getByTestId('custom-chevron')).toBeInTheDocument();
   });
 });

--- a/packages/core/src/Banner/XDSBanner.tsx
+++ b/packages/core/src/Banner/XDSBanner.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSBanner.tsx
- * @input Uses ReactuseState, @heroicons/react/24/solid icons, XDSButton, XDSIcon, StyleX
+ * @input Uses React useState, XDSButton, XDSIcon (with registry string names), StyleX
  * @output Exports XDSBanner component, XDSBannerProps, XDSBannerStatus, XDSBannerContainer types
  * @position Core implementation; consumed by index.ts, tested by XDSBanner.test.tsx
  *
@@ -22,16 +22,9 @@
 import {useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {
-  InformationCircleIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-  CheckCircleIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-} from '@heroicons/react/24/solid';
 import {XDSButton} from '../Button';
 import {XDSIcon} from '../Icon';
+import type {XDSIconName} from '../Icon';
 import {
   colorVars,
   spacingVars,
@@ -189,11 +182,11 @@ export interface XDSBannerProps {
 // Status → Icon mapping
 // =============================================================================
 
-const defaultIcons: Record<XDSBannerStatus, typeof InformationCircleIcon> = {
-  info: InformationCircleIcon,
-  warning: ExclamationTriangleIcon,
-  error: XCircleIcon,
-  success: CheckCircleIcon,
+const defaultIconNames: Record<XDSBannerStatus, XDSIconName> = {
+  info: 'info',
+  warning: 'warning',
+  error: 'xCircle',
+  success: 'checkCircle',
 };
 
 // =============================================================================
@@ -307,6 +300,13 @@ const styles = stylex.create({
     borderBottomLeftRadius: 'var(--banner-radius)',
     borderBottomRightRadius: 'var(--banner-radius)',
   },
+  chevron: {
+    display: 'inline-flex',
+    transition: 'transform 150ms ease',
+  },
+  chevronExpanded: {
+    transform: 'rotate(180deg)',
+  },
 });
 
 const statusStyles = stylex.create({
@@ -392,7 +392,7 @@ export function XDSBanner({
 }: XDSBannerProps) {
   const [isDismissed, setIsDismissed] = useState(false);
   const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
-  const DefaultIcon = defaultIcons[status];
+  const defaultIconName = defaultIconNames[status];
   const role = statusRole[status];
   const iconColor = statusIconColor[status];
   const hasChildren = children != null;
@@ -449,7 +449,7 @@ export function XDSBanner({
           {icon != null ? (
             icon
           ) : (
-            <XDSIcon icon={DefaultIcon} size="md" color={iconColor} />
+            <XDSIcon icon={defaultIconName} size="md" color={iconColor} />
           )}
         </div>
         <div {...stylex.props(styles.headerContent)}>
@@ -468,11 +468,13 @@ export function XDSBanner({
                 label={isExpanded ? 'Collapse' : 'Expand'}
                 tooltip={isExpanded ? 'Collapse' : 'Expand'}
                 icon={
-                  <XDSIcon
-                    icon={isExpanded ? ChevronUpIcon : ChevronDownIcon}
-                    size="sm"
-                    color="inherit"
-                  />
+                  <span
+                    {...stylex.props(
+                      styles.chevron,
+                      isExpanded && styles.chevronExpanded,
+                    )}>
+                    <XDSIcon icon="chevronDown" size="sm" color="inherit" />
+                  </span>
                 }
                 onClick={handleToggleExpand}
                 aria-expanded={isExpanded}


### PR DESCRIPTION
## Summary

`XDSBanner` was importing heroicon components directly and passing them as component references to `XDSIcon`, which bypassed the global icon registry entirely. Icons registered via `registerIcons()` had no effect on banner status icons or chevrons.

## Changes

- **Status icons** (`info`, `warning`, `error`, `success`) now use semantic string names (`'info'`, `'warning'`, `'xCircle'`, `'checkCircle'`) that resolve through `getIcon()`
- **Expand/collapse chevron** uses `'chevronDown'` with a CSS `rotate(180deg)` transition instead of toggling between `ChevronDownIcon`/`ChevronUpIcon` components — avoids needing a new `'chevronUp'` registry entry
- **Removed** the `@heroicons/react/24/solid` import from `XDSBanner.tsx` entirely
- **Added** 2 tests validating that `registerIcons()` overrides are respected by the banner

## Before / After

| Before | After |
|--------|-------|
| `<XDSIcon icon={InformationCircleIcon} />` | `<XDSIcon icon="info" />` |
| `<XDSIcon icon={ChevronUpIcon} />` | `'chevronDown'` + CSS rotation |
| `registerIcons()` ignored by banner | `registerIcons()` works ✓ |

Closes #1150

---
