### PR TITLE
fix(theme): support bare state keys in parseStyleKey

### DIFF
--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -271,6 +271,10 @@ function parseStyleKey(key) {
     .split('+')
     .map(part => {
       const [prop, value] = part.split(':');
+      // Bare state name (no colon) — e.g. 'checked', 'disabled', 'selected'
+      if (value === undefined) {
+        return `.${prop}`;
+      }
       if (/^\d/.test(value)) {
         return `.${prop}-${value}`;
       }

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -63,7 +63,8 @@ export const docs = {
   theming: {
     targets: [
       {className: 'xds-tab-list', visualProps: ['size']},
-      {className: 'xds-tab'},
+      {className: 'xds-tab', states: ['selected']},
+      {className: 'xds-tab-indicator', states: ['selected']},
       {className: 'xds-tab-menu'},
       {className: 'xds-tab-menu-dropdown'},
       {className: 'xds-tab-menu-item'},
@@ -306,7 +307,8 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'xds-tab-list', visualProps: ['size']},
-      {className: 'xds-tab'},
+      {className: 'xds-tab', states: ['selected']},
+      {className: 'xds-tab-indicator', states: ['selected']},
       {className: 'xds-tab-menu'},
       {className: 'xds-tab-menu-dropdown'},
       {className: 'xds-tab-menu-item'},

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -98,36 +98,30 @@ const styles = stylex.create({
     color: colorVars['--color-text-accent'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
   },
-  underlineSelected: {
-    '::after': {
-      content: '""',
-      position: 'absolute',
-      bottom: 0,
-      left: spacingVars['--spacing-3'],
-      right: spacingVars['--spacing-3'],
-      height: '2px',
-      backgroundColor: colorVars['--color-accent'],
-      borderRadius: radiusVars['--radius-full'],
-    },
-  },
-  hoverUnderline: {
+  indicator: {
     position: 'absolute',
     bottom: 0,
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',
-    backgroundColor: colorVars['--color-border'],
     borderRadius: radiusVars['--radius-full'],
+    pointerEvents: 'none',
+    transitionProperty: 'opacity, background-color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  indicatorSelected: {
+    backgroundColor: colorVars['--color-accent'],
+    opacity: 1,
+  },
+  indicatorUnselected: {
+    backgroundColor: colorVars['--color-border'],
     opacity: {
       default: 0,
       [stylex.when.ancestor(':hover')]: {
         '@media (hover: hover)': 1,
       },
     },
-    transitionProperty: 'opacity',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    pointerEvents: 'none',
   },
   icon: {
     display: 'inline-flex',
@@ -203,20 +197,31 @@ export function XDSTab({
   const sharedProps = {
     'aria-current': isSelected ? ('page' as const) : undefined,
     ...mergeProps(
-      xdsClassName('tab'),
+      xdsClassName('tab', {
+        selected: isSelected ? 'selected' : null,
+      }),
       stylex.props(
         styles.base,
         sizeStyles[size],
         isSelected && styles.selected,
-        isSelected && styles.underlineSelected,
         !isSelected && stylex.defaultMarker(),
       ),
     ),
   };
 
-  const hoverUnderlineElement = !isSelected ? (
-    <span {...stylex.props(styles.hoverUnderline)} />
-  ) : null;
+  const indicatorElement = (
+    <span
+      {...mergeProps(
+        xdsClassName('tab-indicator', {
+          selected: isSelected ? 'selected' : null,
+        }),
+        stylex.props(
+          styles.indicator,
+          isSelected ? styles.indicatorSelected : styles.indicatorUnselected,
+        ),
+      )}
+    />
+  );
 
   const labelElement = (
     <span {...stylex.props(styles.labelContainer)}>
@@ -232,7 +237,7 @@ export function XDSTab({
       <LinkComponent href={href} onClick={handleSelect} {...sharedProps}>
         {iconElement}
         {labelElement}
-        {hoverUnderlineElement}
+        {indicatorElement}
       </LinkComponent>
     );
   }
@@ -241,7 +246,7 @@ export function XDSTab({
     <button type="button" onClick={handleSelect} {...sharedProps}>
       {iconElement}
       {labelElement}
-      {hoverUnderlineElement}
+      {indicatorElement}
     </button>
   );
 }

--- a/packages/core/src/utils/parseStyleKey.test.ts
+++ b/packages/core/src/utils/parseStyleKey.test.ts
@@ -24,3 +24,27 @@ describe('parseStyleKey', () => {
     expect(parseStyleKey('variant:primary+level:2')).toBe('.primary.level-2');
   });
 });
+
+describe('parseStyleKey — bare state keys', () => {
+  it('converts bare state to .state', () => {
+    expect(parseStyleKey('checked')).toBe('.checked');
+  });
+
+  it('converts disabled state', () => {
+    expect(parseStyleKey('disabled')).toBe('.disabled');
+  });
+
+  it('converts selected state', () => {
+    expect(parseStyleKey('selected')).toBe('.selected');
+  });
+
+  it('handles compound bare states', () => {
+    expect(parseStyleKey('checked+disabled')).toBe('.checked.disabled');
+  });
+
+  it('handles mixed bare state + prop:value', () => {
+    expect(parseStyleKey('variant:destructive+disabled')).toBe(
+      '.destructive.disabled',
+    );
+  });
+});

--- a/packages/core/src/utils/parseStyleKey.ts
+++ b/packages/core/src/utils/parseStyleKey.ts
@@ -13,9 +13,15 @@
  * Values starting with a digit get prefixed with the prop name since
  * CSS class names can't start with a number.
  *
+ * Bare state names (no colon) are used directly as class names.
+ * This supports state-based theming targets like 'checked', 'disabled',
+ * 'selected' documented in the Theming Infrastructure wiki.
+ *
  * @example
  * ```ts
  * parseStyleKey('base')                        // ''
+ * parseStyleKey('checked')                      // '.checked'
+ * parseStyleKey('checked+disabled')             // '.checked.disabled'
  * parseStyleKey('variant:secondary')            // '.secondary'
  * parseStyleKey('level:1')                      // '.level-1'
  * parseStyleKey('variant:destructive+size:sm')  // '.destructive.sm'
@@ -28,6 +34,10 @@ export function parseStyleKey(key: string): string {
     .split('+')
     .map(part => {
       const [prop, value] = part.split(':');
+      // Bare state name (no colon) — e.g. 'checked', 'disabled', 'selected'
+      if (value === undefined) {
+        return `.${prop}`;
+      }
       // CSS classes can't start with a digit — prefix with prop name
       if (/^\d/.test(value)) {
         return `.${prop}-${value}`;


### PR DESCRIPTION
## Summary

Two fixes to unblock state-based theming documented in the [Theming Infrastructure wiki](https://github.com/facebookexperimental/xds/wiki/Theming-Infrastructure#theming-targets-reference).

### 1. `parseStyleKey` — bare state keys produce `.undefined`

`parseStyleKey('checked')` was producing `.undefined` instead of `.checked`. When a theme uses bare state keys:

```ts
radio: {
  checked: { backgroundColor: 'var(--color-background-surface)' },
}
```

The generated CSS was `.xds-radio.undefined { ... }` — silently broken.

**Root cause:** `part.split(':')` on a bare key returns `['checked', undefined]`, then `\`.\$\{value\}\`` → `.undefined`.

**Fix:** When `value` is `undefined`, use `prop` as the class name. Fixed in both synced copies (core + CLI).

### 2. XDSTab — expose `selected` state and consolidate indicator

XDSTab was missing theming targets for its visible states:
- No `selected` class on `.xds-tab`
- Selected underline was a `::after` pseudo-element (not themeable via defineTheme)
- Hover underline was a separate `<span>` (inconsistent with selected)

**Fix:** 
- Add `selected` state to `xdsClassName('tab', { selected })`
- Consolidate both underlines into a single `.xds-tab-indicator` sub-element with its own `selected` state
- Hover uses `stylex.when.ancestor(':hover')` with `defaultMarker()` for proper containment

Themes can now target:
```ts
tab: { selected: { color: 'var(--color-text-primary)' } },
'tab-indicator': { selected: { backgroundColor: 'var(--color-text-primary)' } },
```

## Test plan

- [x] All 10 parseStyleKey tests pass (5 existing + 5 new bare state cases)
- [x] All 18 TabList tests pass
- [x] Full suite: 2789 tests pass across 154 files