### PR TITLE
feat(AppShell): default contentPadding to 6

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/shell-lab/page.tsx
@@ -825,7 +825,6 @@ export default function ShellLabPage() {
       <XDSAppShell
         variant={config.variant}
         height={config.height}
-        contentPadding={6}
         topNav={
           config.showTopNav ? (
             <SampleTopNav

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -295,7 +295,6 @@ export const Playground: StoryObj<
   }) {
     return (
       <XDSAppShell
-        contentPadding={6}
         topNav={args.showTopNav ? <AppTopNav /> : undefined}
         sideNav={
           args.showSideNav ? (
@@ -325,10 +324,7 @@ export const Playground: StoryObj<
  */
 export const TopNavWithSideNav: Story = {
   render: () => (
-    <XDSAppShell
-      contentPadding={6}
-      topNav={<AppTopNav />}
-      sideNav={<SideNavWithoutHeader />}>
+    <XDSAppShell topNav={<AppTopNav />} sideNav={<SideNavWithoutHeader />}>
       <MockContent />
     </XDSAppShell>
   ),
@@ -341,7 +337,7 @@ export const TopNavWithSideNav: Story = {
  */
 export const SideNavOnly: Story = {
   render: () => (
-    <XDSAppShell contentPadding={6} sideNav={<SideNavWithHeader />}>
+    <XDSAppShell sideNav={<SideNavWithHeader />}>
       <MockContent />
     </XDSAppShell>
   ),
@@ -353,7 +349,7 @@ export const SideNavOnly: Story = {
  */
 export const TopNavOnly: Story = {
   render: () => (
-    <XDSAppShell contentPadding={6} topNav={<AppTopNav />}>
+    <XDSAppShell topNav={<AppTopNav />}>
       <MockContent paragraphs={5} />
     </XDSAppShell>
   ),
@@ -370,7 +366,6 @@ export const TopNavOnly: Story = {
 export const FullFeatured: Story = {
   render: () => (
     <XDSAppShell
-      contentPadding={6}
       topNav={<AppTopNav />}
       sideNav={
         <XDSSideNav
@@ -473,7 +468,6 @@ export const FullFeatured: Story = {
 export const AutoHeight: Story = {
   render: () => (
     <XDSAppShell
-      contentPadding={6}
       topNav={<AppTopNav />}
       sideNav={<SideNavWithoutHeader />}
       height="auto">
@@ -494,7 +488,6 @@ export const ControlledCollapse: Story = {
     const [collapsed, setCollapsed] = useState(false);
     return (
       <XDSAppShell
-        contentPadding={6}
         topNav={
           <XDSTopNav
             label="Main navigation"
@@ -524,7 +517,7 @@ export const ControlledCollapse: Story = {
  */
 export const ContentOnly: Story = {
   render: () => (
-    <XDSAppShell contentPadding={6}>
+    <XDSAppShell>
       <MockContent paragraphs={5} />
     </XDSAppShell>
   ),
@@ -537,7 +530,6 @@ export const ContentOnly: Story = {
 export const WithBanner: Story = {
   render: () => (
     <XDSAppShell
-      contentPadding={6}
       topNav={<AppTopNav />}
       sideNav={<SideNavWithoutHeader />}
       banner={
@@ -618,7 +610,6 @@ export const WithMobileNav: Story = {
 
     return (
       <XDSAppShell
-        contentPadding={6}
         topNav={
           <XDSTopNav
             label="Main navigation"

--- a/packages/cli/templates/dashboard/page.tsx
+++ b/packages/cli/templates/dashboard/page.tsx
@@ -621,8 +621,7 @@ export default function DashboardTemplate() {
           <XDSTopNavHeading>Documents</XDSTopNavHeading>
         </XDSTopNav>
       }
-      variant="elevated"
-      contentPadding={6}>
+      variant="elevated">
       <XDSVStack gap={6}>
         {/* Stats Grid */}
         <div {...stylex.props(styles.statsGrid)}>

--- a/packages/cli/templates/data-table/page.tsx
+++ b/packages/cli/templates/data-table/page.tsx
@@ -415,10 +415,7 @@ export default function DataTableTemplate() {
   const pendingCount = allUsers.filter(u => u.status === 'pending').length;
 
   return (
-    <XDSAppShell
-      sideNav={<DataTableSideNav />}
-      variant="elevated"
-      contentPadding={6}>
+    <XDSAppShell sideNav={<DataTableSideNav />} variant="elevated">
       <XDSVStack gap={6}>
         <XDSHStack gap={3} vAlign="center">
           <div style={{flex: 1}}>

--- a/packages/core/src/AppShell/XDSAppShell.test.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.test.tsx
@@ -516,13 +516,13 @@ describe('XDSAppShell', () => {
     expect(screen.getByText('Content')).toBeInTheDocument();
   });
 
-  it('defaults to contentPadding={0} when not specified', () => {
+  it('defaults to contentPadding={6} when not specified', () => {
     render(
       <XDSAppShell data-testid="shell">
         <div>Content</div>
       </XDSAppShell>,
     );
-    // Should render without error — padding=0 is the default
+    // Should render without error — padding=6 is the default
     expect(screen.getByRole('main')).toBeInTheDocument();
   });
 

--- a/packages/core/src/AppShell/XDSAppShell.tsx
+++ b/packages/core/src/AppShell/XDSAppShell.tsx
@@ -170,10 +170,12 @@ export interface XDSAppShellProps {
   /**
    * Padding for the main content area using the spacing scale.
    * Set based on the dominant content pattern for the page:
-   * - `4` (16px) — standard padding for forms, settings, text-heavy pages
+   * - `6` (24px) — default, comfortable padding for most pages
+   * - `4` (16px) — tighter padding for forms, settings, text-heavy pages
    * - `0` — no padding, for dashboards, maps, tables that need edge-to-edge
    * Override individual sections with `<XDSSection padding={...}>`.
    * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   * @default 6
    */
   contentPadding?: SpacingStep;
 
@@ -711,7 +713,7 @@ export function XDSAppShell({
 
   const mainInner = (
     <XDSLayoutContent
-      padding={contentPadding ?? 0}
+      padding={contentPadding ?? 6}
       role="main"
       id={MAIN_CONTENT_ID}
       isScrollable={isFill}


### PR DESCRIPTION
Templates and stories overwhelmingly use `contentPadding={6}` (12 of 16 usages). This changes the default from `0` to `6` so the most common case requires no prop.

## Changes

- **Default changed**: `contentPadding` defaults to `6` (was `0`)
- **JSDoc updated**: Documents the new default, reorders options to lead with `6`
- **Removed redundant `contentPadding={6}`** from 13 call sites (stories, templates, shell-lab)
- **Kept explicit values**: `contentPadding={0}` (detail-page, product-detail, theme-editor) and `contentPadding={4}` (SandboxShell)
- **Test updated** to reflect new default

## Usage data

| Value | Count | Where |
|-------|-------|-------|
| `6` | 12 | Stories (×9), templates (×2), shell-lab |
| `0` | 3 | detail-page, product-detail, theme-editor |
| `4` | 1 | SandboxShell |