### PR TITLE
fix(Chat): use color-neutral for message bubble background

### DIFF
--- a/packages/core/src/Chat/XDSChatMessageBubble.tsx
+++ b/packages/core/src/Chat/XDSChatMessageBubble.tsx
@@ -99,11 +99,11 @@ const styles = stylex.create({
     paddingInline: 0,
   },
   assistant: {
-    backgroundColor: colorVars['--color-background-muted'],
+    backgroundColor: colorVars['--color-neutral'],
     color: colorVars['--color-text-primary'],
   },
   user: {
-    backgroundColor: colorVars['--color-background-muted'],
+    backgroundColor: colorVars['--color-neutral'],
     color: colorVars['--color-text-primary'],
   },
   system: {


### PR DESCRIPTION
Swap `--color-background-muted` → `--color-neutral` for both assistant and user bubble backgrounds in `XDSChatMessageBubble`.

---
