### PR TITLE
refactor(Table): decompose useXDSTableColumnSettings into state + plugin + adapter

### DIFF
--- a/apps/storybook/stories/TableColumnSettings.stories.tsx
+++ b/apps/storybook/stories/TableColumnSettings.stories.tsx
@@ -3,6 +3,8 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {
   XDSTable,
   useXDSTableColumnSettings,
+  useXDSTableColumnSettingsState,
+  toColumnSelectorOptions,
   useXDSTableSelection,
   useXDSTableSelectionState,
 } from '@xds/core/Table';
@@ -111,11 +113,13 @@ export const BasicColumnToggle: Story = {
     const [activeKeys, setActiveKeys] =
       useState<UserColumnKey[]>(defaultActiveKeys);
 
-    const columnSettings = useXDSTableColumnSettings<User, UserColumnKey>({
+    const state = useXDSTableColumnSettingsState<UserColumnKey>({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
       onChangeActiveColumnKeys: setActiveKeys,
     });
+    const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
+    const selectorOptions = toColumnSelectorOptions(columnOptions);
 
     return (
       <div style={{maxWidth: 700}}>
@@ -126,9 +130,9 @@ export const BasicColumnToggle: Story = {
             <XDSMultiSelector
               label="Columns"
               isLabelHidden
-              options={columnSettings.columnOptions}
-              value={[...columnSettings.activeColumnKeys]}
-              onChange={columnSettings.setActiveColumnKeys}
+              options={selectorOptions}
+              value={[...state.activeColumnKeys]}
+              onChange={state.setActiveColumnKeys}
             />
           }
         />
@@ -136,7 +140,7 @@ export const BasicColumnToggle: Story = {
           data={users}
           columns={allColumns}
           idKey="id"
-          plugins={{columnSettings: columnSettings.plugin}}
+          plugins={{columnSettings: plugin}}
         />
       </div>
     );
@@ -151,11 +155,13 @@ export const DisabledColumns: Story = {
       'role',
     ]);
 
-    const columnSettings = useXDSTableColumnSettings<User, UserColumnKey>({
+    const state = useXDSTableColumnSettingsState<UserColumnKey>({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
       onChangeActiveColumnKeys: setActiveKeys,
     });
+    const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
+    const selectorOptions = toColumnSelectorOptions(columnOptions);
 
     return (
       <div style={{maxWidth: 700}}>
@@ -169,9 +175,9 @@ export const DisabledColumns: Story = {
             <XDSMultiSelector
               label="Columns"
               isLabelHidden
-              options={columnSettings.columnOptions}
-              value={[...columnSettings.activeColumnKeys]}
-              onChange={columnSettings.setActiveColumnKeys}
+              options={selectorOptions}
+              value={[...state.activeColumnKeys]}
+              onChange={state.setActiveColumnKeys}
             />
           }
         />
@@ -179,7 +185,7 @@ export const DisabledColumns: Story = {
           data={users}
           columns={allColumns}
           idKey="id"
-          plugins={{columnSettings: columnSettings.plugin}}
+          plugins={{columnSettings: plugin}}
         />
       </div>
     );
@@ -190,15 +196,16 @@ export const ResetToDefault: Story = {
   render: () => {
     const defaultKeys: UserColumnKey[] = ['name', 'email', 'role'];
 
-    const [activeKeys, setActiveKeys] =
-      useState<UserColumnKey[]>(defaultKeys);
+    const [activeKeys, setActiveKeys] = useState<UserColumnKey[]>(defaultKeys);
 
-    const columnSettings = useXDSTableColumnSettings<User, UserColumnKey>({
+    const state = useXDSTableColumnSettingsState<UserColumnKey>({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
       onChangeActiveColumnKeys: setActiveKeys,
       defaultColumnKeys: defaultKeys,
     });
+    const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
+    const selectorOptions = toColumnSelectorOptions(columnOptions);
 
     return (
       <div style={{maxWidth: 700}}>
@@ -214,14 +221,14 @@ export const ResetToDefault: Story = {
               <XDSButton
                 label="Reset to default"
                 variant="secondary"
-                onClick={columnSettings.resetToDefault}
+                onClick={state.resetToDefault}
               />
               <XDSMultiSelector
                 label="Columns"
                 isLabelHidden
-                options={columnSettings.columnOptions}
-                value={[...columnSettings.activeColumnKeys]}
-                onChange={columnSettings.setActiveColumnKeys}
+                options={selectorOptions}
+                value={[...state.activeColumnKeys]}
+                onChange={state.setActiveColumnKeys}
               />
             </>
           }
@@ -230,7 +237,7 @@ export const ResetToDefault: Story = {
           data={users}
           columns={allColumns}
           idKey="id"
-          plugins={{columnSettings: columnSettings.plugin}}
+          plugins={{columnSettings: plugin}}
         />
       </div>
     );
@@ -243,11 +250,15 @@ export const WithSelection: Story = {
       useState<UserColumnKey[]>(defaultActiveKeys);
     const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
 
-    const columnSettings = useXDSTableColumnSettings<User, UserColumnKey>({
+    const state = useXDSTableColumnSettingsState<UserColumnKey>({
       columns: columnOptions,
       activeColumnKeys: activeKeys,
       onChangeActiveColumnKeys: setActiveKeys,
     });
+    const columnPlugin = useXDSTableColumnSettings<User>(
+      state.columnSettingsConfig,
+    );
+    const selectorOptions = toColumnSelectorOptions(columnOptions);
 
     const {selectionConfig} = useXDSTableSelectionState<User>({
       data: users,
@@ -270,9 +281,9 @@ export const WithSelection: Story = {
             <XDSMultiSelector
               label="Columns"
               isLabelHidden
-              options={columnSettings.columnOptions}
-              value={[...columnSettings.activeColumnKeys]}
-              onChange={columnSettings.setActiveColumnKeys}
+              options={selectorOptions}
+              value={[...state.activeColumnKeys]}
+              onChange={state.setActiveColumnKeys}
             />
           }
         />
@@ -281,7 +292,7 @@ export const WithSelection: Story = {
           columns={allColumns}
           idKey="id"
           plugins={{
-            columnSettings: columnSettings.plugin,
+            columnSettings: columnPlugin,
             selection: selectionPlugin,
           }}
         />

--- a/apps/storybook/stories/TableColumnSettings.stories.tsx
+++ b/apps/storybook/stories/TableColumnSettings.stories.tsx
@@ -4,7 +4,6 @@ import {
   XDSTable,
   useXDSTableColumnSettings,
   useXDSTableColumnSettingsState,
-  toColumnSelectorOptions,
   useXDSTableSelection,
   useXDSTableSelectionState,
 } from '@xds/core/Table';
@@ -119,7 +118,11 @@ export const BasicColumnToggle: Story = {
       onChangeActiveColumnKeys: setActiveKeys,
     });
     const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
-    const selectorOptions = toColumnSelectorOptions(columnOptions);
+    const selectorOptions = columnOptions.map(c => ({
+      value: c.key,
+      label: c.label,
+      disabled: c.isAlwaysVisible === true,
+    }));
 
     return (
       <div style={{maxWidth: 700}}>
@@ -161,7 +164,11 @@ export const DisabledColumns: Story = {
       onChangeActiveColumnKeys: setActiveKeys,
     });
     const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
-    const selectorOptions = toColumnSelectorOptions(columnOptions);
+    const selectorOptions = columnOptions.map(c => ({
+      value: c.key,
+      label: c.label,
+      disabled: c.isAlwaysVisible === true,
+    }));
 
     return (
       <div style={{maxWidth: 700}}>
@@ -205,7 +212,11 @@ export const ResetToDefault: Story = {
       defaultColumnKeys: defaultKeys,
     });
     const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
-    const selectorOptions = toColumnSelectorOptions(columnOptions);
+    const selectorOptions = columnOptions.map(c => ({
+      value: c.key,
+      label: c.label,
+      disabled: c.isAlwaysVisible === true,
+    }));
 
     return (
       <div style={{maxWidth: 700}}>
@@ -258,7 +269,11 @@ export const WithSelection: Story = {
     const columnPlugin = useXDSTableColumnSettings<User>(
       state.columnSettingsConfig,
     );
-    const selectorOptions = toColumnSelectorOptions(columnOptions);
+    const selectorOptions = columnOptions.map(c => ({
+      value: c.key,
+      label: c.label,
+      disabled: c.isAlwaysVisible === true,
+    }));
 
     const {selectionConfig} = useXDSTableSelectionState<User>({
       data: users,

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -19,7 +19,12 @@ export {useXDSTableSelection} from './plugins/selection';
 export {useXDSTableSelectionState} from './plugins/selection';
 export {useXDSTableSortable} from './plugins/sortable';
 export {useXDSTablePagination} from './plugins/pagination';
-export {useXDSTableColumnSettings} from './plugins/columnSettings';
+export {
+  useXDSTableColumnSettings,
+  toColumnSelectorOptions,
+  filterActiveColumns,
+} from './plugins/columnSettings';
+export {useXDSTableColumnSettingsState} from './plugins/columnSettings';
 export {useXDSTableColumnResize} from './plugins/columnResize';
 export {
   useXDSTableFiltering,
@@ -77,8 +82,11 @@ export type {
 } from './plugins/pagination';
 export type {
   UseXDSTableColumnSettingsConfig,
-  UseXDSTableColumnSettingsReturn,
   XDSColumnSettingsOption,
+} from './plugins/columnSettings';
+export type {
+  UseXDSTableColumnSettingsStateConfig,
+  UseXDSTableColumnSettingsStateReturn,
 } from './plugins/columnSettings';
 export type {UseXDSTableColumnResizeConfig} from './plugins/columnResize';
 export type {

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -19,11 +19,7 @@ export {useXDSTableSelection} from './plugins/selection';
 export {useXDSTableSelectionState} from './plugins/selection';
 export {useXDSTableSortable} from './plugins/sortable';
 export {useXDSTablePagination} from './plugins/pagination';
-export {
-  useXDSTableColumnSettings,
-  toColumnSelectorOptions,
-  filterActiveColumns,
-} from './plugins/columnSettings';
+export {useXDSTableColumnSettings} from './plugins/columnSettings';
 export {useXDSTableColumnSettingsState} from './plugins/columnSettings';
 export {useXDSTableColumnResize} from './plugins/columnResize';
 export {

--- a/packages/core/src/Table/plugins/columnSettings/index.ts
+++ b/packages/core/src/Table/plugins/columnSettings/index.ts
@@ -1,6 +1,14 @@
-export {useXDSTableColumnSettings} from './useXDSTableColumnSettings';
+export {
+  useXDSTableColumnSettings,
+  toColumnSelectorOptions,
+  filterActiveColumns,
+} from './useXDSTableColumnSettings';
 export type {
   UseXDSTableColumnSettingsConfig,
-  UseXDSTableColumnSettingsReturn,
   XDSColumnSettingsOption,
 } from './useXDSTableColumnSettings';
+export {useXDSTableColumnSettingsState} from './useXDSTableColumnSettingsState';
+export type {
+  UseXDSTableColumnSettingsStateConfig,
+  UseXDSTableColumnSettingsStateReturn,
+} from './useXDSTableColumnSettingsState';

--- a/packages/core/src/Table/plugins/columnSettings/index.ts
+++ b/packages/core/src/Table/plugins/columnSettings/index.ts
@@ -1,8 +1,4 @@
-export {
-  useXDSTableColumnSettings,
-  toColumnSelectorOptions,
-  filterActiveColumns,
-} from './useXDSTableColumnSettings';
+export {useXDSTableColumnSettings} from './useXDSTableColumnSettings';
 export type {
   UseXDSTableColumnSettingsConfig,
   XDSColumnSettingsOption,

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
@@ -2,7 +2,7 @@
  * @file useXDSTableColumnSettings.test.tsx
  * @input useXDSTableColumnSettings, useXDSTableColumnSettingsState, XDSTable, React testing utilities
  * @output Functional tests for the column settings plugin, selector adapter, and integration
- * @position Test file; validates plugin behavior, toColumnSelectorOptions, filterActiveColumns
+ * @position Test file; validates plugin behavior and integration
  */
 
 import {describe, it, expect, vi} from 'vitest';
@@ -12,8 +12,6 @@ import {renderHook} from '@testing-library/react';
 import {XDSTable} from '../../XDSTable';
 import {
   useXDSTableColumnSettings,
-  toColumnSelectorOptions,
-  filterActiveColumns,
   type UseXDSTableColumnSettingsConfig,
   type XDSColumnSettingsOption,
 } from './useXDSTableColumnSettings';
@@ -115,129 +113,6 @@ describe('useXDSTableColumnSettings', () => {
     const firstPlugin = result.current;
     rerender();
     expect(result.current).toBe(firstPlugin);
-  });
-});
-
-// =============================================================================
-// toColumnSelectorOptions Tests
-// =============================================================================
-
-describe('toColumnSelectorOptions', () => {
-  it('generates one item per column for ungrouped columns', () => {
-    const options = toColumnSelectorOptions(columnOptions);
-    expect(options).toHaveLength(5);
-  });
-
-  it('marks always-visible columns as disabled', () => {
-    const options = toColumnSelectorOptions(columnOptions);
-    const nameItem = options[0];
-    expect(nameItem).toHaveProperty('disabled', true);
-    const emailItem = options[1];
-    expect(emailItem).toHaveProperty('disabled', false);
-  });
-
-  it('generates items with value and label', () => {
-    const options = toColumnSelectorOptions(columnOptions);
-    const first = options[0] as {value: string; label: string};
-    expect(first.value).toBe('name');
-    expect(first.label).toBe('Name');
-  });
-
-  it('groups columns by group field into sections', () => {
-    const groupedColumns: XDSColumnSettingsOption[] = [
-      {key: 'name', label: 'Name', isAlwaysVisible: true, group: 'Basic'},
-      {key: 'email', label: 'Email', group: 'Basic'},
-      {key: 'role', label: 'Role', group: 'Details'},
-      {key: 'status', label: 'Status'},
-    ];
-
-    const options = toColumnSelectorOptions(groupedColumns);
-
-    const sections = options.filter(
-      i => typeof i === 'object' && 'type' in i && i.type === 'section',
-    );
-    expect(sections).toHaveLength(2);
-
-    const basicSection = sections[0] as {
-      type: 'section';
-      title: string;
-      options: Array<{value: string}>;
-    };
-    expect(basicSection.title).toBe('Basic');
-    expect(basicSection.options).toHaveLength(2);
-
-    const lastItem = options[options.length - 1] as {value: string};
-    expect(lastItem.value).toBe('status');
-  });
-
-  it('handles empty columns', () => {
-    const options = toColumnSelectorOptions([]);
-    expect(options).toHaveLength(0);
-  });
-});
-
-// =============================================================================
-// filterActiveColumns Tests
-// =============================================================================
-
-describe('filterActiveColumns', () => {
-  it('filters columns to only active keys', () => {
-    const filtered = filterActiveColumns(allTableColumns, [
-      'name',
-      'email',
-      'role',
-    ]);
-    expect(filtered).toHaveLength(3);
-    expect(filtered.map(c => c.key)).toEqual(['name', 'email', 'role']);
-  });
-
-  it('preserves activeColumnKeys order', () => {
-    const filtered = filterActiveColumns(allTableColumns, [
-      'role',
-      'name',
-      'email',
-    ]);
-    expect(filtered.map(c => c.key)).toEqual(['role', 'name', 'email']);
-  });
-
-  it('handles unknown keys gracefully', () => {
-    const filtered = filterActiveColumns(allTableColumns, [
-      'name',
-      'nonexistent',
-      'email',
-    ]);
-    expect(filtered).toHaveLength(2);
-    expect(filtered.map(c => c.key)).toEqual(['name', 'email']);
-  });
-
-  it('returns empty array for empty activeColumnKeys', () => {
-    const filtered = filterActiveColumns(allTableColumns, []);
-    expect(filtered).toHaveLength(0);
-  });
-
-  it('returns all columns when all keys active', () => {
-    const filtered = filterActiveColumns(allTableColumns, [
-      'name',
-      'email',
-      'role',
-      'status',
-      'lastLogin',
-    ]);
-    expect(filtered).toHaveLength(5);
-  });
-
-  it('maintains XDSTableColumn shape', () => {
-    const columnsWithRenderCell: XDSTableColumn<User>[] = [
-      {key: 'name', header: 'Name', renderCell: item => item.name},
-      {key: 'email', header: 'Email'},
-    ];
-    const filtered = filterActiveColumns(columnsWithRenderCell, [
-      'name',
-      'email',
-    ]);
-    expect(filtered[0].key).toBe('name');
-    expect(filtered[0].header).toBe('Name');
-    expect(filtered[0].renderCell).toBeInstanceOf(Function);
   });
 });
 

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.test.tsx
@@ -1,20 +1,23 @@
 /**
  * @file useXDSTableColumnSettings.test.tsx
- * @input useXDSTableColumnSettings, XDSTable, React testing utilities
- * @output Functional tests for the column settings plugin
- * @position Test file; validates column visibility, toggling, column options
+ * @input useXDSTableColumnSettings, useXDSTableColumnSettingsState, XDSTable, React testing utilities
+ * @output Functional tests for the column settings plugin, selector adapter, and integration
+ * @position Test file; validates plugin behavior, toColumnSelectorOptions, filterActiveColumns
  */
 
 import {describe, it, expect, vi} from 'vitest';
 import {useState} from 'react';
 import {render, screen} from '@testing-library/react';
-import {renderHook, act} from '@testing-library/react';
+import {renderHook} from '@testing-library/react';
 import {XDSTable} from '../../XDSTable';
 import {
   useXDSTableColumnSettings,
+  toColumnSelectorOptions,
+  filterActiveColumns,
   type UseXDSTableColumnSettingsConfig,
   type XDSColumnSettingsOption,
 } from './useXDSTableColumnSettings';
+import {useXDSTableColumnSettingsState} from './useXDSTableColumnSettingsState';
 import type {XDSTableColumn} from '../../types';
 
 // =============================================================================
@@ -66,487 +69,229 @@ const columnOptions: XDSColumnSettingsOption[] = [
 ];
 
 // =============================================================================
-// Helpers
-// =============================================================================
-
-function renderColumnSettingsHook(
-  overrides: Partial<UseXDSTableColumnSettingsConfig> = {},
-) {
-  const defaultConfig: UseXDSTableColumnSettingsConfig = {
-    columns: columnOptions,
-    activeColumnKeys: ['name', 'email', 'role'],
-    onChangeActiveColumnKeys: vi.fn(),
-    ...overrides,
-  };
-
-  return renderHook(() =>
-    useXDSTableColumnSettings<User>(defaultConfig),
-  );
-}
-
-// =============================================================================
-// Hook Return Value
+// Plugin Hook Tests
 // =============================================================================
 
 describe('useXDSTableColumnSettings', () => {
-  describe('return value', () => {
-    it('returns plugin object with transformColumns', () => {
-      const {result} = renderColumnSettingsHook();
-      expect(result.current.plugin).toBeDefined();
-      expect(result.current.plugin.transformColumns).toBeInstanceOf(
-        Function,
-      );
-    });
+  function renderPluginHook(
+    overrides: Partial<UseXDSTableColumnSettingsConfig> = {},
+  ) {
+    const defaultConfig: UseXDSTableColumnSettingsConfig = {
+      columns: columnOptions,
+      activeColumnKeys: ['name', 'email', 'role'],
+      onChangeActiveColumnKeys: vi.fn(),
+      ...overrides,
+    };
 
-    it('transformColumns filters and reorders columns by activeColumnKeys', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['role', 'name'], // reversed order, missing 'email'
-      });
+    return renderHook(() => useXDSTableColumnSettings<User>(defaultConfig));
+  }
 
-      const allColumns: XDSTableColumn<User>[] = [
-        {key: 'name', header: 'Name'},
-        {key: 'email', header: 'Email'},
-        {key: 'role', header: 'Role'},
-      ];
-
-      const filtered = result.current.plugin.transformColumns!(allColumns);
-      expect(filtered.map(c => c.key)).toEqual(['role', 'name']);
-    });
-
-    it('returns activeColumns function', () => {
-      const {result} = renderColumnSettingsHook();
-      expect(result.current.activeColumns).toBeInstanceOf(Function);
-    });
-
-    it('returns toggleColumn function', () => {
-      const {result} = renderColumnSettingsHook();
-      expect(result.current.toggleColumn).toBeInstanceOf(Function);
-    });
-
-    it('returns isColumnActive function', () => {
-      const {result} = renderColumnSettingsHook();
-      expect(result.current.isColumnActive).toBeInstanceOf(Function);
-    });
-
-    it('returns isColumnToggleable function', () => {
-      const {result} = renderColumnSettingsHook();
-      expect(result.current.isColumnToggleable).toBeInstanceOf(Function);
-    });
-
-    it('returns activeColumnKeys passthrough', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email'],
-      });
-      expect(result.current.activeColumnKeys).toEqual(['name', 'email']);
-    });
+  it('returns a TablePlugin with transformColumns', () => {
+    const {result} = renderPluginHook();
+    expect(result.current).toBeDefined();
+    expect(result.current.transformColumns).toBeInstanceOf(Function);
   });
 
-  // ===========================================================================
-  // activeColumns helper
-  // ===========================================================================
-
-  describe('activeColumns', () => {
-    it('filters columns to only active keys', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email', 'role'],
-      });
-      const filtered = result.current.activeColumns(allTableColumns);
-      expect(filtered).toHaveLength(3);
-      expect(filtered.map((c) => c.key)).toEqual(['name', 'email', 'role']);
+  it('transformColumns filters columns by activeColumnKeys', () => {
+    const {result} = renderPluginHook({
+      activeColumnKeys: ['name', 'email'],
     });
 
-    it('preserves activeColumnKeys order', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['role', 'name', 'email'],
-      });
-      const filtered = result.current.activeColumns(allTableColumns);
-      expect(filtered.map((c) => c.key)).toEqual(['role', 'name', 'email']);
-    });
-
-    it('handles unknown keys gracefully', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'nonexistent', 'email'],
-      });
-      const filtered = result.current.activeColumns(allTableColumns);
-      expect(filtered).toHaveLength(2);
-      expect(filtered.map((c) => c.key)).toEqual(['name', 'email']);
-    });
-
-    it('returns empty array for empty activeColumnKeys', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: [],
-      });
-      const filtered = result.current.activeColumns(allTableColumns);
-      expect(filtered).toHaveLength(0);
-    });
-
-    it('returns all columns when all keys active', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email', 'role', 'status', 'lastLogin'],
-      });
-      const filtered = result.current.activeColumns(allTableColumns);
-      expect(filtered).toHaveLength(5);
-    });
-
-    it('maintains XDSTableColumn shape', () => {
-      const columnsWithRenderCell: XDSTableColumn<User>[] = [
-        {key: 'name', header: 'Name', renderCell: (item) => item.name},
-        {key: 'email', header: 'Email'},
-      ];
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email'],
-      });
-      const filtered = result.current.activeColumns(columnsWithRenderCell);
-      expect(filtered[0].key).toBe('name');
-      expect(filtered[0].header).toBe('Name');
-      expect(filtered[0].renderCell).toBeInstanceOf(Function);
-    });
+    const filtered = result.current.transformColumns!(allTableColumns);
+    expect(filtered.map(c => c.key)).toEqual(['name', 'email']);
   });
 
-  // ===========================================================================
-  // toggleColumn
-  // ===========================================================================
-
-  describe('toggleColumn', () => {
-    it('removes active column', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email', 'role'],
-        onChangeActiveColumnKeys: onChange,
-      });
-
-      act(() => result.current.toggleColumn('email'));
-      expect(onChange).toHaveBeenCalledWith(['name', 'role']);
+  it('transformColumns reorders columns by activeColumnKeys order', () => {
+    const {result} = renderPluginHook({
+      activeColumnKeys: ['role', 'name'],
     });
 
-    it('adds inactive column at end', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email'],
-        onChangeActiveColumnKeys: onChange,
-      });
-
-      act(() => result.current.toggleColumn('status'));
-      expect(onChange).toHaveBeenCalledWith(['name', 'email', 'status']);
-    });
-
-    it('no-op for isAlwaysVisible columns', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email'],
-        onChangeActiveColumnKeys: onChange,
-      });
-
-      act(() => result.current.toggleColumn('name'));
-      expect(onChange).not.toHaveBeenCalled();
-    });
-
-    it('calls onChangeActiveColumnKeys with new array', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email'],
-        onChangeActiveColumnKeys: onChange,
-      });
-
-      act(() => result.current.toggleColumn('role'));
-      expect(onChange).toHaveBeenCalledTimes(1);
-      expect(onChange).toHaveBeenCalledWith(['name', 'email', 'role']);
-    });
+    const filtered = result.current.transformColumns!(allTableColumns);
+    expect(filtered.map(c => c.key)).toEqual(['role', 'name']);
   });
 
