### PR TITLE
cleanup: move paginateData to its own file

### DIFF
--- a/packages/core/src/Table/plugins/pagination/index.ts
+++ b/packages/core/src/Table/plugins/pagination/index.ts
@@ -1,2 +1,3 @@
-export {useXDSTablePagination, paginateData} from './useXDSTablePagination';
+export {useXDSTablePagination} from './useXDSTablePagination';
 export type {UseXDSTablePaginationConfig} from './useXDSTablePagination';
+export {paginateData} from './paginateData';

--- a/packages/core/src/Table/plugins/pagination/paginateData.ts
+++ b/packages/core/src/Table/plugins/pagination/paginateData.ts
@@ -1,0 +1,34 @@
+/**
+ * @file paginateData.ts
+ * @input Data array, page number, page size
+ * @output Sliced data array for the current page
+ * @position Pagination utility; used alongside useXDSTablePagination for client-side pagination
+ */
+
+/**
+ * Slice a data array for the current page.
+ *
+ * Pure utility for client-side pagination. For server-side pagination
+ * where data is already sliced, pass it directly to XDSTable.
+ *
+ * @param data - Full data array
+ * @param page - Current page number (1-based)
+ * @param pageSize - Number of items per page
+ * @returns Slice of data for the current page
+ *
+ * @example
+ * ```
+ * const [page, setPage] = useState(1);
+ * const pageSize = 10;
+ *
+ * <XDSTable data={paginateData(data, page, pageSize)} ... />
+ * ```
+ */
+export function paginateData<T>(
+  data: T[],
+  page: number,
+  pageSize: number,
+): T[] {
+  const start = (page - 1) * pageSize;
+  return data.slice(start, start + pageSize);
+}

--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination-perf.test.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination-perf.test.tsx
@@ -12,7 +12,8 @@ import {describe, it, expect} from 'vitest';
 import {render, screen, act} from '@testing-library/react';
 import {useState, useMemo, useRef, useEffect} from 'react';
 import {XDSTable} from '../../XDSTable';
-import {useXDSTablePagination, paginateData} from './useXDSTablePagination';
+import {useXDSTablePagination} from './useXDSTablePagination';
+import {paginateData} from './paginateData';
 import type {XDSTableColumn} from '../../types';
 
 // =============================================================================

--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination.test.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination.test.tsx
@@ -11,7 +11,8 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {renderHook} from '@testing-library/react';
 import {XDSTable} from '../../XDSTable';
-import {useXDSTablePagination, paginateData} from './useXDSTablePagination';
+import {useXDSTablePagination} from './useXDSTablePagination';
+import {paginateData} from './paginateData';
 import {useXDSTableSelection} from '../selection/useXDSTableSelection';
 import type {XDSTableColumn} from '../../types';
 

--- a/packages/core/src/Table/plugins/pagination/useXDSTablePagination.tsx
+++ b/packages/core/src/Table/plugins/pagination/useXDSTablePagination.tsx
@@ -3,13 +3,11 @@
 /**
  * @file useXDSTablePagination.tsx
  * @input React, XDSPagination, Table plugin types
- * @output Exports useXDSTablePagination hook, config type, and paginateData utility
+ * @output Exports useXDSTablePagination hook and config type
  * @position Pagination plugin; consumed by XDSTable via plugins prop
  *
  * Returns a `TablePlugin` directly (same pattern as useXDSTableSortable,
  * useXDSTableSelection, useXDSTableColumnSettings).
- *
- * For client-side data slicing, use the `paginateData` utility.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/plugins/pagination/index.ts (exports)
@@ -202,38 +200,6 @@ export interface UseXDSTablePaginationConfig {
    * @default 'Table pagination'
    */
   label?: string;
-}
-
-// =============================================================================
-// Utility
-// =============================================================================
-
-/**
- * Slice a data array for the current page.
- *
- * Pure utility for client-side pagination. For server-side pagination
- * where data is already sliced, pass it directly to XDSTable.
- *
- * @param data - Full data array
- * @param page - Current page number (1-based)
- * @param pageSize - Number of items per page
- * @returns Slice of data for the current page
- *
- * @example
- * ```
- * const [page, setPage] = useState(1);
- * const pageSize = 10;
- *
- * <XDSTable data={paginateData(data, page, pageSize)} ... />
- * ```
- */
-export function paginateData<T>(
-  data: T[],
-  page: number,
-  pageSize: number,
-): T[] {
-  const start = (page - 1) * pageSize;
-  return data.slice(start, start + pageSize);
 }
 
 // =============================================================================


### PR DESCRIPTION
Quick followup to #1165 — separates the `paginateData` pure utility into its own file (`paginateData.ts`) instead of co-locating it with the hook.

Cleaner module boundaries: hook file has only the hook, utility file has only the utility.

---
