### PR TITLE
chore: bump StyleX 0.17.4 → 0.18.2

### DIFF
--- a/apps/example-nextjs/package.json
+++ b/apps/example-nextjs/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.17.4",
+    "@stylexjs/stylex": "^0.18.2",
     "@xds/core": "*",
     "@xds/theme-default": "*",
     "next": "^15.5.15",
@@ -18,8 +18,8 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.0",
     "@babel/preset-typescript": "^7.25.0",
-    "@stylexjs/babel-plugin": "^0.17.4",
-    "@stylexjs/postcss-plugin": "^0.17.4",
+    "@stylexjs/babel-plugin": "^0.18.2",
+    "@stylexjs/postcss-plugin": "^0.18.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "typescript": "^5.7.0"

--- a/apps/example-vite/package.json
+++ b/apps/example-vite/package.json
@@ -13,7 +13,8 @@
     "@xds/core": "*",
     "@xds/theme-default": "*",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "unplugin": "^2.3.11"
   },
   "devDependencies": {
     "@stylexjs/unplugin": "^0.18.2",

--- a/apps/example-vite/package.json
+++ b/apps/example-vite/package.json
@@ -9,14 +9,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.17.4",
+    "@stylexjs/stylex": "^0.18.2",
     "@xds/core": "*",
     "@xds/theme-default": "*",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   },
   "devDependencies": {
-    "@stylexjs/unplugin": "^0.17.4",
+    "@stylexjs/unplugin": "^0.18.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.0",

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@stylexjs/stylex": "^0.17.4",
+    "@stylexjs/stylex": "^0.18.2",
     "@xds/cli": "*",
     "@xds/core": "*",
     "@xds/lab": "*",
@@ -31,8 +31,8 @@
   "devDependencies": {
     "@babel/preset-react": "^7.25.0",
     "@babel/preset-typescript": "^7.25.0",
-    "@stylexjs/babel-plugin": "^0.17.4",
-    "@stylexjs/postcss-plugin": "^0.17.4",
+    "@stylexjs/babel-plugin": "^0.18.2",
+    "@stylexjs/postcss-plugin": "^0.18.2",
     "@types/node": "^22.0.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -22,7 +22,7 @@
     "@storybook/react": "^8.6.17",
     "@storybook/react-vite": "^8.6.17",
     "@storybook/test": "^8.6.17",
-    "@stylexjs/unplugin": "^0.17.4",
+    "@stylexjs/unplugin": "^0.18.2",
     "storybook": "^8.6.17"
   }
 }

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -8,11 +8,12 @@
   },
   "dependencies": {
     "@xds/core": "*",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
     "@xds/theme-default": "*",
     "@xds/theme-neutral": "*",
-    "@xds/theme-syntax": "*"
+    "@xds/theme-syntax": "*",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "unplugin": "^2.3.11"
   },
   "devDependencies": {
     "@storybook/addon-essentials": "^8.6.17",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -510,11 +510,11 @@
     "@babel/core": "^7.28.5",
     "@babel/preset-react": "^7.28.5",
     "@babel/preset-typescript": "^7.28.5",
-    "@stylexjs/babel-plugin": "^0.17.4",
+    "@stylexjs/babel-plugin": "^0.18.2",
     "@stylexjs/esbuild-plugin": "^0.11.1",
     "@testing-library/jest-dom": "^6.6.0",
     "@testing-library/react": "^16.0.0",
     "esbuild-plugin-babel": "^0.2.3",
-    "@stylexjs/stylex": "^0.17.4"
+    "@stylexjs/stylex": "^0.18.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5660,6 +5660,16 @@ unplugin@^1.3.1:
     acorn "^8.14.0"
     webpack-virtual-modules "^0.6.2"
 
+unplugin@^2.3.11:
+  version "2.3.11"
+  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-2.3.11.tgz#411e020dd2ba90e2fbe1e7bd63a5a399e6ee3b54"
+  integrity sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==
+  dependencies:
+    "@jridgewell/remapping" "^2.3.5"
+    acorn "^8.15.0"
+    picomatch "^4.0.3"
+    webpack-virtual-modules "^0.6.2"
+
 update-browserslist-db@^1.2.0:
   version "1.2.3"
   resolved "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2085,18 +2085,18 @@
     "@stylexjs/shared" "0.11.1"
     "@stylexjs/stylex" "0.11.1"
 
-"@stylexjs/babel-plugin@0.17.5", "@stylexjs/babel-plugin@^0.17.4":
-  version "0.17.5"
-  resolved "https://registry.npmjs.org/@stylexjs/babel-plugin/-/babel-plugin-0.17.5.tgz"
-  integrity sha512-BT+066uVkzcJSLtkGaEmFLEWxs3uC08wuOxeC8AEVyfWibz45/e1OVjDgIf1+8my0XiJXSLAlwjmzkf1/unjNA==
+"@stylexjs/babel-plugin@0.18.2", "@stylexjs/babel-plugin@^0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@stylexjs/babel-plugin/-/babel-plugin-0.18.2.tgz#b6a65985d677818ecff699073b81413fabfb5ff6"
+  integrity sha512-vmdk1DGiMBuz4hKjXh3KiM+E065OE115GZTNrK9icak0wYAgzpF6K/hExBSwS+yjiH/c3p+6tfN7G9UJPet1gA==
   dependencies:
     "@babel/core" "^7.26.8"
     "@babel/helper-module-imports" "^7.25.9"
     "@babel/traverse" "^7.26.8"
     "@babel/types" "^7.26.8"
     "@dual-bundle/import-meta-resolve" "^4.1.0"
-    "@stylexjs/shared" "0.17.5"
-    "@stylexjs/stylex" "0.17.5"
+    "@stylexjs/shared" "0.18.2"
+    "@stylexjs/stylex" "0.18.2"
     postcss-value-parser "^4.1.0"
 
 "@stylexjs/esbuild-plugin@^0.11.1":
@@ -2113,13 +2113,13 @@
     babel-plugin-syntax-hermes-parser "^0.26.0"
     esbuild "^0.24.0"
 
-"@stylexjs/postcss-plugin@^0.17.4":
-  version "0.17.5"
-  resolved "https://registry.npmjs.org/@stylexjs/postcss-plugin/-/postcss-plugin-0.17.5.tgz"
-  integrity sha512-GeveZXN8aDrXTSRpDM0SvCjmmY7WCfoel+lWcsf47QcJvjz5auGmh3a9LhIFLpwmAgpsVr20RyB8yxX93NaKow==
+"@stylexjs/postcss-plugin@^0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@stylexjs/postcss-plugin/-/postcss-plugin-0.18.2.tgz#cdd373cd322ec43f69106389f670bf1f506b0261"
+  integrity sha512-i39zaNnFK0loMM0OX7xqW9yfKle0TqtOX7qA8zUFHb3Wxbq7/NOYSZq08x657Hjb0a1cWqS3TsK3EylGnrj3xA==
   dependencies:
     "@babel/core" "^7.26.8"
-    "@stylexjs/babel-plugin" "0.17.5"
+    "@stylexjs/babel-plugin" "0.18.2"
     fast-glob "^3.3.2"
     glob-parent "^6.0.2"
     is-glob "^4.0.3"
@@ -2132,10 +2132,10 @@
   dependencies:
     postcss-value-parser "^4.1.0"
 
-"@stylexjs/shared@0.17.5":
-  version "0.17.5"
-  resolved "https://registry.npmjs.org/@stylexjs/shared/-/shared-0.17.5.tgz"
-  integrity sha512-Q8HwrvfOl2SBKzjb3+HgaH1mUGBqFcWIwgKvZMyhkXIqhmGMrWA3vdTxtzEpuYiFH7AOPuzebpOJn/3rIqK7iA==
+"@stylexjs/shared@0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@stylexjs/shared/-/shared-0.18.2.tgz#16a32b17a5ffc1b55095bbf0de8f421f525e934f"
+  integrity sha512-CnHG0MWwtQt9DwP0ogl6C19fnKJtMcJq37vTyrfhlz9GOycdDh28Yza0flKikGUF5lQOmknatopwi1Y9XTxTzQ==
 
 "@stylexjs/stylex@0.11.1":
   version "0.11.1"
@@ -2146,25 +2146,25 @@
     invariant "^2.2.4"
     styleq "0.2.1"
 
-"@stylexjs/stylex@0.17.5", "@stylexjs/stylex@^0.17.4":
-  version "0.17.5"
-  resolved "https://registry.npmjs.org/@stylexjs/stylex/-/stylex-0.17.5.tgz"
-  integrity sha512-mV+mIXqj1AsnGHFj/hyno7YOBjBpgRzvD00iif0w/LExeN8mwNb2yTfnTHkx62fLaM7vUtoIEcO/bFHqmiOtpw==
+"@stylexjs/stylex@0.18.2", "@stylexjs/stylex@^0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@stylexjs/stylex/-/stylex-0.18.2.tgz#e95b71394ab690c5408436b038125cb5d9db56df"
+  integrity sha512-wXYe9MBlxE9Lz26KbbM9vwKy746sJWe6NdhY+573KMjcEbrswjFU+121b7TeBAc8gcvC5DOUzDOlBrT3N2xsxA==
   dependencies:
     css-mediaquery "^0.1.2"
     invariant "^2.2.4"
     styleq "0.2.1"
 
-"@stylexjs/unplugin@^0.17.4":
-  version "0.17.5"
-  resolved "https://registry.npmjs.org/@stylexjs/unplugin/-/unplugin-0.17.5.tgz"
-  integrity sha512-ygKFNN3vUeZsmH++fGYm/XDecuNZzqTzCsU4XMiKqUpWwCb7YTJitptLASTk7Qe+dz1bpwmdWfFDUR55Us7WfA==
+"@stylexjs/unplugin@^0.18.2":
+  version "0.18.2"
+  resolved "https://registry.yarnpkg.com/@stylexjs/unplugin/-/unplugin-0.18.2.tgz#5fae22d2c705319a60f4f4d868429e0140eebc87"
+  integrity sha512-OWKckAAhcaBc2/K+3AGMNYgxz36Rjs7UCkE5sJ+NVtECrgoZz3muEoP7fJfM3vnXpawGzerkHoMVMZsJPaC0fA==
   dependencies:
     "@babel/core" "^7.26.8"
     "@babel/plugin-syntax-flow" "^7.26.0"
     "@babel/plugin-syntax-jsx" "^7.25.9"
     "@babel/plugin-syntax-typescript" "^7.25.9"
-    "@stylexjs/babel-plugin" "0.17.5"
+    "@stylexjs/babel-plugin" "0.18.2"
     browserslist "^4.24.0"
     lightningcss "^1.29.1"
 


### PR DESCRIPTION
## What

Bumps all `@stylexjs` packages from 0.17.4 to 0.18.2.

## Why

`stylex.defineMarker()` in 0.17.x returns a `unique symbol` type per call site, which isn't assignable to `CompiledStyles` when passed to `stylex.props()`. This required `as any` casts for scoped markers (#1258 pattern).

0.18.x changes to a shared declared symbol (`typeof StyleXMarkerTag`), fixing the type compatibility.

## Packages bumped

| Package | From | To |
|---------|------|----|
| `@stylexjs/stylex` | 0.17.4 | 0.18.2 |
| `@stylexjs/babel-plugin` | 0.17.4 | 0.18.2 |
| `@stylexjs/postcss-plugin` | 0.17.4 | 0.18.2 |
| `@stylexjs/unplugin` | 0.17.4 | 0.18.2 |
| `@stylexjs/esbuild-plugin` | 0.11.1 | unchanged |

## Verification

- Core package builds clean with zero TS errors
- No API changes required