### PR TITLE
feat(Chat): extract XDSChatSendButton — themeable send/stop button

### DIFF
--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -3,6 +3,7 @@ import {
   XDSChatComposer,
   XDSChatComposerAttachments,
   XDSChatComposerInput,
+  XDSChatSendButton,
 } from '@xds/core/Chat';
 import {XDSToken} from '@xds/core/Token';
 import {XDSButton} from '@xds/core/Button';
@@ -292,4 +293,51 @@ export const WithStatusBottom: Story = {
       }}
     />
   ),
+};
+
+/** Default send button — reads from composer context automatically */
+export const DefaultSendButton: Story = {
+  render: () => (
+    <XDSChatComposer
+      onSubmit={value => {
+        console.log('Submit:', value);
+        alert(`Sent: ${value}`);
+      }}
+      placeholder="Type to enable the send button..."
+    />
+  ),
+};
+
+/** Custom send button via sendButton slot */
+export const CustomSendButton: Story = {
+  render: () => (
+    <XDSChatComposer
+      onSubmit={value => console.log('Submit:', value)}
+      sendButton={
+        <XDSChatSendButton size="sm" onSend={() => alert('Custom send!')} />
+      }
+    />
+  ),
+};
+
+/** Send/stop toggle — type text and submit to start streaming, click stop to end */
+export const SendStopToggle: Story = {
+  render: () => {
+    const [isStreaming, setIsStreaming] = useState(false);
+    return (
+      <XDSChatComposer
+        onSubmit={value => {
+          console.log('Submit:', value);
+          setIsStreaming(true);
+          setTimeout(() => setIsStreaming(false), 5000);
+        }}
+        isStreaming={isStreaming}
+        onStop={() => {
+          console.log('Stopped');
+          setIsStreaming(false);
+        }}
+        placeholder="Send a message to start streaming..."
+      />
+    );
+  },
 };

--- a/packages/core/src/Button/XDSButton.tsx
+++ b/packages/core/src/Button/XDSButton.tsx
@@ -60,7 +60,8 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     whiteSpace: 'nowrap',
     cursor: 'pointer',
-    transitionProperty: 'background-image, transform',
+    transitionProperty:
+      'background-image, background-color, color, opacity, transform',
     transitionDuration: {
       default: durationVars['--duration-fast'],
       '@media (prefers-reduced-motion: reduce)': '0s',

--- a/packages/core/src/Chat/XDSChatComposer.tsx
+++ b/packages/core/src/Chat/XDSChatComposer.tsx
@@ -45,6 +45,7 @@ import {xdsClassName, mergeProps} from '../utils';
 import {XDSIcon} from '../Icon';
 import {XDSChatComposerInput} from './XDSChatComposerInput';
 import {XDSChatComposerContext} from './XDSChatContext';
+import {XDSChatSendButton} from './XDSChatSendButton';
 
 // =============================================================================
 // Types
@@ -203,30 +204,6 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-1'],
   },
