### PR TITLE
fix(Chat): XDSChatComposerInput reads composer context as prop defaults

### DIFF
--- a/packages/core/src/Chat/XDSChatComposerInput.tsx
+++ b/packages/core/src/Chat/XDSChatComposerInput.tsx
@@ -41,6 +41,7 @@ import {
 import {xdsClassName, mergeProps} from '../utils';
 import {useTriggerMenu} from './useTriggerMenu';
 import {XDSBadge, type XDSBadgeProps} from '../Badge';
+import {useXDSChatComposerContext} from './XDSChatContext';
 
 // =============================================================================
 // Types
@@ -259,20 +260,22 @@ function insertTextAtCursor(text: string): void {
 // =============================================================================
 
 export function XDSChatComposerInput(props: XDSChatComposerInputProps) {
+  const composerCtx = useXDSChatComposerContext();
+
   const {
     ref,
-    value: controlledValue,
-    onChange,
-    placeholder = 'Type a message\u2026',
+    value: controlledValue = composerCtx?.value,
+    onChange = composerCtx?.onChange,
+    placeholder = composerCtx?.placeholder ?? 'Type a message\u2026',
     maxRows = 8,
     triggers,
     debounceMs = 150,
     hasHistory = true,
     label = 'Message input',
-    isDisabled = false,
+    isDisabled = composerCtx?.isDisabled ?? false,
     onPaste: onPasteProp,
     onFiles,
-    onSubmit,
+    onSubmit = composerCtx?.onSubmit,
     xstyle,
     className,
     style,


### PR DESCRIPTION
## Summary

- **Bug**: `XDSChatComposerInput` never consumed `XDSChatComposerContext`, so when rendered as the default input inside `XDSChatComposer` (with zero props), typing never synced back to the composer's `value` — `canSend` stayed `false` and the send button stayed permanently disabled.
- **Fix**: The input now calls `useXDSChatComposerContext()` and falls back to context values (`value`, `onChange`, `onSubmit`, `placeholder`, `isDisabled`) when no explicit prop is provided. Explicit props still take priority, so existing controlled usage is unaffected.

## Test plan

- [ ] Open the "Simplest" ChatComposer story — type text, verify send button enables and Enter submits
- [ ] Verify controlled usage (`<XDSChatComposerInput value={v} onChange={setV} />`) still works as before
- [ ] Verify trigger menus (@mentions, /commands) still function inside the composer


Made with [Cursor](https://cursor.com)