### PR TITLE
fix(sandbox): prefix docsite image paths with basePath for GitHub Pages

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/doc-discover/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/doc-discover/page.tsx
@@ -1,0 +1,333 @@
+'use client';
+
+import {useState} from 'react';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSTextInput} from '@xds/core/TextInput';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSCard} from '@xds/core/Card';
+import {
+  XDSSegmentedControl,
+  XDSSegmentedControlItem,
+} from '@xds/core/SegmentedControl';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSEmptyState} from '@xds/core/EmptyState';
+import DocTopNav from '../doc-nav/DocTopNav';
+
+type Category = 'All' | 'Components' | 'Patterns' | 'Templates' | 'Tools';
+const CATEGORIES: Category[] = [
+  'All',
+  'Components',
+  'Patterns',
+  'Templates',
+  'Tools',
+];
+
+interface DiscoverItem {
+  name: string;
+  description: string;
+  category: Category;
+  author: string;
+  downloads: string;
+  tags: string[];
+}
+
+const ITEMS: DiscoverItem[] = [
+  {
+    name: 'DataTable',
+    description:
+      'Full-featured data table with sorting, filtering, pagination, and row selection.',
+    category: 'Components',
+    author: 'XDS Core',
+    downloads: '12.4k',
+    tags: ['table', 'data', 'filtering'],
+  },
+  {
+    name: 'FormBuilder',
+    description:
+      'Declarative form composition with built-in validation and error handling.',
+    category: 'Patterns',
+    author: 'XDS Core',
+    downloads: '8.2k',
+    tags: ['form', 'validation', 'input'],
+  },
+  {
+    name: 'Dashboard',
+    description:
+      'Pre-built dashboard template with sidebar nav, stats cards, and chart areas.',
+    category: 'Templates',
+    author: 'XDS Team',
+    downloads: '6.7k',
+    tags: ['dashboard', 'layout', 'analytics'],
+  },
+  {
+    name: 'Theme Editor',
+    description:
+      'Visual editor for customizing and previewing XDS design tokens in real-time.',
+    category: 'Tools',
+    author: 'XDS Team',
+    downloads: '3.1k',
+    tags: ['theme', 'tokens', 'preview'],
+  },
+  {
+    name: 'NavigationShell',
+    description:
+      'App shell with sidebar, top nav, breadcrumbs, and responsive collapse.',
+    category: 'Components',
+    author: 'XDS Core',
+    downloads: '9.8k',
+    tags: ['navigation', 'shell', 'layout'],
+  },
+  {
+    name: 'CommandPalette',
+    description:
+      'Keyboard-driven command palette for quick actions and search.',
+    category: 'Components',
+    author: 'XDS Labs',
+    downloads: '4.5k',
+    tags: ['search', 'keyboard', 'shortcuts'],
+  },
+  {
+    name: 'Auth Flow',
+    description:
+      'Complete authentication flow with login, registration, and password reset pages.',
+    category: 'Templates',
+    author: 'XDS Team',
+    downloads: '5.3k',
+    tags: ['auth', 'login', 'security'],
+  },
+  {
+    name: 'CRUD Pattern',
+    description:
+      'Create-Read-Update-Delete pattern with modals, toasts, and confirmation dialogs.',
+    category: 'Patterns',
+    author: 'XDS Core',
+    downloads: '7.1k',
+    tags: ['crud', 'modal', 'data'],
+  },
+  {
+    name: 'Vibe Tester',
+    description:
+      'AI-powered tool for testing component usage and validating design system adherence.',
+    category: 'Tools',
+    author: 'XDS Labs',
+    downloads: '2.8k',
+    tags: ['ai', 'testing', 'quality'],
+  },
+  {
+    name: 'MegaMenu',
+    description:
+      'Full-width dropdown navigation menu with sections, icons, and featured content.',
+    category: 'Components',
+    author: 'XDS Core',
+    downloads: '5.9k',
+    tags: ['navigation', 'menu', 'dropdown'],
+  },
+  {
+    name: 'Settings Page',
+    description:
+      'Settings template with tabbed sections, form fields, and save/cancel actions.',
+    category: 'Templates',
+    author: 'XDS Team',
+    downloads: '4.0k',
+    tags: ['settings', 'form', 'tabs'],
+  },
+  {
+    name: 'Empty States',
+    description:
+      'Reusable empty state patterns with illustrations, CTAs, and guidance text.',
+    category: 'Patterns',
+    author: 'XDS Core',
+    downloads: '3.6k',
+    tags: ['empty', 'placeholder', 'onboarding'],
+  },
+];
+
+const CATEGORY_BADGE_VARIANT: Record<
+  string,
+  'blue' | 'purple' | 'teal' | 'orange'
+> = {
+  Components: 'blue',
+  Patterns: 'purple',
+  Templates: 'teal',
+  Tools: 'orange',
+};
+
+function ImagePlaceholder() {
+  return (
+    <svg
+      width="40"
+      height="40"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="#b0b0b0"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round">
+      <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+      <circle cx="8.5" cy="8.5" r="1.5" />
+      <polyline points="21 15 16 10 5 21" />
+    </svg>
+  );
+}
+
+export default function DocDiscoverPage() {
+  const [activeCategory, setActiveCategory] = useState<Category>('All');
+  const [search, setSearch] = useState('');
+
+  const filtered = ITEMS.filter(item => {
+    const matchesCategory =
+      activeCategory === 'All' || item.category === activeCategory;
+    const matchesSearch =
+      !search ||
+      item.name.toLowerCase().includes(search.toLowerCase()) ||
+      item.description.toLowerCase().includes(search.toLowerCase()) ||
+      item.tags.some(t => t.toLowerCase().includes(search.toLowerCase()));
+    return matchesCategory && matchesSearch;
+  });
+
+  return (
+    <div style={{minHeight: '100vh', backgroundColor: '#ffffff'}}>
+      <DocTopNav />
+
+      <div style={{maxWidth: 1280, margin: '0 auto', padding: '0 32px'}}>
+        {/* Compact header: text left, search right */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            paddingTop: 40,
+            paddingBottom: 24,
+            gap: 32,
+          }}>
+          <XDSVStack gap={1}>
+            <XDSHeading level={1}>Discover</XDSHeading>
+            <XDSText type="body" color="secondary">
+              Find components, patterns, templates, and tools for your next
+              project.
+            </XDSText>
+          </XDSVStack>
+
+          <div style={{width: 320, flexShrink: 0}}>
+            <XDSTextInput
+              label="Search"
+              isLabelHidden
+              placeholder="Search..."
+              value={search}
+              onChange={setSearch}
+              hasClear
+            />
+          </div>
+        </div>
+
+        {/* Category filter */}
+        <div style={{paddingBottom: 24}}>
+          <XDSSegmentedControl
+            value={activeCategory}
+            onChange={v => setActiveCategory(v as Category)}
+            label="Filter by category">
+            {CATEGORIES.map(cat => (
+              <XDSSegmentedControlItem key={cat} value={cat} label={cat} />
+            ))}
+          </XDSSegmentedControl>
+        </div>
+
+        {/* Results count */}
+        <div style={{paddingBottom: 16}}>
+          <XDSText type="supporting" color="secondary">
+            {filtered.length} result{filtered.length !== 1 ? 's' : ''}
+          </XDSText>
+        </div>
+
+        {/* Cards grid or empty state */}
+        {filtered.length === 0 ? (
+          <div style={{paddingTop: 40, paddingBottom: 80}}>
+            <XDSEmptyState
+              title="No results found"
+              description="Try adjusting your search or filters."
+            />
+          </div>
+        ) : (
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(3, 1fr)',
+              gap: 20,
+              paddingBottom: 64,
+            }}>
+            {filtered.map(item => (
+              <XDSCard key={item.name} padding={0}>
+                <XDSVStack gap={0}>
+                  {/* Placeholder image area */}
+                  <div
+                    style={{
+                      height: 160,
+                      backgroundColor: '#f5f5f5',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}>
+                    <ImagePlaceholder />
+                  </div>
+
+                  {/* Card body */}
+                  <div style={{padding: 16}}>
+                    <XDSVStack gap={3}>
+                      {/* Name + category badge */}
+                      <XDSHStack gap={2} vAlign="center">
+                        <XDSText type="body" weight="bold">
+                          {item.name}
+                        </XDSText>
+                        <XDSBadge
+                          label={item.category}
+                          variant={
+                            CATEGORY_BADGE_VARIANT[item.category] ?? 'neutral'
+                          }
+                        />
+                      </XDSHStack>
+
+                      {/* Description */}
+                      <XDSText type="supporting" color="secondary">
+                        {item.description}
+                      </XDSText>
+
+                      {/* Tags */}
+                      <div
+                        style={{
+                          display: 'flex',
+                          flexWrap: 'wrap',
+                          gap: 6,
+                        }}>
+                        {item.tags.map(tag => (
+                          <XDSBadge key={tag} label={tag} variant="neutral" />
+                        ))}
+                      </div>
+
+                      {/* Divider */}
+                      <XDSDivider />
+
+                      {/* Footer: author + installs */}
+                      <XDSHStack gap={2} vAlign="center" hAlign="between">
+                        <XDSHStack gap={2} vAlign="center">
+                          <XDSAvatar name={item.author} size="xsmall" />
+                          <XDSText type="supporting" color="secondary">
+                            {item.author}
+                          </XDSText>
+                        </XDSHStack>
+                        <XDSText type="supporting" color="secondary">
+                          {item.downloads} installs
+                        </XDSText>
+                      </XDSHStack>
+                    </XDSVStack>
+                  </div>
+                </XDSVStack>
+              </XDSCard>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/doc-home/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/doc-home/page.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSButton} from '@xds/core/Button';
+import {XDSCard} from '@xds/core/Card';
+import {XDSTextArea} from '@xds/core/TextArea';
+import {colorVars} from '@xds/core/theme/tokens.stylex';
+import {categories} from '../../../sandboxPages';
+import DocTopNav from '../doc-nav/DocTopNav';
+
+const allPages = categories.flatMap(cat =>
+  cat.pages.map(p => ({...p, category: cat.label})),
+);
+
+const GRID_AREAS = `"a a b b b" "c c c d d" "e f f g g" "h h i i i"`;
+const GRID_ROWS = '280px 320px 260px 300px';
+const AREA_KEYS = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i'];
+
+const styles = stylex.create({
+  dashedCard: {
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: colorVars['--color-border'],
+    borderRadius: 16,
+  },
+});
+
+export default function DocHomePage() {
+  const [search, setSearch] = useState('');
+
+  const filtered = search
+    ? allPages.filter(
+        p =>
+          p.name.toLowerCase().includes(search.toLowerCase()) ||
+          p.category.toLowerCase().includes(search.toLowerCase()),
+      )
+    : allPages;
+
+  const gridItems = filtered.slice(0, 8);
+
+  return (
+    <div
+      style={{
+        height: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        backgroundColor: '#ffffff',
+        overflow: 'hidden',
+      }}>
+      <DocTopNav />
+
+      <div style={{display: 'flex', flex: 1, minHeight: 0}}>
+        {/* Left Hero */}
+        <div
+          style={{
+            flex: '0 0 380px',
+            display: 'flex',
+            flexDirection: 'column',
+            padding: '48px 32px 32px',
+          }}>
+          <div style={{display: 'flex', flexDirection: 'column', gap: 20}}>
+            <XDSHeading level={1}>Endless templates for your ideas</XDSHeading>
+            <XDSText type="large" color="secondary">
+              Explore production-ready templates, patterns, and components built
+              with XDS.
+            </XDSText>
+          </div>
+
+          <div style={{display: 'flex', gap: 10, marginTop: 28}}>
+            <XDSButton label="Get started" variant="secondary" size="lg" />
+            <XDSButton label="Browse all" variant="ghost" size="lg" />
+          </div>
+
+          {/* Search at bottom */}
+          <div style={{marginTop: 'auto', maxWidth: 360}}>
+            <XDSTextArea
+              label="Search"
+              isLabelHidden
+              placeholder="See endless designs for..."
+              value={search}
+              onChange={setSearch}
+              rows={2}
+            />
+          </div>
+        </div>
+
+        {/* Right Masonry Grid */}
+        <div
+          style={{
+            flex: 1,
+            overflow: 'hidden',
+            padding: '16px 16px 16px 0',
+            minWidth: 0,
+          }}>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'repeat(5, 1fr)',
+              gridTemplateAreas: GRID_AREAS,
+              gridTemplateRows: GRID_ROWS,
+              gap: 12,
+              height: '100%',
+            }}>
+            {gridItems.map((page, i) => (
+              <a
+                key={page.href}
+                href={page.href}
+                style={{
+                  gridArea: AREA_KEYS[i % AREA_KEYS.length],
+                  textDecoration: 'none',
+                  display: 'flex',
+                }}>
+                <XDSCard width="100%">
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      height: '100%',
+                    }}>
+                    {/* Placeholder image area */}
+                    <div
+                      style={{
+                        flex: 1,
+                        backgroundColor: '#f5f5f5',
+                        borderRadius: 8,
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                      }}>
+                      <svg
+                        width="40"
+                        height="40"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        stroke="#b0b0b0"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round">
+                        <rect
+                          x="3"
+                          y="3"
+                          width="18"
+                          height="18"
+                          rx="2"
+                          ry="2"
+                        />
+                        <circle cx="8.5" cy="8.5" r="1.5" />
+                        <polyline points="21 15 16 10 5 21" />
+                      </svg>
+                    </div>
+                    {/* Label */}
+                    <div style={{paddingTop: 10}}>
+                      <XDSText type="supporting" color="secondary">
+                        {page.name}
+                      </XDSText>
+                    </div>
+                  </div>
+                </XDSCard>
+              </a>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/doc-nav/DocTopNav.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/doc-nav/DocTopNav.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import {usePathname} from 'next/navigation';
+import Link from 'next/link';
+import {XDSTopNav, XDSTopNavHeading, XDSTopNavItem} from '@xds/core/TopNav';
+
+const NAV_ITEMS = [
+  {label: 'Home', href: '/pages/doc-home/'},
+  {label: 'Documentation', href: '/pages/doc-docs/'},
+  {label: 'Discover', href: '/pages/doc-discover/'},
+];
+
+export default function DocTopNav() {
+  const pathname = usePathname();
+
+  return (
+    <XDSTopNav
+      label="Documentation navigation"
+      heading={
+        <XDSTopNavHeading heading="XDS" href="/pages/doc-home/" as={Link} />
+      }
+      centerContent={
+        <>
+          {NAV_ITEMS.map(item => {
+            const isActive = pathname?.startsWith(item.href.replace(/\/$/, ''));
+            return (
+              <XDSTopNavItem
+                key={item.href}
+                label={item.label}
+                href={item.href}
+                isSelected={!!isActive}
+                as={Link}
+              />
+            );
+          })}
+        </>
+      }
+    />
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/icons.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/icons.tsx
@@ -1,0 +1,408 @@
+'use client';
+
+import React from 'react';
+
+export const SearchIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+export const HamburgerIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <line x1="3" y1="6" x2="21" y2="6" />
+    <line x1="3" y1="12" x2="21" y2="12" />
+    <line x1="3" y1="18" x2="21" y2="18" />
+  </svg>
+);
+
+export const FilterIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <line x1="4" y1="8" x2="20" y2="8" />
+    <line x1="4" y1="16" x2="20" y2="16" />
+    <circle
+      cx="10"
+      cy="8"
+      r="3"
+      fill="var(--color-background-surface, white)"
+    />
+    <circle
+      cx="14"
+      cy="16"
+      r="3"
+      fill="var(--color-background-surface, white)"
+    />
+  </svg>
+);
+
+export const MoreIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <circle cx="12" cy="5" r="2" />
+    <circle cx="12" cy="12" r="2" />
+    <circle cx="12" cy="19" r="2" />
+  </svg>
+);
+
+export const PlusIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+export const LinkIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+    <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+  </svg>
+);
+
+export const HeartIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+  </svg>
+);
+
+export const ThumbsUpIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <path d="M14 9V5a3 3 0 0 0-3-3l-4 9v11h11.28a2 2 0 0 0 2-1.7l1.38-9a2 2 0 0 0-2-2.3H14zM7 22H4a2 2 0 0 1-2-2v-7a2 2 0 0 1 2-2h3" />
+  </svg>
+);
+
+export const SendIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <path d="M5 12h14M12 5l7 7-7 7" />
+  </svg>
+);
+
+export const CheckIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <polyline points="20 6 9 17 4 12" />
+  </svg>
+);
+
+export const SidebarCollapseIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="9" y1="3" x2="9" y2="21" />
+    <polyline points="14 9 11 12 14 15" />
+  </svg>
+);
+
+export const AaIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M3 18L8 6h1l5 12" />
+    <line x1="5" y1="14" x2="12" y2="14" />
+    <path d="M15 18c0-2.5 1.5-4 3.5-4s3.5 1.5 3.5 4" />
+    <line x1="22" y1="18" x2="22" y2="13" />
+  </svg>
+);
+
+export const ChevronDownIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <polyline points="6 9 12 15 18 9" />
+  </svg>
+);
+
+export const ExternalLinkIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+    <polyline points="15 3 21 3 21 9" />
+    <line x1="10" y1="14" x2="21" y2="3" />
+  </svg>
+);
+
+export const BookmarkIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
+export const SparkleIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 24 24" fill="currentColor" {...props}>
+    <path d="M12 2l2.4 7.2L22 12l-7.6 2.8L12 22l-2.4-7.2L2 12l7.6-2.8L12 2z" />
+  </svg>
+);
+
+export const UsersIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+    <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+  </svg>
+);
+
+export const CodeIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <polyline points="16 18 22 12 16 6" />
+    <polyline points="8 6 2 12 8 18" />
+  </svg>
+);
+
+export const FullscreenIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+    <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+    <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+    <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+  </svg>
+);
+
+export const SidebarIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <rect x="3" y="3" width="18" height="18" rx="2" />
+    <line x1="9" y1="3" x2="9" y2="21" />
+  </svg>
+);
+
+export const ArrowLeftIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <path d="M19 12H5M12 19l-7-7 7-7" />
+  </svg>
+);
+
+export const CursorIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <path d="M4 4l7.07 17 2.51-7.39L21 11.07z" />
+  </svg>
+);
+
+export const PaletteIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.9 0 1.7-.7 1.7-1.7 0-.4-.2-.8-.4-1.1-.3-.3-.4-.7-.4-1.1 0-.9.7-1.7 1.7-1.7H16c3.3 0 6-2.7 6-6 0-5-4.5-8.5-10-8.5z" />
+    <circle cx="7.5" cy="11.5" r="1.5" fill="currentColor" stroke="none" />
+    <circle cx="10.5" cy="7.5" r="1.5" fill="currentColor" stroke="none" />
+    <circle cx="14.5" cy="7.5" r="1.5" fill="currentColor" stroke="none" />
+    <circle cx="17.5" cy="11.5" r="1.5" fill="currentColor" stroke="none" />
+  </svg>
+);
+
+export const DesktopIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <rect x="2" y="3" width="20" height="14" rx="2" />
+    <path d="M8 21h8M12 17v4" />
+  </svg>
+);
+
+export const TabletIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <rect x="4" y="2" width="16" height="20" rx="2" />
+    <line x1="12" y1="18" x2="12" y2="18" strokeLinecap="round" />
+  </svg>
+);
+
+export const PhoneIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <rect x="5" y="2" width="14" height="20" rx="2" />
+    <line x1="12" y1="18" x2="12" y2="18" strokeLinecap="round" />
+  </svg>
+);
+
+export const TerminalIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    {...props}>
+    <polyline points="4 17 10 11 4 5" />
+    <line x1="12" y1="19" x2="20" y2="19" />
+  </svg>
+);
+
+export const ClaudeIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 248 248" fill="none" {...props}>
+    <path
+      d="M52.4285 162.873L98.7844 136.879L99.5485 134.602L98.7844 133.334H96.4921L88.7237 132.862L62.2346 132.153L39.3113 131.207L17.0249 130.026L11.4214 128.844L6.2 121.873L6.7094 118.447L11.4214 115.257L18.171 115.847L33.0711 116.911L55.485 118.447L71.6586 119.392L95.728 121.873H99.5485L100.058 120.337L98.7844 119.392L97.7656 118.447L74.5877 102.732L49.4995 86.1905L36.3823 76.62L29.3779 71.7757L25.8121 67.2858L24.2839 57.3608L30.6515 50.2716L39.3113 50.8623L41.4763 51.4531L50.2636 58.1879L68.9842 72.7209L93.4357 90.6804L97.0015 93.6343L98.4374 92.6652L98.6571 91.9801L97.0015 89.2625L83.757 65.2772L69.621 40.8192L63.2534 30.6579L61.5978 24.632C60.9565 22.1032 60.579 20.0111 60.579 17.4246L67.8381 7.49965L71.9133 6.19995L81.7193 7.49965L85.7946 11.0443L91.9074 24.9865L101.714 46.8451L116.996 76.62L121.453 85.4816L123.873 93.6343L124.764 96.1155H126.292V94.6976L127.566 77.9197L129.858 57.3608L132.15 30.8942L132.915 23.4505L136.608 14.4708L143.994 9.62643L149.725 12.344L154.437 19.0788L153.8 23.4505L150.998 41.6463L145.522 70.1215L141.957 89.2625H143.994L146.414 86.7813L156.093 74.0206L172.266 53.698L179.398 45.6635L187.803 36.802L193.152 32.5484H203.34L210.726 43.6549L207.415 55.1159L196.972 68.3492L188.312 79.5739L175.896 96.2095L168.191 109.585L168.882 110.689L170.738 110.53L198.755 104.504L213.91 101.787L231.994 98.7149L240.144 102.496L241.036 106.395L237.852 114.311L218.495 119.037L195.826 123.645L162.07 131.592L161.696 131.893L162.137 132.547L177.36 133.925L183.855 134.279H199.774L229.447 136.524L237.215 141.605L241.8 147.867L241.036 152.711L229.065 158.737L213.019 154.956L175.45 145.977L162.587 142.787H160.805V143.85L171.502 154.366L191.242 172.089L215.82 195.011L217.094 200.682L213.91 205.172L210.599 204.699L188.949 188.394L180.544 181.069L161.696 165.118H160.422V166.772L164.752 173.152L187.803 207.771L188.949 218.405L187.294 221.832L181.308 223.959L174.813 222.777L161.187 203.754L147.305 182.486L136.098 163.345L134.745 164.2L128.075 235.42L125.019 239.082L117.887 241.8L111.902 237.31L108.718 229.984L111.902 215.452L115.722 196.547L118.779 181.541L121.58 162.873L123.291 156.636L123.14 156.219L121.773 156.449L107.699 175.752L86.304 204.699L69.3663 222.777L65.291 224.431L58.2867 220.768L58.9235 214.27L62.8713 208.48L86.304 178.705L100.44 160.155L109.551 149.507L109.462 147.967L108.959 147.924L46.6977 188.512L35.6182 189.93L30.7788 185.44L31.4156 178.115L33.7079 175.752L52.4285 162.873Z"
+      fill="#D97757"
+    />
+  </svg>
+);
+
+export const VSCodeIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 100 100" fill="none" {...props}>
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M70.9119 99.3171C72.4869 99.9307 74.2828 99.8914 75.8725 99.1264L96.4608 89.2197C98.6242 88.1787 100 85.9892 100 83.5872V16.4133C100 14.0113 98.6243 11.8218 96.4609 10.7808L75.8725 0.873756C73.7862 -0.130129 71.3446 0.11576 69.5135 1.44695C69.252 1.63711 69.0028 1.84943 68.769 2.08341L29.3551 38.0415L12.1872 25.0096C10.589 23.7965 8.35363 23.8959 6.86933 25.2461L1.36303 30.2549C-0.452552 31.9064 -0.454633 34.7627 1.35853 36.417L16.2471 50.0001L1.35853 63.5832C-0.454633 65.2374 -0.452552 68.0938 1.36303 69.7453L6.86933 74.7541C8.35363 76.1043 10.589 76.2037 12.1872 74.9905L29.3551 61.9587L68.769 97.9167C69.3925 98.5406 70.1246 99.0104 70.9119 99.3171ZM75.0152 27.2989L45.1091 50.0001L75.0152 72.7012V27.2989Z"
+      fill="#007ACC"
+    />
+  </svg>
+);
+
+export const CursorAIIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg viewBox="0 0 512 512" fill="none" {...props}>
+    <path
+      d="M415.035 156.35l-151.503-87.4695c-4.865-2.8094-10.868-2.8094-15.733 0l-151.4969 87.4695c-4.0897 2.362-6.6146 6.729-6.6146 11.459v176.383c0 4.73 2.5249 9.097 6.6146 11.458l151.5039 87.47c4.865 2.809 10.868 2.809 15.733 0l151.504-87.47c4.089-2.361 6.614-6.728 6.614-11.458v-176.383c0-4.73-2.525-9.097-6.614-11.459zm-9.516 18.528l-146.255 253.32c-.988 1.707-3.599 1.01-3.599-.967v-165.872c0-3.314-1.771-6.379-4.644-8.044l-143.645-82.932c-1.707-.988-1.01-3.599.968-3.599h292.509c4.154 0 6.75 4.503 4.673 8.101h-.007z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+export const XDSLogoSvg = () => (
+  <svg
+    width="46"
+    height="24"
+    viewBox="0 0 46 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg">
+    <path
+      d="M2.4239 15.8011C2.03945 16.3796 1.66972 16.9538 1.3147 17.524C0.707427 18.4992 1.42354 19.7348 2.57241 19.7348C3.13302 19.7348 3.64463 19.4209 3.91525 18.93C4.29391 18.243 4.71274 17.5352 5.17173 16.8066C5.38894 16.4618 5.60743 16.12 5.82721 15.7812C6.25251 15.1254 6.46516 14.7976 6.76252 14.68C6.99255 14.5891 7.27368 14.5899 7.50317 14.6822C7.79984 14.8014 8.00881 15.1278 8.42675 15.7804C8.64287 16.1179 8.85732 16.46 9.07008 16.8066C9.52175 17.534 9.93823 18.2339 10.3195 18.9063C10.6075 19.4141 11.1428 19.7348 11.7266 19.7348C12.9476 19.7348 13.7063 18.4203 13.0547 17.3877C12.7332 16.8781 12.3991 16.3639 12.0525 15.8453C11.3983 14.8527 10.7379 13.8906 10.0714 12.9592C9.81687 12.6036 9.68962 12.4258 9.64377 12.2384C9.60589 12.0836 9.60492 11.9307 9.64085 11.7754C9.68435 11.5874 9.80856 11.4091 10.057 11.0526C10.7093 10.1164 11.3596 9.15781 12.0078 8.1768C12.3869 7.60474 12.7521 7.03681 13.1035 6.47298C13.71 5.49987 12.9962 4.26519 11.8496 4.26519C11.2943 4.26519 10.7868 4.57405 10.5169 5.05923C10.1399 5.73688 9.72461 6.43721 9.27114 7.16022C9.06143 7.49458 8.8505 7.82569 8.63835 8.15358C8.21478 8.80819 8.003 9.1355 7.70554 9.25334C7.47561 9.34442 7.19397 9.34375 6.96448 9.25156C6.66759 9.13229 6.45853 8.80578 6.04043 8.15276C5.83116 7.82591 5.62351 7.49506 5.41747 7.16022C4.97918 6.44793 4.5738 5.76096 4.20132 5.0993C3.9136 4.58821 3.37617 4.26519 2.78967 4.26519C1.56624 4.26519 0.805692 5.58299 1.45419 6.62041C1.76588 7.11903 2.08912 7.6231 2.4239 8.1326C3.0752 9.10994 3.73263 10.059 4.3962 10.9796C4.65373 11.337 4.7825 11.5156 4.82882 11.7042C4.86709 11.86 4.86797 12.0139 4.83149 12.1702C4.78732 12.3593 4.66122 12.5385 4.40903 12.897C3.74526 13.8406 3.08355 14.8086 2.4239 15.8011Z"
+      fill="currentColor"
+    />
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M22.4734 4.26519C20.4471 4.26519 19.434 4.26519 18.6657 4.67201C18.0456 5.00031 17.5385 5.50739 17.2102 6.12744C16.8034 6.89579 16.8034 7.90892 16.8034 9.9352V14.0648C16.8034 16.0911 16.8034 17.1042 17.2102 17.8726C17.5385 18.4926 18.0456 18.9997 18.6657 19.328C19.434 19.7348 20.4471 19.7348 22.4734 19.7348H23.2039C24.8496 19.7348 26.2644 19.4033 27.4485 18.7403C28.6399 18.07 29.5559 17.1529 30.1963 15.989C30.8367 14.825 31.1569 13.4954 31.1569 12C31.1569 10.5046 30.8367 9.17495 30.1963 8.01105C29.5559 6.84714 28.6399 5.9337 27.4485 5.27072C26.2644 4.60037 24.8496 4.26519 23.2039 4.26519H22.4734ZM20.0092 8.74707C20.0092 8.16814 20.0092 7.87867 20.1255 7.65914C20.2193 7.48198 20.3641 7.33711 20.5413 7.24331C20.7608 7.12707 21.0503 7.12707 21.6292 7.12707H23.1927C24.6522 7.12707 25.7916 7.57274 26.6107 8.46409C27.4299 9.34807 27.8394 10.5267 27.8394 12C27.8394 13.4659 27.4299 14.6446 26.6107 15.5359C25.7916 16.4273 24.6522 16.8729 23.1927 16.8729H21.6292C21.0503 16.8729 20.7608 16.8729 20.5413 16.7567C20.3641 16.6629 20.2193 16.518 20.1255 16.3409C20.0092 16.1213 20.0092 15.8319 20.0092 15.2529V8.74707Z"
+      fill="currentColor"
+    />
+    <path
+      d="M35.4666 19.2376C36.6134 19.7459 37.9501 20 39.4767 20H39.8006C41.7144 20 43.2261 19.5801 44.3357 18.7403C45.4452 17.9006 46 16.7403 46 15.2597C46 14.3757 45.8213 13.6501 45.4638 13.0829C45.1064 12.5083 44.6559 12.0589 44.1123 11.7348C43.5761 11.4033 43.0325 11.1565 42.4814 10.9945C41.9304 10.8324 41.4575 10.7145 41.0628 10.6409L38.706 10.1878C38.0283 10.0552 37.4698 9.87477 37.0305 9.64641C36.5985 9.41068 36.3826 9.02762 36.3826 8.49724C36.3826 7.96685 36.6395 7.55064 37.1533 7.24862C37.6671 6.93923 38.3857 6.78453 39.3091 6.78453H39.6219C40.3964 6.78453 41.1224 6.93186 41.8001 7.22652C42.0982 7.35474 42.3899 7.5234 42.6754 7.73251C43.326 8.20923 44.2444 8.27802 44.8243 7.71734C45.34 7.21868 45.4053 6.39786 44.8761 5.91349C44.3498 5.43171 43.7638 5.03698 43.1181 4.72928C42.1054 4.24309 40.9511 4 39.6554 4H39.3315C38.0953 4 37.0156 4.19521 36.0922 4.58564C35.1762 4.97606 34.4613 5.52486 33.9475 6.23204C33.4411 6.93186 33.188 7.76059 33.188 8.71823C33.188 9.49171 33.3406 10.1436 33.6459 10.674C33.9587 11.2044 34.3571 11.6354 34.8411 11.9669C35.3326 12.2983 35.8539 12.5599 36.4049 12.7514C36.956 12.9355 37.4698 13.0718 37.9464 13.1602L40.3033 13.6243C40.6905 13.698 41.074 13.8011 41.4538 13.9337C41.841 14.0589 42.1612 14.2431 42.4144 14.4862C42.6676 14.7293 42.7942 15.0608 42.7942 15.4807C42.7942 16.6151 41.7814 17.1823 39.7559 17.1823H39.4432C38.49 17.1823 37.615 17.0055 36.8182 16.6519C36.4847 16.4994 36.1665 16.3134 35.8635 16.0938C35.17 15.5911 34.1857 15.5241 33.5784 16.1282C33.0651 16.6388 32.9912 17.4631 33.5198 17.9578C34.0797 18.4818 34.7287 18.9083 35.4666 19.2376Z"
+      fill="currentColor"
+    />
+  </svg>
+);

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -2234,7 +2234,8 @@ function AppTopNav({
           zIndex: 11,
           transition:
             'box-shadow 300ms var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
-          boxShadow: isScrolled ? '0 1px 3px rgba(0,0,0,0.08)' : 'none',
+          boxShadow:
+            isScrolled && !isFilterOpen ? '0 1px 3px rgba(0,0,0,0.08)' : 'none',
         }}>
         {/* Left: logo nav */}
         <div style={{display: 'flex', alignItems: 'center', gap: 8, flex: 1}}>
