### PR TITLE
docs: fix Storybook @example blocks, add Toast translations and theming

### DIFF
--- a/packages/core/src/Chat/XDSChatToolCalls.tsx
+++ b/packages/core/src/Chat/XDSChatToolCalls.tsx
@@ -347,7 +347,15 @@ function ErrorIcon() {
 
 function WrenchIcon() {
   return (
-    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round">
       <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
     </svg>
   );
@@ -388,11 +396,7 @@ const STATUS_STYLES: Record<
 // Internal: single call row
 // =============================================================================
 
-function CallRow({
-  call,
-}: {
-  call: XDSChatToolCallItem;
-}) {
+function CallRow({call}: {call: XDSChatToolCallItem}) {
   const status = call.status ?? 'complete';
   const Icon = STATUS_ICONS[status];
   const isClickable = call.onClick != null;
@@ -403,12 +407,16 @@ function CallRow({
         role={isClickable ? 'button' : undefined}
         tabIndex={isClickable ? 0 : undefined}
         onClick={call.onClick}
-        onKeyDown={isClickable ? (e: React.KeyboardEvent) => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            call.onClick?.();
-          }
-        } : undefined}
+        onKeyDown={
+          isClickable
+            ? (e: React.KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  call.onClick?.();
+                }
+              }
+            : undefined
+        }
         {...stylex.props(
           styles.callRow,
           isClickable && styles.callRowClickable,
@@ -425,7 +433,11 @@ function CallRow({
         </span>
         <span {...stylex.props(styles.callName)}>{call.name}</span>
         {call.node != null && (
-          <XDSBadge label={call.node} variant="neutral" xstyle={styles.nodePill} />
+          <XDSBadge
+            label={call.node}
+            variant="neutral"
+            xstyle={styles.nodePill}
+          />
         )}
         {call.label != null && (
           <span {...stylex.props(styles.callLabel)}>{call.label}</span>
@@ -433,16 +445,24 @@ function CallRow({
         {call.stats != null && (
           <span {...stylex.props(styles.stats)}>
             {call.stats.files != null && (
-              <span>{call.stats.files} file{call.stats.files !== 1 ? 's' : ''}</span>
+              <span>
+                {call.stats.files} file{call.stats.files !== 1 ? 's' : ''}
+              </span>
             )}
             {call.stats.matches != null && (
-              <span>{call.stats.matches} match{call.stats.matches !== 1 ? 'es' : ''}</span>
+              <span>
+                {call.stats.matches} match{call.stats.matches !== 1 ? 'es' : ''}
+              </span>
             )}
             {call.stats.additions != null && (
-              <span {...stylex.props(styles.statsAdditions)}>+{call.stats.additions}</span>
+              <span {...stylex.props(styles.statsAdditions)}>
+                +{call.stats.additions}
+              </span>
             )}
             {call.stats.deletions != null && (
-              <span {...stylex.props(styles.statsDeletions)}>-{call.stats.deletions}</span>
+              <span {...stylex.props(styles.statsDeletions)}>
+                -{call.stats.deletions}
+              </span>
             )}
           </span>
         )}
@@ -467,7 +487,6 @@ function CallRow({
  *
  * @example
  * ```
- * // Basic — pass the array from your LLM response
  * <XDSChatToolCalls
  *   calls={message.toolCalls.map(tc => ({
  *     name: tc.toolName,
@@ -475,11 +494,6 @@ function CallRow({
  *     duration: tc.duration,
  *   }))}
  * />
- * ```
- *
- * @example
- * ```
- * // With detail rendering
  * <XDSChatToolCalls
  *   calls={toolCalls}
  *   renderDetail={(call) => (
@@ -536,9 +550,12 @@ export function XDSChatToolCalls(props: XDSChatToolCallsProps) {
   const label = customLabel ?? `${calls.length} tool calls`;
   const errorLabel = hasErrors ? (
     <>
-      {label} · <span {...stylex.props(styles.errorText)}>{errorCount} failed</span>
+      {label} ·{' '}
+      <span {...stylex.props(styles.errorText)}>{errorCount} failed</span>
     </>
-  ) : label;
+  ) : (
+    label
+  );
 
   return (
     <div
@@ -582,10 +599,7 @@ export function XDSChatToolCalls(props: XDSChatToolCallsProps) {
         <div {...stylex.props(styles.groupContentInner)}>
           <div {...stylex.props(styles.list, styles.listIndented)}>
             {calls.map((call, i) => (
-              <CallRow
-                key={call.key ?? i}
-                call={call}
-              />
+              <CallRow key={call.key ?? i} call={call} />
             ))}
           </div>
         </div>

--- a/packages/core/src/Toast/Toast.doc.mjs
+++ b/packages/core/src/Toast/Toast.doc.mjs
@@ -80,6 +80,12 @@ export const docs = {
       code: `toast({\n  body: "Item deleted",\n  isAutoHide: false,\n  endContent: <XDSButton label="Undo" variant="secondary" size="sm" onClick={undo} />,\n});`,
     },
   ],
+  theming: {
+    targets: [
+      {className: 'xds-toast', visualProps: ['type']},
+    ],
+  },
+
   usage: {
     summary: 'Transient notification that appears briefly to confirm an action or surface non-critical information.',
     content: `## When to use
@@ -93,5 +99,95 @@ export const docs = {
 - Critical information that requires user action (use Banner instead).
 - Persistent messages (use Banner instead).
 - Validation errors on form fields (use Field status instead).`,
+  },
+};
+
+// -------------------------------------------------------
+// Auto-generated translations below. Do not edit manually.
+// Regenerate with the dense compression protocol.
+// See .context/decisions/dense-compression-protocol.md
+// -------------------------------------------------------
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsZh = {
+  description:
+    'Toast 通知系统，支持自动关闭、堆叠、去重和平滑动画。使用 XDSMediaTheme 进行反转表面主题。',
+  features: [
+    "类型：'info'（默认）、'error'",
+    '自动关闭：info toast 5秒后关闭，error toast 持续显示',
+    '悬停/聚焦暂停：交互时计时器暂停',
+    '堆叠：多个 toast 以平滑进出动画堆叠',
+    '去重：uniqueID 支持 ignore 或 overwrite 碰撞行为',
+    '程序化关闭：show() 返回关闭函数',
+    '尾部内容插槽：尾随操作（按钮、链接）',
+    '回退视口：无需 provider，通过 document.body 回退',
+    '反转表面：使用 XDSMediaTheme 在深色/浅色背景上显示正确颜色',
+    '无障碍：role=status/alert，aria-live=polite/assertive',
+  ],
+  propDescriptions: {
+    body: '主要消息内容。',
+    type: 'Toast 类型，控制背景颜色。error toast 持续显示直到关闭。',
+    isAutoHide: '是否自动关闭。info 默认为 true，error 默认为 false。',
+    autoHideDuration: '自动关闭前的持续时间（毫秒）。',
+    endContent: '尾部渲染的内容（如撤销按钮、链接）。',
+    uniqueID: '用于去重的唯一标识符。',
+    collisionBehavior: '当已存在相同 uniqueID 的 toast 时的行为。',
+    onHide: '当 toast 被移除时触发的回调。',
+  },
+  usage: {
+    summary: '短暂通知，出现片刻以确认操作或显示非关键信息。',
+    content: `## 何时使用
+
+- 确认已完成的操作（如"保存成功"）。
+- 显示非关键的时效性信息。
+- 为可逆操作提供撤销机会。
+
+## 何时不使用
+
+- 需要用户操作的关键信息（使用 Banner）。
+- 持久性消息（使用 Banner）。
+- 表单字段验证错误（使用 Field 状态）。`,
+  },
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description:
+    'toast notification w/ auto-dismiss, stacking, dedup, smooth animations; XDSMediaTheme inverted surface',
+  features: [
+    "types: info (default), error",
+    'auto-dismiss: info 5s, error persists',
+    'pause on hover/focus',
+    'stacking w/ smooth enter/exit animations',
+    'dedup: uniqueID w/ ignore|overwrite collision',
+    'programmatic dismiss: show() returns dismiss fn',
+    'end content slot: trailing actions',
+    'fallback viewport: works w/o provider via document.body',
+    'inverted surface: XDSMediaTheme for dark/light bg colors',
+    'a11y: role=status/alert, aria-live=polite/assertive',
+  ],
+  propDescriptions: {
+    body: 'primary message content',
+    type: 'toast type; controls bg color; error persists until dismissed',
+    isAutoHide: 'auto-dismiss; true for info, false for error',
+    autoHideDuration: 'ms before auto-dismiss',
+    endContent: 'trailing end content (undo btn, link)',
+    uniqueID: 'unique id for dedup',
+    collisionBehavior: 'behavior when matching uniqueID exists',
+    onHide: 'callback when toast removed',
+  },
+  usage: {
+    summary: 'transient notification confirming action or surfacing non-critical info',
+    content: `## When to use
+
+- confirm completed action
+- non-critical time-sensitive info
+- undo opportunities for reversible actions
+
+## When NOT to use
+
+- critical info requiring action (use Banner)
+- persistent messages (use Banner)
+- form field validation errors (use Field status)`,
   },
 };

--- a/packages/core/src/Toast/XDSToastViewport.tsx
+++ b/packages/core/src/Toast/XDSToastViewport.tsx
@@ -78,6 +78,18 @@ export interface XDSToastViewportProps {
   children?: React.ReactNode;
 }
 
+/**
+ * Container that renders and manages toast notifications. Place at the root
+ * of your app to enable useXDSToast(). Toasts stack with enter/exit
+ * animations and auto-promote to the CSS top layer.
+ *
+ * @example
+ * ```
+ * <XDSToastViewport position="bottomEnd" maxVisible={3}>
+ *   <App />
+ * </XDSToastViewport>
+ * ```
+ */
 export function XDSToastViewport({
   position = 'bottomEnd',
   maxVisible = 5,
@@ -148,7 +160,11 @@ export function XDSToastViewport({
     if (!isTopLayer) return;
     const el = viewportRef.current;
     if (el && typeof el.showPopover === 'function') {
-      try { el.showPopover(); } catch { /* already showing */ }
+      try {
+        el.showPopover();
+      } catch {
+        /* already showing */
+      }
     }
   }, [isTopLayer]);
 
@@ -199,7 +215,6 @@ export function XDSToastViewport({
                 <XDSToast
                   type={type}
                   body={o.body}
-
                   endContent={o.endContent}
                   isAutoHide={isAutoHide}
                   autoHideDuration={dur}

--- a/packages/core/src/theme/XDSMediaTheme.tsx
+++ b/packages/core/src/theme/XDSMediaTheme.tsx
@@ -22,8 +22,7 @@
  *    naturally through CSS custom property inheritance
  *
  * @example
- * ```tsx
- * // Dark surface (e.g. toast on a light page)
+ * ```
  * <div style={{ backgroundColor: 'var(--color-background-inverted)' }}>
  *   <XDSMediaTheme mode="dark">
  *     <XDSButton label="Undo" variant="ghost" />


### PR DESCRIPTION
## What

Night Watch Doc Reviewer found and fixed 4 issues:

| File | Issue | Fix |
|------|-------|-----|
| `XDSMediaTheme.tsx` | ```tsx tag + JS comment in @example | Removed language tag and comment |
| `XDSChatToolCalls.tsx` | JS comments in @example + duplicate example blocks | Removed comments, consolidated into single example |
| `Toast.doc.mjs` | Missing docsZh, docsDense translations + no theming section | Added Chinese and dense translations, added `xds-toast` theming target |
| `XDSToastViewport.tsx` | Missing @example JSDoc | Added usage example |

## Validation
- `yarn workspace @xds/core typecheck:docs` passes
- `yarn build` passes
- CLI `--props` output verified for Toast
- Post-fix audit shows zero Storybook compat issues

---
*Crafted with care by Navi — Night Watch Doc Reviewer*