### PR TITLE
fix(hardening): add missing xdsClassName variant props and file headers

### DIFF
--- a/packages/core/src/SegmentedControl/XDSSegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/XDSSegmentedControlItem.tsx
@@ -185,7 +185,11 @@ export function XDSSegmentedControlItem({
       tabIndex={isSelected ? 0 : -1}
       onClick={handleClick}
       {...mergeProps(
-        xdsClassName('segmented-control-item'),
+        xdsClassName('segmented-control-item', {
+          size,
+          selected: isSelected ? 'selected' : null,
+          disabled: isItemDisabled ? 'disabled' : null,
+        }),
         stylex.props(
           styles.base,
           sizeStyles[size],

--- a/packages/core/src/SideNav/XDSSideNavItem.tsx
+++ b/packages/core/src/SideNav/XDSSideNavItem.tsx
@@ -352,7 +352,10 @@ export function XDSSideNavItem({
 
     // Shared collapsed item styles — used by trigger, link, and button
     const collapsedItemStyles = mergeProps(
-      xdsClassName('side-nav-item'),
+      xdsClassName('side-nav-item', {
+        size,
+        selected: isSelected ? 'selected' : null,
+      }),
       stylex.props(
         navItemStyles.item,
         navItemStyles[size],
@@ -484,7 +487,10 @@ export function XDSSideNavItem({
         onClick={handleClick}
         {...ariaProps}
         {...mergeProps(
-          xdsClassName('side-nav-item'),
+          xdsClassName('side-nav-item', {
+            size,
+            selected: isSelected ? 'selected' : null,
+          }),
           stylex.props(
             navItemStyles.item,
             navItemStyles[size],
@@ -502,7 +508,10 @@ export function XDSSideNavItem({
         disabled={isDisabled}
         {...ariaProps}
         {...mergeProps(
-          xdsClassName('side-nav-item'),
+          xdsClassName('side-nav-item', {
+            size,
+            selected: isSelected ? 'selected' : null,
+          }),
           stylex.props(
             navItemStyles.item,
             navItemStyles[size],

--- a/packages/core/src/Skeleton/index.ts
+++ b/packages/core/src/Skeleton/index.ts
@@ -1,4 +1,13 @@
 'use client';
 
+/**
+ * @file index.ts
+ * @input Imports from Skeleton component files
+ * @output Exports XDSSkeleton and its types
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/Skeleton/Skeleton.doc.mjs
+ */
+
 export {XDSSkeleton} from './XDSSkeleton';
 export type {XDSSkeletonProps, XDSSkeletonRadius} from './XDSSkeleton';

--- a/packages/core/src/Slider/index.ts
+++ b/packages/core/src/Slider/index.ts
@@ -1,5 +1,14 @@
 'use client';
 
+/**
+ * @file index.ts
+ * @input Imports from Slider component files
+ * @output Exports XDSSlider and its types
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/Slider/Slider.doc.mjs
+ */
+
 export {XDSSlider} from './XDSSlider';
 export type {
   XDSSliderProps,


### PR DESCRIPTION
## Component Audit — April 11, 2026

Components audited: SegmentedControl, Selector, SideNav, Skeleton, Slider

### Findings & Fixes

- **SegmentedControlItem**: Added size, selected, disabled to xdsClassName (visual props were missing)
- **SideNavItem**: Added size, selected to all 3 xdsClassName calls (collapsed, link, button)
- **Skeleton/index.ts**: Added file header
- **Slider/index.ts**: Added file header

Selector and all other SideNav sub-components passed all 9 audit dimensions.