### PR TITLE
docs: fix Chat @example blocks, add missing theming targets

### DIFF
--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -28,6 +28,13 @@ export const docs = {
     targets: [
       {className: 'xds-chat-composer', visualProps: ['density']},
       {className: 'xds-chat-composer-input'},
+      {className: 'xds-chat-composer-attachments', visualProps: ['collapsed']},
+      {className: 'xds-chat-message', visualProps: ['sender']},
+      {className: 'xds-chat-message-bubble', visualProps: ['sender', 'variant']},
+      {className: 'xds-chat-message-list', visualProps: ['density']},
+      {className: 'xds-chat-system-message', visualProps: ['variant']},
+      {className: 'xds-chat-tool-calls'},
+      {className: 'xds-trigger-menu'},
     ],
     vars: [
       {name: '--composer-radius', description: 'Border radius of the composer body. Inner elements derive their radius concentrically.', default: 'var(--radius-page)'},

--- a/packages/core/src/Chat/XDSChatMessageTokenizedText.tsx
+++ b/packages/core/src/Chat/XDSChatMessageTokenizedText.tsx
@@ -32,17 +32,11 @@ export interface XDSChatMessageTokenizedTextProps {
    *
    * @example
    * ```
-   * // Shared between input and display
    * const mentionTokens = contacts.map(c => ({
    *   value: `@${c.id}`,
    *   label: `@${c.label}`,
    *   variant: 'blue' as const,
    * }));
-   *
-   * // Input trigger
-   * { character: '@', onSelect: (item) => mentionTokens.find(...) }
-   *
-   * // Display
    * <XDSChatMessageTokenizedText tokens={mentionTokens}>
    *   {message.text}
    * </XDSChatMessageTokenizedText>

--- a/packages/core/src/Chat/XDSChatToolCalls.tsx
+++ b/packages/core/src/Chat/XDSChatToolCalls.tsx
@@ -444,21 +444,12 @@ function CallRow({call}: {call: XDSChatToolCallItem}) {
  *
  * @example
  * ```
- * // Basic — pass the array from your LLM response
  * <XDSChatToolCalls
  *   calls={message.toolCalls.map(tc => ({
  *     name: tc.toolName,
  *     status: tc.state,
  *     duration: tc.duration,
  *   }))}
- * />
- * ```
- *
- * @example
- * ```
- * // With detail rendering
- * <XDSChatToolCalls
- *   calls={toolCalls}
  *   renderDetail={(call) => (
  *     <XDSCodeBlock code={call.args} language="json" />
  *   )}

--- a/packages/core/src/CheckboxList/CheckboxList.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxList.doc.mjs
@@ -92,11 +92,7 @@ export const docs = {
 </XDSCheckboxList>`,
     },
   ],
-  theming: {
-    targets: [
-      {className: 'xds-checkbox-list-item'},
-    ],
-  },
+
   notes: [
     'XDSCheckboxList composes XDSField (label, description, status) and XDSList (density, dividers)',
     'XDSCheckboxListItem can be used inside XDSCheckboxList (collection mode) or XDSList (standalone mode)',
@@ -357,11 +353,7 @@ export const docsZh = {
 </XDSCheckboxList>`,
     },
   ],
-  theming: {
-    targets: [
-      {className: 'xds-checkbox-list-item'},
-    ],
-  },
+
   notes: [
     'XDSCheckboxList 组合 XDSField（标签、描述、状态）和 XDSList（密度、分隔线）',
     'XDSCheckboxListItem 可在 XDSCheckboxList（集合模式）或 XDSList（独立模式）内使用',


### PR DESCRIPTION
## What

Fixes Storybook-incompatible `@example` blocks in Chat components (reintroduced by #1266) and adds 7 missing theming targets to Chat.doc.mjs. Also removes a stale theming target from CheckboxList.

### Changes

| File | Fix |
|------|-----|
| XDSChatMessageTokenizedText.tsx | Remove JS comments and blank lines from `@example` |
| XDSChatToolCalls.tsx | Consolidate two `@example` blocks into one, remove JS comments |
| Chat.doc.mjs | Add theming targets: chat-message, chat-message-bubble, chat-message-list, chat-system-message, chat-tool-calls, chat-composer-attachments, trigger-menu |
| CheckboxList.doc.mjs | Remove stale `xds-checkbox-list-item` (no `xdsClassName()` call in source) |

## Checklist
- [x] `tsc --project tsconfig.docs.json` passes
- [x] CLI `--json` output verified (Chat theming targets present)
- [x] No ```tsx in docblocks
- [x] No blank lines, JS comments, or bare `>` inside `@example` code blocks
- [x] `yarn build` passes
- [x] `yarn lint` passes (via lint-staged)

---
*Crafted with care by Navi, Night Watch Doc Reviewer*