### PR TITLE
fix(CodeBlock): promote highlightMode to public API, fix perf page

### DIFF
--- a/apps/sandbox/src/app/(fullscreen)/pages/codeblock-perf/page.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/pages/codeblock-perf/page.tsx
@@ -298,6 +298,7 @@ function PerfPanel({
           title={`${lineCount.toLocaleString()} lines`}
           hasLineNumbers
           maxHeight={maxHeight}
+          highlightMode={mode}
         />
       </div>
     </XDSVStack>

--- a/packages/core/src/CodeBlock/XDSCodeBlock.tsx
+++ b/packages/core/src/CodeBlock/XDSCodeBlock.tsx
@@ -316,15 +316,13 @@ export interface XDSCodeBlockProps extends XDSBaseProps<HTMLPreElement> {
     code: string,
     language: string,
   ) => Array<{type: string; start: number; end: number}>;
-}
-
-/**
- * Internal-only props for testing and performance tuning.
- * Not part of the public API — used by the sandbox perf page.
- * @internal
- */
-interface XDSCodeBlockInternalProps extends XDSCodeBlockProps {
-  /** @internal Force a specific highlighting strategy. */
+  /**
+   * Highlighting strategy.
+   * - `'auto'` — uses CSS Custom Highlight API when available, falls back to spans
+   * - `'ranges'` — force CSS Custom Highlight API (no-op if unsupported)
+   * - `'spans'` — force span-based rendering
+   * @default 'auto'
+   */
   highlightMode?: 'auto' | 'ranges' | 'spans';
 }
 
@@ -605,7 +603,7 @@ export function XDSCodeBlock({
   style,
   ref,
   ...props
-}: XDSCodeBlockInternalProps) {
+}: XDSCodeBlockProps) {
   const [copied, setCopied] = useState(false);
 
   const useSpans =


### PR DESCRIPTION
## What

Moves `highlightMode` from the internal-only `XDSCodeBlockInternalProps` interface to the public `XDSCodeBlockProps`, and wires it through in the sandbox perf page.

## Why

The perf page's `PerfPanel` component accepted a `mode` prop (`'ranges' | 'spans'`) but never forwarded it as `highlightMode` to `XDSCodeBlock`. Both panels rendered with `highlightMode='auto'`, so they always used the same strategy — defeating the purpose of the side-by-side comparison.

Since `highlightMode` is useful beyond the perf page (e.g. forcing span mode for SSR compatibility), promoting it to the public API makes sense.

## Changes

- **XDSCodeBlock.tsx** — moved `highlightMode` prop + JSDoc from `XDSCodeBlockInternalProps` → `XDSCodeBlockProps`, removed the internal interface
- **codeblock-perf/page.tsx** — pass `highlightMode={mode}` to `XDSCodeBlock`

---
