### PR TITLE
fix(CodeBlock): use semantic --text-code-size token for md size

### DIFF
--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -126,13 +126,13 @@ const styles = stylex.create({
     fontSize: textSizeVars['--font-size-sm'],
   },
   sizeMd: {
-    fontSize: textSizeVars['--font-size-base'],
+    fontSize: typeScaleVars['--text-code-size'],
   },
   gutterSm: {
     fontSize: textSizeVars['--font-size-sm'],
   },
   gutterMd: {
-    fontSize: textSizeVars['--font-size-base'],
+    fontSize: typeScaleVars['--text-code-size'],
   },
   copyButton: {
     display: 'inline-flex',


### PR DESCRIPTION
CodeBlock `sizeMd` and `gutterMd` styles were using the raw `textSizeVars['--font-size-base']` instead of the semantic `typeScaleVars['--text-code-size']` token.

This aligns `XDSCodeBlock` with `XDSCode` (inline code), so themes can control code font size through the single `--text-code-size` token consistently across both components.

No visual change — `--text-code-size` defaults to `var(--font-size-base)`. The `sm` size variant stays on `--font-size-sm` as intended.

---
