### PR TITLE
ci: add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+    groups:
+      # Group all patch/minor updates together to reduce PR noise
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Adds a `dependabot.yml` config to enable automated dependency update PRs.

### What this does
- **npm**: Weekly checks for security vulnerabilities and version updates, limited to 5 open PRs at a time
- **GitHub Actions**: Monthly checks for action version updates
- Groups minor/patch updates together to reduce PR noise

### Why
There are currently **15 open Dependabot security alerts** (8 high, 7 moderate) on this repo — affecting minimatch, picomatch, vite, brace-expansion, and esbuild. GitHub is generating alerts but no auto-fix PRs because there's no `dependabot.yml`. This config enables the auto-fix flow.

Config is modeled after what facebook/docusaurus and facebook/lexical use.

---
_— via Navi on behalf of arock1278_