### PR TITLE
fix(SideNav, TopNav): use LinkComponent instead of raw <a> tags

### DIFF
--- a/packages/core/src/SideNav/XDSSideNav.test.tsx
+++ b/packages/core/src/SideNav/XDSSideNav.test.tsx
@@ -157,6 +157,28 @@ describe('XDSSideNavHeading', () => {
     expect(link).toHaveTextContent('My App');
   });
 
+  it('uses custom link component from as prop', () => {
+    render(
+      <XDSSideNavHeading
+        heading="My App"
+        headingHref="/home"
+        as={CustomLink}
+      />,
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('data-custom-link');
+  });
+
+  it('uses custom link component from XDSLinkProvider', () => {
+    render(
+      <XDSLinkProvider component={CustomLink}>
+        <XDSSideNavHeading heading="My App" headingHref="/home" />
+      </XDSLinkProvider>,
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('data-custom-link');
+  });
+
   it('renders independent links when headingHref and superheadingHref are provided', () => {
     render(
       <XDSSideNavHeading

--- a/packages/core/src/SideNav/XDSSideNavHeading.tsx
+++ b/packages/core/src/SideNav/XDSSideNavHeading.tsx
@@ -35,6 +35,8 @@ import {getIcon} from '../Icon/globalIconRegistry';
 import {XDSTooltip} from '../Tooltip';
 import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useXDSSideNavCollapse} from './XDSSideNavCollapseContext';
+import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
+import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
 
 // =============================================================================
@@ -219,6 +221,12 @@ export interface XDSSideNavHeadingProps {
    */
   icon?: ReactNode;
   /**
+   * Custom component to render instead of `<a>`.
+   * Overrides the provider-level default set by XDSLinkProvider.
+   * Must accept href, className, style, and children props.
+   */
+  as?: XDSLinkComponentType;
+  /**
    * Product/app name.
    */
   heading: string;
@@ -319,6 +327,7 @@ export interface XDSSideNavHeadingProps {
  * ```
  */
 export function XDSSideNavHeading({
+  as,
   icon,
   heading,
   headingHref,
@@ -335,6 +344,7 @@ export function XDSSideNavHeading({
   ref,
   ...props
 }: XDSSideNavHeadingProps) {
+  const LinkComponent = useXDSLinkComponent(as);
   const {isCollapsed} = useXDSSideNavCollapse();
   const rootRef = useRef<HTMLDivElement>(null);
   const collapsedItemRef = useRef<HTMLElement>(null);
@@ -380,7 +390,7 @@ export function XDSSideNavHeading({
 
     if (headingHref) {
       collapsedElement = (
-        <a
+        <LinkComponent
           ref={collapsedSetRef as React.Ref<HTMLAnchorElement>}
           href={headingHref}
           aria-label={heading}
@@ -392,7 +402,7 @@ export function XDSSideNavHeading({
             style,
           )}>
           {collapsedIcon}
-        </a>
+        </LinkComponent>
       );
     } else if (menu) {
       collapsedElement = (
@@ -511,11 +521,11 @@ export function XDSSideNavHeading({
         ))}
       <span {...stylex.props(styles.headingRow)}>
         {hasAnyHref && headingHref && menu ? (
-          <a
+          <LinkComponent
             href={headingHref}
             {...stylex.props(styles.heading, styles.headingLink)}>
             {heading}
-          </a>
+          </LinkComponent>
         ) : (
           <span {...stylex.props(styles.heading)}>{heading}</span>
         )}
@@ -564,9 +574,9 @@ export function XDSSideNavHeading({
   // Whole heading is a link (no menu, single headingHref)
   if (isWholeHeadingLink) {
     return (
-      <a
+      <LinkComponent
         ref={ref as React.Ref<HTMLAnchorElement>}
-        href={headingHref}
+        href={headingHref!}
         data-testid={testId}
         {...mergeProps(
           xdsClassName('side-nav-heading'),
@@ -579,7 +589,7 @@ export function XDSSideNavHeading({
         {renderTextContent()}
         {headerEndContentElement}
         {chevronElement}
-      </a>
+      </LinkComponent>
     );
   }
 
@@ -641,9 +651,9 @@ export function XDSSideNavHeading({
           )}>
           {icon &&
             (headingHref ? (
-              <a href={headingHref} {...stylex.props(styles.icon)}>
+              <LinkComponent href={headingHref} {...stylex.props(styles.icon)}>
                 {icon}
-              </a>
+              </LinkComponent>
             ) : (
               <span {...stylex.props(styles.icon)}>{icon}</span>
             ))}
@@ -691,9 +701,9 @@ export function XDSSideNavHeading({
         {...props}>
         {icon &&
           (headingHref ? (
-            <a href={headingHref} {...stylex.props(styles.icon)}>
+            <LinkComponent href={headingHref} {...stylex.props(styles.icon)}>
               {icon}
-            </a>
+            </LinkComponent>
           ) : (
             <span {...stylex.props(styles.icon)}>{icon}</span>
           ))}

--- a/packages/core/src/TopNav/XDSTopNavHeading.tsx
+++ b/packages/core/src/TopNav/XDSTopNavHeading.tsx
@@ -352,11 +352,11 @@ export function XDSTopNavHeading({
         ))}
       <span {...stylex.props(styles.headingRow)}>
         {hasAnyHref && headingHref && menu ? (
-          <a
+          <LinkComponent
             href={headingHref}
             {...stylex.props(styles.heading, styles.headingLink)}>
             {heading}
-          </a>
+          </LinkComponent>
         ) : (
           <span {...stylex.props(styles.heading)}>{heading}</span>
         )}


### PR DESCRIPTION
Fixes the issue from [#1272 review](https://github.com/facebookexperimental/xds/pull/1272) — raw `<a>` tags don't work with routing frameworks like Next.js Link.

## Changes

**SideNavHeading:**
- Add `as` prop + `useXDSLinkComponent` (was missing entirely)
- Replace 5 raw `<a>` tags with `LinkComponent` across collapsed, whole-heading-link, renderTextContent, and mixed-mode paths

**TopNavHeading:**
- Replace 1 remaining raw `<a>` in `renderTextContent` (other paths already used `LinkComponent`)

**Tests:**
- Add tests for `as` prop and `XDSLinkProvider` on `XDSSideNavHeading`

All 73 SideNav tests pass.