### PR TITLE
feat(Chat): add XDSChatLayout with fixed composer dock and container queries

### DIFF
--- a/apps/storybook/stories/Chat.stories.tsx
+++ b/apps/storybook/stories/Chat.stories.tsx
@@ -13,6 +13,7 @@ import {XDSHStack} from '@xds/core/Stack';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSButton} from '@xds/core/Button';
 import {XDSIcon} from '@xds/core/Icon';
+import {XDSEmptyState} from '@xds/core/EmptyState';
 import {XDSTimestamp} from '@xds/core/Timestamp';
 import {HandThumbUpIcon, HandThumbDownIcon} from '@heroicons/react/24/outline';
 import {ClipboardDocumentIcon} from '@heroicons/react/24/outline';
@@ -357,10 +358,10 @@ export const EmptyState: StoryObj = {
     <div style={{height: 400, display: 'flex', flexDirection: 'column'}}>
       <XDSChatMessageList
         emptyState={
-          <div style={{textAlign: 'center', opacity: 0.5}}>
-            <div style={{fontSize: 32, marginBottom: 8}}>💬</div>
-            <div>No messages yet. Start a conversation!</div>
-          </div>
+          <XDSEmptyState
+            title="No messages yet"
+            description="Start a conversation!"
+          />
         }>
         {[]}
       </XDSChatMessageList>

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -426,17 +426,15 @@ export const FullAIChat: StoryObj = {
         }
         headerContext={
           <>
-            <div
+            <XDSProgressBar
               ref={contextTooltip.ref}
               aria-describedby={contextTooltip.describedBy}
-              style={{paddingInlineEnd: 8}}>
-              <XDSProgressBar
-                label="Context"
-                value={12}
-                variant="neutral"
-                isLabelHidden
-              />
-            </div>
+              label="Context"
+              value={12}
+              variant="neutral"
+              isLabelHidden
+              style={{marginInlineEnd: 8}}
+            />
             {contextTooltip.renderTooltip('3k / 100k tokens used')}
           </>
         }

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -190,7 +190,7 @@ export const FullAIChat: StoryObj = {
     const contextTooltip = useXDSTooltip({placement: 'above'});
 
     const mentionTokens = CONTACTS.map(c => ({
-      pattern: `@${c.id}`,
+      value: `@${c.id}`,
       label: `@${c.label}`,
       variant: 'blue' as const,
     }));
@@ -519,7 +519,7 @@ export const PanelView: StoryObj = {
     const inputRef = useRef<XDSChatComposerInputHandle>(null);
 
     const mentionTokens = CONTACTS.map(c => ({
-      pattern: `@${c.id}`,
+      value: `@${c.id}`,
       label: `@${c.label}`,
       variant: 'blue' as const,
     }));

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -21,9 +21,9 @@ import {XDSButton} from '@xds/core/Button';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {XDSAvatar} from '@xds/core/Avatar';
-import {XDSText} from '@xds/core/Text';
 import {useXDSTooltip} from '@xds/core/Tooltip';
 import {createStaticSource} from '@xds/core/Typeahead';
+import {XDSEmptyState} from '@xds/core/EmptyState';
 import {useState, useCallback, useRef} from 'react';
 
 const meta: Meta<typeof XDSChatLayout> = {
@@ -510,53 +510,216 @@ export const FullAIChat: StoryObj = {
   },
 };
 
-/** Panel view — narrow container simulating a sidebar chat */
+/** Panel view — same full features in a narrow sidebar container */
 export const PanelView: StoryObj = {
   name: 'Panel View',
-  render: () => (
-    <div
-      style={{
-        width: 400,
-        height: 600,
-        border: '1px solid #ccc',
-        borderRadius: 8,
-        overflow: 'hidden',
-        position: 'relative',
-      }}>
-      <XDSChatLayout
-        composer={
-          <XDSChatComposer onSubmit={() => {}} placeholder="Type a message…" />
-        }>
-        <XDSChatMessageList>
-          <XDSChatMessage
-            sender="assistant"
-            name="Navi"
-            avatar={<XDSAvatar name="Navi" size="sm" />}>
-            <XDSChatMessageBubble>
-              Hello! How can I help you today?
-            </XDSChatMessageBubble>
-          </XDSChatMessage>
-          <XDSChatMessage sender="user" name="Cindy">
-            <XDSChatMessageBubble>
-              Can you explain how the chat layout works?
-            </XDSChatMessageBubble>
-          </XDSChatMessage>
-          <XDSChatMessage
-            sender="assistant"
-            name="Navi"
-            avatar={<XDSAvatar name="Navi" size="sm" />}>
-            <XDSChatMessageBubble>
-              The chat layout adapts its spacing based on container width. In a
-              narrow panel like this, it uses compact density automatically.
-            </XDSChatMessageBubble>
-          </XDSChatMessage>
-        </XDSChatMessageList>
-      </XDSChatLayout>
-    </div>
-  ),
+  render: () => {
+    const [messages, setMessages] = useState<Message[]>(SEED_MESSAGES);
+    const [files, setFiles] = useState<string[]>([]);
+    const [isStreaming, setIsStreaming] = useState(false);
+    const streamRef = useRef<ReturnType<typeof setInterval>>(undefined);
+    const inputRef = useRef<XDSChatComposerInputHandle>(null);
+
+    const mentionTokens = CONTACTS.map(c => ({
+      pattern: `@${c.id}`,
+      label: `@${c.label}`,
+      variant: 'blue' as const,
+    }));
+
+    const triggers: XDSChatComposerTrigger[] = [
+      {
+        character: '@',
+        searchSource: createStaticSource(CONTACTS),
+        onSelect: item => ({
+          value: `@${item.id}`,
+          label: `@${item.label}`,
+          variant: 'blue' as const,
+        }),
+      },
+      {
+        character: '/',
+        searchSource: createStaticSource(COMMANDS),
+        onSelect: item => `/${item.label} `,
+      },
+    ];
+
+    const streamResponse = useCallback(
+      (introText: string, resultText: string) => {
+        const msgId = Date.now();
+        setIsStreaming(true);
+
+        setMessages(prev => [
+          ...prev,
+          {id: msgId, role: 'assistant', text: '', isStreaming: true},
+        ]);
+
+        let i = 0;
+        const fullText = introText + '\n\n' + resultText;
+        streamRef.current = setInterval(() => {
+          i += 3 + Math.floor(Math.random() * 5);
+          if (i >= fullText.length) {
+            clearInterval(streamRef.current);
+            setMessages(prev =>
+              prev.map(m =>
+                m.id === msgId ? {...m, text: fullText, isStreaming: false} : m,
+              ),
+            );
+            setIsStreaming(false);
+            return;
+          }
+          setMessages(prev =>
+            prev.map(m =>
+              m.id === msgId ? {...m, text: fullText.slice(0, i)} : m,
+            ),
+          );
+        }, 30);
+      },
+      [],
+    );
+
+    const handleSubmit = useCallback(
+      (value: string) => {
+        setMessages(prev => [
+          ...prev,
+          {
+            id: Date.now(),
+            role: 'user',
+            text: value,
+            files: files.length ? [...files] : undefined,
+          },
+        ]);
+        setFiles([]);
+        setTimeout(() => {
+          streamResponse(
+            'Checking the component now.',
+            'Found the issue — the border radius was hardcoded. Replaced with the theme token.',
+          );
+        }, 800);
+      },
+      [files, streamResponse],
+    );
+
+    const handleStop = useCallback(() => {
+      clearInterval(streamRef.current);
+      setIsStreaming(false);
+      setMessages(prev =>
+        prev.map(m =>
+          m.role === 'assistant' && m.isStreaming
+            ? {...m, isStreaming: false}
+            : m,
+        ),
+      );
+    }, []);
+
+    const composerEl = (
+      <XDSChatComposer
+        onSubmit={handleSubmit}
+        onStop={handleStop}
+        isStreaming={isStreaming}
+        attachments={
+          files.length > 0 ? (
+            <XDSChatComposerAttachments>
+              {files.map(f => (
+                <XDSToken
+                  key={f}
+                  label={f}
+                  onRemove={() => setFiles(prev => prev.filter(x => x !== f))}
+                />
+              ))}
+            </XDSChatComposerAttachments>
+          ) : undefined
+        }
+        headerActions={
+          <>
+            <XDSButton
+              label="Mention"
+              variant="ghost"
+              size="sm"
+              icon={AtSignIcon}
+              isIconOnly
+              onClick={() => {
+                inputRef.current?.focus();
+                inputRef.current?.insertText('@');
+              }}
+            />
+            <XDSButton
+              label="Attach"
+              variant="ghost"
+              size="sm"
+              icon={PaperclipIcon}
+              isIconOnly
+              onClick={() =>
+                setFiles(prev => [...prev, `file-${prev.length + 1}.tsx`])
+              }
+            />
+          </>
+        }
+        input={
+          <XDSChatComposerInput
+            ref={inputRef}
+            triggers={triggers}
+            placeholder="Ask something..."
+          />
+        }
+      />
+    );
+
+    return (
+      <div
+        style={{
+          width: 400,
+          height: 600,
+          border: '1px solid #ccc',
+          borderRadius: 8,
+          overflow: 'hidden',
+        }}>
+        <XDSChatLayout composer={composerEl}>
+          <XDSChatMessageList>
+            {messages.map(msg => {
+              if (msg.role === 'system') {
+                return (
+                  <XDSChatSystemMessage key={msg.id} variant="divider">
+                    {msg.text}
+                  </XDSChatSystemMessage>
+                );
+              }
+              if (msg.role === 'user') {
+                return (
+                  <XDSChatMessage key={msg.id} sender="user">
+                    {msg.files && (
+                      <XDSChatComposerAttachments>
+                        {msg.files.map(f => (
+                          <XDSToken key={f} label={f} />
+                        ))}
+                      </XDSChatComposerAttachments>
+                    )}
+                    <XDSChatMessageBubble>
+                      <XDSChatMessageTokenizedText tokens={mentionTokens}>
+                        {msg.text}
+                      </XDSChatMessageTokenizedText>
+                    </XDSChatMessageBubble>
+                  </XDSChatMessage>
+                );
+              }
+              return (
+                <XDSChatMessage key={msg.id} sender="assistant">
+                  {msg.text && (
+                    <XDSMarkdown density="compact">{msg.text}</XDSMarkdown>
+                  )}
+                  {msg.toolCalls && msg.toolCalls.length > 0 && (
+                    <XDSChatToolCalls calls={msg.toolCalls ?? []} />
+                  )}
+                </XDSChatMessage>
+              );
+            })}
+          </XDSChatMessageList>
+        </XDSChatLayout>
+      </div>
+    );
+  },
 };
 
-/** Empty state */
+/** Empty state using XDSEmptyState */
 export const WithEmptyState: StoryObj = {
   name: 'Empty State',
   render: () => (
@@ -569,14 +732,10 @@ export const WithEmptyState: StoryObj = {
           />
         }
         emptyState={
-          <div style={{textAlign: 'center'}}>
-            <XDSText variant="subtitle" color="secondary">
-              No messages yet
-            </XDSText>
-            <XDSText variant="body" color="tertiary">
-              Start a conversation by typing below
-            </XDSText>
-          </div>
+          <XDSEmptyState
+            title="No messages yet"
+            description="Start a conversation by typing below."
+          />
         }>
         {[]}
       </XDSChatLayout>

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -1,5 +1,6 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {
+  XDSChatLayout,
   XDSChatMessageList,
   XDSChatMessage,
   XDSChatMessageBubble,
@@ -19,18 +20,24 @@ import {XDSToken} from '@xds/core/Token';
 import {XDSButton} from '@xds/core/Button';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSText} from '@xds/core/Text';
 import {useXDSTooltip} from '@xds/core/Tooltip';
 import {createStaticSource} from '@xds/core/Typeahead';
 import {useState, useCallback, useRef} from 'react';
 
-const meta: Meta = {
-  title: 'Chat/Compositions',
+const meta: Meta<typeof XDSChatLayout> = {
+  title: 'Chat/XDSChatLayout',
+  component: XDSChatLayout,
   tags: ['autodocs'],
   parameters: {layout: 'fullscreen'},
 };
 export default meta;
 
+// =============================================================================
 // Icons
+// =============================================================================
+
 const PaperclipIcon = (
   <svg
     width="1em"
@@ -74,7 +81,10 @@ const MicIcon = (
   </svg>
 );
 
+// =============================================================================
 // Data
+// =============================================================================
+
 const CONTACTS = [
   {id: 'cindy', label: 'Cindy Zhang'},
   {id: 'alex', label: 'Alex Rivera'},
@@ -164,7 +174,11 @@ const SEED_MESSAGES: Message[] = [
   {id: 5, role: 'user', text: 'Nice, can you also check the Card component?'},
 ];
 
-/** Full AI chat — message list + composer with streaming, tool calls, triggers, attachments, and interactive modals */
+// =============================================================================
+// Stories
+// =============================================================================
+
+/** Full AI chat with streaming, tool calls, triggers, attachments, and frosted glass composer dock */
 export const FullAIChat: StoryObj = {
   name: 'Full AI Chat',
   render: () => {
@@ -174,6 +188,12 @@ export const FullAIChat: StoryObj = {
     const streamRef = useRef<ReturnType<typeof setInterval>>(undefined);
     const inputRef = useRef<XDSChatComposerInputHandle>(null);
     const contextTooltip = useXDSTooltip({placement: 'above'});
+
+    const mentionTokens = CONTACTS.map(c => ({
+      pattern: `@${c.id}`,
+      label: `@${c.label}`,
+      variant: 'blue' as const,
+    }));
 
     const triggers: XDSChatComposerTrigger[] = [
       {
@@ -192,7 +212,6 @@ export const FullAIChat: StoryObj = {
       },
     ];
 
-    // Simulates: stream intro text → run tool calls → stream result text
     const streamResponse = useCallback(
       (
         introText: string,
@@ -202,18 +221,11 @@ export const FullAIChat: StoryObj = {
         const msgId = Date.now();
         setIsStreaming(true);
 
-        // Start with empty message
         setMessages(prev => [
           ...prev,
-          {
-            id: msgId,
-            role: 'assistant',
-            text: '',
-            isStreaming: true,
-          },
+          {id: msgId, role: 'assistant', text: '', isStreaming: true},
         ]);
 
-        // Phase 1: stream intro text
         let i = 0;
         streamRef.current = setInterval(() => {
           i += 2 + Math.floor(Math.random() * 4);
@@ -223,7 +235,6 @@ export const FullAIChat: StoryObj = {
               prev.map(m => (m.id === msgId ? {...m, text: introText} : m)),
             );
 
-            // Phase 2: tool calls appear as running
             if (toolCalls) {
               setTimeout(() => {
                 setMessages(prev =>
@@ -241,7 +252,6 @@ export const FullAIChat: StoryObj = {
                   ),
                 );
 
-                // Phase 2b: tool calls complete
                 setTimeout(() => {
                   setMessages(prev =>
                     prev.map(m =>
@@ -251,7 +261,6 @@ export const FullAIChat: StoryObj = {
                     ),
                   );
 
-                  // Phase 3: stream result text
                   setTimeout(() => {
                     let j = 0;
                     const fullText = introText + '\n\n' + resultText;
@@ -282,7 +291,6 @@ export const FullAIChat: StoryObj = {
                 }, 1800);
               }, 400);
             } else {
-              // No tool calls — just finish
               setMessages(prev =>
                 prev.map(m =>
                   m.id === msgId ? {...m, isStreaming: false} : m,
@@ -373,14 +381,90 @@ export const FullAIChat: StoryObj = {
       );
     }, []);
 
+    const composerEl = (
+      <XDSChatComposer
+        onSubmit={handleSubmit}
+        onStop={handleStop}
+        isStreaming={isStreaming}
+        attachments={
+          files.length > 0 ? (
+            <XDSChatComposerAttachments>
+              {files.map(f => (
+                <XDSToken
+                  key={f}
+                  label={f}
+                  onRemove={() => setFiles(prev => prev.filter(x => x !== f))}
+                />
+              ))}
+            </XDSChatComposerAttachments>
+          ) : undefined
+        }
+        headerActions={
+          <>
+            <XDSButton
+              label="Mention"
+              variant="ghost"
+              size="sm"
+              icon={AtSignIcon}
+              isIconOnly
+              onClick={() => {
+                inputRef.current?.focus();
+                inputRef.current?.insertText('@');
+              }}
+            />
+            <XDSButton
+              label="Attach"
+              variant="ghost"
+              size="sm"
+              icon={PaperclipIcon}
+              isIconOnly
+              onClick={() =>
+                setFiles(prev => [...prev, `file-${prev.length + 1}.tsx`])
+              }
+            />
+          </>
+        }
+        headerContext={
+          <>
+            <div
+              ref={contextTooltip.ref}
+              aria-describedby={contextTooltip.describedBy}
+              style={{paddingInlineEnd: 8}}>
+              <XDSProgressBar
+                label="Context"
+                value={12}
+                variant="neutral"
+                isLabelHidden
+              />
+            </div>
+            {contextTooltip.renderTooltip('3k / 100k tokens used')}
+          </>
+        }
+        input={
+          <XDSChatComposerInput
+            ref={inputRef}
+            triggers={triggers}
+            placeholder="Ask about the codebase..."
+          />
+        }
+        footerActions={
+          <XDSButton label="Claude Opus" variant="ghost" size="md" />
+        }
+        sendActions={
+          <XDSButton
+            label="Microphone"
+            variant="ghost"
+            size="md"
+            icon={MicIcon}
+            isIconOnly
+          />
+        }
+      />
+    );
+
     return (
-      <>
-        <div
-          style={{
-            maxWidth: 800,
-            margin: '0 auto',
-            paddingBottom: 120,
-          }}>
+      <div style={{height: '100vh', display: 'flex', flexDirection: 'column'}}>
+        <XDSChatLayout composer={composerEl}>
           <XDSChatMessageList>
             {messages.map(msg => {
               if (msg.role === 'system') {
@@ -420,117 +504,82 @@ export const FullAIChat: StoryObj = {
               );
             })}
           </XDSChatMessageList>
-        </div>
-
-        {/* Frosted glass layer — sits behind the composer */}
-        <div
-          style={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            height: 120,
-            pointerEvents: 'none',
-            backdropFilter: 'blur(12px)',
-            WebkitBackdropFilter: 'blur(12px)',
-            maskImage: 'linear-gradient(to bottom, transparent, black 48px)',
-            WebkitMaskImage:
-              'linear-gradient(to bottom, transparent, black 48px)',
-          }}
-        />
-        {/* Composer dock */}
-        <div
-          style={{
-            position: 'fixed',
-            bottom: 0,
-            left: 0,
-            right: 0,
-            padding: '0 16px 12px',
-          }}>
-          <div style={{maxWidth: 800, margin: '0 auto'}}>
-            <XDSChatComposer
-              onSubmit={handleSubmit}
-              onStop={handleStop}
-              isStreaming={isStreaming}
-              attachments={
-                files.length > 0 ? (
-                  <XDSChatComposerAttachments>
-                    {files.map(f => (
-                      <XDSToken
-                        key={f}
-                        label={f}
-                        onRemove={() =>
-                          setFiles(prev => prev.filter(x => x !== f))
-                        }
-                      />
-                    ))}
-                  </XDSChatComposerAttachments>
-                ) : undefined
-              }
-              headerActions={
-                <>
-                  <XDSButton
-                    label="Mention"
-                    variant="ghost"
-                    size="sm"
-                    icon={AtSignIcon}
-                    isIconOnly
-                    onClick={() => {
-                      inputRef.current?.focus();
-                      inputRef.current?.insertText('@');
-                    }}
-                  />
-                  <XDSButton
-                    label="Attach"
-                    variant="ghost"
-                    size="sm"
-                    icon={PaperclipIcon}
-                    isIconOnly
-                    onClick={() =>
-                      setFiles(prev => [...prev, `file-${prev.length + 1}.tsx`])
-                    }
-                  />
-                </>
-              }
-              headerContext={
-                <>
-                  <div
-                    ref={contextTooltip.ref}
-                    aria-describedby={contextTooltip.describedBy}
-                    style={{paddingInlineEnd: 8}}>
-                    <XDSProgressBar
-                      label="Context"
-                      value={12}
-                      variant="neutral"
-                      isLabelHidden
-                    />
-                  </div>
-                  {contextTooltip.renderTooltip('3k / 100k tokens used')}
-                </>
-              }
-              input={
-                <XDSChatComposerInput
-                  ref={inputRef}
-                  triggers={triggers}
-                  placeholder="Ask about the codebase..."
-                />
-              }
-              footerActions={
-                <XDSButton label="Claude Opus" variant="ghost" size="md" />
-              }
-              sendActions={
-                <XDSButton
-                  label="Microphone"
-                  variant="ghost"
-                  size="md"
-                  icon={MicIcon}
-                  isIconOnly
-                />
-              }
-            />
-          </div>
-        </div>
-      </>
+        </XDSChatLayout>
+      </div>
     );
   },
+};
+
+/** Panel view — narrow container simulating a sidebar chat */
+export const PanelView: StoryObj = {
+  name: 'Panel View',
+  render: () => (
+    <div
+      style={{
+        width: 400,
+        height: 600,
+        border: '1px solid #ccc',
+        borderRadius: 8,
+        overflow: 'hidden',
+        position: 'relative',
+      }}>
+      <XDSChatLayout
+        composer={
+          <XDSChatComposer onSubmit={() => {}} placeholder="Type a message…" />
+        }>
+        <XDSChatMessageList>
+          <XDSChatMessage
+            sender="assistant"
+            name="Navi"
+            avatar={<XDSAvatar name="Navi" size="sm" />}>
+            <XDSChatMessageBubble>
+              Hello! How can I help you today?
+            </XDSChatMessageBubble>
+          </XDSChatMessage>
+          <XDSChatMessage sender="user" name="Cindy">
+            <XDSChatMessageBubble>
+              Can you explain how the chat layout works?
+            </XDSChatMessageBubble>
+          </XDSChatMessage>
+          <XDSChatMessage
+            sender="assistant"
+            name="Navi"
+            avatar={<XDSAvatar name="Navi" size="sm" />}>
+            <XDSChatMessageBubble>
+              The chat layout adapts its spacing based on container width. In a
+              narrow panel like this, it uses compact density automatically.
+            </XDSChatMessageBubble>
+          </XDSChatMessage>
+        </XDSChatMessageList>
+      </XDSChatLayout>
+    </div>
+  ),
+};
+
+/** Empty state */
+export const WithEmptyState: StoryObj = {
+  name: 'Empty State',
+  render: () => (
+    <div style={{height: '100vh', display: 'flex', flexDirection: 'column'}}>
+      <XDSChatLayout
+        composer={
+          <XDSChatComposer
+            onSubmit={() => {}}
+            placeholder="Start a conversation…"
+          />
+        }
+        emptyState={
+          <div style={{textAlign: 'center'}}>
+            <XDSText variant="subtitle" color="secondary">
+              No messages yet
+            </XDSText>
+            <XDSText variant="body" color="tertiary">
+              Start a conversation by typing below
+            </XDSText>
+          </div>
+        }>
+        {[]}
+      </XDSChatLayout>
+    </div>
+  ),
 };

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -483,7 +483,7 @@ export const FullAIChat: StoryObj = {
                       </XDSChatComposerAttachments>
                     )}
                     <XDSChatMessageBubble>
-                      <XDSChatMessageTokenizedText tokens={msg.tokens}>
+                      <XDSChatMessageTokenizedText tokens={mentionTokens}>
                         {msg.text}
                       </XDSChatMessageTokenizedText>
                     </XDSChatMessageBubble>

--- a/apps/storybook/stories/ChatLayout.stories.tsx
+++ b/apps/storybook/stories/ChatLayout.stories.tsx
@@ -8,7 +8,7 @@ import {
   XDSChatComposer,
   XDSChatComposerAttachments,
   XDSChatComposerInput,
-  XDSChatMessageTokenizedText,
+  XDSChatTokenizedText,
   XDSChatToolCalls,
   type XDSChatComposerInputHandle,
   type XDSChatComposerToken,
@@ -483,9 +483,9 @@ export const FullAIChat: StoryObj = {
                       </XDSChatComposerAttachments>
                     )}
                     <XDSChatMessageBubble>
-                      <XDSChatMessageTokenizedText tokens={mentionTokens}>
+                      <XDSChatTokenizedText tokens={mentionTokens}>
                         {msg.text}
-                      </XDSChatMessageTokenizedText>
+                      </XDSChatTokenizedText>
                     </XDSChatMessageBubble>
                   </XDSChatMessage>
                 );
@@ -692,9 +692,9 @@ export const PanelView: StoryObj = {
                       </XDSChatComposerAttachments>
                     )}
                     <XDSChatMessageBubble>
-                      <XDSChatMessageTokenizedText tokens={mentionTokens}>
+                      <XDSChatTokenizedText tokens={mentionTokens}>
                         {msg.text}
-                      </XDSChatMessageTokenizedText>
+                      </XDSChatTokenizedText>
                     </XDSChatMessageBubble>
                   </XDSChatMessage>
                 );

--- a/apps/storybook/stories/ChatTokenizedText.stories.tsx
+++ b/apps/storybook/stories/ChatTokenizedText.stories.tsx
@@ -1,10 +1,10 @@
 import type {Meta, StoryObj} from '@storybook/react';
-import {XDSChatMessageTokenizedText} from '@xds/core/Chat';
+import {XDSChatTokenizedText} from '@xds/core/Chat';
 import {XDSChatMessage, XDSChatMessageBubble} from '@xds/core/Chat';
 
-const meta: Meta<typeof XDSChatMessageTokenizedText> = {
-  title: 'Chat/XDSChatMessageTokenizedText',
-  component: XDSChatMessageTokenizedText,
+const meta: Meta<typeof XDSChatTokenizedText> = {
+  title: 'Chat/XDSChatTokenizedText',
+  component: XDSChatTokenizedText,
   tags: ['autodocs'],
   parameters: {layout: 'centered'},
   decorators: [
@@ -17,7 +17,7 @@ const meta: Meta<typeof XDSChatMessageTokenizedText> = {
 };
 export default meta;
 
-type Story = StoryObj<typeof XDSChatMessageTokenizedText>;
+type Story = StoryObj<typeof XDSChatTokenizedText>;
 
 const mentionTokens = [
   {value: '@cindy', label: '@Cindy Zhang', variant: 'blue' as const},
@@ -30,9 +30,9 @@ export const SingleToken: Story = {
   render: () => (
     <XDSChatMessage sender="user">
       <XDSChatMessageBubble>
-        <XDSChatMessageTokenizedText tokens={mentionTokens}>
+        <XDSChatTokenizedText tokens={mentionTokens}>
           Hey @cindy can you review this?
-        </XDSChatMessageTokenizedText>
+        </XDSChatTokenizedText>
       </XDSChatMessageBubble>
     </XDSChatMessage>
   ),
@@ -43,9 +43,9 @@ export const MultipleTokens: Story = {
   render: () => (
     <XDSChatMessage sender="user">
       <XDSChatMessageBubble>
-        <XDSChatMessageTokenizedText tokens={mentionTokens}>
+        <XDSChatTokenizedText tokens={mentionTokens}>
           @cindy and @alex can @navi help with the review?
-        </XDSChatMessageTokenizedText>
+        </XDSChatTokenizedText>
       </XDSChatMessageBubble>
     </XDSChatMessage>
   ),
@@ -56,9 +56,9 @@ export const PlainText: Story = {
   render: () => (
     <XDSChatMessage sender="user">
       <XDSChatMessageBubble>
-        <XDSChatMessageTokenizedText>
+        <XDSChatTokenizedText>
           Just a regular message with no mentions.
-        </XDSChatMessageTokenizedText>
+        </XDSChatTokenizedText>
       </XDSChatMessageBubble>
     </XDSChatMessage>
   ),
@@ -69,14 +69,14 @@ export const MixedVariants: Story = {
   render: () => (
     <XDSChatMessage sender="user">
       <XDSChatMessageBubble>
-        <XDSChatMessageTokenizedText
+        <XDSChatTokenizedText
           tokens={[
             {value: '@cindy', label: '@Cindy', variant: 'blue'},
             {value: '#bug', label: '#bug', variant: 'red'},
             {value: '#feat', label: '#feature', variant: 'green'},
           ]}>
           @cindy filed #bug and #feat for the sprint
-        </XDSChatMessageTokenizedText>
+        </XDSChatTokenizedText>
       </XDSChatMessageBubble>
     </XDSChatMessage>
   ),
@@ -87,9 +87,9 @@ export const TokensAtEdges: Story = {
   render: () => (
     <XDSChatMessage sender="user">
       <XDSChatMessageBubble>
-        <XDSChatMessageTokenizedText tokens={mentionTokens}>
+        <XDSChatTokenizedText tokens={mentionTokens}>
           @cindy this is for @navi
-        </XDSChatMessageTokenizedText>
+        </XDSChatTokenizedText>
       </XDSChatMessageBubble>
     </XDSChatMessage>
   ),

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -98,6 +98,12 @@ export const Variants: Story = {
         variant="negative"
         hasValueLabel
       />
+      <XDSProgressBar
+        value={35}
+        label="Neutral"
+        variant="neutral"
+        hasValueLabel
+      />
     </div>
   ),
 };
@@ -186,6 +192,7 @@ export const IndeterminateVariants: Story = {
       <XDSProgressBar isIndeterminate label="Positive" variant="positive" />
       <XDSProgressBar isIndeterminate label="Warning" variant="warning" />
       <XDSProgressBar isIndeterminate label="Negative" variant="negative" />
+      <XDSProgressBar isIndeterminate label="Neutral" variant="neutral" />
     </div>
   ),
 };

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -192,9 +192,24 @@ export const docs = {
     },
   ],
   usage: {
-    summary: 'Chat components for building AI chat interfaces, including message lists, message bubbles, and a composer.',
+    summary: 'Chat components for building AI chat interfaces, including message lists, message bubbles, a composer, and a layout shell.',
   },
 };
+
+// Append XDSChatLayout to all doc variants
+const chatLayoutComponent = {
+  name: 'XDSChatLayout',
+  description: 'Layout shell for full chat interfaces. Messages flow in normal page flow, composer is fixed to the bottom with a frosted glass dock. Adapts spacing via container width observation.',
+  props: [
+    {name: 'children', type: 'ReactNode', description: 'Message content — flows naturally in the page, scrolls with the page.', required: true},
+    {name: 'composer', type: 'ReactNode', description: 'Composer element fixed to the bottom with frosted glass dock.', required: true},
+    {name: 'emptyState', type: 'ReactNode', description: 'Content shown when children is empty.'},
+  ],
+  examples: [
+    {label: 'Basic', code: `<XDSChatLayout composer={<XDSChatComposer onSubmit={handleSubmit} />}>\n  {messages.map(msg => <XDSChatMessage key={msg.id} {...msg} />)}\n</XDSChatLayout>`},
+  ],
+};
+docs.components.push(chatLayoutComponent);
 
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsZh = {
@@ -315,11 +330,20 @@ export const docsZh = {
       },
     },
     {
-      name: 'XDSChatMessageTokenizedText',
+name: 'XDSChatMessageTokenizedText',
       description: '渲染带有标记模式的文本，将匹配的模式替换为内联 XDSBadge 组件。在 XDSChatMessageBubble 内使用，以徽章样式显示 @提及或其他标记。',
       propDescriptions: {
         children: '包含标记模式的消息文本。',
         tokens: '标记定义。每个包含 pattern（匹配字符串）、label（显示文本）和可选 variant。',
+      },
+    },
+    {
+      name: 'XDSChatLayout',
+      description: '完整聊天界面的布局外壳。消息在页面中自然流动，编写器固定在底部，带有毛玻璃效果。',
+      propDescriptions: {
+        children: '消息内容，在页面中自然流动，随页面滚动。',
+        composer: '固定在底部的编写器元素，带有毛玻璃底座。',
+        emptyState: '子元素为空时显示的内容。',
       },
     },
   ],
@@ -443,11 +467,20 @@ export const docsDense = {
       },
     },
     {
-      name: 'XDSChatMessageTokenizedText',
+name: 'XDSChatMessageTokenizedText',
       description: 'renders text w/ token patterns replaced by inline badges; use in bubble for @mentions',
       propDescriptions: {
         children: 'msg text w/ token patterns',
         tokens: 'token defs: pattern+label+variant',
+      },
+    },
+    {
+      name: 'XDSChatLayout',
+      description: 'layout shell for full chat; msgs in page flow, composer fixed bottom w/ frosted glass dock',
+      propDescriptions: {
+        children: 'msg content; flows in page, scrolls w/ page',
+        composer: 'composer element; fixed bottom w/ frosted glass',
+        emptyState: 'content when children empty',
       },
     },
   ],

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -19,7 +19,7 @@ export const docs = {
     'Composer layout shell with named semantic slots',
     'ContentEditable input with @ mention and / command trigger menus',
     'Imperative handle on ComposerInput for programmatic token/text insertion',
-    'Tokenized text rendering in message bubbles via XDSChatMessageTokenizedText',
+    'Tokenized text rendering in message bubbles via XDSChatTokenizedText',
     'XDSSearchSource integration — reuses Typeahead search sources',
     'Concentric radius — inner elements follow outer shell curvature',
     'Themeable via --composer-radius and --composer-padding CSS vars',
@@ -180,14 +180,14 @@ export const docs = {
       ],
     },
     {
-      name: 'XDSChatMessageTokenizedText',
+      name: 'XDSChatTokenizedText',
       description: 'Renders text with token patterns replaced by inline XDSBadge components. Use inside XDSChatMessageBubble to display @mentions or other tokens as styled badges.',
       props: [
         {name: 'children', type: 'string', description: 'The message text containing token patterns.', required: true},
         {name: 'tokens', type: 'XDSChatMessageTokenConfig[]', description: 'Token definitions. Each has pattern (string to match), label (display text), and optional variant.'},
       ],
       examples: [
-        {label: 'With mentions', code: `<XDSChatMessageBubble>\n  <XDSChatMessageTokenizedText\n    tokens={[{pattern: '@cindy', label: '@Cindy Zhang', variant: 'blue'}]}\n  >\n    Hey @cindy, can you review this?\n  </XDSChatMessageTokenizedText>\n</XDSChatMessageBubble>`},
+        {label: 'With mentions', code: `<XDSChatMessageBubble>\n  <XDSChatTokenizedText\n    tokens={[{pattern: '@cindy', label: '@Cindy Zhang', variant: 'blue'}]}\n  >\n    Hey @cindy, can you review this?\n  </XDSChatTokenizedText>\n</XDSChatMessageBubble>`},
       ],
     },
   ],
@@ -231,7 +231,7 @@ export const docsZh = {
     '编写器布局外壳，具有命名语义插槽',
     'ContentEditable 输入框，支持 @ 提及和 / 命令触发菜单',
     'ComposerInput 命令式句柄，支持编程式插入标记/文本',
-    '通过 XDSChatMessageTokenizedText 在消息气泡中渲染标记文本',
+    '通过 XDSChatTokenizedText 在消息气泡中渲染标记文本',
     'XDSSearchSource 集成 — 复用 Typeahead 搜索源',
     '同心圆角 — 内部元素跟随外部外壳曲率',
     '通过 --composer-radius 和 --composer-padding CSS 变量实现主题化',
@@ -332,7 +332,7 @@ export const docsZh = {
       },
     },
     {
-name: 'XDSChatMessageTokenizedText',
+name: 'XDSChatTokenizedText',
       description: '渲染带有标记模式的文本，将匹配的模式替换为内联 XDSBadge 组件。在 XDSChatMessageBubble 内使用，以徽章样式显示 @提及或其他标记。',
       propDescriptions: {
         children: '包含标记模式的消息文本。',
@@ -369,7 +369,7 @@ export const docsDense = {
     'composer layout shell w/ named semantic slots',
     'ContentEditable input w/ @ mention + / command trigger menus',
     'imperative handle on ComposerInput for programmatic token/text insert',
-    'tokenized text rendering in msg bubbles via XDSChatMessageTokenizedText',
+    'tokenized text rendering in msg bubbles via XDSChatTokenizedText',
     'XDSSearchSource integration; reuses Typeahead search sources',
     'concentric radius; inner elements follow outer shell curvature',
     'themeable via --composer-radius + --composer-padding CSS vars',
@@ -470,7 +470,7 @@ export const docsDense = {
       },
     },
     {
-name: 'XDSChatMessageTokenizedText',
+name: 'XDSChatTokenizedText',
       description: 'renders text w/ token patterns replaced by inline badges; use in bubble for @mentions',
       propDescriptions: {
         children: 'msg text w/ token patterns',

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -199,14 +199,16 @@ export const docs = {
 // Append XDSChatLayout to all doc variants
 const chatLayoutComponent = {
   name: 'XDSChatLayout',
-  description: 'Layout shell for full chat interfaces. Messages flow in normal page flow, composer is fixed to the bottom with a frosted glass dock. Adapts spacing via container width observation.',
+  description: 'Layout shell for full chat interfaces. Messages flow in normal page flow, composer is fixed to the bottom with a frosted glass dock. Adapts spacing via container width observation. By default the layout root is the scroll container; pass scrollRef to delegate scrolling to a parent element or the document body.',
   props: [
     {name: 'children', type: 'ReactNode', description: 'Message content — flows naturally in the page, scrolls with the page.', required: true},
     {name: 'composer', type: 'ReactNode', description: 'Composer element fixed to the bottom with frosted glass dock.', required: true},
     {name: 'emptyState', type: 'ReactNode', description: 'Content shown when children is empty.'},
+    {name: 'scrollRef', type: 'React.RefObject<HTMLElement | null>', description: 'External scroll container ref. When provided, auto-scroll and scroll-to-bottom target this element instead of the layout root. Use when the chat is embedded in a page where a parent element or the document body scrolls.'},
   ],
   examples: [
-    {label: 'Basic', code: `<XDSChatLayout composer={<XDSChatComposer onSubmit={handleSubmit} />}>\n  {messages.map(msg => <XDSChatMessage key={msg.id} {...msg} />)}\n</XDSChatLayout>`},
+    {label: 'Basic (self-scrolling)', code: `<XDSChatLayout composer={<XDSChatComposer onSubmit={handleSubmit} />}>\n  {messages.map(msg => <XDSChatMessage key={msg.id} {...msg} />)}\n</XDSChatLayout>`},
+    {label: 'Page body scrolling', code: `const scrollRef = useRef(document.documentElement);\n<XDSChatLayout scrollRef={scrollRef} composer={<XDSChatComposer onSubmit={handleSubmit} />}>\n  {messages.map(msg => <XDSChatMessage key={msg.id} {...msg} />)}\n</XDSChatLayout>`},
   ],
 };
 docs.components.push(chatLayoutComponent);
@@ -339,11 +341,12 @@ name: 'XDSChatMessageTokenizedText',
     },
     {
       name: 'XDSChatLayout',
-      description: '完整聊天界面的布局外壳。消息在页面中自然流动，编写器固定在底部，带有毛玻璃效果。',
+      description: '完整聊天界面的布局外壳。消息在页面中自然流动，编写器固定在底部，带有毛玻璃效果。默认布局根元素为滚动容器；传入 scrollRef 可将滚动委托给父元素或文档主体。',
       propDescriptions: {
         children: '消息内容，在页面中自然流动，随页面滚动。',
         composer: '固定在底部的编写器元素，带有毛玻璃底座。',
         emptyState: '子元素为空时显示的内容。',
+        scrollRef: '外部滚动容器引用。提供时，自动滚动和滚动到底部将目标指向此元素。',
       },
     },
   ],
@@ -476,11 +479,12 @@ name: 'XDSChatMessageTokenizedText',
     },
     {
       name: 'XDSChatLayout',
-      description: 'layout shell for full chat; msgs in page flow, composer fixed bottom w/ frosted glass dock',
+      description: 'layout shell for full chat; msgs in page flow, composer fixed bottom w/ frosted glass dock; scrollRef delegates scrolling to parent/body',
       propDescriptions: {
         children: 'msg content; flows in page, scrolls w/ page',
         composer: 'composer element; fixed bottom w/ frosted glass',
         emptyState: 'content when children empty',
+        scrollRef: 'external scroll container ref; targets parent/body instead of layout root',
       },
     },
   ],

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -62,11 +62,9 @@ export const docs = {
   components: [
     {
       name: 'XDSChatMessageList',
-      description: 'Scrollable message container with auto-scroll and infinite scroll support.',
+      description: 'Presentational message container with density context and infinite scroll support. Auto-scroll is owned by XDSChatLayout.',
       props: [
         {name: 'children', type: 'ReactNode', description: 'Message elements — typically XDSChatMessage or XDSChatSystemMessage.', required: true},
-        {name: 'hasAutoScroll', type: 'boolean', description: 'Enables auto-scroll to bottom on new content when near the bottom.', default: 'true'},
-        {name: 'scrollThreshold', type: 'number', description: 'Distance from bottom (px) within which new content triggers auto-scroll.', default: '50'},
         {name: 'emptyState', type: 'ReactNode', description: 'Content shown when the list has no messages.'},
         {name: 'onScrollToTopAction', type: '() => Promise<void>', description: 'Async action fired when user scrolls to top. Use for loading older messages.'},
         {name: 'density', type: "'compact' | 'balanced' | 'spacious'", description: 'Visual density — flows to child messages via context.', default: "'balanced'"},
@@ -205,6 +203,8 @@ const chatLayoutComponent = {
     {name: 'composer', type: 'ReactNode', description: 'Composer element fixed to the bottom with frosted glass dock.', required: true},
     {name: 'emptyState', type: 'ReactNode', description: 'Content shown when children is empty.'},
     {name: 'scrollRef', type: 'React.RefObject<HTMLElement | null>', description: 'External scroll container ref. When provided, auto-scroll and scroll-to-bottom target this element instead of the layout root. Use when the chat is embedded in a page where a parent element or the document body scrolls.'},
+    {name: 'hasAutoScroll', type: 'boolean', description: 'Whether auto-scroll behavior is enabled.', default: 'true'},
+    {name: 'newMessagesLabel', type: 'string', description: 'Label shown in the scroll-to-bottom button when new messages arrive.', default: "'New messages'"},
   ],
   examples: [
     {label: 'Basic (self-scrolling)', code: `<XDSChatLayout composer={<XDSChatComposer onSubmit={handleSubmit} />}>\n  {messages.map(msg => <XDSChatMessage key={msg.id} {...msg} />)}\n</XDSChatLayout>`},
@@ -239,11 +239,9 @@ export const docsZh = {
   components: [
     {
       name: 'XDSChatMessageList',
-      description: '可滚动的消息容器，支持自动滚动和无限滚动。',
+      description: '消息展示容器，支持密度上下文和无限滚动。自动滚动由 XDSChatLayout 管理。',
       propDescriptions: {
         children: '消息元素，通常是 XDSChatMessage 或 XDSChatSystemMessage。',
-        hasAutoScroll: '在接近底部时，新内容触发自动滚动到底部。',
-        scrollThreshold: '距底部的距离（像素），在此范围内新内容触发自动滚动。',
         emptyState: '列表无消息时显示的内容。',
         onScrollToTopAction: '用户滚动到顶部时触发的异步操作。用于加载更早的消息。',
         density: '视觉密度，通过上下文传递给子消息。',
@@ -377,11 +375,9 @@ export const docsDense = {
   components: [
     {
       name: 'XDSChatMessageList',
-      description: 'scrollable msg container w/ auto-scroll + infinite scroll',
+      description: 'presentational msg container w/ density context + infinite scroll; auto-scroll owned by XDSChatLayout',
       propDescriptions: {
         children: 'msg elements (XDSChatMessage or XDSChatSystemMessage)',
-        hasAutoScroll: 'auto-scroll to bottom on new content near bottom',
-        scrollThreshold: 'px from bottom to trigger auto-scroll',
         emptyState: 'content when no msgs',
         onScrollToTopAction: 'async action at scroll top; load older msgs',
         density: 'visual density; flows to children via context',

--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -161,7 +161,6 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
     marginInlineStart: 'auto',
-    minWidth: '80px',
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/Chat/XDSChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/XDSChatComposerInput.test.tsx
@@ -247,6 +247,104 @@ describe('XDSChatComposerInput', () => {
     });
   });
 
+  describe('token backspace handling', () => {
+    it('removes token and trailing NBSP on backspace', () => {
+      let handle: XDSChatComposerInputHandle | null = null;
+      const onChange = vi.fn();
+      render(
+        <XDSChatComposerInput
+          ref={h => {
+            handle = h;
+          }}
+          onChange={onChange}
+        />,
+      );
+      const textbox = screen.getByRole('textbox');
+
+      // Focus and set a collapsed selection so insertToken has a valid range
+      textbox.focus();
+      const sel = window.getSelection()!;
+      const range = document.createRange();
+      range.selectNodeContents(textbox);
+      range.collapse(false);
+      sel.removeAllRanges();
+      sel.addRange(range);
+
+      // Insert a token programmatically
+      handle!.insertToken({
+        value: '@sam',
+        label: '@Sam Rivera',
+        variant: 'blue' as const,
+      });
+      fireEvent.input(textbox);
+
+      // The DOM should have a token span + trailing NBSP
+      const tokenSpan = textbox.querySelector('[data-xds-token]');
+      expect(tokenSpan).toBeInTheDocument();
+
+      const nbsp = tokenSpan!.nextSibling;
+      expect(nbsp).toBeTruthy();
+      expect(nbsp!.textContent).toBe('\u00A0');
+
+      // Position cursor at end of NBSP text node
+      const r2 = document.createRange();
+      r2.setStart(nbsp!, 1);
+      r2.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(r2);
+
+      // Fire backspace
+      fireEvent.keyDown(textbox, {key: 'Backspace'});
+
+      // Both the NBSP and the token should be removed
+      expect(textbox.querySelector('[data-xds-token]')).toBeNull();
+    });
+
+    it('serializes to empty after token backspace', () => {
+      let handle: XDSChatComposerInputHandle | null = null;
+      const onChange = vi.fn();
+      render(
+        <XDSChatComposerInput
+          ref={h => {
+            handle = h;
+          }}
+          onChange={onChange}
+        />,
+      );
+      const textbox = screen.getByRole('textbox');
+
+      // Focus and set selection
+      textbox.focus();
+      const sel = window.getSelection()!;
+      const range = document.createRange();
+      range.selectNodeContents(textbox);
+      range.collapse(false);
+      sel.removeAllRanges();
+      sel.addRange(range);
+
+      handle!.insertToken({
+        value: '@sam',
+        label: '@Sam Rivera',
+        variant: 'blue' as const,
+      });
+      fireEvent.input(textbox);
+
+      const tokenSpan = textbox.querySelector('[data-xds-token]')!;
+      const nbsp = tokenSpan.nextSibling!;
+
+      // Position cursor in the NBSP
+      const r2 = document.createRange();
+      r2.setStart(nbsp, 1);
+      r2.collapse(true);
+      sel.removeAllRanges();
+      sel.addRange(r2);
+
+      // Backspace should remove token + NBSP and fire onChange
+      fireEvent.keyDown(textbox, {key: 'Backspace'});
+      expect(onChange).toHaveBeenLastCalledWith('');
+    });
+  });
+
   describe('xds class names', () => {
     it('has xds-chat-composer-input class', () => {
       const {container} = render(<XDSChatComposerInput />);

--- a/packages/core/src/Chat/XDSChatComposerInput.tsx
+++ b/packages/core/src/Chat/XDSChatComposerInput.tsx
@@ -410,6 +410,47 @@ export function XDSChatComposerInput(props: XDSChatComposerInputProps) {
         return;
       }
 
+      // Handle Backspace near tokens — prevent browser from creating
+      // stray <br> elements or moving the cursor unexpectedly.
+      if (e.key === 'Backspace') {
+        const selection = window.getSelection();
+        if (selection && selection.isCollapsed && selection.rangeCount > 0) {
+          const range = selection.getRangeAt(0);
+          const {startContainer, startOffset} = range;
+
+          // Case 1: Cursor is in a text node right after a token.
+          // If the text node is just the trailing NBSP, remove it
+          // and place cursor after the token.
+          if (
+            startContainer.nodeType === Node.TEXT_NODE &&
+            startOffset === 0 &&
+            startContainer.previousSibling instanceof HTMLElement &&
+            startContainer.previousSibling.hasAttribute('data-xds-token')
+          ) {
+            // Cursor is at start of text node right after a token — let
+            // the browser handle it normally (it will select/delete the token)
+          } else if (
+            startContainer.nodeType === Node.TEXT_NODE &&
+            startContainer.textContent === ' ' &&
+            startOffset <= 1 &&
+            startContainer.previousSibling instanceof HTMLElement &&
+            startContainer.previousSibling.hasAttribute('data-xds-token')
+          ) {
+            // Cursor is in or after the trailing NBSP — remove the NBSP
+            // and the token in one action
+            e.preventDefault();
+            const tokenSpan = startContainer.previousSibling;
+            const parent = startContainer.parentNode;
+            if (parent) {
+              parent.removeChild(startContainer);
+              parent.removeChild(tokenSpan);
+            }
+            emitChange();
+            return;
+          }
+        }
+      }
+
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
         if (!editableRef.current) return;

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -62,6 +62,8 @@ export function useXDSChatComposerContext(): XDSChatComposerContextValue | null 
 export interface XDSChatLayoutContextValue {
   /** Ref to the scrollable container element that wraps the message area. */
   scrollContainerRef: React.RefObject<HTMLElement | null>;
+  /** Callback ref for the message list content element — layout observes it for size changes. */
+  contentRef: (el: HTMLElement | null) => void;
 }
 
 export const XDSChatLayoutContext =

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -64,6 +64,8 @@ export interface XDSChatLayoutContextValue {
   scrollContainerRef: React.RefObject<HTMLElement | null>;
   /** Height of the composer dock in px. Used to offset the scroll-to-bottom button. */
   dockHeight: number;
+  /** Ref callback for the message list content area — layout observes it for height changes. */
+  contentRef: (el: HTMLElement | null) => void;
 }
 
 export const XDSChatLayoutContext =

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -62,8 +62,6 @@ export function useXDSChatComposerContext(): XDSChatComposerContextValue | null 
 export interface XDSChatLayoutContextValue {
   /** Ref to the scrollable container element that wraps the message area. */
   scrollContainerRef: React.RefObject<HTMLElement | null>;
-  /** Height of the composer dock in px. Used to offset the scroll-to-bottom button. */
-  dockHeight: number;
   /** Ref callback for the message list content area — layout observes it for height changes. */
   contentRef: (el: HTMLElement | null) => void;
 }

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -62,8 +62,6 @@ export function useXDSChatComposerContext(): XDSChatComposerContextValue | null 
 export interface XDSChatLayoutContextValue {
   /** Ref to the scrollable container element that wraps the message area. */
   scrollContainerRef: React.RefObject<HTMLElement | null>;
-  /** Ref callback for the message list content area — layout observes it for height changes. */
-  contentRef: (el: HTMLElement | null) => void;
 }
 
 export const XDSChatLayoutContext =

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -54,3 +54,19 @@ export const XDSChatComposerContext =
 export function useXDSChatComposerContext(): XDSChatComposerContextValue | null {
   return useContext(XDSChatComposerContext);
 }
+
+// =============================================================================
+// Layout context — shared between XDSChatLayout and XDSChatMessageList
+// =============================================================================
+
+export interface XDSChatLayoutContextValue {
+  /** Ref to the scrollable container element that wraps the message area. */
+  scrollContainerRef: React.RefObject<HTMLElement | null>;
+}
+
+export const XDSChatLayoutContext =
+  createContext<XDSChatLayoutContextValue | null>(null);
+
+export function useXDSChatLayoutContext(): XDSChatLayoutContextValue | null {
+  return useContext(XDSChatLayoutContext);
+}

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -62,6 +62,8 @@ export function useXDSChatComposerContext(): XDSChatComposerContextValue | null 
 export interface XDSChatLayoutContextValue {
   /** Ref to the scrollable container element that wraps the message area. */
   scrollContainerRef: React.RefObject<HTMLElement | null>;
+  /** Height of the composer dock in px. Used to offset the scroll-to-bottom button. */
+  dockHeight: number;
 }
 
 export const XDSChatLayoutContext =

--- a/packages/core/src/Chat/XDSChatLayout.test.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.test.tsx
@@ -88,4 +88,14 @@ describe('XDSChatLayout', () => {
     );
     expect(screen.getByTestId('my-layout')).toBeTruthy();
   });
+
+  it('renders scroll-to-bottom button', () => {
+    render(
+      <XDSChatLayout composer={<div>composer</div>}>
+        <div>msg</div>
+      </XDSChatLayout>,
+    );
+    const button = screen.getByRole('button', {name: /Scroll to bottom/});
+    expect(button).toBeTruthy();
+  });
 });

--- a/packages/core/src/Chat/XDSChatLayout.test.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.test.tsx
@@ -1,0 +1,91 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {XDSChatLayout} from './XDSChatLayout';
+
+class FakeResizeObserver {
+  callback: ResizeObserverCallback;
+  constructor(cb: ResizeObserverCallback) {
+    this.callback = cb;
+  }
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+beforeEach(() => {
+  vi.stubGlobal('ResizeObserver', FakeResizeObserver);
+});
+
+describe('XDSChatLayout', () => {
+  it('renders children', () => {
+    render(
+      <XDSChatLayout composer={<div>composer</div>}>
+        <div>Hello message</div>
+      </XDSChatLayout>,
+    );
+    expect(screen.getByText('Hello message')).toBeTruthy();
+  });
+
+  it('renders composer in fixed dock', () => {
+    render(
+      <XDSChatLayout composer={<div data-testid="composer">Compose</div>}>
+        <div>msg</div>
+      </XDSChatLayout>,
+    );
+    const composer = screen.getByTestId('composer');
+    expect(composer).toBeTruthy();
+    // The dock (parent of the composer's wrapper) should have position: fixed
+    const dock = composer.parentElement?.parentElement;
+    expect(dock).toBeTruthy();
+    const dockStyle = window.getComputedStyle(dock!);
+    // StyleX applies classes, so check the element exists in the DOM structure
+    expect(dock?.tagName).toBe('DIV');
+  });
+
+  it('renders empty state when children is empty', () => {
+    render(
+      <XDSChatLayout
+        composer={<div>composer</div>}
+        emptyState={<div>No messages yet</div>}>
+        {[]}
+      </XDSChatLayout>,
+    );
+    expect(screen.getByText('No messages yet')).toBeTruthy();
+  });
+
+  it('does not render empty state when children exist', () => {
+    render(
+      <XDSChatLayout
+        composer={<div>composer</div>}
+        emptyState={<div>No messages yet</div>}>
+        <div>A message</div>
+      </XDSChatLayout>,
+    );
+    expect(screen.getByText('A message')).toBeTruthy();
+    expect(screen.queryByText('No messages yet')).toBeNull();
+  });
+
+  it('has container-type on root', () => {
+    render(
+      <XDSChatLayout
+        composer={<div>composer</div>}
+        data-testid="layout-root">
+        <div>msg</div>
+      </XDSChatLayout>,
+    );
+    const root = screen.getByTestId('layout-root');
+    expect(root).toBeTruthy();
+    expect(root.className).toContain('xds-chat-layout');
+  });
+
+  it('applies data-testid', () => {
+    render(
+      <XDSChatLayout
+        composer={<div>composer</div>}
+        data-testid="my-layout">
+        <div>msg</div>
+      </XDSChatLayout>,
+    );
+    expect(screen.getByTestId('my-layout')).toBeTruthy();
+  });
+});

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -225,25 +225,27 @@ const styles = stylex.create({
   },
 
   // --- Scroll-to-bottom button ---
-  scrollButtonContainer: {
+  // Wrapper centers the button horizontally without affecting layout flow.
+  scrollButtonWrapper: {
     position: 'sticky',
     bottom: spacingVars['--spacing-3'],
-    left: '50%',
+    zIndex: 3,
+    display: 'flex',
+    justifyContent: 'center',
+    pointerEvents: 'none',
+    height: 0,
+  },
+  scrollButtonContainer: {
+    pointerEvents: 'auto',
     contain: 'layout style',
     overflow: 'hidden',
     borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-background-popover'],
     boxShadow: shadowVars['--shadow-med'],
     height: '32px',
-    zIndex: 3,
     transitionProperty: 'opacity, transform, max-width',
     transitionTimingFunction: easeVars['--ease-standard'],
     transitionDuration: durationVars['--duration-fast-max'],
-    // Pull out of flow so it doesn't affect message area height
-    float: 'right',
-    clear: 'both',
-    transform: 'translateX(-50%)',
-    marginBlockStart: '-44px',
   },
   scrollButtonContainerHidden: {
     opacity: 0,
@@ -304,26 +306,29 @@ function ScrollToBottomButton({
 
   return (
     <div
-      {...stylex.props(
-        styles.scrollButtonContainer,
-        isVisible
-          ? styles.scrollButtonContainerVisible
-          : styles.scrollButtonContainerHidden,
-        hasNewMessages
-          ? styles.scrollButtonExpanded
-          : styles.scrollButtonCollapsed,
-      )}
+      {...stylex.props(styles.scrollButtonWrapper)}
       style={{bottom: dockHeight + 12}}>
-      <XDSButton
-        label={hasNewMessages ? label : 'Scroll to bottom'}
-        aria-label={hasNewMessages ? label : 'Scroll to bottom'}
-        icon={<XDSIcon icon="chevronDown" size="md" />}
-        variant="ghost"
-        size="md"
-        onClick={onClick}
-        xstyle={styles.scrollButton}>
-        {hasNewMessages ? label : undefined}
-      </XDSButton>
+      <div
+        {...stylex.props(
+          styles.scrollButtonContainer,
+          isVisible
+            ? styles.scrollButtonContainerVisible
+            : styles.scrollButtonContainerHidden,
+          hasNewMessages
+            ? styles.scrollButtonExpanded
+            : styles.scrollButtonCollapsed,
+        )}>
+        <XDSButton
+          label={hasNewMessages ? label : 'Scroll to bottom'}
+          aria-label={hasNewMessages ? label : 'Scroll to bottom'}
+          icon={<XDSIcon icon="chevronDown" size="md" />}
+          variant="ghost"
+          size="md"
+          onClick={onClick}
+          xstyle={styles.scrollButton}>
+          {hasNewMessages ? label : undefined}
+        </XDSButton>
+      </div>
     </div>
   );
 }
@@ -541,7 +546,7 @@ export function XDSChatLayout({
         {/* Message area */}
         <div
           {...stylex.props(styles.messageArea, messageAreaStyle)}
-          style={{paddingBlockEnd: dockHeight + 24}}>
+>
           {showEmpty && emptyState ? (
             <div {...stylex.props(styles.emptyState)}>{emptyState}</div>
           ) : (

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -388,6 +388,7 @@ export function XDSChatLayout({
     scrollToBottom,
     dismissNewMessages,
     onContentChange,
+    scrollToBottomIfNearBottom,
   } = useAutoScroll({
     enabled: hasAutoScroll,
     scrollContainerRef,
@@ -411,6 +412,11 @@ export function XDSChatLayout({
   }, []);
 
   // Content ref callback — observe the message list for height changes.
+  // Two behaviors:
+  // - New message appended (last element changed) → onContentChange
+  //   (auto-scrolls if near bottom, shows "new messages" if scrolled up)
+  // - Existing message growing (streaming) → just auto-scroll if near
+  //   bottom, but don't flag "new messages"
   const contentRef = useCallback(
     (el: HTMLElement | null) => {
       if (contentObserverRef.current) {
@@ -424,15 +430,20 @@ export function XDSChatLayout({
           const last =
             messages.length > 0 ? messages[messages.length - 1] : null;
           if (last && last !== lastMessageRef.current) {
+            // New message — auto-scroll or show "new messages"
             lastMessageRef.current = last;
             onContentChange();
+          } else {
+            // Existing content growing (streaming) — auto-scroll only,
+            // don't flag "new messages"
+            scrollToBottomIfNearBottom();
           }
         });
         observer.observe(el);
         contentObserverRef.current = observer;
       }
     },
-    [onContentChange],
+    [onContentChange, scrollToBottomIfNearBottom],
   );
 
   // --- Layout context ---

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -158,13 +158,7 @@ const styles = stylex.create({
     backdropFilter: 'blur(12px)',
     WebkitBackdropFilter: 'blur(12px)',
   },
-  blurLayerFixed: {
-    position: 'fixed',
-  },
-  blurLayerAbsolute: {
-    position: 'sticky',
-    marginBlockStart: 'auto',
-  },
+
   blurLayerCompact: {
     height: 80,
     maskImage: 'linear-gradient(to bottom, transparent, black 24px)',
@@ -188,10 +182,11 @@ const styles = stylex.create({
     right: 0,
     zIndex: 2,
   },
-  dockFixed: {
+  // Shared position modes for dock + blur layer
+  positionFixed: {
     position: 'fixed',
   },
-  dockSticky: {
+  positionSticky: {
     position: 'sticky',
   },
   dockCompact: {
@@ -559,7 +554,7 @@ export function XDSChatLayout({
         <div
           {...stylex.props(
             styles.blurLayer,
-            isSelfScrolling ? styles.blurLayerAbsolute : styles.blurLayerFixed,
+            isSelfScrolling ? styles.positionSticky : styles.positionFixed,
             blurLayerStyle,
           )}
         />
@@ -569,7 +564,7 @@ export function XDSChatLayout({
           ref={dockRef}
           {...stylex.props(
             styles.dock,
-            isSelfScrolling ? styles.dockSticky : styles.dockFixed,
+            isSelfScrolling ? styles.positionSticky : styles.positionFixed,
             dockStyle,
           )}>
           <div {...stylex.props(styles.dockInner, dockInnerStyle)}>

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -385,7 +385,7 @@ export function XDSChatLayout({
     isScrolledUp,
     hasNewMessages,
     handleScroll,
-    handleUserScroll,
+    handleScrollEnd,
     scrollToBottom,
     dismissNewMessages,
     onContentChange,
@@ -474,12 +474,10 @@ export function XDSChatLayout({
         const scrollEl = scrollRef.current;
         if (scrollEl) {
           scrollEl.addEventListener('scroll', handleScroll, {passive: true});
-          scrollEl.addEventListener('wheel', handleUserScroll, {passive: true});
-          scrollEl.addEventListener('touchmove', handleUserScroll, {passive: true});
+          scrollEl.addEventListener('scrollend', handleScrollEnd);
           scrollListenerRef.current = () => {
             scrollEl.removeEventListener('scroll', handleScroll);
-            scrollEl.removeEventListener('wheel', handleUserScroll);
-            scrollEl.removeEventListener('touchmove', handleUserScroll);
+            scrollEl.removeEventListener('scrollend', handleScrollEnd);
           };
           // Defer to next frame so content has laid out
           requestAnimationFrame(() => scrollToBottom(false));
@@ -492,7 +490,7 @@ export function XDSChatLayout({
         (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
       }
     },
-    [ref, scrollRef, handleScroll, handleUserScroll, scrollToBottom],
+    [ref, scrollRef, handleScroll, handleScrollEnd, scrollToBottom],
   );
 
   // --- Scroll button handler ---

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -149,12 +149,27 @@ const styles = stylex.create({
     minHeight: 200,
   },
 
-  // --- Blur layer ---
-  blurLayer: {
+  // --- Dock container — holds blur layer + composer as siblings ---
+  dockContainer: {
     bottom: 0,
     left: 0,
     right: 0,
-    zIndex: 1,
+    zIndex: 0,
+    isolation: 'isolate',
+  },
+  dockContainerFixed: {
+    position: 'fixed',
+  },
+  dockContainerSticky: {
+    position: 'sticky',
+  },
+
+  // --- Blur layer (absolute within dock container) ---
+  blurLayer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
     pointerEvents: 'none',
     backdropFilter: 'blur(12px)',
     WebkitBackdropFilter: 'blur(12px)',
@@ -181,13 +196,7 @@ const styles = stylex.create({
     position: 'relative',
     zIndex: 1,
   },
-  // Shared position modes for dock + blur layer
-  positionFixed: {
-    position: 'fixed',
-  },
-  positionSticky: {
-    position: 'sticky',
-  },
+
   dockCompact: {
     paddingInline: spacingVars['--spacing-2'],
     paddingBlockEnd: spacingVars['--spacing-2'],

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -157,6 +157,7 @@ const styles = stylex.create({
     right: 0,
     zIndex: 0,
     isolation: 'isolate',
+    pointerEvents: 'none',
   },
   dockContainerFixed: {
     position: 'fixed',
@@ -196,6 +197,7 @@ const styles = stylex.create({
   dock: {
     position: 'relative',
     zIndex: 1,
+    pointerEvents: 'auto',
   },
 
   dockCompact: {
@@ -226,15 +228,11 @@ const styles = stylex.create({
   },
 
   // --- Scroll-to-bottom button ---
-  // Wrapper centers the button horizontally without affecting layout flow.
+  // Wrapper centers the button above the composer inside the dock container.
   scrollButtonWrapper: {
-    position: 'sticky',
-    bottom: spacingVars['--spacing-3'],
-    zIndex: 3,
     display: 'flex',
     justifyContent: 'center',
-    pointerEvents: 'none',
-    height: 0,
+    paddingBlockEnd: spacingVars['--spacing-3'],
   },
   scrollButtonContainer: {
     pointerEvents: 'auto',
@@ -533,15 +531,7 @@ export function XDSChatLayout({
           )}
         </div>
 
-        {/* Scroll-to-bottom button */}
-        <ScrollToBottomButton
-          isScrolledUp={isScrolledUp}
-          hasNewMessages={hasNewMessages}
-          label={newMessagesLabel}
-          onClick={handleButtonClick}
-        />
-
-        {/* Dock container — sticky/fixed, holds blur + composer */}
+        {/* Dock container — sticky/fixed, holds blur + scroll button + composer */}
         <div
           ref={dockRef}
           {...stylex.props(
@@ -552,6 +542,14 @@ export function XDSChatLayout({
           )}>
           {/* Frosted glass layer — behind composer */}
           <div {...stylex.props(styles.blurLayer, blurLayerStyle)} />
+
+          {/* Scroll-to-bottom button */}
+          <ScrollToBottomButton
+            isScrolledUp={isScrolledUp}
+            hasNewMessages={hasNewMessages}
+            label={newMessagesLabel}
+            onClick={handleButtonClick}
+          />
 
           {/* Composer */}
           <div {...stylex.props(styles.dock, dockStyle)}>

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -388,7 +388,7 @@ export function XDSChatLayout({
     scrollToBottom,
     dismissNewMessages,
     onContentChange,
-    scrollToBottomIfNearBottom,
+    scrollToBottomIfLocked,
   } = useAutoScroll({
     enabled: hasAutoScroll,
     scrollContainerRef,
@@ -436,14 +436,14 @@ export function XDSChatLayout({
           } else {
             // Existing content growing (streaming) — auto-scroll only,
             // don't flag "new messages"
-            scrollToBottomIfNearBottom();
+            scrollToBottomIfLocked();
           }
         });
         observer.observe(el);
         contentObserverRef.current = observer;
       }
     },
-    [onContentChange, scrollToBottomIfNearBottom],
+    [onContentChange, scrollToBottomIfLocked],
   );
 
   // --- Layout context ---

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+/**
+ * @file XDSChatLayout.tsx
+ * @input Uses React, StyleX, theme tokens, XDSChatMessageList
+ * @output Exports XDSChatLayout component and XDSChatLayoutProps
+ * @position Layout shell for full chat interfaces — messages in page flow, composer fixed to bottom
+ *
+ * Arranges a chat page: messages flow naturally in the page, composer is
+ * fixed to the bottom with a frosted glass backdrop. Uses a ResizeObserver
+ * to adapt spacing for narrow (panel/mobile) vs wide (desktop) containers.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Chat/index.ts (exports)
+ * - /apps/storybook/stories/ChatLayout.stories.tsx
+ */
+
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {xdsClassName, mergeProps} from '../utils';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type Density = 'compact' | 'balanced' | 'spacious';
+
+export interface XDSChatLayoutProps {
+  /** Ref forwarded to the root element. */
+  ref?: React.Ref<HTMLDivElement>;
+
+  /**
+   * Message content — flows naturally in the page, scrolls with the page.
+   * Typically XDSChatMessage components.
+   */
+  children: ReactNode;
+
+  /**
+   * Composer element — fixed to the bottom with a frosted glass dock.
+   * Typically XDSChatComposer.
+   */
+  composer: ReactNode;
+
+  /**
+   * Content shown when children is empty.
+   */
+  emptyState?: ReactNode;
+
+  /** StyleX overrides. */
+  xstyle?: StyleXStyles;
+  /** CSS class name(s) appended to the root element. */
+  className?: string;
+  /** Inline styles. */
+  style?: React.CSSProperties;
+  /** Test ID. */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    position: 'relative',
+    containerType: 'inline-size',
+    minHeight: 0,
+  },
+
+  // --- Message area ---
+  messageArea: {
+    // Normal page flow, not in a scroll container
+    display: 'flex',
+    flexDirection: 'column',
+    marginInline: 'auto',
+  },
+
+  // Message area max-width per density
+  messageAreaCompact: {
+    maxWidth: '100%',
+  },
+  messageAreaBalanced: {
+    maxWidth: '100%',
+  },
+  messageAreaSpacious: {
+    maxWidth: 800,
+    paddingInline: spacingVars['--spacing-4'],
+  },
+
+  // Message area bottom padding to clear the fixed dock
+  messageAreaPadding: {
+    // Will be set dynamically via inline style
+  },
+
+  // --- Empty state ---
+  emptyState: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flex: 1,
+    minHeight: 200,
+  },
+
+  // --- Blur layer — purely visual, behind composer ---
+  blurLayer: {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 1,
+    pointerEvents: 'none',
+    backdropFilter: 'blur(12px)',
+    WebkitBackdropFilter: 'blur(12px)',
+  },
+  blurLayerCompact: {
+    height: 80,
+    maskImage: 'linear-gradient(to bottom, transparent, black 24px)',
+    WebkitMaskImage: 'linear-gradient(to bottom, transparent, black 24px)',
+  },
+  blurLayerBalanced: {
+    height: 100,
+    maskImage: 'linear-gradient(to bottom, transparent, black 36px)',
+    WebkitMaskImage: 'linear-gradient(to bottom, transparent, black 36px)',
+  },
+  blurLayerSpacious: {
+    height: 120,
+    maskImage: 'linear-gradient(to bottom, transparent, black 48px)',
+    WebkitMaskImage: 'linear-gradient(to bottom, transparent, black 48px)',
+  },
+
+  // --- Composer dock — interactive, no blur/mask ---
+  dock: {
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 2,
+  },
+  dockCompact: {
+    paddingInline: spacingVars['--spacing-2'],
+    paddingBlockEnd: spacingVars['--spacing-2'],
+  },
+  dockBalanced: {
+    paddingInline: spacingVars['--spacing-3'],
+    paddingBlockEnd: spacingVars['--spacing-3'],
+  },
+  dockSpacious: {
+    paddingInline: spacingVars['--spacing-4'],
+    paddingBlockEnd: spacingVars['--spacing-3'],
+  },
+
+  // --- Dock inner wrapper (max-width centered) ---
+  dockInner: {
+    marginInline: 'auto',
+  },
+  dockInnerCompact: {
+    maxWidth: '100%',
+  },
+  dockInnerBalanced: {
+    maxWidth: '100%',
+  },
+  dockInnerSpacious: {
+    maxWidth: 800,
+  },
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function getDensity(width: number): Density {
+  if (width < 480) return 'compact';
+  if (width <= 768) return 'balanced';
+  return 'spacious';
+}
+
+function hasContent(children: ReactNode): boolean {
+  if (children == null || children === false) return false;
+  if (Array.isArray(children) && children.length === 0) return false;
+  return true;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Layout shell for full chat interfaces.
+ *
+ * Messages flow naturally in the page (no fixed scroll container).
+ * The composer is fixed to the bottom with a frosted glass dock
+ * that adapts padding via container width observation.
+ *
+ * @example
+ * ```
+ * <XDSChatLayout
+ *   composer={<XDSChatComposer onSubmit={handleSubmit} />}
+ *   emptyState={<EmptyState />}
+ * >
+ *   {messages.map(msg => <XDSChatMessage key={msg.id} {...msg} />)}
+ * </XDSChatLayout>
+ * ```
+ */
+export function XDSChatLayout({
+  children,
+  composer,
+  emptyState,
+  xstyle,
+  className,
+  style,
+  'data-testid': testId,
+  ref,
+}: XDSChatLayoutProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const dockRef = useRef<HTMLDivElement>(null);
+  const [density, setDensity] = useState<Density>('balanced');
+  const [dockHeight, setDockHeight] = useState(0);
+
+  // Observe root width for density breakpoints
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        setDensity(getDensity(entry.contentRect.width));
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Observe dock height to set message area bottom padding
+  useEffect(() => {
+    const el = dockRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry) {
+        setDockHeight(entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height);
+      }
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  // Merge refs
+  const setRootRef = useCallback(
+    (el: HTMLDivElement | null) => {
+      (rootRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+      if (typeof ref === 'function') {
+        ref(el);
+      } else if (ref) {
+        (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
+      }
+    },
+    [ref],
+  );
+
+  const showEmpty = !hasContent(children);
+
+  const messageAreaStyle =
+    density === 'compact'
+      ? styles.messageAreaCompact
+      : density === 'spacious'
+        ? styles.messageAreaSpacious
+        : styles.messageAreaBalanced;
+
+  const blurLayerStyle =
+    density === 'compact'
+      ? styles.blurLayerCompact
+      : density === 'spacious'
+        ? styles.blurLayerSpacious
+        : styles.blurLayerBalanced;
+
+  const dockStyle =
+    density === 'compact'
+      ? styles.dockCompact
+      : density === 'spacious'
+        ? styles.dockSpacious
+        : styles.dockBalanced;
+
+  const dockInnerStyle =
+    density === 'compact'
+      ? styles.dockInnerCompact
+      : density === 'spacious'
+        ? styles.dockInnerSpacious
+        : styles.dockInnerBalanced;
+
+  return (
+    <div
+      ref={setRootRef}
+      data-testid={testId}
+      data-density={density}
+      {...mergeProps(
+        xdsClassName('chat-layout', {density}),
+        stylex.props(styles.root, xstyle),
+        className,
+        style,
+      )}>
+      {/* Message area — normal page flow */}
+      <div
+        {...stylex.props(styles.messageArea, messageAreaStyle)}
+        style={{paddingBlockEnd: dockHeight + 24}}>
+        {showEmpty && emptyState ? (
+          <div {...stylex.props(styles.emptyState)}>{emptyState}</div>
+        ) : (
+          children
+        )}
+      </div>
+
+      {/* Frosted glass layer — behind composer, not interactive */}
+      <div {...stylex.props(styles.blurLayer, blurLayerStyle)} />
+
+      {/* Composer dock — interactive, no blur/mask */}
+      <div ref={dockRef} {...stylex.props(styles.dock, dockStyle)}>
+        <div {...stylex.props(styles.dockInner, dockInnerStyle)}>
+          {composer}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+XDSChatLayout.displayName = 'XDSChatLayout';

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -396,13 +396,21 @@ export function XDSChatLayout({
     return () => el.removeEventListener('scroll', handleScroll);
   }, [scrollRef, handleScroll]);
 
-  // Observe message content area for height changes (new messages, streaming)
+  // Observe message content area — only trigger auto-scroll when the
+  // message count actually grows (not when existing content resizes,
+  // e.g. expanding tool calls or collapsing drawers).
+  const messageCountRef = useRef(0);
+
   useEffect(() => {
     const el = contentElRef.current;
     if (!el) return;
 
     const observer = new ResizeObserver(() => {
-      onContentChange();
+      const count = el.querySelectorAll('.xds-chat-message').length;
+      if (count > messageCountRef.current) {
+        messageCountRef.current = count;
+        onContentChange();
+      }
     });
     observer.observe(el);
     return () => observer.disconnect();

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -178,10 +178,8 @@ const styles = stylex.create({
 
   // --- Composer dock ---
   dock: {
-    bottom: 0,
-    left: 0,
-    right: 0,
-    zIndex: 2,
+    position: 'relative',
+    zIndex: 1,
   },
   // Shared position modes for dock + blur layer
   positionFixed: {
@@ -551,25 +549,23 @@ export function XDSChatLayout({
           dockHeight={dockHeight}
         />
 
-        {/* Frosted glass layer */}
-        <div
-          {...stylex.props(
-            styles.blurLayer,
-            isSelfScrolling ? styles.positionSticky : styles.positionFixed,
-            blurLayerStyle,
-          )}
-        />
-
-        {/* Composer dock */}
+        {/* Dock container — sticky/fixed, holds blur + composer */}
         <div
           ref={dockRef}
           {...stylex.props(
-            styles.dock,
-            isSelfScrolling ? styles.positionSticky : styles.positionFixed,
-            dockStyle,
+            styles.dockContainer,
+            isSelfScrolling
+              ? styles.dockContainerSticky
+              : styles.dockContainerFixed,
           )}>
-          <div {...stylex.props(styles.dockInner, dockInnerStyle)}>
-            {composer}
+          {/* Frosted glass layer — behind composer */}
+          <div {...stylex.props(styles.blurLayer, blurLayerStyle)} />
+
+          {/* Composer */}
+          <div {...stylex.props(styles.dock, dockStyle)}>
+            <div {...stylex.props(styles.dockInner, dockInnerStyle)}>
+              {composer}
+            </div>
           </div>
         </div>
       </div>

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -369,7 +369,7 @@ export function XDSChatLayout({
 }: XDSChatLayoutProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
-  const [contentEl, setContentEl] = useState<HTMLElement | null>(null);
+  const contentElRef = useRef<HTMLElement | null>(null);
 
   const scrollContainerRef =
     externalScrollRef ?? (rootRef as React.RefObject<HTMLElement | null>);
@@ -405,27 +405,37 @@ export function XDSChatLayout({
   // Upward loads (older messages) and content resizes (tool call expand,
   // drawer collapse) don't change the last element.
   const lastMessageRef = useRef<Element | null>(null);
+  const observerRef = useRef<ResizeObserver | null>(null);
 
-  useEffect(() => {
-    if (!contentEl) return;
-
-    const observer = new ResizeObserver(() => {
-      const messages = contentEl.getElementsByClassName('xds-chat-message');
-      const last = messages.length > 0 ? messages[messages.length - 1] : null;
-      if (last && last !== lastMessageRef.current) {
-        lastMessageRef.current = last;
-        onContentChange();
+  // Callback ref — connects/disconnects the ResizeObserver when the
+  // message list registers its content element. Fires synchronously
+  // during render, no effect timing issues.
+  const contentRef = useCallback(
+    (el: HTMLElement | null) => {
+      // Disconnect previous observer
+      if (observerRef.current) {
+        observerRef.current.disconnect();
+        observerRef.current = null;
       }
-    });
-    observer.observe(contentEl);
-    return () => observer.disconnect();
-  }, [contentEl, onContentChange]);
 
-  // Content ref callback — message list registers its inner element.
-  // Uses state (not ref) so the ResizeObserver effect re-runs when set.
-  const contentRef = useCallback((el: HTMLElement | null) => {
-    setContentEl(el);
-  }, []);
+      contentElRef.current = el;
+
+      if (el) {
+        const observer = new ResizeObserver(() => {
+          const messages = el.getElementsByClassName('xds-chat-message');
+          const last =
+            messages.length > 0 ? messages[messages.length - 1] : null;
+          if (last && last !== lastMessageRef.current) {
+            lastMessageRef.current = last;
+            onContentChange();
+          }
+        });
+        observer.observe(el);
+        observerRef.current = observer;
+      }
+    },
+    [onContentChange],
+  );
 
   // --- Layout context ---
   const layoutContextValue = useMemo(

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -399,42 +399,55 @@ export function XDSChatLayout({
     return () => el.removeEventListener('scroll', handleScroll);
   }, [scrollRef, handleScroll]);
 
-  // Observe message content area — only trigger auto-scroll when new
-  // messages appear at the bottom. Tracks the last .xds-chat-message
-  // element by reference. A new last element means content was appended.
-  // Upward loads (older messages) and content resizes (tool call expand,
-  // drawer collapse) don't change the last element.
+  // Single ResizeObserver for both density (root width) and content
+  // changes (new messages). Checks entry.target to dispatch.
   const lastMessageRef = useRef<Element | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
 
-  // Callback ref — connects/disconnects the ResizeObserver when the
-  // message list registers its content element. Fires synchronously
-  // during render, no effect timing issues.
+  const getObserver = useCallback(() => {
+    if (!observerRef.current) {
+      observerRef.current = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          if (entry.target === rootRef.current) {
+            setDensity(getDensity(entry.contentRect.width));
+          } else if (entry.target === contentElRef.current) {
+            const messages =
+              entry.target.getElementsByClassName('xds-chat-message');
+            const last =
+              messages.length > 0 ? messages[messages.length - 1] : null;
+            if (last && last !== lastMessageRef.current) {
+              lastMessageRef.current = last;
+              onContentChange();
+            }
+          }
+        }
+      });
+    }
+    return observerRef.current;
+  }, [onContentChange]);
+
+  // Observe root for density
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const observer = getObserver();
+    observer.observe(el);
+    return () => observer.unobserve(el);
+  }, [getObserver]);
+
+  // Callback ref — observe/unobserve content element for new messages
   const contentRef = useCallback(
     (el: HTMLElement | null) => {
-      // Disconnect previous observer
-      if (observerRef.current) {
-        observerRef.current.disconnect();
-        observerRef.current = null;
+      const observer = getObserver();
+      if (contentElRef.current) {
+        observer.unobserve(contentElRef.current);
       }
-
       contentElRef.current = el;
-
       if (el) {
-        const observer = new ResizeObserver(() => {
-          const messages = el.getElementsByClassName('xds-chat-message');
-          const last =
-            messages.length > 0 ? messages[messages.length - 1] : null;
-          if (last && last !== lastMessageRef.current) {
-            lastMessageRef.current = last;
-            onContentChange();
-          }
-        });
         observer.observe(el);
-        observerRef.current = observer;
       }
     },
-    [onContentChange],
+    [getObserver],
   );
 
   // --- Layout context ---
@@ -446,20 +459,7 @@ export function XDSChatLayout({
     [scrollContainerRef, contentRef],
   );
 
-  // --- Density observation ---
-  useEffect(() => {
-    const el = rootRef.current;
-    if (!el) return;
 
-    const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
-      if (entry) {
-        setDensity(getDensity(entry.contentRect.width));
-      }
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
 
   // --- Merge refs ---
   const setRootRef = useCallback(

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -186,8 +186,8 @@ const styles = stylex.create({
   positionFixed: {
     position: 'fixed',
   },
-  positionSticky: {
-    position: 'sticky',
+  positionAbsolute: {
+    position: 'absolute',
   },
   dockCompact: {
     paddingInline: spacingVars['--spacing-2'],
@@ -554,7 +554,7 @@ export function XDSChatLayout({
         <div
           {...stylex.props(
             styles.blurLayer,
-            isSelfScrolling ? styles.positionSticky : styles.positionFixed,
+            isSelfScrolling ? styles.positionAbsolute : styles.positionFixed,
             blurLayerStyle,
           )}
         />
@@ -564,7 +564,7 @@ export function XDSChatLayout({
           ref={dockRef}
           {...stylex.props(
             styles.dock,
-            isSelfScrolling ? styles.positionSticky : styles.positionFixed,
+            isSelfScrolling ? styles.positionAbsolute : styles.positionFixed,
             dockStyle,
           )}>
           <div {...stylex.props(styles.dockInner, dockInnerStyle)}>

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -266,8 +266,9 @@ export function XDSChatLayout({
   const layoutContextValue = useMemo(
     () => ({
       scrollContainerRef,
+      dockHeight,
     }),
-    [scrollContainerRef],
+    [scrollContainerRef, dockHeight],
   );
   const [density, setDensity] = useState<Density>('balanced');
   const [dockHeight, setDockHeight] = useState(0);

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -369,7 +369,6 @@ export function XDSChatLayout({
 }: XDSChatLayoutProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
-  const contentElRef = useRef<HTMLElement | null>(null);
 
   const scrollContainerRef =
     externalScrollRef ?? (rootRef as React.RefObject<HTMLElement | null>);
@@ -402,62 +401,33 @@ export function XDSChatLayout({
   // Single ResizeObserver for both density (root width) and content
   // changes (new messages). Checks entry.target to dispatch.
   const lastMessageRef = useRef<Element | null>(null);
-  const observerRef = useRef<ResizeObserver | null>(null);
 
-  const getObserver = useCallback(() => {
-    if (!observerRef.current) {
-      observerRef.current = new ResizeObserver(() => {
-        const root = rootRef.current;
-        if (root) {
-          setDensity(getDensity(root.clientWidth));
-        }
-
-        const content = contentElRef.current;
-        if (content) {
-          const messages = content.getElementsByClassName('xds-chat-message');
-          const last =
-            messages.length > 0 ? messages[messages.length - 1] : null;
-          if (last && last !== lastMessageRef.current) {
-            lastMessageRef.current = last;
-            onContentChange();
-          }
-        }
-      });
-    }
-    return observerRef.current;
-  }, [onContentChange]);
-
-  // Observe root for density
+  // Single ResizeObserver on root — handles density + new message detection.
   useEffect(() => {
-    const el = rootRef.current;
-    if (!el) return;
-    const observer = getObserver();
-    observer.observe(el);
-    return () => observer.unobserve(el);
-  }, [getObserver]);
+    const root = rootRef.current;
+    if (!root) return;
 
-  // Callback ref — observe/unobserve content element for new messages
-  const contentRef = useCallback(
-    (el: HTMLElement | null) => {
-      const observer = getObserver();
-      if (contentElRef.current) {
-        observer.unobserve(contentElRef.current);
+    const observer = new ResizeObserver(() => {
+      setDensity(getDensity(root.clientWidth));
+
+      const messages = root.getElementsByClassName('xds-chat-message');
+      const last =
+        messages.length > 0 ? messages[messages.length - 1] : null;
+      if (last && last !== lastMessageRef.current) {
+        lastMessageRef.current = last;
+        onContentChange();
       }
-      contentElRef.current = el;
-      if (el) {
-        observer.observe(el);
-      }
-    },
-    [getObserver],
-  );
+    });
+    observer.observe(root);
+    return () => observer.disconnect();
+  }, [onContentChange]);
 
   // --- Layout context ---
   const layoutContextValue = useMemo(
     () => ({
       scrollContainerRef,
-      contentRef,
     }),
-    [scrollContainerRef, contentRef],
+    [scrollContainerRef],
   );
 
 

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -295,20 +295,17 @@ function ScrollToBottomButton({
   hasNewMessages,
   label,
   onClick,
-  dockHeight,
 }: {
   isScrolledUp: boolean;
   hasNewMessages: boolean;
   label: string;
   onClick: () => void;
-  dockHeight: number;
 }) {
   const isVisible = isScrolledUp || hasNewMessages;
 
   return (
     <div
-      {...stylex.props(styles.scrollButtonWrapper)}
-      style={{bottom: dockHeight + 12}}>
+      {...stylex.props(styles.scrollButtonWrapper)}>
       <div
         {...stylex.props(
           styles.scrollButtonContainer,
@@ -381,7 +378,6 @@ export function XDSChatLayout({
   const isSelfScrolling = !externalScrollRef;
 
   const [density, setDensity] = useState<Density>('balanced');
-  const [dockHeight, setDockHeight] = useState(0);
 
   // --- Auto-scroll ---
   const {
@@ -437,10 +433,9 @@ export function XDSChatLayout({
   const layoutContextValue = useMemo(
     () => ({
       scrollContainerRef,
-      dockHeight,
       contentRef,
     }),
-    [scrollContainerRef, dockHeight, contentRef],
+    [scrollContainerRef, contentRef],
   );
 
   // --- Density observation ---
@@ -452,23 +447,6 @@ export function XDSChatLayout({
       const entry = entries[0];
       if (entry) {
         setDensity(getDensity(entry.contentRect.width));
-      }
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  // --- Dock height observation ---
-  useEffect(() => {
-    const el = dockRef.current;
-    if (!el) return;
-
-    const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
-      if (entry) {
-        setDockHeight(
-          entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height,
-        );
       }
     });
     observer.observe(el);
@@ -561,7 +539,6 @@ export function XDSChatLayout({
           hasNewMessages={hasNewMessages}
           label={newMessagesLabel}
           onClick={handleButtonClick}
-          dockHeight={dockHeight}
         />
 
         {/* Dock container — sticky/fixed, holds blur + composer */}

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -369,6 +369,7 @@ export function XDSChatLayout({
 }: XDSChatLayoutProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
+  const [rootMounted, setRootMounted] = useState(false);
 
   const scrollContainerRef =
     externalScrollRef ?? (rootRef as React.RefObject<HTMLElement | null>);
@@ -390,13 +391,15 @@ export function XDSChatLayout({
     scrollContainerRef,
   });
 
-  // Attach scroll listener to the scroll container
+  // Attach scroll listener to the scroll container.
+  // rootMounted triggers re-run after the ref is populated.
   useEffect(() => {
     const el = scrollRef.current;
     if (!el) return;
     el.addEventListener('scroll', handleScroll, {passive: true});
+    scrollToBottom(false);
     return () => el.removeEventListener('scroll', handleScroll);
-  }, [scrollRef, handleScroll]);
+  }, [scrollRef, handleScroll, rootMounted, scrollToBottom]);
 
   // Single ResizeObserver for both density (root width) and content
   // changes (new messages). Checks entry.target to dispatch.
@@ -436,6 +439,7 @@ export function XDSChatLayout({
   const setRootRef = useCallback(
     (el: HTMLDivElement | null) => {
       (rootRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
+      setRootMounted(el != null);
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -2,13 +2,14 @@
 
 /**
  * @file XDSChatLayout.tsx
- * @input Uses React, StyleX, theme tokens, XDSChatMessageList
+ * @input Uses React, StyleX, theme tokens, useAutoScroll
  * @output Exports XDSChatLayout component and XDSChatLayoutProps
  * @position Layout shell for full chat interfaces — messages in page flow, composer fixed to bottom
  *
  * Arranges a chat page: messages flow naturally in the page, composer is
- * fixed to the bottom with a frosted glass backdrop. Uses a ResizeObserver
- * to adapt spacing for narrow (panel/mobile) vs wide (desktop) containers.
+ * fixed to the bottom with a frosted glass backdrop. Owns auto-scroll
+ * behavior and the scroll-to-bottom button. Uses ResizeObserver on the
+ * message content area to detect new content.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Chat/index.ts (exports)
@@ -25,9 +26,19 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  shadowVars,
+  durationVars,
+  easeVars,
+} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSChatLayoutContext} from './XDSChatContext';
+import {useAutoScroll} from './useAutoScroll';
+import {XDSIcon} from '../Icon';
+import {XDSButton} from '../Button';
 
 // =============================================================================
 // Types
@@ -41,7 +52,7 @@ export interface XDSChatLayoutProps {
 
   /**
    * Message content — flows naturally in the page, scrolls with the page.
-   * Typically XDSChatMessage components.
+   * Typically XDSChatMessageList with XDSChatMessage children.
    */
   children: ReactNode;
 
@@ -60,9 +71,6 @@ export interface XDSChatLayoutProps {
    * External scroll container ref. When provided, auto-scroll and
    * scroll-to-bottom target this element instead of the layout root.
    *
-   * Use when the layout is embedded in a page where the scroll
-   * container is a parent element or the document body:
-   *
    * @example
    * ```
    * // Scroll with the page body
@@ -75,6 +83,18 @@ export interface XDSChatLayoutProps {
    * panel chat layouts.
    */
   scrollRef?: React.RefObject<HTMLElement | null>;
+
+  /**
+   * Whether auto-scroll behavior is enabled.
+   * @default true
+   */
+  hasAutoScroll?: boolean;
+
+  /**
+   * Label shown in the scroll-to-bottom button when new messages arrive.
+   * @default 'New messages'
+   */
+  newMessagesLabel?: string;
 
   /** StyleX overrides. */
   xstyle?: StyleXStyles;
@@ -104,13 +124,10 @@ const styles = stylex.create({
 
   // --- Message area ---
   messageArea: {
-    // Normal page flow, not in a scroll container
     display: 'flex',
     flexDirection: 'column',
     marginInline: 'auto',
   },
-
-  // Message area max-width per density
   messageAreaCompact: {
     maxWidth: '100%',
   },
@@ -122,11 +139,6 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-4'],
   },
 
-  // Message area bottom padding to clear the fixed dock
-  messageAreaPadding: {
-    // Will be set dynamically via inline style
-  },
-
   // --- Empty state ---
   emptyState: {
     display: 'flex',
@@ -136,7 +148,7 @@ const styles = stylex.create({
     minHeight: 200,
   },
 
-  // --- Blur layer — purely visual, behind composer ---
+  // --- Blur layer ---
   blurLayer: {
     bottom: 0,
     left: 0,
@@ -169,7 +181,7 @@ const styles = stylex.create({
     WebkitMaskImage: 'linear-gradient(to bottom, transparent, black 48px)',
   },
 
-  // --- Composer dock — interactive, no blur/mask ---
+  // --- Composer dock ---
   dock: {
     bottom: 0,
     left: 0,
@@ -195,7 +207,7 @@ const styles = stylex.create({
     paddingBlockEnd: spacingVars['--spacing-3'],
   },
 
-  // --- Dock inner wrapper (max-width centered) ---
+  // --- Dock inner wrapper ---
   dockInner: {
     marginInline: 'auto',
   },
@@ -207,6 +219,48 @@ const styles = stylex.create({
   },
   dockInnerSpacious: {
     maxWidth: 800,
+  },
+
+  // --- Scroll-to-bottom button ---
+  scrollButtonContainer: {
+    position: 'sticky',
+    bottom: spacingVars['--spacing-3'],
+    left: '50%',
+    contain: 'layout style',
+    overflow: 'hidden',
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-background-popover'],
+    boxShadow: shadowVars['--shadow-med'],
+    height: '32px',
+    zIndex: 3,
+    transitionProperty: 'opacity, transform, max-width',
+    transitionTimingFunction: easeVars['--ease-standard'],
+    transitionDuration: durationVars['--duration-fast-max'],
+    // Pull out of flow so it doesn't affect message area height
+    float: 'right',
+    clear: 'both',
+    transform: 'translateX(-50%)',
+    marginBlockStart: '-44px',
+  },
+  scrollButtonContainerHidden: {
+    opacity: 0,
+    pointerEvents: 'none',
+    maxWidth: '32px',
+  },
+  scrollButtonContainerVisible: {
+    opacity: 1,
+    pointerEvents: 'auto',
+  },
+  scrollButtonCollapsed: {
+    maxWidth: '32px',
+  },
+  scrollButtonExpanded: {
+    maxWidth: '200px',
+  },
+  scrollButton: {
+    [radiusVars['--radius-element'] as string]: radiusVars['--radius-full'],
+    whiteSpace: 'nowrap',
+    paddingInline: spacingVars['--spacing-2'],
   },
 });
 
@@ -220,10 +274,55 @@ function getDensity(width: number): Density {
   return 'spacious';
 }
 
-function hasContent(children: ReactNode): boolean {
+function hasVisibleContent(children: ReactNode): boolean {
   if (children == null || children === false) return false;
   if (Array.isArray(children) && children.length === 0) return false;
   return true;
+}
+
+// =============================================================================
+// Sub-components
+// =============================================================================
+
+function ScrollToBottomButton({
+  isScrolledUp,
+  hasNewMessages,
+  label,
+  onClick,
+  dockHeight,
+}: {
+  isScrolledUp: boolean;
+  hasNewMessages: boolean;
+  label: string;
+  onClick: () => void;
+  dockHeight: number;
+}) {
+  const isVisible = isScrolledUp || hasNewMessages;
+
+  return (
+    <div
+      {...stylex.props(
+        styles.scrollButtonContainer,
+        isVisible
+          ? styles.scrollButtonContainerVisible
+          : styles.scrollButtonContainerHidden,
+        hasNewMessages
+          ? styles.scrollButtonExpanded
+          : styles.scrollButtonCollapsed,
+      )}
+      style={{bottom: dockHeight + 12}}>
+      <XDSButton
+        label={hasNewMessages ? label : 'Scroll to bottom'}
+        aria-label={hasNewMessages ? label : 'Scroll to bottom'}
+        icon={<XDSIcon icon="chevronDown" size="md" />}
+        variant="ghost"
+        size="md"
+        onClick={onClick}
+        xstyle={styles.scrollButton}>
+        {hasNewMessages ? label : undefined}
+      </XDSButton>
+    </div>
+  );
 }
 
 // =============================================================================
@@ -233,9 +332,11 @@ function hasContent(children: ReactNode): boolean {
 /**
  * Layout shell for full chat interfaces.
  *
- * Messages flow naturally in the page (no fixed scroll container).
- * The composer is fixed to the bottom with a frosted glass dock
- * that adapts padding via container width observation.
+ * Messages flow naturally in the page. The composer is fixed to
+ * the bottom with a frosted glass dock. The layout owns auto-scroll
+ * behavior — it observes the message content area via ResizeObserver
+ * and scrolls to bottom when new content arrives (if the user is
+ * near the bottom). Shows a scroll-to-bottom button when scrolled up.
  *
  * @example
  * ```
@@ -243,7 +344,9 @@ function hasContent(children: ReactNode): boolean {
  *   composer={<XDSChatComposer onSubmit={handleSubmit} />}
  *   emptyState={<EmptyState />}
  * >
- *   {messages.map(msg => <XDSChatMessage key={msg.id} {...msg} />)}
+ *   <XDSChatMessageList>
+ *     {messages.map(msg => <XDSChatMessage key={msg.id} {...msg} />)}
+ *   </XDSChatMessageList>
  * </XDSChatLayout>
  * ```
  */
@@ -252,6 +355,8 @@ export function XDSChatLayout({
   composer,
   emptyState,
   scrollRef: externalScrollRef,
+  hasAutoScroll = true,
+  newMessagesLabel = 'New messages',
   xstyle,
   className,
   style,
@@ -260,20 +365,65 @@ export function XDSChatLayout({
 }: XDSChatLayoutProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
+  const contentElRef = useRef<HTMLElement | null>(null);
+
   const scrollContainerRef =
     externalScrollRef ?? (rootRef as React.RefObject<HTMLElement | null>);
   const isSelfScrolling = !externalScrollRef;
+
+  const [density, setDensity] = useState<Density>('balanced');
+  const [dockHeight, setDockHeight] = useState(0);
+
+  // --- Auto-scroll ---
+  const {
+    scrollRef,
+    isScrolledUp,
+    hasNewMessages,
+    handleScroll,
+    scrollToBottom,
+    dismissNewMessages,
+    onContentChange,
+  } = useAutoScroll({
+    enabled: hasAutoScroll,
+    scrollContainerRef,
+  });
+
+  // Attach scroll listener to the scroll container
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', handleScroll, {passive: true});
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [scrollRef, handleScroll]);
+
+  // Observe message content area for height changes (new messages, streaming)
+  useEffect(() => {
+    const el = contentElRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      onContentChange();
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [onContentChange]);
+
+  // Content ref callback — message list registers its inner element
+  const contentRef = useCallback((el: HTMLElement | null) => {
+    contentElRef.current = el;
+  }, []);
+
+  // --- Layout context ---
   const layoutContextValue = useMemo(
     () => ({
       scrollContainerRef,
       dockHeight,
+      contentRef,
     }),
-    [scrollContainerRef, dockHeight],
+    [scrollContainerRef, dockHeight, contentRef],
   );
-  const [density, setDensity] = useState<Density>('balanced');
-  const [dockHeight, setDockHeight] = useState(0);
 
-  // Observe root width for density breakpoints
+  // --- Density observation ---
   useEffect(() => {
     const el = rootRef.current;
     if (!el) return;
@@ -288,7 +438,7 @@ export function XDSChatLayout({
     return () => observer.disconnect();
   }, []);
 
-  // Observe dock height to set message area bottom padding
+  // --- Dock height observation ---
   useEffect(() => {
     const el = dockRef.current;
     if (!el) return;
@@ -305,7 +455,7 @@ export function XDSChatLayout({
     return () => observer.disconnect();
   }, []);
 
-  // Merge refs
+  // --- Merge refs ---
   const setRootRef = useCallback(
     (el: HTMLDivElement | null) => {
       (rootRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
@@ -318,7 +468,17 @@ export function XDSChatLayout({
     [ref],
   );
 
-  const showEmpty = !hasContent(children);
+  // --- Scroll button handler ---
+  const handleButtonClick = useCallback(() => {
+    if (hasNewMessages) {
+      dismissNewMessages();
+    } else {
+      scrollToBottom();
+    }
+  }, [hasNewMessages, dismissNewMessages, scrollToBottom]);
+
+  // --- Derived styles ---
+  const showEmpty = !hasVisibleContent(children);
 
   const messageAreaStyle =
     density === 'compact'
@@ -364,7 +524,7 @@ export function XDSChatLayout({
           className,
           style,
         )}>
-        {/* Message area — normal page flow */}
+        {/* Message area */}
         <div
           {...stylex.props(styles.messageArea, messageAreaStyle)}
           style={{paddingBlockEnd: dockHeight + 24}}>
@@ -375,7 +535,16 @@ export function XDSChatLayout({
           )}
         </div>
 
-        {/* Frosted glass layer — behind composer, not interactive */}
+        {/* Scroll-to-bottom button */}
+        <ScrollToBottomButton
+          isScrolledUp={isScrolledUp}
+          hasNewMessages={hasNewMessages}
+          label={newMessagesLabel}
+          onClick={handleButtonClick}
+          dockHeight={dockHeight}
+        />
+
+        {/* Frosted glass layer */}
         <div
           {...stylex.props(
             styles.blurLayer,
@@ -384,7 +553,7 @@ export function XDSChatLayout({
           )}
         />
 
-        {/* Composer dock — interactive, no blur/mask */}
+        {/* Composer dock */}
         <div
           ref={dockRef}
           {...stylex.props(

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -369,7 +369,7 @@ export function XDSChatLayout({
 }: XDSChatLayoutProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
-  const [rootMounted, setRootMounted] = useState(false);
+  const scrollListenerRef = useRef<(() => void) | null>(null);
 
   const scrollContainerRef =
     externalScrollRef ?? (rootRef as React.RefObject<HTMLElement | null>);
@@ -391,15 +391,7 @@ export function XDSChatLayout({
     scrollContainerRef,
   });
 
-  // Attach scroll listener to the scroll container.
-  // rootMounted triggers re-run after the ref is populated.
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    el.addEventListener('scroll', handleScroll, {passive: true});
-    scrollToBottom(false);
-    return () => el.removeEventListener('scroll', handleScroll);
-  }, [scrollRef, handleScroll, rootMounted, scrollToBottom]);
+
 
   // Single ResizeObserver for both density (root width) and content
   // changes (new messages). Checks entry.target to dispatch.
@@ -436,17 +428,34 @@ export function XDSChatLayout({
 
 
   // --- Merge refs ---
+  // Callback ref attaches scroll listener and triggers initial scroll.
   const setRootRef = useCallback(
     (el: HTMLDivElement | null) => {
+      // Detach previous listener
+      if (scrollListenerRef.current) {
+        scrollListenerRef.current();
+        scrollListenerRef.current = null;
+      }
+
       (rootRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
-      setRootMounted(el != null);
+
+      if (el) {
+        const scrollEl = scrollRef.current;
+        if (scrollEl) {
+          scrollEl.addEventListener('scroll', handleScroll, {passive: true});
+          scrollListenerRef.current = () =>
+            scrollEl.removeEventListener('scroll', handleScroll);
+          scrollToBottom(false);
+        }
+      }
+
       if (typeof ref === 'function') {
         ref(el);
       } else if (ref) {
         (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
       }
     },
-    [ref],
+    [ref, scrollRef, handleScroll, scrollToBottom],
   );
 
   // --- Scroll button handler ---

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -385,6 +385,7 @@ export function XDSChatLayout({
     isScrolledUp,
     hasNewMessages,
     handleScroll,
+    handleUserScroll,
     scrollToBottom,
     dismissNewMessages,
     onContentChange,
@@ -473,8 +474,13 @@ export function XDSChatLayout({
         const scrollEl = scrollRef.current;
         if (scrollEl) {
           scrollEl.addEventListener('scroll', handleScroll, {passive: true});
-          scrollListenerRef.current = () =>
+          scrollEl.addEventListener('wheel', handleUserScroll, {passive: true});
+          scrollEl.addEventListener('touchmove', handleUserScroll, {passive: true});
+          scrollListenerRef.current = () => {
             scrollEl.removeEventListener('scroll', handleScroll);
+            scrollEl.removeEventListener('wheel', handleUserScroll);
+            scrollEl.removeEventListener('touchmove', handleUserScroll);
+          };
           // Defer to next frame so content has laid out
           requestAnimationFrame(() => scrollToBottom(false));
         }
@@ -486,7 +492,7 @@ export function XDSChatLayout({
         (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
       }
     },
-    [ref, scrollRef, handleScroll, scrollToBottom],
+    [ref, scrollRef, handleScroll, handleUserScroll, scrollToBottom],
   );
 
   // --- Scroll button handler ---

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -406,19 +406,20 @@ export function XDSChatLayout({
 
   const getObserver = useCallback(() => {
     if (!observerRef.current) {
-      observerRef.current = new ResizeObserver(entries => {
-        for (const entry of entries) {
-          if (entry.target === rootRef.current) {
-            setDensity(getDensity(entry.contentRect.width));
-          } else if (entry.target === contentElRef.current) {
-            const messages =
-              entry.target.getElementsByClassName('xds-chat-message');
-            const last =
-              messages.length > 0 ? messages[messages.length - 1] : null;
-            if (last && last !== lastMessageRef.current) {
-              lastMessageRef.current = last;
-              onContentChange();
-            }
+      observerRef.current = new ResizeObserver(() => {
+        const root = rootRef.current;
+        if (root) {
+          setDensity(getDensity(root.clientWidth));
+        }
+
+        const content = contentElRef.current;
+        if (content) {
+          const messages = content.getElementsByClassName('xds-chat-message');
+          const last =
+            messages.length > 0 ? messages[messages.length - 1] : null;
+          if (last && last !== lastMessageRef.current) {
+            lastMessageRef.current = last;
+            onContentChange();
           }
         }
       });

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -370,6 +370,8 @@ export function XDSChatLayout({
   const rootRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
   const scrollListenerRef = useRef<(() => void) | null>(null);
+  const contentElRef = useRef<HTMLElement | null>(null);
+  const contentObserverRef = useRef<ResizeObserver | null>(null);
 
   const scrollContainerRef =
     externalScrollRef ?? (rootRef as React.RefObject<HTMLElement | null>);
@@ -397,32 +399,49 @@ export function XDSChatLayout({
   // changes (new messages). Checks entry.target to dispatch.
   const lastMessageRef = useRef<Element | null>(null);
 
-  // Single ResizeObserver on root — handles density + new message detection.
+  // Density observer — watches root width for breakpoints.
   useEffect(() => {
     const root = rootRef.current;
     if (!root) return;
-
     const observer = new ResizeObserver(() => {
       setDensity(getDensity(root.clientWidth));
-
-      const messages = root.getElementsByClassName('xds-chat-message');
-      const last =
-        messages.length > 0 ? messages[messages.length - 1] : null;
-      if (last && last !== lastMessageRef.current) {
-        lastMessageRef.current = last;
-        onContentChange();
-      }
     });
     observer.observe(root);
     return () => observer.disconnect();
-  }, [onContentChange]);
+  }, []);
+
+  // Content ref callback — observe the message list for height changes.
+  const contentRef = useCallback(
+    (el: HTMLElement | null) => {
+      if (contentObserverRef.current) {
+        contentObserverRef.current.disconnect();
+        contentObserverRef.current = null;
+      }
+      contentElRef.current = el;
+      if (el) {
+        const observer = new ResizeObserver(() => {
+          const messages = el.getElementsByClassName('xds-chat-message');
+          const last =
+            messages.length > 0 ? messages[messages.length - 1] : null;
+          if (last && last !== lastMessageRef.current) {
+            lastMessageRef.current = last;
+            onContentChange();
+          }
+        });
+        observer.observe(el);
+        contentObserverRef.current = observer;
+      }
+    },
+    [onContentChange],
+  );
 
   // --- Layout context ---
   const layoutContextValue = useMemo(
     () => ({
       scrollContainerRef,
+      contentRef,
     }),
-    [scrollContainerRef],
+    [scrollContainerRef, contentRef],
   );
 
 

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -138,7 +138,6 @@ const styles = stylex.create({
 
   // --- Blur layer — purely visual, behind composer ---
   blurLayer: {
-    position: 'fixed',
     bottom: 0,
     left: 0,
     right: 0,
@@ -146,6 +145,13 @@ const styles = stylex.create({
     pointerEvents: 'none',
     backdropFilter: 'blur(12px)',
     WebkitBackdropFilter: 'blur(12px)',
+  },
+  blurLayerFixed: {
+    position: 'fixed',
+  },
+  blurLayerAbsolute: {
+    position: 'sticky',
+    marginBlockStart: 'auto',
   },
   blurLayerCompact: {
     height: 80,
@@ -165,11 +171,16 @@ const styles = stylex.create({
 
   // --- Composer dock — interactive, no blur/mask ---
   dock: {
-    position: 'fixed',
     bottom: 0,
     left: 0,
     right: 0,
     zIndex: 2,
+  },
+  dockFixed: {
+    position: 'fixed',
+  },
+  dockSticky: {
+    position: 'sticky',
   },
   dockCompact: {
     paddingInline: spacingVars['--spacing-2'],
@@ -364,10 +375,22 @@ export function XDSChatLayout({
         </div>
 
         {/* Frosted glass layer — behind composer, not interactive */}
-        <div {...stylex.props(styles.blurLayer, blurLayerStyle)} />
+        <div
+          {...stylex.props(
+            styles.blurLayer,
+            isSelfScrolling ? styles.blurLayerAbsolute : styles.blurLayerFixed,
+            blurLayerStyle,
+          )}
+        />
 
         {/* Composer dock — interactive, no blur/mask */}
-        <div ref={dockRef} {...stylex.props(styles.dock, dockStyle)}>
+        <div
+          ref={dockRef}
+          {...stylex.props(
+            styles.dock,
+            isSelfScrolling ? styles.dockSticky : styles.dockFixed,
+            dockStyle,
+          )}>
           <div {...stylex.props(styles.dockInner, dockInnerStyle)}>
             {composer}
           </div>

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -127,6 +127,7 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     marginInline: 'auto',
+    minHeight: '100%',
   },
   messageAreaCompact: {
     maxWidth: '100%',
@@ -186,8 +187,8 @@ const styles = stylex.create({
   positionFixed: {
     position: 'fixed',
   },
-  positionAbsolute: {
-    position: 'absolute',
+  positionSticky: {
+    position: 'sticky',
   },
   dockCompact: {
     paddingInline: spacingVars['--spacing-2'],
@@ -554,7 +555,7 @@ export function XDSChatLayout({
         <div
           {...stylex.props(
             styles.blurLayer,
-            isSelfScrolling ? styles.positionAbsolute : styles.positionFixed,
+            isSelfScrolling ? styles.positionSticky : styles.positionFixed,
             blurLayerStyle,
           )}
         />
@@ -564,7 +565,7 @@ export function XDSChatLayout({
           ref={dockRef}
           {...stylex.props(
             styles.dock,
-            isSelfScrolling ? styles.positionAbsolute : styles.positionFixed,
+            isSelfScrolling ? styles.positionSticky : styles.positionFixed,
             dockStyle,
           )}>
           <div {...stylex.props(styles.dockInner, dockInnerStyle)}>

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -19,6 +19,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from 'react';
@@ -26,6 +27,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import {XDSChatLayoutContext} from './XDSChatContext';
 
 // =============================================================================
 // Types
@@ -54,6 +56,26 @@ export interface XDSChatLayoutProps {
    */
   emptyState?: ReactNode;
 
+  /**
+   * External scroll container ref. When provided, auto-scroll and
+   * scroll-to-bottom target this element instead of the layout root.
+   *
+   * Use when the layout is embedded in a page where the scroll
+   * container is a parent element or the document body:
+   *
+   * @example
+   * ```
+   * // Scroll with the page body
+   * const scrollRef = useRef(document.documentElement);
+   * <XDSChatLayout scrollRef={scrollRef} composer={...}>...</XDSChatLayout>
+   * ```
+   *
+   * When omitted, the layout root itself is the scroll container
+   * (`overflow-y: auto`). This is the default for full-page and
+   * panel chat layouts.
+   */
+  scrollRef?: React.RefObject<HTMLElement | null>;
+
   /** StyleX overrides. */
   xstyle?: StyleXStyles;
   /** CSS class name(s) appended to the root element. */
@@ -73,6 +95,11 @@ const styles = stylex.create({
     position: 'relative',
     containerType: 'inline-size',
     minHeight: 0,
+    flex: 1,
+  },
+  rootScrollable: {
+    overflowY: 'auto',
+    overflowX: 'hidden',
   },
 
   // --- Message area ---
@@ -213,6 +240,7 @@ export function XDSChatLayout({
   children,
   composer,
   emptyState,
+  scrollRef: externalScrollRef,
   xstyle,
   className,
   style,
@@ -221,6 +249,15 @@ export function XDSChatLayout({
 }: XDSChatLayoutProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef =
+    externalScrollRef ?? (rootRef as React.RefObject<HTMLElement | null>);
+  const isSelfScrolling = !externalScrollRef;
+  const layoutContextValue = useMemo(
+    () => ({
+      scrollContainerRef,
+    }),
+    [scrollContainerRef],
+  );
   const [density, setDensity] = useState<Density>('balanced');
   const [dockHeight, setDockHeight] = useState(0);
 
@@ -247,7 +284,9 @@ export function XDSChatLayout({
     const observer = new ResizeObserver(entries => {
       const entry = entries[0];
       if (entry) {
-        setDockHeight(entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height);
+        setDockHeight(
+          entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height,
+        );
       }
     });
     observer.observe(el);
@@ -298,37 +337,43 @@ export function XDSChatLayout({
         : styles.dockInnerBalanced;
 
   return (
-    <div
-      ref={setRootRef}
-      data-testid={testId}
-      data-density={density}
-      {...mergeProps(
-        xdsClassName('chat-layout', {density}),
-        stylex.props(styles.root, xstyle),
-        className,
-        style,
-      )}>
-      {/* Message area — normal page flow */}
+    <XDSChatLayoutContext.Provider value={layoutContextValue}>
       <div
-        {...stylex.props(styles.messageArea, messageAreaStyle)}
-        style={{paddingBlockEnd: dockHeight + 24}}>
-        {showEmpty && emptyState ? (
-          <div {...stylex.props(styles.emptyState)}>{emptyState}</div>
-        ) : (
-          children
-        )}
-      </div>
+        ref={setRootRef}
+        data-testid={testId}
+        data-density={density}
+        {...mergeProps(
+          xdsClassName('chat-layout', {density}),
+          stylex.props(
+            styles.root,
+            isSelfScrolling && styles.rootScrollable,
+            xstyle,
+          ),
+          className,
+          style,
+        )}>
+        {/* Message area — normal page flow */}
+        <div
+          {...stylex.props(styles.messageArea, messageAreaStyle)}
+          style={{paddingBlockEnd: dockHeight + 24}}>
+          {showEmpty && emptyState ? (
+            <div {...stylex.props(styles.emptyState)}>{emptyState}</div>
+          ) : (
+            children
+          )}
+        </div>
 
-      {/* Frosted glass layer — behind composer, not interactive */}
-      <div {...stylex.props(styles.blurLayer, blurLayerStyle)} />
+        {/* Frosted glass layer — behind composer, not interactive */}
+        <div {...stylex.props(styles.blurLayer, blurLayerStyle)} />
 
-      {/* Composer dock — interactive, no blur/mask */}
-      <div ref={dockRef} {...stylex.props(styles.dock, dockStyle)}>
-        <div {...stylex.props(styles.dockInner, dockInnerStyle)}>
-          {composer}
+        {/* Composer dock — interactive, no blur/mask */}
+        <div ref={dockRef} {...stylex.props(styles.dock, dockStyle)}>
+          <div {...stylex.props(styles.dockInner, dockInnerStyle)}>
+            {composer}
+          </div>
         </div>
       </div>
-    </div>
+    </XDSChatLayoutContext.Provider>
   );
 }
 

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -128,6 +128,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     marginInline: 'auto',
     minHeight: '100%',
+    paddingBlockEnd: spacingVars['--spacing-6'],
   },
   messageAreaCompact: {
     maxWidth: '100%',

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -386,6 +386,7 @@ export function XDSChatLayout({
     hasNewMessages,
     handleScroll,
     handleScrollEnd,
+    handleUserScroll,
     scrollToBottom,
     dismissNewMessages,
     onContentChange,
@@ -475,9 +476,13 @@ export function XDSChatLayout({
         if (scrollEl) {
           scrollEl.addEventListener('scroll', handleScroll, {passive: true});
           scrollEl.addEventListener('scrollend', handleScrollEnd);
+          scrollEl.addEventListener('wheel', handleUserScroll, {passive: true});
+          scrollEl.addEventListener('touchstart', handleUserScroll, {passive: true});
           scrollListenerRef.current = () => {
             scrollEl.removeEventListener('scroll', handleScroll);
             scrollEl.removeEventListener('scrollend', handleScrollEnd);
+            scrollEl.removeEventListener('wheel', handleUserScroll);
+            scrollEl.removeEventListener('touchstart', handleUserScroll);
           };
           // Defer to next frame so content has laid out
           requestAnimationFrame(() => scrollToBottom(false));
@@ -490,7 +495,7 @@ export function XDSChatLayout({
         (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
       }
     },
-    [ref, scrollRef, handleScroll, handleScrollEnd, scrollToBottom],
+    [ref, scrollRef, handleScroll, handleScrollEnd, handleUserScroll, scrollToBottom],
   );
 
   // --- Scroll button handler ---

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -445,7 +445,8 @@ export function XDSChatLayout({
           scrollEl.addEventListener('scroll', handleScroll, {passive: true});
           scrollListenerRef.current = () =>
             scrollEl.removeEventListener('scroll', handleScroll);
-          scrollToBottom(false);
+          // Defer to next frame so content has laid out
+          requestAnimationFrame(() => scrollToBottom(false));
         }
       }
 

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -369,7 +369,7 @@ export function XDSChatLayout({
 }: XDSChatLayoutProps) {
   const rootRef = useRef<HTMLDivElement>(null);
   const dockRef = useRef<HTMLDivElement>(null);
-  const contentElRef = useRef<HTMLElement | null>(null);
+  const [contentEl, setContentEl] = useState<HTMLElement | null>(null);
 
   const scrollContainerRef =
     externalScrollRef ?? (rootRef as React.RefObject<HTMLElement | null>);
@@ -407,24 +407,24 @@ export function XDSChatLayout({
   const lastMessageRef = useRef<Element | null>(null);
 
   useEffect(() => {
-    const el = contentElRef.current;
-    if (!el) return;
+    if (!contentEl) return;
 
     const observer = new ResizeObserver(() => {
-      const messages = el.getElementsByClassName('xds-chat-message');
+      const messages = contentEl.getElementsByClassName('xds-chat-message');
       const last = messages.length > 0 ? messages[messages.length - 1] : null;
       if (last && last !== lastMessageRef.current) {
         lastMessageRef.current = last;
         onContentChange();
       }
     });
-    observer.observe(el);
+    observer.observe(contentEl);
     return () => observer.disconnect();
-  }, [onContentChange]);
+  }, [contentEl, onContentChange]);
 
-  // Content ref callback — message list registers its inner element
+  // Content ref callback — message list registers its inner element.
+  // Uses state (not ref) so the ResizeObserver effect re-runs when set.
   const contentRef = useCallback((el: HTMLElement | null) => {
-    contentElRef.current = el;
+    setContentEl(el);
   }, []);
 
   // --- Layout context ---

--- a/packages/core/src/Chat/XDSChatLayout.tsx
+++ b/packages/core/src/Chat/XDSChatLayout.tsx
@@ -396,19 +396,22 @@ export function XDSChatLayout({
     return () => el.removeEventListener('scroll', handleScroll);
   }, [scrollRef, handleScroll]);
 
-  // Observe message content area — only trigger auto-scroll when the
-  // message count actually grows (not when existing content resizes,
-  // e.g. expanding tool calls or collapsing drawers).
-  const messageCountRef = useRef(0);
+  // Observe message content area — only trigger auto-scroll when new
+  // messages appear at the bottom. Tracks the last .xds-chat-message
+  // element by reference. A new last element means content was appended.
+  // Upward loads (older messages) and content resizes (tool call expand,
+  // drawer collapse) don't change the last element.
+  const lastMessageRef = useRef<Element | null>(null);
 
   useEffect(() => {
     const el = contentElRef.current;
     if (!el) return;
 
     const observer = new ResizeObserver(() => {
-      const count = el.querySelectorAll('.xds-chat-message').length;
-      if (count > messageCountRef.current) {
-        messageCountRef.current = count;
+      const messages = el.getElementsByClassName('xds-chat-message');
+      const last = messages.length > 0 ? messages[messages.length - 1] : null;
+      if (last && last !== lastMessageRef.current) {
+        lastMessageRef.current = last;
         onContentChange();
       }
     });

--- a/packages/core/src/Chat/XDSChatMessageList.test.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.test.tsx
@@ -54,13 +54,13 @@ describe('XDSChatMessageList', () => {
     expect(screen.getByTestId('chat-list')).toBeTruthy();
   });
 
-  it('has scroll-to-bottom button (hidden by default)', () => {
+  it('does not render scroll-to-bottom button (owned by XDSChatLayout)', () => {
     render(
       <XDSChatMessageList>
         <div>msg</div>
       </XDSChatMessageList>,
     );
-    const button = screen.getByRole('button', {name: /Scroll to bottom/});
-    expect(button).toBeTruthy();
+    const button = screen.queryByRole('button', {name: /Scroll to bottom/});
+    expect(button).toBeNull();
   });
 });

--- a/packages/core/src/Chat/XDSChatMessageList.test.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.test.tsx
@@ -54,13 +54,4 @@ describe('XDSChatMessageList', () => {
     expect(screen.getByTestId('chat-list')).toBeTruthy();
   });
 
-  it('does not render scroll-to-bottom button (owned by XDSChatLayout)', () => {
-    render(
-      <XDSChatMessageList>
-        <div>msg</div>
-      </XDSChatMessageList>,
-    );
-    const button = screen.queryByRole('button', {name: /Scroll to bottom/});
-    expect(button).toBeNull();
-  });
 });

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -161,21 +161,12 @@ export function XDSChatMessageList({
 }: XDSChatMessageListProps) {
   const layoutContext = useXDSChatLayoutContext();
   const sentinelRef = useRef<HTMLDivElement>(null);
-  const innerRef = useRef<HTMLDivElement>(null);
   const [isLoadingTop, startTransition] = useTransition();
 
   const hasChildren =
     children != null &&
     children !== false &&
     !(Array.isArray(children) && children.length === 0);
-
-  // Register inner content element with the layout for height observation
-  useEffect(() => {
-    if (layoutContext?.contentRef && innerRef.current) {
-      layoutContext.contentRef(innerRef.current);
-      return () => layoutContext.contentRef(null);
-    }
-  }, [layoutContext]);
 
   // IntersectionObserver for scroll-to-top infinite scroll
   useEffect(() => {
@@ -220,7 +211,7 @@ export function XDSChatMessageList({
           className,
           style,
         )}>
-        <div ref={innerRef} {...stylex.props(styles.inner, gapStyle)}>
+        <div {...stylex.props(styles.inner, gapStyle)}>
           {/* Sentinel for infinite scroll */}
           {onScrollToTopAction && <div ref={sentinelRef} aria-hidden />}
 

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -2,14 +2,17 @@
 
 /**
  * @file XDSChatMessageList.tsx
- * @input Uses React, StyleX, XDSChatListContext, XDSIcon, theme tokens, useAutoScroll
+ * @input Uses React, StyleX, XDSChatListContext, theme tokens
  * @output Exports XDSChatMessageList component and XDSChatMessageListProps
- * @position Scrollable message container — holds XDSChatMessage children with auto-scroll
+ * @position Presentational message container — holds XDSChatMessage children
  *
- * Renders a scrollable container with role="log" for chat message histories.
- * Handles auto-scroll (pins to bottom during streaming), a floating
- * scroll-to-bottom button when scrolled up, and a "New messages" label
- * that expands into the button via width animation when new content arrives.
+ * Renders a container with role="log" for chat message histories.
+ * Handles density context, empty state, a spacer that pushes messages
+ * to the bottom, and an infinite scroll sentinel.
+ *
+ * Auto-scroll and the scroll-to-bottom button are owned by
+ * XDSChatLayout. When used standalone (without a layout), the list
+ * is purely presentational — compose useAutoScroll yourself if needed.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Chat/index.ts (exports)
@@ -26,27 +29,13 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {
-  colorVars,
-  spacingVars,
-  radiusVars,
-  durationVars,
-  easeVars,
-  shadowVars,
-} from '../theme/tokens.stylex';
-import {
-  XDSChatListContext,
-  type XDSChatDensity,
-  useXDSChatLayoutContext,
-} from './XDSChatContext';
+import {spacingVars} from '../theme/tokens.stylex';
+import {XDSChatListContext, type XDSChatDensity, useXDSChatLayoutContext} from './XDSChatContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSSpinner} from '../Spinner';
-import {XDSIcon} from '../Icon';
-import {XDSButton} from '../Button';
-import {useAutoScroll} from './useAutoScroll';
 
 export interface XDSChatMessageListProps {
-  /** Ref forwarded to the scrollable container element */
+  /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
 
   /**
@@ -54,35 +43,6 @@ export interface XDSChatMessageListProps {
    * Also accepts XDSDivider (date separators) or any ReactNode.
    */
   children: ReactNode;
-
-  /**
-   * Whether auto-scroll behavior is enabled.
-   * When true (default), the list scrolls to bottom on new content
-   * if the user is near the bottom. When false, no auto-scrolling
-   * occurs — useful for static/view-only conversation history.
-   * @default true
-   */
-  hasAutoScroll?: boolean;
-
-  /**
-   * Distance from bottom (in px) within which new content triggers auto-scroll.
-   * Only applies when `hasAutoScroll` is true.
-   * @default 12
-   */
-  scrollThreshold?: number;
-
-  /**
-   * Distance from bottom (in px) beyond which the scroll-to-bottom button appears.
-   * @default 100
-   */
-  scrollUpThreshold?: number;
-
-  /**
-   * Label shown in the scroll-to-bottom button when new messages arrive.
-   * Revealed via a width animation on the button.
-   * @default 'New messages'
-   */
-  newMessagesLabel?: string;
 
   /**
    * Custom content when the list has no messages.
@@ -120,23 +80,11 @@ export interface XDSChatMessageListProps {
 // =============================================================================
 
 const styles = stylex.create({
-  outer: {
-    position: 'relative',
-    display: 'flex',
-    flexDirection: 'column',
-    flex: 1,
-    minHeight: 0,
-  },
   root: {
     display: 'flex',
     flexDirection: 'column',
     flex: 1,
     minHeight: 0,
-  },
-  rootScrollable: {
-    overflowY: 'auto',
-    overflowX: 'hidden',
-    overflowAnchor: 'auto',
   },
   inner: {
     display: 'flex',
@@ -168,52 +116,6 @@ const styles = stylex.create({
     justifyContent: 'center',
     paddingBlock: spacingVars['--spacing-3'],
   },
-
-  // --- Scroll-to-bottom button ---
-  // Container controls dimensions and clips content. The XDSButton inside
-  // is always full-size; the container's width transition reveals the label.
-  // Opaque popover bg on the container prevents hover tint bleed-through.
-  // `contain: layout style` isolates reflow from the scroll area.
-  scrollButtonContainer: {
-    position: 'absolute',
-    bottom: spacingVars['--spacing-3'],
-    left: '50%',
-    contain: 'layout style',
-    overflow: 'hidden',
-    borderRadius: radiusVars['--radius-full'],
-    backgroundColor: colorVars['--color-background-popover'],
-    boxShadow: shadowVars['--shadow-med'],
-    height: '32px',
-    zIndex: 1,
-    transitionProperty: 'opacity, transform, max-width',
-    transitionTimingFunction: easeVars['--ease-standard'],
-    transitionDuration: durationVars['--duration-fast-max'],
-  },
-  scrollButtonContainerHidden: {
-    opacity: 0,
-    pointerEvents: 'none',
-    maxWidth: '32px',
-    transform: 'translate(-50%, 8px)',
-    transitionDelay: '0ms',
-  },
-  scrollButtonContainerVisible: {
-    opacity: 1,
-    pointerEvents: 'auto',
-    transform: 'translate(-50%, 0)',
-    transitionDelay: '150ms',
-  },
-  scrollButtonCollapsed: {
-    maxWidth: '32px',
-  },
-  scrollButtonExpanded: {
-    maxWidth: '200px',
-  },
-  scrollButton: {
-    [radiusVars['--radius-element'] as string]: radiusVars['--radius-full'],
-    whiteSpace: 'nowrap',
-    paddingInline: spacingVars['--spacing-2'],
-  },
-
   emptyState: {
     display: 'flex',
     alignItems: 'center',
@@ -224,73 +126,18 @@ const styles = stylex.create({
 });
 
 // =============================================================================
-// Sub-components
-// =============================================================================
-
-/**
- * Animated scroll-to-bottom button.
- *
- * - Icon-only ghost XDSButton (chevron down) when the user is scrolled up
- * - Expands via max-width animation to reveal label when new messages arrive
- * - Container provides opaque popover surface so ghost hover tint doesn't bleed
- *
- * Structure: container (positioning, fade, opaque surface) → XDSButton (ghost)
- * The label is always in the DOM but clipped by `max-width: 0` + `overflow: hidden`.
- * `contain: layout style` on the container isolates reflow from the scroll area.
- */
-function ScrollToBottomButton({
-  isScrolledUp,
-  hasNewMessages,
-  label,
-  onClick,
-  bottomOffset = 0,
-}: {
-  isScrolledUp: boolean;
-  hasNewMessages: boolean;
-  label: string;
-  onClick: () => void;
-  bottomOffset?: number;
-}) {
-  const isVisible = isScrolledUp || hasNewMessages;
-
-  return (
-    <div
-      {...stylex.props(
-        styles.scrollButtonContainer,
-        isVisible
-          ? styles.scrollButtonContainerVisible
-          : styles.scrollButtonContainerHidden,
-        hasNewMessages
-          ? styles.scrollButtonExpanded
-          : styles.scrollButtonCollapsed,
-      )}
-      style={bottomOffset ? {bottom: bottomOffset + 12} : undefined}>
-      <XDSButton
-        label={hasNewMessages ? label : 'Scroll to bottom'}
-        aria-label={hasNewMessages ? label : 'Scroll to bottom'}
-        icon={<XDSIcon icon="chevronDown" size="md" />}
-        variant="ghost"
-        size="md"
-        onClick={onClick}
-        xstyle={styles.scrollButton}>
-        {hasNewMessages ? label : undefined}
-      </XDSButton>
-    </div>
-  );
-}
-
-// =============================================================================
 // Component
 // =============================================================================
 
 /**
- * Scrollable container for chat messages with auto-scroll and infinite scroll support.
+ * Presentational container for chat messages.
  *
- * Pins to the bottom when the user is near the end. Shows a muted
- * scroll-to-bottom icon button when scrolled up. When new messages
- * arrive while scrolled up, the button expands to show a
- * "New messages" label. Supports loading older messages via
- * `onScrollToTopAction`.
+ * Renders messages in a flex column with density-based spacing.
+ * A spacer pushes content to the bottom when the list isn't full.
+ * Supports loading older messages via `onScrollToTopAction`.
+ *
+ * Auto-scroll and the scroll-to-bottom button are owned by
+ * XDSChatLayout. Use useAutoScroll for standalone scroll control.
  *
  * @example
  * ```
@@ -298,18 +145,11 @@ function ScrollToBottomButton({
  *   <XDSChatMessage sender="assistant" name="Navi" avatar={<XDSAvatar name="Navi" size="md" />}>
  *     <XDSChatMessageBubble>Hello!</XDSChatMessageBubble>
  *   </XDSChatMessage>
- *   <XDSChatMessage sender="user" name="Cindy">
- *     <XDSChatMessageBubble>Hey there!</XDSChatMessageBubble>
- *   </XDSChatMessage>
  * </XDSChatMessageList>
  * ```
  */
 export function XDSChatMessageList({
   children,
-  hasAutoScroll = true,
-  scrollThreshold = 12,
-  scrollUpThreshold = 100,
-  newMessagesLabel = 'New messages',
   emptyState,
   onScrollToTopAction,
   density = 'balanced',
@@ -320,53 +160,27 @@ export function XDSChatMessageList({
   ref,
 }: XDSChatMessageListProps) {
   const layoutContext = useXDSChatLayoutContext();
-
-  const {
-    scrollRef,
-    isScrolledUp,
-    hasNewMessages,
-    handleScroll,
-    scrollToBottom,
-    dismissNewMessages,
-    onContentChange,
-  } = useAutoScroll({
-    enabled: hasAutoScroll,
-    threshold: scrollThreshold,
-    scrollUpThreshold,
-    scrollContainerRef: layoutContext?.scrollContainerRef,
-  });
-
-  // When inside XDSChatLayout, the scroll container is the layout's
-  // scroll area — attach the scroll listener there instead of on our root.
-  const isInsideLayout = layoutContext != null;
-
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
   const [isLoadingTop, startTransition] = useTransition();
 
-  // Track whether children exist (for empty state)
   const hasChildren =
     children != null &&
     children !== false &&
     !(Array.isArray(children) && children.length === 0);
 
-  // Auto-scroll on new content (children change)
+  // Register inner content element with the layout for height observation
   useEffect(() => {
-    onContentChange();
-  }, [children, onContentChange]);
-
-  // When inside a layout, attach scroll listener to the external scroll container
-  useEffect(() => {
-    if (!isInsideLayout) return;
-    const el = scrollRef.current;
-    if (!el) return;
-    el.addEventListener('scroll', handleScroll, {passive: true});
-    return () => el.removeEventListener('scroll', handleScroll);
-  }, [isInsideLayout, scrollRef, handleScroll]);
+    if (layoutContext?.contentRef && innerRef.current) {
+      layoutContext.contentRef(innerRef.current);
+      return () => layoutContext.contentRef(null);
+    }
+  }, [layoutContext]);
 
   // IntersectionObserver for scroll-to-top infinite scroll
   useEffect(() => {
-    if (!onScrollToTopAction || !sentinelRef.current || !scrollRef.current)
-      return;
+    const scrollContainer = layoutContext?.scrollContainerRef?.current;
+    if (!onScrollToTopAction || !sentinelRef.current) return;
 
     const observer = new IntersectionObserver(
       entries => {
@@ -376,12 +190,12 @@ export function XDSChatMessageList({
           });
         }
       },
-      {root: scrollRef.current, threshold: 0},
+      {root: scrollContainer ?? null, threshold: 0},
     );
 
     observer.observe(sentinelRef.current);
     return () => observer.disconnect();
-  }, [onScrollToTopAction, scrollRef]);
+  }, [onScrollToTopAction, layoutContext]);
 
   const contextValue = useMemo(() => ({density}), [density]);
 
@@ -392,79 +206,41 @@ export function XDSChatMessageList({
         ? styles.gapSpacious
         : styles.gapBalanced;
 
-  // Merge refs
-  const setRefs = useCallback(
-    (el: HTMLDivElement | null) => {
-      (scrollRef as React.MutableRefObject<HTMLDivElement | null>).current = el;
-      if (typeof ref === 'function') {
-        ref(el);
-      } else if (ref) {
-        (ref as React.MutableRefObject<HTMLDivElement | null>).current = el;
-      }
-    },
-    [ref, scrollRef],
-  );
-
-  // Click handler: dismiss new messages (scrolls to bottom) or just scroll
-  const handleButtonClick = useCallback(() => {
-    if (hasNewMessages) {
-      dismissNewMessages();
-    } else {
-      scrollToBottom();
-    }
-  }, [hasNewMessages, dismissNewMessages, scrollToBottom]);
-
   return (
     <XDSChatListContext.Provider value={contextValue}>
-      <div {...stylex.props(styles.outer)}>
-        <div
-          ref={setRefs}
-          role="log"
-          aria-live="polite"
-          tabIndex={0}
-          data-testid={testId}
-          onScroll={handleScroll}
-          {...mergeProps(
-            xdsClassName('chat-message-list', {density}),
-            stylex.props(
-              styles.root,
-              !isInsideLayout && styles.rootScrollable,
-              xstyle,
-            ),
-            className,
-            style,
-          )}>
-          <div {...stylex.props(styles.inner, gapStyle)}>
-            {/* Sentinel for infinite scroll */}
-            {onScrollToTopAction && <div ref={sentinelRef} aria-hidden />}
+      <div
+        ref={ref}
+        role="log"
+        aria-live="polite"
+        tabIndex={0}
+        data-testid={testId}
+        {...mergeProps(
+          xdsClassName('chat-message-list', {density}),
+          stylex.props(styles.root, xstyle),
+          className,
+          style,
+        )}>
+        <div ref={innerRef} {...stylex.props(styles.inner, gapStyle)}>
+          {/* Sentinel for infinite scroll */}
+          {onScrollToTopAction && <div ref={sentinelRef} aria-hidden />}
 
-            {/* Loading spinner at top */}
-            {isLoadingTop && (
-              <div {...stylex.props(styles.loadingTop)}>
-                <XDSSpinner size="md" />
-              </div>
-            )}
+          {/* Loading spinner at top */}
+          {isLoadingTop && (
+            <div {...stylex.props(styles.loadingTop)}>
+              <XDSSpinner size="md" />
+            </div>
+          )}
 
-            {/* Spacer pushes messages to bottom when list isn't full */}
-            <div {...stylex.props(styles.spacer)} aria-hidden />
+          {/* Spacer pushes messages to bottom when list isn't full */}
+          <div {...stylex.props(styles.spacer)} aria-hidden />
 
-            {/* Messages or empty state */}
-            {hasChildren ? (
-              children
-            ) : emptyState ? (
-              <div {...stylex.props(styles.emptyState)}>{emptyState}</div>
-            ) : null}
-          </div>
+          {/* Messages or empty state */}
+          {hasChildren ? (
+            children
+          ) : emptyState ? (
+            <div {...stylex.props(styles.emptyState)}>{emptyState}</div>
+          ) : null}
         </div>
-
-        {/* Scroll-to-bottom button: icon-only when scrolled up, expands with label on new messages */}
-        <ScrollToBottomButton
-          isScrolledUp={isScrolledUp}
-          hasNewMessages={hasNewMessages}
-          label={newMessagesLabel}
-          onClick={handleButtonClick}
-          bottomOffset={isInsideLayout ? layoutContext.dockHeight : 0}
-        />
       </div>
     </XDSChatListContext.Provider>
   );

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -161,7 +161,16 @@ export function XDSChatMessageList({
 }: XDSChatMessageListProps) {
   const layoutContext = useXDSChatLayoutContext();
   const sentinelRef = useRef<HTMLDivElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
   const [isLoadingTop, startTransition] = useTransition();
+
+  // Register inner content element with the layout for height observation
+  useEffect(() => {
+    if (layoutContext?.contentRef && innerRef.current) {
+      layoutContext.contentRef(innerRef.current);
+      return () => layoutContext.contentRef(null);
+    }
+  }, [layoutContext]);
 
   const hasChildren =
     children != null &&
@@ -211,7 +220,7 @@ export function XDSChatMessageList({
           className,
           style,
         )}>
-        <div {...stylex.props(styles.inner, gapStyle)}>
+        <div ref={innerRef} {...stylex.props(styles.inner, gapStyle)}>
           {/* Sentinel for infinite scroll */}
           {onScrollToTopAction && <div ref={sentinelRef} aria-hidden />}
 

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -243,11 +243,13 @@ function ScrollToBottomButton({
   hasNewMessages,
   label,
   onClick,
+  bottomOffset = 0,
 }: {
   isScrolledUp: boolean;
   hasNewMessages: boolean;
   label: string;
   onClick: () => void;
+  bottomOffset?: number;
 }) {
   const isVisible = isScrolledUp || hasNewMessages;
 
@@ -261,7 +263,8 @@ function ScrollToBottomButton({
         hasNewMessages
           ? styles.scrollButtonExpanded
           : styles.scrollButtonCollapsed,
-      )}>
+      )}
+      style={bottomOffset ? {bottom: bottomOffset + 12} : undefined}>
       <XDSButton
         label={hasNewMessages ? label : 'Scroll to bottom'}
         aria-label={hasNewMessages ? label : 'Scroll to bottom'}
@@ -460,6 +463,7 @@ export function XDSChatMessageList({
           hasNewMessages={hasNewMessages}
           label={newMessagesLabel}
           onClick={handleButtonClick}
+          bottomOffset={isInsideLayout ? layoutContext.dockHeight : 0}
         />
       </div>
     </XDSChatListContext.Provider>

--- a/packages/core/src/Chat/XDSChatMessageList.tsx
+++ b/packages/core/src/Chat/XDSChatMessageList.tsx
@@ -34,7 +34,11 @@ import {
   easeVars,
   shadowVars,
 } from '../theme/tokens.stylex';
-import {XDSChatListContext, type XDSChatDensity} from './XDSChatContext';
+import {
+  XDSChatListContext,
+  type XDSChatDensity,
+  useXDSChatLayoutContext,
+} from './XDSChatContext';
 import {xdsClassName, mergeProps} from '../utils';
 import {XDSSpinner} from '../Spinner';
 import {XDSIcon} from '../Icon';
@@ -126,11 +130,13 @@ const styles = stylex.create({
   root: {
     display: 'flex',
     flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+  },
+  rootScrollable: {
     overflowY: 'auto',
     overflowX: 'hidden',
     overflowAnchor: 'auto',
-    flex: 1,
-    minHeight: 0,
   },
   inner: {
     display: 'flex',
@@ -310,6 +316,8 @@ export function XDSChatMessageList({
   'data-testid': testId,
   ref,
 }: XDSChatMessageListProps) {
+  const layoutContext = useXDSChatLayoutContext();
+
   const {
     scrollRef,
     isScrolledUp,
@@ -322,7 +330,12 @@ export function XDSChatMessageList({
     enabled: hasAutoScroll,
     threshold: scrollThreshold,
     scrollUpThreshold,
+    scrollContainerRef: layoutContext?.scrollContainerRef,
   });
+
+  // When inside XDSChatLayout, the scroll container is the layout's
+  // scroll area — attach the scroll listener there instead of on our root.
+  const isInsideLayout = layoutContext != null;
 
   const sentinelRef = useRef<HTMLDivElement>(null);
   const [isLoadingTop, startTransition] = useTransition();
@@ -337,6 +350,15 @@ export function XDSChatMessageList({
   useEffect(() => {
     onContentChange();
   }, [children, onContentChange]);
+
+  // When inside a layout, attach scroll listener to the external scroll container
+  useEffect(() => {
+    if (!isInsideLayout) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    el.addEventListener('scroll', handleScroll, {passive: true});
+    return () => el.removeEventListener('scroll', handleScroll);
+  }, [isInsideLayout, scrollRef, handleScroll]);
 
   // IntersectionObserver for scroll-to-top infinite scroll
   useEffect(() => {
@@ -401,7 +423,11 @@ export function XDSChatMessageList({
           onScroll={handleScroll}
           {...mergeProps(
             xdsClassName('chat-message-list', {density}),
-            stylex.props(styles.root, xstyle),
+            stylex.props(
+              styles.root,
+              !isInsideLayout && styles.rootScrollable,
+              xstyle,
+            ),
             className,
             style,
           )}>

--- a/packages/core/src/Chat/XDSChatTokenizedText.test.tsx
+++ b/packages/core/src/Chat/XDSChatTokenizedText.test.tsx
@@ -1,30 +1,30 @@
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import {XDSChatMessageTokenizedText} from './XDSChatMessageTokenizedText';
+import {XDSChatTokenizedText} from './XDSChatTokenizedText';
 
-describe('XDSChatMessageTokenizedText', () => {
+describe('XDSChatTokenizedText', () => {
   it('renders plain text when no tokens provided', () => {
     render(
-      <XDSChatMessageTokenizedText>Hello world</XDSChatMessageTokenizedText>,
+      <XDSChatTokenizedText>Hello world</XDSChatTokenizedText>,
     );
     expect(screen.getByText('Hello world')).toBeInTheDocument();
   });
 
   it('renders plain text when tokens array is empty', () => {
     render(
-      <XDSChatMessageTokenizedText tokens={[]}>
+      <XDSChatTokenizedText tokens={[]}>
         Hello world
-      </XDSChatMessageTokenizedText>,
+      </XDSChatTokenizedText>,
     );
     expect(screen.getByText('Hello world')).toBeInTheDocument();
   });
 
   it('replaces a single token with a badge', () => {
     render(
-      <XDSChatMessageTokenizedText
+      <XDSChatTokenizedText
         tokens={[{value: '@cindy', label: '@Cindy Zhang', variant: 'blue'}]}>
         Hey @cindy!
-      </XDSChatMessageTokenizedText>,
+      </XDSChatTokenizedText>,
     );
     expect(screen.getByText('@Cindy Zhang')).toBeInTheDocument();
     expect(screen.queryByText('@cindy')).not.toBeInTheDocument();
@@ -32,13 +32,13 @@ describe('XDSChatMessageTokenizedText', () => {
 
   it('replaces multiple different tokens', () => {
     render(
-      <XDSChatMessageTokenizedText
+      <XDSChatTokenizedText
         tokens={[
           {value: '@cindy', label: '@Cindy Zhang', variant: 'blue'},
           {value: '@navi', label: '@Navi', variant: 'blue'},
         ]}>
         Hey @cindy, can @navi help?
-      </XDSChatMessageTokenizedText>,
+      </XDSChatTokenizedText>,
     );
     expect(screen.getByText('@Cindy Zhang')).toBeInTheDocument();
     expect(screen.getByText('@Navi')).toBeInTheDocument();
@@ -46,30 +46,30 @@ describe('XDSChatMessageTokenizedText', () => {
 
   it('handles repeated occurrences of the same token', () => {
     render(
-      <XDSChatMessageTokenizedText
+      <XDSChatTokenizedText
         tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         @cindy and @cindy again
-      </XDSChatMessageTokenizedText>,
+      </XDSChatTokenizedText>,
     );
     expect(screen.getAllByText('@Cindy Zhang')).toHaveLength(2);
   });
 
   it('renders text with no matching tokens as plain text', () => {
     render(
-      <XDSChatMessageTokenizedText
+      <XDSChatTokenizedText
         tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         Hello world
-      </XDSChatMessageTokenizedText>,
+      </XDSChatTokenizedText>,
     );
     expect(screen.getByText('Hello world')).toBeInTheDocument();
   });
 
   it('handles tokens with special regex characters in pattern', () => {
     render(
-      <XDSChatMessageTokenizedText
+      <XDSChatTokenizedText
         tokens={[{value: '/search', label: '/search'}]}>
         Run /search now
-      </XDSChatMessageTokenizedText>,
+      </XDSChatTokenizedText>,
     );
     // The badge should render with the label
     expect(screen.getByText('/search')).toBeInTheDocument();
@@ -77,10 +77,10 @@ describe('XDSChatMessageTokenizedText', () => {
 
   it('preserves surrounding text', () => {
     const {container} = render(
-      <XDSChatMessageTokenizedText
+      <XDSChatTokenizedText
         tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         Before @cindy after
-      </XDSChatMessageTokenizedText>,
+      </XDSChatTokenizedText>,
     );
     expect(container.textContent).toContain('Before');
     expect(container.textContent).toContain('after');

--- a/packages/core/src/Chat/XDSChatTokenizedText.tsx
+++ b/packages/core/src/Chat/XDSChatTokenizedText.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 /**
- * @file XDSChatMessageTokenizedText.tsx
+ * @file XDSChatTokenizedText.tsx
  * @input Uses React, XDSBadge, XDSChatComposerToken
- * @output Exports XDSChatMessageTokenizedText component
+ * @output Exports XDSChatTokenizedText component
  * @position Utility component for rendering tokenized text in message bubbles
  *
  * Parses a plain text string and replaces token values with inline badges.
@@ -22,7 +22,7 @@ import type {XDSChatComposerToken} from './XDSChatComposerInput';
 // Types
 // =============================================================================
 
-export interface XDSChatMessageTokenizedTextProps {
+export interface XDSChatTokenizedTextProps {
   /** The message text containing serialized token values */
   children: string;
   /**
@@ -37,9 +37,14 @@ export interface XDSChatMessageTokenizedTextProps {
    *   label: `@${c.label}`,
    *   variant: 'blue' as const,
    * }));
-   * <XDSChatMessageTokenizedText tokens={mentionTokens}>
+   *
+   * // Input trigger
+   * { character: '@', onSelect: (item) => mentionTokens.find(...) }
+   *
+   * // Display
+   * <XDSChatTokenizedText tokens={mentionTokens}>
    *   {message.text}
-   * </XDSChatMessageTokenizedText>
+   * </XDSChatTokenizedText>
    * ```
    */
   tokens?: XDSChatComposerToken[];
@@ -69,19 +74,19 @@ function escapeRegExp(str: string): string {
  * Accepts the same `XDSChatComposerToken` type used by input triggers,
  * so you can share a single token definition between input and display.
  */
-export function XDSChatMessageTokenizedText({
+export function XDSChatTokenizedText({
   children,
   tokens,
-}: XDSChatMessageTokenizedTextProps) {
-  if (!tokens || tokens.length === 0) {
-    return <span style={{display: 'inline'}}>{children}</span>;
+}: XDSChatTokenizedTextProps) {
+  if (!children || !tokens || tokens.length === 0) {
+    return <span style={{display: 'inline'}}>{children ?? ''}</span>;
   }
 
   const parts = renderTokens(children, tokens);
   return <span style={{display: 'inline'}}>{parts}</span>;
 }
 
-XDSChatMessageTokenizedText.displayName = 'XDSChatMessageTokenizedText';
+XDSChatTokenizedText.displayName = 'XDSChatTokenizedText';
 
 // =============================================================================
 // Render

--- a/packages/core/src/Chat/index.ts
+++ b/packages/core/src/Chat/index.ts
@@ -66,3 +66,6 @@ export type {
   XDSChatToolCallItem,
   XDSChatToolCallStatus,
 } from './XDSChatToolCalls';
+
+export {XDSChatLayout} from './XDSChatLayout';
+export type {XDSChatLayoutProps} from './XDSChatLayout';

--- a/packages/core/src/Chat/index.ts
+++ b/packages/core/src/Chat/index.ts
@@ -30,10 +30,7 @@ export type {
 
 export {XDSChatTokenizedText} from './XDSChatTokenizedText';
 export type {XDSChatTokenizedTextProps} from './XDSChatTokenizedText';
-/** @deprecated Use XDSChatTokenizedText instead */
-export {XDSChatTokenizedText as XDSChatMessageTokenizedText} from './XDSChatTokenizedText';
-/** @deprecated Use XDSChatTokenizedTextProps instead */
-export type {XDSChatTokenizedTextProps as XDSChatMessageTokenizedTextProps} from './XDSChatTokenizedText';
+
 
 export {XDSChatMessageList} from './XDSChatMessageList';
 export type {XDSChatMessageListProps} from './XDSChatMessageList';

--- a/packages/core/src/Chat/index.ts
+++ b/packages/core/src/Chat/index.ts
@@ -28,8 +28,12 @@ export type {
   XDSChatComposerTriggerItem,
 } from './XDSChatComposerInput';
 
-export {XDSChatMessageTokenizedText} from './XDSChatMessageTokenizedText';
-export type {XDSChatMessageTokenizedTextProps} from './XDSChatMessageTokenizedText';
+export {XDSChatTokenizedText} from './XDSChatTokenizedText';
+export type {XDSChatTokenizedTextProps} from './XDSChatTokenizedText';
+/** @deprecated Use XDSChatTokenizedText instead */
+export {XDSChatTokenizedText as XDSChatMessageTokenizedText} from './XDSChatTokenizedText';
+/** @deprecated Use XDSChatTokenizedTextProps instead */
+export type {XDSChatTokenizedTextProps as XDSChatMessageTokenizedTextProps} from './XDSChatTokenizedText';
 
 export {XDSChatMessageList} from './XDSChatMessageList';
 export type {XDSChatMessageListProps} from './XDSChatMessageList';

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -6,13 +6,14 @@
  * @output Exports useAutoScroll hook for scroll-pinning behavior
  * @position Utility hook — used by XDSChatLayout, also usable standalone
  *
- * Uses a scroll-lock model instead of distance thresholds:
- * - **Locked** (default): new content auto-scrolls to bottom
- * - **Unlocked**: user scrolled up, auto-scroll stops
- * - **Re-locked**: user scrolls back to bottom
+ * Scroll-lock model:
+ * - **Locked** (default): content changes auto-scroll to bottom
+ * - **Unlocked**: user manually scrolled, auto-scroll stops
+ * - **Re-locked**: user clicks scroll-to-bottom button
  *
- * scrollToBottom re-locks automatically by scrolling to the bottom,
- * which triggers handleScroll → distance is 0 → re-lock.
+ * Uses `scrollend` to distinguish user scrolls from programmatic ones.
+ * Programmatic scrolls (scrollToBottom) set a flag before scrolling;
+ * when `scrollend` fires without that flag, it was a user scroll → unlock.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Chat/index.ts (exports)
@@ -52,31 +53,31 @@ export interface UseAutoScrollReturn {
   /** Whether new content arrived while unlocked. */
   hasNewMessages: boolean;
 
-  /** Scroll handler — attach to onScroll on the scrollable element. */
+  /** Scroll handler — attach to onScroll. */
   handleScroll: () => void;
 
-  /** User scroll handler — attach to wheel/touchmove to unlock auto-scroll. */
-  handleUserScroll: () => void;
+  /** Scrollend handler — attach to scrollend. */
+  handleScrollEnd: () => void;
 
   /** Scroll to the bottom of the container. */
   scrollToBottom: (smooth?: boolean) => void;
 
-  /** Dismiss the new messages indicator and scroll to bottom. */
+  /** Dismiss the new messages indicator, re-lock, and scroll to bottom. */
   dismissNewMessages: () => void;
 
-  /** New message appended — auto-scroll if locked, flag if unlocked. */
+  /** New message appended — flag "new messages" if unlocked. */
   onContentChange: () => void;
 
-  /** Content grew (streaming) — auto-scroll if locked, no flag. */
+  /** Content grew — auto-scroll if locked, no flag. */
   scrollToBottomIfLocked: () => void;
 }
 
 /**
  * Hook that manages scroll-lock auto-scroll behavior.
  *
- * Starts locked (pinned to bottom). User scrolling up unlocks.
- * User scrolling back to bottom re-locks. Programmatic scrolls
- * (from this hook) don't affect the lock state.
+ * Starts locked (pinned to bottom). User scrolling unlocks (detected
+ * via `scrollend` without the programmatic flag). Clicking the
+ * scroll-to-bottom button re-locks.
  */
 export function useAutoScroll({
   enabled = true,
@@ -92,10 +93,13 @@ export function useAutoScroll({
 
   // Scroll lock: true = auto-scroll follows content
   const lockedRef = useRef(true);
+  // Flag set before programmatic scrolls, cleared on scrollend
+  const isProgrammaticRef = useRef(false);
 
   const scrollToBottom = useCallback((smooth = true) => {
     const el = scrollRef.current;
     if (!el) return;
+    isProgrammaticRef.current = true;
     if (typeof el.scrollTo === 'function') {
       el.scrollTo({
         top: el.scrollHeight,
@@ -106,42 +110,32 @@ export function useAutoScroll({
     }
   }, []);
 
-  // Track user intent to scroll — wheel up or touch sets a flag,
-  // then handleScroll checks if they've actually moved away from bottom.
-  const userScrollingRef = useRef(false);
-
-  const handleUserScroll = useCallback((e: Event) => {
-    if (e instanceof WheelEvent && e.deltaY < 0) {
-      userScrollingRef.current = true;
-    } else if (e.type === 'touchmove') {
-      userScrollingRef.current = true;
-    }
-  }, []);
-
+  // Fires on every scroll frame — just updates button visibility
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
-
     const distanceFromBottom =
       el.scrollHeight - el.scrollTop - el.clientHeight;
-
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
-
-    // Only unlock when the user has actively scrolled away from bottom
-    if (userScrollingRef.current && distanceFromBottom > scrollUpThreshold) {
-      lockedRef.current = false;
-    }
-    userScrollingRef.current = false;
   }, [scrollUpThreshold]);
+
+  // Fires once when scrolling settles
+  const handleScrollEnd = useCallback(() => {
+    if (isProgrammaticRef.current) {
+      // Our scroll — stay locked
+      isProgrammaticRef.current = false;
+      return;
+    }
+    // User scroll — unlock
+    lockedRef.current = false;
+  }, []);
 
   const onContentChange = useCallback(() => {
     if (!enabled) return;
-    if (lockedRef.current) {
-      scrollToBottom(true);
-    } else {
+    if (!lockedRef.current) {
       setHasNewMessages(true);
     }
-  }, [enabled, scrollToBottom]);
+  }, [enabled]);
 
   const scrollToBottomIfLocked = useCallback(() => {
     if (!enabled) return;
@@ -152,6 +146,7 @@ export function useAutoScroll({
 
   const dismissNewMessages = useCallback(() => {
     lockedRef.current = true;
+    isProgrammaticRef.current = true;
     setIsScrolledUp(false);
     setHasNewMessages(false);
     scrollToBottom();
@@ -167,7 +162,7 @@ export function useAutoScroll({
     isScrolledUp,
     hasNewMessages,
     handleScroll,
-    handleUserScroll,
+    handleScrollEnd,
     scrollToBottom,
     dismissNewMessages,
     onContentChange,

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -11,9 +11,8 @@
  * - **Unlocked**: user scrolled up, auto-scroll stops
  * - **Re-locked**: user scrolls back to bottom
  *
- * Distinguishes user-initiated scrolls (wheel, touch, keyboard) from
- * programmatic scrolls (our scrollToBottom calls) using a flag that's
- * set before programmatic scrolls and cleared on the next frame.
+ * scrollToBottom re-locks automatically by scrolling to the bottom,
+ * which triggers handleScroll → distance is 0 → re-lock.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Chat/index.ts (exports)
@@ -98,13 +97,10 @@ export function useAutoScroll({
 
   // Scroll lock: true = auto-scroll follows content
   const lockedRef = useRef(true);
-  // Flag to distinguish programmatic scrolls from user scrolls
-  const isProgrammaticRef = useRef(false);
 
   const scrollToBottom = useCallback((smooth = true) => {
     const el = scrollRef.current;
     if (!el) return;
-    isProgrammaticRef.current = true;
     if (typeof el.scrollTo === 'function') {
       el.scrollTo({
         top: el.scrollHeight,
@@ -113,10 +109,6 @@ export function useAutoScroll({
     } else {
       el.scrollTop = el.scrollHeight;
     }
-    // Clear programmatic flag after the scroll event fires
-    requestAnimationFrame(() => {
-      isProgrammaticRef.current = false;
-    });
   }, []);
 
   const handleScroll = useCallback(() => {
@@ -128,9 +120,6 @@ export function useAutoScroll({
 
     // Update button visibility
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
-
-    // Only user-initiated scrolls affect the lock
-    if (isProgrammaticRef.current) return;
 
     if (distanceFromBottom <= bottomThreshold) {
       // User scrolled to bottom — re-lock

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -103,7 +103,6 @@ export function useAutoScroll({
     const el = scrollRef.current;
     if (!el) return;
     isProgrammaticRef.current = true;
-    console.debug('[auto-scroll] scrollToBottom', {smooth, scrollHeight: el.scrollHeight});
     if (typeof el.scrollTo === 'function') {
       el.scrollTo({
         top: el.scrollHeight,
@@ -116,7 +115,6 @@ export function useAutoScroll({
 
   // User input (wheel/touch) interrupts any in-progress programmatic scroll
   const handleUserScroll = useCallback(() => {
-    if (isProgrammaticRef.current) console.debug('[auto-scroll] user interrupt');
     isProgrammaticRef.current = false;
   }, []);
 
@@ -129,21 +127,18 @@ export function useAutoScroll({
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
 
     if (!isProgrammaticRef.current && distanceFromBottom > scrollUpThreshold) {
-      console.debug('[auto-scroll] UNLOCK', {distanceFromBottom});
       lockedRef.current = false;
     }
   }, [scrollUpThreshold]);
 
   // On scroll end: lock if at bottom, clear programmatic flag
   const handleScrollEnd = useCallback(() => {
-    const wasProgrammatic = isProgrammaticRef.current;
     isProgrammaticRef.current = false;
 
     const el = scrollRef.current;
     if (!el) return;
     const distanceFromBottom =
       el.scrollHeight - el.scrollTop - el.clientHeight;
-    console.debug('[auto-scroll] scrollend', {wasProgrammatic, distanceFromBottom, locked: lockedRef.current});
     if (distanceFromBottom <= scrollUpThreshold) {
       lockedRef.current = true;
       setHasNewMessages(false);
@@ -153,7 +148,6 @@ export function useAutoScroll({
   const onContentChange = useCallback(() => {
     if (!enabled) return;
     if (!lockedRef.current) {
-      console.debug('[auto-scroll] new msg while unlocked');
       setHasNewMessages(true);
     }
   }, [enabled]);
@@ -161,10 +155,7 @@ export function useAutoScroll({
   const scrollToBottomIfLocked = useCallback(() => {
     if (!enabled) return;
     if (lockedRef.current) {
-      console.debug('[auto-scroll] content grew — scrolling (locked)');
       scrollToBottom(true);
-    } else {
-      console.debug('[auto-scroll] content grew — skipped (unlocked)');
     }
   }, [enabled, scrollToBottom]);
 

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -110,7 +110,7 @@ export function useAutoScroll({
     }
   }, []);
 
-  // Fires on every scroll frame — unlock immediately on user scroll
+  // On scroll: unlock if user scrolled past threshold
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -118,14 +118,12 @@ export function useAutoScroll({
       el.scrollHeight - el.scrollTop - el.clientHeight;
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
 
-    // User scroll — unlock immediately
-    if (!isProgrammaticRef.current) {
+    if (!isProgrammaticRef.current && distanceFromBottom > scrollUpThreshold) {
       lockedRef.current = false;
     }
   }, [scrollUpThreshold]);
 
-  // Fires once when scrolling settles — clear programmatic flag,
-  // and re-lock if the user scrolled back to the bottom.
+  // On scroll end: lock if at bottom, clear programmatic flag
   const handleScrollEnd = useCallback(() => {
     isProgrammaticRef.current = false;
 
@@ -136,7 +134,6 @@ export function useAutoScroll({
     if (distanceFromBottom <= scrollUpThreshold) {
       lockedRef.current = true;
       setHasNewMessages(false);
-      setIsScrolledUp(false);
     }
   }, [scrollUpThreshold]);
 

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -124,10 +124,21 @@ export function useAutoScroll({
     }
   }, [scrollUpThreshold]);
 
-  // Fires once when scrolling settles — clear programmatic flag
+  // Fires once when scrolling settles — clear programmatic flag,
+  // and re-lock if the user scrolled back to the bottom.
   const handleScrollEnd = useCallback(() => {
     isProgrammaticRef.current = false;
-  }, []);
+
+    const el = scrollRef.current;
+    if (!el) return;
+    const distanceFromBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom <= scrollUpThreshold) {
+      lockedRef.current = true;
+      setHasNewMessages(false);
+      setIsScrolledUp(false);
+    }
+  }, [scrollUpThreshold]);
 
   const onContentChange = useCallback(() => {
     if (!enabled) return;

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -110,24 +110,23 @@ export function useAutoScroll({
     }
   }, []);
 
-  // Fires on every scroll frame — just updates button visibility
+  // Fires on every scroll frame — unlock immediately on user scroll
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
     const distanceFromBottom =
       el.scrollHeight - el.scrollTop - el.clientHeight;
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
+
+    // User scroll — unlock immediately
+    if (!isProgrammaticRef.current) {
+      lockedRef.current = false;
+    }
   }, [scrollUpThreshold]);
 
-  // Fires once when scrolling settles
+  // Fires once when scrolling settles — clear programmatic flag
   const handleScrollEnd = useCallback(() => {
-    if (isProgrammaticRef.current) {
-      // Our scroll — stay locked
-      isProgrammaticRef.current = false;
-      return;
-    }
-    // User scroll — unlock
-    lockedRef.current = false;
+    isProgrammaticRef.current = false;
   }, []);
 
   const onContentChange = useCallback(() => {

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -103,6 +103,7 @@ export function useAutoScroll({
     const el = scrollRef.current;
     if (!el) return;
     isProgrammaticRef.current = true;
+    console.debug('[auto-scroll] scrollToBottom', {smooth, scrollHeight: el.scrollHeight});
     if (typeof el.scrollTo === 'function') {
       el.scrollTo({
         top: el.scrollHeight,
@@ -115,6 +116,7 @@ export function useAutoScroll({
 
   // User input (wheel/touch) interrupts any in-progress programmatic scroll
   const handleUserScroll = useCallback(() => {
+    if (isProgrammaticRef.current) console.debug('[auto-scroll] user interrupt');
     isProgrammaticRef.current = false;
   }, []);
 
@@ -127,18 +129,21 @@ export function useAutoScroll({
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
 
     if (!isProgrammaticRef.current && distanceFromBottom > scrollUpThreshold) {
+      console.debug('[auto-scroll] UNLOCK', {distanceFromBottom});
       lockedRef.current = false;
     }
   }, [scrollUpThreshold]);
 
   // On scroll end: lock if at bottom, clear programmatic flag
   const handleScrollEnd = useCallback(() => {
+    const wasProgrammatic = isProgrammaticRef.current;
     isProgrammaticRef.current = false;
 
     const el = scrollRef.current;
     if (!el) return;
     const distanceFromBottom =
       el.scrollHeight - el.scrollTop - el.clientHeight;
+    console.debug('[auto-scroll] scrollend', {wasProgrammatic, distanceFromBottom, locked: lockedRef.current});
     if (distanceFromBottom <= scrollUpThreshold) {
       lockedRef.current = true;
       setHasNewMessages(false);
@@ -148,6 +153,7 @@ export function useAutoScroll({
   const onContentChange = useCallback(() => {
     if (!enabled) return;
     if (!lockedRef.current) {
+      console.debug('[auto-scroll] new msg while unlocked');
       setHasNewMessages(true);
     }
   }, [enabled]);
@@ -155,7 +161,10 @@ export function useAutoScroll({
   const scrollToBottomIfLocked = useCallback(() => {
     if (!enabled) return;
     if (lockedRef.current) {
+      console.debug('[auto-scroll] content grew — scrolling (locked)');
       scrollToBottom(true);
+    } else {
+      console.debug('[auto-scroll] content grew — skipped (unlocked)');
     }
   }, [enabled, scrollToBottom]);
 

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -39,6 +39,14 @@ export interface UseAutoScrollOptions {
    * @default 100
    */
   scrollUpThreshold?: number;
+
+  /**
+   * External scroll container ref. When provided, scroll logic targets
+   * this element instead of creating its own. Use when the message list
+   * is in page flow (e.g. inside XDSChatLayout) and the scrollable
+   * ancestor is a parent element or the viewport.
+   */
+  scrollContainerRef?: React.RefObject<HTMLElement | null>;
 }
 
 export interface UseAutoScrollReturn {
@@ -89,8 +97,11 @@ export function useAutoScroll({
   enabled = true,
   threshold = 12,
   scrollUpThreshold = 100,
+  scrollContainerRef,
 }: UseAutoScrollOptions = {}): UseAutoScrollReturn {
-  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const internalRef = useRef<HTMLDivElement | null>(null);
+  const scrollRef = (scrollContainerRef ??
+    internalRef) as React.RefObject<HTMLDivElement | null>;
   const [hasNewMessages, setHasNewMessages] = useState(false);
   const [isScrolledUp, setIsScrolledUp] = useState(false);
   const isNearBottomRef = useRef(true);

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -4,18 +4,20 @@
  * @file useAutoScroll.ts
  * @input Uses React refs, state, and effects
  * @output Exports useAutoScroll hook for scroll-pinning behavior
- * @position Utility hook — used by XDSChatMessageList, also usable standalone
+ * @position Utility hook — used by XDSChatLayout, also usable standalone
  *
- * Exposes two scroll states:
- * - `isScrolledUp` — true when the user has scrolled away from the bottom
- *   (beyond `scrollUpThreshold`), regardless of whether new content arrived.
- *   Drives a scroll-to-bottom affordance.
- * - `hasNewMessages` — true when new content arrived while scrolled up.
- *   Layers on top of isScrolledUp to add a "new messages" notification.
+ * Uses a scroll-lock model instead of distance thresholds:
+ * - **Locked** (default): new content auto-scrolls to bottom
+ * - **Unlocked**: user scrolled up, auto-scroll stops
+ * - **Re-locked**: user scrolls back to bottom
+ *
+ * Distinguishes user-initiated scrolls (wheel, touch, keyboard) from
+ * programmatic scrolls (our scrollToBottom calls) using a flag that's
+ * set before programmatic scrolls and cleared on the next frame.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Chat/index.ts (exports)
- * - /packages/core/src/Chat/XDSChatMessageList.tsx (consumer)
+ * - /packages/core/src/Chat/XDSChatLayout.tsx (consumer)
  */
 
 import {useCallback, useEffect, useRef, useState} from 'react';
@@ -28,23 +30,22 @@ export interface UseAutoScrollOptions {
   enabled?: boolean;
 
   /**
-   * Distance from bottom (in px) within which new content triggers auto-scroll.
-   * @default 12
+   * Distance from bottom (in px) within which the user is considered
+   * "at the bottom" for re-locking auto-scroll.
+   * @default 20
    */
-  threshold?: number;
+  bottomThreshold?: number;
 
   /**
-   * Distance from bottom (in px) beyond which `isScrolledUp` becomes true.
-   * Controls when the scroll-to-bottom button appears.
+   * Distance from bottom (in px) beyond which the scroll-to-bottom
+   * button becomes visible.
    * @default 100
    */
   scrollUpThreshold?: number;
 
   /**
    * External scroll container ref. When provided, scroll logic targets
-   * this element instead of creating its own. Use when the message list
-   * is in page flow (e.g. inside XDSChatLayout) and the scrollable
-   * ancestor is a parent element or the viewport.
+   * this element instead of creating its own.
    */
   scrollContainerRef?: React.RefObject<HTMLElement | null>;
 }
@@ -53,10 +54,10 @@ export interface UseAutoScrollReturn {
   /** Ref to attach to the scrollable container element. */
   scrollRef: React.RefObject<HTMLDivElement | null>;
 
-  /** Whether the user has scrolled up beyond `scrollUpThreshold`. */
+  /** Whether the user has scrolled up (shows scroll-to-bottom button). */
   isScrolledUp: boolean;
 
-  /** Whether new content arrived while the user is scrolled up. */
+  /** Whether new content arrived while unlocked. */
   hasNewMessages: boolean;
 
   /** Scroll handler — attach to onScroll on the scrollable element. */
@@ -68,50 +69,42 @@ export interface UseAutoScrollReturn {
   /** Dismiss the new messages indicator and scroll to bottom. */
   dismissNewMessages: () => void;
 
-  /** Notify the hook that content changed (triggers auto-scroll check). */
+  /** New message appended — auto-scroll if locked, flag if unlocked. */
   onContentChange: () => void;
 
-  /** Scroll to bottom only if the user is near the bottom. Does not flag new messages. */
-  scrollToBottomIfNearBottom: () => void;
+  /** Content grew (streaming) — auto-scroll if locked, no flag. */
+  scrollToBottomIfLocked: () => void;
 }
 
 /**
- * Hook that manages auto-scroll behavior for scrollable containers.
+ * Hook that manages scroll-lock auto-scroll behavior.
  *
- * Pins to the bottom when the user is near the end. Tracks two
- * orthogonal states: whether the user has scrolled up (for a
- * scroll-to-bottom affordance) and whether new content arrived
- * while scrolled up (for a "new messages" notification).
- *
- * @example
- * ```
- * const {scrollRef, isScrolledUp, hasNewMessages, handleScroll, scrollToBottom, dismissNewMessages} = useAutoScroll();
- *
- * return (
- *   <div ref={scrollRef} onScroll={handleScroll}>
- *     {messages}
- *     {isScrolledUp && <button onClick={scrollToBottom}>↓</button>}
- *     {hasNewMessages && <button onClick={dismissNewMessages}>New messages</button>}
- *   </div>
- * );
- * ```
+ * Starts locked (pinned to bottom). User scrolling up unlocks.
+ * User scrolling back to bottom re-locks. Programmatic scrolls
+ * (from this hook) don't affect the lock state.
  */
 export function useAutoScroll({
   enabled = true,
-  threshold = 12,
+  bottomThreshold = 20,
   scrollUpThreshold = 100,
   scrollContainerRef,
 }: UseAutoScrollOptions = {}): UseAutoScrollReturn {
   const internalRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = (scrollContainerRef ??
     internalRef) as React.RefObject<HTMLDivElement | null>;
+
   const [hasNewMessages, setHasNewMessages] = useState(false);
   const [isScrolledUp, setIsScrolledUp] = useState(false);
-  const isNearBottomRef = useRef(true);
+
+  // Scroll lock: true = auto-scroll follows content
+  const lockedRef = useRef(true);
+  // Flag to distinguish programmatic scrolls from user scrolls
+  const isProgrammaticRef = useRef(false);
 
   const scrollToBottom = useCallback((smooth = true) => {
     const el = scrollRef.current;
     if (!el) return;
+    isProgrammaticRef.current = true;
     if (typeof el.scrollTo === 'function') {
       el.scrollTo({
         top: el.scrollHeight,
@@ -120,40 +113,53 @@ export function useAutoScroll({
     } else {
       el.scrollTop = el.scrollHeight;
     }
+    // Clear programmatic flag after the scroll event fires
+    requestAnimationFrame(() => {
+      isProgrammaticRef.current = false;
+    });
   }, []);
 
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
-    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
-    const nearBottom = distanceFromBottom <= threshold;
-    isNearBottomRef.current = nearBottom;
 
-    // Track whether user is scrolled up beyond the visible threshold
+    const distanceFromBottom =
+      el.scrollHeight - el.scrollTop - el.clientHeight;
+
+    // Update button visibility
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
 
-    if (nearBottom) {
+    // Only user-initiated scrolls affect the lock
+    if (isProgrammaticRef.current) return;
+
+    if (distanceFromBottom <= bottomThreshold) {
+      // User scrolled to bottom — re-lock
+      lockedRef.current = true;
       setHasNewMessages(false);
+    } else {
+      // User scrolled up — unlock
+      lockedRef.current = false;
     }
-  }, [threshold, scrollUpThreshold]);
+  }, [bottomThreshold, scrollUpThreshold]);
 
   const onContentChange = useCallback(() => {
     if (!enabled) return;
-    if (isNearBottomRef.current) {
+    if (lockedRef.current) {
       scrollToBottom(true);
     } else {
       setHasNewMessages(true);
     }
   }, [enabled, scrollToBottom]);
 
-  const scrollToBottomIfNearBottom = useCallback(() => {
+  const scrollToBottomIfLocked = useCallback(() => {
     if (!enabled) return;
-    if (isNearBottomRef.current) {
+    if (lockedRef.current) {
       scrollToBottom(true);
     }
   }, [enabled, scrollToBottom]);
 
   const dismissNewMessages = useCallback(() => {
+    lockedRef.current = true;
     scrollToBottom();
     setHasNewMessages(false);
   }, [scrollToBottom]);
@@ -171,6 +177,6 @@ export function useAutoScroll({
     scrollToBottom,
     dismissNewMessages,
     onContentChange,
-    scrollToBottomIfNearBottom,
+    scrollToBottomIfLocked,
   };
 }

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -70,6 +70,9 @@ export interface UseAutoScrollReturn {
 
   /** Notify the hook that content changed (triggers auto-scroll check). */
   onContentChange: () => void;
+
+  /** Scroll to bottom only if the user is near the bottom. Does not flag new messages. */
+  scrollToBottomIfNearBottom: () => void;
 }
 
 /**
@@ -143,6 +146,13 @@ export function useAutoScroll({
     }
   }, [enabled, scrollToBottom]);
 
+  const scrollToBottomIfNearBottom = useCallback(() => {
+    if (!enabled) return;
+    if (isNearBottomRef.current) {
+      scrollToBottom(true);
+    }
+  }, [enabled, scrollToBottom]);
+
   const dismissNewMessages = useCallback(() => {
     scrollToBottom();
     setHasNewMessages(false);
@@ -161,5 +171,6 @@ export function useAutoScroll({
     scrollToBottom,
     dismissNewMessages,
     onContentChange,
+    scrollToBottomIfNearBottom,
   };
 }

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -62,6 +62,9 @@ export interface UseAutoScrollReturn {
   /** Scroll handler — attach to onScroll on the scrollable element. */
   handleScroll: () => void;
 
+  /** User scroll handler — attach to wheel/touchmove to unlock auto-scroll. */
+  handleUserScroll: () => void;
+
   /** Scroll to the bottom of the container. */
   scrollToBottom: (smooth?: boolean) => void;
 
@@ -111,6 +114,21 @@ export function useAutoScroll({
     }
   }, []);
 
+  // Wheel/touch up = user intent to scroll away — unlock.
+  // Only unlocks on upward scroll to avoid false unlocks when
+  // the user scrolls down at the bottom (no-op visually).
+  const handleUserScroll = useCallback((e: Event) => {
+    if (e instanceof WheelEvent && e.deltaY < 0) {
+      lockedRef.current = false;
+    } else if (e.type === 'touchmove') {
+      // Touch direction is tracked via touchstart/touchmove delta
+      // For simplicity, any touchmove unlocks — re-lock happens
+      // automatically when the user reaches the bottom.
+      lockedRef.current = false;
+    }
+  }, []);
+
+  // Scroll position check — only used to re-lock + update button
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -118,16 +136,11 @@ export function useAutoScroll({
     const distanceFromBottom =
       el.scrollHeight - el.scrollTop - el.clientHeight;
 
-    // Update button visibility
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
 
     if (distanceFromBottom <= bottomThreshold) {
-      // User scrolled to bottom — re-lock
       lockedRef.current = true;
       setHasNewMessages(false);
-    } else {
-      // User scrolled up — unlock
-      lockedRef.current = false;
     }
   }, [bottomThreshold, scrollUpThreshold]);
 
@@ -163,6 +176,7 @@ export function useAutoScroll({
     isScrolledUp,
     hasNewMessages,
     handleScroll,
+    handleUserScroll,
     scrollToBottom,
     dismissNewMessages,
     onContentChange,

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -29,13 +29,6 @@ export interface UseAutoScrollOptions {
   enabled?: boolean;
 
   /**
-   * Distance from bottom (in px) within which the user is considered
-   * "at the bottom" for re-locking auto-scroll.
-   * @default 20
-   */
-  bottomThreshold?: number;
-
-  /**
    * Distance from bottom (in px) beyond which the scroll-to-bottom
    * button becomes visible.
    * @default 100
@@ -87,7 +80,6 @@ export interface UseAutoScrollReturn {
  */
 export function useAutoScroll({
   enabled = true,
-  bottomThreshold = 20,
   scrollUpThreshold = 100,
   scrollContainerRef,
 }: UseAutoScrollOptions = {}): UseAutoScrollReturn {
@@ -114,21 +106,18 @@ export function useAutoScroll({
     }
   }, []);
 
-  // Wheel/touch up = user intent to scroll away — unlock.
-  // Only unlocks on upward scroll to avoid false unlocks when
-  // the user scrolls down at the bottom (no-op visually).
+  // Track user intent to scroll — wheel up or touch sets a flag,
+  // then handleScroll checks if they've actually moved away from bottom.
+  const userScrollingRef = useRef(false);
+
   const handleUserScroll = useCallback((e: Event) => {
     if (e instanceof WheelEvent && e.deltaY < 0) {
-      lockedRef.current = false;
+      userScrollingRef.current = true;
     } else if (e.type === 'touchmove') {
-      // Touch direction is tracked via touchstart/touchmove delta
-      // For simplicity, any touchmove unlocks — re-lock happens
-      // automatically when the user reaches the bottom.
-      lockedRef.current = false;
+      userScrollingRef.current = true;
     }
   }, []);
 
-  // Scroll position check — only used to re-lock + update button
   const handleScroll = useCallback(() => {
     const el = scrollRef.current;
     if (!el) return;
@@ -138,11 +127,12 @@ export function useAutoScroll({
 
     setIsScrolledUp(distanceFromBottom > scrollUpThreshold);
 
-    if (distanceFromBottom <= bottomThreshold) {
-      lockedRef.current = true;
-      setHasNewMessages(false);
+    // Only unlock when the user has actively scrolled away from bottom
+    if (userScrollingRef.current && distanceFromBottom > scrollUpThreshold) {
+      lockedRef.current = false;
     }
-  }, [bottomThreshold, scrollUpThreshold]);
+    userScrollingRef.current = false;
+  }, [scrollUpThreshold]);
 
   const onContentChange = useCallback(() => {
     if (!enabled) return;
@@ -162,8 +152,9 @@ export function useAutoScroll({
 
   const dismissNewMessages = useCallback(() => {
     lockedRef.current = true;
-    scrollToBottom();
+    setIsScrolledUp(false);
     setHasNewMessages(false);
+    scrollToBottom();
   }, [scrollToBottom]);
 
   // Scroll to bottom on mount

--- a/packages/core/src/Chat/useAutoScroll.ts
+++ b/packages/core/src/Chat/useAutoScroll.ts
@@ -59,6 +59,9 @@ export interface UseAutoScrollReturn {
   /** Scrollend handler — attach to scrollend. */
   handleScrollEnd: () => void;
 
+  /** User input handler — attach to wheel/touchstart to interrupt programmatic scrolls. */
+  handleUserScroll: () => void;
+
   /** Scroll to the bottom of the container. */
   scrollToBottom: (smooth?: boolean) => void;
 
@@ -108,6 +111,11 @@ export function useAutoScroll({
     } else {
       el.scrollTop = el.scrollHeight;
     }
+  }, []);
+
+  // User input (wheel/touch) interrupts any in-progress programmatic scroll
+  const handleUserScroll = useCallback(() => {
+    isProgrammaticRef.current = false;
   }, []);
 
   // On scroll: unlock if user scrolled past threshold
@@ -170,6 +178,7 @@ export function useAutoScroll({
     hasNewMessages,
     handleScroll,
     handleScrollEnd,
+    handleUserScroll,
     scrollToBottom,
     dismissNewMessages,
     onContentChange,

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -247,6 +247,7 @@ export function XDSProgressBar({
   style,
   'data-testid': dataTestId,
   ref,
+  ...rest
 }: XDSProgressBarProps) {
   const labelId = useId();
   const clampedValue = Math.min(Math.max(0, value), max);
@@ -265,7 +266,8 @@ export function XDSProgressBar({
         className,
         style,
       )}
-      data-testid={dataTestId}>
+      data-testid={dataTestId}
+      {...rest}>
       {/* Label row */}
       {!isLabelHidden || showValueLabel ? (
         <div {...stylex.props(styles.header)}>

--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -131,6 +131,7 @@ const styles = stylex.create({
     flexDirection: 'column',
     gap: spacingVars['--spacing-1'],
     width: '100%',
+    minWidth: '48px',
   },
   header: {
     display: 'flex',


### PR DESCRIPTION
## What

New `XDSChatLayout` component — layout shell for full chat interfaces.

### Architecture
- **Messages**: normal page flow, not in a fixed container. Scrolls with the page.
- **Composer dock**: `position: fixed` at viewport bottom with frosted glass (`backdrop-filter: blur(12px)`) and CSS mask gradient fade at top
- **Container queries**: ResizeObserver on root drives density breakpoints

### Breakpoints

| Container width | Density | Message max-width | Dock padding | Fade |
|----------------|---------|-------------------|--------------|------|
| < 480px | compact | 100% | spacing-2 | 16px |
| 480–768px | balanced | 100% | spacing-3 | 20px |
| > 768px | spacious | 800px centered | spacing-4 | 24px |

### API
```tsx
<XDSChatLayout
  composer={<XDSChatComposer onSubmit={handleSubmit} />}
  emptyState={<EmptyState />}
>
  {messages.map(msg => <XDSChatMessage ... />)}
</XDSChatLayout>
```

### Files
- `XDSChatLayout.tsx` — component with ResizeObserver density
- `XDSChatLayout.test.tsx` — 6 tests
- `ChatLayout.stories.tsx` — Default, PanelView (400px), WithEmptyState
- Updated index.ts exports and Chat.doc.mjs (en/zh/dense)

### Verification
- yarn build ✓
- All 2828 tests pass ✓
- yarn lint clean ✓