-  sendButton: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: '32px',
-    height: '32px',
-    borderRadius: 'var(--button-radius, var(--radius-full))',
-    border: 'none',
-    cursor: 'pointer',
-    transition: `opacity ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
-    flexShrink: 0,
-  },
-  sendButtonSend: {
-    backgroundColor: colorVars['--color-accent'],
-    color: 'white',
-  },
-  sendButtonStop: {
-    backgroundColor: colorVars['--color-background-muted'],
-    color: colorVars['--color-text-primary'],
-  },
-  sendButtonDisabled: {
-    opacity: 0.4,
-    cursor: 'default',
-  },
   statusBar: {
     position: 'relative',
     zIndex: 0,
@@ -265,32 +242,6 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1'],
   },
 });
-
-// =============================================================================
-// Icons
-// =============================================================================
-
-function SendIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-      <path
-        d="M8 3L8 13M8 3L4 7M8 3L12 7"
-        stroke="currentColor"
-        strokeWidth="2"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function StopIcon() {
-  return (
-    <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
-      <rect width="12" height="12" rx="2" fill="currentColor" />
-    </svg>
-  );
-}
 
 // =============================================================================
 // Component
@@ -364,21 +315,6 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
     editable?.focus();
   }, []);
 
-  const defaultSendButton = (
-    <button
-      type="button"
-      aria-label={isStreaming ? 'Stop' : 'Send'}
-      onClick={isStreaming ? onStop : handleSubmit}
-      disabled={!isStreaming && !canSend}
-      {...stylex.props(
-        styles.sendButton,
-        isStreaming ? styles.sendButtonStop : styles.sendButtonSend,
-        !isStreaming && !canSend && styles.sendButtonDisabled,
-      )}>
-      {isStreaming ? <StopIcon /> : <SendIcon />}
-    </button>
-  );
-
   const statusEl = status ? (
     <div
       role={status.type === 'error' ? 'alert' : 'status'}
@@ -404,8 +340,20 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
       onSubmit: handleSubmit,
       placeholder,
       isDisabled,
+      isStreaming,
+      canSend,
+      onStop,
     }),
-    [currentValue, updateValue, handleSubmit, placeholder, isDisabled],
+    [
+      currentValue,
+      updateValue,
+      handleSubmit,
+      placeholder,
+      isDisabled,
+      isStreaming,
+      canSend,
+      onStop,
+    ],
   );
 
   return (
@@ -443,7 +391,7 @@ export function XDSChatComposer(props: XDSChatComposerProps) {
             <div {...stylex.props(styles.footerLeft)}>{footerActions}</div>
             <div {...stylex.props(styles.footerRight)}>
               {sendActions}
-              {sendButton ?? defaultSendButton}
+              {sendButton ?? <XDSChatSendButton />}
             </div>
           </div>
         </div>

--- a/packages/core/src/Chat/XDSChatContext.tsx
+++ b/packages/core/src/Chat/XDSChatContext.tsx
@@ -46,6 +46,9 @@ export interface XDSChatComposerContextValue {
   onSubmit: (value: string) => void;
   placeholder: string;
   isDisabled: boolean;
+  isStreaming: boolean;
+  canSend: boolean;
+  onStop?: () => void;
 }
 
 export const XDSChatComposerContext =

--- a/packages/core/src/Chat/XDSChatSendButton.tsx
+++ b/packages/core/src/Chat/XDSChatSendButton.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+/**
+ * @file XDSChatSendButton.tsx
+ * @input Uses XDSButton, XDSChatComposerContext, icon registry
+ * @output Exports XDSChatSendButton — a circular send/stop toggle button
+ * @position Standalone component; default send button for XDSChatComposer
+ *
+ * Reads composer state from XDSChatComposerContext by default so it "just
+ * works" inside XDSChatComposer. All context-derived values can be
+ * overridden via props for standalone usage.
+ *
+ * States:
+ * - **Send** — accent/primary, arrowUp icon, disabled when nothing to send.
+ * - **Stop** — neutral/secondary, stop icon, calls onStop.
+ */
+
+import type {ReactNode} from 'react';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import * as stylex from '@stylexjs/stylex';
+import {XDSButton} from '../Button';
+import {getIcon} from '../Icon/globalIconRegistry';
+import {useXDSChatComposerContext} from './XDSChatContext';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface XDSChatSendButtonProps {
+  /** Whether the assistant is currently streaming a response. */
+  isStreaming?: boolean;
+  /** Whether the send button is disabled. Defaults to `!canSend` from context. */
+  isDisabled?: boolean;
+  /** Called when the user clicks the send button. Defaults to context onSubmit. */
+  onSend?: () => void;
+  /** Called when the user clicks the stop button during streaming. */
+  onStop?: () => void;
+  /** Icon for the send state. Resolves from icon registry by default. */
+  sendIcon?: ReactNode;
+  /** Icon for the stop/streaming state. Resolves from icon registry by default. */
+  stopIcon?: ReactNode;
+  /** Button size. @default 'md' */
+  size?: 'sm' | 'md';
+  /** Additional StyleX styles. */
+  xstyle?: StyleXStyles;
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  root: {
+    borderRadius: 'var(--button-radius, var(--radius-full))',
+    flexShrink: 0,
+  },
+});
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export function XDSChatSendButton(props: XDSChatSendButtonProps): ReactNode {
+  const context = useXDSChatComposerContext();
+
+  const {
+    isStreaming = context?.isStreaming ?? false,
+    isDisabled = !(context?.canSend ?? false),
+    onSend,
+    onStop = context?.onStop,
+    sendIcon,
+    stopIcon,
+    size = 'md',
+    xstyle,
+  } = props;
+
+  const handleSend = onSend ?? (() => context?.onSubmit(''));
+
+  return (
+    <XDSButton
+      label={isStreaming ? 'Stop' : 'Send'}
+      variant={isStreaming ? 'secondary' : 'primary'}
+      size={size}
+      icon={
+        isStreaming
+          ? (stopIcon ?? getIcon('stop'))
+          : (sendIcon ?? getIcon('arrowUp'))
+      }
+      isIconOnly
+      isDisabled={!isStreaming && isDisabled}
+      onClick={isStreaming ? onStop : handleSend}
+      xstyle={[styles.root, xstyle]}
+    />
+  );
+}
+
+XDSChatSendButton.displayName = 'XDSChatSendButton';

--- a/packages/core/src/Chat/index.ts
+++ b/packages/core/src/Chat/index.ts
@@ -13,6 +13,9 @@ export type {
   XDSChatComposerDensity,
 } from './XDSChatComposer';
 
+export {XDSChatSendButton} from './XDSChatSendButton';
+export type {XDSChatSendButtonProps} from './XDSChatSendButton';
+
 export {XDSChatComposerAttachments} from './XDSChatComposerAttachments';
 export type {XDSChatComposerAttachmentsProps} from './XDSChatComposerAttachments';
 
@@ -30,7 +33,6 @@ export type {
 
 export {XDSChatTokenizedText} from './XDSChatTokenizedText';
 export type {XDSChatTokenizedTextProps} from './XDSChatTokenizedText';
-
 
 export {XDSChatMessageList} from './XDSChatMessageList';
 export type {XDSChatMessageListProps} from './XDSChatMessageList';
@@ -57,14 +59,27 @@ export type {
 } from './XDSChatSystemMessage';
 
 export {useXDSChatStreamScroll} from './useXDSChatStreamScroll';
-export type {UseXDSChatStreamScrollOptions, UseXDSChatStreamScrollReturn} from './useXDSChatStreamScroll';
+export type {
+  UseXDSChatStreamScrollOptions,
+  UseXDSChatStreamScrollReturn,
+} from './useXDSChatStreamScroll';
 export {useXDSChatNewMessages} from './useXDSChatNewMessages';
-export type {UseXDSChatNewMessagesOptions, UseXDSChatNewMessagesReturn} from './useXDSChatNewMessages';
+export type {
+  UseXDSChatNewMessagesOptions,
+  UseXDSChatNewMessagesReturn,
+} from './useXDSChatNewMessages';
 
 export {useXDSChatPasteAsToken} from './useXDSChatPasteAsToken';
-export type {UseXDSChatPasteAsTokenOptions, UseXDSChatPasteAsTokenReturn} from './useXDSChatPasteAsToken';
+export type {
+  UseXDSChatPasteAsTokenOptions,
+  UseXDSChatPasteAsTokenReturn,
+} from './useXDSChatPasteAsToken';
 export {useXDSChatComposerTokens} from './useXDSChatComposerTokens';
-export type {UseXDSChatComposerTokensOptions, UseXDSChatComposerTokensReturn, TokenPortal} from './useXDSChatComposerTokens';
+export type {
+  UseXDSChatComposerTokensOptions,
+  UseXDSChatComposerTokensReturn,
+  TokenPortal,
+} from './useXDSChatComposerTokens';
 export type {XDSChatMessageSender, XDSChatDensity} from './XDSChatContext';
 export {useXDSChatLayoutContext} from './XDSChatContext';
 

--- a/packages/core/src/Icon/defaultIcons.tsx
+++ b/packages/core/src/Icon/defaultIcons.tsx
@@ -241,4 +241,11 @@ export const defaultIcons: XDSIconRegistry = {
       <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
     </svg>
   ),
+
+  /** ■ — stop (rounded square, solid fill for media control) */
+  stop: (
+    <svg {...solidSvgProps}>
+      <rect x="6" y="6" width="12" height="12" rx="2" />
+    </svg>
+  ),
 };

--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -45,7 +45,8 @@ export type XDSIconName =
   | 'viewColumns'
   | 'copy'
   | 'checkDouble'
-  | 'wrench';
+  | 'wrench'
+  | 'stop';
 
 /**
  * Icon registry mapping semantic names to React nodes.

--- a/packages/themes/daily/src/icons.tsx
+++ b/packages/themes/daily/src/icons.tsx
@@ -26,6 +26,7 @@ import {
   Copy,
   CheckCheck,
   Wrench,
+  Square,
 } from 'lucide-react';
 
 const iconProps = {
@@ -58,4 +59,5 @@ export const dailyIconRegistry: XDSIconRegistry = {
   copy: <Copy {...iconProps} />,
   checkDouble: <CheckCheck {...iconProps} />,
   wrench: <Wrench {...iconProps} />,
+  stop: <Square {...iconProps} />,
 };

--- a/packages/themes/default/src/icons.tsx
+++ b/packages/themes/default/src/icons.tsx
@@ -38,6 +38,7 @@ import {
   XCircleIcon,
   ExclamationTriangleIcon,
   ArrowTopRightOnSquareIcon,
+  StopIcon,
 } from '@heroicons/react/24/solid';
 
 const iconProps = {
@@ -71,4 +72,5 @@ export const defaultIconRegistry: XDSIconRegistry = {
   copy: <ClipboardDocumentIcon {...iconProps} />,
   checkDouble: <CheckIcon {...iconProps} />,
   wrench: <WrenchIcon {...iconProps} />,
+  stop: <StopIcon {...iconProps} />,
 };

--- a/packages/themes/meta/src/icons.tsx
+++ b/packages/themes/meta/src/icons.tsx
@@ -39,6 +39,7 @@ import {
   XCircleIcon,
   ExclamationTriangleIcon,
   ArrowTopRightOnSquareIcon,
+  StopIcon,
 } from '@heroicons/react/24/solid';
 
 const iconProps = {
@@ -72,4 +73,5 @@ export const metaIconRegistry: XDSIconRegistry = {
   copy: <ClipboardDocumentIcon {...iconProps} />,
   checkDouble: <CheckIcon {...iconProps} />,
   wrench: <WrenchScrewdriverIcon {...iconProps} />,
+  stop: <StopIcon {...iconProps} />,
 };

--- a/packages/themes/neutral/src/icons.tsx
+++ b/packages/themes/neutral/src/icons.tsx
@@ -36,6 +36,7 @@ import {
   Copy,
   CheckCheck,
   Wrench,
+  Square,
 } from 'lucide-react';
 
 const iconProps = {
@@ -68,4 +69,5 @@ export const neutralIconRegistry: XDSIconRegistry = {
   copy: <Copy {...iconProps} />,
   checkDouble: <CheckCheck {...iconProps} />,
   wrench: <Wrench {...iconProps} />,
+  stop: <Square {...iconProps} />,
 };

--- a/packages/themes/whatsapp/src/icons.tsx
+++ b/packages/themes/whatsapp/src/icons.tsx
@@ -36,6 +36,7 @@ import {
   XCircleIcon,
   ExclamationTriangleIcon,
   ArrowTopRightOnSquareIcon,
+  StopIcon,
 } from '@heroicons/react/24/solid';
 
 const iconProps = {
@@ -69,4 +70,5 @@ export const whatsappIconRegistry: XDSIconRegistry = {
   copy: <ClipboardDocumentIcon {...iconProps} />,
   checkDouble: <CheckIcon {...iconProps} />,
   wrench: <WrenchScrewdriverIcon {...iconProps} />,
+  stop: <StopIcon {...iconProps} />,
 };


### PR DESCRIPTION
## Summary

Extract the inline send/stop button from XDSChatComposer into a standalone `XDSChatSendButton` component that uses `XDSButton` + `XDSIcon` from the design system.

### Changes

- **XDSChatSendButton** — new component, reads from composer context, uses `XDSButton` with `arrowUp`/`stop` icons
- **XDSChatComposerContext** — enriched with `isStreaming`, `canSend`, `onStop`
- **Icon registry** — added `stop` icon to all themes
- **XDSChatComposer** — default send button is now `<XDSChatSendButton />`, inline SVGs + styles removed

### Why

The send button was a raw `<button>` with hand-rolled SVGs — themes didn't affect it, and consumers couldn't easily customize it. Now it's a proper XDS component that themes automatically and can be swapped via the existing `sendButton` slot.

Prerequisite for #1308 (dictation button).

Closes #1312
