### PR TITLE
fix: add missing data-autofocus to TextArea, add escape hatches to TimeInput

### DIFF
--- a/packages/core/src/TextArea/XDSTextArea.tsx
+++ b/packages/core/src/TextArea/XDSTextArea.tsx
@@ -381,6 +381,7 @@ export function XDSTextArea({
           disabled={effectivelyDisabled}
           spellCheck={hasSpellCheck}
           autoFocus={hasAutoFocus}
+          data-autofocus={hasAutoFocus || undefined}
           aria-describedby={ariaDescribedBy}
           aria-required={isRequired && !isOptional ? 'true' : undefined}
           aria-invalid={

--- a/packages/core/src/TimeInput/XDSTimeInput.tsx
+++ b/packages/core/src/TimeInput/XDSTimeInput.tsx
@@ -25,6 +25,7 @@ import {
   type FocusEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import type {XDSIconName} from '../Icon';
 import {
   colorVars,
@@ -249,6 +250,28 @@ export interface XDSTimeInputProps {
    * Tooltip text to display in an info icon at the end of the label.
    */
   labelTooltip?: string;
+
+  /**
+   * StyleX styles created via `stylex.create()`. Merged with the component's
+   * base styles inside a single `stylex.props()` call for optimal deduplication.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { marginBottom: 8 } });
+   * <Component xstyle={overrides.root} />
+   * ```
+   */
+  xstyle?: StyleXStyles;
+  /**
+   * CSS class name(s) appended to the root element.
+   * If you're using StyleX, prefer `xstyle` for optimal style deduplication.
+   */
+  className?: string;
+  /**
+   * Inline styles to apply to the root element. Spread after StyleX
+   * inline styles, so these values take priority.
+   */
+  style?: React.CSSProperties;
 }
 
 /**
@@ -286,6 +309,9 @@ export function XDSTimeInput({
   size = 'md',
   status,
   labelTooltip,
+  xstyle,
+  className,
+  style,
   ref,
 }: XDSTimeInputProps) {
   const id = useId();
@@ -507,7 +533,10 @@ export function XDSTimeInput({
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
             status && inputStatusFocusWithinStyles[status.type],
+            xstyle,
           ),
+          className,
+          style,
         )}>
         <div {...stylex.props(styles.icon)}>
           <XDSIcon icon="clock" size="sm" color="secondary" />


### PR DESCRIPTION
## Component Audit — 2026-04-13

Audited: **Table**, **Text**, **TextArea**, **TextInput**, **TimeInput**

### Fixes

**XDSTextArea — missing `data-autofocus`** (`a11y-gap`)
- `autoFocus={hasAutoFocus}` was present but `data-autofocus={hasAutoFocus || undefined}` was missing
- Required for `XDSDialog` to re-focus the element after `showModal()` — React's `autoFocus` fires before the dialog is visible, so it silently fails (see #1044)
- `XDSTextInput` already had this correctly; now `XDSTextArea` matches

**XDSTimeInput — missing escape hatches** (`structure-issue`)
- Missing `xstyle`, `className`, and `style` props
- Every XDS component must provide these for consumer customization
- Added all three props to `XDSTimeInputProps` and wired them into the outer wrapper div via `mergeProps()`

### No issues found

- **Table** — proper tokens, xdsClassName on all sub-elements (row, cell, header-cell), correct context-based variant styling, full export hygiene, displayName on all components
- **Text** — semantic type scale tokens, proper xdsClassName with type/color variants, escape hatches present, displayName set
- **TextInput** — extends XDSBaseProps, all field props present, proper `data-autofocus`, status/a11y wiring correct

### Needs Review

- **XDSBaseTable** `xdsClassName('base-table')` doesn't include `density`/`dividers` variant props. These flow through context → sub-components rather than being applied at the `<table>` level. Architecturally this is defensible (the table element itself doesn't get variant-specific visual styles), but it means themes can't target `xds-base-table.compact` etc. Worth discussing whether variant classNames should be added for future theming extensibility.

---
