### PR TITLE
feat(Chat): scroll-to-bottom button with streaming label expansion

### DIFF
--- a/apps/storybook/stories/Chat.stories.tsx
+++ b/apps/storybook/stories/Chat.stories.tsx
@@ -610,3 +610,60 @@ For server state, use a library like **TanStack Query** or **SWR**.`}</XDSMarkdo
     </div>
   ),
 };
+
+export const ScrollToBottom: StoryObj = {
+  name: 'Scroll to Bottom',
+  render: () => {
+    const [messages, setMessages] = useState(
+      Array.from({length: 30}, (_, i) => ({
+        id: i + 1,
+        sender: i % 2 === 0 ? ('user' as const) : ('assistant' as const),
+        text:
+          i % 2 === 0
+            ? `User message #${i + 1}`
+            : `This is assistant response #${i + 1}. It has enough content to require scrolling through the message list.`,
+      })),
+    );
+
+    const addNewMessage = useCallback(() => {
+      setMessages(prev => [
+        ...prev,
+        {
+          id: prev.length + 1,
+          sender: 'assistant' as const,
+          text: `New message arrived at ${new Date().toLocaleTimeString()}. Scroll up to see the button expand with a "New messages" label.`,
+        },
+      ]);
+    }, []);
+
+    return (
+      <div style={{height: 400, display: 'flex', flexDirection: 'column'}}>
+        <div
+          style={{
+            padding: '8px 16px',
+            borderBottom: '1px solid var(--color-border)',
+            display: 'flex',
+            gap: 8,
+            alignItems: 'center',
+          }}>
+          <XDSButton
+            label="Add message"
+            variant="secondary"
+            size="sm"
+            onClick={addNewMessage}
+          />
+          <span style={{fontSize: 12, color: 'var(--color-text-secondary)'}}>
+            Scroll up, then click "Add message" to see the button expand
+          </span>
+        </div>
+        <XDSChatMessageList>
+          {messages.map(msg => (
+            <XDSChatMessage key={msg.id} sender={msg.sender}>
+              <XDSChatMessageBubble>{msg.text}</XDSChatMessageBubble>
+            </XDSChatMessage>
+          ))}
+        </XDSChatMessageList>
+      </div>
+    );
+  },
+};

--- a/packages/core/src/Chat/XDSChatMessageList.test.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.test.tsx
@@ -54,13 +54,13 @@ describe('XDSChatMessageList', () => {
     expect(screen.getByTestId('chat-list')).toBeTruthy();
   });
 
-  it('has new messages button (hidden by default)', () => {
+  it('has scroll-to-bottom button (hidden by default)', () => {
     render(
       <XDSChatMessageList>
         <div>msg</div>
       </XDSChatMessageList>,
     );
-    const button = screen.getByLabelText(/New messages/);
+    const button = screen.getByLabelText(/Scroll to bottom/);
     expect(button).toBeTruthy();
   });
 });

