### PR TITLE
feat(theme): add GitHub Dark syntax preset and update default theme

### DIFF
--- a/apps/storybook/stories/CodeTheme.stories.tsx
+++ b/apps/storybook/stories/CodeTheme.stories.tsx
@@ -1,7 +1,10 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import React from 'react';
 import {XDSCodeBlock} from '@xds/core/CodeBlock';
-import {XDSSyntaxTheme as SyntaxThemeProvider, defineSyntaxTheme} from '@xds/core/theme/syntax';
+import {
+  XDSSyntaxTheme as SyntaxThemeProvider,
+  defineSyntaxTheme,
+} from '@xds/core/theme/syntax';
 import {defineTheme, XDSTheme} from '@xds/core/theme';
 import {
   oneDarkPro,
@@ -10,6 +13,7 @@ import {
   nord,
   tokyoNight,
   catppuccinMocha,
+  githubDark,
   githubLight,
   solarizedLight,
   oneLight,
@@ -168,6 +172,19 @@ export const GitHubLight: StoryObj = {
   ),
 };
 
+export const GitHubDark: StoryObj = {
+  render: () => (
+    <SyntaxThemeProvider theme={githubDark}>
+      <XDSCodeBlock
+        code={sampleCode}
+        language="typescript"
+        title="UserCard.tsx"
+        hasLineNumbers
+      />
+    </SyntaxThemeProvider>
+  ),
+};
+
 export const SolarizedLight: StoryObj = {
   render: () => (
     <SyntaxThemeProvider theme={solarizedLight}>
@@ -237,7 +254,7 @@ const shortCode = [
 export const AllThemesGallery: StoryObj = {
   render: () => (
     <div style={{display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16}}>
-      {allSyntaxPresets.map((theme) => (
+      {allSyntaxPresets.map(theme => (
         <SyntaxThemeProvider key={theme.name} theme={theme}>
           <XDSCodeBlock
             code={shortCode}

--- a/packages/themes/default/src/defaultTheme.ts
+++ b/packages/themes/default/src/defaultTheme.ts
@@ -14,24 +14,29 @@
 import {defineTheme, defineSyntaxTheme} from '@xds/core/theme';
 import {defaultIconRegistry} from './icons';
 
-/** Default syntax palette — tuned to the XDS blue color ramp. */
+/**
+ * Default syntax palette — GitHub Light (light) + GitHub Dark (dark).
+ *
+ * Color values sourced from the GitHub VS Code theme by the Primer team.
+ * Original theme: https://github.com/primer/github-vscode-theme (MIT license).
+ */
 const defaultSyntax = defineSyntaxTheme({
   name: 'xds-default',
   tokens: {
-    keyword: ['#0064E0', '#2694FE'],
-    string: ['#09441F', '#A5F690'],
-    comment: ['#4E606F', '#6B7D8D'],
-    number: ['#6B2203', '#FDB876'],
-    function: ['#042F97', '#AFD7FF'],
-    type: ['#3E0697', '#B3B0FE'],
-    variable: ['#0A1317', '#DFE2E5'],
-    operator: ['#006D75', '#56C8D8'],
-    constant: ['#6B2203', '#FDB876'],
-    tag: ['#7B0210', '#FFB2B8'],
-    attribute: ['#7A4F1A', '#E8C580'],
-    property: ['#006064', '#B2EBF2'],
-    punctuation: ['#65737E', '#6F747C'],
-    background: ['#F1F4F7', '#111112'],
+    keyword: ['#cf222e', '#ff7b72'],
+    string: ['#0a3069', '#a5d6ff'],
+    comment: ['#6e7781', '#8b949e'],
+    number: ['#0550ae', '#79c0ff'],
+    function: ['#8250df', '#d2a8ff'],
+    type: ['#953800', '#ffa657'],
+    variable: ['#24292f', '#e6edf3'],
+    operator: ['#cf222e', '#ff7b72'],
+    constant: ['#0550ae', '#79c0ff'],
+    tag: ['#116329', '#7ee787'],
+    attribute: ['#0550ae', '#79c0ff'],
+    property: ['#0550ae', '#79c0ff'],
+    punctuation: ['#24292f', '#c9d1d9'],
+    background: ['#ffffff', '#0d1117'],
   },
 });
 

--- a/packages/themes/syntax/THIRD_PARTY_LICENSES.md
+++ b/packages/themes/syntax/THIRD_PARTY_LICENSES.md
@@ -6,52 +6,67 @@ Only color values have been extracted — no source code from these projects
 is included.
 
 ## One Dark Pro
+
 - Source: https://github.com/Binaryify/OneDark-Pro
 - Author: Binaryify
 - License: MIT
 - Original: Atom One Dark by GitHub (atom/one-dark-syntax)
 
 ## Dracula
+
 - Source: https://github.com/dracula/visual-studio-code
 - Author: Zeno Rocha and contributors
 - License: MIT
 - Website: https://draculatheme.com
 
 ## Monokai
+
 - Source: Built-in VS Code theme (https://github.com/microsoft/vscode)
 - Author: Microsoft Corporation
 - License: MIT
 - Original: Monokai by Wimer Hazenberg (monokai.nl)
 
 ## Nord
+
 - Source: https://github.com/nordtheme/visual-studio-code
 - Author: Sven Greb (Arctic Ice Studio) and contributors
 - License: MIT
 - Website: https://www.nordtheme.com
 
 ## Tokyo Night
+
 - Source: https://github.com/tokyo-night/tokyo-night-vscode-theme
 - Author: enkia and contributors
 - License: MIT
 
 ## Catppuccin (Mocha + Latte)
+
 - Source: https://github.com/catppuccin/vscode
 - Author: Catppuccin contributors
 - License: MIT
 - Website: https://catppuccin.com
 
 ## GitHub Light
+
+- Source: https://github.com/primer/github-vscode-theme
+- Author: GitHub (Primer team)
+- License: MIT
+
+## GitHub Dark
+
 - Source: https://github.com/primer/github-vscode-theme
 - Author: GitHub (Primer team)
 - License: MIT
 
 ## Solarized Light
+
 - Source: https://github.com/altercation/solarized
 - Author: Ethan Schoonover
 - License: MIT
 - Website: https://ethanschoonover.com/solarized
 
 ## One Light
+
 - Source: https://github.com/atom/one-light-syntax
 - Author: GitHub (Atom team)
 - License: MIT

--- a/packages/themes/syntax/src/index.ts
+++ b/packages/themes/syntax/src/index.ts
@@ -1,7 +1,7 @@
 /**
  * @xds/theme-syntax — Community syntax theme presets for XDS
  *
- * 11 themes (6 dark, 5 light) mapped to the XDS 14-token syntax architecture.
+ * 12 themes (7 dark, 5 light) mapped to the XDS 14-token syntax architecture.
  * All original themes are MIT licensed. See THIRD_PARTY_LICENSES.md.
  *
  * @example
@@ -20,6 +20,7 @@ export {monokai} from './presets';
 export {nord} from './presets';
 export {tokyoNight} from './presets';
 export {catppuccinMocha} from './presets';
+export {githubDark} from './presets';
 
 // Light themes
 export {githubLight} from './presets';
@@ -29,4 +30,8 @@ export {catppuccinLatte} from './presets';
 export {tokyoNightLight} from './presets';
 
 // Collections
-export {darkSyntaxPresets, lightSyntaxPresets, allSyntaxPresets} from './presets';
+export {
+  darkSyntaxPresets,
+  lightSyntaxPresets,
+  allSyntaxPresets,
+} from './presets';

--- a/packages/themes/syntax/src/presets.ts
+++ b/packages/themes/syntax/src/presets.ts
@@ -1,6 +1,6 @@
 /**
  * @file presets.ts
- * @output 11 community syntax theme presets
+ * @output 12 community syntax theme presets
  *
  * Color values sourced from each theme's official VS Code extension.
  * All original themes are MIT licensed. Only color values are extracted.
@@ -158,6 +158,27 @@ export const githubLight: SyntaxTheme = defineSyntaxTheme({
   },
 });
 
+/** GitHub Dark (GitHub Primer team) — MIT */
+export const githubDark: SyntaxTheme = defineSyntaxTheme({
+  name: 'github-dark',
+  tokens: {
+    keyword: '#ff7b72',
+    string: '#a5d6ff',
+    comment: '#8b949e',
+    number: '#79c0ff',
+    function: '#d2a8ff',
+    type: '#ffa657',
+    variable: '#e6edf3',
+    operator: '#ff7b72',
+    constant: '#79c0ff',
+    tag: '#7ee787',
+    attribute: '#79c0ff',
+    property: '#79c0ff',
+    punctuation: '#c9d1d9',
+    background: '#0d1117',
+  },
+});
+
 /** Solarized Light (Ethan Schoonover) — MIT */
 export const solarizedLight: SyntaxTheme = defineSyntaxTheme({
   name: 'solarized-light',
@@ -243,10 +264,27 @@ export const tokyoNightLight: SyntaxTheme = defineSyntaxTheme({
 });
 
 /** All dark syntax theme presets */
-export const darkSyntaxPresets = [oneDarkPro, dracula, monokai, nord, tokyoNight, catppuccinMocha] as const;
+export const darkSyntaxPresets = [
+  oneDarkPro,
+  dracula,
+  monokai,
+  nord,
+  tokyoNight,
+  catppuccinMocha,
+  githubDark,
+] as const;
 
 /** All light syntax theme presets */
-export const lightSyntaxPresets = [githubLight, solarizedLight, oneLight, catppuccinLatte, tokyoNightLight] as const;
+export const lightSyntaxPresets = [
+  githubLight,
+  solarizedLight,
+  oneLight,
+  catppuccinLatte,
+  tokyoNightLight,
+] as const;
 
 /** All syntax theme presets */
-export const allSyntaxPresets = [...darkSyntaxPresets, ...lightSyntaxPresets] as const;
+export const allSyntaxPresets = [
+  ...darkSyntaxPresets,
+  ...lightSyntaxPresets,
+] as const;


### PR DESCRIPTION
Adds GitHub Dark to the syntax theme preset library and switches the default theme's syntax highlighting to GitHub Light/Dark.

## Changes

- **`@xds/theme-syntax`**: Add `githubDark` preset (now 12 themes: 7 dark, 5 light)
- **`@xds/theme-default`**: Replace custom XDS blue ramp with GitHub Light (light) + GitHub Dark (dark) using `[light, dark]` tuples — hardcoded inline, no dependency on `@xds/theme-syntax`
- **Storybook**: Add `GitHubDark` story
- **THIRD_PARTY_LICENSES.md**: Add GitHub Dark attribution

## Color source

Hex values resolved from [`primer/github-vscode-theme`](https://github.com/primer/github-vscode-theme) via `@primer/primitives` dark color scales (e.g. `keyword` → `scale.red[3]` → `#ff7b72`). Both GitHub themes are MIT licensed (Primer team).