### PR TITLE
feat(template): docsite-landing SideNav layout with logo and chat

### DIFF
--- a/packages/cli/templates/docsite-landing/page.tsx
+++ b/packages/cli/templates/docsite-landing/page.tsx
@@ -20,6 +20,7 @@ import {XDSToken} from '@xds/core/Token';
 import {XDSToolbar} from '@xds/core/Toolbar';
 import {XDSTooltip} from '@xds/core/Tooltip';
 import {createStaticSource} from '@xds/core/Typeahead';
+import {XDSChatComposer} from '@xds/core/Chat';
 
 // ---------------------------------------------------------------------------
 // Icons
@@ -900,82 +901,7 @@ function ChatPanel({
   );
 }
 
-// ---------------------------------------------------------------------------
-// SideNavComposer (chat composer for side nav footer)
-// ---------------------------------------------------------------------------
-
-function SideNavComposer({onSend}: {onSend?: () => void}) {
-  const [prompt, setPrompt] = useState('');
-
-  return (
-    <div
-      style={{
-        borderRadius: 12,
-        backgroundColor: 'var(--color-background-card, white)',
-        border: '1px solid var(--color-divider)',
-        boxShadow: 'var(--shadow-high)',
-        padding: 8,
-        display: 'flex',
-        flexDirection: 'column' as const,
-        gap: 8,
-      }}>
-      <div
-        style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          alignSelf: 'flex-start',
-          paddingInline: 8,
-          paddingBlock: 2,
-          borderRadius: 9999,
-          backgroundColor: 'var(--color-background-body, #f1f4f7)',
-          fontSize: 12,
-        }}>
-        Template 01
-      </div>
-      <div style={{display: 'flex', alignItems: 'center', padding: 8}}>
-        <input
-          style={{
-            flex: 1,
-            border: 'none',
-            outline: 'none',
-            backgroundColor: 'transparent',
-            fontFamily: 'inherit',
-            fontSize: 14,
-          }}
-          placeholder="What would you like to customize?"
-          value={prompt}
-          onChange={e => setPrompt(e.target.value)}
-        />
-      </div>
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          width: '100%',
-          paddingInlineStart: 4,
-          paddingTop: 4,
-        }}>
-        <XDSButton
-          label="Attach"
-          variant="ghost"
-          size="sm"
-          icon={<PlusIcon />}
-          isIconOnly
-        />
-        <XDSButton
-          label="Send"
-          variant="primary"
-          size="sm"
-          icon={<SendIcon />}
-          style={{borderRadius: 9999}}
-          onClick={onSend}
-          isIconOnly
-        />
-      </div>
-    </div>
-  );
-}
+// SideNavComposer removed — replaced by XDSChatComposer from @xds/core/Chat
 
 // ---------------------------------------------------------------------------
 // Toolbar Icons
@@ -1749,14 +1675,17 @@ export default function DocsiteLandingTemplate() {
     setChatOpen(false);
   }, []);
 
-  const handlePreviewSend = useCallback(() => {
-    if (previewGenerating) return;
-    setPreviewGenerating(true);
-    previewTimerRef.current = setTimeout(() => {
-      setPreviewGenerating(false);
-      previewTimerRef.current = null;
-    }, 5000);
-  }, [previewGenerating]);
+  const handlePreviewSend = useCallback(
+    (_value: string) => {
+      if (previewGenerating) return;
+      setPreviewGenerating(true);
+      previewTimerRef.current = setTimeout(() => {
+        setPreviewGenerating(false);
+        previewTimerRef.current = null;
+      }, 5000);
+    },
+    [previewGenerating],
+  );
 
   useEffect(() => {
     return () => {
@@ -1858,7 +1787,20 @@ export default function DocsiteLandingTemplate() {
                       under the header and use a card for the lists
                     </XDSText>
                   </div>
-                  <SideNavComposer onSend={handlePreviewSend} />
+                  <XDSChatComposer
+                    placeholder="What would you like to customize?"
+                    density="compact"
+                    onSubmit={handlePreviewSend}
+                    footerActions={
+                      <XDSButton
+                        label="Attach"
+                        variant="ghost"
+                        size="md"
+                        icon={<PlusIcon />}
+                        isIconOnly
+                      />
+                    }
+                  />
                 </>
               }>
               {null}


### PR DESCRIPTION
## Summary
- Adds SideNav-based preview mode to the docsite-landing template — clicking a template card transitions from TopNav grid view to a SideNav layout with resizable panel (320–640px), chat bubble + composer, and animated entry transition
- Adds XDS logo SVG (from Figma) to both TopNav and SideNav headings
- Restructures toolbar: back arrow + template name in start, point/theme/dark-mode/device controls in center, "Use in..." dropdown in end
- Uses spacious density (`size="lg"`) for SideNav menu items (Craft, Explore, Doc)

## Test plan
- [ ] Visit `/templates/docsite-landing` in sandbox
- [ ] Verify TopNav shows XDS logo on the grid page
- [ ] Click a template card → verify SideNav slides in with animated transition
- [ ] Verify SideNav heading shows XDS logo, click menu shows Craft/Explore/Doc
- [ ] Drag the resize handle to resize the side panel (min 320px, max 640px)
- [ ] Click the logo in SideNav → returns to grid view
- [ ] Verify toolbar controls (back, theme, dark mode, viewport size, "Use in...")
- [ ] Verify chat bubble and composer render in SideNav footer