### PR TITLE
fix(Chat): attachment drawer fade animation + consistent toggle height

### DIFF
--- a/packages/core/src/Chat/XDSChatComposerAttachments.tsx
+++ b/packages/core/src/Chat/XDSChatComposerAttachments.tsx
@@ -64,8 +64,6 @@ export interface XDSChatComposerAttachmentsProps extends XDSBaseProps<HTMLDivEle
   'data-testid'?: string;
 }
 
-const TOGGLE_HEIGHT = '20px';
-
 const styles = stylex.create({
   root: {
     position: 'relative',
@@ -97,7 +95,7 @@ const styles = stylex.create({
     display: 'grid',
     gridTemplateColumns: '1fr',
     alignItems: 'center',
-    height: TOGGLE_HEIGHT,
+    height: spacingVars['--spacing-5'],
     paddingInline: spacingVars['--spacing-4'],
     marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
     cursor: 'pointer',
@@ -110,7 +108,7 @@ const styles = stylex.create({
     justifySelf: 'start',
     display: 'inline-flex',
     alignItems: 'center',
-    height: TOGGLE_HEIGHT,
+    height: spacingVars['--spacing-5'],
     gap: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-full'],
     opacity: 1,
@@ -130,7 +128,7 @@ const styles = stylex.create({
       },
     },
     fontSize: typeScaleVars['--text-body-size'],
-    lineHeight: TOGGLE_HEIGHT,
+    lineHeight: spacingVars['--spacing-5'],
     transitionProperty: 'color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],

--- a/packages/core/src/Chat/XDSChatComposerAttachments.tsx
+++ b/packages/core/src/Chat/XDSChatComposerAttachments.tsx
@@ -6,7 +6,7 @@
  * @output Exports XDSChatComposerAttachments component
  * @position Layout container for attachment items inside XDSChatComposer.
  *   Supports expanded (full content) and collapsed (count + label) states
- *   with animated grid-template-rows transition.
+ *   with fade animation and grid-template-rows height transition.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Chat/index.ts (exports)
@@ -64,6 +64,8 @@ export interface XDSChatComposerAttachmentsProps extends XDSBaseProps<HTMLDivEle
   'data-testid'?: string;
 }
 
+const TOGGLE_HEIGHT = '20px';
+
 const styles = stylex.create({
   root: {
     position: 'relative',
@@ -89,34 +91,36 @@ const styles = stylex.create({
     borderTopRightRadius: radiusVars['--radius-page'],
   },
 
-  // Toggle row — click target area for collapse/expand
+  // Toggle row — both the bar handle and badge+label live in the
+  // same grid cell so they crossfade without layout shift.
   toggleRow: {
-    display: 'flex',
+    display: 'grid',
+    gridTemplateColumns: '1fr',
     alignItems: 'center',
-    justifyContent: 'center',
-    paddingBlock: spacingVars['--spacing-2'],
+    height: TOGGLE_HEIGHT,
     paddingInline: spacingVars['--spacing-4'],
-    marginBlockStart: `calc(-1 * ${spacingVars['--spacing-2']})`,
     marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
     cursor: 'pointer',
     userSelect: 'none',
   },
-  toggleCollapsed: {
-    justifyContent: 'flex-start',
-    paddingBlockEnd: 0,
-  },
+  toggleCollapsed: {},
   toggleContent: {
+    gridRow: 1,
+    gridColumn: 1,
+    justifySelf: 'start',
     display: 'inline-flex',
     alignItems: 'center',
+    height: TOGGLE_HEIGHT,
     gap: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-full'],
     opacity: 1,
     transitionProperty: 'opacity',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    '@starting-style': {
-      opacity: 0,
-    },
+  },
+  toggleContentHidden: {
+    opacity: 0,
+    pointerEvents: 'none' as const,
   },
   collapseLabel: {
     color: {
@@ -126,12 +130,16 @@ const styles = stylex.create({
       },
     },
     fontSize: typeScaleVars['--text-body-size'],
-    lineHeight: typeScaleVars['--text-body-leading'],
+    lineHeight: TOGGLE_HEIGHT,
     transitionProperty: 'color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   collapseBarHandle: {
+    gridRow: 1,
+    gridColumn: 1,
+    justifySelf: 'center',
+    alignSelf: 'start',
     width: '20px',
     height: '2px',
     borderRadius: radiusVars['--radius-full'],
@@ -145,12 +153,14 @@ const styles = stylex.create({
     transitionProperty: 'background-color, opacity',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    '@starting-style': {
-      opacity: 0,
-    },
+  },
+  collapseBarHandleHidden: {
+    opacity: 0,
+    pointerEvents: 'none' as const,
   },
 
-  // Animated content area
+  // Animated content area — height collapses via grid-template-rows,
+  // items stay in place and fade in/out (no translateY slide).
   contentGrid: {
     display: 'grid',
     gridTemplateRows: '1fr',
@@ -168,14 +178,15 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1'],
     alignItems: 'flex-start',
     opacity: 1,
-    transform: 'translateY(0)',
-    transitionProperty: 'opacity, transform',
-    transitionDuration: `${durationVars['--duration-fast']}, ${durationVars['--duration-medium']}`,
+    transitionProperty: 'opacity',
+    transitionDuration: durationVars['--duration-medium'],
+    transitionDelay: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   contentCollapsed: {
     opacity: 0,
-    transform: `translateY(calc(100% + ${spacingVars['--spacing-3']} + ${radiusVars['--radius-page']}))`,
+    transitionDelay: '0ms',
+    transitionDuration: durationVars['--duration-fast'],
   },
 });
 
@@ -226,38 +237,31 @@ export function XDSChatComposerAttachments({
             isCollapsed && styles.toggleCollapsed,
             stylex.defaultMarker(),
           )}
-          onClick={toggle}>
-          {isCollapsed ? (
-            <div
-              role="button"
-              tabIndex={0}
-              aria-expanded={false}
-              aria-label={`Expand ${label}`}
-              onKeyDown={e => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  toggle();
-                }
-              }}
-              {...stylex.props(styles.toggleContent)}>
-              <XDSBadge variant="neutral" label={count} />
-              <span {...stylex.props(styles.collapseLabel)}>{label}</span>
-            </div>
-          ) : (
-            <div
-              role="button"
-              tabIndex={0}
-              aria-expanded={true}
-              aria-label={`Collapse ${label}`}
-              onKeyDown={e => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  toggle();
-                }
-              }}
-              {...stylex.props(styles.collapseBarHandle)}
-            />
-          )}
+          role="button"
+          tabIndex={0}
+          aria-expanded={!isCollapsed}
+          aria-label={isCollapsed ? `Expand ${label}` : `Collapse ${label}`}
+          onClick={toggle}
+          onKeyDown={e => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              toggle();
+            }
+          }}>
+          <div
+            {...stylex.props(
+              styles.toggleContent,
+              !isCollapsed && styles.toggleContentHidden,
+            )}>
+            <XDSBadge variant="neutral" label={count} />
+            <span {...stylex.props(styles.collapseLabel)}>{label}</span>
+          </div>
+          <div
+            {...stylex.props(
+              styles.collapseBarHandle,
+              isCollapsed && styles.collapseBarHandleHidden,
+            )}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Changes

- **Fade-only animation** — removed `translateY` slide from drawer content. Items stay in place and fade in/out.
- **Staggered timing** — collapse fades out fast (`--duration-fast`, no delay), expand fades in after a short delay so the height has time to open first (`--duration-medium`, delayed by `--duration-fast`).
- **Crossfade toggle controls** — bar handle and badge+label are both always rendered in the same grid cell, crossfading with opacity instead of conditional mount/unmount. No more instant pop between states.
- **Fixed 20px toggle row** — consistent height whether showing the bar handle or the "Attachments" badge+label. No layout jump.
- **Bar handle top-aligned** — `alignSelf: 'start'` keeps the handle near the top of the toggle row.

---
