### PR TITLE
feat(toast): add XDSToast system

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,6 +1,6 @@
 import type {Preview, Decorator} from '@storybook/react';
 import * as React from 'react';
-import {XDSTheme} from '@xds/core';
+import {XDSTheme, XDSLayerProvider} from '@xds/core';
 import {defaultTheme} from '@xds/theme-default';
 import {neutralTheme} from '@xds/theme-neutral';
 import {brutalistTheme} from '@xds/theme-brutalist';
@@ -54,13 +54,15 @@ const withXDSTheme: Decorator = (Story, context) => {
 
   return (
     <XDSTheme theme={theme} mode={mode}>
-      <div
-        style={{
-          backgroundColor: 'var(--color-background-surface)',
-          padding: 16,
-        }}>
-        <Story />
-      </div>
+      <XDSLayerProvider>
+        <div
+          style={{
+            backgroundColor: 'var(--color-background-surface)',
+            padding: 16,
+          }}>
+          <Story />
+        </div>
+      </XDSLayerProvider>
     </XDSTheme>
   );
 };

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -404,3 +404,53 @@ export const NoProvider: StoryObj = {
     },
   },
 };
+
+// =============================================================================
+// Toast over Dialog
+// =============================================================================
+
+import {XDSDialog} from '@xds/core/Dialog';
+
+function ToastOverDialogDemo() {
+  const toast = useXDSToast();
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <XDSStack gap={2}>
+      <XDSButton label="Open dialog" onClick={() => setIsOpen(true)} />
+      <XDSDialog
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        title="Save changes?"
+        footer={
+          <XDSStack direction="row" gap={2}>
+            <XDSButton
+              label="Cancel"
+              variant="secondary"
+              onClick={() => setIsOpen(false)}
+            />
+            <XDSButton
+              label="Save"
+              onClick={() => {
+                toast({body: 'Changes saved successfully.'});
+                setIsOpen(false);
+              }}
+            />
+          </XDSStack>
+        }>
+        <p>Your unsaved changes will be lost. Do you want to save them?</p>
+      </XDSDialog>
+    </XDSStack>
+  );
+}
+
+export const ToastOverDialog: StoryObj = {
+  render: () => <ToastOverDialogDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Toasts render in the top layer via popover="manual", so they appear above dialogs. Click Save to dismiss the dialog and show a toast — it should be visible on top.',
+      },
+    },
+  },
+};

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -1,6 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {useState, useRef} from 'react';
-import {useXDSToast} from '@xds/core/Toast';
+import {useXDSToast, XDSToastViewport} from '@xds/core/Toast';
 import type {XDSToastType} from '@xds/core/Toast';
 import {XDSButton} from '@xds/core/Button';
 import {XDSLink} from '@xds/core/Link';
