### PR TITLE
fix(SegmentedControl): use consistent border-radius for sm size

### DIFF
--- a/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControl.tsx
@@ -84,7 +84,7 @@ const styles = stylex.create({
 
 const sizeStyles = stylex.create({
   sm: {
-    '--segmented-radius': radiusVars['--radius-inner'],
+    '--segmented-radius': radiusVars['--radius-element'],
     borderRadius: 'var(--segmented-radius)',
   },
   md: {


### PR DESCRIPTION
The `sm` (compact) size was using `--radius-inner` while `md` and `lg` used `--radius-element`, making the compact variant look visually inconsistent with the other sizes. Now all three sizes use `--radius-element`.

One-line change in `sizeStyles.sm`.

---
