### PR TITLE
feat(sandbox): Library redesign — component detail pages, storybook sections, hero banner

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -3560,15 +3560,17 @@ function DocsView({
                     onClick={() => setActiveView('craft')}
                   />
                   <XDSDropdownMenu
-                    trigger={
-                      <XDSButton label="Variant" variant="ghost" size="sm" />
-                    }
+                    button={{
+                      label: 'Variants',
+                      variant: 'ghost',
+                      size: 'sm',
+                    }}
+                    hasChevron={false}
                     items={[
-                      {id: 'primary', label: 'Primary'},
-                      {id: 'secondary', label: 'Secondary'},
-                      {id: 'ghost', label: 'Ghost'},
+                      {label: 'Primary', onClick: () => {}},
+                      {label: 'Secondary', onClick: () => {}},
+                      {label: 'Ghost', onClick: () => {}},
                     ]}
-                    onAction={() => {}}
                   />
                   <XDSButton
                     label="Toggle theme"

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -18,6 +18,11 @@ import {XDSBadge} from '@xds/core/Badge';
 import {XDSToken} from '@xds/core/Token';
 import {XDSToolbar} from '@xds/core/Toolbar';
 import {XDSList, XDSListItem} from '@xds/core/List';
+import {XDSBanner} from '@xds/core/Banner';
+import {XDSDialog, XDSDialogHeader} from '@xds/core/Dialog';
+import {XDSDivider} from '@xds/core/Divider';
+import {XDSTooltip} from '@xds/core/Tooltip';
+import {XDSTable} from '@xds/core/Table';
 import {createStaticSource} from '@xds/core/Typeahead';
 
 // ---------------------------------------------------------------------------
@@ -2477,95 +2482,17 @@ const TEMPLATES: Array<{
 ];
 
 // ---------------------------------------------------------------------------
-// Nav Item Component (for DocsView sidebar)
+// Section Label Component (for DocsView sidebar)
 // ---------------------------------------------------------------------------
 
-function NavItem({
-  label,
-  isActive,
-  onClick,
-  hasIcon = true,
-  indent = 0,
-  hasChevron = false,
-  isExpanded = false,
-  onToggle,
-}: {
-  label: string;
-  isActive?: boolean;
-  onClick?: () => void;
-  hasIcon?: boolean;
-  indent?: number;
-  hasChevron?: boolean;
-  isExpanded?: boolean;
-  onToggle?: () => void;
-}) {
-  const [hovered, setHovered] = useState(false);
-
-  return (
-    <div
-      onClick={hasChevron ? onToggle : onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 8,
-        padding: '7px 12px',
-        paddingLeft: 12 + indent * 16,
-        cursor: 'pointer',
-        borderRadius: 6,
-        margin: '1px 8px',
-        backgroundColor: isActive
-          ? 'rgba(0, 102, 255, 0.08)'
-          : hovered
-            ? 'rgba(0, 0, 0, 0.04)'
-            : 'transparent',
-        color: isActive ? '#0066FF' : 'var(--color-text-primary, #1a1a1a)',
-        transition: 'background-color 150ms ease',
-        userSelect: 'none' as const,
-      }}>
-      {hasIcon && (
-        <AaIcon
-          width={16}
-          height={16}
-          style={{
-            flexShrink: 0,
-            opacity: isActive ? 1 : 0.55,
-            color: isActive ? '#0066FF' : 'currentColor',
-          }}
-        />
-      )}
-      <div style={{flex: 1}}>
-        <XDSText
-          type="body"
-          weight={isActive ? 'semibold' : 'normal'}
-          color="inherit">
-          {label}
-        </XDSText>
-      </div>
-      {hasChevron && (
-        <span
-          style={{
-            display: 'flex',
-            transition: 'transform 200ms ease',
-            transform: isExpanded ? 'rotate(0deg)' : 'rotate(-90deg)',
-          }}>
-          <ChevronDownIcon width={14} height={14} style={{opacity: 0.5}} />
-        </span>
-      )}
-    </div>
-  );
-}
-
-function SectionLabel({label, indent = 0}: {label: string; indent?: number}) {
+function SectionLabel({label}: {label: string}) {
   return (
     <div
       style={{
         textTransform: 'uppercase' as const,
         letterSpacing: '0.05em',
-        padding: '12px 12px 4px',
-        paddingLeft: 12 + indent * 16,
-        margin: '0 8px',
+        padding: '12px 8px 4px',
+        margin: 0,
       }}>
       <XDSText type="supporting" weight="semibold" color="secondary">
         {label}
@@ -2640,6 +2567,35 @@ const BUTTON_CODE_LINES: Array<{spans: Array<{text: string; color: string}>}> =
   ];
 
 // ---------------------------------------------------------------------------
+// DialogPreview — stateful dialog preview for component previews
+// ---------------------------------------------------------------------------
+
+function DialogPreview() {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <div>
+      <div style={{marginBottom: 16}}>
+        <XDSHeading level={3}>Dialog</XDSHeading>
+      </div>
+      <XDSButton
+        label="Open Dialog"
+        variant="primary"
+        onClick={() => setIsOpen(true)}
+      />
+      <XDSDialog isOpen={isOpen} onOpenChange={setIsOpen}>
+        <XDSDialogHeader title="Example Dialog" onOpenChange={setIsOpen} />
+        <div style={{padding: 16}}>
+          <XDSText type="body">
+            This is an example dialog. Dialogs are used to require user action
+            or display important information that needs acknowledgment.
+          </XDSText>
+        </div>
+      </XDSDialog>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // DocsView — embedded documentation view
 // ---------------------------------------------------------------------------
 
@@ -2651,7 +2607,6 @@ function DocsView({
   setActiveView: (v: 'craft' | 'library' | 'learn' | 'profile') => void;
 }) {
   const [activeNav, setActiveNav] = useState('button');
-  const [inputsExpanded, setInputsExpanded] = useState(true);
   const [showCode, setShowCode] = useState(true);
   const [activeRightNav, setActiveRightNav] = useState('usage');
   const [selectedComponent, setSelectedComponent] = useState<string | null>(
@@ -2660,38 +2615,177 @@ function DocsView({
 
   const COMPONENT_CATEGORIES = [
     {
-      label: 'Inputs',
+      label: 'Core',
       items: [
-        {key: 'button', name: 'Button', desc: 'Triggers actions and events'},
         {
-          key: 'checkbox',
-          name: 'Checkbox',
-          desc: 'Select multiple options',
+          key: 'appshell',
+          name: 'AppShell',
+          desc: 'AppShell provides a foundational page layout with header, sidebar, and content regions. Use it to establish consistent structure across your application.',
         },
         {
-          key: 'radio',
-          name: 'Radio',
-          desc: 'Select one option from a group',
+          key: 'avatar',
+          name: 'Avatar',
+          desc: 'Avatars represent a person or entity with an image, initials, or icon. They are commonly used in user profiles, comments, and contact lists.',
         },
         {
-          key: 'select',
-          name: 'Select',
-          desc: 'Choose from a dropdown list',
+          key: 'badge',
+          name: 'Badge',
+          desc: 'Badges display small counts or status labels. They can be attached to icons, buttons, or list items to surface key information at a glance.',
         },
         {
-          key: 'switch',
-          name: 'Switch',
-          desc: 'Toggle a setting on or off',
+          key: 'banner',
+          name: 'Banner',
+          desc: 'Banners show important, non-modal messages at the top of a page or section. They communicate status, warnings, or promotional information.',
         },
         {
-          key: 'text-input',
-          name: 'TextInput',
-          desc: 'Single-line text entry',
+          key: 'button',
+          name: 'Button',
+          desc: 'Buttons let people take action. They can be used in forms, dialogs, and toolbars, or as standalone links.',
         },
         {
-          key: 'slider',
-          name: 'Slider',
-          desc: 'Select a value from a range',
+          key: 'calendar',
+          name: 'Calendar',
+          desc: 'Calendar provides a date-picking grid for selecting single dates or date ranges. It integrates with form fields for date input.',
+        },
+        {
+          key: 'dialog',
+          name: 'Dialog',
+          desc: 'Dialogs are modal overlays that require user attention or action before continuing. They are used for confirmations, forms, and critical decisions.',
+        },
+        {
+          key: 'dropdownmenu',
+          name: 'DropdownMenu',
+          desc: 'DropdownMenu presents a list of actions or options in a floating overlay. It is triggered by a button and supports nested submenus.',
+        },
+        {
+          key: 'emptystate',
+          name: 'EmptyState',
+          desc: 'EmptyState provides a placeholder when there is no content to display. It guides users with a message, illustration, and optional call-to-action.',
+        },
+        {
+          key: 'hovercard',
+          name: 'HoverCard',
+          desc: 'HoverCard shows a rich preview of content when users hover over a trigger element. It is ideal for previewing profiles, links, or details.',
+        },
+        {
+          key: 'icon',
+          name: 'Icon',
+          desc: 'Icons are small visual symbols that represent actions, objects, or concepts. They improve scannability and reinforce meaning alongside text.',
+        },
+        {
+          key: 'kbd',
+          name: 'Kbd',
+          desc: 'Kbd renders keyboard shortcut hints in a styled inline element. Use it to show users which key combinations perform specific actions.',
+        },
+        {
+          key: 'link',
+          name: 'Link',
+          desc: 'Links provide navigation between pages or to external resources. They follow accessible anchor semantics with visual affordance.',
+        },
+        {
+          key: 'list',
+          name: 'List',
+          desc: 'List displays a vertical set of related items. It supports selection, icons, and metadata for building menus, nav lists, and more.',
+        },
+        {
+          key: 'metadatalist',
+          name: 'MetadataList',
+          desc: 'MetadataList displays key-value pairs in a structured layout. Use it for detail panels, settings summaries, and record information.',
+        },
+        {
+          key: 'moremenu',
+          name: 'MoreMenu',
+          desc: 'MoreMenu provides an overflow menu triggered by an icon button. It collects secondary actions that do not fit in the primary toolbar.',
+        },
+        {
+          key: 'overflowlist',
+          name: 'OverflowList',
+          desc: 'OverflowList renders as many items as fit in the available space and collapses the rest into an overflow menu automatically.',
+        },
+        {
+          key: 'pagination',
+          name: 'Pagination',
+          desc: 'Pagination lets users navigate through pages of content. It supports page numbers, previous/next controls, and page-size selection.',
+        },
+        {
+          key: 'popover',
+          name: 'Popover',
+          desc: 'Popover displays rich content in a floating panel anchored to a trigger element. It is used for forms, filters, and contextual tools.',
+        },
+        {
+          key: 'progressbar',
+          name: 'ProgressBar',
+          desc: 'ProgressBar shows the completion status of a task or process. It provides visual feedback for uploads, installations, and multi-step flows.',
+        },
+        {
+          key: 'skeleton',
+          name: 'Skeleton',
+          desc: 'Skeleton renders placeholder shapes that mimic content layout while loading. It reduces perceived wait time and prevents layout shifts.',
+        },
+        {
+          key: 'spinner',
+          name: 'Spinner',
+          desc: 'Spinner indicates that a process is in progress when the duration is unknown. It draws attention without blocking the interface.',
+        },
+        {
+          key: 'statusdot',
+          name: 'StatusDot',
+          desc: 'StatusDot shows a small colored indicator for online, offline, busy, or custom statuses. It is often paired with avatars or list items.',
+        },
+        {
+          key: 'table',
+          name: 'Table',
+          desc: 'Table displays structured data in rows and columns with support for sorting, selection, and custom cell rendering.',
+        },
+        {
+          key: 'thumbnail',
+          name: 'Thumbnail',
+          desc: 'Thumbnail renders a small image preview with consistent sizing and optional rounded corners. It is used in media lists, cards, and galleries.',
+        },
+        {
+          key: 'timestamp',
+          name: 'Timestamp',
+          desc: 'Timestamp formats and displays dates and times with relative or absolute labels. It updates automatically to stay current.',
+        },
+        {
+          key: 'toast',
+          name: 'Toast',
+          desc: 'Toasts display brief, non-blocking notifications at the edge of the screen. They auto-dismiss and are used for success, error, or info messages.',
+        },
+        {
+          key: 'togglebutton',
+          name: 'ToggleButton',
+          desc: 'ToggleButton is a button that switches between an on and off state. Use it for binary options like bookmarking, favoriting, or muting.',
+        },
+        {
+          key: 'token',
+          name: 'Token',
+          desc: 'Tokens display compact metadata labels such as tags, categories, or filters. They can be dismissible and support selection state.',
+        },
+        {
+          key: 'tooltip',
+          name: 'Tooltip',
+          desc: 'Tooltips show concise helper text when users hover over or focus an element. They clarify icons, truncated labels, and controls.',
+        },
+        {
+          key: 'treelist',
+          name: 'TreeList',
+          desc: 'TreeList renders hierarchical data in an expandable tree structure. It supports multi-level nesting, selection, and lazy loading.',
+        },
+      ],
+    },
+    {
+      label: 'Typography',
+      items: [
+        {
+          key: 'heading',
+          name: 'Heading',
+          desc: 'Heading renders semantic section titles from h1 through h6. It establishes visual hierarchy and supports multiple weight and size options.',
+        },
+        {
+          key: 'text',
+          name: 'Text',
+          desc: 'Text renders body copy, labels, and supporting content with consistent typography. It supports sizes from display down to caption.',
         },
       ],
     },
@@ -2699,24 +2793,49 @@ function DocsView({
       label: 'Layout',
       items: [
         {
+          key: 'aspectratio',
+          name: 'AspectRatio',
+          desc: 'AspectRatio constrains its child to a specified width-to-height ratio. Use it for responsive images, videos, and embedded media.',
+        },
+        {
           key: 'card',
           name: 'Card',
-          desc: 'Container for grouped content',
+          desc: 'Cards group related content and actions in a contained surface. They can include headers, media, body text, and action bars.',
+        },
+        {
+          key: 'center',
+          name: 'Center',
+          desc: 'Center aligns its child horizontally and vertically within the available space. It is useful for empty states, loading screens, and hero sections.',
         },
         {
           key: 'divider',
           name: 'Divider',
-          desc: 'Separate content sections',
+          desc: 'Dividers separate content into distinct sections with a subtle or strong horizontal line. They can optionally include a label.',
+        },
+        {
+          key: 'grid',
+          name: 'Grid',
+          desc: 'Grid provides a CSS grid-based layout container with configurable columns, rows, and gap. It simplifies responsive multi-column designs.',
+        },
+        {
+          key: 'layout',
+          name: 'Layout',
+          desc: 'Layout provides foundational page-level primitives for header, sidebar, and content regions. It establishes consistent spacing and structure.',
+        },
+        {
+          key: 'section',
+          name: 'Section',
+          desc: 'Section wraps a block of content with consistent vertical spacing and an optional heading. It structures pages into logical groups.',
         },
         {
           key: 'stack',
           name: 'Stack',
-          desc: 'Arrange items in a row or column',
+          desc: 'Stack arranges child elements in a row or column with consistent gap spacing. It is the primary tool for one-dimensional layout composition.',
         },
         {
-          key: 'container',
-          name: 'Container',
-          desc: 'Constrain content width',
+          key: 'toolbar',
+          name: 'Toolbar',
+          desc: 'Toolbar arranges a row of action buttons and controls in a compact, aligned strip. It is used at the top of panels, editors, and cards.',
         },
       ],
     },
@@ -2724,92 +2843,480 @@ function DocsView({
       label: 'Navigation',
       items: [
         {
-          key: 'tab',
-          name: 'Tab',
-          desc: 'Switch between content views',
+          key: 'breadcrumbs',
+          name: 'Breadcrumbs',
+          desc: "Breadcrumbs show the user's current location within a navigation hierarchy. They provide quick links back to parent pages.",
         },
         {
-          key: 'breadcrumb',
-          name: 'Breadcrumb',
-          desc: 'Show navigation hierarchy',
+          key: 'mobilenav',
+          name: 'MobileNav',
+          desc: 'MobileNav provides a responsive navigation menu optimized for small screens. It typically slides in from the edge of the viewport.',
         },
         {
-          key: 'pagination',
-          name: 'Pagination',
-          desc: 'Navigate between pages',
+          key: 'sidenav',
+          name: 'SideNav',
+          desc: 'SideNav renders a vertical navigation panel with links, sections, and collapsible groups. It is used as the primary nav in dashboard layouts.',
         },
         {
-          key: 'top-nav-menu',
-          name: 'TopNavMenu',
-          desc: 'App-level navigation bar',
-        },
-      ],
-    },
-    {
-      label: 'Data Display',
-      items: [
-        {
-          key: 'table',
-          name: 'Table',
-          desc: 'Display structured data in rows',
-        },
-        {key: 'badge', name: 'Badge', desc: 'Show counts or status'},
-        {key: 'token', name: 'Token', desc: 'Display compact metadata'},
-        {
-          key: 'avatar',
-          name: 'Avatar',
-          desc: 'Represent a person or entity',
+          key: 'tablist',
+          name: 'TabList',
+          desc: 'TabList switches between content views using a horizontal row of tabs. Only one tab is active at a time, and content changes without a page reload.',
         },
         {
-          key: 'progress-bar',
-          name: 'ProgressBar',
-          desc: 'Show task completion',
+          key: 'topnav',
+          name: 'TopNav',
+          desc: 'TopNav provides an app-level navigation bar across the top of the page. It holds branding, primary links, search, and user actions.',
         },
       ],
     },
     {
-      label: 'Feedback',
+      label: 'Form',
       items: [
         {
-          key: 'banner',
-          name: 'Banner',
-          desc: 'Show important messages',
-        },
-        {key: 'dialog', name: 'Dialog', desc: 'Require user action'},
-        {
-          key: 'toast',
-          name: 'Toast',
-          desc: 'Temporary notifications',
+          key: 'checkboxinput',
+          name: 'CheckboxInput',
+          desc: 'CheckboxInput renders a single checkbox with a label. It is used for boolean opt-in choices like terms acceptance or feature toggles.',
         },
         {
-          key: 'tooltip',
-          name: 'Tooltip',
-          desc: 'Show contextual hints',
+          key: 'checkboxlist',
+          name: 'CheckboxList',
+          desc: 'CheckboxList displays a group of checkboxes for selecting multiple options. It manages shared state and supports select-all behavior.',
+        },
+        {
+          key: 'dateinput',
+          name: 'DateInput',
+          desc: 'DateInput provides a text field with calendar picker for entering dates. It validates format and supports min/max date constraints.',
+        },
+        {
+          key: 'field',
+          name: 'Field',
+          desc: 'Field wraps a form control with a label, helper text, and error message. It ensures consistent layout and accessibility across all form inputs.',
+        },
+        {
+          key: 'formlayout',
+          name: 'FormLayout',
+          desc: 'FormLayout arranges form fields in a structured vertical or horizontal layout with consistent spacing and alignment.',
+        },
+        {
+          key: 'multiselector',
+          name: 'MultiSelector',
+          desc: 'MultiSelector lets users pick multiple items from a searchable list with tokenized selections. It is ideal for assigning tags, teams, or categories.',
+        },
+        {
+          key: 'numberinput',
+          name: 'NumberInput',
+          desc: 'NumberInput provides a text field for numeric values with optional increment/decrement controls. It supports min, max, and step constraints.',
+        },
+        {
+          key: 'powersearch',
+          name: 'PowerSearch',
+          desc: 'PowerSearch provides an advanced search interface with filters, suggestions, and structured query support for complex data exploration.',
+        },
+        {
+          key: 'radiolist',
+          name: 'RadioList',
+          desc: 'RadioList presents a group of mutually exclusive options. Only one option can be selected at a time, making it ideal for settings and preferences.',
+        },
+        {
+          key: 'selector',
+          name: 'Selector',
+          desc: 'Selector lets users pick a single item from a dropdown list. It supports search, grouping, and custom option rendering.',
+        },
+        {
+          key: 'slider',
+          name: 'Slider',
+          desc: 'Slider lets users select a value or range by dragging a handle along a track. It is used for volume, brightness, and numeric range inputs.',
+        },
+        {
+          key: 'switch',
+          name: 'Switch',
+          desc: 'Switch toggles a setting between on and off states with immediate effect. It is used for preferences, feature flags, and real-time controls.',
+        },
+        {
+          key: 'textarea',
+          name: 'TextArea',
+          desc: 'TextArea provides a multi-line text field for longer-form content like comments, descriptions, and messages. It supports auto-resize.',
+        },
+        {
+          key: 'textinput',
+          name: 'TextInput',
+          desc: 'TextInput is a single-line text field for short user input like names, emails, and search queries. It supports icons, prefixes, and validation.',
+        },
+        {
+          key: 'timeinput',
+          name: 'TimeInput',
+          desc: 'TimeInput provides a field for entering times with optional picker support. It validates format and supports 12- and 24-hour modes.',
+        },
+        {
+          key: 'tokenizer',
+          name: 'Tokenizer',
+          desc: 'Tokenizer is a text input that converts entries into removable tokens. It is used for multi-value fields like email recipients and tags.',
+        },
+        {
+          key: 'typeahead',
+          name: 'Typeahead',
+          desc: 'Typeahead provides an autocomplete search input that suggests results as the user types. It supports async data sources and custom rendering.',
         },
       ],
     },
     {
-      label: 'Content',
+      label: 'Inputs',
       items: [
-        {key: 'text', name: 'Text', desc: 'Display body text'},
         {
-          key: 'heading',
-          name: 'Heading',
-          desc: 'Section and page titles',
+          key: 'segmentedcontrol',
+          name: 'SegmentedControl',
+          desc: 'SegmentedControl lets users toggle between a small set of mutually exclusive options displayed as connected segments. It works like a visual radio group.',
         },
+      ],
+    },
+    {
+      label: 'Components',
+      items: [
         {
-          key: 'code-block',
+          key: 'codeblock',
           name: 'CodeBlock',
-          desc: 'Display formatted code',
+          desc: 'CodeBlock displays formatted, syntax-highlighted source code. It supports line numbers, copy-to-clipboard, and language detection.',
         },
         {
-          key: 'accordion',
-          name: 'Accordion',
-          desc: 'Expandable content sections',
+          key: 'collapsible',
+          name: 'Collapsible',
+          desc: 'Collapsible wraps content that can be expanded or collapsed with a trigger. It is used for FAQs, advanced settings, and progressive disclosure.',
+        },
+        {
+          key: 'markdown',
+          name: 'Markdown',
+          desc: 'Markdown renders markdown-formatted text into styled HTML. It supports headings, lists, links, code blocks, and inline formatting.',
+        },
+      ],
+    },
+    {
+      label: 'Chat',
+      items: [
+        {
+          key: 'chat',
+          name: 'Chat',
+          desc: 'Chat provides a conversational message interface with message bubbles, input, and thread support. It is used for AI assistants and messaging UIs.',
+        },
+      ],
+    },
+    {
+      label: 'CommandPalette',
+      items: [
+        {
+          key: 'commandpalette',
+          name: 'CommandPalette',
+          desc: 'CommandPalette is a keyboard-driven command menu for quick navigation and actions. It is opened with a hotkey and supports fuzzy search.',
         },
       ],
     },
   ];
+
+  const COMPONENT_PREVIEWS: Record<string, React.ReactNode> = {
+    button: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Variants</XDSHeading>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 12,
+            flexWrap: 'wrap' as const,
+            marginBottom: 32,
+          }}>
+          <XDSButton label="Primary" variant="primary" />
+          <XDSButton label="Secondary" variant="secondary" />
+          <XDSButton label="Ghost" variant="ghost" />
+        </div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Sizes</XDSHeading>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 12,
+            alignItems: 'center',
+            flexWrap: 'wrap' as const,
+          }}>
+          <XDSButton label="Small" variant="primary" size="sm" />
+          <XDSButton label="Medium" variant="primary" size="md" />
+          <XDSButton label="Large" variant="primary" size="lg" />
+        </div>
+      </div>
+    ),
+    avatar: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Sizes</XDSHeading>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 16,
+            alignItems: 'center',
+            flexWrap: 'wrap' as const,
+          }}>
+          <XDSAvatar name="Alice" size="small" />
+          <XDSAvatar name="Bob" size="medium" />
+          <XDSAvatar name="Charlie" size="large" />
+        </div>
+      </div>
+    ),
+    badge: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Variants</XDSHeading>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 12,
+            flexWrap: 'wrap' as const,
+          }}>
+          <XDSBadge label="Default" />
+          <XDSBadge label="Info" variant="info" />
+          <XDSBadge label="Success" variant="success" />
+          <XDSBadge label="Warning" variant="warning" />
+          <XDSBadge label="Error" variant="error" />
+        </div>
+      </div>
+    ),
+    card: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Card</XDSHeading>
+        </div>
+        <div style={{maxWidth: 400}}>
+          <XDSCard>
+            <div style={{padding: 16}}>
+              <XDSHeading level={4}>Card Title</XDSHeading>
+              <div style={{marginTop: 8}}>
+                <XDSText type="body" color="secondary">
+                  Cards are containers for grouping related content and actions.
+                  They provide a flexible surface for displaying information.
+                </XDSText>
+              </div>
+            </div>
+          </XDSCard>
+        </div>
+      </div>
+    ),
+    banner: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Status Variants</XDSHeading>
+        </div>
+        <div
+          style={{display: 'flex', flexDirection: 'column' as const, gap: 12}}>
+          <XDSBanner status="info" title="Information">
+            <XDSText type="body">
+              This is an informational banner message.
+            </XDSText>
+          </XDSBanner>
+          <XDSBanner status="success" title="Success">
+            <XDSText type="body">Operation completed successfully.</XDSText>
+          </XDSBanner>
+          <XDSBanner status="warning" title="Warning">
+            <XDSText type="body">Please review before continuing.</XDSText>
+          </XDSBanner>
+        </div>
+      </div>
+    ),
+    dialog: <DialogPreview />,
+    text: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Typography Scale</XDSHeading>
+        </div>
+        <div
+          style={{display: 'flex', flexDirection: 'column' as const, gap: 12}}>
+          <XDSText type="display-1">Display 1</XDSText>
+          <XDSText type="display-2">Display 2</XDSText>
+          <XDSText type="display-3">Display 3</XDSText>
+          <XDSHeading level={1}>Heading 1</XDSHeading>
+          <XDSHeading level={2}>Heading 2</XDSHeading>
+          <XDSHeading level={3}>Heading 3</XDSHeading>
+          <XDSHeading level={4}>Heading 4</XDSHeading>
+          <XDSText type="body">Body text</XDSText>
+          <XDSText type="supporting">Supporting text</XDSText>
+        </div>
+      </div>
+    ),
+    divider: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Divider</XDSHeading>
+        </div>
+        <div
+          style={{display: 'flex', flexDirection: 'column' as const, gap: 24}}>
+          <div>
+            <XDSText type="supporting" color="secondary">
+              Subtle (default)
+            </XDSText>
+            <div style={{marginTop: 8}}>
+              <XDSDivider />
+            </div>
+          </div>
+          <div>
+            <XDSText type="supporting" color="secondary">
+              Strong
+            </XDSText>
+            <div style={{marginTop: 8}}>
+              <XDSDivider variant="strong" />
+            </div>
+          </div>
+          <div>
+            <XDSText type="supporting" color="secondary">
+              With label
+            </XDSText>
+            <div style={{marginTop: 8}}>
+              <XDSDivider label="Section" />
+            </div>
+          </div>
+        </div>
+      </div>
+    ),
+    token: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Tokens</XDSHeading>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 8,
+            flexWrap: 'wrap' as const,
+          }}>
+          <XDSToken label="Design" />
+          <XDSToken label="Engineering" />
+          <XDSToken label="Product" />
+          <XDSToken label="Research" />
+        </div>
+      </div>
+    ),
+    tooltip: (
+      <div>
+        <div style={{marginBottom: 16}}>
+          <XDSHeading level={3}>Tooltip</XDSHeading>
+        </div>
+        <div
+          style={{
+            display: 'flex',
+            gap: 12,
+            flexWrap: 'wrap' as const,
+          }}>
+          <XDSTooltip content="Primary action">
+            <XDSButton label="Hover me" variant="primary" />
+          </XDSTooltip>
+          <XDSTooltip content="Secondary action">
+            <XDSButton label="Or me" variant="secondary" />
+          </XDSTooltip>
+          <XDSTooltip content="Ghost action">
+            <XDSButton label="Or me" variant="ghost" />
+          </XDSTooltip>
+        </div>
+      </div>
+    ),
+  };
+
+  // Helper to find the display name for a component key
+  const getComponentName = (key: string): string => {
+    for (const cat of COMPONENT_CATEGORIES) {
+      const item = cat.items.find(i => i.key === key);
+      if (item) return item.name;
+    }
+    return key;
+  };
+
+  const getComponentDesc = (key: string): string => {
+    for (const cat of COMPONENT_CATEGORIES) {
+      const item = cat.items.find(i => i.key === key);
+      if (item) return item.desc;
+    }
+    return '';
+  };
+
+  const COMPONENT_DOCS: Record<
+    string,
+    {
+      tagline: string;
+      description: string;
+      whenToUse: string[];
+      whenNotToUse: string[];
+      anatomy: {element: string; required: string; description: string}[];
+    }
+  > = {
+    button: {
+      tagline: 'Trigger actions and navigate',
+      description:
+        'Buttons communicate the action that will occur when the user touches them. They can be placed in dialogs, forms, cards, and toolbars. The primary variant is used for the most important action on a page, while secondary and ghost variants provide visual hierarchy.',
+      whenToUse: [
+        'To trigger an action such as submitting a form or opening a dialog',
+        'As a call-to-action in marketing or onboarding surfaces',
+        'In toolbars and action bars for contextual operations',
+      ],
+      whenNotToUse: [
+        'For navigation to another page — use Link instead',
+        'To toggle a state on/off — use ToggleButton or Switch instead',
+        'When the action is part of a menu — use DropdownMenu instead',
+      ],
+      anatomy: [
+        {
+          element: 'Root',
+          required: 'Yes',
+          description:
+            'The outer <button> element that handles click events and focus state',
+        },
+        {
+          element: 'Label',
+          required: 'Yes',
+          description: 'Text content describing the action the button performs',
+        },
+        {
+          element: 'Icon',
+          required: 'No',
+          description:
+            'Optional leading or trailing icon for visual reinforcement',
+        },
+        {
+          element: 'Spinner',
+          required: 'No',
+          description:
+            'Shown when the button is in a loading state, replaces the icon slot',
+        },
+      ],
+    },
+  };
+
+  const getComponentDocs = (key: string) => {
+    if (COMPONENT_DOCS[key]) return COMPONENT_DOCS[key];
+    const name = getComponentName(key);
+    const desc = getComponentDesc(key);
+    return {
+      tagline: desc.split('.')[0] + '.',
+      description: desc,
+      whenToUse: [
+        `Use ${name} when you need the functionality it provides`,
+        'Integrate it into forms, pages, or panels as appropriate',
+      ],
+      whenNotToUse: [
+        'When a simpler alternative achieves the same goal',
+        'If the use case falls outside the intended scope of this component',
+      ],
+      anatomy: [
+        {
+          element: 'Root',
+          required: 'Yes',
+          description: `The outermost container element for ${name}`,
+        },
+        {
+          element: 'Content',
+          required: 'Yes',
+          description: 'The primary content area',
+        },
+      ],
+    };
+  };
 
   return (
     <div
@@ -2848,95 +3355,57 @@ function DocsView({
               />
             </div>
           </div>
-          <XDSButton
-            label="Collapse sidebar"
-            variant="ghost"
-            size="sm"
-            isIconOnly
-            icon={<SidebarCollapseIcon />}
-          />
         </div>
 
         {/* Nav */}
-        <nav style={{flex: 1, overflowY: 'auto' as const, paddingBottom: 16}}>
-          <NavItem
-            label="Overview"
-            isActive={selectedComponent === null}
-            onClick={() => setSelectedComponent(null)}
-          />
-          <NavItem
-            label="Getting started"
-            isActive={activeNav === 'getting-started'}
-            onClick={() => setActiveNav('getting-started')}
-          />
-          <NavItem
-            label="Quick start"
-            isActive={activeNav === 'quick-start'}
-            onClick={() => setActiveNav('quick-start')}
-          />
+        <nav
+          style={{
+            flex: 1,
+            overflowY: 'auto' as const,
+            padding: '0 16px 16px 16px',
+          }}>
+          <XDSList density="balanced">
+            <XDSListItem
+              label="Overview"
+              isSelected={selectedComponent === null}
+              onClick={() => setSelectedComponent(null)}
+            />
+            <XDSListItem
+              label="Getting started"
+              isSelected={
+                selectedComponent !== null && activeNav === 'getting-started'
+              }
+              onClick={() => setActiveNav('getting-started')}
+            />
+            <XDSListItem
+              label="Quick start"
+              isSelected={
+                selectedComponent !== null && activeNav === 'quick-start'
+              }
+              onClick={() => setActiveNav('quick-start')}
+            />
+          </XDSList>
 
-          <SectionLabel label="Components" />
-
-          <NavItem
-            label="Button"
-            isActive={activeNav === 'button'}
-            onClick={() => setActiveNav('button')}
-          />
-          <NavItem
-            label="Stepper"
-            isActive={activeNav === 'stepper'}
-            onClick={() => setActiveNav('stepper')}
-          />
-          <NavItem
-            label="Inputs"
-            hasChevron
-            isExpanded={inputsExpanded}
-            onToggle={() => setInputsExpanded(!inputsExpanded)}
-          />
-
-          {inputsExpanded && (
-            <>
-              <SectionLabel label="Text & Number" indent={1} />
-              <NavItem
-                label="Text input"
-                indent={1}
-                isActive={activeNav === 'text-input'}
-                onClick={() => setActiveNav('text-input')}
-              />
-              <NavItem
-                label="Number input"
-                indent={1}
-                isActive={activeNav === 'number-input'}
-                onClick={() => setActiveNav('number-input')}
-              />
-              <NavItem
-                label="Text area"
-                indent={1}
-                isActive={activeNav === 'text-area'}
-                onClick={() => setActiveNav('text-area')}
-              />
-
-              <SectionLabel label="Date" indent={1} />
-              <NavItem
-                label="Date picker"
-                indent={1}
-                isActive={activeNav === 'date-picker'}
-                onClick={() => setActiveNav('date-picker')}
-              />
-              <NavItem
-                label="Date input"
-                indent={1}
-                isActive={activeNav === 'date-input'}
-                onClick={() => setActiveNav('date-input')}
-              />
-              <NavItem
-                label="Time range picker"
-                indent={1}
-                isActive={activeNav === 'time-range-picker'}
-                onClick={() => setActiveNav('time-range-picker')}
-              />
-            </>
-          )}
+          {COMPONENT_CATEGORIES.map(category => (
+            <div key={category.label}>
+              <SectionLabel label={category.label.toUpperCase()} />
+              <XDSList density="balanced">
+                {category.items.map(item => (
+                  <XDSListItem
+                    key={item.key}
+                    label={item.name}
+                    isSelected={
+                      selectedComponent !== null && activeNav === item.key
+                    }
+                    onClick={() => {
+                      setSelectedComponent(item.key);
+                      setActiveNav(item.key);
+                    }}
+                  />
+                ))}
+              </XDSList>
+            </div>
+          ))}
         </nav>
       </aside>
 
@@ -2949,350 +3418,267 @@ function DocsView({
         }}>
         {selectedComponent === null ? (
           <div style={{maxWidth: 1200, margin: '0 auto'}}>
-            {/* Page header */}
-            <div style={{marginBottom: 40}}>
-              <XDSHeading level={1}>Components</XDSHeading>
-              <div style={{marginTop: 8}}>
-                <XDSText type="body" color="secondary">
-                  Build consistent, accessible UIs with XDS components.
+            {/* Page header — hero banner */}
+            <div
+              style={{
+                marginBottom: 48,
+                backgroundColor:
+                  'var(--color-background-accent-muted, #e3f2fd)',
+                borderRadius: 24,
+                padding: 60,
+                display: 'flex',
+                alignItems: 'center',
+                gap: 48,
+                overflow: 'hidden',
+                minHeight: 320,
+              }}>
+              {/* Left: text content */}
+              <div style={{flex: 1, minWidth: 0}}>
+                <XDSText type="supporting" color="secondary">
+                  XDS Design System
                 </XDSText>
+                <div style={{marginTop: 8}}>
+                  <XDSText type="display-1">Web overview</XDSText>
+                </div>
+                <div style={{marginTop: 16}}>
+                  <XDSText type="large" color="secondary">
+                    XDS Web React is an open-source UI library created by the
+                    XDS Design Team to help developers quickly build beautiful,
+                    accessible products.
+                  </XDSText>
+                </div>
+                <div style={{marginTop: 24}}>
+                  <XDSButton
+                    label="Get started"
+                    variant="primary"
+                    size="lg"
+                    onClick={() => {
+                      setSelectedComponent('getting-started');
+                      setActiveNav('getting-started');
+                    }}
+                  />
+                </div>
               </div>
+              {/* Right: blank space */}
+              <div style={{flex: 1}} />
             </div>
 
             {/* Category sections */}
             {COMPONENT_CATEGORIES.map(category => (
-              <div key={category.label} style={{marginBottom: 40}}>
+              <div key={category.label} style={{marginBottom: 64}}>
                 <div style={{marginBottom: 16}}>
-                  <XDSHeading level={2}>{category.label}</XDSHeading>
+                  <XDSText type="display-2">{category.label}</XDSText>
                 </div>
                 <div
                   style={{
                     display: 'grid',
                     gridTemplateColumns:
                       'repeat(auto-fill, minmax(260px, 1fr))',
-                    gap: 16,
+                    gap: 32,
                   }}>
                   {category.items.map(item => (
-                    <XDSCard
+                    <div
                       key={item.key}
                       onClick={() => {
                         setSelectedComponent(item.key);
                         setActiveNav(item.key);
-                      }}>
-                      {/* Card body */}
-                      <div style={{padding: '12px 16px 16px'}}>
-                        <XDSHeading level={4}>{item.name}</XDSHeading>
-                        <div style={{marginTop: 4}}>
-                          <XDSText
-                            type="supporting"
-                            color="secondary"
-                            maxLines={2}>
-                            {item.desc}
+                      }}
+                      style={{cursor: 'pointer'}}>
+                      <XDSCard
+                        padding={0}
+                        style={{
+                          border: 'none',
+                          boxShadow: 'none',
+                          outline: 'none',
+                        }}>
+                        {/* Preview area */}
+                        <div
+                          style={{
+                            height: 160,
+                            backgroundColor:
+                              'var(--color-background-muted, #c4cdd5)',
+                            borderRadius: 12,
+                          }}
+                        />
+                        {/* Card body */}
+                        <div style={{padding: '12px 0 0'}}>
+                          <XDSText type="body" style={{fontWeight: 700}}>
+                            {item.name}
                           </XDSText>
+                          <div style={{marginTop: 0}}>
+                            <XDSText type="body" color="secondary">
+                              {item.desc}
+                            </XDSText>
+                          </div>
                         </div>
-                      </div>
-                    </XDSCard>
+                      </XDSCard>
+                    </div>
                   ))}
                 </div>
               </div>
             ))}
           </div>
         ) : (
-          <>
-            <div style={{marginBottom: 16}}>
-              <XDSButton
-                label="Back to library"
-                variant="ghost"
-                size="sm"
-                icon={<ArrowLeftIcon />}
-                onClick={() => setSelectedComponent(null)}
-              />
+          <div style={{maxWidth: 840}}>
+            {/* Header */}
+            <div style={{marginBottom: 8}}>
+              <XDSText type="display-1">{getComponentName(activeNav)}</XDSText>
             </div>
-            <div style={{maxWidth: 840}}>
-              {/* Title */}
-              <div
-                style={{margin: 0, letterSpacing: '-0.02em', lineHeight: 1.1}}>
-                <XDSHeading level={1}>Button</XDSHeading>
-              </div>
+            <div style={{marginBottom: 32}}>
+              <XDSText type="supporting" color="secondary">
+                March 30, 2026 · Updated 5:40 p.m. PST
+              </XDSText>
+            </div>
 
-              {/* Date line */}
-              <div style={{margin: '8px 0 32px'}}>
-                <XDSText type="body" color="secondary">
-                  March 30, 2026 · Updated 5:40 p.m. PST
-                </XDSText>
-              </div>
-
-              {/* Live Preview Panel */}
+            {/* Live Preview Card */}
+            <div
+              style={{
+                border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
+                borderRadius: 12,
+                overflow: 'hidden',
+                marginBottom: 48,
+              }}>
               <div
                 style={{
-                  border: '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-                  backgroundColor: 'var(--color-background-card, #fff)',
-                  borderRadius: 12,
-                  boxShadow: '0 8px 40px rgba(0,0,0,0.12)',
-                  overflow: 'hidden',
-                  marginBottom: 40,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  padding: '8px 12px',
+                  borderBottom:
+                    '1px solid var(--color-divider, rgba(0,0,0,0.08))',
+                  backgroundColor: 'var(--color-background-surface, #ffffff)',
                 }}>
-                {/* Preview Header Bar */}
-                <div
-                  style={{
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    padding: '8px 12px',
-                    borderBottom:
-                      '1px solid var(--color-divider, rgba(0,0,0,0.08))',
-                    backgroundColor: 'var(--color-background-surface, #ffffff)',
-                  }}>
-                  <XDSText
-                    type="supporting"
-                    weight="semibold"
-                    color="secondary">
-                    Live preview
+                <XDSText type="supporting" weight="semibold" color="secondary">
+                  Live preview
+                </XDSText>
+                <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
+                  <XDSButton
+                    label="Open in Craft"
+                    variant="ghost"
+                    size="sm"
+                    icon={<ExternalLinkIcon />}
+                    onClick={() => setActiveView('craft')}
+                  />
+                  <XDSDropdownMenu
+                    trigger={
+                      <XDSButton label="Variant" variant="ghost" size="sm" />
+                    }
+                    items={[
+                      {id: 'primary', label: 'Primary'},
+                      {id: 'secondary', label: 'Secondary'},
+                      {id: 'ghost', label: 'Ghost'},
+                    ]}
+                    onAction={() => {}}
+                  />
+                  <XDSButton
+                    label="Toggle theme"
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                    icon={<ContrastIcon />}
+                  />
+                  <XDSButton
+                    label="Fullscreen"
+                    variant="ghost"
+                    size="sm"
+                    isIconOnly
+                    icon={<FullscreenIcon />}
+                  />
+                </div>
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: 280,
+                  backgroundColor: 'var(--color-background-muted, #f5f5f5)',
+                }}>
+                {COMPONENT_PREVIEWS[activeNav] ?? (
+                  <XDSText type="supporting" color="secondary">
+                    Preview coming soon
                   </XDSText>
-                  <div style={{display: 'flex', alignItems: 'center', gap: 4}}>
-                    <XDSButton
-                      label="Open in Craft"
-                      variant="ghost"
-                      size="sm"
-                      isIconOnly
-                      icon={<ExternalLinkIcon />}
-                    />
-                    <XDSDropdownMenu
-                      button={{
-                        label: 'Variant',
-                        variant: 'ghost',
-                        size: 'sm',
-                      }}
-                      hasChevron
-                      items={[
-                        {label: 'Primary', onClick: () => {}},
-                        {label: 'Secondary', onClick: () => {}},
-                        {label: 'Ghost', onClick: () => {}},
-                      ]}
-                    />
-                    <XDSDropdownMenu
-                      button={{
-                        label: 'Light',
-                        variant: 'ghost',
-                        size: 'sm',
-                      }}
-                      hasChevron
-                      items={[
-                        {label: 'Light', onClick: () => {}},
-                        {label: 'Dark', onClick: () => {}},
-                      ]}
-                    />
-                    <XDSButton
-                      label="Toggle code"
-                      variant={showCode ? 'secondary' : 'ghost'}
-                      size="sm"
-                      isIconOnly
-                      icon={<CodeIcon />}
-                      onClick={() => setShowCode(!showCode)}
-                    />
-                    <XDSButton
-                      label="Fullscreen"
-                      variant="ghost"
-                      size="sm"
-                      isIconOnly
-                      icon={<FullscreenIcon />}
-                    />
+                )}
+              </div>
+            </div>
+
+            {/* Description */}
+            {(() => {
+              const docs = getComponentDocs(activeNav);
+              return (
+                <div style={{marginBottom: 48}}>
+                  <XDSHeading level={3}>{docs.tagline}</XDSHeading>
+                  <div style={{marginTop: 12}}>
+                    <XDSText type="body">{docs.description}</XDSText>
+                  </div>
+                  <div style={{marginTop: 24}}>
+                    <XDSHeading level={4}>When to use</XDSHeading>
+                    <div style={{marginTop: 8}}>
+                      <XDSList density="compact" listStyle="disc">
+                        {docs.whenToUse.map((item, i) => (
+                          <XDSListItem key={i} label={item} />
+                        ))}
+                      </XDSList>
+                    </div>
+                  </div>
+                  <div style={{marginTop: 24}}>
+                    <XDSHeading level={4}>When NOT to use</XDSHeading>
+                    <div style={{marginTop: 8}}>
+                      <XDSList density="compact" listStyle="disc">
+                        {docs.whenNotToUse.map((item, i) => (
+                          <XDSListItem key={i} label={item} />
+                        ))}
+                      </XDSList>
+                    </div>
                   </div>
                 </div>
+              );
+            })()}
 
-                {/* Preview + Code Split */}
-                <div
-                  style={{
-                    display: 'flex',
-                    minHeight: 280,
-                  }}>
-                  {/* Preview Area */}
+            {/* Anatomy */}
+            {(() => {
+              const docs = getComponentDocs(activeNav);
+              return (
+                <div style={{marginBottom: 48}}>
+                  <XDSHeading level={2}>Anatomy</XDSHeading>
                   <div
                     style={{
-                      flex: 1,
+                      marginTop: 16,
+                      height: 320,
+                      backgroundColor: 'var(--color-background-muted, #f5f5f5)',
+                      borderRadius: 12,
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
-                      backgroundColor: 'var(--color-background-body, #f5f6f7)',
-                      padding: 32,
                     }}>
-                    <XDSButton
-                      label="Button"
-                      variant="primary"
-                      icon={<PlusIcon />}
-                      endContent={<XDSBadge label="New" variant="info" />}>
-                      Button
-                    </XDSButton>
+                    <XDSText type="supporting" color="secondary">
+                      Anatomy diagram
+                    </XDSText>
                   </div>
-
-                  {/* Code Panel */}
-                  {showCode && (
-                    <div
-                      style={{
-                        width: 360,
-                        backgroundColor: '#282c34',
-                        padding: '20px 0',
-                        overflowX: 'auto' as const,
-                        borderLeft:
-                          '1px solid var(--color-divider, rgba(0,0,0,0.1))',
-                      }}>
-                      <pre
-                        style={{
-                          margin: 0,
-                          fontFamily:
-                            '"SF Mono", "Roboto Mono", "Fira Code", monospace',
-                          fontSize: 13,
-                          lineHeight: '22px',
-                        }}>
-                        {BUTTON_CODE_LINES.map((line, i) => (
-                          <div
-                            key={i}
-                            style={{
-                              display: 'flex',
-                              paddingLeft: 20,
-                              paddingRight: 20,
-                            }}>
-                            <span
-                              style={{
-                                width: 32,
-                                textAlign: 'right' as const,
-                                color: '#636d83',
-                                marginRight: 16,
-                                userSelect: 'none' as const,
-                                flexShrink: 0,
-                              }}>
-                              {i + 1}
-                            </span>
-                            <span>
-                              {line.spans.map((s, j) => (
-                                <span key={j} style={{color: s.color}}>
-                                  {s.text}
-                                </span>
-                              ))}
-                            </span>
-                          </div>
-                        ))}
-                      </pre>
-                    </div>
-                  )}
+                  <div style={{marginTop: 16}}>
+                    <XDSText type="body">
+                      The {getComponentName(activeNav)} is composed of the
+                      following elements. Required elements must always be
+                      present, while optional elements can be included as
+                      needed.
+                    </XDSText>
+                  </div>
+                  <div style={{marginTop: 16}}>
+                    <XDSTable
+                      data={docs.anatomy as Record<string, unknown>[]}
+                      columns={[
+                        {key: 'element', header: 'Element'},
+                        {key: 'required', header: 'Required'},
+                        {key: 'description', header: 'Description'},
+                      ]}
+                    />
+                  </div>
                 </div>
-              </div>
-
-              {/* Documentation Content */}
-              <div style={{marginBottom: 32}}>
-                <XDSHeading level={2}>
-                  A button initiates an instantaneous action.
-                </XDSHeading>
-              </div>
-
-              <div style={{marginBottom: 32}}>
-                <XDSText type="body">
-                  Buttons are clickable elements used to trigger actions. They
-                  communicate calls to action to the user and allow users to
-                  interact with pages in a variety of ways. Button labels
-                  express what action will occur when the user interacts with
-                  it. Buttons can contain a combination of a clear label and an
-                  icon, while standalone icon buttons are reserved for
-                  recurring, universally understood actions.
-                </XDSText>
-              </div>
-
-              <div style={{marginBottom: 16}}>
-                <XDSHeading level={3}>When to use</XDSHeading>
-              </div>
-
-              <ul
-                style={{
-                  margin: 0,
-                  padding: '0 0 0 20px',
-                  lineHeight: 1.7,
-                }}>
-                <li>
-                  <XDSText type="body">
-                    Triggering form submissions or confirming a dialog
-                  </XDSText>
-                </li>
-                <li>
-                  <XDSText type="body">
-                    Navigating to a new page or view within the application
-                  </XDSText>
-                </li>
-                <li>
-                  <XDSText type="body">
-                    Starting a new process or workflow (e.g., &quot;Create
-                    new&quot;)
-                  </XDSText>
-                </li>
-                <li>
-                  <XDSText type="body">
-                    Toggling a UI element or performing an inline action
-                  </XDSText>
-                </li>
-                <li>
-                  <XDSText type="body">
-                    Performing destructive actions such as deleting items — use
-                    the danger variant for these
-                  </XDSText>
-                </li>
-              </ul>
-            </div>
-          </>
+              );
+            })()}
+          </div>
         )}
       </main>
