### PR TITLE
feat(sandbox): add Documentation template

### DIFF
--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -102,6 +102,12 @@ export const categories: SandboxCategory[] = [
         href: t.href,
         description: t.description,
       })),
+      {
+        name: 'Documentation (WIP)',
+        href: '/pages/documentation/',
+        description:
+          'Stripe-style docs reader with sidebar, code blocks, and config tables',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Adds a new "Documentation (WIP)" template to the sandbox
- Stripe-style docs reader layout with XDSAppShell + XDSSideNav
- Features: XDSBreadcrumbs, XDSPowerSearch, XDSCodeBlock with syntax highlighting, XDSTable for config options, XDSBanner for callouts, "Was this page helpful?" feedback section
- Registered in sandboxPages.ts under Templates category
