### PR TITLE
fix(core): export docs-types subpath for external consumers

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -465,6 +465,11 @@
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.mjs",
       "require": "./dist/utils/index.js"
+    },
+    "./docs-types": {
+      "source": "./src/docs-types.ts",
+      "types": "./dist/docs-types.d.ts",
+      "import": "./dist/docs-types.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
Adds ./docs-types to the @xds/core exports map so external consumers can resolve the ComponentDoc type when typechecking .doc.mjs files.