### PR TITLE
hardening: extend XDSBaseProps in List/MetadataList, tokenize MobileNav borders

### DIFF
--- a/packages/core/src/List/XDSList.tsx
+++ b/packages/core/src/List/XDSList.tsx
@@ -17,6 +17,7 @@ import {useId, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {
   XDSListContext,
   type XDSListDensity,
@@ -29,7 +30,9 @@ export {
   type XDSListMarkerStyle as XDSListStyle,
 } from './XDSListContext';
 
-export interface XDSListProps {
+export interface XDSListProps extends XDSBaseProps<
+  HTMLUListElement | HTMLOListElement
+> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLUListElement | HTMLOListElement>;
   /**
@@ -64,28 +67,6 @@ export interface XDSListProps {
    * @default 'none'
    */
   listStyle?: XDSListMarkerStyle;
-
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 
   /**
    * Test ID for testing frameworks.

--- a/packages/core/src/MetadataList/XDSMetadataList.tsx
+++ b/packages/core/src/MetadataList/XDSMetadataList.tsx
@@ -26,6 +26,7 @@ import {
   XDSMetadataListContext,
   type XDSMetadataListLabelConfig,
 } from './XDSMetadataListContext';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -34,7 +35,10 @@ import {xdsClassName, mergeProps} from '../utils';
 
 export type XDSMetadataListColumns = 'multi' | 'single' | number;
 
-export interface XDSMetadataListProps {
+export interface XDSMetadataListProps extends Omit<
+  XDSBaseProps<HTMLDivElement>,
+  'title'
+> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
@@ -79,18 +83,6 @@ export interface XDSMetadataListProps {
    * Optional title or heading rendered above the list.
    */
   title?: ReactNode;
-  /**
-   * StyleX styles created via `stylex.create()`.
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element.
-   */
-  style?: React.CSSProperties;
   /**
    * Test ID for testing frameworks.
    */

--- a/packages/core/src/MetadataList/XDSMetadataListItem.tsx
+++ b/packages/core/src/MetadataList/XDSMetadataListItem.tsx
@@ -23,13 +23,14 @@ import {
   fontWeightVars,
 } from '../theme/tokens.stylex';
 import {XDSMetadataListContext} from './XDSMetadataListContext';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
 // Types
 // =============================================================================
 
-export interface XDSMetadataListItemProps {
+export interface XDSMetadataListItemProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
@@ -44,18 +45,6 @@ export interface XDSMetadataListItemProps {
    * Label text for this metadata item.
    */
   label: string;
-  /**
-   * StyleX styles created via `stylex.create()`.
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element.
-   */
-  style?: React.CSSProperties;
   /**
    * Test ID for testing frameworks.
    */

--- a/packages/core/src/MobileNav/XDSMobileNav.tsx
+++ b/packages/core/src/MobileNav/XDSMobileNav.tsx
@@ -26,6 +26,7 @@
 import {useCallback, useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
+  borderVars,
   colorVars,
   durationVars,
   easeVars,
@@ -109,7 +110,7 @@ const styles = stylex.create({
   },
   drawerStart: {
     insetInlineStart: 0,
-    borderInlineEndWidth: 1,
+    borderInlineEndWidth: borderVars['--border-width'],
     borderInlineEndStyle: 'solid',
     borderInlineEndColor: colorVars['--color-border'],
     transform: {
@@ -122,7 +123,7 @@ const styles = stylex.create({
   },
   drawerEnd: {
     insetInlineEnd: 0,
-    borderInlineStartWidth: 1,
+    borderInlineStartWidth: borderVars['--border-width'],
     borderInlineStartStyle: 'solid',
     borderInlineStartColor: colorVars['--color-border'],
     transform: {
@@ -140,7 +141,7 @@ const styles = stylex.create({
     height: spacingVars['--spacing-12'],
     paddingInline: spacingVars['--spacing-2'],
     flexShrink: 0,
-    borderBlockEndWidth: 1,
+    borderBlockEndWidth: borderVars['--border-width'],
     borderBlockEndStyle: 'solid',
     borderBlockEndColor: colorVars['--color-border'],
   },


### PR DESCRIPTION
## Summary

Nightly component audit (2026-04-08) — audited **Link**, **List**, **MetadataList**, **MobileNav**, **MoreMenu**.

### Fixes

**MobileNav** — hardcoded border widths → `borderVars['--border-width']`

Three borders in `XDSMobileNav` used hardcoded `1` instead of the `borderVars['--border-width']` token:
- `drawerStart.borderInlineEndWidth`
- `drawerEnd.borderInlineStartWidth`
- `header.borderBlockEndWidth`

Added `borderVars` to the token imports and replaced all three instances.

**List** — `XDSListProps` extends `XDSBaseProps`

The interface manually declared `xstyle`, `className`, and `style` (duplicating what `XDSBaseProps` already provides). Changed to `extends XDSBaseProps<HTMLUListElement | HTMLOListElement>` and removed the duplicate props (~20 lines).

**MetadataList** — `XDSMetadataListProps` and `XDSMetadataListItemProps` extend `XDSBaseProps`

Same pattern: both interfaces manually declared escape-hatch props. Migrated to extend `XDSBaseProps`.

Note: `XDSMetadataListProps` uses `Omit<XDSBaseProps<HTMLDivElement>, 'title'>` because it has its own `title?: ReactNode` prop which conflicts with `HTMLElement.title: string`.

### Clean (no changes needed)

- **Link** — all tokens, correct xdsClassName, XDSBaseProps, escape hatches, export hygiene ✓
- **MoreMenu** — tokens, xdsClassName, displayName, export hygiene ✓

---

## Needs Review

**MoreMenu — missing `xstyle`/`className`/`style` escape hatches**

`XDSMoreMenuProps` doesn't extend `XDSBaseProps` and has no style escape hatches. The component renders as a fragment (trigger button + popover), so there's no root element to apply styles to. This is a design question: should the trigger button accept xstyle/className/style? Or is `XDSButton`'s own style system sufficient for consumers who need it? Left for human judgment.

**MetadataList "Show more" toggle — native `<button>` instead of `XDSButton`**

The show/hide toggle in `XDSMetadataList` is a raw `<button>` with custom `toggleButton` StyleX styles. Convention says close buttons should use `XDSButton`, but this is a content toggle, not a close button. The custom styling (no background, text color = accent, specific font) doesn't map cleanly to a ghost button. Flagging for human judgment on whether this should be migrated.

---