@@ -319,7 +319,6 @@ export const NoProvider: StoryObj = {
 
 export const ToastOverDialog: StoryObj = {
   render: function ToastOverDialogStory() {
-    const toast = useXDSToast();
     const [isOpen, setIsOpen] = useState(false);
     return (
       <XDSStack gap={2}>
@@ -327,33 +326,10 @@ export const ToastOverDialog: StoryObj = {
         <XDSDialog
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
-          title="Confirm action"
-          footer={
-            <XDSStack direction="row" gap={2} wrap="wrap">
-              <XDSButton
-                label="Close"
-                variant="secondary"
-                onClick={() => setIsOpen(false)}
-              />
-              <XDSButton
-                label="Toast (stay open)"
-                onClick={() => {
-                  toast({body: 'Toast from inside the dialog!'});
-                }}
-              />
-              <XDSButton
-                label="Error toast"
-                variant="destructive"
-                onClick={() => {
-                  toast({body: 'Something went wrong.', type: 'error'});
-                }}
-              />
-            </XDSStack>
-          }>
-          <p>
-            Fire toasts while the dialog stays open. They should appear above
-            the dialog overlay.
-          </p>
+          title="Dialog with scoped toasts">
+          <XDSToastViewport>
+            <DialogToastContent onClose={() => setIsOpen(false)} />
+          </XDSToastViewport>
         </XDSDialog>
       </XDSStack>
     );
@@ -362,8 +338,40 @@ export const ToastOverDialog: StoryObj = {
     docs: {
       description: {
         story:
-          'Toasts from inside an open dialog. Uses `popover="manual"` on the viewport to render in the top layer above the dialog.',
+          'Dialog with its own `XDSToastViewport` — toasts render inside the dialog\'s top layer context and appear above the dialog overlay.',
       },
     },
   },
 };
+
+function DialogToastContent({onClose}: {onClose: () => void}) {
+  const toast = useXDSToast();
+  return (
+    <XDSStack gap={3}>
+      <p>
+        This dialog has its own toast viewport. Toasts fired here render
+        inside the dialog — above its overlay.
+      </p>
+      <XDSStack direction="row" gap={2} wrap="wrap">
+        <XDSButton
+          label="Close"
+          variant="secondary"
+          onClick={onClose}
+        />
+        <XDSButton
+          label="Show toast"
+          onClick={() => {
+            toast({body: 'Toast from inside the dialog!'});
+          }}
+        />
+        <XDSButton
+          label="Error toast"
+          variant="destructive"
+          onClick={() => {
+            toast({body: 'Something went wrong.', type: 'error'});
+          }}
+        />
+      </XDSStack>
+    </XDSStack>
+  );
+}

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -129,7 +129,7 @@ function WithActionDemo() {
             <XDSButton
               label="Undo"
               variant="ghost"
-              size="compact"
+              size="sm"
               onClick={() => console.log('Undo!')}
             />
           ),

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -3,8 +3,10 @@ import {useState, useRef} from 'react';
 import {useXDSToast} from '@xds/core/Toast';
 import {XDSLayerProvider} from '@xds/core/Layer';
 import {XDSButton} from '@xds/core/Button';
+import {XDSLink} from '@xds/core/Link';
 import {XDSCard} from '@xds/core/Card';
 import {XDSStack} from '@xds/core/Stack';
+import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
 import type {XDSToastPosition, XDSToastType} from '@xds/core/Toast';
 
 // =============================================================================
@@ -39,7 +41,7 @@ function DefaultDemo() {
   return (
     <XDSButton
       label="Show toast"
-      onClick={() => toast({title: 'This is an info toast'})}
+      onClick={() => toast({body: 'This is an info toast'})}
     />
   );
 }
@@ -54,7 +56,7 @@ export const Default: StoryObj = {
 
 function TypesDemo() {
   const toast = useXDSToast();
-  const types: XDSToastType[] = ['info', 'success', 'warning', 'error'];
+  const types: XDSToastType[] = ['info', 'error'];
   return (
     <XDSStack direction="row" gap={2}>
       {types.map(type => (
@@ -64,7 +66,6 @@ function TypesDemo() {
           variant={type === 'error' ? 'destructive' : 'secondary'}
           onClick={() =>
             toast({
-              title: `${type.charAt(0).toUpperCase() + type.slice(1)} toast`,
               body: `This is a ${type} notification.`,
               type,
             })
@@ -81,34 +82,10 @@ export const Types: StoryObj = {
     docs: {
       description: {
         story:
-          'Four toast types: info (default), success, warning, error. Error toasts persist until dismissed.',
+          'Two toast types: info (default) and error. Error toasts persist until dismissed.',
       },
     },
   },
-};
-
-// =============================================================================
-// With Body
-// =============================================================================
-
-function WithBodyDemo() {
-  const toast = useXDSToast();
-  return (
-    <XDSButton
-      label="Show toast with body"
-      onClick={() =>
-        toast({
-          title: 'Changes saved',
-          body: 'Your profile has been updated successfully. Changes may take a few minutes to propagate.',
-          type: 'success',
-        })
-      }
-    />
-  );
-}
-
-export const WithBody: StoryObj = {
-  render: () => <WithBodyDemo />,
 };
 
 // =============================================================================
@@ -118,24 +95,40 @@ export const WithBody: StoryObj = {
 function WithActionDemo() {
   const toast = useXDSToast();
   return (
-    <XDSButton
-      label="Delete item"
-      variant="destructive"
-      onClick={() =>
-        toast({
-          title: 'Item deleted',
-          type: 'info',
-          endContent: (
-            <XDSButton
-              label="Undo"
-              variant="ghost"
-              size="sm"
-              onClick={() => console.log('Undo!')}
-            />
-          ),
-        })
-      }
-    />
+    <XDSStack direction="row" gap={2}>
+      <XDSButton
+        label="With button"
+        onClick={() =>
+          toast({
+            body: 'Item deleted',
+            type: 'info',
+            isAutoHide: false,
+            endContent: (
+              <XDSButton
+                label="Undo"
+                variant="secondary"
+                size="sm"
+                onClick={() => console.log('Undo!')}
+              />
+            ),
+          })
+        }
+      />
+      <XDSButton
+        label="With link"
+        variant="secondary"
+        onClick={() =>
+          toast({
+            body: 'Your report is ready.',
+            type: 'info',
+            isAutoHide: false,
+            endContent: (
+              <XDSLink label="View report" href="#" hasUnderline>View report</XDSLink>
+            ),
+          })
+        }
+      />
+    </XDSStack>
   );
 }
 
@@ -163,7 +156,6 @@ function ErrorPersistsDemo() {
       variant="destructive"
       onClick={() =>
         toast({
-          title: 'Failed to save',
           body: 'Check your network connection and try again.',
           type: 'error',
         })
@@ -197,7 +189,7 @@ function ProgrammaticDismissDemo() {
         label="Show persistent toast"
         onClick={() => {
           dismissRef.current = toast({
-            title: 'Uploading...',
+            body: 'Uploading...',
             type: 'info',
             isAutoHide: false,
           });
@@ -239,8 +231,8 @@ function DeduplicationDemo() {
         label="Show offline toast (ignore)"
         onClick={() =>
           toast({
-            title: 'You are offline',
-            type: 'warning',
+            body: 'You are offline',
+            type: 'info',
             uniqueID: 'offline',
             collisionBehavior: 'ignore',
             isAutoHide: false,
@@ -252,7 +244,7 @@ function DeduplicationDemo() {
         variant="secondary"
         onClick={() =>
           toast({
-            title: `Uploading... ${Math.floor(Math.random() * 100)}%`,
+            body: `Uploading... ${Math.floor(Math.random() * 100)}%`,
             type: 'info',
             uniqueID: 'upload-progress',
             collisionBehavior: 'overwrite',
@@ -288,11 +280,10 @@ function StackingDemo() {
       label="Add toast"
       onClick={() => {
         countRef.current++;
-        const types: XDSToastType[] = ['info', 'success', 'warning', 'error'];
+        const types: XDSToastType[] = ['info', 'error'];
         const type = types[countRef.current % types.length];
         toast({
-          title: `Toast #${countRef.current}`,
-          body: `This is a ${type} toast.`,
+          body: `Toast #${countRef.current} — This is a ${type} toast.`,
           type,
         });
       }}
@@ -316,45 +307,49 @@ export const Stacking: StoryObj = {
 // Positions (with XDSLayerProvider)
 // =============================================================================
 
-function PositionDemoInner({position}: {position: XDSToastPosition}) {
+function PositionsDemoInner({
+  position,
+  onPositionChange,
+}: {
+  position: XDSToastPosition;
+  onPositionChange: (pos: XDSToastPosition) => void;
+}) {
   const toast = useXDSToast();
+
   return (
-    <XDSButton
-      label={position}
-      variant="secondary"
-      onClick={() =>
-        toast({
-          title: `Toast at ${position}`,
-          type: 'info',
-        })
-      }
-    />
+    <XDSStack gap={3}>
+      <XDSToggleButtonGroup
+        type="single"
+        value={position}
+        onChange={(value: string | null) => {
+          if (value != null) onPositionChange(value as XDSToastPosition);
+        }}
+        label="Toast position"
+      >
+        <XDSToggleButton value="topStart" label="Top Start" />
+        <XDSToggleButton value="topEnd" label="Top End" />
+        <XDSToggleButton value="bottomStart" label="Bottom Start" />
+        <XDSToggleButton value="bottomEnd" label="Bottom End" />
+      </XDSToggleButtonGroup>
+      <XDSButton
+        label="Toggle Toast"
+        onClick={() =>
+          toast({
+            body: `Toast at ${position}`,
+            type: 'info',
+          })
+        }
+      />
+    </XDSStack>
   );
 }
 
 function PositionsDemo() {
   const [position, setPosition] = useState<XDSToastPosition>('bottomEnd');
-  const positions: XDSToastPosition[] = [
-    'bottomEnd',
-    'bottomStart',
-    'topEnd',
-    'topStart',
-  ];
+
   return (
     <XDSLayerProvider toast={{position}}>
-      <XDSStack direction="row" gap={2}>
-        {positions.map(pos => (
-          <XDSButton
-            key={pos}
-            label={pos}
-            variant={pos === position ? 'primary' : 'secondary'}
-            onClick={() => setPosition(pos)}
-          />
-        ))}
-      </XDSStack>
-      <div style={{marginTop: 12}}>
-        <PositionDemoInner position={position} />
-      </div>
+      <PositionsDemoInner position={position} onPositionChange={setPosition} />
     </XDSLayerProvider>
   );
 }
@@ -388,9 +383,8 @@ function NoProviderDemo() {
           label="Show toast (no provider)"
           onClick={() =>
             toast({
-              title: 'Works without a provider!',
-              body: 'A fallback viewport was created on document.body.',
-              type: 'success',
+              body: 'Works without a provider! A fallback viewport was created on document.body.',
+              type: 'info',
             })
           }
         />

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -327,7 +327,7 @@ export const ToastOverDialog: StoryObj = {
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
           title="Dialog with scoped toasts">
-          <XDSToastViewport>
+          <XDSToastViewport isTopLayer={false}>
             <DialogToastContent onClose={() => setIsOpen(false)} />
           </XDSToastViewport>
         </XDSDialog>

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -6,8 +6,7 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSLink} from '@xds/core/Link';
 import {XDSCard} from '@xds/core/Card';
 import {XDSStack} from '@xds/core/Stack';
-import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
-import type {XDSToastPosition, XDSToastType} from '@xds/core/Toast';
+import type {XDSToastType} from '@xds/core/Toast';
 
 // =============================================================================
 // Helper — wraps children with a provider for stories that need config
@@ -298,69 +297,6 @@ export const Stacking: StoryObj = {
       description: {
         story:
           'Multiple toasts stack vertically. Click rapidly to see them stack. Default max is 5 visible.',
-      },
-    },
-  },
-};
-
-// =============================================================================
-// Positions (with XDSLayerProvider)
-// =============================================================================
-
-function PositionsDemoInner({
-  position,
-  onPositionChange,
-}: {
-  position: XDSToastPosition;
-  onPositionChange: (pos: XDSToastPosition) => void;
-}) {
-  const toast = useXDSToast();
-
-  return (
-    <XDSStack gap={3}>
-      <XDSToggleButtonGroup
-        type="single"
-        value={position}
-        onChange={(value: string | null) => {
-          if (value != null) onPositionChange(value as XDSToastPosition);
-        }}
-        label="Toast position"
-      >
-        <XDSToggleButton value="topStart" label="Top Start" />
-        <XDSToggleButton value="topEnd" label="Top End" />
-        <XDSToggleButton value="bottomStart" label="Bottom Start" />
-        <XDSToggleButton value="bottomEnd" label="Bottom End" />
-      </XDSToggleButtonGroup>
-      <XDSButton
-        label="Toggle Toast"
-        onClick={() =>
-          toast({
-            body: `Toast at ${position}`,
-            type: 'info',
-          })
-        }
-      />
-    </XDSStack>
-  );
-}
-
-function PositionsDemo() {
-  const [position, setPosition] = useState<XDSToastPosition>('bottomEnd');
-
-  return (
-    <XDSLayerProvider toast={{position}}>
-      <PositionsDemoInner position={position} onPositionChange={setPosition} />
-    </XDSLayerProvider>
-  );
-}
-
-export const Positions: StoryObj = {
-  render: () => <PositionsDemo />,
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Use `XDSLayerProvider` to configure toast position. Supports 4 corners with logical directions (RTL-safe).',
       },
     },
   },

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -1,20 +1,12 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {useState, useRef} from 'react';
 import {useXDSToast} from '@xds/core/Toast';
-import {XDSLayerProvider} from '@xds/core/Layer';
+import type {XDSToastType} from '@xds/core/Toast';
 import {XDSButton} from '@xds/core/Button';
 import {XDSLink} from '@xds/core/Link';
 import {XDSCard} from '@xds/core/Card';
 import {XDSStack} from '@xds/core/Stack';
-import type {XDSToastType} from '@xds/core/Toast';
-
-// =============================================================================
-// Helper — wraps children with a provider for stories that need config
-// =============================================================================
-
-function ToastDemo({children}: {children: React.ReactNode}) {
-  return <>{children}</>;
-}
+import {XDSDialog} from '@xds/core/Dialog';
 
 const meta: Meta = {
   title: 'Core/XDSToast',
@@ -35,48 +27,44 @@ export default meta;
 // Default
 // =============================================================================
 
-function DefaultDemo() {
-  const toast = useXDSToast();
-  return (
-    <XDSButton
-      label="Show toast"
-      onClick={() => toast({body: 'This is an info toast'})}
-    />
-  );
-}
-
 export const Default: StoryObj = {
-  render: () => <DefaultDemo />,
+  render: function DefaultStory() {
+    const toast = useXDSToast();
+    return (
+      <XDSButton
+        label="Show toast"
+        onClick={() => toast({body: 'This is an info toast'})}
+      />
+    );
+  },
 };
 
 // =============================================================================
 // Types
 // =============================================================================
 
-function TypesDemo() {
-  const toast = useXDSToast();
-  const types: XDSToastType[] = ['info', 'error'];
-  return (
-    <XDSStack direction="row" gap={2}>
-      {types.map(type => (
-        <XDSButton
-          key={type}
-          label={type}
-          variant={type === 'error' ? 'destructive' : 'secondary'}
-          onClick={() =>
-            toast({
-              body: `This is a ${type} notification.`,
-              type,
-            })
-          }
-        />
-      ))}
-    </XDSStack>
-  );
-}
-
 export const Types: StoryObj = {
-  render: () => <TypesDemo />,
+  render: function TypesStory() {
+    const toast = useXDSToast();
+    const types: XDSToastType[] = ['info', 'error'];
+    return (
+      <XDSStack direction="row" gap={2}>
+        {types.map(type => (
+          <XDSButton
+            key={type}
+            label={type}
+            variant={type === 'error' ? 'destructive' : 'secondary'}
+            onClick={() =>
+              toast({
+                body: `This is a ${type} notification.`,
+                type,
+              })
+            }
+          />
+        ))}
+      </XDSStack>
+    );
+  },
   parameters: {
     docs: {
       description: {
@@ -91,53 +79,51 @@ export const Types: StoryObj = {
 // With Action (endContent)
 // =============================================================================
 
-function WithActionDemo() {
-  const toast = useXDSToast();
-  return (
-    <XDSStack direction="row" gap={2}>
-      <XDSButton
-        label="With button"
-        onClick={() =>
-          toast({
-            body: 'Item deleted',
-            type: 'info',
-            isAutoHide: false,
-            endContent: (
-              <XDSButton
-                label="Undo"
-                variant="secondary"
-                size="sm"
-                onClick={() => console.log('Undo!')}
-              />
-            ),
-          })
-        }
-      />
-      <XDSButton
-        label="With link"
-        variant="secondary"
-        onClick={() =>
-          toast({
-            body: 'Your report is ready.',
-            type: 'info',
-            isAutoHide: false,
-            endContent: (
-              <XDSLink label="View report" href="#" hasUnderline>View report</XDSLink>
-            ),
-          })
-        }
-      />
-    </XDSStack>
-  );
-}
-
 export const WithAction: StoryObj = {
-  render: () => <WithActionDemo />,
+  render: function WithActionStory() {
+    const toast = useXDSToast();
+    return (
+      <XDSStack direction="row" gap={2}>
+        <XDSButton
+          label="With button"
+          onClick={() =>
+            toast({
+              body: 'Item deleted',
+              isAutoHide: false,
+              endContent: (
+                <XDSButton
+                  label="Undo"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => console.log('Undo!')}
+                />
+              ),
+            })
+          }
+        />
+        <XDSButton
+          label="With link"
+          variant="secondary"
+          onClick={() =>
+            toast({
+              body: 'Your report is ready.',
+              isAutoHide: false,
+              endContent: (
+                <XDSLink href="#" hasUnderline>
+                  View report
+                </XDSLink>
+              ),
+            })
+          }
+        />
+      </XDSStack>
+    );
+  },
   parameters: {
     docs: {
       description: {
         story:
-          'Use `endContent` for action buttons. Named positionally (not `action`) because the slot can hold any content — buttons, spinners, etc.',
+          'Use `endContent` for trailing actions — buttons, links, or any content.',
       },
     },
   },
@@ -147,24 +133,22 @@ export const WithAction: StoryObj = {
 // Error Persists
 // =============================================================================
 
-function ErrorPersistsDemo() {
-  const toast = useXDSToast();
-  return (
-    <XDSButton
-      label="Trigger error"
-      variant="destructive"
-      onClick={() =>
-        toast({
-          body: 'Check your network connection and try again.',
-          type: 'error',
-        })
-      }
-    />
-  );
-}
-
 export const ErrorPersists: StoryObj = {
-  render: () => <ErrorPersistsDemo />,
+  render: function ErrorPersistsStory() {
+    const toast = useXDSToast();
+    return (
+      <XDSButton
+        label="Trigger error"
+        variant="destructive"
+        onClick={() =>
+          toast({
+            body: 'Check your network connection and try again.',
+            type: 'error',
+          })
+        }
+      />
+    );
+  },
   parameters: {
     docs: {
       description: {
@@ -179,40 +163,37 @@ export const ErrorPersists: StoryObj = {
 // Programmatic Dismiss
 // =============================================================================
 
-function ProgrammaticDismissDemo() {
-  const toast = useXDSToast();
-  const dismissRef = useRef<(() => void) | null>(null);
-  return (
-    <XDSStack direction="row" gap={2}>
-      <XDSButton
-        label="Show persistent toast"
-        onClick={() => {
-          dismissRef.current = toast({
-            body: 'Uploading...',
-            type: 'info',
-            isAutoHide: false,
-          });
-        }}
-      />
-      <XDSButton
-        label="Dismiss"
-        variant="secondary"
-        onClick={() => {
-          dismissRef.current?.();
-          dismissRef.current = null;
-        }}
-      />
-    </XDSStack>
-  );
-}
-
 export const ProgrammaticDismiss: StoryObj = {
-  render: () => <ProgrammaticDismissDemo />,
+  render: function ProgrammaticDismissStory() {
+    const toast = useXDSToast();
+    const dismissRef = useRef<(() => void) | null>(null);
+    return (
+      <XDSStack direction="row" gap={2}>
+        <XDSButton
+          label="Show persistent toast"
+          onClick={() => {
+            dismissRef.current = toast({
+              body: 'Uploading...',
+              isAutoHide: false,
+            });
+          }}
+        />
+        <XDSButton
+          label="Dismiss"
+          variant="secondary"
+          onClick={() => {
+            dismissRef.current?.();
+            dismissRef.current = null;
+          }}
+        />
+      </XDSStack>
+    );
+  },
   parameters: {
     docs: {
       description: {
         story:
-          '`useXDSToast()` returns a dismiss function for each toast. Call it to remove the toast programmatically.',
+          '`useXDSToast()` returns a dismiss function. Call it to remove the toast programmatically.',
       },
     },
   },
@@ -222,46 +203,42 @@ export const ProgrammaticDismiss: StoryObj = {
 // Deduplication
 // =============================================================================
 
-function DeduplicationDemo() {
-  const toast = useXDSToast();
-  return (
-    <XDSStack direction="row" gap={2}>
-      <XDSButton
-        label="Show offline toast (ignore)"
-        onClick={() =>
-          toast({
-            body: 'You are offline',
-            type: 'info',
-            uniqueID: 'offline',
-            collisionBehavior: 'ignore',
-            isAutoHide: false,
-          })
-        }
-      />
-      <XDSButton
-        label="Show progress toast (overwrite)"
-        variant="secondary"
-        onClick={() =>
-          toast({
-            body: `Uploading... ${Math.floor(Math.random() * 100)}%`,
-            type: 'info',
-            uniqueID: 'upload-progress',
-            collisionBehavior: 'overwrite',
-            isAutoHide: false,
-          })
-        }
-      />
-    </XDSStack>
-  );
-}
-
 export const Deduplication: StoryObj = {
-  render: () => <DeduplicationDemo />,
+  render: function DeduplicationStory() {
+    const toast = useXDSToast();
+    return (
+      <XDSStack direction="row" gap={2}>
+        <XDSButton
+          label="Offline (ignore)"
+          onClick={() =>
+            toast({
+              body: 'You are offline',
+              uniqueID: 'offline',
+              collisionBehavior: 'ignore',
+              isAutoHide: false,
+            })
+          }
+        />
+        <XDSButton
+          label="Progress (overwrite)"
+          variant="secondary"
+          onClick={() =>
+            toast({
+              body: `Uploading... ${Math.floor(Math.random() * 100)}%`,
+              uniqueID: 'upload-progress',
+              collisionBehavior: 'overwrite',
+              isAutoHide: false,
+            })
+          }
+        />
+      </XDSStack>
+    );
+  },
   parameters: {
     docs: {
       description: {
         story:
-          '`uniqueID` prevents duplicate toasts. `ignore` keeps the existing toast; `overwrite` replaces it.',
+          '`uniqueID` prevents duplicate toasts. `ignore` keeps the existing; `overwrite` replaces it.',
       },
     },
   },
@@ -271,32 +248,30 @@ export const Deduplication: StoryObj = {
 // Stacking
 // =============================================================================
 
-function StackingDemo() {
-  const toast = useXDSToast();
-  const countRef = useRef(0);
-  return (
-    <XDSButton
-      label="Add toast"
-      onClick={() => {
-        countRef.current++;
-        const types: XDSToastType[] = ['info', 'error'];
-        const type = types[countRef.current % types.length];
-        toast({
-          body: `Toast #${countRef.current} — This is a ${type} toast.`,
-          type,
-        });
-      }}
-    />
-  );
-}
-
 export const Stacking: StoryObj = {
-  render: () => <StackingDemo />,
+  render: function StackingStory() {
+    const toast = useXDSToast();
+    const countRef = useRef(0);
+    return (
+      <XDSButton
+        label="Add toast"
+        onClick={() => {
+          countRef.current++;
+          const types: XDSToastType[] = ['info', 'error'];
+          const type = types[countRef.current % types.length];
+          toast({
+            body: `Toast #${countRef.current} — ${type} notification.`,
+            type,
+          });
+        }}
+      />
+    );
+  },
   parameters: {
     docs: {
       description: {
         story:
-          'Multiple toasts stack vertically. Click rapidly to see them stack. Default max is 5 visible.',
+          'Multiple toasts stack vertically. Default max visible is 5.',
       },
     },
   },
@@ -306,36 +281,33 @@ export const Stacking: StoryObj = {
 // No Provider (fallback)
 // =============================================================================
 
-function NoProviderDemo() {
-  const toast = useXDSToast();
-  return (
-    <XDSCard padding={4}>
-      <XDSStack gap={2}>
-        <p style={{margin: 0, fontSize: 14}}>
-          This demo has no XDSLayerProvider. The hook creates a fallback
-          viewport automatically.
-        </p>
-        <XDSButton
-          label="Show toast (no provider)"
-          onClick={() =>
-            toast({
-              body: 'Works without a provider! A fallback viewport was created on document.body.',
-              type: 'info',
-            })
-          }
-        />
-      </XDSStack>
-    </XDSCard>
-  );
-}
-
 export const NoProvider: StoryObj = {
-  render: () => <NoProviderDemo />,
+  render: function NoProviderStory() {
+    const toast = useXDSToast();
+    return (
+      <XDSCard padding={4}>
+        <XDSStack gap={2}>
+          <p style={{margin: 0, fontSize: 14}}>
+            No XDSLayerProvider — the hook creates a fallback viewport on
+            document.body automatically.
+          </p>
+          <XDSButton
+            label="Show toast"
+            onClick={() =>
+              toast({
+                body: 'Works without a provider!',
+              })
+            }
+          />
+        </XDSStack>
+      </XDSCard>
+    );
+  },
   parameters: {
     docs: {
       description: {
         story:
-          '`useXDSToast()` works without `XDSLayerProvider`. On first call, it lazily mounts a fallback viewport with default config.',
+          '`useXDSToast()` works without a provider. It lazily mounts a fallback viewport on first call.',
       },
     },
   },
@@ -345,47 +317,52 @@ export const NoProvider: StoryObj = {
 // Toast over Dialog
 // =============================================================================
 
-import {XDSDialog} from '@xds/core/Dialog';
-
-function ToastOverDialogDemo() {
-  const toast = useXDSToast();
-  const [isOpen, setIsOpen] = useState(false);
-  return (
-    <XDSStack gap={2}>
-      <XDSButton label="Open dialog" onClick={() => setIsOpen(true)} />
-      <XDSDialog
-        isOpen={isOpen}
-        onClose={() => setIsOpen(false)}
-        title="Save changes?"
-        footer={
-          <XDSStack direction="row" gap={2}>
-            <XDSButton
-              label="Cancel"
-              variant="secondary"
-              onClick={() => setIsOpen(false)}
-            />
-            <XDSButton
-              label="Save"
-              onClick={() => {
-                toast({body: 'Changes saved successfully.'});
-                setIsOpen(false);
-              }}
-            />
-          </XDSStack>
-        }>
-        <p>Your unsaved changes will be lost. Do you want to save them?</p>
-      </XDSDialog>
-    </XDSStack>
-  );
-}
-
 export const ToastOverDialog: StoryObj = {
-  render: () => <ToastOverDialogDemo />,
+  render: function ToastOverDialogStory() {
+    const toast = useXDSToast();
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <XDSStack gap={2}>
+        <XDSButton label="Open dialog" onClick={() => setIsOpen(true)} />
+        <XDSDialog
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          title="Confirm action"
+          footer={
+            <XDSStack direction="row" gap={2} wrap="wrap">
+              <XDSButton
+                label="Close"
+                variant="secondary"
+                onClick={() => setIsOpen(false)}
+              />
+              <XDSButton
+                label="Toast (stay open)"
+                onClick={() => {
+                  toast({body: 'Toast from inside the dialog!'});
+                }}
+              />
+              <XDSButton
+                label="Error toast"
+                variant="destructive"
+                onClick={() => {
+                  toast({body: 'Something went wrong.', type: 'error'});
+                }}
+              />
+            </XDSStack>
+          }>
+          <p>
+            Fire toasts while the dialog stays open. They should appear above
+            the dialog overlay.
+          </p>
+        </XDSDialog>
+      </XDSStack>
+    );
+  },
   parameters: {
     docs: {
       description: {
         story:
-          'Toasts render in the top layer via popover="manual", so they appear above dialogs. Click Save to dismiss the dialog and show a toast — it should be visible on top.',
+          'Toasts from inside an open dialog. Uses `popover="manual"` on the viewport to render in the top layer above the dialog.',
       },
     },
   },

--- a/apps/storybook/stories/Toast.stories.tsx
+++ b/apps/storybook/stories/Toast.stories.tsx
@@ -1,0 +1,412 @@
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState, useRef} from 'react';
+import {useXDSToast} from '@xds/core/Toast';
+import {XDSLayerProvider} from '@xds/core/Layer';
+import {XDSButton} from '@xds/core/Button';
+import {XDSCard} from '@xds/core/Card';
+import {XDSStack} from '@xds/core/Stack';
+import type {XDSToastPosition, XDSToastType} from '@xds/core/Toast';
+
+// =============================================================================
+// Helper — wraps children with a provider for stories that need config
+// =============================================================================
+
+function ToastDemo({children}: {children: React.ReactNode}) {
+  return <>{children}</>;
+}
+
+const meta: Meta = {
+  title: 'Core/XDSToast',
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Imperative toast notification system. Use `useXDSToast()` to show transient feedback messages. Works with or without `XDSLayerProvider`.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+// =============================================================================
+// Default
+// =============================================================================
+
+function DefaultDemo() {
+  const toast = useXDSToast();
+  return (
+    <XDSButton
+      label="Show toast"
+      onClick={() => toast({title: 'This is an info toast'})}
+    />
+  );
+}
+
+export const Default: StoryObj = {
+  render: () => <DefaultDemo />,
+};
+
+// =============================================================================
+// Types
+// =============================================================================
+
+function TypesDemo() {
+  const toast = useXDSToast();
+  const types: XDSToastType[] = ['info', 'success', 'warning', 'error'];
+  return (
+    <XDSStack direction="row" gap={2}>
+      {types.map(type => (
+        <XDSButton
+          key={type}
+          label={type}
+          variant={type === 'error' ? 'destructive' : 'secondary'}
+          onClick={() =>
+            toast({
+              title: `${type.charAt(0).toUpperCase() + type.slice(1)} toast`,
+              body: `This is a ${type} notification.`,
+              type,
+            })
+          }
+        />
+      ))}
+    </XDSStack>
+  );
+}
+
+export const Types: StoryObj = {
+  render: () => <TypesDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Four toast types: info (default), success, warning, error. Error toasts persist until dismissed.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// With Body
+// =============================================================================
+
+function WithBodyDemo() {
+  const toast = useXDSToast();
+  return (
+    <XDSButton
+      label="Show toast with body"
+      onClick={() =>
+        toast({
+          title: 'Changes saved',
+          body: 'Your profile has been updated successfully. Changes may take a few minutes to propagate.',
+          type: 'success',
+        })
+      }
+    />
+  );
+}
+
+export const WithBody: StoryObj = {
+  render: () => <WithBodyDemo />,
+};
+
+// =============================================================================
+// With Action (endContent)
+// =============================================================================
+
+function WithActionDemo() {
+  const toast = useXDSToast();
+  return (
+    <XDSButton
+      label="Delete item"
+      variant="destructive"
+      onClick={() =>
+        toast({
+          title: 'Item deleted',
+          type: 'info',
+          endContent: (
+            <XDSButton
+              label="Undo"
+              variant="ghost"
+              size="compact"
+              onClick={() => console.log('Undo!')}
+            />
+          ),
+        })
+      }
+    />
+  );
+}
+
+export const WithAction: StoryObj = {
+  render: () => <WithActionDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use `endContent` for action buttons. Named positionally (not `action`) because the slot can hold any content — buttons, spinners, etc.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// Error Persists
+// =============================================================================
+
+function ErrorPersistsDemo() {
+  const toast = useXDSToast();
+  return (
+    <XDSButton
+      label="Trigger error"
+      variant="destructive"
+      onClick={() =>
+        toast({
+          title: 'Failed to save',
+          body: 'Check your network connection and try again.',
+          type: 'error',
+        })
+      }
+    />
+  );
+}
+
+export const ErrorPersists: StoryObj = {
+  render: () => <ErrorPersistsDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Error toasts default to `isAutoHide: false` — they persist until the user dismisses them.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// Programmatic Dismiss
+// =============================================================================
+
+function ProgrammaticDismissDemo() {
+  const toast = useXDSToast();
+  const dismissRef = useRef<(() => void) | null>(null);
+  return (
+    <XDSStack direction="row" gap={2}>
+      <XDSButton
+        label="Show persistent toast"
+        onClick={() => {
+          dismissRef.current = toast({
+            title: 'Uploading...',
+            type: 'info',
+            isAutoHide: false,
+          });
+        }}
+      />
+      <XDSButton
+        label="Dismiss"
+        variant="secondary"
+        onClick={() => {
+          dismissRef.current?.();
+          dismissRef.current = null;
+        }}
+      />
+    </XDSStack>
+  );
+}
+
+export const ProgrammaticDismiss: StoryObj = {
+  render: () => <ProgrammaticDismissDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`useXDSToast()` returns a dismiss function for each toast. Call it to remove the toast programmatically.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// Deduplication
+// =============================================================================
+
+function DeduplicationDemo() {
+  const toast = useXDSToast();
+  return (
+    <XDSStack direction="row" gap={2}>
+      <XDSButton
+        label="Show offline toast (ignore)"
+        onClick={() =>
+          toast({
+            title: 'You are offline',
+            type: 'warning',
+            uniqueID: 'offline',
+            collisionBehavior: 'ignore',
+            isAutoHide: false,
+          })
+        }
+      />
+      <XDSButton
+        label="Show progress toast (overwrite)"
+        variant="secondary"
+        onClick={() =>
+          toast({
+            title: `Uploading... ${Math.floor(Math.random() * 100)}%`,
+            type: 'info',
+            uniqueID: 'upload-progress',
+            collisionBehavior: 'overwrite',
+            isAutoHide: false,
+          })
+        }
+      />
+    </XDSStack>
+  );
+}
+
+export const Deduplication: StoryObj = {
+  render: () => <DeduplicationDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`uniqueID` prevents duplicate toasts. `ignore` keeps the existing toast; `overwrite` replaces it.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// Stacking
+// =============================================================================
+
+function StackingDemo() {
+  const toast = useXDSToast();
+  const countRef = useRef(0);
+  return (
+    <XDSButton
+      label="Add toast"
+      onClick={() => {
+        countRef.current++;
+        const types: XDSToastType[] = ['info', 'success', 'warning', 'error'];
+        const type = types[countRef.current % types.length];
+        toast({
+          title: `Toast #${countRef.current}`,
+          body: `This is a ${type} toast.`,
+          type,
+        });
+      }}
+    />
+  );
+}
+
+export const Stacking: StoryObj = {
+  render: () => <StackingDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Multiple toasts stack vertically. Click rapidly to see them stack. Default max is 5 visible.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// Positions (with XDSLayerProvider)
+// =============================================================================
+
+function PositionDemoInner({position}: {position: XDSToastPosition}) {
+  const toast = useXDSToast();
+  return (
+    <XDSButton
+      label={position}
+      variant="secondary"
+      onClick={() =>
+        toast({
+          title: `Toast at ${position}`,
+          type: 'info',
+        })
+      }
+    />
+  );
+}
+
+function PositionsDemo() {
+  const [position, setPosition] = useState<XDSToastPosition>('bottomEnd');
+  const positions: XDSToastPosition[] = [
+    'bottomEnd',
+    'bottomStart',
+    'topEnd',
+    'topStart',
+  ];
+  return (
+    <XDSLayerProvider toast={{position}}>
+      <XDSStack direction="row" gap={2}>
+        {positions.map(pos => (
+          <XDSButton
+            key={pos}
+            label={pos}
+            variant={pos === position ? 'primary' : 'secondary'}
+            onClick={() => setPosition(pos)}
+          />
+        ))}
+      </XDSStack>
+      <div style={{marginTop: 12}}>
+        <PositionDemoInner position={position} />
+      </div>
+    </XDSLayerProvider>
+  );
+}
+
+export const Positions: StoryObj = {
+  render: () => <PositionsDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use `XDSLayerProvider` to configure toast position. Supports 4 corners with logical directions (RTL-safe).',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// No Provider (fallback)
+// =============================================================================
+
+function NoProviderDemo() {
+  const toast = useXDSToast();
+  return (
+    <XDSCard padding={4}>
+      <XDSStack gap={2}>
+        <p style={{margin: 0, fontSize: 14}}>
+          This demo has no XDSLayerProvider. The hook creates a fallback
+          viewport automatically.
+        </p>
+        <XDSButton
+          label="Show toast (no provider)"
+          onClick={() =>
+            toast({
+              title: 'Works without a provider!',
+              body: 'A fallback viewport was created on document.body.',
+              type: 'success',
+            })
+          }
+        />
+      </XDSStack>
+    </XDSCard>
+  );
+}
+
+export const NoProvider: StoryObj = {
+  render: () => <NoProviderDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`useXDSToast()` works without `XDSLayerProvider`. On first call, it lazily mounts a fallback viewport with default config.',
+      },
+    },
+  },
+};

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -400,6 +400,12 @@
       "import": "./dist/Timestamp/index.mjs",
       "require": "./dist/Timestamp/index.js"
     },
+    "./Toast": {
+      "source": "./src/Toast/index.ts",
+      "types": "./dist/Toast/index.d.ts",
+      "import": "./dist/Toast/index.mjs",
+      "require": "./dist/Toast/index.js"
+    },
     "./ToggleButton": {
       "source": "./src/ToggleButton/index.ts",
       "types": "./dist/ToggleButton/index.d.ts",

--- a/packages/core/src/Layer/XDSLayerContext.ts
+++ b/packages/core/src/Layer/XDSLayerContext.ts
@@ -1,0 +1,54 @@
+'use client';
+
+/**
+ * @file XDSLayerContext.ts
+ * @input React context
+ * @output Exports XDSLayerContext and related types
+ * @position Context definition for XDSLayerProvider
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/Layer/index.ts
+ * - /packages/core/src/Layer/XDSLayerProvider.tsx
+ */
+
+import {createContext, useContext} from 'react';
+
+/**
+ * Toast configuration passed through the layer provider.
+ */
+export interface LayerToastConfig {
+  /** Position of the toast stack. @default 'bottomEnd' */
+  position?: 'topEnd' | 'topStart' | 'bottomEnd' | 'bottomStart';
+  /** Maximum visible toasts. @default 5 */
+  maxVisible?: number;
+  /** Inset from viewport edges. */
+  inset?: {
+    top?: number;
+    bottom?: number;
+    start?: number;
+    end?: number;
+  };
+}
+
+/**
+ * Context value provided by XDSLayerProvider.
+ */
+export interface XDSLayerContextValue {
+  /** Toast configuration from the provider. */
+  toastConfig: LayerToastConfig;
+  /** Whether this is a real provider (not fallback). */
+  isProvider: true;
+}
+
+/**
+ * React context for the layer provider.
+ * Default value is null — hooks detect this and use the fallback.
+ */
+export const XDSLayerContext = createContext<XDSLayerContextValue | null>(null);
+
+/**
+ * Hook to access the layer context. Returns null if no provider exists.
+ */
+export function useXDSLayerContext(): XDSLayerContextValue | null {
+  return useContext(XDSLayerContext);
+}

--- a/packages/core/src/Layer/XDSLayerProvider.tsx
+++ b/packages/core/src/Layer/XDSLayerProvider.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import {useMemo, type ReactNode} from 'react';
+import {
+  XDSLayerContext,
+  useXDSLayerContext,
+  type XDSLayerContextValue,
+  type LayerToastConfig,
+} from './XDSLayerContext';
+import {XDSToastViewport} from '../Toast/XDSToastViewport';
+
+export interface XDSLayerProviderProps {
+  children: ReactNode;
+  /** Toast configuration. Omit to use defaults. */
+  toast?: LayerToastConfig;
+}
+
+/**
+ * App-level provider for layer systems (toast, sheet, imperative modals).
+ *
+ * Optional — hooks fall back to a lazy self-mounting viewport when no
+ * provider exists. Nested providers are no-ops.
+ *
+ * @example
+ * ```
+ * <XDSLayerProvider toast={{ position: 'topEnd', maxVisible: 3 }}>
+ *   <App />
+ * </XDSLayerProvider>
+ * ```
+ */
+export function XDSLayerProvider({
+  children,
+  toast: toastConfig = {},
+}: XDSLayerProviderProps) {
+  const existingContext = useXDSLayerContext();
+
+  const contextValue = useMemo<XDSLayerContextValue>(
+    () => ({toastConfig, isProvider: true}),
+    [toastConfig],
+  );
+
+  // Nested provider — pass through
+  if (existingContext) {
+    return <>{children}</>;
+  }
+
+  return (
+    <XDSLayerContext.Provider value={contextValue}>
+      <XDSToastViewport
+        position={toastConfig.position}
+        maxVisible={toastConfig.maxVisible}
+        inset={toastConfig.inset}>
+        {children}
+      </XDSToastViewport>
+    </XDSLayerContext.Provider>
+  );
+}
+
+XDSLayerProvider.displayName = 'XDSLayerProvider';

--- a/packages/core/src/Layer/index.ts
+++ b/packages/core/src/Layer/index.ts
@@ -27,6 +27,12 @@ export type {
   FixedLayerReturn,
 } from './useXDSLayer';
 
+// Layer provider
+export {XDSLayerProvider} from './XDSLayerProvider';
+export type {XDSLayerProviderProps} from './XDSLayerProvider';
+export {XDSLayerContext, useXDSLayerContext} from './XDSLayerContext';
+export type {XDSLayerContextValue, LayerToastConfig} from './XDSLayerContext';
+
 // Shared entry animation styles for layer-based components
 export {layerAnimations} from './layerAnimations.stylex';
 

--- a/packages/core/src/Toast/Toast.doc.mjs
+++ b/packages/core/src/Toast/Toast.doc.mjs
@@ -68,15 +68,15 @@ export const docs = {
 
   examples: [
     {
-      title: 'Basic',
+      label: 'Basic',
       code: `const toast = useXDSToast();\ntoast({ body: "Changes saved" });`,
     },
     {
-      title: 'Error',
+      label: 'Error',
       code: `toast({ body: "Failed to save", type: "error" });`,
     },
     {
-      title: 'With action',
+      label: 'With action',
       code: `toast({\n  body: "Item deleted",\n  isAutoHide: false,\n  endContent: <XDSButton label="Undo" variant="secondary" size="sm" onClick={undo} />,\n});`,
     },
   ],

--- a/packages/core/src/Toast/Toast.doc.mjs
+++ b/packages/core/src/Toast/Toast.doc.mjs
@@ -1,0 +1,83 @@
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'Toast',
+  description:
+    'Toast notification system with auto-dismiss, stacking, deduplication, and smooth animations. Uses XDSMediaTheme for inverted surface theming.',
+
+  keywords: ["toast","notification","snackbar","alert","message","feedback","status"],
+  features: [
+    "Types: 'info' (default), 'error'",
+    'Auto-dismiss: info toasts dismiss after 5s, error toasts persist',
+    'Pause on hover/focus: timer pauses during interaction',
+    'Stacking: multiple toasts stack with smooth enter/exit animations',
+    'Deduplication: uniqueID with ignore or overwrite collision behavior',
+    'Programmatic dismiss: show() returns a dismiss function',
+    'End content slot: trailing actions (buttons, links)',
+    'Fallback viewport: works without a provider via document.body fallback',
+    'Inverted surface: uses XDSMediaTheme for correct colors on dark/light backgrounds',
+    'Accessible: role=status/alert, aria-live=polite/assertive',
+  ],
+
+  props: [
+    {
+      name: 'body',
+      type: 'ReactNode',
+      description: 'Primary message content.',
+      required: true,
+    },
+    {
+      name: 'type',
+      type: "'info' | 'error'",
+      description: 'Toast type controlling background color. Error toasts persist until dismissed.',
+      default: "'info'",
+    },
+    {
+      name: 'isAutoHide',
+      type: 'boolean',
+      description: 'Whether the toast auto-dismisses. Defaults to true for info, false for error.',
+    },
+    {
+      name: 'autoHideDuration',
+      type: 'number',
+      description: 'Duration in ms before auto-dismiss.',
+      default: '5000',
+    },
+    {
+      name: 'endContent',
+      type: 'ReactNode',
+      description: 'Content rendered at the trailing end (e.g. Undo button, link).',
+    },
+    {
+      name: 'uniqueID',
+      type: 'string',
+      description: 'Unique identifier for deduplication.',
+    },
+    {
+      name: 'collisionBehavior',
+      type: "'overwrite' | 'ignore'",
+      description: 'Behavior when a toast with matching uniqueID already exists.',
+      default: "'overwrite'",
+    },
+    {
+      name: 'onHide',
+      type: '(reason: "auto" | "manual") => void',
+      description: 'Callback fired when the toast is removed.',
+    },
+  ],
+
+  examples: [
+    {
+      title: 'Basic',
+      code: `const toast = useXDSToast();\ntoast({ body: "Changes saved" });`,
+    },
+    {
+      title: 'Error',
+      code: `toast({ body: "Failed to save", type: "error" });`,
+    },
+    {
+      title: 'With action',
+      code: `toast({\n  body: "Item deleted",\n  isAutoHide: false,\n  endContent: <XDSButton label="Undo" variant="secondary" size="sm" onClick={undo} />,\n});`,
+    },
+  ],
+};

--- a/packages/core/src/Toast/XDSToast.tsx
+++ b/packages/core/src/Toast/XDSToast.tsx
@@ -4,7 +4,7 @@ import {useCallback, useEffect, useRef} from 'react';
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '../Button';
-import {XDSIcon, type XDSIconName} from '../Icon';
+import {XDSIcon} from '../Icon';
 import {
   colorVars,
   spacingVars,
@@ -12,30 +12,26 @@ import {
   durationVars,
   easeVars,
   shadowVars,
-  fontWeightVars,
+  typographyVars,
+  typeScaleDefaults,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import {useXDSTheme} from '../theme';
+import {XDSMediaTheme} from '../theme/XDSMediaTheme';
 import type {XDSToastType, XDSToastDismissReason} from './types';
-
-const TYPE_ICONS: Record<XDSToastType, XDSIconName> = {
-  info: 'info',
-  success: 'checkCircle',
-  warning: 'warning',
-  error: 'xCircle',
-};
 
 const styles = stylex.create({
   root: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    gap: spacingVars['--spacing-3'],
-    paddingBlock: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-4'],
     paddingInline: spacingVars['--spacing-4'],
-    borderRadius: radiusVars['--radius-element'],
+    borderRadius: radiusVars['--radius-container'],
     width: 400,
     maxWidth: 'calc(100vw - 32px)',
     boxShadow: shadowVars['--shadow-med'],
     opacity: 1,
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleDefaults['--text-body-size'],
+    lineHeight: typeScaleDefaults['--text-body-leading'],
     transform: 'translateY(0)',
     transitionProperty: 'opacity, transform',
     transitionDuration: {
@@ -50,45 +46,41 @@ const styles = stylex.create({
   },
   variantDefault: {
     backgroundColor: colorVars['--color-surface-inverted'],
-    color: colorVars['--color-background-surface'],
+  },
+  inner: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: spacingVars['--spacing-3'],
+    width: '100%',
   },
   variantError: {
     backgroundColor: colorVars['--color-error-inverted'],
-    color: colorVars['--color-on-error'],
-  },
-  iconArea: {
-    flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    paddingBlockStart: spacingVars['--spacing-0-5'],
   },
   content: {
     flex: 1,
     minWidth: 0,
   },
-  title: {
-    fontWeight: fontWeightVars['--font-weight-semibold'],
+  exiting: {
+    opacity: 0,
+    transform: 'translateY(-8px)',
   },
-  body: {
-    marginBlockStart: spacingVars['--spacing-1'],
-    opacity: 0.9,
-  },
-  endArea: {
+  endContent: {
     flexShrink: 0,
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
+    marginBlock: `calc(${spacingVars['--spacing-1']} * -1)`,
+    marginInlineEnd: `calc(${spacingVars['--spacing-1']} * -1)`,
   },
 });
 
 export interface XDSToastProps {
   type: XDSToastType;
-  title: ReactNode;
-  body?: ReactNode;
-  icon?: ReactNode;
+  body: ReactNode;
   endContent?: ReactNode;
   isAutoHide: boolean;
   autoHideDuration: number;
+  isExiting?: boolean;
   onDismiss: (reason: XDSToastDismissReason) => void;
 }
 
@@ -96,14 +88,15 @@ export interface XDSToastProps {
  * Individual toast notification.
  *
  * Renders with inverted surface colors for the default variant,
- * and error-inverted for the error variant. Pauses auto-dismiss
+ * and error-inverted for the error variant. Uses XDSMediaTheme
+ * to set the correct token context for children. Pauses auto-dismiss
  * on hover and focus.
  *
  * @example
  * ```
  * <XDSToast
- *   type="success"
- *   title="Saved successfully"
+ *   type="info"
+ *   body="Saved successfully"
  *   isAutoHide={true}
  *   autoHideDuration={5000}
  *   onDismiss={(reason) => removeToast(id, reason)}
@@ -112,12 +105,11 @@ export interface XDSToastProps {
  */
 export function XDSToast({
   type,
-  title,
   body,
-  icon,
   endContent,
   isAutoHide,
   autoHideDuration,
+  isExiting = false,
   onDismiss,
 }: XDSToastProps) {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -164,7 +156,10 @@ export function XDSToast({
   }, [onDismiss]);
 
   const isError = type === 'error';
-  const iconName = TYPE_ICONS[type];
+  // Determine media mode: inverted surface is always dark in light mode,
+  // always light in dark mode. Error toast is always on a dark surface.
+  const {mode} = useXDSTheme();
+  const mediaMode = isError || mode === 'light' ? 'dark' : 'light';
 
   return (
     <div
@@ -180,27 +175,27 @@ export function XDSToast({
         stylex.props(
           styles.root,
           isError ? styles.variantError : styles.variantDefault,
+          isExiting && styles.exiting,
         ),
       )}>
-      <div {...stylex.props(styles.iconArea)}>
-        {icon ?? <XDSIcon icon={iconName} size="md" color="inherit" />}
-      </div>
+      <XDSMediaTheme mode={mediaMode}>
+        <div {...stylex.props(styles.inner)}>
+          <div {...stylex.props(styles.content)}>
+            {body}
+          </div>
 
-      <div {...stylex.props(styles.content)}>
-        <div {...stylex.props(styles.title)}>{title}</div>
-        {body != null && <div {...stylex.props(styles.body)}>{body}</div>}
-      </div>
-
-      <div {...stylex.props(styles.endArea)}>
-        {endContent}
-        <XDSButton
-          variant="ghost"
-          size="sm"
-          icon={<XDSIcon icon="close" size="sm" color="inherit" />}
-          label="Dismiss notification"
-          onClick={handleDismiss}
-        />
-      </div>
+          <div {...stylex.props(styles.endContent)}>
+            {endContent}
+            <XDSButton
+              variant="ghost"
+              size="sm"
+              icon={<XDSIcon icon="close" size="sm" color="inherit" />}
+              label="Dismiss notification"
+              onClick={handleDismiss}
+            />
+          </div>
+        </div>
+      </XDSMediaTheme>
     </div>
   );
 }

--- a/packages/core/src/Toast/XDSToast.tsx
+++ b/packages/core/src/Toast/XDSToast.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import {useCallback, useEffect, useRef} from 'react';
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSButton} from '../Button';
+import {XDSIcon} from '../Icon';
+import type {XDSIconName} from '../Icon';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  durationVars,
+  easeVars,
+  shadowVars,
+} from '../theme/tokens.stylex';
+import {xdsClassName} from '../utils';
+import type {XDSToastType, XDSToastDismissReason} from './types';
+
+const TYPE_ICONS: Record<XDSToastType, XDSIconName> = {
+  info: 'information-circle',
+  success: 'check-circle',
+  warning: 'exclamation-triangle',
+  error: 'x-circle',
+};
+
+const styles = stylex.create({
+  root: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-4'],
+    borderRadius: radiusVars['--radius-element'],
+    width: 400,
+    maxWidth: 'calc(100vw - 32px)',
+    boxShadow: shadowVars['--shadow-med'],
+    opacity: 1,
+    transform: 'translateY(0)',
+    transitionProperty: 'opacity, transform',
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0.01ms',
+    },
+    transitionTimingFunction: easeVars['--ease-standard'],
+    '@starting-style': {
+      opacity: 0,
+      transform: 'translateY(8px)',
+    },
+  },
+  variantDefault: {
+    backgroundColor: colorVars['--color-surface-inverted'],
+    color: colorVars['--color-background-surface'],
+  },
+  variantError: {
+    backgroundColor: colorVars['--color-error-inverted'],
+    color: colorVars['--color-on-error'],
+  },
+  iconArea: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    paddingBlockStart: spacingVars['--spacing-0-5'],
+  },
+  content: {
+    flex: 1,
+    minWidth: 0,
+  },
+  title: {
+    fontWeight: 600,
+  },
+  body: {
+    marginBlockStart: spacingVars['--spacing-1'],
+    opacity: 0.9,
+  },
+  endArea: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+  },
+});
+
+export interface XDSToastProps {
+  type: XDSToastType;
+  title: ReactNode;
+  body?: ReactNode;
+  icon?: ReactNode;
+  endContent?: ReactNode;
+  isAutoHide: boolean;
+  autoHideDuration: number;
+  onDismiss: (reason: XDSToastDismissReason) => void;
+}
+
+/**
+ * Individual toast notification.
+ *
+ * Renders with inverted surface colors for the default variant,
+ * and error-inverted for the error variant. Pauses auto-dismiss
+ * on hover and focus.
+ *
+ * @example
+ * ```
+ * <XDSToast
+ *   type="success"
+ *   title="Saved successfully"
+ *   isAutoHide={true}
+ *   autoHideDuration={5000}
+ *   onDismiss={(reason) => removeToast(id, reason)}
+ * />
+ * ```
+ */
+export function XDSToast({
+  type,
+  title,
+  body,
+  icon,
+  endContent,
+  isAutoHide,
+  autoHideDuration,
+  onDismiss,
+}: XDSToastProps) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isPausedRef = useRef(false);
+  const remainingRef = useRef(autoHideDuration);
+  const startTimeRef = useRef(Date.now());
+
+  const startTimer = useCallback(() => {
+    if (!isAutoHide) return;
+    if (timerRef.current) clearTimeout(timerRef.current);
+    startTimeRef.current = Date.now();
+    timerRef.current = setTimeout(() => {
+      onDismiss('auto');
+    }, remainingRef.current);
+  }, [isAutoHide, onDismiss]);
+
+  const pauseTimer = useCallback(() => {
+    if (!isAutoHide || isPausedRef.current) return;
+    isPausedRef.current = true;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    const elapsed = Date.now() - startTimeRef.current;
+    remainingRef.current = Math.max(remainingRef.current - elapsed, 1000);
+  }, [isAutoHide]);
+
+  const resumeTimer = useCallback(() => {
+    if (!isAutoHide || !isPausedRef.current) return;
+    isPausedRef.current = false;
+    startTimer();
+  }, [isAutoHide, startTimer]);
+
+  useEffect(() => {
+    remainingRef.current = autoHideDuration;
+    startTimer();
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, [autoHideDuration, startTimer]);
+
+  const handleDismiss = useCallback(() => {
+    onDismiss('manual');
+  }, [onDismiss]);
+
+  const isError = type === 'error';
+  const iconName = TYPE_ICONS[type];
+
+  return (
+    <div
+      role={isError ? 'alert' : 'status'}
+      aria-live={isError ? 'assertive' : 'polite'}
+      aria-atomic="true"
+      onMouseEnter={pauseTimer}
+      onMouseLeave={resumeTimer}
+      onFocusCapture={pauseTimer}
+      onBlurCapture={resumeTimer}
+      {...stylex.props(
+        styles.root,
+        isError ? styles.variantError : styles.variantDefault,
+      )}
+      className={xdsClassName('toast', {type}).className}>
+      <div {...stylex.props(styles.iconArea)}>
+        {icon ?? <XDSIcon name={iconName} size={20} color="inherit" />}
+      </div>
+
+      <div {...stylex.props(styles.content)}>
+        <div {...stylex.props(styles.title)}>{title}</div>
+        {body != null && <div {...stylex.props(styles.body)}>{body}</div>}
+      </div>
+
+      <div {...stylex.props(styles.endArea)}>
+        {endContent}
+        <XDSButton
+          variant="ghost"
+          size="compact"
+          icon={<XDSIcon name="x-mark" size={16} color="inherit" />}
+          label="Dismiss notification"
+          onClick={handleDismiss}
+        />
+      </div>
+    </div>
+  );
+}
+
+XDSToast.displayName = 'XDSToast';

--- a/packages/core/src/Toast/XDSToast.tsx
+++ b/packages/core/src/Toast/XDSToast.tsx
@@ -45,7 +45,7 @@ const styles = stylex.create({
     },
   },
   variantDefault: {
-    backgroundColor: colorVars['--color-surface-inverted'],
+    backgroundColor: colorVars['--color-background-inverted'],
   },
   inner: {
     display: 'flex',
@@ -54,7 +54,7 @@ const styles = stylex.create({
     width: '100%',
   },
   variantError: {
-    backgroundColor: colorVars['--color-error-inverted'],
+    backgroundColor: colorVars['--color-background-error-inverted'],
   },
   content: {
     flex: 1,

--- a/packages/core/src/Toast/XDSToast.tsx
+++ b/packages/core/src/Toast/XDSToast.tsx
@@ -14,7 +14,7 @@ import {
   shadowVars,
   fontWeightVars,
 } from '../theme/tokens.stylex';
-import {xdsClassName} from '../utils';
+import {xdsClassName, mergeProps} from '../utils';
 import type {XDSToastType, XDSToastDismissReason} from './types';
 
 const TYPE_ICONS: Record<XDSToastType, XDSIconName> = {
@@ -175,11 +175,13 @@ export function XDSToast({
       onMouseLeave={resumeTimer}
       onFocusCapture={pauseTimer}
       onBlurCapture={resumeTimer}
-      {...stylex.props(
-        styles.root,
-        isError ? styles.variantError : styles.variantDefault,
-      )}
-      className={xdsClassName('toast', {type})}>
+      {...mergeProps(
+        xdsClassName('toast', {type}),
+        stylex.props(
+          styles.root,
+          isError ? styles.variantError : styles.variantDefault,
+        ),
+      )}>
       <div {...stylex.props(styles.iconArea)}>
         {icon ?? <XDSIcon icon={iconName} size="md" color="inherit" />}
       </div>

--- a/packages/core/src/Toast/XDSToast.tsx
+++ b/packages/core/src/Toast/XDSToast.tsx
@@ -4,8 +4,7 @@ import {useCallback, useEffect, useRef} from 'react';
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {XDSButton} from '../Button';
-import {XDSIcon} from '../Icon';
-import type {XDSIconName} from '../Icon';
+import {XDSIcon, type XDSIconName} from '../Icon';
 import {
   colorVars,
   spacingVars,
@@ -13,15 +12,16 @@ import {
   durationVars,
   easeVars,
   shadowVars,
+  fontWeightVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName} from '../utils';
 import type {XDSToastType, XDSToastDismissReason} from './types';
 
 const TYPE_ICONS: Record<XDSToastType, XDSIconName> = {
-  info: 'information-circle',
-  success: 'check-circle',
-  warning: 'exclamation-triangle',
-  error: 'x-circle',
+  info: 'info',
+  success: 'checkCircle',
+  warning: 'warning',
+  error: 'xCircle',
 };
 
 const styles = stylex.create({
@@ -67,7 +67,7 @@ const styles = stylex.create({
     minWidth: 0,
   },
   title: {
-    fontWeight: 600,
+    fontWeight: fontWeightVars['--font-weight-semibold'],
   },
   body: {
     marginBlockStart: spacingVars['--spacing-1'],
@@ -179,9 +179,9 @@ export function XDSToast({
         styles.root,
         isError ? styles.variantError : styles.variantDefault,
       )}
-      className={xdsClassName('toast', {type}).className}>
+      className={xdsClassName('toast', {type})}>
       <div {...stylex.props(styles.iconArea)}>
-        {icon ?? <XDSIcon name={iconName} size={20} color="inherit" />}
+        {icon ?? <XDSIcon icon={iconName} size="md" color="inherit" />}
       </div>
 
       <div {...stylex.props(styles.content)}>
@@ -193,8 +193,8 @@ export function XDSToast({
         {endContent}
         <XDSButton
           variant="ghost"
-          size="compact"
-          icon={<XDSIcon name="x-mark" size={16} color="inherit" />}
+          size="sm"
+          icon={<XDSIcon icon="close" size="sm" color="inherit" />}
           label="Dismiss notification"
           onClick={handleDismiss}
         />

--- a/packages/core/src/Toast/XDSToastContext.ts
+++ b/packages/core/src/Toast/XDSToastContext.ts
@@ -1,0 +1,18 @@
+import {createContext} from 'react';
+import type {XDSToastEntry, XDSToastDismissReason} from './types';
+
+/** Internal context value for toast state management. */
+export interface XDSToastContextValue {
+  /** Add a toast. */
+  addToast: (entry: XDSToastEntry) => void;
+  /** Remove a toast by ID with a reason. */
+  removeToast: (id: string, reason: XDSToastDismissReason) => void;
+  /** Find a toast by uniqueID. */
+  findByUniqueID: (uniqueID: string) => XDSToastEntry | undefined;
+}
+
+/**
+ * React context for toast state. Default is null — the hook
+ * falls back to a self-mounting viewport when no provider exists.
+ */
+export const XDSToastContext = createContext<XDSToastContextValue | null>(null);

--- a/packages/core/src/Toast/XDSToastViewport.tsx
+++ b/packages/core/src/Toast/XDSToastViewport.tsx
@@ -2,7 +2,7 @@
 
 import {useCallback, useMemo, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {spacingVars} from '../theme/tokens.stylex';
+import {spacingVars, durationVars, easeVars} from '../theme/tokens.stylex';
 import {XDSToast} from './XDSToast';
 import {XDSToastContext, type XDSToastContextValue} from './XDSToastContext';
 import type {
@@ -17,7 +17,6 @@ const styles = stylex.create({
     zIndex: 500,
     display: 'flex',
     flexDirection: 'column',
-    gap: spacingVars['--spacing-3'],
     padding: spacingVars['--spacing-4'],
     pointerEvents: 'none',
   },
@@ -35,7 +34,29 @@ const styles = stylex.create({
     alignItems: 'flex-start',
     flexDirection: 'column-reverse',
   },
-  toastWrapper: {pointerEvents: 'auto'},
+  toastWrapper: {
+    pointerEvents: 'auto',
+    display: 'grid',
+    gridTemplateRows: '1fr',
+    paddingBlockEnd: spacingVars['--spacing-3'],
+    transitionProperty: 'grid-template-rows, padding',
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0.01ms',
+    },
+    transitionTimingFunction: easeVars['--ease-standard'],
+    '@starting-style': {
+      gridTemplateRows: '0fr',
+      paddingBlockEnd: 0,
+    },
+  },
+  toastWrapperExiting: {
+    gridTemplateRows: '0fr',
+    paddingBlockEnd: 0,
+  },
+  toastWrapperInner: {
+    overflow: 'hidden',
+  },
 });
 
 export interface XDSToastViewportProps {
@@ -52,6 +73,7 @@ export function XDSToastViewport({
   children,
 }: XDSToastViewportProps) {
   const [toasts, setToasts] = useState<XDSToastEntry[]>([]);
+  const [exitingIds, setExitingIds] = useState<Set<string>>(new Set());
   const toastsRef = useRef(toasts);
   toastsRef.current = toasts;
 
@@ -71,14 +93,25 @@ export function XDSToastViewport({
 
   const removeToast = useCallback(
     (id: string, reason: XDSToastDismissReason) => {
-      setToasts(prev => {
-        const entry = prev.find(t => t.id === id);
-        if (entry) entry.options.onHide?.(reason);
-        return prev.filter(t => t.id !== id);
+      const entry = toastsRef.current.find(t => t.id === id);
+      if (entry) entry.options.onHide?.(reason);
+      setExitingIds(prev => {
+        if (prev.has(id)) return prev;
+        return new Set(prev).add(id);
       });
     },
     [],
   );
+
+  const handleExited = useCallback((id: string) => {
+    setExitingIds(prev => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+    setToasts(prev => prev.filter(t => t.id !== id));
+  }, []);
 
   const findByUniqueID = useCallback((uid: string) => {
     return toastsRef.current.find(t => t.options.uniqueID === uid);
@@ -118,18 +151,35 @@ export function XDSToastViewport({
           const type = o.type ?? 'info';
           const isAutoHide = o.isAutoHide ?? (type === 'error' ? false : true);
           const dur = o.autoHideDuration ?? 5000;
+          const isExiting = exitingIds.has(entry.id);
           return (
-            <div key={entry.id} {...stylex.props(styles.toastWrapper)}>
-              <XDSToast
-                type={type}
-                title={o.title}
-                body={o.body}
-                icon={o.icon}
-                endContent={o.endContent}
-                isAutoHide={isAutoHide}
-                autoHideDuration={dur}
-                onDismiss={reason => removeToast(entry.id, reason)}
-              />
+            <div
+              key={entry.id}
+              {...stylex.props(
+                styles.toastWrapper,
+                isExiting && styles.toastWrapperExiting,
+              )}
+              onTransitionEnd={
+                isExiting
+                  ? (e: React.TransitionEvent) => {
+                      if (e.propertyName === 'grid-template-rows') {
+                        handleExited(entry.id);
+                      }
+                    }
+                  : undefined
+              }>
+              <div {...stylex.props(styles.toastWrapperInner)}>
+                <XDSToast
+                  type={type}
+                  body={o.body}
+
+                  endContent={o.endContent}
+                  isAutoHide={isAutoHide}
+                  autoHideDuration={dur}
+                  isExiting={isExiting}
+                  onDismiss={reason => removeToast(entry.id, reason)}
+                />
+              </div>
             </div>
           );
         })}

--- a/packages/core/src/Toast/XDSToastViewport.tsx
+++ b/packages/core/src/Toast/XDSToastViewport.tsx
@@ -69,6 +69,12 @@ export interface XDSToastViewportProps {
   position?: XDSToastPosition;
   maxVisible?: number;
   inset?: {top?: number; bottom?: number; start?: number; end?: number};
+  /**
+   * Promote viewport to CSS top layer via popover="manual".
+   * Set to false when inside a dialog or other top-layer element.
+   * @default true
+   */
+  isTopLayer?: boolean;
   children?: React.ReactNode;
 }
 
@@ -76,6 +82,7 @@ export function XDSToastViewport({
   position = 'bottomEnd',
   maxVisible = 5,
   inset,
+  isTopLayer = true,
   children,
 }: XDSToastViewportProps) {
   const [toasts, setToasts] = useState<XDSToastEntry[]>([]);
@@ -138,11 +145,12 @@ export function XDSToastViewport({
   // Show the popover on mount so it enters the top layer
   const viewportRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
+    if (!isTopLayer) return;
     const el = viewportRef.current;
     if (el && typeof el.showPopover === 'function') {
       try { el.showPopover(); } catch { /* already showing */ }
     }
-  }, []);
+  }, [isTopLayer]);
 
   const posStyle =
     position === 'topEnd'
@@ -160,9 +168,9 @@ export function XDSToastViewport({
         ref={viewportRef}
         role="region"
         aria-label="Notifications"
-        // popover="manual" promotes to the top layer (above dialogs)
-        // without auto-light-dismiss. We control visibility ourselves.
-        popover="manual"
+        // popover="manual" promotes to the top layer (above dialogs).
+        // Omitted inside dialogs where the viewport is already in a top layer.
+        popover={isTopLayer ? 'manual' : undefined}
         {...stylex.props(styles.viewport, posStyle)}
         style={Object.keys(insetStyle).length > 0 ? insetStyle : undefined}>
         {visibleToasts.map(entry => {

--- a/packages/core/src/Toast/XDSToastViewport.tsx
+++ b/packages/core/src/Toast/XDSToastViewport.tsx
@@ -162,7 +162,6 @@ export function XDSToastViewport({
         aria-label="Notifications"
         // popover="manual" promotes to the top layer (above dialogs)
         // without auto-light-dismiss. We control visibility ourselves.
-        // @ts-expect-error -- React types don't include popover yet
         popover="manual"
         {...stylex.props(styles.viewport, posStyle)}
         style={Object.keys(insetStyle).length > 0 ? insetStyle : undefined}>

--- a/packages/core/src/Toast/XDSToastViewport.tsx
+++ b/packages/core/src/Toast/XDSToastViewport.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import {useCallback, useMemo, useRef, useState} from 'react';
+import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars, durationVars, easeVars} from '../theme/tokens.stylex';
 import {XDSToast} from './XDSToast';
@@ -19,6 +19,12 @@ const styles = stylex.create({
     flexDirection: 'column',
     padding: spacingVars['--spacing-4'],
     pointerEvents: 'none',
+    // Reset popover styles — the popover attribute puts us in the top
+    // layer (above dialogs), but we don't want its default styles.
+    inset: 'unset',
+    border: 'none',
+    background: 'none',
+    overflow: 'visible',
   },
   bottomEnd: {bottom: 0, insetInlineEnd: 0, alignItems: 'flex-end'},
   bottomStart: {bottom: 0, insetInlineStart: 0, alignItems: 'flex-start'},
@@ -129,6 +135,15 @@ export function XDSToastViewport({
   if (inset?.start) insetStyle.insetInlineStart = inset.start;
   if (inset?.end) insetStyle.insetInlineEnd = inset.end;
 
+  // Show the popover on mount so it enters the top layer
+  const viewportRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    const el = viewportRef.current;
+    if (el && typeof el.showPopover === 'function') {
+      try { el.showPopover(); } catch { /* already showing */ }
+    }
+  }, []);
+
   const posStyle =
     position === 'topEnd'
       ? styles.topEnd
@@ -142,8 +157,13 @@ export function XDSToastViewport({
     <XDSToastContext.Provider value={contextValue}>
       {children}
       <div
+        ref={viewportRef}
         role="region"
         aria-label="Notifications"
+        // popover="manual" promotes to the top layer (above dialogs)
+        // without auto-light-dismiss. We control visibility ourselves.
+        // @ts-expect-error -- React types don't include popover yet
+        popover="manual"
         {...stylex.props(styles.viewport, posStyle)}
         style={Object.keys(insetStyle).length > 0 ? insetStyle : undefined}>
         {visibleToasts.map(entry => {

--- a/packages/core/src/Toast/XDSToastViewport.tsx
+++ b/packages/core/src/Toast/XDSToastViewport.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import {useCallback, useMemo, useRef, useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {spacingVars} from '../theme/tokens.stylex';
+import {XDSToast} from './XDSToast';
+import {XDSToastContext, type XDSToastContextValue} from './XDSToastContext';
+import type {
+  XDSToastEntry,
+  XDSToastPosition,
+  XDSToastDismissReason,
+} from './types';
+
+const styles = stylex.create({
+  viewport: {
+    position: 'fixed',
+    zIndex: 500,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-3'],
+    padding: spacingVars['--spacing-4'],
+    pointerEvents: 'none',
+  },
+  bottomEnd: {bottom: 0, insetInlineEnd: 0, alignItems: 'flex-end'},
+  bottomStart: {bottom: 0, insetInlineStart: 0, alignItems: 'flex-start'},
+  topEnd: {
+    top: 0,
+    insetInlineEnd: 0,
+    alignItems: 'flex-end',
+    flexDirection: 'column-reverse',
+  },
+  topStart: {
+    top: 0,
+    insetInlineStart: 0,
+    alignItems: 'flex-start',
+    flexDirection: 'column-reverse',
+  },
+  toastWrapper: {pointerEvents: 'auto'},
+});
+
+export interface XDSToastViewportProps {
+  position?: XDSToastPosition;
+  maxVisible?: number;
+  inset?: {top?: number; bottom?: number; start?: number; end?: number};
+  children?: React.ReactNode;
+}
+
+export function XDSToastViewport({
+  position = 'bottomEnd',
+  maxVisible = 5,
+  inset,
+  children,
+}: XDSToastViewportProps) {
+  const [toasts, setToasts] = useState<XDSToastEntry[]>([]);
+  const toastsRef = useRef(toasts);
+  toastsRef.current = toasts;
+
+  const addToast = useCallback((entry: XDSToastEntry) => {
+    setToasts(prev => {
+      const {uniqueID, collisionBehavior = 'overwrite'} = entry.options;
+      if (uniqueID) {
+        const existing = prev.find(t => t.options.uniqueID === uniqueID);
+        if (existing) {
+          if (collisionBehavior === 'ignore') return prev;
+          return prev.map(t => (t.options.uniqueID === uniqueID ? entry : t));
+        }
+      }
+      return [...prev, entry];
+    });
+  }, []);
+
+  const removeToast = useCallback(
+    (id: string, reason: XDSToastDismissReason) => {
+      setToasts(prev => {
+        const entry = prev.find(t => t.id === id);
+        if (entry) entry.options.onHide?.(reason);
+        return prev.filter(t => t.id !== id);
+      });
+    },
+    [],
+  );
+
+  const findByUniqueID = useCallback((uid: string) => {
+    return toastsRef.current.find(t => t.options.uniqueID === uid);
+  }, []);
+
+  const contextValue = useMemo<XDSToastContextValue>(
+    () => ({addToast, removeToast, findByUniqueID}),
+    [addToast, removeToast, findByUniqueID],
+  );
+
+  const visibleToasts = toasts.slice(-maxVisible);
+  const insetStyle: React.CSSProperties = {};
+  if (inset?.top) insetStyle.top = inset.top;
+  if (inset?.bottom) insetStyle.bottom = inset.bottom;
+  if (inset?.start) insetStyle.insetInlineStart = inset.start;
+  if (inset?.end) insetStyle.insetInlineEnd = inset.end;
+
+  const posStyle =
+    position === 'topEnd'
+      ? styles.topEnd
+      : position === 'topStart'
+        ? styles.topStart
+        : position === 'bottomStart'
+          ? styles.bottomStart
+          : styles.bottomEnd;
+
+  return (
+    <XDSToastContext.Provider value={contextValue}>
+      {children}
+      <div
+        role="region"
+        aria-label="Notifications"
+        {...stylex.props(styles.viewport, posStyle)}
+        style={Object.keys(insetStyle).length > 0 ? insetStyle : undefined}>
+        {visibleToasts.map(entry => {
+          const o = entry.options;
+          const type = o.type ?? 'info';
+          const isAutoHide = o.isAutoHide ?? (type === 'error' ? false : true);
+          const dur = o.autoHideDuration ?? 5000;
+          return (
+            <div key={entry.id} {...stylex.props(styles.toastWrapper)}>
+              <XDSToast
+                type={type}
+                title={o.title}
+                body={o.body}
+                icon={o.icon}
+                endContent={o.endContent}
+                isAutoHide={isAutoHide}
+                autoHideDuration={dur}
+                onDismiss={reason => removeToast(entry.id, reason)}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </XDSToastContext.Provider>
+  );
+}
+XDSToastViewport.displayName = 'XDSToastViewport';

--- a/packages/core/src/Toast/index.ts
+++ b/packages/core/src/Toast/index.ts
@@ -1,0 +1,17 @@
+'use client';
+
+export {useXDSToast} from './useXDSToast';
+
+export type {
+  XDSToastType,
+  XDSToastPosition,
+  XDSToastCollisionBehavior,
+  XDSToastDismissReason,
+  XDSToastOptions,
+  XDSToastDismissFn,
+  XDSShowToastFn,
+} from './types';
+
+// Exported for XDSLayerProvider integration
+export {XDSToastViewport} from './XDSToastViewport';
+export type {XDSToastViewportProps} from './XDSToastViewport';

--- a/packages/core/src/Toast/types.ts
+++ b/packages/core/src/Toast/types.ts
@@ -1,0 +1,66 @@
+import type {ReactNode} from 'react';
+
+/** Toast status type. Controls icon and color scheme. */
+export type XDSToastType = 'info' | 'warning' | 'error' | 'success';
+
+/** Position for the toast stack relative to the viewport. */
+export type XDSToastPosition =
+  | 'topEnd'
+  | 'topStart'
+  | 'bottomEnd'
+  | 'bottomStart';
+
+/** Behavior when a toast with the same uniqueID already exists. */
+export type XDSToastCollisionBehavior = 'overwrite' | 'ignore';
+
+/** Reason why a toast was dismissed. */
+export type XDSToastDismissReason = 'auto' | 'manual';
+
+/** Options for showing a toast. */
+export interface XDSToastOptions {
+  /** Primary message content. Keep it short — one line is ideal. */
+  title: ReactNode;
+  /** Optional secondary content area. */
+  body?: ReactNode;
+  /**
+   * Toast type controlling icon and color.
+   * @default 'info'
+   */
+  type?: XDSToastType;
+  /**
+   * Whether the toast auto-dismisses.
+   * Defaults to true for info/warning/success, false for error.
+   */
+  isAutoHide?: boolean;
+  /**
+   * Duration in ms before auto-dismiss.
+   * @default 5000
+   */
+  autoHideDuration?: number;
+  /** Content rendered at the end of the toast (trailing slot). */
+  endContent?: ReactNode;
+  /** Override the default icon for this toast type. */
+  icon?: ReactNode;
+  /** Unique identifier for deduplication. */
+  uniqueID?: string;
+  /**
+   * Behavior when a toast with matching uniqueID already exists.
+   * @default 'overwrite'
+   */
+  collisionBehavior?: XDSToastCollisionBehavior;
+  /** Callback fired when the toast is removed. */
+  onHide?: (reason: XDSToastDismissReason) => void;
+}
+
+/** Function to programmatically dismiss a toast. */
+export type XDSToastDismissFn = () => void;
+
+/** Function returned by useXDSToast to show toasts. */
+export type XDSShowToastFn = (options: XDSToastOptions) => XDSToastDismissFn;
+
+/** Internal toast state with ID and metadata. */
+export interface XDSToastEntry {
+  id: string;
+  options: XDSToastOptions;
+  createdAt: number;
+}

--- a/packages/core/src/Toast/types.ts
+++ b/packages/core/src/Toast/types.ts
@@ -1,7 +1,7 @@
 import type {ReactNode} from 'react';
 
-/** Toast status type. Controls icon and color scheme. */
-export type XDSToastType = 'info' | 'warning' | 'error' | 'success';
+/** Toast status type. Controls color scheme. */
+export type XDSToastType = 'info' | 'error';
 
 /** Position for the toast stack relative to the viewport. */
 export type XDSToastPosition =
@@ -18,18 +18,16 @@ export type XDSToastDismissReason = 'auto' | 'manual';
 
 /** Options for showing a toast. */
 export interface XDSToastOptions {
-  /** Primary message content. Keep it short — one line is ideal. */
-  title: ReactNode;
-  /** Optional secondary content area. */
-  body?: ReactNode;
+  /** Primary message content. */
+  body: ReactNode;
   /**
-   * Toast type controlling icon and color.
+   * Toast type controlling color.
    * @default 'info'
    */
   type?: XDSToastType;
   /**
    * Whether the toast auto-dismisses.
-   * Defaults to true for info/warning/success, false for error.
+   * Defaults to true for info, false for error.
    */
   isAutoHide?: boolean;
   /**
@@ -39,8 +37,7 @@ export interface XDSToastOptions {
   autoHideDuration?: number;
   /** Content rendered at the end of the toast (trailing slot). */
   endContent?: ReactNode;
-  /** Override the default icon for this toast type. */
-  icon?: ReactNode;
+
   /** Unique identifier for deduplication. */
   uniqueID?: string;
   /**

--- a/packages/core/src/Toast/useXDSToast.tsx
+++ b/packages/core/src/Toast/useXDSToast.tsx
@@ -26,7 +26,7 @@ function getFallbackContext(): XDSToastContextValue {
     );
   }
 
-  if (process.env.NODE_ENV !== 'production' && !fallbackWarned) {
+  if (!fallbackWarned) {
     fallbackWarned = true;
     console.warn(
       'useXDSToast: No XDSLayerProvider found. Using fallback viewport. ' +

--- a/packages/core/src/Toast/useXDSToast.tsx
+++ b/packages/core/src/Toast/useXDSToast.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import {useCallback, useContext, useEffect, useRef} from 'react';
+import {createRoot} from 'react-dom/client';
+import {XDSToastContext, type XDSToastContextValue} from './XDSToastContext';
+import {XDSToastViewport} from './XDSToastViewport';
+import type {
+  XDSToastOptions,
+  XDSToastDismissFn,
+  XDSShowToastFn,
+  XDSToastEntry,
+} from './types';
+
+// Fallback singleton
+let fallbackContext: XDSToastContextValue | null = null;
+let fallbackRoot: ReturnType<typeof createRoot> | null = null;
+let fallbackWarned = false;
+
+function getFallbackContext(): XDSToastContextValue {
+  if (fallbackContext) return fallbackContext;
+
+  if (typeof document === 'undefined') {
+    throw new Error(
+      'useXDSToast: Cannot create fallback viewport during SSR. ' +
+        'Wrap your app with <XDSLayerProvider> or <XDSAppShell>.',
+    );
+  }
+
+  if (process.env.NODE_ENV !== 'production' && !fallbackWarned) {
+    fallbackWarned = true;
+    console.warn(
+      'useXDSToast: No XDSLayerProvider found. Using fallback viewport. ' +
+        'Wrap your app with <XDSLayerProvider> or <XDSAppShell> for full control.',
+    );
+  }
+
+  const container = document.createElement('div');
+  container.setAttribute('data-xds-toast-fallback', '');
+  document.body.appendChild(container);
+
+  let resolveCtx: (ctx: XDSToastContextValue) => void;
+  const ctxReady = new Promise<XDSToastContextValue>(r => {
+    resolveCtx = r;
+  });
+
+  const FallbackCapture = () => {
+    const ctx = useContext(XDSToastContext);
+    const doneRef = useRef(false);
+    useEffect(() => {
+      if (ctx && !doneRef.current) {
+        doneRef.current = true;
+        fallbackContext = ctx;
+        resolveCtx!(ctx);
+      }
+    }, [ctx]);
+    return null;
+  };
+
+  fallbackRoot = createRoot(container);
+  fallbackRoot.render(
+    <XDSToastViewport>
+      <FallbackCapture />
+    </XDSToastViewport>,
+  );
+
+  // Proxy that queues calls until real context is captured
+  const pending: XDSToastEntry[] = [];
+  const proxy: XDSToastContextValue = {
+    addToast: entry => {
+      if (fallbackContext && fallbackContext !== proxy) {
+        fallbackContext.addToast(entry);
+      } else {
+        pending.push(entry);
+        ctxReady.then(ctx => {
+          for (const e of pending) ctx.addToast(e);
+          pending.length = 0;
+        });
+      }
+    },
+    removeToast: (id, reason) => {
+      if (fallbackContext && fallbackContext !== proxy) {
+        fallbackContext.removeToast(id, reason);
+      }
+    },
+    findByUniqueID: uid => {
+      if (fallbackContext && fallbackContext !== proxy) {
+        return fallbackContext.findByUniqueID(uid);
+      }
+      return undefined;
+    },
+  };
+
+  fallbackContext = proxy;
+  return proxy;
+}
+
+let toastIdCounter = 0;
+function generateToastId(): string {
+  return `xds-toast-${++toastIdCounter}`;
+}
+
+/**
+ * Hook to show toast notifications.
+ *
+ * Returns an imperative function that shows a toast and returns a dismiss function.
+ * Works with or without a provider — falls back to a self-mounting viewport.
+ *
+ * @example
+ * ```
+ * function SaveButton() {
+ *   const toast = useXDSToast();
+ *   const handleSave = async () => {
+ *     try {
+ *       await saveData();
+ *       toast({ title: 'Saved successfully', type: 'success' });
+ *     } catch {
+ *       toast({ title: 'Failed to save', type: 'error' });
+ *     }
+ *   };
+ *   return <XDSButton label="Save" onClick={handleSave} />;
+ * }
+ * ```
+ */
+export function useXDSToast(): XDSShowToastFn {
+  const contextFromProvider = useContext(XDSToastContext);
+
+  const showToast = useCallback(
+    (options: XDSToastOptions): XDSToastDismissFn => {
+      const ctx = contextFromProvider ?? getFallbackContext();
+      const id = generateToastId();
+      const entry: XDSToastEntry = {id, options, createdAt: Date.now()};
+      ctx.addToast(entry);
+      return () => ctx.removeToast(id, 'manual');
+    },
+    [contextFromProvider],
+  );
+
+  return showToast;
+}

--- a/packages/core/src/Toast/useXDSToast.tsx
+++ b/packages/core/src/Toast/useXDSToast.tsx
@@ -112,9 +112,9 @@ function generateToastId(): string {
  *   const handleSave = async () => {
  *     try {
  *       await saveData();
- *       toast({ title: 'Saved successfully', type: 'success' });
+ *       toast({ body: 'Saved successfully' });
  *     } catch {
- *       toast({ title: 'Failed to save', type: 'error' });
+ *       toast({ body: 'Failed to save', type: 'error' });
  *     }
  *   };
  *   return <XDSButton label="Save" onClick={handleSave} />;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -91,6 +91,22 @@ export type {
   FixedLayerReturn,
 } from './Layer';
 
+// Layer provider
+export {XDSLayerProvider} from './Layer';
+export type {XDSLayerProviderProps, LayerToastConfig} from './Layer';
+
+// Toast
+export {useXDSToast} from './Toast';
+export type {
+  XDSToastType,
+  XDSToastPosition,
+  XDSToastCollisionBehavior,
+  XDSToastDismissReason,
+  XDSToastOptions,
+  XDSToastDismissFn,
+  XDSShowToastFn,
+} from './Toast';
+
 // Popover component and hook
 export * from './Popover';
 

--- a/packages/core/src/theme/XDSMediaTheme.tsx
+++ b/packages/core/src/theme/XDSMediaTheme.tsx
@@ -24,7 +24,7 @@
  * @example
  * ```tsx
  * // Dark surface (e.g. toast on a light page)
- * <div style={{ backgroundColor: 'var(--color-surface-inverted)' }}>
+ * <div style={{ backgroundColor: 'var(--color-background-inverted)' }}>
  *   <XDSMediaTheme mode="dark">
  *     <XDSButton label="Undo" variant="ghost" />
  *   </XDSMediaTheme>

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -48,6 +48,8 @@ export const colorDefaults = {
   // Surface variants
   '--color-background-card': 'light-dark(#FFFFFF, #1F1F22)',
   '--color-background-popover': 'light-dark(#FFFFFF, #28292C)',
+  '--color-surface-inverted': 'light-dark(#0A1317, #FFFFFF)',
+  '--color-error-inverted': 'light-dark(#AA071E, #E3193B)',
 
   // Status/Sentiment
   '--color-success': 'light-dark(#0D8626, #0D8626)',

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -48,8 +48,8 @@ export const colorDefaults = {
   // Surface variants
   '--color-background-card': 'light-dark(#FFFFFF, #1F1F22)',
   '--color-background-popover': 'light-dark(#FFFFFF, #28292C)',
-  '--color-surface-inverted': 'light-dark(#0A1317, #FFFFFF)',
-  '--color-error-inverted': 'light-dark(#AA071E, #E3193B)',
+  '--color-background-inverted': 'light-dark(#0A1317, #FFFFFF)',
+  '--color-background-error-inverted': 'light-dark(#AA071E, #E3193B)',
 
   // Status/Sentiment
   '--color-success': 'light-dark(#0D8626, #0D8626)',


### PR DESCRIPTION
Closes #181

## Summary

Toast notification system with auto-dismiss, stacking, deduplication, and smooth enter/exit animations. Uses `XDSMediaTheme` for inverted surface theming — no runtime token computation.

## API

```tsx
const toast = useXDSToast();

// Basic
toast({ body: "Changes saved" });

// Error (persists until dismissed)
toast({ body: "Failed to save", type: "error" });

// With action
toast({
  body: "Item deleted",
  isAutoHide: false,
  endContent: <XDSButton label="Undo" variant="secondary" size="sm" onClick={undo} />,
});

// Deduplication
toast({ body: "You are offline", uniqueID: "offline", collisionBehavior: "ignore" });

// Programmatic dismiss
const dismiss = toast({ body: "Uploading...", isAutoHide: false });
dismiss();
```

## Toast Types

- **`info`** (default) — inverted surface, auto-dismisses after 5s
- **`error`** — error-inverted surface, persists until manually dismissed

## Key Design Decisions

**`XDSMediaTheme` for color inversion** — the toast wraps content in `<XDSMediaTheme mode="dark|light">` instead of manually computing token overrides at runtime. The theme system handles the color-scheme flip and token resolution via CSS. Info toast: dark media on light page, light media on dark page. Error toast: always dark media.

**No `title` prop** — body is the primary (and only) content slot. Keeps the API minimal. If you need structured content, compose it in body.

**Two types, not four** — `info` and `error` only. No `success` or `warning` — they added ceremony without meaningful UX differentiation.

**No per-toast icons** — the dismiss button and optional endContent are sufficient. Icons were visual noise in a transient notification.

**Smooth exit animations** — uses CSS `grid-template-rows: 1fr → 0fr` collapse with `@starting-style` for enter. Two-phase exit: fade+translate on the toast, then height collapse on the wrapper.

**Pause on hover/focus** — auto-dismiss timer pauses when the user interacts, resumes on leave.

**Fallback viewport** — `useXDSToast` works without a provider by creating a fallback viewport on `document.body`. No setup required for basic usage.

## Files

| File | Purpose |
|------|---------|
| `XDSToast.tsx` | Individual toast component |
| `XDSToastViewport.tsx` | Stack container + context provider |
| `XDSToastContext.ts` | React context for toast state |
| `useXDSToast.tsx` | Consumer hook with fallback viewport |
| `types.ts` | Shared types |
| `Toast.stories.tsx` | 9 stories covering all features |

## Changes to existing files

- `preview.tsx` — wrap storybook decorator in `XDSLayerProvider`

---