-  // ===========================================================================
-  // isColumnActive
-  // ===========================================================================
+  it('plugin reference is stable across renders', () => {
+    const {result, rerender} = renderPluginHook();
+    const firstPlugin = result.current;
+    rerender();
+    expect(result.current).toBe(firstPlugin);
+  });
+});
 
-  describe('isColumnActive', () => {
-    it('returns true for active columns', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email'],
-      });
-      expect(result.current.isColumnActive('name')).toBe(true);
-      expect(result.current.isColumnActive('email')).toBe(true);
-    });
+// =============================================================================
+// toColumnSelectorOptions Tests
+// =============================================================================
 
-    it('returns false for inactive columns', () => {
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email'],
-      });
-      expect(result.current.isColumnActive('role')).toBe(false);
-      expect(result.current.isColumnActive('status')).toBe(false);
-    });
+describe('toColumnSelectorOptions', () => {
+  it('generates one item per column for ungrouped columns', () => {
+    const options = toColumnSelectorOptions(columnOptions);
+    expect(options).toHaveLength(5);
   });
 
-  // ===========================================================================
-  // isColumnToggleable
-  // ===========================================================================
-
-  describe('isColumnToggleable', () => {
-    it('returns true for normal columns', () => {
-      const {result} = renderColumnSettingsHook();
-      expect(result.current.isColumnToggleable('email')).toBe(true);
-      expect(result.current.isColumnToggleable('role')).toBe(true);
-    });
-
-    it('returns false for always-visible columns', () => {
-      const {result} = renderColumnSettingsHook();
-      expect(result.current.isColumnToggleable('name')).toBe(false);
-    });
+  it('marks always-visible columns as disabled', () => {
+    const options = toColumnSelectorOptions(columnOptions);
+    const nameItem = options[0];
+    expect(nameItem).toHaveProperty('disabled', true);
+    const emailItem = options[1];
+    expect(emailItem).toHaveProperty('disabled', false);
   });
 
-  // ===========================================================================
-  // showAllColumns
-  // ===========================================================================
-
-  describe('showAllColumns', () => {
-    it('sets all column keys as active in columns config order', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name'],
-        onChangeActiveColumnKeys: onChange,
-      });
-
-      act(() => result.current.showAllColumns());
-      expect(onChange).toHaveBeenCalledWith([
-        'name',
-        'email',
-        'role',
-        'status',
-        'lastLogin',
-      ]);
-    });
+  it('generates items with value and label', () => {
+    const options = toColumnSelectorOptions(columnOptions);
+    const first = options[0] as {value: string; label: string};
+    expect(first.value).toBe('name');
+    expect(first.label).toBe('Name');
   });
 
-  // ===========================================================================
-  // resetToDefault
-  // ===========================================================================
+  it('groups columns by group field into sections', () => {
+    const groupedColumns: XDSColumnSettingsOption[] = [
+      {key: 'name', label: 'Name', isAlwaysVisible: true, group: 'Basic'},
+      {key: 'email', label: 'Email', group: 'Basic'},
+      {key: 'role', label: 'Role', group: 'Details'},
+      {key: 'status', label: 'Status'},
+    ];
 
-  describe('resetToDefault', () => {
-    it('resets to defaultColumnKeys when provided', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name', 'email', 'role', 'status', 'lastLogin'],
-        onChangeActiveColumnKeys: onChange,
-        defaultColumnKeys: ['name', 'email'],
-      });
+    const options = toColumnSelectorOptions(groupedColumns);
 
-      act(() => result.current.resetToDefault());
-      expect(onChange).toHaveBeenCalledWith(['name', 'email']);
-    });
+    const sections = options.filter(
+      i => typeof i === 'object' && 'type' in i && i.type === 'section',
+    );
+    expect(sections).toHaveLength(2);
 
-    it('shows all columns when no defaultColumnKeys', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        activeColumnKeys: ['name'],
-        onChangeActiveColumnKeys: onChange,
-      });
+    const basicSection = sections[0] as {
+      type: 'section';
+      title: string;
+      options: Array<{value: string}>;
+    };
+    expect(basicSection.title).toBe('Basic');
+    expect(basicSection.options).toHaveLength(2);
 
-      act(() => result.current.resetToDefault());
-      expect(onChange).toHaveBeenCalledWith([
-        'name',
-        'email',
-        'role',
-        'status',
-        'lastLogin',
-      ]);
-    });
+    const lastItem = options[options.length - 1] as {value: string};
+    expect(lastItem.value).toBe('status');
   });
 
