### PR TITLE
chore: bump all packages to v0.0.12

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@xds/cli",
-  "version": "0.0.11",
-  "description": "XDS design system CLI — init, swizzle, theme, templates, and agent docs",
+  "version": "0.0.12",
+  "description": "XDS design system CLI \u2014 init, swizzle, theme, templates, and agent docs",
   "type": "module",
   "bin": {
     "xds": "./bin/xds.mjs"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/core",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Core XDS components",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@xds/lab",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
-  "description": "Experimental XDS components — not published, available in storybook and sandbox for testing",
+  "description": "Experimental XDS components \u2014 not published, available in storybook and sandbox for testing",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "sideEffects": false,

--- a/packages/themes/brutalist/package.json
+++ b/packages/themes/brutalist/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@xds/theme-brutalist",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
-  "description": "Brutalist theme for XDS — zero radius, monospace, heavy borders",
+  "description": "Brutalist theme for XDS \u2014 zero radius, monospace, heavy borders",
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/source.js",

--- a/packages/themes/daily/package.json
+++ b/packages/themes/daily/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@xds/theme-daily",
-  "version": "0.0.1",
+  "version": "0.0.12",
   "private": false,
-  "description": "Daily theme for XDS components — warm, productivity-focused (Lucide icons)",
+  "description": "Daily theme for XDS components \u2014 warm, productivity-focused (Lucide icons)",
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/source.js",

--- a/packages/themes/default/package.json
+++ b/packages/themes/default/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-default",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": false,
   "description": "Default theme for XDS components (Heroicons)",
   "license": "MIT",

--- a/packages/themes/meta/package.json
+++ b/packages/themes/meta/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@xds/theme-meta",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
-  "description": "Meta theme for XDS components — Meta's brand identity with blue accent and clean aesthetics",
+  "description": "Meta theme for XDS components \u2014 Meta's brand identity with blue accent and clean aesthetics",
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/source.js",

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xds/theme-neutral",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": false,
   "description": "Neutral theme for XDS components (Lucide icons)",
   "license": "MIT",

--- a/packages/themes/whatsapp/package.json
+++ b/packages/themes/whatsapp/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@xds/theme-whatsapp",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
-  "description": "WhatsApp theme for XDS — green accent, warm grays, Roboto, rounded surfaces",
+  "description": "WhatsApp theme for XDS \u2014 green accent, warm grays, Roboto, rounded surfaces",
   "license": "MIT",
   "sideEffects": false,
   "main": "./dist/source.js",


### PR DESCRIPTION
Version bump for the v0.0.12 release.

### Packages
- `@xds/core` 0.0.11 → 0.0.12
- `@xds/cli` 0.0.11 → 0.0.12
- `@xds/theme-default` 0.0.11 → 0.0.12
- `@xds/theme-neutral` 0.0.11 → 0.0.12
- `@xds/theme-daily` 0.0.1 → 0.0.12 (catch-up)
- `@xds/lab` 0.0.11 → 0.0.12 (private)
- `@xds/theme-brutalist` 0.0.11 → 0.0.12 (private)
- `@xds/theme-meta` 0.0.11 → 0.0.12 (private)
- `@xds/theme-whatsapp` 0.0.11 → 0.0.12 (private)
