### PR TITLE
feat(Markdown): contentAlign prop, list/table indent, blockquote border

### DIFF
--- a/apps/storybook/stories/Markdown.stories.tsx
+++ b/apps/storybook/stories/Markdown.stories.tsx
@@ -254,3 +254,77 @@ export const Streaming: Story = {
     );
   },
 };
+
+export const WithImages: Story = {
+  name: 'With Images',
+  render: () => (
+    <div style={{maxWidth: 800}}>
+      <XDSMarkdown>{`
+Here is some text before the image.
+
+![A landscape photo](https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=680&h=400&fit=crop&auto=format)
+
+Text between two images.
+
+![A tall portrait photo](https://images.unsplash.com/photo-1470071459604-3b5ec3a7fe05?w=400&h=600&fit=crop&auto=format)
+
+And here's a really wide one:
+
+![Wide panoramic shot](https://images.unsplash.com/photo-1472214103451-9374bd1c798e?w=1200&h=300&fit=crop&auto=format)
+
+Final paragraph after all images.
+`}</XDSMarkdown>
+    </div>
+  ),
+};
+
+const CONTENT_ALIGN_TEXT = `
+# Content Alignment
+
+This paragraph is constrained by \`contentWidth\`. Notice how it's narrower than the code block and table below. The alignment prop controls where this narrow prose sits within the wider container.
+
+Here's a bullet list that also respects prose width:
+- First item with some explanation text
+- Second item that wraps to show the width constraint
+- Third item for good measure
+
+\`\`\`typescript
+// Code blocks break out to full container width regardless of contentAlign
+export function calculateLayout(items: Item[], containerWidth: number): Layout {
+  const columns = Math.floor(containerWidth / COLUMN_MIN_WIDTH);
+  return { columns, gap: GRID_GAP, items: distributeItems(items, columns) };
+}
+\`\`\`
+
+Back to prose — this paragraph is aligned according to the \`contentAlign\` prop while the code block above spans the full width.
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Button | Stable | Full API |
+| CodeBlock | Stable | With collapsible |
+| Markdown | In progress | Adding alignment |
+
+Final paragraph after the table.
+`;
+
+export const ContentAlignStart: Story = {
+  name: 'Content Align: Start',
+  render: () => (
+    <div style={{maxWidth: 900, border: '1px dashed #ccc', padding: 16}}>
+      <XDSMarkdown contentWidth={580} contentAlign="start">
+        {CONTENT_ALIGN_TEXT}
+      </XDSMarkdown>
+    </div>
+  ),
+};
+
+export const ContentAlignCenter: Story = {
+  name: 'Content Align: Center',
+  render: () => (
+    <div style={{maxWidth: 900, border: '1px dashed #ccc', padding: 16}}>
+      <XDSMarkdown contentWidth={580} contentAlign="center">
+        {CONTENT_ALIGN_TEXT}
+      </XDSMarkdown>
+    </div>
+  ),
+};

