### PR TITLE
fix: 3 codemod import bugs from canary testing

### DIFF
--- a/packages/cli/src/codemods/transforms/v0.0.12/__tests__/add-is-icon-only.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.12/__tests__/add-is-icon-only.test.mjs
@@ -129,4 +129,45 @@ describe('add-is-icon-only', () => {
     const output = await applyTransform(input);
     expect(output).toContain('</XDSIconButton>');
   });
+
+  // Bug fixes (#1346)
+
+  it('does not produce double semicolons after use client directive', async () => {
+    const input = `'use client';
+
+import {XDSButton} from '@xds/core/Button';
+
+function Foo() {
+  return <XDSButton label="X" icon={<I />} />;
+}`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain(';;');
+    expect(output).toContain("'use client'");
+  });
+
+  it('splits type imports to correct module when replacing Button import', async () => {
+    const input = `import {XDSButton, type XDSButtonProps} from '@xds/core/Button';
+
+function Foo(props: XDSButtonProps) {
+  return <XDSButton label="X" icon={<I />} />;
+}`;
+    const output = await applyTransform(input);
+    // Type import should stay on @xds/core/Button
+    expect(output).toContain("XDSButtonProps");
+    expect(output).toContain("'@xds/core/Button'");
+    // Component import should be on @xds/core/IconButton
+    expect(output).toContain("XDSIconButton");
+    expect(output).toContain("'@xds/core/IconButton'");
+    // XDSButton should NOT be in any import (it was the only value import)
+    expect(output).not.toMatch(/import.*XDSButton[^P]/);
+  });
+
+  it('uses single quotes for new imports', async () => {
+    const input = `import {XDSButton} from '@xds/core/Button';
+<><XDSButton label="A" icon={<I />} /><XDSButton label="B" variant="primary" /></>`;
+    const output = await applyTransform(input);
+    // New IconButton import should use single quotes
+    expect(output).toContain("from '@xds/core/IconButton'");
+    expect(output).not.toContain('from "@xds/core/IconButton"');
+  });
 });

--- a/packages/cli/src/codemods/transforms/v0.0.12/add-is-icon-only.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.12/add-is-icon-only.mjs
@@ -201,9 +201,16 @@ export default function transformer(file, api) {
   root.find(j.JSXIdentifier, {name: 'XDSButton'}).forEach(() => {
     hasRemainingXDSButton = true;
   });
+  // Also check for XDSButton in type annotations (e.g. typeof XDSButton)
+  root.find(j.Identifier, {name: 'XDSButton'}).forEach((path) => {
+    // Skip JSX identifiers (already counted above) and import specifiers
+    if (path.parent.node.type === 'JSXOpeningElement' ||
+        path.parent.node.type === 'JSXClosingElement' ||
+        path.parent.node.type === 'ImportSpecifier') return;
+    hasRemainingXDSButton = true;
+  });
 
   if (needsIconButtonImport) {
-    // Check if XDSIconButton is already imported
     let alreadyImported = false;
     root.find(j.ImportDeclaration).forEach((path) => {
       if (path.node.specifiers.some(
@@ -214,9 +221,11 @@ export default function transformer(file, api) {
     });
 
     if (!alreadyImported) {
-      // If no XDSButton usage remains, replace the Button import
+      // Handle @xds/core/Button import — may need splitting if it has
+      // other specifiers (type imports, other components)
       if (!hasRemainingXDSButton) {
         root.find(j.ImportDeclaration).forEach((path) => {
+          if (alreadyImported) return;
           const source = path.node.source.value;
           if (source !== '@xds/core/Button') return;
           const specs = path.node.specifiers;
@@ -225,9 +234,22 @@ export default function transformer(file, api) {
           );
           if (btnIdx === -1) return;
 
-          // Replace XDSButton specifier with XDSIconButton
-          specs[btnIdx] = j.importSpecifier(j.identifier('XDSIconButton'));
-          path.node.source = j.literal('@xds/core/IconButton');
+          // Remove XDSButton from this import
+          specs.splice(btnIdx, 1);
+
+          if (specs.length === 0) {
+            // No other specifiers — replace the entire import
+            specs.push(j.importSpecifier(j.identifier('XDSIconButton')));
+            path.node.source = j.stringLiteral('@xds/core/IconButton');
+          } else {
+            // Other specifiers remain (type imports, etc.) — keep this import
+            // for them and add a new one for XDSIconButton
+            const newImport = j.importDeclaration(
+              [j.importSpecifier(j.identifier('XDSIconButton'))],
+              j.stringLiteral('@xds/core/IconButton'),
+            );
+            path.insertAfter(newImport);
+          }
           alreadyImported = true;
         });
       }
@@ -245,11 +267,11 @@ export default function transformer(file, api) {
         });
       }
 
-      // Otherwise add a new import
+      // Otherwise add a new import after the last @xds import
       if (!alreadyImported) {
         const newImport = j.importDeclaration(
           [j.importSpecifier(j.identifier('XDSIconButton'))],
-          j.literal('@xds/core/IconButton'),
+          j.stringLiteral('@xds/core/IconButton'),
         );
 
         const xdsImports = root
@@ -270,5 +292,5 @@ export default function transformer(file, api) {
     }
   }
 
-  return root.toSource();
+  return root.toSource({quote: 'single'});
 }


### PR DESCRIPTION
Fixes three bugs found during canary upgrade testing of `xds-common` internally (#1346).

### Bug 1: Double semicolon after `'use client'`
`toSource()` without options collapsed blank lines after directives, producing `'use client';;`. Fixed by passing `{quote: 'single'}` which also fixes Bug 3.

### Bug 2: Type imports dragged to wrong module
```ts
// Before (broken)
import {XDSIconButton, type XDSButtonProps} from '@xds/core/IconButton';

// After (fixed — splits into two imports)
import {type XDSButtonProps} from '@xds/core/Button';
import {XDSIconButton} from '@xds/core/IconButton';
```
When replacing `XDSButton` with `XDSIconButton`, the codemod now checks if other specifiers remain. If so, it removes only the `XDSButton` specifier and adds a new import for `XDSIconButton`, keeping type imports on their original module.

### Bug 3: Inconsistent quote style
`j.literal()` / `j.stringLiteral()` + default `toSource()` produced double quotes. Fixed with `toSource({quote: 'single'})`.

### Tests
3 new test cases covering each bug. 21 total, all passing.

Closes #1346

---
