### PR TITLE
fix: remove hardcoded minHeight on TextArea so rows prop works

### DIFF
--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -66,7 +66,6 @@ const styles = stylex.create({
       color: colorVars['--color-text-secondary'],
     },
     resize: 'vertical',
-    minHeight: '80px',
   },
   textareaDisabled: {
     cursor: 'not-allowed',


### PR DESCRIPTION
XDSTextArea had `minHeight: '80px'` on the textarea element, which forced a ~3-row minimum height regardless of the `rows` prop. Setting `rows={1}` would still render 3 rows.

This removes the hardcoded minHeight so the native `rows` attribute controls height as expected.

All 46 existing tests pass.