### PR TITLE
fix(Kbd): extend XDSBaseProps for full HTML attribute passthrough

### DIFF
--- a/packages/core/src/Kbd/XDSKbd.tsx
+++ b/packages/core/src/Kbd/XDSKbd.tsx
@@ -13,8 +13,8 @@
 
 import {useState, useLayoutEffect} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {
   colorVars,
   spacingVars,
@@ -99,7 +99,7 @@ function detectMac(): boolean {
   return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');
 }
 
-export interface XDSKbdProps {
+export interface XDSKbdProps extends XDSBaseProps<HTMLSpanElement> {
   /**
    * Keyboard shortcut string. Use "+" to separate keys.
    * Special keys: mod (Cmd on Mac), ctrl, alt, shift, enter, backspace, escape.
@@ -112,28 +112,6 @@ export interface XDSKbdProps {
    * ```
    */
   keys: string;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 /**
@@ -152,7 +130,7 @@ export interface XDSKbdProps {
  * <XDSKbd keys="mod+k" />
  * ```
  */
-export function XDSKbd({keys, xstyle, className, style}: XDSKbdProps) {
+export function XDSKbd({keys, xstyle, className, style, ...rest}: XDSKbdProps) {
   const [isMac, setIsMac] = useState(false);
 
   useLayoutEffect(() => {
@@ -163,6 +141,7 @@ export function XDSKbd({keys, xstyle, className, style}: XDSKbdProps) {
 
   return (
     <span
+      {...rest}
       {...mergeProps(
         xdsClassName('kbd'),
         stylex.props(styles.wrapper, xstyle),


### PR DESCRIPTION
## Component Audit — 2026-04-07

Audited components: **HoverCard**, **Icon**, **Kbd**, **Layer**, **Layout**

---

### Findings by Component

| Component | Status | Issues |
|-----------|--------|--------|
| HoverCard | ✅ Clean | No issues |
| Icon | ⚠️ Needs Review | `tertiary` color alias |
| Kbd | 🔧 Fixed | Missing `XDSBaseProps` extension |
| Layer | ✅ Clean | No issues (hook, no DOM) |
| Layout | ✅ Clean | No issues |

---

### Fix Included

**Kbd — extend `XDSBaseProps<HTMLSpanElement>`** (`packages/core/src/Kbd/XDSKbd.tsx`)

`XDSKbdProps` was manually declaring `xstyle`, `className`, and `style` but not extending `XDSBaseProps`. This silently blocked all `HTMLAttributes` — `aria-*`, `data-*`, event handlers — from being passed to the root `<span>`. Fixed by replacing the manual declarations with `extends XDSBaseProps<HTMLSpanElement>` and spreading `...rest` on the element.

---

### Needs Review

**Icon — `tertiary` color duplicates `secondary`**
- File: `packages/core/src/Icon/XDSIcon.tsx` lines 53–55
- Both `secondary` and `tertiary` map to `colorVars['--color-icon-secondary']`
- No `--color-icon-tertiary` token exists in the token file
- Options: (1) remove `tertiary` from `XDSIconColor` as a breaking change, (2) add a dedicated `--color-icon-tertiary` token that themes can differentiate, or (3) document it as intentional (tertiary = visual alias for secondary in the default theme)
- This is a naming/API decision — leaving for human review before changing

---
