### PR TITLE
docs: standardize changelog with codemod upgrade instructions

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,76 @@
 # @xds/cli
 
+## 0.0.12
+
+### Codemods
+
+- `add-is-icon-only` — Add `isIconOnly` to icon-only Button and ToggleButton usages (#1257)
+
+### Upgrade
+
+```sh
+npx xds upgrade --apply --to 0.0.12
+```
+
+## 0.0.10
+
+### Codemods
+
+- `remove-size-props` — Remove `size` prop from StatusDot and ProgressBar (#966)
+
+### Upgrade
+
+```sh
+npx xds upgrade --apply --to 0.0.10
+```
+
+## 0.0.8
+
+### New Features
+
+- CLI: tsx parser for .ts files
+- Update hints in postAction hook
+
+### Codemods
+
+- `rename-endslot-to-endcontent` — Button `endSlot` → `endContent` (#895)
+- `migrate-token-renames` — Token name migration to v0.0.8 convention
+
+### Upgrade
+
+```sh
+npx xds upgrade --apply --to 0.0.8
+```
+
+## 0.0.7
+
+### Codemods
+
+- `rename-banner-variant-to-container` — Banner `variant` → `container` (#814)
+
+### Upgrade
+
+```sh
+npx xds upgrade --apply --to 0.0.7
+```
+
+## 0.0.6
+
+### Codemods
+
+- `migrate-token-names` — Design token renames per naming audit
+- `migrate-shadow-tokens` — Elevation → shadow semantic naming
+- `migrate-collapse-to-collapsible` — XDSCollapse → XDSCollapsible
+- `migrate-radius-tokens` — Semantic radius → numeric scale
+- `migrate-skeleton-radius` — Skeleton radius prop → numeric scale
+- `migrate-badge-children-to-label` — Badge children → label prop
+
+### Upgrade
+
+```sh
+npx xds upgrade --apply --to 0.0.6
+```
+
 ## 0.0.5
 
 ### New Features
@@ -8,11 +79,7 @@
 - `--detail` and `--lang` flags for typed `.doc.mjs` output (#636)
 - Fold `agent-docs` into `init` with `--features` flag (#639)
 
-### Codemods
-
-- 5 new codemods for v0.0.5: `migrate-token-names`, `migrate-shadow-tokens`, `migrate-collapse-to-collapsible`, `migrate-radius-tokens`, `migrate-skeleton-radius`
-
-**Upgrade consumers:** `npx xds upgrade --apply`
+> **Note:** Codemods for v0.0.5 breaking changes are registered under v0.0.6. Use `--to 0.0.6`.
 
 ## 0.0.4
 
@@ -35,10 +102,32 @@
 
 ## 0.0.2
 
-### Features
+### New Features
 
 - `xds upgrade` command with codemod support
 - `xds theme build` (formerly `build-theme`)
+
+### Codemods
+
+12 codemods for the v0.0.2 breaking changes:
+- `rename-selector-items-to-options` — Selector `items` → `options`
+- `unify-visibility-to-onOpenChange` — Visibility callbacks → `onOpenChange`
+- `unify-uncontrolled-to-defaultX` — Uncontrolled state → defaultX pattern
+- `rename-banner-endButton-to-endContent` — Banner `endButton` → `endContent`
+- `rename-form-tooltip-startIcon` — Form `tooltip` → `labelTooltip`, `startIcon` → `labelIcon`
+- `rename-isShown-to-isOpen` — Dialog/Popover `isShown` → `isOpen`
+- `rename-topnav-title-to-heading` — TopNav title → heading
+- `rename-sidenav-header-to-heading` — SideNav header → heading
+- `migrate-useXDSIcon-to-getIcon` — `useXDSIcon()` → `getIcon()`
+- `migrate-gap-to-numeric` — String gap tokens → numeric
+- `migrate-isFullBleed-to-padding` — `isFullBleed` → `padding={0}`
+- `migrate-badge-dot-to-statusdot` — Badge dot → StatusDot
+
+### Upgrade
+
+```sh
+npx xds upgrade --apply --to 0.0.2
+```
 
 ## 0.0.1
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,15 +1,164 @@
 # @xds/core
 
-## 0.0.5
+## 0.0.12
 
-### Breaking Changes (codemods included)
+### Breaking Changes
 
-- Rename design tokens per naming audit (`migrate-token-names`)
-- Rename elevation tokens to `shadow-base`/`shadow-menu`/`shadow-hover`/`shadow-dialog` + `insetshadow-border-*` (`migrate-shadow-tokens`)
-- Rename `XDSCollapse` → `XDSCollapsible` (`migrate-collapse-to-collapsible`)
-- Dynamic radius tokens — numeric scale with `radiusScale` config (`migrate-radius-tokens`, `migrate-skeleton-radius`)
+- **Button `isIconOnly` required for icon-only mode** — `XDSButton` and `XDSToggleButton` now require explicit `isIconOnly` for icon-only rendering. (#1257)
 
-**Upgrade:** `npx xds upgrade --apply`
+### New Features
+
+- **XDSThumbnail** component (#1255)
+- **XDSChatLayout** with fixed composer dock and container queries (#1249)
+- **XDSToast** notification system (#1194)
+- **Chat reasoning components** — Reasoning, ToolCall, ToolCallGroup (#1192)
+- **useXDSImperativeDialog** — show/hide without state management (#1239)
+- **Theme syntax system** with 11 community presets + `defineTheme({ syntax })` (#1217, #1219)
+- **XDSMediaTheme** for inverted surface theming (#1211)
+- **Card background color variants** (#1213)
+- **Daily theme** with Figtree font, Lucide icons (#1201)
+- **SideNav/TopNav menu popover and heading variants** (#1272)
+- **TextInput `onEnter` prop** for consistency with NumberInput (#1223)
+- **Button `isPressed` prop** for toggle state (#1202)
+- **CLI programmatic API** — `@xds/cli/api` (#1208)
+- **ChatComposer `headerActions` + `headerContext`** replacing `contextToolbar` (#1242)
+- **Chat trigger menu system** for ComposerInput (#1193)
+
+### Fixes
+
+- Dialog: reset inherited edge signals, prevent ghost button margin shift (#1237)
+- CodeBlock: syntax highlighting missing on scroll + perf improvements (#1221)
+- Chat: harden bubbles, scroll button, drawer animation, status (#1245)
+- Chat: use `color-neutral` for message bubble background (#1271)
+- SegmentedControl: consistent border-radius for sm size (#1206)
+- Omit `children` from XDSBaseProps — require explicit opt-in (#1246)
+- Theme: ship built theme modules to prevent double CSS injection (#1247)
+- Theme: support bare state keys in `parseStyleKey` (#1233)
+- ProgressBar/Section: migrate to XDSBaseProps, fix RadioList double-apply (#1253)
+- CodeBlock: use semantic `--text-code-size` token for md size (#1273)
+- Input: forward native event handlers via `...rest` spread (#1259, #1291)
+
+### Upgrade
+
+Codemods are available for all breaking changes in this release:
+
+```sh
+npx xds upgrade --apply --to 0.0.12
+```
+
+Preview changes first (dry run): `npx xds upgrade --to 0.0.12`
+Run a specific codemod: `npx xds upgrade --apply --codemod add-is-icon-only`
+List all available codemods: `npx xds upgrade --list`
+
+## 0.0.11
+
+### Patch Changes
+
+- Version bump and publish infrastructure fixes
+- No breaking changes
+
+## 0.0.10
+
+### Breaking Changes
+
+- **StatusDot and ProgressBar single size** — Both components now have a single fixed size (8px). The `size` prop has been removed. (#966)
+
+### New Features
+
+- **Layout `defaultHasDividers`** — Container-controlled dividers via context (#969)
+- **Button `href` support** — Link-styled buttons (#935)
+
+### Fixes
+
+- Dialog: propagate `maxHeight` to layout via `--container-max-height` (#965)
+- Popover: embed surface styles in `useXDSPopover` hook (#964)
+- Dialog: lock body scroll on iOS Safari (#948)
+- Dialog: scrollable content, mobile visibility, container styles (#942)
+- Menu components: icon sizing, item density, section headings (#946)
+- Avatar status dot sizes + icon non-semantic colors (#944)
+- Table: truncate overflowing cell text with ellipsis (#933)
+- AppShell: default variant to "elevated" (#934)
+- DialogHeader: re-add capsize with visual adjustment (#956)
+- Hardening sweep (#968)
+
+### Upgrade
+
+Codemods are available for all breaking changes in this release:
+
+```sh
+npx xds upgrade --apply --to 0.0.10
+```
+
+Preview changes first (dry run): `npx xds upgrade --to 0.0.10`
+Run a specific codemod: `npx xds upgrade --apply --codemod remove-size-props`
+List all available codemods: `npx xds upgrade --list`
+
+## 0.0.8
+
+### Breaking Changes
+
+- **Button `endSlot` → `endContent`** — Renamed on XDSButton and forwarded object literals (e.g. XDSDropdownMenu button prop). (#895)
+- **Token renames** — Intermediate token names from v0.0.6 renamed to final v0.0.8 convention per the token spec.
+
+### Fixes
+
+- Align cyan, pink, and yellow token colors with WWW (#907)
+- Dialog hardening (#775)
+- ListItem: support ReactNode for description, fix whiteSpace nowrap breaking line-clamp (#896)
+- Table: default minWidth for proportional columns (#891)
+- Button: prevent text wrap, add ellipsis truncation (#892)
+- ListItem: fixed inline padding (#887)
+- Slider hardening — style clobber, a11y, pointer handling (#882)
+- TextArea hardening — counter a11y, soft maxLength, disabled states (#849)
+- Field hardening — a11y, auto-IDs, disabled styles (#848)
+- Calendar hardening — a11y, keyboard nav, date constraints (#837)
+- CheckboxInput, Button, Switch hardening (#765, #768, #769)
+- DateInput, FormLayout hardening (#771, #772)
+- CSS layer ordering for dist path theming (#806)
+- Rename `@layer xds-reset` to `@layer reset` (#833)
+- Tokenizer truncation behavior (#880)
+- Correct neutral gray token semantics across components (#852)
+- Formalize container padding tokens, prevent internal var access (#847)
+
+### Upgrade
+
+Codemods are available for all breaking changes in this release:
+
+```sh
+npx xds upgrade --apply --to 0.0.8
+```
+
+Preview changes first (dry run): `npx xds upgrade --to 0.0.8`
+Run a specific codemod: `npx xds upgrade --apply --codemod rename-endslot-to-endcontent`
+List all available codemods: `npx xds upgrade --list`
+
+## 0.0.7
+
+### Breaking Changes
+
+- **Banner `variant` → `container`** — Renamed the `variant` prop on XDSBanner to `container`. Type references `XDSBannerVariant` → `XDSBannerContainer` and `XDSBannerVariantMap` → `XDSBannerContainerMap`. (#814)
+
+### Upgrade
+
+Codemods are available for all breaking changes in this release:
+
+```sh
+npx xds upgrade --apply --to 0.0.7
+```
+
+Preview changes first (dry run): `npx xds upgrade --to 0.0.7`
+Run a specific codemod: `npx xds upgrade --apply --codemod rename-banner-variant-to-container`
+List all available codemods: `npx xds upgrade --list`
+
+## 0.0.6
+
+### Breaking Changes
+
+- **Token renames** — Design tokens renamed per naming audit: `positive` → `success`, `negative` → `error`, `divider` → `border`, etc. (`migrate-token-names`)
+- **Shadow tokens** — Elevation tokens renamed to `shadow-base`/`shadow-menu`/`shadow-hover`/`shadow-dialog` + `insetshadow-border-*` (`migrate-shadow-tokens`)
+- **`XDSCollapse` → `XDSCollapsible`** — Component and prop rename (`migrate-collapse-to-collapsible`)
+- **Radius tokens** — Semantic radius tokens renamed to numeric scale (`migrate-radius-tokens`, `migrate-skeleton-radius`)
+- **Badge `children` → `label`** — Content passed as children now uses the `label` prop (`migrate-badge-children-to-label`)
 
 ### New Features
 
@@ -26,16 +175,34 @@
 
 ### Fixes
 
-- CheckboxInput & Switch focus rings + indeterminate aria
-- MegaMenu uniform border radius, TopNav menu positioning/keyboard/focus trapping
-- Popover background transparency, DropdownMenu elevation tokens
-- Badge hardcoded height → spacing token
-- Collapsible hardcoded fontSize/transition → tokens
-- AppShell hardcoded spacing → spacing tokens
+- Badge: hardcoded height → spacing token; add `label` prop for API consistency (#709)
+- CheckboxInput & Switch: focus rings + indeterminate aria (#723)
+- Kbd: platform detection for mod key (#722)
+- MegaMenu: uniform border radius, TopNav menu positioning/keyboard/focus trapping
+- Popover: background transparency, DropdownMenu elevation tokens
+- Collapsible: hardcoded fontSize/transition → tokens
+- AppShell: hardcoded spacing → spacing tokens
 - Dist CSS layer renamed from `@layer xds` to `@layer xds.core.base`
 - `color-scheme` in reset.css for lightningcss light-dark() compatibility
 - Sync package.json exports (NavItem, remove stale typography.css)
 - Type-scale: use Math.round for 4px grid snapping in computeLeading
+
+### Upgrade
+
+Codemods are available for all breaking changes in this release:
+
+```sh
+npx xds upgrade --apply --to 0.0.6
+```
+
+Preview changes first (dry run): `npx xds upgrade --to 0.0.6`
+List all available codemods: `npx xds upgrade --list`
+
+## 0.0.5
+
+> **Note:** v0.0.5 was the published version. Codemods for this release are registered under v0.0.6 in the CLI. Use `--to 0.0.6` to run them.
+
+See 0.0.6 above for breaking changes and upgrade instructions.
 
 ## 0.0.4
 
@@ -75,17 +242,41 @@
 
 ## 0.0.2
 
-### Breaking Changes (codemods included)
+### Breaking Changes
 
 - CSS-based theming replaces StyleX theme system — `defineTheme()` API
 - `className` and `style` props on all components
 - Numeric spacing scale for `padding` and `gap`
 - RSC-compatible icon registry (`registerIcons`/`getIcon`)
 - React 19 ref prop migration
-- Renames: TopNavTitle→TopNavHeading, SideNavHeader→SideNavHeading, useXDSIcon→getIcon
+- Renames: TopNavTitle → TopNavHeading, SideNavHeader → SideNavHeading, useXDSIcon → getIcon
 - `gap="space4"` → `gap={4}`, `isFullBleed` → `padding={0}`
+- Badge dot → StatusDot
 
-**Codemod:** `npx xds upgrade --apply`
+### Upgrade
+
+Codemods are available for all breaking changes in this release:
+
+```sh
+npx xds upgrade --apply --to 0.0.2
+```
+
+Preview changes first (dry run): `npx xds upgrade --to 0.0.2`
+List all available codemods: `npx xds upgrade --list`
+
+12 codemods included:
+- `rename-selector-items-to-options` — Selector `items` → `options`
+- `unify-visibility-to-onOpenChange` — onHide/onClose/onShow/onToggle → `onOpenChange`
+- `unify-uncontrolled-to-defaultX` — initialIsOpen/initialIsExpanded → defaultX
+- `rename-banner-endButton-to-endContent` — Banner `endButton` → `endContent`
+- `rename-form-tooltip-startIcon` — Form `tooltip` → `labelTooltip`, `startIcon` → `labelIcon`
+- `rename-isShown-to-isOpen` — Dialog/Popover `isShown` → `isOpen`
+- `rename-topnav-title-to-heading` — TopNav `title` → `heading`, TopNavTitle → TopNavHeading
+- `rename-sidenav-header-to-heading` — SideNav header → heading, SideNavHeader → SideNavHeading
+- `migrate-useXDSIcon-to-getIcon` — `useXDSIcon()` → `getIcon()`
+- `migrate-gap-to-numeric` — `gap="space4"` → `gap={4}`
+- `migrate-isFullBleed-to-padding` — `isFullBleed` → `padding={0}`
+- `migrate-badge-dot-to-statusdot` — Badge `shape="dot"` → StatusDot
 
 ## 0.0.1
 


### PR DESCRIPTION
Every version with breaking changes now has a consistent **Upgrade** section showing how to run codemods via the CLI.

## What changed

- **Backfilled missing changelog entries** for v0.0.6, v0.0.7, v0.0.8, v0.0.10, v0.0.11, and v0.0.12
- **Standardized format** — every breaking-change version now has:
  - Breaking changes with codemod names inline
  - An `### Upgrade` section with the exact CLI command
  - Dry-run, specific-codemod, and `--list` examples
- **CLI changelog** mirrors with a `### Codemods` section per version listing each transform

## Template for future releases

```markdown
## X.X.X

### Breaking Changes

- **Component \`oldProp\` → \`newProp\`** — Description. (#PR)

### Upgrade

Codemods are available for all breaking changes in this release:

\`\`\`sh
npx xds upgrade --apply --to X.X.X
\`\`\`

Preview changes first (dry run): \`npx xds upgrade --to X.X.X\`
Run a specific codemod: \`npx xds upgrade --apply --codemod <name>\`
List all available codemods: \`npx xds upgrade --list\`
```

---
