### PR TITLE
fix(sandbox): prefix docsite image paths with basePath

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -547,10 +547,11 @@ function BoidsCanvas({
 // Template data — real images from /public/templates/
 // ---------------------------------------------------------------------------
 
-const DUMMY_IMAGE = '/templates/dummy-placeholder.png';
-const FIRST_CARD_IMAGE = '/templates/first-card.png';
-const SHOPPING_DETAILS_IMAGE = '/templates/shopping-details.png';
-const SCREENSHOT_3_IMAGE = '/templates/screenshot-3.png';
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+const DUMMY_IMAGE = `${basePath}/templates/dummy-placeholder.png`;
+const FIRST_CARD_IMAGE = `${basePath}/templates/first-card.png`;
+const SHOPPING_DETAILS_IMAGE = `${basePath}/templates/shopping-details.png`;
+const SCREENSHOT_3_IMAGE = `${basePath}/templates/screenshot-3.png`;
 
 const TEMPLATE_IMAGES = [DUMMY_IMAGE, DUMMY_IMAGE, DUMMY_IMAGE, DUMMY_IMAGE];
 


### PR DESCRIPTION
Images on the docsite page use absolute paths like `/templates/foo.png`, which resolve correctly in local dev but break on GitHub Pages where the app is deployed under a subpath (e.g. `/sandbox/`).

Prefixes all image constants with `NEXT_PUBLIC_BASE_PATH` — the same pattern already used in `ProjectCard.tsx`.