### PR TITLE
fix(sandbox): update library template to use XDS components

### DIFF
--- a/apps/sandbox/postcss.config.js
+++ b/apps/sandbox/postcss.config.js
@@ -10,6 +10,7 @@ module.exports = {
       include: [
         'src/**/*.{js,jsx,ts,tsx}',
         path.join(rootDir, 'packages/core/src/**/*.{ts,tsx}'),
+        path.join(rootDir, 'packages/cli/templates/**/*.{ts,tsx}'),
         path.join(rootDir, 'packages/themes/default/src/**/*.{ts,tsx}'),
         path.join(rootDir, 'packages/themes/neutral/src/**/*.{ts,tsx}'),
       ],

--- a/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
+++ b/apps/sandbox/src/app/(fullscreen)/PreviewShell.tsx
@@ -280,7 +280,7 @@ export function PreviewShell({children}: {children: React.ReactNode}) {
           gap: 8,
           padding: '6px 12px',
           borderBottom: '1px solid var(--color-border-emphasized)',
-          backgroundColor: '#f8f8f8',
+          backgroundColor: 'var(--color-background-surface)',
           flexShrink: 0,
           zIndex: 10,
         }}>

--- a/apps/sandbox/src/app/layout.tsx
+++ b/apps/sandbox/src/app/layout.tsx
@@ -25,6 +25,7 @@ import '@xds/theme-neutral/theme.css';
 import '@xds/theme-brutalist/theme.css';
 import '@xds/theme-meta/theme.css';
 import '@xds/theme-daily/theme.css';
