### PR TITLE
feat(ChatComposer): replace contextToolbar with headerActions + headerContext

### DIFF
--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -147,7 +147,9 @@ export const WithAttachments: Story = {
           iconOnly
         />
       }
-      headerContext="3%"
+      headerContext={
+        <XDSProgressBar label="Context window" value={3} isLabelHidden />
+      }
     />
   ),
 };

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -5,9 +5,53 @@ import {
   XDSChatComposerInput,
 } from '@xds/core/Chat';
 import {XDSToken} from '@xds/core/Token';
-import {XDSToolbar} from '@xds/core/Toolbar';
 import {XDSButton} from '@xds/core/Button';
+import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {useState} from 'react';
+
+// Inline icons for story demos (not in the default icon registry)
+const AtSignIcon = (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <circle cx="12" cy="12" r="4" />
+    <path d="M16 8v5a3 3 0 0 0 6 0v-1a10 10 0 1 0-4 8" />
+  </svg>
+);
+const PaperclipIcon = (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="m21.44 11.05-9.19 9.19a6 6 0 0 1-8.49-8.49l8.57-8.57A4 4 0 1 1 18 8.84l-8.59 8.57a2 2 0 0 1-2.83-2.83l8.49-8.48" />
+  </svg>
+);
+const MicIcon = (
+  <svg
+    width="1em"
+    height="1em"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round">
+    <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+    <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+    <line x1="12" x2="12" y1="19" y2="22" />
+  </svg>
+);
 
 const meta: Meta<typeof XDSChatComposer> = {
   title: 'Chat/XDSChatComposer',
@@ -64,16 +108,20 @@ export const WithStreaming: Story = {
   },
 };
 
