### PR TITLE
fix: component audit — NavIcon, NavItem, NumberInput, Pagination

### DIFF
--- a/packages/core/src/NavIcon/XDSNavIcon.tsx
+++ b/packages/core/src/NavIcon/XDSNavIcon.tsx
@@ -35,7 +35,7 @@ const styles = stylex.create({
   },
 });
 
-export interface XDSNavIconProps extends XDSBaseProps<HTMLDivElement> {
+export interface XDSNavIconProps extends XDSBaseProps<HTMLSpanElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLSpanElement>;
   /**

--- a/packages/core/src/NavItem/index.ts
+++ b/packages/core/src/NavItem/index.ts
@@ -1,1 +1,9 @@
+/**
+ * @file index.ts
+ * @input Imports from navItemStyles.stylex.ts
+ * @output Exports navItemStyles and NavItemSize type
+ * @position Entry point for NavItem module
+ */
+
 export {navItemStyles} from './navItemStyles.stylex';
+export type {NavItemSize} from './navItemStyles.stylex';

--- a/packages/core/src/NumberInput/XDSNumberInput.tsx
+++ b/packages/core/src/NumberInput/XDSNumberInput.tsx
@@ -537,6 +537,7 @@ export function XDSNumberInput({
           placeholder={placeholder}
           disabled={isDisabled}
           autoFocus={hasAutoFocus}
+          data-autofocus={hasAutoFocus || undefined}
           min={min ?? undefined}
           max={max ?? undefined}
           step={step ?? undefined}

--- a/packages/core/src/Pagination/XDSPagination.tsx
+++ b/packages/core/src/Pagination/XDSPagination.tsx
@@ -19,7 +19,6 @@
 
 import {useTransition} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   fontWeightVars,
@@ -34,6 +33,7 @@ import {XDSIcon} from '../Icon';
 import {XDSSelector} from '../Selector';
 import {XDSText} from '../Text';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 // =============================================================================
 // Types
@@ -68,7 +68,10 @@ export type XDSPaginationVariant = keyof XDSPaginationVariantMap;
 /** Size of the pagination controls. */
 export type XDSPaginationSize = 'sm' | 'md';
 
-export interface XDSPaginationProps {
+export interface XDSPaginationProps extends Omit<
+  XDSBaseProps<HTMLElement>,
+  'onChange'
+> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
   // --- Core (required) ---
@@ -142,27 +145,6 @@ export interface XDSPaginationProps {
   // --- Standard XDS ---
   /** Test ID for automated testing. */
   'data-testid'?: string;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
 }
 
 // =============================================================================
@@ -207,8 +189,8 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1'],
   },
   dot: {
-    width: 8,
-    height: 8,
+    width: spacingVars['--spacing-2'],
+    height: spacingVars['--spacing-2'],
     borderWidth: 0,
     borderStyle: 'none',
     padding: 0,
@@ -228,8 +210,8 @@ const styles = stylex.create({
     },
   },
   dotSm: {
-    width: 6,
-    height: 6,
+    width: spacingVars['--spacing-1-5'],
+    height: spacingVars['--spacing-1-5'],
   },
   dotActive: {
     backgroundColor: colorVars['--color-accent'],


### PR DESCRIPTION
## Night Watch Component Auditor — 2026-04-09

Audited 5 components: **NavIcon**, **NavItem**, **NumberInput**, **OverflowList**, **Pagination**

### Findings & Fixes

| Component | Issue | Category | Fix |
|-----------|-------|----------|-----|
| NavIcon | `XDSBaseProps<HTMLDivElement>` but renders `<span>` | `structure-issue` | Changed to `XDSBaseProps<HTMLSpanElement>` |
| NavItem | Missing file header and `NavItemSize` type export in index.ts | `export-gap` | Added file header + type export |
| NumberInput | Missing `data-autofocus` attribute (XDSDialog re-focus, #1044) | `a11y-gap` | Added `data-autofocus={hasAutoFocus \|\| undefined}` |
| Pagination | Manual `xstyle/className/style` instead of `XDSBaseProps` | `structure-issue` | Extended `Omit<XDSBaseProps<HTMLElement>, 'onChange'>` |
| Pagination | Hardcoded dot sizes (8px, 6px) | `hardcoded-value` | Tokenized to `--spacing-2`, `--spacing-1-5` |

### Clean Components (no issues)

- **OverflowList** — all checks pass ✓

### Needs Review

*None — all fixes are objective and mechanical.*

---