-
-      {/* RIGHT SIDEBAR */}
-      <aside
-        style={{
-          width: 200,
-          minWidth: 200,
-          padding: '32px 20px',
-          position: 'sticky' as const,
-          top: 0,
-          height: '100vh',
-          boxSizing: 'border-box' as const,
-        }}>
-        <div
-          style={{
-            textTransform: 'uppercase' as const,
-            letterSpacing: '0.08em',
-            marginBottom: 12,
-          }}>
-          <XDSText type="supporting" weight="bold" color="secondary">
-            On this page
-          </XDSText>
-        </div>
-        {[
-          {id: 'usage', label: 'Usage'},
-          {id: 'code', label: 'Code'},
-          {id: 'tokens', label: 'Tokens'},
-          {id: 'accessibility', label: 'Accessibility'},
-        ].map(item => (
-          <div
-            key={item.id}
-            onClick={() => setActiveRightNav(item.id)}
-            style={{
-              padding: '6px 0',
-              cursor: 'pointer',
-              color:
-                activeRightNav === item.id
-                  ? '#0066FF'
-                  : 'var(--color-text-secondary, #6b7785)',
-              borderLeft:
-                activeRightNav === item.id
-                  ? '2px solid #0066FF'
-                  : '2px solid transparent',
-              paddingLeft: 12,
-              transition: 'color 150ms ease',
-            }}>
-            <XDSText
-              type="supporting"
-              weight={activeRightNav === item.id ? 'semibold' : 'normal'}
-              color="inherit">
-              {item.label}
-            </XDSText>
-          </div>
-        ))}
-      </aside>
     </div>
   );
 }

