### PR TITLE
chore: add branch pruning script

### DIFF
--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -1,4 +1,5 @@
-# Prune remote branches from merged PRs with no activity for > 1 day
+# Prune remote branches whose PRs are merged/closed, plus stale branches
+# with no PR older than 60 days.
 name: Prune merged branches
 
 on:
@@ -13,46 +14,12 @@ jobs:
   prune:
     runs-on: ubuntu-latest
     steps:
-      - name: Delete stale merged branches
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history needed for commit date checks
+
+      - name: Prune branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash {0}
-        run: |
-          echo "Finding branches from merged PRs with no activity for > 1 day..."
-          CUTOFF=$(date -u -d '1 day ago' +%Y-%m-%dT%H:%M:%SZ)
-
-          # List remote branches via API (no checkout needed)
-          BRANCHES=$(gh api repos/${{ github.repository }}/branches --paginate --jq '.[].name' | grep -vE '^(main|gh-pages)$' || true)
-
-          if [ -z "$BRANCHES" ]; then
-            echo "No candidate branches found."
-            exit 0
-          fi
-
-          DELETED=0
-          while IFS= read -r branch; do
-            # Check if this branch had a merged PR
-            PR_STATE=$(gh pr list --head "$branch" --state merged --json mergedAt --jq '.[0].mergedAt // empty' 2>/dev/null)
-            if [ -z "$PR_STATE" ]; then
-              continue
-            fi
-
-            # Check last commit date on the branch via API
-            LAST_COMMIT=$(gh api "repos/${{ github.repository }}/branches/${branch}" --jq '.commit.commit.author.date' 2>/dev/null)
-            if [ -z "$LAST_COMMIT" ]; then
-              continue
-            fi
-
-            # Compare: skip if last activity is within the cutoff
-            if [ "$(date -u -d "$LAST_COMMIT" +%s)" -gt "$(date -u -d "$CUTOFF" +%s)" ]; then
-              echo "⏭️  Skip (recent): $branch"
-              continue
-            fi
-
-            echo "🗑️  Deleting: $branch (merged: $PR_STATE)"
-            gh api "repos/${{ github.repository }}/git/refs/heads/${branch}" -X DELETE 2>/dev/null || true
-            DELETED=$((DELETED + 1))
-          done <<< "$BRANCHES"
-
-          echo ""
-          echo "✅ Pruned $DELETED branches"
+        run: ./scripts/prune-branches.sh --delete

