### PR TITLE
feat: support optional codemods in upgrade pipeline

### DIFF
--- a/packages/cli/src/codemods/runner.mjs
+++ b/packages/cli/src/codemods/runner.mjs
@@ -153,6 +153,7 @@ export async function runCodemods(versionManifests, {apply, path: srcPath, codem
   let totalValidationBlocked = 0;
   const errors = [];
   const writtenFiles = [];
+  const skippedOptional = [];
 
   for (const {version, transforms} of versionManifests) {
     p.log.step(`Applying v${version} codemods...`);
@@ -161,7 +162,14 @@ export async function runCodemods(versionManifests, {apply, path: srcPath, codem
       // Filter by codemod name if specified
       if (codemod && transformEntry.name !== codemod) continue;
 
-      const {name, transform, meta} = transformEntry;
+      const {name, transform, meta, optional} = transformEntry;
+
+      // Skip optional codemods unless explicitly requested via --codemod
+      if (optional && !codemod) {
+        skippedOptional.push({name, meta, version});
+        continue;
+      }
+
       p.log.info(`  ${meta.title}`);
 
       let filesChanged = 0;
@@ -263,5 +271,20 @@ export async function runCodemods(versionManifests, {apply, path: srcPath, codem
     p.log.info('Run with --apply to write changes to disk.');
   }
 
-  return {totalFilesChanged, totalTransformsApplied, totalValidationBlocked, errors};
+  // Report skipped optional codemods so the user knows they exist
+  if (skippedOptional.length > 0) {
+    console.log('');
+    p.log.message(
+      `${skippedOptional.length} optional codemod${skippedOptional.length === 1 ? '' : 's'} available:`,
+    );
+    for (const {name, meta} of skippedOptional) {
+      p.log.info(`  ${name} — ${meta.title}`);
+      if (meta.description) {
+        p.log.info(`    ${meta.description}`);
+      }
+      p.log.info(`    Run: xds upgrade --codemod ${name} --path <dir> --apply`);
+    }
+  }
+
+  return {totalFilesChanged, totalTransformsApplied, totalValidationBlocked, errors, skippedOptional};
 }

--- a/packages/cli/src/codemods/transforms/v0.0.12/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.12/index.mjs
@@ -13,5 +13,10 @@ export default [
     name: 'add-is-icon-only',
     transform: addIsIconOnly,
     meta: addIsIconOnlyMeta,
+    // Optional: heuristic-based detection can produce false positives.
+    // A button with icon + no children might intentionally show the label
+    // in v0.0.12. Run explicitly with --codemod add-is-icon-only after
+    // visually verifying the results.
+    optional: true,
   },
 ];

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -153,15 +153,15 @@ export function registerUpgrade(program) {
         for (const version of versions) {
           const manifests = await getTransformsBetween('0.0.0', version);
           for (const {transforms} of manifests) {
-            for (const {name, meta} of transforms) {
-              codemods.push({name, title: meta.title, version, pr: meta.pr});
+            for (const {name, meta, optional} of transforms) {
+              codemods.push({name, title: meta.title, version, pr: meta.pr, optional: !!optional});
             }
           }
         }
-        if (json) return jsonOut('upgrade.list', codemods.map(({name, title, version}) => ({name, title, version})));
+        if (json) return jsonOut('upgrade.list', codemods.map(({name, title, version, optional}) => ({name, title, version, optional})));
         p.log.step('Available codemods:');
-        for (const {name, title, pr} of codemods) {
-          p.log.info(`  ${name} — ${title} (${pr})`);
+        for (const {name, title, pr, optional} of codemods) {
+          p.log.info(`  ${name} — ${title}${optional ? ' (optional)' : ''} (${pr})`);
         }
         p.outro('Done');
         return;
@@ -219,17 +219,21 @@ export function registerUpgrade(program) {
         return;
       }
 
-      // Count transforms
+      // Count transforms (optional codemods only count when explicitly requested)
       let totalTransforms = 0;
+      let totalOptional = 0;
       for (const {transforms} of versionManifests) {
         for (const t of transforms) {
-          if (!options.codemod || t.name === options.codemod) {
+          if (options.codemod && t.name !== options.codemod) continue;
+          if (t.optional && !options.codemod) {
+            totalOptional++;
+          } else {
             totalTransforms++;
           }
         }
       }
 
-      if (totalTransforms === 0) {
+      if (totalTransforms === 0 && totalOptional === 0) {
         const msg = `Codemod "${options.codemod}" not found. Use --list to see available codemods.`;
         if (json) return jsonError(msg);
         p.log.error(msg);
@@ -239,9 +243,13 @@ export function registerUpgrade(program) {
       }
 
       if (!json) {
-        p.log.step(
-          `${totalTransforms} codemod${totalTransforms === 1 ? '' : 's'} to run${options.apply ? '' : ' (dry run)'}`,
-        );
+        if (totalTransforms > 0) {
+          p.log.step(
+            `${totalTransforms} codemod${totalTransforms === 1 ? '' : 's'} to run${options.apply ? '' : ' (dry run)'}`,
+          );
+        } else {
+          p.log.step('No automatic codemods to run for this version range.');
+        }
       }
 
       const receipt = {from: currentVersion, to: targetVersion, codemods: totalTransforms, depsUpdated: [], agentDocsRefreshed: false};


### PR DESCRIPTION
## Summary

Adds an `optional` flag to codemod manifest entries. Optional codemods are skipped during automatic `xds upgrade` but can be run explicitly with `--codemod <name>`.

### Problem

The `add-is-icon-only` codemod uses heuristic detection (icon present + no children = icon-only). This can produce false positives — a button may intentionally show both icon and label text in v0.0.12. Running it automatically during upgrade risks silent UI changes.

### Solution

Manifest entries can set `optional: true`:

```js
{
  name: 'add-is-icon-only',
  transform: addIsIconOnly,
  meta: addIsIconOnlyMeta,
  optional: true,  // heuristic detection, run explicitly
}
```

When skipped, the CLI calls them out with the exact command to run:

```
┌  XDS Upgrade
│
◇  No automatic codemods to run for this version range.
│
│  1 optional codemod available:
│    add-is-icon-only — Migrate pre-v0.0.12 icon-only buttons to XDSIconButton
│      Converts implicit icon-only <XDSButton icon={...} label="..."> ...
│      Run: xds upgrade --codemod add-is-icon-only --path <dir> --apply
│
└  Dry run complete
```

### Changes

- **Runner**: skips `optional: true` entries unless `--codemod` names them explicitly; reports skipped codemods with description + run command
- **Upgrade command**: excludes optional from "N codemods to run" count; handles the case where all codemods are optional
- **`--list`**: shows `(optional)` tag; JSON output includes `optional` field
- **v0.0.12 manifest**: marks `add-is-icon-only` as optional with explanatory comment

Closes #1321

---
