### PR TITLE
feat(TextInput): add onEnter prop for consistency with NumberInput

### DIFF
--- a/packages/core/src/TextInput/XDSTextInput.test.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.test.tsx
@@ -324,6 +324,81 @@ describe('XDSTextInput', () => {
     });
   });
 
+  describe('onEnter', () => {
+    it('calls onEnter when Enter key is pressed', async () => {
+      const user = userEvent.setup();
+      const handleEnter = vi.fn();
+      render(
+        <XDSTextInput
+          label="Name"
+          value="hello"
+          onChange={() => {}}
+          onEnter={handleEnter}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      await user.click(input);
+      await user.keyboard('{Enter}');
+      expect(handleEnter).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not call onEnter for other keys', async () => {
+      const user = userEvent.setup();
+      const handleEnter = vi.fn();
+      render(
+        <XDSTextInput
+          label="Name"
+          value=""
+          onChange={() => {}}
+          onEnter={handleEnter}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      await user.click(input);
+      await user.keyboard('abc');
+      expect(handleEnter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('onKeyDown', () => {
+    it('passes through onKeyDown events', async () => {
+      const user = userEvent.setup();
+      const handleKeyDown = vi.fn();
+      render(
+        <XDSTextInput
+          label="Name"
+          value=""
+          onChange={() => {}}
+          onKeyDown={handleKeyDown}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      await user.click(input);
+      await user.keyboard('a');
+      expect(handleKeyDown).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls both onKeyDown and onEnter on Enter', async () => {
+      const user = userEvent.setup();
+      const handleKeyDown = vi.fn();
+      const handleEnter = vi.fn();
+      render(
+        <XDSTextInput
+          label="Name"
+          value=""
+          onChange={() => {}}
+          onKeyDown={handleKeyDown}
+          onEnter={handleEnter}
+        />,
+      );
+      const input = screen.getByRole('textbox');
+      await user.click(input);
+      await user.keyboard('{Enter}');
+      expect(handleEnter).toHaveBeenCalledTimes(1);
+      expect(handleKeyDown).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('hasClear', () => {
     it('shows clear button when hasClear is true and value is non-empty', () => {
       render(

--- a/packages/core/src/TextInput/XDSTextInput.tsx
+++ b/packages/core/src/TextInput/XDSTextInput.tsx
@@ -20,6 +20,7 @@ import {
   useCallback,
   useRef,
   type ChangeEvent,
+  type KeyboardEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {XDSIconName} from '../Icon';
@@ -207,6 +208,14 @@ export interface XDSTextInputProps extends Omit<
    * Useful for form submissions.
    */
   htmlName?: string;
+  /**
+   * Callback fired when the user presses the Enter key.
+   */
+  onEnter?: () => void;
+  /**
+   * Callback fired on keydown events on the input.
+   */
+  onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
 }
 
 /**
@@ -238,6 +247,8 @@ export function XDSTextInput({
   hasClear = false,
   hasAutoFocus = false,
   htmlName,
+  onEnter,
+  onKeyDown,
   xstyle,
   className,
   style,
@@ -349,6 +360,16 @@ export function XDSTextInput({
           type={type}
           value={String(optimisticValue)}
           onChange={handleChange}
+          onKeyDown={
+            onEnter || onKeyDown
+              ? e => {
+                  if (e.key === 'Enter') {
+                    onEnter?.();
+                  }
+                  onKeyDown?.(e);
+                }
+              : undefined
+          }
           placeholder={placeholder}
           disabled={isDisabled}
           autoFocus={hasAutoFocus}


### PR DESCRIPTION
XDSNumberInput supports an onEnter callback but XDSTextInput did not.
Add the same prop so consumers can handle Enter key presses consistently.
Also made it allow generic onKeyDown for additional flexibility.