@@ -2367,6 +2368,8 @@ function AppTopNav({
             ? '1fr 1fr 1fr 1fr'
             : '1fr 1fr 1fr 1fr',
           gap: isFilterOpen ? 24 : 0,
+          boxShadow:
+            isFilterOpen && isScrolled ? '0 1px 3px rgba(0,0,0,0.08)' : 'none',
           padding: isFilterOpen ? '24px 40px' : '0 40px',
           maxHeight: isFilterOpen ? 400 : 0,
           overflow: 'hidden',
@@ -3839,7 +3842,7 @@ function TemplateFullPreview({
                       transition: 'border-color 150ms ease',
                     }}>
                     <XDSText
-                      type="body-2"
+                      type="body"
                       color={panelTab === tab ? 'primary' : 'secondary'}>
                       {tab === 'properties' ? 'Details' : 'Chat'}
                     </XDSText>

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -800,9 +800,8 @@ function AIComposer() {
               paddingBlock: 6,
               borderRadius: 9999,
               backgroundColor: 'var(--color-background-body)',
-              fontSize: 13,
             }}>
-            Template 01
+            <XDSText type="supporting">Template 01</XDSText>
           </div>
           <div
             style={{
@@ -973,10 +972,9 @@ function ChatPanel({
               paddingBlock: 2,
               borderRadius: 9999,
               backgroundColor: 'var(--color-overlay-hover, rgba(0,0,0,0.05))',
-              fontSize: 12,
               marginBottom: 8,
             }}>
-            Template 01
+            <XDSText type="supporting">Template 01</XDSText>
           </div>
           <XDSText type="body">
             Can you customize this template by adding a divider line under the
@@ -1011,9 +1009,8 @@ function ChatPanel({
               paddingBlock: 2,
               borderRadius: 9999,
               backgroundColor: 'var(--color-background-body, #f1f4f7)',
-              fontSize: 12,
             }}>
-            Template 01
+            <XDSText type="supporting">Template 01</XDSText>
           </div>
           <div style={{display: 'flex', alignItems: 'center', padding: 8}}>
             <input
@@ -1750,16 +1747,17 @@ function LogoNav({
                     padding: '8px 12px',
                     borderRadius: 8,
                     cursor: 'pointer',
-                    fontWeight: isActive ? 600 : 400,
-                    fontSize: 14,
-                    color: 'var(--color-text-primary, #1a1a1a)',
                     backgroundColor:
                       isActive || isHovered
                         ? 'var(--color-background-body, #f1f4f7)'
                         : 'transparent',
                     transition: 'background-color 150ms ease',
                   }}>
-                  {item.label}
+                  <XDSText
+                    type="body"
+                    weight={isActive ? 'semibold' : 'normal'}>
+                    {item.label}
+                  </XDSText>
                 </div>
               );
             })}
@@ -2076,8 +2074,6 @@ function NavItem({
             ? 'rgba(0, 0, 0, 0.04)'
             : 'transparent',
         color: isActive ? '#0066FF' : 'var(--color-text-primary, #1a1a1a)',
-        fontSize: 14,
-        fontWeight: isActive ? 600 : 400,
         transition: 'background-color 150ms ease',
         userSelect: 'none' as const,
       }}>
@@ -2092,7 +2088,14 @@ function NavItem({
           }}
         />
       )}
