### PR TITLE
fix(core): add missing style escape hatches to Spinner, TabList, Tab

### DIFF
--- a/packages/core/src/Spinner/XDSSpinner.tsx
+++ b/packages/core/src/Spinner/XDSSpinner.tsx
@@ -116,6 +116,11 @@ export interface XDSSpinnerProps {
    */
   className?: string;
   /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
+  /**
    * Visible content displayed below the spinner.
    * Accepts a string or ReactNode for rich content.
    *
@@ -162,6 +167,7 @@ export function XDSSpinner({
   label,
   xstyle,
   className,
+  style,
   'aria-label': ariaLabel,
   'data-testid': testId,
   ref,
@@ -245,8 +251,8 @@ export function XDSSpinner({
         hasLabel ? '' : xdsClassName('spinner', {size, shade}),
         stylex.props(styles.spinner, !hasLabel && xstyle),
         hasLabel ? undefined : className,
-      )}
-      style={{width: frameSize, height: frameSize}}>
+        {...(hasLabel ? {} : style), width: frameSize, height: frameSize},
+      )}>
       <canvas ref={canvasRef} {...stylex.props(styles.canvas)} />
     </span>
   );
@@ -263,6 +269,7 @@ export function XDSSpinner({
         xdsClassName('spinner', {size, shade}),
         stylex.props(styles.wrapper, xstyle),
         className,
+        style,
       )}>
       {spinner}
       {typeof label === 'string' ? (

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -14,6 +14,7 @@
 
 import {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
@@ -57,6 +58,26 @@ export interface XDSTabProps {
    * Icon element shown when tab is selected. Falls back to `icon` if not provided.
    */
   selectedIcon?: ReactNode;
+  /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { paddingInline: 16 } });
+   * <XDSTab xstyle={overrides.root} ... />
+   * ```
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) appended to the root element.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element.
+   */
+  style?: React.CSSProperties;
 }
 
 // =============================================================================
@@ -176,6 +197,9 @@ export function XDSTab({
   href,
   icon,
   selectedIcon,
+  xstyle,
+  className,
+  style,
 }: XDSTabProps) {
   const tabListCtx = useXDSTabListContext();
   const LinkComponent = useXDSLinkComponent(as);
@@ -205,7 +229,10 @@ export function XDSTab({
         sizeStyles[size],
         isSelected && styles.selected,
         !isSelected && stylex.defaultMarker(),
+        xstyle,
       ),
+      className,
+      style,
     ),
   };
 

--- a/packages/core/src/TabList/XDSTabList.tsx
+++ b/packages/core/src/TabList/XDSTabList.tsx
@@ -14,6 +14,7 @@
 
 import {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {borderVars, colorVars, spacingVars} from '../theme/tokens.stylex';
 import {XDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
@@ -38,6 +39,26 @@ export interface XDSTabListProps {
    * @default false
    */
   hasDivider?: boolean;
+  /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <XDSTabList xstyle={overrides.root} ... />
+   * ```
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) appended to the root element.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element.
+   */
+  style?: React.CSSProperties;
   /**
    * XDSTab and XDSTabMenu children.
    */
@@ -78,6 +99,9 @@ export function XDSTabList({
   onChange,
   size = 'md',
   hasDivider = false,
+  xstyle,
+  className,
+  style,
   children,
 }: XDSTabListProps) {
   const contextValue = useMemo(
@@ -91,7 +115,9 @@ export function XDSTabList({
         aria-label="Tabs"
         {...mergeProps(
           xdsClassName('tab-list', {size}),
-          stylex.props(styles.nav, hasDivider && styles.divider),
+          stylex.props(styles.nav, hasDivider && styles.divider, xstyle),
+          className,
+          style,
         )}>
         {children}
       </nav>


### PR DESCRIPTION
## Component Audit — 2026-04-12

Nightly audit of 5 components: **Spinner**, **Stack**, **StatusDot**, **Switch**, **TabList**.

### Findings

| Component | Issue | Category | Fix |
|-----------|-------|----------|-----|
| Spinner | Missing `style` prop escape hatch | structure-issue | Added `style` to XDSSpinnerProps, wired through mergeProps |
| TabList | Missing `xstyle`, `className`, `style` escape hatches | structure-issue | Added all three to XDSTabListProps |
| Tab | Missing `xstyle`, `className`, `style` escape hatches | structure-issue | Added all three to XDSTabProps |

### Clean Components (no issues)

- **Stack** (XDSStack, XDSHStack, XDSVStack, XDSStackItem) — all extend XDSBaseProps, correct xdsClassName usage, proper token usage, displayName set
- **StatusDot** — correct token usage, xdsClassName with variant, extensible variant map, proper a11y (role=img + aria-label)
- **Switch** — extends XDSBaseProps, full input field consistency (label, value, onChange, status, isDisabled, etc.), correct a11y (role=switch, aria-describedby, aria-invalid, aria-busy), sub-element xdsClassName targeting

### Needs Review

- **TabList**: `useXDSTabListContext` hook and `XDSTabListContextValue` type are not exported from the barrel (`index.ts`). These may be needed by consumers building custom tab components, but could also be intentionally internal. Leaving unmodified — human decision needed.

### Verification

- `yarn build` ✅
- `yarn test` (Spinner + TabList) — 33/33 passing ✅
- `yarn lint` (changed files) ✅