### PR TITLE
fix: use context.filename instead of deprecated context.getFilename()

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+    ignore:
+      # jsdom 29 overhauled CSSOM internals and broke aspect-ratio
+      # serialization. Revisit when jsdom fixes it upstream.
+      - dependency-name: "jsdom"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group all patch/minor updates together to reduce PR noise
       dev-dependencies:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-    ignore:
-      # jsdom 29 overhauled CSSOM internals and broke aspect-ratio
-      # serialization. Revisit when jsdom fixes it upstream.
-      - dependency-name: "jsdom"
-        update-types: ["version-update:semver-major"]
     groups:
       # Group all patch/minor updates together to reduce PR noise
       dev-dependencies:

--- a/internal/eslint-plugin-xds/no-react-introspection.js
+++ b/internal/eslint-plugin-xds/no-react-introspection.js
@@ -73,7 +73,7 @@ const noReactIntrospectionRule = {
     const allowFiles = options.allowFiles || [];
 
     // Check if this file is explicitly allowed
-    const filename = context.getFilename();
+    const filename = context.filename ?? context.getFilename();
     if (allowFiles.some(pattern => filename.includes(pattern))) {
       return {};
     }

--- a/internal/eslint-plugin-xds/presentational-component.js
+++ b/internal/eslint-plugin-xds/presentational-component.js
@@ -112,7 +112,7 @@ const presentationalComponentRule = {
     schema: [],
   },
   create(context) {
-    const filename = context.getFilename();
+    const filename = context.filename ?? context.getFilename();
 
     if (!isPresentationalFile(filename)) {
       return {};


### PR DESCRIPTION
ESLint 9.39.4 removed the deprecated `context.getFilename()` method. Our custom lint rules in `eslint-plugin-xds` were using it, causing a TypeError on lint.

Fixed with `context.filename ?? context.getFilename()` for backwards compat.

Unblocks #1334 (eslint bump).

---