-      <span style={{flex: 1}}>{label}</span>
+      <div style={{flex: 1}}>
+        <XDSText
+          type="body"
+          weight={isActive ? 'semibold' : 'normal'}
+          color="inherit">
+          {label}
+        </XDSText>
+      </div>
       {hasChevron && (
         <span
           style={{
@@ -2111,16 +2114,15 @@ function SectionLabel({label, indent = 0}: {label: string; indent?: number}) {
   return (
     <div
       style={{
-        fontSize: 11,
-        fontWeight: 600,
-        color: 'var(--color-text-secondary, #6b7785)',
         textTransform: 'uppercase' as const,
         letterSpacing: '0.05em',
         padding: '12px 12px 4px',
         paddingLeft: 12 + indent * 16,
         margin: '0 8px',
       }}>
-      {label}
+      <XDSText type="supporting" weight="semibold" color="secondary">
+        {label}
+      </XDSText>
     </div>
   );
 }
@@ -2561,27 +2563,17 @@ function DocsView({
             </div>
             <div style={{maxWidth: 840}}>
               {/* Title */}
-              <h1
-                style={{
-                  fontSize: 48,
-                  fontWeight: 700,
-                  margin: 0,
-                  letterSpacing: '-0.02em',
-                  color: 'var(--color-text-primary, #0a1317)',
-                  lineHeight: 1.1,
-                }}>
-                Button
-              </h1>
+              <div
+                style={{margin: 0, letterSpacing: '-0.02em', lineHeight: 1.1}}>
+                <XDSHeading level={1}>Button</XDSHeading>
+              </div>
 
               {/* Date line */}
-              <p
-                style={{
-                  fontSize: 14,
-                  color: 'var(--color-text-secondary, #6b7785)',
-                  margin: '8px 0 32px',
-                }}>
-                March 30, 2026 · Updated 5:40 p.m. PST
-              </p>
+              <div style={{margin: '8px 0 32px'}}>
+                <XDSText type="body" color="secondary">
+                  March 30, 2026 · Updated 5:40 p.m. PST
+                </XDSText>
+              </div>
 
               {/* Live Preview Panel */}
               <div
@@ -2604,14 +2596,12 @@ function DocsView({
                       '1px solid var(--color-divider, rgba(0,0,0,0.08))',
                     backgroundColor: 'var(--color-background-surface, #ffffff)',
                   }}>
-                  <span
-                    style={{
-                      fontSize: 13,
-                      fontWeight: 600,
-                      color: 'var(--color-text-secondary, #6b7785)',
-                    }}>
+                  <XDSText
+                    type="supporting"
+                    weight="semibold"
+                    color="secondary">
                     Live preview
-                  </span>
+                  </XDSText>
                   <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
                     <XDSButton
                       label="Open in Craft"
@@ -2768,20 +2758,34 @@ function DocsView({
                 style={{
                   margin: 0,
                   padding: '0 0 0 20px',
-                  color: 'var(--color-text-primary, #0a1317)',
-                  fontSize: 15,
                   lineHeight: 1.7,
                 }}>
-                <li>Triggering form submissions or confirming a dialog</li>
-                <li>Navigating to a new page or view within the application</li>
                 <li>
-                  Starting a new process or workflow (e.g., &quot;Create
-                  new&quot;)
+                  <XDSText type="body">
+                    Triggering form submissions or confirming a dialog
+                  </XDSText>
                 </li>
-                <li>Toggling a UI element or performing an inline action</li>
                 <li>
-                  Performing destructive actions such as deleting items — use
-                  the danger variant for these
+                  <XDSText type="body">
+                    Navigating to a new page or view within the application
+                  </XDSText>
+                </li>
+                <li>
+                  <XDSText type="body">
+                    Starting a new process or workflow (e.g., &quot;Create
+                    new&quot;)
+                  </XDSText>
+                </li>
+                <li>
+                  <XDSText type="body">
+                    Toggling a UI element or performing an inline action
+                  </XDSText>
+                </li>
+                <li>
+                  <XDSText type="body">
+                    Performing destructive actions such as deleting items — use
+                    the danger variant for these
+                  </XDSText>
                 </li>
               </ul>
             </div>
@@ -2802,14 +2806,13 @@ function DocsView({
         }}>
         <div
           style={{
-            fontSize: 11,
-            fontWeight: 700,
-            color: 'var(--color-text-secondary, #6b7785)',
             textTransform: 'uppercase' as const,
             letterSpacing: '0.08em',
             marginBottom: 12,
           }}>
-          On this page
+          <XDSText type="supporting" weight="bold" color="secondary">
+            On this page
+          </XDSText>
         </div>
         {[
           {id: 'usage', label: 'Usage'},
@@ -2821,14 +2824,12 @@ function DocsView({
             key={item.id}
             onClick={() => setActiveRightNav(item.id)}
             style={{
-              fontSize: 13,
               padding: '6px 0',
               cursor: 'pointer',
               color:
                 activeRightNav === item.id
                   ? '#0066FF'
                   : 'var(--color-text-secondary, #6b7785)',
-              fontWeight: activeRightNav === item.id ? 600 : 400,
               borderLeft:
                 activeRightNav === item.id
                   ? '2px solid #0066FF'
@@ -2836,7 +2837,12 @@ function DocsView({
               paddingLeft: 12,
               transition: 'color 150ms ease',
             }}>
-            {item.label}
+            <XDSText
+              type="supporting"
+              weight={activeRightNav === item.id ? 'semibold' : 'normal'}
+              color="inherit">
+              {item.label}
+            </XDSText>
           </div>
         ))}
       </aside>
@@ -3453,14 +3459,7 @@ function TemplateFullPreview({
             'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms, transform 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms',
         }}>
         {/* Template name */}
-        <XDSHeading level={2}>{templateName}</XDSHeading>
-
-        {/* Subtitle */}
-        <div style={{marginTop: 4}}>
-          <XDSText type="supporting" color="secondary">
-            XDS · 541 usages
-          </XDSText>
-        </div>
+        <XDSHeading level={1}>{templateName}</XDSHeading>
 
         {/* Description */}
         <div style={{marginTop: 12}}>
@@ -3501,8 +3500,15 @@ function TemplateFullPreview({
               hasChevron={false}
               menuWidth={220}
               items={[
-                {label: 'Copy link', onClick: () => {}},
-                {label: 'Share via email', onClick: () => {}},
+                {
+                  label: 'Copy CLI Command...',
+                  icon: TerminalIcon,
+                  onClick: () => {},
+                },
+                {type: 'divider' as const},
+                {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
+                {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
               ]}
             />
           </div>
@@ -3657,11 +3663,23 @@ function TemplateFullPreview({
         {/* Component used */}
         <div style={{marginTop: 32}}>
           <XDSHeading level={3}>Component used</XDSHeading>
-          <div style={{marginTop: 8}}>
-            <XDSText type="body">
-              XDSAppShell, XDSTopNav, XDSVStack, XDSHStack, XDSHeading, XDSText,
-              XDSButton, XDSCard, XDSBadge, XDSAvatar
-            </XDSText>
+          <div
+            style={{
+              display: 'flex',
+              flexWrap: 'wrap' as const,
+              gap: 8,
+              marginTop: 8,
+            }}>
+            <XDSToken label="XDSAppShell" />
+            <XDSToken label="XDSTopNav" />
+            <XDSToken label="XDSVStack" />
+            <XDSToken label="XDSHStack" />
+            <XDSToken label="XDSHeading" />
+            <XDSToken label="XDSText" />
+            <XDSToken label="XDSButton" />
+            <XDSToken label="XDSCard" />
+            <XDSToken label="XDSBadge" />
+            <XDSToken label="XDSAvatar" />
           </div>
         </div>
 
@@ -3696,7 +3714,7 @@ function TemplateFullPreview({
             size={36}
             src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
           />
-          <div>
+          <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
             <XDSText type="supporting" color="secondary">
               Designed by
             </XDSText>
@@ -3985,8 +4003,19 @@ function TemplateCombinedView({
                     hasChevron={false}
                     menuWidth={220}
                     items={[
-                      {label: 'Copy link', onClick: () => {}},
-                      {label: 'Share via email', onClick: () => {}},
+                      {
+                        label: 'Copy CLI Command...',
+                        icon: TerminalIcon,
+                        onClick: () => {},
+                      },
+                      {type: 'divider' as const},
+                      {
+                        label: 'Claude Code',
+                        icon: ClaudeIcon,
+                        onClick: () => {},
+                      },
+                      {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                      {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
                     ]}
                   />
                 </div>
@@ -4103,7 +4132,7 @@ function TemplateCombinedView({
                   size={36}
                   src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
                 />
-                <div>
+                <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
                   <XDSText type="supporting" color="secondary">
                     Designed by
                   </XDSText>
@@ -4398,16 +4427,12 @@ export default function DocsiteLandingTemplate() {
           }}>
           <div style={{textAlign: 'center', opacity: 0.5}}>
             <div style={{fontSize: 48, marginBottom: 16}}>📚</div>
-            <div style={{fontSize: 20, fontWeight: 600, marginBottom: 8}}>
-              Learn
+            <div style={{marginBottom: 8}}>
+              <XDSHeading level={3}>Learn</XDSHeading>
             </div>
-            <div
-              style={{
-                fontSize: 14,
-                color: 'var(--color-text-secondary, #666)',
-              }}>
+            <XDSText type="body" color="secondary">
               Tutorials, guides, and resources — coming soon
-            </div>
+            </XDSText>
           </div>
         </div>
       </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1126,6 +1126,21 @@ const ContrastIcon = (props: React.SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+const SaveIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+    <polyline points="17 21 17 13 7 13 7 21" />
+    <polyline points="7 3 7 8 15 8" />
+  </svg>
+);
+
 const BookmarkIcon = (props: React.SVGProps<SVGSVGElement>) => (
   <svg
     viewBox="0 0 24 24"
@@ -1252,7 +1267,7 @@ export default function DetailPage() {
         <XDSCard>
           <XDSVStack gap={4}>
             <XDSHStack gap={2} vAlign="center">
-              <XDSAvatar name="Jane Doe" size="md" />
+              <XDSAvatar name="Jane Doe" size="medium" />
               <XDSText type="body" weight="bold">Jane Doe</XDSText>
               <XDSBadge label="Active" variant="success" />
             </XDSHStack>
@@ -1327,23 +1342,23 @@ function TemplatePreview({
         flexDirection: 'column' as const,
         height: '100%',
         overflow: 'hidden',
-        paddingTop: 16,
+        paddingTop: 0,
       }}>
       <div
         style={{
           flex: 1,
-          overflow: 'auto',
-          padding: '0 16px 16px 0',
+          overflow: 'hidden',
+          padding: 0,
+          display: 'flex',
+          flexDirection: 'column' as const,
         }}>
         {/* Bordered container: toolbar + preview + code */}
         <div
           style={{
-            border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-            borderRadius: 12,
-            paddingBottom: 8,
             display: 'flex',
             flexDirection: 'column' as const,
-            minHeight: 800,
+            flex: 1,
+            overflow: 'hidden',
           }}>
           {/* Toolbar */}
           <XDSToolbar
@@ -1420,7 +1435,7 @@ function TemplatePreview({
                 <XDSButton
                   label="Save"
                   variant="ghost"
-                  icon={<BookmarkIcon />}
+                  icon={<SaveIcon />}
                   isIconOnly
                   onClick={() => {}}
                 />
@@ -1450,273 +1465,170 @@ function TemplatePreview({
           />
 
           {/* Preview — browser frame + image */}
-          {editorView === 'preview' && (
+          <div
+            style={{
+              backgroundColor: 'var(--color-background-body, #f5f5f5)',
+              borderRadius: 0,
+              padding: 0,
+              margin: 0,
+              display: editorView === 'preview' ? 'flex' : 'none',
+              justifyContent: 'center',
+              alignItems: 'flex-start',
+              flex: 1,
+              overflow: 'hidden',
+            }}>
             <div
+              ref={previewRef}
               style={{
-                backgroundColor: '#f5f5f5',
-                borderRadius: 8,
-                padding: 22,
-                margin: '0 8px',
-                display: 'flex',
-                justifyContent: 'center',
-                minHeight: 700,
-              }}>
-              <div
-                ref={previewRef}
-                style={{
-                  position: 'relative',
-                  width:
-                    VIEWPORT_WIDTHS[viewportSize] === '100%'
-                      ? '100%'
-                      : VIEWPORT_WIDTHS[viewportSize],
-                  maxWidth: '100%',
-                  backgroundColor: '#fff',
-                  borderRadius: viewportSize === 'phone' ? 36 : 12,
-                  border: viewportSize === 'phone' ? '10px solid #fff' : 'none',
-                  boxShadow:
-                    viewportSize === 'phone'
-                      ? '0 8px 40px rgba(0,0,0,0.15), 0 0 0 1px rgba(0,0,0,0.06)'
-                      : '0 8px 40px rgba(0,0,0,0.12)',
-                  overflow: 'hidden',
-                  transition:
-                    'width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
-                }}>
-                {/* Browser chrome dots for desktop */}
-                {viewportSize === 'desktop' && (
-                  <div
-                    style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      padding: '10px 14px',
-                      backgroundColor: '#fff',
-                      borderBottom: '1px solid #f0f0f0',
-                    }}>
-                    <div
-                      style={{display: 'flex', gap: 6, alignItems: 'center'}}>
-                      <div
-                        style={{
-                          width: 10,
-                          height: 10,
-                          borderRadius: '50%',
-                          backgroundColor: '#e0e0e0',
-                        }}
-                      />
-                      <div
-                        style={{
-                          width: 10,
-                          height: 10,
-                          borderRadius: '50%',
-                          backgroundColor: '#e0e0e0',
-                        }}
-                      />
-                      <div
-                        style={{
-                          width: 10,
-                          height: 10,
-                          borderRadius: '50%',
-                          backgroundColor: '#e0e0e0',
-                        }}
-                      />
-                    </div>
-                  </div>
-                )}
-                <img
-                  src={imageSrc}
-                  alt="Template preview"
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    aspectRatio:
-                      viewportSize === 'phone' ? '9 / 19.5' : '1920 / 1200',
-                    objectFit: 'cover',
-                    opacity: isGenerating ? 0 : 1,
-                    transition: 'opacity 600ms ease',
-                  }}
-                />
-                {showCanvas && (
-                  <div
-                    style={{
-                      position: 'absolute',
-                      inset: 0,
-                      opacity: isGenerating ? 1 : 0,
-                      transition: 'opacity 600ms ease',
-                    }}>
-                    <BoidsCanvas
-                      width={previewSize.w}
-                      height={previewSize.h}
-                      simulation={simulation}
-                    />
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Code block */}
-          {editorView === 'code' && (
-            <div
-              style={{
-                margin: '8px 8px 0',
-                border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-                borderRadius: 8,
-                backgroundColor:
-                  'var(--color-background-muted, rgba(0,0,0,0.03))',
+                position: 'relative',
+                width:
+                  VIEWPORT_WIDTHS[viewportSize] === '100%'
+                    ? '100%'
+                    : VIEWPORT_WIDTHS[viewportSize],
+                maxWidth: '100%',
+                backgroundColor: '#fff',
+                borderRadius: viewportSize === 'phone' ? 36 : 12,
+                border: viewportSize === 'phone' ? '10px solid #fff' : 'none',
+                boxShadow:
+                  viewportSize === 'phone'
+                    ? '0 8px 40px rgba(0,0,0,0.15), 0 0 0 1px rgba(0,0,0,0.06)'
+                    : '0 8px 40px rgba(0,0,0,0.12)',
                 overflow: 'hidden',
               }}>
-              {/* Header */}
-              <div
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'space-between',
-                  padding: '8px 12px 8px 16px',
-                }}>
-                <span
-                  style={{
-                    fontFamily: '"Roboto Mono", monospace',
-                    fontSize: 12,
-                    fontWeight: 500,
-                    color: 'var(--color-text-secondary, #4e606f)',
-                  }}>
-                  typescript — useUser.ts
-                </span>
-              </div>
-              {/* Code */}
-              <div style={{display: 'flex'}}>
-                {/* Line numbers */}
+              {/* Browser chrome dots for desktop */}
+              {viewportSize === 'desktop' && (
                 <div
                   style={{
-                    padding: '12px 12px 12px 16px',
-                    borderRight:
-                      '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-                    fontFamily: '"Roboto Mono", monospace',
-                    fontSize: 14,
-                    lineHeight: '20px',
-                    color: 'var(--color-text-disabled, #a4b0bc)',
-                    textAlign: 'right',
-                    userSelect: 'none',
-                    minWidth: 45,
+                    display: 'flex',
+                    alignItems: 'center',
+                    padding: '10px 14px',
+                    backgroundColor: '#fff',
+                    borderBottom: '1px solid #f0f0f0',
                   }}>
-                  {MOCK_CODE.split('\n').map((_, i) => (
-                    <div key={i}>{i + 1}</div>
-                  ))}
+                  <div style={{display: 'flex', gap: 6, alignItems: 'center'}}>
+                    <div
+                      style={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: '50%',
+                        backgroundColor: '#e0e0e0',
+                      }}
+                    />
+                    <div
+                      style={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: '50%',
+                        backgroundColor: '#e0e0e0',
+                      }}
+                    />
+                    <div
+                      style={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: '50%',
+                        backgroundColor: '#e0e0e0',
+                      }}
+                    />
+                  </div>
                 </div>
-                {/* Code content */}
-                <pre
+              )}
+              <img
+                src={imageSrc}
+                alt="Template preview"
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  aspectRatio:
+                    viewportSize === 'phone' ? '9 / 19.5' : '1920 / 1200',
+                  objectFit: 'cover',
+                  opacity: isGenerating ? 0 : 1,
+                  transition: 'opacity 600ms ease',
+                }}
+              />
+              {showCanvas && (
+                <div
                   style={{
-                    flex: 1,
-                    padding: '12px 16px',
-                    fontFamily: '"Roboto Mono", monospace',
-                    fontSize: 14,
-                    lineHeight: '20px',
-                    margin: 0,
-                    overflow: 'auto',
-                    color: 'var(--color-text-primary, #0a1317)',
+                    position: 'absolute',
+                    inset: 0,
+                    opacity: isGenerating ? 1 : 0,
+                    transition: 'opacity 600ms ease',
                   }}>
-                  {MOCK_CODE}
-                </pre>
-              </div>
+                  <BoidsCanvas
+                    width={previewSize.w}
+                    height={previewSize.h}
+                    simulation={simulation}
+                  />
+                </div>
+              )}
             </div>
-          )}
-        </div>
+          </div>
 
-        {/* Title & metadata */}
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column' as const,
-            gap: 16,
-            marginTop: 16,
-          }}>
-          <div style={{maxWidth: 540}}>
+          {/* Code block */}
+          <div
+            style={{
+              margin: '0 8px',
+              border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+              borderRadius: 8,
+              backgroundColor:
+                'var(--color-background-muted, rgba(0,0,0,0.03))',
+              overflow: 'auto',
+              flex: 1,
+              display: editorView === 'code' ? 'block' : 'none',
+            }}>
+            {/* Header */}
             <div
               style={{
                 display: 'flex',
-                flexDirection: 'column' as const,
-                gap: 4,
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '8px 12px 8px 16px',
               }}>
-              <XDSHeading level={1}>{templateName}</XDSHeading>
-              <XDSText type="supporting" color="secondary">
-                XDS · 541 usages
-              </XDSText>
+              <span
+                style={{
+                  fontFamily: '"Roboto Mono", monospace',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: 'var(--color-text-secondary, #4e606f)',
+                }}>
+                typescript — useUser.ts
+              </span>
             </div>
-            <XDSText type="body" style={{marginTop: 16}}>
-              Buttons are clickable elements that are used to trigger actions.
-              They communicate calls to action to the user and allow users to
-              interact with pages in a variety of ways. Button labels express
-              what action will occur when the user interacts with it.
-            </XDSText>
-          </div>
-        </div>
-
-        {/* Similar templates */}
-        <div
-          style={{
-            marginTop: 16,
-            display: 'flex',
-            flexDirection: 'column' as const,
-            gap: 16,
-          }}>
-          <XDSHeading level={2}>Similar templates</XDSHeading>
-          <div style={{display: 'flex', gap: 16}}>
-            {TEMPLATE_IMAGES.slice(0, 3).map((src, i) => (
+            {/* Code */}
+            <div style={{display: 'flex'}}>
+              {/* Line numbers */}
               <div
-                key={i}
+                style={{
+                  padding: '12px 12px 12px 16px',
+                  borderRight:
+                    '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                  fontFamily: '"Roboto Mono", monospace',
+                  fontSize: 14,
+                  lineHeight: '20px',
+                  color: 'var(--color-text-disabled, #a4b0bc)',
+                  textAlign: 'right',
+                  userSelect: 'none',
+                  minWidth: 45,
+                }}>
+                {MOCK_CODE.split('\n').map((_, i) => (
+                  <div key={i}>{i + 1}</div>
+                ))}
+              </div>
+              {/* Code content */}
+              <pre
                 style={{
                   flex: 1,
-                  aspectRatio: '1920 / 1200',
-                  border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-                  backgroundColor: '#fff',
-                  borderRadius: 12,
-                  boxShadow: '0 8px 40px rgba(0,0,0,0.12)',
-                  overflow: 'hidden',
+                  padding: '12px 16px',
+                  fontFamily: '"Roboto Mono", monospace',
+                  fontSize: 14,
+                  lineHeight: '20px',
+                  margin: 0,
+                  overflow: 'auto',
+                  color: 'var(--color-text-primary, #0a1317)',
                 }}>
-                <img
-                  src={src}
-                  alt={`Similar template ${i + 1}`}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'cover',
-                  }}
-                />
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Component used */}
-        <div
-          style={{
-            marginTop: 16,
-            display: 'flex',
-            flexDirection: 'column' as const,
-            gap: 16,
-          }}>
-          <XDSHeading level={2}>Component used</XDSHeading>
-          <XDSText type="body">
-            XDSAppShell, XDSTopNav, XDSVStack, XDSHStack, XDSHeading, XDSText,
-            XDSButton, XDSCard, XDSBadge, XDSAvatar
-          </XDSText>
-        </div>
-
-        {/* Keywords */}
-        <div
-          style={{
-            marginTop: 16,
-            display: 'flex',
-            flexDirection: 'column' as const,
-            gap: 16,
-            paddingBottom: 24,
-          }}>
-          <XDSHeading level={2}>Keywords</XDSHeading>
-          <div style={{display: 'flex', flexWrap: 'wrap' as const, gap: 4}}>
-            <XDSToken label="Dashboard" size="sm" />
-            <XDSToken label="Admin" size="sm" />
-            <XDSToken label="Layout" size="sm" />
-            <XDSToken label="Navigation" size="sm" />
-            <XDSToken label="Settings" size="sm" />
+                {MOCK_CODE}
+              </pre>
+            </div>
           </div>
         </div>
       </div>
@@ -2675,7 +2587,7 @@ function DocsView({
               <div
                 style={{
                   border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-                  backgroundColor: '#fff',
+                  backgroundColor: 'var(--color-background-card, #fff)',
                   borderRadius: 12,
                   boxShadow: '0 8px 40px rgba(0,0,0,0.12)',
                   overflow: 'hidden',
@@ -3379,12 +3291,6 @@ function TemplateFullPreview({
   onUse: () => void;
 }) {
   const [viewMode, setViewMode] = useState<'desktop' | 'mobile'>('desktop');
-  const [selectedPalette, setSelectedPalette] = useState<string | null>(
-    PREVIEW_COLOR_PALETTES[0].name,
-  );
-  const [selectedFontPack, setSelectedFontPack] = useState<string | null>(
-    PREVIEW_FONT_PACKS[0].heading,
-  );
   const [isVisible, setIsVisible] = useState(false);
 
   useEffect(() => {
@@ -3400,7 +3306,7 @@ function TemplateFullPreview({
         style={{
           flex: 1,
           minWidth: 0,
-          backgroundColor: '#f5f5f5',
+          backgroundColor: 'var(--color-background-body, #f5f5f5)',
           display: 'flex',
           flexDirection: 'column' as const,
           opacity: isVisible ? 1 : 0,
@@ -3529,8 +3435,8 @@ function TemplateFullPreview({
           width: '30%',
           maxWidth: 380,
           minWidth: 300,
-          backgroundColor: '#fff',
-          borderLeft: '1px solid #e0e0e0',
+          backgroundColor: 'var(--color-background-card, #fff)',
+          borderLeft: '1px solid var(--color-border-default, #e0e0e0)',
           padding: 32,
           overflowY: 'auto' as const,
           display: 'flex',
@@ -3540,26 +3446,24 @@ function TemplateFullPreview({
           transition:
             'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms, transform 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms',
         }}>
-        {/* Template name & description */}
-        <div>
-          <XDSHeading level={1}>{templateName}</XDSHeading>
-          <div style={{marginTop: 4}}>
-            <XDSText type="body" color="secondary">
-              Continue to customize styles, add features, and more when you
-              start a trial.
-            </XDSText>
-          </div>
+        {/* Template name */}
+        <XDSHeading level={2}>{templateName}</XDSHeading>
+
+        {/* Subtitle */}
+        <div style={{marginTop: 4}}>
+          <XDSText type="supporting" color="secondary">
+            XDS · 541 usages
+          </XDSText>
         </div>
 
-        {/* CTA button */}
-        <div style={{marginTop: 16}}>
-          <XDSButton
-            variant="primary"
-            label="Start crafting"
-            onClick={onUse}
-            size="lg"
-            style={{width: '100%'}}
-          />
+        {/* Description */}
+        <div style={{marginTop: 12}}>
+          <XDSText type="body" color="secondary">
+            Buttons are clickable elements that are used to trigger actions.
+            They communicate calls to action to the user and allow users to
+            interact with pages in a variety of ways. Button labels express what
+            action will occur when the user interacts with it.
+          </XDSText>
         </div>
 
         {/* Stats buttons */}
@@ -3612,87 +3516,80 @@ function TemplateFullPreview({
           </div>
         </div>
 
-        {/* Color palettes */}
+        {/* CTA button */}
+        <div style={{marginTop: 16}}>
+          <XDSButton
+            variant="primary"
+            label="Start crafting"
+            onClick={onUse}
+            size="lg"
+            style={{width: '100%'}}
+          />
+        </div>
+
+        {/* Similar templates */}
         <div style={{marginTop: 32}}>
-          <XDSHeading level={4}>Color palettes</XDSHeading>
+          <XDSHeading level={3}>Similar templates</XDSHeading>
           <div
             style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: 10,
-              marginTop: 8,
+              display: 'flex',
+              gap: 12,
+              marginTop: 12,
+              overflowX: 'auto' as const,
             }}>
-            {PREVIEW_COLOR_PALETTES.map(palette => (
+            {[0, 1, 2, 3].map(i => (
               <div
-                key={palette.name}
-                onClick={() => setSelectedPalette(palette.name)}
+                key={i}
                 style={{
-                  cursor: 'pointer',
-                  border: `2px solid ${selectedPalette === palette.name ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
-                  borderRadius: 14,
+                  flex: '0 0 120px',
+                  aspectRatio: '1920 / 1200',
+                  border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                  backgroundColor: 'var(--color-background-card, #fff)',
+                  borderRadius: 8,
+                  boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
                   overflow: 'hidden',
-                  transition: 'border-color 0.15s ease',
                 }}>
-                <XDSCard padding={0}>
-                  <div
-                    style={{
-                      display: 'flex',
-                      overflow: 'hidden',
-                      height: 48,
-                    }}>
-                    {palette.colors.map((color, i) => (
-                      <div
-                        key={i}
-                        style={{
-                          flex: 1,
-                          backgroundColor: color,
-                        }}
-                      />
-                    ))}
-                  </div>
-                </XDSCard>
+                <img
+                  src={DUMMY_IMAGE}
+                  alt={`Similar template ${i + 1}`}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover',
+                  }}
+                />
               </div>
             ))}
           </div>
         </div>
 
-        {/* Font packs */}
+        {/* Component used */}
         <div style={{marginTop: 32}}>
-          <XDSHeading level={4}>Font packs</XDSHeading>
+          <XDSHeading level={3}>Component used</XDSHeading>
+          <div style={{marginTop: 8}}>
+            <XDSText type="body">
+              XDSAppShell, XDSTopNav, XDSVStack, XDSHStack, XDSHeading, XDSText,
+              XDSButton, XDSCard, XDSBadge, XDSAvatar
+            </XDSText>
+          </div>
+        </div>
+
+        {/* Keywords */}
+        <div style={{marginTop: 32}}>
+          <XDSHeading level={3}>Keywords</XDSHeading>
           <div
             style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: 10,
+              display: 'flex',
+              flexWrap: 'wrap' as const,
+              gap: 4,
               marginTop: 8,
             }}>
-            {PREVIEW_FONT_PACKS.map(pack => (
-              <div
-                key={pack.heading}
-                onClick={() => setSelectedFontPack(pack.heading)}
-                style={{
-                  cursor: 'pointer',
-                  border: `2px solid ${selectedFontPack === pack.heading ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
-                  borderRadius: 14,
-                  overflow: 'hidden',
-                  transition: 'border-color 0.15s ease',
-                }}>
-                <XDSCard padding={2}>
-                  <div style={{fontFamily: pack.heading}}>
-                    <XDSText
-                      type="body"
-                      style={{fontWeight: 600, fontSize: 16}}>
-                      Heading
-                    </XDSText>
-                  </div>
-                  <div style={{fontFamily: pack.paragraph}}>
-                    <XDSText type="supporting" color="secondary">
-                      Paragraph text
-                    </XDSText>
-                  </div>
-                </XDSCard>
-              </div>
-            ))}
+            <XDSToken label="Dashboard" size="sm" />
+            <XDSToken label="Admin" size="sm" />
+            <XDSToken label="Layout" size="sm" />
+            <XDSToken label="Navigation" size="sm" />
+            <XDSToken label="Settings" size="sm" />
           </div>
         </div>
 
@@ -3706,8 +3603,7 @@ function TemplateFullPreview({
             gap: 12,
           }}>
           <XDSAvatar
-            size="sm"
-            style={{width: 36, height: 36}}
+            size={36}
             src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
           />
           <div>
@@ -3765,7 +3661,7 @@ function TemplateCombinedView({
         style={{
           flex: 7,
           minWidth: 0,
-          backgroundColor: '#f5f5f5',
+          backgroundColor: 'var(--color-background-body, #f5f5f5)',
           display: 'flex',
           flexDirection: 'column' as const,
           opacity: isVisible ? 1 : 0,
@@ -3917,8 +3813,8 @@ function TemplateCombinedView({
           flex: 3,
           maxWidth: 380,
           minWidth: 300,
-          backgroundColor: '#fff',
-          borderLeft: '1px solid #e0e0e0',
+          backgroundColor: 'var(--color-background-card, #fff)',
+          borderLeft: '1px solid var(--color-border-default, #e0e0e0)',
           display: 'flex',
           flexDirection: 'column' as const,
           opacity: isVisible ? 1 : 0,
@@ -4114,8 +4010,7 @@ function TemplateCombinedView({
                   gap: 12,
                 }}>
                 <XDSAvatar
-                  size="sm"
-                  style={{width: 36, height: 36}}
+                  size={36}
                   src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
                 />
                 <div>
@@ -4140,7 +4035,7 @@ function TemplateCombinedView({
                 }}>
                 <div
                   style={{
-                    backgroundColor: '#f5f5f5',
+                    backgroundColor: 'var(--color-background-body, #f5f5f5)',
                     borderRadius: 16,
                     padding: '12px 16px',
                     maxWidth: '85%',
@@ -4348,7 +4243,6 @@ export default function DocsiteLandingTemplate() {
         }}
         onUse={() => {
           setUseTarget(previewTarget);
-          setPreviewTarget(null);
         }}
       />
     );

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -2195,9 +2195,11 @@ function LogoNav({
 function AppTopNav({
   activeView,
   setActiveView,
+  scrollContainerRef,
 }: {
   activeView: 'craft' | 'library' | 'learn' | 'profile';
   setActiveView: (view: 'craft' | 'library' | 'learn' | 'profile') => void;
+  scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
 }) {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('all');
@@ -2206,11 +2208,15 @@ function AppTopNav({
 
   useEffect(() => {
     const handleScroll = () => {
-      setIsScrolled(window.scrollY > 120);
+      const scrollTop = scrollContainerRef?.current
+        ? scrollContainerRef.current.scrollTop
+        : window.scrollY;
+      setIsScrolled(scrollTop > 120);
     };
-    window.addEventListener('scroll', handleScroll, {passive: true});
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, []);
+    const target = scrollContainerRef?.current ?? window;
+    target.addEventListener('scroll', handleScroll, {passive: true});
+    return () => target.removeEventListener('scroll', handleScroll);
+  }, [scrollContainerRef]);
 
   return (
     <>
@@ -4990,6 +4996,7 @@ export default function DocsiteLandingTemplate() {
   const [previewTarget, setPreviewTarget] = useState<number | null>(null);
   const [useTarget, setUseTarget] = useState<number | null>(null);
   const [previewGenerating, setPreviewGenerating] = useState(false);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // Reset preview/editor state when switching views
   useEffect(() => {
@@ -5286,7 +5293,11 @@ export default function DocsiteLandingTemplate() {
         height: '100vh',
         backgroundColor: 'var(--color-background-surface, white)',
       }}>
-      <AppTopNav activeView={activeView} setActiveView={setActiveView} />
+      <AppTopNav
+        activeView={activeView}
+        setActiveView={setActiveView}
+        scrollContainerRef={scrollContainerRef}
+      />
       <div
         style={{
           display: 'flex',
@@ -5325,6 +5336,7 @@ export default function DocsiteLandingTemplate() {
           <div style={{display: 'flex', flex: 1, overflow: 'hidden'}}>
             {/* Masonry Grid */}
             <div
+              ref={scrollContainerRef}
               style={{
                 flex: 1,
                 overflow: 'auto',

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -939,7 +939,26 @@ function ChatPanel({
         height: '100%',
         width: '100%',
       }}>
-      {/* Header with back + title */}
+      {/* Header: logo or back+title */}
+      {!templateName && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            padding: '12px 16px',
+            flexShrink: 0,
+          }}>
+          <LogoNav activeView={activeView} setActiveView={setActiveView} />
+          <XDSButton
+            label="Toggle sidebar"
+            variant="ghost"
+            size="sm"
+            isIconOnly
+            icon={<SidebarIcon />}
+          />
+        </div>
+      )}
       {templateName && (
         <div
           style={{
@@ -957,7 +976,7 @@ function ChatPanel({
               icon={<ArrowLeftIcon />}
               isIconOnly
               onClick={onBack}
-              style={{marginLeft: -8, flexShrink: 0}}
+              style={{flexShrink: 0}}
             />
           )}
           <XDSHeading level={1} style={{lineHeight: 1}}>
@@ -3362,7 +3381,7 @@ function TemplateFullPreview({
             backgroundColor: 'var(--color-background-card, #fff)',
             borderRadius: 16,
             boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
-            padding: '16px 32px 32px',
+            padding: showChat ? '16px 32px 32px' : '24px 32px 32px',
             overflowY: 'auto' as const,
             display: 'flex',
             flexDirection: 'column' as const,
@@ -3373,18 +3392,18 @@ function TemplateFullPreview({
               display: 'flex',
               alignItems: 'center',
               gap: 8,
-              marginBottom: showChat ? 32 : 0,
+              marginBottom: showChat ? 32 : 8,
               paddingBottom: 0,
               borderBottom: showChat
                 ? '1px solid var(--color-divider, #e0e0e0)'
                 : 'none',
             }}>
             <XDSButton
-              label="Back"
+              label="Craft"
               variant="ghost"
               size="sm"
               icon={<ArrowLeftIcon />}
-              isIconOnly
+              isIconOnly={!!showChat}
               onClick={onBack}
               style={{marginLeft: -8, flexShrink: 0}}
             />
@@ -3515,9 +3534,9 @@ function TemplateFullPreview({
                   size={36}
                   src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
                 />
-                <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
+                <div style={{display: 'flex', flexDirection: 'column', gap: 0}}>
                   <XDSText type="supporting" color="secondary">
-                    Designed by
+                    Crafted by
                   </XDSText>
                   <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
                     Andrea Anderson
@@ -4466,9 +4485,9 @@ function TemplateCombinedView({
                   size={36}
                   src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
                 />
-                <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
+                <div style={{display: 'flex', flexDirection: 'column', gap: 0}}>
                   <XDSText type="supporting" color="secondary">
-                    Designed by
+                    Crafted by
                   </XDSText>
                   <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
                     Andrea Anderson
@@ -4682,9 +4701,8 @@ export default function DocsiteLandingTemplate() {
         }}>
         <div
           style={{
-            width: 280,
-            minWidth: 280,
-            borderRight: '1px solid var(--color-divider)',
+            width: 380,
+            minWidth: 380,
           }}>
           <ChatPanel
             isGenerating={previewGenerating}

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -3306,6 +3306,7 @@ function TemplateFullPreview({
   onUse,
   onSelectTemplate,
   showChat = false,
+  showEditor = false,
 }: {
   templateName: string;
   imageSrc: string;
@@ -3313,6 +3314,7 @@ function TemplateFullPreview({
   onUse: () => void;
   onSelectTemplate?: (index: number) => void;
   showChat?: boolean;
+  showEditor?: boolean;
 }) {
   const [viewMode, setViewMode] = useState<'desktop' | 'mobile'>('desktop');
   const [editorView, setEditorView] = useState<'preview' | 'code'>('preview');
@@ -3712,10 +3714,113 @@ function TemplateFullPreview({
         }}>
         {/* Editor toolbar */}
         <div style={{backgroundColor: 'var(--color-background-body, #f5f5f5)'}}>
-          <XDSToolbar
-            label="Template actions"
-            startContent={<></>}
-            centerContent={
+          {showEditor ? (
+            <XDSToolbar
+              label="Template actions"
+              startContent={<></>}
+              centerContent={
+                <XDSSegmentedControl
+                  value={viewMode}
+                  onChange={(v: string) =>
+                    setViewMode(v as 'desktop' | 'mobile')
+                  }
+                  label="Viewport size"
+                  size="sm">
+                  <XDSSegmentedControlItem
+                    value="desktop"
+                    label="Desktop"
+                    isLabelHidden
+                    icon={<DesktopIcon />}
+                  />
+                  <XDSSegmentedControlItem
+                    value="mobile"
+                    label="Mobile"
+                    isLabelHidden
+                    icon={<PhoneIcon />}
+                  />
+                </XDSSegmentedControl>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Point"
+                    variant="ghost"
+                    isIconOnly
+                    icon={<CursorIcon />}
+                  />
+                  <XDSDropdownMenu
+                    button={{
+                      label: 'Theme',
+                      variant: 'ghost',
+                      isIconOnly: true,
+                      icon: <PaletteIcon />,
+                    }}
+                    hasChevron={false}
+                    items={XDS_THEMES.map(t => ({
+                      label: t.label,
+                      onClick: () => {},
+                    }))}
+                  />
+                  <XDSButton
+                    label="Toggle theme"
+                    variant="ghost"
+                    isIconOnly
+                    icon={<ContrastIcon />}
+                  />
+                  <XDSButton
+                    label="Toggle code"
+                    variant={editorView === 'code' ? 'secondary' : 'ghost'}
+                    isIconOnly
+                    icon={<CodeIcon />}
+                    onClick={() =>
+                      setEditorView(
+                        editorView === 'preview' ? 'code' : 'preview',
+                      )
+                    }
+                  />
+                  <XDSButton
+                    label="Save"
+                    variant="ghost"
+                    icon={<SaveIcon />}
+                    isIconOnly
+                    onClick={() => {}}
+                  />
+                  <XDSDropdownMenu
+                    button={{
+                      label: 'Share',
+                      variant: 'ghost',
+                      isIconOnly: true,
+                      icon: <PaperPlaneIcon />,
+                    }}
+                    hasChevron={false}
+                    menuWidth={220}
+                    items={[
+                      {
+                        label: 'Copy CLI Command...',
+                        icon: TerminalIcon,
+                        onClick: () => {},
+                      },
+                      {type: 'divider' as const},
+                      {
+                        label: 'Claude Code',
+                        icon: ClaudeIcon,
+                        onClick: () => {},
+                      },
+                      {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                      {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
+                    ]}
+                  />
+                </>
+              }
+            />
+          ) : (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                padding: '12px 24px',
+              }}>
               <XDSSegmentedControl
                 value={viewMode}
                 onChange={(v: string) => setViewMode(v as 'desktop' | 'mobile')}
@@ -3734,74 +3839,8 @@ function TemplateFullPreview({
                   icon={<PhoneIcon />}
                 />
               </XDSSegmentedControl>
-            }
-            endContent={
-              <>
-                <XDSButton
-                  label="Point"
-                  variant="ghost"
-                  isIconOnly
-                  icon={<CursorIcon />}
-                />
-                <XDSDropdownMenu
-                  button={{
-                    label: 'Theme',
-                    variant: 'ghost',
-                    isIconOnly: true,
-                    icon: <PaletteIcon />,
-                  }}
-                  hasChevron={false}
-                  items={XDS_THEMES.map(t => ({
-                    label: t.label,
-                    onClick: () => {},
-                  }))}
-                />
-                <XDSButton
-                  label="Toggle theme"
-                  variant="ghost"
-                  isIconOnly
-                  icon={<ContrastIcon />}
-                />
-                <XDSButton
-                  label="Toggle code"
-                  variant={editorView === 'code' ? 'secondary' : 'ghost'}
-                  isIconOnly
-                  icon={<CodeIcon />}
-                  onClick={() =>
-                    setEditorView(editorView === 'preview' ? 'code' : 'preview')
-                  }
-                />
-                <XDSButton
-                  label="Save"
-                  variant="ghost"
-                  icon={<SaveIcon />}
-                  isIconOnly
-                  onClick={() => {}}
-                />
-                <XDSDropdownMenu
-                  button={{
-                    label: 'Share',
-                    variant: 'ghost',
-                    isIconOnly: true,
-                    icon: <PaperPlaneIcon />,
-                  }}
-                  hasChevron={false}
-                  menuWidth={220}
-                  items={[
-                    {
-                      label: 'Copy CLI Command...',
-                      icon: TerminalIcon,
-                      onClick: () => {},
-                    },
-                    {type: 'divider' as const},
-                    {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
-                    {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
-                    {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
-                  ]}
-                />
-              </>
-            }
-          />
+            </div>
+          )}
         </div>
 
         {/* Preview — browser frame + image */}
@@ -3809,7 +3848,7 @@ function TemplateFullPreview({
           style={{
             backgroundColor: 'var(--color-background-body, #f5f5f5)',
             padding: '22px 22px 22px',
-            display: editorView === 'preview' ? 'flex' : 'none',
+            display: !showEditor || editorView === 'preview' ? 'flex' : 'none',
             justifyContent: 'center',
             alignItems: 'flex-start',
             flex: 1,
@@ -3889,7 +3928,7 @@ function TemplateFullPreview({
             backgroundColor: 'var(--color-background-muted, rgba(0,0,0,0.03))',
             overflow: 'auto',
             flex: 1,
-            display: editorView === 'code' ? 'block' : 'none',
+            display: showEditor && editorView === 'code' ? 'block' : 'none',
           }}>
           <div
             style={{
@@ -3942,7 +3981,7 @@ function TemplateFullPreview({
         </div>
 
         {/* Similar templates — only visible in preview mode */}
-        {editorView === 'preview' && (
+        {(!showEditor || editorView === 'preview') && (
           <div
             style={{
               width: '100%',
@@ -4617,6 +4656,7 @@ export default function DocsiteLandingTemplate() {
           setPreviewTarget(index);
         }}
         showChat
+        showEditor
       />
     );
   }

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1666,6 +1666,372 @@ function TemplatePreview({
   );
 }
 
+function ClassicTemplatePreview({
+  templateName,
+  imageSrc,
+  onBack,
+  isGenerating,
+  simulation,
+}: {
+  templateName: string;
+  imageSrc: string;
+  onBack: () => void;
+  isGenerating: boolean;
+  simulation: BoidsSimulation;
+}) {
+  const [viewportSize, setViewportSize] = useState('desktop');
+  const previewRef = useRef<HTMLDivElement>(null);
+  const [previewSize, setPreviewSize] = useState({w: 0, h: 0});
+  const [showCanvas, setShowCanvas] = useState(false);
+
+  useEffect(() => {
+    if (isGenerating && previewRef.current) {
+      const rect = previewRef.current.getBoundingClientRect();
+      setPreviewSize({w: rect.width, h: rect.height});
+      setShowCanvas(true);
+    }
+  }, [isGenerating]);
+
+  useEffect(() => {
+    if (!isGenerating && showCanvas) {
+      const id = setTimeout(() => setShowCanvas(false), 800);
+      return () => clearTimeout(id);
+    }
+  }, [isGenerating, showCanvas]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column' as const,
+        height: '100%',
+        overflow: 'hidden',
+        paddingTop: 16,
+      }}>
+      <div
+        style={{
+          flex: 1,
+          overflow: 'auto',
+          padding: '0 16px 16px 0',
+        }}>
+        {/* Bordered container: toolbar + preview + code */}
+        <div
+          style={{
+            border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+            borderRadius: 12,
+            paddingBottom: 8,
+            display: 'flex',
+            flexDirection: 'column' as const,
+          }}>
+          {/* Toolbar */}
+          <XDSToolbar
+            label="Template actions"
+            startContent={
+              <>
+                <XDSButton
+                  label="Back"
+                  variant="ghost"
+                  size="sm"
+                  icon={<ArrowLeftIcon />}
+                  onClick={onBack}
+                  style={{marginLeft: -8}}
+                />
+                <XDSText type="body">{templateName}</XDSText>
+              </>
+            }
+            centerContent={
+              <XDSSegmentedControl
+                value={viewportSize}
+                onChange={setViewportSize}
+                label="Viewport size"
+                size="sm">
+                <XDSSegmentedControlItem
+                  value="desktop"
+                  label="Desktop"
+                  isLabelHidden
+                  icon={<DesktopIcon />}
+                />
+                <XDSSegmentedControlItem
+                  value="phone"
+                  label="Phone"
+                  isLabelHidden
+                  icon={<PhoneIcon />}
+                />
+              </XDSSegmentedControl>
+            }
+            endContent={
+              <>
+                <XDSButton
+                  label="Point"
+                  variant="ghost"
+                  icon={<CursorIcon />}
+                />
+                <XDSDropdownMenu
+                  button={{
+                    label: 'Theme',
+                    variant: 'ghost',
+                    icon: <PaletteIcon />,
+                  }}
+                  hasChevron={false}
+                  items={XDS_THEMES.map(t => ({
+                    label: t.label,
+                    onClick: () => {},
+                  }))}
+                />
+                <XDSButton
+                  label="Toggle theme"
+                  variant="ghost"
+                  icon={<ContrastIcon />}
+                />
+                <XDSDropdownMenu
+                  button={{label: 'Share', variant: 'ghost'}}
+                  hasChevron={false}
+                  menuWidth={220}
+                  items={[
+                    {
+                      label: 'Copy CLI Command...',
+                      icon: TerminalIcon,
+                      onClick: () => {},
+                    },
+                    {type: 'divider' as const},
+                    {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
+                    {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                    {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
+                  ]}
+                />
+              </>
+            }
+          />
+
+          {/* Preview image in muted container with grid dots */}
+          <div
+            style={{
+              backgroundColor:
+                'var(--color-background-muted, rgba(0,0,0,0.03))',
+              backgroundImage:
+                'radial-gradient(circle, var(--color-divider, rgba(0,0,0,0.1)) 1px, transparent 1px)',
+              backgroundSize: '16px 16px',
+              borderRadius: 8,
+              padding: 22,
+              margin: '0 8px',
+              display: 'flex',
+              justifyContent: 'center',
+            }}>
+            <div
+              ref={previewRef}
+              style={{
+                position: 'relative',
+                width:
+                  VIEWPORT_WIDTHS[viewportSize] === '100%'
+                    ? '100%'
+                    : VIEWPORT_WIDTHS[viewportSize],
+                maxWidth: '100%',
+                border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                borderRadius: 8,
+                overflow: 'hidden',
+                transition:
+                  'width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
+              }}>
+              <img
+                src={imageSrc}
+                alt="Template preview"
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  aspectRatio: '1920 / 1200',
+                  objectFit: 'cover',
+                  opacity: isGenerating ? 0 : 1,
+                  transition: 'opacity 600ms ease',
+                }}
+              />
+              {showCanvas && (
+                <div
+                  style={{
+                    position: 'absolute',
+                    inset: 0,
+                    opacity: isGenerating ? 1 : 0,
+                    transition: 'opacity 600ms ease',
+                  }}>
+                  <BoidsCanvas
+                    width={previewSize.w}
+                    height={previewSize.h}
+                    simulation={simulation}
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Code block */}
+          <div
+            style={{
+              margin: '8px 8px 0',
+              border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+              borderRadius: 8,
+              backgroundColor:
+                'var(--color-background-muted, rgba(0,0,0,0.03))',
+              overflow: 'hidden',
+            }}>
+            {/* Header */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '8px 12px 8px 16px',
+              }}>
+              <span
+                style={{
+                  fontFamily: '"Roboto Mono", monospace',
+                  fontSize: 12,
+                  fontWeight: 500,
+                  color: 'var(--color-text-secondary, #4e606f)',
+                }}>
+                typescript — useUser.ts
+              </span>
+            </div>
+            {/* Code */}
+            <div style={{display: 'flex'}}>
+              {/* Line numbers */}
+              <div
+                style={{
+                  padding: '12px 12px 12px 16px',
+                  borderRight:
+                    '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                  fontFamily: '"Roboto Mono", monospace',
+                  fontSize: 14,
+                  lineHeight: '20px',
+                  color: 'var(--color-text-disabled, #a4b0bc)',
+                  textAlign: 'right',
+                  userSelect: 'none',
+                  minWidth: 45,
+                }}>
+                {MOCK_CODE.split('\n').map((_, i) => (
+                  <div key={i}>{i + 1}</div>
+                ))}
+              </div>
+              {/* Code content */}
+              <pre
+                style={{
+                  flex: 1,
+                  padding: '12px 16px',
+                  fontFamily: '"Roboto Mono", monospace',
+                  fontSize: 14,
+                  lineHeight: '20px',
+                  margin: 0,
+                  overflow: 'auto',
+                  color: 'var(--color-text-primary, #0a1317)',
+                }}>
+                {MOCK_CODE}
+              </pre>
+            </div>
+          </div>
+        </div>
+
+        {/* Title & metadata */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column' as const,
+            gap: 16,
+            marginTop: 16,
+          }}>
+          <div style={{maxWidth: 540}}>
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column' as const,
+                gap: 4,
+              }}>
+              <XDSHeading level={1}>{templateName}</XDSHeading>
+              <XDSText type="supporting" color="secondary">
+                XDS · 541 usages
+              </XDSText>
+            </div>
+            <XDSText type="body" style={{marginTop: 16}}>
+              Buttons are clickable elements that are used to trigger actions.
+              They communicate calls to action to the user and allow users to
+              interact with pages in a variety of ways. Button labels express
+              what action will occur when the user interacts with it.
+            </XDSText>
+          </div>
+        </div>
+
+        {/* Similar templates */}
+        <div
+          style={{
+            marginTop: 16,
+            display: 'flex',
+            flexDirection: 'column' as const,
+            gap: 16,
+          }}>
+          <XDSHeading level={2}>Similar templates</XDSHeading>
+          <div style={{display: 'flex', gap: 16}}>
+            {TEMPLATE_IMAGES.slice(0, 3).map((src, i) => (
+              <div
+                key={i}
+                style={{
+                  flex: 1,
+                  aspectRatio: '1920 / 1200',
+                  border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                  backgroundColor: '#fff',
+                  borderRadius: 12,
+                  boxShadow: '0 8px 40px rgba(0,0,0,0.12)',
+                  overflow: 'hidden',
+                }}>
+                <img
+                  src={src}
+                  alt={`Similar template ${i + 1}`}
+                  style={{
+                    display: 'block',
+                    width: '100%',
+                    height: '100%',
+                    objectFit: 'cover',
+                  }}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Component used */}
+        <div
+          style={{
+            marginTop: 16,
+            display: 'flex',
+            flexDirection: 'column' as const,
+            gap: 16,
+          }}>
+          <XDSHeading level={2}>Component used</XDSHeading>
+          <XDSText type="body">
+            XDSAppShell, XDSTopNav, XDSVStack, XDSHStack, XDSHeading, XDSText,
+            XDSButton, XDSCard, XDSBadge, XDSAvatar
+          </XDSText>
+        </div>
+
+        {/* Keywords */}
+        <div
+          style={{
+            marginTop: 16,
+            display: 'flex',
+            flexDirection: 'column' as const,
+            gap: 16,
+            paddingBottom: 24,
+          }}>
+          <XDSHeading level={2}>Keywords</XDSHeading>
+          <div style={{display: 'flex', flexWrap: 'wrap' as const, gap: 4}}>
+            <XDSToken label="Dashboard" size="sm" />
+            <XDSToken label="Admin" size="sm" />
+            <XDSToken label="Layout" size="sm" />
+            <XDSToken label="Navigation" size="sm" />
+            <XDSToken label="Settings" size="sm" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Top Nav
 // ---------------------------------------------------------------------------
@@ -4713,7 +5079,7 @@ export default function DocsiteLandingTemplate() {
         </div>
         <div
           style={{flex: 1, display: 'flex', flexDirection: 'column' as const}}>
-          <TemplatePreview
+          <ClassicTemplatePreview
             templateName={t.name}
             imageSrc={t.src}
             onBack={() => {

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -4665,14 +4665,45 @@ export default function DocsiteLandingTemplate() {
   if (useTarget !== null && useTarget !== 1 && activeView === 'craft') {
     const t = TEMPLATES[useTarget % TEMPLATES.length];
     return (
-      <div style={{display: 'flex', height: '100vh', overflow: 'hidden'}}>
-        <div style={{width: 380, minWidth: 380}}>
-          <ChatPanel
-            isGenerating={previewGenerating}
-            onSend={handlePreviewSend}
-            activeView={activeView}
-            setActiveView={setActiveView}
-          />
+      <div
+        style={{
+          display: 'flex',
+          height: '100vh',
+          overflow: 'hidden',
+          backgroundColor: 'var(--color-background-body, #f5f5f5)',
+        }}>
+        <div
+          style={{
+            width: 380,
+            minWidth: 380,
+            padding: 16,
+            display: 'flex',
+            animation: 'slideInLeft 500ms cubic-bezier(0.16, 1, 0.3, 1)',
+          }}>
+          <style>
+            {
+              '@keyframes slideInLeft { from { opacity: 0; transform: translateX(-40px); } to { opacity: 1; transform: translateX(0); } }'
+            }
+          </style>
+          <div
+            style={{
+              flex: 1,
+              backgroundColor: 'var(--color-background-card, #fff)',
+              borderRadius: 16,
+              boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
+              overflow: 'hidden',
+              display: 'flex',
+              flexDirection: 'column' as const,
+            }}>
+            <ChatPanel
+              isGenerating={previewGenerating}
+              onSend={handlePreviewSend}
+              activeView={activeView}
+              setActiveView={setActiveView}
+              templateName={t.name}
+              onBack={handleBackFromUse}
+            />
+          </div>
         </div>
         <div
           style={{flex: 1, display: 'flex', flexDirection: 'column' as const}}>

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -4990,6 +4990,13 @@ export default function DocsiteLandingTemplate() {
   const [previewTarget, setPreviewTarget] = useState<number | null>(null);
   const [useTarget, setUseTarget] = useState<number | null>(null);
   const [previewGenerating, setPreviewGenerating] = useState(false);
+
+  // Reset preview/editor state when switching views
+  useEffect(() => {
+    setPreviewTarget(null);
+    setUseTarget(null);
+    setChatOpen(false);
+  }, [activeView]);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const simRef = useRef<BoidsSimulation | null>(null);

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -919,11 +919,15 @@ function ChatPanel({
   onSend,
   activeView,
   setActiveView,
+  templateName,
+  onBack,
 }: {
   isGenerating: boolean;
   onSend?: () => void;
   activeView: 'craft' | 'library' | 'learn' | 'profile';
   setActiveView: (view: 'craft' | 'library' | 'learn' | 'profile') => void;
+  templateName?: string;
+  onBack?: () => void;
 }) {
   const [prompt, setPrompt] = useState('');
 
@@ -935,24 +939,32 @@ function ChatPanel({
         height: '100%',
         width: '100%',
       }}>
-      {/* Header: hamburger + XDS | Craft */}
-      <div
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'space-between',
-          padding: '12px 16px',
-          flexShrink: 0,
-        }}>
-        <LogoNav activeView={activeView} setActiveView={setActiveView} />
-        <XDSButton
-          label="Toggle sidebar"
-          variant="ghost"
-          size="sm"
-          isIconOnly
-          icon={<SidebarIcon />}
-        />
-      </div>
+      {/* Header with back + title */}
+      {templateName && (
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            padding: '16px 16px 0',
+            flexShrink: 0,
+          }}>
+          {onBack && (
+            <XDSButton
+              label="Back"
+              variant="ghost"
+              size="sm"
+              icon={<ArrowLeftIcon />}
+              isIconOnly
+              onClick={onBack}
+              style={{marginLeft: -8, flexShrink: 0}}
+            />
+          )}
+          <XDSHeading level={1} style={{lineHeight: 1}}>
+            {templateName}
+          </XDSHeading>
+        </div>
+      )}
 
       {/* Chat thread */}
       <div style={{flex: 1, padding: 16, overflow: 'auto'}}>
@@ -988,13 +1000,18 @@ function ChatPanel({
       </div>
 
       {/* Composer pinned to bottom */}
-      <div style={{padding: 12}}>
+      <div
+        style={{
+          padding: 0,
+          borderTop: '1px solid var(--color-divider, #e0e0e0)',
+        }}>
         <div
           style={{
-            borderRadius: 20,
+            borderRadius: 0,
             backgroundColor: 'var(--color-background-card, white)',
-            border: '1px solid var(--color-divider)',
-            boxShadow: 'var(--shadow-high)',
+            border: 'none',
+            borderTop: '1px solid var(--color-divider)',
+            boxShadow: 'none',
             padding: 8,
             display: 'flex',
             flexDirection: 'column' as const,
@@ -1358,108 +1375,105 @@ function TemplatePreview({
             overflow: 'hidden',
           }}>
           {/* Toolbar */}
-          <XDSToolbar
-            label="Template actions"
-            startContent={
-              <>
-                <XDSButton
-                  label="Back"
-                  variant="ghost"
-                  size="sm"
-                  isIconOnly
-                  icon={<ArrowLeftIcon />}
-                  onClick={onBack}
-                />
-                <XDSHeading level={3}>{templateName}</XDSHeading>
-              </>
-            }
-            centerContent={
-              <XDSSegmentedControl
-                value={viewportSize}
-                onChange={setViewportSize}
-                label="Viewport size"
-                size="sm">
-                <XDSSegmentedControlItem
-                  value="desktop"
-                  label="Desktop"
-                  isLabelHidden
-                  icon={<DesktopIcon />}
-                />
-                <XDSSegmentedControlItem
-                  value="phone"
-                  label="Phone"
-                  isLabelHidden
-                  icon={<PhoneIcon />}
-                />
-              </XDSSegmentedControl>
-            }
-            endContent={
-              <>
-                <XDSButton
-                  label="Point"
-                  variant="ghost"
-                  isIconOnly
-                  icon={<CursorIcon />}
-                />
-                <XDSDropdownMenu
-                  button={{
-                    label: 'Theme',
-                    variant: 'ghost',
-                    isIconOnly: true,
-                    icon: <PaletteIcon />,
-                  }}
-                  hasChevron={false}
-                  items={XDS_THEMES.map(t => ({
-                    label: t.label,
-                    onClick: () => {},
-                  }))}
-                />
-                <XDSButton
-                  label="Toggle theme"
-                  variant="ghost"
-                  isIconOnly
-                  icon={<ContrastIcon />}
-                />
-                <XDSButton
-                  label="Toggle code"
-                  variant={editorView === 'code' ? 'secondary' : 'ghost'}
-                  isIconOnly
-                  icon={<CodeIcon />}
-                  onClick={() =>
-                    setEditorView(editorView === 'preview' ? 'code' : 'preview')
-                  }
-                />
-                <XDSButton
-                  label="Save"
-                  variant="ghost"
-                  icon={<SaveIcon />}
-                  isIconOnly
-                  onClick={() => {}}
-                />
-                <XDSDropdownMenu
-                  button={{
-                    label: 'Share',
-                    variant: 'ghost',
-                    isIconOnly: true,
-                    icon: <PaperPlaneIcon />,
-                  }}
-                  hasChevron={false}
-                  menuWidth={220}
-                  items={[
-                    {
-                      label: 'Copy CLI Command...',
-                      icon: TerminalIcon,
+          <div
+            style={{backgroundColor: 'var(--color-background-body, #f5f5f5)'}}>
+            <XDSToolbar
+              label="Template actions"
+              startContent={<></>}
+              centerContent={
+                <XDSSegmentedControl
+                  value={viewportSize}
+                  onChange={setViewportSize}
+                  label="Viewport size"
+                  size="sm">
+                  <XDSSegmentedControlItem
+                    value="desktop"
+                    label="Desktop"
+                    isLabelHidden
+                    icon={<DesktopIcon />}
+                  />
+                  <XDSSegmentedControlItem
+                    value="phone"
+                    label="Phone"
+                    isLabelHidden
+                    icon={<PhoneIcon />}
+                  />
+                </XDSSegmentedControl>
+              }
+              endContent={
+                <>
+                  <XDSButton
+                    label="Point"
+                    variant="ghost"
+                    isIconOnly
+                    icon={<CursorIcon />}
+                  />
+                  <XDSDropdownMenu
+                    button={{
+                      label: 'Theme',
+                      variant: 'ghost',
+                      isIconOnly: true,
+                      icon: <PaletteIcon />,
+                    }}
+                    hasChevron={false}
+                    items={XDS_THEMES.map(t => ({
+                      label: t.label,
                       onClick: () => {},
-                    },
-                    {type: 'divider' as const},
-                    {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
-                    {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
-                    {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
-                  ]}
-                />
-              </>
-            }
-          />
+                    }))}
+                  />
+                  <XDSButton
+                    label="Toggle theme"
+                    variant="ghost"
+                    isIconOnly
+                    icon={<ContrastIcon />}
+                  />
+                  <XDSButton
+                    label="Toggle code"
+                    variant={editorView === 'code' ? 'secondary' : 'ghost'}
+                    isIconOnly
+                    icon={<CodeIcon />}
+                    onClick={() =>
+                      setEditorView(
+                        editorView === 'preview' ? 'code' : 'preview',
+                      )
+                    }
+                  />
+                  <XDSButton
+                    label="Save"
+                    variant="ghost"
+                    icon={<SaveIcon />}
+                    isIconOnly
+                    onClick={() => {}}
+                  />
+                  <XDSDropdownMenu
+                    button={{
+                      label: 'Share',
+                      variant: 'ghost',
+                      isIconOnly: true,
+                      icon: <PaperPlaneIcon />,
+                    }}
+                    hasChevron={false}
+                    menuWidth={220}
+                    items={[
+                      {
+                        label: 'Copy CLI Command...',
+                        icon: TerminalIcon,
+                        onClick: () => {},
+                      },
+                      {type: 'divider' as const},
+                      {
+                        label: 'Claude Code',
+                        icon: ClaudeIcon,
+                        onClick: () => {},
+                      },
+                      {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                      {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
+                    ]}
+                  />
+                </>
+              }
+            />
+          </div>
 
           {/* Preview — browser frame + image */}
           <div
@@ -1564,9 +1578,9 @@ function TemplatePreview({
           {/* Code block */}
           <div
             style={{
-              margin: '0 8px',
-              border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-              borderRadius: 8,
+              margin: 0,
+              border: 'none',
+              borderRadius: 0,
               backgroundColor:
                 'var(--color-background-muted, rgba(0,0,0,0.03))',
               overflow: 'auto',
@@ -3290,13 +3304,16 @@ function TemplateFullPreview({
   imageSrc,
   onBack,
   onUse,
+  onSelectTemplate,
 }: {
   templateName: string;
   imageSrc: string;
   onBack: () => void;
   onUse: () => void;
+  onSelectTemplate?: (index: number) => void;
 }) {
   const [viewMode, setViewMode] = useState<'desktop' | 'mobile'>('desktop');
+  const [editorView, setEditorView] = useState<'preview' | 'code'>('preview');
   const [isVisible, setIsVisible] = useState(false);
   const [selectedPalette, setSelectedPalette] = useState<string | null>(
     PREVIEW_COLOR_PALETTES[0].name,
@@ -3312,8 +3329,279 @@ function TemplateFullPreview({
   }, []);
 
   return (
-    <div style={{display: 'flex', height: '100vh', overflow: 'hidden'}}>
-      {/* LEFT PANEL — preview area */}
+    <div
+      style={{
+        display: 'flex',
+        height: '100vh',
+        overflow: 'hidden',
+        backgroundColor: 'var(--color-background-body, #f5f5f5)',
+      }}>
+      {/* LEFT PANEL — details sidebar */}
+      <div
+        style={{
+          width: '30%',
+          maxWidth: 380,
+          minWidth: 300,
+          padding: '16px 0 16px 16px',
+          display: 'flex',
+          backgroundColor: 'transparent',
+          opacity: isVisible ? 1 : 0,
+          transform: isVisible ? 'translateX(0)' : 'translateX(-60px)',
+          transition:
+            'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms, transform 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms',
+        }}>
+        <div
+          style={{
+            flex: 1,
+            backgroundColor: 'var(--color-background-card, #fff)',
+            borderRadius: 16,
+            boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
+            padding: 32,
+            overflowY: 'auto' as const,
+            display: 'flex',
+            flexDirection: 'column' as const,
+          }}>
+          {/* Back button */}
+          <XDSButton
+            label="Craft"
+            variant="ghost"
+            size="sm"
+            icon={<ArrowLeftIcon />}
+            onClick={onBack}
+            style={{alignSelf: 'flex-start', marginLeft: -8, marginBottom: 8}}
+          />
+          {/* Template name */}
+          <XDSText type="display-2">{templateName}</XDSText>
+
+          {/* Description */}
+          <div style={{marginTop: 8}}>
+            <XDSText type="body" color="secondary">
+              Buttons are clickable elements that are used to trigger actions.
+              They communicate calls to action to the user and allow users to
+              interact with pages in a variety of ways. Button labels express
+              what action will occur when the user interacts with it.
+            </XDSText>
+          </div>
+
+          {/* Stats buttons */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              marginTop: 16,
+              marginLeft: -8,
+              marginRight: -8,
+            }}>
+            <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+              <XDSButton
+                label="Link"
+                variant="ghost"
+                size="sm"
+                isIconOnly
+                icon={<LinkIcon />}
+              />
+              <XDSDropdownMenu
+                button={{
+                  label: 'Share',
+                  variant: 'ghost',
+                  size: 'sm',
+                  isIconOnly: true,
+                  icon: <PaperPlaneIcon />,
+                }}
+                hasChevron={false}
+                menuWidth={220}
+                items={[
+                  {
+                    label: 'Copy CLI Command...',
+                    icon: TerminalIcon,
+                    onClick: () => {},
+                  },
+                  {type: 'divider' as const},
+                  {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
+                  {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                  {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
+                ]}
+              />
+            </div>
+            <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+              <XDSButton
+                label="1,645"
+                variant="ghost"
+                size="sm"
+                icon={<HeartIcon />}
+              />
+              <XDSButton
+                label="892"
+                variant="ghost"
+                size="sm"
+                icon={<BookmarkIcon />}
+              />
+            </div>
+          </div>
+
+          {/* CTA button */}
+          <div style={{marginTop: 16}}>
+            <XDSButton
+              variant="primary"
+              label="Start crafting"
+              onClick={onUse}
+              size="lg"
+              style={{width: '100%'}}
+            />
+          </div>
+
+          {/* Color palettes */}
+          <div style={{marginTop: 32}}>
+            <XDSHeading level={4}>Color palettes</XDSHeading>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: 10,
+                marginTop: 8,
+              }}>
+              {PREVIEW_COLOR_PALETTES.map(palette => (
+                <div
+                  key={palette.name}
+                  onClick={() => setSelectedPalette(palette.name)}
+                  style={{
+                    cursor: 'pointer',
+                    border: `2px solid ${selectedPalette === palette.name ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                    borderRadius: 14,
+                    overflow: 'hidden',
+                    transition: 'border-color 0.15s ease',
+                  }}>
+                  <XDSCard padding={0}>
+                    <div
+                      style={{
+                        display: 'flex',
+                        overflow: 'hidden',
+                        height: 48,
+                      }}>
+                      {palette.colors.map((color, i) => (
+                        <div
+                          key={i}
+                          style={{
+                            flex: 1,
+                            backgroundColor: color,
+                          }}
+                        />
+                      ))}
+                    </div>
+                  </XDSCard>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Font packs */}
+          <div style={{marginTop: 32}}>
+            <XDSHeading level={4}>Font packs</XDSHeading>
+            <div
+              style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: 10,
+                marginTop: 8,
+              }}>
+              {PREVIEW_FONT_PACKS.map(pack => (
+                <div
+                  key={pack.heading}
+                  onClick={() => setSelectedFontPack(pack.heading)}
+                  style={{
+                    cursor: 'pointer',
+                    border: `2px solid ${selectedFontPack === pack.heading ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                    borderRadius: 14,
+                    overflow: 'hidden',
+                    transition: 'border-color 0.15s ease',
+                  }}>
+                  <XDSCard padding={2}>
+                    <div style={{fontFamily: pack.heading}}>
+                      <XDSText
+                        type="body"
+                        style={{fontWeight: 600, fontSize: 16}}>
+                        Heading
+                      </XDSText>
+                    </div>
+                    <div style={{fontFamily: pack.paragraph}}>
+                      <XDSText type="supporting" color="secondary">
+                        Paragraph text
+                      </XDSText>
+                    </div>
+                  </XDSCard>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Component used */}
+          <div style={{marginTop: 32}}>
+            <XDSHeading level={3}>Component used</XDSHeading>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap' as const,
+                gap: 8,
+                marginTop: 8,
+              }}>
+              <XDSToken label="XDSAppShell" />
+              <XDSToken label="XDSTopNav" />
+              <XDSToken label="XDSVStack" />
+              <XDSToken label="XDSHStack" />
+              <XDSToken label="XDSHeading" />
+              <XDSToken label="XDSText" />
+              <XDSToken label="XDSButton" />
+              <XDSToken label="XDSCard" />
+              <XDSToken label="XDSBadge" />
+              <XDSToken label="XDSAvatar" />
+            </div>
+          </div>
+
+          {/* Keywords */}
+          <div style={{marginTop: 32}}>
+            <XDSHeading level={3}>Keywords</XDSHeading>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap' as const,
+                gap: 4,
+                marginTop: 8,
+              }}>
+              <XDSToken label="Dashboard" size="sm" />
+              <XDSToken label="Admin" size="sm" />
+              <XDSToken label="Layout" size="sm" />
+              <XDSToken label="Navigation" size="sm" />
+              <XDSToken label="Settings" size="sm" />
+            </div>
+          </div>
+
+          {/* Author section */}
+          <div
+            style={{
+              marginTop: 'auto',
+              display: 'flex',
+              flexDirection: 'row' as const,
+              alignItems: 'center',
+              gap: 12,
+            }}>
+            <XDSAvatar
+              size={36}
+              src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
+            />
+            <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
+              <XDSText type="supporting" color="secondary">
+                Designed by
+              </XDSText>
+              <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
+                Andrea Anderson
+              </XDSText>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* RIGHT PANEL — preview area */}
       <div
         style={{
           flex: 1,
@@ -3326,54 +3614,110 @@ function TemplateFullPreview({
           transition:
             'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1), transform 500ms cubic-bezier(0.16, 1, 0.3, 1)',
         }}>
-        {/* Top bar */}
-        <div
-          style={{
-            display: 'grid',
-            gridTemplateColumns: '1fr auto 1fr',
-            alignItems: 'center',
-            padding: '12px 24px',
-          }}>
-          <div style={{justifySelf: 'start'}}>
-            <XDSButton
-              label="Templates"
-              variant="ghost"
-              size="sm"
-              icon={<ArrowLeftIcon />}
-              onClick={onBack}
-            />
-          </div>
-          <XDSSegmentedControl
-            value={viewMode}
-            onChange={(v: string) => setViewMode(v as 'desktop' | 'mobile')}
-            label="Viewport size"
-            size="sm">
-            <XDSSegmentedControlItem
-              value="desktop"
-              label="Desktop"
-              isLabelHidden
-              icon={<DesktopIcon />}
-            />
-            <XDSSegmentedControlItem
-              value="mobile"
-              label="Mobile"
-              isLabelHidden
-              icon={<PhoneIcon />}
-            />
-          </XDSSegmentedControl>
-          <div />
+        {/* Editor toolbar */}
+        <div style={{backgroundColor: 'var(--color-background-body, #f5f5f5)'}}>
+          <XDSToolbar
+            label="Template actions"
+            startContent={<></>}
+            centerContent={
+              <XDSSegmentedControl
+                value={viewMode}
+                onChange={(v: string) => setViewMode(v as 'desktop' | 'mobile')}
+                label="Viewport size"
+                size="sm">
+                <XDSSegmentedControlItem
+                  value="desktop"
+                  label="Desktop"
+                  isLabelHidden
+                  icon={<DesktopIcon />}
+                />
+                <XDSSegmentedControlItem
+                  value="mobile"
+                  label="Mobile"
+                  isLabelHidden
+                  icon={<PhoneIcon />}
+                />
+              </XDSSegmentedControl>
+            }
+            endContent={
+              <>
+                <XDSButton
+                  label="Point"
+                  variant="ghost"
+                  isIconOnly
+                  icon={<CursorIcon />}
+                />
+                <XDSDropdownMenu
+                  button={{
+                    label: 'Theme',
+                    variant: 'ghost',
+                    isIconOnly: true,
+                    icon: <PaletteIcon />,
+                  }}
+                  hasChevron={false}
+                  items={XDS_THEMES.map(t => ({
+                    label: t.label,
+                    onClick: () => {},
+                  }))}
+                />
+                <XDSButton
+                  label="Toggle theme"
+                  variant="ghost"
+                  isIconOnly
+                  icon={<ContrastIcon />}
+                />
+                <XDSButton
+                  label="Toggle code"
+                  variant={editorView === 'code' ? 'secondary' : 'ghost'}
+                  isIconOnly
+                  icon={<CodeIcon />}
+                  onClick={() =>
+                    setEditorView(editorView === 'preview' ? 'code' : 'preview')
+                  }
+                />
+                <XDSButton
+                  label="Save"
+                  variant="ghost"
+                  icon={<SaveIcon />}
+                  isIconOnly
+                  onClick={() => {}}
+                />
+                <XDSDropdownMenu
+                  button={{
+                    label: 'Share',
+                    variant: 'ghost',
+                    isIconOnly: true,
+                    icon: <PaperPlaneIcon />,
+                  }}
+                  hasChevron={false}
+                  menuWidth={220}
+                  items={[
+                    {
+                      label: 'Copy CLI Command...',
+                      icon: TerminalIcon,
+                      onClick: () => {},
+                    },
+                    {type: 'divider' as const},
+                    {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
+                    {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                    {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
+                  ]}
+                />
+              </>
+            }
+          />
         </div>
 
-        {/* Browser frame with template image */}
+        {/* Preview — browser frame + image */}
         <div
           style={{
+            backgroundColor: 'var(--color-background-body, #f5f5f5)',
+            padding: '22px 22px 22px',
+            display: editorView === 'preview' ? 'flex' : 'none',
+            justifyContent: 'center',
+            alignItems: 'flex-start',
             flex: 1,
-            display: 'flex',
-            flexDirection: 'column' as const,
-            alignItems: 'center',
-            padding: '24px 24px 24px',
             overflow: 'auto',
-            position: 'relative',
           }}>
           <div
             style={{
@@ -3438,13 +3782,78 @@ function TemplateFullPreview({
               }}
             />
           </div>
+        </div>
 
-          {/* Similar templates */}
+        {/* Code block */}
+        <div
+          style={{
+            margin: 0,
+            border: 'none',
+            borderRadius: 0,
+            backgroundColor: 'var(--color-background-muted, rgba(0,0,0,0.03))',
+            overflow: 'auto',
+            flex: 1,
+            display: editorView === 'code' ? 'block' : 'none',
+          }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              padding: '8px 12px 8px 16px',
+            }}>
+            <span
+              style={{
+                fontFamily: '"Roboto Mono", monospace',
+                fontSize: 12,
+                fontWeight: 500,
+                color: 'var(--color-text-secondary, #4e606f)',
+              }}>
+              typescript — useUser.ts
+            </span>
+          </div>
+          <div style={{display: 'flex'}}>
+            <div
+              style={{
+                padding: '12px 12px 12px 16px',
+                borderRight: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                fontFamily: '"Roboto Mono", monospace',
+                fontSize: 14,
+                lineHeight: '20px',
+                color: 'var(--color-text-disabled, #a4b0bc)',
+                textAlign: 'right',
+                userSelect: 'none',
+                minWidth: 45,
+              }}>
+              {MOCK_CODE.split('\n').map((_, i) => (
+                <div key={i}>{i + 1}</div>
+              ))}
+            </div>
+            <pre
+              style={{
+                flex: 1,
+                padding: '12px 16px',
+                fontFamily: '"Roboto Mono", monospace',
+                fontSize: 14,
+                lineHeight: '20px',
+                margin: 0,
+                overflow: 'auto',
+                color: 'var(--color-text-primary, #0a1317)',
+              }}>
+              {MOCK_CODE}
+            </pre>
+          </div>
+        </div>
+
+        {/* Similar templates — only visible in preview mode */}
+        {editorView === 'preview' && (
           <div
             style={{
               width: '100%',
               padding: '24px 32px 32px',
               boxSizing: 'border-box' as const,
+              marginTop: 'auto',
+              textAlign: 'center' as const,
             }}>
             <XDSHeading level={3}>Similar templates</XDSHeading>
             <div
@@ -3453,10 +3862,12 @@ function TemplateFullPreview({
                 gap: 12,
                 marginTop: 12,
                 overflowX: 'auto' as const,
+                justifyContent: 'center',
               }}>
-              {[0, 1, 2, 3].map(i => (
+              {TEMPLATES.slice(0, 4).map((t, i) => (
                 <div
                   key={i}
+                  onClick={() => onSelectTemplate?.(i)}
                   style={{
                     flex: '0 0 280px',
                     aspectRatio: '1920 / 1200',
@@ -3465,10 +3876,11 @@ function TemplateFullPreview({
                     borderRadius: 8,
                     boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
                     overflow: 'hidden',
+                    cursor: 'pointer',
                   }}>
                   <img
-                    src={DUMMY_IMAGE}
-                    alt={`Similar template ${i + 1}`}
+                    src={t.src}
+                    alt={t.name}
                     style={{
                       display: 'block',
                       width: '100%',
@@ -3480,254 +3892,7 @@ function TemplateFullPreview({
               ))}
             </div>
           </div>
-        </div>
-      </div>
-
-      {/* RIGHT PANEL — details sidebar */}
-      <div
-        style={{
-          width: '30%',
-          maxWidth: 380,
-          minWidth: 300,
-          backgroundColor: 'var(--color-background-card, #fff)',
-          borderLeft: '1px solid var(--color-border-default, #e0e0e0)',
-          padding: 32,
-          overflowY: 'auto' as const,
-          display: 'flex',
-          flexDirection: 'column' as const,
-          opacity: isVisible ? 1 : 0,
-          transform: isVisible ? 'translateX(0)' : 'translateX(60px)',
-          transition:
-            'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms, transform 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms',
-        }}>
-        {/* Template name */}
-        <XDSHeading level={1}>{templateName}</XDSHeading>
-
-        {/* Description */}
-        <div style={{marginTop: 12}}>
-          <XDSText type="body" color="secondary">
-            Buttons are clickable elements that are used to trigger actions.
-            They communicate calls to action to the user and allow users to
-            interact with pages in a variety of ways. Button labels express what
-            action will occur when the user interacts with it.
-          </XDSText>
-        </div>
-
-        {/* Stats buttons */}
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'space-between',
-            marginTop: 16,
-            marginLeft: -8,
-            marginRight: -8,
-          }}>
-          <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
-            <XDSButton
-              label="Link"
-              variant="ghost"
-              size="sm"
-              isIconOnly
-              icon={<LinkIcon />}
-            />
-            <XDSDropdownMenu
-              button={{
-                label: 'Share',
-                variant: 'ghost',
-                size: 'sm',
-                isIconOnly: true,
-                icon: <PaperPlaneIcon />,
-              }}
-              hasChevron={false}
-              menuWidth={220}
-              items={[
-                {
-                  label: 'Copy CLI Command...',
-                  icon: TerminalIcon,
-                  onClick: () => {},
-                },
-                {type: 'divider' as const},
-                {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
-                {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
-                {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
-              ]}
-            />
-          </div>
-          <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
-            <XDSButton
-              label="1,645"
-              variant="ghost"
-              size="sm"
-              icon={<HeartIcon />}
-            />
-            <XDSButton
-              label="892"
-              variant="ghost"
-              size="sm"
-              icon={<BookmarkIcon />}
-            />
-          </div>
-        </div>
-
-        {/* CTA button */}
-        <div style={{marginTop: 16}}>
-          <XDSButton
-            variant="primary"
-            label="Start crafting"
-            onClick={onUse}
-            size="lg"
-            style={{width: '100%'}}
-          />
-        </div>
-
-        {/* Color palettes */}
-        <div style={{marginTop: 32}}>
-          <XDSHeading level={4}>Color palettes</XDSHeading>
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: 10,
-              marginTop: 8,
-            }}>
-            {PREVIEW_COLOR_PALETTES.map(palette => (
-              <div
-                key={palette.name}
-                onClick={() => setSelectedPalette(palette.name)}
-                style={{
-                  cursor: 'pointer',
-                  border: `2px solid ${selectedPalette === palette.name ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
-                  borderRadius: 14,
-                  overflow: 'hidden',
-                  transition: 'border-color 0.15s ease',
-                }}>
-                <XDSCard padding={0}>
-                  <div
-                    style={{
-                      display: 'flex',
-                      overflow: 'hidden',
-                      height: 48,
-                    }}>
-                    {palette.colors.map((color, i) => (
-                      <div
-                        key={i}
-                        style={{
-                          flex: 1,
-                          backgroundColor: color,
-                        }}
-                      />
-                    ))}
-                  </div>
-                </XDSCard>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Font packs */}
-        <div style={{marginTop: 32}}>
-          <XDSHeading level={4}>Font packs</XDSHeading>
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: '1fr 1fr',
-              gap: 10,
-              marginTop: 8,
-            }}>
-            {PREVIEW_FONT_PACKS.map(pack => (
-              <div
-                key={pack.heading}
-                onClick={() => setSelectedFontPack(pack.heading)}
-                style={{
-                  cursor: 'pointer',
-                  border: `2px solid ${selectedFontPack === pack.heading ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
-                  borderRadius: 14,
-                  overflow: 'hidden',
-                  transition: 'border-color 0.15s ease',
-                }}>
-                <XDSCard padding={2}>
-                  <div style={{fontFamily: pack.heading}}>
-                    <XDSText
-                      type="body"
-                      style={{fontWeight: 600, fontSize: 16}}>
-                      Heading
-                    </XDSText>
-                  </div>
-                  <div style={{fontFamily: pack.paragraph}}>
-                    <XDSText type="supporting" color="secondary">
-                      Paragraph text
-                    </XDSText>
-                  </div>
-                </XDSCard>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Component used */}
-        <div style={{marginTop: 32}}>
-          <XDSHeading level={3}>Component used</XDSHeading>
-          <div
-            style={{
-              display: 'flex',
-              flexWrap: 'wrap' as const,
-              gap: 8,
-              marginTop: 8,
-            }}>
-            <XDSToken label="XDSAppShell" />
-            <XDSToken label="XDSTopNav" />
-            <XDSToken label="XDSVStack" />
-            <XDSToken label="XDSHStack" />
-            <XDSToken label="XDSHeading" />
-            <XDSToken label="XDSText" />
-            <XDSToken label="XDSButton" />
-            <XDSToken label="XDSCard" />
-            <XDSToken label="XDSBadge" />
-            <XDSToken label="XDSAvatar" />
-          </div>
-        </div>
-
-        {/* Keywords */}
-        <div style={{marginTop: 32}}>
-          <XDSHeading level={3}>Keywords</XDSHeading>
-          <div
-            style={{
-              display: 'flex',
-              flexWrap: 'wrap' as const,
-              gap: 4,
-              marginTop: 8,
-            }}>
-            <XDSToken label="Dashboard" size="sm" />
-            <XDSToken label="Admin" size="sm" />
-            <XDSToken label="Layout" size="sm" />
-            <XDSToken label="Navigation" size="sm" />
-            <XDSToken label="Settings" size="sm" />
-          </div>
-        </div>
-
-        {/* Author section */}
-        <div
-          style={{
-            marginTop: 'auto',
-            display: 'flex',
-            flexDirection: 'row' as const,
-            alignItems: 'center',
-            gap: 12,
-          }}>
-          <XDSAvatar
-            size={36}
-            src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
-          />
-          <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
-            <XDSText type="supporting" color="secondary">
-              Designed by
-            </XDSText>
-            <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
-              Andrea Anderson
-            </XDSText>
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );
@@ -4248,8 +4413,8 @@ export default function DocsiteLandingTemplate() {
   const [isTablet, setIsTablet] = useState(false);
   const [generatingSource, setGeneratingSource] = useState<number | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
-  const [useTarget, setUseTarget] = useState<number | null>(null);
   const [previewTarget, setPreviewTarget] = useState<number | null>(null);
+  const [useTarget, setUseTarget] = useState<number | null>(null);
   const [previewGenerating, setPreviewGenerating] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -4341,23 +4506,9 @@ export default function DocsiteLandingTemplate() {
 
   const isGenerating = generatingSource !== null;
 
-  // Combined view: only for the 2nd card (index 1, Shopping Details)
-  if ((previewTarget === 1 || useTarget === 1) && activeView === 'craft') {
+  // Combined preview + editor view for 2nd card (index 1)
+  if (previewTarget === 1 && activeView === 'craft') {
     const t = TEMPLATES[1];
-    return (
-      <TemplateCombinedView
-        templateName={t.name}
-        imageSrc={t.src}
-        onBack={handleBackFromUse}
-        isGenerating={previewGenerating}
-        simulation={simRef.current!}
-      />
-    );
-  }
-
-  // Preview flow for all other cards
-  if (previewTarget !== null && useTarget === null && activeView === 'craft') {
-    const t = TEMPLATES[previewTarget % TEMPLATES.length];
     return (
       <TemplateFullPreview
         templateName={t.name}
@@ -4365,14 +4516,15 @@ export default function DocsiteLandingTemplate() {
         onBack={() => {
           setPreviewTarget(null);
         }}
-        onUse={() => {
-          setUseTarget(previewTarget);
+        onUse={() => {}}
+        onSelectTemplate={index => {
+          setPreviewTarget(index);
         }}
       />
     );
   }
 
-  // Editor flow for cards that went through preview → customize
+  // Editor flow for non-2nd cards that went through preview → use
   if (useTarget !== null && useTarget !== 1 && activeView === 'craft') {
     const t = TEMPLATES[useTarget % TEMPLATES.length];
     return (
@@ -4396,6 +4548,28 @@ export default function DocsiteLandingTemplate() {
           />
         </div>
       </div>
+    );
+  }
+
+  // Preview page for all other cards (two-step: preview → editor)
+  if (previewTarget !== null && useTarget === null && activeView === 'craft') {
+    const t = TEMPLATES[previewTarget % TEMPLATES.length];
+    return (
+      <TemplateFullPreview
+        templateName={t.name}
+        imageSrc={t.src}
+        onBack={() => {
+          setPreviewTarget(null);
+        }}
+        onUse={() => {
+          setUseTarget(previewTarget);
+          setPreviewTarget(null);
+          setChatOpen(true);
+        }}
+        onSelectTemplate={index => {
+          setPreviewTarget(index);
+        }}
+      />
     );
   }
 
@@ -4458,9 +4632,7 @@ export default function DocsiteLandingTemplate() {
         height: '100vh',
         backgroundColor: 'var(--color-background-surface, white)',
       }}>
-      {useTarget === null && (
-        <AppTopNav activeView={activeView} setActiveView={setActiveView} />
-      )}
+      <AppTopNav activeView={activeView} setActiveView={setActiveView} />
       <div
         style={{
           display: 'flex',
@@ -4481,7 +4653,7 @@ export default function DocsiteLandingTemplate() {
           {chatOpen && (
             <ChatPanel
               isGenerating={isGenerating || previewGenerating}
-              onSend={useTarget !== null ? handlePreviewSend : undefined}
+              onSend={undefined}
               activeView={activeView}
               setActiveView={setActiveView}
             />
@@ -4496,66 +4668,56 @@ export default function DocsiteLandingTemplate() {
             display: 'flex',
             flexDirection: 'column' as const,
           }}>
-          {useTarget !== null ? (
-            <TemplatePreview
-              templateName={TEMPLATES[useTarget % TEMPLATES.length].name}
-              imageSrc={TEMPLATES[useTarget % TEMPLATES.length].src}
-              onBack={handleBackFromUse}
-              isGenerating={previewGenerating}
-              simulation={simRef.current!}
-            />
-          ) : (
-            <div style={{display: 'flex', flex: 1, overflow: 'hidden'}}>
-              {/* Masonry Grid */}
+          <div style={{display: 'flex', flex: 1, overflow: 'hidden'}}>
+            {/* Masonry Grid */}
+            <div
+              style={{
+                flex: 1,
+                overflow: 'auto',
+                padding: 16,
+              }}>
               <div
                 style={{
-                  flex: 1,
-                  overflow: 'auto',
-                  padding: 16,
+                  maxWidth: 2000,
+                  margin: '0 auto',
+                  display: 'grid',
+                  gridTemplateColumns: isMobile
+                    ? '1fr'
+                    : isTablet
+                      ? 'repeat(2, 1fr)'
+                      : 'repeat(4, 1fr)',
+                  gap: 16,
+                  gridAutoRows: '1fr',
                 }}>
-                <div
-                  style={{
-                    maxWidth: 2000,
-                    margin: '0 auto',
-                    display: 'grid',
-                    gridTemplateColumns: isMobile
-                      ? '1fr'
-                      : isTablet
-                        ? 'repeat(2, 1fr)'
-                        : 'repeat(4, 1fr)',
-                    gap: 16,
-                    gridAutoRows: '1fr',
-                  }}>
-                  {TEMPLATES.map((template, i) => (
-                    <div key={`${template.name}-${i}`}>
-                      <TemplateCard
-                        src={template.src}
-                        name={template.name}
-                        isSelected={selected.has(i)}
-                        isGenerating={isGenerating && generatingSource !== i}
-                        cardSize={template.size}
-                        onSelect={() =>
-                          setSelected(prev => {
-                            const next = new Set(prev);
-                            if (next.has(i)) {
-                              next.delete(i);
-                            } else {
-                              next.add(i);
-                            }
-                            return next;
-                          })
-                        }
-                        onMoreLikeThis={() => handleMoreLikeThis(i)}
-                        onUse={() => handleUse(i)}
-                        onPreview={() => handlePreview(i)}
-                        simulation={simRef.current!}
-                      />
-                    </div>
-                  ))}
-                </div>
+                {TEMPLATES.map((template, i) => (
+                  <div key={`${template.name}-${i}`}>
+                    <TemplateCard
+                      src={template.src}
+                      name={template.name}
+                      isSelected={selected.has(i)}
+                      isGenerating={isGenerating && generatingSource !== i}
+                      cardSize={template.size}
+                      onSelect={() =>
+                        setSelected(prev => {
+                          const next = new Set(prev);
+                          if (next.has(i)) {
+                            next.delete(i);
+                          } else {
+                            next.add(i);
+                          }
+                          return next;
+                        })
+                      }
+                      onMoreLikeThis={() => handleMoreLikeThis(i)}
+                      onUse={() => handleUse(i)}
+                      onPreview={() => handlePreview(i)}
+                      simulation={simRef.current!}
+                    />
+                  </div>
+                ))}
               </div>
             </div>
-          )}
+          </div>
         </div>
       </div>
 

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -3438,6 +3438,48 @@ function TemplateFullPreview({
               }}
             />
           </div>
+
+          {/* Similar templates */}
+          <div
+            style={{
+              width: '100%',
+              padding: '24px 32px 32px',
+              boxSizing: 'border-box' as const,
+            }}>
+            <XDSHeading level={3}>Similar templates</XDSHeading>
+            <div
+              style={{
+                display: 'flex',
+                gap: 12,
+                marginTop: 12,
+                overflowX: 'auto' as const,
+              }}>
+              {[0, 1, 2, 3].map(i => (
+                <div
+                  key={i}
+                  style={{
+                    flex: '0 0 280px',
+                    aspectRatio: '1920 / 1200',
+                    border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                    backgroundColor: 'var(--color-background-card, #fff)',
+                    borderRadius: 8,
+                    boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
+                    overflow: 'hidden',
+                  }}>
+                  <img
+                    src={DUMMY_IMAGE}
+                    alt={`Similar template ${i + 1}`}
+                    style={{
+                      display: 'block',
+                      width: '100%',
+                      height: '100%',
+                      objectFit: 'cover',
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
 
@@ -3618,43 +3660,6 @@ function TemplateFullPreview({
                     </XDSText>
                   </div>
                 </XDSCard>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Similar templates */}
-        <div style={{marginTop: 32}}>
-          <XDSHeading level={3}>Similar templates</XDSHeading>
-          <div
-            style={{
-              display: 'flex',
-              gap: 12,
-              marginTop: 12,
-              overflowX: 'auto' as const,
-            }}>
-            {[0, 1, 2, 3].map(i => (
-              <div
-                key={i}
-                style={{
-                  flex: '0 0 120px',
-                  aspectRatio: '1920 / 1200',
-                  border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-                  backgroundColor: 'var(--color-background-card, #fff)',
-                  borderRadius: 8,
-                  boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
-                  overflow: 'hidden',
-                }}>
-                <img
-                  src={DUMMY_IMAGE}
-                  alt={`Similar template ${i + 1}`}
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    height: '100%',
-                    objectFit: 'cover',
-                  }}
-                />
               </div>
             ))}
           </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -3305,12 +3305,14 @@ function TemplateFullPreview({
   onBack,
   onUse,
   onSelectTemplate,
+  showChat = false,
 }: {
   templateName: string;
   imageSrc: string;
   onBack: () => void;
   onUse: () => void;
   onSelectTemplate?: (index: number) => void;
+  showChat?: boolean;
 }) {
   const [viewMode, setViewMode] = useState<'desktop' | 'mobile'>('desktop');
   const [editorView, setEditorView] = useState<'preview' | 'code'>('preview');
@@ -3321,6 +3323,8 @@ function TemplateFullPreview({
   const [selectedFontPack, setSelectedFontPack] = useState<string | null>(
     PREVIEW_FONT_PACKS[0].heading,
   );
+  const [panelTab, setPanelTab] = useState<'properties' | 'chat'>('properties');
+  const [chatInput, setChatInput] = useState('');
 
   useEffect(() => {
     requestAnimationFrame(() => {
@@ -3370,234 +3374,326 @@ function TemplateFullPreview({
             onClick={onBack}
             style={{alignSelf: 'flex-start', marginLeft: -8, marginBottom: 8}}
           />
-          {/* Template name */}
-          <XDSText type="display-2">{templateName}</XDSText>
 
-          {/* Description */}
-          <div style={{marginTop: 8}}>
-            <XDSText type="body" color="secondary">
-              Buttons are clickable elements that are used to trigger actions.
-              They communicate calls to action to the user and allow users to
-              interact with pages in a variety of ways. Button labels express
-              what action will occur when the user interacts with it.
-            </XDSText>
-          </div>
-
-          {/* Stats buttons */}
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              marginTop: 16,
-              marginLeft: -8,
-              marginRight: -8,
-            }}>
-            <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
-              <XDSButton
-                label="Link"
-                variant="ghost"
-                size="sm"
-                isIconOnly
-                icon={<LinkIcon />}
-              />
-              <XDSDropdownMenu
-                button={{
-                  label: 'Share',
-                  variant: 'ghost',
-                  size: 'sm',
-                  isIconOnly: true,
-                  icon: <PaperPlaneIcon />,
-                }}
-                hasChevron={false}
-                menuWidth={220}
-                items={[
-                  {
-                    label: 'Copy CLI Command...',
-                    icon: TerminalIcon,
-                    onClick: () => {},
-                  },
-                  {type: 'divider' as const},
-                  {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
-                  {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
-                  {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
-                ]}
-              />
+          {/* Tab bar (only when showChat is true) */}
+          {showChat && (
+            <div style={{marginBottom: 16}}>
+              <XDSTabList
+                value={panelTab}
+                onChange={(v: string) =>
+                  setPanelTab(v as 'properties' | 'chat')
+                }
+                size="sm">
+                <XDSTab value="properties" label="Properties" />
+                <XDSTab value="chat" label="Chat" />
+              </XDSTabList>
             </div>
-            <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
-              <XDSButton
-                label="1,645"
-                variant="ghost"
-                size="sm"
-                icon={<HeartIcon />}
-              />
-              <XDSButton
-                label="892"
-                variant="ghost"
-                size="sm"
-                icon={<BookmarkIcon />}
-              />
-            </div>
-          </div>
+          )}
 
-          {/* CTA button */}
-          <div style={{marginTop: 16}}>
-            <XDSButton
-              variant="primary"
-              label="Start crafting"
-              onClick={onUse}
-              size="lg"
-              style={{width: '100%'}}
-            />
-          </div>
-
-          {/* Color palettes */}
-          <div style={{marginTop: 32}}>
-            <XDSHeading level={4}>Color palettes</XDSHeading>
+          {/* Chat tab content */}
+          {showChat && panelTab === 'chat' ? (
             <div
               style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 10,
-                marginTop: 8,
+                display: 'flex',
+                flexDirection: 'column' as const,
+                flex: 1,
+                minHeight: 0,
               }}>
-              {PREVIEW_COLOR_PALETTES.map(palette => (
+              {/* Chat messages area */}
+              <div style={{flex: 1, overflowY: 'auto' as const}}>
+                {/* Welcome message bubble */}
                 <div
-                  key={palette.name}
-                  onClick={() => setSelectedPalette(palette.name)}
                   style={{
-                    cursor: 'pointer',
-                    border: `2px solid ${selectedPalette === palette.name ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
-                    borderRadius: 14,
-                    overflow: 'hidden',
-                    transition: 'border-color 0.15s ease',
+                    backgroundColor: 'var(--color-background-body, #f1f4f7)',
+                    borderRadius: 12,
+                    padding: 12,
                   }}>
-                  <XDSCard padding={0}>
+                  <XDSText type="body">
+                    Hi! I can help you customize this template. Try asking me to
+                    change colors, layout, or content.
+                  </XDSText>
+                </div>
+              </div>
+
+              {/* Composer pinned to bottom */}
+              <div
+                style={{
+                  borderTop: '1px solid var(--color-divider, #e0e0e0)',
+                  padding: 8,
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  margin: '0 -32px -32px -32px',
+                  paddingInline: 32,
+                  paddingBottom: 32,
+                }}>
+                <XDSButton
+                  label="Attach"
+                  variant="ghost"
+                  size="sm"
+                  isIconOnly
+                  icon={<PlusIcon />}
+                />
+                <input
+                  value={chatInput}
+                  onChange={e => setChatInput(e.target.value)}
+                  placeholder="What should we build?"
+                  style={{
+                    flex: 1,
+                    border: 'none',
+                    outline: 'none',
+                    backgroundColor: 'transparent',
+                    fontSize: 14,
+                    color: 'inherit',
+                  }}
+                />
+                <XDSButton
+                  label="Send"
+                  variant="primary"
+                  size="sm"
+                  isIconOnly
+                  icon={<SendIcon />}
+                  style={{borderRadius: 9999}}
+                />
+              </div>
+            </div>
+          ) : (
+            <>
+              {/* Template name */}
+              <XDSText type="display-2">{templateName}</XDSText>
+
+              {/* Description */}
+              <div style={{marginTop: 8}}>
+                <XDSText type="body" color="secondary">
+                  Buttons are clickable elements that are used to trigger
+                  actions. They communicate calls to action to the user and
+                  allow users to interact with pages in a variety of ways.
+                  Button labels express what action will occur when the user
+                  interacts with it.
+                </XDSText>
+              </div>
+
+              {/* Stats buttons */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  marginTop: 16,
+                  marginLeft: -8,
+                  marginRight: -8,
+                }}>
+                <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+                  <XDSButton
+                    label="Link"
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                    icon={<LinkIcon />}
+                  />
+                  <XDSDropdownMenu
+                    button={{
+                      label: 'Share',
+                      variant: 'ghost',
+                      size: 'sm',
+                      isIconOnly: true,
+                      icon: <PaperPlaneIcon />,
+                    }}
+                    hasChevron={false}
+                    menuWidth={220}
+                    items={[
+                      {
+                        label: 'Copy CLI Command...',
+                        icon: TerminalIcon,
+                        onClick: () => {},
+                      },
+                      {type: 'divider' as const},
+                      {
+                        label: 'Claude Code',
+                        icon: ClaudeIcon,
+                        onClick: () => {},
+                      },
+                      {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                      {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
+                    ]}
+                  />
+                </div>
+                <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+                  <XDSButton
+                    label="1,645"
+                    variant="ghost"
+                    size="sm"
+                    icon={<HeartIcon />}
+                  />
+                  <XDSButton
+                    label="892"
+                    variant="ghost"
+                    size="sm"
+                    icon={<BookmarkIcon />}
+                  />
+                </div>
+              </div>
+
+              {/* CTA button */}
+              <div style={{marginTop: 16}}>
+                <XDSButton
+                  variant="primary"
+                  label="Start crafting"
+                  onClick={onUse}
+                  size="lg"
+                  style={{width: '100%'}}
+                />
+              </div>
+
+              {/* Color palettes */}
+              <div style={{marginTop: 32}}>
+                <XDSHeading level={4}>Color palettes</XDSHeading>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gap: 10,
+                    marginTop: 8,
+                  }}>
+                  {PREVIEW_COLOR_PALETTES.map(palette => (
                     <div
+                      key={palette.name}
+                      onClick={() => setSelectedPalette(palette.name)}
                       style={{
-                        display: 'flex',
+                        cursor: 'pointer',
+                        border: `2px solid ${selectedPalette === palette.name ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                        borderRadius: 14,
                         overflow: 'hidden',
-                        height: 48,
+                        transition: 'border-color 0.15s ease',
                       }}>
-                      {palette.colors.map((color, i) => (
+                      <XDSCard padding={0}>
                         <div
-                          key={i}
                           style={{
-                            flex: 1,
-                            backgroundColor: color,
-                          }}
-                        />
-                      ))}
+                            display: 'flex',
+                            overflow: 'hidden',
+                            height: 48,
+                          }}>
+                          {palette.colors.map((color, i) => (
+                            <div
+                              key={i}
+                              style={{
+                                flex: 1,
+                                backgroundColor: color,
+                              }}
+                            />
+                          ))}
+                        </div>
+                      </XDSCard>
                     </div>
-                  </XDSCard>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </div>
+              </div>
 
-          {/* Font packs */}
-          <div style={{marginTop: 32}}>
-            <XDSHeading level={4}>Font packs</XDSHeading>
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: '1fr 1fr',
-                gap: 10,
-                marginTop: 8,
-              }}>
-              {PREVIEW_FONT_PACKS.map(pack => (
+              {/* Font packs */}
+              <div style={{marginTop: 32}}>
+                <XDSHeading level={4}>Font packs</XDSHeading>
                 <div
-                  key={pack.heading}
-                  onClick={() => setSelectedFontPack(pack.heading)}
                   style={{
-                    cursor: 'pointer',
-                    border: `2px solid ${selectedFontPack === pack.heading ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
-                    borderRadius: 14,
-                    overflow: 'hidden',
-                    transition: 'border-color 0.15s ease',
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gap: 10,
+                    marginTop: 8,
                   }}>
-                  <XDSCard padding={2}>
-                    <div style={{fontFamily: pack.heading}}>
-                      <XDSText
-                        type="body"
-                        style={{fontWeight: 600, fontSize: 16}}>
-                        Heading
-                      </XDSText>
+                  {PREVIEW_FONT_PACKS.map(pack => (
+                    <div
+                      key={pack.heading}
+                      onClick={() => setSelectedFontPack(pack.heading)}
+                      style={{
+                        cursor: 'pointer',
+                        border: `2px solid ${selectedFontPack === pack.heading ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                        borderRadius: 14,
+                        overflow: 'hidden',
+                        transition: 'border-color 0.15s ease',
+                      }}>
+                      <XDSCard padding={2}>
+                        <div style={{fontFamily: pack.heading}}>
+                          <XDSText
+                            type="body"
+                            style={{fontWeight: 600, fontSize: 16}}>
+                            Heading
+                          </XDSText>
+                        </div>
+                        <div style={{fontFamily: pack.paragraph}}>
+                          <XDSText type="supporting" color="secondary">
+                            Paragraph text
+                          </XDSText>
+                        </div>
+                      </XDSCard>
                     </div>
-                    <div style={{fontFamily: pack.paragraph}}>
-                      <XDSText type="supporting" color="secondary">
-                        Paragraph text
-                      </XDSText>
-                    </div>
-                  </XDSCard>
+                  ))}
                 </div>
-              ))}
-            </div>
-          </div>
+              </div>
 
-          {/* Component used */}
-          <div style={{marginTop: 32}}>
-            <XDSHeading level={3}>Component used</XDSHeading>
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap' as const,
-                gap: 8,
-                marginTop: 8,
-              }}>
-              <XDSToken label="XDSAppShell" />
-              <XDSToken label="XDSTopNav" />
-              <XDSToken label="XDSVStack" />
-              <XDSToken label="XDSHStack" />
-              <XDSToken label="XDSHeading" />
-              <XDSToken label="XDSText" />
-              <XDSToken label="XDSButton" />
-              <XDSToken label="XDSCard" />
-              <XDSToken label="XDSBadge" />
-              <XDSToken label="XDSAvatar" />
-            </div>
-          </div>
+              {/* Component used */}
+              <div style={{marginTop: 32}}>
+                <XDSHeading level={3}>Component used</XDSHeading>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap' as const,
+                    gap: 8,
+                    marginTop: 8,
+                  }}>
+                  <XDSToken label="XDSAppShell" />
+                  <XDSToken label="XDSTopNav" />
+                  <XDSToken label="XDSVStack" />
+                  <XDSToken label="XDSHStack" />
+                  <XDSToken label="XDSHeading" />
+                  <XDSToken label="XDSText" />
+                  <XDSToken label="XDSButton" />
+                  <XDSToken label="XDSCard" />
+                  <XDSToken label="XDSBadge" />
+                  <XDSToken label="XDSAvatar" />
+                </div>
+              </div>
 
-          {/* Keywords */}
-          <div style={{marginTop: 32}}>
-            <XDSHeading level={3}>Keywords</XDSHeading>
-            <div
-              style={{
-                display: 'flex',
-                flexWrap: 'wrap' as const,
-                gap: 4,
-                marginTop: 8,
-              }}>
-              <XDSToken label="Dashboard" size="sm" />
-              <XDSToken label="Admin" size="sm" />
-              <XDSToken label="Layout" size="sm" />
-              <XDSToken label="Navigation" size="sm" />
-              <XDSToken label="Settings" size="sm" />
-            </div>
-          </div>
+              {/* Keywords */}
+              <div style={{marginTop: 32}}>
+                <XDSHeading level={3}>Keywords</XDSHeading>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexWrap: 'wrap' as const,
+                    gap: 4,
+                    marginTop: 8,
+                  }}>
+                  <XDSToken label="Dashboard" size="sm" />
+                  <XDSToken label="Admin" size="sm" />
+                  <XDSToken label="Layout" size="sm" />
+                  <XDSToken label="Navigation" size="sm" />
+                  <XDSToken label="Settings" size="sm" />
+                </div>
+              </div>
 
-          {/* Author section */}
-          <div
-            style={{
-              marginTop: 'auto',
-              display: 'flex',
-              flexDirection: 'row' as const,
-              alignItems: 'center',
-              gap: 12,
-            }}>
-            <XDSAvatar
-              size={36}
-              src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
-            />
-            <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
-              <XDSText type="supporting" color="secondary">
-                Designed by
-              </XDSText>
-              <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
-                Andrea Anderson
-              </XDSText>
-            </div>
-          </div>
+              {/* Author section */}
+              <div
+                style={{
+                  marginTop: 'auto',
+                  display: 'flex',
+                  flexDirection: 'row' as const,
+                  alignItems: 'center',
+                  gap: 12,
+                }}>
+                <XDSAvatar
+                  size={36}
+                  src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
+                />
+                <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
+                  <XDSText type="supporting" color="secondary">
+                    Designed by
+                  </XDSText>
+                  <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
+                    Andrea Anderson
+                  </XDSText>
+                </div>
+              </div>
+            </>
+          )}
         </div>
       </div>
 
@@ -4520,6 +4616,7 @@ export default function DocsiteLandingTemplate() {
         onSelectTemplate={index => {
           setPreviewTarget(index);
         }}
+        showChat
       />
     );
   }

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -2232,7 +2232,8 @@ function AppTopNav({
           position: 'sticky',
           top: 0,
           zIndex: 11,
-          transition: 'box-shadow 200ms ease',
+          transition:
+            'box-shadow 300ms var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
           boxShadow: isScrolled ? '0 1px 3px rgba(0,0,0,0.08)' : 'none',
         }}>
         {/* Left: logo nav */}
@@ -2240,22 +2241,25 @@ function AppTopNav({
           <LogoNav activeView={activeView} setActiveView={setActiveView} />
         </div>
 
-        {/* Center: tabs (only when scrolled) */}
-        {isScrolled && (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-            }}>
-            <XDSTabList value={activeTab} onChange={setActiveTab} size="sm">
-              <XDSTab value="all" label="All" />
-              <XDSTab value="templates" label="Templates" />
-              <XDSTab value="theme" label="Theme" />
-              <XDSTab value="components" label="Components" />
-            </XDSTabList>
-          </div>
-        )}
+        {/* Center: tabs (slide in when scrolled) */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            opacity: isScrolled ? 1 : 0,
+            transform: isScrolled ? 'translateY(0)' : 'translateY(-8px)',
+            transition:
+              'opacity 300ms var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1)), transform 300ms var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
+            pointerEvents: isScrolled ? ('auto' as const) : ('none' as const),
+          }}>
+          <XDSTabList value={activeTab} onChange={setActiveTab} size="sm">
+            <XDSTab value="all" label="All" />
+            <XDSTab value="templates" label="Templates" />
+            <XDSTab value="theme" label="Theme" />
+            <XDSTab value="components" label="Components" />
+          </XDSTabList>
+        </div>
 
         {/* Right: search + profile */}
         <div
@@ -2266,6 +2270,16 @@ function AppTopNav({
             flex: 1,
             justifyContent: 'flex-end',
           }}>
+          {isScrolled && (
+            <XDSButton
+              label="Filter"
+              variant="ghost"
+              size="sm"
+              isIconOnly
+              icon={<FilterIcon />}
+              onClick={() => setIsFilterOpen(!isFilterOpen)}
+            />
+          )}
           <XDSButton
             label="Search"
             variant="ghost"

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1021,16 +1021,20 @@ function ChatPanel({
       {/* Composer pinned to bottom */}
       <div
         style={{
-          padding: 0,
-          borderTop: '1px solid var(--color-divider, #e0e0e0)',
+          padding: templateName ? 0 : 12,
+          borderTop: templateName
+            ? '1px solid var(--color-divider, #e0e0e0)'
+            : 'none',
         }}>
         <div
           style={{
-            borderRadius: 0,
+            borderRadius: templateName ? 0 : 20,
             backgroundColor: 'var(--color-background-card, white)',
-            border: 'none',
-            borderTop: '1px solid var(--color-divider)',
-            boxShadow: 'none',
+            border: templateName ? 'none' : '1px solid var(--color-divider)',
+            borderTop: templateName
+              ? '1px solid var(--color-divider)'
+              : undefined,
+            boxShadow: templateName ? 'none' : 'var(--shadow-high)',
             padding: 8,
             display: 'flex',
             flexDirection: 'column' as const,
@@ -1733,10 +1737,11 @@ function ClassicTemplatePreview({
                   variant="ghost"
                   size="sm"
                   icon={<ArrowLeftIcon />}
+                  isIconOnly
                   onClick={onBack}
                   style={{marginLeft: -8}}
                 />
-                <XDSText type="body">{templateName}</XDSText>
+                <XDSHeading level={3}>{templateName}</XDSHeading>
               </>
             }
             centerContent={
@@ -1762,8 +1767,15 @@ function ClassicTemplatePreview({
             endContent={
               <>
                 <XDSButton
+                  label="Code"
+                  variant="ghost"
+                  isIconOnly
+                  icon={<CodeIcon />}
+                />
+                <XDSButton
                   label="Point"
                   variant="ghost"
+                  isIconOnly
                   icon={<CursorIcon />}
                 />
                 <XDSDropdownMenu
@@ -1771,6 +1783,7 @@ function ClassicTemplatePreview({
                     label: 'Theme',
                     variant: 'ghost',
                     icon: <PaletteIcon />,
+                    isIconOnly: true,
                   }}
                   hasChevron={false}
                   items={XDS_THEMES.map(t => ({
@@ -1781,10 +1794,22 @@ function ClassicTemplatePreview({
                 <XDSButton
                   label="Toggle theme"
                   variant="ghost"
+                  isIconOnly
                   icon={<ContrastIcon />}
                 />
+                <XDSButton
+                  label="Save"
+                  variant="ghost"
+                  isIconOnly
+                  icon={<SaveIcon />}
+                />
                 <XDSDropdownMenu
-                  button={{label: 'Share', variant: 'ghost'}}
+                  button={{
+                    label: 'Share',
+                    variant: 'ghost',
+                    icon: <PaperPlaneIcon />,
+                    isIconOnly: true,
+                  }}
                   hasChevron={false}
                   menuWidth={220}
                   items={[

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1578,14 +1578,14 @@ function TemplatePreview({
           {/* Code block */}
           <div
             style={{
-              margin: 0,
-              border: 'none',
-              borderRadius: 0,
-              backgroundColor:
-                'var(--color-background-muted, rgba(0,0,0,0.03))',
+              margin: '0 22px 22px',
+              backgroundColor: 'var(--color-background-card, #fff)',
+              borderRadius: 16,
+              boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
               overflow: 'auto',
               flex: 1,
-              display: editorView === 'code' ? 'block' : 'none',
+              display: editorView === 'code' ? 'flex' : 'none',
+              flexDirection: 'column' as const,
             }}>
             {/* Header */}
             <div
@@ -4640,6 +4640,47 @@ export default function DocsiteLandingTemplate() {
   }, []);
 
   const isGenerating = generatingSource !== null;
+
+  // Classic flat editor layout for 3rd card (index 2) — no floating cards
+  if ((previewTarget === 2 || useTarget === 2) && activeView === 'craft') {
+    const t = TEMPLATES[2 % TEMPLATES.length];
+    return (
+      <div
+        style={{
+          display: 'flex',
+          height: '100vh',
+          overflow: 'hidden',
+        }}>
+        <div
+          style={{
+            width: 280,
+            minWidth: 280,
+            borderRight: '1px solid var(--color-divider)',
+          }}>
+          <ChatPanel
+            isGenerating={previewGenerating}
+            onSend={handlePreviewSend}
+            activeView={activeView}
+            setActiveView={setActiveView}
+          />
+        </div>
+        <div
+          style={{flex: 1, display: 'flex', flexDirection: 'column' as const}}>
+          <TemplatePreview
+            templateName={t.name}
+            imageSrc={t.src}
+            onBack={() => {
+              setPreviewTarget(null);
+              setUseTarget(null);
+              setChatOpen(false);
+            }}
+            isGenerating={previewGenerating}
+            simulation={simRef.current!}
+          />
+        </div>
+      </div>
+    );
+  }
 
   // Combined preview + editor view for 2nd card (index 1)
   if (previewTarget === 1 && activeView === 'craft') {

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -3362,35 +3362,62 @@ function TemplateFullPreview({
             backgroundColor: 'var(--color-background-card, #fff)',
             borderRadius: 16,
             boxShadow: '0 4px 24px rgba(0,0,0,0.08)',
-            padding: 32,
+            padding: '16px 32px 32px',
             overflowY: 'auto' as const,
             display: 'flex',
             flexDirection: 'column' as const,
           }}>
-          {/* Back button */}
-          <XDSButton
-            label="Craft"
-            variant="ghost"
-            size="sm"
-            icon={<ArrowLeftIcon />}
-            onClick={onBack}
-            style={{alignSelf: 'flex-start', marginLeft: -8, marginBottom: 8}}
-          />
-
-          {/* Tab bar (only when showChat is true) */}
-          {showChat && (
-            <div style={{marginBottom: 16}}>
-              <XDSTabList
-                value={panelTab}
-                onChange={(v: string) =>
-                  setPanelTab(v as 'properties' | 'chat')
-                }
-                size="sm">
-                <XDSTab value="properties" label="Properties" />
-                <XDSTab value="chat" label="Chat" />
-              </XDSTabList>
-            </div>
-          )}
+          {/* Back button + tabs on same row */}
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              marginBottom: showChat ? 32 : 0,
+              paddingBottom: 0,
+              borderBottom: showChat
+                ? '1px solid var(--color-divider, #e0e0e0)'
+                : 'none',
+            }}>
+            <XDSButton
+              label="Back"
+              variant="ghost"
+              size="sm"
+              icon={<ArrowLeftIcon />}
+              isIconOnly
+              onClick={onBack}
+              style={{marginLeft: -8, flexShrink: 0}}
+            />
+            {showChat && (
+              <div style={{display: 'flex', flex: 1}}>
+                {(['properties', 'chat'] as const).map(tab => (
+                  <button
+                    key={tab}
+                    onClick={() => setPanelTab(tab)}
+                    style={{
+                      flex: 1,
+                      padding: '8px 0',
+                      background: 'none',
+                      border: 'none',
+                      borderBottom:
+                        panelTab === tab
+                          ? '2px solid var(--color-text-primary, #111)'
+                          : '2px solid transparent',
+                      marginBottom: -1,
+                      cursor: 'pointer',
+                      textAlign: 'center' as const,
+                      transition: 'border-color 150ms ease',
+                    }}>
+                    <XDSText
+                      type="body-2"
+                      color={panelTab === tab ? 'primary' : 'secondary'}>
+                      {tab === 'properties' ? 'Details' : 'Chat'}
+                    </XDSText>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
 
           {/* Chat tab content */}
           {showChat && panelTab === 'chat' ? (
@@ -3475,6 +3502,29 @@ function TemplateFullPreview({
                 </XDSText>
               </div>
 
+              {/* Author section */}
+              <div
+                style={{
+                  marginTop: 16,
+                  display: 'flex',
+                  flexDirection: 'row' as const,
+                  alignItems: 'center',
+                  gap: 12,
+                }}>
+                <XDSAvatar
+                  size={36}
+                  src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
+                />
+                <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
+                  <XDSText type="supporting" color="secondary">
+                    Designed by
+                  </XDSText>
+                  <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
+                    Andrea Anderson
+                  </XDSText>
+                </div>
+              </div>
+
               {/* Stats buttons */}
               <div
                 style={{
@@ -3537,19 +3587,21 @@ function TemplateFullPreview({
               </div>
 
               {/* CTA button */}
-              <div style={{marginTop: 16}}>
-                <XDSButton
-                  variant="primary"
-                  label="Start crafting"
-                  onClick={onUse}
-                  size="lg"
-                  style={{width: '100%'}}
-                />
-              </div>
+              {!showEditor && (
+                <div style={{marginTop: 16}}>
+                  <XDSButton
+                    variant="primary"
+                    label="Start crafting"
+                    onClick={onUse}
+                    size="lg"
+                    style={{width: '100%'}}
+                  />
+                </div>
+              )}
 
-              {/* Color palettes */}
+              {/* Themes */}
               <div style={{marginTop: 32}}>
-                <XDSHeading level={4}>Color palettes</XDSHeading>
+                <XDSHeading level={4}>Themes</XDSHeading>
                 <div
                   style={{
                     display: 'grid',
@@ -3591,8 +3643,8 @@ function TemplateFullPreview({
                 </div>
               </div>
 
-              {/* Font packs */}
-              <div style={{marginTop: 32}}>
+              {/* Font packs — removed */}
+              <div style={{marginTop: 32, display: 'none'}}>
                 <XDSHeading level={4}>Font packs</XDSHeading>
                 <div
                   style={{
@@ -3669,29 +3721,6 @@ function TemplateFullPreview({
                   <XDSToken label="Layout" size="sm" />
                   <XDSToken label="Navigation" size="sm" />
                   <XDSToken label="Settings" size="sm" />
-                </div>
-              </div>
-
-              {/* Author section */}
-              <div
-                style={{
-                  marginTop: 'auto',
-                  display: 'flex',
-                  flexDirection: 'row' as const,
-                  alignItems: 'center',
-                  gap: 12,
-                }}>
-                <XDSAvatar
-                  size={36}
-                  src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
-                />
-                <div style={{display: 'flex', flexDirection: 'column', gap: 2}}>
-                  <XDSText type="supporting" color="secondary">
-                    Designed by
-                  </XDSText>
-                  <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
-                    Andrea Anderson
-                  </XDSText>
                 </div>
               </div>
             </>
@@ -4340,9 +4369,9 @@ function TemplateCombinedView({
                 </div>
               </div>
 
-              {/* Section 2 — Color palettes */}
+              {/* Section 2 — Themes */}
               <div style={{marginTop: 32}}>
-                <XDSHeading level={4}>Color palettes</XDSHeading>
+                <XDSHeading level={4}>Themes</XDSHeading>
                 <div
                   style={{
                     display: 'grid',
@@ -4384,8 +4413,8 @@ function TemplateCombinedView({
                 </div>
               </div>
 
-              {/* Section 3 — Font packs */}
-              <div style={{marginTop: 32}}>
+              {/* Section 3 — Font packs — removed */}
+              <div style={{marginTop: 32, display: 'none'}}>
                 <XDSHeading level={4}>Font packs</XDSHeading>
                 <div
                   style={{

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -546,10 +546,11 @@ function BoidsCanvas({
 // Template data — real images from /public/templates/
 // ---------------------------------------------------------------------------
 
-const DUMMY_IMAGE = '/templates/dummy-placeholder.png';
-const FIRST_CARD_IMAGE = '/templates/first-card.png';
-const SHOPPING_DETAILS_IMAGE = '/templates/shopping-details.png';
-const SCREENSHOT_3_IMAGE = '/templates/screenshot-3.png';
+const basePath = process.env.NEXT_PUBLIC_BASE_PATH || '';
+const DUMMY_IMAGE = `${basePath}/templates/dummy-placeholder.png`;
+const FIRST_CARD_IMAGE = `${basePath}/templates/first-card.png`;
+const SHOPPING_DETAILS_IMAGE = `${basePath}/templates/shopping-details.png`;
+const SCREENSHOT_3_IMAGE = `${basePath}/templates/screenshot-3.png`;
 
 const TEMPLATE_IMAGES = [DUMMY_IMAGE, DUMMY_IMAGE, DUMMY_IMAGE, DUMMY_IMAGE];
 
@@ -565,6 +566,7 @@ function TemplateCard({
   isGenerating,
   onMoreLikeThis: _onMoreLikeThis,
   onUse,
+  onPreview,
   simulation,
   cardSize: _cardSize = 'medium',
 }: {
@@ -575,6 +577,7 @@ function TemplateCard({
   isGenerating: boolean;
   onMoreLikeThis?: () => void;
   onUse: () => void;
+  onPreview: () => void;
   simulation: BoidsSimulation;
   cardSize?: 'xlarge' | 'large' | 'medium' | 'small';
 }) {
@@ -610,7 +613,7 @@ function TemplateCard({
         }}
         onMouseEnter={() => setHovered(true)}
         onMouseLeave={() => setHovered(false)}
-        onClick={onUse}>
+        onClick={onPreview}>
         {/* Image layer — always present */}
         <img
           src={src}
@@ -650,49 +653,49 @@ function TemplateCard({
               transition:
                 'opacity var(--duration-fast, 175ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
             }}>
-            {/* Bottom-left action buttons */}
+            {/* Top-right: Copy link, Bookmark, Heart+count */}
             <div
-              onClick={e => e.stopPropagation()}
               style={{
                 position: 'absolute',
-                bottom: 8,
-                left: 8,
+                top: 8,
+                right: 8,
                 display: 'flex',
-                flexDirection: 'row' as const,
+                alignItems: 'center',
                 gap: 4,
-                transform: hovered ? 'translateY(0)' : 'translateY(16px)',
-                opacity: hovered ? 1 : 0,
-                transition:
-                  'transform var(--duration-fast, 175ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1)), opacity var(--duration-fast, 175ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
-              }}>
+              }}
+              onClick={e => e.stopPropagation()}>
               <XDSButton
                 label="Copy link"
-                variant="secondary"
+                variant="ghost"
                 size="sm"
+                isIconOnly
                 icon={<LinkIcon />}
-                isIconOnly
-                style={{backgroundColor: 'var(--color-background-surface)'}}
+                style={{color: '#fff'}}
                 onClick={() => {}}
               />
               <XDSButton
-                label="Favorite"
-                variant="secondary"
+                label="Bookmark"
+                variant="ghost"
                 size="sm"
+                isIconOnly
+                icon={<BookmarkIcon />}
+                style={{color: '#fff'}}
+                onClick={() => {}}
+              />
+              <XDSButton
+                label="Like"
+                variant="ghost"
+                size="sm"
+                isIconOnly
                 icon={<HeartIcon />}
-                isIconOnly
-                style={{backgroundColor: 'var(--color-background-surface)'}}
+                style={{color: '#fff'}}
                 onClick={() => {}}
               />
-              <XDSButton
-                label="Upvote"
-                variant="secondary"
-                size="sm"
-                icon={<ThumbsUpIcon />}
-                isIconOnly
-                style={{backgroundColor: 'var(--color-background-surface)'}}
-                onClick={() => {}}
-              />
+              <XDSText type="supporting" style={{color: '#fff'}}>
+                24
+              </XDSText>
             </div>
+            {/* Bottom-right: Customize + Use dropdown */}
             <div
               onClick={e => e.stopPropagation()}
               style={{
@@ -841,12 +844,14 @@ function AIComposer() {
                 label="Attach"
                 variant="ghost"
                 size="sm"
+                isIconOnly
                 icon={<PlusIcon />}
               />
               <XDSButton
                 label="Send"
                 variant="primary"
                 size="sm"
+                isIconOnly
                 icon={<SendIcon />}
                 style={{borderRadius: 9999}}
               />
@@ -945,8 +950,8 @@ function ChatPanel({
           label="Toggle sidebar"
           variant="ghost"
           size="sm"
-          icon={<SidebarIcon />}
           isIconOnly
+          icon={<SidebarIcon />}
         />
       </div>
 
@@ -1038,12 +1043,14 @@ function ChatPanel({
               label="Attach"
               variant="ghost"
               size="sm"
+              isIconOnly
               icon={<PlusIcon />}
             />
             <XDSButton
               label="Send"
               variant="primary"
               size="sm"
+              isIconOnly
               icon={<SendIcon />}
               style={{borderRadius: 9999}}
               onClick={onSend}
@@ -1076,8 +1083,11 @@ const CursorIcon = (props: React.SVGProps<SVGSVGElement>) => (
     fill="none"
     stroke="currentColor"
     strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
     {...props}>
-    <path d="M4 4l7.07 17 2.51-7.39L21 11.07z" />
+    <path d="m3 3 7.07 16.97 2.51-7.39 7.39-2.51L3 3z" />
+    <path d="m13 13 6 6" />
   </svg>
 );
 
@@ -1090,11 +1100,8 @@ const PaletteIcon = (props: React.SVGProps<SVGSVGElement>) => (
     strokeLinecap="round"
     strokeLinejoin="round"
     {...props}>
-    <path d="M12 2C6.5 2 2 6.5 2 12s4.5 10 10 10c.9 0 1.7-.7 1.7-1.7 0-.4-.2-.8-.4-1.1-.3-.3-.4-.7-.4-1.1 0-.9.7-1.7 1.7-1.7H16c3.3 0 6-2.7 6-6 0-5-4.5-8.5-10-8.5z" />
-    <circle cx="7.5" cy="11.5" r="1.5" fill="currentColor" stroke="none" />
-    <circle cx="10.5" cy="7.5" r="1.5" fill="currentColor" stroke="none" />
-    <circle cx="14.5" cy="7.5" r="1.5" fill="currentColor" stroke="none" />
-    <circle cx="17.5" cy="11.5" r="1.5" fill="currentColor" stroke="none" />
+    <path d="m9.06 11.9 8.07-8.06a2.85 2.85 0 1 1 4.03 4.03l-8.06 8.08" />
+    <path d="M7.07 14.94c-1.66 0-3 1.35-3 3.02 0 1.33-2.5 1.52-2 2.02 1.08 1.1 2.49 2.02 4 2.02 2.2 0 4-1.8 4-4.04a3.01 3.01 0 0 0-3-3.02z" />
   </svg>
 );
 
@@ -1107,8 +1114,42 @@ const ContrastIcon = (props: React.SVGProps<SVGSVGElement>) => (
     strokeLinecap="round"
     strokeLinejoin="round"
     {...props}>
-    <circle cx="12" cy="12" r="10" />
-    <path d="M12 2a10 10 0 0 1 0 20z" fill="currentColor" />
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2" />
+    <path d="M12 20v2" />
+    <path d="m4.93 4.93 1.41 1.41" />
+    <path d="m17.66 17.66 1.41 1.41" />
+    <path d="M2 12h2" />
+    <path d="M20 12h2" />
+    <path d="m6.34 17.66-1.41 1.41" />
+    <path d="m19.07 4.93-1.41 1.41" />
+  </svg>
+);
+
+const BookmarkIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2v16z" />
+  </svg>
+);
+
+const PaperPlaneIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M3.714 3.048a.498.498 0 0 0-.683.627l2.843 7.627a2 2 0 0 1 0 1.396l-2.842 7.627a.498.498 0 0 0 .682.627l18-8.5a.5.5 0 0 0 0-.904z" />
+    <path d="M6 12h16" />
   </svg>
 );
 
@@ -1129,7 +1170,7 @@ const TabletIcon = (props: React.SVGProps<SVGSVGElement>) => (
     viewBox="0 0 24 24"
     fill="none"
     stroke="currentColor"
-    strokeWidth={1.5}
+    strokeWidth={2}
     {...props}>
     <rect x="4" y="2" width="16" height="20" rx="2" />
     <line x1="12" y1="18" x2="12" y2="18" strokeLinecap="round" />
@@ -1236,7 +1277,6 @@ export default function DetailPage() {
 
 const VIEWPORT_WIDTHS: Record<string, number | '100%'> = {
   desktop: 1600,
-  tablet: 768,
   phone: 375,
 };
 
@@ -1260,6 +1300,7 @@ function TemplatePreview({
   simulation: BoidsSimulation;
 }) {
   const [viewportSize, setViewportSize] = useState('desktop');
+  const [editorView, setEditorView] = useState<'preview' | 'code'>('preview');
   const previewRef = useRef<HTMLDivElement>(null);
   const [previewSize, setPreviewSize] = useState({w: 0, h: 0});
   const [showCanvas, setShowCanvas] = useState(false);
@@ -1302,6 +1343,7 @@ function TemplatePreview({
             paddingBottom: 8,
             display: 'flex',
             flexDirection: 'column' as const,
+            minHeight: 800,
           }}>
           {/* Toolbar */}
           <XDSToolbar
@@ -1312,11 +1354,11 @@ function TemplatePreview({
                   label="Back"
                   variant="ghost"
                   size="sm"
+                  isIconOnly
                   icon={<ArrowLeftIcon />}
                   onClick={onBack}
-                  style={{marginLeft: -8}}
                 />
-                <XDSHeading level={4}>{templateName}</XDSHeading>
+                <XDSHeading level={3}>{templateName}</XDSHeading>
               </>
             }
             centerContent={
@@ -1332,12 +1374,6 @@ function TemplatePreview({
                   icon={<DesktopIcon />}
                 />
                 <XDSSegmentedControlItem
-                  value="tablet"
-                  label="Tablet"
-                  isLabelHidden
-                  icon={<TabletIcon />}
-                />
-                <XDSSegmentedControlItem
                   value="phone"
                   label="Phone"
                   isLabelHidden
@@ -1350,15 +1386,15 @@ function TemplatePreview({
                 <XDSButton
                   label="Point"
                   variant="ghost"
-                  icon={<CursorIcon />}
                   isIconOnly
+                  icon={<CursorIcon />}
                 />
                 <XDSDropdownMenu
                   button={{
                     label: 'Theme',
                     variant: 'ghost',
-                    icon: <PaletteIcon />,
                     isIconOnly: true,
+                    icon: <PaletteIcon />,
                   }}
                   hasChevron={false}
                   items={XDS_THEMES.map(t => ({
@@ -1369,11 +1405,32 @@ function TemplatePreview({
                 <XDSButton
                   label="Toggle theme"
                   variant="ghost"
-                  icon={<ContrastIcon />}
                   isIconOnly
+                  icon={<ContrastIcon />}
+                />
+                <XDSButton
+                  label="Toggle code"
+                  variant={editorView === 'code' ? 'secondary' : 'ghost'}
+                  isIconOnly
+                  icon={<CodeIcon />}
+                  onClick={() =>
+                    setEditorView(editorView === 'preview' ? 'code' : 'preview')
+                  }
+                />
+                <XDSButton
+                  label="Save"
+                  variant="ghost"
+                  icon={<BookmarkIcon />}
+                  isIconOnly
+                  onClick={() => {}}
                 />
                 <XDSDropdownMenu
-                  button={{label: 'Share', variant: 'ghost'}}
+                  button={{
+                    label: 'Share',
+                    variant: 'ghost',
+                    isIconOnly: true,
+                    icon: <PaperPlaneIcon />,
+                  }}
                   hasChevron={false}
                   menuWidth={220}
                   items={[
@@ -1392,129 +1449,175 @@ function TemplatePreview({
             }
           />
 
-          {/* Preview image in muted container with grid dots */}
-          <div
-            style={{
-              backgroundColor:
-                'var(--color-background-muted, rgba(0,0,0,0.03))',
-              backgroundImage:
-                'radial-gradient(circle, var(--color-divider, rgba(0,0,0,0.1)) 1px, transparent 1px)',
-              backgroundSize: '16px 16px',
-              borderRadius: 8,
-              padding: 22,
-              margin: '0 8px',
-              display: 'flex',
-              justifyContent: 'center',
-            }}>
+          {/* Preview — browser frame + image */}
+          {editorView === 'preview' && (
             <div
-              ref={previewRef}
               style={{
-                position: 'relative',
-                width:
-                  VIEWPORT_WIDTHS[viewportSize] === '100%'
-                    ? '100%'
-                    : VIEWPORT_WIDTHS[viewportSize],
-                maxWidth: '100%',
-                border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                backgroundColor: '#f5f5f5',
                 borderRadius: 8,
-                overflow: 'hidden',
-                transition:
-                  'width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
+                padding: 22,
+                margin: '0 8px',
+                display: 'flex',
+                justifyContent: 'center',
+                minHeight: 700,
               }}>
-              <img
-                src={imageSrc}
-                alt="Template preview"
+              <div
+                ref={previewRef}
                 style={{
-                  display: 'block',
-                  width: '100%',
-                  aspectRatio: '1920 / 1200',
-                  objectFit: 'cover',
-                  opacity: isGenerating ? 0 : 1,
-                  transition: 'opacity 600ms ease',
-                }}
-              />
-              {showCanvas && (
-                <div
+                  position: 'relative',
+                  width:
+                    VIEWPORT_WIDTHS[viewportSize] === '100%'
+                      ? '100%'
+                      : VIEWPORT_WIDTHS[viewportSize],
+                  maxWidth: '100%',
+                  backgroundColor: '#fff',
+                  borderRadius: viewportSize === 'phone' ? 36 : 12,
+                  border: viewportSize === 'phone' ? '10px solid #fff' : 'none',
+                  boxShadow:
+                    viewportSize === 'phone'
+                      ? '0 8px 40px rgba(0,0,0,0.15), 0 0 0 1px rgba(0,0,0,0.06)'
+                      : '0 8px 40px rgba(0,0,0,0.12)',
+                  overflow: 'hidden',
+                  transition:
+                    'width var(--duration-medium, 410ms) var(--ease-standard, cubic-bezier(0.24, 1, 0.4, 1))',
+                }}>
+                {/* Browser chrome dots for desktop */}
+                {viewportSize === 'desktop' && (
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      padding: '10px 14px',
+                      backgroundColor: '#fff',
+                      borderBottom: '1px solid #f0f0f0',
+                    }}>
+                    <div
+                      style={{display: 'flex', gap: 6, alignItems: 'center'}}>
+                      <div
+                        style={{
+                          width: 10,
+                          height: 10,
+                          borderRadius: '50%',
+                          backgroundColor: '#e0e0e0',
+                        }}
+                      />
+                      <div
+                        style={{
+                          width: 10,
+                          height: 10,
+                          borderRadius: '50%',
+                          backgroundColor: '#e0e0e0',
+                        }}
+                      />
+                      <div
+                        style={{
+                          width: 10,
+                          height: 10,
+                          borderRadius: '50%',
+                          backgroundColor: '#e0e0e0',
+                        }}
+                      />
+                    </div>
+                  </div>
+                )}
+                <img
+                  src={imageSrc}
+                  alt="Template preview"
                   style={{
-                    position: 'absolute',
-                    inset: 0,
-                    opacity: isGenerating ? 1 : 0,
+                    display: 'block',
+                    width: '100%',
+                    aspectRatio:
+                      viewportSize === 'phone' ? '9 / 19.5' : '1920 / 1200',
+                    objectFit: 'cover',
+                    opacity: isGenerating ? 0 : 1,
                     transition: 'opacity 600ms ease',
-                  }}>
-                  <BoidsCanvas
-                    width={previewSize.w}
-                    height={previewSize.h}
-                    simulation={simulation}
-                  />
-                </div>
-              )}
+                  }}
+                />
+                {showCanvas && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      inset: 0,
+                      opacity: isGenerating ? 1 : 0,
+                      transition: 'opacity 600ms ease',
+                    }}>
+                    <BoidsCanvas
+                      width={previewSize.w}
+                      height={previewSize.h}
+                      simulation={simulation}
+                    />
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
+          )}
 
           {/* Code block */}
-          <div
-            style={{
-              margin: '8px 8px 0',
-              border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-              borderRadius: 8,
-              backgroundColor:
-                'var(--color-background-muted, rgba(0,0,0,0.03))',
-              overflow: 'hidden',
-            }}>
-            {/* Header */}
+          {editorView === 'code' && (
             <div
               style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: '8px 12px 8px 16px',
+                margin: '8px 8px 0',
+                border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                borderRadius: 8,
+                backgroundColor:
+                  'var(--color-background-muted, rgba(0,0,0,0.03))',
+                overflow: 'hidden',
               }}>
-              <span
-                style={{
-                  fontFamily: '"Roboto Mono", monospace',
-                  fontSize: 12,
-                  fontWeight: 500,
-                  color: 'var(--color-text-secondary, #4e606f)',
-                }}>
-                typescript — useUser.ts
-              </span>
-            </div>
-            {/* Code */}
-            <div style={{display: 'flex'}}>
-              {/* Line numbers */}
+              {/* Header */}
               <div
                 style={{
-                  padding: '12px 12px 12px 16px',
-                  borderRight:
-                    '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-                  fontFamily: '"Roboto Mono", monospace',
-                  fontSize: 14,
-                  lineHeight: '20px',
-                  color: 'var(--color-text-disabled, #a4b0bc)',
-                  textAlign: 'right',
-                  userSelect: 'none',
-                  minWidth: 45,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '8px 12px 8px 16px',
                 }}>
-                {MOCK_CODE.split('\n').map((_, i) => (
-                  <div key={i}>{i + 1}</div>
-                ))}
+                <span
+                  style={{
+                    fontFamily: '"Roboto Mono", monospace',
+                    fontSize: 12,
+                    fontWeight: 500,
+                    color: 'var(--color-text-secondary, #4e606f)',
+                  }}>
+                  typescript — useUser.ts
+                </span>
               </div>
-              {/* Code content */}
-              <pre
-                style={{
-                  flex: 1,
-                  padding: '12px 16px',
-                  fontFamily: '"Roboto Mono", monospace',
-                  fontSize: 14,
-                  lineHeight: '20px',
-                  margin: 0,
-                  overflow: 'auto',
-                  color: 'var(--color-text-primary, #0a1317)',
-                }}>
-                {MOCK_CODE}
-              </pre>
+              {/* Code */}
+              <div style={{display: 'flex'}}>
+                {/* Line numbers */}
+                <div
+                  style={{
+                    padding: '12px 12px 12px 16px',
+                    borderRight:
+                      '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                    fontFamily: '"Roboto Mono", monospace',
+                    fontSize: 14,
+                    lineHeight: '20px',
+                    color: 'var(--color-text-disabled, #a4b0bc)',
+                    textAlign: 'right',
+                    userSelect: 'none',
+                    minWidth: 45,
+                  }}>
+                  {MOCK_CODE.split('\n').map((_, i) => (
+                    <div key={i}>{i + 1}</div>
+                  ))}
+                </div>
+                {/* Code content */}
+                <pre
+                  style={{
+                    flex: 1,
+                    padding: '12px 16px',
+                    fontFamily: '"Roboto Mono", monospace',
+                    fontSize: 14,
+                    lineHeight: '20px',
+                    margin: 0,
+                    overflow: 'auto',
+                    color: 'var(--color-text-primary, #0a1317)',
+                  }}>
+                  {MOCK_CODE}
+                </pre>
+              </div>
             </div>
-          </div>
+          )}
         </div>
 
         {/* Title & metadata */}
@@ -1563,7 +1666,9 @@ function TemplatePreview({
                   flex: 1,
                   aspectRatio: '1920 / 1200',
                   border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                  backgroundColor: '#fff',
                   borderRadius: 12,
+                  boxShadow: '0 8px 40px rgba(0,0,0,0.12)',
                   overflow: 'hidden',
                 }}>
                 <img
@@ -1763,10 +1868,19 @@ function AppTopNav({
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [activeTab, setActiveTab] = useState('all');
   const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    const handleScroll = () => {
+      setIsScrolled(window.scrollY > 120);
+    };
+    window.addEventListener('scroll', handleScroll, {passive: true});
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
 
   return (
     <>
-      {/* Top nav bar */}
+      {/* Top nav bar — becomes combined bar when scrolled */}
       <nav
         style={{
           display: 'flex',
@@ -1778,11 +1892,30 @@ function AppTopNav({
           position: 'sticky',
           top: 0,
           zIndex: 11,
+          transition: 'box-shadow 200ms ease',
+          boxShadow: isScrolled ? '0 1px 3px rgba(0,0,0,0.08)' : 'none',
         }}>
         {/* Left: logo nav */}
         <div style={{display: 'flex', alignItems: 'center', gap: 8, flex: 1}}>
           <LogoNav activeView={activeView} setActiveView={setActiveView} />
         </div>
+
+        {/* Center: tabs (only when scrolled) */}
+        {isScrolled && (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}>
+            <XDSTabList value={activeTab} onChange={setActiveTab} size="sm">
+              <XDSTab value="all" label="All" />
+              <XDSTab value="templates" label="Templates" />
+              <XDSTab value="theme" label="Theme" />
+              <XDSTab value="components" label="Components" />
+            </XDSTabList>
+          </div>
+        )}
 
         {/* Right: search + profile */}
         <div
@@ -1797,32 +1930,38 @@ function AppTopNav({
             label="Search"
             variant="ghost"
             size="sm"
-            icon={<SearchIcon />}
             isIconOnly
+            icon={<SearchIcon />}
             onClick={() => setIsSearchOpen(true)}
           />
           <XDSButton
             label="Profile"
             variant="ghost"
             size="sm"
-            icon={<ProfileIcon />}
             isIconOnly
+            icon={<ProfileIcon />}
             onClick={() => setActiveView('profile')}
           />
         </div>
       </nav>
 
-      {/* Hero section */}
+      {/* Hero section — collapses when scrolled */}
       <div
         style={{
           display: 'flex',
           flexDirection: 'column',
           alignItems: 'center',
           padding: '16px 16px 32px',
+          maxHeight: isScrolled ? 0 : 200,
+          overflow: 'hidden',
+          opacity: isScrolled ? 0 : 1,
+          transition:
+            'max-height 300ms ease, opacity 200ms ease, padding 300ms ease',
+          ...(isScrolled ? {padding: 0} : {}),
         }}>
         <div style={{textAlign: 'center'}}>
           <div style={{paddingBottom: 4}}>
-            <XDSText type="display-3" color="secondary">
+            <XDSText type="display-3" color="primary">
               Explore the possibilities.
             </XDSText>
           </div>
@@ -1830,7 +1969,7 @@ function AppTopNav({
         </div>
       </div>
 
-      {/* Tabs row with filter icon on the right */}
+      {/* Tabs row — collapses when scrolled (tabs move to nav bar) */}
       <div
         style={{
           display: 'grid',
@@ -1841,6 +1980,12 @@ function AppTopNav({
           top: 48,
           zIndex: 10,
           backgroundColor: 'var(--color-background-card, white)',
+          maxHeight: isScrolled ? 0 : 60,
+          overflow: 'hidden',
+          opacity: isScrolled ? 0 : 1,
+          transition:
+            'max-height 300ms ease, opacity 200ms ease, padding 300ms ease',
+          ...(isScrolled ? {padding: 0} : {}),
         }}>
         <div />
         <XDSTabList value={activeTab} onChange={setActiveTab} size="sm">
@@ -1854,8 +1999,8 @@ function AppTopNav({
             label="Filter"
             variant="ghost"
             size="sm"
-            icon={<FilterIcon />}
             isIconOnly
+            icon={<FilterIcon />}
             onClick={() => setIsFilterOpen(!isFilterOpen)}
           />
         </div>
@@ -2148,6 +2293,162 @@ function DocsView({
   const [inputsExpanded, setInputsExpanded] = useState(true);
   const [showCode, setShowCode] = useState(true);
   const [activeRightNav, setActiveRightNav] = useState('usage');
+  const [selectedComponent, setSelectedComponent] = useState<string | null>(
+    null,
+  );
+
+  const COMPONENT_CATEGORIES = [
+    {
+      label: 'Inputs',
+      items: [
+        {key: 'button', name: 'Button', desc: 'Triggers actions and events'},
+        {
+          key: 'checkbox',
+          name: 'Checkbox',
+          desc: 'Select multiple options',
+        },
+        {
+          key: 'radio',
+          name: 'Radio',
+          desc: 'Select one option from a group',
+        },
+        {
+          key: 'select',
+          name: 'Select',
+          desc: 'Choose from a dropdown list',
+        },
+        {
+          key: 'switch',
+          name: 'Switch',
+          desc: 'Toggle a setting on or off',
+        },
+        {
+          key: 'text-input',
+          name: 'TextInput',
+          desc: 'Single-line text entry',
+        },
+        {
+          key: 'slider',
+          name: 'Slider',
+          desc: 'Select a value from a range',
+        },
+      ],
+    },
+    {
+      label: 'Layout',
+      items: [
+        {
+          key: 'card',
+          name: 'Card',
+          desc: 'Container for grouped content',
+        },
+        {
+          key: 'divider',
+          name: 'Divider',
+          desc: 'Separate content sections',
+        },
+        {
+          key: 'stack',
+          name: 'Stack',
+          desc: 'Arrange items in a row or column',
+        },
+        {
+          key: 'container',
+          name: 'Container',
+          desc: 'Constrain content width',
+        },
+      ],
+    },
+    {
+      label: 'Navigation',
+      items: [
+        {
+          key: 'tab',
+          name: 'Tab',
+          desc: 'Switch between content views',
+        },
+        {
+          key: 'breadcrumb',
+          name: 'Breadcrumb',
+          desc: 'Show navigation hierarchy',
+        },
+        {
+          key: 'pagination',
+          name: 'Pagination',
+          desc: 'Navigate between pages',
+        },
+        {
+          key: 'top-nav-menu',
+          name: 'TopNavMenu',
+          desc: 'App-level navigation bar',
+        },
+      ],
+    },
+    {
+      label: 'Data Display',
+      items: [
+        {
+          key: 'table',
+          name: 'Table',
+          desc: 'Display structured data in rows',
+        },
+        {key: 'badge', name: 'Badge', desc: 'Show counts or status'},
+        {key: 'token', name: 'Token', desc: 'Display compact metadata'},
+        {
+          key: 'avatar',
+          name: 'Avatar',
+          desc: 'Represent a person or entity',
+        },
+        {
+          key: 'progress-bar',
+          name: 'ProgressBar',
+          desc: 'Show task completion',
+        },
+      ],
+    },
+    {
+      label: 'Feedback',
+      items: [
+        {
+          key: 'banner',
+          name: 'Banner',
+          desc: 'Show important messages',
+        },
+        {key: 'dialog', name: 'Dialog', desc: 'Require user action'},
+        {
+          key: 'toast',
+          name: 'Toast',
+          desc: 'Temporary notifications',
+        },
+        {
+          key: 'tooltip',
+          name: 'Tooltip',
+          desc: 'Show contextual hints',
+        },
+      ],
+    },
+    {
+      label: 'Content',
+      items: [
+        {key: 'text', name: 'Text', desc: 'Display body text'},
+        {
+          key: 'heading',
+          name: 'Heading',
+          desc: 'Section and page titles',
+        },
+        {
+          key: 'code-block',
+          name: 'CodeBlock',
+          desc: 'Display formatted code',
+        },
+        {
+          key: 'accordion',
+          name: 'Accordion',
+          desc: 'Expandable content sections',
+        },
+      ],
+    },
+  ];
 
   return (
     <div
@@ -2163,7 +2464,6 @@ function DocsView({
           width: 240,
           minWidth: 240,
           height: '100vh',
-          borderRight: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
           display: 'flex',
           flexDirection: 'column' as const,
           backgroundColor: 'var(--color-background-surface, #ffffff)',
@@ -2191,13 +2491,18 @@ function DocsView({
             label="Collapse sidebar"
             variant="ghost"
             size="sm"
-            icon={<SidebarCollapseIcon />}
             isIconOnly
+            icon={<SidebarCollapseIcon />}
           />
         </div>
 
         {/* Nav */}
         <nav style={{flex: 1, overflowY: 'auto' as const, paddingBottom: 16}}>
+          <NavItem
+            label="Overview"
+            isActive={selectedComponent === null}
+            onClick={() => setSelectedComponent(null)}
+          />
           <NavItem
             label="Getting started"
             isActive={activeNav === 'getting-started'}
@@ -2281,228 +2586,295 @@ function DocsView({
           overflowY: 'auto' as const,
           padding: '32px 40px',
         }}>
-        <div style={{maxWidth: 840}}>
-          {/* Title */}
-          <h1
-            style={{
-              fontSize: 48,
-              fontWeight: 700,
-              margin: 0,
-              letterSpacing: '-0.02em',
-              color: 'var(--color-text-primary, #0a1317)',
-              lineHeight: 1.1,
-            }}>
-            Button
-          </h1>
-
-          {/* Date line */}
-          <p
-            style={{
-              fontSize: 14,
-              color: 'var(--color-text-secondary, #6b7785)',
-              margin: '8px 0 32px',
-            }}>
-            March 30, 2026 · Updated 5:40 p.m. PST
-          </p>
-
-          {/* Live Preview Panel */}
-          <div
-            style={{
-              border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-              borderRadius: 12,
-              overflow: 'hidden',
-              marginBottom: 40,
-            }}>
-            {/* Preview Header Bar */}
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'space-between',
-                padding: '8px 12px',
-                borderBottom:
-                  '1px solid var(--color-divider, rgba(0,0,0,0.08))',
-                backgroundColor: 'var(--color-background-surface, #ffffff)',
-              }}>
-              <span
-                style={{
-                  fontSize: 13,
-                  fontWeight: 600,
-                  color: 'var(--color-text-secondary, #6b7785)',
-                }}>
-                Live preview
-              </span>
-              <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
-                <XDSButton
-                  label="Open in Craft"
-                  variant="ghost"
-                  size="sm"
-                  icon={<ExternalLinkIcon />}
-                />
-                <XDSDropdownMenu
-                  button={{
-                    label: 'Variant',
-                    variant: 'ghost',
-                    size: 'sm',
-                  }}
-                  hasChevron
-                  items={[
-                    {label: 'Primary', onClick: () => {}},
-                    {label: 'Secondary', onClick: () => {}},
-                    {label: 'Ghost', onClick: () => {}},
-                  ]}
-                />
-                <XDSDropdownMenu
-                  button={{
-                    label: 'Light',
-                    variant: 'ghost',
-                    size: 'sm',
-                  }}
-                  hasChevron
-                  items={[
-                    {label: 'Light', onClick: () => {}},
-                    {label: 'Dark', onClick: () => {}},
-                  ]}
-                />
-                <XDSButton
-                  label="Toggle code"
-                  variant={showCode ? 'secondary' : 'ghost'}
-                  size="sm"
-                  icon={<CodeIcon />}
-                  isIconOnly
-                  onClick={() => setShowCode(!showCode)}
-                />
-                <XDSButton
-                  label="Fullscreen"
-                  variant="ghost"
-                  size="sm"
-                  icon={<FullscreenIcon />}
-                  isIconOnly
-                />
+        {selectedComponent === null ? (
+          <div style={{maxWidth: 1200, margin: '0 auto'}}>
+            {/* Page header */}
+            <div style={{marginBottom: 40}}>
+              <XDSHeading level={1}>Components</XDSHeading>
+              <div style={{marginTop: 8}}>
+                <XDSText type="body" color="secondary">
+                  Build consistent, accessible UIs with XDS components.
+                </XDSText>
               </div>
             </div>
 
-            {/* Preview + Code Split */}
-            <div
-              style={{
-                display: 'flex',
-                minHeight: 280,
-              }}>
-              {/* Preview Area */}
-              <div
-                style={{
-                  flex: 1,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  backgroundColor: 'var(--color-background-body, #f5f6f7)',
-                  padding: 32,
-                }}>
-                <XDSButton
-                  label="Button"
-                  variant="primary"
-                  icon={<PlusIcon />}
-                  endContent={<XDSBadge label="New" variant="info" />}>
-                  Button
-                </XDSButton>
-              </div>
-
-              {/* Code Panel */}
-              {showCode && (
+            {/* Category sections */}
+            {COMPONENT_CATEGORIES.map(category => (
+              <div key={category.label} style={{marginBottom: 40}}>
+                <div style={{marginBottom: 16}}>
+                  <XDSHeading level={2}>{category.label}</XDSHeading>
+                </div>
                 <div
                   style={{
-                    width: 360,
-                    backgroundColor: '#282c34',
-                    padding: '20px 0',
-                    overflowX: 'auto' as const,
-                    borderLeft:
-                      '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                    display: 'grid',
+                    gridTemplateColumns:
+                      'repeat(auto-fill, minmax(260px, 1fr))',
+                    gap: 16,
                   }}>
-                  <pre
-                    style={{
-                      margin: 0,
-                      fontFamily:
-                        '"SF Mono", "Roboto Mono", "Fira Code", monospace',
-                      fontSize: 13,
-                      lineHeight: '22px',
-                    }}>
-                    {BUTTON_CODE_LINES.map((line, i) => (
-                      <div
-                        key={i}
-                        style={{
-                          display: 'flex',
-                          paddingLeft: 20,
-                          paddingRight: 20,
-                        }}>
-                        <span
-                          style={{
-                            width: 32,
-                            textAlign: 'right' as const,
-                            color: '#636d83',
-                            marginRight: 16,
-                            userSelect: 'none' as const,
-                            flexShrink: 0,
-                          }}>
-                          {i + 1}
-                        </span>
-                        <span>
-                          {line.spans.map((s, j) => (
-                            <span key={j} style={{color: s.color}}>
-                              {s.text}
-                            </span>
-                          ))}
-                        </span>
+                  {category.items.map(item => (
+                    <XDSCard
+                      key={item.key}
+                      onClick={() => {
+                        setSelectedComponent(item.key);
+                        setActiveNav(item.key);
+                      }}>
+                      {/* Card body */}
+                      <div style={{padding: '12px 16px 16px'}}>
+                        <XDSHeading level={4}>{item.name}</XDSHeading>
+                        <div style={{marginTop: 4}}>
+                          <XDSText
+                            type="supporting"
+                            color="secondary"
+                            maxLines={2}>
+                            {item.desc}
+                          </XDSText>
+                        </div>
                       </div>
-                    ))}
-                  </pre>
+                    </XDSCard>
+                  ))}
                 </div>
-              )}
+              </div>
+            ))}
+          </div>
+        ) : (
+          <>
+            <div style={{marginBottom: 16}}>
+              <XDSButton
+                label="Back to library"
+                variant="ghost"
+                size="sm"
+                icon={<ArrowLeftIcon />}
+                onClick={() => setSelectedComponent(null)}
+              />
             </div>
-          </div>
+            <div style={{maxWidth: 840}}>
+              {/* Title */}
+              <h1
+                style={{
+                  fontSize: 48,
+                  fontWeight: 700,
+                  margin: 0,
+                  letterSpacing: '-0.02em',
+                  color: 'var(--color-text-primary, #0a1317)',
+                  lineHeight: 1.1,
+                }}>
+                Button
+              </h1>
 
-          {/* Documentation Content */}
-          <div style={{marginBottom: 32}}>
-            <XDSHeading level={2}>
-              A button initiates an instantaneous action.
-            </XDSHeading>
-          </div>
+              {/* Date line */}
+              <p
+                style={{
+                  fontSize: 14,
+                  color: 'var(--color-text-secondary, #6b7785)',
+                  margin: '8px 0 32px',
+                }}>
+                March 30, 2026 · Updated 5:40 p.m. PST
+              </p>
 
-          <div style={{marginBottom: 32}}>
-            <XDSText type="body">
-              Buttons are clickable elements used to trigger actions. They
-              communicate calls to action to the user and allow users to
-              interact with pages in a variety of ways. Button labels express
-              what action will occur when the user interacts with it. Buttons
-              can contain a combination of a clear label and an icon, while
-              standalone icon buttons are reserved for recurring, universally
-              understood actions.
-            </XDSText>
-          </div>
+              {/* Live Preview Panel */}
+              <div
+                style={{
+                  border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                  backgroundColor: '#fff',
+                  borderRadius: 12,
+                  boxShadow: '0 8px 40px rgba(0,0,0,0.12)',
+                  overflow: 'hidden',
+                  marginBottom: 40,
+                }}>
+                {/* Preview Header Bar */}
+                <div
+                  style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: '8px 12px',
+                    borderBottom:
+                      '1px solid var(--color-divider, rgba(0,0,0,0.08))',
+                    backgroundColor: 'var(--color-background-surface, #ffffff)',
+                  }}>
+                  <span
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: 'var(--color-text-secondary, #6b7785)',
+                    }}>
+                    Live preview
+                  </span>
+                  <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+                    <XDSButton
+                      label="Open in Craft"
+                      variant="ghost"
+                      size="sm"
+                      isIconOnly
+                      icon={<ExternalLinkIcon />}
+                    />
+                    <XDSDropdownMenu
+                      button={{
+                        label: 'Variant',
+                        variant: 'ghost',
+                        size: 'sm',
+                      }}
+                      hasChevron
+                      items={[
+                        {label: 'Primary', onClick: () => {}},
+                        {label: 'Secondary', onClick: () => {}},
+                        {label: 'Ghost', onClick: () => {}},
+                      ]}
+                    />
+                    <XDSDropdownMenu
+                      button={{
+                        label: 'Light',
+                        variant: 'ghost',
+                        size: 'sm',
+                      }}
+                      hasChevron
+                      items={[
+                        {label: 'Light', onClick: () => {}},
+                        {label: 'Dark', onClick: () => {}},
+                      ]}
+                    />
+                    <XDSButton
+                      label="Toggle code"
+                      variant={showCode ? 'secondary' : 'ghost'}
+                      size="sm"
+                      isIconOnly
+                      icon={<CodeIcon />}
+                      onClick={() => setShowCode(!showCode)}
+                    />
+                    <XDSButton
+                      label="Fullscreen"
+                      variant="ghost"
+                      size="sm"
+                      isIconOnly
+                      icon={<FullscreenIcon />}
+                    />
+                  </div>
+                </div>
 
-          <div style={{marginBottom: 16}}>
-            <XDSHeading level={3}>When to use</XDSHeading>
-          </div>
+                {/* Preview + Code Split */}
+                <div
+                  style={{
+                    display: 'flex',
+                    minHeight: 280,
+                  }}>
+                  {/* Preview Area */}
+                  <div
+                    style={{
+                      flex: 1,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      backgroundColor: 'var(--color-background-body, #f5f6f7)',
+                      padding: 32,
+                    }}>
+                    <XDSButton
+                      label="Button"
+                      variant="primary"
+                      icon={<PlusIcon />}
+                      endContent={<XDSBadge label="New" variant="info" />}>
+                      Button
+                    </XDSButton>
+                  </div>
 
-          <ul
-            style={{
-              margin: 0,
-              padding: '0 0 0 20px',
-              color: 'var(--color-text-primary, #0a1317)',
-              fontSize: 15,
-              lineHeight: 1.7,
-            }}>
-            <li>Triggering form submissions or confirming a dialog</li>
-            <li>Navigating to a new page or view within the application</li>
-            <li>
-              Starting a new process or workflow (e.g., &quot;Create new&quot;)
-            </li>
-            <li>Toggling a UI element or performing an inline action</li>
-            <li>
-              Performing destructive actions such as deleting items — use the
-              danger variant for these
-            </li>
-          </ul>
-        </div>
+                  {/* Code Panel */}
+                  {showCode && (
+                    <div
+                      style={{
+                        width: 360,
+                        backgroundColor: '#282c34',
+                        padding: '20px 0',
+                        overflowX: 'auto' as const,
+                        borderLeft:
+                          '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                      }}>
+                      <pre
+                        style={{
+                          margin: 0,
+                          fontFamily:
+                            '"SF Mono", "Roboto Mono", "Fira Code", monospace',
+                          fontSize: 13,
+                          lineHeight: '22px',
+                        }}>
+                        {BUTTON_CODE_LINES.map((line, i) => (
+                          <div
+                            key={i}
+                            style={{
+                              display: 'flex',
+                              paddingLeft: 20,
+                              paddingRight: 20,
+                            }}>
+                            <span
+                              style={{
+                                width: 32,
+                                textAlign: 'right' as const,
+                                color: '#636d83',
+                                marginRight: 16,
+                                userSelect: 'none' as const,
+                                flexShrink: 0,
+                              }}>
+                              {i + 1}
+                            </span>
+                            <span>
+                              {line.spans.map((s, j) => (
+                                <span key={j} style={{color: s.color}}>
+                                  {s.text}
+                                </span>
+                              ))}
+                            </span>
+                          </div>
+                        ))}
+                      </pre>
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {/* Documentation Content */}
+              <div style={{marginBottom: 32}}>
+                <XDSHeading level={2}>
+                  A button initiates an instantaneous action.
+                </XDSHeading>
+              </div>
+
+              <div style={{marginBottom: 32}}>
+                <XDSText type="body">
+                  Buttons are clickable elements used to trigger actions. They
+                  communicate calls to action to the user and allow users to
+                  interact with pages in a variety of ways. Button labels
+                  express what action will occur when the user interacts with
+                  it. Buttons can contain a combination of a clear label and an
+                  icon, while standalone icon buttons are reserved for
+                  recurring, universally understood actions.
+                </XDSText>
+              </div>
+
+              <div style={{marginBottom: 16}}>
+                <XDSHeading level={3}>When to use</XDSHeading>
+              </div>
+
+              <ul
+                style={{
+                  margin: 0,
+                  padding: '0 0 0 20px',
+                  color: 'var(--color-text-primary, #0a1317)',
+                  fontSize: 15,
+                  lineHeight: 1.7,
+                }}>
+                <li>Triggering form submissions or confirming a dialog</li>
+                <li>Navigating to a new page or view within the application</li>
+                <li>
+                  Starting a new process or workflow (e.g., &quot;Create
+                  new&quot;)
+                </li>
+                <li>Toggling a UI element or performing an inline action</li>
+                <li>
+                  Performing destructive actions such as deleting items — use
+                  the danger variant for these
+                </li>
+              </ul>
+            </div>
+          </>
+        )}
       </main>
 
       {/* RIGHT SIDEBAR */}
@@ -2640,15 +3012,15 @@ function ProfileView({
             label="Search"
             variant="ghost"
             size="sm"
-            icon={<SearchIcon />}
             isIconOnly
+            icon={<SearchIcon />}
           />
           <XDSButton
             label="Profile"
             variant="ghost"
             size="sm"
-            icon={<ProfileIcon />}
             isIconOnly
+            icon={<ProfileIcon />}
           />
         </div>
       </nav>
@@ -2978,6 +3350,873 @@ function ProfileView({
 }
 
 // ---------------------------------------------------------------------------
+// TemplateFullPreview — full-page preview (like Squarespace template demos)
+// ---------------------------------------------------------------------------
+
+const PREVIEW_COLOR_PALETTES = [
+  {name: 'Warm', colors: ['#2D2926', '#D4A574', '#F5E6D3', '#FFFFFF']},
+  {name: 'Cool', colors: ['#1B2838', '#4A90D9', '#B8D4E3', '#F0F4F8']},
+  {name: 'Earth', colors: ['#3D2B1F', '#8B6914', '#C4A35A', '#F5F0E1']},
+  {name: 'Mono', colors: ['#111111', '#555555', '#AAAAAA', '#F5F5F5']},
+];
+
+const PREVIEW_FONT_PACKS = [
+  {heading: 'Georgia', paragraph: 'Helvetica Neue'},
+  {heading: 'Playfair Display', paragraph: 'Source Sans Pro'},
+  {heading: 'Montserrat', paragraph: 'Merriweather'},
+  {heading: 'Futura', paragraph: 'Garamond'},
+];
+
+function TemplateFullPreview({
+  templateName,
+  imageSrc,
+  onBack,
+  onUse,
+}: {
+  templateName: string;
+  imageSrc: string;
+  onBack: () => void;
+  onUse: () => void;
+}) {
+  const [viewMode, setViewMode] = useState<'desktop' | 'mobile'>('desktop');
+  const [selectedPalette, setSelectedPalette] = useState<string | null>(
+    PREVIEW_COLOR_PALETTES[0].name,
+  );
+  const [selectedFontPack, setSelectedFontPack] = useState<string | null>(
+    PREVIEW_FONT_PACKS[0].heading,
+  );
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => setIsVisible(true));
+    });
+  }, []);
+
+  return (
+    <div style={{display: 'flex', height: '100vh', overflow: 'hidden'}}>
+      {/* LEFT PANEL — preview area */}
+      <div
+        style={{
+          flex: 1,
+          minWidth: 0,
+          backgroundColor: '#f5f5f5',
+          display: 'flex',
+          flexDirection: 'column' as const,
+          opacity: isVisible ? 1 : 0,
+          transform: isVisible ? 'translateX(0)' : 'translateX(40px)',
+          transition:
+            'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1), transform 500ms cubic-bezier(0.16, 1, 0.3, 1)',
+        }}>
+        {/* Top bar */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr auto 1fr',
+            alignItems: 'center',
+            padding: '12px 24px',
+          }}>
+          <div style={{justifySelf: 'start'}}>
+            <XDSButton
+              label="Templates"
+              variant="ghost"
+              size="sm"
+              icon={<ArrowLeftIcon />}
+              onClick={onBack}
+            />
+          </div>
+          <XDSSegmentedControl
+            value={viewMode}
+            onChange={(v: string) => setViewMode(v as 'desktop' | 'mobile')}
+            label="Viewport size"
+            size="sm">
+            <XDSSegmentedControlItem
+              value="desktop"
+              label="Desktop"
+              isLabelHidden
+              icon={<DesktopIcon />}
+            />
+            <XDSSegmentedControlItem
+              value="mobile"
+              label="Mobile"
+              isLabelHidden
+              icon={<PhoneIcon />}
+            />
+          </XDSSegmentedControl>
+          <div />
+        </div>
+
+        {/* Browser frame with template image */}
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column' as const,
+            alignItems: 'center',
+            padding: '24px 24px 24px',
+            overflow: 'auto',
+            position: 'relative',
+          }}>
+          <div
+            style={{
+              width: viewMode === 'mobile' ? 375 : '100%',
+              maxWidth: viewMode === 'mobile' ? 375 : 1200,
+              aspectRatio: viewMode === 'mobile' ? '9 / 19.5' : '16 / 10',
+              backgroundColor: '#fff',
+              borderRadius: viewMode === 'mobile' ? 36 : 12,
+              border: viewMode === 'mobile' ? '10px solid #fff' : 'none',
+              boxShadow:
+                viewMode === 'mobile'
+                  ? '0 8px 40px rgba(0,0,0,0.15), 0 0 0 1px rgba(0,0,0,0.06)'
+                  : '0 8px 40px rgba(0,0,0,0.12)',
+              overflow: 'hidden',
+              transition:
+                'width 0.3s ease, aspect-ratio 0.3s ease, border-radius 0.3s ease',
+            }}>
+            {/* Device chrome */}
+            {viewMode === 'desktop' ? (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '10px 14px',
+                  backgroundColor: '#fff',
+                  borderBottom: '1px solid #f0f0f0',
+                }}>
+                <div style={{display: 'flex', gap: 6, alignItems: 'center'}}>
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor: '#e0e0e0',
+                    }}
+                  />
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor: '#e0e0e0',
+                    }}
+                  />
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor: '#e0e0e0',
+                    }}
+                  />
+                </div>
+              </div>
+            ) : null}
+            <img
+              src={imageSrc}
+              alt={templateName}
+              style={{
+                width: '100%',
+                display: 'block',
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* RIGHT PANEL — details sidebar */}
+      <div
+        style={{
+          width: '30%',
+          maxWidth: 380,
+          minWidth: 300,
+          backgroundColor: '#fff',
+          borderLeft: '1px solid #e0e0e0',
+          padding: 32,
+          overflowY: 'auto' as const,
+          display: 'flex',
+          flexDirection: 'column' as const,
+          opacity: isVisible ? 1 : 0,
+          transform: isVisible ? 'translateX(0)' : 'translateX(60px)',
+          transition:
+            'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms, transform 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms',
+        }}>
+        {/* Template name & description */}
+        <div>
+          <XDSHeading level={1}>{templateName}</XDSHeading>
+          <div style={{marginTop: 4}}>
+            <XDSText type="body" color="secondary">
+              Continue to customize styles, add features, and more when you
+              start a trial.
+            </XDSText>
+          </div>
+        </div>
+
+        {/* CTA button */}
+        <div style={{marginTop: 16}}>
+          <XDSButton
+            variant="primary"
+            label="Start crafting"
+            onClick={onUse}
+            size="lg"
+            style={{width: '100%'}}
+          />
+        </div>
+
+        {/* Stats buttons */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            marginTop: 16,
+            marginLeft: -8,
+            marginRight: -8,
+          }}>
+          <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+            <XDSButton
+              label="Link"
+              variant="ghost"
+              size="sm"
+              isIconOnly
+              icon={<LinkIcon />}
+            />
+            <XDSDropdownMenu
+              button={{
+                label: 'Share',
+                variant: 'ghost',
+                size: 'sm',
+                isIconOnly: true,
+                icon: <PaperPlaneIcon />,
+              }}
+              hasChevron={false}
+              menuWidth={220}
+              items={[
+                {label: 'Copy link', onClick: () => {}},
+                {label: 'Share via email', onClick: () => {}},
+              ]}
+            />
+          </div>
+          <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+            <XDSButton
+              label="1,645"
+              variant="ghost"
+              size="sm"
+              icon={<HeartIcon />}
+            />
+            <XDSButton
+              label="892"
+              variant="ghost"
+              size="sm"
+              icon={<BookmarkIcon />}
+            />
+          </div>
+        </div>
+
+        {/* Color palettes */}
+        <div style={{marginTop: 32}}>
+          <XDSHeading level={4}>Color palettes</XDSHeading>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 10,
+              marginTop: 8,
+            }}>
+            {PREVIEW_COLOR_PALETTES.map(palette => (
+              <div
+                key={palette.name}
+                onClick={() => setSelectedPalette(palette.name)}
+                style={{
+                  cursor: 'pointer',
+                  border: `2px solid ${selectedPalette === palette.name ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                  borderRadius: 14,
+                  overflow: 'hidden',
+                  transition: 'border-color 0.15s ease',
+                }}>
+                <XDSCard padding={0}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      overflow: 'hidden',
+                      height: 48,
+                    }}>
+                    {palette.colors.map((color, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          flex: 1,
+                          backgroundColor: color,
+                        }}
+                      />
+                    ))}
+                  </div>
+                </XDSCard>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Font packs */}
+        <div style={{marginTop: 32}}>
+          <XDSHeading level={4}>Font packs</XDSHeading>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 10,
+              marginTop: 8,
+            }}>
+            {PREVIEW_FONT_PACKS.map(pack => (
+              <div
+                key={pack.heading}
+                onClick={() => setSelectedFontPack(pack.heading)}
+                style={{
+                  cursor: 'pointer',
+                  border: `2px solid ${selectedFontPack === pack.heading ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                  borderRadius: 14,
+                  overflow: 'hidden',
+                  transition: 'border-color 0.15s ease',
+                }}>
+                <XDSCard padding={2}>
+                  <div style={{fontFamily: pack.heading}}>
+                    <XDSText
+                      type="body"
+                      style={{fontWeight: 600, fontSize: 16}}>
+                      Heading
+                    </XDSText>
+                  </div>
+                  <div style={{fontFamily: pack.paragraph}}>
+                    <XDSText type="supporting" color="secondary">
+                      Paragraph text
+                    </XDSText>
+                  </div>
+                </XDSCard>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Author section */}
+        <div
+          style={{
+            marginTop: 'auto',
+            display: 'flex',
+            flexDirection: 'row' as const,
+            alignItems: 'center',
+            gap: 12,
+          }}>
+          <XDSAvatar
+            size="sm"
+            style={{width: 36, height: 36}}
+            src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
+          />
+          <div>
+            <XDSText type="supporting" color="secondary">
+              Designed by
+            </XDSText>
+            <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
+              Andrea Anderson
+            </XDSText>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// TemplateCombinedView — preview + customization + chat in one view
+// ---------------------------------------------------------------------------
+
+function TemplateCombinedView({
+  templateName,
+  imageSrc,
+  onBack,
+  isGenerating: _isGenerating,
+  simulation: _simulation,
+}: {
+  templateName: string;
+  imageSrc: string;
+  onBack: () => void;
+  isGenerating: boolean;
+  simulation: BoidsSimulation;
+}) {
+  const [viewMode, setViewMode] = useState<'desktop' | 'mobile'>('desktop');
+  const [selectedPalette, setSelectedPalette] = useState<string | null>(
+    PREVIEW_COLOR_PALETTES[0].name,
+  );
+  const [selectedFontPack, setSelectedFontPack] = useState<string | null>(
+    PREVIEW_FONT_PACKS[0].heading,
+  );
+  const [isVisible, setIsVisible] = useState(false);
+  const [chatPrompt, setChatPrompt] = useState('');
+  const [rightPanelTab, setRightPanelTab] = useState('properties');
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => setIsVisible(true));
+    });
+  }, []);
+
+  return (
+    <div style={{display: 'flex', height: '100vh', overflow: 'hidden'}}>
+      {/* LEFT PANEL — preview area (~70%) */}
+      <div
+        style={{
+          flex: 7,
+          minWidth: 0,
+          backgroundColor: '#f5f5f5',
+          display: 'flex',
+          flexDirection: 'column' as const,
+          opacity: isVisible ? 1 : 0,
+          transform: isVisible ? 'translateX(0)' : 'translateX(40px)',
+          transition:
+            'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1), transform 500ms cubic-bezier(0.16, 1, 0.3, 1)',
+        }}>
+        {/* Top bar */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr auto 1fr',
+            alignItems: 'center',
+            padding: '12px 24px',
+          }}>
+          <div style={{justifySelf: 'start'}}>
+            <XDSButton
+              label="Templates"
+              variant="ghost"
+              size="sm"
+              icon={<ArrowLeftIcon />}
+              onClick={onBack}
+            />
+          </div>
+          <XDSSegmentedControl
+            value={viewMode}
+            onChange={(v: string) => setViewMode(v as 'desktop' | 'mobile')}
+            label="Viewport size"
+            size="sm">
+            <XDSSegmentedControlItem
+              value="desktop"
+              label="Desktop"
+              isLabelHidden
+              icon={<DesktopIcon />}
+            />
+            <XDSSegmentedControlItem
+              value="mobile"
+              label="Mobile"
+              isLabelHidden
+              icon={<PhoneIcon />}
+            />
+          </XDSSegmentedControl>
+          <div style={{justifySelf: 'end'}}>
+            <XDSDropdownMenu
+              button={{
+                label: 'Share',
+                variant: 'ghost',
+                size: 'sm',
+                isIconOnly: true,
+                icon: <PaperPlaneIcon />,
+              }}
+              hasChevron={false}
+              menuWidth={220}
+              items={[
+                {
+                  label: 'Copy CLI Command...',
+                  icon: TerminalIcon,
+                  onClick: () => {},
+                },
+                {type: 'divider' as const},
+                {label: 'Claude Code', icon: ClaudeIcon, onClick: () => {}},
+                {label: 'VSCode', icon: VSCodeIcon, onClick: () => {}},
+                {label: 'Cursor', icon: CursorAIIcon, onClick: () => {}},
+              ]}
+            />
+          </div>
+        </div>
+
+        {/* Browser frame with template image */}
+        <div
+          style={{
+            flex: 1,
+            display: 'flex',
+            flexDirection: 'column' as const,
+            alignItems: 'center',
+            padding: '24px 24px 24px',
+            overflow: 'auto',
+            position: 'relative',
+          }}>
+          <div
+            style={{
+              width: viewMode === 'mobile' ? 375 : '100%',
+              maxWidth: viewMode === 'mobile' ? 375 : 1200,
+              aspectRatio: viewMode === 'mobile' ? '9 / 19.5' : '16 / 10',
+              backgroundColor: '#fff',
+              borderRadius: viewMode === 'mobile' ? 36 : 12,
+              border: viewMode === 'mobile' ? '10px solid #fff' : 'none',
+              boxShadow:
+                viewMode === 'mobile'
+                  ? '0 8px 40px rgba(0,0,0,0.15), 0 0 0 1px rgba(0,0,0,0.06)'
+                  : '0 8px 40px rgba(0,0,0,0.12)',
+              overflow: 'hidden',
+              transition:
+                'width 0.3s ease, aspect-ratio 0.3s ease, border-radius 0.3s ease',
+            }}>
+            {/* Device chrome */}
+            {viewMode === 'desktop' ? (
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  padding: '10px 14px',
+                  backgroundColor: '#fff',
+                  borderBottom: '1px solid #f0f0f0',
+                }}>
+                <div style={{display: 'flex', gap: 6, alignItems: 'center'}}>
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor: '#e0e0e0',
+                    }}
+                  />
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor: '#e0e0e0',
+                    }}
+                  />
+                  <div
+                    style={{
+                      width: 10,
+                      height: 10,
+                      borderRadius: '50%',
+                      backgroundColor: '#e0e0e0',
+                    }}
+                  />
+                </div>
+              </div>
+            ) : null}
+            <img
+              src={imageSrc}
+              alt={templateName}
+              style={{
+                width: '100%',
+                display: 'block',
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* RIGHT SIDEBAR (~30%, max 380px) */}
+      <div
+        style={{
+          flex: 3,
+          maxWidth: 380,
+          minWidth: 300,
+          backgroundColor: '#fff',
+          borderLeft: '1px solid #e0e0e0',
+          display: 'flex',
+          flexDirection: 'column' as const,
+          opacity: isVisible ? 1 : 0,
+          transform: isVisible ? 'translateX(0)' : 'translateX(60px)',
+          transition:
+            'opacity 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms, transform 500ms cubic-bezier(0.16, 1, 0.3, 1) 100ms',
+        }}>
+        {/* Tab navigation */}
+        <div style={{padding: '0 32px', flexShrink: 0}}>
+          <XDSTabList
+            value={rightPanelTab}
+            onChange={setRightPanelTab}
+            size="sm"
+            hasDivider>
+            <XDSTab value="properties" label="Properties" />
+            <XDSTab value="chat" label="Chat" />
+          </XDSTabList>
+        </div>
+
+        {/* Scrollable content area */}
+        <div
+          style={{
+            flex: 1,
+            overflowY: 'auto' as const,
+            padding: '32px 32px 16px',
+            display: 'flex',
+            flexDirection: 'column' as const,
+          }}>
+          {rightPanelTab === 'properties' ? (
+            <>
+              {/* Section 1 — Template info */}
+              <div>
+                <XDSHeading level={2}>{templateName}</XDSHeading>
+                <div style={{marginTop: 4}}>
+                  <XDSText type="body" color="secondary">
+                    Continue to customize styles, add features, and more when
+                    you start a trial.
+                  </XDSText>
+                </div>
+              </div>
+
+              {/* CTA button */}
+              <div style={{marginTop: 16}}>
+                <XDSButton
+                  variant="primary"
+                  label="Start crafting"
+                  size="lg"
+                  style={{width: '100%'}}
+                />
+              </div>
+
+              {/* Stats buttons */}
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  marginTop: 16,
+                  marginLeft: -8,
+                  marginRight: -8,
+                }}>
+                <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+                  <XDSButton
+                    label="Link"
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                    icon={<LinkIcon />}
+                  />
+                  <XDSDropdownMenu
+                    button={{
+                      label: 'Share',
+                      variant: 'ghost',
+                      size: 'sm',
+                      isIconOnly: true,
+                      icon: <PaperPlaneIcon />,
+                    }}
+                    hasChevron={false}
+                    menuWidth={220}
+                    items={[
+                      {label: 'Copy link', onClick: () => {}},
+                      {label: 'Share via email', onClick: () => {}},
+                    ]}
+                  />
+                </div>
+                <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+                  <XDSButton
+                    label="1,645"
+                    variant="ghost"
+                    size="sm"
+                    icon={<HeartIcon />}
+                  />
+                  <XDSButton
+                    label="892"
+                    variant="ghost"
+                    size="sm"
+                    icon={<BookmarkIcon />}
+                  />
+                </div>
+              </div>
+
+              {/* Section 2 — Color palettes */}
+              <div style={{marginTop: 32}}>
+                <XDSHeading level={4}>Color palettes</XDSHeading>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gap: 10,
+                    marginTop: 8,
+                  }}>
+                  {PREVIEW_COLOR_PALETTES.map(palette => (
+                    <div
+                      key={palette.name}
+                      onClick={() => setSelectedPalette(palette.name)}
+                      style={{
+                        cursor: 'pointer',
+                        border: `2px solid ${selectedPalette === palette.name ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                        borderRadius: 14,
+                        overflow: 'hidden',
+                        transition: 'border-color 0.15s ease',
+                      }}>
+                      <XDSCard padding={0}>
+                        <div
+                          style={{
+                            display: 'flex',
+                            overflow: 'hidden',
+                            height: 48,
+                          }}>
+                          {palette.colors.map((color, i) => (
+                            <div
+                              key={i}
+                              style={{
+                                flex: 1,
+                                backgroundColor: color,
+                              }}
+                            />
+                          ))}
+                        </div>
+                      </XDSCard>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Section 3 — Font packs */}
+              <div style={{marginTop: 32}}>
+                <XDSHeading level={4}>Font packs</XDSHeading>
+                <div
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: '1fr 1fr',
+                    gap: 10,
+                    marginTop: 8,
+                  }}>
+                  {PREVIEW_FONT_PACKS.map(pack => (
+                    <div
+                      key={pack.heading}
+                      onClick={() => setSelectedFontPack(pack.heading)}
+                      style={{
+                        cursor: 'pointer',
+                        border: `2px solid ${selectedFontPack === pack.heading ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                        borderRadius: 14,
+                        overflow: 'hidden',
+                        transition: 'border-color 0.15s ease',
+                      }}>
+                      <XDSCard padding={2}>
+                        <div style={{fontFamily: pack.heading}}>
+                          <XDSText
+                            type="body"
+                            style={{fontWeight: 600, fontSize: 16}}>
+                            Heading
+                          </XDSText>
+                        </div>
+                        <div style={{fontFamily: pack.paragraph}}>
+                          <XDSText type="supporting" color="secondary">
+                            Paragraph text
+                          </XDSText>
+                        </div>
+                      </XDSCard>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Author section */}
+              <div
+                style={{
+                  marginTop: 'auto',
+                  display: 'flex',
+                  flexDirection: 'row' as const,
+                  alignItems: 'center',
+                  gap: 12,
+                }}>
+                <XDSAvatar
+                  size="sm"
+                  style={{width: 36, height: 36}}
+                  src="https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=80&h=80&fit=crop&crop=face"
+                />
+                <div>
+                  <XDSText type="supporting" color="secondary">
+                    Designed by
+                  </XDSText>
+                  <XDSText type="body" style={{fontWeight: 600, fontSize: 16}}>
+                    Andrea Anderson
+                  </XDSText>
+                </div>
+              </div>
+            </>
+          ) : (
+            <>
+              {/* Chat welcome message */}
+              <div
+                style={{
+                  display: 'flex',
+                  flexDirection: 'column' as const,
+                  gap: 12,
+                  flex: 1,
+                }}>
+                <div
+                  style={{
+                    backgroundColor: '#f5f5f5',
+                    borderRadius: 16,
+                    padding: '12px 16px',
+                    maxWidth: '85%',
+                  }}>
+                  <XDSText type="body">
+                    Hi! I can help you customize this template. Try asking me to
+                    change colors, layout, or content.
+                  </XDSText>
+                </div>
+              </div>
+
+              {/* AI chat composer */}
+              <div style={{marginTop: 'auto'}}>
+                <div
+                  style={{
+                    borderRadius: 16,
+                    backgroundColor: 'var(--color-background-card, white)',
+                    border: '1px solid var(--color-divider, #e0e0e0)',
+                    boxShadow:
+                      'var(--shadow-medium, 0 2px 8px rgba(0,0,0,0.08))',
+                    padding: 8,
+                    display: 'flex',
+                    flexDirection: 'column' as const,
+                    gap: 4,
+                  }}>
+                  <div
+                    style={{display: 'flex', alignItems: 'center', padding: 8}}>
+                    <input
+                      style={{
+                        flex: 1,
+                        border: 'none',
+                        outline: 'none',
+                        backgroundColor: 'transparent',
+                        fontFamily: 'inherit',
+                        fontSize: 14,
+                      }}
+                      placeholder="Describe your changes..."
+                      value={chatPrompt}
+                      onChange={e => setChatPrompt(e.target.value)}
+                    />
+                  </div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      width: '100%',
+                      paddingInlineStart: 4,
+                    }}>
+                    <XDSButton
+                      label="Attach"
+                      variant="ghost"
+                      size="sm"
+                      isIconOnly
+                      icon={<PlusIcon />}
+                    />
+                    <XDSButton
+                      label="Send"
+                      variant="primary"
+                      size="sm"
+                      isIconOnly
+                      icon={<SendIcon />}
+                      style={{borderRadius: 9999}}
+                    />
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -2991,6 +4230,7 @@ export default function DocsiteLandingTemplate() {
   const [generatingSource, setGeneratingSource] = useState<number | null>(null);
   const [chatOpen, setChatOpen] = useState(false);
   const [useTarget, setUseTarget] = useState<number | null>(null);
+  const [previewTarget, setPreviewTarget] = useState<number | null>(null);
   const [previewGenerating, setPreviewGenerating] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previewTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -3050,6 +4290,7 @@ export default function DocsiteLandingTemplate() {
   );
 
   const handleUse = useCallback((index: number) => {
+    setPreviewTarget(null);
     setUseTarget(index);
     setChatOpen(true);
   }, []);
@@ -3057,6 +4298,10 @@ export default function DocsiteLandingTemplate() {
   const handleBackFromUse = useCallback(() => {
     setUseTarget(null);
     setChatOpen(false);
+  }, []);
+
+  const handlePreview = useCallback((index: number) => {
+    setPreviewTarget(index);
   }, []);
 
   const handlePreviewSend = useCallback(() => {
@@ -3076,6 +4321,65 @@ export default function DocsiteLandingTemplate() {
   }, []);
 
   const isGenerating = generatingSource !== null;
+
+  // Combined view: only for the 2nd card (index 1, Shopping Details)
+  if ((previewTarget === 1 || useTarget === 1) && activeView === 'craft') {
+    const t = TEMPLATES[1];
+    return (
+      <TemplateCombinedView
+        templateName={t.name}
+        imageSrc={t.src}
+        onBack={handleBackFromUse}
+        isGenerating={previewGenerating}
+        simulation={simRef.current!}
+      />
+    );
+  }
+
+  // Preview flow for all other cards
+  if (previewTarget !== null && useTarget === null && activeView === 'craft') {
+    const t = TEMPLATES[previewTarget % TEMPLATES.length];
+    return (
+      <TemplateFullPreview
+        templateName={t.name}
+        imageSrc={t.src}
+        onBack={() => {
+          setPreviewTarget(null);
+        }}
+        onUse={() => {
+          setUseTarget(previewTarget);
+          setPreviewTarget(null);
+        }}
+      />
+    );
+  }
+
+  // Editor flow for cards that went through preview → customize
+  if (useTarget !== null && useTarget !== 1 && activeView === 'craft') {
+    const t = TEMPLATES[useTarget % TEMPLATES.length];
+    return (
+      <div style={{display: 'flex', height: '100vh', overflow: 'hidden'}}>
+        <div style={{width: 380, minWidth: 380}}>
+          <ChatPanel
+            isGenerating={previewGenerating}
+            onSend={handlePreviewSend}
+            activeView={activeView}
+            setActiveView={setActiveView}
+          />
+        </div>
+        <div
+          style={{flex: 1, display: 'flex', flexDirection: 'column' as const}}>
+          <TemplatePreview
+            templateName={t.name}
+            imageSrc={t.src}
+            onBack={handleBackFromUse}
+            isGenerating={previewGenerating}
+            simulation={simRef.current!}
+          />
+        </div>
+      </div>
+    );
+  }
 
   if (activeView === 'library') {
     return <DocsView activeView={activeView} setActiveView={setActiveView} />;
@@ -3209,16 +4513,7 @@ export default function DocsiteLandingTemplate() {
                     gridAutoRows: '1fr',
                   }}>
                   {TEMPLATES.map((template, i) => (
-                    <div
-                      key={`${template.name}-${i}`}
-                      style={{
-                        gridColumn:
-                          template.size === 'xlarge'
-                            ? 'span 3'
-                            : template.size === 'large'
-                              ? 'span 2'
-                              : 'span 1',
-                      }}>
+                    <div key={`${template.name}-${i}`}>
                       <TemplateCard
                         src={template.src}
                         name={template.name}
@@ -3238,6 +4533,7 @@ export default function DocsiteLandingTemplate() {
                         }
                         onMoreLikeThis={() => handleMoreLikeThis(i)}
                         onUse={() => handleUse(i)}
+                        onPreview={() => handlePreview(i)}
                         simulation={simRef.current!}
                       />
                     </div>

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -1469,7 +1469,7 @@ function TemplatePreview({
             style={{
               backgroundColor: 'var(--color-background-body, #f5f5f5)',
               borderRadius: 0,
-              padding: 0,
+              padding: '22px 22px 22px',
               margin: 0,
               display: editorView === 'preview' ? 'flex' : 'none',
               justifyContent: 'center',
@@ -3292,6 +3292,12 @@ function TemplateFullPreview({
 }) {
   const [viewMode, setViewMode] = useState<'desktop' | 'mobile'>('desktop');
   const [isVisible, setIsVisible] = useState(false);
+  const [selectedPalette, setSelectedPalette] = useState<string | null>(
+    PREVIEW_COLOR_PALETTES[0].name,
+  );
+  const [selectedFontPack, setSelectedFontPack] = useState<string | null>(
+    PREVIEW_FONT_PACKS[0].heading,
+  );
 
   useEffect(() => {
     requestAnimationFrame(() => {
@@ -3525,6 +3531,90 @@ function TemplateFullPreview({
             size="lg"
             style={{width: '100%'}}
           />
+        </div>
+
+        {/* Color palettes */}
+        <div style={{marginTop: 32}}>
+          <XDSHeading level={4}>Color palettes</XDSHeading>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 10,
+              marginTop: 8,
+            }}>
+            {PREVIEW_COLOR_PALETTES.map(palette => (
+              <div
+                key={palette.name}
+                onClick={() => setSelectedPalette(palette.name)}
+                style={{
+                  cursor: 'pointer',
+                  border: `2px solid ${selectedPalette === palette.name ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                  borderRadius: 14,
+                  overflow: 'hidden',
+                  transition: 'border-color 0.15s ease',
+                }}>
+                <XDSCard padding={0}>
+                  <div
+                    style={{
+                      display: 'flex',
+                      overflow: 'hidden',
+                      height: 48,
+                    }}>
+                    {palette.colors.map((color, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          flex: 1,
+                          backgroundColor: color,
+                        }}
+                      />
+                    ))}
+                  </div>
+                </XDSCard>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Font packs */}
+        <div style={{marginTop: 32}}>
+          <XDSHeading level={4}>Font packs</XDSHeading>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: 10,
+              marginTop: 8,
+            }}>
+            {PREVIEW_FONT_PACKS.map(pack => (
+              <div
+                key={pack.heading}
+                onClick={() => setSelectedFontPack(pack.heading)}
+                style={{
+                  cursor: 'pointer',
+                  border: `2px solid ${selectedFontPack === pack.heading ? 'var(--color-accent, #0066FF)' : 'transparent'}`,
+                  borderRadius: 14,
+                  overflow: 'hidden',
+                  transition: 'border-color 0.15s ease',
+                }}>
+                <XDSCard padding={2}>
+                  <div style={{fontFamily: pack.heading}}>
+                    <XDSText
+                      type="body"
+                      style={{fontWeight: 600, fontSize: 16}}>
+                      Heading
+                    </XDSText>
+                  </div>
+                  <div style={{fontFamily: pack.paragraph}}>
+                    <XDSText type="supporting" color="secondary">
+                      Paragraph text
+                    </XDSText>
+                  </div>
+                </XDSCard>
+              </div>
+            ))}
+          </div>
         </div>
 
         {/* Similar templates */}

--- a/apps/sandbox/src/app/(fullscreen)/pages/showcase-components/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/showcase-components/page.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import {useState} from 'react';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSButton} from '@xds/core/Button';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSAvatar} from '@xds/core/Avatar';
+import {XDSSwitch} from '@xds/core/Switch';
+
+const BAR_HEIGHTS = [28, 40, 22, 48, 34, 18, 44, 30];
+
+export default function ShowcaseComponentsPage() {
+  const [lightMode, setLightMode] = useState(true);
+  const [animations, setAnimations] = useState(true);
+  const [compact, setCompact] = useState(false);
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        backgroundColor: '#e8e0f0',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        overflow: 'hidden',
+      }}>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: '300px 280px 340px',
+          gridTemplateRows: 'auto auto',
+          gap: 18,
+        }}>
+        {/* Card 1: Hero — left column, spans 2 rows */}
+        <div
+          style={{
+            backgroundColor: '#f0eafc',
+            borderRadius: 20,
+            padding: 28,
+            boxShadow: '0 2px 20px rgba(0,0,0,0.06)',
+            gridRow: 'span 2',
+            display: 'flex',
+            flexDirection: 'column' as const,
+            justifyContent: 'space-between',
+          }}>
+          <XDSVStack gap={4}>
+            <XDSHeading level={2}>Build with XDS</XDSHeading>
+            <XDSText type="body" color="secondary">
+              Open source components for Nest and beyond
+            </XDSText>
+          </XDSVStack>
+          <XDSHStack gap={2}>
+            <XDSButton label="Get started" variant="primary" size="md" />
+            <XDSButton label="Read docs" variant="secondary" size="md" />
+          </XDSHStack>
+        </div>
+
+        {/* Card 2: Settings — middle column, row 1 */}
+        <div
+          style={{
+            backgroundColor: '#ffffff',
+            borderRadius: 20,
+            padding: 24,
+            boxShadow: '0 2px 20px rgba(0,0,0,0.06)',
+          }}>
+          <XDSVStack gap={4}>
+            <XDSText type="body" weight="bold">
+              Settings
+            </XDSText>
+            <XDSSwitch
+              label="Light mode"
+              value={lightMode}
+              onChange={setLightMode}
+            />
+            <XDSSwitch
+              label="Animations"
+              value={animations}
+              onChange={setAnimations}
+            />
+            <XDSSwitch label="Compact" value={compact} onChange={setCompact} />
+          </XDSVStack>
+        </div>
+
+        {/* Card 3: Stats — right column, row 1 */}
+        <div
+          style={{
+            backgroundColor: '#ffffff',
+            borderRadius: 20,
+            padding: 24,
+            boxShadow: '0 2px 20px rgba(0,0,0,0.06)',
+          }}>
+          <XDSVStack gap={3}>
+            <XDSHeading level={3}>Components</XDSHeading>
+            <div
+              style={{
+                fontSize: 48,
+                fontWeight: 700,
+                lineHeight: 1,
+                color: '#111',
+              }}>
+              48
+            </div>
+            <XDSText type="supporting" color="secondary">
+              +12 this quarter
+            </XDSText>
+            <XDSHStack gap={1} vAlign="end">
+              {BAR_HEIGHTS.map((h, i) => (
+                <div
+                  key={i}
+                  style={{
+                    borderRadius: 3,
+                    width: 20,
+                    height: h,
+                    backgroundColor: '#6366f1',
+                  }}
+                />
+              ))}
+            </XDSHStack>
+            <XDSText type="supporting" color="secondary">
+              Coverage → 87%
+            </XDSText>
+            <XDSText type="supporting" color="secondary">
+              Adoption → 92%
+            </XDSText>
+          </XDSVStack>
+        </div>
+
+        {/* Card 4: Badges — middle column, row 2 */}
+        <div
+          style={{
+            backgroundColor: '#ffffff',
+            borderRadius: 20,
+            padding: 24,
+            boxShadow: '0 2px 20px rgba(0,0,0,0.06)',
+          }}>
+          <XDSVStack gap={3}>
+            <XDSHStack gap={2}>
+              <XDSBadge label="v0.0.8 Released" variant="success" />
+            </XDSHStack>
+            <XDSHStack gap={2}>
+              <XDSBadge label="Open Source" variant="info" />
+            </XDSHStack>
+            <XDSHStack gap={2}>
+              <XDSBadge label="AI Ready" variant="warning" />
+            </XDSHStack>
+          </XDSVStack>
+        </div>
+
+        {/* Card 5: Avatars — right column, row 2 */}
+        <div
+          style={{
+            backgroundColor: '#ffffff',
+            borderRadius: 20,
+            padding: 24,
+            boxShadow: '0 2px 20px rgba(0,0,0,0.06)',
+          }}>
+          <XDSVStack gap={3}>
+            <XDSHStack gap={2}>
+              <XDSAvatar name="Ruby C" />
+              <XDSAvatar name="Cindy Z" />
+              <XDSAvatar name="Alex M" />
+              <XDSAvatar name="Sam K" />
+              <XDSAvatar name="+3" />
+            </XDSHStack>
+            <XDSText type="supporting" color="secondary">
+              XDS Core Team
+            </XDSText>
+          </XDSVStack>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/app/(fullscreen)/pages/showcase-header/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/showcase-header/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {XDSVStack, XDSHStack} from '@xds/core/Layout';
+import {XDSHeading, XDSText} from '@xds/core/Text';
+import {XDSBadge} from '@xds/core/Badge';
+import {XDSStatusDot} from '@xds/core/StatusDot';
+
+const styles = stylex.create({
+  container: {
+    width: '100%',
+    height: '100vh',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'var(--color-background-body, #0a0a0a)',
+    padding: 64,
+  },
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: 32,
+  },
+  titleRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 24,
+  },
+  connector: {
+    width: 80,
+    height: 2,
+    backgroundColor: 'var(--color-accent, #0066ff)',
+    opacity: 0.5,
+  },
+  badgeRow: {
+    display: 'flex',
+    gap: 12,
+  },
+  subtitle: {
+    maxWidth: 500,
+    textAlign: 'center' as const,
+  },
+  availableRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  },
+});
+
+export default function ShowcaseHeaderPage() {
+  return (
+    <div {...stylex.props(styles.container)}>
+      <div {...stylex.props(styles.content)}>
+        <div {...stylex.props(styles.badgeRow)}>
+          <XDSBadge label="Open Source" variant="info" />
+          <XDSBadge label="Nest" variant="success" />
+        </div>
+
+        <div {...stylex.props(styles.titleRow)}>
+          <XDSHeading level={1}>XDS</XDSHeading>
+          <div {...stylex.props(styles.connector)} />
+          <XDSHeading level={1}>Nest</XDSHeading>
+        </div>
+
+        <div {...stylex.props(styles.subtitle)}>
+          <XDSText type="large" color="secondary">
+            A ground-up rebuild for modern React, AI tools, and beyond
+          </XDSText>
+        </div>
+
+        <div {...stylex.props(styles.availableRow)}>
+          <XDSStatusDot variant="positive" label="Available" isPulsing />
+          <XDSText type="body" color="secondary">
+            Available now
+          </XDSText>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Image paths in the docsite page were hardcoded as `/templates/foo.png`. On GitHub Pages the app deploys under a basePath (`/sandbox/`), so images failed to load.

Prefixed all image constants with `process.env.NEXT_PUBLIC_BASE_PATH`, matching the existing pattern in `ProjectCard.tsx`.