### PR TITLE
fix(TabList): scope hover indicator to individual tabs

### DIFF
--- a/packages/cli/templates/detail-page/page.tsx
+++ b/packages/cli/templates/detail-page/page.tsx
@@ -26,7 +26,6 @@ import {XDSList, XDSListItem} from '@xds/core/List';
 import {XDSMetadataList, XDSMetadataListItem} from '@xds/core/MetadataList';
 import {XDSProgressBar} from '@xds/core/ProgressBar';
 import {XDSCollapsible} from '@xds/core/Collapsible';
-import {XDSCenter} from '@xds/core/Center';
 
 // ─── Icons ──────────────────────────────────────────────────────────────────
 const HomeIcon = (props: React.SVGProps<SVGSVGElement>) => (
@@ -455,79 +454,77 @@ function PageHeader({
 }) {
   return (
     <XDSLayoutHeader hasDivider padding={4}>
-      <XDSCenter axis="horizontal">
+      <XDSVStack gap={0}>
+        {/* Back link */}
+        <XDSLink href="#" label="All orders" color="secondary">
+          <XDSHStack gap={1} vAlign="center">
+            <ArrowLeftIcon style={{width: 16, height: 16}} />
+            All orders
+          </XDSHStack>
+        </XDSLink>
+        {/* Title + metadata */}
         <XDSVStack gap={0}>
-          {/* Back link */}
-          <XDSLink href="#" label="All orders" color="secondary">
-            <XDSHStack gap={1} vAlign="center">
-              <ArrowLeftIcon style={{width: 16, height: 16}} />
-              All orders
-            </XDSHStack>
-          </XDSLink>
-          {/* Title + metadata */}
-          <XDSVStack gap={0}>
-            {/* Title row */}
-            <XDSHStack
-              gap={2}
-              vAlign="center"
-              style={{justifyContent: 'space-between'}}>
-              <XDSHStack gap={2} vAlign="center">
-                <XDSHeading level={1}>#1001</XDSHeading>
-              </XDSHStack>
-              <XDSHStack gap={2} vAlign="start">
-                <XDSButton label="← 2/9 →" variant="ghost" />
-                <XDSButton label="Restock" variant="secondary" />
-                <XDSButton label="Edit" variant="secondary" />
-              </XDSHStack>
-            </XDSHStack>
-
-            {/* Metadata row */}
-            <XDSHStack gap={1} vAlign="center" style={{flexWrap: 'wrap'}}>
-              <XDSText type="body">{PRODUCTS.length} ordered items</XDSText>
-              <Bullet />
-              <XDSHStack gap={1} vAlign="center">
-                <XDSAvatar name="Jane Doe" size="xsmall" />
-                <XDSText type="body">Jane Doe</XDSText>
-              </XDSHStack>
-              <Bullet />
-              <XDSBadge variant="warning" label="Unfulfilled" />
-              <Bullet />
-              <XDSHStack gap={1} vAlign="center">
-                <CalendarIcon {...stylex.props(pageStyles.metaIcon)} />
-                <XDSText type="body">02/23/2026</XDSText>
-              </XDSHStack>
-              <Bullet />
-              <XDSHStack gap={1} vAlign="center">
-                <FlagIcon {...stylex.props(pageStyles.metaIcon)} />
-                <XDSText type="body">Needs attention</XDSText>
-              </XDSHStack>
-              <Bullet />
-              <XDSLink href="#" label="See all" color="secondary">
-                See all
-              </XDSLink>
-            </XDSHStack>
-          </XDSVStack>
-
-          {/* Tabs */}
+          {/* Title row */}
           <XDSHStack
+            gap={2}
             vAlign="center"
-            style={{
-              justifyContent: 'space-between',
-              marginInline: -12,
-              marginBottom: -16,
-              marginTop: 12,
-            }}>
-            <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
-              <XDSTab value="details" label="Details" />
-              <XDSTab value="invoices" label="Invoices" />
-              <XDSTab value="timeline" label="Timeline" />
-              <XDSTab value="customer" label="Customer" />
-              <XDSTab value="analysis" label="Analysis" />
-            </XDSTabList>
-            <XDSButton label="View options" variant="ghost" size="md" />
+            style={{justifyContent: 'space-between'}}>
+            <XDSHStack gap={2} vAlign="center">
+              <XDSHeading level={1}>#1001</XDSHeading>
+            </XDSHStack>
+            <XDSHStack gap={2} vAlign="start">
+              <XDSButton label="← 2/9 →" variant="ghost" />
+              <XDSButton label="Restock" variant="secondary" />
+              <XDSButton label="Edit" variant="secondary" />
+            </XDSHStack>
+          </XDSHStack>
+
+          {/* Metadata row */}
+          <XDSHStack gap={1} vAlign="center" style={{flexWrap: 'wrap'}}>
+            <XDSText type="body">{PRODUCTS.length} ordered items</XDSText>
+            <Bullet />
+            <XDSHStack gap={1} vAlign="center">
+              <XDSAvatar name="Jane Doe" size="xsmall" />
+              <XDSText type="body">Jane Doe</XDSText>
+            </XDSHStack>
+            <Bullet />
+            <XDSBadge variant="warning" label="Unfulfilled" />
+            <Bullet />
+            <XDSHStack gap={1} vAlign="center">
+              <CalendarIcon {...stylex.props(pageStyles.metaIcon)} />
+              <XDSText type="body">02/23/2026</XDSText>
+            </XDSHStack>
+            <Bullet />
+            <XDSHStack gap={1} vAlign="center">
+              <FlagIcon {...stylex.props(pageStyles.metaIcon)} />
+              <XDSText type="body">Needs attention</XDSText>
+            </XDSHStack>
+            <Bullet />
+            <XDSLink href="#" label="See all" color="secondary">
+              See all
+            </XDSLink>
           </XDSHStack>
         </XDSVStack>
-      </XDSCenter>
+
+        {/* Tabs */}
+        <XDSHStack
+          vAlign="center"
+          style={{
+            justifyContent: 'space-between',
+            marginInline: -12,
+            marginBottom: -16,
+            marginTop: 12,
+          }}>
+          <XDSTabList value={activeTab} onChange={onTabChange} size="lg">
+            <XDSTab value="details" label="Details" />
+            <XDSTab value="invoices" label="Invoices" />
+            <XDSTab value="timeline" label="Timeline" />
+            <XDSTab value="customer" label="Customer" />
+            <XDSTab value="analysis" label="Analysis" />
+          </XDSTabList>
+          <XDSButton label="View options" variant="ghost" size="md" />
+        </XDSHStack>
+      </XDSVStack>
     </XDSLayoutHeader>
   );
 }

--- a/packages/core/src/TabList/XDSTab.tsx
+++ b/packages/core/src/TabList/XDSTab.tsx
@@ -30,6 +30,7 @@ import type {XDSTabListSize} from './XDSTabListContext';
 import {useXDSLinkComponent} from '../Link/useXDSLinkComponent';
 import type {XDSLinkComponentType} from '../Link/types';
 import {xdsClassName, mergeProps} from '../utils';
+import {tabScope} from './tab.markers.stylex';
 
 export interface XDSTabProps {
   /**
@@ -139,7 +140,7 @@ const styles = stylex.create({
     backgroundColor: colorVars['--color-border'],
     opacity: {
       default: 0,
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', tabScope)]: {
         '@media (hover: hover)': 1,
       },
     },
@@ -229,6 +230,7 @@ export function XDSTab({
         sizeStyles[size],
         isSelected && styles.selected,
         !isSelected && stylex.defaultMarker(),
+        !isSelected && tabScope,
         xstyle,
       ),
       className,

--- a/packages/core/src/TabList/XDSTabMenu.tsx
+++ b/packages/core/src/TabList/XDSTabMenu.tsx
@@ -32,6 +32,7 @@ import {XDSDivider} from '../Divider';
 import {useXDSTabListContext} from './XDSTabListContext';
 import type {XDSTabListSize} from './XDSTabListContext';
 import {xdsClassName, mergeProps} from '../utils';
+import {tabScope} from './tab.markers.stylex';
 
 export interface XDSTabMenuOption {
   value: string;
@@ -132,7 +133,7 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-full'],
     opacity: {
       default: 0,
-      [stylex.when.ancestor(':hover')]: {
+      [stylex.when.ancestor(':hover', tabScope)]: {
         '@media (hover: hover)': 1,
       },
     },
@@ -278,6 +279,7 @@ export function XDSTabMenu({label, options}: XDSTabMenuProps) {
             sizeStyles[size],
             hasSelectedOption && styles.triggerSelected,
             !hasSelectedOption && stylex.defaultMarker(),
+            !hasSelectedOption && tabScope,
           ),
         )}>
         <span

--- a/packages/core/src/TabList/tab.markers.stylex.ts
+++ b/packages/core/src/TabList/tab.markers.stylex.ts
@@ -1,0 +1,9 @@
+import * as stylex from '@stylexjs/stylex';
+
+/**
+ * Scoped marker for Tab ancestor selectors.
+ * Scopes hover styles to the individual tab button/anchor,
+ * preventing all unselected tab indicators from showing
+ * when any part of the tab list nav is hovered.
+ */
+export const tabScope = stylex.defineMarker();


### PR DESCRIPTION
## What

Two fixes:

### 1. Tab hover indicator shows on all tabs (component bug)

The unselected tab indicator used an unscoped `stylex.when.ancestor(':hover')`, which matches hovering anywhere in the `<nav>` — so ALL unselected tab indicators appeared simultaneously instead of just the one being hovered.

**Fix:** Added a `tabScope` marker (same pattern as `CheckboxInput`, `RadioList`, `Switch`) and scoped the ancestor hover to it. Now only the individual hovered tab shows its indicator. Applied to both `XDSTab` and `XDSTabMenu`.

### 2. Extra padding in detail-page template header

The `PageHeader` wrapped content in `<XDSCenter axis="horizontal">`, which is redundant — `XDSLayoutHeader` already centers via its inner div (`maxWidth` + `marginInline: auto`). The extra flex container interfered with the negative margin hack used to seat tabs flush against the header divider.

**Fix:** Removed the redundant `XDSCenter` wrapper.

## Files changed

- `packages/core/src/TabList/tab.markers.stylex.ts` — new scoped marker
- `packages/core/src/TabList/XDSTab.tsx` — scoped hover + apply marker
- `packages/core/src/TabList/XDSTabMenu.tsx` — scoped hover + apply marker
- `packages/cli/templates/detail-page/page.tsx` — removed redundant `XDSCenter`

## Testing

- All 18 existing TabList tests pass
- Build passes
- Lint + prettier pass (pre-commit hooks)