--- a/packages/core/src/Markdown/XDSMarkdown.tsx
+++ b/packages/core/src/Markdown/XDSMarkdown.tsx
@@ -95,6 +95,14 @@ export interface XDSMarkdownProps {
    * ```
    */
   contentWidth?: number | string;
+  /**
+   * Alignment of prose content within the container when `contentWidth`
+   * is narrower than the available space.
+   * - 'start': left-aligned (default)
+   * - 'center': centered
+   * @default 'start'
+   */
+  contentAlign?: 'start' | 'center';
   xstyle?: StyleXStyles;
   className?: string;
   style?: React.CSSProperties;
@@ -105,12 +113,28 @@ export interface XDSMarkdownProps {
 // Styles
 // ---------------------------------------------------------------------------
 
+const ALIGN_MARGIN: Record<string, string> = {
+  start: '0',
+  center: 'auto',
+};
+
+const BLOCK_ALIGN_MARGIN: Record<string, string | null> = {
+  start: null,
+  center: 'auto',
+};
+
 const dynamicStyles = stylex.create({
   proseWidth: (maxWidth: string) => ({
     maxWidth,
   }),
+  proseAlign: (marginInline: string) => ({
+    marginInline,
+  }),
   tableMinWidth: (minWidth: string) => ({
     minWidth,
+  }),
+  blockAlign: (marginInline: string) => ({
+    marginInline,
   }),
 });
 
@@ -242,7 +266,7 @@ const styles = stylex.create({
   blockquote: {
     borderInlineStartWidth: spacingVars['--spacing-0-5'],
     borderInlineStartStyle: 'solid',
-    borderInlineStartColor: colorVars['--color-accent'],
+    borderInlineStartColor: colorVars['--color-border-emphasized'],
     paddingInlineStart: spacingVars['--spacing-4'],
     color: colorVars['--color-text-secondary'],
     marginInlineStart: 0,
@@ -252,6 +276,9 @@ const styles = stylex.create({
   tableWrapper: {
     overflowX: 'auto',
     minWidth: 0,
+  },
+  blockIndent: {
+    marginInline: `calc(-1 * ${spacingVars['--spacing-2']})`,
   },
   table: {
     borderCollapse: 'collapse',
@@ -802,6 +829,7 @@ function renderBlock(
   cursor: StreamingCursor,
   citationCtx: CitationContext | null,
   contentWidthValue: string | null,
+  contentAlign: 'start' | 'center',
 ): React.ReactNode {
   const spacing = getElementSpacing(node, density);
   const isFirst = index === 0;
@@ -827,6 +855,9 @@ function renderBlock(
             contentWidthValue != null
               ? dynamicStyles.proseWidth(contentWidthValue)
               : null,
+            contentAlign !== 'start'
+              ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
+              : null,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
           )}>
@@ -844,6 +875,9 @@ function renderBlock(
             spacing,
             contentWidthValue != null
               ? dynamicStyles.proseWidth(contentWidthValue)
+              : null,
+            contentAlign !== 'start'
+              ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
               : null,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
@@ -882,6 +916,9 @@ function renderBlock(
             contentWidthValue != null
               ? dynamicStyles.proseWidth(contentWidthValue)
               : null,
+            contentAlign !== 'start'
+              ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
+              : null,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
           )}>
@@ -896,6 +933,7 @@ function renderBlock(
               cursor,
               citationCtx,
               contentWidthValue,
+              contentAlign,
             ),
           )}
         </blockquote>
@@ -924,6 +962,7 @@ function renderBlock(
               label="Task list"
               isLabelHidden
               value={checkedValues}
+              xstyle={styles.blockIndent}
               isReadOnly
               density="compact">
               {node.items.map((item, i) => {
@@ -954,6 +993,7 @@ function renderBlock(
                         cursor,
                         citationCtx,
                         contentWidthValue,
+                        contentAlign,
                       ),
                     )}
                   </>
@@ -992,12 +1032,16 @@ function renderBlock(
             contentWidthValue != null
               ? dynamicStyles.proseWidth(contentWidthValue)
               : null,
+            contentAlign !== 'start'
+              ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
+              : null,
             isFirst && styles.noMarginBlockStart,
             isLast && styles.noMarginBlockEnd,
           )}>
           <XDSList
             listStyle={node.ordered ? 'decimal' : 'disc'}
-            density="compact">
+            density="compact"
+            xstyle={styles.blockIndent}>
             {node.items.map((item, i) => {
               const firstChild = item.children[0];
               const isInline =
@@ -1028,6 +1072,7 @@ function renderBlock(
                       cursor,
                       citationCtx,
                       contentWidthValue,
+                      contentAlign,
                     ),
                   )}
                 </>
@@ -1068,8 +1113,12 @@ function renderBlock(
           <table
             {...stylex.props(
               styles.table,
+              styles.blockIndent,
               contentWidthValue != null
                 ? dynamicStyles.tableMinWidth(contentWidthValue)
+                : null,
+              BLOCK_ALIGN_MARGIN[contentAlign] != null
+                ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign]!)
                 : null,
             )}>
             <thead>
@@ -1184,6 +1233,7 @@ export function XDSMarkdown({
   sources,
   citationStyle = 'label',
   contentWidth = 680,
+  contentAlign = 'start',
   xstyle,
   className,
   style,
@@ -1261,6 +1311,7 @@ export function XDSMarkdown({
               ? `${contentWidth}px`
               : contentWidth
             : null,
+          contentAlign,
         ),
       )}
     </div>


### PR DESCRIPTION
## Changes

### Markdown
- **`contentAlign` prop** (`'start' | 'center'`, default: `'start'`) — controls alignment of prose content within the container when `contentWidth` is narrower than available space. Center alignment uses `marginInline: auto`.
- **List/table block indent** — lists and tables get `marginInline: calc(-1 * --spacing-2)` via `xstyle` on the inner component (`XDSList`, `XDSCheckboxList`, `<table>`), keeping outer wrapper margins clean for spacing/alignment.
- **Tables center-align** when `contentAlign='center'` — table element gets `marginInline: auto` so it centers within its full-width scroll wrapper. Overflow beyond prose width is symmetric.
- **Blockquote border** — changed from `--color-accent` to `--color-border-emphasized` for subtler, more consistent appearance.
- **Split `proseWidth` dynamic style** — `maxWidth` and `marginInline` are now separate dynamic styles (`proseWidth` + `proseAlign`) so they don't conflict with `blockIndent`.

### Stories
- Added `WithImages` story (landscape, portrait, panoramic)
- Added `Content Align: Start` and `Content Align: Center` stories with 580px prose in 900px container