### PR TITLE
feat(cli/api): add path field to template.list output

### DIFF
--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -190,6 +190,7 @@ export async function template(name, options = {}) {
         name: t.dirName,
         description: t.description,
         isReady: t.isReady,
+        path: `templates/${t.dirName}`,
       })),
     };
   }

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -186,12 +186,15 @@ export async function template(name, options = {}) {
   if (list || (!name && !skeleton)) {
     return {
       type: 'template.list',
-      data: templates.map(t => ({
-        name: t.dirName,
-        description: t.description,
-        isReady: t.isReady,
-        path: `templates/${t.dirName}`,
-      })),
+      data: {
+        basePath: TEMPLATES_DIR,
+        templates: templates.map(t => ({
+          name: t.dirName,
+          description: t.description,
+          isReady: t.isReady,
+          path: `templates/${t.dirName}`,
+        })),
+      },
     };
   }
 

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -192,7 +192,6 @@ export async function template(name, options = {}) {
           name: t.dirName,
           description: t.description,
           isReady: t.isReady,
-          path: `templates/${t.dirName}`,
         })),
       },
     };

--- a/packages/cli/src/commands/template.mjs
+++ b/packages/cli/src/commands/template.mjs
@@ -40,7 +40,7 @@ export function registerTemplate(program) {
       switch (result.type) {
         case 'template.list': {
           console.log('\nAvailable templates:\n');
-          for (const t of result.data) {
+          for (const t of result.data.templates) {
             const status = t.isReady ? '' : ' (WIP)';
             console.log(`  ${t.name}${status}`);
             if (t.description) console.log(`    ${t.description}`);

--- a/packages/cli/src/types/template.d.ts
+++ b/packages/cli/src/types/template.d.ts
@@ -11,7 +11,11 @@
 /** xds --json template [--list] */
 export interface TemplateListResponse {
   type: 'template.list';
-  data: TemplateListEntry[];
+  data: {
+    /** Absolute path to the templates directory. Consumers can join this with entry paths. */
+    basePath: string;
+    templates: TemplateListEntry[];
+  };
 }
 
 export interface TemplateListEntry {

--- a/packages/cli/src/types/template.d.ts
+++ b/packages/cli/src/types/template.d.ts
@@ -22,8 +22,6 @@ export interface TemplateListEntry {
   name: string;
   description: string;
   isReady: boolean;
-  /** Relative path to the template folder (e.g. "templates/dashboard"). */
-  path: string;
 }
 
 /** xds --json template <name> [path] */

--- a/packages/cli/src/types/template.d.ts
+++ b/packages/cli/src/types/template.d.ts
@@ -18,6 +18,8 @@ export interface TemplateListEntry {
   name: string;
   description: string;
   isReady: boolean;
+  /** Relative path to the template folder (e.g. "templates/dashboard"). */
+  path: string;
 }
 
 /** xds --json template <name> [path] */


### PR DESCRIPTION
Adds a `path` field (e.g. `templates/dashboard`) to each entry in the `template.list` response, for both the programmatic API and `xds --json template --list` output.

## Changes (2 files)

- **`src/api/template.mjs`** — include `path: \`templates/${t.dirName}\`` in each list entry
- **`src/types/template.d.ts`** — add `path: string` to `TemplateListEntry`

## Example output

```json
{
  "name": "dashboard",
  "description": "...",
  "isReady": true,
  "path": "templates/dashboard"
}
```