--- a/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/docsite/page.tsx
@@ -3519,7 +3519,7 @@ function DocsView({
             ))}
           </div>
         ) : (
-          <div style={{maxWidth: 840}}>
+          <div style={{maxWidth: 840, margin: '0 auto'}}>
             {/* Header */}
             <div style={{marginBottom: 8}}>
               <XDSText type="display-1">{getComponentName(activeNav)}</XDSText>


### PR DESCRIPTION
## Changes

### Library Overview
- **Hero banner** with light blue background, Display 1 'Web overview' title, large body description, Get started CTA
- **Storybook section groupings**: Core, Typography, Layout, Navigation, Form, Inputs, Components, Chat, CommandPalette
- **73 components** with descriptive 1-2 sentence descriptions (Fluent 2 style)
- **Redesigned cards**: gray preview area, bold title, description, no border
- **Display 2 section headings**, 64px section gap, 32px card grid gap

### Component Detail Pages
- **Display 1 component name** with date subtitle
- **Live Preview card**: bordered card with toolbar (Open in Craft, Variants dropdown, theme toggle, fullscreen)
- **Description section**: tagline, description, When to use / When NOT to use lists (XDSList)
- **Anatomy section**: diagram placeholder + XDSTable with element/required/description columns
- **Button-specific docs** with generic fallback for other components

### Sidebar
- **XDSList/XDSListItem** components replacing custom NavItem
- **Balanced density** (medium size)
- **Section labels** aligned with list item text
- **Full 73-component list** grouped by storybook sections
- Overview / Getting started / Quick start at top

### XDS Components Throughout
- All text uses XDSText/XDSHeading
- Lists use XDSList/XDSListItem
- Anatomy table uses XDSTable
- Buttons use XDSButton with proper isIconOnly