### PR TITLE
fix: rename template to Contact Form (Two-Column)

### DIFF
--- a/packages/cli/templates/form-two-column/template.doc.mjs
+++ b/packages/cli/templates/form-two-column/template.doc.mjs
@@ -1,6 +1,6 @@
 /** @type {import('../../../core/src/docs-types').TemplateDoc} */
 export const doc = {
-  name: 'Form (Two-Column)',
+  name: 'Contact Form (Two-Column)',
   description: 'Hero header with form card layout for data collection',
   isReady: true,
 };


### PR DESCRIPTION
Renames 'Form (Two-Column)' → 'Contact Form (Two-Column)' in template.doc.mjs.