### PR TITLE
fix(Chat): unify TokenizedText to accept XDSChatComposerToken

### DIFF
--- a/apps/storybook/stories/ChatComposition.stories.tsx
+++ b/apps/storybook/stories/ChatComposition.stories.tsx
@@ -10,6 +10,7 @@ import {
   XDSChatMessageTokenizedText,
   XDSChatToolCalls,
   type XDSChatComposerInputHandle,
+  type XDSChatComposerToken,
   type XDSChatComposerTrigger,
   type XDSChatToolCallItem,
 } from '@xds/core/Chat';
@@ -87,7 +88,13 @@ const COMMANDS = [
 ];
 
 type Message =
-  | {id: number; role: 'user'; text: string; files?: string[]}
+  | {
+      id: number;
+      role: 'user';
+      text: string;
+      files?: string[];
+      tokens?: XDSChatComposerToken[];
+    }
   | {
       id: number;
       role: 'assistant';
@@ -167,13 +174,6 @@ export const FullAIChat: StoryObj = {
     const streamRef = useRef<ReturnType<typeof setInterval>>(undefined);
     const inputRef = useRef<XDSChatComposerInputHandle>(null);
     const contextTooltip = useXDSTooltip({placement: 'above'});
-
-    // Token configs for rendering mentions in message bubbles
-    const mentionTokens = CONTACTS.map(c => ({
-      pattern: `@${c.id}`,
-      label: `@${c.label}`,
-      variant: 'blue' as const,
-    }));
 
     const triggers: XDSChatComposerTrigger[] = [
       {
@@ -302,6 +302,14 @@ export const FullAIChat: StoryObj = {
       [],
     );
 
+    // Simulate backend token resolution — extract @mentions from text
+    const resolveTokens = (text: string): XDSChatComposerToken[] =>
+      CONTACTS.filter(c => text.includes(`@${c.id}`)).map(c => ({
+        value: `@${c.id}`,
+        label: `@${c.label}`,
+        variant: 'blue' as const,
+      }));
+
     const handleSubmit = useCallback(
       (value: string) => {
         setMessages(prev => [
@@ -311,6 +319,7 @@ export const FullAIChat: StoryObj = {
             role: 'user',
             text: value,
             files: files.length ? [...files] : undefined,
+            tokens: resolveTokens(value),
           },
         ]);
         setFiles([]);
@@ -392,7 +401,7 @@ export const FullAIChat: StoryObj = {
                       </XDSChatComposerAttachments>
                     )}
                     <XDSChatMessageBubble>
-                      <XDSChatMessageTokenizedText tokens={mentionTokens}>
+                      <XDSChatMessageTokenizedText tokens={msg.tokens}>
                         {msg.text}
                       </XDSChatMessageTokenizedText>
                     </XDSChatMessageBubble>

--- a/apps/storybook/stories/ChatTokenizedText.stories.tsx
+++ b/apps/storybook/stories/ChatTokenizedText.stories.tsx
@@ -20,9 +20,9 @@ export default meta;
 type Story = StoryObj<typeof XDSChatMessageTokenizedText>;
 
 const mentionTokens = [
-  {pattern: '@cindy', label: '@Cindy Zhang', variant: 'blue' as const},
-  {pattern: '@navi', label: '@Navi', variant: 'blue' as const},
-  {pattern: '@alex', label: '@Alex Rivera', variant: 'blue' as const},
+  {value: '@cindy', label: '@Cindy Zhang', variant: 'blue' as const},
+  {value: '@navi', label: '@Navi', variant: 'blue' as const},
+  {value: '@alex', label: '@Alex Rivera', variant: 'blue' as const},
 ];
 
 /** Single mention token */
@@ -71,9 +71,9 @@ export const MixedVariants: Story = {
       <XDSChatMessageBubble>
         <XDSChatMessageTokenizedText
           tokens={[
-            {pattern: '@cindy', label: '@Cindy', variant: 'blue'},
-            {pattern: '#bug', label: '#bug', variant: 'red'},
-            {pattern: '#feat', label: '#feature', variant: 'green'},
+            {value: '@cindy', label: '@Cindy', variant: 'blue'},
+            {value: '#bug', label: '#bug', variant: 'red'},
+            {value: '#feat', label: '#feature', variant: 'green'},
           ]}>
           @cindy filed #bug and #feat for the sprint
         </XDSChatMessageTokenizedText>

--- a/packages/core/src/Chat/XDSChatMessageTokenizedText.test.tsx
+++ b/packages/core/src/Chat/XDSChatMessageTokenizedText.test.tsx
@@ -22,7 +22,7 @@ describe('XDSChatMessageTokenizedText', () => {
   it('replaces a single token with a badge', () => {
     render(
       <XDSChatMessageTokenizedText
-        tokens={[{pattern: '@cindy', label: '@Cindy Zhang', variant: 'blue'}]}>
+        tokens={[{value: '@cindy', label: '@Cindy Zhang', variant: 'blue'}]}>
         Hey @cindy!
       </XDSChatMessageTokenizedText>,
     );
@@ -34,8 +34,8 @@ describe('XDSChatMessageTokenizedText', () => {
     render(
       <XDSChatMessageTokenizedText
         tokens={[
-          {pattern: '@cindy', label: '@Cindy Zhang', variant: 'blue'},
-          {pattern: '@navi', label: '@Navi', variant: 'blue'},
+          {value: '@cindy', label: '@Cindy Zhang', variant: 'blue'},
+          {value: '@navi', label: '@Navi', variant: 'blue'},
         ]}>
         Hey @cindy, can @navi help?
       </XDSChatMessageTokenizedText>,
@@ -47,7 +47,7 @@ describe('XDSChatMessageTokenizedText', () => {
   it('handles repeated occurrences of the same token', () => {
     render(
       <XDSChatMessageTokenizedText
-        tokens={[{pattern: '@cindy', label: '@Cindy Zhang'}]}>
+        tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         @cindy and @cindy again
       </XDSChatMessageTokenizedText>,
     );
@@ -57,7 +57,7 @@ describe('XDSChatMessageTokenizedText', () => {
   it('renders text with no matching tokens as plain text', () => {
     render(
       <XDSChatMessageTokenizedText
-        tokens={[{pattern: '@cindy', label: '@Cindy Zhang'}]}>
+        tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         Hello world
       </XDSChatMessageTokenizedText>,
     );
@@ -67,7 +67,7 @@ describe('XDSChatMessageTokenizedText', () => {
   it('handles tokens with special regex characters in pattern', () => {
     render(
       <XDSChatMessageTokenizedText
-        tokens={[{pattern: '/search', label: '/search'}]}>
+        tokens={[{value: '/search', label: '/search'}]}>
         Run /search now
       </XDSChatMessageTokenizedText>,
     );
@@ -78,7 +78,7 @@ describe('XDSChatMessageTokenizedText', () => {
   it('preserves surrounding text', () => {
     const {container} = render(
       <XDSChatMessageTokenizedText
-        tokens={[{pattern: '@cindy', label: '@Cindy Zhang'}]}>
+        tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         Before @cindy after
       </XDSChatMessageTokenizedText>,
     );

--- a/packages/core/src/Chat/XDSChatMessageTokenizedText.tsx
+++ b/packages/core/src/Chat/XDSChatMessageTokenizedText.tsx
@@ -2,39 +2,67 @@
 
 /**
  * @file XDSChatMessageTokenizedText.tsx
- * @input Uses React, XDSBadge
+ * @input Uses React, XDSBadge, XDSChatComposerToken
  * @output Exports XDSChatMessageTokenizedText component
  * @position Utility component for rendering tokenized text in message bubbles
  *
- * Parses a plain text string and replaces token patterns (e.g. @cindy)
- * with inline XDSBadge components. Falls back to plain text when no
- * tokens match.
+ * Parses a plain text string and replaces token values with inline badges.
+ * Accepts the same XDSChatComposerToken type used by the input triggers,
+ * so the same token definitions work for both input and display.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Chat/index.ts
  */
 
 import type {ReactNode} from 'react';
-import {XDSBadge, type XDSBadgeVariant} from '../Badge';
+import {XDSBadge} from '../Badge';
+import type {XDSChatComposerToken} from './XDSChatComposerInput';
 
 // =============================================================================
 // Types
 // =============================================================================
 
-export interface XDSChatMessageTokenConfig {
-  /** Pattern to match in the text (e.g. '@cindy') */
-  pattern: string;
-  /** Display label for the badge (e.g. '@Cindy Zhang') */
-  label: string;
-  /** Badge variant */
-  variant?: XDSBadgeVariant;
+export interface XDSChatMessageTokenizedTextProps {
+  /** The message text containing serialized token values */
+  children: string;
+  /**
+   * Token definitions — same type returned by trigger onSelect.
+   * Each token's `value` is matched against the text and replaced
+   * with its badge representation (label, variant, icon).
+   *
+   * @example
+   * ```
+   * // Shared between input and display
+   * const mentionTokens = contacts.map(c => ({
+   *   value: `@${c.id}`,
+   *   label: `@${c.label}`,
+   *   variant: 'blue' as const,
+   * }));
+   *
+   * // Input trigger
+   * { character: '@', onSelect: (item) => mentionTokens.find(...) }
+   *
+   * // Display
+   * <XDSChatMessageTokenizedText tokens={mentionTokens}>
+   *   {message.text}
+   * </XDSChatMessageTokenizedText>
+   * ```
+   */
+  tokens?: XDSChatComposerToken[];
 }
 
-export interface XDSChatMessageTokenizedTextProps {
-  /** The message text containing token patterns */
-  children: string;
-  /** Token definitions to match and render as badges */
-  tokens?: XDSChatMessageTokenConfig[];
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function isCustomToken(
+  token: XDSChatComposerToken,
+): token is {value: string; render: () => ReactNode} {
+  return 'render' in token && typeof token.render === 'function';
+}
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&');
 }
 
 // =============================================================================
@@ -42,16 +70,10 @@ export interface XDSChatMessageTokenizedTextProps {
 // =============================================================================
 
 /**
- * Renders text with token patterns replaced by inline badges.
+ * Renders text with token values replaced by inline badges.
  *
- * @example
- * ```
- * <XDSChatMessageTokenizedText
- *   tokens={[{pattern: '@cindy', label: '@Cindy Zhang', variant: 'blue'}]}
- * >
- *   Hey @cindy, can you review this?
- * </XDSChatMessageTokenizedText>
- * ```
+ * Accepts the same `XDSChatComposerToken` type used by input triggers,
+ * so you can share a single token definition between input and display.
  */
 export function XDSChatMessageTokenizedText({
   children,
@@ -68,26 +90,19 @@ export function XDSChatMessageTokenizedText({
 XDSChatMessageTokenizedText.displayName = 'XDSChatMessageTokenizedText';
 
 // =============================================================================
-// Helpers
+// Render
 // =============================================================================
 
-function escapeRegExp(str: string): string {
-  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-/** Parse text and replace token patterns with Badge elements */
 function renderTokens(
   text: string,
-  tokens: XDSChatMessageTokenConfig[],
+  tokens: XDSChatComposerToken[],
 ): ReactNode[] {
-  // Build a combined regex matching any token pattern
-  const pattern = tokens.map(t => escapeRegExp(t.pattern)).join('|');
+  const pattern = tokens.map(t => escapeRegExp(t.value)).join('|');
   const regex = new RegExp(`(${pattern})`, 'g');
 
-  // Build a lookup map for O(1) access
-  const tokenMap = new Map<string, XDSChatMessageTokenConfig>();
+  const tokenMap = new Map<string, XDSChatComposerToken>();
   for (const t of tokens) {
-    tokenMap.set(t.pattern, t);
+    tokenMap.set(t.value, t);
   }
 
   const parts: ReactNode[] = [];
@@ -95,27 +110,30 @@ function renderTokens(
   let match: RegExpExecArray | null;
 
   while ((match = regex.exec(text)) !== null) {
-    // Add text before the match
     if (match.index > lastIndex) {
       parts.push(text.slice(lastIndex, match.index));
     }
 
     const matched = match[0];
-    const config = tokenMap.get(matched);
-    if (config) {
+    const token = tokenMap.get(matched);
+    if (token) {
       parts.push(
-        <XDSBadge
-          key={`${matched}-${match.index}`}
-          label={config.label}
-          variant={config.variant}
-        />,
+        isCustomToken(token) ? (
+          <span key={`${matched}-${match.index}`}>{token.render()}</span>
+        ) : (
+          <XDSBadge
+            key={`${matched}-${match.index}`}
+            label={token.label}
+            variant={token.variant}
+            icon={token.icon}
+          />
+        ),
       );
     }
 
     lastIndex = match.index + matched.length;
   }
 
-  // Add remaining text
   if (lastIndex < text.length) {
     parts.push(text.slice(lastIndex));
   }

--- a/packages/core/src/Chat/index.ts
+++ b/packages/core/src/Chat/index.ts
@@ -29,10 +29,7 @@ export type {
 } from './XDSChatComposerInput';
 
 export {XDSChatMessageTokenizedText} from './XDSChatMessageTokenizedText';
-export type {
-  XDSChatMessageTokenizedTextProps,
-  XDSChatMessageTokenConfig,
-} from './XDSChatMessageTokenizedText';
+export type {XDSChatMessageTokenizedTextProps} from './XDSChatMessageTokenizedText';
 
 export {XDSChatMessageList} from './XDSChatMessageList';
 export type {XDSChatMessageListProps} from './XDSChatMessageList';


### PR DESCRIPTION
## What

`XDSChatMessageTokenizedText` now accepts the same `XDSChatComposerToken` type used by input triggers. This lets consumers share a single token definition between input and display.

### Before
```tsx
// Separate type for display
tokens={[{pattern: '@cindy', label: '@Cindy Zhang', variant: 'blue'}]}
```

### After
```tsx
// Same tokens used by trigger onSelect
const mentionTokens = contacts.map(c => ({
  value: `@${c.id}`,
  label: `@${c.label}`,
  variant: 'blue',
}));

// Input trigger returns matching token
onSelect: (item) => mentionTokens.find(t => t.value === `@${item.id}`)!

// Display uses same tokens
<XDSChatMessageTokenizedText tokens={mentionTokens}>
  {message.text}
</XDSChatMessageTokenizedText>
```

### Changes
- `tokens` prop accepts `XDSChatComposerToken[]` instead of `XDSChatMessageTokenConfig[]`
- Uses `value` as the match pattern (was `pattern`)
- Supports custom render tokens via the `render()` escape hatch
- Removed `XDSChatMessageTokenConfig` export
- Updated composition story to demonstrate shared token flow
- Updated all tests and stories

Closes #1263