### PR TITLE
chore: ignore jsdom major version bumps in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    ignore:
+      # jsdom 29 overhauled CSSOM internals and broke aspect-ratio
+      # serialization. Revisit when jsdom fixes it upstream.
+      - dependency-name: "jsdom"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group all patch/minor updates together to reduce PR noise
       dev-dependencies:


### PR DESCRIPTION
jsdom 29 overhauled their CSSOM implementation (replaced `cssstyle` with `css-tree`-based internals) and broke `aspect-ratio` serialization — `element.style.aspectRatio` returns empty string instead of `X / 1`.

Ignore major bumps until jsdom fixes this upstream. Closes the loop on #1332.

---
