### PR TITLE
fix(checkbox,radio,switch): scope ancestor selectors with defineMarker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ Look for `<!-- SYNC: ... -->` comments and `SYNC:` in file headers as reminders.
 |VARS: stylex.defineVars, stylex.createTheme (require .stylex.ts files) — YES
 |LAYOUT: grid, flex+gap, aspect-ratio, overscrollBehavior, scrollbar-gutter/width — YES
 |PATTERN: dialog entry animation -> @starting-style (not useState+rAF)
-|PATTERN: parent hover child style -> stylex.when.ancestor(':hover') (not CSS nesting). Ancestor element MUST have stylex.defaultMarker() in its stylex.props() call
+|PATTERN: parent hover child style -> stylex.when.ancestor(':hover', marker) (not CSS nesting). Use stylex.defineMarker() in a .stylex.ts file for scoped markers. Ancestor element MUST have marker.marker in its stylex.props() call. NEVER use stylex.defaultMarker() for form controls (CheckboxInput, RadioList, Switch) — it leaks hover/focus-within from outer containers like Popovers. Always use a component-scoped defineMarker() instead.
 |PATTERN: hover on touch -> @media (hover: hover) guard
 |PATTERN: zebra striping -> :nth-child(even) (not index%2 JS)
 |PATTERN: container responsive -> @container (not ResizeObserver)
@@ -127,19 +127,19 @@ Look for `<!-- SYNC: ... -->` comments and `SYNC:` in file headers as reminders.
 XDS CLI|Run from repo root. Load agent docs before any component work.
 XDS="node packages/cli/bin/xds.mjs"
 BOOTSTRAP (run every branch, <500ms):
-  $XDS help                        # discover all commands and options
-  $XDS docs                        # list available doc topics
-  $XDS docs principles --dense     # design rules, anti-patterns, xstyle, tokens
-  $XDS docs tokens --dense         # spacing, color, radius, typography, shadow
-  $XDS docs theme --dense          # theme provider, light/dark, overrides
-  $XDS component --list            # all components grouped by category
-  $XDS template --list             # available page templates
+$XDS help # discover all commands and options
+$XDS docs # list available doc topics
+$XDS docs principles --dense # design rules, anti-patterns, xstyle, tokens
+$XDS docs tokens --dense # spacing, color, radius, typography, shadow
+$XDS docs theme --dense # theme provider, light/dark, overrides
+$XDS component --list # all components grouped by category
+$XDS template --list # available page templates
 ON DEMAND:
-  $XDS component <Name> --dense    # props, variants, usage, anatomy for one component
-  $XDS template <name>             # emit full page source
-  $XDS template <name> --skeleton  # layout skeleton with spatial annotations
-  $XDS swizzle <Name>              # eject component source (use --gap to report why)
-  $XDS upgrade --apply             # run version migration codemods
+$XDS component <Name> --dense # props, variants, usage, anatomy for one component
+$XDS template <name> # emit full page source
+$XDS template <name> --skeleton # layout skeleton with spatial annotations
+$XDS swizzle <Name> # eject component source (use --gap to report why)
+$XDS upgrade --apply # run version migration codemods
 OPTIONS: --detail compact|brief less output | --dense token-efficient | --zh Chinese
 RULE: always run bootstrap on each branch — docs reflect the branch's actual API
 RULE: always run $XDS component <Name> --dense before modifying a component

--- a/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/XDSCheckboxInput.tsx
@@ -40,6 +40,7 @@ import type {XDSIconType} from '../Icon';
 import type {XDSInputStatus} from '../Field/types';
 import {XDSSpinner} from '../Spinner';
 import {xdsClassName, mergeProps} from '../utils';