--- a/packages/core/src/Chat/XDSChatMessageList.test.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.test.tsx
@@ -60,7 +60,7 @@ describe('XDSChatMessageList', () => {
         <div>msg</div>
       </XDSChatMessageList>,
     );
-    const button = screen.getByLabelText(/Scroll to bottom/);
+    const button = screen.getByRole('button', {name: /Scroll to bottom/});
     expect(button).toBeTruthy();
   });
 });

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -198,21 +198,22 @@ const styles = stylex.create({
     transitionDelay: '150ms',
   },
   scrollButton: {
-    // Override element radius to pill and disable icon-only square aspect
-    // so the button can grow with the animated label
     [radiusVars['--radius-element'] as string]: radiusVars['--radius-full'],
-    ['--button-icon-only-aspect' as string]: 'auto',
-    // Animate gap so collapsed state has no dead space between icon and label
-    transitionProperty: 'gap, padding',
+    transitionProperty: 'gap, padding, aspect-ratio',
     transitionDuration: durationVars['--duration-fast-max'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   scrollButtonCollapsed: {
     gap: 0,
-    paddingInlineEnd: 0,
+    // Square icon-only appearance
+    ['--button-icon-only-aspect' as string]: '1 / 1',
+    paddingInline: 0,
   },
   scrollButtonExpanded: {
     gap: spacingVars['--spacing-2'],
+    ['--button-icon-only-aspect' as string]: 'auto',
+    paddingInlineStart: spacingVars['--spacing-2'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
   },
   // Label wrapper — always present, width-animated to reveal/hide
   scrollButtonLabelWrapper: {

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -2,13 +2,14 @@
 
 /**
  * @file XDSChatMessageList.tsx
- * @input Uses React, StyleX, XDSChatListContext, XDSButton, theme tokens
+ * @input Uses React, StyleX, XDSChatListContext, XDSIcon, theme tokens, useAutoScroll, useXDSStreamingText
  * @output Exports XDSChatMessageList component and XDSChatMessageListProps
  * @position Scrollable message container — holds XDSChatMessage children with auto-scroll
  *
  * Renders a scrollable container with role="log" for chat message histories.
- * Handles auto-scroll (pins to bottom during streaming), a "New messages"
- * indicator when scrolled up, and onScrollToTopAction for infinite scroll.
+ * Handles auto-scroll (pins to bottom during streaming), a floating
+ * scroll-to-bottom button when scrolled up, and a "New messages" label
+ * that expands into the button with streaming text when new content arrives.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Chat/index.ts (exports)
@@ -33,11 +34,14 @@ import {
   fontWeightVars,
   durationVars,
   easeVars,
+  shadowVars,
 } from '../theme/tokens.stylex';
 import {XDSChatListContext, type XDSChatDensity} from './XDSChatContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSSpinner} from '../Spinner';
+import {XDSIcon} from '../Icon';
 import {useAutoScroll} from './useAutoScroll';
+import {useXDSStreamingText} from '../hooks/useXDSStreamingText';
 
 export interface XDSChatMessageListProps {
   /** Ref forwarded to the scrollable container element */
@@ -64,6 +68,19 @@ export interface XDSChatMessageListProps {
    * @default 12
    */
   scrollThreshold?: number;
+
+  /**
+   * Distance from bottom (in px) beyond which the scroll-to-bottom button appears.
+   * @default 100
+   */
+  scrollUpThreshold?: number;
+
+  /**
+   * Label shown in the scroll-to-bottom button when new messages arrive.
+   * The label grows in with streaming text animation.
+   * @default 'New messages'
+   */
+  newMessagesLabel?: string;
 
   /**
    * Custom content when the list has no messages.
@@ -147,39 +164,63 @@ const styles = stylex.create({
     justifyContent: 'center',
     paddingBlock: spacingVars['--spacing-3'],
   },
-  newMessagesButton: {
+
+  // --- Scroll-to-bottom button ---
+  scrollButton: {
     position: 'absolute',
     bottom: spacingVars['--spacing-3'],
     left: '50%',
-    transform: 'translateX(-50%)',
     display: 'inline-flex',
     alignItems: 'center',
+    justifyContent: 'center',
     gap: spacingVars['--spacing-1'],
-    paddingBlock: spacingVars['--spacing-1-5'],
-    paddingInline: spacingVars['--spacing-3'],
-    backgroundColor: colorVars['--color-accent'],
-    color: colorVars['--color-on-accent'],
-    border: 'none',
+    border: `1px solid ${colorVars['--color-border']}`,
     borderRadius: radiusVars['--radius-full'],
     cursor: 'pointer',
+    fontFamily: 'inherit',
     fontSize: typeScaleVars['--text-supporting-size'],
-    fontWeight: fontWeightVars['--font-weight-semibold'],
-    boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-    transitionProperty: 'opacity, transform',
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    backgroundColor: colorVars['--color-background-popover'],
+    color: colorVars['--color-text-secondary'],
+    boxShadow: shadowVars['--shadow-med'],
+    transitionProperty:
+      'opacity, transform, padding, color, background-color, box-shadow',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
     zIndex: 1,
+    // Icon-only sizing as default
+    height: '32px',
+    minWidth: '32px',
+    paddingBlock: 0,
+    paddingInline: 0,
+    ':hover': {
+      backgroundColor: colorVars['--color-background-muted'],
+      color: colorVars['--color-text-primary'],
+      boxShadow: shadowVars['--shadow-high'],
+    },
   },
-  newMessagesHidden: {
+  scrollButtonHidden: {
     opacity: 0,
     pointerEvents: 'none',
     transform: 'translate(-50%, 8px)',
   },
-  newMessagesVisible: {
+  scrollButtonVisible: {
     opacity: 1,
     pointerEvents: 'auto',
     transform: 'translate(-50%, 0)',
   },
+  // When showing new messages label, expand with padding
+  scrollButtonExpanded: {
+    paddingInlineStart: spacingVars['--spacing-2'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
+    color: colorVars['--color-text-primary'],
+  },
+  scrollButtonLabel: {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+  },
+
   emptyState: {
     display: 'flex',
     alignItems: 'center',
@@ -190,14 +231,68 @@ const styles = stylex.create({
 });
 
 // =============================================================================
+// Sub-components
+// =============================================================================
+
+/**
+ * Animated scroll-to-bottom button.
+ *
+ * - Icon-only (chevron down) when the user is scrolled up
+ * - Expands with a streaming-text label when new messages arrive
+ * - Muted glass styling, not primary
+ */
+function ScrollToBottomButton({
+  isScrolledUp,
+  showNewMessages,
+  label,
+  onClick,
+}: {
+  isScrolledUp: boolean;
+  showNewMessages: boolean;
+  label: string;
+  onClick: () => void;
+}) {
+  const isVisible = isScrolledUp || showNewMessages;
+
+  // Stream the label in when new messages appear, snap to full when they disappear
+  const streamedLabel = useXDSStreamingText(
+    showNewMessages ? label : '',
+    showNewMessages,
+    {speed: 'fast'},
+  );
+
+  const hasLabel = streamedLabel.length > 0;
+
+  return (
+    <button
+      type="button"
+      aria-label={showNewMessages ? label : 'Scroll to bottom'}
+      onClick={onClick}
+      {...stylex.props(
+        styles.scrollButton,
+        isVisible ? styles.scrollButtonVisible : styles.scrollButtonHidden,
+        hasLabel && styles.scrollButtonExpanded,
+      )}>
+      <XDSIcon icon="chevronDown" size="sm" />
+      {hasLabel && (
+        <span {...stylex.props(styles.scrollButtonLabel)}>{streamedLabel}</span>
+      )}
+    </button>
+  );
+}
+
+// =============================================================================
 // Component
 // =============================================================================
 
 /**
  * Scrollable container for chat messages with auto-scroll and infinite scroll support.
  *
- * Pins to the bottom when the user is near the end. Shows a "New messages" button
- * when scrolled up. Supports loading older messages via `onScrollToTopAction`.
+ * Pins to the bottom when the user is near the end. Shows a muted
+ * scroll-to-bottom icon button when scrolled up. When new messages
+ * arrive while scrolled up, the button expands to show a streaming
+ * "New messages" label. Supports loading older messages via
+ * `onScrollToTopAction`.
  *
  * @example
  * ```
@@ -215,6 +310,8 @@ export function XDSChatMessageList({
   children,
   hasAutoScroll = true,
   scrollThreshold = 12,
+  scrollUpThreshold = 100,
+  newMessagesLabel = 'New messages',
   emptyState,
   onScrollToTopAction,
   density = 'balanced',
@@ -226,11 +323,17 @@ export function XDSChatMessageList({
 }: XDSChatMessageListProps) {
   const {
     scrollRef,
+    isScrolledUp,
     showNewMessages,
     handleScroll,
+    scrollToBottom,
     dismissNewMessages,
     onContentChange,
-  } = useAutoScroll({enabled: hasAutoScroll, threshold: scrollThreshold});
+  } = useAutoScroll({
+    enabled: hasAutoScroll,
+    threshold: scrollThreshold,
+    scrollUpThreshold,
+  });
 
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [isLoadingTop, startTransition] = useTransition();
@@ -288,6 +391,15 @@ export function XDSChatMessageList({
     [ref, scrollRef],
   );
 
+  // Click handler: dismiss new messages (scrolls to bottom) or just scroll
+  const handleButtonClick = useCallback(() => {
+    if (showNewMessages) {
+      dismissNewMessages();
+    } else {
+      scrollToBottom();
+    }
+  }, [showNewMessages, dismissNewMessages, scrollToBottom]);
+
   return (
     <XDSChatListContext.Provider value={contextValue}>
       <div {...stylex.props(styles.outer)}>
@@ -327,19 +439,13 @@ export function XDSChatMessageList({
           </div>
         </div>
 
-        {/* New messages button */}
-        <button
-          type="button"
-          aria-label="New messages — scroll to bottom"
-          onClick={dismissNewMessages}
-          {...stylex.props(
-            styles.newMessagesButton,
-            showNewMessages
-              ? styles.newMessagesVisible
-              : styles.newMessagesHidden,
-          )}>
-          New messages ↓
-        </button>
+        {/* Scroll-to-bottom button: icon-only when scrolled up, expands with label on new messages */}
+        <ScrollToBottomButton
+          isScrolledUp={isScrolledUp}
+          showNewMessages={showNewMessages}
+          label={newMessagesLabel}
+          onClick={handleButtonClick}
+        />
       </div>
     </XDSChatListContext.Provider>
   );

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -164,72 +164,47 @@ const styles = stylex.create({
   },
 
   // --- Scroll-to-bottom button ---
-  // The label is always in the DOM but clipped via animated max-width
-  // on the label wrapper. CSS-only reveal — no per-frame DOM mutations.
-  // The button sits on an opaque container (scrollButtonBg) that provides
-  // the popover surface, so hover/focus translucent states don't bleed.
-  // `contain: layout style` isolates the max-width transition so it
-  // doesn't invalidate layout on the parent scroll container.
+  // Container controls dimensions and clips content. The XDSButton inside
+  // is always full-size; the container's width transition reveals the label.
+  // Opaque popover bg on the container prevents hover tint bleed-through.
+  // `contain: layout style` isolates reflow from the scroll area.
   scrollButtonContainer: {
     position: 'absolute',
     bottom: spacingVars['--spacing-3'],
     left: '50%',
     contain: 'layout style',
-    display: 'inline-flex',
+    overflow: 'hidden',
     borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-background-popover'],
     boxShadow: shadowVars['--shadow-med'],
+    height: '32px',
     zIndex: 1,
-    transitionProperty: 'opacity, transform',
+    transitionProperty: 'opacity, transform, max-width',
     transitionTimingFunction: easeVars['--ease-standard'],
+    transitionDuration: durationVars['--duration-fast-max'],
   },
   scrollButtonContainerHidden: {
     opacity: 0,
     pointerEvents: 'none',
+    maxWidth: '32px',
     transform: 'translate(-50%, 8px)',
-    transitionDuration: durationVars['--duration-fast'],
     transitionDelay: '0ms',
   },
   scrollButtonContainerVisible: {
     opacity: 1,
     pointerEvents: 'auto',
     transform: 'translate(-50%, 0)',
-    transitionDuration: durationVars['--duration-fast'],
     transitionDelay: '150ms',
+  },
+  scrollButtonCollapsed: {
+    maxWidth: '32px',
+  },
+  scrollButtonExpanded: {
+    maxWidth: '200px',
   },
   scrollButton: {
     [radiusVars['--radius-element'] as string]: radiusVars['--radius-full'],
-    transitionProperty: 'gap, padding, aspect-ratio',
-    transitionDuration: durationVars['--duration-fast-max'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-  },
-  scrollButtonCollapsed: {
-    gap: 0,
-    ['--button-icon-only-aspect' as string]: '1 / 1',
-  },
-  scrollButtonExpanded: {
-    gap: spacingVars['--spacing-2'],
-    ['--button-icon-only-aspect' as string]: 'auto',
-  },
-  // Label wrapper — always present, width-animated to reveal/hide
-  scrollButtonLabelWrapper: {
-    display: 'inline-flex',
-    overflow: 'hidden',
     whiteSpace: 'nowrap',
-    // max-width transition drives the expand/collapse animation
-    transitionProperty: 'max-width, padding',
-    transitionDuration: durationVars['--duration-fast-max'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-  },
-  scrollButtonLabelCollapsed: {
-    maxWidth: '0px',
-    paddingInlineStart: 0,
-  },
-  scrollButtonLabelExpanded: {
-    // Generous max-width — actual content determines visual width
-    maxWidth: '200px',
-    paddingInlineStart: spacingVars['--spacing-1'],
-    paddingInlineEnd: spacingVars['--spacing-1'],
   },
 
   emptyState: {
@@ -276,6 +251,9 @@ function ScrollToBottomButton({
         isVisible
           ? styles.scrollButtonContainerVisible
           : styles.scrollButtonContainerHidden,
+        hasNewMessages
+          ? styles.scrollButtonExpanded
+          : styles.scrollButtonCollapsed,
       )}>
       <XDSButton
         label={hasNewMessages ? label : 'Scroll to bottom'}
@@ -284,21 +262,8 @@ function ScrollToBottomButton({
         variant="ghost"
         size="sm"
         onClick={onClick}
-        xstyle={[
-          styles.scrollButton,
-          hasNewMessages
-            ? styles.scrollButtonExpanded
-            : styles.scrollButtonCollapsed,
-        ]}>
-        <span
-          {...stylex.props(
-            styles.scrollButtonLabelWrapper,
-            hasNewMessages
-              ? styles.scrollButtonLabelExpanded
-              : styles.scrollButtonLabelCollapsed,
-          )}>
-          {label}
-        </span>
+        xstyle={styles.scrollButton}>
+        {label}
       </XDSButton>
     </div>
   );

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -205,15 +205,11 @@ const styles = stylex.create({
   },
   scrollButtonCollapsed: {
     gap: 0,
-    // Square icon-only appearance
     ['--button-icon-only-aspect' as string]: '1 / 1',
-    paddingInline: 0,
   },
   scrollButtonExpanded: {
     gap: spacingVars['--spacing-2'],
     ['--button-icon-only-aspect' as string]: 'auto',
-    paddingInlineStart: spacingVars['--spacing-2'],
-    paddingInlineEnd: spacingVars['--spacing-3'],
   },
   // Label wrapper — always present, width-animated to reveal/hide
   scrollButtonLabelWrapper: {

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -202,6 +202,17 @@ const styles = stylex.create({
     // so the button can grow with the animated label
     [radiusVars['--radius-element'] as string]: radiusVars['--radius-full'],
     ['--button-icon-only-aspect' as string]: 'auto',
+    // Animate gap so collapsed state has no dead space between icon and label
+    transitionProperty: 'gap, padding',
+    transitionDuration: durationVars['--duration-fast-max'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  scrollButtonCollapsed: {
+    gap: 0,
+    paddingInlineEnd: 0,
+  },
+  scrollButtonExpanded: {
+    gap: spacingVars['--spacing-2'],
   },
   // Label wrapper — always present, width-animated to reveal/hide
   scrollButtonLabelWrapper: {
@@ -276,7 +287,12 @@ function ScrollToBottomButton({
         variant="ghost"
         size="sm"
         onClick={onClick}
-        xstyle={styles.scrollButton}>
+        xstyle={[
+          styles.scrollButton,
+          hasNewMessages
+            ? styles.scrollButtonExpanded
+            : styles.scrollButtonCollapsed,
+        ]}>
         <span
           {...stylex.props(
             styles.scrollButtonLabelWrapper,

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file XDSChatMessageList.tsx
- * @input Uses React, StyleX, XDSChatListContext, XDSIcon, theme tokens, useAutoScroll, useXDSStreamingText
+ * @input Uses React, StyleX, XDSChatListContext, XDSIcon, theme tokens, useAutoScroll
  * @output Exports XDSChatMessageList component and XDSChatMessageListProps
  * @position Scrollable message container — holds XDSChatMessage children with auto-scroll
  *
@@ -41,7 +41,6 @@ import {xdsClassName, mergeProps} from '../utils';
 import {XDSSpinner} from '../Spinner';
 import {XDSIcon} from '../Icon';
 import {useAutoScroll} from './useAutoScroll';
-import {useXDSStreamingText} from '../hooks/useXDSStreamingText';
 
 export interface XDSChatMessageListProps {
   /** Ref forwarded to the scrollable container element */
@@ -166,14 +165,18 @@ const styles = stylex.create({
   },
 
   // --- Scroll-to-bottom button ---
+  // The label is always in the DOM but clipped via animated max-width
+  // on the label wrapper. CSS-only reveal — no per-frame DOM mutations.
+  // `contain: layout style` isolates the max-width transition so it
+  // doesn't invalidate layout on the parent scroll container.
   scrollButton: {
     position: 'absolute',
     bottom: spacingVars['--spacing-3'],
     left: '50%',
+    contain: 'layout style',
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: spacingVars['--spacing-1'],
     border: `1px solid ${colorVars['--color-border']}`,
     borderRadius: radiusVars['--radius-full'],
     cursor: 'pointer',
@@ -184,15 +187,14 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-background-popover'],
     color: colorVars['--color-text-secondary'],
     boxShadow: shadowVars['--shadow-med'],
-    transitionProperty:
-      'opacity, transform, padding, color, background-color, box-shadow',
+    transitionProperty: 'opacity, transform, box-shadow, color',
     transitionTimingFunction: easeVars['--ease-standard'],
     zIndex: 1,
-    // Icon-only sizing as default
     height: '32px',
-    minWidth: '32px',
     paddingBlock: 0,
-    paddingInline: 0,
+    paddingInlineStart: spacingVars['--spacing-2'],
+    paddingInlineEnd: spacingVars['--spacing-2'],
+    gap: 0,
     ':hover': {
       backgroundColor: colorVars['--color-background-muted'],
       color: colorVars['--color-text-primary'],
@@ -216,15 +218,25 @@ const styles = stylex.create({
     transitionDuration: durationVars['--duration-fast'],
     transitionDelay: '150ms',
   },
-  // When showing new messages label, expand with padding
-  scrollButtonExpanded: {
-    paddingInlineStart: spacingVars['--spacing-2'],
-    paddingInlineEnd: spacingVars['--spacing-3'],
-    color: colorVars['--color-text-primary'],
-  },
-  scrollButtonLabel: {
+  // Label wrapper — always present, width-animated to reveal/hide
+  scrollButtonLabelWrapper: {
+    display: 'inline-flex',
     overflow: 'hidden',
     whiteSpace: 'nowrap',
+    // max-width transition drives the expand/collapse animation
+    transitionProperty: 'max-width, padding',
+    transitionDuration: durationVars['--duration-fast-max'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  scrollButtonLabelCollapsed: {
+    maxWidth: '0px',
+    paddingInlineStart: 0,
+  },
+  scrollButtonLabelExpanded: {
+    // Generous max-width — actual content determines visual width
+    maxWidth: '200px',
+    paddingInlineStart: spacingVars['--spacing-1'],
+    paddingInlineEnd: spacingVars['--spacing-1'],
   },
 
   emptyState: {
@@ -244,8 +256,13 @@ const styles = stylex.create({
  * Animated scroll-to-bottom button.
  *
  * - Icon-only (chevron down) when the user is scrolled up
- * - Expands with a streaming-text label when new messages arrive
- * - Muted glass styling, not primary
+ * - Expands via max-width animation to reveal label when new messages arrive
+ * - Muted popover styling, not primary
+ *
+ * The label is always in the DOM but clipped by `max-width: 0` + `overflow: hidden`
+ * on the wrapper span. This keeps the animation CSS-only (no DOM mutations per frame).
+ * `contain: layout style` on the button prevents the max-width transition from
+ * invalidating layout above (the message list / scroll container).
  */
 function ScrollToBottomButton({
   isScrolledUp,
@@ -260,15 +277,6 @@ function ScrollToBottomButton({
 }) {
   const isVisible = isScrolledUp || hasNewMessages;
 
-  // Stream the label in when new messages appear, snap to full when they disappear
-  const streamedLabel = useXDSStreamingText(
-    hasNewMessages ? label : '',
-    hasNewMessages,
-    {speed: 'fast'},
-  );
-
-  const hasLabel = streamedLabel.length > 0;
-
   return (
     <button
       type="button"
@@ -277,12 +285,17 @@ function ScrollToBottomButton({
       {...stylex.props(
         styles.scrollButton,
         isVisible ? styles.scrollButtonVisible : styles.scrollButtonHidden,
-        hasLabel && styles.scrollButtonExpanded,
       )}>
       <XDSIcon icon="chevronDown" size="sm" />
-      {hasLabel && (
-        <span {...stylex.props(styles.scrollButtonLabel)}>{streamedLabel}</span>
-      )}
+      <span
+        {...stylex.props(
+          styles.scrollButtonLabelWrapper,
+          hasNewMessages
+            ? styles.scrollButtonLabelExpanded
+            : styles.scrollButtonLabelCollapsed,
+        )}>
+        {label}
+      </span>
     </button>
   );
 }

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -167,13 +167,41 @@ const styles = stylex.create({
   // --- Scroll-to-bottom button ---
   // The label is always in the DOM but clipped via animated max-width
   // on the label wrapper. CSS-only reveal — no per-frame DOM mutations.
+  // The button sits on an opaque container (scrollButtonBg) that provides
+  // the popover surface, so hover/focus translucent states don't bleed.
   // `contain: layout style` isolates the max-width transition so it
   // doesn't invalidate layout on the parent scroll container.
-  scrollButton: {
+  scrollButtonContainer: {
     position: 'absolute',
     bottom: spacingVars['--spacing-3'],
     left: '50%',
     contain: 'layout style',
+    zIndex: 1,
+    transitionProperty: 'opacity, transform',
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  scrollButtonContainerHidden: {
+    opacity: 0,
+    pointerEvents: 'none',
+    transform: 'translate(-50%, 8px)',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionDelay: '0ms',
+  },
+  scrollButtonContainerVisible: {
+    opacity: 1,
+    pointerEvents: 'auto',
+    transform: 'translate(-50%, 0)',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionDelay: '150ms',
+  },
+  // Opaque surface behind the button — matches button size via inline-flex
+  scrollButtonBg: {
+    display: 'inline-flex',
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-background-popover'],
+    boxShadow: shadowVars['--shadow-med'],
+  },
+  scrollButton: {
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -184,12 +212,11 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
     fontWeight: fontWeightVars['--font-weight-medium'],
-    backgroundColor: colorVars['--color-background-popover'],
+    backgroundColor: 'transparent',
     color: colorVars['--color-text-secondary'],
-    boxShadow: shadowVars['--shadow-med'],
-    transitionProperty: 'opacity, transform, box-shadow, color',
+    transitionProperty: 'background-color, box-shadow, color',
+    transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    zIndex: 1,
     height: '32px',
     paddingBlock: 0,
     paddingInlineStart: spacingVars['--spacing-2'],
@@ -198,25 +225,7 @@ const styles = stylex.create({
     ':hover': {
       backgroundColor: colorVars['--color-background-muted'],
       color: colorVars['--color-text-primary'],
-      boxShadow: shadowVars['--shadow-high'],
     },
-  },
-  scrollButtonHidden: {
-    opacity: 0,
-    pointerEvents: 'none',
-    transform: 'translate(-50%, 8px)',
-    // Hide instantly — no delay
-    transitionDuration: durationVars['--duration-fast'],
-    transitionDelay: '0ms',
-  },
-  scrollButtonVisible: {
-    opacity: 1,
-    pointerEvents: 'auto',
-    transform: 'translate(-50%, 0)',
-    // Delay appearance so transient scroll positions (auto-scroll)
-    // don't flash the button
-    transitionDuration: durationVars['--duration-fast'],
-    transitionDelay: '150ms',
   },
   // Label wrapper — always present, width-animated to reveal/hide
   scrollButtonLabelWrapper: {
@@ -257,12 +266,11 @@ const styles = stylex.create({
  *
  * - Icon-only (chevron down) when the user is scrolled up
  * - Expands via max-width animation to reveal label when new messages arrive
- * - Muted popover styling, not primary
+ * - Ghost button on an opaque popover surface so hover tint doesn't bleed
  *
- * The label is always in the DOM but clipped by `max-width: 0` + `overflow: hidden`
- * on the wrapper span. This keeps the animation CSS-only (no DOM mutations per frame).
- * `contain: layout style` on the button prevents the max-width transition from
- * invalidating layout above (the message list / scroll container).
+ * Structure: container (positioning + fade) → bg (opaque surface) → button (ghost)
+ * The label is always in the DOM but clipped by `max-width: 0` + `overflow: hidden`.
+ * `contain: layout style` on the container isolates reflow from the scroll area.
  */
 function ScrollToBottomButton({
   isScrolledUp,
@@ -278,25 +286,32 @@ function ScrollToBottomButton({
   const isVisible = isScrolledUp || hasNewMessages;
 
   return (
-    <button
-      type="button"
-      aria-label={hasNewMessages ? label : 'Scroll to bottom'}
-      onClick={onClick}
+    <div
       {...stylex.props(
-        styles.scrollButton,
-        isVisible ? styles.scrollButtonVisible : styles.scrollButtonHidden,
+        styles.scrollButtonContainer,
+        isVisible
+          ? styles.scrollButtonContainerVisible
+          : styles.scrollButtonContainerHidden,
       )}>
-      <XDSIcon icon="chevronDown" size="sm" />
-      <span
-        {...stylex.props(
-          styles.scrollButtonLabelWrapper,
-          hasNewMessages
-            ? styles.scrollButtonLabelExpanded
-            : styles.scrollButtonLabelCollapsed,
-        )}>
-        {label}
-      </span>
-    </button>
+      <div {...stylex.props(styles.scrollButtonBg)}>
+        <button
+          type="button"
+          aria-label={hasNewMessages ? label : 'Scroll to bottom'}
+          onClick={onClick}
+          {...stylex.props(styles.scrollButton)}>
+          <XDSIcon icon="chevronDown" size="sm" />
+          <span
+            {...stylex.props(
+              styles.scrollButtonLabelWrapper,
+              hasNewMessages
+                ? styles.scrollButtonLabelExpanded
+                : styles.scrollButtonLabelCollapsed,
+            )}>
+            {label}
+          </span>
+        </button>
+      </div>
+    </div>
   );
 }
 

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -9,7 +9,7 @@
  * Renders a scrollable container with role="log" for chat message histories.
  * Handles auto-scroll (pins to bottom during streaming), a floating
  * scroll-to-bottom button when scrolled up, and a "New messages" label
- * that expands into the button with streaming text when new content arrives.
+ * that expands into the button via width animation when new content arrives.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Chat/index.ts (exports)
@@ -30,8 +30,6 @@ import {
   colorVars,
   spacingVars,
   radiusVars,
-  typeScaleVars,
-  fontWeightVars,
   durationVars,
   easeVars,
   shadowVars,
@@ -40,6 +38,7 @@ import {XDSChatListContext, type XDSChatDensity} from './XDSChatContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSSpinner} from '../Spinner';
 import {XDSIcon} from '../Icon';
+import {XDSButton} from '../Button';
 import {useAutoScroll} from './useAutoScroll';
 
 export interface XDSChatMessageListProps {
@@ -76,7 +75,7 @@ export interface XDSChatMessageListProps {
 
   /**
    * Label shown in the scroll-to-bottom button when new messages arrive.
-   * The label grows in with streaming text animation.
+   * Revealed via a width animation on the button.
    * @default 'New messages'
    */
   newMessagesLabel?: string;
@@ -176,6 +175,10 @@ const styles = stylex.create({
     bottom: spacingVars['--spacing-3'],
     left: '50%',
     contain: 'layout style',
+    display: 'inline-flex',
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-background-popover'],
+    boxShadow: shadowVars['--shadow-med'],
     zIndex: 1,
     transitionProperty: 'opacity, transform',
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -194,38 +197,11 @@ const styles = stylex.create({
     transitionDuration: durationVars['--duration-fast'],
     transitionDelay: '150ms',
   },
-  // Opaque surface behind the button — matches button size via inline-flex
-  scrollButtonBg: {
-    display: 'inline-flex',
-    borderRadius: radiusVars['--radius-full'],
-    backgroundColor: colorVars['--color-background-popover'],
-    boxShadow: shadowVars['--shadow-med'],
-  },
   scrollButton: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    border: `1px solid ${colorVars['--color-border']}`,
-    borderRadius: radiusVars['--radius-full'],
-    cursor: 'pointer',
-    fontFamily: 'inherit',
-    fontSize: typeScaleVars['--text-supporting-size'],
-    lineHeight: typeScaleVars['--text-supporting-leading'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    backgroundColor: 'transparent',
-    color: colorVars['--color-text-secondary'],
-    transitionProperty: 'background-color, box-shadow, color',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    height: '32px',
-    paddingBlock: 0,
-    paddingInlineStart: spacingVars['--spacing-2'],
-    paddingInlineEnd: spacingVars['--spacing-2'],
-    gap: 0,
-    ':hover': {
-      backgroundColor: colorVars['--color-background-muted'],
-      color: colorVars['--color-text-primary'],
-    },
+    // Override element radius to pill and disable icon-only square aspect
+    // so the button can grow with the animated label
+    [radiusVars['--radius-element'] as string]: radiusVars['--radius-full'],
+    ['--button-icon-only-aspect' as string]: 'auto',
   },
   // Label wrapper — always present, width-animated to reveal/hide
   scrollButtonLabelWrapper: {
@@ -264,11 +240,11 @@ const styles = stylex.create({
 /**
  * Animated scroll-to-bottom button.
  *
- * - Icon-only (chevron down) when the user is scrolled up
+ * - Icon-only ghost XDSButton (chevron down) when the user is scrolled up
  * - Expands via max-width animation to reveal label when new messages arrive
- * - Ghost button on an opaque popover surface so hover tint doesn't bleed
+ * - Container provides opaque popover surface so ghost hover tint doesn't bleed
  *
- * Structure: container (positioning + fade) → bg (opaque surface) → button (ghost)
+ * Structure: container (positioning, fade, opaque surface) → XDSButton (ghost)
  * The label is always in the DOM but clipped by `max-width: 0` + `overflow: hidden`.
  * `contain: layout style` on the container isolates reflow from the scroll area.
  */
@@ -293,24 +269,24 @@ function ScrollToBottomButton({
           ? styles.scrollButtonContainerVisible
           : styles.scrollButtonContainerHidden,
       )}>
-      <div {...stylex.props(styles.scrollButtonBg)}>
-        <button
-          type="button"
-          aria-label={hasNewMessages ? label : 'Scroll to bottom'}
-          onClick={onClick}
-          {...stylex.props(styles.scrollButton)}>
-          <XDSIcon icon="chevronDown" size="sm" />
-          <span
-            {...stylex.props(
-              styles.scrollButtonLabelWrapper,
-              hasNewMessages
-                ? styles.scrollButtonLabelExpanded
-                : styles.scrollButtonLabelCollapsed,
-            )}>
-            {label}
-          </span>
-        </button>
-      </div>
+      <XDSButton
+        label={hasNewMessages ? label : 'Scroll to bottom'}
+        aria-label={hasNewMessages ? label : 'Scroll to bottom'}
+        icon={<XDSIcon icon="chevronDown" size="sm" />}
+        variant="ghost"
+        size="sm"
+        onClick={onClick}
+        xstyle={styles.scrollButton}>
+        <span
+          {...stylex.props(
+            styles.scrollButtonLabelWrapper,
+            hasNewMessages
+              ? styles.scrollButtonLabelExpanded
+              : styles.scrollButtonLabelCollapsed,
+          )}>
+          {label}
+        </span>
+      </XDSButton>
     </div>
   );
 }
@@ -324,7 +300,7 @@ function ScrollToBottomButton({
  *
  * Pins to the bottom when the user is near the end. Shows a muted
  * scroll-to-bottom icon button when scrolled up. When new messages
- * arrive while scrolled up, the button expands to show a streaming
+ * arrive while scrolled up, the button expands to show a
  * "New messages" label. Supports loading older messages via
  * `onScrollToTopAction`.
  *

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -243,21 +243,21 @@ const styles = stylex.create({
  */
 function ScrollToBottomButton({
   isScrolledUp,
-  showNewMessages,
+  hasNewMessages,
   label,
   onClick,
 }: {
   isScrolledUp: boolean;
-  showNewMessages: boolean;
+  hasNewMessages: boolean;
   label: string;
   onClick: () => void;
 }) {
-  const isVisible = isScrolledUp || showNewMessages;
+  const isVisible = isScrolledUp || hasNewMessages;
 
   // Stream the label in when new messages appear, snap to full when they disappear
   const streamedLabel = useXDSStreamingText(
-    showNewMessages ? label : '',
-    showNewMessages,
+    hasNewMessages ? label : '',
+    hasNewMessages,
     {speed: 'fast'},
   );
 
@@ -266,7 +266,7 @@ function ScrollToBottomButton({
   return (
     <button
       type="button"
-      aria-label={showNewMessages ? label : 'Scroll to bottom'}
+      aria-label={hasNewMessages ? label : 'Scroll to bottom'}
       onClick={onClick}
       {...stylex.props(
         styles.scrollButton,
@@ -324,7 +324,7 @@ export function XDSChatMessageList({
   const {
     scrollRef,
     isScrolledUp,
-    showNewMessages,
+    hasNewMessages,
     handleScroll,
     scrollToBottom,
     dismissNewMessages,
@@ -393,12 +393,12 @@ export function XDSChatMessageList({
 
   // Click handler: dismiss new messages (scrolls to bottom) or just scroll
   const handleButtonClick = useCallback(() => {
-    if (showNewMessages) {
+    if (hasNewMessages) {
       dismissNewMessages();
     } else {
       scrollToBottom();
     }
-  }, [showNewMessages, dismissNewMessages, scrollToBottom]);
+  }, [hasNewMessages, dismissNewMessages, scrollToBottom]);
 
   return (
     <XDSChatListContext.Provider value={contextValue}>
@@ -442,7 +442,7 @@ export function XDSChatMessageList({
         {/* Scroll-to-bottom button: icon-only when scrolled up, expands with label on new messages */}
         <ScrollToBottomButton
           isScrolledUp={isScrolledUp}
-          showNewMessages={showNewMessages}
+          hasNewMessages={hasNewMessages}
           label={newMessagesLabel}
           onClick={handleButtonClick}
         />

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -205,6 +205,8 @@ const styles = stylex.create({
   scrollButton: {
     [radiusVars['--radius-element'] as string]: radiusVars['--radius-full'],
     whiteSpace: 'nowrap',
+    paddingInlineStart: spacingVars['--spacing-2'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
   },
 
   emptyState: {
@@ -258,9 +260,9 @@ function ScrollToBottomButton({
       <XDSButton
         label={hasNewMessages ? label : 'Scroll to bottom'}
         aria-label={hasNewMessages ? label : 'Scroll to bottom'}
-        icon={<XDSIcon icon="chevronDown" size="sm" />}
+        icon={<XDSIcon icon="chevronDown" size="md" />}
         variant="ghost"
-        size="sm"
+        size="md"
         onClick={onClick}
         xstyle={styles.scrollButton}>
         {label}
@@ -285,7 +287,7 @@ function ScrollToBottomButton({
  * @example
  * ```
  * <XDSChatMessageList>
- *   <XDSChatMessage sender="assistant" name="Navi" avatar={<XDSAvatar name="Navi" size="sm" />}>
+ *   <XDSChatMessage sender="assistant" name="Navi" avatar={<XDSAvatar name="Navi" size="md" />}>
  *     <XDSChatMessageBubble>Hello!</XDSChatMessageBubble>
  *   </XDSChatMessage>
  *   <XDSChatMessage sender="user" name="Cindy">
@@ -411,7 +413,7 @@ export function XDSChatMessageList({
             {/* Loading spinner at top */}
             {isLoadingTop && (
               <div {...stylex.props(styles.loadingTop)}>
-                <XDSSpinner size="sm" />
+                <XDSSpinner size="md" />
               </div>
             )}
 

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -186,7 +186,6 @@ const styles = stylex.create({
     boxShadow: shadowVars['--shadow-med'],
     transitionProperty:
       'opacity, transform, padding, color, background-color, box-shadow',
-    transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
     zIndex: 1,
     // Icon-only sizing as default
@@ -204,11 +203,18 @@ const styles = stylex.create({
     opacity: 0,
     pointerEvents: 'none',
     transform: 'translate(-50%, 8px)',
+    // Hide instantly — no delay
+    transitionDuration: durationVars['--duration-fast'],
+    transitionDelay: '0ms',
   },
   scrollButtonVisible: {
     opacity: 1,
     pointerEvents: 'auto',
     transform: 'translate(-50%, 0)',
+    // Delay appearance so transient scroll positions (auto-scroll)
+    // don't flash the button
+    transitionDuration: durationVars['--duration-fast'],
+    transitionDelay: '150ms',
   },
   // When showing new messages label, expand with padding
   scrollButtonExpanded: {

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -205,8 +205,7 @@ const styles = stylex.create({
   scrollButton: {
     [radiusVars['--radius-element'] as string]: radiusVars['--radius-full'],
     whiteSpace: 'nowrap',
-    paddingInlineStart: spacingVars['--spacing-2'],
-    paddingInlineEnd: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
   },
 
   emptyState: {

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -10,7 +10,7 @@
  * - `isScrolledUp` — true when the user has scrolled away from the bottom
  *   (beyond `scrollUpThreshold`), regardless of whether new content arrived.
  *   Drives a scroll-to-bottom affordance.
- * - `showNewMessages` — true when new content arrived while scrolled up.
+ * - `hasNewMessages` — true when new content arrived while scrolled up.
  *   Layers on top of isScrolledUp to add a "new messages" notification.
  *
  * SYNC: When modified, update:
@@ -49,7 +49,7 @@ export interface UseAutoScrollReturn {
   isScrolledUp: boolean;
 
   /** Whether new content arrived while the user is scrolled up. */
-  showNewMessages: boolean;
+  hasNewMessages: boolean;
 
   /** Scroll handler — attach to onScroll on the scrollable element. */
   handleScroll: () => void;
@@ -74,13 +74,13 @@ export interface UseAutoScrollReturn {
  *
  * @example
  * ```
- * const {scrollRef, isScrolledUp, showNewMessages, handleScroll, scrollToBottom, dismissNewMessages} = useAutoScroll();
+ * const {scrollRef, isScrolledUp, hasNewMessages, handleScroll, scrollToBottom, dismissNewMessages} = useAutoScroll();
  *
  * return (
  *   <div ref={scrollRef} onScroll={handleScroll}>
  *     {messages}
  *     {isScrolledUp && <button onClick={scrollToBottom}>↓</button>}
- *     {showNewMessages && <button onClick={dismissNewMessages}>New messages</button>}
+ *     {hasNewMessages && <button onClick={dismissNewMessages}>New messages</button>}
  *   </div>
  * );
  * ```
@@ -91,7 +91,7 @@ export function useAutoScroll({
   scrollUpThreshold = 100,
 }: UseAutoScrollOptions = {}): UseAutoScrollReturn {
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const [showNewMessages, setShowNewMessages] = useState(false);
+  const [hasNewMessages, setHasNewMessages] = useState(false);
   const [isScrolledUp, setIsScrolledUp] = useState(false);
   const isNearBottomRef = useRef(true);
 
@@ -119,7 +119,7 @@ export function useAutoScroll({
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
 
     if (nearBottom) {
-      setShowNewMessages(false);
+      setHasNewMessages(false);
     }
   }, [threshold, scrollUpThreshold]);
 
@@ -128,13 +128,13 @@ export function useAutoScroll({
     if (isNearBottomRef.current) {
       scrollToBottom(true);
     } else {
-      setShowNewMessages(true);
+      setHasNewMessages(true);
     }
   }, [enabled, scrollToBottom]);
 
   const dismissNewMessages = useCallback(() => {
     scrollToBottom();
-    setShowNewMessages(false);
+    setHasNewMessages(false);
   }, [scrollToBottom]);
 
   // Scroll to bottom on mount
@@ -145,7 +145,7 @@ export function useAutoScroll({
   return {
     scrollRef,
     isScrolledUp,
-    showNewMessages,
+    hasNewMessages,
     handleScroll,
     scrollToBottom,
     dismissNewMessages,

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -5,13 +5,24 @@
  * @input Uses React refs, state, and effects
  * @output Exports useAutoScroll hook for scroll-pinning behavior
  * @position Utility hook — used by XDSChatMessageList, also usable standalone
+ *
+ * Exposes two scroll states:
+ * - `isScrolledUp` — true when the user has scrolled away from the bottom
+ *   (beyond `scrollUpThreshold`), regardless of whether new content arrived.
+ *   Drives a scroll-to-bottom affordance.
+ * - `showNewMessages` — true when new content arrived while scrolled up.
+ *   Layers on top of isScrolledUp to add a "new messages" notification.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Chat/index.ts (exports)
+ * - /packages/core/src/Chat/XDSChatMessageList.tsx (consumer)
  */
 
 import {useCallback, useEffect, useRef, useState} from 'react';
 
 export interface UseAutoScrollOptions {
   /**
-   * Whether auto-scroll is enabled.
+   * Whether auto-scroll behavior is enabled.
    * @default true
    */
   enabled?: boolean;
@@ -21,13 +32,23 @@ export interface UseAutoScrollOptions {
    * @default 12
    */
   threshold?: number;
+
+  /**
+   * Distance from bottom (in px) beyond which `isScrolledUp` becomes true.
+   * Controls when the scroll-to-bottom button appears.
+   * @default 100
+   */
+  scrollUpThreshold?: number;
 }
 
 export interface UseAutoScrollReturn {
   /** Ref to attach to the scrollable container element. */
   scrollRef: React.RefObject<HTMLDivElement | null>;
 
-  /** Whether the "new messages" indicator should be shown. */
+  /** Whether the user has scrolled up beyond `scrollUpThreshold`. */
+  isScrolledUp: boolean;
+
+  /** Whether new content arrived while the user is scrolled up. */
   showNewMessages: boolean;
 
   /** Scroll handler — attach to onScroll on the scrollable element. */
@@ -46,16 +67,19 @@ export interface UseAutoScrollReturn {
 /**
  * Hook that manages auto-scroll behavior for scrollable containers.
  *
- * Pins to the bottom when the user is near the end. Shows a "new messages"
- * indicator when new content arrives while scrolled up.
+ * Pins to the bottom when the user is near the end. Tracks two
+ * orthogonal states: whether the user has scrolled up (for a
+ * scroll-to-bottom affordance) and whether new content arrived
+ * while scrolled up (for a "new messages" notification).
  *
  * @example
  * ```
- * const {scrollRef, showNewMessages, handleScroll, dismissNewMessages} = useAutoScroll();
+ * const {scrollRef, isScrolledUp, showNewMessages, handleScroll, scrollToBottom, dismissNewMessages} = useAutoScroll();
  *
  * return (
  *   <div ref={scrollRef} onScroll={handleScroll}>
  *     {messages}
+ *     {isScrolledUp && <button onClick={scrollToBottom}>↓</button>}
  *     {showNewMessages && <button onClick={dismissNewMessages}>New messages</button>}
  *   </div>
  * );
@@ -64,9 +88,11 @@ export interface UseAutoScrollReturn {
 export function useAutoScroll({
   enabled = true,
   threshold = 12,
+  scrollUpThreshold = 100,
 }: UseAutoScrollOptions = {}): UseAutoScrollReturn {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const [showNewMessages, setShowNewMessages] = useState(false);
+  const [isScrolledUp, setIsScrolledUp] = useState(false);
   const isNearBottomRef = useRef(true);
 
   const scrollToBottom = useCallback((smooth = true) => {
@@ -82,20 +108,20 @@ export function useAutoScroll({
     }
   }, []);
 
-  const checkNearBottom = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return true;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    return distanceFromBottom <= threshold;
-  }, [threshold]);
-
   const handleScroll = useCallback(() => {
-    const nearBottom = checkNearBottom();
+    const el = scrollRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    const nearBottom = distanceFromBottom <= threshold;
     isNearBottomRef.current = nearBottom;
+
+    // Track whether user is scrolled up beyond the visible threshold
+    setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
+
     if (nearBottom) {
       setShowNewMessages(false);
     }
-  }, [checkNearBottom]);
+  }, [threshold, scrollUpThreshold]);
 
   const onContentChange = useCallback(() => {
     if (!enabled) return;
@@ -118,6 +144,7 @@ export function useAutoScroll({
 
   return {
     scrollRef,
+    isScrolledUp,
     showNewMessages,
     handleScroll,
     scrollToBottom,


### PR DESCRIPTION
## What

Reworks the scroll-to-bottom affordance in `XDSChatMessageList`.

### Before
- Accent-colored "New messages ↓" button only appeared when new content arrived while scrolled up
- No scroll-to-bottom affordance for general "user scrolled up" case
- Primary fill styling was too loud / in-your-face

### After
- **Icon-only button** (muted chevron-down) appears when user scrolls up past threshold (default 100px)
- **Expands with streaming label** when new messages arrive — the text "New messages" grows in character-by-character using `useXDSStreamingText`, so the button widens gradually instead of popping
- **Muted glass styling** — popover background, subtle border, medium shadow, hover elevates. Inspired by Navi's scroll-to-bottom button
- Clicking either state scrolls to bottom

### `useAutoScroll` changes
- New `isScrolledUp` return value — tracks whether user is beyond `scrollUpThreshold`
- New `scrollUpThreshold` option (default 100px) — separate from the auto-scroll `threshold` (12px)
- `showNewMessages` remains for content-changed-while-scrolled-up detection

### New props on `XDSChatMessageList`
- `scrollUpThreshold` — distance from bottom before button appears
- `newMessagesLabel` — customizable label text (default: "New messages")

### Story
Added "Scroll to Bottom" story with manual message injection so you can test: scroll up → see icon button → click "Add message" → watch label stream in.

---
