### PR TITLE
fix(dialog): add padding prop and fix settings-dialog template

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -124,7 +124,7 @@ function DocsiteLandingTemplate() {
   const [selected, setSelected] = useState(new Set());
   const [activeTab, setActiveTab] = useState('all');
   const [isMobile, setIsMobile] = useState(false);
-  const [_isTablet, setIsTablet] = useState(false);
+  const [isTablet, setIsTablet] = useState(false);
   const [generatingSource, setGeneratingSource] = useState(
     null as number | null,
   );
@@ -220,7 +220,7 @@ function DocsiteLandingTemplate() {
   useEffect(() => {
     const mobileMql = window.matchMedia('(max-width: 768px)');
     const tabletMql = window.matchMedia(
-      '(min-width: 769px) and (max-width: 1024px)',
+      '(min-width: 769px) and (max-width: 1280px)',
     );
     setIsMobile(mobileMql.matches);
     setIsTablet(tabletMql.matches);
@@ -553,7 +553,11 @@ function DocsiteLandingTemplate() {
                   maxWidth: 2000,
                   margin: '0 auto',
                   display: 'grid',
-                  gridTemplateColumns: isMobile ? '1fr' : 'repeat(2, 1fr)',
+                  gridTemplateColumns: isMobile
+                    ? '1fr'
+                    : isTablet
+                      ? 'repeat(2, 1fr)'
+                      : 'repeat(3, 1fr)',
                   gap: 16,
                   gridAutoRows: '1fr',
                 }}>
@@ -612,7 +616,7 @@ function DocsiteLandingTemplate() {
               width="90vw"
               maxHeight="90vh"
               purpose="info"
-              style={{padding: 0, overflow: 'visible'}}>
+              style={{padding: 0, overflow: 'visible', maxWidth: 1200}}>
               <div
                 style={{position: 'absolute', top: 0, right: -40, zIndex: 1}}>
                 <XDSCard padding={0} style={{borderRadius: '50%'}}>
@@ -637,7 +641,7 @@ function DocsiteLandingTemplate() {
                     <div
                       style={{
                         flex: 1,
-                        aspectRatio: '16 / 10',
+                        height: 'clamp(300px, 50vh, 600px)',
                         backgroundColor:
                           'var(--color-background-muted, #f9f9f9)',
                         borderRadius: 12,

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -22,6 +22,7 @@ import {XDSSwitch} from '@xds/core/Switch';
 import {XDSLink} from '@xds/core/Link';
 import {XDSTabList, XDSTab} from '@xds/core/TabList';
 import {XDSBadge} from '@xds/core/Badge';
+import {XDSIcon} from '@xds/core/Icon';
 import {colorVars} from '@xds/core/theme/tokens.stylex';
 import {
   UserIcon,
@@ -133,26 +134,20 @@ function ExpandableRow({
   return (
     <>
       {isExpanded ? (
-        <div style={{padding: '16px 0'}}>
-          <div style={{marginBottom: 12}}>
+        <div {...stylex.props(styles.rowPadding)}>
+          <div {...stylex.props(styles.marginBottom12)}>
             <XDSText type="body" weight="semibold" display="block">
               {label}
             </XDSText>
           </div>
-          <div style={{marginBottom: 16}}>{children}</div>
+          <div {...stylex.props(styles.marginBottom16)}>{children}</div>
           <XDSHStack gap={2}>
             <XDSButton label="Save" variant="primary" onClick={onSave} />
             <XDSButton label="Cancel" variant="ghost" onClick={onCancel} />
           </XDSHStack>
         </div>
       ) : (
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'flex-start',
-            padding: '16px 0',
-          }}>
+        <XDSHStack hAlign="justify" vAlign="start" xstyle={styles.rowPadding}>
           <div>
             <XDSText type="body" weight="semibold" display="block">
               {label}
@@ -170,7 +165,7 @@ function ExpandableRow({
             }}>
             Edit
           </XDSLink>
-        </div>
+        </XDSHStack>
       )}
       <XDSDivider />
     </>
@@ -188,13 +183,7 @@ function InfoRowItem({
 }) {
   return (
     <>
-      <div
-        style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'flex-start',
-          padding: '16px 0',
-        }}>
+      <XDSHStack hAlign="justify" vAlign="start" xstyle={styles.rowPadding}>
         <div>
           <XDSText type="body" weight="semibold" display="block">
             {label}
@@ -208,7 +197,7 @@ function InfoRowItem({
             {action}
           </XDSLink>
         )}
-      </div>
+      </XDSHStack>
       <XDSDivider />
     </>
   );
@@ -222,6 +211,88 @@ const styles = stylex.create({
   pageBg: {backgroundColor: colorVars['--color-background-body']},
   cardBg: {backgroundColor: colorVars['--color-background-card']},
   noBorder: {borderWidth: 0},
+  pageCenter: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    position: 'fixed',
+    inset: 0,
+  },
+  dialogInner: {
+    height: '100%',
+    minHeight: 'calc(85vh - 2px)',
+    maxHeight: 'calc(85vh - 2px)',
+    position: 'relative',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 12,
+    right: 12,
+    zIndex: 1,
+  },
+  navHeadingPadding: {
+    paddingLeft: 16,
+    paddingRight: 16,
+  },
+  contentPadding: {
+    padding: '16px 32px',
+    maxWidth: 680,
+  },
+  rowPadding: {
+    padding: '16px 0',
+  },
+  rowPaddingTop: {
+    paddingTop: 16,
+    paddingBottom: 0,
+  },
+  rowPaddingBottom: {
+    paddingTop: 0,
+    paddingBottom: 16,
+  },
+  marginBottom12: {
+    marginBottom: 12,
+  },
+  marginBottom16: {
+    marginBottom: 16,
+  },
+  marginTop8: {
+    marginTop: 8,
+  },
+  marginTop16: {
+    marginTop: 16,
+  },
+  cardMarginTop: {
+    marginTop: 16,
+  },
+  tabOffset: {
+    marginLeft: -12,
+    overflow: 'hidden',
+  },
+  iconBox: {
+    width: 48,
+    height: 48,
+    borderRadius: 12,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+  },
+  iconBoxMuted: {
+    backgroundColor: colorVars['--color-background-muted'],
+  },
+  iconBoxSurface: {
+    backgroundColor: colorVars['--color-background-surface'],
+  },
+  flex1: {
+    flex: 1,
+  },
+  flexShrink0MarginTop2: {
+    flexShrink: 0,
+    marginTop: 2,
+  },
+  paddingTop16: {
+    paddingTop: 16,
+  },
 });
 
 // ---------------------------------------------------------------------------
@@ -254,15 +325,7 @@ export default function SettingsDialogTemplate() {
   const handleSave = () => setExpandedRow(null);
 
   return (
-    <div
-      {...stylex.props(styles.pageBg)}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        position: 'fixed',
-        inset: 0,
-      }}>
+    <div {...stylex.props(styles.pageBg, styles.pageCenter)}>
       <XDSButton
         label="Open settings"
         variant="primary"
@@ -275,15 +338,9 @@ export default function SettingsDialogTemplate() {
         maxHeight="85vh"
         padding={0}
         purpose="form">
-        <div
-          style={{
-            height: '100%',
-            minHeight: 'calc(85vh - 2px)',
-            maxHeight: 'calc(85vh - 2px)',
-            position: 'relative',
-          }}>
+        <div {...stylex.props(styles.dialogInner)}>
           {/* Close button — top right, no header bar */}
-          <div style={{position: 'absolute', top: 12, right: 12, zIndex: 1}}>
+          <div {...stylex.props(styles.closeButton)}>
             <XDSButton
               label="Close"
               icon={<XMarkIcon width={20} height={20} />}
@@ -304,7 +361,7 @@ export default function SettingsDialogTemplate() {
                 padding={3}
                 xstyle={styles.cardBg}>
                 <XDSVStack gap={4}>
-                  <div style={{paddingLeft: 16, paddingRight: 16}}>
+                  <div {...stylex.props(styles.navHeadingPadding)}>
                     <XDSHeading level={2}>Account settings</XDSHeading>
                   </div>
                   <XDSList density="spacious">
@@ -336,7 +393,7 @@ export default function SettingsDialogTemplate() {
             }
             content={
               <XDSLayoutContent>
-                <div style={{padding: '16px 32px', maxWidth: 680}}>
+                <div {...stylex.props(styles.contentPadding)}>
                   {activeNav === 'Personal information' && (
                     <XDSVStack gap={6}>
                       <XDSHeading level={2}>Personal info</XDSHeading>
@@ -383,23 +440,12 @@ export default function SettingsDialogTemplate() {
                         />
                       </XDSVStack>
 
-                      <XDSCard padding={4} style={{marginTop: 16}}>
+                      <XDSCard padding={4} xstyle={styles.cardMarginTop}>
                         <XDSVStack gap={0}>
-                          <div style={{paddingTop: 0, paddingBottom: 16}}>
+                          <div {...stylex.props(styles.rowPaddingBottom)}>
                             <XDSHStack gap={3} vAlign="start">
-                              <div
-                                style={{
-                                  width: 48,
-                                  height: 48,
-                                  borderRadius: 12,
-                                  backgroundColor:
-                                    'var(--xds-color-background-muted, #f5f5f5)',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                  flexShrink: 0,
-                                }}>
-                                <LockClosedIcon width={24} height={24} />
+                              <div {...stylex.props(styles.iconBox, styles.iconBoxMuted)}>
+                                <XDSIcon icon={LockClosedIcon} size="lg" />
                               </div>
                               <XDSVStack gap={0}>
                                 <XDSText
@@ -419,21 +465,10 @@ export default function SettingsDialogTemplate() {
                             </XDSHStack>
                           </div>
                           <XDSDivider />
-                          <div style={{padding: '16px 0'}}>
+                          <div {...stylex.props(styles.rowPadding)}>
                             <XDSHStack gap={3} vAlign="start">
-                              <div
-                                style={{
-                                  width: 48,
-                                  height: 48,
-                                  borderRadius: 12,
-                                  backgroundColor:
-                                    'var(--xds-color-background-muted, #f5f5f5)',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                  flexShrink: 0,
-                                }}>
-                                <PencilSquareIcon width={24} height={24} />
+                              <div {...stylex.props(styles.iconBox, styles.iconBoxMuted)}>
+                                <XDSIcon icon={PencilSquareIcon} size="lg" />
                               </div>
                               <XDSVStack gap={0}>
                                 <XDSText
@@ -456,21 +491,10 @@ export default function SettingsDialogTemplate() {
                             </XDSHStack>
                           </div>
                           <XDSDivider />
-                          <div style={{paddingTop: 16, paddingBottom: 0}}>
+                          <div {...stylex.props(styles.rowPaddingTop)}>
                             <XDSHStack gap={3} vAlign="start">
-                              <div
-                                style={{
-                                  width: 48,
-                                  height: 48,
-                                  borderRadius: 12,
-                                  backgroundColor:
-                                    'var(--xds-color-background-muted, #f5f5f5)',
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  justifyContent: 'center',
-                                  flexShrink: 0,
-                                }}>
-                                <ShareIcon width={24} height={24} />
+                              <div {...stylex.props(styles.iconBox, styles.iconBoxMuted)}>
+                                <XDSIcon icon={ShareIcon} size="lg" />
                               </div>
                               <XDSVStack gap={0}>
                                 <XDSText
@@ -498,7 +522,7 @@ export default function SettingsDialogTemplate() {
                     <XDSVStack gap={6}>
                       <XDSHeading level={2}>Login &amp; security</XDSHeading>
 
-                      <div style={{marginLeft: -12, overflow: 'hidden'}}>
+                      <div {...stylex.props(styles.tabOffset)}>
                         <XDSTabList
                           value={activeTab}
                           onChange={setActiveTab}
@@ -513,7 +537,7 @@ export default function SettingsDialogTemplate() {
                           {/* Login */}
                           <XDSVStack gap={0}>
                             <XDSHeading level={3}>Login</XDSHeading>
-                            <div style={{marginTop: 8}}>
+                            <div {...stylex.props(styles.marginTop8)}>
                               <XDSDivider />
                             </div>
                             {LOGIN_ROWS.map(row => (
@@ -524,7 +548,7 @@ export default function SettingsDialogTemplate() {
                           {/* Social accounts */}
                           <XDSVStack gap={0}>
                             <XDSHeading level={3}>Social accounts</XDSHeading>
-                            <div style={{marginTop: 8}}>
+                            <div {...stylex.props(styles.marginTop8)}>
                               <XDSDivider />
                             </div>
                             {SOCIAL_ROWS.map(row => (
@@ -535,41 +559,24 @@ export default function SettingsDialogTemplate() {
                           {/* Device history */}
                           <XDSVStack gap={0}>
                             <XDSHeading level={3}>Device history</XDSHeading>
-                            <div style={{marginTop: 8}}>
+                            <div {...stylex.props(styles.marginTop8)}>
                               <XDSDivider />
                             </div>
                             {DEVICE_ROWS.map((device, i) => (
                               <div key={i}>
-                                <div
-                                  style={{
-                                    display: 'flex',
-                                    justifyContent: 'space-between',
-                                    alignItems: 'flex-start',
-                                    padding: '16px 0',
-                                    gap: 12,
-                                  }}>
-                                  <ComputerDesktopIcon
-                                    width={32}
-                                    height={32}
-                                    style={{
-                                      flexShrink: 0,
-                                      marginTop: 2,
-                                    }}
-                                  />
-                                  <div style={{flex: 1}}>
-                                    <div
-                                      style={{
-                                        display: 'flex',
-                                        alignItems: 'center',
-                                        gap: 8,
-                                      }}>
+                                <XDSHStack hAlign="justify" vAlign="start" gap={3} xstyle={styles.rowPadding}>
+                                  <div {...stylex.props(styles.flexShrink0MarginTop2)}>
+                                    <XDSIcon icon={ComputerDesktopIcon} size="lg" />
+                                  </div>
+                                  <div {...stylex.props(styles.flex1)}>
+                                    <XDSHStack vAlign="center" gap={2}>
                                       <XDSText type="body" weight="semibold">
                                         {device.label}
                                       </XDSText>
                                       {device.badge && (
                                         <XDSBadge label={device.badge} />
                                       )}
-                                    </div>
+                                    </XDSHStack>
                                     <XDSText
                                       type="supporting"
                                       color="secondary">
@@ -581,7 +588,7 @@ export default function SettingsDialogTemplate() {
                                       {device.action}
                                     </XDSLink>
                                   )}
-                                </div>
+                                </XDSHStack>
                                 <XDSDivider />
                               </div>
                             ))}
@@ -590,16 +597,10 @@ export default function SettingsDialogTemplate() {
                           {/* Account */}
                           <XDSVStack gap={0}>
                             <XDSHeading level={3}>Account</XDSHeading>
-                            <div style={{marginTop: 8}}>
+                            <div {...stylex.props(styles.marginTop8)}>
                               <XDSDivider />
                             </div>
-                            <div
-                              style={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'flex-start',
-                                padding: '16px 0',
-                              }}>
+                            <XDSHStack hAlign="justify" vAlign="start" xstyle={styles.rowPadding}>
                               <div>
                                 <XDSText
                                   type="body"
@@ -617,7 +618,7 @@ export default function SettingsDialogTemplate() {
                               <XDSLink label="Deactivate" href="#">
                                 Deactivate
                               </XDSLink>
-                            </div>
+                            </XDSHStack>
                             <XDSDivider />
                           </XDSVStack>
                         </XDSVStack>
@@ -627,10 +628,10 @@ export default function SettingsDialogTemplate() {
                         <XDSVStack gap={8}>
                           <XDSVStack gap={0}>
                             <XDSHeading level={3}>Shared access</XDSHeading>
-                            <div style={{marginTop: 8}}>
+                            <div {...stylex.props(styles.marginTop8)}>
                               <XDSDivider />
                             </div>
-                            <div style={{paddingTop: 16}}>
+                            <div {...stylex.props(styles.paddingTop16)}>
                               <XDSText type="body" color="secondary">
                                 Review each request carefully before approving
                                 access. We&apos;ll email your employee or
@@ -642,25 +643,9 @@ export default function SettingsDialogTemplate() {
 
                           <XDSCard>
                             <XDSSection variant="wash">
-                              <div
-                                style={{
-                                  display: 'flex',
-                                  gap: 16,
-                                  alignItems: 'flex-start',
-                                }}>
-                                <div
-                                  style={{
-                                    width: 48,
-                                    height: 48,
-                                    borderRadius: 12,
-                                    backgroundColor:
-                                      'var(--xds-color-background-surface, #fff)',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    flexShrink: 0,
-                                  }}>
-                                  <LockClosedIcon width={24} height={24} />
+                              <XDSHStack gap={4} vAlign="start">
+                                <div {...stylex.props(styles.iconBox, styles.iconBoxSurface)}>
+                                  <XDSIcon icon={LockClosedIcon} size="lg" />
                                 </div>
                                 <XDSVStack gap={1}>
                                   <XDSText type="body" weight="bold">
@@ -673,7 +658,7 @@ export default function SettingsDialogTemplate() {
                                     and send messages on your behalf.
                                   </XDSText>
                                 </XDSVStack>
-                              </div>
+                              </XDSHStack>
                             </XDSSection>
                           </XDSCard>
                         </XDSVStack>
@@ -756,7 +741,7 @@ export default function SettingsDialogTemplate() {
                         {/* Messages */}
                         <XDSVStack gap={0}>
                           <XDSHeading level={3}>Messages</XDSHeading>
-                          <div style={{marginTop: 16}}>
+                          <div {...stylex.props(styles.marginTop16)}>
                             <XDSSwitch
                               label="Show people when I've read their messages."
                               value={readReceipts}
@@ -765,20 +750,15 @@ export default function SettingsDialogTemplate() {
                               labelSpacing="spread"
                             />
                           </div>
-                          <div style={{padding: '16px 0'}}>
-                            <div
-                              style={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                              }}>
+                          <div {...stylex.props(styles.rowPadding)}>
+                            <XDSHStack hAlign="justify" vAlign="center">
                               <XDSText type="body" weight="semibold">
                                 Blocked people
                               </XDSText>
                               <XDSLink label="View" href="#">
                                 View
                               </XDSLink>
-                            </div>
+                            </XDSHStack>
                           </div>
                           <XDSDivider />
                         </XDSVStack>
@@ -786,7 +766,7 @@ export default function SettingsDialogTemplate() {
                         {/* Listings */}
                         <XDSVStack gap={0}>
                           <XDSHeading level={3}>Listings</XDSHeading>
-                          <div style={{marginTop: 16}}>
+                          <div {...stylex.props(styles.marginTop16)}>
                             <XDSSwitch
                               label="Include my listing(s) in search engines"
                               description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
@@ -796,7 +776,7 @@ export default function SettingsDialogTemplate() {
                               labelSpacing="spread"
                             />
                           </div>
-                          <div style={{marginTop: 8}}>
+                          <div {...stylex.props(styles.marginTop8)}>
                             <XDSDivider />
                           </div>
                         </XDSVStack>
@@ -815,7 +795,7 @@ export default function SettingsDialogTemplate() {
                               </XDSLink>
                             </XDSText>
                           </div>
-                          <div style={{marginTop: 16}}>
+                          <div {...stylex.props(styles.marginTop16)}>
                             <XDSVStack gap={4}>
                               <XDSSwitch
                                 label="Show my home city and country"
@@ -851,7 +831,7 @@ export default function SettingsDialogTemplate() {
                               />
                             </XDSVStack>
                           </div>
-                          <div style={{marginTop: 16}}>
+                          <div {...stylex.props(styles.marginTop16)}>
                             <XDSDivider />
                           </div>
                         </XDSVStack>
@@ -860,19 +840,14 @@ export default function SettingsDialogTemplate() {
                         <XDSVStack gap={4}>
                           <XDSHeading level={3}>Data privacy</XDSHeading>
                           <XDSCard padding={4}>
-                            <div
-                              style={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                              }}>
+                            <XDSHStack hAlign="justify" vAlign="center">
                               <XDSText type="body">
                                 Request my personal data
                               </XDSText>
                               <XDSLink label="Request" href="#">
                                 Request
                               </XDSLink>
-                            </div>
+                            </XDSHStack>
                           </XDSCard>
                           <XDSSwitch
                             label="Help improve AI-powered features"
@@ -883,39 +858,18 @@ export default function SettingsDialogTemplate() {
                             labelSpacing="spread"
                           />
                           <XDSCard padding={4}>
-                            <div
-                              style={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'center',
-                              }}>
+                            <XDSHStack hAlign="justify" vAlign="center">
                               <XDSText type="body">Delete my account</XDSText>
                               <XDSLink label="Delete" href="#">
                                 Delete
                               </XDSLink>
-                            </div>
+                            </XDSHStack>
                           </XDSCard>
                           <XDSCard>
                             <XDSSection variant="wash">
-                              <div
-                                style={{
-                                  display: 'flex',
-                                  gap: 16,
-                                  alignItems: 'flex-start',
-                                }}>
-                                <div
-                                  style={{
-                                    width: 48,
-                                    height: 48,
-                                    borderRadius: 12,
-                                    backgroundColor:
-                                      'var(--xds-color-background-surface, #fff)',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    flexShrink: 0,
-                                  }}>
-                                  <ShieldCheckIcon width={24} height={24} />
+                              <XDSHStack gap={4} vAlign="start">
+                                <div {...stylex.props(styles.iconBox, styles.iconBoxSurface)}>
+                                  <XDSIcon icon={ShieldCheckIcon} size="lg" />
                                 </div>
                                 <XDSVStack gap={1}>
                                   <XDSText type="body" weight="bold">
@@ -933,7 +887,7 @@ export default function SettingsDialogTemplate() {
                                     .
                                   </XDSText>
                                 </XDSVStack>
-                              </div>
+                              </XDSHStack>
                             </XDSSection>
                           </XDSCard>
                         </XDSVStack>

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -147,7 +147,7 @@ function ExpandableRow({
           </XDSHStack>
         </div>
       ) : (
-        <XDSHStack hAlign="justify" vAlign="start" xstyle={styles.rowPadding}>
+        <XDSHStack hAlign="between" vAlign="start" xstyle={styles.rowPadding}>
           <div>
             <XDSText type="body" weight="semibold" display="block">
               {label}
@@ -183,7 +183,7 @@ function InfoRowItem({
 }) {
   return (
     <>
-      <XDSHStack hAlign="justify" vAlign="start" xstyle={styles.rowPadding}>
+      <XDSHStack hAlign="between" vAlign="start" xstyle={styles.rowPadding}>
         <div>
           <XDSText type="body" weight="semibold" display="block">
             {label}
@@ -444,7 +444,11 @@ export default function SettingsDialogTemplate() {
                         <XDSVStack gap={0}>
                           <div {...stylex.props(styles.rowPaddingBottom)}>
                             <XDSHStack gap={3} vAlign="start">
-                              <div {...stylex.props(styles.iconBox, styles.iconBoxMuted)}>
+                              <div
+                                {...stylex.props(
+                                  styles.iconBox,
+                                  styles.iconBoxMuted,
+                                )}>
                                 <XDSIcon icon={LockClosedIcon} size="lg" />
                               </div>
                               <XDSVStack gap={0}>
@@ -467,7 +471,11 @@ export default function SettingsDialogTemplate() {
                           <XDSDivider />
                           <div {...stylex.props(styles.rowPadding)}>
                             <XDSHStack gap={3} vAlign="start">
-                              <div {...stylex.props(styles.iconBox, styles.iconBoxMuted)}>
+                              <div
+                                {...stylex.props(
+                                  styles.iconBox,
+                                  styles.iconBoxMuted,
+                                )}>
                                 <XDSIcon icon={PencilSquareIcon} size="lg" />
                               </div>
                               <XDSVStack gap={0}>
@@ -493,7 +501,11 @@ export default function SettingsDialogTemplate() {
                           <XDSDivider />
                           <div {...stylex.props(styles.rowPaddingTop)}>
                             <XDSHStack gap={3} vAlign="start">
-                              <div {...stylex.props(styles.iconBox, styles.iconBoxMuted)}>
+                              <div
+                                {...stylex.props(
+                                  styles.iconBox,
+                                  styles.iconBoxMuted,
+                                )}>
                                 <XDSIcon icon={ShareIcon} size="lg" />
                               </div>
                               <XDSVStack gap={0}>
@@ -564,9 +576,19 @@ export default function SettingsDialogTemplate() {
                             </div>
                             {DEVICE_ROWS.map((device, i) => (
                               <div key={i}>
-                                <XDSHStack hAlign="justify" vAlign="start" gap={3} xstyle={styles.rowPadding}>
-                                  <div {...stylex.props(styles.flexShrink0MarginTop2)}>
-                                    <XDSIcon icon={ComputerDesktopIcon} size="lg" />
+                                <XDSHStack
+                                  hAlign="between"
+                                  vAlign="start"
+                                  gap={3}
+                                  xstyle={styles.rowPadding}>
+                                  <div
+                                    {...stylex.props(
+                                      styles.flexShrink0MarginTop2,
+                                    )}>
+                                    <XDSIcon
+                                      icon={ComputerDesktopIcon}
+                                      size="lg"
+                                    />
                                   </div>
                                   <div {...stylex.props(styles.flex1)}>
                                     <XDSHStack vAlign="center" gap={2}>
@@ -600,7 +622,10 @@ export default function SettingsDialogTemplate() {
                             <div {...stylex.props(styles.marginTop8)}>
                               <XDSDivider />
                             </div>
-                            <XDSHStack hAlign="justify" vAlign="start" xstyle={styles.rowPadding}>
+                            <XDSHStack
+                              hAlign="between"
+                              vAlign="start"
+                              xstyle={styles.rowPadding}>
                               <div>
                                 <XDSText
                                   type="body"
@@ -644,7 +669,11 @@ export default function SettingsDialogTemplate() {
                           <XDSCard>
                             <XDSSection variant="wash">
                               <XDSHStack gap={4} vAlign="start">
-                                <div {...stylex.props(styles.iconBox, styles.iconBoxSurface)}>
+                                <div
+                                  {...stylex.props(
+                                    styles.iconBox,
+                                    styles.iconBoxSurface,
+                                  )}>
                                   <XDSIcon icon={LockClosedIcon} size="lg" />
                                 </div>
                                 <XDSVStack gap={1}>
@@ -751,7 +780,7 @@ export default function SettingsDialogTemplate() {
                             />
                           </div>
                           <div {...stylex.props(styles.rowPadding)}>
-                            <XDSHStack hAlign="justify" vAlign="center">
+                            <XDSHStack hAlign="between" vAlign="center">
                               <XDSText type="body" weight="semibold">
                                 Blocked people
                               </XDSText>
@@ -840,7 +869,7 @@ export default function SettingsDialogTemplate() {
                         <XDSVStack gap={4}>
                           <XDSHeading level={3}>Data privacy</XDSHeading>
                           <XDSCard padding={4}>
-                            <XDSHStack hAlign="justify" vAlign="center">
+                            <XDSHStack hAlign="between" vAlign="center">
                               <XDSText type="body">
                                 Request my personal data
                               </XDSText>
@@ -858,7 +887,7 @@ export default function SettingsDialogTemplate() {
                             labelSpacing="spread"
                           />
                           <XDSCard padding={4}>
-                            <XDSHStack hAlign="justify" vAlign="center">
+                            <XDSHStack hAlign="between" vAlign="center">
                               <XDSText type="body">Delete my account</XDSText>
                               <XDSLink label="Delete" href="#">
                                 Delete
@@ -868,7 +897,11 @@ export default function SettingsDialogTemplate() {
                           <XDSCard>
                             <XDSSection variant="wash">
                               <XDSHStack gap={4} vAlign="start">
-                                <div {...stylex.props(styles.iconBox, styles.iconBoxSurface)}>
+                                <div
+                                  {...stylex.props(
+                                    styles.iconBox,
+                                    styles.iconBoxSurface,
+                                  )}>
                                   <XDSIcon icon={ShieldCheckIcon} size="lg" />
                                 </div>
                                 <XDSVStack gap={1}>

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -267,6 +267,7 @@ export default function SettingsDialogTemplate() {
         onOpenChange={open => setIsOpen(open)}
         width={900}
         maxHeight="85vh"
+        padding={0}
         purpose="form">
         <div
           style={{
@@ -643,8 +644,8 @@ export default function SettingsDialogTemplate() {
                         </div>
                       </XDSVStack>
 
-                      <XDSCard padding={0} xstyle={styles.noBorder}>
-                        <XDSSection variant="wash" style={{padding: 16}}>
+                      <XDSCard>
+                        <XDSSection variant="wash">
                           <div
                             style={{
                               display: 'flex',
@@ -688,7 +689,6 @@ export default function SettingsDialogTemplate() {
                 <XDSVStack gap={6}>
                   <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
                   <XDSVStack gap={0}>
-                    <XDSDivider />
                     <ExpandableRow
                       label="Preferred language"
                       value={
@@ -897,8 +897,8 @@ export default function SettingsDialogTemplate() {
                           </XDSLink>
                         </div>
                       </XDSCard>
-                      <XDSCard padding={0} xstyle={styles.noBorder}>
-                        <XDSSection variant="wash" style={{padding: 16}}>
+                      <XDSCard>
+                        <XDSSection variant="wash">
                           <div
                             style={{
                               display: 'flex',

--- a/packages/cli/templates/pages/settings-dialog/page.tsx
+++ b/packages/cli/templates/pages/settings-dialog/page.tsx
@@ -2,7 +2,13 @@
 
 import {useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {
+  XDSVStack,
+  XDSHStack,
+  XDSLayout,
+  XDSLayoutPanel,
+  XDSLayoutContent,
+} from '@xds/core/Layout';
 import {XDSText, XDSHeading} from '@xds/core/Text';
 import {XDSButton} from '@xds/core/Button';
 import {XDSDialog} from '@xds/core/Dialog';
@@ -271,8 +277,6 @@ export default function SettingsDialogTemplate() {
         purpose="form">
         <div
           style={{
-            display: 'flex',
-            flexDirection: 'column',
             height: '100%',
             minHeight: 'calc(85vh - 2px)',
             maxHeight: 'calc(85vh - 2px)',
@@ -289,661 +293,657 @@ export default function SettingsDialogTemplate() {
             />
           </div>
 
-          {/* Body: sidebar + content */}
-          <div style={{display: 'flex', flex: 1, overflow: 'hidden'}}>
-            {/* Sidebar */}
-            <nav
-              {...stylex.props(styles.cardBg)}
-              style={{
-                width: 280,
-                paddingTop: 16,
-                paddingLeft: 12,
-                paddingRight: 12,
-                paddingBottom: 16,
-                borderRight:
-                  '1px solid var(--xds-color-border-primary, #e5e5e5)',
-                flexShrink: 0,
-                overflowY: 'auto',
-              }}>
-              <XDSVStack gap={4}>
-                <div style={{paddingLeft: 16, paddingRight: 16}}>
-                  <XDSHeading level={2}>Account settings</XDSHeading>
-                </div>
-                <XDSList density="spacious">
-                  {NAV_ITEMS.map(item => (
-                    <XDSListItem
-                      key={item.label}
-                      label={item.label}
-                      startContent={<item.icon width={20} height={20} />}
-                      isSelected={activeNav === item.label}
-                      onClick={() => {
-                        setActiveNav(item.label);
-                        setExpandedRow(null);
-                      }}
-                    />
-                  ))}
-                </XDSList>
-                <XDSDivider />
-                <XDSList density="spacious">
-                  <XDSListItem
-                    label="Professional hosting tools"
-                    startContent={
-                      <WrenchScrewdriverIcon width={20} height={20} />
-                    }
-                    onClick={() => {}}
-                  />
-                </XDSList>
-              </XDSVStack>
-            </nav>
-
-            {/* Content */}
-            <div
-              style={{
-                flex: 1,
-                overflowY: 'auto',
-                padding: '16px 32px',
-                maxWidth: 680,
-              }}>
-              {activeNav === 'Personal information' && (
-                <XDSVStack gap={6}>
-                  <XDSHeading level={2}>Personal info</XDSHeading>
-                  <XDSVStack gap={0}>
-                    <InfoRowItem
-                      label="Legal name"
-                      value="Alex Johnson"
-                      action="Edit"
-                    />
-                    <InfoRowItem
-                      label="Preferred first name"
-                      value="Not provided"
-                      action="Add"
-                    />
-                    <InfoRowItem
-                      label="Email address"
-                      value="a***n@example.com"
-                      action="Edit"
-                    />
-                    <InfoRowItem
-                      label="Phone number"
-                      value="+1 ***-***-0123"
-                      action="Edit"
-                    />
-                    <InfoRowItem
-                      label="Identity verification"
-                      value="Verified"
-                      action=""
-                    />
-                    <InfoRowItem
-                      label="Residential address"
-                      value="Not provided"
-                      action="Add"
-                    />
-                    <InfoRowItem
-                      label="Mailing address"
-                      value="Not provided"
-                      action="Add"
-                    />
-                    <InfoRowItem
-                      label="Emergency contact"
-                      value="Provided"
-                      action="Edit"
-                    />
-                  </XDSVStack>
-
-                  <XDSCard padding={4} style={{marginTop: 16}}>
-                    <XDSVStack gap={0}>
-                      <div style={{paddingTop: 0, paddingBottom: 16}}>
-                        <XDSHStack gap={3} vAlign="start">
-                          <div
-                            style={{
-                              width: 48,
-                              height: 48,
-                              borderRadius: 12,
-                              backgroundColor:
-                                'var(--xds-color-background-muted, #f5f5f5)',
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                              flexShrink: 0,
-                            }}>
-                            <LockClosedIcon width={24} height={24} />
-                          </div>
-                          <XDSVStack gap={0}>
-                            <XDSText
-                              type="body"
-                              weight="semibold"
-                              display="block">
-                              Why isn&apos;t my info shown here?
-                            </XDSText>
-                            <XDSText
-                              type="supporting"
-                              color="secondary"
-                              display="block">
-                              We&apos;re hiding some account details to protect
-                              your identity.
-                            </XDSText>
-                          </XDSVStack>
-                        </XDSHStack>
-                      </div>
-                      <XDSDivider />
-                      <div style={{padding: '16px 0'}}>
-                        <XDSHStack gap={3} vAlign="start">
-                          <div
-                            style={{
-                              width: 48,
-                              height: 48,
-                              borderRadius: 12,
-                              backgroundColor:
-                                'var(--xds-color-background-muted, #f5f5f5)',
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                              flexShrink: 0,
-                            }}>
-                            <PencilSquareIcon width={24} height={24} />
-                          </div>
-                          <XDSVStack gap={0}>
-                            <XDSText
-                              type="body"
-                              weight="semibold"
-                              display="block">
-                              Which details can be edited?
-                            </XDSText>
-                            <XDSText
-                              type="supporting"
-                              color="secondary"
-                              display="block">
-                              Contact info and personal details can be edited.
-                              If this info was used to verify your identity,
-                              you&apos;ll need to get verified again the next
-                              time you book—or to continue hosting.
-                            </XDSText>
-                          </XDSVStack>
-                        </XDSHStack>
-                      </div>
-                      <XDSDivider />
-                      <div style={{paddingTop: 16, paddingBottom: 0}}>
-                        <XDSHStack gap={3} vAlign="start">
-                          <div
-                            style={{
-                              width: 48,
-                              height: 48,
-                              borderRadius: 12,
-                              backgroundColor:
-                                'var(--xds-color-background-muted, #f5f5f5)',
-                              display: 'flex',
-                              alignItems: 'center',
-                              justifyContent: 'center',
-                              flexShrink: 0,
-                            }}>
-                            <ShareIcon width={24} height={24} />
-                          </div>
-                          <XDSVStack gap={0}>
-                            <XDSText
-                              type="body"
-                              weight="semibold"
-                              display="block">
-                              What info is shared with others?
-                            </XDSText>
-                            <XDSText
-                              type="supporting"
-                              color="secondary"
-                              display="block">
-                              We only release contact information after a
-                              reservation is confirmed.
-                            </XDSText>
-                          </XDSVStack>
-                        </XDSHStack>
-                      </div>
-                    </XDSVStack>
-                  </XDSCard>
-                </XDSVStack>
-              )}
-
-              {activeNav === 'Login & security' && (
-                <XDSVStack gap={6}>
-                  <XDSHeading level={2}>Login &amp; security</XDSHeading>
-
-                  <div style={{marginLeft: -12, overflow: 'hidden'}}>
-                    <XDSTabList
-                      value={activeTab}
-                      onChange={setActiveTab}
-                      hasDivider>
-                      <XDSTab value="login" label="Login" />
-                      <XDSTab value="shared" label="Shared access" />
-                    </XDSTabList>
+          <XDSLayout
+            height="fill"
+            padding={0}
+            start={
+              <XDSLayoutPanel
+                width={280}
+                hasDivider
+                role="navigation"
+                padding={3}
+                xstyle={styles.cardBg}>
+                <XDSVStack gap={4}>
+                  <div style={{paddingLeft: 16, paddingRight: 16}}>
+                    <XDSHeading level={2}>Account settings</XDSHeading>
                   </div>
-
-                  {activeTab === 'login' && (
-                    <XDSVStack gap={8}>
-                      {/* Login */}
+                  <XDSList density="spacious">
+                    {NAV_ITEMS.map(item => (
+                      <XDSListItem
+                        key={item.label}
+                        label={item.label}
+                        startContent={<item.icon width={20} height={20} />}
+                        isSelected={activeNav === item.label}
+                        onClick={() => {
+                          setActiveNav(item.label);
+                          setExpandedRow(null);
+                        }}
+                      />
+                    ))}
+                  </XDSList>
+                  <XDSDivider />
+                  <XDSList density="spacious">
+                    <XDSListItem
+                      label="Professional hosting tools"
+                      startContent={
+                        <WrenchScrewdriverIcon width={20} height={20} />
+                      }
+                      onClick={() => {}}
+                    />
+                  </XDSList>
+                </XDSVStack>
+              </XDSLayoutPanel>
+            }
+            content={
+              <XDSLayoutContent>
+                <div style={{padding: '16px 32px', maxWidth: 680}}>
+                  {activeNav === 'Personal information' && (
+                    <XDSVStack gap={6}>
+                      <XDSHeading level={2}>Personal info</XDSHeading>
                       <XDSVStack gap={0}>
-                        <XDSHeading level={3}>Login</XDSHeading>
-                        <div style={{marginTop: 8}}>
-                          <XDSDivider />
-                        </div>
-                        {LOGIN_ROWS.map(row => (
-                          <InfoRowItem key={row.label} {...row} />
-                        ))}
+                        <InfoRowItem
+                          label="Legal name"
+                          value="Alex Johnson"
+                          action="Edit"
+                        />
+                        <InfoRowItem
+                          label="Preferred first name"
+                          value="Not provided"
+                          action="Add"
+                        />
+                        <InfoRowItem
+                          label="Email address"
+                          value="a***n@example.com"
+                          action="Edit"
+                        />
+                        <InfoRowItem
+                          label="Phone number"
+                          value="+1 ***-***-0123"
+                          action="Edit"
+                        />
+                        <InfoRowItem
+                          label="Identity verification"
+                          value="Verified"
+                          action=""
+                        />
+                        <InfoRowItem
+                          label="Residential address"
+                          value="Not provided"
+                          action="Add"
+                        />
+                        <InfoRowItem
+                          label="Mailing address"
+                          value="Not provided"
+                          action="Add"
+                        />
+                        <InfoRowItem
+                          label="Emergency contact"
+                          value="Provided"
+                          action="Edit"
+                        />
                       </XDSVStack>
 
-                      {/* Social accounts */}
-                      <XDSVStack gap={0}>
-                        <XDSHeading level={3}>Social accounts</XDSHeading>
-                        <div style={{marginTop: 8}}>
+                      <XDSCard padding={4} style={{marginTop: 16}}>
+                        <XDSVStack gap={0}>
+                          <div style={{paddingTop: 0, paddingBottom: 16}}>
+                            <XDSHStack gap={3} vAlign="start">
+                              <div
+                                style={{
+                                  width: 48,
+                                  height: 48,
+                                  borderRadius: 12,
+                                  backgroundColor:
+                                    'var(--xds-color-background-muted, #f5f5f5)',
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
+                                  flexShrink: 0,
+                                }}>
+                                <LockClosedIcon width={24} height={24} />
+                              </div>
+                              <XDSVStack gap={0}>
+                                <XDSText
+                                  type="body"
+                                  weight="semibold"
+                                  display="block">
+                                  Why isn&apos;t my info shown here?
+                                </XDSText>
+                                <XDSText
+                                  type="supporting"
+                                  color="secondary"
+                                  display="block">
+                                  We&apos;re hiding some account details to
+                                  protect your identity.
+                                </XDSText>
+                              </XDSVStack>
+                            </XDSHStack>
+                          </div>
                           <XDSDivider />
-                        </div>
-                        {SOCIAL_ROWS.map(row => (
-                          <InfoRowItem key={row.label} {...row} />
-                        ))}
-                      </XDSVStack>
+                          <div style={{padding: '16px 0'}}>
+                            <XDSHStack gap={3} vAlign="start">
+                              <div
+                                style={{
+                                  width: 48,
+                                  height: 48,
+                                  borderRadius: 12,
+                                  backgroundColor:
+                                    'var(--xds-color-background-muted, #f5f5f5)',
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
+                                  flexShrink: 0,
+                                }}>
+                                <PencilSquareIcon width={24} height={24} />
+                              </div>
+                              <XDSVStack gap={0}>
+                                <XDSText
+                                  type="body"
+                                  weight="semibold"
+                                  display="block">
+                                  Which details can be edited?
+                                </XDSText>
+                                <XDSText
+                                  type="supporting"
+                                  color="secondary"
+                                  display="block">
+                                  Contact info and personal details can be
+                                  edited. If this info was used to verify your
+                                  identity, you&apos;ll need to get verified
+                                  again the next time you book—or to continue
+                                  hosting.
+                                </XDSText>
+                              </XDSVStack>
+                            </XDSHStack>
+                          </div>
+                          <XDSDivider />
+                          <div style={{paddingTop: 16, paddingBottom: 0}}>
+                            <XDSHStack gap={3} vAlign="start">
+                              <div
+                                style={{
+                                  width: 48,
+                                  height: 48,
+                                  borderRadius: 12,
+                                  backgroundColor:
+                                    'var(--xds-color-background-muted, #f5f5f5)',
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
+                                  flexShrink: 0,
+                                }}>
+                                <ShareIcon width={24} height={24} />
+                              </div>
+                              <XDSVStack gap={0}>
+                                <XDSText
+                                  type="body"
+                                  weight="semibold"
+                                  display="block">
+                                  What info is shared with others?
+                                </XDSText>
+                                <XDSText
+                                  type="supporting"
+                                  color="secondary"
+                                  display="block">
+                                  We only release contact information after a
+                                  reservation is confirmed.
+                                </XDSText>
+                              </XDSVStack>
+                            </XDSHStack>
+                          </div>
+                        </XDSVStack>
+                      </XDSCard>
+                    </XDSVStack>
+                  )}
 
-                      {/* Device history */}
-                      <XDSVStack gap={0}>
-                        <XDSHeading level={3}>Device history</XDSHeading>
-                        <div style={{marginTop: 8}}>
-                          <XDSDivider />
-                        </div>
-                        {DEVICE_ROWS.map((device, i) => (
-                          <div key={i}>
+                  {activeNav === 'Login & security' && (
+                    <XDSVStack gap={6}>
+                      <XDSHeading level={2}>Login &amp; security</XDSHeading>
+
+                      <div style={{marginLeft: -12, overflow: 'hidden'}}>
+                        <XDSTabList
+                          value={activeTab}
+                          onChange={setActiveTab}
+                          hasDivider>
+                          <XDSTab value="login" label="Login" />
+                          <XDSTab value="shared" label="Shared access" />
+                        </XDSTabList>
+                      </div>
+
+                      {activeTab === 'login' && (
+                        <XDSVStack gap={8}>
+                          {/* Login */}
+                          <XDSVStack gap={0}>
+                            <XDSHeading level={3}>Login</XDSHeading>
+                            <div style={{marginTop: 8}}>
+                              <XDSDivider />
+                            </div>
+                            {LOGIN_ROWS.map(row => (
+                              <InfoRowItem key={row.label} {...row} />
+                            ))}
+                          </XDSVStack>
+
+                          {/* Social accounts */}
+                          <XDSVStack gap={0}>
+                            <XDSHeading level={3}>Social accounts</XDSHeading>
+                            <div style={{marginTop: 8}}>
+                              <XDSDivider />
+                            </div>
+                            {SOCIAL_ROWS.map(row => (
+                              <InfoRowItem key={row.label} {...row} />
+                            ))}
+                          </XDSVStack>
+
+                          {/* Device history */}
+                          <XDSVStack gap={0}>
+                            <XDSHeading level={3}>Device history</XDSHeading>
+                            <div style={{marginTop: 8}}>
+                              <XDSDivider />
+                            </div>
+                            {DEVICE_ROWS.map((device, i) => (
+                              <div key={i}>
+                                <div
+                                  style={{
+                                    display: 'flex',
+                                    justifyContent: 'space-between',
+                                    alignItems: 'flex-start',
+                                    padding: '16px 0',
+                                    gap: 12,
+                                  }}>
+                                  <ComputerDesktopIcon
+                                    width={32}
+                                    height={32}
+                                    style={{
+                                      flexShrink: 0,
+                                      marginTop: 2,
+                                    }}
+                                  />
+                                  <div style={{flex: 1}}>
+                                    <div
+                                      style={{
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        gap: 8,
+                                      }}>
+                                      <XDSText type="body" weight="semibold">
+                                        {device.label}
+                                      </XDSText>
+                                      {device.badge && (
+                                        <XDSBadge label={device.badge} />
+                                      )}
+                                    </div>
+                                    <XDSText
+                                      type="supporting"
+                                      color="secondary">
+                                      {device.location}
+                                    </XDSText>
+                                  </div>
+                                  {device.action && (
+                                    <XDSLink label={device.action} href="#">
+                                      {device.action}
+                                    </XDSLink>
+                                  )}
+                                </div>
+                                <XDSDivider />
+                              </div>
+                            ))}
+                          </XDSVStack>
+
+                          {/* Account */}
+                          <XDSVStack gap={0}>
+                            <XDSHeading level={3}>Account</XDSHeading>
+                            <div style={{marginTop: 8}}>
+                              <XDSDivider />
+                            </div>
                             <div
                               style={{
                                 display: 'flex',
                                 justifyContent: 'space-between',
                                 alignItems: 'flex-start',
                                 padding: '16px 0',
-                                gap: 12,
                               }}>
-                              <ComputerDesktopIcon
-                                width={32}
-                                height={32}
-                                style={{
-                                  flexShrink: 0,
-                                  marginTop: 2,
-                                }}
-                              />
-                              <div style={{flex: 1}}>
-                                <div
-                                  style={{
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    gap: 8,
-                                  }}>
-                                  <XDSText type="body" weight="semibold">
-                                    {device.label}
-                                  </XDSText>
-                                  {device.badge && (
-                                    <XDSBadge label={device.badge} />
-                                  )}
-                                </div>
-                                <XDSText type="supporting" color="secondary">
-                                  {device.location}
+                              <div>
+                                <XDSText
+                                  type="body"
+                                  weight="semibold"
+                                  display="block">
+                                  Deactivate your account
+                                </XDSText>
+                                <XDSText
+                                  type="supporting"
+                                  color="secondary"
+                                  display="block">
+                                  This action cannot be undone
                                 </XDSText>
                               </div>
-                              {device.action && (
-                                <XDSLink label={device.action} href="#">
-                                  {device.action}
-                                </XDSLink>
-                              )}
+                              <XDSLink label="Deactivate" href="#">
+                                Deactivate
+                              </XDSLink>
                             </div>
                             <XDSDivider />
-                          </div>
-                        ))}
-                      </XDSVStack>
-
-                      {/* Account */}
-                      <XDSVStack gap={0}>
-                        <XDSHeading level={3}>Account</XDSHeading>
-                        <div style={{marginTop: 8}}>
-                          <XDSDivider />
-                        </div>
-                        <div
-                          style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'flex-start',
-                            padding: '16px 0',
-                          }}>
-                          <div>
-                            <XDSText
-                              type="body"
-                              weight="semibold"
-                              display="block">
-                              Deactivate your account
-                            </XDSText>
-                            <XDSText
-                              type="supporting"
-                              color="secondary"
-                              display="block">
-                              This action cannot be undone
-                            </XDSText>
-                          </div>
-                          <XDSLink label="Deactivate" href="#">
-                            Deactivate
-                          </XDSLink>
-                        </div>
-                        <XDSDivider />
-                      </XDSVStack>
-                    </XDSVStack>
-                  )}
-
-                  {activeTab === 'shared' && (
-                    <XDSVStack gap={8}>
-                      <XDSVStack gap={0}>
-                        <XDSHeading level={3}>Shared access</XDSHeading>
-                        <div style={{marginTop: 8}}>
-                          <XDSDivider />
-                        </div>
-                        <div style={{paddingTop: 16}}>
-                          <XDSText type="body" color="secondary">
-                            Review each request carefully before approving
-                            access. We&apos;ll email your employee or co-worker
-                            a 4-digit code that lets them log into your account
-                            with their trusted device.
-                          </XDSText>
-                        </div>
-                      </XDSVStack>
-
-                      <XDSCard>
-                        <XDSSection variant="wash">
-                          <div
-                            style={{
-                              display: 'flex',
-                              gap: 16,
-                              alignItems: 'flex-start',
-                            }}>
-                            <div
-                              style={{
-                                width: 48,
-                                height: 48,
-                                borderRadius: 12,
-                                backgroundColor:
-                                  'var(--xds-color-background-surface, #fff)',
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'center',
-                                flexShrink: 0,
-                              }}>
-                              <LockClosedIcon width={24} height={24} />
-                            </div>
-                            <XDSVStack gap={1}>
-                              <XDSText type="body" weight="bold">
-                                Adding devices from people you trust
-                              </XDSText>
-                              <XDSText type="body" color="secondary">
-                                When you approve a request, you grant someone
-                                full access to your account. They&apos;ll be
-                                able to change reservations and send messages on
-                                your behalf.
-                              </XDSText>
-                            </XDSVStack>
-                          </div>
-                        </XDSSection>
-                      </XDSCard>
-                    </XDSVStack>
-                  )}
-                </XDSVStack>
-              )}
-
-              {activeNav === 'Languages & currency' && (
-                <XDSVStack gap={6}>
-                  <XDSHeading level={2}>Languages &amp; currency</XDSHeading>
-                  <XDSVStack gap={0}>
-                    <ExpandableRow
-                      label="Preferred language"
-                      value={
-                        LANGUAGES.find(l => l.value === language)?.label ??
-                        language
-                      }
-                      isExpanded={expandedRow === 'language'}
-                      onEdit={() => handleEdit('language')}
-                      onCancel={handleCancel}
-                      onSave={handleSave}>
-                      <XDSSelector
-                        label="Language"
-                        isLabelHidden
-                        size="lg"
-                        value={language}
-                        onChange={setLanguage}
-                        options={LANGUAGES}
-                      />
-                    </ExpandableRow>
-                    <ExpandableRow
-                      label="Preferred currency"
-                      value={
-                        CURRENCIES.find(c => c.value === currency)?.label ??
-                        currency
-                      }
-                      isExpanded={expandedRow === 'currency'}
-                      onEdit={() => handleEdit('currency')}
-                      onCancel={handleCancel}
-                      onSave={handleSave}>
-                      <XDSSelector
-                        label="Currency"
-                        isLabelHidden
-                        size="lg"
-                        value={currency}
-                        onChange={setCurrency}
-                        options={CURRENCIES}
-                      />
-                    </ExpandableRow>
-                    <ExpandableRow
-                      label="Time zone"
-                      value={
-                        TIMEZONES.find(t => t.value === timezone)?.label ??
-                        timezone
-                      }
-                      isExpanded={expandedRow === 'timezone'}
-                      onEdit={() => handleEdit('timezone')}
-                      onCancel={handleCancel}
-                      onSave={handleSave}>
-                      <XDSSelector
-                        label="Time zone"
-                        isLabelHidden
-                        size="lg"
-                        value={timezone}
-                        onChange={setTimezone}
-                        options={TIMEZONES}
-                      />
-                    </ExpandableRow>
-                  </XDSVStack>
-                </XDSVStack>
-              )}
-
-              {activeNav === 'Privacy' && (
-                <XDSVStack gap={6}>
-                  <XDSHeading level={2}>Privacy</XDSHeading>
-
-                  <XDSVStack gap={8}>
-                    {/* Messages */}
-                    <XDSVStack gap={0}>
-                      <XDSHeading level={3}>Messages</XDSHeading>
-                      <div style={{marginTop: 16}}>
-                        <XDSSwitch
-                          label="Show people when I've read their messages."
-                          value={readReceipts}
-                          onChange={setReadReceipts}
-                          labelPosition="start"
-                          labelSpacing="spread"
-                        />
-                      </div>
-                      <div style={{padding: '16px 0'}}>
-                        <div
-                          style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                          }}>
-                          <XDSText type="body" weight="semibold">
-                            Blocked people
-                          </XDSText>
-                          <XDSLink label="View" href="#">
-                            View
-                          </XDSLink>
-                        </div>
-                      </div>
-                      <XDSDivider />
-                    </XDSVStack>
-
-                    {/* Listings */}
-                    <XDSVStack gap={0}>
-                      <XDSHeading level={3}>Listings</XDSHeading>
-                      <div style={{marginTop: 16}}>
-                        <XDSSwitch
-                          label="Include my listing(s) in search engines"
-                          description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
-                          value={searchEngines}
-                          onChange={setSearchEngines}
-                          labelPosition="start"
-                          labelSpacing="spread"
-                        />
-                      </div>
-                      <div style={{marginTop: 8}}>
-                        <XDSDivider />
-                      </div>
-                    </XDSVStack>
-
-                    {/* Reviews */}
-                    <XDSVStack gap={0}>
-                      <XDSHeading level={3}>Reviews</XDSHeading>
-                      <div>
-                        <XDSText type="supporting" color="secondary">
-                          Choose what&apos;s shared when you write a review.{' '}
-                          <XDSLink
-                            label="Learn more"
-                            href="#"
-                            type="supporting">
-                            Learn more
-                          </XDSLink>
-                        </XDSText>
-                      </div>
-                      <div style={{marginTop: 16}}>
-                        <XDSVStack gap={4}>
-                          <XDSSwitch
-                            label="Show my home city and country"
-                            description="Ex: City and country"
-                            value={showCity}
-                            onChange={setShowCity}
-                            labelPosition="start"
-                            labelSpacing="spread"
-                          />
-                          <XDSSwitch
-                            label="Show my trip type"
-                            description="Ex: Stayed with kids or pets"
-                            value={showTripType}
-                            onChange={setShowTripType}
-                            labelPosition="start"
-                            labelSpacing="spread"
-                          />
-                          <XDSSwitch
-                            label="Show my length of stay"
-                            description="Ex: A few nights, about a week, etc."
-                            value={showStayLength}
-                            onChange={setShowStayLength}
-                            labelPosition="start"
-                            labelSpacing="spread"
-                          />
-                          <XDSSwitch
-                            label="Show my booked services"
-                            description="Ex: Gourmet brunch or tasting menu"
-                            value={showServices}
-                            onChange={setShowServices}
-                            labelPosition="start"
-                            labelSpacing="spread"
-                          />
+                          </XDSVStack>
                         </XDSVStack>
-                      </div>
-                      <div style={{marginTop: 16}}>
-                        <XDSDivider />
-                      </div>
-                    </XDSVStack>
+                      )}
 
-                    {/* Data privacy */}
-                    <XDSVStack gap={4}>
-                      <XDSHeading level={3}>Data privacy</XDSHeading>
-                      <XDSCard padding={4}>
-                        <div
-                          style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                          }}>
-                          <XDSText type="body">
-                            Request my personal data
-                          </XDSText>
-                          <XDSLink label="Request" href="#">
-                            Request
-                          </XDSLink>
-                        </div>
-                      </XDSCard>
-                      <XDSSwitch
-                        label="Help improve AI-powered features"
-                        description="When this is on, we use your data to develop and improve AI models."
-                        value={aiFeatures}
-                        onChange={setAiFeatures}
-                        labelPosition="start"
-                        labelSpacing="spread"
-                      />
-                      <XDSCard padding={4}>
-                        <div
-                          style={{
-                            display: 'flex',
-                            justifyContent: 'space-between',
-                            alignItems: 'center',
-                          }}>
-                          <XDSText type="body">Delete my account</XDSText>
-                          <XDSLink label="Delete" href="#">
-                            Delete
-                          </XDSLink>
-                        </div>
-                      </XDSCard>
-                      <XDSCard>
-                        <XDSSection variant="wash">
-                          <div
-                            style={{
-                              display: 'flex',
-                              gap: 16,
-                              alignItems: 'flex-start',
-                            }}>
+                      {activeTab === 'shared' && (
+                        <XDSVStack gap={8}>
+                          <XDSVStack gap={0}>
+                            <XDSHeading level={3}>Shared access</XDSHeading>
+                            <div style={{marginTop: 8}}>
+                              <XDSDivider />
+                            </div>
+                            <div style={{paddingTop: 16}}>
+                              <XDSText type="body" color="secondary">
+                                Review each request carefully before approving
+                                access. We&apos;ll email your employee or
+                                co-worker a 4-digit code that lets them log into
+                                your account with their trusted device.
+                              </XDSText>
+                            </div>
+                          </XDSVStack>
+
+                          <XDSCard>
+                            <XDSSection variant="wash">
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  gap: 16,
+                                  alignItems: 'flex-start',
+                                }}>
+                                <div
+                                  style={{
+                                    width: 48,
+                                    height: 48,
+                                    borderRadius: 12,
+                                    backgroundColor:
+                                      'var(--xds-color-background-surface, #fff)',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    flexShrink: 0,
+                                  }}>
+                                  <LockClosedIcon width={24} height={24} />
+                                </div>
+                                <XDSVStack gap={1}>
+                                  <XDSText type="body" weight="bold">
+                                    Adding devices from people you trust
+                                  </XDSText>
+                                  <XDSText type="body" color="secondary">
+                                    When you approve a request, you grant
+                                    someone full access to your account.
+                                    They&apos;ll be able to change reservations
+                                    and send messages on your behalf.
+                                  </XDSText>
+                                </XDSVStack>
+                              </div>
+                            </XDSSection>
+                          </XDSCard>
+                        </XDSVStack>
+                      )}
+                    </XDSVStack>
+                  )}
+
+                  {activeNav === 'Languages & currency' && (
+                    <XDSVStack gap={6}>
+                      <XDSHeading level={2}>
+                        Languages &amp; currency
+                      </XDSHeading>
+                      <XDSVStack gap={0}>
+                        <ExpandableRow
+                          label="Preferred language"
+                          value={
+                            LANGUAGES.find(l => l.value === language)?.label ??
+                            language
+                          }
+                          isExpanded={expandedRow === 'language'}
+                          onEdit={() => handleEdit('language')}
+                          onCancel={handleCancel}
+                          onSave={handleSave}>
+                          <XDSSelector
+                            label="Language"
+                            isLabelHidden
+                            size="lg"
+                            value={language}
+                            onChange={setLanguage}
+                            options={LANGUAGES}
+                          />
+                        </ExpandableRow>
+                        <ExpandableRow
+                          label="Preferred currency"
+                          value={
+                            CURRENCIES.find(c => c.value === currency)?.label ??
+                            currency
+                          }
+                          isExpanded={expandedRow === 'currency'}
+                          onEdit={() => handleEdit('currency')}
+                          onCancel={handleCancel}
+                          onSave={handleSave}>
+                          <XDSSelector
+                            label="Currency"
+                            isLabelHidden
+                            size="lg"
+                            value={currency}
+                            onChange={setCurrency}
+                            options={CURRENCIES}
+                          />
+                        </ExpandableRow>
+                        <ExpandableRow
+                          label="Time zone"
+                          value={
+                            TIMEZONES.find(t => t.value === timezone)?.label ??
+                            timezone
+                          }
+                          isExpanded={expandedRow === 'timezone'}
+                          onEdit={() => handleEdit('timezone')}
+                          onCancel={handleCancel}
+                          onSave={handleSave}>
+                          <XDSSelector
+                            label="Time zone"
+                            isLabelHidden
+                            size="lg"
+                            value={timezone}
+                            onChange={setTimezone}
+                            options={TIMEZONES}
+                          />
+                        </ExpandableRow>
+                      </XDSVStack>
+                    </XDSVStack>
+                  )}
+
+                  {activeNav === 'Privacy' && (
+                    <XDSVStack gap={6}>
+                      <XDSHeading level={2}>Privacy</XDSHeading>
+
+                      <XDSVStack gap={8}>
+                        {/* Messages */}
+                        <XDSVStack gap={0}>
+                          <XDSHeading level={3}>Messages</XDSHeading>
+                          <div style={{marginTop: 16}}>
+                            <XDSSwitch
+                              label="Show people when I've read their messages."
+                              value={readReceipts}
+                              onChange={setReadReceipts}
+                              labelPosition="start"
+                              labelSpacing="spread"
+                            />
+                          </div>
+                          <div style={{padding: '16px 0'}}>
                             <div
                               style={{
-                                width: 48,
-                                height: 48,
-                                borderRadius: 12,
-                                backgroundColor:
-                                  'var(--xds-color-background-surface, #fff)',
                                 display: 'flex',
+                                justifyContent: 'space-between',
                                 alignItems: 'center',
-                                justifyContent: 'center',
-                                flexShrink: 0,
                               }}>
-                              <ShieldCheckIcon width={24} height={24} />
+                              <XDSText type="body" weight="semibold">
+                                Blocked people
+                              </XDSText>
+                              <XDSLink label="View" href="#">
+                                View
+                              </XDSLink>
                             </div>
-                            <XDSVStack gap={1}>
-                              <XDSText type="body" weight="bold">
-                                Committed to privacy
-                              </XDSText>
-                              <XDSText type="supporting" color="secondary">
-                                We&apos;re committed to keeping your data
-                                protected. See details in our{' '}
-                                <XDSLink
-                                  label="Privacy Policy"
-                                  href="#"
-                                  type="supporting">
-                                  Privacy Policy
-                                </XDSLink>
-                                .
-                              </XDSText>
+                          </div>
+                          <XDSDivider />
+                        </XDSVStack>
+
+                        {/* Listings */}
+                        <XDSVStack gap={0}>
+                          <XDSHeading level={3}>Listings</XDSHeading>
+                          <div style={{marginTop: 16}}>
+                            <XDSSwitch
+                              label="Include my listing(s) in search engines"
+                              description="Turning this on means search engines, like Google, will display your listing page(s) in search results."
+                              value={searchEngines}
+                              onChange={setSearchEngines}
+                              labelPosition="start"
+                              labelSpacing="spread"
+                            />
+                          </div>
+                          <div style={{marginTop: 8}}>
+                            <XDSDivider />
+                          </div>
+                        </XDSVStack>
+
+                        {/* Reviews */}
+                        <XDSVStack gap={0}>
+                          <XDSHeading level={3}>Reviews</XDSHeading>
+                          <div>
+                            <XDSText type="supporting" color="secondary">
+                              Choose what&apos;s shared when you write a review.{' '}
+                              <XDSLink
+                                label="Learn more"
+                                href="#"
+                                type="supporting">
+                                Learn more
+                              </XDSLink>
+                            </XDSText>
+                          </div>
+                          <div style={{marginTop: 16}}>
+                            <XDSVStack gap={4}>
+                              <XDSSwitch
+                                label="Show my home city and country"
+                                description="Ex: City and country"
+                                value={showCity}
+                                onChange={setShowCity}
+                                labelPosition="start"
+                                labelSpacing="spread"
+                              />
+                              <XDSSwitch
+                                label="Show my trip type"
+                                description="Ex: Stayed with kids or pets"
+                                value={showTripType}
+                                onChange={setShowTripType}
+                                labelPosition="start"
+                                labelSpacing="spread"
+                              />
+                              <XDSSwitch
+                                label="Show my length of stay"
+                                description="Ex: A few nights, about a week, etc."
+                                value={showStayLength}
+                                onChange={setShowStayLength}
+                                labelPosition="start"
+                                labelSpacing="spread"
+                              />
+                              <XDSSwitch
+                                label="Show my booked services"
+                                description="Ex: Gourmet brunch or tasting menu"
+                                value={showServices}
+                                onChange={setShowServices}
+                                labelPosition="start"
+                                labelSpacing="spread"
+                              />
                             </XDSVStack>
                           </div>
-                        </XDSSection>
-                      </XDSCard>
+                          <div style={{marginTop: 16}}>
+                            <XDSDivider />
+                          </div>
+                        </XDSVStack>
+
+                        {/* Data privacy */}
+                        <XDSVStack gap={4}>
+                          <XDSHeading level={3}>Data privacy</XDSHeading>
+                          <XDSCard padding={4}>
+                            <div
+                              style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                alignItems: 'center',
+                              }}>
+                              <XDSText type="body">
+                                Request my personal data
+                              </XDSText>
+                              <XDSLink label="Request" href="#">
+                                Request
+                              </XDSLink>
+                            </div>
+                          </XDSCard>
+                          <XDSSwitch
+                            label="Help improve AI-powered features"
+                            description="When this is on, we use your data to develop and improve AI models."
+                            value={aiFeatures}
+                            onChange={setAiFeatures}
+                            labelPosition="start"
+                            labelSpacing="spread"
+                          />
+                          <XDSCard padding={4}>
+                            <div
+                              style={{
+                                display: 'flex',
+                                justifyContent: 'space-between',
+                                alignItems: 'center',
+                              }}>
+                              <XDSText type="body">Delete my account</XDSText>
+                              <XDSLink label="Delete" href="#">
+                                Delete
+                              </XDSLink>
+                            </div>
+                          </XDSCard>
+                          <XDSCard>
+                            <XDSSection variant="wash">
+                              <div
+                                style={{
+                                  display: 'flex',
+                                  gap: 16,
+                                  alignItems: 'flex-start',
+                                }}>
+                                <div
+                                  style={{
+                                    width: 48,
+                                    height: 48,
+                                    borderRadius: 12,
+                                    backgroundColor:
+                                      'var(--xds-color-background-surface, #fff)',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'center',
+                                    flexShrink: 0,
+                                  }}>
+                                  <ShieldCheckIcon width={24} height={24} />
+                                </div>
+                                <XDSVStack gap={1}>
+                                  <XDSText type="body" weight="bold">
+                                    Committed to privacy
+                                  </XDSText>
+                                  <XDSText type="supporting" color="secondary">
+                                    We&apos;re committed to keeping your data
+                                    protected. See details in our{' '}
+                                    <XDSLink
+                                      label="Privacy Policy"
+                                      href="#"
+                                      type="supporting">
+                                      Privacy Policy
+                                    </XDSLink>
+                                    .
+                                  </XDSText>
+                                </XDSVStack>
+                              </div>
+                            </XDSSection>
+                          </XDSCard>
+                        </XDSVStack>
+                      </XDSVStack>
                     </XDSVStack>
-                  </XDSVStack>
-                </XDSVStack>
-              )}
-            </div>
-          </div>
+                  )}
+                </div>
+              </XDSLayoutContent>
+            }
+          />
         </div>
       </XDSDialog>
     </div>

--- a/packages/core/src/Dialog/XDSDialog.tsx
+++ b/packages/core/src/Dialog/XDSDialog.tsx
@@ -25,6 +25,15 @@ import {
   shadowVars,
 } from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
+import type {SpacingToken} from '../Layout/container.stylex';
+import {
+  paddingStyles,
+  containerPaddingInlineVarStyles,
+  containerPaddingBlockStartVarStyles,
+  containerPaddingBlockEndVarStyles,
+  spacingStepToToken,
+} from '../Layout/padding.stylex';
+import type {SpacingStep} from '../utils/types';
 import {xdsClassName, mergeProps} from '../utils';
 
 /**
@@ -265,6 +274,13 @@ export interface XDSDialogProps extends XDSBaseProps<HTMLDialogElement> {
   purpose?: XDSDialogPurpose;
 
   /**
+   * Internal padding of the dialog using the spacing scale.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   * When omitted, uses the theme default for dialogs.
+   */
+  padding?: SpacingStep;
+
+  /**
    * The content of the dialog.
    * Typically an XDSLayout with header, content, and footer slots.
    */
@@ -297,6 +313,7 @@ export function XDSDialog({
   position,
   variant = 'standard',
   purpose = 'info',
+  padding,
   children,
   xstyle,
   className,
@@ -414,6 +431,11 @@ export function XDSDialog({
     }
   };
 
+  // When no explicit padding prop, use theme default (--xds-dialog-padding)
+  const useThemeDefault = padding == null;
+  const effectivePadding = padding ?? 4;
+  const paddingToken = spacingStepToToken[effectivePadding] as SpacingToken;
+
   const isFullscreen = variant === 'fullscreen';
   const hasPosition = position != null && !isFullscreen;
 
@@ -451,14 +473,40 @@ export function XDSDialog({
       <div
         {...stylex.props(
           styles.inner,
-          ...container({
-            useThemeDefault: 'dialog',
-            maxHeight: isFullscreen
-              ? undefined
-              : typeof maxHeight === 'number'
-                ? `${maxHeight}px`
-                : maxHeight,
-          }),
+          ...container(
+            useThemeDefault
+              ? {
+                  useThemeDefault: 'dialog',
+                  maxHeight: isFullscreen
+                    ? undefined
+                    : typeof maxHeight === 'number'
+                      ? `${maxHeight}px`
+                      : maxHeight,
+                }
+              : {
+                  paddingInnerX: paddingToken,
+                  paddingInnerY: paddingToken,
+                  paddingOuterX: paddingToken,
+                  paddingOuterY: paddingToken,
+                  maxHeight: isFullscreen
+                    ? undefined
+                    : typeof maxHeight === 'number'
+                      ? `${maxHeight}px`
+                      : maxHeight,
+                },
+          ),
+          !useThemeDefault &&
+            effectivePadding !== 4 &&
+            paddingStyles[effectivePadding],
+          !useThemeDefault &&
+            effectivePadding !== 4 &&
+            containerPaddingInlineVarStyles[effectivePadding],
+          !useThemeDefault &&
+            effectivePadding !== 4 &&
+            containerPaddingBlockStartVarStyles[effectivePadding],
+          !useThemeDefault &&
+            effectivePadding !== 4 &&
+            containerPaddingBlockEndVarStyles[effectivePadding],
         )}>
         {children}
       </div>


### PR DESCRIPTION
## What

Adds a `padding` prop to `XDSDialog` and fixes the settings-dialog template.

## Changes

**`XDSDialog`** — new `padding?: SpacingStep` prop (same pattern as `XDSCard`). When omitted, uses theme default. When set, overrides container padding.

**`settings-dialog` template:**
1. `padding={0}` on dialog — removes container padding for full-bleed sidebar layout
2. Wash sections use standard full-bleed pattern: `<XDSCard>` + `<XDSSection variant="wash">` (was `<XDSCard padding={0} xstyle={noBorder}>` + `<XDSSection style={{padding:16}}>`)
3. Removed unnecessary divider in Languages & currency section