+import './globals.css';
 import {Providers} from './providers';
 
 export const metadata: Metadata = {

--- a/packages/cli/templates/library/page.tsx
+++ b/packages/cli/templates/library/page.tsx
@@ -12,10 +12,7 @@ import {XDSDivider} from '@xds/core/Divider';
 import {XDSGrid} from '@xds/core/Grid';
 import {XDSHStack, XDSVStack} from '@xds/core/Stack';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
-import {
-  colorVars,
-  spacingVars,
-} from '@xds/core/theme/tokens.stylex';
+import {colorVars, spacingVars} from '@xds/core/theme/tokens.stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
 import {
   XDSSideNav,
@@ -277,7 +274,6 @@ const ITEMS: LibraryItem[] = [
   },
 ];
 
-
 const styles = stylex.create({
   sectionTop: {
     paddingTop: spacingVars['--spacing-4'],
@@ -296,13 +292,13 @@ const styles = stylex.create({
   hideOnSmall: {
     display: {
       default: 'none',
-      '@media (min-width: 600px)': 'block',
+      '@media (min-width: 768px)': 'block',
     },
   },
   hideOnLarge: {
     display: {
       default: 'block',
-      '@media (min-width: 600px)': 'none',
+      '@media (min-width: 768px)': 'none',
     },
   },
 });
@@ -359,11 +355,11 @@ function LibraryNav() {
 function LibraryCard({item}: {item: LibraryItem}) {
   return (
     <XDSCard padding={0}>
-      <XDSAspectRatio ratio={21 / 9} xstyle={styles.thumbnail}><div /></XDSAspectRatio>
+      <XDSAspectRatio ratio={21 / 9} xstyle={styles.thumbnail}>
+        <div />
+      </XDSAspectRatio>
       <XDSVStack gap={1} xstyle={styles.cardBody}>
-        <XDSHeading level={3}>
-          {item.name}
-        </XDSHeading>
+        <XDSHeading level={3}>{item.name}</XDSHeading>
         <XDSText type="body" size="sm" color="secondary">
           {item.description}
         </XDSText>
@@ -488,7 +484,7 @@ export default function LibraryPage() {
                 </div>
               ) : groupedSections != null ? (
                 <XDSVStack gap={6}>
-                  {groupedSections.flatMap((section) => [
+                  {groupedSections.flatMap(section => [
                     <XDSDivider key={`d-${section.category}`} />,
                     <LibrarySection
                       key={section.category}

--- a/packages/cli/templates/library/page.tsx
+++ b/packages/cli/templates/library/page.tsx
@@ -10,12 +10,10 @@ import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSDivider} from '@xds/core/Divider';
 import {XDSGrid} from '@xds/core/Grid';
-import {XDSHStack, XDSStack, XDSStackItem, XDSVStack} from '@xds/core/Stack';
+import {XDSHStack, XDSVStack} from '@xds/core/Stack';
 import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {
   colorVars,
-  radiusVars,
-
   spacingVars,
 } from '@xds/core/theme/tokens.stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
@@ -281,24 +279,31 @@ const ITEMS: LibraryItem[] = [
 
 
 const styles = stylex.create({
-  filterBar: {
-    paddingBottom: spacingVars['--spacing-8'],
-  },
-  filterSearch: {
-    flex: 1,
-    minWidth: 0,
+  sectionTop: {
+    paddingTop: spacingVars['--spacing-4'],
   },
   thumbnail: {
-    backgroundColor: colorVars['--color-background-body'],
+    backgroundColor: colorVars['--color-background-muted'],
     width: '100%',
   },
-
   cardBody: {
     padding: spacingVars['--spacing-4'],
   },
   emptyState: {
     padding: spacingVars['--spacing-12'],
     textAlign: 'center',
+  },
+  hideOnSmall: {
+    display: {
+      default: 'none',
+      '@media (min-width: 600px)': 'block',
+    },
+  },
+  hideOnLarge: {
+    display: {
+      default: 'block',
+      '@media (min-width: 600px)': 'none',
+    },
   },
 });
 
@@ -377,7 +382,7 @@ function LibrarySection({
   return (
     <XDSVStack gap={6}>
       <XDSHeading level={2}>{category}</XDSHeading>
-      <XDSGrid columns={4} gap={5}>
+      <XDSGrid minChildWidth={320} gap={4}>
         {items.map(item => (
           <LibraryCard key={item.id} item={item} />
         ))}
@@ -428,65 +433,78 @@ export default function LibraryPage() {
         }
         content={
           <XDSLayoutContent padding={6}>
-            <XDSStack direction="vertical" gap={3} xstyle={styles.filterBar}>
-              <XDSTextInput
-                label="Search"
-                isLabelHidden
-                placeholder="Search..."
-                value={search}
-                onChange={setSearch}
-                startIcon={MagnifyingGlassIcon}
-                size="lg"
-              />
-              <XDSHStack vAlign="center" hAlign="between">
-                <XDSToggleButtonGroup
-                  label="Filter by category"
-                  value={activeTab}
-                  onChange={v => setActiveTab(v ?? 'All')}>
-                  {CATEGORIES.map(cat => (
-                    <XDSToggleButton
-                      key={cat}
-                      label={cat}
-                      value={cat}
-                      size="lg"
-                    />
-                  ))}
-                </XDSToggleButtonGroup>
-                <XDSDropdownMenu
-                  button={{label: sortOrder, size: 'lg'}}
-                  items={[
-                    {label: 'A-Z', onClick: () => setSortOrder('A-Z')},
-                    {label: 'Z-A', onClick: () => setSortOrder('Z-A')},
-                    {label: 'Newest', onClick: () => setSortOrder('Newest')},
-                  ]}
+            <XDSVStack gap={6}>
+              <XDSVStack gap={4}>
+                <XDSTextInput
+                  label="Search"
+                  isLabelHidden
+                  placeholder="Search..."
+                  value={search}
+                  onChange={setSearch}
+                  startIcon={MagnifyingGlassIcon}
+                  size="lg"
                 />
-              </XDSHStack>
-            </XDSStack>
-
-            {filtered.length === 0 ? (
-              <div {...stylex.props(styles.emptyState)}>
-                <XDSText type="supporting" color="secondary">
-                  No results found.
-                </XDSText>
-              </div>
-            ) : groupedSections != null ? (
-              <XDSVStack gap={8}>
-                {groupedSections.flatMap((section, i) => [
-                  i > 0 && <XDSDivider key={`d-${section.category}`} />,
-                  <LibrarySection
-                    key={section.category}
-                    category={section.category}
-                    items={section.items}
-                  />,
-                ])}
+                <XDSHStack vAlign="center" hAlign="between">
+                  <div {...stylex.props(styles.hideOnSmall)}>
+                    <XDSToggleButtonGroup
+                      label="Filter by category"
+                      value={activeTab}
+                      onChange={v => setActiveTab(v ?? 'All')}>
+                      {CATEGORIES.map(cat => (
+                        <XDSToggleButton
+                          key={cat}
+                          label={cat}
+                          value={cat}
+                          size="lg"
+                        />
+                      ))}
+                    </XDSToggleButtonGroup>
+                  </div>
+                  <div {...stylex.props(styles.hideOnLarge)}>
+                    <XDSDropdownMenu
+                      button={{label: activeTab, size: 'lg'}}
+                      items={CATEGORIES.map(cat => ({
+                        label: cat,
+                        onClick: () => setActiveTab(cat),
+                      }))}
+                    />
+                  </div>
+                  <XDSDropdownMenu
+                    button={{label: sortOrder, size: 'lg'}}
+                    items={[
+                      {label: 'A-Z', onClick: () => setSortOrder('A-Z')},
+                      {label: 'Z-A', onClick: () => setSortOrder('Z-A')},
+                      {label: 'Newest', onClick: () => setSortOrder('Newest')},
+                    ]}
+                  />
+                </XDSHStack>
               </XDSVStack>
-            ) : (
-              <XDSGrid columns={4} gap={5}>
-                {filtered.map(item => (
-                  <LibraryCard key={item.id} item={item} />
-                ))}
-              </XDSGrid>
-            )}
+
+              {filtered.length === 0 ? (
+                <div {...stylex.props(styles.emptyState)}>
+                  <XDSText type="supporting" color="secondary">
+                    No results found.
+                  </XDSText>
+                </div>
+              ) : groupedSections != null ? (
+                <XDSVStack gap={6}>
+                  {groupedSections.flatMap((section) => [
+                    <XDSDivider key={`d-${section.category}`} />,
+                    <LibrarySection
+                      key={section.category}
+                      category={section.category}
+                      items={section.items}
+                    />,
+                  ])}
+                </XDSVStack>
+              ) : (
+                <XDSGrid minChildWidth={320} gap={4} xstyle={styles.sectionTop}>
+                  {filtered.map(item => (
+                    <LibraryCard key={item.id} item={item} />
+                  ))}
+                </XDSGrid>
+              )}
+            </XDSVStack>
           </XDSLayoutContent>
         }
       />

--- a/packages/cli/templates/library/page.tsx
+++ b/packages/cli/templates/library/page.tsx
@@ -9,10 +9,13 @@ import {XDSAspectRatio} from '@xds/core/AspectRatio';
 import {XDSToggleButton, XDSToggleButtonGroup} from '@xds/core/ToggleButton';
 import {XDSTextInput} from '@xds/core/TextInput';
 import {XDSDivider} from '@xds/core/Divider';
+import {XDSGrid} from '@xds/core/Grid';
+import {XDSHStack, XDSStack, XDSStackItem, XDSVStack} from '@xds/core/Stack';
+import {XDSDropdownMenu} from '@xds/core/DropdownMenu';
 import {
   colorVars,
-  textSizeVars,
-  fontWeightVars,
+  radiusVars,
+
   spacingVars,
 } from '@xds/core/theme/tokens.stylex';
 import {XDSAppShell} from '@xds/core/AppShell';
@@ -28,6 +31,7 @@ import {
   BookOpenIcon,
   Squares2X2Icon,
   WrenchScrewdriverIcon,
+  MagnifyingGlassIcon,
 } from '@heroicons/react/24/outline';
 import {
   HomeIcon as HomeIconSolid,
@@ -278,45 +282,19 @@ const ITEMS: LibraryItem[] = [
 
 const styles = stylex.create({
   filterBar: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-3'],
     paddingBottom: spacingVars['--spacing-8'],
-  },
-  toggleRow: {
-    display: 'flex',
   },
   filterSearch: {
     flex: 1,
     minWidth: 0,
   },
-  dividerRow: {
-    paddingTop: spacingVars['--spacing-6'],
-    paddingBottom: spacingVars['--spacing-8'],
-  },
-  sectionHeader: {
-    paddingBottom: spacingVars['--spacing-3'],
-  },
   thumbnail: {
     backgroundColor: colorVars['--color-background-body'],
     width: '100%',
   },
+
   cardBody: {
     padding: spacingVars['--spacing-4'],
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  itemName: {
-    fontSize: textSizeVars['--font-size-base'],
-    fontWeight: fontWeightVars['--font-weight-semibold'],
-    color: colorVars['--color-text-primary'],
-    lineHeight: 1.375,
-    marginBottom: spacingVars['--spacing-2'],
-  },
-  itemDescription: {
-    fontSize: textSizeVars['--font-size-sm'],
-    color: colorVars['--color-text-secondary'],
-    lineHeight: 1.5,
   },
   emptyState: {
     padding: spacingVars['--spacing-12'],
@@ -376,13 +354,15 @@ function LibraryNav() {
 function LibraryCard({item}: {item: LibraryItem}) {
   return (
     <XDSCard padding={0}>
-      <XDSAspectRatio ratio={16 / 9} xstyle={styles.thumbnail}><div /></XDSAspectRatio>
-      <div {...stylex.props(styles.cardBody)}>
-        <span {...stylex.props(styles.itemName)}>{item.name}</span>
-        <span {...stylex.props(styles.itemDescription)}>
+      <XDSAspectRatio ratio={21 / 9} xstyle={styles.thumbnail}><div /></XDSAspectRatio>
+      <XDSVStack gap={1} xstyle={styles.cardBody}>
+        <XDSHeading level={3}>
+          {item.name}
+        </XDSHeading>
+        <XDSText type="body" size="sm" color="secondary">
           {item.description}
-        </span>
-      </div>
+        </XDSText>
+      </XDSVStack>
     </XDSCard>
   );
 }
@@ -395,27 +375,21 @@ function LibrarySection({
   items: LibraryItem[];
 }) {
   return (
-    <div>
-      <div {...stylex.props(styles.sectionHeader)}>
-        <XDSHeading level={3}>{category}</XDSHeading>
-      </div>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(4, 1fr)',
-          gap: 20,
-        }}>
+    <XDSVStack gap={6}>
+      <XDSHeading level={2}>{category}</XDSHeading>
+      <XDSGrid columns={4} gap={5}>
         {items.map(item => (
           <LibraryCard key={item.id} item={item} />
         ))}
-      </div>
-    </div>
+      </XDSGrid>
+    </XDSVStack>
   );
 }
 
 export default function LibraryPage() {
   const [activeTab, setActiveTab] = useState('All');
   const [search, setSearch] = useState('');
+  const [sortOrder, setSortOrder] = useState('A-Z');
 
   const filtered = useMemo(() => {
     let items =
@@ -454,25 +428,40 @@ export default function LibraryPage() {
         }
         content={
           <XDSLayoutContent padding={6}>
-            <div {...stylex.props(styles.filterBar)}>
+            <XDSStack direction="vertical" gap={3} xstyle={styles.filterBar}>
               <XDSTextInput
                 label="Search"
                 isLabelHidden
                 placeholder="Search..."
                 value={search}
                 onChange={setSearch}
+                startIcon={MagnifyingGlassIcon}
+                size="lg"
               />
-              <div {...stylex.props(styles.toggleRow)}>
+              <XDSHStack vAlign="center" hAlign="between">
                 <XDSToggleButtonGroup
                   label="Filter by category"
                   value={activeTab}
                   onChange={v => setActiveTab(v ?? 'All')}>
                   {CATEGORIES.map(cat => (
-                    <XDSToggleButton key={cat} label={cat} value={cat} />
+                    <XDSToggleButton
+                      key={cat}
+                      label={cat}
+                      value={cat}
+                      size="lg"
+                    />
                   ))}
                 </XDSToggleButtonGroup>
-              </div>
-            </div>
+                <XDSDropdownMenu
+                  button={{label: sortOrder, size: 'lg'}}
+                  items={[
+                    {label: 'A-Z', onClick: () => setSortOrder('A-Z')},
+                    {label: 'Z-A', onClick: () => setSortOrder('Z-A')},
+                    {label: 'Newest', onClick: () => setSortOrder('Newest')},
+                  ]}
+                />
+              </XDSHStack>
+            </XDSStack>
 
             {filtered.length === 0 ? (
               <div {...stylex.props(styles.emptyState)}>
@@ -481,32 +470,22 @@ export default function LibraryPage() {
                 </XDSText>
               </div>
             ) : groupedSections != null ? (
-              <div>
-                {groupedSections.map((section, i) => (
-                  <div key={section.category}>
-                    {i > 0 && (
-                      <div {...stylex.props(styles.dividerRow)}>
-                        <XDSDivider />
-                      </div>
-                    )}
-                    <LibrarySection
-                      category={section.category}
-                      items={section.items}
-                    />
-                  </div>
-                ))}
-              </div>
+              <XDSVStack gap={8}>
+                {groupedSections.flatMap((section, i) => [
+                  i > 0 && <XDSDivider key={`d-${section.category}`} />,
+                  <LibrarySection
+                    key={section.category}
+                    category={section.category}
+                    items={section.items}
+                  />,
+                ])}
+              </XDSVStack>
             ) : (
-              <div
-                style={{
-                  display: 'grid',
-                  gridTemplateColumns: 'repeat(4, 1fr)',
-                  gap: 20,
-                }}>
+              <XDSGrid columns={4} gap={5}>
                 {filtered.map(item => (
                   <LibraryCard key={item.id} item={item} />
                 ))}
-              </div>
+              </XDSGrid>
             )}
           </XDSLayoutContent>
         }


### PR DESCRIPTION
The layout on the library page was mostly using `div` wrappers with custom styling. Updated the template to use XDS as much as possible.