-/** With footer actions (model selector, mic button) */
+/** With footer actions (model selector) and mic button */
 export const WithFooterActions: Story = {
   render: () => (
     <XDSChatComposer
       onSubmit={value => console.log('Submit:', value)}
-      footerActions={
-        <>
-          <XDSButton label="GPT-4" variant="ghost" size="md" />
-          <XDSButton label="Mic" variant="ghost" size="md" />
-        </>
+      footerActions={<XDSButton label="GPT-4" variant="ghost" size="md" />}
+      sendActions={
+        <XDSButton
+          label="Microphone"
+          variant="ghost"
+          size="md"
+          icon={MicIcon}
+          iconOnly
+        />
       }
     />
   ),
@@ -86,15 +134,20 @@ export const WithAttachments: Story = {
       onSubmit={value => console.log('Submit:', value)}
       attachments={
         <XDSChatComposerAttachments>
-          <XDSToken label="report.pdf" onDismiss={() => {}} />
-          <XDSToken label="data.csv" onDismiss={() => {}} />
+          <XDSToken label="report.pdf" onRemove={() => {}} />
+          <XDSToken label="data.csv" onRemove={() => {}} />
         </XDSChatComposerAttachments>
       }
-      contextToolbar={
-        <XDSToolbar size="sm">
-          <XDSButton label="Add context" variant="ghost" size="sm" />
-        </XDSToolbar>
+      headerActions={
+        <XDSButton
+          label="Attach file"
+          variant="ghost"
+          size="sm"
+          icon={PaperclipIcon}
+          iconOnly
+        />
       }
+      headerContext="3%"
     />
   ),
 };
@@ -115,21 +168,45 @@ export const FullFeatured: Story = {
         placeholder="Ask me anything..."
         attachments={
           <XDSChatComposerAttachments>
-            <XDSToken label="design-spec.pdf" onDismiss={() => {}} />
+            <XDSToken label="design-spec.pdf" onRemove={() => {}} />
           </XDSChatComposerAttachments>
         }
-        contextToolbar={
-          <XDSToolbar size="sm">
-            <XDSButton label="@workspace" variant="ghost" size="sm" />
-          </XDSToolbar>
+        headerActions={
+          <>
+            <XDSButton
+              label="Mention"
+              variant="ghost"
+              size="sm"
+              icon={AtSignIcon}
+              iconOnly
+            />
+            <XDSButton
+              label="Attach file"
+              variant="ghost"
+              size="sm"
+              icon={PaperclipIcon}
+              iconOnly
+            />
+          </>
+        }
+        headerContext={
+          <XDSProgressBar label="Context window" value={3} isLabelHidden />
         }
         footerActions={
           <>
-            <XDSButton label="Attach" variant="ghost" size="md" />
-            <XDSButton label="GPT-4o" variant="ghost" size="md" />
+            <XDSButton label="Auto" variant="ghost" size="md" />
+            <XDSButton label="Settings" variant="ghost" size="md" />
           </>
         }
-        sendActions={<XDSButton label="Schedule" variant="ghost" size="md" />}
+        sendActions={
+          <XDSButton
+            label="Microphone"
+            variant="ghost"
+            size="md"
+            icon={MicIcon}
+            iconOnly
+          />
+        }
       />
     );
   },
@@ -153,12 +230,12 @@ export const WithManyAttachments: Story = {
       onSubmit={value => console.log('Submit:', value)}
       attachments={
         <XDSChatComposerAttachments count={6}>
-          <XDSToken label="new_feature_prd.docx" onDismiss={() => {}} />
-          <XDSToken label="2026_roadmap.docx" onDismiss={() => {}} />
-          <XDSToken label="user_flow.pdf" onDismiss={() => {}} />
-          <XDSToken label="launch_plan.docx" onDismiss={() => {}} />
-          <XDSToken label="user_feedback.csv" onDismiss={() => {}} />
-          <XDSToken label="kpis.csv" onDismiss={() => {}} />
+          <XDSToken label="new_feature_prd.docx" onRemove={() => {}} />
+          <XDSToken label="2026_roadmap.docx" onRemove={() => {}} />
+          <XDSToken label="user_flow.pdf" onRemove={() => {}} />
+          <XDSToken label="launch_plan.docx" onRemove={() => {}} />
+          <XDSToken label="user_feedback.csv" onRemove={() => {}} />
+          <XDSToken label="kpis.csv" onRemove={() => {}} />
         </XDSChatComposerAttachments>
       }
     />
@@ -186,9 +263,9 @@ export const WithAttachmentsAndStatusTop: Story = {
       statusPosition="top"
       attachments={
         <XDSChatComposerAttachments count={3}>
-          <XDSToken label="report.pdf" onDismiss={() => {}} />
-          <XDSToken label="data.csv" onDismiss={() => {}} />
-          <XDSToken label="notes.docx" onDismiss={() => {}} />
+          <XDSToken label="report.pdf" onRemove={() => {}} />
+          <XDSToken label="data.csv" onRemove={() => {}} />
+          <XDSToken label="notes.docx" onRemove={() => {}} />
         </XDSChatComposerAttachments>
       }
       status={{

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -110,7 +110,7 @@ export const docs = {
     },
     {
       name: 'XDSChatComposer',
-      description: 'Layout shell for a chat composer. Arranges named slots (attachments, toolbar, input, footer, send) with page-radius container, hover/focus shadows, and concentric inner radius for child elements.',
+      description: 'Layout shell for a chat composer. Arranges named slots (attachments, header, input, footer, send) with page-radius container, hover/focus shadows, and concentric inner radius for child elements.',
       props: [
         {name: 'onSubmit', type: '(value: string) => void', description: 'Called when the user submits a message.', required: true},
         {name: 'onStop', type: '() => void', description: 'Called when the user requests to stop generation.'},
@@ -121,7 +121,8 @@ export const docs = {
         {name: 'isDisabled', type: 'boolean', description: 'Disables the composer.', default: 'false'},
         {name: 'density', type: "'compact' | 'balanced' | 'spacious'", description: 'Visual density.', default: "'balanced'"},
         {name: 'attachments', type: 'ReactNode', description: 'Slot: attachment chips above the input. Use XDSChatComposerAttachments.'},
-        {name: 'contextToolbar', type: 'ReactNode', description: 'Slot: toolbar between attachments and input. Use XDSToolbar.'},
+        {name: 'headerActions', type: 'ReactNode', description: 'Slot: left-aligned header actions (attach, mention buttons). Use icon-only size="sm" buttons.'},
+        {name: 'headerContext', type: 'ReactNode', description: 'Slot: right-aligned contextual info in the header (context window usage, XDSProgressBar, supporting text).'},
         {name: 'input', type: 'ReactNode', description: 'Slot: custom input element. Replaces the default textarea. Use XDSChatComposerInput for trigger menus.'},
         {name: 'footerActions', type: 'ReactNode', description: 'Slot: left-aligned footer actions (model selector, etc).'},
         {name: 'sendActions', type: 'ReactNode', description: 'Slot: actions to the left of the send button.'},
@@ -243,7 +244,7 @@ export const docsZh = {
     },
     {
       name: 'XDSChatComposer',
-      description: '聊天编写器布局外壳。排列命名插槽（附件、工具栏、输入、页脚、发送），带有页面圆角容器和同心内圆角。',
+      description: '聊天编写器布局外壳。排列命名插槽（附件、标题栏、输入、页脚、发送），带有页面圆角容器和同心内圆角。',
       propDescriptions: {
         onSubmit: '用户提交消息时调用。',
         onStop: '用户请求停止生成时调用。',
@@ -254,7 +255,8 @@ export const docsZh = {
         isDisabled: '禁用编写器。',
         density: '视觉密度。',
         attachments: '插槽：输入上方的附件标签。使用 XDSChatComposerAttachments。',
-        contextToolbar: '插槽：附件和输入之间的工具栏。使用 XDSToolbar。',
+        headerActions: '插槽：标题左侧操作按钮（附件、提及按钮）。使用仅图标 size="sm" 按钮。',
+        headerContext: '插槽：标题右侧上下文信息（上下文窗口使用情况、XDSProgressBar、辅助文本）。',
         input: '插槽：自定义输入元素。替换默认文本区域。使用 XDSChatComposerInput 实现触发菜单。',
         footerActions: '插槽：左对齐的页脚操作（模型选择器等）。',
         sendActions: '插槽：发送按钮左侧的操作。',
@@ -360,7 +362,7 @@ export const docsDense = {
     },
     {
       name: 'XDSChatComposer',
-      description: 'composer layout shell; named slots (attachments/toolbar/input/footer/send) w/ page-radius + concentric inner radius',
+      description: 'composer layout shell; named slots (attachments/header/input/footer/send) w/ page-radius + concentric inner radius',
       propDescriptions: {
         onSubmit: 'submit msg handler',
         onStop: 'stop generation handler',
@@ -371,7 +373,8 @@ export const docsDense = {
         isDisabled: 'disabled state',
         density: 'visual density',
         attachments: 'slot: attachment chips above input; use XDSChatComposerAttachments',
-        contextToolbar: 'slot: toolbar between attachments+input; use XDSToolbar',
+        headerActions: 'slot: left header actions (attach, mention); icon-only sm buttons',
+        headerContext: 'slot: right header context info (window usage, XDSProgressBar, text)',
         input: 'slot: custom input; replaces default textarea; use XDSChatComposerInput for triggers',
         footerActions: 'slot: left footer actions (model selector etc)',
         sendActions: 'slot: actions left of send btn',

--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -6,7 +6,7 @@
  * @output Exports XDSChatComposer layout shell component
  * @position Core implementation; consumed by index.ts
  *
- * Layout shell for a chat composer. Arranges slots (attachments, toolbar,
+ * Layout shell for a chat composer. Arranges slots (attachments, header,
  * input, footer actions, send button, status) in a vertical stack with
  * page-radius container, hover/focus shadows, and concentric inner radius.
  *
@@ -21,7 +21,14 @@
  * - /apps/storybook/stories/ChatComposer.stories.tsx
  */
 
-import {useState, useCallback, useMemo, type ReactNode} from 'react';
+import {
+  useState,
+  useCallback,
+  useRef,
+  useMemo,
+  type ReactNode,
+  type MouseEvent,
+} from 'react';
 import type {XDSBaseProps} from '../XDSBaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -75,8 +82,10 @@ export interface XDSChatComposerProps extends Omit<
 
   /** Attachment chips rendered above the input */
   attachments?: ReactNode;
-  /** Toolbar rendered between attachments and input (e.g. context chips) */
-  contextToolbar?: ReactNode;
+  /** Actions rendered on the left side of the header (e.g. attach, mention buttons). Use icon-only `size="sm"` buttons. */
+  headerActions?: ReactNode;
+  /** Contextual info rendered on the right side of the header (e.g. context window usage, XDSProgressBar). */
+  headerContext?: ReactNode;
   /** Custom input element — replaces the default textarea */
   input?: ReactNode;
   /** Actions rendered on the left side of the footer. Use `size="md"` buttons to match the send button height. */
@@ -125,6 +134,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-2'],
     borderRadius: 'var(--composer-radius)',
     backgroundColor: colorVars['--color-background-popover'],
+    cursor: 'text',
     boxShadow: {
       default: shadowVars['--shadow-low'],
       ':hover': {'@media (hover: hover)': shadowVars['--shadow-med']},
@@ -133,6 +143,27 @@ const styles = stylex.create({
     ':focus-within': {
       boxShadow: shadowVars['--shadow-med'],
     },
+  },
+  header: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacingVars['--spacing-2'],
+    minHeight: '28px',
+  },
+  headerLeft: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+  },
+  headerRight: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    marginInlineStart: 'auto',
+    fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    color: colorVars['--color-text-secondary'],
   },
   inputArea: {
     display: 'flex',
@@ -276,7 +307,8 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
     isDisabled = false,
     density = 'balanced',
     attachments,
-    contextToolbar,
+    headerActions,
+    headerContext,
     input,
     footerActions,
     sendActions,
@@ -309,10 +341,28 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
     if (!trimmed || isDisabled) return;
     onSubmit(trimmed);
     updateValue('');
-
   }, [currentValue, isDisabled, onSubmit, updateValue]);
 
   const canSend = currentValue.trim().length > 0 && !isDisabled;
+
+  const bodyRef = useRef<HTMLDivElement>(null);
+
+  const handleBodyClick = useCallback((e: MouseEvent<HTMLDivElement>) => {
+    // Focus the input when clicking empty space in the body.
+    // Skip if the click target is a button, link, or interactive element.
+    const target = e.target as HTMLElement;
+    if (
+      target.closest(
+        'button, a, [role="button"], [contenteditable="true"], [data-xds-token]',
+      )
+    ) {
+      return;
+    }
+    const editable = bodyRef.current?.querySelector<HTMLElement>(
+      '[contenteditable="true"], textarea',
+    );
+    editable?.focus();
+  }, []);
 
   const defaultSendButton = (
     <button
@@ -360,36 +410,46 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
 
   return (
     <XDSChatComposerContext.Provider value={composerContext}>
-    <div
-      {...mergeProps(
-        xdsClassName('chat-composer', {density}),
-        stylex.props(styles.root, isDisabled && styles.rootDisabled, xstyle),
-        className,
-        style,
-      )}
-      {...rest}>
-      {statusPosition === 'top' && statusEl}
-      {attachments}
-
       <div
-        {...stylex.props(styles.body, density === 'compact' && styles.compact)}>
-        {contextToolbar}
+        {...mergeProps(
+          xdsClassName('chat-composer', {density}),
+          stylex.props(styles.root, isDisabled && styles.rootDisabled, xstyle),
+          className,
+          style,
+        )}
+        {...rest}>
+        {statusPosition === 'top' && statusEl}
+        {attachments}
 
-        <div {...stylex.props(styles.inputArea)}>
-          {input ?? <XDSChatComposerInput />}
-        </div>
+        <div
+          ref={bodyRef}
+          onClick={handleBodyClick}
+          {...stylex.props(
+            styles.body,
+            density === 'compact' && styles.compact,
+          )}>
+          {(headerActions || headerContext) && (
+            <div {...stylex.props(styles.header)}>
+              <div {...stylex.props(styles.headerLeft)}>{headerActions}</div>
+              <div {...stylex.props(styles.headerRight)}>{headerContext}</div>
+            </div>
+          )}
 
-        <div {...stylex.props(styles.footer)}>
-          <div {...stylex.props(styles.footerLeft)}>{footerActions}</div>
-          <div {...stylex.props(styles.footerRight)}>
-            {sendActions}
-            {sendButton ?? defaultSendButton}
+          <div {...stylex.props(styles.inputArea)}>
+            {input ?? <XDSChatComposerInput />}
+          </div>
+
+          <div {...stylex.props(styles.footer)}>
+            <div {...stylex.props(styles.footerLeft)}>{footerActions}</div>
+            <div {...stylex.props(styles.footerRight)}>
+              {sendActions}
+              {sendButton ?? defaultSendButton}
+            </div>
           </div>
         </div>
-      </div>
 
-      {statusPosition === 'bottom' && statusEl}
-    </div>
+        {statusPosition === 'bottom' && statusEl}
+      </div>
     </XDSChatComposerContext.Provider>
   );
 }

--- a/packages/core/src/Chat/XDSChatComposerAttachments.tsx
+++ b/packages/core/src/Chat/XDSChatComposerAttachments.tsx
@@ -165,7 +165,7 @@ const styles = stylex.create({
     minHeight: 0,
     display: 'flex',
     flexWrap: 'wrap',
-    gap: spacingVars['--spacing-2'],
+    gap: spacingVars['--spacing-1'],
     alignItems: 'flex-start',
     transform: 'translateY(0)',
     transitionProperty: 'transform',

--- a/packages/core/src/Chat/XDSChatComposerInput.tsx
+++ b/packages/core/src/Chat/XDSChatComposerInput.tsx
@@ -301,7 +301,9 @@ export function XDSChatComposerInput(props: XDSChatComposerInputProps) {
   const emitChange = useCallback(() => {
     if (!editableRef.current) return;
     const text = serialize(editableRef.current);
-    setIsEmpty(text.length === 0);
+    // Browsers may leave a trailing <br> when all content is deleted,
+    // which serializes to "\n". Treat whitespace-only as empty.
+    setIsEmpty(text.trim().length === 0);
     onChange?.(text);
     // Clean up portals for tokens no longer in the DOM
     setTokenPortals(prev =>


### PR DESCRIPTION
## What

Replaces the single `contextToolbar` slot with two purpose-specific header slots:

- **`headerActions`** (left) — icon-only `size="sm"` buttons for attach, mention, context injection
- **`headerContext`** (right) — informational content: supporting text (`"3%"`), `<XDSProgressBar>`, meters

```
┌─────────────────────────────────────────────────┐
│ [📎][@]                              3% ━━░░░░  │ ← headerActions / headerContext
│                                                  │
│ [textarea]                                       │
│                                                  │
│ [Auto][Settings]          [🎤]       [↑ send]    │ ← footerActions / sendActions
└─────────────────────────────────────────────────┘
```

The header row only renders when at least one slot is populated. `headerRight` gets `--color-text-secondary` and supporting text size by default so plain strings look right out of the box.

## #1226 Hardening Fixes

| Finding | Severity |
|---------|----------|
| Empty toolbar rendering above textarea | P1 ✅ |
| Click anywhere in composer to focus textarea | P1 ✅ |
| Attachment token spacing `--spacing-2` → `--spacing-1` | P1 ✅ |
| Stories using nonexistent `onDismiss` instead of `onRemove` | P1 ✅ |
| FullFeatured story with proper icons and footer layout | P1 ✅ |
| Placeholder not reappearing after deleting all content | P0 ✅ |
| Mic button in stories | P2 ✅ |

## Breaking Change

`contextToolbar` prop removed → replaced by `headerActions` + `headerContext`. Migration is mechanical:

```diff
- contextToolbar={<XDSToolbar><Button /></XDSToolbar>}
+ headerActions={<Button />}
```

Partially closes #1226