--- a/scripts/prune-branches.sh
+++ b/scripts/prune-branches.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# scripts/prune-branches.sh — Delete remote branches with merged/closed PRs
+#
+# Usage:
+#   ./scripts/prune-branches.sh          # dry run (default)
+#   ./scripts/prune-branches.sh --delete  # actually delete
+#
+# Requires: gh CLI (authenticated), git
+# Works on macOS (zsh default) and Linux
+
+set -euo pipefail
+
+REPO="facebookexperimental/xds"
+PROTECTED="main|gh-pages"
+MODE="${1:-dry-run}"
+PARALLEL=15
+STALE_DAYS=60  # branches with no PR older than this are also flagged
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+DIM='\033[0;90m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+echo -e "${BOLD}🌿 XDS Branch Pruner${NC}"
+echo ""
+
+# Fetch + prune stale tracking refs
+echo -e "${DIM}Fetching and pruning remote refs...${NC}"
+git fetch origin --prune --quiet 2>/dev/null
+
+# Get all remote branches, excluding protected
+branches=()
+while IFS= read -r b; do
+  branches+=("$b")
+done < <(git branch -r | grep -v HEAD | sed 's|  origin/||' | grep -Ev "^($PROTECTED)$")
+total=${#branches[@]}
+echo -e "Found ${BOLD}$total${NC} remote branches (excluding $PROTECTED)"
+echo ""
+
+# Temp dirs — one file per branch avoids concurrent write corruption
+tmp_dir=$(mktemp -d)
+mkdir -p "$tmp_dir/delete" "$tmp_dir/keep" "$tmp_dir/stale"
+trap "rm -rf $tmp_dir" EXIT
+
+# Stale cutoff (epoch seconds)
+if date -v-1d >/dev/null 2>&1; then
+  # macOS date
+  stale_cutoff=$(date -v-${STALE_DAYS}d +%s)
+else
+  # GNU date
+  stale_cutoff=$(date -d "$STALE_DAYS days ago" +%s)
+fi
+
+# Progress tracking
+echo -e "${DIM}Checking PR status ($PARALLEL parallel)...${NC}"
+
+# Use a wrapper script file instead of export -f (works on zsh + bash)
+cat > "$tmp_dir/checker.sh" << 'CHECKER'
+#!/usr/bin/env bash
+branch="$1"
+tmp_dir="$2"
+stale_cutoff="$3"
+repo="$4"
+safe_name=$(echo "$branch" | tr '/' '_')
+
+state=$(gh pr list --repo "$repo" --head "$branch" --state all --json state --jq '.[0].state // "none"' 2>/dev/null || echo "error")
+
+if [ "$state" = "MERGED" ] || [ "$state" = "CLOSED" ]; then
+  echo "$branch" > "$tmp_dir/delete/$safe_name"
+elif [ "$state" = "none" ] || [ "$state" = "error" ]; then
+  commit_epoch=$(git log -1 --format='%ct' "origin/$branch" 2>/dev/null || echo "0")
+  if [ "$commit_epoch" -lt "$stale_cutoff" ]; then
+    echo "$branch" > "$tmp_dir/stale/$safe_name"
+  else
+    echo "$branch" > "$tmp_dir/keep/$safe_name"
+  fi
+else
+  echo "$branch" > "$tmp_dir/keep/$safe_name"
+fi
+
+# Progress (count files in all dirs)
+done_count=$(ls "$tmp_dir/delete" "$tmp_dir/keep" "$tmp_dir/stale" 2>/dev/null | wc -l | tr -d ' ')
+printf "\r  %s/%s checked" "$done_count" "$5" >&2
+CHECKER
+chmod +x "$tmp_dir/checker.sh"
+
+printf '%s\n' "${branches[@]}" | xargs -P "$PARALLEL" -I {} \
+  bash "$tmp_dir/checker.sh" {} "$tmp_dir" "$stale_cutoff" "$REPO" "$total"
+
+echo "" # newline after progress
+
+# Collect results
+delete_branches=()
+while IFS= read -r f; do
+  [ -f "$f" ] && delete_branches+=("$(cat "$f")")
+done < <(find "$tmp_dir/delete" -type f 2>/dev/null)
+
+stale_branches=()
+while IFS= read -r f; do
+  [ -f "$f" ] && stale_branches+=("$(cat "$f")")
+done < <(find "$tmp_dir/stale" -type f 2>/dev/null)
+
+keep_count=$(find "$tmp_dir/keep" -type f 2>/dev/null | wc -l | tr -d ' ')
+delete_count=${#delete_branches[@]}
+stale_count=${#stale_branches[@]}
+
+echo ""
+echo -e "${RED}✗ Delete:${NC}  $delete_count branches (merged/closed PR)"
+echo -e "${YELLOW}⚠ Stale:${NC}   $stale_count branches (no PR, >${STALE_DAYS} days old)"
+echo -e "${GREEN}✓ Keep:${NC}    $keep_count branches (open PR or recent)"
+
+# Combine delete + stale for the kill list
+all_delete=("${delete_branches[@]}" "${stale_branches[@]}")
+total_delete=${#all_delete[@]}
+
+if [ "$total_delete" -eq 0 ]; then
+  echo ""
+  echo -e "${GREEN}Nothing to prune. 🎉${NC}"
+  exit 0
+fi
+
+if [ "$MODE" = "--delete" ]; then
+  echo ""
+  echo -e "${BOLD}Deleting $total_delete branches ($PARALLEL parallel)...${NC}"
+
+  # Parallel deletion
+  printf '%s\n' "${all_delete[@]}" > "$tmp_dir/kill-list.txt"
+  mkdir -p "$tmp_dir/results"
+
+  cat > "$tmp_dir/deleter.sh" << 'DELETER'
+#!/usr/bin/env bash
+branch="$1"
+tmp_dir="$2"
+safe_name=$(echo "$branch" | tr '/' '_')
+if git push origin --delete "$branch" 2>/dev/null; then
+  echo "ok" > "$tmp_dir/results/$safe_name"
+else
+  echo "fail" > "$tmp_dir/results/$safe_name"
+fi
+done_count=$(ls "$tmp_dir/results" 2>/dev/null | wc -l | tr -d ' ')
+printf "\r  %s/%s deleted" "$done_count" "$3" >&2
+DELETER
+  chmod +x "$tmp_dir/deleter.sh"
+
+  cat "$tmp_dir/kill-list.txt" | xargs -P "$PARALLEL" -I {} \
+    bash "$tmp_dir/deleter.sh" {} "$tmp_dir" "$total_delete"
+
+  echo "" # newline after progress
+
+  deleted=$(grep -rl "ok" "$tmp_dir/results" 2>/dev/null | wc -l | tr -d ' ')
+  failed=$(grep -rl "fail" "$tmp_dir/results" 2>/dev/null | wc -l | tr -d ' ')
+
+  echo ""
+  echo -e "${BOLD}Results:${NC}"
+  echo -e "  ${GREEN}Deleted:${NC}   $deleted"
+  [ "$failed" -gt 0 ] && echo -e "  ${RED}Failed:${NC}    $failed"
+  echo -e "  ${YELLOW}Remaining:${NC} $keep_count + protected"
+else
+  echo ""
+  echo -e "${YELLOW}Dry run — pass ${BOLD}--delete${NC}${YELLOW} to actually delete.${NC}"
+
+  if [ "$delete_count" -gt 0 ]; then
+    echo ""
+    echo -e "${DIM}Merged/closed PR (will delete):${NC}"
+    printf '%s\n' "${delete_branches[@]}" | sort | sed 's/^/  /'
+  fi
+
+  if [ "$stale_count" -gt 0 ]; then
+    echo ""
+    echo -e "${DIM}No PR + >${STALE_DAYS} days stale (will delete):${NC}"
+    printf '%s\n' "${stale_branches[@]}" | sort | sed 's/^/  /'
+  fi
+fi


### PR DESCRIPTION
Adds `scripts/prune-branches.sh` — a reusable script to clean up stale remote branches.

## What it does

1. Fetches and prunes remote refs
2. Checks every remote branch against the GitHub API (15 parallel)
3. Flags branches with **merged/closed PRs** for deletion
4. Flags branches with **no PR + >60 days stale** for deletion
5. Keeps branches with **open PRs** or **recent activity**

## Usage

```bash
./scripts/prune-branches.sh          # dry run — shows what would be deleted
./scripts/prune-branches.sh --delete  # actually deletes
```

## Design choices

- **Dry run by default** — safe to run anytime
- **One file per branch in temp dir** — avoids race conditions from parallel writes
- **Script file instead of `export -f`** — works on macOS zsh (default shell)
- **Parallel deletion too** — not just the check phase
- **Progress indicator** — shows N/total during both phases
- **Stale branch detection** — catches orphan branches with no PR that are >60 days old
- **Protected branches** — `main` and `gh-pages` are never touched