### PR TITLE
fix(core): migrate ProgressBar/Section to XDSBaseProps, fix RadioList double-apply

### DIFF
--- a/packages/core/src/ProgressBar/XDSProgressBar.tsx
+++ b/packages/core/src/ProgressBar/XDSProgressBar.tsx
@@ -15,7 +15,7 @@
 
 import {useId} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
+
 import {
   colorVars,
   spacingVars,
@@ -26,6 +26,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {xdsClassName, mergeProps} from '../utils';
+import type {XDSBaseProps} from '../XDSBaseProps';
 
 /**
  * Extensible variant map for XDSProgressBar.
@@ -53,7 +54,7 @@ export interface XDSProgressBarVariantMap {
  */
 export type XDSProgressBarVariant = keyof XDSProgressBarVariantMap;
 
-export interface XDSProgressBarProps {
+export interface XDSProgressBarProps extends XDSBaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLDivElement>;
   /**
@@ -100,27 +101,6 @@ export interface XDSProgressBarProps {
    * @default false
    */
   isIndeterminate?: boolean;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call for optimal deduplication.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <Component xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element. Spread after StyleX
-   * inline styles, so these values take priority.
-   */
-  style?: React.CSSProperties;
   /**
    * Test ID for testing utilities.
    */

--- a/packages/core/src/RadioList/XDSRadioList.tsx
+++ b/packages/core/src/RadioList/XDSRadioList.tsx
@@ -234,10 +234,7 @@ export function XDSRadioList({
           stylex.props(
             styles.radiogroup,
             orientation === 'vertical' ? styles.vertical : styles.horizontal,
-            xstyle,
           ),
-          className,
-          style,
         )}>
         <XDSRadioListContext.Provider value={contextValue}>
           {children}

--- a/packages/core/src/Section/XDSSection.tsx
+++ b/packages/core/src/Section/XDSSection.tsx
@@ -14,8 +14,8 @@
 
 import {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
+import type {XDSBaseProps} from '../XDSBaseProps';
 import {container} from '../Layout/container.stylex';
 import type {SpacingToken} from '../Layout/container.stylex';
 import {
@@ -130,27 +130,8 @@ const dynamicStyles = stylex.create({
   }),
 });
 
-export interface XDSSectionProps {
+export interface XDSSectionProps extends XDSBaseProps<HTMLElement> {
   ref?: React.Ref<HTMLElement>;
-  /**
-   * StyleX styles created via `stylex.create()`. Merged with the component's
-   * base styles inside a single `stylex.props()` call on the outer wrapper.
-   *
-   * @example
-   * ```
-   * const overrides = stylex.create({ root: { marginBottom: 8 } });
-   * <XDSSection xstyle={overrides.root} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /**
-   * CSS class name(s) appended to the root element.
-   */
-  className?: string;
-  /**
-   * Inline styles to apply to the root element.
-   */
-  style?: React.CSSProperties;
   /**
    * Visual variant of the section.
    * - 'section': Surface background color


### PR DESCRIPTION
## Component Audit — 2026-04-10

Audited: **Popover**, **PowerSearch**, **ProgressBar**, **RadioList**, **Section**

### Fixes

**ProgressBar** — `XDSProgressBarProps` now extends `XDSBaseProps<HTMLDivElement>` instead of manually declaring `xstyle`/`className`/`style`. Removes redundant prop definitions and inherits the full HTML attribute surface.

**Section** — `XDSSectionProps` now extends `XDSBaseProps<HTMLElement>` instead of manually declaring `xstyle`/`className`/`style`. Same cleanup.

**RadioList** — Fixed a double-apply bug: `xstyle`, `className`, and `style` were being passed to **both** the outer `XDSField` wrapper **and** the inner radiogroup `<div>`, causing consumer styles (e.g. `marginBottom`, `width`) to apply twice. Now only `XDSField` receives them.

### Clean components (no issues found)

- **Popover** — All tokens, xdsClassName, a11y, exports ✓
- **PowerSearch** — All tokens, prop naming, type naming, exports ✓

### Needs Review

1. **Popover/PowerSearch/RadioList BaseProps migration** — These components also don't extend `XDSBaseProps`, but their prop surfaces are more complex (composition wrappers, context providers). ~30 other components across the codebase also need this migration. Migrating just these 3 would be inconsistent — better to batch as a dedicated PR.

2. **PowerSearch missing xdsClassName** — `XDSPowerSearch` doesn't call `xdsClassName()` on its root element. However, it's a composition wrapper around `XDSTokenizer` (which has its own xdsClassName). Adding one to the wrapper could create specificity conflicts. Needs design decision.

3. **RadioList context export** — `XDSRadioListContext` and `XDSRadioListContextValue` are not exported from `index.ts`, which prevents consumers from building custom radio item components. May be intentionally private — needs human decision.