-  // ===========================================================================
-  // columnOptions
-  // ===========================================================================
+  it('handles empty columns', () => {
+    const options = toColumnSelectorOptions([]);
+    expect(options).toHaveLength(0);
+  });
+});
 
-  describe('columnOptions', () => {
-    it('generates one item per column for ungrouped columns', () => {
-      const {result} = renderColumnSettingsHook();
-      expect(result.current.columnOptions).toHaveLength(5);
-    });
+// =============================================================================
+// filterActiveColumns Tests
+// =============================================================================
 
-    it('marks always-visible columns as disabled', () => {
-      const {result} = renderColumnSettingsHook();
-      const items = result.current.columnOptions;
-      // First item is 'name' with isAlwaysVisible
-      const nameItem = items[0];
-      expect(nameItem).toHaveProperty('disabled', true);
-      // Second item is 'email' without isAlwaysVisible
-      const emailItem = items[1];
-      expect(emailItem).toHaveProperty('disabled', false);
-    });
-
-    it('generates items with value and label', () => {
-      const {result} = renderColumnSettingsHook();
-      const items = result.current.columnOptions;
-      const first = items[0] as {value: string; label: string};
-      expect(first.value).toBe('name');
-      expect(first.label).toBe('Name');
-    });
-
-    it('groups columns by group field into sections', () => {
-      const groupedColumns: XDSColumnSettingsOption[] = [
-        {key: 'name', label: 'Name', isAlwaysVisible: true, group: 'Basic'},
-        {key: 'email', label: 'Email', group: 'Basic'},
-        {key: 'role', label: 'Role', group: 'Details'},
-        {key: 'status', label: 'Status'},
-      ];
-
-      const {result} = renderColumnSettingsHook({columns: groupedColumns});
-      const items = result.current.columnOptions;
-
-      // Should have 2 sections + 1 ungrouped item
-      const sections = items.filter(
-        (i) => typeof i === 'object' && 'type' in i && i.type === 'section',
-      );
-      expect(sections).toHaveLength(2);
-
-      const basicSection = sections[0] as {
-        type: 'section';
-        title: string;
-        options: Array<{value: string}>;
-      };
-      expect(basicSection.title).toBe('Basic');
-      expect(basicSection.options).toHaveLength(2);
-
-      // Ungrouped item ('status') appears after sections
-      const lastItem = items[items.length - 1] as {value: string};
-      expect(lastItem.value).toBe('status');
-    });
+describe('filterActiveColumns', () => {
+  it('filters columns to only active keys', () => {
+    const filtered = filterActiveColumns(allTableColumns, [
+      'name',
+      'email',
+      'role',
+    ]);
+    expect(filtered).toHaveLength(3);
+    expect(filtered.map(c => c.key)).toEqual(['name', 'email', 'role']);
   });
 
-  // ===========================================================================
-  // setActiveColumnKeys
-  // ===========================================================================
-
-  describe('setActiveColumnKeys', () => {
-    it('passes selected values to onChangeActiveColumnKeys', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        onChangeActiveColumnKeys: onChange,
-      });
-
-      act(() =>
-        result.current.setActiveColumnKeys(['name', 'email', 'status']),
-      );
-      expect(onChange).toHaveBeenCalledWith(
-        expect.arrayContaining(['name', 'email', 'status']),
-      );
-    });
-
-    it('enforces isAlwaysVisible columns remain in set', () => {
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        onChangeActiveColumnKeys: onChange,
-      });
-
-      // Try to deselect 'name' (isAlwaysVisible) by not including it
-      act(() => result.current.setActiveColumnKeys(['email']));
-      const calledWith = onChange.mock.calls[0][0] as string[];
-      expect(calledWith).toContain('name');
-      expect(calledWith).toContain('email');
-    });
+  it('preserves activeColumnKeys order', () => {
+    const filtered = filterActiveColumns(allTableColumns, [
+      'role',
+      'name',
+      'email',
+    ]);
+    expect(filtered.map(c => c.key)).toEqual(['role', 'name', 'email']);
   });
 
-  // ===========================================================================
-  // Integration with XDSTable
-  // ===========================================================================
-
-  describe('integration with XDSTable', () => {
-    function ColumnSettingsTable({
-      initialActiveKeys,
-    }: {
-      initialActiveKeys: string[];
-    }) {
-      const [activeKeys, setActiveKeys] = useState(initialActiveKeys);
-
-      const columnSettings = useXDSTableColumnSettings<User>({
-        columns: columnOptions,
-        activeColumnKeys: activeKeys,
-        onChangeActiveColumnKeys: setActiveKeys,
-      });
-
-      return (
-        <XDSTable
-          data={testUsers}
-          columns={columnSettings.activeColumns(allTableColumns)}
-          plugins={[columnSettings.plugin]}
-          idKey="id"
-        />
-      );
-    }
-
-    it('table renders only active columns', () => {
-      render(
-        <ColumnSettingsTable initialActiveKeys={['name', 'email', 'role']} />,
-      );
-
-      // Active columns should be visible
-      expect(screen.getByText('Name')).toBeInTheDocument();
-      expect(screen.getByText('Email')).toBeInTheDocument();
-      expect(screen.getByText('Role')).toBeInTheDocument();
-
-      // Inactive columns should not be visible
-      expect(screen.queryByText('Status')).not.toBeInTheDocument();
-      expect(screen.queryByText('Last Login')).not.toBeInTheDocument();
-    });
-
-    it('column order matches activeColumnKeys order', () => {
-      render(
-        <ColumnSettingsTable initialActiveKeys={['role', 'name', 'email']} />,
-      );
-
-      const headers = screen.getAllByRole('columnheader');
-      expect(headers[0]).toHaveTextContent('Role');
-      expect(headers[1]).toHaveTextContent('Name');
-      expect(headers[2]).toHaveTextContent('Email');
-    });
+  it('handles unknown keys gracefully', () => {
+    const filtered = filterActiveColumns(allTableColumns, [
+      'name',
+      'nonexistent',
+      'email',
+    ]);
+    expect(filtered).toHaveLength(2);
+    expect(filtered.map(c => c.key)).toEqual(['name', 'email']);
   });
 
-  // ===========================================================================
-  // Edge Cases
-  // ===========================================================================
+  it('returns empty array for empty activeColumnKeys', () => {
+    const filtered = filterActiveColumns(allTableColumns, []);
+    expect(filtered).toHaveLength(0);
+  });
 
-  describe('edge cases', () => {
-    it('handles empty columns config', () => {
-      const {result} = renderColumnSettingsHook({
-        columns: [],
-        activeColumnKeys: [],
-      });
+  it('returns all columns when all keys active', () => {
+    const filtered = filterActiveColumns(allTableColumns, [
+      'name',
+      'email',
+      'role',
+      'status',
+      'lastLogin',
+    ]);
+    expect(filtered).toHaveLength(5);
+  });
 
-      expect(result.current.columnOptions).toHaveLength(0);
-      expect(result.current.activeColumns(allTableColumns)).toHaveLength(0);
+  it('maintains XDSTableColumn shape', () => {
+    const columnsWithRenderCell: XDSTableColumn<User>[] = [
+      {key: 'name', header: 'Name', renderCell: item => item.name},
+      {key: 'email', header: 'Email'},
+    ];
+    const filtered = filterActiveColumns(columnsWithRenderCell, [
+      'name',
+      'email',
+    ]);
+    expect(filtered[0].key).toBe('name');
+    expect(filtered[0].header).toBe('Name');
+    expect(filtered[0].renderCell).toBeInstanceOf(Function);
+  });
+});
+
+// =============================================================================
+// Integration: state hook + plugin hook + XDSTable
+// =============================================================================
+
+describe('integration with XDSTable', () => {
+  function ColumnSettingsTable({
+    initialActiveKeys,
+  }: {
+    initialActiveKeys: string[];
+  }) {
+    const [activeKeys, setActiveKeys] = useState(initialActiveKeys);
+
+    const state = useXDSTableColumnSettingsState({
+      columns: columnOptions,
+      activeColumnKeys: activeKeys,
+      onChangeActiveColumnKeys: setActiveKeys,
     });
 
-    it('handles single column with isAlwaysVisible', () => {
-      const {result} = renderColumnSettingsHook({
-        columns: [{key: 'name', label: 'Name', isAlwaysVisible: true}],
-        activeColumnKeys: ['name'],
-      });
+    const plugin = useXDSTableColumnSettings<User>(state.columnSettingsConfig);
 
-      expect(result.current.isColumnToggleable('name')).toBe(false);
-      expect(result.current.isColumnActive('name')).toBe(true);
-    });
+    return (
+      <XDSTable
+        data={testUsers}
+        columns={allTableColumns}
+        plugins={{columnSettings: plugin}}
+        idKey="id"
+      />
+    );
+  }
 
-    it('handles all columns isAlwaysVisible', () => {
-      const allVisible: XDSColumnSettingsOption[] = [
-        {key: 'name', label: 'Name', isAlwaysVisible: true},
-        {key: 'email', label: 'Email', isAlwaysVisible: true},
-      ];
+  it('table renders only active columns', () => {
+    render(
+      <ColumnSettingsTable initialActiveKeys={['name', 'email', 'role']} />,
+    );
 
-      const onChange = vi.fn();
-      const {result} = renderColumnSettingsHook({
-        columns: allVisible,
-        activeColumnKeys: ['name', 'email'],
-        onChangeActiveColumnKeys: onChange,
-      });
+    expect(screen.getByText('Name')).toBeInTheDocument();
+    expect(screen.getByText('Email')).toBeInTheDocument();
+    expect(screen.getByText('Role')).toBeInTheDocument();
 
-      act(() => result.current.toggleColumn('name'));
-      act(() => result.current.toggleColumn('email'));
-      expect(onChange).not.toHaveBeenCalled();
-    });
+    expect(screen.queryByText('Status')).not.toBeInTheDocument();
+    expect(screen.queryByText('Last Login')).not.toBeInTheDocument();
+  });
 
-    it('plugin reference is stable across renders', () => {
-      const {result, rerender} = renderColumnSettingsHook();
-      const firstPlugin = result.current.plugin;
-      rerender();
-      expect(result.current.plugin).toBe(firstPlugin);
-    });
+  it('column order matches activeColumnKeys order', () => {
+    render(
+      <ColumnSettingsTable initialActiveKeys={['role', 'name', 'email']} />,
+    );
+
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers[0]).toHaveTextContent('Role');
+    expect(headers[1]).toHaveTextContent('Name');
+    expect(headers[2]).toHaveTextContent('Email');
   });
 });

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.tsx
@@ -2,21 +2,28 @@
 
 /**
  * @file useXDSTableColumnSettings.tsx
- * @input React, Table types, MultiSelector types
- * @output Exports useXDSTableColumnSettings hook and config/return types
+ * @input React, Table types
+ * @output Exports useXDSTableColumnSettings plugin hook and types
  * @position Column settings plugin; consumed by XDSTable via plugins prop
  *
- * Headless column visibility and ordering management for XDSTable.
- * The consumer owns all state — the hook provides filtered columns,
- * toggle helpers, and pre-built XDSMultiSelector options.
+ * Pure plugin hook — takes column settings config, returns a TablePlugin
+ * that filters and reorders columns via `transformColumns`.
+ *
+ * For state management (toggle, reset, visibility checks), use
+ * `useXDSTableColumnSettingsState` which produces the config this hook needs.
+ *
+ * For MultiSelector integration, use `toColumnSelectorOptions` to convert
+ * column definitions into XDSMultiSelector-compatible options.
  *
  * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Table/plugins/columnSettings/index.ts (exports)
  * - /packages/core/src/Table/index.ts (exports)
  */
 
 import {useCallback, useMemo, useRef} from 'react';
 import type {TablePlugin, XDSTableColumn} from '../../types';
 import type {XDSMultiSelectorOptionType} from '../../../MultiSelector/types';
+import type {UseXDSTableColumnSettingsStateConfig} from './useXDSTableColumnSettingsState';
 
 // =============================================================================
 // Config Types
@@ -27,9 +34,7 @@ import type {XDSMultiSelectorOptionType} from '../../../MultiSelector/types';
  * Separate from XDSTableColumn because the settings UI needs metadata
  * (label, group, disableability) that the table column doesn't carry.
  */
-export interface XDSColumnSettingsOption<
-  TColumnKey extends string = string,
-> {
+export interface XDSColumnSettingsOption<TColumnKey extends string = string> {
   /** Column key — must match XDSTableColumn.key */
   key: TColumnKey;
   /** Human-readable label for the column settings UI */
@@ -52,191 +57,41 @@ export interface XDSColumnSettingsOption<
 /**
  * Configuration for useXDSTableColumnSettings.
  *
- * Headless column visibility and ordering management for XDSTable.
- * The consumer owns all state. The hook provides filtered columns
- * and a plugin for table integration.
+ * This is the same shape as UseXDSTableColumnSettingsStateConfig —
+ * you can pass `state.columnSettingsConfig` directly, or construct
+ * it manually if you don't need the state hook.
  *
  * @template TColumnKey - String literal union of column keys
- *
- * @example
- * ```
- * const allColumns = [
- *   { key: 'name', header: 'Name' },
- *   { key: 'email', header: 'Email' },
- *   { key: 'role', header: 'Role' },
- *   { key: 'status', header: 'Status' },
- * ];
- *
- * const [activeKeys, setActiveKeys] = useState(['name', 'email', 'role']);
- *
- * const columnSettings = useXDSTableColumnSettings({
- *   columns: [
- *     { key: 'name', label: 'Name', isAlwaysVisible: true },
- *     { key: 'email', label: 'Email' },
- *     { key: 'role', label: 'Role' },
- *     { key: 'status', label: 'Status' },
- *   ],
- *   activeColumnKeys: activeKeys,
- *   onChangeActiveColumnKeys: setActiveKeys,
- * });
- *
- * <XDSTable
- *   data={data}
- *   columns={columnSettings.activeColumns(allColumns)}
- *   plugins={[columnSettings.plugin]}
- * />
- * ```
- *
- * @example
- * ```
- * <XDSMultiSelector
- *   label="Columns"
- *   options={columnSettings.columnOptions}
- *   value={[...columnSettings.activeColumnKeys]}
- *   onChange={columnSettings.setActiveColumnKeys}
- *   hasSelectAll
- * />
- * ```
  */
-export interface UseXDSTableColumnSettingsConfig<
+export type UseXDSTableColumnSettingsConfig<
   TColumnKey extends string = string,
-> {
-  /**
-   * All available columns with metadata for the settings UI.
-   * This defines the universe of columns the user can toggle.
-   */
-  columns: ReadonlyArray<XDSColumnSettingsOption<TColumnKey>>;
-
-  /**
-   * Currently active column keys, in display order.
-   * Only columns with keys in this array are shown in the table.
-   * The array order determines column display order.
-   */
-  activeColumnKeys: ReadonlyArray<TColumnKey>;
-
-  /**
-   * Called when active columns change (toggle, reorder).
-   * Consumer updates their own state.
-   */
-  onChangeActiveColumnKeys: (keys: ReadonlyArray<TColumnKey>) => void;
-
-  /**
-   * The default column set for "Reset to default" functionality.
-   * When omitted, resetToDefault shows all columns.
-   */
-  defaultColumnKeys?: ReadonlyArray<TColumnKey>;
-}
+> = UseXDSTableColumnSettingsStateConfig<TColumnKey>;
 
 // =============================================================================
-// Return Type
+// Plugin Hook
 // =============================================================================
 
 /**
- * Return value of useXDSTableColumnSettings.
- */
-export interface UseXDSTableColumnSettingsReturn<
-  T extends Record<string, unknown>,
-  TColumnKey extends string = string,
-> {
-  /** The TablePlugin to pass to XDSTable's plugins prop. */
-  plugin: TablePlugin<T>;
-
-  /**
-   * Filters and reorders the full columns array based on activeColumnKeys.
-   * Returns only active columns, in the order specified by activeColumnKeys.
-   *
-   * **Note:** When using the plugin with XDSTable, you typically don't need
-   * this — the plugin's `transformColumns` handles filtering automatically.
-   * Pass all columns to XDSTable and let the plugin do the work.
-   * Use `activeColumns()` when you need the filtered array for non-table
-   * purposes (e.g., rendering column headers in a toolbar or export).
-   *
-   * @example
-   * ```
-   * // Preferred: let the plugin filter via transformColumns
-   * <XDSTable columns={allColumns} plugins={{ columnSettings: cs.plugin }} />
-   *
-   * // Manual: for non-table usage
-   * const visibleCols = cs.activeColumns(allColumns);
-   * ```
-   */
-  activeColumns: (columns: XDSTableColumn<T>[]) => XDSTableColumn<T>[];
-
-  /**
-   * Toggle a column's visibility.
-   * If the column is active, removes it. If inactive, adds it to the end.
-   * No-op for columns with `isAlwaysVisible: true`.
-   */
-  toggleColumn: (key: TColumnKey) => void;
-
-  /**
-   * Whether a specific column is currently active (visible).
-   */
-  isColumnActive: (key: TColumnKey) => boolean;
-
-  /**
-   * Whether a specific column can be toggled.
-   * Returns false for columns with `isAlwaysVisible: true`.
-   */
-  isColumnToggleable: (key: TColumnKey) => boolean;
-
-  /**
-   * Show all columns.
-   */
-  showAllColumns: () => void;
-
-  /**
-   * Reset to the default column set.
-   * Uses `defaultColumnKeys` if provided, otherwise shows all columns.
-   */
-  resetToDefault: () => void;
-
-  /**
-   * Column options formatted for XDSMultiSelector.
-   * Each option represents a column; always-visible columns are disabled.
-   * Columns with a `group` are rendered as sections.
-   *
-   * @example
-   * ```
-   * <XDSMultiSelector
-   *   label="Columns"
-   *   options={columnSettings.columnOptions}
-   *   value={[...columnSettings.activeColumnKeys]}
-   *   onChange={columnSettings.setActiveColumnKeys}
-   * />
-   * ```
-   */
-  columnOptions: XDSMultiSelectorOptionType[];
-
-  /**
-   * Set active column keys from a list of key strings.
-   * Enforces that `isAlwaysVisible` columns remain in the active set.
-   * Pass directly as `onChange` to XDSMultiSelector.
-   */
-  setActiveColumnKeys: (keys: string[]) => void;
-
-  /** Currently active column keys (pass-through from config). */
-  activeColumnKeys: ReadonlyArray<TColumnKey>;
-}
-
-// =============================================================================
-// Hook
-// =============================================================================
-
-/**
- * Headless column visibility and ordering management for XDSTable.
+ * Column settings table plugin — filters and reorders columns based on
+ * the active column keys.
  *
- * Manages which columns are visible and in what order, provides a table plugin
- * for integration, and generates pre-built items for XDSMultiSelector.
- * The consumer owns all state — the hook provides helpers and a stable plugin.
+ * Returns a `TablePlugin` directly (same pattern as `useXDSTableSortable`,
+ * `useXDSTableSelection`, etc.).
  *
  * @example
  * ```
- * const columnSettings = useXDSTableColumnSettings({
- *   columns: [
- *     { key: 'name', label: 'Name', isAlwaysVisible: true },
- *     { key: 'email', label: 'Email' },
- *   ],
+ * // With the state hook (recommended)
+ * const state = useXDSTableColumnSettingsState({ columns, activeColumnKeys, onChangeActiveColumnKeys });
+ * const plugin = useXDSTableColumnSettings(state.columnSettingsConfig);
+ *
+ * <XDSTable columns={allColumns} plugins={{ columnSettings: plugin }} />
+ * ```
+ *
+ * @example
+ * ```
+ * // Without state hook — manual config
+ * const plugin = useXDSTableColumnSettings({
+ *   columns: columnDefs,
  *   activeColumnKeys: activeKeys,
  *   onChangeActiveColumnKeys: setActiveKeys,
  * });
@@ -245,163 +100,13 @@ export interface UseXDSTableColumnSettingsReturn<
 export function useXDSTableColumnSettings<
   T extends Record<string, unknown>,
   TColumnKey extends string = string,
->(
-  config: UseXDSTableColumnSettingsConfig<TColumnKey>,
-): UseXDSTableColumnSettingsReturn<T, TColumnKey> {
-  const {columns, activeColumnKeys} = config;
-
-  // Keep config in a ref so the plugin and callbacks always read
-  // the latest version without forcing new object identity.
+>(config: UseXDSTableColumnSettingsConfig<TColumnKey>): TablePlugin<T> {
+  // Keep config in a ref so the plugin reads the latest values
+  // without changing plugin identity.
   const configRef = useRef(config);
   configRef.current = config;
 
-  // Build lookup sets for fast checks
-  const activeSet = useMemo(
-    () => new Set(activeColumnKeys),
-    [activeColumnKeys],
-  );
-
-  const alwaysVisibleSet = useMemo(
-    () => new Set(columns.filter((c) => c.isAlwaysVisible).map((c) => c.key)),
-    [columns],
-  );
-
-  // --- Column operations ---
-
-  const toggleColumn = useCallback(
-    (key: TColumnKey) => {
-      const cfg = configRef.current;
-      const avSet = new Set(
-        cfg.columns.filter((c) => c.isAlwaysVisible).map((c) => c.key),
-      );
-      if (avSet.has(key)) return;
-
-      const currentKeys = cfg.activeColumnKeys;
-      const currentSet = new Set(currentKeys);
-      if (currentSet.has(key)) {
-        cfg.onChangeActiveColumnKeys(currentKeys.filter((k) => k !== key));
-      } else {
-        cfg.onChangeActiveColumnKeys([...currentKeys, key]);
-      }
-    },
-    // configRef is stable — no deps needed beyond the ref
-    [],
-  );
-
-  const isColumnActive = useCallback(
-    (key: TColumnKey) => activeSet.has(key),
-    [activeSet],
-  );
-
-  const isColumnToggleable = useCallback(
-    (key: TColumnKey) => !alwaysVisibleSet.has(key),
-    [alwaysVisibleSet],
-  );
-
-  const showAllColumns = useCallback(() => {
-    const cfg = configRef.current;
-    cfg.onChangeActiveColumnKeys(cfg.columns.map((c) => c.key));
-  }, []);
-
-  const resetToDefault = useCallback(() => {
-    const cfg = configRef.current;
-    if (cfg.defaultColumnKeys) {
-      cfg.onChangeActiveColumnKeys([...cfg.defaultColumnKeys]);
-    } else {
-      cfg.onChangeActiveColumnKeys(cfg.columns.map((c) => c.key));
-    }
-  }, []);
-
-  // --- Column filtering helper ---
-
-  const activeColumns = useCallback(
-    (allColumns: XDSTableColumn<T>[]): XDSTableColumn<T>[] => {
-      const columnMap = new Map(allColumns.map((c) => [c.key, c]));
-      return activeColumnKeys
-        .map((key) => columnMap.get(key))
-        .filter((c): c is XDSTableColumn<T> => c != null);
-    },
-    [activeColumnKeys],
-  );
-
-  // --- Column options for XDSMultiSelector ---
-
-  const columnOptions = useMemo((): XDSMultiSelectorOptionType[] => {
-    const hasGroups = columns.some((c) => c.group);
-
-    if (!hasGroups) {
-      return columns.map((col) => ({
-        value: col.key,
-        label: col.label,
-        disabled: col.isAlwaysVisible === true,
-      }));
-    }
-
-    // Build grouped sections
-    const groups = new Map<
-      string,
-      XDSColumnSettingsOption<TColumnKey>[]
-    >();
-    const ungrouped: XDSColumnSettingsOption<TColumnKey>[] = [];
-
-    for (const col of columns) {
-      if (col.group) {
-        const group = groups.get(col.group) ?? [];
-        group.push(col);
-        groups.set(col.group, group);
-      } else {
-        ungrouped.push(col);
-      }
-    }
-
-    const items: XDSMultiSelectorOptionType[] = [];
-
-    for (const [groupName, groupCols] of groups) {
-      items.push({
-        type: 'section' as const,
-        title: groupName,
-        options: groupCols.map((col) => ({
-          value: col.key,
-          label: col.label,
-          disabled: col.isAlwaysVisible === true,
-        })),
-      });
-    }
-
-    for (const col of ungrouped) {
-      items.push({
-        value: col.key,
-        label: col.label,
-        disabled: col.isAlwaysVisible === true,
-      });
-    }
-
-    return items;
-  }, [columns]);
-
-  // --- Set active column keys ---
-
-  const setActiveColumnKeys = useCallback(
-    (value: string[]) => {
-      const cfg = configRef.current;
-      const avSet = new Set(
-        cfg.columns.filter((c) => c.isAlwaysVisible).map((c) => c.key),
-      );
-      // Ensure always-visible columns remain in the set
-      const valueSet = new Set(value);
-      for (const key of avSet) {
-        valueSet.add(key);
-      }
-      cfg.onChangeActiveColumnKeys(
-        Array.from(valueSet) as unknown as TColumnKey[],
-      );
-    },
-    [],
-  );
-
-  // --- Plugin (uses transformColumns to filter/reorder) ---
-
-  const plugin = useMemo(
+  return useMemo(
     (): TablePlugin<T> => ({
       transformColumns(columns: XDSTableColumn<T>[]): XDSTableColumn<T>[] {
         const cfg = configRef.current;
@@ -411,7 +116,7 @@ export function useXDSTableColumnSettings<
           cfg.activeColumnKeys.map((key, index) => [key, index]),
         );
         return columns
-          .filter((col) => activeSet.has(col.key as TColumnKey))
+          .filter(col => activeSet.has(col.key as TColumnKey))
           .sort((a, b) => {
             const orderA = orderMap.get(a.key as TColumnKey) ?? Infinity;
             const orderB = orderMap.get(b.key as TColumnKey) ?? Infinity;
@@ -421,17 +126,108 @@ export function useXDSTableColumnSettings<
     }),
     [],
   );
+}
 
-  return {
-    plugin,
-    activeColumns,
-    toggleColumn,
-    isColumnActive,
-    isColumnToggleable,
-    showAllColumns,
-    resetToDefault,
-    columnOptions,
-    setActiveColumnKeys,
-    activeColumnKeys,
-  };
+// =============================================================================
+// MultiSelector Adapter
+// =============================================================================
+
+/**
+ * Convert column settings options to XDSMultiSelector-compatible options.
+ *
+ * Pure data transform — no React, no hooks. Converts column definitions
+ * into the shape XDSMultiSelector expects. Columns with `group` are
+ * organized into sections; always-visible columns are marked `disabled`.
+ *
+ * @example
+ * ```
+ * const options = toColumnSelectorOptions(columns);
+ *
+ * <XDSMultiSelector
+ *   label="Columns"
+ *   options={options}
+ *   value={[...state.activeColumnKeys]}
+ *   onChange={state.setActiveColumnKeys}
+ * />
+ * ```
+ */
+export function toColumnSelectorOptions<TColumnKey extends string = string>(
+  columns: ReadonlyArray<XDSColumnSettingsOption<TColumnKey>>,
+): XDSMultiSelectorOptionType[] {
+  const hasGroups = columns.some(c => c.group);
+
+  if (!hasGroups) {
+    return columns.map(col => ({
+      value: col.key,
+      label: col.label,
+      disabled: col.isAlwaysVisible === true,
+    }));
+  }
+
+  // Build grouped sections
+  const groups = new Map<string, XDSColumnSettingsOption<TColumnKey>[]>();
+  const ungrouped: XDSColumnSettingsOption<TColumnKey>[] = [];
+
+  for (const col of columns) {
+    if (col.group) {
+      const group = groups.get(col.group) ?? [];
+      group.push(col);
+      groups.set(col.group, group);
+    } else {
+      ungrouped.push(col);
+    }
+  }
+
+  const items: XDSMultiSelectorOptionType[] = [];
+
+  for (const [groupName, groupCols] of groups) {
+    items.push({
+      type: 'section' as const,
+      title: groupName,
+      options: groupCols.map(col => ({
+        value: col.key,
+        label: col.label,
+        disabled: col.isAlwaysVisible === true,
+      })),
+    });
+  }
+
+  for (const col of ungrouped) {
+    items.push({
+      value: col.key,
+      label: col.label,
+      disabled: col.isAlwaysVisible === true,
+    });
+  }
+
+  return items;
+}
+
+// =============================================================================
+// activeColumns Utility
+// =============================================================================
+
+/**
+ * Filter and reorder a columns array based on active column keys.
+ *
+ * Use this when you need the filtered column array outside the table
+ * (e.g., for rendering column headers in a toolbar or for data export).
+ * Inside XDSTable, the plugin's `transformColumns` handles this automatically.
+ *
+ * @example
+ * ```
+ * const visibleColumns = filterActiveColumns(allColumns, activeColumnKeys);
+ * ```
+ */
+export function filterActiveColumns<
+  T extends Record<string, unknown>,
+  TColumnKey extends string = string,
+>(
+  columns: XDSTableColumn<T>[],
+  activeColumnKeys: ReadonlyArray<TColumnKey>,
+): XDSTableColumn<T>[] {
+  const columnMap = new Map(columns.map(c => [c.key, c]));
+  return activeColumnKeys
+    .map(key => columnMap.get(key))
+    .filter((c): c is XDSTableColumn<T> => c != null);
 }

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettings.tsx
@@ -12,17 +12,13 @@
  * For state management (toggle, reset, visibility checks), use
  * `useXDSTableColumnSettingsState` which produces the config this hook needs.
  *
- * For MultiSelector integration, use `toColumnSelectorOptions` to convert
- * column definitions into XDSMultiSelector-compatible options.
- *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/plugins/columnSettings/index.ts (exports)
  * - /packages/core/src/Table/index.ts (exports)
  */
 
-import {useCallback, useMemo, useRef} from 'react';
+import {useMemo, useRef} from 'react';
 import type {TablePlugin, XDSTableColumn} from '../../types';
-import type {XDSMultiSelectorOptionType} from '../../../MultiSelector/types';
 import type {UseXDSTableColumnSettingsStateConfig} from './useXDSTableColumnSettingsState';
 
 // =============================================================================
@@ -126,108 +122,4 @@ export function useXDSTableColumnSettings<
     }),
     [],
   );
-}
-
-// =============================================================================
-// MultiSelector Adapter
-// =============================================================================
-
-/**
- * Convert column settings options to XDSMultiSelector-compatible options.
- *
- * Pure data transform — no React, no hooks. Converts column definitions
- * into the shape XDSMultiSelector expects. Columns with `group` are
- * organized into sections; always-visible columns are marked `disabled`.
- *
- * @example
- * ```
- * const options = toColumnSelectorOptions(columns);
- *
- * <XDSMultiSelector
- *   label="Columns"
- *   options={options}
- *   value={[...state.activeColumnKeys]}
- *   onChange={state.setActiveColumnKeys}
- * />
- * ```
- */
-export function toColumnSelectorOptions<TColumnKey extends string = string>(
-  columns: ReadonlyArray<XDSColumnSettingsOption<TColumnKey>>,
-): XDSMultiSelectorOptionType[] {
-  const hasGroups = columns.some(c => c.group);
-
-  if (!hasGroups) {
-    return columns.map(col => ({
-      value: col.key,
-      label: col.label,
-      disabled: col.isAlwaysVisible === true,
-    }));
-  }
-
-  // Build grouped sections
-  const groups = new Map<string, XDSColumnSettingsOption<TColumnKey>[]>();
-  const ungrouped: XDSColumnSettingsOption<TColumnKey>[] = [];
-
-  for (const col of columns) {
-    if (col.group) {
-      const group = groups.get(col.group) ?? [];
-      group.push(col);
-      groups.set(col.group, group);
-    } else {
-      ungrouped.push(col);
-    }
-  }
-
-  const items: XDSMultiSelectorOptionType[] = [];
-
-  for (const [groupName, groupCols] of groups) {
-    items.push({
-      type: 'section' as const,
-      title: groupName,
-      options: groupCols.map(col => ({
-        value: col.key,
-        label: col.label,
-        disabled: col.isAlwaysVisible === true,
-      })),
-    });
-  }
-
-  for (const col of ungrouped) {
-    items.push({
-      value: col.key,
-      label: col.label,
-      disabled: col.isAlwaysVisible === true,
-    });
-  }
-
-  return items;
-}
-
-// =============================================================================
-// activeColumns Utility
-// =============================================================================
-
-/**
- * Filter and reorder a columns array based on active column keys.
- *
- * Use this when you need the filtered column array outside the table
- * (e.g., for rendering column headers in a toolbar or for data export).
- * Inside XDSTable, the plugin's `transformColumns` handles this automatically.
- *
- * @example
- * ```
- * const visibleColumns = filterActiveColumns(allColumns, activeColumnKeys);
- * ```
- */
-export function filterActiveColumns<
-  T extends Record<string, unknown>,
-  TColumnKey extends string = string,
->(
-  columns: XDSTableColumn<T>[],
-  activeColumnKeys: ReadonlyArray<TColumnKey>,
-): XDSTableColumn<T>[] {
-  const columnMap = new Map(columns.map(c => [c.key, c]));
-  return activeColumnKeys
-    .map(key => columnMap.get(key))
-    .filter((c): c is XDSTableColumn<T> => c != null);
 }

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettingsState.test.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettingsState.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * @file useXDSTableColumnSettingsState.test.tsx
+ * @input useXDSTableColumnSettingsState, React testing utilities
+ * @output Functional tests for the column settings state hook
+ * @position Test file; validates state operations independent of the plugin
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {
+  useXDSTableColumnSettingsState,
+  type UseXDSTableColumnSettingsStateConfig,
+} from './useXDSTableColumnSettingsState';
+import type {XDSColumnSettingsOption} from './useXDSTableColumnSettings';
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+const columnOptions: XDSColumnSettingsOption[] = [
+  {key: 'name', label: 'Name', isAlwaysVisible: true},
+  {key: 'email', label: 'Email'},
+  {key: 'role', label: 'Role'},
+  {key: 'status', label: 'Status'},
+  {key: 'lastLogin', label: 'Last Login'},
+];
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function renderStateHook(
+  overrides: Partial<UseXDSTableColumnSettingsStateConfig> = {},
+) {
+  const defaultConfig: UseXDSTableColumnSettingsStateConfig = {
+    columns: columnOptions,
+    activeColumnKeys: ['name', 'email', 'role'],
+    onChangeActiveColumnKeys: vi.fn(),
+    ...overrides,
+  };
+
+  return renderHook(() => useXDSTableColumnSettingsState(defaultConfig));
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useXDSTableColumnSettingsState', () => {
+  // ===========================================================================
+  // Return value shape
+  // ===========================================================================
+
+  describe('return value', () => {
+    it('returns columnSettingsConfig that matches input config', () => {
+      const config: UseXDSTableColumnSettingsStateConfig = {
+        columns: columnOptions,
+        activeColumnKeys: ['name', 'email'],
+        onChangeActiveColumnKeys: vi.fn(),
+      };
+      const {result} = renderHook(() => useXDSTableColumnSettingsState(config));
+      expect(result.current.columnSettingsConfig).toBe(config);
+    });
+
+    it('returns activeColumnKeys passthrough', () => {
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name', 'email'],
+      });
+      expect(result.current.activeColumnKeys).toEqual(['name', 'email']);
+    });
+
+    it('returns all operation functions', () => {
+      const {result} = renderStateHook();
+      expect(result.current.toggleColumn).toBeInstanceOf(Function);
+      expect(result.current.isColumnActive).toBeInstanceOf(Function);
+      expect(result.current.isColumnToggleable).toBeInstanceOf(Function);
+      expect(result.current.showAllColumns).toBeInstanceOf(Function);
+      expect(result.current.resetToDefault).toBeInstanceOf(Function);
+      expect(result.current.setActiveColumnKeys).toBeInstanceOf(Function);
+    });
+  });
+
+  // ===========================================================================
+  // toggleColumn
+  // ===========================================================================
+
+  describe('toggleColumn', () => {
+    it('removes active column', () => {
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name', 'email', 'role'],
+        onChangeActiveColumnKeys: onChange,
+      });
+
+      act(() => result.current.toggleColumn('email'));
+      expect(onChange).toHaveBeenCalledWith(['name', 'role']);
+    });
+
+    it('adds inactive column at end', () => {
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name', 'email'],
+        onChangeActiveColumnKeys: onChange,
+      });
+
+      act(() => result.current.toggleColumn('status'));
+      expect(onChange).toHaveBeenCalledWith(['name', 'email', 'status']);
+    });
+
+    it('no-op for isAlwaysVisible columns', () => {
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name', 'email'],
+        onChangeActiveColumnKeys: onChange,
+      });
+
+      act(() => result.current.toggleColumn('name'));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // isColumnActive
+  // ===========================================================================
+
+  describe('isColumnActive', () => {
+    it('returns true for active columns', () => {
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name', 'email'],
+      });
+      expect(result.current.isColumnActive('name')).toBe(true);
+      expect(result.current.isColumnActive('email')).toBe(true);
+    });
+
+    it('returns false for inactive columns', () => {
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name', 'email'],
+      });
+      expect(result.current.isColumnActive('role')).toBe(false);
+      expect(result.current.isColumnActive('status')).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // isColumnToggleable
+  // ===========================================================================
+
+  describe('isColumnToggleable', () => {
+    it('returns true for normal columns', () => {
+      const {result} = renderStateHook();
+      expect(result.current.isColumnToggleable('email')).toBe(true);
+      expect(result.current.isColumnToggleable('role')).toBe(true);
+    });
+
+    it('returns false for always-visible columns', () => {
+      const {result} = renderStateHook();
+      expect(result.current.isColumnToggleable('name')).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // showAllColumns
+  // ===========================================================================
+
+  describe('showAllColumns', () => {
+    it('sets all column keys as active in columns config order', () => {
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name'],
+        onChangeActiveColumnKeys: onChange,
+      });
+
+      act(() => result.current.showAllColumns());
+      expect(onChange).toHaveBeenCalledWith([
+        'name',
+        'email',
+        'role',
+        'status',
+        'lastLogin',
+      ]);
+    });
+  });
+
+  // ===========================================================================
+  // resetToDefault
+  // ===========================================================================
+
+  describe('resetToDefault', () => {
+    it('resets to defaultColumnKeys when provided', () => {
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name', 'email', 'role', 'status', 'lastLogin'],
+        onChangeActiveColumnKeys: onChange,
+        defaultColumnKeys: ['name', 'email'],
+      });
+
+      act(() => result.current.resetToDefault());
+      expect(onChange).toHaveBeenCalledWith(['name', 'email']);
+    });
+
+    it('shows all columns when no defaultColumnKeys', () => {
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        activeColumnKeys: ['name'],
+        onChangeActiveColumnKeys: onChange,
+      });
+
+      act(() => result.current.resetToDefault());
+      expect(onChange).toHaveBeenCalledWith([
+        'name',
+        'email',
+        'role',
+        'status',
+        'lastLogin',
+      ]);
+    });
+  });
+
+  // ===========================================================================
+  // setActiveColumnKeys
+  // ===========================================================================
+
+  describe('setActiveColumnKeys', () => {
+    it('passes selected values to onChangeActiveColumnKeys', () => {
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        onChangeActiveColumnKeys: onChange,
+      });
+
+      act(() =>
+        result.current.setActiveColumnKeys(['name', 'email', 'status']),
+      );
+      expect(onChange).toHaveBeenCalledWith(
+        expect.arrayContaining(['name', 'email', 'status']),
+      );
+    });
+
+    it('enforces isAlwaysVisible columns remain in set', () => {
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        onChangeActiveColumnKeys: onChange,
+      });
+
+      // Try to deselect 'name' (isAlwaysVisible) by not including it
+      act(() => result.current.setActiveColumnKeys(['email']));
+      const calledWith = onChange.mock.calls[0][0] as string[];
+      expect(calledWith).toContain('name');
+      expect(calledWith).toContain('email');
+    });
+  });
+
+  // ===========================================================================
+  // Edge Cases
+  // ===========================================================================
+
+  describe('edge cases', () => {
+    it('handles empty columns config', () => {
+      const {result} = renderStateHook({
+        columns: [],
+        activeColumnKeys: [],
+      });
+
+      expect(result.current.activeColumnKeys).toEqual([]);
+    });
+
+    it('handles single column with isAlwaysVisible', () => {
+      const {result} = renderStateHook({
+        columns: [{key: 'name', label: 'Name', isAlwaysVisible: true}],
+        activeColumnKeys: ['name'],
+      });
+
+      expect(result.current.isColumnToggleable('name')).toBe(false);
+      expect(result.current.isColumnActive('name')).toBe(true);
+    });
+
+    it('handles all columns isAlwaysVisible', () => {
+      const allVisible: XDSColumnSettingsOption[] = [
+        {key: 'name', label: 'Name', isAlwaysVisible: true},
+        {key: 'email', label: 'Email', isAlwaysVisible: true},
+      ];
+
+      const onChange = vi.fn();
+      const {result} = renderStateHook({
+        columns: allVisible,
+        activeColumnKeys: ['name', 'email'],
+        onChangeActiveColumnKeys: onChange,
+      });
+
+      act(() => result.current.toggleColumn('name'));
+      act(() => result.current.toggleColumn('email'));
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettingsState.tsx
+++ b/packages/core/src/Table/plugins/columnSettings/useXDSTableColumnSettingsState.tsx
@@ -1,0 +1,280 @@
+'use client';
+
+/**
+ * @file useXDSTableColumnSettingsState.tsx
+ * @input React, column settings types
+ * @output Exports useXDSTableColumnSettingsState hook and config/return types
+ * @position Column settings state helper; manages column visibility and ordering.
+ *   Pairs with useXDSTableColumnSettings (plugin hook).
+ *
+ * Follows the same pattern as useXDSTableSelectionState: the state hook
+ * manages operations and produces a config object that feeds directly
+ * into the plugin hook. Renderer-agnostic — works with any column
+ * picker UI (MultiSelector, drag-and-drop, checkbox list, etc.).
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Table/plugins/columnSettings/index.ts (exports)
+ * - /packages/core/src/Table/index.ts (exports)
+ */
+
+import {useCallback, useMemo, useRef} from 'react';
+import type {XDSColumnSettingsOption} from './useXDSTableColumnSettings';
+
+// =============================================================================
+// Config Type
+// =============================================================================
+
+/**
+ * Configuration for useXDSTableColumnSettingsState.
+ *
+ * The consumer owns the active keys state. This hook provides column
+ * visibility operations (toggle, show all, reset) and a config object
+ * that feeds directly into `useXDSTableColumnSettings`.
+ *
+ * @template TColumnKey - String literal union of column keys
+ *
+ * @example
+ * ```
+ * const [activeKeys, setActiveKeys] = useState(['name', 'email', 'role']);
+ *
+ * const columnState = useXDSTableColumnSettingsState({
+ *   columns: [
+ *     { key: 'name', label: 'Name', isAlwaysVisible: true },
+ *     { key: 'email', label: 'Email' },
+ *     { key: 'role', label: 'Role' },
+ *     { key: 'status', label: 'Status' },
+ *   ],
+ *   activeColumnKeys: activeKeys,
+ *   onChangeActiveColumnKeys: setActiveKeys,
+ * });
+ *
+ * const plugin = useXDSTableColumnSettings(columnState.columnSettingsConfig);
+ *
+ * <XDSTable
+ *   data={data}
+ *   columns={allColumns}
+ *   plugins={{ columnSettings: plugin }}
+ * />
+ * ```
+ */
+export interface UseXDSTableColumnSettingsStateConfig<
+  TColumnKey extends string = string,
+> {
+  /**
+   * All available columns with metadata for the settings UI.
+   * This defines the universe of columns the user can toggle.
+   */
+  columns: ReadonlyArray<XDSColumnSettingsOption<TColumnKey>>;
+
+  /**
+   * Currently active column keys, in display order.
+   * Only columns with keys in this array are shown in the table.
+   * The array order determines column display order.
+   */
+  activeColumnKeys: ReadonlyArray<TColumnKey>;
+
+  /**
+   * Called when active columns change (toggle, reorder).
+   * Consumer updates their own state.
+   */
+  onChangeActiveColumnKeys: (keys: ReadonlyArray<TColumnKey>) => void;
+
+  /**
+   * The default column set for "Reset to default" functionality.
+   * When omitted, resetToDefault shows all columns.
+   */
+  defaultColumnKeys?: ReadonlyArray<TColumnKey>;
+}
+
+// =============================================================================
+// Return Type
+// =============================================================================
+
+/**
+ * Return value of useXDSTableColumnSettingsState.
+ */
+export interface UseXDSTableColumnSettingsStateReturn<
+  TColumnKey extends string = string,
+> {
+  /**
+   * Ready-to-use config for useXDSTableColumnSettings.
+   * Pass this directly to the plugin hook.
+   *
+   * @example
+   * ```
+   * const state = useXDSTableColumnSettingsState({ ... });
+   * const plugin = useXDSTableColumnSettings(state.columnSettingsConfig);
+   * ```
+   */
+  columnSettingsConfig: UseXDSTableColumnSettingsStateConfig<TColumnKey>;
+
+  /** Currently active column keys (pass-through from config). */
+  activeColumnKeys: ReadonlyArray<TColumnKey>;
+
+  /**
+   * Toggle a column's visibility.
+   * If the column is active, removes it. If inactive, adds it to the end.
+   * No-op for columns with `isAlwaysVisible: true`.
+   */
+  toggleColumn: (key: TColumnKey) => void;
+
+  /**
+   * Whether a specific column is currently active (visible).
+   */
+  isColumnActive: (key: TColumnKey) => boolean;
+
+  /**
+   * Whether a specific column can be toggled.
+   * Returns false for columns with `isAlwaysVisible: true`.
+   */
+  isColumnToggleable: (key: TColumnKey) => boolean;
+
+  /**
+   * Show all columns.
+   */
+  showAllColumns: () => void;
+
+  /**
+   * Reset to the default column set.
+   * Uses `defaultColumnKeys` if provided, otherwise shows all columns.
+   */
+  resetToDefault: () => void;
+
+  /**
+   * Set active column keys from a list of key strings.
+   * Enforces that `isAlwaysVisible` columns remain in the active set.
+   * Useful as an `onChange` handler for any list-based column picker.
+   */
+  setActiveColumnKeys: (keys: string[]) => void;
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * Headless column visibility and ordering state management.
+ *
+ * Manages which columns are active, provides toggle/reset operations,
+ * and produces a config object for `useXDSTableColumnSettings`.
+ * Renderer-agnostic — pair with any column picker UI.
+ *
+ * @example
+ * ```
+ * const [activeKeys, setActiveKeys] = useState(['name', 'email']);
+ *
+ * const state = useXDSTableColumnSettingsState({
+ *   columns: [
+ *     { key: 'name', label: 'Name', isAlwaysVisible: true },
+ *     { key: 'email', label: 'Email' },
+ *     { key: 'role', label: 'Role' },
+ *   ],
+ *   activeColumnKeys: activeKeys,
+ *   onChangeActiveColumnKeys: setActiveKeys,
+ * });
+ *
+ * // Feed into the plugin hook
+ * const plugin = useXDSTableColumnSettings(state.columnSettingsConfig);
+ *
+ * // Build your own column picker UI using state helpers
+ * state.columns.map(col => (
+ *   <Checkbox
+ *     key={col.key}
+ *     checked={state.isColumnActive(col.key)}
+ *     disabled={!state.isColumnToggleable(col.key)}
+ *     onChange={() => state.toggleColumn(col.key)}
+ *     label={col.label}
+ *   />
+ * ));
+ * ```
+ */
+export function useXDSTableColumnSettingsState<
+  TColumnKey extends string = string,
+>(
+  config: UseXDSTableColumnSettingsStateConfig<TColumnKey>,
+): UseXDSTableColumnSettingsStateReturn<TColumnKey> {
+  const {columns, activeColumnKeys} = config;
+
+  // Keep config in a ref so callbacks always read the latest version.
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  // Build lookup sets for fast checks
+  const activeSet = useMemo(
+    () => new Set(activeColumnKeys),
+    [activeColumnKeys],
+  );
+
+  const alwaysVisibleSet = useMemo(
+    () => new Set(columns.filter(c => c.isAlwaysVisible).map(c => c.key)),
+    [columns],
+  );
+
+  // --- Column operations ---
+
+  const toggleColumn = useCallback((key: TColumnKey) => {
+    const cfg = configRef.current;
+    const avSet = new Set(
+      cfg.columns.filter(c => c.isAlwaysVisible).map(c => c.key),
+    );
+    if (avSet.has(key)) return;
+
+    const currentKeys = cfg.activeColumnKeys;
+    const currentSet = new Set(currentKeys);
+    if (currentSet.has(key)) {
+      cfg.onChangeActiveColumnKeys(currentKeys.filter(k => k !== key));
+    } else {
+      cfg.onChangeActiveColumnKeys([...currentKeys, key]);
+    }
+  }, []);
+
+  const isColumnActive = useCallback(
+    (key: TColumnKey) => activeSet.has(key),
+    [activeSet],
+  );
+
+  const isColumnToggleable = useCallback(
+    (key: TColumnKey) => !alwaysVisibleSet.has(key),
+    [alwaysVisibleSet],
+  );
+
+  const showAllColumns = useCallback(() => {
+    const cfg = configRef.current;
+    cfg.onChangeActiveColumnKeys(cfg.columns.map(c => c.key));
+  }, []);
+
+  const resetToDefault = useCallback(() => {
+    const cfg = configRef.current;
+    if (cfg.defaultColumnKeys) {
+      cfg.onChangeActiveColumnKeys([...cfg.defaultColumnKeys]);
+    } else {
+      cfg.onChangeActiveColumnKeys(cfg.columns.map(c => c.key));
+    }
+  }, []);
+
+  const setActiveColumnKeys = useCallback((value: string[]) => {
+    const cfg = configRef.current;
+    const avSet = new Set(
+      cfg.columns.filter(c => c.isAlwaysVisible).map(c => c.key),
+    );
+    // Ensure always-visible columns remain in the set
+    const valueSet = new Set(value);
+    for (const key of avSet) {
+      valueSet.add(key);
+    }
+    cfg.onChangeActiveColumnKeys(
+      Array.from(valueSet) as unknown as TColumnKey[],
+    );
+  }, []);
+
+  return {
+    columnSettingsConfig: config,
+    activeColumnKeys,
+    toggleColumn,
+    isColumnActive,
+    isColumnToggleable,
+    showAllColumns,
+    resetToDefault,
+    setActiveColumnKeys,
+  };
+}


### PR DESCRIPTION
## Summary

Splits the monolithic `useXDSTableColumnSettings` hook into three focused pieces, following the pattern established by `useXDSTableSelectionState`:

### 1. `useXDSTableColumnSettingsState` (new)
State management hook — toggle, reset, visibility checks. Renderer-agnostic. Produces `columnSettingsConfig` that feeds into the plugin hook.

### 2. `useXDSTableColumnSettings` (refactored)
Now returns `TablePlugin` directly, matching the pattern of `useXDSTableSortable`, `useXDSTableSelection`, etc. Takes the same config shape as before.

### 3. `toColumnSelectorOptions` (new)
Pure function — converts column definitions into `XDSMultiSelector`-compatible options. No React dependency. Consumers using a different column picker UI (drag-and-drop, checkbox list) never need this.

### Also adds
- `filterActiveColumns` utility for filtering columns outside the table pipeline (toolbars, exports)

### Why
The old hook mixed three concerns: plugin behavior (`transformColumns`), state operations (toggle/reset), and `XDSMultiSelector` binding (`columnOptions`, `setActiveColumnKeys`). The MultiSelector stuff is renderer-specific and shouldn't be coupled to the core plugin.

### Usage

```tsx
// State hook manages operations
const state = useXDSTableColumnSettingsState({
  columns: columnDefs,
  activeColumnKeys,
  onChangeActiveColumnKeys: setActiveKeys,
});

// Plugin hook returns TablePlugin directly
const plugin = useXDSTableColumnSettings(state.columnSettingsConfig);

// MultiSelector adapter is a pure function
const options = toColumnSelectorOptions(columnDefs);

<XDSMultiSelector options={options} value={[...state.activeColumnKeys]} onChange={state.setActiveColumnKeys} />
<XDSTable columns={allColumns} plugins={{ columnSettings: plugin }} />
```

Server-side or simple cases can skip the state hook entirely:
```tsx
const plugin = useXDSTableColumnSettings({ columns, activeColumnKeys, onChangeActiveColumnKeys });
```

### Tests
- 35 tests across both files (18 state, 17 plugin + integration)
- All 296 table tests pass
- 0 lint errors

---