+import {checkboxScope} from './checkbox.markers.stylex';
 
 const styles = stylex.create({
   container: {
@@ -85,25 +86,25 @@ const styles = stylex.create({
   checkboxFocus: {
     outline: {
       default: 'none',
-      [stylex.when.ancestor(':focus-within')]:
+      [stylex.when.ancestor(':focus-within', checkboxScope)]:
         `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
       default: null,
-      [stylex.when.ancestor(':focus-within')]: '2px',
+      [stylex.when.ancestor(':focus-within', checkboxScope)]: '2px',
     },
   },
   // State-dependent colors with ancestor hover behavior
   checkboxUnchecked: {
     borderColor: {
       default: colorVars['--color-border-emphasized'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', checkboxScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-border-emphasized']}, ${colorVars['--color-tint-hover']} 20%)`,
       },
     },
     backgroundColor: {
       default: colorVars['--color-background-surface'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', checkboxScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-tint-hover']} 5%)`,
       },
     },
@@ -111,13 +112,13 @@ const styles = stylex.create({
   checkboxChecked: {
     borderColor: {
       default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', checkboxScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },
     backgroundColor: {
       default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', checkboxScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },
@@ -126,7 +127,7 @@ const styles = stylex.create({
     opacity: 0.5,
     borderColor: {
       default: colorVars['--color-border'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', checkboxScope)]: {
         '@media (hover: hover)': colorVars['--color-border'],
       },
     },
@@ -134,7 +135,7 @@ const styles = stylex.create({
   checkboxDisabledUnchecked: {
     backgroundColor: {
       default: colorVars['--color-background-muted'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', checkboxScope)]: {
         '@media (hover: hover)': colorVars['--color-background-muted'],
       },
     },
@@ -380,7 +381,7 @@ export function XDSCheckboxInput({
         {...stylex.props(
           styles.container,
           isLabelHidden && styles.containerLabelHidden,
-          !isDisabled && stylex.defaultMarker(),
+          !isDisabled && checkboxScope,
         )}>
         <div {...stylex.props(styles.checkboxWrapper, wrapperSizeStyles[size])}>
           <input

--- a/packages/core/src/CheckboxInput/checkbox.markers.stylex.ts
+++ b/packages/core/src/CheckboxInput/checkbox.markers.stylex.ts
@@ -1,0 +1,9 @@
+import * as stylex from '@stylexjs/stylex';
+
+/**
+ * Scoped marker for CheckboxInput ancestor selectors.
+ * Prevents focus-within and hover styles from leaking when
+ * checkboxes are placed inside Popovers or other containers
+ * that also have focus-within state.
+ */
+export const checkboxScope = stylex.defineMarker();

--- a/packages/core/src/RadioList/XDSRadioListItem.tsx
+++ b/packages/core/src/RadioList/XDSRadioListItem.tsx
@@ -27,6 +27,7 @@ import {
 } from '../theme/tokens.stylex';
 import {XDSRadioListContext} from './XDSRadioList';
 import {xdsClassName, mergeProps} from '../utils';
+import {radioScope} from './radio.markers.stylex';
 
 const styles = stylex.create({
   container: {
@@ -67,13 +68,13 @@ const styles = stylex.create({
   radioUnchecked: {
     borderColor: {
       default: colorVars['--color-border-emphasized'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', radioScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-border-emphasized']}, ${colorVars['--color-tint-hover']} 20%)`,
       },
     },
     backgroundColor: {
       default: colorVars['--color-background-surface'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', radioScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-tint-hover']} 5%)`,
       },
     },
@@ -81,13 +82,13 @@ const styles = stylex.create({
   radioChecked: {
     borderColor: {
       default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', radioScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },
     backgroundColor: {
       default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', radioScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },
@@ -252,7 +253,7 @@ export function XDSRadioListItem({
       data-testid={dataTestId}
       {...mergeProps(
         xdsClassName('radio-list-item'),
-        stylex.props(styles.container, !isDisabled && stylex.defaultMarker()),
+        stylex.props(styles.container, !isDisabled && radioScope),
       )}>
       <div
         {...stylex.props(

--- a/packages/core/src/RadioList/radio.markers.stylex.ts
+++ b/packages/core/src/RadioList/radio.markers.stylex.ts
@@ -1,0 +1,7 @@
+import * as stylex from '@stylexjs/stylex';
+
+/**
+ * Scoped marker for RadioListItem ancestor selectors.
+ * Prevents hover styles from leaking from parent containers.
+ */
+export const radioScope = stylex.defineMarker();

--- a/packages/core/src/Switch/XDSSwitch.tsx
+++ b/packages/core/src/Switch/XDSSwitch.tsx
@@ -36,6 +36,7 @@ import type {XDSIconType} from '../Icon';
 import type {XDSInputStatus} from '../Field/types';
 import {XDSSpinner} from '../Spinner';
 import {xdsClassName, mergeProps} from '../utils';
+import {switchScope} from './switch.markers.stylex';
 import {XDSBaseProps} from '../XDSBaseProps';
 
 // Fixed dimensions: 40px width, 24px height, 16px thumb (off), 20px thumb (on)
@@ -105,19 +106,19 @@ const styles = stylex.create({
   trackFocus: {
     outline: {
       default: 'none',
-      [stylex.when.ancestor(':focus-within')]:
+      [stylex.when.ancestor(':focus-within', switchScope)]:
         `2px solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: {
       default: null,
-      [stylex.when.ancestor(':focus-within')]: '2px',
+      [stylex.when.ancestor(':focus-within', switchScope)]: '2px',
     },
   },
   // State-dependent colors with ancestor hover behavior
   trackOff: {
     backgroundColor: {
       default: colorVars['--color-background-gray'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', switchScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-background-gray']}, ${colorVars['--color-tint-hover']} 5%)`,
       },
     },
@@ -125,7 +126,7 @@ const styles = stylex.create({
   trackOn: {
     backgroundColor: {
       default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', switchScope)]: {
         '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
       },
     },
@@ -433,8 +434,9 @@ export function XDSSwitch({
         {...stylex.props(
           styles.container,
           labelSpacing === 'spread' && styles.containerSpread,
-          !isDisabled && stylex.defaultMarker(),
+          !isDisabled && switchScope,
         )}>
+        {' '}
         {labelPosition === 'start' ? (
           <>
             {labelElement}

--- a/packages/core/src/Switch/switch.markers.stylex.ts
+++ b/packages/core/src/Switch/switch.markers.stylex.ts
@@ -1,0 +1,7 @@
+import * as stylex from '@stylexjs/stylex';
+
+/**
+ * Scoped marker for Switch ancestor selectors.
+ * Prevents focus-within and hover styles from leaking from parent containers.
+ */
+export const switchScope = stylex.defineMarker();


### PR DESCRIPTION
## Summary

Fixes all checkboxes/radios/switches inside a Popover showing focus and hover states simultaneously when the popover opens or is hovered.

**Root cause:** These components used `stylex.defaultMarker()` with `stylex.when.ancestor(':focus-within')` / `stylex.when.ancestor(':hover')`. When placed inside a Popover (or any container with `:focus-within`), the ancestor selector matched the *outer* container instead of just the component's own row — causing all instances to light up at once.

**Fix:** Replace `stylex.defaultMarker()` with `stylex.defineMarker()` in dedicated `.stylex.ts` files. Each component gets a scoped marker so ancestor selectors only match its own container.

## Components Fixed

| Component | Handlers Scoped |
|-----------|----------------|
| **XDSCheckboxInput** | `:hover`, `:focus-within` |
| **XDSRadioListItem** | `:hover` |
| **XDSSwitch** | `:hover`, `:focus-within` |

## Pattern

```ts
// checkbox.markers.stylex.ts
export const checkboxScope = stylex.defineMarker();

// XDSCheckboxInput.tsx
// On the container:
!isDisabled && checkboxScope.marker

// In styles:
[stylex.when.ancestor(':hover', checkboxScope)]: { ... }
```

Also updates CLAUDE.md with guidance: never use `defaultMarker()` for form controls — always use a component-scoped `defineMarker()`.

Closes #1258
